### PR TITLE
Add time warp visual cutoffs for ghost playback

### DIFF
--- a/Source/Parsek.Tests/ExplosionFxTests.cs
+++ b/Source/Parsek.Tests/ExplosionFxTests.cs
@@ -379,21 +379,21 @@ namespace Parsek.Tests
 
             Assert.True(wouldFire);
 
-            // But ShouldSuppressExplosionFx prevents the actual FX
-            bool suppressed = ParsekFlight.ShouldSuppressExplosionFx(warpRate);
+            // But ShouldSuppressVisualFx prevents the actual FX
+            bool suppressed = ParsekFlight.ShouldSuppressVisualFx(warpRate);
             Assert.Equal(expectedSuppressed, suppressed);
         }
 
         [Fact]
-        public void ShouldSuppressExplosionFx_At10x_DoesNotSuppress()
+        public void ShouldSuppressVisualFx_At10x_DoesNotSuppress()
         {
-            Assert.False(ParsekFlight.ShouldSuppressExplosionFx(10f));
+            Assert.False(ParsekFlight.ShouldSuppressVisualFx(10f));
         }
 
         [Fact]
-        public void ShouldSuppressExplosionFx_Above10x_Suppresses()
+        public void ShouldSuppressVisualFx_Above10x_Suppresses()
         {
-            Assert.True(ParsekFlight.ShouldSuppressExplosionFx(50f));
+            Assert.True(ParsekFlight.ShouldSuppressVisualFx(50f));
         }
     }
 }

--- a/Source/Parsek.Tests/ExplosionFxTests.cs
+++ b/Source/Parsek.Tests/ExplosionFxTests.cs
@@ -360,5 +360,40 @@ namespace Parsek.Tests
             Assert.NotNull(val);
             Assert.Equal("4", val);
         }
+
+        // --- Warp suppression tests ---
+
+        [Theory]
+        [InlineData(50f, true)]
+        [InlineData(100f, true)]
+        [InlineData(1000f, true)]
+        public void ShouldTriggerExplosion_PassesButWarpSuppresses_LogsSuppression(float warpRate, bool expectedSuppressed)
+        {
+            // ShouldTriggerExplosion returns true (all guards pass)
+            bool wouldFire = ParsekFlight.ShouldTriggerExplosion(
+                explosionAlreadyFired: false,
+                terminalState: TerminalState.Destroyed,
+                ghostExists: true,
+                vesselName: "WarpTestVessel",
+                recIdx: 7);
+
+            Assert.True(wouldFire);
+
+            // But ShouldSuppressExplosionFx prevents the actual FX
+            bool suppressed = ParsekFlight.ShouldSuppressExplosionFx(warpRate);
+            Assert.Equal(expectedSuppressed, suppressed);
+        }
+
+        [Fact]
+        public void ShouldSuppressExplosionFx_At10x_DoesNotSuppress()
+        {
+            Assert.False(ParsekFlight.ShouldSuppressExplosionFx(10f));
+        }
+
+        [Fact]
+        public void ShouldSuppressExplosionFx_Above10x_Suppresses()
+        {
+            Assert.True(ParsekFlight.ShouldSuppressExplosionFx(50f));
+        }
     }
 }

--- a/Source/Parsek.Tests/RuntimePolicyTests.cs
+++ b/Source/Parsek.Tests/RuntimePolicyTests.cs
@@ -81,6 +81,32 @@ namespace Parsek.Tests
         }
 
         [Theory]
+        [InlineData(1f, false)]
+        [InlineData(5f, false)]
+        [InlineData(10f, false)]
+        [InlineData(10.001f, true)]
+        [InlineData(50f, true)]
+        [InlineData(100f, true)]
+        [InlineData(1000f, true)]
+        public void ShouldSuppressExplosionFx_ThresholdAt10x(float warpRate, bool expected)
+        {
+            Assert.Equal(expected, ParsekFlight.ShouldSuppressExplosionFx(warpRate));
+        }
+
+        [Theory]
+        [InlineData(1f, false)]
+        [InlineData(10f, false)]
+        [InlineData(50f, false)]
+        [InlineData(50.001f, true)]
+        [InlineData(100f, true)]
+        [InlineData(1000f, true)]
+        [InlineData(100000f, true)]
+        public void ShouldSuppressGhosts_ThresholdAt50x(float warpRate, bool expected)
+        {
+            Assert.Equal(expected, ParsekFlight.ShouldSuppressGhosts(warpRate));
+        }
+
+        [Theory]
         [InlineData(true, true)]
         [InlineData(false, false)]
         public void ShouldPauseTimelineResourceReplay_ReflectsRecordingState(bool isRecording, bool expected)

--- a/Source/Parsek.Tests/RuntimePolicyTests.cs
+++ b/Source/Parsek.Tests/RuntimePolicyTests.cs
@@ -88,9 +88,9 @@ namespace Parsek.Tests
         [InlineData(50f, true)]
         [InlineData(100f, true)]
         [InlineData(1000f, true)]
-        public void ShouldSuppressExplosionFx_ThresholdAt10x(float warpRate, bool expected)
+        public void ShouldSuppressVisualFx_ThresholdAt10x(float warpRate, bool expected)
         {
-            Assert.Equal(expected, ParsekFlight.ShouldSuppressExplosionFx(warpRate));
+            Assert.Equal(expected, ParsekFlight.ShouldSuppressVisualFx(warpRate));
         }
 
         [Theory]

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -69,6 +69,7 @@ namespace Parsek
             public MaterialPropertyBlock reentryMpb; // per-ghost to avoid shared-state bugs with overlapping ghosts
             public bool explosionFired;
             public bool pauseHidden;
+            public bool rcsSuppressed;
             public Transform cameraPivot; // child of ghost; centroid of active parts — camera targets this
             public Vector3 lastInterpolatedVelocity;
             public string lastInterpolatedBodyName;
@@ -4651,12 +4652,7 @@ namespace Parsek
                             ParsekLog.Info("Flight",
                                 $"Ghost #{i} \"{rec.VesselName}\" hidden: warp {warpRate:F0}x > 50x");
                             if (watchedRecordingIndex == i)
-                            {
-                                watchedOverlapCycleIndex = -1;
-                                overlapRetargetAfterUT = -1;
-                                if (overlapCameraAnchor != null) { Destroy(overlapCameraAnchor); overlapCameraAnchor = null; }
                                 ExitWatchMode();
-                            }
                         }
                         DestroyAllOverlapGhosts(i);
                         if (rec.TreeId == null) ApplyResourceDeltas(rec, currentUT);
@@ -4694,6 +4690,8 @@ namespace Parsek
                         UpdateReentryFx(i, state, rec.VesselName);
                         if (suppressExplosionFx)
                             StopAllRcsEmissions(state);
+                        else
+                            RestoreAllRcsEmissions(state);
                         if (rec.TreeId == null)
                             ApplyResourceDeltas(rec, currentUT);
                     }
@@ -4727,6 +4725,8 @@ namespace Parsek
                         UpdateReentryFx(i, state, rec.VesselName);
                         if (suppressExplosionFx)
                             StopAllRcsEmissions(state);
+                        else
+                            RestoreAllRcsEmissions(state);
                         if (rec.TreeId == null)
                             ApplyResourceDeltas(rec, currentUT);
                     }
@@ -4977,12 +4977,7 @@ namespace Parsek
                     ParsekLog.Info("Flight",
                         $"Ghost #{recIdx} \"{rec.VesselName}\" (loop) hidden: warp > 50x");
                     if (watchedRecordingIndex == recIdx)
-                    {
-                        watchedOverlapCycleIndex = -1;
-                        overlapRetargetAfterUT = -1;
-                        if (overlapCameraAnchor != null) { Destroy(overlapCameraAnchor); overlapCameraAnchor = null; }
                         ExitWatchMode();
-                    }
                 }
                 DestroyAllOverlapGhosts(recIdx);
                 return;
@@ -5136,6 +5131,8 @@ namespace Parsek
             UpdateReentryFx(recIdx, state, rec.VesselName);
             if (suppressExplosionFx)
                 StopAllRcsEmissions(state);
+            else
+                RestoreAllRcsEmissions(state);
         }
 
         /// <summary>
@@ -5243,6 +5240,8 @@ namespace Parsek
                 UpdateReentryFx(recIdx, primaryState, rec.VesselName);
                 if (suppressExplosionFx)
                     StopAllRcsEmissions(primaryState);
+                else
+                    RestoreAllRcsEmissions(primaryState);
             }
 
             // Update overlap ghosts (older cycles)
@@ -5315,6 +5314,8 @@ namespace Parsek
                 UpdateReentryFx(recIdx, ovState, rec.VesselName);
                 if (suppressExplosionFx)
                     StopAllRcsEmissions(ovState);
+                else
+                    RestoreAllRcsEmissions(ovState);
             }
         }
 
@@ -7375,6 +7376,8 @@ namespace Parsek
         internal static void StopAllRcsEmissions(GhostPlaybackState state)
         {
             if (state?.rcsInfos == null) return;
+            if (state.rcsSuppressed) return;
+            state.rcsSuppressed = true;
             foreach (var info in state.rcsInfos.Values)
                 for (int j = 0; j < info.particleSystems.Count; j++)
                 {
@@ -7383,6 +7386,24 @@ namespace Parsek
                     {
                         var em = ps.emission;
                         if (em.enabled) em.enabled = false;
+                    }
+                }
+        }
+
+        internal static void RestoreAllRcsEmissions(GhostPlaybackState state)
+        {
+            if (state?.rcsInfos == null) return;
+            if (!state.rcsSuppressed) return;
+            state.rcsSuppressed = false;
+            foreach (var info in state.rcsInfos.Values)
+                for (int j = 0; j < info.particleSystems.Count; j++)
+                {
+                    var ps = info.particleSystems[j];
+                    if (ps != null)
+                    {
+                        var em = ps.emission;
+                        em.enabled = true;
+                        if (!ps.isPlaying) ps.Play();
                     }
                 }
         }

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -4447,7 +4447,7 @@ namespace Parsek
                 Log("Manual playback complete — reached end of recording");
                 // explosionAlreadyFired=false is safe: preview is one-shot (StopPlayback called immediately after)
                 if (previewRecording != null && ghostObject != null
-                    && !ShouldSuppressExplosionFx(TimeWarp.CurrentRate)
+                    && !ShouldSuppressVisualFx(TimeWarp.CurrentRate)
                     && ShouldTriggerExplosion(false, previewRecording.TerminalStateValue,
                            true, previewRecording.VesselName, -1))
                 {
@@ -4531,7 +4531,7 @@ namespace Parsek
 
             float warpRate = TimeWarp.CurrentRate;
             bool suppressGhosts = ShouldSuppressGhosts(warpRate);
-            bool suppressExplosionFx = ShouldSuppressExplosionFx(warpRate);
+            bool suppressVisualFx = ShouldSuppressVisualFx(warpRate);
 
             for (int i = 0; i < committed.Count; i++)
             {
@@ -4565,7 +4565,7 @@ namespace Parsek
                 if (ShouldLoopPlayback(rec))
                 {
                     UpdateLoopingTimelinePlayback(i, rec, currentUT, state, ghostActive,
-                        suppressGhosts, suppressExplosionFx);
+                        suppressGhosts, suppressVisualFx);
                     continue;
                 }
 
@@ -4688,7 +4688,7 @@ namespace Parsek
 
                         ApplyPartEvents(i, rec, currentUT, state);
                         UpdateReentryFx(i, state, rec.VesselName);
-                        if (suppressExplosionFx)
+                        if (suppressVisualFx)
                             StopAllRcsEmissions(state);
                         else
                             RestoreAllRcsEmissions(state);
@@ -4723,7 +4723,7 @@ namespace Parsek
                         // Reentry FX: no InterpolationResult set for background-only path — bodyName stays null,
                         // so UpdateReentryFx will no-op. Intentional: on-rails vessels don't reenter.
                         UpdateReentryFx(i, state, rec.VesselName);
-                        if (suppressExplosionFx)
+                        if (suppressVisualFx)
                             StopAllRcsEmissions(state);
                         else
                             RestoreAllRcsEmissions(state);
@@ -4963,7 +4963,7 @@ namespace Parsek
             GhostPlaybackState state,
             bool ghostActive,
             bool suppressGhosts,
-            bool suppressExplosionFx)
+            bool suppressVisualFx)
         {
             double intervalSeconds = GetLoopIntervalSeconds(rec);
             double duration = rec.EndUT - rec.StartUT;
@@ -4987,7 +4987,7 @@ namespace Parsek
             if (intervalSeconds < 0)
             {
                 UpdateOverlapLoopPlayback(recIdx, rec, currentUT, state, ghostActive,
-                    intervalSeconds, duration, suppressExplosionFx);
+                    intervalSeconds, duration, suppressVisualFx);
                 return;
             }
 
@@ -5129,7 +5129,7 @@ namespace Parsek
 
             ApplyPartEvents(recIdx, rec, loopUT, state);
             UpdateReentryFx(recIdx, state, rec.VesselName);
-            if (suppressExplosionFx)
+            if (suppressVisualFx)
                 StopAllRcsEmissions(state);
             else
                 RestoreAllRcsEmissions(state);
@@ -5147,7 +5147,7 @@ namespace Parsek
             bool primaryActive,
             double intervalSeconds,
             double duration,
-            bool suppressExplosionFx)
+            bool suppressVisualFx)
         {
             if (currentUT < rec.StartUT)
             {
@@ -5238,7 +5238,7 @@ namespace Parsek
 
                 ApplyPartEvents(recIdx, rec, loopUT, primaryState);
                 UpdateReentryFx(recIdx, primaryState, rec.VesselName);
-                if (suppressExplosionFx)
+                if (suppressVisualFx)
                     StopAllRcsEmissions(primaryState);
                 else
                     RestoreAllRcsEmissions(primaryState);
@@ -5312,7 +5312,7 @@ namespace Parsek
 
                 ApplyPartEvents(recIdx, rec, loopUT, ovState);
                 UpdateReentryFx(recIdx, ovState, rec.VesselName);
-                if (suppressExplosionFx)
+                if (suppressVisualFx)
                     StopAllRcsEmissions(ovState);
                 else
                     RestoreAllRcsEmissions(ovState);
@@ -5741,7 +5741,7 @@ namespace Parsek
                     state.ghost != null, rec.VesselName, recIdx))
                 return;
 
-            if (ShouldSuppressExplosionFx(TimeWarp.CurrentRate))
+            if (ShouldSuppressVisualFx(TimeWarp.CurrentRate))
             {
                 state.explosionFired = true;
                 HideAllGhostParts(state);
@@ -6261,7 +6261,7 @@ namespace Parsek
         internal static void SpawnPartPuffAtPart(GameObject ghost, uint persistentId)
         {
             if (ghost == null) return;
-            if (ShouldSuppressExplosionFx(TimeWarp.CurrentRate)) return;
+            if (ShouldSuppressVisualFx(TimeWarp.CurrentRate)) return;
             var t = ghost.transform.Find($"ghost_part_{persistentId}");
             if (t == null)
             {
@@ -6793,7 +6793,7 @@ namespace Parsek
             var info = state.reentryFxInfo;
             if (info == null || state.ghost == null) return;
 
-            if (ShouldSuppressExplosionFx(TimeWarp.CurrentRate))
+            if (ShouldSuppressVisualFx(TimeWarp.CurrentRate))
             {
                 DriveReentryToZero(info, recIdx, state.lastInterpolatedBodyName,
                     state.lastInterpolatedAltitude, vesselName);
@@ -7363,14 +7363,20 @@ namespace Parsek
             Log($"Warp reset for playback start ({context})");
         }
 
-        internal static bool ShouldSuppressExplosionFx(float currentWarpRate)
+        // KSP rails warp levels: 1, 5, 10, 50, 100, 1000, 10000, 100000.
+        // FX threshold: 10x is the last level where explosions/puffs/reentry/RCS look reasonable.
+        // Ghost threshold: 50x is the last level where ghost meshes update often enough to be useful.
+        internal const float FxSuppressWarpThreshold = 10f;
+        internal const float GhostHideWarpThreshold = 50f;
+
+        internal static bool ShouldSuppressVisualFx(float currentWarpRate)
         {
-            return currentWarpRate > 10f;
+            return currentWarpRate > FxSuppressWarpThreshold;
         }
 
         internal static bool ShouldSuppressGhosts(float currentWarpRate)
         {
-            return currentWarpRate > 50f;
+            return currentWarpRate > GhostHideWarpThreshold;
         }
 
         internal static void StopAllRcsEmissions(GhostPlaybackState state)

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -4450,6 +4450,7 @@ namespace Parsek
                 Log("Manual playback complete — reached end of recording");
                 // explosionAlreadyFired=false is safe: preview is one-shot (StopPlayback called immediately after)
                 if (previewRecording != null && ghostObject != null
+                    && !ShouldSuppressExplosionFx(TimeWarp.CurrentRate)
                     && ShouldTriggerExplosion(false, previewRecording.TerminalStateValue,
                            true, previewRecording.VesselName, -1))
                 {
@@ -4540,6 +4541,10 @@ namespace Parsek
 
             if (committed.Count == 0) return;
 
+            float warpRate = TimeWarp.CurrentRate;
+            bool suppressGhosts = ShouldSuppressGhosts(warpRate);
+            bool suppressExplosionFx = ShouldSuppressExplosionFx(warpRate);
+
             for (int i = 0; i < committed.Count; i++)
             {
                 var rec = committed[i];
@@ -4571,7 +4576,8 @@ namespace Parsek
 
                 if (ShouldLoopPlayback(rec))
                 {
-                    UpdateLoopingTimelinePlayback(i, rec, currentUT, state, ghostActive);
+                    UpdateLoopingTimelinePlayback(i, rec, currentUT, state, ghostActive,
+                        suppressGhosts, suppressExplosionFx);
                     continue;
                 }
 
@@ -4649,6 +4655,27 @@ namespace Parsek
 
                 if (inRange)
                 {
+                    // High time warp: hide ghost visuals for performance
+                    if (suppressGhosts)
+                    {
+                        if (ghostActive && state.ghost.activeSelf)
+                        {
+                            state.ghost.SetActive(false);
+                            ParsekLog.Info("Flight",
+                                $"Ghost #{i} \"{rec.VesselName}\" hidden: warp {warpRate:F0}x > 50x");
+                            if (watchedRecordingIndex == i)
+                            {
+                                watchedOverlapCycleIndex = -1;
+                                overlapRetargetAfterUT = -1;
+                                if (overlapCameraAnchor != null) { Destroy(overlapCameraAnchor); overlapCameraAnchor = null; }
+                                ExitWatchMode();
+                            }
+                        }
+                        DestroyAllOverlapGhosts(i);
+                        if (rec.TreeId == null) ApplyResourceDeltas(rec, currentUT);
+                        continue;
+                    }
+
                     if (hasPoints)
                     {
                         // Normal ghost playback (point-based, with optional orbit segments)
@@ -4658,6 +4685,12 @@ namespace Parsek
                             state = ghostStates[i];
                             if (loggedGhostEnter.Add(i))
                                 Log($"Ghost ENTERED range: #{i} \"{rec.VesselName}\" at UT {currentUT:F1}");
+                        }
+                        else if (!state.ghost.activeSelf)
+                        {
+                            state.ghost.SetActive(true);
+                            ParsekLog.Info("Flight",
+                                $"Ghost #{i} \"{rec.VesselName}\" re-shown after warp-down");
                         }
 
                         int playbackIdx = state.playbackIndex;
@@ -4672,6 +4705,8 @@ namespace Parsek
 
                         ApplyPartEvents(i, rec, currentUT, state);
                         UpdateReentryFx(i, state, rec.VesselName);
+                        if (suppressExplosionFx)
+                            StopAllRcsEmissions(state);
                         if (rec.TreeId == null)
                             ApplyResourceDeltas(rec, currentUT);
                     }
@@ -4682,6 +4717,12 @@ namespace Parsek
                         {
                             SpawnTimelineGhost(i, rec);
                             state = ghostStates[i];
+                        }
+                        else if (!state.ghost.activeSelf)
+                        {
+                            state.ghost.SetActive(true);
+                            ParsekLog.Info("Flight",
+                                $"Ghost #{i} \"{rec.VesselName}\" (background) re-shown after warp-down");
                         }
                         if (state != null && state.ghost != null)
                         {
@@ -4697,6 +4738,8 @@ namespace Parsek
                         // Reentry FX: no InterpolationResult set for background-only path — bodyName stays null,
                         // so UpdateReentryFx will no-op. Intentional: on-rails vessels don't reenter.
                         UpdateReentryFx(i, state, rec.VesselName);
+                        if (suppressExplosionFx)
+                            StopAllRcsEmissions(state);
                         if (rec.TreeId == null)
                             ApplyResourceDeltas(rec, currentUT);
                     }
@@ -4887,15 +4930,38 @@ namespace Parsek
             RecordingStore.Recording rec,
             double currentUT,
             GhostPlaybackState state,
-            bool ghostActive)
+            bool ghostActive,
+            bool suppressGhosts,
+            bool suppressExplosionFx)
         {
             double intervalSeconds = GetLoopIntervalSeconds(rec);
             double duration = rec.EndUT - rec.StartUT;
 
+            // High time warp: hide ghost, destroy overlaps
+            if (suppressGhosts)
+            {
+                if (ghostActive && state.ghost.activeSelf)
+                {
+                    state.ghost.SetActive(false);
+                    ParsekLog.Info("Flight",
+                        $"Ghost #{recIdx} \"{rec.VesselName}\" (loop) hidden: warp > 50x");
+                    if (watchedRecordingIndex == recIdx)
+                    {
+                        watchedOverlapCycleIndex = -1;
+                        overlapRetargetAfterUT = -1;
+                        if (overlapCameraAnchor != null) { Destroy(overlapCameraAnchor); overlapCameraAnchor = null; }
+                        ExitWatchMode();
+                    }
+                }
+                DestroyAllOverlapGhosts(recIdx);
+                return;
+            }
+
             // For negative intervals: use multi-cycle overlap path
             if (intervalSeconds < 0)
             {
-                UpdateOverlapLoopPlayback(recIdx, rec, currentUT, state, ghostActive, intervalSeconds, duration);
+                UpdateOverlapLoopPlayback(recIdx, rec, currentUT, state, ghostActive,
+                    intervalSeconds, duration, suppressExplosionFx);
                 return;
             }
 
@@ -4987,6 +5053,12 @@ namespace Parsek
                         $" camDist={FlightCamera.fetch.Distance:F1}");
                 }
             }
+            else if (ghostActive && !state.ghost.activeSelf)
+            {
+                state.ghost.SetActive(true);
+                ParsekLog.Info("Flight",
+                    $"Ghost #{recIdx} \"{rec.VesselName}\" (loop) re-shown after warp-down");
+            }
 
             if (state == null || state.ghost == null)
                 return;
@@ -5031,6 +5103,8 @@ namespace Parsek
 
             ApplyPartEvents(recIdx, rec, loopUT, state);
             UpdateReentryFx(recIdx, state, rec.VesselName);
+            if (suppressExplosionFx)
+                StopAllRcsEmissions(state);
         }
 
         /// <summary>
@@ -5044,7 +5118,8 @@ namespace Parsek
             GhostPlaybackState primaryState,
             bool primaryActive,
             double intervalSeconds,
-            double duration)
+            double duration,
+            bool suppressExplosionFx)
         {
             if (currentUT < rec.StartUT)
             {
@@ -5135,6 +5210,8 @@ namespace Parsek
 
                 ApplyPartEvents(recIdx, rec, loopUT, primaryState);
                 UpdateReentryFx(recIdx, primaryState, rec.VesselName);
+                if (suppressExplosionFx)
+                    StopAllRcsEmissions(primaryState);
             }
 
             // Update overlap ghosts (older cycles)
@@ -5205,6 +5282,8 @@ namespace Parsek
 
                 ApplyPartEvents(recIdx, rec, loopUT, ovState);
                 UpdateReentryFx(recIdx, ovState, rec.VesselName);
+                if (suppressExplosionFx)
+                    StopAllRcsEmissions(ovState);
             }
         }
 
@@ -5628,6 +5707,16 @@ namespace Parsek
             if (!ShouldTriggerExplosion(state.explosionFired, rec.TerminalStateValue,
                     state.ghost != null, rec.VesselName, recIdx))
                 return;
+
+            if (ShouldSuppressExplosionFx(TimeWarp.CurrentRate))
+            {
+                state.explosionFired = true;
+                HideAllGhostParts(state);
+                ParsekLog.Verbose("ExplosionFx",
+                    $"Explosion suppressed for ghost #{recIdx} \"{rec.VesselName}\": " +
+                    $"warp rate {TimeWarp.CurrentRate:F0}x > 10x");
+                return;
+            }
 
             state.explosionFired = true;
 
@@ -6139,6 +6228,7 @@ namespace Parsek
         internal static void SpawnPartPuffAtPart(GameObject ghost, uint persistentId)
         {
             if (ghost == null) return;
+            if (ShouldSuppressExplosionFx(TimeWarp.CurrentRate)) return;
             var t = ghost.transform.Find($"ghost_part_{persistentId}");
             if (t == null)
             {
@@ -6669,6 +6759,13 @@ namespace Parsek
         {
             var info = state.reentryFxInfo;
             if (info == null || state.ghost == null) return;
+
+            if (ShouldSuppressExplosionFx(TimeWarp.CurrentRate))
+            {
+                DriveReentryToZero(info, recIdx, state.lastInterpolatedBodyName,
+                    state.lastInterpolatedAltitude, vesselName);
+                return;
+            }
 
             Vector3 interpolatedVel = state.lastInterpolatedVelocity;
             string bodyName = state.lastInterpolatedBodyName;
@@ -7231,6 +7328,31 @@ namespace Parsek
             if (!IsAnyWarpActive()) return;
             TimeWarp.SetRate(0, true);
             Log($"Warp reset for playback start ({context})");
+        }
+
+        internal static bool ShouldSuppressExplosionFx(float currentWarpRate)
+        {
+            return currentWarpRate > 10f;
+        }
+
+        internal static bool ShouldSuppressGhosts(float currentWarpRate)
+        {
+            return currentWarpRate > 50f;
+        }
+
+        internal static void StopAllRcsEmissions(GhostPlaybackState state)
+        {
+            if (state?.rcsInfos == null) return;
+            foreach (var info in state.rcsInfos.Values)
+                for (int j = 0; j < info.particleSystems.Count; j++)
+                {
+                    var ps = info.particleSystems[j];
+                    if (ps != null)
+                    {
+                        var em = ps.emission;
+                        if (em.enabled) em.enabled = false;
+                    }
+                }
         }
 
         internal static bool ShouldPauseTimelineResourceReplay(bool isRecording)

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -4650,7 +4650,7 @@ namespace Parsek
                         {
                             state.ghost.SetActive(false);
                             ParsekLog.Info("Flight",
-                                $"Ghost #{i} \"{rec.VesselName}\" hidden: warp {warpRate:F0}x > 50x");
+                                $"Ghost #{i} \"{rec.VesselName}\" hidden: warp {warpRate.ToString("F1", CultureInfo.InvariantCulture)}x > {GhostHideWarpThreshold}x");
                             if (watchedRecordingIndex == i)
                                 ExitWatchMode();
                         }
@@ -4975,7 +4975,7 @@ namespace Parsek
                 {
                     state.ghost.SetActive(false);
                     ParsekLog.Info("Flight",
-                        $"Ghost #{recIdx} \"{rec.VesselName}\" (loop) hidden: warp > 50x");
+                        $"Ghost #{recIdx} \"{rec.VesselName}\" (loop) hidden: warp > {GhostHideWarpThreshold}x");
                     if (watchedRecordingIndex == recIdx)
                         ExitWatchMode();
                 }
@@ -5745,9 +5745,9 @@ namespace Parsek
             {
                 state.explosionFired = true;
                 HideAllGhostParts(state);
-                ParsekLog.Verbose("ExplosionFx",
+                ParsekLog.VerboseRateLimited("ExplosionFx", $"explosion-suppress-{recIdx}",
                     $"Explosion suppressed for ghost #{recIdx} \"{rec.VesselName}\": " +
-                    $"warp rate {TimeWarp.CurrentRate:F0}x > 10x");
+                    $"warp rate {TimeWarp.CurrentRate.ToString("F1", CultureInfo.InvariantCulture)}x > {FxSuppressWarpThreshold}x");
                 return;
             }
 

--- a/Source/Parsek/ParsekKSC.cs
+++ b/Source/Parsek/ParsekKSC.cs
@@ -125,7 +125,9 @@ namespace Parsek
 
             if (suppressGhosts)
             {
-                // High time warp: hide primary ghosts, destroy overlap ghosts
+                // High time warp: hide primary ghosts, destroy overlap ghosts.
+                // KSC scene does not apply resource deltas (flight-only), so no
+                // ApplyResourceDeltas call needed here.
                 foreach (var kvp in kscGhosts)
                     if (kvp.Value.ghost != null && kvp.Value.ghost.activeSelf)
                     {
@@ -249,6 +251,8 @@ namespace Parsek
                     ParsekFlight.ApplyPartEvents(recIdx, rec, targetUT, state);
                 if (suppressExplosionFx)
                     ParsekFlight.StopAllRcsEmissions(state);
+                else
+                    ParsekFlight.RestoreAllRcsEmissions(state);
 
                 if (!state.explosionFired && targetUT >= rec.EndUT)
                     TriggerExplosionIfDestroyed(state, rec, recIdx);
@@ -356,6 +360,8 @@ namespace Parsek
                     ParsekFlight.ApplyPartEvents(recIdx, rec, loopUT, primaryState);
                 if (suppressExplosionFx)
                     ParsekFlight.StopAllRcsEmissions(primaryState);
+                else
+                    ParsekFlight.RestoreAllRcsEmissions(primaryState);
 
                 if (!primaryState.explosionFired && phase >= duration)
                     TriggerExplosionIfDestroyed(primaryState, rec, recIdx);
@@ -399,6 +405,8 @@ namespace Parsek
                     ParsekFlight.ApplyPartEvents(recIdx, rec, loopUT, ovState);
                 if (suppressExplosionFx)
                     ParsekFlight.StopAllRcsEmissions(ovState);
+                else
+                    ParsekFlight.RestoreAllRcsEmissions(ovState);
             }
         }
 

--- a/Source/Parsek/ParsekKSC.cs
+++ b/Source/Parsek/ParsekKSC.cs
@@ -119,6 +119,25 @@ namespace Parsek
 
             double currentUT = Planetarium.GetUniversalTime();
 
+            float warpRate = TimeWarp.CurrentRate;
+            bool suppressGhosts = ParsekFlight.ShouldSuppressGhosts(warpRate);
+            bool suppressExplosionFx = ParsekFlight.ShouldSuppressExplosionFx(warpRate);
+
+            if (suppressGhosts)
+            {
+                // High time warp: hide primary ghosts, destroy overlap ghosts
+                foreach (var kvp in kscGhosts)
+                    if (kvp.Value.ghost != null && kvp.Value.ghost.activeSelf)
+                    {
+                        kvp.Value.ghost.SetActive(false);
+                        ParsekLog.Info("KSCGhost",
+                            $"Ghost #{kvp.Key} hidden: warp {warpRate:F0}x > 50x");
+                    }
+                foreach (int key in new List<int>(kscOverlapGhosts.Keys))
+                    DestroyAllKscOverlapGhosts(key);
+                return;
+            }
+
             for (int i = 0; i < committed.Count; i++)
             {
                 var rec = committed[i];
@@ -148,7 +167,7 @@ namespace Parsek
                     if (intervalSeconds < 0)
                     {
                         // Negative interval: multi-ghost overlap path
-                        UpdateOverlapKsc(i, rec, currentUT, intervalSeconds, duration);
+                        UpdateOverlapKsc(i, rec, currentUT, intervalSeconds, duration, suppressExplosionFx);
                         continue;
                     }
 
@@ -162,14 +181,14 @@ namespace Parsek
                         out targetUT, out cycleIndex, out inPauseWindow);
 
                     UpdateSingleGhostKsc(i, rec, currentUT, targetUT, cycleIndex,
-                        inRange, inPauseWindow);
+                        inRange, inPauseWindow, suppressExplosionFx);
                 }
                 else
                 {
                     // Non-looping: raw UT range check
                     DestroyAllKscOverlapGhosts(i);
                     bool inRange = currentUT >= rec.StartUT && currentUT <= rec.EndUT;
-                    UpdateSingleGhostKsc(i, rec, currentUT, currentUT, 0, inRange, false);
+                    UpdateSingleGhostKsc(i, rec, currentUT, currentUT, 0, inRange, false, suppressExplosionFx);
                 }
             }
         }
@@ -179,7 +198,7 @@ namespace Parsek
         /// </summary>
         void UpdateSingleGhostKsc(int recIdx, RecordingStore.Recording rec,
             double currentUT, double targetUT, int cycleIndex,
-            bool inRange, bool inPauseWindow)
+            bool inRange, bool inPauseWindow, bool suppressExplosionFx)
         {
             ParsekFlight.GhostPlaybackState state;
             kscGhosts.TryGetValue(recIdx, out state);
@@ -213,6 +232,12 @@ namespace Parsek
                             $"cycle={cycleIndex} loop={rec.LoopPlayback} " +
                             $"terminal={rec.TerminalStateValue}");
                 }
+                else if (!state.ghost.activeSelf)
+                {
+                    state.ghost.SetActive(true);
+                    ParsekLog.Info("KSCGhost",
+                        $"Ghost #{recIdx} \"{rec.VesselName}\" re-shown after warp-down");
+                }
 
                 InterpolateAndPositionKsc(
                     state.ghost, rec.Points,
@@ -222,6 +247,8 @@ namespace Parsek
                 // Distance culling: skip expensive part events for ghosts too far from camera
                 if (IsGhostInCullRange(state.ghost))
                     ParsekFlight.ApplyPartEvents(recIdx, rec, targetUT, state);
+                if (suppressExplosionFx)
+                    ParsekFlight.StopAllRcsEmissions(state);
 
                 if (!state.explosionFired && targetUT >= rec.EndUT)
                     TriggerExplosionIfDestroyed(state, rec, recIdx);
@@ -259,7 +286,7 @@ namespace Parsek
         /// (no camera logic, no reentry FX).
         /// </summary>
         void UpdateOverlapKsc(int recIdx, RecordingStore.Recording rec,
-            double currentUT, double intervalSeconds, double duration)
+            double currentUT, double intervalSeconds, double duration, bool suppressExplosionFx)
         {
             ParsekFlight.GhostPlaybackState primaryState;
             kscGhosts.TryGetValue(recIdx, out primaryState);
@@ -327,6 +354,8 @@ namespace Parsek
 
                 if (IsGhostInCullRange(primaryState.ghost))
                     ParsekFlight.ApplyPartEvents(recIdx, rec, loopUT, primaryState);
+                if (suppressExplosionFx)
+                    ParsekFlight.StopAllRcsEmissions(primaryState);
 
                 if (!primaryState.explosionFired && phase >= duration)
                     TriggerExplosionIfDestroyed(primaryState, rec, recIdx);
@@ -368,6 +397,8 @@ namespace Parsek
 
                 if (IsGhostInCullRange(ovState.ghost))
                     ParsekFlight.ApplyPartEvents(recIdx, rec, loopUT, ovState);
+                if (suppressExplosionFx)
+                    ParsekFlight.StopAllRcsEmissions(ovState);
             }
         }
 
@@ -755,6 +786,15 @@ namespace Parsek
             if (state == null || state.ghost == null) return;
             if (state.explosionFired) return;
             if (rec.TerminalStateValue != TerminalState.Destroyed) return;
+
+            if (ParsekFlight.ShouldSuppressExplosionFx(TimeWarp.CurrentRate))
+            {
+                state.explosionFired = true;
+                ParsekFlight.HideAllGhostParts(state);
+                ParsekLog.Verbose("KSCGhost",
+                    $"Explosion suppressed for ghost #{recIdx} \"{rec.VesselName}\": warp > 10x");
+                return;
+            }
 
             state.explosionFired = true;
 

--- a/Source/Parsek/ParsekKSC.cs
+++ b/Source/Parsek/ParsekKSC.cs
@@ -121,7 +121,7 @@ namespace Parsek
 
             float warpRate = TimeWarp.CurrentRate;
             bool suppressGhosts = ParsekFlight.ShouldSuppressGhosts(warpRate);
-            bool suppressExplosionFx = ParsekFlight.ShouldSuppressExplosionFx(warpRate);
+            bool suppressVisualFx = ParsekFlight.ShouldSuppressVisualFx(warpRate);
 
             if (suppressGhosts)
             {
@@ -169,7 +169,7 @@ namespace Parsek
                     if (intervalSeconds < 0)
                     {
                         // Negative interval: multi-ghost overlap path
-                        UpdateOverlapKsc(i, rec, currentUT, intervalSeconds, duration, suppressExplosionFx);
+                        UpdateOverlapKsc(i, rec, currentUT, intervalSeconds, duration, suppressVisualFx);
                         continue;
                     }
 
@@ -183,14 +183,14 @@ namespace Parsek
                         out targetUT, out cycleIndex, out inPauseWindow);
 
                     UpdateSingleGhostKsc(i, rec, currentUT, targetUT, cycleIndex,
-                        inRange, inPauseWindow, suppressExplosionFx);
+                        inRange, inPauseWindow, suppressVisualFx);
                 }
                 else
                 {
                     // Non-looping: raw UT range check
                     DestroyAllKscOverlapGhosts(i);
                     bool inRange = currentUT >= rec.StartUT && currentUT <= rec.EndUT;
-                    UpdateSingleGhostKsc(i, rec, currentUT, currentUT, 0, inRange, false, suppressExplosionFx);
+                    UpdateSingleGhostKsc(i, rec, currentUT, currentUT, 0, inRange, false, suppressVisualFx);
                 }
             }
         }
@@ -200,7 +200,7 @@ namespace Parsek
         /// </summary>
         void UpdateSingleGhostKsc(int recIdx, RecordingStore.Recording rec,
             double currentUT, double targetUT, int cycleIndex,
-            bool inRange, bool inPauseWindow, bool suppressExplosionFx)
+            bool inRange, bool inPauseWindow, bool suppressVisualFx)
         {
             ParsekFlight.GhostPlaybackState state;
             kscGhosts.TryGetValue(recIdx, out state);
@@ -249,7 +249,7 @@ namespace Parsek
                 // Distance culling: skip expensive part events for ghosts too far from camera
                 if (IsGhostInCullRange(state.ghost))
                     ParsekFlight.ApplyPartEvents(recIdx, rec, targetUT, state);
-                if (suppressExplosionFx)
+                if (suppressVisualFx)
                     ParsekFlight.StopAllRcsEmissions(state);
                 else
                     ParsekFlight.RestoreAllRcsEmissions(state);
@@ -290,7 +290,7 @@ namespace Parsek
         /// (no camera logic, no reentry FX).
         /// </summary>
         void UpdateOverlapKsc(int recIdx, RecordingStore.Recording rec,
-            double currentUT, double intervalSeconds, double duration, bool suppressExplosionFx)
+            double currentUT, double intervalSeconds, double duration, bool suppressVisualFx)
         {
             ParsekFlight.GhostPlaybackState primaryState;
             kscGhosts.TryGetValue(recIdx, out primaryState);
@@ -358,7 +358,7 @@ namespace Parsek
 
                 if (IsGhostInCullRange(primaryState.ghost))
                     ParsekFlight.ApplyPartEvents(recIdx, rec, loopUT, primaryState);
-                if (suppressExplosionFx)
+                if (suppressVisualFx)
                     ParsekFlight.StopAllRcsEmissions(primaryState);
                 else
                     ParsekFlight.RestoreAllRcsEmissions(primaryState);
@@ -403,7 +403,7 @@ namespace Parsek
 
                 if (IsGhostInCullRange(ovState.ghost))
                     ParsekFlight.ApplyPartEvents(recIdx, rec, loopUT, ovState);
-                if (suppressExplosionFx)
+                if (suppressVisualFx)
                     ParsekFlight.StopAllRcsEmissions(ovState);
                 else
                     ParsekFlight.RestoreAllRcsEmissions(ovState);
@@ -793,7 +793,7 @@ namespace Parsek
             if (state.explosionFired) return;
             if (rec.TerminalStateValue != TerminalState.Destroyed) return;
 
-            if (ParsekFlight.ShouldSuppressExplosionFx(TimeWarp.CurrentRate))
+            if (ParsekFlight.ShouldSuppressVisualFx(TimeWarp.CurrentRate))
             {
                 state.explosionFired = true;
                 ParsekFlight.HideAllGhostParts(state);

--- a/Source/Parsek/ParsekKSC.cs
+++ b/Source/Parsek/ParsekKSC.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using ClickThroughFix;
 using KSP.UI.Screens;
 using ToolbarControl_NS;
@@ -133,7 +134,7 @@ namespace Parsek
                     {
                         kvp.Value.ghost.SetActive(false);
                         ParsekLog.Info("KSCGhost",
-                            $"Ghost #{kvp.Key} hidden: warp {warpRate:F0}x > 50x");
+                            $"Ghost #{kvp.Key} hidden: warp {warpRate.ToString("F1", CultureInfo.InvariantCulture)}x > {ParsekFlight.GhostHideWarpThreshold}x");
                     }
                 foreach (int key in new List<int>(kscOverlapGhosts.Keys))
                     DestroyAllKscOverlapGhosts(key);
@@ -797,8 +798,8 @@ namespace Parsek
             {
                 state.explosionFired = true;
                 ParsekFlight.HideAllGhostParts(state);
-                ParsekLog.Verbose("KSCGhost",
-                    $"Explosion suppressed for ghost #{recIdx} \"{rec.VesselName}\": warp > 10x");
+                ParsekLog.VerboseRateLimited("KSCGhost", $"explosion-suppress-{recIdx}",
+                    $"Explosion suppressed for ghost #{recIdx} \"{rec.VesselName}\": warp > {ParsekFlight.FxSuppressWarpThreshold}x");
                 return;
             }
 


### PR DESCRIPTION
## Summary
- Suppress expensive FX at >10x warp: explosions, part puffs, reentry plasma, RCS plumes (engine plumes stay as smoke trails)
- Hide all ghost visuals at >50x warp via `SetActive(false)` to preserve `partEventIndex` state
- Seamless re-show on warp-down without respawn or event replay burst

## Details
Two `internal static` threshold methods (`ShouldSuppressExplosionFx`, `ShouldSuppressGhosts`) gate all visual suppression. Ghost hiding uses `SetActive(false)` instead of destroy+recreate to avoid the `partEventIndex` reset that would cause a burst of part puffs and visibility changes on warp-down.

Watch mode auto-exits when ghosts are hidden. Overlap ghosts are destroyed (expendable clones). Vessel spawning and resource deltas continue at all warp rates.

| Warp rate | Ghosts | Engine plumes | RCS | Reentry plasma | Explosions | Puffs |
|-----------|--------|---------------|-----|----------------|------------|-------|
| ≤10x | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| >10x ≤50x | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ |
| >50x | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |

## Test plan
- [x] `dotnet test` — 1516 pass, 0 fail (pre-existing `InjectAllRecordings` excluded)
- [x] In-game: warp 10x → all FX visible
- [x] In-game: warp 50x → ghosts + engine plumes only, no RCS/explosions/puffs/reentry
- [x] In-game: warp 100x → scene clean, no ghosts
- [x] In-game: reduce warp 100x → 50x → ghosts reappear seamlessly
- [x] KSP.log shows suppression messages at transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)