### PR TITLE
Fix watch camera stuck after loop explosion with time warp

### DIFF
--- a/Source/Parsek.Tests/CameraFollowTests.cs
+++ b/Source/Parsek.Tests/CameraFollowTests.cs
@@ -319,5 +319,52 @@ namespace Parsek.Tests
         }
 
         #endregion
+
+        #region ComputeWatchCycleOnLoopRebuild
+
+        [Fact]
+        public void WatchCycleOnRebuild_NotWatching_Unchanged()
+        {
+            // Not watching — value passes through unchanged
+            Assert.Equal(5, ParsekFlight.ComputeWatchCycleOnLoopRebuild(5, false, true, false));
+            Assert.Equal(-1, ParsekFlight.ComputeWatchCycleOnLoopRebuild(-1, false, false, false));
+        }
+
+        [Fact]
+        public void WatchCycleOnRebuild_Watching_NeedsExplosion_NotPaused_ReturnsHold()
+        {
+            // Watching, fresh explosion needed, not in pause window → -2 (hold)
+            Assert.Equal(-2, ParsekFlight.ComputeWatchCycleOnLoopRebuild(3, true, true, false));
+        }
+
+        [Fact]
+        public void WatchCycleOnRebuild_Watching_NeedsExplosion_InPauseWindow_ReturnsReady()
+        {
+            // Watching, explosion needed but we're in pause window → -1 (ready for re-target)
+            Assert.Equal(-1, ParsekFlight.ComputeWatchCycleOnLoopRebuild(3, true, true, true));
+        }
+
+        [Fact]
+        public void WatchCycleOnRebuild_Watching_ExplosionAlreadyFired_ReturnsReady()
+        {
+            // Watching, explosion already fired (e.g. during pause window with time warp) → -1
+            Assert.Equal(-1, ParsekFlight.ComputeWatchCycleOnLoopRebuild(3, true, false, false));
+        }
+
+        [Fact]
+        public void WatchCycleOnRebuild_Watching_NoExplosionTerminal_ReturnsReady()
+        {
+            // Watching, non-explosion terminal state (e.g. Landed) → -1
+            Assert.Equal(-1, ParsekFlight.ComputeWatchCycleOnLoopRebuild(0, true, false, false));
+        }
+
+        [Fact]
+        public void WatchCycleOnRebuild_Watching_AlreadyInHold_ReturnsReady()
+        {
+            // Already in hold (-2) but no new explosion needed → -1 (ready)
+            Assert.Equal(-1, ParsekFlight.ComputeWatchCycleOnLoopRebuild(-2, true, false, false));
+        }
+
+        #endregion
     }
 }

--- a/Source/Parsek.Tests/CameraFollowTests.cs
+++ b/Source/Parsek.Tests/CameraFollowTests.cs
@@ -359,10 +359,12 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void WatchCycleOnRebuild_Watching_AlreadyInHold_ReturnsReady()
+        public void WatchCycleOnRebuild_Watching_AlreadyInHold_StaysInHold()
         {
-            // Already in hold (-2) but no new explosion needed → -1 (ready)
-            Assert.Equal(-1, ParsekFlight.ComputeWatchCycleOnLoopRebuild(-2, true, false, false));
+            // Already in hold (-2) — don't restart, let existing hold expire
+            Assert.Equal(-2, ParsekFlight.ComputeWatchCycleOnLoopRebuild(-2, true, false, false));
+            // Even if a new explosion is needed, don't restart the hold
+            Assert.Equal(-2, ParsekFlight.ComputeWatchCycleOnLoopRebuild(-2, true, true, false));
         }
 
         #endregion

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -4727,7 +4727,7 @@ namespace Parsek
                     ParsekLog.Info("CameraFollow",
                         $"Loop: watched cycle={state?.loopCycleIndex} exploded, holding camera for {OverlapExplosionHoldSeconds:F0}s");
                 }
-                else if (newWatchCycle == -1)
+                else if (newWatchCycle == -1 && isWatching)
                 {
                     // Explosion already fired (e.g. during pause window with time warp) or
                     // non-explosion terminal state — mark ready for immediate re-target

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -292,6 +292,7 @@ namespace Parsek
         float savedCameraHeading = 0f;
         double watchEndHoldUntilUT = -1;      // non-looped end hold timer
         float savedPivotSharpness = 0.5f;
+        int watchNoTargetFrames = 0;          // consecutive frames with no valid camera target (safety net)
 
         // UI
         private Rect windowRect = new Rect(20, 100, 250, 250);
@@ -4708,9 +4709,13 @@ namespace Parsek
 
                 TriggerExplosionIfDestroyed(state, rec, recIdx);
 
-                // If watching and explosion fired, hold camera at explosion site
-                if (isWatching && needsExplosion && !inPauseWindow)
+                // Determine camera transition: -2 = hold at explosion, -1 = ready for re-target
+                int newWatchCycle = ComputeWatchCycleOnLoopRebuild(
+                    watchedOverlapCycleIndex, isWatching, needsExplosion, inPauseWindow);
+
+                if (newWatchCycle == -2)
                 {
+                    // Hold camera at explosion site
                     if (overlapCameraAnchor != null) Destroy(overlapCameraAnchor);
                     overlapCameraAnchor = new GameObject("ParsekLoopCameraAnchor");
                     if (state != null && state.ghost != null)
@@ -4721,6 +4726,18 @@ namespace Parsek
                     watchedOverlapCycleIndex = -2;
                     ParsekLog.Info("CameraFollow",
                         $"Loop: watched cycle={state?.loopCycleIndex} exploded, holding camera for {OverlapExplosionHoldSeconds:F0}s");
+                }
+                else if (newWatchCycle == -1)
+                {
+                    // Explosion already fired (e.g. during pause window with time warp) or
+                    // non-explosion terminal state — mark ready for immediate re-target
+                    // when the new ghost spawns below.
+                    // Clean up any active hold state (anchor, timer) from a previous cycle.
+                    watchedOverlapCycleIndex = -1;
+                    overlapRetargetAfterUT = -1;
+                    if (overlapCameraAnchor != null) { Destroy(overlapCameraAnchor); overlapCameraAnchor = null; }
+                    ParsekLog.Info("CameraFollow",
+                        $"Loop: watched cycle={state?.loopCycleIndex} ended (no hold needed), ready for re-target");
                 }
 
                 ResetReentryFx(state, recIdx);
@@ -6820,6 +6837,16 @@ namespace Parsek
         {
             if (watchedRecordingIndex < 0) return;
 
+            // Safety net: orphaned -2 state with invalid timer — clear to -1 so
+            // normal logic can take over (or exit watch mode via safety net below)
+            if (watchedOverlapCycleIndex == -2 && overlapRetargetAfterUT <= 0)
+            {
+                ParsekLog.Warn("CameraFollow",
+                    $"Orphaned hold state (overlapRetargetAfterUT={overlapRetargetAfterUT:F1}) — clearing");
+                watchedOverlapCycleIndex = -1;
+                if (overlapCameraAnchor != null) { Destroy(overlapCameraAnchor); overlapCameraAnchor = null; }
+            }
+
             // Delayed re-target after watched overlap cycle exploded
             if (watchedOverlapCycleIndex == -2 && overlapRetargetAfterUT > 0)
             {
@@ -6843,21 +6870,27 @@ namespace Parsek
                         var target = primary.cameraPivot ?? primary.ghost.transform;
                         FlightCamera.fetch.SetTargetTransform(target);
                         watchedOverlapCycleIndex = primary.loopCycleIndex;
+                        watchNoTargetFrames = 0;
                         ParsekLog.Info("CameraFollow",
                             $"Overlap: hold ended, now following cycle={primary.loopCycleIndex}");
                     }
                     else
                     {
-                        // No primary available — wait for next spawn
+                        // No primary available yet — set -1, let safety net below
+                        // exit watch mode if no ghost appears within a few frames
                         watchedOverlapCycleIndex = -1;
                         ParsekLog.Info("CameraFollow",
-                            $"Overlap: hold ended, no primary ghost available — waiting for next launch");
+                            $"Overlap: hold ended, no primary ghost available — waiting for next spawn");
                     }
                 }
-                // During hold, keep camera where it is (don't update position)
-                if (FlightCamera.fetch != null)
-                    FlightCamera.fetch.pivotTranslateSharpness = 0f;
-                return;
+                else
+                {
+                    // During hold, keep camera where it is (don't update position)
+                    if (FlightCamera.fetch != null)
+                        FlightCamera.fetch.pivotTranslateSharpness = 0f;
+                    watchNoTargetFrames = 0;
+                    return;
+                }
             }
 
             // Find the ghost we're actually following — may be an overlap ghost, not the primary
@@ -6885,17 +6918,48 @@ namespace Parsek
                         && primary != null && primary.loopCycleIndex == watchedOverlapCycleIndex)
                         state = primary;
                 }
+
+                // Fallback: tracked cycle not found — switch to primary if available
+                if (state == null)
+                {
+                    GhostPlaybackState primary;
+                    if (ghostStates.TryGetValue(watchedRecordingIndex, out primary)
+                        && primary != null && primary.ghost != null
+                        && primary.cameraPivot != null)
+                    {
+                        state = primary;
+                        watchedOverlapCycleIndex = primary.loopCycleIndex;
+                        if (FlightCamera.fetch != null)
+                            FlightCamera.fetch.SetTargetTransform(primary.cameraPivot);
+                        ParsekLog.Info("CameraFollow",
+                            $"Watched cycle lost — falling back to primary cycle={primary.loopCycleIndex}");
+                    }
+                }
             }
             else
             {
                 ghostStates.TryGetValue(watchedRecordingIndex, out state);
             }
 
-            if (state == null || state.cameraPivot == null)
-                return;
             if (FlightCamera.fetch == null || FlightCamera.fetch.transform == null
                 || FlightCamera.fetch.transform.parent == null)
                 return;
+
+            if (state == null || state.cameraPivot == null)
+            {
+                // No valid target — count frames and exit if persistent
+                watchNoTargetFrames++;
+                if (watchNoTargetFrames >= 3)
+                {
+                    ParsekLog.Warn("CameraFollow",
+                        $"No valid camera target for {watchNoTargetFrames} frames — exiting watch mode");
+                    ExitWatchMode();
+                }
+                return;
+            }
+
+            // Valid target found — reset safety counter
+            watchNoTargetFrames = 0;
 
             // Keep sharpness zeroed — KSP resets it on various events
             FlightCamera.fetch.pivotTranslateSharpness = 0f;
@@ -6973,6 +7037,19 @@ namespace Parsek
 
             loopUT = startUT + phase;
             return true;
+        }
+
+        /// <summary>
+        /// Determines the new watchedOverlapCycleIndex when a watched loop cycle
+        /// ends and the ghost is about to be rebuilt. Returns -2 (explosion hold),
+        /// -1 (ready for immediate re-target), or unchanged if not watching.
+        /// </summary>
+        internal static int ComputeWatchCycleOnLoopRebuild(
+            int currentWatchCycle, bool isWatching, bool needsExplosion, bool inPauseWindow)
+        {
+            if (!isWatching) return currentWatchCycle;
+            if (needsExplosion && !inPauseWindow) return -2; // hold at explosion site
+            return -1; // ready for immediate re-target
         }
 
         /// <summary>
@@ -7178,8 +7255,9 @@ namespace Parsek
             InputLockManager.SetControlLock(WatchModeLockMask, WatchModeLockId);
             ParsekLog.Verbose("CameraFollow", $"InputLockManager control lock \"{WatchModeLockId}\" set: {WatchModeLockMask}");
 
-            // Clear hold timer
+            // Clear hold timer and safety counter
             watchEndHoldUntilUT = -1;
+            watchNoTargetFrames = 0;
 
             string body = gs.lastInterpolatedBodyName ?? "?";
             string altStr = gs.lastInterpolatedAltitude.ToString("F0", CultureInfo.InvariantCulture);
@@ -7243,6 +7321,7 @@ namespace Parsek
             savedCameraPitch = 0f;
             savedCameraHeading = 0f;
             watchEndHoldUntilUT = -1;
+            watchNoTargetFrames = 0;
         }
 
         /// <summary>

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -7048,6 +7048,10 @@ namespace Parsek
             int currentWatchCycle, bool isWatching, bool needsExplosion, bool inPauseWindow)
         {
             if (!isWatching) return currentWatchCycle;
+            // Already in a hold — don't start another one, let the current hold
+            // expire naturally. Otherwise the timer keeps resetting during time warp
+            // and the camera never re-targets.
+            if (currentWatchCycle == -2) return currentWatchCycle;
             if (needsExplosion && !inPauseWindow) return -2; // hold at explosion site
             return -1; // ready for immediate re-target
         }


### PR DESCRIPTION
## Summary
- When watching a looped recording with time warp, the explosion fires during the pause window between cycles. On the next cycle change, `needsExplosion` is false so no camera hold is set up and `watchedOverlapCycleIndex` stays at the old value — camera freezes permanently.
- Adds `ComputeWatchCycleOnLoopRebuild` to handle the cycle-change camera transition: sets `-1` (ready for re-target) when no explosion hold is needed, covering positive-interval loops, zero-interval loops, negative-interval overlaps, and non-explosion terminal states.
- Adds cycle fallback in `UpdateWatchCamera`: when the tracked cycle disappears, falls back to the primary ghost instead of silently returning with no target.
- Adds a 3-frame safety net: if no valid camera target is found for 3 consecutive frames, auto-exits watch mode and returns camera to the active vessel — prevents freeze under any unforeseen edge case.
- Fixes orphaned hold state (`-2` with invalid timer) and cleans up stale anchor/timer when transitioning away from hold.

## Test plan
- [x] 6 new unit tests for `ComputeWatchCycleOnLoopRebuild` (all pass)
- [x] Full test suite: 1316 passed, 0 failed
- [x] In-game: watch a looped recording (positive interval) with time warp, verify camera follows new ghost after explosion
- [x] In-game: watch a looped recording (zero interval) with time warp, verify same
- [x] In-game: watch a non-looped recording, verify camera returns to vessel after hold expires
- [x] In-game: watch a looped recording without time warp, verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)