### PR TITLE
Fix compound part ghost visuals (fuel lines, struts)

### DIFF
--- a/Source/Parsek.Tests/CompoundPartDataTests.cs
+++ b/Source/Parsek.Tests/CompoundPartDataTests.cs
@@ -23,10 +23,25 @@ namespace Parsek.Tests
             ParsekLog.SuppressLogging = true;
         }
 
+        private static ConfigNode MakeLinkedMeshConfig(string lineObjName = "obj_line",
+            string targetAnchorName = null, string targetCapName = null)
+        {
+            var partConfig = new ConfigNode("PART");
+            var module = partConfig.AddNode("MODULE");
+            module.AddValue("name", "CModuleLinkedMesh");
+            module.AddValue("lineObjName", lineObjName);
+            if (targetAnchorName != null)
+                module.AddValue("targetAnchorName", targetAnchorName);
+            if (targetCapName != null)
+                module.AddValue("targetCapName", targetCapName);
+            return partConfig;
+        }
+
         [Fact]
-        public void NoPARTDATA_NonCompoundPart_ReturnsFalse_NoLog()
+        public void NoCModuleLinkedMesh_ReturnsFalse_NoLog()
         {
             var partNode = new ConfigNode("PART");
+            partNode.AddNode("PARTDATA").AddValue("pos", "1,2,3");
 
             bool result = GhostVisualBuilder.TryParseCompoundPartData(
                 partNode, null, isCompoundPart: false, 12345, "fuelTank", out _);
@@ -41,7 +56,7 @@ namespace Parsek.Tests
             var partNode = new ConfigNode("PART");
 
             bool result = GhostVisualBuilder.TryParseCompoundPartData(
-                partNode, null, isCompoundPart: true, 12345, "fuelLine", out _);
+                partNode, MakeLinkedMeshConfig(), isCompoundPart: true, 12345, "fuelLine", out _);
 
             Assert.False(result);
             Assert.Contains(logLines, l =>
@@ -59,7 +74,7 @@ namespace Parsek.Tests
             partNode.AddNode("PARTDATA");
 
             bool result = GhostVisualBuilder.TryParseCompoundPartData(
-                partNode, null, isCompoundPart: true, 99999, "strutConnector", out _);
+                partNode, MakeLinkedMeshConfig(), isCompoundPart: true, 99999, "strutConnector", out _);
 
             Assert.False(result);
             Assert.Contains(logLines, l =>
@@ -77,7 +92,7 @@ namespace Parsek.Tests
             partData.AddValue("pos", "not,a,vector,really");
 
             bool result = GhostVisualBuilder.TryParseCompoundPartData(
-                partNode, null, isCompoundPart: true, 55555, "fuelLine", out _);
+                partNode, MakeLinkedMeshConfig(), isCompoundPart: true, 55555, "fuelLine", out _);
 
             Assert.False(result);
             Assert.Contains(logLines, l =>
@@ -94,7 +109,7 @@ namespace Parsek.Tests
 
             CompoundPartData data;
             bool result = GhostVisualBuilder.TryParseCompoundPartData(
-                partNode, null, isCompoundPart: true, 12345, "fuelLine", out data);
+                partNode, MakeLinkedMeshConfig(), isCompoundPart: true, 12345, "fuelLine", out data);
 
             Assert.True(result);
             Assert.Equal(Quaternion.identity, data.targetRot);
@@ -114,7 +129,7 @@ namespace Parsek.Tests
 
             CompoundPartData data;
             bool result = GhostVisualBuilder.TryParseCompoundPartData(
-                partNode, null, isCompoundPart: true, 1306106500, "fuelLine", out data);
+                partNode, MakeLinkedMeshConfig(), isCompoundPart: true, 1306106500, "fuelLine", out data);
 
             Assert.True(result);
             Assert.InRange(data.targetPos.x, -0.224f, -0.223f);
@@ -122,12 +137,11 @@ namespace Parsek.Tests
             Assert.InRange(data.targetPos.z, 0.080f, 0.082f);
             Assert.InRange(data.targetRot.y, 0.499f, 0.501f);
             Assert.InRange(data.targetRot.w, 0.865f, 0.867f);
-            // No warning/skip logs — only a rot-missing log would appear, and rot is present
             Assert.DoesNotContain(logLines, l => l.Contains("skipped") || l.Contains("WARNING"));
         }
 
         [Fact]
-        public void PARTDATA_DefaultTransformNames_WhenNoPartConfig()
+        public void PARTDATA_DefaultTransformNames_WhenNoOverrides()
         {
             var partNode = new ConfigNode("PART");
             var partData = partNode.AddNode("PARTDATA");
@@ -136,7 +150,7 @@ namespace Parsek.Tests
 
             CompoundPartData data;
             GhostVisualBuilder.TryParseCompoundPartData(
-                partNode, null, isCompoundPart: false, 100, "fuelLine", out data);
+                partNode, MakeLinkedMeshConfig(), isCompoundPart: false, 100, "fuelLine", out data);
 
             Assert.Equal("obj_line", data.lineObjName);
             Assert.Equal("obj_targetAnchor", data.targetAnchorName);
@@ -151,12 +165,7 @@ namespace Parsek.Tests
             partData.AddValue("pos", "1,2,3");
             partData.AddValue("rot", "0,0,0,1");
 
-            var partConfig = new ConfigNode("PART");
-            var module = partConfig.AddNode("MODULE");
-            module.AddValue("name", "CModuleLinkedMesh");
-            module.AddValue("lineObjName", "obj_strut");
-            module.AddValue("targetAnchorName", "obj_custom_anchor");
-            module.AddValue("targetCapName", "obj_custom_cap");
+            var partConfig = MakeLinkedMeshConfig("obj_strut", "obj_custom_anchor", "obj_custom_cap");
 
             CompoundPartData data;
             bool result = GhostVisualBuilder.TryParseCompoundPartData(
@@ -176,11 +185,7 @@ namespace Parsek.Tests
             partData.AddValue("pos", "1,2,3");
             partData.AddValue("rot", "0,0,0,1");
 
-            // Config with CModuleLinkedMesh that only specifies lineObjName
-            var partConfig = new ConfigNode("PART");
-            var module = partConfig.AddNode("MODULE");
-            module.AddValue("name", "CModuleLinkedMesh");
-            module.AddValue("lineObjName", "obj_strut");
+            var partConfig = MakeLinkedMeshConfig("obj_strut");
 
             CompoundPartData data;
             GhostVisualBuilder.TryParseCompoundPartData(

--- a/Source/Parsek.Tests/CompoundPartDataTests.cs
+++ b/Source/Parsek.Tests/CompoundPartDataTests.cs
@@ -1,0 +1,194 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    [Collection("Sequential")]
+    public class CompoundPartDataTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public CompoundPartDataTests()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+        }
+
+        [Fact]
+        public void NoPARTDATA_NonCompoundPart_ReturnsFalse_NoLog()
+        {
+            var partNode = new ConfigNode("PART");
+
+            bool result = GhostVisualBuilder.TryParseCompoundPartData(
+                partNode, null, isCompoundPart: false, 12345, "fuelTank", out _);
+
+            Assert.False(result);
+            Assert.Empty(logLines);
+        }
+
+        [Fact]
+        public void NoPARTDATA_CompoundPart_ReturnsFalse_LogsWarning()
+        {
+            var partNode = new ConfigNode("PART");
+
+            bool result = GhostVisualBuilder.TryParseCompoundPartData(
+                partNode, null, isCompoundPart: true, 12345, "fuelLine", out _);
+
+            Assert.False(result);
+            Assert.Contains(logLines, l =>
+                l.Contains("[GhostVisual]") &&
+                l.Contains("CompoundPart fixup WARNING") &&
+                l.Contains("fuelLine") &&
+                l.Contains("12345") &&
+                l.Contains("no PARTDATA node"));
+        }
+
+        [Fact]
+        public void PARTDATA_MissingPos_ReturnsFalse_LogsSkip()
+        {
+            var partNode = new ConfigNode("PART");
+            partNode.AddNode("PARTDATA");
+
+            bool result = GhostVisualBuilder.TryParseCompoundPartData(
+                partNode, null, isCompoundPart: true, 99999, "strutConnector", out _);
+
+            Assert.False(result);
+            Assert.Contains(logLines, l =>
+                l.Contains("[GhostVisual]") &&
+                l.Contains("CompoundPart fixup skipped") &&
+                l.Contains("strutConnector") &&
+                l.Contains("no parseable 'pos'"));
+        }
+
+        [Fact]
+        public void PARTDATA_UnparseablePos_ReturnsFalse_LogsSkip()
+        {
+            var partNode = new ConfigNode("PART");
+            var partData = partNode.AddNode("PARTDATA");
+            partData.AddValue("pos", "not,a,vector,really");
+
+            bool result = GhostVisualBuilder.TryParseCompoundPartData(
+                partNode, null, isCompoundPart: true, 55555, "fuelLine", out _);
+
+            Assert.False(result);
+            Assert.Contains(logLines, l =>
+                l.Contains("CompoundPart fixup skipped") &&
+                l.Contains("no parseable 'pos'"));
+        }
+
+        [Fact]
+        public void PARTDATA_ValidPos_MissingRot_ReturnsTrue_DefaultsToIdentity_Logs()
+        {
+            var partNode = new ConfigNode("PART");
+            var partData = partNode.AddNode("PARTDATA");
+            partData.AddValue("pos", "-0.224, -0.054, 0.081");
+
+            CompoundPartData data;
+            bool result = GhostVisualBuilder.TryParseCompoundPartData(
+                partNode, null, isCompoundPart: true, 12345, "fuelLine", out data);
+
+            Assert.True(result);
+            Assert.Equal(Quaternion.identity, data.targetRot);
+            Assert.Contains(logLines, l =>
+                l.Contains("[GhostVisual]") &&
+                l.Contains("no parseable 'rot'") &&
+                l.Contains("defaulting to identity"));
+        }
+
+        [Fact]
+        public void PARTDATA_ValidPosAndRot_ReturnsTrue_ParsesCorrectly()
+        {
+            var partNode = new ConfigNode("PART");
+            var partData = partNode.AddNode("PARTDATA");
+            partData.AddValue("pos", "-0.223904356,-0.0542270504,0.0808728784");
+            partData.AddValue("rot", "0,0.499999911,6.29212309E-08,0.866025448");
+
+            CompoundPartData data;
+            bool result = GhostVisualBuilder.TryParseCompoundPartData(
+                partNode, null, isCompoundPart: true, 1306106500, "fuelLine", out data);
+
+            Assert.True(result);
+            Assert.InRange(data.targetPos.x, -0.224f, -0.223f);
+            Assert.InRange(data.targetPos.y, -0.055f, -0.054f);
+            Assert.InRange(data.targetPos.z, 0.080f, 0.082f);
+            Assert.InRange(data.targetRot.y, 0.499f, 0.501f);
+            Assert.InRange(data.targetRot.w, 0.865f, 0.867f);
+            // No warning/skip logs — only a rot-missing log would appear, and rot is present
+            Assert.DoesNotContain(logLines, l => l.Contains("skipped") || l.Contains("WARNING"));
+        }
+
+        [Fact]
+        public void PARTDATA_DefaultTransformNames_WhenNoPartConfig()
+        {
+            var partNode = new ConfigNode("PART");
+            var partData = partNode.AddNode("PARTDATA");
+            partData.AddValue("pos", "1,2,3");
+            partData.AddValue("rot", "0,0,0,1");
+
+            CompoundPartData data;
+            GhostVisualBuilder.TryParseCompoundPartData(
+                partNode, null, isCompoundPart: false, 100, "fuelLine", out data);
+
+            Assert.Equal("obj_line", data.lineObjName);
+            Assert.Equal("obj_targetAnchor", data.targetAnchorName);
+            Assert.Equal("obj_targetCap", data.targetCapName);
+        }
+
+        [Fact]
+        public void PARTDATA_ReadsTransformNames_FromCModuleLinkedMeshConfig()
+        {
+            var partNode = new ConfigNode("PART");
+            var partData = partNode.AddNode("PARTDATA");
+            partData.AddValue("pos", "1,2,3");
+            partData.AddValue("rot", "0,0,0,1");
+
+            var partConfig = new ConfigNode("PART");
+            var module = partConfig.AddNode("MODULE");
+            module.AddValue("name", "CModuleLinkedMesh");
+            module.AddValue("lineObjName", "obj_strut");
+            module.AddValue("targetAnchorName", "obj_custom_anchor");
+            module.AddValue("targetCapName", "obj_custom_cap");
+
+            CompoundPartData data;
+            bool result = GhostVisualBuilder.TryParseCompoundPartData(
+                partNode, partConfig, isCompoundPart: true, 200, "strutConnector", out data);
+
+            Assert.True(result);
+            Assert.Equal("obj_strut", data.lineObjName);
+            Assert.Equal("obj_custom_anchor", data.targetAnchorName);
+            Assert.Equal("obj_custom_cap", data.targetCapName);
+        }
+
+        [Fact]
+        public void PARTDATA_PartialLinkedMeshConfig_KeepsDefaults()
+        {
+            var partNode = new ConfigNode("PART");
+            var partData = partNode.AddNode("PARTDATA");
+            partData.AddValue("pos", "1,2,3");
+            partData.AddValue("rot", "0,0,0,1");
+
+            // Config with CModuleLinkedMesh that only specifies lineObjName
+            var partConfig = new ConfigNode("PART");
+            var module = partConfig.AddNode("MODULE");
+            module.AddValue("name", "CModuleLinkedMesh");
+            module.AddValue("lineObjName", "obj_strut");
+
+            CompoundPartData data;
+            GhostVisualBuilder.TryParseCompoundPartData(
+                partNode, partConfig, isCompoundPart: true, 300, "strutConnector", out data);
+
+            Assert.Equal("obj_strut", data.lineObjName);
+            Assert.Equal("obj_targetAnchor", data.targetAnchorName);
+            Assert.Equal("obj_targetCap", data.targetCapName);
+        }
+    }
+}

--- a/Source/Parsek/GhostTypes.cs
+++ b/Source/Parsek/GhostTypes.cs
@@ -187,6 +187,15 @@ namespace Parsek
         public List<(string key, string value)> properties;
     }
 
+    internal struct CompoundPartData
+    {
+        public Vector3 targetPos;
+        public Quaternion targetRot;
+        public string lineObjName;
+        public string targetAnchorName;
+        public string targetCapName;
+    }
+
     /// <summary>
     /// Bundles all output from BuildTimelineGhostFromSnapshot: the root GameObject
     /// plus per-module-type ghost info lists. Replaces the previous 10 out-parameters.

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -5519,6 +5519,119 @@ namespace Parsek
 
         #endregion
 
+        /// <summary>
+        /// Fixes up compound part visuals (fuel lines, struts) by repositioning the
+        /// target anchor and stretching the line mesh using PARTDATA from the snapshot.
+        /// In KSP, CModuleLinkedMesh handles this at runtime; ghosts need manual fixup.
+        /// </summary>
+        private static void TryFixupCompoundPartVisuals(
+            Part prefab, ConfigNode partNode, Transform partRoot,
+            Transform prefabModelRoot, Transform ghostModelNode,
+            Dictionary<Transform, Transform> cloneMap,
+            uint persistentId, string partName)
+        {
+            // Compound parts store target connection data in PARTDATA
+            ConfigNode partData = partNode.GetNode("PARTDATA");
+            if (partData == null) return;
+
+            Vector3 targetPos;
+            if (!TryParseVector3(partData.GetValue("pos"), out targetPos))
+            {
+                ParsekLog.Verbose("GhostVisual", $"  CompoundPart fixup skipped: '{partName}' pid={persistentId} " +
+                    $"PARTDATA has no parseable 'pos'");
+                return;
+            }
+
+            Quaternion targetRot;
+            if (!TryParseQuaternion(partData.GetValue("rot"), out targetRot))
+                targetRot = Quaternion.identity;
+
+            // Read transform names from CModuleLinkedMesh part config (varies: fuel line
+            // uses obj_line, strut uses obj_strut).
+            string lineObjName = "obj_line";
+            string targetAnchorName = "obj_targetAnchor";
+            string targetCapName = "obj_targetCap";
+
+            ConfigNode partConfig = prefab.partInfo?.partConfig;
+            if (partConfig != null)
+            {
+                ConfigNode[] modules = partConfig.GetNodes("MODULE");
+                for (int m = 0; m < modules.Length; m++)
+                {
+                    if (modules[m].GetValue("name") == "CModuleLinkedMesh")
+                    {
+                        lineObjName = modules[m].GetValue("lineObjName") ?? lineObjName;
+                        targetAnchorName = modules[m].GetValue("targetAnchorName") ?? targetAnchorName;
+                        targetCapName = modules[m].GetValue("targetCapName") ?? targetCapName;
+                        break;
+                    }
+                }
+            }
+
+            // Find source transforms on prefab, then look up ghost clones in cloneMap
+            Transform srcLine = prefab.FindModelTransform(lineObjName);
+            Transform srcTargetAnchor = prefab.FindModelTransform(targetAnchorName);
+            Transform srcTargetCap = prefab.FindModelTransform(targetCapName);
+
+            Transform ghostLine = null, ghostTargetAnchor = null, ghostTargetCap = null;
+            if (srcLine != null) cloneMap.TryGetValue(srcLine, out ghostLine);
+            if (srcTargetAnchor != null) cloneMap.TryGetValue(srcTargetAnchor, out ghostTargetAnchor);
+            if (srcTargetCap != null) cloneMap.TryGetValue(srcTargetCap, out ghostTargetCap);
+
+            if (ghostLine == null)
+            {
+                ParsekLog.Verbose("GhostVisual", $"  CompoundPart fixup skipped: '{partName}' pid={persistentId} " +
+                    $"line transform '{lineObjName}' not in cloneMap " +
+                    $"(srcLine={(srcLine != null ? "found" : "null")})");
+                return;
+            }
+
+            // PARTDATA.pos is in compound part local space (= partRoot space).
+            // Move target anchor to the correct position — endCap is a child, moves with it.
+            if (ghostTargetAnchor != null)
+            {
+                ghostTargetAnchor.position = partRoot.TransformPoint(targetPos);
+                ghostTargetAnchor.rotation = partRoot.rotation * targetRot;
+            }
+
+            // Stretch line mesh from its position to the target end.
+            // Mirrors CModuleLinkedMesh.TrackAnchor: LookRotation + Z-scale.
+            Vector3 lineWorldPos = ghostLine.position;
+            Vector3 targetWorldPos;
+            if (ghostTargetCap != null)
+                targetWorldPos = ghostTargetCap.position;
+            else if (ghostTargetAnchor != null)
+                targetWorldPos = ghostTargetAnchor.position;
+            else
+                targetWorldPos = partRoot.TransformPoint(targetPos);
+
+            Vector3 delta = lineWorldPos - targetWorldPos;
+            float distance = delta.magnitude;
+            const float lineMinimumLength = 0.01f;
+
+            if (distance > lineMinimumLength)
+            {
+                ghostLine.rotation = Quaternion.LookRotation(delta.normalized, partRoot.forward);
+                ghostLine.localScale = new Vector3(
+                    ghostLine.localScale.x,
+                    ghostLine.localScale.y,
+                    distance * prefab.scaleFactor);
+
+                if (ghostTargetCap != null)
+                    ghostTargetCap.rotation = ghostLine.rotation;
+
+                ParsekLog.Verbose("GhostVisual", $"  CompoundPart fixup: '{partName}' pid={persistentId} " +
+                    $"line='{lineObjName}' targetPos={targetPos} distance={distance:F3} " +
+                    $"scaleFactor={prefab.scaleFactor} zScale={(distance * prefab.scaleFactor):F3}");
+            }
+            else
+            {
+                ghostLine.gameObject.SetActive(false);
+                ParsekLog.Verbose("GhostVisual", $"  CompoundPart fixup: '{partName}' pid={persistentId} " +
+                    $"line hidden (distance={distance:F4} < {lineMinimumLength})");
+            }
+        }
+
         private static bool AddPartVisuals(Transform root, ConfigNode partNode, Part prefab,
             uint persistentId, string partName, out int meshCount,
             out ParachuteGhostInfo parachuteInfo, out JettisonGhostInfo jettisonInfo,
@@ -5774,6 +5887,11 @@ namespace Parsek
                         $"applied {applied} variant texture properties");
                 }
             }
+
+            // Fix up compound part visuals (fuel lines, struts) — CModuleLinkedMesh
+            // normally stretches the line mesh at runtime; ghosts need manual fixup.
+            TryFixupCompoundPartVisuals(prefab, partNode, partRoot.transform,
+                modelRoot, modelNode.transform, cloneMap, persistentId, partName);
 
             // Detect parachute parts via cloneMap (after cloneMap is fully populated)
             ModuleParachute chute = prefab.FindModuleImplementing<ModuleParachute>();

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -5534,6 +5534,70 @@ namespace Parsek
         #endregion
 
         /// <summary>
+        /// Parses compound part target data from a snapshot PART node.
+        /// Returns false (no-op) for non-compound parts or corrupt data.
+        /// Pure method — no Unity Transform access, directly testable.
+        /// </summary>
+        internal static bool TryParseCompoundPartData(
+            ConfigNode partNode, ConfigNode partConfig, bool isCompoundPart,
+            uint persistentId, string partName,
+            out CompoundPartData data)
+        {
+            data = new CompoundPartData
+            {
+                lineObjName = "obj_line",
+                targetAnchorName = "obj_targetAnchor",
+                targetCapName = "obj_targetCap"
+            };
+
+            ConfigNode partData = partNode.GetNode("PARTDATA");
+            if (partData == null)
+            {
+                // Expected no-op for non-compound parts. Log if the prefab IS a compound
+                // part — that would indicate corrupt/missing snapshot data.
+                if (isCompoundPart)
+                {
+                    ParsekLog.Verbose("GhostVisual", $"  CompoundPart fixup WARNING: '{partName}' pid={persistentId} " +
+                        $"is a CompoundPart but snapshot has no PARTDATA node");
+                }
+                return false;
+            }
+
+            if (!TryParseVector3(partData.GetValue("pos"), out data.targetPos))
+            {
+                ParsekLog.Verbose("GhostVisual", $"  CompoundPart fixup skipped: '{partName}' pid={persistentId} " +
+                    $"PARTDATA has no parseable 'pos'");
+                return false;
+            }
+
+            if (!TryParseQuaternion(partData.GetValue("rot"), out data.targetRot))
+            {
+                data.targetRot = Quaternion.identity;
+                ParsekLog.Verbose("GhostVisual", $"  CompoundPart fixup: '{partName}' pid={persistentId} " +
+                    $"PARTDATA has no parseable 'rot', defaulting to identity");
+            }
+
+            // Read transform names from CModuleLinkedMesh part config (varies: fuel line
+            // uses obj_line, strut uses obj_strut).
+            if (partConfig != null)
+            {
+                ConfigNode[] modules = partConfig.GetNodes("MODULE");
+                for (int m = 0; m < modules.Length; m++)
+                {
+                    if (modules[m].GetValue("name") == "CModuleLinkedMesh")
+                    {
+                        data.lineObjName = modules[m].GetValue("lineObjName") ?? data.lineObjName;
+                        data.targetAnchorName = modules[m].GetValue("targetAnchorName") ?? data.targetAnchorName;
+                        data.targetCapName = modules[m].GetValue("targetCapName") ?? data.targetCapName;
+                        break;
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
         /// Fixes up compound part visuals (fuel lines, struts) by repositioning the
         /// target anchor and stretching the line mesh using PARTDATA from the snapshot.
         /// In KSP, CModuleLinkedMesh handles this at runtime; ghosts need manual fixup.
@@ -5543,58 +5607,15 @@ namespace Parsek
             Dictionary<Transform, Transform> cloneMap,
             uint persistentId, string partName)
         {
-            // Compound parts store target connection data in PARTDATA
-            ConfigNode partData = partNode.GetNode("PARTDATA");
-            if (partData == null)
-            {
-                // Expected no-op for non-compound parts. Log if the prefab IS a compound
-                // part — that would indicate corrupt/missing snapshot data.
-                if (prefab is CompoundPart)
-                {
-                    ParsekLog.Verbose("GhostVisual", $"  CompoundPart fixup WARNING: '{partName}' pid={persistentId} " +
-                        $"is a CompoundPart but snapshot has no PARTDATA node");
-                }
+            CompoundPartData data;
+            if (!TryParseCompoundPartData(partNode, prefab.partInfo?.partConfig,
+                    prefab is CompoundPart, persistentId, partName, out data))
                 return;
-            }
-
-            Vector3 targetPos;
-            if (!TryParseVector3(partData.GetValue("pos"), out targetPos))
-            {
-                ParsekLog.Verbose("GhostVisual", $"  CompoundPart fixup skipped: '{partName}' pid={persistentId} " +
-                    $"PARTDATA has no parseable 'pos'");
-                return;
-            }
-
-            Quaternion targetRot;
-            if (!TryParseQuaternion(partData.GetValue("rot"), out targetRot))
-                targetRot = Quaternion.identity;
-
-            // Read transform names from CModuleLinkedMesh part config (varies: fuel line
-            // uses obj_line, strut uses obj_strut).
-            string lineObjName = "obj_line";
-            string targetAnchorName = "obj_targetAnchor";
-            string targetCapName = "obj_targetCap";
-
-            ConfigNode partConfig = prefab.partInfo?.partConfig;
-            if (partConfig != null)
-            {
-                ConfigNode[] modules = partConfig.GetNodes("MODULE");
-                for (int m = 0; m < modules.Length; m++)
-                {
-                    if (modules[m].GetValue("name") == "CModuleLinkedMesh")
-                    {
-                        lineObjName = modules[m].GetValue("lineObjName") ?? lineObjName;
-                        targetAnchorName = modules[m].GetValue("targetAnchorName") ?? targetAnchorName;
-                        targetCapName = modules[m].GetValue("targetCapName") ?? targetCapName;
-                        break;
-                    }
-                }
-            }
 
             // Find source transforms on prefab, then look up ghost clones in cloneMap
-            Transform srcLine = prefab.FindModelTransform(lineObjName);
-            Transform srcTargetAnchor = prefab.FindModelTransform(targetAnchorName);
-            Transform srcTargetCap = prefab.FindModelTransform(targetCapName);
+            Transform srcLine = prefab.FindModelTransform(data.lineObjName);
+            Transform srcTargetAnchor = prefab.FindModelTransform(data.targetAnchorName);
+            Transform srcTargetCap = prefab.FindModelTransform(data.targetCapName);
 
             Transform ghostLine = null, ghostTargetAnchor = null, ghostTargetCap = null;
             if (srcLine != null) cloneMap.TryGetValue(srcLine, out ghostLine);
@@ -5604,7 +5625,7 @@ namespace Parsek
             if (ghostLine == null)
             {
                 ParsekLog.Verbose("GhostVisual", $"  CompoundPart fixup skipped: '{partName}' pid={persistentId} " +
-                    $"line transform '{lineObjName}' not in cloneMap " +
+                    $"line transform '{data.lineObjName}' not in cloneMap " +
                     $"(srcLine={(srcLine != null ? "found" : "null")})");
                 return;
             }
@@ -5613,8 +5634,8 @@ namespace Parsek
             // Move target anchor to the correct position — endCap is a child, moves with it.
             if (ghostTargetAnchor != null)
             {
-                ghostTargetAnchor.position = partRoot.TransformPoint(targetPos);
-                ghostTargetAnchor.rotation = partRoot.rotation * targetRot;
+                ghostTargetAnchor.position = partRoot.TransformPoint(data.targetPos);
+                ghostTargetAnchor.rotation = partRoot.rotation * data.targetRot;
             }
 
             // Stretch line mesh from its position to the target end.
@@ -5626,7 +5647,7 @@ namespace Parsek
             else if (ghostTargetAnchor != null)
                 targetWorldPos = ghostTargetAnchor.position;
             else
-                targetWorldPos = partRoot.TransformPoint(targetPos);
+                targetWorldPos = partRoot.TransformPoint(data.targetPos);
 
             // NOTE: delta points from target toward source (line - target), matching
             // CModuleLinkedMesh.TrackAnchor which computes (line.position - endCap.position).
@@ -5639,6 +5660,9 @@ namespace Parsek
             if (distance > lineMinimumLength)
             {
                 ghostLine.rotation = Quaternion.LookRotation(delta.normalized, partRoot.forward);
+                // prefab.scaleFactor is the stock prefab value (typically rescaleFactor, default
+                // 1.25). Mods like TweakScale may change scaleFactor on the live part, but the
+                // prefab retains the original value — acceptable for ghost visuals.
                 ghostLine.localScale = new Vector3(
                     ghostLine.localScale.x,
                     ghostLine.localScale.y,
@@ -5648,7 +5672,7 @@ namespace Parsek
                     ghostTargetCap.rotation = ghostLine.rotation;
 
                 ParsekLog.Verbose("GhostVisual", $"  CompoundPart fixup: '{partName}' pid={persistentId} " +
-                    $"line='{lineObjName}' targetPos={targetPos} distance={distance:F3} " +
+                    $"line='{data.lineObjName}' targetPos={data.targetPos} distance={distance:F3} " +
                     $"scaleFactor={prefab.scaleFactor} zScale={(distance * prefab.scaleFactor):F3}");
             }
             else

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -5533,6 +5533,18 @@ namespace Parsek
 
         #endregion
 
+        private static bool HasCModuleLinkedMesh(ConfigNode partConfig)
+        {
+            if (partConfig == null) return false;
+            ConfigNode[] modules = partConfig.GetNodes("MODULE");
+            for (int m = 0; m < modules.Length; m++)
+            {
+                if (modules[m].GetValue("name") == "CModuleLinkedMesh")
+                    return true;
+            }
+            return false;
+        }
+
         /// <summary>
         /// Parses compound part target data from a snapshot PART node.
         /// Returns false (no-op) for non-compound parts or corrupt data.
@@ -5549,6 +5561,11 @@ namespace Parsek
                 targetAnchorName = "obj_targetAnchor",
                 targetCapName = "obj_targetCap"
             };
+
+            // Only process parts that have CModuleLinkedMesh — avoids false positives
+            // from non-compound parts that happen to have a PARTDATA node.
+            if (!HasCModuleLinkedMesh(partConfig))
+                return false;
 
             ConfigNode partData = partNode.GetNode("PARTDATA");
             if (partData == null)

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -5526,13 +5526,22 @@ namespace Parsek
         /// </summary>
         private static void TryFixupCompoundPartVisuals(
             Part prefab, ConfigNode partNode, Transform partRoot,
-            Transform prefabModelRoot, Transform ghostModelNode,
             Dictionary<Transform, Transform> cloneMap,
             uint persistentId, string partName)
         {
             // Compound parts store target connection data in PARTDATA
             ConfigNode partData = partNode.GetNode("PARTDATA");
-            if (partData == null) return;
+            if (partData == null)
+            {
+                // Expected no-op for non-compound parts. Log if the prefab IS a compound
+                // part — that would indicate corrupt/missing snapshot data.
+                if (prefab is CompoundPart)
+                {
+                    ParsekLog.Verbose("GhostVisual", $"  CompoundPart fixup WARNING: '{partName}' pid={persistentId} " +
+                        $"is a CompoundPart but snapshot has no PARTDATA node");
+                }
+                return;
+            }
 
             Vector3 targetPos;
             if (!TryParseVector3(partData.GetValue("pos"), out targetPos))
@@ -5605,6 +5614,10 @@ namespace Parsek
             else
                 targetWorldPos = partRoot.TransformPoint(targetPos);
 
+            // NOTE: delta points from target toward source (line - target), matching
+            // CModuleLinkedMesh.TrackAnchor which computes (line.position - endCap.position).
+            // The stock line mesh faces -Z in the prefab, so LookRotation along this reversed
+            // vector produces the correct orientation. Do not "fix" by swapping operands.
             Vector3 delta = lineWorldPos - targetWorldPos;
             float distance = delta.magnitude;
             const float lineMinimumLength = 0.01f;
@@ -5891,7 +5904,7 @@ namespace Parsek
             // Fix up compound part visuals (fuel lines, struts) — CModuleLinkedMesh
             // normally stretches the line mesh at runtime; ghosts need manual fixup.
             TryFixupCompoundPartVisuals(prefab, partNode, partRoot.transform,
-                modelRoot, modelNode.transform, cloneMap, persistentId, partName);
+                cloneMap, persistentId, partName);
 
             // Detect parachute parts via cloneMap (after cloneMap is fully populated)
             ModuleParachute chute = prefab.FindModuleImplementing<ModuleParachute>();

--- a/docs/dev/part-coverage-catalog.md
+++ b/docs/dev/part-coverage-catalog.md
@@ -155,7 +155,7 @@ checked in; re-run the extraction from the KSP GameData directory to refresh.
 | externalTankCapsule | externalTankCapsule | Stock | — | N/A | — |  |
 | externalTankRound | externalTankRound | Stock | — | N/A | — |  |
 | externalTankToroid | externalTankToroid | Stock | — | N/A | — |  |
-| fuelLine | fuelLine | Stock | — | N/A | — |  |
+| fuelLine | fuelLine | Stock | CModuleLinkedMesh | Mesh+PARTDATA fixup | — | Compound part line stretched via TryFixupCompoundPartVisuals |
 | fuelTank | fuelTank | Stock | — | N/A | — |  |
 | fuelTank_long | fuelTank.long | Stock | — | N/A | — |  |
 | fuelTankSmall | fuelTankSmall | Stock | — | N/A | — |  |
@@ -331,7 +331,7 @@ checked in; re-run the extraction from the KSP GameData directory to refresh.
 | structuralPanel1 | structuralPanel1 | Stock | — | N/A | — |  |
 | structuralPanel2 | structuralPanel2 | Stock | — | N/A | — |  |
 | structuralPylon | structuralPylon | Stock | — | N/A | — |  |
-| strutConnector | strutConnector | Stock | — | N/A | — |  |
+| strutConnector | strutConnector | Stock | CModuleLinkedMesh | Mesh+PARTDATA fixup | — | Compound part line stretched via TryFixupCompoundPartVisuals |
 | strutCube | strutCube | Stock | — | N/A | — |  |
 | strutOcto | strutOcto | Stock | — | N/A | — |  |
 | Triangle0 | Triangle0 | Making History | — | N/A | — |  |


### PR DESCRIPTION
## Summary
- Fuel lines and struts are `CompoundPart`s whose line mesh is dynamically stretched by `CModuleLinkedMesh` at runtime. Ghost parts were rendered with default prefab positions, leaving fuel lines and struts visually disconnected.
- Reads `PARTDATA` (pos/rot) from the snapshot, repositions the target anchor, and stretches the line mesh using the same `LookRotation + Z-scale * scaleFactor` math as stock KSP.
- Reads transform names from the part config (`CModuleLinkedMesh` module) to support both fuel lines (`obj_line`) and struts (`obj_strut`), plus modded compound parts.
- Pure parsing logic extracted into `TryParseCompoundPartData` (internal static) with 9 unit tests covering guard conditions, config reading, and fallback behavior.
- `HasCModuleLinkedMesh` gate skips non-compound parts early, avoiding noisy log lines.
- Part coverage catalog updated for `fuelLine` and `strutConnector`.

## Test plan
- [x] Load save with fuel-line vessel, verify ghost fuel lines connect correctly between parts
- [x] Verify strut connectors also render correctly on ghosts
- [x] Check KSP.log for `CompoundPart fixup` verbose lines with correct distance/scaleFactor values
- [x] 9 unit tests pass (`CompoundPartDataTests`)