### PR TITLE
Remove deprecated settings, add deferred spawn queue

### DIFF
--- a/Source/Parsek.Tests/Fixtures/KspLog/good_atmo_soi_session.log
+++ b/Source/Parsek.Tests/Fixtures/KspLog/good_atmo_soi_session.log
@@ -35,5 +35,3 @@
 [LOG 14:21:30.750] [Parsek][VERBOSE][RecordingStore] Validating chains: 1 branch group(s)
 [LOG 14:21:30.760] [Parsek][VERBOSE][RecordingStore] All chains validated OK
 [LOG 14:21:50.100] [Parsek][VERBOSE][Flight] Ghost #0 destroyed — segment disabled (Mun Transfer, Kerbin atmo)
-[LOG 14:21:50.200] [Parsek][INFO][UI] Setting changed: autoSplitAtAtmosphere=True
-[LOG 14:21:50.300] [Parsek][INFO][UI] Setting changed: autoSplitAtSoi=False

--- a/Source/Parsek.Tests/ParsekLogContractCheckerTests.cs
+++ b/Source/Parsek.Tests/ParsekLogContractCheckerTests.cs
@@ -199,10 +199,6 @@ namespace Parsek.Tests
                 (e.Message ?? "").Contains("All chains validated OK"));
             Assert.Contains(session, e => e.Subsystem == "Flight" &&
                 (e.Message ?? "").Contains("Ghost #0 destroyed") && (e.Message ?? "").Contains("segment disabled"));
-            Assert.Contains(session, e => e.Subsystem == "UI" &&
-                (e.Message ?? "").Contains("autoSplitAtAtmosphere"));
-            Assert.Contains(session, e => e.Subsystem == "UI" &&
-                (e.Message ?? "").Contains("autoSplitAtSoi"));
         }
 
         [Fact]

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -262,16 +262,14 @@ namespace Parsek
             public SurfacePosition surfacePosition;
         }
 
-        // Timeline warp protection — tracks previous frame's UT
-        private double lastTimelineUT = -1;
-
         // Diagnostic logging guards (log once per state transition, not per frame)
         private HashSet<int> loggedGhostEnter = new HashSet<int>();
         private HashSet<int> loggedOrbitSegments = new HashSet<int>();
         private HashSet<int> loggedOrbitRotationSegments = new HashSet<int>();
 
-        // Warp-stop guard: only stop time warp once per recording
-        private HashSet<int> warpStoppedForRecording = new HashSet<int>();
+        // Deferred spawn queue: recording IDs queued during warp, flushed when warp ends
+        private HashSet<string> pendingSpawnRecordingIds = new HashSet<string>();
+        private string pendingWatchRecordingId = null;  // recording ID that was in watch mode when deferred
         private bool timelineResourceReplayPausedLogged = false;
         private const double DefaultLoopIntervalSeconds = 10.0;
         private const double MinLoopDurationSeconds = 0.001;
@@ -625,8 +623,7 @@ namespace Parsek
             }
 
             // Atmosphere boundary: auto-split when crossing atmosphere edge
-            if (recorder != null && recorder.IsRecording && recorder.AtmosphereBoundaryCrossed &&
-                ParsekSettings.Current?.autoSplitAtAtmosphere != false)
+            if (recorder != null && recorder.IsRecording && recorder.AtmosphereBoundaryCrossed)
             {
                 string phase = recorder.EnteredAtmosphere ? "exo" : "atmo";
                 string newPhase = recorder.EnteredAtmosphere ? "atmo" : "exo";
@@ -647,8 +644,7 @@ namespace Parsek
             }
 
             // SOI change: auto-split when transitioning between celestial bodies
-            if (recorder != null && recorder.IsRecording && recorder.SoiChangePending &&
-                ParsekSettings.Current?.autoSplitAtSoi != false)
+            if (recorder != null && recorder.IsRecording && recorder.SoiChangePending)
             {
                 string fromBody = recorder.SoiChangeFromBody ?? "Unknown";
                 string toBody = FlightGlobals.ActiveVessel?.mainBody?.name ?? "Unknown";
@@ -4499,44 +4495,35 @@ namespace Parsek
             var committed = RecordingStore.CommittedRecordings;
             double currentUT = Planetarium.GetUniversalTime();
 
-            // Prevent time warp from skipping ghost playback for vessel spawns
-            if (committed.Count > 0 && IsAnyWarpActive() && lastTimelineUT >= 0
-                && ParsekSettings.Current?.autoWarpStop != false)
+            // Flush deferred spawns when warp ends
+            if (pendingSpawnRecordingIds.Count > 0 && !IsAnyWarpActive())
             {
-                double timelineStep = System.Math.Max(0, currentUT - lastTimelineUT);
+                int spawnedCount = 0;
                 for (int i = 0; i < committed.Count; i++)
                 {
                     var rec = committed[i];
-                    if (rec.Points.Count < 2 && rec.OrbitSegments.Count == 0 && !rec.SurfacePos.HasValue) continue;
-                    if (ShouldLoopPlayback(rec)) continue;
-                    if (!rec.PlaybackEnabled) continue;
-                    if (rec.VesselSnapshot == null || rec.VesselSpawned || rec.VesselDestroyed ||
-                        RecordingStore.IsChainMidSegment(rec)) continue;
-                    if (rec.ChildBranchPointId != null) continue;  // non-leaf, never spawns
-                    if (rec.TerminalStateValue.HasValue)
+                    if (!pendingSpawnRecordingIds.Contains(rec.RecordingId)) continue;
+                    if (rec.VesselSpawned || rec.VesselSnapshot == null)
                     {
-                        var ts = rec.TerminalStateValue.Value;
-                        if (ts == TerminalState.Destroyed || ts == TerminalState.Recovered
-                            || ts == TerminalState.Docked || ts == TerminalState.Boarded)
-                            continue;
+                        ParsekLog.Verbose("Flight", $"Deferred spawn skipped — #{i} \"{rec.VesselName}\" already spawned or no snapshot");
+                        continue;
                     }
+                    ParsekLog.Info("Flight", $"Deferred spawn executing: #{i} \"{rec.VesselName}\" id={rec.RecordingId}");
+                    VesselSpawner.SpawnOrRecoverIfTooClose(rec, i);
+                    spawnedCount++;
 
-                    bool crossedInto = lastTimelineUT < rec.StartUT && currentUT >= rec.StartUT;
-                    bool approaching = currentUT < rec.StartUT &&
-                                       rec.StartUT - currentUT <= System.Math.Max(1.0, timelineStep);
-                    if (crossedInto || approaching)
+                    // Restore camera follow if this recording was being watched when deferred
+                    if (pendingWatchRecordingId == rec.RecordingId && rec.SpawnedVesselPersistentId != 0)
                     {
-                        if (warpStoppedForRecording.Add(i))
-                        {
-                            ExitAllWarpForPlaybackStart(rec.VesselName);
-                            Log($"Stopped warp for recording #{i} ({rec.VesselName}) ghost playback");
-                            ScreenMessage($"Time warp stopped — '{rec.VesselName}' playback", 3f);
-                        }
-                        break;
+                        ParsekLog.Info("CameraFollow",
+                            $"Deferred watch: switching to spawned vessel pid={rec.SpawnedVesselPersistentId}");
+                        StartCoroutine(DeferredActivateVessel(rec.SpawnedVesselPersistentId));
                     }
                 }
+                ParsekLog.Info("Flight", $"Warp ended — flushed {spawnedCount}/{pendingSpawnRecordingIds.Count} deferred spawn(s)");
+                pendingSpawnRecordingIds.Clear();
+                pendingWatchRecordingId = null;
             }
-            lastTimelineUT = currentUT;
 
             if (committed.Count == 0) return;
 
@@ -4708,33 +4695,58 @@ namespace Parsek
                     if (rec.Points.Count > 0)
                         PositionGhostAt(state.ghost, rec.Points[rec.Points.Count - 1], rec.RecordingFormatVersion >= 5);
 
-                    // Watch mode: exit and switch player to spawned vessel
-                    if (watchedRecordingIndex == i)
+                    if (IsAnyWarpActive())
                     {
-                        ExitWatchMode();
-                        VesselSpawner.SpawnOrRecoverIfTooClose(rec, i);
-                        DestroyTimelineGhost(i);
-                        if (rec.SpawnedVesselPersistentId != 0)
+                        // Defer spawn until warp ends — ProtoVessel.Load unsafe during warp
+                        if (watchedRecordingIndex == i)
                         {
-                            ParsekLog.Info("CameraFollow",
-                                $"Recording #{i} spawned vessel pid={rec.SpawnedVesselPersistentId} \u2014 switching active vessel");
-                            StartCoroutine(DeferredActivateVessel(rec.SpawnedVesselPersistentId));
+                            pendingWatchRecordingId = rec.RecordingId;
+                            ParsekLog.Info("Flight", $"Watch mode deferred for spawn: #{i} \"{rec.VesselName}\"");
+                            ExitWatchMode();
                         }
+                        if (pendingSpawnRecordingIds.Add(rec.RecordingId))
+                            ParsekLog.Info("Flight", $"Deferred spawn queued (ghost exit during warp): #{i} \"{rec.VesselName}\"");
+                        DestroyTimelineGhost(i);
                     }
                     else
                     {
-                        VesselSpawner.SpawnOrRecoverIfTooClose(rec, i);
-                        DestroyTimelineGhost(i);
+                        // Watch mode: exit and switch player to spawned vessel
+                        if (watchedRecordingIndex == i)
+                        {
+                            ExitWatchMode();
+                            VesselSpawner.SpawnOrRecoverIfTooClose(rec, i);
+                            DestroyTimelineGhost(i);
+                            if (rec.SpawnedVesselPersistentId != 0)
+                            {
+                                ParsekLog.Info("CameraFollow",
+                                    $"Recording #{i} spawned vessel pid={rec.SpawnedVesselPersistentId} \u2014 switching active vessel");
+                                StartCoroutine(DeferredActivateVessel(rec.SpawnedVesselPersistentId));
+                            }
+                        }
+                        else
+                        {
+                            VesselSpawner.SpawnOrRecoverIfTooClose(rec, i);
+                            DestroyTimelineGhost(i);
+                        }
                     }
                     if (rec.TreeId == null)
                         ApplyResourceDeltas(rec, currentUT);
                 }
                 else if (pastChainEnd && needsSpawn && !ghostActive)
                 {
-                    // UT already past chain EndUT on scene load — spawn immediately, no ghost
-                    Log($"Ghost SKIPPED (UT already past EndUT): #{i} \"{rec.VesselName}\" at UT {currentUT:F1} " +
-                        $"(EndUT={rec.EndUT:F1}) — spawning vessel immediately");
-                    VesselSpawner.SpawnOrRecoverIfTooClose(rec, i);
+                    if (IsAnyWarpActive())
+                    {
+                        // Defer spawn until warp ends — ProtoVessel.Load unsafe during warp
+                        if (pendingSpawnRecordingIds.Add(rec.RecordingId))
+                            ParsekLog.Info("Flight", $"Deferred spawn queued (past EndUT during warp): #{i} \"{rec.VesselName}\"");
+                    }
+                    else
+                    {
+                        // UT already past chain EndUT on scene load — spawn immediately, no ghost
+                        Log($"Ghost SKIPPED (UT already past EndUT): #{i} \"{rec.VesselName}\" at UT {currentUT:F1} " +
+                            $"(EndUT={rec.EndUT:F1}) — spawning vessel immediately");
+                        VesselSpawner.SpawnOrRecoverIfTooClose(rec, i);
+                    }
                     if (rec.TreeId == null)
                         ApplyResourceDeltas(rec, currentUT);
                 }
@@ -5610,7 +5622,8 @@ namespace Parsek
             loggedGhostEnter.Clear();
             loggedOrbitSegments.Clear();
             loggedOrbitRotationSegments.Clear();
-            warpStoppedForRecording.Clear();
+            pendingSpawnRecordingIds.Clear();
+            pendingWatchRecordingId = null;
             CleanupActiveExplosions();
         }
 
@@ -5880,7 +5893,7 @@ namespace Parsek
             loggedGhostEnter.Clear();
             loggedOrbitSegments.Clear();
             loggedOrbitRotationSegments.Clear();
-            warpStoppedForRecording.Clear();
+            pendingSpawnRecordingIds.Remove(rec.RecordingId);
 
             ParsekLog.ScreenMessage($"Recording '{rec.VesselName}' deleted", 2f);
         }

--- a/Source/Parsek/ParsekSettings.cs
+++ b/Source/Parsek/ParsekSettings.cs
@@ -17,18 +17,6 @@ namespace Parsek
             toolTip = "Automatically start recording when a kerbal goes EVA from the pad")]
         public bool autoRecordOnEva = true;
 
-        [GameParameters.CustomParameterUI("Stop time warp for ghost playback",
-            toolTip = "Automatically exit time warp when a ghost recording is about to start playing")]
-        public bool autoWarpStop = true;
-
-        [GameParameters.CustomParameterUI("Auto-split at atmosphere boundary",
-            toolTip = "Automatically split recordings when crossing the atmosphere boundary")]
-        public bool autoSplitAtAtmosphere = true;
-
-        [GameParameters.CustomParameterUI("Auto-split at SOI change",
-            toolTip = "Automatically split recordings when entering a new sphere of influence")]
-        public bool autoSplitAtSoi = true;
-
         [GameParameters.CustomParameterUI("Auto-merge recordings",
             toolTip = "When enabled, recordings are committed to the timeline automatically. When disabled, a confirmation dialog appears after each recording.")]
         public bool autoMerge = false;

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -2697,30 +2697,6 @@ namespace Parsek
                 ParsekLog.Info("UI", $"Setting changed: autoMerge={s.autoMerge}");
             }
 
-            bool autoWarpStop = GUILayout.Toggle(s.autoWarpStop,
-                new GUIContent("Stop time warp for ghost playback", "Exit time warp when a ghost recording is about to start playing"));
-            if (autoWarpStop != s.autoWarpStop)
-            {
-                s.autoWarpStop = autoWarpStop;
-                ParsekLog.Info("UI", $"Setting changed: autoWarpStop={s.autoWarpStop}");
-            }
-
-            bool autoSplitAtAtmosphere = GUILayout.Toggle(s.autoSplitAtAtmosphere,
-                new GUIContent("Auto-split at atmosphere boundary", "Split recordings when crossing the atmosphere boundary"));
-            if (autoSplitAtAtmosphere != s.autoSplitAtAtmosphere)
-            {
-                s.autoSplitAtAtmosphere = autoSplitAtAtmosphere;
-                ParsekLog.Info("UI", $"Setting changed: autoSplitAtAtmosphere={s.autoSplitAtAtmosphere}");
-            }
-
-            bool autoSplitAtSoi = GUILayout.Toggle(s.autoSplitAtSoi,
-                new GUIContent("Auto-split at SOI change", "Split recordings when entering a new sphere of influence"));
-            if (autoSplitAtSoi != s.autoSplitAtSoi)
-            {
-                s.autoSplitAtSoi = autoSplitAtSoi;
-                ParsekLog.Info("UI", $"Setting changed: autoSplitAtSoi={s.autoSplitAtSoi}");
-            }
-
             GUILayout.Space(SpacingSmall);
             GUILayout.Label("Diagnostics", GUI.skin.box);
             bool verboseLogging = GUILayout.Toggle(s.verboseLogging, "Verbose logging (development default)");
@@ -2802,9 +2778,6 @@ namespace Parsek
                 s.autoRecordOnLaunch = true;
                 s.autoRecordOnEva = true;
                 s.autoMerge = false;
-                s.autoWarpStop = true;
-                s.autoSplitAtAtmosphere = true;
-                s.autoSplitAtSoi = true;
                 s.verboseLogging = true;
                 s.maxSampleInterval = 3.0f;
                 s.velocityDirThreshold = 2.0f;


### PR DESCRIPTION
## Summary
- Remove three always-on settings (`autoWarpStop`, `autoSplitAtAtmosphere`, `autoSplitAtSoi`) from ParsekSettings, UI toggles, and defaults button
- Hardcode atmosphere/SOI auto-splits to always trigger (required for recording chaining)
- Replace warp-stop-for-playback with a deferred spawn queue: spawns are queued by recording ID during warp and flushed when warp returns to 1x, avoiding unsafe `ProtoVessel.Load` during rails/physics warp
- Poll-based flush in `UpdateTimelinePlayback` (no event subscription) avoids race conditions with `onTimeWarpRateChanged`

## Test plan
- [x] `dotnet build` compiles cleanly
- [x] `dotnet test` — 1437/1437 pass
- [ ] In-game: settings window no longer shows the three removed toggles
- [ ] In-game: atmosphere boundary and SOI change auto-splits trigger without any toggle
- [ ] In-game: time warp past a recording's spawn point queues the spawn, vessel appears when warp ends
- [ ] In-game: watch mode exits cleanly if ghost is destroyed during warp deferral

🤖 Generated with [Claude Code](https://claude.com/claude-code)