### PR TITLE
Add Commit Flight button for non-revert recording commitment

### DIFF
--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -153,6 +153,7 @@ namespace Parsek
                 return result;
             }
         }
+        public bool HasActiveChain => activeChainId != null;
 
         #endregion
 
@@ -1367,6 +1368,106 @@ namespace Parsek
             recorder = null;
             lastPlaybackIndex = 0;
             Log("Recording cleared");
+        }
+
+        public void CommitFlight()
+        {
+            // Guard: no recording data
+            if (recorder == null || recorder.Recording.Count < 2)
+            {
+                ParsekLog.ScreenMessage("No recording to commit", 2f);
+                return;
+            }
+
+            // Guard: mid-chain recordings can't be committed standalone
+            if (activeChainId != null)
+            {
+                ParsekLog.ScreenMessage("Cannot commit mid-chain \u2014 finish or revert first", 2f);
+                Log("CommitFlight blocked: active chain in progress");
+                return;
+            }
+
+            // Stop recording if still active
+            if (recorder.IsRecording)
+                StopRecording();
+
+            // Stop any continuation sampling
+            if (continuationVesselPid != 0)
+            {
+                RefreshContinuationSnapshot();
+                StopContinuation("commit flight");
+            }
+            if (undockContinuationPid != 0)
+            {
+                RefreshUndockContinuationSnapshot();
+                StopUndockContinuation("commit flight");
+            }
+
+            string vesselName = FlightGlobals.ActiveVessel != null
+                ? FlightGlobals.ActiveVessel.vesselName
+                : "Unknown Vessel";
+
+            var captured = recorder.CaptureAtStop;
+
+            // Stash as pending recording (reuses OnSceneChangeRequested pattern)
+            RecordingStore.StashPending(
+                recorder.Recording,
+                vesselName,
+                recorder.OrbitSegments,
+                recordingId: captured != null ? captured.RecordingId : null,
+                recordingFormatVersion: captured != null ? (int?)captured.RecordingFormatVersion : null,
+                ghostGeometryVersion: captured != null ? (int?)captured.GhostGeometryVersion : null,
+                partEvents: recorder.PartEvents);
+
+            if (!RecordingStore.HasPending)
+            {
+                Log("CommitFlight: StashPending rejected recording (too short?)");
+                return;
+            }
+
+            // Apply snapshot/geometry artifacts from stop-time capture
+            if (captured != null)
+            {
+                RecordingStore.Pending.ApplyPersistenceArtifactsFrom(captured);
+                Log("CommitFlight: applied stop-time artifacts");
+            }
+            else
+            {
+                // Fallback: capture vessel now
+                bool wasDestroyed = recorder.VesselDestroyedDuringRecording;
+                VesselSpawner.SnapshotVessel(
+                    RecordingStore.Pending,
+                    wasDestroyed,
+                    destroyedFallbackSnapshot: recorder.InitialGhostVisualSnapshot
+                        ?? recorder.LastGoodVesselSnapshot);
+                RecordingStore.Pending.GhostVisualSnapshot =
+                    recorder.InitialGhostVisualSnapshot != null
+                        ? recorder.InitialGhostVisualSnapshot.CreateCopy()
+                        : (RecordingStore.Pending.VesselSnapshot != null
+                            ? RecordingStore.Pending.VesselSnapshot.CreateCopy()
+                            : null);
+                Log("CommitFlight: captured vessel snapshot (fallback path)");
+            }
+
+            // Mark as non-revert commit:
+            // - VesselSpawned=true prevents duplicate spawn while vessel is in-game
+            // - SpawnedVesselPersistentId enables duplicate detection on save/load
+            // - LastAppliedResourceIndex prevents double-applying deltas
+            // All three reset naturally on "Revert to Launch" (launch quicksave has no RECORDING nodes)
+            var pending = RecordingStore.Pending;
+            pending.VesselSpawned = true;
+            pending.SpawnedVesselPersistentId = recorder.RecordingVesselId;
+            pending.LastAppliedResourceIndex = pending.Points.Count - 1;
+
+            // Commit to timeline
+            RecordingStore.CommitPending();
+
+            // Clear recorder state
+            recorder = null;
+            lastPlaybackIndex = 0;
+
+            Log($"CommitFlight: committed \"{vesselName}\" to timeline");
+            ParsekLog.ScreenMessage("Flight committed to timeline!", 3f);
         }
 
         #endregion

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -155,6 +155,13 @@ namespace Parsek
                 flight.ClearRecording();
             }
 
+            GUI.enabled = !flight.IsRecording && !flight.IsPlaying
+                && flight.recording.Count >= 2 && !flight.HasActiveChain;
+            if (GUILayout.Button("Commit Flight"))
+            {
+                flight.CommitFlight();
+            }
+
             GUI.enabled = activeGhosts > 0;
             if (GUILayout.Button($"Despawn Ghosts ({activeGhosts})"))
             {


### PR DESCRIPTION
## Summary
- Adds a "Commit Flight" button to the Parsek UI that commits the current recording to the timeline without requiring a revert
- Marks committed recordings as already-spawned (`VesselSpawned`, `SpawnedVesselPersistentId`, `LastAppliedResourceIndex`) to prevent duplicate spawns and double resource deltas
- All markers reset naturally on Revert to Launch, so the existing ghost playback and vessel spawn flow works unchanged

## Test plan
- [x] Build succeeds with zero warnings (`dotnet build`)
- [x] All 594 existing tests pass (`dotnet test`)
- [ ] Launch vessel, F9 start, fly 30s, F9 stop, click "Commit Flight" — screen message appears, timeline count increments, recorded points reset to 0
- [ ] Continue flying after commit — no duplicate spawn or resource weirdness
- [ ] Revert to Launch after commit — ghost plays back, vessel spawns at EndUT, crew reserved/swapped correctly
- [ ] Record → Commit → Record → Commit → Revert — two ghosts play back
- [ ] Record → Commit → F5 → F9 — no duplicate spawn or double resources
- [ ] Button disabled during recording, preview, and mid-chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)