### PR TITLE
Fix bugs #17, #20, #25, #27

### DIFF
--- a/Source/Parsek.Tests/ComputeStatsTests.cs
+++ b/Source/Parsek.Tests/ComputeStatsTests.cs
@@ -5,6 +5,7 @@ using Xunit;
 
 namespace Parsek.Tests
 {
+    [Collection("Sequential")]
     public class ComputeStatsTests
     {
         [Fact]

--- a/Source/Parsek.Tests/RecordingStoreTests.cs
+++ b/Source/Parsek.Tests/RecordingStoreTests.cs
@@ -1129,5 +1129,41 @@ namespace Parsek.Tests
             Assert.Equal(5, RecordingStore.Pending.Points.Count);
             Assert.Equal(100.0, RecordingStore.Pending.StartUT);
         }
+
+        [Fact]
+        public void StashPending_OverwritesExistingPending_DiscardsOld()
+        {
+            RecordingStore.StashPending(MakePoints(3, 100), "RocketA");
+            Assert.True(RecordingStore.HasPending);
+            Assert.Equal("RocketA", RecordingStore.Pending.VesselName);
+
+            RecordingStore.StashPending(MakePoints(4, 200), "RocketB");
+            Assert.True(RecordingStore.HasPending);
+            Assert.Equal("RocketB", RecordingStore.Pending.VesselName);
+            Assert.Equal(4, RecordingStore.Pending.Points.Count);
+        }
+
+        [Fact]
+        public void StashPending_OverwriteLogsWarning()
+        {
+            var logLines = new List<string>();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+            try
+            {
+                RecordingStore.StashPending(MakePoints(3, 100), "RocketA");
+                RecordingStore.StashPending(MakePoints(3, 200), "RocketB");
+
+                Assert.Contains(logLines, l =>
+                    l.Contains("overwriting unresolved pending") &&
+                    l.Contains("RocketA") &&
+                    l.Contains("RocketB"));
+            }
+            finally
+            {
+                ParsekLog.SuppressLogging = true;
+                ParsekLog.ResetTestOverrides();
+            }
+        }
     }
 }

--- a/Source/Parsek.Tests/SyntheticRecordingTests.cs
+++ b/Source/Parsek.Tests/SyntheticRecordingTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 
 namespace Parsek.Tests
 {
+    [Collection("Sequential")]
     public class SyntheticRecordingTests
     {
         private static string ProjectRoot => ResolveProjectRoot();

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -305,6 +305,15 @@ namespace Parsek
                 }
             }
 
+            if (pendingRecording != null)
+            {
+                ParsekLog.Warn("RecordingStore",
+                    $"StashPending: overwriting unresolved pending from '{pendingRecording.VesselName}' " +
+                    $"with new pending from '{vesselName}' — discarding old pending");
+                ParsekScenario.UnreserveCrewInSnapshot(pendingRecording.VesselSnapshot);
+                DiscardPending();
+            }
+
             pendingRecording = new Recording
             {
                 RecordingId = string.IsNullOrEmpty(recordingId) ? Guid.NewGuid().ToString("N") : recordingId,

--- a/Source/README.md
+++ b/Source/README.md
@@ -129,7 +129,7 @@ cd Source/Parsek.Tests
 dotnet test
 ```
 
-1263 tests total.
+1342 tests total.
 
 ### Live KSP Log Validation
 

--- a/docs/dev/known-bugs.md
+++ b/docs/dev/known-bugs.md
@@ -220,6 +220,8 @@ If the player has an unresolved pending recording (merge dialog not yet shown/cl
 
 **Reproduction:** Requires both an active recording and an unresolved pending simultaneously — very rare in practice. Could theoretically happen if: record flight A → go to KSC (pending A) → launch new vessel → record flight B → F9 quickload (pending A overwritten by pending B).
 
-**Root cause:** `RecordingStore.StashPending` overwrites the existing `pendingRecording` static field without checking if one already exists. No warning logged.
+**Root cause:** `RecordingStore.StashPending` overwrites the existing `pendingRecording` static field without checking if one already exists. No warning logged. Crew reservations from the old pending are leaked (kerbals stuck in Assigned status).
 
-**Status:** Open — pre-existing, very unlikely edge case
+**Fix:** Added a guard at the top of `StashPending`: if a pending recording already exists, unreserve its crew via `UnreserveCrewInSnapshot` and call `DiscardPending()` (which cleans up sidecar files) before creating the new pending. Logs a WARN with both vessel names.
+
+**Status:** Fixed

--- a/docs/dev/known-bugs.md
+++ b/docs/dev/known-bugs.md
@@ -107,7 +107,9 @@ Ghost re-entry heating FX appear as oversized square arrangements (6 spaced-out 
 1. **Scale/pattern:** Each flame particle system renders as a grid/square pattern instead of a smooth heating glow — many individual flame sprites arranged in a grid-like formation
 2. **Direction:** Flame direction vector is inverted relative to the velocity vector — should face into the airstream (prograde) but instead faces retrograde
 
-**Status:** Open — needs investigation of `ReentryFx` particle placement and velocity alignment in ParsekFlight.cs
+**Fix:** Completely reworked across multiple PRs: square particle sprites replaced with smooth fire streak trails (#30), then replaced again with mesh-surface fire particles matching the stock KSP `aeroFX` intensity formula from `Physics.cfg` (#32). Fire shell overlay added and reentry meshes rebuilt on decouple events. Direction and scale issues resolved.
+
+**Status:** Fixed
 
 ## 18. Engine nozzle glow persists after engine cutoff
 
@@ -139,7 +141,9 @@ In the second segment of a chain recording (e.g., Kerbin exo after atmosphere ex
 
 **Reproduction:** Record a full flight with staging (R2 default career). Watch the exo-atmospheric chain segment — after the booster separates, the remaining vessel orientation is visibly wrong.
 
-**Status:** Open — needs investigation of rotation handling around decouple events in the playback path
+**Fix:** Resolved by the v5 surface-relative rotation overhaul (`9775e8f`) and the orbital-frame rotation work (`c0a8ced`, `8c869a4`). Rotation is now stored as `srfRelRotation` (surface-relative) and reconstructed at playback via `bodyTransform.rotation * storedRot`. Old v4 recordings auto-migrated to v5 at flight-scene load. The rotation system was completely rewritten after this bug was filed — ghost rotation is correct regardless of staging/decouple events.
+
+**Status:** Fixed
 
 ## 21. Ghost build warning spam for snapshot-less recordings
 
@@ -190,7 +194,11 @@ During ghost visual builds, some parts log `Variant active-state fallback: no ac
 
 **Reproduction:** `dotnet test` (full suite) — fails ~50% of runs. `dotnet test --filter GetCommittedTechIds_MultipleMilestones` — always passes.
 
-**Status:** Open — needs investigation of shared state cleanup between tests
+**Root cause:** `ComputeStatsTests` and `SyntheticRecordingTests` called `MilestoneStore.ResetForTesting()` but were missing `[Collection("Sequential")]`. xUnit runs test classes without a collection attribute in parallel. When these classes ran in parallel with `CommittedActionTests`, they wiped the `MilestoneStore` mid-test.
+
+**Fix:** Added `[Collection("Sequential")]` to `ComputeStatsTests` and `SyntheticRecordingTests`. Verified 5 consecutive full-suite runs with 0 failures.
+
+**Status:** Fixed
 
 ## 26. EVA crew swap fails after merging from KSC
 

--- a/docs/dev/synthetic-recordings.md
+++ b/docs/dev/synthetic-recordings.md
@@ -131,11 +131,11 @@ Three builder classes in `Source/Parsek.Tests/Generators/`:
 
 ### RecordingBuilder
 
-Fluent API that produces a `ConfigNode("RECORDING")` matching `ParsekScenario.OnSave()` format exactly. Supports both v2 (inline) and external sidecar-file format (current `recordingFormatVersion = 4`) outputs.
+Fluent API that produces a `ConfigNode("RECORDING")` matching `ParsekScenario.OnSave()` format exactly. Supports both v2 (inline) and external sidecar-file format (current `recordingFormatVersion = 5`) outputs.
 
 ```csharp
 var rec = new RecordingBuilder("My Recording")
-    .WithDefaultRotation(0.33f, -0.63f, -0.63f, -0.33f)  // upright at KSC
+    .WithDefaultRotation(-0.7009714f, -0.09230039f, -0.09728389f, 0.7004681f)  // upright at KSC (v5, surface-relative)
     .AddPoint(127000, -0.0972, -74.5575, 77)
     .AddPoint(127010, -0.0972, -74.5575, 500)
     .AddOrbitSegment(129500, 132000, sma: 700000, ecc: 0.001, inc: 28.5)
@@ -153,7 +153,7 @@ rec.GetVesselSnapshot();     // vessel snapshot ConfigNode
 rec.GetGhostVisualSnapshot(); // ghost snapshot ConfigNode
 ```
 
-**WithDefaultRotation(x, y, z, w)** - sets a default rotation quaternion applied to all subsequent `AddPoint` calls that don't specify an explicit rotation. Use this for surface-aligned recordings (e.g. KSC upright ≈ 0.33, -0.63, -0.63, -0.33). Points with explicit non-identity rotation are unaffected.
+**WithDefaultRotation(x, y, z, w)** - sets a default rotation quaternion applied to all subsequent `AddPoint` calls that don't specify an explicit rotation. Use this for surface-aligned recordings (e.g. KSC upright v5 ≈ -0.7010, -0.0923, -0.0973, 0.7005). Points with explicit non-identity rotation are unaffected.
 
 **AddPoint** parameters: `(ut, lat, lon, alt, body, rotX/Y/Z/W, funds, science, rep)` - all optional after alt, defaults to Kerbin with identity rotation (or default rotation if set) and zero resources.
 

--- a/docs/parsek-architecture.md
+++ b/docs/parsek-architecture.md
@@ -831,7 +831,7 @@ Record entire multi-vessel missions as a single unit. Builds on top of the exist
 
 **Key design principle:** the tree is additive. Existing chains, per-segment loop control, per-recording resources, atmospheric/SOI phase splits, merge dialogs - all preserved. Nothing removed.
 
-**13 tasks completed.** 1076 tests pass. See `docs/dev/done/design-mission-tree.md` for full design, task breakdown, and progress tracker.
+**13 tasks completed.** 1342 tests pass. See `docs/dev/done/design-mission-tree.md` for full design, task breakdown, and progress tracker.
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -122,7 +122,7 @@ After rewind resource adjustment, `ActionReplay.ReplayCommittedActions` programm
 
 **Design:** `docs/dev/done/design-restore-points.md`, `docs/dev/done/design-going-back-in-time.md`
 
-**Test coverage:** 1263 tests.
+**Test coverage:** 1342 tests.
 
 ---
 
@@ -154,7 +154,7 @@ The recording tree builds on top of the existing chain system. Each node in the 
 | 12. Tree verbose logging | 11 logging gaps filled across RecordingTree, ParsekFlight, ResourceBudget. |
 | 13. Tree test coverage | 18 non-vacuous tests + 3 synthetic tree recordings for in-game validation. |
 
-**Test coverage:** 1263 tests.
+**Test coverage:** 1342 tests.
 
 ---
 


### PR DESCRIPTION
## Summary

- **#17 (reentry FX)** and **#20 (exo rotation after staging)**: marked as Fixed in known-bugs.md — both were resolved by prior PRs (reentry FX rework, v5 surface-relative rotation overhaul)
- **#25 (flaky test)**: `ComputeStatsTests` and `SyntheticRecordingTests` were missing `[Collection("Sequential")]` but called `MilestoneStore.ResetForTesting()`, causing parallel races with `CommittedActionTests`. Verified 5/5 clean full-suite runs.
- **#27 (StashPending overwrite)**: Added guard in `RecordingStore.StashPending` — if a pending already exists, unreserves its crew and calls `DiscardPending()` before creating the new one. Prevents silent data loss and crew reservation leaks.
- **Stale docs**: Updated test counts (1076/1263 → 1342) in roadmap, architecture doc, and Source/README. Fixed synthetic-recordings.md format version (v4 → v5) and rotation constants to match current v5 surface-relative values.

## Test plan

- [x] All 1342 tests pass (up from 1340, +2 new tests for #27)
- [x] 5 consecutive full-suite runs with 0 failures (verifies #25 fix)
- [x] In-game #27: disable auto-merge → launch vessel A → go to KSC (don't click dialog) → launch vessel B → F9 quickload → verify WARN log `StashPending: overwriting unresolved pending` and no stuck crew

🤖 Generated with [Claude Code](https://claude.com/claude-code)