### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/Source/Parsek/Properties/AssemblyInfo.cs
+++ b/Source/Parsek/Properties/AssemblyInfo.cs
@@ -17,7 +17,7 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("a1b2c3d4-e5f6-7890-abcd-ef1234567890")]
 
-[assembly: AssemblyVersion("0.3.1.0")]
-[assembly: AssemblyFileVersion("0.3.1.0")]
+[assembly: AssemblyVersion("0.4.0.0")]
+[assembly: AssemblyFileVersion("0.4.0.0")]
 
-[assembly: KSPAssembly("Parsek", 0, 3)]
+[assembly: KSPAssembly("Parsek", 0, 4)]

--- a/Source/README.md
+++ b/Source/README.md
@@ -9,20 +9,38 @@ Parsek/
 ├── FlightRecorder.cs          # Physics-frame recording logic (Harmony-driven, part event polling)
 ├── ParsekHarmony.cs           # Harmony patcher entry point (KSPAddon.Startup.Instantly)
 ├── Patches/
-│   └── PhysicsFramePatch.cs   # Harmony postfix hook for per-frame sampling
+│   ├── PhysicsFramePatch.cs   # Harmony postfix hook for per-frame sampling
+│   ├── TechResearchPatch.cs   # Action blocking: prevent re-researching committed tech
+│   ├── FacilityUpgradePatch.cs # Action blocking: prevent re-upgrading committed facilities
+│   └── ScienceSubjectPatch.cs # Science subject tracking patch
 ├── ParsekUI.cs                # UI windows (main window, recordings manager) and map view markers
+├── ParsekSettings.cs          # GameParameters settings (auto-record, thresholds)
 ├── RecordingStore.cs          # Static storage for pending/committed recordings (survives scene changes)
 ├── ParsekScenario.cs          # ScenarioModule - persists recordings to save games, crew reservation
 ├── ParsekLog.cs               # Shared logging utilities
 ├── TrajectoryPoint.cs         # Position/rotation/resource data struct
-├── TrajectoryMath.cs          # Pure static math (sampling, interpolation, orbit search)
-├── OrbitSegment.cs            # Keplerian orbit parameters for on-rails recording
+├── TrajectoryMath.cs          # Pure static math (sampling, interpolation, orbit search, orbital-frame rotation)
+├── OrbitSegment.cs            # Keplerian orbit parameters + orbital-frame rotation for on-rails recording
 ├── PartEvent.cs               # Part event enum + struct (28 event types)
-├── GhostVisualBuilder.cs      # Ghost mesh building from vessel snapshots (engine/RCS FX, fairings)
+├── GhostVisualBuilder.cs      # Ghost mesh building from vessel snapshots (engine/RCS FX, fairings, re-entry)
 ├── VesselSpawner.cs           # Vessel spawn/recover/snapshot utilities
 ├── MergeDialog.cs             # Post-revert merge dialog
 ├── RecordingPaths.cs          # Save-scoped path resolution for external recording files
-└── ParsekToolbarRegistration.cs # ToolbarControl registration
+├── ParsekToolbarRegistration.cs # ToolbarControl registration
+├── ActionReplay.cs            # Replays committed game actions (tech, parts, facilities) after rewind
+├── CommittedActionDialog.cs   # Popup dialog for blocked actions
+├── GameStateEvent.cs          # Career event struct (tech, parts, facilities, contracts, crew, resources)
+├── GameStateRecorder.cs       # Subscribes to KSP career GameEvents, records into GameStateStore
+├── GameStateStore.cs          # Static persistent event log
+├── GameStateBaseline.cs       # Full game state snapshot at commit points
+├── Milestone.cs               # Groups game state events into committed timeline units
+├── MilestoneStore.cs          # Milestone collection management
+├── ResourceBudget.cs          # On-the-fly resource budget computation from recordings + milestones
+├── RecordingTree.cs           # Rooted DAG of recordings for multi-vessel missions
+├── BranchPoint.cs             # Links parent/child recordings at split/merge events
+├── BackgroundRecorder.cs      # Dual-mode recording for non-active tree vessels
+├── TerminalState.cs           # How a recording ended (8 end conditions)
+└── SurfacePosition.cs         # Background recording data for landed/splashed vessels
 
 Parsek.Tests/
 ├── Generators/
@@ -30,11 +48,10 @@ Parsek.Tests/
 │   ├── VesselSnapshotBuilder.cs     # Minimal VESSEL ConfigNode builder
 │   └── ScenarioWriter.cs           # SCENARIO assembly + .sfs injection
 ├── WaypointSearchTests.cs           # FindWaypointIndex binary search tests
-├── InterpolationTests.cs            # Interpolation and edge case tests
 ├── TrajectoryPointTests.cs          # TrajectoryPoint struct tests
 ├── QuaternionSanitizationTests.cs   # Quaternion NaN/Infinity handling tests
 ├── AdaptiveSamplingTests.cs         # Adaptive threshold sampling tests
-├── OrbitSegmentTests.cs             # Orbit segment serialization tests
+├── OrbitSegmentTests.cs             # Orbit segment + orbital-frame rotation tests
 ├── RecordingStoreTests.cs           # RecordingStore stash/commit/discard tests
 ├── VesselPersistenceTests.cs        # Merge-decision logic tests
 ├── PartEventTests.cs                # Part event serialization, subtree, transition tests
@@ -43,7 +60,33 @@ Parsek.Tests/
 ├── DiagnosticLoggingTests.cs        # Regression tests for playback logging
 ├── RuntimePolicyTests.cs            # Runtime decision logic tests
 ├── RecordingsManagerTests.cs        # Recordings Manager UI logic tests
-└── SyntheticRecordingTests.cs       # Synthetic recording generation + save file injection
+├── SyntheticRecordingTests.cs       # Synthetic recording generation + save file injection
+├── ActionReplayTests.cs             # Action replay tests
+├── AtmosphereSplitTests.cs          # Atmosphere boundary split tests
+├── BackgroundRecorderTests.cs       # Background recorder tests
+├── BackwardCompatTests.cs           # Backward compatibility tests
+├── CameraFollowTests.cs            # Camera follow ghost tests
+├── CommittedActionTests.cs          # Committed action blocking tests
+├── ComputeStatsTests.cs            # Recording statistics computation tests
+├── FxDiagnosticsTests.cs           # FX diagnostic logging tests
+├── GameStateEventTests.cs          # Game state event serialization tests
+├── LiveKspLogValidationTests.cs    # KSP.log contract validation
+├── MergeDialogTests.cs             # Merge dialog logic tests
+├── MergeEventDetectionTests.cs     # Tree merge event detection tests
+├── MilestoneTests.cs               # Milestone creation/replay tests
+├── ParsekLogTests.cs               # Logging utility tests
+├── ParsekKspLogParserTests.cs      # KSP log parser tests
+├── ParsekLogContractCheckerTests.cs # Log contract checker tests
+├── RecordingTreeTests.cs           # Recording tree serialization/query tests
+├── ReentryIntensityTests.cs        # Re-entry FX intensity formula tests
+├── ResourceBudgetTests.cs          # Resource budget computation tests
+├── RewindTests.cs                  # Rewind logic tests
+├── RewindLoggingTests.cs           # Rewind diagnostic logging tests
+├── SplitEventDetectionTests.cs     # Tree split event detection tests
+├── TerminalEventTests.cs           # Terminal event detection tests
+├── TreeCommitTests.cs              # Tree commit logic tests
+├── TreeLogVerificationTests.cs     # Tree logging verification tests
+└── VesselSwitchTreeTests.cs        # Vessel switch tree decision tests
 ```
 
 ## Building
@@ -86,7 +129,7 @@ cd Source/Parsek.Tests
 dotnet test
 ```
 
-652 tests total: 651 pass, 1 skipped (QuaternionSlerp NaN edge case - Unity behavior).
+1263 tests total.
 
 ### Live KSP Log Validation
 

--- a/Source/README.md
+++ b/Source/README.md
@@ -220,7 +220,7 @@ The script exits non-zero if required log contracts fail.
 - **TrajectoryPoint** - struct storing per-tick data: position (lat/lon/alt), rotation, velocity, body name, and career resources (funds, science, reputation). All timestamps use absolute UT.
 - **PartEvent** - struct + enum covering 28 event types: decoupled, destroyed, parachute deploy/cut/destroyed, shroud jettison, engine ignition/shutdown/throttle, deployable extend/retract, light on/off/blink, gear deploy/retract, cargo bay open/close, fairing jettison, RCS activate/stop/throttle, dock/undock, inventory place/remove.
 
-### External Recording Files (v4)
+### External Recording Files (v5)
 
 Bulk data (trajectory points, orbit segments, part events, snapshots) is stored in external sidecar files under `saves/<save>/Parsek/Recordings/`, keeping the `.sfs` save file lightweight. File types: `.prec` (trajectory), `_vessel.craft` / `_ghost.craft` (vessel snapshots). Safe-write via `.tmp` + rename.
 
@@ -234,7 +234,7 @@ On scene change (revert), the active vessel is snapshotted via `Vessel.BackupVes
 | Vessel moved >=100m AND destroyed | **Merge only** (trajectory captured) |
 | Vessel moved >=100m AND intact | **Persist** (respawn via ProtoVessel injection) |
 
-Vessel respawn uses `ProtoVessel` injection into `flightState.protoVessels`. Recovery uses `ShipConstruction.RecoverVesselFromFlight`. Vessel snapshots are persisted to external `.craft` sidecar files (v4 format).
+Vessel respawn uses `ProtoVessel` injection into `flightState.protoVessels`. Recovery uses `ShipConstruction.RecoverVesselFromFlight`. Vessel snapshots are persisted to external `.craft` sidecar files (v5 format).
 
 ### Crew Replacement System
 

--- a/docs/dev/known-bugs.md
+++ b/docs/dev/known-bugs.md
@@ -99,8 +99,6 @@ No format version bump — missing keys default to prograde fallback (backward c
 
 See `docs/dev/done/design-orbital-rotation.md` for full design.
 
-**Remaining open item:** `Planetarium.right` drift may cause minor orientation mismatch for very long orbital segments (interplanetary transfers). Requires empirical measurement before deciding whether to implement drift compensation (future Phase 6).
-
 **Status:** Fixed
 
 ## 17. Re-entry flame effects too large and pointing wrong direction

--- a/docs/dev/known-bugs.md
+++ b/docs/dev/known-bugs.md
@@ -97,7 +97,7 @@ Additionally, when the PersistentRotation mod is detected at recording time and 
 
 No format version bump — missing keys default to prograde fallback (backward compatible). Old Parsek versions ignore unknown keys (forward compatible).
 
-See `docs/dev/design-orbital-rotation.md` for full design.
+See `docs/dev/done/design-orbital-rotation.md` for full design.
 
 **Remaining open item:** `Planetarium.right` drift may cause minor orientation mismatch for very long orbital segments (interplanetary transfers). Requires empirical measurement before deciding whether to implement drift compensation (future Phase 6).
 

--- a/docs/parsek-architecture.md
+++ b/docs/parsek-architecture.md
@@ -1,8 +1,8 @@
 # Parsek: Preliminary Architecture
 
 ## Document Status
-**Version:** 1.0
-**Phase:** Phase 6 complete (recording tree / multi-vessel recording)
+**Version:** 1.1
+**Phase:** Parsek 0.4.0
 **Last Updated:** March 2026
 
 ---
@@ -496,13 +496,13 @@ Time advances
 
 ### Save Game Integration
 
-Using KSP's `ScenarioModule` system (`ParsekScenario`). Lightweight metadata + mutable playback state stored in the `.sfs` save file; bulk data stored in external per-recording sidecar files (format version 4).
+Using KSP's `ScenarioModule` system (`ParsekScenario`). Lightweight metadata + mutable playback state stored in the `.sfs` save file; bulk data stored in external per-recording sidecar files (format version 5).
 
-**In .sfs (per RECORDING node):** `recordingId`, `vesselName`, `pointCount`, `recordingFormatVersion = 4`, mutable state (`vesselDestroyed`, `takenControl`, `spawnedPid`, `lastResIdx`), EVA linkage, ghost geometry metadata.
+**In .sfs (per RECORDING node):** `recordingId`, `vesselName`, `pointCount`, `recordingFormatVersion = 5`, mutable state (`vesselDestroyed`, `takenControl`, `spawnedPid`, `lastResIdx`), EVA linkage, ghost geometry metadata.
 
 **No inline POINT, ORBIT_SEGMENT, PART_EVENT, or snapshot nodes** - all bulk data lives in external files.
 
-### External Recording Files (v4)
+### External Recording Files (v5)
 
 ```
 saves/<save-name>/Parsek/Recordings/
@@ -731,7 +731,7 @@ Localization files go in `GameData/Parsek/Localization/en-us.cfg`.
 - [x] Part event playback (decoupled subtrees hidden, destroyed parts hidden)
 - [x] Real parachute canopy deploy on ghost (semi-deployed animation sampled from prefab)
 - [x] Event-driven shroud jettison for ghost engine parts
-- [x] External recording files (v4) - bulk data in sidecar files, lightweight .sfs
+- [x] External recording files (v5) - bulk data in sidecar files, lightweight .sfs
 - [x] Engine FX on ghost vessels (modern EFFECTS + legacy fx_* prefab fallback)
 
 **Remaining for MVP:**
@@ -852,9 +852,9 @@ The architecture naturally enables use cases like racing your own ghosts, but th
 1. **Trajectory interpolation:** Linear (`Vector3.Lerp`, `Quaternion.Lerp`) - cubic adds complexity with negligible visual improvement at typical adaptive sample rates.
 2. **Ghost vessel rendering:** Opaque replica from prefab meshes with original materials. No shader modification.
 3. **SOI transitions:** Body name (`string BodyName`) per TrajectoryFrame. Naturally handles multi-body trajectories.
-4. **Recording file size:** External sidecar files (v4) - bulk data in `.prec` and `.craft` files, lightweight metadata in `.sfs`.
+4. **Recording file size:** External sidecar files (v5) - bulk data in `.prec` and `.craft` files, lightweight metadata in `.sfs`.
 5. **Recording tree is additive:** The tree layer builds on top of existing chains. Chain fields, per-segment loop/enable control, atmospheric/SOI phase splits, per-recording resource tracking, and chain merge dialogs are all preserved. The tree adds vessel split/merge tracking, not replaces existing infrastructure.
 
 ---
 
-*Document version: 1.0 - Phase 6 complete (recording tree / multi-vessel recording)*
+*Document version: 1.1 - Parsek 0.4.0 (orbital rotation fidelity, re-entry FX, camera follow)*

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -159,8 +159,8 @@ Making "jump into a ghost and fly it" reliable is desirable but creates paradox 
 
 Current status: experimental button exists in UI, not recommended for normal play.
 
-### Camera follow for ghost vessels
-Allow the player to move the camera to a recorded vessel during playback. Clicking a ghost (or selecting it from the UI) anchors the camera on that vessel, letting the player watch the mission from that perspective without interrupting their current flight.
+### ~~Camera follow for ghost vessels~~ (Done)
+The W (Watch) button in the Recordings Manager moves the camera to a ghost vessel during playback. The camera follows the ghost until the player presses Backspace to return. Camera automatically recenters on visible parts after separation events.
 
 ### Planetarium.right drift compensation for long orbital segments
 KSP's inertial reference frame (`Planetarium.right`) may drift over very long time warp durations. This could cause ghost orientation mismatch for interplanetary transfer segments. Needs empirical measurement first — if drift is sub-degree for typical segment lengths, no fix needed. If significant, store `Planetarium.right` snapshot at recording time and apply correction at playback (~10 lines + 3 ConfigNode keys). See `docs/dev/done/design-orbital-rotation.md` Phase 6.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -19,15 +19,15 @@ Like git, you can go back to any earlier point and start new work. Existing reco
 - Orbital/time-warp recording with analytical Keplerian orbits
 - Auto-recording on launch and EVA
 - Chained recordings (vessel → EVA → vessel, docking/undocking)
-- External recording files (v4 format)
+- External recording files (v5 format, surface-relative rotation)
 
 ### Phase 2: Ghost Visual Fidelity
 
 28 part event types recorded and replayed on ghost vessels: decoupling, staging, parachutes, engines (with FX), solar panels, antennas, radiators, landing gear, lights, cargo bays, fairings (runtime mesh), RCS (with FX), docking/undocking, inventory parts.
 
-Recordings Manager UI with sortable columns, per-recording loop/delete, and status indicators.
+Re-entry heating FX with mesh-surface fire particles matching stock KSP aeroFX intensity formula.
 
----
+Recordings Manager UI with sortable columns, per-recording loop/delete, and status indicators.
 
 ### Orbital Rotation Fidelity
 
@@ -38,6 +38,12 @@ When the PersistentRotation mod is detected, Parsek also records the vessel's an
 Old recordings without attitude data fall back to prograde (unchanged behavior). No format version bump required.
 
 **Design:** `docs/dev/done/design-orbital-rotation.md`
+
+### Camera Follow for Ghost Vessels
+
+The W (Watch) button in the Recordings Manager moves the camera to a ghost vessel during playback. The camera follows the ghost until the player presses Backspace to return. Camera automatically recenters on visible parts after separation events.
+
+**Design:** `docs/dev/done/design-camera-follow-ghost.md`
 
 ---
 
@@ -116,7 +122,7 @@ After rewind resource adjustment, `ActionReplay.ReplayCommittedActions` programm
 
 **Design:** `docs/dev/done/design-restore-points.md`, `docs/dev/done/design-going-back-in-time.md`
 
-**Test coverage:** 1251 tests (1250 pass, 1 known failure).
+**Test coverage:** 1263 tests.
 
 ---
 
@@ -148,7 +154,7 @@ The recording tree builds on top of the existing chain system. Each node in the 
 | 12. Tree verbose logging | 11 logging gaps filled across RecordingTree, ParsekFlight, ResourceBudget. |
 | 13. Tree test coverage | 18 non-vacuous tests + 3 synthetic tree recordings for in-game validation. |
 
-**Test coverage:** 1076 tests pass, 1 skipped, 0 failures.
+**Test coverage:** 1263 tests.
 
 ---
 
@@ -158,9 +164,6 @@ The recording tree builds on top of the existing chain system. Each node in the 
 Making "jump into a ghost and fly it" reliable is desirable but creates paradox problems: what happens to the recording's future events, reserved crew, and applied resource deltas? Each answer requires hard restrictions that may frustrate players. This needs careful design and should not be rushed.
 
 Current status: experimental button exists in UI, not recommended for normal play.
-
-### ~~Camera follow for ghost vessels~~ (Done)
-The W (Watch) button in the Recordings Manager moves the camera to a ghost vessel during playback. The camera follows the ghost until the player presses Backspace to return. Camera automatically recenters on visible parts after separation events.
 
 ### Planetarium.right drift compensation for long orbital segments
 KSP's inertial reference frame (`Planetarium.right`) may drift over very long time warp durations. This could cause ghost orientation mismatch for interplanetary transfer segments. Needs empirical measurement first — if drift is sub-degree for typical segment lengths, no fix needed. If significant, store `Planetarium.right` snapshot at recording time and apply correction at playback (~10 lines + 3 ConfigNode keys). See `docs/dev/done/design-orbital-rotation.md` Phase 6.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -162,6 +162,9 @@ Current status: experimental button exists in UI, not recommended for normal pla
 ### Camera follow for ghost vessels
 Allow the player to move the camera to a recorded vessel during playback. Clicking a ghost (or selecting it from the UI) anchors the camera on that vessel, letting the player watch the mission from that perspective without interrupting their current flight.
 
+### Planetarium.right drift compensation for long orbital segments
+KSP's inertial reference frame (`Planetarium.right`) may drift over very long time warp durations. This could cause ghost orientation mismatch for interplanetary transfer segments. Needs empirical measurement first — if drift is sub-degree for typical segment lengths, no fix needed. If significant, store `Planetarium.right` snapshot at recording time and apply correction at playback (~10 lines + 3 ConfigNode keys). See `docs/dev/done/design-orbital-rotation.md` Phase 6.
+
 ### Additional part event coverage
 - Control surface deflection (continuous float - thousands of events per flight, unclear visual value)
 - Robotics / Breaking Ground DLC (continuous servo motion, DLC-dependent)


### PR DESCRIPTION
## Summary

Version bump for the 0.4.0 release.

- AssemblyInfo: `0.3.1.0` → `0.4.0.0`, `KSPAssembly(0, 3)` → `(0, 4)`
- Source/README.md: updated file tree (35 source files, 42 test files) and test count (652 → 1263)
- known-bugs.md: fix design doc path for bug #16 (moved to `done/`)

## Changes since 0.3.1

### New features
- **Orbital rotation fidelity** — ghost vessels hold their recorded SAS orientation during orbital playback instead of always facing prograde (#33)
- **PersistentRotation mod support** — spinning vessels reproduced during orbital playback when the mod is detected
- **Camera recenters on ghost** after separation events during playback (#35)

### Bug fixes
- **#17**: Re-entry FX too large and wrong direction — replaced with mesh-surface fire particles (#30, #32)
- **#18**: Engine nozzle glow persists after shutdown (#28)
- **#19**: Watch button broken for looped segments (#28)
- **#21**: Ghost build warning spam — snapshot-less recordings no longer log every frame (#29)
- **#22**: Facility not found during action replay — downgraded to expected INFO (#29)
- **#23**: Dead ghost geometry stub removed, orphan file cleanup added (#31)
- **#24**: Part variant renderer false warnings — GAMEOBJECT rule filtering now recognized (#29)
- **v5 format sync**: Prevent double-migration on load (#34)

### Other
- Terrain clipping fix for Landing Craft / EVA recordings (#28)
- 1263 tests (up from ~650 at 0.3.0)
- Full documentation updates (README, roadmap, architecture, user guide)
- Supported Mods section added to README

🤖 Generated with [Claude Code](https://claude.com/claude-code)