### PR TITLE
Fix #45: suppress vessel spawn for SubOrbital terminal state

### DIFF
--- a/Source/Parsek.Tests/RewindTimelineTests.cs
+++ b/Source/Parsek.Tests/RewindTimelineTests.cs
@@ -315,18 +315,20 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void ShouldSpawn_SubOrbital_Allowed()
+        public void ShouldSpawn_SubOrbital_ReturnsFalse()
         {
+            // SubOrbital vessel would materialize mid-air and crash (#45)
             var rec = new Recording
             {
                 VesselSnapshot = new ConfigNode("VESSEL"),
                 TerminalStateValue = TerminalState.SubOrbital
             };
 
-            var (needsSpawn, _) = GhostPlaybackLogic.ShouldSpawnAtRecordingEnd(
+            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtRecordingEnd(
                 rec, isActiveChainMember: false, isChainLoopingOrDisabled: false);
 
-            Assert.True(needsSpawn);
+            Assert.False(needsSpawn);
+            Assert.Contains("terminal state SubOrbital", reason);
         }
 
         [Fact]

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -1996,12 +1996,14 @@ namespace Parsek
             if (rec.IsDebris)
                 return (false, "debris recording (visual-only)");
 
-            // Terminal states: destroyed/recovered/docked/boarded should not spawn
+            // Terminal states: destroyed/recovered/docked/boarded/suborbital should not spawn
+            // SubOrbital includes FLYING and ESCAPING — vessel would materialize mid-air and crash (#45)
             if (rec.TerminalStateValue.HasValue)
             {
                 var ts = rec.TerminalStateValue.Value;
                 if (ts == TerminalState.Destroyed || ts == TerminalState.Recovered
-                    || ts == TerminalState.Docked || ts == TerminalState.Boarded)
+                    || ts == TerminalState.Docked || ts == TerminalState.Boarded
+                    || ts == TerminalState.SubOrbital)
                     return (false, $"terminal state {ts}");
             }
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -706,7 +706,7 @@ When a recording's final position is SUB_ORBITAL (e.g., the vessel was on a subo
 2. Propagate the orbit forward to find where it lands, spawn at that position
 3. Add a "safe spawn" check: if situation is SUB_ORBITAL and altitude is low, defer spawn until vessel reaches surface
 
-**Status:** Open
+**Status:** Fixed — SubOrbital added to non-spawnable terminal states in `ShouldSpawnAtRecordingEnd` (option 1)
 
 ## 46. EVA kerbals disappear in water after spawn
 


### PR DESCRIPTION
## Summary
- Vessels ending mid-air (SUB_ORBITAL/FLYING/ESCAPING) were spawned at their last recorded position, materializing in mid-air and immediately crashing
- Added `TerminalState.SubOrbital` to the blocked terminal states in `ShouldSpawnAtRecordingEnd` — these recordings now remain ghost-only
- Updated existing test from asserting spawn-allowed to asserting spawn-suppressed

## Test plan
- [x] `ShouldSpawn_SubOrbital_ReturnsFalse` passes
- [x] All 42 `ShouldSpawn*` tests pass