### PR TITLE
Add atmosphere boundary auto-split and per-segment playback

### DIFF
--- a/Source/Parsek.Tests/AtmosphereSplitTests.cs
+++ b/Source/Parsek.Tests/AtmosphereSplitTests.cs
@@ -203,6 +203,18 @@ namespace Parsek.Tests
 
             rec.SegmentPhase = "exo";
             Assert.Equal("Kerbin exo", RecordingStore.GetSegmentPhaseLabel(rec));
+
+            rec.SegmentPhase = "space";
+            rec.SegmentBodyName = "Mun";
+            Assert.Equal("Mun space", RecordingStore.GetSegmentPhaseLabel(rec));
+        }
+
+        [Fact]
+        public void SoiChangeFlag_DefaultsFalse()
+        {
+            var recorder = new FlightRecorder();
+            Assert.False(recorder.SoiChangePending);
+            Assert.Null(recorder.SoiChangeFromBody);
         }
     }
 }

--- a/Source/Parsek.Tests/AtmosphereSplitTests.cs
+++ b/Source/Parsek.Tests/AtmosphereSplitTests.cs
@@ -1,0 +1,208 @@
+using Xunit;
+
+namespace Parsek.Tests
+{
+    [Collection("Sequential")]
+    public class AtmosphereSplitTests
+    {
+        // Kerbin atmosphere depth
+        private const double KerbinAtmoDepth = 70000.0;
+
+        [Fact]
+        public void NoAtmosphere_ReturnsFalse()
+        {
+            // Body without atmosphere (atmoDepth = 0)
+            bool result = FlightRecorder.ShouldSplitAtAtmosphereBoundary(
+                wasInAtmo: true, altitude: 50000, atmosphereDepth: 0,
+                pendingCross: true, pendingUT: 0, currentUT: 10);
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void SameSide_ReturnsFalse()
+        {
+            // Still inside atmosphere (no boundary crossed)
+            bool result = FlightRecorder.ShouldSplitAtAtmosphereBoundary(
+                wasInAtmo: true, altitude: 50000, atmosphereDepth: KerbinAtmoDepth,
+                pendingCross: true, pendingUT: 0, currentUT: 10);
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void CrossedButNotFarEnough_ReturnsFalse()
+        {
+            // Just barely past atmosphere boundary (100m past, need 1000m)
+            bool result = FlightRecorder.ShouldSplitAtAtmosphereBoundary(
+                wasInAtmo: true, altitude: KerbinAtmoDepth + 100, atmosphereDepth: KerbinAtmoDepth,
+                pendingCross: true, pendingUT: 0, currentUT: 10);
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void CrossedFarButNotLongEnough_ReturnsFalse()
+        {
+            // Past 1000m but timer not started (pendingCross = false)
+            bool result = FlightRecorder.ShouldSplitAtAtmosphereBoundary(
+                wasInAtmo: true, altitude: KerbinAtmoDepth + 2000, atmosphereDepth: KerbinAtmoDepth,
+                pendingCross: false, pendingUT: 0, currentUT: 10);
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void CrossedFarAndLongEnough_ExitAtmo_ReturnsTrue()
+        {
+            // Exiting atmosphere: was in atmo, now above + 2000m, timer sustained 5s
+            bool result = FlightRecorder.ShouldSplitAtAtmosphereBoundary(
+                wasInAtmo: true, altitude: KerbinAtmoDepth + 2000, atmosphereDepth: KerbinAtmoDepth,
+                pendingCross: true, pendingUT: 100, currentUT: 105);
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void CrossedFarAndLongEnough_EnterAtmo_ReturnsTrue()
+        {
+            // Entering atmosphere: was exo, now below by 2000m, timer sustained 5s
+            bool result = FlightRecorder.ShouldSplitAtAtmosphereBoundary(
+                wasInAtmo: false, altitude: KerbinAtmoDepth - 2000, atmosphereDepth: KerbinAtmoDepth,
+                pendingCross: true, pendingUT: 100, currentUT: 105);
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void HysteresisTimeNotMet_ReturnsFalse()
+        {
+            // Only 2s elapsed, need 3s
+            bool result = FlightRecorder.ShouldSplitAtAtmosphereBoundary(
+                wasInAtmo: true, altitude: KerbinAtmoDepth + 2000, atmosphereDepth: KerbinAtmoDepth,
+                pendingCross: true, pendingUT: 100, currentUT: 102);
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void ExactlyAtHysteresisThreshold_ReturnsTrue()
+        {
+            // Exactly 3s elapsed, exactly 1000m past
+            bool result = FlightRecorder.ShouldSplitAtAtmosphereBoundary(
+                wasInAtmo: true, altitude: KerbinAtmoDepth + 1000, atmosphereDepth: KerbinAtmoDepth,
+                pendingCross: true, pendingUT: 100, currentUT: 103);
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void CustomHysteresis_Respected()
+        {
+            // Custom: 1s time, 500m distance
+            bool result = FlightRecorder.ShouldSplitAtAtmosphereBoundary(
+                wasInAtmo: true, altitude: KerbinAtmoDepth + 600, atmosphereDepth: KerbinAtmoDepth,
+                pendingCross: true, pendingUT: 100, currentUT: 101.5,
+                hysteresisSeconds: 1.0, hysteresisMeters: 500.0);
+            Assert.True(result);
+
+            // Same custom, but not enough distance
+            bool result2 = FlightRecorder.ShouldSplitAtAtmosphereBoundary(
+                wasInAtmo: true, altitude: KerbinAtmoDepth + 400, atmosphereDepth: KerbinAtmoDepth,
+                pendingCross: true, pendingUT: 100, currentUT: 101.5,
+                hysteresisSeconds: 1.0, hysteresisMeters: 500.0);
+            Assert.False(result2);
+        }
+
+        [Fact]
+        public void ChainHelpers_IsChainLooping()
+        {
+            RecordingStore.SuppressLogging = true;
+            GameStateStore.SuppressLogging = true;
+            ParsekLog.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+
+            try
+            {
+                // Add two recordings in a chain
+                var points = new System.Collections.Generic.List<TrajectoryPoint>
+                {
+                    new TrajectoryPoint { ut = 100 },
+                    new TrajectoryPoint { ut = 200 }
+                };
+
+                RecordingStore.StashPending(points, "Test1");
+                RecordingStore.Pending.ChainId = "chain1";
+                RecordingStore.Pending.ChainIndex = 0;
+                RecordingStore.Pending.ChainBranch = 0;
+                RecordingStore.Pending.PlaybackEnabled = true;
+                RecordingStore.Pending.LoopPlayback = true;
+                RecordingStore.CommitPending();
+
+                Assert.True(RecordingStore.IsChainLooping("chain1"));
+                Assert.False(RecordingStore.IsChainFullyDisabled("chain1"));
+            }
+            finally
+            {
+                RecordingStore.ResetForTesting();
+                RecordingStore.SuppressLogging = false;
+                GameStateStore.SuppressLogging = false;
+                ParsekLog.SuppressLogging = false;
+            }
+        }
+
+        [Fact]
+        public void ChainHelpers_IsChainFullyDisabled()
+        {
+            RecordingStore.SuppressLogging = true;
+            GameStateStore.SuppressLogging = true;
+            ParsekLog.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+
+            try
+            {
+                var points = new System.Collections.Generic.List<TrajectoryPoint>
+                {
+                    new TrajectoryPoint { ut = 100 },
+                    new TrajectoryPoint { ut = 200 }
+                };
+
+                RecordingStore.StashPending(points, "Test1");
+                RecordingStore.Pending.ChainId = "chain2";
+                RecordingStore.Pending.ChainIndex = 0;
+                RecordingStore.Pending.ChainBranch = 0;
+                RecordingStore.Pending.PlaybackEnabled = false;
+                RecordingStore.CommitPending();
+
+                RecordingStore.StashPending(points, "Test2");
+                RecordingStore.Pending.ChainId = "chain2";
+                RecordingStore.Pending.ChainIndex = 1;
+                RecordingStore.Pending.ChainBranch = 0;
+                RecordingStore.Pending.PlaybackEnabled = false;
+                RecordingStore.CommitPending();
+
+                Assert.True(RecordingStore.IsChainFullyDisabled("chain2"));
+                Assert.False(RecordingStore.IsChainLooping("chain2"));
+
+                // Enable one segment — no longer fully disabled
+                RecordingStore.CommittedRecordings[0].PlaybackEnabled = true;
+                Assert.False(RecordingStore.IsChainFullyDisabled("chain2"));
+            }
+            finally
+            {
+                RecordingStore.ResetForTesting();
+                RecordingStore.SuppressLogging = false;
+                GameStateStore.SuppressLogging = false;
+                ParsekLog.SuppressLogging = false;
+            }
+        }
+
+        [Fact]
+        public void GetSegmentPhaseLabel_Formats()
+        {
+            var rec = new RecordingStore.Recording();
+            Assert.Equal("", RecordingStore.GetSegmentPhaseLabel(rec));
+
+            rec.SegmentPhase = "atmo";
+            Assert.Equal("atmo", RecordingStore.GetSegmentPhaseLabel(rec));
+
+            rec.SegmentBodyName = "Kerbin";
+            Assert.Equal("Kerbin atmo", RecordingStore.GetSegmentPhaseLabel(rec));
+
+            rec.SegmentPhase = "exo";
+            Assert.Equal("Kerbin exo", RecordingStore.GetSegmentPhaseLabel(rec));
+        }
+    }
+}

--- a/Source/Parsek.Tests/Fixtures/KspLog/bad_atmo_error.log
+++ b/Source/Parsek.Tests/Fixtures/KspLog/bad_atmo_error.log
@@ -1,0 +1,8 @@
+[LOG 14:50:01.000] [Parsek][INFO][Init] SessionStart runUtc=1700004000
+[LOG 14:50:10.100] [Parsek][INFO][Recorder] Recording started (physics-frame sampling)
+[LOG 14:50:10.110] [Parsek][VERBOSE][Recorder] Boundary detection initialized: body=Kerbin, inAtmo=True, hasAtmo=True, alt=75m
+[LOG 14:50:25.300] [Parsek][VERBOSE][Recorder] Atmosphere boundary detected — starting hysteresis timer (body=Kerbin, exiting, alt=71200m, atmoDepth=70000m)
+[LOG 14:50:28.500] [Parsek][ERROR][Flight] Boundary split failed: null recorder reference during SOI change
+[LOG 14:50:28.600] [Parsek][INFO][Recorder] Recording stopped (chain boundary). 48 points, 0 orbit segments over 18.4s
+[LOG 14:50:28.700] [Parsek][INFO][Recorder] Recording started (physics-frame sampling)
+[LOG 14:50:50.700] [Parsek][INFO][Recorder] Recording stopped. 35 points, 1 orbit segments over 40.4s

--- a/Source/Parsek.Tests/Fixtures/KspLog/bad_atmo_split_metrics.log
+++ b/Source/Parsek.Tests/Fixtures/KspLog/bad_atmo_split_metrics.log
@@ -1,0 +1,5 @@
+[LOG 14:30:01.000] [Parsek][INFO][Init] SessionStart runUtc=1700002000
+[LOG 14:30:10.100] [Parsek][INFO][Recorder] Recording started (physics-frame sampling)
+[LOG 14:30:28.500] [Parsek][INFO][Recorder] Recording stopped (chain boundary). 1 points, 0 orbit segments over 18.4s
+[LOG 14:30:28.600] [Parsek][INFO][Recorder] Recording started (physics-frame sampling)
+[LOG 14:30:50.700] [Parsek][INFO][Recorder] Recording stopped. 35 points, 1 orbit segments over 40.4s

--- a/Source/Parsek.Tests/Fixtures/KspLog/bad_atmo_warning.log
+++ b/Source/Parsek.Tests/Fixtures/KspLog/bad_atmo_warning.log
@@ -1,0 +1,7 @@
+[LOG 14:40:01.000] [Parsek][INFO][Init] SessionStart runUtc=1700003000
+[LOG 14:40:10.100] [Parsek][INFO][Recorder] Recording started (physics-frame sampling)
+[LOG 14:40:10.110] [Parsek][VERBOSE][Recorder] Boundary detection initialized: body=Kerbin, inAtmo=True, hasAtmo=True, alt=75m
+[LOG 14:40:25.300] [Parsek][WARN][Recorder] WARNING: Atmosphere boundary timer reset — this should not use WARNING: prefix
+[LOG 14:40:28.500] [Parsek][INFO][Recorder] Recording stopped (chain boundary). 48 points, 0 orbit segments over 18.4s
+[LOG 14:40:28.600] [Parsek][INFO][Recorder] Recording started (physics-frame sampling)
+[LOG 14:40:50.700] [Parsek][INFO][Recorder] Recording stopped. 35 points, 1 orbit segments over 40.4s

--- a/Source/Parsek.Tests/Fixtures/KspLog/good_atmo_soi_session.log
+++ b/Source/Parsek.Tests/Fixtures/KspLog/good_atmo_soi_session.log
@@ -1,0 +1,39 @@
+[LOG 14:20:01.000] [ModuleManager] Applying update pass
+[LOG 14:20:01.200] [ToolbarControl] Toolbar initialized
+[LOG 14:20:02.001] [Parsek][INFO][Init] SessionStart runUtc=1700001000
+[LOG 14:20:02.050] [Parsek][INFO][Harmony] Harmony patches applied for assembly 'Parsek'
+[LOG 14:20:10.100] [Parsek][INFO][Recorder] Recording started (physics-frame sampling)
+[LOG 14:20:10.110] [Parsek][VERBOSE][Recorder] Boundary detection initialized: body=Kerbin, inAtmo=True, hasAtmo=True, alt=75m
+[LOG 14:20:10.120] [Parsek][VERBOSE][Recorder] Atmosphere state reseeded: body=Kerbin, inAtmo=True (was False), hasAtmo=True, alt=75m, atmoDepth=70000m
+[LOG 14:20:25.300] [Parsek][VERBOSE][Recorder] Atmosphere boundary detected — starting hysteresis timer (body=Kerbin, exiting, alt=71200m, atmoDepth=70000m)
+[LOG 14:20:28.500] [Parsek][INFO][Recorder] Atmosphere boundary confirmed: exited atmosphere of Kerbin at alt 72500m (hysteresis: 3.2s, 2500m past boundary)
+[LOG 14:20:28.510] [Parsek][INFO][Recorder] Recording stopped (chain boundary). 48 points, 0 orbit segments over 18.4s
+[LOG 14:20:28.520] [Parsek][INFO][Flight] Atmosphere auto-split triggered: Kerbin atmo→exo (chain=abc12345, points=48)
+[LOG 14:20:28.530] [Parsek][INFO][Flight] Boundary split: committing segment (id=rec001, phase=atmo, body=Kerbin, points=48, orbits=0)
+[LOG 14:20:28.540] [Parsek][INFO][Flight] Boundary split: started new chain (id=abc12345)
+[LOG 14:20:28.550] [Parsek][VERBOSE][Flight] Boundary split committed: chain=abc12345, nextIdx=1, segment=Kerbin atmo, totalRecordings=1
+[LOG 14:20:28.560] [Parsek][VERBOSE][Scenario] Saved metadata: id=rec001, phase=atmo, body=Kerbin, playback=True, chain=abc12345/0
+[LOG 14:20:28.600] [Parsek][INFO][Recorder] Recording started (physics-frame sampling)
+[LOG 14:20:28.610] [Parsek][VERBOSE][Recorder] Boundary detection initialized: body=Kerbin, inAtmo=False, hasAtmo=True, alt=72500m
+[LOG 14:20:28.620] [Parsek][INFO][Flight] Recording continues after atmosphere boundary (Kerbin exo, chain=abc12345)
+[LOG 14:20:50.100] [Parsek][VERBOSE][Recorder] SOI changed during orbit recording: Kerbin → Mun
+[LOG 14:20:50.200] [Parsek][VERBOSE][Recorder] Atmosphere state reseeded: body=Mun, inAtmo=False (was False), hasAtmo=False, alt=25000m
+[LOG 14:20:50.210] [Parsek][INFO][Recorder] Recording stopped (chain boundary). 22 points, 1 orbit segments over 21.6s
+[LOG 14:20:50.220] [Parsek][INFO][Flight] SOI auto-split triggered: Kerbin (exo) → Mun (chain=abc12345, points=22)
+[LOG 14:20:50.230] [Parsek][INFO][Flight] Boundary split: committing segment (id=rec002, phase=exo, body=Kerbin, points=22, orbits=1)
+[LOG 14:20:50.240] [Parsek][VERBOSE][Flight] Boundary split committed: chain=abc12345, nextIdx=2, segment=Kerbin exo, totalRecordings=2
+[LOG 14:20:50.250] [Parsek][VERBOSE][Scenario] Saved metadata: id=rec002, phase=exo, body=Kerbin, playback=True, chain=abc12345/1
+[LOG 14:20:50.300] [Parsek][INFO][Recorder] Recording started (physics-frame sampling)
+[LOG 14:20:50.310] [Parsek][VERBOSE][Recorder] Boundary detection initialized: body=Mun, inAtmo=False, hasAtmo=False, alt=25000m
+[LOG 14:20:50.320] [Parsek][INFO][Flight] Recording continues after SOI change (Kerbin → Mun, chain=abc12345)
+[LOG 14:21:10.500] [Parsek][VERBOSE][Recorder] Sample skipped due to adaptive threshold | suppressed=5
+[LOG 14:21:30.700] [Parsek][INFO][Recorder] Recording stopped. 35 points, 1 orbit segments over 40.4s
+[LOG 14:21:30.710] [Parsek][VERBOSE][Scenario] Saved metadata: id=rec003, phase=space, body=Mun, playback=True, chain=abc12345/2
+[LOG 14:21:30.720] [Parsek][VERBOSE][Scenario] Loaded metadata: id=rec001, phase=atmo, body=Kerbin, playback=True, chain=abc12345/0
+[LOG 14:21:30.730] [Parsek][VERBOSE][Scenario] Loaded metadata: id=rec002, phase=exo, body=Kerbin, playback=True, chain=abc12345/1
+[LOG 14:21:30.740] [Parsek][VERBOSE][Scenario] Loaded metadata: id=rec003, phase=space, body=Mun, playback=True, chain=abc12345/2
+[LOG 14:21:30.750] [Parsek][VERBOSE][RecordingStore] Validating chains: 1 branch group(s)
+[LOG 14:21:30.760] [Parsek][VERBOSE][RecordingStore] All chains validated OK
+[LOG 14:21:50.100] [Parsek][VERBOSE][Flight] Ghost #0 destroyed — segment disabled (Mun Transfer, Kerbin atmo)
+[LOG 14:21:50.200] [Parsek][INFO][UI] Setting changed: autoSplitAtAtmosphere=True
+[LOG 14:21:50.300] [Parsek][INFO][UI] Setting changed: autoSplitAtSoi=False

--- a/Source/Parsek.Tests/Generators/RecordingBuilder.cs
+++ b/Source/Parsek.Tests/Generators/RecordingBuilder.cs
@@ -21,6 +21,9 @@ namespace Parsek.Tests.Generators
         private int chainBranch = -1;
         private bool loopPlayback;
         private double loopPauseSeconds = 10.0;
+        private string segmentPhase;
+        private string segmentBodyName;
+        private bool playbackEnabled = true;
 
         // Default rotation for points that don't specify one explicitly
         private float defaultRotX, defaultRotY, defaultRotZ;
@@ -182,6 +185,24 @@ namespace Parsek.Tests.Generators
             return this;
         }
 
+        public RecordingBuilder WithSegmentPhase(string phase)
+        {
+            segmentPhase = phase;
+            return this;
+        }
+
+        public RecordingBuilder WithSegmentBodyName(string body)
+        {
+            segmentBodyName = body;
+            return this;
+        }
+
+        public RecordingBuilder WithPlaybackEnabled(bool enabled)
+        {
+            playbackEnabled = enabled;
+            return this;
+        }
+
         public RecordingBuilder WithGhostVisualSnapshot(ConfigNode snapshot)
         {
             ghostVisualSnapshot = snapshot;
@@ -252,6 +273,14 @@ namespace Parsek.Tests.Generators
                 node.AddValue("spawnedPid", spawnedPid);
 
             node.AddValue("lastResIdx", lastResIdx);
+
+            // Atmosphere segment metadata
+            if (!string.IsNullOrEmpty(segmentPhase))
+                node.AddValue("segmentPhase", segmentPhase);
+            if (!string.IsNullOrEmpty(segmentBodyName))
+                node.AddValue("segmentBodyName", segmentBodyName);
+            if (!playbackEnabled)
+                node.AddValue("playbackEnabled", playbackEnabled.ToString());
 
             return node;
         }

--- a/Source/Parsek.Tests/ParsekLogContractCheckerTests.cs
+++ b/Source/Parsek.Tests/ParsekLogContractCheckerTests.cs
@@ -24,6 +24,9 @@ namespace Parsek.Tests
         [InlineData("bad_suppressed_value.log", "RAT-001")]
         [InlineData("bad_recording_stop_values.log", "REC-002")]
         [InlineData("bad_negative_resource.log", "RES-001")]
+        [InlineData("bad_atmo_split_metrics.log", "REC-002")]
+        [InlineData("bad_atmo_warning.log", "WRN-001")]
+        [InlineData("bad_atmo_error.log", "ERR-001")]
         public void BadFixtures_ReportExpectedViolationCode(string fixtureName, string expectedCode)
         {
             var entries = ParsekKspLogParser.ParseFile(TestFixtureLoader.GetFixturePath(fixtureName));
@@ -150,6 +153,94 @@ namespace Parsek.Tests
             var violations = ParsekLogContractChecker.ValidateLatestSession(entries);
 
             Assert.Empty(violations);
+        }
+
+        [Fact]
+        public void AtmoSoiFixture_HasNoViolations()
+        {
+            var entries = ParsekKspLogParser.ParseFile(TestFixtureLoader.GetFixturePath("good_atmo_soi_session.log"));
+
+            var violations = ParsekLogContractChecker.ValidateLatestSession(entries);
+
+            Assert.Empty(violations);
+        }
+
+        [Fact]
+        public void AtmoSoiFixture_ContainsExpectedSubsystems()
+        {
+            var entries = ParsekKspLogParser.ParseFile(TestFixtureLoader.GetFixturePath("good_atmo_soi_session.log"));
+            var session = ParsekKspLogParser.SelectLatestSession(entries);
+
+            Assert.Contains(session, e => e.Subsystem == "Recorder" &&
+                (e.Message ?? "").Contains("Atmosphere boundary confirmed"));
+            Assert.Contains(session, e => e.Subsystem == "Recorder" &&
+                (e.Message ?? "").Contains("Atmosphere boundary detected"));
+            Assert.Contains(session, e => e.Subsystem == "Recorder" &&
+                (e.Message ?? "").Contains("Atmosphere state reseeded"));
+            Assert.Contains(session, e => e.Subsystem == "Recorder" &&
+                (e.Message ?? "").Contains("Boundary detection initialized"));
+            Assert.Contains(session, e => e.Subsystem == "Recorder" &&
+                (e.Message ?? "").Contains("SOI changed during orbit recording"));
+            Assert.Contains(session, e => e.Subsystem == "Flight" &&
+                (e.Message ?? "").Contains("Atmosphere auto-split triggered"));
+            Assert.Contains(session, e => e.Subsystem == "Flight" &&
+                (e.Message ?? "").Contains("SOI auto-split triggered"));
+            Assert.Contains(session, e => e.Subsystem == "Flight" &&
+                (e.Message ?? "").Contains("Boundary split: committing segment"));
+            Assert.Contains(session, e => e.Subsystem == "Flight" &&
+                (e.Message ?? "").Contains("Boundary split committed"));
+            Assert.Contains(session, e => e.Subsystem == "Scenario" &&
+                (e.Message ?? "").Contains("Saved metadata:") && (e.Message ?? "").Contains("phase=atmo"));
+            Assert.Contains(session, e => e.Subsystem == "Scenario" &&
+                (e.Message ?? "").Contains("Loaded metadata:") && (e.Message ?? "").Contains("phase=space"));
+            Assert.Contains(session, e => e.Subsystem == "RecordingStore" &&
+                (e.Message ?? "").Contains("Validating chains"));
+            Assert.Contains(session, e => e.Subsystem == "RecordingStore" &&
+                (e.Message ?? "").Contains("All chains validated OK"));
+            Assert.Contains(session, e => e.Subsystem == "Flight" &&
+                (e.Message ?? "").Contains("Ghost #0 destroyed") && (e.Message ?? "").Contains("segment disabled"));
+            Assert.Contains(session, e => e.Subsystem == "UI" &&
+                (e.Message ?? "").Contains("autoSplitAtAtmosphere"));
+            Assert.Contains(session, e => e.Subsystem == "UI" &&
+                (e.Message ?? "").Contains("autoSplitAtSoi"));
+        }
+
+        [Fact]
+        public void AtmoSoiFixture_ChainBoundaryStopMetricsValidated()
+        {
+            // Chain boundary stops must pass the same REC-002 metrics validation
+            var entries = ParsekKspLogParser.ParseFile(TestFixtureLoader.GetFixturePath("good_atmo_soi_session.log"));
+            var session = ParsekKspLogParser.SelectLatestSession(entries);
+
+            var chainBoundaryStops = session.Where(e =>
+                e.Subsystem == "Recorder" &&
+                (e.Message ?? "").Contains("Recording stopped (chain boundary)")).ToList();
+
+            Assert.True(chainBoundaryStops.Count >= 2,
+                $"Expected at least 2 chain boundary stops, found {chainBoundaryStops.Count}");
+        }
+
+        [Fact]
+        public void ChainBoundaryStopWithTooFewPoints_ReportsRec002()
+        {
+            var entries = ParsekKspLogParser.ParseFile(TestFixtureLoader.GetFixturePath("bad_atmo_split_metrics.log"));
+
+            var violations = ParsekLogContractChecker.ValidateLatestSession(entries);
+
+            Assert.Contains(violations, v => v.Code == "REC-002");
+        }
+
+        [Fact]
+        public void AtmoSoiSession_MultipleStartStopPairs_NoRecViolations()
+        {
+            // A session with atmosphere/SOI splits has multiple start/stop pairs;
+            // the contract checker should not report REC-001 or REC-003
+            var entries = ParsekKspLogParser.ParseFile(TestFixtureLoader.GetFixturePath("good_atmo_soi_session.log"));
+
+            var violations = ParsekLogContractChecker.ValidateLatestSession(entries);
+
+            Assert.DoesNotContain(violations, v => v.Code == "REC-001");
+            Assert.DoesNotContain(violations, v => v.Code == "REC-003");
         }
     }
 }

--- a/Source/Parsek.Tests/SyntheticRecordingTests.cs
+++ b/Source/Parsek.Tests/SyntheticRecordingTests.cs
@@ -638,6 +638,108 @@ namespace Parsek.Tests
         }
 
         /// <summary>
+        /// 4-segment chain: Kerbin atmo → Kerbin exo → Mun space → Kerbin exo (return).
+        /// Tests SOI-change auto-split with orbit segments at the Mun.
+        /// </summary>
+        internal static RecordingBuilder[] KerbinMunTransfer(double baseUT = 0)
+        {
+            string chainId = "chain-mun-transfer-test";
+            double t = baseUT + 630;
+            double baseLat = -0.0972;
+            double baseLon = -74.5575;
+
+            // Segment 0: Atmospheric ascent (0-60s)
+            var seg0 = new RecordingBuilder("Mun Transfer")
+                .WithDefaultRotation(KscRotX, KscRotY, KscRotZ, KscRotW)
+                .WithRecordingId("chain-mun-seg0")
+                .WithChainId(chainId)
+                .WithChainIndex(0)
+                .WithSegmentPhase("atmo")
+                .WithSegmentBodyName("Kerbin");
+
+            seg0.AddPoint(t,      baseLat, baseLon,            77);
+            seg0.AddPoint(t + 20, baseLat, baseLon + 0.003,    25000);
+            seg0.AddPoint(t + 40, baseLat, baseLon + 0.012,    55000);
+            seg0.AddPoint(t + 60, baseLat, baseLon + 0.025,    71000);
+
+            seg0.WithGhostVisualSnapshot(
+                VesselSnapshotBuilder.FleaRocket("Mun Transfer", "Bill Kerman", pid: 88000000)
+                    .AsLanded(baseLat, baseLon, 77));
+
+            // Segment 1: Kerbin exo — coast to Mun SOI (60-300s, with orbit segment)
+            var seg1 = new RecordingBuilder("Mun Transfer")
+                .WithDefaultRotation(KscRotX, KscRotY, KscRotZ, KscRotW)
+                .WithRecordingId("chain-mun-seg1")
+                .WithChainId(chainId)
+                .WithChainIndex(1)
+                .WithParentRecordingId("chain-mun-seg0")
+                .WithSegmentPhase("exo")
+                .WithSegmentBodyName("Kerbin");
+
+            seg1.AddPoint(t + 60,  baseLat, baseLon + 0.025, 71000);
+            seg1.AddPoint(t + 80,  baseLat, baseLon + 0.04,  100000);
+            seg1.AddPoint(t + 100, baseLat, baseLon + 0.06,  150000);
+            // Orbit segment for coast phase
+            seg1.AddOrbitSegment(t + 100, t + 300,
+                inc: 0, ecc: 0.7, sma: 3000000,
+                lan: 0, argPe: 0, mna: 0.5, epoch: t + 100,
+                body: "Kerbin");
+            seg1.AddPoint(t + 300, 5.0, -60.0, 500000); // approaching Mun SOI
+
+            seg1.WithGhostVisualSnapshot(
+                VesselSnapshotBuilder.FleaRocket("Mun Transfer", "Bill Kerman", pid: 88000000)
+                    .AsLanded(baseLat, baseLon, 77));
+
+            // Segment 2: Mun space — orbit the Mun (300-500s)
+            var seg2 = new RecordingBuilder("Mun Transfer")
+                .WithDefaultRotation(KscRotX, KscRotY, KscRotZ, KscRotW)
+                .WithRecordingId("chain-mun-seg2")
+                .WithChainId(chainId)
+                .WithChainIndex(2)
+                .WithParentRecordingId("chain-mun-seg1")
+                .WithSegmentPhase("space")
+                .WithSegmentBodyName("Mun");
+
+            seg2.AddPoint(t + 300, 0.0, 0.0, 50000, body: "Mun");
+            // Orbit segment around the Mun
+            seg2.AddOrbitSegment(t + 300, t + 500,
+                inc: 5, ecc: 0.01, sma: 250000,
+                lan: 0, argPe: 90, mna: 0, epoch: t + 300,
+                body: "Mun");
+            seg2.AddPoint(t + 500, 0.0, 90.0, 50000, body: "Mun");
+
+            seg2.WithGhostVisualSnapshot(
+                VesselSnapshotBuilder.FleaRocket("Mun Transfer", "Bill Kerman", pid: 88000000)
+                    .AsLanded(baseLat, baseLon, 77));
+
+            // Segment 3: Return to Kerbin exo (500-700s)
+            var seg3 = new RecordingBuilder("Mun Transfer")
+                .WithDefaultRotation(KscRotX, KscRotY, KscRotZ, KscRotW)
+                .WithRecordingId("chain-mun-seg3")
+                .WithChainId(chainId)
+                .WithChainIndex(3)
+                .WithParentRecordingId("chain-mun-seg2")
+                .WithSegmentPhase("exo")
+                .WithSegmentBodyName("Kerbin");
+
+            seg3.AddPoint(t + 500, 5.0, -60.0, 500000);
+            seg3.AddOrbitSegment(t + 500, t + 700,
+                inc: 0, ecc: 0.8, sma: 4000000,
+                lan: 0, argPe: 180, mna: 2.5, epoch: t + 500,
+                body: "Kerbin");
+            seg3.AddPoint(t + 700, baseLat + 1.0, baseLon + 2.0, 100000);
+
+            seg3.WithVesselSnapshot(
+                VesselSnapshotBuilder.FleaRocket("Mun Transfer", "Bill Kerman", pid: 88000000)
+                    .AsOrbiting(sma: 4000000, ecc: 0.8, inc: 0));
+            seg3.WithGhostVisualSnapshot(
+                VesselSnapshotBuilder.FleaRocket("Mun Transfer", "Bill Kerman", pid: 88000000)
+                    .AsLanded(baseLat, baseLon, 77));
+
+            return new[] { seg0, seg1, seg2, seg3 };
+        }
+
+        /// <summary>
         /// Generalized helper for building a static-trajectory, looping showcase recording
         /// that toggles a pair of part events every 3 seconds. Used for lights, deployables,
         /// gear, cargo bays, engines, and deployed science fixtures.
@@ -3396,6 +3498,9 @@ namespace Parsek.Tests
             var atmoChainSegments = KerbinAscentChain(baseUT);
             for (int i = 0; i < atmoChainSegments.Length; i++)
                 writer.AddRecording(atmoChainSegments[i].WithLoopPlayback());
+            var munTransferSegments = KerbinMunTransfer(baseUT);
+            for (int i = 0; i < munTransferSegments.Length; i++)
+                writer.AddRecording(munTransferSegments[i].WithLoopPlayback());
 
             foreach (string file in targets)
             {
@@ -3639,8 +3744,8 @@ namespace Parsek.Tests
                     $"Expected Parsek/Recordings directory at {recordingsDir}");
 
                 string[] precFiles = Directory.GetFiles(recordingsDir, "*.prec");
-                Assert.True(precFiles.Length >= 181,
-                    $"Expected at least 181 .prec files (8 baseline + 6 lights + 18 deployables + 7 gear + 11 cargo + 3 engines + 2 ladders + 3 RCS + 5 fairings + 2 extra radiators + 2 drills + 8 deployed science + 2 animation-group + 5 parachutes + 14 special deploy animations + 29 jettison showcases + 21 robotics + 1 aero-surface + 3 robot-arm-scanner + 24 control-surface + 6 wheel-dynamics + 13 animate-heat + 1 inventory-placement + 3 board-chain + 2 walk-chain + 3 atmo-chain), found {precFiles.Length}");
+                Assert.True(precFiles.Length >= 185,
+                    $"Expected at least 185 .prec files (8 baseline + 6 lights + 18 deployables + 7 gear + 11 cargo + 3 engines + 2 ladders + 3 RCS + 5 fairings + 2 extra radiators + 2 drills + 8 deployed science + 2 animation-group + 5 parachutes + 14 special deploy animations + 29 jettison showcases + 21 robotics + 1 aero-surface + 3 robot-arm-scanner + 24 control-surface + 6 wheel-dynamics + 13 animate-heat + 1 inventory-placement + 3 board-chain + 2 walk-chain + 3 atmo-chain + 4 mun-transfer-chain), found {precFiles.Length}");
             }
         }
 

--- a/Source/Parsek.Tests/SyntheticRecordingTests.cs
+++ b/Source/Parsek.Tests/SyntheticRecordingTests.cs
@@ -554,6 +554,90 @@ namespace Parsek.Tests
         }
 
         /// <summary>
+        /// 3-segment atmosphere boundary chain: atmo ascent → exo coast → atmo reentry.
+        /// Tests SegmentPhase/SegmentBodyName serialization and chain grouping in UI.
+        /// </summary>
+        internal static RecordingBuilder[] KerbinAscentChain(double baseUT = 0)
+        {
+            string chainId = "chain-atmo-split-test";
+            double t = baseUT + 430;
+            double baseLat = -0.0972;
+            double baseLon = -74.5575;
+
+            // Segment 0: Atmospheric ascent (0-60s, 77m → 71000m)
+            var seg0 = new RecordingBuilder("Kerbin Ascent")
+                .WithDefaultRotation(KscRotX, KscRotY, KscRotZ, KscRotW)
+                .WithRecordingId("chain-atmo-seg0")
+                .WithChainId(chainId)
+                .WithChainIndex(0)
+                .WithSegmentPhase("atmo")
+                .WithSegmentBodyName("Kerbin");
+
+            seg0.AddPoint(t,      baseLat, baseLon,            77);
+            seg0.AddPoint(t + 10, baseLat, baseLon + 0.001,    5000);
+            seg0.AddPoint(t + 20, baseLat, baseLon + 0.003,    15000);
+            seg0.AddPoint(t + 30, baseLat, baseLon + 0.007,    30000);
+            seg0.AddPoint(t + 40, baseLat, baseLon + 0.012,    50000);
+            seg0.AddPoint(t + 50, baseLat, baseLon + 0.018,    65000);
+            seg0.AddPoint(t + 60, baseLat, baseLon + 0.025,    71000); // boundary crossing
+
+            seg0.WithGhostVisualSnapshot(
+                VesselSnapshotBuilder.FleaRocket("Kerbin Ascent", "Valentina Kerman", pid: 77000000)
+                    .AsLanded(baseLat, baseLon, 77));
+
+            // Segment 1: Exo-atmospheric coast (60-120s, 71000m → 80000m → 71000m)
+            var seg1 = new RecordingBuilder("Kerbin Ascent")
+                .WithDefaultRotation(KscRotX, KscRotY, KscRotZ, KscRotW)
+                .WithRecordingId("chain-atmo-seg1")
+                .WithChainId(chainId)
+                .WithChainIndex(1)
+                .WithParentRecordingId("chain-atmo-seg0")
+                .WithSegmentPhase("exo")
+                .WithSegmentBodyName("Kerbin");
+
+            seg1.AddPoint(t + 60,  baseLat, baseLon + 0.025,  71000); // boundary anchor
+            seg1.AddPoint(t + 70,  baseLat, baseLon + 0.032,  75000);
+            seg1.AddPoint(t + 80,  baseLat, baseLon + 0.040,  80000); // apoapsis
+            seg1.AddPoint(t + 90,  baseLat, baseLon + 0.048,  78000);
+            seg1.AddPoint(t + 100, baseLat, baseLon + 0.055,  74000);
+            seg1.AddPoint(t + 110, baseLat, baseLon + 0.062,  72000);
+            seg1.AddPoint(t + 120, baseLat, baseLon + 0.068,  71000); // re-entry boundary
+
+            seg1.WithGhostVisualSnapshot(
+                VesselSnapshotBuilder.FleaRocket("Kerbin Ascent", "Valentina Kerman", pid: 77000000)
+                    .AsLanded(baseLat, baseLon, 77));
+
+            // Segment 2: Atmospheric reentry (120-180s, 71000m → 55m landed)
+            var seg2 = new RecordingBuilder("Kerbin Ascent")
+                .WithDefaultRotation(KscRotX, KscRotY, KscRotZ, KscRotW)
+                .WithRecordingId("chain-atmo-seg2")
+                .WithChainId(chainId)
+                .WithChainIndex(2)
+                .WithParentRecordingId("chain-atmo-seg1")
+                .WithSegmentPhase("atmo")
+                .WithSegmentBodyName("Kerbin");
+
+            double landLat = baseLat + 0.005;
+            double landLon = baseLon + 0.075;
+            seg2.AddPoint(t + 120, baseLat,           baseLon + 0.068, 71000); // boundary anchor
+            seg2.AddPoint(t + 130, baseLat + 0.001,   baseLon + 0.070, 55000);
+            seg2.AddPoint(t + 140, baseLat + 0.002,   baseLon + 0.072, 35000);
+            seg2.AddPoint(t + 150, baseLat + 0.003,   baseLon + 0.073, 15000);
+            seg2.AddPoint(t + 160, baseLat + 0.004,   baseLon + 0.074, 5000);
+            seg2.AddPoint(t + 170, landLat - 0.0005,  landLon - 0.0005, 500);
+            seg2.AddPoint(t + 180, landLat,            landLon,          55); // landed
+
+            seg2.WithVesselSnapshot(
+                VesselSnapshotBuilder.FleaRocket("Kerbin Ascent", "Valentina Kerman", pid: 77000000)
+                    .AsLanded(landLat, landLon, 55));
+            seg2.WithGhostVisualSnapshot(
+                VesselSnapshotBuilder.FleaRocket("Kerbin Ascent", "Valentina Kerman", pid: 77000000)
+                    .AsLanded(baseLat, baseLon, 77));
+
+            return new[] { seg0, seg1, seg2 };
+        }
+
+        /// <summary>
         /// Generalized helper for building a static-trajectory, looping showcase recording
         /// that toggles a pair of part events every 3 seconds. Used for lights, deployables,
         /// gear, cargo bays, engines, and deployed science fixtures.
@@ -3272,6 +3356,9 @@ namespace Parsek.Tests
             var walkChainSegments = EvaWalkChain(baseUT);
             for (int i = 0; i < walkChainSegments.Length; i++)
                 writer.AddRecording(walkChainSegments[i].WithLoopPlayback());
+            var atmoChainSegments = KerbinAscentChain(baseUT);
+            for (int i = 0; i < atmoChainSegments.Length; i++)
+                writer.AddRecording(atmoChainSegments[i].WithLoopPlayback());
 
             foreach (string file in targets)
             {
@@ -3484,6 +3571,11 @@ namespace Parsek.Tests
                     Assert.Contains("chainId = chain-eva-board-test", content);
                     Assert.Contains("vesselName = Landing Craft", content);
                     Assert.Contains("chainId = chain-eva-walk-test", content);
+                    Assert.Contains("vesselName = Kerbin Ascent", content);
+                    Assert.Contains("chainId = chain-atmo-split-test", content);
+                    Assert.Contains("segmentPhase = atmo", content);
+                    Assert.Contains("segmentPhase = exo", content);
+                    Assert.Contains("segmentBodyName = Kerbin", content);
                     Assert.Contains("FLIGHTSTATE", content);
 
                     // v3: no inline POINT data in .sfs
@@ -3510,8 +3602,8 @@ namespace Parsek.Tests
                     $"Expected Parsek/Recordings directory at {recordingsDir}");
 
                 string[] precFiles = Directory.GetFiles(recordingsDir, "*.prec");
-                Assert.True(precFiles.Length >= 178,
-                    $"Expected at least 178 .prec files (8 baseline + 6 lights + 18 deployables + 7 gear + 11 cargo + 3 engines + 2 ladders + 3 RCS + 5 fairings + 2 extra radiators + 2 drills + 8 deployed science + 2 animation-group + 5 parachutes + 14 special deploy animations + 29 jettison showcases + 21 robotics + 1 aero-surface + 3 robot-arm-scanner + 24 control-surface + 6 wheel-dynamics + 13 animate-heat + 1 inventory-placement + 3 board-chain + 2 walk-chain), found {precFiles.Length}");
+                Assert.True(precFiles.Length >= 181,
+                    $"Expected at least 181 .prec files (8 baseline + 6 lights + 18 deployables + 7 gear + 11 cargo + 3 engines + 2 ladders + 3 RCS + 5 fairings + 2 extra radiators + 2 drills + 8 deployed science + 2 animation-group + 5 parachutes + 14 special deploy animations + 29 jettison showcases + 21 robotics + 1 aero-surface + 3 robot-arm-scanner + 24 control-surface + 6 wheel-dynamics + 13 animate-heat + 1 inventory-placement + 3 board-chain + 2 walk-chain + 3 atmo-chain), found {precFiles.Length}");
             }
         }
 

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -2862,6 +2862,7 @@ namespace Parsek
 
                 AtmosphereBoundaryCrossed = true;
                 EnteredAtmosphere = nowInAtmo;
+                wasInAtmosphere = nowInAtmo;
                 atmosphereBoundaryPending = false;
                 ParsekLog.Log($"Atmosphere boundary confirmed: {(nowInAtmo ? "entered" : "exited")} " +
                     $"atmosphere of {v.mainBody.name} at alt {altitude:F0}m");

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -115,6 +115,13 @@ namespace Parsek
         private bool isOnRails;
         private OrbitSegment currentOrbitSegment;
 
+        // Atmosphere boundary detection
+        private bool wasInAtmosphere;
+        private bool atmosphereBoundaryPending;
+        private double atmosphereBoundaryPendingUT;
+        public bool AtmosphereBoundaryCrossed { get; private set; }
+        public bool EnteredAtmosphere { get; private set; }
+
         #region Part Event Subscription
 
         private void SubscribePartEvents()
@@ -2785,6 +2792,101 @@ namespace Parsek
 
         #endregion
 
+        #region Atmosphere Boundary Detection
+
+        /// <summary>
+        /// Pure testable function: determines whether a recording should split at the atmosphere boundary.
+        /// Requires both sustained time (hysteresisSeconds) AND distance beyond boundary (hysteresisMeters).
+        /// </summary>
+        internal static bool ShouldSplitAtAtmosphereBoundary(
+            bool wasInAtmo, double altitude, double atmosphereDepth,
+            bool pendingCross, double pendingUT, double currentUT,
+            double hysteresisSeconds = 3.0, double hysteresisMeters = 1000.0)
+        {
+            if (atmosphereDepth <= 0) return false; // no atmosphere
+
+            bool nowInAtmo = altitude < atmosphereDepth;
+            if (nowInAtmo == wasInAtmo)
+                return false; // no boundary crossed
+
+            // Check distance beyond boundary
+            double distBeyond = nowInAtmo
+                ? (atmosphereDepth - altitude)
+                : (altitude - atmosphereDepth);
+            if (distBeyond < hysteresisMeters)
+                return false; // not far enough past boundary
+
+            // Check sustained time
+            if (!pendingCross)
+                return false; // first detection — caller should start the timer
+
+            return (currentUT - pendingUT) >= hysteresisSeconds;
+        }
+
+        /// <summary>
+        /// Called every physics frame to detect atmosphere boundary crossings.
+        /// Sets AtmosphereBoundaryCrossed and EnteredAtmosphere when confirmed.
+        /// </summary>
+        public void CheckAtmosphereBoundary(Vessel v)
+        {
+            if (!IsRecording || isOnRails) return;
+            if (v == null || v.mainBody == null || !v.mainBody.atmosphere) return;
+
+            double altitude = v.altitude;
+            double atmoDepth = v.mainBody.atmosphereDepth;
+            bool nowInAtmo = altitude < atmoDepth;
+            double currentUT = Planetarium.GetUniversalTime();
+
+            if (nowInAtmo == wasInAtmosphere)
+            {
+                // No boundary — reset pending if we drifted back
+                atmosphereBoundaryPending = false;
+                return;
+            }
+
+            // Boundary detected — check hysteresis
+            if (!atmosphereBoundaryPending)
+            {
+                // Start the timer
+                atmosphereBoundaryPending = true;
+                atmosphereBoundaryPendingUT = currentUT;
+                return;
+            }
+
+            if (ShouldSplitAtAtmosphereBoundary(
+                wasInAtmosphere, altitude, atmoDepth,
+                atmosphereBoundaryPending, atmosphereBoundaryPendingUT, currentUT))
+            {
+                // Confirmed crossing — force-sample a boundary point to ensure >= 2 points
+                SamplePosition(v);
+
+                AtmosphereBoundaryCrossed = true;
+                EnteredAtmosphere = nowInAtmo;
+                atmosphereBoundaryPending = false;
+                ParsekLog.Log($"Atmosphere boundary confirmed: {(nowInAtmo ? "entered" : "exited")} " +
+                    $"atmosphere of {v.mainBody.name} at alt {altitude:F0}m");
+            }
+        }
+
+        /// <summary>
+        /// Reseeds atmosphere state from current vessel. Call on SOI change and off-rails.
+        /// </summary>
+        private void ReseedAtmosphereState(Vessel v)
+        {
+            if (v == null || v.mainBody == null)
+            {
+                wasInAtmosphere = false;
+            }
+            else
+            {
+                wasInAtmosphere = v.mainBody.atmosphere && v.altitude < v.mainBody.atmosphereDepth;
+            }
+            atmosphereBoundaryPending = false;
+            AtmosphereBoundaryCrossed = false;
+        }
+
+        #endregion
+
         public void StartRecording()
         {
             if (Time.timeScale < 0.01f)
@@ -2873,6 +2975,13 @@ namespace Parsek
             RecordingStartedAsEva = v.isEVA;
             lastRecordedUT = -1;
             lastRecordedVelocity = Vector3.zero;
+
+            // Seed atmosphere state
+            wasInAtmosphere = v.mainBody != null && v.mainBody.atmosphere
+                && v.altitude < v.mainBody.atmosphereDepth;
+            atmosphereBoundaryPending = false;
+            AtmosphereBoundaryCrossed = false;
+            EnteredAtmosphere = false;
 
             // Insert boundary anchor from previous chain segment if present.
             // Must come AFTER the lastRecordedUT reset above so the anchor's
@@ -3106,6 +3215,9 @@ namespace Parsek
                 return;
             }
 
+            // Check atmosphere boundary (before part state polling)
+            CheckAtmosphereBoundary(v);
+
             // Poll parachute, jettison, engine, RCS, and deployable state every physics frame (before adaptive sampling skip)
             CheckParachuteState(v);
             CheckJettisonState(v);
@@ -3229,6 +3341,9 @@ namespace Parsek
             // Record a boundary TrajectoryPoint at current UT
             SamplePosition(v);
 
+            // Reseed atmosphere state for the current body
+            ReseedAtmosphereState(v);
+
             ParsekLog.Log($"Vessel went off rails — orbit segment closed " +
                 $"(UT {currentOrbitSegment.startUT:F0}-{currentOrbitSegment.endUT:F0})");
         }
@@ -3257,6 +3372,9 @@ namespace Parsek
                 epoch = v.orbit.epoch,
                 bodyName = v.mainBody.name
             };
+
+            // Reseed atmosphere state for the new body
+            ReseedAtmosphereState(v);
 
             ParsekLog.Log($"SOI changed during orbit recording: {data.from.name} → {data.to.name}");
         }

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -122,6 +122,10 @@ namespace Parsek
         public bool AtmosphereBoundaryCrossed { get; private set; }
         public bool EnteredAtmosphere { get; private set; }
 
+        // SOI change detection
+        public bool SoiChangePending { get; private set; }
+        public string SoiChangeFromBody { get; private set; }
+
         #region Part Event Subscription
 
         private void SubscribePartEvents()
@@ -3013,6 +3017,8 @@ namespace Parsek
             atmosphereBoundaryPending = false;
             AtmosphereBoundaryCrossed = false;
             EnteredAtmosphere = false;
+            SoiChangePending = false;
+            SoiChangeFromBody = null;
 
             // Insert boundary anchor from previous chain segment if present.
             // Must come AFTER the lastRecordedUT reset above so the anchor's
@@ -3406,6 +3412,10 @@ namespace Parsek
 
             // Reseed atmosphere state for the new body
             ReseedAtmosphereState(v);
+
+            // Flag for ParsekFlight to trigger chain split in Update()
+            SoiChangePending = true;
+            SoiChangeFromBody = data.from.name;
 
             ParsekLog.Log($"SOI changed during orbit recording: {data.from.name} → {data.to.name}");
         }

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -354,6 +354,24 @@ namespace Parsek
                 }
             }
 
+            // Atmosphere boundary: auto-split when crossing atmosphere edge
+            if (recorder != null && recorder.IsRecording && recorder.AtmosphereBoundaryCrossed &&
+                ParsekSettings.Current?.autoSplitAtAtmosphere != false)
+            {
+                string phase = recorder.EnteredAtmosphere ? "exo" : "atmo";
+                string bodyName = FlightGlobals.ActiveVessel?.mainBody?.name ?? "Unknown";
+                recorder.StopRecordingForChainBoundary();
+                CommitAtmosphereSegment(phase, bodyName);
+                recorder = null;
+                StartRecording();
+                if (IsRecording)
+                {
+                    recorder.UndockSiblingPid = undockContinuationPid;
+                    Log($"Recording continues after atmosphere boundary (chain={activeChainId}, idx={activeChainNextIndex}, phase={phase}→{(phase == "atmo" ? "exo" : "atmo")})");
+                    ScreenMessage($"Recording continues ({(recorder.EnteredAtmosphere ? "entering" : "exiting")} atmosphere)", 2f);
+                }
+            }
+
             // Complete deferred auto-record for EVA (vessel switch may take a frame)
             if (pendingAutoRecord && !IsRecording &&
                 FlightGlobals.ActiveVessel != null && FlightGlobals.ActiveVessel.isEVA)
@@ -530,6 +548,18 @@ namespace Parsek
                         RecordingStore.Pending.ChainIndex = activeChainNextIndex;
                         RecordingStore.Pending.ParentRecordingId = activeChainPrevId;
                         RecordingStore.Pending.EvaCrewName = activeChainCrewName;
+                    }
+
+                    // Tag atmosphere phase in fallback path
+                    if (RecordingStore.HasPending && string.IsNullOrEmpty(RecordingStore.Pending.SegmentPhase))
+                    {
+                        var v = FlightGlobals.ActiveVessel;
+                        if (v != null && v.mainBody != null && v.mainBody.atmosphere)
+                        {
+                            bool inAtmo = v.altitude < v.mainBody.atmosphereDepth;
+                            RecordingStore.Pending.SegmentPhase = inAtmo ? "atmo" : "exo";
+                            RecordingStore.Pending.SegmentBodyName = v.mainBody.name;
+                        }
                     }
                 }
 
@@ -1038,6 +1068,69 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Commits the current segment as an atmosphere boundary chain split.
+        /// Follows the same pattern as CommitDockUndockSegment.
+        /// </summary>
+        void CommitAtmosphereSegment(string completedPhase, string bodyName)
+        {
+            var captured = recorder.CaptureAtStop;
+            string segmentId = captured != null ? captured.RecordingId : null;
+            Log($"Atmosphere chain: committing segment (id={segmentId}, phase={completedPhase}, body={bodyName})");
+
+            RecordingStore.StashPending(
+                recorder.Recording,
+                captured != null ? captured.VesselName : (FlightGlobals.ActiveVessel?.vesselName ?? "Unknown"),
+                recorder.OrbitSegments,
+                recordingId: segmentId,
+                recordingFormatVersion: captured != null ? (int?)captured.RecordingFormatVersion : null,
+                ghostGeometryVersion: captured != null ? (int?)captured.GhostGeometryVersion : null,
+                partEvents: recorder.PartEvents);
+
+            if (!RecordingStore.HasPending)
+            {
+                Log("Atmosphere chain: segment too short to stash — aborting");
+                return;
+            }
+
+            if (captured != null)
+                RecordingStore.Pending.ApplyPersistenceArtifactsFrom(captured);
+
+            // Tag segment with atmosphere phase
+            RecordingStore.Pending.SegmentPhase = completedPhase;
+            RecordingStore.Pending.SegmentBodyName = bodyName;
+
+            // First transition: initialize chain
+            if (activeChainId == null)
+            {
+                activeChainId = System.Guid.NewGuid().ToString("N");
+                activeChainNextIndex = 0;
+                Log($"Atmosphere chain: started new chain (id={activeChainId})");
+            }
+
+            // Tag segment with chain metadata
+            RecordingStore.Pending.ChainId = activeChainId;
+            RecordingStore.Pending.ChainIndex = activeChainNextIndex;
+            RecordingStore.Pending.ChainBranch = 0;
+            RecordingStore.Pending.ParentRecordingId = activeChainPrevId;
+            RecordingStore.Pending.EvaCrewName = activeChainCrewName;
+
+            // Mid-chain segments are ghost-only
+            RecordingStore.Pending.VesselSnapshot = null;
+
+            RecordingStore.CommitPending();
+            ParsekScenario.ReserveSnapshotCrew();
+            ParsekScenario.SwapReservedCrewInFlight();
+
+            // Prepare boundary anchor from last point of committed segment
+            if (recorder.Recording.Count > 0)
+                pendingBoundaryAnchor = recorder.Recording[recorder.Recording.Count - 1];
+
+            // Advance chain state
+            activeChainNextIndex++;
+            activeChainPrevId = segmentId;
+        }
+
+        /// <summary>
         /// Starts ghost-only continuation recording for the "other" vessel after undock.
         /// This vessel gets ChainBranch = 1 so it plays back as a ghost but never spawns.
         /// </summary>
@@ -1361,6 +1454,18 @@ namespace Parsek
                 recorder.CaptureAtStop.ParentRecordingId = activeChainPrevId;
                 recorder.CaptureAtStop.EvaCrewName = activeChainCrewName;
             }
+
+            // Tag final segment with atmosphere phase if untagged
+            if (recorder?.CaptureAtStop != null && string.IsNullOrEmpty(recorder.CaptureAtStop.SegmentPhase))
+            {
+                var v = FlightGlobals.ActiveVessel;
+                if (v != null && v.mainBody != null && v.mainBody.atmosphere)
+                {
+                    bool inAtmo = v.altitude < v.mainBody.atmosphereDepth;
+                    recorder.CaptureAtStop.SegmentPhase = inAtmo ? "atmo" : "exo";
+                    recorder.CaptureAtStop.SegmentBodyName = v.mainBody.name;
+                }
+            }
         }
 
         public void ClearRecording()
@@ -1579,6 +1684,7 @@ namespace Parsek
                     var rec = committed[i];
                     if (rec.Points.Count < 2) continue;
                     if (ShouldLoopPlayback(rec)) continue;
+                    if (!rec.PlaybackEnabled) continue;
                     if (rec.VesselSnapshot == null || rec.VesselSpawned || rec.VesselDestroyed ||
                         RecordingStore.IsChainMidSegment(rec)) continue;
 
@@ -1612,6 +1718,16 @@ namespace Parsek
                 ghostStates.TryGetValue(i, out state);
                 bool ghostActive = state != null && state.ghost != null;
 
+                // Disabled segments: destroy ghost if active, still apply resource deltas
+                if (!rec.PlaybackEnabled)
+                {
+                    if (ghostActive)
+                        DestroyTimelineGhost(i);
+                    if (pastEnd)
+                        ApplyResourceDeltas(rec, currentUT);
+                    continue;
+                }
+
                 if (ShouldLoopPlayback(rec))
                 {
                     UpdateLoopingTimelinePlayback(i, rec, currentUT, state, ghostActive);
@@ -1633,6 +1749,14 @@ namespace Parsek
                 if (needsSpawn && activeChainId != null && rec.ChainId == activeChainId)
                 {
                     needsSpawn = false;
+                }
+
+                // Suppress spawn for looping or fully-disabled chains
+                if (needsSpawn && !string.IsNullOrEmpty(rec.ChainId))
+                {
+                    if (RecordingStore.IsChainLooping(rec.ChainId) ||
+                        RecordingStore.IsChainFullyDisabled(rec.ChainId))
+                        needsSpawn = false;
                 }
 
                 // One-time chain spawn diagnostics when entering the spawn window

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -361,7 +361,7 @@ namespace Parsek
                 string phase = recorder.EnteredAtmosphere ? "exo" : "atmo";
                 string bodyName = FlightGlobals.ActiveVessel?.mainBody?.name ?? "Unknown";
                 recorder.StopRecordingForChainBoundary();
-                CommitAtmosphereSegment(phase, bodyName);
+                CommitBoundarySplit(phase, bodyName);
                 recorder = null;
                 StartRecording();
                 if (IsRecording)
@@ -369,6 +369,27 @@ namespace Parsek
                     recorder.UndockSiblingPid = undockContinuationPid;
                     Log($"Recording continues after atmosphere boundary (chain={activeChainId}, idx={activeChainNextIndex}, phase={phase}→{(phase == "atmo" ? "exo" : "atmo")})");
                     ScreenMessage($"Recording continues ({(recorder.EnteredAtmosphere ? "entering" : "exiting")} atmosphere)", 2f);
+                }
+            }
+
+            // SOI change: auto-split when transitioning between celestial bodies
+            if (recorder != null && recorder.IsRecording && recorder.SoiChangePending &&
+                ParsekSettings.Current?.autoSplitAtSoi != false)
+            {
+                string fromBody = recorder.SoiChangeFromBody ?? "Unknown";
+                string toBody = FlightGlobals.ActiveVessel?.mainBody?.name ?? "Unknown";
+                // Completed segment was at fromBody — tag as "exo" if it has atmosphere, "space" otherwise
+                CelestialBody fromCB = FlightGlobals.Bodies?.Find(b => b.name == fromBody);
+                string fromPhase = (fromCB != null && fromCB.atmosphere) ? "exo" : "space";
+                recorder.StopRecordingForChainBoundary();
+                CommitBoundarySplit(fromPhase, fromBody);
+                recorder = null;
+                StartRecording();
+                if (IsRecording)
+                {
+                    recorder.UndockSiblingPid = undockContinuationPid;
+                    Log($"Recording continues after SOI change ({fromBody} → {toBody}, chain={activeChainId}, idx={activeChainNextIndex})");
+                    ScreenMessage($"Recording continues (entering {toBody} SOI)", 2f);
                 }
             }
 
@@ -550,15 +571,17 @@ namespace Parsek
                         RecordingStore.Pending.EvaCrewName = activeChainCrewName;
                     }
 
-                    // Tag atmosphere phase in fallback path
+                    // Tag segment phase in fallback path
                     if (RecordingStore.HasPending && string.IsNullOrEmpty(RecordingStore.Pending.SegmentPhase))
                     {
                         var v = FlightGlobals.ActiveVessel;
-                        if (v != null && v.mainBody != null && v.mainBody.atmosphere)
+                        if (v != null && v.mainBody != null)
                         {
-                            bool inAtmo = v.altitude < v.mainBody.atmosphereDepth;
-                            RecordingStore.Pending.SegmentPhase = inAtmo ? "atmo" : "exo";
                             RecordingStore.Pending.SegmentBodyName = v.mainBody.name;
+                            if (v.mainBody.atmosphere)
+                                RecordingStore.Pending.SegmentPhase = v.altitude < v.mainBody.atmosphereDepth ? "atmo" : "exo";
+                            else
+                                RecordingStore.Pending.SegmentPhase = "space";
                         }
                     }
                 }
@@ -1071,11 +1094,11 @@ namespace Parsek
         /// Commits the current segment as an atmosphere boundary chain split.
         /// Follows the same pattern as CommitDockUndockSegment.
         /// </summary>
-        void CommitAtmosphereSegment(string completedPhase, string bodyName)
+        void CommitBoundarySplit(string completedPhase, string bodyName)
         {
             var captured = recorder.CaptureAtStop;
             string segmentId = captured != null ? captured.RecordingId : null;
-            Log($"Atmosphere chain: committing segment (id={segmentId}, phase={completedPhase}, body={bodyName})");
+            Log($"Boundary split: committing segment (id={segmentId}, phase={completedPhase}, body={bodyName})");
 
             RecordingStore.StashPending(
                 recorder.Recording,
@@ -1088,14 +1111,14 @@ namespace Parsek
 
             if (!RecordingStore.HasPending)
             {
-                Log("Atmosphere chain: segment too short to stash — aborting");
+                Log("Boundary split: segment too short to stash — aborting");
                 return;
             }
 
             if (captured != null)
                 RecordingStore.Pending.ApplyPersistenceArtifactsFrom(captured);
 
-            // Tag segment with atmosphere phase
+            // Tag segment with phase and body
             RecordingStore.Pending.SegmentPhase = completedPhase;
             RecordingStore.Pending.SegmentBodyName = bodyName;
 
@@ -1104,7 +1127,7 @@ namespace Parsek
             {
                 activeChainId = System.Guid.NewGuid().ToString("N");
                 activeChainNextIndex = 0;
-                Log($"Atmosphere chain: started new chain (id={activeChainId})");
+                Log($"Boundary split: started new chain (id={activeChainId})");
             }
 
             // Tag segment with chain metadata
@@ -1455,15 +1478,17 @@ namespace Parsek
                 recorder.CaptureAtStop.EvaCrewName = activeChainCrewName;
             }
 
-            // Tag final segment with atmosphere phase if untagged
+            // Tag final segment phase if untagged
             if (recorder?.CaptureAtStop != null && string.IsNullOrEmpty(recorder.CaptureAtStop.SegmentPhase))
             {
                 var v = FlightGlobals.ActiveVessel;
-                if (v != null && v.mainBody != null && v.mainBody.atmosphere)
+                if (v != null && v.mainBody != null)
                 {
-                    bool inAtmo = v.altitude < v.mainBody.atmosphereDepth;
-                    recorder.CaptureAtStop.SegmentPhase = inAtmo ? "atmo" : "exo";
                     recorder.CaptureAtStop.SegmentBodyName = v.mainBody.name;
+                    if (v.mainBody.atmosphere)
+                        recorder.CaptureAtStop.SegmentPhase = v.altitude < v.mainBody.atmosphereDepth ? "atmo" : "exo";
+                    else
+                        recorder.CaptureAtStop.SegmentPhase = "space";
                 }
             }
         }

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -164,6 +164,7 @@ namespace Parsek
                     uint savedPid = 0;
                     bool savedTaken = false;
                     int resIdx = -1;
+                    bool savedPlaybackEnabled = true;
                     if (i < savedRecNodes.Length)
                     {
                         string pidStr = savedRecNodes[i].GetValue("spawnedPid");
@@ -177,10 +178,15 @@ namespace Parsek
                         string resIdxStr = savedRecNodes[i].GetValue("lastResIdx");
                         if (resIdxStr != null)
                             int.TryParse(resIdxStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out resIdx);
+
+                        string playbackEnabledStr = savedRecNodes[i].GetValue("playbackEnabled");
+                        if (playbackEnabledStr != null)
+                            bool.TryParse(playbackEnabledStr, out savedPlaybackEnabled);
                     }
                     recordings[i].SpawnedVesselPersistentId = savedPid;
                     recordings[i].TakenControl = savedTaken;
                     recordings[i].LastAppliedResourceIndex = resIdx;
+                    recordings[i].PlaybackEnabled = savedPlaybackEnabled;
                 }
 
                 ReserveSnapshotCrew();
@@ -359,6 +365,14 @@ namespace Parsek
             recNode.AddValue("ghostGeometryAvailable", rec.GhostGeometryAvailable);
             if (!string.IsNullOrEmpty(rec.GhostGeometryCaptureError))
                 recNode.AddValue("ghostGeometryError", rec.GhostGeometryCaptureError);
+
+            // Atmosphere segment metadata (only if set, saves space)
+            if (!string.IsNullOrEmpty(rec.SegmentPhase))
+                recNode.AddValue("segmentPhase", rec.SegmentPhase);
+            if (!string.IsNullOrEmpty(rec.SegmentBodyName))
+                recNode.AddValue("segmentBodyName", rec.SegmentBodyName);
+            if (!rec.PlaybackEnabled)
+                recNode.AddValue("playbackEnabled", rec.PlaybackEnabled.ToString());
         }
 
         /// <summary>
@@ -419,6 +433,17 @@ namespace Parsek
                     rec.GhostGeometryAvailable = geomAvailable;
             }
             rec.GhostGeometryCaptureError = recNode.GetValue("ghostGeometryError");
+
+            // Atmosphere segment metadata
+            rec.SegmentPhase = recNode.GetValue("segmentPhase");
+            rec.SegmentBodyName = recNode.GetValue("segmentBodyName");
+            string playbackEnabledStr = recNode.GetValue("playbackEnabled");
+            if (playbackEnabledStr != null)
+            {
+                bool playbackEnabled;
+                if (bool.TryParse(playbackEnabledStr, out playbackEnabled))
+                    rec.PlaybackEnabled = playbackEnabled;
+            }
         }
 
         /// <summary>
@@ -436,6 +461,7 @@ namespace Parsek
                 foreach (var rec in RecordingStore.CommittedRecordings)
                 {
                     if (rec.LoopPlayback) continue;
+                    if (RecordingStore.IsChainFullyDisabled(rec.ChainId)) continue;
                     ReserveCrewIn(rec.VesselSnapshot, rec.VesselSpawned, roster);
                 }
 

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -164,7 +164,6 @@ namespace Parsek
                     uint savedPid = 0;
                     bool savedTaken = false;
                     int resIdx = -1;
-                    bool savedPlaybackEnabled = true;
                     if (i < savedRecNodes.Length)
                     {
                         string pidStr = savedRecNodes[i].GetValue("spawnedPid");
@@ -181,12 +180,15 @@ namespace Parsek
 
                         string playbackEnabledStr = savedRecNodes[i].GetValue("playbackEnabled");
                         if (playbackEnabledStr != null)
-                            bool.TryParse(playbackEnabledStr, out savedPlaybackEnabled);
+                        {
+                            bool savedPlaybackEnabled;
+                            if (bool.TryParse(playbackEnabledStr, out savedPlaybackEnabled))
+                                recordings[i].PlaybackEnabled = savedPlaybackEnabled;
+                        }
                     }
                     recordings[i].SpawnedVesselPersistentId = savedPid;
                     recordings[i].TakenControl = savedTaken;
                     recordings[i].LastAppliedResourceIndex = resIdx;
-                    recordings[i].PlaybackEnabled = savedPlaybackEnabled;
                 }
 
                 ReserveSnapshotCrew();

--- a/Source/Parsek/ParsekSettings.cs
+++ b/Source/Parsek/ParsekSettings.cs
@@ -25,6 +25,10 @@ namespace Parsek
             toolTip = "Automatically split recordings when crossing the atmosphere boundary")]
         public bool autoSplitAtAtmosphere = true;
 
+        [GameParameters.CustomParameterUI("Auto-split at SOI change",
+            toolTip = "Automatically split recordings when entering a new sphere of influence")]
+        public bool autoSplitAtSoi = true;
+
         [GameParameters.CustomFloatParameterUI("Max sample interval (s)", minValue = 1f, maxValue = 10f,
             stepCount = 19, displayFormat = "F1",
             toolTip = "Maximum seconds between trajectory samples")]

--- a/Source/Parsek/ParsekSettings.cs
+++ b/Source/Parsek/ParsekSettings.cs
@@ -21,6 +21,10 @@ namespace Parsek
             toolTip = "Stop time warp when a ghost playback is about to begin")]
         public bool autoWarpStop = true;
 
+        [GameParameters.CustomParameterUI("Auto-split at atmosphere boundary",
+            toolTip = "Automatically split recordings when crossing the atmosphere boundary")]
+        public bool autoSplitAtAtmosphere = true;
+
         [GameParameters.CustomFloatParameterUI("Max sample interval (s)", minValue = 1f, maxValue = 10f,
             stepCount = 19, displayFormat = "F1",
             toolTip = "Maximum seconds between trajectory samples")]

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -35,6 +35,8 @@ namespace Parsek
         private const string SettingsInputLockId = "Parsek_SettingsWindow";
 
         // Column widths — shared between header and body for alignment
+        private const float ColW_Enable = 15f;
+        private const float ColW_Phase = 70f;
         private const float ColW_Index = 25f;
         private const float ColW_Launch = 110f;
         private const float ColW_Dur = 55f;
@@ -43,6 +45,13 @@ namespace Parsek
         private const float ColW_LoopToggle = 15f;
         private const float ColW_Delete = 25f;
         private const float ScrollbarWidth = 16f;
+
+        // Chain grouping state
+        private HashSet<string> expandedChains = new HashSet<string>();
+
+        // Cached phase label styles
+        private GUIStyle phaseStyleAtmo;
+        private GUIStyle phaseStyleExo;
 
         // Sort state
         internal enum SortColumn { Index, Name, LaunchTime, Duration, Status }
@@ -255,12 +264,24 @@ namespace Parsek
             recordingsWindowHasInputLock = false;
         }
 
+        private void EnsurePhaseStyles()
+        {
+            if (phaseStyleAtmo != null) return;
+
+            phaseStyleAtmo = new GUIStyle(GUI.skin.label);
+            phaseStyleAtmo.normal.textColor = new Color(1f, 0.6f, 0.2f); // orange
+
+            phaseStyleExo = new GUIStyle(GUI.skin.label);
+            phaseStyleExo.normal.textColor = new Color(0.3f, 0.8f, 1f); // cyan
+        }
+
         private void DrawRecordingsWindow(int windowID)
         {
             var committed = RecordingStore.CommittedRecordings;
             double now = Planetarium.GetUniversalTime();
 
             EnsureStatusStyles();
+            EnsurePhaseStyles();
             RebuildSortedIndices(committed, now);
 
             if (committed.Count == 0)
@@ -269,12 +290,11 @@ namespace Parsek
             }
             else
             {
-                // Header row with sortable columns
-                // Use same widths as body row cells to ensure alignment.
-                // Add scrollbar-width spacer at end so header spans the same
-                // content width as the scroll view body.
+                // Header row
                 GUILayout.BeginHorizontal();
+                GUILayout.Label("", GUILayout.Width(ColW_Enable)); // enable column header
                 DrawSortableHeader("#", SortColumn.Index, ColW_Index);
+                GUILayout.Label("Phase", GUILayout.Width(ColW_Phase));
                 DrawSortableHeader("Name", SortColumn.Name, 0, true);
                 DrawSortableHeader("Launch", SortColumn.LaunchTime, ColW_Launch);
                 DrawSortableHeader("Dur", SortColumn.Duration, ColW_Dur);
@@ -295,84 +315,84 @@ namespace Parsek
                 }
 
                 GUILayout.Button("", GUI.skin.label, GUILayout.Width(ColW_Delete)); // placeholder
-                GUILayout.Space(ScrollbarWidth); // account for scrollbar in body
+                GUILayout.Space(ScrollbarWidth);
                 GUILayout.EndHorizontal();
 
-                // Scrollable table body (expands to fill available window space)
+                // Scrollable table body
                 recordingsScrollPos = GUILayout.BeginScrollView(
                     recordingsScrollPos, GUILayout.ExpandHeight(true));
+
+                // Build chain grouping: chainId → list of sorted row indices
+                var chainRows = new Dictionary<string, List<int>>();
+                var standaloneRows = new List<int>();
+                var seenChains = new HashSet<string>();
 
                 for (int row = 0; row < sortedIndices.Length; row++)
                 {
                     int ri = sortedIndices[row];
                     var rec = committed[ri];
-                    GUILayout.BeginHorizontal();
-
-                    // #
-                    GUILayout.Label((ri + 1).ToString(), GUILayout.Width(ColW_Index));
-
-                    // Name
-                    string name = string.IsNullOrEmpty(rec.VesselName) ? "Untitled" : rec.VesselName;
-                    GUILayout.Label(name, GUILayout.ExpandWidth(true));
-
-                    // Launch Time
-                    string launchTime = rec.Points.Count > 0
-                        ? KSPUtil.PrintDateCompact(rec.StartUT, true)
-                        : "-";
-                    GUILayout.Label(launchTime, GUILayout.Width(ColW_Launch));
-
-                    // Duration
-                    double dur = rec.EndUT - rec.StartUT;
-                    GUILayout.Label(FormatDuration(dur), GUILayout.Width(ColW_Dur));
-
-                    // Status
-                    GUIStyle statusStyle;
-                    string statusText;
-                    if (now < rec.StartUT)
+                    if (!string.IsNullOrEmpty(rec.ChainId))
                     {
-                        statusStyle = statusStyleFuture;
-                        statusText = "future";
-                    }
-                    else if (now <= rec.EndUT)
-                    {
-                        statusStyle = statusStyleActive;
-                        statusText = "active";
+                        List<int> list;
+                        if (!chainRows.TryGetValue(rec.ChainId, out list))
+                        {
+                            list = new List<int>();
+                            chainRows[rec.ChainId] = list;
+                        }
+                        list.Add(ri);
                     }
                     else
                     {
-                        statusStyle = statusStylePast;
-                        statusText = "past";
+                        standaloneRows.Add(ri);
                     }
-                    GUILayout.Label(statusText, statusStyle, GUILayout.Width(ColW_Status));
+                }
 
-                    // Loop checkbox
-                    GUILayout.Label("", GUILayout.Width(ColW_LoopLabel));
-                    bool loop = GUILayout.Toggle(rec.LoopPlayback, "", GUILayout.Width(ColW_LoopToggle));
-                    if (loop != rec.LoopPlayback)
-                        rec.LoopPlayback = loop;
+                // Draw standalone recordings first
+                for (int s = 0; s < standaloneRows.Count; s++)
+                {
+                    if (DrawRecordingRow(standaloneRows[s], committed, now, false))
+                        break;
+                }
 
-                    // Delete button (disabled during recording/continuation)
-                    GUI.enabled = flight.CanDeleteRecording;
-                    if (deleteConfirmIndex == ri)
+                // Draw chain groups
+                foreach (var kvp in chainRows)
+                {
+                    string chainId = kvp.Key;
+                    var members = kvp.Value;
+                    if (members.Count == 0) continue;
+
+                    // Chain header
+                    GUILayout.BeginHorizontal();
+                    bool expanded = expandedChains.Contains(chainId);
+                    string arrow = expanded ? "\u25bc" : "\u25b6";
+                    string chainName = committed[members[0]].VesselName;
+                    if (string.IsNullOrEmpty(chainName)) chainName = "Chain";
+
+                    // Aggregate duration
+                    double chainStart = double.MaxValue, chainEnd = double.MinValue;
+                    for (int m = 0; m < members.Count; m++)
                     {
-                        if (GUILayout.Button("?", GUILayout.Width(ColW_Delete)))
+                        var mr = committed[members[m]];
+                        if (mr.StartUT < chainStart) chainStart = mr.StartUT;
+                        if (mr.EndUT > chainEnd) chainEnd = mr.EndUT;
+                    }
+
+                    if (GUILayout.Button($"{arrow} {chainName} ({members.Count} segments, {FormatDuration(chainEnd - chainStart)})",
+                        GUI.skin.label, GUILayout.ExpandWidth(true)))
+                    {
+                        if (expanded) expandedChains.Remove(chainId);
+                        else expandedChains.Add(chainId);
+                    }
+                    GUILayout.EndHorizontal();
+
+                    if (expanded)
+                    {
+                        for (int m = 0; m < members.Count; m++)
                         {
-                            deleteConfirmIndex = -1;
-                            flight.DeleteRecording(ri);
-                            InvalidateSort();
-                            GUI.enabled = true;
-                            GUILayout.EndHorizontal();
-                            break; // list changed, stop iterating
+                            if (DrawRecordingRow(members[m], committed, now, true))
+                                break;
                         }
                     }
-                    else
-                    {
-                        if (GUILayout.Button("X", GUILayout.Width(ColW_Delete)))
-                            deleteConfirmIndex = ri;
-                    }
-                    GUI.enabled = true;
-
-                    GUILayout.EndHorizontal();
                 }
 
                 GUILayout.EndScrollView();
@@ -399,6 +419,102 @@ namespace Parsek
             }
 
             GUI.DragWindow();
+        }
+
+        /// <summary>
+        /// Draws a single recording row. Returns true if the list was modified (break iteration).
+        /// </summary>
+        private bool DrawRecordingRow(int ri, List<RecordingStore.Recording> committed, double now, bool indented)
+        {
+            var rec = committed[ri];
+            GUILayout.BeginHorizontal();
+
+            if (indented)
+                GUILayout.Space(15f); // indent chain children
+
+            // Enable checkbox
+            bool enabled = GUILayout.Toggle(rec.PlaybackEnabled, "", GUILayout.Width(ColW_Enable));
+            if (enabled != rec.PlaybackEnabled)
+                rec.PlaybackEnabled = enabled;
+
+            // #
+            GUILayout.Label((ri + 1).ToString(), GUILayout.Width(ColW_Index));
+
+            // Phase label
+            string phaseLabel = RecordingStore.GetSegmentPhaseLabel(rec);
+            if (!string.IsNullOrEmpty(phaseLabel))
+            {
+                GUIStyle phaseStyle = rec.SegmentPhase == "atmo" ? phaseStyleAtmo : phaseStyleExo;
+                GUILayout.Label(phaseLabel, phaseStyle, GUILayout.Width(ColW_Phase));
+            }
+            else
+            {
+                GUILayout.Label("", GUILayout.Width(ColW_Phase));
+            }
+
+            // Name
+            string name = string.IsNullOrEmpty(rec.VesselName) ? "Untitled" : rec.VesselName;
+            GUILayout.Label(name, GUILayout.ExpandWidth(true));
+
+            // Launch Time
+            string launchTime = rec.Points.Count > 0
+                ? KSPUtil.PrintDateCompact(rec.StartUT, true)
+                : "-";
+            GUILayout.Label(launchTime, GUILayout.Width(ColW_Launch));
+
+            // Duration
+            double dur = rec.EndUT - rec.StartUT;
+            GUILayout.Label(FormatDuration(dur), GUILayout.Width(ColW_Dur));
+
+            // Status
+            GUIStyle statusStyle;
+            string statusText;
+            if (now < rec.StartUT)
+            {
+                statusStyle = statusStyleFuture;
+                statusText = "future";
+            }
+            else if (now <= rec.EndUT)
+            {
+                statusStyle = statusStyleActive;
+                statusText = "active";
+            }
+            else
+            {
+                statusStyle = statusStylePast;
+                statusText = "past";
+            }
+            GUILayout.Label(statusText, statusStyle, GUILayout.Width(ColW_Status));
+
+            // Loop checkbox
+            GUILayout.Label("", GUILayout.Width(ColW_LoopLabel));
+            bool loop = GUILayout.Toggle(rec.LoopPlayback, "", GUILayout.Width(ColW_LoopToggle));
+            if (loop != rec.LoopPlayback)
+                rec.LoopPlayback = loop;
+
+            // Delete button
+            GUI.enabled = flight.CanDeleteRecording;
+            if (deleteConfirmIndex == ri)
+            {
+                if (GUILayout.Button("?", GUILayout.Width(ColW_Delete)))
+                {
+                    deleteConfirmIndex = -1;
+                    flight.DeleteRecording(ri);
+                    InvalidateSort();
+                    GUI.enabled = true;
+                    GUILayout.EndHorizontal();
+                    return true; // list changed
+                }
+            }
+            else
+            {
+                if (GUILayout.Button("X", GUILayout.Width(ColW_Delete)))
+                    deleteConfirmIndex = ri;
+            }
+            GUI.enabled = true;
+
+            GUILayout.EndHorizontal();
+            return false;
         }
 
         private void DrawSortableHeader(string label, SortColumn col, float width, bool expand = false)

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -378,50 +378,55 @@ namespace Parsek
                 }
 
                 // Draw standalone recordings first
+                bool deleted = false;
                 for (int s = 0; s < standaloneRows.Count; s++)
                 {
                     if (DrawRecordingRow(standaloneRows[s], committed, now, false))
-                        break;
+                    { deleted = true; break; }
                 }
 
                 // Draw chain groups
-                foreach (var kvp in chainRows)
+                if (!deleted)
                 {
-                    string chainId = kvp.Key;
-                    var members = kvp.Value;
-                    if (members.Count == 0) continue;
-
-                    // Chain header
-                    GUILayout.BeginHorizontal();
-                    bool expanded = expandedChains.Contains(chainId);
-                    string arrow = expanded ? "\u25bc" : "\u25b6";
-                    string chainName = committed[members[0]].VesselName;
-                    if (string.IsNullOrEmpty(chainName)) chainName = "Chain";
-
-                    // Aggregate duration
-                    double chainStart = double.MaxValue, chainEnd = double.MinValue;
-                    for (int m = 0; m < members.Count; m++)
+                    foreach (var kvp in chainRows)
                     {
-                        var mr = committed[members[m]];
-                        if (mr.StartUT < chainStart) chainStart = mr.StartUT;
-                        if (mr.EndUT > chainEnd) chainEnd = mr.EndUT;
-                    }
+                        string chainId = kvp.Key;
+                        var members = kvp.Value;
+                        if (members.Count == 0) continue;
 
-                    if (GUILayout.Button($"{arrow} {chainName} ({members.Count} segments, {FormatDuration(chainEnd - chainStart)})",
-                        GUI.skin.label, GUILayout.ExpandWidth(true)))
-                    {
-                        if (expanded) expandedChains.Remove(chainId);
-                        else expandedChains.Add(chainId);
-                    }
-                    GUILayout.EndHorizontal();
+                        // Chain header
+                        GUILayout.BeginHorizontal();
+                        bool expanded = expandedChains.Contains(chainId);
+                        string arrow = expanded ? "\u25bc" : "\u25b6";
+                        string chainName = committed[members[0]].VesselName;
+                        if (string.IsNullOrEmpty(chainName)) chainName = "Chain";
 
-                    if (expanded)
-                    {
+                        // Aggregate duration
+                        double chainStart = double.MaxValue, chainEnd = double.MinValue;
                         for (int m = 0; m < members.Count; m++)
                         {
-                            if (DrawRecordingRow(members[m], committed, now, true))
-                                break;
+                            var mr = committed[members[m]];
+                            if (mr.StartUT < chainStart) chainStart = mr.StartUT;
+                            if (mr.EndUT > chainEnd) chainEnd = mr.EndUT;
                         }
+
+                        if (GUILayout.Button($"{arrow} {chainName} ({members.Count} segments, {FormatDuration(chainEnd - chainStart)})",
+                            GUI.skin.label, GUILayout.ExpandWidth(true)))
+                        {
+                            if (expanded) expandedChains.Remove(chainId);
+                            else expandedChains.Add(chainId);
+                        }
+                        GUILayout.EndHorizontal();
+
+                        if (expanded)
+                        {
+                            for (int m = 0; m < members.Count; m++)
+                            {
+                                if (DrawRecordingRow(members[m], committed, now, true))
+                                { deleted = true; break; }
+                            }
+                        }
+                        if (deleted) break;
                     }
                 }
 

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -358,7 +358,6 @@ namespace Parsek
 
                 // Build chain grouping: chainId → list of sorted row indices
                 var chainRows = new Dictionary<string, List<int>>();
-                var standaloneRows = new List<int>();
                 var seenChains = new HashSet<string>();
 
                 for (int row = 0; row < sortedIndices.Length; row++)
@@ -375,32 +374,30 @@ namespace Parsek
                         }
                         list.Add(ri);
                     }
-                    else
-                    {
-                        standaloneRows.Add(ri);
-                    }
                 }
 
-                // Draw standalone recordings first
+                // Draw in sorted order — standalone rows inline, chain groups
+                // emitted at the position of their first sorted member
                 bool deleted = false;
-                for (int s = 0; s < standaloneRows.Count; s++)
+                for (int row = 0; row < sortedIndices.Length && !deleted; row++)
                 {
-                    if (DrawRecordingRow(standaloneRows[s], committed, now, false))
-                    { deleted = true; break; }
-                }
+                    int ri = sortedIndices[row];
+                    var rec = committed[ri];
 
-                // Draw chain groups
-                if (!deleted)
-                {
-                    foreach (var kvp in chainRows)
+                    if (string.IsNullOrEmpty(rec.ChainId))
                     {
-                        string chainId = kvp.Key;
-                        var members = kvp.Value;
-                        if (members.Count == 0) continue;
+                        // Standalone recording
+                        if (DrawRecordingRow(ri, committed, now, false))
+                        { deleted = true; break; }
+                    }
+                    else if (seenChains.Add(rec.ChainId))
+                    {
+                        // First time seeing this chain — draw the whole group here
+                        var members = chainRows[rec.ChainId];
 
                         // Chain header
                         GUILayout.BeginHorizontal();
-                        bool expanded = expandedChains.Contains(chainId);
+                        bool expanded = expandedChains.Contains(rec.ChainId);
                         string arrow = expanded ? "\u25bc" : "\u25b6";
                         string chainName = committed[members[0]].VesselName;
                         if (string.IsNullOrEmpty(chainName)) chainName = "Chain";
@@ -417,8 +414,8 @@ namespace Parsek
                         if (GUILayout.Button($"{arrow} {chainName} ({members.Count} segments, {FormatDuration(chainEnd - chainStart)})",
                             GUI.skin.label, GUILayout.ExpandWidth(true)))
                         {
-                            if (expanded) expandedChains.Remove(chainId);
-                            else expandedChains.Add(chainId);
+                            if (expanded) expandedChains.Remove(rec.ChainId);
+                            else expandedChains.Add(rec.ChainId);
                         }
                         GUILayout.EndHorizontal();
 
@@ -430,8 +427,8 @@ namespace Parsek
                                 { deleted = true; break; }
                             }
                         }
-                        if (deleted) break;
                     }
+                    // else: chain member already drawn with its group — skip
                 }
 
                 GUILayout.EndScrollView();

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -52,6 +52,7 @@ namespace Parsek
         // Cached phase label styles
         private GUIStyle phaseStyleAtmo;
         private GUIStyle phaseStyleExo;
+        private GUIStyle phaseStyleSpace;
 
         // Sort state
         internal enum SortColumn { Index, Name, LaunchTime, Duration, Status }
@@ -290,6 +291,9 @@ namespace Parsek
 
             phaseStyleExo = new GUIStyle(GUI.skin.label);
             phaseStyleExo.normal.textColor = new Color(0.3f, 0.8f, 1f); // cyan
+
+            phaseStyleSpace = new GUIStyle(GUI.skin.label);
+            phaseStyleSpace.normal.textColor = new Color(0.2f, 1f, 0.6f); // lime green
         }
 
         private void DrawRecordingsWindow(int windowID)
@@ -507,7 +511,10 @@ namespace Parsek
             string phaseLabel = RecordingStore.GetSegmentPhaseLabel(rec);
             if (!string.IsNullOrEmpty(phaseLabel))
             {
-                GUIStyle phaseStyle = rec.SegmentPhase == "atmo" ? phaseStyleAtmo : phaseStyleExo;
+                GUIStyle phaseStyle;
+                if (rec.SegmentPhase == "atmo") phaseStyle = phaseStyleAtmo;
+                else if (rec.SegmentPhase == "space") phaseStyle = phaseStyleSpace;
+                else phaseStyle = phaseStyleExo;
                 GUILayout.Label(phaseLabel, phaseStyle, GUILayout.Width(ColW_Phase));
             }
             else

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -59,6 +59,11 @@ namespace Parsek
             public bool LoopPlayback;
             public double LoopPauseSeconds = 10.0;
 
+            // Atmosphere segment metadata
+            public string SegmentPhase;      // "atmo" or "exo" (null = untagged/legacy)
+            public string SegmentBodyName;   // body name at split point (e.g., "Kerbin", "Duna")
+            public bool PlaybackEnabled = true;  // false = skip ghost during playback
+
             // EVA child recording linkage
             public string ParentRecordingId;
             public string EvaCrewName;
@@ -127,6 +132,9 @@ namespace Parsek
                 ChainBranch = source.ChainBranch;
                 LoopPlayback = source.LoopPlayback;
                 LoopPauseSeconds = source.LoopPauseSeconds;
+                SegmentPhase = source.SegmentPhase;
+                SegmentBodyName = source.SegmentBodyName;
+                PlaybackEnabled = source.PlaybackEnabled;
             }
         }
 
@@ -449,6 +457,53 @@ namespace Parsek
             DeleteRecordingFiles(rec);
             committedRecordings.RemoveAt(index);
             Log($"[Parsek] Removed recording '{rec.VesselName}' (id={rec.RecordingId}) at index {index}");
+        }
+
+        /// <summary>
+        /// Returns true if any branch-0 enabled segment in the chain has LoopPlayback set.
+        /// </summary>
+        internal static bool IsChainLooping(string chainId)
+        {
+            if (string.IsNullOrEmpty(chainId)) return false;
+            for (int i = 0; i < committedRecordings.Count; i++)
+            {
+                var rec = committedRecordings[i];
+                if (rec.ChainId == chainId && rec.ChainBranch == 0 &&
+                    rec.PlaybackEnabled && rec.LoopPlayback)
+                    return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Returns true if all branch-0 segments in the chain have PlaybackEnabled == false.
+        /// </summary>
+        internal static bool IsChainFullyDisabled(string chainId)
+        {
+            if (string.IsNullOrEmpty(chainId)) return false;
+            bool anyBranch0 = false;
+            for (int i = 0; i < committedRecordings.Count; i++)
+            {
+                var rec = committedRecordings[i];
+                if (rec.ChainId == chainId && rec.ChainBranch == 0)
+                {
+                    anyBranch0 = true;
+                    if (rec.PlaybackEnabled) return false;
+                }
+            }
+            return anyBranch0; // false if no branch-0 segments found
+        }
+
+        /// <summary>
+        /// Returns a human-readable phase label like "Kerbin atmo" or "exo".
+        /// Returns empty string for untagged/legacy recordings.
+        /// </summary>
+        internal static string GetSegmentPhaseLabel(Recording rec)
+        {
+            if (string.IsNullOrEmpty(rec.SegmentPhase)) return "";
+            if (!string.IsNullOrEmpty(rec.SegmentBodyName))
+                return rec.SegmentBodyName + " " + rec.SegmentPhase;
+            return rec.SegmentPhase;
         }
 
         /// <summary>

--- a/docs/research/logistics-network-design.md
+++ b/docs/research/logistics-network-design.md
@@ -1,0 +1,254 @@
+# Logistics Network: Recorded Routes as Automated Supply Chains
+
+## The Idea
+
+Parsek records flights and replays them as ghosts. A natural extension: recorded flights that loop become **reusable supply routes**. A player manually flies a resupply mission from KSC to their Mun base once. Parsek records it. Then that recording becomes an automated logistics route — periodically consuming fuel at the origin and delivering cargo at the destination. The ghost replays visually as a reminder that the supply run is happening.
+
+This turns Parsek from a flight recorder into an economic automation layer on top of KSP's career mode.
+
+## Why This Fits Parsek
+
+The mod is already 80% of the way there:
+
+**What exists today:**
+- Trajectory recordings with per-point resource tracking (funds, science, reputation)
+- Vessel snapshots defining what ship flew the route
+- Chain segments splitting recordings by phase (atmo/exo/space) and body
+- Loop playback with configurable period and pause interval
+- Per-segment enable/disable and per-chain grouping
+- Ghost visual playback with engine FX, part events, the full visual narrative
+- Game state recording tracking contracts, tech, crew, facilities, and currency changes
+
+**What's missing:**
+- Physical resource tracking per trajectory point (LF, Ox, Ore, MonoPropellant, etc.)
+- A "route" abstraction on top of recordings
+- Resource transfer logic between origin and destination vessels/bases
+- Transfer window validation for interplanetary routes
+- UI for route management
+
+The game state recording system (`GameStateRecorder`, `GameStateStore`, `GameStateBaseline`) is particularly relevant. It already captures career-level economic events at specific UTs with before/after values. Extending this to track physical resource flows during a logistics route execution would be natural — a route dispatch is just another game state event.
+
+## The Connection to Game State Recording
+
+The game state system captures a baseline snapshot of the entire career state (funds, science, tech tree, crew roster, facility levels, active contracts) and then records delta events as they happen. This is exactly the foundation a logistics system needs:
+
+**Baseline captures** could be extended to include:
+- Resource inventories at known bases/stations (total LF, Ox, Ore, etc.)
+- Active logistics routes and their schedules
+- Pending deliveries in transit
+
+**Game state events** could include new types:
+- `RouteDispatched` — fuel deducted from origin, delivery scheduled
+- `RouteDelivered` — cargo added to destination
+- `RouteFailed` — origin ran out of fuel, destination destroyed, etc.
+- `RouteEstablished` / `RouteRetired` — lifecycle events
+
+This means logistics would integrate cleanly with the existing revert system. If the player reverts to before a route dispatch, the game state rollback naturally undoes the fuel deduction and cancels the delivery. The same infrastructure that handles "undo this tech research" handles "undo this supply run."
+
+## How a Route Works
+
+### Recording Phase (Manual)
+
+1. Player builds a cargo vessel at KSC (or orbital station, or wherever)
+2. Loads it with fuel and cargo
+3. Flies it to the destination (Mun base, Duna outpost, orbital station)
+4. Parsek records the flight, including physical resource snapshots at each sample point
+5. On arrival, player lands/docks and completes the delivery manually
+
+### Route Definition (Automatic)
+
+When the recording is committed, Parsek can extract:
+- **Origin**: body + location of first point (e.g., Kerbin, KSC coordinates)
+- **Destination**: body + location of last point (e.g., Mun, specific base coordinates)
+- **Transit time**: EndUT - StartUT
+- **Fuel cost**: resource delta between first and last point (what was consumed)
+- **Cargo manifest**: what resources were aboard at arrival (from vessel snapshot)
+- **Vessel template**: the vessel snapshot itself (what ship type runs this route)
+
+The player doesn't configure any of this — it's all derived from the recording they already made.
+
+### Route Execution (Automated)
+
+Each cycle:
+1. Check if origin has enough fuel to dispatch
+2. Deduct fuel cost from origin inventory
+3. Start transit timer (duration = recorded transit time)
+4. Ghost replays the flight visually (existing loop playback)
+5. When transit timer expires, add cargo to destination inventory
+6. Log as game state event
+7. Wait for next cycle
+
+### Abstracted vs Physical
+
+**Abstracted (recommended):** No actual vessel exists during transit. Just math — deduct at origin, wait, add at destination. The ghost is purely visual. Simple, no physics edge cases, works with time warp.
+
+**Physical (future):** Spawn an actual vessel, put it on rails following the recorded trajectory, despawn on arrival. More immersive but requires solving vessel persistence across scene changes, SOI transitions while unloaded, and resource tracking on packed vessels. Significant additional complexity for marginal gameplay benefit.
+
+The abstracted approach is the right starting point. It can always be upgraded to physical later.
+
+## Looping and Transfer Windows
+
+### Local Routes (Same Parent Body)
+
+KSC → Mun Base, KSC → Minmus Station, Orbital Station → Surface Base — these work at any time because the destination is always reachable. The loop interval is just the transit time plus turnaround time, set by the player.
+
+The Mun's orbital period is ~6.4 days. A Mun resupply that takes 2 days transit could run every 4-5 days comfortably. Minmus (12 day orbit) might need slightly longer intervals but is always reachable.
+
+### Interplanetary Routes
+
+Kerbin → Duna transfers only work during specific planetary alignments (~2 Kerbin years apart). A recorded Hohmann transfer captures the trajectory at a specific alignment. The route can only re-execute when the planets return to approximately the same configuration.
+
+**Approach: synodic period scheduling.** The synodic period between two bodies is the time between consecutive transfer windows. For Kerbin-Duna it's about 2.135 Kerbin years. Rather than computing phase angles, the route simply declares: "This route repeats every N days" where N approximates the synodic period. The recording already implicitly encodes the correct alignment — the route interval just needs to match the orbital mechanics.
+
+| Route | Synodic Period | Practical Interval |
+|-------|---------------|-------------------|
+| Kerbin → Mun | ~6.4 days | Player-set (e.g., 5-10 days) |
+| Kerbin → Minmus | ~14.5 days | Player-set (e.g., 15-20 days) |
+| Kerbin → Duna | ~2.14 years | ~2.14 years (auto-computed) |
+| Kerbin → Eve | ~1.58 years | ~1.58 years (auto-computed) |
+| Kerbin → Jool | ~3.6 years | ~3.6 years (auto-computed) |
+
+For interplanetary routes, the mod could auto-compute the interval from the origin and destination body orbital periods, or let the player override it.
+
+### Atmospheric Segments Loop Freely
+
+An important insight from the loop playback analysis: atmospheric segments of a route (launch, landing) can replay at any time because they use geographic coordinates. `GetWorldSurfacePosition(lat, lon, alt)` always returns the correct position regardless of when it's called. So the launch and landing ghosts look correct on every cycle.
+
+Exo/orbital segments drift slightly per cycle (~1 km per 110 seconds for a Kerbin orbit) due to body orbital motion, but this is cosmetic and invisible in practice. Nobody watches the transit ghost in detail.
+
+## Resource Tracking
+
+### What Needs to Be Captured
+
+Currently, `TrajectoryPoint` tracks career currencies (funds, science, reputation). For logistics, we need physical resources:
+
+```
+// Per trajectory point, snapshot of total vessel resources
+LiquidFuel: 1200.0
+Oxidizer: 1466.7
+MonoPropellant: 30.0
+Ore: 0.0
+ElectricCharge: 200.0
+```
+
+This can be stored as a flat key-value dictionary on the trajectory point. The recording format already supports extensibility through the external `.prec` sidecar files — adding resource keys is a format version bump, not a schema redesign.
+
+### Computing Route Cost and Delivery
+
+```
+First point resources:  LF=1200, Ox=1467, Ore=0
+Last point resources:   LF=50,   Ox=67,   Ore=500
+
+Route cost:    LF=1150, Ox=1400  (consumed during flight)
+Route delivery: Ore=500           (gained at destination)
+```
+
+The delta between first and last point tells you everything. Fuel consumed is the cost. Resources gained (from mining, science experiments, etc.) is the delivery.
+
+### Integration with Game State Events
+
+A route dispatch becomes a game state event:
+```
+UT=50000  RouteDispatched  key="route-mun-resupply"
+          detail="origin=KSC;dest=MunBase;cost=LF:1150,Ox:1400;deliver=Ore:500"
+          valueBefore=1200  valueAfter=50  (origin LF before/after)
+```
+
+A delivery becomes another event:
+```
+UT=50173  RouteDelivered  key="route-mun-resupply"
+          detail="dest=MunBase;delivered=Ore:500"
+```
+
+These integrate with the existing revert system — reverting past a dispatch event undoes the deduction and cancels the delivery.
+
+## Base/Station Identification
+
+A key question: how does the system know what counts as a "base" or "station" at the origin and destination?
+
+**Simple approach:** Any landed or orbiting vessel within 500m of the route's first/last point coordinates. The player doesn't explicitly designate bases — the system finds them by proximity to the recorded start/end positions.
+
+**Better approach:** Let the player tag vessels as "logistics endpoints" in the Parsek UI. This avoids false matches (a rover parked near the base shouldn't receive cargo) and survives minor base relocations.
+
+**Best approach:** Both. Auto-detect by proximity, but allow player override. Show the detected endpoint in the route UI and let them change it.
+
+## UI Concepts
+
+### Route Panel (Extension of Recordings Window)
+
+The existing recordings window shows chains with segments. A route-enabled chain would show additional info:
+
+```
+> Mun Resupply (4 segments, 2d 3h transit)
+  [Route: Active | Every 5 days | Next dispatch in 1d 14h]
+  [Cost: 1,150 LF + 1,400 Ox | Delivers: 500 Ore]
+  [Origin: KSC (1,200 LF available) | Dest: Mun Base Alpha]
+    Kerbin atmo  | 0:02:30 | active
+    Kerbin exo   | 0:45:00 | active
+    Mun space    | 1:10:00 | active
+    Mun atmo     | 0:05:30 | active
+```
+
+### Route Establishment Flow
+
+1. Player records a cargo flight (normal Parsek recording)
+2. After committing, a "Create Route" button appears in the chain header
+3. Clicking it opens a route configuration panel:
+   - Auto-detected origin and destination
+   - Computed cost and delivery
+   - Cadence slider (every N days)
+   - Enable/disable toggle
+4. Player confirms, route is established
+
+### Map View Integration
+
+Parsek already renders map markers for recordings. Routes could show:
+- Origin and destination markers connected by a line
+- Current ghost position along the route (during transit)
+- Delivery countdown timer
+- Color-coded by status (green=active, yellow=waiting for fuel, red=broken)
+
+## Crew Implications
+
+Routes that use crewed vessels need crew management. Parsek already handles crew reservation and replacement for recordings — the same system applies:
+
+- When a route dispatches, the crew is "reserved" (unavailable for other missions)
+- A replacement kerbal with the same trait is hired
+- When the route completes, the crew returns (or stays at destination, player's choice)
+- If the route loops, crew is reserved for the duration
+
+This is exactly what `ParsekScenario.ReserveSnapshotCrew` and `SwapReservedCrewInFlight` already do. No new crew logic needed.
+
+## Risks and Open Questions
+
+**Reliability:** What happens if the origin base runs out of fuel mid-game? Route should gracefully degrade — show a warning, pause dispatches, resume when fuel is available.
+
+**Multiple routes sharing fuel:** If two routes draw from the same KSC fuel supply, they could compete. Need priority ordering or fair-share allocation. Or just first-come-first-served and let the player manage it.
+
+**Base destruction:** If the Mun base is destroyed (asteroid impact, Kraken), pending deliveries should be lost and the route should auto-pause with a notification.
+
+**Save/load:** Route state (next dispatch time, pending deliveries) must serialize into the save file. The existing `GameStateStore` persistence handles this pattern.
+
+**Performance:** 10 active routes checking once per in-game day is negligible. 100 routes with per-frame checks would need optimization. The existing loop playback system already handles this efficiently — route scheduling would piggyback on the same timing.
+
+**Mod compatibility:** ISRU (mining drills), planetary bases, and life support mods all add resources. The route system should work with any resource name — just capture whatever the vessel has, delta it, transfer it. No hard-coded resource names.
+
+## Implementation Phases
+
+**Phase 0 (prerequisite, in progress):** Game state recording with extended resource tracking. This is already being built — the `GameStateRecorder` and `GameStateStore` infrastructure exists.
+
+**Phase 1:** Physical resource snapshots per trajectory point. Extend `TrajectoryPoint` or add a parallel resource log. This is the foundation — everything else builds on knowing what resources were where during the flight.
+
+**Phase 2:** Route definition. Extract origin, destination, cost, delivery from a committed recording. Store as metadata on the chain. UI: "Create Route" button on eligible chains.
+
+**Phase 3:** Abstracted route execution. Dispatch/delivery scheduling using existing loop timing. Deduct from origin vessel resources, add to destination after transit time. Game state events for each dispatch/delivery.
+
+**Phase 4:** Route management UI. Status display, cadence configuration, fuel warnings, map view integration.
+
+**Phase 5 (optional):** Physical vessel routing. Spawn actual vessels on recorded trajectories. Significantly more complex, may not be worth the effort vs abstracted approach.
+
+## Summary
+
+Logistics is a natural evolution of Parsek's recording system. The "fly it once, automate it forever" model is compelling because it ties automation to player skill — you earn routes by flying them. The infrastructure is largely in place: recordings, chains, loops, vessel snapshots, game state tracking, crew management. The main new work is physical resource tracking and the route scheduling layer, both of which build directly on existing code.
+
+The game state recording system being developed now is the key enabler. Once resource deltas are tracked per-flight with before/after values, the route system is mostly UI and scheduling on top of data that already exists.

--- a/docs/research/logistics-network-design.md
+++ b/docs/research/logistics-network-design.md
@@ -30,20 +30,42 @@ The game state recording system (`GameStateRecorder`, `GameStateStore`, `GameSta
 
 ## The Connection to Game State Recording
 
-The game state system captures a baseline snapshot of the entire career state (funds, science, tech tree, crew roster, facility levels, active contracts) and then records delta events as they happen. This is exactly the foundation a logistics system needs:
+### What Exists Today (GameStateStore + GameStateRecorder)
+
+The game state system captures a baseline snapshot of the entire career state (funds, science, tech tree, crew roster, facility levels, active contracts) and then records delta events as they happen. Events are typed (`GameStateEventType` enum covering contracts, tech, crew, facilities, currencies) with UT, key, detail, and before/after values.
+
+### What's Being Built (Milestones + ResourceBudget — timeline-actions branch)
+
+The milestone system in development takes this further:
+
+- **Milestones** bundle semantic events (tech research, part purchases, facility upgrades) into time-bounded groups linked to specific flight recordings. Each milestone captures events from its UT range, filtering out raw resource deltas to keep only meaningful career progression events.
+
+- **Epoch isolation** prevents abandoned timeline branches from polluting future milestones. Each revert increments a global epoch counter. Milestones created after the quicksave point get their `LastReplayedEventIndex` reset to -1 (unreplayed), ensuring clean branch separation.
+
+- **ResourceBudget** aggregates committed costs across all recordings and milestones, computing "available = current - reserved" for funds, science, and reputation. Pre-launch snapshots (`PreLaunchFunds`, etc.) captured at recording start provide the baseline for cost calculations.
+
+- **Replay tracking** via `LastReplayedEventIndex` persists which events have been applied during playback, surviving save/load cycles. This is exactly the pattern a logistics route would need — tracking which dispatches have been executed vs pending.
+
+### How Logistics Extends This
+
+The milestone/epoch/replay pattern is the exact foundation logistics needs:
 
 **Baseline captures** could be extended to include:
 - Resource inventories at known bases/stations (total LF, Ox, Ore, etc.)
 - Active logistics routes and their schedules
 - Pending deliveries in transit
 
-**Game state events** could include new types:
+**New event types** (extending `GameStateEventType`):
 - `RouteDispatched` — fuel deducted from origin, delivery scheduled
 - `RouteDelivered` — cargo added to destination
 - `RouteFailed` — origin ran out of fuel, destination destroyed, etc.
 - `RouteEstablished` / `RouteRetired` — lifecycle events
 
-This means logistics would integrate cleanly with the existing revert system. If the player reverts to before a route dispatch, the game state rollback naturally undoes the fuel deduction and cancels the delivery. The same infrastructure that handles "undo this tech research" handles "undo this supply run."
+**Epoch isolation applies directly:** If the player reverts to before a route dispatch, the epoch increment naturally invalidates the dispatch. `RestoreMutableState(resetUnmatched: true)` resets route milestones to unreplayed, undoing fuel deductions. The same infrastructure that handles "undo this tech research" handles "undo this supply run."
+
+**ResourceBudget extends naturally:** Route fuel costs become another line item in the budget. "Funds: 35,000 available (15,000 committed)" becomes "LiquidFuel: 1,200 available at KSC (1,150 committed to Mun Resupply)". The budget pattern already handles partial replay and aggregation across multiple recordings — routes are just another source of committed costs.
+
+**Replay tracking maps to dispatch tracking:** `LastReplayedEventIndex` on a milestone tracks which events have been applied. For logistics, a `LastDispatchedCycle` index on a route tracks which delivery cycles have executed. Both need persistence, both need reset on revert, both use the same epoch isolation.
 
 ## How a Route Works
 
@@ -235,15 +257,15 @@ This is exactly what `ParsekScenario.ReserveSnapshotCrew` and `SwapReservedCrewI
 
 ## Implementation Phases
 
-**Phase 0 (prerequisite, in progress):** Game state recording with extended resource tracking. This is already being built — the `GameStateRecorder` and `GameStateStore` infrastructure exists.
+**Phase 0 (prerequisite, in progress — timeline-actions branch):** Milestone system with epoch isolation, replay tracking, and resource budget. This is actively being built. The `MilestoneStore`, `ResourceBudget`, and `PreLaunch*` snapshot infrastructure establishes the patterns that logistics would reuse: time-bounded event bundles, branch-aware replay state, and committed cost aggregation.
 
-**Phase 1:** Physical resource snapshots per trajectory point. Extend `TrajectoryPoint` or add a parallel resource log. This is the foundation — everything else builds on knowing what resources were where during the flight.
+**Phase 1:** Physical resource snapshots per trajectory point. Extend `TrajectoryPoint` or add a parallel resource log. This is the foundation — everything else builds on knowing what resources were where during the flight. The `.prec` sidecar format already supports extensibility; adding resource keys is a format version bump.
 
-**Phase 2:** Route definition. Extract origin, destination, cost, delivery from a committed recording. Store as metadata on the chain. UI: "Create Route" button on eligible chains.
+**Phase 2:** Route definition. Extract origin, destination, cost, delivery from a committed recording. Store as metadata on the chain. UI: "Create Route" button on eligible chains. Routes become a new entity alongside milestones — both linked to recordings, both time-bounded, both epoch-aware.
 
-**Phase 3:** Abstracted route execution. Dispatch/delivery scheduling using existing loop timing. Deduct from origin vessel resources, add to destination after transit time. Game state events for each dispatch/delivery.
+**Phase 3:** Abstracted route execution. Dispatch/delivery scheduling using existing loop timing. Deduct from origin vessel resources, add to destination after transit time. Route dispatches become game state events (new `GameStateEventType` values), bundled into milestones at commit time. `LastDispatchedCycle` parallels `LastReplayedEventIndex` for replay tracking.
 
-**Phase 4:** Route management UI. Status display, cadence configuration, fuel warnings, map view integration.
+**Phase 4:** Route management UI. Status display, cadence configuration, fuel warnings, map view integration. Extends `ResourceBudget.ComputeTotal()` to include route fuel commitments alongside recording and milestone costs.
 
 **Phase 5 (optional):** Physical vessel routing. Spawn actual vessels on recorded trajectories. Significantly more complex, may not be worth the effort vs abstracted approach.
 
@@ -251,4 +273,4 @@ This is exactly what `ParsekScenario.ReserveSnapshotCrew` and `SwapReservedCrewI
 
 Logistics is a natural evolution of Parsek's recording system. The "fly it once, automate it forever" model is compelling because it ties automation to player skill — you earn routes by flying them. The infrastructure is largely in place: recordings, chains, loops, vessel snapshots, game state tracking, crew management. The main new work is physical resource tracking and the route scheduling layer, both of which build directly on existing code.
 
-The game state recording system being developed now is the key enabler. Once resource deltas are tracked per-flight with before/after values, the route system is mostly UI and scheduling on top of data that already exists.
+The milestone system being developed on `timeline-actions` is the key enabler. It establishes the patterns logistics would reuse: epoch-isolated event bundles tied to recordings, replay tracking with persistent indices, resource budget aggregation, and branch-aware state management. Once milestones land, adding route dispatches as another event type in the same framework is a natural next step — the hard architectural problems (revert handling, branch isolation, cost tracking, persistence) are already solved.

--- a/docs/research/loop-playback-and-logistics.md
+++ b/docs/research/loop-playback-and-logistics.md
@@ -1,0 +1,155 @@
+# Loop Playback, Orbital Drift, and Logistics Network Research
+
+## 1. Atmospheric Loops Are Position-Independent
+
+Atmospheric ("atmo") recordings use geographic coordinates (lat/lon/alt) stored per trajectory point. Ghost position is computed via `body.GetWorldSurfacePosition(lat, lon, alt)`, which is a KSP API that converts geographic coords to world-space position **accounting for the body's current rotation and orbital position at the current UT**.
+
+This means atmo recordings can loop at any interval without visual drift:
+- The ghost always appears at the correct surface location relative to terrain
+- Body rotation is handled internally by KSP — same lat/lon tracks the same ground point
+- Body orbital motion doesn't matter — the coordinate system is body-relative
+
+**Loop mechanics** (`ParsekFlight.TryComputeLoopPlaybackUT`):
+- Compute cycle: `cycleDuration = recordingDuration + pauseSeconds`
+- Remap current UT into the recording's UT range: `loopUT = startUT + (elapsed % cycleDuration)`
+- Ghost is rebuilt fresh each cycle (part events, engine FX reset cleanly)
+- Resource deltas are NOT replayed during loops (visual only)
+
+**No issues here. Atmo loops work perfectly.**
+
+---
+
+## 2. Exoatmospheric Loops and Orbital Drift
+
+### The Problem
+
+Exo/space recordings use orbit segments with Keplerian parameters. Ghost position is computed via:
+```
+orbit = new Orbit(inc, ecc, sma, lan, argPe, mna, epoch, body)
+worldPos = orbit.getPositionAtUT(loopUT)
+```
+
+The orbit's `epoch` is fixed from recording time. When looping, `loopUT` remaps back to the original UT range. But `orbit.getPositionAtUT(loopUT)` returns position relative to the **body's center in inertial space** — and the body itself has moved since the original recording.
+
+### Drift Quantification
+
+For a 100km Kerbin orbit, 100-second recording looping every 110 seconds:
+- Kerbin orbital velocity: ~9.285 km/s
+- Kerbin moves ~1,021 km per loop cycle
+- Ghost drifts ~1 km per cycle relative to the planet's actual position
+- After 10 loops: ~10 km accumulated drift
+
+For heliocentric "Sun space" segments, the ghost position relative to the Sun is correct (orbit is around the Sun), but relative to any planet it drifts by the planet's orbital motion.
+
+### Why This Doesn't Matter in Practice
+
+Nobody watches orbital recordings loop. Exo segments are transit phases between interesting atmospheric events. The drift is slow (~1 km per 2 minutes) and the ghost is in space where there's no visual reference to notice it.
+
+The only scenario where it would matter: looping a specific orbital rendezvous or station flyby recording. This is an extreme edge case.
+
+### Transfer Window Constraint
+
+An exo recording captures a trajectory that was valid at a specific planetary alignment. If you wanted to loop an interplanetary transfer, you'd need the planets in the same relative positions — which only happens at transfer window intervals:
+- Kerbin-Mun: ~6.4 day synodic period (frequent)
+- Kerbin-Duna: ~2 year synodic period (rare)
+- Kerbin-Jool: ~3.6 year synodic period (very rare)
+
+This constraint is irrelevant for current playback (recordings play at their original UTs after revert, so planets are in the right positions). It only becomes relevant for the logistics concept below.
+
+---
+
+## 3. Future Concept: Logistics Network via Recorded Routes
+
+### Core Idea
+
+A recorded flight becomes a reusable "route" — a supply run between two locations. When enabled, the route periodically transfers resources from origin to destination, consuming fuel and delivering cargo. The ghost replays visually while resources flow automatically.
+
+### How It Builds on Existing Infrastructure
+
+| Existing System | Logistics Extension |
+|----------------|-------------------|
+| Resource tracking (funds/science/rep per point) | Add physical resources (LF, Ox, Ore, etc.) per point |
+| Vessel snapshots | Define what vessel runs the route (fuel capacity, cargo capacity) |
+| Chain segments (atmo/exo/space per body) | Multi-phase routes: launch → transit → landing |
+| Loop playback with configurable period | Route cadence: "every N days" |
+| PlaybackEnabled toggle | Route enabled/disabled toggle |
+| VesselSpawner | Spawn delivery vessel at destination |
+
+### Resource Tracking Extension
+
+Currently `TrajectoryPoint` tracks only career currencies. Logistics would need physical resources:
+```
+// Snapshot total vessel resources at each sample point
+Dictionary<string, double> partResources  // "LiquidFuel" → 450, "Ore" → 500
+```
+
+The delta between first and last point defines the route's cost and delivery:
+- Cost = resources consumed during flight (fuel burn)
+- Delivery = resources gained at destination (mining, cargo)
+
+### Two Implementation Approaches
+
+**Option A: Abstracted Routes (simpler, recommended for MVP)**
+- No physical vessel during transit
+- Deduct fuel cost from origin, add cargo to destination after elapsed time
+- Just math + scheduling, no physics
+- Example: "Route costs 1,200 LF, delivers 500 Ore in 6 days"
+- Implementation: ~500 lines, reuses existing loop timing
+
+**Option B: Physical Vessel Routing (realistic, complex)**
+- Spawn actual vessel at origin, put on rails with recorded trajectory
+- Vessel exists in tracking station during transit
+- Despawn at destination, transfer resources to base
+- More immersive but harder to debug (vessel loading, time warp, SOI transitions)
+- Implementation: significant, needs deep KSP vessel lifecycle integration
+
+### Route Scheduling
+
+**Local routes (same body, e.g., KSC → Mun Base):**
+- Always available (Mun's orbital period is short, ~6.4 days)
+- Cadence set by player: "every 10 days"
+- No transfer window validation needed
+
+**Interplanetary routes (e.g., Kerbin → Duna):**
+- Only available during transfer windows
+- Two approaches:
+  1. **Astronomical**: Check current phase angle between bodies, compare to recorded alignment
+  2. **Pragmatic**: "This route is available every N days" where N ≈ synodic period
+- Pragmatic is clearer to players and avoids exposing orbital mechanics
+
+### KSP API for Resource Manipulation
+
+The APIs exist and are straightforward:
+- `vessel.parts[i].Resources["LiquidFuel"].amount` — read/write resource amounts
+- `vessel.parts[i].Resources["Ore"].maxAmount` — check capacity
+- Works on both loaded (unpacked) and unloaded (packed/on-rails) vessels
+- For on-rails vessels, modify the ConfigNode protoVessel instead
+
+### Game Balance
+
+Key constraint: routes should not be free. Each execution must:
+1. Consume fuel proportional to the recorded flight
+2. Have a minimum interval (prevent instant resource duplication)
+3. Fail if origin doesn't have enough fuel
+4. Fail if destination is destroyed or inaccessible
+
+The recording itself acts as a "proof of capability" — you can only automate what you've already flown manually. This keeps the logistics system grounded in gameplay.
+
+### Example Workflow
+
+1. Record a KSC → Mun Base resupply mission (manual flight)
+2. After landing, mark recording as "logistics route" in Parsek UI
+3. System extracts: origin (KSC), destination (Mun Base), cost (1,500 LF), delivery (500 Ore), transit time (6 days)
+4. Enable route, set cadence to 10 days
+5. Every 10 days: check fuel at KSC, deduct, schedule delivery
+6. After 6 days: add 500 Ore to Mun Base inventory
+7. Ghost replays the flight visually during transit (optional)
+
+### Open Questions
+
+- Should the logistics vessel show as a ghost during transit, or be invisible?
+- How to handle base destruction mid-transit? (Refund? Lost cargo?)
+- Should routes degrade over time? (Simulating wear, requiring re-recording?)
+- Integration with KSP's contract system? (Automatic contracts for route establishment?)
+- Can logistics routes chain? (KSC → Station A → Mun Base, with Station A as relay)
+- How to handle multiple routes competing for the same fuel supply?

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -124,7 +124,8 @@ Playback already supports multiple simultaneous ghosts. Recording is currently s
 
 ## Out of Scope
 
-- Racing modes or lap timing
-- AI playback or autopilot
-- Multiplayer synchronization
-- Timeline branching or alternate histories
+- **Racing modes or lap timing**
+- **AI playback or autopilot**
+- **Multiplayer synchronization**
+- **Timeline branching or alternate histories**
+- **Logistics network** — Parsek's recording infrastructure (looped playback, chain segments, vessel snapshots, game state events, resource tracking) forms a natural foundation for automated supply routes between bases. The concept: fly a cargo mission once, Parsek records it, then that recording becomes a reusable logistics route that periodically deducts fuel at the origin and delivers cargo at the destination, with the ghost replaying visually during transit. This will be built as a separate mod on top of Parsek rather than integrated directly. See `docs/research/logistics-network-design.md` for the full design exploration.


### PR DESCRIPTION
## Summary
- Auto-split recordings at atmosphere boundaries into chained segments with dual hysteresis (3s + 1000m) to prevent spurious splits from boundary skimming
- Tag each segment with phase (atmo/exo) and body name; per-segment enable/disable and loop controls for selective playback of individual flight phases
- UI groups chain segments with expand/collapse headers, colored phase labels (orange atmo / cyan exo), and per-segment enable toggle

## Test plan
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 610 passed, 1 skipped (pre-existing)
- [ ] In-game: launch → record through atmosphere exit → verify 2-segment chain with atmo/exo labels
- [ ] In-game: expand chain → disable exo segment → verify only atmo ghost plays
- [ ] In-game: toggle loop on atmo segment → verify it loops independently
- [ ] Save/reload → verify phase tags and PlaybackEnabled persist
- [ ] Verify warp doesn't stop for disabled segments

🤖 Generated with [Claude Code](https://claude.com/claude-code)