### PR TITLE
Add auto-loop: per-recording unit selector and global interval

### DIFF
--- a/Source/Parsek.Tests/AutoLoopTests.cs
+++ b/Source/Parsek.Tests/AutoLoopTests.cs
@@ -1,0 +1,311 @@
+using System.Collections.Generic;
+using UnityEngine;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    [Collection("Sequential")]
+    public class AutoLoopTests : System.IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public AutoLoopTests()
+        {
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+            ParsekLog.SuppressLogging = false;
+            RecordingStore.SuppressLogging = true;
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            RecordingStore.ResetForTesting();
+        }
+
+        static RecordingStore.Recording MakeRec(
+            double startUT = 100, double endUT = 200,
+            double loopInterval = 10.0,
+            RecordingStore.LoopTimeUnit unit = RecordingStore.LoopTimeUnit.Sec)
+        {
+            var rec = new RecordingStore.Recording
+            {
+                VesselName = "TestVessel",
+                LoopPlayback = true,
+                LoopIntervalSeconds = loopInterval,
+                LoopTimeUnit = unit,
+            };
+            rec.Points.Add(new TrajectoryPoint
+            {
+                ut = startUT, latitude = 0, longitude = 0, altitude = 0,
+                bodyName = "Kerbin", rotation = Quaternion.identity, velocity = Vector3.zero
+            });
+            rec.Points.Add(new TrajectoryPoint
+            {
+                ut = endUT, latitude = 0, longitude = 0, altitude = 0,
+                bodyName = "Kerbin", rotation = Quaternion.identity, velocity = Vector3.zero
+            });
+            return rec;
+        }
+
+        // --- Serialization round-trip ---
+
+        [Fact]
+        public void LoopTimeUnit_SaveLoad_RoundTrip_Auto()
+        {
+            var source = new RecordingStore.Recording
+            {
+                RecordingId = "auto-test",
+                LoopPlayback = true,
+                LoopIntervalSeconds = 30.0,
+                LoopTimeUnit = RecordingStore.LoopTimeUnit.Auto,
+            };
+            var node = new ConfigNode("RECORDING");
+            ParsekScenario.SaveRecordingMetadata(node, source);
+
+            var loaded = new RecordingStore.Recording();
+            ParsekScenario.LoadRecordingMetadata(node, loaded);
+
+            Assert.Equal(RecordingStore.LoopTimeUnit.Auto, loaded.LoopTimeUnit);
+        }
+
+        [Fact]
+        public void LoopTimeUnit_SaveLoad_RoundTrip_Hour()
+        {
+            var source = new RecordingStore.Recording
+            {
+                RecordingId = "hr-test",
+                LoopTimeUnit = RecordingStore.LoopTimeUnit.Hour,
+            };
+            var node = new ConfigNode("RECORDING");
+            ParsekScenario.SaveRecordingMetadata(node, source);
+
+            var loaded = new RecordingStore.Recording();
+            ParsekScenario.LoadRecordingMetadata(node, loaded);
+
+            Assert.Equal(RecordingStore.LoopTimeUnit.Hour, loaded.LoopTimeUnit);
+        }
+
+        [Fact]
+        public void LoopTimeUnit_Load_MissingKey_DefaultsSec()
+        {
+            var node = new ConfigNode("RECORDING");
+            // No loopTimeUnit key at all
+            var loaded = new RecordingStore.Recording();
+            ParsekScenario.LoadRecordingMetadata(node, loaded);
+
+            Assert.Equal(RecordingStore.LoopTimeUnit.Sec, loaded.LoopTimeUnit);
+        }
+
+        [Fact]
+        public void LoopTimeUnit_Save_DefaultSec_NotWritten()
+        {
+            var source = new RecordingStore.Recording
+            {
+                RecordingId = "sec-default",
+                LoopTimeUnit = RecordingStore.LoopTimeUnit.Sec,
+            };
+            var node = new ConfigNode("RECORDING");
+            ParsekScenario.SaveRecordingMetadata(node, source);
+
+            Assert.Null(node.GetValue("loopTimeUnit"));
+        }
+
+        // --- ResolveLoopInterval ---
+
+        [Fact]
+        public void ResolveLoopInterval_AutoMode_ReturnsGlobalValue()
+        {
+            var rec = MakeRec(unit: RecordingStore.LoopTimeUnit.Auto, loopInterval: 999);
+            double result = ParsekFlight.ResolveLoopInterval(rec, 42.0, 10.0, 1.0);
+            Assert.Equal(42.0, result);
+        }
+
+        [Fact]
+        public void ResolveLoopInterval_AutoMode_ClampsNonNegative()
+        {
+            var rec = MakeRec(unit: RecordingStore.LoopTimeUnit.Auto);
+            double result = ParsekFlight.ResolveLoopInterval(rec, -5.0, 10.0, 1.0);
+            Assert.Equal(0.0, result);
+        }
+
+        [Fact]
+        public void ResolveLoopInterval_AutoMode_NaN_ReturnsDefault()
+        {
+            var rec = MakeRec(unit: RecordingStore.LoopTimeUnit.Auto);
+            double result = ParsekFlight.ResolveLoopInterval(rec, double.NaN, 10.0, 1.0);
+            Assert.Equal(10.0, result);
+        }
+
+        [Fact]
+        public void ResolveLoopInterval_ManualMode_ReturnsRecordingValue()
+        {
+            var rec = MakeRec(unit: RecordingStore.LoopTimeUnit.Sec, loopInterval: 25.0);
+            double result = ParsekFlight.ResolveLoopInterval(rec, 42.0, 10.0, 1.0);
+            Assert.Equal(25.0, result);
+        }
+
+        [Fact]
+        public void ResolveLoopInterval_ManualMode_NegativePreserved()
+        {
+            var rec = MakeRec(unit: RecordingStore.LoopTimeUnit.Min, loopInterval: -30.0);
+            // duration=100, so clamp is Max(-100+0.001, -30) = -30
+            double result = ParsekFlight.ResolveLoopInterval(rec, 42.0, 10.0, 1.0);
+            Assert.Equal(-30.0, result);
+        }
+
+        [Fact]
+        public void ResolveLoopInterval_NullRec_ReturnsDefault()
+        {
+            double result = ParsekFlight.ResolveLoopInterval(null, 42.0, 10.0, 1.0);
+            Assert.Equal(10.0, result);
+        }
+
+        // --- Unit helpers ---
+
+        [Theory]
+        [InlineData(RecordingStore.LoopTimeUnit.Sec, "sec")]
+        [InlineData(RecordingStore.LoopTimeUnit.Min, "min")]
+        [InlineData(RecordingStore.LoopTimeUnit.Hour, "hr")]
+        [InlineData(RecordingStore.LoopTimeUnit.Auto, "auto")]
+        public void UnitLabel_AllValues(RecordingStore.LoopTimeUnit unit, string expected)
+        {
+            Assert.Equal(expected, ParsekUI.UnitLabel(unit));
+        }
+
+        [Fact]
+        public void CycleRecordingUnit_FullCycle()
+        {
+            var u = RecordingStore.LoopTimeUnit.Sec;
+            u = ParsekUI.CycleRecordingUnit(u); Assert.Equal(RecordingStore.LoopTimeUnit.Min, u);
+            u = ParsekUI.CycleRecordingUnit(u); Assert.Equal(RecordingStore.LoopTimeUnit.Hour, u);
+            u = ParsekUI.CycleRecordingUnit(u); Assert.Equal(RecordingStore.LoopTimeUnit.Auto, u);
+            u = ParsekUI.CycleRecordingUnit(u); Assert.Equal(RecordingStore.LoopTimeUnit.Sec, u);
+        }
+
+        [Fact]
+        public void CycleDisplayUnit_FullCycle_NoAuto()
+        {
+            var u = RecordingStore.LoopTimeUnit.Sec;
+            u = ParsekUI.CycleDisplayUnit(u); Assert.Equal(RecordingStore.LoopTimeUnit.Min, u);
+            u = ParsekUI.CycleDisplayUnit(u); Assert.Equal(RecordingStore.LoopTimeUnit.Hour, u);
+            u = ParsekUI.CycleDisplayUnit(u); Assert.Equal(RecordingStore.LoopTimeUnit.Sec, u);
+        }
+
+        [Theory]
+        [InlineData(3600.0, RecordingStore.LoopTimeUnit.Sec, 3600.0)]
+        [InlineData(3600.0, RecordingStore.LoopTimeUnit.Min, 60.0)]
+        [InlineData(3600.0, RecordingStore.LoopTimeUnit.Hour, 1.0)]
+        [InlineData(120.0, RecordingStore.LoopTimeUnit.Min, 2.0)]
+        public void ConvertFromSeconds_AllUnits(double seconds, RecordingStore.LoopTimeUnit unit, double expected)
+        {
+            Assert.Equal(expected, ParsekUI.ConvertFromSeconds(seconds, unit), 6);
+        }
+
+        [Theory]
+        [InlineData(10.0, RecordingStore.LoopTimeUnit.Sec, 10.0)]
+        [InlineData(2.0, RecordingStore.LoopTimeUnit.Min, 120.0)]
+        [InlineData(1.0, RecordingStore.LoopTimeUnit.Hour, 3600.0)]
+        public void ConvertToSeconds_AllUnits(double value, RecordingStore.LoopTimeUnit unit, double expected)
+        {
+            Assert.Equal(expected, ParsekUI.ConvertToSeconds(value, unit), 6);
+        }
+
+        // --- ApplyPersistenceArtifactsFrom ---
+
+        [Fact]
+        public void ApplyPersistenceArtifactsFrom_CopiesLoopTimeUnit()
+        {
+            var source = new RecordingStore.Recording
+            {
+                LoopTimeUnit = RecordingStore.LoopTimeUnit.Auto,
+            };
+            var target = new RecordingStore.Recording();
+            target.ApplyPersistenceArtifactsFrom(source);
+
+            Assert.Equal(RecordingStore.LoopTimeUnit.Auto, target.LoopTimeUnit);
+        }
+
+        // --- FormatLoopValue ---
+
+        [Theory]
+        [InlineData(0.0, RecordingStore.LoopTimeUnit.Sec, "0")]
+        [InlineData(5.5, RecordingStore.LoopTimeUnit.Sec, "5")]
+        [InlineData(10.0, RecordingStore.LoopTimeUnit.Sec, "10")]
+        [InlineData(1.5, RecordingStore.LoopTimeUnit.Min, "1.5")]
+        [InlineData(2.0, RecordingStore.LoopTimeUnit.Min, "2.0")]
+        [InlineData(0.5, RecordingStore.LoopTimeUnit.Hour, "0.5")]
+        [InlineData(1.0, RecordingStore.LoopTimeUnit.Hour, "1.0")]
+        public void FormatLoopValue_Formatting(double value, RecordingStore.LoopTimeUnit unit, string expected)
+        {
+            Assert.Equal(expected, ParsekUI.FormatLoopValue(value, unit));
+        }
+
+        // --- TryParseLoopInput ---
+
+        [Theory]
+        [InlineData("10", RecordingStore.LoopTimeUnit.Sec, true, 10.0)]
+        [InlineData("1.5", RecordingStore.LoopTimeUnit.Sec, false, 0.0)]  // float rejected for sec
+        [InlineData("1.5", RecordingStore.LoopTimeUnit.Min, true, 1.5)]
+        [InlineData("0.5", RecordingStore.LoopTimeUnit.Hour, true, 0.5)]
+        [InlineData("abc", RecordingStore.LoopTimeUnit.Sec, false, 0.0)]
+        [InlineData("abc", RecordingStore.LoopTimeUnit.Min, false, 0.0)]
+        [InlineData("", RecordingStore.LoopTimeUnit.Sec, false, 0.0)]    // empty string
+        [InlineData("", RecordingStore.LoopTimeUnit.Min, false, 0.0)]    // empty string
+        [InlineData("-5", RecordingStore.LoopTimeUnit.Sec, true, -5.0)]  // negative allowed in recordings
+        [InlineData("-1.5", RecordingStore.LoopTimeUnit.Min, true, -1.5)]
+        public void TryParseLoopInput_UnitRules(string text, RecordingStore.LoopTimeUnit unit, bool expectedOk, double expectedVal)
+        {
+            double val;
+            bool ok = ParsekUI.TryParseLoopInput(text, unit, out val);
+            Assert.Equal(expectedOk, ok);
+            if (expectedOk) Assert.Equal(expectedVal, val, 6);
+        }
+
+        // --- ResolveLoopInterval log assertions ---
+
+        [Fact]
+        public void ResolveLoopInterval_AutoMode_ShortDuration_Clamps()
+        {
+            // Recording only 5s long, global interval is 0 → clamp to -duration + minCycleDuration
+            var rec = MakeRec(startUT: 100, endUT: 105, unit: RecordingStore.LoopTimeUnit.Auto);
+            double result = ParsekFlight.ResolveLoopInterval(rec, 0.0, 10.0, 1.0);
+            Assert.Equal(0.0, result); // auto always >= 0
+        }
+
+        [Fact]
+        public void ResolveLoopInterval_ManualMode_ShortDuration_Clamps()
+        {
+            // 5s recording, -10s interval → clamp to -(5 - 1.0) = -4.0
+            var rec = MakeRec(startUT: 100, endUT: 105, loopInterval: -10.0,
+                unit: RecordingStore.LoopTimeUnit.Sec);
+            double result = ParsekFlight.ResolveLoopInterval(rec, 42.0, 10.0, 1.0);
+            Assert.Equal(-4.0, result, 6);
+        }
+
+        [Fact]
+        public void ResolveLoopInterval_AutoMode_Infinity_ReturnsDefault()
+        {
+            var rec = MakeRec(unit: RecordingStore.LoopTimeUnit.Auto);
+            double result = ParsekFlight.ResolveLoopInterval(rec, double.PositiveInfinity, 10.0, 1.0);
+            Assert.Equal(10.0, result);
+        }
+
+        [Fact]
+        public void ResolveLoopInterval_ManualMode_NaN_ReturnsDefault()
+        {
+            var rec = MakeRec(unit: RecordingStore.LoopTimeUnit.Sec);
+            rec.LoopIntervalSeconds = double.NaN;
+            double result = ParsekFlight.ResolveLoopInterval(rec, 42.0, 10.0, 1.0);
+            Assert.Equal(10.0, result);
+        }
+
+        [Fact]
+        public void ResolveLoopInterval_ManualMode_Infinity_ReturnsDefault()
+        {
+            var rec = MakeRec(unit: RecordingStore.LoopTimeUnit.Min);
+            rec.LoopIntervalSeconds = double.PositiveInfinity;
+            double result = ParsekFlight.ResolveLoopInterval(rec, 42.0, 10.0, 1.0);
+            Assert.Equal(10.0, result);
+        }
+    }
+}

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -272,8 +272,8 @@ namespace Parsek
         private string pendingWatchRecordingId = null;  // recording ID that was in watch mode when deferred
         private bool timelineResourceReplayPausedLogged = false;
         private const double DefaultLoopIntervalSeconds = 10.0;
-        private const double MinLoopDurationSeconds = 0.001;
-        private const double MinCycleDuration = 0.001;
+        private const double MinLoopDurationSeconds = 1.0;
+        private const double MinCycleDuration = 1.0;
         private const double OverlapExplosionHoldSeconds = 3.0;
 
         // Camera follow (watch mode) — transient, never serialized
@@ -4849,12 +4849,31 @@ namespace Parsek
 
         private double GetLoopIntervalSeconds(RecordingStore.Recording rec)
         {
-            if (rec == null) return DefaultLoopIntervalSeconds;
-            if (double.IsNaN(rec.LoopIntervalSeconds) || double.IsInfinity(rec.LoopIntervalSeconds))
-                return DefaultLoopIntervalSeconds;
+            double globalInterval = ParsekSettings.Current?.autoLoopIntervalSeconds
+                                    ?? DefaultLoopIntervalSeconds;
+            return ResolveLoopInterval(rec, globalInterval, DefaultLoopIntervalSeconds, MinCycleDuration);
+        }
+
+        internal static double ResolveLoopInterval(
+            RecordingStore.Recording rec, double globalAutoInterval,
+            double defaultInterval, double minCycleDuration)
+        {
+            if (rec == null) return defaultInterval;
+
+            double interval;
+            if (rec.LoopTimeUnit == RecordingStore.LoopTimeUnit.Auto)
+            {
+                interval = double.IsNaN(globalAutoInterval) || double.IsInfinity(globalAutoInterval)
+                    ? defaultInterval : Math.Max(0, globalAutoInterval);
+            }
+            else
+            {
+                interval = double.IsNaN(rec.LoopIntervalSeconds) || double.IsInfinity(rec.LoopIntervalSeconds)
+                    ? defaultInterval : rec.LoopIntervalSeconds;
+            }
+
             double duration = rec.EndUT - rec.StartUT;
-            // Clamp so cycleDuration is always >= MinCycleDuration
-            return Math.Max(-duration + MinCycleDuration, rec.LoopIntervalSeconds);
+            return Math.Max(-duration + minCycleDuration, interval);
         }
 
         private bool TryComputeLoopPlaybackUT(

--- a/Source/Parsek/ParsekKSC.cs
+++ b/Source/Parsek/ParsekKSC.cs
@@ -36,8 +36,8 @@ namespace Parsek
         private HashSet<int> loggedGhostSpawn = new HashSet<int>();
 
         private const double DefaultLoopIntervalSeconds = 10.0;
-        private const double MinLoopDurationSeconds = 0.001;
-        private const double MinCycleDuration = 0.001;
+        private const double MinLoopDurationSeconds = 1.0;
+        private const double MinCycleDuration = 1.0;
         // Safety cap for overlap ghosts. Natural phase expiration keeps count bounded for
         // well-behaved recordings, but pathological cases (very short duration, very negative
         // interval) could spawn many before expiration catches up.
@@ -737,12 +737,10 @@ namespace Parsek
         /// </summary>
         internal static double GetLoopIntervalSeconds(RecordingStore.Recording rec)
         {
-            if (rec == null) return DefaultLoopIntervalSeconds;
-            if (double.IsNaN(rec.LoopIntervalSeconds) || double.IsInfinity(rec.LoopIntervalSeconds))
-                return DefaultLoopIntervalSeconds;
-            // Caller guards duration <= 0 before calling (Update checks MinLoopDurationSeconds).
-            double duration = rec.EndUT - rec.StartUT;
-            return Math.Max(-duration + MinCycleDuration, rec.LoopIntervalSeconds);
+            double globalInterval = ParsekSettings.Current?.autoLoopIntervalSeconds
+                                    ?? DefaultLoopIntervalSeconds;
+            return ParsekFlight.ResolveLoopInterval(
+                rec, globalInterval, DefaultLoopIntervalSeconds, MinCycleDuration);
         }
 
         /// <summary>

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -1336,6 +1336,8 @@ namespace Parsek
             recNode.AddValue("recordingFormatVersion", rec.RecordingFormatVersion);
             recNode.AddValue("loopPlayback", rec.LoopPlayback);
             recNode.AddValue("loopIntervalSeconds", rec.LoopIntervalSeconds.ToString("R", CultureInfo.InvariantCulture));
+            if (rec.LoopTimeUnit != RecordingStore.LoopTimeUnit.Sec)
+                recNode.AddValue("loopTimeUnit", rec.LoopTimeUnit.ToString());
             if (rec.PreLaunchFunds != 0)
                 recNode.AddValue("preLaunchFunds", rec.PreLaunchFunds.ToString("R", CultureInfo.InvariantCulture));
             if (rec.PreLaunchScience != 0)
@@ -1413,6 +1415,14 @@ namespace Parsek
                 double loopIntervalSeconds;
                 if (double.TryParse(loopIntervalStr, NumberStyles.Float, CultureInfo.InvariantCulture, out loopIntervalSeconds))
                     rec.LoopIntervalSeconds = loopIntervalSeconds;
+            }
+
+            string loopTimeUnitStr = recNode.GetValue("loopTimeUnit");
+            if (loopTimeUnitStr != null)
+            {
+                RecordingStore.LoopTimeUnit loopTimeUnit;
+                if (System.Enum.TryParse(loopTimeUnitStr, out loopTimeUnit))
+                    rec.LoopTimeUnit = loopTimeUnit;
             }
 
             rec.GhostGeometryRelativePath = recNode.GetValue("ghostGeometryPath");

--- a/Source/Parsek/ParsekSettings.cs
+++ b/Source/Parsek/ParsekSettings.cs
@@ -40,6 +40,18 @@ namespace Parsek
             toolTip = "Speed change (percent) that triggers a new sample")]
         public float speedChangeThreshold = 5.0f;
 
+        public float autoLoopIntervalSeconds = 10.0f;
+        public int autoLoopTimeUnit = 0; // 0=Sec, 1=Min, 2=Hour
+
+        public RecordingStore.LoopTimeUnit AutoLoopDisplayUnit
+        {
+            get => autoLoopTimeUnit == 1 ? RecordingStore.LoopTimeUnit.Min
+                 : autoLoopTimeUnit == 2 ? RecordingStore.LoopTimeUnit.Hour
+                 : RecordingStore.LoopTimeUnit.Sec;
+            set => autoLoopTimeUnit = value == RecordingStore.LoopTimeUnit.Min ? 1
+                 : value == RecordingStore.LoopTimeUnit.Hour ? 2 : 0;
+        }
+
         public static ParsekSettings Current =>
             HighLogic.CurrentGame?.Parameters?.CustomParams<ParsekSettings>();
     }

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -63,8 +63,8 @@ namespace Parsek
         private const float ColW_Phase = 70f;
         private const float ColW_Index = 30f;
         private const float ColW_Launch = 110f;
-        private const float ColW_Dur = 55f;
-        private const float ColW_Status = 45f;
+        private const float ColW_Dur = 65f;
+        private const float ColW_Status = 55f;
         private const float ColW_Loop = 55f;
         private const float ColW_Watch = 50f;
         private const float ColW_Rewind = 55f;
@@ -139,10 +139,16 @@ namespace Parsek
         private const float ColW_Dist = 65f;
         private const float ColW_Pts = 35f;
 
-        // Loop period editing
-        private int editingLoopPeriodIdx = -1;
-        private string editingLoopPeriodText = "";
-        private const float ColW_Period = 55f;
+        // Loop period editing — buffer used while text field is focused
+        private int loopPeriodFocusedRi = -1;
+        private string loopPeriodEditText = "";
+        private Rect loopPeriodEditRect;
+
+        // Settings auto-loop editing
+        private string settingsAutoLoopText = "";
+        private bool settingsAutoLoopEditing;
+        private Rect settingsAutoLoopEditRect;
+        private const float ColW_Period = 80f;
 
         // Cached styles for status labels
         private GUIStyle statusStyleFuture;
@@ -748,7 +754,7 @@ namespace Parsek
                 recordingsWindowRect = new Rect(
                     mainWindowRect.x + mainWindowRect.width + 10,
                     mainWindowRect.y,
-                    790, recHeight);
+                    883, recHeight);
                 var ic = System.Globalization.CultureInfo.InvariantCulture;
                 ParsekLog.Verbose("UI", $"Recordings window initial position: x={recordingsWindowRect.x.ToString("F0", ic)} y={recordingsWindowRect.y.ToString("F0", ic)}");
             }
@@ -900,6 +906,15 @@ namespace Parsek
                 }
             }
 
+            // Click outside active loop period field → commit and defocus
+            if (Event.current.type == EventType.MouseDown && loopPeriodFocusedRi >= 0)
+            {
+                if (loopPeriodEditRect.width > 0 && !loopPeriodEditRect.Contains(Event.current.mousePosition))
+                {
+                    CommitLoopPeriodEdit(committed);
+                }
+            }
+
             EnsureStatusStyles();
             EnsurePhaseStyles();
             RebuildSortedIndices(committed, now);
@@ -971,7 +986,7 @@ namespace Parsek
                 GUILayout.BeginHorizontal(GUILayout.Width(ColW_Period));
                 GUILayout.FlexibleSpace();
                 GUILayout.Label(new GUIContent("Every",
-                    "Loop interval (seconds):\n  Positive: wait N seconds after end\n  Zero: restart immediately\n  Negative: overlap by N seconds"));
+                    "Loop interval between cycles.\nClick unit to cycle: sec \u2192 min \u2192 hr \u2192 auto.\n\"auto\" inherits from Settings > Looping."));
                 GUILayout.FlexibleSpace();
                 GUILayout.EndHorizontal();
 
@@ -1115,8 +1130,6 @@ namespace Parsek
             // Reset out-of-range state
             if (deleteConfirmIndex >= committed.Count)
                 deleteConfirmIndex = -1;
-            if (editingLoopPeriodIdx >= committed.Count)
-                editingLoopPeriodIdx = -1;
 
             // Bottom button bar
             GUILayout.Space(5);
@@ -1132,7 +1145,7 @@ namespace Parsek
                     if (showExpandedStats && recordingsWindowRect.width < 1150f)
                         recordingsWindowRect.width = 1150f;
                     else if (!showExpandedStats)
-                        recordingsWindowRect.width = 790f;
+                        recordingsWindowRect.width = 883f;
                 }
             }
 
@@ -1323,9 +1336,9 @@ namespace Parsek
             if (loop != rec.LoopPlayback)
             {
                 rec.LoopPlayback = loop;
+                if (!loop && loopPeriodFocusedRi == ri)
+                    loopPeriodFocusedRi = -1;
                 ParsekLog.Info("UI", $"Recording '{rec.VesselName}' loop playback set to {loop}");
-                if (!loop && editingLoopPeriodIdx == ri)
-                    editingLoopPeriodIdx = -1;
             }
 
             // Period
@@ -1422,8 +1435,8 @@ namespace Parsek
                     {
                         ParsekLog.Info("UI", $"Delete confirmed for recording index={capturedIndex} name='{capturedName}'");
                         // Adjust index-based state fields
-                        AdjustIndexOnDelete(ref editingLoopPeriodIdx, capturedIndex);
                         AdjustIndexOnDelete(ref renamingRecordingIdx, capturedIndex);
+                        AdjustIndexOnDelete(ref loopPeriodFocusedRi, capturedIndex);
                         if (groupPopupRecIdx == capturedIndex) groupPopupOpen = false;
                         else if (groupPopupRecIdx > capturedIndex) groupPopupRecIdx--;
                         if (InFlight)
@@ -2513,79 +2526,191 @@ namespace Parsek
                 content, tooltipLabelStyle);
         }
 
-        private static readonly GUIContent intervalTooltip = new GUIContent("",
-            "Loop interval (seconds):\n  Positive: wait N seconds after end\n  Zero: restart immediately\n  Negative: overlap by N seconds");
+        // --- Loop time unit helpers (internal static for testability) ---
 
-        private string FormatInterval(double interval)
+        internal static string UnitLabel(RecordingStore.LoopTimeUnit unit)
+            => unit == RecordingStore.LoopTimeUnit.Min ? "min"
+             : unit == RecordingStore.LoopTimeUnit.Hour ? "hr"
+             : unit == RecordingStore.LoopTimeUnit.Auto ? "auto"
+             : "sec";
+
+        internal static RecordingStore.LoopTimeUnit CycleRecordingUnit(RecordingStore.LoopTimeUnit u)
+            => u == RecordingStore.LoopTimeUnit.Sec ? RecordingStore.LoopTimeUnit.Min
+             : u == RecordingStore.LoopTimeUnit.Min ? RecordingStore.LoopTimeUnit.Hour
+             : u == RecordingStore.LoopTimeUnit.Hour ? RecordingStore.LoopTimeUnit.Auto
+             : RecordingStore.LoopTimeUnit.Sec;
+
+        internal static RecordingStore.LoopTimeUnit CycleDisplayUnit(RecordingStore.LoopTimeUnit u)
+            => u == RecordingStore.LoopTimeUnit.Sec ? RecordingStore.LoopTimeUnit.Min
+             : u == RecordingStore.LoopTimeUnit.Min ? RecordingStore.LoopTimeUnit.Hour
+             : RecordingStore.LoopTimeUnit.Sec;
+
+        // Auto is resolved separately by callers; falls through to seconds if called directly.
+        internal static double ConvertFromSeconds(double seconds, RecordingStore.LoopTimeUnit unit)
+            => unit == RecordingStore.LoopTimeUnit.Min ? seconds / 60.0
+             : unit == RecordingStore.LoopTimeUnit.Hour ? seconds / 3600.0
+             : seconds;
+
+        // Auto is resolved separately by callers; falls through to seconds if called directly.
+        internal static double ConvertToSeconds(double value, RecordingStore.LoopTimeUnit unit)
+            => unit == RecordingStore.LoopTimeUnit.Min ? value * 60.0
+             : unit == RecordingStore.LoopTimeUnit.Hour ? value * 3600.0
+             : value;
+
+        internal static string FormatLoopValue(double value, RecordingStore.LoopTimeUnit unit)
         {
-            string sign = interval < 0 ? "-" : "";
-            return sign + FormatDuration(System.Math.Abs(interval));
+            if (unit == RecordingStore.LoopTimeUnit.Min || unit == RecordingStore.LoopTimeUnit.Hour)
+                return value.ToString("F1", System.Globalization.CultureInfo.InvariantCulture);
+            return ((long)System.Math.Truncate(value)).ToString(System.Globalization.CultureInfo.InvariantCulture);
         }
+
+        internal static bool TryParseLoopInput(string text, RecordingStore.LoopTimeUnit unit, out double value)
+        {
+            if (unit == RecordingStore.LoopTimeUnit.Min || unit == RecordingStore.LoopTimeUnit.Hour)
+                return double.TryParse(text, System.Globalization.NumberStyles.Float,
+                    System.Globalization.CultureInfo.InvariantCulture, out value);
+            int intVal;
+            bool ok = int.TryParse(text, System.Globalization.NumberStyles.Integer,
+                System.Globalization.CultureInfo.InvariantCulture, out intVal);
+            value = intVal;
+            return ok;
+        }
+
+        // --- Loop period cell ---
 
         private void DrawLoopPeriodCell(RecordingStore.Recording rec, int ri, double dur)
         {
+            // All states use same [value area][unit button] layout to keep column alignment consistent.
+            const float unitBtnW = 40f;
+            float valueBtnW = ColW_Period - unitBtnW - 2f;
+
             if (!rec.LoopPlayback)
             {
+                // Disabled: gray out the same two-control layout
                 GUI.enabled = false;
-                GUILayout.Label("-", GUILayout.Width(ColW_Period));
+                string disabledText;
+                if (rec.LoopTimeUnit == RecordingStore.LoopTimeUnit.Auto)
+                {
+                    var settings = ParsekSettings.Current;
+                    double gv = settings != null
+                        ? ConvertFromSeconds(settings.autoLoopIntervalSeconds, settings.AutoLoopDisplayUnit) : 10;
+                    var gu = settings != null ? settings.AutoLoopDisplayUnit : RecordingStore.LoopTimeUnit.Sec;
+                    disabledText = FormatLoopValue(gv, gu);
+                }
+                else
+                {
+                    disabledText = FormatLoopValue(ConvertFromSeconds(rec.LoopIntervalSeconds, rec.LoopTimeUnit), rec.LoopTimeUnit);
+                }
+                GUILayout.TextField(disabledText, GUILayout.Width(valueBtnW));
+                GUILayout.Button(UnitLabel(rec.LoopTimeUnit), GUILayout.Width(unitBtnW));
                 GUI.enabled = true;
                 return;
             }
 
-            if (editingLoopPeriodIdx == ri)
+            if (rec.LoopTimeUnit == RecordingStore.LoopTimeUnit.Auto)
             {
-                GUI.SetNextControlName("PeriodEdit");
-                editingLoopPeriodText = GUILayout.TextField(
-                    editingLoopPeriodText, GUILayout.Width(ColW_Period));
-
-                if (Event.current.type == EventType.KeyUp &&
-                    Event.current.keyCode == KeyCode.Return &&
-                    GUI.GetNameOfFocusedControl() == "PeriodEdit")
-                {
-                    ApplyLoopIntervalEdit(rec, dur);
-                    editingLoopPeriodIdx = -1;
-                }
+                // Auto mode: disabled text field showing global value + "auto" unit button
+                var settings = ParsekSettings.Current;
+                double globalVal = settings != null
+                    ? ConvertFromSeconds(settings.autoLoopIntervalSeconds, settings.AutoLoopDisplayUnit)
+                    : 10;
+                GUI.enabled = false;
+                var globalDisplayUnit = settings != null ? settings.AutoLoopDisplayUnit : RecordingStore.LoopTimeUnit.Sec;
+                GUILayout.TextField(FormatLoopValue(globalVal, globalDisplayUnit), GUILayout.Width(valueBtnW));
+                GUI.enabled = true;
             }
             else
             {
-                var content = new GUIContent(FormatInterval(rec.LoopIntervalSeconds), intervalTooltip.tooltip);
-                if (GUILayout.Button(content, GUILayout.Width(ColW_Period)))
+                // Manual mode: editable text field with edit buffer.
+                // When not actively editing, show formatted value from model.
+                // When editing (loopPeriodFocusedRi == ri), use buffer.
+                // Commit happens via click-outside (MouseDown check at top)
+                // or Enter key.
+                if (loopPeriodFocusedRi != ri)
                 {
-                    // Save any in-progress edit on another recording
-                    if (editingLoopPeriodIdx >= 0)
+                    // Not editing: show model value, click to start editing
+                    double displayValue = ConvertFromSeconds(rec.LoopIntervalSeconds, rec.LoopTimeUnit);
+                    string displayText = FormatLoopValue(displayValue, rec.LoopTimeUnit);
+                    string controlName = "LoopPeriod_" + ri;
+                    GUI.SetNextControlName(controlName);
+                    string newText = GUILayout.TextField(displayText, GUILayout.Width(valueBtnW));
+                    if (GUI.GetNameOfFocusedControl() == controlName)
                     {
-                        var committed = RecordingStore.CommittedRecordings;
-                        if (editingLoopPeriodIdx < committed.Count)
-                        {
-                            var editRec = committed[editingLoopPeriodIdx];
-                            double editDur = editRec.EndUT - editRec.StartUT;
-                            ApplyLoopIntervalEdit(editRec, editDur);
-                        }
+                        loopPeriodEditText = newText;
+                        loopPeriodFocusedRi = ri;
+                        loopPeriodEditRect = GUILayoutUtility.GetLastRect();
+                        ParsekLog.Verbose("UI",
+                            $"Recording '{rec.VesselName}' loop period edit started: " +
+                            $"value='{newText}' unit={UnitLabel(rec.LoopTimeUnit)}");
                     }
-
-                    editingLoopPeriodIdx = ri;
-                    editingLoopPeriodText = ((int)rec.LoopIntervalSeconds).ToString();
                 }
+                else
+                {
+                    // Enter key → commit (check before TextField, which consumes KeyDown)
+                    bool submitPeriod = Event.current.type == EventType.KeyDown &&
+                        (Event.current.keyCode == KeyCode.Return || Event.current.keyCode == KeyCode.KeypadEnter);
+
+                    // Editing: use buffer, track rect for click-outside
+                    GUI.SetNextControlName("LoopPeriod_" + ri);
+                    string newText = GUILayout.TextField(loopPeriodEditText, GUILayout.Width(valueBtnW));
+                    loopPeriodEditRect = GUILayoutUtility.GetLastRect();
+                    if (newText != loopPeriodEditText)
+                        loopPeriodEditText = newText;
+
+                    if (submitPeriod)
+                    {
+                        CommitLoopPeriodEdit(RecordingStore.CommittedRecordings);
+                        Event.current.Use();
+                    }
+                }
+            }
+
+            // Unit cycling button (shared by both auto and manual modes)
+            if (GUILayout.Button(UnitLabel(rec.LoopTimeUnit), GUILayout.Width(unitBtnW)))
+            {
+                var newUnit = CycleRecordingUnit(rec.LoopTimeUnit);
+                rec.LoopTimeUnit = newUnit;
+                GUIUtility.keyboardControl = 0;
+                loopPeriodFocusedRi = -1;
+                ParsekLog.Info("UI",
+                    $"Recording '{rec.VesselName}' loop unit changed to {newUnit}");
             }
         }
 
-        private void ApplyLoopIntervalEdit(RecordingStore.Recording rec, double dur)
+        private void CommitLoopPeriodEdit(System.Collections.Generic.List<RecordingStore.Recording> committed)
         {
-            double newInterval;
-            if (double.TryParse(editingLoopPeriodText, System.Globalization.NumberStyles.Float,
-                    System.Globalization.CultureInfo.InvariantCulture, out newInterval)
-                && newInterval > -(dur - 0.001))
+            if (loopPeriodFocusedRi < 0 || loopPeriodFocusedRi >= committed.Count) { loopPeriodFocusedRi = -1; return; }
+            var rec = committed[loopPeriodFocusedRi];
+            double dur = rec.EndUT - rec.StartUT;
+            double parsed;
+            if (TryParseLoopInput(loopPeriodEditText, rec.LoopTimeUnit, out parsed))
             {
-                rec.LoopIntervalSeconds = newInterval;
+                double newSeconds = ConvertToSeconds(parsed, rec.LoopTimeUnit);
+                double minSeconds = -(dur - 1.0); // cap: -totalDuration + 1s
+                if (newSeconds < minSeconds)
+                {
+                    newSeconds = minSeconds;
+                    ParsekLog.Info("UI",
+                        $"Recording '{rec.VesselName}' loop interval clamped to " +
+                        $"{newSeconds.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)}s " +
+                        $"(minimum for duration {dur.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)}s)");
+                }
+                rec.LoopIntervalSeconds = newSeconds;
                 ParsekLog.Info("UI",
                     $"Recording '{rec.VesselName}' loop interval updated to " +
-                    rec.LoopIntervalSeconds.ToString("F1", System.Globalization.CultureInfo.InvariantCulture) + "s");
+                    rec.LoopIntervalSeconds.ToString("F1", System.Globalization.CultureInfo.InvariantCulture) +
+                    $"s (display: {FormatLoopValue(ConvertFromSeconds(newSeconds, rec.LoopTimeUnit), rec.LoopTimeUnit)} " +
+                    $"{UnitLabel(rec.LoopTimeUnit)})");
             }
             else
             {
                 ParsekLog.Warn("UI",
-                    $"Rejected loop interval edit '{editingLoopPeriodText}' for recording '{rec.VesselName}'");
+                    $"Recording '{rec.VesselName}' loop interval edit rejected: " +
+                    $"invalid input '{loopPeriodEditText}' for unit {rec.LoopTimeUnit}");
             }
+            loopPeriodFocusedRi = -1;
+            loopPeriodEditRect = default;
+            GUIUtility.keyboardControl = 0;
         }
 
         private void EnsureTooltipStyle()
@@ -2660,6 +2785,27 @@ namespace Parsek
             settingsWindowHasInputLock = false;
         }
 
+        private void CommitSettingsAutoLoopEdit(ParsekSettings s)
+        {
+            double parsed;
+            if (TryParseLoopInput(settingsAutoLoopText, s.AutoLoopDisplayUnit, out parsed) && parsed >= 0)
+            {
+                // float cast: KSP GameParameters requires float; loses precision beyond ~7 digits (fine for practical intervals)
+                s.autoLoopIntervalSeconds = (float)ConvertToSeconds(parsed, s.AutoLoopDisplayUnit);
+                ParsekLog.Info("UI",
+                    $"Setting changed: autoLoopIntervalSeconds={s.autoLoopIntervalSeconds.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)}s");
+            }
+            else
+            {
+                ParsekLog.Warn("UI",
+                    $"Auto-loop settings edit rejected: invalid or negative input '{settingsAutoLoopText}' " +
+                    $"for unit {UnitLabel(s.AutoLoopDisplayUnit)}");
+            }
+            settingsAutoLoopEditing = false;
+            settingsAutoLoopEditRect = default;
+            GUIUtility.keyboardControl = 0;
+        }
+
         private void DrawSettingsWindow(int windowID)
         {
             var s = ParsekSettings.Current;
@@ -2670,6 +2816,13 @@ namespace Parsek
                     showSettingsWindow = false;
                 GUI.DragWindow();
                 return;
+            }
+
+            // Click outside active settings edit field → commit
+            if (Event.current.type == EventType.MouseDown && settingsAutoLoopEditing)
+            {
+                if (settingsAutoLoopEditRect.width > 0 && !settingsAutoLoopEditRect.Contains(Event.current.mousePosition))
+                    CommitSettingsAutoLoopEdit(s);
             }
 
             GUILayout.Label("Recording", GUI.skin.box);
@@ -2696,6 +2849,58 @@ namespace Parsek
                 s.autoMerge = autoMerge;
                 ParsekLog.Info("UI", $"Setting changed: autoMerge={s.autoMerge}");
             }
+
+            GUILayout.Space(SpacingSmall);
+            GUILayout.Label("Looping", GUI.skin.box);
+            GUILayout.BeginHorizontal();
+            GUILayout.Label(new GUIContent("Auto-loop every",
+                "Default loop interval for recordings set to 'auto' unit"), GUILayout.Width(100));
+            {
+                if (!settingsAutoLoopEditing)
+                {
+                    // Not editing: show formatted value from model
+                    double displayVal = ConvertFromSeconds(s.autoLoopIntervalSeconds, s.AutoLoopDisplayUnit);
+                    string displayText = FormatLoopValue(displayVal, s.AutoLoopDisplayUnit);
+                    GUI.SetNextControlName("AutoLoopEdit");
+                    string newText = GUILayout.TextField(displayText, GUILayout.Width(45));
+                    if (GUI.GetNameOfFocusedControl() == "AutoLoopEdit")
+                    {
+                        settingsAutoLoopText = newText;
+                        settingsAutoLoopEditing = true;
+                        settingsAutoLoopEditRect = GUILayoutUtility.GetLastRect();
+                        ParsekLog.Verbose("UI",
+                            $"Auto-loop settings edit started: value='{newText}' unit={UnitLabel(s.AutoLoopDisplayUnit)}");
+                    }
+                }
+                else
+                {
+                    // Enter key → commit (check before TextField, which consumes KeyDown)
+                    bool submitAutoLoop = Event.current.type == EventType.KeyDown &&
+                        (Event.current.keyCode == KeyCode.Return || Event.current.keyCode == KeyCode.KeypadEnter);
+
+                    // Editing: use buffer, track rect for click-outside
+                    GUI.SetNextControlName("AutoLoopEdit");
+                    string newText = GUILayout.TextField(settingsAutoLoopText, GUILayout.Width(45));
+                    settingsAutoLoopEditRect = GUILayoutUtility.GetLastRect();
+                    if (newText != settingsAutoLoopText)
+                        settingsAutoLoopText = newText;
+
+                    if (submitAutoLoop)
+                    {
+                        CommitSettingsAutoLoopEdit(s);
+                        Event.current.Use();
+                    }
+                }
+
+                if (GUILayout.Button(UnitLabel(s.AutoLoopDisplayUnit), GUILayout.Width(40)))
+                {
+                    if (settingsAutoLoopEditing)
+                        CommitSettingsAutoLoopEdit(s);
+                    s.AutoLoopDisplayUnit = CycleDisplayUnit(s.AutoLoopDisplayUnit);
+                    ParsekLog.Info("UI", $"Setting changed: autoLoopDisplayUnit={s.AutoLoopDisplayUnit}");
+                }
+            }
+            GUILayout.EndHorizontal();
 
             GUILayout.Space(SpacingSmall);
             GUILayout.Label("Diagnostics", GUI.skin.box);
@@ -2782,6 +2987,9 @@ namespace Parsek
                 s.maxSampleInterval = 3.0f;
                 s.velocityDirThreshold = 2.0f;
                 s.speedChangeThreshold = 5.0f;
+                s.autoLoopIntervalSeconds = 10.0f;
+                s.autoLoopTimeUnit = 0;
+                settingsAutoLoopEditing = false;
                 ParsekLog.Info("UI", "Settings reset to defaults");
             }
             if (GUILayout.Button("Close"))

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -63,6 +63,8 @@ namespace Parsek
             Persist      // Vessel intact with snapshot — respawn where it ended up
         }
 
+        public enum LoopTimeUnit { Sec, Min, Hour, Auto }
+
         public class Recording
         {
             public string RecordingId = Guid.NewGuid().ToString("N");
@@ -73,6 +75,7 @@ namespace Parsek
             public List<PartEvent> PartEvents = new List<PartEvent>();
             public bool LoopPlayback;
             public double LoopIntervalSeconds = 10.0;
+            public LoopTimeUnit LoopTimeUnit = LoopTimeUnit.Sec;
 
             // UI grouping tags (e.g. "Synthetic", "Part Showcase") — multi-group membership
             public List<string> RecordingGroups;
@@ -199,6 +202,7 @@ namespace Parsek
                 ChainBranch = source.ChainBranch;
                 LoopPlayback = source.LoopPlayback;
                 LoopIntervalSeconds = source.LoopIntervalSeconds;
+                LoopTimeUnit = source.LoopTimeUnit;
                 PreLaunchFunds = source.PreLaunchFunds;
                 PreLaunchScience = source.PreLaunchScience;
                 PreLaunchReputation = source.PreLaunchReputation;


### PR DESCRIPTION
## Summary
- Adds `LoopTimeUnit` enum (`Sec/Min/Hour/Auto`) to per-recording loop settings — users can view/edit intervals in their preferred time unit
- "Auto" mode makes a recording inherit the global auto-loop interval from a new **Settings > Looping** section
- Auto mode enforces non-negative intervals (no overlap); manual per-recording negative intervals still work
- Shared `ResolveLoopInterval` static helper used by both flight and KSC playback
- "Every" column widened from 55px to 80px with `[value][unit]` split layout; auto mode shows single "auto" button

## Test plan
- [x] `dotnet build` compiles cleanly
- [x] `dotnet test` — 29 new tests pass (serialization round-trip, ResolveLoopInterval edge cases, unit helpers, persistence copy, formatting)
- [x] In-game: set a recording to "auto" unit, change global interval in Settings > Looping, verify ghost loops at new interval
- [x] Save/load game, verify auto-loop settings persist
- [x] Verify negative interval still works for manual per-recording override
- [x] Verify unit cycling: sec → min → hr → auto → sec per-recording, sec → min → hr → sec in settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)