### PR TITLE
Recenter camera on separation events during ghost playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Parsek was inspired by and learned from the KSP modding community. The following
 - **[Kerbal Alarm Clock](https://github.com/TriggerAu/KerbalAlarmClock)** (TriggerAu) - time-based event scheduling
 - **[ClickThroughBlocker](https://github.com/linuxgurugamer/ClickThroughBlocker)** (linuxgurugamer) - UI click-through prevention
 - **[ToolbarControl](https://github.com/linuxgurugamer/ToolbarControl)** (linuxgurugamer) - toolbar integration
+- **[Camera Focus Changer](https://github.com/linuxgurugamer/camerafocuschanger)** (linuxgurugamer) - camera pivot techniques for ghost vessel tracking
 - **[Module Manager](https://github.com/sarbian/ModuleManager)** (sarbian) - essential config patching
 - **[Harmony (HarmonyKSP)](https://github.com/KSPModdingLibs/HarmonyKSP)** (KSPModdingLibs / pardeike) - runtime method patching
 

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -268,6 +268,7 @@ namespace Parsek
         float savedCameraPitch = 0f;
         float savedCameraHeading = 0f;
         double watchEndHoldUntilUT = -1;      // non-looped end hold timer
+        float savedPivotSharpness = 0.5f;
 
         // UI
         private Rect windowRect = new Rect(20, 100, 250, 250);
@@ -809,6 +810,8 @@ namespace Parsek
                 }
             }
             ghostPosEntries.Clear();
+
+            UpdateWatchCamera();
         }
 
         void OnGUI()
@@ -4958,7 +4961,6 @@ namespace Parsek
                 rec.VesselName);
 
             ghostStates[index] = state;
-            RecalculateCameraPivot(state);
         }
 
         internal void DestroyTimelineGhost(int index)
@@ -6232,17 +6234,50 @@ namespace Parsek
         }
 
         /// <summary>
-        /// Set the camera pivot to the root part position (localPosition zero).
-        /// This matches KSP's own camera behavior which orbits around the root part
-        /// (command pod). The root part is always in the surviving stage after decoupling.
+        /// Recalculate cameraPivot position after a visibility change (decouple/destroy).
+        /// Sets localPosition to midpoint of remaining active parts' bounding extent.
         /// </summary>
         static void RecalculateCameraPivot(GhostPlaybackState state)
         {
-            if (state.cameraPivot == null || state.ghost == null) return;
-            state.cameraPivot.localPosition = Vector3.zero;
-            ParsekLog.Info("Flight",
-                $"Camera pivot set to root part origin (0,0,0)" +
-                $" ghostPos=({state.ghost.transform.position.x:F1},{state.ghost.transform.position.y:F1},{state.ghost.transform.position.z:F1})");
+            if (state.ghost == null || state.cameraPivot == null) return;
+            var ghostTransform = state.ghost.transform;
+            int count = 0;
+            Vector3 min = Vector3.zero, max = Vector3.zero;
+            for (int i = 0; i < ghostTransform.childCount; i++)
+            {
+                var child = ghostTransform.GetChild(i);
+                if (!child.gameObject.activeSelf || !child.name.StartsWith("ghost_part_"))
+                    continue;
+                var pos = child.localPosition;
+                if (count == 0) { min = max = pos; }
+                else { min = Vector3.Min(min, pos); max = Vector3.Max(max, pos); }
+                count++;
+            }
+            state.cameraPivot.localPosition = count > 0 ? (min + max) * 0.5f : Vector3.zero;
+            ParsekLog.Info("CameraFollow",
+                $"Camera pivot recalculated: localPos=({state.cameraPivot.localPosition.x:F2},{state.cameraPivot.localPosition.y:F2},{state.cameraPivot.localPosition.z:F2})" +
+                $" activeParts={count}");
+        }
+
+        /// <summary>
+        /// Drive the camera pivot position every frame during watch mode.
+        /// pivotTranslateSharpness is zeroed for the entire watch session to prevent
+        /// KSP from pulling the camera back toward the active vessel.
+        /// </summary>
+        void UpdateWatchCamera()
+        {
+            if (watchedRecordingIndex < 0) return;
+
+            GhostPlaybackState state;
+            if (!ghostStates.TryGetValue(watchedRecordingIndex, out state) ||
+                state == null || state.cameraPivot == null)
+                return;
+
+            // Keep sharpness zeroed — KSP resets it on various events
+            FlightCamera.fetch.pivotTranslateSharpness = 0f;
+
+            // Drive camera orbit center to the cameraPivot's world position
+            FlightCamera.fetch.transform.parent.position = state.cameraPivot.position;
         }
 
         bool IsAnyWarpActive()
@@ -6451,7 +6486,11 @@ namespace Parsek
                 savedCameraDistance = FlightCamera.fetch.Distance;
                 savedCameraPitch = FlightCamera.fetch.camPitch;
                 savedCameraHeading = FlightCamera.fetch.camHdg;
+                savedPivotSharpness = FlightCamera.fetch.pivotTranslateSharpness;
             }
+
+            // Disable KSP's internal pivot tracking — we drive the camera manually
+            FlightCamera.fetch.pivotTranslateSharpness = 0f;
 
             // Point camera at ghost (use cameraPivot — centroid of active parts)
             var watchTarget = gs.cameraPivot ?? gs.ghost.transform;
@@ -6483,6 +6522,7 @@ namespace Parsek
         internal void ExitWatchMode(bool skipCameraRestore = false)
         {
             if (watchedRecordingIndex < 0) return;
+            FlightCamera.fetch.pivotTranslateSharpness = savedPivotSharpness;
 
             // Restore camera to the active vessel (unless switching between ghosts)
             if (!skipCameraRestore)

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -1251,9 +1251,15 @@ namespace Parsek
             {
                 GhostPlaybackState ws;
                 if (ghostStates.TryGetValue(watchedRecordingIndex, out ws) && ws != null && ws.ghost != null)
-                    FlightCamera.fetch.SetTargetTransform(ws.cameraPivot ?? ws.ghost.transform);
-                ParsekLog.Verbose("CameraFollow",
-                    $"onVesselChange fired while watching \u2014 re-targeting camera to ghost #{watchedRecordingIndex}");
+                {
+                    var target = ws.cameraPivot ?? ws.ghost.transform;
+                    FlightCamera.fetch.SetTargetTransform(target);
+                    ParsekLog.Info("CameraFollow",
+                        $"onVesselChange re-target: ghost #{watchedRecordingIndex}" +
+                        $" target='{target.name}' localPos=({target.localPosition.x:F2},{target.localPosition.y:F2},{target.localPosition.z:F2})" +
+                        $" worldPos=({target.position.x:F1},{target.position.y:F1},{target.position.z:F1})" +
+                        $" camDist={FlightCamera.fetch.Distance:F1}");
+                }
             }
 
             if (activeTree == null) return;
@@ -4570,7 +4576,14 @@ namespace Parsek
 
                 // Ghost was rebuilt for new loop cycle — re-target camera
                 if (watchedRecordingIndex == recIdx && state.ghost != null)
-                    FlightCamera.fetch.SetTargetTransform(state.cameraPivot ?? state.ghost.transform);
+                {
+                    var target = state.cameraPivot ?? state.ghost.transform;
+                    FlightCamera.fetch.SetTargetTransform(target);
+                    ParsekLog.Info("CameraFollow",
+                        $"Loop rebuild re-target: ghost #{recIdx}" +
+                        $" target='{target.name}' localPos=({target.localPosition.x:F2},{target.localPosition.y:F2},{target.localPosition.z:F2})" +
+                        $" camDist={FlightCamera.fetch.Distance:F1}");
+                }
             }
 
             if (state == null || state.ghost == null)
@@ -6219,26 +6232,17 @@ namespace Parsek
         }
 
         /// <summary>
-        /// Recompute the camera pivot to the centroid of all active ghost_part_ children.
-        /// Called after part visibility changes (decouple, destroy, etc.) so the camera
-        /// stays centered on the remaining visible mesh.
+        /// Set the camera pivot to the root part position (localPosition zero).
+        /// This matches KSP's own camera behavior which orbits around the root part
+        /// (command pod). The root part is always in the surviving stage after decoupling.
         /// </summary>
         static void RecalculateCameraPivot(GhostPlaybackState state)
         {
             if (state.cameraPivot == null || state.ghost == null) return;
-            var ghostTransform = state.ghost.transform;
-            int count = 0;
-            Vector3 sum = Vector3.zero;
-            for (int i = 0; i < ghostTransform.childCount; i++)
-            {
-                var child = ghostTransform.GetChild(i);
-                if (child.gameObject.activeSelf && child.name.StartsWith("ghost_part_"))
-                {
-                    sum += child.localPosition;
-                    count++;
-                }
-            }
-            state.cameraPivot.localPosition = count > 0 ? sum / count : Vector3.zero;
+            state.cameraPivot.localPosition = Vector3.zero;
+            ParsekLog.Info("Flight",
+                $"Camera pivot set to root part origin (0,0,0)" +
+                $" ghostPos=({state.ghost.transform.position.x:F1},{state.ghost.transform.position.y:F1},{state.ghost.transform.position.z:F1})");
         }
 
         bool IsAnyWarpActive()
@@ -6450,10 +6454,14 @@ namespace Parsek
             }
 
             // Point camera at ghost (use cameraPivot — centroid of active parts)
-            FlightCamera.fetch.SetTargetTransform(gs.cameraPivot ?? gs.ghost.transform);
+            var watchTarget = gs.cameraPivot ?? gs.ghost.transform;
+            FlightCamera.fetch.SetTargetTransform(watchTarget);
             FlightCamera.fetch.SetDistance(50f);  // override [75,400] entry clamp
-            ParsekLog.Verbose("CameraFollow",
-                $"FlightCamera.SetTargetTransform on ghost #{index} at {gs.ghost.transform.position}, distance={FlightCamera.fetch.Distance.ToString("F1", CultureInfo.InvariantCulture)}");
+            ParsekLog.Info("CameraFollow",
+                $"EnterWatchMode: ghost #{index} \"{committed[index].VesselName}\"" +
+                $" target='{watchTarget.name}' pivotLocal=({watchTarget.localPosition.x:F2},{watchTarget.localPosition.y:F2},{watchTarget.localPosition.z:F2})" +
+                $" ghostPos=({gs.ghost.transform.position.x:F1},{gs.ghost.transform.position.y:F1},{gs.ghost.transform.position.z:F1})" +
+                $" camDist={FlightCamera.fetch.Distance.ToString("F1", CultureInfo.InvariantCulture)}");
 
             // Block inputs that could affect the active vessel
             InputLockManager.SetControlLock(WatchModeLockMask, WatchModeLockId);
@@ -6701,13 +6709,17 @@ namespace Parsek
             savedCameraPitch = preservedPitch;
             savedCameraHeading = preservedHeading;
 
-            FlightCamera.fetch.SetTargetTransform(gs.cameraPivot ?? gs.ghost.transform);
+            var segTarget = gs.cameraPivot ?? gs.ghost.transform;
+            FlightCamera.fetch.SetTargetTransform(segTarget);
             InputLockManager.SetControlLock(WatchModeLockMask, WatchModeLockId);
 
             watchEndHoldUntilUT = -1;
 
-            ParsekLog.Verbose("CameraFollow",
-                $"Camera re-targeted to ghost #{nextIndex} at {gs.ghost.transform.position}");
+            ParsekLog.Info("CameraFollow",
+                $"TransferWatch re-target: ghost #{nextIndex} \"{newName}\"" +
+                $" target='{segTarget.name}' pivotLocal=({segTarget.localPosition.x:F2},{segTarget.localPosition.y:F2},{segTarget.localPosition.z:F2})" +
+                $" ghostPos=({gs.ghost.transform.position.x:F1},{gs.ghost.transform.position.y:F1},{gs.ghost.transform.position.z:F1})" +
+                $" camDist={FlightCamera.fetch.Distance:F1}");
         }
 
         #endregion

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -5309,10 +5309,12 @@ namespace Parsek
                         break;
                     case PartEventType.InventoryPartPlaced:
                         SetGhostPartActive(ghost, evt.partPersistentId, true);
+                        visibilityChanged = true;
                         Log($"Part event applied: InventoryPartPlaced '{evt.partName}' pid={evt.partPersistentId}");
                         break;
                     case PartEventType.InventoryPartRemoved:
                         SetGhostPartActive(ghost, evt.partPersistentId, false);
+                        visibilityChanged = true;
                         Log($"Part event applied: InventoryPartRemoved '{evt.partName}' pid={evt.partPersistentId}");
                         break;
                 }
@@ -5320,7 +5322,7 @@ namespace Parsek
             }
 
             state.partEventIndex = evtIdx;
-            if (visibilityChanged && recIdx == watchedRecordingIndex)
+            if (visibilityChanged)
                 RecalculateCameraPivot(state);
             UpdateBlinkingLights(state, currentUT);
             UpdateActiveRobotics(state, currentUT);

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -66,6 +66,7 @@ namespace Parsek
             public Dictionary<uint, FairingGhostInfo> fairingInfos;
             public Dictionary<uint, GameObject> fakeCanopies;
             public ReentryFxInfo reentryFxInfo;
+            public Transform cameraPivot; // child of ghost; centroid of active parts — camera targets this
             public Vector3 lastInterpolatedVelocity;
             public string lastInterpolatedBodyName;
             public double lastInterpolatedAltitude;
@@ -1250,7 +1251,7 @@ namespace Parsek
             {
                 GhostPlaybackState ws;
                 if (ghostStates.TryGetValue(watchedRecordingIndex, out ws) && ws != null && ws.ghost != null)
-                    FlightCamera.fetch.SetTargetTransform(ws.ghost.transform);
+                    FlightCamera.fetch.SetTargetTransform(ws.cameraPivot ?? ws.ghost.transform);
                 ParsekLog.Verbose("CameraFollow",
                     $"onVesselChange fired while watching \u2014 re-targeting camera to ghost #{watchedRecordingIndex}");
             }
@@ -4569,7 +4570,7 @@ namespace Parsek
 
                 // Ghost was rebuilt for new loop cycle — re-target camera
                 if (watchedRecordingIndex == recIdx && state.ghost != null)
-                    FlightCamera.fetch.SetTargetTransform(state.ghost.transform);
+                    FlightCamera.fetch.SetTargetTransform(state.cameraPivot ?? state.ghost.transform);
             }
 
             if (state == null || state.ghost == null)
@@ -4834,9 +4835,13 @@ namespace Parsek
                     : $"Timeline ghost #{index}: built from vessel snapshot");
             }
 
+            var cameraPivotObj = new GameObject("cameraPivot");
+            cameraPivotObj.transform.SetParent(ghost.transform, false);
+
             var state = new GhostPlaybackState
             {
                 ghost = ghost,
+                cameraPivot = cameraPivotObj.transform,
                 playbackIndex = 0,
                 partEventIndex = 0,
                 partTree = GhostVisualBuilder.BuildPartSubtreeMap(GhostVisualBuilder.GetGhostSnapshot(rec))
@@ -4940,6 +4945,7 @@ namespace Parsek
                 rec.VesselName);
 
             ghostStates[index] = state;
+            RecalculateCameraPivot(state);
         }
 
         internal void DestroyTimelineGhost(int index)
@@ -5090,6 +5096,7 @@ namespace Parsek
             int evtIdx = state.partEventIndex;
             var tree = state.partTree;
             var ghost = state.ghost;
+            bool visibilityChanged = false;
 
             while (evtIdx < rec.PartEvents.Count && rec.PartEvents[evtIdx].ut <= currentUT)
             {
@@ -5106,6 +5113,7 @@ namespace Parsek
                             HideGhostPart(ghost, evt.partPersistentId);
                         Log($"Part event applied: Decoupled '{evt.partName}' pid={evt.partPersistentId}");
                         GhostVisualBuilder.RebuildReentryMeshes(ghost, state.reentryFxInfo);
+                        visibilityChanged = true;
                         break;
                     case PartEventType.Destroyed:
                         StopEngineFxForPart(state, evt.partPersistentId);
@@ -5114,6 +5122,7 @@ namespace Parsek
                         HideGhostPart(ghost, evt.partPersistentId);
                         Log($"Part event applied: Destroyed '{evt.partName}' pid={evt.partPersistentId}");
                         GhostVisualBuilder.RebuildReentryMeshes(ghost, state.reentryFxInfo);
+                        visibilityChanged = true;
                         break;
                     case PartEventType.ParachuteCut:
                         if (state.parachuteInfos != null)
@@ -5148,6 +5157,7 @@ namespace Parsek
                         DestroyFakeCanopy(state, evt.partPersistentId);
                         HideGhostPart(ghost, evt.partPersistentId);
                         Log($"Part event applied: ParachuteDestroyed '{evt.partName}' pid={evt.partPersistentId}");
+                        visibilityChanged = true;
                         break;
                     case PartEventType.ParachuteSemiDeployed:
                         if (state.parachuteInfos != null)
@@ -5310,6 +5320,8 @@ namespace Parsek
             }
 
             state.partEventIndex = evtIdx;
+            if (visibilityChanged && recIdx == watchedRecordingIndex)
+                RecalculateCameraPivot(state);
             UpdateBlinkingLights(state, currentUT);
             UpdateActiveRobotics(state, currentUT);
         }
@@ -6204,6 +6216,29 @@ namespace Parsek
             }
         }
 
+        /// <summary>
+        /// Recompute the camera pivot to the centroid of all active ghost_part_ children.
+        /// Called after part visibility changes (decouple, destroy, etc.) so the camera
+        /// stays centered on the remaining visible mesh.
+        /// </summary>
+        static void RecalculateCameraPivot(GhostPlaybackState state)
+        {
+            if (state.cameraPivot == null || state.ghost == null) return;
+            var ghostTransform = state.ghost.transform;
+            int count = 0;
+            Vector3 sum = Vector3.zero;
+            for (int i = 0; i < ghostTransform.childCount; i++)
+            {
+                var child = ghostTransform.GetChild(i);
+                if (child.gameObject.activeSelf && child.name.StartsWith("ghost_part_"))
+                {
+                    sum += child.localPosition;
+                    count++;
+                }
+            }
+            state.cameraPivot.localPosition = count > 0 ? sum / count : Vector3.zero;
+        }
+
         bool IsAnyWarpActive()
         {
             // CurrentRateIndex > 0 covers both rails warp and physics warp.
@@ -6412,8 +6447,8 @@ namespace Parsek
                 savedCameraHeading = FlightCamera.fetch.camHdg;
             }
 
-            // Point camera at ghost
-            FlightCamera.fetch.SetTargetTransform(gs.ghost.transform);
+            // Point camera at ghost (use cameraPivot — centroid of active parts)
+            FlightCamera.fetch.SetTargetTransform(gs.cameraPivot ?? gs.ghost.transform);
             FlightCamera.fetch.SetDistance(50f);  // override [75,400] entry clamp
             ParsekLog.Verbose("CameraFollow",
                 $"FlightCamera.SetTargetTransform on ghost #{index} at {gs.ghost.transform.position}, distance={FlightCamera.fetch.Distance.ToString("F1", CultureInfo.InvariantCulture)}");
@@ -6664,7 +6699,7 @@ namespace Parsek
             savedCameraPitch = preservedPitch;
             savedCameraHeading = preservedHeading;
 
-            FlightCamera.fetch.SetTargetTransform(gs.ghost.transform);
+            FlightCamera.fetch.SetTargetTransform(gs.cameraPivot ?? gs.ghost.transform);
             InputLockManager.SetControlLock(WatchModeLockMask, WatchModeLockId);
 
             watchEndHoldUntilUT = -1;


### PR DESCRIPTION
## Summary
- Zero `FlightCamera.pivotTranslateSharpness` during watch mode to prevent KSP from pulling the camera back toward the active vessel
- Drive camera pivot position every frame in `LateUpdate` via `UpdateWatchCamera()`, keeping the orbit center locked on the ghost
- `RecalculateCameraPivot` computes the midpoint of remaining active `ghost_part_` children after decouple/destroy events, shifting the `cameraPivot` child transform so the camera recenters on the surviving stage
- Save/restore `pivotTranslateSharpness` on enter/exit watch mode
- All `SetTargetTransform` calls target `cameraPivot ?? ghost.transform` with diagnostic logging
- Camera Focus Changer mod added to README acknowledgements (technique reference)

## Test plan
- [x] `dotnet build` succeeds
- [x] In-game: camera starts centered on root part for full vessel
- [x] In-game: camera recenters on upper stage after separation
- [x] In-game: camera stays centered after separation (no drift back to active vessel)
- [x] In-game: verify loop playback correctly resets camera pivot when ghost is rebuilt
- [x] In-game: verify exit watch mode restores normal camera behavior