### PR TITLE
Remove Recover option from merge dialog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,9 +167,8 @@ See `docs/synthetic-recordings.md` for builder API docs.
 4. Press **F9** to stop recording
 5. Revert to Launch (Esc → Revert to Launch)
 6. A context-aware merge dialog appears with recommended action:
-   - **Vessel barely moved (<100m):** "Merge + Recover" (default), "Merge + Keep Vessel", "Discard"
-   - **Vessel destroyed:** "Merge to Timeline" (default), "Discard"
-   - **Vessel intact, moved far:** "Merge + Keep Vessel" (default), "Merge + Recover", "Discard"
+   - **Vessel destroyed:** "Merge to Timeline", "Discard"
+   - **Vessel intact:** "Merge to Timeline", "Discard"
 7. Wait on the pad until UT reaches original recording timestamps
 8. Ghost vessel appears (opaque replica with original part textures) and replays previous flight
 9. Engine flames and smoke appear on the ghost during burn phases
@@ -177,12 +176,11 @@ See `docs/synthetic-recordings.md` for builder API docs.
 11. Funds/science/reputation deltas are applied at the correct UT
 
 **Vessel persistence test:**
-1. Launch to orbit → F9 record → revert → "Merge + Keep Vessel"
+1. Launch to orbit → F9 record → revert → "Merge to Timeline"
 2. Go to Tracking Station → vessel appears in orbit
-3. Or choose "Merge + Recover" → funds credited, no vessel in orbit
 
 **Crew replacement test:**
-1. Record with Jeb → revert → "Merge + Keep Vessel"
+1. Record with Jeb → revert → "Merge to Timeline"
 2. Check Astronaut Complex: Jeb is Assigned, a new kerbal with same trait appeared
 3. Launch new flight — replacement kerbal is available in crew selection
 4. Wait for EndUT → Jeb's vessel spawns, replacement is removed from roster

--- a/Source/Parsek.Tests/ChainTests.cs
+++ b/Source/Parsek.Tests/ChainTests.cs
@@ -118,48 +118,30 @@ namespace Parsek.Tests
         #region GetRecommendedAction
 
         [Fact]
-        public void GetRecommendedAction_DestroyedNearPad_ReturnsRecover()
+        public void GetRecommendedAction_Destroyed_ReturnsGhostOnly()
         {
-            var result = RecordingStore.GetRecommendedAction(50, destroyed: true, hasSnapshot: false);
-            Assert.Equal(RecordingStore.MergeDefault.Recover, result);
+            var result = RecordingStore.GetRecommendedAction(destroyed: true, hasSnapshot: false);
+            Assert.Equal(RecordingStore.MergeDefault.GhostOnly, result);
         }
 
         [Fact]
-        public void GetRecommendedAction_DestroyedFarAway_ReturnsMergeOnly()
+        public void GetRecommendedAction_DestroyedWithSnapshot_ReturnsGhostOnly()
         {
-            var result = RecordingStore.GetRecommendedAction(500, destroyed: true, hasSnapshot: false);
-            Assert.Equal(RecordingStore.MergeDefault.MergeOnly, result);
+            var result = RecordingStore.GetRecommendedAction(destroyed: true, hasSnapshot: true);
+            Assert.Equal(RecordingStore.MergeDefault.GhostOnly, result);
         }
 
         [Fact]
-        public void GetRecommendedAction_NoSnapshot_FarAway_ReturnsMergeOnly()
+        public void GetRecommendedAction_NoSnapshot_ReturnsGhostOnly()
         {
-            var result = RecordingStore.GetRecommendedAction(500, destroyed: false, hasSnapshot: false);
-            Assert.Equal(RecordingStore.MergeDefault.MergeOnly, result);
+            var result = RecordingStore.GetRecommendedAction(destroyed: false, hasSnapshot: false);
+            Assert.Equal(RecordingStore.MergeDefault.GhostOnly, result);
         }
 
         [Fact]
-        public void GetRecommendedAction_IntactNearPad_ShortDuration_ReturnsRecover()
+        public void GetRecommendedAction_IntactWithSnapshot_ReturnsPersist()
         {
-            var result = RecordingStore.GetRecommendedAction(50, destroyed: false, hasSnapshot: true,
-                duration: 5, maxDistance: 50);
-            Assert.Equal(RecordingStore.MergeDefault.Recover, result);
-        }
-
-        [Fact]
-        public void GetRecommendedAction_IntactFarAway_ReturnsPersist()
-        {
-            var result = RecordingStore.GetRecommendedAction(500, destroyed: false, hasSnapshot: true,
-                duration: 60, maxDistance: 500);
-            Assert.Equal(RecordingStore.MergeDefault.Persist, result);
-        }
-
-        [Fact]
-        public void GetRecommendedAction_IntactNearPad_LongDuration_HighMaxDist_ReturnsPersist()
-        {
-            // Near pad now but traveled far — still persist
-            var result = RecordingStore.GetRecommendedAction(50, destroyed: false, hasSnapshot: true,
-                duration: 60, maxDistance: 5000);
+            var result = RecordingStore.GetRecommendedAction(destroyed: false, hasSnapshot: true);
             Assert.Equal(RecordingStore.MergeDefault.Persist, result);
         }
 

--- a/Source/Parsek.Tests/RecordingStoreTests.cs
+++ b/Source/Parsek.Tests/RecordingStoreTests.cs
@@ -558,9 +558,9 @@ namespace Parsek.Tests
         {
             // destroyed=true takes priority over hasSnapshot=true
             var result = RecordingStore.GetRecommendedAction(
-                distance: 500, destroyed: true, hasSnapshot: true);
+                destroyed: true, hasSnapshot: true);
 
-            Assert.Equal(RecordingStore.MergeDefault.MergeOnly, result);
+            Assert.Equal(RecordingStore.MergeDefault.GhostOnly, result);
         }
     }
 
@@ -815,28 +815,14 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void BuildMergeMessage_Recover_MentionsLaunchSite()
-        {
-            var rec = new RecordingStore.Recording { VesselName = "TestShip" };
-            rec.Points.AddRange(MakePoints(3));
-            rec.DistanceFromLaunch = 50;
-
-            string msg = MergeDialog.BuildMergeMessage(rec, 30,
-                RecordingStore.MergeDefault.Recover);
-
-            Assert.Contains("TestShip", msg);
-            Assert.Contains("launch site", msg);
-        }
-
-        [Fact]
-        public void BuildMergeMessage_MergeOnly_MentionsDestroyed()
+        public void BuildMergeMessage_GhostOnly_MentionsDestroyed()
         {
             var rec = new RecordingStore.Recording { VesselName = "Boom" };
             rec.Points.AddRange(MakePoints(5));
             rec.VesselDestroyed = true;
 
             string msg = MergeDialog.BuildMergeMessage(rec, 60,
-                RecordingStore.MergeDefault.MergeOnly);
+                RecordingStore.MergeDefault.GhostOnly);
 
             Assert.Contains("destroyed", msg);
         }
@@ -877,7 +863,7 @@ namespace Parsek.Tests
             rec.Points.AddRange(MakePoints(7));
 
             string msg = MergeDialog.BuildMergeMessage(rec, 60,
-                RecordingStore.MergeDefault.Recover);
+                RecordingStore.MergeDefault.GhostOnly);
 
             Assert.Contains("7", msg);
         }
@@ -889,7 +875,7 @@ namespace Parsek.Tests
             rec.Points.AddRange(MakePoints(3));
 
             string msg = MergeDialog.BuildMergeMessage(rec, 45.3,
-                RecordingStore.MergeDefault.Recover);
+                RecordingStore.MergeDefault.GhostOnly);
 
             // Duration is locale-formatted ("45.3" or "45,3"), just check it contains "45"
             Assert.Contains("45", msg);

--- a/Source/Parsek.Tests/RecordingStoreTests.cs
+++ b/Source/Parsek.Tests/RecordingStoreTests.cs
@@ -815,7 +815,7 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void BuildMergeMessage_GhostOnly_MentionsDestroyed()
+        public void BuildMergeMessage_GhostOnly_Destroyed_MentionsDestroyed()
         {
             var rec = new RecordingStore.Recording { VesselName = "Boom" };
             rec.Points.AddRange(MakePoints(5));
@@ -825,6 +825,20 @@ namespace Parsek.Tests
                 RecordingStore.MergeDefault.GhostOnly);
 
             Assert.Contains("destroyed", msg);
+        }
+
+        [Fact]
+        public void BuildMergeMessage_GhostOnly_NotDestroyed_DoesNotMentionDestroyed()
+        {
+            var rec = new RecordingStore.Recording { VesselName = "Phantom" };
+            rec.Points.AddRange(MakePoints(5));
+            rec.VesselDestroyed = false;
+
+            string msg = MergeDialog.BuildMergeMessage(rec, 60,
+                RecordingStore.MergeDefault.GhostOnly);
+
+            Assert.DoesNotContain("destroyed", msg);
+            Assert.Contains("Recording captured", msg);
         }
 
         [Fact]

--- a/Source/Parsek.Tests/VesselPersistenceTests.cs
+++ b/Source/Parsek.Tests/VesselPersistenceTests.cs
@@ -5,186 +5,41 @@ namespace Parsek.Tests
     public class VesselPersistenceTests
     {
         [Fact]
-        public void GetMergeDefault_ShortDistance_ReturnsRecover()
+        public void GetMergeDefault_IntactWithSnapshot_ReturnsPersist()
         {
             var result = RecordingStore.GetRecommendedAction(
-                distance: 50, destroyed: false, hasSnapshot: true);
-
-            Assert.Equal(RecordingStore.MergeDefault.Recover, result);
-        }
-
-        [Fact]
-        public void GetMergeDefault_ZeroDistance_ReturnsRecover()
-        {
-            var result = RecordingStore.GetRecommendedAction(
-                distance: 0, destroyed: false, hasSnapshot: true);
-
-            Assert.Equal(RecordingStore.MergeDefault.Recover, result);
-        }
-
-        [Fact]
-        public void GetMergeDefault_ShortDistance_DestroyedStillRecovers()
-        {
-            // Even if destroyed, short distance means recover
-            var result = RecordingStore.GetRecommendedAction(
-                distance: 10, destroyed: true, hasSnapshot: false);
-
-            Assert.Equal(RecordingStore.MergeDefault.Recover, result);
-        }
-
-        [Fact]
-        public void GetMergeDefault_FarAndDestroyed_ReturnsMergeOnly()
-        {
-            var result = RecordingStore.GetRecommendedAction(
-                distance: 500, destroyed: true, hasSnapshot: false);
-
-            Assert.Equal(RecordingStore.MergeDefault.MergeOnly, result);
-        }
-
-        [Fact]
-        public void GetMergeDefault_FarAndIntact_ReturnsPersist()
-        {
-            var result = RecordingStore.GetRecommendedAction(
-                distance: 500, destroyed: false, hasSnapshot: true);
+                destroyed: false, hasSnapshot: true);
 
             Assert.Equal(RecordingStore.MergeDefault.Persist, result);
         }
 
         [Fact]
-        public void GetMergeDefault_ExactThreshold_ReturnsPersist()
+        public void GetMergeDefault_DestroyedNoSnapshot_ReturnsGhostOnly()
         {
-            // distance == 100m is >= 100, so should be Persist
             var result = RecordingStore.GetRecommendedAction(
-                distance: 100, destroyed: false, hasSnapshot: true);
+                destroyed: true, hasSnapshot: false);
 
-            Assert.Equal(RecordingStore.MergeDefault.Persist, result);
+            Assert.Equal(RecordingStore.MergeDefault.GhostOnly, result);
         }
 
         [Fact]
-        public void GetMergeDefault_JustBelowThreshold_ReturnsRecover()
+        public void GetMergeDefault_DestroyedWithSnapshot_ReturnsGhostOnly()
         {
+            // destroyed=true takes priority over hasSnapshot=true
             var result = RecordingStore.GetRecommendedAction(
-                distance: 99.99, destroyed: false, hasSnapshot: true);
+                destroyed: true, hasSnapshot: true);
 
-            Assert.Equal(RecordingStore.MergeDefault.Recover, result);
+            Assert.Equal(RecordingStore.MergeDefault.GhostOnly, result);
         }
 
         [Fact]
-        public void GetMergeDefault_NoSnapshot_FarNotDestroyed_ReturnsMergeOnly()
+        public void GetMergeDefault_NotDestroyedNoSnapshot_ReturnsGhostOnly()
         {
-            // Defensive: far + not destroyed but snapshot missing
+            // Defensive: not destroyed but snapshot missing
             var result = RecordingStore.GetRecommendedAction(
-                distance: 500, destroyed: false, hasSnapshot: false);
+                destroyed: false, hasSnapshot: false);
 
-            Assert.Equal(RecordingStore.MergeDefault.MergeOnly, result);
-        }
-
-        // --- Returned-to-pad tests ---
-
-        [Fact]
-        public void GetMergeDefault_ShortDistance_LongDuration_HighMaxDist_ReturnsPersist()
-        {
-            // Real mission that returned to pad — should persist
-            var result = RecordingStore.GetRecommendedAction(
-                distance: 50, destroyed: false, hasSnapshot: true,
-                duration: 60, maxDistance: 5000);
-
-            Assert.Equal(RecordingStore.MergeDefault.Persist, result);
-        }
-
-        [Fact]
-        public void GetMergeDefault_ShortDistance_LongDuration_LowMaxDist_ReturnsRecover()
-        {
-            // Sat on pad for a while but didn't go anywhere
-            var result = RecordingStore.GetRecommendedAction(
-                distance: 50, destroyed: false, hasSnapshot: true,
-                duration: 60, maxDistance: 50);
-
-            Assert.Equal(RecordingStore.MergeDefault.Recover, result);
-        }
-
-        [Fact]
-        public void GetMergeDefault_ShortDistance_ShortDuration_HighMaxDist_ReturnsRecover()
-        {
-            // Quick bounce — short duration means recover even with high max distance
-            var result = RecordingStore.GetRecommendedAction(
-                distance: 50, destroyed: false, hasSnapshot: true,
-                duration: 5, maxDistance: 200);
-
-            Assert.Equal(RecordingStore.MergeDefault.Recover, result);
-        }
-
-        [Fact]
-        public void GetMergeDefault_ShortDistance_LongDuration_ExactMaxDistThreshold_ReturnsRecover()
-        {
-            // maxDistance exactly 100 is <= 100, so Recover
-            var result = RecordingStore.GetRecommendedAction(
-                distance: 50, destroyed: false, hasSnapshot: true,
-                duration: 60, maxDistance: 100);
-
-            Assert.Equal(RecordingStore.MergeDefault.Recover, result);
-        }
-
-        [Fact]
-        public void GetMergeDefault_ShortDistance_ExactDurationThreshold_HighMaxDist_ReturnsRecover()
-        {
-            // duration exactly 10 is <= 10, so Recover
-            var result = RecordingStore.GetRecommendedAction(
-                distance: 50, destroyed: false, hasSnapshot: true,
-                duration: 10, maxDistance: 5000);
-
-            Assert.Equal(RecordingStore.MergeDefault.Recover, result);
-        }
-
-        [Fact]
-        public void GetMergeDefault_ShortDistance_JustAboveBothThresholds_ReturnsPersist()
-        {
-            // Both duration > 10 and maxDistance > 100 → Persist
-            var result = RecordingStore.GetRecommendedAction(
-                distance: 50, destroyed: false, hasSnapshot: true,
-                duration: 10.1, maxDistance: 100.1);
-
-            Assert.Equal(RecordingStore.MergeDefault.Persist, result);
-        }
-
-        [Fact]
-        public void GetMergeDefault_NegativeDistance_TreatsAsRecover()
-        {
-            // Negative distance (shouldn't happen, but test defensive behavior)
-            var result = RecordingStore.GetRecommendedAction(
-                distance: -50, destroyed: false, hasSnapshot: true);
-
-            Assert.Equal(RecordingStore.MergeDefault.Recover, result);
-        }
-
-        [Fact]
-        public void GetMergeDefault_ZeroDistance_Destroyed_Recovers()
-        {
-            var result = RecordingStore.GetRecommendedAction(
-                distance: 0, destroyed: true, hasSnapshot: false);
-
-            Assert.Equal(RecordingStore.MergeDefault.Recover, result);
-        }
-
-        [Fact]
-        public void GetMergeDefault_BoundaryDuration_ExactlyTen()
-        {
-            // duration=10.0 exactly is <= 10, so still Recover
-            var result = RecordingStore.GetRecommendedAction(
-                distance: 50, destroyed: false, hasSnapshot: true,
-                duration: 10.0, maxDistance: 5000);
-
-            Assert.Equal(RecordingStore.MergeDefault.Recover, result);
-        }
-
-        [Fact]
-        public void GetMergeDefault_LargeDistance_AllFlags()
-        {
-            // Large distance + destroyed + hasSnapshot → destroyed takes priority → MergeOnly
-            var result = RecordingStore.GetRecommendedAction(
-                distance: 50000, destroyed: true, hasSnapshot: true);
-
-            Assert.Equal(RecordingStore.MergeDefault.MergeOnly, result);
+            Assert.Equal(RecordingStore.MergeDefault.GhostOnly, result);
         }
     }
 }

--- a/Source/Parsek/MergeDialog.cs
+++ b/Source/Parsek/MergeDialog.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using UnityEngine;
 
@@ -44,20 +45,17 @@ namespace Parsek
         {
             double duration = pending.EndUT - pending.StartUT;
             var recommended = RecordingStore.GetRecommendedAction(
-                pending.DistanceFromLaunch, pending.VesselDestroyed,
-                pending.VesselSnapshot != null,
-                duration, pending.MaxDistanceFromLaunch);
+                pending.VesselDestroyed, pending.VesselSnapshot != null);
 
-            ParsekLog.Info("MergeDialog", $"Merge dialog: distance={pending.DistanceFromLaunch:F0}m, " +
-                $"maxDistance={pending.MaxDistanceFromLaunch:F0}m, duration={duration:F1}s, " +
+            ParsekLog.Info("MergeDialog", $"Merge dialog: " +
                 $"destroyed={pending.VesselDestroyed}, hasSnapshot={pending.VesselSnapshot != null}, " +
                 $"recommended={recommended}");
 
-            DialogGUIButton[] buttons;
+            DialogGUIButton[] buttons = null;
 
             switch (recommended)
             {
-                case RecordingStore.MergeDefault.MergeOnly:
+                case RecordingStore.MergeDefault.GhostOnly:
                     // Vessel destroyed or no snapshot — no vessel to persist
                     buttons = new[]
                     {
@@ -80,30 +78,18 @@ namespace Parsek
                     };
                     break;
 
-                default: // Recover or Persist — vessel intact with snapshot
+                case RecordingStore.MergeDefault.Persist:
+                    // Vessel intact with snapshot — persist in timeline
                     buttons = new[]
                     {
-                        new DialogGUIButton("Merge + Keep Vessel", () =>
+                        new DialogGUIButton("Merge to Timeline", () =>
                         {
                             // Defer spawn — vessel appears when ghost finishes at EndUT
                             RecordingStore.CommitPending();
                             ParsekScenario.ReserveSnapshotCrew();
                             ParsekScenario.SwapReservedCrewInFlight();
                             ParsekLog.ScreenMessage("Recording merged — vessel will appear after ghost playback", 3f);
-                            ParsekLog.Info("MergeDialog", "User chose: Merge + Keep Vessel (deferred spawn)");
-                        }),
-                        new DialogGUIButton("Merge + Recover", () =>
-                        {
-                            RecordingStore.CommitPending();
-                            if (pending.VesselSnapshot != null)
-                            {
-                                ParsekScenario.UnreserveCrewInSnapshot(pending.VesselSnapshot);
-                                VesselSpawner.RecoverVessel(pending.VesselSnapshot);
-                            }
-                            // Clear snapshot so ghost despawns normally at EndUT
-                            pending.VesselSnapshot = null;
-                            ParsekLog.ScreenMessage("Recording merged, vessel recovered!", 3f);
-                            ParsekLog.Info("MergeDialog", "User chose: Merge + Recover");
+                            ParsekLog.Info("MergeDialog", "User chose: Merge to Timeline (deferred spawn)");
                         }),
                         new DialogGUIButton("Discard", () =>
                         {
@@ -138,13 +124,9 @@ namespace Parsek
         {
             string chainId = pending.ChainId;
             double duration = pending.EndUT - pending.StartUT;
-            var recommended = RecordingStore.GetRecommendedAction(
-                pending.DistanceFromLaunch, pending.VesselDestroyed,
-                pending.VesselSnapshot != null,
-                duration, pending.MaxDistanceFromLaunch);
 
             ParsekLog.Info("MergeDialog", $"Chain merge dialog: chain={chainId}, segments={totalSegments}, " +
-                $"recommended={recommended}, hasSnapshot={pending.VesselSnapshot != null}");
+                $"hasSnapshot={pending.VesselSnapshot != null}");
 
             DialogGUIButton[] buttons;
 
@@ -152,27 +134,13 @@ namespace Parsek
             {
                 buttons = new[]
                 {
-                    new DialogGUIButton("Merge + Keep Vessel", () =>
+                    new DialogGUIButton("Merge to Timeline", () =>
                     {
                         RecordingStore.CommitPending();
                         ParsekScenario.ReserveSnapshotCrew();
                         ParsekScenario.SwapReservedCrewInFlight();
                         ParsekLog.ScreenMessage($"Mission chain ({totalSegments} segments) merged — vessel will appear!", 3f);
-                        ParsekLog.Info("MergeDialog", $"User chose: Chain Merge + Keep Vessel ({totalSegments} segments)");
-                    }),
-                    new DialogGUIButton("Merge + Recover", () =>
-                    {
-                        RecordingStore.CommitPending();
-                        // Recover and null snapshots on ALL chain segments (siblings + pending)
-                        if (pending.VesselSnapshot != null)
-                        {
-                            ParsekScenario.UnreserveCrewInSnapshot(pending.VesselSnapshot);
-                            VesselSpawner.RecoverVessel(pending.VesselSnapshot);
-                        }
-                        pending.VesselSnapshot = null;
-                        RecoverChainSiblingSnapshots(chainSiblings);
-                        ParsekLog.ScreenMessage($"Mission chain ({totalSegments} segments) merged, vessel recovered!", 3f);
-                        ParsekLog.Info("MergeDialog", $"User chose: Chain Merge + Recover ({totalSegments} segments)");
+                        ParsekLog.Info("MergeDialog", $"User chose: Chain Merge to Timeline ({totalSegments} segments)");
                     }),
                     new DialogGUIButton("Discard All", () =>
                     {
@@ -215,8 +183,8 @@ namespace Parsek
 
             string message = $"{segmentLabel}\n" +
                 $"Vessel: {pending.VesselName}\n" +
-                $"Duration: {duration:F1}s\n" +
-                $"Distance: {pending.DistanceFromLaunch:F0}m\n\n";
+                $"Duration: {duration.ToString("F1", CultureInfo.InvariantCulture)}s\n" +
+                $"Distance: {pending.DistanceFromLaunch.ToString("F0", CultureInfo.InvariantCulture)}m\n\n";
 
             if (pending.VesselSnapshot != null && !pending.VesselDestroyed)
                 message += "The final vessel will persist in the timeline.";
@@ -238,25 +206,6 @@ namespace Parsek
                 false,
                 HighLogic.UISkin
             );
-        }
-
-        /// <summary>
-        /// Unreserves crew, recovers vessels for funds, and nulls VesselSnapshot on siblings.
-        /// Used by the Recover path where the user expects funds back.
-        /// </summary>
-        static void RecoverChainSiblingSnapshots(List<RecordingStore.Recording> siblings)
-        {
-            if (siblings == null) return;
-            for (int i = 0; i < siblings.Count; i++)
-            {
-                if (siblings[i].VesselSnapshot != null)
-                {
-                    ParsekScenario.UnreserveCrewInSnapshot(siblings[i].VesselSnapshot);
-                    VesselSpawner.RecoverVessel(siblings[i].VesselSnapshot);
-                    siblings[i].VesselSnapshot = null;
-                    ParsekLog.Info("MergeDialog", $"Chain sibling #{i} snapshot recovered + nulled");
-                }
-            }
         }
 
         /// <summary>
@@ -319,10 +268,7 @@ namespace Parsek
 
             switch (recommended)
             {
-                case RecordingStore.MergeDefault.Recover:
-                    return header + "Your vessel hasn't moved far from the launch site.";
-
-                case RecordingStore.MergeDefault.MergeOnly:
+                case RecordingStore.MergeDefault.GhostOnly:
                     return header + "Your vessel was destroyed. Recording captured.";
 
                 default: // Persist

--- a/Source/Parsek/MergeDialog.cs
+++ b/Source/Parsek/MergeDialog.cs
@@ -102,6 +102,7 @@ namespace Parsek
                     break;
 
                 default:
+                    ParsekLog.Warn("MergeDialog", $"Unexpected MergeDefault value: {recommended}");
                     buttons = new DialogGUIButton[0];
                     break;
             }

--- a/Source/Parsek/MergeDialog.cs
+++ b/Source/Parsek/MergeDialog.cs
@@ -51,7 +51,7 @@ namespace Parsek
                 $"destroyed={pending.VesselDestroyed}, hasSnapshot={pending.VesselSnapshot != null}, " +
                 $"recommended={recommended}");
 
-            DialogGUIButton[] buttons = null;
+            DialogGUIButton[] buttons;
 
             switch (recommended)
             {
@@ -99,6 +99,10 @@ namespace Parsek
                             ParsekLog.Info("MergeDialog", "User chose: Discard");
                         })
                     };
+                    break;
+
+                default:
+                    buttons = new DialogGUIButton[0];
                     break;
             }
 
@@ -263,20 +267,25 @@ namespace Parsek
         {
             string header = $"Vessel: {pending.VesselName}\n" +
                 $"Points: {pending.Points.Count}\n" +
-                $"Duration: {duration:F1}s\n" +
-                $"Distance from launch: {pending.DistanceFromLaunch:F0}m\n\n";
+                $"Duration: {duration.ToString("F1", CultureInfo.InvariantCulture)}s\n" +
+                $"Distance from launch: {pending.DistanceFromLaunch.ToString("F0", CultureInfo.InvariantCulture)}m\n\n";
 
             switch (recommended)
             {
                 case RecordingStore.MergeDefault.GhostOnly:
-                    return header + "Your vessel was destroyed. Recording captured.";
+                    return header + (pending.VesselDestroyed
+                        ? "Your vessel was destroyed. Recording captured."
+                        : "Recording captured.");
 
-                default: // Persist
+                case RecordingStore.MergeDefault.Persist:
                     string situation = pending.DistanceFromLaunch < 100.0
                         ? "Your vessel returned near the launch site after traveling " +
-                          $"{pending.MaxDistanceFromLaunch:F0}m."
+                          pending.MaxDistanceFromLaunch.ToString("F0", CultureInfo.InvariantCulture) + "m."
                         : $"Your vessel is {pending.VesselSituation}.";
                     return header + situation + "\nIt will persist in the timeline.";
+
+                default:
+                    return header;
             }
         }
     }

--- a/Source/Parsek/ParsekHarmony.cs
+++ b/Source/Parsek/ParsekHarmony.cs
@@ -1,5 +1,6 @@
 using HarmonyLib;
 using System;
+using System.Linq;
 using UnityEngine;
 
 namespace Parsek
@@ -21,20 +22,33 @@ namespace Parsek
                 return;
             }
 
-            try
+            var assembly = typeof(ParsekHarmony).Assembly;
+            var harmony = new Harmony("com.parsek.mod");
+
+            // Apply patches individually so one failure doesn't block the rest
+            int applied = 0;
+            int failed = 0;
+            var patchTypes = assembly.GetTypes()
+                .Where(t => t.GetCustomAttributes(typeof(HarmonyPatch), false).Length > 0);
+
+            foreach (var patchType in patchTypes)
             {
-                var assembly = typeof(ParsekHarmony).Assembly;
-                var harmony = new Harmony("com.parsek.mod");
-                harmony.PatchAll(assembly);
-                initialized = true;
-                DontDestroyOnLoad(gameObject);
-                ParsekLog.Info("Init", $"SessionStart runUtc={DateTimeOffset.UtcNow.ToUnixTimeSeconds()}");
-                ParsekLog.Info("Harmony", $"Harmony patches applied for assembly '{assembly.GetName().Name}'");
+                try
+                {
+                    harmony.CreateClassProcessor(patchType).Patch();
+                    applied++;
+                }
+                catch (Exception ex)
+                {
+                    failed++;
+                    ParsekLog.Error("Harmony", $"Failed to apply patch {patchType.Name}: {ex.Message}");
+                }
             }
-            catch (System.Exception ex)
-            {
-                ParsekLog.Error("Harmony", $"Failed to apply Harmony patches: {ex.Message}");
-            }
+
+            initialized = true;
+            DontDestroyOnLoad(gameObject);
+            ParsekLog.Info("Init", $"SessionStart runUtc={DateTimeOffset.UtcNow.ToUnixTimeSeconds()}");
+            ParsekLog.Info("Harmony", $"Harmony patches applied: {applied} succeeded, {failed} failed");
         }
     }
 }

--- a/Source/Parsek/Patches/FacilityUpgradePatch.cs
+++ b/Source/Parsek/Patches/FacilityUpgradePatch.cs
@@ -10,16 +10,16 @@ namespace Parsek.Patches
     [HarmonyPatch(typeof(UpgradeableFacility), nameof(UpgradeableFacility.SetLevel))]
     internal static class FacilityUpgradePatch
     {
-        static bool Prefix(UpgradeableFacility __instance, int level)
+        static bool Prefix(UpgradeableFacility __instance, int lvl)
         {
             if (__instance == null) return true;
 
             // Only block upgrades (level increases), not downgrades or resets
             int currentLevel = __instance.FacilityLevel;
-            if (level <= currentLevel)
+            if (lvl <= currentLevel)
             {
                 ParsekLog.Verbose("FacilityUpgradePatch",
-                    $"Allowing facility level change: '{__instance.id}' level {currentLevel} → {level} (not an upgrade)");
+                    $"Allowing facility level change: '{__instance.id}' level {currentLevel} → {lvl} (not an upgrade)");
                 return true;
             }
 
@@ -30,7 +30,7 @@ namespace Parsek.Patches
             if (!committedFacilities.Contains(facilityId))
             {
                 ParsekLog.Verbose("FacilityUpgradePatch",
-                    $"Allowing facility upgrade: '{facilityId}' level {currentLevel} → {level} — not in committed set ({committedFacilities.Count} committed)");
+                    $"Allowing facility upgrade: '{facilityId}' level {currentLevel} → {lvl} — not in committed set ({committedFacilities.Count} committed)");
                 return true;
             }
 
@@ -42,7 +42,7 @@ namespace Parsek.Patches
                 : "";
 
             ParsekLog.Info("FacilityUpgradePatch",
-                $"Blocking facility upgrade: '{facilityId}' level {currentLevel} → {level} — already committed{utStr}");
+                $"Blocking facility upgrade: '{facilityId}' level {currentLevel} → {lvl} — already committed{utStr}");
 
             CommittedActionDialog.ShowBlocked(
                 "Cannot upgrade \"" + facilityId + "\"",

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -46,9 +46,8 @@ namespace Parsek
         /// </summary>
         public enum MergeDefault
         {
-            Recover,    // Vessel barely moved — recover for funds
-            MergeOnly,  // Vessel destroyed or snapshot missing — merge recording only
-            Persist     // Vessel intact and moved — respawn where it ended up
+            GhostOnly,  // Vessel destroyed or snapshot missing — merge recording only
+            Persist      // Vessel intact with snapshot — respawn where it ended up
         }
 
         public class Recording
@@ -158,21 +157,10 @@ namespace Parsek
         /// <summary>
         /// Determines the recommended merge action based on vessel state.
         /// </summary>
-        public static MergeDefault GetRecommendedAction(
-            double distance, bool destroyed, bool hasSnapshot,
-            double duration = 0, double maxDistance = 0)
+        public static MergeDefault GetRecommendedAction(bool destroyed, bool hasSnapshot)
         {
             if (destroyed || !hasSnapshot)
-            {
-                if (distance < 100.0)
-                    return MergeDefault.Recover;
-                return MergeDefault.MergeOnly;
-            }
-
-            // Vessel intact with snapshot — did it actually go somewhere?
-            if (distance < 100.0 && (duration <= 10.0 || maxDistance <= 100.0))
-                return MergeDefault.Recover;
-
+                return MergeDefault.GhostOnly;
             return MergeDefault.Persist;
         }
 

--- a/Source/Parsek/VesselSpawner.cs
+++ b/Source/Parsek/VesselSpawner.cs
@@ -463,20 +463,6 @@ namespace Parsek
                 $"nearest vessel={closestDist:F0}m");
         }
 
-        public static void RecoverVessel(ConfigNode vesselNode)
-        {
-            try
-            {
-                ProtoVessel pv = new ProtoVessel(vesselNode, HighLogic.CurrentGame);
-                ShipConstruction.RecoverVesselFromFlight(pv, HighLogic.CurrentGame.flightState, true);
-                ParsekLog.Info("Spawner", "Vessel recovered for funds");
-            }
-            catch (System.Exception ex)
-            {
-                ParsekLog.Error("Spawner", $"Failed to recover vessel: {ex.Message}");
-            }
-        }
-
         public static void RemoveSpecificCrewFromSnapshot(ConfigNode snapshot, HashSet<string> crewNames)
         {
             if (snapshot == null || crewNames == null || crewNames.Count == 0)

--- a/Source/README.md
+++ b/Source/README.md
@@ -122,12 +122,8 @@ The script exits non-zero if required log contracts fail.
 
 **Persist in orbit:**
 1. Launch to orbit, F9 record, revert to launch
-2. Dialog defaults to "Merge + Keep Vessel" — click it
+2. Dialog defaults to "Merge to Timeline" — click it
 3. Go to Tracking Station — vessel should appear in orbit
-
-**Auto-recover on pad:**
-1. Sit on pad, F9 record briefly, revert
-2. Dialog defaults to "Merge + Recover" — funds returned
 
 **Destroyed vessel:**
 1. Launch, crash, revert
@@ -136,7 +132,7 @@ The script exits non-zero if required log contracts fail.
 ### Crew Replacement Tests
 
 **Basic flow:**
-1. Record with Jeb → revert → "Merge + Keep Vessel"
+1. Record with Jeb → revert → "Merge to Timeline"
 2. Check Astronaut Complex: Jeb is Assigned, a new kerbal with matching trait appeared
 3. Launch new flight — replacement kerbal is available in crew selection
 4. Wait for EndUT → Jeb's vessel spawns, replacement is cleaned up from roster
@@ -200,7 +196,7 @@ Vessel respawn uses `ProtoVessel` injection into `flightState.protoVessels`. Rec
 
 ### Crew Replacement System
 
-When a kerbal is reserved for a deferred vessel spawn ("Merge + Keep Vessel"), they're marked as `Assigned` and become unavailable in the VAB/SPH. To prevent the player from running out of crew, the system automatically hires a replacement kerbal with the same trait (Pilot/Engineer/Scientist).
+When a kerbal is reserved for a deferred vessel spawn ("Merge to Timeline"), they're marked as `Assigned` and become unavailable in the VAB/SPH. To prevent the player from running out of crew, the system automatically hires a replacement kerbal with the same trait (Pilot/Engineer/Scientist).
 
 **Lifecycle:**
 1. **Reserve** — `ReserveCrewIn()` sets kerbal to Assigned, hires replacement via `roster.GetNewKerbal()`, stores mapping in `crewReplacements[originalName] = replacementName`

--- a/docs/manual-testing/test-general.md
+++ b/docs/manual-testing/test-general.md
@@ -18,28 +18,15 @@ Use career mode for all tests (resource tracking requires it).
 
 ## Merge Dialog Options
 
-### Vessel barely moved
-1. Launch, fly a few meters, F9 stop, revert
-2. Verify: dialog shows "Keep Vessel / Recover / Discard" buttons
-3. Verify: message says vessel hasn't moved far
-4. Pick "Merge + Recover" — vessel recovered for funds, no vessel in tracking station
-
-### Vessel returned to pad
-1. Launch, fly a suborbital hop (gain altitude, fly >100m away), land back on or near the pad
-2. F9 stop, revert
-3. Verify: dialog shows "Keep Vessel / Recover / Discard" buttons
-4. Verify: message mentions the vessel returned near the launch site and shows max distance traveled
-5. Pick "Merge + Keep Vessel" — vessel appears at pad after ghost finishes
-
 ### Vessel destroyed
 1. Launch, crash into the ground, revert
-2. Verify: dialog default is "Merge to Timeline"
+2. Verify: dialog shows "Merge to Timeline" and "Discard" buttons
 3. Pick "Merge to Timeline" — ghost plays back, no vessel spawns
 
-### Vessel intact, moved far
+### Vessel intact
 1. Launch to orbit, F9 stop, revert
-2. Verify: dialog shows "Keep Vessel / Recover / Discard" buttons (Keep Vessel first)
-3. Pick "Merge + Keep Vessel" — vessel appears in Tracking Station after ghost finishes
+2. Verify: dialog shows "Merge to Timeline" and "Discard" buttons
+3. Pick "Merge to Timeline" — vessel appears in Tracking Station after ghost finishes
 
 ### Discard
 1. Record anything, revert
@@ -47,9 +34,8 @@ Use career mode for all tests (resource tracking requires it).
 
 ## Vessel Persistence
 
-1. Launch to orbit → record → revert → "Merge + Keep Vessel"
+1. Launch to orbit → record → revert → "Merge to Timeline"
 2. Go to Tracking Station → verify vessel appears in orbit
-3. Alternatively: choose "Merge + Recover" → verify funds credited, no vessel in orbit
 
 ## Crew Replacement
 
@@ -57,7 +43,7 @@ Use career mode for all tests (resource tracking requires it).
 1. Launch a vessel with Jeb as pilot
 2. F9 start recording, fly around briefly, F9 stop
 3. Revert to Launch
-4. Merge dialog appears — pick "Merge + Keep Vessel"
+4. Merge dialog appears — pick "Merge to Timeline"
 5. **Verify on the pad:** the vessel's crew portrait should show a REPLACEMENT kerbal, NOT Jeb
    - If Jeb is still shown, the swap failed (this was the bug)
 6. Check `KSP.log` for `[Parsek Scenario] Swapped 'Jebediah Kerman' → '...'`
@@ -68,7 +54,7 @@ Use career mode for all tests (resource tracking requires it).
 9. Verify: replacement kerbal is removed from roster (Astronaut Complex)
 
 ### Astronaut Complex verification
-1. Record with Jeb → revert → "Merge + Keep Vessel"
+1. Record with Jeb → revert → "Merge to Timeline"
 2. Go to Space Center → Astronaut Complex
 3. Jeb should be Assigned (not Available)
 4. A new kerbal with Pilot trait should appear as Available
@@ -77,7 +63,7 @@ Use career mode for all tests (resource tracking requires it).
 
 ### Multi-crew vessel swap
 1. Build a vessel with 3 crew (e.g. Mk1-3 pod with Jeb, Bill, Valentina)
-2. Record → revert → "Merge + Keep Vessel"
+2. Record → revert → "Merge to Timeline"
 3. Verify: ALL three originals are swapped for replacements on the pad vessel
 4. Check log for three `Swapped` entries
 5. At EndUT: spawned vessel should have all three original kerbals

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -37,17 +37,12 @@ If a kerbal goes EVA while recording a vessel, Parsek automatically:
 
 After reverting, a dialog appears with context-aware options:
 
-| Situation | Default Option | Other Options |
-|-----------|---------------|---------------|
-| Vessel barely moved (short duration or low max distance) | Merge + Keep Vessel | Merge + Recover, Discard |
-| Vessel returned to pad after a real mission | Merge + Keep Vessel | Merge + Recover, Discard |
-| Vessel destroyed, near pad | Merge + Recover | Discard |
-| Vessel destroyed, far from pad | Merge to Timeline | Discard |
-| Vessel intact, moved far | Merge + Keep Vessel | Merge + Recover, Discard |
+| Situation | Options |
+|-----------|---------|
+| Vessel destroyed or no snapshot | Merge to Timeline, Discard |
+| Vessel intact with snapshot | Merge to Timeline, Discard |
 
-- **Merge + Recover** — Recording is merged; vessel is recovered for funds immediately
-- **Merge + Keep Vessel** — Recording is merged; vessel will appear in the game world when the ghost finishes playing
-- **Merge to Timeline** — Recording is merged; no vessel spawned (for destroyed vessels)
+- **Merge to Timeline** — Recording is merged; if the vessel is intact, it will appear in the game world when the ghost finishes playing
 - **Discard** — Recording is thrown away
 
 ### Timeline Playback
@@ -70,7 +65,7 @@ After merging, wait on the pad (or time warp) until UT reaches the recording's t
 
 ### Crew Management
 
-When you choose "Merge + Keep Vessel", the recorded crew (e.g. Jeb) are reserved for the deferred vessel spawn. A replacement kerbal with the same trait is hired automatically so your available crew pool stays the same size. When the vessel spawns at EndUT, the original crew board it and the replacement is removed.
+When you choose "Merge to Timeline", the recorded crew (e.g. Jeb) are reserved for the deferred vessel spawn. A replacement kerbal with the same trait is hired automatically so your available crew pool stays the same size. When the vessel spawns at EndUT, the original crew board it and the replacement is removed.
 
 ### Take Control (Experimental)
 


### PR DESCRIPTION
## Summary

- Remove the "Merge + Recover" button from both standalone and chain merge dialogs, simplifying to two options: "Merge to Timeline" and "Discard"
- Simplify `MergeDefault` enum (delete `Recover`, rename `MergeOnly` → `GhostOnly`) and `GetRecommendedAction` to a 2-param signature — distance/duration/maxDistance heuristic removed entirely
- Fix locale-sensitive formatting in `BuildMergeMessage` and chain dialog (3 `F1`/`F0` instances → `InvariantCulture`)
- GhostOnly message now distinguishes destroyed vessels from missing-snapshot vessels
- Remove dead `VesselSpawner.RecoverVessel` method (no remaining callers)
- Apply Harmony patches individually so one failure doesn't block the rest
- Fix `FacilityUpgradePatch` parameter name (`level` → `lvl`) to match KSP method signature

## Test plan

- [x] `dotnet build` clean (0 warnings, 0 errors)
- [x] `dotnet test` passes (855 passed, 1 skipped)
- [x] In-game: 3/3 Harmony patches applied, 0 failed
- [x] In-game: launch → record (374 points) → revert → dialog shows "Merge to Timeline" / "Discard" → merge succeeds
- [x] No errors or warnings in KSP.log

🤖 Generated with [Claude Code](https://claude.com/claude-code)