### PR TITLE
Add explosion FX on impact end

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -56,6 +56,27 @@ pwsh -File scripts/validate-ksp-log.ps1            # structured log validation
 
 Alt+F12 opens Unity debug console in-game.
 
+## Logging Requirements
+
+Every action, state transition, guard condition skip, and FX lifecycle event MUST be logged. The KSP.log is our primary debugging tool — if it didn't get logged, it didn't happen.
+
+- Use `ParsekLog.Log` / `ParsekLog.Info` / `ParsekLog.Warn` for important events
+- Use `ParsekLog.Verbose` for high-frequency or detailed diagnostic info
+- Use `ParsekLog.VerboseRateLimited` for per-frame data (avoids log spam)
+- Include subsystem tag, relevant IDs (recording index, vessel name, part PID), and numeric values
+- Log format: `[Parsek][LEVEL][Subsystem] message` (handled by ParsekLog.Write)
+- See existing patterns in `ParsekFlight.cs` (ghost lifecycle) and `GhostVisualBuilder.cs` (FX build chain) for reference
+
+## Testing Requirements
+
+- Every new method with logic (guards, state transitions, decisions) needs unit tests
+- Pure/static methods should be `internal static` for direct testability
+- Use `ParsekLog.TestSinkForTesting` to capture log output and assert on it — log assertions verify that code paths executed and logged the expected data
+- Test pattern: `ParsekLog.TestSinkForTesting = line => logLines.Add(line)` in constructor, `ParsekLog.ResetTestOverrides()` in Dispose
+- Assert with: `Assert.Contains(logLines, l => l.Contains("[Subsystem]") && l.Contains("expected text"))`
+- Use `[Collection("Sequential")]` on test classes that touch shared static state (ParsekLog, RecordingStore, etc.)
+- See `RewindLoggingTests.cs` for the canonical log-capture test pattern
+
 ## Post-Change Checklist
 
 After any change to enums, event types, serialized fields, or schema:

--- a/Source/Parsek.Tests/ExplosionFxTests.cs
+++ b/Source/Parsek.Tests/ExplosionFxTests.cs
@@ -1,0 +1,239 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Parsek.Tests.Generators;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Tests for explosion FX trigger logic and RecordingBuilder terminal state support.
+    /// Validates guard conditions, logging, and serialization roundtrip.
+    /// </summary>
+    [Collection("Sequential")]
+    public class ExplosionFxTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public ExplosionFxTests()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+        }
+
+        // --- ShouldTriggerExplosion guard condition tests ---
+
+        [Fact]
+        public void ShouldTriggerExplosion_Destroyed_GhostAlive_ReturnsTrueAndLogs()
+        {
+            bool result = ParsekFlight.ShouldTriggerExplosion(
+                explosionAlreadyFired: false,
+                terminalState: TerminalState.Destroyed,
+                ghostExists: true,
+                vesselName: "TestVessel",
+                recIdx: 3);
+
+            Assert.True(result);
+            Assert.Contains(logLines, l =>
+                l.Contains("[ExplosionFx]") && l.Contains("will fire") && l.Contains("#3") && l.Contains("TestVessel"));
+        }
+
+        [Fact]
+        public void ShouldTriggerExplosion_AlreadyFired_ReturnsFalseAndLogs()
+        {
+            bool result = ParsekFlight.ShouldTriggerExplosion(
+                explosionAlreadyFired: true,
+                terminalState: TerminalState.Destroyed,
+                ghostExists: true,
+                vesselName: "TestVessel",
+                recIdx: 5);
+
+            Assert.False(result);
+            Assert.Contains(logLines, l =>
+                l.Contains("[ExplosionFx]") && l.Contains("already fired") && l.Contains("#5"));
+        }
+
+        [Fact]
+        public void ShouldTriggerExplosion_NotDestroyed_Landed_ReturnsFalseAndLogs()
+        {
+            bool result = ParsekFlight.ShouldTriggerExplosion(
+                explosionAlreadyFired: false,
+                terminalState: TerminalState.Landed,
+                ghostExists: true,
+                vesselName: "Lander",
+                recIdx: 1);
+
+            Assert.False(result);
+            Assert.Contains(logLines, l =>
+                l.Contains("[ExplosionFx]") && l.Contains("terminalState=Landed") && l.Contains("not Destroyed"));
+        }
+
+        [Fact]
+        public void ShouldTriggerExplosion_NullTerminalState_ReturnsFalseAndLogs()
+        {
+            bool result = ParsekFlight.ShouldTriggerExplosion(
+                explosionAlreadyFired: false,
+                terminalState: null,
+                ghostExists: true,
+                vesselName: "Legacy",
+                recIdx: 0);
+
+            Assert.False(result);
+            Assert.Contains(logLines, l =>
+                l.Contains("[ExplosionFx]") && l.Contains("terminalState=null") && l.Contains("not Destroyed"));
+        }
+
+        [Fact]
+        public void ShouldTriggerExplosion_GhostNull_ReturnsFalseAndLogs()
+        {
+            bool result = ParsekFlight.ShouldTriggerExplosion(
+                explosionAlreadyFired: false,
+                terminalState: TerminalState.Destroyed,
+                ghostExists: false,
+                vesselName: "NoGhost",
+                recIdx: 7);
+
+            Assert.False(result);
+            Assert.Contains(logLines, l =>
+                l.Contains("[ExplosionFx]") && l.Contains("ghost GO is null") && l.Contains("#7"));
+        }
+
+        [Theory]
+        [InlineData(TerminalState.Orbiting)]
+        [InlineData(TerminalState.Splashed)]
+        [InlineData(TerminalState.SubOrbital)]
+        [InlineData(TerminalState.Recovered)]
+        [InlineData(TerminalState.Docked)]
+        [InlineData(TerminalState.Boarded)]
+        public void ShouldTriggerExplosion_NonDestroyedStates_AllReturnFalse(TerminalState state)
+        {
+            bool result = ParsekFlight.ShouldTriggerExplosion(
+                explosionAlreadyFired: false,
+                terminalState: state,
+                ghostExists: true,
+                vesselName: "Vessel",
+                recIdx: 0);
+
+            Assert.False(result);
+            Assert.Contains(logLines, l =>
+                l.Contains("[ExplosionFx]") && l.Contains("not Destroyed"));
+        }
+
+        // --- Guard evaluation order: already-fired checked before terminal state ---
+
+        [Fact]
+        public void ShouldTriggerExplosion_AlreadyFired_SkipsBeforeCheckingTerminalState()
+        {
+            // Even with Destroyed state, already-fired should be checked first
+            ParsekFlight.ShouldTriggerExplosion(
+                explosionAlreadyFired: true,
+                terminalState: TerminalState.Destroyed,
+                ghostExists: true,
+                vesselName: "V",
+                recIdx: 0);
+
+            Assert.Contains(logLines, l => l.Contains("already fired"));
+            Assert.DoesNotContain(logLines, l => l.Contains("will fire"));
+        }
+
+        // --- RecordingBuilder.WithTerminalState serialization ---
+
+        [Fact]
+        public void WithTerminalState_Build_EmitsTerminalStateValue()
+        {
+            var builder = new RecordingBuilder("Crasher");
+            builder.WithTerminalState((int)TerminalState.Destroyed);
+            builder.AddPoint(100, -0.09, -74.5, 70);
+
+            var node = builder.Build();
+
+            string val = node.GetValue("terminalState");
+            Assert.NotNull(val);
+            Assert.Equal("4", val);
+        }
+
+        [Fact]
+        public void WithTerminalState_BuildV3Metadata_EmitsTerminalStateValue()
+        {
+            var builder = new RecordingBuilder("Crasher");
+            builder.WithTerminalState((int)TerminalState.Destroyed);
+            builder.AddPoint(100, -0.09, -74.5, 70);
+
+            var node = builder.BuildV3Metadata();
+
+            string val = node.GetValue("terminalState");
+            Assert.NotNull(val);
+            Assert.Equal("4", val);
+        }
+
+        [Fact]
+        public void WithoutTerminalState_Build_OmitsTerminalStateKey()
+        {
+            var builder = new RecordingBuilder("Normal");
+            builder.AddPoint(100, -0.09, -74.5, 70);
+
+            var node = builder.Build();
+
+            Assert.Null(node.GetValue("terminalState"));
+        }
+
+        [Fact]
+        public void WithoutTerminalState_BuildV3Metadata_OmitsTerminalStateKey()
+        {
+            var builder = new RecordingBuilder("Normal");
+            builder.AddPoint(100, -0.09, -74.5, 70);
+
+            var node = builder.BuildV3Metadata();
+
+            Assert.Null(node.GetValue("terminalState"));
+        }
+
+        [Theory]
+        [InlineData(0, "0")]   // Orbiting
+        [InlineData(1, "1")]   // Landed
+        [InlineData(4, "4")]   // Destroyed
+        [InlineData(5, "5")]   // Recovered
+        public void WithTerminalState_AllValues_RoundtripCorrectly(int stateInt, string expected)
+        {
+            var builder = new RecordingBuilder("V");
+            builder.WithTerminalState(stateInt);
+            builder.AddPoint(100, 0, 0, 70);
+
+            var buildNode = builder.Build();
+            Assert.Equal(expected, buildNode.GetValue("terminalState"));
+
+            var v3Node = builder.BuildV3Metadata();
+            Assert.Equal(expected, v3Node.GetValue("terminalState"));
+        }
+
+        // --- KscPadDestroyed synthetic recording has terminal state ---
+
+        [Fact]
+        public void KscPadDestroyed_HasDestroyedTerminalState()
+        {
+            var node = SyntheticRecordingTests.KscPadDestroyed().Build();
+
+            string val = node.GetValue("terminalState");
+            Assert.NotNull(val);
+            Assert.Equal("4", val); // TerminalState.Destroyed
+        }
+
+        [Fact]
+        public void KscPadDestroyed_V3Metadata_HasDestroyedTerminalState()
+        {
+            var node = SyntheticRecordingTests.KscPadDestroyed().BuildV3Metadata();
+
+            string val = node.GetValue("terminalState");
+            Assert.NotNull(val);
+            Assert.Equal("4", val);
+        }
+    }
+}

--- a/Source/Parsek.Tests/Generators/RecordingBuilder.cs
+++ b/Source/Parsek.Tests/Generators/RecordingBuilder.cs
@@ -29,6 +29,7 @@ namespace Parsek.Tests.Generators
         private double rewindReservedFunds;
         private double rewindReservedScience;
         private float rewindReservedRep;
+        private int? terminalState;
 
         // Default rotation for points that don't specify one explicitly
         private float defaultRotX, defaultRotY, defaultRotZ;
@@ -258,6 +259,12 @@ namespace Parsek.Tests.Generators
             return this;
         }
 
+        public RecordingBuilder WithTerminalState(int terminalState)
+        {
+            this.terminalState = terminalState;
+            return this;
+        }
+
         /// <summary>
         /// Returns the recording ID (auto-generates one if not set).
         /// </summary>
@@ -336,6 +343,9 @@ namespace Parsek.Tests.Generators
                 node.AddValue("rewindResRep", rewindReservedRep.ToString("R", ic2));
             }
 
+            if (terminalState.HasValue)
+                node.AddValue("terminalState", terminalState.Value.ToString(CultureInfo.InvariantCulture));
+
             return node;
         }
 
@@ -410,6 +420,9 @@ namespace Parsek.Tests.Generators
                 node.AddValue("rewindResSci", rewindReservedScience.ToString("R", ic2));
                 node.AddValue("rewindResRep", rewindReservedRep.ToString("R", ic2));
             }
+
+            if (terminalState.HasValue)
+                node.AddValue("terminalState", terminalState.Value.ToString(CultureInfo.InvariantCulture));
 
             return node;
         }

--- a/Source/Parsek.Tests/SyntheticRecordingTests.cs
+++ b/Source/Parsek.Tests/SyntheticRecordingTests.cs
@@ -287,6 +287,7 @@ namespace Parsek.Tests
             b.AddPoint(t + 12, lat, lon + 0.0012, 65, funds: 43429);
 
             // No snapshot intentionally to force destroyed/no-snapshot fallback path.
+            b.WithTerminalState((int)TerminalState.Destroyed);
             return b;
         }
 

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -5951,7 +5951,7 @@ namespace Parsek
             var main = ps.main;
             main.simulationSpace = ParticleSystemSimulationSpace.World;
             main.startLifetime = new ParticleSystem.MinMaxCurve(1.5f, 2.5f);
-            main.startSpeed = new ParticleSystem.MinMaxCurve(vesselLength * 2f, vesselLength * 6f);
+            main.startSpeed = new ParticleSystem.MinMaxCurve(vesselLength * 1f, vesselLength * 3f);
             main.startSize = new ParticleSystem.MinMaxCurve(vesselLength * 0.08f, vesselLength * 0.35f);
             main.maxParticles = 400;
             main.playOnAwake = false;
@@ -6032,10 +6032,95 @@ namespace Parsek
             var cleanup = obj.AddComponent<MaterialCleanup>();
             cleanup.material = mat;
 
+            // --- Smoke child particle system ---
+            Shader alphaShader = Shader.Find("KSP/Particles/Alpha Blended");
+            if (alphaShader != null)
+            {
+                var smokeObj = new GameObject("Smoke");
+                smokeObj.transform.SetParent(obj.transform, false);
+
+                var smokePs = smokeObj.AddComponent<ParticleSystem>();
+                var smokeMain = smokePs.main;
+                smokeMain.simulationSpace = ParticleSystemSimulationSpace.World;
+                smokeMain.startLifetime = new ParticleSystem.MinMaxCurve(2.0f, 3.5f);
+                smokeMain.startSpeed = new ParticleSystem.MinMaxCurve(vesselLength * 0.25f, vesselLength * 1f);
+                smokeMain.startSize = new ParticleSystem.MinMaxCurve(vesselLength * 0.3f, vesselLength * 0.8f);
+                smokeMain.maxParticles = 400;
+                smokeMain.playOnAwake = false;
+                smokeMain.loop = false;
+                smokeMain.gravityModifier = 0.03f;
+                smokeMain.startColor = new ParticleSystem.MinMaxGradient(
+                    new Color(0.3f, 0.3f, 0.3f, 0.6f),
+                    new Color(0.15f, 0.12f, 0.1f, 0.5f));
+
+                var smokeShape = smokePs.shape;
+                smokeShape.shapeType = ParticleSystemShapeType.Sphere;
+                smokeShape.radius = vesselLength * 0.3f;
+
+                var smokeEmission = smokePs.emission;
+                smokeEmission.enabled = true;
+                smokeEmission.rateOverTime = 0f;
+                smokeEmission.SetBursts(new ParticleSystem.Burst[]
+                {
+                    new ParticleSystem.Burst(0.1f, 160, 240)
+                });
+
+                var smokeColor = smokePs.colorOverLifetime;
+                smokeColor.enabled = true;
+                var smokeGradient = new Gradient();
+                smokeGradient.SetKeys(
+                    new GradientColorKey[]
+                    {
+                        new GradientColorKey(new Color(0.4f, 0.35f, 0.3f), 0f),
+                        new GradientColorKey(new Color(0.25f, 0.22f, 0.2f), 0.4f),
+                        new GradientColorKey(new Color(0.15f, 0.13f, 0.12f), 1f)
+                    },
+                    new GradientAlphaKey[]
+                    {
+                        new GradientAlphaKey(0.0f, 0f),
+                        new GradientAlphaKey(0.5f, 0.1f),
+                        new GradientAlphaKey(0.4f, 0.5f),
+                        new GradientAlphaKey(0f, 1f)
+                    }
+                );
+                smokeColor.color = smokeGradient;
+
+                var smokeSize = smokePs.sizeOverLifetime;
+                smokeSize.enabled = true;
+                smokeSize.size = new ParticleSystem.MinMaxCurve(1f,
+                    new AnimationCurve(
+                        new Keyframe(0f, 0.5f),
+                        new Keyframe(0.3f, 1.5f),
+                        new Keyframe(1f, 3.0f)));
+
+                var smokeNoise = smokePs.noise;
+                smokeNoise.enabled = true;
+                smokeNoise.strength = vesselLength * 0.2f;
+                smokeNoise.frequency = 1.5f;
+                smokeNoise.scrollSpeed = 0.8f;
+                smokeNoise.damping = true;
+
+                var smokeRenderer = smokeObj.GetComponent<ParticleSystemRenderer>();
+                smokeRenderer.renderMode = ParticleSystemRenderMode.Billboard;
+                smokeRenderer.maxParticleSize = 12f;
+
+                if (cachedExplosionTexture == null)
+                    cachedExplosionTexture = CreateSoftCircleTexture(32);
+                var smokeMat = new Material(alphaShader);
+                smokeMat.mainTexture = cachedExplosionTexture;
+                smokeMat.SetColor("_TintColor", new Color(0.3f, 0.25f, 0.2f, 0.5f));
+                smokeRenderer.material = smokeMat;
+
+                var smokeCleanup = smokeObj.AddComponent<MaterialCleanup>();
+                smokeCleanup.material = smokeMat;
+
+                smokePs.Play();
+            }
+
             ps.Play();
 
-            // Auto-destroy after max particle lifetime + buffer
-            Object.Destroy(obj, 3.5f);
+            // Auto-destroy after max smoke lifetime + buffer
+            Object.Destroy(obj, 5.0f);
 
             ParsekLog.Info("ExplosionFx",
                 $"Spawned at ({worldPosition.x:F1},{worldPosition.y:F1},{worldPosition.z:F1}) vesselLength={vesselLength:F1}m");

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -5915,6 +5915,20 @@ namespace Parsek
         private static Texture2D cachedExplosionTexture;
 
         /// <summary>
+        /// Self-cleanup component: destroys dynamically created Materials when the
+        /// GameObject is destroyed (prevents Material leak on fire-and-forget objects).
+        /// </summary>
+        private class MaterialCleanup : MonoBehaviour
+        {
+            public Material material;
+            void OnDestroy()
+            {
+                if (material != null)
+                    Destroy(material);
+            }
+        }
+
+        /// <summary>
         /// Spawns a fire-and-forget explosion particle effect at the given world position.
         /// The returned GameObject auto-destroys after particles expire.
         /// Used when ghost playback reaches the end of a destroyed recording.
@@ -6014,12 +6028,17 @@ namespace Parsek
             mat.SetColor("_TintColor", new Color(1f, 0.7f, 0.3f, 0.5f));
             psRenderer.material = mat;
 
+            // Attach self-cleanup so the Material is destroyed when the GO is destroyed
+            var cleanup = obj.AddComponent<MaterialCleanup>();
+            cleanup.material = mat;
+
             ps.Play();
 
             // Auto-destroy after max particle lifetime + buffer
             Object.Destroy(obj, 3.5f);
 
-            ParsekLog.Log($"  ExplosionFx: spawned at ({worldPosition.x:F1},{worldPosition.y:F1},{worldPosition.z:F1}) vesselLength={vesselLength:F1}m");
+            ParsekLog.Info("ExplosionFx",
+                $"Spawned at ({worldPosition.x:F1},{worldPosition.y:F1},{worldPosition.z:F1}) vesselLength={vesselLength:F1}m");
 
             return obj;
         }

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -5953,7 +5953,7 @@ namespace Parsek
             main.startLifetime = new ParticleSystem.MinMaxCurve(1.5f, 2.5f);
             main.startSpeed = new ParticleSystem.MinMaxCurve(vesselLength * 2f, vesselLength * 6f);
             main.startSize = new ParticleSystem.MinMaxCurve(vesselLength * 0.08f, vesselLength * 0.35f);
-            main.maxParticles = 200;
+            main.maxParticles = 400;
             main.playOnAwake = false;
             main.prewarm = false;
             main.loop = false;
@@ -5973,7 +5973,7 @@ namespace Parsek
             emission.rateOverTime = 0f;
             emission.SetBursts(new ParticleSystem.Burst[]
             {
-                new ParticleSystem.Burst(0f, 100, 150)
+                new ParticleSystem.Burst(0f, 200, 300)
             });
 
             // Color over lifetime: bright yellow-white → orange → red-brown → fade

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -5911,6 +5911,119 @@ namespace Parsek
             return Mathf.Max(length, 2f);
         }
 
+        // Cached soft-circle texture for explosion FX (avoids per-explosion allocation in looping playback)
+        private static Texture2D cachedExplosionTexture;
+
+        /// <summary>
+        /// Spawns a fire-and-forget explosion particle effect at the given world position.
+        /// The returned GameObject auto-destroys after particles expire.
+        /// Used when ghost playback reaches the end of a destroyed recording.
+        /// </summary>
+        internal static GameObject SpawnExplosionFx(Vector3 worldPosition, float vesselLength)
+        {
+            Shader particleShader = Shader.Find("KSP/Particles/Additive");
+            if (particleShader == null)
+            {
+                ParsekLog.Warn("ExplosionFx", "Shader 'KSP/Particles/Additive' not found — explosion will not be created");
+                return null;
+            }
+
+            var obj = new GameObject("GhostExplosionFx");
+            obj.transform.position = worldPosition;
+
+            var ps = obj.AddComponent<ParticleSystem>();
+
+            // Main module
+            var main = ps.main;
+            main.simulationSpace = ParticleSystemSimulationSpace.World;
+            main.startLifetime = new ParticleSystem.MinMaxCurve(1.5f, 2.5f);
+            main.startSpeed = new ParticleSystem.MinMaxCurve(vesselLength * 2f, vesselLength * 6f);
+            main.startSize = new ParticleSystem.MinMaxCurve(vesselLength * 0.08f, vesselLength * 0.35f);
+            main.maxParticles = 200;
+            main.playOnAwake = false;
+            main.prewarm = false;
+            main.loop = false;
+            main.gravityModifier = 0.15f;
+            main.startColor = new ParticleSystem.MinMaxGradient(
+                new Color(1f, 0.9f, 0.5f, 0.9f),
+                new Color(1f, 0.6f, 0.2f, 0.9f));
+
+            // Shape: sphere burst
+            var shape = ps.shape;
+            shape.shapeType = ParticleSystemShapeType.Sphere;
+            shape.radius = vesselLength * 0.2f;
+
+            // Emission: single burst
+            var emission = ps.emission;
+            emission.enabled = true;
+            emission.rateOverTime = 0f;
+            emission.SetBursts(new ParticleSystem.Burst[]
+            {
+                new ParticleSystem.Burst(0f, 100, 150)
+            });
+
+            // Color over lifetime: bright yellow-white → orange → red-brown → fade
+            var colorOverLifetime = ps.colorOverLifetime;
+            colorOverLifetime.enabled = true;
+            var gradient = new Gradient();
+            gradient.SetKeys(
+                new GradientColorKey[]
+                {
+                    new GradientColorKey(new Color(1f, 0.95f, 0.6f), 0f),
+                    new GradientColorKey(new Color(1f, 0.5f, 0.1f), 0.25f),
+                    new GradientColorKey(new Color(0.8f, 0.25f, 0.05f), 0.6f),
+                    new GradientColorKey(new Color(0.3f, 0.1f, 0.02f), 1f)
+                },
+                new GradientAlphaKey[]
+                {
+                    new GradientAlphaKey(0.9f, 0f),
+                    new GradientAlphaKey(0.7f, 0.25f),
+                    new GradientAlphaKey(0.2f, 0.7f),
+                    new GradientAlphaKey(0f, 1f)
+                }
+            );
+            colorOverLifetime.color = gradient;
+
+            // Size over lifetime: expanding fireball
+            var sizeOverLifetime = ps.sizeOverLifetime;
+            sizeOverLifetime.enabled = true;
+            sizeOverLifetime.size = new ParticleSystem.MinMaxCurve(1f,
+                new AnimationCurve(
+                    new Keyframe(0f, 1f),
+                    new Keyframe(0.4f, 1.5f),
+                    new Keyframe(1f, 2.0f)));
+
+            // Noise: turbulence for organic explosion look
+            var noise = ps.noise;
+            noise.enabled = true;
+            noise.strength = vesselLength * 0.15f;
+            noise.frequency = 2.5f;
+            noise.scrollSpeed = 1.5f;
+            noise.damping = true;
+
+            // Renderer: additive shader with soft-circle texture
+            var psRenderer = obj.GetComponent<ParticleSystemRenderer>();
+            psRenderer.renderMode = ParticleSystemRenderMode.Billboard;
+            psRenderer.maxParticleSize = 10f;
+
+            if (cachedExplosionTexture == null)
+                cachedExplosionTexture = CreateSoftCircleTexture(32);
+
+            var mat = new Material(particleShader);
+            mat.mainTexture = cachedExplosionTexture;
+            mat.SetColor("_TintColor", new Color(1f, 0.7f, 0.3f, 0.5f));
+            psRenderer.material = mat;
+
+            ps.Play();
+
+            // Auto-destroy after max particle lifetime + buffer
+            Object.Destroy(obj, 3.5f);
+
+            ParsekLog.Log($"  ExplosionFx: spawned at ({worldPosition.x:F1},{worldPosition.y:F1},{worldPosition.z:F1}) vesselLength={vesselLength:F1}m");
+
+            return obj;
+        }
+
         /// <summary>
         /// Creates a soft-circle texture at runtime for additive particle rendering.
         /// White center fading to transparent edges — avoids sprite sheet issues.

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -4203,24 +4203,27 @@ namespace Parsek
             if (recordingTime > recording[recording.Count - 1].ut)
             {
                 Log("Manual playback complete — reached end of recording");
-                if (previewRecording != null
-                    && previewRecording.TerminalStateValue == TerminalState.Destroyed
-                    && ghostObject != null)
+                if (previewRecording != null && ghostObject != null
+                    && ShouldTriggerExplosion(false, previewRecording.TerminalStateValue,
+                           true, previewRecording.VesselName, -1))
                 {
                     Vector3 pos = ghostObject.transform.position;
                     float len = GhostVisualBuilder.ComputeGhostLength(ghostObject);
                     ParsekLog.Info("ExplosionFx",
                         $"Manual preview explosion for \"{previewRecording.VesselName}\" " +
                         $"at ({pos.x:F1},{pos.y:F1},{pos.z:F1}) vesselLength={len:F1}m");
+                    // Hide ghost parts before explosion renders
+                    if (previewGhostState != null)
+                        HideAllGhostParts(previewGhostState);
+                    else
+                    {
+                        var t = ghostObject.transform;
+                        for (int c = 0; c < t.childCount; c++)
+                            t.GetChild(c).gameObject.SetActive(false);
+                    }
                     var explosion = GhostVisualBuilder.SpawnExplosionFx(pos, len);
                     if (explosion != null)
                         activeExplosions.Add(explosion);
-                }
-                else if (previewRecording != null)
-                {
-                    ParsekLog.Verbose("ExplosionFx",
-                        $"Manual preview ended — no explosion (terminalState={previewRecording.TerminalStateValue?.ToString() ?? "null"}" +
-                        $", ghostObject={(ghostObject != null ? "alive" : "null")})");
                 }
                 StopPlayback();
                 ScreenMessage("Preview playback complete", 2f);

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -4204,6 +4204,7 @@ namespace Parsek
             if (recordingTime > recording[recording.Count - 1].ut)
             {
                 Log("Manual playback complete — reached end of recording");
+                // explosionAlreadyFired=false is safe: preview is one-shot (StopPlayback called immediately after)
                 if (previewRecording != null && ghostObject != null
                     && ShouldTriggerExplosion(false, previewRecording.TerminalStateValue,
                            true, previewRecording.VesselName, -1))
@@ -5126,12 +5127,15 @@ namespace Parsek
 
         /// <summary>
         /// Checks whether the recording ended with destruction and spawns an explosion FX if so.
-        /// Returns true if an explosion was triggered, false otherwise (guard conditions not met).
         /// Pure decision logic is in ShouldTriggerExplosion; this method handles the side effects.
         /// </summary>
         void TriggerExplosionIfDestroyed(GhostPlaybackState state, RecordingStore.Recording rec, int recIdx)
         {
-            if (state == null) return;
+            if (state == null)
+            {
+                ParsekLog.Verbose("ExplosionFx", $"TriggerExplosionIfDestroyed: ghost #{recIdx} — skipped (state is null)");
+                return;
+            }
             if (!ShouldTriggerExplosion(state.explosionFired, rec.TerminalStateValue,
                     state.ghost != null, rec.VesselName, recIdx))
                 return;
@@ -5202,7 +5206,7 @@ namespace Parsek
                     hidden++;
                 }
             }
-            ParsekLog.Verbose("ExplosionFx", $"HideAllGhostParts: hidden {hidden}/{t.childCount} children");
+            ParsekLog.Verbose("GhostVisual", $"HideAllGhostParts: hidden {hidden}/{t.childCount} children");
         }
 
         void CleanupActiveExplosions()

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -66,6 +66,7 @@ namespace Parsek
             public Dictionary<uint, FairingGhostInfo> fairingInfos;
             public Dictionary<uint, GameObject> fakeCanopies;
             public ReentryFxInfo reentryFxInfo;
+            public bool explosionFired;
             public Transform cameraPivot; // child of ghost; centroid of active parts — camera targets this
             public Vector3 lastInterpolatedVelocity;
             public string lastInterpolatedBodyName;
@@ -102,6 +103,7 @@ namespace Parsek
 
         private Dictionary<int, GhostPlaybackState> ghostStates = new Dictionary<int, GhostPlaybackState>();
         private readonly MaterialPropertyBlock reentryShellMpb = new MaterialPropertyBlock();
+        private readonly List<GameObject> activeExplosions = new List<GameObject>();
 
         // --- Floating-origin correction ---
         // Ghosts are plain GameObjects not registered with KSP's FloatingOrigin.
@@ -4201,6 +4203,25 @@ namespace Parsek
             if (recordingTime > recording[recording.Count - 1].ut)
             {
                 Log("Manual playback complete — reached end of recording");
+                if (previewRecording != null
+                    && previewRecording.TerminalStateValue == TerminalState.Destroyed
+                    && ghostObject != null)
+                {
+                    Vector3 pos = ghostObject.transform.position;
+                    float len = GhostVisualBuilder.ComputeGhostLength(ghostObject);
+                    ParsekLog.Info("ExplosionFx",
+                        $"Manual preview explosion for \"{previewRecording.VesselName}\" " +
+                        $"at ({pos.x:F1},{pos.y:F1},{pos.z:F1}) vesselLength={len:F1}m");
+                    var explosion = GhostVisualBuilder.SpawnExplosionFx(pos, len);
+                    if (explosion != null)
+                        activeExplosions.Add(explosion);
+                }
+                else if (previewRecording != null)
+                {
+                    ParsekLog.Verbose("ExplosionFx",
+                        $"Manual preview ended — no explosion (terminalState={previewRecording.TerminalStateValue?.ToString() ?? "null"}" +
+                        $", ghostObject={(ghostObject != null ? "alive" : "null")})");
+                }
                 StopPlayback();
                 ScreenMessage("Preview playback complete", 2f);
                 return;
@@ -4508,6 +4529,7 @@ namespace Parsek
                                 watchEndHoldUntilUT = Planetarium.GetUniversalTime() + 3.0;
                                 ParsekLog.Info("CameraFollow",
                                     $"Recording #{i} ended \u2014 holding camera at last position until UT {watchEndHoldUntilUT.ToString("F1", CultureInfo.InvariantCulture)}");
+                                TriggerExplosionIfDestroyed(state, rec, i);
                                 // Keep ghost alive during hold — skip destroy
                                 if (pastEnd && rec.TreeId == null)
                                     ApplyResourceDeltas(rec, currentUT);
@@ -4530,6 +4552,7 @@ namespace Parsek
                             }
                         }
 
+                        TriggerExplosionIfDestroyed(state, rec, i);
                         Log($"Ghost EXITED range: #{i} \"{rec.VesselName}\" at UT {currentUT:F1} — no vessel to spawn");
                         DestroyTimelineGhost(i);
                     }
@@ -4670,6 +4693,7 @@ namespace Parsek
                     state.lastInterpolatedBodyName = lastPt.bodyName;
                     state.lastInterpolatedAltitude = lastPt.altitude;
                 }
+                TriggerExplosionIfDestroyed(state, rec, recIdx);
                 if (state.reentryFxInfo != null)
                 {
                     // Only zero velocity — keep body/altitude from last frame for smooth intensity decay
@@ -5085,6 +5109,104 @@ namespace Parsek
             loggedOrbitSegments.Clear();
             loggedOrbitRotationSegments.Clear();
             warpStoppedForRecording.Clear();
+            CleanupActiveExplosions();
+        }
+
+        /// <summary>
+        /// Checks whether the recording ended with destruction and spawns an explosion FX if so.
+        /// Returns true if an explosion was triggered, false otherwise (guard conditions not met).
+        /// Pure decision logic is in ShouldTriggerExplosion; this method handles the side effects.
+        /// </summary>
+        void TriggerExplosionIfDestroyed(GhostPlaybackState state, RecordingStore.Recording rec, int recIdx)
+        {
+            if (state == null) return;
+            if (!ShouldTriggerExplosion(state.explosionFired, rec.TerminalStateValue,
+                    state.ghost != null, rec.VesselName, recIdx))
+                return;
+
+            state.explosionFired = true;
+
+            Vector3 worldPos = state.ghost.transform.position;
+            float vesselLength = state.reentryFxInfo != null
+                ? state.reentryFxInfo.vesselLength
+                : GhostVisualBuilder.ComputeGhostLength(state.ghost);
+
+            ParsekLog.Info("ExplosionFx",
+                $"Triggering explosion for ghost #{recIdx} \"{rec.VesselName}\" " +
+                $"at ({worldPos.x:F1},{worldPos.y:F1},{worldPos.z:F1}) vesselLength={vesselLength:F1}m");
+
+            var explosion = GhostVisualBuilder.SpawnExplosionFx(worldPos, vesselLength);
+            if (explosion != null)
+            {
+                activeExplosions.Add(explosion);
+                ParsekLog.Verbose("ExplosionFx",
+                    $"Explosion GO created for ghost #{recIdx}, activeExplosions.Count={activeExplosions.Count}");
+            }
+
+            // Hide all ghost parts so the explosion plays over empty space
+            HideAllGhostParts(state);
+            ParsekLog.Verbose("ExplosionFx", $"Ghost #{recIdx} parts hidden after explosion");
+        }
+
+        /// <summary>
+        /// Pure decision logic: should we trigger an explosion for this ghost/recording pair?
+        /// Extracted for testability and logging of guard condition skips.
+        /// Parameters are primitives so this can be called from tests without GhostPlaybackState.
+        /// </summary>
+        internal static bool ShouldTriggerExplosion(bool explosionAlreadyFired, TerminalState? terminalState,
+            bool ghostExists, string vesselName, int recIdx)
+        {
+            if (explosionAlreadyFired)
+            {
+                ParsekLog.Verbose("ExplosionFx", $"ShouldTriggerExplosion: ghost #{recIdx} — skipped (already fired)");
+                return false;
+            }
+            if (terminalState != TerminalState.Destroyed)
+            {
+                ParsekLog.Verbose("ExplosionFx",
+                    $"ShouldTriggerExplosion: ghost #{recIdx} — skipped (terminalState={terminalState?.ToString() ?? "null"}, not Destroyed)");
+                return false;
+            }
+            if (!ghostExists)
+            {
+                ParsekLog.Verbose("ExplosionFx", $"ShouldTriggerExplosion: ghost #{recIdx} — skipped (ghost GO is null)");
+                return false;
+            }
+            ParsekLog.Verbose("ExplosionFx", $"ShouldTriggerExplosion: ghost #{recIdx} \"{vesselName}\" — will fire");
+            return true;
+        }
+
+        static void HideAllGhostParts(GhostPlaybackState state)
+        {
+            if (state.ghost == null) return;
+            var t = state.ghost.transform;
+            int hidden = 0;
+            for (int c = 0; c < t.childCount; c++)
+            {
+                var child = t.GetChild(c).gameObject;
+                if (child.activeSelf)
+                {
+                    child.SetActive(false);
+                    hidden++;
+                }
+            }
+            ParsekLog.Verbose("ExplosionFx", $"HideAllGhostParts: hidden {hidden}/{t.childCount} children");
+        }
+
+        void CleanupActiveExplosions()
+        {
+            if (activeExplosions.Count == 0) return;
+            int destroyed = 0;
+            for (int i = activeExplosions.Count - 1; i >= 0; i--)
+            {
+                if (activeExplosions[i] != null)
+                {
+                    Destroy(activeExplosions[i]);
+                    destroyed++;
+                }
+            }
+            ParsekLog.Verbose("ExplosionFx", $"CleanupActiveExplosions: destroyed {destroyed}/{activeExplosions.Count} explosion GOs");
+            activeExplosions.Clear();
         }
 
         public bool CanDeleteRecording =>

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -67,6 +67,7 @@ namespace Parsek
             public Dictionary<uint, GameObject> fakeCanopies;
             public ReentryFxInfo reentryFxInfo;
             public bool explosionFired;
+            public bool pauseHidden;
             public Transform cameraPivot; // child of ghost; centroid of active parts — camera targets this
             public Vector3 lastInterpolatedVelocity;
             public string lastInterpolatedBodyName;
@@ -4696,7 +4697,15 @@ namespace Parsek
                     state.lastInterpolatedBodyName = lastPt.bodyName;
                     state.lastInterpolatedAltitude = lastPt.altitude;
                 }
+                // Destroyed recordings get an explosion; all recordings hide during pause
                 TriggerExplosionIfDestroyed(state, rec, recIdx);
+                if (!state.pauseHidden)
+                {
+                    state.pauseHidden = true;
+                    HideAllGhostParts(state);
+                    ParsekLog.Verbose("Flight",
+                        $"Ghost #{recIdx} \"{rec.VesselName}\" hidden during loop pause window");
+                }
                 if (state.reentryFxInfo != null)
                 {
                     // Only zero velocity — keep body/altitude from last frame for smooth intensity decay

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -5205,16 +5205,20 @@ namespace Parsek
             if (state.ghost == null) return;
             var t = state.ghost.transform;
             int hidden = 0;
+            // Keep cameraPivot active — FlightCamera targets it during watch-mode hold.
+            // Disabling it would make KSP snap the camera back to the active vessel.
+            var pivotT = state.cameraPivot;
             for (int c = 0; c < t.childCount; c++)
             {
-                var child = t.GetChild(c).gameObject;
-                if (child.activeSelf)
+                var child = t.GetChild(c);
+                if (pivotT != null && child == pivotT) continue;
+                if (child.gameObject.activeSelf)
                 {
-                    child.SetActive(false);
+                    child.gameObject.SetActive(false);
                     hidden++;
                 }
             }
-            ParsekLog.Verbose("GhostVisual", $"HideAllGhostParts: hidden {hidden}/{t.childCount} children");
+            ParsekLog.Verbose("GhostVisual", $"HideAllGhostParts: hidden {hidden}/{t.childCount} children (cameraPivot preserved)");
         }
 
         void CleanupActiveExplosions()

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -1967,6 +1967,13 @@ namespace Parsek
                         pending.EvaCrewName = activeChainCrewName;
                     }
 
+                    // Set terminal state for destroyed vessels
+                    if (captured.VesselDestroyed)
+                    {
+                        pending.TerminalStateValue = TerminalState.Destroyed;
+                        ParsekLog.Verbose("Flight", "FallbackCommitSplitRecorder: set TerminalState=Destroyed");
+                    }
+
                     // Tag segment phase if untagged
                     if (string.IsNullOrEmpty(pending.SegmentPhase))
                     {

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -4531,7 +4531,8 @@ namespace Parsek
                             }
                             else if (watchEndHoldUntilUT < 0)
                             {
-                                watchEndHoldUntilUT = Planetarium.GetUniversalTime() + 3.0;
+                                double holdSeconds = rec.TerminalStateValue == TerminalState.Destroyed ? 5.0 : 3.0;
+                                watchEndHoldUntilUT = Planetarium.GetUniversalTime() + holdSeconds;
                                 ParsekLog.Info("CameraFollow",
                                     $"Recording #{i} ended \u2014 holding camera at last position until UT {watchEndHoldUntilUT.ToString("F1", CultureInfo.InvariantCulture)}");
                                 TriggerExplosionIfDestroyed(state, rec, i);

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -343,10 +343,16 @@ namespace Parsek
                 // save preserves these, preventing duplicate spawns and ghost replays.
                 // NOTE: This loop only covers standalone recordings (not tree recordings).
                 // Tree recordings get their mutable state from RECORDING_TREE nodes below.
-                // Use a separate counter (standaloneIdx) for savedRecNodes because tree
-                // recordings are interspersed in the in-memory list but absent from the
-                // saved RECORDING nodes.
-                int standaloneIdx = 0;
+                // Match by recordingId (not positional index) — the saved RECORDING nodes
+                // may be from a stale quicksave with a different number/order of recordings
+                // than the current in-memory list (e.g. after clear-all + re-record).
+                var savedRecById = new Dictionary<string, ConfigNode>(savedRecNodes.Length);
+                for (int s = 0; s < savedRecNodes.Length; s++)
+                {
+                    string sid = savedRecNodes[s].GetValue("recordingId");
+                    if (!string.IsNullOrEmpty(sid))
+                        savedRecById[sid] = savedRecNodes[s];
+                }
                 for (int i = 0; i < recordings.Count; i++)
                 {
                     // Skip tree recordings — their mutable state is restored from tree nodes
@@ -358,21 +364,22 @@ namespace Parsek
                     uint savedPid = 0;
                     bool savedTaken = false;
                     int resIdx = -1;
-                    if (standaloneIdx < savedRecNodes.Length)
+                    ConfigNode savedNode;
+                    if (recordings[i].RecordingId != null && savedRecById.TryGetValue(recordings[i].RecordingId, out savedNode))
                     {
-                        string pidStr = savedRecNodes[standaloneIdx].GetValue("spawnedPid");
+                        string pidStr = savedNode.GetValue("spawnedPid");
                         if (pidStr != null && !uint.TryParse(pidStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out savedPid))
                             ParsekLog.Warn("Scenario", $"Failed to parse spawnedPid '{pidStr}' for recording #{i}");
 
-                        string takenStr = savedRecNodes[standaloneIdx].GetValue("takenControl");
+                        string takenStr = savedNode.GetValue("takenControl");
                         if (takenStr != null && !bool.TryParse(takenStr, out savedTaken))
                             ParsekLog.Warn("Scenario", $"Failed to parse takenControl '{takenStr}' for recording #{i}");
 
-                        string resIdxStr = savedRecNodes[standaloneIdx].GetValue("lastResIdx");
+                        string resIdxStr = savedNode.GetValue("lastResIdx");
                         if (resIdxStr != null && !int.TryParse(resIdxStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out resIdx))
                             ParsekLog.Warn("Scenario", $"Failed to parse lastResIdx '{resIdxStr}' for recording #{i}");
 
-                        string playbackEnabledStr = savedRecNodes[standaloneIdx].GetValue("playbackEnabled");
+                        string playbackEnabledStr = savedNode.GetValue("playbackEnabled");
                         if (playbackEnabledStr != null)
                         {
                             bool savedPlaybackEnabled;
@@ -382,10 +389,15 @@ namespace Parsek
                                 ParsekLog.Warn("Scenario", $"Failed to parse playbackEnabled '{playbackEnabledStr}' for recording #{i}");
                         }
                     }
+                    else
+                    {
+                        ParsekLog.Verbose("Scenario",
+                            $"No saved mutable state for recording #{i} \"{recordings[i].VesselName}\" " +
+                            $"(id={recordings[i].RecordingId ?? "null"}) — using defaults");
+                    }
                     recordings[i].SpawnedVesselPersistentId = savedPid;
                     recordings[i].TakenControl = savedTaken;
                     recordings[i].LastAppliedResourceIndex = resIdx;
-                    standaloneIdx++;
                 }
 
                 // Restore tree recording mutable state from RECORDING_TREE nodes.


### PR DESCRIPTION
## Summary
- Spawns a fire-and-forget particle explosion when ghost playback reaches the end of a `TerminalState.Destroyed` recording
- Custom `ParticleSystem` with burst emission, color gradient (yellow→orange→red→fade), expanding size, turbulence noise — matches existing reentry FX patterns
- Wired into all 3 playback paths: non-looping timeline, looping timeline, and manual preview
- Ghost parts hidden on explosion so fireball plays over empty space
- Ghost hidden during loop pause window (non-destroyed recordings too) — prevents frozen ghost between cycles
- `ShouldTriggerExplosion` extracted as `internal static` pure method with verbose logging on every guard condition
- `RecordingBuilder.WithTerminalState()` added to both `Build()` and `BuildV3Metadata()`
- KscPadDestroyed synthetic recording now sets `TerminalState.Destroyed`
- CLAUDE.md updated with logging and testing requirements
- Fix: mutable state restoration now matches saved RECORDING nodes by `recordingId` instead of positional index — prevents stale quicksave state from silently disabling playback after clear-all + re-record

## Test plan
- [x] 22 new unit tests (guard conditions, log assertions, serialization roundtrip)
- [x] All 1284 tests pass
- [x] In-game: "KSC Pad Destroyed" recording shows explosion at end
- [x] In-game: looping playback — explosion fires each cycle, ghost rebuilds
- [x] In-game: manual preview of destroyed recording shows explosion
- [x] In-game: clear all recordings, record new one, verify playback still works after scene change
- [x] Edge case: destroyed recording with no snapshot (sphere fallback) still explodes