### PR TITLE
Fix save contamination: recordings leaking across save games

### DIFF
--- a/Source/Parsek.Tests/SaveContaminationTests.cs
+++ b/Source/Parsek.Tests/SaveContaminationTests.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    [Collection("Sequential")]
+    public class SaveContaminationTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public SaveContaminationTests()
+        {
+            RecordingStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+            MilestoneStore.SuppressLogging = true;
+            MilestoneStore.ResetForTesting();
+            GameStateStore.SuppressLogging = true;
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+            RecordingStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+            MilestoneStore.ResetForTesting();
+        }
+
+        // --- IsSaveFolderMismatch tests ---
+
+        [Fact]
+        public void IsSaveFolderMismatch_DifferentFolders_ReturnsTrue()
+        {
+            Assert.True(ParsekScenario.IsSaveFolderMismatch("saveA", "saveB"));
+        }
+
+        [Fact]
+        public void IsSaveFolderMismatch_SameFolders_ReturnsFalse()
+        {
+            Assert.False(ParsekScenario.IsSaveFolderMismatch("saveA", "saveA"));
+        }
+
+        [Fact]
+        public void IsSaveFolderMismatch_NullScenarioFolder_ReturnsFalse()
+        {
+            Assert.False(ParsekScenario.IsSaveFolderMismatch(null, "saveB"));
+        }
+
+        [Fact]
+        public void IsSaveFolderMismatch_EmptyScenarioFolder_ReturnsFalse()
+        {
+            Assert.False(ParsekScenario.IsSaveFolderMismatch("", "saveB"));
+        }
+
+        [Fact]
+        public void IsSaveFolderMismatch_BothNull_ReturnsFalse()
+        {
+            Assert.False(ParsekScenario.IsSaveFolderMismatch(null, null));
+        }
+
+        // --- CommittedTrees contamination scenario ---
+
+        [Fact]
+        public void CommittedTrees_SurvivesRecordingsClear_DemonstratesBugScenario()
+        {
+            // Simulate save A: commit a tree (adds to both CommittedTrees and CommittedRecordings)
+            var tree = MakeSimpleTree("tree_saveA");
+            RecordingStore.CommitTree(tree);
+
+            Assert.Single(RecordingStore.CommittedTrees);
+            Assert.Single(RecordingStore.CommittedRecordings);
+
+            // Simulate initial load of save B: only CommittedRecordings.Clear() runs.
+            // This is what the old code did when save B had no trees.
+            RecordingStore.CommittedRecordings.Clear();
+
+            // Bug: CommittedTrees still has save A's tree
+            Assert.Single(RecordingStore.CommittedTrees);
+            Assert.Equal("tree_saveA", RecordingStore.CommittedTrees[0].Id);
+        }
+
+        [Fact]
+        public void CommittedTrees_ExplicitClear_RemovesStaleTreesRegardlessOfNewTreeCount()
+        {
+            // Simulate save A: commit a tree
+            var tree = MakeSimpleTree("tree_saveA");
+            RecordingStore.CommitTree(tree);
+            Assert.Single(RecordingStore.CommittedTrees);
+
+            // Simulate the fix: always clear both lists on initial load
+            RecordingStore.CommittedRecordings.Clear();
+            RecordingStore.CommittedTrees.Clear();
+
+            // Now save B has no trees — both lists are empty
+            Assert.Empty(RecordingStore.CommittedTrees);
+            Assert.Empty(RecordingStore.CommittedRecordings);
+        }
+
+        [Fact]
+        public void DiscardPendingTree_ClearsStalePendingTree()
+        {
+            var tree = MakeSimpleTree("pending_tree");
+            RecordingStore.StashPendingTree(tree);
+            Assert.True(RecordingStore.HasPendingTree);
+
+            RecordingStore.SuppressLogging = false;
+            RecordingStore.DiscardPendingTree();
+
+            Assert.False(RecordingStore.HasPendingTree);
+        }
+
+        [Fact]
+        public void DiscardPending_ClearsStalePendingRecording()
+        {
+            var points = new List<TrajectoryPoint>
+            {
+                new TrajectoryPoint { ut = 100 },
+                new TrajectoryPoint { ut = 200 }
+            };
+            RecordingStore.StashPending(points, "StalePending");
+            Assert.True(RecordingStore.HasPending);
+
+            RecordingStore.DiscardPending();
+
+            Assert.False(RecordingStore.HasPending);
+        }
+
+        // --- Helpers ---
+
+        private RecordingTree MakeSimpleTree(string treeId)
+        {
+            var tree = new RecordingTree
+            {
+                Id = treeId,
+                TreeName = "Test Tree",
+                RootRecordingId = "root",
+                ActiveRecordingId = "root"
+            };
+
+            tree.Recordings["root"] = new RecordingStore.Recording
+            {
+                RecordingId = "root",
+                TreeId = treeId,
+                VesselName = "Root Vessel",
+                VesselPersistentId = 1000
+            };
+
+            return tree;
+        }
+    }
+}

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -38,6 +38,18 @@ namespace Parsek
 
         public override void OnSave(ConfigNode node)
         {
+            // Diagnostic: detect if HighLogic.SaveFolder changed since this scenario loaded.
+            // Under normal KSP flow OnSave fires before the folder changes, but if it doesn't,
+            // file writes (SaveRecordingFiles, GameStateStore, MilestoneStore) would target
+            // the wrong save directory.
+            string currentSaveFolder = HighLogic.SaveFolder;
+            if (IsSaveFolderMismatch(scenarioSaveFolder, currentSaveFolder))
+            {
+                ParsekLog.Warn("Scenario",
+                    $"OnSave: save folder mismatch — loaded for '{scenarioSaveFolder}' " +
+                    $"but current is '{currentSaveFolder}'. Data may write to wrong save directory.");
+            }
+
             // Clear any existing recording nodes
             node.RemoveNodes("RECORDING");
 
@@ -159,12 +171,17 @@ namespace Parsek
         private static string lastSaveFolder = null;
         private static uint budgetDeductionEpoch = 0;
 
+        // Tracks which save folder this scenario instance was loaded for.
+        // Used to detect OnSave firing after HighLogic.SaveFolder has changed.
+        private string scenarioSaveFolder;
+
         public override void OnLoad(ConfigNode node)
         {
             var recordings = RecordingStore.CommittedRecordings;
 
             // Detect loading a different save game (not a revert)
             string currentSave = HighLogic.SaveFolder;
+            scenarioSaveFolder = currentSave;
             if (currentSave != lastSaveFolder)
             {
                 initialLoadDone = false;
@@ -505,6 +522,32 @@ namespace Parsek
             }
 
             initialLoadDone = true;
+
+            // Clear any pending state leaked from a previous save.
+            // Static fields survive scene changes, so pending recordings/trees
+            // from save A would otherwise be auto-committed into save B's timeline.
+            if (RecordingStore.HasPending)
+            {
+                ParsekLog.Warn("Scenario",
+                    $"OnLoad initial: discarding pending recording " +
+                    $"'{RecordingStore.Pending.VesselName}' from previous save");
+                RecordingStore.DiscardPending();
+            }
+            if (RecordingStore.HasPendingTree)
+            {
+                ParsekLog.Warn("Scenario",
+                    "OnLoad initial: discarding pending tree from previous save");
+                RecordingStore.DiscardPendingTree();
+            }
+            if (RecordingStore.IsRewinding)
+            {
+                ParsekLog.Warn("Scenario",
+                    "OnLoad initial: clearing stale rewind flags from previous save");
+                RecordingStore.IsRewinding = false;
+                RecordingStore.RewindUT = 0;
+                RecordingStore.RewindAdjustedUT = 0;
+            }
+
             recordings.Clear();
 
             ConfigNode[] recNodes = node.GetNodes("RECORDING");
@@ -615,14 +658,17 @@ namespace Parsek
             // Validate chain integrity before any playback
             RecordingStore.ValidateChains();
 
-            // Load committed recording trees
+            // Load committed recording trees.
+            // Always clear CommittedTrees — if the new save has no trees, stale trees
+            // from the previous save would otherwise persist and contaminate this save.
             ConfigNode[] treeNodes = node.GetNodes("RECORDING_TREE");
+            var committedTrees = RecordingStore.CommittedTrees;
+            committedTrees.Clear();
+            ParsekLog.Info("Scenario",
+                $"OnLoad initial: cleared CommittedTrees, loading {treeNodes.Length} tree(s)");
+
             if (treeNodes.Length > 0)
             {
-                ScenarioLog($"[Parsek Scenario] Loading {treeNodes.Length} committed tree(s)");
-                var committedTrees = RecordingStore.CommittedTrees;
-                committedTrees.Clear();
-
                 for (int t = 0; t < treeNodes.Length; t++)
                 {
                     var tree = RecordingTree.Load(treeNodes[t]);
@@ -1605,6 +1651,16 @@ namespace Parsek
             }
 
             return swapCount;
+        }
+
+        /// <summary>
+        /// Returns true if OnSave should warn about a save folder mismatch.
+        /// This detects when HighLogic.SaveFolder has changed since the scenario
+        /// was loaded, which could cause file writes to target the wrong save.
+        /// </summary>
+        internal static bool IsSaveFolderMismatch(string scenarioFolder, string currentFolder)
+        {
+            return !string.IsNullOrEmpty(scenarioFolder) && currentFolder != scenarioFolder;
         }
 
         /// <summary>

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -546,6 +546,10 @@ namespace Parsek
                 RecordingStore.IsRewinding = false;
                 RecordingStore.RewindUT = 0;
                 RecordingStore.RewindAdjustedUT = 0;
+                RecordingStore.RewindReserved = default(ResourceBudget.BudgetSummary);
+                RecordingStore.RewindBaselineFunds = 0;
+                RecordingStore.RewindBaselineScience = 0;
+                RecordingStore.RewindBaselineRep = 0;
             }
 
             recordings.Clear();


### PR DESCRIPTION
## Summary

- **CommittedTrees not cleared on save switch**: `committedTrees.Clear()` was inside `if (treeNodes.Length > 0)` in OnLoad's initial-load path. When switching from save A (has tree recordings) to save B (no trees), save A's trees persisted in the static list and got serialized to save B's .sfs on next OnSave. Moved `Clear()` before the conditional.
- **Pending recordings/trees leak across saves**: Static `pendingRecording`/`pendingTree` survived save switches. Auto-commit logic at end of OnLoad would commit save A's pending data into save B. Added cleanup at start of initial-load path.
- **Rewind statics leak across saves**: `IsRewinding` could survive a save switch, causing the rewind branch to execute instead of normal initial load. Added stale rewind flag cleanup.
- **Diagnostic warning**: OnSave now logs a warning if `HighLogic.SaveFolder` doesn't match the scenario's loaded save folder (log-only, no behavioral change).
- 9 new unit tests in `SaveContaminationTests.cs`.

## Test plan

- [x] `dotnet build` from `Source/Parsek/` succeeds
- [x] `dotnet test` from `Source/Parsek.Tests/` — all new tests pass, no regressions
- [x] In-game: load save A with tree recordings, switch to save B (no trees), verify save B's .sfs has no save A recordings
- [x] In-game: start recording in save A, switch to save B before committing, verify pending recording is discarded (not auto-committed to save B)