### PR TITLE
Fix surface vehicle ghost positioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Parsek are documented here.
 
 ---
 
+## 0.5.1
+
+### Bug Fixes
+
+- **#93**: Surface vehicle ghost slides away during on-rails playback — orbit segments with sub-surface SMA now skipped for LANDED/SPLASHED/PRELAUNCH vessels at recording time; playback uses `IsSurfaceAtUT` to suppress orbit interpolation for surface TrackSections; SMA < 90% body radius rejected as safety net
+- **Terrain clamp** — ghost positions clamped above terrain in LateUpdate, preventing any ghost from appearing underground regardless of interpolation source
+
+---
+
 ## 0.5.0
 
 Recording system redesign: multi-vessel sessions, ghost chain paradox prevention, spawn safety, time jump, and rendering zones. Recording format v5 → v7 (backward compatible).

--- a/Source/Parsek.Tests/OrbitSegmentTests.cs
+++ b/Source/Parsek.Tests/OrbitSegmentTests.cs
@@ -863,5 +863,85 @@ namespace Parsek.Tests
         }
 
         #endregion
+
+        #region IsSurfaceAtUT
+
+        [Fact]
+        public void IsSurfaceAtUT_SurfaceMobile_ReturnsTrue()
+        {
+            var sections = new List<TrackSection>
+            {
+                new TrackSection { environment = SegmentEnvironment.SurfaceMobile, startUT = 100, endUT = 200 }
+            };
+            Assert.True(TrajectoryMath.IsSurfaceAtUT(sections, 150));
+        }
+
+        [Fact]
+        public void IsSurfaceAtUT_SurfaceStationary_ReturnsTrue()
+        {
+            var sections = new List<TrackSection>
+            {
+                new TrackSection { environment = SegmentEnvironment.SurfaceStationary, startUT = 100, endUT = 200 }
+            };
+            Assert.True(TrajectoryMath.IsSurfaceAtUT(sections, 150));
+        }
+
+        [Fact]
+        public void IsSurfaceAtUT_Atmospheric_ReturnsFalse()
+        {
+            var sections = new List<TrackSection>
+            {
+                new TrackSection { environment = SegmentEnvironment.Atmospheric, startUT = 100, endUT = 200 }
+            };
+            Assert.False(TrajectoryMath.IsSurfaceAtUT(sections, 150));
+        }
+
+        [Fact]
+        public void IsSurfaceAtUT_ExoBallistic_ReturnsFalse()
+        {
+            var sections = new List<TrackSection>
+            {
+                new TrackSection { environment = SegmentEnvironment.ExoBallistic, startUT = 100, endUT = 200 }
+            };
+            Assert.False(TrajectoryMath.IsSurfaceAtUT(sections, 150));
+        }
+
+        [Fact]
+        public void IsSurfaceAtUT_NullSections_ReturnsFalse()
+        {
+            Assert.False(TrajectoryMath.IsSurfaceAtUT(null, 150));
+        }
+
+        [Fact]
+        public void IsSurfaceAtUT_EmptySections_ReturnsFalse()
+        {
+            Assert.False(TrajectoryMath.IsSurfaceAtUT(new List<TrackSection>(), 150));
+        }
+
+        [Fact]
+        public void IsSurfaceAtUT_UTOutsideRange_ReturnsFalse()
+        {
+            var sections = new List<TrackSection>
+            {
+                new TrackSection { environment = SegmentEnvironment.SurfaceMobile, startUT = 100, endUT = 200 }
+            };
+            Assert.False(TrajectoryMath.IsSurfaceAtUT(sections, 300));
+        }
+
+        [Fact]
+        public void IsSurfaceAtUT_MixedSections_CorrectlyIdentifiesSurface()
+        {
+            var sections = new List<TrackSection>
+            {
+                new TrackSection { environment = SegmentEnvironment.Atmospheric, startUT = 100, endUT = 200 },
+                new TrackSection { environment = SegmentEnvironment.SurfaceMobile, startUT = 200, endUT = 300 },
+                new TrackSection { environment = SegmentEnvironment.ExoBallistic, startUT = 300, endUT = 400 }
+            };
+            Assert.False(TrajectoryMath.IsSurfaceAtUT(sections, 150));
+            Assert.True(TrajectoryMath.IsSurfaceAtUT(sections, 250));
+            Assert.False(TrajectoryMath.IsSurfaceAtUT(sections, 350));
+        }
+
+        #endregion
     }
 }

--- a/Source/Parsek.Tests/TerrainCorrectorTests.cs
+++ b/Source/Parsek.Tests/TerrainCorrectorTests.cs
@@ -138,6 +138,65 @@ namespace Parsek.Tests
 
         #endregion
 
+        #region ClampAltitude
+
+        [Fact]
+        public void ClampAltitude_AboveTerrain_NoChange()
+        {
+            // Ghost at 75m, terrain at 70m — already above terrain + 0.5m
+            double result = TerrainCorrector.ClampAltitude(75.0, 70.0);
+            Assert.Equal(75.0, result);
+        }
+
+        [Fact]
+        public void ClampAltitude_BelowTerrain_ClampsUp()
+        {
+            // Ghost at 65m, terrain at 70m — below terrain
+            double result = TerrainCorrector.ClampAltitude(65.0, 70.0);
+            Assert.Equal(70.5, result);
+        }
+
+        [Fact]
+        public void ClampAltitude_AtTerrain_ClampsUp()
+        {
+            // Ghost exactly at terrain height — needs clearance
+            double result = TerrainCorrector.ClampAltitude(70.0, 70.0);
+            Assert.Equal(70.5, result);
+        }
+
+        [Fact]
+        public void ClampAltitude_NegativeTerrain_Ocean_NoChange()
+        {
+            // Ghost at sea level (0m), ocean floor at -500m — already above
+            double result = TerrainCorrector.ClampAltitude(0.0, -500.0);
+            Assert.Equal(0.0, result);
+        }
+
+        [Fact]
+        public void ClampAltitude_DeepUnderground_ClampsUp()
+        {
+            // Ghost at -8444m (orbit reconstruction underground), terrain at 70m
+            double result = TerrainCorrector.ClampAltitude(-8444.0, 70.0);
+            Assert.Equal(70.5, result);
+        }
+
+        [Fact]
+        public void ClampAltitude_CustomClearance()
+        {
+            double result = TerrainCorrector.ClampAltitude(70.0, 70.0, 1.0);
+            Assert.Equal(71.0, result);
+        }
+
+        [Fact]
+        public void ClampAltitude_JustAboveClearance_NoChange()
+        {
+            // Ghost at 70.6m, terrain at 70m, clearance 0.5m — just above threshold
+            double result = TerrainCorrector.ClampAltitude(70.6, 70.0);
+            Assert.Equal(70.6, result);
+        }
+
+        #endregion
+
         #region Serialization round-trip
 
         [Fact]

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -4419,6 +4419,18 @@ namespace Parsek
             // Record a boundary TrajectoryPoint at current UT (stitching point)
             SamplePosition(v);
 
+            // Layer 1: Surface vessels (LANDED/SPLASHED/PRELAUNCH) stay in place on rails —
+            // their Keplerian orbit is a sub-surface path through the planet, not a valid trajectory.
+            // Skip orbit segment creation and keep the current Absolute track section.
+            if (v.situation == Vessel.Situations.LANDED ||
+                v.situation == Vessel.Situations.SPLASHED ||
+                v.situation == Vessel.Situations.PRELAUNCH)
+            {
+                ParsekLog.Info("Recorder",
+                    $"Vessel went on rails (surface, sit={v.situation}) — skipping orbit segment, position unchanged");
+                return;
+            }
+
             currentOrbitSegment = new OrbitSegment
             {
                 startUT = Planetarium.GetUniversalTime(),
@@ -4485,7 +4497,7 @@ namespace Parsek
 
         public void OnVesselGoOffRails(Vessel v)
         {
-            if (!IsRecording || !isOnRails) return;
+            if (!IsRecording) return;
             if (v != FlightGlobals.ActiveVessel)
             {
                 ParsekLog.VerboseRateLimited("Recorder", "off-rails-other-vessel",
@@ -4493,6 +4505,13 @@ namespace Parsek
                 return;
             }
             if (v.persistentId != RecordingVesselId) return;
+
+            // Surface vessel went on rails without orbit segment — sample boundary point for continuity
+            if (!isOnRails)
+            {
+                SamplePosition(v);
+                return;
+            }
 
             // Finalize orbit segment
             currentOrbitSegment.endUT = Planetarium.GetUniversalTime();
@@ -4673,8 +4692,13 @@ namespace Parsek
             // Close current TrackSection before backgrounding (v6+)
             CloseCurrentTrackSection(Planetarium.GetUniversalTime());
 
-            // Start a new orbit segment for the background phase
-            if (v != null && v.orbit != null)
+            // Start a new orbit segment for the background phase.
+            // Layer 1: Skip for surface vessels — their Keplerian orbit is sub-surface.
+            bool isSurfaceVessel = v != null &&
+                (v.situation == Vessel.Situations.LANDED ||
+                 v.situation == Vessel.Situations.SPLASHED ||
+                 v.situation == Vessel.Situations.PRELAUNCH);
+            if (v != null && v.orbit != null && !isSurfaceVessel)
             {
                 currentOrbitSegment = new OrbitSegment
                 {
@@ -4689,6 +4713,11 @@ namespace Parsek
                     bodyName = v.mainBody?.name ?? "Kerbin"
                 };
                 isOnRails = true;
+            }
+            else if (isSurfaceVessel)
+            {
+                ParsekLog.Info("Recorder",
+                    $"Background transition: surface vessel (sit={v.situation}), skipping orbit segment");
             }
 
             // Disconnect from Harmony patch (stop physics-frame sampling)

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -568,6 +568,35 @@ namespace Parsek
                     }
                 }
             }
+
+            // Terrain clamp: prevent ghosts from appearing below terrain surface.
+            // Sub-orbital orbit reconstruction can place ghosts underground (periapsis
+            // below surface), and procedural terrain height varies between sessions.
+            for (int i = 0; i < ghostPosEntries.Count; i++)
+            {
+                var e = ghostPosEntries[i];
+                if (e.ghost == null || !e.ghost.activeSelf) continue;
+                if (e.mode == GhostPosMode.Relative) continue;
+
+                CelestialBody body = (e.mode == GhostPosMode.Orbit) ? e.orbitBody : e.bodyBefore;
+                if (body == null || body.pqsController == null) continue;
+
+                Vector3d pos = e.ghost.transform.position;
+                double alt = body.GetAltitude(pos);
+                if (alt > 10000) continue; // skip in-flight ghosts (no terrain risk)
+
+                double lat = body.GetLatitude(pos);
+                double lon = body.GetLongitude(pos);
+                double terrainHeight = body.TerrainAltitude(lat, lon, true);
+                double clamped = TerrainCorrector.ClampAltitude(alt, terrainHeight);
+                if (clamped > alt)
+                {
+                    e.ghost.transform.position = body.GetWorldSurfacePosition(lat, lon, clamped);
+                    ParsekLog.VerboseRateLimited("TerrainCorrect", "clamp-ghost",
+                        $"Ghost terrain clamp: alt={alt:F1} terrain={terrainHeight:F1} -> {clamped:F1}");
+                }
+            }
+
             ghostPosEntries.Clear();
 
             UpdateWatchCamera();

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -5354,9 +5354,11 @@ namespace Parsek
 
             InterpolationResult interpResult;
             bool srfRel = previewRecording != null && previewRecording.RecordingFormatVersion >= 5;
+            bool surfaceSkip = previewRecording != null &&
+                TrajectoryMath.IsSurfaceAtUT(previewRecording.TrackSections, recordingTime);
             InterpolateAndPosition(ghostObject, recording, orbitSegments,
                 ref lastPlaybackIndex, recordingTime, 10000, out interpResult,
-                surfaceRelativeRotation: srfRel);
+                surfaceRelativeRotation: srfRel, skipOrbitSegments: surfaceSkip);
 
             if (previewGhostState != null && previewRecording != null)
             {
@@ -5504,10 +5506,11 @@ namespace Parsek
                     // TODO: cachedIdx resets to 0 each frame — when ghost GO creation is implemented
                     // (6b-4), cache this on the ghost state or chain for O(1) amortized lookup.
                     bool srfRel = bgRec.RecordingFormatVersion >= 5;
+                    bool surfaceSkip = TrajectoryMath.IsSurfaceAtUT(bgRec.TrackSections, currentUT);
                     int cachedIdx = 0;
                     InterpolateAndPosition(info.ghostGO, bgRec.Points, bgRec.OrbitSegments,
                         ref cachedIdx, currentUT, (int)(chain.OriginalVesselPid * 10000),
-                        out _, surfaceRelativeRotation: srfRel);
+                        out _, surfaceRelativeRotation: srfRel, skipOrbitSegments: surfaceSkip);
 
                     ParsekLog.VerboseRateLimited("Flight", "chain-ghost-trajectory-" + chain.OriginalVesselPid,
                         string.Format(CultureInfo.InvariantCulture,
@@ -5945,9 +5948,12 @@ namespace Parsek
 
                         if (!usedRelative)
                         {
+                            // Layer 2: Skip orbit segments when the current TrackSection
+                            // is a surface environment — use point interpolation instead.
+                            bool surfaceSkip = TrajectoryMath.IsSurfaceAtUT(rec.TrackSections, currentUT);
                             InterpolateAndPosition(state.ghost, rec.Points, rec.OrbitSegments,
                                 ref playbackIdx, currentUT, i * 10000, out interpResult,
-                                surfaceRelativeRotation: srfRel);
+                                surfaceRelativeRotation: srfRel, skipOrbitSegments: surfaceSkip);
                         }
 
                         state.SetInterpolated(interpResult);
@@ -6007,7 +6013,11 @@ namespace Parsek
 
                         if (state != null && state.ghost != null)
                         {
-                            if (hasOrbitData)
+                            // Layer 2: Prefer surface positioning over orbit for surface recordings.
+                            // Orbit data from surface vessels is sub-surface and produces wrong positions.
+                            if (hasSurfaceData && TrajectoryMath.IsSurfaceAtUT(rec.TrackSections, currentUT))
+                                PositionGhostAtSurface(state.ghost, rec.SurfacePos.Value);
+                            else if (hasOrbitData)
                                 PositionGhostFromOrbitOnly(state.ghost, rec, currentUT, i * 10000);
                             else if (hasSurfaceData)
                                 PositionGhostAtSurface(state.ghost, rec.SurfacePos.Value);
@@ -8892,29 +8902,44 @@ namespace Parsek
 
         void InterpolateAndPosition(GameObject ghost, List<TrajectoryPoint> points,
             List<OrbitSegment> segments, ref int cachedIndex, double targetUT, int orbitCacheBase,
-            out InterpolationResult interpResult, bool surfaceRelativeRotation = false)
+            out InterpolationResult interpResult, bool surfaceRelativeRotation = false,
+            bool skipOrbitSegments = false)
         {
-            // Check orbit segments first
-            if (segments != null && segments.Count > 0)
+            // Check orbit segments first (unless suppressed for surface vehicles)
+            if (!skipOrbitSegments && segments != null && segments.Count > 0)
             {
                 OrbitSegment? seg = FindOrbitSegment(segments, targetUT);
                 if (seg.HasValue)
                 {
-                    // Use segment index as cache key offset
-                    int segIdx = segments.IndexOf(seg.Value);
-                    int cacheKey = orbitCacheBase + segIdx;
-                    if (loggedOrbitSegments.Add(cacheKey))
-                        Log($"Orbit segment activated: cache={cacheKey}, body={seg.Value.bodyName}, " +
-                            $"sma={seg.Value.semiMajorAxis:F0}, UT {seg.Value.startUT:F0}-{seg.Value.endUT:F0}");
-                    PositionGhostFromOrbit(ghost, seg.Value, targetUT, cacheKey);
-                    Vector3 vel = Vector3.zero;
-                    Orbit orbit;
-                    if (orbitCache.TryGetValue(cacheKey, out orbit))
-                        vel = orbit.getOrbitalVelocityAtUT(targetUT);
+                    // Layer 3: SMA sanity check — reject orbit segments where the orbit
+                    // is mostly sub-surface (SMA < 90% of body radius). This catches
+                    // old recordings that have invalid orbit segments for surface vessels.
                     CelestialBody segBody = FlightGlobals.Bodies?.Find(b => b.name == seg.Value.bodyName);
-                    double segAlt = segBody != null ? segBody.GetAltitude(ghost.transform.position) : 0;
-                    interpResult = new InterpolationResult(vel, seg.Value.bodyName, segAlt);
-                    return;
+                    double bodyRadius = segBody?.Radius ?? 600000;
+                    if (seg.Value.semiMajorAxis < bodyRadius * 0.9)
+                    {
+                        int smaKey = orbitCacheBase + 900000;
+                        if (loggedOrbitSegments.Add(smaKey))
+                            Log($"Orbit segment rejected (sub-surface): sma={seg.Value.semiMajorAxis:F0} < " +
+                                $"bodyRadius*0.9={bodyRadius * 0.9:F0}, falling through to point interpolation");
+                    }
+                    else
+                    {
+                        // Use segment index as cache key offset
+                        int segIdx = segments.IndexOf(seg.Value);
+                        int cacheKey = orbitCacheBase + segIdx;
+                        if (loggedOrbitSegments.Add(cacheKey))
+                            Log($"Orbit segment activated: cache={cacheKey}, body={seg.Value.bodyName}, " +
+                                $"sma={seg.Value.semiMajorAxis:F0}, UT {seg.Value.startUT:F0}-{seg.Value.endUT:F0}");
+                        PositionGhostFromOrbit(ghost, seg.Value, targetUT, cacheKey);
+                        Vector3 vel = Vector3.zero;
+                        Orbit orbit;
+                        if (orbitCache.TryGetValue(cacheKey, out orbit))
+                            vel = orbit.getOrbitalVelocityAtUT(targetUT);
+                        double segAlt = segBody != null ? segBody.GetAltitude(ghost.transform.position) : 0;
+                        interpResult = new InterpolationResult(vel, seg.Value.bodyName, segAlt);
+                        return;
+                    }
                 }
             }
 

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -19,6 +19,9 @@ namespace Parsek
         internal const string MODID = "Parsek_NS";
         internal const string MODNAME = "Parsek";
 
+        /// <summary>Above this altitude, skip the per-frame terrain clamp (no terrain risk in flight).</summary>
+        const double TerrainClampAltitudeLimit = 10000;
+
         #region State
 
         // Recording (delegated to FlightRecorder)
@@ -583,7 +586,7 @@ namespace Parsek
 
                 Vector3d pos = e.ghost.transform.position;
                 double alt = body.GetAltitude(pos);
-                if (alt > 10000) continue; // skip in-flight ghosts (no terrain risk)
+                if (alt > TerrainClampAltitudeLimit) continue;
 
                 double lat = body.GetLatitude(pos);
                 double lon = body.GetLongitude(pos);
@@ -8918,7 +8921,7 @@ namespace Parsek
                     double bodyRadius = segBody?.Radius ?? 600000;
                     if (seg.Value.semiMajorAxis < bodyRadius * 0.9)
                     {
-                        int smaKey = orbitCacheBase + 900000;
+                        int smaKey = ~orbitCacheBase; // bitwise complement — guaranteed no collision with positive cache keys
                         if (loggedOrbitSegments.Add(smaKey))
                             Log($"Orbit segment rejected (sub-surface): sma={seg.Value.semiMajorAxis:F0} < " +
                                 $"bodyRadius*0.9={bodyRadius * 0.9:F0}, falling through to point interpolation");

--- a/Source/Parsek/TerrainCorrector.cs
+++ b/Source/Parsek/TerrainCorrector.cs
@@ -47,6 +47,19 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Clamps a ghost altitude so it stays above terrain surface.
+        /// Pure math — testable without KSP runtime.
+        /// Returns ghostAltitude unchanged if already above terrain + minClearance,
+        /// otherwise returns terrainHeight + minClearance.
+        /// </summary>
+        internal static double ClampAltitude(double ghostAltitude, double terrainHeight,
+            double minClearance = 0.5)
+        {
+            double minAlt = terrainHeight + minClearance;
+            return ghostAltitude < minAlt ? minAlt : ghostAltitude;
+        }
+
+        /// <summary>
         /// Pure decision: should terrain correction apply to this recording?
         ///
         /// Returns true when:

--- a/Source/Parsek/TrajectoryMath.cs
+++ b/Source/Parsek/TrajectoryMath.cs
@@ -610,5 +610,18 @@ namespace Parsek
             }
             return -1;
         }
+
+        /// <summary>
+        /// Returns true if the TrackSection covering the given UT has a surface environment
+        /// (SurfaceMobile or SurfaceStationary). Surface vessels should not use orbit segment
+        /// interpolation — their Keplerian orbit is a sub-surface path through the planet.
+        /// </summary>
+        internal static bool IsSurfaceAtUT(List<TrackSection> sections, double ut)
+        {
+            int idx = FindTrackSectionForUT(sections, ut);
+            if (idx < 0) return false;
+            var env = sections[idx].environment;
+            return env == SegmentEnvironment.SurfaceMobile || env == SegmentEnvironment.SurfaceStationary;
+        }
     }
 }

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -981,7 +981,7 @@ Unlike `CheckOverlapAgainstLoadedVessels` which properly excludes Debris/EVA/Fla
 
 Lines 90-97: For `ecc >= 1.0 || sma <= 0`, the fallback returns `(0, 0, sma - bodyRadius)`. When `sma < bodyRadius`, this produces a negative altitude, placing the ghost underground. Should use `Math.Max(0, sma - bodyRadius)`.
 
-**Status:** Open
+**Status:** Mitigated — the LateUpdate terrain clamp (`e5c5340`) prevents any ghost from appearing below terrain, and the SMA sanity check in `InterpolateAndPosition` (`ea14b8f`) rejects orbit segments with SMA < 90% body radius. The root GhostExtender fallback formula is still uncorrected.
 
 ## 77. TerrainCorrector log format strings use system culture
 
@@ -1086,3 +1086,9 @@ The Watch (W) button is shown enabled for a recording whose time range is entire
 `GetZoneRenderingPolicy(Visual)` and `ShouldApplyPartEventsForZone(Visual)` were changed to apply part events in the Visual zone (2.3-120km) so that structural changes (fairing jettison, staging, crash destruction) work at altitude. Two existing tests still assert the old behavior (`skipPartEvents = true` for Visual zone). Update them to expect `skipPartEvents = false` and `ShouldApplyPartEventsForZone(Visual) = true`.
 
 **Status:** Open — test-only fix, no production code change needed
+
+## 93. Surface vehicle ghost slides away from recorded position during on-rails playback
+
+When a surface vessel (rover, lander) goes on rails during recording (e.g., time warp), an orbit segment is created with SMA ≈ half the body radius. During playback, `InterpolateAndPosition` prioritizes orbit segments over point-based interpolation. The Keplerian orbit path goes through the planet interior — the terrain clamp corrects altitude but the lat/lon follows the orbital path, causing the ghost to slide along the ground away from the runway/landing site. Observed with Crater Crawler rover on the KSC runway: ghost altitude fell to -6281m (clamped back to 65.3m each frame), but the ghost drifted off its recorded position.
+
+**Status:** Fixed (`6996b65`, `ea14b8f`) — three-layer fix: (1) skip orbit segment creation for LANDED/SPLASHED/PRELAUNCH vessels, (2) `IsSurfaceAtUT` skips orbit segments during playback for surface TrackSections, (3) SMA < 90% body radius sanity check rejects sub-surface orbits

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -981,7 +981,7 @@ Unlike `CheckOverlapAgainstLoadedVessels` which properly excludes Debris/EVA/Fla
 
 Lines 90-97: For `ecc >= 1.0 || sma <= 0`, the fallback returns `(0, 0, sma - bodyRadius)`. When `sma < bodyRadius`, this produces a negative altitude, placing the ghost underground. Should use `Math.Max(0, sma - bodyRadius)`.
 
-**Status:** Mitigated — the LateUpdate terrain clamp (`e5c5340`) prevents any ghost from appearing below terrain, and the SMA sanity check in `InterpolateAndPosition` (`ea14b8f`) rejects orbit segments with SMA < 90% body radius. The root GhostExtender fallback formula is still uncorrected.
+**Status:** Mitigated — the LateUpdate terrain clamp (`6996b65`) prevents any ghost from appearing below terrain, and the SMA sanity check in `InterpolateAndPosition` (`ea14b8f`) rejects orbit segments with SMA < 90% body radius. The root GhostExtender fallback formula is still uncorrected.
 
 ## 77. TerrainCorrector log format strings use system culture
 


### PR DESCRIPTION
## Summary
- **Terrain clamp**: Ghost positions are clamped above terrain in LateUpdate, preventing ghosts from appearing underground when sub-orbital orbit reconstruction places them below the surface
- **Surface orbit segment fix**: Surface vessels (LANDED/SPLASHED/PRELAUNCH) no longer use Keplerian orbit interpolation during playback — their orbits have SMA far below body radius, producing positions deep inside the planet that cause ghosts to slide away from their actual surface position

### Three-layer fix for orbit segments
1. **Recording prevention**: `OnVesselGoOnRails` and `TransitionToBackground` skip orbit segment creation when the vessel is on the surface
2. **Playback filtering**: `TrajectoryMath.IsSurfaceAtUT()` detects surface TrackSections and suppresses orbit segments at all four interpolation call sites (timeline, chain, preview, background ghosts)
3. **SMA sanity check**: `InterpolateAndPosition` rejects orbit segments with SMA < 90% of body radius as a safety net for old recordings

## Test plan
- [x] 8 new `IsSurfaceAtUT` tests (surface mobile, stationary, atmospheric, exo-ballistic, null, empty, out-of-range, mixed sections)
- [x] Existing `TerrainCorrectorTests` pass
- [x] Full suite: 3058 tests pass
- [x] In-game: record a rover on the runway, time-warp, revert, verify ghost stays on runway
- [x] In-game: verify orbital vessel ghosts still use orbit segment interpolation correctly