### PR TITLE
Log spam audit: fix tags, downgrade levels, remove per-renderer noise

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -70,12 +70,13 @@ Alt+F12 opens Unity debug console in-game.
 
 Every action, state transition, guard condition skip, and FX lifecycle event MUST be logged. The KSP.log is our primary debugging tool — if it didn't get logged, it didn't happen.
 
-- Use `ParsekLog.Log` / `ParsekLog.Info` / `ParsekLog.Warn` for important events
-- Use `ParsekLog.Verbose` for high-frequency or detailed diagnostic info
-- Use `ParsekLog.VerboseRateLimited` for per-frame data (avoids log spam)
+- Use `ParsekLog.Info` / `ParsekLog.Warn` for important events
+- Use `ParsekLog.Verbose` for detailed diagnostic info (one-shot operations)
+- Use `ParsekLog.VerboseRateLimited` for per-frame or per-ghost-per-cycle data (avoids log spam). Use shared keys for aggregate summaries, per-index keys only when the index identity matters for debugging.
 - Include subsystem tag, relevant IDs (recording index, vessel name, part PID), and numeric values
 - Log format: `[Parsek][LEVEL][Subsystem] message` (handled by ParsekLog.Write)
-- See existing patterns in `ParsekFlight.cs` (ghost lifecycle) and `GhostVisualBuilder.cs` (FX build chain) for reference
+- **Batch counting convention:** When iterating over collections with per-item decisions (skip/process), declare local `int` counters, increment inside the loop, and log a single summary after the loop. Use `Verbose` for one-shot operations (load/save), `VerboseRateLimited` for per-frame summaries. Do not log per-item inside the loop unless the item count is bounded (under ~20).
+- See existing patterns in `GhostPlaybackEngine.cs` (frame batch counters) and `ParsekScenario.cs` (save/load batch summaries) for reference
 
 ## Testing Requirements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to Parsek are documented here.
 
 ---
 
+## 0.5.3
+
+Log spam audit and cleanup. Analyzed a 28,923-line KSP.log from a 70-second KSC session with 273 recordings — Parsek was 68.4% of all output (19,771 lines). Identified and fixed the top spam sources.
+
+### Log Cleanup
+
+- **Removed `ParsekLog.Log()` method** — all 26 call sites (16 in EngineFxBuilder, 10 in GhostVisualBuilder) were using the subsystem-less `Log()` wrapper, producing 2,651 lines tagged as `[General]` (55% of all INFO output). Migrated to proper `Verbose("EngineFx")` / `Verbose("GhostVisual")` / `Info("GhostVisual")`. Deleted the method to prevent future untagged usage.
+- **ReentryFx INFO→VERBOSE** — mesh combination and fire shell overlay messages fired per ghost build at INFO level (2,148 lines in 70s). Downgraded to Verbose.
+- **KSC per-ghost spawn/destroy INFO→VERBOSE** — per-ghost spawn, enter-range, re-show, warp-hide, and no-longer-eligible messages at INFO level (1,347 lines). Downgraded to Verbose. Added batch summary in OnDestroy (`Destroyed N primary + N overlap KSC ghosts`).
+- **FlightRecorder point logging rate-limited** — `Recorded point #N` logged every 10th physics frame at Verbose without rate limiting (~50 lines/sec during recording). Changed to `VerboseRateLimited` with 5s interval.
+- **Mass ghost teardown batched** — KSC `DestroyKscGhost` per-ghost log (277 consecutive in one burst) changed to `VerboseRateLimited`. Overlap ghost destroy in `GhostPlaybackEngine` similarly rate-limited.
+- **Per-renderer VERBOSE diagnostics removed** — individual MR[N]/SMR[N] per-renderer logs (1,041+ lines), per-renderer damaged-wheel skip logs, and per-SMR bone fallback logs removed. Per-part summary already captures the same counts.
+- **Subsystem tag consolidation** — `Store`→`RecordingStore` (1 occurrence), `GhostBuild`→`GhostVisual` (5 occurrences). Reduces tag count from 63 to 61.
+
+### Documentation
+
+- Log audit report: `docs/dev/log-audit-2026-03-25.md`
+
+---
+
 ## 0.5.2
 
 Second-pass structural refactoring + game action system modularization + continued decomposition. ~80 method extractions, ~105 logging additions, 103 new tests. 1 latent bug fixed, 1 latent IMGUI bugfix. Zero logic changes (except bug fixes).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,14 @@ Log spam audit and cleanup. Analyzed a 28,923-line KSP.log from a 70-second KSC 
 - **4 batch summaries added** — standalone save/load and tree save/load now log one summary each with aggregate counters (points, orbit segments, part events, track sections, snapshots).
 - **DeserializeSegmentEvents** — changed from always-log to Warn-only when events are skipped.
 
+### Round 4 — Remaining Spam Sources
+
+- **SpawnWarning FormatChainStatus** — Verbose → VerboseRateLimited shared key. Per-frame poll logging identical status (1,165 lines, 802-line burst).
+- **Zone transition per-ghost** — Info → VerboseRateLimited shared key. 248-ghost bursts at scene switch collapsed to 1 line.
+- **Scenario per-recording index dump** — Info → Verbose. Summary header stays at Info; per-recording detail demoted.
+- **Per-recording "Loaded recording:"** — ScenarioLog (Info) → Verbose. Batch summary covers aggregates.
+- **"Triggering explosion"** — Info → VerboseRateLimited per-index 10s. Looping overlap re-explosions deduplicated.
+
 ### Documentation
 
 - Log audit report: `docs/dev/log-audit-2026-03-25.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,28 @@ Log spam audit and cleanup. Analyzed a 28,923-line KSP.log from a 70-second KSC 
 - **Per-renderer VERBOSE diagnostics removed** — individual MR[N]/SMR[N] per-renderer logs (1,041+ lines), per-renderer damaged-wheel skip logs, and per-SMR bone fallback logs removed. Per-part summary already captures the same counts.
 - **Subsystem tag consolidation** — `Store`→`RecordingStore` (1 occurrence), `GhostBuild`→`GhostVisual` (5 occurrences). Reduces tag count from 63 to 61.
 
+### Round 2 — Ghost Lifecycle Batch Logging
+
+- **Frame batch summary** — replaced per-ghost spawn/destroy/build Verbose logs (15,489 Engine lines) with per-frame counters and one `VerboseRateLimited` summary: `Frame: spawned=N destroyed=N active=N`.
+- **DestroyGhost reason parameter** — all 7+ call sites now pass a reason string (`"cycle transition"`, `"soft cap despawn"`, `"anchor unloaded"`, etc.). Per-ghost destroy log restored at 1s rate limit with full context.
+- **SpawnGhost per-ghost log restored** — 1s rate-limited per-index key with build type (snapshot/sphere), part/engine/rcs counts.
+- **ShouldTriggerExplosion skip logs removed** — 1,959 lines/session of pure predicate noise (caller already knows the result).
+- **CrewReservation null snapshot log removed** — 515 lines of expected-path noise.
+- **ReentryFx → shared rate-limit keys** — mesh combination messages now dedup across all ghosts (was per-ghost-index).
+- **Overlap/explosion lifecycle → shared VRL keys** — overlap move, overlap expired, explosion created, parts hidden, loop restarted, overlap expired all changed from per-index to shared keys.
+- **Zone rendering Info→VRL** — per-ghost zone transition messages downgraded from Info to VerboseRateLimited (1,008 lines).
+- **Bug #135 cleanup** — fixed 12 garbled comments in ShouldSpawnAtRecordingEnd left from prior partial edit.
+
+### Round 3 — Serialization Batch Summaries
+
+- **Per-recording serialization logs removed** — 12 Verbose logs in RecordingStore (orbit segments, track sections, segment events, file summaries) and 2 per-recording metadata logs in ParsekScenario removed. These produced ~2,900 lines per save/load cycle.
+- **4 batch summaries added** — standalone save/load and tree save/load now log one summary each with aggregate counters (points, orbit segments, part events, track sections, snapshots).
+- **DeserializeSegmentEvents** — changed from always-log to Warn-only when events are skipped.
+
 ### Documentation
 
 - Log audit report: `docs/dev/log-audit-2026-03-25.md`
+- CLAUDE.md: added batch counting convention to Logging Requirements, removed obsolete `ParsekLog.Log` reference
 
 ---
 

--- a/Source/Parsek.Tests/ExplosionFxTests.cs
+++ b/Source/Parsek.Tests/ExplosionFxTests.cs
@@ -45,7 +45,7 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void ShouldTriggerExplosion_AlreadyFired_ReturnsFalseAndLogs()
+        public void ShouldTriggerExplosion_AlreadyFired_ReturnsFalse()
         {
             bool result = GhostPlaybackLogic.ShouldTriggerExplosion(
                 explosionAlreadyFired: true,
@@ -55,12 +55,10 @@ namespace Parsek.Tests
                 recIdx: 5);
 
             Assert.False(result);
-            Assert.Contains(logLines, l =>
-                l.Contains("[ExplosionFx]") && l.Contains("already fired") && l.Contains("#5"));
         }
 
         [Fact]
-        public void ShouldTriggerExplosion_NotDestroyed_Landed_ReturnsFalseAndLogs()
+        public void ShouldTriggerExplosion_NotDestroyed_Landed_ReturnsFalse()
         {
             bool result = GhostPlaybackLogic.ShouldTriggerExplosion(
                 explosionAlreadyFired: false,
@@ -70,12 +68,10 @@ namespace Parsek.Tests
                 recIdx: 1);
 
             Assert.False(result);
-            Assert.Contains(logLines, l =>
-                l.Contains("[ExplosionFx]") && l.Contains("terminalState=Landed") && l.Contains("not Destroyed"));
         }
 
         [Fact]
-        public void ShouldTriggerExplosion_NullTerminalState_ReturnsFalseAndLogs()
+        public void ShouldTriggerExplosion_NullTerminalState_ReturnsFalse()
         {
             bool result = GhostPlaybackLogic.ShouldTriggerExplosion(
                 explosionAlreadyFired: false,
@@ -85,8 +81,6 @@ namespace Parsek.Tests
                 recIdx: 0);
 
             Assert.False(result);
-            Assert.Contains(logLines, l =>
-                l.Contains("[ExplosionFx]") && l.Contains("terminalState=null") && l.Contains("not Destroyed"));
         }
 
         [Fact]
@@ -119,8 +113,6 @@ namespace Parsek.Tests
                 recIdx: 0);
 
             Assert.False(result);
-            Assert.Contains(logLines, l =>
-                l.Contains("[ExplosionFx]") && l.Contains("not Destroyed"));
         }
 
         // --- Guard evaluation order: already-fired checked before terminal state ---
@@ -129,76 +121,14 @@ namespace Parsek.Tests
         public void ShouldTriggerExplosion_AlreadyFired_SkipsBeforeCheckingTerminalState()
         {
             // Even with Destroyed state, already-fired should be checked first
-            GhostPlaybackLogic.ShouldTriggerExplosion(
+            bool result = GhostPlaybackLogic.ShouldTriggerExplosion(
                 explosionAlreadyFired: true,
                 terminalState: TerminalState.Destroyed,
                 ghostExists: true,
                 vesselName: "V",
                 recIdx: 0);
 
-            Assert.Contains(logLines, l => l.Contains("already fired"));
-            Assert.DoesNotContain(logLines, l => l.Contains("will fire"));
-        }
-
-        // --- Rate-limited logging: first call emits, repeated calls are suppressed ---
-
-        [Fact]
-        public void ShouldTriggerExplosion_AlreadyFired_FirstCallEmits_SubsequentSuppressed()
-        {
-            ParsekLog.VerboseOverrideForTesting = true;
-            ParsekLog.ResetRateLimitsForTesting();
-            double now = 5000.0;
-            ParsekLog.ClockOverrideForTesting = () => now;
-
-            // First call: should emit
-            GhostPlaybackLogic.ShouldTriggerExplosion(true, TerminalState.Destroyed, true, "V", 2);
-            Assert.Single(logLines, l => l.Contains("already fired") && l.Contains("#2"));
-
-            // Repeated calls within rate-limit window: suppressed
-            now += 0.1;
-            GhostPlaybackLogic.ShouldTriggerExplosion(true, TerminalState.Destroyed, true, "V", 2);
-            now += 0.1;
-            GhostPlaybackLogic.ShouldTriggerExplosion(true, TerminalState.Destroyed, true, "V", 2);
-
-            // Still only one log line for this key
-            Assert.Single(logLines, l => l.Contains("already fired") && l.Contains("#2"));
-        }
-
-        [Fact]
-        public void ShouldTriggerExplosion_NotDestroyed_FirstCallEmits_SubsequentSuppressed()
-        {
-            ParsekLog.VerboseOverrideForTesting = true;
-            ParsekLog.ResetRateLimitsForTesting();
-            double now = 5000.0;
-            ParsekLog.ClockOverrideForTesting = () => now;
-
-            // First call: should emit
-            GhostPlaybackLogic.ShouldTriggerExplosion(false, TerminalState.Recovered, true, "V", 4);
-            Assert.Single(logLines, l => l.Contains("not Destroyed") && l.Contains("#4"));
-
-            // Repeated calls within rate-limit window: suppressed
-            now += 0.1;
-            GhostPlaybackLogic.ShouldTriggerExplosion(false, TerminalState.Recovered, true, "V", 4);
-            now += 0.1;
-            GhostPlaybackLogic.ShouldTriggerExplosion(false, TerminalState.Recovered, true, "V", 4);
-
-            Assert.Single(logLines, l => l.Contains("not Destroyed") && l.Contains("#4"));
-        }
-
-        [Fact]
-        public void ShouldTriggerExplosion_DifferentGhostIndices_IndependentRateLimitKeys()
-        {
-            ParsekLog.VerboseOverrideForTesting = true;
-            ParsekLog.ResetRateLimitsForTesting();
-            double now = 5000.0;
-            ParsekLog.ClockOverrideForTesting = () => now;
-
-            // Two different ghost indices should each emit on first call
-            GhostPlaybackLogic.ShouldTriggerExplosion(true, TerminalState.Destroyed, true, "V", 1);
-            GhostPlaybackLogic.ShouldTriggerExplosion(true, TerminalState.Destroyed, true, "V", 2);
-
-            Assert.Single(logLines, l => l.Contains("already fired") && l.Contains("#1"));
-            Assert.Single(logLines, l => l.Contains("already fired") && l.Contains("#2"));
+            Assert.False(result);
         }
 
         // --- ApplyDestroyedFallback tests ---

--- a/Source/Parsek.Tests/FastForwardTests.cs
+++ b/Source/Parsek.Tests/FastForwardTests.cs
@@ -64,7 +64,7 @@ namespace Parsek.Tests
             // Bug #117: blocked-path VERBOSE logs removed (per-frame UI spam).
             // Reason is conveyed via the out parameter, not log output.
             Assert.DoesNotContain(logLines, l =>
-                l.Contains("[Store]") && l.Contains("CanFastForward") && l.Contains("blocked"));
+                l.Contains("[RecordingStore]") && l.Contains("CanFastForward") && l.Contains("blocked"));
         }
 
         [Fact]

--- a/Source/Parsek.Tests/Fixtures/KspLog/good_atmo_soi_session.log
+++ b/Source/Parsek.Tests/Fixtures/KspLog/good_atmo_soi_session.log
@@ -12,7 +12,6 @@
 [LOG 14:20:28.530] [Parsek][INFO][Flight] Boundary split: committing segment (id=rec001, phase=atmo, body=Kerbin, points=48, orbits=0)
 [LOG 14:20:28.540] [Parsek][INFO][Flight] Boundary split: started new chain (id=abc12345)
 [LOG 14:20:28.550] [Parsek][VERBOSE][Flight] Boundary split committed: chain=abc12345, nextIdx=1, segment=Kerbin atmo, totalRecordings=1
-[LOG 14:20:28.560] [Parsek][VERBOSE][Scenario] Saved metadata: id=rec001, phase=atmo, body=Kerbin, playback=True, chain=abc12345/0
 [LOG 14:20:28.600] [Parsek][INFO][Recorder] Recording started (physics-frame sampling)
 [LOG 14:20:28.610] [Parsek][VERBOSE][Recorder] Boundary detection initialized: body=Kerbin, inAtmo=False, hasAtmo=True, alt=72500m
 [LOG 14:20:28.620] [Parsek][INFO][Flight] Recording continues after atmosphere boundary (Kerbin exo, chain=abc12345)
@@ -22,16 +21,11 @@
 [LOG 14:20:50.220] [Parsek][INFO][Flight] SOI auto-split triggered: Kerbin (exo) → Mun (chain=abc12345, points=22)
 [LOG 14:20:50.230] [Parsek][INFO][Flight] Boundary split: committing segment (id=rec002, phase=exo, body=Kerbin, points=22, orbits=1)
 [LOG 14:20:50.240] [Parsek][VERBOSE][Flight] Boundary split committed: chain=abc12345, nextIdx=2, segment=Kerbin exo, totalRecordings=2
-[LOG 14:20:50.250] [Parsek][VERBOSE][Scenario] Saved metadata: id=rec002, phase=exo, body=Kerbin, playback=True, chain=abc12345/1
 [LOG 14:20:50.300] [Parsek][INFO][Recorder] Recording started (physics-frame sampling)
 [LOG 14:20:50.310] [Parsek][VERBOSE][Recorder] Boundary detection initialized: body=Mun, inAtmo=False, hasAtmo=False, alt=25000m
 [LOG 14:20:50.320] [Parsek][INFO][Flight] Recording continues after SOI change (Kerbin → Mun, chain=abc12345)
 [LOG 14:21:10.500] [Parsek][VERBOSE][Recorder] Sample skipped due to adaptive threshold | suppressed=5
 [LOG 14:21:30.700] [Parsek][INFO][Recorder] Recording stopped. 35 points, 1 orbit segments over 40.4s
-[LOG 14:21:30.710] [Parsek][VERBOSE][Scenario] Saved metadata: id=rec003, phase=space, body=Mun, playback=True, chain=abc12345/2
-[LOG 14:21:30.720] [Parsek][VERBOSE][Scenario] Loaded metadata: id=rec001, phase=atmo, body=Kerbin, playback=True, chain=abc12345/0
-[LOG 14:21:30.730] [Parsek][VERBOSE][Scenario] Loaded metadata: id=rec002, phase=exo, body=Kerbin, playback=True, chain=abc12345/1
-[LOG 14:21:30.740] [Parsek][VERBOSE][Scenario] Loaded metadata: id=rec003, phase=space, body=Mun, playback=True, chain=abc12345/2
 [LOG 14:21:30.750] [Parsek][VERBOSE][RecordingStore] Validating chains: 1 branch group(s)
 [LOG 14:21:30.760] [Parsek][VERBOSE][RecordingStore] All chains validated OK
 [LOG 14:21:50.100] [Parsek][VERBOSE][Flight] Ghost #0 destroyed — segment disabled (Mun Transfer, Kerbin atmo)

--- a/Source/Parsek.Tests/ParsekLogContractCheckerTests.cs
+++ b/Source/Parsek.Tests/ParsekLogContractCheckerTests.cs
@@ -189,10 +189,8 @@ namespace Parsek.Tests
                 (e.Message ?? "").Contains("Boundary split: committing segment"));
             Assert.Contains(session, e => e.Subsystem == "Flight" &&
                 (e.Message ?? "").Contains("Boundary split committed"));
-            Assert.Contains(session, e => e.Subsystem == "Scenario" &&
-                (e.Message ?? "").Contains("Saved metadata:") && (e.Message ?? "").Contains("phase=atmo"));
-            Assert.Contains(session, e => e.Subsystem == "Scenario" &&
-                (e.Message ?? "").Contains("Loaded metadata:") && (e.Message ?? "").Contains("phase=space"));
+            Assert.Contains(session, e => e.Subsystem == "Flight" &&
+                (e.Message ?? "").Contains("Boundary split: committing segment") && (e.Message ?? "").Contains("phase=atmo"));
             Assert.Contains(session, e => e.Subsystem == "RecordingStore" &&
                 (e.Message ?? "").Contains("Validating chains"));
             Assert.Contains(session, e => e.Subsystem == "RecordingStore" &&

--- a/Source/Parsek.Tests/RecordingBuilderV6Tests.cs
+++ b/Source/Parsek.Tests/RecordingBuilderV6Tests.cs
@@ -576,31 +576,8 @@ namespace Parsek.Tests
 
         #region Log assertions
 
-        [Fact]
-        public void BuildTrajectoryNode_WithTrackSections_LogsSerializationCount()
-        {
-            var builder = new RecordingBuilder("LogTest")
-                .AddAtmosphericSection(17000.0, 17100.0)
-                .AddAtmosphericSection(17100.0, 17200.0);
-
-            builder.BuildTrajectoryNode();
-
-            Assert.Contains(logLines, l =>
-                l.Contains("[RecordingStore]") && l.Contains("serialized 2 track section(s)"));
-        }
-
-        [Fact]
-        public void BuildTrajectoryNode_WithSegmentEvents_LogsSerializationCount()
-        {
-            var builder = new RecordingBuilder("SegEventLogTest")
-                .AddSegmentEvent(SegmentEventType.ControllerChange, 17050.0, "test")
-                .AddSegmentEvent(SegmentEventType.PartDestroyed, 17080.0, "test2");
-
-            builder.BuildTrajectoryNode();
-
-            Assert.Contains(logLines, l =>
-                l.Contains("RecordingStore") && l.Contains("2 segment events serialized"));
-        }
+        // BuildTrajectoryNode_WithTrackSections_LogsSerializationCount removed: per-recording verbose log replaced with batch summary
+        // BuildTrajectoryNode_WithSegmentEvents_LogsSerializationCount removed: per-recording verbose log replaced with batch summary
 
         #endregion
 

--- a/Source/Parsek.Tests/RecordingBuilderV6Tests.cs
+++ b/Source/Parsek.Tests/RecordingBuilderV6Tests.cs
@@ -574,13 +574,6 @@ namespace Parsek.Tests
 
         #endregion
 
-        #region Log assertions
-
-        // BuildTrajectoryNode_WithTrackSections_LogsSerializationCount removed: per-recording verbose log replaced with batch summary
-        // BuildTrajectoryNode_WithSegmentEvents_LogsSerializationCount removed: per-recording verbose log replaced with batch summary
-
-        #endregion
-
         #region Empty collections: no nodes emitted
 
         [Fact]

--- a/Source/Parsek.Tests/SegmentEventSerializationTests.cs
+++ b/Source/Parsek.Tests/SegmentEventSerializationTests.cs
@@ -308,35 +308,7 @@ namespace Parsek.Tests
 
         #region Log assertions
 
-        [Fact]
-        public void Serialize_LogsEventCount()
-        {
-            var logLines = new List<string>();
-            ParsekLog.SuppressLogging = false;
-            RecordingStore.SuppressLogging = false;
-            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
-
-            try
-            {
-                var events = new List<SegmentEvent>
-                {
-                    new SegmentEvent { ut = 100.0, type = SegmentEventType.ControllerChange },
-                    new SegmentEvent { ut = 200.0, type = SegmentEventType.ControllerDisabled }
-                };
-
-                var node = new ConfigNode("ROOT");
-                RecordingStore.SerializeSegmentEvents(node, events);
-
-                Assert.Contains(logLines, l =>
-                    l.Contains("RecordingStore") && l.Contains("2 segment events serialized"));
-            }
-            finally
-            {
-                ParsekLog.SuppressLogging = true;
-                RecordingStore.SuppressLogging = true;
-                ParsekLog.ResetTestOverrides();
-            }
-        }
+        // Serialize_LogsEventCount removed: per-recording verbose log replaced with batch summary
 
         [Fact]
         public void UnknownType_LogsWarningWithBadValue()

--- a/Source/Parsek.Tests/SegmentEventSerializationTests.cs
+++ b/Source/Parsek.Tests/SegmentEventSerializationTests.cs
@@ -308,8 +308,6 @@ namespace Parsek.Tests
 
         #region Log assertions
 
-        // Serialize_LogsEventCount removed: per-recording verbose log replaced with batch summary
-
         [Fact]
         public void UnknownType_LogsWarningWithBadValue()
         {

--- a/Source/Parsek.Tests/TrackSectionSerializationTests.cs
+++ b/Source/Parsek.Tests/TrackSectionSerializationTests.cs
@@ -475,12 +475,6 @@ namespace Parsek.Tests
 
         #endregion
 
-        #region Test 10: Log assertion - serialization logs track section count
-
-        // Serialize_LogsTrackSectionCount removed: per-recording verbose log replaced with batch summary
-
-        #endregion
-
         #region AnchorPid not written when zero
 
         [Fact]

--- a/Source/Parsek.Tests/TrackSectionSerializationTests.cs
+++ b/Source/Parsek.Tests/TrackSectionSerializationTests.cs
@@ -477,46 +477,7 @@ namespace Parsek.Tests
 
         #region Test 10: Log assertion - serialization logs track section count
 
-        [Fact]
-        public void Serialize_LogsTrackSectionCount()
-        {
-            var tracks = new List<TrackSection>
-            {
-                new TrackSection
-                {
-                    environment = SegmentEnvironment.Atmospheric,
-                    referenceFrame = ReferenceFrame.Absolute,
-                    startUT = 17000.0,
-                    endUT = 17100.0,
-                    sampleRateHz = 10.0f,
-                    frames = new List<TrajectoryPoint>
-                    {
-                        MakePoint(17000.0, 0, 0, 100),
-                        MakePoint(17100.0, 0, 0, 200),
-                    },
-                    checkpoints = new List<OrbitSegment>()
-                },
-                new TrackSection
-                {
-                    environment = SegmentEnvironment.ExoBallistic,
-                    referenceFrame = ReferenceFrame.OrbitalCheckpoint,
-                    startUT = 17100.0,
-                    endUT = 18000.0,
-                    sampleRateHz = 0.1f,
-                    frames = new List<TrajectoryPoint>(),
-                    checkpoints = new List<OrbitSegment>
-                    {
-                        MakeOrbitSegment(17100, 18000),
-                    }
-                }
-            };
-
-            var parent = new ConfigNode("TEST");
-            RecordingStore.SerializeTrackSections(parent, tracks);
-
-            Assert.Contains(logLines, l =>
-                l.Contains("[RecordingStore]") && l.Contains("serialized 2 track section(s)"));
-        }
+        // Serialize_LogsTrackSectionCount removed: per-recording verbose log replaced with batch summary
 
         #endregion
 

--- a/Source/Parsek/CrewReservationManager.cs
+++ b/Source/Parsek/CrewReservationManager.cs
@@ -107,11 +107,7 @@ namespace Parsek
         internal static void ReserveCrewIn(ConfigNode snapshot, bool alreadySpawned, KerbalRoster roster)
         {
             if (snapshot == null || alreadySpawned)
-            {
-                if (snapshot == null)
-                    ParsekLog.Verbose("CrewReservation", "ReserveCrewIn: null snapshot — skipping");
                 return;
-            }
 
             foreach (ConfigNode partNode in snapshot.GetNodes("PART"))
             {

--- a/Source/Parsek/EngineFxBuilder.cs
+++ b/Source/Parsek/EngineFxBuilder.cs
@@ -73,7 +73,7 @@ namespace Parsek
                             {
                                 if (TryGetFxModelFallbackRotation(modelName, out mmpLocalRot))
                                 {
-                                    ParsekLog.Log($"    Engine FX model rotation fallback: '{modelName}' euler={mmpLocalRot.eulerAngles}");
+                                    ParsekLog.Verbose("EngineFx", $"model rotation fallback: '{modelName}' euler={mmpLocalRot.eulerAngles}");
                                 }
                             }
 
@@ -280,7 +280,7 @@ namespace Parsek
                         srcFxTransform, prefab.transform, modelRoot, ghostModelNode, cloneMap);
                     if (ghostFxParent == null)
                     {
-                        ParsekLog.Log($"    Engine FX: '{partName}' midx={moduleIndex} " +
+                        ParsekLog.Verbose("EngineFx", $"'{partName}' midx={moduleIndex} " +
                             $"transform='{transformName}' parent resolution failed");
                         continue;
                     }
@@ -309,14 +309,14 @@ namespace Parsek
                                 Vector3 srcFwd = srcFxTransform.forward;
                                 Vector3 srcUp = srcFxTransform.up;
                                 Quaternion srcLocalRot = srcFxTransform.localRotation;
-                                ParsekLog.Log($"    Engine FX cloned: '{partName}' midx={moduleIndex} " +
+                                ParsekLog.Verbose("EngineFx", $"cloned: '{partName}' midx={moduleIndex} " +
                                     $"type={nodeType} transform='{transformName}' model='{modelName}' " +
                                     $"systems={addedSystems} " +
                                     $"srcLocalRot={srcLocalRot} srcFwd={srcFwd} srcUp={srcUp}");
                             }
                             else
                             {
-                                ParsekLog.Log($"    Engine FX model has no ParticleSystem: '{modelName}' for '{partName}'");
+                                ParsekLog.Verbose("EngineFx", $"model has no ParticleSystem: '{modelName}' for '{partName}'");
                                 Object.Destroy(fxInstance);
                             }
                         }
@@ -351,14 +351,14 @@ namespace Parsek
                 GameObject fxPrefab = GhostVisualBuilder.FindFxPrefab(prefabName);
                 if (fxPrefab == null)
                 {
-                    ParsekLog.Log($"    Engine FX prefab not found: '{prefabName}' for '{partName}'");
+                    ParsekLog.Verbose("EngineFx", $"prefab not found: '{prefabName}' for '{partName}'");
                     continue;
                 }
 
                 var fxTransforms = GhostVisualBuilder.FindTransformsRecursive(prefab.transform, transformName);
                 if (fxTransforms.Count == 0)
                 {
-                    ParsekLog.Log($"    Engine FX (prefab): '{partName}' midx={moduleIndex} " +
+                    ParsekLog.Verbose("EngineFx", $"'{partName}' midx={moduleIndex} " +
                         $"transform '{transformName}' not found on prefab");
                     continue;
                 }
@@ -373,8 +373,8 @@ namespace Parsek
                         srcFxTransform, prefab.transform, modelRoot, ghostModelNode, cloneMap);
                     if (ghostFxParent == null)
                     {
-                        ParsekLog.Log($"    Engine FX (prefab): '{partName}' midx={moduleIndex} " +
-                            $"transform='{transformName}' parent resolution failed");
+                        ParsekLog.Verbose("EngineFx", $"'{partName}' midx={moduleIndex} " +
+                            $"transform='{transformName}' (prefab) parent resolution failed");
                         continue;
                     }
                     GhostVisualBuilder.LogFxParentAlignmentDiagnostic(partName, moduleIndex, "PREFAB_PARTICLE", transformName,
@@ -406,12 +406,12 @@ namespace Parsek
                         GhostVisualBuilder.LogFxInstancePlacementDiagnostic(partName, moduleIndex, "PREFAB_PARTICLE", transformName,
                             prefabName, prefab.transform, ghostModelNode, srcFxTransform, ghostFxParent,
                             fxInstance.transform, localOffset, localRot, hasLocalRot);
-                        ParsekLog.Log($"    Engine FX (prefab): '{partName}' midx={moduleIndex} " +
+                        ParsekLog.Verbose("EngineFx", $"(prefab): '{partName}' midx={moduleIndex} " +
                             $"transform='{transformName}' prefab='{prefabName}' systems={addedSystems}");
                     }
                     else
                     {
-                        ParsekLog.Log($"    Engine FX (prefab): '{partName}' midx={moduleIndex} " +
+                        ParsekLog.Verbose("EngineFx", $"(prefab): '{partName}' midx={moduleIndex} " +
                             $"prefab '{prefabName}' has no ParticleSystem");
                         Object.Destroy(fxInstance);
                     }
@@ -464,7 +464,7 @@ namespace Parsek
                 {
                     // RAPIER has multi-mode engine modules sharing nozzle transforms; recording events
                     // target midx=0, so skip duplicate module FX to avoid doubled plumes.
-                    ParsekLog.Log($"    Engine '{partName}' midx={moduleIndex}: skipped duplicate multi-mode FX module");
+                    ParsekLog.Verbose("EngineFx", $"'{partName}' midx={moduleIndex}: skipped duplicate multi-mode FX module");
                     continue;
                 }
 
@@ -598,7 +598,7 @@ namespace Parsek
 
                     prefabFxEntries.Add((prefabName, fallbackTransform, fallbackOffset, localRotation, hasLocalRotation));
                     string rotationSuffix = hasLocalRotation ? $" rot={localRotation.eulerAngles}" : "";
-                    ParsekLog.Log($"    Engine FX fallback: '{partName}' midx={moduleIndex} " +
+                    ParsekLog.Verbose("EngineFx", $"fallback: '{partName}' midx={moduleIndex} " +
                         $"added {description} on '{fallbackTransform}' offset={fallbackOffset}{rotationSuffix}");
                 }
 
@@ -700,7 +700,7 @@ namespace Parsek
                         kickbackTransform, kickbackOffset, kickbackThumperLocalRot, true));
                     prefabFxEntries.Add(("fx_exhaustFlame_yellow",
                         kickbackTransform, kickbackOffset, kickbackThumperLocalRot, true));
-                    ParsekLog.Log($"    Engine FX fallback: '{partName}' midx={moduleIndex} " +
+                    ParsekLog.Verbose("EngineFx", $"fallback: '{partName}' midx={moduleIndex} " +
                         $"forced Thumper-style plume on '{kickbackTransform}' offset={kickbackOffset} " +
                         $"rot={kickbackThumperLocalRot.eulerAngles} hasRot=true " +
                         $"(removed MODEL={removedKickbackModelFx}, PREFAB={removedKickbackPrefabs})");
@@ -764,7 +764,7 @@ namespace Parsek
 
                     prefabFxEntries.Add(("fx_smokeTrail_light", rhinoTransform, rhinoOffset, rhinoPlumeRotation, true));
                     prefabFxEntries.Add(("fx_exhaustFlame_yellow_medium", rhinoTransform, rhinoOffset, rhinoPlumeRotation, true));
-                    ParsekLog.Log($"    Engine FX fallback: '{partName}' midx={moduleIndex} " +
+                    ParsekLog.Verbose("EngineFx", $"fallback: '{partName}' midx={moduleIndex} " +
                         $"forced compact Mainsail-like plume on '{rhinoTransform}' offset={rhinoOffset} " +
                         $"(removed MODEL={removedRhinoModelFx}, PREFAB={removedRhinoPrefabs})");
                 }
@@ -850,7 +850,7 @@ namespace Parsek
                         }
 
                         prefabFxEntries.Add(("fx_exhaustFlame_blue", fallbackTransform, fallbackOffset, fallbackRotation, fallbackHasLocalRotation));
-                        ParsekLog.Log($"    Engine FX fallback: '{partName}' midx={moduleIndex} " +
+                        ParsekLog.Verbose("EngineFx", $"fallback: '{partName}' midx={moduleIndex} " +
                             $"added Skipper-style blue flame prefab on '{fallbackTransform}' offset={fallbackOffset} rot={fallbackRotation.eulerAngles}");
                     }
                 }
@@ -907,7 +907,7 @@ namespace Parsek
 
                     prefabFxEntries.Add(("fx_smokeTrail_large", rapierSmokeTransform, rapierSmokeOffset,
                         rapierSmokeRotation, rapierSmokeHasLocalRotation));
-                    ParsekLog.Log($"    Engine FX fallback: '{partName}' midx={moduleIndex} " +
+                    ParsekLog.Verbose("EngineFx", $"fallback: '{partName}' midx={moduleIndex} " +
                         $"replaced {removedRapierSmoke} smoke entries with Vector-style smoke on '{rapierSmokeTransform}' " +
                         $"offset={rapierSmokeOffset} rot={rapierSmokeRotation.eulerAngles}");
 
@@ -941,7 +941,7 @@ namespace Parsek
 
                         Quaternion flameRotation = Quaternion.Euler(-90f, 0f, 0f);
                         prefabFxEntries.Add(("fx_exhaustFlame_white", flameTransform, flameOffset, flameRotation, true));
-                        ParsekLog.Log($"    Engine FX fallback: '{partName}' midx={moduleIndex} " +
+                        ParsekLog.Verbose("EngineFx", $"fallback: '{partName}' midx={moduleIndex} " +
                             $"added Vector-style white flame on '{flameTransform}' offset={flameOffset} rot={flameRotation.eulerAngles}");
                     }
                 }

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -4448,7 +4448,8 @@ namespace Parsek
 
             if (Recording.Count % 10 == 0)
             {
-                ParsekLog.Verbose("Recorder", $"Recorded point #{Recording.Count}: {point}");
+                ParsekLog.VerboseRateLimited("Recorder", "recorded-point",
+                    $"Recorded point #{Recording.Count}: {point}", 5.0);
             }
         }
 

--- a/Source/Parsek/GhostPlaybackEngine.cs
+++ b/Source/Parsek/GhostPlaybackEngine.cs
@@ -1382,8 +1382,8 @@ namespace Parsek
         internal void DestroyOverlapGhostState(GhostPlaybackState state)
         {
             if (state == null) return;
-            ParsekLog.Verbose("Engine",
-                $"Destroying overlap ghost cycle={state.loopCycleIndex}");
+            ParsekLog.VerboseRateLimited("Engine", "destroy-overlap",
+                $"Destroying overlap ghost cycle={state.loopCycleIndex}", 2.0);
             DestroyGhostResources(state);
         }
 

--- a/Source/Parsek/GhostPlaybackEngine.cs
+++ b/Source/Parsek/GhostPlaybackEngine.cs
@@ -130,8 +130,7 @@ namespace Parsek
                     if (ghostStates.ContainsKey(i))
                     {
                         DestroyAllOverlapGhosts(i);
-                        DestroyGhost(i, traj, f);
-                        ParsekLog.Info("Engine", $"Ghost #{i} destroyed — recording skipped (disabled/suppressed)");
+                        DestroyGhost(i, traj, f, reason: "disabled/suppressed");
                     }
                     continue;
                 }
@@ -157,8 +156,7 @@ namespace Parsek
                     {
                         if (ghostActive)
                         {
-                            ParsekLog.Info("Engine", $"Loop ghost #{i} \"{traj.VesselName}\" — anchor vessel {traj.LoopAnchorVesselId} unloaded, destroying ghost");
-                            DestroyGhost(i, traj, f);
+                            DestroyGhost(i, traj, f, reason: $"anchor {traj.LoopAnchorVesselId} unloaded");
                             DestroyAllOverlapGhosts(i);
                         }
                         continue;
@@ -427,7 +425,7 @@ namespace Parsek
                                     $"SoftCap: despawning ghost #{capIdx} \"{vesselName}\"");
                                 IPlaybackTrajectory capTraj = capIdx >= 0 && capIdx < trajectories.Count
                                     ? trajectories[capIdx] : null;
-                                DestroyGhost(capIdx, capTraj);
+                                DestroyGhost(capIdx, capTraj, reason: "soft cap despawn");
                                 softCapSuppressed.Add(capIdx);
                                 break;
                             case GhostCapAction.SimplifyToOrbitLine:
@@ -537,7 +535,7 @@ namespace Parsek
                     out loopUT, out cycleIndex, out inPauseWindow, index))
             {
                 if (ghostActive)
-                    DestroyGhost(index, traj, flags);
+                    DestroyGhost(index, traj, flags, reason: "loop UT computation failed");
                 return;
             }
 
@@ -576,7 +574,7 @@ namespace Parsek
                 });
 
                 GhostPlaybackLogic.ResetReentryFx(state, index);
-                DestroyGhost(index, traj, flags);
+                DestroyGhost(index, traj, flags, reason: "loop cycle boundary");
                 ghostActive = false;
                 state = null;
             }
@@ -683,7 +681,7 @@ namespace Parsek
         {
             if (ctx.currentUT < traj.StartUT)
             {
-                if (primaryActive) DestroyGhost(index, traj, flags);
+                if (primaryActive) DestroyGhost(index, traj, flags, reason: "before start UT");
                 DestroyAllOverlapGhosts(index);
                 return;
             }
@@ -719,7 +717,7 @@ namespace Parsek
                 }
                 else if (primaryActive)
                 {
-                    DestroyGhost(index, traj, flags);
+                    DestroyGhost(index, traj, flags, reason: "cycle transition");
                 }
 
                 // Spawn new primary for lastCycle
@@ -1285,6 +1283,14 @@ namespace Parsek
             GhostPlaybackLogic.InitializeFlagVisibility(traj, state);
 
             ghostStates[index] = state;
+
+            string buildType = builtFromSnapshot
+                ? (traj.GhostVisualSnapshot != null ? "recording-start snapshot" : "vessel snapshot")
+                : "sphere fallback";
+            ParsekLog.VerboseRateLimited("Engine", $"spawn-{index}",
+                $"Ghost #{index} \"{traj?.VesselName}\" spawned ({buildType}, " +
+                $"parts={state.partTree?.Count ?? 0} engines={state.engineInfos?.Count ?? 0} " +
+                $"rcs={state.rcsInfos?.Count ?? 0})", 1.0);
         }
 
         /// <summary>
@@ -1348,13 +1354,16 @@ namespace Parsek
         /// removes it from ghostStates and loopPhaseOffsets.
         /// </summary>
         internal void DestroyGhost(int index, IPlaybackTrajectory traj = null,
-            TrajectoryPlaybackFlags flags = default)
+            TrajectoryPlaybackFlags flags = default, string reason = null)
         {
             frameDestroyCount++;
 
             GhostPlaybackState state;
             if (!ghostStates.TryGetValue(index, out state))
                 return;
+
+            ParsekLog.VerboseRateLimited("Engine", $"destroy-{index}",
+                $"Ghost #{index} \"{traj?.VesselName}\" destroyed ({reason ?? "unknown"})", 1.0);
 
             // Fire before destroy so subscribers can read state
             OnGhostDestroyed?.Invoke(new GhostLifecycleEvent

--- a/Source/Parsek/GhostPlaybackEngine.cs
+++ b/Source/Parsek/GhostPlaybackEngine.cs
@@ -51,6 +51,10 @@ namespace Parsek
         internal const int MaxOverlapGhostsPerRecording = 5;
         internal const double OverlapExplosionHoldSeconds = 3.0;
 
+        // Per-frame batch counters (avoid per-ghost log spam)
+        private int frameSpawnCount;
+        private int frameDestroyCount;
+
         // Deferred event lists (reused per frame to avoid GC allocation)
         private readonly List<PlaybackCompletedEvent> deferredCompletedEvents = new List<PlaybackCompletedEvent>();
         private readonly List<GhostLifecycleEvent> deferredCreatedEvents = new List<GhostLifecycleEvent>();
@@ -112,6 +116,8 @@ namespace Parsek
 
             deferredCompletedEvents.Clear();
             deferredCreatedEvents.Clear();
+            frameSpawnCount = 0;
+            frameDestroyCount = 0;
 
             for (int i = 0; i < trajectories.Count; i++)
             {
@@ -199,6 +205,11 @@ namespace Parsek
                     HandlePastEndGhost(i, traj, f, ctx, state, ghostActive, hasPoints);
             }
 
+            // Post-loop: batch summary
+            if (frameSpawnCount > 0 || frameDestroyCount > 0)
+                ParsekLog.VerboseRateLimited("Engine", "frame-summary",
+                    $"Frame: spawned={frameSpawnCount} destroyed={frameDestroyCount} active={ghostStates.Count}");
+
             // Post-loop: soft caps
             EvaluateSoftCaps(trajectories, ctx);
 
@@ -233,9 +244,7 @@ namespace Parsek
                 ghostActive = state != null && state.ghost != null;
                 if (ghostActive)
                 {
-                    if (loggedGhostEnter.Add(i))
-                        ParsekLog.VerboseRateLimited("Engine", $"enter-{i}",
-                            $"Ghost ENTERED range: #{i} \"{traj.VesselName}\" ({f.segmentLabel})");
+                    loggedGhostEnter.Add(i);
 
                     if (OnGhostCreated != null)
                     {
@@ -705,7 +714,7 @@ namespace Parsek
                 {
                     ghostStates.Remove(index);
                     overlaps.Add(primaryState);
-                    ParsekLog.Verbose("Engine",
+                    ParsekLog.VerboseRateLimited("Engine", "overlap-move",
                         $"Ghost #{index} cycle={primaryState.loopCycleIndex} moved to overlap list");
                 }
                 else if (primaryActive)
@@ -789,7 +798,7 @@ namespace Parsek
                         ExplosionPosition = ovState.ghost != null ? ovState.ghost.transform.position : Vector3.zero
                     });
 
-                    ParsekLog.Info("Engine",
+                    ParsekLog.VerboseRateLimited("Engine", "overlap-expired",
                         $"Ghost EXITED range: #{index} \"{traj.VesselName}\" cycle={cycle} (overlap expired)");
                     DestroyOverlapGhostState(ovState);
                     overlaps.RemoveAt(i);
@@ -1221,8 +1230,7 @@ namespace Parsek
         /// </summary>
         internal void SpawnGhost(int index, IPlaybackTrajectory traj)
         {
-            ParsekLog.VerboseRateLimited("Engine", $"spawn-{index}",
-                $"SpawnGhost index={index} vessel={traj?.VesselName}");
+            frameSpawnCount++;
             completedEventFired.Remove(index); // Reset dedup for time-jump backward
 
             Color ghostColor = new Color(0.2f, 1f, 0.4f, 0.8f); // bright green-cyan
@@ -1243,16 +1251,6 @@ namespace Parsek
             if (ghost == null)
             {
                 ghost = GhostVisualBuilder.CreateGhostSphere($"Parsek_Timeline_{index}", ghostColor);
-                ParsekLog.VerboseRateLimited("Engine", $"build-{index}",
-                    $"Timeline ghost #{index}: using sphere fallback");
-            }
-            else
-            {
-                bool usedStartSnapshot = traj.GhostVisualSnapshot != null;
-                ParsekLog.VerboseRateLimited("Engine", $"build-{index}",
-                    usedStartSnapshot
-                    ? $"Timeline ghost #{index}: built from recording-start snapshot"
-                    : $"Timeline ghost #{index}: built from vessel snapshot");
             }
 
             var cameraPivotObj = new GameObject("cameraPivot");
@@ -1287,10 +1285,6 @@ namespace Parsek
             GhostPlaybackLogic.InitializeFlagVisibility(traj, state);
 
             ghostStates[index] = state;
-
-            ParsekLog.VerboseRateLimited("Engine", $"spawned-{index}",
-                $"Ghost #{index} spawned: snapshot={builtFromSnapshot} parts={state.partTree?.Count ?? 0} " +
-                $"engines={state.engineInfos?.Count ?? 0} rcs={state.rcsInfos?.Count ?? 0}");
         }
 
         /// <summary>
@@ -1356,8 +1350,7 @@ namespace Parsek
         internal void DestroyGhost(int index, IPlaybackTrajectory traj = null,
             TrajectoryPlaybackFlags flags = default)
         {
-            ParsekLog.VerboseRateLimited("Engine", $"destroy-{index}",
-                $"DestroyGhost index={index}");
+            frameDestroyCount++;
 
             GhostPlaybackState state;
             if (!ghostStates.TryGetValue(index, out state))
@@ -1462,12 +1455,13 @@ namespace Parsek
                     }
                 }
 
-                ParsekLog.Verbose("Engine",
+                ParsekLog.VerboseRateLimited("ExplosionFx", "explosion-created",
                     $"Explosion GO created for ghost #{recIdx}, activeExplosions.Count={activeExplosions.Count}");
             }
 
             GhostPlaybackLogic.HideAllGhostParts(state);
-            ParsekLog.Verbose("Engine", $"Ghost #{recIdx} parts hidden after explosion");
+            ParsekLog.VerboseRateLimited("Engine", "parts-hidden-explosion",
+                $"Ghost #{recIdx} parts hidden after explosion");
         }
 
         /// <summary>

--- a/Source/Parsek/GhostPlaybackEngine.cs
+++ b/Source/Parsek/GhostPlaybackEngine.cs
@@ -1445,9 +1445,9 @@ namespace Parsek
                 ? state.reentryFxInfo.vesselLength
                 : GhostVisualBuilder.ComputeGhostLength(state.ghost);
 
-            ParsekLog.Info("Engine",
+            ParsekLog.VerboseRateLimited("ExplosionFx", $"trigger-{recIdx}",
                 $"Triggering explosion for ghost #{recIdx} \"{traj.VesselName}\" " +
-                $"at ({worldPos.x:F1},{worldPos.y:F1},{worldPos.z:F1}) vesselLength={vesselLength:F1}m");
+                $"at ({worldPos.x:F1},{worldPos.y:F1},{worldPos.z:F1}) vesselLength={vesselLength:F1}m", 10.0);
 
             var explosion = GhostVisualBuilder.SpawnExplosionFx(worldPos, vesselLength);
             if (explosion != null)

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -1984,31 +1984,26 @@ namespace Parsek
             // Base condition: must have a snapshot, not already spawned, not destroyed
             if (rec.VesselSnapshot == null)
             {
-                // Reason returned to caller; per-frame logging removed (was 73% of all log output)no vessel snapshot");
                 return (false, "no vessel snapshot");
             }
             if (rec.VesselSpawned)
             {
-                // Reason returned to caller; per-frame logging removed (was 73% of all log output)already spawned (VesselSpawned=true)");
                 return (false, "already spawned (VesselSpawned=true)");
             }
             if (rec.VesselDestroyed)
             {
-                // Reason returned to caller; per-frame logging removed (was 73% of all log output)vessel destroyed");
                 return (false, "vessel destroyed");
             }
 
             // Branch > 0 recordings are ghost-only (undock continuations) — never spawn
             if (rec.ChainBranch > 0)
             {
-                // Reason returned to caller; per-frame logging removed (was 73% of all log output)branch > 0 (ghost-only)");
                 return (false, "branch > 0 (ghost-only)");
             }
 
             // Suppress spawning for recordings belonging to a chain currently being built
             if (isActiveChainMember)
             {
-                // Reason returned to caller; per-frame logging removed (was 73% of all log output)active chain being built");
                 return (false, "active chain being built");
             }
 
@@ -2020,14 +2015,12 @@ namespace Parsek
             // Suppress spawn for looping or fully-disabled chains
             if (isChainLoopingOrDisabled)
             {
-                // Reason returned to caller; per-frame logging removed (was 73% of all log output)chain looping or fully disabled");
                 return (false, "chain looping or fully disabled");
             }
 
             // Non-leaf tree recordings should never spawn (they branched into children)
             if (rec.ChildBranchPointId != null)
             {
-                // Reason returned to caller; per-frame logging removed (was 73% of all log output)non-leaf tree recording");
                 return (false, "non-leaf tree recording");
             }
 
@@ -2036,14 +2029,12 @@ namespace Parsek
             // ChildBranchPointId was not set (e.g., serialization gaps). (#114)
             if (IsNonLeafInCommittedTree(rec))
             {
-                // Reason returned to caller; per-frame logging removed (was 73% of all log output)non-leaf in committed tree (safety net)");
                 return (false, "non-leaf in committed tree (safety net)");
             }
 
             // Debris recordings are visual-only (short TTL, no meaningful vessel to persist)
             if (rec.IsDebris)
             {
-                // Reason returned to caller; per-frame logging removed (was 73% of all log output)debris recording (visual-only)");
                 return (false, "debris recording (visual-only)");
             }
 
@@ -2056,7 +2047,6 @@ namespace Parsek
                     || ts == TerminalState.Docked || ts == TerminalState.Boarded
                     || ts == TerminalState.SubOrbital)
                 {
-                    // Reason returned to caller; per-frame logging removed (was 73% of all log output)terminal state {ts}");
                     return (false, $"terminal state {ts}");
                 }
             }
@@ -2067,7 +2057,6 @@ namespace Parsek
             // captured mid-flight. (#114)
             if (IsSnapshotSituationUnsafe(rec.VesselSnapshot))
             {
-                // Reason returned to caller; per-frame logging removed (was 73% of all log output)snapshot situation unsafe (FLYING/SUB_ORBITAL)");
                 return (false, "snapshot situation unsafe (FLYING/SUB_ORBITAL)");
             }
 
@@ -2075,7 +2064,6 @@ namespace Parsek
             // On revert, SpawnedVesselPersistentId resets to 0 from quicksave so reverts still work.
             if (rec.SpawnedVesselPersistentId != 0)
             {
-                // Reason returned to caller; per-frame logging removed (was 73% of all log output)already spawned (pid={rec.SpawnedVesselPersistentId})");
                 return (false, $"already spawned (pid={rec.SpawnedVesselPersistentId})");
             }
 

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -678,17 +678,9 @@ namespace Parsek
             bool ghostExists, string vesselName, int recIdx)
         {
             if (explosionAlreadyFired)
-            {
-                ParsekLog.VerboseRateLimited("ExplosionFx", $"explosion_fired_{recIdx}",
-                    $"ShouldTriggerExplosion: ghost #{recIdx} — skipped (already fired)");
                 return false;
-            }
             if (terminalState != TerminalState.Destroyed)
-            {
-                ParsekLog.VerboseRateLimited("ExplosionFx", $"not_destroyed_{recIdx}",
-                    $"ShouldTriggerExplosion: ghost #{recIdx} — skipped (terminalState={terminalState?.ToString() ?? "null"}, not Destroyed)");
                 return false;
-            }
             if (!ghostExists)
             {
                 return false;

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -5528,7 +5528,8 @@ namespace Parsek
                 info.fireParticles = ps;
                 info.combinedEmissionMesh = combinedMesh;
 
-                ParsekLog.Verbose("ReentryFx", $"combined {combines.Count} meshes into emission shape " +
+                ParsekLog.VerboseRateLimited("ReentryFx", "emission-build",
+                    $"combined {combines.Count} meshes into emission shape " +
                     $"({(combinedMesh != null ? combinedMesh.vertexCount : 0)} verts) for ghost #{ghostIndex}");
             }
 
@@ -5548,7 +5549,8 @@ namespace Parsek
                     info.allClonedMaterials.Add(shellMat);
                 }
 
-                ParsekLog.Verbose("ReentryFx", $"{info.fireShellMeshes.Count} meshes collected for fire shell overlay on ghost #{ghostIndex}");
+                ParsekLog.VerboseRateLimited("ReentryFx", "shell-build",
+                    $"{info.fireShellMeshes.Count} meshes collected for fire shell overlay on ghost #{ghostIndex}");
             }
 
             return info;

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -137,7 +137,7 @@ namespace Parsek
                     if (result != null)
                     {
                         fxPrefabCache[prefabName] = result;
-                        ParsekLog.Log($"  FX prefab substitution: '{prefabName}' -> '{fallbackName}'");
+                        ParsekLog.Verbose("GhostVisual", $"FX prefab substitution: '{prefabName}' -> '{fallbackName}'");
                         return result;
                     }
                 }
@@ -186,7 +186,7 @@ namespace Parsek
                 GameObject result = Resources.Load<GameObject>(resourcePath);
                 if (result != null)
                 {
-                    ParsekLog.Log($"  FX prefab loaded from Resources: '{prefabName}' (path='{resourcePath}')");
+                    ParsekLog.Verbose("GhostVisual", $"FX prefab loaded from Resources: '{prefabName}' (path='{resourcePath}')");
                     return result;
                 }
             }
@@ -196,14 +196,14 @@ namespace Parsek
                 : null;
             if (modelPrefab != null)
             {
-                ParsekLog.Log($"  FX prefab loaded from GameDatabase model: '{prefabName}'");
+                ParsekLog.Verbose("GhostVisual", $"FX prefab loaded from GameDatabase model: '{prefabName}'");
                 return modelPrefab;
             }
 
             PopulateFxPrefabCacheFromLoadedObjects();
             if (TryGetFxPrefabFromCache(prefabName, out GameObject cached))
             {
-                ParsekLog.Log($"  FX prefab resolved from loaded objects: '{prefabName}'");
+                ParsekLog.Verbose("GhostVisual", $"FX prefab resolved from loaded objects: '{prefabName}'");
                 return cached;
             }
 
@@ -239,7 +239,7 @@ namespace Parsek
                 added++;
             }
 
-            ParsekLog.Log($"  FX prefab cache extended from loaded objects: +{added} entries");
+            ParsekLog.Info("GhostVisual", $"FX prefab cache extended from loaded objects: +{added} entries");
         }
 
         private static void RebuildFxPrefabCache()
@@ -264,7 +264,7 @@ namespace Parsek
                     }
                 }
             }
-            ParsekLog.Log($"  FX prefab cache built from PartLoader: {fxPrefabCache.Count} entries");
+            ParsekLog.Info("GhostVisual", $"FX prefab cache built from PartLoader: {fxPrefabCache.Count} entries");
         }
 
         /// <summary>Clear the fx prefab cache (e.g., on scene change).</summary>
@@ -2271,7 +2271,7 @@ namespace Parsek
                             srcFxTransform, prefab.transform, modelRoot, ghostModelNode, cloneMap);
                         if (ghostFxParent == null)
                         {
-                            ParsekLog.Log($"    RCS '{partName}' midx={moduleIndex}: " +
+                            ParsekLog.Verbose("GhostVisual", $"RCS '{partName}' midx={moduleIndex}: " +
                                 $"transform='{transformName}' parent resolution failed");
                             continue;
                         }
@@ -4418,6 +4418,7 @@ namespace Parsek
             ref int meshCount, ref int damagedSkipped, ref int nullMeshSkipped)
         {
             int skinnedCloned = 0;
+            int partRootFallbackCount = 0;
             for (int r = 0; r < skinnedRenderers.Length; r++)
             {
                 var smr = skinnedRenderers[r];
@@ -4439,9 +4440,6 @@ namespace Parsek
                 if (IsRendererOnDamagedTransform(smr.transform, damagedWheelNames))
                 {
                     damagedSkipped++;
-                    ParsekLog.VerboseRateLimited("GhostVisual", $"dmg_smr_{partName}_{r}",
-                        $"    Part '{partName}' pid={persistentId}: skipping damaged wheel " +
-                        $"SkinnedMeshRenderer '{smr.name}' (ModuleWheelDamage.damagedTransformName match)", 60.0);
                     continue;
                 }
 
@@ -4493,15 +4491,8 @@ namespace Parsek
                 ghostSmr.receiveShadows = smr.receiveShadows;
                 meshCount++;
                 skinnedCloned++;
-                ParsekLog.VerboseRateLimited("GhostVisual", $"smr_{partName}_{r}",
-                    $"    SMR[{r}] '{smr.gameObject.name}' mesh={smr.sharedMesh.name} " +
-                    $"localPos={leaf.localPosition} localScale={leaf.localScale} " +
-                    $"bones={resolvedBones}/{(smr.bones != null ? smr.bones.Length : 0)}", 60.0);
                 if (usedPartRootFallbackForBones)
-                {
-                    ParsekLog.VerboseRateLimited("GhostVisual", $"smr_fb_{partName}_{r}",
-                        $"      SMR[{r}] '{smr.gameObject.name}': used part-root fallback for external bone transforms", 60.0);
-                }
+                    partRootFallbackCount++;
             }
 
             return skinnedCloned;
@@ -4924,9 +4915,6 @@ namespace Parsek
                 if (IsRendererOnDamagedTransform(mr.transform, damagedWheelNames))
                 {
                     damagedSkipped++;
-                    ParsekLog.VerboseRateLimited("GhostVisual", $"dmg_mr_{partName}_{r}",
-                        $"    Part '{partName}' pid={persistentId}: skipping damaged wheel " +
-                        $"MeshRenderer '{mr.gameObject.name}' (ModuleWheelDamage.damagedTransformName match)", 60.0);
                     continue;
                 }
                 var mf = mr.GetComponent<MeshFilter>();
@@ -4936,9 +4924,6 @@ namespace Parsek
                 leaf.gameObject.AddComponent<MeshFilter>().sharedMesh = mf.sharedMesh;
                 leaf.gameObject.AddComponent<MeshRenderer>().sharedMaterials = mr.sharedMaterials;
                 meshCount++;
-                ParsekLog.VerboseRateLimited("GhostVisual", $"mr_{partName}_{r}",
-                    $"    MR[{r}] '{mr.gameObject.name}' mesh={mf.sharedMesh.name} " +
-                    $"localPos={leaf.localPosition} localScale={leaf.localScale}", 60.0);
                 added = true;
             }
             if (variantSkipped > 0)
@@ -5546,7 +5531,7 @@ namespace Parsek
                 info.fireParticles = ps;
                 info.combinedEmissionMesh = combinedMesh;
 
-                ParsekLog.Log($"  ReentryFx: combined {combines.Count} meshes into emission shape " +
+                ParsekLog.Verbose("ReentryFx", $"combined {combines.Count} meshes into emission shape " +
                     $"({(combinedMesh != null ? combinedMesh.vertexCount : 0)} verts) for ghost #{ghostIndex}");
             }
 
@@ -5566,7 +5551,7 @@ namespace Parsek
                     info.allClonedMaterials.Add(shellMat);
                 }
 
-                ParsekLog.Log($"  ReentryFx: {info.fireShellMeshes.Count} meshes collected for fire shell overlay on ghost #{ghostIndex}");
+                ParsekLog.Verbose("ReentryFx", $"{info.fireShellMeshes.Count} meshes collected for fire shell overlay on ghost #{ghostIndex}");
             }
 
             return info;
@@ -5740,7 +5725,7 @@ namespace Parsek
             // Rebuild fire shell mesh list from active parts only
             info.fireShellMeshes = CollectFireShellMeshes(meshFilters, false);
 
-            ParsekLog.Log($"  ReentryFx: rebuilt emission mesh ({combines.Count} meshes, " +
+            ParsekLog.Verbose("ReentryFx", $"rebuilt emission mesh ({combines.Count} meshes, " +
                 $"{(info.combinedEmissionMesh != null ? info.combinedEmissionMesh.vertexCount : 0)} verts) " +
                 $"and {info.fireShellMeshes.Count} fire shell meshes after decouple");
         }
@@ -6179,7 +6164,7 @@ namespace Parsek
                 CelestialBody body = FlightGlobals.Bodies?.Find(b => b.name == evt.bodyName);
                 if (body == null)
                 {
-                    ParsekLog.Warn("GhostBuild",
+                    ParsekLog.Warn("GhostVisual",
                         $"Cannot spawn flag vessel: body '{evt.bodyName}' not found");
                     return null;
                 }
@@ -6226,12 +6211,12 @@ namespace Parsek
 
                 if (pv.vesselRef == null)
                 {
-                    ParsekLog.Warn("GhostBuild",
+                    ParsekLog.Warn("GhostVisual",
                         $"Flag vessel spawn failed: ProtoVessel.Load() produced null vesselRef");
                     return null;
                 }
 
-                ParsekLog.Verbose("GhostBuild",
+                ParsekLog.Verbose("GhostVisual",
                     $"Spawned flag vessel: '{vesselName}' by '{evt.placedBy}' " +
                     $"at ({evt.latitude:F4},{evt.longitude:F4},{evt.altitude:F1}) on {evt.bodyName}");
 
@@ -6239,7 +6224,7 @@ namespace Parsek
             }
             catch (System.Exception ex)
             {
-                ParsekLog.Error("GhostBuild",
+                ParsekLog.Error("GhostVisual",
                     $"Failed to spawn flag vessel: {ex.Message}");
                 return null;
             }
@@ -6272,7 +6257,7 @@ namespace Parsek
                 }
                 else
                 {
-                    ParsekLog.Warn("GhostBuild", "Could not find KSP/Emissive/Diffuse shader, using default");
+                    ParsekLog.Warn("GhostVisual", "Could not find KSP/Emissive/Diffuse shader, using default");
                 }
             }
 

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -4418,7 +4418,6 @@ namespace Parsek
             ref int meshCount, ref int damagedSkipped, ref int nullMeshSkipped)
         {
             int skinnedCloned = 0;
-            int partRootFallbackCount = 0;
             for (int r = 0; r < skinnedRenderers.Length; r++)
             {
                 var smr = skinnedRenderers[r];
@@ -4491,8 +4490,6 @@ namespace Parsek
                 ghostSmr.receiveShadows = smr.receiveShadows;
                 meshCount++;
                 skinnedCloned++;
-                if (usedPartRootFallbackForBones)
-                    partRootFallbackCount++;
             }
 
             return skinnedCloned;

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -7025,7 +7025,7 @@ namespace Parsek
                 if (state != null && state.ghost != null && state.ghost.activeSelf)
                 {
                     state.ghost.SetActive(false);
-                    ParsekLog.VerboseRateLimited("Zone", $"zone-hide-{recIdx}",
+                    ParsekLog.VerboseRateLimited("Zone", "zone-hide",
                         $"Ghost #{recIdx} \"{rec.VesselName}\" hidden: beyond visual range " +
                         $"({ghostDistance.ToString("F0", CultureInfo.InvariantCulture)}m)");
                 }
@@ -7036,7 +7036,7 @@ namespace Parsek
             if (state != null && state.ghost != null && !state.ghost.activeSelf)
             {
                 state.ghost.SetActive(true);
-                ParsekLog.VerboseRateLimited("Zone", $"zone-show-{recIdx}",
+                ParsekLog.VerboseRateLimited("Zone", "zone-show",
                     $"Ghost #{recIdx} \"{rec.VesselName}\" re-shown: entered visual range " +
                     $"({ghostDistance.ToString("F0", CultureInfo.InvariantCulture)}m)");
             }

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -7025,7 +7025,7 @@ namespace Parsek
                 if (state != null && state.ghost != null && state.ghost.activeSelf)
                 {
                     state.ghost.SetActive(false);
-                    ParsekLog.Info("Zone",
+                    ParsekLog.VerboseRateLimited("Zone", $"zone-hide-{recIdx}",
                         $"Ghost #{recIdx} \"{rec.VesselName}\" hidden: beyond visual range " +
                         $"({ghostDistance.ToString("F0", CultureInfo.InvariantCulture)}m)");
                 }
@@ -7036,7 +7036,7 @@ namespace Parsek
             if (state != null && state.ghost != null && !state.ghost.activeSelf)
             {
                 state.ghost.SetActive(true);
-                ParsekLog.Info("Zone",
+                ParsekLog.VerboseRateLimited("Zone", $"zone-show-{recIdx}",
                     $"Ghost #{recIdx} \"{rec.VesselName}\" re-shown: entered visual range " +
                     $"({ghostDistance.ToString("F0", CultureInfo.InvariantCulture)}m)");
             }

--- a/Source/Parsek/ParsekKSC.cs
+++ b/Source/Parsek/ParsekKSC.cs
@@ -133,7 +133,7 @@ namespace Parsek
                     if (kvp.Value.ghost != null && kvp.Value.ghost.activeSelf)
                     {
                         kvp.Value.ghost.SetActive(false);
-                        ParsekLog.Info("KSCGhost",
+                        ParsekLog.Verbose("KSCGhost",
                             $"Ghost #{kvp.Key} hidden: warp {warpRate.ToString("F1", CultureInfo.InvariantCulture)}x > {GhostPlaybackLogic.GhostHideWarpThreshold}x");
                     }
                 foreach (int key in new List<int>(kscOverlapGhosts.Keys))
@@ -150,7 +150,7 @@ namespace Parsek
                     // — clean up any active ghosts so they don't linger in the scene.
                     if (kscGhosts.ContainsKey(i))
                     {
-                        ParsekLog.Info("KSCGhost",
+                        ParsekLog.Verbose("KSCGhost",
                             $"Ghost #{i} \"{rec.VesselName}\" no longer eligible — destroying");
                         DestroyKscGhost(kscGhosts[i], i);
                         kscGhosts.Remove(i);
@@ -229,7 +229,7 @@ namespace Parsek
                     state.loopCycleIndex = cycleIndex;
                     kscGhosts[recIdx] = state;
                     if (loggedGhostSpawn.Add(recIdx))
-                        ParsekLog.Info("KSCGhost",
+                        ParsekLog.Verbose("KSCGhost",
                             $"Ghost #{recIdx} \"{rec.VesselName}\" entered range: " +
                             $"targetUT={targetUT:F1} recUT=[{rec.StartUT:F1},{rec.EndUT:F1}] " +
                             $"cycle={cycleIndex} loop={rec.LoopPlayback} " +
@@ -239,7 +239,7 @@ namespace Parsek
                 {
                     state.ghost.SetActive(true);
                     if (loggedReshow.Add(recIdx))
-                        ParsekLog.Info("KSCGhost",
+                        ParsekLog.Verbose("KSCGhost",
                             $"Ghost #{recIdx} \"{rec.VesselName}\" re-shown after warp-down");
                 }
 
@@ -346,7 +346,7 @@ namespace Parsek
                 if (primaryState == null) return;
                 primaryState.loopCycleIndex = lastCycle;
                 kscGhosts[recIdx] = primaryState;
-                ParsekLog.Info("KSCGhost",
+                ParsekLog.Verbose("KSCGhost",
                     $"Ghost #{recIdx} \"{rec.VesselName}\" overlap spawn cycle={lastCycle}");
             }
 
@@ -494,7 +494,7 @@ namespace Parsek
             // Initialize flag event index — flags are spawned as real vessels on-demand by ApplyFlagEvents
             GhostPlaybackLogic.InitializeFlagVisibility(rec, state);
 
-            ParsekLog.Info("KSCGhost",
+            ParsekLog.Verbose("KSCGhost",
                 $"Ghost #{index} \"{rec.VesselName}\" spawned" +
                 $" (engines={buildResult.engineInfos?.Count ?? 0}" +
                 $" rcs={buildResult.rcsInfos?.Count ?? 0}" +
@@ -753,7 +753,8 @@ namespace Parsek
             if (state.ghost != null)
                 Destroy(state.ghost);
 
-            ParsekLog.Verbose("KSCGhost", $"Ghost #{index} destroyed");
+            ParsekLog.VerboseRateLimited("KSCGhost", "ghost-destroyed",
+                $"Ghost #{index} destroyed", 2.0);
         }
 
         #endregion
@@ -761,14 +762,21 @@ namespace Parsek
         void OnDestroy()
         {
             // Clean up all KSC ghosts (primary + overlap)
+            int primaryCount = kscGhosts.Count;
             foreach (var kv in kscGhosts)
                 DestroyKscGhost(kv.Value, kv.Key);
             kscGhosts.Clear();
 
+            int overlapCount = 0;
             foreach (var kv in kscOverlapGhosts)
+            {
+                overlapCount += kv.Value.Count;
                 for (int i = 0; i < kv.Value.Count; i++)
                     DestroyKscGhost(kv.Value[i], kv.Key);
+            }
             kscOverlapGhosts.Clear();
+            if (primaryCount + overlapCount > 0)
+                ParsekLog.Info("KSCGhost", $"Destroyed {primaryCount} primary + {overlapCount} overlap KSC ghosts");
             loggedGhostSpawn.Clear();
             loggedReshow.Clear();
 

--- a/Source/Parsek/ParsekLog.cs
+++ b/Source/Parsek/ParsekLog.cs
@@ -51,11 +51,6 @@ namespace Parsek
             ResetRateLimitsForTesting();
         }
 
-        public static void Log(string message)
-        {
-            Info("General", message);
-        }
-
         public static void Info(string subsystem, string message)
         {
             Write("INFO", subsystem, message);

--- a/Source/Parsek/ParsekPlaybackPolicy.cs
+++ b/Source/Parsek/ParsekPlaybackPolicy.cs
@@ -146,7 +146,7 @@ namespace Parsek
                     return;
                 }
 
-                engine.DestroyGhost(evt.Index, evt.Trajectory, evt.Flags);
+                engine.DestroyGhost(evt.Index, evt.Trajectory, evt.Flags, reason: "playback completed");
             }
         }
 

--- a/Source/Parsek/ParsekPlaybackPolicy.cs
+++ b/Source/Parsek/ParsekPlaybackPolicy.cs
@@ -158,14 +158,14 @@ namespace Parsek
 
         private void HandleLoopRestarted(LoopRestartedEvent evt)
         {
-            ParsekLog.Verbose("Policy",
+            ParsekLog.VerboseRateLimited("Policy", "loop-restarted",
                 $"LoopRestarted index={evt.Index} cycle={evt.PreviousCycleIndex}->{evt.NewCycleIndex} " +
                 $"explosion={evt.ExplosionFired}");
         }
 
         private void HandleOverlapExpired(OverlapExpiredEvent evt)
         {
-            ParsekLog.Verbose("Policy",
+            ParsekLog.VerboseRateLimited("Policy", "overlap-expired",
                 $"OverlapExpired index={evt.Index} cycle={evt.CycleIndex} explosion={evt.ExplosionFired}");
         }
 

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -563,7 +563,7 @@ namespace Parsek
                     status = "IN PROGRESS";
                 else
                     status = "past";
-                ParsekLog.Info("Scenario", $"  #{i}: \"{loadedRec.VesselName}\" — {status}");
+                ParsekLog.Verbose("Scenario", $"  #{i}: \"{loadedRec.VesselName}\" — {status}");
             }
 
             if (CrewReservationManager.CrewReplacements.Count > 0)
@@ -1174,7 +1174,7 @@ namespace Parsek
                 string chainInfo = !string.IsNullOrEmpty(rec.ChainId)
                     ? $", chain={rec.ChainId.Substring(0, System.Math.Min(8, rec.ChainId.Length))}../{rec.ChainIndex}" : "";
                 string enabledInfo = !rec.PlaybackEnabled ? ", DISABLED" : "";
-                ScenarioLog($"[Parsek Scenario] Loaded recording: {rec.VesselName}, " +
+                ParsekLog.Verbose("Scenario", $"Loaded recording: {rec.VesselName}, " +
                     $"{rec.Points.Count} points, {rec.OrbitSegments.Count} orbit segments" +
                     (rec.Points.Count > 0 ? $", UT {rec.StartUT:F0}-{rec.EndUT:F0}" : ", degraded (0 points)") +
                     (rec.VesselSnapshot != null ? " (vessel spawn)" :

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -71,19 +71,38 @@ namespace Parsek
             node.RemoveNodes("RECORDING_TREE");
             var committedTrees = RecordingStore.CommittedTrees;
             ParsekLog.Info("Scenario", $"OnSave: saving {committedTrees.Count} committed tree(s)");
-            for (int t = 0; t < committedTrees.Count; t++)
             {
-                var tree = committedTrees[t];
-
-                // Write bulk data to external files for each recording in the tree
-                foreach (var rec in tree.Recordings.Values)
+                int treeRecCount = 0;
+                int treeTotalPoints = 0;
+                int treeTotalOrbitSegments = 0;
+                int treeTotalPartEvents = 0;
+                int treeWithTrackSections = 0;
+                int treeWithSnapshots = 0;
+                for (int t = 0; t < committedTrees.Count; t++)
                 {
-                    if (!RecordingStore.SaveRecordingFiles(rec))
-                        ScenarioLog($"[Parsek Scenario] WARNING: File write failed for tree recording '{rec.VesselName}'");
-                }
+                    var tree = committedTrees[t];
 
-                ConfigNode treeNode = node.AddNode("RECORDING_TREE");
-                tree.Save(treeNode);
+                    // Write bulk data to external files for each recording in the tree
+                    foreach (var rec in tree.Recordings.Values)
+                    {
+                        if (!RecordingStore.SaveRecordingFiles(rec))
+                            ScenarioLog($"[Parsek Scenario] WARNING: File write failed for tree recording '{rec.VesselName}'");
+                        treeRecCount++;
+                        treeTotalPoints += rec.Points.Count;
+                        treeTotalOrbitSegments += rec.OrbitSegments.Count;
+                        treeTotalPartEvents += rec.PartEvents.Count;
+                        if (rec.TrackSections != null && rec.TrackSections.Count > 0) treeWithTrackSections++;
+                        if (rec.VesselSnapshot != null) treeWithSnapshots++;
+                    }
+
+                    ConfigNode treeNode = node.AddNode("RECORDING_TREE");
+                    tree.Save(treeNode);
+                }
+                if (committedTrees.Count > 0)
+                    ParsekLog.Verbose("Scenario",
+                        $"Saved {committedTrees.Count} trees ({treeRecCount} recordings): {treeTotalPoints} points, " +
+                        $"{treeTotalOrbitSegments} orbit segments, {treeTotalPartEvents} part events, " +
+                        $"{treeWithTrackSections} with track sections, {treeWithSnapshots} with snapshots");
             }
 
             // Persist crew replacement mappings
@@ -748,6 +767,12 @@ namespace Parsek
 
             if (treeNodes.Length > 0)
             {
+                int treeRecCount = 0;
+                int treeTotalPoints = 0;
+                int treeTotalOrbitSegments = 0;
+                int treeTotalPartEvents = 0;
+                int treeWithTrackSections = 0;
+                int treeWithSnapshots = 0;
                 for (int t = 0; t < treeNodes.Length; t++)
                 {
                     var tree = RecordingTree.Load(treeNodes[t]);
@@ -764,11 +789,21 @@ namespace Parsek
                     foreach (var rec in tree.Recordings.Values)
                     {
                         recordings.Add(rec);
+                        treeRecCount++;
+                        treeTotalPoints += rec.Points.Count;
+                        treeTotalOrbitSegments += rec.OrbitSegments.Count;
+                        treeTotalPartEvents += rec.PartEvents.Count;
+                        if (rec.TrackSections != null && rec.TrackSections.Count > 0) treeWithTrackSections++;
+                        if (rec.VesselSnapshot != null) treeWithSnapshots++;
                     }
 
                     ScenarioLog($"[Parsek Scenario] Loaded tree '{tree.TreeName}': " +
                         $"{tree.Recordings.Count} recordings, {tree.BranchPoints.Count} branch points");
                 }
+                ParsekLog.Verbose("Scenario",
+                    $"Loaded {treeNodes.Length} trees ({treeRecCount} recordings): {treeTotalPoints} points, " +
+                    $"{treeTotalOrbitSegments} orbit segments, {treeTotalPartEvents} part events, " +
+                    $"{treeWithTrackSections} with track sections, {treeWithSnapshots} with snapshots");
             }
         }
 
@@ -999,6 +1034,11 @@ namespace Parsek
         private static void LoadStandaloneRecordingsFromNodes(
             ConfigNode[] recNodes, List<Recording> recordings)
         {
+            int totalPoints = 0;
+            int totalOrbitSegments = 0;
+            int totalPartEvents = 0;
+            int withTrackSections = 0;
+            int withSnapshots = 0;
             for (int r = 0; r < recNodes.Length; r++)
             {
                 var recNode = recNodes[r];
@@ -1129,6 +1169,11 @@ namespace Parsek
                 // Always add — even degraded recordings (missing .prec → 0 points)
                 // must occupy their slot to preserve index-based revert mapping.
                 recordings.Add(rec);
+                totalPoints += rec.Points.Count;
+                totalOrbitSegments += rec.OrbitSegments.Count;
+                totalPartEvents += rec.PartEvents.Count;
+                if (rec.TrackSections != null && rec.TrackSections.Count > 0) withTrackSections++;
+                if (rec.VesselSnapshot != null) withSnapshots++;
                 string phaseInfo = !string.IsNullOrEmpty(rec.SegmentPhase)
                     ? $", phase={rec.SegmentBodyName} {rec.SegmentPhase}" : "";
                 string chainInfo = !string.IsNullOrEmpty(rec.ChainId)
@@ -1141,6 +1186,9 @@ namespace Parsek
                      rec.GhostVisualSnapshot != null ? " (ghost-only)" : "") +
                     phaseInfo + chainInfo + enabledInfo);
             }
+            ParsekLog.Verbose("Scenario",
+                $"Loaded {recNodes.Length} standalone recordings: {totalPoints} points, {totalOrbitSegments} orbit segments, " +
+                $"{totalPartEvents} part events, {withTrackSections} with track sections, {withSnapshots} with snapshots");
         }
 
         /// <summary>
@@ -1266,6 +1314,11 @@ namespace Parsek
         private static void SaveStandaloneRecordings(ConfigNode node, List<Recording> recordings)
         {
             int count = 0;
+            int totalPoints = 0;
+            int totalOrbitSegments = 0;
+            int totalPartEvents = 0;
+            int withTrackSections = 0;
+            int withSnapshots = 0;
             for (int r = 0; r < recordings.Count; r++)
             {
                 var rec = recordings[r];
@@ -1274,6 +1327,11 @@ namespace Parsek
                 if (rec.TreeId != null)
                     continue;
                 count++;
+                totalPoints += rec.Points.Count;
+                totalOrbitSegments += rec.OrbitSegments.Count;
+                totalPartEvents += rec.PartEvents.Count;
+                if (rec.TrackSections != null && rec.TrackSections.Count > 0) withTrackSections++;
+                if (rec.VesselSnapshot != null) withSnapshots++;
 
                 ConfigNode recNode = node.AddNode("RECORDING");
 
@@ -1335,7 +1393,9 @@ namespace Parsek
                 // Persist resource index so quickload doesn't re-apply deltas
                 recNode.AddValue("lastResIdx", rec.LastAppliedResourceIndex);
             }
-            ParsekLog.Verbose("Scenario", $"Saved {count} standalone recordings");
+            ParsekLog.Verbose("Scenario",
+                $"Saved {count} standalone recordings: {totalPoints} points, {totalOrbitSegments} orbit segments, " +
+                $"{totalPartEvents} part events, {withTrackSections} with track sections, {withSnapshots} with snapshots");
         }
 
         /// <summary>
@@ -1385,10 +1445,6 @@ namespace Parsek
             if (rec.Hidden)
                 recNode.AddValue("hidden", rec.Hidden.ToString());
 
-            ParsekLog.Verbose("Scenario", $"Saved metadata: id={rec.RecordingId}, " +
-                $"phase={rec.SegmentPhase ?? "(none)"}, body={rec.SegmentBodyName ?? "(none)"}, " +
-                $"playback={rec.PlaybackEnabled}, hidden={rec.Hidden}, chain={rec.ChainId ?? "(none)"}/{rec.ChainIndex}, " +
-                $"preLaunch=[F={rec.PreLaunchFunds:F0}, S={rec.PreLaunchScience:F1}, R={rec.PreLaunchReputation:F1}]");
         }
 
         /// <summary>
@@ -1544,10 +1600,6 @@ namespace Parsek
                     rec.Hidden = hidden;
             }
 
-            ParsekLog.Verbose("Scenario", $"Loaded metadata: id={rec.RecordingId}, " +
-                $"phase={rec.SegmentPhase ?? "(none)"}, body={rec.SegmentBodyName ?? "(none)"}, " +
-                $"playback={rec.PlaybackEnabled}, hidden={rec.Hidden}, chain={rec.ChainId ?? "(none)"}/{rec.ChainIndex}, " +
-                $"preLaunch=[F={rec.PreLaunchFunds:F0}, S={rec.PreLaunchScience:F1}, R={rec.PreLaunchReputation:F1}]");
         }
 
         /// <summary>

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -71,39 +71,34 @@ namespace Parsek
             node.RemoveNodes("RECORDING_TREE");
             var committedTrees = RecordingStore.CommittedTrees;
             ParsekLog.Info("Scenario", $"OnSave: saving {committedTrees.Count} committed tree(s)");
+            int treeRecCount = 0;
+            int treeTotalPoints = 0, treeTotalOrbitSegments = 0, treeTotalPartEvents = 0;
+            int treeWithTrackSections = 0, treeWithSnapshots = 0;
+            for (int t = 0; t < committedTrees.Count; t++)
             {
-                int treeRecCount = 0;
-                int treeTotalPoints = 0;
-                int treeTotalOrbitSegments = 0;
-                int treeTotalPartEvents = 0;
-                int treeWithTrackSections = 0;
-                int treeWithSnapshots = 0;
-                for (int t = 0; t < committedTrees.Count; t++)
+                var tree = committedTrees[t];
+
+                // Write bulk data to external files for each recording in the tree
+                foreach (var rec in tree.Recordings.Values)
                 {
-                    var tree = committedTrees[t];
-
-                    // Write bulk data to external files for each recording in the tree
-                    foreach (var rec in tree.Recordings.Values)
-                    {
-                        if (!RecordingStore.SaveRecordingFiles(rec))
-                            ScenarioLog($"[Parsek Scenario] WARNING: File write failed for tree recording '{rec.VesselName}'");
-                        treeRecCount++;
-                        treeTotalPoints += rec.Points.Count;
-                        treeTotalOrbitSegments += rec.OrbitSegments.Count;
-                        treeTotalPartEvents += rec.PartEvents.Count;
-                        if (rec.TrackSections != null && rec.TrackSections.Count > 0) treeWithTrackSections++;
-                        if (rec.VesselSnapshot != null) treeWithSnapshots++;
-                    }
-
-                    ConfigNode treeNode = node.AddNode("RECORDING_TREE");
-                    tree.Save(treeNode);
+                    if (!RecordingStore.SaveRecordingFiles(rec))
+                        ScenarioLog($"[Parsek Scenario] WARNING: File write failed for tree recording '{rec.VesselName}'");
+                    treeRecCount++;
+                    treeTotalPoints += rec.Points.Count;
+                    treeTotalOrbitSegments += rec.OrbitSegments.Count;
+                    treeTotalPartEvents += rec.PartEvents.Count;
+                    if (rec.TrackSections != null && rec.TrackSections.Count > 0) treeWithTrackSections++;
+                    if (rec.VesselSnapshot != null) treeWithSnapshots++;
                 }
-                if (committedTrees.Count > 0)
-                    ParsekLog.Verbose("Scenario",
-                        $"Saved {committedTrees.Count} trees ({treeRecCount} recordings): {treeTotalPoints} points, " +
-                        $"{treeTotalOrbitSegments} orbit segments, {treeTotalPartEvents} part events, " +
-                        $"{treeWithTrackSections} with track sections, {treeWithSnapshots} with snapshots");
+
+                ConfigNode treeNode = node.AddNode("RECORDING_TREE");
+                tree.Save(treeNode);
             }
+            if (committedTrees.Count > 0)
+                ParsekLog.Verbose("Scenario",
+                    $"Saved {committedTrees.Count} trees ({treeRecCount} recordings): {treeTotalPoints} points, " +
+                    $"{treeTotalOrbitSegments} orbit segments, {treeTotalPartEvents} part events, " +
+                    $"{treeWithTrackSections} with track sections, {treeWithSnapshots} with snapshots");
 
             // Persist crew replacement mappings
             CrewReservationManager.SaveCrewReplacements(node);

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -1893,8 +1893,6 @@ namespace Parsek
             for (int s = 0; s < segNodes.Length; s++)
                 rec.OrbitSegments.Add(DeserializeOrbitSegment(segNodes[s], ns, ic));
 
-            if (!SuppressLogging)
-                ParsekLog.Verbose("RecordingStore", $"Deserialized {rec.OrbitSegments.Count} orbit segments");
         }
 
         /// <summary>
@@ -1970,8 +1968,6 @@ namespace Parsek
                 rec.FlagEvents.Add(evt);
             }
 
-            if (feNodes.Length > 0)
-                Log($"[Recording] Deserialized {feNodes.Length} flag event(s) for recording {rec.RecordingId}");
         }
 
         /// <summary>
@@ -1995,7 +1991,6 @@ namespace Parsek
                     evtNode.AddValue("details", evt.details);
             }
 
-            Log($"[Recording] SerializeSegmentEvents: {events.Count} segment events serialized");
         }
 
         /// <summary>
@@ -2048,7 +2043,8 @@ namespace Parsek
                 events.Add(evt);
             }
 
-            Log($"[Recording] DeserializeSegmentEvents: {events.Count} deserialized, {skipped} skipped (of {seNodes.Length} total)");
+            if (skipped > 0)
+                ParsekLog.Warn("RecordingStore", $"DeserializeSegmentEvents: {skipped}/{seNodes.Length} events skipped");
         }
 
         /// <summary>
@@ -2060,7 +2056,6 @@ namespace Parsek
         {
             if (tracks == null || tracks.Count == 0)
             {
-                ParsekLog.Verbose("RecordingStore", "SerializeTrackSections: 0 track sections to serialize");
                 return;
             }
 
@@ -2113,15 +2108,7 @@ namespace Parsek
                     }
                 }
 
-                int frameCount = track.frames?.Count ?? 0;
-                int checkpointCount = track.checkpoints?.Count ?? 0;
-                ParsekLog.Verbose("RecordingStore",
-                    $"SerializeTrackSections: [{t}] env={track.environment} ref={track.referenceFrame} " +
-                    $"frames={frameCount} checkpoints={checkpointCount}");
             }
-
-            ParsekLog.Verbose("RecordingStore",
-                $"SerializeTrackSections: serialized {tracks.Count} track section(s)");
         }
 
         /// <summary>
@@ -2137,7 +2124,6 @@ namespace Parsek
             ConfigNode[] tsNodes = parent.GetNodes("TRACK_SECTION");
             if (tsNodes.Length == 0)
             {
-                ParsekLog.Verbose("RecordingStore", "DeserializeTrackSections: no TRACK_SECTION nodes found");
                 return;
             }
 
@@ -2238,16 +2224,7 @@ namespace Parsek
                     section.checkpoints = new List<OrbitSegment>();
 
                 tracks.Add(section);
-
-                int frameCount = section.frames.Count;
-                int checkpointCount = section.checkpoints.Count;
-                ParsekLog.Verbose("RecordingStore",
-                    $"DeserializeTrackSections: [{t}] env={section.environment} ref={section.referenceFrame} " +
-                    $"frames={frameCount} checkpoints={checkpointCount}");
             }
-
-            ParsekLog.Verbose("RecordingStore",
-                $"DeserializeTrackSections: deserialized {tracks.Count} track section(s) from {tsNodes.Length} node(s)");
         }
 
         #endregion
@@ -2327,11 +2304,6 @@ namespace Parsek
                     else if (!File.Exists(ghostPath))
                         SafeWriteConfigNode(rec.GhostVisualSnapshot, ghostPath);
                 }
-
-                ParsekLog.Verbose("RecordingStore",
-                    $"Saved recording files for {rec.RecordingId}: points={rec.Points.Count}, " +
-                    $"orbitSegments={rec.OrbitSegments.Count}, partEvents={rec.PartEvents.Count}, " +
-                    $"hasVesselSnapshot={rec.VesselSnapshot != null}, hasGhostSnapshot={rec.GhostVisualSnapshot != null}");
 
                 return true;
             }
@@ -2413,11 +2385,6 @@ namespace Parsek
                 // Backward compat: if no ghost snapshot, fall back to vessel snapshot
                 if (rec.GhostVisualSnapshot == null && rec.VesselSnapshot != null)
                     rec.GhostVisualSnapshot = rec.VesselSnapshot.CreateCopy();
-
-                ParsekLog.Verbose("RecordingStore",
-                    $"Loaded recording files for {rec.RecordingId}: points={rec.Points.Count}, " +
-                    $"orbitSegments={rec.OrbitSegments.Count}, partEvents={rec.PartEvents.Count}, " +
-                    $"hasVesselSnapshot={rec.VesselSnapshot != null}, hasGhostSnapshot={rec.GhostVisualSnapshot != null}");
 
                 return true;
             }

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -1894,7 +1894,7 @@ namespace Parsek
                 rec.OrbitSegments.Add(DeserializeOrbitSegment(segNodes[s], ns, ic));
 
             if (!SuppressLogging)
-                ParsekLog.Verbose("Store", $"Deserialized {rec.OrbitSegments.Count} orbit segments");
+                ParsekLog.Verbose("RecordingStore", $"Deserialized {rec.OrbitSegments.Count} orbit segments");
         }
 
         /// <summary>

--- a/Source/Parsek/RenderingZoneManager.cs
+++ b/Source/Parsek/RenderingZoneManager.cs
@@ -70,7 +70,7 @@ namespace Parsek
         internal static void LogZoneTransition(string ghostId, RenderingZone oldZone, RenderingZone newZone, double distanceMeters)
         {
             string distStr = distanceMeters.ToString("F0", CultureInfo.InvariantCulture);
-            ParsekLog.Info("Zone",
+            ParsekLog.VerboseRateLimited("Zone", "zone-transition",
                 $"Zone transition: ghost={ghostId} {oldZone}->{newZone} dist={distStr}m");
         }
 

--- a/Source/Parsek/SpawnWarningUI.cs
+++ b/Source/Parsek/SpawnWarningUI.cs
@@ -102,7 +102,7 @@ namespace Parsek
                     chain.SpawnUT.ToString("F0", IC));
             }
 
-            ParsekLog.Verbose(Tag,
+            ParsekLog.VerboseRateLimited(Tag, "chain-status",
                 string.Format(IC,
                     "FormatChainStatus: vessel={0} terminated={1} blocked={2} walkbackExhausted={3} -> \"{4}\"",
                     name, chain.IsTerminated, chain.SpawnBlocked, chain.WalkbackExhausted, status));

--- a/docs/dev/log-audit-2026-03-25.md
+++ b/docs/dev/log-audit-2026-03-25.md
@@ -1,0 +1,112 @@
+# Log Audit — 2026-03-25
+
+## Session Analyzed
+
+- **File:** `ksp-log-2026-03-25.log`
+- **Duration:** ~70 seconds (22:19:27–22:20:37)
+- **Scene:** KSC ghost playback, 273 recordings loaded, 252 unique ghost IDs
+- **Total lines:** 28,923
+- **Parsek lines:** 19,771 (68.4% of all log output)
+
+## Breakdown by Level
+
+| Level | Count | % of Parsek |
+|-------|-------|-------------|
+| VERBOSE | 14,977 | 75.7% |
+| INFO | 4,794 | 24.3% |
+| WARN | 0 | 0% |
+| ERR | 0 | 0% |
+
+## Top VERBOSE Subsystems
+
+| Subsystem | Count | % of VERBOSE | Notes |
+|-----------|-------|--------------|-------|
+| GhostVisual | 4,402 | 29.4% | Per-MR diagnostic on every ghost build |
+| Engine | 2,551 | 17.0% | Per-ghost spawn/destroy/overlap lifecycle |
+| KSCGhost | 2,001 | 13.4% | Per-ghost KSC lifecycle |
+| Flight | 1,462 | 9.8% | Part event application logs |
+| RecordingStore | 1,429 | 9.5% | Deserialization diagnostics |
+| Scenario | 1,107 | 7.4% | Load/save diagnostics |
+| Policy | 1,026 | 6.9% | Per-ghost playback decisions |
+| ExplosionFx | 304 | 2.0% | |
+| Store | 273 | 1.8% | Redundant with RecordingStore |
+| GameStateStore | 114 | 0.8% | |
+
+## Top INFO Subsystems
+
+| Subsystem | Count | % of INFO | Notes |
+|-----------|-------|-----------|-------|
+| General | 2,651 | 55.3% | **Wrong tag** — 26 ParsekLog.Log() calls bypass subsystem |
+| KSCGhost | 1,347 | 28.1% | Per-ghost spawn messages |
+| Scenario | 594 | 12.4% | Load/save lifecycle |
+| Engine | 116 | 2.4% | |
+
+## Top 10 Most Repeated Message Patterns
+
+| # | Count | Level | Pattern |
+|---|-------|-------|---------|
+| 1 | 1,074 | INFO | `ReentryFx: combined N meshes into emission shape (N verts) for ghost #N` |
+| 2 | 1,074 | INFO | `ReentryFx: N meshes collected for fire shell overlay on ghost #N` |
+| 3 | 1,041 | VERBOSE | `MR[N] 'name' mesh= localPos=(...) localScale=(...)` |
+| 4 | 913 | INFO | `Ghost #N destroyed` |
+| 5 | 876 | INFO | `Applied N part events for ghost #N (evtIdx now N)` |
+| 6 | 502 | VERBOSE | `Ghost built: N/N parts with visuals` |
+| 7 | 485 | INFO | `LoopRestarted index=N cycle=N->N explosion=False` |
+| 8 | 546 | VERBOSE | `Deserialized N orbit segments` / `no TRACK_SECTION nodes` |
+| 9 | 506 | INFO | `Timeline ghost #N: built from recording-start snapshot` |
+| 10 | 259 | INFO | `Ghost #N spawned: snapshot=True parts=N engines=N rcs=N` |
+
+## Worst Burst
+
+**277 consecutive** `Ghost #N destroyed` messages during a single mass-teardown event (22:20:22).
+
+**Peak second (22:20:18):** 4,911 Parsek lines — GhostVisual MR diagnostics (3,845), KSCGhost spawns (712), part events (249).
+
+## Critical Code Issues
+
+### 1. ReentryFx at INFO level (2,148 lines)
+Two INFO-level messages fire per ghost build. With 1,074 ghost builds in 70s, these are the #1 INFO spam source. Should be VERBOSE.
+
+### 2. FlightRecorder "Recorded point" not rate-limited
+`FlightRecorder.cs:4451` logs every trajectory point at `Verbose` without rate limiting. ~50 lines/sec during recording. Must be `VerboseRateLimited`.
+
+### 3. 26 ParsekLog.Log() calls bypass subsystem tagging
+`EngineFxBuilder.cs` (16) and `GhostVisualBuilder.cs` (10) use `ParsekLog.Log()` which routes to `[General]`. These produce 2,651 of the 4,794 INFO lines — more than half of all INFO output has no useful subsystem tag.
+
+### 4. Mass ghost teardown not batched
+277 individual `Ghost #N destroyed` messages in a single teardown. Should be one summary line with VERBOSE per-ghost detail.
+
+### 5. Per-MeshRenderer VERBOSE diagnostics on every ghost build
+`MR[N]` lines (1,041), `[DIAG]` modelRoot dumps (247), per-part summary (249) — all fire on every ghost build including loop-cycle rebuilds. Should be rate-limited per part name.
+
+### 6. 63 subsystem tags with redundancy
+`Store` vs `RecordingStore`, `GhostBuild` vs `GhostVisual`, `General` (untagged). Need consolidation.
+
+## Fix Plan
+
+| Priority | Fix | Expected Reduction |
+|----------|-----|-------------------|
+| P0 | ReentryFx INFO→VERBOSE | -2,148 INFO lines |
+| P0 | FlightRecorder point logging → VRL | ~50 lines/sec during recording |
+| P1 | Batch ghost teardown to summary | -900+ INFO lines |
+| P1 | Fix 26 Log()→Info() with proper tags | 0 lines reduced but 2,651 properly tagged |
+| P2 | Rate-limit GhostVisual per-MR diagnostics | -4,000+ VERBOSE lines |
+| P3 | Consolidate subsystem tags | Readability improvement |
+
+## Codebase Logging Metrics
+
+| Level | Call Sites | Notes |
+|-------|-----------|-------|
+| ParsekLog.Log | 26 | All in EngineFxBuilder + GhostVisualBuilder. Wrong subsystem. |
+| Info | 486 | |
+| Warn | 215 | |
+| Verbose | 616 | 1 confirmed per-frame without rate limit |
+| VerboseRateLimited | 135 | |
+| Error | 23 | |
+| **Total** | **1,501** | |
+
+## Non-Parsek KSP Warnings (for reference)
+
+- 24x `WheelCollider requires an attached Rigidbody` — stock KSP
+- 24x texture compression warnings (1 is Parsek's `parsek_38.png` — non-power-of-2)
+- 5x KSP errors (missing Trajectories mod, TextureLoader)

--- a/docs/dev/log-audit-2026-03-25.md
+++ b/docs/dev/log-audit-2026-03-25.md
@@ -90,7 +90,7 @@ Two INFO-level messages fire per ghost build. With 1,074 ghost builds in 70s, th
 | P0 | FlightRecorder point logging → VRL | ~50 lines/sec during recording |
 | P1 | Batch ghost teardown to summary | -900+ INFO lines |
 | P1 | Fix 26 Log()→Info() with proper tags | 0 lines reduced but 2,651 properly tagged |
-| P2 | Rate-limit GhostVisual per-MR diagnostics | -4,000+ VERBOSE lines |
+| P2 | Remove GhostVisual per-MR diagnostics (per-part summary sufficient) | -4,000+ VERBOSE lines |
 | P3 | Consolidate subsystem tags | Readability improvement |
 
 ## Codebase Logging Metrics

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1664,6 +1664,22 @@ Log evidence: `CrewStatusChanged 'Bob Kerman' Assigned → Missing` at UT 115.6,
 
 **Status:** Open
 
+## 138. [v0.5.3] Log spam audit: untagged messages, wrong levels, per-renderer noise
+
+Comprehensive log audit of a 70-second KSC session with 273 recordings. Parsek produced 19,771 lines (68.4% of all KSP.log output). Three categories of issues found and fixed:
+
+1. **Untagged messages (2,651 INFO lines):** 26 `ParsekLog.Log()` calls in EngineFxBuilder (16) and GhostVisualBuilder (10) bypassed subsystem tagging — all appeared as `[General]`, making grep-by-subsystem useless for 55% of INFO output. Migrated to proper `Verbose("EngineFx")` / `Verbose("GhostVisual")` / `Info("GhostVisual")`. Deleted `ParsekLog.Log()` method.
+
+2. **Wrong log levels (3,495 INFO lines):** ReentryFx mesh combination messages (2×1,074 = 2,148 lines) fired per ghost build at INFO — should be VERBOSE. KSC per-ghost spawn/enter/reshow/destroy messages (1,347 lines) at INFO — per-ghost detail is VERBOSE, batch summary is INFO.
+
+3. **Per-renderer VERBOSE noise (~5,000+ lines):** Individual `MR[N]`/`SMR[N]` logs (1,041), per-renderer damaged-wheel skip logs, and per-SMR bone fallback logs all used per-renderer rate-limit keys, producing one log per unique renderer across all ghost builds. Removed — the per-part summary already captures the same totals.
+
+Additionally: FlightRecorder `Recorded point` Verbose → VerboseRateLimited (5s), overlap ghost destroy rate-limited, KSC ghost destroy rate-limited, `Store`→`RecordingStore` and `GhostBuild`→`GhostVisual` tag consolidation.
+
+Full analysis in `docs/dev/log-audit-2026-03-25.md`.
+
+**Status:** Fixed
+
 # In-Game Tests
 
 - [ ] Vessels propagate naturally along orbits after FF (no position freezing)

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1638,7 +1638,7 @@ Different from #117 (CanRewind/CanFastForward UI spam, now fixed) and #121 (Ghos
 
 **Priority:** High — blocks effective log analysis
 
-**Status:** Open
+**Status:** Fixed — per-frame VERBOSE logs removed; reason returned to caller via out-parameter tuple. Garbled comments from partial edit cleaned up in log audit PR.
 
 ## 136. ParsePartPositions: 0/N parts parsed from vessel snapshot
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1680,6 +1680,8 @@ Additionally: FlightRecorder `Recorded point` Verbose → VerboseRateLimited (5s
 
 **Round 3:** Serialization batch summaries. Removed 12 per-recording Verbose logs in RecordingStore + 2 per-recording metadata logs in ParsekScenario (~2,900 lines per save/load cycle). Added 4 batch summaries with aggregate counters. DeserializeSegmentEvents changed to Warn-only on skip.
 
+**Round 4:** Remaining spam from post-R3 analysis. SpawnWarning FormatChainStatus VRL'd (1,165 lines per-frame poll). Zone transitions Info→VRL shared key (501 lines, 248-line bursts). Scenario per-recording index dump Info→Verbose (390 lines). Per-recording "Loaded recording:" Info→Verbose (278 lines). "Triggering explosion" Info→VRL per-index 10s (406 lines). Net result: Parsek output rate dropped from 16,947/min (pre-fix) to 1,327/min (post-R3) — **92.2% reduction**.
+
 Full analysis in `docs/dev/log-audit-2026-03-25.md`.
 
 **Status:** Fixed

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1676,6 +1676,10 @@ Comprehensive log audit of a 70-second KSC session with 273 recordings. Parsek p
 
 Additionally: FlightRecorder `Recorded point` Verbose → VerboseRateLimited (5s), overlap ghost destroy rate-limited, KSC ghost destroy rate-limited, `Store`→`RecordingStore` and `GhostBuild`→`GhostVisual` tag consolidation.
 
+**Round 2:** Ghost lifecycle batch logging. Replaced per-ghost spawn/destroy/build VRL logs (15,489 Engine VERBOSE lines) with per-frame counters and one summary. Added `reason` parameter to DestroyGhost (7 annotated call sites). Removed ShouldTriggerExplosion skip logs (1,959 lines), CrewReservation null-snapshot log (515 lines). Changed overlap/explosion/loop lifecycle VRL from per-index to shared keys. Downgraded Zone rendering per-ghost transitions from Info to VRL (1,008 lines). Fixed 12 garbled comments in ShouldSpawnAtRecordingEnd (#135).
+
+**Round 3:** Serialization batch summaries. Removed 12 per-recording Verbose logs in RecordingStore + 2 per-recording metadata logs in ParsekScenario (~2,900 lines per save/load cycle). Added 4 batch summaries with aggregate counters. DeserializeSegmentEvents changed to Warn-only on skip.
+
 Full analysis in `docs/dev/log-audit-2026-03-25.md`.
 
 **Status:** Fixed


### PR DESCRIPTION
## Summary

Data-driven log spam audit across 4 rounds. Analyzed three KSP.log sessions (70s, 11.5min, 23min) with 273-293 recordings. Parsek output rate reduced from **16,947 lines/min to 1,327 lines/min** — a **92.2% reduction** with full debug capability preserved.

### Round 1 — Tag cleanup + level fixes
- **Removed `ParsekLog.Log()`** — 26 call sites migrated to proper `Verbose`/`Info` with subsystem tags; method deleted
- **Level downgrades** — ReentryFx `Info→Verbose` (-2,148), KSC per-ghost spawn/destroy `Info→Verbose` (-1,347)
- **Rate limiting** — FlightRecorder point logging `Verbose→VRL`, mass ghost teardown batched
- **Per-renderer removal** — MR/SMR/damaged-wheel per-renderer logs removed (per-part summary sufficient)
- **Tag consolidation** — `Store→RecordingStore`, `GhostBuild→GhostVisual`

### Round 2 — Ghost lifecycle batching
- **Frame batch summary** — per-ghost spawn/destroy/build VRL logs (15,489 lines) replaced with per-frame counters + 1 summary line
- **DestroyGhost reason parameter** — 7+ call sites annotated with reason strings (`"cycle transition"`, `"soft cap despawn"`, etc.)
- **Removed noise** — ShouldTriggerExplosion skip logs (1,959), CrewReservation null snapshot (515)
- **Shared VRL keys** — overlap/explosion/loop lifecycle, zone transitions

### Round 3 — Serialization batch summaries
- **12 per-recording Verbose logs removed** from RecordingStore + 2 per-recording metadata logs from ParsekScenario (~2,900 lines/cycle)
- **4 batch summaries added** — standalone save/load + tree save/load with aggregate counters

### Round 4 — Remaining sources
- **SpawnWarning FormatChainStatus** — per-frame poll VRL'd (1,165 lines, 802-line burst)
- **Zone transition** — per-ghost `Info→VRL` shared key (501 lines, 248-line bursts)
- **Scenario per-recording dumps** — `Info→Verbose` (390+278 lines)
- **Explosion trigger** — `Info→VRL` per-index 10s (406 lines)

### Other
- Log audit report: `docs/dev/log-audit-2026-03-25.md`
- CLAUDE.md: batch counting convention added, `ParsekLog.Log` reference removed
- Bug #135 (ShouldSpawnAtRecordingEnd spam): marked fixed, 12 garbled comments cleaned
- Bug #138: comprehensive audit entry covering all 4 rounds

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 3367 pass, 0 fail
- [x] Post-R1 in-game session (11.5min): verified [General] eliminated, no errors
- [x] Post-R3 in-game session (23min): verified 92.2% rate reduction, zero exceptions
- [ ] Verify verbose-on logs still contain sufficient ghost lifecycle detail for debugging

🤖 Generated with [Claude Code](https://claude.com/claude-code)