### PR TITLE
Unify FF button with instant time warp

### DIFF
--- a/Source/Parsek.Tests/FastForwardTests.cs
+++ b/Source/Parsek.Tests/FastForwardTests.cs
@@ -1,0 +1,126 @@
+using System.Collections.Generic;
+using UnityEngine;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    [Collection("Sequential")]
+    public class FastForwardTests : System.IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public FastForwardTests()
+        {
+            RecordingStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+            MilestoneStore.SuppressLogging = true;
+            MilestoneStore.ResetForTesting();
+            GameStateStore.SuppressLogging = true;
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.VerboseOverrideForTesting = true;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+        }
+
+        public void Dispose()
+        {
+            RecordingStore.ResetForTesting();
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+        }
+
+        private static Recording MakeFutureRecording()
+        {
+            var rec = new Recording { VesselName = "TestVessel" };
+            // Points with UTs far in the future (won't collide with Planetarium default of 0)
+            rec.Points.Add(new TrajectoryPoint { ut = 999999 });
+            rec.Points.Add(new TrajectoryPoint { ut = 1000099 });
+            return rec;
+        }
+
+        private List<TrajectoryPoint> MakePoints(int count, double startUT = 100)
+        {
+            var points = new List<TrajectoryPoint>();
+            for (int i = 0; i < count; i++)
+            {
+                points.Add(new TrajectoryPoint
+                {
+                    ut = startUT + i * 10,
+                    latitude = 0, longitude = 0, altitude = 100,
+                    velocity = new Vector3(10, 50, 0)
+                });
+            }
+            return points;
+        }
+
+        [Fact]
+        public void CanFastForward_AlreadyRewinding_ReturnsFalse()
+        {
+            var rec = MakeFutureRecording();
+            RecordingStore.IsRewinding = true;
+            string reason;
+            Assert.False(RecordingStore.CanFastForward(rec, out reason, isRecording: false));
+            Assert.Equal("Rewind already in progress", reason);
+            Assert.Contains(logLines, l =>
+                l.Contains("[Store]") && l.Contains("CanFastForward") && l.Contains("blocked"));
+        }
+
+        [Fact]
+        public void CanFastForward_NullRecording_ReturnsFalse()
+        {
+            string reason;
+            Assert.False(RecordingStore.CanFastForward(null, out reason, isRecording: false));
+            Assert.Equal("Recording not available", reason);
+        }
+
+        [Fact]
+        public void CanFastForward_EmptyPoints_ReturnsFalse()
+        {
+            var rec = new Recording { VesselName = "Empty" };
+            string reason;
+            Assert.False(RecordingStore.CanFastForward(rec, out reason, isRecording: false));
+            Assert.Equal("Recording not available", reason);
+        }
+
+        [Fact]
+        public void CanFastForward_IsRecording_ReturnsFalse()
+        {
+            var rec = MakeFutureRecording();
+            string reason;
+            Assert.False(RecordingStore.CanFastForward(rec, out reason, isRecording: true));
+            Assert.Equal("Stop recording before fast-forwarding", reason);
+        }
+
+        [Fact]
+        public void CanFastForward_HasPending_ReturnsFalse()
+        {
+            var rec = MakeFutureRecording();
+            RecordingStore.StashPending(MakePoints(3), "PendingVessel");
+            Assert.True(RecordingStore.HasPending);
+
+            string reason;
+            Assert.False(RecordingStore.CanFastForward(rec, out reason, isRecording: false));
+            Assert.Equal("Merge or discard pending recording first", reason);
+        }
+
+        [Fact]
+        public void CanFastForward_NoSaveFile_PassesPreRuntimeGuards()
+        {
+            // Key difference from CanRewind: FF does NOT require a save file.
+            // Verify it passes all non-runtime guards (IsRewinding, null, isRecording,
+            // HasPending, HasPendingTree). The Planetarium.GetUniversalTime() timing
+            // check requires KSP runtime and can't be tested here.
+            var rec = MakeFutureRecording();
+            Assert.Null(rec.RewindSaveFileName);
+            Assert.False(RecordingStore.IsRewinding);
+            Assert.False(RecordingStore.HasPending);
+            Assert.False(RecordingStore.HasPendingTree);
+            // If we get past all testable guards, the next call would be
+            // Planetarium.GetUniversalTime() which throws in unit tests.
+            // The fact that it throws (not returns false) proves all prior guards passed.
+            string reason;
+            Assert.Throws<System.NullReferenceException>(() =>
+                RecordingStore.CanFastForward(rec, out reason, isRecording: false));
+        }
+    }
+}

--- a/Source/Parsek.Tests/FastForwardTests.cs
+++ b/Source/Parsek.Tests/FastForwardTests.cs
@@ -104,6 +104,18 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void CanFastForward_HasPendingTree_ReturnsFalse()
+        {
+            var rec = MakeFutureRecording();
+            RecordingStore.StashPendingTree(new RecordingTree());
+            Assert.True(RecordingStore.HasPendingTree);
+
+            string reason;
+            Assert.False(RecordingStore.CanFastForward(rec, out reason, isRecording: false));
+            Assert.Equal("Merge or discard pending tree first", reason);
+        }
+
+        [Fact]
         public void CanFastForward_NoSaveFile_PassesPreRuntimeGuards()
         {
             // Key difference from CanRewind: FF does NOT require a save file.

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -944,12 +944,6 @@ namespace Parsek
                             $"Stripped {typeName} from '{fxClone.name}'");
                         Object.Destroy(behaviours[i]);
                         break;
-                    default:
-                        // Diagnostic: log surviving MonoBehaviours to confirm what's on cloned FX objects.
-                        // Remove this default case after in-game verification.
-                        ParsekLog.Verbose("GhostVisual",
-                            $"Kept {typeName} on '{fxClone.name}'");
-                        break;
                 }
             }
         }

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -916,6 +916,44 @@ namespace Parsek
                 $"sourceToFx=({sourceToFx}) parentToFx=({parentToFx})", 60.0);
         }
 
+        /// <summary>
+        /// Strip KSP FX controller components from cloned particle system GameObjects.
+        /// KSPParticleEmitter.Update() overwrites renderer materials, colors, and renderMode
+        /// on cloned particle systems, producing colored bubble artifacts (bug #105).
+        /// ModelMultiParticleFX/ModelParticleFX can re-initialize emitters via the effect system.
+        /// SmokeTrailControl modifies material color every frame based on atmospheric density.
+        /// FXPrefab registers particles with FloatingOrigin — pollutes global state on ghosts.
+        /// </summary>
+        private static void StripKspFxControllers(GameObject fxClone)
+        {
+            if (fxClone == null) return;
+
+            MonoBehaviour[] behaviours = fxClone.GetComponentsInChildren<MonoBehaviour>(true);
+            for (int i = 0; i < behaviours.Length; i++)
+            {
+                if (behaviours[i] == null) continue;
+                string typeName = behaviours[i].GetType().Name;
+                switch (typeName)
+                {
+                    case "KSPParticleEmitter":
+                    case "ModelMultiParticleFX":
+                    case "ModelParticleFX":
+                    case "SmokeTrailControl":
+                    case "FXPrefab":
+                        ParsekLog.Verbose("GhostVisual",
+                            $"Stripped {typeName} from '{fxClone.name}'");
+                        Object.Destroy(behaviours[i]);
+                        break;
+                    default:
+                        // Diagnostic: log surviving MonoBehaviours to confirm what's on cloned FX objects.
+                        // Remove this default case after in-game verification.
+                        ParsekLog.Verbose("GhostVisual",
+                            $"Kept {typeName} on '{fxClone.name}'");
+                        break;
+                }
+            }
+        }
+
         private static int ConfigureGhostEngineParticleSystems(
             GameObject fxInstance, List<ParticleSystem> sink)
         {
@@ -2302,9 +2340,7 @@ namespace Parsek
                         fxClone.transform.localRotation = legacyLocalRot;
                         fxClone.transform.localScale = child.localScale;
 
-                        var smokeTrail = fxClone.GetComponent("SmokeTrailControl");
-                        if (smokeTrail != null)
-                            Object.Destroy(smokeTrail);
+                        StripKspFxControllers(fxClone);
 
                         int addedSystems = ConfigureGhostEngineParticleSystems(fxClone, info.particleSystems);
                         if (addedSystems > 0)
@@ -2332,9 +2368,7 @@ namespace Parsek
                     fxClone.transform.localRotation = child.localRotation;
                     fxClone.transform.localScale = child.localScale;
 
-                    var smokeTrail = fxClone.GetComponent("SmokeTrailControl");
-                    if (smokeTrail != null)
-                        Object.Destroy(smokeTrail);
+                    StripKspFxControllers(fxClone);
 
                     int addedSystems = ConfigureGhostEngineParticleSystems(fxClone, info.particleSystems);
                     if (addedSystems > 0)
@@ -2399,6 +2433,8 @@ namespace Parsek
                             fxInstance.transform.SetParent(ghostFxParent, false);
                             fxInstance.transform.localPosition = mmpLocalPos;
                             fxInstance.transform.localRotation = mmpLocalRot;
+
+                            StripKspFxControllers(fxInstance);
 
                             int addedSystems = ConfigureGhostEngineParticleSystems(fxInstance, info.particleSystems);
                             if (addedSystems > 0)
@@ -2498,9 +2534,7 @@ namespace Parsek
                         }
                     }
 
-                    var smokeTrail = fxInstance.GetComponent("SmokeTrailControl");
-                    if (smokeTrail != null)
-                        Object.Destroy(smokeTrail);
+                    StripKspFxControllers(fxInstance);
 
                     int addedSystems = ConfigureGhostEngineParticleSystems(fxInstance, info.particleSystems);
                     if (addedSystems > 0)
@@ -3343,6 +3377,8 @@ namespace Parsek
                                 fxInstance.transform.localPosition = fxDefinitions[f].localOffset;
                                 fxInstance.transform.localRotation = fxDefinitions[f].localRotation;
                                 fxInstance.transform.localScale = fxDefinitions[f].localScale;
+
+                                StripKspFxControllers(fxInstance);
 
                                 // Configure ALL particle systems in the FX hierarchy (not just the first).
                                 // KSP RCS FX models have multiple child systems (plume + glow/smoke).

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -2522,6 +2522,8 @@ namespace Parsek
                     if (hasLocalRot)
                         fxInstance.transform.localRotation = localRot;
 
+                    StripKspFxControllers(fxInstance);
+
                     if (isRapierWhiteFlame)
                     {
                         fxInstance.transform.localScale *= 0.35f;
@@ -2533,8 +2535,6 @@ namespace Parsek
                             main.startSpeedMultiplier *= 0.75f;
                         }
                     }
-
-                    StripKspFxControllers(fxInstance);
 
                     int addedSystems = ConfigureGhostEngineParticleSystems(fxInstance, info.particleSystems);
                     if (addedSystems > 0)

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -9649,6 +9649,46 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Fast-forwards to a recording's StartUT by advancing UT without epoch-shifting.
+        /// Unlike WarpToRecordingEnd (which epoch-shifts for Real Spawn Control),
+        /// this lets orbits propagate naturally — a regular instant time warp.
+        /// Keeps the current view (KSC stays KSC, flight stays on current vessel).
+        /// </summary>
+        internal void FastForwardToRecording(Recording rec)
+        {
+            if (rec == null)
+            {
+                ParsekLog.Warn("Flight", "FastForwardToRecording: null recording — aborted");
+                return;
+            }
+
+            double targetUT = rec.StartUT;
+            double currentUT = Planetarium.GetUniversalTime();
+
+            if (!TimeJumpManager.IsValidJump(currentUT, targetUT))
+            {
+                ParsekLog.Warn("Flight",
+                    string.Format(CultureInfo.InvariantCulture,
+                        "FastForwardToRecording: invalid jump current={0:F1} target={1:F1} — aborted",
+                        currentUT, targetUT));
+                return;
+            }
+
+            ParsekLog.Info("Flight",
+                string.Format(CultureInfo.InvariantCulture,
+                    "FastForwardToRecording: jumping to UT={0:F1} for '{1}' (delta={2:F1}s)",
+                    targetUT, rec.VesselName, targetUT - currentUT));
+
+            TimeJumpManager.NotifyRecorder(recorder, currentUT, targetUT);
+            TimeJumpManager.ExecuteForwardJump(targetUT);
+
+            ParsekLog.ScreenMessage(
+                string.Format(CultureInfo.InvariantCulture,
+                    "Fast-forwarded to \"{0}\" ({1:F0}s)",
+                    rec.VesselName, targetUT - currentUT), 3f);
+        }
+
+        /// <summary>
         /// Warps to the earliest nearby spawn candidate's EndUT.
         /// </summary>
         internal void WarpToNextCraftSpawn()

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -1391,17 +1391,31 @@ namespace Parsek
                 bool isFuture = now < rec.StartUT;
                 bool isActive = now >= rec.StartUT && now <= rec.EndUT;
                 bool hasRewindSave = !string.IsNullOrEmpty(rec.RewindSaveFileName);
-                if (hasRewindSave)
+                if (isFuture)
                 {
+                    // Future recording: FF button advances UT to recording start
+                    string ffReason;
+                    bool isRecording = InFlight && flight.IsRecording;
+                    bool canFF = RecordingStore.CanFastForward(rec, out ffReason, isRecording: isRecording);
+                    GUI.enabled = canFF;
+                    string tooltip = canFF
+                        ? "Fast-forward to this launch"
+                        : ffReason;
+                    if (GUILayout.Button(new GUIContent("FF", tooltip), GUILayout.Width(ColW_Rewind)))
+                        ShowFastForwardConfirmation(rec);
+                    GUI.enabled = true;
+                }
+                else if (hasRewindSave)
+                {
+                    // Past/active recording with save: R button loads quicksave
                     string rewindReason;
                     bool isRecording = InFlight && flight.IsRecording;
                     bool canRewind = RecordingStore.CanRewind(rec, out rewindReason, isRecording: isRecording);
                     GUI.enabled = canRewind;
-                    string label = isFuture ? "FF" : "R";
                     string tooltip = canRewind
-                        ? (isFuture ? "Fast-forward to this launch" : "Rewind to this launch")
+                        ? "Rewind to this launch"
                         : rewindReason;
-                    if (GUILayout.Button(new GUIContent(label, tooltip), GUILayout.Width(ColW_Rewind)))
+                    if (GUILayout.Button(new GUIContent("R", tooltip), GUILayout.Width(ColW_Rewind)))
                         ShowRewindConfirmation(rec);
                     GUI.enabled = true;
                 }
@@ -2292,6 +2306,45 @@ namespace Parsek
                     new DialogGUIButton("Cancel", () =>
                     {
                         ParsekLog.Info("Rewind", "User cancelled rewind confirmation");
+                    })
+                ),
+                false, HighLogic.UISkin);
+        }
+
+        private void ShowFastForwardConfirmation(Recording rec)
+        {
+            var ic = System.Globalization.CultureInfo.InvariantCulture;
+            double now = Planetarium.GetUniversalTime();
+            double delta = rec.StartUT - now;
+            string launchDate = KSPUtil.PrintDateCompact(rec.StartUT, true);
+            string message = string.Format(ic,
+                "Fast-forward to \"{0}\" launch at {1}?\n\nTime will advance by {2:F0} seconds.",
+                rec.VesselName, launchDate, delta);
+
+            var capturedRec = rec;
+            PopupDialog.SpawnPopupDialog(
+                new Vector2(0.5f, 0.5f),
+                new Vector2(0.5f, 0.5f),
+                new MultiOptionDialog(
+                    "ParsekFastForwardConfirm",
+                    message,
+                    "Confirm Fast-Forward",
+                    HighLogic.UISkin,
+                    new DialogGUIButton("Fast-Forward", () =>
+                    {
+                        ParsekLog.Info("FastForward",
+                            string.Format(ic,
+                                "User confirmed fast-forward to \"{0}\" at UT {1:F1}",
+                                capturedRec.VesselName, capturedRec.StartUT));
+                        if (InFlight && flight != null)
+                            flight.FastForwardToRecording(capturedRec);
+                        else
+                            ParsekLog.Warn("FastForward",
+                                "Fast-forward requires flight scene — aborted");
+                    }),
+                    new DialogGUIButton("Cancel", () =>
+                    {
+                        ParsekLog.Info("FastForward", "User cancelled fast-forward confirmation");
                     })
                 ),
                 false, HighLogic.UISkin);

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -2340,8 +2340,10 @@ namespace Parsek
                             flight.FastForwardToRecording(capturedRec);
                         else
                         {
-                            // KSC or other non-flight scene: advance UT directly
-                            // (no loaded vessels to rail, no recorder to notify)
+                            // KSC or other non-flight scene: advance UT directly.
+                            // Intentionally duplicates jump+message from FastForwardToRecording —
+                            // flight path has additional steps (NotifyRecorder, recorder state)
+                            // that don't apply outside flight.
                             double preJumpUT = Planetarium.GetUniversalTime();
                             double jumpDelta = capturedRec.StartUT - preJumpUT;
                             ParsekLog.Info("FastForward",

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -2339,8 +2339,21 @@ namespace Parsek
                         if (InFlight && flight != null)
                             flight.FastForwardToRecording(capturedRec);
                         else
-                            ParsekLog.Warn("FastForward",
-                                "Fast-forward requires flight scene — aborted");
+                        {
+                            // KSC or other non-flight scene: advance UT directly
+                            // (no loaded vessels to rail, no recorder to notify)
+                            double preJumpUT = Planetarium.GetUniversalTime();
+                            double jumpDelta = capturedRec.StartUT - preJumpUT;
+                            ParsekLog.Info("FastForward",
+                                string.Format(ic,
+                                    "Non-flight FF to UT={0:F1} for '{1}' (delta={2:F1}s)",
+                                    capturedRec.StartUT, capturedRec.VesselName, jumpDelta));
+                            TimeJumpManager.ExecuteForwardJump(capturedRec.StartUT);
+                            ParsekLog.ScreenMessage(
+                                string.Format(ic,
+                                    "Fast-forwarded to \"{0}\" ({1:F0}s)",
+                                    capturedRec.VesselName, jumpDelta), 3f);
+                        }
                     }),
                     new DialogGUIButton("Cancel", () =>
                     {

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -1356,17 +1356,6 @@ namespace Parsek
                 return false;
             }
 
-            double now = Planetarium.GetUniversalTime();
-            if (now >= rec.StartUT)
-            {
-                reason = "Recording is not in the future";
-                ParsekLog.Verbose("Store",
-                    string.Format(CultureInfo.InvariantCulture,
-                        "CanFastForward: blocked for '{0}' — {1} (now={2:F1} startUT={3:F1})",
-                        rec.VesselName, reason, now, rec.StartUT));
-                return false;
-            }
-
             if (isRecording)
             {
                 reason = "Stop recording before fast-forwarding";
@@ -1385,6 +1374,18 @@ namespace Parsek
             {
                 reason = "Merge or discard pending tree first";
                 ParsekLog.Verbose("Store", $"CanFastForward: blocked — {reason}");
+                return false;
+            }
+
+            // Timing check last — requires KSP runtime (Planetarium)
+            double now = Planetarium.GetUniversalTime();
+            if (now >= rec.StartUT)
+            {
+                reason = "Recording is not in the future";
+                ParsekLog.Verbose("Store",
+                    string.Format(CultureInfo.InvariantCulture,
+                        "CanFastForward: blocked for '{0}' — {1} (now={2:F1} startUT={3:F1})",
+                        rec.VesselName, reason, now, rec.StartUT));
                 return false;
             }
 

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -1337,6 +1337,62 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Validates whether the player can fast-forward to a future recording's start.
+        /// Subset of CanRewind — no save file required (FF advances UT, doesn't load a save).
+        /// </summary>
+        internal static bool CanFastForward(Recording rec, out string reason, bool isRecording)
+        {
+            if (IsRewinding)
+            {
+                reason = "Rewind already in progress";
+                ParsekLog.Verbose("Store", $"CanFastForward: blocked — {reason}");
+                return false;
+            }
+
+            if (rec == null || rec.Points.Count == 0)
+            {
+                reason = "Recording not available";
+                ParsekLog.Verbose("Store", $"CanFastForward: blocked — {reason}");
+                return false;
+            }
+
+            double now = Planetarium.GetUniversalTime();
+            if (now >= rec.StartUT)
+            {
+                reason = "Recording is not in the future";
+                ParsekLog.Verbose("Store",
+                    string.Format(CultureInfo.InvariantCulture,
+                        "CanFastForward: blocked for '{0}' — {1} (now={2:F1} startUT={3:F1})",
+                        rec.VesselName, reason, now, rec.StartUT));
+                return false;
+            }
+
+            if (isRecording)
+            {
+                reason = "Stop recording before fast-forwarding";
+                ParsekLog.Verbose("Store", $"CanFastForward: blocked — {reason}");
+                return false;
+            }
+
+            if (HasPending)
+            {
+                reason = "Merge or discard pending recording first";
+                ParsekLog.Verbose("Store", $"CanFastForward: blocked — {reason}");
+                return false;
+            }
+
+            if (HasPendingTree)
+            {
+                reason = "Merge or discard pending tree first";
+                ParsekLog.Verbose("Store", $"CanFastForward: blocked — {reason}");
+                return false;
+            }
+
+            reason = "";
+            return true;
+        }
+
+        /// <summary>
         /// Initiates a rewind to the given recording's launch point.
         /// Sets rewind flags, copies the save file to the root saves dir (KSP's LoadGame
         /// doesn't support subdirectory paths), loads it, then deletes the temp copy.

--- a/Source/Parsek/TimeJumpManager.cs
+++ b/Source/Parsek/TimeJumpManager.cs
@@ -512,7 +512,8 @@ namespace Parsek
             }
 
             int fixedCount = 0;
-            foreach (Vessel v in FlightGlobals.VesselsLoaded)
+            var vessels = new List<Vessel>(FlightGlobals.VesselsLoaded);
+            foreach (Vessel v in vessels)
             {
                 if (v == null || v.parts == null) continue;
 

--- a/Source/Parsek/TimeJumpManager.cs
+++ b/Source/Parsek/TimeJumpManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Reflection;
 using UnityEngine;
 
 namespace Parsek
@@ -373,6 +374,164 @@ namespace Parsek
                 string.Format(ic,
                     "TIME_JUMP SegmentEvent emitted for recording vessel pid={0} name={1}",
                     v.persistentId, v.vesselName));
+        }
+
+        /// <summary>
+        /// Executes a forward UT jump WITHOUT epoch-shifting orbits.
+        /// Unlike ExecuteJump (which freezes relative positions for Real Spawn Control),
+        /// this lets orbits propagate naturally — vessels advance along their Keplerian paths.
+        /// Used for the FF button to skip ahead to a future recording's start.
+        ///
+        /// After advancing UT, fixes ModuleResourceConverter.lastUpdateTime on all loaded
+        /// vessels to prevent burst resource production/consumption from the large time delta.
+        /// </summary>
+        internal static void ExecuteForwardJump(double targetUT)
+        {
+            double t0 = Planetarium.GetUniversalTime();
+            double jumpDelta = targetUT - t0;
+
+            if (!IsValidJump(t0, targetUT))
+            {
+                ParsekLog.Warn(Tag,
+                    string.Format(ic,
+                        "ExecuteForwardJump: invalid jump t0={0:F1} target={1:F1} — aborted",
+                        t0, targetUT));
+                return;
+            }
+
+            int objectCount = FlightGlobals.VesselsLoaded != null
+                ? FlightGlobals.VesselsLoaded.Count
+                : 0;
+
+            ParsekLog.Info(Tag,
+                string.Format(ic,
+                    "Forward jump initiated: T0={0:F1} target={1:F1} delta={2:F1}s objects={3}",
+                    t0, targetUT, jumpDelta, objectCount));
+
+            // Put in-physics vessels on rails temporarily so SetUniversalTime doesn't
+            // cause physics interactions during the jump
+            var onRailsVessels = new List<Vessel>();
+            if (FlightGlobals.VesselsLoaded != null)
+            {
+                foreach (Vessel v in FlightGlobals.VesselsLoaded)
+                {
+                    if (v == null) continue;
+                    if (!v.packed && v.loaded)
+                    {
+                        try
+                        {
+                            v.GoOnRails();
+                            onRailsVessels.Add(v);
+                            ParsekLog.Verbose(Tag,
+                                string.Format(ic,
+                                    "Put vessel on rails: pid={0} name={1}",
+                                    v.persistentId, v.vesselName));
+                        }
+                        catch (Exception ex)
+                        {
+                            ParsekLog.Warn(Tag,
+                                string.Format(ic,
+                                    "Failed to put vessel on rails: pid={0} name={1} error={2}",
+                                    v.persistentId, v.vesselName, ex.Message));
+                        }
+                    }
+                }
+            }
+
+            // Advance UT — orbits propagate naturally (no epoch shift)
+            Planetarium.SetUniversalTime(targetUT);
+
+            ParsekLog.Verbose(Tag,
+                string.Format(ic, "Forward jump: UT set to {0:F1}", targetUT));
+
+            // Fix resource converter timestamps to prevent burst production/consumption.
+            // BaseConverter.lastUpdateTime tracks when the converter last ran; after a large
+            // UT jump, converters see a massive deltaTime and drain/produce in one burst.
+            FixResourceConverterTimestamps(targetUT);
+
+            // Take vessels off rails
+            foreach (Vessel v in onRailsVessels)
+            {
+                if (v == null) continue;
+                try
+                {
+                    v.GoOffRails();
+                    ParsekLog.Verbose(Tag,
+                        string.Format(ic,
+                            "Took vessel off rails: pid={0} name={1}",
+                            v.persistentId, v.vesselName));
+                }
+                catch (Exception ex)
+                {
+                    ParsekLog.Warn(Tag,
+                        string.Format(ic,
+                            "Failed to take vessel off rails: pid={0} name={1} error={2}",
+                            v.persistentId, v.vesselName, ex.Message));
+                }
+            }
+
+            ParsekLog.Info(Tag,
+                string.Format(ic,
+                    "Forward jump complete: delta={0:F1}s, {1} vessels temporarily on-railed",
+                    jumpDelta, onRailsVessels.Count));
+        }
+
+        /// <summary>
+        /// Resets lastUpdateTime on all BaseConverter (ModuleResourceConverter) modules
+        /// across all loaded vessels to the given UT. This prevents converters from seeing
+        /// the full time jump delta and producing/consuming resources in a single burst.
+        /// lastUpdateTime is protected, so we use reflection.
+        /// </summary>
+        private static readonly FieldInfo lastUpdateTimeField =
+            typeof(BaseConverter).GetField("lastUpdateTime",
+                BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+
+        private static void FixResourceConverterTimestamps(double newUT)
+        {
+            if (FlightGlobals.VesselsLoaded == null) return;
+
+            if (lastUpdateTimeField == null)
+            {
+                ParsekLog.Warn(Tag,
+                    "FixResourceConverterTimestamps: lastUpdateTime field not found via reflection — skipping");
+                return;
+            }
+
+            int fixedCount = 0;
+            foreach (Vessel v in FlightGlobals.VesselsLoaded)
+            {
+                if (v == null || v.parts == null) continue;
+
+                foreach (Part p in v.parts)
+                {
+                    if (p == null || p.Modules == null) continue;
+
+                    for (int m = 0; m < p.Modules.Count; m++)
+                    {
+                        var converter = p.Modules[m] as BaseConverter;
+                        if (converter != null)
+                        {
+                            double oldTime = (double)lastUpdateTimeField.GetValue(converter);
+                            lastUpdateTimeField.SetValue(converter, newUT);
+                            fixedCount++;
+
+                            ParsekLog.Verbose(Tag,
+                                string.Format(ic,
+                                    "Fixed converter timestamp: vessel={0} part={1} module={2} old={3:F1} new={4:F1}",
+                                    v.vesselName, p.partInfo?.name ?? "?", converter.GetType().Name,
+                                    oldTime, newUT));
+                        }
+                    }
+                }
+            }
+
+            if (fixedCount > 0)
+            {
+                ParsekLog.Info(Tag,
+                    string.Format(ic,
+                        "Fixed {0} resource converter timestamp(s) to UT={1:F1}",
+                        fixedCount, newUT));
+            }
         }
     }
 }

--- a/Source/Parsek/TimeJumpManager.cs
+++ b/Source/Parsek/TimeJumpManager.cs
@@ -409,13 +409,27 @@ namespace Parsek
                     t0, targetUT, jumpDelta, objectCount));
 
             // Put in-physics vessels on rails temporarily so SetUniversalTime doesn't
-            // cause physics interactions during the jump
+            // cause physics interactions during the jump.
+            // Copy to list first — GoOnRails callbacks could mutate VesselsLoaded.
             var onRailsVessels = new List<Vessel>();
             if (FlightGlobals.VesselsLoaded != null)
             {
-                foreach (Vessel v in FlightGlobals.VesselsLoaded)
+                var loadedSnapshot = new List<Vessel>(FlightGlobals.VesselsLoaded);
+                foreach (Vessel v in loadedSnapshot)
                 {
                     if (v == null) continue;
+
+                    // Atmospheric warning: Keplerian propagation ignores drag,
+                    // vessel may end up underground after forward jump
+                    if (v.mainBody != null && v.mainBody.atmosphere &&
+                        v.altitude < v.mainBody.atmosphereDepth)
+                    {
+                        ParsekLog.Warn(Tag,
+                            string.Format(ic,
+                                "WARNING: vessel '{0}' is in atmosphere — orbit propagation is approximate",
+                                v.vesselName));
+                    }
+
                     if (!v.packed && v.loaded)
                     {
                         try

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1256,3 +1256,8 @@ When a spawn is permanently blocked by an immovable vessel (e.g., a landed spawn
 **Priority:** High
 
 **Status:** Open
+
+# In-Game Tests
+
+- [ ] Vessels propagate naturally along orbits after FF (no position freezing)
+- [ ] Resource converters don't burst after FF jump

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1238,3 +1238,21 @@ Likely cause: `CheckEngineTransition` may not detect the `EngineIgnited → fals
 **Priority:** Medium — ghost engines keep burning past cutoff, visually incorrect
 
 **Status:** Open
+
+## 109. Missing CleanupOrphanedSpawnedVessels on second Rewind flight-ready
+
+After a second Rewind, `CleanupOrphanedSpawnedVessels` does not run, leaving a previously-spawned vessel in the scene at the spawn coordinates. The first Rewind correctly recovers the old spawned vessel, but the second one skips cleanup entirely. This leaves a stale vessel that blocks future spawns at that location.
+
+**Priority:** High
+
+**Status:** Open
+
+## 110. Spawn collision retry has no limit — infinite loop on permanent overlap
+
+When a spawn is permanently blocked by an immovable vessel (e.g., a landed spawned vessel from a previous cycle that wasn't cleaned up), the spawn retry loop runs every frame indefinitely (~8ms per retry). In one test session this produced 6,270 retries over 27 seconds, flooding ~24,000 lines into KSP.log until the user exited to the main menu. There is no retry limit, timeout, or backoff.
+
+**Fix approach:** Add a maximum retry count (e.g., 60 retries = ~1 second at 60fps). After exhausting retries, log a warning and either skip the spawn or force-spawn at an offset position.
+
+**Priority:** High
+
+**Status:** Open

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1197,15 +1197,13 @@ Fix: disambiguate with a launch number suffix. Check existing group names via `R
 
 ## 105. Colored bubbles visible in ghost engine plume FX
 
-Ghost engine plumes show colored bubble/sphere artifacts instead of smooth exhaust trails. Most likely cause: KSP FX controller components (`ModelMultiParticlePersistFX`, `KSPParticleEmitter`) survive the `Object.Instantiate` clone and interfere with particle system state at runtime. `ConfigureGhostEngineParticleSystems` (GhostVisualBuilder.cs:919) correctly configures the cloned systems, but surviving KSP components may re-initialize materials or override emission shape afterward.
+Ghost engine plumes show colored bubble/sphere artifacts instead of smooth exhaust trails. Root cause: `KSPParticleEmitter` (actual class name, not `ModelMultiParticlePersistFX` as originally noted) survives `Object.Instantiate`. Its `Awake()` marks `dirty=true`, then `Update()` calls `SetupProperties()` which overwrites renderer materials, colors, and renderMode on the cloned particle systems.
 
-The code only strips `SmokeTrailControl` (lines 2305, 2335, 2501) but does not strip other KSP FX management components. A secondary possibility: `TextureSheetAnimation` UV state lost if materials are cloned or replaced after instantiation, causing particles to render the full sprite atlas as a colored circle.
-
-**Fix approach:** Strip all `ModelMultiParticlePersistFX` and `KSPParticleEmitter` components from the cloned FX hierarchy after instantiation (similar to `SmokeTrailControl` stripping). Verify `ParticleSystemRenderer.renderMode` is `Billboard` or `StretchedBillboard` (not `Mesh`).
+Fix: `StripKspFxControllers` helper strips `KSPParticleEmitter`, `ModelMultiParticleFX`, `ModelParticleFX`, `SmokeTrailControl`, and `FXPrefab` from all 5 FX clone sites (engine legacy, engine model, engine prefab, RCS). Previously only `SmokeTrailControl` was stripped at 3 of 5 sites.
 
 **Priority:** Medium — visually distracting on every engine ghost
 
-**Status:** Open
+**Status:** Fixed
 
 ## 106. Watch mode camera follows booster instead of main vessel at BREAKUP
 


### PR DESCRIPTION
## Summary

- **FF button** in Recordings window now does an instant UT jump forward instead of loading a quicksave (which is what Rewind does)
- Adds `ExecuteForwardJump` in TimeJumpManager — advances UT via `SetUniversalTime` without epoch-shifting (orbits propagate naturally, unlike Real Spawn Control warp)
- Fixes `BaseConverter.lastUpdateTime` via reflection after the jump to prevent burst resource production/consumption
- Puts in-physics vessels temporarily on rails during the jump
- Keeps current view (KSC stays KSC, flight stays on current vessel)

## Changes

- `RecordingStore.cs`: Add `CanFastForward()` validation (no save file required, checks recording is future)
- `TimeJumpManager.cs`: Add `ExecuteForwardJump()` + `FixResourceConverterTimestamps()`
- `ParsekFlight.cs`: Add `FastForwardToRecording()` entry point
- `ParsekUI.cs`: Split FF/R button into separate code paths with dedicated `ShowFastForwardConfirmation` dialog

## Test plan

- [x] In-game: verify FF button appears for future recordings, R for past
- [x] In-game: FF advances UT and keeps current view (no scene switch)
- [ ] In-game: vessels propagate naturally along orbits after FF (no position freezing)
- [x] In-game: R button still loads quicksave as before
- [ ] In-game: resource converters don't burst after FF jump