### PR TITLE
Fix ghost plume bubble artifacts (bug #105)

### DIFF
--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -916,6 +916,44 @@ namespace Parsek
                 $"sourceToFx=({sourceToFx}) parentToFx=({parentToFx})", 60.0);
         }
 
+        /// <summary>
+        /// Strip KSP FX controller components from cloned particle system GameObjects.
+        /// KSPParticleEmitter.Update() overwrites renderer materials, colors, and renderMode
+        /// on cloned particle systems, producing colored bubble artifacts (bug #105).
+        /// ModelMultiParticleFX/ModelParticleFX can re-initialize emitters via the effect system.
+        /// SmokeTrailControl modifies material color every frame based on atmospheric density.
+        /// FXPrefab registers particles with FloatingOrigin — pollutes global state on ghosts.
+        /// </summary>
+        private static void StripKspFxControllers(GameObject fxClone)
+        {
+            if (fxClone == null) return;
+
+            MonoBehaviour[] behaviours = fxClone.GetComponentsInChildren<MonoBehaviour>(true);
+            for (int i = 0; i < behaviours.Length; i++)
+            {
+                if (behaviours[i] == null) continue;
+                string typeName = behaviours[i].GetType().Name;
+                switch (typeName)
+                {
+                    case "KSPParticleEmitter":
+                    case "ModelMultiParticleFX":
+                    case "ModelParticleFX":
+                    case "SmokeTrailControl":
+                    case "FXPrefab":
+                        ParsekLog.Verbose("GhostVisual",
+                            $"Stripped {typeName} from '{fxClone.name}'");
+                        Object.Destroy(behaviours[i]);
+                        break;
+                    default:
+                        // Diagnostic: log surviving MonoBehaviours to confirm what's on cloned FX objects.
+                        // Remove this default case after in-game verification.
+                        ParsekLog.Verbose("GhostVisual",
+                            $"Kept {typeName} on '{fxClone.name}'");
+                        break;
+                }
+            }
+        }
+
         private static int ConfigureGhostEngineParticleSystems(
             GameObject fxInstance, List<ParticleSystem> sink)
         {
@@ -2302,9 +2340,7 @@ namespace Parsek
                         fxClone.transform.localRotation = legacyLocalRot;
                         fxClone.transform.localScale = child.localScale;
 
-                        var smokeTrail = fxClone.GetComponent("SmokeTrailControl");
-                        if (smokeTrail != null)
-                            Object.Destroy(smokeTrail);
+                        StripKspFxControllers(fxClone);
 
                         int addedSystems = ConfigureGhostEngineParticleSystems(fxClone, info.particleSystems);
                         if (addedSystems > 0)
@@ -2332,9 +2368,7 @@ namespace Parsek
                     fxClone.transform.localRotation = child.localRotation;
                     fxClone.transform.localScale = child.localScale;
 
-                    var smokeTrail = fxClone.GetComponent("SmokeTrailControl");
-                    if (smokeTrail != null)
-                        Object.Destroy(smokeTrail);
+                    StripKspFxControllers(fxClone);
 
                     int addedSystems = ConfigureGhostEngineParticleSystems(fxClone, info.particleSystems);
                     if (addedSystems > 0)
@@ -2399,6 +2433,8 @@ namespace Parsek
                             fxInstance.transform.SetParent(ghostFxParent, false);
                             fxInstance.transform.localPosition = mmpLocalPos;
                             fxInstance.transform.localRotation = mmpLocalRot;
+
+                            StripKspFxControllers(fxInstance);
 
                             int addedSystems = ConfigureGhostEngineParticleSystems(fxInstance, info.particleSystems);
                             if (addedSystems > 0)
@@ -2498,9 +2534,7 @@ namespace Parsek
                         }
                     }
 
-                    var smokeTrail = fxInstance.GetComponent("SmokeTrailControl");
-                    if (smokeTrail != null)
-                        Object.Destroy(smokeTrail);
+                    StripKspFxControllers(fxInstance);
 
                     int addedSystems = ConfigureGhostEngineParticleSystems(fxInstance, info.particleSystems);
                     if (addedSystems > 0)
@@ -3343,6 +3377,8 @@ namespace Parsek
                                 fxInstance.transform.localPosition = fxDefinitions[f].localOffset;
                                 fxInstance.transform.localRotation = fxDefinitions[f].localRotation;
                                 fxInstance.transform.localScale = fxDefinitions[f].localScale;
+
+                                StripKspFxControllers(fxInstance);
 
                                 // Configure ALL particle systems in the FX hierarchy (not just the first).
                                 // KSP RCS FX models have multiple child systems (plume + glow/smoke).

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -2522,6 +2522,8 @@ namespace Parsek
                     if (hasLocalRot)
                         fxInstance.transform.localRotation = localRot;
 
+                    StripKspFxControllers(fxInstance);
+
                     if (isRapierWhiteFlame)
                     {
                         fxInstance.transform.localScale *= 0.35f;
@@ -2533,8 +2535,6 @@ namespace Parsek
                             main.startSpeedMultiplier *= 0.75f;
                         }
                     }
-
-                    StripKspFxControllers(fxInstance);
 
                     int addedSystems = ConfigureGhostEngineParticleSystems(fxInstance, info.particleSystems);
                     if (addedSystems > 0)

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1197,15 +1197,13 @@ Fix: disambiguate with a launch number suffix. Check existing group names via `R
 
 ## 105. Colored bubbles visible in ghost engine plume FX
 
-Ghost engine plumes show colored bubble/sphere artifacts instead of smooth exhaust trails. Most likely cause: KSP FX controller components (`ModelMultiParticlePersistFX`, `KSPParticleEmitter`) survive the `Object.Instantiate` clone and interfere with particle system state at runtime. `ConfigureGhostEngineParticleSystems` (GhostVisualBuilder.cs:919) correctly configures the cloned systems, but surviving KSP components may re-initialize materials or override emission shape afterward.
+Ghost engine plumes show colored bubble/sphere artifacts instead of smooth exhaust trails. Root cause: `KSPParticleEmitter` (actual class name, not `ModelMultiParticlePersistFX` as originally noted) survives `Object.Instantiate`. Its `Awake()` marks `dirty=true`, then `Update()` calls `SetupProperties()` which overwrites renderer materials, colors, and renderMode on the cloned particle systems.
 
-The code only strips `SmokeTrailControl` (lines 2305, 2335, 2501) but does not strip other KSP FX management components. A secondary possibility: `TextureSheetAnimation` UV state lost if materials are cloned or replaced after instantiation, causing particles to render the full sprite atlas as a colored circle.
-
-**Fix approach:** Strip all `ModelMultiParticlePersistFX` and `KSPParticleEmitter` components from the cloned FX hierarchy after instantiation (similar to `SmokeTrailControl` stripping). Verify `ParticleSystemRenderer.renderMode` is `Billboard` or `StretchedBillboard` (not `Mesh`).
+Fix: `StripKspFxControllers` helper strips `KSPParticleEmitter`, `ModelMultiParticleFX`, `ModelParticleFX`, `SmokeTrailControl`, and `FXPrefab` from all 5 FX clone sites (engine legacy, engine model, engine prefab, RCS). Previously only `SmokeTrailControl` was stripped at 3 of 5 sites.
 
 **Priority:** Medium — visually distracting on every engine ghost
 
-**Status:** Open
+**Status:** Fixed
 
 ## 106. Watch mode camera follows booster instead of main vessel at BREAKUP
 


### PR DESCRIPTION
## Summary
- Ghost engine/RCS plumes showed colored bubble artifacts because `KSPParticleEmitter.Update()` survived `Object.Instantiate` and overwrote renderer materials, colors, and renderMode on the next frame
- Added `StripKspFxControllers` helper that strips `KSPParticleEmitter`, `ModelMultiParticleFX`, `ModelParticleFX`, `SmokeTrailControl`, and `FXPrefab` from cloned FX hierarchies
- Applied at all 5 FX clone sites (engine legacy anchor, engine legacy fallback, engine model, engine prefab, RCS model) — previously only `SmokeTrailControl` was stripped at 3 of 5 sites
- Includes diagnostic logging (`default` case) to confirm which components are actually present on clones — remove after in-game verification

## Test plan
- [x] `dotnet build` — 0 warnings
- [x] `dotnet test` — 3108/3108 pass
- [x] In-game: record engine burn, play ghost, verify smooth plume (no colored bubbles)
- [x] In-game: verify RCS ghost FX also clean
- [x] Check KSP.log for `Stripped KSPParticleEmitter` lines confirming components are removed
- [ ] After verification, remove diagnostic `default` case from `StripKspFxControllers`

🤖 Generated with [Claude Code](https://claude.com/claude-code)