### PR TITLE
Add two-phase parachute visuals (semi-deployed + deployed)

### DIFF
--- a/Source/Parsek.Tests/PartEventTests.cs
+++ b/Source/Parsek.Tests/PartEventTests.cs
@@ -192,67 +192,115 @@ namespace Parsek.Tests
         #region Parachute state tracking
 
         [Fact]
-        public void ParachuteTransition_StowedToDeployed_EmitsDeployedEvent()
+        public void ParachuteTransition_StowedToSemiDeployed_EmitsSemiDeployedEvent()
         {
-            var deployed = new HashSet<uint>();
-            var evt = FlightRecorder.CheckParachuteTransition(
-                42, "parachute", isDeployed: true, deployed, 100.0);
+            var states = new Dictionary<uint, int>();
+            var evt = FlightRecorder.CheckParachuteTransition(42, "parachute", 1, states, 100.0);
 
             Assert.NotNull(evt);
-            Assert.Equal(PartEventType.ParachuteDeployed, evt.Value.eventType);
+            Assert.Equal(PartEventType.ParachuteSemiDeployed, evt.Value.eventType);
             Assert.Equal(42u, evt.Value.partPersistentId);
             Assert.Equal(100.0, evt.Value.ut);
-            Assert.Contains(42u, deployed);
+            Assert.Equal(1, states[42]);
         }
 
         [Fact]
-        public void ParachuteTransition_DeployedToCut_EmitsCutEvent()
+        public void ParachuteTransition_SemiToFullyDeployed_EmitsDeployedEvent()
         {
-            var deployed = new HashSet<uint> { 42 };
-            var evt = FlightRecorder.CheckParachuteTransition(
-                42, "parachute", isDeployed: false, deployed, 120.0);
+            var states = new Dictionary<uint, int> { { 42, 1 } };
+            var evt = FlightRecorder.CheckParachuteTransition(42, "parachute", 2, states, 110.0);
+
+            Assert.NotNull(evt);
+            Assert.Equal(PartEventType.ParachuteDeployed, evt.Value.eventType);
+            Assert.Equal(2, states[42]);
+        }
+
+        [Fact]
+        public void ParachuteTransition_StowedToFullyDeployed_EmitsDeployedEvent()
+        {
+            // Edge case: recording starts with chute already deployed
+            var states = new Dictionary<uint, int>();
+            var evt = FlightRecorder.CheckParachuteTransition(42, "parachute", 2, states, 100.0);
+
+            Assert.NotNull(evt);
+            Assert.Equal(PartEventType.ParachuteDeployed, evt.Value.eventType);
+            Assert.Equal(2, states[42]);
+        }
+
+        [Fact]
+        public void ParachuteTransition_SemiDeployedToCut_EmitsCutEvent()
+        {
+            var states = new Dictionary<uint, int> { { 42, 1 } };
+            var evt = FlightRecorder.CheckParachuteTransition(42, "parachute", 0, states, 120.0);
 
             Assert.NotNull(evt);
             Assert.Equal(PartEventType.ParachuteCut, evt.Value.eventType);
-            Assert.Equal(42u, evt.Value.partPersistentId);
-            Assert.DoesNotContain(42u, deployed);
+            Assert.False(states.ContainsKey(42));
+        }
+
+        [Fact]
+        public void ParachuteTransition_FullyDeployedToCut_EmitsCutEvent()
+        {
+            var states = new Dictionary<uint, int> { { 42, 2 } };
+            var evt = FlightRecorder.CheckParachuteTransition(42, "parachute", 0, states, 120.0);
+
+            Assert.NotNull(evt);
+            Assert.Equal(PartEventType.ParachuteCut, evt.Value.eventType);
+            Assert.False(states.ContainsKey(42));
         }
 
         [Fact]
         public void ParachuteTransition_NoChange_ReturnsNull()
         {
-            var deployed = new HashSet<uint>();
-            var evt = FlightRecorder.CheckParachuteTransition(
-                42, "parachute", isDeployed: false, deployed, 100.0);
+            var states = new Dictionary<uint, int>();
+            var evt = FlightRecorder.CheckParachuteTransition(42, "parachute", 0, states, 100.0);
 
             Assert.Null(evt);
         }
 
         [Fact]
-        public void ParachuteTransition_AlreadyDeployed_ReturnsNull()
+        public void ParachuteTransition_AlreadySemiDeployed_ReturnsNull()
         {
-            var deployed = new HashSet<uint> { 42 };
-            var evt = FlightRecorder.CheckParachuteTransition(
-                42, "parachute", isDeployed: true, deployed, 100.0);
+            var states = new Dictionary<uint, int> { { 42, 1 } };
+            var evt = FlightRecorder.CheckParachuteTransition(42, "parachute", 1, states, 100.0);
 
             Assert.Null(evt);
         }
 
         [Fact]
-        public void ParachuteDestroyed_DeployedChuteDeath_EmitsParachuteDestroyed()
+        public void ParachuteTransition_AlreadyFullyDeployed_ReturnsNull()
         {
-            var deployed = new HashSet<uint> { 42 };
-            var evtType = FlightRecorder.ClassifyPartDeath(42, hasParachuteModule: true, deployed);
+            var states = new Dictionary<uint, int> { { 42, 2 } };
+            var evt = FlightRecorder.CheckParachuteTransition(42, "parachute", 2, states, 100.0);
+
+            Assert.Null(evt);
+        }
+
+        [Fact]
+        public void ParachuteDestroyed_SemiDeployedChuteDeath_EmitsParachuteDestroyed()
+        {
+            var states = new Dictionary<uint, int> { { 42, 1 } };
+            var evtType = FlightRecorder.ClassifyPartDeath(42, hasParachuteModule: true, states);
 
             Assert.Equal(PartEventType.ParachuteDestroyed, evtType);
-            Assert.DoesNotContain(42u, deployed);
+            Assert.False(states.ContainsKey(42));
+        }
+
+        [Fact]
+        public void ParachuteDestroyed_FullyDeployedChuteDeath_EmitsParachuteDestroyed()
+        {
+            var states = new Dictionary<uint, int> { { 42, 2 } };
+            var evtType = FlightRecorder.ClassifyPartDeath(42, hasParachuteModule: true, states);
+
+            Assert.Equal(PartEventType.ParachuteDestroyed, evtType);
+            Assert.False(states.ContainsKey(42));
         }
 
         [Fact]
         public void ParachuteDestroyed_StowedChuteDeath_EmitsDestroyed()
         {
-            var deployed = new HashSet<uint>();
-            var evtType = FlightRecorder.ClassifyPartDeath(42, hasParachuteModule: true, deployed);
+            var states = new Dictionary<uint, int>();
+            var evtType = FlightRecorder.ClassifyPartDeath(42, hasParachuteModule: true, states);
 
             Assert.Equal(PartEventType.Destroyed, evtType);
         }
@@ -260,11 +308,11 @@ namespace Parsek.Tests
         [Fact]
         public void ParachuteDestroyed_NonChutePart_EmitsDestroyed()
         {
-            var deployed = new HashSet<uint> { 42 };
-            var evtType = FlightRecorder.ClassifyPartDeath(99, hasParachuteModule: false, deployed);
+            var states = new Dictionary<uint, int> { { 42, 2 } };
+            var evtType = FlightRecorder.ClassifyPartDeath(99, hasParachuteModule: false, states);
 
             Assert.Equal(PartEventType.Destroyed, evtType);
-            Assert.Contains(42u, deployed); // other entries untouched
+            Assert.Contains(42u, (IDictionary<uint, int>)states); // other entries untouched
         }
 
         #endregion

--- a/Source/Parsek.Tests/SyntheticRecordingTests.cs
+++ b/Source/Parsek.Tests/SyntheticRecordingTests.cs
@@ -982,26 +982,60 @@ namespace Parsek.Tests
 
         internal static RecordingBuilder[] ParachuteShowcaseRecordings(double baseUT = 0)
         {
-            // firstEventOffsetSeconds: 3.0 gives a 3s window showing the stowed (packed) canopy
-            // before the ParachuteDeployed event fires and transitions to the deployed dome.
+            // 3-phase cycle: semi-deployed (streamer) → deployed (dome) → cut → repeat
             return new[]
             {
-                BuildPartShowcaseRecording(baseUT, "Part Showcase - Parachute Mk16", "parachuteSingle", 69,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ParachuteDeployed, PartEventType.ParachuteCut, 98300000, SinglePartPid,
-                    firstEventOffsetSeconds: 3.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
-                BuildPartShowcaseRecording(baseUT, "Part Showcase - Parachute Mk2-R", "parachuteRadial", 70,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ParachuteDeployed, PartEventType.ParachuteCut, 98300000, SinglePartPid,
-                    firstEventOffsetSeconds: 3.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
-                BuildPartShowcaseRecording(baseUT, "Part Showcase - Drogue Mk25", "parachuteDrogue", 71,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ParachuteDeployed, PartEventType.ParachuteCut, 98300000, SinglePartPid,
-                    firstEventOffsetSeconds: 3.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
-                BuildPartShowcaseRecording(baseUT, "Part Showcase - Drogue Mk12-R", "radialDrogue", 72,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ParachuteDeployed, PartEventType.ParachuteCut, 98300000, SinglePartPid,
-                    firstEventOffsetSeconds: 3.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5),
-                BuildPartShowcaseRecording(baseUT, "Part Showcase - Parachute Mk16-XL", "parachuteLarge", 73,
-                    ShowcaseDistanceFromPadMeters, PartEventType.ParachuteDeployed, PartEventType.ParachuteCut, 98300000, SinglePartPid,
-                    firstEventOffsetSeconds: 3.0, onDurationSeconds: 4.5, offDurationSeconds: 1.5)
+                BuildParachuteShowcaseRecording(baseUT, "Part Showcase - Parachute Mk16", "parachuteSingle", 69, 98300000),
+                BuildParachuteShowcaseRecording(baseUT, "Part Showcase - Parachute Mk2-R", "parachuteRadial", 70, 98300000),
+                BuildParachuteShowcaseRecording(baseUT, "Part Showcase - Drogue Mk25", "parachuteDrogue", 71, 98300000),
+                BuildParachuteShowcaseRecording(baseUT, "Part Showcase - Drogue Mk12-R", "radialDrogue", 72, 98300000),
+                BuildParachuteShowcaseRecording(baseUT, "Part Showcase - Parachute Mk16-XL", "parachuteLarge", 73, 98300000)
             };
+        }
+
+        private static RecordingBuilder BuildParachuteShowcaseRecording(
+            double baseUT, string vesselName, string partName, int rowIndex, uint pidBase)
+        {
+            const double metersPerDegree = (2.0 * Math.PI * 600000.0) / 360.0;
+            const double spacingMeters = 5.0;
+
+            double t = baseUT + 30;
+            double baseLat = -0.0972;
+            double baseLon = -74.5575;
+            double rowCenterOffsetMeters = -((ShowcaseRowCount - 1) * spacingMeters * 0.5);
+            double lat = baseLat + ((rowIndex * spacingMeters + rowCenterOffsetMeters) / metersPerDegree);
+            double lon = baseLon + ((ShowcaseDistanceFromPadMeters) / metersPerDegree);
+            double alt = 66.0;
+
+            var b = new RecordingBuilder(vesselName)
+                .WithDefaultRotation(KscRotX, KscRotY, KscRotZ, KscRotW)
+                .WithLoopPlayback(loop: true, pauseSeconds: 0.0);
+
+            // Static trajectory (24s)
+            for (int i = 0; i <= 8; i++)
+                b.AddPoint(t + (i * 3), lat, lon, alt);
+
+            // 3-phase parachute cycle: semi-deployed (3s) → deployed (3s) → cut (2s) → repeat
+            double offset = 0.0;
+            for (int cycle = 0; cycle < 3; cycle++)
+            {
+                b.AddPartEvent(t + offset, SinglePartPid, (int)PartEventType.ParachuteSemiDeployed, partName);
+                offset += 3.0;
+                b.AddPartEvent(t + offset, SinglePartPid, (int)PartEventType.ParachuteDeployed, partName);
+                offset += 3.0;
+                b.AddPartEvent(t + offset, SinglePartPid, (int)PartEventType.ParachuteCut, partName);
+                offset += 2.0;
+            }
+
+            var snap = new VesselSnapshotBuilder()
+                .WithName(vesselName)
+                .WithPersistentId((uint)(pidBase + rowIndex))
+                .AddPart(partName, rotation: "0,-0.7071068,0,0.7071068")
+                .AsLanded(lat, lon, alt)
+                .Build();
+            b.WithGhostVisualSnapshot(snap);
+
+            return b;
         }
 
         internal static RecordingBuilder[] SpecialDeployAnimationShowcaseRecordings(double baseUT = 0)
@@ -2314,11 +2348,12 @@ namespace Parsek.Tests
             var first = recordings[0].Build();
             Assert.Equal("Part Showcase - Parachute Mk16", first.GetValue("vesselName"));
             Assert.Equal("True", first.GetValue("loopPlayback"));
-            Assert.Equal(8, first.GetNodes("PART_EVENT").Length);
+            Assert.Equal(9, first.GetNodes("PART_EVENT").Length); // 3 cycles × 3 events (semi, deploy, cut)
 
             var events = first.GetNodes("PART_EVENT");
-            Assert.Equal(((int)PartEventType.ParachuteDeployed).ToString(), events[0].GetValue("type"));
-            Assert.Equal(((int)PartEventType.ParachuteCut).ToString(), events[1].GetValue("type"));
+            Assert.Equal(((int)PartEventType.ParachuteSemiDeployed).ToString(), events[0].GetValue("type"));
+            Assert.Equal(((int)PartEventType.ParachuteDeployed).ToString(), events[1].GetValue("type"));
+            Assert.Equal(((int)PartEventType.ParachuteCut).ToString(), events[2].GetValue("type"));
 
             var names = new[] { "parachuteSingle", "parachuteRadial", "parachuteDrogue", "radialDrogue", "parachuteLarge" };
             for (int i = 0; i < recordings.Length; i++)

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -28,7 +28,7 @@ namespace Parsek
         public List<PartEvent> PartEvents { get; } = new List<PartEvent>();
 
         // Part event tracking
-        private HashSet<uint> deployedParachutes = new HashSet<uint>();
+        private Dictionary<uint, int> parachuteStates = new Dictionary<uint, int>(); // 0=stowed, 1=semi, 2=deployed
         private HashSet<uint> jettisonedShrouds = new HashSet<uint>();
         private HashSet<uint> extendedDeployables = new HashSet<uint>();
         private HashSet<uint> lightsOn = new HashSet<uint>();
@@ -140,7 +140,7 @@ namespace Parsek
             if (p.vessel.persistentId != RecordingVesselId) return;
 
             bool hasChute = p.FindModuleImplementing<ModuleParachute>() != null;
-            var evtType = ClassifyPartDeath(p.persistentId, hasChute, deployedParachutes);
+            var evtType = ClassifyPartDeath(p.persistentId, hasChute, parachuteStates);
 
             PartEvents.Add(new PartEvent
             {
@@ -153,10 +153,14 @@ namespace Parsek
         }
 
         internal static PartEventType ClassifyPartDeath(
-            uint partPersistentId, bool hasParachuteModule, HashSet<uint> deployedSet)
+            uint partPersistentId, bool hasParachuteModule, Dictionary<uint, int> parachuteStates)
         {
-            if (hasParachuteModule && deployedSet.Remove(partPersistentId))
+            int state;
+            if (hasParachuteModule && parachuteStates.TryGetValue(partPersistentId, out state) && state > 0)
+            {
+                parachuteStates.Remove(partPersistentId);
                 return PartEventType.ParachuteDestroyed;
+            }
             return PartEventType.Destroyed;
         }
 
@@ -176,14 +180,39 @@ namespace Parsek
             ParsekLog.Log($"Part event: Decoupled '{joint.Child.partInfo?.name}' pid={joint.Child.persistentId}");
         }
 
+        /// <summary>
+        /// Detect parachute state transitions. States: 0=stowed/active/cut, 1=semi-deployed, 2=deployed.
+        /// </summary>
         internal static PartEvent? CheckParachuteTransition(
-            uint partPersistentId, string partName, bool isDeployed, HashSet<uint> deployedSet, double ut)
+            uint partPersistentId, string partName, int newState, Dictionary<uint, int> stateMap, double ut)
         {
-            bool wasDeployed = deployedSet.Contains(partPersistentId);
+            int oldState;
+            if (!stateMap.TryGetValue(partPersistentId, out oldState))
+                oldState = 0;
 
-            if (isDeployed && !wasDeployed)
+            if (newState == oldState)
+                return null;
+
+            if (newState > 0)
+                stateMap[partPersistentId] = newState;
+            else
+                stateMap.Remove(partPersistentId);
+
+            // 0→1: semi-deployed (streamer)
+            if (newState == 1 && oldState == 0)
             {
-                deployedSet.Add(partPersistentId);
+                return new PartEvent
+                {
+                    ut = ut,
+                    partPersistentId = partPersistentId,
+                    eventType = PartEventType.ParachuteSemiDeployed,
+                    partName = partName
+                };
+            }
+
+            // 0→2 or 1→2: fully deployed (dome)
+            if (newState == 2)
+            {
                 return new PartEvent
                 {
                     ut = ut,
@@ -193,9 +222,9 @@ namespace Parsek
                 };
             }
 
-            if (!isDeployed && wasDeployed)
+            // 1→0 or 2→0: cut
+            if (newState == 0 && oldState > 0)
             {
-                deployedSet.Remove(partPersistentId);
                 return new PartEvent
                 {
                     ut = ut,
@@ -221,11 +250,12 @@ namespace Parsek
                 var chute = p.FindModuleImplementing<ModuleParachute>();
                 if (chute == null) continue;
 
-                bool isDeployed = chute.deploymentState == ModuleParachute.deploymentStates.DEPLOYED ||
-                                  chute.deploymentState == ModuleParachute.deploymentStates.SEMIDEPLOYED;
+                int state = chute.deploymentState == ModuleParachute.deploymentStates.DEPLOYED ? 2
+                          : chute.deploymentState == ModuleParachute.deploymentStates.SEMIDEPLOYED ? 1
+                          : 0;
 
                 var evt = CheckParachuteTransition(
-                    p.persistentId, p.partInfo?.name ?? "unknown", isDeployed, deployedParachutes, ut);
+                    p.persistentId, p.partInfo?.name ?? "unknown", state, parachuteStates, ut);
                 if (evt.HasValue)
                 {
                     PartEvents.Add(evt.Value);
@@ -2804,7 +2834,7 @@ namespace Parsek
             Recording.Clear();
             OrbitSegments.Clear();
             PartEvents.Clear();
-            deployedParachutes.Clear();
+            parachuteStates.Clear();
             jettisonedShrouds.Clear();
             extendedDeployables.Clear();
             lightsOn.Clear();

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -19,10 +19,10 @@ namespace Parsek
         public Vector3 deployedCanopyScale;
         public Vector3 deployedCanopyPos;
         public Quaternion deployedCanopyRot;
-        public Vector3 stowedCanopyScale;
-        public Vector3 stowedCanopyPos;
-        public Quaternion stowedCanopyRot;
-        public bool stowedSampled;
+        public Vector3 semiDeployedCanopyScale;
+        public Vector3 semiDeployedCanopyPos;
+        public Quaternion semiDeployedCanopyRot;
+        public bool semiDeployedSampled;
     }
 
     internal class EngineGhostInfo
@@ -672,8 +672,8 @@ namespace Parsek
             return canopy;
         }
 
-        // Cache: partName → (stowed + deployed canopy states) — sample once per part type, reuse across ghosts
-        private static readonly Dictionary<string, (Vector3 sScale, Vector3 sPos, Quaternion sRot, bool stowedSampled,
+        // Cache: partName → (semi-deployed + deployed canopy states) — sample once per part type, reuse across ghosts
+        private static readonly Dictionary<string, (Vector3 sdScale, Vector3 sdPos, Quaternion sdRot, bool semiDeployedSampled,
             Vector3 dScale, Vector3 dPos, Quaternion dRot)> canopyCache =
             new Dictionary<string, (Vector3, Vector3, Quaternion, bool, Vector3, Vector3, Quaternion)>();
 
@@ -682,27 +682,29 @@ namespace Parsek
             canopyCache.Clear();
         }
 
-        private static (Vector3 sScale, Vector3 sPos, Quaternion sRot, bool stowedSampled,
+        /// <summary>
+        /// Sample both semi-deployed (streamer) and fully deployed (dome) canopy states from animations.
+        /// KSP parachute animations are sequential:
+        ///   semiDeployedAnimation@time=1 → streamer (textile on wires, no air)
+        ///   fullyDeployedAnimation@time=1 → inflated dome
+        /// Stowed state is invisible (canopy mesh starts at zero scale in prefabs).
+        /// </summary>
+        private static (Vector3 sdScale, Vector3 sdPos, Quaternion sdRot, bool semiDeployedSampled,
             Vector3 dScale, Vector3 dPos, Quaternion dRot) SampleCanopyStates(Part prefab, ModuleParachute chute)
         {
             string key = prefab.partInfo?.name ?? prefab.name;
             if (canopyCache.TryGetValue(key, out var cached))
                 return cached;
 
-            // KSP parachute animations are sequential:
-            //   semiDeployedAnimation: stowed → semi-deployed
-            //   fullyDeployedAnimation: semi-deployed → fully deployed
-            // Therefore: stowed = semiDeployedAnimation@time=0
-            //            deployed = fullyDeployedAnimation@time=1 (fallback: semiDeployedAnimation@time=1)
             string semiAnim = chute.semiDeployedAnimation;
             string fullAnim = chute.fullyDeployedAnimation;
 
             string deployedAnimName = !string.IsNullOrEmpty(fullAnim) ? fullAnim
                 : !string.IsNullOrEmpty(semiAnim) ? semiAnim : null;
 
-            Vector3 sScale = Vector3.zero, sPos = Vector3.zero;
-            Quaternion sRot = Quaternion.identity;
-            bool stowedSampled = false;
+            Vector3 sdScale = Vector3.zero, sdPos = Vector3.zero;
+            Quaternion sdRot = Quaternion.identity;
+            bool semiDeployedSampled = false;
 
             Vector3 dScale = Vector3.one, dPos = Vector3.zero;
             Quaternion dRot = Quaternion.identity;
@@ -710,7 +712,6 @@ namespace Parsek
 
             string canopyName = chute.canopyName;
 
-            // Need at least one animation to sample
             if (!string.IsNullOrEmpty(semiAnim) || !string.IsNullOrEmpty(deployedAnimName))
             {
                 Transform prefabModel = prefab.transform.Find("model") ?? prefab.transform;
@@ -718,35 +719,49 @@ namespace Parsek
 
                 try
                 {
-                    // Sample stowed state from the prefab rest pose (before any animation plays).
-                    // KSP parachute animations start from zero scale, so semiDeployedAnimation@time=0
-                    // is invisible. The actual packed canopy shape is the prefab's default mesh state.
-                    Transform stowedCanopy = !string.IsNullOrEmpty(canopyName)
-                        ? FindTransformRecursive(tempClone.transform, canopyName) : null;
-                    if (stowedCanopy != null)
-                    {
-                        sScale = stowedCanopy.localScale;
-                        sPos = tempClone.transform.InverseTransformPoint(stowedCanopy.position);
-                        sRot = Quaternion.Inverse(tempClone.transform.rotation) * stowedCanopy.rotation;
-                        // Only mark as sampled if the rest pose has visible geometry
-                        if (sScale.magnitude > 0.01f)
-                        {
-                            stowedSampled = true;
-                            ParsekLog.Log($"  Stowed canopy from prefab rest pose: scale={sScale} " +
-                                $"rootPos={sPos} rootRot={sRot.eulerAngles}");
-                        }
-                        else
-                        {
-                            ParsekLog.Log($"  Stowed canopy rest pose has near-zero scale ({sScale}), skipping");
-                        }
-                    }
-
                     Animation anim = tempClone.GetComponentInChildren<Animation>(true);
                     if (anim != null)
                     {
-                        // Sample deployed state from fullyDeployedAnimation@time=1 (or semiDeployedAnimation@time=1)
+                        // Sample semi-deployed state: semiDeployedAnimation@time=1 (streamer)
+                        if (!string.IsNullOrEmpty(semiAnim))
+                        {
+                            AnimationState semiState = anim[semiAnim];
+                            if (semiState != null)
+                            {
+                                anim.Stop();
+                                semiState.enabled = true;
+                                semiState.speed = 0f;
+                                semiState.normalizedTime = 1f;
+                                semiState.weight = 1f;
+                                anim.Play(semiAnim);
+                                anim.Sample();
+
+                                Transform canopy = !string.IsNullOrEmpty(canopyName)
+                                    ? FindTransformRecursive(tempClone.transform, canopyName) : null;
+                                if (canopy != null && canopy.localScale.magnitude > 0.01f)
+                                {
+                                    sdScale = canopy.localScale;
+                                    sdPos = tempClone.transform.InverseTransformPoint(canopy.position);
+                                    sdRot = Quaternion.Inverse(tempClone.transform.rotation) * canopy.rotation;
+                                    semiDeployedSampled = true;
+                                    ParsekLog.Log($"  Semi-deployed canopy sampled via '{semiAnim}'@1: scale={sdScale} " +
+                                        $"rootPos={sdPos} rootRot={sdRot.eulerAngles}");
+                                }
+                                else
+                                {
+                                    ParsekLog.Log($"  Semi-deploy animation '{semiAnim}'@1 gave near-zero scale, skipping");
+                                }
+                            }
+                            else
+                            {
+                                ParsekLog.Log($"  Semi-deploy animation '{semiAnim}' not found on clone for '{key}'");
+                            }
+                        }
+
+                        // Sample deployed state: fullyDeployedAnimation@time=1 (dome)
                         if (!string.IsNullOrEmpty(deployedAnimName))
                         {
+                            anim.Stop();
                             AnimationState deployState = anim[deployedAnimName];
                             if (deployState != null)
                             {
@@ -786,9 +801,7 @@ namespace Parsek
                 }
             }
 
-            // If deployed animation produced a near-zero scale, it failed to animate properly.
-            // Use a conservative fallback. Threshold is very low because stock parachutes
-            // (e.g. parachuteSingle) legitimately deploy at small scales like (0.1, 0.1, 0.1).
+            // Deployed fallback: if animation produced near-zero scale
             if (deployedSampled && dScale.magnitude < 0.01f)
             {
                 ParsekLog.Log($"  Deploy animation produced near-zero scale ({dScale}), using deployed canopy fallback");
@@ -797,9 +810,9 @@ namespace Parsek
                 dRot = Quaternion.identity;
             }
 
-            var result = (sScale, sPos, sRot, stowedSampled, dScale, dPos, dRot);
+            var result = (sdScale, sdPos, sdRot, semiDeployedSampled, dScale, dPos, dRot);
             canopyCache[key] = result;
-            ParsekLog.Log($"  Canopy states for '{key}': stowed={stowedSampled} sScale={sScale} " +
+            ParsekLog.Log($"  Canopy states for '{key}': semiDeployed={semiDeployedSampled} sdScale={sdScale} " +
                 $"deployed dScale={dScale} dPos={dPos} dRot={dRot.eulerAngles}");
             return result;
         }
@@ -3394,7 +3407,7 @@ namespace Parsek
 
                 if (ghostCanopy != null)
                 {
-                    var (sScale, sPos, sRot, stowedOk, dScale, dPos, dRot) = SampleCanopyStates(prefab, chute);
+                    var (sdScale, sdPos, sdRot, semiOk, dScale, dPos, dRot) = SampleCanopyStates(prefab, chute);
                     parachuteInfo = new ParachuteGhostInfo
                     {
                         partPersistentId = persistentId,
@@ -3403,24 +3416,14 @@ namespace Parsek
                         deployedCanopyScale = dScale,
                         deployedCanopyPos = dPos,
                         deployedCanopyRot = dRot,
-                        stowedCanopyScale = sScale,
-                        stowedCanopyPos = sPos,
-                        stowedCanopyRot = sRot,
-                        stowedSampled = stowedOk
+                        semiDeployedCanopyScale = sdScale,
+                        semiDeployedCanopyPos = sdPos,
+                        semiDeployedCanopyRot = sdRot,
+                        semiDeployedSampled = semiOk
                     };
 
-                    // Set initial canopy state: show packed shape if stowed was sampled,
-                    // otherwise hide until deploy event (current fallback behavior)
-                    if (stowedOk)
-                    {
-                        ghostCanopy.localScale = sScale;
-                        ghostCanopy.localPosition = sPos;
-                        ghostCanopy.localRotation = sRot;
-                    }
-                    else
-                    {
-                        ghostCanopy.localScale = Vector3.zero;
-                    }
+                    // Stowed = invisible (canopy mesh starts at zero scale in KSP prefabs)
+                    ghostCanopy.localScale = Vector3.zero;
 
                     if (canopySubtreeRoot != null && partName.StartsWith("kerbalEVA"))
                     {
@@ -3428,39 +3431,29 @@ namespace Parsek
                         // movement — the kerbal body pose change that swings the backpack
                         // overhead is a separate animation we can't sample. Override with a
                         // position above the kerbal's head and dome-down rotation.
-                        // EVA chutes are invisible when packed in the kerbal's backpack.
                         ghostCanopy.SetParent(partRoot.transform, false);
                         ghostCanopy.localPosition = Vector3.zero;
                         ghostCanopy.localRotation = Quaternion.identity;
                         ghostCanopy.localScale = Vector3.zero;
-                        parachuteInfo.stowedSampled = false;
+                        // EVA: both semi-deployed and deployed appear above the kerbal's head
+                        parachuteInfo.semiDeployedCanopyPos = new Vector3(0f, 1f, 0f);
+                        parachuteInfo.semiDeployedCanopyRot = Quaternion.Euler(270f, 0f, 0f);
                         parachuteInfo.deployedCanopyPos = new Vector3(0f, 1f, 0f);
                         parachuteInfo.deployedCanopyRot = Quaternion.Euler(270f, 0f, 0f);
-                        ParsekLog.Log($"    EVA parachute: overriding deployed pos=(0,1,0) rot=(270,0,0) " +
-                            $"stowed=hidden (animation sampled dPos={dPos} dRot={dRot.eulerAngles})");
+                        ParsekLog.Log($"    EVA parachute: overriding semi/deployed pos=(0,1,0) rot=(270,0,0) " +
+                            $"(animation sampled sdScale={sdScale} dScale={dScale})");
                     }
                     else if (canopySubtreeRoot != null)
                     {
                         // Non-EVA part with canopy outside modelRoot: reparent under
-                        // subtree root so root-relative deployed position works.
+                        // subtree root so root-relative positions work.
                         ghostCanopy.SetParent(canopySubtreeRoot, false);
-                        // Re-apply stowed pose after reparent (SetParent zeroes local transforms).
-                        // Without this, canopy stays pinned at subtree origin until deployment.
-                        if (stowedOk)
-                        {
-                            ghostCanopy.localScale = sScale;
-                            ghostCanopy.localPosition = sPos;
-                            ghostCanopy.localRotation = sRot;
-                        }
-                        else
-                        {
-                            ghostCanopy.localPosition = Vector3.zero;
-                            ghostCanopy.localRotation = Quaternion.identity;
-                        }
+                        ghostCanopy.localPosition = Vector3.zero;
+                        ghostCanopy.localRotation = Quaternion.identity;
                     }
 
                     ParsekLog.Log($"    Parachute detected: canopy='{canopyName}' cap='{capName}' " +
-                        $"stowed={parachuteInfo.stowedSampled} stowScale={parachuteInfo.stowedCanopyScale} " +
+                        $"semiDeployed={parachuteInfo.semiDeployedSampled} sdScale={parachuteInfo.semiDeployedCanopyScale} " +
                         $"deployScale={parachuteInfo.deployedCanopyScale} " +
                         $"deployPos={parachuteInfo.deployedCanopyPos} " +
                         $"deployRot={parachuteInfo.deployedCanopyRot.eulerAngles} " +

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -718,42 +718,32 @@ namespace Parsek
 
                 try
                 {
+                    // Sample stowed state from the prefab rest pose (before any animation plays).
+                    // KSP parachute animations start from zero scale, so semiDeployedAnimation@time=0
+                    // is invisible. The actual packed canopy shape is the prefab's default mesh state.
+                    Transform stowedCanopy = !string.IsNullOrEmpty(canopyName)
+                        ? FindTransformRecursive(tempClone.transform, canopyName) : null;
+                    if (stowedCanopy != null)
+                    {
+                        sScale = stowedCanopy.localScale;
+                        sPos = tempClone.transform.InverseTransformPoint(stowedCanopy.position);
+                        sRot = Quaternion.Inverse(tempClone.transform.rotation) * stowedCanopy.rotation;
+                        // Only mark as sampled if the rest pose has visible geometry
+                        if (sScale.magnitude > 0.01f)
+                        {
+                            stowedSampled = true;
+                            ParsekLog.Log($"  Stowed canopy from prefab rest pose: scale={sScale} " +
+                                $"rootPos={sPos} rootRot={sRot.eulerAngles}");
+                        }
+                        else
+                        {
+                            ParsekLog.Log($"  Stowed canopy rest pose has near-zero scale ({sScale}), skipping");
+                        }
+                    }
+
                     Animation anim = tempClone.GetComponentInChildren<Animation>(true);
                     if (anim != null)
                     {
-                        // Sample stowed state from semiDeployedAnimation@time=0
-                        if (!string.IsNullOrEmpty(semiAnim))
-                        {
-                            AnimationState semiState = anim[semiAnim];
-                            if (semiState != null)
-                            {
-                                semiState.enabled = true;
-                                semiState.speed = 0f;
-                                semiState.normalizedTime = 0f;
-                                semiState.weight = 1f;
-                                anim.Play(semiAnim);
-                                anim.Sample();
-
-                                Transform canopy = !string.IsNullOrEmpty(canopyName)
-                                    ? FindTransformRecursive(tempClone.transform, canopyName) : null;
-                                if (canopy != null)
-                                {
-                                    sScale = canopy.localScale;
-                                    sPos = tempClone.transform.InverseTransformPoint(canopy.position);
-                                    sRot = Quaternion.Inverse(tempClone.transform.rotation) * canopy.rotation;
-                                    stowedSampled = true;
-                                    ParsekLog.Log($"  Stowed canopy sampled via '{semiAnim}'@0: scale={sScale} " +
-                                        $"rootPos={sPos} rootRot={sRot.eulerAngles}");
-                                }
-
-                                semiState.enabled = false;
-                            }
-                            else
-                            {
-                                ParsekLog.Log($"  Semi-deployed animation '{semiAnim}' not found on clone for '{key}'");
-                            }
-                        }
-
                         // Sample deployed state from fullyDeployedAnimation@time=1 (or semiDeployedAnimation@time=1)
                         if (!string.IsNullOrEmpty(deployedAnimName))
                         {

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -2199,6 +2199,26 @@ namespace Parsek
                         HideGhostPart(ghost, evt.partPersistentId);
                         Log($"Part event applied: ParachuteDestroyed '{evt.partName}' pid={evt.partPersistentId}");
                         break;
+                    case PartEventType.ParachuteSemiDeployed:
+                        if (state.parachuteInfos != null)
+                        {
+                            ParachuteGhostInfo semiInfo;
+                            if (state.parachuteInfos.TryGetValue(evt.partPersistentId, out semiInfo) &&
+                                semiInfo.canopyTransform != null && semiInfo.semiDeployedSampled)
+                            {
+                                semiInfo.canopyTransform.localScale = semiInfo.semiDeployedCanopyScale;
+                                semiInfo.canopyTransform.localPosition = semiInfo.semiDeployedCanopyPos;
+                                semiInfo.canopyTransform.localRotation = semiInfo.semiDeployedCanopyRot;
+                                if (semiInfo.capTransform != null)
+                                    semiInfo.capTransform.gameObject.SetActive(false);
+                                Log($"Part event: ParachuteSemiDeployed '{evt.partName}' — streamer canopy shown");
+                            }
+                            else
+                            {
+                                Log($"Part event: ParachuteSemiDeployed '{evt.partName}' — no semi-deployed state sampled, skipping");
+                            }
+                        }
+                        break;
                     case PartEventType.ParachuteDeployed:
                         bool usedRealCanopy = false;
 

--- a/Source/Parsek/PartEvent.cs
+++ b/Source/Parsek/PartEvent.cs
@@ -34,7 +34,8 @@ namespace Parsek
         RoboticPositionSample, // 29 - robotic module motion sample (value = sampled position)
         RoboticMotionStopped, // 30 - robotic module stopped moving (value = sampled position)
         ThermalAnimationHot,  // 31 - ModuleAnimateHeat entered hot visual state
-        ThermalAnimationCold  // 32 - ModuleAnimateHeat returned to cold visual state
+        ThermalAnimationCold, // 32 - ModuleAnimateHeat returned to cold visual state
+        ParachuteSemiDeployed // 33 - parachute entered semi-deployed (streamer) state
     }
 
     public struct PartEvent


### PR DESCRIPTION
## Summary
- Add `ParachuteSemiDeployed` event type for the streamer/textile-on-wires state
- Ghost parachutes now transition: hidden → semi-deployed (streamer) → deployed (dome) → cut
- `FlightRecorder` tracks `SEMIDEPLOYED` and `DEPLOYED` as separate transitions (previously lumped together)
- `SampleCanopyStates` samples `semiDeployedAnimation@time=1` for streamer, `fullyDeployedAnimation@time=1` for dome
- Showcase recordings use 3-phase looping cycle

## Test plan
- [x] 633 tests pass, 1 skipped (pre-existing)
- [x] In-game verification: all 5 stock parachute types cycle through semi → deployed → cut correctly
- [x] KSP.log clean — zero errors, all transitions logged properly
- [x] Real-flight recording captures both ParachuteSemiDeployed and ParachuteDeployed events separately