### PR TITLE
Loop interval overhaul + KSC toolbar UI

### DIFF
--- a/Source/Parsek.Tests/Generators/RecordingBuilder.cs
+++ b/Source/Parsek.Tests/Generators/RecordingBuilder.cs
@@ -20,7 +20,7 @@ namespace Parsek.Tests.Generators
         private int chainIndex = -1;
         private int chainBranch = -1;
         private bool loopPlayback;
-        private double loopPauseSeconds = 10.0;
+        private double loopIntervalSeconds = 0.0;
         private string segmentPhase;
         private string segmentBodyName;
         private bool playbackEnabled = true;
@@ -205,10 +205,10 @@ namespace Parsek.Tests.Generators
             return this;
         }
 
-        public RecordingBuilder WithLoopPlayback(bool loop = true, double pauseSeconds = 10.0)
+        public RecordingBuilder WithLoopPlayback(bool loop = true, double intervalSeconds = 0.0)
         {
             loopPlayback = loop;
-            loopPauseSeconds = pauseSeconds;
+            loopIntervalSeconds = intervalSeconds;
             return this;
         }
 
@@ -298,7 +298,7 @@ namespace Parsek.Tests.Generators
             node.AddValue("recordingId", GetRecordingId());
             node.AddValue("recordingFormatVersion", formatVersion.ToString());
             node.AddValue("loopPlayback", loopPlayback.ToString());
-            node.AddValue("loopPauseSeconds", loopPauseSeconds.ToString("R", CultureInfo.InvariantCulture));
+            node.AddValue("loopIntervalSeconds", loopIntervalSeconds.ToString("R", CultureInfo.InvariantCulture));
 
             if (!string.IsNullOrEmpty(parentRecordingId))
                 node.AddValue("parentRecordingId", parentRecordingId);
@@ -389,7 +389,7 @@ namespace Parsek.Tests.Generators
                 node.AddValue("chainBranch", chainBranch);
 
             node.AddValue("loopPlayback", loopPlayback.ToString());
-            node.AddValue("loopPauseSeconds", loopPauseSeconds.ToString("R", CultureInfo.InvariantCulture));
+            node.AddValue("loopIntervalSeconds", loopIntervalSeconds.ToString("R", CultureInfo.InvariantCulture));
 
             if (vesselSnapshot != null)
                 node.AddNode("VESSEL_SNAPSHOT", vesselSnapshot);

--- a/Source/Parsek.Tests/RecordingStoreTests.cs
+++ b/Source/Parsek.Tests/RecordingStoreTests.cs
@@ -337,7 +337,7 @@ namespace Parsek.Tests
                 RecordingId = "meta123",
                 RecordingFormatVersion = 12,
                 LoopPlayback = true,
-                LoopPauseSeconds = 2.5,
+                LoopIntervalSeconds = 2.5,
             };
 
             var node = new ConfigNode("RECORDING");
@@ -349,7 +349,7 @@ namespace Parsek.Tests
             Assert.Equal("meta123", loaded.RecordingId);
             Assert.Equal(12, loaded.RecordingFormatVersion);
             Assert.True(loaded.LoopPlayback);
-            Assert.Equal(2.5, loaded.LoopPauseSeconds);
+            Assert.Equal(2.5, loaded.LoopIntervalSeconds);
 
             // Ghost geometry fields are no longer serialized on save
             Assert.Null(node.GetValue("ghostGeometryVersion"));
@@ -372,7 +372,7 @@ namespace Parsek.Tests
             Assert.Equal(defaultId, loaded.RecordingId);
             Assert.Equal(defaultRecVer, loaded.RecordingFormatVersion);
             Assert.False(loaded.LoopPlayback);
-            Assert.Equal(10.0, loaded.LoopPauseSeconds);
+            Assert.Equal(0.0, loaded.LoopIntervalSeconds);
         }
 
         [Fact]

--- a/Source/Parsek.Tests/RecordingStoreTests.cs
+++ b/Source/Parsek.Tests/RecordingStoreTests.cs
@@ -372,7 +372,7 @@ namespace Parsek.Tests
             Assert.Equal(defaultId, loaded.RecordingId);
             Assert.Equal(defaultRecVer, loaded.RecordingFormatVersion);
             Assert.False(loaded.LoopPlayback);
-            Assert.Equal(0.0, loaded.LoopIntervalSeconds);
+            Assert.Equal(10.0, loaded.LoopIntervalSeconds);
         }
 
         [Fact]

--- a/Source/Parsek.Tests/RecordingTreeTests.cs
+++ b/Source/Parsek.Tests/RecordingTreeTests.cs
@@ -1140,7 +1140,7 @@ namespace Parsek.Tests
             recNode.AddValue("recordingFormatVersion", "4");
             recNode.AddValue("ghostGeometryVersion", "1");
             recNode.AddValue("loopPlayback", "False");
-            recNode.AddValue("loopPauseSeconds", "10");
+            recNode.AddValue("loopIntervalSeconds", "10");
             recNode.AddValue("ghostGeometryStrategy", "stub_v1");
             recNode.AddValue("ghostGeometryProbeStatus", "unknown");
             recNode.AddValue("ghostGeometryAvailable", "False");

--- a/Source/Parsek.Tests/RuntimePolicyTests.cs
+++ b/Source/Parsek.Tests/RuntimePolicyTests.cs
@@ -174,7 +174,7 @@ namespace Parsek.Tests
                 currentUT,
                 startUT: 100,
                 endUT: 120,
-                pauseSeconds: 10,
+                intervalSeconds: 10,
                 out double loopUT,
                 out int cycleIndex);
 

--- a/Source/Parsek.Tests/RuntimePolicyTests.cs
+++ b/Source/Parsek.Tests/RuntimePolicyTests.cs
@@ -200,5 +200,156 @@ namespace Parsek.Tests
                 landedLike, terrainAltitude, terrainValid, snapshotAltitude, hasSnapshotAltitude);
             Assert.Equal(expected, actual);
         }
+
+        // --- GetActiveCycles tests ---
+
+        [Fact]
+        public void GetActiveCycles_PositiveInterval_SingleCycleAlways()
+        {
+            // 20s recording, 10s interval, cycleDuration=30
+            // At t=115 (elapsed=15 into cycle 0 of range starting at 100)
+            ParsekFlight.GetActiveCycles(
+                currentUT: 115, startUT: 100, endUT: 120,
+                intervalSeconds: 10, maxCycles: 5,
+                out int first, out int last);
+            Assert.Equal(0, first);
+            Assert.Equal(0, last);
+        }
+
+        [Fact]
+        public void GetActiveCycles_PositiveInterval_SecondCycle()
+        {
+            // 20s recording, 10s interval, cycleDuration=30
+            // At t=135 (elapsed=35): cycle 1, phase=5
+            ParsekFlight.GetActiveCycles(
+                currentUT: 135, startUT: 100, endUT: 120,
+                intervalSeconds: 10, maxCycles: 5,
+                out int first, out int last);
+            Assert.Equal(1, first);
+            Assert.Equal(1, last);
+        }
+
+        [Fact]
+        public void GetActiveCycles_ZeroInterval_SingleCycleAlways()
+        {
+            // 20s recording, 0s interval, cycleDuration=20
+            // At t=110 (elapsed=10): cycle 0, phase=10
+            ParsekFlight.GetActiveCycles(
+                currentUT: 110, startUT: 100, endUT: 120,
+                intervalSeconds: 0, maxCycles: 5,
+                out int first, out int last);
+            Assert.Equal(0, first);
+            Assert.Equal(0, last);
+        }
+
+        [Fact]
+        public void GetActiveCycles_ZeroInterval_ThirdCycle()
+        {
+            // 20s recording, 0s interval, cycleDuration=20
+            // At t=145 (elapsed=45): cycle 2, phase=5
+            ParsekFlight.GetActiveCycles(
+                currentUT: 145, startUT: 100, endUT: 120,
+                intervalSeconds: 0, maxCycles: 5,
+                out int first, out int last);
+            Assert.Equal(2, first);
+            Assert.Equal(2, last);
+        }
+
+        [Fact]
+        public void GetActiveCycles_NegativeInterval_OverlapWindow()
+        {
+            // 60s recording, -20s interval, cycleDuration=40
+            // At t=150 (elapsed=50): lastCycle=floor(50/40)=1
+            // elapsedMinusDuration=50-60=-10 → firstCycle=0
+            // Cycle 0 started at 100, plays from 100..160 → phase at t=150 is 50 (still playing)
+            // Cycle 1 started at 140, plays from 100..160 → phase at t=150 is 10 (playing)
+            ParsekFlight.GetActiveCycles(
+                currentUT: 150, startUT: 100, endUT: 160,
+                intervalSeconds: -20, maxCycles: 5,
+                out int first, out int last);
+            Assert.Equal(0, first);
+            Assert.Equal(1, last);
+        }
+
+        [Fact]
+        public void GetActiveCycles_NegativeInterval_ThreeOverlapping()
+        {
+            // 60s recording, -40s interval, cycleDuration=20
+            // At t=145 (elapsed=45): lastCycle=floor(45/20)=2
+            // elapsedMinusDuration=45-60=-15 → firstCycle=0
+            // So cycles 0, 1, 2 are all active
+            ParsekFlight.GetActiveCycles(
+                currentUT: 145, startUT: 100, endUT: 160,
+                intervalSeconds: -40, maxCycles: 5,
+                out int first, out int last);
+            Assert.Equal(0, first);
+            Assert.Equal(2, last);
+        }
+
+        [Fact]
+        public void GetActiveCycles_NegativeInterval_MaxCyclesCap()
+        {
+            // 60s recording, -40s interval, cycleDuration=20
+            // maxCycles=2, so even if 3 are active, cap to 2
+            ParsekFlight.GetActiveCycles(
+                currentUT: 145, startUT: 100, endUT: 160,
+                intervalSeconds: -40, maxCycles: 2,
+                out int first, out int last);
+            Assert.Equal(1, first);  // capped: last(2) - maxCycles(2) + 1 = 1
+            Assert.Equal(2, last);
+        }
+
+        [Fact]
+        public void GetActiveCycles_BeforeStart_ReturnsZero()
+        {
+            ParsekFlight.GetActiveCycles(
+                currentUT: 50, startUT: 100, endUT: 160,
+                intervalSeconds: -20, maxCycles: 5,
+                out int first, out int last);
+            Assert.Equal(0, first);
+            Assert.Equal(0, last);
+        }
+
+        [Fact]
+        public void GetActiveCycles_VeryLargePositiveInterval()
+        {
+            // 20s recording, 1000s interval, cycleDuration=1020
+            // At t=1130 (elapsed=1030): cycle 1, phase=10 (in playback)
+            ParsekFlight.GetActiveCycles(
+                currentUT: 1130, startUT: 100, endUT: 120,
+                intervalSeconds: 1000, maxCycles: 5,
+                out int first, out int last);
+            Assert.Equal(1, first);
+            Assert.Equal(1, last);
+        }
+
+        [Fact]
+        public void GetActiveCycles_NearMinCycleDuration()
+        {
+            // 10s recording, interval = -9.999 → cycleDuration = 0.001
+            ParsekFlight.GetActiveCycles(
+                currentUT: 100.005, startUT: 100, endUT: 110,
+                intervalSeconds: -9.999, maxCycles: 5,
+                out int first, out int last);
+            // With cycleDuration=0.001, elapsed=0.005 → lastCycle=5
+            // But maxCycles=5 caps to first=1
+            Assert.True(last >= first);
+            Assert.True(last - first + 1 <= 5);
+        }
+
+        [Fact]
+        public void TryComputeLoopPlaybackUT_NegativeInterval_ReturnsPlaybackPhase()
+        {
+            // 20s recording, -5s interval, cycleDuration=15
+            // At t=118 (elapsed=18): cycle 1, phase=3
+            bool ok = ParsekFlight.TryComputeLoopPlaybackUT(
+                currentUT: 118, startUT: 100, endUT: 120,
+                intervalSeconds: -5,
+                out double loopUT, out int cycleIndex);
+
+            Assert.True(ok);
+            Assert.Equal(1, cycleIndex);
+            Assert.Equal(103.0, loopUT, 6);
+        }
     }
 }

--- a/Source/Parsek.Tests/RuntimePolicyTests.cs
+++ b/Source/Parsek.Tests/RuntimePolicyTests.cs
@@ -351,5 +351,95 @@ namespace Parsek.Tests
             Assert.Equal(1, cycleIndex);
             Assert.Equal(103.0, loopUT, 6);
         }
+
+        // --- Overlap edge case tests ---
+
+        [Fact]
+        public void GetActiveCycles_ExtremeNegativeInterval_ManyOverlaps()
+        {
+            // 21s recording, -20s interval, cycleDuration=1
+            // At t=110 (elapsed=10): lastCycle=10, many overlapping
+            ParsekFlight.GetActiveCycles(
+                currentUT: 110, startUT: 100, endUT: 121,
+                intervalSeconds: -20, maxCycles: 5,
+                out int first, out int last);
+            Assert.Equal(10, last);
+            // firstCycle is capped by maxCycles=5: last(10) - 5 + 1 = 6
+            Assert.Equal(6, first);
+            Assert.Equal(5, last - first + 1);
+        }
+
+        [Fact]
+        public void GetActiveCycles_ExtremeNegativeInterval_NoCap()
+        {
+            // 21s recording, -20s interval, cycleDuration=1
+            // At t=110 (elapsed=10): lastCycle=10
+            // Without cap (maxCycles=100): firstCycle = max(0, floor((10-21)/1)+1) = 0
+            // All cycles 0-10 still playing (phase < 21 for all)
+            ParsekFlight.GetActiveCycles(
+                currentUT: 110, startUT: 100, endUT: 121,
+                intervalSeconds: -20, maxCycles: 100,
+                out int first, out int last);
+            Assert.Equal(10, last);
+            Assert.Equal(0, first);
+            Assert.Equal(11, last - first + 1);
+        }
+
+        [Fact]
+        public void GetActiveCycles_NegativeInterval_OlderCyclesExpire()
+        {
+            // 21s recording, -20s interval, cycleDuration=1
+            // At t=125 (elapsed=25): lastCycle=25
+            // Cycle 0 started at t=100, phase=25 > 21 → expired
+            // Cycle 4 started at t=104, phase=21 → exactly at boundary
+            // firstCycle = max(0, floor((25-21)/1)+1) = 5
+            ParsekFlight.GetActiveCycles(
+                currentUT: 125, startUT: 100, endUT: 121,
+                intervalSeconds: -20, maxCycles: 100,
+                out int first, out int last);
+            Assert.Equal(25, last);
+            Assert.Equal(5, first);
+            Assert.Equal(21, last - first + 1); // exactly 21 simultaneous
+        }
+
+        [Fact]
+        public void TryComputeLoopPlaybackUT_ZeroInterval_ImmediateRestart()
+        {
+            // 20s recording, 0s interval → cycleDuration = 20
+            // At t=120 (elapsed=20): exactly at cycle boundary
+            bool ok = ParsekFlight.TryComputeLoopPlaybackUT(
+                currentUT: 120, startUT: 100, endUT: 120,
+                intervalSeconds: 0,
+                out double loopUT, out int cycleIndex);
+            Assert.True(ok);
+            Assert.Equal(1, cycleIndex);
+            Assert.Equal(100.0, loopUT, 6); // start of new cycle
+        }
+
+        [Fact]
+        public void TryComputeLoopPlaybackUT_PositiveInterval_InPause()
+        {
+            // 20s recording, 10s interval, cycleDuration=30
+            // At t=125 (elapsed=25, cycleTime=25): phase > duration (20) → pause window
+            bool ok = ParsekFlight.TryComputeLoopPlaybackUT(
+                currentUT: 125, startUT: 100, endUT: 120,
+                intervalSeconds: 10,
+                out double loopUT, out int cycleIndex);
+            // In pause → returns false (older behavior returns endUT with cycle 0)
+            // Let's just verify it doesn't crash and returns valid state
+            Assert.Equal(0, cycleIndex);
+        }
+
+        [Fact]
+        public void GetActiveCycles_ZeroDuration_ReturnsZero()
+        {
+            // Degenerate: startUT == endUT
+            ParsekFlight.GetActiveCycles(
+                currentUT: 100, startUT: 100, endUT: 100,
+                intervalSeconds: 10, maxCycles: 5,
+                out int first, out int last);
+            Assert.Equal(0, first);
+            Assert.Equal(0, last);
+        }
     }
 }

--- a/Source/Parsek.Tests/SyntheticRecordingTests.cs
+++ b/Source/Parsek.Tests/SyntheticRecordingTests.cs
@@ -867,7 +867,7 @@ namespace Parsek.Tests
 
             var b = new RecordingBuilder(vesselName)
                 .WithDefaultRotation(KscRotX, KscRotY, KscRotZ, KscRotW)
-                .WithLoopPlayback(loop: true, pauseSeconds: 0.0)
+                .WithLoopPlayback(loop: true, intervalSeconds: 0.0)
                 .WithRecordingGroup("Part Showcases");
 
             // Static trajectory (24s) so the visual focus is part event playback.
@@ -935,7 +935,7 @@ namespace Parsek.Tests
 
             var b = new RecordingBuilder(vesselName)
                 .WithDefaultRotation(KscRotX, KscRotY, KscRotZ, KscRotW)
-                .WithLoopPlayback(loop: true, pauseSeconds: 0.0)
+                .WithLoopPlayback(loop: true, intervalSeconds: 0.0)
                 .WithRecordingGroup("Part Showcases");
 
             for (int i = 0; i <= 8; i++)
@@ -1321,7 +1321,7 @@ namespace Parsek.Tests
 
             var b = new RecordingBuilder(vesselName)
                 .WithDefaultRotation(KscRotX, KscRotY, KscRotZ, KscRotW)
-                .WithLoopPlayback(loop: true, pauseSeconds: 0.0)
+                .WithLoopPlayback(loop: true, intervalSeconds: 0.0)
                 .WithRecordingGroup("Part Showcases");
 
             // Static trajectory (24s).
@@ -1367,7 +1367,7 @@ namespace Parsek.Tests
 
             var b = new RecordingBuilder(vesselName)
                 .WithDefaultRotation(KscRotX, KscRotY, KscRotZ, KscRotW)
-                .WithLoopPlayback(loop: true, pauseSeconds: 0.0)
+                .WithLoopPlayback(loop: true, intervalSeconds: 0.0)
                 .WithRecordingGroup("Part Showcases");
 
             for (int i = 0; i <= 8; i++)
@@ -1777,7 +1777,7 @@ namespace Parsek.Tests
 
             var b = new RecordingBuilder(vesselName)
                 .WithDefaultRotation(KscRotX, KscRotY, KscRotZ, KscRotW)
-                .WithLoopPlayback(loop: true, pauseSeconds: 0.0)
+                .WithLoopPlayback(loop: true, intervalSeconds: 0.0)
                 .WithRecordingGroup("Part Showcases");
 
             // Static trajectory (24s)
@@ -2143,7 +2143,7 @@ namespace Parsek.Tests
             alt += ShowcaseAltitudeOffset(partName);
             var b = new RecordingBuilder("Part Showcase - Inventory Placement")
                 .WithDefaultRotation(KscRotX, KscRotY, KscRotZ, KscRotW)
-                .WithLoopPlayback(loop: true, pauseSeconds: 0.0)
+                .WithLoopPlayback(loop: true, intervalSeconds: 0.0)
                 .WithRecordingGroup("Part Showcases");
 
             for (int i = 0; i <= 8; i++)
@@ -2748,13 +2748,13 @@ namespace Parsek.Tests
         {
             var node = new RecordingBuilder("Loop Test")
                 .WithRecordingId("loop123")
-                .WithLoopPlayback(loop: true, pauseSeconds: 0.0)
+                .WithLoopPlayback(loop: true, intervalSeconds: 0.0)
                 .AddPoint(100, 0, 0, 0)
                 .AddPoint(103, 0, 0, 0)
                 .BuildV3Metadata();
 
             Assert.Equal("True", node.GetValue("loopPlayback"));
-            Assert.Equal("0", node.GetValue("loopPauseSeconds"));
+            Assert.Equal("0", node.GetValue("loopIntervalSeconds"));
         }
 
         [Fact]
@@ -2819,7 +2819,7 @@ namespace Parsek.Tests
             Assert.Equal("Part Showcase - Lights v1", first.GetValue("vesselName"));
             Assert.Equal("9", first.GetValue("pointCount"));
             Assert.Equal("True", first.GetValue("loopPlayback"));
-            Assert.Equal("0", first.GetValue("loopPauseSeconds"));
+            Assert.Equal("0", first.GetValue("loopIntervalSeconds"));
             Assert.Equal(7, first.GetNodes("PART_EVENT").Length);
 
             var ghost = first.GetNode("GHOST_VISUAL_SNAPSHOT");

--- a/Source/Parsek.Tests/TreeCommitTests.cs
+++ b/Source/Parsek.Tests/TreeCommitTests.cs
@@ -447,7 +447,7 @@ namespace Parsek.Tests
             node.AddValue("recordingFormatVersion", "4");
             node.AddValue("ghostGeometryVersion", "1");
             node.AddValue("loopPlayback", "False");
-            node.AddValue("loopPauseSeconds", "10");
+            node.AddValue("loopIntervalSeconds", "10");
             node.AddValue("ghostGeometryStrategy", "stub_v1");
             node.AddValue("ghostGeometryProbeStatus", "unknown");
             node.AddValue("ghostGeometryAvailable", "False");

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -5371,7 +5371,20 @@ namespace Parsek
             var explosion = GhostVisualBuilder.SpawnExplosionFx(worldPos, vesselLength);
             if (explosion != null)
             {
+                // Auto-destroy after 6 seconds to prevent accumulation during looping
+                Destroy(explosion, 6f);
                 activeExplosions.Add(explosion);
+
+                // Prune already-destroyed entries to keep list bounded
+                if (activeExplosions.Count > 20)
+                {
+                    for (int e = activeExplosions.Count - 1; e >= 0; e--)
+                    {
+                        if (activeExplosions[e] == null)
+                            activeExplosions.RemoveAt(e);
+                    }
+                }
+
                 ParsekLog.Verbose("ExplosionFx",
                     $"Explosion GO created for ghost #{recIdx}, activeExplosions.Count={activeExplosions.Count}");
             }

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -284,6 +284,7 @@ namespace Parsek
         string watchedRecordingId = null;     // stable across index shifts
         int watchedOverlapCycleIndex = -1;    // which overlap cycle the camera is following (-1 = ready for next, -2 = holding after explosion)
         double overlapRetargetAfterUT = -1;   // delay re-target after watched cycle explodes
+        GameObject overlapCameraAnchor;       // temp anchor so FlightCamera doesn't reference destroyed ghost
         Vessel savedCameraVessel = null;
         float savedCameraDistance = 0f;
         float savedCameraPitch = 0f;
@@ -4895,15 +4896,24 @@ namespace Parsek
                         PositionGhostAt(ovState.ghost, rec.Points[rec.Points.Count - 1], srfRel);
                     TriggerExplosionIfDestroyed(ovState, rec, recIdx);
 
-                    // If camera was following this cycle, schedule delayed re-target
-                    // so user can see the explosion before camera jumps
+                    // If camera was following this cycle, park FlightCamera on a temp anchor
+                    // at the explosion site so it doesn't reference the destroyed ghost
                     if (watchedRecordingIndex == recIdx && watchedOverlapCycleIndex == cycle)
                     {
                         double holdSeconds = rec.TerminalStateValue == TerminalState.Destroyed ? 5.0 : 3.0;
                         overlapRetargetAfterUT = Planetarium.GetUniversalTime() + holdSeconds;
                         watchedOverlapCycleIndex = -2; // sentinel: waiting to re-target
+
+                        // Create temp anchor at ghost position before ghost is destroyed
+                        if (overlapCameraAnchor != null) Destroy(overlapCameraAnchor);
+                        overlapCameraAnchor = new GameObject("ParsekOverlapCameraAnchor");
+                        if (ovState.ghost != null)
+                            overlapCameraAnchor.transform.position = ovState.ghost.transform.position;
+                        if (FlightCamera.fetch != null)
+                            FlightCamera.fetch.SetTargetTransform(overlapCameraAnchor.transform);
+
                         ParsekLog.Info("CameraFollow",
-                            $"Overlap: watched cycle={cycle} expired, holding camera for 3s before re-target");
+                            $"Overlap: watched cycle={cycle} expired, holding camera at explosion site for {holdSeconds:F0}s");
                     }
 
                     ParsekLog.Info("Flight",
@@ -6789,6 +6799,12 @@ namespace Parsek
             {
                 if (Planetarium.GetUniversalTime() >= overlapRetargetAfterUT)
                 {
+                    // Destroy temp camera anchor
+                    if (overlapCameraAnchor != null)
+                    {
+                        Destroy(overlapCameraAnchor);
+                        overlapCameraAnchor = null;
+                    }
                     // Set to -1 so the next new cycle spawn will pick up the camera
                     watchedOverlapCycleIndex = -1;
                     overlapRetargetAfterUT = -1;
@@ -7178,6 +7194,7 @@ namespace Parsek
             watchedRecordingId = null;
             watchedOverlapCycleIndex = -1;
             overlapRetargetAfterUT = -1;
+            if (overlapCameraAnchor != null) { Destroy(overlapCameraAnchor); overlapCameraAnchor = null; }
             savedCameraVessel = null;
             savedCameraDistance = 0f;
             savedCameraPitch = 0f;

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -262,8 +262,9 @@ namespace Parsek
         // Warp-stop guard: only stop time warp once per recording
         private HashSet<int> warpStoppedForRecording = new HashSet<int>();
         private bool timelineResourceReplayPausedLogged = false;
-        private const double DefaultLoopPauseSeconds = 10.0;
+        private const double DefaultLoopIntervalSeconds = 0.0;
         private const double MinLoopDurationSeconds = 0.001;
+        private const double MinCycleDuration = 0.001;
 
         // Camera follow (watch mode) — transient, never serialized
         private const string WatchModeLockId = "ParsekWatch";
@@ -4564,12 +4565,14 @@ namespace Parsek
             return rec.EndUT - rec.StartUT > MinLoopDurationSeconds;
         }
 
-        private double GetLoopPauseSeconds(RecordingStore.Recording rec)
+        private double GetLoopIntervalSeconds(RecordingStore.Recording rec)
         {
-            if (rec == null) return DefaultLoopPauseSeconds;
-            if (double.IsNaN(rec.LoopPauseSeconds) || double.IsInfinity(rec.LoopPauseSeconds))
-                return DefaultLoopPauseSeconds;
-            return Math.Max(0.0, rec.LoopPauseSeconds);
+            if (rec == null) return DefaultLoopIntervalSeconds;
+            if (double.IsNaN(rec.LoopIntervalSeconds) || double.IsInfinity(rec.LoopIntervalSeconds))
+                return DefaultLoopIntervalSeconds;
+            double duration = rec.EndUT - rec.StartUT;
+            // Clamp so cycleDuration is always >= MinCycleDuration
+            return Math.Max(-duration + MinCycleDuration, rec.LoopIntervalSeconds);
         }
 
         private bool TryComputeLoopPlaybackUT(
@@ -4588,8 +4591,8 @@ namespace Parsek
             double duration = rec.EndUT - rec.StartUT;
             if (duration <= MinLoopDurationSeconds) return false;
 
-            double pauseSeconds = GetLoopPauseSeconds(rec);
-            double cycleDuration = duration + pauseSeconds;
+            double intervalSeconds = GetLoopIntervalSeconds(rec);
+            double cycleDuration = duration + intervalSeconds;
             if (cycleDuration <= MinLoopDurationSeconds)
                 cycleDuration = duration;
 
@@ -4598,7 +4601,7 @@ namespace Parsek
             if (cycleIndex < 0) cycleIndex = 0;
 
             double cycleTime = elapsed - (cycleIndex * cycleDuration);
-            if (pauseSeconds > 0 && cycleTime > duration)
+            if (intervalSeconds > 0 && cycleTime > duration)
             {
                 inPauseWindow = true;
                 loopUT = rec.EndUT;
@@ -6387,27 +6390,31 @@ namespace Parsek
         }
 
         internal static bool TryComputeLoopPlaybackUT(
-            double currentUT, double startUT, double endUT, double pauseSeconds,
+            double currentUT, double startUT, double endUT, double intervalSeconds,
             out double loopUT, out int cycleIndex)
         {
             loopUT = startUT;
             cycleIndex = 0;
 
             double duration = endUT - startUT;
-            if (duration <= 0 || pauseSeconds < 0 || currentUT < startUT)
+            if (duration <= 0 || currentUT < startUT)
                 return false;
 
-            double cycleDuration = duration + pauseSeconds;
-            if (cycleDuration <= 0)
-                return false;
+            double cycleDuration = duration + intervalSeconds;
+            if (cycleDuration <= MinCycleDuration)
+                cycleDuration = MinCycleDuration;
 
             double elapsed = currentUT - startUT;
             cycleIndex = (int)Math.Floor(elapsed / cycleDuration);
             double phase = elapsed - (cycleIndex * cycleDuration);
 
-            const double epsilon = 1e-6;
-            if (phase > duration + epsilon)
-                return false;
+            // For positive intervals: phase > duration means we're in the pause window
+            if (intervalSeconds >= 0)
+            {
+                const double epsilon = 1e-6;
+                if (phase > duration + epsilon)
+                    return false;
+            }
 
             if (phase < 0) phase = 0;
             if (phase > duration) phase = duration;

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -4592,8 +4592,9 @@ namespace Parsek
             // Apply tree-level resource deltas (lump sum when UT passes tree EndUT)
             ApplyTreeResourceDeltas(currentUT);
 
-            // Watch mode: verify ghost still exists
-            if (watchedRecordingIndex >= 0)
+            // Watch mode: verify ghost still exists (skip during explosion hold —
+            // the ghost is intentionally destroyed while camera is parked on anchor)
+            if (watchedRecordingIndex >= 0 && watchedOverlapCycleIndex != -2)
             {
                 GhostPlaybackState ws;
                 bool ghostOk = ghostStates.TryGetValue(watchedRecordingIndex, out ws)

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -273,6 +273,7 @@ namespace Parsek
         private const double DefaultLoopIntervalSeconds = 10.0;
         private const double MinLoopDurationSeconds = 0.001;
         private const double MinCycleDuration = 0.001;
+        private const double OverlapExplosionHoldSeconds = 3.0;
 
         // Camera follow (watch mode) — transient, never serialized
         private const string WatchModeLockId = "ParsekWatch";
@@ -4900,7 +4901,7 @@ namespace Parsek
                     // at the explosion site so it doesn't reference the destroyed ghost
                     if (watchedRecordingIndex == recIdx && watchedOverlapCycleIndex == cycle)
                     {
-                        overlapRetargetAfterUT = Planetarium.GetUniversalTime() + 3.0;
+                        overlapRetargetAfterUT = Planetarium.GetUniversalTime() + OverlapExplosionHoldSeconds;
                         watchedOverlapCycleIndex = -2; // sentinel: waiting to re-target
 
                         // Create temp anchor at ghost position before ghost is destroyed
@@ -4912,7 +4913,7 @@ namespace Parsek
                             FlightCamera.fetch.SetTargetTransform(overlapCameraAnchor.transform);
 
                         ParsekLog.Info("CameraFollow",
-                            $"Overlap: watched cycle={cycle} expired, holding camera at explosion site for 3s");
+                            $"Overlap: watched cycle={cycle} expired, holding camera at explosion site for {OverlapExplosionHoldSeconds:F0}s");
                     }
 
                     ParsekLog.Info("Flight",

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -4900,8 +4900,7 @@ namespace Parsek
                     // at the explosion site so it doesn't reference the destroyed ghost
                     if (watchedRecordingIndex == recIdx && watchedOverlapCycleIndex == cycle)
                     {
-                        double holdSeconds = rec.TerminalStateValue == TerminalState.Destroyed ? 5.0 : 3.0;
-                        overlapRetargetAfterUT = Planetarium.GetUniversalTime() + holdSeconds;
+                        overlapRetargetAfterUT = Planetarium.GetUniversalTime() + 3.0;
                         watchedOverlapCycleIndex = -2; // sentinel: waiting to re-target
 
                         // Create temp anchor at ghost position before ghost is destroyed
@@ -4913,7 +4912,7 @@ namespace Parsek
                             FlightCamera.fetch.SetTargetTransform(overlapCameraAnchor.transform);
 
                         ParsekLog.Info("CameraFollow",
-                            $"Overlap: watched cycle={cycle} expired, holding camera at explosion site for {holdSeconds:F0}s");
+                            $"Overlap: watched cycle={cycle} expired, holding camera at explosion site for 3s");
                     }
 
                     ParsekLog.Info("Flight",
@@ -6805,11 +6804,28 @@ namespace Parsek
                         Destroy(overlapCameraAnchor);
                         overlapCameraAnchor = null;
                     }
-                    // Set to -1 so the next new cycle spawn will pick up the camera
-                    watchedOverlapCycleIndex = -1;
                     overlapRetargetAfterUT = -1;
-                    ParsekLog.Info("CameraFollow",
-                        $"Overlap: explosion hold ended, waiting for next launch to follow");
+
+                    // Immediately target the current primary ghost so FlightCamera
+                    // doesn't reference the destroyed anchor
+                    GhostPlaybackState primary;
+                    if (FlightCamera.fetch != null
+                        && ghostStates.TryGetValue(watchedRecordingIndex, out primary)
+                        && primary != null && primary.ghost != null)
+                    {
+                        var target = primary.cameraPivot ?? primary.ghost.transform;
+                        FlightCamera.fetch.SetTargetTransform(target);
+                        watchedOverlapCycleIndex = primary.loopCycleIndex;
+                        ParsekLog.Info("CameraFollow",
+                            $"Overlap: hold ended, now following cycle={primary.loopCycleIndex}");
+                    }
+                    else
+                    {
+                        // No primary available — wait for next spawn
+                        watchedOverlapCycleIndex = -1;
+                        ParsekLog.Info("CameraFollow",
+                            $"Overlap: hold ended, no primary ghost available — waiting for next launch");
+                    }
                 }
                 // During hold, keep camera where it is (don't update position)
                 if (FlightCamera.fetch != null)

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -4692,7 +4692,7 @@ namespace Parsek
             if (cycleChanged && ghostActive)
             {
                 // Position at final point so explosion appears at crash site, not mid-air
-                if (rec.Points.Count > 0)
+                if (rec.Points.Count > 0 && state != null && state.ghost != null)
                     PositionGhostAt(state.ghost, rec.Points[rec.Points.Count - 1],
                         rec.RecordingFormatVersion >= 5);
                 TriggerExplosionIfDestroyed(state, rec, recIdx);
@@ -4705,13 +4705,14 @@ namespace Parsek
             if (!ghostActive)
             {
                 SpawnTimelineGhost(recIdx, rec);
-                state = ghostStates[recIdx];
+                if (!ghostStates.TryGetValue(recIdx, out state) || state == null)
+                    return;
                 state.loopCycleIndex = cycleIndex;
                 if (loggedGhostEnter.Add(recIdx))
                     Log($"Ghost ENTERED range: #{recIdx} \"{rec.VesselName}\" at UT {currentUT:F1} (loop cycle={cycleIndex})");
 
                 // Ghost was rebuilt for new loop cycle — re-target camera
-                if (watchedRecordingIndex == recIdx && state.ghost != null)
+                if (watchedRecordingIndex == recIdx && state.ghost != null && FlightCamera.fetch != null)
                 {
                     var target = state.cameraPivot ?? state.ghost.transform;
                     FlightCamera.fetch.SetTargetTransform(target);
@@ -4908,6 +4909,12 @@ namespace Parsek
                     ParsekLog.Info("Flight",
                         $"Ghost EXITED range: #{recIdx} \"{rec.VesselName}\" cycle={cycle} (overlap expired)");
                     DestroyOverlapGhostState(ovState);
+                    overlaps.RemoveAt(i);
+                    continue;
+                }
+
+                if (ovState.ghost == null)
+                {
                     overlaps.RemoveAt(i);
                     continue;
                 }

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -270,7 +270,7 @@ namespace Parsek
         // Warp-stop guard: only stop time warp once per recording
         private HashSet<int> warpStoppedForRecording = new HashSet<int>();
         private bool timelineResourceReplayPausedLogged = false;
-        private const double DefaultLoopIntervalSeconds = 0.0;
+        private const double DefaultLoopIntervalSeconds = 10.0;
         private const double MinLoopDurationSeconds = 0.001;
         private const double MinCycleDuration = 0.001;
 
@@ -4685,6 +4685,8 @@ namespace Parsek
             bool cycleChanged = !ghostActive || state == null || state.loopCycleIndex != cycleIndex;
             if (cycleChanged && ghostActive)
             {
+                // Fire explosion at end of cycle before destroying (works even with zero pause)
+                TriggerExplosionIfDestroyed(state, rec, recIdx);
                 ResetReentryFx(state, recIdx);
                 DestroyTimelineGhost(recIdx);
                 ghostActive = false;

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -4697,12 +4697,38 @@ namespace Parsek
                 if (rec.Points.Count > 0 && state != null && state.ghost != null)
                     PositionGhostAt(state.ghost, rec.Points[rec.Points.Count - 1],
                         rec.RecordingFormatVersion >= 5);
+
+                bool isWatching = watchedRecordingIndex == recIdx;
+                bool needsExplosion = state != null
+                    && rec.TerminalStateValue == TerminalState.Destroyed
+                    && !state.explosionFired;
+
                 TriggerExplosionIfDestroyed(state, rec, recIdx);
+
+                // If watching and explosion fired, hold camera at explosion site
+                if (isWatching && needsExplosion && !inPauseWindow)
+                {
+                    if (overlapCameraAnchor != null) Destroy(overlapCameraAnchor);
+                    overlapCameraAnchor = new GameObject("ParsekLoopCameraAnchor");
+                    if (state != null && state.ghost != null)
+                        overlapCameraAnchor.transform.position = state.ghost.transform.position;
+                    if (FlightCamera.fetch != null)
+                        FlightCamera.fetch.SetTargetTransform(overlapCameraAnchor.transform);
+                    overlapRetargetAfterUT = Planetarium.GetUniversalTime() + OverlapExplosionHoldSeconds;
+                    watchedOverlapCycleIndex = -2;
+                    ParsekLog.Info("CameraFollow",
+                        $"Loop: watched cycle={state?.loopCycleIndex} exploded, holding camera for {OverlapExplosionHoldSeconds:F0}s");
+                }
+
                 ResetReentryFx(state, recIdx);
                 DestroyTimelineGhost(recIdx);
                 ghostActive = false;
                 state = null;
             }
+
+            // During explosion hold, don't spawn new ghost — camera is parked at explosion site
+            if (watchedRecordingIndex == recIdx && watchedOverlapCycleIndex == -2)
+                return;
 
             if (!ghostActive)
             {
@@ -4714,7 +4740,8 @@ namespace Parsek
                     Log($"Ghost ENTERED range: #{recIdx} \"{rec.VesselName}\" at UT {currentUT:F1} (loop cycle={cycleIndex})");
 
                 // Ghost was rebuilt for new loop cycle — re-target camera
-                if (watchedRecordingIndex == recIdx && state.ghost != null && FlightCamera.fetch != null)
+                if (watchedRecordingIndex == recIdx && watchedOverlapCycleIndex == -1
+                    && state.ghost != null && FlightCamera.fetch != null)
                 {
                     var target = state.cameraPivot ?? state.ghost.transform;
                     FlightCamera.fetch.SetTargetTransform(target);

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -282,6 +282,7 @@ namespace Parsek
             ControlTypes.CAMERAMODES;
         int watchedRecordingIndex = -1;       // -1 = not watching
         string watchedRecordingId = null;     // stable across index shifts
+        int watchedOverlapCycleIndex = -1;    // which overlap cycle the camera is following (-1 = primary)
         Vessel savedCameraVessel = null;
         float savedCameraDistance = 0f;
         float savedCameraPitch = 0f;
@@ -4326,6 +4327,7 @@ namespace Parsek
                 // Disabled segments: destroy ghost if active, still apply resource deltas
                 if (!rec.PlaybackEnabled)
                 {
+                    DestroyAllOverlapGhosts(i);
                     if (ghostActive)
                     {
                         DestroyTimelineGhost(i);
@@ -4342,6 +4344,9 @@ namespace Parsek
                     UpdateLoopingTimelinePlayback(i, rec, currentUT, state, ghostActive);
                     continue;
                 }
+
+                // Loop was disabled — clean up any leftover overlap ghosts
+                DestroyAllOverlapGhosts(i);
 
                 bool isMidChain = RecordingStore.IsChainMidSegment(rec);
                 double chainEndUT = isMidChain ? RecordingStore.GetChainEndUT(rec) : rec.EndUT;
@@ -4685,7 +4690,10 @@ namespace Parsek
             bool cycleChanged = !ghostActive || state == null || state.loopCycleIndex != cycleIndex;
             if (cycleChanged && ghostActive)
             {
-                // Fire explosion at end of cycle before destroying (works even with zero pause)
+                // Position at final point so explosion appears at crash site, not mid-air
+                if (rec.Points.Count > 0)
+                    PositionGhostAt(state.ghost, rec.Points[rec.Points.Count - 1],
+                        rec.RecordingFormatVersion >= 5);
                 TriggerExplosionIfDestroyed(state, rec, recIdx);
                 ResetReentryFx(state, recIdx);
                 DestroyTimelineGhost(recIdx);
@@ -4823,13 +4831,15 @@ namespace Parsek
                 ParsekLog.Info("Flight",
                     $"Ghost ENTERED range: #{recIdx} \"{rec.VesselName}\" cycle={lastCycle} at UT {currentUT:F1} (overlap)");
 
-                // Re-target camera
-                if (watchedRecordingIndex == recIdx && primaryState.ghost != null)
+                // Re-target camera only if not currently following an overlap ghost
+                if (watchedRecordingIndex == recIdx && watchedOverlapCycleIndex < 0
+                    && primaryState.ghost != null)
                 {
                     var target = primaryState.cameraPivot ?? primaryState.ghost.transform;
                     FlightCamera.fetch.SetTargetTransform(target);
+                    watchedOverlapCycleIndex = lastCycle;
                     ParsekLog.Info("CameraFollow",
-                        $"Overlap cycle re-target: ghost #{recIdx} cycle={lastCycle}");
+                        $"Overlap: camera now following ghost #{recIdx} cycle={lastCycle}");
                 }
             }
 
@@ -4869,8 +4879,24 @@ namespace Parsek
                 // Check if this cycle has expired (phase > duration)
                 double cycleStart = rec.StartUT + cycle * cycleDuration;
                 double phase = currentUT - cycleStart;
-                if (phase > duration || cycle < firstCycle)
+                if (phase > duration)
                 {
+                    // Position at final point so explosion appears at crash site
+                    if (rec.Points.Count > 0)
+                        PositionGhostAt(ovState.ghost, rec.Points[rec.Points.Count - 1], srfRel);
+                    TriggerExplosionIfDestroyed(ovState, rec, recIdx);
+
+                    // If camera was following this cycle, re-target to current primary
+                    if (watchedRecordingIndex == recIdx && watchedOverlapCycleIndex == cycle
+                        && primaryState != null && primaryState.ghost != null)
+                    {
+                        var target = primaryState.cameraPivot ?? primaryState.ghost.transform;
+                        FlightCamera.fetch.SetTargetTransform(target);
+                        watchedOverlapCycleIndex = primaryState.loopCycleIndex;
+                        ParsekLog.Info("CameraFollow",
+                            $"Overlap: watched cycle={cycle} expired, re-targeting to cycle={primaryState.loopCycleIndex}");
+                    }
+
                     ParsekLog.Info("Flight",
                         $"Ghost EXITED range: #{recIdx} \"{rec.VesselName}\" cycle={cycle} (overlap expired)");
                     DestroyOverlapGhostState(ovState);
@@ -6720,9 +6746,38 @@ namespace Parsek
         {
             if (watchedRecordingIndex < 0) return;
 
-            GhostPlaybackState state;
-            if (!ghostStates.TryGetValue(watchedRecordingIndex, out state) ||
-                state == null || state.cameraPivot == null)
+            // Find the ghost we're actually following — may be an overlap ghost, not the primary
+            GhostPlaybackState state = null;
+            if (watchedOverlapCycleIndex >= 0)
+            {
+                // Look for the watched cycle in the overlap list
+                List<GhostPlaybackState> overlaps;
+                if (overlapGhosts.TryGetValue(watchedRecordingIndex, out overlaps))
+                {
+                    for (int i = 0; i < overlaps.Count; i++)
+                    {
+                        if (overlaps[i] != null && overlaps[i].loopCycleIndex == watchedOverlapCycleIndex)
+                        {
+                            state = overlaps[i];
+                            break;
+                        }
+                    }
+                }
+                // Also check if the primary IS the watched cycle
+                if (state == null)
+                {
+                    GhostPlaybackState primary;
+                    if (ghostStates.TryGetValue(watchedRecordingIndex, out primary)
+                        && primary != null && primary.loopCycleIndex == watchedOverlapCycleIndex)
+                        state = primary;
+                }
+            }
+            else
+            {
+                ghostStates.TryGetValue(watchedRecordingIndex, out state);
+            }
+
+            if (state == null || state.cameraPivot == null)
                 return;
 
             // Keep sharpness zeroed — KSP resets it on various events
@@ -6995,6 +7050,7 @@ namespace Parsek
             var watchTarget = gs.cameraPivot ?? gs.ghost.transform;
             FlightCamera.fetch.SetTargetTransform(watchTarget);
             FlightCamera.fetch.SetDistance(50f);  // override [75,400] entry clamp
+            watchedOverlapCycleIndex = gs.loopCycleIndex; // track which cycle we're following
             ParsekLog.Info("CameraFollow",
                 $"EnterWatchMode: ghost #{index} \"{committed[index].VesselName}\"" +
                 $" target='{watchTarget.name}' pivotLocal=({watchTarget.localPosition.x:F2},{watchTarget.localPosition.y:F2},{watchTarget.localPosition.z:F2})" +
@@ -7058,6 +7114,7 @@ namespace Parsek
 
             watchedRecordingIndex = -1;
             watchedRecordingId = null;
+            watchedOverlapCycleIndex = -1;
             savedCameraVessel = null;
             savedCameraDistance = 0f;
             savedCameraPitch = 0f;

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -5410,6 +5410,8 @@ namespace Parsek
         private void DestroyOverlapGhostState(GhostPlaybackState state)
         {
             if (state == null) return;
+            ParsekLog.Verbose("Flight",
+                $"Destroying overlap ghost cycle={state.loopCycleIndex}");
 
             if (state.materials != null)
             {
@@ -5442,6 +5444,9 @@ namespace Parsek
         {
             List<GhostPlaybackState> list;
             if (!overlapGhosts.TryGetValue(recIdx, out list)) return;
+            if (list.Count > 0)
+                ParsekLog.Verbose("Flight",
+                    $"Destroying all {list.Count} overlap ghost(s) for recording #{recIdx}");
 
             for (int i = 0; i < list.Count; i++)
                 DestroyOverlapGhostState(list[i]);

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -6771,7 +6771,8 @@ namespace Parsek
                         $"Overlap: explosion hold ended, waiting for next launch to follow");
                 }
                 // During hold, keep camera where it is (don't update position)
-                FlightCamera.fetch.pivotTranslateSharpness = 0f;
+                if (FlightCamera.fetch != null)
+                    FlightCamera.fetch.pivotTranslateSharpness = 0f;
                 return;
             }
 
@@ -6807,6 +6808,9 @@ namespace Parsek
             }
 
             if (state == null || state.cameraPivot == null)
+                return;
+            if (FlightCamera.fetch == null || FlightCamera.fetch.transform == null
+                || FlightCamera.fetch.transform.parent == null)
                 return;
 
             // Keep sharpness zeroed — KSP resets it on various events

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -4828,7 +4828,12 @@ namespace Parsek
 
                 // Spawn new primary for lastCycle
                 SpawnTimelineGhost(recIdx, rec);
-                primaryState = ghostStates[recIdx];
+                if (!ghostStates.TryGetValue(recIdx, out primaryState) || primaryState == null)
+                {
+                    ParsekLog.Warn("Flight",
+                        $"Overlap: SpawnTimelineGhost failed for #{recIdx} cycle={lastCycle} — skipping");
+                    return;
+                }
                 primaryState.loopCycleIndex = lastCycle;
                 ParsekLog.Info("Flight",
                     $"Ghost ENTERED range: #{recIdx} \"{rec.VesselName}\" cycle={lastCycle} at UT {currentUT:F1} (overlap)");
@@ -4836,7 +4841,7 @@ namespace Parsek
                 // Re-target camera only if ready for a new launch (-1 = not following anyone)
                 // -2 = holding after explosion, don't interrupt the hold
                 if (watchedRecordingIndex == recIdx && watchedOverlapCycleIndex == -1
-                    && primaryState.ghost != null)
+                    && primaryState.ghost != null && FlightCamera.fetch != null)
                 {
                     var target = primaryState.cameraPivot ?? primaryState.ghost.transform;
                     FlightCamera.fetch.SetTargetTransform(target);
@@ -4885,7 +4890,7 @@ namespace Parsek
                 if (phase > duration)
                 {
                     // Position at final point so explosion appears at crash site
-                    if (rec.Points.Count > 0)
+                    if (rec.Points.Count > 0 && ovState.ghost != null)
                         PositionGhostAt(ovState.ghost, rec.Points[rec.Points.Count - 1], srfRel);
                     TriggerExplosionIfDestroyed(ovState, rec, recIdx);
 

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -66,6 +66,7 @@ namespace Parsek
             public Dictionary<uint, FairingGhostInfo> fairingInfos;
             public Dictionary<uint, GameObject> fakeCanopies;
             public ReentryFxInfo reentryFxInfo;
+            public MaterialPropertyBlock reentryMpb; // per-ghost to avoid shared-state bugs with overlapping ghosts
             public Transform cameraPivot; // child of ghost; centroid of active parts — camera targets this
             public Vector3 lastInterpolatedVelocity;
             public string lastInterpolatedBodyName;
@@ -101,7 +102,10 @@ namespace Parsek
         }
 
         private Dictionary<int, GhostPlaybackState> ghostStates = new Dictionary<int, GhostPlaybackState>();
-        private readonly MaterialPropertyBlock reentryShellMpb = new MaterialPropertyBlock();
+
+        // Older cycle ghosts still alive due to negative interval overlap
+        private Dictionary<int, List<GhostPlaybackState>> overlapGhosts = new Dictionary<int, List<GhostPlaybackState>>();
+        private const int MaxOverlapGhostsPerRecording = 5;
 
         // --- Floating-origin correction ---
         // Ghosts are plain GameObjects not registered with KSP's FloatingOrigin.
@@ -4619,6 +4623,17 @@ namespace Parsek
             GhostPlaybackState state,
             bool ghostActive)
         {
+            double intervalSeconds = GetLoopIntervalSeconds(rec);
+            double duration = rec.EndUT - rec.StartUT;
+
+            // For negative intervals: use multi-cycle overlap path
+            if (intervalSeconds < 0)
+            {
+                UpdateOverlapLoopPlayback(recIdx, rec, currentUT, state, ghostActive, intervalSeconds, duration);
+                return;
+            }
+
+            // --- Positive/zero interval: single ghost path (no overlap) ---
             double loopUT;
             int cycleIndex;
             bool inPauseWindow;
@@ -4645,7 +4660,7 @@ namespace Parsek
                 state = ghostStates[recIdx];
                 state.loopCycleIndex = cycleIndex;
                 if (loggedGhostEnter.Add(recIdx))
-                    Log($"Ghost ENTERED range: #{recIdx} \"{rec.VesselName}\" at UT {currentUT:F1} (loop)");
+                    Log($"Ghost ENTERED range: #{recIdx} \"{rec.VesselName}\" at UT {currentUT:F1} (loop cycle={cycleIndex})");
 
                 // Ghost was rebuilt for new loop cycle — re-target camera
                 if (watchedRecordingIndex == recIdx && state.ghost != null)
@@ -4693,6 +4708,143 @@ namespace Parsek
 
             ApplyPartEvents(recIdx, rec, loopUT, state);
             UpdateReentryFx(recIdx, state, rec.VesselName);
+        }
+
+        /// <summary>
+        /// Multi-cycle overlap path for negative intervals. Multiple ghosts from
+        /// different cycles may be visible simultaneously.
+        /// </summary>
+        private void UpdateOverlapLoopPlayback(
+            int recIdx,
+            RecordingStore.Recording rec,
+            double currentUT,
+            GhostPlaybackState primaryState,
+            bool primaryActive,
+            double intervalSeconds,
+            double duration)
+        {
+            if (currentUT < rec.StartUT)
+            {
+                if (primaryActive) DestroyTimelineGhost(recIdx);
+                DestroyAllOverlapGhosts(recIdx);
+                return;
+            }
+
+            double cycleDuration = duration + intervalSeconds;
+            if (cycleDuration < MinCycleDuration) cycleDuration = MinCycleDuration;
+
+            int firstCycle, lastCycle;
+            GetActiveCycles(currentUT, rec.StartUT, rec.EndUT, intervalSeconds,
+                MaxOverlapGhostsPerRecording, out firstCycle, out lastCycle);
+
+            // Ensure overlap list exists
+            List<GhostPlaybackState> overlaps;
+            if (!overlapGhosts.TryGetValue(recIdx, out overlaps))
+            {
+                overlaps = new List<GhostPlaybackState>();
+                overlapGhosts[recIdx] = overlaps;
+            }
+
+            bool srfRel = rec.RecordingFormatVersion >= 5;
+
+            // Primary ghost always represents the newest (lastCycle)
+            // Check if primary needs to be rebuilt for a new cycle
+            bool primaryCycleChanged = !primaryActive || primaryState == null
+                || primaryState.loopCycleIndex != lastCycle;
+
+            if (primaryCycleChanged)
+            {
+                // Move old primary to overlap list if still alive
+                if (primaryActive && primaryState != null && primaryState.ghost != null)
+                {
+                    // Detach from ghostStates (don't destroy) — move to overlap
+                    ghostStates.Remove(recIdx);
+                    overlaps.Add(primaryState);
+                    ParsekLog.Verbose("Flight",
+                        $"Ghost #{recIdx} cycle={primaryState.loopCycleIndex} moved to overlap list");
+                }
+                else if (primaryActive)
+                {
+                    DestroyTimelineGhost(recIdx);
+                }
+
+                // Spawn new primary for lastCycle
+                SpawnTimelineGhost(recIdx, rec);
+                primaryState = ghostStates[recIdx];
+                primaryState.loopCycleIndex = lastCycle;
+                ParsekLog.Info("Flight",
+                    $"Ghost ENTERED range: #{recIdx} \"{rec.VesselName}\" cycle={lastCycle} at UT {currentUT:F1} (overlap)");
+
+                // Re-target camera
+                if (watchedRecordingIndex == recIdx && primaryState.ghost != null)
+                {
+                    var target = primaryState.cameraPivot ?? primaryState.ghost.transform;
+                    FlightCamera.fetch.SetTargetTransform(target);
+                    ParsekLog.Info("CameraFollow",
+                        $"Overlap cycle re-target: ghost #{recIdx} cycle={lastCycle}");
+                }
+            }
+
+            // Update primary ghost position
+            if (primaryState != null && primaryState.ghost != null)
+            {
+                double cycleStartUT = rec.StartUT + lastCycle * cycleDuration;
+                double phase = currentUT - cycleStartUT;
+                if (phase < 0) phase = 0;
+                if (phase > duration) phase = duration;
+                double loopUT = rec.StartUT + phase;
+
+                int playbackIdx = primaryState.playbackIndex;
+                InterpolationResult interpResult;
+                InterpolateAndPosition(primaryState.ghost, rec.Points, rec.OrbitSegments,
+                    ref playbackIdx, loopUT, recIdx * 10000, out interpResult,
+                    surfaceRelativeRotation: srfRel);
+                primaryState.SetInterpolated(interpResult);
+                primaryState.playbackIndex = playbackIdx;
+
+                ApplyPartEvents(recIdx, rec, loopUT, primaryState);
+                UpdateReentryFx(recIdx, primaryState, rec.VesselName);
+            }
+
+            // Update overlap ghosts (older cycles)
+            for (int i = overlaps.Count - 1; i >= 0; i--)
+            {
+                var ovState = overlaps[i];
+                if (ovState == null || ovState.ghost == null)
+                {
+                    overlaps.RemoveAt(i);
+                    continue;
+                }
+
+                int cycle = ovState.loopCycleIndex;
+
+                // Check if this cycle has expired (phase > duration)
+                double cycleStart = rec.StartUT + cycle * cycleDuration;
+                double phase = currentUT - cycleStart;
+                if (phase > duration || cycle < firstCycle)
+                {
+                    ParsekLog.Info("Flight",
+                        $"Ghost EXITED range: #{recIdx} \"{rec.VesselName}\" cycle={cycle} (overlap expired)");
+                    DestroyOverlapGhostState(ovState);
+                    overlaps.RemoveAt(i);
+                    continue;
+                }
+
+                if (phase < 0) phase = 0;
+                if (phase > duration) phase = duration;
+                double loopUT = rec.StartUT + phase;
+
+                int playbackIdx = ovState.playbackIndex;
+                InterpolationResult interpResult;
+                InterpolateAndPosition(ovState.ghost, rec.Points, rec.OrbitSegments,
+                    ref playbackIdx, loopUT, recIdx * 10000 + (cycle + 1) * 100, out interpResult,
+                    surfaceRelativeRotation: srfRel);
+                ovState.SetInterpolated(interpResult);
+                ovState.playbackIndex = playbackIdx;
+
+                ApplyPartEvents(recIdx, rec, loopUT, ovState);
+                UpdateReentryFx(recIdx, ovState, rec.VesselName);
+            }
         }
 
         /// <summary>
@@ -5029,6 +5181,7 @@ namespace Parsek
                 state.heatInfos,
                 index,
                 rec.VesselName);
+            state.reentryMpb = new MaterialPropertyBlock();
 
             ghostStates[index] = state;
         }
@@ -5083,11 +5236,65 @@ namespace Parsek
             {
                 DestroyTimelineGhost(key);
             }
+
+            // Destroy all overlap ghosts
+            foreach (var kvp in overlapGhosts)
+            {
+                for (int i = 0; i < kvp.Value.Count; i++)
+                    DestroyOverlapGhostState(kvp.Value[i]);
+            }
+            overlapGhosts.Clear();
+
             orbitCache.Clear();
             loggedGhostEnter.Clear();
             loggedOrbitSegments.Clear();
             loggedOrbitRotationSegments.Clear();
             warpStoppedForRecording.Clear();
+        }
+
+        /// <summary>
+        /// Destroys a single overlap ghost's resources (materials, FX, GameObject).
+        /// Does NOT remove from any collection — caller handles that.
+        /// </summary>
+        private void DestroyOverlapGhostState(GhostPlaybackState state)
+        {
+            if (state == null) return;
+
+            if (state.materials != null)
+            {
+                for (int i = 0; i < state.materials.Count; i++)
+                    if (state.materials[i] != null)
+                        Destroy(state.materials[i]);
+            }
+
+            if (state.engineInfos != null)
+                foreach (var info in state.engineInfos.Values)
+                    for (int i = 0; i < info.particleSystems.Count; i++)
+                        if (info.particleSystems[i] != null)
+                            Destroy(info.particleSystems[i].gameObject);
+
+            if (state.rcsInfos != null)
+                foreach (var info in state.rcsInfos.Values)
+                    for (int i = 0; i < info.particleSystems.Count; i++)
+                        if (info.particleSystems[i] != null)
+                            Destroy(info.particleSystems[i].gameObject);
+
+            DestroyReentryFxResources(state.reentryFxInfo);
+            if (state.ghost != null) Destroy(state.ghost);
+            DestroyAllFakeCanopies(state);
+        }
+
+        /// <summary>
+        /// Destroys all overlap ghosts for a single recording index.
+        /// </summary>
+        private void DestroyAllOverlapGhosts(int recIdx)
+        {
+            List<GhostPlaybackState> list;
+            if (!overlapGhosts.TryGetValue(recIdx, out list)) return;
+
+            for (int i = 0; i < list.Count; i++)
+                DestroyOverlapGhostState(list[i]);
+            list.Clear();
         }
 
         public bool CanDeleteRecording =>
@@ -5116,7 +5323,8 @@ namespace Parsek
             // Unreserve crew
             ParsekScenario.UnreserveCrewInSnapshot(rec.VesselSnapshot);
 
-            // Destroy ghost if active
+            // Destroy ghost if active (primary + overlap)
+            DestroyAllOverlapGhosts(index);
             DestroyTimelineGhost(index);
 
             // Remove from store (handles chain degradation + file deletion)
@@ -5155,6 +5363,18 @@ namespace Parsek
                 else if (kvp.Key > index)
                     ghostStates[kvp.Key - 1] = kvp.Value;
                 // kvp.Key == index was already removed by DestroyTimelineGhost
+            }
+
+            // Reindex overlap ghosts the same way
+            var oldOverlap = new Dictionary<int, List<GhostPlaybackState>>(overlapGhosts);
+            overlapGhosts.Clear();
+            foreach (var kvp in oldOverlap)
+            {
+                if (kvp.Key < index)
+                    overlapGhosts[kvp.Key] = kvp.Value;
+                else if (kvp.Key > index)
+                    overlapGhosts[kvp.Key - 1] = kvp.Value;
+                // kvp.Key == index was already destroyed by DestroyAllOverlapGhosts
             }
 
             // Clear orbit cache — keys are index-derived (i * 10000 + segIdx),
@@ -5990,12 +6210,13 @@ namespace Parsek
             if (smoothedIntensity < 0.001f && rawIntensity == 0f)
                 smoothedIntensity = 0f;
 
-            DriveReentryLayers(info, smoothedIntensity, surfaceVel, recIdx, bodyName, altitude, machNumber, vesselName);
+            DriveReentryLayers(info, smoothedIntensity, surfaceVel, recIdx, bodyName, altitude, machNumber, vesselName, state);
             info.lastIntensity = smoothedIntensity;
         }
 
         private void DriveReentryLayers(ReentryFxInfo info, float intensity, Vector3 surfaceVel,
-            int recIdx, string bodyName, double altitude, float machNumber, string vesselName)
+            int recIdx, string bodyName, double altitude, float machNumber, string vesselName,
+            GhostPlaybackState state = null)
         {
             bool wasActive = info.lastIntensity > 0f;
             bool isActive = intensity > 0f;
@@ -6093,7 +6314,8 @@ namespace Parsek
                     float alpha = baseTint * (1f - t * 0.7f); // closer passes are brighter
                     Color tint = GhostVisualBuilder.ReentryFireShellColor * alpha;
 
-                    reentryShellMpb.SetColor("_TintColor", tint);
+                    var mpb = state.reentryMpb ?? new MaterialPropertyBlock();
+                    mpb.SetColor("_TintColor", tint);
 
                     for (int m = 0; m < info.fireShellMeshes.Count; m++)
                     {
@@ -6103,7 +6325,7 @@ namespace Parsek
                         if (!fsm.transform.gameObject.activeInHierarchy) continue;
 
                         Matrix4x4 matrix = Matrix4x4.Translate(offset) * fsm.transform.localToWorldMatrix;
-                        Graphics.DrawMesh(fsm.mesh, matrix, info.fireShellMaterial, 0, null, 0, reentryShellMpb);
+                        Graphics.DrawMesh(fsm.mesh, matrix, info.fireShellMaterial, 0, null, 0, mpb);
                     }
                 }
             }

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -7110,7 +7110,8 @@ namespace Parsek
         internal void ExitWatchMode(bool skipCameraRestore = false)
         {
             if (watchedRecordingIndex < 0) return;
-            FlightCamera.fetch.pivotTranslateSharpness = savedPivotSharpness;
+            if (FlightCamera.fetch != null)
+                FlightCamera.fetch.pivotTranslateSharpness = savedPivotSharpness;
 
             // Restore camera to the active vessel (unless switching between ghosts)
             if (!skipCameraRestore)
@@ -7124,20 +7125,23 @@ namespace Parsek
                 ParsekLog.Info("CameraFollow",
                     $"Exiting watch mode for recording #{watchedRecordingIndex} \"{recVesselName}\" \u2014 returning to {targetName}");
 
-                if (savedCameraVessel != null && savedCameraVessel.gameObject != null)
+                if (FlightCamera.fetch != null)
                 {
-                    FlightCamera.fetch.SetTargetVessel(savedCameraVessel);
-                    FlightCamera.fetch.SetDistance(savedCameraDistance);
-                    FlightCamera.fetch.camPitch = savedCameraPitch;
-                    FlightCamera.fetch.camHdg = savedCameraHeading;
-                    ParsekLog.Verbose("CameraFollow",
-                        $"FlightCamera.SetTargetVessel restored to {savedCameraVessel.vesselName}, distance={savedCameraDistance.ToString("F1", CultureInfo.InvariantCulture)}");
-                }
-                else
-                {
-                    FlightCamera.fetch.SetTargetVessel(FlightGlobals.ActiveVessel);
-                    ParsekLog.Verbose("CameraFollow",
-                        $"FlightCamera.SetTargetVessel restored to {FlightGlobals.ActiveVessel?.vesselName ?? "unknown"}, distance={savedCameraDistance.ToString("F1", CultureInfo.InvariantCulture)}");
+                    if (savedCameraVessel != null && savedCameraVessel.gameObject != null)
+                    {
+                        FlightCamera.fetch.SetTargetVessel(savedCameraVessel);
+                        FlightCamera.fetch.SetDistance(savedCameraDistance);
+                        FlightCamera.fetch.camPitch = savedCameraPitch;
+                        FlightCamera.fetch.camHdg = savedCameraHeading;
+                        ParsekLog.Verbose("CameraFollow",
+                            $"FlightCamera.SetTargetVessel restored to {savedCameraVessel.vesselName}, distance={savedCameraDistance.ToString("F1", CultureInfo.InvariantCulture)}");
+                    }
+                    else if (FlightGlobals.ActiveVessel != null)
+                    {
+                        FlightCamera.fetch.SetTargetVessel(FlightGlobals.ActiveVessel);
+                        ParsekLog.Verbose("CameraFollow",
+                            $"FlightCamera.SetTargetVessel restored to {FlightGlobals.ActiveVessel.vesselName}, distance={savedCameraDistance.ToString("F1", CultureInfo.InvariantCulture)}");
+                    }
                 }
             }
 

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -282,7 +282,8 @@ namespace Parsek
             ControlTypes.CAMERAMODES;
         int watchedRecordingIndex = -1;       // -1 = not watching
         string watchedRecordingId = null;     // stable across index shifts
-        int watchedOverlapCycleIndex = -1;    // which overlap cycle the camera is following (-1 = primary)
+        int watchedOverlapCycleIndex = -1;    // which overlap cycle the camera is following (-1 = ready for next, -2 = holding after explosion)
+        double overlapRetargetAfterUT = -1;   // delay re-target after watched cycle explodes
         Vessel savedCameraVessel = null;
         float savedCameraDistance = 0f;
         float savedCameraPitch = 0f;
@@ -4714,8 +4715,9 @@ namespace Parsek
                 {
                     var target = state.cameraPivot ?? state.ghost.transform;
                     FlightCamera.fetch.SetTargetTransform(target);
+                    watchedOverlapCycleIndex = cycleIndex;
                     ParsekLog.Info("CameraFollow",
-                        $"Loop rebuild re-target: ghost #{recIdx}" +
+                        $"Loop rebuild re-target: ghost #{recIdx} cycle={cycleIndex}" +
                         $" target='{target.name}' localPos=({target.localPosition.x:F2},{target.localPosition.y:F2},{target.localPosition.z:F2})" +
                         $" camDist={FlightCamera.fetch.Distance:F1}");
                 }
@@ -4831,8 +4833,9 @@ namespace Parsek
                 ParsekLog.Info("Flight",
                     $"Ghost ENTERED range: #{recIdx} \"{rec.VesselName}\" cycle={lastCycle} at UT {currentUT:F1} (overlap)");
 
-                // Re-target camera only if not currently following an overlap ghost
-                if (watchedRecordingIndex == recIdx && watchedOverlapCycleIndex < 0
+                // Re-target camera only if ready for a new launch (-1 = not following anyone)
+                // -2 = holding after explosion, don't interrupt the hold
+                if (watchedRecordingIndex == recIdx && watchedOverlapCycleIndex == -1
                     && primaryState.ghost != null)
                 {
                     var target = primaryState.cameraPivot ?? primaryState.ghost.transform;
@@ -4886,15 +4889,14 @@ namespace Parsek
                         PositionGhostAt(ovState.ghost, rec.Points[rec.Points.Count - 1], srfRel);
                     TriggerExplosionIfDestroyed(ovState, rec, recIdx);
 
-                    // If camera was following this cycle, re-target to current primary
-                    if (watchedRecordingIndex == recIdx && watchedOverlapCycleIndex == cycle
-                        && primaryState != null && primaryState.ghost != null)
+                    // If camera was following this cycle, schedule delayed re-target
+                    // so user can see the explosion before camera jumps
+                    if (watchedRecordingIndex == recIdx && watchedOverlapCycleIndex == cycle)
                     {
-                        var target = primaryState.cameraPivot ?? primaryState.ghost.transform;
-                        FlightCamera.fetch.SetTargetTransform(target);
-                        watchedOverlapCycleIndex = primaryState.loopCycleIndex;
+                        overlapRetargetAfterUT = Planetarium.GetUniversalTime() + 3.0;
+                        watchedOverlapCycleIndex = -2; // sentinel: waiting to re-target
                         ParsekLog.Info("CameraFollow",
-                            $"Overlap: watched cycle={cycle} expired, re-targeting to cycle={primaryState.loopCycleIndex}");
+                            $"Overlap: watched cycle={cycle} expired, holding camera for 3s before re-target");
                     }
 
                     ParsekLog.Info("Flight",
@@ -5479,6 +5481,16 @@ namespace Parsek
             for (int i = 0; i < list.Count; i++)
                 DestroyOverlapGhostState(list[i]);
             list.Clear();
+
+            // If camera was following an overlap cycle for this recording, reset tracking
+            // so we don't get stuck in the hold state for a destroyed ghost
+            if (watchedRecordingIndex == recIdx && watchedOverlapCycleIndex != -1)
+            {
+                ParsekLog.Info("CameraFollow",
+                    $"Overlap ghosts destroyed for watched recording #{recIdx} — resetting overlap cycle tracking from {watchedOverlapCycleIndex}");
+                watchedOverlapCycleIndex = -1;
+                overlapRetargetAfterUT = -1;
+            }
         }
 
         public bool CanDeleteRecording =>
@@ -6746,6 +6758,22 @@ namespace Parsek
         {
             if (watchedRecordingIndex < 0) return;
 
+            // Delayed re-target after watched overlap cycle exploded
+            if (watchedOverlapCycleIndex == -2 && overlapRetargetAfterUT > 0)
+            {
+                if (Planetarium.GetUniversalTime() >= overlapRetargetAfterUT)
+                {
+                    // Set to -1 so the next new cycle spawn will pick up the camera
+                    watchedOverlapCycleIndex = -1;
+                    overlapRetargetAfterUT = -1;
+                    ParsekLog.Info("CameraFollow",
+                        $"Overlap: explosion hold ended, waiting for next launch to follow");
+                }
+                // During hold, keep camera where it is (don't update position)
+                FlightCamera.fetch.pivotTranslateSharpness = 0f;
+                return;
+            }
+
             // Find the ghost we're actually following — may be an overlap ghost, not the primary
             GhostPlaybackState state = null;
             if (watchedOverlapCycleIndex >= 0)
@@ -7115,6 +7143,7 @@ namespace Parsek
             watchedRecordingIndex = -1;
             watchedRecordingId = null;
             watchedOverlapCycleIndex = -1;
+            overlapRetargetAfterUT = -1;
             savedCameraVessel = null;
             savedCameraDistance = 0f;
             savedCameraPitch = 0f;

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -4893,7 +4893,8 @@ namespace Parsek
                     // so user can see the explosion before camera jumps
                     if (watchedRecordingIndex == recIdx && watchedOverlapCycleIndex == cycle)
                     {
-                        overlapRetargetAfterUT = Planetarium.GetUniversalTime() + 3.0;
+                        double holdSeconds = rec.TerminalStateValue == TerminalState.Destroyed ? 5.0 : 3.0;
+                        overlapRetargetAfterUT = Planetarium.GetUniversalTime() + holdSeconds;
                         watchedOverlapCycleIndex = -2; // sentinel: waiting to re-target
                         ParsekLog.Info("CameraFollow",
                             $"Overlap: watched cycle={cycle} expired, holding camera for 3s before re-target");

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -6423,6 +6423,49 @@ namespace Parsek
             return true;
         }
 
+        /// <summary>
+        /// Computes the range of active loop cycles at a given time.
+        /// For positive/zero intervals, firstActiveCycle == lastActiveCycle (no overlap).
+        /// For negative intervals, multiple cycles may be active simultaneously.
+        /// </summary>
+        internal static void GetActiveCycles(
+            double currentUT, double startUT, double endUT,
+            double intervalSeconds, int maxCycles,
+            out int firstActiveCycle, out int lastActiveCycle)
+        {
+            firstActiveCycle = 0;
+            lastActiveCycle = 0;
+
+            double duration = endUT - startUT;
+            if (duration <= 0 || currentUT < startUT)
+                return;
+
+            double cycleDuration = duration + intervalSeconds;
+            if (cycleDuration < MinCycleDuration)
+                cycleDuration = MinCycleDuration;
+
+            double elapsed = currentUT - startUT;
+            lastActiveCycle = (int)Math.Floor(elapsed / cycleDuration);
+            if (lastActiveCycle < 0) lastActiveCycle = 0;
+
+            // First cycle whose playback hasn't finished yet
+            double elapsedMinusDuration = elapsed - duration;
+            if (elapsedMinusDuration < 0)
+            {
+                firstActiveCycle = 0;
+            }
+            else
+            {
+                firstActiveCycle = (int)Math.Floor(elapsedMinusDuration / cycleDuration) + 1;
+                if (firstActiveCycle < 0) firstActiveCycle = 0;
+            }
+
+            // Cap by maxCycles
+            if (firstActiveCycle < lastActiveCycle - maxCycles + 1)
+                firstActiveCycle = lastActiveCycle - maxCycles + 1;
+            if (firstActiveCycle < 0) firstActiveCycle = 0;
+        }
+
         internal static bool IsAnyWarpActive(int currentRateIndex, float currentRate)
         {
             return currentRateIndex > 0 || currentRate > 1f;

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -4679,6 +4679,8 @@ namespace Parsek
             }
 
             // --- Positive/zero interval: single ghost path (no overlap) ---
+            // Clean up any leftover overlap ghosts from a previous negative interval
+            DestroyAllOverlapGhosts(recIdx);
             double loopUT;
             int cycleIndex;
             bool inPauseWindow;

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -4729,10 +4729,6 @@ namespace Parsek
                 state = null;
             }
 
-            // During explosion hold, don't spawn new ghost — camera is parked at explosion site
-            if (watchedRecordingIndex == recIdx && watchedOverlapCycleIndex == -2)
-                return;
-
             if (!ghostActive)
             {
                 SpawnTimelineGhost(recIdx, rec);

--- a/Source/Parsek/ParsekKSC.cs
+++ b/Source/Parsek/ParsekKSC.cs
@@ -1,0 +1,64 @@
+using ClickThroughFix;
+using KSP.UI.Screens;
+using ToolbarControl_NS;
+using UnityEngine;
+
+namespace Parsek
+{
+    /// <summary>
+    /// KSC scene host for the Parsek UI. Provides recording management,
+    /// resource budget viewing, and game actions in the Space Center scene.
+    /// Reuses ParsekUI in KSC mode (flight-only controls hidden).
+    /// </summary>
+    [KSPAddon(KSPAddon.Startup.SpaceCentre, false)]
+    public class ParsekKSC : MonoBehaviour
+    {
+        private ToolbarControl toolbarControl;
+        private ParsekUI ui;
+        private bool showUI;
+        private Rect windowRect = new Rect(20, 100, 250, 250);
+
+        void Start()
+        {
+            ParsekLog.Info("KSC", "ParsekKSC starting in Space Center scene");
+
+            ui = new ParsekUI(ParsekUI.UIMode.KSC);
+
+            toolbarControl = gameObject.AddComponent<ToolbarControl>();
+            toolbarControl.AddToAllToolbars(
+                () => { showUI = true; ParsekLog.Verbose("KSC", "Toolbar button ON"); },
+                () => { showUI = false; ParsekLog.Verbose("KSC", "Toolbar button OFF"); },
+                ApplicationLauncher.AppScenes.SPACECENTER,
+                ParsekFlight.MODID, "parsekKSCButton",
+                "Parsek/Textures/parsek_38",
+                "Parsek/Textures/parsek_24",
+                ParsekFlight.MODNAME
+            );
+
+            ParsekLog.Info("KSC", "ParsekKSC initialized");
+        }
+
+        void OnGUI()
+        {
+            if (!showUI) return;
+
+            windowRect = ClickThruBlocker.GUILayoutWindow(
+                GetInstanceID(), windowRect, ui.DrawWindow,
+                "Parsek", GUILayout.Width(250));
+
+            ui.DrawRecordingsWindowIfOpen(windowRect);
+            ui.DrawActionsWindowIfOpen(windowRect);
+            ui.DrawSettingsWindowIfOpen(windowRect);
+        }
+
+        void OnDestroy()
+        {
+            ParsekLog.Info("KSC", "ParsekKSC destroyed");
+            if (toolbarControl != null)
+            {
+                toolbarControl.OnDestroy();
+                Destroy(toolbarControl);
+            }
+        }
+    }
+}

--- a/Source/Parsek/ParsekKSC.cs
+++ b/Source/Parsek/ParsekKSC.cs
@@ -54,6 +54,7 @@ namespace Parsek
         void OnDestroy()
         {
             ParsekLog.Info("KSC", "ParsekKSC destroyed");
+            ui?.Cleanup();
             if (toolbarControl != null)
             {
                 toolbarControl.OnDestroy();

--- a/Source/Parsek/ParsekKSC.cs
+++ b/Source/Parsek/ParsekKSC.cs
@@ -44,7 +44,7 @@ namespace Parsek
 
             windowRect = ClickThruBlocker.GUILayoutWindow(
                 GetInstanceID(), windowRect, ui.DrawWindow,
-                "Parsek", GUILayout.Width(250));
+                "Parsek");
 
             ui.DrawRecordingsWindowIfOpen(windowRect);
             ui.DrawActionsWindowIfOpen(windowRect);

--- a/Source/Parsek/ParsekKSC.cs
+++ b/Source/Parsek/ParsekKSC.cs
@@ -16,7 +16,7 @@ namespace Parsek
         private ToolbarControl toolbarControl;
         private ParsekUI ui;
         private bool showUI;
-        private Rect windowRect = new Rect(20, 100, 250, 250);
+        private Rect windowRect = new Rect(20, 100, 200, 10);
 
         void Start()
         {
@@ -44,7 +44,7 @@ namespace Parsek
 
             windowRect = ClickThruBlocker.GUILayoutWindow(
                 GetInstanceID(), windowRect, ui.DrawWindow,
-                "Parsek");
+                "Parsek", GUILayout.Width(250));
 
             ui.DrawRecordingsWindowIfOpen(windowRect);
             ui.DrawActionsWindowIfOpen(windowRect);

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -1136,7 +1136,7 @@ namespace Parsek
             recNode.AddValue("recordingId", rec.RecordingId ?? "");
             recNode.AddValue("recordingFormatVersion", rec.RecordingFormatVersion);
             recNode.AddValue("loopPlayback", rec.LoopPlayback);
-            recNode.AddValue("loopPauseSeconds", rec.LoopPauseSeconds.ToString("R", CultureInfo.InvariantCulture));
+            recNode.AddValue("loopIntervalSeconds", rec.LoopIntervalSeconds.ToString("R", CultureInfo.InvariantCulture));
             if (rec.PreLaunchFunds != 0)
                 recNode.AddValue("preLaunchFunds", rec.PreLaunchFunds.ToString("R", CultureInfo.InvariantCulture));
             if (rec.PreLaunchScience != 0)
@@ -1206,12 +1206,13 @@ namespace Parsek
                     rec.LoopPlayback = loopPlayback;
             }
 
-            string loopPauseStr = recNode.GetValue("loopPauseSeconds");
-            if (loopPauseStr != null)
+            string loopIntervalStr = recNode.GetValue("loopIntervalSeconds")
+                                  ?? recNode.GetValue("loopPauseSeconds"); // migration fallback
+            if (loopIntervalStr != null)
             {
-                double loopPauseSeconds;
-                if (double.TryParse(loopPauseStr, NumberStyles.Float, CultureInfo.InvariantCulture, out loopPauseSeconds))
-                    rec.LoopPauseSeconds = loopPauseSeconds;
+                double loopIntervalSeconds;
+                if (double.TryParse(loopIntervalStr, NumberStyles.Float, CultureInfo.InvariantCulture, out loopIntervalSeconds))
+                    rec.LoopIntervalSeconds = loopIntervalSeconds;
             }
 
             rec.GhostGeometryRelativePath = recNode.GetValue("ghostGeometryPath");

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -1562,7 +1562,7 @@ namespace Parsek
             }
             else
             {
-                double period = dur + rec.LoopPauseSeconds;
+                double period = dur + rec.LoopIntervalSeconds;
                 if (GUILayout.Button(FormatDuration(period), GUILayout.Width(ColW_Period)))
                 {
                     // Save any in-progress edit on another recording
@@ -1578,7 +1578,7 @@ namespace Parsek
                     }
 
                     editingLoopPeriodIdx = ri;
-                    editingLoopPeriodText = ((int)(dur + rec.LoopPauseSeconds)).ToString();
+                    editingLoopPeriodText = ((int)(dur + rec.LoopIntervalSeconds)).ToString();
                 }
             }
         }
@@ -1590,9 +1590,9 @@ namespace Parsek
             {
                 double pause = newPeriod - dur;
                 if (pause < 0) pause = 0;
-                rec.LoopPauseSeconds = pause;
+                rec.LoopIntervalSeconds = pause;
                 ParsekLog.Info("UI",
-                    $"Recording '{rec.VesselName}' loop period updated to {(dur + rec.LoopPauseSeconds):F1}s (pause={pause:F1}s)");
+                    $"Recording '{rec.VesselName}' loop period updated to {(dur + rec.LoopIntervalSeconds):F1}s (pause={pause:F1}s)");
             }
             else
             {

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -62,7 +62,7 @@ namespace Parsek
         private const float ColW_Launch = 110f;
         private const float ColW_Dur = 55f;
         private const float ColW_Status = 45f;
-        private const float ColW_Loop = 45f;
+        private const float ColW_Loop = 55f;
         private const float ColW_Watch = 50f;
         private const float ColW_Rewind = 55f;
         private const float ColW_Delete = 50f;
@@ -360,12 +360,9 @@ namespace Parsek
 
             if (parts.Count > 0)
             {
-                string line = "Reserved: " + string.Join("  ", parts);
-                if (GUILayout.Button(line, GUI.skin.label))
-                {
-                    showActionsWindow = !showActionsWindow;
-                    ParsekLog.Verbose("UI", $"Budget line clicked — Actions window toggled: {(showActionsWindow ? "open" : "closed")}");
-                }
+                GUILayout.Label("Reserved:");
+                for (int i = 0; i < parts.Count; i++)
+                    GUILayout.Label("  \u2022 " + parts[i]);
             }
         }
 
@@ -702,10 +699,11 @@ namespace Parsek
             // Position to the right of main window on first open
             if (recordingsWindowRect.width < 1f)
             {
+                float recHeight = InFlight ? mainWindowRect.height : mainWindowRect.height * 2;
                 recordingsWindowRect = new Rect(
                     mainWindowRect.x + mainWindowRect.width + 10,
                     mainWindowRect.y,
-                    790, mainWindowRect.height);
+                    790, recHeight);
                 var ic = System.Globalization.CultureInfo.InvariantCulture;
                 ParsekLog.Verbose("UI", $"Recordings window initial position: x={recordingsWindowRect.x.ToString("F0", ic)} y={recordingsWindowRect.y.ToString("F0", ic)}");
             }
@@ -849,10 +847,8 @@ namespace Parsek
                     GUILayout.Width(ColW_Period));
 
                 if (InFlight)
-                {
                     GUILayout.Label("Watch", GUILayout.Width(ColW_Watch));
-                    GUILayout.Label("Rewind", GUILayout.Width(ColW_Rewind));
-                }
+                GUILayout.Label("Rewind", GUILayout.Width(ColW_Rewind));
                 GUILayout.Label("Delete", GUILayout.Width(ColW_Delete));
                 GUILayout.Space(ScrollbarWidth);
                 GUILayout.EndHorizontal();
@@ -1186,14 +1182,14 @@ namespace Parsek
                 GUI.enabled = true;
             }
 
-            // Rewind button (flight only)
-            if (InFlight)
+            // Rewind button
             {
                 bool hasRewindSave = !string.IsNullOrEmpty(rec.RewindSaveFileName);
                 if (hasRewindSave)
                 {
                     string rewindReason;
-                    bool canRewind = RecordingStore.CanRewind(rec, out rewindReason, isRecording: flight.IsRecording);
+                    bool isRecording = InFlight && flight.IsRecording;
+                    bool canRewind = RecordingStore.CanRewind(rec, out rewindReason, isRecording: isRecording);
                     GUI.enabled = canRewind;
                     string tooltip = canRewind ? "Rewind to this launch" : rewindReason;
                     if (GUILayout.Button(new GUIContent("R", tooltip), GUILayout.Width(ColW_Rewind)))

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -1649,11 +1649,14 @@ namespace Parsek
         private void ApplyLoopIntervalEdit(RecordingStore.Recording rec, double dur)
         {
             double newInterval;
-            if (double.TryParse(editingLoopPeriodText, out newInterval) && newInterval > -(dur - 0.001))
+            if (double.TryParse(editingLoopPeriodText, System.Globalization.NumberStyles.Float,
+                    System.Globalization.CultureInfo.InvariantCulture, out newInterval)
+                && newInterval > -(dur - 0.001))
             {
                 rec.LoopIntervalSeconds = newInterval;
                 ParsekLog.Info("UI",
-                    $"Recording '{rec.VesselName}' loop interval updated to {rec.LoopIntervalSeconds:F1}s");
+                    $"Recording '{rec.VesselName}' loop interval updated to " +
+                    rec.LoopIntervalSeconds.ToString("F1", System.Globalization.CultureInfo.InvariantCulture) + "s");
             }
             else
             {

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -842,9 +842,12 @@ namespace Parsek
                     ParsekLog.Info("UI", $"Set loop playback for all recordings: enabled={newAllLoop}");
                 }
 
+                GUILayout.BeginHorizontal(GUILayout.Width(ColW_Period));
+                GUILayout.FlexibleSpace();
                 GUILayout.Label(new GUIContent("Every",
-                    "Loop interval (seconds):\n  Positive: wait N seconds after end\n  Zero: restart immediately\n  Negative: overlap by N seconds"),
-                    GUILayout.Width(ColW_Period));
+                    "Loop interval (seconds):\n  Positive: wait N seconds after end\n  Zero: restart immediately\n  Negative: overlap by N seconds"));
+                GUILayout.FlexibleSpace();
+                GUILayout.EndHorizontal();
 
                 if (InFlight)
                     GUILayout.Label("Watch", GUILayout.Width(ColW_Watch));

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -10,6 +10,10 @@ namespace Parsek
     /// </summary>
     public class ParsekUI
     {
+        public enum UIMode { Flight, KSC }
+        private readonly UIMode mode;
+        private bool InFlight => mode == UIMode.Flight;
+
         private readonly ParsekFlight flight;
 
         // Map view markers
@@ -111,6 +115,13 @@ namespace Parsek
         public ParsekUI(ParsekFlight flight)
         {
             this.flight = flight;
+            this.mode = UIMode.Flight;
+        }
+
+        public ParsekUI(UIMode mode)
+        {
+            this.flight = null;
+            this.mode = mode;
         }
 
         private const float SpacingSmall = 3f;
@@ -120,16 +131,9 @@ namespace Parsek
         {
             GUILayout.BeginVertical();
 
-            // --- Status ---
-            GUILayout.Label("Status", GUI.skin.box);
-            GUILayout.Label($"State: {GetStatusText()}");
-            GUILayout.Label($"Recorded Points: {flight.recording.Count}");
-            if (flight.recording.Count > 0)
-            {
-                double duration = flight.recording[flight.recording.Count - 1].ut - flight.recording[0].ut;
-                GUILayout.Label($"Duration: {duration:F1}s");
-            }
-            GUILayout.Label($"Active Ghosts: {flight.TimelineGhostCount}");
+            if (InFlight)
+                DrawFlightStatus();
+
             DrawCompactBudgetLine();
 
             // --- Timeline buttons ---
@@ -151,7 +155,38 @@ namespace Parsek
                 ParsekLog.Verbose("UI", $"Actions window toggled: {(showActionsWindow ? "open" : "closed")}");
             }
 
-            // --- Recording controls ---
+            if (InFlight)
+                DrawFlightRecordingControls();
+
+            // --- Settings button ---
+            GUILayout.Space(SpacingLarge);
+            if (GUILayout.Button("Settings"))
+            {
+                showSettingsWindow = !showSettingsWindow;
+                ParsekLog.Verbose("UI", $"Settings window toggled: {(showSettingsWindow ? "open" : "closed")}");
+            }
+
+            GUILayout.EndVertical();
+
+            // Make window draggable
+            GUI.DragWindow();
+        }
+
+        private void DrawFlightStatus()
+        {
+            GUILayout.Label("Status", GUI.skin.box);
+            GUILayout.Label($"State: {GetStatusText()}");
+            GUILayout.Label($"Recorded Points: {flight.recording.Count}");
+            if (flight.recording.Count > 0)
+            {
+                double duration = flight.recording[flight.recording.Count - 1].ut - flight.recording[0].ut;
+                GUILayout.Label($"Duration: {duration:F1}s");
+            }
+            GUILayout.Label($"Active Ghosts: {flight.TimelineGhostCount}");
+        }
+
+        private void DrawFlightRecordingControls()
+        {
             GUILayout.Space(SpacingLarge);
 
             if (!flight.IsRecording)
@@ -214,19 +249,6 @@ namespace Parsek
                     flight.CommitFlight();
             }
             GUI.enabled = true;
-
-            // --- Settings button ---
-            GUILayout.Space(SpacingLarge);
-            if (GUILayout.Button("Settings"))
-            {
-                showSettingsWindow = !showSettingsWindow;
-                ParsekLog.Verbose("UI", $"Settings window toggled: {(showSettingsWindow ? "open" : "closed")}");
-            }
-
-            GUILayout.EndVertical();
-
-            // Make window draggable
-            GUI.DragWindow();
         }
 
         /// <summary>
@@ -826,8 +848,11 @@ namespace Parsek
                     "Loop interval (seconds):\n  Positive: wait N seconds after end\n  Zero: restart immediately\n  Negative: overlap by N seconds"),
                     GUILayout.Width(ColW_Period));
 
-                GUILayout.Label("Watch", GUILayout.Width(ColW_Watch));
-                GUILayout.Label("Rewind", GUILayout.Width(ColW_Rewind));
+                if (InFlight)
+                {
+                    GUILayout.Label("Watch", GUILayout.Width(ColW_Watch));
+                    GUILayout.Label("Rewind", GUILayout.Width(ColW_Rewind));
+                }
                 GUILayout.Label("Delete", GUILayout.Width(ColW_Delete));
                 GUILayout.Space(ScrollbarWidth);
                 GUILayout.EndHorizontal();
@@ -1139,7 +1164,8 @@ namespace Parsek
             // Period
             DrawLoopPeriodCell(rec, ri, dur);
 
-            // Watch button
+            // Watch button (flight only)
+            if (InFlight)
             {
                 bool hasGhost = flight.HasActiveGhost(ri);
                 bool sameBody = flight.IsGhostOnSameBody(ri);
@@ -1160,7 +1186,8 @@ namespace Parsek
                 GUI.enabled = true;
             }
 
-            // Rewind button
+            // Rewind button (flight only)
+            if (InFlight)
             {
                 bool hasRewindSave = !string.IsNullOrEmpty(rec.RewindSaveFileName);
                 if (hasRewindSave)
@@ -1180,7 +1207,7 @@ namespace Parsek
             }
 
             // Delete button (X → ? confirm → delete, right-click ? to cancel)
-            GUI.enabled = flight.CanDeleteRecording;
+            GUI.enabled = InFlight ? flight.CanDeleteRecording : true;
             if (deleteConfirmIndex == ri)
             {
                 if (GUILayout.Button("?", GUILayout.Width(ColW_Delete)))
@@ -1191,7 +1218,10 @@ namespace Parsek
                     else if (editingLoopPeriodIdx > ri)
                         editingLoopPeriodIdx--;
                     ParsekLog.Info("UI", $"Delete confirmed for recording index={ri} name='{rec.VesselName}'");
-                    flight.DeleteRecording(ri);
+                    if (InFlight)
+                        flight.DeleteRecording(ri);
+                    else
+                        RecordingStore.DeleteRecordingFull(ri);
                     InvalidateSort();
                     GUI.enabled = true;
                     GUILayout.EndHorizontal();
@@ -1302,7 +1332,7 @@ namespace Parsek
                         foreach (var rec in RecordingStore.CommittedRecordings)
                             ParsekScenario.UnreserveCrewInSnapshot(rec.VesselSnapshot);
                         ParsekScenario.ClearReplacements();
-                        flight.DestroyAllTimelineGhosts();
+                        if (InFlight) flight.DestroyAllTimelineGhosts();
                         RecordingStore.ClearCommitted();
                         GameStateStore.ClearScienceSubjects();
                         ParsekLog.Info("UI", "All recordings wiped");
@@ -1789,14 +1819,17 @@ namespace Parsek
                 ShowWipeActionsConfirmation(milestoneCount);
             GUI.enabled = true;
 
-            int activeGhosts = flight.TimelineGhostCount;
-            GUI.enabled = activeGhosts > 0;
-            if (GUILayout.Button($"Despawn Ghosts ({activeGhosts})"))
+            if (InFlight)
             {
-                flight.DestroyAllTimelineGhosts();
-                ParsekLog.Info("UI", "Ghosts despawned from settings");
+                int activeGhosts = flight.TimelineGhostCount;
+                GUI.enabled = activeGhosts > 0;
+                if (GUILayout.Button($"Despawn Ghosts ({activeGhosts})"))
+                {
+                    flight.DestroyAllTimelineGhosts();
+                    ParsekLog.Info("UI", "Ghosts despawned from settings");
+                }
+                GUI.enabled = true;
             }
-            GUI.enabled = true;
 
             GUILayout.Space(SpacingLarge);
             GUILayout.BeginHorizontal();

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -1206,28 +1206,17 @@ namespace Parsek
                 }
             }
 
-            // Delete button (X → ? confirm → delete, right-click ? to cancel)
+            // Delete button (X → ? → PopupDialog confirm → delete)
             GUI.enabled = InFlight ? flight.CanDeleteRecording : true;
             if (deleteConfirmIndex == ri)
             {
                 if (GUILayout.Button("?", GUILayout.Width(ColW_Delete)))
                 {
                     deleteConfirmIndex = -1;
-                    if (editingLoopPeriodIdx == ri)
-                        editingLoopPeriodIdx = -1;
-                    else if (editingLoopPeriodIdx > ri)
-                        editingLoopPeriodIdx--;
-                    ParsekLog.Info("UI", $"Delete confirmed for recording index={ri} name='{rec.VesselName}'");
-                    if (InFlight)
-                        flight.DeleteRecording(ri);
-                    else
-                        RecordingStore.DeleteRecordingFull(ri);
-                    InvalidateSort();
-                    GUI.enabled = true;
-                    GUILayout.EndHorizontal();
-                    return true; // list changed
+                    ParsekLog.Verbose("UI", $"Delete confirm clicked for recording index={ri} name='{rec.VesselName}'");
+                    ShowDeleteRecordingConfirmation(ri, rec.VesselName);
                 }
-                // Right-click cancels the delete confirmation
+                // Right-click cancels
                 if (Event.current.type == EventType.MouseDown && Event.current.button == 1 &&
                     GUILayoutUtility.GetLastRect().Contains(Event.current.mousePosition))
                 {
@@ -1256,6 +1245,39 @@ namespace Parsek
             }
 
             return false;
+        }
+
+        private void ShowDeleteRecordingConfirmation(int index, string vesselName)
+        {
+            int capturedIndex = index;
+            string capturedName = vesselName;
+            PopupDialog.SpawnPopupDialog(
+                new Vector2(0.5f, 0.5f),
+                new Vector2(0.5f, 0.5f),
+                new MultiOptionDialog(
+                    "ParsekDeleteRecordingConfirm",
+                    $"Delete recording \"{capturedName}\" and its files?\n\nThis cannot be undone.",
+                    "Confirm Delete Recording",
+                    HighLogic.UISkin,
+                    new DialogGUIButton("Delete", () =>
+                    {
+                        ParsekLog.Info("UI", $"Delete confirmed for recording index={capturedIndex} name='{capturedName}'");
+                        if (editingLoopPeriodIdx == capturedIndex)
+                            editingLoopPeriodIdx = -1;
+                        else if (editingLoopPeriodIdx > capturedIndex)
+                            editingLoopPeriodIdx--;
+                        if (InFlight)
+                            flight.DeleteRecording(capturedIndex);
+                        else
+                            RecordingStore.DeleteRecordingFull(capturedIndex);
+                        InvalidateSort();
+                    }),
+                    new DialogGUIButton("Cancel", () =>
+                    {
+                        ParsekLog.Verbose("UI", $"Delete cancelled for recording '{capturedName}'");
+                    })
+                ),
+                false, HighLogic.UISkin);
         }
 
         private void ShowRewindConfirmation(RecordingStore.Recording rec)

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -822,7 +822,9 @@ namespace Parsek
                     ParsekLog.Info("UI", $"Set loop playback for all recordings: enabled={newAllLoop}");
                 }
 
-                GUILayout.Label("Period", GUILayout.Width(ColW_Period));
+                GUILayout.Label(new GUIContent("Every",
+                    "Loop interval (seconds):\n  Positive: wait N seconds after end\n  Zero: restart immediately\n  Negative: overlap by N seconds"),
+                    GUILayout.Width(ColW_Period));
 
                 GUILayout.Label("Watch", GUILayout.Width(ColW_Watch));
                 GUILayout.Label("Rewind", GUILayout.Width(ColW_Rewind));
@@ -1536,6 +1538,15 @@ namespace Parsek
                 content, tooltipLabelStyle);
         }
 
+        private static readonly GUIContent intervalTooltip = new GUIContent("",
+            "Loop interval (seconds):\n  Positive: wait N seconds after end\n  Zero: restart immediately\n  Negative: overlap by N seconds");
+
+        private string FormatInterval(double interval)
+        {
+            string sign = interval < 0 ? "-" : "";
+            return sign + FormatDuration(System.Math.Abs(interval));
+        }
+
         private void DrawLoopPeriodCell(RecordingStore.Recording rec, int ri, double dur)
         {
             if (!rec.LoopPlayback)
@@ -1556,14 +1567,14 @@ namespace Parsek
                     Event.current.keyCode == KeyCode.Return &&
                     GUI.GetNameOfFocusedControl() == "PeriodEdit")
                 {
-                    ApplyLoopPeriodEdit(rec, dur);
+                    ApplyLoopIntervalEdit(rec, dur);
                     editingLoopPeriodIdx = -1;
                 }
             }
             else
             {
-                double period = dur + rec.LoopIntervalSeconds;
-                if (GUILayout.Button(FormatDuration(period), GUILayout.Width(ColW_Period)))
+                var content = new GUIContent(FormatInterval(rec.LoopIntervalSeconds), intervalTooltip.tooltip);
+                if (GUILayout.Button(content, GUILayout.Width(ColW_Period)))
                 {
                     // Save any in-progress edit on another recording
                     if (editingLoopPeriodIdx >= 0)
@@ -1573,31 +1584,29 @@ namespace Parsek
                         {
                             var editRec = committed[editingLoopPeriodIdx];
                             double editDur = editRec.EndUT - editRec.StartUT;
-                            ApplyLoopPeriodEdit(editRec, editDur);
+                            ApplyLoopIntervalEdit(editRec, editDur);
                         }
                     }
 
                     editingLoopPeriodIdx = ri;
-                    editingLoopPeriodText = ((int)(dur + rec.LoopIntervalSeconds)).ToString();
+                    editingLoopPeriodText = ((int)rec.LoopIntervalSeconds).ToString();
                 }
             }
         }
 
-        private void ApplyLoopPeriodEdit(RecordingStore.Recording rec, double dur)
+        private void ApplyLoopIntervalEdit(RecordingStore.Recording rec, double dur)
         {
-            double newPeriod;
-            if (double.TryParse(editingLoopPeriodText, out newPeriod) && newPeriod > 0)
+            double newInterval;
+            if (double.TryParse(editingLoopPeriodText, out newInterval) && newInterval > -(dur - 0.001))
             {
-                double pause = newPeriod - dur;
-                if (pause < 0) pause = 0;
-                rec.LoopIntervalSeconds = pause;
+                rec.LoopIntervalSeconds = newInterval;
                 ParsekLog.Info("UI",
-                    $"Recording '{rec.VesselName}' loop period updated to {(dur + rec.LoopIntervalSeconds):F1}s (pause={pause:F1}s)");
+                    $"Recording '{rec.VesselName}' loop interval updated to {rec.LoopIntervalSeconds:F1}s");
             }
             else
             {
                 ParsekLog.Warn("UI",
-                    $"Rejected loop period edit '{editingLoopPeriodText}' for recording '{rec.VesselName}'");
+                    $"Rejected loop interval edit '{editingLoopPeriodText}' for recording '{rec.VesselName}'");
             }
         }
 

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -72,7 +72,7 @@ namespace Parsek
             public List<OrbitSegment> OrbitSegments = new List<OrbitSegment>();
             public List<PartEvent> PartEvents = new List<PartEvent>();
             public bool LoopPlayback;
-            public double LoopPauseSeconds = 10.0;
+            public double LoopIntervalSeconds = 0.0;
 
             // UI grouping tag (e.g. "Synthetic", "Part Showcase")
             public string RecordingGroup;
@@ -198,7 +198,7 @@ namespace Parsek
                 ChainIndex = source.ChainIndex;
                 ChainBranch = source.ChainBranch;
                 LoopPlayback = source.LoopPlayback;
-                LoopPauseSeconds = source.LoopPauseSeconds;
+                LoopIntervalSeconds = source.LoopIntervalSeconds;
                 PreLaunchFunds = source.PreLaunchFunds;
                 PreLaunchScience = source.PreLaunchScience;
                 PreLaunchReputation = source.PreLaunchReputation;

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -679,6 +679,24 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Deletes a recording from the committed list, cleans up sidecar files, and
+        /// unreserves crew. Use when there are no active ghosts (e.g. KSC scene).
+        /// In flight scene, use ParsekFlight.DeleteRecording instead (handles ghost cleanup).
+        /// </summary>
+        public static void DeleteRecordingFull(int index)
+        {
+            if (index < 0 || index >= committedRecordings.Count)
+            {
+                ParsekLog.Warn("RecordingStore", $"DeleteRecordingFull: invalid index={index} (count={committedRecordings.Count})");
+                return;
+            }
+            var rec = committedRecordings[index];
+            ParsekLog.Info("RecordingStore", $"DeleteRecordingFull: deleting '{rec.VesselName}' at index {index}");
+            ParsekScenario.UnreserveCrewInSnapshot(rec.VesselSnapshot);
+            RemoveRecordingAt(index);
+        }
+
+        /// <summary>
         /// Returns true if any branch-0 enabled segment in the chain has LoopPlayback set.
         /// </summary>
         internal static bool IsChainLooping(string chainId)

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -72,7 +72,7 @@ namespace Parsek
             public List<OrbitSegment> OrbitSegments = new List<OrbitSegment>();
             public List<PartEvent> PartEvents = new List<PartEvent>();
             public bool LoopPlayback;
-            public double LoopIntervalSeconds = 0.0;
+            public double LoopIntervalSeconds = 10.0;
 
             // UI grouping tag (e.g. "Synthetic", "Part Showcase")
             public string RecordingGroup;

--- a/Source/Parsek/RecordingTree.cs
+++ b/Source/Parsek/RecordingTree.cs
@@ -203,7 +203,7 @@ namespace Parsek
             // Existing recording metadata
             recNode.AddValue("recordingFormatVersion", rec.RecordingFormatVersion);
             recNode.AddValue("loopPlayback", rec.LoopPlayback);
-            recNode.AddValue("loopPauseSeconds", rec.LoopPauseSeconds.ToString("R", ic));
+            recNode.AddValue("loopIntervalSeconds", rec.LoopIntervalSeconds.ToString("R", ic));
             if (!rec.PlaybackEnabled)
                 recNode.AddValue("playbackEnabled", rec.PlaybackEnabled.ToString());
 
@@ -347,12 +347,13 @@ namespace Parsek
                     rec.LoopPlayback = loopPlayback;
             }
 
-            string loopPauseStr = recNode.GetValue("loopPauseSeconds");
-            if (loopPauseStr != null)
+            string loopIntervalStr = recNode.GetValue("loopIntervalSeconds")
+                                   ?? recNode.GetValue("loopPauseSeconds"); // migration fallback
+            if (loopIntervalStr != null)
             {
-                double loopPauseSeconds;
-                if (double.TryParse(loopPauseStr, inv, ic, out loopPauseSeconds))
-                    rec.LoopPauseSeconds = loopPauseSeconds;
+                double loopIntervalSeconds;
+                if (double.TryParse(loopIntervalStr, inv, ic, out loopIntervalSeconds))
+                    rec.LoopIntervalSeconds = loopIntervalSeconds;
             }
 
             string playbackEnabledStr = recNode.GetValue("playbackEnabled");


### PR DESCRIPTION
## Summary
- **Loop interval rework**: Replace "Period" (duration + pause) with "Loop every N seconds" — negative values spawn overlapping ghosts, zero = immediate restart, positive = gap after end
- **Overlapping ghosts**: Negative intervals spawn multiple simultaneous ghost instances capped at 5 per recording, managed via parallel `overlapGhosts` dict. Each ghost plays its full trajectory before being destroyed with an explosion at the crash site
- **KSC toolbar UI**: Parsek toolbar button in Space Center scene, reusing the same UI with flight-only controls (Watch, recording controls) hidden. Recordings management, resource budget, game actions, settings, and Rewind all available
- **Delete confirmation**: Individual recording deletion now uses PopupDialog (X → ? → popup → Delete/Cancel)
- **Watch mode for overlapping loops**: Camera follows one ghost to completion, holds 3s at explosion site, then picks up the next launch. Works for all interval values (positive, zero, negative)

## Changes
- `LoopPauseSeconds` → `LoopIntervalSeconds` (default 10s, serialization migration from old key)
- "Period" column → centered "Every" column with tooltip explaining semantics
- `GetActiveCycles` pure static cycle math for overlap computation (17 new tests)
- Per-ghost `MaterialPropertyBlock` fixes reentry FX sharing bug
- `overlapGhosts` dict for older cycle ghosts, cleanup on disable/loop-off/interval-change
- Camera anchor mechanism for explosion hold — prevents FlightCamera NRE on destroyed ghost
- Auto-destroy explosion GameObjects after 6s to prevent accumulation
- `ParsekUI.UIMode` enum with `InFlight` guard, flight-only sections extracted to helper methods
- New `ParsekKSC.cs` MonoBehaviour for SpaceCenter scene (auto-fit height, 250px width)
- `RecordingStore.DeleteRecordingFull` for KSC-mode deletion
- Reserved resources displayed as bullet points
- Comprehensive null guards for FlightCamera in watch mode lifecycle

## Test plan
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 1301 passed, 0 failed
- [x] In-game: positive interval → single ghost loops with gap + explosion hold when watching
- [x] In-game: interval = 0 → immediate restart + explosion hold when watching
- [x] In-game: negative interval → overlapping ghosts, full trajectory, explosion at crash site
- [x] In-game: watch mode follows one ghost to completion, 3s hold at explosion, picks up next launch
- [x] In-game: toggling loop/enable cleans up overlap ghosts
- [x] In-game: changing interval from negative to positive cleans up overlap ghosts
- [x] In-game: KSC toolbar → UI opens → recordings/budget/actions/settings/rewind work
- [x] In-game: delete recording from KSC → PopupDialog confirmation
- [x] No game freezes during overlap looping with watch mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)