### PR TITLE
Fix ghost visual warning spam and noisy log messages

### DIFF
--- a/Source/Parsek/ActionReplay.cs
+++ b/Source/Parsek/ActionReplay.cs
@@ -371,8 +371,9 @@ namespace Parsek
                         facilityId, out var proto)
                     || proto.facilityRefs == null || proto.facilityRefs.Count == 0)
                 {
-                    ParsekLog.Warn("ActionReplay",
-                        $"Facility upgrade: '{facilityId}' — facility not found, skipping");
+                    ParsekLog.Info("ActionReplay",
+                        $"Facility upgrade: '{facilityId}' — facility not found, skipping " +
+                        "(expected in Flight scene where facility refs are unavailable)");
                     skipped = true;
                     return true;
                 }

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -403,7 +403,7 @@ namespace Parsek
             ConfigNode snapshotNode = GetGhostSnapshot(rec);
             if (snapshotNode == null)
             {
-                ParsekLog.Warn("GhostVisual",
+                ParsekLog.Info("GhostVisual",
                     $"Ghost build aborted for '{rec?.VesselName ?? "unknown"}': no snapshot node");
                 return null;
             }
@@ -411,7 +411,7 @@ namespace Parsek
             var partNodes = snapshotNode.GetNodes("PART");
             if (partNodes == null || partNodes.Length == 0)
             {
-                ParsekLog.Warn("GhostVisual",
+                ParsekLog.Info("GhostVisual",
                     $"Ghost build aborted for '{rec?.VesselName ?? "unknown"}': snapshot has no PART nodes");
                 return null;
             }
@@ -4394,10 +4394,10 @@ namespace Parsek
                 ParsekLog.Verbose("GhostVisual", $"  Variant selection: '{selectedVariantName}' with " +
                     $"{selectedVariantGameObjects.Count} GAMEOBJECT rules");
             }
-            if (hasPartVariants && !filterInactiveVariantRenderers)
+            if (hasPartVariants && !filterInactiveVariantRenderers && !hasVariantGameObjectRules)
             {
-                ParsekLog.Verbose("GhostVisual", $"  Variant active-state fallback: no active variant renderers found " +
-                    $"(active MR={activeMR}, active SMR={activeSMR})");
+                ParsekLog.Verbose("GhostVisual", $"  Variant fallback: no active variant renderers and no GAMEOBJECT rules " +
+                    $"— including all renderers (active MR={activeMR}, active SMR={activeSMR})");
             }
 
             // Name by persistentId for O(1) lookup during playback; fall back to part name

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -4799,20 +4799,29 @@ namespace Parsek
 
             // Use a slightly different color to distinguish from manual preview
             Color ghostColor = new Color(0.2f, 1f, 0.4f, 0.8f); // bright green-cyan
-            List<ParachuteGhostInfo> parachuteInfoList;
-            List<JettisonGhostInfo> jettisonInfoList;
-            List<EngineGhostInfo> engineInfoList;
-            List<DeployableGhostInfo> deployableInfoList;
-            List<HeatGhostInfo> heatInfoList;
-            List<LightGhostInfo> lightInfoList;
-            List<FairingGhostInfo> fairingInfoList;
-            List<RcsGhostInfo> rcsInfoList;
-            List<RoboticGhostInfo> roboticInfoList;
-            GameObject ghost = GhostVisualBuilder.BuildTimelineGhostFromSnapshot(
-                rec, $"Parsek_Timeline_{index}", out parachuteInfoList, out jettisonInfoList,
-                out engineInfoList, out deployableInfoList, out heatInfoList, out lightInfoList, out fairingInfoList,
-                out rcsInfoList, out roboticInfoList);
-            bool builtFromSnapshot = ghost != null;
+            List<ParachuteGhostInfo> parachuteInfoList = null;
+            List<JettisonGhostInfo> jettisonInfoList = null;
+            List<EngineGhostInfo> engineInfoList = null;
+            List<DeployableGhostInfo> deployableInfoList = null;
+            List<HeatGhostInfo> heatInfoList = null;
+            List<LightGhostInfo> lightInfoList = null;
+            List<FairingGhostInfo> fairingInfoList = null;
+            List<RcsGhostInfo> rcsInfoList = null;
+            List<RoboticGhostInfo> roboticInfoList = null;
+            GameObject ghost = null;
+            bool builtFromSnapshot = false;
+
+            // Skip expensive snapshot build when no snapshot exists — go straight to sphere fallback.
+            // Avoids per-loop-cycle warning spam for snapshot-less recordings (bug #21).
+            if (GhostVisualBuilder.GetGhostSnapshot(rec) != null)
+            {
+                ghost = GhostVisualBuilder.BuildTimelineGhostFromSnapshot(
+                    rec, $"Parsek_Timeline_{index}", out parachuteInfoList, out jettisonInfoList,
+                    out engineInfoList, out deployableInfoList, out heatInfoList, out lightInfoList, out fairingInfoList,
+                    out rcsInfoList, out roboticInfoList);
+                builtFromSnapshot = ghost != null;
+            }
+
             if (ghost == null)
             {
                 ghost = CreateGhostSphere($"Parsek_Timeline_{index}", ghostColor);

--- a/docs/dev/known-bugs.md
+++ b/docs/dev/known-bugs.md
@@ -155,17 +155,17 @@ Recordings without a ghost visual snapshot (e.g., "KSC Pad Destroyed" synthetic 
 
 **Fix options:** (1) Set a `ghostBuildAttempted` flag on the recording after first failure to skip subsequent attempts, (2) only log once per recording per flight scene, (3) fall back to sphere silently without WARN for recordings known to lack snapshots.
 
-**Status:** Open
+**Status:** Fixed — `SpawnTimelineGhost` now checks `GetGhostSnapshot(rec)` before calling `BuildTimelineGhostFromSnapshot`. When null, skips straight to sphere fallback without the snapshot build attempt. Also downgraded the "no snapshot node" and "no PART nodes" messages from WARN to INFO for cases where the build is attempted directly.
 
 ## 22. Facility not found during action replay on rewind
 
 During rewind, action replay logs `Facility upgrade: 'SpaceCenter/LaunchPad' — facility not found, skipping`. The facility upgrade is silently skipped, potentially leaving game state inconsistent.
 
-**Root cause:** Likely a timing issue — `ActionReplay.ReplayCommittedActions` runs during `OnLoad` before KSP's `SpaceCenter` facility objects are fully instantiated. The facility lookup returns null.
+**Root cause:** `UpgradeableFacility` MonoBehaviours only exist in SpaceCenter scene. In Flight scene (after rewind/quicksave load), `ScenarioUpgradeableFacilities.protoUpgradeables` entries have empty `facilityRefs` lists. This is expected — the quicksave already contains the correct facility level data from save time, so the skip is benign.
 
 **Reproduction:** Rewind to a point before a launchpad upgrade milestone. Check log for "facility not found" warning.
 
-**Status:** Open — needs investigation of facility readiness timing in the rewind path
+**Status:** Fixed — downgraded from WARN to INFO with explanatory message ("expected in Flight scene where facility refs are unavailable"). The facility level data from the quicksave is authoritative; the action replay skip is harmless.
 
 ## 23. Real career recordings missing ghost geometry (sphere fallback)
 
@@ -181,6 +181,6 @@ During rewind, action replay logs `Facility upgrade: 'SpaceCenter/LaunchPad' —
 
 During ghost visual builds, some parts log `Variant active-state fallback: no active variant renderers found`. The ghost part renders but may show incorrect variant appearance (e.g., wrong texture/color for parts with multiple visual variants like fuel tanks).
 
-**Root cause:** `GhostVisualBuilder` attempts to match the recorded part variant by enabling/disabling variant-specific renderers. When no renderer is tagged as active for the recorded variant, all renderers fall back to their default state.
+**Root cause:** `GhostVisualBuilder` attempts to match the recorded part variant by enabling/disabling variant-specific renderers. When no renderer is tagged as active for the recorded variant, all renderers fall back to their default state. However, when the variant has GAMEOBJECT rules in the part config, those rules still filter renderers correctly — the fallback warning was firing even when GAMEOBJECT rule filtering was working.
 
-**Status:** Open — low severity, cosmetic only
+**Status:** Fixed — variant fallback warning now only fires when BOTH active-state filtering AND GAMEOBJECT rules are unavailable (the true fallback case). When GAMEOBJECT rules exist, variant filtering works correctly and no warning is logged.


### PR DESCRIPTION
## Summary
- **Bug #21**: Skip `BuildTimelineGhostFromSnapshot` when no snapshot exists, preventing per-loop-cycle WARN spam for snapshot-less recordings (e.g. "KSC Pad Destroyed"). Downgraded the messages from WARN to INFO as defense-in-depth.
- **Bug #22**: Downgrade facility-not-found warning to INFO — `facilityRefs` are empty in Flight scene because `UpgradeableFacility` MonoBehaviours only exist in SpaceCenter scene. The quicksave data is authoritative for facility levels.
- **Bug #24**: Narrow variant fallback warning to only fire when both active-state filtering AND GAMEOBJECT rules are unavailable. Previously warned even when GAMEOBJECT rules were correctly handling variant filtering.

## Test plan
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 1218 passed, 0 failed
- [ ] In-game: play back a snapshot-less recording (KSC Pad Destroyed) with loop enabled — verify no WARN spam in KSP.log
- [ ] In-game: rewind to a point before a facility upgrade — verify INFO (not WARN) in log
- [ ] In-game: play back a recording with variant parts — verify no false-positive variant fallback warnings