### PR TITLE
Fix ghost plume bubble artifacts (bug #105)

### DIFF
--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -1246,7 +1246,6 @@ namespace Parsek
                     Transform t = ps.transform;
                     string parentName = t != null && t.parent != null ? t.parent.name : "<none>";
                     var diagMain = ps.main;
-                    var diagEmission = ps.emission;
                     string diagLine = BuildEngineFxEmissionDiagnostic(
                         evt.partName,
                         evt.partPersistentId,
@@ -1259,7 +1258,7 @@ namespace Parsek
                         t != null ? t.position : Vector3.zero,
                         t != null ? t.forward : Vector3.zero,
                         t != null ? t.up : Vector3.zero,
-                        diagEmission.rateOverTimeMultiplier,
+                        power > 0f ? 1f : 0f, // KSP emitter emit state (Unity emission disabled)
                         diagMain.startSpeedMultiplier,
                         ps.isPlaying);
                     string diagKey = $"engine-fx-{evt.partPersistentId}-{evt.moduleIndex}-{ps.GetInstanceID()}";
@@ -1330,15 +1329,14 @@ namespace Parsek
         /// KSPParticleEmitter is the ONLY particle creation source on ghost FX objects —
         /// Unity's emission module is permanently disabled to prevent bubble artifacts (bug #105).
         /// </summary>
-        private static void SetKspEmittersEnabled(List<MonoBehaviour> kspEmitters, bool enabled)
+        private static void SetKspEmittersEnabled(List<KspEmitterRef> kspEmitters, bool enabled)
         {
             if (kspEmitters == null) return;
             for (int i = 0; i < kspEmitters.Count; i++)
             {
-                if (kspEmitters[i] == null) continue;
-                var emitField = kspEmitters[i].GetType().GetField("emit");
-                if (emitField != null)
-                    emitField.SetValue(kspEmitters[i], enabled);
+                var r = kspEmitters[i];
+                if (r.emitter == null || r.emitField == null) continue;
+                r.emitField.SetValue(r.emitter, enabled);
             }
         }
 

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -1220,29 +1220,22 @@ namespace Parsek
             EngineGhostInfo info;
             if (!state.engineInfos.TryGetValue(key, out info)) return;
 
+            // Control KSPParticleEmitter.emit via reflection — this is the ONLY particle
+            // creation source. Unity's emission module is permanently disabled (bug #105).
+            SetKspEmittersEnabled(info.kspEmitters, power > 0f);
+
             for (int i = 0; i < info.particleSystems.Count; i++)
             {
                 var ps = info.particleSystems[i];
                 if (ps == null) continue;
 
-                var emission = ps.emission;
                 if (power > 0f)
                 {
-                    emission.enabled = true;
-                    float emRate = info.emissionCurve != null ? info.emissionCurve.Evaluate(power) : power * 100f;
-                    emission.rateOverTimeMultiplier = emRate;
-
-                    var main = ps.main;
-                    float spd = info.speedCurve != null ? info.speedCurve.Evaluate(power) : power * 10f;
-                    main.startSpeedMultiplier = spd;
-
                     SetParticleRenderersEnabled(ps, true);
                     if (!ps.isPlaying) ps.Play();
                 }
                 else
                 {
-                    emission.enabled = false;
-                    emission.rateOverTimeMultiplier = 0;
                     ps.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
                     ps.Clear(true);
                     SetParticleRenderersEnabled(ps, false);
@@ -1253,6 +1246,7 @@ namespace Parsek
                     Transform t = ps.transform;
                     string parentName = t != null && t.parent != null ? t.parent.name : "<none>";
                     var diagMain = ps.main;
+                    var diagEmission = ps.emission;
                     string diagLine = BuildEngineFxEmissionDiagnostic(
                         evt.partName,
                         evt.partPersistentId,
@@ -1265,7 +1259,7 @@ namespace Parsek
                         t != null ? t.position : Vector3.zero,
                         t != null ? t.forward : Vector3.zero,
                         t != null ? t.up : Vector3.zero,
-                        emission.rateOverTimeMultiplier,
+                        diagEmission.rateOverTimeMultiplier,
                         diagMain.startSpeedMultiplier,
                         ps.isPlaying);
                     string diagKey = $"engine-fx-{evt.partPersistentId}-{evt.moduleIndex}-{ps.GetInstanceID()}";
@@ -1284,13 +1278,11 @@ namespace Parsek
             foreach (var info in state.engineInfos.Values)
             {
                 if (info.partPersistentId != partPersistentId) continue;
+                SetKspEmittersEnabled(info.kspEmitters, false);
                 for (int i = 0; i < info.particleSystems.Count; i++)
                 {
                     var ps = info.particleSystems[i];
                     if (ps == null) continue;
-                    var emission = ps.emission;
-                    emission.enabled = false;
-                    emission.rateOverTimeMultiplier = 0;
                     ps.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
                     ps.Clear(true);
                     SetParticleRenderersEnabled(ps, false);
@@ -1308,13 +1300,11 @@ namespace Parsek
             foreach (var info in state.rcsInfos.Values)
             {
                 if (info.partPersistentId != partPersistentId) continue;
+                SetKspEmittersEnabled(info.kspEmitters, false);
                 for (int i = 0; i < info.particleSystems.Count; i++)
                 {
                     var ps = info.particleSystems[i];
                     if (ps == null) continue;
-                    var emission = ps.emission;
-                    emission.enabled = false;
-                    emission.rateOverTimeMultiplier = 0;
                     ps.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
                     ps.Clear(true);
                     SetParticleRenderersEnabled(ps, false);
@@ -1335,6 +1325,23 @@ namespace Parsek
             }
         }
 
+        /// <summary>
+        /// Enable or disable KSPParticleEmitter.emit on all captured emitters via reflection.
+        /// KSPParticleEmitter is the ONLY particle creation source on ghost FX objects —
+        /// Unity's emission module is permanently disabled to prevent bubble artifacts (bug #105).
+        /// </summary>
+        private static void SetKspEmittersEnabled(List<MonoBehaviour> kspEmitters, bool enabled)
+        {
+            if (kspEmitters == null) return;
+            for (int i = 0; i < kspEmitters.Count; i++)
+            {
+                if (kspEmitters[i] == null) continue;
+                var emitField = kspEmitters[i].GetType().GetField("emit");
+                if (emitField != null)
+                    emitField.SetValue(kspEmitters[i], enabled);
+            }
+        }
+
         #endregion
 
         #region RCS FX
@@ -1347,10 +1354,13 @@ namespace Parsek
             RcsGhostInfo info;
             if (!state.rcsInfos.TryGetValue(key, out info)) return;
 
+            // Control KSPParticleEmitter.emit via reflection — this is the ONLY particle
+            // creation source. Unity's emission module is permanently disabled (bug #105).
+            SetKspEmittersEnabled(info.kspEmitters, power > 0f);
+
             int configuredSystems = 0;
             int enabledRenderers = 0;
             int playingSystems = 0;
-            float sampleRate = 0f;
             float sampleSpeed = 0f;
             float sampleSize = 0f;
             float sampleLifetime = 0f;
@@ -1361,32 +1371,21 @@ namespace Parsek
                 if (ps == null) continue;
 
                 configuredSystems++;
-                var emission = ps.emission;
                 if (power > 0f)
                 {
-                    emission.enabled = true;
-                    float emRate = ComputeScaledRcsEmissionRate(info.emissionCurve, power, info.emissionScale);
-                    emission.rateOverTimeMultiplier = emRate;
-
-                    var main = ps.main;
-                    float spd = ComputeScaledRcsSpeed(info.speedCurve, power, info.speedScale);
-                    main.startSpeedMultiplier = spd;
-
                     SetParticleRenderersEnabled(ps, true);
                     if (!ps.isPlaying) ps.Play();
 
-                    if (sampleRate <= 0f)
+                    if (sampleSpeed <= 0f)
                     {
-                        sampleRate = emRate;
-                        sampleSpeed = spd;
+                        var main = ps.main;
+                        sampleSpeed = main.startSpeedMultiplier;
                         sampleSize = main.startSizeMultiplier;
                         sampleLifetime = main.startLifetimeMultiplier;
                     }
                 }
                 else
                 {
-                    emission.enabled = false;
-                    emission.rateOverTimeMultiplier = 0;
                     ps.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
                     ps.Clear(true);
                     SetParticleRenderersEnabled(ps, false);
@@ -1401,7 +1400,7 @@ namespace Parsek
             {
                 ParsekLog.Verbose("Flight", $"RCS showcase diagnostics: part='{evt.partName}' pid={evt.partPersistentId} midx={evt.moduleIndex} " +
                     $"power={power:F2} systems={configuredSystems} playing={playingSystems} renderers={enabledRenderers} " +
-                    $"rate={sampleRate:F1} speed={sampleSpeed:F1} size={sampleSize:F2} life={sampleLifetime:F2}");
+                    $"speed={sampleSpeed:F1} size={sampleSize:F2} life={sampleLifetime:F2}");
             }
         }
 
@@ -1437,15 +1436,18 @@ namespace Parsek
             if (state.rcsSuppressed) return;
             state.rcsSuppressed = true;
             foreach (var info in state.rcsInfos.Values)
+            {
+                SetKspEmittersEnabled(info.kspEmitters, false);
                 for (int j = 0; j < info.particleSystems.Count; j++)
                 {
                     var ps = info.particleSystems[j];
                     if (ps != null)
                     {
-                        var em = ps.emission;
-                        if (em.enabled) em.enabled = false;
+                        ps.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
+                        ps.Clear(true);
                     }
                 }
+            }
         }
 
         internal static void RestoreAllRcsEmissions(GhostPlaybackState state)
@@ -1454,25 +1456,36 @@ namespace Parsek
             if (!state.rcsSuppressed) return;
             state.rcsSuppressed = false;
             foreach (var info in state.rcsInfos.Values)
+            {
+                // Only restore emission for RCS that had active KSP emitters.
+                // Check if any KSPParticleEmitter was playing before suppression
+                // by looking at whether the particle system was playing (ps.isPlaying
+                // stays true after Stop with StopEmittingAndClear until particles expire).
+                // Since we call Clear(), isPlaying is false after suppress. Instead, check
+                // if any renderers are enabled — SetRcsEmission enables renderers when active.
+                bool wasActive = false;
                 for (int j = 0; j < info.particleSystems.Count; j++)
                 {
                     var ps = info.particleSystems[j];
-                    if (ps != null)
+                    if (ps == null) continue;
+                    var renderer = ps.GetComponent<ParticleSystemRenderer>();
+                    if (renderer != null && renderer.enabled)
                     {
-                        var em = ps.emission;
-                        // Only restore emission for RCS that was actually activated by an event.
-                        // The ghost builder initializes rateOverTimeMultiplier=0 and calls Stop().
-                        // SetRcsEmission sets rate>0 when an RCSActivated event fires.
-                        // Without this check, suppression cycling (warp on/off) would blindly
-                        // Play() all particle systems — including those never activated.
-                        float rate = em.rateOverTimeMultiplier;
-                        if (rate > 0f)
-                        {
-                            em.enabled = true;
-                            if (!ps.isPlaying) ps.Play();
-                        }
+                        wasActive = true;
+                        break;
                     }
                 }
+                if (wasActive)
+                {
+                    SetKspEmittersEnabled(info.kspEmitters, true);
+                    for (int j = 0; j < info.particleSystems.Count; j++)
+                    {
+                        var ps = info.particleSystems[j];
+                        if (ps != null && !ps.isPlaying)
+                            ps.Play();
+                    }
+                }
+            }
         }
 
         #endregion

--- a/Source/Parsek/GhostTypes.cs
+++ b/Source/Parsek/GhostTypes.cs
@@ -28,6 +28,7 @@ namespace Parsek
         public uint partPersistentId;
         public int moduleIndex;
         public List<ParticleSystem> particleSystems = new List<ParticleSystem>();
+        public List<MonoBehaviour> kspEmitters = new List<MonoBehaviour>();
         public FloatCurve emissionCurve;
         public FloatCurve speedCurve;
     }
@@ -107,6 +108,7 @@ namespace Parsek
         public uint partPersistentId;
         public int moduleIndex;
         public List<ParticleSystem> particleSystems = new List<ParticleSystem>();
+        public List<MonoBehaviour> kspEmitters = new List<MonoBehaviour>();
         public FloatCurve emissionCurve;
         public FloatCurve speedCurve;
         public float emissionScale = 1f;

--- a/Source/Parsek/GhostTypes.cs
+++ b/Source/Parsek/GhostTypes.cs
@@ -23,12 +23,18 @@ namespace Parsek
         public bool semiDeployedSampled;
     }
 
+    internal struct KspEmitterRef
+    {
+        public MonoBehaviour emitter;
+        public System.Reflection.FieldInfo emitField;
+    }
+
     internal class EngineGhostInfo
     {
         public uint partPersistentId;
         public int moduleIndex;
         public List<ParticleSystem> particleSystems = new List<ParticleSystem>();
-        public List<MonoBehaviour> kspEmitters = new List<MonoBehaviour>();
+        public List<KspEmitterRef> kspEmitters = new List<KspEmitterRef>();
         public FloatCurve emissionCurve;
         public FloatCurve speedCurve;
     }
@@ -108,7 +114,7 @@ namespace Parsek
         public uint partPersistentId;
         public int moduleIndex;
         public List<ParticleSystem> particleSystems = new List<ParticleSystem>();
-        public List<MonoBehaviour> kspEmitters = new List<MonoBehaviour>();
+        public List<KspEmitterRef> kspEmitters = new List<KspEmitterRef>();
         public FloatCurve emissionCurve;
         public FloatCurve speedCurve;
         public float emissionScale = 1f;

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -926,7 +926,7 @@ namespace Parsek
         /// SmokeTrailControl modifies material color every frame based on atmospheric density.
         /// FXPrefab registers particles with FloatingOrigin — pollutes global state on ghosts.
         /// </summary>
-        private static void StripKspFxControllers(GameObject fxClone, List<MonoBehaviour> kspEmitterSink)
+        private static void StripKspFxControllers(GameObject fxClone, List<KspEmitterRef> kspEmitterSink)
         {
             if (fxClone == null) return;
 
@@ -938,12 +938,18 @@ namespace Parsek
                 switch (typeName)
                 {
                     case "KSPParticleEmitter":
-                        // Set emit=false so KSP doesn't create particles until
-                        // SetEngineEmission/SetRcsEmission enables it.
+                        // Cache FieldInfo at capture time to avoid per-frame reflection in
+                        // SetKspEmittersEnabled (called from SetEngineEmission/SetRcsEmission).
                         var emitField = behaviours[i].GetType().GetField("emit");
                         if (emitField != null)
+                        {
                             emitField.SetValue(behaviours[i], false);
-                        kspEmitterSink?.Add(behaviours[i]);
+                            kspEmitterSink?.Add(new KspEmitterRef
+                            {
+                                emitter = behaviours[i],
+                                emitField = emitField
+                            });
+                        }
                         ParsekLog.Verbose("GhostVisual",
                             $"Captured KSPParticleEmitter on '{fxClone.name}' (emit=false)");
                         break;

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -916,6 +916,47 @@ namespace Parsek
                 $"sourceToFx=({sourceToFx}) parentToFx=({parentToFx})", 60.0);
         }
 
+        /// <summary>
+        /// Strip KSP FX controller components from cloned particle system GameObjects.
+        /// KSPParticleEmitter is KEPT alive (it handles material setup and particle creation)
+        /// but set to emit=false initially. It is collected into kspEmitterSink for later
+        /// control via reflection in SetEngineEmission/SetRcsEmission.
+        /// Unity's emission module is disabled separately (in ConfigureGhostEngineParticleSystems)
+        /// to prevent Unity from creating its own material-less "bubble" particles.
+        /// SmokeTrailControl modifies material color every frame based on atmospheric density.
+        /// FXPrefab registers particles with FloatingOrigin — pollutes global state on ghosts.
+        /// </summary>
+        private static void StripKspFxControllers(GameObject fxClone, List<MonoBehaviour> kspEmitterSink)
+        {
+            if (fxClone == null) return;
+
+            MonoBehaviour[] behaviours = fxClone.GetComponentsInChildren<MonoBehaviour>(true);
+            for (int i = 0; i < behaviours.Length; i++)
+            {
+                if (behaviours[i] == null) continue;
+                string typeName = behaviours[i].GetType().Name;
+                switch (typeName)
+                {
+                    case "KSPParticleEmitter":
+                        // Set emit=false so KSP doesn't create particles until
+                        // SetEngineEmission/SetRcsEmission enables it.
+                        var emitField = behaviours[i].GetType().GetField("emit");
+                        if (emitField != null)
+                            emitField.SetValue(behaviours[i], false);
+                        kspEmitterSink?.Add(behaviours[i]);
+                        ParsekLog.Verbose("GhostVisual",
+                            $"Captured KSPParticleEmitter on '{fxClone.name}' (emit=false)");
+                        break;
+                    case "SmokeTrailControl":
+                    case "FXPrefab":
+                        ParsekLog.Verbose("GhostVisual",
+                            $"Stripped {typeName} from '{fxClone.name}'");
+                        Object.Destroy(behaviours[i]);
+                        break;
+                }
+            }
+        }
+
         private static int ConfigureGhostEngineParticleSystems(
             GameObject fxInstance, List<ParticleSystem> sink)
         {
@@ -934,9 +975,13 @@ namespace Parsek
                 main.playOnAwake = false;
                 main.prewarm = false;
 
+                // Permanently disable Unity's emission module — all particle creation
+                // is handled by KSPParticleEmitter.EmitParticle(). Leaving emission.enabled=true
+                // causes Unity to create its own particles using main.startSize and
+                // ParticleSystemRenderer.material, which are never set from KSP values,
+                // producing huge material-less "bubble" artifacts (bug #105).
                 var emission = ps.emission;
-                emission.enabled = true;
-                emission.rateOverTimeMultiplier = 0f;
+                emission.enabled = false;
 
                 ps.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
                 ps.Clear(true);
@@ -2302,9 +2347,7 @@ namespace Parsek
                         fxClone.transform.localRotation = legacyLocalRot;
                         fxClone.transform.localScale = child.localScale;
 
-                        var smokeTrail = fxClone.GetComponent("SmokeTrailControl");
-                        if (smokeTrail != null)
-                            Object.Destroy(smokeTrail);
+                        StripKspFxControllers(fxClone, info.kspEmitters);
 
                         int addedSystems = ConfigureGhostEngineParticleSystems(fxClone, info.particleSystems);
                         if (addedSystems > 0)
@@ -2332,9 +2375,7 @@ namespace Parsek
                     fxClone.transform.localRotation = child.localRotation;
                     fxClone.transform.localScale = child.localScale;
 
-                    var smokeTrail = fxClone.GetComponent("SmokeTrailControl");
-                    if (smokeTrail != null)
-                        Object.Destroy(smokeTrail);
+                    StripKspFxControllers(fxClone, info.kspEmitters);
 
                     int addedSystems = ConfigureGhostEngineParticleSystems(fxClone, info.particleSystems);
                     if (addedSystems > 0)
@@ -2399,6 +2440,8 @@ namespace Parsek
                             fxInstance.transform.SetParent(ghostFxParent, false);
                             fxInstance.transform.localPosition = mmpLocalPos;
                             fxInstance.transform.localRotation = mmpLocalRot;
+
+                            StripKspFxControllers(fxInstance, info.kspEmitters);
 
                             int addedSystems = ConfigureGhostEngineParticleSystems(fxInstance, info.particleSystems);
                             if (addedSystems > 0)
@@ -2498,9 +2541,7 @@ namespace Parsek
                         }
                     }
 
-                    var smokeTrail = fxInstance.GetComponent("SmokeTrailControl");
-                    if (smokeTrail != null)
-                        Object.Destroy(smokeTrail);
+                    StripKspFxControllers(fxInstance, info.kspEmitters);
 
                     int addedSystems = ConfigureGhostEngineParticleSystems(fxInstance, info.particleSystems);
                     if (addedSystems > 0)
@@ -3344,6 +3385,8 @@ namespace Parsek
                                 fxInstance.transform.localRotation = fxDefinitions[f].localRotation;
                                 fxInstance.transform.localScale = fxDefinitions[f].localScale;
 
+                                StripKspFxControllers(fxInstance, info.kspEmitters);
+
                                 // Configure ALL particle systems in the FX hierarchy (not just the first).
                                 // KSP RCS FX models have multiple child systems (plume + glow/smoke).
                                 // Using singular GetComponentInChildren only stopped the first one —
@@ -3356,9 +3399,10 @@ namespace Parsek
                                     main.playOnAwake = false;
                                     main.prewarm = false;
 
+                                    // Permanently disable Unity's emission module — all particle
+                                    // creation is handled by KSPParticleEmitter (bug #105 fix).
                                     var emission = ps.emission;
-                                    emission.enabled = true;
-                                    emission.rateOverTimeMultiplier = 0;
+                                    emission.enabled = false;
                                     ps.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
                                     ps.Clear(true);
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1231,7 +1231,7 @@ When a ghost vessel is destroyed (recording ends, zone exit, loop cycle boundary
 
 ## 108. EngineShutdown event not recorded when engine cuts off
 
-Engine shutdown not recorded. Ghost engine plumes continue firing past cutoff. Verified in recording `b656f9d4` (save `s10`, Aeris-4A with 2x `turboFanEngine` J-X4 "Whiplash" Turbo Ramjet side by side + `toroidalAerospike`): `turboFanEngine` had 2 `EngineIgnited` + 238 `EngineThrottle` but 0 `EngineShutdown`. `toroidalAerospike` had zero engine events entirely.
+Engine throttle/shutdown events not recorded for some engine types. Ghost engine plumes stay at full intensity from ignition until shutdown (no throttle response), or never stop if shutdown is also missing. Observed on Aeris-4A (save `s10`) with `turboFanEngine` (J-X4 "Whiplash" Turbo Ramjet, `ModuleEnginesFX`): playback log shows `EngineIgnited` and `EngineShutdown` but zero `EngineThrottle` events between them. An earlier recording of the same craft had 238 throttle events but no shutdown — inconsistent behavior suggests a timing or caching issue in `CheckEngineTransition` / `CacheEngineModules`.
 
 Likely cause: `CheckEngineTransition` may not detect the `EngineIgnited → false` transition correctly, or the transition check polls `engine.EngineIgnited && engine.isOperational` which may remain true in certain states (e.g., fuel depletion vs. manual shutdown).
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1228,3 +1228,13 @@ When a ghost vessel is destroyed (recording ends, zone exit, loop cycle boundary
 **Priority:** Low — cosmetic polish, no functional impact
 
 **Status:** Open
+
+## 108. EngineShutdown event not recorded when engine cuts off
+
+Recordings contain `EngineIgnited` and `EngineThrottle` events but no `EngineShutdown` when the engine is turned off. Ghost engine plumes continue firing past the point where the real engine was shut down. Verified by inspecting a recording file: type 5 (`EngineIgnited`) = 2 events, type 7 (`EngineThrottle`) = 238 events, type 6 (`EngineShutdown`) = 0 events despite the engine being shut down during the recorded flight.
+
+Likely cause: `CheckEngineTransition` may not detect the `EngineIgnited → false` transition correctly, or the transition check polls `engine.EngineIgnited && engine.isOperational` which may remain true in certain states (e.g., fuel depletion vs. manual shutdown).
+
+**Priority:** Medium — ghost engines keep burning past cutoff, visually incorrect
+
+**Status:** Open

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1231,7 +1231,7 @@ When a ghost vessel is destroyed (recording ends, zone exit, loop cycle boundary
 
 ## 108. EngineShutdown event not recorded when engine cuts off
 
-Recordings contain `EngineIgnited` and `EngineThrottle` events but no `EngineShutdown` when the engine is turned off. Ghost engine plumes continue firing past the point where the real engine was shut down. Verified by inspecting a recording file: type 5 (`EngineIgnited`) = 2 events, type 7 (`EngineThrottle`) = 238 events, type 6 (`EngineShutdown`) = 0 events despite the engine being shut down during the recorded flight.
+Recordings contain `EngineIgnited` and `EngineThrottle` events but no `EngineShutdown` when the engine is turned off. Ghost engine plumes continue firing past the point where the real engine was shut down. Verified by inspecting recording `b656f9d4` (save `s10`): `turboFanEngine` (J-33 "Wheesley" turbofan) had type 5 (`EngineIgnited`) = 2 events, type 7 (`EngineThrottle`) = 238 events, type 6 (`EngineShutdown`) = 0 events despite the engine being shut down during the recorded flight.
 
 Likely cause: `CheckEngineTransition` may not detect the `EngineIgnited → false` transition correctly, or the transition check polls `engine.EngineIgnited && engine.isOperational` which may remain true in certain states (e.g., fuel depletion vs. manual shutdown).
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1231,7 +1231,7 @@ When a ghost vessel is destroyed (recording ends, zone exit, loop cycle boundary
 
 ## 108. EngineShutdown event not recorded when engine cuts off
 
-Engine shutdown not recorded. Ghost engine plumes continue firing past cutoff. Verified in recording `b656f9d4` (save `s10`): `turboFanEngine` (J-33 "Wheesley" jet, blue afterburner flames) had 2 `EngineIgnited` + 238 `EngineThrottle` events but 0 `EngineShutdown`, despite the engines being shut down during the recorded flight.
+Engine events missing or incomplete in recordings. Ghost engine plumes fire when they shouldn't or continue past cutoff. Verified in recording `b656f9d4` (save `s10`, craft has `turboFanEngine` + `toroidalAerospike`): `turboFanEngine` had 2 `EngineIgnited` + 238 `EngineThrottle` but 0 `EngineShutdown`. `toroidalAerospike` (blue flame engine) had only a `ShroudJettisoned` event — zero engine events despite being active during the flight.
 
 Likely cause: `CheckEngineTransition` may not detect the `EngineIgnited → false` transition correctly, or the transition check polls `engine.EngineIgnited && engine.isOperational` which may remain true in certain states (e.g., fuel depletion vs. manual shutdown).
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1231,7 +1231,7 @@ When a ghost vessel is destroyed (recording ends, zone exit, loop cycle boundary
 
 ## 108. EngineShutdown event not recorded when engine cuts off
 
-Engine events missing or incomplete in recordings. Ghost engine plumes fire when they shouldn't or continue past cutoff. Verified in recording `b656f9d4` (save `s10`, craft has `turboFanEngine` + `toroidalAerospike`): `turboFanEngine` had 2 `EngineIgnited` + 238 `EngineThrottle` but 0 `EngineShutdown`. `toroidalAerospike` (blue flame engine) had only a `ShroudJettisoned` event — zero engine events despite being active during the flight.
+Engine shutdown not recorded. Ghost engine plumes continue firing past cutoff. Verified in recording `b656f9d4` (save `s10`, Aeris-4A with 2x `turboFanEngine` J-X4 "Whiplash" Turbo Ramjet side by side + `toroidalAerospike`): `turboFanEngine` had 2 `EngineIgnited` + 238 `EngineThrottle` but 0 `EngineShutdown`. `toroidalAerospike` had zero engine events entirely.
 
 Likely cause: `CheckEngineTransition` may not detect the `EngineIgnited → false` transition correctly, or the transition check polls `engine.EngineIgnited && engine.isOperational` which may remain true in certain states (e.g., fuel depletion vs. manual shutdown).
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1231,7 +1231,7 @@ When a ghost vessel is destroyed (recording ends, zone exit, loop cycle boundary
 
 ## 108. EngineShutdown event not recorded when engine cuts off
 
-Engine events missing or incomplete in recordings. Ghost engine plumes fire when they shouldn't or continue past cutoff. Verified in recording `b656f9d4` (save `s10`): `toroidalAerospike` (LV-1R "Spider" / Aerospike, blue flame engine) had zero engine events — no EngineIgnited, no EngineThrottle, no EngineShutdown — despite being active during the flight. Only a ShroudJettisoned event was recorded. The `turboFanEngine` on the same craft had ignition and throttle events but no shutdown.
+Engine shutdown not recorded. Ghost engine plumes continue firing past cutoff. Verified in recording `b656f9d4` (save `s10`): `turboFanEngine` (J-33 "Wheesley" jet, blue afterburner flames) had 2 `EngineIgnited` + 238 `EngineThrottle` events but 0 `EngineShutdown`, despite the engines being shut down during the recorded flight.
 
 Likely cause: `CheckEngineTransition` may not detect the `EngineIgnited → false` transition correctly, or the transition check polls `engine.EngineIgnited && engine.isOperational` which may remain true in certain states (e.g., fuel depletion vs. manual shutdown).
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1193,17 +1193,15 @@ Fix: disambiguate with a launch number suffix. Check existing group names via `R
 
 **Status:** Open
 
-## 105. Colored bubbles visible in ghost engine plume FX
+## 105. Colored bubbles visible in ghost engine/RCS plume FX
 
-Ghost engine plumes show colored bubble/sphere artifacts instead of smooth exhaust trails. Most likely cause: KSP FX controller components (`ModelMultiParticlePersistFX`, `KSPParticleEmitter`) survive the `Object.Instantiate` clone and interfere with particle system state at runtime. `ConfigureGhostEngineParticleSystems` (GhostVisualBuilder.cs:919) correctly configures the cloned systems, but surviving KSP components may re-initialize materials or override emission shape afterward.
+Ghost engine and RCS plumes showed colored bubble/sphere artifacts. Root cause: ghost plumes had TWO particle emission sources fighting each other — `KSPParticleEmitter.EmitParticle()` (creates correctly-textured particles) and Unity's emission module (`emission.rateOverTimeMultiplier`) which creates particles using `ParticleSystem.main.startSize` and `ParticleSystemRenderer.material`, neither of which are set from KSP values, producing huge material-less "bubbles".
 
-The code only strips `SmokeTrailControl` (lines 2305, 2335, 2501) but does not strip other KSP FX management components. A secondary possibility: `TextureSheetAnimation` UV state lost if materials are cloned or replaced after instantiation, causing particles to render the full sprite atlas as a colored circle.
+Fix: Permanently disable Unity's emission module (`emission.enabled = false`) at build time. Keep `KSPParticleEmitter` alive (it handles material setup and particle creation) but control it via reflection (`emit` field) in `SetEngineEmission`/`SetRcsEmission`. `StripKspFxControllers` captures `KSPParticleEmitter` references into `kspEmitters` lists on `EngineGhostInfo`/`RcsGhostInfo` instead of destroying them. `SmokeTrailControl` and `FXPrefab` are still stripped.
 
-**Fix approach:** Strip all `ModelMultiParticlePersistFX` and `KSPParticleEmitter` components from the cloned FX hierarchy after instantiation (similar to `SmokeTrailControl` stripping). Verify `ParticleSystemRenderer.renderMode` is `Billboard` or `StretchedBillboard` (not `Mesh`).
+**Priority:** Medium — visually distracting on every engine/RCS ghost
 
-**Priority:** Medium — visually distracting on every engine ghost
-
-**Status:** Open
+**Status:** Fixed
 
 ## 106. Watch mode camera follows booster instead of main vessel at BREAKUP
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1231,7 +1231,7 @@ When a ghost vessel is destroyed (recording ends, zone exit, loop cycle boundary
 
 ## 108. EngineShutdown event not recorded when engine cuts off
 
-Recordings contain `EngineIgnited` and `EngineThrottle` events but no `EngineShutdown` when the engine is turned off. Ghost engine plumes continue firing past the point where the real engine was shut down. Verified by inspecting recording `b656f9d4` (save `s10`): `turboFanEngine` (J-33 "Wheesley" turbofan) had type 5 (`EngineIgnited`) = 2 events, type 7 (`EngineThrottle`) = 238 events, type 6 (`EngineShutdown`) = 0 events despite the engine being shut down during the recorded flight.
+Engine events missing or incomplete in recordings. Ghost engine plumes fire when they shouldn't or continue past cutoff. Verified in recording `b656f9d4` (save `s10`): `toroidalAerospike` (LV-1R "Spider" / Aerospike, blue flame engine) had zero engine events — no EngineIgnited, no EngineThrottle, no EngineShutdown — despite being active during the flight. Only a ShroudJettisoned event was recorded. The `turboFanEngine` on the same craft had ignition and throttle events but no shutdown.
 
 Likely cause: `CheckEngineTransition` may not detect the `EngineIgnited → false` transition correctly, or the transition check polls `engine.EngineIgnited && engine.isOperational` which may remain true in certain states (e.g., fuel depletion vs. manual shutdown).
 


### PR DESCRIPTION
## Summary
- Ghost plumes had two particle emission sources: `KSPParticleEmitter.EmitParticle()` (correct particles) and Unity's `emission.rateOverTimeMultiplier` (particles with default Unity properties = material-less bubbles)
- Disable Unity's emission module entirely and control `KSPParticleEmitter.emit` via reflection based on recorded engine/RCS events
- KSP now handles all particle creation natively with correct materials, sizes, and colors
- Cache `FieldInfo` at capture time to avoid per-frame reflection cost
- Also documents bug #108: engine throttle/shutdown events missing for some engine types (separate recording-side issue)

## Changes
- **GhostTypes.cs**: Added `KspEmitterRef` struct (emitter + cached FieldInfo) and `kspEmitters` list to `EngineGhostInfo` and `RcsGhostInfo`
- **GhostVisualBuilder.cs**: `StripKspFxControllers` captures `KSPParticleEmitter` refs (emit=false) with cached FieldInfo; `ConfigureGhostEngineParticleSystems` disables Unity emission module; applied at all 5 FX clone sites
- **GhostPlaybackLogic.cs**: `SetEngineEmission`/`SetRcsEmission` toggle `KSPParticleEmitter.emit` via cached reflection; added `SetKspEmittersEnabled` helper
- **todo-and-known-bugs.md**: Bug #105 marked fixed, bug #108 added (engine event recording gaps)

## Test plan
- [x] `dotnet build` — 0 warnings
- [x] `dotnet test` — 3114/3114 pass
- [x] In-game: engine plumes render correctly, no bubble artifacts
- [x] In-game: RCS plumes render correctly
- [x] KSP.log confirms `Captured KSPParticleEmitter` at build time
- [x] Engine shutdown correctly stops plumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)