### PR TITLE
Fix spawn cleanup and collision retry bugs (#109, #110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,32 +22,95 @@ All notable changes to Parsek are documented here.
 
 ## 0.5.1
 
+Spawn safety hardening, ghost visual improvements, booster/debris tree recording, flag planting, and Fast Forward redesign. 20 PRs merged, 24 bugs fixed.
+
+### Spawn Safety & Reliability
+
+- **Bounding box collision detection** — replaced proximity-offset heuristic with oriented bounding box overlap checks against all loaded vessels (active vessel, debris, EVA, flags excluded)
+- **Spawn collision retry limit** — 150-frame (~2.5s) collision block limit for non-chain spawns; walkback exhaustion flag for chain-tip spawns; spawn abandoned with WARN after limit hit (#110)
+- **Spawn-die-respawn prevention** — 3-cycle death counter with permanent abandon for vessels destroyed immediately after spawn (e.g., FLYING at sea level killed by on-rails aero) (#110b)
+- **Spawn abandon flag** — `SpawnAbandoned` prevents vessel-gone reset cycle from re-triggering spawn indefinitely
+- **Non-leaf spawn suppression** — non-leaf tree recordings and FLYING/SUB_ORBITAL snapshot situations blocked from spawning; crew stripped from Destroyed-terminal-state spawn snapshots (#114)
+- **SubOrbital terminal spawn suppression** — recordings with SubOrbital terminal state no longer attempt vessel spawn (#45)
+- **Debris spawn suppression** — debris recordings (`IsDebris=true`) blocked from spawning real vessels
+- **Orphaned vessel cleanup** — spawned vessels stripped from FLIGHTSTATE on revert and rewind; guards preserve already-set cleanup data on second rewind (#109)
+- **ForceSpawnNewVessel on tree merge** — tree recordings correctly set ForceSpawnNewVessel during merge dialog callback, preventing PID dedup from skipping spawn after revert (#120)
+- **ForceSpawnNewVessel on flight entry** — all same-PID committed recordings marked at flight entry for standalone recordings
+- **Terminal state protection** — recovered/destroyed terminal state no longer corrupts committed recordings (#94)
+- **Save stale data leak** — `initialLoadDone` reset on main menu transition prevents old recordings leaking into new saves with the same name (#98)
+
+### Recording Improvements
+
+- **Booster/debris tree recording** — `PromoteToTreeForBreakup` auto-promotes standalone recordings to trees on staging; creates root, continuation, and debris child recordings with 30s debris TTL. Continuation seeded with post-breakup points from root recording (#106 watch camera fix)
+- **Flag planting recording/playback** — flag planting captured via `afterFlagPlanted`, stored as `FlagEvent` with position/rotation/flagUrl. Ghost flags built from stock flagPole prefab. Flags spawn as real vessels at playback end with world-space distance dedup
+- **Auto-record from LANDED** — recording now triggers from LANDED state (not just PRELAUNCH) with 5-second settle timer to filter physics bounces, enabling save-loaded pad vessels and Mun takeoffs
+- **Settle timer seed on vessel switch** — `lastLandedUT` seeded in `OnVesselSwitchComplete` for already-landed vessels, fixing auto-record for spawned vessels (#111)
+- **Terminal engine/RCS events** — synthetic EngineShutdown, RCSStopped, and RoboticMotionStopped events emitted at recording stop for all active entries, preventing ghost plumes from persisting past recording end (#108)
+- **Localization resolution** — `#autoLOC` keys resolved to human-readable names in vessel names and group headers via `Localizer.Format()` (#103)
+- **Group name dedup** — multiple launches of same craft get unique group names: "Flea (2)", "Flea (3)" etc. (#104)
+- **Chain boundary fix** — boundary splits skip standalone chain commits during tree mode, preventing nested groups in UI (#87)
+
+### Ghost Visual Improvements
+
+- **Compound part visuals** — fuel lines and struts render correctly on ghosts via PARTDATA/CModuleLinkedMesh fixup
+- **Plume bubble fix** — ghost plume bubble artifacts eliminated by using KSP-native `KSPParticleEmitter.emit` via reflection instead of Unity emission module (#105)
+- **Smoke trail fix** — Unity emission only disabled on FX objects that have KSPParticleEmitter; objects without it (smoke trails) keep their emission intact
+- **Engine plume persistence** — `ModelMultiParticlePersistFX`/`ModelParticleFX` kept alive on ghosts for native KSP plume visuals (stripping them killed smoke trails)
+- **Fairing cap** — `GenerateFairingConeMesh` generates flat disc cap when top XSECTION has non-zero radius (#85)
+- **Fairing internal structure** — prefab Cap/Truss meshes permanently hidden; internal structure revealed only on `FairingJettisoned` event (#91)
+- **Heat material fallback** — fallback path only clones materials that are tracked in `materialStates`, preventing red tint on non-heat parts (#86)
+- **Surface ghost slide fix** — orbit segments skipped for LANDED/SPLASHED/PRELAUNCH vessels; `IsSurfaceAtUT` suppresses orbit interpolation for surface TrackSections; SMA < 90% body radius rejected (#93)
+- **Terrain clamp** — ghost positions clamped above terrain in LateUpdate, preventing underground ghosts regardless of interpolation source
+- **Part events in Visual zone** — structural part events (fairing jettison, staging, destruction) now applied in the Visual zone (2.3-120km), not just Physics zone
+
+### UI Improvements
+
+- **Real Spawn Control window** — proximity-based UI showing ghosts within 500m whose recording ends in the future. Per-craft Warp button, sortable columns (Craft, Dist, Spawns at, In T-), and "Warp to Next Spawn" quick-jump button
+- **Countdown column** — `T-Xd Xh Xm Xs` countdown in Recordings Manager, updates live during playback
+- **Screen notification** when ghost craft enters spawn proximity range (10-second duration)
+- **Toggle button** — "Real Spawn Control (N)" in main window, grayed out when no candidates nearby
+- **Fast Forward redesign** — FF button performs instant UT jump forward (like time warp) instead of loading a quicksave; uses reflection for `BaseConverter.lastUpdateTime` to prevent burst resource production
+- **Pinned bottom buttons** — Warp, Close, and action buttons pinned to window bottom in Actions, Recordings, and Spawn Control windows
+- **Recordings window widened** — 1106 collapsed, 1324 expanded for better readability
+- **Spawn abandon status** — spawn warnings show "walkback exhausted" / "spawn abandoned" status instead of silently retrying
+- **Watch button guards** — disabled for out-of-range ghosts (tooltip: "Ghost is beyond visual range") and past recordings (#89, #90)
+- **Watch overlay repositioned** — moved to left half of screen to avoid altimeter overlap
+
+### Performance & Logging
+
+- **CanRewind/CanFastForward log spam removed** — per-frame VERBOSE logs eliminated (was 578K lines/session, 94% of all output) (#117)
+- **Main menu hook warning downgraded** — "Failed to register main menu hook" from WARN to VERBOSE (#118)
+- **Spawn collision log demotion** — per-frame overlap log from Info to VerboseRateLimited (was ~24K lines/session)
+- **GC allocation reduction** — per-frame allocations reduced in spawn UI via cached vessel names and eliminated redundant scans
+- **Ghost FX audit** — systematic review of KSP-native component usage on ghosts; `KSPParticleEmitter` kept alive with `emit` control, `SmokeTrailControl` stripped (sets alpha to 0 on ghosts), `FXPrefab` stripped (pollutes FloatingOrigin), engine heat/RCS glow reimplementations retained (#113)
+- **ParsekLog thread safety** — test overrides made thread-static to prevent cross-test pollution (#47)
+
 ### Bug Fixes
 
-- **#93**: Surface vehicle ghost slides away during on-rails playback — orbit segments with sub-surface SMA now skipped for LANDED/SPLASHED/PRELAUNCH vessels at recording time; playback uses `IsSurfaceAtUT` to suppress orbit interpolation for surface TrackSections; SMA < 90% body radius rejected as safety net
-- **#109**: Spawned vessels not cleaned up on second rewind — revert path overwrote rewind cleanup data with null; added guard to preserve already-set cleanup data
-- **#110**: Spawn collision retry ran every frame with no limit — added 150-frame (~2.5s) collision block limit for non-chain spawns, walkback exhaustion flag for chain-tip spawns, rate-limited collision log messages
-- **#110b**: Spawn-die-respawn infinite loop — vessels spawned FLYING at sea level are immediately killed by KSP on-rails aero, triggering respawn every frame (~24K cycles/session); added 3-cycle death counter with permanent abandon
-- **#111**: Auto-record not starting for spawned vessels — `lastLandedUT` not seeded on vessel switch to already-landed vessel
-- **Smoke trails** — engine and booster smoke trails invisible on ghosts; Unity emission was disabled on all particle systems but smoke FX have no KSPParticleEmitter to compensate; now only disables Unity emission on FX objects that have KSPParticleEmitter
-- **Terrain clamp** — ghost positions clamped above terrain in LateUpdate, preventing any ghost from appearing underground regardless of interpolation source
-- **#87**: Chain boundary commits no longer create nested groups — boundary splits skip standalone chain commits during tree mode
-- **#104**: Multiple launches of same craft get unique group names — "Flea (2)", "Flea (3)" etc.
-- **#108**: Synthetic EngineShutdown/RCSStopped events emitted at recording stop for all active engines/RCS, preventing ghost plumes from persisting past recording end
-- **#114**: Non-leaf tree recordings and FLYING/SUB_ORBITAL snapshot situations blocked from spawning; crew stripped from Destroyed-terminal-state spawn snapshots
-- **#119**: Watch mode no longer exits when ghost exceeds 120km from active vessel — watched ghosts are exempt from zone distance hiding
-- **#120**: Tree recordings correctly set ForceSpawnNewVessel on merge, preventing PID dedup from skipping spawn after revert
-- **Smoke trails** — engine and booster smoke trails invisible on ghosts; Unity emission was disabled on all particle systems but smoke FX have no KSPParticleEmitter to compensate; now only disables Unity emission on FX objects that have KSPParticleEmitter
-- **Engine plumes** — ModelMultiParticlePersistFX/ModelParticleFX kept alive for native KSP plume visuals
-- **Terrain clamp** — ghost positions clamped above terrain in LateUpdate, preventing any ghost from appearing underground regardless of interpolation source
-- **Compound part ghost visuals** — fuel lines and struts now render correctly on ghosts via PARTDATA fixup (CModuleLinkedMesh replacement)
-
-### Improvements
-
-- **Spawn abandon UI** — spawn warnings show "walkback exhausted" / "spawn abandoned" status instead of silently retrying forever
-- Spawn collision overlap log demoted from Info to VerboseRateLimited (was ~24K lines/session)
-- CanRewind/CanFastForward per-frame VERBOSE log spam removed (was 578K lines/session)
-- "Failed to register main menu hook" downgraded from WARN to VERBOSE
+- **#45**: SubOrbital terminal state recordings no longer attempt vessel spawn
+- **#47**: ParsekLog test overrides made thread-static
+- **#85**: Fairing nosecone cap added to generated cone mesh
+- **#86**: Heat material fallback only clones tracked materials, preventing red tint
+- **#87**: Chain boundary commits no longer create nested groups in tree mode
+- **#89**: Watch button disabled for ghosts beyond visual range
+- **#90**: Watch button disabled for past (finished) recordings
+- **#91**: Fairing internal structure hidden on ghost, revealed on jettison
+- **#92**: Zone rendering tests updated for Visual-zone part events
+- **#93**: Surface ghost slide fixed via orbit segment skip and SMA sanity check
+- **#94**: Recovered/destroyed terminal state no longer corrupts committed recordings
+- **#98**: Save data leak on same-name save recreation fixed via main menu reset
+- **#103**: Localization keys resolved in vessel names and group headers
+- **#104**: Multiple launches of same craft get unique group names
+- **#105**: Ghost plume bubble artifacts fixed by using KSP-native emission
+- **#106**: Watch camera booster fix via continuation point seeding
+- **#108**: Synthetic shutdown events emitted at recording stop for all active engines/RCS
+- **#109**: Spawned vessel cleanup preserved on second rewind
+- **#110**: Spawn collision retry limited to 150 frames with abandon
+- **#110b**: Spawn-die-respawn infinite loop stopped after 3 death cycles
+- **#111**: Auto-record settle timer seeded on vessel switch
+- **#114**: Non-leaf and FLYING/SUB_ORBITAL recordings blocked from spawning; crew stripped from destroyed-vessel snapshots
+- **#119**: Watched ghosts exempt from zone distance hiding
+- **#120**: Tree recordings set ForceSpawnNewVessel on merge
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,8 @@ Spawn safety hardening, ghost visual improvements, booster/debris tree recording
 
 ### Recording Improvements
 
-- **Booster/debris tree recording** — `PromoteToTreeForBreakup` auto-promotes standalone recordings to trees on staging; creates root, continuation, and debris child recordings with 30s debris TTL. Continuation seeded with post-breakup points from root recording (#106 watch camera fix)
+- **Booster/debris tree recording** — `PromoteToTreeForBreakup` auto-promotes standalone recordings to trees on staging; creates root, continuation, and debris child recordings with 60s debris TTL. Continuation seeded with post-breakup points from root recording (#106 watch camera fix)
+- **Controlled child recording** — `ProcessBreakupEvent` now creates child recordings for controlled children (vessels with probe cores surviving breakup), not just debris. Added to BackgroundRecorder with no TTL. Fixes RELATIVE anchor availability during playback (#61)
 - **Flag planting recording/playback** — flag planting captured via `afterFlagPlanted`, stored as `FlagEvent` with position/rotation/flagUrl. Ghost flags built from stock flagPole prefab. Flags spawn as real vessels at playback end with world-space distance dedup
 - **Auto-record from LANDED** — recording now triggers from LANDED state (not just PRELAUNCH) with 5-second settle timer to filter physics bounces, enabling save-loaded pad vessels and Mun takeoffs
 - **Settle timer seed on vessel switch** — `lastLandedUT` seeded in `OnVesselSwitchComplete` for already-landed vessels, fixing auto-record for spawned vessels (#111)
@@ -61,6 +62,7 @@ Spawn safety hardening, ghost visual improvements, booster/debris tree recording
 - **Heat material fallback** — fallback path only clones materials that are tracked in `materialStates`, preventing red tint on non-heat parts (#86)
 - **Surface ghost slide fix** — orbit segments skipped for LANDED/SPLASHED/PRELAUNCH vessels; `IsSurfaceAtUT` suppresses orbit interpolation for surface TrackSections; SMA < 90% body radius rejected (#93)
 - **Terrain clamp** — ghost positions clamped above terrain in LateUpdate, preventing underground ghosts regardless of interpolation source
+- **RELATIVE anchor fallback** — ghosts freeze at last known position instead of hiding when RELATIVE section anchor vessel is missing
 - **Part events in Visual zone** — structural part events (fairing jettison, staging, destruction) now applied in the Visual zone (2.3-120km), not just Physics zone
 
 ### UI Improvements
@@ -73,6 +75,7 @@ Spawn safety hardening, ghost visual improvements, booster/debris tree recording
 - **Pinned bottom buttons** — Warp, Close, and action buttons pinned to window bottom in Actions, Recordings, and Spawn Control windows
 - **Recordings window widened** — 1106 collapsed, 1324 expanded for better readability
 - **Spawn abandon status** — spawn warnings show "walkback exhausted" / "spawn abandoned" status instead of silently retrying
+- **Watch exit key** — changed from Backspace (conflicts with KSP Abort action group) to `[` or `]` bracket keys (#124)
 - **Watch button guards** — disabled for out-of-range ghosts (tooltip: "Ghost is beyond visual range") and past recordings (#89, #90)
 - **Watch overlay repositioned** — moved to left half of screen to avoid altimeter overlap
 
@@ -111,6 +114,8 @@ Spawn safety hardening, ghost visual improvements, booster/debris tree recording
 - **#114**: Non-leaf and FLYING/SUB_ORBITAL recordings blocked from spawning; crew stripped from destroyed-vessel snapshots
 - **#119**: Watched ghosts exempt from zone distance hiding
 - **#120**: Tree recordings set ForceSpawnNewVessel on merge
+- **#61**: Controlled children now recorded after breakup (was "deferred to Phase 2")
+- **#124**: Watch exit key changed from Backspace to brackets (Abort action group conflict)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to Parsek are documented here.
 - **#93**: Surface vehicle ghost slides away during on-rails playback — orbit segments with sub-surface SMA now skipped for LANDED/SPLASHED/PRELAUNCH vessels at recording time; playback uses `IsSurfaceAtUT` to suppress orbit interpolation for surface TrackSections; SMA < 90% body radius rejected as safety net
 - **#109**: Spawned vessels not cleaned up on second rewind — revert path overwrote rewind cleanup data with null; added guard to preserve already-set cleanup data
 - **#110**: Spawn collision retry ran every frame with no limit — added 150-frame (~2.5s) collision block limit for non-chain spawns, walkback exhaustion flag for chain-tip spawns, rate-limited collision log messages
+- **#110b**: Spawn-die-respawn infinite loop — vessels spawned FLYING at sea level are immediately killed by KSP on-rails aero, triggering respawn every frame (~24K cycles/session); added 3-cycle death counter with permanent abandon
 - **#111**: Auto-record not starting for spawned vessels — `lastLandedUT` not seeded on vessel switch to already-landed vessel
 - **Smoke trails** — engine and booster smoke trails invisible on ghosts; Unity emission was disabled on all particle systems but smoke FX have no KSPParticleEmitter to compensate; now only disables Unity emission on FX objects that have KSPParticleEmitter
 - **Terrain clamp** — ghost positions clamped above terrain in LateUpdate, preventing any ghost from appearing underground regardless of interpolation source

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,17 @@ All notable changes to Parsek are documented here.
 ### Bug Fixes
 
 - **#93**: Surface vehicle ghost slides away during on-rails playback — orbit segments with sub-surface SMA now skipped for LANDED/SPLASHED/PRELAUNCH vessels at recording time; playback uses `IsSurfaceAtUT` to suppress orbit interpolation for surface TrackSections; SMA < 90% body radius rejected as safety net
+- **#109**: Spawned vessels not cleaned up on second rewind — revert path overwrote rewind cleanup data with null; added guard to preserve already-set cleanup data
+- **#110**: Spawn collision retry ran every frame with no limit — added 150-frame (~2.5s) collision block limit for non-chain spawns, walkback exhaustion flag for chain-tip spawns, rate-limited collision log messages
+- **#111**: Auto-record not starting for spawned vessels — `lastLandedUT` not seeded on vessel switch to already-landed vessel
+- **Smoke trails** — engine and booster smoke trails invisible on ghosts; Unity emission was disabled on all particle systems but smoke FX have no KSPParticleEmitter to compensate; now only disables Unity emission on FX objects that have KSPParticleEmitter
 - **Terrain clamp** — ghost positions clamped above terrain in LateUpdate, preventing any ghost from appearing underground regardless of interpolation source
+- **Compound part ghost visuals** — fuel lines and struts now render correctly on ghosts via PARTDATA fixup (CModuleLinkedMesh replacement)
+
+### Improvements
+
+- **Spawn abandon UI** — spawn warnings show "walkback exhausted" / "spawn abandoned" status instead of silently retrying forever
+- Spawn collision overlap log demoted from Info to VerboseRateLimited (was ~24K lines/session)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,12 +31,23 @@ All notable changes to Parsek are documented here.
 - **#111**: Auto-record not starting for spawned vessels — `lastLandedUT` not seeded on vessel switch to already-landed vessel
 - **Smoke trails** — engine and booster smoke trails invisible on ghosts; Unity emission was disabled on all particle systems but smoke FX have no KSPParticleEmitter to compensate; now only disables Unity emission on FX objects that have KSPParticleEmitter
 - **Terrain clamp** — ghost positions clamped above terrain in LateUpdate, preventing any ghost from appearing underground regardless of interpolation source
+- **#87**: Chain boundary commits no longer create nested groups — boundary splits skip standalone chain commits during tree mode
+- **#104**: Multiple launches of same craft get unique group names — "Flea (2)", "Flea (3)" etc.
+- **#108**: Synthetic EngineShutdown/RCSStopped events emitted at recording stop for all active engines/RCS, preventing ghost plumes from persisting past recording end
+- **#114**: Non-leaf tree recordings and FLYING/SUB_ORBITAL snapshot situations blocked from spawning; crew stripped from Destroyed-terminal-state spawn snapshots
+- **#119**: Watch mode no longer exits when ghost exceeds 120km from active vessel — watched ghosts are exempt from zone distance hiding
+- **#120**: Tree recordings correctly set ForceSpawnNewVessel on merge, preventing PID dedup from skipping spawn after revert
+- **Smoke trails** — engine and booster smoke trails invisible on ghosts; Unity emission was disabled on all particle systems but smoke FX have no KSPParticleEmitter to compensate; now only disables Unity emission on FX objects that have KSPParticleEmitter
+- **Engine plumes** — ModelMultiParticlePersistFX/ModelParticleFX kept alive for native KSP plume visuals
+- **Terrain clamp** — ghost positions clamped above terrain in LateUpdate, preventing any ghost from appearing underground regardless of interpolation source
 - **Compound part ghost visuals** — fuel lines and struts now render correctly on ghosts via PARTDATA fixup (CModuleLinkedMesh replacement)
 
 ### Improvements
 
 - **Spawn abandon UI** — spawn warnings show "walkback exhausted" / "spawn abandoned" status instead of silently retrying forever
 - Spawn collision overlap log demoted from Info to VerboseRateLimited (was ~24K lines/session)
+- CanRewind/CanFastForward per-frame VERBOSE log spam removed (was 578K lines/session)
+- "Failed to register main menu hook" downgraded from WARN to VERBOSE
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The Parsek window is available from the toolbar button in Flight and Map view.
 | Mod | Integration |
 |-----|-------------|
 | [PersistentRotation](https://github.com/MarkusA380/PersistentRotation) | When detected, Parsek records vessel angular velocity at time warp boundaries. Ghost vessels spin during orbital playback, matching what the player saw with PersistentRotation active. Without it, ghosts hold their SAS-locked attitude (the correct behavior for stock KSP, which freezes rotation on rails). |
+| [Better Time Warp](https://github.com/linuxgurugamer/BetterTimeWarp) | Compatible — Parsek's recording and playback systems work correctly with custom time warp rates. |
 
 ## Installation
 
@@ -108,5 +109,6 @@ Parsek was inspired by and learned from the KSP modding community. The following
 - **[RemoteTech](https://github.com/RemoteTechnologiesGroup/RemoteTech)** (RemoteTechnologiesGroup) - CommNet replacement detection, graceful degradation patterns
 - **[Module Manager](https://github.com/sarbian/ModuleManager)** (sarbian) - essential config patching
 - **[Harmony (HarmonyKSP)](https://github.com/KSPModdingLibs/HarmonyKSP)** (KSPModdingLibs / pardeike) - runtime method patching
+- **[Better Time Warp](https://github.com/linuxgurugamer/BetterTimeWarp)** (linuxgurugamer) - custom time warp rate compatibility testing
 
 Special thanks to **[linuxgurugamer](https://github.com/linuxgurugamer/)** for maintaining so many essential KSP mods, and to the KSP modding community for making this kind of project possible.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ The Parsek window is available from the toolbar button in Flight and Map view.
 | Mod | Integration |
 |-----|-------------|
 | [PersistentRotation](https://github.com/MarkusA380/PersistentRotation) | When detected, Parsek records vessel angular velocity at time warp boundaries. Ghost vessels spin during orbital playback, matching what the player saw with PersistentRotation active. Without it, ghosts hold their SAS-locked attitude (the correct behavior for stock KSP, which freezes rotation on rails). |
-| [Better Time Warp](https://github.com/linuxgurugamer/BetterTimeWarp) | Compatible — Parsek's recording and playback systems work correctly with custom time warp rates. |
 
 ## Installation
 

--- a/Source/Parsek.Tests/BackgroundSplitTests.cs
+++ b/Source/Parsek.Tests/BackgroundSplitTests.cs
@@ -265,9 +265,9 @@ namespace Parsek.Tests
         #region TTL Constant
 
         [Fact]
-        public void DebrisTTLSeconds_Is30()
+        public void DebrisTTLSeconds_Is60()
         {
-            Assert.Equal(30.0, BackgroundRecorder.DebrisTTLSeconds);
+            Assert.Equal(60.0, BackgroundRecorder.DebrisTTLSeconds);
         }
 
         #endregion

--- a/Source/Parsek.Tests/FastForwardTests.cs
+++ b/Source/Parsek.Tests/FastForwardTests.cs
@@ -61,7 +61,9 @@ namespace Parsek.Tests
             string reason;
             Assert.False(RecordingStore.CanFastForward(rec, out reason, isRecording: false));
             Assert.Equal("Rewind already in progress", reason);
-            Assert.Contains(logLines, l =>
+            // Bug #117: blocked-path VERBOSE logs removed (per-frame UI spam).
+            // Reason is conveyed via the out parameter, not log output.
+            Assert.DoesNotContain(logLines, l =>
                 l.Contains("[Store]") && l.Contains("CanFastForward") && l.Contains("blocked"));
         }
 

--- a/Source/Parsek.Tests/MergeDialogVesselTests.cs
+++ b/Source/Parsek.Tests/MergeDialogVesselTests.cs
@@ -326,5 +326,134 @@ namespace Parsek.Tests
 
             Assert.Contains("<-- you are here", text);
         }
+
+        // ============================================================
+        // MarkForceSpawnOnTreeRecordings
+        // ============================================================
+
+        [Fact]
+        public void MarkForceSpawnOnTreeRecordings_MatchingPid_SetsFlag()
+        {
+            var tree = new RecordingTree { TreeName = "TestTree" };
+            tree.Recordings["r1"] = new Recording
+            {
+                RecordingId = "r1",
+                VesselName = "Capsule",
+                VesselPersistentId = 42,
+                VesselSpawned = false,
+                ForceSpawnNewVessel = false
+            };
+
+            int count = MergeDialog.MarkForceSpawnOnTreeRecordings(tree, 42);
+
+            Assert.Equal(1, count);
+            Assert.True(tree.Recordings["r1"].ForceSpawnNewVessel);
+            Assert.Contains(logLines, l => l.Contains("[MergeDialog]") && l.Contains("marked") && l.Contains("Capsule"));
+        }
+
+        [Fact]
+        public void MarkForceSpawnOnTreeRecordings_DifferentPid_NoChange()
+        {
+            var tree = new RecordingTree { TreeName = "TestTree" };
+            tree.Recordings["r1"] = new Recording
+            {
+                RecordingId = "r1",
+                VesselName = "Capsule",
+                VesselPersistentId = 42,
+                VesselSpawned = false,
+                ForceSpawnNewVessel = false
+            };
+
+            int count = MergeDialog.MarkForceSpawnOnTreeRecordings(tree, 99);
+
+            Assert.Equal(0, count);
+            Assert.False(tree.Recordings["r1"].ForceSpawnNewVessel);
+            Assert.Contains(logLines, l => l.Contains("[MergeDialog]") && l.Contains("no recordings matched"));
+        }
+
+        [Fact]
+        public void MarkForceSpawnOnTreeRecordings_AlreadySpawned_Skipped()
+        {
+            var tree = new RecordingTree { TreeName = "TestTree" };
+            tree.Recordings["r1"] = new Recording
+            {
+                RecordingId = "r1",
+                VesselName = "Capsule",
+                VesselPersistentId = 42,
+                VesselSpawned = true,
+                ForceSpawnNewVessel = false
+            };
+
+            int count = MergeDialog.MarkForceSpawnOnTreeRecordings(tree, 42);
+
+            Assert.Equal(0, count);
+            Assert.False(tree.Recordings["r1"].ForceSpawnNewVessel);
+        }
+
+        [Fact]
+        public void MarkForceSpawnOnTreeRecordings_ZeroPid_Skipped()
+        {
+            var tree = new RecordingTree { TreeName = "TestTree" };
+            tree.Recordings["r1"] = new Recording
+            {
+                RecordingId = "r1",
+                VesselName = "Capsule",
+                VesselPersistentId = 42,
+                VesselSpawned = false,
+                ForceSpawnNewVessel = false
+            };
+
+            int count = MergeDialog.MarkForceSpawnOnTreeRecordings(tree, 0);
+
+            Assert.Equal(0, count);
+            Assert.False(tree.Recordings["r1"].ForceSpawnNewVessel);
+            Assert.Contains(logLines, l => l.Contains("[MergeDialog]") && l.Contains("skip"));
+        }
+
+        [Fact]
+        public void MarkForceSpawnOnTreeRecordings_NullTree_ReturnsZero()
+        {
+            int count = MergeDialog.MarkForceSpawnOnTreeRecordings(null, 42);
+
+            Assert.Equal(0, count);
+            Assert.Contains(logLines, l => l.Contains("[MergeDialog]") && l.Contains("skip"));
+        }
+
+        [Fact]
+        public void MarkForceSpawnOnTreeRecordings_MultipleRecordings_OnlyMatchingMarked()
+        {
+            var tree = new RecordingTree { TreeName = "TestTree" };
+            tree.Recordings["r1"] = new Recording
+            {
+                RecordingId = "r1",
+                VesselName = "Booster",
+                VesselPersistentId = 42,
+                VesselSpawned = false,
+                ForceSpawnNewVessel = false
+            };
+            tree.Recordings["r2"] = new Recording
+            {
+                RecordingId = "r2",
+                VesselName = "Capsule",
+                VesselPersistentId = 99,
+                VesselSpawned = false,
+                ForceSpawnNewVessel = false
+            };
+            tree.Recordings["r3"] = new Recording
+            {
+                RecordingId = "r3",
+                VesselName = "Payload",
+                VesselPersistentId = 42,
+                VesselSpawned = false,
+                ForceSpawnNewVessel = false
+            };
+
+            int count = MergeDialog.MarkForceSpawnOnTreeRecordings(tree, 42);
+
+            Assert.Equal(2, count);
+            Assert.True(tree.Recordings["r1"].ForceSpawnNewVessel);
+            Assert.False(tree.Recordings["r2"].ForceSpawnNewVessel);
+            Assert.True(tree.Recordings["r3"].ForceSpawnNewVessel);
+        }
     }
 }

--- a/Source/Parsek.Tests/SpawnCleanupGuardTests.cs
+++ b/Source/Parsek.Tests/SpawnCleanupGuardTests.cs
@@ -1,0 +1,282 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Tests for the PendingCleanup guard logic in the revert path (bug #109).
+    /// Verifies that cleanup data set by the rewind path is not overwritten
+    /// by the subsequent false-positive revert path.
+    /// </summary>
+    [Collection("Sequential")]
+    public class SpawnCleanupGuardTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public SpawnCleanupGuardTests()
+        {
+            RecordingStore.SuppressLogging = false;
+            RecordingStore.ResetForTesting();
+            MilestoneStore.SuppressLogging = true;
+            MilestoneStore.ResetForTesting();
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+            RecordingStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+            MilestoneStore.ResetForTesting();
+        }
+
+        [Fact]
+        public void PendingCleanupPids_SurviveWhenAlreadySet()
+        {
+            // Simulate the rewind path setting cleanup data
+            var rewindPids = new HashSet<uint> { 42, 99 };
+            RecordingStore.PendingCleanupPids = rewindPids;
+
+            // After rewind, ResetAllPlaybackState zeros spawn tracking,
+            // so CollectSpawnedVesselInfo returns empty.
+            // The revert path's guard should detect already-set data and skip.
+
+            // Verify the data survives (it should not be overwritten)
+            Assert.NotNull(RecordingStore.PendingCleanupPids);
+            Assert.Equal(2, RecordingStore.PendingCleanupPids.Count);
+            Assert.Contains(42u, RecordingStore.PendingCleanupPids);
+            Assert.Contains(99u, RecordingStore.PendingCleanupPids);
+        }
+
+        [Fact]
+        public void PendingCleanupNames_SurviveWhenAlreadySet()
+        {
+            // Simulate the rewind path setting cleanup names
+            var rewindNames = new HashSet<string> { "Rocket", "Shuttle" };
+            RecordingStore.PendingCleanupNames = rewindNames;
+
+            // Verify the data survives
+            Assert.NotNull(RecordingStore.PendingCleanupNames);
+            Assert.Equal(2, RecordingStore.PendingCleanupNames.Count);
+            Assert.Contains("Rocket", RecordingStore.PendingCleanupNames);
+            Assert.Contains("Shuttle", RecordingStore.PendingCleanupNames);
+        }
+
+        [Fact]
+        public void RevertPath_SetsCleanupData_WhenNotAlreadySet()
+        {
+            // When PendingCleanupPids/Names are both null, the revert path
+            // should collect and set them.
+            Assert.Null(RecordingStore.PendingCleanupPids);
+            Assert.Null(RecordingStore.PendingCleanupNames);
+
+            // Add a spawned recording so CollectSpawnedVesselInfo returns data
+            RecordingStore.CommittedRecordings.Add(new Recording
+                { VesselName = "Probe", SpawnedVesselPersistentId = 77 });
+
+            var info = RecordingStore.CollectSpawnedVesselInfo();
+            var spawnedPids = info.pids.Count > 0 ? info.pids : null;
+            var spawnedNames = info.names.Count > 0 ? info.names : null;
+            RecordingStore.PendingCleanupPids = spawnedPids;
+            RecordingStore.PendingCleanupNames = spawnedNames;
+
+            Assert.NotNull(RecordingStore.PendingCleanupPids);
+            Assert.Contains(77u, RecordingStore.PendingCleanupPids);
+            Assert.NotNull(RecordingStore.PendingCleanupNames);
+            Assert.Contains("Probe", RecordingStore.PendingCleanupNames);
+        }
+
+        [Fact]
+        public void Guard_DetectsAlreadySetPids_SkipsCollection()
+        {
+            // Pre-set only PIDs (names null)
+            RecordingStore.PendingCleanupPids = new HashSet<uint> { 50 };
+
+            bool alreadyHasCleanupData = RecordingStore.PendingCleanupPids != null
+                                          || RecordingStore.PendingCleanupNames != null;
+
+            Assert.True(alreadyHasCleanupData);
+        }
+
+        [Fact]
+        public void Guard_DetectsAlreadySetNames_SkipsCollection()
+        {
+            // Pre-set only names (PIDs null)
+            RecordingStore.PendingCleanupNames = new HashSet<string> { "Vessel" };
+
+            bool alreadyHasCleanupData = RecordingStore.PendingCleanupPids != null
+                                          || RecordingStore.PendingCleanupNames != null;
+
+            Assert.True(alreadyHasCleanupData);
+        }
+
+        [Fact]
+        public void Guard_BothNull_AllowsCollection()
+        {
+            // Both null: guard should allow collection
+            bool alreadyHasCleanupData = RecordingStore.PendingCleanupPids != null
+                                          || RecordingStore.PendingCleanupNames != null;
+
+            Assert.False(alreadyHasCleanupData);
+        }
+
+        [Fact]
+        public void RewindThenRevert_CleanupDataSurvives()
+        {
+            // Full sequence simulation: rewind sets data, then revert path fires.
+            // Step 1: Rewind path sets cleanup data
+            RecordingStore.CommittedRecordings.Add(new Recording
+                { VesselName = "Rocket", SpawnedVesselPersistentId = 42 });
+
+            var (rewindPids, _) = RecordingStore.CollectSpawnedVesselInfo();
+            RecordingStore.PendingCleanupPids = rewindPids.Count > 0 ? rewindPids : null;
+            var allNames = RecordingStore.CollectAllRecordingVesselNames();
+            RecordingStore.PendingCleanupNames = allNames.Count > 0 ? allNames : null;
+
+            // Step 2: ResetAllPlaybackState zeros spawn tracking
+            RecordingStore.ResetAllPlaybackState();
+
+            // Step 3: CollectSpawnedVesselInfo now returns empty (PIDs are zero)
+            var (emptyPids, emptyNames) = RecordingStore.CollectSpawnedVesselInfo();
+            Assert.Empty(emptyPids);
+            Assert.Empty(emptyNames);
+
+            // Step 4: Guard check (what the revert path does)
+            bool alreadyHasCleanupData = RecordingStore.PendingCleanupPids != null
+                                          || RecordingStore.PendingCleanupNames != null;
+            Assert.True(alreadyHasCleanupData,
+                "Cleanup data from rewind must survive through the revert path");
+
+            // Step 5: Verify the original data is intact
+            Assert.Contains(42u, RecordingStore.PendingCleanupPids);
+            Assert.Contains("Rocket", RecordingStore.PendingCleanupNames);
+        }
+
+        [Fact]
+        public void RewindThenRevert_WithoutGuard_WouldLoseData()
+        {
+            // Demonstrates the bug: without the guard, the revert path
+            // would overwrite rewind data with empty.
+            RecordingStore.CommittedRecordings.Add(new Recording
+                { VesselName = "Rocket", SpawnedVesselPersistentId = 42 });
+
+            // Rewind path sets data
+            var (rewindPids, _) = RecordingStore.CollectSpawnedVesselInfo();
+            RecordingStore.PendingCleanupPids = rewindPids.Count > 0 ? rewindPids : null;
+            var allNames = RecordingStore.CollectAllRecordingVesselNames();
+            RecordingStore.PendingCleanupNames = allNames.Count > 0 ? allNames : null;
+
+            Assert.NotNull(RecordingStore.PendingCleanupPids);
+            Assert.NotNull(RecordingStore.PendingCleanupNames);
+
+            // ResetAllPlaybackState zeros spawn tracking
+            RecordingStore.ResetAllPlaybackState();
+
+            // Without guard: unconditional collection returns empty and overwrites
+            var (emptyPids, emptyNames) = RecordingStore.CollectSpawnedVesselInfo();
+            var wouldSetPids = emptyPids.Count > 0 ? emptyPids : null;
+            var wouldSetNames = emptyNames.Count > 0 ? emptyNames : null;
+
+            // This is what the bug would do: overwrite with null
+            Assert.Null(wouldSetPids);
+            Assert.Null(wouldSetNames);
+
+            // But the guard prevents this: original data is still there
+            Assert.NotNull(RecordingStore.PendingCleanupPids);
+            Assert.NotNull(RecordingStore.PendingCleanupNames);
+        }
+
+        [Fact]
+        public void ResetForTesting_ClearsPendingCleanupData()
+        {
+            RecordingStore.PendingCleanupPids = new HashSet<uint> { 1, 2, 3 };
+            RecordingStore.PendingCleanupNames = new HashSet<string> { "A", "B" };
+
+            RecordingStore.ResetForTesting();
+
+            Assert.Null(RecordingStore.PendingCleanupPids);
+            Assert.Null(RecordingStore.PendingCleanupNames);
+        }
+
+        #region Log Assertion Tests
+
+        [Fact]
+        public void Guard_LogsSkipMessage_WhenAlreadySet()
+        {
+            // Pre-set cleanup data (simulating rewind path)
+            RecordingStore.PendingCleanupPids = new HashSet<uint> { 42 };
+            RecordingStore.PendingCleanupNames = new HashSet<string> { "Rocket", "Shuttle" };
+
+            // Simulate the guard logging (same logic as ParsekScenario.OnLoad)
+            bool alreadyHasCleanupData = RecordingStore.PendingCleanupPids != null
+                                          || RecordingStore.PendingCleanupNames != null;
+            if (alreadyHasCleanupData)
+            {
+                ParsekLog.Info("Scenario",
+                    $"OnLoad: revert path skipping cleanup collection — " +
+                    $"already set ({RecordingStore.PendingCleanupPids?.Count ?? 0} pid(s), " +
+                    $"{RecordingStore.PendingCleanupNames?.Count ?? 0} name(s)) from prior rewind/revert");
+            }
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[Scenario]") &&
+                l.Contains("revert path skipping cleanup collection") &&
+                l.Contains("1 pid(s)") &&
+                l.Contains("2 name(s)"));
+        }
+
+        [Fact]
+        public void RewindPath_LogsCleanupDataSet()
+        {
+            // Add a recording so we get non-empty data
+            RecordingStore.CommittedRecordings.Add(new Recording
+                { VesselName = "Rocket", SpawnedVesselPersistentId = 42 });
+
+            // Simulate the rewind path's collection and logging
+            var (rewindPids, _) = RecordingStore.CollectSpawnedVesselInfo();
+            RecordingStore.PendingCleanupPids = rewindPids.Count > 0 ? rewindPids : null;
+            var allNames = RecordingStore.CollectAllRecordingVesselNames();
+            RecordingStore.PendingCleanupNames = allNames.Count > 0 ? allNames : null;
+
+            ParsekLog.Info("Rewind",
+                $"OnLoad: rewind cleanup data set — " +
+                $"{rewindPids.Count} pid(s), {allNames.Count} name(s)");
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[Rewind]") &&
+                l.Contains("rewind cleanup data set") &&
+                l.Contains("1 pid(s)") &&
+                l.Contains("1 name(s)"));
+        }
+
+        [Fact]
+        public void RevertPath_LogsCollected_WhenNotAlreadySet()
+        {
+            // Simulate the revert path collecting data (guard allows it)
+            RecordingStore.CommittedRecordings.Add(new Recording
+                { VesselName = "Probe", SpawnedVesselPersistentId = 77 });
+
+            var info = RecordingStore.CollectSpawnedVesselInfo();
+            var spawnedPids = info.pids.Count > 0 ? info.pids : null;
+            var spawnedNames = info.names.Count > 0 ? info.names : null;
+            RecordingStore.PendingCleanupPids = spawnedPids;
+            RecordingStore.PendingCleanupNames = spawnedNames;
+
+            ParsekLog.Verbose("Scenario",
+                $"OnLoad: revert cleanup collected — " +
+                $"{spawnedPids?.Count ?? 0} pid(s), {spawnedNames?.Count ?? 0} name(s)");
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[Scenario]") &&
+                l.Contains("revert cleanup collected") &&
+                l.Contains("1 pid(s)") &&
+                l.Contains("1 name(s)"));
+        }
+
+        #endregion
+    }
+}

--- a/Source/Parsek.Tests/SpawnCollisionBlockLimitTests.cs
+++ b/Source/Parsek.Tests/SpawnCollisionBlockLimitTests.cs
@@ -194,5 +194,58 @@ namespace Parsek.Tests
             var rec = new Recording();
             Assert.Equal(0, rec.CollisionBlockCount);
         }
+
+        // ────────────────────────────────────────────────────────────
+        //  Recording.SpawnAbandoned field
+        // ────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void Recording_SpawnAbandoned_DefaultsFalse()
+        {
+            var rec = new Recording();
+            Assert.False(rec.SpawnAbandoned);
+        }
+
+        [Fact]
+        public void SpawnAbandoned_PreventsVesselGoneReset()
+        {
+            // Simulate abandon: VesselSpawned=true, SpawnAbandoned=true, PID=0
+            var rec = new Recording
+            {
+                VesselSpawned = true,
+                SpawnAbandoned = true,
+                SpawnedVesselPersistentId = 0,
+                CollisionBlockCount = 150
+            };
+
+            // The vessel-gone check guards on !rec.SpawnAbandoned.
+            // When SpawnAbandoned is true, the check should be skipped
+            // — VesselSpawned stays true and CollisionBlockCount is not reset.
+            bool wouldEnterVesselGoneCheck = !rec.SpawnAbandoned
+                && (rec.VesselSpawned || rec.SpawnedVesselPersistentId != 0);
+
+            Assert.False(wouldEnterVesselGoneCheck,
+                "SpawnAbandoned should prevent the vessel-gone check from resetting spawn state");
+            Assert.True(rec.VesselSpawned, "VesselSpawned must remain true after abandon");
+            Assert.Equal(150, rec.CollisionBlockCount);
+        }
+
+        [Fact]
+        public void SpawnAbandoned_False_AllowsVesselGoneReset()
+        {
+            // Normal spawn (not abandoned): vessel-gone check should be allowed
+            var rec = new Recording
+            {
+                VesselSpawned = true,
+                SpawnAbandoned = false,
+                SpawnedVesselPersistentId = 0
+            };
+
+            bool wouldEnterVesselGoneCheck = !rec.SpawnAbandoned
+                && (rec.VesselSpawned || rec.SpawnedVesselPersistentId != 0);
+
+            Assert.True(wouldEnterVesselGoneCheck,
+                "Normal spawns should still allow the vessel-gone reset check");
+        }
     }
 }

--- a/Source/Parsek.Tests/SpawnCollisionBlockLimitTests.cs
+++ b/Source/Parsek.Tests/SpawnCollisionBlockLimitTests.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Tests for the collision block limit (bug #110 fix):
+    /// - <see cref="VesselSpawner.ShouldAbandonCollisionBlockedSpawn"/> pure method
+    /// - <see cref="SpawnWarningUI.FormatChainStatus"/> walkback-exhausted variant
+    /// - <see cref="SpawnWarningUI.ComputeGhostLabelText"/> walkback-exhausted variant
+    /// </summary>
+    [Collection("Sequential")]
+    public class SpawnCollisionBlockLimitTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public SpawnCollisionBlockLimitTests()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.VerboseOverrideForTesting = true;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+        }
+
+        // ────────────────────────────────────────────────────────────
+        //  ShouldAbandonCollisionBlockedSpawn
+        // ────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void ShouldAbandonCollisionBlockedSpawn_AtMax_ReturnsTrue()
+        {
+            Assert.True(VesselSpawner.ShouldAbandonCollisionBlockedSpawn(150, 150));
+        }
+
+        [Fact]
+        public void ShouldAbandonCollisionBlockedSpawn_AboveMax_ReturnsTrue()
+        {
+            Assert.True(VesselSpawner.ShouldAbandonCollisionBlockedSpawn(200, 150));
+        }
+
+        [Fact]
+        public void ShouldAbandonCollisionBlockedSpawn_BelowMax_ReturnsFalse()
+        {
+            Assert.False(VesselSpawner.ShouldAbandonCollisionBlockedSpawn(149, 150));
+        }
+
+        [Fact]
+        public void ShouldAbandonCollisionBlockedSpawn_Zero_ReturnsFalse()
+        {
+            Assert.False(VesselSpawner.ShouldAbandonCollisionBlockedSpawn(0, 150));
+        }
+
+        [Fact]
+        public void ShouldAbandonCollisionBlockedSpawn_ZeroMax_ZeroCount_ReturnsTrue()
+        {
+            // Edge case: max=0 means abandon immediately
+            Assert.True(VesselSpawner.ShouldAbandonCollisionBlockedSpawn(0, 0));
+        }
+
+        [Fact]
+        public void MaxCollisionBlocks_ConstantValue()
+        {
+            // Verify the constant is set to 150 (~2.5s at 60fps)
+            Assert.Equal(150, VesselSpawner.MaxCollisionBlocks);
+        }
+
+        // ────────────────────────────────────────────────────────────
+        //  FormatChainStatus — walkback exhausted
+        // ────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void FormatChainStatus_BlockedAndWalkbackExhausted_ShowsExhaustedMessage()
+        {
+            var chain = new GhostChain
+            {
+                OriginalVesselPid = 100,
+                SpawnUT = 18500.0,
+                TipRecordingId = "rec-1",
+                IsTerminated = false,
+                SpawnBlocked = true,
+                WalkbackExhausted = true
+            };
+
+            string status = SpawnWarningUI.FormatChainStatus(chain, "TestVessel");
+
+            Assert.Contains("walkback exhausted", status);
+            Assert.Contains("manual placement required", status);
+            Assert.Contains(logLines, l => l.Contains("[SpawnWarning]") && l.Contains("FormatChainStatus")
+                && l.Contains("walkbackExhausted=True"));
+        }
+
+        [Fact]
+        public void FormatChainStatus_BlockedNotExhausted_ShowsWaitingMessage()
+        {
+            var chain = new GhostChain
+            {
+                OriginalVesselPid = 100,
+                SpawnUT = 18500.0,
+                TipRecordingId = "rec-1",
+                IsTerminated = false,
+                SpawnBlocked = true,
+                WalkbackExhausted = false
+            };
+
+            string status = SpawnWarningUI.FormatChainStatus(chain, "TestVessel");
+
+            Assert.Contains("waiting for clearance", status);
+            Assert.DoesNotContain("walkback exhausted", status);
+        }
+
+        [Fact]
+        public void FormatChainStatus_WalkbackExhaustedButNotBlocked_ShowsNormalStatus()
+        {
+            // WalkbackExhausted without SpawnBlocked should show normal status
+            var chain = new GhostChain
+            {
+                OriginalVesselPid = 100,
+                SpawnUT = 18500.0,
+                TipRecordingId = "rec-1",
+                IsTerminated = false,
+                SpawnBlocked = false,
+                WalkbackExhausted = true
+            };
+
+            string status = SpawnWarningUI.FormatChainStatus(chain, "TestVessel");
+
+            Assert.Contains("spawns at UT=18500", status);
+            Assert.DoesNotContain("walkback exhausted", status);
+        }
+
+        // ────────────────────────────────────────────────────────────
+        //  ComputeGhostLabelText — walkback exhausted
+        // ────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void ComputeGhostLabelText_BlockedAndWalkbackExhausted_ShowsAbandoned()
+        {
+            string label = SpawnWarningUI.ComputeGhostLabelText(
+                "TestVessel", 18500.0, false, true, true);
+
+            Assert.Contains("spawn abandoned", label);
+            Assert.DoesNotContain("spawn blocked\n", label);
+            Assert.Contains(logLines, l => l.Contains("[SpawnWarning]")
+                && l.Contains("ComputeGhostLabelText")
+                && l.Contains("walkbackExhausted=True"));
+        }
+
+        [Fact]
+        public void ComputeGhostLabelText_BlockedNotExhausted_ShowsBlocked()
+        {
+            string label = SpawnWarningUI.ComputeGhostLabelText(
+                "TestVessel", 18500.0, false, true, false);
+
+            Assert.Contains("spawn blocked", label);
+            Assert.DoesNotContain("abandoned", label);
+        }
+
+        [Fact]
+        public void ComputeGhostLabelText_DefaultParam_BackwardCompatible()
+        {
+            // Existing callers without the isWalkbackExhausted param should still work
+            string label = SpawnWarningUI.ComputeGhostLabelText(
+                "TestVessel", 18500.0, false, true);
+
+            Assert.Contains("spawn blocked", label);
+            Assert.DoesNotContain("abandoned", label);
+        }
+
+        // ────────────────────────────────────────────────────────────
+        //  GhostChain.WalkbackExhausted field
+        // ────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void GhostChain_WalkbackExhausted_DefaultsFalse()
+        {
+            var chain = new GhostChain();
+            Assert.False(chain.WalkbackExhausted);
+        }
+
+        // ────────────────────────────────────────────────────────────
+        //  Recording.CollisionBlockCount field
+        // ────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void Recording_CollisionBlockCount_DefaultsZero()
+        {
+            var rec = new Recording();
+            Assert.Equal(0, rec.CollisionBlockCount);
+        }
+    }
+}

--- a/Source/Parsek.Tests/SpawnCollisionBlockLimitTests.cs
+++ b/Source/Parsek.Tests/SpawnCollisionBlockLimitTests.cs
@@ -247,5 +247,99 @@ namespace Parsek.Tests
             Assert.True(wouldEnterVesselGoneCheck,
                 "Normal spawns should still allow the vessel-gone reset check");
         }
+
+        // ────────────────────────────────────────────────────────────
+        //  ShouldAbandonSpawnDeathLoop
+        // ────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void ShouldAbandonSpawnDeathLoop_AtMax_ReturnsTrue()
+        {
+            Assert.True(VesselSpawner.ShouldAbandonSpawnDeathLoop(3, 3));
+        }
+
+        [Fact]
+        public void ShouldAbandonSpawnDeathLoop_AboveMax_ReturnsTrue()
+        {
+            Assert.True(VesselSpawner.ShouldAbandonSpawnDeathLoop(5, 3));
+        }
+
+        [Fact]
+        public void ShouldAbandonSpawnDeathLoop_BelowMax_ReturnsFalse()
+        {
+            Assert.False(VesselSpawner.ShouldAbandonSpawnDeathLoop(2, 3));
+        }
+
+        [Fact]
+        public void ShouldAbandonSpawnDeathLoop_Zero_ReturnsFalse()
+        {
+            Assert.False(VesselSpawner.ShouldAbandonSpawnDeathLoop(0, 3));
+        }
+
+        [Fact]
+        public void MaxSpawnDeathCycles_ConstantValue()
+        {
+            Assert.Equal(3, VesselSpawner.MaxSpawnDeathCycles);
+        }
+
+        [Fact]
+        public void Recording_SpawnDeathCount_DefaultsZero()
+        {
+            var rec = new Recording();
+            Assert.Equal(0, rec.SpawnDeathCount);
+        }
+
+        [Fact]
+        public void SpawnDeathLoop_AtMax_AbandonsSpawn()
+        {
+            var rec = new Recording
+            {
+                VesselSpawned = true,
+                SpawnedVesselPersistentId = 42,
+                SpawnDeathCount = 2 // will become 3 after increment
+            };
+
+            // Simulate the vessel-gone check incrementing and hitting the cap
+            rec.SpawnDeathCount++;
+            bool shouldAbandon = VesselSpawner.ShouldAbandonSpawnDeathLoop(
+                rec.SpawnDeathCount, VesselSpawner.MaxSpawnDeathCycles);
+
+            Assert.True(shouldAbandon);
+
+            // Apply abandon state
+            rec.VesselSpawned = true;
+            rec.SpawnAbandoned = true;
+
+            Assert.True(rec.VesselSpawned);
+            Assert.True(rec.SpawnAbandoned);
+            Assert.Equal(3, rec.SpawnDeathCount);
+        }
+
+        [Fact]
+        public void SpawnDeathLoop_BelowMax_ResetsSpawnState()
+        {
+            var rec = new Recording
+            {
+                VesselSpawned = true,
+                SpawnedVesselPersistentId = 42,
+                SpawnDeathCount = 0
+            };
+
+            // Simulate first death
+            rec.SpawnDeathCount++;
+            bool shouldAbandon = VesselSpawner.ShouldAbandonSpawnDeathLoop(
+                rec.SpawnDeathCount, VesselSpawner.MaxSpawnDeathCycles);
+
+            Assert.False(shouldAbandon);
+
+            // Apply reset state (what the vessel-gone check does)
+            rec.VesselSpawned = false;
+            rec.SpawnedVesselPersistentId = 0;
+            rec.CollisionBlockCount = 0;
+
+            Assert.False(rec.VesselSpawned);
+            Assert.Equal(0u, rec.SpawnedVesselPersistentId);
+            Assert.Equal(1, rec.SpawnDeathCount); // count preserved across reset
+        }
     }
 }

--- a/Source/Parsek.Tests/SpawnSafetyNetTests.cs
+++ b/Source/Parsek.Tests/SpawnSafetyNetTests.cs
@@ -1,0 +1,469 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Tests for bug #114 fixes: non-leaf tree spawn suppression safety net,
+    /// snapshot situation unsafe check, and crew stripping for destroyed vessels.
+    /// </summary>
+    [Collection("Sequential")]
+    public class SpawnSafetyNetTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public SpawnSafetyNetTests()
+        {
+            RecordingStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+            MilestoneStore.SuppressLogging = true;
+            MilestoneStore.ResetForTesting();
+            GameStateStore.SuppressLogging = true;
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+            RecordingStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+            MilestoneStore.ResetForTesting();
+        }
+
+        #region IsNonLeafInCommittedTree
+
+        [Fact]
+        public void IsNonLeafInCommittedTree_ParentOfBranchPoint_ReturnsTrue()
+        {
+            // Build a committed tree where "root-rec" is a parent of a branch point
+            var tree = new RecordingTree
+            {
+                Id = "tree-1",
+                TreeName = "CrashTree",
+                RootRecordingId = "root-rec"
+            };
+
+            var rootRec = new Recording
+            {
+                RecordingId = "root-rec",
+                TreeId = "tree-1",
+                VesselPersistentId = 100,
+                // Simulate the bug: ChildBranchPointId is null (not set)
+                ChildBranchPointId = null
+            };
+
+            var childRec = new Recording
+            {
+                RecordingId = "child-rec",
+                TreeId = "tree-1",
+                VesselPersistentId = 100,
+                ParentBranchPointId = "bp-1"
+            };
+
+            var bp = new BranchPoint
+            {
+                Id = "bp-1",
+                Type = BranchPointType.Breakup,
+                UT = 78.0
+            };
+            bp.ParentRecordingIds.Add("root-rec");
+            bp.ChildRecordingIds.Add("child-rec");
+
+            tree.Recordings["root-rec"] = rootRec;
+            tree.Recordings["child-rec"] = childRec;
+            tree.BranchPoints.Add(bp);
+
+            RecordingStore.CommittedRecordings.Add(rootRec);
+            RecordingStore.CommittedRecordings.Add(childRec);
+            RecordingStore.CommittedTrees.Add(tree);
+
+            bool result = GhostPlaybackLogic.IsNonLeafInCommittedTree(rootRec);
+
+            Assert.True(result);
+            Assert.Contains(logLines, l =>
+                l.Contains("[Spawner]") &&
+                l.Contains("IsNonLeafInCommittedTree") &&
+                l.Contains("root-rec") &&
+                l.Contains("safety net triggered"));
+        }
+
+        [Fact]
+        public void IsNonLeafInCommittedTree_LeafRecording_ReturnsFalse()
+        {
+            var tree = new RecordingTree
+            {
+                Id = "tree-2",
+                TreeName = "SimpleTree",
+                RootRecordingId = "root-rec"
+            };
+
+            var leafRec = new Recording
+            {
+                RecordingId = "leaf-rec",
+                TreeId = "tree-2",
+                VesselPersistentId = 200,
+                ChildBranchPointId = null
+            };
+
+            // No branch point references leaf-rec as parent
+            tree.Recordings["leaf-rec"] = leafRec;
+            RecordingStore.CommittedRecordings.Add(leafRec);
+            RecordingStore.CommittedTrees.Add(tree);
+
+            bool result = GhostPlaybackLogic.IsNonLeafInCommittedTree(leafRec);
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsNonLeafInCommittedTree_StandaloneRecording_ReturnsFalse()
+        {
+            // Recording without TreeId — standalone, not in any tree
+            var standalone = new Recording
+            {
+                RecordingId = "standalone-1",
+                TreeId = null,
+                VesselPersistentId = 300
+            };
+
+            bool result = GhostPlaybackLogic.IsNonLeafInCommittedTree(standalone);
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsNonLeafInCommittedTree_EmptyRecordingId_ReturnsFalse()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "",
+                TreeId = "tree-x"
+            };
+
+            bool result = GhostPlaybackLogic.IsNonLeafInCommittedTree(rec);
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsNonLeafInCommittedTree_TreeNotCommitted_ReturnsFalse()
+        {
+            // Recording references a tree that is not in CommittedTrees
+            var rec = new Recording
+            {
+                RecordingId = "orphan-rec",
+                TreeId = "nonexistent-tree"
+            };
+
+            bool result = GhostPlaybackLogic.IsNonLeafInCommittedTree(rec);
+
+            Assert.False(result);
+        }
+
+        #endregion
+
+        #region IsSnapshotSituationUnsafe
+
+        [Fact]
+        public void IsSnapshotSituationUnsafe_Flying_ReturnsTrue()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            snapshot.AddValue("sit", "FLYING");
+
+            Assert.True(GhostPlaybackLogic.IsSnapshotSituationUnsafe(snapshot));
+        }
+
+        [Fact]
+        public void IsSnapshotSituationUnsafe_SubOrbital_ReturnsTrue()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            snapshot.AddValue("sit", "SUB_ORBITAL");
+
+            Assert.True(GhostPlaybackLogic.IsSnapshotSituationUnsafe(snapshot));
+        }
+
+        [Fact]
+        public void IsSnapshotSituationUnsafe_Landed_ReturnsFalse()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            snapshot.AddValue("sit", "LANDED");
+
+            Assert.False(GhostPlaybackLogic.IsSnapshotSituationUnsafe(snapshot));
+        }
+
+        [Fact]
+        public void IsSnapshotSituationUnsafe_Orbiting_ReturnsFalse()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            snapshot.AddValue("sit", "ORBITING");
+
+            Assert.False(GhostPlaybackLogic.IsSnapshotSituationUnsafe(snapshot));
+        }
+
+        [Fact]
+        public void IsSnapshotSituationUnsafe_Splashed_ReturnsFalse()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            snapshot.AddValue("sit", "SPLASHED");
+
+            Assert.False(GhostPlaybackLogic.IsSnapshotSituationUnsafe(snapshot));
+        }
+
+        [Fact]
+        public void IsSnapshotSituationUnsafe_Prelaunch_ReturnsFalse()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            snapshot.AddValue("sit", "PRELAUNCH");
+
+            Assert.False(GhostPlaybackLogic.IsSnapshotSituationUnsafe(snapshot));
+        }
+
+        [Fact]
+        public void IsSnapshotSituationUnsafe_NullSnapshot_ReturnsFalse()
+        {
+            Assert.False(GhostPlaybackLogic.IsSnapshotSituationUnsafe(null));
+        }
+
+        [Fact]
+        public void IsSnapshotSituationUnsafe_NoSitField_ReturnsFalse()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            // No sit field at all
+            Assert.False(GhostPlaybackLogic.IsSnapshotSituationUnsafe(snapshot));
+        }
+
+        [Fact]
+        public void IsSnapshotSituationUnsafe_CaseInsensitive()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            snapshot.AddValue("sit", "flying");
+
+            Assert.True(GhostPlaybackLogic.IsSnapshotSituationUnsafe(snapshot));
+        }
+
+        #endregion
+
+        #region ShouldSpawnAtRecordingEnd — Snapshot Situation Suppression
+
+        [Fact]
+        public void ShouldSpawn_FlyingSnapshot_ReturnsFalse()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            snapshot.AddValue("sit", "FLYING");
+
+            var rec = new Recording
+            {
+                VesselSnapshot = snapshot,
+                TerminalStateValue = null // No terminal state set
+            };
+
+            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtRecordingEnd(
+                rec, isActiveChainMember: false, isChainLoopingOrDisabled: false);
+
+            Assert.False(needsSpawn);
+            Assert.Contains("snapshot situation unsafe", reason);
+        }
+
+        [Fact]
+        public void ShouldSpawn_SubOrbitalSnapshot_ReturnsFalse()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            snapshot.AddValue("sit", "SUB_ORBITAL");
+
+            var rec = new Recording
+            {
+                VesselSnapshot = snapshot,
+                TerminalStateValue = null
+            };
+
+            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtRecordingEnd(
+                rec, isActiveChainMember: false, isChainLoopingOrDisabled: false);
+
+            Assert.False(needsSpawn);
+            Assert.Contains("snapshot situation unsafe", reason);
+        }
+
+        [Fact]
+        public void ShouldSpawn_LandedSnapshot_NoTerminalState_Allowed()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            snapshot.AddValue("sit", "LANDED");
+
+            var rec = new Recording
+            {
+                VesselSnapshot = snapshot,
+                TerminalStateValue = null
+            };
+
+            var (needsSpawn, _) = GhostPlaybackLogic.ShouldSpawnAtRecordingEnd(
+                rec, isActiveChainMember: false, isChainLoopingOrDisabled: false);
+
+            Assert.True(needsSpawn);
+        }
+
+        #endregion
+
+        #region ShouldSpawnAtRecordingEnd — Non-Leaf Safety Net
+
+        [Fact]
+        public void ShouldSpawn_NonLeafInTree_NullChildBranchPointId_ReturnsFalse()
+        {
+            // Tree where root has children but ChildBranchPointId is null (the bug)
+            var tree = new RecordingTree
+            {
+                Id = "tree-crash",
+                TreeName = "CrashTree",
+                RootRecordingId = "root-rec"
+            };
+
+            var rootRec = new Recording
+            {
+                RecordingId = "root-rec",
+                TreeId = "tree-crash",
+                VesselPersistentId = 100,
+                VesselSnapshot = new ConfigNode("VESSEL"),
+                ChildBranchPointId = null // Bug: not set
+            };
+
+            var bp = new BranchPoint
+            {
+                Id = "bp-crash",
+                Type = BranchPointType.Breakup,
+                UT = 78.0
+            };
+            bp.ParentRecordingIds.Add("root-rec");
+            bp.ChildRecordingIds.Add("child-rec");
+
+            tree.Recordings["root-rec"] = rootRec;
+            tree.BranchPoints.Add(bp);
+            RecordingStore.CommittedTrees.Add(tree);
+
+            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtRecordingEnd(
+                rootRec, isActiveChainMember: false, isChainLoopingOrDisabled: false);
+
+            Assert.False(needsSpawn);
+            Assert.Contains("non-leaf in committed tree", reason);
+        }
+
+        #endregion
+
+        #region ShouldStripCrewForSpawn
+
+        [Fact]
+        public void ShouldStripCrewForSpawn_Destroyed_ReturnsTrue()
+        {
+            var rec = new Recording { TerminalStateValue = TerminalState.Destroyed };
+
+            Assert.True(VesselSpawner.ShouldStripCrewForSpawn(rec));
+        }
+
+        [Fact]
+        public void ShouldStripCrewForSpawn_Landed_ReturnsFalse()
+        {
+            var rec = new Recording { TerminalStateValue = TerminalState.Landed };
+
+            Assert.False(VesselSpawner.ShouldStripCrewForSpawn(rec));
+        }
+
+        [Fact]
+        public void ShouldStripCrewForSpawn_Orbiting_ReturnsFalse()
+        {
+            var rec = new Recording { TerminalStateValue = TerminalState.Orbiting };
+
+            Assert.False(VesselSpawner.ShouldStripCrewForSpawn(rec));
+        }
+
+        [Fact]
+        public void ShouldStripCrewForSpawn_NullTerminalState_ReturnsFalse()
+        {
+            var rec = new Recording { TerminalStateValue = null };
+
+            Assert.False(VesselSpawner.ShouldStripCrewForSpawn(rec));
+        }
+
+        [Fact]
+        public void ShouldStripCrewForSpawn_Recovered_ReturnsFalse()
+        {
+            var rec = new Recording { TerminalStateValue = TerminalState.Recovered };
+
+            Assert.False(VesselSpawner.ShouldStripCrewForSpawn(rec));
+        }
+
+        [Fact]
+        public void ShouldStripCrewForSpawn_SubOrbital_ReturnsFalse()
+        {
+            var rec = new Recording { TerminalStateValue = TerminalState.SubOrbital };
+
+            Assert.False(VesselSpawner.ShouldStripCrewForSpawn(rec));
+        }
+
+        #endregion
+
+        #region StripAllCrewFromSnapshot
+
+        [Fact]
+        public void StripAllCrewFromSnapshot_RemovesAllCrew()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            var part1 = new ConfigNode("PART");
+            part1.AddValue("crew", "Jebediah Kerman");
+            part1.AddValue("crew", "Bill Kerman");
+            var part2 = new ConfigNode("PART");
+            part2.AddValue("crew", "Valentina Kerman");
+            snapshot.AddNode(part1);
+            snapshot.AddNode(part2);
+
+            int removed = VesselSpawner.StripAllCrewFromSnapshot(snapshot);
+
+            Assert.Equal(3, removed);
+
+            // Verify no crew remain
+            foreach (ConfigNode partNode in snapshot.GetNodes("PART"))
+            {
+                Assert.Empty(partNode.GetValues("crew"));
+            }
+        }
+
+        [Fact]
+        public void StripAllCrewFromSnapshot_NoCrew_ReturnsZero()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            var part = new ConfigNode("PART");
+            snapshot.AddNode(part);
+
+            int removed = VesselSpawner.StripAllCrewFromSnapshot(snapshot);
+
+            Assert.Equal(0, removed);
+        }
+
+        [Fact]
+        public void StripAllCrewFromSnapshot_NullSnapshot_ReturnsZero()
+        {
+            int removed = VesselSpawner.StripAllCrewFromSnapshot(null);
+
+            Assert.Equal(0, removed);
+        }
+
+        [Fact]
+        public void StripAllCrewFromSnapshot_LogsRemovedCrew()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            var part = new ConfigNode("PART");
+            part.AddValue("crew", "Jebediah Kerman");
+            snapshot.AddNode(part);
+
+            VesselSpawner.StripAllCrewFromSnapshot(snapshot);
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[Spawner]") &&
+                l.Contains("StripAllCrewFromSnapshot") &&
+                l.Contains("Jebediah Kerman"));
+        }
+
+        #endregion
+    }
+}

--- a/Source/Parsek.Tests/SyntheticRecordingTests.cs
+++ b/Source/Parsek.Tests/SyntheticRecordingTests.cs
@@ -1349,7 +1349,7 @@ namespace Parsek.Tests
             double rowCenterOffsetMeters = -((ShowcaseEntriesPerLine - 1) * spacingMeters * 0.5);
             lat = -0.0972 + ((lineRowIndex * spacingMeters + rowCenterOffsetMeters + rowOffsetMeters) / metersPerDegree);
             lon = -74.5575 + ((distanceFromPadMeters + lineIndex * ShowcaseLineSpacingMeters + distanceOffsetMeters) / metersPerDegree);
-            alt = 66.0;
+            alt = 116.0; // 50m above ground level so engine exhaust is visible from below
         }
 
         /// <summary>

--- a/Source/Parsek.Tests/TerminalEngineRcsEventTests.cs
+++ b/Source/Parsek.Tests/TerminalEngineRcsEventTests.cs
@@ -1,0 +1,387 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Tests for FlightRecorder.EmitTerminalEngineAndRcsEvents — synthetic shutdown
+    /// events emitted at recording boundary for engines/RCS/robotics still active.
+    /// Bug #108.
+    /// </summary>
+    [Collection("Sequential")]
+    public class TerminalEngineRcsEventTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public TerminalEngineRcsEventTests()
+        {
+            RecordingStore.SuppressLogging = true;
+            MilestoneStore.SuppressLogging = true;
+            MilestoneStore.ResetForTesting();
+            GameStateStore.SuppressLogging = true;
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+            ParsekLog.VerboseOverrideForTesting = true;
+            RecordingStore.ResetForTesting();
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+            RecordingStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+            MilestoneStore.ResetForTesting();
+        }
+
+        #region No active keys — empty result
+
+        [Fact]
+        public void EmitTerminal_NoActiveKeys_ReturnsEmptyList()
+        {
+            var engines = new HashSet<ulong>();
+            var rcs = new HashSet<ulong>();
+            var robotics = new HashSet<ulong>();
+            var roboticPos = new Dictionary<ulong, float>();
+
+            var events = FlightRecorder.EmitTerminalEngineAndRcsEvents(
+                engines, rcs, robotics, roboticPos, 5000.0, "Test");
+
+            Assert.Empty(events);
+        }
+
+        [Fact]
+        public void EmitTerminal_NullSets_ReturnsEmptyList()
+        {
+            var events = FlightRecorder.EmitTerminalEngineAndRcsEvents(
+                null, null, null, null, 5000.0, "Test");
+
+            Assert.Empty(events);
+        }
+
+        [Fact]
+        public void EmitTerminal_NoActiveKeys_NoLogEmitted()
+        {
+            var engines = new HashSet<ulong>();
+            var rcs = new HashSet<ulong>();
+            var robotics = new HashSet<ulong>();
+            var roboticPos = new Dictionary<ulong, float>();
+
+            FlightRecorder.EmitTerminalEngineAndRcsEvents(
+                engines, rcs, robotics, roboticPos, 5000.0, "Test");
+
+            // No summary log when zero events emitted
+            Assert.DoesNotContain(logLines, l => l.Contains("terminal events"));
+        }
+
+        #endregion
+
+        #region Engine terminal events
+
+        [Fact]
+        public void EmitTerminal_OneActiveEngine_EmitsEngineShutdown()
+        {
+            uint pid = 42000;
+            int midx = 0;
+            ulong key = FlightRecorder.EncodeEngineKey(pid, midx);
+
+            var engines = new HashSet<ulong> { key };
+            var rcs = new HashSet<ulong>();
+            var robotics = new HashSet<ulong>();
+            var roboticPos = new Dictionary<ulong, float>();
+
+            var events = FlightRecorder.EmitTerminalEngineAndRcsEvents(
+                engines, rcs, robotics, roboticPos, 5000.0, "Test");
+
+            Assert.Single(events);
+            Assert.Equal(PartEventType.EngineShutdown, events[0].eventType);
+            Assert.Equal(pid, events[0].partPersistentId);
+            Assert.Equal(midx, events[0].moduleIndex);
+            Assert.Equal(5000.0, events[0].ut);
+        }
+
+        [Fact]
+        public void EmitTerminal_MultipleActiveEngines_EmitsShutdownForEach()
+        {
+            ulong key1 = FlightRecorder.EncodeEngineKey(100, 0);
+            ulong key2 = FlightRecorder.EncodeEngineKey(200, 1);
+            ulong key3 = FlightRecorder.EncodeEngineKey(300, 2);
+
+            var engines = new HashSet<ulong> { key1, key2, key3 };
+            var rcs = new HashSet<ulong>();
+            var robotics = new HashSet<ulong>();
+            var roboticPos = new Dictionary<ulong, float>();
+
+            var events = FlightRecorder.EmitTerminalEngineAndRcsEvents(
+                engines, rcs, robotics, roboticPos, 9999.0, "Test");
+
+            Assert.Equal(3, events.Count);
+            Assert.All(events, e => Assert.Equal(PartEventType.EngineShutdown, e.eventType));
+            Assert.All(events, e => Assert.Equal(9999.0, e.ut));
+
+            var pids = events.Select(e => e.partPersistentId).OrderBy(p => p).ToList();
+            Assert.Equal(new List<uint> { 100, 200, 300 }, pids);
+        }
+
+        [Fact]
+        public void EmitTerminal_EngineWithNonZeroModuleIndex_PreservesModuleIndex()
+        {
+            uint pid = 55555;
+            int midx = 3;
+            ulong key = FlightRecorder.EncodeEngineKey(pid, midx);
+
+            var engines = new HashSet<ulong> { key };
+
+            var events = FlightRecorder.EmitTerminalEngineAndRcsEvents(
+                engines, new HashSet<ulong>(), new HashSet<ulong>(),
+                new Dictionary<ulong, float>(), 7000.0, "Test");
+
+            Assert.Single(events);
+            Assert.Equal(3, events[0].moduleIndex);
+            Assert.Equal(pid, events[0].partPersistentId);
+        }
+
+        [Fact]
+        public void EmitTerminal_ActiveEngine_LogsTerminalEvent()
+        {
+            ulong key = FlightRecorder.EncodeEngineKey(42000, 0);
+            var engines = new HashSet<ulong> { key };
+
+            FlightRecorder.EmitTerminalEngineAndRcsEvents(
+                engines, new HashSet<ulong>(), new HashSet<ulong>(),
+                new Dictionary<ulong, float>(), 5000.0, "TestTag");
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[TestTag]") &&
+                l.Contains("Terminal event: EngineShutdown") &&
+                l.Contains("pid=42000") &&
+                l.Contains("midx=0"));
+        }
+
+        #endregion
+
+        #region RCS terminal events
+
+        [Fact]
+        public void EmitTerminal_OneActiveRcs_EmitsRcsStopped()
+        {
+            uint pid = 88000;
+            int midx = 1;
+            ulong key = FlightRecorder.EncodeEngineKey(pid, midx);
+
+            var engines = new HashSet<ulong>();
+            var rcs = new HashSet<ulong> { key };
+            var robotics = new HashSet<ulong>();
+            var roboticPos = new Dictionary<ulong, float>();
+
+            var events = FlightRecorder.EmitTerminalEngineAndRcsEvents(
+                engines, rcs, robotics, roboticPos, 6000.0, "Test");
+
+            Assert.Single(events);
+            Assert.Equal(PartEventType.RCSStopped, events[0].eventType);
+            Assert.Equal(pid, events[0].partPersistentId);
+            Assert.Equal(midx, events[0].moduleIndex);
+            Assert.Equal(6000.0, events[0].ut);
+        }
+
+        [Fact]
+        public void EmitTerminal_MultipleActiveRcs_EmitsStoppedForEach()
+        {
+            ulong key1 = FlightRecorder.EncodeEngineKey(400, 0);
+            ulong key2 = FlightRecorder.EncodeEngineKey(500, 0);
+
+            var rcs = new HashSet<ulong> { key1, key2 };
+
+            var events = FlightRecorder.EmitTerminalEngineAndRcsEvents(
+                new HashSet<ulong>(), rcs, new HashSet<ulong>(),
+                new Dictionary<ulong, float>(), 8000.0, "Test");
+
+            Assert.Equal(2, events.Count);
+            Assert.All(events, e => Assert.Equal(PartEventType.RCSStopped, e.eventType));
+            Assert.All(events, e => Assert.Equal(8000.0, e.ut));
+        }
+
+        [Fact]
+        public void EmitTerminal_ActiveRcs_LogsTerminalEvent()
+        {
+            ulong key = FlightRecorder.EncodeEngineKey(88000, 1);
+            var rcs = new HashSet<ulong> { key };
+
+            FlightRecorder.EmitTerminalEngineAndRcsEvents(
+                new HashSet<ulong>(), rcs, new HashSet<ulong>(),
+                new Dictionary<ulong, float>(), 6000.0, "TestTag");
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[TestTag]") &&
+                l.Contains("Terminal event: RCSStopped") &&
+                l.Contains("pid=88000") &&
+                l.Contains("midx=1"));
+        }
+
+        #endregion
+
+        #region Robotic terminal events
+
+        [Fact]
+        public void EmitTerminal_OneActiveRobotic_EmitsRoboticMotionStopped()
+        {
+            uint pid = 77000;
+            int midx = 0;
+            ulong key = FlightRecorder.EncodeEngineKey(pid, midx);
+
+            var robotics = new HashSet<ulong> { key };
+            var roboticPos = new Dictionary<ulong, float> { { key, 0.75f } };
+
+            var events = FlightRecorder.EmitTerminalEngineAndRcsEvents(
+                new HashSet<ulong>(), new HashSet<ulong>(), robotics,
+                roboticPos, 7000.0, "Test");
+
+            Assert.Single(events);
+            Assert.Equal(PartEventType.RoboticMotionStopped, events[0].eventType);
+            Assert.Equal(pid, events[0].partPersistentId);
+            Assert.Equal(midx, events[0].moduleIndex);
+            Assert.Equal(0.75f, events[0].value);
+            Assert.Equal(7000.0, events[0].ut);
+        }
+
+        [Fact]
+        public void EmitTerminal_ActiveRoboticNoPositionMap_UsesZero()
+        {
+            ulong key = FlightRecorder.EncodeEngineKey(77000, 0);
+            var robotics = new HashSet<ulong> { key };
+
+            var events = FlightRecorder.EmitTerminalEngineAndRcsEvents(
+                new HashSet<ulong>(), new HashSet<ulong>(), robotics,
+                null, 7000.0, "Test");
+
+            Assert.Single(events);
+            Assert.Equal(0f, events[0].value);
+        }
+
+        [Fact]
+        public void EmitTerminal_ActiveRoboticKeyNotInPositionMap_UsesZero()
+        {
+            ulong key = FlightRecorder.EncodeEngineKey(77000, 0);
+            var robotics = new HashSet<ulong> { key };
+            var roboticPos = new Dictionary<ulong, float>(); // empty — key not present
+
+            var events = FlightRecorder.EmitTerminalEngineAndRcsEvents(
+                new HashSet<ulong>(), new HashSet<ulong>(), robotics,
+                roboticPos, 7000.0, "Test");
+
+            Assert.Single(events);
+            Assert.Equal(0f, events[0].value);
+        }
+
+        [Fact]
+        public void EmitTerminal_ActiveRobotic_LogsTerminalEvent()
+        {
+            ulong key = FlightRecorder.EncodeEngineKey(77000, 0);
+            var robotics = new HashSet<ulong> { key };
+            var roboticPos = new Dictionary<ulong, float> { { key, 0.5f } };
+
+            FlightRecorder.EmitTerminalEngineAndRcsEvents(
+                new HashSet<ulong>(), new HashSet<ulong>(), robotics,
+                roboticPos, 7000.0, "TestTag");
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[TestTag]") &&
+                l.Contains("Terminal event: RoboticMotionStopped") &&
+                l.Contains("pid=77000"));
+        }
+
+        #endregion
+
+        #region Mixed active sets
+
+        [Fact]
+        public void EmitTerminal_EnginesAndRcsAndRobotics_EmitsAllTerminalEvents()
+        {
+            ulong engineKey = FlightRecorder.EncodeEngineKey(1000, 0);
+            ulong rcsKey = FlightRecorder.EncodeEngineKey(2000, 0);
+            ulong roboticKey = FlightRecorder.EncodeEngineKey(3000, 0);
+
+            var engines = new HashSet<ulong> { engineKey };
+            var rcs = new HashSet<ulong> { rcsKey };
+            var robotics = new HashSet<ulong> { roboticKey };
+            var roboticPos = new Dictionary<ulong, float> { { roboticKey, 0.3f } };
+
+            var events = FlightRecorder.EmitTerminalEngineAndRcsEvents(
+                engines, rcs, robotics, roboticPos, 10000.0, "Test");
+
+            Assert.Equal(3, events.Count);
+            Assert.Contains(events, e => e.eventType == PartEventType.EngineShutdown && e.partPersistentId == 1000);
+            Assert.Contains(events, e => e.eventType == PartEventType.RCSStopped && e.partPersistentId == 2000);
+            Assert.Contains(events, e => e.eventType == PartEventType.RoboticMotionStopped && e.partPersistentId == 3000);
+            Assert.All(events, e => Assert.Equal(10000.0, e.ut));
+        }
+
+        [Fact]
+        public void EmitTerminal_MixedActive_LogsSummaryWithCounts()
+        {
+            ulong engineKey1 = FlightRecorder.EncodeEngineKey(1000, 0);
+            ulong engineKey2 = FlightRecorder.EncodeEngineKey(1001, 1);
+            ulong rcsKey = FlightRecorder.EncodeEngineKey(2000, 0);
+
+            var engines = new HashSet<ulong> { engineKey1, engineKey2 };
+            var rcs = new HashSet<ulong> { rcsKey };
+
+            FlightRecorder.EmitTerminalEngineAndRcsEvents(
+                engines, rcs, new HashSet<ulong>(),
+                new Dictionary<ulong, float>(), 10000.0, "TestTag");
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[TestTag]") &&
+                l.Contains("Emitted 3 terminal events") &&
+                l.Contains("engines=2") &&
+                l.Contains("rcs=1") &&
+                l.Contains("robotics=0"));
+        }
+
+        #endregion
+
+        #region UT correctness
+
+        [Fact]
+        public void EmitTerminal_AllEventsUseFinalUT()
+        {
+            double finalUT = 12345.678;
+            ulong engineKey = FlightRecorder.EncodeEngineKey(100, 0);
+            ulong rcsKey = FlightRecorder.EncodeEngineKey(200, 0);
+
+            var events = FlightRecorder.EmitTerminalEngineAndRcsEvents(
+                new HashSet<ulong> { engineKey },
+                new HashSet<ulong> { rcsKey },
+                new HashSet<ulong>(),
+                new Dictionary<ulong, float>(),
+                finalUT, "Test");
+
+            Assert.All(events, e => Assert.Equal(finalUT, e.ut));
+        }
+
+        #endregion
+
+        #region Part name is "unknown" (no live vessel lookup in static method)
+
+        [Fact]
+        public void EmitTerminal_PartNameIsUnknown()
+        {
+            ulong key = FlightRecorder.EncodeEngineKey(42000, 0);
+
+            var events = FlightRecorder.EmitTerminalEngineAndRcsEvents(
+                new HashSet<ulong> { key },
+                new HashSet<ulong>(),
+                new HashSet<ulong>(),
+                new Dictionary<ulong, float>(),
+                5000.0, "Test");
+
+            Assert.Single(events);
+            Assert.Equal("unknown", events[0].partName);
+        }
+
+        #endregion
+    }
+}

--- a/Source/Parsek.Tests/UniqueGroupNameTests.cs
+++ b/Source/Parsek.Tests/UniqueGroupNameTests.cs
@@ -1,0 +1,148 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    [Collection("Sequential")]
+    public class UniqueGroupNameTests : System.IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public UniqueGroupNameTests()
+        {
+            RecordingStore.SuppressLogging = false;
+            RecordingStore.ResetForTesting();
+            MilestoneStore.SuppressLogging = true;
+            MilestoneStore.ResetForTesting();
+            GameStateStore.SuppressLogging = true;
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+            ParsekScenario.ResetGroupsForTesting();
+            ParsekScenario.ResetReplacementsForTesting();
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+            RecordingStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+            ParsekScenario.ResetGroupsForTesting();
+            ParsekScenario.ResetReplacementsForTesting();
+        }
+
+        [Fact]
+        public void FirstUse_ReturnsBaseNameUnchanged()
+        {
+            string result = RecordingStore.GenerateUniqueGroupName("Flea");
+
+            Assert.Equal("Flea", result);
+            Assert.Contains(logLines, l =>
+                l.Contains("[RecordingStore]") && l.Contains("'Flea' is unique"));
+        }
+
+        [Fact]
+        public void SecondUse_AppendsSuffix2()
+        {
+            // Commit a recording in the "Flea" group
+            RecordingStore.CommittedRecordings.Add(new Recording
+            {
+                VesselName = "Flea",
+                RecordingGroups = new List<string> { "Flea" }
+            });
+
+            string result = RecordingStore.GenerateUniqueGroupName("Flea");
+
+            Assert.Equal("Flea (2)", result);
+            Assert.Contains(logLines, l =>
+                l.Contains("[RecordingStore]") && l.Contains("using 'Flea (2)'"));
+        }
+
+        [Fact]
+        public void ThirdUse_AppendsSuffix3()
+        {
+            // Two existing groups: "Flea" and "Flea (2)"
+            RecordingStore.CommittedRecordings.Add(new Recording
+            {
+                VesselName = "Flea",
+                RecordingGroups = new List<string> { "Flea" }
+            });
+            RecordingStore.CommittedRecordings.Add(new Recording
+            {
+                VesselName = "Flea",
+                RecordingGroups = new List<string> { "Flea (2)" }
+            });
+
+            string result = RecordingStore.GenerateUniqueGroupName("Flea");
+
+            Assert.Equal("Flea (3)", result);
+            Assert.Contains(logLines, l =>
+                l.Contains("[RecordingStore]") && l.Contains("using 'Flea (3)'"));
+        }
+
+        [Fact]
+        public void DifferentBaseName_DoesNotCollide()
+        {
+            RecordingStore.CommittedRecordings.Add(new Recording
+            {
+                VesselName = "Flea",
+                RecordingGroups = new List<string> { "Flea" }
+            });
+
+            string result = RecordingStore.GenerateUniqueGroupName("Hopper");
+
+            Assert.Equal("Hopper", result);
+        }
+
+        [Fact]
+        public void NullBaseName_FallsBackToChain()
+        {
+            string result = RecordingStore.GenerateUniqueGroupName(null);
+
+            Assert.Equal("Chain", result);
+            Assert.Contains(logLines, l =>
+                l.Contains("[RecordingStore]") && l.Contains("baseName is null/empty"));
+        }
+
+        [Fact]
+        public void EmptyBaseName_FallsBackToChain()
+        {
+            string result = RecordingStore.GenerateUniqueGroupName("");
+
+            Assert.Equal("Chain", result);
+            Assert.Contains(logLines, l =>
+                l.Contains("[RecordingStore]") && l.Contains("baseName is null/empty"));
+        }
+
+        [Fact]
+        public void CaseInsensitive_DetectsCollision()
+        {
+            RecordingStore.CommittedRecordings.Add(new Recording
+            {
+                VesselName = "flea",
+                RecordingGroups = new List<string> { "flea" }
+            });
+
+            // "Flea" should collide with "flea" (case-insensitive)
+            string result = RecordingStore.GenerateUniqueGroupName("Flea");
+
+            Assert.Equal("Flea (2)", result);
+        }
+
+        [Fact]
+        public void GapInSequence_FillsFirstAvailable()
+        {
+            // Existing: "Flea" and "Flea (3)" — gap at (2)
+            RecordingStore.CommittedRecordings.Add(new Recording
+            {
+                VesselName = "Flea",
+                RecordingGroups = new List<string> { "Flea", "Flea (3)" }
+            });
+
+            string result = RecordingStore.GenerateUniqueGroupName("Flea");
+
+            Assert.Equal("Flea (2)", result);
+        }
+    }
+}

--- a/Source/Parsek/BackgroundRecorder.cs
+++ b/Source/Parsek/BackgroundRecorder.cs
@@ -1207,7 +1207,7 @@ namespace Parsek
                 }
             }
 
-            // Close and flush TrackSections for all loaded vessels
+            // Close and flush TrackSections for all loaded vessels, emit terminal engine/RCS/robotic events (bug #108)
             foreach (var kvp in loadedStates)
             {
                 var state = kvp.Value;
@@ -1217,6 +1217,11 @@ namespace Parsek
                 if (tree.Recordings.TryGetValue(state.recordingId, out flushRec))
                 {
                     FlushTrackSectionsToRecording(state, flushRec);
+
+                    var terminalEvents = FlightRecorder.EmitTerminalEngineAndRcsEvents(
+                        state.activeEngineKeys, state.activeRcsKeys, state.activeRoboticKeys,
+                        state.lastRoboticPosition, commitUT, "BgRecorder");
+                    flushRec.PartEvents.AddRange(terminalEvents);
                 }
             }
 

--- a/Source/Parsek/BackgroundRecorder.cs
+++ b/Source/Parsek/BackgroundRecorder.cs
@@ -34,7 +34,7 @@ namespace Parsek
         private const double ExplicitEndUpdateInterval = 30.0;
 
         // Debris TTL: stop recording debris after this many seconds
-        internal const double DebrisTTLSeconds = 30.0;
+        internal const double DebrisTTLSeconds = 60.0;
 
         // Per-vessel debris TTL tracking (vesselPid -> UT at which to stop recording)
         // double.NaN = no TTL (controlled vessel, keep recording indefinitely)

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -125,6 +125,22 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Clears atmosphere-boundary and SOI-change flags without stopping or restarting
+        /// the recorder. Used when tree mode intercepts a boundary crossing — the recorder
+        /// keeps accumulating data into the tree recording, but the standalone chain-commit
+        /// path is suppressed.
+        /// </summary>
+        public void ClearBoundaryFlags()
+        {
+            AtmosphereBoundaryCrossed = false;
+            EnteredAtmosphere = false;
+            atmosphereBoundaryPending = false;
+            SoiChangePending = false;
+            SoiChangeFromBody = null;
+            ParsekLog.Verbose("Recorder", "Boundary flags cleared (tree mode bypass)");
+        }
+
+        /// <summary>
         /// True when the recorder is conceptually recording but not actively sampling
         /// physics frames (e.g., vessel switched away in tree mode).
         /// </summary>
@@ -2038,6 +2054,101 @@ namespace Parsek
             moduleIndex = (int)(key & 0xFF);
         }
 
+        /// <summary>
+        /// Emits synthetic EngineShutdown, RCSStopped, and RoboticMotionStopped events
+        /// for all engines/RCS/robotics still active when a recording ends (user stop,
+        /// chain boundary, scene change). Without these, ghost plumes and FX may stay
+        /// frozen at the last throttle level instead of shutting down at recording end.
+        /// Bug #108.
+        /// </summary>
+        internal static List<PartEvent> EmitTerminalEngineAndRcsEvents(
+            HashSet<ulong> activeEngineKeys,
+            HashSet<ulong> activeRcsKeys,
+            HashSet<ulong> activeRoboticKeys,
+            Dictionary<ulong, float> lastRoboticPosition,
+            double finalUT,
+            string logTag)
+        {
+            var events = new List<PartEvent>();
+
+            // Terminal EngineShutdown for each active engine
+            if (activeEngineKeys != null && activeEngineKeys.Count > 0)
+            {
+                // Snapshot keys before iterating (we don't modify the set here, but defensive)
+                var keys = new List<ulong>(activeEngineKeys);
+                for (int i = 0; i < keys.Count; i++)
+                {
+                    uint pid; int midx;
+                    DecodeEngineKey(keys[i], out pid, out midx);
+                    events.Add(new PartEvent
+                    {
+                        ut = finalUT,
+                        partPersistentId = pid,
+                        eventType = PartEventType.EngineShutdown,
+                        partName = "unknown",
+                        moduleIndex = midx
+                    });
+                    ParsekLog.Verbose(logTag,
+                        $"Terminal event: EngineShutdown pid={pid} midx={midx} at UT={finalUT.ToString("F2", System.Globalization.CultureInfo.InvariantCulture)}");
+                }
+            }
+
+            // Terminal RCSStopped for each active RCS
+            if (activeRcsKeys != null && activeRcsKeys.Count > 0)
+            {
+                var keys = new List<ulong>(activeRcsKeys);
+                for (int i = 0; i < keys.Count; i++)
+                {
+                    uint pid; int midx;
+                    DecodeEngineKey(keys[i], out pid, out midx);
+                    events.Add(new PartEvent
+                    {
+                        ut = finalUT,
+                        partPersistentId = pid,
+                        eventType = PartEventType.RCSStopped,
+                        partName = "unknown",
+                        moduleIndex = midx
+                    });
+                    ParsekLog.Verbose(logTag,
+                        $"Terminal event: RCSStopped pid={pid} midx={midx} at UT={finalUT.ToString("F2", System.Globalization.CultureInfo.InvariantCulture)}");
+                }
+            }
+
+            // Terminal RoboticMotionStopped for each active robotic module
+            if (activeRoboticKeys != null && activeRoboticKeys.Count > 0)
+            {
+                var keys = new List<ulong>(activeRoboticKeys);
+                for (int i = 0; i < keys.Count; i++)
+                {
+                    uint pid; int midx;
+                    DecodeEngineKey(keys[i], out pid, out midx);
+                    float lastPos = 0f;
+                    if (lastRoboticPosition != null)
+                        lastRoboticPosition.TryGetValue(keys[i], out lastPos);
+                    events.Add(new PartEvent
+                    {
+                        ut = finalUT,
+                        partPersistentId = pid,
+                        eventType = PartEventType.RoboticMotionStopped,
+                        partName = "unknown",
+                        value = lastPos,
+                        moduleIndex = midx
+                    });
+                    ParsekLog.Verbose(logTag,
+                        $"Terminal event: RoboticMotionStopped pid={pid} midx={midx} pos={lastPos.ToString("F3", System.Globalization.CultureInfo.InvariantCulture)} at UT={finalUT.ToString("F2", System.Globalization.CultureInfo.InvariantCulture)}");
+                }
+            }
+
+            if (events.Count > 0)
+            {
+                ParsekLog.Info(logTag,
+                    $"Emitted {events.Count} terminal events at UT={finalUT.ToString("F2", System.Globalization.CultureInfo.InvariantCulture)}" +
+                    $" (engines={activeEngineKeys?.Count ?? 0}, rcs={activeRcsKeys?.Count ?? 0}, robotics={activeRoboticKeys?.Count ?? 0})");
+            }
+
+            return events;
+        }
+
         private static string FormatCoverageEntries(List<string> entries, int maxEntries = 8)
         {
             if (entries == null || entries.Count == 0)
@@ -3938,6 +4049,13 @@ namespace Parsek
             UnsubscribePartEvents();
             IsRecording = false;
 
+            // Emit terminal shutdown events for engines/RCS/robotics still active at recording end (bug #108)
+            double stopUT = Planetarium.GetUniversalTime();
+            var terminalEvents = EmitTerminalEngineAndRcsEvents(
+                activeEngineKeys, activeRcsKeys, activeRoboticKeys,
+                lastRoboticPosition, stopUT, "Recorder");
+            PartEvents.AddRange(terminalEvents);
+
             // Sort part/flag events chronologically (mixed event sources may produce non-chronological order)
             PartEvents.Sort((a, b) => a.ut.CompareTo(b.ut));
             FlagEvents.Sort((a, b) => a.ut.CompareTo(b.ut));
@@ -3991,6 +4109,13 @@ namespace Parsek
             Patches.PhysicsFramePatch.ActiveRecorder = null;
             UnsubscribePartEvents();
             IsRecording = false;
+
+            // Emit terminal shutdown events for engines/RCS/robotics still active at recording end (bug #108)
+            double chainStopUT = Planetarium.GetUniversalTime();
+            var terminalEvents = EmitTerminalEngineAndRcsEvents(
+                activeEngineKeys, activeRcsKeys, activeRoboticKeys,
+                lastRoboticPosition, chainStopUT, "Recorder");
+            PartEvents.AddRange(terminalEvents);
 
             PartEvents.Sort((a, b) => a.ut.CompareTo(b.ut));
             FlagEvents.Sort((a, b) => a.ut.CompareTo(b.ut));

--- a/Source/Parsek/GhostChain.cs
+++ b/Source/Parsek/GhostChain.cs
@@ -33,6 +33,7 @@ namespace Parsek
         public bool SpawnBlocked;
         public double BlockedSinceUT;
         public float BlockedInitialDistance;  // distance to blocker when first blocked
+        public bool WalkbackExhausted;        // true after walkback scanned entire trajectory with no valid position
 
         public GhostChain()
         {

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -2045,7 +2045,7 @@ namespace Parsek
         /// This catches cases where ChildBranchPointId was not set on the recording
         /// (e.g., serialization gaps, edge-case commit paths) but the tree structure
         /// shows the recording has children. (#114)
-        /// Pure static method for testability.
+        /// Static method, testable via RecordingStore.CommittedTrees setup.
         /// </summary>
         internal static bool IsNonLeafInCommittedTree(Recording rec)
         {

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -2003,6 +2003,12 @@ namespace Parsek
             if (rec.ChildBranchPointId != null)
                 return (false, "non-leaf tree recording");
 
+            // Safety net: even if ChildBranchPointId is null, check committed trees
+            // for recordings that are parents of a branch point. Covers edge cases where
+            // ChildBranchPointId was not set (e.g., serialization gaps). (#114)
+            if (IsNonLeafInCommittedTree(rec))
+                return (false, "non-leaf in committed tree (safety net)");
+
             // Debris recordings are visual-only (short TTL, no meaningful vessel to persist)
             if (rec.IsDebris)
                 return (false, "debris recording (visual-only)");
@@ -2018,12 +2024,76 @@ namespace Parsek
                     return (false, $"terminal state {ts}");
             }
 
+            // Snapshot situation check: if the snapshot's sit field is FLYING or SUB_ORBITAL,
+            // KSP's on-rails aero check (101.3 kPa) immediately destroys spawned vessels.
+            // This catches cases where TerminalState is null/Landed but the snapshot was
+            // captured mid-flight. (#114)
+            if (IsSnapshotSituationUnsafe(rec.VesselSnapshot))
+                return (false, "snapshot situation unsafe (FLYING/SUB_ORBITAL)");
+
             // PID dedup: if vessel was already spawned (PID recorded), never re-spawn.
             // On revert, SpawnedVesselPersistentId resets to 0 from quicksave so reverts still work.
             if (rec.SpawnedVesselPersistentId != 0)
                 return (false, $"already spawned (pid={rec.SpawnedVesselPersistentId})");
 
             return (true, "");
+        }
+
+        /// <summary>
+        /// Safety-net check: determines whether a recording is a non-leaf node in a
+        /// committed tree by scanning the tree's branch points for parent references.
+        /// This catches cases where ChildBranchPointId was not set on the recording
+        /// (e.g., serialization gaps, edge-case commit paths) but the tree structure
+        /// shows the recording has children. (#114)
+        /// Pure static method for testability.
+        /// </summary>
+        internal static bool IsNonLeafInCommittedTree(Recording rec)
+        {
+            if (string.IsNullOrEmpty(rec.TreeId) || string.IsNullOrEmpty(rec.RecordingId))
+                return false;
+
+            var trees = RecordingStore.CommittedTrees;
+            for (int t = 0; t < trees.Count; t++)
+            {
+                var tree = trees[t];
+                if (tree.Id != rec.TreeId) continue;
+
+                // Check if any branch point lists this recording as a parent
+                for (int b = 0; b < tree.BranchPoints.Count; b++)
+                {
+                    var bp = tree.BranchPoints[b];
+                    if (bp.ParentRecordingIds != null && bp.ParentRecordingIds.Contains(rec.RecordingId))
+                    {
+                        ParsekLog.Info("Spawner",
+                            string.Format(CultureInfo.InvariantCulture,
+                                "IsNonLeafInCommittedTree: recording {0} is parent of branch point {1} " +
+                                "in tree {2} (ChildBranchPointId was null — safety net triggered)",
+                                rec.RecordingId, bp.Id, tree.Id));
+                        return true;
+                    }
+                }
+                break; // Found the tree, no need to check others
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Checks whether a vessel snapshot's situation is unsafe for spawning.
+        /// FLYING and SUB_ORBITAL vessels are immediately killed by KSP's on-rails
+        /// atmospheric pressure check (101.3 kPa at sea level). (#114)
+        /// Pure static method for testability.
+        /// </summary>
+        internal static bool IsSnapshotSituationUnsafe(ConfigNode vesselSnapshot)
+        {
+            if (vesselSnapshot == null) return false;
+
+            string sit = vesselSnapshot.GetValue("sit");
+            if (string.IsNullOrEmpty(sit)) return false;
+
+            // KSP situation strings: LANDED, SPLASHED, PRELAUNCH, FLYING,
+            // SUB_ORBITAL, ORBITING, ESCAPING, DOCKED
+            return sit.Equals("FLYING", System.StringComparison.OrdinalIgnoreCase)
+                || sit.Equals("SUB_ORBITAL", System.StringComparison.OrdinalIgnoreCase);
         }
 
         #endregion

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -926,7 +926,7 @@ namespace Parsek
         /// SmokeTrailControl is STRIPPED — tested keeping alive (audit #113) but it sets material
         /// alpha to 0 on ghosts, making smoke invisible. Needs vessel context to work correctly.
         /// ModelMultiParticlePersistFX/ModelParticleFX are EffectBehaviour subclasses that reference
-        /// Host (the Part) — stripped because they NRE without Part context.
+        /// Host (the Part). KEPT ALIVE — stripping kills smoke trails. Any NREs are non-fatal.
         /// FXPrefab registers particles with FloatingOrigin — pollutes global state on ghosts.
         ///
         /// Audit #113: FXModuleAnimateThrottle and FXModuleAnimateRCS are PartModules (not
@@ -975,10 +975,11 @@ namespace Parsek
                     case "ModelMultiParticlePersistFX":
                     case "ModelParticleFX":
                         // EffectBehaviour subclasses that reference Host (Part).
-                        // NRE without Part context — strip them.
+                        // Audit #113 stripped these assuming NRE, but they were alive
+                        // pre-audit and smoke trails worked. Stripping kills smoke.
+                        // Keep alive — any NREs are caught by Unity and don't crash.
                         ParsekLog.Verbose("GhostVisual",
-                            $"Stripped {typeName} from '{fxClone.name}'");
-                        Object.Destroy(behaviours[i]);
+                            $"Kept {typeName} alive on '{fxClone.name}' (smoke trail driver)");
                         break;
                     case "FXPrefab":
                         ParsekLog.Verbose("GhostVisual",

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -1008,13 +1008,15 @@ namespace Parsek
                 main.playOnAwake = false;
                 main.prewarm = false;
 
-                // Permanently disable Unity's emission module — all particle creation
-                // is handled by KSPParticleEmitter.EmitParticle(). Leaving emission.enabled=true
-                // causes Unity to create its own particles using main.startSize and
-                // ParticleSystemRenderer.material, which are never set from KSP values,
-                // producing huge material-less "bubble" artifacts (bug #105).
+                // Only disable Unity's emission module when KSPParticleEmitter is present
+                // on this FX object — KSPParticleEmitter handles particle creation via
+                // EmitParticle(), so Unity's emission produces duplicate "bubble" artifacts
+                // (bug #105). Smoke trail FX (fx_smokeTrail_*) have NO KSPParticleEmitter
+                // and rely on Unity's emission module — disabling it kills all smoke.
+                bool hasKspEmitter = fxInstance.GetComponent("KSPParticleEmitter") != null;
                 var emission = ps.emission;
-                emission.enabled = false;
+                if (hasKspEmitter)
+                    emission.enabled = false;
 
                 ps.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
                 ps.Clear(true);
@@ -3432,10 +3434,12 @@ namespace Parsek
                                     main.playOnAwake = false;
                                     main.prewarm = false;
 
-                                    // Permanently disable Unity's emission module — all particle
-                                    // creation is handled by KSPParticleEmitter (bug #105 fix).
+                                    // Only disable Unity emission when KSPParticleEmitter is present
+                                    // (same logic as engine FX — smoke FX need Unity emission).
+                                    bool hasKspEmitter = fxInstance.GetComponent("KSPParticleEmitter") != null;
                                     var emission = ps.emission;
-                                    emission.enabled = false;
+                                    if (hasKspEmitter)
+                                        emission.enabled = false;
                                     ps.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
                                     ps.Clear(true);
 

--- a/Source/Parsek/MergeDialog.cs
+++ b/Source/Parsek/MergeDialog.cs
@@ -387,6 +387,11 @@ namespace Parsek
             {
                 new DialogGUIButton("Merge to Timeline", () =>
                 {
+                    // Mark tree recordings for force-spawn if active vessel shares PID
+                    // (after revert, pad vessel has same PID — dedup would skip spawn)
+                    var av = FlightGlobals.ActiveVessel;
+                    if (av != null && av.persistentId != 0)
+                        MarkForceSpawnOnTreeRecordings(tree, av.persistentId);
                     RecordingStore.CommitPendingTree();
                     ParsekScenario.ReserveSnapshotCrew();
                     ParsekScenario.SwapReservedCrewInFlight();
@@ -582,6 +587,49 @@ namespace Parsek
             return count;
         }
 
+        /// <summary>
+        /// Marks ForceSpawnNewVessel on tree recordings whose VesselPersistentId matches
+        /// the active vessel's PID and that haven't been spawned yet. This prevents PID
+        /// dedup from skipping spawn when the pad vessel shares a PID with the recording's
+        /// vessel (common after revert). Pure static for testability.
+        /// </summary>
+        /// <param name="tree">The recording tree to scan.</param>
+        /// <param name="activePid">The active vessel's persistentId (0 = skip).</param>
+        /// <returns>Number of recordings marked.</returns>
+        internal static int MarkForceSpawnOnTreeRecordings(RecordingTree tree, uint activePid)
+        {
+            if (tree == null || activePid == 0)
+            {
+                ParsekLog.Verbose("MergeDialog",
+                    $"MarkForceSpawnOnTreeRecordings: skip — tree={tree != null}, activePid={activePid}");
+                return 0;
+            }
+
+            int count = 0;
+            foreach (var rec in tree.Recordings.Values)
+            {
+                if (rec.VesselPersistentId == activePid && !rec.VesselSpawned)
+                {
+                    rec.ForceSpawnNewVessel = true;
+                    count++;
+                    ParsekLog.Verbose("MergeDialog",
+                        $"MarkForceSpawnOnTreeRecordings: marked '{rec.VesselName}' " +
+                        $"(id={rec.RecordingId}, pid={rec.VesselPersistentId})");
+                }
+            }
+
+            if (count > 0)
+                ParsekLog.Info("MergeDialog",
+                    $"MarkForceSpawnOnTreeRecordings: marked {count} recording(s) " +
+                    $"with ForceSpawnNewVessel (activePid={activePid}, tree='{tree.TreeName}')");
+            else
+                ParsekLog.Verbose("MergeDialog",
+                    $"MarkForceSpawnOnTreeRecordings: no recordings matched activePid={activePid} " +
+                    $"in tree '{tree.TreeName}' ({tree.Recordings.Count} recordings)");
+
+            return count;
+        }
+
         #endregion
 
         // ================================================================
@@ -752,6 +800,11 @@ namespace Parsek
             {
                 new DialogGUIButton("Commit All", () =>
                 {
+                    // Mark tree recordings for force-spawn if active vessel shares PID
+                    // (after revert, pad vessel has same PID — dedup would skip spawn)
+                    var av = FlightGlobals.ActiveVessel;
+                    if (av != null && av.persistentId != 0)
+                        MarkForceSpawnOnTreeRecordings(capturedTree, av.persistentId);
                     ApplyVesselDecisions(capturedTree, capturedDecisions);
                     RecordingStore.CommitPendingTree();
                     ParsekScenario.ReserveSnapshotCrew();

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -3970,6 +3970,11 @@ namespace Parsek
                 RecordingStore.PendingCleanupPids = null;
                 RecordingStore.PendingCleanupNames = null;
             }
+            else
+            {
+                ParsekLog.Verbose("Flight",
+                    "OnFlightReady: no pending cleanup data — skipping CleanupOrphanedSpawnedVessels");
+            }
 
             // Apply ghost soft cap settings from persisted game parameters
             var capSettings = ParsekSettings.Current;
@@ -5419,6 +5424,10 @@ namespace Parsek
         /// </summary>
         void CleanupOrphanedSpawnedVessels(HashSet<uint> pids, HashSet<string> names)
         {
+            ParsekLog.Info("Flight",
+                $"CleanupOrphanedSpawnedVessels: starting with " +
+                $"{pids?.Count ?? 0} pid(s), {names?.Count ?? 0} name(s), " +
+                $"{FlightGlobals.Vessels.Count} loaded vessel(s)");
             var activeVessel = FlightGlobals.ActiveVessel;
             uint activePid = activeVessel != null ? activeVessel.persistentId : 0;
             bool hasPids = pids != null && pids.Count > 0;
@@ -6246,6 +6255,7 @@ namespace Parsek
                     {
                         rec.VesselSpawned = false;
                         rec.SpawnedVesselPersistentId = 0;
+                        rec.CollisionBlockCount = 0;
                         Log($"Spawned vessel gone (pid={checkPid}) — reset spawn state for recording #{i} \"{rec.VesselName}\"");
                     }
                 }
@@ -9469,7 +9479,8 @@ namespace Parsek
                 string vesselName = info != null ? info.vesselName : "(unknown)";
 
                 string labelText = SpawnWarningUI.ComputeGhostLabelText(
-                    vesselName, chain.SpawnUT, chain.IsTerminated, chain.SpawnBlocked);
+                    vesselName, chain.SpawnUT, chain.IsTerminated, chain.SpawnBlocked,
+                    chain.WalkbackExhausted);
 
                 // Unity screen coordinates have Y=0 at bottom; GUI has Y=0 at top
                 float guiY = Screen.height - screenPos.y;

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -2348,17 +2348,109 @@ namespace Parsek
             // Set ChildBranchPointId on the active recording to link to this breakup
             activeRec.ChildBranchPointId = breakupBp.Id;
 
-            // TODO Phase 2: Create child recording segments for controlled children.
-            // Currently, controlled children survive the breakup but have no recording
-            // segments created for them. Full implementation requires the background
-            // recording infrastructure for multiple vessels (Phase 2 multi-vessel sessions).
+            // Create child recording segments for controlled children (vessels with probe
+            // cores that survive the breakup). Same pattern as PromoteToTreeForBreakup step 8.
+            // These are NOT debris — they record indefinitely (no TTL) and can serve as
+            // RELATIVE anchors during playback.
             var controlledChildren = crashCoalescer.LastEmittedControlledChildPids;
             if (controlledChildren != null && controlledChildren.Count > 0)
             {
                 for (int i = 0; i < controlledChildren.Count; i++)
                 {
-                    ParsekLog.Warn("Coalescer",
-                        $"BREAKUP controlled child pid={controlledChildren[i]} — child segment creation deferred to Phase 2");
+                    uint pid = controlledChildren[i];
+                    Vessel childVessel = FlightRecorder.FindVesselByPid(pid);
+                    string childRecId = Guid.NewGuid().ToString("N");
+                    string vesselName = childVessel?.vesselName ?? "Unknown";
+
+                    var childRec = new Recording
+                    {
+                        RecordingId = childRecId,
+                        TreeId = activeTree.Id,
+                        VesselPersistentId = pid,
+                        VesselName = vesselName,
+                        ParentBranchPointId = breakupBp.Id,
+                        ExplicitStartUT = breakupBp.UT,
+                        IsDebris = false
+                    };
+
+                    if (childVessel != null)
+                    {
+                        ConfigNode childSnapshot = VesselSpawner.TryBackupSnapshot(childVessel);
+                        childRec.GhostVisualSnapshot = childSnapshot;
+                        childRec.VesselSnapshot = childSnapshot != null ? childSnapshot.CreateCopy() : null;
+                    }
+                    else
+                    {
+                        childRec.TerminalStateValue = TerminalState.Destroyed;
+                        childRec.ExplicitEndUT = breakupBp.UT;
+                    }
+
+                    activeTree.Recordings[childRecId] = childRec;
+                    breakupBp.ChildRecordingIds.Add(childRecId);
+
+                    // Add to BackgroundRecorder for trajectory sampling (no TTL — records indefinitely)
+                    if (childVessel != null && backgroundRecorder != null)
+                    {
+                        activeTree.BackgroundMap[pid] = childRecId;
+                        backgroundRecorder.OnVesselBackgrounded(pid);
+                    }
+
+                    ParsekLog.Info("Coalescer",
+                        $"ProcessBreakupEvent: controlled child created: pid={pid}, " +
+                        $"name='{vesselName}', recId={childRecId}, " +
+                        $"alive={childVessel != null}, bgRecorder={backgroundRecorder != null}");
+                }
+            }
+
+            // Also create debris child recordings for new debris from this breakup
+            var debrisPids = crashCoalescer.LastEmittedDebrisPids;
+            if (debrisPids != null && debrisPids.Count > 0)
+            {
+                double debrisExpiryUT = breakupBp.UT + BackgroundRecorder.DebrisTTLSeconds;
+                for (int i = 0; i < debrisPids.Count; i++)
+                {
+                    uint pid = debrisPids[i];
+                    Vessel debrisVessel = FlightRecorder.FindVesselByPid(pid);
+                    string childRecId = Guid.NewGuid().ToString("N");
+                    string vesselName = debrisVessel?.vesselName ?? "Debris";
+
+                    var childRec = new Recording
+                    {
+                        RecordingId = childRecId,
+                        TreeId = activeTree.Id,
+                        VesselPersistentId = pid,
+                        VesselName = vesselName,
+                        ParentBranchPointId = breakupBp.Id,
+                        ExplicitStartUT = breakupBp.UT,
+                        IsDebris = true
+                    };
+
+                    if (debrisVessel != null)
+                    {
+                        ConfigNode debrisSnapshot = VesselSpawner.TryBackupSnapshot(debrisVessel);
+                        childRec.GhostVisualSnapshot = debrisSnapshot;
+                        childRec.VesselSnapshot = debrisSnapshot != null ? debrisSnapshot.CreateCopy() : null;
+                    }
+                    else
+                    {
+                        childRec.TerminalStateValue = TerminalState.Destroyed;
+                        childRec.ExplicitEndUT = breakupBp.UT;
+                    }
+
+                    activeTree.Recordings[childRecId] = childRec;
+                    breakupBp.ChildRecordingIds.Add(childRecId);
+
+                    if (debrisVessel != null && backgroundRecorder != null)
+                    {
+                        activeTree.BackgroundMap[pid] = childRecId;
+                        backgroundRecorder.OnVesselBackgrounded(pid);
+                        backgroundRecorder.SetDebrisExpiry(pid, debrisExpiryUT);
+                    }
+
+                    ParsekLog.Info("Coalescer",
+                        $"ProcessBreakupEvent: debris child created: pid={pid}, " +
+                        $"name='{vesselName}', recId={childRecId}, " +
+                        $"alive={debrisVessel != null}");
                 }
             }
 

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -6254,10 +6254,24 @@ namespace Parsek
                         ? rec.SpawnedVesselPersistentId : rec.VesselPersistentId;
                     if (checkPid != 0 && !GhostPlaybackLogic.RealVesselExists(checkPid))
                     {
-                        rec.VesselSpawned = false;
-                        rec.SpawnedVesselPersistentId = 0;
-                        rec.CollisionBlockCount = 0;
-                        Log($"Spawned vessel gone (pid={checkPid}) — reset spawn state for recording #{i} \"{rec.VesselName}\"");
+                        rec.SpawnDeathCount++;
+                        if (VesselSpawner.ShouldAbandonSpawnDeathLoop(
+                                rec.SpawnDeathCount, VesselSpawner.MaxSpawnDeathCycles))
+                        {
+                            rec.VesselSpawned = true;
+                            rec.SpawnAbandoned = true;
+                            ParsekLog.Warn("Flight",
+                                $"Spawn ABANDONED for #{i} \"{rec.VesselName}\": vessel died immediately " +
+                                $"after spawn {rec.SpawnDeathCount} times (pid={checkPid}) — giving up");
+                        }
+                        else
+                        {
+                            rec.VesselSpawned = false;
+                            rec.SpawnedVesselPersistentId = 0;
+                            rec.CollisionBlockCount = 0;
+                            Log($"Spawned vessel gone (pid={checkPid}) — reset spawn state for recording #{i} " +
+                                $"\"{rec.VesselName}\" (spawnDeathCount={rec.SpawnDeathCount}/{VesselSpawner.MaxSpawnDeathCycles})");
+                        }
                     }
                 }
 

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -4006,6 +4006,12 @@ namespace Parsek
             if (RecordingStore.HasPendingTree)
             {
                 var pt = RecordingStore.PendingTree;
+                // Belt-and-suspenders: mark tree recordings for force-spawn before dialog.
+                // The merge dialog callbacks also call MarkForceSpawnOnTreeRecordings,
+                // but this covers the case where the tree is committed without a dialog
+                // (e.g., auto-merge setting, or future code paths).
+                if (activeVessel != null && activeVessel.persistentId != 0)
+                    MergeDialog.MarkForceSpawnOnTreeRecordings(pt, activeVessel.persistentId);
                 ParsekLog.Warn("Flight", $"Pending tree '{pt.TreeName}' reached OnFlightReady — showing tree merge dialog (fallback)");
                 MergeDialog.ShowTreeDialog(pt);
             }
@@ -8669,11 +8675,16 @@ namespace Parsek
 
             watchEndHoldUntilUT = -1;
 
+            // Reset watch start time so the zone-exemption logging starts fresh
+            // for the new segment (no stale elapsed time from the previous segment)
+            watchStartTime = Time.time;
+
             ParsekLog.Info("CameraFollow",
                 $"TransferWatch re-target: ghost #{nextIndex} \"{newName}\"" +
                 $" target='{segTarget.name}' pivotLocal=({segTarget.localPosition.x:F2},{segTarget.localPosition.y:F2},{segTarget.localPosition.z:F2})" +
                 $" ghostPos=({gs.ghost.transform.position.x:F1},{gs.ghost.transform.position.y:F1},{gs.ghost.transform.position.z:F1})" +
-                $" camDist={FlightCamera.fetch.Distance:F1}");
+                $" camDist={FlightCamera.fetch.Distance:F1}" +
+                $" watchStartTime={watchStartTime.ToString("F2", CultureInfo.InvariantCulture)}");
         }
 
         #endregion
@@ -8732,35 +8743,23 @@ namespace Parsek
                 GhostPlaybackLogic.GetZoneRenderingPolicy(zone);
 
             // Beyond zone: hide mesh for non-watched ghosts.
-            // Watched ghost gets a grace period: when Watch starts, the ghost may be near
-            // the player. As it flies away and crosses ~120km from the active vessel,
-            // terrain unloads and jitter occurs. Exit Watch after a 2s grace period so
-            // the camera has time to lock on before zone checks kick in. This also avoids
-            // the original bug where Watch on a chain segment already beyond 120km would
-            // exit instantly before the player saw anything.
+            // Watched ghost is NEVER hidden by zone distance — the camera is at the ghost,
+            // so the user can always see it regardless of distance from ActiveVessel.
+            // The old grace-period approach (bug #54) was wrong: it exited watch mode after
+            // 2 seconds, but ascending rockets naturally exceed 120km and the camera is
+            // right there watching them. Skip the hide entirely for the watched ghost.
+            if (shouldHideMesh && isWatchedGhost)
+            {
+                // Watched ghost is never hidden by zone — camera is at the ghost
+                shouldHideMesh = false;
+                ParsekLog.VerboseRateLimited("Zone", $"watched-zone-exempt-{recIdx}",
+                    $"Ghost #{recIdx} \"{rec.VesselName}\" beyond visual range " +
+                    $"({ghostDistance.ToString("F0", CultureInfo.InvariantCulture)}m) but watched — exempt from zone hide",
+                    5.0);
+            }
+
             if (shouldHideMesh)
             {
-                if (isWatchedGhost)
-                {
-                    if (Time.time - watchStartTime > GhostPlaybackLogic.WatchModeZoneGraceSeconds)
-                    {
-                        ExitWatchMode();
-                        ParsekLog.Info("Zone",
-                            $"Watch exited: ghost #{recIdx} exceeded visual range " +
-                            $"({ghostDistance.ToString("F0", CultureInfo.InvariantCulture)}m)");
-                        // Fall through to hide the ghost normally
-                    }
-                    else
-                    {
-                        // Grace period: keep watching, don't hide
-                        ParsekLog.VerboseRateLimited("Zone", $"watched-zone-{recIdx}",
-                            $"Ghost #{recIdx} \"{rec.VesselName}\" beyond visual range " +
-                            $"({ghostDistance.ToString("F0", CultureInfo.InvariantCulture)}m) but watched (grace period) — keeping visible",
-                            5.0);
-                        return new ZoneRenderingResult { hiddenByZone = false, skipPartEvents = shouldSkipPartEvents };
-                    }
-                }
-
                 if (state != null && state.ghost != null && state.ghost.activeSelf)
                 {
                     state.ghost.SetActive(false);

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -2962,8 +2962,10 @@ namespace Parsek
             {
                 activeChainId = System.Guid.NewGuid().ToString("N");
                 activeChainNextIndex = 0;
-                // Auto-group chain under a group named after the starting vessel
-                string chainGroupName = RecordingStore.Pending.VesselName ?? "Chain";
+                // Auto-group chain under a group named after the starting vessel.
+                // Use GenerateUniqueGroupName to avoid merging multiple launches into one group (bug #104).
+                string chainGroupName = RecordingStore.GenerateUniqueGroupName(
+                    RecordingStore.Pending.VesselName ?? "Chain");
                 RecordingStore.Pending.RecordingGroups = new System.Collections.Generic.List<string> { chainGroupName };
                 Log($"Chain: started new chain (id={activeChainId}, group='{chainGroupName}')");
             }
@@ -3577,7 +3579,9 @@ namespace Parsek
             {
                 activeChainId = System.Guid.NewGuid().ToString("N");
                 activeChainNextIndex = 0;
-                string chainGroupName = RecordingStore.Pending.VesselName ?? "Chain";
+                // Use GenerateUniqueGroupName to avoid merging multiple launches into one group (bug #104).
+                string chainGroupName = RecordingStore.GenerateUniqueGroupName(
+                    RecordingStore.Pending.VesselName ?? "Chain");
                 RecordingStore.Pending.RecordingGroups = new System.Collections.Generic.List<string> { chainGroupName };
                 Log($"Dock/Undock chain: started new chain (id={activeChainId}, group='{chainGroupName}')");
             }
@@ -3739,7 +3743,9 @@ namespace Parsek
             {
                 activeChainId = System.Guid.NewGuid().ToString("N");
                 activeChainNextIndex = 0;
-                string chainGroupName = RecordingStore.Pending.VesselName ?? "Chain";
+                // Use GenerateUniqueGroupName to avoid merging multiple launches into one group (bug #104).
+                string chainGroupName = RecordingStore.GenerateUniqueGroupName(
+                    RecordingStore.Pending.VesselName ?? "Chain");
                 RecordingStore.Pending.RecordingGroups = new System.Collections.Generic.List<string> { chainGroupName };
                 ParsekLog.Info("Flight", $"Boundary split: started new chain (id={activeChainId}, group='{chainGroupName}')");
             }
@@ -4592,6 +4598,20 @@ namespace Parsek
             if (recorder == null || !recorder.IsRecording || !recorder.AtmosphereBoundaryCrossed)
                 return;
 
+            // Bug #87: In tree mode, boundary splits must not commit standalone chain segments.
+            // The recorder keeps accumulating data into the tree recording — just clear the
+            // boundary flags so they don't re-trigger.
+            if (activeTree != null)
+            {
+                string skipPhase = recorder.EnteredAtmosphere ? "atmo" : "exo";
+                string skipBody = FlightGlobals.ActiveVessel?.mainBody?.name ?? "Unknown";
+                ParsekLog.Info("Flight", $"Atmosphere boundary suppressed in tree mode: " +
+                    $"{skipBody} entering {skipPhase} (tree={activeTree.Id}, " +
+                    $"activeRec={activeTree.ActiveRecordingId})");
+                recorder.ClearBoundaryFlags();
+                return;
+            }
+
             string phase = recorder.EnteredAtmosphere ? "exo" : "atmo";
             string newPhase = recorder.EnteredAtmosphere ? "atmo" : "exo";
             string bodyName = FlightGlobals.ActiveVessel?.mainBody?.name ?? "Unknown";
@@ -4618,6 +4638,20 @@ namespace Parsek
         {
             if (recorder == null || !recorder.IsRecording || !recorder.SoiChangePending)
                 return;
+
+            // Bug #87: In tree mode, boundary splits must not commit standalone chain segments.
+            // The recorder keeps accumulating data into the tree recording — just clear the
+            // boundary flags so they don't re-trigger.
+            if (activeTree != null)
+            {
+                string skipFrom = recorder.SoiChangeFromBody ?? "Unknown";
+                string skipTo = FlightGlobals.ActiveVessel?.mainBody?.name ?? "Unknown";
+                ParsekLog.Info("Flight", $"SOI change boundary suppressed in tree mode: " +
+                    $"{skipFrom} to {skipTo} (tree={activeTree.Id}, " +
+                    $"activeRec={activeTree.ActiveRecordingId})");
+                recorder.ClearBoundaryFlags();
+                return;
+            }
 
             string fromBody = recorder.SoiChangeFromBody ?? "Unknown";
             string toBody = FlightGlobals.ActiveVessel?.mainBody?.name ?? "Unknown";

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -9308,18 +9308,19 @@ namespace Parsek
             }
             else
             {
-                // Anchor not found — hide ghost entirely.
-                // RELATIVE frames store dx/dy/dz meter offsets in lat/lon/alt fields,
-                // so interpreting them as geographic coordinates would place the ghost
-                // at completely wrong positions. Hiding is the safe fallback.
+                // Anchor not found — keep ghost at its last position instead of hiding.
+                // RELATIVE frames store dx/dy/dz meter offsets, not geographic coordinates,
+                // so we can't position the ghost. But hiding it during watch mode is worse
+                // than freezing it in place. The ghost stays visible at its last known
+                // position from the previous ABSOLUTE section.
                 long key = ((long)anchorVesselId << 32);
                 if (loggedAnchorNotFound.Add(key))
                     ParsekLog.Warn("Anchor",
-                        $"RELATIVE playback: anchor vessel pid={anchorVesselId} not found, " +
-                        $"hiding ghost until anchor loads");
+                        $"RELATIVE playback: anchor vessel pid={anchorVesselId} not found — " +
+                        $"ghost frozen at last known position (RELATIVE offsets unusable without anchor)");
 
+                // Return zero result — the ghost stays where it was positioned last frame
                 interpResult = InterpolationResult.Zero;
-                ghost.SetActive(false);
             }
         }
 
@@ -9360,16 +9361,14 @@ namespace Parsek
             }
             else
             {
-                // Anchor not found — hide ghost entirely.
-                // RELATIVE frames store dx/dy/dz meter offsets in lat/lon/alt fields,
-                // so interpreting them as geographic coordinates would place the ghost
-                // at completely wrong positions. Hiding is the safe fallback.
+                // Anchor not found — keep ghost at its last position instead of hiding.
+                // Same rationale as InterpolateAndPositionRelative: freezing in place is
+                // better than disappearing during watch mode.
                 long key = ((long)anchorVesselId << 32);
                 if (loggedAnchorNotFound.Add(key))
                     ParsekLog.Warn("Anchor",
-                        $"PositionGhostRelativeAt: anchor vessel pid={anchorVesselId} not found, " +
-                        $"hiding ghost until anchor loads");
-                ghost.SetActive(false);
+                        $"PositionGhostRelativeAt: anchor vessel pid={anchorVesselId} not found — " +
+                        $"ghost frozen at last known position");
             }
         }
 

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -8418,7 +8418,7 @@ namespace Parsek
             GUI.color = Color.white;
 
             GUI.Label(new Rect(x, y + 5, boxW, 22f), "Watching: " + vesselName, watchOverlayStyle);
-            GUI.Label(new Rect(x, y + 27, boxW, 18f), "[  ]  Return to vessel", watchOverlayHintStyle);
+            GUI.Label(new Rect(x, y + 27, boxW, 18f), "Press [ or ] to return to vessel", watchOverlayHintStyle);
         }
 
         /// <summary>

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -4795,8 +4795,10 @@ namespace Parsek
 
         void HandleInput()
         {
-            // Backspace - Exit watch mode (return to vessel)
-            if (watchedRecordingIndex >= 0 && Input.GetKeyDown(KeyCode.Backspace))
+            // [ or ] — Exit watch mode (return to vessel)
+            // Avoids Backspace which is KSP's Abort action group key
+            if (watchedRecordingIndex >= 0
+                && (Input.GetKeyDown(KeyCode.LeftBracket) || Input.GetKeyDown(KeyCode.RightBracket)))
             {
                 ExitWatchMode();
             }
@@ -8324,7 +8326,7 @@ namespace Parsek
             GUI.color = Color.white;
 
             GUI.Label(new Rect(x, y + 5, boxW, 22f), "Watching: " + vesselName, watchOverlayStyle);
-            GUI.Label(new Rect(x, y + 27, boxW, 18f), "[Backspace] Return to vessel", watchOverlayHintStyle);
+            GUI.Label(new Rect(x, y + 27, boxW, 18f), "[  ]  Return to vessel", watchOverlayHintStyle);
         }
 
         /// <summary>

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -6247,7 +6247,8 @@ namespace Parsek
                 // Reverse: if marked as spawned but the real vessel no longer exists
                 // (recovered, destroyed, or cleared), reset spawn state so the recording
                 // can be spawned again via Real Spawn Control or natural playback.
-                if (!needsSpawn && (rec.VesselSpawned || rec.SpawnedVesselPersistentId != 0))
+                if (!needsSpawn && !rec.SpawnAbandoned
+                    && (rec.VesselSpawned || rec.SpawnedVesselPersistentId != 0))
                 {
                     uint checkPid = rec.SpawnedVesselPersistentId != 0
                         ? rec.SpawnedVesselPersistentId : rec.VesselPersistentId;

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -529,6 +529,7 @@ namespace Parsek
 
                     recordings[i].VesselSpawned = false;
                     recordings[i].SpawnAttempts = 0;
+                    recordings[i].SpawnDeathCount = 0;
                     recordings[i].SpawnedVesselPersistentId = 0;
 
                     recordings[i].LastAppliedResourceIndex = -1;
@@ -1475,6 +1476,7 @@ namespace Parsek
 
                 recordings[i].VesselSpawned = false;
                 recordings[i].SpawnAttempts = 0;
+                recordings[i].SpawnDeathCount = 0;
 
                 uint savedPid = 0;
                 int resIdx = -1;

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -379,6 +379,9 @@ namespace Parsek
                     // (PIDs may already be zero from a previous rewind's ResetAllPlaybackState.)
                     var allRecordingNames = RecordingStore.CollectAllRecordingVesselNames();
                     RecordingStore.PendingCleanupNames = allRecordingNames.Count > 0 ? allRecordingNames : null;
+                    ParsekLog.Info("Rewind",
+                        $"OnLoad: rewind cleanup data set — " +
+                        $"{rewindSpawnedPids.Count} pid(s), {allRecordingNames.Count} name(s)");
 
                     // Reset ALL playback state (recordings + trees)
                     var (standaloneCount, treeCount) = RecordingStore.ResetAllPlaybackState();
@@ -462,15 +465,33 @@ namespace Parsek
                 // Collect spawned vessel PIDs + names BEFORE restore resets them.
                 // Only on revert — on normal scene changes the spawned vessels are
                 // legitimate and must not be cleaned up.
-                HashSet<uint> spawnedPids = null;
-                HashSet<string> spawnedNames = null;
+                // Guard: if cleanup data was already set by a prior rewind path,
+                // do NOT overwrite — the rewind path's data is authoritative.
+                // (After rewind, ResetAllPlaybackState zeros spawn tracking, so
+                // CollectSpawnedVesselInfo returns empty here and would clobber
+                // the rewind data with null.)
                 if (isRevert)
                 {
-                    var info = RecordingStore.CollectSpawnedVesselInfo();
-                    spawnedPids = info.pids.Count > 0 ? info.pids : null;
-                    spawnedNames = info.names.Count > 0 ? info.names : null;
-                    RecordingStore.PendingCleanupPids = spawnedPids;
-                    RecordingStore.PendingCleanupNames = spawnedNames;
+                    bool alreadyHasCleanupData = RecordingStore.PendingCleanupPids != null
+                                                  || RecordingStore.PendingCleanupNames != null;
+                    if (alreadyHasCleanupData)
+                    {
+                        ParsekLog.Info("Scenario",
+                            $"OnLoad: revert path skipping cleanup collection — " +
+                            $"already set ({RecordingStore.PendingCleanupPids?.Count ?? 0} pid(s), " +
+                            $"{RecordingStore.PendingCleanupNames?.Count ?? 0} name(s)) from prior rewind/revert");
+                    }
+                    else
+                    {
+                        var info = RecordingStore.CollectSpawnedVesselInfo();
+                        var spawnedPids = info.pids.Count > 0 ? info.pids : null;
+                        var spawnedNames = info.names.Count > 0 ? info.names : null;
+                        RecordingStore.PendingCleanupPids = spawnedPids;
+                        RecordingStore.PendingCleanupNames = spawnedNames;
+                        ParsekLog.Verbose("Scenario",
+                            $"OnLoad: revert cleanup collected — " +
+                            $"{spawnedPids?.Count ?? 0} pid(s), {spawnedNames?.Count ?? 0} name(s)");
+                    }
                 }
 
                 // Restore mutable state from save. On revert the launch quicksave has
@@ -517,11 +538,14 @@ namespace Parsek
                 // These vessels were spawned by Parsek in a previous flight but their
                 // tracking was lost when spawn flags were reset. Without stripping,
                 // they contaminate the next launch quicksave and persist across reverts.
-                if (isRevert && spawnedNames != null && spawnedNames.Count > 0)
+                // Use RecordingStore.PendingCleanupNames as the authoritative source —
+                // the local collection may have been skipped by the guard above.
+                var cleanupNames = RecordingStore.PendingCleanupNames;
+                if (isRevert && cleanupNames != null && cleanupNames.Count > 0)
                 {
                     var flightState = HighLogic.CurrentGame?.flightState;
                     if (flightState != null)
-                        StripOrphanedSpawnedVessels(flightState.protoVessels, spawnedNames,
+                        StripOrphanedSpawnedVessels(flightState.protoVessels, cleanupNames,
                             skipPrelaunch: true);
                 }
 

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -245,7 +245,7 @@ namespace Parsek
                 }
                 catch (System.NullReferenceException)
                 {
-                    ParsekLog.Warn("Scenario",
+                    ParsekLog.Verbose("Scenario",
                         "Failed to register main menu hook (GameEvents not ready) — will retry on next OnLoad");
                 }
             }

--- a/Source/Parsek/Properties/AssemblyInfo.cs
+++ b/Source/Parsek/Properties/AssemblyInfo.cs
@@ -17,7 +17,7 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("a1b2c3d4-e5f6-7890-abcd-ef1234567890")]
 
-[assembly: AssemblyVersion("0.5.0.0")]
-[assembly: AssemblyFileVersion("0.5.0.0")]
+[assembly: AssemblyVersion("0.5.1.0")]
+[assembly: AssemblyFileVersion("0.5.1.0")]
 
 [assembly: KSPAssembly("Parsek", 0, 5)]

--- a/Source/Parsek/Recording.cs
+++ b/Source/Parsek/Recording.cs
@@ -138,6 +138,7 @@ namespace Parsek
 
         public uint SpawnedVesselPersistentId;  // persistentId of spawned vessel (0 = not yet spawned)
         public int SpawnAttempts;               // Number of failed spawn attempts (give up after 3)
+        public int CollisionBlockCount;         // Consecutive collision-blocked frames (give up after MaxCollisionBlocks)
         public int SceneExitSituation = -1;     // Vessel.Situations at scene exit (-1 = still in flight/unknown)
 
         public double StartUT => Points.Count > 0 ? Points[0].ut :

--- a/Source/Parsek/Recording.cs
+++ b/Source/Parsek/Recording.cs
@@ -139,7 +139,8 @@ namespace Parsek
         public uint SpawnedVesselPersistentId;  // persistentId of spawned vessel (0 = not yet spawned)
         public int SpawnAttempts;               // Number of failed spawn attempts (give up after 3)
         public int CollisionBlockCount;         // Consecutive collision-blocked frames (give up after MaxCollisionBlocks)
-        public bool SpawnAbandoned;              // True after collision block limit reached — prevents vessel-gone check from resetting (transient)
+        public bool SpawnAbandoned;              // True after collision/death limit reached — prevents vessel-gone check from resetting (transient)
+        public int SpawnDeathCount;              // Spawn-then-die cycles: vessel spawned but immediately destroyed (transient)
         public int SceneExitSituation = -1;     // Vessel.Situations at scene exit (-1 = still in flight/unknown)
 
         public double StartUT => Points.Count > 0 ? Points[0].ut :

--- a/Source/Parsek/Recording.cs
+++ b/Source/Parsek/Recording.cs
@@ -139,6 +139,7 @@ namespace Parsek
         public uint SpawnedVesselPersistentId;  // persistentId of spawned vessel (0 = not yet spawned)
         public int SpawnAttempts;               // Number of failed spawn attempts (give up after 3)
         public int CollisionBlockCount;         // Consecutive collision-blocked frames (give up after MaxCollisionBlocks)
+        public bool SpawnAbandoned;              // True after collision block limit reached — prevents vessel-gone check from resetting (transient)
         public int SceneExitSituation = -1;     // Vessel.Situations at scene exit (-1 = still in flight/unknown)
 
         public double StartUT => Points.Count > 0 ? Points[0].ut :

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -304,9 +304,11 @@ namespace Parsek
 
             // Auto-group: assign all tree recordings to a group named after the tree
             // so they appear collapsed in the recordings window instead of as separate entries.
+            // Use GenerateUniqueGroupName to avoid merging multiple launches of the same vessel
+            // into one group (bug #104).
             if (!string.IsNullOrEmpty(tree.TreeName) && tree.Recordings.Count > 1)
             {
-                string groupName = tree.TreeName;
+                string groupName = GenerateUniqueGroupName(tree.TreeName);
                 foreach (var rec in tree.Recordings.Values)
                 {
                     if (rec.RecordingGroups == null)
@@ -718,6 +720,40 @@ namespace Parsek
             var result = new List<string>(names);
             result.Sort(StringComparer.OrdinalIgnoreCase);
             return result;
+        }
+
+        /// <summary>
+        /// Returns a group name that doesn't collide with existing group names.
+        /// If baseName is not already used, returns it unchanged.
+        /// Otherwise appends " (2)", " (3)", etc. until a unique name is found.
+        /// </summary>
+        internal static string GenerateUniqueGroupName(string baseName)
+        {
+            if (string.IsNullOrEmpty(baseName))
+            {
+                ParsekLog.Verbose("RecordingStore",
+                    "GenerateUniqueGroupName: baseName is null/empty, returning 'Chain'");
+                baseName = "Chain";
+            }
+
+            var existing = new HashSet<string>(GetGroupNames(), System.StringComparer.OrdinalIgnoreCase);
+            if (!existing.Contains(baseName))
+            {
+                ParsekLog.Verbose("RecordingStore",
+                    $"GenerateUniqueGroupName: '{baseName}' is unique, returning unchanged");
+                return baseName;
+            }
+
+            for (int n = 2; ; n++)
+            {
+                string candidate = $"{baseName} ({n})";
+                if (!existing.Contains(candidate))
+                {
+                    ParsekLog.Info("RecordingStore",
+                        $"GenerateUniqueGroupName: '{baseName}' already exists, using '{candidate}'");
+                    return candidate;
+                }
+            }
         }
 
         /// <summary>

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -1141,6 +1141,7 @@ namespace Parsek
 
             rec.VesselSpawned = false;
             rec.SpawnAttempts = 0;
+            rec.SpawnDeathCount = 0;
             rec.SpawnedVesselPersistentId = 0;
             rec.LastAppliedResourceIndex = -1;
 

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -744,7 +744,7 @@ namespace Parsek
                 return baseName;
             }
 
-            for (int n = 2; ; n++)
+            for (int n = 2; n < 1000; n++)
             {
                 string candidate = $"{baseName} ({n})";
                 if (!existing.Contains(candidate))
@@ -754,6 +754,12 @@ namespace Parsek
                     return candidate;
                 }
             }
+
+            // Safety fallback — should never happen in practice
+            string fallback = $"{baseName} ({Guid.NewGuid().ToString("N").Substring(0, 6)})";
+            ParsekLog.Warn("RecordingStore",
+                $"GenerateUniqueGroupName: exhausted 999 candidates for '{baseName}', using fallback '{fallback}'");
+            return fallback;
         }
 
         /// <summary>

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -1291,35 +1291,30 @@ namespace Parsek
             if (IsRewinding)
             {
                 reason = "Rewind already in progress";
-                ParsekLog.Verbose("Store", $"CanRewind: blocked — {reason}");
                 return false;
             }
 
             if (string.IsNullOrEmpty(rec.RewindSaveFileName))
             {
                 reason = "No rewind save available";
-                ParsekLog.Verbose("Store", $"CanRewind: blocked for '{rec.VesselName}' — {reason}");
                 return false;
             }
 
             if (isRecording)
             {
                 reason = "Stop recording before rewinding";
-                ParsekLog.Verbose("Store", $"CanRewind: blocked — {reason}");
                 return false;
             }
 
             if (HasPending)
             {
                 reason = "Merge or discard pending recording first";
-                ParsekLog.Verbose("Store", $"CanRewind: blocked — {reason}");
                 return false;
             }
 
             if (HasPendingTree)
             {
                 reason = "Merge or discard pending tree first";
-                ParsekLog.Verbose("Store", $"CanRewind: blocked — {reason}");
                 return false;
             }
 
@@ -1329,7 +1324,6 @@ namespace Parsek
             if (string.IsNullOrEmpty(savePath) || !File.Exists(savePath))
             {
                 reason = "Rewind save file missing";
-                ParsekLog.Verbose("Store", $"CanRewind: blocked for '{rec.VesselName}' — {reason} (path={savePath ?? "null"})");
                 return false;
             }
 
@@ -1346,35 +1340,30 @@ namespace Parsek
             if (IsRewinding)
             {
                 reason = "Rewind already in progress";
-                ParsekLog.Verbose("Store", $"CanFastForward: blocked — {reason}");
                 return false;
             }
 
             if (rec == null || rec.Points.Count == 0)
             {
                 reason = "Recording not available";
-                ParsekLog.Verbose("Store", $"CanFastForward: blocked — {reason}");
                 return false;
             }
 
             if (isRecording)
             {
                 reason = "Stop recording before fast-forwarding";
-                ParsekLog.Verbose("Store", $"CanFastForward: blocked — {reason}");
                 return false;
             }
 
             if (HasPending)
             {
                 reason = "Merge or discard pending recording first";
-                ParsekLog.Verbose("Store", $"CanFastForward: blocked — {reason}");
                 return false;
             }
 
             if (HasPendingTree)
             {
                 reason = "Merge or discard pending tree first";
-                ParsekLog.Verbose("Store", $"CanFastForward: blocked — {reason}");
                 return false;
             }
 
@@ -1383,10 +1372,6 @@ namespace Parsek
             if (now >= rec.StartUT)
             {
                 reason = "Recording is not in the future";
-                ParsekLog.Verbose("Store",
-                    string.Format(CultureInfo.InvariantCulture,
-                        "CanFastForward: blocked for '{0}' — {1} (now={2:F1} startUT={3:F1})",
-                        rec.VesselName, reason, now, rec.StartUT));
                 return false;
             }
 

--- a/Source/Parsek/SpawnCollisionDetector.cs
+++ b/Source/Parsek/SpawnCollisionDetector.cs
@@ -313,8 +313,9 @@ namespace Parsek
                         blockerName = other.vesselName;
                     }
 
-                    ParsekLog.Info(Tag,
-                        $"Spawn blocked: overlaps with {other.vesselName} at {dist.ToString("F1", IC)}m");
+                    ParsekLog.VerboseRateLimited(Tag,
+                        "overlap-" + other.persistentId,
+                        $"Spawn overlaps with {other.vesselName} (pid={other.persistentId}) at {dist.ToString("F1", IC)}m");
                 }
                 else
                 {

--- a/Source/Parsek/SpawnWarningUI.cs
+++ b/Source/Parsek/SpawnWarningUI.cs
@@ -70,6 +70,7 @@ namespace Parsek
         /// Active chain: "Ghosted -- spawns at UT={SpawnUT:F0}"
         /// Terminated chain: "Ghosted -- chain terminated"
         /// Blocked chain: "Spawn blocked -- waiting for clearance"
+        /// Walkback exhausted: "Spawn blocked -- walkback exhausted, manual placement required"
         /// </summary>
         internal static string FormatChainStatus(GhostChain chain, string vesselName)
         {
@@ -82,7 +83,11 @@ namespace Parsek
             string name = string.IsNullOrEmpty(vesselName) ? "(unknown)" : vesselName;
             string status;
 
-            if (chain.SpawnBlocked)
+            if (chain.SpawnBlocked && chain.WalkbackExhausted)
+            {
+                status = "Spawn blocked -- walkback exhausted, manual placement required";
+            }
+            else if (chain.SpawnBlocked)
             {
                 status = "Spawn blocked -- waiting for clearance";
             }
@@ -99,8 +104,8 @@ namespace Parsek
 
             ParsekLog.Verbose(Tag,
                 string.Format(IC,
-                    "FormatChainStatus: vessel={0} terminated={1} blocked={2} -> \"{3}\"",
-                    name, chain.IsTerminated, chain.SpawnBlocked, status));
+                    "FormatChainStatus: vessel={0} terminated={1} blocked={2} walkbackExhausted={3} -> \"{4}\"",
+                    name, chain.IsTerminated, chain.SpawnBlocked, chain.WalkbackExhausted, status));
 
             return status;
         }
@@ -111,16 +116,22 @@ namespace Parsek
 
         /// <summary>
         /// Pure: compute the floating label text for a ghost vessel.
-        /// Normal chain: "{vesselName}\nGhost -- spawns at UT={spawnUT:F0}"
-        /// Terminated:   "{vesselName}\nGhost -- chain terminated"
-        /// Blocked:      "{vesselName}\nGhost -- spawn blocked"
+        /// Normal chain:         "{vesselName}\nGhost -- spawns at UT={spawnUT:F0}"
+        /// Terminated:           "{vesselName}\nGhost -- chain terminated"
+        /// Blocked:              "{vesselName}\nGhost -- spawn blocked"
+        /// Walkback exhausted:   "{vesselName}\nGhost -- spawn abandoned"
         /// </summary>
-        internal static string ComputeGhostLabelText(string vesselName, double spawnUT, bool isTerminated, bool isBlocked)
+        internal static string ComputeGhostLabelText(string vesselName, double spawnUT,
+            bool isTerminated, bool isBlocked, bool isWalkbackExhausted = false)
         {
             string name = string.IsNullOrEmpty(vesselName) ? "(unknown)" : vesselName;
             string line2;
 
-            if (isBlocked)
+            if (isBlocked && isWalkbackExhausted)
+            {
+                line2 = "Ghost -- spawn abandoned";
+            }
+            else if (isBlocked)
             {
                 line2 = "Ghost -- spawn blocked";
             }
@@ -139,8 +150,8 @@ namespace Parsek
 
             ParsekLog.Verbose(Tag,
                 string.Format(IC,
-                    "ComputeGhostLabelText: vessel={0} spawnUT={1} terminated={2} blocked={3} -> \"{4}\"",
-                    name, spawnUT.ToString("F0", IC), isTerminated, isBlocked,
+                    "ComputeGhostLabelText: vessel={0} spawnUT={1} terminated={2} blocked={3} walkbackExhausted={4} -> \"{5}\"",
+                    name, spawnUT.ToString("F0", IC), isTerminated, isBlocked, isWalkbackExhausted,
                     label.Replace("\n", "\\n")));
 
             return label;

--- a/Source/Parsek/VesselGhoster.cs
+++ b/Source/Parsek/VesselGhoster.cs
@@ -274,8 +274,10 @@ namespace Parsek
 
                 // Trajectory walkback: if blocked for > 5s and blocker hasn't moved,
                 // walk backward along the recorded trajectory to find a valid spawn position.
+                // Skip walkback if already exhausted (entire trajectory was scanned with no valid spot).
                 float distanceChange = Math.Abs(distance - chain.BlockedInitialDistance);
-                if (SpawnCollisionDetector.ShouldTriggerWalkback(
+                if (!chain.WalkbackExhausted
+                    && SpawnCollisionDetector.ShouldTriggerWalkback(
                         chain.BlockedSinceUT, currentUT, 5.0, distanceChange, 1.0f)
                     && tipRecording.Points != null && tipRecording.Points.Count > 1)
                 {
@@ -328,18 +330,22 @@ namespace Parsek
                     }
                     else
                     {
+                        chain.WalkbackExhausted = true;
                         ParsekLog.Warn("SpawnCollision",
                             string.Format(ic,
-                                "Trajectory walkback EXHAUSTED: vessel={0} — entire trajectory overlaps with {1}. Manual placement required.",
+                                "Trajectory walkback EXHAUSTED: vessel={0} — entire trajectory overlaps with {1}. " +
+                                "Manual placement required. Walkback will not re-scan.",
                                 tipRecording.VesselName ?? "(unknown)", blockerName ?? "(unknown)"));
                     }
                 }
 
+                string exhaustedSuffix = chain.WalkbackExhausted ? " [walkback exhausted]" : "";
                 ParsekLog.VerboseRateLimited("SpawnCollision", "blocked-recheck-" + chain.OriginalVesselPid,
                     string.Format(ic,
-                        "Spawn still blocked: vessel={0} overlaps with {1} at {2}m (blocked {3}s)",
+                        "Spawn still blocked: vessel={0} overlaps with {1} at {2}m (blocked {3}s){4}",
                         tipRecording.VesselName ?? "(unknown)", blockerName ?? "(unknown)",
-                        distance.ToString("F1", ic), blockedDuration.ToString("F1", ic)));
+                        distance.ToString("F1", ic), blockedDuration.ToString("F1", ic),
+                        exhaustedSuffix));
                 return 0;
             }
 

--- a/Source/Parsek/VesselSpawner.cs
+++ b/Source/Parsek/VesselSpawner.cs
@@ -244,7 +244,8 @@ namespace Parsek
                     rec.CollisionBlockCount++;
                     if (ShouldAbandonCollisionBlockedSpawn(rec.CollisionBlockCount, MaxCollisionBlocks))
                     {
-                        rec.VesselSpawned = true; // prevent further spawn attempts
+                        rec.VesselSpawned = true;   // prevent ShouldSpawnAtRecordingEnd from returning true
+                        rec.SpawnAbandoned = true;  // prevent vessel-gone check from resetting VesselSpawned
                         ParsekLog.Warn("Spawner",
                             $"Spawn ABANDONED for #{index} ({rec.VesselName}): collision-blocked for " +
                             $"{rec.CollisionBlockCount} consecutive frames by '{blockerName}' at {overlapDist:F0}m — " +

--- a/Source/Parsek/VesselSpawner.cs
+++ b/Source/Parsek/VesselSpawner.cs
@@ -304,6 +304,22 @@ namespace Parsek
             return collisionBlockCount >= maxBlocks;
         }
 
+        /// <summary>
+        /// Maximum spawn-then-die cycles before abandoning spawn.
+        /// A vessel that spawns and immediately dies (e.g., FLYING at sea level,
+        /// destroyed by KSP on-rails aero check) should not retry forever.
+        /// </summary>
+        internal const int MaxSpawnDeathCycles = 3;
+
+        /// <summary>
+        /// Pure decision: should we abandon a spawn that keeps dying immediately?
+        /// Returns true when the spawn-death count has reached or exceeded the maximum.
+        /// </summary>
+        internal static bool ShouldAbandonSpawnDeathLoop(int spawnDeathCount, int maxCycles)
+        {
+            return spawnDeathCount >= maxCycles;
+        }
+
         internal static HashSet<string> BuildExcludeCrewSet(Recording rec)
         {
             if (string.IsNullOrEmpty(rec.RecordingId)) return null;

--- a/Source/Parsek/VesselSpawner.cs
+++ b/Source/Parsek/VesselSpawner.cs
@@ -187,6 +187,20 @@ namespace Parsek
             if (rec.SpawnAttempts >= maxSpawnAttempts)
                 return;
 
+            // Crew protection: strip crew from spawn snapshot when recording ended in
+            // destruction to prevent killing crew during spawn-death cycles (#114).
+            // Uses a working copy so the original snapshot is not modified.
+            if (ShouldStripCrewForSpawn(rec))
+            {
+                if (rec.VesselSnapshot != null)
+                {
+                    int stripped = StripAllCrewFromSnapshot(rec.VesselSnapshot);
+                    ParsekLog.Info("Spawner",
+                        $"Stripped {stripped} crew from spawn snapshot for destroyed recording " +
+                        $"#{index} ({rec.VesselName}) — prevents crew death on spawn");
+                }
+            }
+
             // Build exclude set once for all spawn paths (EVA'd crew spawn via child recordings)
             HashSet<string> excludeCrew = BuildExcludeCrewSet(rec);
 
@@ -543,6 +557,44 @@ namespace Parsek
                         partNode.AddValue("crew", name);
                 }
             }
+        }
+
+        /// <summary>
+        /// Pure decision: should crew be stripped from the spawn snapshot?
+        /// Returns true when the recording's terminal state is Destroyed,
+        /// preventing crew deaths during spawn-death cycles. (#114)
+        /// </summary>
+        internal static bool ShouldStripCrewForSpawn(Recording rec)
+        {
+            return rec.TerminalStateValue.HasValue
+                && rec.TerminalStateValue.Value == TerminalState.Destroyed;
+        }
+
+        /// <summary>
+        /// Strips ALL crew from a vessel snapshot. Removes crew values from PART
+        /// nodes and resets the crewAssignment field. Returns the number of crew removed.
+        /// Modifies the snapshot in-place. (#114)
+        /// </summary>
+        internal static int StripAllCrewFromSnapshot(ConfigNode snapshot)
+        {
+            if (snapshot == null) return 0;
+
+            int removedCount = 0;
+            foreach (ConfigNode partNode in snapshot.GetNodes("PART"))
+            {
+                var crewNames = partNode.GetValues("crew");
+                if (crewNames.Length > 0)
+                {
+                    for (int c = 0; c < crewNames.Length; c++)
+                    {
+                        ParsekLog.Verbose("Spawner",
+                            $"StripAllCrewFromSnapshot: removing '{crewNames[c]}'");
+                    }
+                    removedCount += crewNames.Length;
+                    partNode.RemoveValues("crew");
+                }
+            }
+            return removedCount;
         }
 
         public static void RemoveDeadCrewFromSnapshot(ConfigNode snapshot)

--- a/Source/Parsek/VesselSpawner.cs
+++ b/Source/Parsek/VesselSpawner.cs
@@ -13,6 +13,13 @@ namespace Parsek
         // Proximity offset removed — spawn collision detection now uses bounding box
         // overlap check via SpawnCollisionDetector (same system as chain-tip spawns).
 
+        /// <summary>
+        /// Maximum consecutive collision-blocked frames before abandoning spawn.
+        /// ~2.5 seconds at 60fps. After this many frames the spawn is abandoned
+        /// to prevent infinite retry loops (bug #110).
+        /// </summary>
+        internal const int MaxCollisionBlocks = 150;
+
         public static ConfigNode TryBackupSnapshot(Vessel vessel)
         {
             if (vessel == null) return null;
@@ -234,12 +241,28 @@ namespace Parsek
                     SpawnCollisionDetector.CheckOverlapAgainstLoadedVessels(spawnPos, spawnBounds, 5f);
                 if (overlap)
                 {
-                    ParsekLog.Info("Spawner",
-                        $"Spawn blocked for #{index} ({rec.VesselName}): overlaps '{blockerName}' at {overlapDist:F0}m — " +
-                        $"will retry next frame");
+                    rec.CollisionBlockCount++;
+                    if (ShouldAbandonCollisionBlockedSpawn(rec.CollisionBlockCount, MaxCollisionBlocks))
+                    {
+                        rec.VesselSpawned = true; // prevent further spawn attempts
+                        ParsekLog.Warn("Spawner",
+                            $"Spawn ABANDONED for #{index} ({rec.VesselName}): collision-blocked for " +
+                            $"{rec.CollisionBlockCount} consecutive frames by '{blockerName}' at {overlapDist:F0}m — " +
+                            $"giving up (max={MaxCollisionBlocks})");
+                    }
+                    else
+                    {
+                        ParsekLog.VerboseRateLimited("Spawner",
+                            "collision-block-" + index,
+                            $"Spawn blocked for #{index} ({rec.VesselName}): overlaps '{blockerName}' at {overlapDist:F0}m — " +
+                            $"will retry next frame (block={rec.CollisionBlockCount}/{MaxCollisionBlocks})");
+                    }
                     return;
                 }
             }
+
+            // Reset collision block counter on successful spawn path
+            rec.CollisionBlockCount = 0;
 
             // Find nearest vessel for spawn context logging
             double closestDist = double.MaxValue;
@@ -269,6 +292,15 @@ namespace Parsek
                 else
                     ParsekLog.Warn("Spawner", $"Vessel spawn failed for recording #{index} ({rec.VesselName}) — will retry (attempt {rec.SpawnAttempts}/{maxSpawnAttempts})");
             }
+        }
+
+        /// <summary>
+        /// Pure decision: should we abandon a collision-blocked spawn?
+        /// Returns true when the collision block count has reached or exceeded the maximum.
+        /// </summary>
+        internal static bool ShouldAbandonCollisionBlockedSpawn(int collisionBlockCount, int maxBlocks)
+        {
+            return collisionBlockCount >= maxBlocks;
         }
 
         internal static HashSet<string> BuildExcludeCrewSet(Recording rec)

--- a/Source/Parsek/VesselSpawner.cs
+++ b/Source/Parsek/VesselSpawner.cs
@@ -189,7 +189,8 @@ namespace Parsek
 
             // Crew protection: strip crew from spawn snapshot when recording ended in
             // destruction to prevent killing crew during spawn-death cycles (#114).
-            // Uses a working copy so the original snapshot is not modified.
+            // Modifies the snapshot in-place — acceptable for Destroyed recordings
+            // since they won't be re-spawned (blocked by FLYING/non-leaf checks).
             if (ShouldStripCrewForSpawn(rec))
             {
                 if (rec.VesselSnapshot != null)

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1416,6 +1416,36 @@ After revert, the quicksave restores the pre-launch vessel on the pad with the s
 
 **Status:** Fixed
 
+## 121. Ghost SKIPPED per-frame spam during collision-blocked spawn
+
+When a recording's ghost is past EndUT and spawn is collision-blocked, `UpdateTimelinePlayback` logs `Ghost SKIPPED (UT already past EndUT) — spawning vessel immediately` every physics frame until the collision block limit (150 frames) is reached. Session 4 showed 151 identical messages in 1.3 seconds for recording #5.
+
+**Fix:** Rate-limit or deduplicate the "Ghost SKIPPED" message during collision-blocked state. Log once when first blocked, suppress until resolved.
+
+**Priority:** Low — VERBOSE level only, does not affect gameplay
+
+**Status:** Open
+
+## 122. Dead→Dead crew status identity transitions logged as events
+
+When a spawned vessel is immediately destroyed (bug #110b), KSP fires `CrewStatusChanged` for crew already marked Dead. `GameStateRecorder` records these `Dead → Dead` no-op transitions as real events. Session 4 showed 10 such events across 3 spawn-death cycles.
+
+**Fix:** Filter identity transitions (`oldStatus == newStatus`) in `GameStateRecorder` before recording.
+
+**Priority:** Low — minor log noise, bounded by #110b's 3-cycle limit
+
+**Status:** Open
+
+## 123. `#autoLOC` localization keys in internal log messages
+
+Bug #103 fixed user-facing group headers, but some internal code paths (`TimeJumpManager`, `SpawnCollisionDetector`, `FlightRecorder`) still pass raw `Vessel.vesselName` (which may be an `#autoLOC_XXXXX` key) to log messages. Session 4 showed `vessel '#autoLOC_501224'` in TimeJump WARN messages and spawn collision logs.
+
+**Fix:** Apply `ResolveVesselName` more broadly to internal log call sites, or accept as cosmetic log-only issue.
+
+**Priority:** Low — log readability only, no gameplay impact
+
+**Status:** Open
+
 # In-Game Tests
 
 - [ ] Vessels propagate naturally along orbits after FF (no position freezing)

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1335,29 +1335,36 @@ When a recording tree ends because the vessel crashed, recording #0 (the root, p
 
 **Observed in:** Session 3 (2026-03-22). Aeris 4A crash tree: root recording UT 53-78, crash at UT 100-102. Ghost exits range at UT 78 → spawns vessel → immediate explosion. Happened twice (once after revert, with crew dedup removing Jeb too).
 
-**Root cause:** `ShouldSpawnAtRecordingEnd` does not check whether the recording is a non-leaf node in a committed tree. Non-leaf recordings are superseded by their children and should never spawn.
+**Root cause:** `ShouldSpawnAtRecordingEnd` had a `ChildBranchPointId` check but this could be null in edge cases (serialization gaps, commit-path variations). Additionally, the snapshot's `sit=FLYING` was not checked independently of `TerminalState`.
+
+**Fix:** Three-layer defense in `ShouldSpawnAtRecordingEnd`:
+1. Safety-net tree check: `IsNonLeafInCommittedTree` scans committed tree branch points for parent references, catching non-leaf recordings even when `ChildBranchPointId` is null.
+2. Snapshot situation check: `IsSnapshotSituationUnsafe` blocks spawn when snapshot `sit` is FLYING or SUB_ORBITAL, independent of `TerminalState`.
+3. Crew protection: `ShouldStripCrewForSpawn` / `StripAllCrewFromSnapshot` strips all crew from spawn snapshots for `TerminalState.Destroyed` recordings, preventing crew death during spawn-death cycles.
+
+28 new tests in `SpawnSafetyNetTests.cs` covering all three mechanisms.
 
 **Priority:** Critical — causes cascading destruction, crew death, and confusing UX
 
-**Status:** Open
+**Status:** Fixed (branch `fix-spawn-cleanup`)
 
 ## 115. Crew dedup removes pilot from spawned vessel after revert
 
 After revert, the pilot (Jebediah) is already on the pad vessel from the quicksave. When Parsek spawns the Aeris 4A at recording endpoint, crew dedup finds Jeb "already on a vessel in the scene" and removes him from the spawn snapshot. The vessel spawns crewless.
 
-**Root cause:** The crew reservation system should have replaced Jeb with a temporary kerbal on the pad vessel, but after revert + tree commit, the reservation may have been cleared.
+**Root cause:** The crew reservation system should have replaced Jeb with a temporary kerbal on the pad vessel, but after revert + tree commit, the reservation may have been cleared. Partially mitigated by #114 fix: non-leaf and FLYING recordings no longer spawn, eliminating the primary trigger for this bug.
 
 **Priority:** Medium
 
-**Status:** Open
+**Status:** Open (mitigated by #114 fix — primary trigger eliminated)
 
 ## 116. Valentina Kerman lost to Missing status after rewind vessel strip
 
-Rewind stripped 8 orphaned spawned vessels from the save. Valentina was assigned to one of them but wasn't in Parsek's crew reservation system. KSP set her to Missing. Parsek's crew rescue only handles reserved crew (Bill, Dudfrid were rescued), not all crew affected by the strip.
+Rewind stripped 8 orphaned spawned vessels from the save. Valentina was assigned to one of them but wasn't in Parsek's crew reservation system. KSP set her to Missing. Parsek's crew rescue only handles reserved crew (Bill, Dudfrid were rescued), not all crew affected by the strip. Partially mitigated by #114 crew protection: destroyed-vessel spawns now strip crew from snapshot, preventing crew from being placed on doomed vessels.
 
 **Priority:** Medium
 
-**Status:** Open
+**Status:** Open (mitigated by #114 crew protection — fewer crew placed on doomed vessels)
 
 ## 117. CanRewind/CanFastForward VERBOSE log spam — 578K lines/session
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1277,7 +1277,7 @@ When Parsek spawns a vessel from a recording and switches the active vessel to i
 
 After rewinding and re-entering flight, the Aeris 4A recording's spawn-at-end tried to place a new vessel at the same position where a previously-spawned (but not cleaned up) Aeris 4A already sat. The spawn collision detector correctly blocked it, but because the overlap is permanent (both vessels at the same runway position), this triggered bug #110's infinite retry loop. The log showed `Spawn blocked: overlaps with #autoLOC_501176 at 5m — will retry next frame` repeating every frame for the remainder of the session.
 
-**Root cause:** `CleanupOrphanedSpawnedVessels` recovered one copy, but a second Aeris 4A was loaded from the save and occupied the spawn slot. The spawn system has no dedup against already-present matching vessels.
+**Root cause:** `CleanupOrphanedSpawnedVessels` recovered one copy, but a second Aeris 4A was loaded from the save and occupied the spawn slot. The duplicate presence is partly caused by bug #109 (cleanup skipped on second rewind, leaving a stale vessel in the save). The spawn system has no dedup against already-present matching vessels.
 
 **Note:** The infinite retry loop symptom is resolved by bug #110's fix (spawn abandoned after 150 frames). The root cause of duplicate vessel presence remains a separate issue.
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1363,21 +1363,21 @@ Rewind stripped 8 orphaned spawned vessels from the save. Valentina was assigned
 
 `RecordingStore.CanRewind` and `RecordingStore.CanFastForward` log at VERBOSE on every blocked call. Called per-recording per-frame from UI. With active recording + multiple recordings, produces 374K+ CanRewind and 184K+ CanFastForward lines in a single session (94% of all log output). Makes log analysis extremely difficult.
 
-**Fix:** Remove or heavily rate-limit the blocked-path VERBOSE logs. These are read-only UI state checks that should not produce per-frame output.
+**Fix:** Removed all blocked-path VERBOSE logs from both methods. These are read-only UI state checks called per-recording per-frame — the `reason` out-parameter already conveys the block reason to the caller without needing log output. Success-path logs were already removed in #52.
 
 **Priority:** High — blocks effective log analysis
 
-**Status:** Open
+**Status:** Fixed
 
 ## 118. "Failed to register main menu hook" WARN on every non-MAINMENU OnLoad
 
 `ParsekScenario.OnLoad` logs WARN when main menu hook registration fails outside MAINMENU scene. Expected behavior (retries on next OnLoad), but WARN level is too high for a benign retry.
 
-**Fix:** Downgrade from WARN to VERBOSE.
+**Fix:** Downgraded from `ParsekLog.Warn` to `ParsekLog.Verbose`. This is a benign retry path — not an error condition.
 
 **Priority:** Low
 
-**Status:** Open
+**Status:** Fixed
 
 # In-Game Tests
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -850,9 +850,11 @@ Tagged as Phase 6f-1 in code. Requires in-game API investigation.
 
 ## 61. Controlled children have no recording segments after breakup
 
-`ParsekFlight.cs:2225` — when a crash/breakup creates a recording tree, controlled children (non-debris parts that survive) have no recording segments created for them. The code logs their PIDs but does not start background recordings. Full implementation requires multi-vessel background recording infrastructure.
+`ParsekFlight.cs:2225` — when a crash/breakup creates a recording tree, controlled children (non-debris parts that survive) had no recording segments created for them. The code logged "deferred to Phase 2" but the multi-vessel background recording infrastructure already existed.
 
-**Status:** Open — deferred
+**Fix:** `ProcessBreakupEvent` now creates child recordings for controlled children (same pattern as debris but `IsDebris = false`, no TTL). They are added to BackgroundRecorder for trajectory sampling. This also fixes the RELATIVE anchor issue — controlled children now have recordings and can be spawned during playback, making them available as anchor vessels. `PromoteToTreeForBreakup` already handled this case correctly; only the in-tree breakup path was missing.
+
+**Status:** Fixed
 
 ## 62. Background ghost positioning cachedIdx not persistent
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1446,6 +1446,16 @@ Bug #103 fixed user-facing group headers, but some internal code paths (`TimeJum
 
 **Status:** Open
 
+## 124. Watch mode exit key conflicts with KSP Abort action group
+
+Backspace was used to exit watch mode and return to the active vessel. But Backspace is also KSP's default Abort action group key — pressing it during watch mode triggers abort on the active vessel (deploying parachutes, firing escape tower, etc.).
+
+**Fix:** Changed exit-watch keybinding from Backspace to `[` or `]` (either bracket key). Updated the on-screen overlay hint from `[Backspace] Return to vessel` to `[ ] Return to vessel`.
+
+**Priority:** Medium — caused unintended abort actions during normal watch mode use
+
+**Status:** Fixed
+
 # In-Game Tests
 
 - [ ] Vessels propagate naturally along orbits after FF (no position freezing)

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1261,6 +1261,18 @@ When a spawn is permanently blocked by an immovable vessel (e.g., a landed spawn
 
 **Status:** Fixed (branch `fix/spawn-cleanup`)
 
+## 110b. Spawn-die-respawn infinite loop for FLYING vessels
+
+When a recording's end-of-timeline spawn creates a vessel with `sit=FLYING` at sea level, KSP's on-rails aero check immediately destroys it (101.3 kPa pressure). The "spawned vessel gone" check resets spawn state and the next frame spawns again. This produced 24,000+ spawn-die cycles in one 18-minute session (~960K of 1M log lines). Side effects include unbounded `CrewStatusChanged` event accumulation (3,900+ events) and crew status corruption.
+
+**Root cause:** The vessel-gone check unconditionally resets `VesselSpawned=false` when the spawned vessel disappears, with no counter for how many times this has happened. Unlike the collision-block loop (#110), the spawn SUCCEEDS but the vessel immediately dies.
+
+**Fix:** Added `SpawnDeathCount` field to Recording. The vessel-gone check increments it each time a spawned vessel disappears. After `MaxSpawnDeathCycles` (3) cycles, sets `SpawnAbandoned=true` to permanently stop retries. Resets on revert/load (transient field).
+
+**Priority:** Critical
+
+**Status:** Fixed (branch `fix/spawn-cleanup`)
+
 ## 111. Auto-record fails for spawned vessels (settle timer not seeded on vessel switch)
 
 When Parsek spawns a vessel from a recording and switches the active vessel to it, `lastLandedUT` is never initialized. Spawned vessels are created directly in LANDED state — there is no situation *transition*, so `OnVesselSituationChange` never fires. `OnVesselSwitchComplete` also did not seed the timer. When the user takes off (LANDED → FLYING), `settledTime` computes as 0 (fallback from `lastLandedUT = -1`), which is less than the 5-second settle threshold, and auto-recording is silently suppressed.

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1456,6 +1456,16 @@ Backspace was used to exit watch mode and return to the active vessel. But Backs
 
 **Status:** Fixed
 
+## 125. Engine plate covers / fairings not visible on ghost
+
+Engine plates (`EnginePlate1` etc.) have protective covers (interstage fairings) that are built by `ModuleProceduralFairing` at runtime — similar to stock procedural fairings but integrated into the engine plate part. These covers are not visible on ghost vessels during playback. The ghost shows the engine plate base and attached engines but the fairing shell is missing.
+
+Likely same root cause as the original procedural fairing work: the fairing mesh is generated procedurally from XSECTION data at runtime by `ModuleProceduralFairing`, not stored as a static mesh on the prefab. The ghost builder's `GenerateFairingConeMesh` may not be triggered for engine plate fairings, or the engine plate's MODULE config may differ from standalone fairings.
+
+**Priority:** Medium — visually noticeable on any vessel using engine plates
+
+**Status:** Open
+
 # In-Game Tests
 
 - [ ] Vessels propagate naturally along orbits after FF (no position freezing)

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1046,7 +1046,11 @@ Bug #68 fix limits material cloning to heat-animated transforms, but `FXModuleAn
 
 When a chain recording hits a boundary split (e.g., atmosphere exit), the committed segments appear as a nested group inside a group in the recordings UI. The RecordingGroup logic may be double-nesting chain segments.
 
-**Status:** Open — needs investigation of RecordingGroup assignment during chain boundary commits
+**Root cause:** `HandleAtmosphereBoundarySplit` and `HandleSoiChangeSplit` had no `activeTree != null` guard. During tree mode (after booster separation via `PromoteToTreeForBreakup`), boundary splits still fired and committed chain segments as standalone recordings with group names via `CommitBoundarySplit`, leaking data outside the tree. When `CommitTree` later added the same group name, recordings appeared in both a chain block and tree recordings under the same group.
+
+**Fix:** Added `activeTree != null` early-return guards to both handlers. In tree mode, the recorder keeps accumulating data into the tree recording continuously — boundary crossings are noted in the log but don't trigger standalone chain commits. `ClearBoundaryFlags()` method added to `FlightRecorder` to reset the flags without stopping the recorder.
+
+**Status:** Fixed
 
 ## 88. No merge/approval dialog shown on recording commit
 
@@ -1193,7 +1197,7 @@ Fix: disambiguate with a launch number suffix. Check existing group names via `R
 
 **Priority:** Medium — confusing UI when same craft is launched multiple times
 
-**Status:** Open
+**Status:** Fixed — `RecordingStore.GenerateUniqueGroupName` checks existing group names and appends ` (2)`, ` (3)` etc. Applied at all 4 call sites: `CommitTree`, EVA chain, dock/undock chain, boundary split chain.
 
 ## 105. Colored bubbles visible in ghost engine/RCS plume FX
 
@@ -1237,9 +1241,11 @@ Engine throttle/shutdown events not recorded for some engine types. Ghost engine
 
 Likely cause: `CheckEngineTransition` may not detect the `EngineIgnited → false` transition correctly, or the transition check polls `engine.EngineIgnited && engine.isOperational` which may remain true in certain states (e.g., fuel depletion vs. manual shutdown).
 
+**Partial fix:** `FlightRecorder.EmitTerminalEngineAndRcsEvents` emits synthetic `EngineShutdown`, `RCSStopped`, and `RoboticMotionStopped` events for all entries still in `activeEngineKeys`/`activeRcsKeys`/`activeRoboticKeys` at recording end. Called from `StopRecording()`, `StopRecordingForChainBoundary()`, and `BackgroundRecorder.FinalizeAllForCommit()`. This guarantees ghost plumes shut down at recording boundaries. The original Aeris-4A mid-flight detection issue (missing throttle events / missed shutdown transition during normal polling) may be a separate problem.
+
 **Priority:** Medium — ghost engines keep burning past cutoff, visually incorrect
 
-**Status:** Open
+**Status:** Partially fixed (terminal events added; mid-flight detection issue may remain)
 
 ## 109. Missing CleanupOrphanedSpawnedVessels on second Rewind flight-ready
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1322,7 +1322,7 @@ Bug #105 revealed that fighting KSP's own FX components (KSPParticleEmitter, Mod
 Audit results:
 - **KSPParticleEmitter**: KEPT alive, controlled via `emit` reflection (bug #105 fix, already merged)
 - **SmokeTrailControl**: STRIPPED — tested keeping alive but it sets material alpha to 0 on ghosts, making smoke invisible. Needs vessel context to work correctly
-- **ModelMultiParticlePersistFX / ModelParticleFX**: STRIPPED — EffectBehaviour subclasses that reference Host (Part), NRE without Part context
+- **ModelMultiParticlePersistFX / ModelParticleFX**: KEPT ALIVE — initially stripped (audit #113) but this killed smoke trails. These drive smoke emission; any NREs from missing Part context are non-fatal
 - **FXPrefab**: STRIPPED — registers particles with FloatingOrigin, pollutes global state on ghosts
 - **FXModuleAnimateThrottle**: KEEP REIMPLEMENTATION — PartModule requiring Part/Vessel context. Current HeatGhostInfo animation sampling is correct: one-shot cached build cost, near-zero runtime (3-level quantized snaps), correct multi-instance disambiguation
 - **FXModuleAnimateRCS**: KEEP REIMPLEMENTATION — same PartModule constraints, shares HeatGhostInfo infrastructure

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -779,9 +779,11 @@ Ghosts toggled SetActive(false)/SetActive(true) every frame in KSC and Flight sc
 
 Watch mode keeps the ghost visible at any distance (per the earlier fix to skip zone hiding for watched ghosts). But when the ghost exceeds ~120km from the active vessel, KSP's terrain is not loaded around the ghost's position, causing terrain disappearance and floating-point jitter.
 
-**Fix:** Watch mode now has a 2-second real-time grace period (`WatchModeZoneGraceSeconds`). After grace, if the ghost enters Beyond zone (>120km), Watch exits and the ghost hides normally.
+**Fix (original):** Watch mode had a 2-second real-time grace period (`WatchModeZoneGraceSeconds`). After grace, if the ghost entered Beyond zone (>120km), Watch exited and the ghost hid normally.
 
-**Status:** Fixed
+**Fix (superseded by #119):** The grace-period approach was wrong — ascending rockets naturally exceed 120km and the camera is at the ghost, so the user can see it fine. Replaced with a full zone-hide exemption for the watched ghost (see #119).
+
+**Status:** Superseded by #119
 
 ## 55. RELATIVE anchor triggers on debris and launch pad structures
 
@@ -1383,6 +1385,28 @@ Rewind stripped 8 orphaned spawned vessels from the save. Valentina was assigned
 **Fix:** Downgraded from `ParsekLog.Warn` to `ParsekLog.Verbose`. This is a benign retry path — not an error condition.
 
 **Priority:** Low
+
+**Status:** Fixed
+
+## 119. Watch mode exits when ghost exceeds 120km — camera is at the ghost
+
+During watch mode, zone distance is measured from the ghost to `FlightGlobals.ActiveVessel` (the pad vessel). A rocket ascending naturally exceeds 120km, but the camera is AT the ghost — the user can see it fine. The Beyond zone check (bug #54's grace-period approach) hid the ghost and exited watch mode after 2 seconds, which was wrong for any flight that climbs above 120km altitude.
+
+**Root cause:** Bug #54 introduced a 2-second grace period for the watched ghost in Beyond zone. After the grace period, `ExitWatchMode()` was called and the ghost was hidden. This was designed for the case where a ghost drifts away from the player, but it also triggers during normal ascent when the camera is right at the ghost the entire time.
+
+**Fix:** Replaced the grace-period logic with a full zone-hide exemption for the watched ghost. When `shouldHideMesh` is true and `isWatchedGhost` is true, `shouldHideMesh` is set to false and the ghost falls through to the visible-zone code path. The watched ghost is never hidden by zone distance. Also reset `watchStartTime = Time.time` in `TransferWatchToNextSegment` so logging timestamps are fresh after a chain transfer.
+
+**Priority:** High — watch mode was unusable for any suborbital or orbital flight
+
+**Status:** Fixed
+
+## 120. Capsule doesn't spawn after revert — PID dedup finds pad vessel instead (tree recordings)
+
+After revert, the quicksave restores the pre-launch vessel on the pad with the same PID as the recording's vessel. When the ghost reaches end-of-recording, `RealVesselExists(pid)` finds the pad vessel and skips spawning. The existing `ForceSpawnNewVessel` flag solves this for standalone recordings (set in `OnFlightReady`), but for TREE recordings the tree is still pending when `OnFlightReady` runs — it gets committed later via the merge dialog callback, so `ForceSpawnNewVessel` is never set.
+
+**Fix:** Added `MergeDialog.MarkForceSpawnOnTreeRecordings(tree, activePid)` — iterates tree recordings, sets `ForceSpawnNewVessel = true` on recordings where `VesselPersistentId == activePid && !VesselSpawned`. Called from: (1) single-leaf "Merge to Timeline" callback, (2) multi-vessel "Commit All" callback, (3) `OnFlightReady` pending tree path (belt-and-suspenders).
+
+**Priority:** High — prevents vessel spawn after revert in tree mode
 
 **Status:** Fixed
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1078,7 +1078,7 @@ The Watch (W) button is shown enabled for a recording whose time range is entire
 
 `GetZoneRenderingPolicy(Visual)` and `ShouldApplyPartEventsForZone(Visual)` were changed to apply part events in the Visual zone (2.3-120km) so that structural changes (fairing jettison, staging, crash destruction) work at altitude. Two existing tests still assert the old behavior (`skipPartEvents = true` for Visual zone). Update them to expect `skipPartEvents = false` and `ShouldApplyPartEventsForZone(Visual) = true`.
 
-**Status:** Open — test-only fix, no production code change needed
+**Status:** Fixed (commit 90b73d8)
 
 ## 93. Surface vehicle ghost slides away from recorded position during on-rails playback
 
@@ -1181,7 +1181,7 @@ KSP stock vessels use `#autoLOC_XXXXX` localization keys as vessel names (e.g., 
 
 **Priority:** Medium — every stock vessel shows unreadable group headers
 
-**Status:** Open
+**Status:** Fixed (commit 1104b7e — `ResolveVesselName` via `Localizer.Format()` at storage time)
 
 ## 104. Multiple launches of same vessel merge into one recording group
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1243,19 +1243,23 @@ Likely cause: `CheckEngineTransition` may not detect the `EngineIgnited → fals
 
 After a second Rewind, `CleanupOrphanedSpawnedVessels` does not run, leaving a previously-spawned vessel in the scene at the spawn coordinates. The first Rewind correctly recovers the old spawned vessel, but the second one skips cleanup entirely. This leaves a stale vessel that blocks future spawns at that location.
 
+**Root cause:** After a rewind, the rewind path in `OnLoad` sets `PendingCleanupPids`/`PendingCleanupNames`, then `ResetAllPlaybackState` zeros all spawn tracking. When the false-positive revert path fires on the subsequent SpaceCenter-to-Flight transition, `CollectSpawnedVesselInfo()` returns empty (PIDs are zero) and overwrites the rewind data with null. `OnFlightReady` then sees null and skips cleanup.
+
+**Fix:** Added a guard in the revert path: if `PendingCleanupPids` or `PendingCleanupNames` are already set, skip collection and keep the existing data. Also changed the flightState strip to use `RecordingStore.PendingCleanupNames` (the authoritative source) instead of the local variable. Added entry/skip logging to `CleanupOrphanedSpawnedVessels` and `OnFlightReady`.
+
 **Priority:** High
 
-**Status:** Open
+**Status:** Fixed
 
 ## 110. Spawn collision retry has no limit — infinite loop on permanent overlap
 
 When a spawn is permanently blocked by an immovable vessel (e.g., a landed spawned vessel from a previous cycle that wasn't cleaned up), the spawn retry loop runs every frame indefinitely (~8ms per retry). In one test session this produced 6,270 retries over 27 seconds, flooding ~24,000 lines into KSP.log until the user exited to the main menu. There is no retry limit, timeout, or backoff.
 
-**Fix approach:** Add a maximum retry count (e.g., 60 retries = ~1 second at 60fps). After exhausting retries, log a warning and either skip the spawn or force-spawn at an offset position.
+**Fix:** Added `CollisionBlockCount` field to Recording and `MaxCollisionBlocks = 150` (~2.5s at 60fps) constant to VesselSpawner. After 150 consecutive collision-blocked frames, the spawn is abandoned (`VesselSpawned = true` prevents further attempts) and a WARN is logged. The per-frame overlap log was changed from `ParsekLog.Info` to `ParsekLog.VerboseRateLimited` to prevent log flooding. For chain-tip spawns, `WalkbackExhausted` flag on GhostChain prevents repeated trajectory re-scanning after walkback found no valid position. `SpawnCollisionDetector.CheckOverlapAgainstLoadedVessels` per-vessel overlap log also rate-limited. SpawnWarningUI updated with "walkback exhausted" and "spawn abandoned" status text.
 
 **Priority:** High
 
-**Status:** Open
+**Status:** Fixed (branch `fix/spawn-cleanup`)
 
 ## 111. Auto-record fails for spawned vessels (settle timer not seeded on vessel switch)
 
@@ -1275,7 +1279,25 @@ After rewinding and re-entering flight, the Aeris 4A recording's spawn-at-end tr
 
 **Root cause:** `CleanupOrphanedSpawnedVessels` recovered one copy, but a second Aeris 4A was loaded from the save and occupied the spawn slot. The spawn system has no dedup against already-present matching vessels.
 
-**Priority:** Medium (consequence of #110 infinite retry)
+**Note:** The infinite retry loop symptom is resolved by bug #110's fix (spawn abandoned after 150 frames). The root cause of duplicate vessel presence remains a separate issue.
+
+**Priority:** Medium (consequence of #110 infinite retry — infinite loop symptom now resolved)
+
+**Status:** Open (root cause of duplicate vessel remains; infinite loop symptom resolved by #110 fix)
+
+## 113. Audit ghost FX for KSP-native component usage
+
+Bug #105 revealed that fighting KSP's own FX components (KSPParticleEmitter, ModelMultiParticleFX) produces artifacts. The fix — letting KSP handle particle creation natively and controlling `emit` via reflection — produced much better visuals than any approach that tried to replace KSP's emission with Unity's.
+
+Audit all ghost visual systems for similar opportunities to use KSP-native components instead of reimplementing or stripping them:
+- **Smoke trails**: currently strip `SmokeTrailControl` which fades smoke by atmospheric density. Could we keep it and let KSP handle density-based fading?
+- **Engine heat glow**: `FXModuleAnimateThrottle` animates engine heat materials. Ghost code reimplements this with `HeatGhostInfo`. Could we keep the stock module and drive it?
+- **RCS glow**: `FXModuleAnimateRCS` handles RCS nozzle glow. Same question.
+- **Other FX components**: check if any stripped components would produce better visuals if kept alive and controlled
+
+General principle: prefer toggling KSP's own components on/off via reflection over reimplementing their behavior. KSP's components handle edge cases (material setup, animation curves, density fading) that are hard to replicate correctly.
+
+**Priority:** Low — improvement opportunity, not a bug
 
 **Status:** Open
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1468,6 +1468,26 @@ Likely same root cause as the original procedural fairing work: the fairing mesh
 
 **Status:** Open
 
+## 126. Rewind vessel strip fails due to localization key mismatch
+
+`PreProcessRewindSave` searches for `name = Aeris 4A` in the quicksave .sfs, but the vessel is stored as `name = #autoLOC_501176`. The string comparison fails — zero vessels stripped. The original vessel survives rewind and sits on the runway. `CleanupOrphanedSpawnedVessels` also fails for the same reason: it compares `vessel.vesselName` (returns `#autoLOC_501176`) against recording names ("Aeris 4A").
+
+**Fix:** Resolve localization keys before comparing, or include the raw `#autoLOC` key in the strip set alongside the display name.
+
+**Priority:** High — causes spawn-on-top-of-existing-vessel explosions after rewind
+
+**Status:** Open
+
+## 127. SpawnCollisionDetector checks wrong position — trajectory endpoint vs snapshot
+
+`SpawnOrRecoverIfTooClose` computes `spawnPos` from the recording's last trajectory point (the landing/crash site), but `RespawnVessel` spawns at the vessel snapshot's stored position (the runway). The collision check passes because nothing is at the trajectory endpoint, but the vessel materializes at the snapshot position where another vessel already exists.
+
+**Fix:** Use the snapshot's lat/lon/alt for the collision check, not the last trajectory point.
+
+**Priority:** High — direct cause of spawn-into-existing-vessel explosions
+
+**Status:** Open
+
 # In-Game Tests
 
 - [ ] Vessels propagate naturally along orbits after FF (no position freezing)

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1329,6 +1329,56 @@ Audit results:
 
 **Status:** Done
 
+## 114. Non-leaf tree recording spawns vessel at crash endpoint — immediate destruction
+
+When a recording tree ends because the vessel crashed, recording #0 (the root, pre-crash flight) reaches its endpoint and Parsek spawns a real vessel there. But the endpoint was where the vessel was still FLYING at high speed. Spawned as LANDED, the gear snaps and the entire vessel cascade-explodes. The tree's children (crash debris) represent the final state — the root recording should NOT spawn.
+
+**Observed in:** Session 3 (2026-03-22). Aeris 4A crash tree: root recording UT 53-78, crash at UT 100-102. Ghost exits range at UT 78 → spawns vessel → immediate explosion. Happened twice (once after revert, with crew dedup removing Jeb too).
+
+**Root cause:** `ShouldSpawnAtRecordingEnd` does not check whether the recording is a non-leaf node in a committed tree. Non-leaf recordings are superseded by their children and should never spawn.
+
+**Priority:** Critical — causes cascading destruction, crew death, and confusing UX
+
+**Status:** Open
+
+## 115. Crew dedup removes pilot from spawned vessel after revert
+
+After revert, the pilot (Jebediah) is already on the pad vessel from the quicksave. When Parsek spawns the Aeris 4A at recording endpoint, crew dedup finds Jeb "already on a vessel in the scene" and removes him from the spawn snapshot. The vessel spawns crewless.
+
+**Root cause:** The crew reservation system should have replaced Jeb with a temporary kerbal on the pad vessel, but after revert + tree commit, the reservation may have been cleared.
+
+**Priority:** Medium
+
+**Status:** Open
+
+## 116. Valentina Kerman lost to Missing status after rewind vessel strip
+
+Rewind stripped 8 orphaned spawned vessels from the save. Valentina was assigned to one of them but wasn't in Parsek's crew reservation system. KSP set her to Missing. Parsek's crew rescue only handles reserved crew (Bill, Dudfrid were rescued), not all crew affected by the strip.
+
+**Priority:** Medium
+
+**Status:** Open
+
+## 117. CanRewind/CanFastForward VERBOSE log spam — 578K lines/session
+
+`RecordingStore.CanRewind` and `RecordingStore.CanFastForward` log at VERBOSE on every blocked call. Called per-recording per-frame from UI. With active recording + multiple recordings, produces 374K+ CanRewind and 184K+ CanFastForward lines in a single session (94% of all log output). Makes log analysis extremely difficult.
+
+**Fix:** Remove or heavily rate-limit the blocked-path VERBOSE logs. These are read-only UI state checks that should not produce per-frame output.
+
+**Priority:** High — blocks effective log analysis
+
+**Status:** Open
+
+## 118. "Failed to register main menu hook" WARN on every non-MAINMENU OnLoad
+
+`ParsekScenario.OnLoad` logs WARN when main menu hook registration fails outside MAINMENU scene. Expected behavior (retries on next OnLoad), but WARN level is too high for a benign retry.
+
+**Fix:** Downgrade from WARN to VERBOSE.
+
+**Priority:** Low
+
+**Status:** Open
+
 # In-Game Tests
 
 - [ ] Vessels propagate naturally along orbits after FF (no position freezing)


### PR DESCRIPTION
## Summary

Spawn safety hardening, ghost visual improvements, watch mode fixes, recording improvements, and log cleanup for v0.5.1 release.

### Spawn Safety (8 fixes)
- **#109**: Cleanup guard on revert path
- **#110**: Collision block limit (150 frames)
- **#110b**: Spawn-die loop (3 cycle cap)
- **#114**: Non-leaf + FLYING spawn blocked + crew stripped from destroyed vessels
- **#119**: Watch mode zone exemption (watched ghosts never hidden by distance)
- **#120**: Tree PID dedup ForceSpawnNewVessel on merge
- SpawnAbandoned flag for permanent abandon
- Debris TTL bumped from 30s to 60s

### Recording Improvements (5 fixes)
- **#61**: Controlled children recorded after breakup (was "deferred to Phase 2")
- **#87**: Boundary splits skip standalone chain commits in tree mode
- **#104**: Group name dedup for multiple launches
- **#108**: Synthetic terminal engine/RCS events at recording stop
- RELATIVE anchor fallback: ghost freezes instead of hiding

### Ghost Visuals (2 fixes)
- Smoke trails restored (Unity emission only disabled when KSPParticleEmitter present)
- ModelMultiParticlePersistFX/ModelParticleFX kept alive for native plumes

### UI & Controls (1 fix)
- **#124**: Watch exit key changed from Backspace to [ ] (Abort action group conflict)

### Logging (2 fixes)
- **#117**: CanRewind/CanFastForward VERBOSE spam removed (was 578K lines/session)
- **#118**: Main menu hook WARN downgraded to VERBOSE

### Docs & Version
- Version bumped to 0.5.1
- Comprehensive changelog covering all 20+ PRs since 0.5.0
- 27 bugs fixed, bugs #121-125 filed
- Better Time Warp added to acknowledgements

## Test plan
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 3227 tests pass (~100 new)
- [x] In-game: spawn safety nets trigger correctly (session 4)
- [x] In-game: engine plumes look correct (session 5)
- [x] In-game: watch mode follows through staging (session 6 — zone exemption works)
- [x] In-game: controlled child recording + RELATIVE anchor playback
- [x] In-game: verify no regressions in fresh save

🤖 Generated with [Claude Code](https://claude.com/claude-code)