### PR TITLE
Recording quality: final position capture, pad trimming, merge dialog controls

### DIFF
--- a/Source/Parsek.Tests/AdaptiveSamplingTests.cs
+++ b/Source/Parsek.Tests/AdaptiveSamplingTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using UnityEngine;
 using Xunit;
 
@@ -258,6 +259,61 @@ namespace Parsek.Tests
 
             // Negative interval: 99-100 = -1, not >= 3
             Assert.False(result);
+        }
+
+        // --- FindFirstMovingPoint tests ---
+
+        private static List<TrajectoryPoint> MakePoints(params (double alt, float speed)[] specs)
+        {
+            var points = new List<TrajectoryPoint>();
+            for (int i = 0; i < specs.Length; i++)
+            {
+                points.Add(new TrajectoryPoint
+                {
+                    ut = 100 + i,
+                    altitude = specs[i].alt,
+                    velocity = new Vector3(specs[i].speed, 0, 0)
+                });
+            }
+            return points;
+        }
+
+        [Fact]
+        public void FindFirstMoving_AllStationary_ReturnsZero()
+        {
+            var points = MakePoints((78, 0.3f), (78, 0.5f), (78, 0.2f));
+            Assert.Equal(0, TrajectoryMath.FindFirstMovingPoint(points));
+        }
+
+        [Fact]
+        public void FindFirstMoving_MovingFromStart_ReturnsZero()
+        {
+            var points = MakePoints((78, 10f), (80, 15f));
+            Assert.Equal(0, TrajectoryMath.FindFirstMovingPoint(points));
+        }
+
+        [Fact]
+        public void FindFirstMoving_AltitudeChange_ReturnsCorrectIndex()
+        {
+            // Pad at alt 78, then lifts off at index 3
+            var points = MakePoints((78, 0.3f), (78, 0.5f), (78.2, 0.4f), (79.5, 2f), (85, 10f));
+            Assert.Equal(3, TrajectoryMath.FindFirstMovingPoint(points));
+        }
+
+        [Fact]
+        public void FindFirstMoving_SpeedThreshold_ReturnsCorrectIndex()
+        {
+            // Runway: same altitude, picks up speed at index 2
+            var points = MakePoints((10, 0.3f), (10, 2f), (10, 6f), (10, 15f));
+            Assert.Equal(2, TrajectoryMath.FindFirstMovingPoint(points));
+        }
+
+        [Fact]
+        public void FindFirstMoving_NullOrShort_ReturnsZero()
+        {
+            Assert.Equal(0, TrajectoryMath.FindFirstMovingPoint(null));
+            Assert.Equal(0, TrajectoryMath.FindFirstMovingPoint(new List<TrajectoryPoint>()));
+            Assert.Equal(0, TrajectoryMath.FindFirstMovingPoint(MakePoints((78, 0.1f))));
         }
     }
 }

--- a/Source/Parsek.Tests/RecordingStoreTests.cs
+++ b/Source/Parsek.Tests/RecordingStoreTests.cs
@@ -978,5 +978,95 @@ namespace Parsek.Tests
 
             Assert.Equal(4, rec.RecordingFormatVersion);
         }
+
+        // --- Stationary point trimming tests ---
+
+        private List<TrajectoryPoint> MakePadLaunchPoints()
+        {
+            // 5 stationary points on pad (alt=78, speed=0.3), then 5 moving points
+            var points = new List<TrajectoryPoint>();
+            for (int i = 0; i < 5; i++)
+                points.Add(new TrajectoryPoint
+                {
+                    ut = 100 + i, altitude = 78, velocity = new Vector3(0.3f, 0, 0), bodyName = "Kerbin"
+                });
+            for (int i = 0; i < 5; i++)
+                points.Add(new TrajectoryPoint
+                {
+                    ut = 105 + i, altitude = 80 + i * 5, velocity = new Vector3(10 + i * 5, 0, 0), bodyName = "Kerbin"
+                });
+            return points;
+        }
+
+        [Fact]
+        public void StashPending_TrimsLeadingStationaryPoints()
+        {
+            var points = MakePadLaunchPoints();
+            RecordingStore.StashPending(points, "TrimTest");
+
+            Assert.True(RecordingStore.HasPending);
+            // First 5 stationary points should be trimmed
+            Assert.Equal(5, RecordingStore.Pending.Points.Count);
+            Assert.Equal(105.0, RecordingStore.Pending.StartUT);
+        }
+
+        [Fact]
+        public void StashPending_RetimesPartEventsFromTrimmedWindow()
+        {
+            var points = MakePadLaunchPoints();
+            var partEvents = new List<PartEvent>
+            {
+                new PartEvent { ut = 100, eventType = PartEventType.ShroudJettisoned, partPersistentId = 1 },
+                new PartEvent { ut = 101, eventType = PartEventType.EngineIgnited, partPersistentId = 2 },
+                new PartEvent { ut = 107, eventType = PartEventType.Decoupled, partPersistentId = 3 }
+            };
+
+            RecordingStore.StashPending(points, "RetimeTest", partEvents: partEvents);
+
+            Assert.True(RecordingStore.HasPending);
+            var events = RecordingStore.Pending.PartEvents;
+            Assert.Equal(3, events.Count);
+            // First two events should be retimed to the new start (105)
+            Assert.Equal(105.0, events[0].ut);
+            Assert.Equal(105.0, events[1].ut);
+            // Third event is after trim point, unchanged
+            Assert.Equal(107.0, events[2].ut);
+        }
+
+        [Fact]
+        public void StashPending_RemovesOrbitSegmentsBeforeTrim()
+        {
+            var points = MakePadLaunchPoints();
+            var orbitSegments = new List<OrbitSegment>
+            {
+                new OrbitSegment { startUT = 100, endUT = 103, bodyName = "Kerbin" },
+                new OrbitSegment { startUT = 106, endUT = 108, bodyName = "Kerbin" }
+            };
+
+            RecordingStore.StashPending(points, "OrbitTrimTest", orbitSegments: orbitSegments);
+
+            Assert.True(RecordingStore.HasPending);
+            // First segment ends at 103 < trimUT 105, should be removed
+            Assert.Single(RecordingStore.Pending.OrbitSegments);
+            Assert.Equal(106.0, RecordingStore.Pending.OrbitSegments[0].startUT);
+        }
+
+        [Fact]
+        public void StashPending_NoTrimWhenAlreadyMoving()
+        {
+            // All points are moving from the start
+            var points = new List<TrajectoryPoint>();
+            for (int i = 0; i < 5; i++)
+                points.Add(new TrajectoryPoint
+                {
+                    ut = 100 + i, altitude = 80 + i * 10, velocity = new Vector3(20, 0, 0), bodyName = "Kerbin"
+                });
+
+            RecordingStore.StashPending(points, "NoTrimTest");
+
+            Assert.True(RecordingStore.HasPending);
+            Assert.Equal(5, RecordingStore.Pending.Points.Count);
+            Assert.Equal(100.0, RecordingStore.Pending.StartUT);
+        }
     }
 }

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -3912,9 +3912,15 @@ namespace Parsek
                     isOnRails = false;
                 }
 
+                // Capture final trajectory point at destruction — the last adaptively-sampled
+                // point can be meters above/away from the actual impact location.
+                SamplePosition(v);
+
                 VesselDestroyedDuringRecording = true;
                 RefreshBackupSnapshot(v, "destroy_event", force: true);
-                ParsekLog.Warn("Recorder", "Active vessel destroyed during recording");
+                ParsekLog.Warn("Recorder",
+                    $"Active vessel destroyed during recording — captured final position at " +
+                    $"lat={v.latitude:F4} lon={v.longitude:F4} alt={v.altitude:F1}m");
             }
         }
 

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -163,6 +163,11 @@ namespace Parsek
         public bool SoiChangePending { get; private set; }
         public string SoiChangeFromBody { get; private set; }
 
+        // Deferred first sample: skip recording while the vessel is still stationary on
+        // the pad/runway so the ghost doesn't overlap the real vessel at the start.
+        private bool waitingForMovement;
+        private const float movementSpeedThreshold = 0.5f; // m/s
+
         #region Part Event Subscription
 
         private void SubscribePartEvents()
@@ -3224,6 +3229,13 @@ namespace Parsek
             lastRecordedUT = -1;
             lastRecordedVelocity = Vector3.zero;
 
+            // Defer first sample until the vessel is actually moving, so the ghost
+            // doesn't overlap the real vessel sitting on the pad/runway at playback start.
+            // Only for fresh launches — chain continuations and promotions start immediately.
+            waitingForMovement = !isPromotion && BoundaryAnchor == null
+                && (v.situation == Vessel.Situations.PRELAUNCH
+                    || v.situation == Vessel.Situations.LANDED);
+
             hasPersistentRotation = AssemblyLoader.loadedAssemblies.Any(
                 a => a.name == "PersistentRotation");
             ParsekLog.Info("Recorder", $"PersistentRotation mod detected: {hasPersistentRotation}");
@@ -3686,6 +3698,21 @@ namespace Parsek
 
             // Krakensbane-corrected true velocity
             Vector3 currentVelocity = (Vector3)(v.rb_velocityD + Krakensbane.GetFrameVelocity());
+
+            // Defer recording until the vessel has meaningful movement (avoids ghost
+            // overlapping the real vessel on the pad/runway at playback start)
+            if (waitingForMovement)
+            {
+                if (currentVelocity.magnitude < movementSpeedThreshold)
+                {
+                    ParsekLog.VerboseRateLimited("Recorder", "waiting-for-movement",
+                        $"Waiting for movement (speed={currentVelocity.magnitude:F2} m/s, threshold={movementSpeedThreshold} m/s)");
+                    return;
+                }
+                waitingForMovement = false;
+                ParsekLog.Info("Recorder",
+                    $"Vessel moving — recording first point (speed={currentVelocity.magnitude:F2} m/s)");
+            }
 
             if (!TrajectoryMath.ShouldRecordPoint(currentVelocity, lastRecordedVelocity,
                 Planetarium.GetUniversalTime(), lastRecordedUT,

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -3902,26 +3902,28 @@ namespace Parsek
                 ParsekLog.Verbose("Recorder", "OnVesselWillDestroy: no active vessel — skipping");
                 return;
             }
-            if (v == FlightGlobals.ActiveVessel)
+            if (v != FlightGlobals.ActiveVessel) return;
+            if (v.persistentId != RecordingVesselId) return;
+
+            // Finalize in-progress orbit segment if on rails
+            if (isOnRails)
             {
-                // Finalize in-progress orbit segment if on rails
-                if (isOnRails)
-                {
-                    currentOrbitSegment.endUT = Planetarium.GetUniversalTime();
-                    OrbitSegments.Add(currentOrbitSegment);
-                    isOnRails = false;
-                }
-
-                // Capture final trajectory point at destruction — the last adaptively-sampled
-                // point can be meters above/away from the actual impact location.
-                SamplePosition(v);
-
-                VesselDestroyedDuringRecording = true;
-                RefreshBackupSnapshot(v, "destroy_event", force: true);
-                ParsekLog.Warn("Recorder",
-                    $"Active vessel destroyed during recording — captured final position at " +
-                    $"lat={v.latitude:F4} lon={v.longitude:F4} alt={v.altitude:F1}m");
+                currentOrbitSegment.endUT = Planetarium.GetUniversalTime();
+                OrbitSegments.Add(currentOrbitSegment);
+                isOnRails = false;
             }
+
+            // Capture final trajectory point at destruction — the last adaptively-sampled
+            // point can be meters above/away from the actual impact location.
+            SamplePosition(v);
+
+            VesselDestroyedDuringRecording = true;
+            RefreshBackupSnapshot(v, "destroy_event", force: true);
+            ParsekLog.Warn("Recorder",
+                "Active vessel destroyed during recording — captured final position at " +
+                $"lat={v.latitude.ToString("F4", CultureInfo.InvariantCulture)} " +
+                $"lon={v.longitude.ToString("F4", CultureInfo.InvariantCulture)} " +
+                $"alt={v.altitude.ToString("F1", CultureInfo.InvariantCulture)}m");
         }
 
         /// <summary>

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -163,14 +163,6 @@ namespace Parsek
         public bool SoiChangePending { get; private set; }
         public string SoiChangeFromBody { get; private set; }
 
-        // Deferred first sample: skip recording while the vessel is still stationary on
-        // the pad/runway so the ghost doesn't overlap the real vessel at the start.
-        // Uses altitude change (immune to pad flex) with a speed fallback for runway rolls.
-        private bool waitingForMovement;
-        private double waitingForMovementAltitude;
-        private const double movementAltitudeThreshold = 1.0; // meters
-        private const float movementSpeedThreshold = 5.0f; // m/s (runway taxiing)
-
         #region Part Event Subscription
 
         private void SubscribePartEvents()
@@ -3232,14 +3224,6 @@ namespace Parsek
             lastRecordedUT = -1;
             lastRecordedVelocity = Vector3.zero;
 
-            // Defer first sample until the vessel has actually moved off the pad/runway,
-            // so the ghost doesn't overlap the real vessel at playback start.
-            // Only for fresh launches — chain continuations and promotions start immediately.
-            waitingForMovement = !isPromotion && BoundaryAnchor == null
-                && (v.situation == Vessel.Situations.PRELAUNCH
-                    || v.situation == Vessel.Situations.LANDED);
-            waitingForMovementAltitude = v.altitude;
-
             hasPersistentRotation = AssemblyLoader.loadedAssemblies.Any(
                 a => a.name == "PersistentRotation");
             ParsekLog.Info("Recorder", $"PersistentRotation mod detected: {hasPersistentRotation}");
@@ -3703,24 +3687,6 @@ namespace Parsek
             // Krakensbane-corrected true velocity
             Vector3 currentVelocity = (Vector3)(v.rb_velocityD + Krakensbane.GetFrameVelocity());
 
-            // Defer recording until the vessel has actually moved off the pad/runway.
-            // Altitude change catches vertical launches; speed catches runway rolls.
-            // Pad flex (rocket settling) produces ~0.5-2 m/s but <1m altitude change.
-            if (waitingForMovement)
-            {
-                double altDelta = System.Math.Abs(v.altitude - waitingForMovementAltitude);
-                float speed = currentVelocity.magnitude;
-                if (altDelta < movementAltitudeThreshold && speed < movementSpeedThreshold)
-                {
-                    ParsekLog.VerboseRateLimited("Recorder", "waiting-for-movement",
-                        $"Waiting for movement (altDelta={altDelta:F2}m, speed={speed:F2} m/s)");
-                    return;
-                }
-                waitingForMovement = false;
-                ParsekLog.Info("Recorder",
-                    $"Vessel moving — recording first point (altDelta={altDelta:F2}m, speed={speed:F2} m/s)");
-            }
-
             if (!TrajectoryMath.ShouldRecordPoint(currentVelocity, lastRecordedVelocity,
                 Planetarium.GetUniversalTime(), lastRecordedUT,
                 maxSampleInterval, velocityDirThreshold, speedChangeThreshold))
@@ -3801,14 +3767,6 @@ namespace Parsek
                 return;
             }
             if (v.persistentId != RecordingVesselId) return;
-
-            // Don't create orbit segments while waiting for the vessel to move off the pad.
-            // Time-warping on the pad produces nonsensical orbital data that puts the ghost underground.
-            if (waitingForMovement)
-            {
-                ParsekLog.Verbose("Recorder", "OnVesselGoOnRails: skipping — still waiting for movement");
-                return;
-            }
 
             // Record a boundary TrajectoryPoint at current UT (stitching point)
             SamplePosition(v);

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -165,8 +165,11 @@ namespace Parsek
 
         // Deferred first sample: skip recording while the vessel is still stationary on
         // the pad/runway so the ghost doesn't overlap the real vessel at the start.
+        // Uses altitude change (immune to pad flex) with a speed fallback for runway rolls.
         private bool waitingForMovement;
-        private const float movementSpeedThreshold = 0.5f; // m/s
+        private double waitingForMovementAltitude;
+        private const double movementAltitudeThreshold = 1.0; // meters
+        private const float movementSpeedThreshold = 5.0f; // m/s (runway taxiing)
 
         #region Part Event Subscription
 
@@ -3229,12 +3232,13 @@ namespace Parsek
             lastRecordedUT = -1;
             lastRecordedVelocity = Vector3.zero;
 
-            // Defer first sample until the vessel is actually moving, so the ghost
-            // doesn't overlap the real vessel sitting on the pad/runway at playback start.
+            // Defer first sample until the vessel has actually moved off the pad/runway,
+            // so the ghost doesn't overlap the real vessel at playback start.
             // Only for fresh launches — chain continuations and promotions start immediately.
             waitingForMovement = !isPromotion && BoundaryAnchor == null
                 && (v.situation == Vessel.Situations.PRELAUNCH
                     || v.situation == Vessel.Situations.LANDED);
+            waitingForMovementAltitude = v.altitude;
 
             hasPersistentRotation = AssemblyLoader.loadedAssemblies.Any(
                 a => a.name == "PersistentRotation");
@@ -3699,19 +3703,22 @@ namespace Parsek
             // Krakensbane-corrected true velocity
             Vector3 currentVelocity = (Vector3)(v.rb_velocityD + Krakensbane.GetFrameVelocity());
 
-            // Defer recording until the vessel has meaningful movement (avoids ghost
-            // overlapping the real vessel on the pad/runway at playback start)
+            // Defer recording until the vessel has actually moved off the pad/runway.
+            // Altitude change catches vertical launches; speed catches runway rolls.
+            // Pad flex (rocket settling) produces ~0.5-2 m/s but <1m altitude change.
             if (waitingForMovement)
             {
-                if (currentVelocity.magnitude < movementSpeedThreshold)
+                double altDelta = System.Math.Abs(v.altitude - waitingForMovementAltitude);
+                float speed = currentVelocity.magnitude;
+                if (altDelta < movementAltitudeThreshold && speed < movementSpeedThreshold)
                 {
                     ParsekLog.VerboseRateLimited("Recorder", "waiting-for-movement",
-                        $"Waiting for movement (speed={currentVelocity.magnitude:F2} m/s, threshold={movementSpeedThreshold} m/s)");
+                        $"Waiting for movement (altDelta={altDelta:F2}m, speed={speed:F2} m/s)");
                     return;
                 }
                 waitingForMovement = false;
                 ParsekLog.Info("Recorder",
-                    $"Vessel moving — recording first point (speed={currentVelocity.magnitude:F2} m/s)");
+                    $"Vessel moving — recording first point (altDelta={altDelta:F2}m, speed={speed:F2} m/s)");
             }
 
             if (!TrajectoryMath.ShouldRecordPoint(currentVelocity, lastRecordedVelocity,
@@ -3794,6 +3801,14 @@ namespace Parsek
                 return;
             }
             if (v.persistentId != RecordingVesselId) return;
+
+            // Don't create orbit segments while waiting for the vessel to move off the pad.
+            // Time-warping on the pad produces nonsensical orbital data that puts the ghost underground.
+            if (waitingForMovement)
+            {
+                ParsekLog.Verbose("Recorder", "OnVesselGoOnRails: skipping — still waiting for movement");
+                return;
+            }
 
             // Record a boundary TrajectoryPoint at current UT (stitching point)
             SamplePosition(v);

--- a/Source/Parsek/MergeDialog.cs
+++ b/Source/Parsek/MergeDialog.cs
@@ -20,6 +20,16 @@ namespace Parsek
             ParsekScenario.MergeDialogPending = false;
         }
 
+        /// <summary>
+        /// Called from button callbacks to replay KSP's flight results dialog
+        /// that was intercepted by the Harmony patch. Only replays if there's
+        /// a pending message (i.e., we intercepted a Display call).
+        /// </summary>
+        internal static void ReplayFlightResultsIfPending()
+        {
+            Patches.FlightResultsPatch.ReplayFlightResults();
+        }
+
         public static void Show(RecordingStore.Recording pending)
         {
             if (pending == null)
@@ -76,6 +86,9 @@ namespace Parsek
                             pending.VesselSnapshot = null;
                             RecordingStore.CommitPending();
                             ClearPendingFlag();
+                    ReplayFlightResultsIfPending();
+                        ReplayFlightResultsIfPending();
+                            ReplayFlightResultsIfPending();
                             ParsekLog.ScreenMessage("Recording merged to timeline!", 3f);
                             ParsekLog.Info("MergeDialog", "User chose: Merge to Timeline (vessel destroyed)");
                         }),
@@ -84,6 +97,9 @@ namespace Parsek
                             ParsekScenario.UnreserveCrewInSnapshot(pending.VesselSnapshot);
                             RecordingStore.DiscardPending();
                             ClearPendingFlag();
+                    ReplayFlightResultsIfPending();
+                        ReplayFlightResultsIfPending();
+                            ReplayFlightResultsIfPending();
                             ParsekLog.ScreenMessage("Recording discarded", 2f);
                             ParsekLog.Info("MergeDialog", "User chose: Discard");
                         })
@@ -101,6 +117,9 @@ namespace Parsek
                             ParsekScenario.ReserveSnapshotCrew();
                             ParsekScenario.SwapReservedCrewInFlight();
                             ClearPendingFlag();
+                    ReplayFlightResultsIfPending();
+                        ReplayFlightResultsIfPending();
+                            ReplayFlightResultsIfPending();
                             ParsekLog.ScreenMessage("Recording merged — vessel will appear after ghost playback", 3f);
                             ParsekLog.Info("MergeDialog", "User chose: Merge to Timeline (deferred spawn)");
                         }),
@@ -109,6 +128,9 @@ namespace Parsek
                             ParsekScenario.UnreserveCrewInSnapshot(pending.VesselSnapshot);
                             RecordingStore.DiscardPending();
                             ClearPendingFlag();
+                    ReplayFlightResultsIfPending();
+                        ReplayFlightResultsIfPending();
+                            ReplayFlightResultsIfPending();
                             ParsekLog.ScreenMessage("Recording discarded", 2f);
                             ParsekLog.Info("MergeDialog", "User chose: Discard");
                         })
@@ -160,6 +182,8 @@ namespace Parsek
                         ParsekScenario.ReserveSnapshotCrew();
                         ParsekScenario.SwapReservedCrewInFlight();
                         ClearPendingFlag();
+                    ReplayFlightResultsIfPending();
+                        ReplayFlightResultsIfPending();
                         ParsekLog.ScreenMessage($"Mission chain ({totalSegments} segments) merged — vessel will appear!", 3f);
                         ParsekLog.Info("MergeDialog", $"User chose: Chain Merge to Timeline ({totalSegments} segments)");
                     }),
@@ -167,6 +191,8 @@ namespace Parsek
                     {
                         DiscardChain(pending, chainId);
                         ClearPendingFlag();
+                    ReplayFlightResultsIfPending();
+                        ReplayFlightResultsIfPending();
                         ParsekLog.ScreenMessage($"Mission chain ({totalSegments} segments) discarded", 2f);
                         ParsekLog.Info("MergeDialog", $"User chose: Chain Discard ({totalSegments} segments)");
                     })
@@ -185,6 +211,8 @@ namespace Parsek
                         NullChainSiblingSnapshots(chainSiblings);
                         RecordingStore.CommitPending();
                         ClearPendingFlag();
+                    ReplayFlightResultsIfPending();
+                        ReplayFlightResultsIfPending();
                         ParsekLog.ScreenMessage($"Mission chain ({totalSegments} segments) merged!", 3f);
                         ParsekLog.Info("MergeDialog", $"User chose: Chain Merge to Timeline ({totalSegments} segments)");
                     }),
@@ -192,6 +220,8 @@ namespace Parsek
                     {
                         DiscardChain(pending, chainId);
                         ClearPendingFlag();
+                    ReplayFlightResultsIfPending();
+                        ReplayFlightResultsIfPending();
                         ParsekLog.ScreenMessage($"Mission chain ({totalSegments} segments) discarded", 2f);
                         ParsekLog.Info("MergeDialog", $"User chose: Chain Discard ({totalSegments} segments)");
                     })
@@ -393,6 +423,7 @@ namespace Parsek
                     ParsekScenario.ReserveSnapshotCrew();
                     ParsekScenario.SwapReservedCrewInFlight();
                     ClearPendingFlag();
+                    ReplayFlightResultsIfPending();
                     if (spawnCount > 0)
                         ParsekLog.ScreenMessage(
                             $"Tree merged \u2014 {spawnCount} vessel(s) will appear after ghost playback", 3f);
@@ -411,6 +442,7 @@ namespace Parsek
                     }
                     RecordingStore.DiscardPendingTree();
                     ClearPendingFlag();
+                    ReplayFlightResultsIfPending();
                     ParsekLog.ScreenMessage("Recording tree discarded", 2f);
                     ParsekLog.Info("MergeDialog",
                         $"User chose: Tree Discard (tree='{tree.TreeName}', " +

--- a/Source/Parsek/MergeDialog.cs
+++ b/Source/Parsek/MergeDialog.cs
@@ -11,13 +11,26 @@ namespace Parsek
     /// </summary>
     public static class MergeDialog
     {
+        private const string MergeLockId = "ParsekMergeDialog";
+
         /// <summary>
-        /// Clears the deferred merge dialog flag in ParsekScenario.
-        /// Called from every button callback so the flag doesn't block re-showing.
+        /// Clears the deferred merge dialog flag and removes the input lock.
+        /// Called from every button callback.
         /// </summary>
         internal static void ClearPendingFlag()
         {
             ParsekScenario.MergeDialogPending = false;
+            InputLockManager.RemoveControlLock(MergeLockId);
+        }
+
+        /// <summary>
+        /// Blocks all player interaction while the merge dialog is shown.
+        /// Prevents entering KSC buildings or other actions during the dialog.
+        /// </summary>
+        internal static void LockInput()
+        {
+            InputLockManager.SetControlLock(ControlTypes.All, MergeLockId);
+            ParsekLog.Verbose("MergeDialog", "Input lock set");
         }
 
         /// <summary>
@@ -145,6 +158,7 @@ namespace Parsek
 
             string message = BuildMergeMessage(pending, duration, recommended);
 
+            LockInput();
             PopupDialog.DismissPopup("ParsekMerge");
             PopupDialog.SpawnPopupDialog(
                 new Vector2(0.5f, 0.5f),
@@ -248,6 +262,7 @@ namespace Parsek
             else
                 message += "All segments will replay as ghosts.";
 
+            LockInput();
             PopupDialog.DismissPopup("ParsekMerge");
             PopupDialog.SpawnPopupDialog(
                 new Vector2(0.5f, 0.5f),
@@ -450,6 +465,7 @@ namespace Parsek
                 })
             };
 
+            LockInput();
             PopupDialog.DismissPopup("ParsekMerge");
             PopupDialog.SpawnPopupDialog(
                 new Vector2(0.5f, 0.5f),

--- a/Source/Parsek/MergeDialog.cs
+++ b/Source/Parsek/MergeDialog.cs
@@ -11,6 +11,15 @@ namespace Parsek
     /// </summary>
     public static class MergeDialog
     {
+        /// <summary>
+        /// Clears the deferred merge dialog flag in ParsekScenario.
+        /// Called from every button callback so the flag doesn't block re-showing.
+        /// </summary>
+        internal static void ClearPendingFlag()
+        {
+            ParsekScenario.MergeDialogPending = false;
+        }
+
         public static void Show(RecordingStore.Recording pending)
         {
             if (pending == null)
@@ -66,6 +75,7 @@ namespace Parsek
                                 ParsekScenario.UnreserveCrewInSnapshot(pending.VesselSnapshot);
                             pending.VesselSnapshot = null;
                             RecordingStore.CommitPending();
+                            ClearPendingFlag();
                             ParsekLog.ScreenMessage("Recording merged to timeline!", 3f);
                             ParsekLog.Info("MergeDialog", "User chose: Merge to Timeline (vessel destroyed)");
                         }),
@@ -73,6 +83,7 @@ namespace Parsek
                         {
                             ParsekScenario.UnreserveCrewInSnapshot(pending.VesselSnapshot);
                             RecordingStore.DiscardPending();
+                            ClearPendingFlag();
                             ParsekLog.ScreenMessage("Recording discarded", 2f);
                             ParsekLog.Info("MergeDialog", "User chose: Discard");
                         })
@@ -89,6 +100,7 @@ namespace Parsek
                             RecordingStore.CommitPending();
                             ParsekScenario.ReserveSnapshotCrew();
                             ParsekScenario.SwapReservedCrewInFlight();
+                            ClearPendingFlag();
                             ParsekLog.ScreenMessage("Recording merged — vessel will appear after ghost playback", 3f);
                             ParsekLog.Info("MergeDialog", "User chose: Merge to Timeline (deferred spawn)");
                         }),
@@ -96,6 +108,7 @@ namespace Parsek
                         {
                             ParsekScenario.UnreserveCrewInSnapshot(pending.VesselSnapshot);
                             RecordingStore.DiscardPending();
+                            ClearPendingFlag();
                             ParsekLog.ScreenMessage("Recording discarded", 2f);
                             ParsekLog.Info("MergeDialog", "User chose: Discard");
                         })
@@ -110,6 +123,7 @@ namespace Parsek
 
             string message = BuildMergeMessage(pending, duration, recommended);
 
+            PopupDialog.DismissPopup("ParsekMerge");
             PopupDialog.SpawnPopupDialog(
                 new Vector2(0.5f, 0.5f),
                 new Vector2(0.5f, 0.5f),
@@ -145,12 +159,14 @@ namespace Parsek
                         RecordingStore.CommitPending();
                         ParsekScenario.ReserveSnapshotCrew();
                         ParsekScenario.SwapReservedCrewInFlight();
+                        ClearPendingFlag();
                         ParsekLog.ScreenMessage($"Mission chain ({totalSegments} segments) merged — vessel will appear!", 3f);
                         ParsekLog.Info("MergeDialog", $"User chose: Chain Merge to Timeline ({totalSegments} segments)");
                     }),
                     new DialogGUIButton("Discard All", () =>
                     {
                         DiscardChain(pending, chainId);
+                        ClearPendingFlag();
                         ParsekLog.ScreenMessage($"Mission chain ({totalSegments} segments) discarded", 2f);
                         ParsekLog.Info("MergeDialog", $"User chose: Chain Discard ({totalSegments} segments)");
                     })
@@ -168,12 +184,14 @@ namespace Parsek
                         pending.VesselSnapshot = null;
                         NullChainSiblingSnapshots(chainSiblings);
                         RecordingStore.CommitPending();
+                        ClearPendingFlag();
                         ParsekLog.ScreenMessage($"Mission chain ({totalSegments} segments) merged!", 3f);
                         ParsekLog.Info("MergeDialog", $"User chose: Chain Merge to Timeline ({totalSegments} segments)");
                     }),
                     new DialogGUIButton("Discard All", () =>
                     {
                         DiscardChain(pending, chainId);
+                        ClearPendingFlag();
                         ParsekLog.ScreenMessage($"Mission chain ({totalSegments} segments) discarded", 2f);
                         ParsekLog.Info("MergeDialog", $"User chose: Chain Discard ({totalSegments} segments)");
                     })
@@ -200,6 +218,7 @@ namespace Parsek
             else
                 message += "All segments will replay as ghosts.";
 
+            PopupDialog.DismissPopup("ParsekMerge");
             PopupDialog.SpawnPopupDialog(
                 new Vector2(0.5f, 0.5f),
                 new Vector2(0.5f, 0.5f),
@@ -373,6 +392,7 @@ namespace Parsek
                     RecordingStore.CommitPendingTree();
                     ParsekScenario.ReserveSnapshotCrew();
                     ParsekScenario.SwapReservedCrewInFlight();
+                    ClearPendingFlag();
                     if (spawnCount > 0)
                         ParsekLog.ScreenMessage(
                             $"Tree merged \u2014 {spawnCount} vessel(s) will appear after ghost playback", 3f);
@@ -390,6 +410,7 @@ namespace Parsek
                             ParsekScenario.UnreserveCrewInSnapshot(rec.VesselSnapshot);
                     }
                     RecordingStore.DiscardPendingTree();
+                    ClearPendingFlag();
                     ParsekLog.ScreenMessage("Recording tree discarded", 2f);
                     ParsekLog.Info("MergeDialog",
                         $"User chose: Tree Discard (tree='{tree.TreeName}', " +
@@ -397,6 +418,7 @@ namespace Parsek
                 })
             };
 
+            PopupDialog.DismissPopup("ParsekMerge");
             PopupDialog.SpawnPopupDialog(
                 new Vector2(0.5f, 0.5f),
                 new Vector2(0.5f, 0.5f),

--- a/Source/Parsek/MergeDialog.cs
+++ b/Source/Parsek/MergeDialog.cs
@@ -99,8 +99,6 @@ namespace Parsek
                             pending.VesselSnapshot = null;
                             RecordingStore.CommitPending();
                             ClearPendingFlag();
-                    ReplayFlightResultsIfPending();
-                        ReplayFlightResultsIfPending();
                             ReplayFlightResultsIfPending();
                             ParsekLog.ScreenMessage("Recording merged to timeline!", 3f);
                             ParsekLog.Info("MergeDialog", "User chose: Merge to Timeline (vessel destroyed)");
@@ -110,8 +108,6 @@ namespace Parsek
                             ParsekScenario.UnreserveCrewInSnapshot(pending.VesselSnapshot);
                             RecordingStore.DiscardPending();
                             ClearPendingFlag();
-                    ReplayFlightResultsIfPending();
-                        ReplayFlightResultsIfPending();
                             ReplayFlightResultsIfPending();
                             ParsekLog.ScreenMessage("Recording discarded", 2f);
                             ParsekLog.Info("MergeDialog", "User chose: Discard");
@@ -130,8 +126,6 @@ namespace Parsek
                             ParsekScenario.ReserveSnapshotCrew();
                             ParsekScenario.SwapReservedCrewInFlight();
                             ClearPendingFlag();
-                    ReplayFlightResultsIfPending();
-                        ReplayFlightResultsIfPending();
                             ReplayFlightResultsIfPending();
                             ParsekLog.ScreenMessage("Recording merged — vessel will appear after ghost playback", 3f);
                             ParsekLog.Info("MergeDialog", "User chose: Merge to Timeline (deferred spawn)");
@@ -141,8 +135,6 @@ namespace Parsek
                             ParsekScenario.UnreserveCrewInSnapshot(pending.VesselSnapshot);
                             RecordingStore.DiscardPending();
                             ClearPendingFlag();
-                    ReplayFlightResultsIfPending();
-                        ReplayFlightResultsIfPending();
                             ReplayFlightResultsIfPending();
                             ParsekLog.ScreenMessage("Recording discarded", 2f);
                             ParsekLog.Info("MergeDialog", "User chose: Discard");
@@ -196,7 +188,6 @@ namespace Parsek
                         ParsekScenario.ReserveSnapshotCrew();
                         ParsekScenario.SwapReservedCrewInFlight();
                         ClearPendingFlag();
-                    ReplayFlightResultsIfPending();
                         ReplayFlightResultsIfPending();
                         ParsekLog.ScreenMessage($"Mission chain ({totalSegments} segments) merged — vessel will appear!", 3f);
                         ParsekLog.Info("MergeDialog", $"User chose: Chain Merge to Timeline ({totalSegments} segments)");
@@ -205,7 +196,6 @@ namespace Parsek
                     {
                         DiscardChain(pending, chainId);
                         ClearPendingFlag();
-                    ReplayFlightResultsIfPending();
                         ReplayFlightResultsIfPending();
                         ParsekLog.ScreenMessage($"Mission chain ({totalSegments} segments) discarded", 2f);
                         ParsekLog.Info("MergeDialog", $"User chose: Chain Discard ({totalSegments} segments)");
@@ -225,7 +215,6 @@ namespace Parsek
                         NullChainSiblingSnapshots(chainSiblings);
                         RecordingStore.CommitPending();
                         ClearPendingFlag();
-                    ReplayFlightResultsIfPending();
                         ReplayFlightResultsIfPending();
                         ParsekLog.ScreenMessage($"Mission chain ({totalSegments} segments) merged!", 3f);
                         ParsekLog.Info("MergeDialog", $"User chose: Chain Merge to Timeline ({totalSegments} segments)");
@@ -234,7 +223,6 @@ namespace Parsek
                     {
                         DiscardChain(pending, chainId);
                         ClearPendingFlag();
-                    ReplayFlightResultsIfPending();
                         ReplayFlightResultsIfPending();
                         ParsekLog.ScreenMessage($"Mission chain ({totalSegments} segments) discarded", 2f);
                         ParsekLog.Info("MergeDialog", $"User chose: Chain Discard ({totalSegments} segments)");

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -1021,7 +1021,7 @@ namespace Parsek
                     // Revert: preserve snapshots for merge dialog
                     CommitTreeRevert(commitUT);
                 }
-                else if (ParsekSettings.Current?.autoMerge == false)
+                else if (!ParsekScenario.IsAutoMerge)
                 {
                     // autoMerge OFF: safe finalization but preserve snapshots for dialog in KSC/TS.
                     // Uses isSceneExit: true (no live vessel re-snapshots during teardown)
@@ -2041,7 +2041,7 @@ namespace Parsek
                         RecordingStore.DiscardPending();
                         return;
                     }
-                    if (ParsekSettings.Current?.autoMerge != false)
+                    if (ParsekScenario.IsAutoMerge)
                     {
                         RecordingStore.CommitPending();
                         ParsekLog.Info("Flight",
@@ -7996,7 +7996,7 @@ namespace Parsek
         /// </summary>
         void CommitOrShowDialog(RecordingStore.Recording pending)
         {
-            if (ParsekSettings.Current?.autoMerge != false)
+            if (ParsekScenario.IsAutoMerge)
             {
                 RecordingStore.CommitPending();
                 Log($"Auto-merged recording from {pending.VesselName} ({pending.Points.Count} points)");

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -1321,16 +1321,16 @@ namespace Parsek
             recorder = null;
             lastPlaybackIndex = 0;
 
-            // Auto-discard very short destroyed recordings (pad failures, immediate explosions).
-            // Threshold is 5s after stationary trimming — trimming can remove 1-3s from the
-            // start, so a 10s raw flight might be 7-8s after trimming.
+            // Auto-discard pad failures: destroyed within 10s AND never moved far from spawn.
+            // Real crashes (even short ones) travel 50+ meters; pad failures stay near the pad.
             if (RecordingStore.HasPending)
             {
                 double flightDuration = RecordingStore.Pending.EndUT - RecordingStore.Pending.StartUT;
-                if (flightDuration < 5.0)
+                double maxDist = RecordingStore.Pending.MaxDistanceFromLaunch;
+                if (flightDuration < 10.0 && maxDist < 30.0)
                 {
-                    Log($"Post-destruction: recording too short ({flightDuration:F1}s) — auto-discarding");
-                    ScreenMessage("Recording discarded — too short", 3f);
+                    Log($"Post-destruction: pad failure ({flightDuration:F1}s, {maxDist:F0}m) — auto-discarding");
+                    ScreenMessage("Recording discarded — pad failure", 3f);
                     RecordingStore.DiscardPending();
                     yield break;
                 }
@@ -2025,14 +2025,15 @@ namespace Parsek
                     }
                 }
 
-                // Destroyed vessels: discard if too short, otherwise show merge dialog
+                // Destroyed vessels: discard pad failures, otherwise show merge dialog
                 if (RecordingStore.Pending.VesselDestroyed)
                 {
                     double dur = RecordingStore.Pending.EndUT - RecordingStore.Pending.StartUT;
-                    if (dur < 5.0)
+                    double maxDist = RecordingStore.Pending.MaxDistanceFromLaunch;
+                    if (dur < 10.0 && maxDist < 30.0)
                     {
                         ParsekLog.Info("Flight",
-                            $"Vessel destroyed during split — recording too short ({dur:F1}s), discarding");
+                            $"Vessel destroyed during split — pad failure ({dur:F1}s, {maxDist:F0}m), discarding");
                         RecordingStore.DiscardPending();
                         return;
                     }

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -1328,8 +1328,8 @@ namespace Parsek
             // Show merge dialog
             if (RecordingStore.HasPending)
             {
-                Log("Post-destruction: showing merge dialog");
-                MergeDialog.Show(RecordingStore.Pending);
+                Log("Post-destruction: commit or dialog");
+                CommitOrShowDialog(RecordingStore.Pending);
             }
         }
 
@@ -2014,7 +2014,7 @@ namespace Parsek
                     }
                 }
 
-                // Auto-discard short destroyed recordings (pad failures, immediate explosions)
+                // Destroyed vessels: discard if too short, otherwise show merge dialog
                 if (RecordingStore.Pending.VesselDestroyed)
                 {
                     double dur = RecordingStore.Pending.EndUT - RecordingStore.Pending.StartUT;
@@ -2025,6 +2025,10 @@ namespace Parsek
                         RecordingStore.DiscardPending();
                         return;
                     }
+                    ParsekLog.Info("Flight",
+                        $"Vessel destroyed during split — commit or dialog ({dur:F1}s)");
+                    CommitOrShowDialog(RecordingStore.Pending);
+                    return;
                 }
 
                 RecordingStore.CommitPending();
@@ -3339,7 +3343,7 @@ namespace Parsek
                 {
                     // Chain-level merge dialog (covers all segments)
                     Log($"Found pending chain recording (chain={pending.ChainId}, idx={pending.ChainIndex})");
-                    MergeDialog.Show(pending);
+                    CommitOrShowDialog(pending);
                 }
                 else if (!string.IsNullOrEmpty(pending.ParentRecordingId))
                 {
@@ -3361,14 +3365,14 @@ namespace Parsek
                     }
                     else
                     {
-                        Log($"EVA child recording has no matching parent — showing merge dialog");
-                        MergeDialog.Show(pending);
+                        Log($"EVA child recording has no matching parent — commit or dialog");
+                        CommitOrShowDialog(pending);
                     }
                 }
                 else
                 {
                     Log($"Found pending recording from {pending.VesselName} ({pending.Points.Count} points)");
-                    MergeDialog.Show(pending);
+                    CommitOrShowDialog(pending);
                 }
             }
 
@@ -7959,6 +7963,23 @@ namespace Parsek
             if (FlightGlobals.ActiveVessel == null)
                 return "no active vessel";
             return "unknown guard in FlightRecorder.StartRecording";
+        }
+
+        /// <summary>
+        /// Commits or shows merge dialog for the pending recording, depending on the autoMerge setting.
+        /// </summary>
+        void CommitOrShowDialog(RecordingStore.Recording pending)
+        {
+            if (ParsekSettings.Current?.autoMerge != false)
+            {
+                RecordingStore.CommitPending();
+                Log($"Auto-merged recording from {pending.VesselName} ({pending.Points.Count} points)");
+            }
+            else
+            {
+                Log($"Showing merge dialog for {pending.VesselName} ({pending.Points.Count} points)");
+                MergeDialog.Show(pending);
+            }
         }
 
         void Log(string message) => ParsekLog.Verbose("Flight", message);

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -2025,7 +2025,8 @@ namespace Parsek
                     }
                 }
 
-                // Destroyed vessels: discard pad failures, otherwise show merge dialog
+                // Destroyed vessels: discard pad failures, otherwise commit or defer to dialog.
+                // Dialog is deferred via coroutine so it appears AFTER KSP's crash report.
                 if (RecordingStore.Pending.VesselDestroyed)
                 {
                     double dur = RecordingStore.Pending.EndUT - RecordingStore.Pending.StartUT;
@@ -2037,9 +2038,19 @@ namespace Parsek
                         RecordingStore.DiscardPending();
                         return;
                     }
-                    ParsekLog.Info("Flight",
-                        $"Vessel destroyed during split — commit or dialog ({dur:F1}s)");
-                    CommitOrShowDialog(RecordingStore.Pending);
+                    if (ParsekSettings.Current?.autoMerge != false)
+                    {
+                        RecordingStore.CommitPending();
+                        ParsekLog.Info("Flight",
+                            $"Vessel destroyed during split — auto-merged ({dur:F1}s)");
+                    }
+                    else
+                    {
+                        // Defer dialog — pending stays stashed, coroutine shows it after 2s
+                        ParsekLog.Info("Flight",
+                            $"Vessel destroyed during split — deferring dialog ({dur:F1}s)");
+                        StartCoroutine(ShowDeferredSplitMergeDialog());
+                    }
                     return;
                 }
 
@@ -7992,6 +8003,21 @@ namespace Parsek
                 Log($"Showing merge dialog for {pending.VesselName} ({pending.Points.Count} points)");
                 MergeDialog.Show(pending);
             }
+        }
+
+        /// <summary>
+        /// Deferred merge dialog for destroyed vessels in the split path.
+        /// Waits 2 seconds so the dialog appears after KSP's crash report.
+        /// </summary>
+        IEnumerator ShowDeferredSplitMergeDialog()
+        {
+            yield return new WaitForSeconds(2f);
+
+            if (!RecordingStore.HasPending)
+                yield break;
+
+            Log($"Showing deferred split merge dialog for {RecordingStore.Pending.VesselName}");
+            MergeDialog.Show(RecordingStore.Pending);
         }
 
         void Log(string message) => ParsekLog.Verbose("Flight", message);

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -1311,14 +1311,15 @@ namespace Parsek
             recorder = null;
             lastPlaybackIndex = 0;
 
-            // Auto-discard pad failures: destroyed within seconds of first movement
+            // Auto-discard short destroyed recordings (pad failures, immediate explosions).
+            // After stationary trimming, real flights are typically 10s+.
             if (RecordingStore.HasPending)
             {
                 double flightDuration = RecordingStore.Pending.EndUT - RecordingStore.Pending.StartUT;
-                if (flightDuration < 5.0)
+                if (flightDuration < 10.0)
                 {
-                    Log($"Post-destruction: recording too short ({flightDuration:F1}s) — auto-discarding pad failure");
-                    ScreenMessage("Recording discarded — pad failure", 3f);
+                    Log($"Post-destruction: recording too short ({flightDuration:F1}s) — auto-discarding");
+                    ScreenMessage("Recording discarded — too short", 3f);
                     RecordingStore.DiscardPending();
                     yield break;
                 }
@@ -2012,6 +2013,20 @@ namespace Parsek
                         }
                     }
                 }
+
+                // Auto-discard short destroyed recordings (pad failures, immediate explosions)
+                if (RecordingStore.Pending.VesselDestroyed)
+                {
+                    double dur = RecordingStore.Pending.EndUT - RecordingStore.Pending.StartUT;
+                    if (dur < 10.0)
+                    {
+                        ParsekLog.Info("Flight",
+                            $"Vessel destroyed during split — recording too short ({dur:F1}s), discarding");
+                        RecordingStore.DiscardPending();
+                        return;
+                    }
+                }
+
                 RecordingStore.CommitPending();
                 string chainInfo = activeChainId != null
                     ? $" (chain={activeChainId}, idx={activeChainNextIndex})"

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -1321,12 +1321,13 @@ namespace Parsek
             recorder = null;
             lastPlaybackIndex = 0;
 
-            // Auto-discard short destroyed recordings (pad failures, immediate explosions).
-            // After stationary trimming, real flights are typically 10s+.
+            // Auto-discard very short destroyed recordings (pad failures, immediate explosions).
+            // Threshold is 5s after stationary trimming — trimming can remove 1-3s from the
+            // start, so a 10s raw flight might be 7-8s after trimming.
             if (RecordingStore.HasPending)
             {
                 double flightDuration = RecordingStore.Pending.EndUT - RecordingStore.Pending.StartUT;
-                if (flightDuration < 10.0)
+                if (flightDuration < 5.0)
                 {
                     Log($"Post-destruction: recording too short ({flightDuration:F1}s) — auto-discarding");
                     ScreenMessage("Recording discarded — too short", 3f);
@@ -2028,7 +2029,7 @@ namespace Parsek
                 if (RecordingStore.Pending.VesselDestroyed)
                 {
                     double dur = RecordingStore.Pending.EndUT - RecordingStore.Pending.StartUT;
-                    if (dur < 10.0)
+                    if (dur < 5.0)
                     {
                         ParsekLog.Info("Flight",
                             $"Vessel destroyed during split — recording too short ({dur:F1}s), discarding");

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -1255,7 +1255,10 @@ namespace Parsek
         /// </summary>
         IEnumerator ShowPostDestructionMergeDialog()
         {
-            yield return new WaitForSeconds(2f);
+            // Wait one frame to let the destruction sequence complete.
+            // The Harmony patch on FlightResultsDialog.Display suppresses KSP's
+            // crash report until the merge dialog is resolved — no hardcoded delay needed.
+            yield return null;
 
             // Guard: only proceed if recorder still exists and vessel was destroyed
             if (recorder == null || !recorder.VesselDestroyedDuringRecording)
@@ -8007,11 +8010,12 @@ namespace Parsek
 
         /// <summary>
         /// Deferred merge dialog for destroyed vessels in the split path.
-        /// Waits 2 seconds so the dialog appears after KSP's crash report.
+        /// Waits one frame to let the destruction sequence complete. The Harmony
+        /// patch on FlightResultsDialog.Display handles ordering with KSP's report.
         /// </summary>
         IEnumerator ShowDeferredSplitMergeDialog()
         {
-            yield return new WaitForSeconds(2f);
+            yield return null;
 
             if (!RecordingStore.HasPending)
                 yield break;

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -8018,7 +8018,10 @@ namespace Parsek
             yield return null;
 
             if (!RecordingStore.HasPending)
+            {
+                Log("Deferred split merge dialog: pending consumed during wait — aborting");
                 yield break;
+            }
 
             Log($"Showing deferred split merge dialog for {RecordingStore.Pending.VesselName}");
             MergeDialog.Show(RecordingStore.Pending);

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -1322,7 +1322,7 @@ namespace Parsek
             lastPlaybackIndex = 0;
 
             // Auto-discard pad failures: destroyed within 10s AND never moved far from spawn.
-            // Real crashes (even short ones) travel 50+ meters; pad failures stay near the pad.
+            // Real crashes travel 30+ meters; pad failures stay near the pad.
             if (RecordingStore.HasPending)
             {
                 double flightDuration = RecordingStore.Pending.EndUT - RecordingStore.Pending.StartUT;

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -1310,6 +1310,19 @@ namespace Parsek
             recorder = null;
             lastPlaybackIndex = 0;
 
+            // Auto-discard pad failures: destroyed within seconds of first movement
+            if (RecordingStore.HasPending)
+            {
+                double flightDuration = RecordingStore.Pending.EndUT - RecordingStore.Pending.StartUT;
+                if (flightDuration < 5.0)
+                {
+                    Log($"Post-destruction: recording too short ({flightDuration:F1}s) — auto-discarding pad failure");
+                    ScreenMessage("Recording discarded — pad failure", 3f);
+                    RecordingStore.DiscardPending();
+                    yield break;
+                }
+            }
+
             // Show merge dialog
             if (RecordingStore.HasPending)
             {

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -1021,6 +1021,16 @@ namespace Parsek
                     // Revert: preserve snapshots for merge dialog
                     CommitTreeRevert(commitUT);
                 }
+                else if (ParsekSettings.Current?.autoMerge == false)
+                {
+                    // autoMerge OFF: safe finalization but preserve snapshots for dialog in KSC/TS.
+                    // Uses isSceneExit: true (no live vessel re-snapshots during teardown)
+                    // but skips snapshot nulling so the dialog can offer vessel spawning.
+                    FinalizeTreeRecordings(activeTree, commitUT, isSceneExit: true);
+                    RecordingStore.StashPendingTree(activeTree);
+                    ParsekLog.Info("Flight",
+                        $"CommitTreeSceneExit (autoMerge off): stashed tree '{activeTree.TreeName}' with snapshots preserved");
+                }
                 else
                 {
                     // Scene exit: null snapshots (ghost-only, no spawning outside Flight)

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -555,9 +555,11 @@ namespace Parsek
                 }
 
                 // Handle pending recordings on non-revert scene exits to non-flight scenes.
+                // Always auto-commit on main menu (game is being unloaded, dialog would be meaningless).
+                bool forceAutoMerge = HighLogic.LoadedScene == GameScenes.MAINMENU;
                 if (!isRevert && HighLogic.LoadedScene != GameScenes.FLIGHT)
                 {
-                    if (IsAutoMerge)
+                    if (IsAutoMerge || forceAutoMerge)
                     {
                         // autoMerge ON: auto-commit ghost-only (existing behavior)
                         if (RecordingStore.HasPending)
@@ -813,10 +815,11 @@ namespace Parsek
             }
 
             // Handle pending recordings outside Flight (Esc > Abort Mission → Space Center path).
+            // Always auto-commit on main menu (game is being unloaded).
             if (HighLogic.LoadedScene != GameScenes.FLIGHT &&
                 (RecordingStore.HasPending || RecordingStore.HasPendingTree))
             {
-                if (IsAutoMerge)
+                if (IsAutoMerge || HighLogic.LoadedScene == GameScenes.MAINMENU)
                 {
                     // autoMerge ON: auto-commit ghost-only
                     if (RecordingStore.HasPending)

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -38,6 +38,27 @@ namespace Parsek
 
         public override void OnSave(ConfigNode node)
         {
+            // Safety net (defense-in-depth): if a pending recording still exists outside Flight
+            // and the dialog is not actively pending, auto-commit ghost-only before serialization.
+            // Under normal operation this is unreachable — Sites A/B handle all paths.
+            if (HighLogic.LoadedScene != GameScenes.FLIGHT && !mergeDialogPending)
+            {
+                if (RecordingStore.HasPending)
+                {
+                    AutoCommitGhostOnly(RecordingStore.Pending);
+                    RecordingStore.CommitPending();
+                    ParsekLog.Warn("Scenario",
+                        "Safety net: committed pending recording on save outside Flight");
+                }
+                if (RecordingStore.HasPendingTree)
+                {
+                    AutoCommitTreeGhostOnly(RecordingStore.PendingTree);
+                    RecordingStore.CommitPendingTree();
+                    ParsekLog.Warn("Scenario",
+                        "Safety net: committed pending tree on save outside Flight");
+                }
+            }
+
             // Diagnostic: detect if HighLogic.SaveFolder changed since this scenario loaded.
             // Under normal KSP flow OnSave fires before the folder changes, but if it doesn't,
             // file writes (SaveRecordingFiles, GameStateStore, MilestoneStore) would target
@@ -171,12 +192,25 @@ namespace Parsek
         private static string lastSaveFolder = null;
         private static uint budgetDeductionEpoch = 0;
 
+        // Deferred merge dialog: when autoMerge is off, the dialog follows the player
+        // across scenes until they address it. Reset on each OnLoad so scene changes
+        // get a fresh chance to show the dialog.
+        private static bool mergeDialogPending = false;
+        internal static bool MergeDialogPending
+        {
+            get => mergeDialogPending;
+            set => mergeDialogPending = value;
+        }
+
         // Tracks which save folder this scenario instance was loaded for.
         // Used to detect OnSave firing after HighLogic.SaveFolder has changed.
         private string scenarioSaveFolder;
 
         public override void OnLoad(ConfigNode node)
         {
+            // Reset deferred dialog flag so each scene gets a fresh chance
+            mergeDialogPending = false;
+
             var recordings = RecordingStore.CommittedRecordings;
 
             // Detect loading a different save game (not a revert)
@@ -497,22 +531,30 @@ namespace Parsek
                     ParsekLog.Verbose("Scenario", "Scene change — milestone state restored (resetUnmatched=false)");
                 }
 
-                // Auto-commit pending recordings on non-revert scene exits to non-flight scenes.
-                // This replaces the old approach of deferring pending recordings to the next
-                // OnFlightReady, which confused players with stale merge dialogs at next launch.
+                // Handle pending recordings on non-revert scene exits to non-flight scenes.
                 if (!isRevert && HighLogic.LoadedScene != GameScenes.FLIGHT)
                 {
-                    if (RecordingStore.HasPending)
+                    if (ParsekSettings.Current?.autoMerge != false)
                     {
-                        AutoCommitGhostOnly(RecordingStore.Pending);
-                        RecordingStore.CommitPending();
-                        ScreenMessages.PostScreenMessage("[Parsek] Recording committed to timeline", 5f);
+                        // autoMerge ON: auto-commit ghost-only (existing behavior)
+                        if (RecordingStore.HasPending)
+                        {
+                            AutoCommitGhostOnly(RecordingStore.Pending);
+                            RecordingStore.CommitPending();
+                            ScreenMessages.PostScreenMessage("[Parsek] Recording committed to timeline", 5f);
+                        }
+                        if (RecordingStore.HasPendingTree)
+                        {
+                            AutoCommitTreeGhostOnly(RecordingStore.PendingTree);
+                            RecordingStore.CommitPendingTree();
+                            ScreenMessages.PostScreenMessage("[Parsek] Tree recording committed to timeline", 5f);
+                        }
                     }
-                    if (RecordingStore.HasPendingTree)
+                    else if ((RecordingStore.HasPending || RecordingStore.HasPendingTree) && !mergeDialogPending)
                     {
-                        AutoCommitTreeGhostOnly(RecordingStore.PendingTree);
-                        RecordingStore.CommitPendingTree();
-                        ScreenMessages.PostScreenMessage("[Parsek] Tree recording committed to timeline", 5f);
+                        // autoMerge OFF: defer to merge dialog in the new scene
+                        mergeDialogPending = true;
+                        StartCoroutine(ShowDeferredMergeDialog());
                     }
                 }
 
@@ -747,36 +789,108 @@ namespace Parsek
                 }
             }
 
-            // If pending recording exists but we're not in Flight, auto-commit it.
-            // Merge dialog can only show in Flight (ParsekFlight is Flight-only).
-            // This handles Esc > Abort Mission → Space Center path.
-            if (RecordingStore.HasPending && HighLogic.LoadedScene != GameScenes.FLIGHT)
+            // Handle pending recordings outside Flight (Esc > Abort Mission → Space Center path).
+            if (HighLogic.LoadedScene != GameScenes.FLIGHT &&
+                (RecordingStore.HasPending || RecordingStore.HasPendingTree))
             {
-                var pending = RecordingStore.Pending;
-                if (pending.VesselSnapshot != null)
-                    UnreserveCrewInSnapshot(pending.VesselSnapshot);
-                pending.VesselSnapshot = null;
-                RecordingStore.CommitPending();
-                ScenarioLog($"[Parsek Scenario] Auto-committed pending recording outside Flight " +
-                    $"(scene: {HighLogic.LoadedScene})");
-            }
-
-            // If pending tree exists but we're not in Flight, auto-commit ghost-only.
-            if (RecordingStore.HasPendingTree && HighLogic.LoadedScene != GameScenes.FLIGHT)
-            {
-                var pt = RecordingStore.PendingTree;
-                // Null all vessel snapshots (ghost-only commit — no spawning outside Flight)
-                foreach (var rec in pt.Recordings.Values)
+                if (ParsekSettings.Current?.autoMerge != false)
                 {
-                    if (rec.VesselSnapshot != null)
-                        UnreserveCrewInSnapshot(rec.VesselSnapshot);
-                    rec.VesselSnapshot = null;
+                    // autoMerge ON: auto-commit ghost-only
+                    if (RecordingStore.HasPending)
+                    {
+                        var pending = RecordingStore.Pending;
+                        if (pending.VesselSnapshot != null)
+                            UnreserveCrewInSnapshot(pending.VesselSnapshot);
+                        pending.VesselSnapshot = null;
+                        RecordingStore.CommitPending();
+                        ScenarioLog($"[Parsek Scenario] Auto-committed pending recording outside Flight " +
+                            $"(scene: {HighLogic.LoadedScene})");
+                    }
+                    if (RecordingStore.HasPendingTree)
+                    {
+                        var pt = RecordingStore.PendingTree;
+                        foreach (var rec in pt.Recordings.Values)
+                        {
+                            if (rec.VesselSnapshot != null)
+                                UnreserveCrewInSnapshot(rec.VesselSnapshot);
+                            rec.VesselSnapshot = null;
+                        }
+                        RecordingStore.CommitPendingTree();
+                        ScenarioLog($"[Parsek Scenario] Auto-committed pending tree outside Flight " +
+                            $"(scene: {HighLogic.LoadedScene})");
+                    }
                 }
-                RecordingStore.CommitPendingTree();
-                ScenarioLog($"[Parsek Scenario] Auto-committed pending tree outside Flight " +
-                    $"(scene: {HighLogic.LoadedScene})");
+                else if (!mergeDialogPending)
+                {
+                    // autoMerge OFF: defer to merge dialog
+                    mergeDialogPending = true;
+                    StartCoroutine(ShowDeferredMergeDialog());
+                }
             }
         }
+
+        #region Deferred Merge Dialog
+
+        /// <summary>
+        /// Shows the merge dialog after a short delay, allowing the scene to fully load.
+        /// Used when autoMerge is off and the player leaves Flight with a pending recording.
+        /// </summary>
+        private IEnumerator ShowDeferredMergeDialog()
+        {
+            // Wait ~60 frames for scene to fully load (UI skin, singletons, etc.)
+            int waitFrames = 60;
+            while (waitFrames-- > 0)
+                yield return null;
+
+            // Guard: pending may have been consumed during the wait
+            if (!RecordingStore.HasPending && !RecordingStore.HasPendingTree)
+            {
+                mergeDialogPending = false;
+                ParsekLog.Verbose("Scenario", "Deferred merge dialog: pending consumed during wait — aborting");
+                yield break;
+            }
+
+            // EVA child recordings with a matching parent: auto-commit silently
+            // (matches ParsekFlight.OnFlightReady behavior)
+            if (RecordingStore.HasPending && !string.IsNullOrEmpty(RecordingStore.Pending.ParentRecordingId))
+            {
+                bool parentFound = false;
+                foreach (var rec in RecordingStore.CommittedRecordings)
+                {
+                    if (rec.RecordingId == RecordingStore.Pending.ParentRecordingId)
+                    {
+                        parentFound = true;
+                        break;
+                    }
+                }
+                if (parentFound)
+                {
+                    ParsekLog.Info("Scenario",
+                        $"Deferred merge: auto-committing EVA child recording (parent={RecordingStore.Pending.ParentRecordingId})");
+                    RecordingStore.CommitPending();
+                    mergeDialogPending = false;
+                    yield break;
+                }
+            }
+
+            // Show the appropriate dialog
+            if (RecordingStore.HasPendingTree)
+            {
+                ParsekLog.Info("Scenario",
+                    $"Showing deferred tree merge dialog in {HighLogic.LoadedScene}");
+                MergeDialog.ShowTreeDialog(RecordingStore.PendingTree);
+            }
+            else if (RecordingStore.HasPending)
+            {
+                ParsekLog.Info("Scenario",
+                    $"Showing deferred merge dialog in {HighLogic.LoadedScene}");
+                MergeDialog.Show(RecordingStore.Pending);
+            }
+            // mergeDialogPending stays true until the user clicks a button
+            // (ClearPendingFlag is called from the button callbacks)
+        }
+
+        #endregion
 
         #region Budget Deduction
 

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -192,6 +192,11 @@ namespace Parsek
         private static string lastSaveFolder = null;
         private static uint budgetDeductionEpoch = 0;
 
+        // Cached autoMerge setting — ParsekSettings.Current can be null during early
+        // scene loads (OnLoad fires before GameParameters are available). This is set
+        // from ParsekSettings.Current whenever it's accessible, and used as fallback.
+        private static bool cachedAutoMerge = true;
+
         // Deferred merge dialog: when autoMerge is off, the dialog follows the player
         // across scenes until they address it. Reset on each OnLoad so scene changes
         // get a fresh chance to show the dialog.
@@ -200,6 +205,24 @@ namespace Parsek
         {
             get => mergeDialogPending;
             set => mergeDialogPending = value;
+        }
+
+        /// <summary>
+        /// Reads the autoMerge setting reliably. ParsekSettings.Current can be null
+        /// during early scene loads — falls back to the cached value in that case.
+        /// </summary>
+        internal static bool IsAutoMerge
+        {
+            get
+            {
+                var settings = ParsekSettings.Current;
+                if (settings != null)
+                {
+                    cachedAutoMerge = settings.autoMerge;
+                    return settings.autoMerge;
+                }
+                return cachedAutoMerge;
+            }
         }
 
         // Tracks which save folder this scenario instance was loaded for.
@@ -534,7 +557,7 @@ namespace Parsek
                 // Handle pending recordings on non-revert scene exits to non-flight scenes.
                 if (!isRevert && HighLogic.LoadedScene != GameScenes.FLIGHT)
                 {
-                    if (ParsekSettings.Current?.autoMerge != false)
+                    if (IsAutoMerge)
                     {
                         // autoMerge ON: auto-commit ghost-only (existing behavior)
                         if (RecordingStore.HasPending)
@@ -793,7 +816,7 @@ namespace Parsek
             if (HighLogic.LoadedScene != GameScenes.FLIGHT &&
                 (RecordingStore.HasPending || RecordingStore.HasPendingTree))
             {
-                if (ParsekSettings.Current?.autoMerge != false)
+                if (IsAutoMerge)
                 {
                     // autoMerge ON: auto-commit ghost-only
                     if (RecordingStore.HasPending)

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -195,7 +195,7 @@ namespace Parsek
         // Cached autoMerge setting — ParsekSettings.Current can be null during early
         // scene loads (OnLoad fires before GameParameters are available). This is set
         // from ParsekSettings.Current whenever it's accessible, and used as fallback.
-        private static bool cachedAutoMerge = true;
+        private static bool cachedAutoMerge = false;
 
         // Deferred merge dialog: when autoMerge is off, the dialog follows the player
         // across scenes until they address it. Reset on each OnLoad so scene changes

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -231,8 +231,10 @@ namespace Parsek
 
         public override void OnLoad(ConfigNode node)
         {
-            // Reset deferred dialog flag so each scene gets a fresh chance
+            // Reset deferred dialog flag and clear input lock (dialog may have been
+            // destroyed by scene change without the user clicking a button)
             mergeDialogPending = false;
+            InputLockManager.RemoveControlLock("ParsekMergeDialog");
 
             var recordings = RecordingStore.CommittedRecordings;
 

--- a/Source/Parsek/ParsekSettings.cs
+++ b/Source/Parsek/ParsekSettings.cs
@@ -29,6 +29,10 @@ namespace Parsek
             toolTip = "Automatically split recordings when entering a new sphere of influence")]
         public bool autoSplitAtSoi = true;
 
+        [GameParameters.CustomParameterUI("Auto-merge recordings",
+            toolTip = "When enabled, recordings are committed to the timeline automatically. When disabled, a confirmation dialog appears after each recording.")]
+        public bool autoMerge = true;
+
         [GameParameters.CustomParameterUI("Verbose logging",
             toolTip = "When enabled, write detailed diagnostics to KSP.log (default for development)")]
         public bool verboseLogging = true;

--- a/Source/Parsek/ParsekSettings.cs
+++ b/Source/Parsek/ParsekSettings.cs
@@ -17,8 +17,8 @@ namespace Parsek
             toolTip = "Automatically start recording when a kerbal goes EVA from the pad")]
         public bool autoRecordOnEva = true;
 
-        [GameParameters.CustomParameterUI("Auto-stop time warp",
-            toolTip = "Stop time warp when a ghost playback is about to begin")]
+        [GameParameters.CustomParameterUI("Stop time warp for ghost playback",
+            toolTip = "Automatically exit time warp when a ghost recording is about to start playing")]
         public bool autoWarpStop = true;
 
         [GameParameters.CustomParameterUI("Auto-split at atmosphere boundary",

--- a/Source/Parsek/ParsekSettings.cs
+++ b/Source/Parsek/ParsekSettings.cs
@@ -31,7 +31,7 @@ namespace Parsek
 
         [GameParameters.CustomParameterUI("Auto-merge recordings",
             toolTip = "When enabled, recordings are committed to the timeline automatically. When disabled, a confirmation dialog appears after each recording.")]
-        public bool autoMerge = true;
+        public bool autoMerge = false;
 
         [GameParameters.CustomParameterUI("Verbose logging",
             toolTip = "When enabled, write detailed diagnostics to KSP.log (default for development)")]

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -1747,42 +1747,48 @@ namespace Parsek
             }
 
             GUILayout.Label("Recording", GUI.skin.box);
-            bool autoRecordOnLaunch = GUILayout.Toggle(s.autoRecordOnLaunch, "Auto-record on launch");
+            bool autoRecordOnLaunch = GUILayout.Toggle(s.autoRecordOnLaunch,
+                new GUIContent("Auto-record on launch", "Start recording when a vessel leaves the pad or runway"));
             if (autoRecordOnLaunch != s.autoRecordOnLaunch)
             {
                 s.autoRecordOnLaunch = autoRecordOnLaunch;
                 ParsekLog.Info("UI", $"Setting changed: autoRecordOnLaunch={s.autoRecordOnLaunch}");
             }
 
-            bool autoRecordOnEva = GUILayout.Toggle(s.autoRecordOnEva, "Auto-record on EVA");
+            bool autoRecordOnEva = GUILayout.Toggle(s.autoRecordOnEva,
+                new GUIContent("Auto-record on EVA", "Start recording when a kerbal goes EVA from the pad"));
             if (autoRecordOnEva != s.autoRecordOnEva)
             {
                 s.autoRecordOnEva = autoRecordOnEva;
                 ParsekLog.Info("UI", $"Setting changed: autoRecordOnEva={s.autoRecordOnEva}");
             }
 
-            bool autoMerge = GUILayout.Toggle(s.autoMerge, "Auto-merge recordings");
+            bool autoMerge = GUILayout.Toggle(s.autoMerge,
+                new GUIContent("Auto-merge recordings", "When off, a confirmation dialog appears after each recording"));
             if (autoMerge != s.autoMerge)
             {
                 s.autoMerge = autoMerge;
                 ParsekLog.Info("UI", $"Setting changed: autoMerge={s.autoMerge}");
             }
 
-            bool autoWarpStop = GUILayout.Toggle(s.autoWarpStop, "Stop time warp for ghost playback");
+            bool autoWarpStop = GUILayout.Toggle(s.autoWarpStop,
+                new GUIContent("Stop time warp for ghost playback", "Exit time warp when a ghost recording is about to start playing"));
             if (autoWarpStop != s.autoWarpStop)
             {
                 s.autoWarpStop = autoWarpStop;
                 ParsekLog.Info("UI", $"Setting changed: autoWarpStop={s.autoWarpStop}");
             }
 
-            bool autoSplitAtAtmosphere = GUILayout.Toggle(s.autoSplitAtAtmosphere, "Auto-split at atmosphere boundary");
+            bool autoSplitAtAtmosphere = GUILayout.Toggle(s.autoSplitAtAtmosphere,
+                new GUIContent("Auto-split at atmosphere boundary", "Split recordings when crossing the atmosphere boundary"));
             if (autoSplitAtAtmosphere != s.autoSplitAtAtmosphere)
             {
                 s.autoSplitAtAtmosphere = autoSplitAtAtmosphere;
                 ParsekLog.Info("UI", $"Setting changed: autoSplitAtAtmosphere={s.autoSplitAtAtmosphere}");
             }
 
-            bool autoSplitAtSoi = GUILayout.Toggle(s.autoSplitAtSoi, "Auto-split at SOI change");
+            bool autoSplitAtSoi = GUILayout.Toggle(s.autoSplitAtSoi,
+                new GUIContent("Auto-split at SOI change", "Split recordings when entering a new sphere of influence"));
             if (autoSplitAtSoi != s.autoSplitAtSoi)
             {
                 s.autoSplitAtSoi = autoSplitAtSoi;
@@ -1885,6 +1891,13 @@ namespace Parsek
                 ParsekLog.Verbose("UI", "Settings window closed via button");
             }
             GUILayout.EndHorizontal();
+
+            // Render tooltip at bottom of window when hovering a control with GUIContent tooltip
+            if (!string.IsNullOrEmpty(GUI.tooltip))
+            {
+                GUILayout.Space(SpacingSmall);
+                GUILayout.Label(GUI.tooltip, GUI.skin.box);
+            }
 
             GUI.DragWindow();
         }

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -1875,7 +1875,7 @@ namespace Parsek
                 ParsekLog.Verbose("UI", "Settings Defaults button clicked");
                 s.autoRecordOnLaunch = true;
                 s.autoRecordOnEva = true;
-                s.autoMerge = true;
+                s.autoMerge = false;
                 s.autoWarpStop = true;
                 s.autoSplitAtAtmosphere = true;
                 s.autoSplitAtSoi = true;

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -1768,7 +1768,7 @@ namespace Parsek
                 ParsekLog.Info("UI", $"Setting changed: autoMerge={s.autoMerge}");
             }
 
-            bool autoWarpStop = GUILayout.Toggle(s.autoWarpStop, "Auto-stop time warp");
+            bool autoWarpStop = GUILayout.Toggle(s.autoWarpStop, "Stop time warp for ghost playback");
             if (autoWarpStop != s.autoWarpStop)
             {
                 s.autoWarpStop = autoWarpStop;

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -1761,6 +1761,13 @@ namespace Parsek
                 ParsekLog.Info("UI", $"Setting changed: autoRecordOnEva={s.autoRecordOnEva}");
             }
 
+            bool autoMerge = GUILayout.Toggle(s.autoMerge, "Auto-merge recordings");
+            if (autoMerge != s.autoMerge)
+            {
+                s.autoMerge = autoMerge;
+                ParsekLog.Info("UI", $"Setting changed: autoMerge={s.autoMerge}");
+            }
+
             bool autoWarpStop = GUILayout.Toggle(s.autoWarpStop, "Auto-stop time warp");
             if (autoWarpStop != s.autoWarpStop)
             {
@@ -1862,6 +1869,7 @@ namespace Parsek
                 ParsekLog.Verbose("UI", "Settings Defaults button clicked");
                 s.autoRecordOnLaunch = true;
                 s.autoRecordOnEva = true;
+                s.autoMerge = true;
                 s.autoWarpStop = true;
                 s.autoSplitAtAtmosphere = true;
                 s.autoSplitAtSoi = true;

--- a/Source/Parsek/Patches/FlightResultsPatch.cs
+++ b/Source/Parsek/Patches/FlightResultsPatch.cs
@@ -33,7 +33,7 @@ namespace Parsek.Patches
             }
 
             // Only intercept when autoMerge is off
-            if (ParsekSettings.Current?.autoMerge != false)
+            if (ParsekScenario.IsAutoMerge)
                 return true;
 
             // Only intercept when there's a pending recording or the recorder has pending data

--- a/Source/Parsek/Patches/FlightResultsPatch.cs
+++ b/Source/Parsek/Patches/FlightResultsPatch.cs
@@ -1,0 +1,83 @@
+using HarmonyLib;
+using KSP.UI.Dialogs;
+
+namespace Parsek.Patches
+{
+    /// <summary>
+    /// Harmony prefix on FlightResultsDialog.Display to intercept the crash/mission
+    /// report dialog. When autoMerge is off and a recording was just captured, shows
+    /// the Parsek merge dialog first, then lets the KSP dialog through after the user
+    /// makes a choice.
+    /// </summary>
+    [HarmonyPatch(typeof(FlightResultsDialog), nameof(FlightResultsDialog.Display))]
+    internal static class FlightResultsPatch
+    {
+        /// <summary>
+        /// When set, the next Display call is a replay after our merge dialog — let it through.
+        /// </summary>
+        internal static bool Bypass;
+
+        /// <summary>
+        /// Stored outcome message from the suppressed Display call, replayed after merge dialog.
+        /// </summary>
+        internal static string PendingOutcomeMsg;
+
+        static bool Prefix(string outcomeMsg)
+        {
+            // Bypass flag: this is our replay call after the merge dialog — let KSP show its report
+            if (Bypass)
+            {
+                Bypass = false;
+                ParsekLog.Verbose("FlightResultsPatch", "Bypass active — letting FlightResultsDialog.Display through");
+                return true;
+            }
+
+            // Only intercept when autoMerge is off
+            if (ParsekSettings.Current?.autoMerge != false)
+                return true;
+
+            // Only intercept when there's a pending recording or the recorder has pending data
+            if (!RecordingStore.HasPending && !HasActiveDestroyedRecording())
+                return true;
+
+            // Store the outcome message for later replay
+            PendingOutcomeMsg = outcomeMsg;
+            ParsekLog.Info("FlightResultsPatch",
+                $"Intercepted FlightResultsDialog.Display — deferring until merge dialog completes (msg=\"{outcomeMsg}\")");
+
+            // Suppress KSP's dialog — our merge dialog flow will handle showing it later
+            return false;
+        }
+
+        /// <summary>
+        /// Re-shows KSP's flight results dialog with the stored outcome message.
+        /// Called from MergeDialog button callbacks after the user makes a choice.
+        /// </summary>
+        internal static void ReplayFlightResults()
+        {
+            if (string.IsNullOrEmpty(PendingOutcomeMsg))
+            {
+                ParsekLog.Verbose("FlightResultsPatch", "ReplayFlightResults: no pending message — skipping");
+                return;
+            }
+
+            string msg = PendingOutcomeMsg;
+            PendingOutcomeMsg = null;
+            Bypass = true;
+            ParsekLog.Info("FlightResultsPatch", $"Replaying FlightResultsDialog.Display (msg=\"{msg}\")");
+            FlightResultsDialog.Display(msg);
+        }
+
+        /// <summary>
+        /// Checks if the active recorder has a destroyed vessel recording in progress
+        /// that hasn't been stashed yet (the split/coroutine path will stash it shortly).
+        /// </summary>
+        static bool HasActiveDestroyedRecording()
+        {
+            var recorder = PhysicsFramePatch.ActiveRecorder;
+            if (recorder != null && recorder.VesselDestroyedDuringRecording)
+                return true;
+            return false;
+        }
+    }
+}

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -288,9 +288,21 @@ namespace Parsek
                 // Remove orbit segments that end before the new start
                 if (orbitSegments != null)
                     orbitSegments.RemoveAll(s => s.endUT <= trimUT);
-                // Remove part events that occur before the new start
+                // Retime part events from the trimmed window to the new start so their
+                // visual effects (shroud jettison, engine ignition, etc.) are applied
+                // at the beginning of playback rather than being lost.
                 if (partEvents != null)
-                    partEvents.RemoveAll(e => e.ut < trimUT);
+                {
+                    for (int i = 0; i < partEvents.Count; i++)
+                    {
+                        if (partEvents[i].ut < trimUT)
+                        {
+                            var e = partEvents[i];
+                            e.ut = trimUT;
+                            partEvents[i] = e;
+                        }
+                    }
+                }
             }
 
             pendingRecording = new Recording

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -270,6 +270,29 @@ namespace Parsek
                 return;
             }
 
+            // Trim leading stationary points (vessel sitting on pad/runway before launch).
+            // This prevents the ghost from overlapping the real vessel at the start position.
+            // Also trims any orbit segments and part events that fall before the new start.
+            int firstMoving = TrajectoryMath.FindFirstMovingPoint(points);
+            if (firstMoving > 0)
+            {
+                double trimUT = points[firstMoving].ut;
+                Log($"[Parsek] Trimmed {firstMoving} leading stationary points for '{vesselName}' " +
+                    $"(alt delta < 1m, speed < 5 m/s, new startUT={trimUT:F1})");
+                points = points.GetRange(firstMoving, points.Count - firstMoving);
+                if (points.Count < 2)
+                {
+                    Log($"[Parsek] Recording too short after trimming for '{vesselName}' ({points.Count} points) — discarded");
+                    return;
+                }
+                // Remove orbit segments that end before the new start
+                if (orbitSegments != null)
+                    orbitSegments.RemoveAll(s => s.endUT <= trimUT);
+                // Remove part events that occur before the new start
+                if (partEvents != null)
+                    partEvents.RemoveAll(e => e.ut < trimUT);
+            }
+
             pendingRecording = new Recording
             {
                 RecordingId = string.IsNullOrEmpty(recordingId) ? Guid.NewGuid().ToString("N") : recordingId,

--- a/Source/Parsek/TrajectoryMath.cs
+++ b/Source/Parsek/TrajectoryMath.cs
@@ -58,6 +58,28 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Returns the index of the first point where the vessel has meaningfully moved
+        /// from its initial position (altitude changed by >= altThreshold meters, or speed
+        /// exceeds speedThreshold m/s). Returns 0 if the vessel is moving from the start
+        /// or the list is too short.
+        /// </summary>
+        internal static int FindFirstMovingPoint(List<TrajectoryPoint> points,
+            double altThreshold = 1.0, float speedThreshold = 5.0f)
+        {
+            if (points == null || points.Count < 2) return 0;
+            double startAlt = points[0].altitude;
+            for (int i = 0; i < points.Count; i++)
+            {
+                if (System.Math.Abs(points[i].altitude - startAlt) >= altThreshold)
+                    return i;
+                if (points[i].velocity.magnitude >= speedThreshold)
+                    return i;
+            }
+            // Vessel never moved significantly — keep all points
+            return 0;
+        }
+
+        /// <summary>
         /// Find an orbit segment that covers the given UT. Returns null if none match.
         /// Linear scan — the list is tiny (typically 0-3 segments per recording).
         /// </summary>

--- a/docs/dev/known-bugs.md
+++ b/docs/dev/known-bugs.md
@@ -191,3 +191,13 @@ During ghost visual builds, some parts log `Variant active-state fallback: no ac
 **Reproduction:** `dotnet test` (full suite) — fails ~50% of runs. `dotnet test --filter GetCommittedTechIds_MultipleMilestones` — always passes.
 
 **Status:** Open — needs investigation of shared state cleanup between tests
+
+## 26. EVA crew swap fails after merging from KSC
+
+When `autoMerge` is off and an EVA recording is merged via the dialog in KSC (not Flight), the crew reservation (Valentina → Agasel) is created correctly, but on revert `SwapReservedCrewInFlight` finds 0 matches on the active vessel. The reserved crew member (Valentina) is not in the active vessel's part crew list after revert, causing a duplicate kerbal on spawn.
+
+**Reproduction:** Career mode → disable auto-merge → EVA Valentina from pad → walk around → go to KSC → merge dialog appears → click Merge → revert to launch → ghost shows different kerbal walking, but Valentina also spawns at the end = 2 Valentinas.
+
+**Root cause:** The rewind quicksave is captured at recording start. For EVA recordings, Valentina is already outside the vessel at that point (on EVA). On revert, the quicksave loads with Valentina on EVA (not in a pod), so `SwapReservedCrewInFlight` iterates `ActiveVessel.parts` crew and finds no match. The swap logic only checks the active vessel's part crew, not EVA kerbals.
+
+**Status:** Open — pre-existing issue in crew reservation system, not caused by the autoMerge/cross-scene dialog changes

--- a/docs/dev/known-bugs.md
+++ b/docs/dev/known-bugs.md
@@ -201,3 +201,13 @@ When `autoMerge` is off and an EVA recording is merged via the dialog in KSC (no
 **Root cause:** The rewind quicksave is captured at recording start. For EVA recordings, Valentina is already outside the vessel at that point (on EVA). On revert, the quicksave loads with Valentina on EVA (not in a pod), so `SwapReservedCrewInFlight` iterates `ActiveVessel.parts` crew and finds no match. The swap logic only checks the active vessel's part crew, not EVA kerbals.
 
 **Status:** Open — pre-existing issue in crew reservation system, not caused by the autoMerge/cross-scene dialog changes
+
+## 27. F9 quickload can silently overwrite a pending recording
+
+If the player has an unresolved pending recording (merge dialog not yet shown/clicked) AND an active recording in progress, pressing F9 quickload causes `OnSceneChangeRequested` to stash the active recording as a new pending — overwriting the old pending silently. The old recording's data and crew reservations are lost.
+
+**Reproduction:** Requires both an active recording and an unresolved pending simultaneously — very rare in practice. Could theoretically happen if: record flight A → go to KSC (pending A) → launch new vessel → record flight B → F9 quickload (pending A overwritten by pending B).
+
+**Root cause:** `RecordingStore.StashPending` overwrites the existing `pendingRecording` static field without checking if one already exists. No warning logged.
+
+**Status:** Open — pre-existing, very unlikely edge case

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -168,6 +168,9 @@ Current status: experimental button exists in UI, not recommended for normal pla
 ### Planetarium.right drift compensation for long orbital segments
 KSP's inertial reference frame (`Planetarium.right`) may drift over very long time warp durations. This could cause ghost orientation mismatch for interplanetary transfer segments. Needs empirical measurement first — if drift is sub-degree for typical segment lengths, no fix needed. If significant, store `Planetarium.right` snapshot at recording time and apply correction at playback (~10 lines + 3 ConfigNode keys). See `docs/dev/done/design-orbital-rotation.md` Phase 6.
 
+### Crash-safe pending recording recovery
+If the game crashes or the player alt-F4s while a merge dialog is pending, the recording data is lost from memory. The sidecar files (`.prec`, `_vessel.craft`, `_ghost.craft`) already exist on disk, but the metadata entry in `.sfs` referencing them is missing. Solution: write a `pending_manifest.cfg` file to `Parsek/Recordings/` when a recording is stashed. On next game load, if the manifest exists but the recording ID isn't in committed recordings, auto-recover it. Delete the manifest on commit or discard.
+
 ### Additional part event coverage
 - Control surface deflection (continuous float - thousands of events per flight, unclear visual value)
 - Robotics / Breaking Ground DLC (continuous servo motion, DLC-dependent)


### PR DESCRIPTION
## Summary

### Final position capture
- Force-sample a trajectory point in `OnVesselWillDestroy` so the recording ends at the actual impact point, not meters above it
- Added `RecordingVesselId` guard and InvariantCulture log formatting

### Pad/runway trimming
- `FindFirstMovingPoint` in `TrajectoryMath` trims leading stationary points at commit time (altitude change <1m AND speed <5 m/s)
- Prevents ghost from overlapping the real vessel on the pad during playback
- Orbit segments before the trim point are removed; part events are retimed to the new start (preserves shroud jettison, engine ignition, etc.)

### Short destroyed recording discard
- Destroyed recordings shorter than 10 seconds (after trimming) are auto-discarded in both the coroutine and split paths
- Prevents useless pad-failure recordings from cluttering the timeline

### Auto-merge setting
- New `autoMerge` toggle in settings (default: on)
- When on: recordings auto-commit as before
- When off: confirmation dialog appears for every recording, including crashes

### Cross-scene merge dialog
- When `autoMerge` is off, pending recordings follow the player across scenes (KSC, Tracking Station, Editor) instead of being auto-committed
- `ParsekScenario` shows a deferred merge dialog via coroutine after ~1s in any non-Flight scene
- EVA child recordings with matching parents are auto-committed silently
- `PopupDialog.DismissPopup` guard prevents double-dialogs on rapid scene changes
- Defense-in-depth safety net in `OnSave` for edge cases
- Tree snapshots preserved on scene exit when `autoMerge` is off

## Test plan
- [x] **Final position:** Crash a rocket, verify ghost ends at impact point
- [x] **Pad trimming:** Wait on pad before launching, verify ghost starts when vessel moves
- [x] **Part events:** Verify engine shrouds are off on the ghost after trimming
- [x] **Pad failure:** Rocket falls apart on pad — "Recording discarded" message, no commit
- [x] **Normal crash (>10s):** Recording auto-commits (autoMerge on) or dialog appears (autoMerge off)
- [x] **autoMerge OFF — Flight:** Dialog appears after revert
- [x] **autoMerge OFF — KSC:** Record flight, go to KSC — dialog appears
- [x] **autoMerge OFF — TS:** Record flight, go to Tracking Station — dialog appears
- [x] **autoMerge OFF — scene hop:** Ignore dialog in KSC, go to TS — dialog reappears
- [x] **autoMerge ON:** All existing behavior unchanged