### PR TITLE
Fix rewind vessel strip and spawn collision position (#126, #127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,12 @@ All notable changes to Parsek are documented here.
 
 ## 0.5.1
 
-Spawn safety hardening, ghost visual improvements, booster/debris tree recording, flag planting, and Fast Forward redesign. 20 PRs merged, 24 bugs fixed.
+Spawn safety hardening, ghost visual improvements, booster/debris tree recording, flag planting, and Fast Forward redesign. 20 PRs merged, 26 bugs fixed.
+
+### Bug Fixes (Late)
+
+- **Localization key mismatch on rewind** — stock vessels using `#autoLOC` keys (e.g., Aeris 4A stored as `#autoLOC_501176`) survived rewind vessel strip because name comparisons failed. Now resolves localization keys via `ResolveLocalizedName()` at all 4 strip/cleanup sites and all recording-creation sites (#126)
+- **Collision check at wrong position** — `SpawnOrRecoverIfTooClose` checked the trajectory endpoint for collisions but `RespawnVessel` spawned at the snapshot position, allowing vessels to materialize on top of existing vessels. Now reads lat/lon/alt from the vessel snapshot for the collision check, with trajectory fallback. Also fixed in chain-tip spawn path (#127)
 
 ### Spawn Safety & Reliability
 

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -1786,7 +1786,7 @@ namespace Parsek
 
             // 4. Get merged vessel name
             Vessel mergedVessel = FlightRecorder.FindVesselByPid(mergedVesselPid);
-            string mergedVesselName = mergedVessel?.vesselName ?? "Merged Vessel";
+            string mergedVesselName = Recording.ResolveLocalizedName(mergedVessel?.vesselName) ?? "Merged Vessel";
 
             // 5. Build merge branch data
             var (bp, mergedChild) = BuildMergeBranchData(
@@ -2360,7 +2360,7 @@ namespace Parsek
                     uint pid = controlledChildren[i];
                     Vessel childVessel = FlightRecorder.FindVesselByPid(pid);
                     string childRecId = Guid.NewGuid().ToString("N");
-                    string vesselName = childVessel?.vesselName ?? "Unknown";
+                    string vesselName = Recording.ResolveLocalizedName(childVessel?.vesselName) ?? "Unknown";
 
                     var childRec = new Recording
                     {
@@ -2412,7 +2412,7 @@ namespace Parsek
                     uint pid = debrisPids[i];
                     Vessel debrisVessel = FlightRecorder.FindVesselByPid(pid);
                     string childRecId = Guid.NewGuid().ToString("N");
-                    string vesselName = debrisVessel?.vesselName ?? "Debris";
+                    string vesselName = Recording.ResolveLocalizedName(debrisVessel?.vesselName) ?? "Debris";
 
                     var childRec = new Recording
                     {
@@ -2547,7 +2547,7 @@ namespace Parsek
                 RecordingId = contRecId,
                 TreeId = treeId,
                 VesselPersistentId = splitRecorder.RecordingVesselId,
-                VesselName = activeVessel?.vesselName ?? cap.VesselName ?? "Unknown",
+                VesselName = Recording.ResolveLocalizedName(activeVessel?.vesselName) ?? cap.VesselName ?? "Unknown",
                 ParentBranchPointId = breakupBp.Id,
                 ExplicitStartUT = breakupBp.UT,
                 GhostVisualSnapshot = activeSnapshot,
@@ -2587,7 +2587,7 @@ namespace Parsek
                     uint pid = debrisPids[i];
                     Vessel debrisVessel = FlightRecorder.FindVesselByPid(pid);
                     string childRecId = Guid.NewGuid().ToString("N");
-                    string vesselName = debrisVessel?.vesselName ?? "Debris";
+                    string vesselName = Recording.ResolveLocalizedName(debrisVessel?.vesselName) ?? "Debris";
 
                     var childRec = new Recording
                     {
@@ -2632,7 +2632,7 @@ namespace Parsek
                     uint pid = controlledPids[i];
                     Vessel childVessel = FlightRecorder.FindVesselByPid(pid);
                     string childRecId = Guid.NewGuid().ToString("N");
-                    string vesselName = childVessel?.vesselName ?? "Unknown";
+                    string vesselName = Recording.ResolveLocalizedName(childVessel?.vesselName) ?? "Unknown";
 
                     var childRec = new Recording
                     {
@@ -3907,7 +3907,7 @@ namespace Parsek
 
             var contRec = new Recording
             {
-                VesselName = otherVessel.vesselName + " (undock continuation)",
+                VesselName = Recording.ResolveLocalizedName(otherVessel.vesselName) + " (undock continuation)",
                 ChainId = activeChainId,
                 ChainIndex = activeChainNextIndex - 1, // same index as the player's new segment
                 ChainBranch = 1, // parallel branch — ghost-only, never spawns
@@ -5574,7 +5574,7 @@ namespace Parsek
                 if (vessel.persistentId == activePid) continue;
 
                 bool matchByPid = hasPids && pids.Contains(vessel.persistentId);
-                bool matchByName = hasNames && names.Contains(vessel.vesselName);
+                bool matchByName = hasNames && names.Contains(Recording.ResolveLocalizedName(vessel.vesselName));
 
                 if (matchByPid || matchByName)
                 {

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -1532,7 +1532,7 @@ namespace Parsek
             for (int i = protoVessels.Count - 1; i >= 0; i--)
             {
                 var pv = protoVessels[i];
-                if (!spawnedNames.Contains(pv.vesselName))
+                if (!spawnedNames.Contains(Recording.ResolveLocalizedName(pv.vesselName)))
                     continue;
 
                 // On KSP Revert, skip PRELAUNCH vessels — these are the user's launch

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -1620,7 +1620,7 @@ namespace Parsek
                 var vesselNodes = flightState.GetNodes("VESSEL");
                 for (int i = vesselNodes.Length - 1; i >= 0; i--)
                 {
-                    string name = vesselNodes[i].GetValue("name");
+                    string name = Recording.ResolveLocalizedName(vesselNodes[i].GetValue("name"));
                     if (vesselNames.Contains(name))
                     {
                         flightState.RemoveNode(vesselNodes[i]);
@@ -1686,7 +1686,7 @@ namespace Parsek
             var vesselNodes = flightState.GetNodes("VESSEL");
             for (int i = vesselNodes.Length - 1; i >= 0; i--)
             {
-                string name = vesselNodes[i].GetValue("name");
+                string name = Recording.ResolveLocalizedName(vesselNodes[i].GetValue("name"));
                 if (vesselNames.Contains(name))
                 {
                     flightState.RemoveNode(vesselNodes[i]);

--- a/Source/Parsek/VesselGhoster.cs
+++ b/Source/Parsek/VesselGhoster.cs
@@ -189,15 +189,32 @@ namespace Parsek
             if (hasSnapPos)
             {
                 string bodyName = tipRecording?.Points != null && tipRecording.Points.Count > 0
-                    ? tipRecording.Points[tipRecording.Points.Count - 1].bodyName : "Kerbin";
+                    ? tipRecording.Points[tipRecording.Points.Count - 1].bodyName : null;
+                if (string.IsNullOrEmpty(bodyName)) bodyName = "Kerbin";
                 CelestialBody snapBody = FlightGlobals.GetBodyByName(bodyName);
-                spawnPos = snapBody != null
-                    ? snapBody.GetWorldSurfacePosition(snapLat, snapLon, snapAlt)
-                    : ComputeSpawnWorldPosition(tipRecording);
+                if (snapBody != null)
+                {
+                    spawnPos = snapBody.GetWorldSurfacePosition(snapLat, snapLon, snapAlt);
+                    ParsekLog.Verbose(Tag,
+                        string.Format(ic,
+                            "SpawnAtChainTip: collision check using snapshot pos lat={0} lon={1} alt={2} body={3}",
+                            snapLat.ToString("F4", ic), snapLon.ToString("F4", ic),
+                            snapAlt.ToString("F1", ic), bodyName));
+                }
+                else
+                {
+                    spawnPos = ComputeSpawnWorldPosition(tipRecording);
+                    ParsekLog.Verbose(Tag,
+                        string.Format(ic,
+                            "SpawnAtChainTip: body '{0}' not found — falling back to ComputeSpawnWorldPosition",
+                            bodyName));
+                }
             }
             else
             {
                 spawnPos = ComputeSpawnWorldPosition(tipRecording);
+                ParsekLog.Verbose(Tag,
+                    "SpawnAtChainTip: no snapshot lat/lon/alt — falling back to ComputeSpawnWorldPosition");
             }
             var (overlap, distance, blockerName) =
                 SpawnCollisionDetector.CheckOverlapAgainstLoadedVessels(spawnPos, spawnBounds, SpawnCollisionPadding);

--- a/Source/Parsek/VesselGhoster.cs
+++ b/Source/Parsek/VesselGhoster.cs
@@ -178,9 +178,27 @@ namespace Parsek
                 return 0;
             }
 
-            // Collision check: compute bounds and check overlap against loaded vessels
+            // Collision check: use snapshot lat/lon/alt (where RespawnVessel actually places
+            // the vessel), falling back to trajectory/terminal position (#127).
             Bounds spawnBounds = SpawnCollisionDetector.ComputeVesselBounds(vesselSnapshot);
-            Vector3d spawnPos = ComputeSpawnWorldPosition(tipRecording);
+            double snapLat = 0, snapLon = 0, snapAlt = 0;
+            bool hasSnapPos = VesselSpawner.TryGetSnapshotDouble(vesselSnapshot, "lat", out snapLat)
+                           && VesselSpawner.TryGetSnapshotDouble(vesselSnapshot, "lon", out snapLon)
+                           && VesselSpawner.TryGetSnapshotDouble(vesselSnapshot, "alt", out snapAlt);
+            Vector3d spawnPos;
+            if (hasSnapPos)
+            {
+                string bodyName = tipRecording?.Points != null && tipRecording.Points.Count > 0
+                    ? tipRecording.Points[tipRecording.Points.Count - 1].bodyName : "Kerbin";
+                CelestialBody snapBody = FlightGlobals.GetBodyByName(bodyName);
+                spawnPos = snapBody != null
+                    ? snapBody.GetWorldSurfacePosition(snapLat, snapLon, snapAlt)
+                    : ComputeSpawnWorldPosition(tipRecording);
+            }
+            else
+            {
+                spawnPos = ComputeSpawnWorldPosition(tipRecording);
+            }
             var (overlap, distance, blockerName) =
                 SpawnCollisionDetector.CheckOverlapAgainstLoadedVessels(spawnPos, spawnBounds, SpawnCollisionPadding);
 

--- a/Source/Parsek/VesselSpawner.cs
+++ b/Source/Parsek/VesselSpawner.cs
@@ -221,7 +221,23 @@ namespace Parsek
                 return;
             }
 
+            // Use snapshot lat/lon/alt for collision check — this is where RespawnVessel
+            // actually places the vessel. Falls back to trajectory endpoint if snapshot
+            // lacks position data (#127).
             var lastPt = rec.Points[rec.Points.Count - 1];
+            double spawnLat = 0, spawnLon = 0, spawnAlt = 0;
+            bool hasSnapshotPos = TryGetSnapshotDouble(rec.VesselSnapshot, "lat", out spawnLat)
+                               && TryGetSnapshotDouble(rec.VesselSnapshot, "lon", out spawnLon)
+                               && TryGetSnapshotDouble(rec.VesselSnapshot, "alt", out spawnAlt);
+            if (!hasSnapshotPos)
+            {
+                spawnLat = lastPt.latitude;
+                spawnLon = lastPt.longitude;
+                spawnAlt = lastPt.altitude;
+                ParsekLog.Verbose("Spawner",
+                    $"No snapshot lat/lon/alt for #{index} ({rec.VesselName}) — using trajectory endpoint for collision check");
+            }
+
             CelestialBody body = FlightGlobals.Bodies?.Find(b => b.name == lastPt.bodyName);
             if (body == null)
             {
@@ -241,8 +257,7 @@ namespace Parsek
                 return;
             }
 
-            Vector3d spawnPos = body.GetWorldSurfacePosition(
-                lastPt.latitude, lastPt.longitude, lastPt.altitude);
+            Vector3d spawnPos = body.GetWorldSurfacePosition(spawnLat, spawnLon, spawnAlt);
 
             // Bounding box overlap check — block spawn if overlapping a loaded vessel.
             // Ghost continues at its last position; next frame retries via UpdateTimelinePlayback.
@@ -891,7 +906,7 @@ namespace Parsek
             return bool.TryParse(raw, out value);
         }
 
-        private static bool TryGetSnapshotDouble(ConfigNode node, string key, out double value)
+        internal static bool TryGetSnapshotDouble(ConfigNode node, string key, out double value)
         {
             value = 0.0;
             if (node == null) return false;

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1472,21 +1472,21 @@ Likely same root cause as the original procedural fairing work: the fairing mesh
 
 `PreProcessRewindSave` searches for `name = Aeris 4A` in the quicksave .sfs, but the vessel is stored as `name = #autoLOC_501176`. The string comparison fails — zero vessels stripped. The original vessel survives rewind and sits on the runway. `CleanupOrphanedSpawnedVessels` also fails for the same reason: it compares `vessel.vesselName` (returns `#autoLOC_501176`) against recording names ("Aeris 4A").
 
-**Fix:** Resolve localization keys before comparing, or include the raw `#autoLOC` key in the strip set alongside the display name.
+**Fix:** Resolve localization keys before comparing via `Recording.ResolveLocalizedName()` at all 4 comparison sites (`PreProcessRewindSave` x2, `CleanupOrphanedSpawnedVessels`, `StripOrphanedSpawnedVessels`) and at all recording-creation sites that store `vessel.vesselName` without resolving.
 
 **Priority:** High — causes spawn-on-top-of-existing-vessel explosions after rewind
 
-**Status:** Open
+**Status:** Fixed
 
 ## 127. SpawnCollisionDetector checks wrong position — trajectory endpoint vs snapshot
 
 `SpawnOrRecoverIfTooClose` computes `spawnPos` from the recording's last trajectory point (the landing/crash site), but `RespawnVessel` spawns at the vessel snapshot's stored position (the runway). The collision check passes because nothing is at the trajectory endpoint, but the vessel materializes at the snapshot position where another vessel already exists.
 
-**Fix:** Use the snapshot's lat/lon/alt for the collision check, not the last trajectory point.
+**Fix:** Read `lat`/`lon`/`alt` from `rec.VesselSnapshot` for the collision check in both `SpawnOrRecoverIfTooClose` and `SpawnAtChainTip`, falling back to trajectory endpoint if snapshot lacks position data.
 
 **Priority:** High — direct cause of spawn-into-existing-vessel explosions
 
-**Status:** Open
+**Status:** Fixed
 
 # In-Game Tests
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1488,6 +1488,16 @@ Likely same root cause as the original procedural fairing work: the fairing mesh
 
 **Status:** Fixed
 
+## 128. Crew replacement not found in roster on second rewind
+
+On the second rewind in session 7, `UnreserveCrewIn` logs `Replacement 'Hadfry Kerman' not found in roster (already removed?)`. Hadfry was hired as a replacement for Jebediah at the start of the second rewind cycle, but by the time unreservation runs after load, Hadfry is gone from the roster. The first rewind cycle (Cerlan Kerman) works fine. The code handles it gracefully (no crash), but the missing replacement may leave stale crew reservation state that accumulates across rewinds.
+
+**Fix:** Investigate ordering between rewind save-load and crew roster cleanup. The replacement may be getting removed by KSP's own roster management before Parsek's unreservation runs.
+
+**Priority:** Low — no crash, handled gracefully, but may cause crew roster drift over many rewinds
+
+**Status:** Open
+
 # In-Game Tests
 
 - [ ] Vessels propagate naturally along orbits after FF (no position freezing)


### PR DESCRIPTION
## Summary

- **#126 — Localization key mismatch on rewind:** stock vessels using `#autoLOC` keys (e.g., `#autoLOC_501176` = "Aeris 4A") survived rewind strip and orphan cleanup because name comparisons failed. Resolves keys via `ResolveLocalizedName()` at all 4 comparison sites and 7 recording-creation sites that stored raw `vessel.vesselName`.
- **#127 — Collision check at wrong position:** `SpawnOrRecoverIfTooClose` checked the trajectory endpoint for collisions but `RespawnVessel` spawned at the snapshot position. Now reads `lat`/`lon`/`alt` from `VesselSnapshot` for the collision check, with trajectory fallback. Also fixed in `SpawnAtChainTip`.

## Test plan

- [x] `dotnet build` — clean
- [x] `dotnet test` — 3227 pass, 0 fail
- [x] In-game: record stock vessel (Aeris 4A), rewind — verify vessel stripped from runway
- [x] In-game: verify spawn collision detection blocks spawn at correct (snapshot) position

🤖 Generated with [Claude Code](https://claude.com/claude-code)