### PR TITLE
Remove Take Control feature

### DIFF
--- a/Source/Parsek.Tests/RewindTests.cs
+++ b/Source/Parsek.Tests/RewindTests.cs
@@ -73,7 +73,7 @@ namespace Parsek.Tests
                 SpawnAttempts = 3,
                 SpawnedVesselPersistentId = 42,
                 LastAppliedResourceIndex = 5,
-                TakenControl = true,
+
                 SceneExitSituation = 4
             };
             rec.Points.Add(new TrajectoryPoint { ut = 100 });
@@ -88,7 +88,7 @@ namespace Parsek.Tests
             Assert.Equal(0, rec.SpawnAttempts);
             Assert.Equal(0u, rec.SpawnedVesselPersistentId);
             Assert.Equal(-1, rec.LastAppliedResourceIndex);
-            Assert.False(rec.TakenControl);
+
             Assert.Equal(-1, rec.SceneExitSituation);
         }
 

--- a/Source/Parsek.Tests/TreeCommitTests.cs
+++ b/Source/Parsek.Tests/TreeCommitTests.cs
@@ -409,7 +409,6 @@ namespace Parsek.Tests
             var rec = MakeRecording("r1", "t1");
             rec.SpawnedVesselPersistentId = 42;
             rec.VesselDestroyed = true;
-            rec.TakenControl = true;
             rec.LastAppliedResourceIndex = 7;
             rec.Points.Add(new TrajectoryPoint
             {
@@ -427,7 +426,7 @@ namespace Parsek.Tests
 
             Assert.Equal("42", node.GetValue("spawnedPid"));
             Assert.Equal("True", node.GetValue("vesselDestroyed"));
-            Assert.Equal("True", node.GetValue("takenControl"));
+
             Assert.Equal("7", node.GetValue("lastResIdx"));
             Assert.Equal("2", node.GetValue("pointCount"));
         }
@@ -441,7 +440,7 @@ namespace Parsek.Tests
             node.AddValue("vesselPersistentId", "100");
             node.AddValue("spawnedPid", "42");
             node.AddValue("vesselDestroyed", "True");
-            node.AddValue("takenControl", "True");
+
             node.AddValue("lastResIdx", "7");
             node.AddValue("pointCount", "10");
             node.AddValue("recordingFormatVersion", "4");
@@ -457,7 +456,6 @@ namespace Parsek.Tests
 
             Assert.Equal(42u, rec.SpawnedVesselPersistentId);
             Assert.True(rec.VesselDestroyed);
-            Assert.True(rec.TakenControl);
             Assert.Equal(7, rec.LastAppliedResourceIndex);
         }
 
@@ -468,7 +466,7 @@ namespace Parsek.Tests
             tree.Recordings["child1"].TerminalStateValue = TerminalState.Orbiting;
             tree.Recordings["child1"].SpawnedVesselPersistentId = 55555;
             tree.Recordings["child1"].VesselDestroyed = false;
-            tree.Recordings["child1"].TakenControl = true;
+
             tree.Recordings["child1"].LastAppliedResourceIndex = 12;
             tree.Recordings["child2"].TerminalStateValue = TerminalState.Landed;
             tree.Recordings["child2"].SpawnedVesselPersistentId = 66666;
@@ -483,11 +481,11 @@ namespace Parsek.Tests
 
             // Verify mutable state round-tripped
             Assert.Equal(55555u, restored.Recordings["child1"].SpawnedVesselPersistentId);
-            Assert.True(restored.Recordings["child1"].TakenControl);
+
             Assert.Equal(12, restored.Recordings["child1"].LastAppliedResourceIndex);
 
             Assert.Equal(66666u, restored.Recordings["child2"].SpawnedVesselPersistentId);
-            Assert.False(restored.Recordings["child2"].TakenControl);
+
             Assert.Equal(5, restored.Recordings["child2"].LastAppliedResourceIndex);
         }
 

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -4413,7 +4413,7 @@ namespace Parsek
                 bool isMidChain = RecordingStore.IsChainMidSegment(rec);
                 double chainEndUT = isMidChain ? RecordingStore.GetChainEndUT(rec) : rec.EndUT;
                 bool pastChainEnd = currentUT > chainEndUT;
-                bool needsSpawn = rec.VesselSnapshot != null && !rec.VesselSpawned && !rec.VesselDestroyed && !rec.TakenControl;
+                bool needsSpawn = rec.VesselSnapshot != null && !rec.VesselSpawned && !rec.VesselDestroyed;
 
                 // Branch > 0 recordings are ghost-only (undock continuations) — never spawn
                 if (needsSpawn && rec.ChainBranch > 0)
@@ -4476,14 +4476,6 @@ namespace Parsek
                     rec.VesselSpawned = true;
                     needsSpawn = false;
                     Log($"Vessel already spawned (pid={rec.SpawnedVesselPersistentId}) — skipping duplicate spawn for recording #{i}");
-                }
-
-                // Skip ghost playback entirely for recordings where player took control
-                if (rec.TakenControl)
-                {
-                    if (ghostActive)
-                        DestroyTimelineGhost(i);
-                    continue;
                 }
 
                 if (inRange)
@@ -7259,10 +7251,6 @@ namespace Parsek
             string ghostBody = gs.lastInterpolatedBodyName;
             string activeBody = FlightGlobals.ActiveVessel?.mainBody?.name;
             if (string.IsNullOrEmpty(ghostBody) || string.IsNullOrEmpty(activeBody) || ghostBody != activeBody)
-                return;
-
-            // Cannot enter watch mode for a taken-control recording
-            if (committed[index].TakenControl)
                 return;
 
             // Flight warning: if active vessel is in an unsafe state, show a brief screen message

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -116,9 +116,6 @@ namespace Parsek
                 if (rec.VesselDestroyed)
                     recNode.AddValue("vesselDestroyed", rec.VesselDestroyed.ToString());
 
-                if (rec.TakenControl)
-                    recNode.AddValue("takenControl", rec.TakenControl.ToString());
-
                 // Persist terminal state + vessel PID for standalone recordings
                 if (rec.TerminalStateValue.HasValue)
                     recNode.AddValue("terminalState", ((int)rec.TerminalStateValue.Value).ToString(CultureInfo.InvariantCulture));
@@ -414,7 +411,7 @@ namespace Parsek
                     $"memoryRecordings={recordings.Count}, isRevert={isRevert}");
 
                 // Restore mutable state from save. On revert the launch quicksave has
-                // no spawnedPid / takenControl / lastResIdx, so they naturally reset.
+                // no spawnedPid / lastResIdx, so they naturally reset.
                 // On non-revert scene changes (e.g. tracking station → flight) the
                 // save preserves these, preventing duplicate spawns and ghost replays.
                 // NOTE: This loop only covers standalone recordings (not tree recordings).
@@ -438,7 +435,6 @@ namespace Parsek
                     recordings[i].SpawnAttempts = 0;
 
                     uint savedPid = 0;
-                    bool savedTaken = false;
                     int resIdx = -1;
                     ConfigNode savedNode;
                     if (recordings[i].RecordingId != null && savedRecById.TryGetValue(recordings[i].RecordingId, out savedNode))
@@ -446,10 +442,6 @@ namespace Parsek
                         string pidStr = savedNode.GetValue("spawnedPid");
                         if (pidStr != null && !uint.TryParse(pidStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out savedPid))
                             ParsekLog.Warn("Scenario", $"Failed to parse spawnedPid '{pidStr}' for recording #{i}");
-
-                        string takenStr = savedNode.GetValue("takenControl");
-                        if (takenStr != null && !bool.TryParse(takenStr, out savedTaken))
-                            ParsekLog.Warn("Scenario", $"Failed to parse takenControl '{takenStr}' for recording #{i}");
 
                         string resIdxStr = savedNode.GetValue("lastResIdx");
                         if (resIdxStr != null && !int.TryParse(resIdxStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out resIdx))
@@ -472,7 +464,6 @@ namespace Parsek
                             $"(id={recordings[i].RecordingId ?? "null"}) — using defaults");
                     }
                     recordings[i].SpawnedVesselPersistentId = savedPid;
-                    recordings[i].TakenControl = savedTaken;
                     recordings[i].LastAppliedResourceIndex = resIdx;
                 }
 
@@ -488,7 +479,7 @@ namespace Parsek
                     recordings[i].VesselSpawned = false;
                     recordings[i].SpawnAttempts = 0;
                     recordings[i].SpawnedVesselPersistentId = 0;
-                    recordings[i].TakenControl = false;
+
                     recordings[i].LastAppliedResourceIndex = -1;
                 }
 
@@ -515,12 +506,6 @@ namespace Parsek
                                     if (pidStr != null)
                                         uint.TryParse(pidStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out savedPid);
                                     recordings[i].SpawnedVesselPersistentId = savedPid;
-
-                                    string takenStr = savedTreeRecNode.GetValue("takenControl");
-                                    bool savedTaken = false;
-                                    if (takenStr != null)
-                                        bool.TryParse(takenStr, out savedTaken);
-                                    recordings[i].TakenControl = savedTaken;
 
                                     string resIdxStr = savedTreeRecNode.GetValue("lastResIdx");
                                     int resIdx = -1;
@@ -675,15 +660,6 @@ namespace Parsek
                     bool destroyed;
                     if (bool.TryParse(destroyedStr, out destroyed))
                         rec.VesselDestroyed = destroyed;
-                }
-
-                // Restore taken control flag
-                string takenStr = recNode.GetValue("takenControl");
-                if (takenStr != null)
-                {
-                    bool taken;
-                    if (bool.TryParse(takenStr, out taken))
-                        rec.TakenControl = taken;
                 }
 
                 // Restore terminal state + vessel PID for standalone recordings

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -1169,7 +1169,7 @@ namespace Parsek
                 bool hasGhost = flight.HasActiveGhost(ri);
                 bool sameBody = flight.IsGhostOnSameBody(ri);
                 bool isWatching = flight.WatchedRecordingIndex == ri;
-                bool canWatch = hasGhost && sameBody && !committed[ri].TakenControl;
+                bool canWatch = hasGhost && sameBody;
 
                 GUI.enabled = canWatch;
                 string watchLabel = isWatching ? "W*" : "W";

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -161,7 +161,7 @@ namespace Parsek
             public string VesselSituation;          // "Orbiting Kerbin", "Landed on Mun", etc.
             public double MaxDistanceFromLaunch;     // Peak distance reached during recording
             public bool VesselSpawned;              // True after deferred RespawnVessel has fired
-            public bool TakenControl;               // True after player took control of ghost mid-playback
+
             public uint SpawnedVesselPersistentId;  // persistentId of spawned vessel (0 = not yet spawned)
             public int SpawnAttempts;               // Number of failed spawn attempts (give up after 3)
             public int SceneExitSituation = -1;     // Vessel.Situations at scene exit (-1 = still in flight/unknown)
@@ -1018,7 +1018,7 @@ namespace Parsek
             rec.SpawnAttempts = 0;
             rec.SpawnedVesselPersistentId = 0;
             rec.LastAppliedResourceIndex = -1;
-            rec.TakenControl = false;
+
             rec.SceneExitSituation = -1;
         }
 

--- a/Source/Parsek/RecordingTree.cs
+++ b/Source/Parsek/RecordingTree.cs
@@ -249,8 +249,6 @@ namespace Parsek
                 recNode.AddValue("spawnedPid", rec.SpawnedVesselPersistentId);
             if (rec.VesselDestroyed)
                 recNode.AddValue("vesselDestroyed", rec.VesselDestroyed.ToString());
-            if (rec.TakenControl)
-                recNode.AddValue("takenControl", rec.TakenControl.ToString());
             recNode.AddValue("lastResIdx", rec.LastAppliedResourceIndex);
             recNode.AddValue("pointCount", rec.Points != null ? rec.Points.Count : 0);
         }
@@ -467,13 +465,6 @@ namespace Parsek
                 bool destroyed;
                 if (bool.TryParse(destroyedStr, out destroyed))
                     rec.VesselDestroyed = destroyed;
-            }
-            string takenStr = recNode.GetValue("takenControl");
-            if (takenStr != null)
-            {
-                bool taken;
-                if (bool.TryParse(takenStr, out taken))
-                    rec.TakenControl = taken;
             }
             string resIdxStr = recNode.GetValue("lastResIdx");
             if (resIdxStr != null)

--- a/docs/parsek-architecture.md
+++ b/docs/parsek-architecture.md
@@ -52,7 +52,7 @@
 │                                                                  │
 │  ┌─────────────┐  ┌─────────────┐  ┌─────────────────────────┐ │
 │  │  Recording  │  │  Timeline   │  │  Playback Controls      │ │
-│  │  Controls   │  │  Viewer     │  │  (take control, etc.)   │ │
+│  │  Controls   │  │  Viewer     │  │  (watch, loop, etc.)   │ │
 │  └─────────────┘  └─────────────┘  └─────────────────────────┘ │
 │                                                                  │
 └──────────────────────────────────────────────────────────────────┘
@@ -412,8 +412,6 @@ public class PlaybackVessel
     // Vessel reference (when spawned)
     public Vessel KSPVessel { get; }
     
-    // Control
-    public void TakeControl();  // Player assumes control
 }
 ```
 
@@ -629,7 +627,7 @@ Summary of the recording strategy derived from mod analysis:
 │ Status: In transit              │
 │ Next event: SOI change (D182)   │
 │                                 │
-│ [Take Control] [Warp to Event]  │
+│ [Watch] [Warp to Event]         │
 └─────────────────────────────────┘
 ```
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -160,11 +160,6 @@ The recording tree builds on top of the existing chain system. Each node in the 
 
 ## Future
 
-### Take Control stabilization
-Making "jump into a ghost and fly it" reliable is desirable but creates paradox problems: what happens to the recording's future events, reserved crew, and applied resource deltas? Each answer requires hard restrictions that may frustrate players. This needs careful design and should not be rushed.
-
-Current status: experimental button exists in UI, not recommended for normal play.
-
 ### Planetarium.right drift compensation for long orbital segments
 KSP's inertial reference frame (`Planetarium.right`) may drift over very long time warp durations. This could cause ghost orientation mismatch for interplanetary transfer segments. Needs empirical measurement first — if drift is sub-degree for typical segment lengths, no fix needed. If significant, store `Planetarium.right` snapshot at recording time and apply correction at playback (~10 lines + 3 ConfigNode keys). See `docs/dev/done/design-orbital-rotation.md` Phase 6.
 
@@ -183,5 +178,6 @@ If the game crashes or the player alt-F4s while a merge dialog is pending, the r
 - **Racing modes or lap timing**
 - **AI playback or autopilot**
 - **Multiplayer synchronization**
+- **Taking control of recorded vessels** - jumping into a ghost mid-playback creates unresolvable paradoxes (recording future events, reserved crew, applied resource deltas). The complexity is not worth the payoff.
 - **Timeline branching or alternate histories**
 - **Logistics network** - Parsek's recording infrastructure (looped playback, chain segments, vessel snapshots, game state events, resource tracking) forms a natural foundation for automated supply routes between bases. The concept: fly a cargo mission once, Parsek records it, then that recording becomes a reusable logistics route that periodically deducts fuel at the origin and delivers cargo at the destination, with the ghost replaying visually during transit. This will be built as a separate mod on top of Parsek rather than integrated directly. See `docs/dev/research/logistics-network-design.md` for the full design exploration.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -67,17 +67,6 @@ After merging, wait on the pad (or time warp) until UT reaches the recording's t
 
 When you choose "Merge to Timeline", the recorded crew (e.g. Jeb) are reserved for the deferred vessel spawn. A replacement kerbal with the same trait is hired automatically so your available crew pool stays the same size. When the vessel spawns at EndUT, the original crew board it and the replacement is removed.
 
-### Take Control (Experimental)
-
-Take Control is available in the UI but is experimental and not recommended for normal play. Taking control of a ghost creates paradoxes - what happens to the recording's remaining events, reserved crew, and already-applied resource deltas? Resolving these cleanly requires restrictions that are not yet implemented.
-
-Current behavior:
-1. Open the Parsek window (toolbar button)
-2. Click "Take Control" next to an active ghost
-3. Parsek attempts to replace the ghost with a real vessel at the ghost's current position/velocity
-
-Use the normal EndUT vessel spawn flow for reliable timeline progression.
-
 ### Preview Playback
 
 You can preview a recording without reverting:


### PR DESCRIPTION
## Summary

- Remove the `TakenControl` field from `Recording` struct and all serialization/deserialization
- Remove guard checks in playback loop, vessel spawn, watch mode, and UI
- Remove "Take Control (Experimental)" section from user guide
- Move Take Control to Out of Scope in roadmap
- Update architecture doc mockups
- Update tests (RewindTests, TreeCommitTests)

The `TakeControlOfGhost` method was already removed previously. This cleans up the remaining dead field, serialization paths, guard conditions, and documentation.

Old saves with `takenControl` keys are harmless — the keys are simply ignored on load.

## Test plan

- [x] Build: 0 errors, 0 warnings
- [x] Tests: 1342 passed (1 pre-existing InjectAllRecordings skip)
- [x] No `TakenControl` references remain in source

🤖 Generated with [Claude Code](https://claude.com/claude-code)