### PR TITLE
Refactor-2 continued: D7, D15/T27, T19-T24, C1-C3 audits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,13 @@ Second-pass structural refactoring. ~80 method extractions, ~105 logging additio
   - `AnimLookup` enum + `FindAnimation` resolver parameterize 3 animation lookup strategies
   - 4 animation sample caches consolidated into 1 `animationSampleCache`
   - `CommitBoundaryAndRestart` shared tail extracted from atmosphere/SOI split handlers (D7)
+- **Performance**
+  - Per-frame `List<PartEvent>` allocations eliminated — 4 transition-check methods now append to reusable buffer (T19)
+  - `TimelineGhosts` dictionary cached per-frame instead of allocating on every property access (T20)
+  - `ResourceBudget.ComputeTotal` cached per-frame, shared across `DrawResourceBudget` and `DrawCompactBudgetLine` (T21)
+- **Audits**
+  - C2: namespace consistency verified — all 73 files correct (`Parsek` or `Parsek.Patches`)
+  - C3: one-class-per-file verified — 5 files have multiple types but all are acceptable data-type bundles or tightly coupled enum+class pairs
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ Second-pass structural refactoring. ~80 method extractions, ~105 logging additio
   - `BudgetSummary` and `UIMode` nested types extracted to top-level
   - Dead code removed: `GetFairingShowMesh`, `GenerateFairingTrussMesh` (zero call sites)
   - `SanitizeQuaternion` unnecessary instance wrapper removed
+- **Pass 4 — Continued dedup**
+  - `SampleAnimationStates` unified core extracted from 4 near-identical methods (D15/T27, -139 lines)
+  - `AnimLookup` enum + `FindAnimation` resolver parameterize 3 animation lookup strategies
+  - 4 animation sample caches consolidated into 1 `animationSampleCache`
+  - `CommitBoundaryAndRestart` shared tail extracted from atmosphere/SOI split handlers (D7)
 
 ### Bug Fixes
 
@@ -37,7 +42,7 @@ Second-pass structural refactoring. ~80 method extractions, ~105 logging additio
 
 ### Test Coverage
 
-3227 → 3315 tests (+88). New test areas:
+3227 → 3322 tests (+95). New test areas:
 - GroupTreeDataTests (14): recordings tree data-computation
 - PostSpawnTerminalStateTests (12): spawn terminal state clearing
 - InterpolatePointsTests (11): trajectory interpolation edge cases
@@ -45,12 +50,16 @@ Second-pass structural refactoring. ~80 method extractions, ~105 logging additio
 - ParsePartPositions + WalkbackAlongTrajectory (14): spawn collision parsing and walkback
 - ReindexTests (7): ghost dict reindexing after deletion
 - AppendCapturedDataTests (7): recording data append + sort
+- GhostSoftCapManager Enabled=false guard (T22)
+- SessionMerger frame trimming verification (T23)
+- EnvironmentDetector ORBITING/ESCAPING situations (T24, 5 tests)
 
 ### Documentation
 
 - Refactor plan, inventory, review checklist, architecture analysis
 - 21 deferred items tracked in `refactor-2-deferred.md` with Open/Done/Closed status
 - 7 future TODO items (T25-T31) added to `todo-and-known-bugs.md`
+- C1, D7, D15, T22-T24, T27 marked done
 
 ---
 

--- a/Source/Parsek.Tests/BackgroundRecorderTests.cs
+++ b/Source/Parsek.Tests/BackgroundRecorderTests.cs
@@ -272,10 +272,11 @@ namespace Parsek.Tests
             ulong key = FlightRecorder.EncodeEngineKey(42, 0);
 
             // Engine off -> on at 80% throttle
-            var events = FlightRecorder.CheckEngineTransition(
+            var events = new List<PartEvent>();
+            FlightRecorder.CheckEngineTransition(
                 key, 42, 0, "liquidEngine1-2",
                 true, 0.8f,
-                activeEngineKeys, lastThrottle, 100.0);
+                activeEngineKeys, lastThrottle, 100.0, events);
 
             Assert.NotNull(events);
             Assert.True(events.Count > 0);
@@ -358,10 +359,11 @@ namespace Parsek.Tests
             ulong key = FlightRecorder.EncodeEngineKey(42, 0);
 
             // RCS off -> on
-            var events = FlightRecorder.CheckRcsTransition(
+            var events = new List<PartEvent>();
+            FlightRecorder.CheckRcsTransition(
                 key, 42, 0, "RCSBlock",
                 true, 0.5f,
-                activeRcsKeys, lastRcsThrottle, 100.0);
+                activeRcsKeys, lastRcsThrottle, 100.0, events);
 
             Assert.NotNull(events);
             Assert.True(events.Count > 0);

--- a/Source/Parsek.Tests/EnvironmentDetectorTests.cs
+++ b/Source/Parsek.Tests/EnvironmentDetectorTests.cs
@@ -143,6 +143,85 @@ namespace Parsek.Tests
 
         #endregion
 
+        #region Classify — ORBITING and ESCAPING situations
+
+        [Fact]
+        public void Classify_OrbitingAboveAtmosphereNoThrust_ReturnsExoBallistic()
+        {
+            // Kerbin: hasAtmosphere=true, above atmosphere, ORBITING, coasting
+            var result = EnvironmentDetector.Classify(
+                hasAtmosphere: true,
+                altitude: 100000,
+                atmosphereDepth: 70000,
+                situation: 32, // ORBITING
+                srfSpeed: 2200,
+                hasActiveThrust: false);
+
+            Assert.Equal(SegmentEnvironment.ExoBallistic, result);
+        }
+
+        [Fact]
+        public void Classify_OrbitingAboveAtmosphereWithThrust_ReturnsExoPropulsive()
+        {
+            // Kerbin: hasAtmosphere=true, above atmosphere, ORBITING, engine firing
+            var result = EnvironmentDetector.Classify(
+                hasAtmosphere: true,
+                altitude: 100000,
+                atmosphereDepth: 70000,
+                situation: 32, // ORBITING
+                srfSpeed: 2200,
+                hasActiveThrust: true);
+
+            Assert.Equal(SegmentEnvironment.ExoPropulsive, result);
+        }
+
+        [Fact]
+        public void Classify_EscapingNoThrust_ReturnsExoBallistic()
+        {
+            // ESCAPING trajectory, no thrust — coasting on escape
+            var result = EnvironmentDetector.Classify(
+                hasAtmosphere: true,
+                altitude: 500000,
+                atmosphereDepth: 70000,
+                situation: 64, // ESCAPING
+                srfSpeed: 3000,
+                hasActiveThrust: false);
+
+            Assert.Equal(SegmentEnvironment.ExoBallistic, result);
+        }
+
+        [Fact]
+        public void Classify_EscapingWithThrust_ReturnsExoPropulsive()
+        {
+            // ESCAPING trajectory, engine firing
+            var result = EnvironmentDetector.Classify(
+                hasAtmosphere: true,
+                altitude: 500000,
+                atmosphereDepth: 70000,
+                situation: 64, // ESCAPING
+                srfSpeed: 3000,
+                hasActiveThrust: true);
+
+            Assert.Equal(SegmentEnvironment.ExoPropulsive, result);
+        }
+
+        [Fact]
+        public void Classify_OrbitingAirlessBodyNoThrust_ReturnsExoBallistic()
+        {
+            // Mun: no atmosphere, ORBITING, coasting
+            var result = EnvironmentDetector.Classify(
+                hasAtmosphere: false,
+                altitude: 50000,
+                atmosphereDepth: 0,
+                situation: 32, // ORBITING
+                srfSpeed: 500,
+                hasActiveThrust: false);
+
+            Assert.Equal(SegmentEnvironment.ExoBallistic, result);
+        }
+
+        #endregion
+
         #region Classify — SurfaceMobile
 
         [Fact]

--- a/Source/Parsek.Tests/GhostSoftCapTests.cs
+++ b/Source/Parsek.Tests/GhostSoftCapTests.cs
@@ -100,6 +100,23 @@ namespace Parsek.Tests
 
         #endregion
 
+        #region EvaluateCaps — Disabled
+
+        [Fact]
+        public void EvaluateCaps_Disabled_ReturnsEmpty_EvenAboveAllThresholds()
+        {
+            GhostSoftCapManager.Enabled = false;
+            // 20 zone1 (above despawn 15), 25 zone2 (above simplify 20)
+            var zone1 = MakeGhostList(20, GhostPriority.LoopedOldest);
+            var zone2 = MakeGhostList(25, GhostPriority.FullTimeline);
+
+            var actions = GhostSoftCapManager.EvaluateCaps(20, 25, zone1, zone2);
+
+            Assert.Empty(actions);
+        }
+
+        #endregion
+
         #region EvaluateCaps — Below Thresholds
 
         [Fact]

--- a/Source/Parsek.Tests/PartEventTests.cs
+++ b/Source/Parsek.Tests/PartEventTests.cs
@@ -473,8 +473,9 @@ namespace Parsek.Tests
             var active = new HashSet<ulong>();
             var throttles = new Dictionary<ulong, float>();
             ulong key = FlightRecorder.EncodeEngineKey(100, 0);
-            var events = FlightRecorder.CheckEngineTransition(
-                key, 100, 0, "liquidEngine", true, 0.8f, active, throttles, 200.0);
+            var events = new List<PartEvent>();
+            FlightRecorder.CheckEngineTransition(
+                key, 100, 0, "liquidEngine", true, 0.8f, active, throttles, 200.0, events);
 
             Assert.Single(events);
             Assert.Equal(PartEventType.EngineIgnited, events[0].eventType);
@@ -491,8 +492,9 @@ namespace Parsek.Tests
             ulong key = FlightRecorder.EncodeEngineKey(100, 0);
             var active = new HashSet<ulong> { key };
             var throttles = new Dictionary<ulong, float> { { key, 1.0f } };
-            var events = FlightRecorder.CheckEngineTransition(
-                key, 100, 0, "liquidEngine", false, 0f, active, throttles, 210.0);
+            var events = new List<PartEvent>();
+            FlightRecorder.CheckEngineTransition(
+                key, 100, 0, "liquidEngine", false, 0f, active, throttles, 210.0, events);
 
             Assert.Single(events);
             Assert.Equal(PartEventType.EngineShutdown, events[0].eventType);
@@ -507,8 +509,9 @@ namespace Parsek.Tests
             ulong key = FlightRecorder.EncodeEngineKey(100, 0);
             var active = new HashSet<ulong> { key };
             var throttles = new Dictionary<ulong, float> { { key, 0.5f } };
-            var events = FlightRecorder.CheckEngineTransition(
-                key, 100, 0, "liquidEngine", true, 0.9f, active, throttles, 215.0);
+            var events = new List<PartEvent>();
+            FlightRecorder.CheckEngineTransition(
+                key, 100, 0, "liquidEngine", true, 0.9f, active, throttles, 215.0, events);
 
             Assert.Single(events);
             Assert.Equal(PartEventType.EngineThrottle, events[0].eventType);
@@ -522,8 +525,9 @@ namespace Parsek.Tests
             ulong key = FlightRecorder.EncodeEngineKey(100, 0);
             var active = new HashSet<ulong> { key };
             var throttles = new Dictionary<ulong, float> { { key, 0.5f } };
-            var events = FlightRecorder.CheckEngineTransition(
-                key, 100, 0, "liquidEngine", true, 0.505f, active, throttles, 215.0);
+            var events = new List<PartEvent>();
+            FlightRecorder.CheckEngineTransition(
+                key, 100, 0, "liquidEngine", true, 0.505f, active, throttles, 215.0, events);
 
             Assert.Empty(events);
         }
@@ -534,8 +538,9 @@ namespace Parsek.Tests
             var active = new HashSet<ulong>();
             var throttles = new Dictionary<ulong, float>();
             ulong key = FlightRecorder.EncodeEngineKey(100, 0);
-            var events = FlightRecorder.CheckEngineTransition(
-                key, 100, 0, "liquidEngine", false, 0f, active, throttles, 200.0);
+            var events = new List<PartEvent>();
+            FlightRecorder.CheckEngineTransition(
+                key, 100, 0, "liquidEngine", false, 0f, active, throttles, 200.0, events);
 
             Assert.Empty(events);
         }
@@ -548,13 +553,15 @@ namespace Parsek.Tests
 
             // First engine on part 200, midx=0
             ulong key0 = FlightRecorder.EncodeEngineKey(200, 0);
-            var events0 = FlightRecorder.CheckEngineTransition(
-                key0, 200, 0, "rapier", true, 1.0f, active, throttles, 300.0);
+            var events0 = new List<PartEvent>();
+            FlightRecorder.CheckEngineTransition(
+                key0, 200, 0, "rapier", true, 1.0f, active, throttles, 300.0, events0);
 
             // Second engine on same part 200, midx=1
             ulong key1 = FlightRecorder.EncodeEngineKey(200, 1);
-            var events1 = FlightRecorder.CheckEngineTransition(
-                key1, 200, 1, "rapier", true, 0.5f, active, throttles, 300.0);
+            var events1 = new List<PartEvent>();
+            FlightRecorder.CheckEngineTransition(
+                key1, 200, 1, "rapier", true, 0.5f, active, throttles, 300.0, events1);
 
             Assert.Single(events0);
             Assert.Equal(0, events0[0].moduleIndex);
@@ -823,9 +830,10 @@ namespace Parsek.Tests
             var blinking = new HashSet<uint>();
             var blinkRates = new Dictionary<uint, float>();
 
-            var events = FlightRecorder.CheckLightBlinkTransition(
+            var events = new List<PartEvent>();
+            FlightRecorder.CheckLightBlinkTransition(
                 42, "spotLight1", isBlinking: true, blinkRate: 2.5f,
-                blinking, blinkRates, 100.0);
+                blinking, blinkRates, 100.0, events);
 
             Assert.Single(events);
             Assert.Equal(PartEventType.LightBlinkEnabled, events[0].eventType);
@@ -840,9 +848,10 @@ namespace Parsek.Tests
             var blinking = new HashSet<uint> { 42 };
             var blinkRates = new Dictionary<uint, float> { { 42, 1.2f } };
 
-            var events = FlightRecorder.CheckLightBlinkTransition(
+            var events = new List<PartEvent>();
+            FlightRecorder.CheckLightBlinkTransition(
                 42, "spotLight1", isBlinking: false, blinkRate: 1.2f,
-                blinking, blinkRates, 110.0);
+                blinking, blinkRates, 110.0, events);
 
             Assert.Single(events);
             Assert.Equal(PartEventType.LightBlinkDisabled, events[0].eventType);
@@ -856,9 +865,10 @@ namespace Parsek.Tests
             var blinking = new HashSet<uint> { 42 };
             var blinkRates = new Dictionary<uint, float> { { 42, 1.0f } };
 
-            var events = FlightRecorder.CheckLightBlinkTransition(
+            var events = new List<PartEvent>();
+            FlightRecorder.CheckLightBlinkTransition(
                 42, "spotLight1", isBlinking: true, blinkRate: 3.0f,
-                blinking, blinkRates, 120.0);
+                blinking, blinkRates, 120.0, events);
 
             Assert.Single(events);
             Assert.Equal(PartEventType.LightBlinkRate, events[0].eventType);
@@ -872,9 +882,10 @@ namespace Parsek.Tests
             var blinking = new HashSet<uint> { 42 };
             var blinkRates = new Dictionary<uint, float> { { 42, 2.0f } };
 
-            var events = FlightRecorder.CheckLightBlinkTransition(
+            var events = new List<PartEvent>();
+            FlightRecorder.CheckLightBlinkTransition(
                 42, "spotLight1", isBlinking: true, blinkRate: 2.005f,
-                blinking, blinkRates, 130.0);
+                blinking, blinkRates, 130.0, events);
 
             Assert.Empty(events);
         }
@@ -1542,8 +1553,9 @@ namespace Parsek.Tests
             var active = new HashSet<ulong>();
             var throttles = new Dictionary<ulong, float>();
             ulong key = FlightRecorder.EncodeEngineKey(100, 0);
-            var events = FlightRecorder.CheckRcsTransition(
-                key, 100, 0, "RCSBlock", true, 0.6f, active, throttles, 200.0);
+            var events = new List<PartEvent>();
+            FlightRecorder.CheckRcsTransition(
+                key, 100, 0, "RCSBlock", true, 0.6f, active, throttles, 200.0, events);
 
             Assert.Single(events);
             Assert.Equal(PartEventType.RCSActivated, events[0].eventType);
@@ -1560,8 +1572,9 @@ namespace Parsek.Tests
             ulong key = FlightRecorder.EncodeEngineKey(100, 0);
             var active = new HashSet<ulong> { key };
             var throttles = new Dictionary<ulong, float> { { key, 0.5f } };
-            var events = FlightRecorder.CheckRcsTransition(
-                key, 100, 0, "RCSBlock", false, 0f, active, throttles, 210.0);
+            var events = new List<PartEvent>();
+            FlightRecorder.CheckRcsTransition(
+                key, 100, 0, "RCSBlock", false, 0f, active, throttles, 210.0, events);
 
             Assert.Single(events);
             Assert.Equal(PartEventType.RCSStopped, events[0].eventType);
@@ -1576,8 +1589,9 @@ namespace Parsek.Tests
             ulong key = FlightRecorder.EncodeEngineKey(100, 0);
             var active = new HashSet<ulong> { key };
             var throttles = new Dictionary<ulong, float> { { key, 0.3f } };
-            var events = FlightRecorder.CheckRcsTransition(
-                key, 100, 0, "RCSBlock", true, 0.8f, active, throttles, 215.0);
+            var events = new List<PartEvent>();
+            FlightRecorder.CheckRcsTransition(
+                key, 100, 0, "RCSBlock", true, 0.8f, active, throttles, 215.0, events);
 
             Assert.Single(events);
             Assert.Equal(PartEventType.RCSThrottle, events[0].eventType);
@@ -1591,8 +1605,9 @@ namespace Parsek.Tests
             ulong key = FlightRecorder.EncodeEngineKey(100, 0);
             var active = new HashSet<ulong> { key };
             var throttles = new Dictionary<ulong, float> { { key, 0.5f } };
-            var events = FlightRecorder.CheckRcsTransition(
-                key, 100, 0, "RCSBlock", true, 0.505f, active, throttles, 215.0);
+            var events = new List<PartEvent>();
+            FlightRecorder.CheckRcsTransition(
+                key, 100, 0, "RCSBlock", true, 0.505f, active, throttles, 215.0, events);
 
             Assert.Empty(events);
         }
@@ -1603,8 +1618,9 @@ namespace Parsek.Tests
             var active = new HashSet<ulong>();
             var throttles = new Dictionary<ulong, float>();
             ulong key = FlightRecorder.EncodeEngineKey(100, 0);
-            var events = FlightRecorder.CheckRcsTransition(
-                key, 100, 0, "RCSBlock", false, 0f, active, throttles, 200.0);
+            var events = new List<PartEvent>();
+            FlightRecorder.CheckRcsTransition(
+                key, 100, 0, "RCSBlock", false, 0f, active, throttles, 200.0, events);
 
             Assert.Empty(events);
         }
@@ -1616,12 +1632,14 @@ namespace Parsek.Tests
             var throttles = new Dictionary<ulong, float>();
 
             ulong key0 = FlightRecorder.EncodeEngineKey(200, 0);
-            var events0 = FlightRecorder.CheckRcsTransition(
-                key0, 200, 0, "RCSBlock", true, 0.7f, active, throttles, 300.0);
+            var events0 = new List<PartEvent>();
+            FlightRecorder.CheckRcsTransition(
+                key0, 200, 0, "RCSBlock", true, 0.7f, active, throttles, 300.0, events0);
 
             ulong key1 = FlightRecorder.EncodeEngineKey(200, 1);
-            var events1 = FlightRecorder.CheckRcsTransition(
-                key1, 200, 1, "RCSBlock", true, 0.3f, active, throttles, 300.0);
+            var events1 = new List<PartEvent>();
+            FlightRecorder.CheckRcsTransition(
+                key1, 200, 1, "RCSBlock", true, 0.3f, active, throttles, 300.0, events1);
 
             Assert.Single(events0);
             Assert.Equal(0, events0[0].moduleIndex);
@@ -2640,8 +2658,9 @@ namespace Parsek.Tests
             ulong key = FlightRecorder.EncodeEngineKey(100, 0);
             var active = new HashSet<ulong> { key };
             var throttles = new Dictionary<ulong, float> { { key, 0.8f } };
-            var events = FlightRecorder.CheckEngineTransition(
-                key, 100, 0, "liquidEngine", true, 0.8f, active, throttles, 200.0);
+            var events = new List<PartEvent>();
+            FlightRecorder.CheckEngineTransition(
+                key, 100, 0, "liquidEngine", true, 0.8f, active, throttles, 200.0, events);
 
             Assert.Empty(events); // No EngineIgnited event
         }
@@ -2653,8 +2672,9 @@ namespace Parsek.Tests
             ulong key = FlightRecorder.EncodeEngineKey(100, 0);
             var empty = new HashSet<ulong>();
             var throttles = new Dictionary<ulong, float>();
-            var events = FlightRecorder.CheckEngineTransition(
-                key, 100, 0, "liquidEngine", true, 0.8f, empty, throttles, 200.0);
+            var events = new List<PartEvent>();
+            FlightRecorder.CheckEngineTransition(
+                key, 100, 0, "liquidEngine", true, 0.8f, empty, throttles, 200.0, events);
 
             Assert.Single(events);
             Assert.Equal(PartEventType.EngineIgnited, events[0].eventType);
@@ -2750,8 +2770,9 @@ namespace Parsek.Tests
             ulong key = FlightRecorder.EncodeEngineKey(700, 0);
             var active = new HashSet<ulong> { key };
             var throttles = new Dictionary<ulong, float> { { key, 0.5f } };
-            var events = FlightRecorder.CheckRcsTransition(
-                key, 700, 0, "rcsBlock", true, 0.5f, active, throttles, 100.0);
+            var events = new List<PartEvent>();
+            FlightRecorder.CheckRcsTransition(
+                key, 700, 0, "rcsBlock", true, 0.5f, active, throttles, 100.0, events);
 
             Assert.Empty(events); // No RCSActivated event
         }

--- a/Source/Parsek.Tests/SessionMergerTests.cs
+++ b/Source/Parsek.Tests/SessionMergerTests.cs
@@ -687,6 +687,100 @@ namespace Parsek.Tests
 
         #endregion
 
+        #region ResolveOverlaps — frame trimming
+
+        [Fact]
+        public void ResolveOverlaps_FramesTrimmedToResultBoundaries()
+        {
+            // Background section [0-200] with frames at 0, 25, 50, 75, 100, 125, 150, 175, 200
+            var bgFrames = new List<TrajectoryPoint>();
+            for (int i = 0; i <= 8; i++)
+            {
+                bgFrames.Add(new TrajectoryPoint
+                {
+                    ut = i * 25.0,
+                    latitude = 0, longitude = 0, altitude = 70000,
+                    bodyName = "Kerbin",
+                    rotation = Quaternion.identity,
+                    velocity = Vector3.zero
+                });
+            }
+            var bgSection = new TrackSection
+            {
+                environment = SegmentEnvironment.Atmospheric,
+                referenceFrame = ReferenceFrame.Absolute,
+                startUT = 0,
+                endUT = 200,
+                source = TrackSectionSource.Background,
+                sampleRateHz = 10f,
+                frames = bgFrames,
+                checkpoints = new List<OrbitSegment>(),
+                boundaryDiscontinuityMeters = 0f
+            };
+
+            // Active section [50-150] with frames at 50, 75, 100, 125, 150
+            var activeFrames = new List<TrajectoryPoint>();
+            for (int i = 2; i <= 6; i++)
+            {
+                activeFrames.Add(new TrajectoryPoint
+                {
+                    ut = i * 25.0,
+                    latitude = 0, longitude = 0, altitude = 71000,
+                    bodyName = "Kerbin",
+                    rotation = Quaternion.identity,
+                    velocity = Vector3.zero
+                });
+            }
+            var activeSection = new TrackSection
+            {
+                environment = SegmentEnvironment.Atmospheric,
+                referenceFrame = ReferenceFrame.Absolute,
+                startUT = 50,
+                endUT = 150,
+                source = TrackSectionSource.Active,
+                sampleRateHz = 10f,
+                frames = activeFrames,
+                checkpoints = new List<OrbitSegment>(),
+                boundaryDiscontinuityMeters = 0f
+            };
+
+            var sections = new List<TrackSection> { bgSection, activeSection };
+
+            var result = SessionMerger.ResolveOverlaps(sections);
+
+            // Expected: Background[0-50] + Active[50-150] + Background[150-200]
+            Assert.Equal(3, result.Count);
+
+            // Background [0-50]: frames at 0, 25, 50
+            Assert.Equal(TrackSectionSource.Background, result[0].source);
+            Assert.Equal(0, result[0].startUT);
+            Assert.Equal(50, result[0].endUT);
+            Assert.NotNull(result[0].frames);
+            Assert.Equal(3, result[0].frames.Count);
+            Assert.Equal(0, result[0].frames[0].ut);
+            Assert.Equal(50, result[0].frames[result[0].frames.Count - 1].ut);
+
+            // Active [50-150]: all 5 frames preserved
+            Assert.Equal(TrackSectionSource.Active, result[1].source);
+            Assert.Equal(50, result[1].startUT);
+            Assert.Equal(150, result[1].endUT);
+            Assert.NotNull(result[1].frames);
+            Assert.Equal(5, result[1].frames.Count);
+            Assert.Equal(50, result[1].frames[0].ut);
+            Assert.Equal(150, result[1].frames[result[1].frames.Count - 1].ut);
+
+            // Background [150-200]: frames at 150, 175, 200
+            Assert.Equal(TrackSectionSource.Background, result[2].source);
+            Assert.Equal(150, result[2].startUT);
+            Assert.Equal(200, result[2].endUT);
+            Assert.NotNull(result[2].frames);
+            Assert.Equal(3, result[2].frames.Count);
+            Assert.Equal(150, result[2].frames[0].ut);
+            Assert.Equal(200, result[2].frames[result[2].frames.Count - 1].ut);
+        }
+
+        #endregion
+
         #region ResolveOverlaps — equal priority (same source)
 
         [Fact]

--- a/Source/Parsek/BackgroundRecorder.cs
+++ b/Source/Parsek/BackgroundRecorder.cs
@@ -52,6 +52,9 @@ namespace Parsek
         private Dictionary<uint, HashSet<uint>> preBreakVesselPidSnapshots
             = new Dictionary<uint, HashSet<uint>>();
 
+        // Reusable buffer for transition-check methods (avoids per-frame List<PartEvent> allocations)
+        private readonly List<PartEvent> reusableEventBuffer = new List<PartEvent>();
+
         // Robotic sampling constants (mirrors FlightRecorder)
         private const double roboticSampleIntervalSeconds = 0.25;
         private const float roboticAngularDeadbandDegrees = 0.5f;
@@ -1924,15 +1927,16 @@ namespace Parsek
                         $"pid={evt.Value.partPersistentId} (bg vessel {state.vesselPid})");
                 }
 
-                var blinkEvents = FlightRecorder.CheckLightBlinkTransition(
+                reusableEventBuffer.Clear();
+                FlightRecorder.CheckLightBlinkTransition(
                     p.persistentId, p.partInfo?.name ?? "unknown",
                     light.isBlinking, light.blinkRate,
-                    state.blinkingLights, state.lightBlinkRates, ut);
-                for (int e = 0; e < blinkEvents.Count; e++)
+                    state.blinkingLights, state.lightBlinkRates, ut, reusableEventBuffer);
+                for (int e = 0; e < reusableEventBuffer.Count; e++)
                 {
-                    treeRec.PartEvents.Add(blinkEvents[e]);
-                    ParsekLog.Verbose("BgRecorder", $"Part event: {blinkEvents[e].eventType} '{blinkEvents[e].partName}' " +
-                        $"pid={blinkEvents[e].partPersistentId} val={blinkEvents[e].value:F2} (bg vessel {state.vesselPid})");
+                    treeRec.PartEvents.Add(reusableEventBuffer[e]);
+                    ParsekLog.Verbose("BgRecorder", $"Part event: {reusableEventBuffer[e].eventType} '{reusableEventBuffer[e].partName}' " +
+                        $"pid={reusableEventBuffer[e].partPersistentId} val={reusableEventBuffer[e].value:F2} (bg vessel {state.vesselPid})");
                 }
             }
         }
@@ -2084,21 +2088,22 @@ namespace Parsek
                 bool ignited = engine.EngineIgnited && engine.isOperational;
                 float throttle = engine.currentThrottle;
 
-                var events = FlightRecorder.CheckEngineTransition(
+                reusableEventBuffer.Clear();
+                FlightRecorder.CheckEngineTransition(
                     key, part.persistentId, moduleIndex,
                     part.partInfo?.name ?? "unknown",
                     ignited, throttle,
-                    state.activeEngineKeys, state.lastThrottle, ut);
+                    state.activeEngineKeys, state.lastThrottle, ut, reusableEventBuffer);
 
-                for (int e = 0; e < events.Count; e++)
+                for (int e = 0; e < reusableEventBuffer.Count; e++)
                 {
-                    treeRec.PartEvents.Add(events[e]);
-                    ParsekLog.Verbose("BgRecorder", $"Part event: {events[e].eventType} '{events[e].partName}' " +
-                        $"pid={events[e].partPersistentId} midx={events[e].moduleIndex} " +
-                        $"val={events[e].value:F2} (bg vessel {state.vesselPid})");
+                    treeRec.PartEvents.Add(reusableEventBuffer[e]);
+                    ParsekLog.Verbose("BgRecorder", $"Part event: {reusableEventBuffer[e].eventType} '{reusableEventBuffer[e].partName}' " +
+                        $"pid={reusableEventBuffer[e].partPersistentId} midx={reusableEventBuffer[e].moduleIndex} " +
+                        $"val={reusableEventBuffer[e].value:F2} (bg vessel {state.vesselPid})");
 
                     // Engine-ignite jettison fallback (same as FlightRecorder)
-                    if (events[e].eventType == PartEventType.EngineIgnited &&
+                    if (reusableEventBuffer[e].eventType == PartEventType.EngineIgnited &&
                         part.FindModuleImplementing<ModuleJettison>() != null)
                     {
                         var shroudEvt = FlightRecorder.CheckJettisonTransition(
@@ -2133,16 +2138,17 @@ namespace Parsek
                 uint pid = part.persistentId;
                 string partName = part.partInfo?.name ?? "unknown";
 
-                var events = FlightRecorder.ProcessRcsDebounce(
+                reusableEventBuffer.Clear();
+                FlightRecorder.ProcessRcsDebounce(
                     key, pid, moduleIndex, partName,
                     active, rcs.thrustForces, rcs.thrusterPower, ut,
-                    state.rcsActiveFrameCount, state.activeRcsKeys, state.lastRcsThrottle);
-                for (int e = 0; e < events.Count; e++)
+                    state.rcsActiveFrameCount, state.activeRcsKeys, state.lastRcsThrottle, reusableEventBuffer);
+                for (int e = 0; e < reusableEventBuffer.Count; e++)
                 {
-                    treeRec.PartEvents.Add(events[e]);
-                    ParsekLog.Verbose("BgRecorder", $"Part event: {events[e].eventType} '{events[e].partName}' " +
-                        $"pid={events[e].partPersistentId} midx={events[e].moduleIndex} " +
-                        $"val={events[e].value:F2} (bg vessel {state.vesselPid})");
+                    treeRec.PartEvents.Add(reusableEventBuffer[e]);
+                    ParsekLog.Verbose("BgRecorder", $"Part event: {reusableEventBuffer[e].eventType} '{reusableEventBuffer[e].partName}' " +
+                        $"pid={reusableEventBuffer[e].partPersistentId} midx={reusableEventBuffer[e].moduleIndex} " +
+                        $"val={reusableEventBuffer[e].value:F2} (bg vessel {state.vesselPid})");
                 }
             }
         }

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -92,6 +92,9 @@ namespace Parsek
         private HashSet<ulong> loggedControlSurfaceClassificationMisses = new HashSet<ulong>();
         private HashSet<ulong> loggedRobotArmScannerClassificationMisses = new HashSet<ulong>();
         private HashSet<ulong> loggedAnimateHeatClassificationMisses = new HashSet<ulong>();
+        // Reusable buffer for transition-check methods that return multiple events per call.
+        // Cleared before each call to avoid per-frame List<PartEvent> allocations.
+        private readonly List<PartEvent> reusableEventBuffer = new List<PartEvent>();
         private HashSet<uint> loggedCargoBayDeployIndexIssues = new HashSet<uint>();
         private HashSet<uint> loggedCargoBayAnimationIssues = new HashSet<uint>();
         private HashSet<uint> loggedCargoBayClosedPositionIssues = new HashSet<uint>();
@@ -606,11 +609,11 @@ namespace Parsek
             return null;
         }
 
-        internal static List<PartEvent> CheckLightBlinkTransition(
+        internal static void CheckLightBlinkTransition(
             uint partPersistentId, string partName, bool isBlinking, float blinkRate,
-            HashSet<uint> blinkingSet, Dictionary<uint, float> blinkRateMap, double ut)
+            HashSet<uint> blinkingSet, Dictionary<uint, float> blinkRateMap, double ut,
+            List<PartEvent> events)
         {
-            var events = new List<PartEvent>();
             bool wasBlinking = blinkingSet.Contains(partPersistentId);
             float safeBlinkRate = blinkRate > 0f ? blinkRate : 1f;
 
@@ -626,7 +629,7 @@ namespace Parsek
                     partName = partName,
                     value = safeBlinkRate
                 });
-                return events;
+                return;
             }
 
             if (!isBlinking && wasBlinking)
@@ -640,7 +643,7 @@ namespace Parsek
                     eventType = PartEventType.LightBlinkDisabled,
                     partName = partName
                 });
-                return events;
+                return;
             }
 
             if (isBlinking && wasBlinking)
@@ -662,8 +665,6 @@ namespace Parsek
                     });
                 }
             }
-
-            return events;
         }
 
         internal static void ClassifyLadderState(float animTime, out bool isExtended, out bool isRetracted)
@@ -827,15 +828,16 @@ namespace Parsek
                         ParsekLog.Verbose("Recorder", $"Part event: {evt.Value.eventType} '{evt.Value.partName}' pid={evt.Value.partPersistentId}");
                     }
 
-                    var blinkEvents = CheckLightBlinkTransition(
+                    reusableEventBuffer.Clear();
+                    CheckLightBlinkTransition(
                         p.persistentId, p.partInfo?.name ?? "unknown",
                         light.isBlinking, light.blinkRate,
-                        blinkingLights, lightBlinkRates, ut);
-                    for (int e = 0; e < blinkEvents.Count; e++)
+                        blinkingLights, lightBlinkRates, ut, reusableEventBuffer);
+                    for (int e = 0; e < reusableEventBuffer.Count; e++)
                     {
-                        PartEvents.Add(blinkEvents[e]);
-                        ParsekLog.Verbose("Recorder", $"Part event: {blinkEvents[e].eventType} '{blinkEvents[e].partName}' " +
-                            $"pid={blinkEvents[e].partPersistentId} val={blinkEvents[e].value:F2}");
+                        PartEvents.Add(reusableEventBuffer[e]);
+                        ParsekLog.Verbose("Recorder", $"Part event: {reusableEventBuffer[e].eventType} '{reusableEventBuffer[e].partName}' " +
+                            $"pid={reusableEventBuffer[e].partPersistentId} val={reusableEventBuffer[e].value:F2}");
                     }
                 }
 
@@ -2392,12 +2394,12 @@ namespace Parsek
             LogCoverageDetails("Robotics", roboticModules);
         }
 
-        internal static List<PartEvent> CheckEngineTransition(
+        internal static void CheckEngineTransition(
             ulong key, uint pid, int moduleIndex, string partName,
             bool ignited, float throttle,
-            HashSet<ulong> activeSet, Dictionary<ulong, float> lastThrottleMap, double ut)
+            HashSet<ulong> activeSet, Dictionary<ulong, float> lastThrottleMap, double ut,
+            List<PartEvent> events)
         {
-            var events = new List<PartEvent>();
             bool wasActive = activeSet.Contains(key);
 
             if (ignited && !wasActive)
@@ -2448,8 +2450,6 @@ namespace Parsek
                     });
                 }
             }
-
-            return events;
         }
 
         private void CheckEngineState(Vessel v)
@@ -2475,22 +2475,23 @@ namespace Parsek
                         $"midx={moduleIndex} id={engineId} thrustTransforms={thrustTransformCount}");
                 }
 
-                var events = CheckEngineTransition(
+                reusableEventBuffer.Clear();
+                CheckEngineTransition(
                     key, part.persistentId, moduleIndex,
                     part.partInfo?.name ?? "unknown",
                     ignited, throttle,
-                    activeEngineKeys, lastThrottle, ut);
+                    activeEngineKeys, lastThrottle, ut, reusableEventBuffer);
 
-                for (int e = 0; e < events.Count; e++)
+                for (int e = 0; e < reusableEventBuffer.Count; e++)
                 {
-                    PartEvents.Add(events[e]);
-                    ParsekLog.Verbose("Recorder", $"Part event: {events[e].eventType} '{events[e].partName}' " +
-                        $"pid={events[e].partPersistentId} midx={events[e].moduleIndex} val={events[e].value:F2}");
+                    PartEvents.Add(reusableEventBuffer[e]);
+                    ParsekLog.Verbose("Recorder", $"Part event: {reusableEventBuffer[e].eventType} '{reusableEventBuffer[e].partName}' " +
+                        $"pid={reusableEventBuffer[e].partPersistentId} midx={reusableEventBuffer[e].moduleIndex} val={reusableEventBuffer[e].value:F2}");
 
                     // Some engines with ModuleJettison (e.g. Mainsail/Skipper/Vector) can
                     // visually drop covers on ignition even when isJettisoned polling lags.
                     // Emit a one-shot shroud event on ignition as a reliable fallback.
-                    if (events[e].eventType == PartEventType.EngineIgnited &&
+                    if (reusableEventBuffer[e].eventType == PartEventType.EngineIgnited &&
                         part.FindModuleImplementing<ModuleJettison>() != null)
                     {
                         var shroudEvt = CheckJettisonTransition(
@@ -2567,12 +2568,12 @@ namespace Parsek
             return frameCount >= threshold;
         }
 
-        internal static List<PartEvent> CheckRcsTransition(
+        internal static void CheckRcsTransition(
             ulong key, uint pid, int moduleIndex, string partName,
             bool active, float power,
-            HashSet<ulong> activeSet, Dictionary<ulong, float> lastThrottleMap, double ut)
+            HashSet<ulong> activeSet, Dictionary<ulong, float> lastThrottleMap, double ut,
+            List<PartEvent> events)
         {
-            var events = new List<PartEvent>();
             bool wasActive = activeSet.Contains(key);
 
             if (active && !wasActive)
@@ -2623,8 +2624,6 @@ namespace Parsek
                     });
                 }
             }
-
-            return events;
         }
 
         /// <summary>
@@ -2632,14 +2631,13 @@ namespace Parsek
         /// threshold crossing, throttle change detection, and micro-correction
         /// filtering. Returns any part events produced this frame.
         /// </summary>
-        internal static List<PartEvent> ProcessRcsDebounce(
+        internal static void ProcessRcsDebounce(
             ulong key, uint pid, int moduleIndex, string partName,
             bool active, float[] thrustForces, float thrusterPower, double ut,
             Dictionary<ulong, int> frameCountMap,
-            HashSet<ulong> activeSet, Dictionary<ulong, float> throttleMap)
+            HashSet<ulong> activeSet, Dictionary<ulong, float> throttleMap,
+            List<PartEvent> events)
         {
-            var events = new List<PartEvent>();
-
             if (active)
             {
                 int count;
@@ -2651,19 +2649,17 @@ namespace Parsek
                 {
                     // Debounce threshold crossed — emit RCSActivated
                     float power = ComputeRcsPower(thrustForces, thrusterPower);
-                    var transition = CheckRcsTransition(
+                    CheckRcsTransition(
                         key, pid, moduleIndex, partName,
-                        true, power, activeSet, throttleMap, ut);
-                    events.AddRange(transition);
+                        true, power, activeSet, throttleMap, ut, events);
                 }
                 else if (count > RcsDebounceFrameThreshold)
                 {
                     // Already recording — check for throttle changes
                     float power = ComputeRcsPower(thrustForces, thrusterPower);
-                    var transition = CheckRcsTransition(
+                    CheckRcsTransition(
                         key, pid, moduleIndex, partName,
-                        true, power, activeSet, throttleMap, ut);
-                    events.AddRange(transition);
+                        true, power, activeSet, throttleMap, ut, events);
                 }
                 // else: count < threshold, still debouncing — skip
             }
@@ -2676,10 +2672,9 @@ namespace Parsek
                     if (IsRcsRecordingSustained(count, RcsDebounceFrameThreshold))
                     {
                         // Was a sustained activation — emit RCSStopped
-                        var transition = CheckRcsTransition(
+                        CheckRcsTransition(
                             key, pid, moduleIndex, partName,
-                            false, 0f, activeSet, throttleMap, ut);
-                        events.AddRange(transition);
+                            false, 0f, activeSet, throttleMap, ut, events);
                     }
                     else
                     {
@@ -2690,8 +2685,6 @@ namespace Parsek
                     frameCountMap.Remove(key);
                 }
             }
-
-            return events;
         }
 
         private void CheckRcsState(Vessel v)
@@ -2717,15 +2710,16 @@ namespace Parsek
                 uint pid = part.persistentId;
                 string partName = part.partInfo?.name ?? "unknown";
 
-                var events = ProcessRcsDebounce(
+                reusableEventBuffer.Clear();
+                ProcessRcsDebounce(
                     key, pid, moduleIndex, partName,
                     active, rcs.thrustForces, rcs.thrusterPower, ut,
-                    rcsActiveFrameCount, activeRcsKeys, lastRcsThrottle);
-                for (int e = 0; e < events.Count; e++)
+                    rcsActiveFrameCount, activeRcsKeys, lastRcsThrottle, reusableEventBuffer);
+                for (int e = 0; e < reusableEventBuffer.Count; e++)
                 {
-                    PartEvents.Add(events[e]);
-                    ParsekLog.Verbose("Recorder", $"Part event: {events[e].eventType} '{events[e].partName}' " +
-                        $"pid={events[e].partPersistentId} midx={events[e].moduleIndex} val={events[e].value:F2}");
+                    PartEvents.Add(reusableEventBuffer[e]);
+                    ParsekLog.Verbose("Recorder", $"Part event: {reusableEventBuffer[e].eventType} '{reusableEventBuffer[e].partName}' " +
+                        $"pid={reusableEventBuffer[e].partPersistentId} midx={reusableEventBuffer[e].moduleIndex} val={reusableEventBuffer[e].value:F2}");
                 }
             }
         }

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -439,6 +439,7 @@ namespace Parsek
                 return vesselExistsOverride(vesselPersistentId);
 
             if (FlightGlobals.Vessels == null) return false;
+
             for (int i = 0; i < FlightGlobals.Vessels.Count; i++)
             {
                 if (FlightGlobals.Vessels[i] != null &&

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -1196,44 +1196,231 @@ namespace Parsek
             return result;
         }
 
-        // Cache: partName → list of (path, stowed state, deployed state) — sample once per part type
+        // Unified cache for all animation-sampled transform states (deployable, gear, ladder, cargo bay).
+        // Key collision is impossible: Deployable/Gear/CargoBay use plain part names but a part enters
+        // exactly one code path (priority cascade in TryBuildDeployableInfo). Ladder uses compound keys
+        // with '|' separators that never match plain part names.
         private static readonly Dictionary<string, List<(string path, Vector3 sPos, Quaternion sRot, Vector3 sScale,
-            Vector3 dPos, Quaternion dRot, Vector3 dScale)>> deployableCache =
+            Vector3 dPos, Quaternion dRot, Vector3 dScale)>> animationSampleCache =
             new Dictionary<string, List<(string, Vector3, Quaternion, Vector3, Vector3, Quaternion, Vector3)>>();
 
-        internal static void ClearDeployableCache()
+        internal static void ClearAnimationSampleCache()
         {
-            deployableCache.Clear();
+            animationSampleCache.Clear();
         }
 
-        // Cache: partName → list of gear animation transform states — sample once per part type
-        private static readonly Dictionary<string, List<(string path, Vector3 sPos, Quaternion sRot, Vector3 sScale,
-            Vector3 dPos, Quaternion dRot, Vector3 dScale)>> gearCache =
-            new Dictionary<string, List<(string, Vector3, Quaternion, Vector3, Vector3, Quaternion, Vector3)>>();
-
-        internal static void ClearGearCache()
+        /// <summary>
+        /// How to locate the Animation component on a cloned prefab model.
+        /// </summary>
+        private enum AnimLookup
         {
-            gearCache.Clear();
+            /// <summary>GetComponentInChildren (simplest — used by ModuleDeployablePart).</summary>
+            Simple,
+            /// <summary>Try named transform first, fallback to GetComponentInChildren (used by landing gear).</summary>
+            ByTransformName,
+            /// <summary>Search all Animation components for one containing the clip, fallback to GetComponentInChildren (used by cargo bays).</summary>
+            ByClipSearch,
+            /// <summary>Try named transform, then search all for clip. Intentionally NO GetComponentInChildren fallback (used by ladders/animation groups).</summary>
+            ByTransformThenClipSearch
         }
 
-        // Cache: partName(+anim) → list of ladder animation transform states — sample once per part type
-        private static readonly Dictionary<string, List<(string path, Vector3 sPos, Quaternion sRot, Vector3 sScale,
-            Vector3 dPos, Quaternion dRot, Vector3 dScale)>> ladderCache =
-            new Dictionary<string, List<(string, Vector3, Quaternion, Vector3, Vector3, Quaternion, Vector3)>>();
-
-        internal static void ClearLadderCache()
+        /// <summary>
+        /// Find the Animation component on a cloned model using the specified lookup strategy.
+        /// Returns null if no suitable Animation is found.
+        /// </summary>
+        private static Animation FindAnimation(
+            GameObject clone, string animName, string transformName,
+            AnimLookup mode, string label, string partKey)
         {
-            ladderCache.Clear();
+            Animation anim = null;
+
+            switch (mode)
+            {
+                case AnimLookup.Simple:
+                    anim = clone.GetComponentInChildren<Animation>(true);
+                    break;
+
+                case AnimLookup.ByTransformName:
+                    if (!string.IsNullOrEmpty(transformName))
+                    {
+                        Transform trf = FindTransformRecursive(clone.transform, transformName);
+                        if (trf != null)
+                            anim = trf.GetComponent<Animation>();
+                    }
+                    if (anim == null)
+                        anim = clone.GetComponentInChildren<Animation>(true);
+                    break;
+
+                case AnimLookup.ByClipSearch:
+                    foreach (var candidate in clone.GetComponentsInChildren<Animation>(true))
+                    {
+                        if (candidate[animName] != null)
+                        {
+                            anim = candidate;
+                            break;
+                        }
+                    }
+                    if (anim == null)
+                        anim = clone.GetComponentInChildren<Animation>(true);
+                    break;
+
+                case AnimLookup.ByTransformThenClipSearch:
+                    // Try named transform first
+                    if (!string.IsNullOrEmpty(transformName))
+                    {
+                        Transform animRoot = FindTransformRecursive(clone.transform, transformName);
+                        if (animRoot != null)
+                            anim = animRoot.GetComponent<Animation>();
+                        else
+                            ParsekLog.Verbose("GhostVisual", $"  {label} '{partKey}': animation root '{transformName}' not found on clone");
+                    }
+                    // Fallback: search all Animation components for one containing the clip
+                    // Intentionally NO GetComponentInChildren fallback — if clip isn't found, return null
+                    if (anim == null)
+                    {
+                        foreach (var candidate in clone.GetComponentsInChildren<Animation>(true))
+                        {
+                            if (candidate[animName] != null)
+                            {
+                                anim = candidate;
+                                break;
+                            }
+                        }
+                    }
+                    break;
+            }
+
+            return anim;
         }
 
-        // Cache: partName → list of cargo bay animation transform states — sample once per part type
-        private static readonly Dictionary<string, List<(string path, Vector3 sPos, Quaternion sRot, Vector3 sScale,
-            Vector3 dPos, Quaternion dRot, Vector3 dScale)>> cargoBayCache =
-            new Dictionary<string, List<(string, Vector3, Quaternion, Vector3, Vector3, Quaternion, Vector3)>>();
-
-        internal static void ClearCargoBayCache()
+        /// <summary>
+        /// Core animation sampling: clones prefab model, finds Animation via the specified strategy,
+        /// samples at two time points (or uses 3-snapshot scoring for endpoint detection), and returns
+        /// transform deltas between stowed and deployed states.
+        /// Returns null if no animation found, no AnimationState, or no deltas produced.
+        /// Does NOT handle caching — callers manage their own cache read/write.
+        /// </summary>
+        private static List<(string path, Vector3 sPos, Quaternion sRot, Vector3 sScale,
+            Vector3 dPos, Quaternion dRot, Vector3 dScale)> SampleAnimationStates(
+            Part prefab, string animName, string label,
+            AnimLookup lookupMode, string lookupTransformName,
+            float stowedTime, float deployedTime, bool useScoring)
         {
-            cargoBayCache.Clear();
+            string partKey = prefab.partInfo?.name ?? prefab.name;
+            Transform modelRoot = FindModelRoot(prefab);
+            GameObject tempClone = Object.Instantiate(modelRoot.gameObject);
+            List<(string, Vector3, Quaternion, Vector3, Vector3, Quaternion, Vector3)> result = null;
+
+            try
+            {
+                Animation anim = FindAnimation(tempClone, animName, lookupTransformName,
+                    lookupMode, label, partKey);
+                if (anim == null)
+                {
+                    ParsekLog.Verbose("GhostVisual", $"  {label} '{partKey}': no Animation component on model clone");
+                    return null;
+                }
+
+                AnimationState state = anim[animName];
+                if (state == null)
+                {
+                    ParsekLog.Verbose("GhostVisual", $"  {label} '{partKey}': animation '{animName}' not found on clone");
+                    return null;
+                }
+
+                var allTransforms = tempClone.GetComponentsInChildren<Transform>(true);
+
+                if (useScoring)
+                {
+                    // 3-snapshot scoring: capture default state BEFORE setting anim properties
+                    // (ordering is critical — captures prefab defaults before any animation influence)
+                    var defaultStates = SnapshotTransformStates(allTransforms, tempClone.transform);
+
+                    state.enabled = true;
+                    state.speed = 0f;
+                    state.weight = 1f;
+
+                    state.normalizedTime = 0f;
+                    anim.Play(animName);
+                    anim.Sample();
+                    var time0States = SnapshotTransformStates(allTransforms, tempClone.transform);
+
+                    state.normalizedTime = 1f;
+                    anim.Sample();
+                    var time1States = SnapshotTransformStates(allTransforms, tempClone.transform);
+
+                    // Score: which endpoint is closer to the default (= stowed)?
+                    float score0 = 0f;
+                    float score1 = 0f;
+                    foreach (var kv in defaultStates)
+                    {
+                        if (!time0States.TryGetValue(kv.Key, out var t0) ||
+                            !time1States.TryGetValue(kv.Key, out var t1))
+                            continue;
+
+                        float rot0 = Quaternion.Angle(kv.Value.rot, t0.rot);
+                        float rot1 = Quaternion.Angle(kv.Value.rot, t1.rot);
+                        score0 += (t0.pos - kv.Value.pos).sqrMagnitude +
+                            (t0.scale - kv.Value.scale).sqrMagnitude + (rot0 * rot0 * 0.0001f);
+                        score1 += (t1.pos - kv.Value.pos).sqrMagnitude +
+                            (t1.scale - kv.Value.scale).sqrMagnitude + (rot1 * rot1 * 0.0001f);
+                    }
+
+                    bool stowedIsTime0 = score0 <= score1;
+                    var stowedStates = stowedIsTime0 ? time0States : time1States;
+                    float scoredDeployedTime = stowedIsTime0 ? 1f : 0f;
+
+                    // Re-sample at deployed time so transforms hold deployed state
+                    state.normalizedTime = scoredDeployedTime;
+                    anim.Sample();
+
+                    result = CollectTransformDeltas(allTransforms, tempClone.transform, stowedStates);
+
+                    if (result.Count == 0)
+                    {
+                        ParsekLog.Verbose("GhostVisual", $"  {label} '{partKey}': animation '{animName}' produced no transform deltas");
+                        result = null;
+                    }
+                    else
+                    {
+                        ParsekLog.Verbose("GhostVisual", $"  {label} '{partKey}': sampled {result.Count} animated transforms from '{animName}' " +
+                            $"(stowed=time{(stowedIsTime0 ? "0" : "1")})");
+                    }
+                }
+                else
+                {
+                    // Simple 2-point sampling
+                    state.enabled = true;
+                    state.speed = 0f;
+                    state.normalizedTime = stowedTime;
+                    state.weight = 1f;
+                    anim.Play(animName);
+                    anim.Sample();
+
+                    var stowedStates = SnapshotTransformStates(allTransforms, tempClone.transform);
+
+                    state.normalizedTime = deployedTime;
+                    anim.Sample();
+
+                    result = CollectTransformDeltas(allTransforms, tempClone.transform, stowedStates);
+
+                    if (result.Count == 0)
+                    {
+                        ParsekLog.Verbose("GhostVisual", $"  {label} '{partKey}': animation '{animName}' produced no transform deltas");
+                        result = null;
+                    }
+                    else
+                    {
+                        ParsekLog.Verbose("GhostVisual", $"  {label} '{partKey}': sampled {result.Count} animated transforms from '{animName}'");
+                    }
+                }
+            }
+            finally
+            {
+                Object.DestroyImmediate(tempClone);
+            }
+
+            return result;
         }
 
         // Cache: partName(+anim) -> sampled 3-state ModuleAnimateHeat transform states
@@ -1248,101 +1435,29 @@ namespace Parsek
             animateHeatCache.Clear();
         }
 
-        /// <summary>
-        /// Sample stowed and deployed transform states from a landing gear's animation.
-        /// Uses animationTrfName to resolve the correct Animation component (avoids binding spotlight
-        /// animation on parts like GearSmall that have multiple Animation components).
-        /// deployedPosition determines which animation endpoint is "deployed" (1 for most gear, 0 for rover wheels).
-        /// Returns null if no animation or no transform deltas.
-        /// </summary>
         private static List<(string path, Vector3 sPos, Quaternion sRot, Vector3 sScale,
             Vector3 dPos, Quaternion dRot, Vector3 dScale)> SampleGearStates(
             Part prefab, string animationStateName, string animationTrfName, float deployedPosition)
         {
             string key = prefab.partInfo?.name ?? prefab.name;
-            if (gearCache.TryGetValue(key, out var cached))
+            if (animationSampleCache.TryGetValue(key, out var cached))
                 return cached;
 
             if (string.IsNullOrEmpty(animationStateName))
             {
                 ParsekLog.Verbose("GhostVisual", $"  Gear '{key}': no animationStateName — skipping animation sampling");
-                gearCache[key] = null;
+                animationSampleCache[key] = null;
                 return null;
             }
 
-            Transform modelRoot = FindModelRoot(prefab);
-            GameObject tempClone = Object.Instantiate(modelRoot.gameObject);
+            // Most gear: deployedPosition=1 → stowed=0, deployed=1
+            // Rover wheel: deployedPosition=0 → stowed=1, deployed=0
+            float stowedTime = deployedPosition >= 0.5f ? 0f : 1f;
+            float deployedTime = deployedPosition >= 0.5f ? 1f : 0f;
 
-            List<(string, Vector3, Quaternion, Vector3, Vector3, Quaternion, Vector3)> result = null;
-
-            try
-            {
-                // Resolve Animation via animationTrfName first (prevents binding wrong animation)
-                Animation anim = null;
-                if (!string.IsNullOrEmpty(animationTrfName))
-                {
-                    Transform animTrf = FindTransformRecursive(tempClone.transform, animationTrfName);
-                    if (animTrf != null)
-                        anim = animTrf.GetComponent<Animation>();
-                }
-                // Fallback to any Animation on the clone
-                if (anim == null)
-                    anim = tempClone.GetComponentInChildren<Animation>(true);
-
-                if (anim == null)
-                {
-                    ParsekLog.Verbose("GhostVisual", $"  Gear '{key}': no Animation component on model clone");
-                    gearCache[key] = null;
-                    return null;
-                }
-
-                AnimationState state = anim[animationStateName];
-                if (state == null)
-                {
-                    ParsekLog.Verbose("GhostVisual", $"  Gear '{key}': animation '{animationStateName}' not found on clone");
-                    gearCache[key] = null;
-                    return null;
-                }
-
-                // Determine animation endpoints based on deployedPosition.
-                // Most gear: deployedPosition=1 → stowed at time=0, deployed at time=1
-                // Rover wheel: deployedPosition=0 → stowed at time=1, deployed at time=0
-                float stowedTime = deployedPosition >= 0.5f ? 0f : 1f;
-                float deployedTime = deployedPosition >= 0.5f ? 1f : 0f;
-
-                // Sample stowed state
-                state.enabled = true;
-                state.speed = 0f;
-                state.normalizedTime = stowedTime;
-                state.weight = 1f;
-                anim.Play(animationStateName);
-                anim.Sample();
-
-                var allTransforms = tempClone.GetComponentsInChildren<Transform>(true);
-                var stowedStates = SnapshotTransformStates(allTransforms, tempClone.transform);
-
-                // Sample deployed state
-                state.normalizedTime = deployedTime;
-                anim.Sample();
-
-                result = CollectTransformDeltas(allTransforms, tempClone.transform, stowedStates);
-
-                if (result.Count == 0)
-                {
-                    ParsekLog.Verbose("GhostVisual", $"  Gear '{key}': animation '{animationStateName}' produced no transform deltas");
-                    result = null;
-                }
-                else
-                {
-                    ParsekLog.Verbose("GhostVisual", $"  Gear '{key}': sampled {result.Count} animated transforms from '{animationStateName}'");
-                }
-            }
-            finally
-            {
-                Object.DestroyImmediate(tempClone);
-            }
-
-            gearCache[key] = result;
+            var result = SampleAnimationStates(prefab, animationStateName, "Gear",
+                AnimLookup.ByTransformName, animationTrfName, stowedTime, deployedTime, false);
+            animationSampleCache[key] = result;
             return result;
         }
 
@@ -1686,165 +1801,40 @@ namespace Parsek
             return result;
         }
 
-        /// <summary>
-        /// Sample stowed and deployed transform states for stock RetractableLadder modules.
-        /// Ladders expose "ladderRetractAnimationName" rather than ModuleDeployablePart, and
-        /// clip direction is not guaranteed, so stowed endpoint is inferred from prefab defaults.
-        /// </summary>
         private static List<(string path, Vector3 sPos, Quaternion sRot, Vector3 sScale,
             Vector3 dPos, Quaternion dRot, Vector3 dScale)> SampleLadderStates(
             Part prefab, string animationName, string animationRootName)
         {
             string partKey = prefab.partInfo?.name ?? prefab.name;
             string cacheKey = partKey + "|" + (animationName ?? string.Empty) + "|" + (animationRootName ?? string.Empty);
-            if (ladderCache.TryGetValue(cacheKey, out var cached))
+            if (animationSampleCache.TryGetValue(cacheKey, out var cached))
                 return cached;
 
             if (string.IsNullOrEmpty(animationName))
             {
                 ParsekLog.Verbose("GhostVisual", $"  Ladder '{partKey}': no ladderRetractAnimationName — skipping animation sampling");
-                ladderCache[cacheKey] = null;
+                animationSampleCache[cacheKey] = null;
                 return null;
             }
 
-            Transform modelRoot = FindModelRoot(prefab);
-            GameObject tempClone = Object.Instantiate(modelRoot.gameObject);
-            List<(string, Vector3, Quaternion, Vector3, Vector3, Quaternion, Vector3)> result = null;
-
-            try
-            {
-                Animation anim = null;
-                if (!string.IsNullOrEmpty(animationRootName))
-                {
-                    Transform animRoot = FindTransformRecursive(tempClone.transform, animationRootName);
-                    if (animRoot != null)
-                        anim = animRoot.GetComponent<Animation>();
-                    else
-                        ParsekLog.Verbose("GhostVisual", $"  Ladder '{partKey}': animation root '{animationRootName}' not found on clone");
-                }
-
-                if (anim == null)
-                {
-                    foreach (var candidate in tempClone.GetComponentsInChildren<Animation>(true))
-                    {
-                        if (candidate[animationName] != null)
-                        {
-                            anim = candidate;
-                            break;
-                        }
-                    }
-                }
-
-                if (anim == null)
-                {
-                    ParsekLog.Verbose("GhostVisual", $"  Ladder '{partKey}': no Animation component on model clone");
-                    ladderCache[cacheKey] = null;
-                    return null;
-                }
-
-                AnimationState state = anim[animationName];
-                if (state == null)
-                {
-                    ParsekLog.Verbose("GhostVisual", $"  Ladder '{partKey}': animation '{animationName}' not found on clone");
-                    ladderCache[cacheKey] = null;
-                    return null;
-                }
-
-                var allTransforms = tempClone.GetComponentsInChildren<Transform>(true);
-                var defaultStates = SnapshotTransformStates(allTransforms, tempClone.transform);
-
-                state.enabled = true;
-                state.speed = 0f;
-                state.weight = 1f;
-
-                state.normalizedTime = 0f;
-                anim.Play(animationName);
-                anim.Sample();
-                var time0States = SnapshotTransformStates(allTransforms, tempClone.transform);
-
-                state.normalizedTime = 1f;
-                anim.Sample();
-                var time1States = SnapshotTransformStates(allTransforms, tempClone.transform);
-
-                float score0 = 0f;
-                float score1 = 0f;
-                foreach (var kv in defaultStates)
-                {
-                    if (!time0States.TryGetValue(kv.Key, out var t0) ||
-                        !time1States.TryGetValue(kv.Key, out var t1))
-                        continue;
-
-                    float rot0 = Quaternion.Angle(kv.Value.rot, t0.rot);
-                    float rot1 = Quaternion.Angle(kv.Value.rot, t1.rot);
-                    score0 += (t0.pos - kv.Value.pos).sqrMagnitude +
-                        (t0.scale - kv.Value.scale).sqrMagnitude + (rot0 * rot0 * 0.0001f);
-                    score1 += (t1.pos - kv.Value.pos).sqrMagnitude +
-                        (t1.scale - kv.Value.scale).sqrMagnitude + (rot1 * rot1 * 0.0001f);
-                }
-
-                bool stowedIsTime0 = score0 <= score1;
-                var stowedStates = stowedIsTime0 ? time0States : time1States;
-                var deployedStates = stowedIsTime0 ? time1States : time0States;
-
-                result = new List<(string, Vector3, Quaternion, Vector3, Vector3, Quaternion, Vector3)>();
-                for (int i = 0; i < allTransforms.Length; i++)
-                {
-                    string path = GetTransformPath(allTransforms[i], tempClone.transform);
-                    if (!stowedStates.TryGetValue(path, out var stowed) ||
-                        !deployedStates.TryGetValue(path, out var deployed))
-                        continue;
-
-                    float posDelta = (deployed.pos - stowed.pos).sqrMagnitude;
-                    float rotDelta = Quaternion.Angle(deployed.rot, stowed.rot);
-                    float scaleDelta = (deployed.scale - stowed.scale).sqrMagnitude;
-
-                    if (posDelta > 0.0001f || rotDelta > 0.01f || scaleDelta > 0.0001f)
-                    {
-                        result.Add((path, stowed.pos, stowed.rot, stowed.scale,
-                            deployed.pos, deployed.rot, deployed.scale));
-                    }
-                }
-
-                if (result.Count == 0)
-                {
-                    ParsekLog.Verbose("GhostVisual", $"  Ladder '{partKey}': animation '{animationName}' produced no transform deltas");
-                    result = null;
-                }
-                else
-                {
-                    ParsekLog.Verbose("GhostVisual", $"  Ladder '{partKey}': sampled {result.Count} animated transforms from '{animationName}' " +
-                        $"(stowed=time{(stowedIsTime0 ? "0" : "1")})");
-                }
-            }
-            finally
-            {
-                Object.DestroyImmediate(tempClone);
-            }
-
-            ladderCache[cacheKey] = result;
+            var result = SampleAnimationStates(prefab, animationName, "Ladder",
+                AnimLookup.ByTransformThenClipSearch, animationRootName, 0f, 0f, useScoring: true);
+            animationSampleCache[cacheKey] = result;
             return result;
         }
 
-        /// <summary>
-        /// Sample closed and open transform states from a cargo bay's animation.
-        /// closedPosition determines which animation endpoint is "closed":
-        ///   near 0 → closed at time=0, open at time=1 (service bays)
-        ///   near 1 → closed at time=1, open at time=0 (Mk3/Mk2 cargo bays)
-        /// Returns stowed=closed, deployed=open (normalized for DeployableGhostInfo reuse).
-        /// Returns null if no animation or no transform deltas.
-        /// </summary>
         private static List<(string path, Vector3 sPos, Quaternion sRot, Vector3 sScale,
             Vector3 dPos, Quaternion dRot, Vector3 dScale)> SampleCargoBayStates(
             Part prefab, string animationName, float closedPosition)
         {
             string key = prefab.partInfo?.name ?? prefab.name;
-            if (cargoBayCache.TryGetValue(key, out var cached))
+            if (animationSampleCache.TryGetValue(key, out var cached))
                 return cached;
 
             if (string.IsNullOrEmpty(animationName))
             {
                 ParsekLog.Verbose("GhostVisual", $"  CargoBay '{key}': no animationName — skipping animation sampling");
-                cargoBayCache[key] = null;
+                animationSampleCache[key] = null;
                 return null;
             }
 
@@ -1863,161 +1853,35 @@ namespace Parsek
             else
             {
                 ParsekLog.Verbose("GhostVisual", $"  CargoBay '{key}': non-standard closedPosition={closedPosition} — skipping");
-                cargoBayCache[key] = null;
+                animationSampleCache[key] = null;
                 return null;
             }
 
-            Transform modelRoot = FindModelRoot(prefab);
-            GameObject tempClone = Object.Instantiate(modelRoot.gameObject);
-
-            List<(string, Vector3, Quaternion, Vector3, Vector3, Quaternion, Vector3)> result = null;
-
-            try
-            {
-                // Search all Animation components for one containing the specific animationName clip
-                Animation anim = null;
-                foreach (var candidate in tempClone.GetComponentsInChildren<Animation>(true))
-                {
-                    if (candidate[animationName] != null)
-                    {
-                        anim = candidate;
-                        break;
-                    }
-                }
-                // Fallback to any Animation on the clone
-                if (anim == null)
-                    anim = tempClone.GetComponentInChildren<Animation>(true);
-
-                if (anim == null)
-                {
-                    ParsekLog.Verbose("GhostVisual", $"  CargoBay '{key}': no Animation component on model clone");
-                    cargoBayCache[key] = null;
-                    return null;
-                }
-
-                AnimationState state = anim[animationName];
-                if (state == null)
-                {
-                    ParsekLog.Verbose("GhostVisual", $"  CargoBay '{key}': animation '{animationName}' not found on clone");
-                    cargoBayCache[key] = null;
-                    return null;
-                }
-
-                // Sample closed state (stowed)
-                state.enabled = true;
-                state.speed = 0f;
-                state.normalizedTime = closedTime;
-                state.weight = 1f;
-                anim.Play(animationName);
-                anim.Sample();
-
-                var allTransforms = tempClone.GetComponentsInChildren<Transform>(true);
-                var stowedStates = SnapshotTransformStates(allTransforms, tempClone.transform);
-
-                // Sample open state (deployed)
-                state.normalizedTime = openTime;
-                anim.Sample();
-
-                result = CollectTransformDeltas(allTransforms, tempClone.transform, stowedStates);
-
-                if (result.Count == 0)
-                {
-                    ParsekLog.Verbose("GhostVisual", $"  CargoBay '{key}': animation '{animationName}' produced no transform deltas");
-                    result = null;
-                }
-                else
-                {
-                    ParsekLog.Verbose("GhostVisual", $"  CargoBay '{key}': sampled {result.Count} animated transforms from '{animationName}'");
-                }
-            }
-            finally
-            {
-                Object.DestroyImmediate(tempClone);
-            }
-
-            cargoBayCache[key] = result;
+            var result = SampleAnimationStates(prefab, animationName, "CargoBay",
+                AnimLookup.ByClipSearch, null, closedTime, openTime, false);
+            animationSampleCache[key] = result;
             return result;
         }
 
-        /// <summary>
-        /// Sample stowed (time=0) and deployed (time=1) transform states from a deployable part's animation.
-        /// Returns a list of (path, stowed, deployed) tuples for transforms that actually change.
-        /// Returns null if the part has no animationName or no animation component.
-        /// </summary>
         private static List<(string path, Vector3 sPos, Quaternion sRot, Vector3 sScale,
             Vector3 dPos, Quaternion dRot, Vector3 dScale)> SampleDeployableStates(
             Part prefab, ModuleDeployablePart deployable)
         {
             string key = prefab.partInfo?.name ?? prefab.name;
-            if (deployableCache.TryGetValue(key, out var cached))
+            if (animationSampleCache.TryGetValue(key, out var cached))
                 return cached;
 
             string animName = deployable.animationName;
             if (string.IsNullOrEmpty(animName))
             {
                 ParsekLog.Verbose("GhostVisual", $"  Deployable '{key}': no animationName — skipping animation sampling");
-                deployableCache[key] = null;
+                animationSampleCache[key] = null;
                 return null;
             }
 
-            Transform modelRoot = FindModelRoot(prefab);
-            GameObject tempClone = Object.Instantiate(modelRoot.gameObject);
-
-            List<(string, Vector3, Quaternion, Vector3, Vector3, Quaternion, Vector3)> result = null;
-
-            try
-            {
-                Animation anim = tempClone.GetComponentInChildren<Animation>(true);
-                if (anim == null)
-                {
-                    ParsekLog.Verbose("GhostVisual", $"  Deployable '{key}': no Animation component on model clone");
-                    deployableCache[key] = null;
-                    return null;
-                }
-
-                AnimationState state = anim[animName];
-                if (state == null)
-                {
-                    ParsekLog.Verbose("GhostVisual", $"  Deployable '{key}': animation '{animName}' not found on clone");
-                    deployableCache[key] = null;
-                    return null;
-                }
-
-                // Sample stowed state (time=0)
-                state.enabled = true;
-                state.speed = 0f;
-                state.normalizedTime = 0f;
-                state.weight = 1f;
-                anim.Play(animName);
-                anim.Sample();
-
-                // Capture all child transforms at stowed
-                var allTransforms = tempClone.GetComponentsInChildren<Transform>(true);
-                var stowedStates = SnapshotTransformStates(allTransforms, tempClone.transform);
-
-                // Sample deployed state (time=1)
-                state.normalizedTime = 1f;
-                anim.Sample();
-
-                // Compare and collect transforms that differ
-                result = CollectTransformDeltas(allTransforms, tempClone.transform, stowedStates);
-
-                if (result.Count == 0)
-                {
-                    ParsekLog.Verbose("GhostVisual", $"  Deployable '{key}': animation '{animName}' produced no transform deltas");
-                    result = null;
-                }
-                else
-                {
-                    ParsekLog.Verbose("GhostVisual", $"  Deployable '{key}': sampled {result.Count} animated transforms from '{animName}'");
-                }
-            }
-            finally
-            {
-                Object.DestroyImmediate(tempClone);
-            }
-
-            deployableCache[key] = result;
+            var result = SampleAnimationStates(prefab, animName, "Deployable",
+                AnimLookup.Simple, null, 0f, 1f, false);
+            animationSampleCache[key] = result;
             return result;
         }
 

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -1299,6 +1299,9 @@ namespace Parsek
         /// transform deltas between stowed and deployed states.
         /// Returns null if no animation found, no AnimationState, or no deltas produced.
         /// Does NOT handle caching — callers manage their own cache read/write.
+        /// When <paramref name="useScoring"/> is true, <paramref name="stowedTime"/> and
+        /// <paramref name="deployedTime"/> are ignored — endpoints are determined by scoring
+        /// both animation endpoints against the prefab's default transform state.
         /// </summary>
         private static List<(string path, Vector3 sPos, Quaternion sRot, Vector3 sScale,
             Vector3 dPos, Quaternion dRot, Vector3 dScale)> SampleAnimationStates(

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -4682,6 +4682,25 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Shared tail for boundary splits: stops recording, commits the segment,
+        /// restarts recording and restores undock continuation PID.
+        /// </summary>
+        private void CommitBoundaryAndRestart(string phase, string bodyName,
+            string logMessage, string screenMessage)
+        {
+            recorder.StopRecordingForChainBoundary();
+            CommitBoundarySplit(phase, bodyName);
+            recorder = null;
+            StartRecording();
+            if (IsRecording)
+            {
+                recorder.UndockSiblingPid = undockContinuationPid;
+                ParsekLog.Info("Flight", logMessage);
+                ParsekLog.ScreenMessage(screenMessage, 2f);
+            }
+        }
+
+        /// <summary>
         /// Handles atmosphere boundary auto-split when crossing the atmosphere edge.
         /// Commits the current segment, restarts recording in the new phase.
         /// </summary>
@@ -4709,17 +4728,10 @@ namespace Parsek
             string bodyName = FlightGlobals.ActiveVessel?.mainBody?.name ?? "Unknown";
             ParsekLog.Info("Flight", $"Atmosphere auto-split triggered: {bodyName} {phase}\u2192{newPhase} " +
                 $"(chain={activeChainId ?? "(new)"}, points={recorder.Recording.Count})");
-            recorder.StopRecordingForChainBoundary();
-            CommitBoundarySplit(phase, bodyName);
-            recorder = null;
-            StartRecording();
-            if (IsRecording)
-            {
-                recorder.UndockSiblingPid = undockContinuationPid;
-                ParsekLog.Info("Flight", $"Recording continues after atmosphere boundary " +
-                    $"(chain={activeChainId}, idx={activeChainNextIndex}, {bodyName} {phase}\u2192{newPhase})");
-                ParsekLog.ScreenMessage($"Recording continues ({(newPhase == "atmo" ? "entering" : "exiting")} atmosphere)", 2f);
-            }
+            CommitBoundaryAndRestart(phase, bodyName,
+                $"Recording continues after atmosphere boundary " +
+                    $"(chain={activeChainId}, idx={activeChainNextIndex}, {bodyName} {phase}\u2192{newPhase})",
+                $"Recording continues ({(newPhase == "atmo" ? "entering" : "exiting")} atmosphere)");
         }
 
         /// <summary>
@@ -4752,17 +4764,10 @@ namespace Parsek
             string fromPhase = (fromCB != null && fromCB.atmosphere) ? "exo" : "space";
             ParsekLog.Info("Flight", $"SOI auto-split triggered: {fromBody} ({fromPhase}) \u2192 {toBody} " +
                 $"(chain={activeChainId ?? "(new)"}, points={recorder.Recording.Count})");
-            recorder.StopRecordingForChainBoundary();
-            CommitBoundarySplit(fromPhase, fromBody);
-            recorder = null;
-            StartRecording();
-            if (IsRecording)
-            {
-                recorder.UndockSiblingPid = undockContinuationPid;
-                ParsekLog.Info("Flight", $"Recording continues after SOI change " +
-                    $"({fromBody} \u2192 {toBody}, chain={activeChainId}, idx={activeChainNextIndex})");
-                ParsekLog.ScreenMessage($"Recording continues (entering {toBody} SOI)", 2f);
-            }
+            CommitBoundaryAndRestart(fromPhase, fromBody,
+                $"Recording continues after SOI change " +
+                    $"({fromBody} \u2192 {toBody}, chain={activeChainId}, idx={activeChainNextIndex})",
+                $"Recording continues (entering {toBody} SOI)");
         }
 
         /// <summary>

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -757,11 +757,8 @@ namespace Parsek
             StopPlayback();
             DestroyAllTimelineGhosts();
             GhostVisualBuilder.ClearCanopyCache();
-            GhostVisualBuilder.ClearDeployableCache();
+            GhostVisualBuilder.ClearAnimationSampleCache();
             GhostVisualBuilder.ClearFxPrefabCache();
-            GhostVisualBuilder.ClearGearCache();
-            GhostVisualBuilder.ClearLadderCache();
-            GhostVisualBuilder.ClearCargoBayCache();
             GhostVisualBuilder.ClearAnimateHeatCache();
         }
 

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -48,6 +48,10 @@ namespace Parsek
         internal int lastPlaybackIndex = 0;
 
         private Dictionary<int, GhostPlaybackState> ghostStates = new Dictionary<int, GhostPlaybackState>();
+
+        // Cached TimelineGhosts dictionary — rebuilt once per frame on first access
+        private Dictionary<int, GameObject> cachedTimelineGhosts = new Dictionary<int, GameObject>();
+        private int cachedTimelineGhostsFrame = -1;
         private readonly MaterialPropertyBlock reentryShellMpb = new MaterialPropertyBlock();
         private readonly List<GameObject> activeExplosions = new List<GameObject>();
 
@@ -307,10 +311,17 @@ namespace Parsek
         {
             get
             {
-                var result = new Dictionary<int, GameObject>();
-                foreach (var kv in ghostStates)
-                    result[kv.Key] = kv.Value.ghost;
-                return result;
+                int currentFrame = Time.frameCount;
+                if (cachedTimelineGhostsFrame != currentFrame)
+                {
+                    cachedTimelineGhosts.Clear();
+                    foreach (var kv in ghostStates)
+                        cachedTimelineGhosts[kv.Key] = kv.Value.ghost;
+                    cachedTimelineGhostsFrame = currentFrame;
+                    ParsekLog.Verbose("Flight",
+                        $"TimelineGhosts: rebuilt cache, {cachedTimelineGhosts.Count} ghosts (frame {currentFrame})");
+                }
+                return cachedTimelineGhosts;
             }
         }
         public bool HasActiveChain => activeChainId != null;

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -179,6 +179,11 @@ namespace Parsek
         private SpawnSortColumn cachedSortColumn = SpawnSortColumn.Distance;
         private bool cachedSortAscending = true;
 
+        // Per-frame cached resource budget — avoids duplicate ComputeTotal calls
+        // when both DrawCompactBudgetLine (main window) and DrawResourceBudget (actions window) run
+        private BudgetSummary cachedBudget;
+        private int cachedBudgetFrame = -1;
+
         public ParsekUI(ParsekFlight flight)
         {
             this.flight = flight;
@@ -193,6 +198,26 @@ namespace Parsek
 
         private const float SpacingSmall = 3f;
         private const float SpacingLarge = 10f;
+
+        /// <summary>
+        /// Returns the resource budget, cached once per frame. Avoids duplicate
+        /// ComputeTotal calls when both the main window and actions window render.
+        /// </summary>
+        private BudgetSummary GetCachedBudget()
+        {
+            int currentFrame = Time.frameCount;
+            if (cachedBudgetFrame != currentFrame)
+            {
+                cachedBudget = ResourceBudget.ComputeTotal(
+                    RecordingStore.CommittedRecordings,
+                    MilestoneStore.Milestones,
+                    RecordingStore.CommittedTrees);
+                cachedBudgetFrame = currentFrame;
+                ParsekLog.Verbose("UI",
+                    $"GetCachedBudget: recomputed budget (frame {currentFrame})");
+            }
+            return cachedBudget;
+        }
 
         public void DrawWindow(int windowID)
         {
@@ -352,10 +377,7 @@ namespace Parsek
 
         private void DrawResourceBudget()
         {
-            var budget = ResourceBudget.ComputeTotal(
-                RecordingStore.CommittedRecordings,
-                MilestoneStore.Milestones,
-                RecordingStore.CommittedTrees);
+            var budget = GetCachedBudget();
 
             if (budget.reservedFunds <= 0 && budget.reservedScience <= 0 && budget.reservedReputation <= 0)
                 return;
@@ -420,10 +442,7 @@ namespace Parsek
 
         private void DrawCompactBudgetLine()
         {
-            var budget = ResourceBudget.ComputeTotal(
-                RecordingStore.CommittedRecordings,
-                MilestoneStore.Milestones,
-                RecordingStore.CommittedTrees);
+            var budget = GetCachedBudget();
 
             if (budget.reservedFunds <= 0 && budget.reservedScience <= 0 && budget.reservedReputation <= 0)
                 return;

--- a/docs/dev/plans/refactor-2-deferred.md
+++ b/docs/dev/plans/refactor-2-deferred.md
@@ -76,7 +76,7 @@ The shared core would need 3-4 parameters/flags to account for these differences
 
 **What:** Same structure (guard → tree suppress → non-tree commit+restart), differ in phase-name derivation and ScreenMessage text.
 
-**Why deferred:** Each is only 36-38 lines. The differences (phase derivation, screen message, which recorder flag is checked) would require 3 parameters that make the shared method harder to read than the two explicit copies. Net savings would be ~15 lines.
+**Status:** **DONE** — extracted `CommitBoundaryAndRestart(phase, bodyName, logMessage, screenMessage)` shared tail. Guards, tree-mode suppression, and phase computation stay in each method.
 
 ---
 
@@ -198,7 +198,7 @@ All three violate zero-logic-changes constraint.
 
 ### C1. SanitizeQuaternion instance wrapper removal
 **What:** ParsekFlight has a 3-line instance method `SanitizeQuaternion(Quaternion q)` that just forwards to `TrajectoryMath.SanitizeQuaternion(q)`. ParsekKSC correctly calls TrajectoryMath directly. 4 call sites in ParsekFlight.
-**Action:** Replace 4 call sites with `TrajectoryMath.SanitizeQuaternion(q)`, delete the wrapper.
+**Status:** **DONE** — wrapper was already removed during refactor-2. All call sites already use `TrajectoryMath.SanitizeQuaternion` directly.
 
 ### C2. Namespace consistency verification
 **Action:** Verify all files use `namespace Parsek` (or `namespace Parsek.Patches`). Verify new files (EngineFxBuilder.cs, MaterialCleanup.cs) match.
@@ -221,7 +221,7 @@ All three violate zero-logic-changes constraint.
 | D4 | ParsekFlight+ParsekKSC | ~60 | Low | **DONE** (Phase 3A Split 4: shared positioning) |
 | D5 | ParsekFlight | ~80 | Medium | Open — needs D20 first |
 | D6 | ParsekFlight | ~15 | N/A | Closed — below 5-line min |
-| D7 | ParsekFlight | ~75 | Low | Open |
+| D7 | ParsekFlight | ~75 | Low | **DONE** (CommitBoundaryAndRestart shared tail) |
 | D8 | ParsekFlight | ~500 | High | Open — needs D20 first |
 | D9 | ParsekFlight | ~194 | Low | Closed — minimal gain |
 | D10 | ParsekFlight | ~60 | Medium | Closed — API divergence |

--- a/docs/dev/plans/refactor-2-deferred.md
+++ b/docs/dev/plans/refactor-2-deferred.md
@@ -138,9 +138,7 @@ The shared core would need 3-4 parameters/flags to account for these differences
 
 **What:** 4 methods share ~80% structure but differ in: animation lookup strategy, stowed/deployed endpoint logic, cache keys, and (for heat) sample point count. ~300 lines savings possible but risky.
 
-**Why deferred:** Differences in animation lookup, endpoint logic, cache keys, and sample point count prevent clean parameterization without introducing fragile conditionals.
-
-**Revisit when:** Pass 3 candidate.
+**Status:** **DONE** (PR #82). Extracted `SampleAnimationStates` core method with `AnimLookup` enum + `FindAnimation` resolver. Consolidated 4 caches into 1 `animationSampleCache`. Ladder scoring via `useScoring` flag. Net -139 lines.
 
 ### D16. GhostVisualBuilder particle builder dedup
 
@@ -231,7 +229,7 @@ All three violate zero-logic-changes constraint.
 | D12 | GhostPlaybackLogic | ~110 | Medium | Closed — ~47% similarity not worth it |
 | D13 | GhostVisualBuilder | ~565 | High | **DONE** (Phase 3B Split 10: EngineFxBuilder) |
 | D14 | GhostVisualBuilder | ~80 | Medium | Closed — interleaved state |
-| D15 | GhostVisualBuilder | ~300 | Medium | Open — SampleXxxStates unification |
+| D15 | GhostVisualBuilder | ~300 | Medium | **DONE** (PR #82: SampleAnimationStates + AnimLookup) |
 | D16 | GhostVisualBuilder | ~300 | Medium | Closed — too many numeric params |
 | D17 | GhostVisualBuilder | ~30 | Low | Closed — guard param |
 | D18 | ParsekUI | ~125 | Medium | Open |

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1544,6 +1544,56 @@ Root cause likely in `StripOrphanedSpawnedVessels` or `PreProcessRewindSave` —
 
 **Status:** Open
 
+## 130. CleanupOrphanedSpawnedVessels destroys freshly-spawned past vessel on first flight after rewind
+
+After rewind to UT ~99.8, entering flight at UT ~111. The Aeris 4A recording (UT 53–78, **before** the rewind point) correctly spawns a LANDED vessel on frame 1 (`VesselSpawned=true`). Half a second later, `CleanupOrphanedSpawnedVessels` runs during `OnFlightReady` and **destroys** the just-spawned vessel because "Aeris 4A" matches the cleanup names list. The vessel-gone check resets `VesselSpawned=false` (spawnDeathCount 1/3), the re-spawn attempt is collision-blocked by Crater Crawler at 14m for 150 frames, and eventually abandoned.
+
+**Root cause:** The rewind path populates `PendingCleanupNames` with ALL recording vessel names (11 names) via `CollectAllRecordingVesselNames()`. This makes sense for stripping future vessels from the save, but `CleanupOrphanedSpawnedVessels` at `OnFlightReady` also uses these same names. By then, past-recording vessels have already been correctly spawned by `UpdateTimelinePlayback`, and the cleanup destroys them.
+
+Different from #109 (missing cleanup on second rewind) — here cleanup runs but is over-aggressive on the first flight. Different from #112 (self-overlap) — here the vessel is destroyed by cleanup, not blocked by its own copy.
+
+**Fix:** `CleanupOrphanedSpawnedVessels` should exclude vessels that were just spawned by Parsek in the current frame/scene (check `VesselSpawned=true` or `SpawnedVesselPersistentId` against loaded vessels). Or: clear `PendingCleanupNames` after `StripOrphanedSpawnedVessels` runs in OnLoad so the cleanup doesn't re-fire at OnFlightReady.
+
+**Priority:** High — destroys correctly-spawned vessels after rewind
+
+**Status:** Open
+
+## 131. ShouldSpawnAtRecordingEnd VERBOSE log spam — 377K lines/session
+
+`GhostPlaybackLogic.ShouldSpawnAtRecordingEnd` logs a VERBOSE line for every suppressed recording on every call. Called from `UpdateTimelinePlayback()` → `Update()` per-recording per-frame. With 37 recordings and 60fps, this produces ~2,200 lines/second. In the analyzed session: 377,350 lines — 73% of all Parsek log output and the single largest spam source.
+
+Different from #117 (CanRewind/CanFastForward UI spam, now fixed) and #121 (Ghost SKIPPED during collision-blocked spawn).
+
+**Fix:** Remove all VERBOSE logs from `ShouldSpawnAtRecordingEnd`. Like CanRewind/CanFastForward (#117), this is a per-frame read-only check where the `reason` out-parameter already conveys the suppression reason to the caller.
+
+**Priority:** High — blocks effective log analysis
+
+**Status:** Open
+
+## 132. ParsePartPositions: 0/N parts parsed from vessel snapshot
+
+`SpawnCollisionDetector.ParsePartPositions` parsed 0 of 40 parts from the Aeris 4A vessel snapshot, falling back to a 2m bounds estimate. This makes the collision check unreliable — the actual vessel footprint is much larger than 2m but the detector can't compute it.
+
+Different from #127 (wrong position source for collision check, now fixed). This is about the part position parser itself failing to extract coordinates from snapshot PART nodes.
+
+**Fix:** Investigate why `ParsePartPositions` fails on the Aeris 4A snapshot. Likely the PART nodes use a different position format or key name than expected. Add a VERBOSE diagnostic log showing what keys/values the parser found vs expected.
+
+**Priority:** Low — fallback bounds work but are inaccurate
+
+**Status:** Open
+
+## 133. Crew status corruption: reserved kerbals become Missing after post-rewind EVA vessel removal
+
+After rewind, `OnFlightReady` removes reserved EVA vessels (Bob Kerman pid=2373555091, Halemy Kerman pid=2924298993). KSP's removal sets their status from Assigned to Missing. The crew rescue logic (`Rescued Missing crew → Available`) runs earlier during OnLoad but not after OnFlightReady, so these kerbals stay Missing for the rest of the session until the next save/load cycle.
+
+Log evidence: `CrewStatusChanged 'Bob Kerman' Assigned → Missing` at UT 115.6, and `CrewStatusChanged 'Halemy Kerman' Assigned → Missing` at UT 115.6. Similar to #116 (Valentina lost to Missing) but triggered by EVA vessel removal rather than vessel strip.
+
+**Fix:** Run crew status rescue after `OnFlightReady` EVA vessel removal, not just during OnLoad. Or: prevent EVA vessels for reserved crew from existing in the save in the first place.
+
+**Priority:** Medium — crew becomes unavailable until next load
+
+**Status:** Open
+
 # In-Game Tests
 
 - [ ] Vessels propagate naturally along orbits after FF (no position freezing)

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -75,7 +75,7 @@ Engine and RCS particle systems are instantiated per ghost. Pooling would reduce
 
 ### T10. RealVesselExists O(n) per frame (bug #49)
 
-`GhostPlaybackLogic.RealVesselExists` scans `FlightGlobals.Vessels` linearly. A HashSet lookup by PID would be O(1).
+`GhostPlaybackLogic.RealVesselExists` scans `FlightGlobals.Vessels` linearly. A HashSet lookup by PID would be O(1). Attempted frame-cached HashSet but `Time.frameCount` (Unity native) crashes in test environment. Needs a non-Unity cache invalidation approach (e.g., manual invalidation from the playback update loop).
 
 **Priority:** Low — only matters with many committed recordings
 
@@ -143,23 +143,17 @@ Redesign milestone capture, resource budgeting, and action replay validated per 
 
 **Priority:** Low — test infrastructure
 
-### T19. FlightRecorder per-frame List<PartEvent> allocations
+### ~~T19. FlightRecorder per-frame List&lt;PartEvent&gt; allocations~~ DONE
 
-`CheckLightBlinkTransition`, `CheckEngineTransition`, `CheckRcsTransition`, and `ProcessRcsDebounce` allocate `new List<PartEvent>()` every physics frame for every cached module. At 50Hz with e.g. 10 engines, that's 500 allocations/second producing zero events most of the time. Should use a caller-owned reusable list or return `PartEvent?` for the common single-event case.
+Methods now append to a caller-owned reusable buffer instead of allocating per call.
 
-**Priority:** Medium — GC pressure during recording
+### ~~T20. ParsekFlight.TimelineGhosts allocates new Dictionary on every access~~ DONE
 
-### T20. ParsekFlight.TimelineGhosts allocates new Dictionary on every access
+Cached per-frame via `Time.frameCount`.
 
-The `TimelineGhosts` property creates `new Dictionary<int, GameObject>()` every call. If accessed per-frame from UI code, generates garbage. Should cache or return a read-only view.
+### ~~T21. ParsekUI double ComputeTotal calls~~ DONE
 
-**Priority:** Low — UI-path only
-
-### T21. ParsekUI double ComputeTotal calls
-
-Both `DrawResourceBudget` and `DrawCompactBudgetLine` call `ResourceBudget.ComputeTotal(...)` independently. If both are drawn in the same OnGUI frame, budget is computed twice. Should compute once and pass the result.
-
-**Priority:** Low — minor perf
+Cached per-frame via `GetCachedBudget()` helper.
 
 ### ~~T22. GhostSoftCapManager.EvaluateCaps not tested when Enabled=false~~ DONE
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -197,11 +197,9 @@ Extract chain state + 4 commit methods (~400-500 lines) into a `ChainSegmentMana
 
 **Priority:** Medium — depends on T25 or parallel state isolation work
 
-### T27. GhostVisualBuilder SampleXxxStates unification (D15)
+### ~~T27. GhostVisualBuilder SampleXxxStates unification (D15)~~ DONE (PR #82)
 
-Unify 4 animation sampling methods (`SampleDeployableStates`, `SampleGearStates`, `SampleLadderStates`, `SampleCargoBayStates`) that share ~80% structure. ~300 lines savings. Blocked by differences in animation lookup strategy, stowed/deployed endpoint logic, cache keys, and sample point count.
-
-**Priority:** Low — methods work correctly, just repetitive
+Extracted `SampleAnimationStates` core method with `AnimLookup` enum + `FindAnimation` resolver. 4 methods reduced to thin wrappers, 4 caches consolidated into 1 `animationSampleCache`. Net -139 lines.
 
 ### T28. ParsekFlight commit-pattern dedup (D2)
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -161,23 +161,17 @@ Both `DrawResourceBudget` and `DrawCompactBudgetLine` call `ResourceBudget.Compu
 
 **Priority:** Low — minor perf
 
-### T22. GhostSoftCapManager.EvaluateCaps not tested when Enabled=false
+### ~~T22. GhostSoftCapManager.EvaluateCaps not tested when Enabled=false~~ DONE
 
-No test verifies that `EvaluateCaps` returns empty actions when `Enabled = false`. This is the critical production toggle — if the guard were removed, no test would catch it.
+Added `EvaluateCaps_Disabled_ReturnsEmpty_EvenAboveAllThresholds` test.
 
-**Priority:** Low — test gap
+### ~~T23. SessionMerger frame trimming not tested~~ DONE
 
-### T23. SessionMerger frame trimming not tested
+Added `ResolveOverlaps_FramesTrimmedToResultBoundaries` test with multi-frame sections.
 
-Tests assert `startUT`/`endUT`/`source` after `ResolveOverlaps` but never check that the `frames` lists were actually trimmed. `TrimFrames` could be broken and tests would still pass.
+### ~~T24. EnvironmentDetector untested for ORBITING and ESCAPING situations~~ DONE
 
-**Priority:** Low — test gap
-
-### T24. EnvironmentDetector untested for ORBITING and ESCAPING situations
-
-Tests only cover LANDED(1), SPLASHED(2), PRELAUNCH(4), FLYING(8), SUB_ORBITAL(16). The ORBITING(32) and ESCAPING(64) situations are untested. They fall through to the altitude/thrust check, which is likely correct but should be verified.
-
-**Priority:** Low — test gap
+Added 5 tests covering ORBITING(32) and ESCAPING(64) with thrust/no-thrust and airless body variants.
 
 ---
 


### PR DESCRIPTION
## Summary
- **D15/T27**: Extract shared `SampleAnimationStates` core from 4 animation sampling methods, `AnimLookup` enum + `FindAnimation` resolver, consolidate 4 caches into 1 (-139 lines)
- **D7**: Extract `CommitBoundaryAndRestart` shared tail from atmosphere/SOI split handlers
- **T19**: Eliminate per-frame `List<PartEvent>` allocations — 4 transition-check methods now append to reusable buffer
- **T20**: Cache `TimelineGhosts` dictionary per-frame instead of allocating on every property access
- **T21**: Cache `ResourceBudget.ComputeTotal` per-frame, shared across both draw methods
- **T22/T23/T24**: Fill 3 test gaps (+7 tests: soft cap disabled guard, frame trimming, ORBITING/ESCAPING situations)
- **C1**: Already done (discovered during investigation)
- **C2/C3**: Namespace consistency and one-class-per-file audits — all clean
- **Bugs #130-133**: Log analysis from rewind test session — cleanup destroys freshly-spawned past vessel, ShouldSpawnAtRecordingEnd VERBOSE spam (377K lines), ParsePartPositions snapshot parsing failure, crew Missing after EVA vessel removal

## Test plan
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 3322/3322 pass (was 3315)
- [x] In-game: verified log spam reduced from 515K to 2.4K Parsek lines (99.5% reduction)
- [x] In-game: verify ghost deploy/retract animations, atmosphere/SOI boundary splits, engine/RCS recording