### PR TITLE
Audit ghost FX for KSP-native component usage (#113)

### DIFF
--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -923,8 +923,8 @@ namespace Parsek
         /// control via reflection in SetEngineEmission/SetRcsEmission.
         /// Unity's emission module is disabled separately (in ConfigureGhostEngineParticleSystems)
         /// to prevent Unity from creating its own material-less "bubble" particles.
-        /// SmokeTrailControl is KEPT alive — it fades smoke trail opacity by atmospheric density
-        /// using transform.position + FlightGlobals.getAtmDensity(), both of which work on ghosts.
+        /// SmokeTrailControl is STRIPPED — tested keeping alive (audit #113) but it sets material
+        /// alpha to 0 on ghosts, making smoke invisible. Needs vessel context to work correctly.
         /// ModelMultiParticlePersistFX/ModelParticleFX are EffectBehaviour subclasses that reference
         /// Host (the Part) — stripped because they NRE without Part context.
         /// FXPrefab registers particles with FloatingOrigin — pollutes global state on ghosts.
@@ -965,11 +965,12 @@ namespace Parsek
                             $"Captured KSPParticleEmitter on '{fxClone.name}' (emit=false)");
                         break;
                     case "SmokeTrailControl":
-                        // Kept alive — fades smoke by atmospheric density using
-                        // transform.position + FlightGlobals.getAtmDensity().
-                        // Both work on ghosts (valid world position, static API).
+                        // Stripped — tested keeping alive (audit #113) but it makes smoke
+                        // invisible on ghosts. SmokeTrailControl sets material alpha to 0
+                        // without valid vessel context.
                         ParsekLog.Verbose("GhostVisual",
-                            $"Kept SmokeTrailControl alive on '{fxClone.name}' (density-based smoke fading)");
+                            $"Stripped {typeName} from '{fxClone.name}'");
+                        Object.Destroy(behaviours[i]);
                         break;
                     case "ModelMultiParticlePersistFX":
                     case "ModelParticleFX":

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -917,14 +917,25 @@ namespace Parsek
         }
 
         /// <summary>
-        /// Strip KSP FX controller components from cloned particle system GameObjects.
+        /// Configure KSP FX controller components on cloned particle system GameObjects.
         /// KSPParticleEmitter is KEPT alive (it handles material setup and particle creation)
         /// but set to emit=false initially. It is collected into kspEmitterSink for later
         /// control via reflection in SetEngineEmission/SetRcsEmission.
         /// Unity's emission module is disabled separately (in ConfigureGhostEngineParticleSystems)
         /// to prevent Unity from creating its own material-less "bubble" particles.
-        /// SmokeTrailControl modifies material color every frame based on atmospheric density.
+        /// SmokeTrailControl is KEPT alive — it fades smoke trail opacity by atmospheric density
+        /// using transform.position + FlightGlobals.getAtmDensity(), both of which work on ghosts.
+        /// ModelMultiParticlePersistFX/ModelParticleFX are EffectBehaviour subclasses that reference
+        /// Host (the Part) — stripped because they NRE without Part context.
         /// FXPrefab registers particles with FloatingOrigin — pollutes global state on ghosts.
+        ///
+        /// Audit #113: FXModuleAnimateThrottle and FXModuleAnimateRCS are PartModules (not
+        /// MonoBehaviours) requiring Part/Vessel context. They are reimplemented via HeatGhostInfo
+        /// animation sampling, which is architecturally correct: one-shot build cost cached per
+        /// part type, near-zero runtime cost (3-level quantized transform/material snaps on event
+        /// boundaries), correct multi-instance disambiguation. Native modules are infeasible on
+        /// ghosts and the reimplementation is intentionally minimal per the visual efficiency
+        /// design principle.
         /// </summary>
         private static void StripKspFxControllers(GameObject fxClone, List<KspEmitterRef> kspEmitterSink)
         {
@@ -954,6 +965,20 @@ namespace Parsek
                             $"Captured KSPParticleEmitter on '{fxClone.name}' (emit=false)");
                         break;
                     case "SmokeTrailControl":
+                        // Kept alive — fades smoke by atmospheric density using
+                        // transform.position + FlightGlobals.getAtmDensity().
+                        // Both work on ghosts (valid world position, static API).
+                        ParsekLog.Verbose("GhostVisual",
+                            $"Kept SmokeTrailControl alive on '{fxClone.name}' (density-based smoke fading)");
+                        break;
+                    case "ModelMultiParticlePersistFX":
+                    case "ModelParticleFX":
+                        // EffectBehaviour subclasses that reference Host (Part).
+                        // NRE without Part context — strip them.
+                        ParsekLog.Verbose("GhostVisual",
+                            $"Stripped {typeName} from '{fxClone.name}'");
+                        Object.Destroy(behaviours[i]);
+                        break;
                     case "FXPrefab":
                         ParsekLog.Verbose("GhostVisual",
                             $"Stripped {typeName} from '{fxClone.name}'");
@@ -6391,6 +6416,9 @@ namespace Parsek
             }
 
             // Detect ModuleAnimateHeat / FXModuleAnimateThrottle visual states (thermal glow / heat-driven animation).
+            // Audit #113: these are PartModules requiring Part/Vessel context that ghosts don't have.
+            // Reimplemented via animation sampling (SampleHeatAnimation3State) + 3-level quantized
+            // HeatGhostInfo playback (ApplyHeatState). Same applies to FXModuleAnimateRCS.
             if (hasAnyHeatAnim)
             {
                 string heatSource = hasAnimateHeat ? "ModuleAnimateHeat"

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1285,7 +1285,7 @@ Bug #105 revealed that fighting KSP's own FX components (KSPParticleEmitter, Mod
 
 Audit results:
 - **KSPParticleEmitter**: KEPT alive, controlled via `emit` reflection (bug #105 fix, already merged)
-- **SmokeTrailControl**: KEPT alive — MonoBehaviour that fades smoke by atmospheric density using `transform.position` + `FlightGlobals.getAtmDensity()`, both of which work on ghosts
+- **SmokeTrailControl**: STRIPPED — tested keeping alive but it sets material alpha to 0 on ghosts, making smoke invisible. Needs vessel context to work correctly
 - **ModelMultiParticlePersistFX / ModelParticleFX**: STRIPPED — EffectBehaviour subclasses that reference Host (Part), NRE without Part context
 - **FXPrefab**: STRIPPED — registers particles with FloatingOrigin, pollutes global state on ghosts
 - **FXModuleAnimateThrottle**: KEEP REIMPLEMENTATION — PartModule requiring Part/Vessel context. Current HeatGhostInfo animation sampling is correct: one-shot cached build cost, near-zero runtime (3-level quantized snaps), correct multi-instance disambiguation

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1230,3 +1230,19 @@ When a ghost vessel is destroyed (recording ends, zone exit, loop cycle boundary
 **Priority:** Low — cosmetic polish, no functional impact
 
 **Status:** Open
+
+## 109. Audit ghost FX for KSP-native component usage
+
+Bug #105 revealed that fighting KSP's own FX components (KSPParticleEmitter, ModelMultiParticleFX) produces artifacts. The fix — letting KSP handle particle creation natively and controlling `emit` via reflection — produced much better visuals than any approach that tried to replace KSP's emission with Unity's.
+
+Audit all ghost visual systems for similar opportunities to use KSP-native components instead of reimplementing or stripping them:
+- **Smoke trails**: currently strip `SmokeTrailControl` which fades smoke by atmospheric density. Could we keep it and let KSP handle density-based fading?
+- **Engine heat glow**: `FXModuleAnimateThrottle` animates engine heat materials. Ghost code reimplements this with `HeatGhostInfo`. Could we keep the stock module and drive it?
+- **RCS glow**: `FXModuleAnimateRCS` handles RCS nozzle glow. Same question.
+- **Other FX components**: check if any stripped components would produce better visuals if kept alive and controlled
+
+General principle: prefer toggling KSP's own components on/off via reflection over reimplementing their behavior. KSP's components handle edge cases (material setup, animation curves, density fading) that are hard to replicate correctly.
+
+**Priority:** Low — improvement opportunity, not a bug
+
+**Status:** Open

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1283,17 +1283,17 @@ After rewinding and re-entering flight, the Aeris 4A recording's spawn-at-end tr
 
 Bug #105 revealed that fighting KSP's own FX components (KSPParticleEmitter, ModelMultiParticleFX) produces artifacts. The fix — letting KSP handle particle creation natively and controlling `emit` via reflection — produced much better visuals than any approach that tried to replace KSP's emission with Unity's.
 
-Audit all ghost visual systems for similar opportunities to use KSP-native components instead of reimplementing or stripping them:
-- **Smoke trails**: currently strip `SmokeTrailControl` which fades smoke by atmospheric density. Could we keep it and let KSP handle density-based fading?
-- **Engine heat glow**: `FXModuleAnimateThrottle` animates engine heat materials. Ghost code reimplements this with `HeatGhostInfo`. Could we keep the stock module and drive it?
-- **RCS glow**: `FXModuleAnimateRCS` handles RCS nozzle glow. Same question.
-- **Other FX components**: check if any stripped components would produce better visuals if kept alive and controlled
-
-General principle: prefer toggling KSP's own components on/off via reflection over reimplementing their behavior. KSP's components handle edge cases (material setup, animation curves, density fading) that are hard to replicate correctly.
+Audit results:
+- **KSPParticleEmitter**: KEPT alive, controlled via `emit` reflection (bug #105 fix, already merged)
+- **SmokeTrailControl**: KEPT alive — MonoBehaviour that fades smoke by atmospheric density using `transform.position` + `FlightGlobals.getAtmDensity()`, both of which work on ghosts
+- **ModelMultiParticlePersistFX / ModelParticleFX**: STRIPPED — EffectBehaviour subclasses that reference Host (Part), NRE without Part context
+- **FXPrefab**: STRIPPED — registers particles with FloatingOrigin, pollutes global state on ghosts
+- **FXModuleAnimateThrottle**: KEEP REIMPLEMENTATION — PartModule requiring Part/Vessel context. Current HeatGhostInfo animation sampling is correct: one-shot cached build cost, near-zero runtime (3-level quantized snaps), correct multi-instance disambiguation
+- **FXModuleAnimateRCS**: KEEP REIMPLEMENTATION — same PartModule constraints, shares HeatGhostInfo infrastructure
 
 **Priority:** Low — improvement opportunity, not a bug
 
-**Status:** Open
+**Status:** Done
 
 # In-Game Tests
 


### PR DESCRIPTION
## Summary

- Strip `ModelMultiParticlePersistFX` / `ModelParticleFX` — `EffectBehaviour` subclasses that reference `Host` (Part), NRE without Part context
- Document why `FXModuleAnimateThrottle` / `FXModuleAnimateRCS` are reimplemented via `HeatGhostInfo` rather than kept native (PartModules requiring Part/Vessel context)
- Tested keeping `SmokeTrailControl` alive — it sets material alpha to 0 on ghosts, making smoke invisible. Reverted to stripped with documented reasoning.
- Mark todo #113 as Done with per-component audit verdicts

## Audit verdicts

| Component | Verdict | Reason |
|-----------|---------|--------|
| KSPParticleEmitter | KEEP (already done, #105) | MonoBehaviour, emit controlled via reflection |
| SmokeTrailControl | STRIP (tested, breaks visuals) | Sets material alpha to 0 without vessel context |
| ModelMultiParticlePersistFX | STRIP (this PR) | EffectBehaviour, needs Part Host |
| ModelParticleFX | STRIP (this PR) | EffectBehaviour, needs Part Host |
| FXPrefab | STRIP (already done, #105) | Pollutes FloatingOrigin global state |
| FXModuleAnimateThrottle | KEEP REIMPL | PartModule, needs Part/Vessel context |
| FXModuleAnimateRCS | KEEP REIMPL | PartModule, shares HeatGhostInfo infra |

## Test plan

- [x] `dotnet build` succeeds
- [x] `dotnet test` — 3130 tests pass
- [x] In-game: SmokeTrailControl kept alive makes smoke invisible — reverted to stripped
- [x] No in-game verification needed — net behavioral change is defensive stripping of ModelMultiParticlePersistFX/ModelParticleFX + documentation