### PR TITLE
Visual bug fixes and gameplay improvements

### DIFF
--- a/Source/Parsek.Tests/SeedEventTests.cs
+++ b/Source/Parsek.Tests/SeedEventTests.cs
@@ -1,0 +1,649 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Tests for PartStateSeeder.EmitSeedEvents and FlightRecorder.DecodeEngineKey.
+    /// Verifies that initial visual state is correctly captured as seed PartEvents
+    /// at recording start (bugs #70/#65).
+    /// </summary>
+    [Collection("Sequential")]
+    public class SeedEventTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public SeedEventTests()
+        {
+            RecordingStore.SuppressLogging = true;
+            MilestoneStore.SuppressLogging = true;
+            MilestoneStore.ResetForTesting();
+            GameStateStore.SuppressLogging = true;
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+            ParsekLog.VerboseOverrideForTesting = true;
+            RecordingStore.ResetForTesting();
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+            RecordingStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+            MilestoneStore.ResetForTesting();
+        }
+
+        #region DecodeEngineKey
+
+        [Fact]
+        public void DecodeEngineKey_RoundtripsWithEncodeEngineKey()
+        {
+            uint pid = 42000;
+            int moduleIndex = 3;
+            ulong key = FlightRecorder.EncodeEngineKey(pid, moduleIndex);
+
+            uint decodedPid;
+            int decodedMidx;
+            FlightRecorder.DecodeEngineKey(key, out decodedPid, out decodedMidx);
+
+            Assert.Equal(pid, decodedPid);
+            Assert.Equal(moduleIndex, decodedMidx);
+        }
+
+        [Fact]
+        public void DecodeEngineKey_ZeroModuleIndex()
+        {
+            uint pid = 100000;
+            int moduleIndex = 0;
+            ulong key = FlightRecorder.EncodeEngineKey(pid, moduleIndex);
+
+            uint decodedPid;
+            int decodedMidx;
+            FlightRecorder.DecodeEngineKey(key, out decodedPid, out decodedMidx);
+
+            Assert.Equal(pid, decodedPid);
+            Assert.Equal(0, decodedMidx);
+        }
+
+        [Fact]
+        public void DecodeEngineKey_MaxModuleIndex255()
+        {
+            uint pid = 999999;
+            int moduleIndex = 255;
+            ulong key = FlightRecorder.EncodeEngineKey(pid, moduleIndex);
+
+            uint decodedPid;
+            int decodedMidx;
+            FlightRecorder.DecodeEngineKey(key, out decodedPid, out decodedMidx);
+
+            Assert.Equal(pid, decodedPid);
+            Assert.Equal(255, decodedMidx);
+        }
+
+        [Fact]
+        public void DecodeEngineKey_LargePid()
+        {
+            uint pid = uint.MaxValue;
+            int moduleIndex = 7;
+            ulong key = FlightRecorder.EncodeEngineKey(pid, moduleIndex);
+
+            uint decodedPid;
+            int decodedMidx;
+            FlightRecorder.DecodeEngineKey(key, out decodedPid, out decodedMidx);
+
+            Assert.Equal(pid, decodedPid);
+            Assert.Equal(moduleIndex, decodedMidx);
+        }
+
+        #endregion
+
+        #region EmitSeedEvents — empty sets
+
+        [Fact]
+        public void EmitSeedEvents_EmptySets_ReturnsZeroEvents()
+        {
+            var sets = new PartTrackingSets
+            {
+                deployedFairings = new HashSet<uint>(),
+                jettisonedShrouds = new HashSet<uint>(),
+                parachuteStates = new Dictionary<uint, int>(),
+                extendedDeployables = new HashSet<uint>(),
+                lightsOn = new HashSet<uint>(),
+                blinkingLights = new HashSet<uint>(),
+                lightBlinkRates = new Dictionary<uint, float>(),
+                deployedGear = new HashSet<uint>(),
+                openCargoBays = new HashSet<uint>(),
+                deployedLadders = new HashSet<ulong>(),
+                deployedAnimationGroups = new HashSet<ulong>(),
+                deployedAnimateGenericModules = new HashSet<ulong>(),
+                deployedAeroSurfaceModules = new HashSet<ulong>(),
+                deployedControlSurfaceModules = new HashSet<ulong>(),
+                deployedRobotArmScannerModules = new HashSet<ulong>(),
+                animateHeatLevels = new Dictionary<ulong, HeatLevel>(),
+                activeEngineKeys = new HashSet<ulong>(),
+                lastThrottle = new Dictionary<ulong, float>(),
+                activeRcsKeys = new HashSet<ulong>(),
+                lastRcsThrottle = new Dictionary<ulong, float>(),
+            };
+            var names = new Dictionary<uint, string>();
+
+            var result = PartStateSeeder.EmitSeedEvents(sets, names, 1000.0, "Test");
+
+            Assert.Empty(result);
+            Assert.Contains(logLines, l => l.Contains("Seed events emitted: 0"));
+        }
+
+        [Fact]
+        public void EmitSeedEvents_NullSets_ReturnsZeroEvents()
+        {
+            var result = PartStateSeeder.EmitSeedEvents(null, new Dictionary<uint, string>(), 1000.0, "Test");
+            Assert.Empty(result);
+        }
+
+        #endregion
+
+        #region EmitSeedEvents — individual set types
+
+        [Fact]
+        public void EmitSeedEvents_OneExtendedDeployable_EmitsDeployableExtended()
+        {
+            var sets = MakeEmptySets();
+            sets.extendedDeployables.Add(500u);
+            var names = new Dictionary<uint, string> { { 500u, "solarPanel" } };
+
+            var result = PartStateSeeder.EmitSeedEvents(sets, names, 2000.0, "Test");
+
+            Assert.Single(result);
+            Assert.Equal(PartEventType.DeployableExtended, result[0].eventType);
+            Assert.Equal(500u, result[0].partPersistentId);
+            Assert.Equal(2000.0, result[0].ut);
+            Assert.Equal("solarPanel", result[0].partName);
+            Assert.Equal(0, result[0].moduleIndex);
+            Assert.Contains(logLines, l => l.Contains("Seed event: DeployableExtended pid=500"));
+        }
+
+        [Fact]
+        public void EmitSeedEvents_OneJettisonedShroud_EmitsShroudJettisoned()
+        {
+            var sets = MakeEmptySets();
+            sets.jettisonedShrouds.Add(600u);
+            var names = new Dictionary<uint, string> { { 600u, "engineShroud" } };
+
+            var result = PartStateSeeder.EmitSeedEvents(sets, names, 3000.0, "Test");
+
+            Assert.Single(result);
+            Assert.Equal(PartEventType.ShroudJettisoned, result[0].eventType);
+            Assert.Equal(600u, result[0].partPersistentId);
+            Assert.Equal(3000.0, result[0].ut);
+            Assert.Equal("engineShroud", result[0].partName);
+        }
+
+        [Fact]
+        public void EmitSeedEvents_DeployedFairing_EmitsFairingJettisoned()
+        {
+            var sets = MakeEmptySets();
+            sets.deployedFairings.Add(700u);
+            var names = new Dictionary<uint, string> { { 700u, "proceduralFairing" } };
+
+            var result = PartStateSeeder.EmitSeedEvents(sets, names, 4000.0, "Test");
+
+            Assert.Single(result);
+            Assert.Equal(PartEventType.FairingJettisoned, result[0].eventType);
+            Assert.Equal(700u, result[0].partPersistentId);
+        }
+
+        [Fact]
+        public void EmitSeedEvents_LightOn_EmitsLightOn()
+        {
+            var sets = MakeEmptySets();
+            sets.lightsOn.Add(800u);
+            var names = new Dictionary<uint, string> { { 800u, "spotLight" } };
+
+            var result = PartStateSeeder.EmitSeedEvents(sets, names, 5000.0, "Test");
+
+            Assert.Single(result);
+            Assert.Equal(PartEventType.LightOn, result[0].eventType);
+            Assert.Equal(800u, result[0].partPersistentId);
+        }
+
+        [Fact]
+        public void EmitSeedEvents_BlinkingLight_EmitsLightBlinkEnabledWithRate()
+        {
+            var sets = MakeEmptySets();
+            sets.blinkingLights.Add(900u);
+            sets.lightBlinkRates[900u] = 2.5f;
+            var names = new Dictionary<uint, string> { { 900u, "navLight" } };
+
+            var result = PartStateSeeder.EmitSeedEvents(sets, names, 6000.0, "Test");
+
+            Assert.Single(result);
+            Assert.Equal(PartEventType.LightBlinkEnabled, result[0].eventType);
+            Assert.Equal(900u, result[0].partPersistentId);
+            Assert.Equal(2.5f, result[0].value);
+            Assert.Contains(logLines, l => l.Contains("LightBlinkEnabled") && l.Contains("rate=2.50"));
+        }
+
+        [Fact]
+        public void EmitSeedEvents_DeployedGear_EmitsGearDeployed()
+        {
+            var sets = MakeEmptySets();
+            sets.deployedGear.Add(1000u);
+            var names = new Dictionary<uint, string> { { 1000u, "gearFixed" } };
+
+            var result = PartStateSeeder.EmitSeedEvents(sets, names, 7000.0, "Test");
+
+            Assert.Single(result);
+            Assert.Equal(PartEventType.GearDeployed, result[0].eventType);
+            Assert.Equal(1000u, result[0].partPersistentId);
+        }
+
+        [Fact]
+        public void EmitSeedEvents_OpenCargoBay_EmitsCargoBayOpened()
+        {
+            var sets = MakeEmptySets();
+            sets.openCargoBays.Add(1100u);
+            var names = new Dictionary<uint, string> { { 1100u, "serviceBay" } };
+
+            var result = PartStateSeeder.EmitSeedEvents(sets, names, 8000.0, "Test");
+
+            Assert.Single(result);
+            Assert.Equal(PartEventType.CargoBayOpened, result[0].eventType);
+            Assert.Equal(1100u, result[0].partPersistentId);
+        }
+
+        [Fact]
+        public void EmitSeedEvents_ParachuteDeployed_EmitsParachuteDeployed()
+        {
+            var sets = MakeEmptySets();
+            sets.parachuteStates[1200u] = 2; // fully deployed
+            var names = new Dictionary<uint, string> { { 1200u, "parachuteMk1" } };
+
+            var result = PartStateSeeder.EmitSeedEvents(sets, names, 9000.0, "Test");
+
+            Assert.Single(result);
+            Assert.Equal(PartEventType.ParachuteDeployed, result[0].eventType);
+            Assert.Equal(1200u, result[0].partPersistentId);
+        }
+
+        [Fact]
+        public void EmitSeedEvents_ParachuteSemiDeployed_EmitsParachuteSemiDeployed()
+        {
+            var sets = MakeEmptySets();
+            sets.parachuteStates[1300u] = 1; // semi-deployed
+            var names = new Dictionary<uint, string> { { 1300u, "parachuteMk2" } };
+
+            var result = PartStateSeeder.EmitSeedEvents(sets, names, 9500.0, "Test");
+
+            Assert.Single(result);
+            Assert.Equal(PartEventType.ParachuteSemiDeployed, result[0].eventType);
+            Assert.Equal(1300u, result[0].partPersistentId);
+        }
+
+        [Fact]
+        public void EmitSeedEvents_ParachuteStowed_NoEvent()
+        {
+            var sets = MakeEmptySets();
+            sets.parachuteStates[1400u] = 0; // stowed — should not emit
+            var names = new Dictionary<uint, string> { { 1400u, "parachuteMk3" } };
+
+            var result = PartStateSeeder.EmitSeedEvents(sets, names, 9600.0, "Test");
+
+            Assert.Empty(result);
+        }
+
+        #endregion
+
+        #region EmitSeedEvents — ulong-keyed sets (decoded moduleIndex)
+
+        [Fact]
+        public void EmitSeedEvents_DeployedLadder_EmitsDeployableExtendedWithModuleIndex()
+        {
+            var sets = MakeEmptySets();
+            uint pid = 2000u;
+            int midx = 5;
+            ulong key = FlightRecorder.EncodeEngineKey(pid, midx);
+            sets.deployedLadders.Add(key);
+            var names = new Dictionary<uint, string> { { pid, "ladder1" } };
+
+            var result = PartStateSeeder.EmitSeedEvents(sets, names, 10000.0, "Test");
+
+            Assert.Single(result);
+            Assert.Equal(PartEventType.DeployableExtended, result[0].eventType);
+            Assert.Equal(pid, result[0].partPersistentId);
+            Assert.Equal(midx, result[0].moduleIndex);
+            Assert.Contains(logLines, l => l.Contains("ladder") && l.Contains("midx=5"));
+        }
+
+        [Fact]
+        public void EmitSeedEvents_DeployedAnimationGroup_EmitsDeployableExtendedWithModuleIndex()
+        {
+            var sets = MakeEmptySets();
+            uint pid = 2100u;
+            int midx = 2;
+            ulong key = FlightRecorder.EncodeEngineKey(pid, midx);
+            sets.deployedAnimationGroups.Add(key);
+            var names = new Dictionary<uint, string> { { pid, "drillS" } };
+
+            var result = PartStateSeeder.EmitSeedEvents(sets, names, 11000.0, "Test");
+
+            Assert.Single(result);
+            Assert.Equal(PartEventType.DeployableExtended, result[0].eventType);
+            Assert.Equal(pid, result[0].partPersistentId);
+            Assert.Equal(midx, result[0].moduleIndex);
+        }
+
+        [Fact]
+        public void EmitSeedEvents_DeployedAnimateGeneric_EmitsDeployableExtendedWithModuleIndex()
+        {
+            var sets = MakeEmptySets();
+            uint pid = 2200u;
+            int midx = 3;
+            ulong key = FlightRecorder.EncodeEngineKey(pid, midx);
+            sets.deployedAnimateGenericModules.Add(key);
+            var names = new Dictionary<uint, string> { { pid, "structuralWing" } };
+
+            var result = PartStateSeeder.EmitSeedEvents(sets, names, 12000.0, "Test");
+
+            Assert.Single(result);
+            Assert.Equal(PartEventType.DeployableExtended, result[0].eventType);
+            Assert.Equal(pid, result[0].partPersistentId);
+            Assert.Equal(midx, result[0].moduleIndex);
+        }
+
+        [Fact]
+        public void EmitSeedEvents_DeployedAeroSurface_EmitsDeployableExtendedWithModuleIndex()
+        {
+            var sets = MakeEmptySets();
+            uint pid = 2300u;
+            int midx = 1;
+            ulong key = FlightRecorder.EncodeEngineKey(pid, midx);
+            sets.deployedAeroSurfaceModules.Add(key);
+            var names = new Dictionary<uint, string> { { pid, "airbrake" } };
+
+            var result = PartStateSeeder.EmitSeedEvents(sets, names, 13000.0, "Test");
+
+            Assert.Single(result);
+            Assert.Equal(PartEventType.DeployableExtended, result[0].eventType);
+            Assert.Equal(pid, result[0].partPersistentId);
+            Assert.Equal(midx, result[0].moduleIndex);
+        }
+
+        [Fact]
+        public void EmitSeedEvents_DeployedControlSurface_EmitsDeployableExtendedWithModuleIndex()
+        {
+            var sets = MakeEmptySets();
+            uint pid = 2400u;
+            int midx = 4;
+            ulong key = FlightRecorder.EncodeEngineKey(pid, midx);
+            sets.deployedControlSurfaceModules.Add(key);
+            var names = new Dictionary<uint, string> { { pid, "elevon" } };
+
+            var result = PartStateSeeder.EmitSeedEvents(sets, names, 14000.0, "Test");
+
+            Assert.Single(result);
+            Assert.Equal(PartEventType.DeployableExtended, result[0].eventType);
+            Assert.Equal(pid, result[0].partPersistentId);
+            Assert.Equal(midx, result[0].moduleIndex);
+        }
+
+        [Fact]
+        public void EmitSeedEvents_DeployedRobotArmScanner_EmitsDeployableExtendedWithModuleIndex()
+        {
+            var sets = MakeEmptySets();
+            uint pid = 2500u;
+            int midx = 6;
+            ulong key = FlightRecorder.EncodeEngineKey(pid, midx);
+            sets.deployedRobotArmScannerModules.Add(key);
+            var names = new Dictionary<uint, string> { { pid, "robotArm" } };
+
+            var result = PartStateSeeder.EmitSeedEvents(sets, names, 15000.0, "Test");
+
+            Assert.Single(result);
+            Assert.Equal(PartEventType.DeployableExtended, result[0].eventType);
+            Assert.Equal(pid, result[0].partPersistentId);
+            Assert.Equal(midx, result[0].moduleIndex);
+        }
+
+        #endregion
+
+        #region EmitSeedEvents — thermal, engine, RCS
+
+        [Fact]
+        public void EmitSeedEvents_HeatLevelHot_EmitsThermalAnimationHot()
+        {
+            var sets = MakeEmptySets();
+            uint pid = 3000u;
+            int midx = 2;
+            ulong key = FlightRecorder.EncodeEngineKey(pid, midx);
+            sets.animateHeatLevels[key] = HeatLevel.Hot;
+            var names = new Dictionary<uint, string> { { pid, "engineBell" } };
+
+            var result = PartStateSeeder.EmitSeedEvents(sets, names, 16000.0, "Test");
+
+            Assert.Single(result);
+            Assert.Equal(PartEventType.ThermalAnimationHot, result[0].eventType);
+            Assert.Equal(pid, result[0].partPersistentId);
+            Assert.Equal(midx, result[0].moduleIndex);
+        }
+
+        [Fact]
+        public void EmitSeedEvents_HeatLevelMedium_EmitsThermalAnimationMedium()
+        {
+            var sets = MakeEmptySets();
+            uint pid = 3100u;
+            int midx = 1;
+            ulong key = FlightRecorder.EncodeEngineKey(pid, midx);
+            sets.animateHeatLevels[key] = HeatLevel.Medium;
+            var names = new Dictionary<uint, string> { { pid, "heatShield" } };
+
+            var result = PartStateSeeder.EmitSeedEvents(sets, names, 17000.0, "Test");
+
+            Assert.Single(result);
+            Assert.Equal(PartEventType.ThermalAnimationMedium, result[0].eventType);
+            Assert.Equal(pid, result[0].partPersistentId);
+            Assert.Equal(midx, result[0].moduleIndex);
+        }
+
+        [Fact]
+        public void EmitSeedEvents_HeatLevelCold_NoEvent()
+        {
+            var sets = MakeEmptySets();
+            uint pid = 3200u;
+            int midx = 0;
+            ulong key = FlightRecorder.EncodeEngineKey(pid, midx);
+            sets.animateHeatLevels[key] = HeatLevel.Cold;
+            var names = new Dictionary<uint, string> { { pid, "nosecone" } };
+
+            var result = PartStateSeeder.EmitSeedEvents(sets, names, 18000.0, "Test");
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void EmitSeedEvents_ActiveEngine_EmitsEngineIgnitedWithThrottle()
+        {
+            var sets = MakeEmptySets();
+            uint pid = 4000u;
+            int midx = 1;
+            ulong key = FlightRecorder.EncodeEngineKey(pid, midx);
+            sets.activeEngineKeys.Add(key);
+            sets.lastThrottle[key] = 0.75f;
+            var names = new Dictionary<uint, string> { { pid, "liquidEngine" } };
+
+            var result = PartStateSeeder.EmitSeedEvents(sets, names, 19000.0, "Test");
+
+            Assert.Single(result);
+            Assert.Equal(PartEventType.EngineIgnited, result[0].eventType);
+            Assert.Equal(pid, result[0].partPersistentId);
+            Assert.Equal(midx, result[0].moduleIndex);
+            Assert.Equal(0.75f, result[0].value);
+            Assert.Contains(logLines, l => l.Contains("EngineIgnited") && l.Contains("throttle=0.75"));
+        }
+
+        [Fact]
+        public void EmitSeedEvents_ActiveEngine_NoThrottleEntry_DefaultsToZero()
+        {
+            var sets = MakeEmptySets();
+            uint pid = 4100u;
+            int midx = 0;
+            ulong key = FlightRecorder.EncodeEngineKey(pid, midx);
+            sets.activeEngineKeys.Add(key);
+            // No lastThrottle entry — should default to 0
+            var names = new Dictionary<uint, string> { { pid, "solidBooster" } };
+
+            var result = PartStateSeeder.EmitSeedEvents(sets, names, 19500.0, "Test");
+
+            Assert.Single(result);
+            Assert.Equal(PartEventType.EngineIgnited, result[0].eventType);
+            Assert.Equal(0f, result[0].value);
+        }
+
+        [Fact]
+        public void EmitSeedEvents_ActiveRcs_EmitsRCSActivatedWithPower()
+        {
+            var sets = MakeEmptySets();
+            uint pid = 5000u;
+            int midx = 3;
+            ulong key = FlightRecorder.EncodeEngineKey(pid, midx);
+            sets.activeRcsKeys.Add(key);
+            sets.lastRcsThrottle[key] = 0.6f;
+            var names = new Dictionary<uint, string> { { pid, "rcsBlock" } };
+
+            var result = PartStateSeeder.EmitSeedEvents(sets, names, 20000.0, "Test");
+
+            Assert.Single(result);
+            Assert.Equal(PartEventType.RCSActivated, result[0].eventType);
+            Assert.Equal(pid, result[0].partPersistentId);
+            Assert.Equal(midx, result[0].moduleIndex);
+            Assert.Equal(0.6f, result[0].value);
+            Assert.Contains(logLines, l => l.Contains("RCSActivated") && l.Contains("power=0.60"));
+        }
+
+        #endregion
+
+        #region EmitSeedEvents — multiple mixed states
+
+        [Fact]
+        public void EmitSeedEvents_MultipleMixedStates_CorrectCountAndAllAtStartUT()
+        {
+            var sets = MakeEmptySets();
+            double startUT = 25000.0;
+
+            // Add various states
+            sets.extendedDeployables.Add(100u);
+            sets.jettisonedShrouds.Add(200u);
+            sets.deployedFairings.Add(300u);
+            sets.lightsOn.Add(400u);
+            sets.deployedGear.Add(500u);
+            sets.parachuteStates[600u] = 2; // deployed
+            sets.parachuteStates[700u] = 1; // semi-deployed
+
+            ulong engineKey = FlightRecorder.EncodeEngineKey(800u, 0);
+            sets.activeEngineKeys.Add(engineKey);
+            sets.lastThrottle[engineKey] = 1.0f;
+
+            ulong ladderKey = FlightRecorder.EncodeEngineKey(900u, 2);
+            sets.deployedLadders.Add(ladderKey);
+
+            var names = new Dictionary<uint, string>
+            {
+                { 100u, "solarPanel" },
+                { 200u, "engineShroud" },
+                { 300u, "fairing" },
+                { 400u, "light" },
+                { 500u, "gear" },
+                { 600u, "chute1" },
+                { 700u, "chute2" },
+                { 800u, "engine" },
+                { 900u, "ladder" },
+            };
+
+            var result = PartStateSeeder.EmitSeedEvents(sets, names, startUT, "Test");
+
+            Assert.Equal(9, result.Count);
+
+            // All events should be at startUT
+            Assert.All(result, e => Assert.Equal(startUT, e.ut));
+
+            // Verify each event type is present
+            Assert.Contains(result, e => e.eventType == PartEventType.DeployableExtended && e.partPersistentId == 100u);
+            Assert.Contains(result, e => e.eventType == PartEventType.ShroudJettisoned && e.partPersistentId == 200u);
+            Assert.Contains(result, e => e.eventType == PartEventType.FairingJettisoned && e.partPersistentId == 300u);
+            Assert.Contains(result, e => e.eventType == PartEventType.LightOn && e.partPersistentId == 400u);
+            Assert.Contains(result, e => e.eventType == PartEventType.GearDeployed && e.partPersistentId == 500u);
+            Assert.Contains(result, e => e.eventType == PartEventType.ParachuteDeployed && e.partPersistentId == 600u);
+            Assert.Contains(result, e => e.eventType == PartEventType.ParachuteSemiDeployed && e.partPersistentId == 700u);
+            Assert.Contains(result, e => e.eventType == PartEventType.EngineIgnited && e.partPersistentId == 800u);
+            Assert.Contains(result, e => e.eventType == PartEventType.DeployableExtended && e.partPersistentId == 900u && e.moduleIndex == 2);
+
+            // Summary log line
+            Assert.Contains(logLines, l => l.Contains("Seed events emitted: 9"));
+        }
+
+        #endregion
+
+        #region EmitSeedEvents — part name lookup
+
+        [Fact]
+        public void EmitSeedEvents_UnknownPid_UsesUnknownPartName()
+        {
+            var sets = MakeEmptySets();
+            sets.lightsOn.Add(9999u);
+            var names = new Dictionary<uint, string>(); // empty — pid not found
+
+            var result = PartStateSeeder.EmitSeedEvents(sets, names, 30000.0, "Test");
+
+            Assert.Single(result);
+            Assert.Equal("unknown", result[0].partName);
+        }
+
+        [Fact]
+        public void EmitSeedEvents_NullPartNamesByPid_UsesUnknown()
+        {
+            var sets = MakeEmptySets();
+            sets.deployedGear.Add(8888u);
+
+            var result = PartStateSeeder.EmitSeedEvents(sets, null, 31000.0, "Test");
+
+            Assert.Single(result);
+            Assert.Equal("unknown", result[0].partName);
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private static PartTrackingSets MakeEmptySets()
+        {
+            return new PartTrackingSets
+            {
+                deployedFairings = new HashSet<uint>(),
+                jettisonedShrouds = new HashSet<uint>(),
+                parachuteStates = new Dictionary<uint, int>(),
+                extendedDeployables = new HashSet<uint>(),
+                lightsOn = new HashSet<uint>(),
+                blinkingLights = new HashSet<uint>(),
+                lightBlinkRates = new Dictionary<uint, float>(),
+                deployedGear = new HashSet<uint>(),
+                openCargoBays = new HashSet<uint>(),
+                deployedLadders = new HashSet<ulong>(),
+                deployedAnimationGroups = new HashSet<ulong>(),
+                deployedAnimateGenericModules = new HashSet<ulong>(),
+                deployedAeroSurfaceModules = new HashSet<ulong>(),
+                deployedControlSurfaceModules = new HashSet<ulong>(),
+                deployedRobotArmScannerModules = new HashSet<ulong>(),
+                animateHeatLevels = new Dictionary<ulong, HeatLevel>(),
+                activeEngineKeys = new HashSet<ulong>(),
+                lastThrottle = new Dictionary<ulong, float>(),
+                activeRcsKeys = new HashSet<ulong>(),
+                lastRcsThrottle = new Dictionary<ulong, float>(),
+            };
+        }
+
+        #endregion
+    }
+}

--- a/Source/Parsek.Tests/ZoneRenderingTests.cs
+++ b/Source/Parsek.Tests/ZoneRenderingTests.cs
@@ -146,12 +146,12 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void GetZoneRenderingPolicy_Visual_MeshOnlyNoPartEvents()
+        public void GetZoneRenderingPolicy_Visual_MeshAndPartEvents()
         {
             var (shouldHide, skipPartEvents, skipPositioning) =
                 GhostPlaybackLogic.GetZoneRenderingPolicy(RenderingZone.Visual);
             Assert.False(shouldHide);
-            Assert.True(skipPartEvents);
+            Assert.False(skipPartEvents); // part events apply in Visual zone for staging/jettison/destruction
             Assert.False(skipPositioning);
         }
 
@@ -234,9 +234,9 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void ShouldApplyPartEventsForZone_Visual_ReturnsFalse()
+        public void ShouldApplyPartEventsForZone_Visual_ReturnsTrue()
         {
-            Assert.False(GhostPlaybackLogic.ShouldApplyPartEventsForZone(RenderingZone.Visual));
+            Assert.True(GhostPlaybackLogic.ShouldApplyPartEventsForZone(RenderingZone.Visual));
         }
 
         [Fact]

--- a/Source/Parsek/BackgroundRecorder.cs
+++ b/Source/Parsek/BackgroundRecorder.cs
@@ -1413,6 +1413,48 @@ namespace Parsek
             // Seed all tracking sets with current part state (mirrors FlightRecorder.SeedExistingPartStates)
             SeedBackgroundPartStates(v, state);
 
+            // Emit seed events for the initial visual state (bugs #70/#65)
+            var partNamesByPid = new Dictionary<uint, string>();
+            if (v.parts != null)
+            {
+                for (int i = 0; i < v.parts.Count; i++)
+                {
+                    Part p = v.parts[i];
+                    if (p != null && !partNamesByPid.ContainsKey(p.persistentId))
+                        partNamesByPid[p.persistentId] = p.partInfo?.name ?? "unknown";
+                }
+            }
+            double seedUT = Planetarium.GetUniversalTime();
+            var seedSets = new PartTrackingSets
+            {
+                deployedFairings = state.deployedFairings,
+                jettisonedShrouds = state.jettisonedShrouds,
+                parachuteStates = state.parachuteStates,
+                extendedDeployables = state.extendedDeployables,
+                lightsOn = state.lightsOn,
+                blinkingLights = state.blinkingLights,
+                lightBlinkRates = state.lightBlinkRates,
+                deployedGear = state.deployedGear,
+                openCargoBays = state.openCargoBays,
+                deployedLadders = state.deployedLadders,
+                deployedAnimationGroups = state.deployedAnimationGroups,
+                deployedAnimateGenericModules = state.deployedAnimateGenericModules,
+                deployedAeroSurfaceModules = state.deployedAeroSurfaceModules,
+                deployedControlSurfaceModules = state.deployedControlSurfaceModules,
+                deployedRobotArmScannerModules = state.deployedRobotArmScannerModules,
+                animateHeatLevels = state.animateHeatLevels,
+                activeEngineKeys = state.activeEngineKeys,
+                lastThrottle = state.lastThrottle,
+                activeRcsKeys = state.activeRcsKeys,
+                lastRcsThrottle = state.lastRcsThrottle,
+            };
+            var seedEvents = PartStateSeeder.EmitSeedEvents(seedSets, partNamesByPid, seedUT, "BgRecorder");
+            Recording treeRecForSeed;
+            if (seedEvents.Count > 0 && tree.Recordings.TryGetValue(recordingId, out treeRecForSeed))
+            {
+                treeRecForSeed.PartEvents.AddRange(seedEvents);
+            }
+
             // Initialize environment tracking and open first TrackSection
             double ut = Planetarium.GetUniversalTime();
             bool hasAtmo = v.mainBody != null && v.mainBody.atmosphere;

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -2031,6 +2031,12 @@ namespace Parsek
             return ((ulong)pid << 8) | (uint)moduleIndex;
         }
 
+        internal static void DecodeEngineKey(ulong key, out uint pid, out int moduleIndex)
+        {
+            pid = (uint)(key >> 8);
+            moduleIndex = (int)(key & 0xFF);
+        }
+
         private static string FormatCoverageEntries(List<string> entries, int maxEntries = 8)
         {
             if (entries == null || entries.Count == 0)
@@ -3770,6 +3776,45 @@ namespace Parsek
             // false events at first poll (e.g., shrouds already jettisoned,
             // engines already running, lights already on, etc.)
             SeedExistingPartStates(v);
+
+            // Emit seed events for the initial visual state so ghost playback
+            // can reconstruct correct visuals from recording start (bugs #70/#65).
+            var partNamesByPid = new Dictionary<uint, string>();
+            if (v.parts != null)
+            {
+                for (int i = 0; i < v.parts.Count; i++)
+                {
+                    Part p = v.parts[i];
+                    if (p != null && !partNamesByPid.ContainsKey(p.persistentId))
+                        partNamesByPid[p.persistentId] = p.partInfo?.name ?? "unknown";
+                }
+            }
+            var seedSets = new PartTrackingSets
+            {
+                deployedFairings = deployedFairings,
+                jettisonedShrouds = jettisonedShrouds,
+                parachuteStates = parachuteStates,
+                extendedDeployables = extendedDeployables,
+                lightsOn = lightsOn,
+                blinkingLights = blinkingLights,
+                lightBlinkRates = lightBlinkRates,
+                deployedGear = deployedGear,
+                openCargoBays = openCargoBays,
+                deployedLadders = deployedLadders,
+                deployedAnimationGroups = deployedAnimationGroups,
+                deployedAnimateGenericModules = deployedAnimateGenericModules,
+                deployedAeroSurfaceModules = deployedAeroSurfaceModules,
+                deployedControlSurfaceModules = deployedControlSurfaceModules,
+                deployedRobotArmScannerModules = deployedRobotArmScannerModules,
+                animateHeatLevels = animateHeatLevels,
+                activeEngineKeys = activeEngineKeys,
+                lastThrottle = lastThrottle,
+                activeRcsKeys = activeRcsKeys,
+                lastRcsThrottle = lastRcsThrottle,
+            };
+            double seedUT = Planetarium.GetUniversalTime();
+            var seedEvents = PartStateSeeder.EmitSeedEvents(seedSets, partNamesByPid, seedUT, "Recorder");
+            PartEvents.AddRange(seedEvents);
         }
 
         /// <summary>

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -898,12 +898,6 @@ namespace Parsek
                                 && fInfo.fairingMeshObject != null)
                             {
                                 fInfo.fairingMeshObject.SetActive(false);
-                                // Show procedural truss structure (generated from XSECTION data at build time)
-                                if (fInfo.trussStructureObject != null)
-                                {
-                                    fInfo.trussStructureObject.SetActive(true);
-                                    ParsekLog.Verbose("Flight", $"Fairing truss structure revealed for pid={evt.partPersistentId}");
-                                }
                                 ParsekLog.Verbose("Flight", $"Part event applied: FairingJettisoned '{evt.partName}' pid={evt.partPersistentId}");
                             }
                         }

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -898,6 +898,15 @@ namespace Parsek
                                 && fInfo.fairingMeshObject != null)
                             {
                                 fInfo.fairingMeshObject.SetActive(false);
+                                if (fInfo.showInternalOnJettison && fInfo.internalStructureObjects != null)
+                                {
+                                    for (int s = 0; s < fInfo.internalStructureObjects.Count; s++)
+                                    {
+                                        if (fInfo.internalStructureObjects[s] != null)
+                                            fInfo.internalStructureObjects[s].SetActive(true);
+                                    }
+                                    ParsekLog.Verbose("Flight", $"Fairing internal structure revealed for pid={evt.partPersistentId} ({fInfo.internalStructureObjects.Count} objects)");
+                                }
                                 ParsekLog.Verbose("Flight", $"Part event applied: FairingJettisoned '{evt.partName}' pid={evt.partPersistentId}");
                             }
                         }

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -2040,16 +2040,18 @@ namespace Parsek
 
         /// <summary>
         /// Determines whether part events should be applied for the given zone.
-        /// Part events only fire in the Physics zone (within 2.3 km).
+        /// Part events fire in Physics and Visual zones — structural changes (decoupling,
+        /// fairing jettison, destruction) must be applied even when the ghost is distant.
+        /// Only Beyond zone skips part events (ghost mesh is hidden anyway).
         /// </summary>
         internal static bool ShouldApplyPartEventsForZone(RenderingZone zone)
         {
-            return zone == RenderingZone.Physics;
+            return zone != RenderingZone.Beyond;
         }
 
         /// <summary>
         /// Determines the rendering actions to take when a ghost transitions between zones.
-        /// Returns (shouldHideMesh, shouldExitWatch, shouldSkipPartEvents, shouldSkipPositioning).
+        /// Returns (shouldHideMesh, shouldSkipPartEvents, shouldSkipPositioning).
         /// </summary>
         internal static (bool shouldHideMesh, bool shouldSkipPartEvents, bool shouldSkipPositioning)
             GetZoneRenderingPolicy(RenderingZone zone)
@@ -2059,7 +2061,7 @@ namespace Parsek
                 case RenderingZone.Beyond:
                     return (true, true, true);
                 case RenderingZone.Visual:
-                    return (false, true, false);
+                    return (false, false, false); // part events apply in Visual zone
                 case RenderingZone.Physics:
                 default:
                     return (false, false, false);

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -1082,18 +1082,27 @@ namespace Parsek
 
         internal static void HidePartSubtree(GameObject ghost, uint rootPid, Dictionary<uint, List<uint>> tree)
         {
+            int hidden = 0;
+            int notFound = 0;
             var stack = new Stack<uint>();
             stack.Push(rootPid);
             while (stack.Count > 0)
             {
                 uint pid = stack.Pop();
                 var t = ghost.transform.Find($"ghost_part_{pid}");
-                if (t != null) t.gameObject.SetActive(false);
+                if (t != null)
+                {
+                    t.gameObject.SetActive(false);
+                    hidden++;
+                }
+                else
+                    notFound++;
                 List<uint> children;
                 if (tree.TryGetValue(pid, out children))
                     for (int c = 0; c < children.Count; c++)
                         stack.Push(children[c]);
             }
+            ParsekLog.Verbose("Flight", $"HidePartSubtree: rootPid={rootPid}, hidden={hidden}, notFound={notFound}, treeHasRoot={tree.ContainsKey(rootPid)}");
         }
 
         /// <summary>

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -898,15 +898,9 @@ namespace Parsek
                                 && fInfo.fairingMeshObject != null)
                             {
                                 fInfo.fairingMeshObject.SetActive(false);
-                                if (fInfo.showInternalOnJettison && fInfo.internalStructureObjects != null)
-                                {
-                                    for (int s = 0; s < fInfo.internalStructureObjects.Count; s++)
-                                    {
-                                        if (fInfo.internalStructureObjects[s] != null)
-                                            fInfo.internalStructureObjects[s].SetActive(true);
-                                    }
-                                    ParsekLog.Verbose("Flight", $"Fairing internal structure revealed for pid={evt.partPersistentId} ({fInfo.internalStructureObjects.Count} objects)");
-                                }
+                                // Internal structure (Cap/Truss) meshes stay hidden: they are cloned at
+                                // prefab default scale which is meaningless without ModuleProceduralFairing's
+                                // runtime rescaling. Revealing them would show enormous flat planes.
                                 ParsekLog.Verbose("Flight", $"Part event applied: FairingJettisoned '{evt.partName}' pid={evt.partPersistentId}");
                             }
                         }

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -898,9 +898,12 @@ namespace Parsek
                                 && fInfo.fairingMeshObject != null)
                             {
                                 fInfo.fairingMeshObject.SetActive(false);
-                                // Internal structure (Cap/Truss) meshes stay hidden: they are cloned at
-                                // prefab default scale which is meaningless without ModuleProceduralFairing's
-                                // runtime rescaling. Revealing them would show enormous flat planes.
+                                // Show procedural truss structure (generated from XSECTION data at build time)
+                                if (fInfo.trussStructureObject != null)
+                                {
+                                    fInfo.trussStructureObject.SetActive(true);
+                                    ParsekLog.Verbose("Flight", $"Fairing truss structure revealed for pid={evt.partPersistentId}");
+                                }
                                 ParsekLog.Verbose("Flight", $"Part event applied: FairingJettisoned '{evt.partName}' pid={evt.partPersistentId}");
                             }
                         }

--- a/Source/Parsek/GhostTypes.cs
+++ b/Source/Parsek/GhostTypes.cs
@@ -149,7 +149,6 @@ namespace Parsek
         public uint partPersistentId;
         public GameObject fairingMeshObject;
         public GameObject trussStructureObject;            // procedural truss mesh, initially hidden, shown on jettison
-        public List<GameObject> internalStructureObjects;  // prefab truss/cap clones, permanently hidden (wrong scale)
     }
 
     internal struct FireShellMesh

--- a/Source/Parsek/GhostTypes.cs
+++ b/Source/Parsek/GhostTypes.cs
@@ -148,8 +148,8 @@ namespace Parsek
     {
         public uint partPersistentId;
         public GameObject fairingMeshObject;
-        public List<GameObject> internalStructureObjects; // truss/cap clones, initially hidden
-        public bool showInternalOnJettison;               // from ModuleStructuralNodeToggle.showMesh
+        public GameObject trussStructureObject;            // procedural truss mesh, initially hidden, shown on jettison
+        public List<GameObject> internalStructureObjects;  // prefab truss/cap clones, permanently hidden (wrong scale)
     }
 
     internal struct FireShellMesh

--- a/Source/Parsek/GhostTypes.cs
+++ b/Source/Parsek/GhostTypes.cs
@@ -148,6 +148,8 @@ namespace Parsek
     {
         public uint partPersistentId;
         public GameObject fairingMeshObject;
+        public List<GameObject> internalStructureObjects; // truss/cap clones, initially hidden
+        public bool showInternalOnJettison;               // from ModuleStructuralNodeToggle.showMesh
     }
 
     internal struct FireShellMesh

--- a/Source/Parsek/GhostTypes.cs
+++ b/Source/Parsek/GhostTypes.cs
@@ -148,7 +148,6 @@ namespace Parsek
     {
         public uint partPersistentId;
         public GameObject fairingMeshObject;
-        public GameObject trussStructureObject;            // procedural truss mesh, initially hidden, shown on jettison
     }
 
     internal struct FireShellMesh

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -3344,12 +3344,15 @@ namespace Parsek
                                 fxInstance.transform.localRotation = fxDefinitions[f].localRotation;
                                 fxInstance.transform.localScale = fxDefinitions[f].localScale;
 
-                                var ps = fxInstance.GetComponentInChildren<ParticleSystem>();
-                                if (ps != null)
+                                // Configure ALL particle systems in the FX hierarchy (not just the first).
+                                // KSP RCS FX models have multiple child systems (plume + glow/smoke).
+                                // Using singular GetComponentInChildren only stopped the first one —
+                                // the rest kept playOnAwake=true and auto-played on ghost activation.
+                                var allPs = fxInstance.GetComponentsInChildren<ParticleSystem>(true);
+                                for (int p = 0; p < allPs.Length; p++)
                                 {
+                                    var ps = allPs[p];
                                     var main = ps.main;
-                                    // Keep showcase/startup visuals deterministic: cloned FX must not
-                                    // auto-emit before the first explicit RCS event is applied.
                                     main.playOnAwake = false;
                                     main.prewarm = false;
 
@@ -3359,15 +3362,16 @@ namespace Parsek
                                     ps.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
                                     ps.Clear(true);
 
-                                    if (raiseRcsVisualOnly)
-                                    {
-                                        var psRenderer = ps.GetComponent<ParticleSystemRenderer>();
-                                        if (psRenderer != null)
-                                        {
-                                            psRenderer.enabled = true;
-                                        }
-                                    }
+                                    // Disable renderer at build time (matching engine FX pattern).
+                                    // SetRcsEmission re-enables renderers when RCS events fire.
+                                    var psRenderer = ps.GetComponent<ParticleSystemRenderer>();
+                                    if (psRenderer != null)
+                                        psRenderer.enabled = raiseRcsVisualOnly;
+
                                     info.particleSystems.Add(ps);
+                                }
+                                if (allPs.Length > 0)
+                                {
                                     LogFxInstancePlacementDiagnostic(
                                         partName,
                                         moduleIndex,
@@ -3382,16 +3386,18 @@ namespace Parsek
                                         fxDefinitions[f].localOffset,
                                         fxDefinitions[f].localRotation,
                                         true);
-                                    var diagRenderer = ps.GetComponent<ParticleSystemRenderer>();
-                                    var diagMain = ps.main;
+                                    var diagPs = allPs[0];
+                                    var diagRenderer = diagPs.GetComponent<ParticleSystemRenderer>();
+                                    var diagMain = diagPs.main;
                                     ParsekLog.Verbose("GhostVisual", $"    RCS FX cloned: '{partName}' midx={moduleIndex} " +
                                         $"transform='{transformName}' model='{modelName}' " +
                                         $"offset={fxDefinitions[f].localOffset} " +
                                         $"rot={fxDefinitions[f].localRotation.eulerAngles} " +
                                         $"scale={fxDefinitions[f].localScale} " +
-                                        $"active={ps.gameObject.activeInHierarchy} " +
+                                        $"active={diagPs.gameObject.activeInHierarchy} " +
                                         $"sim={diagMain.simulationSpace} playOnAwake={diagMain.playOnAwake} prewarm={diagMain.prewarm} " +
-                                        $"renderer={(diagRenderer != null && diagRenderer.enabled)}");
+                                        $"renderer={(diagRenderer != null && diagRenderer.enabled)} " +
+                                        $"totalSystems={allPs.Length}");
                                 }
                             }
                             else

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -3482,6 +3482,102 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Extracts rootObject values from all ModuleStructuralNode MODULE nodes
+        /// in the given part config. These are the internal truss/cap transforms
+        /// that should be hidden when procedural fairings are intact.
+        /// Returns an empty set if no structural node modules exist.
+        /// </summary>
+        internal static HashSet<string> GetFairingInternalStructureNames(ConfigNode partConfig)
+        {
+            var names = new HashSet<string>();
+            if (partConfig == null) return names;
+
+            var modules = partConfig.GetNodes("MODULE");
+            if (modules == null) return names;
+
+            for (int i = 0; i < modules.Length; i++)
+            {
+                if (modules[i].GetValue("name") != "ModuleStructuralNode")
+                    continue;
+                string rootObject = modules[i].GetValue("rootObject");
+                if (!string.IsNullOrEmpty(rootObject))
+                    names.Add(rootObject);
+            }
+            return names;
+        }
+
+        /// <summary>
+        /// Reads the showMesh field from ModuleStructuralNodeToggle in the snapshot
+        /// partNode. This is a KSPField serialized at runtime indicating whether
+        /// internal structure should be visible when fairings are jettisoned.
+        /// Defaults to true if the module or field is not found.
+        /// </summary>
+        internal static bool GetFairingShowMesh(ConfigNode partNode)
+        {
+            if (partNode == null) return true;
+
+            ConfigNode toggleModule = FindModuleNode(partNode, "ModuleStructuralNodeToggle");
+            if (toggleModule == null) return true;
+
+            string showMeshVal = toggleModule.GetValue("showMesh");
+            if (string.IsNullOrEmpty(showMeshVal)) return true;
+
+            bool result;
+            if (bool.TryParse(showMeshVal, out result))
+                return result;
+            return true;
+        }
+
+        /// <summary>
+        /// Finds already-cloned transforms in the ghost model hierarchy that match
+        /// fairing internal structure names (truss/cap objects from ModuleStructuralNode),
+        /// hides them, and populates the FairingGhostInfo with references for later
+        /// reveal on fairing jettison.
+        /// </summary>
+        internal static void HideFairingInternalStructure(
+            FairingGhostInfo fairingInfo, ConfigNode partConfig, ConfigNode partNode,
+            Transform ghostModelNode, uint persistentId, string partName)
+        {
+            if (fairingInfo == null || ghostModelNode == null) return;
+
+            HashSet<string> structureNames = GetFairingInternalStructureNames(partConfig);
+            if (structureNames.Count == 0)
+            {
+                ParsekLog.Verbose("GhostVisual", $"    Fairing '{partName}' pid={persistentId}: " +
+                    "no ModuleStructuralNode rootObject names found — no internal structure to hide");
+                return;
+            }
+
+            bool showMesh = GetFairingShowMesh(partNode);
+            fairingInfo.showInternalOnJettison = showMesh;
+
+            var hidden = new List<GameObject>();
+            CollectMatchingTransforms(ghostModelNode, structureNames, hidden);
+
+            for (int i = 0; i < hidden.Count; i++)
+                hidden[i].SetActive(false);
+
+            fairingInfo.internalStructureObjects = hidden.Count > 0 ? hidden : null;
+
+            ParsekLog.Verbose("GhostVisual", $"    Fairing '{partName}' pid={persistentId}: " +
+                $"found {structureNames.Count} structure names [{string.Join(", ", structureNames)}], " +
+                $"hidden {hidden.Count} transforms, showInternalOnJettison={showMesh}");
+        }
+
+        /// <summary>
+        /// Recursively walks a transform hierarchy collecting GameObjects whose name
+        /// matches one of the given names.
+        /// </summary>
+        private static void CollectMatchingTransforms(Transform root, HashSet<string> names, List<GameObject> results)
+        {
+            if (root == null) return;
+            if (names.Contains(root.name))
+                results.Add(root.gameObject);
+            for (int i = 0; i < root.childCount; i++)
+                CollectMatchingTransforms(root.GetChild(i), names, results);
+        }
+
+        /// <summary>
         /// Checks whether a renderer's transform (or any of its ancestors up to but not
         /// including the hierarchy root) has a name matching one of the damaged wheel
         /// transform names. The damaged mesh may be a child of the named transform.
@@ -4739,7 +4835,8 @@ namespace Parsek
         }
 
         private static List<HeatMaterialState> BuildHeatMaterialStates(
-            Transform modelNode, string partName, uint persistentId)
+            Transform modelNode, string partName, uint persistentId,
+            List<HeatTransformState> affectedTransforms)
         {
             if (modelNode == null)
                 return null;
@@ -4748,14 +4845,47 @@ namespace Parsek
             if (renderers == null || renderers.Length == 0)
                 return null;
 
+            // Build set of transforms affected by heat animation so we only clone
+            // materials on renderers that actually participate in the heat visual.
+            // When null/empty, fall back to cloning all renderers (legacy behavior).
+            HashSet<Transform> affectedSet = null;
+            if (affectedTransforms != null && affectedTransforms.Count > 0)
+            {
+                affectedSet = new HashSet<Transform>();
+                for (int a = 0; a < affectedTransforms.Count; a++)
+                {
+                    Transform root = affectedTransforms[a].t;
+                    if (root == null) continue;
+                    affectedSet.Add(root);
+                    var descendants = root.GetComponentsInChildren<Transform>(true);
+                    for (int d = 0; d < descendants.Length; d++)
+                        affectedSet.Add(descendants[d]);
+                }
+                ParsekLog.Verbose("GhostVisual", $"    AnimateHeat '{partName}' pid={persistentId}: " +
+                    $"filtering renderers to {affectedSet.Count} affected transforms from {affectedTransforms.Count} heat anim target(s)");
+            }
+            else
+            {
+                ParsekLog.Verbose("GhostVisual", $"    AnimateHeat '{partName}' pid={persistentId}: " +
+                    $"no affected transforms provided, cloning all renderers (fallback)");
+            }
+
             var materialStates = new List<HeatMaterialState>();
             int clonedMaterials = 0;
             int trackedMaterials = 0;
+            int skippedRenderers = 0;
 
             for (int i = 0; i < renderers.Length; i++)
             {
                 Renderer renderer = renderers[i];
                 if (renderer == null) continue;
+
+                // Skip renderers not under any heat-animated transform
+                if (affectedSet != null && !affectedSet.Contains(renderer.transform))
+                {
+                    skippedRenderers++;
+                    continue;
+                }
 
                 Material[] sourceMaterials = renderer.sharedMaterials;
                 if (sourceMaterials == null || sourceMaterials.Length == 0)
@@ -4819,6 +4949,12 @@ namespace Parsek
 
                 if (hasAnyMaterial)
                     renderer.materials = cloned;
+            }
+
+            if (skippedRenderers > 0)
+            {
+                ParsekLog.Verbose("GhostVisual", $"    AnimateHeat '{partName}' pid={persistentId}: " +
+                    $"skipped {skippedRenderers} renderer(s) outside heat-animated subtree");
             }
 
             if (trackedMaterials > 0)
@@ -5903,7 +6039,7 @@ namespace Parsek
                 }
 
                 List<HeatMaterialState> heatMaterialStates =
-                    BuildHeatMaterialStates(modelNode.transform, partName, persistentId);
+                    BuildHeatMaterialStates(modelNode.transform, partName, persistentId, resolvedHeatTransforms);
 
                 if ((resolvedHeatTransforms != null && resolvedHeatTransforms.Count > 0) ||
                     (heatMaterialStates != null && heatMaterialStates.Count > 0))
@@ -5954,7 +6090,12 @@ namespace Parsek
             // Detect procedural fairings and generate simplified cone mesh
             fairingInfo = BuildFairingVisual(partNode, prefab, modelNode.transform, persistentId, partName);
             if (fairingInfo != null)
+            {
                 added = true;
+                // Hide internal truss/cap structure that would poke through the fairing cone
+                HideFairingInternalStructure(fairingInfo, prefab.partInfo?.partConfig, partNode,
+                    modelNode.transform, persistentId, partName);
+            }
 
             if (!added)
             {

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -5040,7 +5040,7 @@ namespace Parsek
                     continue;
 
                 var cloned = new Material[sourceMaterials.Length];
-                bool hasAnyMaterial = false;
+                bool hasTrackedMaterial = false;
                 for (int m = 0; m < sourceMaterials.Length; m++)
                 {
                     Material source = sourceMaterials[m];
@@ -5052,7 +5052,6 @@ namespace Parsek
 
                     Material materialClone = new Material(source);
                     cloned[m] = materialClone;
-                    hasAnyMaterial = true;
                     clonedMaterials++;
 
                     string colorProperty = materialClone.HasProperty("_Color")
@@ -5062,6 +5061,8 @@ namespace Parsek
 
                     if (colorProperty == null && emissiveProperty == null)
                         continue;
+
+                    hasTrackedMaterial = true;
 
                     Color coldColor = colorProperty != null
                         ? materialClone.GetColor(colorProperty)
@@ -5095,7 +5096,10 @@ namespace Parsek
                     trackedMaterials++;
                 }
 
-                if (hasAnyMaterial)
+                // Only replace renderer materials if at least one is tracked for heat animation.
+                // Renderers with no trackable properties keep their original sharedMaterials,
+                // preventing color contamination from orphaned material clones.
+                if (hasTrackedMaterial)
                     renderer.materials = cloned;
             }
 

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -5063,10 +5063,16 @@ namespace Parsek
                         continue;
                     }
 
-                    string colorProperty = source.HasProperty("_Color")
-                        ? "_Color"
-                        : null;
                     string emissiveProperty = TryGetHeatEmissiveProperty(source);
+
+                    // In the fallback path (no resolved transforms), only track materials
+                    // with emissive properties. _Color alone is too broad — every KSP material
+                    // has it, including body/casing materials that should not get heat tinted.
+                    // When transforms ARE resolved (affectedSet != null), _Color is safe because
+                    // the renderer filter already limits to heat-animated meshes (nozzles).
+                    string colorProperty = null;
+                    if (affectedSet != null && source.HasProperty("_Color"))
+                        colorProperty = "_Color";
 
                     if (colorProperty == null && emissiveProperty == null)
                     {

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -3512,30 +3512,14 @@ namespace Parsek
         /// internal structure should be visible when fairings are jettisoned.
         /// Defaults to true if the module or field is not found.
         /// </summary>
-        internal static bool GetFairingShowMesh(ConfigNode partNode)
-        {
-            if (partNode == null) return true;
-
-            ConfigNode toggleModule = FindModuleNode(partNode, "ModuleStructuralNodeToggle");
-            if (toggleModule == null) return true;
-
-            string showMeshVal = toggleModule.GetValue("showMesh");
-            if (string.IsNullOrEmpty(showMeshVal)) return true;
-
-            bool result;
-            if (bool.TryParse(showMeshVal, out result))
-                return result;
-            return true;
-        }
-
         /// <summary>
         /// Finds already-cloned transforms in the ghost model hierarchy that match
-        /// fairing internal structure names (truss/cap objects from ModuleStructuralNode),
-        /// hides them, and populates the FairingGhostInfo with references for later
-        /// reveal on fairing jettison.
+        /// fairing internal structure names (truss/cap objects from ModuleStructuralNode)
+        /// and permanently hides them. Prefab Cap/Truss meshes are at placeholder scale
+        /// (2000,10,2000) — the procedural truss mesh replaces them visually.
         /// </summary>
         internal static void HideFairingInternalStructure(
-            FairingGhostInfo fairingInfo, ConfigNode partConfig, ConfigNode partNode,
+            FairingGhostInfo fairingInfo, ConfigNode partConfig,
             Transform ghostModelNode, uint persistentId, string partName)
         {
             if (fairingInfo == null || ghostModelNode == null) return;
@@ -3548,9 +3532,9 @@ namespace Parsek
                 return;
             }
 
-            bool showMesh = GetFairingShowMesh(partNode);
-            fairingInfo.showInternalOnJettison = showMesh;
-
+            // Permanently hide prefab Cap/Truss clones — they are at meaningless prefab default scale
+            // (2000,10,2000). The procedural truss mesh on FairingGhostInfo.trussStructureObject
+            // provides the correct post-jettison visual instead.
             var hidden = new List<GameObject>();
             CollectMatchingTransforms(ghostModelNode, structureNames, hidden);
 
@@ -3561,7 +3545,7 @@ namespace Parsek
 
             ParsekLog.Verbose("GhostVisual", $"    Fairing '{partName}' pid={persistentId}: " +
                 $"found {structureNames.Count} structure names [{string.Join(", ", structureNames)}], " +
-                $"hidden {hidden.Count} transforms, showInternalOnJettison={showMesh}");
+                $"hidden {hidden.Count} prefab structure transforms (procedural truss used instead)");
         }
 
         /// <summary>
@@ -4354,6 +4338,124 @@ namespace Parsek
             return mesh;
         }
 
+        /// <summary>
+        /// Generates a procedural truss structure mesh from XSECTION data: horizontal cap discs
+        /// at each internal ring boundary and vertical struts connecting adjacent rings.
+        /// Shown after fairing jettison to represent the exposed interstage structure.
+        /// </summary>
+        internal static Mesh GenerateFairingTrussMesh(
+            List<(float h, float r)> sections, int nSides, Vector3 pivot, Vector3 axis)
+        {
+            if (sections.Count < 2) return null;
+
+            sections.Sort((a, b) => a.h.CompareTo(b.h));
+            nSides = Mathf.Min(nSides, 24);
+            if (nSides < 3) nSides = 3;
+
+            Quaternion axisRot = Quaternion.FromToRotation(Vector3.up, axis.normalized);
+            var vertices = new List<Vector3>();
+            var uvs = new List<Vector2>();
+            var triangles = new List<int>();
+
+            // --- Horizontal cap discs at each internal XSECTION boundary ---
+            // Skip the bottom (index 0) and top (last index) — caps are only at interior boundaries.
+            for (int i = 1; i < sections.Count - 1; i++)
+            {
+                float h = sections[i].h;
+                float r = sections[i].r;
+                if (r < 0.01f) continue;
+
+                // Center vertex of the disc
+                int centerIdx = vertices.Count;
+                vertices.Add(axisRot * new Vector3(0f, h, 0f) + pivot);
+                uvs.Add(new Vector2(0.5f, 0.5f));
+
+                // Ring vertices
+                int ringStart = vertices.Count;
+                for (int s = 0; s <= nSides; s++)
+                {
+                    float angle = (float)s / nSides * Mathf.PI * 2f;
+                    float x = Mathf.Cos(angle) * r;
+                    float z = Mathf.Sin(angle) * r;
+                    vertices.Add(axisRot * new Vector3(x, h, z) + pivot);
+                    uvs.Add(new Vector2((Mathf.Cos(angle) + 1f) * 0.5f, (Mathf.Sin(angle) + 1f) * 0.5f));
+                }
+
+                // Triangle fan (both sides visible via doubled winding)
+                for (int s = 0; s < nSides; s++)
+                {
+                    int left = ringStart + s;
+                    int right = ringStart + s + 1;
+                    // Top face
+                    triangles.Add(centerIdx);
+                    triangles.Add(left);
+                    triangles.Add(right);
+                    // Bottom face
+                    triangles.Add(centerIdx);
+                    triangles.Add(right);
+                    triangles.Add(left);
+                }
+            }
+
+            // --- Vertical struts connecting adjacent rings ---
+            // Place struts at evenly-spaced azimuthal positions.
+            int strutCount = Mathf.Max(nSides / 3, 6);
+            float strutHalfWidth = 0.03f; // thin struts as fraction of local scale
+
+            for (int s = 0; s < strutCount; s++)
+            {
+                float angle = (float)s / strutCount * Mathf.PI * 2f;
+                float cos = Mathf.Cos(angle);
+                float sin = Mathf.Sin(angle);
+
+                // Perpendicular direction for strut width
+                float perpCos = Mathf.Cos(angle + Mathf.PI * 0.5f);
+                float perpSin = Mathf.Sin(angle + Mathf.PI * 0.5f);
+
+                for (int i = 0; i < sections.Count - 1; i++)
+                {
+                    float h0 = sections[i].h;
+                    float r0 = sections[i].r;
+                    float h1 = sections[i + 1].h;
+                    float r1 = sections[i + 1].r;
+
+                    if (r0 < 0.01f || r1 < 0.01f) continue;
+
+                    // Inset struts slightly inside the cone surface so they don't z-fight
+                    float inset = 0.97f;
+                    float w0 = r0 * strutHalfWidth;
+                    float w1 = r1 * strutHalfWidth;
+
+                    // Four corners of the strut quad
+                    Vector3 bl = axisRot * new Vector3(cos * r0 * inset - perpCos * w0, h0, sin * r0 * inset - perpSin * w0) + pivot;
+                    Vector3 br = axisRot * new Vector3(cos * r0 * inset + perpCos * w0, h0, sin * r0 * inset + perpSin * w0) + pivot;
+                    Vector3 tl = axisRot * new Vector3(cos * r1 * inset - perpCos * w1, h1, sin * r1 * inset - perpSin * w1) + pivot;
+                    Vector3 tr = axisRot * new Vector3(cos * r1 * inset + perpCos * w1, h1, sin * r1 * inset + perpSin * w1) + pivot;
+
+                    int baseIdx = vertices.Count;
+                    vertices.Add(bl); vertices.Add(br); vertices.Add(tl); vertices.Add(tr);
+                    uvs.Add(new Vector2(0f, 0f)); uvs.Add(new Vector2(1f, 0f));
+                    uvs.Add(new Vector2(0f, 1f)); uvs.Add(new Vector2(1f, 1f));
+
+                    // Both sides visible
+                    triangles.Add(baseIdx); triangles.Add(baseIdx + 2); triangles.Add(baseIdx + 1);
+                    triangles.Add(baseIdx + 1); triangles.Add(baseIdx + 2); triangles.Add(baseIdx + 3);
+                    triangles.Add(baseIdx); triangles.Add(baseIdx + 1); triangles.Add(baseIdx + 2);
+                    triangles.Add(baseIdx + 1); triangles.Add(baseIdx + 3); triangles.Add(baseIdx + 2);
+                }
+            }
+
+            if (vertices.Count == 0) return null;
+
+            Mesh mesh = new Mesh();
+            mesh.SetVertices(vertices);
+            mesh.SetUVs(0, uvs);
+            mesh.SetTriangles(triangles, 0);
+            mesh.RecalculateNormals();
+            mesh.RecalculateBounds();
+            return mesh;
+        }
+
         private static FairingGhostInfo BuildFairingVisual(
             ConfigNode partNode, Part prefab, Transform modelNode,
             uint persistentId, string partName)
@@ -4402,13 +4504,31 @@ namespace Parsek
                 color = new Color(0.85f, 0.85f, 0.85f)
             };
 
+            // Generate truss structure mesh (hidden initially, revealed on jettison)
+            GameObject trussGo = null;
+            Mesh trussMesh = GenerateFairingTrussMesh(sections, nSides, pivot, axis);
+            if (trussMesh != null)
+            {
+                trussGo = new GameObject("fairing_truss");
+                trussGo.transform.SetParent(modelNode, false);
+                trussGo.AddComponent<MeshFilter>().mesh = trussMesh;
+                var trussMr = trussGo.AddComponent<MeshRenderer>();
+                trussMr.material = new Material(Shader.Find("KSP/Diffuse"))
+                {
+                    color = new Color(0.65f, 0.65f, 0.65f) // slightly darker than the fairing shell
+                };
+                trussGo.SetActive(false);
+            }
+
             ParsekLog.Verbose("GhostVisual", $"    Fairing detected: '{partName}' pid={persistentId}, " +
-                $"cone mesh generated ({sections.Count} sections, {nSides} sides)");
+                $"cone mesh generated ({sections.Count} sections, {nSides} sides)" +
+                (trussGo != null ? ", truss structure mesh generated" : ""));
 
             return new FairingGhostInfo
             {
                 partPersistentId = persistentId,
-                fairingMeshObject = go
+                fairingMeshObject = go,
+                trussStructureObject = trussGo
             };
         }
 
@@ -6115,7 +6235,7 @@ namespace Parsek
             {
                 added = true;
                 // Hide internal truss/cap structure that would poke through the fairing cone
-                HideFairingInternalStructure(fairingInfo, prefab.partInfo?.partConfig, partNode,
+                HideFairingInternalStructure(fairingInfo, prefab.partInfo?.partConfig,
                     modelNode.transform, persistentId, partName);
             }
 

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -3518,6 +3518,22 @@ namespace Parsek
         /// internal structure should be visible when fairings are jettisoned.
         /// Defaults to true if the module or field is not found.
         /// </summary>
+        internal static bool GetFairingShowMesh(ConfigNode partNode)
+        {
+            if (partNode == null) return true;
+
+            ConfigNode toggleModule = FindModuleNode(partNode, "ModuleStructuralNodeToggle");
+            if (toggleModule == null) return true;
+
+            string showMeshVal = toggleModule.GetValue("showMesh");
+            if (string.IsNullOrEmpty(showMeshVal)) return true;
+
+            bool result;
+            if (bool.TryParse(showMeshVal, out result))
+                return result;
+            return true;
+        }
+
         /// <summary>
         /// Finds already-cloned transforms in the ghost model hierarchy that match
         /// fairing internal structure names (truss/cap objects from ModuleStructuralNode)
@@ -4328,10 +4344,13 @@ namespace Parsek
                     int left = lastRingBase + s;
                     int right = lastRingBase + s + 1;
 
-                    // CW winding facing upward (outward from the top)
+                    // Double-sided cap disc (visible from both above and below)
                     triangles.Add(right);
                     triangles.Add(capCenterIdx);
                     triangles.Add(left);
+                    triangles.Add(left);
+                    triangles.Add(capCenterIdx);
+                    triangles.Add(right);
                 }
             }
 
@@ -4511,19 +4530,24 @@ namespace Parsek
             };
 
             // Generate truss structure mesh (hidden initially, revealed on jettison)
+            // Only if the player has truss structure enabled (showMesh from ModuleStructuralNodeToggle)
             GameObject trussGo = null;
-            Mesh trussMesh = GenerateFairingTrussMesh(sections, nSides, pivot, axis);
-            if (trussMesh != null)
+            bool showMesh = GetFairingShowMesh(partNode);
+            if (showMesh)
             {
-                trussGo = new GameObject("fairing_truss");
-                trussGo.transform.SetParent(modelNode, false);
-                trussGo.AddComponent<MeshFilter>().mesh = trussMesh;
-                var trussMr = trussGo.AddComponent<MeshRenderer>();
-                trussMr.material = new Material(Shader.Find("KSP/Diffuse"))
+                Mesh trussMesh = GenerateFairingTrussMesh(sections, nSides, pivot, axis);
+                if (trussMesh != null)
                 {
-                    color = new Color(0.65f, 0.65f, 0.65f) // slightly darker than the fairing shell
-                };
-                trussGo.SetActive(false);
+                    trussGo = new GameObject("fairing_truss");
+                    trussGo.transform.SetParent(modelNode, false);
+                    trussGo.AddComponent<MeshFilter>().mesh = trussMesh;
+                    var trussMr = trussGo.AddComponent<MeshRenderer>();
+                    trussMr.material = new Material(Shader.Find("KSP/Diffuse"))
+                    {
+                        color = new Color(0.65f, 0.65f, 0.65f) // slightly darker than the fairing shell
+                    };
+                    trussGo.SetActive(false);
+                }
             }
 
             ParsekLog.Verbose("GhostVisual", $"    Fairing detected: '{partName}' pid={persistentId}, " +

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -4327,28 +4327,28 @@ namespace Parsek
                 }
             }
 
-            // Cap disc for truncated cone (top ring has non-zero radius, e.g. capRadius)
+            // Conical cap for truncated cone (top ring has non-zero radius, e.g. capRadius).
+            // Creates a pointed cone from the last ring to an apex above it, matching the
+            // shape of a real fairing nosecone. Apex height = lastR * 1.5 above last ring.
             if (!hasApex && ringsToGenerate > 0)
             {
                 float capH = sections[ringCount - 1].h;
-                Vector3 capCenter = axisRot * new Vector3(0f, capH, 0f) + pivot;
-                int capCenterIdx = vertices.Count;
-                vertices.Add(capCenter);
+                float capR = sections[ringCount - 1].r;
+                float coneApexH = capH + capR * 1.5f;
+                Vector3 coneApex = axisRot * new Vector3(0f, coneApexH, 0f) + pivot;
+                int coneApexIdx = vertices.Count;
+                vertices.Add(coneApex);
                 uvs.Add(new Vector2(0.5f, 1f));
 
                 int lastRingBase = (ringsToGenerate - 1) * vertsPerRing;
                 for (int s = 0; s < nSides; s++)
                 {
-                    int left = lastRingBase + s;
-                    int right = lastRingBase + s + 1;
+                    int bl = lastRingBase + s;
+                    int br = lastRingBase + s + 1;
 
-                    // Double-sided cap disc (visible from both above and below)
-                    triangles.Add(right);
-                    triangles.Add(capCenterIdx);
-                    triangles.Add(left);
-                    triangles.Add(left);
-                    triangles.Add(capCenterIdx);
-                    triangles.Add(right);
+                    triangles.Add(bl);
+                    triangles.Add(coneApexIdx);
+                    triangles.Add(br);
                 }
             }
 

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -4521,11 +4521,22 @@ namespace Parsek
             go.transform.SetParent(modelNode, false);
             go.AddComponent<MeshFilter>().mesh = mesh;
 
+            // Use the base adapter's material (includes variant textures) instead of hardcoded gray.
+            // The first active MeshRenderer on the ghost model node is the base adapter mesh
+            // (Cap/Truss are further down in the hierarchy).
             var mr = go.AddComponent<MeshRenderer>();
-            mr.material = new Material(Shader.Find("KSP/Diffuse"))
+            var baseMr = modelNode.GetComponentInChildren<MeshRenderer>();
+            if (baseMr != null && baseMr.sharedMaterial != null)
             {
-                color = new Color(0.85f, 0.85f, 0.85f)
-            };
+                mr.sharedMaterial = baseMr.sharedMaterial;
+            }
+            else
+            {
+                mr.material = new Material(Shader.Find("KSP/Diffuse"))
+                {
+                    color = new Color(0.85f, 0.85f, 0.85f)
+                };
+            }
 
             ParsekLog.Verbose("GhostVisual", $"    Fairing detected: '{partName}' pid={persistentId}, " +
                 $"cone mesh generated ({sections.Count} sections, {nSides} sides)");
@@ -5038,6 +5049,9 @@ namespace Parsek
                 if (sourceMaterials == null || sourceMaterials.Length == 0)
                     continue;
 
+                // Only clone materials that have trackable heat properties (_Color or emissive).
+                // Untracked materials keep their original shared reference to avoid visual
+                // divergence from orphaned material clones.
                 var cloned = new Material[sourceMaterials.Length];
                 bool hasTrackedMaterial = false;
                 for (int m = 0; m < sourceMaterials.Length; m++)
@@ -5049,18 +5063,22 @@ namespace Parsek
                         continue;
                     }
 
+                    string colorProperty = source.HasProperty("_Color")
+                        ? "_Color"
+                        : null;
+                    string emissiveProperty = TryGetHeatEmissiveProperty(source);
+
+                    if (colorProperty == null && emissiveProperty == null)
+                    {
+                        // Keep shared reference — no heat properties to animate
+                        cloned[m] = source;
+                        continue;
+                    }
+
+                    // Clone only materials that will be tracked
                     Material materialClone = new Material(source);
                     cloned[m] = materialClone;
                     clonedMaterials++;
-
-                    string colorProperty = materialClone.HasProperty("_Color")
-                        ? "_Color"
-                        : null;
-                    string emissiveProperty = TryGetHeatEmissiveProperty(materialClone);
-
-                    if (colorProperty == null && emissiveProperty == null)
-                        continue;
-
                     hasTrackedMaterial = true;
 
                     Color coldColor = colorProperty != null
@@ -5095,9 +5113,6 @@ namespace Parsek
                     trackedMaterials++;
                 }
 
-                // Only replace renderer materials if at least one is tracked for heat animation.
-                // Renderers with no trackable properties keep their original sharedMaterials,
-                // preventing color contamination from orphaned material clones.
                 if (hasTrackedMaterial)
                     renderer.materials = cloned;
             }

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -4308,7 +4308,7 @@ namespace Parsek
                 }
             }
 
-            // Connect last ring to apex
+            // Connect last ring to apex (pointy nosecone)
             if (hasApex && ringsToGenerate > 0)
             {
                 int lastRingBase = (ringsToGenerate - 1) * vertsPerRing;
@@ -4320,6 +4320,28 @@ namespace Parsek
                     triangles.Add(bl);
                     triangles.Add(apexIndex);
                     triangles.Add(br);
+                }
+            }
+
+            // Cap disc for truncated cone (top ring has non-zero radius, e.g. capRadius)
+            if (!hasApex && ringsToGenerate > 0)
+            {
+                float capH = sections[ringCount - 1].h;
+                Vector3 capCenter = axisRot * new Vector3(0f, capH, 0f) + pivot;
+                int capCenterIdx = vertices.Count;
+                vertices.Add(capCenter);
+                uvs.Add(new Vector2(0.5f, 1f));
+
+                int lastRingBase = (ringsToGenerate - 1) * vertsPerRing;
+                for (int s = 0; s < nSides; s++)
+                {
+                    int left = lastRingBase + s;
+                    int right = lastRingBase + s + 1;
+
+                    // CW winding facing upward (outward from the top)
+                    triangles.Add(right);
+                    triangles.Add(capCenterIdx);
+                    triangles.Add(left);
                 }
             }
 

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -3563,8 +3563,6 @@ namespace Parsek
             for (int i = 0; i < hidden.Count; i++)
                 hidden[i].SetActive(false);
 
-            fairingInfo.internalStructureObjects = hidden.Count > 0 ? hidden : null;
-
             ParsekLog.Verbose("GhostVisual", $"    Fairing '{partName}' pid={persistentId}: " +
                 $"found {structureNames.Count} structure names [{string.Join(", ", structureNames)}], " +
                 $"hidden {hidden.Count} prefab structure transforms (procedural truss used instead)");

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -4527,36 +4527,13 @@ namespace Parsek
                 color = new Color(0.85f, 0.85f, 0.85f)
             };
 
-            // Generate truss structure mesh (hidden initially, revealed on jettison)
-            // Only if the player has truss structure enabled (showMesh from ModuleStructuralNodeToggle)
-            GameObject trussGo = null;
-            bool showMesh = GetFairingShowMesh(partNode);
-            if (showMesh)
-            {
-                Mesh trussMesh = GenerateFairingTrussMesh(sections, nSides, pivot, axis);
-                if (trussMesh != null)
-                {
-                    trussGo = new GameObject("fairing_truss");
-                    trussGo.transform.SetParent(modelNode, false);
-                    trussGo.AddComponent<MeshFilter>().mesh = trussMesh;
-                    var trussMr = trussGo.AddComponent<MeshRenderer>();
-                    trussMr.material = new Material(Shader.Find("KSP/Diffuse"))
-                    {
-                        color = new Color(0.65f, 0.65f, 0.65f) // slightly darker than the fairing shell
-                    };
-                    trussGo.SetActive(false);
-                }
-            }
-
             ParsekLog.Verbose("GhostVisual", $"    Fairing detected: '{partName}' pid={persistentId}, " +
-                $"cone mesh generated ({sections.Count} sections, {nSides} sides)" +
-                (trussGo != null ? ", truss structure mesh generated" : ""));
+                $"cone mesh generated ({sections.Count} sections, {nSides} sides)");
 
             return new FairingGhostInfo
             {
                 partPersistentId = persistentId,
-                fairingMeshObject = go,
-                trussStructureObject = trussGo
+                fairingMeshObject = go
             };
         }
 

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -28,6 +28,12 @@ namespace Parsek
         private static readonly List<TrajectoryPoint> noRecording = new List<TrajectoryPoint>();
         private static readonly List<OrbitSegment> noOrbitSegments = new List<OrbitSegment>();
 
+        // Auto-record from LANDED: tracks when the active vessel last entered LANDED state.
+        // Only triggers auto-record if the vessel was settled for at least this long,
+        // filtering out physics bounces (rovers, crashes, EVA kerbals).
+        private double lastLandedUT = -1;
+        private const double LandedSettleThreshold = 5.0; // seconds
+
         // Manual playback state (preview of current recording)
         private bool isPlaying = false;
         private double playbackStartUT;
@@ -2504,6 +2510,13 @@ namespace Parsek
 
         void OnVesselSituationChange(GameEvents.HostedFromToAction<Vessel, Vessel.Situations> data)
         {
+            // Track when the active vessel enters LANDED/SPLASHED for the settle timer
+            if (data.host == FlightGlobals.ActiveVessel &&
+                (data.to == Vessel.Situations.LANDED || data.to == Vessel.Situations.SPLASHED))
+            {
+                lastLandedUT = Planetarium.GetUniversalTime();
+            }
+
             if (IsRecording) return;
             if (data.host != FlightGlobals.ActiveVessel)
             {
@@ -2511,10 +2524,27 @@ namespace Parsek
                     $"OnVesselSituationChange: ignoring non-active vessel ({data.from} → {data.to})");
                 return;
             }
-            if (data.from != Vessel.Situations.PRELAUNCH)
+
+            bool isPrelaunch = data.from == Vessel.Situations.PRELAUNCH;
+            bool isSettledLaunch = false;
+            if (!isPrelaunch && data.from == Vessel.Situations.LANDED)
             {
-                ParsekLog.VerboseRateLimited("Flight", "sit-change-not-prelaunch",
-                    $"OnVesselSituationChange: not from PRELAUNCH ({data.from} → {data.to})");
+                double settledTime = lastLandedUT >= 0
+                    ? Planetarium.GetUniversalTime() - lastLandedUT
+                    : 0;
+                isSettledLaunch = settledTime >= LandedSettleThreshold;
+                if (!isSettledLaunch)
+                {
+                    ParsekLog.VerboseRateLimited("Flight", "sit-change-bounce",
+                        $"OnVesselSituationChange: LANDED → {data.to} after {settledTime:F1}s (< {LandedSettleThreshold}s settle threshold)");
+                }
+            }
+
+            if (!isPrelaunch && !isSettledLaunch)
+            {
+                if (data.from != Vessel.Situations.LANDED) // already logged above for LANDED bounces
+                    ParsekLog.VerboseRateLimited("Flight", "sit-change-not-launch",
+                        $"OnVesselSituationChange: not a launch transition ({data.from} → {data.to})");
                 return;
             }
             if (ParsekSettings.Current?.autoRecordOnLaunch == false)
@@ -2524,7 +2554,7 @@ namespace Parsek
             }
 
             StartRecording();
-            Log("Auto-record started (vessel left pad/runway)");
+            Log($"Auto-record started ({data.from} → {data.to})");
             ScreenMessage("Recording STARTED (auto)", 2f);
         }
 
@@ -3504,6 +3534,16 @@ namespace Parsek
                     capSettings.ghostCapZone1Reduce,
                     capSettings.ghostCapZone1Despawn,
                     capSettings.ghostCapZone2Simplify);
+            }
+
+            // Seed lastLandedUT if vessel is already on the surface (save-loaded pad, Mun lander, etc.)
+            var activeVessel = FlightGlobals.ActiveVessel;
+            if (activeVessel != null &&
+                (activeVessel.situation == Vessel.Situations.LANDED ||
+                 activeVessel.situation == Vessel.Situations.SPLASHED))
+            {
+                lastLandedUT = Planetarium.GetUniversalTime();
+                ParsekLog.Verbose("Flight", $"Seeded lastLandedUT={lastLandedUT:F1} (vessel already {activeVessel.situation})");
             }
 
             // Phase 6b: Evaluate ghost chains and ghost claimed vessels

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -7633,6 +7633,16 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Returns true if the ghost at index is within visual range (not in the Beyond zone).
+        /// </summary>
+        internal bool IsGhostWithinVisualRange(int index)
+        {
+            GhostPlaybackState s;
+            if (!ghostStates.TryGetValue(index, out s) || s == null) return false;
+            return s.currentZone != RenderingZone.Beyond;
+        }
+
+        /// <summary>
         /// Returns true if the ghost at index is on the same celestial body as the active vessel.
         /// </summary>
         internal bool IsGhostOnSameBody(int index)

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -3566,6 +3566,21 @@ namespace Parsek
             {
                 var pending = RecordingStore.Pending;
 
+                // After revert, the original vessel exists at its reverted position (e.g., on the pad),
+                // not at the recording's end position. Mark for fresh spawn with a new PID so the
+                // dedup check doesn't skip it. Also mark committed chain siblings.
+                pending.ForceSpawnNewVessel = true;
+                if (!string.IsNullOrEmpty(pending.ChainId))
+                {
+                    var chainSiblings = RecordingStore.GetChainRecordings(pending.ChainId);
+                    if (chainSiblings != null)
+                    {
+                        for (int cs = 0; cs < chainSiblings.Count; cs++)
+                            chainSiblings[cs].ForceSpawnNewVessel = true;
+                    }
+                }
+                ParsekLog.Verbose("Flight", $"Pending recording on flight ready: ForceSpawnNewVessel=true for '{pending.VesselName}'");
+
                 // Check if this is part of a chain with committed siblings
                 bool hasChainSiblings = !string.IsNullOrEmpty(pending.ChainId) &&
                     RecordingStore.GetChainRecordings(pending.ChainId) != null;
@@ -5430,7 +5445,10 @@ namespace Parsek
             // Real vessel dedup: if a vessel with this PID still exists in the game world,
             // skip spawning a duplicate. This runs only at actual spawn time (pastChainEnd),
             // not every frame like ShouldSpawnAtRecordingEnd.
-            if (rec.VesselPersistentId != 0 && GhostPlaybackLogic.RealVesselExists(rec.VesselPersistentId))
+            // Exception: ForceSpawnNewVessel is set after revert — the existing vessel is at the
+            // reverted position, not the recording's end position. Spawn a fresh copy with a new PID.
+            if (!rec.ForceSpawnNewVessel &&
+                rec.VesselPersistentId != 0 && GhostPlaybackLogic.RealVesselExists(rec.VesselPersistentId))
             {
                 rec.VesselSpawned = true;
                 rec.SpawnedVesselPersistentId = rec.VesselPersistentId;

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -7798,7 +7798,7 @@ namespace Parsek
                 vesselName = committed[watchedRecordingIndex].VesselName;
 
             float boxW = 300f, boxH = 50f;
-            float x = (Screen.width - boxW) / 2f;
+            float x = (Screen.width * 0.5f - boxW) / 2f; // centered in the left half of the screen
             float y = 10f;
             Rect bgRect = new Rect(x, y, boxW, boxH);
 

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -1319,12 +1319,15 @@ namespace Parsek
             {
                 bool hasGhost = flight.HasActiveGhost(ri);
                 bool sameBody = flight.IsGhostOnSameBody(ri);
+                bool inRange = flight.IsGhostWithinVisualRange(ri);
                 bool isWatching = flight.WatchedRecordingIndex == ri;
-                bool canWatch = hasGhost && sameBody;
+                bool canWatch = hasGhost && sameBody && inRange;
 
                 GUI.enabled = canWatch;
                 string watchLabel = isWatching ? "W*" : "W";
-                string watchTooltip = (hasGhost && !sameBody) ? "Ghost is on a different body" : "";
+                string watchTooltip = (hasGhost && !sameBody) ? "Ghost is on a different body"
+                    : (hasGhost && !inRange) ? "Ghost is beyond visual range"
+                    : "";
                 var watchContent = new GUIContent(watchLabel, watchTooltip);
                 if (GUILayout.Button(watchContent, GUILayout.Width(ColW_Watch)))
                 {

--- a/Source/Parsek/PartStateSeeder.cs
+++ b/Source/Parsek/PartStateSeeder.cs
@@ -584,12 +584,12 @@ namespace Parsek
                 }
             }
 
-            // --- ulong-keyed sets (encoded pid+moduleIndex) ---
+            // --- ulong-keyed deployable sets (all emit DeployableExtended with decoded moduleIndex) ---
 
-            // deployedLadders → DeployableExtended with decoded moduleIndex
-            if (sets.deployedLadders != null)
+            void EmitDeployableFromUlongSet(HashSet<ulong> set, string source)
             {
-                foreach (ulong key in sets.deployedLadders)
+                if (set == null) return;
+                foreach (ulong key in set)
                 {
                     uint pid; int midx;
                     FlightRecorder.DecodeEngineKey(key, out pid, out midx);
@@ -602,109 +602,16 @@ namespace Parsek
                         value = 0f,
                         moduleIndex = midx
                     });
-                    ParsekLog.Verbose(logTag, $"Seed event: DeployableExtended (ladder) pid={pid} midx={midx} part='{NameFor(pid)}'");
+                    ParsekLog.Verbose(logTag, $"Seed event: DeployableExtended ({source}) pid={pid} midx={midx} part='{NameFor(pid)}'");
                 }
             }
 
-            // deployedAnimationGroups → DeployableExtended with decoded moduleIndex
-            if (sets.deployedAnimationGroups != null)
-            {
-                foreach (ulong key in sets.deployedAnimationGroups)
-                {
-                    uint pid; int midx;
-                    FlightRecorder.DecodeEngineKey(key, out pid, out midx);
-                    events.Add(new PartEvent
-                    {
-                        ut = startUT,
-                        partPersistentId = pid,
-                        eventType = PartEventType.DeployableExtended,
-                        partName = NameFor(pid),
-                        value = 0f,
-                        moduleIndex = midx
-                    });
-                    ParsekLog.Verbose(logTag, $"Seed event: DeployableExtended (animGroup) pid={pid} midx={midx} part='{NameFor(pid)}'");
-                }
-            }
-
-            // deployedAnimateGenericModules → DeployableExtended with decoded moduleIndex
-            if (sets.deployedAnimateGenericModules != null)
-            {
-                foreach (ulong key in sets.deployedAnimateGenericModules)
-                {
-                    uint pid; int midx;
-                    FlightRecorder.DecodeEngineKey(key, out pid, out midx);
-                    events.Add(new PartEvent
-                    {
-                        ut = startUT,
-                        partPersistentId = pid,
-                        eventType = PartEventType.DeployableExtended,
-                        partName = NameFor(pid),
-                        value = 0f,
-                        moduleIndex = midx
-                    });
-                    ParsekLog.Verbose(logTag, $"Seed event: DeployableExtended (animGeneric) pid={pid} midx={midx} part='{NameFor(pid)}'");
-                }
-            }
-
-            // deployedAeroSurfaceModules → DeployableExtended with decoded moduleIndex
-            if (sets.deployedAeroSurfaceModules != null)
-            {
-                foreach (ulong key in sets.deployedAeroSurfaceModules)
-                {
-                    uint pid; int midx;
-                    FlightRecorder.DecodeEngineKey(key, out pid, out midx);
-                    events.Add(new PartEvent
-                    {
-                        ut = startUT,
-                        partPersistentId = pid,
-                        eventType = PartEventType.DeployableExtended,
-                        partName = NameFor(pid),
-                        value = 0f,
-                        moduleIndex = midx
-                    });
-                    ParsekLog.Verbose(logTag, $"Seed event: DeployableExtended (aeroSurface) pid={pid} midx={midx} part='{NameFor(pid)}'");
-                }
-            }
-
-            // deployedControlSurfaceModules → DeployableExtended with decoded moduleIndex
-            if (sets.deployedControlSurfaceModules != null)
-            {
-                foreach (ulong key in sets.deployedControlSurfaceModules)
-                {
-                    uint pid; int midx;
-                    FlightRecorder.DecodeEngineKey(key, out pid, out midx);
-                    events.Add(new PartEvent
-                    {
-                        ut = startUT,
-                        partPersistentId = pid,
-                        eventType = PartEventType.DeployableExtended,
-                        partName = NameFor(pid),
-                        value = 0f,
-                        moduleIndex = midx
-                    });
-                    ParsekLog.Verbose(logTag, $"Seed event: DeployableExtended (controlSurface) pid={pid} midx={midx} part='{NameFor(pid)}'");
-                }
-            }
-
-            // deployedRobotArmScannerModules → DeployableExtended with decoded moduleIndex
-            if (sets.deployedRobotArmScannerModules != null)
-            {
-                foreach (ulong key in sets.deployedRobotArmScannerModules)
-                {
-                    uint pid; int midx;
-                    FlightRecorder.DecodeEngineKey(key, out pid, out midx);
-                    events.Add(new PartEvent
-                    {
-                        ut = startUT,
-                        partPersistentId = pid,
-                        eventType = PartEventType.DeployableExtended,
-                        partName = NameFor(pid),
-                        value = 0f,
-                        moduleIndex = midx
-                    });
-                    ParsekLog.Verbose(logTag, $"Seed event: DeployableExtended (robotArmScanner) pid={pid} midx={midx} part='{NameFor(pid)}'");
-                }
-            }
+            EmitDeployableFromUlongSet(sets.deployedLadders, "ladder");
+            EmitDeployableFromUlongSet(sets.deployedAnimationGroups, "animGroup");
+            EmitDeployableFromUlongSet(sets.deployedAnimateGenericModules, "animGeneric");
+            EmitDeployableFromUlongSet(sets.deployedAeroSurfaceModules, "aeroSurface");
+            EmitDeployableFromUlongSet(sets.deployedControlSurfaceModules, "controlSurface");
+            EmitDeployableFromUlongSet(sets.deployedRobotArmScannerModules, "robotArmScanner");
 
             // animateHeatLevels → ThermalAnimationHot or ThermalAnimationMedium
             if (sets.animateHeatLevels != null)

--- a/Source/Parsek/PartStateSeeder.cs
+++ b/Source/Parsek/PartStateSeeder.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Globalization;
 using UnityEngine;
 
 namespace Parsek
@@ -393,6 +394,392 @@ namespace Parsek
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Emits seed PartEvents for all non-default initial part states found in
+        /// the tracking sets. These events are inserted at recording start so that
+        /// ghost playback can reconstruct the correct visual state even when playback
+        /// begins at the start of the recording (before any transition events).
+        ///
+        /// Pure static method — no Unity dependency beyond the data already captured
+        /// in the tracking sets. Directly testable.
+        /// </summary>
+        /// <param name="sets">The populated tracking sets (after SeedPartStates).</param>
+        /// <param name="partNamesByPid">Map from part persistentId to part name for event logging.</param>
+        /// <param name="startUT">The UT to stamp on all seed events.</param>
+        /// <param name="logTag">Log subsystem tag ("Recorder" or "BgRecorder").</param>
+        /// <returns>List of seed PartEvents (may be empty, never null).</returns>
+        internal static List<PartEvent> EmitSeedEvents(
+            PartTrackingSets sets,
+            Dictionary<uint, string> partNamesByPid,
+            double startUT,
+            string logTag)
+        {
+            var events = new List<PartEvent>();
+            if (sets == null) return events;
+
+            // Helper to look up part name by pid
+            string NameFor(uint pid)
+            {
+                string n;
+                return partNamesByPid != null && partNamesByPid.TryGetValue(pid, out n) ? n : "unknown";
+            }
+
+            // --- uint-keyed sets (pid only, moduleIndex = 0) ---
+
+            // extendedDeployables → DeployableExtended
+            if (sets.extendedDeployables != null)
+            {
+                foreach (uint pid in sets.extendedDeployables)
+                {
+                    events.Add(new PartEvent
+                    {
+                        ut = startUT,
+                        partPersistentId = pid,
+                        eventType = PartEventType.DeployableExtended,
+                        partName = NameFor(pid),
+                        value = 0f,
+                        moduleIndex = 0
+                    });
+                    ParsekLog.Verbose(logTag, $"Seed event: DeployableExtended pid={pid} part='{NameFor(pid)}'");
+                }
+            }
+
+            // jettisonedShrouds → ShroudJettisoned
+            if (sets.jettisonedShrouds != null)
+            {
+                foreach (uint pid in sets.jettisonedShrouds)
+                {
+                    events.Add(new PartEvent
+                    {
+                        ut = startUT,
+                        partPersistentId = pid,
+                        eventType = PartEventType.ShroudJettisoned,
+                        partName = NameFor(pid),
+                        value = 0f,
+                        moduleIndex = 0
+                    });
+                    ParsekLog.Verbose(logTag, $"Seed event: ShroudJettisoned pid={pid} part='{NameFor(pid)}'");
+                }
+            }
+
+            // deployedFairings → FairingJettisoned
+            if (sets.deployedFairings != null)
+            {
+                foreach (uint pid in sets.deployedFairings)
+                {
+                    events.Add(new PartEvent
+                    {
+                        ut = startUT,
+                        partPersistentId = pid,
+                        eventType = PartEventType.FairingJettisoned,
+                        partName = NameFor(pid),
+                        value = 0f,
+                        moduleIndex = 0
+                    });
+                    ParsekLog.Verbose(logTag, $"Seed event: FairingJettisoned pid={pid} part='{NameFor(pid)}'");
+                }
+            }
+
+            // lightsOn → LightOn
+            if (sets.lightsOn != null)
+            {
+                foreach (uint pid in sets.lightsOn)
+                {
+                    events.Add(new PartEvent
+                    {
+                        ut = startUT,
+                        partPersistentId = pid,
+                        eventType = PartEventType.LightOn,
+                        partName = NameFor(pid),
+                        value = 0f,
+                        moduleIndex = 0
+                    });
+                    ParsekLog.Verbose(logTag, $"Seed event: LightOn pid={pid} part='{NameFor(pid)}'");
+                }
+            }
+
+            // blinkingLights → LightBlinkEnabled (value = blink rate from lightBlinkRates)
+            if (sets.blinkingLights != null)
+            {
+                foreach (uint pid in sets.blinkingLights)
+                {
+                    float blinkRate = 1f;
+                    if (sets.lightBlinkRates != null)
+                        sets.lightBlinkRates.TryGetValue(pid, out blinkRate);
+                    events.Add(new PartEvent
+                    {
+                        ut = startUT,
+                        partPersistentId = pid,
+                        eventType = PartEventType.LightBlinkEnabled,
+                        partName = NameFor(pid),
+                        value = blinkRate,
+                        moduleIndex = 0
+                    });
+                    ParsekLog.Verbose(logTag, $"Seed event: LightBlinkEnabled pid={pid} part='{NameFor(pid)}' rate={blinkRate.ToString("F2", CultureInfo.InvariantCulture)}");
+                }
+            }
+
+            // deployedGear → GearDeployed
+            if (sets.deployedGear != null)
+            {
+                foreach (uint pid in sets.deployedGear)
+                {
+                    events.Add(new PartEvent
+                    {
+                        ut = startUT,
+                        partPersistentId = pid,
+                        eventType = PartEventType.GearDeployed,
+                        partName = NameFor(pid),
+                        value = 0f,
+                        moduleIndex = 0
+                    });
+                    ParsekLog.Verbose(logTag, $"Seed event: GearDeployed pid={pid} part='{NameFor(pid)}'");
+                }
+            }
+
+            // openCargoBays → CargoBayOpened
+            if (sets.openCargoBays != null)
+            {
+                foreach (uint pid in sets.openCargoBays)
+                {
+                    events.Add(new PartEvent
+                    {
+                        ut = startUT,
+                        partPersistentId = pid,
+                        eventType = PartEventType.CargoBayOpened,
+                        partName = NameFor(pid),
+                        value = 0f,
+                        moduleIndex = 0
+                    });
+                    ParsekLog.Verbose(logTag, $"Seed event: CargoBayOpened pid={pid} part='{NameFor(pid)}'");
+                }
+            }
+
+            // parachuteStates → ParachuteSemiDeployed (value=1) or ParachuteDeployed (value=2)
+            if (sets.parachuteStates != null)
+            {
+                foreach (var kvp in sets.parachuteStates)
+                {
+                    uint pid = kvp.Key;
+                    int chuteState = kvp.Value;
+                    PartEventType eventType;
+                    if (chuteState == 2)
+                        eventType = PartEventType.ParachuteDeployed;
+                    else if (chuteState == 1)
+                        eventType = PartEventType.ParachuteSemiDeployed;
+                    else
+                        continue; // state 0 = stowed, no seed event needed
+                    events.Add(new PartEvent
+                    {
+                        ut = startUT,
+                        partPersistentId = pid,
+                        eventType = eventType,
+                        partName = NameFor(pid),
+                        value = 0f,
+                        moduleIndex = 0
+                    });
+                    ParsekLog.Verbose(logTag, $"Seed event: {eventType} pid={pid} part='{NameFor(pid)}'");
+                }
+            }
+
+            // --- ulong-keyed sets (encoded pid+moduleIndex) ---
+
+            // deployedLadders → DeployableExtended with decoded moduleIndex
+            if (sets.deployedLadders != null)
+            {
+                foreach (ulong key in sets.deployedLadders)
+                {
+                    uint pid; int midx;
+                    FlightRecorder.DecodeEngineKey(key, out pid, out midx);
+                    events.Add(new PartEvent
+                    {
+                        ut = startUT,
+                        partPersistentId = pid,
+                        eventType = PartEventType.DeployableExtended,
+                        partName = NameFor(pid),
+                        value = 0f,
+                        moduleIndex = midx
+                    });
+                    ParsekLog.Verbose(logTag, $"Seed event: DeployableExtended (ladder) pid={pid} midx={midx} part='{NameFor(pid)}'");
+                }
+            }
+
+            // deployedAnimationGroups → DeployableExtended with decoded moduleIndex
+            if (sets.deployedAnimationGroups != null)
+            {
+                foreach (ulong key in sets.deployedAnimationGroups)
+                {
+                    uint pid; int midx;
+                    FlightRecorder.DecodeEngineKey(key, out pid, out midx);
+                    events.Add(new PartEvent
+                    {
+                        ut = startUT,
+                        partPersistentId = pid,
+                        eventType = PartEventType.DeployableExtended,
+                        partName = NameFor(pid),
+                        value = 0f,
+                        moduleIndex = midx
+                    });
+                    ParsekLog.Verbose(logTag, $"Seed event: DeployableExtended (animGroup) pid={pid} midx={midx} part='{NameFor(pid)}'");
+                }
+            }
+
+            // deployedAnimateGenericModules → DeployableExtended with decoded moduleIndex
+            if (sets.deployedAnimateGenericModules != null)
+            {
+                foreach (ulong key in sets.deployedAnimateGenericModules)
+                {
+                    uint pid; int midx;
+                    FlightRecorder.DecodeEngineKey(key, out pid, out midx);
+                    events.Add(new PartEvent
+                    {
+                        ut = startUT,
+                        partPersistentId = pid,
+                        eventType = PartEventType.DeployableExtended,
+                        partName = NameFor(pid),
+                        value = 0f,
+                        moduleIndex = midx
+                    });
+                    ParsekLog.Verbose(logTag, $"Seed event: DeployableExtended (animGeneric) pid={pid} midx={midx} part='{NameFor(pid)}'");
+                }
+            }
+
+            // deployedAeroSurfaceModules → DeployableExtended with decoded moduleIndex
+            if (sets.deployedAeroSurfaceModules != null)
+            {
+                foreach (ulong key in sets.deployedAeroSurfaceModules)
+                {
+                    uint pid; int midx;
+                    FlightRecorder.DecodeEngineKey(key, out pid, out midx);
+                    events.Add(new PartEvent
+                    {
+                        ut = startUT,
+                        partPersistentId = pid,
+                        eventType = PartEventType.DeployableExtended,
+                        partName = NameFor(pid),
+                        value = 0f,
+                        moduleIndex = midx
+                    });
+                    ParsekLog.Verbose(logTag, $"Seed event: DeployableExtended (aeroSurface) pid={pid} midx={midx} part='{NameFor(pid)}'");
+                }
+            }
+
+            // deployedControlSurfaceModules → DeployableExtended with decoded moduleIndex
+            if (sets.deployedControlSurfaceModules != null)
+            {
+                foreach (ulong key in sets.deployedControlSurfaceModules)
+                {
+                    uint pid; int midx;
+                    FlightRecorder.DecodeEngineKey(key, out pid, out midx);
+                    events.Add(new PartEvent
+                    {
+                        ut = startUT,
+                        partPersistentId = pid,
+                        eventType = PartEventType.DeployableExtended,
+                        partName = NameFor(pid),
+                        value = 0f,
+                        moduleIndex = midx
+                    });
+                    ParsekLog.Verbose(logTag, $"Seed event: DeployableExtended (controlSurface) pid={pid} midx={midx} part='{NameFor(pid)}'");
+                }
+            }
+
+            // deployedRobotArmScannerModules → DeployableExtended with decoded moduleIndex
+            if (sets.deployedRobotArmScannerModules != null)
+            {
+                foreach (ulong key in sets.deployedRobotArmScannerModules)
+                {
+                    uint pid; int midx;
+                    FlightRecorder.DecodeEngineKey(key, out pid, out midx);
+                    events.Add(new PartEvent
+                    {
+                        ut = startUT,
+                        partPersistentId = pid,
+                        eventType = PartEventType.DeployableExtended,
+                        partName = NameFor(pid),
+                        value = 0f,
+                        moduleIndex = midx
+                    });
+                    ParsekLog.Verbose(logTag, $"Seed event: DeployableExtended (robotArmScanner) pid={pid} midx={midx} part='{NameFor(pid)}'");
+                }
+            }
+
+            // animateHeatLevels → ThermalAnimationHot or ThermalAnimationMedium
+            if (sets.animateHeatLevels != null)
+            {
+                foreach (var kvp in sets.animateHeatLevels)
+                {
+                    ulong key = kvp.Key;
+                    HeatLevel level = kvp.Value;
+                    if (level == HeatLevel.Cold) continue; // no seed event for cold
+                    uint pid; int midx;
+                    FlightRecorder.DecodeEngineKey(key, out pid, out midx);
+                    PartEventType eventType = level == HeatLevel.Hot
+                        ? PartEventType.ThermalAnimationHot
+                        : PartEventType.ThermalAnimationMedium;
+                    events.Add(new PartEvent
+                    {
+                        ut = startUT,
+                        partPersistentId = pid,
+                        eventType = eventType,
+                        partName = NameFor(pid),
+                        value = 0f,
+                        moduleIndex = midx
+                    });
+                    ParsekLog.Verbose(logTag, $"Seed event: {eventType} pid={pid} midx={midx} part='{NameFor(pid)}'");
+                }
+            }
+
+            // activeEngineKeys → EngineIgnited (value = throttle from lastThrottle)
+            if (sets.activeEngineKeys != null)
+            {
+                foreach (ulong key in sets.activeEngineKeys)
+                {
+                    uint pid; int midx;
+                    FlightRecorder.DecodeEngineKey(key, out pid, out midx);
+                    float throttle = 0f;
+                    if (sets.lastThrottle != null)
+                        sets.lastThrottle.TryGetValue(key, out throttle);
+                    events.Add(new PartEvent
+                    {
+                        ut = startUT,
+                        partPersistentId = pid,
+                        eventType = PartEventType.EngineIgnited,
+                        partName = NameFor(pid),
+                        value = throttle,
+                        moduleIndex = midx
+                    });
+                    ParsekLog.Verbose(logTag, $"Seed event: EngineIgnited pid={pid} midx={midx} throttle={throttle.ToString("F2", CultureInfo.InvariantCulture)} part='{NameFor(pid)}'");
+                }
+            }
+
+            // activeRcsKeys → RCSActivated (value = power from lastRcsThrottle)
+            if (sets.activeRcsKeys != null)
+            {
+                foreach (ulong key in sets.activeRcsKeys)
+                {
+                    uint pid; int midx;
+                    FlightRecorder.DecodeEngineKey(key, out pid, out midx);
+                    float power = 0f;
+                    if (sets.lastRcsThrottle != null)
+                        sets.lastRcsThrottle.TryGetValue(key, out power);
+                    events.Add(new PartEvent
+                    {
+                        ut = startUT,
+                        partPersistentId = pid,
+                        eventType = PartEventType.RCSActivated,
+                        partName = NameFor(pid),
+                        value = power,
+                        moduleIndex = midx
+                    });
+                    ParsekLog.Verbose(logTag, $"Seed event: RCSActivated pid={pid} midx={midx} power={power.ToString("F2", CultureInfo.InvariantCulture)} part='{NameFor(pid)}'");
+                }
+            }
+
+            ParsekLog.Info(logTag, $"Seed events emitted: {events.Count} events at UT={startUT.ToString("F2", CultureInfo.InvariantCulture)}");
+            return events;
         }
     }
 

--- a/Source/Parsek/Recording.cs
+++ b/Source/Parsek/Recording.cs
@@ -134,7 +134,7 @@ namespace Parsek
         public string VesselSituation;          // "Orbiting Kerbin", "Landed on Mun", etc.
         public double MaxDistanceFromLaunch;     // Peak distance reached during recording
         public bool VesselSpawned;              // True after deferred RespawnVessel has fired
-        public bool ForceSpawnNewVessel;        // Skip PID dedup — vessel exists at reverted position, not recording end
+        public bool ForceSpawnNewVessel;        // Skip PID dedup — vessel exists at reverted position, not recording end (transient, not serialized)
 
         public uint SpawnedVesselPersistentId;  // persistentId of spawned vessel (0 = not yet spawned)
         public int SpawnAttempts;               // Number of failed spawn attempts (give up after 3)

--- a/Source/Parsek/Recording.cs
+++ b/Source/Parsek/Recording.cs
@@ -133,6 +133,7 @@ namespace Parsek
         public string VesselSituation;          // "Orbiting Kerbin", "Landed on Mun", etc.
         public double MaxDistanceFromLaunch;     // Peak distance reached during recording
         public bool VesselSpawned;              // True after deferred RespawnVessel has fired
+        public bool ForceSpawnNewVessel;        // Skip PID dedup — vessel exists at reverted position, not recording end
 
         public uint SpawnedVesselPersistentId;  // persistentId of spawned vessel (0 = not yet spawned)
         public int SpawnAttempts;               // Number of failed spawn attempts (give up after 3)

--- a/Source/Parsek/SessionMerger.cs
+++ b/Source/Parsek/SessionMerger.cs
@@ -180,7 +180,6 @@ namespace Parsek
                 }
 
                 // Check against all existing output sections for overlaps
-                bool added = false;
                 var newOutput = new List<TrackSection>();
 
                 for (int j = 0; j < output.Count; j++)

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -476,7 +476,7 @@ Additionally, `ComputeRcsPower` normalizes thrust across all nozzles (`sum / (th
 
 **Fix:** Added 8-frame debounce (~0.15s at 50Hz) to `CheckRcsState` in both `FlightRecorder` and `BackgroundRecorder`. RCS must be continuously `rcs_active` for 8 consecutive physics frames before `RCSActivated` is emitted. `RCSStopped` fires immediately when activity stops after a sustained activation. Micro-corrections below the threshold are silently filtered — no events emitted. Debounce state tracked in `rcsActiveFrameCount` dictionary, cleared on reset. Pure static helpers `ShouldStartRcsRecording`/`IsRcsRecordingSustained` extracted for testability. No changes to PartEvent struct, serialization, playback, or ghost builder.
 
-**Status:** Fixed (two-part). Recording-side: 8-frame debounce filters SAS micro-corrections. Playback-side: `RestoreAllRcsEmissions` was unconditionally calling `Play()` on ALL RCS particle systems after warp/suppression cycling, even those never activated by an event. Fixed by checking `rateOverTimeMultiplier > 0` before restoring — only RCS modules that received an `RCSActivated` event get restored.
+**Status:** Fixed (three-part). Recording-side: 8-frame debounce filters SAS micro-corrections. Playback-side: `RestoreAllRcsEmissions` was unconditionally calling `Play()` on ALL RCS particle systems after warp/suppression cycling, even those never activated by an event. Fixed by checking `rateOverTimeMultiplier > 0` before restoring — only RCS modules that received an `RCSActivated` event get restored. Build-side: `TryBuildRcsFX` used `GetComponentInChildren` (singular) which only configured the first `ParticleSystem` per FX model; child systems (glow/smoke) kept `playOnAwake=true` and auto-played on every ghost activation. Fixed by using `GetComponentsInChildren` (plural) to stop, clear, and disable renderers on all child systems.
 
 ## 31. Engine shroud/cover not rendered correctly for some engines
 
@@ -876,7 +876,7 @@ Related to bug #42 (engine shroud missing at recording start) and bug #31 (shrou
 
 **Repro:** Launch a vessel with SRB shroud → wait for shroud to jettison → start recording → stop → commit → play back ghost → shroud is visible on the ghost.
 
-**Status:** Open
+**Status:** Fixed — `PartStateSeeder.EmitSeedEvents` now emits synthetic `ShroudJettisoned` events at `startUT` for all pre-jettisoned shrouds. The existing `ApplyPartEvents` playback applies them on the first frame.
 
 ## 66. [v0.5.1] Booster/debris recording: auto-tree creation for DebrisSplit events
 
@@ -919,15 +919,15 @@ When a ghost recording reaches its end UT during watch mode while time-warping, 
 
 ## 68. Ghost parts colored red despite not being hot (engine thrust color leak)
 
-Many ghost parts appear red/orange even when they are not experiencing reentry heating. Likely related to the engine thrust level coloring system bleeding into non-engine parts — the emissive color or material override applied for active engines may be leaking to adjacent parts or not being properly scoped to engine renderers only.
+Many ghost parts appear red/orange even when they are not experiencing reentry heating. The engine thrust level coloring system was cloning materials on ALL renderers of heat-animated parts, not just the heat-affected ones.
 
-**Status:** Open
+**Status:** Fixed — `BuildHeatMaterialStates` now filters renderers by the resolved heat transform subtree. Fallback path (material-only animations) only replaces `renderer.materials` when at least one material is tracked (#86 follow-up).
 
 ## 69. Procedural fairing shows internal structure on ghost
 
 The procedural fairing ghost displays its internal structural framework/skeleton part sticking out through the fairing shell. The fairing's internal structure mesh should be hidden on the ghost — only the outer shell panels should be visible.
 
-**Status:** Open
+**Status:** Fixed — Prefab Cap/Truss clones (at placeholder scale 2000x10x2000) are permanently hidden. A procedural truss mesh is generated from XSECTION data with horizontal cap discs and vertical struts, hidden by default and revealed on `FairingJettisoned` event. Fairing cone mesh now has a cap disc for truncated tops (#85).
 
 ## 70. Deployed solar panels shown retracted on ghost during playback
 
@@ -937,7 +937,7 @@ Related to the general "initial part state" problem — the ghost builder needs 
 
 **Observed in:** Rover recording session (2026-03-21). Recording shows `deployables=2` (2 solar panels EXTENDED), but ghost renders them retracted.
 
-**Status:** Open
+**Status:** Fixed — `PartStateSeeder.EmitSeedEvents` now emits synthetic `DeployableExtended` events at `startUT` for all pre-extended deployables. Covers all 16 tracking set types including gear, lights, engines, RCS, thermal animations, and more.
 
 ## 71. GhostCommNetRelay.RegisterNode orphans CommNet nodes on double registration
 
@@ -1022,3 +1022,53 @@ After CommNet reinitialization, the existing `CommNode` objects in `activeGhostN
 Line 289: `int cycleIndex = (int)(elapsed / cycleDuration)` — for very long-running loops with short cycle durations, the double value can exceed `Int32.MaxValue`. The cast produces undefined behavior in C# (typically `Int32.MinValue` or garbage). A 0.1s recording looping for 250+ in-game days would overflow.
 
 **Status:** Open — extreme edge case
+
+## 85. Fairing nosecone cap missing on ghost
+
+The generated fairing cone mesh (`GenerateFairingConeMesh`) builds a surface-of-revolution from XSECTION data but may not close off the top with a cap face. The topmost fairing cap piece (the nose tip) is visually missing on the ghost. The Cap1-Cap6 transforms from AutoTruss are interstage discs, not the nosecone.
+
+**Repro:** Build a vessel with a procedural fairing → launch → commit → play back ghost → top of fairing has a hole.
+
+**Status:** Fixed — `GenerateFairingConeMesh` now generates a flat disc cap when the top XSECTION has non-zero radius (capRadius).
+
+## 86. Heat material fallback still colors non-heat renderers (material-only animations)
+
+Bug #68 fix limits material cloning to heat-animated transforms, but `FXModuleAnimateThrottle` animations like `overheat` on engines (e.g., `engineLargeSkipper`) animate material properties only (no transform deltas). `SampleAnimateHeatStates` returns 0 transform deltas, triggering the clone-all fallback. All 7 materials are cloned but only 4 are tracked — the 3 untracked clones keep stale colors, causing the red tint on non-heat parts.
+
+**Log evidence:** `AnimateHeat 'engineLargeSkipper.v2': no affected transforms provided, cloning all renderers (fallback)` — `tracked=4 cloned=7`
+
+**Fix:** In the fallback path, don't clone materials that won't be tracked. Only clone materials that have `_Color` or emissive properties. Leave untracked materials as `sharedMaterials`.
+
+**Status:** Fixed — `BuildHeatMaterialStates` fallback path now only assigns `renderer.materials = cloned` when at least one material on that renderer is tracked in `materialStates`.
+
+## 87. Chain boundary commit creates group inside group in UI
+
+When a chain recording hits a boundary split (e.g., atmosphere exit), the committed segments appear as a nested group inside a group in the recordings UI. The RecordingGroup logic may be double-nesting chain segments.
+
+**Status:** Open — needs investigation of RecordingGroup assignment during chain boundary commits
+
+## 88. No merge/approval dialog shown on recording commit
+
+After recording completes (via chain boundary or scene change), the recording is auto-committed without showing a dialog asking the user to approve. The merge dialog is currently only shown on revert, not on normal commit flow. User expects to be asked before committing.
+
+**Status:** Open — design decision needed: should normal commits require approval?
+
+## 89. Watch button enabled for distant ghosts beyond visual range
+
+Pressing Watch (W) on a ghost that is beyond visual range (100km+) switches the camera to it, then immediately exits watch mode because the ghost exceeds range. The Watch button should be disabled (or the switch should be prevented) when the ghost is too far away.
+
+**Log evidence:** `EnterWatchMode` at 161km → `Watch exited: ghost exceeded visual range (163142m)` after 2 seconds.
+
+**Status:** Fixed — Watch button now requires `IsGhostWithinVisualRange` (currentZone != Beyond). Tooltip shows "Ghost is beyond visual range" when disabled.
+
+## 90. Watch button enabled for recordings from the past
+
+The Watch (W) button is shown enabled for a recording whose time range is entirely in the past (already finished playing). Watching a finished recording is meaningless — the ghost doesn't exist. The button should be disabled for recordings outside the current playback window.
+
+**Status:** Fixed — Non-looping past ghosts are destroyed (hasGhost=false → button disabled). Looping ghosts that drift beyond range are caught by the visual range check (#89).
+
+## 91. Fairing internal structure shown on ghost when disabled on real vessel
+
+`GetFairingShowMesh` reads `showMesh` from `ModuleStructuralNodeToggle` in the snapshot but returns `True` even when the player set it to hidden. Log shows `showInternalOnJettison=True` when the real vessel has structure hidden. Either the snapshot doesn't contain the updated `showMesh` value, or the field name is wrong.
+
+**Status:** Fixed — Prefab Cap/Truss meshes are at placeholder scale (2000x10x2000) that only KSP's runtime `ModuleProceduralFairing` can adjust. Procedural truss mesh generated from XSECTION data replaces them. The `showMesh` field in snapshots was always `True` for this vessel — the visual issue was the enormous prefab-scale meshes, not a reading error.

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -83,6 +83,14 @@ Engine and RCS particle systems are instantiated per ghost. Pooling would reduce
 
 ## TODO — Features
 
+### T25. Fairing internal truss structure after jettison
+
+After fairing jettison, the ghost currently shows just the payload and base adapter. KSP's real vessel can show an internal truss structure (Cap/Truss meshes controlled by `ModuleStructuralNodeToggle.showMesh`). The prefab meshes are at placeholder scale (2000x10x2000) that only KSP's runtime `ModuleProceduralFairing` can set correctly. A procedural truss mesh was attempted but removed due to insufficient visual quality.
+
+To implement properly: either rescale prefab Cap/Truss meshes from XSECTION data (need to reverse-engineer the mesh unit geometry), or generate higher-fidelity procedural geometry with proper materials.
+
+**Priority:** Low — cosmetic, only visible briefly after fairing jettison
+
 ### T11. Ghost map presence KSP integration (bug #60)
 
 `GhostMapPresence` pure data layer is complete. 4 KSP integration points need in-game API investigation: tracking station registration, map orbit lines, nav target support, cleanup on despawn.

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1080,3 +1080,9 @@ The Watch (W) button is shown enabled for a recording whose time range is entire
 `GetFairingShowMesh` reads `showMesh` from `ModuleStructuralNodeToggle` in the snapshot but returns `True` even when the player set it to hidden. Log shows `showInternalOnJettison=True` when the real vessel has structure hidden. Either the snapshot doesn't contain the updated `showMesh` value, or the field name is wrong.
 
 **Status:** Fixed — Prefab Cap/Truss meshes are at placeholder scale (2000x10x2000) that only KSP's runtime `ModuleProceduralFairing` can adjust. Procedural truss mesh generated from XSECTION data replaces them. The `showMesh` field in snapshots was always `True` for this vessel — the visual issue was the enormous prefab-scale meshes, not a reading error.
+
+## 92. Zone rendering policy tests expect old Visual-zone behavior
+
+`GetZoneRenderingPolicy(Visual)` and `ShouldApplyPartEventsForZone(Visual)` were changed to apply part events in the Visual zone (2.3-120km) so that structural changes (fairing jettison, staging, crash destruction) work at altitude. Two existing tests still assert the old behavior (`skipPartEvents = true` for Visual zone). Update them to expect `skipPartEvents = false` and `ShouldApplyPartEventsForZone(Visual) = true`.
+
+**Status:** Open — test-only fix, no production code change needed


### PR DESCRIPTION
## Summary

Fixes 10 bugs and adds 2 gameplay improvements across ghost visuals, recording, and UI.

### Visual correctness (every-session bugs)
- **#68** — Ghost parts no longer turn red from engine heat color leak. `BuildHeatMaterialStates` now filters renderers by heat-animated transform subtree instead of cloning all materials.
- **#86** — Follow-up: material-only heat animations (zero transform deltas) no longer contaminate non-heat renderers. Fallback path only replaces `renderer.materials` when at least one material is tracked.
- **#69** — Procedural fairing internal structure (Cap/Truss) no longer pokes through the fairing shell. Prefab meshes permanently hidden (placeholder scale 2000x10x2000). Procedural truss mesh generated from XSECTION data shown after jettison.
- **#85** — Fairing nosecone cap no longer missing. `GenerateFairingConeMesh` generates a flat disc cap for truncated tops (stock fairings have capRadius 0.2-0.375).
- **#91** — Fairing internal structure no longer shown at wrong scale after jettison.
- **#70, #65** — Ghost initial visual state now correct. Solar panels deployed at recording start show deployed on ghost. Jettisoned shrouds are hidden. `PartStateSeeder.EmitSeedEvents` emits synthetic events at startUT for all 16 tracking set types (deployables, jettisons, fairings, lights, gear, cargo bays, parachutes, engines, RCS, thermal).
- **#30** — RCS thrusters no longer fire constantly on ghosts. `TryBuildRcsFX` used `GetComponentInChildren` (singular) — child particle systems kept `playOnAwake=true`. Now uses `GetComponentsInChildren` (plural).

### UI fixes
- **#89** — Watch button disabled when ghost is beyond visual range (120km+). Tooltip: "Ghost is beyond visual range".
- **#90** — Watch button disabled for past recordings (ghost destroyed or beyond range).

### Gameplay improvements
- **Auto-record from LANDED** — Recording now triggers on LANDED→FLYING transitions (not just PRELAUNCH) with a 5-second settle timer to filter physics bounces. Covers save-loaded pad vessels and Mun takeoffs.
- **Vessel spawn after revert** — Committed recordings now spawn a fresh vessel at the recording's end position after revert, instead of skipping because the reverted vessel has the same PID.

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 3025 pass, 0 fail (31 new seed event tests)
- [x] In-game: verify fairing cone has cap, truss structure appears after jettison
- [x] In-game: verify engine/booster parts not red when cold
- [x] In-game: verify RCS not firing on ghost
- [x] In-game: verify solar panels/shrouds show correct initial state
- [x] In-game: verify Watch button disabled for distant/past ghosts
- [x] In-game: verify auto-record from LANDED, no bounce spam
- [x] In-game: verify rover spawns at recording end after revert