### PR TITLE
Add player-created recording groups with nesting

### DIFF
--- a/Source/Parsek.Tests/Generators/RecordingBuilder.cs
+++ b/Source/Parsek.Tests/Generators/RecordingBuilder.cs
@@ -24,7 +24,7 @@ namespace Parsek.Tests.Generators
         private string segmentPhase;
         private string segmentBodyName;
         private bool playbackEnabled = true;
-        private string recordingGroup;
+        private List<string> recordingGroups = new List<string>();
         private string rewindSaveFileName;
         private double rewindReservedFunds;
         private double rewindReservedScience;
@@ -233,7 +233,8 @@ namespace Parsek.Tests.Generators
 
         public RecordingBuilder WithRecordingGroup(string group)
         {
-            recordingGroup = group;
+            if (!recordingGroups.Contains(group))
+                recordingGroups.Add(group);
             return this;
         }
 
@@ -324,9 +325,9 @@ namespace Parsek.Tests.Generators
 
             node.AddValue("lastResIdx", lastResIdx);
 
-            // Atmosphere segment metadata
-            if (!string.IsNullOrEmpty(recordingGroup))
-                node.AddValue("recordingGroup", recordingGroup);
+            // UI grouping tags (multi-group membership)
+            for (int g = 0; g < recordingGroups.Count; g++)
+                node.AddValue("recordingGroup", recordingGroups[g]);
             if (!string.IsNullOrEmpty(segmentPhase))
                 node.AddValue("segmentPhase", segmentPhase);
             if (!string.IsNullOrEmpty(segmentBodyName))

--- a/Source/Parsek.Tests/GroupManagementTests.cs
+++ b/Source/Parsek.Tests/GroupManagementTests.cs
@@ -1,0 +1,660 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    [Collection("Sequential")]
+    public class GroupManagementTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public GroupManagementTests()
+        {
+            RecordingStore.SuppressLogging = false;
+            RecordingStore.ResetForTesting();
+            MilestoneStore.SuppressLogging = true;
+            MilestoneStore.ResetForTesting();
+            GameStateStore.SuppressLogging = true;
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+            ParsekScenario.ResetGroupsForTesting();
+            ParsekScenario.ResetReplacementsForTesting();
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+            RecordingStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+            ParsekScenario.ResetGroupsForTesting();
+            ParsekScenario.ResetReplacementsForTesting();
+        }
+
+        // ─── IsAncestorOrSelf ──────────────────────────────────────────────
+
+        [Fact]
+        public void IsAncestorOrSelf_DirectParent_ReturnsTrue()
+        {
+            ParsekScenario.groupParents["Child"] = "Parent";
+
+            Assert.True(ParsekScenario.IsAncestorOrSelf("Child", "Parent"));
+        }
+
+        [Fact]
+        public void IsAncestorOrSelf_Grandparent_ReturnsTrue()
+        {
+            ParsekScenario.groupParents["C"] = "B";
+            ParsekScenario.groupParents["B"] = "A";
+
+            Assert.True(ParsekScenario.IsAncestorOrSelf("C", "A"));
+        }
+
+        [Fact]
+        public void IsAncestorOrSelf_Self_ReturnsTrue()
+        {
+            Assert.True(ParsekScenario.IsAncestorOrSelf("X", "X"));
+        }
+
+        [Fact]
+        public void IsAncestorOrSelf_Unrelated_ReturnsFalse()
+        {
+            ParsekScenario.groupParents["A"] = "Root";
+            ParsekScenario.groupParents["B"] = "Root";
+
+            Assert.False(ParsekScenario.IsAncestorOrSelf("A", "B"));
+        }
+
+        [Fact]
+        public void IsAncestorOrSelf_EmptyGroupParents_ReturnsFalse()
+        {
+            // groupParents is empty after ResetGroupsForTesting
+            Assert.False(ParsekScenario.IsAncestorOrSelf("Alpha", "Beta"));
+        }
+
+        [Fact]
+        public void IsAncestorOrSelf_MaxDepthGuard_DoesNotHang()
+        {
+            // Build a chain of 150 groups — exceeds the 100-depth guard
+            for (int i = 0; i < 150; i++)
+                ParsekScenario.groupParents[$"G{i + 1}"] = $"G{i}";
+
+            // Should hit max depth and return true (assumes cycle)
+            bool result = ParsekScenario.IsAncestorOrSelf("G150", "G0");
+            Assert.True(result);
+            Assert.Contains(logLines, l => l.Contains("max depth reached"));
+        }
+
+        [Fact]
+        public void IsAncestorOrSelf_NullGroup_ReturnsFalse()
+        {
+            Assert.False(ParsekScenario.IsAncestorOrSelf(null, "A"));
+        }
+
+        [Fact]
+        public void IsAncestorOrSelf_NullCandidate_ReturnsFalse()
+        {
+            Assert.False(ParsekScenario.IsAncestorOrSelf("A", null));
+        }
+
+        // ─── SetGroupParent ────────────────────────────────────────────────
+
+        [Fact]
+        public void SetGroupParent_NormalAssignment_ReturnsTrue()
+        {
+            bool result = ParsekScenario.SetGroupParent("Child", "Parent");
+
+            Assert.True(result);
+            Assert.True(ParsekScenario.groupParents.ContainsKey("Child"));
+            Assert.Contains(logLines, l => l.Contains("assigned to parent group"));
+        }
+
+        [Fact]
+        public void SetGroupParent_NullParent_RemovesFromHierarchy()
+        {
+            ParsekScenario.groupParents["Child"] = "Parent";
+
+            bool result = ParsekScenario.SetGroupParent("Child", null);
+
+            Assert.True(result);
+            Assert.False(ParsekScenario.groupParents.ContainsKey("Child"));
+            Assert.Contains(logLines, l => l.Contains("moved to root level"));
+        }
+
+        [Fact]
+        public void SetGroupParent_CycleDetection_ReturnsFalse()
+        {
+            ParsekScenario.SetGroupParent("B", "A");
+
+            bool result = ParsekScenario.SetGroupParent("A", "B");
+
+            Assert.False(result);
+            Assert.Contains(logLines, l => l.Contains("would create cycle"));
+        }
+
+        [Fact]
+        public void SetGroupParent_SelfAssignment_ReturnsFalse()
+        {
+            bool result = ParsekScenario.SetGroupParent("X", "X");
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void SetGroupParent_EmptyChild_ReturnsFalse()
+        {
+            bool result = ParsekScenario.SetGroupParent("", "Parent");
+
+            Assert.False(result);
+        }
+
+        // ─── RemoveGroupFromHierarchy ──────────────────────────────────────
+
+        [Fact]
+        public void RemoveGroupFromHierarchy_RemovesGroup_PromotesChildren()
+        {
+            ParsekScenario.groupParents["Child1"] = "Middle";
+            ParsekScenario.groupParents["Child2"] = "Middle";
+            ParsekScenario.groupParents["Middle"] = "Root";
+
+            ParsekScenario.RemoveGroupFromHierarchy("Middle");
+
+            // Middle should be gone as child and as parent
+            Assert.False(ParsekScenario.groupParents.ContainsKey("Middle"));
+            Assert.False(ParsekScenario.groupParents.ContainsKey("Child1"));
+            Assert.False(ParsekScenario.groupParents.ContainsKey("Child2"));
+        }
+
+        [Fact]
+        public void RemoveGroupFromHierarchy_LogsPromotedCount()
+        {
+            ParsekScenario.groupParents["Sub1"] = "Parent";
+            ParsekScenario.groupParents["Sub2"] = "Parent";
+            ParsekScenario.groupParents["Sub3"] = "Parent";
+
+            ParsekScenario.RemoveGroupFromHierarchy("Parent");
+
+            Assert.Contains(logLines, l =>
+                l.Contains("removed from hierarchy") && l.Contains("3 sub-groups promoted to root"));
+        }
+
+        [Fact]
+        public void RemoveGroupFromHierarchy_NoChildren_LogsZeroPromoted()
+        {
+            ParsekScenario.groupParents["Leaf"] = "Root";
+
+            ParsekScenario.RemoveGroupFromHierarchy("Leaf");
+
+            Assert.Contains(logLines, l =>
+                l.Contains("removed from hierarchy") && l.Contains("0 sub-groups promoted to root"));
+        }
+
+        // ─── GetDescendantGroups ───────────────────────────────────────────
+
+        [Fact]
+        public void GetDescendantGroups_SingleLevel_ReturnsChildren()
+        {
+            ParsekScenario.groupParents["Child1"] = "Root";
+            ParsekScenario.groupParents["Child2"] = "Root";
+
+            var descendants = ParsekScenario.GetDescendantGroups("Root");
+
+            Assert.True(descendants.Count == 2);
+            Assert.Contains("Child1", descendants);
+            Assert.Contains("Child2", descendants);
+        }
+
+        [Fact]
+        public void GetDescendantGroups_MultiLevel_ReturnsGrandchildren()
+        {
+            ParsekScenario.groupParents["B"] = "A";
+            ParsekScenario.groupParents["C"] = "B";
+
+            var descendants = ParsekScenario.GetDescendantGroups("A");
+
+            Assert.True(descendants.Count == 2);
+            Assert.Contains("B", descendants);
+            Assert.Contains("C", descendants);
+        }
+
+        [Fact]
+        public void GetDescendantGroups_NoDescendants_ReturnsEmptyList()
+        {
+            ParsekScenario.groupParents["Leaf"] = "Root";
+
+            var descendants = ParsekScenario.GetDescendantGroups("Leaf");
+
+            Assert.True(descendants.Count == 0);
+        }
+
+        [Fact]
+        public void GetDescendantGroups_NullGroup_ReturnsEmptyList()
+        {
+            var descendants = ParsekScenario.GetDescendantGroups(null);
+
+            Assert.True(descendants.Count == 0);
+        }
+
+        // ─── RenameGroupInHierarchy ────────────────────────────────────────
+
+        [Fact]
+        public void RenameGroupInHierarchy_UpdatesAsChild()
+        {
+            ParsekScenario.groupParents["OldName"] = "Parent";
+
+            ParsekScenario.RenameGroupInHierarchy("OldName", "NewName");
+
+            Assert.False(ParsekScenario.groupParents.ContainsKey("OldName"));
+            Assert.True(ParsekScenario.groupParents.ContainsKey("NewName"));
+            Assert.Contains(logLines, l => l.Contains("RenameGroupInHierarchy"));
+        }
+
+        [Fact]
+        public void RenameGroupInHierarchy_UpdatesAsParent()
+        {
+            ParsekScenario.groupParents["Child"] = "OldParent";
+
+            ParsekScenario.RenameGroupInHierarchy("OldParent", "NewParent");
+
+            Assert.True(ParsekScenario.groupParents.ContainsKey("Child"));
+            string parentVal;
+            ParsekScenario.groupParents.TryGetValue("Child", out parentVal);
+            Assert.Equal("NewParent", parentVal);
+        }
+
+        [Fact]
+        public void RenameGroupInHierarchy_BothKeyAndValue()
+        {
+            // "Mid" is both a child of "Top" and a parent of "Bottom"
+            ParsekScenario.groupParents["Mid"] = "Top";
+            ParsekScenario.groupParents["Bottom"] = "Mid";
+
+            ParsekScenario.RenameGroupInHierarchy("Mid", "Middle");
+
+            Assert.False(ParsekScenario.groupParents.ContainsKey("Mid"));
+            Assert.True(ParsekScenario.groupParents.ContainsKey("Middle"));
+            string topParent;
+            ParsekScenario.groupParents.TryGetValue("Middle", out topParent);
+            Assert.Equal("Top", topParent);
+            string bottomParent;
+            ParsekScenario.groupParents.TryGetValue("Bottom", out bottomParent);
+            Assert.Equal("Middle", bottomParent);
+        }
+
+        [Fact]
+        public void RenameGroupInHierarchy_SameName_NoOp()
+        {
+            ParsekScenario.groupParents["X"] = "Root";
+
+            ParsekScenario.RenameGroupInHierarchy("X", "X");
+
+            // No log emitted since it's a no-op
+            Assert.DoesNotContain(logLines, l => l.Contains("RenameGroupInHierarchy"));
+        }
+
+        // ─── RecordingStore.AddRecordingToGroup / RemoveRecordingFromGroup ─
+
+        [Fact]
+        public void AddRecordingToGroup_CreatesListIfNull()
+        {
+            RecordingStore.CommittedRecordings.Add(new RecordingStore.Recording
+            {
+                VesselName = "TestVessel",
+                RecordingGroups = null
+            });
+
+            RecordingStore.AddRecordingToGroup(0, "MyGroup");
+
+            var rec = RecordingStore.CommittedRecordings[0];
+            Assert.NotNull(rec.RecordingGroups);
+            Assert.Contains("MyGroup", rec.RecordingGroups);
+            Assert.Contains(logLines, l => l.Contains("added to group"));
+        }
+
+        [Fact]
+        public void AddRecordingToGroup_Idempotent_NoDuplicates()
+        {
+            RecordingStore.CommittedRecordings.Add(new RecordingStore.Recording
+            {
+                VesselName = "TestVessel",
+                RecordingGroups = null
+            });
+
+            RecordingStore.AddRecordingToGroup(0, "MyGroup");
+            RecordingStore.AddRecordingToGroup(0, "MyGroup");
+
+            var rec = RecordingStore.CommittedRecordings[0];
+            Assert.True(rec.RecordingGroups.Count == 1);
+        }
+
+        [Fact]
+        public void RemoveRecordingFromGroup_CleansUpEmptyListToNull()
+        {
+            RecordingStore.CommittedRecordings.Add(new RecordingStore.Recording
+            {
+                VesselName = "TestVessel",
+                RecordingGroups = new List<string> { "OnlyGroup" }
+            });
+
+            RecordingStore.RemoveRecordingFromGroup(0, "OnlyGroup");
+
+            var rec = RecordingStore.CommittedRecordings[0];
+            Assert.Null(rec.RecordingGroups);
+            Assert.Contains(logLines, l => l.Contains("removed from group"));
+        }
+
+        [Fact]
+        public void RemoveRecordingFromGroup_Idempotent_NoErrorIfNotMember()
+        {
+            RecordingStore.CommittedRecordings.Add(new RecordingStore.Recording
+            {
+                VesselName = "TestVessel",
+                RecordingGroups = new List<string> { "GroupA" }
+            });
+
+            // Removing a group the recording doesn't belong to — should be a no-op
+            RecordingStore.RemoveRecordingFromGroup(0, "NonExistent");
+
+            var rec = RecordingStore.CommittedRecordings[0];
+            Assert.NotNull(rec.RecordingGroups);
+            Assert.True(rec.RecordingGroups.Count == 1);
+            Assert.Contains("GroupA", rec.RecordingGroups);
+        }
+
+        [Fact]
+        public void RemoveRecordingFromGroup_NullGroups_NoError()
+        {
+            RecordingStore.CommittedRecordings.Add(new RecordingStore.Recording
+            {
+                VesselName = "TestVessel",
+                RecordingGroups = null
+            });
+
+            // Should not throw
+            RecordingStore.RemoveRecordingFromGroup(0, "Anything");
+
+            Assert.Null(RecordingStore.CommittedRecordings[0].RecordingGroups);
+        }
+
+        // ─── RecordingStore.AddChainToGroup / RemoveChainFromGroup ─────────
+
+        [Fact]
+        public void AddChainToGroup_AddsToAllChainMembers()
+        {
+            RecordingStore.CommittedRecordings.Add(new RecordingStore.Recording
+            {
+                VesselName = "Seg0", ChainId = "chain-1", RecordingGroups = null
+            });
+            RecordingStore.CommittedRecordings.Add(new RecordingStore.Recording
+            {
+                VesselName = "Seg1", ChainId = "chain-1", RecordingGroups = null
+            });
+            RecordingStore.CommittedRecordings.Add(new RecordingStore.Recording
+            {
+                VesselName = "Other", ChainId = null, RecordingGroups = null
+            });
+
+            RecordingStore.AddChainToGroup("chain-1", "Flights");
+
+            Assert.Contains("Flights", RecordingStore.CommittedRecordings[0].RecordingGroups);
+            Assert.Contains("Flights", RecordingStore.CommittedRecordings[1].RecordingGroups);
+            Assert.Null(RecordingStore.CommittedRecordings[2].RecordingGroups);
+            Assert.Contains(logLines, l => l.Contains("2 members added to group"));
+        }
+
+        [Fact]
+        public void AddChainToGroup_OnlyAffectsMatchingChain()
+        {
+            RecordingStore.CommittedRecordings.Add(new RecordingStore.Recording
+            {
+                VesselName = "A0", ChainId = "chain-a", RecordingGroups = null
+            });
+            RecordingStore.CommittedRecordings.Add(new RecordingStore.Recording
+            {
+                VesselName = "B0", ChainId = "chain-b", RecordingGroups = null
+            });
+
+            RecordingStore.AddChainToGroup("chain-a", "GroupX");
+
+            Assert.Contains("GroupX", RecordingStore.CommittedRecordings[0].RecordingGroups);
+            Assert.Null(RecordingStore.CommittedRecordings[1].RecordingGroups);
+        }
+
+        [Fact]
+        public void RemoveChainFromGroup_RemovesFromAllChainMembers()
+        {
+            RecordingStore.CommittedRecordings.Add(new RecordingStore.Recording
+            {
+                VesselName = "Seg0", ChainId = "chain-1",
+                RecordingGroups = new List<string> { "Flights" }
+            });
+            RecordingStore.CommittedRecordings.Add(new RecordingStore.Recording
+            {
+                VesselName = "Seg1", ChainId = "chain-1",
+                RecordingGroups = new List<string> { "Flights" }
+            });
+            RecordingStore.CommittedRecordings.Add(new RecordingStore.Recording
+            {
+                VesselName = "Other", ChainId = null,
+                RecordingGroups = new List<string> { "Flights" }
+            });
+
+            RecordingStore.RemoveChainFromGroup("chain-1", "Flights");
+
+            // Chain members should have group removed (and list set to null since empty)
+            Assert.Null(RecordingStore.CommittedRecordings[0].RecordingGroups);
+            Assert.Null(RecordingStore.CommittedRecordings[1].RecordingGroups);
+            // Non-chain member should keep its group
+            Assert.Contains("Flights", RecordingStore.CommittedRecordings[2].RecordingGroups);
+            Assert.Contains(logLines, l => l.Contains("2 members removed from group"));
+        }
+
+        [Fact]
+        public void RemoveChainFromGroup_OnlyAffectsMatchingChain()
+        {
+            RecordingStore.CommittedRecordings.Add(new RecordingStore.Recording
+            {
+                VesselName = "A0", ChainId = "chain-a",
+                RecordingGroups = new List<string> { "SharedGroup" }
+            });
+            RecordingStore.CommittedRecordings.Add(new RecordingStore.Recording
+            {
+                VesselName = "B0", ChainId = "chain-b",
+                RecordingGroups = new List<string> { "SharedGroup" }
+            });
+
+            RecordingStore.RemoveChainFromGroup("chain-a", "SharedGroup");
+
+            Assert.Null(RecordingStore.CommittedRecordings[0].RecordingGroups);
+            Assert.Contains("SharedGroup", RecordingStore.CommittedRecordings[1].RecordingGroups);
+        }
+
+        // ─── RecordingStore.RenameGroup ────────────────────────────────────
+
+        [Fact]
+        public void RenameGroup_RenamesInAllRecordingGroupLists()
+        {
+            RecordingStore.CommittedRecordings.Add(new RecordingStore.Recording
+            {
+                VesselName = "Vessel1",
+                RecordingGroups = new List<string> { "OldName" }
+            });
+            RecordingStore.CommittedRecordings.Add(new RecordingStore.Recording
+            {
+                VesselName = "Vessel2",
+                RecordingGroups = new List<string> { "OldName" }
+            });
+
+            bool result = RecordingStore.RenameGroup("OldName", "NewName");
+
+            Assert.True(result);
+            Assert.Contains("NewName", RecordingStore.CommittedRecordings[0].RecordingGroups);
+            Assert.Contains("NewName", RecordingStore.CommittedRecordings[1].RecordingGroups);
+            Assert.DoesNotContain("OldName", RecordingStore.CommittedRecordings[0].RecordingGroups);
+            Assert.Contains(logLines, l =>
+                l.Contains("RenameGroup") && l.Contains("2 recordings updated"));
+        }
+
+        [Fact]
+        public void RenameGroup_ReturnsFalseOnCollision()
+        {
+            RecordingStore.CommittedRecordings.Add(new RecordingStore.Recording
+            {
+                VesselName = "Vessel1",
+                RecordingGroups = new List<string> { "GroupA" }
+            });
+            RecordingStore.CommittedRecordings.Add(new RecordingStore.Recording
+            {
+                VesselName = "Vessel2",
+                RecordingGroups = new List<string> { "GroupB" }
+            });
+
+            bool result = RecordingStore.RenameGroup("GroupA", "GroupB");
+
+            Assert.False(result);
+            // Original names should be unchanged
+            Assert.Contains("GroupA", RecordingStore.CommittedRecordings[0].RecordingGroups);
+            Assert.Contains("GroupB", RecordingStore.CommittedRecordings[1].RecordingGroups);
+            Assert.Contains(logLines, l => l.Contains("name already exists"));
+        }
+
+        [Fact]
+        public void RenameGroup_HandlesMultipleGroups()
+        {
+            RecordingStore.CommittedRecordings.Add(new RecordingStore.Recording
+            {
+                VesselName = "Multi",
+                RecordingGroups = new List<string> { "Alpha", "Beta", "Gamma" }
+            });
+
+            bool result = RecordingStore.RenameGroup("Beta", "BetaRenamed");
+
+            Assert.True(result);
+            var groups = RecordingStore.CommittedRecordings[0].RecordingGroups;
+            Assert.Contains("Alpha", groups);
+            Assert.Contains("BetaRenamed", groups);
+            Assert.Contains("Gamma", groups);
+            Assert.DoesNotContain("Beta", groups);
+        }
+
+        [Fact]
+        public void RenameGroup_SameName_ReturnsFalse()
+        {
+            bool result = RecordingStore.RenameGroup("Same", "Same");
+
+            Assert.False(result);
+        }
+
+        // ─── RecordingStore.GetGroupNames ──────────────────────────────────
+
+        [Fact]
+        public void GetGroupNames_ReturnsDistinctSortedNames()
+        {
+            RecordingStore.CommittedRecordings.Add(new RecordingStore.Recording
+            {
+                VesselName = "V1",
+                RecordingGroups = new List<string> { "Zebra", "Alpha" }
+            });
+            RecordingStore.CommittedRecordings.Add(new RecordingStore.Recording
+            {
+                VesselName = "V2",
+                RecordingGroups = new List<string> { "Alpha", "Middle" }
+            });
+
+            var names = RecordingStore.GetGroupNames();
+
+            Assert.True(names.Count == 3);
+            Assert.Equal("Alpha", names[0]);
+            Assert.Equal("Middle", names[1]);
+            Assert.Equal("Zebra", names[2]);
+        }
+
+        [Fact]
+        public void GetGroupNames_EmptyRecordings_ReturnsEmptyList()
+        {
+            var names = RecordingStore.GetGroupNames();
+
+            Assert.True(names.Count == 0);
+        }
+
+        [Fact]
+        public void GetGroupNames_AllNullGroups_ReturnsEmptyList()
+        {
+            RecordingStore.CommittedRecordings.Add(new RecordingStore.Recording
+            {
+                VesselName = "V1",
+                RecordingGroups = null
+            });
+            RecordingStore.CommittedRecordings.Add(new RecordingStore.Recording
+            {
+                VesselName = "V2",
+                RecordingGroups = null
+            });
+
+            var names = RecordingStore.GetGroupNames();
+
+            Assert.True(names.Count == 0);
+        }
+
+        // ─── RecordingStore.RemoveGroupFromAll ─────────────────────────────
+
+        [Fact]
+        public void RemoveGroupFromAll_RemovesFromAllRecordings_ReturnsCount()
+        {
+            RecordingStore.CommittedRecordings.Add(new RecordingStore.Recording
+            {
+                VesselName = "V1",
+                RecordingGroups = new List<string> { "Target", "Keep" }
+            });
+            RecordingStore.CommittedRecordings.Add(new RecordingStore.Recording
+            {
+                VesselName = "V2",
+                RecordingGroups = new List<string> { "Target" }
+            });
+            RecordingStore.CommittedRecordings.Add(new RecordingStore.Recording
+            {
+                VesselName = "V3",
+                RecordingGroups = new List<string> { "Other" }
+            });
+
+            int count = RecordingStore.RemoveGroupFromAll("Target");
+
+            Assert.Equal(2, count);
+            // V1 should still have "Keep"
+            Assert.Contains("Keep", RecordingStore.CommittedRecordings[0].RecordingGroups);
+            Assert.DoesNotContain("Target", RecordingStore.CommittedRecordings[0].RecordingGroups);
+            // V2 had only "Target" so RecordingGroups should be null
+            Assert.Null(RecordingStore.CommittedRecordings[1].RecordingGroups);
+            // V3 should be unaffected
+            Assert.Contains("Other", RecordingStore.CommittedRecordings[2].RecordingGroups);
+            Assert.Contains(logLines, l =>
+                l.Contains("RemoveGroupFromAll") && l.Contains("removed from 2 recordings"));
+        }
+
+        [Fact]
+        public void RemoveGroupFromAll_NoMatches_ReturnsZero()
+        {
+            RecordingStore.CommittedRecordings.Add(new RecordingStore.Recording
+            {
+                VesselName = "V1",
+                RecordingGroups = new List<string> { "GroupA" }
+            });
+
+            int count = RecordingStore.RemoveGroupFromAll("NonExistent");
+
+            Assert.Equal(0, count);
+            // Original group should be untouched
+            Assert.Contains("GroupA", RecordingStore.CommittedRecordings[0].RecordingGroups);
+        }
+
+        [Fact]
+        public void RemoveGroupFromAll_NullGroupName_ReturnsZero()
+        {
+            int count = RecordingStore.RemoveGroupFromAll(null);
+
+            Assert.Equal(0, count);
+        }
+    }
+}

--- a/Source/Parsek.Tests/GroupManagementTests.cs
+++ b/Source/Parsek.Tests/GroupManagementTests.cs
@@ -33,70 +33,70 @@ namespace Parsek.Tests
             ParsekScenario.ResetReplacementsForTesting();
         }
 
-        // ─── IsAncestorOrSelf ──────────────────────────────────────────────
+        // ─── IsInAncestorChain ──────────────────────────────────────────────
 
         [Fact]
-        public void IsAncestorOrSelf_DirectParent_ReturnsTrue()
+        public void IsInAncestorChain_DirectParent_ReturnsTrue()
         {
             ParsekScenario.groupParents["Child"] = "Parent";
 
-            Assert.True(ParsekScenario.IsAncestorOrSelf("Child", "Parent"));
+            Assert.True(ParsekScenario.IsInAncestorChain("Child", "Parent"));
         }
 
         [Fact]
-        public void IsAncestorOrSelf_Grandparent_ReturnsTrue()
+        public void IsInAncestorChain_Grandparent_ReturnsTrue()
         {
             ParsekScenario.groupParents["C"] = "B";
             ParsekScenario.groupParents["B"] = "A";
 
-            Assert.True(ParsekScenario.IsAncestorOrSelf("C", "A"));
+            Assert.True(ParsekScenario.IsInAncestorChain("C", "A"));
         }
 
         [Fact]
-        public void IsAncestorOrSelf_Self_ReturnsTrue()
+        public void IsInAncestorChain_Self_ReturnsTrue()
         {
-            Assert.True(ParsekScenario.IsAncestorOrSelf("X", "X"));
+            Assert.True(ParsekScenario.IsInAncestorChain("X", "X"));
         }
 
         [Fact]
-        public void IsAncestorOrSelf_Unrelated_ReturnsFalse()
+        public void IsInAncestorChain_Unrelated_ReturnsFalse()
         {
             ParsekScenario.groupParents["A"] = "Root";
             ParsekScenario.groupParents["B"] = "Root";
 
-            Assert.False(ParsekScenario.IsAncestorOrSelf("A", "B"));
+            Assert.False(ParsekScenario.IsInAncestorChain("A", "B"));
         }
 
         [Fact]
-        public void IsAncestorOrSelf_EmptyGroupParents_ReturnsFalse()
+        public void IsInAncestorChain_EmptyGroupParents_ReturnsFalse()
         {
             // groupParents is empty after ResetGroupsForTesting
-            Assert.False(ParsekScenario.IsAncestorOrSelf("Alpha", "Beta"));
+            Assert.False(ParsekScenario.IsInAncestorChain("Alpha", "Beta"));
         }
 
         [Fact]
-        public void IsAncestorOrSelf_MaxDepthGuard_DoesNotHang()
+        public void IsInAncestorChain_MaxDepthGuard_DoesNotHang()
         {
             // Build a chain of 150 groups — exceeds the 100-depth guard
             for (int i = 0; i < 150; i++)
                 ParsekScenario.groupParents[$"G{i + 1}"] = $"G{i}";
 
             // Should hit max depth and return true (assumes cycle)
-            bool result = ParsekScenario.IsAncestorOrSelf("G150", "G0");
+            bool result = ParsekScenario.IsInAncestorChain("G150", "G0");
             Assert.True(result);
             Assert.Contains(logLines, l => l.Contains("max depth reached"));
         }
 
         [Fact]
-        public void IsAncestorOrSelf_NullGroup_ReturnsFalse()
+        public void IsInAncestorChain_NullGroup_ReturnsFalse()
         {
-            Assert.False(ParsekScenario.IsAncestorOrSelf(null, "A"));
+            Assert.False(ParsekScenario.IsInAncestorChain(null, "A"));
         }
 
         [Fact]
-        public void IsAncestorOrSelf_NullCandidate_ReturnsFalse()
+        public void IsInAncestorChain_NullCandidate_ReturnsFalse()
         {
-            Assert.False(ParsekScenario.IsAncestorOrSelf("A", null));
+            Assert.False(ParsekScenario.IsInAncestorChain("A", null));
         }
 
         // ─── SetGroupParent ────────────────────────────────────────────────
@@ -153,7 +153,7 @@ namespace Parsek.Tests
         // ─── RemoveGroupFromHierarchy ──────────────────────────────────────
 
         [Fact]
-        public void RemoveGroupFromHierarchy_RemovesGroup_PromotesChildren()
+        public void RemoveGroupFromHierarchy_ReparentsChildrenToGrandparent()
         {
             ParsekScenario.groupParents["Child1"] = "Middle";
             ParsekScenario.groupParents["Child2"] = "Middle";
@@ -161,14 +161,15 @@ namespace Parsek.Tests
 
             ParsekScenario.RemoveGroupFromHierarchy("Middle");
 
-            // Middle should be gone as child and as parent
+            // Middle should be gone
             Assert.False(ParsekScenario.groupParents.ContainsKey("Middle"));
-            Assert.False(ParsekScenario.groupParents.ContainsKey("Child1"));
-            Assert.False(ParsekScenario.groupParents.ContainsKey("Child2"));
+            // Children reparented to grandparent "Root"
+            Assert.Equal("Root", ParsekScenario.groupParents["Child1"]);
+            Assert.Equal("Root", ParsekScenario.groupParents["Child2"]);
         }
 
         [Fact]
-        public void RemoveGroupFromHierarchy_LogsPromotedCount()
+        public void RemoveGroupFromHierarchy_RootGroup_PromotesChildrenToRoot()
         {
             ParsekScenario.groupParents["Sub1"] = "Parent";
             ParsekScenario.groupParents["Sub2"] = "Parent";
@@ -176,19 +177,23 @@ namespace Parsek.Tests
 
             ParsekScenario.RemoveGroupFromHierarchy("Parent");
 
+            // Parent was root-level (no grandparent), so children become root
+            Assert.False(ParsekScenario.groupParents.ContainsKey("Sub1"));
+            Assert.False(ParsekScenario.groupParents.ContainsKey("Sub2"));
+            Assert.False(ParsekScenario.groupParents.ContainsKey("Sub3"));
             Assert.Contains(logLines, l =>
                 l.Contains("removed from hierarchy") && l.Contains("3 sub-groups promoted to root"));
         }
 
         [Fact]
-        public void RemoveGroupFromHierarchy_NoChildren_LogsZeroPromoted()
+        public void RemoveGroupFromHierarchy_NoChildren_LogsZero()
         {
             ParsekScenario.groupParents["Leaf"] = "Root";
 
             ParsekScenario.RemoveGroupFromHierarchy("Leaf");
 
             Assert.Contains(logLines, l =>
-                l.Contains("removed from hierarchy") && l.Contains("0 sub-groups promoted to root"));
+                l.Contains("removed from hierarchy") && l.Contains("0 sub-groups"));
         }
 
         // ─── GetDescendantGroups ───────────────────────────────────────────

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -912,6 +912,7 @@ namespace Parsek
                     windowRect,
                     ui.DrawWindow,
                     "Parsek",
+                    ui.GetOpaqueWindowStyle(),
                     GUILayout.Width(250)
                 );
                 ui.LogMainWindowPosition(windowRect);
@@ -2729,7 +2730,10 @@ namespace Parsek
             {
                 activeChainId = System.Guid.NewGuid().ToString("N");
                 activeChainNextIndex = 0;
-                Log($"Chain: started new chain (id={activeChainId})");
+                // Auto-group chain under a group named after the starting vessel
+                string chainGroupName = RecordingStore.Pending.VesselName ?? "Chain";
+                RecordingStore.Pending.RecordingGroups = new System.Collections.Generic.List<string> { chainGroupName };
+                Log($"Chain: started new chain (id={activeChainId}, group='{chainGroupName}')");
             }
 
             // Tag segment with chain metadata
@@ -3176,7 +3180,9 @@ namespace Parsek
             {
                 activeChainId = System.Guid.NewGuid().ToString("N");
                 activeChainNextIndex = 0;
-                Log($"Dock/Undock chain: started new chain (id={activeChainId})");
+                string chainGroupName = RecordingStore.Pending.VesselName ?? "Chain";
+                RecordingStore.Pending.RecordingGroups = new System.Collections.Generic.List<string> { chainGroupName };
+                Log($"Dock/Undock chain: started new chain (id={activeChainId}, group='{chainGroupName}')");
             }
 
             // Tag segment with chain metadata
@@ -3241,7 +3247,9 @@ namespace Parsek
             {
                 activeChainId = System.Guid.NewGuid().ToString("N");
                 activeChainNextIndex = 0;
-                ParsekLog.Info("Flight", $"Boundary split: started new chain (id={activeChainId})");
+                string chainGroupName = RecordingStore.Pending.VesselName ?? "Chain";
+                RecordingStore.Pending.RecordingGroups = new System.Collections.Generic.List<string> { chainGroupName };
+                ParsekLog.Info("Flight", $"Boundary split: started new chain (id={activeChainId}, group='{chainGroupName}')");
             }
 
             // Tag segment with chain metadata
@@ -6870,7 +6878,6 @@ namespace Parsek
             if (info == null) return;
 
             info.lastIntensity = 0f;
-
 
             if (info.fireParticles != null)
             {

--- a/Source/Parsek/ParsekKSC.cs
+++ b/Source/Parsek/ParsekKSC.cs
@@ -103,7 +103,7 @@ namespace Parsek
 
             windowRect = ClickThruBlocker.GUILayoutWindow(
                 GetInstanceID(), windowRect, ui.DrawWindow,
-                "Parsek", GUILayout.Width(250));
+                "Parsek", ui.GetOpaqueWindowStyle(), GUILayout.Width(250));
 
             ui.DrawRecordingsWindowIfOpen(windowRect);
             ui.DrawActionsWindowIfOpen(windowRect);

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -1748,6 +1748,28 @@ namespace Parsek
                 }
             }
 
+            // Post-load validation: detect and break corrupted cycles
+            var visited = new HashSet<string>();
+            var toRemove = new List<string>();
+            foreach (var kvp in groupParents)
+            {
+                visited.Clear();
+                string current = kvp.Key;
+                bool hasCycle = false;
+                while (groupParents.TryGetValue(current, out string p))
+                {
+                    if (!visited.Add(current)) { hasCycle = true; break; }
+                    current = p;
+                }
+                if (hasCycle && !toRemove.Contains(kvp.Key))
+                    toRemove.Add(kvp.Key);
+            }
+            for (int i = 0; i < toRemove.Count; i++)
+            {
+                groupParents.Remove(toRemove[i]);
+                ParsekLog.Warn("Scenario", $"LoadGroupHierarchy: broke cycle involving group '{toRemove[i]}'");
+            }
+
             ScenarioLog($"[Parsek Scenario] Loaded {groupParents.Count} group hierarchy entries");
         }
 
@@ -1934,22 +1956,23 @@ namespace Parsek
         // ─── Group hierarchy management ──────────────────────────────────────
 
         /// <summary>
-        /// Returns true if 'candidate' is 'group' itself or an ancestor of 'group'.
+        /// Walks the parent chain from 'startGroup' upward, returns true if 'targetAncestor'
+        /// is found (or equals 'startGroup' itself). Used for cycle detection.
         /// Max depth guard protects against corrupted cycles.
         /// </summary>
-        internal static bool IsAncestorOrSelf(string group, string candidate)
+        internal static bool IsInAncestorChain(string startGroup, string targetAncestor)
         {
-            if (string.IsNullOrEmpty(group) || string.IsNullOrEmpty(candidate))
+            if (string.IsNullOrEmpty(startGroup) || string.IsNullOrEmpty(targetAncestor))
                 return false;
-            string current = group;
+            string current = startGroup;
             for (int depth = 0; depth < 100; depth++)
             {
-                if (current == candidate) return true;
+                if (current == targetAncestor) return true;
                 if (!groupParents.TryGetValue(current, out string parent))
                     return false;
                 current = parent;
             }
-            ParsekLog.Warn("Scenario", $"IsAncestorOrSelf: max depth reached for group '{group}' — possible cycle");
+            ParsekLog.Warn("Scenario", $"IsInAncestorChain: max depth reached for group '{startGroup}' — possible cycle");
             return true; // Assume cycle, block the assignment
         }
 
@@ -1968,7 +1991,7 @@ namespace Parsek
                 return true;
             }
 
-            if (IsAncestorOrSelf(parentGroup, childGroup))
+            if (IsInAncestorChain(parentGroup, childGroup))
             {
                 ParsekLog.Warn("Scenario", $"SetGroupParent: cannot assign '{childGroup}' to parent '{parentGroup}' — would create cycle");
                 return false;
@@ -1986,20 +2009,30 @@ namespace Parsek
         {
             if (string.IsNullOrEmpty(groupName)) return;
 
+            // Find grandparent (null if this group was root-level)
+            string grandparent;
+            groupParents.TryGetValue(groupName, out grandparent);
+
             // Remove as child
             groupParents.Remove(groupName);
 
-            // Promote children to root (remove entries where this group is the parent)
-            var toPromote = new List<string>();
+            // Reparent children to grandparent (or root if no grandparent)
+            var toReparent = new List<string>();
             foreach (var kvp in groupParents)
             {
                 if (kvp.Value == groupName)
-                    toPromote.Add(kvp.Key);
+                    toReparent.Add(kvp.Key);
             }
-            for (int i = 0; i < toPromote.Count; i++)
-                groupParents.Remove(toPromote[i]);
+            for (int i = 0; i < toReparent.Count; i++)
+            {
+                if (grandparent != null)
+                    groupParents[toReparent[i]] = grandparent;
+                else
+                    groupParents.Remove(toReparent[i]);
+            }
 
-            ParsekLog.Info("Scenario", $"Group '{groupName}' removed from hierarchy ({toPromote.Count} sub-groups promoted to root)");
+            string destLabel = grandparent != null ? $"reparented under '{grandparent}'" : "promoted to root";
+            ParsekLog.Info("Scenario", $"Group '{groupName}' removed from hierarchy ({toReparent.Count} sub-groups {destLabel})");
         }
 
         /// <summary>
@@ -2015,7 +2048,11 @@ namespace Parsek
 
         private static void CollectDescendants(string groupName, List<string> result, int depth)
         {
-            if (depth > 100) return; // Guard against corrupted cycles
+            if (depth > 100)
+            {
+                ParsekLog.Warn("Scenario", $"CollectDescendants: max depth reached for group '{groupName}' — possible cycle, result truncated");
+                return;
+            }
             foreach (var kvp in groupParents)
             {
                 if (kvp.Value == groupName)

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -29,6 +29,9 @@ namespace Parsek
         // Maps reserved kerbal name → replacement kerbal name
         private static Dictionary<string, string> crewReplacements = new Dictionary<string, string>();
 
+        // Group hierarchy: child group name → parent group name
+        internal static Dictionary<string, string> groupParents = new Dictionary<string, string>();
+
         /// <summary>
         /// Read-only access to current replacement mappings. For testing/diagnostics.
         /// </summary>
@@ -158,6 +161,19 @@ namespace Parsek
                 ScenarioLog($"[Parsek Scenario] Saved {crewReplacements.Count} crew replacement(s)");
             }
 
+            // Persist group hierarchy
+            if (groupParents.Count > 0)
+            {
+                ConfigNode hierarchyNode = node.AddNode("GROUP_HIERARCHY");
+                foreach (var kvp in groupParents)
+                {
+                    ConfigNode entry = hierarchyNode.AddNode("ENTRY");
+                    entry.AddValue("child", kvp.Key);
+                    entry.AddValue("parent", kvp.Value);
+                }
+                ScenarioLog($"[Parsek Scenario] Saved group hierarchy: {groupParents.Count} entries");
+            }
+
             // Save game state events to external file
             GameStateStore.SaveEventFile();
             node.AddValue("gameStateEventCount", GameStateStore.EventCount);
@@ -249,7 +265,10 @@ namespace Parsek
             // Skip during go-back: in-memory crewReplacements is the source of truth
             // (it has replacements for recordings committed after this quicksave).
             if (!RecordingStore.IsRewinding)
+            {
                 LoadCrewReplacements(node);
+                LoadGroupHierarchy(node);
+            }
 
             // Game state recorder lifecycle — re-subscribe on every OnLoad (handles reverts)
             stateRecorder?.Unsubscribe();
@@ -1333,9 +1352,10 @@ namespace Parsek
                 recNode.AddValue("rewindResRep", rec.RewindReservedRep.ToString("R", CultureInfo.InvariantCulture));
             }
 
-            // UI grouping tag
-            if (!string.IsNullOrEmpty(rec.RecordingGroup))
-                recNode.AddValue("recordingGroup", rec.RecordingGroup);
+            // UI grouping tags (multi-group membership)
+            if (rec.RecordingGroups != null)
+                for (int g = 0; g < rec.RecordingGroups.Count; g++)
+                    recNode.AddValue("recordingGroup", rec.RecordingGroups[g]);
 
             // Atmosphere segment metadata (only if set, saves space)
             if (!string.IsNullOrEmpty(rec.SegmentPhase))
@@ -1457,8 +1477,10 @@ namespace Parsek
                     rec.RewindReservedRep = rewindRep;
             }
 
-            // UI grouping tag
-            rec.RecordingGroup = recNode.GetValue("recordingGroup");
+            // UI grouping tags (multi-group membership, backward compat with single value)
+            string[] groups = recNode.GetValues("recordingGroup");
+            if (groups != null && groups.Length > 0)
+                rec.RecordingGroups = new List<string>(groups);
 
             // Atmosphere segment metadata
             rec.SegmentPhase = recNode.GetValue("segmentPhase");
@@ -1702,6 +1724,34 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Load group hierarchy from a ConfigNode.
+        /// </summary>
+        private static void LoadGroupHierarchy(ConfigNode node)
+        {
+            groupParents.Clear();
+
+            ConfigNode hierarchyNode = node.GetNode("GROUP_HIERARCHY");
+            if (hierarchyNode == null)
+            {
+                ScenarioLog("[Parsek Scenario] Loaded 0 group hierarchy entries (no GROUP_HIERARCHY node)");
+                return;
+            }
+
+            ConfigNode[] entries = hierarchyNode.GetNodes("ENTRY");
+            for (int i = 0; i < entries.Length; i++)
+            {
+                string child = entries[i].GetValue("child");
+                string parent = entries[i].GetValue("parent");
+                if (!string.IsNullOrEmpty(child) && !string.IsNullOrEmpty(parent))
+                {
+                    groupParents[child] = parent;
+                }
+            }
+
+            ScenarioLog($"[Parsek Scenario] Loaded {groupParents.Count} group hierarchy entries");
+        }
+
+        /// <summary>
         /// Swap reserved crew out of the active flight vessel, replacing them
         /// with their hired replacements. Prevents the player from recording
         /// with a reserved kerbal again after revert.
@@ -1879,6 +1929,144 @@ namespace Parsek
         internal static void ResetReplacementsForTesting()
         {
             crewReplacements.Clear();
+        }
+
+        // ─── Group hierarchy management ──────────────────────────────────────
+
+        /// <summary>
+        /// Returns true if 'candidate' is 'group' itself or an ancestor of 'group'.
+        /// Max depth guard protects against corrupted cycles.
+        /// </summary>
+        internal static bool IsAncestorOrSelf(string group, string candidate)
+        {
+            if (string.IsNullOrEmpty(group) || string.IsNullOrEmpty(candidate))
+                return false;
+            string current = group;
+            for (int depth = 0; depth < 100; depth++)
+            {
+                if (current == candidate) return true;
+                if (!groupParents.TryGetValue(current, out string parent))
+                    return false;
+                current = parent;
+            }
+            ParsekLog.Warn("Scenario", $"IsAncestorOrSelf: max depth reached for group '{group}' — possible cycle");
+            return true; // Assume cycle, block the assignment
+        }
+
+        /// <summary>
+        /// Sets the parent of a child group. Pass null parentGroup to make root-level.
+        /// Returns false if assignment would create a cycle.
+        /// </summary>
+        public static bool SetGroupParent(string childGroup, string parentGroup)
+        {
+            if (string.IsNullOrEmpty(childGroup)) return false;
+
+            if (parentGroup == null)
+            {
+                if (groupParents.Remove(childGroup))
+                    ParsekLog.Info("Scenario", $"Group '{childGroup}' moved to root level");
+                return true;
+            }
+
+            if (IsAncestorOrSelf(parentGroup, childGroup))
+            {
+                ParsekLog.Warn("Scenario", $"SetGroupParent: cannot assign '{childGroup}' to parent '{parentGroup}' — would create cycle");
+                return false;
+            }
+
+            groupParents[childGroup] = parentGroup;
+            ParsekLog.Info("Scenario", $"Group '{childGroup}' assigned to parent group '{parentGroup}'");
+            return true;
+        }
+
+        /// <summary>
+        /// Removes a group from the hierarchy. Promotes its children to root-level.
+        /// </summary>
+        public static void RemoveGroupFromHierarchy(string groupName)
+        {
+            if (string.IsNullOrEmpty(groupName)) return;
+
+            // Remove as child
+            groupParents.Remove(groupName);
+
+            // Promote children to root (remove entries where this group is the parent)
+            var toPromote = new List<string>();
+            foreach (var kvp in groupParents)
+            {
+                if (kvp.Value == groupName)
+                    toPromote.Add(kvp.Key);
+            }
+            for (int i = 0; i < toPromote.Count; i++)
+                groupParents.Remove(toPromote[i]);
+
+            ParsekLog.Info("Scenario", $"Group '{groupName}' removed from hierarchy ({toPromote.Count} sub-groups promoted to root)");
+        }
+
+        /// <summary>
+        /// Returns all descendant group names (recursive).
+        /// </summary>
+        public static List<string> GetDescendantGroups(string groupName)
+        {
+            var descendants = new List<string>();
+            if (string.IsNullOrEmpty(groupName)) return descendants;
+            CollectDescendants(groupName, descendants, 0);
+            return descendants;
+        }
+
+        private static void CollectDescendants(string groupName, List<string> result, int depth)
+        {
+            if (depth > 100) return; // Guard against corrupted cycles
+            foreach (var kvp in groupParents)
+            {
+                if (kvp.Value == groupName)
+                {
+                    result.Add(kvp.Key);
+                    CollectDescendants(kvp.Key, result, depth + 1);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Renames a group in the hierarchy (updates both keys and values).
+        /// </summary>
+        public static void RenameGroupInHierarchy(string oldName, string newName)
+        {
+            if (string.IsNullOrEmpty(oldName) || string.IsNullOrEmpty(newName) || oldName == newName)
+                return;
+
+            int updated = 0;
+
+            // Update as child (key)
+            if (groupParents.TryGetValue(oldName, out string parent))
+            {
+                groupParents.Remove(oldName);
+                groupParents[newName] = parent;
+                updated++;
+            }
+
+            // Update as parent (values)
+            var toUpdate = new List<string>();
+            foreach (var kvp in groupParents)
+            {
+                if (kvp.Value == oldName)
+                    toUpdate.Add(kvp.Key);
+            }
+            for (int i = 0; i < toUpdate.Count; i++)
+            {
+                groupParents[toUpdate[i]] = newName;
+                updated++;
+            }
+
+            if (updated > 0)
+                ParsekLog.Info("Scenario", $"RenameGroupInHierarchy: '{oldName}' → '{newName}' ({updated} hierarchy entries updated)");
+        }
+
+        /// <summary>
+        /// Resets group hierarchy for testing.
+        /// </summary>
+        public static void ResetGroupsForTesting()
+        {
+            groupParents.Clear();
         }
 
         #region Vessel Lifecycle Events

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -16,6 +16,9 @@ namespace Parsek
 
         private readonly ParsekFlight flight;
 
+        // Opaque window style (replaces KSP's semi-transparent default)
+        private GUIStyle opaqueWindowStyle;
+
         // Map view markers
         private GUIStyle mapMarkerStyle;
         private Texture2D mapMarkerTexture;
@@ -56,9 +59,9 @@ namespace Parsek
         private bool actionsSortAscending = true;
 
         // Column widths — shared between header and body for alignment
-        private const float ColW_Enable = 15f;
+        private const float ColW_Enable = 20f;
         private const float ColW_Phase = 70f;
-        private const float ColW_Index = 25f;
+        private const float ColW_Index = 30f;
         private const float ColW_Launch = 110f;
         private const float ColW_Dur = 55f;
         private const float ColW_Status = 45f;
@@ -66,7 +69,6 @@ namespace Parsek
         private const float ColW_Watch = 50f;
         private const float ColW_Rewind = 55f;
         private const float ColW_Delete = 50f;
-        private const float ScrollbarWidth = 16f;
 
         // Chain and group expansion state
         private HashSet<string> expandedChains = new HashSet<string>();
@@ -75,10 +77,13 @@ namespace Parsek
         // Group rename (deferred to next frame to avoid IMGUI layout mismatch)
         private string renamingGroup;
         private string renamingGroupText = "";
+        private bool renamingGroupFocused;
 
         // Recording rename (deferred to next frame)
         private int renamingRecordingIdx = -1;
         private string renamingRecordingText = "";
+        private bool renamingRecordingFocused;
+        private Rect activeRenameRect;
 
         // Double-click detection
         private int lastClickedRecIdx = -1;
@@ -99,11 +104,10 @@ namespace Parsek
         private string groupPopupNewName = "";
         private Rect groupPopupRect;
         private Vector2 groupPopupScrollPos;
+        private bool isResizingGroupPopup;
         private const float ColW_Group = 50f;
-
-        // Group-level loop period editing
-        private string editingGroupLoopPeriod;
-        private string editingGroupLoopText = "";
+        private const float GroupPopupMinW = 220f;
+        private const float GroupPopupMinH = 200f;
 
         // Group delete confirm
         private string deleteConfirmGroup;
@@ -117,7 +121,7 @@ namespace Parsek
         private GUIStyle phaseStyleSpace;
 
         // Sort state
-        internal enum SortColumn { Index, Name, LaunchTime, Duration, Status }
+        internal enum SortColumn { Index, Phase, Name, LaunchTime, Duration, Status }
         private SortColumn sortColumn = SortColumn.Index;
         private bool sortAscending = true;
         private int[] sortedIndices; // maps display row → CommittedRecordings index
@@ -443,11 +447,13 @@ namespace Parsek
                     Event.current.Use();
             }
 
+            EnsureOpaqueWindowStyle();
             actionsWindowRect = ClickThruBlocker.GUILayoutWindow(
                 "ParsekActions".GetHashCode(),
                 actionsWindowRect,
                 DrawActionsWindow,
                 "Parsek \u2014 Game Actions",
+                opaqueWindowStyle,
                 GUILayout.Width(actionsWindowRect.width),
                 GUILayout.Height(actionsWindowRect.height)
             );
@@ -767,11 +773,13 @@ namespace Parsek
                     Event.current.Use();
             }
 
+            EnsureOpaqueWindowStyle();
             recordingsWindowRect = ClickThruBlocker.GUILayoutWindow(
                 "ParsekRecordings".GetHashCode(),
                 recordingsWindowRect,
                 DrawRecordingsWindow,
                 "Parsek \u2014 Recordings",
+                opaqueWindowStyle,
                 GUILayout.Width(recordingsWindowRect.width),
                 GUILayout.Height(recordingsWindowRect.height)
             );
@@ -804,6 +812,62 @@ namespace Parsek
             recordingsWindowHasInputLock = false;
         }
 
+        private void EnsureOpaqueWindowStyle()
+        {
+            if (opaqueWindowStyle != null) return;
+
+            // Copy KSP's default window style, then make background textures opaque
+            // while preserving all border/highlight details
+            opaqueWindowStyle = new GUIStyle(GUI.skin.window);
+            opaqueWindowStyle.normal.background = MakeOpaqueCopy(opaqueWindowStyle.normal.background);
+            opaqueWindowStyle.onNormal.background = MakeOpaqueCopy(opaqueWindowStyle.onNormal.background);
+            opaqueWindowStyle.focused.background = MakeOpaqueCopy(opaqueWindowStyle.focused.background);
+            opaqueWindowStyle.onFocused.background = MakeOpaqueCopy(opaqueWindowStyle.onFocused.background);
+            opaqueWindowStyle.active.background = MakeOpaqueCopy(opaqueWindowStyle.active.background);
+            opaqueWindowStyle.onActive.background = MakeOpaqueCopy(opaqueWindowStyle.onActive.background);
+            opaqueWindowStyle.hover.background = MakeOpaqueCopy(opaqueWindowStyle.hover.background);
+            opaqueWindowStyle.onHover.background = MakeOpaqueCopy(opaqueWindowStyle.onHover.background);
+        }
+
+        /// <summary>
+        /// Creates a readable copy of a texture with all pixel alpha set to 1.
+        /// Uses RenderTexture blit to handle non-readable source textures (KSP skin).
+        /// </summary>
+        private static Texture2D MakeOpaqueCopy(Texture2D source)
+        {
+            if (source == null) return null;
+
+            // Blit to RenderTexture (works even for non-readable textures)
+            RenderTexture rt = RenderTexture.GetTemporary(source.width, source.height, 0, RenderTextureFormat.ARGB32);
+            RenderTexture prev = RenderTexture.active;
+            Graphics.Blit(source, rt);
+            RenderTexture.active = rt;
+
+            Texture2D copy = new Texture2D(source.width, source.height, TextureFormat.ARGB32, false);
+            copy.ReadPixels(new Rect(0, 0, source.width, source.height), 0, 0);
+
+            RenderTexture.active = prev;
+            RenderTexture.ReleaseTemporary(rt);
+
+            // Max out alpha on all pixels
+            Color[] pixels = copy.GetPixels();
+            for (int i = 0; i < pixels.Length; i++)
+                pixels[i].a = 1f;
+            copy.SetPixels(pixels);
+            copy.Apply();
+            copy.filterMode = source.filterMode;
+            return copy;
+        }
+
+        /// <summary>
+        /// Returns the opaque window style for use by external callers (ParsekFlight, ParsekKSC).
+        /// </summary>
+        public GUIStyle GetOpaqueWindowStyle()
+        {
+            EnsureOpaqueWindowStyle();
+            return opaqueWindowStyle;
+        }
+
         private void EnsurePhaseStyles()
         {
             if (phaseStyleAtmo != null) return;
@@ -823,6 +887,19 @@ namespace Parsek
             var committed = RecordingStore.CommittedRecordings;
             double now = Planetarium.GetUniversalTime();
 
+            // Click outside active rename field → commit and close
+            if (Event.current.type == EventType.MouseDown &&
+                (renamingRecordingIdx >= 0 || renamingGroup != null))
+            {
+                if (activeRenameRect.width > 0 && !activeRenameRect.Contains(Event.current.mousePosition))
+                {
+                    if (renamingRecordingIdx >= 0)
+                        CommitRecordingRename(committed);
+                    if (renamingGroup != null)
+                        CommitGroupRename(renamingGroup);
+                }
+            }
+
             EnsureStatusStyles();
             EnsurePhaseStyles();
             RebuildSortedIndices(committed, now);
@@ -835,6 +912,10 @@ namespace Parsek
             }
             else
             {
+                // Scrollable table body (header inside scroll view for guaranteed alignment)
+                recordingsScrollPos = GUILayout.BeginScrollView(
+                    recordingsScrollPos, false, true, GUILayout.ExpandHeight(true));
+
                 // Header row
                 GUILayout.BeginHorizontal();
                 // Select-all enable header checkbox
@@ -850,10 +931,10 @@ namespace Parsek
                     ParsekLog.Info("UI", $"Set playback enabled for all recordings: enabled={newAllEnabled}");
                 }
                 DrawSortableHeader("#", SortColumn.Index, ColW_Index);
-                GUILayout.Label("Phase", GUILayout.Width(ColW_Phase));
                 DrawSortableHeader("Name", SortColumn.Name, 0, true);
+                DrawSortableHeader("Phase", SortColumn.Phase, ColW_Phase);
                 DrawSortableHeader("Launch", SortColumn.LaunchTime, ColW_Launch);
-                DrawSortableHeader("Dur", SortColumn.Duration, ColW_Dur);
+                DrawSortableHeader("Duration", SortColumn.Duration, ColW_Dur);
 
                 if (showExpandedStats)
                 {
@@ -898,12 +979,7 @@ namespace Parsek
                     GUILayout.Label("Watch", GUILayout.Width(ColW_Watch));
                 GUILayout.Label("Rewind", GUILayout.Width(ColW_Rewind));
                 GUILayout.Label("Delete", GUILayout.Width(ColW_Delete));
-                GUILayout.Space(ScrollbarWidth);
                 GUILayout.EndHorizontal();
-
-                // Scrollable table body (alwaysShowVertical keeps columns aligned with header)
-                recordingsScrollPos = GUILayout.BeginScrollView(
-                    recordingsScrollPos, false, true, GUILayout.ExpandHeight(true));
 
                 // Rebuild if a header click invalidated during this frame
                 RebuildSortedIndices(committed, now);
@@ -1053,8 +1129,10 @@ namespace Parsek
                 {
                     showExpandedStats = !showExpandedStats;
                     ParsekLog.Verbose("UI", $"Recordings Stats toggled: {(showExpandedStats ? "expanded" : "collapsed")}");
-                    if (showExpandedStats && recordingsWindowRect.width < 1015f)
-                        recordingsWindowRect.width = 1015f;
+                    if (showExpandedStats && recordingsWindowRect.width < 1150f)
+                        recordingsWindowRect.width = 1150f;
+                    else if (!showExpandedStats)
+                        recordingsWindowRect.width = 790f;
                 }
             }
 
@@ -1077,15 +1155,6 @@ namespace Parsek
             }
 
             GUILayout.EndHorizontal();
-
-            // Tooltip rendering (on top of all window content, before DragWindow)
-            if (Event.current.type == EventType.Repaint && hoveredRecIdx >= 0 &&
-                hoveredRecIdx < committed.Count &&
-                scrollViewRect.width > 0 &&
-                scrollViewRect.Contains(Event.current.mousePosition))
-            {
-                DrawRecordingTooltip(committed[hoveredRecIdx]);
-            }
 
             // Resize handle (bottom-right corner)
             Rect handleRect = new Rect(
@@ -1111,10 +1180,7 @@ namespace Parsek
             var rec = committed[ri];
             GUILayout.BeginHorizontal();
 
-            if (indentPx > 0f)
-                GUILayout.Space(indentPx);
-
-            // Enable checkbox
+            // Enable checkbox (always at column 0)
             bool enabled = GUILayout.Toggle(rec.PlaybackEnabled, "", GUILayout.Width(ColW_Enable));
             if (enabled != rec.PlaybackEnabled)
             {
@@ -1125,6 +1191,65 @@ namespace Parsek
 
             // #
             GUILayout.Label((ri + 1).ToString(), GUILayout.Width(ColW_Index));
+
+            // Name (double-click to rename, deferred to next frame)
+            // Indent inside Name column for grouped/chained recordings
+            if (indentPx > 0f) GUILayout.Space(indentPx);
+            string name = string.IsNullOrEmpty(rec.VesselName) ? "Untitled" : rec.VesselName;
+            if (renamingRecordingIdx == ri)
+            {
+                bool submitRec = Event.current.type == EventType.KeyDown &&
+                    (Event.current.keyCode == KeyCode.Return || Event.current.keyCode == KeyCode.KeypadEnter);
+                bool cancelRec = Event.current.type == EventType.KeyDown &&
+                    Event.current.keyCode == KeyCode.Escape;
+
+                GUI.SetNextControlName("RecRename");
+                renamingRecordingText = GUILayout.TextField(renamingRecordingText, GUILayout.ExpandWidth(true));
+                activeRenameRect = GUILayoutUtility.GetLastRect();
+
+                // Auto-focus once on first frame
+                if (!renamingRecordingFocused)
+                {
+                    GUI.FocusControl("RecRename");
+                    renamingRecordingFocused = true;
+                }
+
+                if (submitRec)
+                {
+                    CommitRecordingRename(committed);
+                    Event.current.Use();
+                }
+                else if (cancelRec)
+                {
+                    renamingRecordingIdx = -1;
+                    activeRenameRect = default;
+                    Event.current.Use();
+                }
+            }
+            else
+            {
+                if (GUILayout.Button(name, GUI.skin.label, GUILayout.ExpandWidth(true)))
+                {
+                    float now2 = Time.realtimeSinceStartup;
+                    if (lastClickedRecIdx == ri && now2 - lastClickTime < DoubleClickThreshold)
+                    {
+                        // Commit any active rename first
+                        if (renamingRecordingIdx >= 0)
+                            CommitRecordingRename(committed);
+                        if (renamingGroup != null)
+                            CommitGroupRename(renamingGroup);
+                        renamingRecordingIdx = ri;
+                        renamingRecordingText = rec.VesselName ?? "";
+                        renamingRecordingFocused = false;
+                        lastClickedRecIdx = -1;
+                    }
+                    else
+                    {
+                        lastClickedRecIdx = ri;
+                        lastClickTime = now2;
+                    }
+                }
+            }
 
             // Phase label
             string phaseLabel = RecordingStore.GetSegmentPhaseLabel(rec);
@@ -1139,54 +1264,6 @@ namespace Parsek
             else
             {
                 GUILayout.Label("", GUILayout.Width(ColW_Phase));
-            }
-
-            // Name (double-click to rename, deferred to next frame)
-            string name = string.IsNullOrEmpty(rec.VesselName) ? "Untitled" : rec.VesselName;
-            if (renamingRecordingIdx == ri)
-            {
-                GUI.SetNextControlName("RecRename");
-                renamingRecordingText = GUILayout.TextField(renamingRecordingText, GUILayout.ExpandWidth(true));
-                if (GUI.GetNameOfFocusedControl() != "RecRename")
-                    GUI.FocusControl("RecRename");
-                if (Event.current.type == EventType.KeyDown)
-                {
-                    if (Event.current.keyCode == KeyCode.Return || Event.current.keyCode == KeyCode.KeypadEnter)
-                    {
-                        string trimmed = renamingRecordingText.Trim();
-                        if (!string.IsNullOrEmpty(trimmed) && trimmed != rec.VesselName)
-                        {
-                            ParsekLog.Info("UI", $"Recording '{rec.VesselName}' renamed to '{trimmed}'");
-                            rec.VesselName = trimmed;
-                        }
-                        renamingRecordingIdx = -1;
-                        Event.current.Use();
-                    }
-                    else if (Event.current.keyCode == KeyCode.Escape)
-                    {
-                        renamingRecordingIdx = -1;
-                        Event.current.Use();
-                    }
-                }
-            }
-            else
-            {
-                if (GUILayout.Button(name, GUI.skin.label, GUILayout.ExpandWidth(true)))
-                {
-                    float now2 = Time.realtimeSinceStartup;
-                    if (lastClickedRecIdx == ri && now2 - lastClickTime < DoubleClickThreshold)
-                    {
-                        // Double-click detected — defer rename to next frame
-                        renamingRecordingIdx = ri;
-                        renamingRecordingText = rec.VesselName ?? "";
-                        lastClickedRecIdx = -1;
-                    }
-                    else
-                    {
-                        lastClickedRecIdx = ri;
-                        lastClickTime = now2;
-                    }
-                }
             }
 
             // Launch Time
@@ -1326,14 +1403,6 @@ namespace Parsek
 
             GUILayout.EndHorizontal();
 
-            // Hover detection
-            if (Event.current.type == EventType.Repaint)
-            {
-                Rect rowRect = GUILayoutUtility.GetLastRect();
-                if (rowRect.Contains(Event.current.mousePosition))
-                    hoveredRecIdx = ri;
-            }
-
             return false;
         }
 
@@ -1391,9 +1460,8 @@ namespace Parsek
 
             // ── Group header ──
             GUILayout.BeginHorizontal();
-            if (indent > 0f) GUILayout.Space(indent);
 
-            // Enable checkbox (aggregate)
+            // Enable checkbox (always at column 0)
             int enabledCount = 0;
             foreach (int idx in descendants)
                 if (committed[idx].PlaybackEnabled) enabledCount++;
@@ -1406,29 +1474,42 @@ namespace Parsek
                 ParsekLog.Info("UI", $"Set playback enabled for group '{groupName}': enabled={newEnabled}");
             }
 
-            // Expand/collapse + name (or rename TextField)
+            // Spacer for # column
+            GUILayout.Space(ColW_Index);
+
+            // Expand/collapse + name (indent inside Name column for sub-groups)
+            if (indent > 0f) GUILayout.Space(indent);
             bool expanded = expandedGroups.Contains(groupName);
             string arrow = expanded ? "\u25bc" : "\u25b6";
 
             if (renamingGroup == groupName)
             {
+                bool submitGrp = Event.current.type == EventType.KeyDown &&
+                    (Event.current.keyCode == KeyCode.Return || Event.current.keyCode == KeyCode.KeypadEnter);
+                bool cancelGrp = Event.current.type == EventType.KeyDown &&
+                    Event.current.keyCode == KeyCode.Escape;
+
                 GUILayout.Label(arrow, GUILayout.Width(15));
                 GUI.SetNextControlName("GrpRename");
                 renamingGroupText = GUILayout.TextField(renamingGroupText, GUILayout.ExpandWidth(true));
-                if (GUI.GetNameOfFocusedControl() != "GrpRename")
-                    GUI.FocusControl("GrpRename");
-                if (Event.current.type == EventType.KeyDown)
+                activeRenameRect = GUILayoutUtility.GetLastRect();
+
+                if (!renamingGroupFocused)
                 {
-                    if (Event.current.keyCode == KeyCode.Return || Event.current.keyCode == KeyCode.KeypadEnter)
-                    {
-                        CommitGroupRename(groupName);
-                        Event.current.Use();
-                    }
-                    else if (Event.current.keyCode == KeyCode.Escape)
-                    {
-                        renamingGroup = null;
-                        Event.current.Use();
-                    }
+                    GUI.FocusControl("GrpRename");
+                    renamingGroupFocused = true;
+                }
+
+                if (submitGrp)
+                {
+                    CommitGroupRename(groupName);
+                    Event.current.Use();
+                }
+                else if (cancelGrp)
+                {
+                    renamingGroup = null;
+                    activeRenameRect = default;
+                    Event.current.Use();
                 }
             }
             else
@@ -1439,8 +1520,14 @@ namespace Parsek
                     float t = Time.realtimeSinceStartup;
                     if (lastClickedGroup == groupName && t - lastGroupClickTime < DoubleClickThreshold)
                     {
+                        // Commit any active rename first
+                        if (renamingRecordingIdx >= 0)
+                            CommitRecordingRename(committed);
+                        if (renamingGroup != null)
+                            CommitGroupRename(renamingGroup);
                         renamingGroup = groupName;
                         renamingGroupText = groupName;
+                        renamingGroupFocused = false;
                         lastClickedGroup = null;
                     }
                     else
@@ -1583,6 +1670,12 @@ namespace Parsek
             float indent = depth * 15f;
 
             GUILayout.BeginHorizontal();
+
+            // Spacers matching header widget types for alignment
+            GUILayout.Space(ColW_Enable);
+            GUILayout.Space(ColW_Index);
+
+            // Indent inside Name column for chains in sub-groups
             if (indent > 0f) GUILayout.Space(indent);
 
             bool expanded = expandedChains.Contains(chainId);
@@ -1613,6 +1706,13 @@ namespace Parsek
                 OpenGroupPopupForChain(chainId);
                 ParsekLog.Verbose("UI", $"Group popup opened for chain '{chainName}'");
             }
+
+            // Spacers for remaining columns (Loop, Period, Watch, Rewind, Delete)
+            GUILayout.Label("", GUILayout.Width(ColW_Loop));
+            GUILayout.Label("", GUILayout.Width(ColW_Period));
+            if (InFlight) GUILayout.Label("", GUILayout.Width(ColW_Watch));
+            GUILayout.Label("", GUILayout.Width(ColW_Rewind));
+            GUILayout.Label("", GUILayout.Width(ColW_Delete));
 
             GUILayout.EndHorizontal();
 
@@ -1646,10 +1746,26 @@ namespace Parsek
                     CollectDescendantRecordings(children[c], grpToRecs, grpChildren, result);
         }
 
+        private void CommitRecordingRename(List<RecordingStore.Recording> committed)
+        {
+            int ri = renamingRecordingIdx;
+            renamingRecordingIdx = -1;
+            activeRenameRect = default;
+            if (ri < 0 || ri >= committed.Count) return;
+
+            string trimmed = renamingRecordingText.Trim();
+            if (!string.IsNullOrEmpty(trimmed) && trimmed != committed[ri].VesselName)
+            {
+                ParsekLog.Info("UI", $"Recording '{committed[ri].VesselName}' renamed to '{trimmed}'");
+                committed[ri].VesselName = trimmed;
+            }
+        }
+
         private void CommitGroupRename(string oldName)
         {
             string newName = renamingGroupText.Trim();
             renamingGroup = null;
+            activeRenameRect = default;
 
             if (string.IsNullOrEmpty(newName) || newName == oldName) return;
 
@@ -1708,9 +1824,14 @@ namespace Parsek
             grpChildren.TryGetValue(groupName, out children);
             int childCount = children != null ? children.Count : 0;
 
-            string subText = childCount > 0
-                ? $"\n{childCount} sub-group(s) will become top-level."
-                : "";
+            string subText = "";
+            if (childCount > 0)
+            {
+                string parentName;
+                ParsekScenario.groupParents.TryGetValue(groupName, out parentName);
+                string dest = parentName != null ? $"move under \"{parentName}\"" : "become top-level";
+                subText = $"\n{childCount} sub-group(s) will {dest}.";
+            }
             string msg = $"Delete group \"{groupName}\"?\n\n" +
                 $"{recCount} recording(s) will be removed from this group.{subText}\n\n" +
                 "No recordings are deleted.";
@@ -1796,6 +1917,9 @@ namespace Parsek
 
         private void InitGroupPopupExpansion()
         {
+            // Reset popup rect so it repositions near the clicked G button
+            groupPopupRect = new Rect(0, 0, 0, 0);
+            isResizingGroupPopup = false;
             groupPopupExpanded = new HashSet<string>();
             // Default: all groups expanded
             foreach (var kvp in ParsekScenario.groupParents)
@@ -1861,106 +1985,136 @@ namespace Parsek
             }
             rootNames.Sort(System.StringComparer.OrdinalIgnoreCase);
 
-            // Popup window
-            float popupWidth = 280f;
-            float popupHeight = 300f;
-            Rect popupRect = new Rect(
-                Mathf.Clamp(groupPopupPosition.x, 0, Screen.width - popupWidth),
-                Mathf.Clamp(groupPopupPosition.y, 0, Screen.height - popupHeight),
-                popupWidth, popupHeight);
-            groupPopupRect = popupRect;
-
-            GUILayout.Window("ParsekGroupPopup".GetHashCode(), popupRect, (id) =>
+            // Handle resize drag (outside window function to track across frames)
+            if (isResizingGroupPopup)
             {
-                bool isGroupPopup = groupPopupGroup != null;
-                string title = isGroupPopup ? "Set Parent Group" : "Manage Groups";
-                GUILayout.Label(title, GUI.skin.label);
-                GUILayout.Space(3);
-
-                groupPopupScrollPos = GUILayout.BeginScrollView(groupPopupScrollPos, GUILayout.Height(180));
-
-                // For group-in-group: add "(None / Root)" option
-                if (isGroupPopup)
+                if (Event.current.type == EventType.MouseDrag || Event.current.type == EventType.MouseUp)
                 {
-                    bool noneChecked = groupPopupChecked.Count == 0;
-                    bool newNone = GUILayout.Toggle(noneChecked, "(None / Root level)");
-                    if (newNone && !noneChecked)
-                        groupPopupChecked.Clear();
+                    float newW = Mathf.Max(GroupPopupMinW, Event.current.mousePosition.x - groupPopupRect.x);
+                    float newH = Mathf.Max(GroupPopupMinH, Event.current.mousePosition.y - groupPopupRect.y);
+                    groupPopupRect.width = newW;
+                    groupPopupRect.height = newH;
                 }
+                if (Event.current.type == EventType.MouseUp)
+                    isResizingGroupPopup = false;
+            }
 
-                // Draw group hierarchy with checkboxes
-                for (int r = 0; r < rootNames.Count; r++)
-                    DrawGroupPopupNode(rootNames[r], 0, parentToChildren, cycleInvalid, isGroupPopup);
+            // Initialize popup rect on first open
+            if (groupPopupRect.width < 1f)
+            {
+                groupPopupRect = new Rect(
+                    Mathf.Clamp(groupPopupPosition.x, 0, Screen.width - 280f),
+                    Mathf.Clamp(groupPopupPosition.y, 0, Screen.height - 300f),
+                    280f, 300f);
+            }
 
-                GUILayout.EndScrollView();
+            bool isGroupPopup = groupPopupGroup != null;
+            string popupTitle = isGroupPopup ? "Set Parent Group" : "Manage Groups";
 
-                GUILayout.Space(3);
+            EnsureOpaqueWindowStyle();
+            groupPopupRect = ClickThruBlocker.GUILayoutWindow(
+                "ParsekGroupPopup".GetHashCode(),
+                groupPopupRect,
+                (id) => DrawGroupPopupContents(rootNames, parentToChildren, cycleInvalid, allNames, isGroupPopup),
+                popupTitle,
+                opaqueWindowStyle,
+                GUILayout.Width(groupPopupRect.width),
+                GUILayout.Height(groupPopupRect.height));
+        }
 
-                // New group creation
-                GUILayout.BeginHorizontal();
-                groupPopupNewName = GUILayout.TextField(groupPopupNewName, GUILayout.ExpandWidth(true));
-                if (GUILayout.Button("+", GUILayout.Width(25)))
+        private void DrawGroupPopupContents(List<string> rootNames,
+            Dictionary<string, List<string>> parentToChildren,
+            HashSet<string> cycleInvalid, HashSet<string> allNames, bool isGroupPopup)
+        {
+            groupPopupScrollPos = GUILayout.BeginScrollView(groupPopupScrollPos, GUILayout.ExpandHeight(true));
+
+            // For group-in-group: add "(None / Root)" option
+            if (isGroupPopup)
+            {
+                bool noneChecked = groupPopupChecked.Count == 0;
+                bool newNone = GUILayout.Toggle(noneChecked, "(None / Root level)");
+                if (newNone && !noneChecked)
+                    groupPopupChecked.Clear();
+            }
+
+            // Draw group hierarchy with checkboxes
+            for (int r = 0; r < rootNames.Count; r++)
+                DrawGroupPopupNode(rootNames[r], 0, parentToChildren, cycleInvalid, isGroupPopup);
+
+            GUILayout.EndScrollView();
+
+            GUILayout.Space(3);
+
+            // New group creation
+            GUILayout.BeginHorizontal();
+            groupPopupNewName = GUILayout.TextField(groupPopupNewName, GUILayout.ExpandWidth(true));
+            if (GUILayout.Button("+", GUILayout.Width(25)))
+            {
+                string newName = groupPopupNewName.Trim();
+                if (!RecordingStore.IsInvalidGroupName(newName) &&
+                    !allNames.Contains(newName) && !knownEmptyGroups.Contains(newName))
                 {
-                    string newName = groupPopupNewName.Trim();
-                    if (!RecordingStore.IsInvalidGroupName(newName) &&
-                        !allNames.Contains(newName) && !knownEmptyGroups.Contains(newName))
-                    {
-                        knownEmptyGroups.Add(newName);
-                        if (!isGroupPopup)
-                            groupPopupChecked.Add(newName);
-                        groupPopupNewName = "";
-                        ParsekLog.Info("UI", $"Group '{newName}' created via popup");
-                    }
+                    knownEmptyGroups.Add(newName);
+                    if (!isGroupPopup)
+                        groupPopupChecked.Add(newName);
+                    groupPopupNewName = "";
+                    ParsekLog.Info("UI", $"Group '{newName}' created via popup");
                 }
-                GUILayout.EndHorizontal();
+            }
+            GUILayout.EndHorizontal();
 
-                GUILayout.Space(3);
+            GUILayout.Space(3);
 
-                // Done / Cancel
-                GUILayout.BeginHorizontal();
-                GUILayout.FlexibleSpace();
-                if (GUILayout.Button("Done", GUILayout.Width(60)))
-                {
-                    ApplyGroupPopupChanges();
-                    groupPopupOpen = false;
-                }
-                if (GUILayout.Button("Cancel", GUILayout.Width(60)))
-                {
-                    groupPopupOpen = false;
-                }
-                GUILayout.FlexibleSpace();
-                GUILayout.EndHorizontal();
-
-                GUI.DragWindow();
-            }, "");
-
-            // Click outside → close
-            if (Event.current.type == EventType.MouseDown &&
-                !groupPopupRect.Contains(Event.current.mousePosition))
+            // Done / Cancel
+            GUILayout.BeginHorizontal();
+            GUILayout.FlexibleSpace();
+            if (GUILayout.Button("OK", GUILayout.Width(60)))
+            {
+                ApplyGroupPopupChanges();
+                groupPopupOpen = false;
+            }
+            if (GUILayout.Button("Cancel", GUILayout.Width(60)))
             {
                 groupPopupOpen = false;
+            }
+            GUILayout.FlexibleSpace();
+            GUILayout.EndHorizontal();
+
+            // Resize handle (bottom-right corner)
+            Rect handleRect = new Rect(
+                groupPopupRect.width - ResizeHandleSize,
+                groupPopupRect.height - ResizeHandleSize,
+                ResizeHandleSize, ResizeHandleSize);
+            GUI.Label(handleRect, "\u25e2");
+            if (Event.current.type == EventType.MouseDown && handleRect.Contains(Event.current.mousePosition))
+            {
+                isResizingGroupPopup = true;
                 Event.current.Use();
             }
+
+            GUI.DragWindow();
         }
 
         private void DrawGroupPopupNode(string groupName, int depth,
             Dictionary<string, List<string>> parentToChildren,
             HashSet<string> cycleInvalid, bool singleSelect)
         {
-            GUILayout.BeginHorizontal();
-            if (depth > 0) GUILayout.Space(depth * 15f);
+            // Skip self + all descendants (can't assign a group to itself or its children)
+            if (cycleInvalid != null && cycleInvalid.Contains(groupName))
+                return;
 
-            bool isCycleInvalid = cycleInvalid != null && cycleInvalid.Contains(groupName);
-            bool wasEnabled = GUI.enabled;
-            if (isCycleInvalid) GUI.enabled = false;
+            List<string> children;
+            bool hasChildren = parentToChildren.TryGetValue(groupName, out children) && children.Count > 0;
+
+            GUILayout.BeginHorizontal();
+            if (depth > 0) GUILayout.Space(depth * 12f);
 
             bool isChecked = groupPopupChecked.Contains(groupName);
-            bool newChecked = GUILayout.Toggle(isChecked, "");
-            if (newChecked != isChecked && !isCycleInvalid)
+            bool newChecked = GUILayout.Toggle(isChecked, "", GUILayout.Width(20));
+            if (newChecked != isChecked)
             {
                 if (singleSelect)
                 {
-                    // For group-in-group: single parent only
                     groupPopupChecked.Clear();
                     if (newChecked) groupPopupChecked.Add(groupName);
                 }
@@ -1971,29 +2125,18 @@ namespace Parsek
                 }
             }
 
-            if (isCycleInvalid) GUI.enabled = wasEnabled;
-
-            // Group name with expand arrow if has children
-            List<string> children;
-            bool hasChildren = parentToChildren.TryGetValue(groupName, out children) && children.Count > 0;
-
             if (hasChildren)
             {
                 bool expanded = groupPopupExpanded.Contains(groupName);
                 string arrow = expanded ? "\u25bc" : "\u25b6";
-                if (GUILayout.Button(arrow, GUI.skin.label, GUILayout.Width(15)))
+                if (GUILayout.Button(arrow, GUI.skin.label, GUILayout.Width(14)))
                 {
                     if (expanded) groupPopupExpanded.Remove(groupName);
                     else groupPopupExpanded.Add(groupName);
                 }
             }
-            else
-            {
-                GUILayout.Space(15);
-            }
 
-            string tooltip = isCycleInvalid ? "Cannot assign (would create cycle)" : "";
-            GUILayout.Label(new GUIContent(groupName, tooltip));
+            GUILayout.Label(groupName, GUILayout.ExpandWidth(true));
 
             GUILayout.EndHorizontal();
 
@@ -2241,6 +2384,11 @@ namespace Parsek
                 case SortColumn.Index:
                     cmp = 0; // stable — Array.Sort preserves original order for equal elements
                     break;
+                case SortColumn.Phase:
+                    string pa = RecordingStore.GetSegmentPhaseLabel(ra);
+                    string pb = RecordingStore.GetSegmentPhaseLabel(rb);
+                    cmp = string.Compare(pa, pb, System.StringComparison.OrdinalIgnoreCase);
+                    break;
                 case SortColumn.Name:
                     string na = string.IsNullOrEmpty(ra.VesselName) ? "Untitled" : ra.VesselName;
                     string nb = string.IsNullOrEmpty(rb.VesselName) ? "Untitled" : rb.VesselName;
@@ -2480,11 +2628,13 @@ namespace Parsek
                 ParsekLog.Verbose("UI", $"Settings window initial position: x={settingsWindowRect.x.ToString("F0", ic)} y={settingsWindowRect.y.ToString("F0", ic)}");
             }
 
+            EnsureOpaqueWindowStyle();
             settingsWindowRect = ClickThruBlocker.GUILayoutWindow(
                 "ParsekSettings".GetHashCode(),
                 settingsWindowRect,
                 DrawSettingsWindow,
                 "Parsek \u2014 Settings",
+                opaqueWindowStyle,
                 GUILayout.Width(280)
             );
             LogWindowPosition("Settings", ref lastSettingsWindowRect, settingsWindowRect);

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -68,9 +68,48 @@ namespace Parsek
         private const float ColW_Delete = 50f;
         private const float ScrollbarWidth = 16f;
 
-        // Chain grouping state
+        // Chain and group expansion state
         private HashSet<string> expandedChains = new HashSet<string>();
         private HashSet<string> expandedGroups = new HashSet<string>();
+
+        // Group rename (deferred to next frame to avoid IMGUI layout mismatch)
+        private string renamingGroup;
+        private string renamingGroupText = "";
+
+        // Recording rename (deferred to next frame)
+        private int renamingRecordingIdx = -1;
+        private string renamingRecordingText = "";
+
+        // Double-click detection
+        private int lastClickedRecIdx = -1;
+        private float lastClickTime;
+        private string lastClickedGroup;
+        private float lastGroupClickTime;
+        private const float DoubleClickThreshold = 0.3f;
+
+        // Group picker popup state
+        private bool groupPopupOpen;
+        private int groupPopupRecIdx = -1;
+        private string groupPopupChainId;
+        private string groupPopupGroup;
+        private Vector2 groupPopupPosition;
+        private HashSet<string> groupPopupChecked;
+        private HashSet<string> groupPopupOriginal;
+        private HashSet<string> groupPopupExpanded;
+        private string groupPopupNewName = "";
+        private Rect groupPopupRect;
+        private Vector2 groupPopupScrollPos;
+        private const float ColW_Group = 50f;
+
+        // Group-level loop period editing
+        private string editingGroupLoopPeriod;
+        private string editingGroupLoopText = "";
+
+        // Group delete confirm
+        private string deleteConfirmGroup;
+
+        // Runtime-only empty groups (not persisted)
+        private List<string> knownEmptyGroups = new List<string>();
 
         // Cached phase label styles
         private GUIStyle phaseStyleAtmo;
@@ -738,6 +777,9 @@ namespace Parsek
             );
             LogWindowPosition("Recordings", ref lastRecordingsWindowRect, recordingsWindowRect);
 
+            // Group picker popup (rendered outside recordings window to avoid scroll clipping)
+            DrawGroupPickerPopup();
+
             // Lock camera controls (including scroll zoom) when mouse is over window.
             // ClickThroughBlocker uses ALLBUTCAMERAS which intentionally leaves camera
             // controls unlocked. We add our own lock for CAMERACONTROLS to block scroll zoom.
@@ -823,6 +865,9 @@ namespace Parsek
 
                 DrawSortableHeader("Status", SortColumn.Status, ColW_Status);
 
+                // Group column header
+                GUILayout.Label("Group", GUILayout.Width(ColW_Group));
+
                 // Select-all loop header + checkbox
                 int loopCount = 0;
                 for (int i = 0; i < committed.Count; i++)
@@ -863,142 +908,125 @@ namespace Parsek
                 // Rebuild if a header click invalidated during this frame
                 RebuildSortedIndices(committed, now);
 
-                // Build chain grouping: chainId → list of sorted row indices
-                // Build tag grouping: recordingGroup → list of sorted row indices
-                var chainRows = new Dictionary<string, List<int>>();
-                var seenChains = new HashSet<string>();
-                var groupRows = new Dictionary<string, List<int>>();
+                // ── Build group tree data ──────────────────────────────────
+                // group name → list of recording indices directly in that group
+                var grpToRecs = new Dictionary<string, List<int>>();
+                // chainId → list of recording indices
+                var chainToRecs = new Dictionary<string, List<int>>();
 
                 for (int row = 0; row < sortedIndices.Length; row++)
                 {
                     int ri = sortedIndices[row];
                     var rec = committed[ri];
+
+                    // Multi-group: recording appears in each group it belongs to
+                    if (rec.RecordingGroups != null)
+                    {
+                        for (int g = 0; g < rec.RecordingGroups.Count; g++)
+                        {
+                            string grp = rec.RecordingGroups[g];
+                            List<int> list;
+                            if (!grpToRecs.TryGetValue(grp, out list))
+                            {
+                                list = new List<int>();
+                                grpToRecs[grp] = list;
+                            }
+                            if (!list.Contains(ri)) list.Add(ri);
+                        }
+                    }
+
+                    // Build chain lookup
                     if (!string.IsNullOrEmpty(rec.ChainId))
                     {
                         List<int> list;
-                        if (!chainRows.TryGetValue(rec.ChainId, out list))
+                        if (!chainToRecs.TryGetValue(rec.ChainId, out list))
                         {
                             list = new List<int>();
-                            chainRows[rec.ChainId] = list;
-                        }
-                        list.Add(ri);
-                    }
-                    else if (!string.IsNullOrEmpty(rec.RecordingGroup))
-                    {
-                        List<int> list;
-                        if (!groupRows.TryGetValue(rec.RecordingGroup, out list))
-                        {
-                            list = new List<int>();
-                            groupRows[rec.RecordingGroup] = list;
+                            chainToRecs[rec.ChainId] = list;
                         }
                         list.Add(ri);
                     }
                 }
 
-                // Draw in sorted order — standalone rows inline, chain groups
-                // emitted at the position of their first sorted member
-                bool deleted = false;
-                var groupSet = new HashSet<int>();
-                foreach (var glist in groupRows.Values)
-                    foreach (var gi in glist) groupSet.Add(gi);
-                var drawnGroups = new HashSet<string>();
+                // Build parent → children map from hierarchy
+                var grpChildren = new Dictionary<string, List<string>>();
+                var allGrpNames = new HashSet<string>(grpToRecs.Keys);
+                foreach (var kvp in ParsekScenario.groupParents)
+                {
+                    allGrpNames.Add(kvp.Key);
+                    allGrpNames.Add(kvp.Value);
+                }
+                for (int i = 0; i < knownEmptyGroups.Count; i++)
+                    allGrpNames.Add(knownEmptyGroups[i]);
 
+                foreach (var kvp in ParsekScenario.groupParents)
+                {
+                    List<string> children;
+                    if (!grpChildren.TryGetValue(kvp.Value, out children))
+                    {
+                        children = new List<string>();
+                        grpChildren[kvp.Value] = children;
+                    }
+                    if (!children.Contains(kvp.Key)) children.Add(kvp.Key);
+                }
+                foreach (var ch in grpChildren.Values)
+                    ch.Sort(System.StringComparer.OrdinalIgnoreCase);
+
+                // Root groups: in allGrpNames but not a child in groupParents
+                var rootGrps = new List<string>();
+                foreach (var g in allGrpNames)
+                {
+                    if (!ParsekScenario.groupParents.ContainsKey(g))
+                        rootGrps.Add(g);
+                }
+                rootGrps.Sort(System.StringComparer.OrdinalIgnoreCase);
+
+                // Root chains: chains where NO member has any RecordingGroups
+                var rootChainIds = new HashSet<string>();
+                foreach (var kvp in chainToRecs)
+                {
+                    bool anyInGrp = false;
+                    for (int i = 0; i < kvp.Value.Count; i++)
+                    {
+                        var rec = committed[kvp.Value[i]];
+                        if (rec.RecordingGroups != null && rec.RecordingGroups.Count > 0)
+                        { anyInGrp = true; break; }
+                    }
+                    if (!anyInGrp) rootChainIds.Add(kvp.Key);
+                }
+
+                // ── Draw tree ─────────────────────────────────────────────
+                bool deleted = false;
+
+                // Root groups
+                for (int g = 0; g < rootGrps.Count && !deleted; g++)
+                    deleted = DrawGroupTree(rootGrps[g], 0, committed, now,
+                        grpToRecs, chainToRecs, grpChildren);
+
+                // Root chains
+                var drawnRootChains = new HashSet<string>();
                 for (int row = 0; row < sortedIndices.Length && !deleted; row++)
                 {
                     int ri = sortedIndices[row];
                     var rec = committed[ri];
+                    if (string.IsNullOrEmpty(rec.ChainId) || !rootChainIds.Contains(rec.ChainId))
+                        continue;
+                    if (!drawnRootChains.Add(rec.ChainId)) continue;
+                    deleted = DrawChainBlock(rec.ChainId, chainToRecs[rec.ChainId],
+                        0, committed, now);
+                }
 
-                    if (groupSet.Contains(ri))
+                // Standalone recordings (no groups, no chain)
+                for (int row = 0; row < sortedIndices.Length && !deleted; row++)
+                {
+                    int ri = sortedIndices[row];
+                    var rec = committed[ri];
+                    if ((rec.RecordingGroups == null || rec.RecordingGroups.Count == 0) &&
+                        string.IsNullOrEmpty(rec.ChainId))
                     {
-                        string grp = rec.RecordingGroup;
-                        if (drawnGroups.Add(grp))
-                        {
-                            var members = groupRows[grp];
-                            // Group header
-                            GUILayout.BeginHorizontal();
-
-                            // Group enable checkbox
-                            int enabledCount = 0;
-                            for (int s = 0; s < members.Count; s++)
-                                if (committed[members[s]].PlaybackEnabled) enabledCount++;
-                            bool grpAllEnabled = enabledCount == members.Count;
-                            bool grpNewEnabled = GUILayout.Toggle(grpAllEnabled, "", GUILayout.Width(ColW_Enable));
-                            if (grpNewEnabled != grpAllEnabled)
-                            {
-                                for (int s = 0; s < members.Count; s++)
-                                    committed[members[s]].PlaybackEnabled = grpNewEnabled;
-                                ParsekLog.Info("UI", $"Set playback enabled for group '{grp}': enabled={grpNewEnabled}");
-                            }
-
-                            bool expanded = expandedGroups.Contains(grp);
-                            string arrow = expanded ? "\u25bc" : "\u25b6";
-                            if (GUILayout.Button($"{arrow} {grp} ({members.Count})",
-                                GUI.skin.label, GUILayout.ExpandWidth(true)))
-                            {
-                                if (expanded) expandedGroups.Remove(grp);
-                                else expandedGroups.Add(grp);
-                                expanded = !expanded;
-                                ParsekLog.Verbose("UI", $"Group '{grp}' {(expanded ? "expanded" : "collapsed")} ({members.Count} recordings)");
-                            }
-                            GUILayout.EndHorizontal();
-
-                            if (expanded)
-                            {
-                                for (int s = 0; s < members.Count; s++)
-                                {
-                                    if (DrawRecordingRow(members[s], committed, now, true))
-                                    { deleted = true; break; }
-                                }
-                            }
-                        }
-                        // else: already drawn with group — skip
-                    }
-                    else if (string.IsNullOrEmpty(rec.ChainId))
-                    {
-                        // Standalone recording (non-showcase)
-                        if (DrawRecordingRow(ri, committed, now, false))
+                        if (DrawRecordingRow(ri, committed, now, 0f))
                         { deleted = true; break; }
                     }
-                    else if (seenChains.Add(rec.ChainId))
-                    {
-                        // First time seeing this chain — draw the whole group here
-                        var members = chainRows[rec.ChainId];
-
-                        // Chain header
-                        GUILayout.BeginHorizontal();
-                        bool expanded = expandedChains.Contains(rec.ChainId);
-                        string arrow = expanded ? "\u25bc" : "\u25b6";
-                        string chainName = committed[members[0]].VesselName;
-                        if (string.IsNullOrEmpty(chainName)) chainName = "Chain";
-
-                        // Aggregate duration
-                        double chainStart = double.MaxValue, chainEnd = double.MinValue;
-                        for (int m = 0; m < members.Count; m++)
-                        {
-                            var mr = committed[members[m]];
-                            if (mr.StartUT < chainStart) chainStart = mr.StartUT;
-                            if (mr.EndUT > chainEnd) chainEnd = mr.EndUT;
-                        }
-
-                        if (GUILayout.Button($"{arrow} {chainName} ({members.Count} segments, {FormatDuration(chainEnd - chainStart)})",
-                            GUI.skin.label, GUILayout.ExpandWidth(true)))
-                        {
-                            if (expanded) expandedChains.Remove(rec.ChainId);
-                            else expandedChains.Add(rec.ChainId);
-                            ParsekLog.Verbose("UI", $"Chain '{chainName}' {(expanded ? "collapsed" : "expanded")} ({members.Count} segments)");
-                        }
-                        GUILayout.EndHorizontal();
-
-                        if (expanded)
-                        {
-                            for (int m = 0; m < members.Count; m++)
-                            {
-                                if (DrawRecordingRow(members[m], committed, now, true))
-                                { deleted = true; break; }
-                            }
-                        }
-                    }
-                    // else: chain member already drawn with its group — skip
                 }
 
                 GUILayout.EndScrollView();
@@ -1030,10 +1058,21 @@ namespace Parsek
                 }
             }
 
+            if (GUILayout.Button("New Group", GUILayout.Width(80)))
+            {
+                string newName = GenerateUniqueGroupName();
+                knownEmptyGroups.Add(newName);
+                expandedGroups.Add(newName);
+                renamingGroup = newName;
+                renamingGroupText = newName;
+                ParsekLog.Info("UI", $"Group '{newName}' created");
+            }
+
             if (GUILayout.Button("Close"))
             {
                 showRecordingsWindow = false;
                 deleteConfirmIndex = -1;
+                groupPopupOpen = false;
                 ParsekLog.Verbose("UI", "Recordings window closed via button");
             }
 
@@ -1067,13 +1106,13 @@ namespace Parsek
         /// <summary>
         /// Draws a single recording row. Returns true if the list was modified (break iteration).
         /// </summary>
-        private bool DrawRecordingRow(int ri, List<RecordingStore.Recording> committed, double now, bool indented)
+        private bool DrawRecordingRow(int ri, List<RecordingStore.Recording> committed, double now, float indentPx)
         {
             var rec = committed[ri];
             GUILayout.BeginHorizontal();
 
-            if (indented)
-                GUILayout.Space(15f); // indent chain children
+            if (indentPx > 0f)
+                GUILayout.Space(indentPx);
 
             // Enable checkbox
             bool enabled = GUILayout.Toggle(rec.PlaybackEnabled, "", GUILayout.Width(ColW_Enable));
@@ -1102,9 +1141,51 @@ namespace Parsek
                 GUILayout.Label("", GUILayout.Width(ColW_Phase));
             }
 
-            // Name
+            // Name (double-click to rename, deferred to next frame)
             string name = string.IsNullOrEmpty(rec.VesselName) ? "Untitled" : rec.VesselName;
-            GUILayout.Label(name, GUILayout.ExpandWidth(true));
+            if (renamingRecordingIdx == ri)
+            {
+                GUI.SetNextControlName("RecRename");
+                renamingRecordingText = GUILayout.TextField(renamingRecordingText, GUILayout.ExpandWidth(true));
+                if (Event.current.type == EventType.KeyDown)
+                {
+                    if (Event.current.keyCode == KeyCode.Return || Event.current.keyCode == KeyCode.KeypadEnter)
+                    {
+                        string trimmed = renamingRecordingText.Trim();
+                        if (!string.IsNullOrEmpty(trimmed) && trimmed != rec.VesselName)
+                        {
+                            ParsekLog.Info("UI", $"Recording '{rec.VesselName}' renamed to '{trimmed}'");
+                            rec.VesselName = trimmed;
+                        }
+                        renamingRecordingIdx = -1;
+                        Event.current.Use();
+                    }
+                    else if (Event.current.keyCode == KeyCode.Escape)
+                    {
+                        renamingRecordingIdx = -1;
+                        Event.current.Use();
+                    }
+                }
+            }
+            else
+            {
+                if (GUILayout.Button(name, GUI.skin.label, GUILayout.ExpandWidth(true)))
+                {
+                    float now2 = Time.realtimeSinceStartup;
+                    if (lastClickedRecIdx == ri && now2 - lastClickTime < DoubleClickThreshold)
+                    {
+                        // Double-click detected — defer rename to next frame
+                        renamingRecordingIdx = ri;
+                        renamingRecordingText = rec.VesselName ?? "";
+                        lastClickedRecIdx = -1;
+                    }
+                    else
+                    {
+                        lastClickedRecIdx = ri;
+                        lastClickTime = now2;
+                    }
+                }
+            }
 
             // Launch Time
             string launchTime = rec.Points.Count > 0
@@ -1145,6 +1226,14 @@ namespace Parsek
                 statusText = "past";
             }
             GUILayout.Label(statusText, statusStyle, GUILayout.Width(ColW_Status));
+
+            // Group assignment button
+            if (GUILayout.Button("G", GUILayout.Width(ColW_Group)))
+            {
+                groupPopupPosition = GUIUtility.GUIToScreenPoint(Event.current.mousePosition);
+                OpenGroupPopupForRecording(ri);
+                ParsekLog.Verbose("UI", $"Group popup opened for recording index={ri} name='{rec.VesselName}'");
+            }
 
             // Loop checkbox
             GUILayout.BeginHorizontal(GUILayout.Width(ColW_Loop));
@@ -1261,10 +1350,11 @@ namespace Parsek
                     new DialogGUIButton("Delete", () =>
                     {
                         ParsekLog.Info("UI", $"Delete confirmed for recording index={capturedIndex} name='{capturedName}'");
-                        if (editingLoopPeriodIdx == capturedIndex)
-                            editingLoopPeriodIdx = -1;
-                        else if (editingLoopPeriodIdx > capturedIndex)
-                            editingLoopPeriodIdx--;
+                        // Adjust index-based state fields
+                        AdjustIndexOnDelete(ref editingLoopPeriodIdx, capturedIndex);
+                        AdjustIndexOnDelete(ref renamingRecordingIdx, capturedIndex);
+                        if (groupPopupRecIdx == capturedIndex) groupPopupOpen = false;
+                        else if (groupPopupRecIdx > capturedIndex) groupPopupRecIdx--;
                         if (InFlight)
                             flight.DeleteRecording(capturedIndex);
                         else
@@ -1277,6 +1367,692 @@ namespace Parsek
                     })
                 ),
                 false, HighLogic.UISkin);
+        }
+
+        // ─── Group tree rendering helpers ─────────────────────────────────
+
+        /// <summary>
+        /// Recursively draws a group and its children. Returns true if the recording list was modified.
+        /// </summary>
+        private bool DrawGroupTree(string groupName, int depth,
+            List<RecordingStore.Recording> committed, double now,
+            Dictionary<string, List<int>> grpToRecs,
+            Dictionary<string, List<int>> chainToRecs,
+            Dictionary<string, List<string>> grpChildren)
+        {
+            // Collect unique descendant recordings for aggregate controls
+            var descendants = new HashSet<int>();
+            CollectDescendantRecordings(groupName, grpToRecs, grpChildren, descendants);
+            int memberCount = descendants.Count;
+
+            float indent = depth * 15f;
+
+            // ── Group header ──
+            GUILayout.BeginHorizontal();
+            if (indent > 0f) GUILayout.Space(indent);
+
+            // Enable checkbox (aggregate)
+            int enabledCount = 0;
+            foreach (int idx in descendants)
+                if (committed[idx].PlaybackEnabled) enabledCount++;
+            bool allEnabled = memberCount > 0 && enabledCount == memberCount;
+            bool newEnabled = GUILayout.Toggle(allEnabled, "", GUILayout.Width(ColW_Enable));
+            if (newEnabled != allEnabled)
+            {
+                foreach (int idx in descendants)
+                    committed[idx].PlaybackEnabled = newEnabled;
+                ParsekLog.Info("UI", $"Set playback enabled for group '{groupName}': enabled={newEnabled}");
+            }
+
+            // Expand/collapse + name (or rename TextField)
+            bool expanded = expandedGroups.Contains(groupName);
+            string arrow = expanded ? "\u25bc" : "\u25b6";
+
+            if (renamingGroup == groupName)
+            {
+                GUILayout.Label(arrow, GUILayout.Width(15));
+                GUI.SetNextControlName("GrpRename");
+                renamingGroupText = GUILayout.TextField(renamingGroupText, GUILayout.ExpandWidth(true));
+                if (Event.current.type == EventType.KeyDown)
+                {
+                    if (Event.current.keyCode == KeyCode.Return || Event.current.keyCode == KeyCode.KeypadEnter)
+                    {
+                        CommitGroupRename(groupName);
+                        Event.current.Use();
+                    }
+                    else if (Event.current.keyCode == KeyCode.Escape)
+                    {
+                        renamingGroup = null;
+                        Event.current.Use();
+                    }
+                }
+            }
+            else
+            {
+                if (GUILayout.Button($"{arrow} {groupName} ({memberCount})",
+                    GUI.skin.label, GUILayout.ExpandWidth(true)))
+                {
+                    float t = Time.realtimeSinceStartup;
+                    if (lastClickedGroup == groupName && t - lastGroupClickTime < DoubleClickThreshold)
+                    {
+                        renamingGroup = groupName;
+                        renamingGroupText = groupName;
+                        lastClickedGroup = null;
+                    }
+                    else
+                    {
+                        if (expanded) expandedGroups.Remove(groupName);
+                        else expandedGroups.Add(groupName);
+                        expanded = !expanded;
+                        lastClickedGroup = groupName;
+                        lastGroupClickTime = t;
+                        ParsekLog.Verbose("UI", $"Group '{groupName}' {(expanded ? "expanded" : "collapsed")} ({memberCount} recordings)");
+                    }
+                }
+            }
+
+            // G button (assign parent group)
+            if (GUILayout.Button("G", GUILayout.Width(ColW_Group)))
+            {
+                groupPopupPosition = GUIUtility.GUIToScreenPoint(Event.current.mousePosition);
+                OpenGroupPopupForGroup(groupName);
+                ParsekLog.Verbose("UI", $"Group popup opened for group '{groupName}'");
+            }
+
+            // Loop checkbox (aggregate)
+            int loopCount = 0;
+            foreach (int idx in descendants)
+                if (committed[idx].LoopPlayback) loopCount++;
+            bool allLoop = memberCount > 0 && loopCount == memberCount;
+            GUILayout.BeginHorizontal(GUILayout.Width(ColW_Loop));
+            GUILayout.FlexibleSpace();
+            bool newLoop = GUILayout.Toggle(allLoop, "");
+            GUILayout.FlexibleSpace();
+            GUILayout.EndHorizontal();
+            if (newLoop != allLoop)
+            {
+                foreach (int idx in descendants)
+                    committed[idx].LoopPlayback = newLoop;
+                ParsekLog.Info("UI", $"Group '{groupName}' loop set to {newLoop} ({descendants.Count} recordings)");
+            }
+
+            // Period placeholder
+            GUILayout.Label("", GUILayout.Width(ColW_Period));
+
+            // Spacers for Watch/Rewind
+            if (InFlight) GUILayout.Label("", GUILayout.Width(ColW_Watch));
+            GUILayout.Label("", GUILayout.Width(ColW_Rewind));
+
+            // Delete group button (two-stage)
+            if (deleteConfirmGroup == groupName)
+            {
+                if (GUILayout.Button("?", GUILayout.Width(ColW_Delete)))
+                {
+                    deleteConfirmGroup = null;
+                    ShowDeleteGroupConfirmation(groupName, descendants, grpChildren);
+                }
+                if (Event.current.type == EventType.MouseDown && Event.current.button == 1 &&
+                    GUILayoutUtility.GetLastRect().Contains(Event.current.mousePosition))
+                {
+                    deleteConfirmGroup = null;
+                    Event.current.Use();
+                }
+            }
+            else
+            {
+                if (GUILayout.Button("X", GUILayout.Width(ColW_Delete)))
+                {
+                    deleteConfirmGroup = groupName;
+                    ParsekLog.Verbose("UI", $"Delete armed for group '{groupName}'");
+                }
+            }
+
+            GUILayout.EndHorizontal();
+
+            if (!expanded) return false;
+
+            // ── Draw children ──
+            List<int> directMembers;
+            grpToRecs.TryGetValue(groupName, out directMembers);
+
+            if (directMembers != null)
+            {
+                // Separate chained vs standalone within this group
+                var chainsInGrp = new HashSet<string>();
+                var standaloneInGrp = new List<int>();
+
+                for (int i = 0; i < directMembers.Count; i++)
+                {
+                    int ri = directMembers[i];
+                    var rec = committed[ri];
+                    if (!string.IsNullOrEmpty(rec.ChainId))
+                        chainsInGrp.Add(rec.ChainId);
+                    else
+                        standaloneInGrp.Add(ri);
+                }
+
+                // Draw chains within this group
+                var drawnChains = new HashSet<string>();
+                for (int i = 0; i < directMembers.Count; i++)
+                {
+                    var rec = committed[directMembers[i]];
+                    if (!string.IsNullOrEmpty(rec.ChainId) && drawnChains.Add(rec.ChainId))
+                    {
+                        List<int> fullChain;
+                        if (chainToRecs.TryGetValue(rec.ChainId, out fullChain))
+                        {
+                            if (DrawChainBlock(rec.ChainId, fullChain, depth + 1, committed, now))
+                                return true;
+                        }
+                    }
+                }
+
+                // Draw standalone recordings
+                for (int i = 0; i < standaloneInGrp.Count; i++)
+                {
+                    if (DrawRecordingRow(standaloneInGrp[i], committed, now, (depth + 1) * 15f))
+                        return true;
+                }
+            }
+
+            // Draw child groups
+            List<string> children;
+            if (grpChildren.TryGetValue(groupName, out children))
+            {
+                for (int c = 0; c < children.Count; c++)
+                {
+                    if (DrawGroupTree(children[c], depth + 1, committed, now,
+                        grpToRecs, chainToRecs, grpChildren))
+                        return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Draws a chain block (header + members). Returns true if the recording list was modified.
+        /// </summary>
+        private bool DrawChainBlock(string chainId, List<int> members, int depth,
+            List<RecordingStore.Recording> committed, double now)
+        {
+            float indent = depth * 15f;
+
+            GUILayout.BeginHorizontal();
+            if (indent > 0f) GUILayout.Space(indent);
+
+            bool expanded = expandedChains.Contains(chainId);
+            string arrow = expanded ? "\u25bc" : "\u25b6";
+            string chainName = committed[members[0]].VesselName;
+            if (string.IsNullOrEmpty(chainName)) chainName = "Chain";
+
+            double chainStart = double.MaxValue, chainEnd = double.MinValue;
+            for (int m = 0; m < members.Count; m++)
+            {
+                var mr = committed[members[m]];
+                if (mr.StartUT < chainStart) chainStart = mr.StartUT;
+                if (mr.EndUT > chainEnd) chainEnd = mr.EndUT;
+            }
+
+            if (GUILayout.Button($"{arrow} {chainName} ({members.Count} segments, {FormatDuration(chainEnd - chainStart)})",
+                GUI.skin.label, GUILayout.ExpandWidth(true)))
+            {
+                if (expanded) expandedChains.Remove(chainId);
+                else expandedChains.Add(chainId);
+                ParsekLog.Verbose("UI", $"Chain '{chainName}' {(expanded ? "collapsed" : "expanded")} ({members.Count} segments)");
+            }
+
+            // Chain G button
+            if (GUILayout.Button("G", GUILayout.Width(ColW_Group)))
+            {
+                groupPopupPosition = GUIUtility.GUIToScreenPoint(Event.current.mousePosition);
+                OpenGroupPopupForChain(chainId);
+                ParsekLog.Verbose("UI", $"Group popup opened for chain '{chainName}'");
+            }
+
+            GUILayout.EndHorizontal();
+
+            if (expanded)
+            {
+                for (int m = 0; m < members.Count; m++)
+                {
+                    if (DrawRecordingRow(members[m], committed, now, (depth + 1) * 15f))
+                        return true;
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Recursively collects all unique recording indices under a group.
+        /// </summary>
+        private void CollectDescendantRecordings(string groupName,
+            Dictionary<string, List<int>> grpToRecs,
+            Dictionary<string, List<string>> grpChildren,
+            HashSet<int> result)
+        {
+            List<int> direct;
+            if (grpToRecs.TryGetValue(groupName, out direct))
+                for (int i = 0; i < direct.Count; i++)
+                    result.Add(direct[i]);
+
+            List<string> children;
+            if (grpChildren.TryGetValue(groupName, out children))
+                for (int c = 0; c < children.Count; c++)
+                    CollectDescendantRecordings(children[c], grpToRecs, grpChildren, result);
+        }
+
+        private void CommitGroupRename(string oldName)
+        {
+            string newName = renamingGroupText.Trim();
+            renamingGroup = null;
+
+            if (string.IsNullOrEmpty(newName) || newName == oldName) return;
+
+            // Validate characters
+            if (newName.Contains("=") || newName.Contains("{") || newName.Contains("}") ||
+                newName.Contains("\n") || newName.Contains("\r"))
+            {
+                ParsekLog.Warn("UI", $"Group rename rejected: '{newName}' contains invalid characters");
+                return;
+            }
+
+            // Apply rename in recordings and hierarchy
+            if (!RecordingStore.RenameGroup(oldName, newName))
+            {
+                ParsekLog.Warn("UI", $"Group rename rejected: '{newName}' already exists");
+                return;
+            }
+
+            ParsekScenario.RenameGroupInHierarchy(oldName, newName);
+
+            // Update expansion state
+            if (expandedGroups.Remove(oldName))
+                expandedGroups.Add(newName);
+
+            // Update knownEmptyGroups
+            int emptyIdx = knownEmptyGroups.IndexOf(oldName);
+            if (emptyIdx >= 0) knownEmptyGroups[emptyIdx] = newName;
+
+            ParsekLog.Info("UI", $"Group '{oldName}' renamed to '{newName}'");
+        }
+
+        private static void AdjustIndexOnDelete(ref int idx, int deletedIndex)
+        {
+            if (idx == deletedIndex) idx = -1;
+            else if (idx > deletedIndex) idx--;
+        }
+
+        private string GenerateUniqueGroupName()
+        {
+            var existing = RecordingStore.GetGroupNames();
+            for (int i = 0; i < knownEmptyGroups.Count; i++)
+                if (!existing.Contains(knownEmptyGroups[i]))
+                    existing.Add(knownEmptyGroups[i]);
+
+            for (int n = 1; ; n++)
+            {
+                string name = "Group " + n;
+                if (!existing.Contains(name)) return name;
+            }
+        }
+
+        private void ShowDeleteGroupConfirmation(string groupName,
+            HashSet<int> descendants,
+            Dictionary<string, List<string>> grpChildren)
+        {
+            int recCount = descendants.Count;
+            List<string> children;
+            grpChildren.TryGetValue(groupName, out children);
+            int childCount = children != null ? children.Count : 0;
+
+            string subText = childCount > 0
+                ? $"\n{childCount} sub-group(s) will become top-level."
+                : "";
+            string msg = $"Delete group \"{groupName}\"?\n\n" +
+                $"{recCount} recording(s) will be removed from this group.{subText}\n\n" +
+                "No recordings are deleted.";
+
+            string capturedName = groupName;
+            PopupDialog.SpawnPopupDialog(
+                new Vector2(0.5f, 0.5f), new Vector2(0.5f, 0.5f),
+                new MultiOptionDialog("ParsekDeleteGroupConfirm", msg,
+                    "Confirm Delete Group", HighLogic.UISkin,
+                    new DialogGUIButton("Delete Group", () =>
+                    {
+                        int updated = RecordingStore.RemoveGroupFromAll(capturedName);
+                        ParsekScenario.RemoveGroupFromHierarchy(capturedName);
+                        knownEmptyGroups.Remove(capturedName);
+                        expandedGroups.Remove(capturedName);
+                        ParsekLog.Info("UI", $"Group '{capturedName}' deleted ({updated} recordings updated)");
+                    }),
+                    new DialogGUIButton("Cancel", () =>
+                    {
+                        ParsekLog.Verbose("UI", $"Delete group '{capturedName}' cancelled");
+                    })
+                ), false, HighLogic.UISkin);
+        }
+
+        // ─── Group picker popup ───────────────────────────────────────
+
+        private void OpenGroupPopupForRecording(int ri)
+        {
+            var rec = RecordingStore.CommittedRecordings[ri];
+            groupPopupOpen = true;
+            groupPopupRecIdx = ri;
+            groupPopupChainId = null;
+            groupPopupGroup = null;
+            groupPopupChecked = rec.RecordingGroups != null
+                ? new HashSet<string>(rec.RecordingGroups) : new HashSet<string>();
+            groupPopupOriginal = new HashSet<string>(groupPopupChecked);
+            groupPopupNewName = "";
+            InitGroupPopupExpansion();
+        }
+
+        private void OpenGroupPopupForChain(string chainId)
+        {
+            groupPopupOpen = true;
+            groupPopupRecIdx = -1;
+            groupPopupChainId = chainId;
+            groupPopupGroup = null;
+            // Checked = groups that ALL chain members are in
+            var committed = RecordingStore.CommittedRecordings;
+            var allGroups = RecordingStore.GetGroupNames();
+            groupPopupChecked = new HashSet<string>();
+            for (int g = 0; g < allGroups.Count; g++)
+            {
+                bool allIn = true;
+                for (int i = 0; i < committed.Count; i++)
+                {
+                    if (committed[i].ChainId == chainId)
+                    {
+                        if (committed[i].RecordingGroups == null || !committed[i].RecordingGroups.Contains(allGroups[g]))
+                        { allIn = false; break; }
+                    }
+                }
+                if (allIn) groupPopupChecked.Add(allGroups[g]);
+            }
+            groupPopupOriginal = new HashSet<string>(groupPopupChecked);
+            groupPopupNewName = "";
+            InitGroupPopupExpansion();
+        }
+
+        private void OpenGroupPopupForGroup(string groupName)
+        {
+            groupPopupOpen = true;
+            groupPopupRecIdx = -1;
+            groupPopupChainId = null;
+            groupPopupGroup = groupName;
+            // For group-in-group: checked = current parent (if any)
+            groupPopupChecked = new HashSet<string>();
+            string parent;
+            if (ParsekScenario.groupParents.TryGetValue(groupName, out parent))
+                groupPopupChecked.Add(parent);
+            groupPopupOriginal = new HashSet<string>(groupPopupChecked);
+            groupPopupNewName = "";
+            InitGroupPopupExpansion();
+        }
+
+        private void InitGroupPopupExpansion()
+        {
+            groupPopupExpanded = new HashSet<string>();
+            // Default: all groups expanded
+            foreach (var kvp in ParsekScenario.groupParents)
+            {
+                groupPopupExpanded.Add(kvp.Value);
+            }
+            var allNames = RecordingStore.GetGroupNames();
+            for (int i = 0; i < allNames.Count; i++)
+                groupPopupExpanded.Add(allNames[i]);
+            for (int i = 0; i < knownEmptyGroups.Count; i++)
+                groupPopupExpanded.Add(knownEmptyGroups[i]);
+            groupPopupScrollPos = Vector2.zero;
+        }
+
+        /// <summary>
+        /// Draws the group picker popup. Called from OnGUI or after the recordings window.
+        /// </summary>
+        private void DrawGroupPickerPopup()
+        {
+            if (!groupPopupOpen) return;
+
+            // Collect all group names
+            var allNames = new HashSet<string>(RecordingStore.GetGroupNames());
+            foreach (var kvp in ParsekScenario.groupParents)
+            {
+                allNames.Add(kvp.Key);
+                allNames.Add(kvp.Value);
+            }
+            for (int i = 0; i < knownEmptyGroups.Count; i++)
+                allNames.Add(knownEmptyGroups[i]);
+
+            // For group-in-group popup: determine which groups are cycle-invalid
+            HashSet<string> cycleInvalid = null;
+            if (groupPopupGroup != null)
+            {
+                cycleInvalid = new HashSet<string>();
+                cycleInvalid.Add(groupPopupGroup);
+                var desc = ParsekScenario.GetDescendantGroups(groupPopupGroup);
+                for (int i = 0; i < desc.Count; i++)
+                    cycleInvalid.Add(desc[i]);
+            }
+
+            // Build hierarchy for display
+            var parentToChildren = new Dictionary<string, List<string>>();
+            foreach (var kvp in ParsekScenario.groupParents)
+            {
+                List<string> ch;
+                if (!parentToChildren.TryGetValue(kvp.Value, out ch))
+                {
+                    ch = new List<string>();
+                    parentToChildren[kvp.Value] = ch;
+                }
+                if (!ch.Contains(kvp.Key)) ch.Add(kvp.Key);
+            }
+            foreach (var ch in parentToChildren.Values)
+                ch.Sort(System.StringComparer.OrdinalIgnoreCase);
+
+            var rootNames = new List<string>();
+            foreach (var n in allNames)
+            {
+                if (!ParsekScenario.groupParents.ContainsKey(n))
+                    rootNames.Add(n);
+            }
+            rootNames.Sort(System.StringComparer.OrdinalIgnoreCase);
+
+            // Popup window
+            float popupWidth = 280f;
+            float popupHeight = 300f;
+            Rect popupRect = new Rect(
+                Mathf.Clamp(groupPopupPosition.x, 0, Screen.width - popupWidth),
+                Mathf.Clamp(groupPopupPosition.y, 0, Screen.height - popupHeight),
+                popupWidth, popupHeight);
+            groupPopupRect = popupRect;
+
+            GUILayout.Window("ParsekGroupPopup".GetHashCode(), popupRect, (id) =>
+            {
+                bool isGroupPopup = groupPopupGroup != null;
+                string title = isGroupPopup ? "Set Parent Group" : "Manage Groups";
+                GUILayout.Label(title, GUI.skin.label);
+                GUILayout.Space(3);
+
+                groupPopupScrollPos = GUILayout.BeginScrollView(groupPopupScrollPos, GUILayout.Height(180));
+
+                // For group-in-group: add "(None / Root)" option
+                if (isGroupPopup)
+                {
+                    bool noneChecked = groupPopupChecked.Count == 0;
+                    bool newNone = GUILayout.Toggle(noneChecked, "(None / Root level)");
+                    if (newNone && !noneChecked)
+                        groupPopupChecked.Clear();
+                }
+
+                // Draw group hierarchy with checkboxes
+                for (int r = 0; r < rootNames.Count; r++)
+                    DrawGroupPopupNode(rootNames[r], 0, parentToChildren, cycleInvalid, isGroupPopup);
+
+                GUILayout.EndScrollView();
+
+                GUILayout.Space(3);
+
+                // New group creation
+                GUILayout.BeginHorizontal();
+                groupPopupNewName = GUILayout.TextField(groupPopupNewName, GUILayout.ExpandWidth(true));
+                if (GUILayout.Button("+", GUILayout.Width(25)))
+                {
+                    string newName = groupPopupNewName.Trim();
+                    if (!string.IsNullOrEmpty(newName) && !allNames.Contains(newName) &&
+                        !newName.Contains("=") && !newName.Contains("{") && !newName.Contains("}") &&
+                        !newName.Contains("\n") && !newName.Contains("\r"))
+                    {
+                        knownEmptyGroups.Add(newName);
+                        if (!isGroupPopup)
+                            groupPopupChecked.Add(newName);
+                        groupPopupNewName = "";
+                        ParsekLog.Info("UI", $"Group '{newName}' created via popup");
+                    }
+                }
+                GUILayout.EndHorizontal();
+
+                GUILayout.Space(3);
+
+                // Done / Cancel
+                GUILayout.BeginHorizontal();
+                GUILayout.FlexibleSpace();
+                if (GUILayout.Button("Done", GUILayout.Width(60)))
+                {
+                    ApplyGroupPopupChanges();
+                    groupPopupOpen = false;
+                }
+                if (GUILayout.Button("Cancel", GUILayout.Width(60)))
+                {
+                    groupPopupOpen = false;
+                }
+                GUILayout.FlexibleSpace();
+                GUILayout.EndHorizontal();
+
+                GUI.DragWindow();
+            }, "");
+
+            // Click outside → close
+            if (Event.current.type == EventType.MouseDown &&
+                !groupPopupRect.Contains(Event.current.mousePosition))
+            {
+                groupPopupOpen = false;
+                Event.current.Use();
+            }
+        }
+
+        private void DrawGroupPopupNode(string groupName, int depth,
+            Dictionary<string, List<string>> parentToChildren,
+            HashSet<string> cycleInvalid, bool singleSelect)
+        {
+            GUILayout.BeginHorizontal();
+            if (depth > 0) GUILayout.Space(depth * 15f);
+
+            bool isCycleInvalid = cycleInvalid != null && cycleInvalid.Contains(groupName);
+            bool wasEnabled = GUI.enabled;
+            if (isCycleInvalid) GUI.enabled = false;
+
+            bool isChecked = groupPopupChecked.Contains(groupName);
+            bool newChecked = GUILayout.Toggle(isChecked, "");
+            if (newChecked != isChecked && !isCycleInvalid)
+            {
+                if (singleSelect)
+                {
+                    // For group-in-group: single parent only
+                    groupPopupChecked.Clear();
+                    if (newChecked) groupPopupChecked.Add(groupName);
+                }
+                else
+                {
+                    if (newChecked) groupPopupChecked.Add(groupName);
+                    else groupPopupChecked.Remove(groupName);
+                }
+            }
+
+            if (isCycleInvalid) GUI.enabled = wasEnabled;
+
+            // Group name with expand arrow if has children
+            List<string> children;
+            bool hasChildren = parentToChildren.TryGetValue(groupName, out children) && children.Count > 0;
+
+            if (hasChildren)
+            {
+                bool expanded = groupPopupExpanded.Contains(groupName);
+                string arrow = expanded ? "\u25bc" : "\u25b6";
+                if (GUILayout.Button(arrow, GUI.skin.label, GUILayout.Width(15)))
+                {
+                    if (expanded) groupPopupExpanded.Remove(groupName);
+                    else groupPopupExpanded.Add(groupName);
+                }
+            }
+            else
+            {
+                GUILayout.Space(15);
+            }
+
+            string tooltip = isCycleInvalid ? "Cannot assign (would create cycle)" : "";
+            GUILayout.Label(new GUIContent(groupName, tooltip));
+
+            GUILayout.EndHorizontal();
+
+            // Draw children if expanded
+            if (hasChildren && groupPopupExpanded.Contains(groupName))
+            {
+                for (int c = 0; c < children.Count; c++)
+                    DrawGroupPopupNode(children[c], depth + 1, parentToChildren, cycleInvalid, singleSelect);
+            }
+        }
+
+        private void ApplyGroupPopupChanges()
+        {
+            var committed = RecordingStore.CommittedRecordings;
+
+            if (groupPopupGroup != null)
+            {
+                // Group-in-group: set parent
+                if (groupPopupChecked.Count == 0)
+                {
+                    // Remove parent (root level)
+                    ParsekScenario.SetGroupParent(groupPopupGroup, null);
+                }
+                else
+                {
+                    // Set parent to the single checked group
+                    foreach (var parent in groupPopupChecked)
+                    {
+                        ParsekScenario.SetGroupParent(groupPopupGroup, parent);
+                        break;
+                    }
+                }
+            }
+            else if (groupPopupChainId != null)
+            {
+                // Chain: add/remove groups for all chain members
+                var added = new HashSet<string>(groupPopupChecked);
+                added.ExceptWith(groupPopupOriginal);
+                var removed = new HashSet<string>(groupPopupOriginal);
+                removed.ExceptWith(groupPopupChecked);
+
+                foreach (var g in added)
+                    RecordingStore.AddChainToGroup(groupPopupChainId, g);
+                foreach (var g in removed)
+                    RecordingStore.RemoveChainFromGroup(groupPopupChainId, g);
+            }
+            else if (groupPopupRecIdx >= 0 && groupPopupRecIdx < committed.Count)
+            {
+                // Recording: add/remove groups
+                var added = new HashSet<string>(groupPopupChecked);
+                added.ExceptWith(groupPopupOriginal);
+                var removed = new HashSet<string>(groupPopupOriginal);
+                removed.ExceptWith(groupPopupChecked);
+
+                foreach (var g in added)
+                    RecordingStore.AddRecordingToGroup(groupPopupRecIdx, g);
+                foreach (var g in removed)
+                    RecordingStore.RemoveRecordingFromGroup(groupPopupRecIdx, g);
+            }
         }
 
         private void ShowRewindConfirmation(RecordingStore.Recording rec)

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -1147,6 +1147,8 @@ namespace Parsek
             {
                 GUI.SetNextControlName("RecRename");
                 renamingRecordingText = GUILayout.TextField(renamingRecordingText, GUILayout.ExpandWidth(true));
+                if (GUI.GetNameOfFocusedControl() != "RecRename")
+                    GUI.FocusControl("RecRename");
                 if (Event.current.type == EventType.KeyDown)
                 {
                     if (Event.current.keyCode == KeyCode.Return || Event.current.keyCode == KeyCode.KeypadEnter)
@@ -1413,6 +1415,8 @@ namespace Parsek
                 GUILayout.Label(arrow, GUILayout.Width(15));
                 GUI.SetNextControlName("GrpRename");
                 renamingGroupText = GUILayout.TextField(renamingGroupText, GUILayout.ExpandWidth(true));
+                if (GUI.GetNameOfFocusedControl() != "GrpRename")
+                    GUI.FocusControl("GrpRename");
                 if (Event.current.type == EventType.KeyDown)
                 {
                     if (Event.current.keyCode == KeyCode.Return || Event.current.keyCode == KeyCode.KeypadEnter)
@@ -1649,9 +1653,7 @@ namespace Parsek
 
             if (string.IsNullOrEmpty(newName) || newName == oldName) return;
 
-            // Validate characters
-            if (newName.Contains("=") || newName.Contains("{") || newName.Contains("}") ||
-                newName.Contains("\n") || newName.Contains("\r"))
+            if (RecordingStore.IsInvalidGroupName(newName))
             {
                 ParsekLog.Warn("UI", $"Group rename rejected: '{newName}' contains invalid characters");
                 return;
@@ -1755,22 +1757,21 @@ namespace Parsek
             groupPopupRecIdx = -1;
             groupPopupChainId = chainId;
             groupPopupGroup = null;
-            // Checked = groups that ALL chain members are in
+            // Checked = groups that ALL chain members are in (single pass to find members, then check)
             var committed = RecordingStore.CommittedRecordings;
+            var memberIndices = RecordingStore.GetChainMemberIndices(chainId);
             var allGroups = RecordingStore.GetGroupNames();
             groupPopupChecked = new HashSet<string>();
             for (int g = 0; g < allGroups.Count; g++)
             {
                 bool allIn = true;
-                for (int i = 0; i < committed.Count; i++)
+                for (int m = 0; m < memberIndices.Count; m++)
                 {
-                    if (committed[i].ChainId == chainId)
-                    {
-                        if (committed[i].RecordingGroups == null || !committed[i].RecordingGroups.Contains(allGroups[g]))
-                        { allIn = false; break; }
-                    }
+                    var rec = committed[memberIndices[m]];
+                    if (rec.RecordingGroups == null || !rec.RecordingGroups.Contains(allGroups[g]))
+                    { allIn = false; break; }
                 }
-                if (allIn) groupPopupChecked.Add(allGroups[g]);
+                if (allIn && memberIndices.Count > 0) groupPopupChecked.Add(allGroups[g]);
             }
             groupPopupOriginal = new HashSet<string>(groupPopupChecked);
             groupPopupNewName = "";
@@ -1847,7 +1848,7 @@ namespace Parsek
                     ch = new List<string>();
                     parentToChildren[kvp.Value] = ch;
                 }
-                if (!ch.Contains(kvp.Key)) ch.Add(kvp.Key);
+                ch.Add(kvp.Key);
             }
             foreach (var ch in parentToChildren.Values)
                 ch.Sort(System.StringComparer.OrdinalIgnoreCase);
@@ -1901,9 +1902,8 @@ namespace Parsek
                 if (GUILayout.Button("+", GUILayout.Width(25)))
                 {
                     string newName = groupPopupNewName.Trim();
-                    if (!string.IsNullOrEmpty(newName) && !allNames.Contains(newName) &&
-                        !newName.Contains("=") && !newName.Contains("{") && !newName.Contains("}") &&
-                        !newName.Contains("\n") && !newName.Contains("\r"))
+                    if (!RecordingStore.IsInvalidGroupName(newName) &&
+                        !allNames.Contains(newName) && !knownEmptyGroups.Contains(newName))
                     {
                         knownEmptyGroups.Add(newName);
                         if (!isGroupPopup)

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -792,6 +792,16 @@ namespace Parsek
         // ─── Group management helpers ────────────────────────────────────────
 
         /// <summary>
+        /// Returns true if the group name contains characters that would break ConfigNode serialization.
+        /// </summary>
+        internal static bool IsInvalidGroupName(string name)
+        {
+            return string.IsNullOrEmpty(name) ||
+                   name.Contains("=") || name.Contains("{") || name.Contains("}") ||
+                   name.Contains("\n") || name.Contains("\r");
+        }
+
+        /// <summary>
         /// Returns distinct group names across all committed recordings.
         /// </summary>
         public static List<string> GetGroupNames()
@@ -814,7 +824,7 @@ namespace Parsek
         /// </summary>
         public static void AddRecordingToGroup(int index, string groupName)
         {
-            if (index < 0 || index >= committedRecordings.Count || string.IsNullOrEmpty(groupName)) return;
+            if (index < 0 || index >= committedRecordings.Count || IsInvalidGroupName(groupName)) return;
             var rec = committedRecordings[index];
             if (rec.RecordingGroups == null)
                 rec.RecordingGroups = new List<string>();
@@ -841,24 +851,35 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Returns indices of all recordings in a given chain. Single scan, reusable for batch ops.
+        /// </summary>
+        public static List<int> GetChainMemberIndices(string chainId)
+        {
+            var indices = new List<int>();
+            if (string.IsNullOrEmpty(chainId)) return indices;
+            for (int i = 0; i < committedRecordings.Count; i++)
+                if (committedRecordings[i].ChainId == chainId)
+                    indices.Add(i);
+            return indices;
+        }
+
+        /// <summary>
         /// Adds all chain members to a group.
         /// </summary>
         public static void AddChainToGroup(string chainId, string groupName)
         {
-            if (string.IsNullOrEmpty(chainId) || string.IsNullOrEmpty(groupName)) return;
+            if (string.IsNullOrEmpty(chainId) || IsInvalidGroupName(groupName)) return;
+            var members = GetChainMemberIndices(chainId);
             int count = 0;
-            for (int i = 0; i < committedRecordings.Count; i++)
+            for (int i = 0; i < members.Count; i++)
             {
-                var rec = committedRecordings[i];
-                if (rec.ChainId == chainId)
+                var rec = committedRecordings[members[i]];
+                if (rec.RecordingGroups == null)
+                    rec.RecordingGroups = new List<string>();
+                if (!rec.RecordingGroups.Contains(groupName))
                 {
-                    if (rec.RecordingGroups == null)
-                        rec.RecordingGroups = new List<string>();
-                    if (!rec.RecordingGroups.Contains(groupName))
-                    {
-                        rec.RecordingGroups.Add(groupName);
-                        count++;
-                    }
+                    rec.RecordingGroups.Add(groupName);
+                    count++;
                 }
             }
             if (count > 0)
@@ -871,11 +892,12 @@ namespace Parsek
         public static void RemoveChainFromGroup(string chainId, string groupName)
         {
             if (string.IsNullOrEmpty(chainId) || string.IsNullOrEmpty(groupName)) return;
+            var members = GetChainMemberIndices(chainId);
             int count = 0;
-            for (int i = 0; i < committedRecordings.Count; i++)
+            for (int i = 0; i < members.Count; i++)
             {
-                var rec = committedRecordings[i];
-                if (rec.ChainId == chainId && rec.RecordingGroups != null && rec.RecordingGroups.Remove(groupName))
+                var rec = committedRecordings[members[i]];
+                if (rec.RecordingGroups != null && rec.RecordingGroups.Remove(groupName))
                 {
                     if (rec.RecordingGroups.Count == 0)
                         rec.RecordingGroups = null;

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -74,8 +74,8 @@ namespace Parsek
             public bool LoopPlayback;
             public double LoopIntervalSeconds = 10.0;
 
-            // UI grouping tag (e.g. "Synthetic", "Part Showcase")
-            public string RecordingGroup;
+            // UI grouping tags (e.g. "Synthetic", "Part Showcase") — multi-group membership
+            public List<string> RecordingGroups;
 
             // Atmosphere segment metadata
             public string SegmentPhase;      // "atmo" or "exo" (null = untagged/legacy)
@@ -226,6 +226,8 @@ namespace Parsek
                 ChildBranchPointId = source.ChildBranchPointId;
                 ExplicitStartUT = source.ExplicitStartUT;
                 ExplicitEndUT = source.ExplicitEndUT;
+                RecordingGroups = source.RecordingGroups != null
+                    ? new List<string>(source.RecordingGroups) : null;
             }
         }
 
@@ -785,6 +787,162 @@ namespace Parsek
             if (!string.IsNullOrEmpty(rec.SegmentBodyName))
                 return rec.SegmentBodyName + " " + rec.SegmentPhase;
             return rec.SegmentPhase;
+        }
+
+        // ─── Group management helpers ────────────────────────────────────────
+
+        /// <summary>
+        /// Returns distinct group names across all committed recordings.
+        /// </summary>
+        public static List<string> GetGroupNames()
+        {
+            var names = new HashSet<string>();
+            for (int i = 0; i < committedRecordings.Count; i++)
+            {
+                var groups = committedRecordings[i].RecordingGroups;
+                if (groups == null) continue;
+                for (int j = 0; j < groups.Count; j++)
+                    names.Add(groups[j]);
+            }
+            var result = new List<string>(names);
+            result.Sort(StringComparer.OrdinalIgnoreCase);
+            return result;
+        }
+
+        /// <summary>
+        /// Adds a recording to a group. No-op if already a member or index invalid.
+        /// </summary>
+        public static void AddRecordingToGroup(int index, string groupName)
+        {
+            if (index < 0 || index >= committedRecordings.Count || string.IsNullOrEmpty(groupName)) return;
+            var rec = committedRecordings[index];
+            if (rec.RecordingGroups == null)
+                rec.RecordingGroups = new List<string>();
+            if (!rec.RecordingGroups.Contains(groupName))
+            {
+                rec.RecordingGroups.Add(groupName);
+                ParsekLog.Info("RecordingStore", $"Recording '{rec.VesselName}' added to group '{groupName}'");
+            }
+        }
+
+        /// <summary>
+        /// Removes a recording from a group. No-op if not a member or index invalid.
+        /// </summary>
+        public static void RemoveRecordingFromGroup(int index, string groupName)
+        {
+            if (index < 0 || index >= committedRecordings.Count || string.IsNullOrEmpty(groupName)) return;
+            var rec = committedRecordings[index];
+            if (rec.RecordingGroups != null && rec.RecordingGroups.Remove(groupName))
+            {
+                if (rec.RecordingGroups.Count == 0)
+                    rec.RecordingGroups = null;
+                ParsekLog.Info("RecordingStore", $"Recording '{rec.VesselName}' removed from group '{groupName}'");
+            }
+        }
+
+        /// <summary>
+        /// Adds all chain members to a group.
+        /// </summary>
+        public static void AddChainToGroup(string chainId, string groupName)
+        {
+            if (string.IsNullOrEmpty(chainId) || string.IsNullOrEmpty(groupName)) return;
+            int count = 0;
+            for (int i = 0; i < committedRecordings.Count; i++)
+            {
+                var rec = committedRecordings[i];
+                if (rec.ChainId == chainId)
+                {
+                    if (rec.RecordingGroups == null)
+                        rec.RecordingGroups = new List<string>();
+                    if (!rec.RecordingGroups.Contains(groupName))
+                    {
+                        rec.RecordingGroups.Add(groupName);
+                        count++;
+                    }
+                }
+            }
+            if (count > 0)
+                ParsekLog.Info("RecordingStore", $"Chain '{chainId}': {count} members added to group '{groupName}'");
+        }
+
+        /// <summary>
+        /// Removes all chain members from a group.
+        /// </summary>
+        public static void RemoveChainFromGroup(string chainId, string groupName)
+        {
+            if (string.IsNullOrEmpty(chainId) || string.IsNullOrEmpty(groupName)) return;
+            int count = 0;
+            for (int i = 0; i < committedRecordings.Count; i++)
+            {
+                var rec = committedRecordings[i];
+                if (rec.ChainId == chainId && rec.RecordingGroups != null && rec.RecordingGroups.Remove(groupName))
+                {
+                    if (rec.RecordingGroups.Count == 0)
+                        rec.RecordingGroups = null;
+                    count++;
+                }
+            }
+            if (count > 0)
+                ParsekLog.Info("RecordingStore", $"Chain '{chainId}': {count} members removed from group '{groupName}'");
+        }
+
+        /// <summary>
+        /// Renames a group across all committed recordings. Returns false if newName already exists.
+        /// </summary>
+        public static bool RenameGroup(string oldName, string newName)
+        {
+            if (string.IsNullOrEmpty(oldName) || string.IsNullOrEmpty(newName) || oldName == newName)
+                return false;
+
+            // Check for collision
+            for (int i = 0; i < committedRecordings.Count; i++)
+            {
+                var groups = committedRecordings[i].RecordingGroups;
+                if (groups != null && groups.Contains(newName))
+                {
+                    ParsekLog.Warn("RecordingStore", $"RenameGroup: cannot rename '{oldName}' to '{newName}' — name already exists");
+                    return false;
+                }
+            }
+
+            int updated = 0;
+            for (int i = 0; i < committedRecordings.Count; i++)
+            {
+                var groups = committedRecordings[i].RecordingGroups;
+                if (groups != null)
+                {
+                    int idx = groups.IndexOf(oldName);
+                    if (idx >= 0)
+                    {
+                        groups[idx] = newName;
+                        updated++;
+                    }
+                }
+            }
+            ParsekLog.Info("RecordingStore", $"RenameGroup: '{oldName}' → '{newName}' ({updated} recordings updated)");
+            return true;
+        }
+
+        /// <summary>
+        /// Removes a group from all committed recordings' group lists.
+        /// Returns the number of recordings that were modified.
+        /// </summary>
+        public static int RemoveGroupFromAll(string groupName)
+        {
+            if (string.IsNullOrEmpty(groupName)) return 0;
+            int updated = 0;
+            for (int i = 0; i < committedRecordings.Count; i++)
+            {
+                var rec = committedRecordings[i];
+                if (rec.RecordingGroups != null && rec.RecordingGroups.Remove(groupName))
+                {
+                    if (rec.RecordingGroups.Count == 0)
+                        rec.RecordingGroups = null;
+                    updated++;
+                }
+            }
+            ParsekLog.Info("RecordingStore", $"RemoveGroupFromAll: '{groupName}' removed from {updated} recordings");
+            return updated;
         }
 
         /// <summary>

--- a/Source/Parsek/RecordingTree.cs
+++ b/Source/Parsek/RecordingTree.cs
@@ -251,6 +251,11 @@ namespace Parsek
                 recNode.AddValue("vesselDestroyed", rec.VesselDestroyed.ToString());
             recNode.AddValue("lastResIdx", rec.LastAppliedResourceIndex);
             recNode.AddValue("pointCount", rec.Points != null ? rec.Points.Count : 0);
+
+            // UI grouping tags (multi-group membership)
+            if (rec.RecordingGroups != null)
+                for (int g = 0; g < rec.RecordingGroups.Count; g++)
+                    recNode.AddValue("recordingGroup", rec.RecordingGroups[g]);
         }
 
         internal static void LoadRecordingFrom(ConfigNode recNode, RecordingStore.Recording rec)
@@ -474,6 +479,11 @@ namespace Parsek
                     rec.LastAppliedResourceIndex = resIdx;
             }
             // pointCount is informational — Points list is loaded from sidecar file
+
+            // UI grouping tags (multi-group membership, backward compat with single value)
+            string[] recGroups = recNode.GetValues("recordingGroup");
+            if (recGroups != null && recGroups.Length > 0)
+                rec.RecordingGroups = new List<string>(recGroups);
         }
 
         // --- BranchPoint serialization helpers ---


### PR DESCRIPTION
## Summary
- **Multi-group membership**: recordings can belong to multiple groups simultaneously, preparing for future DAG model
- **Nested groups**: groups can be inside other groups (tree hierarchy), with cycle detection
- **Full group management UI**: create, rename (double-click), delete, assign recordings/chains via G button checklist popup with foldable hierarchy
- **Group-level controls**: aggregate enable/loop checkboxes on group headers
- **43 new unit tests** covering hierarchy logic, group helpers, serialization round-trips

## Test plan
- [ ] `dotnet build` — 0 errors, 0 warnings
- [ ] `dotnet test` — 1414 passed (1 pre-existing failure in InjectAllRecordings)
- [ ] In-game: create group via "New Group" button, rename via double-click
- [ ] In-game: assign recording to group via G button popup, verify it appears under group
- [ ] In-game: assign same recording to multiple groups, verify it appears under each
- [ ] In-game: assign chain to group via chain header G button
- [ ] In-game: nest groups (G button on group header), verify recursive rendering
- [ ] In-game: cycle prevention — cannot assign group to itself or its descendants
- [ ] In-game: group loop checkbox toggles all descendant recordings
- [ ] In-game: delete group — recordings ungrouped, sub-groups promoted
- [ ] In-game: save/load — groups, multi-membership, and hierarchy persist
- [ ] In-game: load old save — single recordingGroup backward compatible

🤖 Generated with [Claude Code](https://claude.com/claude-code)