### PR TITLE
Expand showcase: lights, RCS, gear, blink cycle + engine flame FX

### DIFF
--- a/Source/Parsek.Tests/FxDiagnosticsTests.cs
+++ b/Source/Parsek.Tests/FxDiagnosticsTests.cs
@@ -3,7 +3,6 @@ using Xunit;
 
 namespace Parsek.Tests
 {
-    [Collection("Sequential")]
     public class FxDiagnosticsTests
     {
         [Theory]

--- a/Source/Parsek.Tests/LogValidation/ParsekLogContractChecker.cs
+++ b/Source/Parsek.Tests/LogValidation/ParsekLogContractChecker.cs
@@ -177,7 +177,9 @@ namespace Parsek.Tests.LogValidation
             if (!string.Equals(entry.Subsystem, "Recorder", StringComparison.Ordinal))
                 return false;
 
-            return (entry.Message ?? string.Empty).StartsWith("Recording stopped", StringComparison.Ordinal);
+            string message = entry.Message ?? string.Empty;
+            return message.StartsWith("Recording stopped", StringComparison.Ordinal) ||
+                message.StartsWith("Auto-stopped recording due to scene change", StringComparison.Ordinal);
         }
 
         private static void ValidateSuppressedCount(KspLogEntry entry, List<LogViolation> violations)

--- a/Source/Parsek.Tests/LogValidation/ParsekLogContractChecker.cs
+++ b/Source/Parsek.Tests/LogValidation/ParsekLogContractChecker.cs
@@ -252,6 +252,16 @@ namespace Parsek.Tests.LogValidation
                 return;
             }
 
+            if (double.IsNaN(value) || double.IsInfinity(value))
+            {
+                violations.Add(new LogViolation(
+                    code: "RES-002",
+                    lineNumber: entry.LineNumber,
+                    message: $"Resource post-value '{match.Groups["value"].Value}' is not finite.",
+                    rawLine: entry.RawLine));
+                return;
+            }
+
             if (value < 0.0)
             {
                 violations.Add(new LogViolation(

--- a/Source/Parsek.Tests/ParsekLogContractCheckerTests.cs
+++ b/Source/Parsek.Tests/ParsekLogContractCheckerTests.cs
@@ -87,7 +87,53 @@ namespace Parsek.Tests
 
             var violations = ParsekLogContractChecker.ValidateLatestSession(entries);
 
-            Assert.DoesNotContain(violations, v => v.Code == "REC-003");
+            Assert.Empty(violations);
+        }
+
+        [Fact]
+        public void MalformedSessionStart_ReportsSes002()
+        {
+            var entries = ParsekKspLogParser.ParseLines(new[]
+            {
+                "[LOG] [Parsek][INFO][Init] SessionStart runUtc=abc",
+                "[LOG] [Parsek][INFO][Recorder] Recording started (physics-frame sampling)",
+                "[LOG] [Parsek][INFO][Recorder] Recording stopped. 3 points, 0 orbit segments over 1.2s"
+            });
+
+            var violations = ParsekLogContractChecker.ValidateLatestSession(entries);
+
+            Assert.Contains(violations, v => v.Code == "SES-002");
+        }
+
+        [Fact]
+        public void InvalidLogLevel_ReportsFmt002()
+        {
+            var entries = ParsekKspLogParser.ParseLines(new[]
+            {
+                "[LOG] [Parsek][INFO][Init] SessionStart runUtc=3004",
+                "[LOG] [Parsek][DEBUG][Recorder] Recording started (physics-frame sampling)",
+                "[LOG] [Parsek][INFO][Recorder] Recording stopped. 3 points, 0 orbit segments over 1.2s"
+            });
+
+            var violations = ParsekLogContractChecker.ValidateLatestSession(entries);
+
+            Assert.Contains(violations, v => v.Code == "FMT-002");
+        }
+
+        [Fact]
+        public void UnparseableResourcePostValue_ReportsRes002()
+        {
+            var entries = ParsekKspLogParser.ParseLines(new[]
+            {
+                "[LOG] [Parsek][INFO][Init] SessionStart runUtc=3005",
+                "[LOG] [Parsek][INFO][Recorder] Recording started (physics-frame sampling)",
+                "[LOG] [Parsek][INFO][GameStateRecorder] Game state: FundsChanged +50 (Test) -> 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999",
+                "[LOG] [Parsek][INFO][Recorder] Recording stopped. 3 points, 0 orbit segments over 1.2s"
+            });
+
+            var violations = ParsekLogContractChecker.ValidateLatestSession(entries);
+
+            Assert.Contains(violations, v => v.Code == "RES-002");
         }
 
         [Fact]

--- a/Source/Parsek.Tests/ParsekLogContractCheckerTests.cs
+++ b/Source/Parsek.Tests/ParsekLogContractCheckerTests.cs
@@ -76,6 +76,21 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void AutoStoppedSceneChange_CountsAsRecordingStop()
+        {
+            var entries = ParsekKspLogParser.ParseLines(new[]
+            {
+                "[LOG] [Parsek][INFO][Init] SessionStart runUtc=3003",
+                "[LOG] [Parsek][INFO][Recorder] Recording started (physics-frame sampling)",
+                "[LOG] [Parsek][INFO][Recorder] Auto-stopped recording due to scene change"
+            });
+
+            var violations = ParsekLogContractChecker.ValidateLatestSession(entries);
+
+            Assert.DoesNotContain(violations, v => v.Code == "REC-003");
+        }
+
+        [Fact]
         public void AsciiArrowResourceLine_IsAccepted()
         {
             var entries = ParsekKspLogParser.ParseLines(new[]

--- a/Source/Parsek.Tests/RecordingStoreTests.cs
+++ b/Source/Parsek.Tests/RecordingStoreTests.cs
@@ -528,6 +528,15 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void TryParseFxLocalRotation_AcceptsValidAxisAngle()
+        {
+            bool ok = GhostVisualBuilder.TryParseFxLocalRotation("0,0,0,90", out Quaternion parsed);
+
+            Assert.True(ok);
+            Assert.Equal(Quaternion.identity, parsed);
+        }
+
+        [Fact]
         public void GetPartTransformRaw_PrefersLegacyKeys_ButSupportsProtoKeys()
         {
             var node = new ConfigNode("PART");

--- a/Source/Parsek.Tests/SyntheticRecordingTests.cs
+++ b/Source/Parsek.Tests/SyntheticRecordingTests.cs
@@ -754,10 +754,11 @@ namespace Parsek.Tests
         /// </summary>
         private static RecordingBuilder BuildEngineFlameShowcaseRecording(
             double baseUT, string vesselName, string enginePartName, int rowIndex,
-            uint pidBase)
+            uint pidBase, double altitudeOffsetMeters = 0.0)
         {
             double t = baseUT + 30;
             ShowcasePosition(rowIndex, ShowcaseDistanceFromPadMeters, out double lat, out double lon, out double alt);
+            alt += altitudeOffsetMeters;
 
             var b = new RecordingBuilder(vesselName)
                 .WithDefaultRotation(KscRotX, KscRotY, KscRotZ, KscRotW)
@@ -793,10 +794,11 @@ namespace Parsek.Tests
         /// </summary>
         private static RecordingBuilder BuildSrbFlameShowcaseRecording(
             double baseUT, string vesselName, string srbPartName, int rowIndex,
-            uint pidBase)
+            uint pidBase, double altitudeOffsetMeters = 0.0)
         {
             double t = baseUT + 30;
             ShowcasePosition(rowIndex, ShowcaseDistanceFromPadMeters, out double lat, out double lon, out double alt);
+            alt += altitudeOffsetMeters;
 
             var b = new RecordingBuilder(vesselName)
                 .WithDefaultRotation(KscRotX, KscRotY, KscRotZ, KscRotW)
@@ -908,7 +910,7 @@ namespace Parsek.Tests
                     ShowcaseDistanceFromPadMeters, PartEventType.GearDeployed, PartEventType.GearRetracted, 90000000, SinglePartPid),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Landing Leg LT-05", "miniLandingLeg", 30,
                     ShowcaseDistanceFromPadMeters, PartEventType.GearDeployed, PartEventType.GearRetracted, 90000000, SinglePartPid),
-                BuildPartShowcaseRecording(baseUT, "Part Showcase - Gear Extra Large", "GearExtraLarge", 189,
+                BuildPartShowcaseRecording(baseUT, "Part Showcase - Gear Extra Large", "GearLarge", 189,
                     ShowcaseDistanceFromPadMeters, PartEventType.GearDeployed, PartEventType.GearRetracted, 90000000, SinglePartPid)
             };
         }
@@ -1528,7 +1530,7 @@ namespace Parsek.Tests
                 BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame LV-T30 v2", "liquidEngine.v2", 193, pidBase),
                 BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame LV-T45", "liquidEngine2", 194, pidBase),
                 BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame LV-T45 v2", "liquidEngine2.v2", 195, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Poodle", "liquidEngine2-2.v2", 196, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Poodle", "liquidEngine2-2.v2", 196, pidBase, altitudeOffsetMeters: 5.0),
                 BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Terrier", "liquidEngine3.v2", 197, pidBase),
                 BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Spark", "liquidEngineMini.v2", 198, pidBase),
                 BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Ant", "microEngine.v2", 199, pidBase),
@@ -1539,35 +1541,35 @@ namespace Parsek.Tests
                 BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame NERV", "nuclearEngine", 204, pidBase),
                 BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Aerospike", "toroidalAerospike", 205, pidBase),
                 BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Cub", "omsEngine", 206, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Twin-Boar", "Size2LFB", 207, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Twin-Boar v2", "Size2LFB.v2", 208, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Mammoth", "Size3EngineCluster", 209, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Vector", "Size3AdvancedEngine", 210, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Kodiak", "LiquidEngineKE-1", 211, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Cheetah", "LiquidEngineLV-T91", 212, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Wolfhound", "LiquidEngineLV-TX87", 213, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Twin-Boar", "Size2LFB", 207, pidBase, altitudeOffsetMeters: 8.0),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Twin-Boar v2", "Size2LFB.v2", 208, pidBase, altitudeOffsetMeters: 8.0),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Mammoth", "Size3EngineCluster", 209, pidBase, altitudeOffsetMeters: 10.0),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Vector", "Size3AdvancedEngine", 210, pidBase, altitudeOffsetMeters: 8.0),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Kodiak", "LiquidEngineKE-1", 211, pidBase, altitudeOffsetMeters: 5.0),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Cheetah", "LiquidEngineLV-T91", 212, pidBase, altitudeOffsetMeters: 5.0),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Wolfhound", "LiquidEngineLV-TX87", 213, pidBase, altitudeOffsetMeters: 5.0),
                 BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Bobcat", "LiquidEngineRE-I2", 214, pidBase),
                 BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Skiff", "LiquidEngineRE-J10", 215, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Mastodon", "LiquidEngineRK-7", 216, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Mastodon", "LiquidEngineRK-7", 216, pidBase, altitudeOffsetMeters: 10.0),
                 BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Pug", "LiquidEngineRV-1", 217, pidBase),
                 BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame RAPIER", "RAPIER", 218, pidBase),
                 // Solid boosters (rows 219-228) — simple ignite/burnout cycle
                 BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Flea", "solidBooster.sm.v2", 219, pidBase),
                 BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Hammer", "solidBooster.v2", 220, pidBase),
-                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Thumper", "solidBooster1-1", 221, pidBase),
-                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Kickback", "MassiveBooster", 222, pidBase),
+                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Thumper", "solidBooster1-1", 221, pidBase, altitudeOffsetMeters: 5.0),
+                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Kickback", "MassiveBooster", 222, pidBase, altitudeOffsetMeters: 8.0),
                 BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Mite", "Mite", 223, pidBase),
                 BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Shrimp", "Shrimp", 224, pidBase),
                 BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Thoroughbred", "Thoroughbred", 225, pidBase),
-                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Clydesdale", "Clydesdale", 226, pidBase),
-                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Pollux", "Pollux", 227, pidBase),
+                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Clydesdale", "Clydesdale", 226, pidBase, altitudeOffsetMeters: 10.0),
+                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Pollux", "Pollux", 227, pidBase, altitudeOffsetMeters: 10.0),
                 BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Sepatron", "sepMotor1", 228, pidBase),
                 // Jet engines (rows 229-233) — throttle-varying cycle
                 BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Juno", "miniJetEngine", 229, pidBase),
                 BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Wheesley", "JetEngine", 230, pidBase),
                 BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Whiplash", "turboFanEngine", 231, pidBase),
                 BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Panther", "turboJet", 232, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Goliath", "turboFanSize2", 233, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Goliath", "turboFanSize2", 233, pidBase, altitudeOffsetMeters: 8.0),
                 // Special (row 234)
                 BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Ion", "ionEngine", 234, pidBase)
             };
@@ -2208,7 +2210,7 @@ namespace Parsek.Tests
             Assert.Equal(ghost.GetNodes("PART")[0].GetValue("persistentId"), events[0].GetValue("pid"));
 
             var names = new[] { "SmallGearBay", "GearSmall", "GearMedium", "GearLarge",
-                "landingLeg1", "landingLeg1-2", "miniLandingLeg", "GearExtraLarge" };
+                "landingLeg1", "landingLeg1-2", "miniLandingLeg", "GearLarge" };
             for (int i = 0; i < recordings.Length; i++)
             {
                 var g = recordings[i].Build().GetNode("GHOST_VISUAL_SNAPSHOT");

--- a/Source/Parsek.Tests/SyntheticRecordingTests.cs
+++ b/Source/Parsek.Tests/SyntheticRecordingTests.cs
@@ -678,7 +678,7 @@ namespace Parsek.Tests
         private const uint SinglePartPid = 100000;
         // Optional companion part (e.g., kerbal actor) receives the second slot.
         // Total visible showcase row entries (indices 0-235, including inventory placement).
-        private const int ShowcaseRowCount = 235;
+        private const int ShowcaseRowCount = 237;
         // Split showcase into two parallel lines to avoid runway clipping.
         private static readonly int ShowcaseEntriesPerLine = (ShowcaseRowCount + 1) / 2;
         private const double ShowcaseLineSpacingMeters = 20.0;
@@ -1036,13 +1036,17 @@ namespace Parsek.Tests
         }
 
         /// <summary>
-        /// Builds an engine flame showcase recording with a throttle-varying 8-event cycle:
-        /// ignite low → ramp up → full → shutdown → full restart → throttle down → near-idle → shutdown.
-        /// 24s clip with 9 trajectory points, suitable for liquid/jet/special engines.
+        /// Unified engine showcase builder. Handles liquid engines, SRBs, and jets with
+        /// optional shroud jettison before the flame cycle.
+        /// - Liquid/jet with shroud: ShroudJettisoned at t+0.5, then 7 throttle events (8 total)
+        /// - Liquid/jet without shroud: 8 throttle events (ignite→ramp→full→shutdown→restart cycle)
+        /// - SRB with shroud: ShroudJettisoned at t+0.5, then ignite+shutdown (3 total)
+        /// - SRB without shroud: ignite+shutdown (2 events)
+        /// 24s clip with 9 trajectory points.
         /// </summary>
-        private static RecordingBuilder BuildEngineFlameShowcaseRecording(
+        private static RecordingBuilder BuildCombinedEngineShowcaseRecording(
             double baseUT, string vesselName, string enginePartName, int rowIndex,
-            uint pidBase)
+            uint pidBase, bool isSrb = false, bool hasShroud = false)
         {
             double t = baseUT + 30;
             ShowcasePosition(rowIndex, ShowcaseDistanceFromPadMeters, out double lat, out double lon, out double alt);
@@ -1055,53 +1059,44 @@ namespace Parsek.Tests
             for (int i = 0; i <= 8; i++)
                 b.AddPoint(t + (i * 3), lat, lon, alt);
 
-            b.AddPartEvent(t + 0,  SinglePartPid, (int)PartEventType.EngineIgnited,  enginePartName, value: 0.3f);
-            b.AddPartEvent(t + 3,  SinglePartPid, (int)PartEventType.EngineThrottle, enginePartName, value: 0.7f);
-            b.AddPartEvent(t + 6,  SinglePartPid, (int)PartEventType.EngineThrottle, enginePartName, value: 1.0f);
-            b.AddPartEvent(t + 9,  SinglePartPid, (int)PartEventType.EngineShutdown, enginePartName);
-            b.AddPartEvent(t + 12, SinglePartPid, (int)PartEventType.EngineIgnited,  enginePartName, value: 1.0f);
-            b.AddPartEvent(t + 15, SinglePartPid, (int)PartEventType.EngineThrottle, enginePartName, value: 0.5f);
-            b.AddPartEvent(t + 18, SinglePartPid, (int)PartEventType.EngineThrottle, enginePartName, value: 0.15f);
-            b.AddPartEvent(t + 21, SinglePartPid, (int)PartEventType.EngineShutdown, enginePartName);
+            if (isSrb)
+            {
+                if (hasShroud)
+                    b.AddPartEvent(t + 0.5, SinglePartPid, (int)PartEventType.ShroudJettisoned, enginePartName);
+                double igniteT = hasShroud ? t + 3 : t + 0;
+                b.AddPartEvent(igniteT,      SinglePartPid, (int)PartEventType.EngineIgnited,  enginePartName, value: 1.0f);
+                b.AddPartEvent(igniteT + 12, SinglePartPid, (int)PartEventType.EngineShutdown, enginePartName);
+            }
+            else
+            {
+                if (hasShroud)
+                {
+                    b.AddPartEvent(t + 0.5, SinglePartPid, (int)PartEventType.ShroudJettisoned, enginePartName);
+                    b.AddPartEvent(t + 3,   SinglePartPid, (int)PartEventType.EngineIgnited,  enginePartName, value: 0.3f);
+                    b.AddPartEvent(t + 6,   SinglePartPid, (int)PartEventType.EngineThrottle, enginePartName, value: 0.7f);
+                    b.AddPartEvent(t + 9,   SinglePartPid, (int)PartEventType.EngineThrottle, enginePartName, value: 1.0f);
+                    b.AddPartEvent(t + 12,  SinglePartPid, (int)PartEventType.EngineShutdown, enginePartName);
+                    b.AddPartEvent(t + 15,  SinglePartPid, (int)PartEventType.EngineIgnited,  enginePartName, value: 1.0f);
+                    b.AddPartEvent(t + 18,  SinglePartPid, (int)PartEventType.EngineThrottle, enginePartName, value: 0.5f);
+                    b.AddPartEvent(t + 21,  SinglePartPid, (int)PartEventType.EngineShutdown, enginePartName);
+                }
+                else
+                {
+                    b.AddPartEvent(t + 0,  SinglePartPid, (int)PartEventType.EngineIgnited,  enginePartName, value: 0.3f);
+                    b.AddPartEvent(t + 3,  SinglePartPid, (int)PartEventType.EngineThrottle, enginePartName, value: 0.7f);
+                    b.AddPartEvent(t + 6,  SinglePartPid, (int)PartEventType.EngineThrottle, enginePartName, value: 1.0f);
+                    b.AddPartEvent(t + 9,  SinglePartPid, (int)PartEventType.EngineShutdown, enginePartName);
+                    b.AddPartEvent(t + 12, SinglePartPid, (int)PartEventType.EngineIgnited,  enginePartName, value: 1.0f);
+                    b.AddPartEvent(t + 15, SinglePartPid, (int)PartEventType.EngineThrottle, enginePartName, value: 0.5f);
+                    b.AddPartEvent(t + 18, SinglePartPid, (int)PartEventType.EngineThrottle, enginePartName, value: 0.15f);
+                    b.AddPartEvent(t + 21, SinglePartPid, (int)PartEventType.EngineShutdown, enginePartName);
+                }
+            }
 
             var snap = new VesselSnapshotBuilder()
                 .WithName(vesselName)
                 .WithPersistentId((uint)(pidBase + rowIndex))
                 .AddPart(enginePartName, rotation: "0,-0.7071068,0,0.7071068")
-                .AsLanded(lat, lon, alt)
-                .Build();
-
-            b.WithGhostVisualSnapshot(snap);
-            return b;
-        }
-
-        /// <summary>
-        /// Builds an SRB flame showcase recording with a simple 2-event cycle:
-        /// ignite at full power → burnout after 12s (no restart, fixed throttle).
-        /// 24s clip with 9 trajectory points, physically accurate for solid boosters.
-        /// </summary>
-        private static RecordingBuilder BuildSrbFlameShowcaseRecording(
-            double baseUT, string vesselName, string srbPartName, int rowIndex,
-            uint pidBase)
-        {
-            double t = baseUT + 30;
-            ShowcasePosition(rowIndex, ShowcaseDistanceFromPadMeters, out double lat, out double lon, out double alt);
-            alt += ShowcaseAltitudeOffset(srbPartName);
-
-            var b = new RecordingBuilder(vesselName)
-                .WithDefaultRotation(KscRotX, KscRotY, KscRotZ, KscRotW)
-                .WithLoopPlayback(loop: true, pauseSeconds: 0.0);
-
-            for (int i = 0; i <= 8; i++)
-                b.AddPoint(t + (i * 3), lat, lon, alt);
-
-            b.AddPartEvent(t + 0,  SinglePartPid, (int)PartEventType.EngineIgnited,  srbPartName, value: 1.0f);
-            b.AddPartEvent(t + 12, SinglePartPid, (int)PartEventType.EngineShutdown, srbPartName);
-
-            var snap = new VesselSnapshotBuilder()
-                .WithName(vesselName)
-                .WithPersistentId((uint)(pidBase + rowIndex))
-                .AddPart(srbPartName, rotation: "0,-0.7071068,0,0.7071068")
                 .AsLanded(lat, lon, alt)
                 .Build();
 
@@ -1126,16 +1121,16 @@ namespace Parsek.Tests
             };
         }
 
-        // Two parallel lines (rows 0-117 at 200m, rows 118-234 at 220m from pad):
+        // Two parallel lines (rows 0-118 at 200m, rows 119-236 at 220m from pad):
         // Back line — Lights: 0-5, Deployables: 6-23, Airplane Gear: 24-27, Landing Legs: 28-30,
-        //   Cargo: 31-41, Engines: 42-44, Ladders: 45-46, RCS: 47-49, Fairings: 50-54,
+        //   Cargo: 31-41, Engines (old unused): 42-44, Ladders: 45-46, RCS: 47-49, Fairings: 50-54,
         //   Extra Radiators: 55-56, Drills: 57-58, Deployed Science: 59-66,
-        //   Animation Group: 67-68, Parachutes: 69-73, Special Deploy Animations: 74-85 and 115-116,
-        //   Jettison Coverage: 86-114, Robotics: 117 (partial)
-        // Front line — Robotics: 118-137, AeroSurface: 138, Robot Arm Scanners: 139-141,
+        //   Animation Group: 67-68, Parachutes: 69-73, Special Deploy Animations: 74-85,
+        //   Jettison (non-engine): 86-94, Robotics: 117-118 (partial)
+        // Front line — Robotics: 119-137, AeroSurface: 138, Robot Arm Scanners: 139-141,
         //   Control Surfaces: 142-165, Wheel Dynamics: 166-171, AnimateHeat: 172-184,
         //   Lights (extra): 185-188, RCS (extra): 189-190,
-        //   Engine Flames: 191-233, Inventory Placement: 234.
+        //   Engines (all 45): 191-235, Inventory Placement: 236.
 
         internal static RecordingBuilder[] DeployableShowcaseRecordings(double baseUT = 0)
         {
@@ -1232,11 +1227,64 @@ namespace Parsek.Tests
 
         internal static RecordingBuilder[] EngineShowcaseRecordings(double baseUT = 0)
         {
+            const uint pidBase = 99200000;
             return new[]
             {
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Mainsail", "liquidEngineMainsail.v2", 42, 92000000),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Skipper", "engineLargeSkipper.v2", 43, 92000000),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - SSME", "SSME", 44, 92000000)
+                // ── Liquid engines with shroud jettison + flame (rows 191-210) ──
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - LV-T30", "liquidEngine", 191, pidBase, hasShroud: true),
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - LV-T30 v2", "liquidEngine.v2", 192, pidBase, hasShroud: true),
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - LV-T45", "liquidEngine2", 193, pidBase, hasShroud: true),
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - LV-T45 v2", "liquidEngine2.v2", 194, pidBase, hasShroud: true),
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Poodle v2", "liquidEngine2-2.v2", 195, pidBase, hasShroud: true),
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Terrier v2", "liquidEngine3.v2", 196, pidBase, hasShroud: true),
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Spark v2", "liquidEngineMini.v2", 197, pidBase, hasShroud: true),
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - NERV", "nuclearEngine", 198, pidBase, hasShroud: true),
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Aerospike", "toroidalAerospike", 199, pidBase, hasShroud: true),
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Vector", "Size3AdvancedEngine", 200, pidBase, hasShroud: true),
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Kodiak", "LiquidEngineKE-1", 201, pidBase, hasShroud: true),
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Cheetah", "LiquidEngineLV-T91", 202, pidBase, hasShroud: true),
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Wolfhound", "LiquidEngineLV-TX87", 203, pidBase, hasShroud: true),
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Bobcat", "LiquidEngineRE-I2", 204, pidBase, hasShroud: true),
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Skiff", "LiquidEngineRE-J10", 205, pidBase, hasShroud: true),
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Mastodon", "LiquidEngineRK-7", 206, pidBase, hasShroud: true),
+                // SRBs with shroud (rows 207-210)
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Flea v2", "solidBooster.sm.v2", 207, pidBase, isSrb: true, hasShroud: true),
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Hammer v2", "solidBooster.v2", 208, pidBase, isSrb: true, hasShroud: true),
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Mite", "Mite", 209, pidBase, isSrb: true, hasShroud: true),
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Shrimp", "Shrimp", 210, pidBase, isSrb: true, hasShroud: true),
+
+                // ── Liquid engines flame only (rows 211-222) ──
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Ant", "microEngine.v2", 211, pidBase),
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Spider", "radialEngineMini.v2", 212, pidBase),
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Twitch", "smallRadialEngine", 213, pidBase),
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Twitch v2", "smallRadialEngine.v2", 214, pidBase),
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Thud", "radialLiquidEngine1-2", 215, pidBase),
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Cub", "omsEngine", 216, pidBase),
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Mainsail", "liquidEngineMainsail.v2", 217, pidBase),
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Skipper", "engineLargeSkipper.v2", 218, pidBase),
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - SSME", "SSME", 219, pidBase),
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Twin-Boar", "Size2LFB.v2", 220, pidBase),
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Mammoth", "Size3EngineCluster", 221, pidBase),
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Pug", "LiquidEngineRV-1", 222, pidBase),
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - RAPIER", "RAPIER", 223, pidBase),
+
+                // ── SRBs flame only (rows 224-229) ──
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Thumper", "solidBooster1-1", 224, pidBase, isSrb: true),
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Kickback", "MassiveBooster", 225, pidBase, isSrb: true),
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Thoroughbred", "Thoroughbred", 226, pidBase, isSrb: true),
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Clydesdale", "Clydesdale", 227, pidBase, isSrb: true),
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Pollux", "Pollux", 228, pidBase, isSrb: true),
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Sepatron", "sepMotor1", 229, pidBase, isSrb: true),
+
+                // ── Jets (rows 230-234) ──
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Juno", "miniJetEngine", 230, pidBase),
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Wheesley", "JetEngine", 231, pidBase),
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Whiplash", "turboFanEngine", 232, pidBase),
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Panther", "turboJet", 233, pidBase),
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Goliath", "turboFanSize2", 234, pidBase),
+
+                // ── Special (row 235) ──
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Ion", "ionEngine", 235, pidBase)
             };
         }
 
@@ -1450,13 +1498,7 @@ namespace Parsek.Tests
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Mk2 Lander Cabin", "mk2LanderCabin_v2", 85,
                     ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98400000, SinglePartPid,
-                    firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
-                BuildPartShowcaseRecording(baseUT, "Part Showcase - Jet Engine", "JetEngine", 115,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98400000, SinglePartPid,
-                    firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
-                BuildPartShowcaseRecording(baseUT, "Part Showcase - Turbofan Size 2", "turboFanSize2", 116,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ShroudJettisoned, PartEventType.ShroudJettisoned, 98500000, SinglePartPid,
-                    firstEventOffsetSeconds: 3.0)
+                    firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5)
             };
         }
 
@@ -1742,122 +1784,7 @@ namespace Parsek.Tests
                     firstEventOffsetSeconds: 3.0),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Heat Shield 1.5", "HeatShield1p5", 94,
                     ShowcaseDistanceFromPadMeters, PartEventType.ShroudJettisoned, PartEventType.ShroudJettisoned, 98500000, SinglePartPid,
-                    firstEventOffsetSeconds: 3.0),
-                BuildPartShowcaseRecording(baseUT, "Part Showcase - LV-T30", "liquidEngine", 95,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ShroudJettisoned, PartEventType.ShroudJettisoned, 98500000, SinglePartPid,
-                    firstEventOffsetSeconds: 3.0),
-                BuildPartShowcaseRecording(baseUT, "Part Showcase - LV-T30 v2", "liquidEngine.v2", 96,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ShroudJettisoned, PartEventType.ShroudJettisoned, 98500000, SinglePartPid,
-                    firstEventOffsetSeconds: 3.0),
-                BuildPartShowcaseRecording(baseUT, "Part Showcase - LV-T45", "liquidEngine2", 97,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ShroudJettisoned, PartEventType.ShroudJettisoned, 98500000, SinglePartPid,
-                    firstEventOffsetSeconds: 3.0),
-                BuildPartShowcaseRecording(baseUT, "Part Showcase - LV-T45 v2", "liquidEngine2.v2", 98,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ShroudJettisoned, PartEventType.ShroudJettisoned, 98500000, SinglePartPid,
-                    firstEventOffsetSeconds: 3.0),
-                BuildPartShowcaseRecording(baseUT, "Part Showcase - Poodle v2", "liquidEngine2-2.v2", 99,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ShroudJettisoned, PartEventType.ShroudJettisoned, 98500000, SinglePartPid,
-                    firstEventOffsetSeconds: 3.0),
-                BuildPartShowcaseRecording(baseUT, "Part Showcase - Terrier v2", "liquidEngine3.v2", 100,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ShroudJettisoned, PartEventType.ShroudJettisoned, 98500000, SinglePartPid,
-                    firstEventOffsetSeconds: 3.0),
-                BuildPartShowcaseRecording(baseUT, "Part Showcase - Spark v2", "liquidEngineMini.v2", 101,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ShroudJettisoned, PartEventType.ShroudJettisoned, 98500000, SinglePartPid,
-                    firstEventOffsetSeconds: 3.0),
-                BuildPartShowcaseRecording(baseUT, "Part Showcase - NERV", "nuclearEngine", 102,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ShroudJettisoned, PartEventType.ShroudJettisoned, 98500000, SinglePartPid,
-                    firstEventOffsetSeconds: 3.0),
-                BuildPartShowcaseRecording(baseUT, "Part Showcase - Aerospike", "toroidalAerospike", 103,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ShroudJettisoned, PartEventType.ShroudJettisoned, 98500000, SinglePartPid,
-                    firstEventOffsetSeconds: 3.0),
-                BuildPartShowcaseRecording(baseUT, "Part Showcase - Thud Mite", "Mite", 104,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ShroudJettisoned, PartEventType.ShroudJettisoned, 98500000, SinglePartPid,
-                    firstEventOffsetSeconds: 3.0),
-                BuildPartShowcaseRecording(baseUT, "Part Showcase - Shrimp", "Shrimp", 105,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ShroudJettisoned, PartEventType.ShroudJettisoned, 98500000, SinglePartPid,
-                    firstEventOffsetSeconds: 3.0),
-                BuildPartShowcaseRecording(baseUT, "Part Showcase - Flea v2", "solidBooster.sm.v2", 106,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ShroudJettisoned, PartEventType.ShroudJettisoned, 98500000, SinglePartPid,
-                    firstEventOffsetSeconds: 3.0),
-                BuildPartShowcaseRecording(baseUT, "Part Showcase - Hammer v2", "solidBooster.v2", 107,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ShroudJettisoned, PartEventType.ShroudJettisoned, 98500000, SinglePartPid,
-                    firstEventOffsetSeconds: 3.0),
-                BuildPartShowcaseRecording(baseUT, "Part Showcase - Vector", "Size3AdvancedEngine", 108,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ShroudJettisoned, PartEventType.ShroudJettisoned, 98500000, SinglePartPid,
-                    firstEventOffsetSeconds: 3.0),
-                BuildPartShowcaseRecording(baseUT, "Part Showcase - Kodiak", "LiquidEngineKE-1", 109,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ShroudJettisoned, PartEventType.ShroudJettisoned, 98500000, SinglePartPid,
-                    firstEventOffsetSeconds: 3.0),
-                BuildPartShowcaseRecording(baseUT, "Part Showcase - Cheetah", "LiquidEngineLV-T91", 110,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ShroudJettisoned, PartEventType.ShroudJettisoned, 98500000, SinglePartPid,
-                    firstEventOffsetSeconds: 3.0),
-                BuildPartShowcaseRecording(baseUT, "Part Showcase - Wolfhound", "LiquidEngineLV-TX87", 111,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ShroudJettisoned, PartEventType.ShroudJettisoned, 98500000, SinglePartPid,
-                    firstEventOffsetSeconds: 3.0),
-                BuildPartShowcaseRecording(baseUT, "Part Showcase - Bobcat", "LiquidEngineRE-I2", 112,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ShroudJettisoned, PartEventType.ShroudJettisoned, 98500000, SinglePartPid,
-                    firstEventOffsetSeconds: 3.0, rowOffsetMeters: -1.0),
-                BuildPartShowcaseRecording(baseUT, "Part Showcase - Skiff", "LiquidEngineRE-J10", 113,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ShroudJettisoned, PartEventType.ShroudJettisoned, 98500000, SinglePartPid,
-                    firstEventOffsetSeconds: 3.0, rowOffsetMeters: 1.0),
-                BuildPartShowcaseRecording(baseUT, "Part Showcase - Mastodon", "LiquidEngineRK-7", 114,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ShroudJettisoned, PartEventType.ShroudJettisoned, 98500000, SinglePartPid,
                     firstEventOffsetSeconds: 3.0)
-            };
-        }
-
-        internal static RecordingBuilder[] EngineFlameShowcaseRecordings(double baseUT = 0)
-        {
-            const uint pidBase = 99200000;
-            return new[]
-            {
-                // Liquid engines (rows 191-217) — throttle-varying cycle
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame LV-T30", "liquidEngine", 191, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame LV-T30 v2", "liquidEngine.v2", 192, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame LV-T45", "liquidEngine2", 193, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame LV-T45 v2", "liquidEngine2.v2", 194, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Poodle", "liquidEngine2-2.v2", 195, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Terrier", "liquidEngine3.v2", 196, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Spark", "liquidEngineMini.v2", 197, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Ant", "microEngine.v2", 198, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Spider", "radialEngineMini.v2", 199, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Twitch", "smallRadialEngine", 200, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Twitch v2", "smallRadialEngine.v2", 201, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Thud", "radialLiquidEngine1-2", 202, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame NERV", "nuclearEngine", 203, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Aerospike", "toroidalAerospike", 204, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Cub", "omsEngine", 205, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Skipper", "engineLargeSkipper.v2", 206, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Twin-Boar", "Size2LFB.v2", 207, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Mammoth", "Size3EngineCluster", 208, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Vector", "Size3AdvancedEngine", 209, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Kodiak", "LiquidEngineKE-1", 210, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Cheetah", "LiquidEngineLV-T91", 211, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Wolfhound", "LiquidEngineLV-TX87", 212, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Bobcat", "LiquidEngineRE-I2", 213, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Skiff", "LiquidEngineRE-J10", 214, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Mastodon", "LiquidEngineRK-7", 215, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Pug", "LiquidEngineRV-1", 216, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame RAPIER", "RAPIER", 217, pidBase),
-                // Solid boosters (rows 218-227) — simple ignite/burnout cycle
-                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Flea", "solidBooster.sm.v2", 218, pidBase),
-                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Hammer", "solidBooster.v2", 219, pidBase),
-                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Thumper", "solidBooster1-1", 220, pidBase),
-                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Kickback", "MassiveBooster", 221, pidBase),
-                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Mite", "Mite", 222, pidBase),
-                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Shrimp", "Shrimp", 223, pidBase),
-                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Thoroughbred", "Thoroughbred", 224, pidBase),
-                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Clydesdale", "Clydesdale", 225, pidBase),
-                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Pollux", "Pollux", 226, pidBase),
-                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Sepatron", "sepMotor1", 227, pidBase),
-                // Jet engines (rows 228-232) — throttle-varying cycle
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Juno", "miniJetEngine", 228, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Wheesley", "JetEngine", 229, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Whiplash", "turboFanEngine", 230, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Panther", "turboJet", 231, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Goliath", "turboFanSize2", 232, pidBase),
-                // Special (row 233)
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Ion", "ionEngine", 233, pidBase)
             };
         }
 
@@ -2540,63 +2467,61 @@ namespace Parsek.Tests
         [Fact]
         public void EngineShowcaseRecordings_BuildExpectedShape()
         {
-            // Existing 3 engines (rows 42-44) now use throttle-varying builder
             var recordings = EngineShowcaseRecordings(baseUT: 17000);
-            Assert.Equal(3, recordings.Length);
+            Assert.Equal(45, recordings.Length);
 
+            // First entry: liquid with shroud (LV-T30) → 8 events, first is ShroudJettisoned
             var first = recordings[0].Build();
-            Assert.Equal("Part Showcase - Mainsail", first.GetValue("vesselName"));
+            Assert.Equal("Part Showcase - LV-T30", first.GetValue("vesselName"));
             Assert.Equal("True", first.GetValue("loopPlayback"));
             Assert.Equal(8, first.GetNodes("PART_EVENT").Length);
 
-            // Throttle builder: first event is EngineIgnited at 0.3
             var events = first.GetNodes("PART_EVENT");
-            Assert.Equal(((int)PartEventType.EngineIgnited).ToString(), events[0].GetValue("type"));
-            Assert.Equal("0.3", events[0].GetValue("value"));
-            Assert.Equal(((int)PartEventType.EngineThrottle).ToString(), events[1].GetValue("type"));
-            Assert.Equal("0.7", events[1].GetValue("value"));
+            Assert.Equal(((int)PartEventType.ShroudJettisoned).ToString(), events[0].GetValue("type"));
+            Assert.Equal(((int)PartEventType.EngineIgnited).ToString(), events[1].GetValue("type"));
+            Assert.Equal("0.3", events[1].GetValue("value"));
+            Assert.Equal(((int)PartEventType.EngineThrottle).ToString(), events[2].GetValue("type"));
 
             var ghost = first.GetNode("GHOST_VISUAL_SNAPSHOT");
             Assert.NotNull(ghost);
-            Assert.Equal("liquidEngineMainsail.v2", ghost.GetNodes("PART")[0].GetValue("name"));
+            Assert.Equal("liquidEngine", ghost.GetNodes("PART")[0].GetValue("name"));
             Assert.Equal(ghost.GetNodes("PART")[0].GetValue("persistentId"), events[0].GetValue("pid"));
 
-            var names = new[] { "liquidEngineMainsail.v2", "engineLargeSkipper.v2", "SSME" };
-            for (int i = 0; i < recordings.Length; i++)
-            {
-                var g = recordings[i].Build().GetNode("GHOST_VISUAL_SNAPSHOT");
-                Assert.Equal(names[i], g.GetNodes("PART")[0].GetValue("name"));
-            }
+            // SRB with shroud (index 16 = Flea v2) → 3 events
+            var srbShroud = recordings[16].Build();
+            Assert.Equal("Part Showcase - Flea v2", srbShroud.GetValue("vesselName"));
+            Assert.Equal(3, srbShroud.GetNodes("PART_EVENT").Length);
+            var srbEvents = srbShroud.GetNodes("PART_EVENT");
+            Assert.Equal(((int)PartEventType.ShroudJettisoned).ToString(), srbEvents[0].GetValue("type"));
+            Assert.Equal(((int)PartEventType.EngineIgnited).ToString(), srbEvents[1].GetValue("type"));
+            Assert.Equal("1", srbEvents[1].GetValue("value"));
+            Assert.Equal(((int)PartEventType.EngineShutdown).ToString(), srbEvents[2].GetValue("type"));
 
-            // 43 new engine flame entries (rows 192-234)
-            var flames = EngineFlameShowcaseRecordings(baseUT: 17000);
-            Assert.Equal(43, flames.Length);
+            // Liquid flame-only (index 20 = Ant) → 8 events, first is EngineIgnited
+            var flameOnly = recordings[20].Build();
+            Assert.Equal("Part Showcase - Ant", flameOnly.GetValue("vesselName"));
+            Assert.Equal(8, flameOnly.GetNodes("PART_EVENT").Length);
+            var flameEvents = flameOnly.GetNodes("PART_EVENT");
+            Assert.Equal(((int)PartEventType.EngineIgnited).ToString(), flameEvents[0].GetValue("type"));
+            Assert.Equal("0.3", flameEvents[0].GetValue("value"));
 
-            // Liquid engines (0-26) use throttle builder → 8 events
-            var liquid = flames[0].Build();
-            Assert.Equal("Part Showcase - Flame LV-T30", liquid.GetValue("vesselName"));
-            Assert.Equal(8, liquid.GetNodes("PART_EVENT").Length);
-            var liqEvents = liquid.GetNodes("PART_EVENT");
-            Assert.Equal(((int)PartEventType.EngineIgnited).ToString(), liqEvents[0].GetValue("type"));
-            Assert.Equal("0.3", liqEvents[0].GetValue("value"));
+            // SRB flame-only (index 33 = Thumper) → 2 events
+            var srbFlame = recordings[33].Build();
+            Assert.Equal("Part Showcase - Thumper", srbFlame.GetValue("vesselName"));
+            Assert.Equal(2, srbFlame.GetNodes("PART_EVENT").Length);
+            var srbFlameEvents = srbFlame.GetNodes("PART_EVENT");
+            Assert.Equal(((int)PartEventType.EngineIgnited).ToString(), srbFlameEvents[0].GetValue("type"));
+            Assert.Equal("1", srbFlameEvents[0].GetValue("value"));
+            Assert.Equal(((int)PartEventType.EngineShutdown).ToString(), srbFlameEvents[1].GetValue("type"));
 
-            // SRBs (27-36) use SRB builder → 2 events
-            var srb = flames[27].Build();
-            Assert.Equal("Part Showcase - Flame Flea", srb.GetValue("vesselName"));
-            Assert.Equal(2, srb.GetNodes("PART_EVENT").Length);
-            var srbEvents = srb.GetNodes("PART_EVENT");
-            Assert.Equal(((int)PartEventType.EngineIgnited).ToString(), srbEvents[0].GetValue("type"));
-            Assert.Equal("1", srbEvents[0].GetValue("value"));
-            Assert.Equal(((int)PartEventType.EngineShutdown).ToString(), srbEvents[1].GetValue("type"));
-
-            // Jets (37-41) use throttle builder → 8 events
-            var jet = flames[37].Build();
-            Assert.Equal("Part Showcase - Flame Juno", jet.GetValue("vesselName"));
+            // Jet (index 39 = Juno) → 8 events
+            var jet = recordings[39].Build();
+            Assert.Equal("Part Showcase - Juno", jet.GetValue("vesselName"));
             Assert.Equal(8, jet.GetNodes("PART_EVENT").Length);
 
-            // Ion (42) uses throttle builder → 8 events
-            var ion = flames[42].Build();
-            Assert.Equal("Part Showcase - Flame Ion", ion.GetValue("vesselName"));
+            // Ion (index 44) → 8 events
+            var ion = recordings[44].Build();
+            Assert.Equal("Part Showcase - Ion", ion.GetValue("vesselName"));
             Assert.Equal(8, ion.GetNodes("PART_EVENT").Length);
         }
 
@@ -2818,7 +2743,7 @@ namespace Parsek.Tests
         public void SpecialDeployAnimationShowcaseRecordings_BuildExpectedShape()
         {
             var recordings = SpecialDeployAnimationShowcaseRecordings(baseUT: 17000);
-            Assert.Equal(14, recordings.Length);
+            Assert.Equal(12, recordings.Length);
 
             var first = recordings[0].Build();
             Assert.Equal("Part Showcase - Rover Wheel M1-F", first.GetValue("vesselName"));
@@ -2841,8 +2766,7 @@ namespace Parsek.Tests
             var names = new[]
             {
                 "roverWheelM1-F", "GooExperiment", "science_module", "Magnetometer", "InflatableHeatShield", "InflatableAirlock",
-                "dockingPort1", "dockingPortLateral", "GrapplingDevice", "smallClaw", "mk2DockingPort", "mk2LanderCabin_v2",
-                "JetEngine", "turboFanSize2"
+                "dockingPort1", "dockingPortLateral", "GrapplingDevice", "smallClaw", "mk2DockingPort", "mk2LanderCabin_v2"
             };
             for (int i = 0; i < recordings.Length; i++)
             {
@@ -2885,7 +2809,7 @@ namespace Parsek.Tests
         public void JettisonShowcaseRecordings_BuildExpectedShape()
         {
             var recordings = JettisonShowcaseRecordings(baseUT: 17000);
-            Assert.Equal(29, recordings.Length);
+            Assert.Equal(9, recordings.Length);
 
             var first = recordings[0].Build();
             Assert.Equal("Part Showcase - Engine Plate 1.5", first.GetValue("vesselName"));
@@ -2899,14 +2823,7 @@ namespace Parsek.Tests
             var names = new[]
             {
                 "EnginePlate1p5", "EnginePlate2", "EnginePlate3", "EnginePlate4", "EnginePlate5",
-                "HeatShield1", "HeatShield2", "HeatShield3", "HeatShield1p5",
-                "liquidEngine", "liquidEngine.v2", "liquidEngine2", "liquidEngine2.v2",
-                "liquidEngine2-2.v2", "liquidEngine3.v2", "liquidEngineMini.v2",
-                "nuclearEngine", "toroidalAerospike",
-                "Mite", "Shrimp", "solidBooster.sm.v2", "solidBooster.v2",
-                "Size3AdvancedEngine",
-                "LiquidEngineKE-1", "LiquidEngineLV-T91", "LiquidEngineLV-TX87",
-                "LiquidEngineRE-I2", "LiquidEngineRE-J10", "LiquidEngineRK-7"
+                "HeatShield1", "HeatShield2", "HeatShield3", "HeatShield1p5"
             };
             for (int i = 0; i < recordings.Length; i++)
             {
@@ -3111,8 +3028,7 @@ namespace Parsek.Tests
                 RobotArmScannerShowcaseRecordings(17000),
                 ControlSurfaceShowcaseRecordings(17000),
                 WheelDynamicsShowcaseRecordings(17000),
-                AnimateHeatShowcaseRecordings(17000),
-                EngineFlameShowcaseRecordings(17000)
+                AnimateHeatShowcaseRecordings(17000)
             };
 
             foreach (var category in allShowcases)
@@ -3162,8 +3078,7 @@ namespace Parsek.Tests
                 RobotArmScannerShowcaseRecordings(17000),
                 ControlSurfaceShowcaseRecordings(17000),
                 WheelDynamicsShowcaseRecordings(17000),
-                AnimateHeatShowcaseRecordings(17000),
-                EngineFlameShowcaseRecordings(17000)
+                AnimateHeatShowcaseRecordings(17000)
             };
 
             var positions = new HashSet<string>();
@@ -3178,7 +3093,7 @@ namespace Parsek.Tests
                         $"Duplicate position in '{rec.GetValue("vesselName")}': {key}");
                 }
             }
-            Assert.Equal(234, positions.Count); // 10 + 18 + 7 + 11 + 3 + 2 + 5 + 5 + 2 + 2 + 8 + 2 + 5 + 14 + 29 + 21 + 1 + 3 + 24 + 6 + 13 + 43
+            Assert.Equal(211, positions.Count); // 10 + 18 + 7 + 11 + 45 + 2 + 5 + 5 + 2 + 2 + 8 + 2 + 5 + 12 + 9 + 21 + 1 + 3 + 24 + 6 + 13
         }
 
         [Fact]
@@ -3754,9 +3669,6 @@ namespace Parsek.Tests
             var animateHeatShowcases = AnimateHeatShowcaseRecordings(baseUT);
             for (int i = 0; i < animateHeatShowcases.Length; i++)
                 writer.AddRecording(animateHeatShowcases[i]);
-            var engineFlameShowcases = EngineFlameShowcaseRecordings(baseUT);
-            for (int i = 0; i < engineFlameShowcases.Length; i++)
-                writer.AddRecording(engineFlameShowcases[i]);
             writer.AddRecording(InventoryPlacementShowcaseRecording(baseUT));
 
             var chainSegments = EvaBoardChain(baseUT);
@@ -3833,9 +3745,8 @@ namespace Parsek.Tests
                     Assert.Contains("vesselName = Part Showcase - Cargo Mk3 Medium", content);
                     Assert.Contains("vesselName = Part Showcase - Cargo Mk3 Long", content);
                     Assert.Contains("vesselName = Part Showcase - Cargo Mk3 Ramp", content);
-                    Assert.Contains("vesselName = Part Showcase - Mainsail", content);
-                    Assert.Contains("vesselName = Part Showcase - Skipper", content);
-                    Assert.Contains("vesselName = Part Showcase - SSME", content);
+                    Assert.Contains("vesselName = Part Showcase - LV-T30", content);
+                    Assert.Contains("vesselName = Part Showcase - Ion", content);
                     Assert.Contains("vesselName = Part Showcase - Ladder Telescopic", content);
                     Assert.Contains("vesselName = Part Showcase - Ladder Bay", content);
                     Assert.Contains("vesselName = Part Showcase - RCS RV-105", content);
@@ -3879,8 +3790,6 @@ namespace Parsek.Tests
                     Assert.Contains("vesselName = Part Showcase - Small Claw", content);
                     Assert.Contains("vesselName = Part Showcase - Mk2 Docking Port", content);
                     Assert.Contains("vesselName = Part Showcase - Mk2 Lander Cabin", content);
-                    Assert.Contains("vesselName = Part Showcase - Jet Engine", content);
-                    Assert.Contains("vesselName = Part Showcase - Turbofan Size 2", content);
                     Assert.Contains("vesselName = Part Showcase - Engine Plate 1.5", content);
                     Assert.Contains("vesselName = Part Showcase - Engine Plate 2", content);
                     Assert.Contains("vesselName = Part Showcase - Engine Plate 3", content);
@@ -3899,7 +3808,7 @@ namespace Parsek.Tests
                     Assert.Contains("vesselName = Part Showcase - Spark v2", content);
                     Assert.Contains("vesselName = Part Showcase - NERV", content);
                     Assert.Contains("vesselName = Part Showcase - Aerospike", content);
-                    Assert.Contains("vesselName = Part Showcase - Thud Mite", content);
+                    Assert.Contains("vesselName = Part Showcase - Mite", content);
                     Assert.Contains("vesselName = Part Showcase - Shrimp", content);
                     Assert.Contains("vesselName = Part Showcase - Flea v2", content);
                     Assert.Contains("vesselName = Part Showcase - Hammer v2", content);
@@ -3978,49 +3887,6 @@ namespace Parsek.Tests
                     Assert.Contains("vesselName = Part Showcase - AnimateHeat Ram Air Intake", content);
                     Assert.Contains("vesselName = Part Showcase - AnimateHeat Shock Cone Intake", content);
                     Assert.Contains("vesselName = Part Showcase - AnimateHeat Standard Nose Cone", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame LV-T30", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame LV-T30 v2", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame LV-T45", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame LV-T45 v2", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame Poodle", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame Terrier", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame Spark", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame Ant", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame Spider", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame Twitch", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame Twitch v2", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame Thud", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame NERV", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame Aerospike", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame Cub", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame Skipper", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame Twin-Boar", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame Mammoth", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame Vector", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame Kodiak", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame Cheetah", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame Wolfhound", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame Bobcat", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame Skiff", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame Mastodon", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame Pug", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame RAPIER", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame Flea", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame Hammer", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame Thumper", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame Kickback", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame Mite", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame Shrimp", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame Thoroughbred", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame Clydesdale", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame Pollux", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame Sepatron", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame Juno", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame Wheesley", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame Whiplash", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame Panther", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame Goliath", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame Ion", content);
                     Assert.Contains("vesselName = Part Showcase - Inventory Placement", content);
                     Assert.Contains("vesselName = Flea Chain", content);
                     Assert.Contains("chainId = chain-eva-board-test", content);
@@ -4052,8 +3918,8 @@ namespace Parsek.Tests
                     $"Expected Parsek/Recordings directory at {recordingsDir}");
 
                 string[] precFiles = Directory.GetFiles(recordingsDir, "*.prec");
-                Assert.True(precFiles.Length >= 227,
-                    $"Expected at least 227 .prec files (8 baseline + 10 lights + 18 deployables + 7 gear + 11 cargo + 3 engines + 2 ladders + 5 RCS + 5 fairings + 2 extra radiators + 2 drills + 8 deployed science + 2 animation-group + 5 parachutes + 14 special deploy animations + 29 jettison showcases + 21 robotics + 1 aero-surface + 3 robot-arm-scanner + 24 control-surface + 6 wheel-dynamics + 13 animate-heat + 43 engine-flame + 1 inventory-placement + 3 board-chain + 2 walk-chain), found {precFiles.Length}");
+                Assert.True(precFiles.Length >= 225,
+                    $"Expected at least 225 .prec files (8 baseline + 10 lights + 18 deployables + 7 gear + 11 cargo + 45 engines + 2 ladders + 5 RCS + 5 fairings + 2 extra radiators + 2 drills + 8 deployed science + 2 animation-group + 5 parachutes + 12 special deploy animations + 9 jettison + 21 robotics + 1 aero-surface + 3 robot-arm-scanner + 24 control-surface + 6 wheel-dynamics + 13 animate-heat + 1 inventory-placement + 3 board-chain + 2 walk-chain), found {precFiles.Length}");
             }
         }
 

--- a/Source/Parsek.Tests/SyntheticRecordingTests.cs
+++ b/Source/Parsek.Tests/SyntheticRecordingTests.cs
@@ -678,7 +678,7 @@ namespace Parsek.Tests
         private const uint SinglePartPid = 100000;
         // Optional companion part (e.g., kerbal actor) receives the second slot.
         // Total visible showcase row entries (indices 0-235, including inventory placement).
-        private const int ShowcaseRowCount = 236;
+        private const int ShowcaseRowCount = 235;
         // Split showcase into two parallel lines to avoid runway clipping.
         private static readonly int ShowcaseEntriesPerLine = (ShowcaseRowCount + 1) / 2;
         private const double ShowcaseLineSpacingMeters = 20.0;
@@ -838,7 +838,7 @@ namespace Parsek.Tests
             };
         }
 
-        // Two parallel lines (rows 0-117 at 200m, rows 118-235 at 220m from pad):
+        // Two parallel lines (rows 0-117 at 200m, rows 118-234 at 220m from pad):
         // Back line — Lights: 0-5, Deployables: 6-23, Airplane Gear: 24-27, Landing Legs: 28-30,
         //   Cargo: 31-41, Engines: 42-44, Ladders: 45-46, RCS: 47-49, Fairings: 50-54,
         //   Extra Radiators: 55-56, Drills: 57-58, Deployed Science: 59-66,
@@ -846,8 +846,8 @@ namespace Parsek.Tests
         //   Jettison Coverage: 86-114, Robotics: 117 (partial)
         // Front line — Robotics: 118-137, AeroSurface: 138, Robot Arm Scanners: 139-141,
         //   Control Surfaces: 142-165, Wheel Dynamics: 166-171, AnimateHeat: 172-184,
-        //   Lights (extra): 185-188, Gear Extra Large: 189, RCS (extra): 190-191,
-        //   Engine Flames: 192-234, Inventory Placement: 235.
+        //   Lights (extra): 185-188, RCS (extra): 189-190,
+        //   Engine Flames: 191-233, Inventory Placement: 234.
 
         internal static RecordingBuilder[] DeployableShowcaseRecordings(double baseUT = 0)
         {
@@ -909,8 +909,6 @@ namespace Parsek.Tests
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Landing Leg LT-2", "landingLeg1-2", 29,
                     ShowcaseDistanceFromPadMeters, PartEventType.GearDeployed, PartEventType.GearRetracted, 90000000, SinglePartPid),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Landing Leg LT-05", "miniLandingLeg", 30,
-                    ShowcaseDistanceFromPadMeters, PartEventType.GearDeployed, PartEventType.GearRetracted, 90000000, SinglePartPid),
-                BuildPartShowcaseRecording(baseUT, "Part Showcase - Gear Extra Large", "GearLarge", 189,
                     ShowcaseDistanceFromPadMeters, PartEventType.GearDeployed, PartEventType.GearRetracted, 90000000, SinglePartPid)
             };
         }
@@ -981,11 +979,11 @@ namespace Parsek.Tests
                     ShowcaseDistanceFromPadMeters, PartEventType.RCSActivated, PartEventType.RCSStopped, 94000000, SinglePartPid,
                     eventValue: 1.0f, moduleIndex: 0,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
-                BuildPartShowcaseRecording(baseUT, "Part Showcase - RCS Linear Port", "linearRcs", 190,
+                BuildPartShowcaseRecording(baseUT, "Part Showcase - RCS Linear Port", "linearRcs", 189,
                     ShowcaseDistanceFromPadMeters, PartEventType.RCSActivated, PartEventType.RCSStopped, 94000000, SinglePartPid,
                     eventValue: 1.0f, moduleIndex: 0,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
-                BuildPartShowcaseRecording(baseUT, "Part Showcase - RCS Vernor", "vernierEngine", 191,
+                BuildPartShowcaseRecording(baseUT, "Part Showcase - RCS Vernor", "vernierEngine", 190,
                     ShowcaseDistanceFromPadMeters, PartEventType.RCSActivated, PartEventType.RCSStopped, 94000000, SinglePartPid,
                     eventValue: 1.0f, moduleIndex: 0,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5)
@@ -1525,53 +1523,53 @@ namespace Parsek.Tests
             const uint pidBase = 99200000;
             return new[]
             {
-                // Liquid engines (rows 192-218) — throttle-varying cycle
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame LV-T30", "liquidEngine", 192, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame LV-T30 v2", "liquidEngine.v2", 193, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame LV-T45", "liquidEngine2", 194, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame LV-T45 v2", "liquidEngine2.v2", 195, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Poodle", "liquidEngine2-2.v2", 196, pidBase, altitudeOffsetMeters: 5.0),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Terrier", "liquidEngine3.v2", 197, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Spark", "liquidEngineMini.v2", 198, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Ant", "microEngine.v2", 199, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Spider", "radialEngineMini.v2", 200, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Twitch", "smallRadialEngine", 201, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Twitch v2", "smallRadialEngine.v2", 202, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Thud", "radialLiquidEngine1-2", 203, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame NERV", "nuclearEngine", 204, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Aerospike", "toroidalAerospike", 205, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Cub", "omsEngine", 206, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Twin-Boar", "Size2LFB", 207, pidBase, altitudeOffsetMeters: 8.0),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Twin-Boar v2", "Size2LFB.v2", 208, pidBase, altitudeOffsetMeters: 8.0),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Mammoth", "Size3EngineCluster", 209, pidBase, altitudeOffsetMeters: 10.0),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Vector", "Size3AdvancedEngine", 210, pidBase, altitudeOffsetMeters: 8.0),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Kodiak", "LiquidEngineKE-1", 211, pidBase, altitudeOffsetMeters: 5.0),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Cheetah", "LiquidEngineLV-T91", 212, pidBase, altitudeOffsetMeters: 5.0),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Wolfhound", "LiquidEngineLV-TX87", 213, pidBase, altitudeOffsetMeters: 5.0),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Bobcat", "LiquidEngineRE-I2", 214, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Skiff", "LiquidEngineRE-J10", 215, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Mastodon", "LiquidEngineRK-7", 216, pidBase, altitudeOffsetMeters: 10.0),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Pug", "LiquidEngineRV-1", 217, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame RAPIER", "RAPIER", 218, pidBase),
-                // Solid boosters (rows 219-228) — simple ignite/burnout cycle
-                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Flea", "solidBooster.sm.v2", 219, pidBase),
-                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Hammer", "solidBooster.v2", 220, pidBase),
-                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Thumper", "solidBooster1-1", 221, pidBase, altitudeOffsetMeters: 5.0),
-                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Kickback", "MassiveBooster", 222, pidBase, altitudeOffsetMeters: 8.0),
-                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Mite", "Mite", 223, pidBase),
-                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Shrimp", "Shrimp", 224, pidBase),
-                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Thoroughbred", "Thoroughbred", 225, pidBase),
-                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Clydesdale", "Clydesdale", 226, pidBase, altitudeOffsetMeters: 10.0),
-                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Pollux", "Pollux", 227, pidBase, altitudeOffsetMeters: 10.0),
-                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Sepatron", "sepMotor1", 228, pidBase),
-                // Jet engines (rows 229-233) — throttle-varying cycle
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Juno", "miniJetEngine", 229, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Wheesley", "JetEngine", 230, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Whiplash", "turboFanEngine", 231, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Panther", "turboJet", 232, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Goliath", "turboFanSize2", 233, pidBase, altitudeOffsetMeters: 8.0),
-                // Special (row 234)
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Ion", "ionEngine", 234, pidBase)
+                // Liquid engines (rows 191-217) — throttle-varying cycle
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame LV-T30", "liquidEngine", 191, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame LV-T30 v2", "liquidEngine.v2", 192, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame LV-T45", "liquidEngine2", 193, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame LV-T45 v2", "liquidEngine2.v2", 194, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Poodle", "liquidEngine2-2.v2", 195, pidBase, altitudeOffsetMeters: 5.0),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Terrier", "liquidEngine3.v2", 196, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Spark", "liquidEngineMini.v2", 197, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Ant", "microEngine.v2", 198, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Spider", "radialEngineMini.v2", 199, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Twitch", "smallRadialEngine", 200, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Twitch v2", "smallRadialEngine.v2", 201, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Thud", "radialLiquidEngine1-2", 202, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame NERV", "nuclearEngine", 203, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Aerospike", "toroidalAerospike", 204, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Cub", "omsEngine", 205, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Skipper", "engineLargeSkipper.v2", 206, pidBase, altitudeOffsetMeters: 8.0),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Twin-Boar", "Size2LFB.v2", 207, pidBase, altitudeOffsetMeters: 8.0),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Mammoth", "Size3EngineCluster", 208, pidBase, altitudeOffsetMeters: 10.0),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Vector", "Size3AdvancedEngine", 209, pidBase, altitudeOffsetMeters: 8.0),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Kodiak", "LiquidEngineKE-1", 210, pidBase, altitudeOffsetMeters: 5.0),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Cheetah", "LiquidEngineLV-T91", 211, pidBase, altitudeOffsetMeters: 5.0),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Wolfhound", "LiquidEngineLV-TX87", 212, pidBase, altitudeOffsetMeters: 5.0),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Bobcat", "LiquidEngineRE-I2", 213, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Skiff", "LiquidEngineRE-J10", 214, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Mastodon", "LiquidEngineRK-7", 215, pidBase, altitudeOffsetMeters: 10.0),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Pug", "LiquidEngineRV-1", 216, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame RAPIER", "RAPIER", 217, pidBase),
+                // Solid boosters (rows 218-227) — simple ignite/burnout cycle
+                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Flea", "solidBooster.sm.v2", 218, pidBase),
+                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Hammer", "solidBooster.v2", 219, pidBase),
+                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Thumper", "solidBooster1-1", 220, pidBase, altitudeOffsetMeters: 15.0),
+                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Kickback", "MassiveBooster", 221, pidBase, altitudeOffsetMeters: 15.0),
+                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Mite", "Mite", 222, pidBase),
+                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Shrimp", "Shrimp", 223, pidBase),
+                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Thoroughbred", "Thoroughbred", 224, pidBase),
+                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Clydesdale", "Clydesdale", 225, pidBase, altitudeOffsetMeters: 15.0),
+                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Pollux", "Pollux", 226, pidBase, altitudeOffsetMeters: 15.0),
+                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Sepatron", "sepMotor1", 227, pidBase),
+                // Jet engines (rows 228-232) — throttle-varying cycle
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Juno", "miniJetEngine", 228, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Wheesley", "JetEngine", 229, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Whiplash", "turboFanEngine", 230, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Panther", "turboJet", 231, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Goliath", "turboFanSize2", 232, pidBase, altitudeOffsetMeters: 8.0),
+                // Special (row 233)
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Ion", "ionEngine", 233, pidBase)
             };
         }
 
@@ -2193,7 +2191,7 @@ namespace Parsek.Tests
         public void GearShowcaseRecordings_BuildExpectedShape()
         {
             var recordings = GearShowcaseRecordings(baseUT: 17000);
-            Assert.Equal(8, recordings.Length);
+            Assert.Equal(7, recordings.Length);
 
             var first = recordings[0].Build();
             Assert.Equal("Part Showcase - Gear Bay", first.GetValue("vesselName"));
@@ -2210,7 +2208,7 @@ namespace Parsek.Tests
             Assert.Equal(ghost.GetNodes("PART")[0].GetValue("persistentId"), events[0].GetValue("pid"));
 
             var names = new[] { "SmallGearBay", "GearSmall", "GearMedium", "GearLarge",
-                "landingLeg1", "landingLeg1-2", "miniLandingLeg", "GearLarge" };
+                "landingLeg1", "landingLeg1-2", "miniLandingLeg" };
             for (int i = 0; i < recordings.Length; i++)
             {
                 var g = recordings[i].Build().GetNode("GHOST_VISUAL_SNAPSHOT");
@@ -2892,7 +2890,7 @@ namespace Parsek.Tests
                         $"Duplicate position in '{rec.GetValue("vesselName")}': {key}");
                 }
             }
-            Assert.Equal(235, positions.Count); // 10 + 18 + 8 + 11 + 3 + 2 + 5 + 5 + 2 + 2 + 8 + 2 + 5 + 14 + 29 + 21 + 1 + 3 + 24 + 6 + 13 + 43
+            Assert.Equal(234, positions.Count); // 10 + 18 + 7 + 11 + 3 + 2 + 5 + 5 + 2 + 2 + 8 + 2 + 5 + 14 + 29 + 21 + 1 + 3 + 24 + 6 + 13 + 43
         }
 
         [Fact]
@@ -3533,7 +3531,6 @@ namespace Parsek.Tests
                     Assert.Contains("vesselName = Part Showcase - Gear Small", content);
                     Assert.Contains("vesselName = Part Showcase - Gear Medium", content);
                     Assert.Contains("vesselName = Part Showcase - Gear Large", content);
-                    Assert.Contains("vesselName = Part Showcase - Gear Extra Large", content);
                     Assert.Contains("vesselName = Part Showcase - Landing Leg LT-1", content);
                     Assert.Contains("vesselName = Part Showcase - Landing Leg LT-2", content);
                     Assert.Contains("vesselName = Part Showcase - Landing Leg LT-05", content);
@@ -3708,8 +3705,8 @@ namespace Parsek.Tests
                     Assert.Contains("vesselName = Part Showcase - Flame NERV", content);
                     Assert.Contains("vesselName = Part Showcase - Flame Aerospike", content);
                     Assert.Contains("vesselName = Part Showcase - Flame Cub", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame Skipper", content);
                     Assert.Contains("vesselName = Part Showcase - Flame Twin-Boar", content);
-                    Assert.Contains("vesselName = Part Showcase - Flame Twin-Boar v2", content);
                     Assert.Contains("vesselName = Part Showcase - Flame Mammoth", content);
                     Assert.Contains("vesselName = Part Showcase - Flame Vector", content);
                     Assert.Contains("vesselName = Part Showcase - Flame Kodiak", content);
@@ -3767,8 +3764,8 @@ namespace Parsek.Tests
                     $"Expected Parsek/Recordings directory at {recordingsDir}");
 
                 string[] precFiles = Directory.GetFiles(recordingsDir, "*.prec");
-                Assert.True(precFiles.Length >= 228,
-                    $"Expected at least 228 .prec files (8 baseline + 10 lights + 18 deployables + 8 gear + 11 cargo + 3 engines + 2 ladders + 5 RCS + 5 fairings + 2 extra radiators + 2 drills + 8 deployed science + 2 animation-group + 5 parachutes + 14 special deploy animations + 29 jettison showcases + 21 robotics + 1 aero-surface + 3 robot-arm-scanner + 24 control-surface + 6 wheel-dynamics + 13 animate-heat + 43 engine-flame + 1 inventory-placement + 3 board-chain + 2 walk-chain), found {precFiles.Length}");
+                Assert.True(precFiles.Length >= 227,
+                    $"Expected at least 227 .prec files (8 baseline + 10 lights + 18 deployables + 7 gear + 11 cargo + 3 engines + 2 ladders + 5 RCS + 5 fairings + 2 extra radiators + 2 drills + 8 deployed science + 2 animation-group + 5 parachutes + 14 special deploy animations + 29 jettison showcases + 21 robotics + 1 aero-surface + 3 robot-arm-scanner + 24 control-surface + 6 wheel-dynamics + 13 animate-heat + 43 engine-flame + 1 inventory-placement + 3 board-chain + 2 walk-chain), found {precFiles.Length}");
             }
         }
 

--- a/Source/Parsek.Tests/SyntheticRecordingTests.cs
+++ b/Source/Parsek.Tests/SyntheticRecordingTests.cs
@@ -1253,16 +1253,18 @@ namespace Parsek.Tests
                 BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Mite", "Mite", 209, pidBase, isSrb: true, hasShroud: true),
                 BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Shrimp", "Shrimp", 210, pidBase, isSrb: true, hasShroud: true),
 
-                // ── Liquid engines flame only (rows 211-222) ──
+                // ── Liquid engines flame only (rows 211-216) ──
                 BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Ant", "microEngine.v2", 211, pidBase),
                 BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Spider", "radialEngineMini.v2", 212, pidBase),
                 BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Twitch", "smallRadialEngine", 213, pidBase),
                 BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Twitch v2", "smallRadialEngine.v2", 214, pidBase),
                 BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Thud", "radialLiquidEngine1-2", 215, pidBase),
                 BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Cub", "omsEngine", 216, pidBase),
-                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Mainsail", "liquidEngineMainsail.v2", 217, pidBase),
-                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Skipper", "engineLargeSkipper.v2", 218, pidBase),
-                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - SSME", "SSME", 219, pidBase),
+
+                // ── Liquid engines with shroud jettison + flame (rows 217-219) ──
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Mainsail", "liquidEngineMainsail.v2", 217, pidBase, hasShroud: true),
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Skipper", "engineLargeSkipper.v2", 218, pidBase, hasShroud: true),
+                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - SSME", "SSME", 219, pidBase, hasShroud: true),
                 BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Twin-Boar", "Size2LFB.v2", 220, pidBase),
                 BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Mammoth", "Size3EngineCluster", 221, pidBase),
                 BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Pug", "LiquidEngineRV-1", 222, pidBase),
@@ -2504,6 +2506,22 @@ namespace Parsek.Tests
             var flameEvents = flameOnly.GetNodes("PART_EVENT");
             Assert.Equal(((int)PartEventType.EngineIgnited).ToString(), flameEvents[0].GetValue("type"));
             Assert.Equal("0.3", flameEvents[0].GetValue("value"));
+
+            // Late large-liquid rows also use shroud+jettison (indices 26-28).
+            var mainsail = recordings[26].Build();
+            Assert.Equal("Part Showcase - Mainsail", mainsail.GetValue("vesselName"));
+            Assert.Equal(8, mainsail.GetNodes("PART_EVENT").Length);
+            Assert.Equal(((int)PartEventType.ShroudJettisoned).ToString(), mainsail.GetNodes("PART_EVENT")[0].GetValue("type"));
+
+            var skipper = recordings[27].Build();
+            Assert.Equal("Part Showcase - Skipper", skipper.GetValue("vesselName"));
+            Assert.Equal(8, skipper.GetNodes("PART_EVENT").Length);
+            Assert.Equal(((int)PartEventType.ShroudJettisoned).ToString(), skipper.GetNodes("PART_EVENT")[0].GetValue("type"));
+
+            var ssme = recordings[28].Build();
+            Assert.Equal("Part Showcase - SSME", ssme.GetValue("vesselName"));
+            Assert.Equal(8, ssme.GetNodes("PART_EVENT").Length);
+            Assert.Equal(((int)PartEventType.ShroudJettisoned).ToString(), ssme.GetNodes("PART_EVENT")[0].GetValue("type"));
 
             // SRB flame-only (index 33 = Thumper) → 2 events
             var srbFlame = recordings[33].Build();

--- a/Source/Parsek.Tests/SyntheticRecordingTests.cs
+++ b/Source/Parsek.Tests/SyntheticRecordingTests.cs
@@ -575,8 +575,7 @@ namespace Parsek.Tests
             double t = baseUT + 30;
             ShowcasePosition(rowIndex, distanceFromPadMeters, out double lat, out double lon, out double alt,
                 rowOffsetMeters, distanceOffsetMeters);
-            if (onEvent == PartEventType.ShroudJettisoned && offEvent == PartEventType.ShroudJettisoned)
-                alt += ShroudShowcaseAltitudeOffsetMeters;
+            alt += ShowcaseAltitudeOffset(partName);
 
             var b = new RecordingBuilder(vesselName)
                 .WithDefaultRotation(KscRotX, KscRotY, KscRotZ, KscRotW)
@@ -643,6 +642,7 @@ namespace Parsek.Tests
 
             double t = baseUT + 30;
             ShowcasePosition(rowIndex, distanceFromPadMeters, out double lat, out double lon, out double alt);
+            alt += ShowcaseAltitudeOffset(partName);
 
             var b = new RecordingBuilder(vesselName)
                 .WithDefaultRotation(KscRotX, KscRotY, KscRotZ, KscRotW)
@@ -684,8 +684,295 @@ namespace Parsek.Tests
         private const double ShowcaseLineSpacingMeters = 20.0;
         // Keep showcases close to the launchpad centerline without overlapping pad geometry.
         private const double ShowcaseDistanceFromPadMeters = 200.0;
-        // Shroud-jettison showcase parts include tall engine plates and engines that clip at base altitude.
-        private const double ShroudShowcaseAltitudeOffsetMeters = 12.0;
+        // Target top height (meters above KSC ground level). Every part's top is placed at
+        // this height. With Clydesdale (topY=10.8, total ~22.3m) the bottom sits ~5.7m
+        // above ground. Small parts float at ~28m — fine at 200m viewing distance.
+        private const double ShowcaseTargetTopHeight = 28.0;
+
+        // Maps partName -> topY (meters above part origin, from node_stack_top Y or visual
+        // estimate). Used to compute per-part altitude offset for top-aligned showcase layout.
+        // Surface-attach-only parts (lights, control surfaces, RCS, etc.) use 0.0.
+        private static readonly Dictionary<string, double> ShowcasePartTopY = new Dictionary<string, double>
+        {
+            // ── Lights (surface-attach) ──
+            { "domeLight1", 0.0 },
+            { "navLight1", 0.0 },
+            { "stripLight1", 0.0 },
+            { "spotLight3", 0.0 },
+            { "groundLight1", 0.0 },
+            { "groundLight2", 0.0 },
+            { "spotLight1", 0.0 },
+            { "spotLight1_v2", 0.0 },
+            { "spotLight2", 0.0 },
+            { "spotLight2_v2", 0.0 },
+
+            // ── Solar panels / Antennas / Radiator (surface-attach or radial) ──
+            { "solarPanels4", 0.0 },
+            { "largeSolarPanel", 0.0 },
+            { "LgRadialSolarPanel", 0.0 },
+            { "solarPanelOX10C", 0.0 },
+            { "solarPanelOX10L", 0.0 },
+            { "solarPanels1", 0.0 },
+            { "solarPanels2", 0.0 },
+            { "solarPanels3", 0.0 },
+            { "solarPanels5", 0.0 },
+            { "solarPanelSP10C", 0.0 },
+            { "solarPanelSP10L", 0.0 },
+            { "longAntenna", 0.0 },
+            { "commDish", 0.0 },
+            { "HighGainAntenna", 0.0 },
+            { "HighGainAntenna5", 0.0 },
+            { "HighGainAntenna5.v2", 0.0 },
+            { "mediumDishAntenna", 0.0 },
+            { "foldingRadSmall", 0.0 },
+            { "foldingRadMed", 0.0 },
+            { "foldingRadLarge", 0.0 },
+
+            // ── Landing gear (surface-attach) ──
+            { "SmallGearBay", 0.0 },
+            { "GearSmall", 0.0 },
+            { "GearMedium", 0.0 },
+            { "GearLarge", 0.0 },
+
+            // ── Landing legs (surface-attach) ──
+            { "landingLeg1", 0.0 },
+            { "landingLeg1-2", 0.0 },
+            { "miniLandingLeg", 0.0 },
+
+            // ── Service bays / Cargo bays ──
+            { "ServiceBay.125.v2", 0.3 },
+            { "ServiceBay.250.v2", 0.65 },
+            { "ServiceModule18", 0.75 },
+            { "ServiceModule25", 1.55 },
+            { "Size1to0ServiceModule", 0.3125 },
+            { "mk2CargoBayS", 0.9375 },
+            { "mk2CargoBayL", 1.875 },
+            { "mk3CargoBayS", 1.25 },
+            { "mk3CargoBayM", 2.5 },
+            { "mk3CargoBayL", 5.0 },
+            { "mk3CargoRamp", 3.0 },
+
+            // ── Engines (EngineShowcaseRecordings — shroud jettison + flame) ──
+            { "liquidEngineMainsail.v2", 1.01359 },
+            { "engineLargeSkipper.v2", 1.013 },
+            { "SSME", 0.0 },
+
+            // ── Ladders (surface-attach) ──
+            { "telescopicLadder", 0.0 },
+            { "telescopicLadderBay", 0.0 },
+
+            // ── RCS (surface-attach) ──
+            { "RCSBlock.v2", 0.0 },
+            { "RCSblock.01.small", 0.0 },
+            { "RCSLinearSmall", 0.0 },
+            { "linearRcs", 0.0 },
+            { "vernierEngine", 0.0 },
+
+            // ── Fairings ──
+            { "fairingSize1", 0.22 },
+            { "fairingSize1p5", 0.22 },
+            { "fairingSize2", 0.22 },
+            { "fairingSize3", 0.22 },
+            { "fairingSize4", 0.22 },
+
+            // ── Drills (surface-attach / radial) ──
+            { "MiniDrill", 0.0 },
+            { "RadialDrill", 0.0 },
+
+            // ── Deployed science (surface-attach) ──
+            { "DeployedCentralStation", 0.0 },
+            { "DeployedGoExOb", 0.0 },
+            { "DeployedIONExp", 0.0 },
+            { "DeployedRTG", 0.0 },
+            { "DeployedSatDish", 0.0 },
+            { "DeployedSeismicSensor", 0.0 },
+            { "DeployedSolarPanel", 0.0 },
+            { "DeployedWeatherStn", 0.0 },
+
+            // ── Animation group / Survey / Anchor ──
+            { "groundAnchor", 0.12236 },
+            { "SurveyScanner", 0.0 },
+
+            // ── Parachutes (surface-attach / radial) ──
+            { "parachuteSingle", 0.0 },
+            { "parachuteRadial", 0.0 },
+            { "parachuteDrogue", 0.0 },
+            { "radialDrogue", 0.0 },
+            { "parachuteLarge", 0.0 },
+
+            // ── Special deploy animations ──
+            { "roverWheelM1-F", 0.0 },
+            { "GooExperiment", 0.0 },
+            { "science_module", 0.49 },
+            { "Magnetometer", 0.0 },
+            { "InflatableHeatShield", 1.4 },       // Inverted nodes: real top is node_stack_bottom Y
+            { "InflatableAirlock", 0.0 },
+            { "dockingPort1", 0.0 },
+            { "dockingPortLateral", 0.5753132 },
+            { "GrapplingDevice", 0.0 },             // node_stack_top Y is negative; treat as 0.0
+            { "smallClaw", 0.0 },                    // node_stack_top Y is negative; treat as 0.0
+            { "mk2DockingPort", 0.625 },
+            { "mk2LanderCabin_v2", 0.751929 },
+
+            // ── Jets (part showcase, non-flame) ──
+            { "JetEngine", 0.972875 },
+            { "turboFanSize2", 2.0 },
+
+            // ── Robotics ──
+            { "hinge.01", 0.3125 },
+            { "hinge.01.s", 0.10348 },
+            { "hinge.03", 0.0 },                    // Negative node_stack_top; treat as 0.0
+            { "hinge.03.s", 0.0 },                  // Negative node_stack_top; treat as 0.0
+            { "hinge.04", 0.0 },                    // Negative node_stack_top; treat as 0.0
+            { "piston.01", 1.30408 },
+            { "piston.02", 0.643867 },
+            { "piston.03", 1.32439 },
+            { "piston.04", 0.662193 },
+            { "rotoServo.00", 0.21796 },
+            { "rotoServo.02", 0.21796 },
+            { "rotoServo.03", 0.62483 },
+            { "rotoServo.04", 0.9375 },
+            { "rotor.01", 0.415 },
+            { "rotor.01s", 0.343347 },
+            { "rotor.02", 0.42 },
+            { "rotor.02s", 0.42 },
+            { "rotor.03", 1.25 },
+            { "rotor.03s", 0.955512 },
+            { "RotorEngine.02", 0.415 },
+            { "RotorEngine.03", 0.415 },
+
+            // ── Airbrake (surface-attach) ──
+            { "airbrake1", 0.0 },
+
+            // ── Robot arm scanners (surface-attach) ──
+            { "RobotArmScanner_S1", 0.0 },
+            { "RobotArmScanner_S2", 0.0 },
+            { "RobotArmScanner_S3", 0.0 },
+
+            // ── Control surfaces (surface-attach) ──
+            { "AdvancedCanard", 0.0 },
+            { "airlinerCtrlSrf", 0.0 },
+            { "airlinerTailFin", 0.0 },
+            { "CanardController", 0.0 },
+            { "elevon2", 0.0 },
+            { "elevon3", 0.0 },
+            { "elevon5", 0.0 },
+            { "largeFanBlade", 0.0 },
+            { "largeHeliBlade", 0.0 },
+            { "largePropeller", 0.0 },
+            { "mediumFanBlade", 0.0 },
+            { "mediumHeliBlade", 0.0 },
+            { "mediumPropeller", 0.0 },
+            { "R8winglet", 0.0 },
+            { "smallCtrlSrf", 0.0 },
+            { "smallFanBlade", 0.0 },
+            { "smallHeliBlade", 0.0 },
+            { "smallPropeller", 0.0 },
+            { "StandardCtrlSrf", 0.0 },
+            { "tailfin", 0.0 },
+            { "winglet3", 0.0 },
+            { "wingShuttleElevon1", 0.0 },
+            { "wingShuttleElevon2", 0.0 },
+            { "wingShuttleRudder", 0.0 },
+
+            // ── Wheel dynamics (surface-attach) ──
+            { "GearFixed", 0.0 },
+            { "GearFree", 0.0 },
+            { "roverWheel1", 0.0 },
+            { "roverWheel2", 0.0 },
+            { "roverWheel3", 0.0 },
+            { "wheelMed", 0.0 },
+
+            // ── AnimateHeat parts ──
+            { "airplaneTail", 0.0 },
+            { "airplaneTailB", 0.0 },
+            { "avionicsNoseCone", 0.0 },
+            { "CircularIntake", 0.0 },
+            { "MK1IntakeFuselage", 0.9375 },
+            { "nacelleBody", 0.9375 },
+            { "noseConeAdapter", 1.125 },
+            { "pointyNoseConeA", 0.0 },
+            { "pointyNoseConeB", 0.0 },
+            { "radialEngineBody", 0.9375 },
+            { "ramAirIntake", 0.0 },
+            { "shockConeIntake", 0.0 },
+            { "standardNoseCone", 0.0 },
+
+            // ── Jettison coverage: engine plates ──
+            { "EnginePlate1p5", 0.15 },
+            { "EnginePlate2", 0.2 },
+            { "EnginePlate3", 0.3 },
+            { "EnginePlate4", 0.4 },
+            { "EnginePlate5", 0.1 },
+
+            // ── Jettison coverage: heat shields ──
+            { "HeatShield1", 0.022 },
+            { "HeatShield2", 0.034 },
+            { "HeatShield3", 0.25 },
+            { "HeatShield1p5", 0.125 },
+
+            // ── Jettison coverage: engines (v1 / v2 / MH) ──
+            { "liquidEngine", 0.721461 },           // scale=0.1 applied
+            { "liquidEngine.v2", 0.0 },
+            { "liquidEngine2", 0.721461 },           // scale=0.1 applied
+            { "liquidEngine2.v2", 0.0 },
+            { "liquidEngine2-2.v2", 0.0 },
+            { "liquidEngine3.v2", 0.0 },
+            { "liquidEngineMini.v2", 0.0 },
+            { "nuclearEngine", 1.40383 },
+            { "toroidalAerospike", 0.0 },
+            { "Mite", 0.874462 },
+            { "Shrimp", 1.98582 },
+            { "solidBooster.sm.v2", 0.7575 },
+            { "solidBooster.v2", 1.2818375 },
+            { "Size3AdvancedEngine", 1.487975 },
+            { "LiquidEngineKE-1", 0.8 },
+            { "LiquidEngineLV-T91", 0.84028 },
+            { "LiquidEngineLV-TX87", 0.76784 },
+            { "LiquidEngineRE-I2", 1.80521 },
+            { "LiquidEngineRE-J10", 0.361067 },
+            { "LiquidEngineRK-7", 0.75 },
+
+            // ── Engine flame showcase: additional liquid engines ──
+            { "microEngine.v2", 0.0 },
+            { "radialEngineMini.v2", 0.0 },
+            { "smallRadialEngine", 0.0 },
+            { "smallRadialEngine.v2", 0.0 },
+            { "radialLiquidEngine1-2", 0.0 },
+            { "omsEngine", 0.0 },
+            { "Size2LFB.v2", 4.356 },
+            { "Size3EngineCluster", 1.527248 },
+            { "LiquidEngineRV-1", 0.0 },
+            { "RAPIER", 0.741545 },
+
+            // ── SRB flame showcase: additional SRBs ──
+            { "solidBooster1-1", 3.92 },
+            { "MassiveBooster", 7.429159 },
+            { "Thoroughbred", 6.14614 },
+            { "Clydesdale", 10.8 },
+            { "Pollux", 7.83746 },
+            { "sepMotor1", 0.0 },
+
+            // ── Jet flame showcase ──
+            { "miniJetEngine", 0.0 },
+            { "turboFanEngine", 1.4 },
+            { "turboJet", 0.0 },
+            { "ionEngine", 0.2135562 },
+
+            // ── Inventory placement (kerbalEVA companion, not offset) ──
+            // DeployedWeatherStn already listed above.
+        };
+
+        /// <summary>
+        /// Returns the altitude offset (meters above base altitude) so the part's top aligns
+        /// with <see cref="ShowcaseTargetTopHeight"/> above KSC ground level.
+        /// </summary>
+        private static double ShowcaseAltitudeOffset(string partName)
+        {
+            if (ShowcasePartTopY.TryGetValue(partName, out double topY))
+                return ShowcaseTargetTopHeight - topY;
+            return ShowcaseTargetTopHeight; // fallback: assume origin is at top
+        }
 
         /// <summary>
         /// Computes lat/lon/alt for a showcase row, splitting rows across two parallel lines.
@@ -718,6 +1005,7 @@ namespace Parsek.Tests
         {
             double t = baseUT + 30;
             ShowcasePosition(rowIndex, ShowcaseDistanceFromPadMeters, out double lat, out double lon, out double alt);
+            alt += ShowcaseAltitudeOffset(lightPartName);
 
             var b = new RecordingBuilder(vesselName)
                 .WithDefaultRotation(KscRotX, KscRotY, KscRotZ, KscRotW)
@@ -754,11 +1042,11 @@ namespace Parsek.Tests
         /// </summary>
         private static RecordingBuilder BuildEngineFlameShowcaseRecording(
             double baseUT, string vesselName, string enginePartName, int rowIndex,
-            uint pidBase, double altitudeOffsetMeters = 0.0)
+            uint pidBase)
         {
             double t = baseUT + 30;
             ShowcasePosition(rowIndex, ShowcaseDistanceFromPadMeters, out double lat, out double lon, out double alt);
-            alt += altitudeOffsetMeters;
+            alt += ShowcaseAltitudeOffset(enginePartName);
 
             var b = new RecordingBuilder(vesselName)
                 .WithDefaultRotation(KscRotX, KscRotY, KscRotZ, KscRotW)
@@ -794,11 +1082,11 @@ namespace Parsek.Tests
         /// </summary>
         private static RecordingBuilder BuildSrbFlameShowcaseRecording(
             double baseUT, string vesselName, string srbPartName, int rowIndex,
-            uint pidBase, double altitudeOffsetMeters = 0.0)
+            uint pidBase)
         {
             double t = baseUT + 30;
             ShowcasePosition(rowIndex, ShowcaseDistanceFromPadMeters, out double lat, out double lon, out double alt);
-            alt += altitudeOffsetMeters;
+            alt += ShowcaseAltitudeOffset(srbPartName);
 
             var b = new RecordingBuilder(vesselName)
                 .WithDefaultRotation(KscRotX, KscRotY, KscRotZ, KscRotW)
@@ -1528,7 +1816,7 @@ namespace Parsek.Tests
                 BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame LV-T30 v2", "liquidEngine.v2", 192, pidBase),
                 BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame LV-T45", "liquidEngine2", 193, pidBase),
                 BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame LV-T45 v2", "liquidEngine2.v2", 194, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Poodle", "liquidEngine2-2.v2", 195, pidBase, altitudeOffsetMeters: 5.0),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Poodle", "liquidEngine2-2.v2", 195, pidBase),
                 BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Terrier", "liquidEngine3.v2", 196, pidBase),
                 BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Spark", "liquidEngineMini.v2", 197, pidBase),
                 BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Ant", "microEngine.v2", 198, pidBase),
@@ -1539,35 +1827,35 @@ namespace Parsek.Tests
                 BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame NERV", "nuclearEngine", 203, pidBase),
                 BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Aerospike", "toroidalAerospike", 204, pidBase),
                 BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Cub", "omsEngine", 205, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Skipper", "engineLargeSkipper.v2", 206, pidBase, altitudeOffsetMeters: 8.0),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Twin-Boar", "Size2LFB.v2", 207, pidBase, altitudeOffsetMeters: 8.0),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Mammoth", "Size3EngineCluster", 208, pidBase, altitudeOffsetMeters: 10.0),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Vector", "Size3AdvancedEngine", 209, pidBase, altitudeOffsetMeters: 8.0),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Kodiak", "LiquidEngineKE-1", 210, pidBase, altitudeOffsetMeters: 5.0),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Cheetah", "LiquidEngineLV-T91", 211, pidBase, altitudeOffsetMeters: 5.0),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Wolfhound", "LiquidEngineLV-TX87", 212, pidBase, altitudeOffsetMeters: 5.0),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Skipper", "engineLargeSkipper.v2", 206, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Twin-Boar", "Size2LFB.v2", 207, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Mammoth", "Size3EngineCluster", 208, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Vector", "Size3AdvancedEngine", 209, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Kodiak", "LiquidEngineKE-1", 210, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Cheetah", "LiquidEngineLV-T91", 211, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Wolfhound", "LiquidEngineLV-TX87", 212, pidBase),
                 BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Bobcat", "LiquidEngineRE-I2", 213, pidBase),
                 BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Skiff", "LiquidEngineRE-J10", 214, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Mastodon", "LiquidEngineRK-7", 215, pidBase, altitudeOffsetMeters: 10.0),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Mastodon", "LiquidEngineRK-7", 215, pidBase),
                 BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Pug", "LiquidEngineRV-1", 216, pidBase),
                 BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame RAPIER", "RAPIER", 217, pidBase),
                 // Solid boosters (rows 218-227) — simple ignite/burnout cycle
                 BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Flea", "solidBooster.sm.v2", 218, pidBase),
                 BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Hammer", "solidBooster.v2", 219, pidBase),
-                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Thumper", "solidBooster1-1", 220, pidBase, altitudeOffsetMeters: 15.0),
-                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Kickback", "MassiveBooster", 221, pidBase, altitudeOffsetMeters: 15.0),
+                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Thumper", "solidBooster1-1", 220, pidBase),
+                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Kickback", "MassiveBooster", 221, pidBase),
                 BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Mite", "Mite", 222, pidBase),
                 BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Shrimp", "Shrimp", 223, pidBase),
                 BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Thoroughbred", "Thoroughbred", 224, pidBase),
-                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Clydesdale", "Clydesdale", 225, pidBase, altitudeOffsetMeters: 15.0),
-                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Pollux", "Pollux", 226, pidBase, altitudeOffsetMeters: 15.0),
+                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Clydesdale", "Clydesdale", 225, pidBase),
+                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Pollux", "Pollux", 226, pidBase),
                 BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Sepatron", "sepMotor1", 227, pidBase),
                 // Jet engines (rows 228-232) — throttle-varying cycle
                 BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Juno", "miniJetEngine", 228, pidBase),
                 BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Wheesley", "JetEngine", 229, pidBase),
                 BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Whiplash", "turboFanEngine", 230, pidBase),
                 BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Panther", "turboJet", 231, pidBase),
-                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Goliath", "turboFanSize2", 232, pidBase, altitudeOffsetMeters: 8.0),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Goliath", "turboFanSize2", 232, pidBase),
                 // Special (row 233)
                 BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Ion", "ionEngine", 233, pidBase)
             };
@@ -1576,10 +1864,10 @@ namespace Parsek.Tests
         internal static RecordingBuilder InventoryPlacementShowcaseRecording(double baseUT = 0)
         {
             const int rowIndex = ShowcaseRowCount - 1;
+            const string partName = "DeployedWeatherStn";
             double t = baseUT + 30;
             ShowcasePosition(rowIndex, ShowcaseDistanceFromPadMeters, out double lat, out double lon, out double alt);
-
-            const string partName = "DeployedWeatherStn";
+            alt += ShowcaseAltitudeOffset(partName);
             var b = new RecordingBuilder("Part Showcase - Inventory Placement")
                 .WithDefaultRotation(KscRotX, KscRotY, KscRotZ, KscRotW)
                 .WithLoopPlayback(loop: true, pauseSeconds: 0.0);

--- a/Source/Parsek.Tests/SyntheticRecordingTests.cs
+++ b/Source/Parsek.Tests/SyntheticRecordingTests.cs
@@ -664,7 +664,7 @@ namespace Parsek.Tests
 
             var snap = new VesselSnapshotBuilder()
                 .WithName(vesselName)
-                .WithPersistentId((uint)(98400000 + rowIndex))
+                .WithPersistentId((uint)(SpecialDeployShowcasePidBase + rowIndex))
                 .AddPart(partName, rotation: "0,-0.7071068,0,0.7071068")
                 .AsLanded(lat, lon, alt)
                 .Build();
@@ -676,6 +676,28 @@ namespace Parsek.Tests
         // The first part added by VesselSnapshotBuilder gets persistentId = 100000.
         // Event PIDs must match this so the ghost visual builder can find the part.
         private const uint SinglePartPid = 100000;
+        private const uint LightShowcasePidBase = 88000000;
+        private const uint DeployableShowcasePidBase = 89000000;
+        private const uint GearShowcasePidBase = 90000000;
+        private const uint CargoBayShowcasePidBase = 91000000;
+        private const uint LadderShowcasePidBase = 93000000;
+        private const uint RcsShowcasePidBase = 94000000;
+        private const uint FairingShowcasePidBase = 95000000;
+        private const uint RadiatorShowcasePidBase = 96000000;
+        private const uint DrillShowcasePidBase = 97000000;
+        private const uint DeployedScienceShowcasePidBase = 98000000;
+        private const uint InventoryPlacementPid = 98100000;
+        private const uint AnimationGroupShowcasePidBase = 98200000;
+        private const uint ParachuteShowcasePidBase = 98300000;
+        private const uint SpecialDeployShowcasePidBase = 98400000;
+        private const uint JettisonShowcasePidBase = 98500000;
+        private const uint RoboticsShowcasePidBase = 98600000;
+        private const uint AeroSurfaceShowcasePidBase = 98700000;
+        private const uint RobotArmScannerShowcasePidBase = 98800000;
+        private const uint ControlSurfaceShowcasePidBase = 98900000;
+        private const uint WheelDynamicsShowcasePidBase = 99000000;
+        private const uint AnimateHeatShowcasePidBase = 99100000;
+        private const uint EngineShowcasePidBase = 99200000;
         // Optional companion part (e.g., kerbal actor) receives the second slot.
         // Total visible showcase row entries (indices 0-235, including inventory placement).
         private const int ShowcaseRowCount = 237;
@@ -1026,7 +1048,7 @@ namespace Parsek.Tests
 
             var snap = new VesselSnapshotBuilder()
                 .WithName(vesselName)
-                .WithPersistentId((uint)(88000000 + rowIndex))
+                .WithPersistentId((uint)(LightShowcasePidBase + rowIndex))
                 .AddPart(lightPartName, rotation: "0,-0.7071068,0,0.7071068")
                 .AsLanded(lat, lon, alt)
                 .Build();
@@ -1137,41 +1159,41 @@ namespace Parsek.Tests
             return new[]
             {
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Solar Tracking", "solarPanels4", 6,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 89000000, SinglePartPid),
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, DeployableShowcasePidBase, SinglePartPid),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Solar Large", "largeSolarPanel", 7,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 89000000, SinglePartPid),
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, DeployableShowcasePidBase, SinglePartPid),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Solar Radial XL", "LgRadialSolarPanel", 8,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 89000000, SinglePartPid),
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, DeployableShowcasePidBase, SinglePartPid),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Solar OX-10C", "solarPanelOX10C", 9,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 89000000, SinglePartPid),
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, DeployableShowcasePidBase, SinglePartPid),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Solar OX-10L", "solarPanelOX10L", 10,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 89000000, SinglePartPid),
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, DeployableShowcasePidBase, SinglePartPid),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Solar 3x2 Shrouded", "solarPanels1", 11,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 89000000, SinglePartPid),
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, DeployableShowcasePidBase, SinglePartPid),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Solar 1x6 Shrouded", "solarPanels2", 12,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 89000000, SinglePartPid),
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, DeployableShowcasePidBase, SinglePartPid),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Solar 3x2", "solarPanels3", 13,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 89000000, SinglePartPid),
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, DeployableShowcasePidBase, SinglePartPid),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Solar Flat", "solarPanels5", 14,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 89000000, SinglePartPid),
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, DeployableShowcasePidBase, SinglePartPid),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Solar SP-10C", "solarPanelSP10C", 15,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 89000000, SinglePartPid),
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, DeployableShowcasePidBase, SinglePartPid),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Solar SP-10L", "solarPanelSP10L", 16,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 89000000, SinglePartPid),
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, DeployableShowcasePidBase, SinglePartPid),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Antenna Comm", "longAntenna", 17,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 89000000, SinglePartPid),
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, DeployableShowcasePidBase, SinglePartPid),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Antenna Dish", "commDish", 18,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 89000000, SinglePartPid),
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, DeployableShowcasePidBase, SinglePartPid),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Antenna High Gain", "HighGainAntenna", 19,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 89000000, SinglePartPid),
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, DeployableShowcasePidBase, SinglePartPid),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Antenna HG-5", "HighGainAntenna5", 20,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 89000000, SinglePartPid),
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, DeployableShowcasePidBase, SinglePartPid),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Antenna HG-5 v2", "HighGainAntenna5.v2", 21,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 89000000, SinglePartPid),
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, DeployableShowcasePidBase, SinglePartPid),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Antenna Medium Dish", "mediumDishAntenna", 22,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 89000000, SinglePartPid),
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, DeployableShowcasePidBase, SinglePartPid),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Radiator", "foldingRadSmall", 23,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 89000000, SinglePartPid)
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, DeployableShowcasePidBase, SinglePartPid)
             };
         }
 
@@ -1180,19 +1202,19 @@ namespace Parsek.Tests
             return new[]
             {
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Gear Bay", "SmallGearBay", 24,
-                    ShowcaseDistanceFromPadMeters, PartEventType.GearDeployed, PartEventType.GearRetracted, 90000000, SinglePartPid),
+                    ShowcaseDistanceFromPadMeters, PartEventType.GearDeployed, PartEventType.GearRetracted, GearShowcasePidBase, SinglePartPid),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Gear Small", "GearSmall", 25,
-                    ShowcaseDistanceFromPadMeters, PartEventType.GearDeployed, PartEventType.GearRetracted, 90000000, SinglePartPid),
+                    ShowcaseDistanceFromPadMeters, PartEventType.GearDeployed, PartEventType.GearRetracted, GearShowcasePidBase, SinglePartPid),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Gear Medium", "GearMedium", 26,
-                    ShowcaseDistanceFromPadMeters, PartEventType.GearDeployed, PartEventType.GearRetracted, 90000000, SinglePartPid),
+                    ShowcaseDistanceFromPadMeters, PartEventType.GearDeployed, PartEventType.GearRetracted, GearShowcasePidBase, SinglePartPid),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Gear Large", "GearLarge", 27,
-                    ShowcaseDistanceFromPadMeters, PartEventType.GearDeployed, PartEventType.GearRetracted, 90000000, SinglePartPid),
+                    ShowcaseDistanceFromPadMeters, PartEventType.GearDeployed, PartEventType.GearRetracted, GearShowcasePidBase, SinglePartPid),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Landing Leg LT-1", "landingLeg1", 28,
-                    ShowcaseDistanceFromPadMeters, PartEventType.GearDeployed, PartEventType.GearRetracted, 90000000, SinglePartPid),
+                    ShowcaseDistanceFromPadMeters, PartEventType.GearDeployed, PartEventType.GearRetracted, GearShowcasePidBase, SinglePartPid),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Landing Leg LT-2", "landingLeg1-2", 29,
-                    ShowcaseDistanceFromPadMeters, PartEventType.GearDeployed, PartEventType.GearRetracted, 90000000, SinglePartPid),
+                    ShowcaseDistanceFromPadMeters, PartEventType.GearDeployed, PartEventType.GearRetracted, GearShowcasePidBase, SinglePartPid),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Landing Leg LT-05", "miniLandingLeg", 30,
-                    ShowcaseDistanceFromPadMeters, PartEventType.GearDeployed, PartEventType.GearRetracted, 90000000, SinglePartPid)
+                    ShowcaseDistanceFromPadMeters, PartEventType.GearDeployed, PartEventType.GearRetracted, GearShowcasePidBase, SinglePartPid)
             };
         }
 
@@ -1201,33 +1223,33 @@ namespace Parsek.Tests
             return new[]
             {
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Service Bay", "ServiceBay.125.v2", 31,
-                    ShowcaseDistanceFromPadMeters, PartEventType.CargoBayOpened, PartEventType.CargoBayClosed, 91000000, SinglePartPid),
+                    ShowcaseDistanceFromPadMeters, PartEventType.CargoBayOpened, PartEventType.CargoBayClosed, CargoBayShowcasePidBase, SinglePartPid),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Service Bay 2.5", "ServiceBay.250.v2", 32,
-                    ShowcaseDistanceFromPadMeters, PartEventType.CargoBayOpened, PartEventType.CargoBayClosed, 91000000, SinglePartPid),
+                    ShowcaseDistanceFromPadMeters, PartEventType.CargoBayOpened, PartEventType.CargoBayClosed, CargoBayShowcasePidBase, SinglePartPid),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Service Module 1.8", "ServiceModule18", 33,
-                    ShowcaseDistanceFromPadMeters, PartEventType.CargoBayOpened, PartEventType.CargoBayClosed, 91000000, SinglePartPid),
+                    ShowcaseDistanceFromPadMeters, PartEventType.CargoBayOpened, PartEventType.CargoBayClosed, CargoBayShowcasePidBase, SinglePartPid),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Service Module 2.5", "ServiceModule25", 34,
-                    ShowcaseDistanceFromPadMeters, PartEventType.CargoBayOpened, PartEventType.CargoBayClosed, 91000000, SinglePartPid),
+                    ShowcaseDistanceFromPadMeters, PartEventType.CargoBayOpened, PartEventType.CargoBayClosed, CargoBayShowcasePidBase, SinglePartPid),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Service Module 1-0", "Size1to0ServiceModule", 35,
-                    ShowcaseDistanceFromPadMeters, PartEventType.CargoBayOpened, PartEventType.CargoBayClosed, 91000000, SinglePartPid),
+                    ShowcaseDistanceFromPadMeters, PartEventType.CargoBayOpened, PartEventType.CargoBayClosed, CargoBayShowcasePidBase, SinglePartPid),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Cargo Mk2", "mk2CargoBayS", 36,
-                    ShowcaseDistanceFromPadMeters, PartEventType.CargoBayOpened, PartEventType.CargoBayClosed, 91000000, SinglePartPid),
+                    ShowcaseDistanceFromPadMeters, PartEventType.CargoBayOpened, PartEventType.CargoBayClosed, CargoBayShowcasePidBase, SinglePartPid),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Cargo Mk2 Long", "mk2CargoBayL", 37,
-                    ShowcaseDistanceFromPadMeters, PartEventType.CargoBayOpened, PartEventType.CargoBayClosed, 91000000, SinglePartPid),
+                    ShowcaseDistanceFromPadMeters, PartEventType.CargoBayOpened, PartEventType.CargoBayClosed, CargoBayShowcasePidBase, SinglePartPid),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Cargo Mk3", "mk3CargoBayS", 38,
-                    ShowcaseDistanceFromPadMeters, PartEventType.CargoBayOpened, PartEventType.CargoBayClosed, 91000000, SinglePartPid),
+                    ShowcaseDistanceFromPadMeters, PartEventType.CargoBayOpened, PartEventType.CargoBayClosed, CargoBayShowcasePidBase, SinglePartPid),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Cargo Mk3 Medium", "mk3CargoBayM", 39,
-                    ShowcaseDistanceFromPadMeters, PartEventType.CargoBayOpened, PartEventType.CargoBayClosed, 91000000, SinglePartPid),
+                    ShowcaseDistanceFromPadMeters, PartEventType.CargoBayOpened, PartEventType.CargoBayClosed, CargoBayShowcasePidBase, SinglePartPid),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Cargo Mk3 Long", "mk3CargoBayL", 40,
-                    ShowcaseDistanceFromPadMeters, PartEventType.CargoBayOpened, PartEventType.CargoBayClosed, 91000000, SinglePartPid),
+                    ShowcaseDistanceFromPadMeters, PartEventType.CargoBayOpened, PartEventType.CargoBayClosed, CargoBayShowcasePidBase, SinglePartPid),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Cargo Mk3 Ramp", "mk3CargoRamp", 41,
-                    ShowcaseDistanceFromPadMeters, PartEventType.CargoBayOpened, PartEventType.CargoBayClosed, 91000000, SinglePartPid)
+                    ShowcaseDistanceFromPadMeters, PartEventType.CargoBayOpened, PartEventType.CargoBayClosed, CargoBayShowcasePidBase, SinglePartPid)
             };
         }
 
         internal static RecordingBuilder[] EngineShowcaseRecordings(double baseUT = 0)
         {
-            const uint pidBase = 99200000;
+            const uint pidBase = EngineShowcasePidBase;
             return new[]
             {
                 // ── Liquid engines with shroud jettison + flame (rows 191-210) ──
@@ -1295,9 +1317,9 @@ namespace Parsek.Tests
             return new[]
             {
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Ladder Telescopic", "telescopicLadder", 45,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 93000000, SinglePartPid),
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, LadderShowcasePidBase, SinglePartPid),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Ladder Bay", "telescopicLadderBay", 46,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 93000000, SinglePartPid)
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, LadderShowcasePidBase, SinglePartPid)
             };
         }
 
@@ -1306,23 +1328,23 @@ namespace Parsek.Tests
             return new[]
             {
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - RCS RV-105", "RCSBlock.v2", 47,
-                    ShowcaseDistanceFromPadMeters, PartEventType.RCSActivated, PartEventType.RCSStopped, 94000000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.RCSActivated, PartEventType.RCSStopped, RcsShowcasePidBase, SinglePartPid,
                     eventValue: 1.0f, moduleIndex: 0,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - RCS RV-1X", "RCSblock.01.small", 48,
-                    ShowcaseDistanceFromPadMeters, PartEventType.RCSActivated, PartEventType.RCSStopped, 94000000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.RCSActivated, PartEventType.RCSStopped, RcsShowcasePidBase, SinglePartPid,
                     eventValue: 1.0f, moduleIndex: 0,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - RCS Linear", "RCSLinearSmall", 49,
-                    ShowcaseDistanceFromPadMeters, PartEventType.RCSActivated, PartEventType.RCSStopped, 94000000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.RCSActivated, PartEventType.RCSStopped, RcsShowcasePidBase, SinglePartPid,
                     eventValue: 1.0f, moduleIndex: 0,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - RCS Linear Port", "linearRcs", 189,
-                    ShowcaseDistanceFromPadMeters, PartEventType.RCSActivated, PartEventType.RCSStopped, 94000000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.RCSActivated, PartEventType.RCSStopped, RcsShowcasePidBase, SinglePartPid,
                     eventValue: 1.0f, moduleIndex: 0,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - RCS Vernor", "vernierEngine", 190,
-                    ShowcaseDistanceFromPadMeters, PartEventType.RCSActivated, PartEventType.RCSStopped, 94000000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.RCSActivated, PartEventType.RCSStopped, RcsShowcasePidBase, SinglePartPid,
                     eventValue: 1.0f, moduleIndex: 0,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5)
             };
@@ -1356,19 +1378,19 @@ namespace Parsek.Tests
             return new[]
             {
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Fairing Size 1", "fairingSize1", 50,
-                    ShowcaseDistanceFromPadMeters, PartEventType.FairingJettisoned, PartEventType.FairingJettisoned, 95000000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.FairingJettisoned, PartEventType.FairingJettisoned, FairingShowcasePidBase, SinglePartPid,
                     configureGhostPartNode: part => AddProceduralFairingModule(part, baseRadius: 0.625f, topHeight: 2.0f)),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Fairing Size 1.5", "fairingSize1p5", 51,
-                    ShowcaseDistanceFromPadMeters, PartEventType.FairingJettisoned, PartEventType.FairingJettisoned, 95000000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.FairingJettisoned, PartEventType.FairingJettisoned, FairingShowcasePidBase, SinglePartPid,
                     configureGhostPartNode: part => AddProceduralFairingModule(part, baseRadius: 0.9375f, topHeight: 2.8f)),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Fairing Size 2", "fairingSize2", 52,
-                    ShowcaseDistanceFromPadMeters, PartEventType.FairingJettisoned, PartEventType.FairingJettisoned, 95000000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.FairingJettisoned, PartEventType.FairingJettisoned, FairingShowcasePidBase, SinglePartPid,
                     configureGhostPartNode: part => AddProceduralFairingModule(part, baseRadius: 1.25f, topHeight: 3.2f)),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Fairing Size 3", "fairingSize3", 53,
-                    ShowcaseDistanceFromPadMeters, PartEventType.FairingJettisoned, PartEventType.FairingJettisoned, 95000000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.FairingJettisoned, PartEventType.FairingJettisoned, FairingShowcasePidBase, SinglePartPid,
                     configureGhostPartNode: part => AddProceduralFairingModule(part, baseRadius: 1.875f, topHeight: 4.5f)),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Fairing Size 4", "fairingSize4", 54,
-                    ShowcaseDistanceFromPadMeters, PartEventType.FairingJettisoned, PartEventType.FairingJettisoned, 95000000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.FairingJettisoned, PartEventType.FairingJettisoned, FairingShowcasePidBase, SinglePartPid,
                     configureGhostPartNode: part => AddProceduralFairingModule(part, baseRadius: 2.5f, topHeight: 6.0f))
             };
         }
@@ -1378,9 +1400,9 @@ namespace Parsek.Tests
             return new[]
             {
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Radiator Medium", "foldingRadMed", 55,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 96000000, SinglePartPid),
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, RadiatorShowcasePidBase, SinglePartPid),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Radiator Large", "foldingRadLarge", 56,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 96000000, SinglePartPid)
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, RadiatorShowcasePidBase, SinglePartPid)
             };
         }
 
@@ -1389,10 +1411,10 @@ namespace Parsek.Tests
             return new[]
             {
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Drill Junior", "MiniDrill", 57,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 97000000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, DrillShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Drill-O-Matic", "RadialDrill", 58,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 97000000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, DrillShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5)
             };
         }
@@ -1402,28 +1424,28 @@ namespace Parsek.Tests
             return new[]
             {
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Deployed Central Station", "DeployedCentralStation", 59,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98000000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, DeployedScienceShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Deployed Goo Observation", "DeployedGoExOb", 60,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98000000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, DeployedScienceShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Deployed Ion Collector", "DeployedIONExp", 61,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98000000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, DeployedScienceShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Deployed RTG", "DeployedRTG", 62,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98000000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, DeployedScienceShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Deployed Sat Dish", "DeployedSatDish", 63,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98000000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, DeployedScienceShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Deployed Seismic Sensor", "DeployedSeismicSensor", 64,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98000000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, DeployedScienceShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Deployed Solar Panel", "DeployedSolarPanel", 65,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98000000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, DeployedScienceShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Deployed Weather Station", "DeployedWeatherStn", 66,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98000000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, DeployedScienceShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5)
             };
         }
@@ -1433,10 +1455,10 @@ namespace Parsek.Tests
             return new[]
             {
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Ground Anchor", "groundAnchor", 67,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98200000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, AnimationGroupShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Survey Scanner", "SurveyScanner", 68,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98200000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, AnimationGroupShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5)
             };
         }
@@ -1446,27 +1468,20 @@ namespace Parsek.Tests
             // 3-phase cycle: semi-deployed (streamer) → deployed (dome) → cut → repeat
             return new[]
             {
-                BuildParachuteShowcaseRecording(baseUT, "Part Showcase - Parachute Mk16", "parachuteSingle", 69, 98300000),
-                BuildParachuteShowcaseRecording(baseUT, "Part Showcase - Parachute Mk2-R", "parachuteRadial", 70, 98300000),
-                BuildParachuteShowcaseRecording(baseUT, "Part Showcase - Drogue Mk25", "parachuteDrogue", 71, 98300000),
-                BuildParachuteShowcaseRecording(baseUT, "Part Showcase - Drogue Mk12-R", "radialDrogue", 72, 98300000),
-                BuildParachuteShowcaseRecording(baseUT, "Part Showcase - Parachute Mk16-XL", "parachuteLarge", 73, 98300000)
+                BuildParachuteShowcaseRecording(baseUT, "Part Showcase - Parachute Mk16", "parachuteSingle", 69, ParachuteShowcasePidBase),
+                BuildParachuteShowcaseRecording(baseUT, "Part Showcase - Parachute Mk2-R", "parachuteRadial", 70, ParachuteShowcasePidBase),
+                BuildParachuteShowcaseRecording(baseUT, "Part Showcase - Drogue Mk25", "parachuteDrogue", 71, ParachuteShowcasePidBase),
+                BuildParachuteShowcaseRecording(baseUT, "Part Showcase - Drogue Mk12-R", "radialDrogue", 72, ParachuteShowcasePidBase),
+                BuildParachuteShowcaseRecording(baseUT, "Part Showcase - Parachute Mk16-XL", "parachuteLarge", 73, ParachuteShowcasePidBase)
             };
         }
 
         private static RecordingBuilder BuildParachuteShowcaseRecording(
             double baseUT, string vesselName, string partName, int rowIndex, uint pidBase)
         {
-            const double metersPerDegree = (2.0 * Math.PI * 600000.0) / 360.0;
-            const double spacingMeters = 5.0;
-
             double t = baseUT + 30;
-            double baseLat = -0.0972;
-            double baseLon = -74.5575;
-            double rowCenterOffsetMeters = -((ShowcaseRowCount - 1) * spacingMeters * 0.5);
-            double lat = baseLat + ((rowIndex * spacingMeters + rowCenterOffsetMeters) / metersPerDegree);
-            double lon = baseLon + ((ShowcaseDistanceFromPadMeters) / metersPerDegree);
-            double alt = 66.0;
+            ShowcasePosition(rowIndex, ShowcaseDistanceFromPadMeters, out double lat, out double lon, out double alt);
+            alt += ShowcaseAltitudeOffset(partName);
 
             var b = new RecordingBuilder(vesselName)
                 .WithDefaultRotation(KscRotX, KscRotY, KscRotZ, KscRotW)
@@ -1504,38 +1519,38 @@ namespace Parsek.Tests
             return new[]
             {
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Rover Wheel M1-F", "roverWheelM1-F", 74,
-                    ShowcaseDistanceFromPadMeters, PartEventType.GearDeployed, PartEventType.GearRetracted, 98400000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.GearDeployed, PartEventType.GearRetracted, SpecialDeployShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Goo Experiment", "GooExperiment", 75,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98400000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, SpecialDeployShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Science Jr", "science_module", 76,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98400000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, SpecialDeployShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Magnetometer Boom", "Magnetometer", 77,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98400000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, SpecialDeployShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildInflatableHeatShieldShowcaseRecording(baseUT, 78, ShowcaseDistanceFromPadMeters),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Inflatable Airlock", "InflatableAirlock", 79,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98400000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, SpecialDeployShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Docking Port Shielded", "dockingPort1", 80,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98400000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, SpecialDeployShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Docking Port Inline", "dockingPortLateral", 81,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98400000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, SpecialDeployShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Grappling Device", "GrapplingDevice", 82,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98400000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, SpecialDeployShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Small Claw", "smallClaw", 83,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98400000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, SpecialDeployShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Mk2 Docking Port", "mk2DockingPort", 84,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98400000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, SpecialDeployShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Mk2 Lander Cabin", "mk2LanderCabin_v2", 85,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98400000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, SpecialDeployShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5)
             };
         }
@@ -1545,67 +1560,67 @@ namespace Parsek.Tests
             return new[]
             {
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Robotics Hinge G-11", "hinge.01", 117,
-                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, 98600000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, RoboticsShowcasePidBase, SinglePartPid,
                     eventValue: 45f, firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Robotics Hinge G-00", "hinge.01.s", 118,
-                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, 98600000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, RoboticsShowcasePidBase, SinglePartPid,
                     eventValue: 45f, firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Robotics Hinge M-12", "hinge.03", 119,
-                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, 98600000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, RoboticsShowcasePidBase, SinglePartPid,
                     eventValue: 45f, firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Robotics Hinge M-06", "hinge.03.s", 120,
-                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, 98600000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, RoboticsShowcasePidBase, SinglePartPid,
                     eventValue: 45f, firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Robotics Hinge XL", "hinge.04", 121,
-                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, 98600000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, RoboticsShowcasePidBase, SinglePartPid,
                     eventValue: 45f, firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Robotics Piston 3P6", "piston.01", 122,
-                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, 98600000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, RoboticsShowcasePidBase, SinglePartPid,
                     eventValue: 0.3f, firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Robotics Piston 1P2", "piston.02", 123,
-                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, 98600000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, RoboticsShowcasePidBase, SinglePartPid,
                     eventValue: 0.2f, firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Robotics Piston 1P4", "piston.03", 124,
-                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, 98600000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, RoboticsShowcasePidBase, SinglePartPid,
                     eventValue: 0.4f, firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Robotics Piston 3P12", "piston.04", 125,
-                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, 98600000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, RoboticsShowcasePidBase, SinglePartPid,
                     eventValue: 0.9f, firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Robotics Rotation Servo M-06", "rotoServo.00", 126,
-                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, 98600000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, RoboticsShowcasePidBase, SinglePartPid,
                     eventValue: 90f, firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Robotics Rotation Servo M-12", "rotoServo.02", 127,
-                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, 98600000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, RoboticsShowcasePidBase, SinglePartPid,
                     eventValue: 90f, firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Robotics Rotation Servo F-12", "rotoServo.03", 128,
-                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, 98600000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, RoboticsShowcasePidBase, SinglePartPid,
                     eventValue: 90f, firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Robotics Rotation Servo F-33", "rotoServo.04", 129,
-                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, 98600000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, RoboticsShowcasePidBase, SinglePartPid,
                     eventValue: 90f, firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Robotics Rotor EM-16", "rotor.01", 130,
-                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, 98600000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, RoboticsShowcasePidBase, SinglePartPid,
                     eventValue: 240f, firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Robotics Rotor EM-16S", "rotor.01s", 131,
-                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, 98600000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, RoboticsShowcasePidBase, SinglePartPid,
                     eventValue: 240f, firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Robotics Rotor EM-32", "rotor.02", 132,
-                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, 98600000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, RoboticsShowcasePidBase, SinglePartPid,
                     eventValue: 240f, firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Robotics Rotor EM-32S", "rotor.02s", 133,
-                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, 98600000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, RoboticsShowcasePidBase, SinglePartPid,
                     eventValue: 240f, firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Robotics Rotor EM-64", "rotor.03", 134,
-                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, 98600000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, RoboticsShowcasePidBase, SinglePartPid,
                     eventValue: 240f, firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Robotics Rotor EM-64S", "rotor.03s", 135,
-                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, 98600000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, RoboticsShowcasePidBase, SinglePartPid,
                     eventValue: 240f, firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Robotics Rotor Motor R121", "RotorEngine.02", 136,
-                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, 98600000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, RoboticsShowcasePidBase, SinglePartPid,
                     eventValue: 240f, firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Robotics Rotor Motor R7000", "RotorEngine.03", 137,
-                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, 98600000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, RoboticsShowcasePidBase, SinglePartPid,
                     eventValue: 240f, firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5)
             };
         }
@@ -1615,7 +1630,7 @@ namespace Parsek.Tests
             return new[]
             {
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Airbrake", "airbrake1", 138,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98700000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, AeroSurfaceShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5)
             };
         }
@@ -1625,13 +1640,13 @@ namespace Parsek.Tests
             return new[]
             {
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Robot Arm Scanner S1", "RobotArmScanner_S1", 139,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98800000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, RobotArmScannerShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Robot Arm Scanner S2", "RobotArmScanner_S2", 140,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98800000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, RobotArmScannerShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Robot Arm Scanner S3", "RobotArmScanner_S3", 141,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98800000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, RobotArmScannerShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5)
             };
         }
@@ -1641,76 +1656,76 @@ namespace Parsek.Tests
             return new[]
             {
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Control Surface Advanced Canard", "AdvancedCanard", 142,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98900000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, ControlSurfaceShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Control Surface Airliner", "airlinerCtrlSrf", 143,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98900000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, ControlSurfaceShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Control Surface Airliner Tail", "airlinerTailFin", 144,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98900000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, ControlSurfaceShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Control Surface Canard", "CanardController", 145,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98900000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, ControlSurfaceShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Control Surface Elevon 2", "elevon2", 146,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98900000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, ControlSurfaceShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Control Surface Elevon 3", "elevon3", 147,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98900000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, ControlSurfaceShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Control Surface Elevon 5", "elevon5", 148,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98900000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, ControlSurfaceShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Control Surface Large Fan Blade", "largeFanBlade", 149,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98900000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, ControlSurfaceShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Control Surface Large Heli Blade", "largeHeliBlade", 150,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98900000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, ControlSurfaceShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Control Surface Large Propeller", "largePropeller", 151,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98900000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, ControlSurfaceShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Control Surface Medium Fan Blade", "mediumFanBlade", 152,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98900000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, ControlSurfaceShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Control Surface Medium Heli Blade", "mediumHeliBlade", 153,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98900000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, ControlSurfaceShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Control Surface Medium Propeller", "mediumPropeller", 154,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98900000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, ControlSurfaceShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Control Surface R8 Winglet", "R8winglet", 155,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98900000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, ControlSurfaceShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Control Surface Small", "smallCtrlSrf", 156,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98900000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, ControlSurfaceShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Control Surface Small Fan Blade", "smallFanBlade", 157,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98900000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, ControlSurfaceShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Control Surface Small Heli Blade", "smallHeliBlade", 158,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98900000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, ControlSurfaceShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Control Surface Small Propeller", "smallPropeller", 159,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98900000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, ControlSurfaceShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Control Surface Standard", "StandardCtrlSrf", 160,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98900000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, ControlSurfaceShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Control Surface Tailfin", "tailfin", 161,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98900000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, ControlSurfaceShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Control Surface Winglet", "winglet3", 162,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98900000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, ControlSurfaceShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Control Surface Shuttle Elevon 1", "wingShuttleElevon1", 163,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98900000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, ControlSurfaceShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Control Surface Shuttle Elevon 2", "wingShuttleElevon2", 164,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98900000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, ControlSurfaceShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Control Surface Shuttle Rudder", "wingShuttleRudder", 165,
-                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, 98900000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.DeployableExtended, PartEventType.DeployableRetracted, ControlSurfaceShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5)
             };
         }
@@ -1720,27 +1735,27 @@ namespace Parsek.Tests
             return new[]
             {
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Wheel Dynamics Gear Fixed", "GearFixed", 166,
-                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, 99000000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, WheelDynamicsShowcasePidBase, SinglePartPid,
                     eventValue: 0.08f, moduleIndex: 0,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Wheel Dynamics Gear Free", "GearFree", 167,
-                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, 99000000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, WheelDynamicsShowcasePidBase, SinglePartPid,
                     eventValue: 24f, moduleIndex: 1,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Wheel Dynamics Rover M1", "roverWheel1", 168,
-                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, 99000000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, WheelDynamicsShowcasePidBase, SinglePartPid,
                     eventValue: 180f, moduleIndex: 2,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Wheel Dynamics Rover S2", "roverWheel2", 169,
-                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, 99000000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, WheelDynamicsShowcasePidBase, SinglePartPid,
                     eventValue: 180f, moduleIndex: 2,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Wheel Dynamics Rover XL3", "roverWheel3", 170,
-                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, 99000000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, WheelDynamicsShowcasePidBase, SinglePartPid,
                     eventValue: 120f, moduleIndex: 1,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Wheel Dynamics TR-2L", "wheelMed", 171,
-                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, 99000000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.RoboticMotionStarted, PartEventType.RoboticMotionStopped, WheelDynamicsShowcasePidBase, SinglePartPid,
                     eventValue: 180f, moduleIndex: 2,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5)
             };
@@ -1751,43 +1766,43 @@ namespace Parsek.Tests
             return new[]
             {
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - AnimateHeat Airplane Tail", "airplaneTail", 172,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ThermalAnimationHot, PartEventType.ThermalAnimationCold, 99100000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.ThermalAnimationHot, PartEventType.ThermalAnimationCold, AnimateHeatShowcasePidBase, SinglePartPid,
                     eventValue: 1f, firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - AnimateHeat Airplane Tail B", "airplaneTailB", 173,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ThermalAnimationHot, PartEventType.ThermalAnimationCold, 99100000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.ThermalAnimationHot, PartEventType.ThermalAnimationCold, AnimateHeatShowcasePidBase, SinglePartPid,
                     eventValue: 1f, firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - AnimateHeat Avionics Nose Cone", "avionicsNoseCone", 174,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ThermalAnimationHot, PartEventType.ThermalAnimationCold, 99100000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.ThermalAnimationHot, PartEventType.ThermalAnimationCold, AnimateHeatShowcasePidBase, SinglePartPid,
                     eventValue: 1f, firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - AnimateHeat Circular Intake", "CircularIntake", 175,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ThermalAnimationHot, PartEventType.ThermalAnimationCold, 99100000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.ThermalAnimationHot, PartEventType.ThermalAnimationCold, AnimateHeatShowcasePidBase, SinglePartPid,
                     eventValue: 1f, firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - AnimateHeat Mk1 Intake Fuselage", "MK1IntakeFuselage", 176,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ThermalAnimationHot, PartEventType.ThermalAnimationCold, 99100000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.ThermalAnimationHot, PartEventType.ThermalAnimationCold, AnimateHeatShowcasePidBase, SinglePartPid,
                     eventValue: 1f, firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - AnimateHeat Nacelle Body", "nacelleBody", 177,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ThermalAnimationHot, PartEventType.ThermalAnimationCold, 99100000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.ThermalAnimationHot, PartEventType.ThermalAnimationCold, AnimateHeatShowcasePidBase, SinglePartPid,
                     eventValue: 1f, firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - AnimateHeat Nose Cone Adapter", "noseConeAdapter", 178,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ThermalAnimationHot, PartEventType.ThermalAnimationCold, 99100000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.ThermalAnimationHot, PartEventType.ThermalAnimationCold, AnimateHeatShowcasePidBase, SinglePartPid,
                     eventValue: 1f, firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - AnimateHeat Pointy Nose Cone A", "pointyNoseConeA", 179,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ThermalAnimationHot, PartEventType.ThermalAnimationCold, 99100000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.ThermalAnimationHot, PartEventType.ThermalAnimationCold, AnimateHeatShowcasePidBase, SinglePartPid,
                     eventValue: 1f, firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - AnimateHeat Pointy Nose Cone B", "pointyNoseConeB", 180,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ThermalAnimationHot, PartEventType.ThermalAnimationCold, 99100000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.ThermalAnimationHot, PartEventType.ThermalAnimationCold, AnimateHeatShowcasePidBase, SinglePartPid,
                     eventValue: 1f, firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - AnimateHeat Radial Engine Body", "radialEngineBody", 181,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ThermalAnimationHot, PartEventType.ThermalAnimationCold, 99100000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.ThermalAnimationHot, PartEventType.ThermalAnimationCold, AnimateHeatShowcasePidBase, SinglePartPid,
                     eventValue: 1f, firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - AnimateHeat Ram Air Intake", "ramAirIntake", 182,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ThermalAnimationHot, PartEventType.ThermalAnimationCold, 99100000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.ThermalAnimationHot, PartEventType.ThermalAnimationCold, AnimateHeatShowcasePidBase, SinglePartPid,
                     eventValue: 1f, firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - AnimateHeat Shock Cone Intake", "shockConeIntake", 183,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ThermalAnimationHot, PartEventType.ThermalAnimationCold, 99100000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.ThermalAnimationHot, PartEventType.ThermalAnimationCold, AnimateHeatShowcasePidBase, SinglePartPid,
                     eventValue: 1f, firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - AnimateHeat Standard Nose Cone", "standardNoseCone", 184,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ThermalAnimationHot, PartEventType.ThermalAnimationCold, 99100000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.ThermalAnimationHot, PartEventType.ThermalAnimationCold, AnimateHeatShowcasePidBase, SinglePartPid,
                     eventValue: 1f, firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5)
             };
         }
@@ -1797,31 +1812,31 @@ namespace Parsek.Tests
             return new[]
             {
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Engine Plate 1.5", "EnginePlate1p5", 86,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ShroudJettisoned, PartEventType.ShroudJettisoned, 98500000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.ShroudJettisoned, PartEventType.ShroudJettisoned, JettisonShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 3.0),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Engine Plate 2", "EnginePlate2", 87,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ShroudJettisoned, PartEventType.ShroudJettisoned, 98500000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.ShroudJettisoned, PartEventType.ShroudJettisoned, JettisonShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 3.0),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Engine Plate 3", "EnginePlate3", 88,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ShroudJettisoned, PartEventType.ShroudJettisoned, 98500000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.ShroudJettisoned, PartEventType.ShroudJettisoned, JettisonShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 3.0),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Engine Plate 4", "EnginePlate4", 89,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ShroudJettisoned, PartEventType.ShroudJettisoned, 98500000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.ShroudJettisoned, PartEventType.ShroudJettisoned, JettisonShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 3.0),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Engine Plate 5", "EnginePlate5", 90,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ShroudJettisoned, PartEventType.ShroudJettisoned, 98500000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.ShroudJettisoned, PartEventType.ShroudJettisoned, JettisonShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 3.0),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Heat Shield 1", "HeatShield1", 91,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ShroudJettisoned, PartEventType.ShroudJettisoned, 98500000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.ShroudJettisoned, PartEventType.ShroudJettisoned, JettisonShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 3.0),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Heat Shield 2", "HeatShield2", 92,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ShroudJettisoned, PartEventType.ShroudJettisoned, 98500000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.ShroudJettisoned, PartEventType.ShroudJettisoned, JettisonShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 3.0),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Heat Shield 3", "HeatShield3", 93,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ShroudJettisoned, PartEventType.ShroudJettisoned, 98500000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.ShroudJettisoned, PartEventType.ShroudJettisoned, JettisonShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 3.0),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Heat Shield 1.5", "HeatShield1p5", 94,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ShroudJettisoned, PartEventType.ShroudJettisoned, 98500000, SinglePartPid,
+                    ShowcaseDistanceFromPadMeters, PartEventType.ShroudJettisoned, PartEventType.ShroudJettisoned, JettisonShowcasePidBase, SinglePartPid,
                     firstEventOffsetSeconds: 3.0)
             };
         }
@@ -1852,7 +1867,7 @@ namespace Parsek.Tests
 
             var snap = new VesselSnapshotBuilder()
                 .WithName("Part Showcase - Inventory Placement")
-                .WithPersistentId(98100000)
+                .WithPersistentId(InventoryPlacementPid)
                 .AddPart(partName, rotation: "0,-0.7071068,0,0.7071068")
                 .AddPart("kerbalEVA", position: "2.25,0,0", rotation: "0,0.7071068,0,0.7071068", parentIndex: 0)
                 .AsLanded(lat, lon, alt)
@@ -3966,12 +3981,15 @@ namespace Parsek.Tests
                 RobotArmScannerShowcaseRecordings(17000),
                 ControlSurfaceShowcaseRecordings(17000),
                 WheelDynamicsShowcaseRecordings(17000),
-                AnimateHeatShowcaseRecordings(17000)
+                AnimateHeatShowcaseRecordings(17000),
+                new[] { InventoryPlacementShowcaseRecording(17000) }
             };
 
             var positions = new HashSet<string>();
+            int expectedCount = 0;
             foreach (var category in allShowcases)
             {
+                expectedCount += category.Length;
                 foreach (var rb in category)
                 {
                     var rec = rb.Build();
@@ -3981,7 +3999,7 @@ namespace Parsek.Tests
                         $"Duplicate position in '{rec.GetValue("vesselName")}': {key}");
                 }
             }
-            Assert.Equal(211, positions.Count); // 10 + 18 + 7 + 11 + 45 + 2 + 5 + 5 + 2 + 2 + 8 + 2 + 5 + 12 + 9 + 21 + 1 + 3 + 24 + 6 + 13
+            Assert.Equal(expectedCount, positions.Count);
         }
 
         [Fact]

--- a/Source/Parsek.Tests/SyntheticRecordingTests.cs
+++ b/Source/Parsek.Tests/SyntheticRecordingTests.cs
@@ -572,17 +572,9 @@ namespace Parsek.Tests
             double rowOffsetMeters = 0.0,
             double distanceOffsetMeters = 0.0)
         {
-            const double metersPerDegree = (2.0 * Math.PI * 600000.0) / 360.0;
-            const double spacingMeters = 5.0;
-
             double t = baseUT + 30;
-            double baseLat = -0.0972;
-            double baseLon = -74.5575;
-            // Keep the row centered on the launchpad as we expand showcase coverage.
-            double rowCenterOffsetMeters = -((ShowcaseRowCount - 1) * spacingMeters * 0.5);
-            double lat = baseLat + ((rowIndex * spacingMeters + rowCenterOffsetMeters + rowOffsetMeters) / metersPerDegree);
-            double lon = baseLon + ((distanceFromPadMeters + distanceOffsetMeters) / metersPerDegree);
-            double alt = 66.0;
+            ShowcasePosition(rowIndex, distanceFromPadMeters, out double lat, out double lon, out double alt,
+                rowOffsetMeters, distanceOffsetMeters);
             if (onEvent == PartEventType.ShroudJettisoned && offEvent == PartEventType.ShroudJettisoned)
                 alt += ShroudShowcaseAltitudeOffsetMeters;
 
@@ -646,18 +638,11 @@ namespace Parsek.Tests
         private static RecordingBuilder BuildInflatableHeatShieldShowcaseRecording(
             double baseUT, int rowIndex, double distanceFromPadMeters)
         {
-            const double metersPerDegree = (2.0 * Math.PI * 600000.0) / 360.0;
-            const double spacingMeters = 5.0;
             const string partName = "InflatableHeatShield";
             const string vesselName = "Part Showcase - Inflatable Heat Shield";
 
             double t = baseUT + 30;
-            double baseLat = -0.0972;
-            double baseLon = -74.5575;
-            double rowCenterOffsetMeters = -((ShowcaseRowCount - 1) * spacingMeters * 0.5);
-            double lat = baseLat + ((rowIndex * spacingMeters + rowCenterOffsetMeters) / metersPerDegree);
-            double lon = baseLon + (distanceFromPadMeters / metersPerDegree);
-            double alt = 66.0;
+            ShowcasePosition(rowIndex, distanceFromPadMeters, out double lat, out double lon, out double alt);
 
             var b = new RecordingBuilder(vesselName)
                 .WithDefaultRotation(KscRotX, KscRotY, KscRotZ, KscRotW)
@@ -694,10 +679,34 @@ namespace Parsek.Tests
         // Optional companion part (e.g., kerbal actor) receives the second slot.
         // Total visible showcase row entries (indices 0-235, including inventory placement).
         private const int ShowcaseRowCount = 236;
+        // Split showcase into two parallel lines to avoid runway clipping.
+        private static readonly int ShowcaseEntriesPerLine = (ShowcaseRowCount + 1) / 2;
+        private const double ShowcaseLineSpacingMeters = 20.0;
         // Keep showcases close to the launchpad centerline without overlapping pad geometry.
         private const double ShowcaseDistanceFromPadMeters = 200.0;
         // Shroud-jettison showcase parts include tall engine plates and engines that clip at base altitude.
         private const double ShroudShowcaseAltitudeOffsetMeters = 12.0;
+
+        /// <summary>
+        /// Computes lat/lon/alt for a showcase row, splitting rows across two parallel lines.
+        /// Rows 0 to ShowcaseEntriesPerLine-1 are on the back line (200m from pad),
+        /// rows ShowcaseEntriesPerLine to ShowcaseRowCount-1 are on the front line (220m from pad).
+        /// </summary>
+        private static void ShowcasePosition(int rowIndex, double distanceFromPadMeters,
+            out double lat, out double lon, out double alt,
+            double rowOffsetMeters = 0.0, double distanceOffsetMeters = 0.0)
+        {
+            const double metersPerDegree = (2.0 * Math.PI * 600000.0) / 360.0;
+            const double spacingMeters = 5.0;
+
+            int lineIndex = rowIndex / ShowcaseEntriesPerLine;
+            int lineRowIndex = rowIndex % ShowcaseEntriesPerLine;
+
+            double rowCenterOffsetMeters = -((ShowcaseEntriesPerLine - 1) * spacingMeters * 0.5);
+            lat = -0.0972 + ((lineRowIndex * spacingMeters + rowCenterOffsetMeters + rowOffsetMeters) / metersPerDegree);
+            lon = -74.5575 + ((distanceFromPadMeters + lineIndex * ShowcaseLineSpacingMeters + distanceOffsetMeters) / metersPerDegree);
+            alt = 66.0;
+        }
 
         /// <summary>
         /// Builds a light showcase recording with an on → blink → off cycle that exercises
@@ -707,16 +716,8 @@ namespace Parsek.Tests
         private static RecordingBuilder BuildLightBlinkShowcaseRecording(
             double baseUT, string vesselName, string lightPartName, int rowIndex)
         {
-            const double metersPerDegree = (2.0 * Math.PI * 600000.0) / 360.0;
-            const double spacingMeters = 5.0;
-
             double t = baseUT + 30;
-            double baseLat = -0.0972;
-            double baseLon = -74.5575;
-            double rowCenterOffsetMeters = -((ShowcaseRowCount - 1) * spacingMeters * 0.5);
-            double lat = baseLat + ((rowIndex * spacingMeters + rowCenterOffsetMeters) / metersPerDegree);
-            double lon = baseLon + (ShowcaseDistanceFromPadMeters / metersPerDegree);
-            double alt = 66.0;
+            ShowcasePosition(rowIndex, ShowcaseDistanceFromPadMeters, out double lat, out double lon, out double alt);
 
             var b = new RecordingBuilder(vesselName)
                 .WithDefaultRotation(KscRotX, KscRotY, KscRotZ, KscRotW)
@@ -755,16 +756,8 @@ namespace Parsek.Tests
             double baseUT, string vesselName, string enginePartName, int rowIndex,
             uint pidBase)
         {
-            const double metersPerDegree = (2.0 * Math.PI * 600000.0) / 360.0;
-            const double spacingMeters = 5.0;
-
             double t = baseUT + 30;
-            double baseLat = -0.0972;
-            double baseLon = -74.5575;
-            double rowCenterOffsetMeters = -((ShowcaseRowCount - 1) * spacingMeters * 0.5);
-            double lat = baseLat + ((rowIndex * spacingMeters + rowCenterOffsetMeters) / metersPerDegree);
-            double lon = baseLon + (ShowcaseDistanceFromPadMeters / metersPerDegree);
-            double alt = 66.0;
+            ShowcasePosition(rowIndex, ShowcaseDistanceFromPadMeters, out double lat, out double lon, out double alt);
 
             var b = new RecordingBuilder(vesselName)
                 .WithDefaultRotation(KscRotX, KscRotY, KscRotZ, KscRotW)
@@ -802,16 +795,8 @@ namespace Parsek.Tests
             double baseUT, string vesselName, string srbPartName, int rowIndex,
             uint pidBase)
         {
-            const double metersPerDegree = (2.0 * Math.PI * 600000.0) / 360.0;
-            const double spacingMeters = 5.0;
-
             double t = baseUT + 30;
-            double baseLat = -0.0972;
-            double baseLon = -74.5575;
-            double rowCenterOffsetMeters = -((ShowcaseRowCount - 1) * spacingMeters * 0.5);
-            double lat = baseLat + ((rowIndex * spacingMeters + rowCenterOffsetMeters) / metersPerDegree);
-            double lon = baseLon + (ShowcaseDistanceFromPadMeters / metersPerDegree);
-            double alt = 66.0;
+            ShowcasePosition(rowIndex, ShowcaseDistanceFromPadMeters, out double lat, out double lon, out double alt);
 
             var b = new RecordingBuilder(vesselName)
                 .WithDefaultRotation(KscRotX, KscRotY, KscRotZ, KscRotW)
@@ -851,14 +836,16 @@ namespace Parsek.Tests
             };
         }
 
-        // Row indices continue from lights (0-5) so all showcases form one line.
-        // Lights: 0-5 + 185-188, Deployables: 6-23, Airplane Gear: 24-27, Landing Legs: 28-30,
-        // Cargo: 31-41, Engines: 42-44, Ladders: 45-46, RCS: 47-49 + 190-191, Fairings: 50-54,
-        // Extra Radiators: 55-56, Drills: 57-58, Deployed Science: 59-66,
-        // Animation Group: 67-68, Parachutes: 69-73, Special Deploy Animations: 74-85 and 115-116,
-        // Jettison Coverage: 86-114, Robotics: 117-137, AeroSurface: 138, Robot Arm Scanners: 139-141,
-        // Control Surfaces: 142-165, Wheel Dynamics: 166-171, AnimateHeat: 172-184,
-        // Gear Extra Large: 189, Engine Flames: 192-234, Inventory Placement: 235.
+        // Two parallel lines (rows 0-117 at 200m, rows 118-235 at 220m from pad):
+        // Back line — Lights: 0-5, Deployables: 6-23, Airplane Gear: 24-27, Landing Legs: 28-30,
+        //   Cargo: 31-41, Engines: 42-44, Ladders: 45-46, RCS: 47-49, Fairings: 50-54,
+        //   Extra Radiators: 55-56, Drills: 57-58, Deployed Science: 59-66,
+        //   Animation Group: 67-68, Parachutes: 69-73, Special Deploy Animations: 74-85 and 115-116,
+        //   Jettison Coverage: 86-114, Robotics: 117 (partial)
+        // Front line — Robotics: 118-137, AeroSurface: 138, Robot Arm Scanners: 139-141,
+        //   Control Surfaces: 142-165, Wheel Dynamics: 166-171, AnimateHeat: 172-184,
+        //   Lights (extra): 185-188, Gear Extra Large: 189, RCS (extra): 190-191,
+        //   Engine Flames: 192-234, Inventory Placement: 235.
 
         internal static RecordingBuilder[] DeployableShowcaseRecordings(double baseUT = 0)
         {
@@ -1588,18 +1575,9 @@ namespace Parsek.Tests
 
         internal static RecordingBuilder InventoryPlacementShowcaseRecording(double baseUT = 0)
         {
-            const double metersPerDegree = (2.0 * Math.PI * 600000.0) / 360.0;
-            const double spacingMeters = 5.0;
-
-            // Keep inventory placement inside the same centered showcase line.
             const int rowIndex = ShowcaseRowCount - 1;
             double t = baseUT + 30;
-            double baseLat = -0.0972;
-            double baseLon = -74.5575;
-            double rowCenterOffsetMeters = -((ShowcaseRowCount - 1) * spacingMeters * 0.5);
-            double lat = baseLat + ((rowIndex * spacingMeters + rowCenterOffsetMeters) / metersPerDegree);
-            double lon = baseLon + (ShowcaseDistanceFromPadMeters / metersPerDegree);
-            double alt = 66.0;
+            ShowcasePosition(rowIndex, ShowcaseDistanceFromPadMeters, out double lat, out double lon, out double alt);
 
             const string partName = "DeployedWeatherStn";
             var b = new RecordingBuilder("Part Showcase - Inventory Placement")

--- a/Source/Parsek.Tests/SyntheticRecordingTests.cs
+++ b/Source/Parsek.Tests/SyntheticRecordingTests.cs
@@ -1866,6 +1866,76 @@ namespace Parsek.Tests
 
         #region Unit Tests
 
+        private const string ShowcasePrimaryRotation = "0,-0.7071068,0,0.7071068";
+
+        private static double ParseInvariantDouble(string value)
+        {
+            return double.Parse(value, CultureInfo.InvariantCulture);
+        }
+
+        private static float ParseInvariantFloat(string value)
+        {
+            return float.Parse(value, CultureInfo.InvariantCulture);
+        }
+
+        private static void AssertFloatClose(float expected, float actual, float tolerance = 0.0001f)
+        {
+            Assert.True(
+                Math.Abs(expected - actual) <= tolerance,
+                $"Expected {expected.ToString("R", CultureInfo.InvariantCulture)} but got {actual.ToString("R", CultureInfo.InvariantCulture)}");
+        }
+
+        private static void AssertEventTargetsPrimaryPart(ConfigNode eventNode, ConfigNode primaryPart)
+        {
+            Assert.Equal(primaryPart.GetValue("persistentId"), eventNode.GetValue("pid"));
+            Assert.Equal(primaryPart.GetValue("name"), eventNode.GetValue("part"));
+        }
+
+        private static void AssertAlternatingPartEvents(
+            ConfigNode recording,
+            PartEventType onEvent,
+            PartEventType offEvent,
+            double firstEventOffsetSeconds,
+            double onDurationSeconds,
+            double offDurationSeconds,
+            float expectedOnValue,
+            int expectedModuleIndex = 0,
+            int expectedEventCount = 8)
+        {
+            ConfigNode[] events = recording.GetNodes("PART_EVENT");
+            Assert.Equal(expectedEventCount, events.Length);
+
+            ConfigNode ghost = recording.GetNode("GHOST_VISUAL_SNAPSHOT");
+            Assert.NotNull(ghost);
+            ConfigNode[] parts = ghost.GetNodes("PART");
+            Assert.True(parts.Length >= 1, $"Missing ghost PART for {recording.GetValue("vesselName")}");
+            ConfigNode primaryPart = parts[0];
+
+            double baseUt = ParseInvariantDouble(events[0].GetValue("ut")) - firstEventOffsetSeconds;
+            double expectedOffset = firstEventOffsetSeconds;
+            for (int i = 0; i < events.Length; i++)
+            {
+                bool onPhase = (i % 2) == 0;
+                ConfigNode evt = events[i];
+
+                Assert.Equal(
+                    ((int)(onPhase ? onEvent : offEvent)).ToString(CultureInfo.InvariantCulture),
+                    evt.GetValue("type"));
+                AssertEventTargetsPrimaryPart(evt, primaryPart);
+                Assert.Equal(expectedModuleIndex.ToString(CultureInfo.InvariantCulture), evt.GetValue("midx"));
+
+                float expectedValue = onPhase ? expectedOnValue : 0f;
+                float actualValue = ParseInvariantFloat(evt.GetValue("value"));
+                AssertFloatClose(expectedValue, actualValue);
+
+                double expectedUt = baseUt + expectedOffset;
+                double actualUt = ParseInvariantDouble(evt.GetValue("ut"));
+                Assert.Equal(expectedUt, actualUt, 6);
+
+                expectedOffset += onPhase ? onDurationSeconds : offDurationSeconds;
+            }
+        }
+
         [Fact]
         public void PadWalk_HasEvaGhostSnapshot()
         {
@@ -3213,6 +3283,610 @@ namespace Parsek.Tests
             Assert.Equal("DeployedWeatherStn", parts[0].GetValue("name"));
             Assert.Equal("kerbalEVA", parts[1].GetValue("name"));
             Assert.Equal(parts[0].GetValue("persistentId"), events[0].GetValue("pid"));
+        }
+
+        [Fact]
+        public void ShowcaseRecordings_PrimaryPartRotationIsConsistent()
+        {
+            var allShowcases = new[]
+            {
+                LightShowcaseRecordings(17000),
+                DeployableShowcaseRecordings(17000),
+                GearShowcaseRecordings(17000),
+                CargoBayShowcaseRecordings(17000),
+                EngineShowcaseRecordings(17000),
+                LadderShowcaseRecordings(17000),
+                RcsShowcaseRecordings(17000),
+                FairingShowcaseRecordings(17000),
+                RadiatorShowcaseRecordings(17000),
+                DrillShowcaseRecordings(17000),
+                DeployedScienceShowcaseRecordings(17000),
+                AnimationGroupShowcaseRecordings(17000),
+                ParachuteShowcaseRecordings(17000),
+                SpecialDeployAnimationShowcaseRecordings(17000),
+                JettisonShowcaseRecordings(17000),
+                RoboticsShowcaseRecordings(17000),
+                AeroSurfaceShowcaseRecordings(17000),
+                RobotArmScannerShowcaseRecordings(17000),
+                ControlSurfaceShowcaseRecordings(17000),
+                WheelDynamicsShowcaseRecordings(17000),
+                AnimateHeatShowcaseRecordings(17000),
+                new[] { InventoryPlacementShowcaseRecording(17000) }
+            };
+
+            foreach (var category in allShowcases)
+            {
+                foreach (var rb in category)
+                {
+                    var rec = rb.Build();
+                    var ghost = rec.GetNode("GHOST_VISUAL_SNAPSHOT");
+                    Assert.NotNull(ghost);
+                    var primaryPart = ghost.GetNodes("PART")[0];
+                    Assert.Equal(ShowcasePrimaryRotation, primaryPart.GetValue("rotation"));
+                }
+            }
+        }
+
+        [Fact]
+        public void ShowcaseToggleRecordings_DefaultCadenceCategoriesUseExpectedStateMachine()
+        {
+            var categories = new[]
+            {
+                new
+                {
+                    Recordings = DeployableShowcaseRecordings(17000),
+                    OnEvent = PartEventType.DeployableExtended,
+                    OffEvent = PartEventType.DeployableRetracted
+                },
+                new
+                {
+                    Recordings = GearShowcaseRecordings(17000),
+                    OnEvent = PartEventType.GearDeployed,
+                    OffEvent = PartEventType.GearRetracted
+                },
+                new
+                {
+                    Recordings = CargoBayShowcaseRecordings(17000),
+                    OnEvent = PartEventType.CargoBayOpened,
+                    OffEvent = PartEventType.CargoBayClosed
+                },
+                new
+                {
+                    Recordings = LadderShowcaseRecordings(17000),
+                    OnEvent = PartEventType.DeployableExtended,
+                    OffEvent = PartEventType.DeployableRetracted
+                },
+                new
+                {
+                    Recordings = RadiatorShowcaseRecordings(17000),
+                    OnEvent = PartEventType.DeployableExtended,
+                    OffEvent = PartEventType.DeployableRetracted
+                }
+            };
+
+            foreach (var category in categories)
+            {
+                foreach (var rb in category.Recordings)
+                {
+                    AssertAlternatingPartEvents(
+                        rb.Build(),
+                        category.OnEvent,
+                        category.OffEvent,
+                        firstEventOffsetSeconds: 3.0,
+                        onDurationSeconds: 3.0,
+                        offDurationSeconds: 3.0,
+                        expectedOnValue: 0f);
+                }
+            }
+        }
+
+        [Fact]
+        public void ShowcaseToggleRecordings_FastCadenceCategoriesUseExpectedStateMachine()
+        {
+            var categories = new[]
+            {
+                new
+                {
+                    Recordings = RcsShowcaseRecordings(17000),
+                    OnEvent = PartEventType.RCSActivated,
+                    OffEvent = PartEventType.RCSStopped,
+                    OnValue = 1.0f
+                },
+                new
+                {
+                    Recordings = DrillShowcaseRecordings(17000),
+                    OnEvent = PartEventType.DeployableExtended,
+                    OffEvent = PartEventType.DeployableRetracted,
+                    OnValue = 0f
+                },
+                new
+                {
+                    Recordings = DeployedScienceShowcaseRecordings(17000),
+                    OnEvent = PartEventType.DeployableExtended,
+                    OffEvent = PartEventType.DeployableRetracted,
+                    OnValue = 0f
+                },
+                new
+                {
+                    Recordings = AnimationGroupShowcaseRecordings(17000),
+                    OnEvent = PartEventType.DeployableExtended,
+                    OffEvent = PartEventType.DeployableRetracted,
+                    OnValue = 0f
+                },
+                new
+                {
+                    Recordings = AeroSurfaceShowcaseRecordings(17000),
+                    OnEvent = PartEventType.DeployableExtended,
+                    OffEvent = PartEventType.DeployableRetracted,
+                    OnValue = 0f
+                },
+                new
+                {
+                    Recordings = RobotArmScannerShowcaseRecordings(17000),
+                    OnEvent = PartEventType.DeployableExtended,
+                    OffEvent = PartEventType.DeployableRetracted,
+                    OnValue = 0f
+                },
+                new
+                {
+                    Recordings = ControlSurfaceShowcaseRecordings(17000),
+                    OnEvent = PartEventType.DeployableExtended,
+                    OffEvent = PartEventType.DeployableRetracted,
+                    OnValue = 0f
+                },
+                new
+                {
+                    Recordings = AnimateHeatShowcaseRecordings(17000),
+                    OnEvent = PartEventType.ThermalAnimationHot,
+                    OffEvent = PartEventType.ThermalAnimationCold,
+                    OnValue = 1.0f
+                }
+            };
+
+            foreach (var category in categories)
+            {
+                foreach (var rb in category.Recordings)
+                {
+                    AssertAlternatingPartEvents(
+                        rb.Build(),
+                        category.OnEvent,
+                        category.OffEvent,
+                        firstEventOffsetSeconds: 0.0,
+                        onDurationSeconds: 4.5,
+                        offDurationSeconds: 1.5,
+                        expectedOnValue: category.OnValue);
+                }
+            }
+        }
+
+        [Fact]
+        public void SpecialDeployAnimationShowcases_NonHeatShieldEntriesUseFastAlternatingStateMachine()
+        {
+            var recordings = SpecialDeployAnimationShowcaseRecordings(17000);
+            Assert.Equal(12, recordings.Length);
+
+            foreach (var rb in recordings)
+            {
+                var rec = rb.Build();
+                string vesselName = rec.GetValue("vesselName");
+                if (vesselName == "Part Showcase - Inflatable Heat Shield")
+                    continue;
+
+                PartEventType onEvent = vesselName == "Part Showcase - Rover Wheel M1-F"
+                    ? PartEventType.GearDeployed
+                    : PartEventType.DeployableExtended;
+                PartEventType offEvent = vesselName == "Part Showcase - Rover Wheel M1-F"
+                    ? PartEventType.GearRetracted
+                    : PartEventType.DeployableRetracted;
+
+                AssertAlternatingPartEvents(
+                    rec,
+                    onEvent,
+                    offEvent,
+                    firstEventOffsetSeconds: 0.0,
+                    onDurationSeconds: 4.5,
+                    offDurationSeconds: 1.5,
+                    expectedOnValue: 0f);
+            }
+        }
+
+        [Fact]
+        public void SpecialDeployAnimationShowcases_InflatableHeatShieldUsesExpectedSequence()
+        {
+            var recordings = SpecialDeployAnimationShowcaseRecordings(17000);
+            ConfigNode heatShield = null;
+
+            foreach (var rb in recordings)
+            {
+                var rec = rb.Build();
+                if (rec.GetValue("vesselName") == "Part Showcase - Inflatable Heat Shield")
+                {
+                    heatShield = rec;
+                    break;
+                }
+            }
+
+            Assert.NotNull(heatShield);
+            var events = heatShield.GetNodes("PART_EVENT");
+            Assert.Equal(8, events.Length);
+
+            var expectedTypes = new[]
+            {
+                PartEventType.ShroudJettisoned,
+                PartEventType.DeployableExtended,
+                PartEventType.DeployableRetracted,
+                PartEventType.DeployableExtended,
+                PartEventType.DeployableRetracted,
+                PartEventType.DeployableExtended,
+                PartEventType.DeployableRetracted,
+                PartEventType.DeployableExtended
+            };
+            var expectedOffsets = new[] { 0.5, 1.0, 4.5, 7.5, 10.5, 13.5, 16.5, 19.5 };
+
+            var ghost = heatShield.GetNode("GHOST_VISUAL_SNAPSHOT");
+            var primaryPart = ghost.GetNodes("PART")[0];
+            double baseUt = ParseInvariantDouble(events[0].GetValue("ut")) - expectedOffsets[0];
+
+            for (int i = 0; i < events.Length; i++)
+            {
+                Assert.Equal(((int)expectedTypes[i]).ToString(CultureInfo.InvariantCulture), events[i].GetValue("type"));
+                AssertEventTargetsPrimaryPart(events[i], primaryPart);
+                Assert.Equal("0", events[i].GetValue("midx"));
+                AssertFloatClose(0f, ParseInvariantFloat(events[i].GetValue("value")));
+                Assert.Equal(baseUt + expectedOffsets[i], ParseInvariantDouble(events[i].GetValue("ut")), 6);
+            }
+        }
+
+        [Fact]
+        public void FairingShowcaseRecordings_UseExpectedModulesAndJettisonCadence()
+        {
+            var expectedBaseRadius = new Dictionary<string, float>
+            {
+                ["Part Showcase - Fairing Size 1"] = 0.625f,
+                ["Part Showcase - Fairing Size 1.5"] = 0.9375f,
+                ["Part Showcase - Fairing Size 2"] = 1.25f,
+                ["Part Showcase - Fairing Size 3"] = 1.875f,
+                ["Part Showcase - Fairing Size 4"] = 2.5f
+            };
+            var expectedTopHeight = new Dictionary<string, float>
+            {
+                ["Part Showcase - Fairing Size 1"] = 2.0f,
+                ["Part Showcase - Fairing Size 1.5"] = 2.8f,
+                ["Part Showcase - Fairing Size 2"] = 3.2f,
+                ["Part Showcase - Fairing Size 3"] = 4.5f,
+                ["Part Showcase - Fairing Size 4"] = 6.0f
+            };
+
+            foreach (var rb in FairingShowcaseRecordings(17000))
+            {
+                var rec = rb.Build();
+                AssertAlternatingPartEvents(
+                    rec,
+                    PartEventType.FairingJettisoned,
+                    PartEventType.FairingJettisoned,
+                    firstEventOffsetSeconds: 3.0,
+                    onDurationSeconds: 3.0,
+                    offDurationSeconds: 3.0,
+                    expectedOnValue: 0f);
+
+                var part = rec.GetNode("GHOST_VISUAL_SNAPSHOT").GetNodes("PART")[0];
+                ConfigNode fairingModule = null;
+                foreach (var module in part.GetNodes("MODULE"))
+                {
+                    if (module.GetValue("name") == "ModuleProceduralFairing")
+                    {
+                        fairingModule = module;
+                        break;
+                    }
+                }
+
+                Assert.NotNull(fairingModule);
+                var xsections = fairingModule.GetNodes("XSECTION");
+                Assert.Equal(2, xsections.Length);
+                AssertFloatClose(0f, ParseInvariantFloat(xsections[0].GetValue("h")));
+                AssertFloatClose(expectedBaseRadius[rec.GetValue("vesselName")], ParseInvariantFloat(xsections[0].GetValue("r")));
+                AssertFloatClose(expectedTopHeight[rec.GetValue("vesselName")], ParseInvariantFloat(xsections[1].GetValue("h")));
+                AssertFloatClose(0f, ParseInvariantFloat(xsections[1].GetValue("r")));
+            }
+        }
+
+        [Fact]
+        public void JettisonShowcaseRecordings_UseRepeatedShroudJettisonCadence()
+        {
+            foreach (var rb in JettisonShowcaseRecordings(17000))
+            {
+                AssertAlternatingPartEvents(
+                    rb.Build(),
+                    PartEventType.ShroudJettisoned,
+                    PartEventType.ShroudJettisoned,
+                    firstEventOffsetSeconds: 3.0,
+                    onDurationSeconds: 3.0,
+                    offDurationSeconds: 3.0,
+                    expectedOnValue: 0f);
+            }
+        }
+
+        [Fact]
+        public void LightShowcaseRecordings_AllEntriesFollowExpectedBlinkStateMachine()
+        {
+            var expectedTypes = new[]
+            {
+                PartEventType.LightOn,
+                PartEventType.LightBlinkEnabled,
+                PartEventType.LightBlinkDisabled,
+                PartEventType.LightBlinkEnabled,
+                PartEventType.LightBlinkRate,
+                PartEventType.LightBlinkDisabled,
+                PartEventType.LightOff
+            };
+            var expectedValues = new[] { 0f, 0.5f, 0f, 2.0f, 5.0f, 0f, 0f };
+            var expectedOffsets = new[] { 0.0, 6.0, 12.0, 15.0, 18.0, 21.0, 22.0 };
+
+            foreach (var rb in LightShowcaseRecordings(17000))
+            {
+                var rec = rb.Build();
+                var events = rec.GetNodes("PART_EVENT");
+                Assert.Equal(7, events.Length);
+                var primaryPart = rec.GetNode("GHOST_VISUAL_SNAPSHOT").GetNodes("PART")[0];
+                double baseUt = ParseInvariantDouble(events[0].GetValue("ut"));
+
+                for (int i = 0; i < events.Length; i++)
+                {
+                    Assert.Equal(((int)expectedTypes[i]).ToString(CultureInfo.InvariantCulture), events[i].GetValue("type"));
+                    AssertEventTargetsPrimaryPart(events[i], primaryPart);
+                    Assert.Equal("0", events[i].GetValue("midx"));
+                    AssertFloatClose(expectedValues[i], ParseInvariantFloat(events[i].GetValue("value")));
+                    Assert.Equal(baseUt + expectedOffsets[i], ParseInvariantDouble(events[i].GetValue("ut")), 6);
+                }
+            }
+        }
+
+        [Fact]
+        public void ParachuteShowcaseRecordings_AllEntriesFollowThreePhaseStateCycle()
+        {
+            var expectedTypes = new[]
+            {
+                PartEventType.ParachuteSemiDeployed,
+                PartEventType.ParachuteDeployed,
+                PartEventType.ParachuteCut,
+                PartEventType.ParachuteSemiDeployed,
+                PartEventType.ParachuteDeployed,
+                PartEventType.ParachuteCut,
+                PartEventType.ParachuteSemiDeployed,
+                PartEventType.ParachuteDeployed,
+                PartEventType.ParachuteCut
+            };
+            var expectedOffsets = new[] { 0.0, 3.0, 6.0, 8.0, 11.0, 14.0, 16.0, 19.0, 22.0 };
+
+            foreach (var rb in ParachuteShowcaseRecordings(17000))
+            {
+                var rec = rb.Build();
+                var events = rec.GetNodes("PART_EVENT");
+                Assert.Equal(9, events.Length);
+
+                var primaryPart = rec.GetNode("GHOST_VISUAL_SNAPSHOT").GetNodes("PART")[0];
+                double baseUt = ParseInvariantDouble(events[0].GetValue("ut"));
+                for (int i = 0; i < events.Length; i++)
+                {
+                    Assert.Equal(((int)expectedTypes[i]).ToString(CultureInfo.InvariantCulture), events[i].GetValue("type"));
+                    AssertEventTargetsPrimaryPart(events[i], primaryPart);
+                    Assert.Equal("0", events[i].GetValue("midx"));
+                    AssertFloatClose(0f, ParseInvariantFloat(events[i].GetValue("value")));
+                    Assert.Equal(baseUt + expectedOffsets[i], ParseInvariantDouble(events[i].GetValue("ut")), 6);
+                }
+            }
+        }
+
+        [Fact]
+        public void InventoryPlacementShowcaseRecording_UsesRepeatableLifecycleStateMachine()
+        {
+            var rec = InventoryPlacementShowcaseRecording(17000).Build();
+            var events = rec.GetNodes("PART_EVENT");
+            Assert.Equal(8, events.Length);
+
+            var expectedTypes = new[]
+            {
+                PartEventType.InventoryPartPlaced,
+                PartEventType.DeployableExtended,
+                PartEventType.DeployableRetracted,
+                PartEventType.InventoryPartRemoved,
+                PartEventType.InventoryPartPlaced,
+                PartEventType.DeployableExtended,
+                PartEventType.DeployableRetracted,
+                PartEventType.InventoryPartRemoved
+            };
+            var expectedOffsets = new[] { 0.5, 1.0, 4.0, 4.5, 12.5, 13.0, 16.0, 16.5 };
+            var primaryPart = rec.GetNode("GHOST_VISUAL_SNAPSHOT").GetNodes("PART")[0];
+            double baseUt = ParseInvariantDouble(events[0].GetValue("ut")) - expectedOffsets[0];
+
+            for (int i = 0; i < events.Length; i++)
+            {
+                Assert.Equal(((int)expectedTypes[i]).ToString(CultureInfo.InvariantCulture), events[i].GetValue("type"));
+                AssertEventTargetsPrimaryPart(events[i], primaryPart);
+                Assert.Equal("0", events[i].GetValue("midx"));
+                AssertFloatClose(0f, ParseInvariantFloat(events[i].GetValue("value")));
+                Assert.Equal(baseUt + expectedOffsets[i], ParseInvariantDouble(events[i].GetValue("ut")), 6);
+            }
+        }
+
+        [Fact]
+        public void EngineShowcaseRecordings_AllEntriesUseDeterministicTimelineAndValues()
+        {
+            var recordings = EngineShowcaseRecordings(17000);
+            Assert.Equal(45, recordings.Length);
+
+            var withShroudTypes = new[]
+            {
+                PartEventType.ShroudJettisoned,
+                PartEventType.EngineIgnited,
+                PartEventType.EngineThrottle,
+                PartEventType.EngineThrottle,
+                PartEventType.EngineShutdown,
+                PartEventType.EngineIgnited,
+                PartEventType.EngineThrottle,
+                PartEventType.EngineShutdown
+            };
+            var withShroudOffsets = new[] { 0.5, 3.0, 6.0, 9.0, 12.0, 15.0, 18.0, 21.0 };
+            var withShroudValues = new[] { 0f, 0.3f, 0.7f, 1.0f, 0f, 1.0f, 0.5f, 0f };
+
+            var flameOnlyTypes = new[]
+            {
+                PartEventType.EngineIgnited,
+                PartEventType.EngineThrottle,
+                PartEventType.EngineThrottle,
+                PartEventType.EngineShutdown,
+                PartEventType.EngineIgnited,
+                PartEventType.EngineThrottle,
+                PartEventType.EngineThrottle,
+                PartEventType.EngineShutdown
+            };
+            var flameOnlyOffsets = new[] { 0.0, 3.0, 6.0, 9.0, 12.0, 15.0, 18.0, 21.0 };
+            var flameOnlyValues = new[] { 0.3f, 0.7f, 1.0f, 0f, 1.0f, 0.5f, 0.15f, 0f };
+
+            foreach (var rb in recordings)
+            {
+                var rec = rb.Build();
+                var events = rec.GetNodes("PART_EVENT");
+                Assert.True(
+                    events.Length == 2 || events.Length == 3 || events.Length == 8,
+                    $"Unexpected event count {events.Length} for {rec.GetValue("vesselName")}");
+
+                var primaryPart = rec.GetNode("GHOST_VISUAL_SNAPSHOT").GetNodes("PART")[0];
+
+                if (events.Length == 2)
+                {
+                    double baseUt = ParseInvariantDouble(events[0].GetValue("ut"));
+                    var expectedTypes = new[] { PartEventType.EngineIgnited, PartEventType.EngineShutdown };
+                    var expectedOffsets = new[] { 0.0, 12.0 };
+                    var expectedValues = new[] { 1.0f, 0f };
+                    for (int i = 0; i < events.Length; i++)
+                    {
+                        Assert.Equal(((int)expectedTypes[i]).ToString(CultureInfo.InvariantCulture), events[i].GetValue("type"));
+                        AssertEventTargetsPrimaryPart(events[i], primaryPart);
+                        Assert.Equal("0", events[i].GetValue("midx"));
+                        AssertFloatClose(expectedValues[i], ParseInvariantFloat(events[i].GetValue("value")));
+                        Assert.Equal(baseUt + expectedOffsets[i], ParseInvariantDouble(events[i].GetValue("ut")), 6);
+                    }
+                    continue;
+                }
+
+                if (events.Length == 3)
+                {
+                    double baseUt = ParseInvariantDouble(events[0].GetValue("ut")) - 0.5;
+                    var expectedTypes = new[] { PartEventType.ShroudJettisoned, PartEventType.EngineIgnited, PartEventType.EngineShutdown };
+                    var expectedOffsets = new[] { 0.5, 3.0, 15.0 };
+                    var expectedValues = new[] { 0f, 1.0f, 0f };
+                    for (int i = 0; i < events.Length; i++)
+                    {
+                        Assert.Equal(((int)expectedTypes[i]).ToString(CultureInfo.InvariantCulture), events[i].GetValue("type"));
+                        AssertEventTargetsPrimaryPart(events[i], primaryPart);
+                        Assert.Equal("0", events[i].GetValue("midx"));
+                        AssertFloatClose(expectedValues[i], ParseInvariantFloat(events[i].GetValue("value")));
+                        Assert.Equal(baseUt + expectedOffsets[i], ParseInvariantDouble(events[i].GetValue("ut")), 6);
+                    }
+                    continue;
+                }
+
+                bool hasShroud = events[0].GetValue("type") ==
+                    ((int)PartEventType.ShroudJettisoned).ToString(CultureInfo.InvariantCulture);
+                var expectedTypes8 = hasShroud ? withShroudTypes : flameOnlyTypes;
+                var expectedOffsets8 = hasShroud ? withShroudOffsets : flameOnlyOffsets;
+                var expectedValues8 = hasShroud ? withShroudValues : flameOnlyValues;
+                double baseUt8 = ParseInvariantDouble(events[0].GetValue("ut")) - expectedOffsets8[0];
+
+                for (int i = 0; i < events.Length; i++)
+                {
+                    Assert.Equal(((int)expectedTypes8[i]).ToString(CultureInfo.InvariantCulture), events[i].GetValue("type"));
+                    AssertEventTargetsPrimaryPart(events[i], primaryPart);
+                    Assert.Equal("0", events[i].GetValue("midx"));
+                    AssertFloatClose(expectedValues8[i], ParseInvariantFloat(events[i].GetValue("value")));
+                    Assert.Equal(baseUt8 + expectedOffsets8[i], ParseInvariantDouble(events[i].GetValue("ut")), 6);
+                }
+            }
+        }
+
+        [Fact]
+        public void RoboticsShowcaseRecordings_UseExpectedMotionTargetsAndCadence()
+        {
+            var expectedOnValueByVessel = new Dictionary<string, float>
+            {
+                ["Part Showcase - Robotics Hinge G-11"] = 45f,
+                ["Part Showcase - Robotics Hinge G-00"] = 45f,
+                ["Part Showcase - Robotics Hinge M-12"] = 45f,
+                ["Part Showcase - Robotics Hinge M-06"] = 45f,
+                ["Part Showcase - Robotics Hinge XL"] = 45f,
+                ["Part Showcase - Robotics Piston 3P6"] = 0.3f,
+                ["Part Showcase - Robotics Piston 1P2"] = 0.2f,
+                ["Part Showcase - Robotics Piston 1P4"] = 0.4f,
+                ["Part Showcase - Robotics Piston 3P12"] = 0.9f,
+                ["Part Showcase - Robotics Rotation Servo M-06"] = 90f,
+                ["Part Showcase - Robotics Rotation Servo M-12"] = 90f,
+                ["Part Showcase - Robotics Rotation Servo F-12"] = 90f,
+                ["Part Showcase - Robotics Rotation Servo F-33"] = 90f,
+                ["Part Showcase - Robotics Rotor EM-16"] = 240f,
+                ["Part Showcase - Robotics Rotor EM-16S"] = 240f,
+                ["Part Showcase - Robotics Rotor EM-32"] = 240f,
+                ["Part Showcase - Robotics Rotor EM-32S"] = 240f,
+                ["Part Showcase - Robotics Rotor EM-64"] = 240f,
+                ["Part Showcase - Robotics Rotor EM-64S"] = 240f,
+                ["Part Showcase - Robotics Rotor Motor R121"] = 240f,
+                ["Part Showcase - Robotics Rotor Motor R7000"] = 240f
+            };
+
+            foreach (var rb in RoboticsShowcaseRecordings(17000))
+            {
+                var rec = rb.Build();
+                string vesselName = rec.GetValue("vesselName");
+                Assert.True(expectedOnValueByVessel.ContainsKey(vesselName), $"Missing expected motion target for {vesselName}");
+                AssertAlternatingPartEvents(
+                    rec,
+                    PartEventType.RoboticMotionStarted,
+                    PartEventType.RoboticMotionStopped,
+                    firstEventOffsetSeconds: 0.0,
+                    onDurationSeconds: 4.5,
+                    offDurationSeconds: 1.5,
+                    expectedOnValue: expectedOnValueByVessel[vesselName]);
+            }
+        }
+
+        [Fact]
+        public void WheelDynamicsShowcaseRecordings_UseExpectedModulesAndMotionTargets()
+        {
+            var expectedOnValueByVessel = new Dictionary<string, float>
+            {
+                ["Part Showcase - Wheel Dynamics Gear Fixed"] = 0.08f,
+                ["Part Showcase - Wheel Dynamics Gear Free"] = 24f,
+                ["Part Showcase - Wheel Dynamics Rover M1"] = 180f,
+                ["Part Showcase - Wheel Dynamics Rover S2"] = 180f,
+                ["Part Showcase - Wheel Dynamics Rover XL3"] = 120f,
+                ["Part Showcase - Wheel Dynamics TR-2L"] = 180f
+            };
+            var expectedModuleIndexByVessel = new Dictionary<string, int>
+            {
+                ["Part Showcase - Wheel Dynamics Gear Fixed"] = 0,
+                ["Part Showcase - Wheel Dynamics Gear Free"] = 1,
+                ["Part Showcase - Wheel Dynamics Rover M1"] = 2,
+                ["Part Showcase - Wheel Dynamics Rover S2"] = 2,
+                ["Part Showcase - Wheel Dynamics Rover XL3"] = 1,
+                ["Part Showcase - Wheel Dynamics TR-2L"] = 2
+            };
+
+            foreach (var rb in WheelDynamicsShowcaseRecordings(17000))
+            {
+                var rec = rb.Build();
+                string vesselName = rec.GetValue("vesselName");
+                Assert.True(expectedOnValueByVessel.ContainsKey(vesselName), $"Missing expected wheel target for {vesselName}");
+                Assert.True(expectedModuleIndexByVessel.ContainsKey(vesselName), $"Missing expected wheel module for {vesselName}");
+                AssertAlternatingPartEvents(
+                    rec,
+                    PartEventType.RoboticMotionStarted,
+                    PartEventType.RoboticMotionStopped,
+                    firstEventOffsetSeconds: 0.0,
+                    onDurationSeconds: 4.5,
+                    offDurationSeconds: 1.5,
+                    expectedOnValue: expectedOnValueByVessel[vesselName],
+                    expectedModuleIndex: expectedModuleIndexByVessel[vesselName]);
+            }
         }
 
         [Fact]

--- a/Source/Parsek.Tests/SyntheticRecordingTests.cs
+++ b/Source/Parsek.Tests/SyntheticRecordingTests.cs
@@ -692,8 +692,8 @@ namespace Parsek.Tests
         // Event PIDs must match this so the ghost visual builder can find the part.
         private const uint SinglePartPid = 100000;
         // Optional companion part (e.g., kerbal actor) receives the second slot.
-        // Total visible showcase row entries (indices 0-192, including inventory placement).
-        private const int ShowcaseRowCount = 193;
+        // Total visible showcase row entries (indices 0-235, including inventory placement).
+        private const int ShowcaseRowCount = 236;
         // Keep showcases close to the launchpad centerline without overlapping pad geometry.
         private const double ShowcaseDistanceFromPadMeters = 200.0;
         // Shroud-jettison showcase parts include tall engine plates and engines that clip at base altitude.
@@ -746,6 +746,94 @@ namespace Parsek.Tests
             return b;
         }
 
+        /// <summary>
+        /// Builds an engine flame showcase recording with a throttle-varying 8-event cycle:
+        /// ignite low → ramp up → full → shutdown → full restart → throttle down → near-idle → shutdown.
+        /// 24s clip with 9 trajectory points, suitable for liquid/jet/special engines.
+        /// </summary>
+        private static RecordingBuilder BuildEngineFlameShowcaseRecording(
+            double baseUT, string vesselName, string enginePartName, int rowIndex,
+            uint pidBase)
+        {
+            const double metersPerDegree = (2.0 * Math.PI * 600000.0) / 360.0;
+            const double spacingMeters = 5.0;
+
+            double t = baseUT + 30;
+            double baseLat = -0.0972;
+            double baseLon = -74.5575;
+            double rowCenterOffsetMeters = -((ShowcaseRowCount - 1) * spacingMeters * 0.5);
+            double lat = baseLat + ((rowIndex * spacingMeters + rowCenterOffsetMeters) / metersPerDegree);
+            double lon = baseLon + (ShowcaseDistanceFromPadMeters / metersPerDegree);
+            double alt = 66.0;
+
+            var b = new RecordingBuilder(vesselName)
+                .WithDefaultRotation(KscRotX, KscRotY, KscRotZ, KscRotW)
+                .WithLoopPlayback(loop: true, pauseSeconds: 0.0);
+
+            for (int i = 0; i <= 8; i++)
+                b.AddPoint(t + (i * 3), lat, lon, alt);
+
+            b.AddPartEvent(t + 0,  SinglePartPid, (int)PartEventType.EngineIgnited,  enginePartName, value: 0.3f);
+            b.AddPartEvent(t + 3,  SinglePartPid, (int)PartEventType.EngineThrottle, enginePartName, value: 0.7f);
+            b.AddPartEvent(t + 6,  SinglePartPid, (int)PartEventType.EngineThrottle, enginePartName, value: 1.0f);
+            b.AddPartEvent(t + 9,  SinglePartPid, (int)PartEventType.EngineShutdown, enginePartName);
+            b.AddPartEvent(t + 12, SinglePartPid, (int)PartEventType.EngineIgnited,  enginePartName, value: 1.0f);
+            b.AddPartEvent(t + 15, SinglePartPid, (int)PartEventType.EngineThrottle, enginePartName, value: 0.5f);
+            b.AddPartEvent(t + 18, SinglePartPid, (int)PartEventType.EngineThrottle, enginePartName, value: 0.15f);
+            b.AddPartEvent(t + 21, SinglePartPid, (int)PartEventType.EngineShutdown, enginePartName);
+
+            var snap = new VesselSnapshotBuilder()
+                .WithName(vesselName)
+                .WithPersistentId((uint)(pidBase + rowIndex))
+                .AddPart(enginePartName, rotation: "0,-0.7071068,0,0.7071068")
+                .AsLanded(lat, lon, alt)
+                .Build();
+
+            b.WithGhostVisualSnapshot(snap);
+            return b;
+        }
+
+        /// <summary>
+        /// Builds an SRB flame showcase recording with a simple 2-event cycle:
+        /// ignite at full power → burnout after 12s (no restart, fixed throttle).
+        /// 24s clip with 9 trajectory points, physically accurate for solid boosters.
+        /// </summary>
+        private static RecordingBuilder BuildSrbFlameShowcaseRecording(
+            double baseUT, string vesselName, string srbPartName, int rowIndex,
+            uint pidBase)
+        {
+            const double metersPerDegree = (2.0 * Math.PI * 600000.0) / 360.0;
+            const double spacingMeters = 5.0;
+
+            double t = baseUT + 30;
+            double baseLat = -0.0972;
+            double baseLon = -74.5575;
+            double rowCenterOffsetMeters = -((ShowcaseRowCount - 1) * spacingMeters * 0.5);
+            double lat = baseLat + ((rowIndex * spacingMeters + rowCenterOffsetMeters) / metersPerDegree);
+            double lon = baseLon + (ShowcaseDistanceFromPadMeters / metersPerDegree);
+            double alt = 66.0;
+
+            var b = new RecordingBuilder(vesselName)
+                .WithDefaultRotation(KscRotX, KscRotY, KscRotZ, KscRotW)
+                .WithLoopPlayback(loop: true, pauseSeconds: 0.0);
+
+            for (int i = 0; i <= 8; i++)
+                b.AddPoint(t + (i * 3), lat, lon, alt);
+
+            b.AddPartEvent(t + 0,  SinglePartPid, (int)PartEventType.EngineIgnited,  srbPartName, value: 1.0f);
+            b.AddPartEvent(t + 12, SinglePartPid, (int)PartEventType.EngineShutdown, srbPartName);
+
+            var snap = new VesselSnapshotBuilder()
+                .WithName(vesselName)
+                .WithPersistentId((uint)(pidBase + rowIndex))
+                .AddPart(srbPartName, rotation: "0,-0.7071068,0,0.7071068")
+                .AsLanded(lat, lon, alt)
+                .Build();
+
+            b.WithGhostVisualSnapshot(snap);
+            return b;
+        }
+
         internal static RecordingBuilder[] LightShowcaseRecordings(double baseUT = 0)
         {
             return new[]
@@ -770,7 +858,7 @@ namespace Parsek.Tests
         // Animation Group: 67-68, Parachutes: 69-73, Special Deploy Animations: 74-85 and 115-116,
         // Jettison Coverage: 86-114, Robotics: 117-137, AeroSurface: 138, Robot Arm Scanners: 139-141,
         // Control Surfaces: 142-165, Wheel Dynamics: 166-171, AnimateHeat: 172-184,
-        // Gear Extra Large: 189, Inventory Placement: 192.
+        // Gear Extra Large: 189, Engine Flames: 192-234, Inventory Placement: 235.
 
         internal static RecordingBuilder[] DeployableShowcaseRecordings(double baseUT = 0)
         {
@@ -871,15 +959,9 @@ namespace Parsek.Tests
         {
             return new[]
             {
-                BuildPartShowcaseRecording(baseUT, "Part Showcase - Mainsail", "liquidEngineMainsail.v2", 42,
-                    ShowcaseDistanceFromPadMeters, PartEventType.EngineIgnited, PartEventType.EngineShutdown, 92000000, SinglePartPid,
-                    eventValue: 1.0f),
-                BuildPartShowcaseRecording(baseUT, "Part Showcase - Skipper", "engineLargeSkipper.v2", 43,
-                    ShowcaseDistanceFromPadMeters, PartEventType.EngineIgnited, PartEventType.EngineShutdown, 92000000, SinglePartPid,
-                    eventValue: 1.0f),
-                BuildPartShowcaseRecording(baseUT, "Part Showcase - SSME", "SSME", 44,
-                    ShowcaseDistanceFromPadMeters, PartEventType.EngineIgnited, PartEventType.EngineShutdown, 92000000, SinglePartPid,
-                    eventValue: 1.0f)
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Mainsail", "liquidEngineMainsail.v2", 42, 92000000),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Skipper", "engineLargeSkipper.v2", 43, 92000000),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - SSME", "SSME", 44, 92000000)
             };
         }
 
@@ -1446,6 +1528,61 @@ namespace Parsek.Tests
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Mastodon", "LiquidEngineRK-7", 114,
                     ShowcaseDistanceFromPadMeters, PartEventType.ShroudJettisoned, PartEventType.ShroudJettisoned, 98500000, SinglePartPid,
                     firstEventOffsetSeconds: 3.0)
+            };
+        }
+
+        internal static RecordingBuilder[] EngineFlameShowcaseRecordings(double baseUT = 0)
+        {
+            const uint pidBase = 99200000;
+            return new[]
+            {
+                // Liquid engines (rows 192-218) — throttle-varying cycle
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame LV-T30", "liquidEngine", 192, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame LV-T30 v2", "liquidEngine.v2", 193, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame LV-T45", "liquidEngine2", 194, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame LV-T45 v2", "liquidEngine2.v2", 195, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Poodle", "liquidEngine2-2.v2", 196, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Terrier", "liquidEngine3.v2", 197, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Spark", "liquidEngineMini.v2", 198, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Ant", "microEngine.v2", 199, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Spider", "radialEngineMini.v2", 200, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Twitch", "smallRadialEngine", 201, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Twitch v2", "smallRadialEngine.v2", 202, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Thud", "radialLiquidEngine1-2", 203, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame NERV", "nuclearEngine", 204, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Aerospike", "toroidalAerospike", 205, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Cub", "omsEngine", 206, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Twin-Boar", "Size2LFB", 207, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Twin-Boar v2", "Size2LFB.v2", 208, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Mammoth", "Size3EngineCluster", 209, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Vector", "Size3AdvancedEngine", 210, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Kodiak", "LiquidEngineKE-1", 211, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Cheetah", "LiquidEngineLV-T91", 212, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Wolfhound", "LiquidEngineLV-TX87", 213, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Bobcat", "LiquidEngineRE-I2", 214, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Skiff", "LiquidEngineRE-J10", 215, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Mastodon", "LiquidEngineRK-7", 216, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Pug", "LiquidEngineRV-1", 217, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame RAPIER", "RAPIER", 218, pidBase),
+                // Solid boosters (rows 219-228) — simple ignite/burnout cycle
+                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Flea", "solidBooster.sm.v2", 219, pidBase),
+                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Hammer", "solidBooster.v2", 220, pidBase),
+                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Thumper", "solidBooster1-1", 221, pidBase),
+                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Kickback", "MassiveBooster", 222, pidBase),
+                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Mite", "Mite", 223, pidBase),
+                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Shrimp", "Shrimp", 224, pidBase),
+                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Thoroughbred", "Thoroughbred", 225, pidBase),
+                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Clydesdale", "Clydesdale", 226, pidBase),
+                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Pollux", "Pollux", 227, pidBase),
+                BuildSrbFlameShowcaseRecording(baseUT, "Part Showcase - Flame Sepatron", "sepMotor1", 228, pidBase),
+                // Jet engines (rows 229-233) — throttle-varying cycle
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Juno", "miniJetEngine", 229, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Wheesley", "JetEngine", 230, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Whiplash", "turboFanEngine", 231, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Panther", "turboJet", 232, pidBase),
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Goliath", "turboFanSize2", 233, pidBase),
+                // Special (row 234)
+                BuildEngineFlameShowcaseRecording(baseUT, "Part Showcase - Flame Ion", "ionEngine", 234, pidBase)
             };
         }
 
@@ -2137,6 +2274,7 @@ namespace Parsek.Tests
         [Fact]
         public void EngineShowcaseRecordings_BuildExpectedShape()
         {
+            // Existing 3 engines (rows 42-44) now use throttle-varying builder
             var recordings = EngineShowcaseRecordings(baseUT: 17000);
             Assert.Equal(3, recordings.Length);
 
@@ -2145,14 +2283,13 @@ namespace Parsek.Tests
             Assert.Equal("True", first.GetValue("loopPlayback"));
             Assert.Equal(8, first.GetNodes("PART_EVENT").Length);
 
-            // Verify engine events have value=1 for ignition, 0 for shutdown
+            // Throttle builder: first event is EngineIgnited at 0.3
             var events = first.GetNodes("PART_EVENT");
             Assert.Equal(((int)PartEventType.EngineIgnited).ToString(), events[0].GetValue("type"));
-            Assert.Equal("1", events[0].GetValue("value"));
-            Assert.Equal(((int)PartEventType.EngineShutdown).ToString(), events[1].GetValue("type"));
-            Assert.Equal("0", events[1].GetValue("value"));
+            Assert.Equal("0.3", events[0].GetValue("value"));
+            Assert.Equal(((int)PartEventType.EngineThrottle).ToString(), events[1].GetValue("type"));
+            Assert.Equal("0.7", events[1].GetValue("value"));
 
-            // Uses dot-form part name
             var ghost = first.GetNode("GHOST_VISUAL_SNAPSHOT");
             Assert.NotNull(ghost);
             Assert.Equal("liquidEngineMainsail.v2", ghost.GetNodes("PART")[0].GetValue("name"));
@@ -2164,6 +2301,37 @@ namespace Parsek.Tests
                 var g = recordings[i].Build().GetNode("GHOST_VISUAL_SNAPSHOT");
                 Assert.Equal(names[i], g.GetNodes("PART")[0].GetValue("name"));
             }
+
+            // 43 new engine flame entries (rows 192-234)
+            var flames = EngineFlameShowcaseRecordings(baseUT: 17000);
+            Assert.Equal(43, flames.Length);
+
+            // Liquid engines (0-26) use throttle builder → 8 events
+            var liquid = flames[0].Build();
+            Assert.Equal("Part Showcase - Flame LV-T30", liquid.GetValue("vesselName"));
+            Assert.Equal(8, liquid.GetNodes("PART_EVENT").Length);
+            var liqEvents = liquid.GetNodes("PART_EVENT");
+            Assert.Equal(((int)PartEventType.EngineIgnited).ToString(), liqEvents[0].GetValue("type"));
+            Assert.Equal("0.3", liqEvents[0].GetValue("value"));
+
+            // SRBs (27-36) use SRB builder → 2 events
+            var srb = flames[27].Build();
+            Assert.Equal("Part Showcase - Flame Flea", srb.GetValue("vesselName"));
+            Assert.Equal(2, srb.GetNodes("PART_EVENT").Length);
+            var srbEvents = srb.GetNodes("PART_EVENT");
+            Assert.Equal(((int)PartEventType.EngineIgnited).ToString(), srbEvents[0].GetValue("type"));
+            Assert.Equal("1", srbEvents[0].GetValue("value"));
+            Assert.Equal(((int)PartEventType.EngineShutdown).ToString(), srbEvents[1].GetValue("type"));
+
+            // Jets (37-41) use throttle builder → 8 events
+            var jet = flames[37].Build();
+            Assert.Equal("Part Showcase - Flame Juno", jet.GetValue("vesselName"));
+            Assert.Equal(8, jet.GetNodes("PART_EVENT").Length);
+
+            // Ion (42) uses throttle builder → 8 events
+            var ion = flames[42].Build();
+            Assert.Equal("Part Showcase - Flame Ion", ion.GetValue("vesselName"));
+            Assert.Equal(8, ion.GetNodes("PART_EVENT").Length);
         }
 
         [Fact]
@@ -2677,7 +2845,8 @@ namespace Parsek.Tests
                 RobotArmScannerShowcaseRecordings(17000),
                 ControlSurfaceShowcaseRecordings(17000),
                 WheelDynamicsShowcaseRecordings(17000),
-                AnimateHeatShowcaseRecordings(17000)
+                AnimateHeatShowcaseRecordings(17000),
+                EngineFlameShowcaseRecordings(17000)
             };
 
             foreach (var category in allShowcases)
@@ -2727,7 +2896,8 @@ namespace Parsek.Tests
                 RobotArmScannerShowcaseRecordings(17000),
                 ControlSurfaceShowcaseRecordings(17000),
                 WheelDynamicsShowcaseRecordings(17000),
-                AnimateHeatShowcaseRecordings(17000)
+                AnimateHeatShowcaseRecordings(17000),
+                EngineFlameShowcaseRecordings(17000)
             };
 
             var positions = new HashSet<string>();
@@ -2742,7 +2912,7 @@ namespace Parsek.Tests
                         $"Duplicate position in '{rec.GetValue("vesselName")}': {key}");
                 }
             }
-            Assert.Equal(192, positions.Count); // 10 + 18 + 8 + 11 + 3 + 2 + 5 + 5 + 2 + 2 + 8 + 2 + 5 + 14 + 29 + 21 + 1 + 3 + 24 + 6 + 13
+            Assert.Equal(235, positions.Count); // 10 + 18 + 8 + 11 + 3 + 2 + 5 + 5 + 2 + 2 + 8 + 2 + 5 + 14 + 29 + 21 + 1 + 3 + 24 + 6 + 13 + 43
         }
 
         [Fact]
@@ -3318,6 +3488,9 @@ namespace Parsek.Tests
             var animateHeatShowcases = AnimateHeatShowcaseRecordings(baseUT);
             for (int i = 0; i < animateHeatShowcases.Length; i++)
                 writer.AddRecording(animateHeatShowcases[i]);
+            var engineFlameShowcases = EngineFlameShowcaseRecordings(baseUT);
+            for (int i = 0; i < engineFlameShowcases.Length; i++)
+                writer.AddRecording(engineFlameShowcases[i]);
             writer.AddRecording(InventoryPlacementShowcaseRecording(baseUT));
 
             var chainSegments = EvaBoardChain(baseUT);
@@ -3540,6 +3713,49 @@ namespace Parsek.Tests
                     Assert.Contains("vesselName = Part Showcase - AnimateHeat Ram Air Intake", content);
                     Assert.Contains("vesselName = Part Showcase - AnimateHeat Shock Cone Intake", content);
                     Assert.Contains("vesselName = Part Showcase - AnimateHeat Standard Nose Cone", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame LV-T30", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame LV-T30 v2", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame LV-T45", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame LV-T45 v2", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame Poodle", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame Terrier", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame Spark", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame Ant", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame Spider", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame Twitch", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame Twitch v2", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame Thud", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame NERV", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame Aerospike", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame Cub", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame Twin-Boar", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame Twin-Boar v2", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame Mammoth", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame Vector", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame Kodiak", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame Cheetah", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame Wolfhound", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame Bobcat", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame Skiff", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame Mastodon", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame Pug", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame RAPIER", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame Flea", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame Hammer", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame Thumper", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame Kickback", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame Mite", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame Shrimp", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame Thoroughbred", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame Clydesdale", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame Pollux", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame Sepatron", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame Juno", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame Wheesley", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame Whiplash", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame Panther", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame Goliath", content);
+                    Assert.Contains("vesselName = Part Showcase - Flame Ion", content);
                     Assert.Contains("vesselName = Part Showcase - Inventory Placement", content);
                     Assert.Contains("vesselName = Flea Chain", content);
                     Assert.Contains("chainId = chain-eva-board-test", content);
@@ -3571,8 +3787,8 @@ namespace Parsek.Tests
                     $"Expected Parsek/Recordings directory at {recordingsDir}");
 
                 string[] precFiles = Directory.GetFiles(recordingsDir, "*.prec");
-                Assert.True(precFiles.Length >= 185,
-                    $"Expected at least 185 .prec files (8 baseline + 10 lights + 18 deployables + 8 gear + 11 cargo + 3 engines + 2 ladders + 5 RCS + 5 fairings + 2 extra radiators + 2 drills + 8 deployed science + 2 animation-group + 5 parachutes + 14 special deploy animations + 29 jettison showcases + 21 robotics + 1 aero-surface + 3 robot-arm-scanner + 24 control-surface + 6 wheel-dynamics + 13 animate-heat + 1 inventory-placement + 3 board-chain + 2 walk-chain), found {precFiles.Length}");
+                Assert.True(precFiles.Length >= 228,
+                    $"Expected at least 228 .prec files (8 baseline + 10 lights + 18 deployables + 8 gear + 11 cargo + 3 engines + 2 ladders + 5 RCS + 5 fairings + 2 extra radiators + 2 drills + 8 deployed science + 2 animation-group + 5 parachutes + 14 special deploy animations + 29 jettison showcases + 21 robotics + 1 aero-surface + 3 robot-arm-scanner + 24 control-surface + 6 wheel-dynamics + 13 animate-heat + 43 engine-flame + 1 inventory-placement + 3 board-chain + 2 walk-chain), found {precFiles.Length}");
             }
         }
 

--- a/Source/Parsek.Tests/SyntheticRecordingTests.cs
+++ b/Source/Parsek.Tests/SyntheticRecordingTests.cs
@@ -692,41 +692,85 @@ namespace Parsek.Tests
         // Event PIDs must match this so the ghost visual builder can find the part.
         private const uint SinglePartPid = 100000;
         // Optional companion part (e.g., kerbal actor) receives the second slot.
-        // Total visible showcase row entries (indices 0-185, including inventory placement).
-        private const int ShowcaseRowCount = 186;
+        // Total visible showcase row entries (indices 0-192, including inventory placement).
+        private const int ShowcaseRowCount = 193;
         // Keep showcases close to the launchpad centerline without overlapping pad geometry.
         private const double ShowcaseDistanceFromPadMeters = 200.0;
         // Shroud-jettison showcase parts include tall engine plates and engines that clip at base altitude.
         private const double ShroudShowcaseAltitudeOffsetMeters = 12.0;
 
-        private static RecordingBuilder BuildLightShowcaseRecording(
+        /// <summary>
+        /// Builds a light showcase recording with an on → blink → off cycle that exercises
+        /// all 5 light event types: LightOn, LightOff, LightBlinkEnabled, LightBlinkDisabled,
+        /// LightBlinkRate. 24s clip with 9 trajectory points.
+        /// </summary>
+        private static RecordingBuilder BuildLightBlinkShowcaseRecording(
             double baseUT, string vesselName, string lightPartName, int rowIndex)
         {
-            return BuildPartShowcaseRecording(baseUT, vesselName, lightPartName, rowIndex,
-                distanceFromPadMeters: ShowcaseDistanceFromPadMeters, onEvent: PartEventType.LightOn,
-                offEvent: PartEventType.LightOff, pidBase: 88000000, evtPid: SinglePartPid);
+            const double metersPerDegree = (2.0 * Math.PI * 600000.0) / 360.0;
+            const double spacingMeters = 5.0;
+
+            double t = baseUT + 30;
+            double baseLat = -0.0972;
+            double baseLon = -74.5575;
+            double rowCenterOffsetMeters = -((ShowcaseRowCount - 1) * spacingMeters * 0.5);
+            double lat = baseLat + ((rowIndex * spacingMeters + rowCenterOffsetMeters) / metersPerDegree);
+            double lon = baseLon + (ShowcaseDistanceFromPadMeters / metersPerDegree);
+            double alt = 66.0;
+
+            var b = new RecordingBuilder(vesselName)
+                .WithDefaultRotation(KscRotX, KscRotY, KscRotZ, KscRotW)
+                .WithLoopPlayback(loop: true, pauseSeconds: 0.0);
+
+            // Static trajectory (24s).
+            for (int i = 0; i <= 8; i++)
+                b.AddPoint(t + (i * 3), lat, lon, alt);
+
+            // On → slow blink → solid → fast blink → faster blink → solid → off.
+            b.AddPartEvent(t + 0.0,  SinglePartPid, (int)PartEventType.LightOn, lightPartName);
+            b.AddPartEvent(t + 6.0,  SinglePartPid, (int)PartEventType.LightBlinkEnabled, lightPartName, value: 0.5f);
+            b.AddPartEvent(t + 12.0, SinglePartPid, (int)PartEventType.LightBlinkDisabled, lightPartName);
+            b.AddPartEvent(t + 15.0, SinglePartPid, (int)PartEventType.LightBlinkEnabled, lightPartName, value: 2.0f);
+            b.AddPartEvent(t + 18.0, SinglePartPid, (int)PartEventType.LightBlinkRate, lightPartName, value: 5.0f);
+            b.AddPartEvent(t + 21.0, SinglePartPid, (int)PartEventType.LightBlinkDisabled, lightPartName);
+            b.AddPartEvent(t + 22.0, SinglePartPid, (int)PartEventType.LightOff, lightPartName);
+
+            var snap = new VesselSnapshotBuilder()
+                .WithName(vesselName)
+                .WithPersistentId((uint)(88000000 + rowIndex))
+                .AddPart(lightPartName, rotation: "0,-0.7071068,0,0.7071068")
+                .AsLanded(lat, lon, alt)
+                .Build();
+
+            b.WithGhostVisualSnapshot(snap);
+            return b;
         }
 
         internal static RecordingBuilder[] LightShowcaseRecordings(double baseUT = 0)
         {
             return new[]
             {
-                BuildLightShowcaseRecording(baseUT, "Part Showcase - Lights v1", "domeLight1", rowIndex: 0),
-                BuildLightShowcaseRecording(baseUT, "Part Showcase - Light - Nav v1", "navLight1", rowIndex: 1),
-                BuildLightShowcaseRecording(baseUT, "Part Showcase - Light - Strip v1", "stripLight1", rowIndex: 2),
-                BuildLightShowcaseRecording(baseUT, "Part Showcase - Light - Spot v1", "spotLight3", rowIndex: 3),
-                BuildLightShowcaseRecording(baseUT, "Part Showcase - Light - Ground Small v1", "groundLight1", rowIndex: 4),
-                BuildLightShowcaseRecording(baseUT, "Part Showcase - Light - Ground Stand v1", "groundLight2", rowIndex: 5)
+                BuildLightBlinkShowcaseRecording(baseUT, "Part Showcase - Lights v1", "domeLight1", rowIndex: 0),
+                BuildLightBlinkShowcaseRecording(baseUT, "Part Showcase - Light - Nav v1", "navLight1", rowIndex: 1),
+                BuildLightBlinkShowcaseRecording(baseUT, "Part Showcase - Light - Strip v1", "stripLight1", rowIndex: 2),
+                BuildLightBlinkShowcaseRecording(baseUT, "Part Showcase - Light - Spot v1", "spotLight3", rowIndex: 3),
+                BuildLightBlinkShowcaseRecording(baseUT, "Part Showcase - Light - Ground Small v1", "groundLight1", rowIndex: 4),
+                BuildLightBlinkShowcaseRecording(baseUT, "Part Showcase - Light - Ground Stand v1", "groundLight2", rowIndex: 5),
+                BuildLightBlinkShowcaseRecording(baseUT, "Part Showcase - Light - Spot Mk1", "spotLight1", rowIndex: 185),
+                BuildLightBlinkShowcaseRecording(baseUT, "Part Showcase - Light - Spot Mk1 v2", "spotLight1_v2", rowIndex: 186),
+                BuildLightBlinkShowcaseRecording(baseUT, "Part Showcase - Light - Spot Mk2", "spotLight2", rowIndex: 187),
+                BuildLightBlinkShowcaseRecording(baseUT, "Part Showcase - Light - Spot Mk2 v2", "spotLight2_v2", rowIndex: 188)
             };
         }
 
         // Row indices continue from lights (0-5) so all showcases form one line.
-        // Lights: 0-5, Deployables: 6-23, Airplane Gear: 24-27, Landing Legs: 28-30,
-        // Cargo: 31-41, Engines: 42-44, Ladders: 45-46, RCS: 47-49, Fairings: 50-54,
+        // Lights: 0-5 + 185-188, Deployables: 6-23, Airplane Gear: 24-27, Landing Legs: 28-30,
+        // Cargo: 31-41, Engines: 42-44, Ladders: 45-46, RCS: 47-49 + 190-191, Fairings: 50-54,
         // Extra Radiators: 55-56, Drills: 57-58, Deployed Science: 59-66,
         // Animation Group: 67-68, Parachutes: 69-73, Special Deploy Animations: 74-85 and 115-116,
         // Jettison Coverage: 86-114, Robotics: 117-137, AeroSurface: 138, Robot Arm Scanners: 139-141,
-        // Control Surfaces: 142-165, Wheel Dynamics: 166-171, AnimateHeat: 172-184, Inventory Placement: 185.
+        // Control Surfaces: 142-165, Wheel Dynamics: 166-171, AnimateHeat: 172-184,
+        // Gear Extra Large: 189, Inventory Placement: 192.
 
         internal static RecordingBuilder[] DeployableShowcaseRecordings(double baseUT = 0)
         {
@@ -788,6 +832,8 @@ namespace Parsek.Tests
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Landing Leg LT-2", "landingLeg1-2", 29,
                     ShowcaseDistanceFromPadMeters, PartEventType.GearDeployed, PartEventType.GearRetracted, 90000000, SinglePartPid),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - Landing Leg LT-05", "miniLandingLeg", 30,
+                    ShowcaseDistanceFromPadMeters, PartEventType.GearDeployed, PartEventType.GearRetracted, 90000000, SinglePartPid),
+                BuildPartShowcaseRecording(baseUT, "Part Showcase - Gear Extra Large", "GearExtraLarge", 189,
                     ShowcaseDistanceFromPadMeters, PartEventType.GearDeployed, PartEventType.GearRetracted, 90000000, SinglePartPid)
             };
         }
@@ -861,6 +907,14 @@ namespace Parsek.Tests
                     eventValue: 1.0f, moduleIndex: 0,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
                 BuildPartShowcaseRecording(baseUT, "Part Showcase - RCS Linear", "RCSLinearSmall", 49,
+                    ShowcaseDistanceFromPadMeters, PartEventType.RCSActivated, PartEventType.RCSStopped, 94000000, SinglePartPid,
+                    eventValue: 1.0f, moduleIndex: 0,
+                    firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
+                BuildPartShowcaseRecording(baseUT, "Part Showcase - RCS Linear Port", "linearRcs", 190,
+                    ShowcaseDistanceFromPadMeters, PartEventType.RCSActivated, PartEventType.RCSStopped, 94000000, SinglePartPid,
+                    eventValue: 1.0f, moduleIndex: 0,
+                    firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
+                BuildPartShowcaseRecording(baseUT, "Part Showcase - RCS Vernor", "vernierEngine", 191,
                     ShowcaseDistanceFromPadMeters, PartEventType.RCSActivated, PartEventType.RCSStopped, 94000000, SinglePartPid,
                     eventValue: 1.0f, moduleIndex: 0,
                     firstEventOffsetSeconds: 0.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5)
@@ -1963,14 +2017,14 @@ namespace Parsek.Tests
         public void LightShowcaseRecordings_BuildExpectedShape()
         {
             var recordings = LightShowcaseRecordings(baseUT: 17000);
-            Assert.Equal(6, recordings.Length);
+            Assert.Equal(10, recordings.Length);
 
             var first = recordings[0].Build();
             Assert.Equal("Part Showcase - Lights v1", first.GetValue("vesselName"));
             Assert.Equal("9", first.GetValue("pointCount"));
             Assert.Equal("True", first.GetValue("loopPlayback"));
             Assert.Equal("0", first.GetValue("loopPauseSeconds"));
-            Assert.Equal(8, first.GetNodes("PART_EVENT").Length);
+            Assert.Equal(7, first.GetNodes("PART_EVENT").Length);
 
             var ghost = first.GetNode("GHOST_VISUAL_SNAPSHOT");
             Assert.NotNull(ghost);
@@ -2022,7 +2076,7 @@ namespace Parsek.Tests
         public void GearShowcaseRecordings_BuildExpectedShape()
         {
             var recordings = GearShowcaseRecordings(baseUT: 17000);
-            Assert.Equal(7, recordings.Length);
+            Assert.Equal(8, recordings.Length);
 
             var first = recordings[0].Build();
             Assert.Equal("Part Showcase - Gear Bay", first.GetValue("vesselName"));
@@ -2039,7 +2093,7 @@ namespace Parsek.Tests
             Assert.Equal(ghost.GetNodes("PART")[0].GetValue("persistentId"), events[0].GetValue("pid"));
 
             var names = new[] { "SmallGearBay", "GearSmall", "GearMedium", "GearLarge",
-                "landingLeg1", "landingLeg1-2", "miniLandingLeg" };
+                "landingLeg1", "landingLeg1-2", "miniLandingLeg", "GearExtraLarge" };
             for (int i = 0; i < recordings.Length; i++)
             {
                 var g = recordings[i].Build().GetNode("GHOST_VISUAL_SNAPSHOT");
@@ -2116,7 +2170,7 @@ namespace Parsek.Tests
         public void RcsShowcaseRecordings_BuildExpectedShape()
         {
             var recordings = RcsShowcaseRecordings(baseUT: 17000);
-            Assert.Equal(3, recordings.Length);
+            Assert.Equal(5, recordings.Length);
 
             var first = recordings[0].Build();
             Assert.Equal("Part Showcase - RCS RV-105", first.GetValue("vesselName"));
@@ -2135,7 +2189,7 @@ namespace Parsek.Tests
             Assert.Equal("RCSBlock.v2", ghost.GetNodes("PART")[0].GetValue("name"));
             Assert.Equal(ghost.GetNodes("PART")[0].GetValue("persistentId"), events[0].GetValue("pid"));
 
-            var names = new[] { "RCSBlock.v2", "RCSblock.01.small", "RCSLinearSmall" };
+            var names = new[] { "RCSBlock.v2", "RCSblock.01.small", "RCSLinearSmall", "linearRcs", "vernierEngine" };
             for (int i = 0; i < recordings.Length; i++)
             {
                 var g = recordings[i].Build().GetNode("GHOST_VISUAL_SNAPSHOT");
@@ -2688,7 +2742,7 @@ namespace Parsek.Tests
                         $"Duplicate position in '{rec.GetValue("vesselName")}': {key}");
                 }
             }
-            Assert.Equal(185, positions.Count); // 6 + 18 + 7 + 11 + 3 + 2 + 3 + 5 + 2 + 2 + 8 + 2 + 5 + 14 + 29 + 21 + 1 + 3 + 24 + 6 + 13
+            Assert.Equal(192, positions.Count); // 10 + 18 + 8 + 11 + 3 + 2 + 5 + 5 + 2 + 2 + 8 + 2 + 5 + 14 + 29 + 21 + 1 + 3 + 24 + 6 + 13
         }
 
         [Fact]
@@ -3300,6 +3354,10 @@ namespace Parsek.Tests
                     Assert.Contains("vesselName = Part Showcase - Light - Spot v1", content);
                     Assert.Contains("vesselName = Part Showcase - Light - Ground Small v1", content);
                     Assert.Contains("vesselName = Part Showcase - Light - Ground Stand v1", content);
+                    Assert.Contains("vesselName = Part Showcase - Light - Spot Mk1", content);
+                    Assert.Contains("vesselName = Part Showcase - Light - Spot Mk1 v2", content);
+                    Assert.Contains("vesselName = Part Showcase - Light - Spot Mk2", content);
+                    Assert.Contains("vesselName = Part Showcase - Light - Spot Mk2 v2", content);
                     Assert.Contains("vesselName = Part Showcase - Solar Tracking", content);
                     Assert.Contains("vesselName = Part Showcase - Solar Large", content);
                     Assert.Contains("vesselName = Part Showcase - Solar Radial XL", content);
@@ -3322,6 +3380,7 @@ namespace Parsek.Tests
                     Assert.Contains("vesselName = Part Showcase - Gear Small", content);
                     Assert.Contains("vesselName = Part Showcase - Gear Medium", content);
                     Assert.Contains("vesselName = Part Showcase - Gear Large", content);
+                    Assert.Contains("vesselName = Part Showcase - Gear Extra Large", content);
                     Assert.Contains("vesselName = Part Showcase - Landing Leg LT-1", content);
                     Assert.Contains("vesselName = Part Showcase - Landing Leg LT-2", content);
                     Assert.Contains("vesselName = Part Showcase - Landing Leg LT-05", content);
@@ -3344,6 +3403,8 @@ namespace Parsek.Tests
                     Assert.Contains("vesselName = Part Showcase - RCS RV-105", content);
                     Assert.Contains("vesselName = Part Showcase - RCS RV-1X", content);
                     Assert.Contains("vesselName = Part Showcase - RCS Linear", content);
+                    Assert.Contains("vesselName = Part Showcase - RCS Linear Port", content);
+                    Assert.Contains("vesselName = Part Showcase - RCS Vernor", content);
                     Assert.Contains("vesselName = Part Showcase - Fairing Size 1", content);
                     Assert.Contains("vesselName = Part Showcase - Fairing Size 1.5", content);
                     Assert.Contains("vesselName = Part Showcase - Fairing Size 2", content);
@@ -3510,8 +3571,8 @@ namespace Parsek.Tests
                     $"Expected Parsek/Recordings directory at {recordingsDir}");
 
                 string[] precFiles = Directory.GetFiles(recordingsDir, "*.prec");
-                Assert.True(precFiles.Length >= 178,
-                    $"Expected at least 178 .prec files (8 baseline + 6 lights + 18 deployables + 7 gear + 11 cargo + 3 engines + 2 ladders + 3 RCS + 5 fairings + 2 extra radiators + 2 drills + 8 deployed science + 2 animation-group + 5 parachutes + 14 special deploy animations + 29 jettison showcases + 21 robotics + 1 aero-surface + 3 robot-arm-scanner + 24 control-surface + 6 wheel-dynamics + 13 animate-heat + 1 inventory-placement + 3 board-chain + 2 walk-chain), found {precFiles.Length}");
+                Assert.True(precFiles.Length >= 185,
+                    $"Expected at least 185 .prec files (8 baseline + 10 lights + 18 deployables + 8 gear + 11 cargo + 3 engines + 2 ladders + 5 RCS + 5 fairings + 2 extra radiators + 2 drills + 8 deployed science + 2 animation-group + 5 parachutes + 14 special deploy animations + 29 jettison showcases + 21 robotics + 1 aero-surface + 3 robot-arm-scanner + 24 control-surface + 6 wheel-dynamics + 13 animate-heat + 1 inventory-placement + 3 board-chain + 2 walk-chain), found {precFiles.Length}");
             }
         }
 

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -30,6 +30,8 @@ namespace Parsek
         // Part event tracking
         private Dictionary<uint, int> parachuteStates = new Dictionary<uint, int>(); // 0=stowed, 1=semi, 2=deployed
         private HashSet<uint> jettisonedShrouds = new HashSet<uint>();
+        private Dictionary<ulong, string> jettisonNameRawCache = new Dictionary<ulong, string>();
+        private Dictionary<ulong, string[]> parsedJettisonNamesCache = new Dictionary<ulong, string[]>();
         private HashSet<uint> extendedDeployables = new HashSet<uint>();
         private HashSet<uint> lightsOn = new HashSet<uint>();
         private HashSet<uint> blinkingLights = new HashSet<uint>();
@@ -293,6 +295,43 @@ namespace Parsek
             return null;
         }
 
+        private string[] GetCachedJettisonNames(ulong moduleKey, string rawNames)
+        {
+            rawNames = rawNames ?? string.Empty;
+            string cachedRaw;
+            if (jettisonNameRawCache.TryGetValue(moduleKey, out cachedRaw) &&
+                string.Equals(cachedRaw, rawNames, StringComparison.Ordinal) &&
+                parsedJettisonNamesCache.TryGetValue(moduleKey, out string[] cachedNames))
+            {
+                return cachedNames;
+            }
+
+            string[] parsedNames = ParseJettisonNames(rawNames);
+            jettisonNameRawCache[moduleKey] = rawNames;
+            parsedJettisonNamesCache[moduleKey] = parsedNames;
+            return parsedNames;
+        }
+
+        private static string[] ParseJettisonNames(string rawNames)
+        {
+            if (string.IsNullOrWhiteSpace(rawNames))
+                return Array.Empty<string>();
+
+            string[] split = rawNames.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+            if (split.Length == 0)
+                return Array.Empty<string>();
+
+            var cleaned = new List<string>(split.Length);
+            for (int i = 0; i < split.Length; i++)
+            {
+                string name = split[i].Trim();
+                if (!string.IsNullOrEmpty(name))
+                    cleaned.Add(name);
+            }
+
+            return cleaned.Count > 0 ? cleaned.ToArray() : Array.Empty<string>();
+        }
+
         private void CheckJettisonState(Vessel v)
         {
             if (v == null || v.parts == null) return;
@@ -305,11 +344,14 @@ namespace Parsek
 
                 bool hasJettisonModule = false;
                 bool isJettisoned = false;
+                int jettisonModuleIndex = 0;
                 for (int m = 0; m < p.Modules.Count; m++)
                 {
                     var jettison = p.Modules[m] as ModuleJettison;
                     if (jettison == null) continue;
                     hasJettisonModule = true;
+                    ulong moduleKey = EncodeEngineKey(p.persistentId, jettisonModuleIndex);
+                    jettisonModuleIndex++;
 
                     // Primary state flag.
                     if (jettison.isJettisoned)
@@ -324,15 +366,10 @@ namespace Parsek
                     if (string.IsNullOrWhiteSpace(jettisonNames))
                         continue;
 
-                    string[] names = jettisonNames.Split(
-                        new[] { ',' }, System.StringSplitOptions.RemoveEmptyEntries);
+                    string[] names = GetCachedJettisonNames(moduleKey, jettisonNames);
                     for (int n = 0; n < names.Length; n++)
                     {
-                        string jettisonName = names[n].Trim();
-                        if (string.IsNullOrEmpty(jettisonName))
-                            continue;
-
-                        Transform jt = p.FindModelTransform(jettisonName);
+                        Transform jt = p.FindModelTransform(names[n]);
                         if (jt != null && !jt.gameObject.activeInHierarchy)
                         {
                             isJettisoned = true;
@@ -2178,7 +2215,7 @@ namespace Parsek
                         if (shroudEvt.HasValue)
                         {
                             PartEvents.Add(shroudEvt.Value);
-                            ParsekLog.Log($"Part event: {shroudEvt.Value.eventType} '{shroudEvt.Value.partName}' " +
+                            ParsekLog.Info("Recorder", $"Part event: {shroudEvt.Value.eventType} '{shroudEvt.Value.partName}' " +
                                 $"pid={shroudEvt.Value.partPersistentId} (engine-ignite fallback)");
                         }
                     }
@@ -2909,6 +2946,8 @@ namespace Parsek
             PartEvents.Clear();
             parachuteStates.Clear();
             jettisonedShrouds.Clear();
+            jettisonNameRawCache.Clear();
+            parsedJettisonNamesCache.Clear();
             extendedDeployables.Clear();
             lightsOn.Clear();
             blinkingLights.Clear();

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -3433,6 +3433,15 @@ namespace Parsek
             Patches.PhysicsFramePatch.ActiveRecorder = null;
             UnsubscribePartEvents();
             IsRecording = false;
+            PartEvents.Sort((a, b) => a.ut.CompareTo(b.ut));
+
+            double duration = Recording.Count > 0
+                ? Recording[Recording.Count - 1].ut - Recording[0].ut
+                : 0;
+
+            // Keep stop-line contract identical to normal StopRecording so live
+            // KSP.log validation does not require a manual in-flight stop.
+            ParsekLog.Info("Recorder", $"Recording stopped. {Recording.Count} points, {OrbitSegments.Count} orbit segments over {duration:F1}s");
             ParsekLog.Info("Recorder", "Auto-stopped recording due to scene change");
         }
 

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -261,11 +261,50 @@ namespace Parsek
                 Part p = v.parts[i];
                 if (p == null) continue;
 
-                var jettison = p.FindModuleImplementing<ModuleJettison>();
-                if (jettison == null) continue;
+                bool hasJettisonModule = false;
+                bool isJettisoned = false;
+                for (int m = 0; m < p.Modules.Count; m++)
+                {
+                    var jettison = p.Modules[m] as ModuleJettison;
+                    if (jettison == null) continue;
+                    hasJettisonModule = true;
+
+                    // Primary state flag.
+                    if (jettison.isJettisoned)
+                    {
+                        isJettisoned = true;
+                        break;
+                    }
+
+                    // Fallback for parts where the module flag may lag/never set:
+                    // if any configured jettison object is already hidden, treat as jettisoned.
+                    string jettisonNames = jettison.jettisonName;
+                    if (string.IsNullOrWhiteSpace(jettisonNames))
+                        continue;
+
+                    string[] names = jettisonNames.Split(
+                        new[] { ',' }, System.StringSplitOptions.RemoveEmptyEntries);
+                    for (int n = 0; n < names.Length; n++)
+                    {
+                        string jettisonName = names[n].Trim();
+                        if (string.IsNullOrEmpty(jettisonName))
+                            continue;
+
+                        Transform jt = p.FindModelTransform(jettisonName);
+                        if (jt != null && !jt.gameObject.activeInHierarchy)
+                        {
+                            isJettisoned = true;
+                            break;
+                        }
+                    }
+                    if (isJettisoned)
+                        break;
+                }
+
+                if (!hasJettisonModule) continue;
 
                 var evt = CheckJettisonTransition(
-                    p.persistentId, p.partInfo?.name ?? "unknown", jettison.isJettisoned, jettisonedShrouds, ut);
+                    p.persistentId, p.partInfo?.name ?? "unknown", isJettisoned, jettisonedShrouds, ut);
                 if (evt.HasValue)
                 {
                     PartEvents.Add(evt.Value);

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -2120,6 +2120,26 @@ namespace Parsek
                     PartEvents.Add(events[e]);
                     ParsekLog.Log($"Part event: {events[e].eventType} '{events[e].partName}' " +
                         $"pid={events[e].partPersistentId} midx={events[e].moduleIndex} val={events[e].value:F2}");
+
+                    // Some engines with ModuleJettison (e.g. Mainsail/Skipper/Vector) can
+                    // visually drop covers on ignition even when isJettisoned polling lags.
+                    // Emit a one-shot shroud event on ignition as a reliable fallback.
+                    if (events[e].eventType == PartEventType.EngineIgnited &&
+                        part.FindModuleImplementing<ModuleJettison>() != null)
+                    {
+                        var shroudEvt = CheckJettisonTransition(
+                            part.persistentId,
+                            part.partInfo?.name ?? "unknown",
+                            isJettisoned: true,
+                            jettisonedSet: jettisonedShrouds,
+                            ut: ut);
+                        if (shroudEvt.HasValue)
+                        {
+                            PartEvents.Add(shroudEvt.Value);
+                            ParsekLog.Log($"Part event: {shroudEvt.Value.eventType} '{shroudEvt.Value.partName}' " +
+                                $"pid={shroudEvt.Value.partPersistentId} (engine-ignite fallback)");
+                        }
+                    }
                 }
             }
         }

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -137,6 +137,42 @@ namespace Parsek
         private static readonly Color HeatTintColor = new Color(1f, 0.45f, 0.2f, 1f);
         private static readonly Color HeatEmissionColor = new Color(1.5f, 0.6f, 0.15f, 1f);
 
+        // Cache for PREFAB_PARTICLE fx_* prefabs found via FindObjectsOfTypeAll.
+        // Built once per scene (cleared on scene change or when empty).
+        private static Dictionary<string, GameObject> fxPrefabCache;
+
+        /// <summary>
+        /// Find a KSP fx_* prefab by name. These exist as children of legacy parts
+        /// (e.g., fx_exhaustFlame_blue(Clone) on liquidEngine) but are NOT Unity Resources.
+        /// We scan all GameObjects in memory once and cache the results.
+        /// </summary>
+        private static GameObject FindFxPrefab(string prefabName)
+        {
+            if (fxPrefabCache == null)
+            {
+                fxPrefabCache = new Dictionary<string, GameObject>();
+                var allObjects = Resources.FindObjectsOfTypeAll<GameObject>();
+                for (int i = 0; i < allObjects.Length; i++)
+                {
+                    string name = allObjects[i].name;
+                    // Strip "(Clone)" suffix if present
+                    if (name.EndsWith("(Clone)"))
+                        name = name.Substring(0, name.Length - 7);
+                    // Only cache fx_* objects that have a ParticleSystem
+                    if (name.StartsWith("fx_") && !fxPrefabCache.ContainsKey(name)
+                        && allObjects[i].GetComponentInChildren<ParticleSystem>() != null)
+                    {
+                        fxPrefabCache[name] = allObjects[i];
+                    }
+                }
+                ParsekLog.Log($"  FX prefab cache built: {fxPrefabCache.Count} entries");
+            }
+
+            GameObject result;
+            fxPrefabCache.TryGetValue(prefabName, out result);
+            return result;
+        }
+
         internal static GameObject BuildTimelineGhostFromSnapshot(
             RecordingStore.Recording rec, string rootName,
             out List<ParachuteGhostInfo> parachuteInfos,
@@ -1566,8 +1602,7 @@ namespace Parsek
                 // Scan EFFECTS for particle FX entries (MODEL_MULTI_PARTICLE and PREFAB_PARTICLE)
                 var fxTransformNames = new List<string>();
                 var fxModelNames = new List<string>();
-                var prefabFxNames = new List<string>();
-                var prefabTransformNames = new List<string>();
+                var prefabFxEntries = new List<(string prefabName, string transformName, Vector3 localOffset, Quaternion localRotation)>();
                 FloatCurve emissionCurve = null;
                 FloatCurve speedCurve = null;
 
@@ -1627,13 +1662,39 @@ namespace Parsek
                             if (lower.Contains("flameout") || lower.Contains("sparks") || lower.Contains("debris"))
                                 continue;
 
-                            prefabFxNames.Add(prefabName);
-                            prefabTransformNames.Add(transformName);
+                            // Parse localOffset (comma-separated x,y,z)
+                            Vector3 localOffset = Vector3.zero;
+                            string offsetStr = ppNodes[pp].GetValue("localOffset");
+                            if (!string.IsNullOrEmpty(offsetStr))
+                            {
+                                string[] parts = offsetStr.Split(',');
+                                if (parts.Length >= 3 &&
+                                    float.TryParse(parts[0].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out float ox) &&
+                                    float.TryParse(parts[1].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out float oy) &&
+                                    float.TryParse(parts[2].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out float oz))
+                                    localOffset = new Vector3(ox, oy, oz);
+                            }
+
+                            // Parse localRotation (x,y,z,angle format — axis-angle, not quaternion)
+                            Quaternion localRot = Quaternion.identity;
+                            string rotStr = ppNodes[pp].GetValue("localRotation");
+                            if (!string.IsNullOrEmpty(rotStr))
+                            {
+                                string[] parts = rotStr.Split(',');
+                                if (parts.Length >= 4 &&
+                                    float.TryParse(parts[0].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out float rx) &&
+                                    float.TryParse(parts[1].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out float ry) &&
+                                    float.TryParse(parts[2].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out float rz) &&
+                                    float.TryParse(parts[3].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out float angle))
+                                    localRot = Quaternion.AngleAxis(angle, new Vector3(rx, ry, rz));
+                            }
+
+                            prefabFxEntries.Add((prefabName, transformName, localOffset, localRot));
                         }
                     }
                 }
 
-                if (fxTransformNames.Count == 0 && prefabFxNames.Count == 0)
+                if (fxTransformNames.Count == 0 && prefabFxEntries.Count == 0)
                 {
                     // No EFFECTS node, or EFFECTS has no particle entries (e.g. Mainsail: AUDIO only).
                     // Fall through to legacy fx_* child search.
@@ -1752,13 +1813,12 @@ namespace Parsek
                 }
 
                 // Process PREFAB_PARTICLE entries (Spark, Twitch, Pug, Juno, Wheesley, Goliath)
-                for (int f = 0; f < prefabFxNames.Count; f++)
+                for (int f = 0; f < prefabFxEntries.Count; f++)
                 {
-                    string prefabName = prefabFxNames[f];
-                    string transformName = prefabTransformNames[f];
+                    var (prefabName, transformName, localOffset, localRot) = prefabFxEntries[f];
 
-                    // Load the Unity prefab by resource name
-                    GameObject fxPrefab = Resources.Load<GameObject>(prefabName);
+                    // Find the fx_* prefab in memory (children of legacy parts, not Unity Resources)
+                    GameObject fxPrefab = FindFxPrefab(prefabName);
                     if (fxPrefab == null)
                     {
                         ParsekLog.Log($"    Engine FX prefab not found: '{prefabName}' for '{partName}'");
@@ -1788,11 +1848,11 @@ namespace Parsek
                             ghostFxParent = fxHolder.transform;
                         }
 
-                        // Clone the prefab
+                        // Clone the prefab and apply localOffset/localRotation from config
                         GameObject fxInstance = Object.Instantiate(fxPrefab);
                         fxInstance.transform.SetParent(ghostFxParent, false);
-                        fxInstance.transform.localPosition = Vector3.zero;
-                        fxInstance.transform.localRotation = Quaternion.identity;
+                        fxInstance.transform.localPosition = localOffset;
+                        fxInstance.transform.localRotation = localRot;
 
                         // SmokeTrailControl expects real vessel/part state — destroy it on the ghost
                         var smokeTrail = fxInstance.GetComponent("SmokeTrailControl");

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -1562,10 +1562,81 @@ namespace Parsek
                 }
 
                 ConfigNode effectsNode = partConfig.GetNode("EFFECTS");
-                if (effectsNode == null)
+
+                // Scan EFFECTS for particle FX entries (MODEL_MULTI_PARTICLE and PREFAB_PARTICLE)
+                var fxTransformNames = new List<string>();
+                var fxModelNames = new List<string>();
+                var prefabFxNames = new List<string>();
+                var prefabTransformNames = new List<string>();
+                FloatCurve emissionCurve = null;
+                FloatCurve speedCurve = null;
+
+                if (effectsNode != null)
                 {
-                    // Legacy FX fallback: stock early-career parts (Flea SRB, LV-T30, etc.)
-                    // use fx_* prefab children instead of modern EFFECTS configs.
+                    ConfigNode[] effectGroups = effectsNode.GetNodes();
+
+                    // Scan for MODEL_MULTI_PARTICLE / MODEL_MULTI_PARTICLE_PERSIST
+                    for (int g = 0; g < effectGroups.Length; g++)
+                    {
+                        ConfigNode[] mmpNodes = effectGroups[g].GetNodes("MODEL_MULTI_PARTICLE_PERSIST");
+                        if (mmpNodes.Length == 0)
+                            mmpNodes = effectGroups[g].GetNodes("MODEL_MULTI_PARTICLE");
+
+                        for (int mp = 0; mp < mmpNodes.Length; mp++)
+                        {
+                            string transformName = mmpNodes[mp].GetValue("transformName");
+                            string modelName = mmpNodes[mp].GetValue("modelName");
+                            if (!string.IsNullOrEmpty(transformName))
+                            {
+                                fxTransformNames.Add(transformName);
+                                fxModelNames.Add(modelName ?? "");
+
+                                // Parse emission and speed curves from the first entry
+                                if (emissionCurve == null)
+                                {
+                                    ConfigNode emNode = mmpNodes[mp].GetNode("emission");
+                                    if (emNode != null)
+                                    {
+                                        emissionCurve = new FloatCurve();
+                                        emissionCurve.Load(emNode);
+                                    }
+                                    ConfigNode spNode = mmpNodes[mp].GetNode("speed");
+                                    if (spNode != null)
+                                    {
+                                        speedCurve = new FloatCurve();
+                                        speedCurve.Load(spNode);
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    // Scan for PREFAB_PARTICLE (used by Spark, Twitch, Pug, Juno, Wheesley, Goliath)
+                    for (int g = 0; g < effectGroups.Length; g++)
+                    {
+                        ConfigNode[] ppNodes = effectGroups[g].GetNodes("PREFAB_PARTICLE");
+                        for (int pp = 0; pp < ppNodes.Length; pp++)
+                        {
+                            string prefabName = ppNodes[pp].GetValue("prefabName");
+                            string transformName = ppNodes[pp].GetValue("transformName");
+                            if (string.IsNullOrEmpty(prefabName) || string.IsNullOrEmpty(transformName))
+                                continue;
+
+                            // Skip flameout/engage/disengage prefabs — only want running FX
+                            string lower = prefabName.ToLowerInvariant();
+                            if (lower.Contains("flameout") || lower.Contains("sparks") || lower.Contains("debris"))
+                                continue;
+
+                            prefabFxNames.Add(prefabName);
+                            prefabTransformNames.Add(transformName);
+                        }
+                    }
+                }
+
+                if (fxTransformNames.Count == 0 && prefabFxNames.Count == 0)
+                {
+                    // No EFFECTS node, or EFFECTS has no particle entries (e.g. Mainsail: AUDIO only).
+                    // Fall through to legacy fx_* child search.
                     // Only process once per part — legacy FX are shared, not per-module.
                     if (moduleIndex > 0)
                     {
@@ -1617,60 +1688,10 @@ namespace Parsek
                     continue;
                 }
 
-                // Scan all effect groups for MODEL_MULTI_PARTICLE entries.
-                // We can't reliably filter by runningEffectName from a prefab context,
-                // so we collect all particle FX from the EFFECTS node.
-                var fxTransformNames = new List<string>();
-                var fxModelNames = new List<string>();
-                FloatCurve emissionCurve = null;
-                FloatCurve speedCurve = null;
-
-                ConfigNode[] effectGroups = effectsNode.GetNodes();
-
-                for (int g = 0; g < effectGroups.Length; g++)
-                {
-                    ConfigNode[] mmpNodes = effectGroups[g].GetNodes("MODEL_MULTI_PARTICLE_PERSIST");
-                    if (mmpNodes.Length == 0)
-                        mmpNodes = effectGroups[g].GetNodes("MODEL_MULTI_PARTICLE");
-
-                    for (int mp = 0; mp < mmpNodes.Length; mp++)
-                    {
-                        string transformName = mmpNodes[mp].GetValue("transformName");
-                        string modelName = mmpNodes[mp].GetValue("modelName");
-                        if (!string.IsNullOrEmpty(transformName))
-                        {
-                            fxTransformNames.Add(transformName);
-                            fxModelNames.Add(modelName ?? "");
-
-                            // Parse emission and speed curves from the first entry
-                            if (emissionCurve == null)
-                            {
-                                ConfigNode emNode = mmpNodes[mp].GetNode("emission");
-                                if (emNode != null)
-                                {
-                                    emissionCurve = new FloatCurve();
-                                    emissionCurve.Load(emNode);
-                                }
-                                ConfigNode spNode = mmpNodes[mp].GetNode("speed");
-                                if (spNode != null)
-                                {
-                                    speedCurve = new FloatCurve();
-                                    speedCurve.Load(spNode);
-                                }
-                            }
-                        }
-                    }
-                }
-
-                if (fxTransformNames.Count == 0)
-                {
-                    ParsekLog.Log($"    Engine '{partName}' midx={moduleIndex}: no FX transforms found in EFFECTS");
-                    continue;
-                }
-
                 info.emissionCurve = emissionCurve;
                 info.speedCurve = speedCurve;
 
+                // Process MODEL_MULTI_PARTICLE entries
                 for (int f = 0; f < fxTransformNames.Count; f++)
                 {
                     string transformName = fxTransformNames[f];
@@ -1726,6 +1747,67 @@ namespace Parsek
                             {
                                 ParsekLog.Log($"    Engine FX model not found: '{modelName}' for '{partName}'");
                             }
+                        }
+                    }
+                }
+
+                // Process PREFAB_PARTICLE entries (Spark, Twitch, Pug, Juno, Wheesley, Goliath)
+                for (int f = 0; f < prefabFxNames.Count; f++)
+                {
+                    string prefabName = prefabFxNames[f];
+                    string transformName = prefabTransformNames[f];
+
+                    // Load the Unity prefab by resource name
+                    GameObject fxPrefab = Resources.Load<GameObject>(prefabName);
+                    if (fxPrefab == null)
+                    {
+                        ParsekLog.Log($"    Engine FX prefab not found: '{prefabName}' for '{partName}'");
+                        continue;
+                    }
+
+                    // Find the attachment transform(s) on the part
+                    var fxTransforms = FindTransformsRecursive(prefab.transform, transformName);
+                    for (int t = 0; t < fxTransforms.Count; t++)
+                    {
+                        Transform srcFxTransform = fxTransforms[t];
+
+                        // Same transform chain mirroring as MODEL_MULTI_PARTICLE
+                        Transform ghostFxParent;
+                        bool isUnderModel = IsDescendantOf(srcFxTransform, modelRoot);
+                        if (isUnderModel)
+                        {
+                            ghostFxParent = MirrorTransformChain(srcFxTransform, modelRoot, ghostModelNode, cloneMap);
+                        }
+                        else
+                        {
+                            GameObject fxHolder = new GameObject(srcFxTransform.name);
+                            fxHolder.transform.SetParent(ghostModelNode, false);
+                            fxHolder.transform.localPosition = srcFxTransform.localPosition;
+                            fxHolder.transform.localRotation = srcFxTransform.localRotation;
+                            fxHolder.transform.localScale = srcFxTransform.localScale;
+                            ghostFxParent = fxHolder.transform;
+                        }
+
+                        // Clone the prefab
+                        GameObject fxInstance = Object.Instantiate(fxPrefab);
+                        fxInstance.transform.SetParent(ghostFxParent, false);
+                        fxInstance.transform.localPosition = Vector3.zero;
+                        fxInstance.transform.localRotation = Quaternion.identity;
+
+                        // SmokeTrailControl expects real vessel/part state — destroy it on the ghost
+                        var smokeTrail = fxInstance.GetComponent("SmokeTrailControl");
+                        if (smokeTrail != null)
+                            Object.Destroy(smokeTrail);
+
+                        var ps = fxInstance.GetComponentInChildren<ParticleSystem>();
+                        if (ps != null)
+                        {
+                            var emission = ps.emission;
+                            emission.rateOverTimeMultiplier = 0;
+                            ps.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
+                            info.particleSystems.Add(ps);
+                            ParsekLog.Log($"    Engine FX (prefab): '{partName}' midx={moduleIndex} " +
+                                $"transform='{transformName}' prefab='{prefabName}'");
                         }
                     }
                 }

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -2003,6 +2003,228 @@ namespace Parsek
                     }
                 }
 
+                // Ant/Spider configs only define MODEL_MULTI_PARTICLE Monoprop_small in running FX.
+                // Add a Twitch-style prefab flame fallback so they render a visible plume like Twitch.
+                bool isAntOrSpider =
+                    string.Equals(partName, "microEngine.v2", System.StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(partName, "microEngine_v2", System.StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(partName, "microEngine", System.StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(partName, "radialEngineMini.v2", System.StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(partName, "radialEngineMini_v2", System.StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(partName, "radialEngineMini", System.StringComparison.OrdinalIgnoreCase);
+                if (isAntOrSpider)
+                {
+                    bool hasFlamePrefab = false;
+                    for (int i = 0; i < prefabFxEntries.Count; i++)
+                    {
+                        string existingPrefab = NormalizeFxPrefabName(prefabFxEntries[i].prefabName);
+                        if (string.Equals(existingPrefab, "fx_exhaustFlame_yellow_tiny_Z", System.StringComparison.OrdinalIgnoreCase) ||
+                            string.Equals(existingPrefab, "fx_exhaustFlame_yellow_tiny", System.StringComparison.OrdinalIgnoreCase))
+                        {
+                            hasFlamePrefab = true;
+                            break;
+                        }
+                    }
+
+                    if (!hasFlamePrefab)
+                    {
+                        string fallbackTransform = "FXTransform";
+                        if (FindTransformsRecursive(prefab.transform, fallbackTransform).Count == 0)
+                        {
+                            if (engine != null && !string.IsNullOrEmpty(engine.thrustVectorTransformName))
+                                fallbackTransform = engine.thrustVectorTransformName;
+                            else if (FindTransformsRecursive(prefab.transform, "thrustTransform").Count > 0)
+                                fallbackTransform = "thrustTransform";
+                        }
+
+                        Vector3 fallbackOffset = new Vector3(0f, 0f, 0.08f);
+                        for (int i = 0; i < modelFxEntries.Count; i++)
+                        {
+                            if (string.Equals(modelFxEntries[i].transformName, fallbackTransform, System.StringComparison.OrdinalIgnoreCase) ||
+                                string.Equals(modelFxEntries[i].transformName, "FXTransform", System.StringComparison.OrdinalIgnoreCase))
+                            {
+                                fallbackOffset = modelFxEntries[i].localPos;
+                                break;
+                            }
+                        }
+
+                        prefabFxEntries.Add(("fx_exhaustFlame_yellow_tiny_Z", fallbackTransform, fallbackOffset, Quaternion.identity));
+                        ParsekLog.Log($"    Engine FX fallback: '{partName}' midx={moduleIndex} " +
+                            $"added Twitch plume prefab on '{fallbackTransform}' offset={fallbackOffset}");
+                    }
+                }
+
+                // Kickback uses model FX + smoke prefab; add a Thumper-style flame prefab fallback.
+                bool isKickback =
+                    string.Equals(partName, "MassiveBooster", System.StringComparison.OrdinalIgnoreCase);
+                if (isKickback)
+                {
+                    string kickbackSmokeTransform = "thrustTransform";
+                    if (FindTransformsRecursive(prefab.transform, kickbackSmokeTransform).Count == 0)
+                    {
+                        if (FindTransformsRecursive(prefab.transform, "smokePoint").Count > 0)
+                            kickbackSmokeTransform = "smokePoint";
+                        else if (engine != null && !string.IsNullOrEmpty(engine.thrustVectorTransformName))
+                            kickbackSmokeTransform = engine.thrustVectorTransformName;
+                    }
+                    Vector3 kickbackSmokeOffset =
+                        string.Equals(kickbackSmokeTransform, "thrustTransform", System.StringComparison.OrdinalIgnoreCase)
+                        ? (engine != null ? engine.fxOffset : Vector3.zero)
+                        : new Vector3(0f, 0f, 1f);
+
+                    bool replacedSmokePrefab = false;
+                    for (int i = prefabFxEntries.Count - 1; i >= 0; i--)
+                    {
+                        string existingPrefab = NormalizeFxPrefabName(prefabFxEntries[i].prefabName);
+                        if (existingPrefab != null &&
+                            existingPrefab.IndexOf("smoketrail", System.StringComparison.OrdinalIgnoreCase) >= 0)
+                        {
+                            prefabFxEntries.RemoveAt(i);
+                            replacedSmokePrefab = true;
+                        }
+                    }
+                    prefabFxEntries.Add(("fx_smokeTrail_medium", kickbackSmokeTransform, kickbackSmokeOffset, Quaternion.identity));
+                    ParsekLog.Log($"    Engine FX fallback: '{partName}' midx={moduleIndex} " +
+                        $"{(replacedSmokePrefab ? "replaced smoke with" : "added")} Thumper smoke prefab on '{kickbackSmokeTransform}' offset={kickbackSmokeOffset}");
+
+                    bool hasFlamePrefab = false;
+                    for (int i = 0; i < prefabFxEntries.Count; i++)
+                    {
+                        string existingPrefab = NormalizeFxPrefabName(prefabFxEntries[i].prefabName);
+                        if (existingPrefab != null && existingPrefab.IndexOf("exhaustflame", System.StringComparison.OrdinalIgnoreCase) >= 0)
+                        {
+                            hasFlamePrefab = true;
+                            break;
+                        }
+                    }
+
+                    if (!hasFlamePrefab)
+                    {
+                        string fallbackTransform = "fxPoint";
+                        if (FindTransformsRecursive(prefab.transform, fallbackTransform).Count == 0)
+                        {
+                            if (engine != null && !string.IsNullOrEmpty(engine.thrustVectorTransformName))
+                                fallbackTransform = engine.thrustVectorTransformName;
+                            else if (FindTransformsRecursive(prefab.transform, "thrustTransform").Count > 0)
+                                fallbackTransform = "thrustTransform";
+                        }
+
+                        Vector3 fallbackOffset = Vector3.zero;
+                        for (int i = 0; i < modelFxEntries.Count; i++)
+                        {
+                            if (string.Equals(modelFxEntries[i].transformName, fallbackTransform, System.StringComparison.OrdinalIgnoreCase))
+                            {
+                                fallbackOffset = modelFxEntries[i].localPos;
+                                break;
+                            }
+                        }
+
+                        prefabFxEntries.Add(("fx_exhaustFlame_yellow", fallbackTransform, fallbackOffset, Quaternion.identity));
+                        ParsekLog.Log($"    Engine FX fallback: '{partName}' midx={moduleIndex} " +
+                            $"added Thumper plume prefab on '{fallbackTransform}' offset={fallbackOffset}");
+                    }
+                }
+
+                // Puff (omsEngine) often renders only Monoprop_big model FX; add Thud-style blue flame.
+                bool isPuff =
+                    string.Equals(partName, "omsEngine", System.StringComparison.OrdinalIgnoreCase);
+                if (isPuff)
+                {
+                    bool hasFlamePrefab = false;
+                    for (int i = 0; i < prefabFxEntries.Count; i++)
+                    {
+                        string existingPrefab = NormalizeFxPrefabName(prefabFxEntries[i].prefabName);
+                        if (existingPrefab != null && existingPrefab.IndexOf("exhaustflame", System.StringComparison.OrdinalIgnoreCase) >= 0)
+                        {
+                            hasFlamePrefab = true;
+                            break;
+                        }
+                    }
+
+                    if (!hasFlamePrefab)
+                    {
+                        string fallbackTransform = "FXTransform";
+                        if (FindTransformsRecursive(prefab.transform, fallbackTransform).Count == 0)
+                        {
+                            if (engine != null && !string.IsNullOrEmpty(engine.thrustVectorTransformName))
+                                fallbackTransform = engine.thrustVectorTransformName;
+                            else if (FindTransformsRecursive(prefab.transform, "thrustTransform").Count > 0)
+                                fallbackTransform = "thrustTransform";
+                        }
+
+                        Vector3 fallbackOffset = new Vector3(0f, 0f, 0.12f);
+                        for (int i = 0; i < modelFxEntries.Count; i++)
+                        {
+                            if (string.Equals(modelFxEntries[i].transformName, fallbackTransform, System.StringComparison.OrdinalIgnoreCase) ||
+                                string.Equals(modelFxEntries[i].transformName, "FXTransform", System.StringComparison.OrdinalIgnoreCase))
+                            {
+                                fallbackOffset = modelFxEntries[i].localPos;
+                                break;
+                            }
+                        }
+
+                        prefabFxEntries.Add(("fx_exhaustFlame_blue_small", fallbackTransform, fallbackOffset, Quaternion.identity));
+                        ParsekLog.Log($"    Engine FX fallback: '{partName}' midx={moduleIndex} " +
+                            $"added Thud plume prefab on '{fallbackTransform}' offset={fallbackOffset}");
+                    }
+                }
+
+                // Rhino/Mammoth/Twin-Boar can show smoke without a visible core flame in ghost playback.
+                // Add a white flame prefab fallback used by stock medium/large plume setups.
+                bool isHeavyLargeEngine =
+                    string.Equals(partName, "Size3AdvancedEngine", System.StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(partName, "Size3EngineCluster", System.StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(partName, "Size2LFB.v2", System.StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(partName, "Size2LFB_v2", System.StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(partName, "Size2LFB", System.StringComparison.OrdinalIgnoreCase);
+                if (isHeavyLargeEngine)
+                {
+                    bool hasFlamePrefab = false;
+                    for (int i = 0; i < prefabFxEntries.Count; i++)
+                    {
+                        string existingPrefab = NormalizeFxPrefabName(prefabFxEntries[i].prefabName);
+                        if (existingPrefab != null && existingPrefab.IndexOf("exhaustflame", System.StringComparison.OrdinalIgnoreCase) >= 0)
+                        {
+                            hasFlamePrefab = true;
+                            break;
+                        }
+                    }
+
+                    if (!hasFlamePrefab)
+                    {
+                        string fallbackTransform = "thrustTransform";
+                        if (string.Equals(partName, "Size3AdvancedEngine", System.StringComparison.OrdinalIgnoreCase))
+                            fallbackTransform = "fxPoint";
+
+                        if (FindTransformsRecursive(prefab.transform, fallbackTransform).Count == 0)
+                        {
+                            if (engine != null && !string.IsNullOrEmpty(engine.thrustVectorTransformName))
+                                fallbackTransform = engine.thrustVectorTransformName;
+                            else if (FindTransformsRecursive(prefab.transform, "fxPoint").Count > 0)
+                                fallbackTransform = "fxPoint";
+                            else if (FindTransformsRecursive(prefab.transform, "thrustTransform").Count > 0)
+                                fallbackTransform = "thrustTransform";
+                        }
+
+                        Vector3 fallbackOffset = Vector3.zero;
+                        for (int i = 0; i < modelFxEntries.Count; i++)
+                        {
+                            if (string.Equals(modelFxEntries[i].transformName, fallbackTransform, System.StringComparison.OrdinalIgnoreCase))
+                            {
+                                fallbackOffset = modelFxEntries[i].localPos;
+                                break;
+                            }
+                        }
+
+                        // White flame prefab is authored in a Y-up frame; on these thrust/fx transforms
+                        // it needs a -90deg X adjustment to align with nozzle direction.
+                        Quaternion fallbackRotation = Quaternion.Euler(-90f, 0f, 0f);
+                        prefabFxEntries.Add(("fx_exhaustFlame_white", fallbackTransform, fallbackOffset, fallbackRotation));
+                        ParsekLog.Log($"    Engine FX fallback: '{partName}' midx={moduleIndex} " +
+                            $"added white flame prefab on '{fallbackTransform}' offset={fallbackOffset} rot={fallbackRotation.eulerAngles}");
+                    }
+                }
+
                 if (modelFxEntries.Count == 0 && prefabFxEntries.Count == 0)
                 {
                     // No EFFECTS node, or EFFECTS has no particle entries (e.g. Mainsail: AUDIO only).

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -2225,6 +2225,58 @@ namespace Parsek
                     }
                 }
 
+                // Vector (SSME) can look underpowered with only blue_small + model flame.
+                // Add a Skipper-style blue flame core on the same transform as its stock blue_small prefab.
+                bool isVector =
+                    string.Equals(partName, "SSME", System.StringComparison.OrdinalIgnoreCase);
+                if (isVector)
+                {
+                    bool hasSkipperStyleFlame = false;
+                    for (int i = 0; i < prefabFxEntries.Count; i++)
+                    {
+                        string existingPrefab = NormalizeFxPrefabName(prefabFxEntries[i].prefabName);
+                        if (string.Equals(existingPrefab, "fx_exhaustFlame_blue", System.StringComparison.OrdinalIgnoreCase))
+                        {
+                            hasSkipperStyleFlame = true;
+                            break;
+                        }
+                    }
+
+                    if (!hasSkipperStyleFlame)
+                    {
+                        string fallbackTransform = "thrustTransformYup";
+                        Vector3 fallbackOffset = Vector3.zero;
+                        Quaternion fallbackRotation = Quaternion.identity;
+
+                        bool copiedFromExistingBlueSmall = false;
+                        for (int i = 0; i < prefabFxEntries.Count; i++)
+                        {
+                            string existingPrefab = NormalizeFxPrefabName(prefabFxEntries[i].prefabName);
+                            if (string.Equals(existingPrefab, "fx_exhaustFlame_blue_small", System.StringComparison.OrdinalIgnoreCase))
+                            {
+                                fallbackTransform = prefabFxEntries[i].transformName;
+                                fallbackOffset = prefabFxEntries[i].localOffset;
+                                fallbackRotation = prefabFxEntries[i].localRotation;
+                                copiedFromExistingBlueSmall = true;
+                                break;
+                            }
+                        }
+
+                        if (!copiedFromExistingBlueSmall &&
+                            FindTransformsRecursive(prefab.transform, fallbackTransform).Count == 0)
+                        {
+                            if (FindTransformsRecursive(prefab.transform, "thrustTransform").Count > 0)
+                                fallbackTransform = "thrustTransform";
+                            else if (engine != null && !string.IsNullOrEmpty(engine.thrustVectorTransformName))
+                                fallbackTransform = engine.thrustVectorTransformName;
+                        }
+
+                        prefabFxEntries.Add(("fx_exhaustFlame_blue", fallbackTransform, fallbackOffset, fallbackRotation));
+                        ParsekLog.Log($"    Engine FX fallback: '{partName}' midx={moduleIndex} " +
+                            $"added Skipper-style blue flame prefab on '{fallbackTransform}' offset={fallbackOffset} rot={fallbackRotation.eulerAngles}");
+                    }
+                }
+
                 if (modelFxEntries.Count == 0 && prefabFxEntries.Count == 0)
                 {
                     // No EFFECTS node, or EFFECTS has no particle entries (e.g. Mainsail: AUDIO only).

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -2070,95 +2070,62 @@ namespace Parsek
                     }
                 }
 
-                // Kickback uses model FX + smoke prefab; add a Thumper-style flame prefab fallback.
+                // Kickback: force Thumper-style FX so smoke/flame match solidBooster1-1 visuals.
+                // This avoids the stock veryLarge/large smoke prefab orientation mismatch.
                 bool isKickback =
                     string.Equals(partName, "MassiveBooster", System.StringComparison.OrdinalIgnoreCase);
                 if (isKickback)
                 {
-                    string kickbackSmokeTransform = "smokePoint";
-                    Vector3 kickbackSmokeOffset = new Vector3(0f, 0f, 1f);
-                    Quaternion kickbackSmokeRotation = Quaternion.identity;
-                    bool kickbackSmokeHasLocalRotation = false;
-                    bool copiedSmokeAnchor = false;
+                    int removedKickbackModelFx = modelFxEntries.Count;
+                    modelFxEntries.Clear();
 
-                    bool replacedSmokePrefab = false;
+                    int removedKickbackPrefabs = 0;
                     for (int i = prefabFxEntries.Count - 1; i >= 0; i--)
                     {
                         string existingPrefab = NormalizeFxPrefabName(prefabFxEntries[i].prefabName);
-                        if (existingPrefab != null &&
-                            existingPrefab.IndexOf("smoketrail", System.StringComparison.OrdinalIgnoreCase) >= 0)
+                        if (existingPrefab == null)
+                            continue;
+
+                        if (existingPrefab.IndexOf("smoketrail", System.StringComparison.OrdinalIgnoreCase) >= 0)
                         {
-                            if (!copiedSmokeAnchor)
-                            {
-                                kickbackSmokeTransform = prefabFxEntries[i].transformName;
-                                kickbackSmokeOffset = prefabFxEntries[i].localOffset;
-                                kickbackSmokeRotation = prefabFxEntries[i].localRotation;
-                                kickbackSmokeHasLocalRotation = prefabFxEntries[i].hasLocalRotation;
-                                copiedSmokeAnchor = true;
-                            }
                             prefabFxEntries.RemoveAt(i);
-                            replacedSmokePrefab = true;
+                            removedKickbackPrefabs++;
+                            continue;
                         }
-                    }
 
-                    if (!copiedSmokeAnchor)
-                    {
-                        if (FindTransformsRecursive(prefab.transform, kickbackSmokeTransform).Count == 0)
+                        if (existingPrefab.IndexOf("exhaustflame", System.StringComparison.OrdinalIgnoreCase) >= 0)
                         {
-                            if (FindTransformsRecursive(prefab.transform, "thrustTransform").Count > 0)
-                            {
-                                kickbackSmokeTransform = "thrustTransform";
-                                kickbackSmokeOffset = engine != null ? engine.fxOffset : Vector3.zero;
-                            }
-                            else if (engine != null && !string.IsNullOrEmpty(engine.thrustVectorTransformName))
-                            {
-                                kickbackSmokeTransform = engine.thrustVectorTransformName;
-                                kickbackSmokeOffset = engine.fxOffset;
-                            }
+                            prefabFxEntries.RemoveAt(i);
+                            removedKickbackPrefabs++;
                         }
                     }
 
-                    prefabFxEntries.Add(("fx_smokeTrail_medium", kickbackSmokeTransform, kickbackSmokeOffset, kickbackSmokeRotation, kickbackSmokeHasLocalRotation));
+                    string kickbackTransform = "thrustTransform";
+                    if (engine != null && !string.IsNullOrEmpty(engine.thrustVectorTransformName))
+                        kickbackTransform = engine.thrustVectorTransformName;
+                    if (FindTransformsRecursive(prefab.transform, kickbackTransform).Count == 0)
+                    {
+                        if (FindTransformsRecursive(prefab.transform, "thrustTransform").Count > 0)
+                            kickbackTransform = "thrustTransform";
+                        else if (FindTransformsRecursive(prefab.transform, "smokePoint").Count > 0)
+                            kickbackTransform = "smokePoint";
+                        else if (FindTransformsRecursive(prefab.transform, "fxPoint").Count > 0)
+                            kickbackTransform = "fxPoint";
+                    }
+
+                    Vector3 kickbackOffset = engine != null ? engine.fxOffset : new Vector3(0f, 0f, 0.35f);
+                    if (kickbackOffset.sqrMagnitude <= 0.000001f)
+                        kickbackOffset = new Vector3(0f, 0f, 0.35f);
+                    Quaternion kickbackThumperLocalRot = Quaternion.Euler(-90f, 0f, 0f);
+
+                    prefabFxEntries.Add(("fx_smokeTrail_medium",
+                        kickbackTransform, kickbackOffset, kickbackThumperLocalRot, true));
+                    prefabFxEntries.Add(("fx_exhaustFlame_yellow",
+                        kickbackTransform, kickbackOffset, kickbackThumperLocalRot, true));
                     ParsekLog.Log($"    Engine FX fallback: '{partName}' midx={moduleIndex} " +
-                        $"{(replacedSmokePrefab ? "replaced smoke with" : "added")} Thumper smoke prefab on '{kickbackSmokeTransform}' " +
-                        $"offset={kickbackSmokeOffset} rot={kickbackSmokeRotation.eulerAngles}");
-
-                    bool hasFlamePrefab = false;
-                    for (int i = 0; i < prefabFxEntries.Count; i++)
-                    {
-                        string existingPrefab = NormalizeFxPrefabName(prefabFxEntries[i].prefabName);
-                        if (existingPrefab != null && existingPrefab.IndexOf("exhaustflame", System.StringComparison.OrdinalIgnoreCase) >= 0)
-                        {
-                            hasFlamePrefab = true;
-                            break;
-                        }
-                    }
-
-                    if (!hasFlamePrefab)
-                    {
-                        string fallbackTransform = "fxPoint";
-                        if (FindTransformsRecursive(prefab.transform, fallbackTransform).Count == 0)
-                        {
-                            if (engine != null && !string.IsNullOrEmpty(engine.thrustVectorTransformName))
-                                fallbackTransform = engine.thrustVectorTransformName;
-                            else if (FindTransformsRecursive(prefab.transform, "thrustTransform").Count > 0)
-                                fallbackTransform = "thrustTransform";
-                        }
-
-                        Vector3 fallbackOffset = Vector3.zero;
-                        for (int i = 0; i < modelFxEntries.Count; i++)
-                        {
-                            if (string.Equals(modelFxEntries[i].transformName, fallbackTransform, System.StringComparison.OrdinalIgnoreCase))
-                            {
-                                fallbackOffset = modelFxEntries[i].localPos;
-                                break;
-                            }
-                        }
-
-                        prefabFxEntries.Add(("fx_exhaustFlame_yellow", fallbackTransform, fallbackOffset, Quaternion.identity, false));
-                        ParsekLog.Log($"    Engine FX fallback: '{partName}' midx={moduleIndex} " +
-                            $"added Thumper plume prefab on '{fallbackTransform}' offset={fallbackOffset}");
-                    }
+                        $"forced Thumper-style plume on '{kickbackTransform}' offset={kickbackOffset} " +
+                        $"rot={kickbackThumperLocalRot.eulerAngles} hasRot=true " +
+                        $"(removed MODEL={removedKickbackModelFx}, PREFAB={removedKickbackPrefabs})");
                 }
 
                 // Puff (omsEngine) often renders only Monoprop_big model FX; add Thud-style blue flame.

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -162,6 +162,17 @@ namespace Parsek
                     RebuildFxPrefabCache();
                     fxPrefabCache.TryGetValue(prefabName, out result);
                 }
+                return result;
+            }
+
+            // Fallback: some fx_* prefabs (fx_exhaustFlame_yellow_tiny_Z,
+            // fx_smokeTrail_veryLarge, fx_smokeTrail_aeroSpike) are Unity
+            // built-in Resources in resources.assets, not part prefab children.
+            result = Resources.Load<GameObject>(prefabName);
+            if (result != null)
+            {
+                fxPrefabCache[prefabName] = result;
+                ParsekLog.Log($"  FX prefab loaded from Resources: '{prefabName}'");
             }
             return result;
         }

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -146,7 +146,8 @@ namespace Parsek
             {
                 { "fx_exhaustFlame_yellow_tiny_Z", new[] { "fx_exhaustFlame_yellow_tiny" } },
                 { "fx_smokeTrail_veryLarge", new[] { "fx_smokeTrail_large", "fx_smokeTrail_light" } },
-                { "fx_smokeTrail_aeroSpike", new[] { "fx_smokeTrail_light", "fx_smokeTrail_large" } }
+                // RAPIER's smokePoint frame matches stock large-smoke setups more closely.
+                { "fx_smokeTrail_aeroSpike", new[] { "fx_smokeTrail_large", "fx_smokeTrail_light" } }
             };
         private static readonly Dictionary<string, Vector3> fxModelRotationFallbackEuler =
             new Dictionary<string, Vector3>(System.StringComparer.OrdinalIgnoreCase)
@@ -2059,18 +2060,10 @@ namespace Parsek
                     string.Equals(partName, "MassiveBooster", System.StringComparison.OrdinalIgnoreCase);
                 if (isKickback)
                 {
-                    string kickbackSmokeTransform = "thrustTransform";
-                    if (FindTransformsRecursive(prefab.transform, kickbackSmokeTransform).Count == 0)
-                    {
-                        if (FindTransformsRecursive(prefab.transform, "smokePoint").Count > 0)
-                            kickbackSmokeTransform = "smokePoint";
-                        else if (engine != null && !string.IsNullOrEmpty(engine.thrustVectorTransformName))
-                            kickbackSmokeTransform = engine.thrustVectorTransformName;
-                    }
-                    Vector3 kickbackSmokeOffset =
-                        string.Equals(kickbackSmokeTransform, "thrustTransform", System.StringComparison.OrdinalIgnoreCase)
-                        ? (engine != null ? engine.fxOffset : Vector3.zero)
-                        : new Vector3(0f, 0f, 1f);
+                    string kickbackSmokeTransform = "smokePoint";
+                    Vector3 kickbackSmokeOffset = new Vector3(0f, 0f, 1f);
+                    Quaternion kickbackSmokeRotation = Quaternion.identity;
+                    bool copiedSmokeAnchor = false;
 
                     bool replacedSmokePrefab = false;
                     for (int i = prefabFxEntries.Count - 1; i >= 0; i--)
@@ -2079,13 +2072,39 @@ namespace Parsek
                         if (existingPrefab != null &&
                             existingPrefab.IndexOf("smoketrail", System.StringComparison.OrdinalIgnoreCase) >= 0)
                         {
+                            if (!copiedSmokeAnchor)
+                            {
+                                kickbackSmokeTransform = prefabFxEntries[i].transformName;
+                                kickbackSmokeOffset = prefabFxEntries[i].localOffset;
+                                kickbackSmokeRotation = prefabFxEntries[i].localRotation;
+                                copiedSmokeAnchor = true;
+                            }
                             prefabFxEntries.RemoveAt(i);
                             replacedSmokePrefab = true;
                         }
                     }
-                    prefabFxEntries.Add(("fx_smokeTrail_medium", kickbackSmokeTransform, kickbackSmokeOffset, Quaternion.identity));
+
+                    if (!copiedSmokeAnchor)
+                    {
+                        if (FindTransformsRecursive(prefab.transform, kickbackSmokeTransform).Count == 0)
+                        {
+                            if (FindTransformsRecursive(prefab.transform, "thrustTransform").Count > 0)
+                            {
+                                kickbackSmokeTransform = "thrustTransform";
+                                kickbackSmokeOffset = engine != null ? engine.fxOffset : Vector3.zero;
+                            }
+                            else if (engine != null && !string.IsNullOrEmpty(engine.thrustVectorTransformName))
+                            {
+                                kickbackSmokeTransform = engine.thrustVectorTransformName;
+                                kickbackSmokeOffset = engine.fxOffset;
+                            }
+                        }
+                    }
+
+                    prefabFxEntries.Add(("fx_smokeTrail_medium", kickbackSmokeTransform, kickbackSmokeOffset, kickbackSmokeRotation));
                     ParsekLog.Log($"    Engine FX fallback: '{partName}' midx={moduleIndex} " +
-                        $"{(replacedSmokePrefab ? "replaced smoke with" : "added")} Thumper smoke prefab on '{kickbackSmokeTransform}' offset={kickbackSmokeOffset}");
+                        $"{(replacedSmokePrefab ? "replaced smoke with" : "added")} Thumper smoke prefab on '{kickbackSmokeTransform}' " +
+                        $"offset={kickbackSmokeOffset} rot={kickbackSmokeRotation.eulerAngles}");
 
                     bool hasFlamePrefab = false;
                     for (int i = 0; i < prefabFxEntries.Count; i++)

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -1637,8 +1637,7 @@ namespace Parsek
                 ConfigNode effectsNode = partConfig.GetNode("EFFECTS");
 
                 // Scan EFFECTS for particle FX entries (MODEL_MULTI_PARTICLE and PREFAB_PARTICLE)
-                var fxTransformNames = new List<string>();
-                var fxModelNames = new List<string>();
+                var mmpEntries = new List<(string transformName, string modelName, Vector3 localPos, Quaternion localRot)>();
                 var prefabFxEntries = new List<(string prefabName, string transformName, Vector3 localOffset, Quaternion localRotation)>();
                 FloatCurve emissionCurve = null;
                 FloatCurve speedCurve = null;
@@ -1660,8 +1659,29 @@ namespace Parsek
                             string modelName = mmpNodes[mp].GetValue("modelName");
                             if (!string.IsNullOrEmpty(transformName))
                             {
-                                fxTransformNames.Add(transformName);
-                                fxModelNames.Add(modelName ?? "");
+                                // Parse localPosition from config
+                                Vector3 mmpLocalPos = Vector3.zero;
+                                TryParseVector3(mmpNodes[mp].GetValue("localPosition"), out mmpLocalPos);
+
+                                // Parse localRotation (axis-angle x,y,z,angle)
+                                Quaternion mmpLocalRot = Quaternion.identity;
+                                string mmpRotStr = mmpNodes[mp].GetValue("localRotation");
+                                if (!string.IsNullOrEmpty(mmpRotStr))
+                                {
+                                    string[] rp = mmpRotStr.Split(',');
+                                    if (rp.Length >= 4 &&
+                                        float.TryParse(rp[0].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out float rx) &&
+                                        float.TryParse(rp[1].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out float ry) &&
+                                        float.TryParse(rp[2].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out float rz) &&
+                                        float.TryParse(rp[3].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out float angle))
+                                    {
+                                        var axis = new Vector3(rx, ry, rz);
+                                        if (axis.sqrMagnitude > 0.0001f)
+                                            mmpLocalRot = Quaternion.AngleAxis(angle, axis);
+                                    }
+                                }
+
+                                mmpEntries.Add((transformName, modelName ?? "", mmpLocalPos, mmpLocalRot));
 
                                 // Parse emission and speed curves from the first entry
                                 if (emissionCurve == null)
@@ -1699,18 +1719,12 @@ namespace Parsek
                             if (lower.Contains("flameout") || lower.Contains("sparks") || lower.Contains("debris"))
                                 continue;
 
-                            // Parse localOffset (comma-separated x,y,z)
+                            // Parse localOffset or localPosition (comma-separated x,y,z)
                             Vector3 localOffset = Vector3.zero;
                             string offsetStr = ppNodes[pp].GetValue("localOffset");
-                            if (!string.IsNullOrEmpty(offsetStr))
-                            {
-                                string[] parts = offsetStr.Split(',');
-                                if (parts.Length >= 3 &&
-                                    float.TryParse(parts[0].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out float ox) &&
-                                    float.TryParse(parts[1].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out float oy) &&
-                                    float.TryParse(parts[2].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out float oz))
-                                    localOffset = new Vector3(ox, oy, oz);
-                            }
+                            if (string.IsNullOrEmpty(offsetStr))
+                                offsetStr = ppNodes[pp].GetValue("localPosition");
+                            TryParseVector3(offsetStr, out localOffset);
 
                             // Parse localRotation (x,y,z,angle format — axis-angle, not quaternion)
                             Quaternion localRot = Quaternion.identity;
@@ -1735,7 +1749,7 @@ namespace Parsek
                     }
                 }
 
-                if (fxTransformNames.Count == 0 && prefabFxEntries.Count == 0)
+                if (mmpEntries.Count == 0 && prefabFxEntries.Count == 0)
                 {
                     // No EFFECTS node, or EFFECTS has no particle entries (e.g. Mainsail: AUDIO only).
                     // Fall through to legacy fx_* child search.
@@ -1794,10 +1808,9 @@ namespace Parsek
                 info.speedCurve = speedCurve;
 
                 // Process MODEL_MULTI_PARTICLE entries
-                for (int f = 0; f < fxTransformNames.Count; f++)
+                for (int f = 0; f < mmpEntries.Count; f++)
                 {
-                    string transformName = fxTransformNames[f];
-                    string modelName = fxModelNames[f];
+                    var (transformName, modelName, mmpLocalPos, mmpLocalRot) = mmpEntries[f];
 
                     // Find matching transform(s) in prefab — may be multiple (multi-nozzle engines)
                     var fxTransforms = FindTransformsRecursive(prefab.transform, transformName);
@@ -1832,8 +1845,8 @@ namespace Parsek
                             {
                                 GameObject fxInstance = Object.Instantiate(fxPrefab);
                                 fxInstance.transform.SetParent(ghostFxParent, false);
-                                fxInstance.transform.localPosition = Vector3.zero;
-                                fxInstance.transform.localRotation = Quaternion.identity;
+                                fxInstance.transform.localPosition = mmpLocalPos;
+                                fxInstance.transform.localRotation = mmpLocalRot;
 
                                 var ps = fxInstance.GetComponentInChildren<ParticleSystem>();
                                 if (ps != null)

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -1977,6 +1977,32 @@ namespace Parsek
                         continue;
                     }
 
+                    // Legacy PART-level fx_* entries are driven by thrust transform + fxOffset.
+                    // The child prefab position on part root can be far from nozzle on some parts
+                    // (e.g., Terrier/Swivel), so prefer anchoring to thrust transforms.
+                    var legacyAnchors = new List<Transform>();
+                    if (engine != null && engine.thrustTransforms != null)
+                    {
+                        for (int t = 0; t < engine.thrustTransforms.Count; t++)
+                        {
+                            Transform anchor = engine.thrustTransforms[t];
+                            if (anchor != null && !legacyAnchors.Contains(anchor))
+                                legacyAnchors.Add(anchor);
+                        }
+                    }
+                    if (legacyAnchors.Count == 0 && engine != null &&
+                        !string.IsNullOrEmpty(engine.thrustVectorTransformName))
+                    {
+                        var namedAnchors = FindTransformsRecursive(prefab.transform, engine.thrustVectorTransformName);
+                        for (int t = 0; t < namedAnchors.Count; t++)
+                        {
+                            Transform anchor = namedAnchors[t];
+                            if (anchor != null && !legacyAnchors.Contains(anchor))
+                                legacyAnchors.Add(anchor);
+                        }
+                    }
+                    Vector3 legacyFxOffset = engine != null ? engine.fxOffset : Vector3.zero;
+
                     for (int c = 0; c < prefab.transform.childCount; c++)
                     {
                         Transform child = prefab.transform.GetChild(c);
@@ -1992,26 +2018,66 @@ namespace Parsek
                         var ps = child.GetComponentInChildren<ParticleSystem>(true);
                         if (ps == null) continue;
 
-                        GameObject fxClone = Object.Instantiate(child.gameObject);
-                        fxClone.transform.SetParent(ghostModelNode.parent, false);
-                        fxClone.transform.localPosition = child.localPosition;
-                        fxClone.transform.localRotation = child.localRotation;
-                        fxClone.transform.localScale = child.localScale;
-
-                        // SmokeTrailControl expects real vessel/part state — destroy it on the ghost
-                        var smokeTrail = fxClone.GetComponent("SmokeTrailControl");
-                        if (smokeTrail != null)
-                            Object.Destroy(smokeTrail);
-
-                        int addedSystems = ConfigureGhostEngineParticleSystems(fxClone, info.particleSystems);
-                        if (addedSystems > 0)
+                        int clonesAdded = 0;
+                        if (legacyAnchors.Count > 0)
                         {
-                            ParsekLog.Log($"    Engine FX (legacy): '{partName}' midx={moduleIndex} " +
-                                $"fx='{child.name}' systems={addedSystems}");
+                            for (int t = 0; t < legacyAnchors.Count; t++)
+                            {
+                                Transform srcLegacyAnchor = legacyAnchors[t];
+                                Transform ghostLegacyParent = ResolveGhostFxParent(
+                                    srcLegacyAnchor, prefab.transform, modelRoot, ghostModelNode, cloneMap);
+                                if (ghostLegacyParent == null)
+                                    continue;
+
+                                GameObject fxClone = Object.Instantiate(child.gameObject);
+                                fxClone.transform.SetParent(ghostLegacyParent, false);
+                                fxClone.transform.localPosition = legacyFxOffset;
+                                fxClone.transform.localRotation = child.localRotation;
+                                fxClone.transform.localScale = child.localScale;
+
+                                // SmokeTrailControl expects real vessel/part state — destroy it on the ghost
+                                var smokeTrail = fxClone.GetComponent("SmokeTrailControl");
+                                if (smokeTrail != null)
+                                    Object.Destroy(smokeTrail);
+
+                                int addedSystems = ConfigureGhostEngineParticleSystems(fxClone, info.particleSystems);
+                                if (addedSystems > 0)
+                                {
+                                    clonesAdded++;
+                                    ParsekLog.Log($"    Engine FX (legacy): '{partName}' midx={moduleIndex} " +
+                                        $"fx='{child.name}' anchor='{srcLegacyAnchor.name}' offset={legacyFxOffset} systems={addedSystems}");
+                                }
+                                else
+                                {
+                                    Object.Destroy(fxClone);
+                                }
+                            }
                         }
-                        else
+
+                        if (clonesAdded == 0)
                         {
-                            Object.Destroy(fxClone);
+                            // Fallback for uncommon prefabs where thrust anchors are unavailable.
+                            GameObject fxClone = Object.Instantiate(child.gameObject);
+                            fxClone.transform.SetParent(ghostModelNode.parent, false);
+                            fxClone.transform.localPosition = child.localPosition;
+                            fxClone.transform.localRotation = child.localRotation;
+                            fxClone.transform.localScale = child.localScale;
+
+                            // SmokeTrailControl expects real vessel/part state — destroy it on the ghost
+                            var smokeTrail = fxClone.GetComponent("SmokeTrailControl");
+                            if (smokeTrail != null)
+                                Object.Destroy(smokeTrail);
+
+                            int addedSystems = ConfigureGhostEngineParticleSystems(fxClone, info.particleSystems);
+                            if (addedSystems > 0)
+                            {
+                                ParsekLog.Log($"    Engine FX (legacy): '{partName}' midx={moduleIndex} " +
+                                    $"fx='{child.name}' systems={addedSystems}");
+                            }
+                            else
+                            {
+                                Object.Destroy(fxClone);
+                            }
                         }
                     }
 

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -877,6 +877,42 @@ namespace Parsek
                 $"deltaPos={deltaPos} deltaRot={deltaRot:F3}");
         }
 
+        private static int ConfigureGhostEngineParticleSystems(
+            GameObject fxInstance, List<ParticleSystem> sink)
+        {
+            if (fxInstance == null || sink == null)
+                return 0;
+
+            ParticleSystem[] systems = fxInstance.GetComponentsInChildren<ParticleSystem>(true);
+            int added = 0;
+            for (int i = 0; i < systems.Length; i++)
+            {
+                ParticleSystem ps = systems[i];
+                if (ps == null)
+                    continue;
+
+                var main = ps.main;
+                main.playOnAwake = false;
+                main.prewarm = false;
+
+                var emission = ps.emission;
+                emission.enabled = true;
+                emission.rateOverTimeMultiplier = 0f;
+
+                ps.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
+                ps.Clear(true);
+
+                var renderer = ps.GetComponent<ParticleSystemRenderer>();
+                if (renderer != null)
+                    renderer.enabled = false;
+
+                sink.Add(ps);
+                added++;
+            }
+
+            return added;
+        }
+
         /// <summary>
         /// Create a fake parachute canopy (flattened hemisphere) and parent it to
         /// the ghost part identified by persistentId. Returns the canopy GameObject.
@@ -1812,8 +1848,8 @@ namespace Parsek
 
                 ConfigNode effectsNode = partConfig.GetNode("EFFECTS");
 
-                // Scan EFFECTS for particle FX entries (MODEL_MULTI_PARTICLE and PREFAB_PARTICLE)
-                var mmpEntries = new List<(string transformName, string modelName, Vector3 localPos, Quaternion localRot)>();
+                // Scan EFFECTS for particle FX entries (MODEL_MULTI_PARTICLE, MODEL_PARTICLE, PREFAB_PARTICLE)
+                var modelFxEntries = new List<(string nodeType, string transformName, string modelName, Vector3 localPos, Quaternion localRot)>();
                 var prefabFxEntries = new List<(string prefabName, string transformName, Vector3 localOffset, Quaternion localRotation)>();
                 FloatCurve emissionCurve = null;
                 FloatCurve speedCurve = null;
@@ -1822,57 +1858,62 @@ namespace Parsek
                 {
                     ConfigNode[] effectGroups = effectsNode.GetNodes();
 
-                    // Scan for MODEL_MULTI_PARTICLE / MODEL_MULTI_PARTICLE_PERSIST
+                    // Scan for model FX nodes used by engines.
                     for (int g = 0; g < effectGroups.Length; g++)
                     {
-                        ConfigNode[] mmpNodes = effectGroups[g].GetNodes("MODEL_MULTI_PARTICLE_PERSIST");
-                        if (mmpNodes.Length == 0)
-                            mmpNodes = effectGroups[g].GetNodes("MODEL_MULTI_PARTICLE");
-
-                        for (int mp = 0; mp < mmpNodes.Length; mp++)
+                        string[] modelNodeTypes = { "MODEL_MULTI_PARTICLE_PERSIST", "MODEL_MULTI_PARTICLE", "MODEL_PARTICLE" };
+                        for (int n = 0; n < modelNodeTypes.Length; n++)
                         {
-                            string transformName = mmpNodes[mp].GetValue("transformName");
-                            string modelName = mmpNodes[mp].GetValue("modelName");
-                            if (!string.IsNullOrEmpty(transformName))
+                            string nodeType = modelNodeTypes[n];
+                            ConfigNode[] modelNodes = effectGroups[g].GetNodes(nodeType);
+                            for (int mp = 0; mp < modelNodes.Length; mp++)
                             {
-                                // Parse localPosition from config
-                                Vector3 mmpLocalPos = Vector3.zero;
-                                TryParseVector3(mmpNodes[mp].GetValue("localPosition"), out mmpLocalPos);
-
-                                // Parse localRotation (axis-angle x,y,z,angle)
-                                Quaternion mmpLocalRot = Quaternion.identity;
-                                string mmpRotStr = mmpNodes[mp].GetValue("localRotation");
-                                if (!string.IsNullOrEmpty(mmpRotStr))
+                                string transformName = modelNodes[mp].GetValue("transformName");
+                                string modelName = modelNodes[mp].GetValue("modelName");
+                                if (!string.IsNullOrEmpty(transformName))
                                 {
-                                    string[] rp = mmpRotStr.Split(',');
-                                    if (rp.Length >= 4 &&
-                                        float.TryParse(rp[0].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out float rx) &&
-                                        float.TryParse(rp[1].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out float ry) &&
-                                        float.TryParse(rp[2].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out float rz) &&
-                                        float.TryParse(rp[3].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out float angle))
-                                    {
-                                        var axis = new Vector3(rx, ry, rz);
-                                        if (axis.sqrMagnitude > 0.0001f)
-                                            mmpLocalRot = Quaternion.AngleAxis(angle, axis);
-                                    }
-                                }
+                                    // Parse localPosition/localOffset from config
+                                    Vector3 mmpLocalPos = Vector3.zero;
+                                    string mmpOffsetStr = modelNodes[mp].GetValue("localPosition");
+                                    if (string.IsNullOrEmpty(mmpOffsetStr))
+                                        mmpOffsetStr = modelNodes[mp].GetValue("localOffset");
+                                    TryParseVector3(mmpOffsetStr, out mmpLocalPos);
 
-                                mmpEntries.Add((transformName, modelName ?? "", mmpLocalPos, mmpLocalRot));
-
-                                // Parse emission and speed curves from the first entry
-                                if (emissionCurve == null)
-                                {
-                                    ConfigNode emNode = mmpNodes[mp].GetNode("emission");
-                                    if (emNode != null)
+                                    // Parse localRotation (axis-angle x,y,z,angle)
+                                    Quaternion mmpLocalRot = Quaternion.identity;
+                                    string mmpRotStr = modelNodes[mp].GetValue("localRotation");
+                                    if (!string.IsNullOrEmpty(mmpRotStr))
                                     {
-                                        emissionCurve = new FloatCurve();
-                                        emissionCurve.Load(emNode);
+                                        string[] rp = mmpRotStr.Split(',');
+                                        if (rp.Length >= 4 &&
+                                            float.TryParse(rp[0].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out float rx) &&
+                                            float.TryParse(rp[1].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out float ry) &&
+                                            float.TryParse(rp[2].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out float rz) &&
+                                            float.TryParse(rp[3].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out float angle))
+                                        {
+                                            var axis = new Vector3(rx, ry, rz);
+                                            if (axis.sqrMagnitude > 0.0001f)
+                                                mmpLocalRot = Quaternion.AngleAxis(angle, axis);
+                                        }
                                     }
-                                    ConfigNode spNode = mmpNodes[mp].GetNode("speed");
-                                    if (spNode != null)
+
+                                    modelFxEntries.Add((nodeType, transformName, modelName ?? "", mmpLocalPos, mmpLocalRot));
+
+                                    // Parse emission and speed curves from the first model entry.
+                                    if (emissionCurve == null)
                                     {
-                                        speedCurve = new FloatCurve();
-                                        speedCurve.Load(spNode);
+                                        ConfigNode emNode = modelNodes[mp].GetNode("emission");
+                                        if (emNode != null)
+                                        {
+                                            emissionCurve = new FloatCurve();
+                                            emissionCurve.Load(emNode);
+                                        }
+                                        ConfigNode spNode = modelNodes[mp].GetNode("speed");
+                                        if (spNode != null)
+                                        {
+                                            speedCurve = new FloatCurve();
+                                            speedCurve.Load(spNode);
+                                        }
                                     }
                                 }
                             }
@@ -1925,7 +1966,7 @@ namespace Parsek
                     }
                 }
 
-                if (mmpEntries.Count == 0 && prefabFxEntries.Count == 0)
+                if (modelFxEntries.Count == 0 && prefabFxEntries.Count == 0)
                 {
                     // No EFFECTS node, or EFFECTS has no particle entries (e.g. Mainsail: AUDIO only).
                     // Fall through to legacy fx_* child search.
@@ -1948,7 +1989,7 @@ namespace Parsek
                         if (!childName.Contains("flame") && !childName.Contains("exhaust") && !childName.Contains("smoke"))
                             continue;
 
-                        var ps = child.GetComponentInChildren<ParticleSystem>();
+                        var ps = child.GetComponentInChildren<ParticleSystem>(true);
                         if (ps == null) continue;
 
                         GameObject fxClone = Object.Instantiate(child.gameObject);
@@ -1962,14 +2003,15 @@ namespace Parsek
                         if (smokeTrail != null)
                             Object.Destroy(smokeTrail);
 
-                        var clonedPs = fxClone.GetComponentInChildren<ParticleSystem>();
-                        if (clonedPs != null)
+                        int addedSystems = ConfigureGhostEngineParticleSystems(fxClone, info.particleSystems);
+                        if (addedSystems > 0)
                         {
-                            var emission = clonedPs.emission;
-                            emission.rateOverTimeMultiplier = 0;
-                            clonedPs.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
-                            info.particleSystems.Add(clonedPs);
-                            ParsekLog.Log($"    Engine FX (legacy): '{partName}' midx={moduleIndex} fx='{child.name}'");
+                            ParsekLog.Log($"    Engine FX (legacy): '{partName}' midx={moduleIndex} " +
+                                $"fx='{child.name}' systems={addedSystems}");
+                        }
+                        else
+                        {
+                            Object.Destroy(fxClone);
                         }
                     }
 
@@ -1983,10 +2025,10 @@ namespace Parsek
                 info.emissionCurve = emissionCurve;
                 info.speedCurve = speedCurve;
 
-                // Process MODEL_MULTI_PARTICLE entries
-                for (int f = 0; f < mmpEntries.Count; f++)
+                // Process model FX entries (MODEL_MULTI_PARTICLE/MODEL_PARTICLE variants).
+                for (int f = 0; f < modelFxEntries.Count; f++)
                 {
-                    var (transformName, modelName, mmpLocalPos, mmpLocalRot) = mmpEntries[f];
+                    var (nodeType, transformName, modelName, mmpLocalPos, mmpLocalRot) = modelFxEntries[f];
 
                     // Find matching transform(s) in prefab — may be multiple (multi-nozzle engines)
                     var fxTransforms = FindTransformsRecursive(prefab.transform, transformName);
@@ -2003,7 +2045,7 @@ namespace Parsek
                             continue;
                         }
                         LogFxParentAlignmentDiagnostic(
-                            partName, moduleIndex, "MODEL_MULTI_PARTICLE", transformName,
+                            partName, moduleIndex, nodeType, transformName,
                             prefab.transform, ghostModelNode, srcFxTransform, ghostFxParent);
 
                         // Instantiate FX model prefab if available
@@ -2017,14 +2059,17 @@ namespace Parsek
                                 fxInstance.transform.localPosition = mmpLocalPos;
                                 fxInstance.transform.localRotation = mmpLocalRot;
 
-                                var ps = fxInstance.GetComponentInChildren<ParticleSystem>();
-                                if (ps != null)
+                                int addedSystems = ConfigureGhostEngineParticleSystems(fxInstance, info.particleSystems);
+                                if (addedSystems > 0)
                                 {
-                                    var emission = ps.emission;
-                                    emission.rateOverTimeMultiplier = 0;
-                                    info.particleSystems.Add(ps);
                                     ParsekLog.Log($"    Engine FX cloned: '{partName}' midx={moduleIndex} " +
-                                        $"transform='{transformName}' model='{modelName}'");
+                                        $"type={nodeType} transform='{transformName}' model='{modelName}' " +
+                                        $"systems={addedSystems}");
+                                }
+                                else
+                                {
+                                    ParsekLog.Log($"    Engine FX model has no ParticleSystem: '{modelName}' for '{partName}'");
+                                    Object.Destroy(fxInstance);
                                 }
                             }
                             else
@@ -2083,15 +2128,11 @@ namespace Parsek
                         if (smokeTrail != null)
                             Object.Destroy(smokeTrail);
 
-                        var ps = fxInstance.GetComponentInChildren<ParticleSystem>();
-                        if (ps != null)
+                        int addedSystems = ConfigureGhostEngineParticleSystems(fxInstance, info.particleSystems);
+                        if (addedSystems > 0)
                         {
-                            var emission = ps.emission;
-                            emission.rateOverTimeMultiplier = 0;
-                            ps.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
-                            info.particleSystems.Add(ps);
                             ParsekLog.Log($"    Engine FX (prefab): '{partName}' midx={moduleIndex} " +
-                                $"transform='{transformName}' prefab='{prefabName}'");
+                                $"transform='{transformName}' prefab='{prefabName}' systems={addedSystems}");
                         }
                         else
                         {

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -921,15 +921,14 @@ namespace Parsek
             Quaternion ghostPartLocalRot = Quaternion.Inverse(ghostPartRoot.rotation) * ghostFxParent.rotation;
             float deltaRot = Quaternion.Angle(srcPartLocalRot, ghostPartLocalRot);
 
-            bool alwaysLog = !string.IsNullOrEmpty(partName) &&
-                string.Equals(partName, "omsEngine", System.StringComparison.OrdinalIgnoreCase);
-            if (!alwaysLog && deltaPos.sqrMagnitude < 0.000001f && deltaRot < 0.05f)
-                return;
-
+            // Always log for debugging FX orientation
+            Vector3 ghostFwd = ghostFxParent.forward;
+            Vector3 ghostUp = ghostFxParent.up;
             ParsekLog.Log($"    [DIAG] FX align '{partName}' midx={moduleIndex} type={fxKind} transform='{transformName}' " +
-                $"srcWorld={srcFxTransform.position} ghostWorld={ghostFxParent.position} " +
-                $"srcPartLocal={srcPartLocalPos} ghostPartLocal={ghostPartLocalPos} " +
-                $"deltaPos={deltaPos} deltaRot={deltaRot:F3}");
+                $"ghostFwd={ghostFwd} ghostUp={ghostUp} " +
+                $"srcFwd={srcFxTransform.forward} srcUp={srcFxTransform.up} " +
+                $"ghostLocalRot={ghostFxParent.localRotation} srcLocalRot={srcFxTransform.localRotation} " +
+                $"deltaRot={deltaRot:F3}");
         }
 
         private static int ConfigureGhostEngineParticleSystems(
@@ -2070,7 +2069,10 @@ namespace Parsek
                                 GameObject fxClone = Object.Instantiate(child.gameObject);
                                 fxClone.transform.SetParent(ghostLegacyParent, false);
                                 fxClone.transform.localPosition = legacyFxOffset;
-                                fxClone.transform.localRotation = child.localRotation;
+                                // child.localRotation is relative to part root, but this clone is
+                                // parented to the mirrored thrust anchor. Convert to anchor-local.
+                                Quaternion legacyLocalRot = Quaternion.Inverse(srcLegacyAnchor.rotation) * child.rotation;
+                                fxClone.transform.localRotation = legacyLocalRot;
                                 fxClone.transform.localScale = child.localScale;
 
                                 // SmokeTrailControl expects real vessel/part state — destroy it on the ghost
@@ -2166,9 +2168,14 @@ namespace Parsek
                                 int addedSystems = ConfigureGhostEngineParticleSystems(fxInstance, info.particleSystems);
                                 if (addedSystems > 0)
                                 {
+                                    // Diagnostic: log source transform orientation to debug FX direction
+                                    Vector3 srcFwd = srcFxTransform.forward;
+                                    Vector3 srcUp = srcFxTransform.up;
+                                    Quaternion srcLocalRot = srcFxTransform.localRotation;
                                     ParsekLog.Log($"    Engine FX cloned: '{partName}' midx={moduleIndex} " +
                                         $"type={nodeType} transform='{transformName}' model='{modelName}' " +
-                                        $"systems={addedSystems}");
+                                        $"systems={addedSystems} " +
+                                        $"srcLocalRot={srcLocalRot} srcFwd={srcFwd} srcUp={srcUp}");
                                 }
                                 else
                                 {

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -140,6 +140,14 @@ namespace Parsek
         // Cache for PREFAB_PARTICLE fx_* prefabs found on PartLoader part prefabs.
         // Built once from PartLoader.LoadedPartsList (stable prefab templates).
         private static Dictionary<string, GameObject> fxPrefabCache;
+        private static bool fxLoadedObjectScanCompleted;
+        private static readonly Dictionary<string, string[]> fxPrefabFallbacks =
+            new Dictionary<string, string[]>(System.StringComparer.OrdinalIgnoreCase)
+            {
+                { "fx_exhaustFlame_yellow_tiny_Z", new[] { "fx_exhaustFlame_yellow_tiny" } },
+                { "fx_smokeTrail_veryLarge", new[] { "fx_smokeTrail_large", "fx_smokeTrail_light" } },
+                { "fx_smokeTrail_aeroSpike", new[] { "fx_smokeTrail_light", "fx_smokeTrail_large" } }
+            };
 
         /// <summary>
         /// Find a KSP fx_* prefab by name. These exist as children of legacy part
@@ -149,37 +157,154 @@ namespace Parsek
         /// </summary>
         private static GameObject FindFxPrefab(string prefabName)
         {
+            prefabName = NormalizeFxPrefabName(prefabName);
+            if (string.IsNullOrEmpty(prefabName))
+                return null;
+
             if (fxPrefabCache == null)
                 RebuildFxPrefabCache();
 
             GameObject result;
-            if (fxPrefabCache.TryGetValue(prefabName, out result))
+            if (TryGetFxPrefabFromCache(prefabName, out result))
             {
-                // Self-heal: if cached object was destroyed, remove and try rebuild
-                if (result == null)
-                {
-                    fxPrefabCache.Remove(prefabName);
-                    RebuildFxPrefabCache();
-                    fxPrefabCache.TryGetValue(prefabName, out result);
-                }
                 return result;
             }
 
-            // Fallback: some fx_* prefabs (fx_exhaustFlame_yellow_tiny_Z,
-            // fx_smokeTrail_veryLarge, fx_smokeTrail_aeroSpike) are Unity
-            // built-in Resources in resources.assets, not part prefab children.
-            result = Resources.Load<GameObject>(prefabName);
+            result = TryResolveFxPrefabExact(prefabName);
             if (result != null)
             {
                 fxPrefabCache[prefabName] = result;
-                ParsekLog.Log($"  FX prefab loaded from Resources: '{prefabName}'");
+                return result;
             }
-            return result;
+
+            if (fxPrefabFallbacks.TryGetValue(prefabName, out string[] fallbackNames))
+            {
+                for (int i = 0; i < fallbackNames.Length; i++)
+                {
+                    string fallbackName = NormalizeFxPrefabName(fallbackNames[i]);
+                    if (string.IsNullOrEmpty(fallbackName) ||
+                        string.Equals(fallbackName, prefabName, System.StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    if (!TryGetFxPrefabFromCache(fallbackName, out result))
+                    {
+                        result = TryResolveFxPrefabExact(fallbackName);
+                        if (result != null)
+                            fxPrefabCache[fallbackName] = result;
+                    }
+
+                    if (result != null)
+                    {
+                        fxPrefabCache[prefabName] = result;
+                        ParsekLog.Log($"  FX prefab substitution: '{prefabName}' -> '{fallbackName}'");
+                        return result;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private static string NormalizeFxPrefabName(string rawName)
+        {
+            if (string.IsNullOrEmpty(rawName))
+                return rawName;
+
+            string name = rawName.Trim();
+            if (name.EndsWith("(Clone)"))
+                name = name.Substring(0, name.Length - 7);
+            return name;
+        }
+
+        private static bool TryGetFxPrefabFromCache(string prefabName, out GameObject result)
+        {
+            result = null;
+            if (fxPrefabCache == null)
+                return false;
+
+            if (!fxPrefabCache.TryGetValue(prefabName, out result))
+                return false;
+
+            // Self-heal: if cached object was destroyed, remove and rebuild.
+            if (result == null)
+            {
+                fxPrefabCache.Remove(prefabName);
+                RebuildFxPrefabCache();
+                return fxPrefabCache.TryGetValue(prefabName, out result) && result != null;
+            }
+
+            return true;
+        }
+
+        private static GameObject TryResolveFxPrefabExact(string prefabName)
+        {
+            string[] resourcePaths = { prefabName, $"FX/{prefabName}", $"fx/{prefabName}" };
+            for (int i = 0; i < resourcePaths.Length; i++)
+            {
+                string resourcePath = resourcePaths[i];
+                GameObject result = Resources.Load<GameObject>(resourcePath);
+                if (result != null)
+                {
+                    ParsekLog.Log($"  FX prefab loaded from Resources: '{prefabName}' (path='{resourcePath}')");
+                    return result;
+                }
+            }
+
+            GameObject modelPrefab = GameDatabase.Instance != null
+                ? GameDatabase.Instance.GetModelPrefab(prefabName)
+                : null;
+            if (modelPrefab != null)
+            {
+                ParsekLog.Log($"  FX prefab loaded from GameDatabase model: '{prefabName}'");
+                return modelPrefab;
+            }
+
+            PopulateFxPrefabCacheFromLoadedObjects();
+            if (TryGetFxPrefabFromCache(prefabName, out GameObject cached))
+            {
+                ParsekLog.Log($"  FX prefab resolved from loaded objects: '{prefabName}'");
+                return cached;
+            }
+
+            return null;
+        }
+
+        private static void PopulateFxPrefabCacheFromLoadedObjects()
+        {
+            if (fxLoadedObjectScanCompleted)
+                return;
+
+            fxLoadedObjectScanCompleted = true;
+            if (fxPrefabCache == null)
+                fxPrefabCache = new Dictionary<string, GameObject>(System.StringComparer.OrdinalIgnoreCase);
+
+            GameObject[] loadedObjects = Resources.FindObjectsOfTypeAll<GameObject>();
+            int added = 0;
+            for (int i = 0; i < loadedObjects.Length; i++)
+            {
+                GameObject go = loadedObjects[i];
+                if (go == null)
+                    continue;
+
+                string name = NormalizeFxPrefabName(go.name);
+                if (string.IsNullOrEmpty(name) || !name.StartsWith("fx_"))
+                    continue;
+                if (fxPrefabCache.ContainsKey(name))
+                    continue;
+                if (go.GetComponentInChildren<ParticleSystem>(true) == null)
+                    continue;
+
+                fxPrefabCache[name] = go;
+                added++;
+            }
+
+            ParsekLog.Log($"  FX prefab cache extended from loaded objects: +{added} entries");
         }
 
         private static void RebuildFxPrefabCache()
         {
-            fxPrefabCache = new Dictionary<string, GameObject>();
+            fxPrefabCache = new Dictionary<string, GameObject>(System.StringComparer.OrdinalIgnoreCase);
+            fxLoadedObjectScanCompleted = false;
             if (PartLoader.LoadedPartsList == null) return;
 
             for (int p = 0; p < PartLoader.LoadedPartsList.Count; p++)
@@ -190,10 +315,7 @@ namespace Parsek
                 for (int c = 0; c < prefab.transform.childCount; c++)
                 {
                     Transform child = prefab.transform.GetChild(c);
-                    string name = child.name;
-                    // Strip "(Clone)" suffix if present
-                    if (name.EndsWith("(Clone)"))
-                        name = name.Substring(0, name.Length - 7);
+                    string name = NormalizeFxPrefabName(child.name);
                     if (name.StartsWith("fx_") && !fxPrefabCache.ContainsKey(name)
                         && child.GetComponentInChildren<ParticleSystem>() != null)
                     {
@@ -208,6 +330,7 @@ namespace Parsek
         internal static void ClearFxPrefabCache()
         {
             fxPrefabCache = null;
+            fxLoadedObjectScanCompleted = false;
         }
 
         internal static GameObject BuildTimelineGhostFromSnapshot(
@@ -699,6 +822,59 @@ namespace Parsek
             }
 
             return parent;
+        }
+
+        private static Transform ResolveGhostFxParent(
+            Transform srcFxTransform, Transform prefabRoot, Transform modelRoot,
+            Transform ghostModelNode, Dictionary<Transform, Transform> cloneMap)
+        {
+            if (srcFxTransform == null || ghostModelNode == null)
+                return null;
+
+            if (IsDescendantOf(srcFxTransform, modelRoot))
+                return MirrorTransformChain(srcFxTransform, modelRoot, ghostModelNode, cloneMap);
+
+            Transform ghostPartRoot = ghostModelNode.parent != null ? ghostModelNode.parent : ghostModelNode;
+            if (prefabRoot != null && IsDescendantOf(srcFxTransform, prefabRoot))
+                return MirrorTransformChain(srcFxTransform, prefabRoot, ghostPartRoot, cloneMap);
+
+            // Last-resort fallback for unexpected hierarchy shapes.
+            GameObject fxHolder = new GameObject(srcFxTransform.name);
+            fxHolder.transform.SetParent(ghostModelNode, false);
+            fxHolder.transform.localPosition = srcFxTransform.localPosition;
+            fxHolder.transform.localRotation = srcFxTransform.localRotation;
+            fxHolder.transform.localScale = srcFxTransform.localScale;
+            return fxHolder.transform;
+        }
+
+        private static void LogFxParentAlignmentDiagnostic(
+            string partName, int moduleIndex, string fxKind, string transformName,
+            Transform prefabRoot, Transform ghostModelNode,
+            Transform srcFxTransform, Transform ghostFxParent)
+        {
+            if (prefabRoot == null || ghostModelNode == null ||
+                srcFxTransform == null || ghostFxParent == null)
+                return;
+
+            Transform ghostPartRoot = ghostModelNode.parent != null ? ghostModelNode.parent : ghostModelNode;
+
+            Vector3 srcPartLocalPos = prefabRoot.InverseTransformPoint(srcFxTransform.position);
+            Vector3 ghostPartLocalPos = ghostPartRoot.InverseTransformPoint(ghostFxParent.position);
+            Vector3 deltaPos = ghostPartLocalPos - srcPartLocalPos;
+
+            Quaternion srcPartLocalRot = Quaternion.Inverse(prefabRoot.rotation) * srcFxTransform.rotation;
+            Quaternion ghostPartLocalRot = Quaternion.Inverse(ghostPartRoot.rotation) * ghostFxParent.rotation;
+            float deltaRot = Quaternion.Angle(srcPartLocalRot, ghostPartLocalRot);
+
+            bool alwaysLog = !string.IsNullOrEmpty(partName) &&
+                string.Equals(partName, "omsEngine", System.StringComparison.OrdinalIgnoreCase);
+            if (!alwaysLog && deltaPos.sqrMagnitude < 0.000001f && deltaRot < 0.05f)
+                return;
+
+            ParsekLog.Log($"    [DIAG] FX align '{partName}' midx={moduleIndex} type={fxKind} transform='{transformName}' " +
+                $"srcWorld={srcFxTransform.position} ghostWorld={ghostFxParent.position} " +
+                $"srcPartLocal={srcPartLocalPos} ghostPartLocal={ghostPartLocalPos} " +
+                $"deltaPos={deltaPos} deltaRot={deltaRot:F3}");
         }
 
         /// <summary>
@@ -1818,24 +1994,17 @@ namespace Parsek
                     {
                         Transform srcFxTransform = fxTransforms[t];
 
-                        // Clone the FX transform chain into the ghost
-                        Transform ghostFxParent;
-                        // Check if the FX transform is under modelRoot (common case)
-                        bool isUnderModel = IsDescendantOf(srcFxTransform, modelRoot);
-                        if (isUnderModel)
+                        Transform ghostFxParent = ResolveGhostFxParent(
+                            srcFxTransform, prefab.transform, modelRoot, ghostModelNode, cloneMap);
+                        if (ghostFxParent == null)
                         {
-                            ghostFxParent = MirrorTransformChain(srcFxTransform, modelRoot, ghostModelNode, cloneMap);
+                            ParsekLog.Log($"    Engine FX: '{partName}' midx={moduleIndex} " +
+                                $"transform='{transformName}' parent resolution failed");
+                            continue;
                         }
-                        else
-                        {
-                            // FX transform is outside model subtree — create under ghost model node directly
-                            GameObject fxHolder = new GameObject(srcFxTransform.name);
-                            fxHolder.transform.SetParent(ghostModelNode, false);
-                            fxHolder.transform.localPosition = srcFxTransform.localPosition;
-                            fxHolder.transform.localRotation = srcFxTransform.localRotation;
-                            fxHolder.transform.localScale = srcFxTransform.localScale;
-                            ghostFxParent = fxHolder.transform;
-                        }
+                        LogFxParentAlignmentDiagnostic(
+                            partName, moduleIndex, "MODEL_MULTI_PARTICLE", transformName,
+                            prefab.transform, ghostModelNode, srcFxTransform, ghostFxParent);
 
                         // Instantiate FX model prefab if available
                         if (!string.IsNullOrEmpty(modelName))
@@ -1871,7 +2040,7 @@ namespace Parsek
                 {
                     var (prefabName, transformName, localOffset, localRot) = prefabFxEntries[f];
 
-                    // Find the fx_* prefab in memory (children of legacy parts, not Unity Resources)
+                    // Resolve the fx_* prefab (cache, Resources, loaded objects, then substitutions).
                     GameObject fxPrefab = FindFxPrefab(prefabName);
                     if (fxPrefab == null)
                     {
@@ -1891,22 +2060,17 @@ namespace Parsek
                     {
                         Transform srcFxTransform = fxTransforms[t];
 
-                        // Same transform chain mirroring as MODEL_MULTI_PARTICLE
-                        Transform ghostFxParent;
-                        bool isUnderModel = IsDescendantOf(srcFxTransform, modelRoot);
-                        if (isUnderModel)
+                        Transform ghostFxParent = ResolveGhostFxParent(
+                            srcFxTransform, prefab.transform, modelRoot, ghostModelNode, cloneMap);
+                        if (ghostFxParent == null)
                         {
-                            ghostFxParent = MirrorTransformChain(srcFxTransform, modelRoot, ghostModelNode, cloneMap);
+                            ParsekLog.Log($"    Engine FX (prefab): '{partName}' midx={moduleIndex} " +
+                                $"transform='{transformName}' parent resolution failed");
+                            continue;
                         }
-                        else
-                        {
-                            GameObject fxHolder = new GameObject(srcFxTransform.name);
-                            fxHolder.transform.SetParent(ghostModelNode, false);
-                            fxHolder.transform.localPosition = srcFxTransform.localPosition;
-                            fxHolder.transform.localRotation = srcFxTransform.localRotation;
-                            fxHolder.transform.localScale = srcFxTransform.localScale;
-                            ghostFxParent = fxHolder.transform;
-                        }
+                        LogFxParentAlignmentDiagnostic(
+                            partName, moduleIndex, "PREFAB_PARTICLE", transformName,
+                            prefab.transform, ghostModelNode, srcFxTransform, ghostFxParent);
 
                         // Clone the prefab and apply localOffset/localRotation from config
                         GameObject fxInstance = Object.Instantiate(fxPrefab);
@@ -2085,21 +2249,17 @@ namespace Parsek
                     {
                         Transform srcFxTransform = fxTransforms[t];
 
-                        Transform ghostFxParent;
-                        bool isUnderModel = IsDescendantOf(srcFxTransform, modelRoot);
-                        if (isUnderModel)
+                        Transform ghostFxParent = ResolveGhostFxParent(
+                            srcFxTransform, prefab.transform, modelRoot, ghostModelNode, cloneMap);
+                        if (ghostFxParent == null)
                         {
-                            ghostFxParent = MirrorTransformChain(srcFxTransform, modelRoot, ghostModelNode, cloneMap);
+                            ParsekLog.Log($"    RCS '{partName}' midx={moduleIndex}: " +
+                                $"transform='{transformName}' parent resolution failed");
+                            continue;
                         }
-                        else
-                        {
-                            GameObject fxHolder = new GameObject(srcFxTransform.name);
-                            fxHolder.transform.SetParent(ghostModelNode, false);
-                            fxHolder.transform.localPosition = srcFxTransform.localPosition;
-                            fxHolder.transform.localRotation = srcFxTransform.localRotation;
-                            fxHolder.transform.localScale = srcFxTransform.localScale;
-                            ghostFxParent = fxHolder.transform;
-                        }
+                        LogFxParentAlignmentDiagnostic(
+                            partName, moduleIndex, "RCS_MODEL_MULTI_PARTICLE", transformName,
+                            prefab.transform, ghostModelNode, srcFxTransform, ghostFxParent);
 
                         if (!string.IsNullOrEmpty(modelName))
                         {

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -163,6 +163,8 @@ namespace Parsek
                 { "Squad/FX/shockExhaust_blue_small", new Vector3(-90f, 0f, 0f) },
                 { "Squad/FX/shockExhaust_red_small", new Vector3(-90f, 0f, 0f) }
             };
+        private static readonly string[] EngineModelNodeTypes =
+            { "MODEL_MULTI_PARTICLE_PERSIST", "MODEL_MULTI_PARTICLE", "MODEL_PARTICLE" };
 
         /// <summary>
         /// Find a KSP fx_* prefab by name. These exist as children of legacy part
@@ -914,6 +916,7 @@ namespace Parsek
             fxHolder.transform.localPosition = srcFxTransform.localPosition;
             fxHolder.transform.localRotation = srcFxTransform.localRotation;
             fxHolder.transform.localScale = srcFxTransform.localScale;
+            cloneMap[srcFxTransform] = fxHolder.transform;
             return fxHolder.transform;
         }
 
@@ -2104,10 +2107,9 @@ namespace Parsek
                     // Scan for model FX nodes used by engines.
                     for (int g = 0; g < effectGroups.Length; g++)
                     {
-                        string[] modelNodeTypes = { "MODEL_MULTI_PARTICLE_PERSIST", "MODEL_MULTI_PARTICLE", "MODEL_PARTICLE" };
-                        for (int n = 0; n < modelNodeTypes.Length; n++)
+                        for (int n = 0; n < EngineModelNodeTypes.Length; n++)
                         {
-                            string nodeType = modelNodeTypes[n];
+                            string nodeType = EngineModelNodeTypes[n];
                             ConfigNode[] modelNodes = effectGroups[g].GetNodes(nodeType);
                             for (int mp = 0; mp < modelNodes.Length; mp++)
                             {
@@ -2189,6 +2191,112 @@ namespace Parsek
                     }
                 }
 
+                var namedTransformCache = new Dictionary<string, List<Transform>>(System.StringComparer.OrdinalIgnoreCase);
+
+                List<Transform> FindNamedTransformsCached(string transformName)
+                {
+                    if (string.IsNullOrEmpty(transformName))
+                        return new List<Transform>();
+
+                    if (namedTransformCache.TryGetValue(transformName, out List<Transform> cached))
+                        return cached;
+
+                    List<Transform> found = FindTransformsRecursive(prefab.transform, transformName);
+                    namedTransformCache[transformName] = found;
+                    return found;
+                }
+
+                bool HasNamedTransform(string transformName)
+                {
+                    return FindNamedTransformsCached(transformName).Count > 0;
+                }
+
+                bool HasPrefabMatch(System.Func<string, bool> matcher)
+                {
+                    for (int i = 0; i < prefabFxEntries.Count; i++)
+                    {
+                        string existingPrefab = NormalizeFxPrefabName(prefabFxEntries[i].prefabName);
+                        if (!string.IsNullOrEmpty(existingPrefab) && matcher(existingPrefab))
+                            return true;
+                    }
+
+                    return false;
+                }
+
+                string ResolveFallbackTransform(
+                    string preferredTransform,
+                    bool includeEngineTransform,
+                    params string[] alternateTransforms)
+                {
+                    if (!string.IsNullOrEmpty(preferredTransform) && HasNamedTransform(preferredTransform))
+                        return preferredTransform;
+
+                    if (includeEngineTransform &&
+                        engine != null &&
+                        !string.IsNullOrEmpty(engine.thrustVectorTransformName) &&
+                        HasNamedTransform(engine.thrustVectorTransformName))
+                    {
+                        return engine.thrustVectorTransformName;
+                    }
+
+                    for (int i = 0; i < alternateTransforms.Length; i++)
+                    {
+                        string candidate = alternateTransforms[i];
+                        if (!string.IsNullOrEmpty(candidate) && HasNamedTransform(candidate))
+                            return candidate;
+                    }
+
+                    return preferredTransform;
+                }
+
+                Vector3 ResolveFallbackOffset(
+                    string fallbackTransform,
+                    Vector3 defaultOffset,
+                    bool matchFxTransformAlias)
+                {
+                    for (int i = 0; i < modelFxEntries.Count; i++)
+                    {
+                        if (string.Equals(modelFxEntries[i].transformName, fallbackTransform, System.StringComparison.OrdinalIgnoreCase) ||
+                            (matchFxTransformAlias &&
+                             string.Equals(modelFxEntries[i].transformName, "FXTransform", System.StringComparison.OrdinalIgnoreCase)))
+                        {
+                            return modelFxEntries[i].localPos;
+                        }
+                    }
+
+                    return defaultOffset;
+                }
+
+                void AddPrefabFallbackIfMissing(
+                    System.Func<string, bool> hasExistingPrefab,
+                    string prefabName,
+                    string preferredTransform,
+                    bool includeEngineTransform,
+                    string[] alternateTransforms,
+                    Vector3 defaultOffset,
+                    bool matchFxTransformAlias,
+                    Quaternion localRotation,
+                    bool hasLocalRotation,
+                    string description)
+                {
+                    if (HasPrefabMatch(hasExistingPrefab))
+                        return;
+
+                    string fallbackTransform = ResolveFallbackTransform(
+                        preferredTransform,
+                        includeEngineTransform,
+                        alternateTransforms);
+                    Vector3 fallbackOffset = ResolveFallbackOffset(
+                        fallbackTransform,
+                        defaultOffset,
+                        matchFxTransformAlias);
+
+                    prefabFxEntries.Add((prefabName, fallbackTransform, fallbackOffset, localRotation, hasLocalRotation));
+                    string rotationSuffix = hasLocalRotation ? $" rot={localRotation.eulerAngles}" : "";
+                    ParsekLog.Log($"    Engine FX fallback: '{partName}' midx={moduleIndex} " +
+                        $"added {description} on '{fallbackTransform}' offset={fallbackOffset}{rotationSuffix}");
+                }
+
                 // Ant/Spider configs only define MODEL_MULTI_PARTICLE Monoprop_small in running FX.
                 // Add a Twitch-style prefab flame fallback so they render a visible plume like Twitch.
                 bool isAntOrSpider =
@@ -2200,44 +2308,19 @@ namespace Parsek
                     string.Equals(partName, "radialEngineMini", System.StringComparison.OrdinalIgnoreCase);
                 if (isAntOrSpider)
                 {
-                    bool hasFlamePrefab = false;
-                    for (int i = 0; i < prefabFxEntries.Count; i++)
-                    {
-                        string existingPrefab = NormalizeFxPrefabName(prefabFxEntries[i].prefabName);
-                        if (string.Equals(existingPrefab, "fx_exhaustFlame_yellow_tiny_Z", System.StringComparison.OrdinalIgnoreCase) ||
-                            string.Equals(existingPrefab, "fx_exhaustFlame_yellow_tiny", System.StringComparison.OrdinalIgnoreCase))
-                        {
-                            hasFlamePrefab = true;
-                            break;
-                        }
-                    }
-
-                    if (!hasFlamePrefab)
-                    {
-                        string fallbackTransform = "FXTransform";
-                        if (FindTransformsRecursive(prefab.transform, fallbackTransform).Count == 0)
-                        {
-                            if (engine != null && !string.IsNullOrEmpty(engine.thrustVectorTransformName))
-                                fallbackTransform = engine.thrustVectorTransformName;
-                            else if (FindTransformsRecursive(prefab.transform, "thrustTransform").Count > 0)
-                                fallbackTransform = "thrustTransform";
-                        }
-
-                        Vector3 fallbackOffset = new Vector3(0f, 0f, 0.08f);
-                        for (int i = 0; i < modelFxEntries.Count; i++)
-                        {
-                            if (string.Equals(modelFxEntries[i].transformName, fallbackTransform, System.StringComparison.OrdinalIgnoreCase) ||
-                                string.Equals(modelFxEntries[i].transformName, "FXTransform", System.StringComparison.OrdinalIgnoreCase))
-                            {
-                                fallbackOffset = modelFxEntries[i].localPos;
-                                break;
-                            }
-                        }
-
-                        prefabFxEntries.Add(("fx_exhaustFlame_yellow_tiny_Z", fallbackTransform, fallbackOffset, Quaternion.identity, false));
-                        ParsekLog.Log($"    Engine FX fallback: '{partName}' midx={moduleIndex} " +
-                            $"added Twitch plume prefab on '{fallbackTransform}' offset={fallbackOffset}");
-                    }
+                    AddPrefabFallbackIfMissing(
+                        existingPrefab =>
+                            string.Equals(existingPrefab, "fx_exhaustFlame_yellow_tiny_Z", System.StringComparison.OrdinalIgnoreCase) ||
+                            string.Equals(existingPrefab, "fx_exhaustFlame_yellow_tiny", System.StringComparison.OrdinalIgnoreCase),
+                        prefabName: "fx_exhaustFlame_yellow_tiny_Z",
+                        preferredTransform: "FXTransform",
+                        includeEngineTransform: true,
+                        alternateTransforms: new[] { "thrustTransform" },
+                        defaultOffset: new Vector3(0f, 0f, 0.08f),
+                        matchFxTransformAlias: true,
+                        localRotation: Quaternion.identity,
+                        hasLocalRotation: false,
+                        description: "Twitch plume prefab");
                 }
 
                 // Kickback: force Thumper-style FX so smoke/flame match solidBooster1-1 visuals.
@@ -2273,13 +2356,13 @@ namespace Parsek
                     string kickbackTransform = "thrustTransform";
                     if (engine != null && !string.IsNullOrEmpty(engine.thrustVectorTransformName))
                         kickbackTransform = engine.thrustVectorTransformName;
-                    if (FindTransformsRecursive(prefab.transform, kickbackTransform).Count == 0)
+                    if (!HasNamedTransform(kickbackTransform))
                     {
-                        if (FindTransformsRecursive(prefab.transform, "thrustTransform").Count > 0)
+                        if (HasNamedTransform("thrustTransform"))
                             kickbackTransform = "thrustTransform";
-                        else if (FindTransformsRecursive(prefab.transform, "smokePoint").Count > 0)
+                        else if (HasNamedTransform("smokePoint"))
                             kickbackTransform = "smokePoint";
-                        else if (FindTransformsRecursive(prefab.transform, "fxPoint").Count > 0)
+                        else if (HasNamedTransform("fxPoint"))
                             kickbackTransform = "fxPoint";
                     }
 
@@ -2287,7 +2370,7 @@ namespace Parsek
                     if (kickbackOffset.sqrMagnitude <= 0.000001f)
                         kickbackOffset = new Vector3(0f, 0f, 0.35f);
                     Quaternion kickbackThumperLocalRot = Quaternion.Euler(-90f, 0f, 0f);
-                    var kickbackAnchors = FindTransformsRecursive(prefab.transform, kickbackTransform);
+                    var kickbackAnchors = FindNamedTransformsCached(kickbackTransform);
                     if (kickbackAnchors.Count > 0)
                     {
                         Transform diagAnchor = kickbackAnchors[0];
@@ -2316,48 +2399,67 @@ namespace Parsek
                         $"(removed MODEL={removedKickbackModelFx}, PREFAB={removedKickbackPrefabs})");
                 }
 
-                // Puff (omsEngine) often renders only Monoprop_big model FX; add Thud-style blue flame.
+                // Puff (omsEngine) often renders only Monoprop_big model FX; add a compact blue flame core.
                 bool isPuff =
                     string.Equals(partName, "omsEngine", System.StringComparison.OrdinalIgnoreCase);
                 if (isPuff)
                 {
-                    bool hasFlamePrefab = false;
-                    for (int i = 0; i < prefabFxEntries.Count; i++)
+                    AddPrefabFallbackIfMissing(
+                        existingPrefab => existingPrefab.IndexOf("exhaustflame", System.StringComparison.OrdinalIgnoreCase) >= 0,
+                        prefabName: "fx_exhaustFlame_blue_small",
+                        preferredTransform: "FXTransform",
+                        includeEngineTransform: true,
+                        alternateTransforms: new[] { "thrustTransform" },
+                        defaultOffset: new Vector3(0f, 0f, 0.12f),
+                        matchFxTransformAlias: true,
+                        localRotation: Quaternion.identity,
+                        hasLocalRotation: false,
+                        description: "Puff blue flame prefab");
+                }
+
+                // Rhino: force a compact Mainsail-like plume profile (small yellow flame + light smoke),
+                // aligned to the actual nozzle thrust axis.
+                bool isRhino =
+                    string.Equals(partName, "Size3AdvancedEngine", System.StringComparison.OrdinalIgnoreCase);
+                if (isRhino)
+                {
+                    int removedRhinoModelFx = modelFxEntries.Count;
+                    modelFxEntries.Clear();
+
+                    int removedRhinoPrefabs = 0;
+                    for (int i = prefabFxEntries.Count - 1; i >= 0; i--)
                     {
                         string existingPrefab = NormalizeFxPrefabName(prefabFxEntries[i].prefabName);
-                        if (existingPrefab != null && existingPrefab.IndexOf("exhaustflame", System.StringComparison.OrdinalIgnoreCase) >= 0)
+                        if (existingPrefab == null)
+                            continue;
+
+                        if (existingPrefab.IndexOf("smoketrail", System.StringComparison.OrdinalIgnoreCase) >= 0 ||
+                            existingPrefab.IndexOf("exhaustflame", System.StringComparison.OrdinalIgnoreCase) >= 0)
                         {
-                            hasFlamePrefab = true;
-                            break;
+                            prefabFxEntries.RemoveAt(i);
+                            removedRhinoPrefabs++;
                         }
                     }
 
-                    if (!hasFlamePrefab)
-                    {
-                        string fallbackTransform = "FXTransform";
-                        if (FindTransformsRecursive(prefab.transform, fallbackTransform).Count == 0)
-                        {
-                            if (engine != null && !string.IsNullOrEmpty(engine.thrustVectorTransformName))
-                                fallbackTransform = engine.thrustVectorTransformName;
-                            else if (FindTransformsRecursive(prefab.transform, "thrustTransform").Count > 0)
-                                fallbackTransform = "thrustTransform";
-                        }
+                    string rhinoPreferredTransform =
+                        (engine != null && !string.IsNullOrEmpty(engine.thrustVectorTransformName))
+                            ? engine.thrustVectorTransformName
+                            : "thrustTransform";
+                    string rhinoTransform = ResolveFallbackTransform(
+                        preferredTransform: rhinoPreferredTransform,
+                        includeEngineTransform: true,
+                        alternateTransforms: new[] { "thrustTransform", "smokePoint", "fxPoint" });
+                    Vector3 rhinoOffset = ResolveFallbackOffset(
+                        rhinoTransform,
+                        defaultOffset: engine != null ? engine.fxOffset : Vector3.zero,
+                        matchFxTransformAlias: false);
+                    Quaternion rhinoPlumeRotation = Quaternion.Euler(-90f, 0f, 0f);
 
-                        Vector3 fallbackOffset = new Vector3(0f, 0f, 0.12f);
-                        for (int i = 0; i < modelFxEntries.Count; i++)
-                        {
-                            if (string.Equals(modelFxEntries[i].transformName, fallbackTransform, System.StringComparison.OrdinalIgnoreCase) ||
-                                string.Equals(modelFxEntries[i].transformName, "FXTransform", System.StringComparison.OrdinalIgnoreCase))
-                            {
-                                fallbackOffset = modelFxEntries[i].localPos;
-                                break;
-                            }
-                        }
-
-                        prefabFxEntries.Add(("fx_exhaustFlame_blue_small", fallbackTransform, fallbackOffset, Quaternion.identity, false));
-                        ParsekLog.Log($"    Engine FX fallback: '{partName}' midx={moduleIndex} " +
-                            $"added Thud plume prefab on '{fallbackTransform}' offset={fallbackOffset}");
-                    }
+                    prefabFxEntries.Add(("fx_smokeTrail_light", rhinoTransform, rhinoOffset, rhinoPlumeRotation, true));
+                    prefabFxEntries.Add(("fx_exhaustFlame_yellow_medium", rhinoTransform, rhinoOffset, rhinoPlumeRotation, true));
+                    ParsekLog.Log($"    Engine FX fallback: '{partName}' midx={moduleIndex} " +
+                        $"forced compact Mainsail-like plume on '{rhinoTransform}' offset={rhinoOffset} " +
+                        $"(removed MODEL={removedRhinoModelFx}, PREFAB={removedRhinoPrefabs})");
                 }
 
                 // Rhino/Mammoth/Twin-Boar can show smoke without a visible core flame in ghost playback.
@@ -2370,50 +2472,24 @@ namespace Parsek
                     string.Equals(partName, "Size2LFB", System.StringComparison.OrdinalIgnoreCase);
                 if (isHeavyLargeEngine)
                 {
-                    bool hasFlamePrefab = false;
-                    for (int i = 0; i < prefabFxEntries.Count; i++)
-                    {
-                        string existingPrefab = NormalizeFxPrefabName(prefabFxEntries[i].prefabName);
-                        if (existingPrefab != null && existingPrefab.IndexOf("exhaustflame", System.StringComparison.OrdinalIgnoreCase) >= 0)
-                        {
-                            hasFlamePrefab = true;
-                            break;
-                        }
-                    }
+                    string preferredTransform = "thrustTransform";
+                    if (string.Equals(partName, "Size3AdvancedEngine", System.StringComparison.OrdinalIgnoreCase))
+                        preferredTransform = "fxPoint";
 
-                    if (!hasFlamePrefab)
-                    {
-                        string fallbackTransform = "thrustTransform";
-                        if (string.Equals(partName, "Size3AdvancedEngine", System.StringComparison.OrdinalIgnoreCase))
-                            fallbackTransform = "fxPoint";
-
-                        if (FindTransformsRecursive(prefab.transform, fallbackTransform).Count == 0)
-                        {
-                            if (engine != null && !string.IsNullOrEmpty(engine.thrustVectorTransformName))
-                                fallbackTransform = engine.thrustVectorTransformName;
-                            else if (FindTransformsRecursive(prefab.transform, "fxPoint").Count > 0)
-                                fallbackTransform = "fxPoint";
-                            else if (FindTransformsRecursive(prefab.transform, "thrustTransform").Count > 0)
-                                fallbackTransform = "thrustTransform";
-                        }
-
-                        Vector3 fallbackOffset = Vector3.zero;
-                        for (int i = 0; i < modelFxEntries.Count; i++)
-                        {
-                            if (string.Equals(modelFxEntries[i].transformName, fallbackTransform, System.StringComparison.OrdinalIgnoreCase))
-                            {
-                                fallbackOffset = modelFxEntries[i].localPos;
-                                break;
-                            }
-                        }
-
-                        // White flame prefab is authored in a Y-up frame; on these thrust/fx transforms
-                        // it needs a -90deg X adjustment to align with nozzle direction.
-                        Quaternion fallbackRotation = Quaternion.Euler(-90f, 0f, 0f);
-                        prefabFxEntries.Add(("fx_exhaustFlame_white", fallbackTransform, fallbackOffset, fallbackRotation, true));
-                        ParsekLog.Log($"    Engine FX fallback: '{partName}' midx={moduleIndex} " +
-                            $"added white flame prefab on '{fallbackTransform}' offset={fallbackOffset} rot={fallbackRotation.eulerAngles}");
-                    }
+                    // White flame prefab is authored in a Y-up frame; on these thrust/fx transforms
+                    // it needs a -90deg X adjustment to align with nozzle direction.
+                    Quaternion fallbackRotation = Quaternion.Euler(-90f, 0f, 0f);
+                    AddPrefabFallbackIfMissing(
+                        existingPrefab => existingPrefab.IndexOf("exhaustflame", System.StringComparison.OrdinalIgnoreCase) >= 0,
+                        prefabName: "fx_exhaustFlame_white",
+                        preferredTransform: preferredTransform,
+                        includeEngineTransform: true,
+                        alternateTransforms: new[] { "fxPoint", "thrustTransform" },
+                        defaultOffset: Vector3.zero,
+                        matchFxTransformAlias: false,
+                        localRotation: fallbackRotation,
+                        hasLocalRotation: true,
+                        description: "white flame prefab");
                 }
 
                 // Vector (SSME) can look underpowered with only blue_small + model flame.
@@ -2456,11 +2532,13 @@ namespace Parsek
                         }
 
                         if (!copiedFromExistingBlueSmall &&
-                            FindTransformsRecursive(prefab.transform, fallbackTransform).Count == 0)
+                            !HasNamedTransform(fallbackTransform))
                         {
-                            if (FindTransformsRecursive(prefab.transform, "thrustTransform").Count > 0)
+                            if (HasNamedTransform("thrustTransform"))
                                 fallbackTransform = "thrustTransform";
-                            else if (engine != null && !string.IsNullOrEmpty(engine.thrustVectorTransformName))
+                            else if (engine != null &&
+                                !string.IsNullOrEmpty(engine.thrustVectorTransformName) &&
+                                HasNamedTransform(engine.thrustVectorTransformName))
                                 fallbackTransform = engine.thrustVectorTransformName;
                         }
 
@@ -2472,9 +2550,7 @@ namespace Parsek
 
                 // RAPIER can resolve to dark/perpendicular smoke when aeroSpike smoke prefab falls back.
                 // Force a Vector-like visible plume: single large smoke + white flame core.
-                bool isRapier =
-                    string.Equals(partName, "RAPIER", System.StringComparison.OrdinalIgnoreCase);
-                if (isRapier)
+                if (isRapierPart)
                 {
                     string rapierSmokeTransform = "smokePoint";
                     Vector3 rapierSmokeOffset = new Vector3(0f, 0f, 1f);
@@ -2505,14 +2581,16 @@ namespace Parsek
 
                     if (!copiedRapierSmokeAnchor)
                     {
-                        if (FindTransformsRecursive(prefab.transform, rapierSmokeTransform).Count == 0)
+                        if (!HasNamedTransform(rapierSmokeTransform))
                         {
-                            if (FindTransformsRecursive(prefab.transform, "thrustTransform").Count > 0)
+                            if (HasNamedTransform("thrustTransform"))
                             {
                                 rapierSmokeTransform = "thrustTransform";
                                 rapierSmokeOffset = engine != null ? engine.fxOffset : Vector3.zero;
                             }
-                            else if (engine != null && !string.IsNullOrEmpty(engine.thrustVectorTransformName))
+                            else if (engine != null &&
+                                !string.IsNullOrEmpty(engine.thrustVectorTransformName) &&
+                                HasNamedTransform(engine.thrustVectorTransformName))
                             {
                                 rapierSmokeTransform = engine.thrustVectorTransformName;
                                 rapierSmokeOffset = engine.fxOffset;
@@ -2542,11 +2620,13 @@ namespace Parsek
                         // Keep it compact: anchor the added white core to the same smokePoint frame.
                         string flameTransform = rapierSmokeTransform;
                         Vector3 flameOffset = Vector3.zero;
-                        if (FindTransformsRecursive(prefab.transform, flameTransform).Count == 0)
+                        if (!HasNamedTransform(flameTransform))
                         {
                             flameTransform = "thrustTransform";
-                            if (FindTransformsRecursive(prefab.transform, flameTransform).Count == 0 &&
-                                engine != null && !string.IsNullOrEmpty(engine.thrustVectorTransformName))
+                            if (!HasNamedTransform(flameTransform) &&
+                                engine != null &&
+                                !string.IsNullOrEmpty(engine.thrustVectorTransformName) &&
+                                HasNamedTransform(engine.thrustVectorTransformName))
                             {
                                 flameTransform = engine.thrustVectorTransformName;
                             }

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -1896,6 +1896,16 @@ namespace Parsek
                     moduleIndex = moduleIndex
                 };
 
+                bool isRapierPart =
+                    string.Equals(partName, "RAPIER", System.StringComparison.OrdinalIgnoreCase);
+                if (isRapierPart && moduleIndex > 0)
+                {
+                    // RAPIER has multi-mode engine modules sharing nozzle transforms; recording events
+                    // target midx=0, so skip duplicate module FX to avoid doubled plumes.
+                    ParsekLog.Log($"    Engine '{partName}' midx={moduleIndex}: skipped duplicate multi-mode FX module");
+                    continue;
+                }
+
                 // Try to read EFFECTS config from the part config
                 ConfigNode partConfig = prefab.partInfo?.partConfig;
                 if (partConfig == null)
@@ -1908,7 +1918,12 @@ namespace Parsek
 
                 // Scan EFFECTS for particle FX entries (MODEL_MULTI_PARTICLE, MODEL_PARTICLE, PREFAB_PARTICLE)
                 var modelFxEntries = new List<(string nodeType, string transformName, string modelName, Vector3 localPos, Quaternion localRot)>();
-                var prefabFxEntries = new List<(string prefabName, string transformName, Vector3 localOffset, Quaternion localRotation)>();
+                var prefabFxEntries = new List<(
+                    string prefabName,
+                    string transformName,
+                    Vector3 localOffset,
+                    Quaternion localRotation,
+                    bool hasLocalRotation)>();
                 FloatCurve emissionCurve = null;
                 FloatCurve speedCurve = null;
 
@@ -1997,9 +2012,9 @@ namespace Parsek
 
                             Quaternion localRot = Quaternion.identity;
                             string rotStr = ppNodes[pp].GetValue("localRotation");
-                            TryParseFxLocalRotation(rotStr, out localRot);
+                            bool hasLocalRot = TryParseFxLocalRotation(rotStr, out localRot);
 
-                            prefabFxEntries.Add((prefabName, transformName, localOffset, localRot));
+                            prefabFxEntries.Add((prefabName, transformName, localOffset, localRot, hasLocalRot));
                         }
                     }
                 }
@@ -2049,7 +2064,7 @@ namespace Parsek
                             }
                         }
 
-                        prefabFxEntries.Add(("fx_exhaustFlame_yellow_tiny_Z", fallbackTransform, fallbackOffset, Quaternion.identity));
+                        prefabFxEntries.Add(("fx_exhaustFlame_yellow_tiny_Z", fallbackTransform, fallbackOffset, Quaternion.identity, false));
                         ParsekLog.Log($"    Engine FX fallback: '{partName}' midx={moduleIndex} " +
                             $"added Twitch plume prefab on '{fallbackTransform}' offset={fallbackOffset}");
                     }
@@ -2063,6 +2078,7 @@ namespace Parsek
                     string kickbackSmokeTransform = "smokePoint";
                     Vector3 kickbackSmokeOffset = new Vector3(0f, 0f, 1f);
                     Quaternion kickbackSmokeRotation = Quaternion.identity;
+                    bool kickbackSmokeHasLocalRotation = false;
                     bool copiedSmokeAnchor = false;
 
                     bool replacedSmokePrefab = false;
@@ -2077,6 +2093,7 @@ namespace Parsek
                                 kickbackSmokeTransform = prefabFxEntries[i].transformName;
                                 kickbackSmokeOffset = prefabFxEntries[i].localOffset;
                                 kickbackSmokeRotation = prefabFxEntries[i].localRotation;
+                                kickbackSmokeHasLocalRotation = prefabFxEntries[i].hasLocalRotation;
                                 copiedSmokeAnchor = true;
                             }
                             prefabFxEntries.RemoveAt(i);
@@ -2101,7 +2118,7 @@ namespace Parsek
                         }
                     }
 
-                    prefabFxEntries.Add(("fx_smokeTrail_medium", kickbackSmokeTransform, kickbackSmokeOffset, kickbackSmokeRotation));
+                    prefabFxEntries.Add(("fx_smokeTrail_medium", kickbackSmokeTransform, kickbackSmokeOffset, kickbackSmokeRotation, kickbackSmokeHasLocalRotation));
                     ParsekLog.Log($"    Engine FX fallback: '{partName}' midx={moduleIndex} " +
                         $"{(replacedSmokePrefab ? "replaced smoke with" : "added")} Thumper smoke prefab on '{kickbackSmokeTransform}' " +
                         $"offset={kickbackSmokeOffset} rot={kickbackSmokeRotation.eulerAngles}");
@@ -2138,7 +2155,7 @@ namespace Parsek
                             }
                         }
 
-                        prefabFxEntries.Add(("fx_exhaustFlame_yellow", fallbackTransform, fallbackOffset, Quaternion.identity));
+                        prefabFxEntries.Add(("fx_exhaustFlame_yellow", fallbackTransform, fallbackOffset, Quaternion.identity, false));
                         ParsekLog.Log($"    Engine FX fallback: '{partName}' midx={moduleIndex} " +
                             $"added Thumper plume prefab on '{fallbackTransform}' offset={fallbackOffset}");
                     }
@@ -2182,7 +2199,7 @@ namespace Parsek
                             }
                         }
 
-                        prefabFxEntries.Add(("fx_exhaustFlame_blue_small", fallbackTransform, fallbackOffset, Quaternion.identity));
+                        prefabFxEntries.Add(("fx_exhaustFlame_blue_small", fallbackTransform, fallbackOffset, Quaternion.identity, false));
                         ParsekLog.Log($"    Engine FX fallback: '{partName}' midx={moduleIndex} " +
                             $"added Thud plume prefab on '{fallbackTransform}' offset={fallbackOffset}");
                     }
@@ -2238,7 +2255,7 @@ namespace Parsek
                         // White flame prefab is authored in a Y-up frame; on these thrust/fx transforms
                         // it needs a -90deg X adjustment to align with nozzle direction.
                         Quaternion fallbackRotation = Quaternion.Euler(-90f, 0f, 0f);
-                        prefabFxEntries.Add(("fx_exhaustFlame_white", fallbackTransform, fallbackOffset, fallbackRotation));
+                        prefabFxEntries.Add(("fx_exhaustFlame_white", fallbackTransform, fallbackOffset, fallbackRotation, true));
                         ParsekLog.Log($"    Engine FX fallback: '{partName}' midx={moduleIndex} " +
                             $"added white flame prefab on '{fallbackTransform}' offset={fallbackOffset} rot={fallbackRotation.eulerAngles}");
                     }
@@ -2266,6 +2283,7 @@ namespace Parsek
                         string fallbackTransform = "thrustTransformYup";
                         Vector3 fallbackOffset = Vector3.zero;
                         Quaternion fallbackRotation = Quaternion.identity;
+                        bool fallbackHasLocalRotation = false;
 
                         bool copiedFromExistingBlueSmall = false;
                         for (int i = 0; i < prefabFxEntries.Count; i++)
@@ -2276,6 +2294,7 @@ namespace Parsek
                                 fallbackTransform = prefabFxEntries[i].transformName;
                                 fallbackOffset = prefabFxEntries[i].localOffset;
                                 fallbackRotation = prefabFxEntries[i].localRotation;
+                                fallbackHasLocalRotation = prefabFxEntries[i].hasLocalRotation;
                                 copiedFromExistingBlueSmall = true;
                                 break;
                             }
@@ -2290,9 +2309,98 @@ namespace Parsek
                                 fallbackTransform = engine.thrustVectorTransformName;
                         }
 
-                        prefabFxEntries.Add(("fx_exhaustFlame_blue", fallbackTransform, fallbackOffset, fallbackRotation));
+                        prefabFxEntries.Add(("fx_exhaustFlame_blue", fallbackTransform, fallbackOffset, fallbackRotation, fallbackHasLocalRotation));
                         ParsekLog.Log($"    Engine FX fallback: '{partName}' midx={moduleIndex} " +
                             $"added Skipper-style blue flame prefab on '{fallbackTransform}' offset={fallbackOffset} rot={fallbackRotation.eulerAngles}");
+                    }
+                }
+
+                // RAPIER can resolve to dark/perpendicular smoke when aeroSpike smoke prefab falls back.
+                // Force a Vector-like visible plume: single large smoke + white flame core.
+                bool isRapier =
+                    string.Equals(partName, "RAPIER", System.StringComparison.OrdinalIgnoreCase);
+                if (isRapier)
+                {
+                    string rapierSmokeTransform = "smokePoint";
+                    Vector3 rapierSmokeOffset = new Vector3(0f, 0f, 1f);
+                    Quaternion rapierSmokeRotation = Quaternion.identity;
+                    bool rapierSmokeHasLocalRotation = false;
+                    bool copiedRapierSmokeAnchor = false;
+
+                    int removedRapierSmoke = 0;
+                    for (int i = prefabFxEntries.Count - 1; i >= 0; i--)
+                    {
+                        string existingPrefab = NormalizeFxPrefabName(prefabFxEntries[i].prefabName);
+                        if (existingPrefab == null ||
+                            existingPrefab.IndexOf("smoketrail", System.StringComparison.OrdinalIgnoreCase) < 0)
+                            continue;
+
+                        if (!copiedRapierSmokeAnchor)
+                        {
+                            rapierSmokeTransform = prefabFxEntries[i].transformName;
+                            rapierSmokeOffset = prefabFxEntries[i].localOffset;
+                            rapierSmokeRotation = prefabFxEntries[i].localRotation;
+                            rapierSmokeHasLocalRotation = prefabFxEntries[i].hasLocalRotation;
+                            copiedRapierSmokeAnchor = true;
+                        }
+
+                        prefabFxEntries.RemoveAt(i);
+                        removedRapierSmoke++;
+                    }
+
+                    if (!copiedRapierSmokeAnchor)
+                    {
+                        if (FindTransformsRecursive(prefab.transform, rapierSmokeTransform).Count == 0)
+                        {
+                            if (FindTransformsRecursive(prefab.transform, "thrustTransform").Count > 0)
+                            {
+                                rapierSmokeTransform = "thrustTransform";
+                                rapierSmokeOffset = engine != null ? engine.fxOffset : Vector3.zero;
+                            }
+                            else if (engine != null && !string.IsNullOrEmpty(engine.thrustVectorTransformName))
+                            {
+                                rapierSmokeTransform = engine.thrustVectorTransformName;
+                                rapierSmokeOffset = engine.fxOffset;
+                            }
+                        }
+                    }
+
+                    prefabFxEntries.Add(("fx_smokeTrail_large", rapierSmokeTransform, rapierSmokeOffset,
+                        rapierSmokeRotation, rapierSmokeHasLocalRotation));
+                    ParsekLog.Log($"    Engine FX fallback: '{partName}' midx={moduleIndex} " +
+                        $"replaced {removedRapierSmoke} smoke entries with Vector-style smoke on '{rapierSmokeTransform}' " +
+                        $"offset={rapierSmokeOffset} rot={rapierSmokeRotation.eulerAngles}");
+
+                    bool hasWhiteFlame = false;
+                    for (int i = 0; i < prefabFxEntries.Count; i++)
+                    {
+                        string existingPrefab = NormalizeFxPrefabName(prefabFxEntries[i].prefabName);
+                        if (string.Equals(existingPrefab, "fx_exhaustFlame_white", System.StringComparison.OrdinalIgnoreCase))
+                        {
+                            hasWhiteFlame = true;
+                            break;
+                        }
+                    }
+
+                    if (!hasWhiteFlame)
+                    {
+                        // Keep it compact: anchor the added white core to the same smokePoint frame.
+                        string flameTransform = rapierSmokeTransform;
+                        Vector3 flameOffset = Vector3.zero;
+                        if (FindTransformsRecursive(prefab.transform, flameTransform).Count == 0)
+                        {
+                            flameTransform = "thrustTransform";
+                            if (FindTransformsRecursive(prefab.transform, flameTransform).Count == 0 &&
+                                engine != null && !string.IsNullOrEmpty(engine.thrustVectorTransformName))
+                            {
+                                flameTransform = engine.thrustVectorTransformName;
+                            }
+                        }
+
+                        Quaternion flameRotation = Quaternion.Euler(-90f, 0f, 0f);
+                        prefabFxEntries.Add(("fx_exhaustFlame_white", flameTransform, flameOffset, flameRotation, true));
+                        ParsekLog.Log($"    Engine FX fallback: '{partName}' midx={moduleIndex} " +
+                            $"added Vector-style white flame on '{flameTransform}' offset={flameOffset} rot={flameRotation.eulerAngles}");
                     }
                 }
 
@@ -2487,7 +2595,11 @@ namespace Parsek
                 // Process PREFAB_PARTICLE entries (Spark, Twitch, Pug, Juno, Wheesley, Goliath)
                 for (int f = 0; f < prefabFxEntries.Count; f++)
                 {
-                    var (prefabName, transformName, localOffset, localRot) = prefabFxEntries[f];
+                    var (prefabName, transformName, localOffset, localRot, hasLocalRot) = prefabFxEntries[f];
+                    string normalizedPrefabName = NormalizeFxPrefabName(prefabName);
+                    bool isRapierWhiteFlame =
+                        string.Equals(partName, "RAPIER", System.StringComparison.OrdinalIgnoreCase) &&
+                        string.Equals(normalizedPrefabName, "fx_exhaustFlame_white", System.StringComparison.OrdinalIgnoreCase);
 
                     // Resolve the fx_* prefab (cache, Resources, loaded objects, then substitutions).
                     GameObject fxPrefab = FindFxPrefab(prefabName);
@@ -2507,6 +2619,9 @@ namespace Parsek
                     }
                     for (int t = 0; t < fxTransforms.Count; t++)
                     {
+                        if (isRapierWhiteFlame && t > 0)
+                            continue; // keep single compact white core on RAPIER
+
                         Transform srcFxTransform = fxTransforms[t];
 
                         Transform ghostFxParent = ResolveGhostFxParent(
@@ -2525,7 +2640,21 @@ namespace Parsek
                         GameObject fxInstance = Object.Instantiate(fxPrefab);
                         fxInstance.transform.SetParent(ghostFxParent, false);
                         fxInstance.transform.localPosition = localOffset;
-                        fxInstance.transform.localRotation = localRot;
+                        if (hasLocalRot)
+                            fxInstance.transform.localRotation = localRot;
+
+                        if (isRapierWhiteFlame)
+                        {
+                            // Prevent SRB-sized white plume look on RAPIER.
+                            fxInstance.transform.localScale *= 0.35f;
+                            ParticleSystem[] rapierWhiteSystems = fxInstance.GetComponentsInChildren<ParticleSystem>(true);
+                            for (int psIndex = 0; psIndex < rapierWhiteSystems.Length; psIndex++)
+                            {
+                                var main = rapierWhiteSystems[psIndex].main;
+                                main.startSizeMultiplier *= 0.45f;
+                                main.startSpeedMultiplier *= 0.75f;
+                            }
+                        }
 
                         // SmokeTrailControl expects real vessel/part state — destroy it on the ghost
                         var smokeTrail = fxInstance.GetComponent("SmokeTrailControl");

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -148,6 +148,16 @@ namespace Parsek
                 { "fx_smokeTrail_veryLarge", new[] { "fx_smokeTrail_large", "fx_smokeTrail_light" } },
                 { "fx_smokeTrail_aeroSpike", new[] { "fx_smokeTrail_light", "fx_smokeTrail_large" } }
             };
+        private static readonly Dictionary<string, Vector3> fxModelRotationFallbackEuler =
+            new Dictionary<string, Vector3>(System.StringComparer.OrdinalIgnoreCase)
+            {
+                // These stock model FX are authored with implicit -90deg X orientation in KSP's
+                // runtime FX pipeline when localRotation is omitted in EFFECTS config.
+                { "Squad/FX/Monoprop_small", new Vector3(-90f, 0f, 0f) },
+                { "Squad/FX/Monoprop_medium", new Vector3(-90f, 0f, 0f) },
+                { "Squad/FX/shockExhaust_blue_small", new Vector3(-90f, 0f, 0f) },
+                { "Squad/FX/shockExhaust_red_small", new Vector3(-90f, 0f, 0f) }
+            };
 
         /// <summary>
         /// Find a KSP fx_* prefab by name. These exist as children of legacy part
@@ -699,6 +709,51 @@ namespace Parsek
             return true;
         }
 
+        internal static bool TryParseFxLocalRotation(string value, out Quaternion result)
+        {
+            result = Quaternion.identity;
+            if (string.IsNullOrEmpty(value))
+                return false;
+
+            string[] parts = value.Split(',');
+            if (parts.Length == 3)
+            {
+                if (!TryParseVector3(value, out Vector3 euler))
+                    return false;
+                result = Quaternion.Euler(euler);
+                return true;
+            }
+
+            if (parts.Length >= 4 &&
+                float.TryParse(parts[0].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out float ax) &&
+                float.TryParse(parts[1].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out float ay) &&
+                float.TryParse(parts[2].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out float az) &&
+                float.TryParse(parts[3].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out float angle))
+            {
+                Vector3 axis = new Vector3(ax, ay, az);
+                result = axis.sqrMagnitude > 0.0001f
+                    ? Quaternion.AngleAxis(angle, axis)
+                    : Quaternion.identity;
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool TryGetFxModelFallbackRotation(string modelName, out Quaternion result)
+        {
+            result = Quaternion.identity;
+            if (string.IsNullOrEmpty(modelName))
+                return false;
+
+            string normalized = modelName.Trim();
+            if (!fxModelRotationFallbackEuler.TryGetValue(normalized, out Vector3 fallbackEuler))
+                return false;
+
+            result = Quaternion.Euler(fallbackEuler);
+            return true;
+        }
+
         internal static string GetPartPositionRaw(ConfigNode partNode)
         {
             if (partNode == null) return null;
@@ -902,9 +957,12 @@ namespace Parsek
                 ps.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
                 ps.Clear(true);
 
-                var renderer = ps.GetComponent<ParticleSystemRenderer>();
-                if (renderer != null)
-                    renderer.enabled = false;
+                ParticleSystemRenderer[] renderers = ps.GetComponentsInChildren<ParticleSystemRenderer>(true);
+                for (int r = 0; r < renderers.Length; r++)
+                {
+                    if (renderers[r] != null)
+                        renderers[r].enabled = false;
+                }
 
                 sink.Add(ps);
                 added++;
@@ -1879,21 +1937,15 @@ namespace Parsek
                                         mmpOffsetStr = modelNodes[mp].GetValue("localOffset");
                                     TryParseVector3(mmpOffsetStr, out mmpLocalPos);
 
-                                    // Parse localRotation (axis-angle x,y,z,angle)
                                     Quaternion mmpLocalRot = Quaternion.identity;
                                     string mmpRotStr = modelNodes[mp].GetValue("localRotation");
-                                    if (!string.IsNullOrEmpty(mmpRotStr))
+                                    if (!TryParseFxLocalRotation(mmpRotStr, out mmpLocalRot))
                                     {
-                                        string[] rp = mmpRotStr.Split(',');
-                                        if (rp.Length >= 4 &&
-                                            float.TryParse(rp[0].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out float rx) &&
-                                            float.TryParse(rp[1].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out float ry) &&
-                                            float.TryParse(rp[2].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out float rz) &&
-                                            float.TryParse(rp[3].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out float angle))
+                                        // Some stock model FX rely on implicit orientation when
+                                        // localRotation is omitted from EFFECTS config.
+                                        if (TryGetFxModelFallbackRotation(modelName, out mmpLocalRot))
                                         {
-                                            var axis = new Vector3(rx, ry, rz);
-                                            if (axis.sqrMagnitude > 0.0001f)
-                                                mmpLocalRot = Quaternion.AngleAxis(angle, axis);
+                                            ParsekLog.Log($"    Engine FX model rotation fallback: '{modelName}' euler={mmpLocalRot.eulerAngles}");
                                         }
                                     }
 
@@ -1943,23 +1995,9 @@ namespace Parsek
                                 offsetStr = ppNodes[pp].GetValue("localPosition");
                             TryParseVector3(offsetStr, out localOffset);
 
-                            // Parse localRotation (x,y,z,angle format — axis-angle, not quaternion)
                             Quaternion localRot = Quaternion.identity;
                             string rotStr = ppNodes[pp].GetValue("localRotation");
-                            if (!string.IsNullOrEmpty(rotStr))
-                            {
-                                string[] parts = rotStr.Split(',');
-                                if (parts.Length >= 4 &&
-                                    float.TryParse(parts[0].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out float rx) &&
-                                    float.TryParse(parts[1].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out float ry) &&
-                                    float.TryParse(parts[2].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out float rz) &&
-                                    float.TryParse(parts[3].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out float angle))
-                                {
-                                    var axis = new Vector3(rx, ry, rz);
-                                    if (axis.sqrMagnitude > 0.0001f)
-                                        localRot = Quaternion.AngleAxis(angle, axis);
-                                }
-                            }
+                            TryParseFxLocalRotation(rotStr, out localRot);
 
                             prefabFxEntries.Add((prefabName, transformName, localOffset, localRot));
                         }
@@ -2301,8 +2339,7 @@ namespace Parsek
                             localOffset = parsedVector;
                         if (TryParseVector3(mmpNodes[mp].GetValue("localScale"), out parsedVector))
                             localScale = parsedVector;
-                        if (TryParseVector3(mmpNodes[mp].GetValue("localRotation"), out parsedVector))
-                            localRotation = Quaternion.Euler(parsedVector);
+                        TryParseFxLocalRotation(mmpNodes[mp].GetValue("localRotation"), out localRotation);
 
                         fxDefinitions.Add(new FxModelDefinition
                         {

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -137,40 +137,66 @@ namespace Parsek
         private static readonly Color HeatTintColor = new Color(1f, 0.45f, 0.2f, 1f);
         private static readonly Color HeatEmissionColor = new Color(1.5f, 0.6f, 0.15f, 1f);
 
-        // Cache for PREFAB_PARTICLE fx_* prefabs found via FindObjectsOfTypeAll.
-        // Built once per scene (cleared on scene change or when empty).
+        // Cache for PREFAB_PARTICLE fx_* prefabs found on PartLoader part prefabs.
+        // Built once from PartLoader.LoadedPartsList (stable prefab templates).
         private static Dictionary<string, GameObject> fxPrefabCache;
 
         /// <summary>
-        /// Find a KSP fx_* prefab by name. These exist as children of legacy parts
-        /// (e.g., fx_exhaustFlame_blue(Clone) on liquidEngine) but are NOT Unity Resources.
-        /// We scan all GameObjects in memory once and cache the results.
+        /// Find a KSP fx_* prefab by name. These exist as children of legacy part
+        /// prefabs (e.g., fx_exhaustFlame_blue(Clone) on liquidEngine's prefab transform).
+        /// We scan PartLoader.LoadedPartsList once and cache the results.
+        /// Self-heals: if a cached reference becomes Unity-null, removes and re-scans.
         /// </summary>
         private static GameObject FindFxPrefab(string prefabName)
         {
             if (fxPrefabCache == null)
+                RebuildFxPrefabCache();
+
+            GameObject result;
+            if (fxPrefabCache.TryGetValue(prefabName, out result))
             {
-                fxPrefabCache = new Dictionary<string, GameObject>();
-                var allObjects = Resources.FindObjectsOfTypeAll<GameObject>();
-                for (int i = 0; i < allObjects.Length; i++)
+                // Self-heal: if cached object was destroyed, remove and try rebuild
+                if (result == null)
                 {
-                    string name = allObjects[i].name;
+                    fxPrefabCache.Remove(prefabName);
+                    RebuildFxPrefabCache();
+                    fxPrefabCache.TryGetValue(prefabName, out result);
+                }
+            }
+            return result;
+        }
+
+        private static void RebuildFxPrefabCache()
+        {
+            fxPrefabCache = new Dictionary<string, GameObject>();
+            if (PartLoader.LoadedPartsList == null) return;
+
+            for (int p = 0; p < PartLoader.LoadedPartsList.Count; p++)
+            {
+                Part prefab = PartLoader.LoadedPartsList[p]?.partPrefab;
+                if (prefab == null) continue;
+
+                for (int c = 0; c < prefab.transform.childCount; c++)
+                {
+                    Transform child = prefab.transform.GetChild(c);
+                    string name = child.name;
                     // Strip "(Clone)" suffix if present
                     if (name.EndsWith("(Clone)"))
                         name = name.Substring(0, name.Length - 7);
-                    // Only cache fx_* objects that have a ParticleSystem
                     if (name.StartsWith("fx_") && !fxPrefabCache.ContainsKey(name)
-                        && allObjects[i].GetComponentInChildren<ParticleSystem>() != null)
+                        && child.GetComponentInChildren<ParticleSystem>() != null)
                     {
-                        fxPrefabCache[name] = allObjects[i];
+                        fxPrefabCache[name] = child.gameObject;
                     }
                 }
-                ParsekLog.Log($"  FX prefab cache built: {fxPrefabCache.Count} entries");
             }
+            ParsekLog.Log($"  FX prefab cache built from PartLoader: {fxPrefabCache.Count} entries");
+        }
 
-            GameObject result;
-            fxPrefabCache.TryGetValue(prefabName, out result);
-            return result;
+        /// <summary>Clear the fx prefab cache (e.g., on scene change).</summary>
+        internal static void ClearFxPrefabCache()
+        {
+            fxPrefabCache = null;
         }
 
         internal static GameObject BuildTimelineGhostFromSnapshot(
@@ -1686,7 +1712,11 @@ namespace Parsek
                                     float.TryParse(parts[1].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out float ry) &&
                                     float.TryParse(parts[2].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out float rz) &&
                                     float.TryParse(parts[3].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out float angle))
-                                    localRot = Quaternion.AngleAxis(angle, new Vector3(rx, ry, rz));
+                                {
+                                    var axis = new Vector3(rx, ry, rz);
+                                    if (axis.sqrMagnitude > 0.0001f)
+                                        localRot = Quaternion.AngleAxis(angle, axis);
+                                }
                             }
 
                             prefabFxEntries.Add((prefabName, transformName, localOffset, localRot));
@@ -1827,6 +1857,12 @@ namespace Parsek
 
                     // Find the attachment transform(s) on the part
                     var fxTransforms = FindTransformsRecursive(prefab.transform, transformName);
+                    if (fxTransforms.Count == 0)
+                    {
+                        ParsekLog.Log($"    Engine FX (prefab): '{partName}' midx={moduleIndex} " +
+                            $"transform '{transformName}' not found on prefab");
+                        continue;
+                    }
                     for (int t = 0; t < fxTransforms.Count; t++)
                     {
                         Transform srcFxTransform = fxTransforms[t];
@@ -1868,6 +1904,12 @@ namespace Parsek
                             info.particleSystems.Add(ps);
                             ParsekLog.Log($"    Engine FX (prefab): '{partName}' midx={moduleIndex} " +
                                 $"transform='{transformName}' prefab='{prefabName}'");
+                        }
+                        else
+                        {
+                            ParsekLog.Log($"    Engine FX (prefab): '{partName}' midx={moduleIndex} " +
+                                $"prefab '{prefabName}' has no ParticleSystem");
+                            Object.Destroy(fxInstance);
                         }
                     }
                 }

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -548,6 +548,7 @@ namespace Parsek
             DestroyAllTimelineGhosts();
             GhostVisualBuilder.ClearDeployedCanopyCache();
             GhostVisualBuilder.ClearDeployableCache();
+            GhostVisualBuilder.ClearFxPrefabCache();
             GhostVisualBuilder.ClearGearCache();
             GhostVisualBuilder.ClearLadderCache();
             GhostVisualBuilder.ClearCargoBayCache();

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -2425,6 +2425,8 @@ namespace Parsek
             ulong key = FlightRecorder.EncodeEngineKey(evt.partPersistentId, evt.moduleIndex);
             EngineGhostInfo info;
             if (!state.engineInfos.TryGetValue(key, out info)) return;
+            bool logKickback =
+                string.Equals(evt.partName, "MassiveBooster", StringComparison.OrdinalIgnoreCase);
 
             for (int i = 0; i < info.particleSystems.Count; i++)
             {
@@ -2451,6 +2453,17 @@ namespace Parsek
                     ps.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
                     ps.Clear(true);
                     SetParticleRenderersEnabled(ps, false);
+                }
+
+                if (logKickback)
+                {
+                    Transform t = ps.transform;
+                    string parentName = t != null && t.parent != null ? t.parent.name : "<none>";
+                    var main = ps.main;
+                    ParsekLog.Log($"Kickback emission diag: power={power:F2} pid={evt.partPersistentId} midx={evt.moduleIndex} " +
+                        $"ps='{ps.name}' parent='{parentName}' localRot={t.localRotation.eulerAngles} " +
+                        $"worldFwd={t.forward} worldUp={t.up} rate={emission.rateOverTimeMultiplier:F2} " +
+                        $"speed={main.startSpeedMultiplier:F2} playing={ps.isPlaying}");
                 }
             }
         }

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -2538,10 +2538,19 @@ namespace Parsek
             return $"Engine FX emission diag: part='{safePartName}' pid={partPersistentId} midx={moduleIndex} " +
                 $"power={power.ToString("F2", CultureInfo.InvariantCulture)} " +
                 $"ps='{safeParticleName}' parent='{safeParentName}' " +
-                $"localPos={localPosition} localRot={localRotationRaw} " +
-                $"worldPos={worldPosition} worldFwd={worldForward} worldUp={worldUp} " +
+                $"localPos={FormatVector3Invariant(localPosition)} localRot={localRotationRaw} " +
+                $"worldPos={FormatVector3Invariant(worldPosition)} " +
+                $"worldFwd={FormatVector3Invariant(worldForward)} " +
+                $"worldUp={FormatVector3Invariant(worldUp)} " +
                 $"rate={emissionRate.ToString("F2", CultureInfo.InvariantCulture)} " +
                 $"speed={startSpeed.ToString("F2", CultureInfo.InvariantCulture)} playing={isPlaying}";
+        }
+
+        private static string FormatVector3Invariant(Vector3 value)
+        {
+            return $"({value.x.ToString("F4", CultureInfo.InvariantCulture)}," +
+                $"{value.y.ToString("F4", CultureInfo.InvariantCulture)}," +
+                $"{value.z.ToString("F4", CultureInfo.InvariantCulture)})";
         }
 
         static void SetEngineEmission(GhostPlaybackState state, PartEvent evt, float power)
@@ -2573,32 +2582,36 @@ namespace Parsek
                 }
                 else
                 {
+                    emission.enabled = false;
                     emission.rateOverTimeMultiplier = 0;
                     ps.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
                     ps.Clear(true);
                     SetParticleRenderersEnabled(ps, false);
                 }
 
-                Transform t = ps.transform;
-                string parentName = t != null && t.parent != null ? t.parent.name : "<none>";
-                var diagMain = ps.main;
-                string diagLine = BuildEngineFxEmissionDiagnostic(
-                    evt.partName,
-                    evt.partPersistentId,
-                    evt.moduleIndex,
-                    power,
-                    ps.name,
-                    parentName,
-                    t != null ? t.localPosition : Vector3.zero,
-                    t != null ? t.localRotation : Quaternion.identity,
-                    t != null ? t.position : Vector3.zero,
-                    t != null ? t.forward : Vector3.zero,
-                    t != null ? t.up : Vector3.zero,
-                    emission.rateOverTimeMultiplier,
-                    diagMain.startSpeedMultiplier,
-                    ps.isPlaying);
-                string diagKey = $"engine-fx-{evt.partPersistentId}-{evt.moduleIndex}-{ps.GetInstanceID()}";
-                ParsekLog.VerboseRateLimited("Flight", diagKey, diagLine, 0.5);
+                if (ParsekLog.IsVerboseEnabled)
+                {
+                    Transform t = ps.transform;
+                    string parentName = t != null && t.parent != null ? t.parent.name : "<none>";
+                    var diagMain = ps.main;
+                    string diagLine = BuildEngineFxEmissionDiagnostic(
+                        evt.partName,
+                        evt.partPersistentId,
+                        evt.moduleIndex,
+                        power,
+                        ps.name,
+                        parentName,
+                        t != null ? t.localPosition : Vector3.zero,
+                        t != null ? t.localRotation : Quaternion.identity,
+                        t != null ? t.position : Vector3.zero,
+                        t != null ? t.forward : Vector3.zero,
+                        t != null ? t.up : Vector3.zero,
+                        emission.rateOverTimeMultiplier,
+                        diagMain.startSpeedMultiplier,
+                        ps.isPlaying);
+                    string diagKey = $"engine-fx-{evt.partPersistentId}-{evt.moduleIndex}-{ps.GetInstanceID()}";
+                    ParsekLog.VerboseRateLimited("Flight", diagKey, diagLine, 0.5);
+                }
             }
         }
 
@@ -2648,6 +2661,7 @@ namespace Parsek
                     float spd = ComputeScaledRcsSpeed(info.speedCurve, power, info.speedScale);
                     main.startSpeedMultiplier = spd;
 
+                    SetParticleRenderersEnabled(ps, true);
                     if (!ps.isPlaying) ps.Play();
 
                     if (sampleRate <= 0f)
@@ -2660,9 +2674,11 @@ namespace Parsek
                 }
                 else
                 {
+                    emission.enabled = false;
                     emission.rateOverTimeMultiplier = 0;
                     ps.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
                     ps.Clear(true);
+                    SetParticleRenderersEnabled(ps, false);
                 }
 
                 if (ps.isPlaying) playingSystems++;

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -2432,7 +2432,6 @@ namespace Parsek
                 if (ps == null) continue;
 
                 var emission = ps.emission;
-                var renderer = ps.GetComponent<ParticleSystemRenderer>();
                 if (power > 0f)
                 {
                     emission.enabled = true;
@@ -2443,7 +2442,7 @@ namespace Parsek
                     float spd = info.speedCurve != null ? info.speedCurve.Evaluate(power) : power * 10f;
                     main.startSpeedMultiplier = spd;
 
-                    if (renderer != null) renderer.enabled = true;
+                    SetParticleRenderersEnabled(ps, true);
                     if (!ps.isPlaying) ps.Play();
                 }
                 else
@@ -2451,8 +2450,21 @@ namespace Parsek
                     emission.rateOverTimeMultiplier = 0;
                     ps.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
                     ps.Clear(true);
-                    if (renderer != null) renderer.enabled = false;
+                    SetParticleRenderersEnabled(ps, false);
                 }
+            }
+        }
+
+        static void SetParticleRenderersEnabled(ParticleSystem ps, bool enabled)
+        {
+            if (ps == null)
+                return;
+
+            ParticleSystemRenderer[] renderers = ps.GetComponentsInChildren<ParticleSystemRenderer>(true);
+            for (int i = 0; i < renderers.Length; i++)
+            {
+                if (renderers[i] != null)
+                    renderers[i].enabled = enabled;
             }
         }
 

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -2432,8 +2432,10 @@ namespace Parsek
                 if (ps == null) continue;
 
                 var emission = ps.emission;
+                var renderer = ps.GetComponent<ParticleSystemRenderer>();
                 if (power > 0f)
                 {
+                    emission.enabled = true;
                     float emRate = info.emissionCurve != null ? info.emissionCurve.Evaluate(power) : power * 100f;
                     emission.rateOverTimeMultiplier = emRate;
 
@@ -2441,12 +2443,15 @@ namespace Parsek
                     float spd = info.speedCurve != null ? info.speedCurve.Evaluate(power) : power * 10f;
                     main.startSpeedMultiplier = spd;
 
+                    if (renderer != null) renderer.enabled = true;
                     if (!ps.isPlaying) ps.Play();
                 }
                 else
                 {
                     emission.rateOverTimeMultiplier = 0;
-                    ps.Stop();
+                    ps.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
+                    ps.Clear(true);
+                    if (renderer != null) renderer.enabled = false;
                 }
             }
         }


### PR DESCRIPTION
## Summary

- **7 new parts** added to showcase line: 4 spotlights (Mk1, Mk1 v2, Mk2, Mk2 v2), 1 extra-large gear, 2 RCS (linear port, vernor)
- **Light blink cycle**: all 10 light recordings upgraded from simple on/off toggle to a 7-event cycle exercising LightOn, LightOff, LightBlinkEnabled, LightBlinkDisabled, LightBlinkRate
- **43 engine flame/smoke FX recordings**: throttle-varying cycle for liquid/jet engines (ignite 0.3 → 0.7 → 1.0 → shutdown → full restart → 0.5 → 0.15 → shutdown), simple ignite/burnout for SRBs
- Covers all **46 stock engines** with ModuleEngines/ModuleEnginesFX (27 liquid, 10 SRB, 5 jet, 1 ion + 3 existing upgraded)
- ShowcaseRowCount 193 → 236, total showcase line now 236 entries

## Test plan

- [x] `dotnet build` compiles without errors
- [x] `dotnet test` — all 628 tests pass, 1 skipped
- [x] `dotnet test --filter InjectAllRecordings` — inject into save, verify in-game:
  - Ghost engines appear at expected positions
  - Liquid/jet engines: flames ramp through throttle levels, shut down, restart
  - SRBs: ignite at full, burnout after 12s, loop restart
  - Light blink cycle visible from pad
  - Loop restarts cleanly (no stale FX particles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)