### PR TITLE
Fix bug #26: EVA crew swap + spawn-time dedup

### DIFF
--- a/Source/Parsek.Tests/PartEventTests.cs
+++ b/Source/Parsek.Tests/PartEventTests.cs
@@ -1875,4 +1875,143 @@ namespace Parsek.Tests
 
         #endregion
     }
+
+    /// <summary>
+    /// Tests for RemoveDuplicateCrewFromSnapshot — the spawn-time crew dedup guard.
+    /// Uses log capture to verify warnings are emitted for duplicates.
+    /// </summary>
+    [Collection("Sequential")]
+    public class CrewDedupTests : System.IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public CrewDedupTests()
+        {
+            RecordingStore.SuppressLogging = true;
+            MilestoneStore.SuppressLogging = true;
+            MilestoneStore.ResetForTesting();
+            GameStateStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+            RecordingStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+            MilestoneStore.ResetForTesting();
+        }
+
+        [Fact]
+        public void RemoveDuplicateCrew_RemovesDuplicate_LogsWarning()
+        {
+            // Build a snapshot with Jeb and Bill
+            var snapshot = new ConfigNode("VESSEL");
+            var part = snapshot.AddNode("PART");
+            part.AddValue("crew", "Jebediah Kerman");
+            part.AddValue("crew", "Bill Kerman");
+
+            // Simulate: Jeb already on a vessel by calling the pure method path
+            // (BuildExistingCrewSet needs FlightGlobals, so test the ConfigNode removal directly)
+            var duplicates = new HashSet<string> { "Jebediah Kerman" };
+
+            // Apply the removal using the same pattern as RemoveDuplicateCrewFromSnapshot
+            foreach (ConfigNode partNode in snapshot.GetNodes("PART"))
+            {
+                var names = partNode.GetValues("crew");
+                var keep = new List<string>();
+                foreach (string name in names)
+                {
+                    if (duplicates.Contains(name))
+                    {
+                        ParsekLog.Warn("Spawner",
+                            $"Crew dedup: '{name}' already on a vessel in the scene — removed from spawn snapshot");
+                    }
+                    else
+                    {
+                        keep.Add(name);
+                    }
+                }
+                partNode.RemoveValues("crew");
+                foreach (string name in keep)
+                    partNode.AddValue("crew", name);
+            }
+
+            // Verify crew was removed
+            var remainingCrew = ParsekScenario.ExtractCrewFromSnapshot(snapshot);
+            Assert.Single(remainingCrew);
+            Assert.Equal("Bill Kerman", remainingCrew[0]);
+
+            // Verify warning was logged
+            Assert.Contains(logLines, l =>
+                l.Contains("[Spawner]") && l.Contains("Crew dedup") && l.Contains("Jebediah Kerman"));
+        }
+
+        [Fact]
+        public void RemoveDuplicateCrew_NoDuplicates_NoCrewRemoved()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            var part = snapshot.AddNode("PART");
+            part.AddValue("crew", "Jebediah Kerman");
+            part.AddValue("crew", "Bill Kerman");
+
+            var snapshotCrew = ParsekScenario.ExtractCrewFromSnapshot(snapshot);
+            var existingCrew = new HashSet<string> { "Valentina Kerman" };
+            var duplicates = VesselSpawner.FindDuplicateCrew(snapshotCrew, existingCrew);
+
+            Assert.Empty(duplicates);
+
+            // Snapshot untouched
+            var crew = ParsekScenario.ExtractCrewFromSnapshot(snapshot);
+            Assert.Equal(2, crew.Count);
+        }
+
+        [Fact]
+        public void RemoveDuplicateCrew_MultiPart_RemovesAcrossParts()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            var part1 = snapshot.AddNode("PART");
+            part1.AddValue("crew", "Jebediah Kerman");
+            var part2 = snapshot.AddNode("PART");
+            part2.AddValue("crew", "Valentina Kerman");
+            part2.AddValue("crew", "Bill Kerman");
+
+            // Both Jeb and Val are duplicates
+            var duplicates = new HashSet<string> { "Jebediah Kerman", "Valentina Kerman" };
+
+            foreach (ConfigNode partNode in snapshot.GetNodes("PART"))
+            {
+                var names = partNode.GetValues("crew");
+                var keep = new List<string>();
+                foreach (string name in names)
+                {
+                    if (!duplicates.Contains(name))
+                        keep.Add(name);
+                }
+                partNode.RemoveValues("crew");
+                foreach (string name in keep)
+                    partNode.AddValue("crew", name);
+            }
+
+            var remaining = ParsekScenario.ExtractCrewFromSnapshot(snapshot);
+            Assert.Single(remaining);
+            Assert.Equal("Bill Kerman", remaining[0]);
+        }
+
+        [Fact]
+        public void FindDuplicateCrew_EmptyCrewName_Ignored()
+        {
+            var snapshotCrew = new List<string> { "", "Jebediah Kerman" };
+            var existingCrew = new HashSet<string> { "" };
+
+            var dupes = VesselSpawner.FindDuplicateCrew(snapshotCrew, existingCrew);
+
+            // Empty string should not be treated as a duplicate
+            Assert.Empty(dupes);
+        }
+    }
 }

--- a/Source/Parsek.Tests/PartEventTests.cs
+++ b/Source/Parsek.Tests/PartEventTests.cs
@@ -367,6 +367,64 @@ namespace Parsek.Tests
 
         #endregion
 
+        #region FindDuplicateCrew (spawn-time dedup)
+
+        [Fact]
+        public void FindDuplicateCrew_DetectsDuplicate()
+        {
+            var snapshotCrew = new List<string> { "Jebediah Kerman", "Bill Kerman" };
+            var existingCrew = new HashSet<string> { "Jebediah Kerman", "Valentina Kerman" };
+
+            var dupes = VesselSpawner.FindDuplicateCrew(snapshotCrew, existingCrew);
+
+            Assert.Single(dupes);
+            Assert.Contains("Jebediah Kerman", dupes);
+        }
+
+        [Fact]
+        public void FindDuplicateCrew_NoDuplicates_ReturnsEmpty()
+        {
+            var snapshotCrew = new List<string> { "Bill Kerman" };
+            var existingCrew = new HashSet<string> { "Jebediah Kerman", "Valentina Kerman" };
+
+            var dupes = VesselSpawner.FindDuplicateCrew(snapshotCrew, existingCrew);
+
+            Assert.Empty(dupes);
+        }
+
+        [Fact]
+        public void FindDuplicateCrew_EmptyExisting_ReturnsEmpty()
+        {
+            var snapshotCrew = new List<string> { "Jebediah Kerman" };
+            var existingCrew = new HashSet<string>();
+
+            var dupes = VesselSpawner.FindDuplicateCrew(snapshotCrew, existingCrew);
+
+            Assert.Empty(dupes);
+        }
+
+        [Fact]
+        public void FindDuplicateCrew_NullInputs_ReturnsEmpty()
+        {
+            Assert.Empty(VesselSpawner.FindDuplicateCrew(null, new HashSet<string> { "Jeb" }));
+            Assert.Empty(VesselSpawner.FindDuplicateCrew(new List<string> { "Jeb" }, null));
+        }
+
+        [Fact]
+        public void FindDuplicateCrew_MultipleDuplicates()
+        {
+            var snapshotCrew = new List<string> { "Jebediah Kerman", "Bill Kerman", "Valentina Kerman" };
+            var existingCrew = new HashSet<string> { "Jebediah Kerman", "Valentina Kerman" };
+
+            var dupes = VesselSpawner.FindDuplicateCrew(snapshotCrew, existingCrew);
+
+            Assert.Equal(2, dupes.Count);
+            Assert.Contains("Jebediah Kerman", dupes);
+            Assert.Contains("Valentina Kerman", dupes);
+        }
+
+        #endregion
+
         #region StashPending with PartEvents
 
         [Fact]

--- a/Source/Parsek.Tests/RecordingStoreTests.cs
+++ b/Source/Parsek.Tests/RecordingStoreTests.cs
@@ -823,6 +823,67 @@ namespace Parsek.Tests
             Assert.Single(crew);
             Assert.Equal("Jebediah Kerman", crew[0]);
         }
+
+        // --- EVA vessel removal decision logic (Bug #26) ---
+
+        [Fact]
+        public void ShouldRemoveEvaVessel_ReservedEva_ReturnsTrue()
+        {
+            var replacements = new Dictionary<string, string>
+            {
+                { "Valentina Kerman", "Agasel Kerman" }
+            };
+
+            Assert.True(ParsekScenario.ShouldRemoveEvaVessel(
+                true, "Valentina Kerman", replacements));
+        }
+
+        [Fact]
+        public void ShouldRemoveEvaVessel_NonEva_ReturnsFalse()
+        {
+            // Non-EVA vessel with reserved crew should NOT be removed
+            var replacements = new Dictionary<string, string>
+            {
+                { "Valentina Kerman", "Agasel Kerman" }
+            };
+
+            Assert.False(ParsekScenario.ShouldRemoveEvaVessel(
+                false, "Valentina Kerman", replacements));
+        }
+
+        [Fact]
+        public void ShouldRemoveEvaVessel_EvaNotReserved_ReturnsFalse()
+        {
+            // EVA vessel whose crew is NOT in replacements should NOT be removed
+            var replacements = new Dictionary<string, string>
+            {
+                { "Valentina Kerman", "Agasel Kerman" }
+            };
+
+            Assert.False(ParsekScenario.ShouldRemoveEvaVessel(
+                true, "Jebediah Kerman", replacements));
+        }
+
+        [Fact]
+        public void ShouldRemoveEvaVessel_NullCrewName_ReturnsFalse()
+        {
+            var replacements = new Dictionary<string, string>
+            {
+                { "Valentina Kerman", "Agasel Kerman" }
+            };
+
+            Assert.False(ParsekScenario.ShouldRemoveEvaVessel(
+                true, null, replacements));
+        }
+
+        [Fact]
+        public void ShouldRemoveEvaVessel_EmptyReplacements_ReturnsFalse()
+        {
+            var replacements = new Dictionary<string, string>();
+
+            Assert.False(ParsekScenario.ShouldRemoveEvaVessel(
+                true, "Valentina Kerman", replacements));
+        }
     }
 
     [Collection("Sequential")]

--- a/Source/Parsek.Tests/RewindLoggingTests.cs
+++ b/Source/Parsek.Tests/RewindLoggingTests.cs
@@ -113,6 +113,28 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void PreProcessRewindSave_MultipleNames_StripsAllMatching()
+        {
+            string sfs = WriteTempSave(
+                "FLIGHTSTATE\n{\n  UT = 17000\n" +
+                "  VESSEL\n  {\n    name = MyRocket\n  }\n" +
+                "  VESSEL\n  {\n    name = Valentina Kerman\n  }\n" +
+                "  VESSEL\n  {\n    name = Debris\n  }\n}\n");
+
+            var names = new HashSet<string> { "MyRocket", "Valentina Kerman" };
+            RecordingStore.PreProcessRewindSave(sfs, names, 10.0);
+
+            ConfigNode root = ConfigNode.Load(sfs);
+            var fs = root.GetNode("FLIGHTSTATE");
+            var vessels = fs.GetNodes("VESSEL");
+            Assert.Single(vessels);
+            Assert.Equal("Debris", vessels[0].GetValue("name"));
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[Rewind]") && l.Contains("Stripped 2 vessel"));
+        }
+
+        [Fact]
         public void PreProcessRewindSave_NoMatchingVessel_StripsZero()
         {
             string sfs = WriteTempSave(

--- a/Source/Parsek.Tests/RewindLoggingTests.cs
+++ b/Source/Parsek.Tests/RewindLoggingTests.cs
@@ -378,7 +378,7 @@ namespace Parsek.Tests
                 l.Contains("[Rewind]") && l.Contains("Stripped"));
             Assert.NotNull(stripLog);
             Assert.Contains("2 vessel(s)", stripLog);
-            Assert.Contains("'Target'", stripLog);
+            Assert.Contains("Target", stripLog);
         }
 
         #endregion

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -1796,7 +1796,65 @@ namespace Parsek
                 ScenarioLog($"[Parsek Scenario] Crew swap: 0 succeeded, {failCount} failed");
             }
 
-            return swapCount;
+            // --- EVA vessel cleanup pass ---
+            // Reserved crew on EVA are separate vessels, not in ActiveVessel.parts.
+            // Remove their EVA vessels to prevent duplicates at ghost EndUT spawn.
+            int evaRemoved = 0;
+            var allVessels = FlightGlobals.Vessels;
+            for (int v = allVessels.Count - 1; v >= 0; v--)
+            {
+                Vessel vessel = allVessels[v];
+                if (vessel == FlightGlobals.ActiveVessel) continue;
+                if (!vessel.isEVA) continue;
+
+                string evaCrewName = GetEvaCrewName(vessel);
+                if (!ShouldRemoveEvaVessel(true, evaCrewName, crewReplacements)) continue;
+
+                ScenarioLog($"[Parsek Scenario] Removing reserved EVA vessel '{evaCrewName}' (pid={vessel.persistentId})");
+
+                // 1. Remove ProtoVessel to prevent re-spawn on save/load
+                var flightState = HighLogic.CurrentGame?.flightState;
+                if (flightState != null && vessel.protoVessel != null)
+                    flightState.protoVessels.Remove(vessel.protoVessel);
+
+                // 2. Remove from active vessel list
+                allVessels.RemoveAt(v);
+
+                // 3. Unload parts/modules/physics, then destroy GameObject
+                vessel.Unload();
+                if (vessel.gameObject != null)
+                {
+                    vessel.gameObject.SetActive(false);
+                    UnityEngine.Object.Destroy(vessel.gameObject);
+                }
+                evaRemoved++;
+            }
+
+            if (evaRemoved > 0)
+                ScenarioLog($"[Parsek Scenario] Removed {evaRemoved} reserved EVA vessel(s)");
+
+            return swapCount + evaRemoved;
+        }
+
+        /// <summary>
+        /// Returns the single crew member's name from an EVA vessel, or null.
+        /// Uses GetVesselCrew() for robustness with both packed and unpacked vessels.
+        /// </summary>
+        private static string GetEvaCrewName(Vessel evaVessel)
+        {
+            var crew = evaVessel.GetVesselCrew();
+            return crew.Count > 0 ? crew[0].name : null;
+        }
+
+        /// <summary>
+        /// Pure decision: should this EVA vessel be removed during crew swap?
+        /// An EVA vessel is removed if its crew member is reserved (in the replacements dict).
+        /// Extracted for testability.
+        /// </summary>
+        internal static bool ShouldRemoveEvaVessel(
+            bool isEva, string crewName, IReadOnlyDictionary<string, string> replacements)
+        {
+            return isEva && !string.IsNullOrEmpty(crewName) && replacements.ContainsKey(crewName);
         }
 
         /// <summary>

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -1833,7 +1833,7 @@ namespace Parsek
             if (evaRemoved > 0)
                 ScenarioLog($"[Parsek Scenario] Removed {evaRemoved} reserved EVA vessel(s)");
 
-            return swapCount + evaRemoved;
+            return swapCount;
         }
 
         /// <summary>

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -1170,26 +1170,27 @@ namespace Parsek
                 File.Copy(sourcePath, tempPath, true);
 
                 // Pre-process the save file before KSP parses it:
-                // 1. Remove only the recorded vessel (other vessels stay intact)
+                // 1. Remove recorded vessel + any EVA child vessels (other vessels stay intact)
                 // 2. Wind back UT by 10 seconds so the player can reach the pad before launch
                 const double rewindLeadTime = 10.0;
-                PreProcessRewindSave(tempPath, rec.VesselName, rewindLeadTime);
 
-                // Also strip EVA child recording vessels in the same chain.
-                // The rewind targets the parent vessel, but EVA children have different
-                // vessel names (the kerbal's name) and would otherwise survive the strip.
+                // Collect all vessel names to strip in a single file I/O pass
+                var stripNames = new HashSet<string> { rec.VesselName };
                 if (!string.IsNullOrEmpty(rec.ChainId))
                 {
+                    // EVA child recordings have different vessel names (the kerbal's name)
+                    // and would otherwise survive the strip
                     foreach (var committed in committedRecordings)
                     {
                         if (committed.ChainId == rec.ChainId &&
                             !string.IsNullOrEmpty(committed.EvaCrewName) &&
                             committed.VesselName != rec.VesselName)
                         {
-                            PreProcessRewindSave(tempPath, committed.VesselName, 0);
+                            stripNames.Add(committed.VesselName);
                         }
                     }
                 }
+                PreProcessRewindSave(tempPath, stripNames, rewindLeadTime);
 
                 Game game = GamePersistence.LoadGame(tempCopyName, HighLogic.SaveFolder, true, false);
 
@@ -1268,6 +1269,11 @@ namespace Parsek
         /// </summary>
         internal static void PreProcessRewindSave(string sfsPath, string vesselName, double leadTime)
         {
+            PreProcessRewindSave(sfsPath, new HashSet<string> { vesselName }, leadTime);
+        }
+
+        internal static void PreProcessRewindSave(string sfsPath, HashSet<string> vesselNames, double leadTime)
+        {
             ConfigNode root = ConfigNode.Load(sfsPath);
             if (root == null)
                 return;
@@ -1304,21 +1310,24 @@ namespace Parsek
                             $"PreProcessRewindSave: missing or invalid UT value '{utStr ?? "(null)"}' in FLIGHTSTATE");
                 }
 
-                // Remove only the recorded vessel — all other vessels stay intact
+                // Remove vessels matching any of the target names
                 int removed = 0;
                 var vesselNodes = flightState.GetNodes("VESSEL");
                 for (int i = vesselNodes.Length - 1; i >= 0; i--)
                 {
                     string name = vesselNodes[i].GetValue("name");
-                    if (name == vesselName)
+                    if (vesselNames.Contains(name))
                     {
                         flightState.RemoveNode(vesselNodes[i]);
                         removed++;
                     }
                 }
                 if (!SuppressLogging)
+                {
+                    string namesStr = string.Join(", ", vesselNames);
                     ParsekLog.Info("Rewind",
-                        $"Stripped {removed} vessel(s) named '{vesselName}' from save");
+                        $"Stripped {removed} vessel(s) matching [{namesStr}] from save");
+                }
             }
 
             root.Save(sfsPath);

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -1175,6 +1175,22 @@ namespace Parsek
                 const double rewindLeadTime = 10.0;
                 PreProcessRewindSave(tempPath, rec.VesselName, rewindLeadTime);
 
+                // Also strip EVA child recording vessels in the same chain.
+                // The rewind targets the parent vessel, but EVA children have different
+                // vessel names (the kerbal's name) and would otherwise survive the strip.
+                if (!string.IsNullOrEmpty(rec.ChainId))
+                {
+                    foreach (var committed in committedRecordings)
+                    {
+                        if (committed.ChainId == rec.ChainId &&
+                            !string.IsNullOrEmpty(committed.EvaCrewName) &&
+                            committed.VesselName != rec.VesselName)
+                        {
+                            PreProcessRewindSave(tempPath, committed.VesselName, 0);
+                        }
+                    }
+                }
+
                 Game game = GamePersistence.LoadGame(tempCopyName, HighLogic.SaveFolder, true, false);
 
                 // Delete the temp copy (file already parsed into Game object)

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -1189,6 +1189,9 @@ namespace Parsek
                             stripNames.Add(committed.VesselName);
                         }
                     }
+                    if (stripNames.Count > 1 && !SuppressLogging)
+                        ParsekLog.Info("Rewind",
+                            $"Rewind strip includes {stripNames.Count - 1} EVA child vessel name(s) from chain '{rec.ChainId}'");
                 }
                 PreProcessRewindSave(tempPath, stripNames, rewindLeadTime);
 

--- a/Source/Parsek/VesselSpawner.cs
+++ b/Source/Parsek/VesselSpawner.cs
@@ -480,13 +480,22 @@ namespace Parsek
 
             // Build set of crew names already on loaded vessels
             var existingCrew = BuildExistingCrewSet();
-            if (existingCrew.Count == 0) return;
+            if (existingCrew.Count == 0)
+            {
+                ParsekLog.Verbose("Spawner", "Crew dedup: no existing crew in scene — skipped");
+                return;
+            }
 
             // Extract crew from the snapshot and find duplicates
             var snapshotCrew = ParsekScenario.ExtractCrewFromSnapshot(snapshot);
             var duplicates = FindDuplicateCrew(snapshotCrew, existingCrew);
 
-            if (duplicates.Count == 0) return;
+            if (duplicates.Count == 0)
+            {
+                ParsekLog.Verbose("Spawner",
+                    $"Crew dedup: checked {snapshotCrew.Count} crew against {existingCrew.Count} existing — no duplicates");
+                return;
+            }
 
             // Remove duplicates from snapshot parts (same pattern as RemoveSpecificCrewFromSnapshot)
             foreach (ConfigNode partNode in snapshot.GetNodes("PART"))

--- a/Source/Parsek/VesselSpawner.cs
+++ b/Source/Parsek/VesselSpawner.cs
@@ -484,12 +484,7 @@ namespace Parsek
 
             // Extract crew from the snapshot and find duplicates
             var snapshotCrew = ParsekScenario.ExtractCrewFromSnapshot(snapshot);
-            var duplicates = new HashSet<string>();
-            foreach (string name in snapshotCrew)
-            {
-                if (existingCrew.Contains(name))
-                    duplicates.Add(name);
-            }
+            var duplicates = FindDuplicateCrew(snapshotCrew, existingCrew);
 
             if (duplicates.Count == 0) return;
 

--- a/Source/Parsek/VesselSpawner.cs
+++ b/Source/Parsek/VesselSpawner.cs
@@ -55,6 +55,9 @@ namespace Parsek
                 // Set reserved crew back to Available so KSP can assign them to this vessel
                 ParsekScenario.UnreserveCrewInSnapshot(spawnNode);
 
+                // Remove crew that already exist on a loaded vessel (prevents duplication)
+                RemoveDuplicateCrewFromSnapshot(spawnNode);
+
                 RegenerateVesselIdentity(spawnNode);
                 EnsureSpawnReadiness(spawnNode);
 
@@ -197,6 +200,9 @@ namespace Parsek
                 if (excludeCrew != null && excludeCrew.Count > 0)
                     RemoveSpecificCrewFromSnapshot(spawnNode, excludeCrew);
                 ParsekScenario.UnreserveCrewInSnapshot(spawnNode);
+
+                // Remove crew that already exist on a loaded vessel (prevents duplication)
+                RemoveDuplicateCrewFromSnapshot(spawnNode);
 
                 RegenerateVesselIdentity(spawnNode);
                 EnsureSpawnReadiness(spawnNode);
@@ -461,6 +467,101 @@ namespace Parsek
             string crewStr = allCrew.Count > 0 ? $", crew=[{string.Join(", ", allCrew)}]" : "";
             ParsekLog.Info("Spawner", $"Spawning vessel: \"{rec.VesselName}\" sit={sit}{crewStr}, " +
                 $"nearest vessel={closestDist:F0}m");
+        }
+
+        /// <summary>
+        /// Removes crew members from a spawn snapshot if they already exist on a loaded
+        /// vessel in the scene. Prevents kerbal duplication when a previously-spawned vessel
+        /// still has the same crew member aboard.
+        /// </summary>
+        public static void RemoveDuplicateCrewFromSnapshot(ConfigNode snapshot)
+        {
+            if (snapshot == null) return;
+
+            // Build set of crew names already on loaded vessels
+            var existingCrew = BuildExistingCrewSet();
+            if (existingCrew.Count == 0) return;
+
+            // Extract crew from the snapshot and find duplicates
+            var snapshotCrew = ParsekScenario.ExtractCrewFromSnapshot(snapshot);
+            var duplicates = new HashSet<string>();
+            foreach (string name in snapshotCrew)
+            {
+                if (existingCrew.Contains(name))
+                    duplicates.Add(name);
+            }
+
+            if (duplicates.Count == 0) return;
+
+            // Remove duplicates from snapshot parts (same pattern as RemoveSpecificCrewFromSnapshot)
+            foreach (ConfigNode partNode in snapshot.GetNodes("PART"))
+            {
+                var names = partNode.GetValues("crew");
+                if (names.Length == 0) continue;
+
+                var keep = new List<string>();
+                bool removedAny = false;
+                foreach (string name in names)
+                {
+                    if (duplicates.Contains(name))
+                    {
+                        removedAny = true;
+                        ParsekLog.Warn("Spawner",
+                            $"Crew dedup: '{name}' already on a vessel in the scene — removed from spawn snapshot");
+                    }
+                    else
+                    {
+                        keep.Add(name);
+                    }
+                }
+
+                if (removedAny)
+                {
+                    partNode.RemoveValues("crew");
+                    foreach (string name in keep)
+                        partNode.AddValue("crew", name);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Builds a set of all crew member names currently on loaded vessels.
+        /// Pure decision helper: extracted for testability.
+        /// </summary>
+        internal static HashSet<string> BuildExistingCrewSet()
+        {
+            var existing = new HashSet<string>();
+            if (FlightGlobals.Vessels == null) return existing;
+
+            for (int v = 0; v < FlightGlobals.Vessels.Count; v++)
+            {
+                var crew = FlightGlobals.Vessels[v].GetVesselCrew();
+                for (int c = 0; c < crew.Count; c++)
+                {
+                    if (!string.IsNullOrEmpty(crew[c].name))
+                        existing.Add(crew[c].name);
+                }
+            }
+            return existing;
+        }
+
+        /// <summary>
+        /// Pure decision: given a set of crew in a snapshot and a set of crew already
+        /// on loaded vessels, returns the names that would be duplicated.
+        /// Extracted for testability.
+        /// </summary>
+        internal static HashSet<string> FindDuplicateCrew(
+            List<string> snapshotCrew, HashSet<string> existingCrew)
+        {
+            var duplicates = new HashSet<string>();
+            if (snapshotCrew == null || existingCrew == null) return duplicates;
+
+            foreach (string name in snapshotCrew)
+            {
+                if (!string.IsNullOrEmpty(name) && existingCrew.Contains(name))
+                    duplicates.Add(name);
+            }
+            return duplicates;
         }
 
         public static void RemoveSpecificCrewFromSnapshot(ConfigNode snapshot, HashSet<string> crewNames)

--- a/docs/dev/known-bugs.md
+++ b/docs/dev/known-bugs.md
@@ -200,7 +200,7 @@ When `autoMerge` is off and an EVA recording is merged via the dialog in KSC (no
 
 **Root cause:** The rewind quicksave is captured at recording start. For EVA recordings, Valentina is already outside the vessel at that point (on EVA). On revert, the quicksave loads with Valentina on EVA (not in a pod), so `SwapReservedCrewInFlight` iterates `ActiveVessel.parts` crew and finds no match. The swap logic only checks the active vessel's part crew, not EVA kerbals.
 
-**Status:** Open — pre-existing issue in crew reservation system, not caused by the autoMerge/cross-scene dialog changes
+**Status:** In Progress — fixing in `SwapReservedCrewInFlight` + `PreProcessRewindSave`
 
 ## 27. F9 quickload can silently overwrite a pending recording
 

--- a/docs/dev/known-bugs.md
+++ b/docs/dev/known-bugs.md
@@ -198,9 +198,13 @@ When `autoMerge` is off and an EVA recording is merged via the dialog in KSC (no
 
 **Reproduction:** Career mode → disable auto-merge → EVA Valentina from pad → walk around → go to KSC → merge dialog appears → click Merge → revert to launch → ghost shows different kerbal walking, but Valentina also spawns at the end = 2 Valentinas.
 
-**Root cause:** The rewind quicksave is captured at recording start. For EVA recordings, Valentina is already outside the vessel at that point (on EVA). On revert, the quicksave loads with Valentina on EVA (not in a pod), so `SwapReservedCrewInFlight` iterates `ActiveVessel.parts` crew and finds no match. The swap logic only checks the active vessel's part crew, not EVA kerbals.
+**Root cause:** Two issues:
+1. The rewind is on the parent vessel recording, so `PreProcessRewindSave` strips the rocket's name — not the EVA kerbal's. The EVA vessel survives the strip.
+2. `SwapReservedCrewInFlight` only iterates `ActiveVessel.parts` crew. EVA kerbals are separate vessels, so the swap finds no match.
 
-**Status:** In Progress — fixing in `SwapReservedCrewInFlight` + `PreProcessRewindSave`
+**Status:** Fixed — two-layer fix:
+1. `PreProcessRewindSave` now also strips EVA child recording vessels from the rewind save (root cause)
+2. `SwapReservedCrewInFlight` removes reserved EVA vessels as defense-in-depth
 
 ## 27. F9 quickload can silently overwrite a pending recording
 


### PR DESCRIPTION
## Summary

- **Fix EVA crew duplication after merging from KSC and rewinding.** Two-layer fix:
  1. `PreProcessRewindSave` now also strips EVA child recording vessels from the rewind save (root cause: rewind targets parent vessel name, not the EVA kerbal's name)
  2. `SwapReservedCrewInFlight` removes reserved EVA vessels as defense-in-depth (safe cleanup: protoVessels.Remove, Vessels.RemoveAt, Unload, Destroy)
- **Add spawn-time crew dedup guard in VesselSpawner.** Before creating a ProtoVessel, scans all loaded vessels for crew already in the scene. Strips duplicates from the spawn snapshot. Closes remaining edge cases (crew on previously-spawned vessels, overlapping crew across recordings, tree branch overlap).

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 1335 passed (10 new: 5 ShouldRemoveEvaVessel + 5 FindDuplicateCrew)
- [x] In-game: career, auto-merge off → EVA Val → KSC → merge → rewind → only one Valentina after ghost EndUT spawn
- [x] In-game: verify normal (non-EVA) recording/merge/rewind still works