### PR TITLE
Fix engine nozzle glow after shutdown and watch button for looped segments

### DIFF
--- a/Source/Parsek.Tests/SyntheticRecordingTests.cs
+++ b/Source/Parsek.Tests/SyntheticRecordingTests.cs
@@ -507,12 +507,12 @@ namespace Parsek.Tests
             seg0.AddPoint(t + 40, baseLat, baseLon + 0.0079,   160);
             seg0.AddPoint(t + 45, baseLat, baseLon + 0.0084,   110);
             seg0.AddPoint(t + 50, baseLat - 0.0005, baseLon + 0.0088, 80);
-            // Parachute descent — slow final approach
-            seg0.AddPoint(t + 55, baseLat - 0.0008, baseLon + 0.0091, 70);
-            seg0.AddPoint(t + 60, baseLat - 0.0012, baseLon + 0.0093, 62);
-            seg0.AddPoint(t + 65, baseLat - 0.0014, baseLon + 0.0094, 57);
-            seg0.AddPoint(t + 70, baseLat - 0.0016, baseLon + 0.0095, 55);
-            seg0.AddPoint(t + 75, baseLat - 0.0016, baseLon + 0.0095, 55); // landed
+            // Parachute descent — slow final approach (KSC terrain ~67-69m)
+            seg0.AddPoint(t + 55, baseLat - 0.0008, baseLon + 0.0091, 75);
+            seg0.AddPoint(t + 60, baseLat - 0.0012, baseLon + 0.0093, 72);
+            seg0.AddPoint(t + 65, baseLat - 0.0014, baseLon + 0.0094, 70);
+            seg0.AddPoint(t + 70, baseLat - 0.0016, baseLon + 0.0095, 69);
+            seg0.AddPoint(t + 75, baseLat - 0.0016, baseLon + 0.0095, 69); // landed
 
             // Engine events: SRB ignition and burnout
             seg0.AddPartEvent(t, 101111, 5, "solidBooster.sm.v2", value: 1f);
@@ -525,10 +525,10 @@ namespace Parsek.Tests
             double landLon = baseLon + 0.0095;
             seg0.WithVesselSnapshot(
                 VesselSnapshotBuilder.FleaRocket("Landing Craft", "Bill Kerman", pid: 88888888)
-                    .AsLanded(landLat, landLon, 55));
+                    .AsLanded(landLat, landLon, 69));
             seg0.WithGhostVisualSnapshot(
                 VesselSnapshotBuilder.FleaRocket("Landing Craft", "Bill Kerman", pid: 88888888)
-                    .AsLanded(landLat, landLon, 55));
+                    .AsLanded(landLat, landLon, 69));
 
             // Segment 1: EVA walk — Bill walks ~25m from landing point (25s)
             var seg1 = new RecordingBuilder("Bill Kerman")
@@ -540,17 +540,17 @@ namespace Parsek.Tests
                 .WithEvaCrewName("Bill Kerman");
 
             // Boundary anchor — same position as vessel's final point
-            seg1.AddPoint(t + 75, landLat,           landLon,            55);
-            seg1.AddPoint(t + 80, landLat - 0.0001,  landLon + 0.0001,  55);
-            seg1.AddPoint(t + 85, landLat - 0.0002,  landLon + 0.0002,  55);
-            seg1.AddPoint(t + 90, landLat - 0.0003,  landLon + 0.0002,  55);
-            seg1.AddPoint(t + 95, landLat - 0.0003,  landLon + 0.0003,  55);
-            seg1.AddPoint(t + 100, landLat - 0.0004, landLon + 0.0003,  55);
+            seg1.AddPoint(t + 75, landLat,           landLon,            69);
+            seg1.AddPoint(t + 80, landLat - 0.0001,  landLon + 0.0001,  69);
+            seg1.AddPoint(t + 85, landLat - 0.0002,  landLon + 0.0002,  69);
+            seg1.AddPoint(t + 90, landLat - 0.0003,  landLon + 0.0002,  69);
+            seg1.AddPoint(t + 95, landLat - 0.0003,  landLon + 0.0003,  69);
+            seg1.AddPoint(t + 100, landLat - 0.0004, landLon + 0.0003,  69);
 
             // Ghost-only EVA snapshot
             seg1.WithGhostVisualSnapshot(
                 VesselSnapshotBuilder.EvaKerbal("Bill Kerman", pid: 99999999)
-                    .AsLanded(landLat - 0.0004, landLon + 0.0003, 55));
+                    .AsLanded(landLat - 0.0004, landLon + 0.0003, 69));
 
             return new[] { seg0, seg1 };
         }

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -4586,8 +4586,16 @@ namespace Parsek
 
             if (inPauseWindow)
             {
-                PositionGhostAt(state.ghost, rec.Points[rec.Points.Count - 1], rec.RecordingFormatVersion >= 5);
-                if (state != null && state.reentryFxInfo != null)
+                var lastPt = rec.Points[rec.Points.Count - 1];
+                PositionGhostAt(state.ghost, lastPt, rec.RecordingFormatVersion >= 5);
+                // Ensure body/altitude are set even during pause — needed for
+                // IsGhostOnSameBody (watch button) after a cycle-change respawn.
+                if (string.IsNullOrEmpty(state.lastInterpolatedBodyName))
+                {
+                    state.lastInterpolatedBodyName = lastPt.bodyName;
+                    state.lastInterpolatedAltitude = lastPt.altitude;
+                }
+                if (state.reentryFxInfo != null)
                 {
                     // Only zero velocity — keep body/altitude from last frame for smooth intensity decay
                     state.lastInterpolatedVelocity = Vector3.zero;
@@ -5094,6 +5102,9 @@ namespace Parsek
                 switch (evt.eventType)
                 {
                     case PartEventType.Decoupled:
+                        StopEngineFxForPart(state, evt.partPersistentId);
+                        StopRcsFxForPart(state, evt.partPersistentId);
+                        ApplyHeatState(state, evt, heated: false);
                         if (tree != null)
                             HidePartSubtree(ghost, evt.partPersistentId, tree);
                         else
@@ -5101,6 +5112,9 @@ namespace Parsek
                         Log($"Part event applied: Decoupled '{evt.partName}' pid={evt.partPersistentId}");
                         break;
                     case PartEventType.Destroyed:
+                        StopEngineFxForPart(state, evt.partPersistentId);
+                        StopRcsFxForPart(state, evt.partPersistentId);
+                        ApplyHeatState(state, evt, heated: false);
                         HideGhostPart(ghost, evt.partPersistentId);
                         Log($"Part event applied: Destroyed '{evt.partName}' pid={evt.partPersistentId}");
                         break;
@@ -5196,6 +5210,9 @@ namespace Parsek
                         break;
                     case PartEventType.EngineShutdown:
                         SetEngineEmission(state, evt, 0f);
+                        // Also reset heat animation glow — engine nozzles stay emissive
+                        // after shutdown if ThermalAnimationCold hasn't fired yet.
+                        ApplyHeatState(state, evt, heated: false);
                         Log($"Part event applied: EngineShutdown '{evt.partName}' pid={evt.partPersistentId} midx={evt.moduleIndex}");
                         break;
                     case PartEventType.EngineThrottle:
@@ -5477,6 +5494,54 @@ namespace Parsek
                         ps.isPlaying);
                     string diagKey = $"engine-fx-{evt.partPersistentId}-{evt.moduleIndex}-{ps.GetInstanceID()}";
                     ParsekLog.VerboseRateLimited("Flight", diagKey, diagLine, 0.5);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Stop all engine FX particle systems for a given part (by PID).
+        /// Used defensively on decouple/destroy to ensure no orphaned engine glow.
+        /// </summary>
+        static void StopEngineFxForPart(GhostPlaybackState state, uint partPersistentId)
+        {
+            if (state?.engineInfos == null) return;
+            foreach (var info in state.engineInfos.Values)
+            {
+                if (info.partPersistentId != partPersistentId) continue;
+                for (int i = 0; i < info.particleSystems.Count; i++)
+                {
+                    var ps = info.particleSystems[i];
+                    if (ps == null) continue;
+                    var emission = ps.emission;
+                    emission.enabled = false;
+                    emission.rateOverTimeMultiplier = 0;
+                    ps.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
+                    ps.Clear(true);
+                    SetParticleRenderersEnabled(ps, false);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Stop all RCS FX particle systems for a given part (by PID).
+        /// Used defensively on decouple/destroy to ensure no orphaned RCS glow.
+        /// </summary>
+        static void StopRcsFxForPart(GhostPlaybackState state, uint partPersistentId)
+        {
+            if (state?.rcsInfos == null) return;
+            foreach (var info in state.rcsInfos.Values)
+            {
+                if (info.partPersistentId != partPersistentId) continue;
+                for (int i = 0; i < info.particleSystems.Count; i++)
+                {
+                    var ps = info.particleSystems[i];
+                    if (ps == null) continue;
+                    var emission = ps.emission;
+                    emission.enabled = false;
+                    emission.rateOverTimeMultiplier = 0;
+                    ps.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
+                    ps.Clear(true);
+                    SetParticleRenderersEnabled(ps, false);
                 }
             }
         }

--- a/docs/dev/known-bugs.md
+++ b/docs/dev/known-bugs.md
@@ -129,7 +129,11 @@ Ghost engine nozzle continues glowing after the engine shutdown event during pla
 
 **Reproduction:** Record a flight with booster separation (engine burns out → decouples). Watch the ghost playback — the booster nozzle continues glowing even after the engine cutoff event fires.
 
-**Status:** Open — needs investigation of engine FX state management in `GhostVisualBuilder`/`ParsekFlight` part event application
+**Root cause:** Two issues: (1) `EngineShutdown` stopped the exhaust particle FX but did not reset the heat animation emissive glow (`ModuleAnimateHeat` material properties) — the nozzle mesh stayed emissive. (2) If `EngineShutdown` was not recorded before a `Decoupled` event (same-frame burnout+decouple race), engine/RCS particle systems were not explicitly stopped before the part was hidden.
+
+**Fix:** `EngineShutdown` now also calls `ApplyHeatState(heated: false)` to reset nozzle emissive materials. `Decoupled` and `Destroyed` events now defensively call `StopEngineFxForPart` and `StopRcsFxForPart` (plus heat reset) before hiding the part, ensuring no orphaned FX regardless of event ordering.
+
+**Status:** Fixed
 
 ## 19. Watch (W) button does not work for looped recording segments
 
@@ -137,7 +141,11 @@ Pressing W to watch a looped recording segment does nothing — the camera does 
 
 **Reproduction:** Enable loop on any recording segment, press W on that segment in the UI. Camera stays on the active vessel instead of switching to the ghost.
 
-**Status:** Open — needs investigation of watch target logic for looped playback in `ParsekFlight`/`ParsekUI`
+**Root cause:** In `UpdateLoopingTimelinePlayback`, the pause window path called `PositionGhostAt` but never called `SetInterpolated`, leaving `lastInterpolatedBodyName` null on the `GhostPlaybackState`. When the ghost was respawned at a cycle boundary and the first frame fell in the pause window, the body name stayed null for the entire pause duration. `IsGhostOnSameBody` returned false → W button was disabled (grayed out). Even outside the pause window, a freshly spawned ghost had null body name for the first frame.
+
+**Fix:** The pause window path now initializes `lastInterpolatedBodyName` and `lastInterpolatedAltitude` from the last trajectory point when they are empty. This ensures `IsGhostOnSameBody` returns true as soon as the ghost exists.
+
+**Status:** Fixed
 
 ## 20. Ghost orientation wrong in exo-atmospheric segment after staging
 


### PR DESCRIPTION
## Summary
- **Bug #18:** Engine nozzle glow now properly clears on shutdown — `EngineShutdown` resets heat animation emissive materials, and `Decoupled`/`Destroyed` events defensively stop all engine/RCS FX before hiding parts
- **Bug #19:** Watch (W) button now works for looped recording segments — pause window path initializes `lastInterpolatedBodyName` from the last trajectory point so `IsGhostOnSameBody` returns true immediately after ghost spawn

## Test plan
- [x] Record a flight with SRB burnout + booster separation, verify ghost nozzle stops glowing after engine cutoff
- [x] Enable loop on a recording, press W — camera should follow the ghost
- [x] Verify W button stays functional across loop cycle boundaries and during pause windows
- [x] Run `dotnet test` — all 1218 tests pass