### PR TITLE
Fix bug #47: thread-static ParsekLog test overrides

### DIFF
--- a/Source/Parsek/ParsekLog.cs
+++ b/Source/Parsek/ParsekLog.cs
@@ -10,6 +10,7 @@ namespace Parsek
     public static class ParsekLog
     {
         // When true, suppresses Debug.Log calls (for unit testing outside Unity)
+        [ThreadStatic]
         internal static bool SuppressLogging;
 
         private struct RateLimitState
@@ -18,13 +19,20 @@ namespace Parsek
             public int suppressedCount;
         }
 
-        private static readonly Dictionary<string, RateLimitState> rateLimitStateByKey =
-            new Dictionary<string, RateLimitState>();
+        // ThreadStatic so each xUnit thread gets its own rate-limit state.
+        // Backing field is null on non-initial threads; property lazy-creates.
+        [ThreadStatic]
+        private static Dictionary<string, RateLimitState> t_rateLimitStateByKey;
+        private static Dictionary<string, RateLimitState> rateLimitStateByKey =>
+            t_rateLimitStateByKey ?? (t_rateLimitStateByKey = new Dictionary<string, RateLimitState>());
 
         private const double DefaultRateLimitSeconds = 5.0;
         private static readonly DateTime UnixEpochUtc = new DateTime(1970, 1, 1);
+        [ThreadStatic]
         internal static Func<double> ClockOverrideForTesting;
+        [ThreadStatic]
         internal static Action<string> TestSinkForTesting;
+        [ThreadStatic]
         internal static bool? VerboseOverrideForTesting;
 
         public static bool IsVerboseEnabled =>

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -723,15 +723,13 @@ Player landed in water, EVA'd 3 kerbals from the pad vessel, but 2 of them disap
 
 **Status:** Open — needs investigation
 
-## 47. ParsekLog.TestSinkForTesting race condition (test infrastructure)
+## 47. ~~ParsekLog.TestSinkForTesting race condition (test infrastructure)~~
 
 xUnit eagerly instantiates test classes, so one class's constructor can overwrite `TestSinkForTesting` while another class's test method is running. Causes log assertion tests to be flaky.
 
-**Workaround applied:** ActionReplayTests converted most log assertions to behavioral assertions. Three remaining use a "local sink" pattern.
+**Fix applied:** All test override fields (`SuppressLogging`, `ClockOverrideForTesting`, `TestSinkForTesting`, `VerboseOverrideForTesting`) and `rateLimitStateByKey` marked `[ThreadStatic]` so each xUnit thread gets its own copy. No cross-thread interference.
 
-**Proper fix:** Make the test sink thread-local (`[ThreadStatic]`) or instance-scoped (`AsyncLocal<Action<string>>`). Apply in ParsekLog.cs, not individual test files.
-
-**Status:** Open — workaround in place
+**Status:** Fixed
 
 ## 48. ComputeBoundaryDiscontinuity hardcodes Kerbin radius
 


### PR DESCRIPTION
## Summary
- Mark all ParsekLog test override fields (`SuppressLogging`, `ClockOverrideForTesting`, `TestSinkForTesting`, `VerboseOverrideForTesting`) and `rateLimitStateByKey` as `[ThreadStatic]` so each xUnit thread gets its own copy
- Eliminates cross-thread sink clobbering that caused flaky log assertion tests
- No changes needed in any test files — existing patterns work as before, just thread-isolated

## Test plan
- [x] `dotnet test` — 3108 pass
- [x] 5 consecutive runs with zero flakiness