### PR TITLE
Implement exhaustive structured logging with verbose mode default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+See [CLAUDE.md](CLAUDE.md) for all project instructions and development workflow.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,20 +1,320 @@
-# CLAUDE.md
+## Git Commits
+- Do NOT add `Co-Authored-By` or any signature line to commit messages
 
-## Local KSP.log validation
+# Claude Development Notes
 
-Use this local workflow while developing logging-sensitive features:
+## Project Configuration
 
-1. Run unit tests:
-   - `dotnet test Source/Parsek.Tests/Parsek.Tests.csproj`
-2. Run an in-game manual scenario in KSP.
-3. Validate the latest Parsek log session:
-   - `pwsh -File scripts/validate-ksp-log.ps1`
+### KSP Installation
+- **Local KSP instance** at `Kerbal Space Program/` in project root
+- This is a **clean copy** for testing, NOT the Steam installation
+- Steam installation stays intact for normal gameplay
+- Safe to test and modify without affecting Steam
+
+### KSP Instance Setup
+**Minimal mods installed (testing environment):**
+- Squad / SquadExpansion (stock game files)
+- ModuleManager 4.2.3 (essential for mods)
+- Harmony (essential for runtime patching)
+- ClickThroughBlocker (prevents UI click-through)
+- ToolbarControl (stock + Blizzy toolbar integration)
+- **Parsek** (our mod being developed)
+
+All other mods removed for clean testing environment.
+
+### Build Configuration
+- KSP assemblies referenced from: `Kerbal Space Program/KSP_x64_Data/Managed/`
+- Build output copied to: `Kerbal Space Program/GameData/Parsek/Plugins/`
+- Auto-deployed on every build via MSBuild post-build target
+
+### Project Structure
+```
+Parsek/
+├── Kerbal Space Program/    # Local KSP instance for testing
+│   ├── GameData/
+│   │   ├── Squad/           # Stock parts
+│   │   ├── 000_Harmony/     # Essential dependency
+│   │   ├── ModuleManager.*  # Essential dependency
+│   │   └── Parsek/          # Our mod (auto-deployed)
+│   │       └── Plugins/
+│   │           ├── Parsek.dll
+│   │           └── Parsek.pdb
+│   ├── KSP_x64_Data/
+│   │   └── Managed/         # Assembly references
+│   └── KSP.log              # Debug output here
+├── Source/                   # Mod source code
+│   ├── Parsek/
+│   │   ├── Parsek.csproj    # SDK-style project
+│   │   ├── ParsekFlight.cs  # Main flight-scene controller (playback, timeline, input)
+│   │   ├── FlightRecorder.cs # Recording state + sampling (called by Harmony patch)
+│   │   ├── ParsekHarmony.cs  # Harmony patcher entry point (KSPAddon.Startup.Instantly)
+│   │   ├── Patches/
+│   │   │   ├── PhysicsFramePatch.cs # Harmony postfix on VesselPrecalculate
+│   │   │   ├── TechResearchPatch.cs # Blocks re-researching committed tech
+│   │   │   └── FacilityUpgradePatch.cs # Blocks re-upgrading committed facilities
+│   │   ├── ParsekUI.cs      # UI window and map view markers
+│   │   ├── ParsekLog.cs     # Shared logging utilities
+│   │   ├── ParsekScenario.cs # ScenarioModule for save/load, crew reservation & replacement
+│   │   ├── ParsekToolbarRegistration.cs # ToolbarControl registration
+│   │   ├── RecordingStore.cs # Static storage surviving scene changes
+│   │   ├── TrajectoryPoint.cs # Position/rotation/resource data struct
+│   │   ├── OrbitSegment.cs   # Keplerian orbit parameters for on-rails recording
+│   │   ├── TrajectoryMath.cs # Pure static math (sampling, interpolation, orbit search)
+│   │   ├── VesselSpawner.cs  # Vessel spawn/recover/snapshot utilities
+│   │   ├── MergeDialog.cs    # Post-revert merge dialog
+│   │   ├── PartEvent.cs      # Part event enum + struct (decoupled, destroyed, parachute)
+│   │   ├── GhostVisualBuilder.cs # Ghost mesh building from vessel snapshots
+│   │   ├── RecordingPaths.cs # Save-scoped path resolution
+│   │   ├── ParsekSettings.cs # GameParameters.CustomParameterNode (per-save settings)
+│   │   ├── Milestone.cs      # Milestone data class (events grouped into timeline commits)
+│   │   ├── MilestoneStore.cs # Static milestone collection, file I/O, committed action queries
+│   │   ├── ResourceBudget.cs # On-the-fly budget computation from recordings + milestones
+│   │   ├── GameStateEvent.cs # Event struct + enum (18 types), ContractSnapshot
+│   │   ├── GameStateStore.cs # Persistent event log, contract snapshots, baselines
+│   │   ├── GameStateRecorder.cs # Career event subscriber (contracts, tech, crew, facilities)
+│   │   ├── GameStateBaseline.cs # Full game state snapshot at commit points
+│   │   └── CommittedActionDialog.cs # PopupDialog for blocked actions
+│   └── Parsek.Tests/         # Unit tests (xUnit)
+│       ├── Generators/
+│       │   ├── RecordingBuilder.cs       # Fluent RECORDING ConfigNode builder
+│       │   ├── VesselSnapshotBuilder.cs  # Minimal VESSEL ConfigNode builder
+│       │   └── ScenarioWriter.cs         # SCENARIO assembly + .sfs injection
+│       ├── SyntheticRecordingTests.cs    # 8 synthetic recordings + injection tests
+│       ├── PartEventTests.cs            # Part event serialization, subtree, parachute tests
+│       ├── DiagnosticLoggingTests.cs    # Regression tests for playback logging
+│       ├── MilestoneTests.cs            # Milestone creation, flushing, partial replay
+│       ├── ResourceBudgetTests.cs       # Resource reservation, partial replay, over-commit
+│       ├── GameStateEventTests.cs       # Event serialization and epoch filtering
+│       └── CommittedActionTests.cs      # Action-blocking logic tests
+├── docs/                     # Documentation
+├── mods/                     # Reference mods (git-ignored)
+├── CLAUDE.md                 # This file
+├── build.bat                 # Build script (alternative to dotnet)
+└── .gitignore               # Git ignore rules
+```
+
+## Development Workflow
+
+### Build
+```bash
+cd Source/Parsek
+dotnet build              # Debug build (default)
+dotnet build -c Release   # Release build
+```
+
+Builds automatically copy to `Kerbal Space Program/GameData/Parsek/Plugins/`
+
+### Unit Tests
+```bash
+cd Source/Parsek.Tests
+dotnet test
+```
+
+### Local KSP.log Validation
+
+After running a manual in-game scenario, validate the latest Parsek session:
+
+```bash
+pwsh -File scripts/validate-ksp-log.ps1
+```
 
 The validator reads `KSP.log`, selects entries from the last
 `[Parsek][INFO][Init] SessionStart runUtc=...` marker, and fails if
-structured log contracts are violated.
+structured log contracts are violated. Verbose logging is expected to be
+enabled during development. The script exits non-zero on failure.
 
-## Notes
+### Synthetic Recording Injection
+```bash
+cd Source/Parsek.Tests
+dotnet test --filter InjectAllRecordings
+```
 
-- Verbose logging is expected to be enabled during development.
-- The validation script exits non-zero on failure and should be treated as a failed local check.
+Injects 8 synthetic recordings into `saves/test career/` (both `persistent.sfs` and `1.sfs`):
+- **Pad Walk** — 30s EVA ghost (Jeb walks near launchpad)
+- **KSC Hopper** — 56s ghost ship (Val hops east ~600m)
+- **Flea Flight** — 90s vessel spawn (Bob, lands ~2km east, real flight data)
+- **Suborbital Arc** — 300s ghost ship (Bill, gravity turn to 71km)
+- **KSC Pad Destroyed** — 12s sphere ghost (no snapshot, destroyed vessel)
+- **Orbit-1** — 3000s vessel spawn (Bill, orbit with Keplerian segment)
+- **Close Spawn Conflict** — 12s vessel spawn (Jeb, tests proximity offset)
+- **Island Probe** — 180s vessel spawn (Val, flies to island airfield)
+
+**How it works:**
+- Save UT is set to 17000 (KSC mid-morning) during `--clean-start` for consistent daytime lighting
+- Recording offsets are 30s apart from that base UT (first ghost at +30s)
+- Injected into both `persistent.sfs` and `1.sfs` (KSP's `initialLoadDone` guard skips reload if only one is patched)
+- All crewed recordings use the FleaRocket craft (mk1pod.v2 + solidBooster.sm.v2 + parachuteSingle) with real part positions
+
+**Reproducible end-to-end test workflow:**
+1. `dotnet test --filter InjectAllRecordings` — inject recordings
+2. (Re)start KSP (required if DLL changed — post-build copy fails while KSP locks it)
+3. Load `test career` → save 1
+4. Enter flight (launch any vessel or EVA from pad)
+5. Time warp — ghosts appear at scheduled UTs, vessels spawn at end
+6. `grep "[Parsek]" "Kerbal Space Program/KSP.log"` — verify full diagnostic narrative
+
+See `docs/synthetic-recordings.md` for builder API docs.
+
+### In-Game Test
+```bash
+"Kerbal Space Program/KSP_x64.exe"
+```
+
+**Recording + Timeline (core flow):**
+1. Launch KSP, start any flight (career mode for resource tracking)
+2. Press **F9** to start recording
+3. Fly around for 30-60 seconds
+4. Press **F9** to stop recording
+5. Revert to Launch (Esc → Revert to Launch)
+6. A context-aware merge dialog appears with recommended action:
+   - **Vessel barely moved (<100m):** "Merge + Recover" (default), "Merge + Keep Vessel", "Discard"
+   - **Vessel destroyed:** "Merge to Timeline" (default), "Discard"
+   - **Vessel intact, moved far:** "Merge + Keep Vessel" (default), "Merge + Recover", "Discard"
+7. Wait on the pad until UT reaches original recording timestamps
+8. Ghost vessel appears (opaque replica with original part textures) and replays previous flight
+9. Engine flames and smoke appear on the ghost during burn phases
+10. Decoupled/destroyed parts disappear from ghost at the correct time
+11. Funds/science/reputation deltas are applied at the correct UT
+
+**Vessel persistence test:**
+1. Launch to orbit → F9 record → revert → "Merge + Keep Vessel"
+2. Go to Tracking Station → vessel appears in orbit
+3. Or choose "Merge + Recover" → funds credited, no vessel in orbit
+
+**Crew replacement test:**
+1. Record with Jeb → revert → "Merge + Keep Vessel"
+2. Check Astronaut Complex: Jeb is Assigned, a new kerbal with same trait appeared
+3. Launch new flight — replacement kerbal is available in crew selection
+4. Wait for EndUT → Jeb's vessel spawns, replacement is removed from roster
+5. Repeat: record again → replacement pool stays stable (no kerbal leak)
+
+**Wipe cleanup test:**
+1. Record + merge several times with "Keep Vessel"
+2. Click "Wipe Recordings" in Parsek UI
+3. All reserved kerbals return to Available, all replacements removed
+
+**Orbital recording test (hybrid orbit segments):**
+1. Launch → establish orbit → F9 record → time warp 50x for one orbit → drop to 1x → F9 stop → revert → merge
+2. Verify ghost follows orbital path during playback (uses analytical orbit, not sampled points)
+3. Record Mun encounter with time warp → verify SOI transition in ghost playback
+4. Record with multiple time warp on/off cycles → verify smooth transitions at boundary points
+
+**Part event test (staging/decoupling):**
+1. Launch vessel with SRB + parachute → F9 record → stage SRB → deploy chute → F9 stop → revert → merge
+2. Watch ghost: SRB + everything below decoupler disappears at staging UT
+3. Parachute events logged (canopy mesh not replayed — procedural)
+
+**EVA child recording test:**
+1. Launch with crew → F9 record → EVA kerbal → verify parent auto-commits + child recording starts
+2. Revert → both ghosts play back (vessel ghost and EVA kerbal ghost)
+3. Parent vessel spawns without EVA'd kerbal → EVA kerbal spawns separately
+
+**Settings test:**
+1. Open Parsek UI → Settings → toggle auto-record off
+2. Launch → verify no auto-recording
+3. Toggle auto-warp-stop off → warp past recording → verify warp continues
+4. Adjust sampling sliders → record → observe different sample density
+5. Click Defaults → verify all values reset
+6. Save/reload → verify settings persist
+7. Esc > Settings > Parsek → verify same values in KSP difficulty screen
+
+**Manual preview (no revert needed):**
+1. Record as above, press **F10** to preview playback immediately
+2. Press **F11** to stop preview
+
+**Controls:**
+- **F9** — Start/Stop recording
+- **F10** — Preview playback (current recording, relative time)
+- **F11** — Stop preview
+- **Toolbar button** (top-right) — Toggle Parsek UI window
+
+### Automatic Behaviors
+
+These happen silently to keep gameplay smooth. All are logged to `KSP.log` with `[Parsek]` or `[Parsek Scenario]` prefixes.
+
+**Auto-recording:**
+- Recording starts automatically when a vessel leaves PRELAUNCH (pad/runway liftoff)
+- Recording starts automatically when a kerbal goes EVA from a vessel on the pad/runway
+- EVA auto-record is deferred by one frame via `pendingAutoRecord` flag (vessel switch delay)
+- Mid-recording EVA: auto-stops parent, commits it to timeline, starts linked child recording for EVA kerbal
+
+**Part event recording:**
+- Part death (`onPartDie`) and joint break (`onPartJointBreak`) are recorded as `PartEvent` entries
+- Parachute state transitions are polled every physics frame (before adaptive sampling early-return)
+- Part events are serialized as `PART_EVENT` ConfigNodes in the save file
+
+**Recording safeguards:**
+- Recording is blocked while the game is paused
+- Recording auto-stops if the active vessel changes (docking, pressing `[`/`]`)
+- Recordings shorter than 2 sample points are silently dropped on revert
+- Adaptive sampling: Harmony postfix fires every physics frame but only records when velocity direction changes >2deg, speed changes >5%, or 3s max interval elapses
+- When vessel goes on rails (time warp), trajectory sampling stops and an OrbitSegment captures the Keplerian orbit parameters instead
+- When vessel goes off rails, the orbit segment is finalized and sampling resumes with boundary points at each transition
+- SOI changes during on-rails recording close the current orbit segment and open a new one for the new body
+
+**Ghost playback:**
+- Ghost built from vessel snapshot using prefab meshes with original materials (fully opaque, realistic appearance)
+- Falls back to green sphere if no vessel snapshot available
+- Engine FX (flames, smoke) displayed during burn phases — modern EFFECTS engines use cloned MODEL_MULTI_PARTICLE prefabs; legacy stock parts (Flea SRB, LV-T30) use cloned fx_* prefab children with SmokeTrailControl stripped
+- Part events applied during playback: decoupled subtrees hidden, destroyed parts hidden, parachute events logged
+- Ghost part tree (persistentId-based) enables O(1) part lookup and recursive subtree hiding on decouple
+- Time warp is stopped once when UT first enters a recording's range (only if the recording has an unspawned vessel). Time warp during active ghost playback is allowed.
+- SOI changes during recording are handled — each trajectory point references its own celestial body
+- During orbit segments, ghost position is computed analytically from Keplerian orbit parameters (no interpolation needed)
+
+**Vessel spawning:**
+- If a vessel would spawn within 200m of any other vessel, it is offset to 250m away to prevent physics collisions
+- Duplicate spawns are prevented by tracking each spawned vessel's `persistentId`
+- Dead or missing crew are stripped from vessel snapshots before spawning
+
+**Resource deltas:**
+- Funds, science, and reputation deltas are clamped so they never go below zero
+- `LastAppliedResourceIndex` is persisted in saves so quickload doesn't double-apply deltas
+
+**Scene transitions:**
+- If a pending recording exists when leaving Flight (e.g. Abort Mission → Space Center), it is auto-committed to the timeline without vessel persistence
+- If UT passes a recording's EndUT while outside Flight (Space Center, Tracking Station), reserved crew are auto-unreserved to prevent them being stuck as Assigned forever
+
+### Debug
+- Check `Kerbal Space Program/KSP.log` for errors
+- `grep "[Parsek]" KSP.log` captures all diagnostic logs (single prefix)
+- `[Parsek Scenario]` prefix used only by legacy OnSave/OnLoad bookkeeping
+- Alt+F12 opens Unity debug console in-game
+
+**Diagnostic log narrative** (all use `[Parsek]` prefix):
+- **Scenario load:** recording count, per-recording status (future/in-progress/past), crew reservations
+- **Flight ready:** per-recording summary (UT range, point count, orbit segments, vessel/ghost-only)
+- **Ghost lifecycle:** ENTERED/EXITED range with UT, spawn or no-spawn reason
+- **Orbit segments:** activation with cache key, body, SMA, UT range
+- **Resource deltas:** completion summary with recorded fund/science/rep totals
+- **Vessel spawn:** situation, crew list, nearest vessel distance
+- **Warp stop:** one log per recording (not per-frame — guarded by HashSet)
+
+## Git Configuration
+
+**Ignored folders:**
+- `Kerbal Space Program/` - Local KSP instance (too large)
+- `mods/` - Reference mods (submodules/clones)
+- `.claude/` - Local Claude settings
+- `bin/`, `obj/` - Build artifacts
+
+**Tracked:**
+- `Source/` - Mod source code
+- `docs/` - Documentation
+- `build.bat` - Build script
+- `.gitignore` - Git ignore rules
+
+## Post-Change Checklist
+
+After any major change (new enum values, new event types, new serialized fields, schema changes):
+1. **Check save serialization** — verify `ParsekScenario.cs` OnSave/OnLoad handles the new data (int casts, ConfigNode keys)
+2. **Check synthetic recording injector** — verify `RecordingBuilder` / `VesselSnapshotBuilder` / `ScenarioWriter` in `Tests/Generators/` can produce test data exercising the new feature
+3. **Consider adding a synthetic recording** that exercises the new feature for end-to-end KSP testing via `dotnet test --filter InjectAllRecordings`
+4. **Run `dotnet test`** — all existing tests must still pass
+
+## Why This Approach
+
+- **Isolated testing** - No conflicts with Steam installation
+- **Clean environment** - Minimal mods = easier debugging
+- **Fast iteration** - Auto-deployment on build
+- **Reproducible** - Can share exact test environment setup

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,20 @@
+# CLAUDE.md
+
+## Local KSP.log validation
+
+Use this local workflow while developing logging-sensitive features:
+
+1. Run unit tests:
+   - `dotnet test Source/Parsek.Tests/Parsek.Tests.csproj`
+2. Run an in-game manual scenario in KSP.
+3. Validate the latest Parsek log session:
+   - `pwsh -File scripts/validate-ksp-log.ps1`
+
+The validator reads `KSP.log`, selects entries from the last
+`[Parsek][INFO][Init] SessionStart runUtc=...` marker, and fails if
+structured log contracts are violated.
+
+## Notes
+
+- Verbose logging is expected to be enabled during development.
+- The validation script exits non-zero on failure and should be treated as a failed local check.

--- a/Source/Parsek.Tests/Fixtures/KspLog/bad_error_present.log
+++ b/Source/Parsek.Tests/Fixtures/KspLog/bad_error_present.log
@@ -1,0 +1,6 @@
+[LOG 11:21:00.500] [KSP] Entering flight scene
+[LOG 11:21:01.010] [Parsek][INFO][Init] SessionStart runUtc=1700000300
+[LOG 11:21:01.020] [Parsek][INFO][Recorder] Recording started (physics-frame sampling)
+[LOG 11:21:01.700] [Parsek][ERROR][Spawner] SpawnAtPosition failed: vesselRef is null
+[LOG 11:21:02.100] [Parsek][INFO][GameStateRecorder] Game state: FundsChanged +40 (Test) → 40
+[LOG 11:21:04.500] [Parsek][INFO][Recorder] Recording stopped. 5 points, 0 orbit segments over 3.5s

--- a/Source/Parsek.Tests/Fixtures/KspLog/bad_malformed_parsek_line.log
+++ b/Source/Parsek.Tests/Fixtures/KspLog/bad_malformed_parsek_line.log
@@ -1,0 +1,6 @@
+[LOG 11:20:00.500] [KSP] Entering flight scene
+[LOG 11:20:01.010] [Parsek][INFO][Init] SessionStart runUtc=1700000200
+[LOG 11:20:01.020] [Parsek][INFO][Recorder] Recording started (physics-frame sampling)
+[LOG 11:20:01.050] [Parsek][INFO][Recorder Recording started without closing bracket
+[LOG 11:20:01.150] [Parsek][INFO][GameStateRecorder] Game state: FundsChanged +10 (Test) → 10
+[LOG 11:20:03.500] [Parsek][INFO][Recorder] Recording stopped. 4 points, 0 orbit segments over 2.4s

--- a/Source/Parsek.Tests/Fixtures/KspLog/bad_negative_resource.log
+++ b/Source/Parsek.Tests/Fixtures/KspLog/bad_negative_resource.log
@@ -1,0 +1,5 @@
+[LOG 11:25:00.500] [KSP] Entering flight scene
+[LOG 11:25:01.010] [Parsek][INFO][Init] SessionStart runUtc=1700000700
+[LOG 11:25:01.020] [Parsek][INFO][Recorder] Recording started (physics-frame sampling)
+[LOG 11:25:02.100] [Parsek][INFO][GameStateRecorder] Game state: FundsChanged -200 (Penalty) → -1
+[LOG 11:25:04.500] [Parsek][INFO][Recorder] Recording stopped. 5 points, 0 orbit segments over 3.5s

--- a/Source/Parsek.Tests/Fixtures/KspLog/bad_recording_stop_values.log
+++ b/Source/Parsek.Tests/Fixtures/KspLog/bad_recording_stop_values.log
@@ -1,0 +1,5 @@
+[LOG 11:24:00.500] [KSP] Entering flight scene
+[LOG 11:24:01.010] [Parsek][INFO][Init] SessionStart runUtc=1700000600
+[LOG 11:24:01.020] [Parsek][INFO][Recorder] Recording started (physics-frame sampling)
+[LOG 11:24:02.100] [Parsek][INFO][GameStateRecorder] Game state: FundsChanged +40 (Test) → 40
+[LOG 11:24:04.500] [Parsek][INFO][Recorder] Recording stopped. 1 points, -1 orbit segments over -3.5s

--- a/Source/Parsek.Tests/Fixtures/KspLog/bad_suppressed_value.log
+++ b/Source/Parsek.Tests/Fixtures/KspLog/bad_suppressed_value.log
@@ -1,0 +1,6 @@
+[LOG 11:23:00.500] [KSP] Entering flight scene
+[LOG 11:23:01.010] [Parsek][INFO][Init] SessionStart runUtc=1700000500
+[LOG 11:23:01.020] [Parsek][INFO][Recorder] Recording started (physics-frame sampling)
+[LOG 11:23:01.060] [Parsek][VERBOSE][Recorder] Sample skipped due to adaptive threshold | suppressed=abc
+[LOG 11:23:02.100] [Parsek][INFO][GameStateRecorder] Game state: FundsChanged +40 (Test) → 40
+[LOG 11:23:04.500] [Parsek][INFO][Recorder] Recording stopped. 5 points, 0 orbit segments over 3.5s

--- a/Source/Parsek.Tests/Fixtures/KspLog/bad_warn_warning_prefix.log
+++ b/Source/Parsek.Tests/Fixtures/KspLog/bad_warn_warning_prefix.log
@@ -1,0 +1,6 @@
+[LOG 11:22:00.500] [KSP] Entering flight scene
+[LOG 11:22:01.010] [Parsek][INFO][Init] SessionStart runUtc=1700000400
+[LOG 11:22:01.020] [Parsek][INFO][Recorder] Recording started (physics-frame sampling)
+[LOG 11:22:01.700] [Parsek][WARN][Spawner] WARNING: Spawn attempt delayed by cooldown
+[LOG 11:22:02.100] [Parsek][INFO][GameStateRecorder] Game state: FundsChanged +40 (Test) → 40
+[LOG 11:22:04.500] [Parsek][INFO][Recorder] Recording stopped. 5 points, 0 orbit segments over 3.5s

--- a/Source/Parsek.Tests/Fixtures/KspLog/good_latest_session.log
+++ b/Source/Parsek.Tests/Fixtures/KspLog/good_latest_session.log
@@ -1,0 +1,11 @@
+[LOG 11:10:01.100] [ModuleManager] Applying update pass
+[LOG 11:10:01.250] [ToolbarControl] Toolbar initialized
+[LOG 11:10:02.001] [Parsek][INFO][Init] SessionStart runUtc=1700000100
+[LOG 11:10:02.140] [Parsek][INFO][Harmony] Harmony patches applied for assembly 'Parsek'
+[LOG 11:10:12.410] [Parsek][INFO][Recorder] Recording started (physics-frame sampling)
+[LOG 11:10:12.900] [Parsek][VERBOSE][Recorder] Sample skipped due to adaptive threshold | suppressed=2
+[LOG 11:10:13.100] [Parsek][INFO][GameStateRecorder] Game state: FundsChanged +1200 (ContractReward) → 10000
+[LOG 11:10:13.200] [Parsek][INFO][GameStateRecorder] Game state: ScienceChanged +1.5 (Research) → 12.5
+[LOG 11:10:13.300] [Parsek][INFO][GameStateRecorder] Game state: ReputationChanged +0.3 (Recovery) → 2.1
+[LOG 11:10:55.700] [Parsek][INFO][Recorder] Recording stopped. 15 points, 1 orbit segments over 42.5s
+[LOG 11:10:56.010] [Roster] Kerbal roster sync completed

--- a/Source/Parsek.Tests/Fixtures/KspLog/multi_session_uses_last_marker.log
+++ b/Source/Parsek.Tests/Fixtures/KspLog/multi_session_uses_last_marker.log
@@ -1,0 +1,9 @@
+[LOG 11:30:00.010] [Parsek][INFO][Init] SessionStart runUtc=1000
+[LOG 11:30:00.020] [Parsek][INFO][Recorder] Recording started (physics-frame sampling)
+[LOG 11:30:00.200] [Parsek][ERROR][Spawner] Old failure from prior session
+[LOG 11:30:00.300] [Parsek][INFO][Recorder] Recording stopped. 5 points, 0 orbit segments over 3.0s
+[LOG 11:35:00.010] [Parsek][INFO][Init] SessionStart runUtc=2000
+[LOG 11:35:00.020] [Parsek][INFO][Recorder] Recording started (physics-frame sampling)
+[LOG 11:35:00.120] [Parsek][VERBOSE][Recorder] Sample skipped due to adaptive threshold | suppressed=1
+[LOG 11:35:00.220] [Parsek][INFO][GameStateRecorder] Game state: FundsChanged +20 (Test) → 20
+[LOG 11:35:00.320] [Parsek][INFO][Recorder] Recording stopped. 3 points, 0 orbit segments over 2.0s

--- a/Source/Parsek.Tests/LiveKspLogValidationTests.cs
+++ b/Source/Parsek.Tests/LiveKspLogValidationTests.cs
@@ -1,0 +1,45 @@
+using System;
+using System.IO;
+using System.Text;
+using Parsek.Tests.LogValidation;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    public class LiveKspLogValidationTests
+    {
+        [Fact]
+        public void ValidateLatestSession()
+        {
+            if (!string.Equals(
+                    Environment.GetEnvironmentVariable("PARSEK_LIVE_VALIDATE_REQUIRED"),
+                    "1",
+                    StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            string logPath = Environment.GetEnvironmentVariable("PARSEK_LIVE_KSP_LOG_PATH");
+            Assert.False(
+                string.IsNullOrWhiteSpace(logPath),
+                "PARSEK_LIVE_KSP_LOG_PATH must be set when PARSEK_LIVE_VALIDATE_REQUIRED=1.");
+            Assert.True(
+                File.Exists(logPath),
+                $"Live validation log path does not exist: {logPath}");
+
+            var entries = ParsekKspLogParser.ParseFile(logPath);
+            var violations = ParsekLogContractChecker.ValidateLatestSession(entries);
+
+            if (violations.Count == 0)
+                return;
+
+            var sb = new StringBuilder();
+            sb.AppendLine($"Live KSP.log validation failed for '{logPath}'.");
+            sb.AppendLine("Violations:");
+            for (int i = 0; i < violations.Count; i++)
+                sb.AppendLine(violations[i].ToDisplayString());
+
+            Assert.True(false, sb.ToString());
+        }
+    }
+}

--- a/Source/Parsek.Tests/LogValidation/KspLogEntry.cs
+++ b/Source/Parsek.Tests/LogValidation/KspLogEntry.cs
@@ -1,0 +1,28 @@
+namespace Parsek.Tests.LogValidation
+{
+    internal sealed class KspLogEntry
+    {
+        public KspLogEntry(
+            int lineNumber,
+            string rawLine,
+            bool isStructured,
+            string level,
+            string subsystem,
+            string message)
+        {
+            LineNumber = lineNumber;
+            RawLine = rawLine ?? string.Empty;
+            IsStructured = isStructured;
+            Level = level;
+            Subsystem = subsystem;
+            Message = message;
+        }
+
+        public int LineNumber { get; }
+        public string RawLine { get; }
+        public bool IsStructured { get; }
+        public string Level { get; }
+        public string Subsystem { get; }
+        public string Message { get; }
+    }
+}

--- a/Source/Parsek.Tests/LogValidation/LogViolation.cs
+++ b/Source/Parsek.Tests/LogValidation/LogViolation.cs
@@ -1,0 +1,23 @@
+namespace Parsek.Tests.LogValidation
+{
+    internal sealed class LogViolation
+    {
+        public LogViolation(string code, int lineNumber, string message, string rawLine)
+        {
+            Code = code;
+            LineNumber = lineNumber;
+            Message = message;
+            RawLine = rawLine ?? string.Empty;
+        }
+
+        public string Code { get; }
+        public int LineNumber { get; }
+        public string Message { get; }
+        public string RawLine { get; }
+
+        public string ToDisplayString()
+        {
+            return $"[{Code}] line {LineNumber}: {Message}{System.Environment.NewLine}  {RawLine}";
+        }
+    }
+}

--- a/Source/Parsek.Tests/LogValidation/ParsekKspLogParser.cs
+++ b/Source/Parsek.Tests/LogValidation/ParsekKspLogParser.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace Parsek.Tests.LogValidation
+{
+    internal static class ParsekKspLogParser
+    {
+        private static readonly Regex StructuredLinePattern = new Regex(
+            @"\[Parsek\]\[(?<level>[^\]]+)\]\[(?<subsystem>[^\]]+)\]\s(?<message>.*)$",
+            RegexOptions.Compiled);
+
+        public static IReadOnlyList<KspLogEntry> ParseFile(string logPath)
+        {
+            if (string.IsNullOrWhiteSpace(logPath))
+                throw new ArgumentException("Log path must be provided.", nameof(logPath));
+
+            return ParseLines(File.ReadLines(logPath));
+        }
+
+        public static IReadOnlyList<KspLogEntry> ParseLines(IEnumerable<string> lines)
+        {
+            if (lines == null)
+                throw new ArgumentNullException(nameof(lines));
+
+            var entries = new List<KspLogEntry>();
+            int lineNumber = 0;
+            foreach (string line in lines)
+            {
+                lineNumber++;
+                string rawLine = line ?? string.Empty;
+                if (rawLine.IndexOf("[Parsek]", StringComparison.Ordinal) < 0)
+                    continue;
+
+                Match match = StructuredLinePattern.Match(rawLine);
+                if (!match.Success)
+                {
+                    entries.Add(new KspLogEntry(
+                        lineNumber: lineNumber,
+                        rawLine: rawLine,
+                        isStructured: false,
+                        level: null,
+                        subsystem: null,
+                        message: null));
+                    continue;
+                }
+
+                entries.Add(new KspLogEntry(
+                    lineNumber: lineNumber,
+                    rawLine: rawLine,
+                    isStructured: true,
+                    level: match.Groups["level"].Value,
+                    subsystem: match.Groups["subsystem"].Value,
+                    message: match.Groups["message"].Value));
+            }
+
+            return entries;
+        }
+
+        public static IReadOnlyList<KspLogEntry> SelectLatestSession(IReadOnlyList<KspLogEntry> parsekEntries)
+        {
+            if (parsekEntries == null)
+                throw new ArgumentNullException(nameof(parsekEntries));
+
+            int startIndex = -1;
+            for (int i = 0; i < parsekEntries.Count; i++)
+            {
+                KspLogEntry entry = parsekEntries[i];
+                if (!entry.IsStructured)
+                    continue;
+
+                if (!string.Equals(entry.Subsystem, "Init", StringComparison.Ordinal))
+                    continue;
+
+                if ((entry.Message ?? string.Empty).StartsWith("SessionStart runUtc=", StringComparison.Ordinal))
+                    startIndex = i;
+            }
+
+            if (startIndex < 0)
+                return parsekEntries;
+
+            var latest = new List<KspLogEntry>(parsekEntries.Count - startIndex);
+            for (int i = startIndex; i < parsekEntries.Count; i++)
+                latest.Add(parsekEntries[i]);
+
+            return latest;
+        }
+    }
+}

--- a/Source/Parsek.Tests/LogValidation/ParsekLogContractChecker.cs
+++ b/Source/Parsek.Tests/LogValidation/ParsekLogContractChecker.cs
@@ -1,0 +1,263 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace Parsek.Tests.LogValidation
+{
+    internal static class ParsekLogContractChecker
+    {
+        private static readonly HashSet<string> AllowedLevels = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "INFO",
+            "VERBOSE",
+            "WARN",
+            "ERROR"
+        };
+
+        private static readonly Regex SuppressedPattern = new Regex(
+            @"\bsuppressed=(?<count>[^\s|,]+)",
+            RegexOptions.Compiled);
+
+        private static readonly Regex StopMetricsPattern = new Regex(
+            @"^Recording stopped(?: \(chain boundary\))?\.\s*(?<points>\d+)\s+points,\s*(?<segments>-?\d+)\s+orbit segments over\s*(?<duration>-?[0-9]+(?:\.[0-9]+)?)s$",
+            RegexOptions.Compiled);
+
+        private static readonly Regex ResourcePostValuePattern = new Regex(
+            @"^Game state: (?<type>FundsChanged|ScienceChanged|ReputationChanged).*(?:\u2192|->)\s*(?<value>-?[0-9]+(?:\.[0-9]+)?)$",
+            RegexOptions.Compiled);
+
+        private static readonly Regex SessionStartPattern = new Regex(
+            @"^SessionStart runUtc=(?<utc>\d+)$",
+            RegexOptions.Compiled);
+
+        public static IReadOnlyList<LogViolation> ValidateLatestSession(IReadOnlyList<KspLogEntry> parsekEntries)
+        {
+            if (parsekEntries == null)
+                throw new ArgumentNullException(nameof(parsekEntries));
+
+            var violations = new List<LogViolation>();
+            if (parsekEntries.Count == 0)
+            {
+                violations.Add(new LogViolation(
+                    code: "SES-000",
+                    lineNumber: 0,
+                    message: "No [Parsek] lines were found in the log.",
+                    rawLine: string.Empty));
+                return violations;
+            }
+
+            IReadOnlyList<KspLogEntry> latestSession = ParsekKspLogParser.SelectLatestSession(parsekEntries);
+            if (latestSession.Count == 0)
+            {
+                violations.Add(new LogViolation(
+                    code: "SES-000",
+                    lineNumber: 0,
+                    message: "No [Parsek] lines were found in the latest session.",
+                    rawLine: string.Empty));
+                return violations;
+            }
+
+            int sessionMarkerCount = 0;
+            bool hasRecordingStart = false;
+            bool hasRecordingStop = false;
+
+            foreach (KspLogEntry entry in latestSession)
+            {
+                if (!entry.IsStructured)
+                {
+                    violations.Add(new LogViolation(
+                        code: "FMT-001",
+                        lineNumber: entry.LineNumber,
+                        message: "Malformed Parsek log line; expected [Parsek][LEVEL][Subsystem] message format.",
+                        rawLine: entry.RawLine));
+                    continue;
+                }
+
+                if (!AllowedLevels.Contains(entry.Level ?? string.Empty))
+                {
+                    violations.Add(new LogViolation(
+                        code: "FMT-002",
+                        lineNumber: entry.LineNumber,
+                        message: $"Invalid log level '{entry.Level}'.",
+                        rawLine: entry.RawLine));
+                }
+
+                if (IsSessionStart(entry))
+                {
+                    sessionMarkerCount++;
+                    if (!SessionStartPattern.IsMatch(entry.Message ?? string.Empty))
+                    {
+                        violations.Add(new LogViolation(
+                            code: "SES-002",
+                            lineNumber: entry.LineNumber,
+                            message: "SessionStart marker must use 'SessionStart runUtc=<unix-seconds>'.",
+                            rawLine: entry.RawLine));
+                    }
+                }
+
+                // TODO: add whitelist support when intentional error-path scenarios are introduced.
+                if (string.Equals(entry.Level, "ERROR", StringComparison.Ordinal))
+                {
+                    violations.Add(new LogViolation(
+                        code: "ERR-001",
+                        lineNumber: entry.LineNumber,
+                        message: "Unexpected ERROR log found in latest session.",
+                        rawLine: entry.RawLine));
+                }
+
+                if (string.Equals(entry.Level, "WARN", StringComparison.Ordinal) &&
+                    (entry.Message ?? string.Empty).TrimStart().StartsWith("WARNING:", StringComparison.OrdinalIgnoreCase))
+                {
+                    violations.Add(new LogViolation(
+                        code: "WRN-001",
+                        lineNumber: entry.LineNumber,
+                        message: "WARN logs should not include a redundant 'WARNING:' prefix in the message.",
+                        rawLine: entry.RawLine));
+                }
+
+                ValidateSuppressedCount(entry, violations);
+                ValidateStopMetrics(entry, violations);
+                ValidateResourcePostValue(entry, violations);
+
+                if (IsRecordingStart(entry))
+                    hasRecordingStart = true;
+                if (IsRecordingStop(entry))
+                    hasRecordingStop = true;
+            }
+
+            if (sessionMarkerCount != 1)
+            {
+                violations.Add(new LogViolation(
+                    code: "SES-001",
+                    lineNumber: 0,
+                    message: $"Latest session must contain exactly one SessionStart marker, found {sessionMarkerCount}.",
+                    rawLine: string.Empty));
+            }
+
+            if (!hasRecordingStart)
+            {
+                violations.Add(new LogViolation(
+                    code: "REC-001",
+                    lineNumber: 0,
+                    message: "Latest session is missing a Recorder 'Recording started' line.",
+                    rawLine: string.Empty));
+            }
+
+            if (!hasRecordingStop)
+            {
+                violations.Add(new LogViolation(
+                    code: "REC-003",
+                    lineNumber: 0,
+                    message: "Latest session is missing a Recorder 'Recording stopped' line.",
+                    rawLine: string.Empty));
+            }
+
+            return violations;
+        }
+
+        private static bool IsSessionStart(KspLogEntry entry)
+        {
+            if (!string.Equals(entry.Subsystem, "Init", StringComparison.Ordinal))
+                return false;
+
+            return (entry.Message ?? string.Empty).StartsWith("SessionStart runUtc=", StringComparison.Ordinal);
+        }
+
+        private static bool IsRecordingStart(KspLogEntry entry)
+        {
+            if (!string.Equals(entry.Subsystem, "Recorder", StringComparison.Ordinal))
+                return false;
+
+            return (entry.Message ?? string.Empty).StartsWith("Recording started", StringComparison.Ordinal);
+        }
+
+        private static bool IsRecordingStop(KspLogEntry entry)
+        {
+            if (!string.Equals(entry.Subsystem, "Recorder", StringComparison.Ordinal))
+                return false;
+
+            return (entry.Message ?? string.Empty).StartsWith("Recording stopped", StringComparison.Ordinal);
+        }
+
+        private static void ValidateSuppressedCount(KspLogEntry entry, List<LogViolation> violations)
+        {
+            MatchCollection matches = SuppressedPattern.Matches(entry.Message ?? string.Empty);
+            for (int i = 0; i < matches.Count; i++)
+            {
+                string raw = matches[i].Groups["count"].Value;
+                if (!int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out int count) || count < 1)
+                {
+                    violations.Add(new LogViolation(
+                        code: "RAT-001",
+                        lineNumber: entry.LineNumber,
+                        message: $"Invalid suppressed count '{raw}'. Expected integer >= 1.",
+                        rawLine: entry.RawLine));
+                }
+            }
+        }
+
+        private static void ValidateStopMetrics(KspLogEntry entry, List<LogViolation> violations)
+        {
+            Match match = StopMetricsPattern.Match(entry.Message ?? string.Empty);
+            if (!match.Success)
+                return;
+
+            bool parsedPoints = int.TryParse(
+                match.Groups["points"].Value,
+                NumberStyles.Integer,
+                CultureInfo.InvariantCulture,
+                out int points);
+            bool parsedSegments = int.TryParse(
+                match.Groups["segments"].Value,
+                NumberStyles.Integer,
+                CultureInfo.InvariantCulture,
+                out int orbitSegments);
+            bool parsedDuration = double.TryParse(
+                match.Groups["duration"].Value,
+                NumberStyles.Float,
+                CultureInfo.InvariantCulture,
+                out double durationSeconds);
+
+            if (!parsedPoints || !parsedSegments || !parsedDuration ||
+                points < 2 || orbitSegments < 0 || durationSeconds <= 0.0)
+            {
+                violations.Add(new LogViolation(
+                    code: "REC-002",
+                    lineNumber: entry.LineNumber,
+                    message: "Recording stopped metrics must satisfy points>=2, orbitSegments>=0, duration>0.",
+                    rawLine: entry.RawLine));
+            }
+        }
+
+        private static void ValidateResourcePostValue(KspLogEntry entry, List<LogViolation> violations)
+        {
+            Match match = ResourcePostValuePattern.Match(entry.Message ?? string.Empty);
+            if (!match.Success)
+                return;
+
+            if (!double.TryParse(
+                    match.Groups["value"].Value,
+                    NumberStyles.Float,
+                    CultureInfo.InvariantCulture,
+                    out double value))
+            {
+                violations.Add(new LogViolation(
+                    code: "RES-002",
+                    lineNumber: entry.LineNumber,
+                    message: $"Unable to parse resource post-value '{match.Groups["value"].Value}'.",
+                    rawLine: entry.RawLine));
+                return;
+            }
+
+            if (value < 0.0)
+            {
+                violations.Add(new LogViolation(
+                    code: "RES-001",
+                    lineNumber: entry.LineNumber,
+                    message: "Resource post-value must be non-negative.",
+                    rawLine: entry.RawLine));
+            }
+        }
+    }
+}

--- a/Source/Parsek.Tests/LogValidation/TestFixtureLoader.cs
+++ b/Source/Parsek.Tests/LogValidation/TestFixtureLoader.cs
@@ -1,0 +1,32 @@
+using System;
+using System.IO;
+
+namespace Parsek.Tests.LogValidation
+{
+    internal static class TestFixtureLoader
+    {
+        public static string GetFixturePath(string fileName)
+        {
+            string repoRoot = ResolveRepoRoot();
+            string fixturePath = Path.Combine(repoRoot, "Source", "Parsek.Tests", "Fixtures", "KspLog", fileName);
+            if (!File.Exists(fixturePath))
+                throw new FileNotFoundException($"Fixture file not found: {fixturePath}");
+            return fixturePath;
+        }
+
+        private static string ResolveRepoRoot()
+        {
+            DirectoryInfo current = new DirectoryInfo(AppContext.BaseDirectory);
+            while (current != null)
+            {
+                string markerPath = Path.Combine(current.FullName, "Source", "Parsek.Tests", "Parsek.Tests.csproj");
+                if (File.Exists(markerPath))
+                    return current.FullName;
+                current = current.Parent;
+            }
+
+            throw new InvalidOperationException(
+                $"Unable to resolve repository root from base directory '{AppContext.BaseDirectory}'.");
+        }
+    }
+}

--- a/Source/Parsek.Tests/ParsekKspLogParserTests.cs
+++ b/Source/Parsek.Tests/ParsekKspLogParserTests.cs
@@ -1,0 +1,49 @@
+using System.Linq;
+using Parsek.Tests.LogValidation;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    public class ParsekKspLogParserTests
+    {
+        [Fact]
+        public void ParseFile_ParsesStructuredEntriesFromNoisyFixture()
+        {
+            var entries = ParsekKspLogParser.ParseFile(TestFixtureLoader.GetFixturePath("good_latest_session.log"));
+
+            Assert.NotEmpty(entries);
+            Assert.All(entries, e => Assert.True(e.LineNumber > 0));
+            Assert.Contains(entries, e =>
+                e.IsStructured &&
+                e.Level == "INFO" &&
+                e.Subsystem == "Init" &&
+                e.Message.StartsWith("SessionStart runUtc=", System.StringComparison.Ordinal));
+        }
+
+        [Fact]
+        public void ParseFile_MarksMalformedParsekLines()
+        {
+            var entries = ParsekKspLogParser.ParseFile(TestFixtureLoader.GetFixturePath("bad_malformed_parsek_line.log"));
+
+            Assert.Contains(entries, e => !e.IsStructured);
+        }
+
+        [Fact]
+        public void SelectLatestSession_UsesLastSessionStartMarker()
+        {
+            var entries = ParsekKspLogParser.ParseFile(TestFixtureLoader.GetFixturePath("multi_session_uses_last_marker.log"));
+            var latestSession = ParsekKspLogParser.SelectLatestSession(entries);
+
+            Assert.NotEmpty(latestSession);
+            Assert.True(latestSession[0].IsStructured);
+            Assert.Equal("Init", latestSession[0].Subsystem);
+            Assert.Equal("SessionStart runUtc=2000", latestSession[0].Message);
+            Assert.DoesNotContain(latestSession, e =>
+                e.IsStructured &&
+                e.Level == "ERROR" &&
+                (e.Message ?? string.Empty).IndexOf("Old failure", System.StringComparison.Ordinal) >= 0);
+            Assert.True(latestSession.Count < entries.Count);
+            Assert.Equal(2, entries.Count(e => e.IsStructured && e.Subsystem == "Init"));
+        }
+    }
+}

--- a/Source/Parsek.Tests/ParsekLogContractCheckerTests.cs
+++ b/Source/Parsek.Tests/ParsekLogContractCheckerTests.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Linq;
+using Parsek.Tests.LogValidation;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    public class ParsekLogContractCheckerTests
+    {
+        [Fact]
+        public void GoodFixture_HasNoViolations()
+        {
+            var entries = ParsekKspLogParser.ParseFile(TestFixtureLoader.GetFixturePath("good_latest_session.log"));
+
+            var violations = ParsekLogContractChecker.ValidateLatestSession(entries);
+
+            Assert.Empty(violations);
+        }
+
+        [Theory]
+        [InlineData("bad_malformed_parsek_line.log", "FMT-001")]
+        [InlineData("bad_error_present.log", "ERR-001")]
+        [InlineData("bad_warn_warning_prefix.log", "WRN-001")]
+        [InlineData("bad_suppressed_value.log", "RAT-001")]
+        [InlineData("bad_recording_stop_values.log", "REC-002")]
+        [InlineData("bad_negative_resource.log", "RES-001")]
+        public void BadFixtures_ReportExpectedViolationCode(string fixtureName, string expectedCode)
+        {
+            var entries = ParsekKspLogParser.ParseFile(TestFixtureLoader.GetFixturePath(fixtureName));
+
+            var violations = ParsekLogContractChecker.ValidateLatestSession(entries);
+
+            Assert.NotEmpty(violations);
+            Assert.Contains(violations, v => v.Code == expectedCode);
+        }
+
+        [Fact]
+        public void MultiSessionFixture_ValidatesOnlyLatestSession()
+        {
+            var entries = ParsekKspLogParser.ParseFile(TestFixtureLoader.GetFixturePath("multi_session_uses_last_marker.log"));
+            var latestSession = ParsekKspLogParser.SelectLatestSession(entries);
+
+            var violations = ParsekLogContractChecker.ValidateLatestSession(entries);
+
+            Assert.DoesNotContain(latestSession, e =>
+                (e.Message ?? string.Empty).IndexOf("Old failure", StringComparison.Ordinal) >= 0);
+            Assert.Empty(violations);
+        }
+
+        [Fact]
+        public void MissingRecordingStart_ReportsRec001()
+        {
+            var entries = ParsekKspLogParser.ParseLines(new[]
+            {
+                "[LOG] [Parsek][INFO][Init] SessionStart runUtc=3000",
+                "[LOG] [Parsek][INFO][Recorder] Recording stopped. 4 points, 0 orbit segments over 3.0s"
+            });
+
+            var violations = ParsekLogContractChecker.ValidateLatestSession(entries);
+
+            Assert.Contains(violations, v => v.Code == "REC-001");
+        }
+
+        [Fact]
+        public void MissingRecordingStop_ReportsRec003()
+        {
+            var entries = ParsekKspLogParser.ParseLines(new[]
+            {
+                "[LOG] [Parsek][INFO][Init] SessionStart runUtc=3001",
+                "[LOG] [Parsek][INFO][Recorder] Recording started (physics-frame sampling)"
+            });
+
+            var violations = ParsekLogContractChecker.ValidateLatestSession(entries);
+
+            Assert.Contains(violations, v => v.Code == "REC-003");
+        }
+
+        [Fact]
+        public void AsciiArrowResourceLine_IsAccepted()
+        {
+            var entries = ParsekKspLogParser.ParseLines(new[]
+            {
+                "[LOG] [Parsek][INFO][Init] SessionStart runUtc=3002",
+                "[LOG] [Parsek][INFO][Recorder] Recording started (physics-frame sampling)",
+                "[LOG] [Parsek][INFO][GameStateRecorder] Game state: FundsChanged +50 (Test) -> 150",
+                "[LOG] [Parsek][INFO][Recorder] Recording stopped. 3 points, 0 orbit segments over 1.2s"
+            });
+
+            var violations = ParsekLogContractChecker.ValidateLatestSession(entries);
+
+            Assert.Empty(violations);
+        }
+    }
+}

--- a/Source/Parsek.Tests/ParsekLogTests.cs
+++ b/Source/Parsek.Tests/ParsekLogTests.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    [Collection("Sequential")]
+    public class ParsekLogTests
+    {
+        public ParsekLogTests()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+        }
+
+        [Fact]
+        public void Info_UsesStructuredFormat()
+        {
+            var lines = new List<string>();
+            ParsekLog.TestSinkForTesting = line => lines.Add(line);
+
+            ParsekLog.Info("UnitTest", "hello");
+
+            Assert.Single(lines);
+            Assert.Equal("[Parsek][INFO][UnitTest] hello", lines[0]);
+        }
+
+        [Fact]
+        public void Verbose_SuppressedWhenVerboseDisabled()
+        {
+            var lines = new List<string>();
+            ParsekLog.TestSinkForTesting = line => lines.Add(line);
+            ParsekLog.VerboseOverrideForTesting = false;
+
+            ParsekLog.Verbose("UnitTest", "detail");
+            ParsekLog.VerboseRateLimited("UnitTest", "key", "detail", 2.0);
+            ParsekLog.Info("UnitTest", "always");
+
+            Assert.Single(lines);
+            Assert.Equal("[Parsek][INFO][UnitTest] always", lines[0]);
+        }
+
+        [Fact]
+        public void VerboseRateLimited_EmitsSuppressedCountAfterInterval()
+        {
+            var lines = new List<string>();
+            ParsekLog.TestSinkForTesting = line => lines.Add(line);
+            ParsekLog.VerboseOverrideForTesting = true;
+            ParsekLog.ResetRateLimitsForTesting();
+
+            double now = 1000.0;
+            ParsekLog.ClockOverrideForTesting = () => now;
+
+            ParsekLog.VerboseRateLimited("UnitTest", "sample", "tick", 2.0);
+            now = 1000.5;
+            ParsekLog.VerboseRateLimited("UnitTest", "sample", "tick", 2.0);
+            now = 1001.0;
+            ParsekLog.VerboseRateLimited("UnitTest", "sample", "tick", 2.0);
+            now = 1002.1;
+            ParsekLog.VerboseRateLimited("UnitTest", "sample", "tick", 2.0);
+
+            Assert.Equal(2, lines.Count);
+            Assert.Equal("[Parsek][VERBOSE][UnitTest] tick", lines[0]);
+            Assert.Equal("[Parsek][VERBOSE][UnitTest] tick | suppressed=2", lines[1]);
+        }
+    }
+}

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -123,6 +123,7 @@ namespace Parsek
             GameEvents.onPartDie.Add(OnPartDie);
             GameEvents.onPartJointBreak.Add(OnPartJointBreak);
             partEventsSubscribed = true;
+            ParsekLog.Verbose("Recorder", "Subscribed part event hooks");
         }
 
         private void UnsubscribePartEvents()
@@ -131,6 +132,7 @@ namespace Parsek
             GameEvents.onPartDie.Remove(OnPartDie);
             GameEvents.onPartJointBreak.Remove(OnPartJointBreak);
             partEventsSubscribed = false;
+            ParsekLog.Verbose("Recorder", "Unsubscribed part event hooks");
         }
 
         private void OnPartDie(Part p)
@@ -149,7 +151,7 @@ namespace Parsek
                 eventType = evtType,
                 partName = p.partInfo?.name ?? "unknown"
             });
-            ParsekLog.Log($"Part event: {evtType} '{p.partInfo?.name}' pid={p.persistentId}");
+            ParsekLog.Verbose("Recorder", $"Part event: {evtType} '{p.partInfo?.name}' pid={p.persistentId}");
         }
 
         internal static PartEventType ClassifyPartDeath(
@@ -177,7 +179,7 @@ namespace Parsek
                 eventType = PartEventType.Decoupled,
                 partName = joint.Child.partInfo?.name ?? "unknown"
             });
-            ParsekLog.Log($"Part event: Decoupled '{joint.Child.partInfo?.name}' pid={joint.Child.persistentId}");
+            ParsekLog.Verbose("Recorder", $"Part event: Decoupled '{joint.Child.partInfo?.name}' pid={joint.Child.persistentId}");
         }
 
         /// <summary>
@@ -259,7 +261,7 @@ namespace Parsek
                 if (evt.HasValue)
                 {
                     PartEvents.Add(evt.Value);
-                    ParsekLog.Log($"Part event: {evt.Value.eventType} '{evt.Value.partName}' pid={evt.Value.partPersistentId}");
+                    ParsekLog.Verbose("Recorder", $"Part event: {evt.Value.eventType} '{evt.Value.partName}' pid={evt.Value.partPersistentId}");
                 }
             }
         }
@@ -299,7 +301,7 @@ namespace Parsek
                 if (evt.HasValue)
                 {
                     PartEvents.Add(evt.Value);
-                    ParsekLog.Log($"Part event: {evt.Value.eventType} '{evt.Value.partName}' pid={evt.Value.partPersistentId}");
+                    ParsekLog.Verbose("Recorder", $"Part event: {evt.Value.eventType} '{evt.Value.partName}' pid={evt.Value.partPersistentId}");
                 }
             }
         }
@@ -363,7 +365,7 @@ namespace Parsek
                 if (evt.HasValue)
                 {
                     PartEvents.Add(evt.Value);
-                    ParsekLog.Log($"Part event: {evt.Value.eventType} '{evt.Value.partName}' pid={evt.Value.partPersistentId}");
+                    ParsekLog.Verbose("Recorder", $"Part event: {evt.Value.eventType} '{evt.Value.partName}' pid={evt.Value.partPersistentId}");
                 }
             }
         }
@@ -592,7 +594,7 @@ namespace Parsek
                 if (evt.HasValue)
                 {
                     PartEvents.Add(evt.Value);
-                    ParsekLog.Log($"Part event: {evt.Value.eventType} '{evt.Value.partName}' pid={evt.Value.partPersistentId}");
+                    ParsekLog.Verbose("Recorder", $"Part event: {evt.Value.eventType} '{evt.Value.partName}' pid={evt.Value.partPersistentId}");
                 }
 
                 var blinkEvents = CheckLightBlinkTransition(
@@ -602,7 +604,7 @@ namespace Parsek
                 for (int e = 0; e < blinkEvents.Count; e++)
                 {
                     PartEvents.Add(blinkEvents[e]);
-                    ParsekLog.Log($"Part event: {blinkEvents[e].eventType} '{blinkEvents[e].partName}' " +
+                    ParsekLog.Verbose("Recorder", $"Part event: {blinkEvents[e].eventType} '{blinkEvents[e].partName}' " +
                         $"pid={blinkEvents[e].partPersistentId} val={blinkEvents[e].value:F2}");
                 }
             }
@@ -1230,7 +1232,7 @@ namespace Parsek
                     if (evt.HasValue)
                     {
                         PartEvents.Add(evt.Value);
-                        ParsekLog.Log($"Part event: {evt.Value.eventType} '{evt.Value.partName}' pid={evt.Value.partPersistentId}");
+                        ParsekLog.Verbose("Recorder", $"Part event: {evt.Value.eventType} '{evt.Value.partName}' pid={evt.Value.partPersistentId}");
                     }
                     break; // one deployment module per part
                 }
@@ -1315,7 +1317,7 @@ namespace Parsek
                 {
                     if (loggedCargoBayDeployIndexIssues.Add(p.persistentId))
                     {
-                        ParsekLog.Log($"CargoBay: invalid DeployModuleIndex for '{p.partInfo?.name}' " +
+                        ParsekLog.Verbose("Recorder", $"CargoBay: invalid DeployModuleIndex for '{p.partInfo?.name}' " +
                             $"pid={p.persistentId} deployIdx={deployIdx} modules={p.Modules.Count}");
                     }
                     continue;
@@ -1327,7 +1329,7 @@ namespace Parsek
                     {
                         PartModule moduleAtIndex = p.Modules[deployIdx];
                         string moduleName = moduleAtIndex?.moduleName ?? "<null>";
-                        ParsekLog.Log($"CargoBay: DeployModuleIndex did not resolve to ModuleAnimateGeneric for " +
+                        ParsekLog.Verbose("Recorder", $"CargoBay: DeployModuleIndex did not resolve to ModuleAnimateGeneric for " +
                             $"'{p.partInfo?.name}' pid={p.persistentId} deployIdx={deployIdx} module='{moduleName}'");
                     }
                     continue;
@@ -1341,7 +1343,7 @@ namespace Parsek
                     if (cargo.closedPosition >= 0.1f && cargo.closedPosition <= 0.9f &&
                         loggedCargoBayClosedPositionIssues.Add(p.persistentId))
                     {
-                        ParsekLog.Log($"CargoBay: unsupported closedPosition for '{p.partInfo?.name}' " +
+                        ParsekLog.Verbose("Recorder", $"CargoBay: unsupported closedPosition for '{p.partInfo?.name}' " +
                             $"pid={p.persistentId} closedPosition={cargo.closedPosition:F3} animTime={animModule.animTime:F3}");
                     }
                     continue; // mid-transition or non-standard closedPosition
@@ -1352,7 +1354,7 @@ namespace Parsek
                 if (evt.HasValue)
                 {
                     PartEvents.Add(evt.Value);
-                    ParsekLog.Log($"Part event: {evt.Value.eventType} '{evt.Value.partName}' pid={evt.Value.partPersistentId}");
+                    ParsekLog.Verbose("Recorder", $"Part event: {evt.Value.eventType} '{evt.Value.partName}' pid={evt.Value.partPersistentId}");
                 }
             }
         }
@@ -1381,7 +1383,7 @@ namespace Parsek
                     {
                         if (loggedLadderClassificationMisses.Add(key))
                         {
-                            ParsekLog.Log($"Ladder: unable to classify '{p.partInfo?.name}' pid={p.persistentId} " +
+                            ParsekLog.Verbose("Recorder", $"Ladder: unable to classify '{p.partInfo?.name}' pid={p.persistentId} " +
                                 $"midx={m}; fields=[{DescribeModuleFields(module)}]");
                         }
                         continue;
@@ -1393,7 +1395,7 @@ namespace Parsek
                     if (evt.HasValue)
                     {
                         PartEvents.Add(evt.Value);
-                        ParsekLog.Log($"Part event: {evt.Value.eventType} '{evt.Value.partName}' " +
+                        ParsekLog.Verbose("Recorder", $"Part event: {evt.Value.eventType} '{evt.Value.partName}' " +
                             $"pid={evt.Value.partPersistentId} (ladder)");
                     }
 
@@ -1426,7 +1428,7 @@ namespace Parsek
                         ulong diagnosticKey = EncodeEngineKey(p.persistentId, m);
                         if (loggedAnimationGroupClassificationMisses.Add(diagnosticKey))
                         {
-                            ParsekLog.Log($"AnimationGroup: unable to classify '{p.partInfo?.name}' pid={p.persistentId} " +
+                            ParsekLog.Verbose("Recorder", $"AnimationGroup: unable to classify '{p.partInfo?.name}' pid={p.persistentId} " +
                                 $"midx={m}; fields=[{DescribeModuleFields(module)}]");
                         }
                         continue;
@@ -1439,7 +1441,7 @@ namespace Parsek
                     if (evt.HasValue)
                     {
                         PartEvents.Add(evt.Value);
-                        ParsekLog.Log($"Part event: {evt.Value.eventType} '{evt.Value.partName}' " +
+                        ParsekLog.Verbose("Recorder", $"Part event: {evt.Value.eventType} '{evt.Value.partName}' " +
                             $"pid={evt.Value.partPersistentId} midx={evt.Value.moduleIndex} (animation-group)");
                     }
                 }
@@ -1470,7 +1472,7 @@ namespace Parsek
                         ulong diagnosticKey = EncodeEngineKey(p.persistentId, m);
                         if (loggedAeroSurfaceClassificationMisses.Add(diagnosticKey))
                         {
-                            ParsekLog.Log($"AeroSurface: unable to classify '{p.partInfo?.name}' pid={p.persistentId} " +
+                            ParsekLog.Verbose("Recorder", $"AeroSurface: unable to classify '{p.partInfo?.name}' pid={p.persistentId} " +
                                 $"midx={m}; fields=[{DescribeModuleFields(module)}]");
                         }
                         continue;
@@ -1485,7 +1487,7 @@ namespace Parsek
                     if (evt.HasValue)
                     {
                         PartEvents.Add(evt.Value);
-                        ParsekLog.Log($"Part event: {evt.Value.eventType} '{evt.Value.partName}' " +
+                        ParsekLog.Verbose("Recorder", $"Part event: {evt.Value.eventType} '{evt.Value.partName}' " +
                             $"pid={evt.Value.partPersistentId} midx={evt.Value.moduleIndex} (aero-surface)");
                     }
                 }
@@ -1516,7 +1518,7 @@ namespace Parsek
                         ulong diagnosticKey = EncodeEngineKey(p.persistentId, m);
                         if (loggedControlSurfaceClassificationMisses.Add(diagnosticKey))
                         {
-                            ParsekLog.Log($"ControlSurface: unable to classify '{p.partInfo?.name}' pid={p.persistentId} " +
+                            ParsekLog.Verbose("Recorder", $"ControlSurface: unable to classify '{p.partInfo?.name}' pid={p.persistentId} " +
                                 $"midx={m}; fields=[{DescribeModuleFields(module)}]");
                         }
                         continue;
@@ -1531,7 +1533,7 @@ namespace Parsek
                     if (evt.HasValue)
                     {
                         PartEvents.Add(evt.Value);
-                        ParsekLog.Log($"Part event: {evt.Value.eventType} '{evt.Value.partName}' " +
+                        ParsekLog.Verbose("Recorder", $"Part event: {evt.Value.eventType} '{evt.Value.partName}' " +
                             $"pid={evt.Value.partPersistentId} midx={evt.Value.moduleIndex} (control-surface)");
                     }
                 }
@@ -1562,7 +1564,7 @@ namespace Parsek
                         ulong diagnosticKey = EncodeEngineKey(p.persistentId, m);
                         if (loggedRobotArmScannerClassificationMisses.Add(diagnosticKey))
                         {
-                            ParsekLog.Log($"RobotArmScanner: unable to classify '{p.partInfo?.name}' pid={p.persistentId} " +
+                            ParsekLog.Verbose("Recorder", $"RobotArmScanner: unable to classify '{p.partInfo?.name}' pid={p.persistentId} " +
                                 $"midx={m}; fields=[{DescribeModuleFields(module)}]");
                         }
                         continue;
@@ -1577,7 +1579,7 @@ namespace Parsek
                     if (evt.HasValue)
                     {
                         PartEvents.Add(evt.Value);
-                        ParsekLog.Log($"Part event: {evt.Value.eventType} '{evt.Value.partName}' " +
+                        ParsekLog.Verbose("Recorder", $"Part event: {evt.Value.eventType} '{evt.Value.partName}' " +
                             $"pid={evt.Value.partPersistentId} midx={evt.Value.moduleIndex} (robot-arm-scanner)");
                     }
                 }
@@ -1642,7 +1644,7 @@ namespace Parsek
                         ulong diagnosticKey = EncodeEngineKey(p.persistentId, m);
                         if (loggedAnimateGenericClassificationMisses.Add(diagnosticKey))
                         {
-                            ParsekLog.Log($"AnimateGeneric: unable to classify '{p.partInfo?.name}' pid={p.persistentId} " +
+                            ParsekLog.Verbose("Recorder", $"AnimateGeneric: unable to classify '{p.partInfo?.name}' pid={p.persistentId} " +
                                 $"midx={m} anim='{animateModule.animationName}'; fields=[{DescribeModuleFields(animateModule)}]");
                         }
                         continue;
@@ -1657,7 +1659,7 @@ namespace Parsek
                     if (evt.HasValue)
                     {
                         PartEvents.Add(evt.Value);
-                        ParsekLog.Log($"Part event: {evt.Value.eventType} '{evt.Value.partName}' " +
+                        ParsekLog.Verbose("Recorder", $"Part event: {evt.Value.eventType} '{evt.Value.partName}' " +
                             $"pid={evt.Value.partPersistentId} midx={evt.Value.moduleIndex} (anim-generic)");
                     }
                 }
@@ -1688,7 +1690,7 @@ namespace Parsek
                         ulong diagnosticKey = EncodeEngineKey(p.persistentId, m);
                         if (loggedAnimateHeatClassificationMisses.Add(diagnosticKey))
                         {
-                            ParsekLog.Log($"AnimateHeat: unable to classify '{p.partInfo?.name}' pid={p.persistentId} " +
+                            ParsekLog.Verbose("Recorder", $"AnimateHeat: unable to classify '{p.partInfo?.name}' pid={p.persistentId} " +
                                 $"midx={m}; fields=[{DescribeModuleFields(module)}]");
                         }
                         continue;
@@ -1701,7 +1703,7 @@ namespace Parsek
                     if (evt.HasValue)
                     {
                         PartEvents.Add(evt.Value);
-                        ParsekLog.Log($"Part event: {evt.Value.eventType} '{evt.Value.partName}' " +
+                        ParsekLog.Verbose("Recorder", $"Part event: {evt.Value.eventType} '{evt.Value.partName}' " +
                             $"pid={evt.Value.partPersistentId} midx={evt.Value.moduleIndex} " +
                             $"heat={normalizedHeat:F2} src={sourceField ?? "<unknown>"}");
                     }
@@ -1750,7 +1752,7 @@ namespace Parsek
                 {
                     if (loggedFairingReadFailures.Add(p.persistentId))
                     {
-                        ParsekLog.Log($"Fairing: unable to read GetScalar for '{p.partInfo?.name}' " +
+                        ParsekLog.Verbose("Recorder", $"Fairing: unable to read GetScalar for '{p.partInfo?.name}' " +
                             $"pid={p.persistentId} ({ex.GetType().Name}: {ex.Message})");
                     }
                     continue;
@@ -1761,7 +1763,7 @@ namespace Parsek
                 if (evt.HasValue)
                 {
                     PartEvents.Add(evt.Value);
-                    ParsekLog.Log($"Part event: {evt.Value.eventType} '{evt.Value.partName}' pid={evt.Value.partPersistentId}");
+                    ParsekLog.Verbose("Recorder", $"Part event: {evt.Value.eventType} '{evt.Value.partName}' pid={evt.Value.partPersistentId}");
                 }
             }
         }
@@ -1809,7 +1811,7 @@ namespace Parsek
 
         private static void LogCoverageDetails(string label, List<string> entries)
         {
-            ParsekLog.Log($"  Visual coverage [{label}] {entries.Count}: {FormatCoverageEntries(entries)}");
+            ParsekLog.Verbose("Recorder", $"  Visual coverage [{label}] {entries.Count}: {FormatCoverageEntries(entries)}");
         }
 
         private void LogVisualRecordingCoverage(Vessel v)
@@ -1988,7 +1990,7 @@ namespace Parsek
                 }
             }
 
-            ParsekLog.Log(
+            ParsekLog.Verbose("Recorder", 
                 $"Visual recording coverage for '{v.vesselName}' pid={v.persistentId}: " +
                 $"parts={v.parts.Count} modules={moduleCount} " +
                 $"parachute={parachuteParts.Count} jettison={jettisonModules.Count} deployable={deployableParts.Count} " +
@@ -2096,7 +2098,7 @@ namespace Parsek
                         ? engine.thrustTransforms.Count
                         : 0;
                     string engineId = string.IsNullOrEmpty(engine.engineID) ? "<none>" : engine.engineID;
-                    ParsekLog.Log($"Engine tracking: '{part.partInfo?.name}' pid={part.persistentId} " +
+                    ParsekLog.Verbose("Recorder", $"Engine tracking: '{part.partInfo?.name}' pid={part.persistentId} " +
                         $"midx={moduleIndex} id={engineId} thrustTransforms={thrustTransformCount}");
                 }
 
@@ -2109,7 +2111,7 @@ namespace Parsek
                 for (int e = 0; e < events.Count; e++)
                 {
                     PartEvents.Add(events[e]);
-                    ParsekLog.Log($"Part event: {events[e].eventType} '{events[e].partName}' " +
+                    ParsekLog.Verbose("Recorder", $"Part event: {events[e].eventType} '{events[e].partName}' " +
                         $"pid={events[e].partPersistentId} midx={events[e].moduleIndex} val={events[e].value:F2}");
                 }
             }
@@ -2231,7 +2233,7 @@ namespace Parsek
                 {
                     int thrusterCount = rcs.thrusterTransforms != null ? rcs.thrusterTransforms.Count : 0;
                     int forceCount = rcs.thrustForces != null ? rcs.thrustForces.Length : 0;
-                    ParsekLog.Log($"RCS tracking: '{part.partInfo?.name}' pid={part.persistentId} " +
+                    ParsekLog.Verbose("Recorder", $"RCS tracking: '{part.partInfo?.name}' pid={part.persistentId} " +
                         $"midx={moduleIndex} thrusters={thrusterCount} forces={forceCount} power={rcs.thrusterPower:F2}");
                 }
 
@@ -2244,7 +2246,7 @@ namespace Parsek
                 for (int e = 0; e < events.Count; e++)
                 {
                     PartEvents.Add(events[e]);
-                    ParsekLog.Log($"Part event: {events[e].eventType} '{events[e].partName}' " +
+                    ParsekLog.Verbose("Recorder", $"Part event: {events[e].eventType} '{events[e].partName}' " +
                         $"pid={events[e].partPersistentId} midx={events[e].moduleIndex} val={events[e].value:F2}");
                 }
             }
@@ -2783,7 +2785,7 @@ namespace Parsek
                 {
                     if (loggedRoboticModuleKeys.Add(key))
                     {
-                        ParsekLog.Log($"Robotics: unable to sample '{part.partInfo?.name}' pid={part.persistentId} " +
+                        ParsekLog.Verbose("Recorder", $"Robotics: unable to sample '{part.partInfo?.name}' pid={part.persistentId} " +
                             $"midx={moduleIndex} module={moduleName}; fields=[{DescribeModuleFields(module)}]");
                     }
                     continue;
@@ -2792,7 +2794,7 @@ namespace Parsek
                 if (loggedRoboticModuleKeys.Add(key))
                 {
                     string movingSource = hasMovingSignal ? "module-flag" : "inferred";
-                    ParsekLog.Log($"Robotics: tracking '{part.partInfo?.name}' pid={part.persistentId} " +
+                    ParsekLog.Verbose("Recorder", $"Robotics: tracking '{part.partInfo?.name}' pid={part.persistentId} " +
                         $"midx={moduleIndex} module={moduleName} source={sourceField} " +
                         $"deadband={deadband:F3} sampleHz=4.0 moving={movingSource}");
                 }
@@ -2806,7 +2808,7 @@ namespace Parsek
                 for (int e = 0; e < events.Count; e++)
                 {
                     PartEvents.Add(events[e]);
-                    ParsekLog.Log($"Part event: {events[e].eventType} '{events[e].partName}' " +
+                    ParsekLog.Verbose("Recorder", $"Part event: {events[e].eventType} '{events[e].partName}' " +
                         $"pid={events[e].partPersistentId} midx={events[e].moduleIndex} " +
                         $"val={events[e].value:F3}");
                 }
@@ -2819,7 +2821,7 @@ namespace Parsek
         {
             if (Time.timeScale < 0.01f)
             {
-                ParsekLog.Log("Cannot start recording while paused");
+                ParsekLog.Warn("Recorder", "Cannot start recording while paused");
                 ParsekLog.ScreenMessage("Cannot record while paused", 2f);
                 return;
             }
@@ -2827,7 +2829,7 @@ namespace Parsek
             Vessel v = FlightGlobals.ActiveVessel;
             if (v == null)
             {
-                ParsekLog.Log("No active vessel to record!");
+                ParsekLog.Warn("Recorder", "Cannot start recording: no active vessel");
                 return;
             }
 
@@ -2874,6 +2876,9 @@ namespace Parsek
             lastRoboticPosition = new Dictionary<ulong, float>();
             lastRoboticSampleUT = new Dictionary<ulong, double>();
             loggedRoboticModuleKeys = new HashSet<ulong>();
+            ParsekLog.Info("Recorder",
+                $"Module caches seeded for vessel pid={v.persistentId}: engines={cachedEngines?.Count ?? 0}, " +
+                $"rcs={cachedRcsModules?.Count ?? 0}, robotics={cachedRoboticModules?.Count ?? 0}");
 
             // Seed already-deployed fairings so we don't emit false events at first poll
             if (v != null && v.parts != null)
@@ -2918,7 +2923,7 @@ namespace Parsek
                 lastRecordedUT = anchorUT;
                 lastRecordedVelocity = anchor.velocity;
                 BoundaryAnchor = null;
-                ParsekLog.Log($"Boundary anchor inserted at UT {anchorUT:F3}");
+                ParsekLog.Verbose("Recorder", $"Boundary anchor inserted at UT {anchorUT:F3}");
             }
             RefreshBackupSnapshot(v, "record_start", force: true);
             initialGhostVisualSnapshot = lastGoodVesselSnapshot != null
@@ -2944,7 +2949,7 @@ namespace Parsek
                     bodyName = v.mainBody.name
                 };
                 isOnRails = true;
-                ParsekLog.Log($"Recording started on rails — capturing orbit (body={v.mainBody.name})");
+                ParsekLog.Info("Recorder", $"Recording started on rails — capturing orbit (body={v.mainBody.name})");
             }
 
             // Register the Harmony patch to call us each physics frame
@@ -2952,7 +2957,7 @@ namespace Parsek
 
             SubscribePartEvents();
 
-            ParsekLog.Log("Recording started (physics-frame sampling)");
+            ParsekLog.Info("Recorder", "Recording started (physics-frame sampling)");
             ParsekLog.ScreenMessage("Recording STARTED", 2f);
         }
 
@@ -3004,7 +3009,7 @@ namespace Parsek
                 ? Recording[Recording.Count - 1].ut - Recording[0].ut
                 : 0;
 
-            ParsekLog.Log($"Recording stopped. {Recording.Count} points, {OrbitSegments.Count} orbit segments over {duration:F1}s");
+            ParsekLog.Info("Recorder", $"Recording stopped. {Recording.Count} points, {OrbitSegments.Count} orbit segments over {duration:F1}s");
             ParsekLog.ScreenMessage($"Recording STOPPED: {Recording.Count} points", 3f);
         }
 
@@ -3055,7 +3060,7 @@ namespace Parsek
                 ? Recording[Recording.Count - 1].ut - Recording[0].ut
                 : 0;
 
-            ParsekLog.Log($"Recording stopped (chain boundary). {Recording.Count} points, {OrbitSegments.Count} orbit segments over {duration:F1}s");
+            ParsekLog.Info("Recorder", $"Recording stopped (chain boundary). {Recording.Count} points, {OrbitSegments.Count} orbit segments over {duration:F1}s");
         }
 
         /// <summary>
@@ -3079,7 +3084,7 @@ namespace Parsek
                     RecordingVesselId = v.persistentId;
                     SamplePosition(v);
                     RefreshBackupSnapshot(v, "eva_switch", force: true);
-                    ParsekLog.Log($"Recording switched to EVA vessel (pid={v.persistentId})");
+                    ParsekLog.Verbose("Recorder", $"Recording switched to EVA vessel (pid={v.persistentId})");
                     return;
                 }
 
@@ -3111,25 +3116,25 @@ namespace Parsek
                 if (decision == VesselSwitchDecision.ChainToVessel)
                 {
                     ChainToVesselPending = true;
-                    ParsekLog.Log($"EVA boarded vessel (was pid={RecordingVesselId}, now pid={v.persistentId}) — chain pending");
+                    ParsekLog.Verbose("Recorder", $"EVA boarded vessel (was pid={RecordingVesselId}, now pid={v.persistentId}) — chain pending");
                     return;
                 }
 
                 if (decision == VesselSwitchDecision.DockMerge)
                 {
                     DockMergePending = true;
-                    ParsekLog.Log($"Dock merge detected (was pid={RecordingVesselId}, now pid={v.persistentId}) — dock pending");
+                    ParsekLog.Verbose("Recorder", $"Dock merge detected (was pid={RecordingVesselId}, now pid={v.persistentId}) — dock pending");
                     return;
                 }
 
                 if (decision == VesselSwitchDecision.UndockSwitch)
                 {
                     UndockSwitchPending = true;
-                    ParsekLog.Log($"Undock sibling switch (was pid={RecordingVesselId}, now pid={v.persistentId}) — undock switch pending");
+                    ParsekLog.Verbose("Recorder", $"Undock sibling switch (was pid={RecordingVesselId}, now pid={v.persistentId}) — undock switch pending");
                     return;
                 }
 
-                ParsekLog.Log($"Active vessel changed during recording — auto-stopping " +
+                ParsekLog.Verbose("Recorder", $"Active vessel changed during recording — auto-stopping " +
                     $"(decision={decision}, was pid={RecordingVesselId}, now pid={v.persistentId}, " +
                     $"nowIsEva={v.isEVA}, startedAsEva={RecordingStartedAsEva})");
                 ParsekLog.ScreenMessage("Recording stopped — vessel changed", 3f);
@@ -3161,7 +3166,11 @@ namespace Parsek
             if (!TrajectoryMath.ShouldRecordPoint(currentVelocity, lastRecordedVelocity,
                 Planetarium.GetUniversalTime(), lastRecordedUT,
                 maxSampleInterval, velocityDirThreshold, speedChangeThreshold))
+            {
+                ParsekLog.VerboseRateLimited("Recorder", "sample-skipped",
+                    $"Sample skipped at ut={Planetarium.GetUniversalTime():F2}; waiting for threshold trigger", 2.0);
                 return;
+            }
 
             TrajectoryPoint point = new TrajectoryPoint
             {
@@ -3185,7 +3194,7 @@ namespace Parsek
 
             if (Recording.Count % 10 == 0)
             {
-                ParsekLog.Log($"Recorded point #{Recording.Count}: {point}");
+                ParsekLog.Verbose("Recorder", $"Recorded point #{Recording.Count}: {point}");
             }
         }
 
@@ -3242,7 +3251,7 @@ namespace Parsek
             };
 
             isOnRails = true;
-            ParsekLog.Log($"Vessel went on rails — capturing orbit segment (body={v.mainBody.name})");
+            ParsekLog.Verbose("Recorder", $"Vessel went on rails — capturing orbit segment (body={v.mainBody.name})");
         }
 
         public void OnVesselGoOffRails(Vessel v)
@@ -3259,7 +3268,7 @@ namespace Parsek
             // Record a boundary TrajectoryPoint at current UT
             SamplePosition(v);
 
-            ParsekLog.Log($"Vessel went off rails — orbit segment closed " +
+            ParsekLog.Verbose("Recorder", $"Vessel went off rails — orbit segment closed " +
                 $"(UT {currentOrbitSegment.startUT:F0}-{currentOrbitSegment.endUT:F0})");
         }
 
@@ -3288,7 +3297,7 @@ namespace Parsek
                 bodyName = v.mainBody.name
             };
 
-            ParsekLog.Log($"SOI changed during orbit recording: {data.from.name} → {data.to.name}");
+            ParsekLog.Verbose("Recorder", $"SOI changed during orbit recording: {data.from.name} → {data.to.name}");
         }
 
         public void OnVesselWillDestroy(Vessel v)
@@ -3307,7 +3316,7 @@ namespace Parsek
 
                 VesselDestroyedDuringRecording = true;
                 RefreshBackupSnapshot(v, "destroy_event", force: true);
-                ParsekLog.Log("Active vessel destroyed during recording!");
+                ParsekLog.Warn("Recorder", "Active vessel destroyed during recording");
             }
         }
 
@@ -3329,7 +3338,7 @@ namespace Parsek
             Patches.PhysicsFramePatch.ActiveRecorder = null;
             UnsubscribePartEvents();
             IsRecording = false;
-            ParsekLog.Log("Auto-stopped recording due to scene change");
+            ParsekLog.Info("Recorder", "Auto-stopped recording due to scene change");
         }
 
         internal static Vessel FindVesselByPid(uint pid)
@@ -3363,13 +3372,13 @@ namespace Parsek
             }
             else
             {
-                ParsekLog.Log($"Snapshot backup FAILED ({reason}): pid={vessel.persistentId}, " +
+                ParsekLog.Warn("Recorder", $"Snapshot backup failed ({reason}): pid={vessel.persistentId}, " +
                     $"loaded={vessel.loaded}, packed={vessel.packed} — using previous snapshot");
             }
 
             if (elapsedMs >= snapshotPerfLogThresholdMs)
             {
-                ParsekLog.Log(
+                ParsekLog.Verbose("Recorder", 
                     $"Snapshot backup cost ({reason}): {elapsedMs:F1}ms " +
                     $"pid={vessel.persistentId}, points={Recording.Count}");
             }

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -138,7 +138,12 @@ namespace Parsek
         private void OnPartDie(Part p)
         {
             if (!IsRecording) return;
-            if (p?.vessel == null) return;
+            if (p?.vessel == null)
+            {
+                ParsekLog.VerboseRateLimited("Recorder", "part-die-null",
+                    "OnPartDie: part or vessel is null");
+                return;
+            }
             if (p.vessel.persistentId != RecordingVesselId) return;
 
             bool hasChute = p.FindModuleImplementing<ModuleParachute>() != null;
@@ -169,7 +174,12 @@ namespace Parsek
         private void OnPartJointBreak(PartJoint joint, float breakForce)
         {
             if (!IsRecording) return;
-            if (joint?.Child?.vessel == null) return;
+            if (joint?.Child?.vessel == null)
+            {
+                ParsekLog.VerboseRateLimited("Recorder", "joint-break-null",
+                    "OnPartJointBreak: joint, child, or vessel is null");
+                return;
+            }
             if (joint.Child.vessel.persistentId != RecordingVesselId) return;
 
             PartEvents.Add(new PartEvent
@@ -2305,8 +2315,10 @@ namespace Parsek
             {
                 return module.Fields[fieldName];
             }
-            catch
+            catch (Exception ex)
             {
+                ParsekLog.VerboseRateLimited("Recorder", $"field-{fieldName}",
+                    $"FindModuleField exception for '{fieldName}' on {module.GetType().Name}: {ex.Message}");
                 return null;
             }
         }
@@ -3203,7 +3215,12 @@ namespace Parsek
         /// </summary>
         public void SamplePosition(Vessel v)
         {
-            if (v == null) return;
+            if (v == null)
+            {
+                ParsekLog.VerboseRateLimited("Recorder", "sample-null-vessel",
+                    "SamplePosition called with null vessel");
+                return;
+            }
 
             Vector3 currentVelocity = v.packed
                 ? (Vector3)v.obt_velocity
@@ -3231,7 +3248,12 @@ namespace Parsek
         public void OnVesselGoOnRails(Vessel v)
         {
             if (!IsRecording) return;
-            if (v != FlightGlobals.ActiveVessel) return;
+            if (v != FlightGlobals.ActiveVessel)
+            {
+                ParsekLog.VerboseRateLimited("Recorder", "on-rails-other-vessel",
+                    $"OnVesselGoOnRails: ignoring non-active vessel (pid={v?.persistentId})");
+                return;
+            }
             if (v.persistentId != RecordingVesselId) return;
 
             // Record a boundary TrajectoryPoint at current UT (stitching point)
@@ -3257,7 +3279,12 @@ namespace Parsek
         public void OnVesselGoOffRails(Vessel v)
         {
             if (!IsRecording || !isOnRails) return;
-            if (v != FlightGlobals.ActiveVessel) return;
+            if (v != FlightGlobals.ActiveVessel)
+            {
+                ParsekLog.VerboseRateLimited("Recorder", "off-rails-other-vessel",
+                    $"OnVesselGoOffRails: ignoring non-active vessel (pid={v?.persistentId})");
+                return;
+            }
             if (v.persistentId != RecordingVesselId) return;
 
             // Finalize orbit segment
@@ -3275,7 +3302,12 @@ namespace Parsek
         public void OnVesselSOIChanged(GameEvents.HostedFromToAction<Vessel, CelestialBody> data)
         {
             if (!IsRecording || !isOnRails) return;
-            if (data.host != FlightGlobals.ActiveVessel) return;
+            if (data.host != FlightGlobals.ActiveVessel)
+            {
+                ParsekLog.VerboseRateLimited("Recorder", "soi-other-vessel",
+                    $"OnVesselSOIChanged: ignoring non-active vessel (pid={data.host?.persistentId})");
+                return;
+            }
             if (data.host.persistentId != RecordingVesselId) return;
 
             // Close current orbit segment in old SOI
@@ -3303,7 +3335,11 @@ namespace Parsek
         public void OnVesselWillDestroy(Vessel v)
         {
             if (!IsRecording) return;
-            if (FlightGlobals.ActiveVessel == null) return;
+            if (FlightGlobals.ActiveVessel == null)
+            {
+                ParsekLog.Verbose("Recorder", "OnVesselWillDestroy: no active vessel — skipping");
+                return;
+            }
             if (v == FlightGlobals.ActiveVessel)
             {
                 // Finalize in-progress orbit segment if on rails

--- a/Source/Parsek/GameStateBaseline.cs
+++ b/Source/Parsek/GameStateBaseline.cs
@@ -93,6 +93,11 @@ namespace Parsek
                         baseline.buildingIntact[db.id] = !db.IsDestroyed;
                 }
             }
+            if (baseline.buildingIntact.Count == 0)
+            {
+                ParsekLog.Verbose("Baseline",
+                    $"Captured baseline at ut={baseline.ut:F0} with no building state entries (scene={HighLogic.LoadedScene})");
+            }
 
             // Active contracts
             if (ContractSystem.Instance != null)
@@ -128,6 +133,11 @@ namespace Parsek
                     }
                 }
             }
+
+            ParsekLog.Info("Baseline",
+                $"Captured baseline at ut={baseline.ut:F0}: tech={baseline.researchedTechIds.Count}, " +
+                $"facilities={baseline.facilityLevels.Count}, buildings={baseline.buildingIntact.Count}, " +
+                $"contracts={baseline.activeContracts.Count}, crew={baseline.crewEntries.Count}");
 
             return baseline;
         }
@@ -174,19 +184,31 @@ namespace Parsek
 
             string utStr = node.GetValue("ut");
             if (utStr != null)
-                double.TryParse(utStr, NumberStyles.Float, CultureInfo.InvariantCulture, out baseline.ut);
+            {
+                if (!double.TryParse(utStr, NumberStyles.Float, CultureInfo.InvariantCulture, out baseline.ut))
+                    ParsekLog.Warn("Baseline", $"Failed to parse baseline UT '{utStr}'");
+            }
 
             string fundsStr = node.GetValue("funds");
             if (fundsStr != null)
-                double.TryParse(fundsStr, NumberStyles.Float, CultureInfo.InvariantCulture, out baseline.funds);
+            {
+                if (!double.TryParse(fundsStr, NumberStyles.Float, CultureInfo.InvariantCulture, out baseline.funds))
+                    ParsekLog.Warn("Baseline", $"Failed to parse baseline funds '{fundsStr}'");
+            }
 
             string sciStr = node.GetValue("science");
             if (sciStr != null)
-                double.TryParse(sciStr, NumberStyles.Float, CultureInfo.InvariantCulture, out baseline.science);
+            {
+                if (!double.TryParse(sciStr, NumberStyles.Float, CultureInfo.InvariantCulture, out baseline.science))
+                    ParsekLog.Warn("Baseline", $"Failed to parse baseline science '{sciStr}'");
+            }
 
             string repStr = node.GetValue("reputation");
             if (repStr != null)
-                float.TryParse(repStr, NumberStyles.Float, CultureInfo.InvariantCulture, out baseline.reputation);
+            {
+                if (!float.TryParse(repStr, NumberStyles.Float, CultureInfo.InvariantCulture, out baseline.reputation))
+                    ParsekLog.Warn("Baseline", $"Failed to parse baseline reputation '{repStr}'");
+            }
 
             // Tech
             ConfigNode techNode = node.GetNode("TECH_IDS");
@@ -206,6 +228,8 @@ namespace Parsek
                     float level;
                     if (float.TryParse(v.value, NumberStyles.Float, CultureInfo.InvariantCulture, out level))
                         baseline.facilityLevels[v.name] = level;
+                    else
+                        ParsekLog.Warn("Baseline", $"Failed to parse facility level '{v.value}' for '{v.name}'");
                 }
             }
 
@@ -218,6 +242,8 @@ namespace Parsek
                     bool intact;
                     if (bool.TryParse(v.value, out intact))
                         baseline.buildingIntact[v.name] = intact;
+                    else
+                        ParsekLog.Warn("Baseline", $"Failed to parse building intact value '{v.value}' for '{v.name}'");
                 }
             }
 
@@ -236,6 +262,11 @@ namespace Parsek
                 foreach (ConfigNode entryNode in crewNode.GetNodes("CREW"))
                     baseline.crewEntries.Add(CrewEntry.DeserializeFrom(entryNode));
             }
+
+            ParsekLog.Verbose("Baseline",
+                $"Deserialized baseline at ut={baseline.ut:F0}: tech={baseline.researchedTechIds.Count}, " +
+                $"facilities={baseline.facilityLevels.Count}, buildings={baseline.buildingIntact.Count}, " +
+                $"contracts={baseline.activeContracts.Count}, crew={baseline.crewEntries.Count}");
 
             return baseline;
         }

--- a/Source/Parsek/GameStateEvent.cs
+++ b/Source/Parsek/GameStateEvent.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Globalization;
 
 namespace Parsek
@@ -53,14 +54,30 @@ namespace Parsek
 
             string utStr = node.GetValue("ut");
             if (utStr != null)
-                double.TryParse(utStr, NumberStyles.Float, CultureInfo.InvariantCulture, out e.ut);
+            {
+                if (!double.TryParse(utStr, NumberStyles.Float, CultureInfo.InvariantCulture, out e.ut))
+                    ParsekLog.Warn("GameStateEvent", $"Failed to parse 'ut' value '{utStr}'");
+            }
 
             string typeStr = node.GetValue("type");
             if (typeStr != null)
             {
                 int typeInt;
                 if (int.TryParse(typeStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out typeInt))
-                    e.eventType = (GameStateEventType)typeInt;
+                {
+                    if (Enum.IsDefined(typeof(GameStateEventType), typeInt))
+                    {
+                        e.eventType = (GameStateEventType)typeInt;
+                    }
+                    else
+                    {
+                        ParsekLog.Warn("GameStateEvent", $"Unknown event type id '{typeInt}' while deserializing");
+                    }
+                }
+                else
+                {
+                    ParsekLog.Warn("GameStateEvent", $"Failed to parse event type value '{typeStr}'");
+                }
             }
 
             e.key = node.GetValue("key") ?? "";
@@ -68,11 +85,17 @@ namespace Parsek
 
             string valBeforeStr = node.GetValue("valBefore");
             if (valBeforeStr != null)
-                double.TryParse(valBeforeStr, NumberStyles.Float, CultureInfo.InvariantCulture, out e.valueBefore);
+            {
+                if (!double.TryParse(valBeforeStr, NumberStyles.Float, CultureInfo.InvariantCulture, out e.valueBefore))
+                    ParsekLog.Warn("GameStateEvent", $"Failed to parse valBefore '{valBeforeStr}'");
+            }
 
             string valAfterStr = node.GetValue("valAfter");
             if (valAfterStr != null)
-                double.TryParse(valAfterStr, NumberStyles.Float, CultureInfo.InvariantCulture, out e.valueAfter);
+            {
+                if (!double.TryParse(valAfterStr, NumberStyles.Float, CultureInfo.InvariantCulture, out e.valueAfter))
+                    ParsekLog.Warn("GameStateEvent", $"Failed to parse valAfter '{valAfterStr}'");
+            }
 
             return e;
         }

--- a/Source/Parsek/GameStateRecorder.cs
+++ b/Source/Parsek/GameStateRecorder.cs
@@ -75,7 +75,7 @@ namespace Parsek
             // Poll facility/building state for changes since last save
             PollFacilityState();
 
-            ParsekLog.Log($"GameStateRecorder subscribed ({GameStateStore.EventCount} events in history)");
+            ParsekLog.Info("GameStateRecorder", $"GameStateRecorder subscribed ({GameStateStore.EventCount} events in history)");
         }
 
         internal void Unsubscribe()
@@ -105,7 +105,7 @@ namespace Parsek
             GameEvents.OnScienceChanged.Remove(OnScienceChanged);
             GameEvents.OnReputationChanged.Remove(OnReputationChanged);
 
-            ParsekLog.Log("GameStateRecorder unsubscribed");
+            ParsekLog.Info("GameStateRecorder", "GameStateRecorder unsubscribed");
         }
 
         #endregion
@@ -123,7 +123,7 @@ namespace Parsek
                 key = contract.ContractGuid.ToString(),
                 detail = title
             });
-            ParsekLog.Log($"Game state: ContractOffered '{title}'");
+            ParsekLog.Info("GameStateRecorder", $"Game state: ContractOffered '{title}'");
         }
 
         private void OnContractAccepted(Contract contract)
@@ -146,11 +146,11 @@ namespace Parsek
                 var contractNode = new ConfigNode("CONTRACT");
                 contract.Save(contractNode);
                 GameStateStore.AddContractSnapshot(guid, contractNode);
-                ParsekLog.Log($"Game state: ContractAccepted '{title}' (snapshot saved)");
+                ParsekLog.Info("GameStateRecorder", $"Game state: ContractAccepted '{title}' (snapshot saved)");
             }
             catch (Exception ex)
             {
-                ParsekLog.Log($"Game state: ContractAccepted '{title}' (snapshot FAILED: {ex.Message})");
+                ParsekLog.Warn("GameStateRecorder", $"Game state: ContractAccepted '{title}' (snapshot FAILED: {ex.Message})");
             }
         }
 
@@ -165,7 +165,7 @@ namespace Parsek
                 key = contract.ContractGuid.ToString(),
                 detail = title
             });
-            ParsekLog.Log($"Game state: ContractCompleted '{title}'");
+            ParsekLog.Info("GameStateRecorder", $"Game state: ContractCompleted '{title}'");
         }
 
         private void OnContractFailed(Contract contract)
@@ -179,7 +179,7 @@ namespace Parsek
                 key = contract.ContractGuid.ToString(),
                 detail = title
             });
-            ParsekLog.Log($"Game state: ContractFailed '{title}'");
+            ParsekLog.Info("GameStateRecorder", $"Game state: ContractFailed '{title}'");
         }
 
         private void OnContractCancelled(Contract contract)
@@ -193,7 +193,7 @@ namespace Parsek
                 key = contract.ContractGuid.ToString(),
                 detail = title
             });
-            ParsekLog.Log($"Game state: ContractCancelled '{title}'");
+            ParsekLog.Info("GameStateRecorder", $"Game state: ContractCancelled '{title}'");
         }
 
         private void OnContractDeclined(Contract contract)
@@ -207,7 +207,7 @@ namespace Parsek
                 key = contract.ContractGuid.ToString(),
                 detail = title
             });
-            ParsekLog.Log($"Game state: ContractDeclined '{title}'");
+            ParsekLog.Info("GameStateRecorder", $"Game state: ContractDeclined '{title}'");
         }
 
         #endregion
@@ -245,7 +245,7 @@ namespace Parsek
                     ? ResearchAndDevelopment.Instance.Science
                     : 0
             });
-            ParsekLog.Log($"Game state: TechResearched '{techId}' (cost={data.host.scienceCost})");
+            ParsekLog.Info("GameStateRecorder", $"Game state: TechResearched '{techId}' (cost={data.host.scienceCost})");
         }
 
         private void OnPartPurchased(AvailablePart part)
@@ -262,7 +262,7 @@ namespace Parsek
                 valueBefore = Funding.Instance != null ? Funding.Instance.Funds + part.cost : 0,
                 valueAfter = Funding.Instance != null ? Funding.Instance.Funds : 0
             });
-            ParsekLog.Log($"Game state: PartPurchased '{partName}' (cost={part.cost})");
+            ParsekLog.Info("GameStateRecorder", $"Game state: PartPurchased '{partName}' (cost={part.cost})");
         }
 
         #endregion
@@ -271,7 +271,13 @@ namespace Parsek
 
         private void OnKerbalAdded(ProtoCrewMember crew)
         {
-            if (SuppressCrewEvents || crew == null) return;
+            if (SuppressCrewEvents)
+            {
+                ParsekLog.VerboseRateLimited("GameStateRecorder", "suppress-crew-added",
+                    "Suppressed CrewHired event while Parsek mutates crew state", 5.0);
+                return;
+            }
+            if (crew == null) return;
             var name = crew.name ?? "";
 
             GameStateStore.AddEvent(new GameStateEvent
@@ -281,12 +287,18 @@ namespace Parsek
                 key = name,
                 detail = $"trait={crew.trait ?? ""}"
             });
-            ParsekLog.Log($"Game state: CrewHired '{name}' ({crew.trait ?? "?"})");
+            ParsekLog.Info("GameStateRecorder", $"Game state: CrewHired '{name}' ({crew.trait ?? "?"})");
         }
 
         private void OnKerbalRemoved(ProtoCrewMember crew)
         {
-            if (SuppressCrewEvents || crew == null) return;
+            if (SuppressCrewEvents)
+            {
+                ParsekLog.VerboseRateLimited("GameStateRecorder", "suppress-crew-removed",
+                    "Suppressed CrewRemoved event while Parsek mutates crew state", 5.0);
+                return;
+            }
+            if (crew == null) return;
             var name = crew.name ?? "";
 
             GameStateStore.AddEvent(new GameStateEvent
@@ -296,13 +308,19 @@ namespace Parsek
                 key = name,
                 detail = $"trait={crew.trait ?? ""}"
             });
-            ParsekLog.Log($"Game state: CrewRemoved '{name}'");
+            ParsekLog.Info("GameStateRecorder", $"Game state: CrewRemoved '{name}'");
         }
 
         private void OnKerbalStatusChange(ProtoCrewMember crew,
             ProtoCrewMember.RosterStatus oldStatus, ProtoCrewMember.RosterStatus newStatus)
         {
-            if (SuppressCrewEvents || crew == null) return;
+            if (SuppressCrewEvents)
+            {
+                ParsekLog.VerboseRateLimited("GameStateRecorder", "suppress-crew-status",
+                    "Suppressed CrewStatusChanged event while Parsek mutates crew state", 5.0);
+                return;
+            }
+            if (crew == null) return;
             var name = crew.name ?? "";
 
             GameStateStore.AddEvent(new GameStateEvent
@@ -312,7 +330,7 @@ namespace Parsek
                 key = name,
                 detail = $"from={oldStatus};to={newStatus}"
             });
-            ParsekLog.Log($"Game state: CrewStatusChanged '{name}' {oldStatus} → {newStatus}");
+            ParsekLog.Info("GameStateRecorder", $"Game state: CrewStatusChanged '{name}' {oldStatus} → {newStatus}");
         }
 
         #endregion
@@ -334,10 +352,20 @@ namespace Parsek
             double oldFunds = lastFunds;
             lastFunds = newFunds;
 
-            if (SuppressResourceEvents) return;
+            if (SuppressResourceEvents)
+            {
+                ParsekLog.VerboseRateLimited("GameStateRecorder", "suppress-funds",
+                    $"Suppressed FundsChanged event ({reason}) during timeline replay", 5.0);
+                return;
+            }
             if (double.IsNaN(oldFunds)) return;
             double delta = newFunds - oldFunds;
-            if (Math.Abs(delta) < FundsThreshold) return;
+            if (Math.Abs(delta) < FundsThreshold)
+            {
+                ParsekLog.VerboseRateLimited("GameStateRecorder", "funds-threshold",
+                    $"Ignored FundsChanged delta={delta:+0.0;-0.0} below threshold={FundsThreshold:F1}", 5.0);
+                return;
+            }
 
             GameStateStore.AddEvent(new GameStateEvent
             {
@@ -347,7 +375,7 @@ namespace Parsek
                 valueBefore = oldFunds,
                 valueAfter = newFunds
             });
-            ParsekLog.Log($"Game state: FundsChanged {delta:+0;-0} ({reason}) → {newFunds:F0}");
+            ParsekLog.Info("GameStateRecorder", $"Game state: FundsChanged {delta:+0;-0} ({reason}) → {newFunds:F0}");
         }
 
         private void OnScienceChanged(float newScience, TransactionReasons reason)
@@ -355,10 +383,20 @@ namespace Parsek
             double oldScience = lastScience;
             lastScience = newScience;
 
-            if (SuppressResourceEvents) return;
+            if (SuppressResourceEvents)
+            {
+                ParsekLog.VerboseRateLimited("GameStateRecorder", "suppress-science",
+                    $"Suppressed ScienceChanged event ({reason}) during timeline replay", 5.0);
+                return;
+            }
             if (double.IsNaN(oldScience)) return;
             double delta = newScience - oldScience;
-            if (Math.Abs(delta) < ScienceThreshold) return;
+            if (Math.Abs(delta) < ScienceThreshold)
+            {
+                ParsekLog.VerboseRateLimited("GameStateRecorder", "science-threshold",
+                    $"Ignored ScienceChanged delta={delta:+0.0;-0.0} below threshold={ScienceThreshold:F1}", 5.0);
+                return;
+            }
 
             GameStateStore.AddEvent(new GameStateEvent
             {
@@ -368,7 +406,7 @@ namespace Parsek
                 valueBefore = oldScience,
                 valueAfter = newScience
             });
-            ParsekLog.Log($"Game state: ScienceChanged {delta:+0.0;-0.0} ({reason}) → {newScience:F1}");
+            ParsekLog.Info("GameStateRecorder", $"Game state: ScienceChanged {delta:+0.0;-0.0} ({reason}) → {newScience:F1}");
         }
 
         private void OnReputationChanged(float newReputation, TransactionReasons reason)
@@ -376,10 +414,20 @@ namespace Parsek
             float oldReputation = lastReputation;
             lastReputation = newReputation;
 
-            if (SuppressResourceEvents) return;
+            if (SuppressResourceEvents)
+            {
+                ParsekLog.VerboseRateLimited("GameStateRecorder", "suppress-reputation",
+                    $"Suppressed ReputationChanged event ({reason}) during timeline replay", 5.0);
+                return;
+            }
             if (float.IsNaN(oldReputation)) return;
             float delta = newReputation - oldReputation;
-            if (Math.Abs(delta) < ReputationThreshold) return;
+            if (Math.Abs(delta) < ReputationThreshold)
+            {
+                ParsekLog.VerboseRateLimited("GameStateRecorder", "reputation-threshold",
+                    $"Ignored ReputationChanged delta={delta:+0.0;-0.0} below threshold={ReputationThreshold:F1}", 5.0);
+                return;
+            }
 
             GameStateStore.AddEvent(new GameStateEvent
             {
@@ -389,7 +437,7 @@ namespace Parsek
                 valueBefore = oldReputation,
                 valueAfter = newReputation
             });
-            ParsekLog.Log($"Game state: ReputationChanged {delta:+0.0;-0.0} ({reason}) → {newReputation:F1}");
+            ParsekLog.Info("GameStateRecorder", $"Game state: ReputationChanged {delta:+0.0;-0.0} ({reason}) → {newReputation:F1}");
         }
 
         #endregion
@@ -430,7 +478,7 @@ namespace Parsek
                 }
             }
 
-            ParsekLog.Log($"Game state: Facility cache seeded from current state " +
+            ParsekLog.Info("GameStateRecorder", $"Game state: Facility cache seeded from current state " +
                 $"({lastFacilityLevels.Count} facilities, {lastBuildingIntact.Count} buildings)");
         }
 
@@ -441,6 +489,9 @@ namespace Parsek
         internal void PollFacilityState()
         {
             double ut = Planetarium.GetUniversalTime();
+            int facilitiesChecked = 0;
+            int buildingsChecked = 0;
+            int eventsEmitted = 0;
 
             // Check facility levels
             if (ScenarioUpgradeableFacilities.protoUpgradeables != null)
@@ -453,6 +504,7 @@ namespace Parsek
                     var facility = kvp.Value.facilityRefs[0];
                     if (facility == null) continue;
 
+                    facilitiesChecked++;
                     float currentLevel = facility.GetNormLevel();
                     float cachedLevel;
 
@@ -472,7 +524,8 @@ namespace Parsek
                                 valueBefore = cachedLevel,
                                 valueAfter = currentLevel
                             });
-                            ParsekLog.Log($"Game state: {eventType} '{kvp.Key}' {cachedLevel:F2} → {currentLevel:F2}");
+                            eventsEmitted++;
+                            ParsekLog.Info("GameStateRecorder", $"Game state: {eventType} '{kvp.Key}' {cachedLevel:F2} → {currentLevel:F2}");
                         }
                     }
 
@@ -488,6 +541,7 @@ namespace Parsek
                 {
                     if (db == null || string.IsNullOrEmpty(db.id)) continue;
 
+                    buildingsChecked++;
                     bool currentIntact = !db.IsDestroyed;
                     bool cachedIntact;
 
@@ -505,13 +559,18 @@ namespace Parsek
                                 eventType = eventType,
                                 key = db.id
                             });
-                            ParsekLog.Log($"Game state: {eventType} '{db.id}'");
+                            eventsEmitted++;
+                            ParsekLog.Info("GameStateRecorder", $"Game state: {eventType} '{db.id}'");
                         }
                     }
 
                     lastBuildingIntact[db.id] = currentIntact;
                 }
             }
+
+            ParsekLog.Verbose("GameStateRecorder",
+                $"Facility poll pass: facilitiesChecked={facilitiesChecked}, buildingsChecked={buildingsChecked}, " +
+                $"eventsEmitted={eventsEmitted}");
         }
 
         #endregion

--- a/Source/Parsek/GameStateStore.cs
+++ b/Source/Parsek/GameStateStore.cs
@@ -65,7 +65,11 @@ namespace Parsek
 
         internal static void AddContractSnapshot(string guid, ConfigNode contractNode)
         {
-            if (string.IsNullOrEmpty(guid) || contractNode == null) return;
+            if (string.IsNullOrEmpty(guid) || contractNode == null)
+            {
+                ParsekLog.Verbose("GameStateStore", $"AddContractSnapshot skipped: guid={guid ?? "null"}, node={contractNode != null}");
+                return;
+            }
 
             // Replace existing snapshot for same GUID (contract re-accepted after failure)
             for (int i = 0; i < contractSnapshots.Count; i++)

--- a/Source/Parsek/GameStateStore.cs
+++ b/Source/Parsek/GameStateStore.cs
@@ -388,14 +388,12 @@ namespace Parsek
             if (clean.StartsWith(LegacyPrefix, StringComparison.Ordinal))
                 clean = clean.Substring(LegacyPrefix.Length);
 
-            if (clean.StartsWith("WARNING:", StringComparison.OrdinalIgnoreCase))
+            if (clean.StartsWith("WARNING:", StringComparison.OrdinalIgnoreCase) ||
+                clean.StartsWith("WARN:", StringComparison.OrdinalIgnoreCase))
             {
-                ParsekLog.Warn("GameStateStore", clean.Substring("WARNING:".Length).TrimStart());
-                return;
-            }
-            if (clean.IndexOf("failed", StringComparison.OrdinalIgnoreCase) >= 0)
-            {
-                ParsekLog.Warn("GameStateStore", clean);
+                int idx = clean.IndexOf(':');
+                string trimmed = idx >= 0 ? clean.Substring(idx + 1).TrimStart() : clean;
+                ParsekLog.Warn("GameStateStore", trimmed);
                 return;
             }
 

--- a/Source/Parsek/GameStateStore.cs
+++ b/Source/Parsek/GameStateStore.cs
@@ -16,6 +16,7 @@ namespace Parsek
         private static string lastSaveFolder = null;
 
         internal static bool SuppressLogging = false;
+        private const string LegacyPrefix = "[Parsek] ";
 
         private const double ResourceCoalesceEpsilon = 0.1; // seconds
 
@@ -42,6 +43,8 @@ namespace Parsek
                         // Update the existing event's valueAfter
                         existing.valueAfter = e.valueAfter;
                         events[i] = existing;
+                        ParsekLog.VerboseRateLimited("GameStateStore", "resource-coalesce",
+                            $"Coalesced {e.eventType} event at ut={e.ut:F2}");
                         return;
                     }
                     // Stop searching once we pass the epsilon window
@@ -156,7 +159,12 @@ namespace Parsek
 
             try
             {
-                RecordingPaths.EnsureGameStateDirectory();
+                string dir = RecordingPaths.EnsureGameStateDirectory();
+                if (string.IsNullOrEmpty(dir))
+                {
+                    Log("[Parsek] WARNING: EnsureGameStateDirectory returned null during SaveEventFile");
+                    return false;
+                }
 
                 // Events are stored in insertion (capture) order, not UT order.
                 // After reverts, events from an abandoned future branch precede
@@ -221,6 +229,18 @@ namespace Parsek
                     return false;
                 }
 
+                int version = 1;
+                string versionStr = rootNode.GetValue("version");
+                if (!string.IsNullOrEmpty(versionStr) && !int.TryParse(versionStr, out version))
+                {
+                    Log($"[Parsek] WARNING: Invalid game state events version '{versionStr}'");
+                    version = 1;
+                }
+                if (version != 1)
+                {
+                    Log($"[Parsek] WARNING: Unsupported game state events version={version} (expected 1)");
+                }
+
                 // ConfigNode.Load returns the file contents directly
                 ConfigNode[] eventNodes = rootNode.GetNodes("GAME_STATE_EVENT");
                 if (eventNodes != null)
@@ -261,7 +281,12 @@ namespace Parsek
 
             try
             {
-                RecordingPaths.EnsureGameStateDirectory();
+                string dir = RecordingPaths.EnsureGameStateDirectory();
+                if (string.IsNullOrEmpty(dir))
+                {
+                    Log("[Parsek] WARNING: EnsureGameStateDirectory returned null during SaveBaseline");
+                    return false;
+                }
 
                 var rootNode = new ConfigNode("PARSEK_BASELINE");
                 baseline.SerializeInto(rootNode);
@@ -317,8 +342,27 @@ namespace Parsek
             string tmpPath = path + ".tmp";
             node.Save(tmpPath);
             if (File.Exists(path))
-                File.Delete(path);
-            File.Move(tmpPath, path);
+            {
+                try
+                {
+                    File.Delete(path);
+                }
+                catch (Exception ex)
+                {
+                    Log($"[Parsek] WARNING: Failed to delete existing file '{path}': {ex.Message}");
+                    throw;
+                }
+            }
+
+            try
+            {
+                File.Move(tmpPath, path);
+            }
+            catch (Exception ex)
+            {
+                Log($"[Parsek] WARNING: Failed to move temp file '{tmpPath}' to '{path}': {ex.Message}");
+                throw;
+            }
         }
 
         #endregion
@@ -338,8 +382,24 @@ namespace Parsek
 
         private static void Log(string msg)
         {
-            if (!SuppressLogging)
-                Debug.Log(msg);
+            if (SuppressLogging) return;
+
+            string clean = msg ?? "(empty)";
+            if (clean.StartsWith(LegacyPrefix, StringComparison.Ordinal))
+                clean = clean.Substring(LegacyPrefix.Length);
+
+            if (clean.StartsWith("WARNING:", StringComparison.OrdinalIgnoreCase))
+            {
+                ParsekLog.Warn("GameStateStore", clean.Substring("WARNING:".Length).TrimStart());
+                return;
+            }
+            if (clean.IndexOf("failed", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                ParsekLog.Warn("GameStateStore", clean);
+                return;
+            }
+
+            ParsekLog.Info("GameStateStore", clean);
         }
     }
 }

--- a/Source/Parsek/GhostGeometryCapture.cs
+++ b/Source/Parsek/GhostGeometryCapture.cs
@@ -12,7 +12,11 @@ namespace Parsek
         /// </summary>
         internal static void CaptureStub(RecordingStore.Recording rec, Vessel vesselAtCapture)
         {
-            if (rec == null) return;
+            if (rec == null)
+            {
+                ParsekLog.Warn("GhostGeometry", "CaptureStub called with null recording");
+                return;
+            }
 
             rec.RecordingFormatVersion = RecordingStore.CurrentRecordingFormatVersion;
             rec.GhostGeometryVersion = RecordingStore.CurrentGhostGeometryVersion;
@@ -35,6 +39,9 @@ namespace Parsek
                 }
             }
             rec.GhostGeometryProbeStatus = DetermineProbeStatus(vesselLoaded, partCount, missingTransforms);
+            ParsekLog.Verbose("GhostGeometry",
+                $"Probe status for '{rec.VesselName}' id={rec.RecordingId}: {rec.GhostGeometryProbeStatus} " +
+                $"(vesselLoaded={vesselLoaded}, partCount={partCount}, missingTransforms={missingTransforms})");
 
             try
             {
@@ -42,6 +49,8 @@ namespace Parsek
                 if (string.IsNullOrEmpty(absolutePath))
                 {
                     rec.GhostGeometryCaptureError = "no_save_context";
+                    ParsekLog.Warn("GhostGeometry",
+                        $"Stub capture skipped for '{rec.VesselName}' id={rec.RecordingId}: no save context");
                     return;
                 }
                 string dir = Path.GetDirectoryName(absolutePath);
@@ -60,11 +69,15 @@ namespace Parsek
                 node.AddValue("capturedUT", Planetarium.GetUniversalTime().ToString("R"));
                 node.AddValue("vesselName", vesselAtCapture != null ? vesselAtCapture.vesselName : rec.VesselName);
                 node.Save(absolutePath);
+                ParsekLog.Info("GhostGeometry",
+                    $"Stub capture wrote '{absolutePath}' for '{rec.VesselName}' id={rec.RecordingId} " +
+                    $"probe={rec.GhostGeometryProbeStatus}");
             }
             catch (Exception ex)
             {
                 rec.GhostGeometryCaptureError = $"stub_write_failed:{ex.GetType().Name}";
-                ParsekLog.Log($"Ghost geometry stub write failed for '{rec.VesselName}': {ex.Message}");
+                ParsekLog.Error("GhostGeometry",
+                    $"Stub capture write failed for '{rec.VesselName}' id={rec.RecordingId}: {ex.Message}");
             }
         }
 

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -164,11 +164,19 @@ namespace Parsek
             roboticInfos = null;
             ConfigNode snapshotNode = GetGhostSnapshot(rec);
             if (snapshotNode == null)
+            {
+                ParsekLog.Warn("GhostVisual",
+                    $"Ghost build aborted for '{rec?.VesselName ?? "unknown"}': no snapshot node");
                 return null;
+            }
 
             var partNodes = snapshotNode.GetNodes("PART");
             if (partNodes == null || partNodes.Length == 0)
+            {
+                ParsekLog.Warn("GhostVisual",
+                    $"Ghost build aborted for '{rec?.VesselName ?? "unknown"}': snapshot has no PART nodes");
                 return null;
+            }
 
             GameObject root = new GameObject(rootName);
             bool addedAnyVisual = false;
@@ -196,7 +204,7 @@ namespace Parsek
                 if (string.IsNullOrEmpty(partName))
                 {
                     skippedName++;
-                    ParsekLog.Log($"  Ghost part SKIPPED (no name): raw='{rawPart ?? "null"}' index={i}");
+                    ParsekLog.Verbose("GhostVisual", $"  Ghost part SKIPPED (no name): raw='{rawPart ?? "null"}' index={i}");
                     continue;
                 }
 
@@ -210,14 +218,14 @@ namespace Parsek
                 if (ap == null || ap.partPrefab == null)
                 {
                     skippedPrefab++;
-                    ParsekLog.Log($"  Ghost part SKIPPED (no prefab): '{partName}' pid={persistentId}");
+                    ParsekLog.Verbose("GhostVisual", $"  Ghost part SKIPPED (no prefab): '{partName}' pid={persistentId}");
                     continue;
                 }
                 string resolvedName = ap.partPrefab.partInfo?.name ?? ap.name;
                 if (!string.IsNullOrEmpty(resolvedName) &&
                     !string.Equals(resolvedName, partName, System.StringComparison.OrdinalIgnoreCase))
                 {
-                    ParsekLog.Log($"  Ghost part lookup alias: '{partName}' -> '{resolvedName}'");
+                    ParsekLog.Verbose("GhostVisual", $"  Ghost part lookup alias: '{partName}' -> '{resolvedName}'");
                 }
 
                 int meshCount = 0;
@@ -245,7 +253,7 @@ namespace Parsek
                 else
                 {
                     skippedMesh++;
-                    ParsekLog.Log($"  Ghost part SKIPPED (no mesh): '{partName}' pid={persistentId}");
+                    ParsekLog.Verbose("GhostVisual", $"  Ghost part SKIPPED (no mesh): '{partName}' pid={persistentId}");
                 }
                 addedAnyVisual = addedAnyVisual || partVisualAdded;
 
@@ -269,7 +277,7 @@ namespace Parsek
                     collectedRoboticInfos.AddRange(partRoboticInfos);
             }
 
-            ParsekLog.Log($"Ghost built: {visualCount}/{partNodes.Length} parts with visuals" +
+            ParsekLog.Verbose("GhostVisual", $"Ghost built: {visualCount}/{partNodes.Length} parts with visuals" +
                 (skippedName > 0 ? $", {skippedName} bad name" : "") +
                 (skippedPrefab > 0 ? $", {skippedPrefab} no prefab" : "") +
                 (skippedMesh > 0 ? $", {skippedMesh} no mesh" : ""));
@@ -277,6 +285,8 @@ namespace Parsek
             if (!addedAnyVisual)
             {
                 Object.Destroy(root);
+                ParsekLog.Warn("GhostVisual",
+                    $"Ghost build produced zero visuals for '{rec?.VesselName ?? "unknown"}' (parts={partNodes.Length})");
                 return null;
             }
 
@@ -744,17 +754,17 @@ namespace Parsek
                                     sdPos = tempClone.transform.InverseTransformPoint(canopy.position);
                                     sdRot = Quaternion.Inverse(tempClone.transform.rotation) * canopy.rotation;
                                     semiDeployedSampled = true;
-                                    ParsekLog.Log($"  Semi-deployed canopy sampled via '{semiAnim}'@1: scale={sdScale} " +
+                                    ParsekLog.Verbose("GhostVisual", $"  Semi-deployed canopy sampled via '{semiAnim}'@1: scale={sdScale} " +
                                         $"rootPos={sdPos} rootRot={sdRot.eulerAngles}");
                                 }
                                 else
                                 {
-                                    ParsekLog.Log($"  Semi-deploy animation '{semiAnim}'@1 gave near-zero scale, skipping");
+                                    ParsekLog.Verbose("GhostVisual", $"  Semi-deploy animation '{semiAnim}'@1 gave near-zero scale, skipping");
                                 }
                             }
                             else
                             {
-                                ParsekLog.Log($"  Semi-deploy animation '{semiAnim}' not found on clone for '{key}'");
+                                ParsekLog.Verbose("GhostVisual", $"  Semi-deploy animation '{semiAnim}' not found on clone for '{key}'");
                             }
                         }
 
@@ -780,19 +790,19 @@ namespace Parsek
                                     dPos = tempClone.transform.InverseTransformPoint(canopy.position);
                                     dRot = Quaternion.Inverse(tempClone.transform.rotation) * canopy.rotation;
                                     deployedSampled = true;
-                                    ParsekLog.Log($"  Deployed canopy sampled via '{deployedAnimName}'@1: scale={dScale} " +
+                                    ParsekLog.Verbose("GhostVisual", $"  Deployed canopy sampled via '{deployedAnimName}'@1: scale={dScale} " +
                                         $"rootPos={dPos} rootRot={dRot.eulerAngles}");
                                 }
                             }
                             else
                             {
-                                ParsekLog.Log($"  Deploy animation '{deployedAnimName}' not found on clone for '{key}'");
+                                ParsekLog.Verbose("GhostVisual", $"  Deploy animation '{deployedAnimName}' not found on clone for '{key}'");
                             }
                         }
                     }
                     else
                     {
-                        ParsekLog.Log($"  No Animation component on model clone for '{key}'");
+                        ParsekLog.Verbose("GhostVisual", $"  No Animation component on model clone for '{key}'");
                     }
                 }
                 finally
@@ -804,7 +814,7 @@ namespace Parsek
             // Deployed fallback: if animation produced near-zero scale
             if (deployedSampled && dScale.magnitude < 0.01f)
             {
-                ParsekLog.Log($"  Deploy animation produced near-zero scale ({dScale}), using deployed canopy fallback");
+                ParsekLog.Verbose("GhostVisual", $"  Deploy animation produced near-zero scale ({dScale}), using deployed canopy fallback");
                 dScale = Vector3.one;
                 dPos = Vector3.zero;
                 dRot = Quaternion.identity;
@@ -812,7 +822,7 @@ namespace Parsek
 
             var result = (sdScale, sdPos, sdRot, semiDeployedSampled, dScale, dPos, dRot);
             canopyCache[key] = result;
-            ParsekLog.Log($"  Canopy states for '{key}': semiDeployed={semiDeployedSampled} sdScale={sdScale} " +
+            ParsekLog.Verbose("GhostVisual", $"  Canopy states for '{key}': semiDeployed={semiDeployedSampled} sdScale={sdScale} " +
                 $"deployed dScale={dScale} dPos={dPos} dRot={dRot.eulerAngles}");
             return result;
         }
@@ -884,7 +894,7 @@ namespace Parsek
 
             if (string.IsNullOrEmpty(animationStateName))
             {
-                ParsekLog.Log($"  Gear '{key}': no animationStateName — skipping animation sampling");
+                ParsekLog.Verbose("GhostVisual", $"  Gear '{key}': no animationStateName — skipping animation sampling");
                 gearCache[key] = null;
                 return null;
             }
@@ -910,7 +920,7 @@ namespace Parsek
 
                 if (anim == null)
                 {
-                    ParsekLog.Log($"  Gear '{key}': no Animation component on model clone");
+                    ParsekLog.Verbose("GhostVisual", $"  Gear '{key}': no Animation component on model clone");
                     gearCache[key] = null;
                     return null;
                 }
@@ -918,7 +928,7 @@ namespace Parsek
                 AnimationState state = anim[animationStateName];
                 if (state == null)
                 {
-                    ParsekLog.Log($"  Gear '{key}': animation '{animationStateName}' not found on clone");
+                    ParsekLog.Verbose("GhostVisual", $"  Gear '{key}': animation '{animationStateName}' not found on clone");
                     gearCache[key] = null;
                     return null;
                 }
@@ -972,12 +982,12 @@ namespace Parsek
 
                 if (result.Count == 0)
                 {
-                    ParsekLog.Log($"  Gear '{key}': animation '{animationStateName}' produced no transform deltas");
+                    ParsekLog.Verbose("GhostVisual", $"  Gear '{key}': animation '{animationStateName}' produced no transform deltas");
                     result = null;
                 }
                 else
                 {
-                    ParsekLog.Log($"  Gear '{key}': sampled {result.Count} animated transforms from '{animationStateName}'");
+                    ParsekLog.Verbose("GhostVisual", $"  Gear '{key}': sampled {result.Count} animated transforms from '{animationStateName}'");
                 }
             }
             finally
@@ -1113,7 +1123,7 @@ namespace Parsek
 
             if (string.IsNullOrEmpty(animationName))
             {
-                ParsekLog.Log($"  Ladder '{partKey}': no ladderRetractAnimationName — skipping animation sampling");
+                ParsekLog.Verbose("GhostVisual", $"  Ladder '{partKey}': no ladderRetractAnimationName — skipping animation sampling");
                 ladderCache[cacheKey] = null;
                 return null;
             }
@@ -1131,7 +1141,7 @@ namespace Parsek
                     if (animRoot != null)
                         anim = animRoot.GetComponent<Animation>();
                     else
-                        ParsekLog.Log($"  Ladder '{partKey}': animation root '{animationRootName}' not found on clone");
+                        ParsekLog.Verbose("GhostVisual", $"  Ladder '{partKey}': animation root '{animationRootName}' not found on clone");
                 }
 
                 if (anim == null)
@@ -1148,7 +1158,7 @@ namespace Parsek
 
                 if (anim == null)
                 {
-                    ParsekLog.Log($"  Ladder '{partKey}': no Animation component on model clone");
+                    ParsekLog.Verbose("GhostVisual", $"  Ladder '{partKey}': no Animation component on model clone");
                     ladderCache[cacheKey] = null;
                     return null;
                 }
@@ -1156,7 +1166,7 @@ namespace Parsek
                 AnimationState state = anim[animationName];
                 if (state == null)
                 {
-                    ParsekLog.Log($"  Ladder '{partKey}': animation '{animationName}' not found on clone");
+                    ParsekLog.Verbose("GhostVisual", $"  Ladder '{partKey}': animation '{animationName}' not found on clone");
                     ladderCache[cacheKey] = null;
                     return null;
                 }
@@ -1233,12 +1243,12 @@ namespace Parsek
 
                 if (result.Count == 0)
                 {
-                    ParsekLog.Log($"  Ladder '{partKey}': animation '{animationName}' produced no transform deltas");
+                    ParsekLog.Verbose("GhostVisual", $"  Ladder '{partKey}': animation '{animationName}' produced no transform deltas");
                     result = null;
                 }
                 else
                 {
-                    ParsekLog.Log($"  Ladder '{partKey}': sampled {result.Count} animated transforms from '{animationName}' " +
+                    ParsekLog.Verbose("GhostVisual", $"  Ladder '{partKey}': sampled {result.Count} animated transforms from '{animationName}' " +
                         $"(stowed=time{(stowedIsTime0 ? "0" : "1")})");
                 }
             }
@@ -1269,7 +1279,7 @@ namespace Parsek
 
             if (string.IsNullOrEmpty(animationName))
             {
-                ParsekLog.Log($"  CargoBay '{key}': no animationName — skipping animation sampling");
+                ParsekLog.Verbose("GhostVisual", $"  CargoBay '{key}': no animationName — skipping animation sampling");
                 cargoBayCache[key] = null;
                 return null;
             }
@@ -1288,7 +1298,7 @@ namespace Parsek
             }
             else
             {
-                ParsekLog.Log($"  CargoBay '{key}': non-standard closedPosition={closedPosition} — skipping");
+                ParsekLog.Verbose("GhostVisual", $"  CargoBay '{key}': non-standard closedPosition={closedPosition} — skipping");
                 cargoBayCache[key] = null;
                 return null;
             }
@@ -1316,7 +1326,7 @@ namespace Parsek
 
                 if (anim == null)
                 {
-                    ParsekLog.Log($"  CargoBay '{key}': no Animation component on model clone");
+                    ParsekLog.Verbose("GhostVisual", $"  CargoBay '{key}': no Animation component on model clone");
                     cargoBayCache[key] = null;
                     return null;
                 }
@@ -1324,7 +1334,7 @@ namespace Parsek
                 AnimationState state = anim[animationName];
                 if (state == null)
                 {
-                    ParsekLog.Log($"  CargoBay '{key}': animation '{animationName}' not found on clone");
+                    ParsekLog.Verbose("GhostVisual", $"  CargoBay '{key}': animation '{animationName}' not found on clone");
                     cargoBayCache[key] = null;
                     return null;
                 }
@@ -1372,12 +1382,12 @@ namespace Parsek
 
                 if (result.Count == 0)
                 {
-                    ParsekLog.Log($"  CargoBay '{key}': animation '{animationName}' produced no transform deltas");
+                    ParsekLog.Verbose("GhostVisual", $"  CargoBay '{key}': animation '{animationName}' produced no transform deltas");
                     result = null;
                 }
                 else
                 {
-                    ParsekLog.Log($"  CargoBay '{key}': sampled {result.Count} animated transforms from '{animationName}'");
+                    ParsekLog.Verbose("GhostVisual", $"  CargoBay '{key}': sampled {result.Count} animated transforms from '{animationName}'");
                 }
             }
             finally
@@ -1405,7 +1415,7 @@ namespace Parsek
             string animName = deployable.animationName;
             if (string.IsNullOrEmpty(animName))
             {
-                ParsekLog.Log($"  Deployable '{key}': no animationName — skipping animation sampling");
+                ParsekLog.Verbose("GhostVisual", $"  Deployable '{key}': no animationName — skipping animation sampling");
                 deployableCache[key] = null;
                 return null;
             }
@@ -1420,7 +1430,7 @@ namespace Parsek
                 Animation anim = tempClone.GetComponentInChildren<Animation>(true);
                 if (anim == null)
                 {
-                    ParsekLog.Log($"  Deployable '{key}': no Animation component on model clone");
+                    ParsekLog.Verbose("GhostVisual", $"  Deployable '{key}': no Animation component on model clone");
                     deployableCache[key] = null;
                     return null;
                 }
@@ -1428,7 +1438,7 @@ namespace Parsek
                 AnimationState state = anim[animName];
                 if (state == null)
                 {
-                    ParsekLog.Log($"  Deployable '{key}': animation '{animName}' not found on clone");
+                    ParsekLog.Verbose("GhostVisual", $"  Deployable '{key}': animation '{animName}' not found on clone");
                     deployableCache[key] = null;
                     return null;
                 }
@@ -1479,12 +1489,12 @@ namespace Parsek
 
                 if (result.Count == 0)
                 {
-                    ParsekLog.Log($"  Deployable '{key}': animation '{animName}' produced no transform deltas");
+                    ParsekLog.Verbose("GhostVisual", $"  Deployable '{key}': animation '{animName}' produced no transform deltas");
                     result = null;
                 }
                 else
                 {
-                    ParsekLog.Log($"  Deployable '{key}': sampled {result.Count} animated transforms from '{animName}'");
+                    ParsekLog.Verbose("GhostVisual", $"  Deployable '{key}': sampled {result.Count} animated transforms from '{animName}'");
                 }
             }
             finally
@@ -1571,7 +1581,7 @@ namespace Parsek
             }
             string compStr = compNames.Count > 0 ? " [" + string.Join(", ", compNames) + "]" : "";
             string activeStr = t.gameObject.activeSelf ? "" : " (INACTIVE)";
-            ParsekLog.Log($"    HIERARCHY {partName}: {indent}{t.name}{compStr}{activeStr}");
+            ParsekLog.Verbose("GhostVisual", $"    HIERARCHY {partName}: {indent}{t.name}{compStr}{activeStr}");
             for (int i = 0; i < t.childCount; i++)
                 DumpTransformHierarchy(t.GetChild(i), depth + 1, partName);
         }
@@ -1610,7 +1620,7 @@ namespace Parsek
                 ConfigNode partConfig = prefab.partInfo?.partConfig;
                 if (partConfig == null)
                 {
-                    ParsekLog.Log($"    Engine '{partName}' midx={moduleIndex}: no partConfig — skipping FX");
+                    ParsekLog.Verbose("GhostVisual", $"    Engine '{partName}' midx={moduleIndex}: no partConfig — skipping FX");
                     continue;
                 }
 
@@ -1622,7 +1632,7 @@ namespace Parsek
                     // Only process once per part — legacy FX are shared, not per-module.
                     if (moduleIndex > 0)
                     {
-                        ParsekLog.Log($"    Engine '{partName}' midx={moduleIndex}: legacy FX already handled by midx=0");
+                        ParsekLog.Verbose("GhostVisual", $"    Engine '{partName}' midx={moduleIndex}: legacy FX already handled by midx=0");
                         continue;
                     }
 
@@ -1659,14 +1669,14 @@ namespace Parsek
                             emission.rateOverTimeMultiplier = 0;
                             clonedPs.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
                             info.particleSystems.Add(clonedPs);
-                            ParsekLog.Log($"    Engine FX (legacy): '{partName}' midx={moduleIndex} fx='{child.name}'");
+                            ParsekLog.Verbose("GhostVisual", $"    Engine FX (legacy): '{partName}' midx={moduleIndex} fx='{child.name}'");
                         }
                     }
 
                     if (info.particleSystems.Count > 0)
                         result.Add(info);
                     else
-                        ParsekLog.Log($"    Engine '{partName}' midx={moduleIndex}: no legacy fx_* children found");
+                        ParsekLog.Verbose("GhostVisual", $"    Engine '{partName}' midx={moduleIndex}: no legacy fx_* children found");
                     continue;
                 }
 
@@ -1717,7 +1727,7 @@ namespace Parsek
 
                 if (fxTransformNames.Count == 0)
                 {
-                    ParsekLog.Log($"    Engine '{partName}' midx={moduleIndex}: no FX transforms found in EFFECTS");
+                    ParsekLog.Verbose("GhostVisual", $"    Engine '{partName}' midx={moduleIndex}: no FX transforms found in EFFECTS");
                     continue;
                 }
 
@@ -1771,13 +1781,13 @@ namespace Parsek
                                     var emission = ps.emission;
                                     emission.rateOverTimeMultiplier = 0;
                                     info.particleSystems.Add(ps);
-                                    ParsekLog.Log($"    Engine FX cloned: '{partName}' midx={moduleIndex} " +
+                                    ParsekLog.Verbose("GhostVisual", $"    Engine FX cloned: '{partName}' midx={moduleIndex} " +
                                         $"transform='{transformName}' model='{modelName}'");
                                 }
                             }
                             else
                             {
-                                ParsekLog.Log($"    Engine FX model not found: '{modelName}' for '{partName}'");
+                                ParsekLog.Verbose("GhostVisual", $"    Engine FX model not found: '{modelName}' for '{partName}'");
                             }
                         }
                     }
@@ -1826,14 +1836,14 @@ namespace Parsek
                 ConfigNode partConfig = prefab.partInfo?.partConfig;
                 if (partConfig == null)
                 {
-                    ParsekLog.Log($"    RCS '{partName}' midx={moduleIndex}: no partConfig — skipping FX");
+                    ParsekLog.Verbose("GhostVisual", $"    RCS '{partName}' midx={moduleIndex}: no partConfig — skipping FX");
                     continue;
                 }
 
                 ConfigNode effectsNode = partConfig.GetNode("EFFECTS");
                 if (effectsNode == null)
                 {
-                    ParsekLog.Log($"    RCS '{partName}' midx={moduleIndex}: no EFFECTS node — skipping FX");
+                    ParsekLog.Verbose("GhostVisual", $"    RCS '{partName}' midx={moduleIndex}: no EFFECTS node — skipping FX");
                     continue;
                 }
 
@@ -1849,7 +1859,7 @@ namespace Parsek
                 ConfigNode effectGroup = effectsNode.GetNode(runningEffect);
                 if (effectGroup == null)
                 {
-                    ParsekLog.Log($"    RCS '{partName}' midx={moduleIndex}: no '{runningEffect}' effect group");
+                    ParsekLog.Verbose("GhostVisual", $"    RCS '{partName}' midx={moduleIndex}: no '{runningEffect}' effect group");
                     continue;
                 }
 
@@ -1907,7 +1917,7 @@ namespace Parsek
 
                 if (fxDefinitions.Count == 0)
                 {
-                    ParsekLog.Log($"    RCS '{partName}' midx={moduleIndex}: no FX transforms in '{runningEffect}' group");
+                    ParsekLog.Verbose("GhostVisual", $"    RCS '{partName}' midx={moduleIndex}: no FX transforms in '{runningEffect}' group");
                     continue;
                 }
 
@@ -1922,7 +1932,7 @@ namespace Parsek
                     var fxTransforms = FindTransformsRecursive(prefab.transform, transformName);
                     if (fxTransforms.Count == 0)
                     {
-                        ParsekLog.Log($"    RCS '{partName}' midx={moduleIndex}: transform '{transformName}' not found on prefab");
+                        ParsekLog.Verbose("GhostVisual", $"    RCS '{partName}' midx={moduleIndex}: transform '{transformName}' not found on prefab");
                         continue;
                     }
 
@@ -1984,7 +1994,7 @@ namespace Parsek
                                     info.particleSystems.Add(ps);
                                     var diagRenderer = ps.GetComponent<ParticleSystemRenderer>();
                                     var diagMain = ps.main;
-                                    ParsekLog.Log($"    RCS FX cloned: '{partName}' midx={moduleIndex} " +
+                                    ParsekLog.Verbose("GhostVisual", $"    RCS FX cloned: '{partName}' midx={moduleIndex} " +
                                         $"transform='{transformName}' model='{modelName}' " +
                                         $"offset={fxDefinitions[f].localOffset} " +
                                         $"rot={fxDefinitions[f].localRotation.eulerAngles} " +
@@ -1996,7 +2006,7 @@ namespace Parsek
                             }
                             else
                             {
-                                ParsekLog.Log($"    RCS FX model not found: '{modelName}' for '{partName}'");
+                                ParsekLog.Verbose("GhostVisual", $"    RCS FX model not found: '{modelName}' for '{partName}'");
                             }
                         }
                     }
@@ -2004,14 +2014,14 @@ namespace Parsek
 
                 if (info.particleSystems.Count > 0)
                 {
-                    ParsekLog.Log($"    RCS module ready: '{partName}' midx={moduleIndex} " +
+                    ParsekLog.Verbose("GhostVisual", $"    RCS module ready: '{partName}' midx={moduleIndex} " +
                         $"particles={info.particleSystems.Count} " +
                         $"emissionScale={info.emissionScale:F1} speedScale={info.speedScale:F2}");
                     result.Add(info);
                 }
                 else
                 {
-                    ParsekLog.Log($"    RCS '{partName}' midx={moduleIndex}: no particle systems cloned");
+                    ParsekLog.Verbose("GhostVisual", $"    RCS '{partName}' midx={moduleIndex}: no particle systems cloned");
                 }
             }
 
@@ -2476,7 +2486,7 @@ namespace Parsek
             if (xNodes == null || xNodes.Length < 2)
             {
                 if (xNodes != null && xNodes.Length > 0)
-                    ParsekLog.Log($"    Fairing '{partName}': only {xNodes.Length} XSECTION(s) — skipping cone mesh");
+                    ParsekLog.Verbose("GhostVisual", $"    Fairing '{partName}': only {xNodes.Length} XSECTION(s) — skipping cone mesh");
                 return null;
             }
 
@@ -2509,7 +2519,7 @@ namespace Parsek
                 color = new Color(0.85f, 0.85f, 0.85f)
             };
 
-            ParsekLog.Log($"    Fairing detected: '{partName}' pid={persistentId}, " +
+            ParsekLog.Verbose("GhostVisual", $"    Fairing detected: '{partName}' pid={persistentId}, " +
                 $"cone mesh generated ({sections.Count} sections, {nSides} sides)");
 
             return new FairingGhostInfo
@@ -2891,14 +2901,14 @@ namespace Parsek
                 if (!TryResolveRoboticTransform(
                     prefab, module, moduleName, out string servoTransformName, out Vector3 axis, out string transformSource))
                 {
-                    ParsekLog.Log($"    Robotics '{partName}' midx={moduleIndex}: missing transform binding on {moduleName}");
+                    ParsekLog.Verbose("GhostVisual", $"    Robotics '{partName}' midx={moduleIndex}: missing transform binding on {moduleName}");
                     continue;
                 }
 
                 Transform sourceServo = prefab.FindModelTransform(servoTransformName);
                 if (sourceServo == null)
                 {
-                    ParsekLog.Log($"    Robotics '{partName}' midx={moduleIndex}: servo transform '{servoTransformName}' not found");
+                    ParsekLog.Verbose("GhostVisual", $"    Robotics '{partName}' midx={moduleIndex}: servo transform '{servoTransformName}' not found");
                     continue;
                 }
 
@@ -2911,7 +2921,7 @@ namespace Parsek
                     }
                     else
                     {
-                        ParsekLog.Log($"    Robotics '{partName}' midx={moduleIndex}: servo '{servoTransformName}' outside model root");
+                        ParsekLog.Verbose("GhostVisual", $"    Robotics '{partName}' midx={moduleIndex}: servo '{servoTransformName}' outside model root");
                         continue;
                     }
                 }
@@ -2934,7 +2944,7 @@ namespace Parsek
                 };
 
                 infos.Add(info);
-                ParsekLog.Log($"    Robotics detected: '{partName}' pid={persistentId} midx={moduleIndex} " +
+                ParsekLog.Verbose("GhostVisual", $"    Robotics detected: '{partName}' pid={persistentId} midx={moduleIndex} " +
                     $"module={moduleName} servo={servoTransformName} source={transformSource} axis={info.axisLocal} seed={currentValue:F3}");
             }
 
@@ -3043,14 +3053,14 @@ namespace Parsek
 
             if (trackedMaterials > 0)
             {
-                ParsekLog.Log($"    AnimateHeat materials detected: '{partName}' pid={persistentId}, " +
+                ParsekLog.Verbose("GhostVisual", $"    AnimateHeat materials detected: '{partName}' pid={persistentId}, " +
                     $"tracked={trackedMaterials} cloned={clonedMaterials}");
                 return materialStates;
             }
 
             if (clonedMaterials > 0)
             {
-                ParsekLog.Log($"    AnimateHeat '{partName}' pid={persistentId}: " +
+                ParsekLog.Verbose("GhostVisual", $"    AnimateHeat '{partName}' pid={persistentId}: " +
                     $"cloned {clonedMaterials} material(s) but no _Color/emissive properties found");
             }
 
@@ -3082,7 +3092,7 @@ namespace Parsek
             // Search from the Part root (not just modelRoot) to catch siblings of "model".
             if (prefab.FindModuleImplementing<ModuleEngines>() != null)
             {
-                ParsekLog.Log($"  ENGINE PART HIERARCHY DUMP for '{partName}' pid={persistentId}:");
+                ParsekLog.Verbose("GhostVisual", $"  ENGINE PART HIERARCHY DUMP for '{partName}' pid={persistentId}:");
                 DumpTransformHierarchy(prefab.transform, 0, partName);
 
                 // Also log MeshRenderers found from Part root vs modelRoot
@@ -3090,7 +3100,7 @@ namespace Parsek
                 var modelMR = modelRoot.GetComponentsInChildren<MeshRenderer>(true);
                 if (allMR.Length != modelMR.Length)
                 {
-                    ParsekLog.Log($"  WARNING: Part root has {allMR.Length} MeshRenderers but " +
+                    ParsekLog.Verbose("GhostVisual", $"  WARNING: Part root has {allMR.Length} MeshRenderers but " +
                         $"modelRoot '{modelRoot.name}' has only {modelMR.Length}! " +
                         $"Missing renderers are OUTSIDE the model subtree.");
                     foreach (var mr in allMR)
@@ -3106,7 +3116,7 @@ namespace Parsek
                         {
                             var mf = mr.GetComponent<MeshFilter>();
                             string meshName = mf?.sharedMesh?.name ?? "(no mesh)";
-                            ParsekLog.Log($"    OUTSIDE-MODEL MR: '{mr.gameObject.name}' mesh={meshName} " +
+                            ParsekLog.Verbose("GhostVisual", $"    OUTSIDE-MODEL MR: '{mr.gameObject.name}' mesh={meshName} " +
                                 $"path={GetTransformPath(mr.transform, prefab.transform)}");
                         }
                     }
@@ -3160,18 +3170,18 @@ namespace Parsek
                 }
             }
             bool filterInactiveVariantRenderers = hasPartVariants && (activeMR > 0 || activeSMR > 0);
-            ParsekLog.Log($"  Part '{partName}' pid={persistentId}: modelRoot='{modelRoot.name}' " +
+            ParsekLog.Verbose("GhostVisual", $"  Part '{partName}' pid={persistentId}: modelRoot='{modelRoot.name}' " +
                 $"modelScale={modelRoot.localScale}, " +
                 $"{totalMR} MeshRenderers, {totalSMR} SkinnedMeshRenderers" +
                 (hasPartVariants ? " (has ModulePartVariants)" : ""));
             if (hasPartVariants && hasVariantGameObjectRules)
             {
-                ParsekLog.Log($"  Variant selection: '{selectedVariantName}' with " +
+                ParsekLog.Verbose("GhostVisual", $"  Variant selection: '{selectedVariantName}' with " +
                     $"{selectedVariantGameObjects.Count} GAMEOBJECT rules");
             }
             if (hasPartVariants && !filterInactiveVariantRenderers)
             {
-                ParsekLog.Log($"  Variant active-state fallback: no active variant renderers found " +
+                ParsekLog.Verbose("GhostVisual", $"  Variant active-state fallback: no active variant renderers found " +
                     $"(active MR={activeMR}, active SMR={activeSMR})");
             }
 
@@ -3204,7 +3214,7 @@ namespace Parsek
             modelNode.transform.localPosition = modelRoot.localPosition;
             modelNode.transform.localRotation = modelRoot.localRotation;
             modelNode.transform.localScale = modelRoot.localScale;
-            ParsekLog.Log($"  [DIAG] part '{partName}' modelRoot '{modelRoot.name}' localRot={modelRoot.localRotation} localPos={modelRoot.localPosition} localScale={modelRoot.localScale}");
+            ParsekLog.Verbose("GhostVisual", $"  [DIAG] part '{partName}' modelRoot '{modelRoot.name}' localRot={modelRoot.localRotation} localPos={modelRoot.localPosition} localScale={modelRoot.localScale}");
             cloneMap[modelRoot] = modelNode.transform;
 
             // For light showcase recordings, lift only light-part visuals so probes stay
@@ -3238,14 +3248,14 @@ namespace Parsek
                 leaf.gameObject.AddComponent<MeshFilter>().sharedMesh = mf.sharedMesh;
                 leaf.gameObject.AddComponent<MeshRenderer>().sharedMaterials = mr.sharedMaterials;
                 meshCount++;
-                ParsekLog.Log($"    MR[{r}] '{mr.gameObject.name}' mesh={mf.sharedMesh.name} " +
+                ParsekLog.Verbose("GhostVisual", $"    MR[{r}] '{mr.gameObject.name}' mesh={mf.sharedMesh.name} " +
                     $"localPos={leaf.localPosition} localScale={leaf.localScale}");
                 added = true;
             }
             if (variantSkipped > 0)
-                ParsekLog.Log($"  Skipped {variantSkipped} MeshRenderers on inactive variant objects");
+                ParsekLog.Verbose("GhostVisual", $"  Skipped {variantSkipped} MeshRenderers on inactive variant objects");
             if (variantRuleSkipped > 0)
-                ParsekLog.Log($"  Skipped {variantRuleSkipped} MeshRenderers by selected variant GAMEOBJECT rules");
+                ParsekLog.Verbose("GhostVisual", $"  Skipped {variantRuleSkipped} MeshRenderers by selected variant GAMEOBJECT rules");
 
             for (int r = 0; r < skinnedRenderers.Length; r++)
             {
@@ -3324,12 +3334,12 @@ namespace Parsek
                 ghostSmr.shadowCastingMode = smr.shadowCastingMode;
                 ghostSmr.receiveShadows = smr.receiveShadows;
                 meshCount++;
-                ParsekLog.Log($"    SMR[{r}] '{smr.gameObject.name}' mesh={smr.sharedMesh.name} " +
+                ParsekLog.Verbose("GhostVisual", $"    SMR[{r}] '{smr.gameObject.name}' mesh={smr.sharedMesh.name} " +
                     $"localPos={leaf.localPosition} localScale={leaf.localScale} " +
                     $"bones={resolvedBones}/{(smr.bones != null ? smr.bones.Length : 0)}");
                 if (usedPartRootFallbackForBones)
                 {
-                    ParsekLog.Log($"      SMR[{r}] '{smr.gameObject.name}': used part-root fallback for external bone transforms");
+                    ParsekLog.Verbose("GhostVisual", $"      SMR[{r}] '{smr.gameObject.name}': used part-root fallback for external bone transforms");
                 }
                 added = true;
             }
@@ -3357,7 +3367,7 @@ namespace Parsek
                     Transform canopyVisualRoot = FindImmediateChildOf(srcCanopy, prefab.transform);
                     if (canopyVisualRoot != null && canopyVisualRoot != modelRoot)
                     {
-                        ParsekLog.Log($"    Canopy '{canopyName}' is outside modelRoot '{modelRoot.name}'" +
+                        ParsekLog.Verbose("GhostVisual", $"    Canopy '{canopyName}' is outside modelRoot '{modelRoot.name}'" +
                             $" — cloning canopy/cap only from '{canopyVisualRoot.name}'");
 
                         GameObject subNode = new GameObject(canopyVisualRoot.name);
@@ -3384,7 +3394,7 @@ namespace Parsek
                                 leaf.gameObject.AddComponent<MeshRenderer>().sharedMaterials = mr.sharedMaterials;
                                 meshCount++;
                                 added = true;
-                                ParsekLog.Log($"      CANOPY-CLONE '{target.gameObject.name}' " +
+                                ParsekLog.Verbose("GhostVisual", $"      CANOPY-CLONE '{target.gameObject.name}' " +
                                     $"mesh={mf.sharedMesh.name}");
                             }
                             else
@@ -3393,7 +3403,7 @@ namespace Parsek
                                 // so it enters cloneMap for lookup
                                 MirrorTransformChain(target, canopyVisualRoot,
                                     subNode.transform, cloneMap);
-                                ParsekLog.Log($"      CANOPY-CLONE '{target.gameObject.name}' (no mesh, chain only)");
+                                ParsekLog.Verbose("GhostVisual", $"      CANOPY-CLONE '{target.gameObject.name}' (no mesh, chain only)");
                             }
                         }
                     }
@@ -3440,7 +3450,7 @@ namespace Parsek
                         parachuteInfo.semiDeployedCanopyRot = Quaternion.Euler(270f, 0f, 0f);
                         parachuteInfo.deployedCanopyPos = new Vector3(0f, 1f, 0f);
                         parachuteInfo.deployedCanopyRot = Quaternion.Euler(270f, 0f, 0f);
-                        ParsekLog.Log($"    EVA parachute: overriding semi/deployed pos=(0,1,0) rot=(270,0,0) " +
+                        ParsekLog.Verbose("GhostVisual", $"    EVA parachute: overriding semi/deployed pos=(0,1,0) rot=(270,0,0) " +
                             $"(animation sampled sdScale={sdScale} dScale={dScale})");
                     }
                     else if (canopySubtreeRoot != null)
@@ -3452,7 +3462,7 @@ namespace Parsek
                         ghostCanopy.localRotation = Quaternion.identity;
                     }
 
-                    ParsekLog.Log($"    Parachute detected: canopy='{canopyName}' cap='{capName}' " +
+                    ParsekLog.Verbose("GhostVisual", $"    Parachute detected: canopy='{canopyName}' cap='{capName}' " +
                         $"semiDeployed={parachuteInfo.semiDeployedSampled} sdScale={parachuteInfo.semiDeployedCanopyScale} " +
                         $"deployScale={parachuteInfo.deployedCanopyScale} " +
                         $"deployPos={parachuteInfo.deployedCanopyPos} " +
@@ -3461,7 +3471,7 @@ namespace Parsek
                 }
                 else if (srcCanopy != null)
                 {
-                    ParsekLog.Log($"    Parachute '{canopyName}' found on prefab but not in cloneMap " +
+                    ParsekLog.Verbose("GhostVisual", $"    Parachute '{canopyName}' found on prefab but not in cloneMap " +
                         $"— will use fake canopy");
                 }
             }
@@ -3489,14 +3499,14 @@ namespace Parsek
                     Transform srcJettison = prefab.FindModelTransform(jettisonName);
                     if (srcJettison == null)
                     {
-                        ParsekLog.Log($"    Jettison '{jettisonName}' not found on prefab for module {moduleIndex} ({partName})");
+                        ParsekLog.Verbose("GhostVisual", $"    Jettison '{jettisonName}' not found on prefab for module {moduleIndex} ({partName})");
                         continue;
                     }
 
                     Transform ghostJettison;
                     if (!cloneMap.TryGetValue(srcJettison, out ghostJettison) || ghostJettison == null)
                     {
-                        ParsekLog.Log($"    Jettison '{jettisonName}' found on prefab but not in cloneMap");
+                        ParsekLog.Verbose("GhostVisual", $"    Jettison '{jettisonName}' found on prefab but not in cloneMap");
                         continue;
                     }
 
@@ -3513,7 +3523,7 @@ namespace Parsek
                     partPersistentId = persistentId,
                     jettisonTransforms = ghostJettisonTransforms
                 };
-                ParsekLog.Log($"    Jettison detected: '{string.Join(", ", resolvedJettisonNames.ToArray())}' pid={persistentId}");
+                ParsekLog.Verbose("GhostVisual", $"    Jettison detected: '{string.Join(", ", resolvedJettisonNames.ToArray())}' pid={persistentId}");
             }
 
             // Detect engine parts and clone FX particle systems
@@ -3583,7 +3593,7 @@ namespace Parsek
                     MirrorTransformChain(src, modelRoot, modelNode.transform, cloneMap);
                     created++;
                 }
-                ParsekLog.Log($"    EnsureFullHierarchy '{partName}': " +
+                ParsekLog.Verbose("GhostVisual", $"    EnsureFullHierarchy '{partName}': " +
                     (created > 0
                         ? $"created {created} missing intermediate transforms for animation support"
                         : $"all {allModelTransforms.Length} model transforms already in cloneMap"));
@@ -3624,7 +3634,7 @@ namespace Parsek
                         {
                             unresolved++;
                             if (unresolved <= 5)
-                                ParsekLog.Log($"    [DIAG] Deployable '{partName}': unresolved path '{path}'");
+                                ParsekLog.Verbose("GhostVisual", $"    [DIAG] Deployable '{partName}': unresolved path '{path}'");
                         }
                     }
 
@@ -3635,12 +3645,12 @@ namespace Parsek
                             partPersistentId = persistentId,
                             transforms = resolvedTransforms
                         };
-                        ParsekLog.Log($"    Deployable detected: '{partName}' pid={persistentId}, " +
+                        ParsekLog.Verbose("GhostVisual", $"    Deployable detected: '{partName}' pid={persistentId}, " +
                             $"{resolvedTransforms.Count}/{sampledStates.Count} transforms resolved");
                     }
                     else
                     {
-                        ParsekLog.Log($"    Deployable '{partName}' pid={persistentId}: " +
+                        ParsekLog.Verbose("GhostVisual", $"    Deployable '{partName}' pid={persistentId}: " +
                             $"sampled {sampledStates.Count} transforms but none resolved to ghost");
                     }
                 }
@@ -3687,7 +3697,7 @@ namespace Parsek
                                 partPersistentId = persistentId,
                                 transforms = resolvedTransforms
                             };
-                            ParsekLog.Log($"    Gear detected: '{partName}' pid={persistentId}, " +
+                            ParsekLog.Verbose("GhostVisual", $"    Gear detected: '{partName}' pid={persistentId}, " +
                                 $"{resolvedTransforms.Count}/{sampledStates.Count} transforms resolved");
                         }
                     }
@@ -3696,7 +3706,7 @@ namespace Parsek
             }
             else if (prefab.FindModuleImplementing<ModuleWheels.ModuleWheelDeployment>() != null)
             {
-                ParsekLog.Log($"    WARNING: '{partName}' pid={persistentId} has both " +
+                ParsekLog.Verbose("GhostVisual", $"    WARNING: '{partName}' pid={persistentId} has both " +
                     $"ModuleDeployablePart and ModuleWheels.ModuleWheelDeployment — gear visuals skipped");
             }
 
@@ -3729,7 +3739,7 @@ namespace Parsek
                         {
                             unresolved++;
                             if (unresolved <= 5)
-                                ParsekLog.Log($"    [DIAG] Ladder '{partName}': unresolved path '{path}'");
+                                ParsekLog.Verbose("GhostVisual", $"    [DIAG] Ladder '{partName}': unresolved path '{path}'");
                         }
                     }
 
@@ -3740,12 +3750,12 @@ namespace Parsek
                             partPersistentId = persistentId,
                             transforms = resolvedTransforms
                         };
-                        ParsekLog.Log($"    Ladder detected: '{partName}' pid={persistentId}, " +
+                        ParsekLog.Verbose("GhostVisual", $"    Ladder detected: '{partName}' pid={persistentId}, " +
                             $"{resolvedTransforms.Count}/{sampledStates.Count} transforms resolved");
                     }
                     else
                     {
-                        ParsekLog.Log($"    Ladder '{partName}' pid={persistentId}: " +
+                        ParsekLog.Verbose("GhostVisual", $"    Ladder '{partName}' pid={persistentId}: " +
                             $"sampled {sampledStates.Count} transforms but none resolved to ghost");
                     }
                 }
@@ -3780,7 +3790,7 @@ namespace Parsek
                         {
                             unresolved++;
                             if (unresolved <= 5)
-                                ParsekLog.Log($"    [DIAG] AnimationGroup '{partName}': unresolved path '{path}'");
+                                ParsekLog.Verbose("GhostVisual", $"    [DIAG] AnimationGroup '{partName}': unresolved path '{path}'");
                         }
                     }
 
@@ -3791,7 +3801,7 @@ namespace Parsek
                             partPersistentId = persistentId,
                             transforms = resolvedTransforms
                         };
-                        ParsekLog.Log($"    AnimationGroup deployable detected: '{partName}' pid={persistentId}, " +
+                        ParsekLog.Verbose("GhostVisual", $"    AnimationGroup deployable detected: '{partName}' pid={persistentId}, " +
                             $"{resolvedTransforms.Count}/{sampledStates.Count} transforms resolved");
                     }
                 }
@@ -3826,7 +3836,7 @@ namespace Parsek
                         {
                             unresolved++;
                             if (unresolved <= 5)
-                                ParsekLog.Log($"    [DIAG] AnimateGeneric '{partName}': unresolved path '{path}'");
+                                ParsekLog.Verbose("GhostVisual", $"    [DIAG] AnimateGeneric '{partName}': unresolved path '{path}'");
                         }
                     }
 
@@ -3837,7 +3847,7 @@ namespace Parsek
                             partPersistentId = persistentId,
                             transforms = resolvedTransforms
                         };
-                        ParsekLog.Log($"    AnimateGeneric deployable detected: '{partName}' pid={persistentId}, " +
+                        ParsekLog.Verbose("GhostVisual", $"    AnimateGeneric deployable detected: '{partName}' pid={persistentId}, " +
                             $"{resolvedTransforms.Count}/{sampledStates.Count} transforms resolved");
                     }
                 }
@@ -3887,14 +3897,14 @@ namespace Parsek
                             partPersistentId = persistentId,
                             transforms = resolvedTransforms
                         };
-                        ParsekLog.Log($"    AeroSurface deployable detected: '{partName}' pid={persistentId}, " +
+                        ParsekLog.Verbose("GhostVisual", $"    AeroSurface deployable detected: '{partName}' pid={persistentId}, " +
                             $"transform='{aeroSurfaceTransformName}' angle={aeroSurfaceDeployAngle:F1} " +
                             $"resolved={resolvedTransforms.Count}");
                     }
                 }
                 else
                 {
-                    ParsekLog.Log($"    AeroSurface '{partName}' pid={persistentId}: " +
+                    ParsekLog.Verbose("GhostVisual", $"    AeroSurface '{partName}' pid={persistentId}: " +
                         $"transform '{aeroSurfaceTransformName}' not found under modelRoot");
                 }
             }
@@ -3943,14 +3953,14 @@ namespace Parsek
                             partPersistentId = persistentId,
                             transforms = resolvedTransforms
                         };
-                        ParsekLog.Log($"    ControlSurface deployable detected: '{partName}' pid={persistentId}, " +
+                        ParsekLog.Verbose("GhostVisual", $"    ControlSurface deployable detected: '{partName}' pid={persistentId}, " +
                             $"transform='{controlSurfaceTransformName}' angle={controlSurfaceDeployAngle:F1} " +
                             $"resolved={resolvedTransforms.Count}");
                     }
                 }
                 else
                 {
-                    ParsekLog.Log($"    ControlSurface '{partName}' pid={persistentId}: " +
+                    ParsekLog.Verbose("GhostVisual", $"    ControlSurface '{partName}' pid={persistentId}: " +
                         $"transform '{controlSurfaceTransformName}' not found under modelRoot");
                 }
             }
@@ -3968,7 +3978,7 @@ namespace Parsek
                     string candidateAnim = robotArmScannerAnimCandidates[i];
                     var candidateStates = SampleLadderStates(prefab, candidateAnim, null);
                     int candidateCount = candidateStates != null ? candidateStates.Count : 0;
-                    ParsekLog.Log($"    RobotArmScanner '{partName}' candidate anim='{candidateAnim}' sampled={candidateCount}");
+                    ParsekLog.Verbose("GhostVisual", $"    RobotArmScanner '{partName}' candidate anim='{candidateAnim}' sampled={candidateCount}");
                     if (candidateCount > bestCount)
                     {
                         bestCount = candidateCount;
@@ -4002,7 +4012,7 @@ namespace Parsek
                         {
                             unresolved++;
                             if (unresolved <= 5)
-                                ParsekLog.Log($"    [DIAG] RobotArmScanner '{partName}': unresolved path '{path}'");
+                                ParsekLog.Verbose("GhostVisual", $"    [DIAG] RobotArmScanner '{partName}': unresolved path '{path}'");
                         }
                     }
 
@@ -4013,7 +4023,7 @@ namespace Parsek
                             partPersistentId = persistentId,
                             transforms = resolvedTransforms
                         };
-                        ParsekLog.Log($"    RobotArmScanner deployable detected: '{partName}' pid={persistentId}, " +
+                        ParsekLog.Verbose("GhostVisual", $"    RobotArmScanner deployable detected: '{partName}' pid={persistentId}, " +
                             $"anim='{selectedAnimName}' {resolvedTransforms.Count}/{sampledStates.Count} transforms resolved");
                     }
                 }
@@ -4037,7 +4047,7 @@ namespace Parsek
                     {
                         animModule = prefab.FindModuleImplementing<ModuleAnimateGeneric>();
                         if (animModule != null)
-                            ParsekLog.Log($"    CargoBay '{partName}': DeployModuleIndex={deployIdx} " +
+                            ParsekLog.Verbose("GhostVisual", $"    CargoBay '{partName}': DeployModuleIndex={deployIdx} " +
                                 $"didn't resolve to ModuleAnimateGeneric (Modules.Count={prefab.Modules.Count}), " +
                                 $"using fallback FindModuleImplementing");
                     }
@@ -4068,7 +4078,7 @@ namespace Parsek
                                 }
                                 else if (s < 5)
                                 {
-                                    ParsekLog.Log($"    [DIAG] CargoBay '{partName}': unresolved path '{path}'");
+                                    ParsekLog.Verbose("GhostVisual", $"    [DIAG] CargoBay '{partName}': unresolved path '{path}'");
                                 }
                             }
 
@@ -4092,7 +4102,7 @@ namespace Parsek
                                     ts.t.localScale = ts.stowedScale;
                                 }
 
-                                ParsekLog.Log($"    CargoBay detected: '{partName}' pid={persistentId}, " +
+                                ParsekLog.Verbose("GhostVisual", $"    CargoBay detected: '{partName}' pid={persistentId}, " +
                                     $"{resolvedTransforms.Count}/{sampledStates.Count} transforms resolved" +
                                     $" (closedPosition={cargoBay.closedPosition})");
                             }
@@ -4131,7 +4141,7 @@ namespace Parsek
                         {
                             unresolved++;
                             if (unresolved <= 5)
-                                ParsekLog.Log($"    [DIAG] AnimateHeat '{partName}': unresolved path '{path}'");
+                                ParsekLog.Verbose("GhostVisual", $"    [DIAG] AnimateHeat '{partName}': unresolved path '{path}'");
                         }
                     }
                 }
@@ -4163,13 +4173,13 @@ namespace Parsek
                         }
                     }
 
-                    ParsekLog.Log($"    AnimateHeat detected: '{partName}' pid={persistentId}, anim='{animateHeatAnimName}' " +
+                    ParsekLog.Verbose("GhostVisual", $"    AnimateHeat detected: '{partName}' pid={persistentId}, anim='{animateHeatAnimName}' " +
                         $"transforms={(resolvedHeatTransforms != null ? resolvedHeatTransforms.Count : 0)} " +
                         $"materials={(heatMaterialStates != null ? heatMaterialStates.Count : 0)}");
                 }
                 else
                 {
-                    ParsekLog.Log($"    AnimateHeat '{partName}' pid={persistentId}: no transform/material deltas");
+                    ParsekLog.Verbose("GhostVisual", $"    AnimateHeat '{partName}' pid={persistentId}: no transform/material deltas");
                 }
             }
 
@@ -4221,7 +4231,7 @@ namespace Parsek
                             : srcLight.renderMode;
                         ghostLight.enabled = false;
                         clonedLights.Add(ghostLight);
-                        ParsekLog.Log(
+                        ParsekLog.Verbose("GhostVisual", 
                             $"      Light clone[{li}] '{srcLight.name}': " +
                             $"srcI={srcLight.intensity:F2} srcR={srcLight.range:F1} " +
                             $"-> ghostI={clonedIntensity:F2} ghostR={clonedRange:F1} " +
@@ -4235,7 +4245,7 @@ namespace Parsek
                             partPersistentId = persistentId,
                             lights = clonedLights
                         };
-                        ParsekLog.Log($"    Light detected: '{partName}' pid={persistentId}, " +
+                        ParsekLog.Verbose("GhostVisual", $"    Light detected: '{partName}' pid={persistentId}, " +
                             $"{clonedLights.Count} Light component(s) cloned");
                     }
                 }

--- a/Source/Parsek/MergeDialog.cs
+++ b/Source/Parsek/MergeDialog.cs
@@ -11,6 +11,12 @@ namespace Parsek
     {
         public static void Show(RecordingStore.Recording pending)
         {
+            if (pending == null)
+            {
+                ParsekLog.Warn("MergeDialog", "Cannot show merge dialog: pending recording is null");
+                return;
+            }
+
             // Detect if this is a chain recording with committed siblings
             bool isChain = !string.IsNullOrEmpty(pending.ChainId);
             List<RecordingStore.Recording> chainSiblings = isChain
@@ -22,6 +28,12 @@ namespace Parsek
             {
                 ShowChainDialog(pending, chainSiblings, chainSegmentCount);
                 return;
+            }
+
+            if (isChain && chainSiblings == null)
+            {
+                ParsekLog.Warn("MergeDialog",
+                    $"Pending recording references chain='{pending.ChainId}' but no siblings were found; falling back to standalone dialog");
             }
 
             // Non-chain: use existing dialog
@@ -36,7 +48,7 @@ namespace Parsek
                 pending.VesselSnapshot != null,
                 duration, pending.MaxDistanceFromLaunch);
 
-            ParsekLog.Log($"Merge dialog: distance={pending.DistanceFromLaunch:F0}m, " +
+            ParsekLog.Info("MergeDialog", $"Merge dialog: distance={pending.DistanceFromLaunch:F0}m, " +
                 $"maxDistance={pending.MaxDistanceFromLaunch:F0}m, duration={duration:F1}s, " +
                 $"destroyed={pending.VesselDestroyed}, hasSnapshot={pending.VesselSnapshot != null}, " +
                 $"recommended={recommended}");
@@ -56,14 +68,14 @@ namespace Parsek
                             pending.VesselSnapshot = null;
                             RecordingStore.CommitPending();
                             ParsekLog.ScreenMessage("Recording merged to timeline!", 3f);
-                            ParsekLog.Log("User chose: Merge to Timeline (vessel destroyed)");
+                            ParsekLog.Info("MergeDialog", "User chose: Merge to Timeline (vessel destroyed)");
                         }),
                         new DialogGUIButton("Discard", () =>
                         {
                             ParsekScenario.UnreserveCrewInSnapshot(pending.VesselSnapshot);
                             RecordingStore.DiscardPending();
                             ParsekLog.ScreenMessage("Recording discarded", 2f);
-                            ParsekLog.Log("User chose: Discard");
+                            ParsekLog.Info("MergeDialog", "User chose: Discard");
                         })
                     };
                     break;
@@ -78,7 +90,7 @@ namespace Parsek
                             ParsekScenario.ReserveSnapshotCrew();
                             ParsekScenario.SwapReservedCrewInFlight();
                             ParsekLog.ScreenMessage("Recording merged — vessel will appear after ghost playback", 3f);
-                            ParsekLog.Log("User chose: Merge + Keep Vessel (deferred spawn)");
+                            ParsekLog.Info("MergeDialog", "User chose: Merge + Keep Vessel (deferred spawn)");
                         }),
                         new DialogGUIButton("Merge + Recover", () =>
                         {
@@ -91,14 +103,14 @@ namespace Parsek
                             // Clear snapshot so ghost despawns normally at EndUT
                             pending.VesselSnapshot = null;
                             ParsekLog.ScreenMessage("Recording merged, vessel recovered!", 3f);
-                            ParsekLog.Log("User chose: Merge + Recover");
+                            ParsekLog.Info("MergeDialog", "User chose: Merge + Recover");
                         }),
                         new DialogGUIButton("Discard", () =>
                         {
                             ParsekScenario.UnreserveCrewInSnapshot(pending.VesselSnapshot);
                             RecordingStore.DiscardPending();
                             ParsekLog.ScreenMessage("Recording discarded", 2f);
-                            ParsekLog.Log("User chose: Discard");
+                            ParsekLog.Info("MergeDialog", "User chose: Discard");
                         })
                     };
                     break;
@@ -131,7 +143,7 @@ namespace Parsek
                 pending.VesselSnapshot != null,
                 duration, pending.MaxDistanceFromLaunch);
 
-            ParsekLog.Log($"Chain merge dialog: chain={chainId}, segments={totalSegments}, " +
+            ParsekLog.Info("MergeDialog", $"Chain merge dialog: chain={chainId}, segments={totalSegments}, " +
                 $"recommended={recommended}, hasSnapshot={pending.VesselSnapshot != null}");
 
             DialogGUIButton[] buttons;
@@ -146,7 +158,7 @@ namespace Parsek
                         ParsekScenario.ReserveSnapshotCrew();
                         ParsekScenario.SwapReservedCrewInFlight();
                         ParsekLog.ScreenMessage($"Mission chain ({totalSegments} segments) merged — vessel will appear!", 3f);
-                        ParsekLog.Log($"User chose: Chain Merge + Keep Vessel ({totalSegments} segments)");
+                        ParsekLog.Info("MergeDialog", $"User chose: Chain Merge + Keep Vessel ({totalSegments} segments)");
                     }),
                     new DialogGUIButton("Merge + Recover", () =>
                     {
@@ -160,13 +172,13 @@ namespace Parsek
                         pending.VesselSnapshot = null;
                         RecoverChainSiblingSnapshots(chainSiblings);
                         ParsekLog.ScreenMessage($"Mission chain ({totalSegments} segments) merged, vessel recovered!", 3f);
-                        ParsekLog.Log($"User chose: Chain Merge + Recover ({totalSegments} segments)");
+                        ParsekLog.Info("MergeDialog", $"User chose: Chain Merge + Recover ({totalSegments} segments)");
                     }),
                     new DialogGUIButton("Discard All", () =>
                     {
                         DiscardChain(pending, chainId);
                         ParsekLog.ScreenMessage($"Mission chain ({totalSegments} segments) discarded", 2f);
-                        ParsekLog.Log($"User chose: Chain Discard ({totalSegments} segments)");
+                        ParsekLog.Info("MergeDialog", $"User chose: Chain Discard ({totalSegments} segments)");
                     })
                 };
             }
@@ -183,13 +195,13 @@ namespace Parsek
                         NullChainSiblingSnapshots(chainSiblings);
                         RecordingStore.CommitPending();
                         ParsekLog.ScreenMessage($"Mission chain ({totalSegments} segments) merged!", 3f);
-                        ParsekLog.Log($"User chose: Chain Merge to Timeline ({totalSegments} segments)");
+                        ParsekLog.Info("MergeDialog", $"User chose: Chain Merge to Timeline ({totalSegments} segments)");
                     }),
                     new DialogGUIButton("Discard All", () =>
                     {
                         DiscardChain(pending, chainId);
                         ParsekLog.ScreenMessage($"Mission chain ({totalSegments} segments) discarded", 2f);
-                        ParsekLog.Log($"User chose: Chain Discard ({totalSegments} segments)");
+                        ParsekLog.Info("MergeDialog", $"User chose: Chain Discard ({totalSegments} segments)");
                     })
                 };
             }
@@ -242,7 +254,7 @@ namespace Parsek
                     ParsekScenario.UnreserveCrewInSnapshot(siblings[i].VesselSnapshot);
                     VesselSpawner.RecoverVessel(siblings[i].VesselSnapshot);
                     siblings[i].VesselSnapshot = null;
-                    ParsekLog.Log($"Chain sibling #{i} snapshot recovered + nulled");
+                    ParsekLog.Info("MergeDialog", $"Chain sibling #{i} snapshot recovered + nulled");
                 }
             }
         }
@@ -260,16 +272,21 @@ namespace Parsek
                 {
                     ParsekScenario.UnreserveCrewInSnapshot(siblings[i].VesselSnapshot);
                     siblings[i].VesselSnapshot = null;
-                    ParsekLog.Log($"Chain sibling #{i} snapshot nulled (no recovery)");
+                    ParsekLog.Info("MergeDialog", $"Chain sibling #{i} snapshot nulled (no recovery)");
                 }
             }
         }
 
         static void DiscardChain(RecordingStore.Recording pending, string chainId)
         {
+            int unreservedCount = 0;
+
             // Unreserve crew from pending
             if (pending.VesselSnapshot != null)
+            {
                 ParsekScenario.UnreserveCrewInSnapshot(pending.VesselSnapshot);
+                unreservedCount++;
+            }
 
             // Unreserve crew from all committed chain siblings
             var siblings = RecordingStore.GetChainRecordings(chainId);
@@ -278,13 +295,18 @@ namespace Parsek
                 for (int i = 0; i < siblings.Count; i++)
                 {
                     if (siblings[i].VesselSnapshot != null)
+                    {
                         ParsekScenario.UnreserveCrewInSnapshot(siblings[i].VesselSnapshot);
+                        unreservedCount++;
+                    }
                 }
             }
 
             // Remove committed chain recordings and discard pending
             RecordingStore.RemoveChainRecordings(chainId);
             RecordingStore.DiscardPending();
+            ParsekLog.Info("MergeDialog",
+                $"Discarded chain '{chainId}': unreservedSnapshots={unreservedCount}, siblingCount={siblings?.Count ?? 0}");
         }
 
         internal static string BuildMergeMessage(RecordingStore.Recording pending, double duration,

--- a/Source/Parsek/OrbitSegment.cs
+++ b/Source/Parsek/OrbitSegment.cs
@@ -11,5 +11,11 @@ namespace Parsek
         public double longitudeOfAscendingNode, argumentOfPeriapsis;
         public double meanAnomalyAtEpoch, epoch;
         public string bodyName;
+
+        public override string ToString()
+        {
+            return $"UT={startUT:F1}-{endUT:F1} body={bodyName ?? "?"} inc={inclination:F2} " +
+                   $"ecc={eccentricity:F4} sma={semiMajorAxis:F1}";
+        }
     }
 }

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -592,9 +592,23 @@ namespace Parsek
         void OnVesselSituationChange(GameEvents.HostedFromToAction<Vessel, Vessel.Situations> data)
         {
             if (IsRecording) return;
-            if (data.host != FlightGlobals.ActiveVessel) return;
-            if (data.from != Vessel.Situations.PRELAUNCH) return;
-            if (ParsekSettings.Current?.autoRecordOnLaunch == false) return;
+            if (data.host != FlightGlobals.ActiveVessel)
+            {
+                ParsekLog.VerboseRateLimited("Flight", "sit-change-other",
+                    $"OnVesselSituationChange: ignoring non-active vessel ({data.from} → {data.to})");
+                return;
+            }
+            if (data.from != Vessel.Situations.PRELAUNCH)
+            {
+                ParsekLog.VerboseRateLimited("Flight", "sit-change-not-prelaunch",
+                    $"OnVesselSituationChange: not from PRELAUNCH ({data.from} → {data.to})");
+                return;
+            }
+            if (ParsekSettings.Current?.autoRecordOnLaunch == false)
+            {
+                ParsekLog.Verbose("Flight", "OnVesselSituationChange: auto-record disabled in settings");
+                return;
+            }
 
             StartRecording();
             Log("Auto-record started (vessel left pad/runway)");
@@ -603,8 +617,16 @@ namespace Parsek
 
         void OnCrewBoardVessel(GameEvents.FromToAction<Part, Part> data)
         {
-            if (activeChainId == null) return;
-            if (data.to?.vessel == null) return;
+            if (activeChainId == null)
+            {
+                ParsekLog.Verbose("Flight", "OnCrewBoardVessel: no active chain — ignoring");
+                return;
+            }
+            if (data.to?.vessel == null)
+            {
+                ParsekLog.Verbose("Flight", "OnCrewBoardVessel: target vessel is null — ignoring");
+                return;
+            }
 
             pendingBoardingTargetPid = data.to.vessel.persistentId;
             boardingConfirmFrames = 0;
@@ -838,9 +860,22 @@ namespace Parsek
                 return;
             }
 
-            if (data.from?.vessel == null) return;
-            if (data.from.vessel.situation != Vessel.Situations.PRELAUNCH) return;
-            if (ParsekSettings.Current?.autoRecordOnEva == false) return;
+            if (data.from?.vessel == null)
+            {
+                ParsekLog.Verbose("Flight", "OnCrewOnEva: source vessel is null — ignoring");
+                return;
+            }
+            if (data.from.vessel.situation != Vessel.Situations.PRELAUNCH)
+            {
+                ParsekLog.VerboseRateLimited("Flight", "eva-not-prelaunch",
+                    $"OnCrewOnEva: vessel not on pad (sit={data.from.vessel.situation}) — ignoring");
+                return;
+            }
+            if (ParsekSettings.Current?.autoRecordOnEva == false)
+            {
+                ParsekLog.Verbose("Flight", "OnCrewOnEva: auto-record on EVA disabled in settings");
+                return;
+            }
 
             // The EVA kerbal may not yet be the active vessel, defer to Update()
             pendingAutoRecord = true;
@@ -911,7 +946,11 @@ namespace Parsek
         void OnPartUndock(Part undockedPart)
         {
             if (recorder == null || !recorder.IsRecording) return;
-            if (undockedPart?.vessel == null) return;
+            if (undockedPart?.vessel == null)
+            {
+                ParsekLog.Verbose("Flight", "OnPartUndock: undocked part or vessel is null — ignoring");
+                return;
+            }
 
             uint newPid = undockedPart.vessel.persistentId;
             if (newPid != recorder.RecordingVesselId)
@@ -1636,7 +1675,11 @@ namespace Parsek
 
                 // Branch > 0 recordings are ghost-only (undock continuations) — never spawn
                 if (needsSpawn && rec.ChainBranch > 0)
+                {
                     needsSpawn = false;
+                    if (loggedGhostEnter.Add(i + 200000))
+                        ParsekLog.Verbose("Flight", $"Spawn suppressed for #{i} ({rec.VesselName}): branch > 0 (ghost-only)");
+                }
 
                 // Suppress spawning for recordings belonging to a chain currently being built.
                 // Without this guard, CommitChainSegment commits the vessel segment mid-flight,
@@ -1644,6 +1687,8 @@ namespace Parsek
                 if (needsSpawn && activeChainId != null && rec.ChainId == activeChainId)
                 {
                     needsSpawn = false;
+                    if (loggedGhostEnter.Add(i + 300000))
+                        ParsekLog.Verbose("Flight", $"Spawn suppressed for #{i} ({rec.VesselName}): active chain being built");
                 }
 
                 // One-time chain spawn diagnostics when entering the spawn window
@@ -2165,7 +2210,12 @@ namespace Parsek
         void ApplyPartEvents(int recIdx, RecordingStore.Recording rec, double currentUT, GhostPlaybackState state)
         {
             if (rec.PartEvents == null || rec.PartEvents.Count == 0) return;
-            if (state.ghost == null) return;
+            if (state.ghost == null)
+            {
+                ParsekLog.VerboseRateLimited("Flight", $"apply-part-events-null-ghost-{recIdx}",
+                    $"ApplyPartEvents: ghost is null for recording #{recIdx}");
+                return;
+            }
 
             int evtIdx = state.partEventIndex;
             var tree = state.partTree;
@@ -2898,10 +2948,18 @@ namespace Parsek
         GameObject BuildPreviewGhostFromActiveVessel(string name)
         {
             Vessel vessel = FlightGlobals.ActiveVessel;
-            if (vessel == null) return null;
+            if (vessel == null)
+            {
+                ParsekLog.Warn("Flight", "BuildPreviewGhost: no active vessel");
+                return null;
+            }
 
             ProtoVessel pv = vessel.BackupVessel();
-            if (pv == null) return null;
+            if (pv == null)
+            {
+                ParsekLog.Warn("Flight", "BuildPreviewGhost: BackupVessel() returned null");
+                return null;
+            }
 
             ConfigNode node = new ConfigNode("VESSEL");
             pv.Save(node);
@@ -3226,7 +3284,12 @@ namespace Parsek
         void PositionGhostAt(GameObject ghost, TrajectoryPoint point)
         {
             CelestialBody body = FlightGlobals.Bodies.Find(b => b.name == point.bodyName);
-            if (body == null) return;
+            if (body == null)
+            {
+                ParsekLog.VerboseRateLimited("Flight", "position-ghost-no-body",
+                    $"PositionGhostAt: body '{point.bodyName}' not found — ghost position not updated");
+                return;
+            }
 
             Vector3 worldPos = body.GetWorldSurfacePosition(
                 point.latitude, point.longitude, point.altitude);

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -200,6 +200,7 @@ namespace Parsek
                 boardingConfirmFrames++;
                 if (boardingConfirmFrames > 3)
                 {
+                    Log($"Boarding confirmation expired (targetPid={pendingBoardingTargetPid})");
                     pendingBoardingTargetPid = 0;
                     boardingConfirmFrames = 0;
                 }
@@ -211,6 +212,7 @@ namespace Parsek
                 dockConfirmFrames++;
                 if (dockConfirmFrames > 5)
                 {
+                    Log($"Dock confirmation expired (mergedPid={pendingDockMergedPid})");
                     pendingDockMergedPid = 0;
                     pendingDockAsTarget = false;
                     dockConfirmFrames = 0;
@@ -221,6 +223,7 @@ namespace Parsek
                 undockConfirmFrames++;
                 if (undockConfirmFrames > 5)
                 {
+                    Log($"Undock confirmation expired (otherPid={pendingUndockOtherPid})");
                     pendingUndockOtherPid = 0;
                     undockConfirmFrames = 0;
                 }
@@ -1347,6 +1350,14 @@ namespace Parsek
                 pendingBoundaryAnchor = null;
             }
             recorder.StartRecording();
+            if (!recorder.IsRecording)
+            {
+                ParsekLog.Warn("Flight", $"StartRecording blocked: {DetermineRecordingBlockReason()}");
+                return;
+            }
+
+            uint pid = FlightGlobals.ActiveVessel != null ? FlightGlobals.ActiveVessel.persistentId : 0;
+            ParsekLog.Info("Flight", $"StartRecording succeeded: pid={pid}, chainActive={activeChainId != null}");
         }
 
         public void StopRecording()
@@ -2101,8 +2112,19 @@ namespace Parsek
         public void DeleteRecording(int index)
         {
             var committed = RecordingStore.CommittedRecordings;
-            if (index < 0 || index >= committed.Count) return;
-            if (!CanDeleteRecording) return;
+            if (index < 0 || index >= committed.Count)
+            {
+                ParsekLog.Warn("Flight", $"DeleteRecording ignored: index={index} out of range (count={committed.Count})");
+                return;
+            }
+
+            if (!CanDeleteRecording)
+            {
+                ParsekLog.Warn("Flight",
+                    $"DeleteRecording blocked: index={index}, isRecording={IsRecording}, " +
+                    $"continuationRecordingIdx={continuationRecordingIdx}, undockContinuationRecIdx={undockContinuationRecIdx}");
+                return;
+            }
 
             var rec = committed[index];
             Log($"Deleting recording '{rec.VesselName}' at index {index}");
@@ -2527,7 +2549,7 @@ namespace Parsek
 
             if (info.emissionScale > 1f)
             {
-                ParsekLog.Log($"RCS showcase diagnostics: part='{evt.partName}' pid={evt.partPersistentId} midx={evt.moduleIndex} " +
+                ParsekLog.Verbose("Flight", $"RCS showcase diagnostics: part='{evt.partName}' pid={evt.partPersistentId} midx={evt.moduleIndex} " +
                     $"power={power:F2} systems={configuredSystems} playing={playingSystems} renderers={enabledRenderers} " +
                     $"rate={sampleRate:F1} speed={sampleSpeed:F1} size={sampleSize:F2} life={sampleLifetime:F2}");
             }
@@ -3289,7 +3311,16 @@ namespace Parsek
 
         #region Utilities
 
-        void Log(string message) => ParsekLog.Log(message);
+        private static string DetermineRecordingBlockReason()
+        {
+            if (Time.timeScale < 0.01f)
+                return "game paused";
+            if (FlightGlobals.ActiveVessel == null)
+                return "no active vessel";
+            return "unknown guard in FlightRecorder.StartRecording";
+        }
+
+        void Log(string message) => ParsekLog.Verbose("Flight", message);
         void ScreenMessage(string message, float duration) => ParsekLog.ScreenMessage(message, duration);
 
         #endregion

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -200,7 +200,7 @@ namespace Parsek
                 boardingConfirmFrames++;
                 if (boardingConfirmFrames > 3)
                 {
-                    Log($"Boarding confirmation expired (targetPid={pendingBoardingTargetPid})");
+                    ParsekLog.Info("Flight", $"Boarding confirmation expired (targetPid={pendingBoardingTargetPid})");
                     pendingBoardingTargetPid = 0;
                     boardingConfirmFrames = 0;
                 }
@@ -212,7 +212,7 @@ namespace Parsek
                 dockConfirmFrames++;
                 if (dockConfirmFrames > 5)
                 {
-                    Log($"Dock confirmation expired (mergedPid={pendingDockMergedPid})");
+                    ParsekLog.Info("Flight", $"Dock confirmation expired (mergedPid={pendingDockMergedPid})");
                     pendingDockMergedPid = 0;
                     pendingDockAsTarget = false;
                     dockConfirmFrames = 0;
@@ -223,7 +223,7 @@ namespace Parsek
                 undockConfirmFrames++;
                 if (undockConfirmFrames > 5)
                 {
-                    Log($"Undock confirmation expired (otherPid={pendingUndockOtherPid})");
+                    ParsekLog.Info("Flight", $"Undock confirmation expired (otherPid={pendingUndockOtherPid})");
                     pendingUndockOtherPid = 0;
                     undockConfirmFrames = 0;
                 }

--- a/Source/Parsek/ParsekHarmony.cs
+++ b/Source/Parsek/ParsekHarmony.cs
@@ -1,4 +1,5 @@
 using HarmonyLib;
+using System;
 using UnityEngine;
 
 namespace Parsek
@@ -27,6 +28,7 @@ namespace Parsek
                 harmony.PatchAll(assembly);
                 initialized = true;
                 DontDestroyOnLoad(gameObject);
+                ParsekLog.Info("Init", $"SessionStart runUtc={DateTimeOffset.UtcNow.ToUnixTimeSeconds()}");
                 ParsekLog.Info("Harmony", $"Harmony patches applied for assembly '{assembly.GetName().Name}'");
             }
             catch (System.Exception ex)

--- a/Source/Parsek/ParsekHarmony.cs
+++ b/Source/Parsek/ParsekHarmony.cs
@@ -10,12 +10,29 @@ namespace Parsek
     [KSPAddon(KSPAddon.Startup.Instantly, true)]
     public class ParsekHarmony : MonoBehaviour
     {
+        private static bool initialized;
+
         void Awake()
         {
-            var harmony = new Harmony("com.parsek.mod");
-            harmony.PatchAll(typeof(ParsekHarmony).Assembly);
-            DontDestroyOnLoad(gameObject);
-            ParsekLog.Log("Harmony patches applied");
+            if (initialized)
+            {
+                ParsekLog.Warn("Harmony", "Awake called after initialization; skipping duplicate PatchAll");
+                return;
+            }
+
+            try
+            {
+                var assembly = typeof(ParsekHarmony).Assembly;
+                var harmony = new Harmony("com.parsek.mod");
+                harmony.PatchAll(assembly);
+                initialized = true;
+                DontDestroyOnLoad(gameObject);
+                ParsekLog.Info("Harmony", $"Harmony patches applied for assembly '{assembly.GetName().Name}'");
+            }
+            catch (System.Exception ex)
+            {
+                ParsekLog.Error("Harmony", $"Failed to apply Harmony patches: {ex.Message}");
+            }
         }
     }
 }

--- a/Source/Parsek/ParsekLog.cs
+++ b/Source/Parsek/ParsekLog.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace Parsek
@@ -10,10 +12,128 @@ namespace Parsek
         // When true, suppresses Debug.Log calls (for unit testing outside Unity)
         internal static bool SuppressLogging;
 
+        private struct RateLimitState
+        {
+            public double lastEmitSeconds;
+            public int suppressedCount;
+        }
+
+        private static readonly Dictionary<string, RateLimitState> rateLimitStateByKey =
+            new Dictionary<string, RateLimitState>();
+
+        private const double DefaultRateLimitSeconds = 5.0;
+
+        public static bool IsVerboseEnabled => ParsekSettings.Current?.verboseLogging ?? true;
+
+        internal static void ResetRateLimitsForTesting()
+        {
+            rateLimitStateByKey.Clear();
+        }
+
         public static void Log(string message)
         {
-            if (!SuppressLogging)
-                Debug.Log($"[Parsek] {message}");
+            Info("General", message);
+        }
+
+        public static void Info(string subsystem, string message)
+        {
+            Write("INFO", subsystem, message);
+        }
+
+        public static void Verbose(string subsystem, string message)
+        {
+            if (!IsVerboseEnabled) return;
+            Write("VERBOSE", subsystem, message);
+        }
+
+        public static void Warn(string subsystem, string message)
+        {
+            Write("WARN", subsystem, message);
+        }
+
+        public static void Error(string subsystem, string message)
+        {
+            Write("ERROR", subsystem, message);
+        }
+
+        public static void VerboseRateLimited(
+            string subsystem,
+            string key,
+            string message,
+            double minIntervalSeconds = DefaultRateLimitSeconds)
+        {
+            if (!IsVerboseEnabled)
+                return;
+
+            if (string.IsNullOrEmpty(key))
+            {
+                Verbose(subsystem, message);
+                return;
+            }
+
+            string compositeKey = $"{subsystem}|{key}";
+            double now = GetLogClockSeconds();
+            if (!rateLimitStateByKey.TryGetValue(compositeKey, out var state))
+            {
+                rateLimitStateByKey[compositeKey] = new RateLimitState
+                {
+                    lastEmitSeconds = now,
+                    suppressedCount = 0
+                };
+                Verbose(subsystem, message);
+                return;
+            }
+
+            if ((now - state.lastEmitSeconds) >= minIntervalSeconds)
+            {
+                string suffix = state.suppressedCount > 0
+                    ? $" | suppressed={state.suppressedCount}"
+                    : string.Empty;
+                Verbose(subsystem, $"{message}{suffix}");
+                state.lastEmitSeconds = now;
+                state.suppressedCount = 0;
+            }
+            else
+            {
+                state.suppressedCount++;
+            }
+
+            rateLimitStateByKey[compositeKey] = state;
+        }
+
+        private static double GetLogClockSeconds()
+        {
+            try
+            {
+                return Planetarium.GetUniversalTime();
+            }
+            catch (Exception)
+            {
+                return DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalSeconds;
+            }
+        }
+
+        private static void Write(string level, string subsystem, string message)
+        {
+            if (SuppressLogging)
+                return;
+
+            string safeSubsystem = string.IsNullOrEmpty(subsystem) ? "General" : subsystem;
+            string safeMessage = string.IsNullOrEmpty(message) ? "(empty)" : message;
+            string line = $"[Parsek][{level}][{safeSubsystem}] {safeMessage}";
+
+            try
+            {
+                Debug.Log(line);
+            }
+            catch (System.Security.SecurityException)
+            {
+                // Unit-test runtime can throw when Unity internals are unavailable.
+            }
+            catch (MethodAccessException)
+            {
+                // Same fallback for some non-Unity execution environments.
+            }
         }
 
         public static void ScreenMessage(string message, float duration)

--- a/Source/Parsek/ParsekLog.cs
+++ b/Source/Parsek/ParsekLog.cs
@@ -22,12 +22,25 @@ namespace Parsek
             new Dictionary<string, RateLimitState>();
 
         private const double DefaultRateLimitSeconds = 5.0;
+        private static readonly DateTime UnixEpochUtc = new DateTime(1970, 1, 1);
+        internal static Func<double> ClockOverrideForTesting;
+        internal static Action<string> TestSinkForTesting;
+        internal static bool? VerboseOverrideForTesting;
 
-        public static bool IsVerboseEnabled => ParsekSettings.Current?.verboseLogging ?? true;
+        public static bool IsVerboseEnabled =>
+            VerboseOverrideForTesting ?? (ParsekSettings.Current?.verboseLogging ?? true);
 
         internal static void ResetRateLimitsForTesting()
         {
             rateLimitStateByKey.Clear();
+        }
+
+        internal static void ResetTestOverrides()
+        {
+            ClockOverrideForTesting = null;
+            TestSinkForTesting = null;
+            VerboseOverrideForTesting = null;
+            ResetRateLimitsForTesting();
         }
 
         public static void Log(string message)
@@ -103,14 +116,10 @@ namespace Parsek
 
         private static double GetLogClockSeconds()
         {
-            try
-            {
-                return Planetarium.GetUniversalTime();
-            }
-            catch (Exception)
-            {
-                return DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalSeconds;
-            }
+            if (ClockOverrideForTesting != null)
+                return ClockOverrideForTesting();
+
+            return DateTime.UtcNow.Subtract(UnixEpochUtc).TotalSeconds;
         }
 
         private static void Write(string level, string subsystem, string message)
@@ -121,6 +130,11 @@ namespace Parsek
             string safeSubsystem = string.IsNullOrEmpty(subsystem) ? "General" : subsystem;
             string safeMessage = string.IsNullOrEmpty(message) ? "(empty)" : message;
             string line = $"[Parsek][{level}][{safeSubsystem}] {safeMessage}";
+            if (TestSinkForTesting != null)
+            {
+                TestSinkForTesting(line);
+                return;
+            }
 
             try
             {

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -777,14 +777,12 @@ namespace Parsek
             if (clean.StartsWith(legacyPrefix, StringComparison.Ordinal))
                 clean = clean.Substring(legacyPrefix.Length);
 
-            if (clean.StartsWith("WARNING:", StringComparison.OrdinalIgnoreCase))
+            if (clean.StartsWith("WARNING:", StringComparison.OrdinalIgnoreCase) ||
+                clean.StartsWith("WARN:", StringComparison.OrdinalIgnoreCase))
             {
-                ParsekLog.Warn("Scenario", clean.Substring("WARNING:".Length).TrimStart());
-                return;
-            }
-            if (clean.IndexOf("failed", StringComparison.OrdinalIgnoreCase) >= 0)
-            {
-                ParsekLog.Warn("Scenario", clean);
+                int idx = clean.IndexOf(':');
+                string trimmed = idx >= 0 ? clean.Substring(idx + 1).TrimStart() : clean;
+                ParsekLog.Warn("Scenario", trimmed);
                 return;
             }
 

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -168,16 +168,16 @@ namespace Parsek
                     if (i < savedRecNodes.Length)
                     {
                         string pidStr = savedRecNodes[i].GetValue("spawnedPid");
-                        if (pidStr != null)
-                            uint.TryParse(pidStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out savedPid);
+                        if (pidStr != null && !uint.TryParse(pidStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out savedPid))
+                            ParsekLog.Warn("Scenario", $"Failed to parse spawnedPid '{pidStr}' for recording #{i}");
 
                         string takenStr = savedRecNodes[i].GetValue("takenControl");
-                        if (takenStr != null)
-                            bool.TryParse(takenStr, out savedTaken);
+                        if (takenStr != null && !bool.TryParse(takenStr, out savedTaken))
+                            ParsekLog.Warn("Scenario", $"Failed to parse takenControl '{takenStr}' for recording #{i}");
 
                         string resIdxStr = savedRecNodes[i].GetValue("lastResIdx");
-                        if (resIdxStr != null)
-                            int.TryParse(resIdxStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out resIdx);
+                        if (resIdxStr != null && !int.TryParse(resIdxStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out resIdx))
+                            ParsekLog.Warn("Scenario", $"Failed to parse lastResIdx '{resIdxStr}' for recording #{i}");
                     }
                     recordings[i].SpawnedVesselPersistentId = savedPid;
                     recordings[i].TakenControl = savedTaken;
@@ -496,9 +496,11 @@ namespace Parsek
             {
                 foreach (string name in partNode.GetValues("crew"))
                 {
+                    bool found = false;
                     foreach (ProtoCrewMember pcm in roster.Crew)
                     {
                         if (pcm.name != name) continue;
+                        found = true;
 
                         // Skip dead crew — they're truly gone
                         if (pcm.rosterStatus == ProtoCrewMember.RosterStatus.Dead)
@@ -545,6 +547,8 @@ namespace Parsek
 
                         break;
                     }
+                    if (!found)
+                        ScenarioLog($"[Parsek Scenario] WARNING: Crew '{name}' not found in roster during reservation");
                 }
             }
         }

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using UnityEngine;
@@ -37,7 +38,7 @@ namespace Parsek
             node.RemoveNodes("RECORDING");
 
             var recordings = RecordingStore.CommittedRecordings;
-            Debug.Log($"[Parsek Scenario] Saving {recordings.Count} committed recordings");
+            ScenarioLog($"[Parsek Scenario] Saving {recordings.Count} committed recordings");
 
             for (int r = 0; r < recordings.Count; r++)
             {
@@ -47,7 +48,7 @@ namespace Parsek
                 // Write bulk data to external files
                 rec.RecordingFormatVersion = RecordingStore.CurrentRecordingFormatVersion;
                 if (!RecordingStore.SaveRecordingFiles(rec))
-                    Debug.Log($"[Parsek Scenario] WARNING: File write failed for '{rec.VesselName}'");
+                    ScenarioLog($"[Parsek Scenario] WARNING: File write failed for '{rec.VesselName}'");
 
                 SaveRecordingMetadata(recNode, rec);
                 recNode.AddValue("vesselName", rec.VesselName);
@@ -91,7 +92,7 @@ namespace Parsek
                     entry.AddValue("original", kvp.Key);
                     entry.AddValue("replacement", kvp.Value);
                 }
-                Debug.Log($"[Parsek Scenario] Saved {crewReplacements.Count} crew replacement(s)");
+                ScenarioLog($"[Parsek Scenario] Saved {crewReplacements.Count} crew replacement(s)");
             }
 
             // Save game state events to external file
@@ -119,7 +120,7 @@ namespace Parsek
             {
                 initialLoadDone = false;
                 lastSaveFolder = currentSave;
-                Debug.Log($"[Parsek Scenario] Save folder changed to '{currentSave}' — resetting session state");
+                ScenarioLog($"[Parsek Scenario] Save folder changed to '{currentSave}' — resetting session state");
             }
 
             // Load crew replacement mappings from the node (both initial and revert paths need this)
@@ -145,7 +146,7 @@ namespace Parsek
                 }
                 catch (System.Exception ex)
                 {
-                    Debug.Log($"[Parsek Scenario] Failed to capture initial baseline: {ex.Message}");
+                    ScenarioLog($"[Parsek Scenario] Failed to capture initial baseline: {ex.Message}");
                 }
             }
 
@@ -184,7 +185,7 @@ namespace Parsek
                 }
 
                 ReserveSnapshotCrew();
-                Debug.Log($"[Parsek Scenario] Revert detected — preserving {recordings.Count} session recordings");
+                ScenarioLog($"[Parsek Scenario] Revert detected — preserving {recordings.Count} session recordings");
                 return;
             }
 
@@ -192,7 +193,7 @@ namespace Parsek
             recordings.Clear();
 
             ConfigNode[] recNodes = node.GetNodes("RECORDING");
-            Debug.Log($"[Parsek Scenario] Loading {recNodes.Length} committed recordings");
+            ScenarioLog($"[Parsek Scenario] Loading {recNodes.Length} committed recordings");
 
             for (int r = 0; r < recNodes.Length; r++)
             {
@@ -266,7 +267,7 @@ namespace Parsek
                 // Always add — even degraded recordings (missing .prec → 0 points)
                 // must occupy their slot to preserve index-based revert mapping.
                 recordings.Add(rec);
-                Debug.Log($"[Parsek Scenario] Loaded recording: {rec.VesselName}, " +
+                ScenarioLog($"[Parsek Scenario] Loaded recording: {rec.VesselName}, " +
                     $"{rec.Points.Count} points, {rec.OrbitSegments.Count} orbit segments" +
                     (rec.Points.Count > 0 ? $", UT {rec.StartUT:F0}-{rec.EndUT:F0}" : ", degraded (0 points)") +
                     (rec.VesselSnapshot != null ? " (vessel spawn)" :
@@ -283,7 +284,7 @@ namespace Parsek
 
             // Diagnostic summary of loaded recordings with UT context
             double loadUT = Planetarium.GetUniversalTime();
-            ParsekLog.Log($"Scenario load summary — UT: {loadUT:F0}, {recordings.Count} recording(s)");
+            ParsekLog.Info("Scenario", $"Scenario load summary — UT: {loadUT:F0}, {recordings.Count} recording(s)");
             for (int i = 0; i < recordings.Count; i++)
             {
                 var loadedRec = recordings[i];
@@ -297,14 +298,14 @@ namespace Parsek
                     status = "IN PROGRESS";
                 else
                     status = "past";
-                ParsekLog.Log($"  #{i}: \"{loadedRec.VesselName}\" — {status}");
+                ParsekLog.Info("Scenario", $"  #{i}: \"{loadedRec.VesselName}\" — {status}");
             }
 
             if (crewReplacements.Count > 0)
             {
-                ParsekLog.Log($"Crew reservations active ({crewReplacements.Count}):");
+                ParsekLog.Info("Scenario", $"Crew reservations active ({crewReplacements.Count}):");
                 foreach (var kvp in crewReplacements)
-                    ParsekLog.Log($"  {kvp.Key} -> replacement: {kvp.Value}");
+                    ParsekLog.Info("Scenario", $"  {kvp.Key} -> replacement: {kvp.Value}");
             }
 
             // Auto-unreserve crew for recordings whose EndUT has already passed
@@ -319,7 +320,7 @@ namespace Parsek
                     UnreserveCrewInSnapshot(rec.VesselSnapshot);
                     rec.VesselSnapshot = null;
                     rec.VesselSpawned = true;
-                    Debug.Log($"[Parsek Scenario] Auto-unreserved crew for recording #{i} " +
+                    ScenarioLog($"[Parsek Scenario] Auto-unreserved crew for recording #{i} " +
                         $"({rec.VesselName}) — EndUT passed without spawn");
                 }
             }
@@ -334,7 +335,7 @@ namespace Parsek
                     UnreserveCrewInSnapshot(pending.VesselSnapshot);
                 pending.VesselSnapshot = null;
                 RecordingStore.CommitPending();
-                Debug.Log($"[Parsek Scenario] Auto-committed pending recording outside Flight " +
+                ScenarioLog($"[Parsek Scenario] Auto-committed pending recording outside Flight " +
                     $"(scene: {HighLogic.LoadedScene})");
             }
         }
@@ -470,7 +471,7 @@ namespace Parsek
                             if (pcm.name == name && pcm.rosterStatus == ProtoCrewMember.RosterStatus.Assigned)
                             {
                                 pcm.rosterStatus = ProtoCrewMember.RosterStatus.Available;
-                                Debug.Log($"[Parsek Scenario] Unreserved crew '{name}'");
+                                ScenarioLog($"[Parsek Scenario] Unreserved crew '{name}'");
 
                                 // Clean up the replacement kerbal
                                 CleanUpReplacement(name, roster);
@@ -509,14 +510,14 @@ namespace Parsek
                         if (pcm.rosterStatus == ProtoCrewMember.RosterStatus.Missing)
                         {
                             pcm.rosterStatus = ProtoCrewMember.RosterStatus.Available;
-                            Debug.Log($"[Parsek Scenario] Rescued Missing crew '{name}' → Available for reservation");
+                            ScenarioLog($"[Parsek Scenario] Rescued Missing crew '{name}' → Available for reservation");
                         }
 
                         // Mark as Assigned if Available
                         if (NeedsStatusChange(pcm.rosterStatus))
                         {
                             pcm.rosterStatus = ProtoCrewMember.RosterStatus.Assigned;
-                            Debug.Log($"[Parsek Scenario] Reserved crew '{name}' for deferred vessel spawn");
+                            ScenarioLog($"[Parsek Scenario] Reserved crew '{name}' for deferred vessel spawn");
                         }
 
                         // Hire a replacement kerbal so the available pool stays constant.
@@ -532,13 +533,13 @@ namespace Parsek
                                 {
                                     KerbalRoster.SetExperienceTrait(replacement, pcm.experienceTrait.TypeName);
                                     crewReplacements[name] = replacement.name;
-                                    Debug.Log($"[Parsek Scenario] Hired replacement '{replacement.name}' " +
+                                    ScenarioLog($"[Parsek Scenario] Hired replacement '{replacement.name}' " +
                                         $"(trait: {pcm.experienceTrait.TypeName}) for reserved '{name}'");
                                 }
                             }
                             catch (System.Exception ex)
                             {
-                                Debug.Log($"[Parsek Scenario] Failed to hire replacement for '{name}': {ex.Message}");
+                                ScenarioLog($"[Parsek Scenario] Failed to hire replacement for '{name}': {ex.Message}");
                             }
                         }
 
@@ -573,18 +574,18 @@ namespace Parsek
 
             if (replacement == null)
             {
-                Debug.Log($"[Parsek Scenario] Replacement '{replacementName}' not found in roster (already removed?)");
+                ScenarioLog($"[Parsek Scenario] Replacement '{replacementName}' not found in roster (already removed?)");
                 return;
             }
 
             if (replacement.rosterStatus == ProtoCrewMember.RosterStatus.Available)
             {
                 roster.Remove(replacement);
-                Debug.Log($"[Parsek Scenario] Removed replacement '{replacementName}' (was unused)");
+                ScenarioLog($"[Parsek Scenario] Removed replacement '{replacementName}' (was unused)");
             }
             else
             {
-                Debug.Log($"[Parsek Scenario] Kept replacement '{replacementName}' " +
+                ScenarioLog($"[Parsek Scenario] Kept replacement '{replacementName}' " +
                     $"(status: {replacement.rosterStatus} — now a real kerbal)");
             }
         }
@@ -611,7 +612,7 @@ namespace Parsek
                 }
 
                 crewReplacements.Clear();
-                Debug.Log("[Parsek Scenario] Cleared all crew replacements");
+                ScenarioLog("[Parsek Scenario] Cleared all crew replacements");
             }
             finally
             {
@@ -629,7 +630,7 @@ namespace Parsek
             ConfigNode replacementsNode = node.GetNode("CREW_REPLACEMENTS");
             if (replacementsNode == null)
             {
-                Debug.Log("[Parsek Scenario] Loaded 0 crew replacements (no CREW_REPLACEMENTS node)");
+                ScenarioLog("[Parsek Scenario] Loaded 0 crew replacements (no CREW_REPLACEMENTS node)");
                 return;
             }
 
@@ -644,7 +645,7 @@ namespace Parsek
                 }
             }
 
-            Debug.Log($"[Parsek Scenario] Loaded {crewReplacements.Count} crew replacement(s)");
+            ScenarioLog($"[Parsek Scenario] Loaded {crewReplacements.Count} crew replacement(s)");
         }
 
         /// <summary>
@@ -686,7 +687,7 @@ namespace Parsek
 
                     if (replacement == null)
                     {
-                        Debug.Log($"[Parsek Scenario] Cannot swap '{original.name}': replacement '{replacementName}' not in roster");
+                        ScenarioLog($"[Parsek Scenario] Cannot swap '{original.name}': replacement '{replacementName}' not in roster");
                         failCount++;
                         continue;
                     }
@@ -694,14 +695,14 @@ namespace Parsek
                     int seatIndex = part.protoModuleCrew.IndexOf(original);
                     if (seatIndex < 0)
                     {
-                        Debug.Log($"[Parsek Scenario] Cannot swap '{original.name}': not found in part crew list");
+                        ScenarioLog($"[Parsek Scenario] Cannot swap '{original.name}': not found in part crew list");
                         failCount++;
                         continue;
                     }
                     part.RemoveCrewmember(original);
                     part.AddCrewmemberAt(replacement, seatIndex);
                     swapCount++;
-                    Debug.Log($"[Parsek Scenario] Swapped '{original.name}' → '{replacement.name}' in part '{part.partInfo.title}'");
+                    ScenarioLog($"[Parsek Scenario] Swapped '{original.name}' → '{replacement.name}' in part '{part.partInfo.title}'");
                 }
             }
 
@@ -709,13 +710,13 @@ namespace Parsek
             {
                 FlightGlobals.ActiveVessel.SpawnCrew();
                 GameEvents.onVesselCrewWasModified.Fire(FlightGlobals.ActiveVessel);
-                Debug.Log($"[Parsek Scenario] Crew swap complete: {swapCount} succeeded" +
+                ScenarioLog($"[Parsek Scenario] Crew swap complete: {swapCount} succeeded" +
                     (failCount > 0 ? $", {failCount} failed" : "") +
                     " — refreshed vessel crew display");
             }
             else if (failCount > 0)
             {
-                Debug.Log($"[Parsek Scenario] Crew swap: 0 succeeded, {failCount} failed");
+                ScenarioLog($"[Parsek Scenario] Crew swap: 0 succeeded, {failCount} failed");
             }
 
             return swapCount;
@@ -767,6 +768,27 @@ namespace Parsek
         internal static void ResetReplacementsForTesting()
         {
             crewReplacements.Clear();
+        }
+
+        private static void ScenarioLog(string message)
+        {
+            const string legacyPrefix = "[Parsek Scenario] ";
+            string clean = message ?? "(empty)";
+            if (clean.StartsWith(legacyPrefix, StringComparison.Ordinal))
+                clean = clean.Substring(legacyPrefix.Length);
+
+            if (clean.StartsWith("WARNING:", StringComparison.OrdinalIgnoreCase))
+            {
+                ParsekLog.Warn("Scenario", clean.Substring("WARNING:".Length).TrimStart());
+                return;
+            }
+            if (clean.IndexOf("failed", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                ParsekLog.Warn("Scenario", clean);
+                return;
+            }
+
+            ParsekLog.Info("Scenario", clean);
         }
 
         #endregion

--- a/Source/Parsek/ParsekSettings.cs
+++ b/Source/Parsek/ParsekSettings.cs
@@ -21,6 +21,10 @@ namespace Parsek
             toolTip = "Stop time warp when a ghost playback is about to begin")]
         public bool autoWarpStop = true;
 
+        [GameParameters.CustomParameterUI("Verbose logging",
+            toolTip = "When enabled, write detailed diagnostics to KSP.log (default for development)")]
+        public bool verboseLogging = true;
+
         [GameParameters.CustomFloatParameterUI("Max sample interval (s)", minValue = 1f, maxValue = 10f,
             stepCount = 19, displayFormat = "F1",
             toolTip = "Maximum seconds between trajectory samples")]

--- a/Source/Parsek/ParsekToolbarRegistration.cs
+++ b/Source/Parsek/ParsekToolbarRegistration.cs
@@ -6,9 +6,27 @@ namespace Parsek
     [KSPAddon(KSPAddon.Startup.Instantly, true)]
     public class ParsekToolbarRegistration : MonoBehaviour
     {
+        private static bool registered;
+
         void Start()
         {
-            ToolbarControl.RegisterMod(ParsekFlight.MODID, ParsekFlight.MODNAME);
+            if (registered)
+            {
+                ParsekLog.Warn("Toolbar", "Toolbar registration skipped: already registered");
+                return;
+            }
+
+            try
+            {
+                ToolbarControl.RegisterMod(ParsekFlight.MODID, ParsekFlight.MODNAME);
+                registered = true;
+                ParsekLog.Info("Toolbar",
+                    $"Toolbar registered: modId={ParsekFlight.MODID}, modName={ParsekFlight.MODNAME}");
+            }
+            catch (System.Exception ex)
+            {
+                ParsekLog.Error("Toolbar", $"Toolbar registration failed: {ex.Message}");
+            }
         }
     }
 }

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -183,7 +183,7 @@ namespace Parsek
             if (GUILayout.Button($"Despawn Ghosts ({activeGhosts})"))
             {
                 flight.DestroyAllTimelineGhosts();
-                ParsekLog.Log("Ghosts despawned");
+                ParsekLog.Info("UI", "Ghosts despawned");
             }
 
             GUI.enabled = committedCount > 0;
@@ -195,7 +195,7 @@ namespace Parsek
                 ParsekScenario.ClearReplacements();
                 flight.DestroyAllTimelineGhosts();
                 RecordingStore.ClearCommitted();
-                ParsekLog.Log("All recordings wiped");
+                ParsekLog.Info("UI", "All recordings wiped");
                 ParsekLog.ScreenMessage("All recordings wiped", 2f);
             }
             GUI.enabled = true;
@@ -317,6 +317,7 @@ namespace Parsek
                 {
                     for (int i = 0; i < committed.Count; i++)
                         committed[i].LoopPlayback = newAllLoop;
+                    ParsekLog.Info("UI", $"Set loop playback for all recordings: enabled={newAllLoop}");
                 }
 
                 GUILayout.Label("Period", GUILayout.Width(ColW_Period));
@@ -388,6 +389,7 @@ namespace Parsek
                     if (loop != rec.LoopPlayback)
                     {
                         rec.LoopPlayback = loop;
+                        ParsekLog.Info("UI", $"Recording '{rec.VesselName}' loop playback set to {loop}");
                         if (!loop && editingLoopPeriodIdx == ri)
                             editingLoopPeriodIdx = -1;
                     }
@@ -407,6 +409,7 @@ namespace Parsek
                                 editingLoopPeriodIdx = -1;
                             else if (editingLoopPeriodIdx > ri)
                                 editingLoopPeriodIdx--;
+                            ParsekLog.Info("UI", $"Delete confirmed for recording index={ri} name='{rec.VesselName}'");
                             flight.DeleteRecording(ri);
                             InvalidateSort();
                             GUI.enabled = true;
@@ -417,7 +420,10 @@ namespace Parsek
                     else
                     {
                         if (GUILayout.Button("X", GUILayout.Width(ColW_Delete)))
+                        {
                             deleteConfirmIndex = ri;
+                            ParsekLog.Verbose("UI", $"Delete armed for recording index={ri} name='{rec.VesselName}'");
+                        }
                     }
                     GUI.enabled = true;
 
@@ -732,6 +738,13 @@ namespace Parsek
                 double pause = newPeriod - dur;
                 if (pause < 0) pause = 0;
                 rec.LoopPauseSeconds = pause;
+                ParsekLog.Info("UI",
+                    $"Recording '{rec.VesselName}' loop period updated to {(dur + rec.LoopPauseSeconds):F1}s (pause={pause:F1}s)");
+            }
+            else
+            {
+                ParsekLog.Warn("UI",
+                    $"Rejected loop period edit '{editingLoopPeriodText}' for recording '{rec.VesselName}'");
             }
         }
 
@@ -815,26 +828,70 @@ namespace Parsek
             }
 
             GUILayout.Label("Recording", GUI.skin.box);
-            s.autoRecordOnLaunch = GUILayout.Toggle(s.autoRecordOnLaunch, "Auto-record on launch");
-            s.autoRecordOnEva = GUILayout.Toggle(s.autoRecordOnEva, "Auto-record on EVA");
-            s.autoWarpStop = GUILayout.Toggle(s.autoWarpStop, "Auto-stop time warp");
+            bool autoRecordOnLaunch = GUILayout.Toggle(s.autoRecordOnLaunch, "Auto-record on launch");
+            if (autoRecordOnLaunch != s.autoRecordOnLaunch)
+            {
+                s.autoRecordOnLaunch = autoRecordOnLaunch;
+                ParsekLog.Info("UI", $"Setting changed: autoRecordOnLaunch={s.autoRecordOnLaunch}");
+            }
+
+            bool autoRecordOnEva = GUILayout.Toggle(s.autoRecordOnEva, "Auto-record on EVA");
+            if (autoRecordOnEva != s.autoRecordOnEva)
+            {
+                s.autoRecordOnEva = autoRecordOnEva;
+                ParsekLog.Info("UI", $"Setting changed: autoRecordOnEva={s.autoRecordOnEva}");
+            }
+
+            bool autoWarpStop = GUILayout.Toggle(s.autoWarpStop, "Auto-stop time warp");
+            if (autoWarpStop != s.autoWarpStop)
+            {
+                s.autoWarpStop = autoWarpStop;
+                ParsekLog.Info("UI", $"Setting changed: autoWarpStop={s.autoWarpStop}");
+            }
+
+            GUILayout.Space(5);
+            GUILayout.Label("Diagnostics", GUI.skin.box);
+            bool verboseLogging = GUILayout.Toggle(s.verboseLogging, "Verbose logging (development default)");
+            if (verboseLogging != s.verboseLogging)
+            {
+                s.verboseLogging = verboseLogging;
+                ParsekLog.Info("UI", $"Setting changed: verboseLogging={s.verboseLogging}");
+            }
 
             GUILayout.Space(5);
             GUILayout.Label("Sampling", GUI.skin.box);
 
             GUILayout.BeginHorizontal();
             GUILayout.Label($"Max interval: {s.maxSampleInterval:F1}s", GUILayout.Width(140));
-            s.maxSampleInterval = GUILayout.HorizontalSlider(s.maxSampleInterval, 1f, 10f);
+            float maxSampleInterval = GUILayout.HorizontalSlider(s.maxSampleInterval, 1f, 10f);
+            if (Mathf.Abs(maxSampleInterval - s.maxSampleInterval) > 0.0001f)
+            {
+                s.maxSampleInterval = maxSampleInterval;
+                ParsekLog.VerboseRateLimited("UI", "sampling.maxSampleInterval",
+                    $"Setting changed: maxSampleInterval={s.maxSampleInterval:F1}s", 1.0);
+            }
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
             GUILayout.Label($"Direction: {s.velocityDirThreshold:F1}\u00b0", GUILayout.Width(140));
-            s.velocityDirThreshold = GUILayout.HorizontalSlider(s.velocityDirThreshold, 0.5f, 10f);
+            float velocityDirThreshold = GUILayout.HorizontalSlider(s.velocityDirThreshold, 0.5f, 10f);
+            if (Mathf.Abs(velocityDirThreshold - s.velocityDirThreshold) > 0.0001f)
+            {
+                s.velocityDirThreshold = velocityDirThreshold;
+                ParsekLog.VerboseRateLimited("UI", "sampling.velocityDirThreshold",
+                    $"Setting changed: velocityDirThreshold={s.velocityDirThreshold:F1}", 1.0);
+            }
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
             GUILayout.Label($"Speed: {s.speedChangeThreshold:F0}%", GUILayout.Width(140));
-            s.speedChangeThreshold = GUILayout.HorizontalSlider(s.speedChangeThreshold, 1f, 20f);
+            float speedChangeThreshold = GUILayout.HorizontalSlider(s.speedChangeThreshold, 1f, 20f);
+            if (Mathf.Abs(speedChangeThreshold - s.speedChangeThreshold) > 0.0001f)
+            {
+                s.speedChangeThreshold = speedChangeThreshold;
+                ParsekLog.VerboseRateLimited("UI", "sampling.speedChangeThreshold",
+                    $"Setting changed: speedChangeThreshold={s.speedChangeThreshold:F0}%", 1.0);
+            }
             GUILayout.EndHorizontal();
 
             GUILayout.Space(5);
@@ -844,9 +901,11 @@ namespace Parsek
                 s.autoRecordOnLaunch = true;
                 s.autoRecordOnEva = true;
                 s.autoWarpStop = true;
+                s.verboseLogging = true;
                 s.maxSampleInterval = 3.0f;
                 s.velocityDirThreshold = 2.0f;
                 s.speedChangeThreshold = 5.0f;
+                ParsekLog.Info("UI", "Settings reset to defaults");
             }
             if (GUILayout.Button("Close"))
                 showSettingsWindow = false;

--- a/Source/Parsek/PartEvent.cs
+++ b/Source/Parsek/PartEvent.cs
@@ -46,5 +46,11 @@ namespace Parsek
         public string partName;
         public float value;       // throttle 0-1 for engine events; 0 for others
         public int moduleIndex;   // index of ModuleEngines on part (0 for single-engine parts)
+
+        public override string ToString()
+        {
+            return $"UT={ut:F2} event={eventType} part='{partName ?? "?"}' pid={partPersistentId} " +
+                   $"midx={moduleIndex} value={value:F3}";
+        }
     }
 }

--- a/Source/Parsek/Patches/PhysicsFramePatch.cs
+++ b/Source/Parsek/Patches/PhysicsFramePatch.cs
@@ -17,16 +17,38 @@ namespace Parsek.Patches
         /// Null when not recording.
         /// </summary>
         internal static FlightRecorder ActiveRecorder;
+        private static FlightRecorder lastObservedRecorder;
 
         static void Postfix(VesselPrecalculate __instance)
         {
-            if (ActiveRecorder == null) return;
+            if (ActiveRecorder != lastObservedRecorder)
+            {
+                if (ActiveRecorder == null)
+                    ParsekLog.Info("PhysicsPatch", "Active recorder cleared");
+                else
+                    ParsekLog.Info("PhysicsPatch", "Active recorder attached");
+                lastObservedRecorder = ActiveRecorder;
+            }
+
+            if (ActiveRecorder == null)
+                return;
 
             // VesselPrecalculate.vessel is protected; resolve the vessel
             // via the GameObject instead.
             Vessel v = FlightGlobals.ActiveVessel;
-            if (v == null) return;
-            if (__instance.gameObject != v.gameObject) return;
+            if (v == null)
+            {
+                ParsekLog.VerboseRateLimited("PhysicsPatch", "active-vessel-null",
+                    "Skipping physics callback: active vessel is null", 5.0);
+                return;
+            }
+
+            if (__instance.gameObject != v.gameObject)
+            {
+                ParsekLog.VerboseRateLimited("PhysicsPatch", "non-active-vessel",
+                    "Skipping physics callback: patch fired for non-active vessel", 5.0);
+                return;
+            }
 
             ActiveRecorder.OnPhysicsFrame(v);
         }

--- a/Source/Parsek/RecordingPaths.cs
+++ b/Source/Parsek/RecordingPaths.cs
@@ -30,7 +30,13 @@ namespace Parsek
             string root = KSPUtil.ApplicationRootPath ?? "";
             string saveFolder = HighLogic.SaveFolder ?? "";
             if (string.IsNullOrEmpty(root) || string.IsNullOrEmpty(saveFolder) || string.IsNullOrEmpty(relativePath))
+            {
+                ParsekLog.VerboseRateLimited("Paths", "resolve-save-scoped-missing-context",
+                    $"ResolveSaveScopedPath missing context: rootSet={!string.IsNullOrEmpty(root)}, " +
+                    $"saveSet={!string.IsNullOrEmpty(saveFolder)}, relativeSet={!string.IsNullOrEmpty(relativePath)}",
+                    5.0);
                 return null;
+            }
             return Path.GetFullPath(Path.Combine(root, "saves", saveFolder, relativePath));
         }
 
@@ -39,11 +45,19 @@ namespace Parsek
             string root = KSPUtil.ApplicationRootPath ?? "";
             string saveFolder = HighLogic.SaveFolder ?? "";
             if (string.IsNullOrEmpty(root) || string.IsNullOrEmpty(saveFolder))
+            {
+                ParsekLog.VerboseRateLimited("Paths", "ensure-recordings-missing-context",
+                    $"EnsureRecordingsDirectory missing context: rootSet={!string.IsNullOrEmpty(root)}, " +
+                    $"saveSet={!string.IsNullOrEmpty(saveFolder)}", 5.0);
                 return null;
+            }
 
             string dir = Path.GetFullPath(Path.Combine(root, "saves", saveFolder, "Parsek", "Recordings"));
             if (!Directory.Exists(dir))
+            {
                 Directory.CreateDirectory(dir);
+                ParsekLog.Info("Paths", $"Created recordings directory '{dir}'");
+            }
             return dir;
         }
 
@@ -63,11 +77,19 @@ namespace Parsek
             string root = KSPUtil.ApplicationRootPath ?? "";
             string saveFolder = HighLogic.SaveFolder ?? "";
             if (string.IsNullOrEmpty(root) || string.IsNullOrEmpty(saveFolder))
+            {
+                ParsekLog.VerboseRateLimited("Paths", "ensure-gamestate-missing-context",
+                    $"EnsureGameStateDirectory missing context: rootSet={!string.IsNullOrEmpty(root)}, " +
+                    $"saveSet={!string.IsNullOrEmpty(saveFolder)}", 5.0);
                 return null;
+            }
 
             string dir = Path.GetFullPath(Path.Combine(root, "saves", saveFolder, "Parsek", "GameState"));
             if (!Directory.Exists(dir))
+            {
                 Directory.CreateDirectory(dir);
+                ParsekLog.Info("Paths", $"Created game state directory '{dir}'");
+            }
             return dir;
         }
 
@@ -76,7 +98,12 @@ namespace Parsek
             string root = KSPUtil.ApplicationRootPath ?? "";
             string saveFolder = HighLogic.SaveFolder ?? "";
             if (string.IsNullOrEmpty(root) || string.IsNullOrEmpty(saveFolder))
+            {
+                ParsekLog.VerboseRateLimited("Paths", "resolve-gamestate-missing-context",
+                    $"ResolveGameStateDirectory missing context: rootSet={!string.IsNullOrEmpty(root)}, " +
+                    $"saveSet={!string.IsNullOrEmpty(saveFolder)}", 5.0);
                 return null;
+            }
 
             return Path.GetFullPath(Path.Combine(root, "saves", saveFolder, "Parsek", "GameState"));
         }
@@ -84,14 +111,23 @@ namespace Parsek
         internal static bool ValidateRecordingId(string id)
         {
             if (string.IsNullOrEmpty(id))
+            {
+                ParsekLog.Warn("Paths", "Recording id validation failed: id is null or empty");
                 return false;
+            }
             if (id.Contains("/") || id.Contains("\\") || id.Contains(".."))
+            {
+                ParsekLog.Warn("Paths", $"Recording id validation failed for '{id}': contains invalid path sequence");
                 return false;
+            }
             char[] invalidChars = Path.GetInvalidFileNameChars();
             for (int i = 0; i < id.Length; i++)
             {
                 if (Array.IndexOf(invalidChars, id[i]) >= 0)
+                {
+                    ParsekLog.Warn("Paths", $"Recording id validation failed for '{id}': contains invalid file-name char");
                     return false;
+                }
             }
             return true;
         }

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -204,7 +204,11 @@ namespace Parsek
 
         public static void CommitPending()
         {
-            if (pendingRecording == null) return;
+            if (pendingRecording == null)
+            {
+                ParsekLog.Verbose("RecordingStore", "CommitPending called with no pending recording");
+                return;
+            }
 
             committedRecordings.Add(pendingRecording);
             Log($"[Parsek] Committed recording from {pendingRecording.VesselName} " +
@@ -217,7 +221,11 @@ namespace Parsek
 
         public static void DiscardPending()
         {
-            if (pendingRecording == null) return;
+            if (pendingRecording == null)
+            {
+                ParsekLog.Verbose("RecordingStore", "DiscardPending called with no pending recording");
+                return;
+            }
 
             DeleteRecordingFiles(pendingRecording);
             Log($"[Parsek] Discarded pending recording from {pendingRecording.VesselName}");
@@ -226,9 +234,11 @@ namespace Parsek
 
         public static void ClearCommitted()
         {
+            int count = committedRecordings.Count;
             for (int i = 0; i < committedRecordings.Count; i++)
                 DeleteRecordingFiles(committedRecordings[i]);
             committedRecordings.Clear();
+            Log($"[Parsek] Cleared {count} committed recordings");
         }
 
         public static void Clear()
@@ -432,7 +442,11 @@ namespace Parsek
         /// </summary>
         internal static void RemoveRecordingAt(int index)
         {
-            if (index < 0 || index >= committedRecordings.Count) return;
+            if (index < 0 || index >= committedRecordings.Count)
+            {
+                ParsekLog.Warn("RecordingStore", $"RemoveRecordingAt called with invalid index={index} (count={committedRecordings.Count})");
+                return;
+            }
 
             var rec = committedRecordings[index];
 
@@ -471,8 +485,16 @@ namespace Parsek
 
         internal static void DeleteRecordingFiles(Recording rec)
         {
-            if (rec == null) return;
-            if (!RecordingPaths.ValidateRecordingId(rec.RecordingId)) return;
+            if (rec == null)
+            {
+                ParsekLog.Verbose("RecordingStore", "DeleteRecordingFiles called with null recording");
+                return;
+            }
+            if (!RecordingPaths.ValidateRecordingId(rec.RecordingId))
+            {
+                ParsekLog.Warn("RecordingStore", $"DeleteRecordingFiles skipped: invalid recording id '{rec.RecordingId}'");
+                return;
+            }
 
             DeleteFileIfExists(RecordingPaths.BuildTrajectoryRelativePath(rec.RecordingId));
             DeleteFileIfExists(RecordingPaths.BuildVesselSnapshotRelativePath(rec.RecordingId));
@@ -488,7 +510,10 @@ namespace Parsek
                 if (!string.IsNullOrEmpty(absolutePath) && File.Exists(absolutePath))
                     File.Delete(absolutePath);
             }
-            catch { }
+            catch (Exception ex)
+            {
+                Log($"[Parsek] WARNING: Failed to delete file '{relativePath}': {ex.Message}");
+            }
         }
 
         #region Trajectory Serialization
@@ -552,15 +577,19 @@ namespace Parsek
             var ic = CultureInfo.InvariantCulture;
 
             ConfigNode[] ptNodes = sourceNode.GetNodes("POINT");
+            int parseFailCount = 0;
             for (int i = 0; i < ptNodes.Length; i++)
             {
                 var ptNode = ptNodes[i];
                 var pt = new TrajectoryPoint();
 
-                double.TryParse(ptNode.GetValue("ut"), inv, ic, out pt.ut);
+                bool utOk = double.TryParse(ptNode.GetValue("ut"), inv, ic, out pt.ut);
                 double.TryParse(ptNode.GetValue("lat"), inv, ic, out pt.latitude);
                 double.TryParse(ptNode.GetValue("lon"), inv, ic, out pt.longitude);
                 double.TryParse(ptNode.GetValue("alt"), inv, ic, out pt.altitude);
+
+                if (!utOk)
+                    parseFailCount++;
 
                 float rx, ry, rz, rw;
                 float.TryParse(ptNode.GetValue("rotX"), inv, ic, out rx);
@@ -589,6 +618,8 @@ namespace Parsek
 
                 rec.Points.Add(pt);
             }
+            if (parseFailCount > 0)
+                Log($"[Parsek] WARNING: {parseFailCount}/{ptNodes.Length} trajectory points had unparseable UT in recording {rec.RecordingId}");
 
             ConfigNode[] segNodes = sourceNode.GetNodes("ORBIT_SEGMENT");
             for (int s = 0; s < segNodes.Length; s++)

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -29,14 +29,12 @@ namespace Parsek
             if (clean.StartsWith(LegacyPrefix, StringComparison.Ordinal))
                 clean = clean.Substring(LegacyPrefix.Length);
 
-            if (clean.StartsWith("WARNING:", StringComparison.OrdinalIgnoreCase))
+            if (clean.StartsWith("WARNING:", StringComparison.OrdinalIgnoreCase) ||
+                clean.StartsWith("WARN:", StringComparison.OrdinalIgnoreCase))
             {
-                ParsekLog.Warn("RecordingStore", clean.Substring("WARNING:".Length).TrimStart());
-                return;
-            }
-            if (clean.IndexOf("failed", StringComparison.OrdinalIgnoreCase) >= 0)
-            {
-                ParsekLog.Warn("RecordingStore", clean);
+                int idx = clean.IndexOf(':');
+                string trimmed = idx >= 0 ? clean.Substring(idx + 1).TrimStart() : clean;
+                ParsekLog.Warn("RecordingStore", trimmed);
                 return;
             }
 

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -16,26 +16,31 @@ namespace Parsek
         public const int CurrentRecordingFormatVersion = 4;
         public const int CurrentGhostGeometryVersion = 1;
 
-        // When true, suppresses Debug.Log calls (for unit testing outside Unity)
+        // When true, suppresses logging calls (for unit testing outside Unity)
         internal static bool SuppressLogging;
+
+        private const string LegacyPrefix = "[Parsek] ";
 
         static void Log(string message)
         {
-            if (!SuppressLogging)
+            if (SuppressLogging) return;
+
+            string clean = message ?? "(empty)";
+            if (clean.StartsWith(LegacyPrefix, StringComparison.Ordinal))
+                clean = clean.Substring(LegacyPrefix.Length);
+
+            if (clean.StartsWith("WARNING:", StringComparison.OrdinalIgnoreCase))
             {
-                try
-                {
-                    UnityEngine.Debug.Log(message);
-                }
-                catch (System.Security.SecurityException)
-                {
-                    // Unit-test runtime can throw when Unity internals are unavailable.
-                }
-                catch (MethodAccessException)
-                {
-                    // Same fallback for some non-Unity execution environments.
-                }
+                ParsekLog.Warn("RecordingStore", clean.Substring("WARNING:".Length).TrimStart());
+                return;
             }
+            if (clean.IndexOf("failed", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                ParsekLog.Warn("RecordingStore", clean);
+                return;
+            }
+
+            ParsekLog.Info("RecordingStore", clean);
         }
 
         /// <summary>
@@ -619,7 +624,12 @@ namespace Parsek
                     evt.partPersistentId = pid;
                 int typeInt;
                 if (int.TryParse(peNode.GetValue("type"), NumberStyles.Integer, ic, out typeInt))
-                    evt.eventType = (PartEventType)typeInt;
+                {
+                    if (Enum.IsDefined(typeof(PartEventType), typeInt))
+                        evt.eventType = (PartEventType)typeInt;
+                    else
+                        Log($"[Parsek] WARNING: Unknown PartEvent type id '{typeInt}' in recording {rec.RecordingId}");
+                }
                 evt.partName = peNode.GetValue("part") ?? "";
 
                 float val;
@@ -639,13 +649,25 @@ namespace Parsek
 
         internal static bool SaveRecordingFiles(Recording rec)
         {
-            if (rec == null || !RecordingPaths.ValidateRecordingId(rec.RecordingId))
+            if (rec == null)
+            {
+                Log("[Parsek] WARNING: SaveRecordingFiles called with null recording");
                 return false;
+            }
+            if (!RecordingPaths.ValidateRecordingId(rec.RecordingId))
+            {
+                Log($"[Parsek] WARNING: SaveRecordingFiles rejected invalid recording id '{rec.RecordingId}'");
+                return false;
+            }
 
             try
             {
                 string dir = RecordingPaths.EnsureRecordingsDirectory();
-                if (dir == null) return false;
+                if (dir == null)
+                {
+                    Log($"[Parsek] WARNING: SaveRecordingFiles could not resolve recordings directory for {rec.RecordingId}");
+                    return false;
+                }
 
                 // Save .prec trajectory file
                 var precNode = new ConfigNode("PARSEK_RECORDING");
@@ -655,18 +677,35 @@ namespace Parsek
 
                 string precPath = RecordingPaths.ResolveSaveScopedPath(
                     RecordingPaths.BuildTrajectoryRelativePath(rec.RecordingId));
+                if (string.IsNullOrEmpty(precPath))
+                {
+                    Log($"[Parsek] WARNING: SaveRecordingFiles could not resolve trajectory path for {rec.RecordingId}");
+                    return false;
+                }
                 SafeWriteConfigNode(precNode, precPath);
 
                 // Save _vessel.craft (always rewrite — snapshot can be mutated by spawn offset)
                 string vesselPath = RecordingPaths.ResolveSaveScopedPath(
                     RecordingPaths.BuildVesselSnapshotRelativePath(rec.RecordingId));
+                if (string.IsNullOrEmpty(vesselPath))
+                {
+                    Log($"[Parsek] WARNING: SaveRecordingFiles could not resolve vessel snapshot path for {rec.RecordingId}");
+                    return false;
+                }
                 if (rec.VesselSnapshot != null)
                 {
                     SafeWriteConfigNode(rec.VesselSnapshot, vesselPath);
                 }
                 else if (File.Exists(vesselPath))
                 {
-                    File.Delete(vesselPath);
+                    try
+                    {
+                        File.Delete(vesselPath);
+                    }
+                    catch (Exception ex)
+                    {
+                        Log($"[Parsek] WARNING: Failed deleting stale vessel snapshot '{vesselPath}': {ex.Message}");
+                    }
                 }
 
                 // Save _ghost.craft (write once — immutable after creation)
@@ -674,9 +713,17 @@ namespace Parsek
                 {
                     string ghostPath = RecordingPaths.ResolveSaveScopedPath(
                         RecordingPaths.BuildGhostSnapshotRelativePath(rec.RecordingId));
-                    if (!File.Exists(ghostPath))
+                    if (string.IsNullOrEmpty(ghostPath))
+                    {
+                        Log($"[Parsek] WARNING: SaveRecordingFiles could not resolve ghost snapshot path for {rec.RecordingId}");
+                    }
+                    else if (!File.Exists(ghostPath))
                         SafeWriteConfigNode(rec.GhostVisualSnapshot, ghostPath);
                 }
+
+                Log($"[Parsek] Saved recording files for {rec.RecordingId}: points={rec.Points.Count}, " +
+                    $"orbitSegments={rec.OrbitSegments.Count}, partEvents={rec.PartEvents.Count}, " +
+                    $"hasVesselSnapshot={rec.VesselSnapshot != null}, hasGhostSnapshot={rec.GhostVisualSnapshot != null}");
 
                 return true;
             }
@@ -689,8 +736,16 @@ namespace Parsek
 
         internal static bool LoadRecordingFiles(Recording rec)
         {
-            if (rec == null || !RecordingPaths.ValidateRecordingId(rec.RecordingId))
+            if (rec == null)
+            {
+                Log("[Parsek] WARNING: LoadRecordingFiles called with null recording");
                 return false;
+            }
+            if (!RecordingPaths.ValidateRecordingId(rec.RecordingId))
+            {
+                Log($"[Parsek] WARNING: LoadRecordingFiles rejected invalid recording id '{rec.RecordingId}'");
+                return false;
+            }
 
             try
             {
@@ -746,6 +801,10 @@ namespace Parsek
                 if (rec.GhostVisualSnapshot == null && rec.VesselSnapshot != null)
                     rec.GhostVisualSnapshot = rec.VesselSnapshot.CreateCopy();
 
+                Log($"[Parsek] Loaded recording files for {rec.RecordingId}: points={rec.Points.Count}, " +
+                    $"orbitSegments={rec.OrbitSegments.Count}, partEvents={rec.PartEvents.Count}, " +
+                    $"hasVesselSnapshot={rec.VesselSnapshot != null}, hasGhostSnapshot={rec.GhostVisualSnapshot != null}");
+
                 return true;
             }
             catch (Exception ex)
@@ -760,8 +819,27 @@ namespace Parsek
             string tmpPath = path + ".tmp";
             node.Save(tmpPath);
             if (File.Exists(path))
-                File.Delete(path);
-            File.Move(tmpPath, path);
+            {
+                try
+                {
+                    File.Delete(path);
+                }
+                catch (Exception ex)
+                {
+                    Log($"[Parsek] WARNING: Failed to delete existing file '{path}': {ex.Message}");
+                    throw;
+                }
+            }
+
+            try
+            {
+                File.Move(tmpPath, path);
+            }
+            catch (Exception ex)
+            {
+                Log($"[Parsek] WARNING: Failed to move temp file '{tmpPath}' to '{path}': {ex.Message}");
+                throw;
+            }
         }
 
         #endregion

--- a/Source/Parsek/TrajectoryMath.cs
+++ b/Source/Parsek/TrajectoryMath.cs
@@ -313,14 +313,21 @@ namespace Parsek
         /// </summary>
         internal static Quaternion SanitizeQuaternion(Quaternion q)
         {
-            if (float.IsNaN(q.x) || float.IsInfinity(q.x)) q.x = 0;
-            if (float.IsNaN(q.y) || float.IsInfinity(q.y)) q.y = 0;
-            if (float.IsNaN(q.z) || float.IsInfinity(q.z)) q.z = 0;
-            if (float.IsNaN(q.w) || float.IsInfinity(q.w)) q.w = 1;
+            bool hadBadComponent = false;
+            if (float.IsNaN(q.x) || float.IsInfinity(q.x)) { q.x = 0; hadBadComponent = true; }
+            if (float.IsNaN(q.y) || float.IsInfinity(q.y)) { q.y = 0; hadBadComponent = true; }
+            if (float.IsNaN(q.z) || float.IsInfinity(q.z)) { q.z = 0; hadBadComponent = true; }
+            if (float.IsNaN(q.w) || float.IsInfinity(q.w)) { q.w = 1; hadBadComponent = true; }
+
+            if (hadBadComponent)
+                ParsekLog.VerboseRateLimited("TrajectoryMath", "sanitize-quat",
+                    "SanitizeQuaternion replaced NaN/Infinity component(s)");
 
             float magnitude = Mathf.Sqrt(q.x * q.x + q.y * q.y + q.z * q.z + q.w * q.w);
             if (float.IsNaN(magnitude) || float.IsInfinity(magnitude) || magnitude < 0.001f)
             {
+                ParsekLog.VerboseRateLimited("TrajectoryMath", "sanitize-quat-identity",
+                    "SanitizeQuaternion returned identity (near-zero magnitude)");
                 return Quaternion.identity;
             }
 

--- a/Source/Parsek/TrajectoryMath.cs
+++ b/Source/Parsek/TrajectoryMath.cs
@@ -82,7 +82,11 @@ namespace Parsek
         internal static int FindWaypointIndex(List<TrajectoryPoint> points, ref int cachedIndex, double targetUT)
         {
             if (points.Count < 2)
+            {
+                ParsekLog.VerboseRateLimited("TrajectoryMath", "waypoint-too-few-points",
+                    $"FindWaypointIndex skipped: points.Count={points.Count} targetUT={targetUT:F3}", 5.0);
                 return -1;
+            }
 
             if (targetUT < points[0].ut)
                 return -1;
@@ -138,10 +142,14 @@ namespace Parsek
                 if (points[i].ut <= targetUT && points[i + 1].ut > targetUT)
                 {
                     cachedIndex = i;
+                    ParsekLog.VerboseRateLimited("TrajectoryMath", "waypoint-linear-fallback-hit",
+                        $"Linear fallback used for targetUT={targetUT:F3}, idx={i}", 5.0);
                     return i;
                 }
             }
 
+            ParsekLog.VerboseRateLimited("TrajectoryMath", "waypoint-index-not-found",
+                $"No waypoint index found for targetUT={targetUT:F3}", 5.0);
             return -1;
         }
 
@@ -159,7 +167,12 @@ namespace Parsek
             stats.orbitSegmentCount = rec.OrbitSegments.Count;
             stats.partEventCount = rec.PartEvents.Count;
 
-            if (rec.Points.Count == 0) return stats;
+            if (rec.Points.Count == 0)
+            {
+                ParsekLog.VerboseRateLimited("TrajectoryMath", "compute-stats-empty",
+                    "ComputeStats called with empty trajectory", 5.0);
+                return stats;
+            }
 
             var bodyCounts = new Dictionary<string, int>();
             double lat0 = rec.Points[0].latitude;

--- a/Source/Parsek/VesselSpawner.cs
+++ b/Source/Parsek/VesselSpawner.cs
@@ -68,7 +68,7 @@ namespace Parsek
                     return 0;
                 }
                 if (pv.vesselRef.orbitDriver == null)
-                    ParsekLog.Warn("Spawner", "WARNING: Spawned vessel has no orbitDriver — may not appear in map view");
+                    ParsekLog.Warn("Spawner", "Spawned vessel has no orbitDriver — may not appear in map view");
 
                 GameEvents.onNewVesselCreated.Fire(pv.vesselRef);
 
@@ -211,7 +211,7 @@ namespace Parsek
                     return 0;
                 }
                 if (pv.vesselRef.orbitDriver == null)
-                    ParsekLog.Warn("Spawner", "WARNING: SpawnAtPosition — vessel has no orbitDriver — may not appear in map view");
+                    ParsekLog.Warn("Spawner", "SpawnAtPosition vessel has no orbitDriver — may not appear in map view");
 
                 GameEvents.onNewVesselCreated.Fire(pv.vesselRef);
 
@@ -221,7 +221,7 @@ namespace Parsek
             }
             catch (Exception ex)
             {
-                ParsekLog.Info("Spawner", $"SpawnAtPosition failed: {ex.Message}");
+                ParsekLog.Error("Spawner", $"SpawnAtPosition failed: {ex.Message}");
                 return 0;
             }
         }
@@ -244,9 +244,9 @@ namespace Parsek
                 {
                     rec.SpawnAttempts++;
                     if (rec.SpawnAttempts >= maxSpawnAttempts)
-                        ParsekLog.Info("Spawner", $"Vessel spawn failed permanently for recording #{index} ({rec.VesselName}) after {maxSpawnAttempts} attempts");
+                        ParsekLog.Error("Spawner", $"Vessel spawn failed permanently for recording #{index} ({rec.VesselName}) after {maxSpawnAttempts} attempts");
                     else
-                        ParsekLog.Info("Spawner", $"Vessel spawn failed for recording #{index} ({rec.VesselName}) — will retry (attempt {rec.SpawnAttempts}/{maxSpawnAttempts})");
+                        ParsekLog.Warn("Spawner", $"Vessel spawn failed for recording #{index} ({rec.VesselName}) — will retry (attempt {rec.SpawnAttempts}/{maxSpawnAttempts})");
                 }
                 return;
             }
@@ -264,9 +264,9 @@ namespace Parsek
                 {
                     rec.SpawnAttempts++;
                     if (rec.SpawnAttempts >= maxSpawnAttempts)
-                        ParsekLog.Info("Spawner", $"Vessel spawn failed permanently for recording #{index} ({rec.VesselName}) after {maxSpawnAttempts} attempts");
+                        ParsekLog.Error("Spawner", $"Vessel spawn failed permanently for recording #{index} ({rec.VesselName}) after {maxSpawnAttempts} attempts");
                     else
-                        ParsekLog.Info("Spawner", $"Vessel spawn failed for recording #{index} ({rec.VesselName}) — will retry (attempt {rec.SpawnAttempts}/{maxSpawnAttempts})");
+                        ParsekLog.Warn("Spawner", $"Vessel spawn failed for recording #{index} ({rec.VesselName}) — will retry (attempt {rec.SpawnAttempts}/{maxSpawnAttempts})");
                 }
                 return;
             }
@@ -369,9 +369,9 @@ namespace Parsek
             {
                 rec.SpawnAttempts++;
                 if (rec.SpawnAttempts >= maxSpawnAttempts)
-                    ParsekLog.Info("Spawner", $"Vessel spawn failed permanently for recording #{index} ({rec.VesselName}) after {maxSpawnAttempts} attempts");
+                    ParsekLog.Error("Spawner", $"Vessel spawn failed permanently for recording #{index} ({rec.VesselName}) after {maxSpawnAttempts} attempts");
                 else
-                    ParsekLog.Info("Spawner", $"Vessel spawn failed for recording #{index} ({rec.VesselName}) — will retry (attempt {rec.SpawnAttempts}/{maxSpawnAttempts})");
+                    ParsekLog.Warn("Spawner", $"Vessel spawn failed for recording #{index} ({rec.VesselName}) — will retry (attempt {rec.SpawnAttempts}/{maxSpawnAttempts})");
             }
         }
 
@@ -718,7 +718,7 @@ namespace Parsek
 
             // Snapshot the vessel (works for regular vessels and EVA kerbals)
             if (!vessel.loaded)
-                ParsekLog.Warn("Spawner", "WARNING: Active vessel is unloaded at snapshot time — snapshot may be incomplete");
+                ParsekLog.Warn("Spawner", "Active vessel is unloaded at snapshot time — snapshot may be incomplete");
             ConfigNode node = TryBackupSnapshot(vessel);
             if (node == null)
             {

--- a/Source/Parsek/VesselSpawner.cs
+++ b/Source/Parsek/VesselSpawner.cs
@@ -654,6 +654,8 @@ namespace Parsek
             // Compute distance from launch
             var firstPoint = pending.Points[0];
             CelestialBody bodyFirst = FlightGlobals.Bodies?.Find(b => b.name == firstPoint.bodyName);
+            if (bodyFirst == null)
+                ParsekLog.Warn("Spawner", $"SnapshotVessel: body '{firstPoint.bodyName}' not found — distance computation will be skipped");
 
             if (vesselDestroyed)
             {
@@ -754,15 +756,22 @@ namespace Parsek
             Vector3d launchPos = bodyFirst.GetWorldSurfacePosition(
                 firstPoint.latitude, firstPoint.longitude, firstPoint.altitude);
             double maxDist = 0;
+            int bodyLookupFailCount = 0;
             for (int i = 1; i < pending.Points.Count; i++)
             {
                 var pt = pending.Points[i];
                 CelestialBody bodyPt = FlightGlobals.Bodies?.Find(b => b.name == pt.bodyName);
-                if (bodyPt == null) continue;
+                if (bodyPt == null)
+                {
+                    bodyLookupFailCount++;
+                    continue;
+                }
                 Vector3d ptPos = bodyPt.GetWorldSurfacePosition(pt.latitude, pt.longitude, pt.altitude);
                 double d = Vector3d.Distance(launchPos, ptPos);
                 if (d > maxDist) maxDist = d;
             }
+            if (bodyLookupFailCount > 0)
+                ParsekLog.Warn("Spawner", $"ComputeMaxDistance: {bodyLookupFailCount} points had unresolvable body names");
             pending.MaxDistanceFromLaunch = maxDist;
         }
 

--- a/Source/Parsek/VesselSpawner.cs
+++ b/Source/Parsek/VesselSpawner.cs
@@ -29,7 +29,7 @@ namespace Parsek
             }
             catch (Exception ex)
             {
-                ParsekLog.Log($"Failed to backup vessel snapshot: {ex.Message}");
+                ParsekLog.Error("Spawner", $"Failed to backup vessel snapshot: {ex.Message}");
                 return null;
             }
         }
@@ -64,20 +64,20 @@ namespace Parsek
 
                 if (pv.vesselRef == null)
                 {
-                    ParsekLog.Log("CRITICAL: ProtoVessel.Load() produced null vesselRef — vessel will not appear");
+                    ParsekLog.Error("Spawner", "CRITICAL: ProtoVessel.Load() produced null vesselRef — vessel will not appear");
                     return 0;
                 }
                 if (pv.vesselRef.orbitDriver == null)
-                    ParsekLog.Log("WARNING: Spawned vessel has no orbitDriver — may not appear in map view");
+                    ParsekLog.Warn("Spawner", "WARNING: Spawned vessel has no orbitDriver — may not appear in map view");
 
                 GameEvents.onNewVesselCreated.Fire(pv.vesselRef);
 
-                ParsekLog.Log($"Vessel respawned (sit={spawnNode.GetValue("sit")}, pid={pv.vesselRef.persistentId})");
+                ParsekLog.Info("Spawner", $"Vessel respawned (sit={spawnNode.GetValue("sit")}, pid={pv.vesselRef.persistentId})");
                 return pv.vesselRef.persistentId;
             }
             catch (System.Exception ex)
             {
-                ParsekLog.Log($"Failed to respawn vessel: {ex.Message}");
+                ParsekLog.Error("Spawner", $"Failed to respawn vessel: {ex.Message}");
                 return 0;
             }
         }
@@ -188,7 +188,7 @@ namespace Parsek
                     SaveOrbitToNode(orbit, orbitNode, body);
                     spawnNode.AddNode(orbitNode);
 
-                    ParsekLog.Log($"SpawnAtPosition: offset from {closestDist:F0}m to 250m from nearest vessel");
+                    ParsekLog.Info("Spawner", $"SpawnAtPosition: offset from {closestDist:F0}m to 250m from nearest vessel");
                 }
 
                 // Crew handling
@@ -207,21 +207,21 @@ namespace Parsek
 
                 if (pv.vesselRef == null)
                 {
-                    ParsekLog.Log("CRITICAL: SpawnAtPosition — ProtoVessel.Load() produced null vesselRef");
+                    ParsekLog.Error("Spawner", "CRITICAL: SpawnAtPosition — ProtoVessel.Load() produced null vesselRef");
                     return 0;
                 }
                 if (pv.vesselRef.orbitDriver == null)
-                    ParsekLog.Log("WARNING: SpawnAtPosition — vessel has no orbitDriver — may not appear in map view");
+                    ParsekLog.Warn("Spawner", "WARNING: SpawnAtPosition — vessel has no orbitDriver — may not appear in map view");
 
                 GameEvents.onNewVesselCreated.Fire(pv.vesselRef);
 
-                ParsekLog.Log($"SpawnAtPosition: vessel spawned (sit={sit}, pid={pv.vesselRef.persistentId}, " +
+                ParsekLog.Info("Spawner", $"SpawnAtPosition: vessel spawned (sit={sit}, pid={pv.vesselRef.persistentId}, " +
                     $"body={body.name}, alt={alt:F0}m)");
                 return pv.vesselRef.persistentId;
             }
             catch (Exception ex)
             {
-                ParsekLog.Log($"SpawnAtPosition failed: {ex.Message}");
+                ParsekLog.Info("Spawner", $"SpawnAtPosition failed: {ex.Message}");
                 return 0;
             }
         }
@@ -244,9 +244,9 @@ namespace Parsek
                 {
                     rec.SpawnAttempts++;
                     if (rec.SpawnAttempts >= maxSpawnAttempts)
-                        ParsekLog.Log($"Vessel spawn failed permanently for recording #{index} ({rec.VesselName}) after {maxSpawnAttempts} attempts");
+                        ParsekLog.Info("Spawner", $"Vessel spawn failed permanently for recording #{index} ({rec.VesselName}) after {maxSpawnAttempts} attempts");
                     else
-                        ParsekLog.Log($"Vessel spawn failed for recording #{index} ({rec.VesselName}) — will retry (attempt {rec.SpawnAttempts}/{maxSpawnAttempts})");
+                        ParsekLog.Info("Spawner", $"Vessel spawn failed for recording #{index} ({rec.VesselName}) — will retry (attempt {rec.SpawnAttempts}/{maxSpawnAttempts})");
                 }
                 return;
             }
@@ -255,7 +255,7 @@ namespace Parsek
             CelestialBody body = FlightGlobals.Bodies?.Find(b => b.name == lastPt.bodyName);
             if (body == null)
             {
-                ParsekLog.Log($"Body lookup failed for spawn: bodyName='{lastPt.bodyName}' not found — " +
+                ParsekLog.Info("Spawner", $"Body lookup failed for spawn: bodyName='{lastPt.bodyName}' not found — " +
                     $"falling back to RespawnVessel without position");
                 LogSpawnContext(rec, double.MaxValue);
                 rec.SpawnedVesselPersistentId = RespawnVessel(rec.VesselSnapshot, excludeCrew);
@@ -264,9 +264,9 @@ namespace Parsek
                 {
                     rec.SpawnAttempts++;
                     if (rec.SpawnAttempts >= maxSpawnAttempts)
-                        ParsekLog.Log($"Vessel spawn failed permanently for recording #{index} ({rec.VesselName}) after {maxSpawnAttempts} attempts");
+                        ParsekLog.Info("Spawner", $"Vessel spawn failed permanently for recording #{index} ({rec.VesselName}) after {maxSpawnAttempts} attempts");
                     else
-                        ParsekLog.Log($"Vessel spawn failed for recording #{index} ({rec.VesselName}) — will retry (attempt {rec.SpawnAttempts}/{maxSpawnAttempts})");
+                        ParsekLog.Info("Spawner", $"Vessel spawn failed for recording #{index} ({rec.VesselName}) — will retry (attempt {rec.SpawnAttempts}/{maxSpawnAttempts})");
                 }
                 return;
             }
@@ -353,7 +353,7 @@ namespace Parsek
                 SaveOrbitToNode(relocOrbit, relocOrbitNode, body);
                 rec.VesselSnapshot.AddNode(relocOrbitNode);
 
-                ParsekLog.Log($"Offset vessel #{index} ({rec.VesselName}) from {closestDist:F0}m to 250m from nearest vessel/recording");
+                ParsekLog.Info("Spawner", $"Offset vessel #{index} ({rec.VesselName}) from {closestDist:F0}m to 250m from nearest vessel/recording");
             }
 
             LogSpawnContext(rec, closestDist);
@@ -362,16 +362,16 @@ namespace Parsek
             rec.VesselSpawned = rec.SpawnedVesselPersistentId != 0;
             if (rec.VesselSpawned)
             {
-                ParsekLog.Log($"Vessel spawn for recording #{index} ({rec.VesselName})");
+                ParsekLog.Info("Spawner", $"Vessel spawn for recording #{index} ({rec.VesselName})");
                 ParsekLog.ScreenMessage($"Vessel '{rec.VesselName}' has appeared!", 4f);
             }
             else
             {
                 rec.SpawnAttempts++;
                 if (rec.SpawnAttempts >= maxSpawnAttempts)
-                    ParsekLog.Log($"Vessel spawn failed permanently for recording #{index} ({rec.VesselName}) after {maxSpawnAttempts} attempts");
+                    ParsekLog.Info("Spawner", $"Vessel spawn failed permanently for recording #{index} ({rec.VesselName}) after {maxSpawnAttempts} attempts");
                 else
-                    ParsekLog.Log($"Vessel spawn failed for recording #{index} ({rec.VesselName}) — will retry (attempt {rec.SpawnAttempts}/{maxSpawnAttempts})");
+                    ParsekLog.Info("Spawner", $"Vessel spawn failed for recording #{index} ({rec.VesselName}) — will retry (attempt {rec.SpawnAttempts}/{maxSpawnAttempts})");
             }
         }
 
@@ -424,7 +424,7 @@ namespace Parsek
                 }
 
                 if (excludeCrew != null)
-                    ParsekLog.Log($"Excluding EVA'd crew from chain vessel spawn: [{string.Join(", ", excludeCrew)}]");
+                    ParsekLog.Info("Spawner", $"Excluding EVA'd crew from chain vessel spawn: [{string.Join(", ", excludeCrew)}]");
                 return excludeCrew;
             }
 
@@ -441,7 +441,7 @@ namespace Parsek
             }
 
             if (excludeCrew != null)
-                ParsekLog.Log($"Excluding EVA'd crew from parent spawn: [{string.Join(", ", excludeCrew)}]");
+                ParsekLog.Info("Spawner", $"Excluding EVA'd crew from parent spawn: [{string.Join(", ", excludeCrew)}]");
             return excludeCrew;
         }
 
@@ -459,7 +459,7 @@ namespace Parsek
                 }
             }
             string crewStr = allCrew.Count > 0 ? $", crew=[{string.Join(", ", allCrew)}]" : "";
-            ParsekLog.Log($"Spawning vessel: \"{rec.VesselName}\" sit={sit}{crewStr}, " +
+            ParsekLog.Info("Spawner", $"Spawning vessel: \"{rec.VesselName}\" sit={sit}{crewStr}, " +
                 $"nearest vessel={closestDist:F0}m");
         }
 
@@ -469,17 +469,22 @@ namespace Parsek
             {
                 ProtoVessel pv = new ProtoVessel(vesselNode, HighLogic.CurrentGame);
                 ShipConstruction.RecoverVesselFromFlight(pv, HighLogic.CurrentGame.flightState, true);
-                ParsekLog.Log("Vessel recovered for funds");
+                ParsekLog.Info("Spawner", "Vessel recovered for funds");
             }
             catch (System.Exception ex)
             {
-                ParsekLog.Log($"Failed to recover vessel: {ex.Message}");
+                ParsekLog.Error("Spawner", $"Failed to recover vessel: {ex.Message}");
             }
         }
 
         public static void RemoveSpecificCrewFromSnapshot(ConfigNode snapshot, HashSet<string> crewNames)
         {
-            if (snapshot == null || crewNames == null || crewNames.Count == 0) return;
+            if (snapshot == null || crewNames == null || crewNames.Count == 0)
+            {
+                ParsekLog.VerboseRateLimited("Spawner", "remove-specific-crew-skipped",
+                    "RemoveSpecificCrewFromSnapshot skipped due to missing snapshot or crew set", 5.0);
+                return;
+            }
 
             foreach (ConfigNode partNode in snapshot.GetNodes("PART"))
             {
@@ -493,7 +498,7 @@ namespace Parsek
                     if (crewNames.Contains(name))
                     {
                         removedAny = true;
-                        ParsekLog.Log($"Removed EVA'd crew '{name}' from vessel snapshot");
+                        ParsekLog.Info("Spawner", $"Removed EVA'd crew '{name}' from vessel snapshot");
                     }
                     else
                     {
@@ -513,7 +518,11 @@ namespace Parsek
         public static void RemoveDeadCrewFromSnapshot(ConfigNode snapshot)
         {
             var roster = HighLogic.CurrentGame?.CrewRoster;
-            if (roster == null) return;
+            if (roster == null)
+            {
+                ParsekLog.Warn("Spawner", "RemoveDeadCrewFromSnapshot skipped: crew roster unavailable");
+                return;
+            }
 
             var reserved = ParsekScenario.CrewReplacements;
             int removedCount = 0;
@@ -546,7 +555,7 @@ namespace Parsek
                              pcm.rosterStatus == ProtoCrewMember.RosterStatus.Missing))
                         {
                             isDead = true;
-                            ParsekLog.Log($"Removed dead/missing crew '{name}' from vessel snapshot");
+                            ParsekLog.Info("Spawner", $"Removed dead/missing crew '{name}' from vessel snapshot");
                             removedCount++;
                             break;
                         }
@@ -566,7 +575,7 @@ namespace Parsek
             }
 
             if (removedCount > 0)
-                ParsekLog.Log($"Spawn prep: removed {removedCount} dead/missing crew from snapshot");
+                ParsekLog.Info("Spawner", $"Spawn prep: removed {removedCount} dead/missing crew from snapshot");
         }
 
         /// <summary>
@@ -577,7 +586,11 @@ namespace Parsek
         public static void EnsureCrewExistInRoster(ConfigNode snapshot)
         {
             var roster = HighLogic.CurrentGame?.CrewRoster;
-            if (roster == null) return;
+            if (roster == null)
+            {
+                ParsekLog.Warn("Spawner", "EnsureCrewExistInRoster skipped: crew roster unavailable");
+                return;
+            }
 
             int createdCount = 0;
             foreach (ConfigNode partNode in snapshot.GetNodes("PART"))
@@ -605,14 +618,14 @@ namespace Parsek
                     {
                         newCrew.ChangeName(name);
                         newCrew.rosterStatus = ProtoCrewMember.RosterStatus.Assigned;
-                        ParsekLog.Log($"Created missing crew '{name}' in roster for vessel spawn");
+                        ParsekLog.Info("Spawner", $"Created missing crew '{name}' in roster for vessel spawn");
                         createdCount++;
                     }
                 }
             }
 
             if (createdCount > 0)
-                ParsekLog.Log($"Spawn prep: created {createdCount} missing crew in roster");
+                ParsekLog.Info("Spawner", $"Spawn prep: created {createdCount} missing crew in roster");
         }
 
         public static bool VesselExistsByPid(uint pid)
@@ -632,7 +645,11 @@ namespace Parsek
             Vessel vesselOverride = null,
             ConfigNode destroyedFallbackSnapshot = null)
         {
-            if (pending == null || pending.Points.Count == 0) return;
+            if (pending == null || pending.Points.Count == 0)
+            {
+                ParsekLog.Warn("Spawner", "SnapshotVessel skipped: pending recording is null or has no points");
+                return;
+            }
 
             // Compute distance from launch
             var firstPoint = pending.Points[0];
@@ -669,7 +686,7 @@ namespace Parsek
                 ComputeMaxDistance(pending, bodyFirst, firstPoint);
 
                 pending.VesselSituation = pending.VesselSnapshot != null ? "Destroyed (snapshot kept)" : "Destroyed";
-                ParsekLog.Log($"Vessel was destroyed during recording. Distance from launch: {pending.DistanceFromLaunch:F0}m, " +
+                ParsekLog.Info("Spawner", $"Vessel was destroyed during recording. Distance from launch: {pending.DistanceFromLaunch:F0}m, " +
                     $"Max distance: {pending.MaxDistanceFromLaunch:F0}m, Snapshot kept: {pending.VesselSnapshot != null}");
                 return;
             }
@@ -684,7 +701,7 @@ namespace Parsek
                 pending.GhostGeometryCaptureStrategy = "live_hierarchy_probe_v1";
                 pending.GhostGeometryProbeStatus = "no_active_vessel";
                 pending.VesselSituation = "Unknown (no active vessel)";
-                ParsekLog.Log("No active vessel at snapshot time");
+                ParsekLog.Info("Spawner", "No active vessel at snapshot time");
                 return;
             }
 
@@ -701,7 +718,7 @@ namespace Parsek
 
             // Snapshot the vessel (works for regular vessels and EVA kerbals)
             if (!vessel.loaded)
-                ParsekLog.Log("Warning: Active vessel is unloaded at snapshot time — snapshot may be incomplete");
+                ParsekLog.Warn("Spawner", "WARNING: Active vessel is unloaded at snapshot time — snapshot may be incomplete");
             ConfigNode node = TryBackupSnapshot(vessel);
             if (node == null)
             {
@@ -712,7 +729,7 @@ namespace Parsek
                 pending.GhostGeometryCaptureStrategy = "live_hierarchy_probe_v1";
                 pending.GhostGeometryProbeStatus = "snapshot_backup_failed";
                 pending.VesselSituation = "Unknown (snapshot failed)";
-                ParsekLog.Log("Failed to backup active vessel at snapshot time");
+                ParsekLog.Error("Spawner", "Failed to backup active vessel at snapshot time");
                 return;
             }
             pending.VesselSnapshot = node;
@@ -726,7 +743,7 @@ namespace Parsek
             // Atomic capture: snapshot and ghost geometry metadata are captured together.
             GhostGeometryCapture.CaptureStub(pending, vessel);
 
-            ParsekLog.Log($"Vessel snapshot taken. Distance from launch: {pending.DistanceFromLaunch:F0}m, " +
+            ParsekLog.Info("Spawner", $"Vessel snapshot taken. Distance from launch: {pending.DistanceFromLaunch:F0}m, " +
                 $"Max distance: {pending.MaxDistanceFromLaunch:F0}m, Situation: {pending.VesselSituation}");
         }
 
@@ -754,14 +771,23 @@ namespace Parsek
         {
             bool landedLike = IsLandedLikeSnapshot(rec?.VesselSnapshot);
             bool hasSnapshotAlt = TryGetSnapshotDouble(rec?.VesselSnapshot, "alt", out double snapshotAlt);
+            double selectedAltitude;
             if (landedLike)
             {
                 double terrainAlt = body.TerrainAltitude(latitude, longitude);
                 bool terrainValid = !double.IsNaN(terrainAlt) && !double.IsInfinity(terrainAlt);
-                return SelectRelocatedAltitude(landedLike, terrainAlt, terrainValid, snapshotAlt, hasSnapshotAlt);
+                selectedAltitude = SelectRelocatedAltitude(landedLike, terrainAlt, terrainValid, snapshotAlt, hasSnapshotAlt);
+                ParsekLog.Verbose("Spawner",
+                    $"Relocation altitude selected={selectedAltitude:F1} source={(terrainValid ? "terrain" : hasSnapshotAlt ? "snapshot" : "fallback")} " +
+                    $"landedLike={landedLike} terrainValid={terrainValid} snapshotAltSet={hasSnapshotAlt}");
+                return selectedAltitude;
             }
 
-            return SelectRelocatedAltitude(landedLike, 0.0, false, snapshotAlt, hasSnapshotAlt);
+            selectedAltitude = SelectRelocatedAltitude(landedLike, 0.0, false, snapshotAlt, hasSnapshotAlt);
+            ParsekLog.Verbose("Spawner",
+                $"Relocation altitude selected={selectedAltitude:F1} source={(hasSnapshotAlt ? "snapshot" : "fallback")} " +
+                $"landedLike={landedLike}");
+            return selectedAltitude;
         }
 
         private static bool IsLandedLikeSnapshot(ConfigNode snapshot)
@@ -856,7 +882,7 @@ namespace Parsek
             { spawnNode.AddNode("VESSELMODULES"); fixCount++; }
 
             if (fixCount > 0)
-                ParsekLog.Log($"Spawn prep: added {fixCount} missing node(s) to snapshot");
+                ParsekLog.Info("Spawner", $"Spawn prep: added {fixCount} missing node(s) to snapshot");
         }
 
         internal static double SelectRelocatedAltitude(

--- a/Source/README.md
+++ b/Source/README.md
@@ -87,7 +87,17 @@ cd Source/Parsek.Tests
 dotnet test
 ```
 
-532 tests total: 531 pass, 1 skipped (QuaternionSlerp NaN edge case — Unity behavior).
+652 tests total: 651 pass, 1 skipped (QuaternionSlerp NaN edge case — Unity behavior).
+
+### Live KSP Log Validation
+
+After running a manual in-game scenario, validate the latest Parsek session in `KSP.log`:
+
+```bash
+pwsh -File scripts/validate-ksp-log.ps1
+```
+
+The script exits non-zero if required log contracts fail.
 
 ## Testing In-Game
 

--- a/docs/manual-testing/test-general.md
+++ b/docs/manual-testing/test-general.md
@@ -243,3 +243,12 @@ Search `KSP.log` for `[Parsek]` and `[Parsek Scenario]`:
 - No unexpected errors or exceptions
 - Auto-record triggers logged correctly
 - Crew replacement actions logged as "Hired replacement ..." / "Removed replacement ..."
+
+### Post-run validation command
+After running a manual scenario, run:
+
+```bash
+pwsh -File scripts/validate-ksp-log.ps1
+```
+
+Treat a non-zero exit as a failed local validation.

--- a/scripts/validate-ksp-log.ps1
+++ b/scripts/validate-ksp-log.ps1
@@ -1,0 +1,73 @@
+param(
+    [string]$LogPath,
+    [switch]$NoBuild
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$attemptedPaths = @()
+
+if (-not [string]::IsNullOrWhiteSpace($LogPath)) {
+    $attemptedPaths += $LogPath
+}
+
+if (-not [string]::IsNullOrWhiteSpace($env:KSPDIR)) {
+    $attemptedPaths += (Join-Path $env:KSPDIR "KSP.log")
+}
+
+$parentRoot = (Resolve-Path (Join-Path $repoRoot "..")).Path
+$attemptedPaths += (Join-Path $parentRoot "Kerbal Space Program\KSP.log")
+
+$resolvedLogPath = $null
+foreach ($candidate in $attemptedPaths) {
+    if ([string]::IsNullOrWhiteSpace($candidate)) { continue }
+    try {
+        $resolved = (Resolve-Path $candidate -ErrorAction Stop).Path
+    } catch {
+        continue
+    }
+
+    if (Test-Path $resolved -PathType Leaf) {
+        $resolvedLogPath = $resolved
+        break
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($resolvedLogPath)) {
+    $formattedAttempts = if ($attemptedPaths.Count -gt 0) {
+        ($attemptedPaths | ForEach-Object { " - $_" }) -join [Environment]::NewLine
+    } else {
+        " - (no paths were generated)"
+    }
+
+    Write-Error @"
+KSP.log was not found. Validation cannot continue.
+Attempted paths:
+$formattedAttempts
+"@
+    exit 1
+}
+
+$env:PARSEK_LIVE_VALIDATE_REQUIRED = "1"
+$env:PARSEK_LIVE_KSP_LOG_PATH = $resolvedLogPath
+
+$testArgs = @(
+    "test",
+    "Source/Parsek.Tests/Parsek.Tests.csproj",
+    "--filter", "FullyQualifiedName~LiveKspLogValidationTests.ValidateLatestSession",
+    "-v", "minimal"
+)
+
+if ($NoBuild) {
+    $testArgs += "--no-build"
+}
+
+Write-Host "Validating latest Parsek session in '$resolvedLogPath'"
+dotnet @testArgs
+
+if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}
+
+Write-Host "KSP.log validation passed."


### PR DESCRIPTION
## Summary
- add structured `ParsekLog` levels (`INFO`/`VERBOSE`/`WARN`/`ERROR`) with unified formatting
- add verbose-mode control in `ParsekSettings` and expose it in the in-game settings UI (default = verbose)
- unify legacy logging paths (`Debug.Log`, store/scenario wrappers) into subsystem-based Parsek logging
- add exhaustive diagnostics across recorder, flight, spawner, game-state, merge, ghost, path, toolbar, harmony, and physics patch code
- add rate-limited verbose logging for hot paths to avoid log spam while preserving debugging signal
- add boundary parse/version/fallback diagnostics for save/load and serialization paths

## Validation
- `dotnet build` (`Source/Parsek`): pass (deployment copy warnings only due file lock/access)
- `dotnet test --filter "FullyQualifiedName!~InjectAllRecordings"` (`Source/Parsek.Tests`): pass (632 passed, 0 failed, 1 skipped)
- full `dotnet test`: single known failure `InjectAllRecordings` due unauthorized access to KSP save file path in this environment
