### PR TITLE
Fix re-entry flame FX size and direction (bug #17)

### DIFF
--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -5613,11 +5613,11 @@ namespace Parsek
 
                 ParticleSystem flame = flameObj.AddComponent<ParticleSystem>();
                 var main = flame.main;
-                main.simulationSpace = ParticleSystemSimulationSpace.Local;
-                main.startLifetime = new ParticleSystem.MinMaxCurve(0.3f, 0.8f);
+                main.simulationSpace = ParticleSystemSimulationSpace.World;
+                main.startLifetime = new ParticleSystem.MinMaxCurve(0.15f, 0.5f);
                 main.startColor = new ParticleSystem.MinMaxGradient(new Color(1f, 0.7f, 0.2f, 0.9f));
-                main.startSize = new ParticleSystem.MinMaxCurve(2f, 5f);
-                main.startSpeed = new ParticleSystem.MinMaxCurve(5f, 15f);
+                main.startSize = new ParticleSystem.MinMaxCurve(0.5f, 1.5f);
+                main.startSpeed = new ParticleSystem.MinMaxCurve(1f, 5f);
                 main.maxParticles = 500;
                 main.playOnAwake = false;
 
@@ -5628,13 +5628,13 @@ namespace Parsek
                 var shape = flame.shape;
                 shape.enabled = true;
                 shape.shapeType = ParticleSystemShapeType.Cone;
-                shape.angle = 25f;
-                shape.radius = 1f;
+                shape.angle = 15f;
+                shape.radius = 0.3f;
 
                 var flameRenderer = flameObj.GetComponent<ParticleSystemRenderer>();
                 if (flameRenderer != null)
                 {
-                    flameRenderer.maxParticleSize = 80f;
+                    flameRenderer.maxParticleSize = 15f;
                     Shader additiveShader = Shader.Find("KSP/Particles/Additive");
                     if (additiveShader != null)
                     {
@@ -5662,7 +5662,7 @@ namespace Parsek
                 main.simulationSpace = ParticleSystemSimulationSpace.World;
                 main.startLifetime = new ParticleSystem.MinMaxCurve(4f, 10f);
                 main.startColor = new ParticleSystem.MinMaxGradient(new Color(1f, 0.5f, 0.1f, 0.7f));
-                main.startSize = new ParticleSystem.MinMaxCurve(3f, 8f);
+                main.startSize = new ParticleSystem.MinMaxCurve(1.5f, 4f);
                 main.startSpeed = new ParticleSystem.MinMaxCurve(0f, 0.5f);
                 main.maxParticles = 2000;
                 main.gravityModifier = 0.03f;
@@ -5675,12 +5675,12 @@ namespace Parsek
                 var shape = smoke.shape;
                 shape.enabled = true;
                 shape.shapeType = ParticleSystemShapeType.Sphere;
-                shape.radius = 0.5f;
+                shape.radius = 0.3f;
 
                 var smokeRenderer = smokeObj.GetComponent<ParticleSystemRenderer>();
                 if (smokeRenderer != null)
                 {
-                    smokeRenderer.maxParticleSize = 80f;
+                    smokeRenderer.maxParticleSize = 40f;
                     Shader alphaBlendedShader = Shader.Find("KSP/Particles/Alpha Blended");
                     if (alphaBlendedShader != null)
                     {

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -5972,7 +5972,7 @@ namespace Parsek
                         var emission = flame.emission;
                         emission.rateOverTime = flameFraction * GhostVisualBuilder.ReentryFlameMaxEmission;
                         var main = flame.main;
-                        main.startSize = Mathf.Lerp(1f, 5f, flameFraction);
+                        main.startSize = Mathf.Lerp(0.5f, 2f, flameFraction);
                         if (surfaceVel.sqrMagnitude > 1f)
                             flame.transform.rotation = Quaternion.LookRotation(surfaceVel.normalized);
                         if (!flame.isPlaying) flame.Play();
@@ -6001,7 +6001,7 @@ namespace Parsek
                         var emission = smoke.emission;
                         emission.rateOverTime = smokeFraction * GhostVisualBuilder.ReentrySmokeMaxEmission;
                         var main = smoke.main;
-                        main.startSize = Mathf.Lerp(2f, 10f, smokeFraction);
+                        main.startSize = Mathf.Lerp(1f, 5f, smokeFraction);
                         if (surfaceVel.sqrMagnitude > 1f)
                             smoke.transform.rotation = Quaternion.LookRotation(surfaceVel.normalized);
                         if (!smoke.isPlaying) smoke.Play();


### PR DESCRIPTION
## Summary
- **Root cause:** Flame particles used `SimulationSpace.Local`, keeping them stuck to the vessel as a cluster of oversized billboard quads instead of trailing naturally in world space. Vessel rotation during re-entry also caused the flame cloud to swing to the wrong side of the velocity vector.
- **Fix:** Switch flame to `SimulationSpace.World` so particles trail behind as the vessel outruns them. Reduce particle sizes, tighten the emission cone, and lower the screen-space size clamp for a smoother flame trail.
- Smoke layer (already World space) also gets proportional size reductions.

## Changes
**GhostVisualBuilder.cs** (`TryBuildReentryFx`):
- Flame: `Local` → `World` sim space, lifetime 0.15–0.5s (was 0.3–0.8), startSize 0.5–1.5 (was 2–5), startSpeed 1–5 (was 5–15), cone angle 15° (was 25°), radius 0.3 (was 1.0), maxParticleSize 15 (was 80)
- Smoke: startSize 1.5–4 (was 3–8), radius 0.3 (was 0.5), maxParticleSize 40 (was 80)

**ParsekFlight.cs** (`DriveReentryLayers`):
- Flame runtime size ramp: Lerp(0.5, 2) (was 1–5)
- Smoke runtime size ramp: Lerp(1, 5) (was 2–10)

## Test plan
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 1218 pass, 0 fail
- [ ] In-game: play back Suborbital Arc recording, verify flame trail appears as a smooth trailing wake (not blocky square patches)
- [ ] In-game: verify flame trail extends behind the vessel (retrograde) and originates from the prograde face
- [ ] In-game: verify smoke trail is proportionally smaller and blends smoothly

🤖 Generated with [Claude Code](https://claude.com/claude-code)