### PR TITLE
Settings UI polish + maintenance sweep (27 bugs fixed, 8 new tracked)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ All notable changes to Parsek are documented here.
 - **Fix #150: Engine/RCS FX not stopped at on-rails.** `FlightRecorder.OnVesselGoOnRails` now calls `EmitTerminalEngineAndRcsEvents()` before going on-rails. Ghost engine plumes no longer persist during orbit segments.
 - **Fix #151: FF watch renders broken scene.** Added 100km distance guard in `EnterWatchMode` — refuses watch when ghost is beyond rendering-safe distance from active vessel. Rate-limited `FindNextWatchTarget` logging during watch hold.
 - **Fix: Enter key on camera cutoff input.** Enter key now commits the value (KeyDown was consumed by TextField before the check ran).
+- **Fix #74: RELATIVE mode boundary point at on-rails.** `SamplePosition` recorded absolute lat/lon/alt into a RELATIVE TrackSection at on-rails boundaries. Moved RELATIVE clearing before boundary sampling.
+- **Fix #107: Engine/SRB smoke trails vanish on ghost despawn.** Particle systems are now detached from the ghost hierarchy before destruction, allowing trails to fade naturally (8s linger).
+- **Fix #125: Engine plate shrouds not visible on ghost.** Inactive-variant renderer filter preempted GAMEOBJECT rules. When explicit variant rules exist, they are now the sole authority on object inclusion.
 
 ### Features
 
@@ -74,6 +77,8 @@ All notable changes to Parsek are documented here.
 - **#121** (Ghost SKIPPED log spam) — resolved by T25 Phase 9 engine extraction.
 - **#133** — removed 6 dead forwarding methods + 2 unused properties from ParsekFlight, inlined call sites.
 - **#63** — added `errorWhitelist` parameter to `ParsekLogContractChecker.ValidateLatestSession`.
+- **#83** — CommNet stale nodes concern is not a bug; follows stock KSP re-registration pattern.
+- **#108** — engine cutoff polling logic (`EngineIgnited && isOperational`) correctly catches flameout; remaining inconsistency needs in-game repro.
 
 Log spam audit and cleanup. Analyzed a 28,923-line KSP.log from a 70-second KSC session with 273 recordings — Parsek was 68.4% of all output (19,771 lines). Identified and fixed the top spam sources.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ All notable changes to Parsek are documented here.
 - **Fix #162: AutoCommitGhostOnly strips snapshot from landed EVAs.** Preserves `VesselSnapshot` for Landed/Splashed terminals.
 - **Fix #163: KSC spawns vessels from the future after rewind.** `ShouldSpawnAtKscEnd` now checks `currentUT >= EndUT`.
 - **Fix #165: Engine flame flash on ignition.** `EngineIgnited` with throttle=0 now uses min 0.01 emission.
+- **Fix #164: Strip all future vessels on rewind, not just PRELAUNCH.** Flags, landed capsules, and other player-created vessels from the future now removed after rewind.
+- **DeferredActivateVessel timeout increased** from 10 frames to 5 seconds. Distant spawned vessels (37km+) couldn't load in 10 frames.
 - **ComputeTotal logging removed.** Eliminated 52% of all Parsek log output (pure computation was logging every UI frame).
 - **Status column widened** (95→120px) for longer T+ timestamps.
 - **R/FF button state transition logging** for debugging enable/disable issues.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,14 @@ All notable changes to Parsek are documented here.
 - **Fix #115/#116: Crew lost to Missing after rewind vessel strip.** New `RescueOrphanedCrew` sets orphaned Assigned crew to Available after vessel stripping, before KSP's validation marks them Missing.
 - **Fix #155: Orphaned recording lost on auto-record vessel switch.** `StartRecording` now commits the orphaned recorder's data before creating a new one.
 - **Fix #76: GhostExtender hyperbolic fallback negative altitude.** Added `Math.Max(0, ...)` to prevent ghost underground placement.
+- **Fix #157: Green sphere ghost for ghost-only debris.** `ApplyVesselDecisions` now preserves `GhostVisualSnapshot` before nulling spawn snapshot.
+- **Fix #161: EVA snapshot situation stale.** `ShouldSpawnAtRecordingEnd` overrides unsafe-situation check when terminal state is Landed/Splashed.
+- **Fix #162: AutoCommitGhostOnly strips snapshot from landed EVAs.** Preserves `VesselSnapshot` for Landed/Splashed terminals.
+- **Fix #163: KSC spawns vessels from the future after rewind.** `ShouldSpawnAtKscEnd` now checks `currentUT >= EndUT`.
+- **Fix #165: Engine flame flash on ignition.** `EngineIgnited` with throttle=0 now uses min 0.01 emission.
+- **ComputeTotal logging removed.** Eliminated 52% of all Parsek log output (pure computation was logging every UI frame).
+- **Status column widened** (95→120px) for longer T+ timestamps.
+- **R/FF button state transition logging** for debugging enable/disable issues.
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ All notable changes to Parsek are documented here.
 - **Fix #57: Boarding confirmation timeout too short.** Increased from 3 frames (~60ms) to 10 frames (~200ms).
 - **Fix #115/#116: Crew lost to Missing after rewind vessel strip.** New `RescueOrphanedCrew` sets orphaned Assigned crew to Available after vessel stripping, before KSP's validation marks them Missing.
 - **Fix #155: Orphaned recording lost on auto-record vessel switch.** `StartRecording` now commits the orphaned recorder's data before creating a new one.
+- **Fix #76: GhostExtender hyperbolic fallback negative altitude.** Added `Math.Max(0, ...)` to prevent ghost underground placement.
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ All notable changes to Parsek are documented here.
 - **Fix #74: RELATIVE mode boundary point at on-rails.** `SamplePosition` recorded absolute lat/lon/alt into a RELATIVE TrackSection at on-rails boundaries. Moved RELATIVE clearing before boundary sampling.
 - **Fix #107: Engine/SRB smoke trails vanish on ghost despawn.** Particle systems are now detached from the ghost hierarchy before destruction, allowing trails to fade naturally (8s linger).
 - **Fix #125: Engine plate shrouds not visible on ghost.** Inactive-variant renderer filter preempted GAMEOBJECT rules. When explicit variant rules exist, they are now the sole authority on object inclusion.
+- **Engine throttle deadband increased to 5%.** SRBs with smooth thrust curves generated excessive EngineThrottle events at 1% deadband. Matches RCS deadband (#149).
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,10 @@ All notable changes to Parsek are documented here.
 - **Fix #107: Engine/SRB smoke trails vanish on ghost despawn.** Particle systems are now detached from the ghost hierarchy before destruction, allowing trails to fade naturally (8s linger).
 - **Fix #125: Engine plate shrouds not visible on ghost.** Inactive-variant renderer filter preempted GAMEOBJECT rules. When explicit variant rules exist, they are now the sole authority on object inclusion.
 - **Engine throttle deadband increased to 5%.** SRBs with smooth thrust curves generated excessive EngineThrottle events at 1% deadband. Matches RCS deadband (#149).
+- **Fix #56: Auto-record EVA from any vessel situation.** Removed PRELAUNCH restriction — kerbals EVA'ing from landed bases, orbiting stations, etc. now auto-record.
+- **Fix #57: Boarding confirmation timeout too short.** Increased from 3 frames (~60ms) to 10 frames (~200ms).
+- **Fix #115/#116: Crew lost to Missing after rewind vessel strip.** New `RescueOrphanedCrew` sets orphaned Assigned crew to Available after vessel stripping, before KSP's validation marks them Missing.
+- **Fix #155: Orphaned recording lost on auto-record vessel switch.** `StartRecording` now commits the orphaned recorder's data before creating a new one.
 
 ### Features
 
@@ -80,6 +84,9 @@ All notable changes to Parsek are documented here.
 - **#63** — added `errorWhitelist` parameter to `ParsekLogContractChecker.ValidateLatestSession`.
 - **#83** — CommNet stale nodes concern is not a bug; follows stock KSP re-registration pattern.
 - **#108** — engine cutoff polling logic (`EngineIgnited && isOperational`) correctly catches flameout; remaining inconsistency needs in-game repro.
+- **#113** — stock FX modules infeasible on ghost architecture; current reimplementation is correct.
+- **#153** — AnimateHeat nose cone classification requires reflection hack for negligible visual effect; won't fix.
+- **#156** — extracted `IsPadFailure` static method + 7 tests; remaining items need Unity runtime.
 
 Log spam audit and cleanup. Analyzed a 28,923-line KSP.log from a 70-second KSC session with 273 recordings — Parsek was 68.4% of all output (19,771 lines). Identified and fixed the top spam sources.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,16 @@ All notable changes to Parsek are documented here.
 - **Fix #148: Fast-forward doesn't transfer watch to target.** `FastForwardToRecording` now exits watch and defers entering on the FF target after engine positions ghosts.
 - **Fix #149: RCS throttle event spam.** Deadband increased from 1% to 5% — reduces RCS part events by ~90% for SAS-active flights.
 
+- **Fix #135: ParsePartPositions wrong key.** `SpawnCollisionDetector.ParsePartPositions` only checked `"pos"` but KSP vessel snapshots use `"position"`. Parsed 0/40 parts on real vessels, falling back to inaccurate 2m bounds. Now checks both keys.
+- **Fix #150: Engine/RCS FX not stopped at on-rails.** `FlightRecorder.OnVesselGoOnRails` now calls `EmitTerminalEngineAndRcsEvents()` before going on-rails. Ghost engine plumes no longer persist during orbit segments.
+- **Fix #151: FF watch renders broken scene.** Added 100km distance guard in `EnterWatchMode` — refuses watch when ghost is beyond rendering-safe distance from active vessel. Rate-limited `FindNextWatchTarget` logging during watch hold.
+- **Fix: Enter key on camera cutoff input.** Enter key now commits the value (KeyDown was consumed by TextField before the check ran).
+
 ### Features
+
+- **Settings window: "Ghosts" group.** Merged "Ghost Camera" and "Ghost Soft Caps" sections into a single "Ghosts" group. Added checkbox-to-label spacing for all settings toggles.
+- **Fix #50: Chain block enable/loop checkboxes.** Chain headers now have aggregate enable and loop checkboxes (were empty spacers).
+- **Fix #98: Merge Countdown into Status column.** Status now shows `T-Xm Xs` for future, `Active` for playing, terminal state name for past.
 
 - **Ghost camera cutoff setting.** Settings > Ghost Camera > Cutoff [300] km. Watch mode auto-exits when ghost exceeds this distance. Watch button disabled for ghosts beyond cutoff. Default 300km, configurable 10-10000km.
 - **Watch mode distance overlay.** "Watching: Vessel (45.2 km)" in the notification bar shows distance from ghost to active vessel.
@@ -62,7 +71,9 @@ All notable changes to Parsek are documented here.
 ### Previously Fixed (Confirmed)
 
 - **#43** (shader fallback), **#49** (RealVesselExists O(n)) — already fixed in prior releases.
-- **#50** (subgroup checkboxes) — code appears to draw them via recursive `DrawGroupTree`; needs in-game verification.
+- **#121** (Ghost SKIPPED log spam) — resolved by T25 Phase 9 engine extraction.
+- **#133** — removed 6 dead forwarding methods + 2 unused properties from ParsekFlight, inlined call sites.
+- **#63** — added `errorWhitelist` parameter to `ParsekLogContractChecker.ValidateLatestSession`.
 
 Log spam audit and cleanup. Analyzed a 28,923-line KSP.log from a 70-second KSC session with 273 recordings — Parsek was 68.4% of all output (19,771 lines). Identified and fixed the top spam sources.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ All notable changes to Parsek are documented here.
 - **Settings window: "Ghosts" group.** Merged "Ghost Camera" and "Ghost Soft Caps" sections into a single "Ghosts" group. Added checkbox-to-label spacing for all settings toggles.
 - **Fix #50: Chain block enable/loop checkboxes.** Chain headers now have aggregate enable and loop checkboxes (were empty spacers).
 - **Fix #98: Merge Countdown into Status column.** Status now shows `T-Xm Xs` for future, `Active` for playing, terminal state name for past.
+- **Fix #88: Commit approval dialog for landed/splashed vessels.** When leaving Flight to KSC or Tracking Station with a landed/splashed vessel, shows Keep/Discard dialog instead of auto-committing. Game exit still auto-commits.
 
 - **Ghost camera cutoff setting.** Settings > Ghost Camera > Cutoff [300] km. Watch mode auto-exits when ghost exceeds this distance. Watch button disabled for ghosts beyond cutoff. Default 300km, configurable 10-10000km.
 - **Watch mode distance overlay.** "Watching: Vessel (45.2 km)" in the notification bar shows distance from ghost to active vessel.

--- a/Source/Parsek.Tests/Bug156Tests.cs
+++ b/Source/Parsek.Tests/Bug156Tests.cs
@@ -1,23 +1,18 @@
 using System;
-using System.Collections.Generic;
 using Xunit;
 
 namespace Parsek.Tests
 {
     /// <summary>
-    /// Bug #156: pad-failure threshold tests and CacheEngineModules null-safety.
+    /// Bug #156: pad-failure threshold tests, commit approval, and CacheEngineModules null-safety.
     /// </summary>
     [Collection("Sequential")]
     public class Bug156_PadFailureThresholdTests : IDisposable
     {
-        private readonly List<string> logLines = new List<string>();
-
         public Bug156_PadFailureThresholdTests()
         {
             ParsekLog.ResetTestOverrides();
-            ParsekLog.SuppressLogging = false;
-            ParsekLog.VerboseOverrideForTesting = true;
-            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+            ParsekLog.SuppressLogging = true;
         }
 
         public void Dispose()
@@ -71,6 +66,12 @@ namespace Parsek.Tests
             Assert.True(ParsekFlight.IsPadFailure(0.0, 0.0));
         }
 
+        [Fact]
+        public void IsPadFailure_DistanceJustUnderThreshold_ReturnsTrue()
+        {
+            Assert.True(ParsekFlight.IsPadFailure(5.0, 29.9));
+        }
+
         // ────────────────────────────────────────────────────────────
         //  ShouldShowCommitApproval — commit dialog trigger (#88)
         // ────────────────────────────────────────────────────────────
@@ -80,6 +81,20 @@ namespace Parsek.Tests
         {
             Assert.True(GhostPlaybackLogic.ShouldShowCommitApproval(
                 GameScenes.SPACECENTER, TerminalState.Landed));
+        }
+
+        [Fact]
+        public void ShouldShowCommitApproval_SplashedAtKSC_ReturnsTrue()
+        {
+            Assert.True(GhostPlaybackLogic.ShouldShowCommitApproval(
+                GameScenes.SPACECENTER, TerminalState.Splashed));
+        }
+
+        [Fact]
+        public void ShouldShowCommitApproval_LandedAtTrackStation_ReturnsTrue()
+        {
+            Assert.True(GhostPlaybackLogic.ShouldShowCommitApproval(
+                GameScenes.TRACKSTATION, TerminalState.Landed));
         }
 
         [Fact]

--- a/Source/Parsek.Tests/Bug156Tests.cs
+++ b/Source/Parsek.Tests/Bug156Tests.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Bug #156: pad-failure threshold tests and CacheEngineModules null-safety.
+    /// </summary>
+    [Collection("Sequential")]
+    public class Bug156_PadFailureThresholdTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public Bug156_PadFailureThresholdTests()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.VerboseOverrideForTesting = true;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+        }
+
+        // ────────────────────────────────────────────────────────────
+        //  IsPadFailure — pad-failure discard threshold
+        // ────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void IsPadFailure_ShortDurationAndCloseDistance_ReturnsTrue()
+        {
+            // Bug #156: 5s duration, 20m from launch — both under thresholds (10s, 30m)
+            Assert.True(ParsekFlight.IsPadFailure(5.0, 20.0));
+        }
+
+        [Fact]
+        public void IsPadFailure_LongDuration_ReturnsFalse()
+        {
+            // Bug #156: 15s duration exceeds 10s threshold — not a pad failure
+            Assert.False(ParsekFlight.IsPadFailure(15.0, 20.0));
+        }
+
+        [Fact]
+        public void IsPadFailure_FarDistance_ReturnsFalse()
+        {
+            // Bug #156: 50m distance exceeds 30m threshold — not a pad failure
+            Assert.False(ParsekFlight.IsPadFailure(5.0, 50.0));
+        }
+
+        [Fact]
+        public void IsPadFailure_ExactThresholds_ReturnsFalse()
+        {
+            // Boundary: exactly 10s and 30m — strict less-than means not a pad failure
+            Assert.False(ParsekFlight.IsPadFailure(10.0, 30.0));
+        }
+
+        [Fact]
+        public void IsPadFailure_BothExceedThresholds_ReturnsFalse()
+        {
+            Assert.False(ParsekFlight.IsPadFailure(15.0, 50.0));
+        }
+
+        [Fact]
+        public void IsPadFailure_ZeroDurationAndZeroDistance_ReturnsTrue()
+        {
+            // Edge case: immediate destruction at spawn point
+            Assert.True(ParsekFlight.IsPadFailure(0.0, 0.0));
+        }
+
+        // ────────────────────────────────────────────────────────────
+        //  CacheEngineModules — null-vessel guard
+        // ────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void CacheEngineModules_NullVessel_ReturnsEmptyList()
+        {
+            // Bug #156: null vessel must not crash, must return empty list
+            var result = FlightRecorder.CacheEngineModules(null);
+            Assert.Empty(result);
+        }
+    }
+}

--- a/Source/Parsek.Tests/Bug156Tests.cs
+++ b/Source/Parsek.Tests/Bug156Tests.cs
@@ -72,6 +72,52 @@ namespace Parsek.Tests
         }
 
         // ────────────────────────────────────────────────────────────
+        //  ShouldShowCommitApproval — commit dialog trigger (#88)
+        // ────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void ShouldShowCommitApproval_LandedAtKSC_ReturnsTrue()
+        {
+            Assert.True(GhostPlaybackLogic.ShouldShowCommitApproval(
+                GameScenes.SPACECENTER, TerminalState.Landed));
+        }
+
+        [Fact]
+        public void ShouldShowCommitApproval_SplashedAtTrackStation_ReturnsTrue()
+        {
+            Assert.True(GhostPlaybackLogic.ShouldShowCommitApproval(
+                GameScenes.TRACKSTATION, TerminalState.Splashed));
+        }
+
+        [Fact]
+        public void ShouldShowCommitApproval_OrbitingAtKSC_ReturnsFalse()
+        {
+            Assert.False(GhostPlaybackLogic.ShouldShowCommitApproval(
+                GameScenes.SPACECENTER, TerminalState.Orbiting));
+        }
+
+        [Fact]
+        public void ShouldShowCommitApproval_LandedAtMainMenu_ReturnsFalse()
+        {
+            Assert.False(GhostPlaybackLogic.ShouldShowCommitApproval(
+                GameScenes.MAINMENU, TerminalState.Landed));
+        }
+
+        [Fact]
+        public void ShouldShowCommitApproval_LandedAtFlight_ReturnsFalse()
+        {
+            Assert.False(GhostPlaybackLogic.ShouldShowCommitApproval(
+                GameScenes.FLIGHT, TerminalState.Landed));
+        }
+
+        [Fact]
+        public void ShouldShowCommitApproval_NullTerminalState_ReturnsFalse()
+        {
+            Assert.False(GhostPlaybackLogic.ShouldShowCommitApproval(
+                GameScenes.SPACECENTER, null));
+        }
+
+        // ────────────────────────────────────────────────────────────
         //  CacheEngineModules — null-vessel guard
         // ────────────────────────────────────────────────────────────
 

--- a/Source/Parsek.Tests/KscSpawnTests.cs
+++ b/Source/Parsek.Tests/KscSpawnTests.cs
@@ -76,7 +76,7 @@ namespace Parsek.Tests
         {
             var rec = MakeEligibleRecording();
 
-            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtKscEnd(rec);
+            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtKscEnd(rec, rec.EndUT + 1);
 
             Assert.True(needsSpawn);
             Assert.Equal("", reason);
@@ -88,7 +88,7 @@ namespace Parsek.Tests
             var rec = MakeEligibleRecording();
             rec.ChainId = null;
 
-            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtKscEnd(rec);
+            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtKscEnd(rec, rec.EndUT + 1);
 
             Assert.True(needsSpawn);
             Assert.Equal("", reason);
@@ -104,7 +104,7 @@ namespace Parsek.Tests
             var rec = MakeEligibleRecording();
             rec.VesselSnapshot = null;
 
-            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtKscEnd(rec);
+            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtKscEnd(rec, rec.EndUT + 1);
 
             Assert.False(needsSpawn);
             Assert.Contains("no vessel snapshot", reason);
@@ -116,7 +116,7 @@ namespace Parsek.Tests
             var rec = MakeEligibleRecording();
             rec.VesselSpawned = true;
 
-            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtKscEnd(rec);
+            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtKscEnd(rec, rec.EndUT + 1);
 
             Assert.False(needsSpawn);
             Assert.Contains("already spawned", reason);
@@ -128,7 +128,7 @@ namespace Parsek.Tests
             var rec = MakeEligibleRecording();
             rec.VesselDestroyed = true;
 
-            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtKscEnd(rec);
+            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtKscEnd(rec, rec.EndUT + 1);
 
             Assert.False(needsSpawn);
             Assert.Contains("vessel destroyed", reason);
@@ -140,7 +140,7 @@ namespace Parsek.Tests
             var rec = MakeEligibleRecording();
             rec.ChainBranch = 1;
 
-            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtKscEnd(rec);
+            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtKscEnd(rec, rec.EndUT + 1);
 
             Assert.False(needsSpawn);
             Assert.Contains("branch > 0", reason);
@@ -152,7 +152,7 @@ namespace Parsek.Tests
             var rec = MakeEligibleRecording();
             rec.TerminalStateValue = TerminalState.Destroyed;
 
-            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtKscEnd(rec);
+            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtKscEnd(rec, rec.EndUT + 1);
 
             Assert.False(needsSpawn);
             Assert.Contains("terminal state", reason);
@@ -164,7 +164,7 @@ namespace Parsek.Tests
             var rec = MakeEligibleRecording();
             rec.TerminalStateValue = TerminalState.Recovered;
 
-            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtKscEnd(rec);
+            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtKscEnd(rec, rec.EndUT + 1);
 
             Assert.False(needsSpawn);
             Assert.Contains("terminal state", reason);
@@ -176,7 +176,7 @@ namespace Parsek.Tests
             var rec = MakeEligibleRecording();
             rec.IsDebris = true;
 
-            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtKscEnd(rec);
+            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtKscEnd(rec, rec.EndUT + 1);
 
             Assert.False(needsSpawn);
             Assert.Contains("debris", reason);
@@ -188,7 +188,7 @@ namespace Parsek.Tests
             var rec = MakeEligibleRecording();
             rec.ChildBranchPointId = "bp-1";
 
-            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtKscEnd(rec);
+            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtKscEnd(rec, rec.EndUT + 1);
 
             Assert.False(needsSpawn);
             Assert.Contains("non-leaf", reason);
@@ -200,7 +200,7 @@ namespace Parsek.Tests
             var rec = MakeEligibleRecording();
             rec.SpawnedVesselPersistentId = 99999;
 
-            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtKscEnd(rec);
+            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtKscEnd(rec, rec.EndUT + 1);
 
             Assert.False(needsSpawn);
             Assert.Contains("already spawned", reason);
@@ -212,7 +212,7 @@ namespace Parsek.Tests
             var rec = MakeEligibleRecording();
             rec.VesselSnapshot.SetValue("sit", "FLYING", true);
 
-            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtKscEnd(rec);
+            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtKscEnd(rec, rec.EndUT + 1);
 
             Assert.False(needsSpawn);
             Assert.Contains("snapshot situation unsafe", reason);
@@ -230,7 +230,7 @@ namespace Parsek.Tests
             rec.LoopPlayback = true;
             rec.VesselSpawned = false;
 
-            var (needsSpawn, _) = GhostPlaybackLogic.ShouldSpawnAtKscEnd(rec);
+            var (needsSpawn, _) = GhostPlaybackLogic.ShouldSpawnAtKscEnd(rec, rec.EndUT + 1);
 
             Assert.True(needsSpawn);
         }
@@ -244,7 +244,7 @@ namespace Parsek.Tests
             rec.LoopPlayback = true;
             rec.VesselSpawned = true;
 
-            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtKscEnd(rec);
+            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtKscEnd(rec, rec.EndUT + 1);
 
             Assert.False(needsSpawn);
             Assert.Contains("already spawned", reason);
@@ -273,7 +273,7 @@ namespace Parsek.Tests
             RecordingStore.CommittedRecordings.Add(midRec);
             RecordingStore.CommittedRecordings.Add(tipRec);
 
-            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtKscEnd(tipRec);
+            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtKscEnd(tipRec, tipRec.EndUT + 1);
 
             Assert.False(needsSpawn);
             Assert.Contains("chain looping", reason);
@@ -298,7 +298,7 @@ namespace Parsek.Tests
             RecordingStore.CommittedRecordings.Add(midRec);
             RecordingStore.CommittedRecordings.Add(tipRec);
 
-            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtKscEnd(tipRec);
+            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtKscEnd(tipRec, tipRec.EndUT + 1);
 
             Assert.False(needsSpawn);
             Assert.Contains("chain looping or fully disabled", reason);
@@ -325,7 +325,7 @@ namespace Parsek.Tests
             RecordingStore.CommittedRecordings.Add(midRec);
             RecordingStore.CommittedRecordings.Add(tipRec);
 
-            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtKscEnd(tipRec);
+            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtKscEnd(tipRec, tipRec.EndUT + 1);
 
             Assert.True(needsSpawn);
             Assert.Equal("", reason);
@@ -389,7 +389,7 @@ namespace Parsek.Tests
             RecordingStore.CommittedRecordings.Add(midRec);
             RecordingStore.CommittedRecordings.Add(tipRec);
 
-            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtKscEnd(midRec);
+            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtKscEnd(midRec, midRec.EndUT + 1);
             Assert.False(needsSpawn);
             Assert.Contains("intermediate chain segment", reason);
         }
@@ -408,7 +408,7 @@ namespace Parsek.Tests
             RecordingStore.CommittedRecordings.Add(midRec);
             RecordingStore.CommittedRecordings.Add(tipRec);
 
-            var (needsSpawn, _) = GhostPlaybackLogic.ShouldSpawnAtKscEnd(tipRec);
+            var (needsSpawn, _) = GhostPlaybackLogic.ShouldSpawnAtKscEnd(tipRec, tipRec.EndUT + 1);
             Assert.True(needsSpawn);
         }
 

--- a/Source/Parsek.Tests/LogValidation/ParsekLogContractChecker.cs
+++ b/Source/Parsek.Tests/LogValidation/ParsekLogContractChecker.cs
@@ -31,7 +31,9 @@ namespace Parsek.Tests.LogValidation
             @"^SessionStart runUtc=(?<utc>\d+)$",
             RegexOptions.Compiled);
 
-        public static IReadOnlyList<LogViolation> ValidateLatestSession(IReadOnlyList<KspLogEntry> parsekEntries)
+        public static IReadOnlyList<LogViolation> ValidateLatestSession(
+            IReadOnlyList<KspLogEntry> parsekEntries,
+            IReadOnlyList<string> errorWhitelist = null)
         {
             if (parsekEntries == null)
                 throw new ArgumentNullException(nameof(parsekEntries));
@@ -96,8 +98,8 @@ namespace Parsek.Tests.LogValidation
                     }
                 }
 
-                // TODO: add whitelist support when intentional error-path scenarios are introduced.
-                if (string.Equals(entry.Level, "ERROR", StringComparison.Ordinal))
+                if (string.Equals(entry.Level, "ERROR", StringComparison.Ordinal) &&
+                    !IsWhitelisted(entry.Message, errorWhitelist))
                 {
                     violations.Add(new LogViolation(
                         code: "ERR-001",
@@ -154,6 +156,19 @@ namespace Parsek.Tests.LogValidation
             }
 
             return violations;
+        }
+
+        private static bool IsWhitelisted(string message, IReadOnlyList<string> whitelist)
+        {
+            if (whitelist == null || whitelist.Count == 0)
+                return false;
+            string msg = message ?? string.Empty;
+            for (int i = 0; i < whitelist.Count; i++)
+            {
+                if (msg.IndexOf(whitelist[i], StringComparison.Ordinal) >= 0)
+                    return true;
+            }
+            return false;
         }
 
         private static bool IsSessionStart(KspLogEntry entry)

--- a/Source/Parsek.Tests/ParsekLogContractCheckerTests.cs
+++ b/Source/Parsek.Tests/ParsekLogContractCheckerTests.cs
@@ -156,6 +156,40 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void ErrorWhitelist_SuppressesMatchingErrors()
+        {
+            var entries = ParsekKspLogParser.ParseLines(new[]
+            {
+                "[LOG] [Parsek][INFO][Init] SessionStart runUtc=3010",
+                "[LOG] [Parsek][INFO][Recorder] Recording started (physics-frame sampling)",
+                "[LOG] [Parsek][ERROR][Test] Expected error for testing",
+                "[LOG] [Parsek][INFO][Recorder] Recording stopped. 3 points, 0 orbit segments over 1.2s"
+            });
+
+            var violations = ParsekLogContractChecker.ValidateLatestSession(entries,
+                errorWhitelist: new[] { "Expected error for testing" });
+
+            Assert.DoesNotContain(violations, v => v.Code == "ERR-001");
+        }
+
+        [Fact]
+        public void ErrorWhitelist_DoesNotSuppressNonMatchingErrors()
+        {
+            var entries = ParsekKspLogParser.ParseLines(new[]
+            {
+                "[LOG] [Parsek][INFO][Init] SessionStart runUtc=3011",
+                "[LOG] [Parsek][INFO][Recorder] Recording started (physics-frame sampling)",
+                "[LOG] [Parsek][ERROR][Test] Some other error",
+                "[LOG] [Parsek][INFO][Recorder] Recording stopped. 3 points, 0 orbit segments over 1.2s"
+            });
+
+            var violations = ParsekLogContractChecker.ValidateLatestSession(entries,
+                errorWhitelist: new[] { "Expected error for testing" });
+
+            Assert.Contains(violations, v => v.Code == "ERR-001");
+        }
+
+        [Fact]
         public void AtmoSoiFixture_HasNoViolations()
         {
             var entries = ParsekKspLogParser.ParseFile(TestFixtureLoader.GetFixturePath("good_atmo_soi_session.log"));

--- a/Source/Parsek.Tests/RewindPrelaunchStripTests.cs
+++ b/Source/Parsek.Tests/RewindPrelaunchStripTests.cs
@@ -61,18 +61,18 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void ShouldStripFuturePrelaunch_NonPrelaunch_ReturnsFalse()
+        public void ShouldStripFuturePrelaunch_NonPrelaunch_AlsoStripped()
         {
-            // A LANDED vessel should never be stripped regardless of PID
+            // #164: ALL vessel types not in whitelist are stripped (not just PRELAUNCH)
             var quicksavePids = new HashSet<uint> { 100 };
 
-            Assert.False(ParsekScenario.ShouldStripFuturePrelaunch(
+            Assert.True(ParsekScenario.ShouldStripFuturePrelaunch(
                 Vessel.Situations.LANDED, 999, quicksavePids));
-            Assert.False(ParsekScenario.ShouldStripFuturePrelaunch(
+            Assert.True(ParsekScenario.ShouldStripFuturePrelaunch(
                 Vessel.Situations.ORBITING, 999, quicksavePids));
-            Assert.False(ParsekScenario.ShouldStripFuturePrelaunch(
+            Assert.True(ParsekScenario.ShouldStripFuturePrelaunch(
                 Vessel.Situations.FLYING, 999, quicksavePids));
-            Assert.False(ParsekScenario.ShouldStripFuturePrelaunch(
+            Assert.True(ParsekScenario.ShouldStripFuturePrelaunch(
                 Vessel.Situations.SPLASHED, 999, quicksavePids));
         }
 

--- a/Source/Parsek.Tests/SpawnCollisionDetectorTests.cs
+++ b/Source/Parsek.Tests/SpawnCollisionDetectorTests.cs
@@ -468,6 +468,39 @@ namespace Parsek.Tests
                 l.Contains("2/3"));
         }
 
+        [Fact]
+        public void ParsePartPositions_PositionKey_ReturnsPositions()
+        {
+            // Bug #135: KSP vessel snapshots use "position" key, not "pos"
+            var p1 = new ConfigNode("PART");
+            p1.AddValue("position", "1.5,2.5,3.5");
+            var p2 = new ConfigNode("PART");
+            p2.AddValue("position", "-1,0,4.2");
+
+            var result = SpawnCollisionDetector.ParsePartPositions(new[] { p1, p2 });
+
+            Assert.Equal(2, result.Count);
+            Assert.Equal(1.5, (double)result[0].localPos.x, 4);
+            Assert.Equal(2.5, (double)result[0].localPos.y, 4);
+            Assert.Equal(3.5, (double)result[0].localPos.z, 4);
+        }
+
+        [Fact]
+        public void ParsePartPositions_MixedPosAndPosition_BothParsed()
+        {
+            // Both "pos" (synthetic snapshots) and "position" (KSP runtime) should work
+            var posNode = new ConfigNode("PART");
+            posNode.AddValue("pos", "1,2,3");
+            var positionNode = new ConfigNode("PART");
+            positionNode.AddValue("position", "4,5,6");
+
+            var result = SpawnCollisionDetector.ParsePartPositions(new[] { posNode, positionNode });
+
+            Assert.Equal(2, result.Count);
+            Assert.Equal(1.0, (double)result[0].localPos.x, 4);
+            Assert.Equal(4.0, (double)result[1].localPos.x, 4);
+        }
+
         // ────────────────────────────────────────────────────────────
         //  WalkbackAlongTrajectory
         // ────────────────────────────────────────────────────────────

--- a/Source/Parsek.Tests/TreeLogVerificationTests.cs
+++ b/Source/Parsek.Tests/TreeLogVerificationTests.cs
@@ -109,43 +109,7 @@ namespace Parsek.Tests
                 line => line.Contains("Discarded pending tree 'Mun Mission'"));
         }
 
-        // ============================================================
-        // C4: ComputeTotal tree loop — per-tree verbose log
-        // ============================================================
-
-        [Fact]
-        public void ComputeTotal_LogsPerTreeBreakdown()
-        {
-            var treeA = new RecordingTree
-            {
-                Id = "treeA",
-                TreeName = "Applied Tree",
-                DeltaFunds = -3000,
-                ResourcesApplied = true
-            };
-            var treeB = new RecordingTree
-            {
-                Id = "treeB",
-                TreeName = "Pending Tree",
-                DeltaFunds = -2000,
-                ResourcesApplied = false
-            };
-
-            var trees = new List<RecordingTree> { treeA, treeB };
-
-            ResourceBudget.ComputeTotal(
-                new List<Recording>(),
-                new List<Milestone>(),
-                trees);
-
-            // Tree A logged as applied (funds=0 since TreeCommittedFundsCost returns 0 for applied)
-            Assert.Contains(capturedLines,
-                line => line.Contains("Applied Tree") && line.Contains("resourcesApplied=True"));
-
-            // Tree B logged as not applied with cost contribution
-            Assert.Contains(capturedLines,
-                line => line.Contains("Pending Tree") && line.Contains("resourcesApplied=False"));
-        }
+        // C4: ComputeTotal logging removed — pure computation should not log (log spam fix)
 
         // ============================================================
         // C5: RecordingTree.Save logs summary

--- a/Source/Parsek/CrewReservationManager.cs
+++ b/Source/Parsek/CrewReservationManager.cs
@@ -419,6 +419,7 @@ namespace Parsek
         /// </summary>
         internal static int RescueOrphanedCrew(List<ProtoVessel> survivingVessels)
         {
+            if (survivingVessels == null) return 0;
             var roster = HighLogic.CurrentGame?.CrewRoster;
             if (roster == null)
             {

--- a/Source/Parsek/CrewReservationManager.cs
+++ b/Source/Parsek/CrewReservationManager.cs
@@ -411,6 +411,60 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Rescues crew orphaned by vessel stripping during rewind/revert (#116).
+        /// Any crew member with Assigned status who is not on a surviving ProtoVessel
+        /// is set to Available. Dead crew are skipped. Must be called after
+        /// StripOrphanedSpawnedVessels / StripFuturePrelaunchVessels and before
+        /// ReserveSnapshotCrew (which re-reserves Available crew from snapshots).
+        /// </summary>
+        internal static int RescueOrphanedCrew(List<ProtoVessel> survivingVessels)
+        {
+            var roster = HighLogic.CurrentGame?.CrewRoster;
+            if (roster == null)
+            {
+                CrewLog("RescueOrphanedCrew: no crew roster — skipping");
+                return 0;
+            }
+
+            // Build set of crew names still referenced by surviving vessels
+            var survivingCrew = new HashSet<string>();
+            for (int i = 0; i < survivingVessels.Count; i++)
+            {
+                var crew = survivingVessels[i].GetVesselCrew();
+                for (int j = 0; j < crew.Count; j++)
+                    if (!string.IsNullOrEmpty(crew[j].name))
+                        survivingCrew.Add(crew[j].name);
+            }
+
+            GameStateRecorder.SuppressCrewEvents = true;
+            try
+            {
+                int rescued = 0;
+                foreach (ProtoCrewMember pcm in roster.Crew)
+                {
+                    if (pcm.rosterStatus != ProtoCrewMember.RosterStatus.Assigned)
+                        continue;
+                    if (survivingCrew.Contains(pcm.name))
+                        continue;
+
+                    pcm.rosterStatus = ProtoCrewMember.RosterStatus.Available;
+                    rescued++;
+                    CrewLog($"Rescued orphaned crew '{pcm.name}' → Available " +
+                        $"(was Assigned but no vessel references them)");
+                }
+
+                if (rescued > 0)
+                    ParsekLog.Info("Crew",
+                        $"Rescued {rescued} orphaned crew member(s) from vessel strip → Available");
+                return rescued;
+            }
+            finally
+            {
+                GameStateRecorder.SuppressCrewEvents = false;
+            }
+        }
+
+        /// <summary>
         /// Returns the single crew member's name from an EVA vessel, or null.
         /// Uses GetVesselCrew() for robustness with both packed and unpacked vessels.
         /// </summary>

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -4580,6 +4580,23 @@ namespace Parsek
                 }
             }
 
+            // Emit terminal engine/RCS/robotic events so ghost FX stops during orbit segment (#150)
+            double railsUT = Planetarium.GetUniversalTime();
+            var railsTerminalEvts = EmitTerminalEngineAndRcsEvents(
+                activeEngineKeys, activeRcsKeys, activeRoboticKeys,
+                lastRoboticPosition, railsUT, "Recorder");
+            PartEvents.AddRange(railsTerminalEvts);
+            if (railsTerminalEvts.Count > 0)
+                ParsekLog.Info("Recorder",
+                    $"Emitted {railsTerminalEvts.Count} terminal FX events at on-rails transition (UT={railsUT.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)})");
+
+            // Clear active state so off-rails re-detection starts fresh
+            activeEngineKeys.Clear();
+            activeRcsKeys.Clear();
+            activeRoboticKeys.Clear();
+            lastThrottle.Clear();
+            lastRcsThrottle.Clear();
+            lastRoboticPosition.Clear();
             rcsActiveFrameCount.Clear();
             decoupledPartIds.Clear();
 

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -2436,7 +2436,7 @@ namespace Parsek
                     lastT = 0f;
 
                 float delta = throttle - lastT;
-                if (delta > 0.01f || delta < -0.01f)
+                if (delta > 0.05f || delta < -0.05f)
                 {
                     lastThrottleMap[key] = throttle;
                     events.Add(new PartEvent

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -4544,6 +4544,24 @@ namespace Parsek
             }
             if (v.persistentId != RecordingVesselId) return;
 
+            // Clear RELATIVE mode BEFORE sampling the boundary point (#74).
+            // SamplePosition records raw lat/lon/alt (absolute coordinates). If called
+            // while isRelativeMode is true, the point would have absolute values in a
+            // RELATIVE TrackSection — causing a position discontinuity during playback.
+            if (isRelativeMode)
+            {
+                ParsekLog.Info("Anchor",
+                    $"RELATIVE mode cleared on rails transition: anchorPid={currentAnchorPid}");
+                double clearUT = Planetarium.GetUniversalTime();
+                var clearEnv = environmentHysteresis != null
+                    ? environmentHysteresis.CurrentEnvironment
+                    : SegmentEnvironment.ExoBallistic;
+                CloseCurrentTrackSection(clearUT);
+                StartNewTrackSection(clearEnv, ReferenceFrame.Absolute, clearUT);
+                isRelativeMode = false;
+                currentAnchorPid = 0;
+            }
+
             // Record a boundary TrajectoryPoint at current UT (stitching point)
             SamplePosition(v);
 
@@ -4602,16 +4620,8 @@ namespace Parsek
 
             isOnRails = true;
 
-            // Clear RELATIVE mode — orbital sections are always OrbitalCheckpoint
-            if (isRelativeMode)
-            {
-                ParsekLog.Info("Anchor",
-                    $"RELATIVE mode cleared on rails transition: anchorPid={currentAnchorPid}");
-                isRelativeMode = false;
-                currentAnchorPid = 0;
-            }
-
-            // Reference frame transition: ABSOLUTE/RELATIVE -> ORBITAL_CHECKPOINT
+            // Reference frame transition: ABSOLUTE -> ORBITAL_CHECKPOINT
+            // (RELATIVE already cleared above before SamplePosition)
             double onRailsUT = Planetarium.GetUniversalTime();
             var currentEnv = environmentHysteresis != null
                 ? environmentHysteresis.CurrentEnvironment

--- a/Source/Parsek/GhostExtender.cs
+++ b/Source/Parsek/GhostExtender.cs
@@ -93,7 +93,7 @@ namespace Parsek
                     string.Format(CultureInfo.InvariantCulture,
                         "PropagateOrbital: unsupported orbit (ecc={0}, sma={1}) — returning epoch position",
                         ecc, sma));
-                return (0, 0, sma > 0 ? sma - bodyRadius : 0);
+                return (0, 0, sma > 0 ? Math.Max(0, sma - bodyRadius) : 0);
             }
 
             // Compute body-centered inertial position from orbital elements

--- a/Source/Parsek/GhostPlaybackEngine.cs
+++ b/Source/Parsek/GhostPlaybackEngine.cs
@@ -1311,21 +1311,15 @@ namespace Parsek
                 }
             }
 
+            // Detach active engine/RCS particle systems so smoke trails linger (#107).
+            // Stopped systems with no live particles are destroyed immediately.
             if (state.engineInfos != null)
-            {
                 foreach (var info in state.engineInfos.Values)
-                    for (int i = 0; i < info.particleSystems.Count; i++)
-                        if (info.particleSystems[i] != null)
-                            UnityEngine.Object.Destroy(info.particleSystems[i].gameObject);
-            }
+                    GhostPlaybackLogic.DetachAndLingerParticleSystems(info.particleSystems, info.kspEmitters);
 
             if (state.rcsInfos != null)
-            {
                 foreach (var info in state.rcsInfos.Values)
-                    for (int i = 0; i < info.particleSystems.Count; i++)
-                        if (info.particleSystems[i] != null)
-                            UnityEngine.Object.Destroy(info.particleSystems[i].gameObject);
-            }
+                    GhostPlaybackLogic.DetachAndLingerParticleSystems(info.particleSystems, info.kspEmitters);
 
             DestroyReentryFxResources(state.reentryFxInfo);
 

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -1324,6 +1324,37 @@ namespace Parsek
             }
         }
 
+        /// <summary>
+        /// Detaches active particle systems from the ghost hierarchy so they can linger
+        /// and fade out naturally after the ghost is destroyed (#107). Stops emission,
+        /// unparents, and schedules delayed destruction.
+        /// </summary>
+        internal static void DetachAndLingerParticleSystems(
+            List<ParticleSystem> particleSystems, List<KspEmitterRef> kspEmitters, float lingerSeconds = 8f)
+        {
+            if (kspEmitters != null)
+                SetKspEmittersEnabled(kspEmitters, false);
+            if (particleSystems == null) return;
+
+            for (int i = 0; i < particleSystems.Count; i++)
+            {
+                var ps = particleSystems[i];
+                if (ps == null) continue;
+
+                // Only detach if particles are alive (no point lingering an empty system)
+                if (ps.particleCount == 0)
+                {
+                    UnityEngine.Object.Destroy(ps.gameObject);
+                    continue;
+                }
+
+                ps.Stop(true, ParticleSystemStopBehavior.StopEmitting);
+                ps.transform.SetParent(null, true);
+                UnityEngine.Object.Destroy(ps.gameObject, lingerSeconds);
+            }
+            particleSystems.Clear();
+        }
+
         internal static void SetParticleRenderersEnabled(ParticleSystem ps, bool enabled)
         {
             if (ps == null)

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -843,7 +843,10 @@ namespace Parsek
                         }
                         break;
                     case PartEventType.EngineIgnited:
-                        SetEngineEmission(state, evt, evt.value);
+                        // Use at least a minimum emission on ignition (#165) — seed events
+                        // may record throttle=0 when engines are staged but not yet throttled.
+                        // The next EngineThrottle event will set the correct level.
+                        SetEngineEmission(state, evt, System.Math.Max(evt.value, 0.01f));
                         ApplyHeatState(state, evt, HeatLevel.Hot);
                         break;
                     case PartEventType.EngineShutdown:

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -35,6 +35,20 @@ namespace Parsek
             return currentWarpRate > GhostHideWarpThreshold;
         }
 
+        /// <summary>
+        /// Returns true if a commit approval dialog should be shown instead of auto-committing (#88).
+        /// Triggers when leaving Flight to KSC or Tracking Station with a landed/splashed vessel.
+        /// </summary>
+        internal static bool ShouldShowCommitApproval(GameScenes destination, TerminalState? terminalState)
+        {
+            if (destination != GameScenes.SPACECENTER && destination != GameScenes.TRACKSTATION)
+                return false;
+            if (!terminalState.HasValue)
+                return false;
+            var ts = terminalState.Value;
+            return ts == TerminalState.Landed || ts == TerminalState.Splashed;
+        }
+
         internal static bool ShouldFlushDeferredSpawns(int pendingCount, bool isWarpActive)
         {
             return pendingCount > 0 && !isWarpActive;

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -2102,7 +2102,11 @@ namespace Parsek
             // KSP's on-rails aero check (101.3 kPa) immediately destroys spawned vessels.
             // This catches cases where TerminalState is null/Landed but the snapshot was
             // captured mid-flight. (#114)
-            if (IsSnapshotSituationUnsafe(rec.VesselSnapshot))
+            // Override: if terminal state is Landed/Splashed, the vessel DID land safely —
+            // the snapshot's sit field may be stale from recording start (Bug 2b). (#EVA-spawn)
+            bool terminalOverridesUnsafe = rec.TerminalStateValue == TerminalState.Landed ||
+                rec.TerminalStateValue == TerminalState.Splashed;
+            if (!terminalOverridesUnsafe && IsSnapshotSituationUnsafe(rec.VesselSnapshot))
             {
                 return (false, "snapshot situation unsafe (FLYING/SUB_ORBITAL)");
             }
@@ -2125,6 +2129,15 @@ namespace Parsek
         /// </summary>
         internal static (bool needsSpawn, string reason) ShouldSpawnAtKscEnd(Recording rec)
         {
+            return ShouldSpawnAtKscEnd(rec, Planetarium.GetUniversalTime());
+        }
+
+        internal static (bool needsSpawn, string reason) ShouldSpawnAtKscEnd(Recording rec, double currentUT)
+        {
+            // Don't spawn vessels whose recording hasn't finished yet at the current UT (#rewind-persistence)
+            if (currentUT < rec.EndUT)
+                return (false, $"current UT {currentUT:F0} before recording end {rec.EndUT:F0}");
+
             // At KSC, no chain is being built → isActiveChainMember = false
             bool isChainLoopingOrDisabled = !string.IsNullOrEmpty(rec.ChainId) &&
                 (RecordingStore.IsChainLooping(rec.ChainId) ||

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -4432,7 +4432,7 @@ namespace Parsek
                         $"may be procedurally generated at runtime. Ghost will be missing this mesh.");
                     continue;
                 }
-                if (filterInactiveVariantRenderers && !smr.gameObject.activeInHierarchy) continue;
+                if (filterInactiveVariantRenderers && !hasVariantGameObjectRules && !smr.gameObject.activeInHierarchy) continue;
                 if (hasVariantGameObjectRules &&
                     !IsRendererEnabledByVariantRule(
                         smr.transform, modelRoot, selectedVariantGameObjects,
@@ -4898,7 +4898,10 @@ namespace Parsek
             {
                 var mr = meshRenderers[r];
                 if (mr == null) continue;
-                if (filterInactiveVariantRenderers && !mr.gameObject.activeInHierarchy)
+                // Skip inactive renderers only when no GAMEOBJECT rules exist (#125).
+                // When rules are present, they are the sole authority on which objects to include —
+                // the prefab's base variant may have different objects active than the snapshot's variant.
+                if (filterInactiveVariantRenderers && !hasVariantGameObjectRules && !mr.gameObject.activeInHierarchy)
                 {
                     variantSkipped++;
                     continue;

--- a/Source/Parsek/MergeDialog.cs
+++ b/Source/Parsek/MergeDialog.cs
@@ -739,10 +739,14 @@ namespace Parsek
                     {
                         if (rec.VesselSnapshot != null)
                         {
+                            // Preserve GhostVisualSnapshot for ghost rendering if not already set
+                            if (rec.GhostVisualSnapshot == null)
+                                rec.GhostVisualSnapshot = rec.VesselSnapshot.CreateCopy();
                             CrewReservationManager.UnreserveCrewInSnapshot(rec.VesselSnapshot);
                             rec.VesselSnapshot = null;
                             ParsekLog.Info("MergeDialog",
-                                $"ApplyVesselDecisions: ghost-only for '{rec.VesselName}' (id={kvp.Key}), snapshot nulled");
+                                $"ApplyVesselDecisions: ghost-only for '{rec.VesselName}' (id={kvp.Key}), " +
+                                $"spawn snapshot nulled, ghostVisual={rec.GhostVisualSnapshot != null}");
                         }
                     }
                 }

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -3091,12 +3091,6 @@ namespace Parsek
                 ParsekLog.Verbose("Flight", "OnCrewOnEva: source vessel is null — ignoring");
                 return;
             }
-            if (data.from.vessel.situation != Vessel.Situations.PRELAUNCH)
-            {
-                ParsekLog.VerboseRateLimited("Flight", "eva-not-prelaunch",
-                    $"OnCrewOnEva: vessel not on pad (sit={data.from.vessel.situation}) — ignoring");
-                return;
-            }
             if (ParsekSettings.Current?.autoRecordOnEva == false)
             {
                 ParsekLog.Verbose("Flight", "OnCrewOnEva: auto-record on EVA disabled in settings");
@@ -3105,7 +3099,7 @@ namespace Parsek
 
             // The EVA kerbal may not yet be the active vessel, defer to Update()
             pendingAutoRecord = true;
-            Log("EVA from pad detected — pending auto-record");
+            Log($"EVA detected (sit={data.from.vessel.situation}) — pending auto-record");
         }
 
         internal static string ExtractEvaKerbalName(GameEvents.FromToAction<Part, Part> data)

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -138,7 +138,7 @@ namespace Parsek
 
         // Boarding confirmation via onCrewBoardVessel
         private uint pendingBoardingTargetPid; // vessel PID from onCrewBoardVessel, 0 = none
-        private int boardingConfirmFrames;     // frames since boarding event (auto-clear after 3)
+        private int boardingConfirmFrames;     // frames since boarding event (auto-clear after 10)
 
         // Pending dock/undock transitions (set by event handlers, consumed by Update)
         private uint pendingDockMergedPid;          // merged vessel pid, 0 = no pending dock
@@ -3866,11 +3866,12 @@ namespace Parsek
         /// </summary>
         private void ClearStaleConfirmations()
         {
-            // Auto-clear stale boarding confirmation after 3 frames
+            // Auto-clear stale boarding confirmation after 10 frames (#57)
+            // Was 3 frames (~60ms at 50fps) — too short for vessel switches
             if (pendingBoardingTargetPid != 0)
             {
                 boardingConfirmFrames++;
-                if (boardingConfirmFrames > 3)
+                if (boardingConfirmFrames > 10)
                 {
                     ParsekLog.Info("Flight", $"Boarding confirmation expired (targetPid={pendingBoardingTargetPid})");
                     pendingBoardingTargetPid = 0;

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -4386,6 +4386,16 @@ namespace Parsek
             // this method is called, so a non-null value reliably indicates a continuation.
             bool isContinuation = chainManager.ActiveChainId != null;
 
+            // Commit orphaned CaptureAtStop from a previous recorder that was stopped
+            // by vessel switch but never committed (e.g., auto-record started on new
+            // vessel before scene change). Without this, the old recording data is lost.
+            if (recorder != null && !recorder.IsRecording && recorder.CaptureAtStop != null
+                && chainManager.ActiveChainId == null && activeTree == null)
+            {
+                FallbackCommitSplitRecorder(recorder);
+                ParsekLog.Info("Flight", "Committed orphaned recording before starting new one");
+            }
+
             recorder = new FlightRecorder();
             if (chainManager.PendingBoundaryAnchor.HasValue)
             {

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -7040,19 +7040,23 @@ namespace Parsek
 
         IEnumerator DeferredActivateVessel(uint pid)
         {
-            for (int frame = 0; frame < 10; frame++)
+            // Wait up to 5 seconds for the vessel to appear and load.
+            // Distant vessels (e.g. splashdown site 37km away) take much longer
+            // than 10 frames to load — KSP must range-load them first.
+            float deadline = UnityEngine.Time.time + 5f;
+            while (UnityEngine.Time.time < deadline)
             {
                 yield return null;
                 Vessel v = FlightGlobals.Vessels?.Find(vessel => vessel.persistentId == pid);
-                if (v != null && v.loaded)
+                if (v != null)
                 {
                     v.IgnoreGForces(240);
                     FlightGlobals.ForceSetActiveVessel(v);
-                    Log($"Activated vessel pid={pid}");
+                    Log($"Activated vessel pid={pid} (loaded={v.loaded})");
                     yield break;
                 }
             }
-            Log($"WARNING: Could not activate vessel pid={pid} within 10 frames");
+            Log($"WARNING: Could not activate vessel pid={pid} within 5 seconds");
         }
 
         #region Zone Rendering (shared by normal, background, and looped ghosts)

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -740,6 +740,7 @@ namespace Parsek
         void OnSceneChangeRequested(GameScenes scene)
         {
             sceneChangeInProgress = true;
+            RecordingStore.PendingDestinationScene = scene;
             ParsekLog.Info("Flight", $"Scene change requested: {scene}");
 
             // Exit watch mode on scene change

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -1114,7 +1114,7 @@ namespace Parsek
             {
                 double flightDuration = RecordingStore.Pending.EndUT - RecordingStore.Pending.StartUT;
                 double maxDist = RecordingStore.Pending.MaxDistanceFromLaunch;
-                if (flightDuration < 10.0 && maxDist < 30.0)
+                if (IsPadFailure(flightDuration, maxDist))
                 {
                     Log($"Post-destruction: pad failure ({flightDuration:F1}s, {maxDist:F0}m) — auto-discarding");
                     ScreenMessage("Recording discarded — pad failure", 3f);
@@ -1938,7 +1938,7 @@ namespace Parsek
                 {
                     double dur = RecordingStore.Pending.EndUT - RecordingStore.Pending.StartUT;
                     double maxDist = RecordingStore.Pending.MaxDistanceFromLaunch;
-                    if (dur < 10.0 && maxDist < 30.0)
+                    if (IsPadFailure(dur, maxDist))
                     {
                         ParsekLog.Info("Flight",
                             $"Vessel destroyed during split — pad failure ({dur:F1}s, {maxDist:F0}m), discarding");
@@ -6261,6 +6261,15 @@ namespace Parsek
         /// Reindexes an int-keyed dictionary after a deletion: keys above removedIndex shift down by 1.
         /// The entry at removedIndex (if any) is dropped.
         /// </summary>
+        /// <summary>
+        /// Returns true if the recording should be discarded as a pad failure:
+        /// duration &lt; 10s AND max distance from launch &lt; 30m.
+        /// </summary>
+        internal static bool IsPadFailure(double duration, double maxDistanceFromLaunch)
+        {
+            return duration < 10.0 && maxDistanceFromLaunch < 30.0;
+        }
+
         internal static void ReindexAfterDelete<T>(Dictionary<int, T> dict, int removedIndex)
         {
             var old = new Dictionary<int, T>(dict);

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -215,11 +215,8 @@ namespace Parsek
         }
 
         // Diagnostic logging guards (log once per state transition, not per frame)
-        // loggedGhostEnter and loggedReshow moved to engine (T25).
-        private HashSet<int> loggedGhostEnter => engine.loggedGhostEnter;
         private HashSet<int> loggedOrbitSegments = new HashSet<int>();
         private HashSet<int> loggedOrbitRotationSegments = new HashSet<int>();
-        private HashSet<int> loggedReshow => engine.loggedReshow;
 
         // Anchor vessel tracking moved to engine (T25).
         private HashSet<uint> loadedAnchorVessels => engine.loadedAnchorVessels;
@@ -3182,7 +3179,7 @@ namespace Parsek
                     ParsekLog.Info("Loop",
                         $"Anchor vessel unloaded: pid={pid}, destroying looped ghost #{i} '{rec.VesselName}'");
                     DestroyAllOverlapGhosts(i);
-                    DestroyTimelineGhost(i);
+                    engine.DestroyGhost(i);
                 }
             }
         }
@@ -5283,7 +5280,7 @@ namespace Parsek
                                 Destroy(info.particleSystems[i].gameObject);
                 }
 
-                DestroyReentryFxResources(previewGhostState.reentryFxInfo);
+                engine.DestroyReentryFxResources(previewGhostState.reentryFxInfo);
 
                 GhostPlaybackLogic.DestroyAllFakeCanopies(previewGhostState);
                 previewGhostState = null;
@@ -5368,7 +5365,7 @@ namespace Parsek
                 previewGhostState.SetInterpolated(interpResult);
                 GhostPlaybackLogic.ApplyPartEvents(-1, previewRecording, recordingTime, previewGhostState);
                 GhostPlaybackLogic.ApplyFlagEvents(previewGhostState, previewRecording, recordingTime);
-                UpdateReentryFx(-1, previewGhostState, previewRecording.VesselName ?? "Preview");
+                engine.UpdateReentryFx(-1, previewGhostState, previewRecording.VesselName ?? "Preview", TimeWarp.CurrentRate);
             }
         }
 
@@ -6141,15 +6138,6 @@ namespace Parsek
             return null;
         }
 
-        void SpawnTimelineGhost(int index, Recording rec)
-        {
-            engine.SpawnGhost(index, rec);
-        }
-
-        internal void DestroyTimelineGhost(int index)
-        {
-            engine.DestroyGhost(index);
-        }
 
         public void DestroyAllTimelineGhosts()
         {
@@ -6175,17 +6163,6 @@ namespace Parsek
         /// Checks whether the recording ended with destruction and spawns an explosion FX if so.
         /// Pure decision logic is in ShouldTriggerExplosion; this method handles the side effects.
         /// </summary>
-        void TriggerExplosionIfDestroyed(GhostPlaybackState state, Recording rec, int recIdx)
-        {
-            engine.TriggerExplosionIfDestroyed(state, rec, recIdx, TimeWarp.CurrentRate);
-        }
-
-        void CleanupActiveExplosions()
-        {
-            engine.CleanupActiveExplosions();
-        }
-
-        // DestroyGhostResources moved to engine (T25 Phase 4)
 
         /// <summary>
         /// Destroys all overlap ghosts for a recording index.
@@ -6233,7 +6210,7 @@ namespace Parsek
 
             // Destroy ghost if active (primary + overlap)
             DestroyAllOverlapGhosts(index);
-            DestroyTimelineGhost(index);
+            engine.DestroyGhost(index);
 
             // Remove from store (handles chain degradation + file deletion)
             RecordingStore.RemoveRecordingAt(index);
@@ -6293,16 +6270,6 @@ namespace Parsek
             }
         }
 
-        // DriveReentryToZero, UpdateReentryFx, DriveReentryLayers moved to engine (T25 Phase 5)
-        private void UpdateReentryFx(int recIdx, GhostPlaybackState state, string vesselName)
-        {
-            engine.UpdateReentryFx(recIdx, state, vesselName, TimeWarp.CurrentRate);
-        }
-
-        private void DestroyReentryFxResources(ReentryFxInfo info)
-        {
-            engine.DestroyReentryFxResources(info);
-        }
 
         /// <summary>
         /// Drive the camera pivot position every frame during watch mode.
@@ -6723,6 +6690,24 @@ namespace Parsek
             if (string.IsNullOrEmpty(ghostBody) || string.IsNullOrEmpty(activeBody) || ghostBody != activeBody)
                 return;
 
+            // Distance guard: KSP rendering breaks when camera is far from the active vessel
+            // (FloatingOrigin, terrain, atmosphere, skybox are all anchored to active vessel).
+            // Refuse watch if ghost is beyond the rendering-safe distance (#151).
+            const float MaxWatchDistanceKm = 100f;
+            if (FlightGlobals.ActiveVessel != null && gs.ghost != null)
+            {
+                float distKm = (float)(Vector3d.Distance(
+                    gs.ghost.transform.position, FlightGlobals.ActiveVessel.transform.position) / 1000.0);
+                if (distKm > MaxWatchDistanceKm)
+                {
+                    ParsekLog.Info("CameraFollow",
+                        $"EnterWatchMode refused: ghost #{index} \"{committed[index].VesselName}\" " +
+                        $"is {distKm.ToString("F0", CultureInfo.InvariantCulture)}km from active vessel (max {MaxWatchDistanceKm}km)");
+                    ScreenMessage($"Ghost too far to watch ({distKm:F0}km)", 3f);
+                    return;
+                }
+            }
+
             // Flight warning: if active vessel is in an unsafe state, show a brief screen message
             var av = FlightGlobals.ActiveVessel;
             if (av != null)
@@ -6958,8 +6943,8 @@ namespace Parsek
         /// </summary>
         int FindNextWatchTarget(int currentIndex, Recording currentRec)
         {
-            if (ParsekLog.IsVerboseEnabled)
-                ParsekLog.Verbose("Watch", $"FindNextWatchTarget: currentIndex={currentIndex}, chainId={currentRec.ChainId ?? "null"}, chainIndex={currentRec.ChainIndex}, treeId={currentRec.TreeId ?? "null"}, childBpId={currentRec.ChildBranchPointId ?? "null"}");
+            ParsekLog.VerboseRateLimited("Watch", "findNextWatch",
+                $"FindNextWatchTarget: currentIndex={currentIndex}, chainId={currentRec.ChainId ?? "null"}, chainIndex={currentRec.ChainIndex}, treeId={currentRec.TreeId ?? "null"}, childBpId={currentRec.ChildBranchPointId ?? "null"}");
 
             int result = GhostPlaybackLogic.FindNextWatchTarget(
                 currentRec,
@@ -6967,13 +6952,9 @@ namespace Parsek
                 RecordingStore.CommittedTrees,
                 HasActiveGhost);
 
-            if (ParsekLog.IsVerboseEnabled)
-            {
-                if (result >= 0)
-                    ParsekLog.Verbose("Watch", $"FindNextWatchTarget: found target at index {result}");
-                else
-                    ParsekLog.Verbose("Watch", $"FindNextWatchTarget: no next target found for index {currentIndex}");
-            }
+            if (result >= 0)
+                ParsekLog.Info("Watch", $"FindNextWatchTarget: found target at index {result}");
+
             return result;
         }
 

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -6260,10 +6260,6 @@ namespace Parsek
         }
 
         /// <summary>
-        /// Reindexes an int-keyed dictionary after a deletion: keys above removedIndex shift down by 1.
-        /// The entry at removedIndex (if any) is dropped.
-        /// </summary>
-        /// <summary>
         /// Returns true if the recording should be discarded as a pad failure:
         /// duration &lt; 10s AND max distance from launch &lt; 30m.
         /// </summary>
@@ -6272,6 +6268,10 @@ namespace Parsek
             return duration < 10.0 && maxDistanceFromLaunch < 30.0;
         }
 
+        /// <summary>
+        /// Reindexes an int-keyed dictionary after a deletion: keys above removedIndex shift down by 1.
+        /// The entry at removedIndex (if any) is dropped.
+        /// </summary>
         internal static void ReindexAfterDelete<T>(Dictionary<int, T> dict, int removedIndex)
         {
             var old = new Dictionary<int, T>(dict);

--- a/Source/Parsek/ParsekKSC.cs
+++ b/Source/Parsek/ParsekKSC.cs
@@ -819,8 +819,13 @@ namespace Parsek
         {
             if (state == null) return;
 
-            GhostPlaybackLogic.StopAllEngineFx(state);
-            GhostPlaybackLogic.StopAllRcsFx(state);
+            // Detach active particle systems so smoke trails linger (#107)
+            if (state.engineInfos != null)
+                foreach (var info in state.engineInfos.Values)
+                    GhostPlaybackLogic.DetachAndLingerParticleSystems(info.particleSystems, info.kspEmitters);
+            if (state.rcsInfos != null)
+                foreach (var info in state.rcsInfos.Values)
+                    GhostPlaybackLogic.DetachAndLingerParticleSystems(info.particleSystems, info.kspEmitters);
 
             GhostPlaybackLogic.DestroyAllFakeCanopies(state);
             if (state.ghost != null)

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -528,18 +528,47 @@ namespace Parsek
                 {
                     if (IsAutoMerge || forceAutoMerge)
                     {
-                        // autoMerge ON: auto-commit ghost-only (existing behavior)
+                        // Check if commit approval dialog should be shown (#88):
+                        // landed/splashed vessel going to KSC or Tracking Station
+                        var destScene = RecordingStore.PendingDestinationScene;
+                        TerminalState? termState = null;
                         if (RecordingStore.HasPending)
+                            termState = RecordingStore.Pending.TerminalStateValue;
+                        else if (RecordingStore.HasPendingTree)
                         {
-                            AutoCommitGhostOnly(RecordingStore.Pending);
-                            RecordingStore.CommitPending();
-                            ScreenMessages.PostScreenMessage("[Parsek] Recording committed to timeline", 5f);
+                            // Find root recording's terminal state from tree
+                            Recording rootRec;
+                            if (RecordingStore.PendingTree.Recordings.TryGetValue(
+                                RecordingStore.PendingTree.RootRecordingId, out rootRec))
+                                termState = rootRec.TerminalStateValue;
                         }
-                        if (RecordingStore.HasPendingTree)
+                        bool showApproval = !forceAutoMerge && destScene.HasValue &&
+                            GhostPlaybackLogic.ShouldShowCommitApproval(destScene.Value, termState);
+                        RecordingStore.PendingDestinationScene = null;
+
+                        if (showApproval && !mergeDialogPending)
                         {
-                            AutoCommitTreeGhostOnly(RecordingStore.PendingTree);
-                            RecordingStore.CommitPendingTree();
-                            ScreenMessages.PostScreenMessage("[Parsek] Tree recording committed to timeline", 5f);
+                            // Defer to approval dialog instead of auto-committing
+                            mergeDialogPending = true;
+                            StartCoroutine(ShowDeferredMergeDialog());
+                            ParsekLog.Info("Scenario",
+                                "Commit approval deferred: vessel landed/splashed at KSC/TS exit");
+                        }
+                        else
+                        {
+                            // autoMerge ON: auto-commit ghost-only (existing behavior)
+                            if (RecordingStore.HasPending)
+                            {
+                                AutoCommitGhostOnly(RecordingStore.Pending);
+                                RecordingStore.CommitPending();
+                                ScreenMessages.PostScreenMessage("[Parsek] Recording committed to timeline", 5f);
+                            }
+                            if (RecordingStore.HasPendingTree)
+                            {
+                                AutoCommitTreeGhostOnly(RecordingStore.PendingTree);
+                                RecordingStore.CommitPendingTree();
+                                ScreenMessages.PostScreenMessage("[Parsek] Tree recording committed to timeline", 5f);
+                            }
                         }
                     }
                     else if ((RecordingStore.HasPending || RecordingStore.HasPendingTree) && !mergeDialogPending)

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -1461,8 +1461,8 @@ namespace Parsek
                     continue;
 
                 ParsekLog.Info("Scenario",
-                    $"Stripping future PRELAUNCH vessel '{pv.vesselName}' " +
-                    $"(pid={pv.persistentId}) — not in quicksave whitelist");
+                    $"Stripping future vessel '{pv.vesselName}' " +
+                    $"(pid={pv.persistentId}, sit={pv.situation}) — not in quicksave whitelist");
                 protoVessels.RemoveAt(i);
                 stripped++;
             }
@@ -1480,8 +1480,9 @@ namespace Parsek
         {
             if (quicksavePids == null)
                 return false;
-            if (situation != Vessel.Situations.PRELAUNCH)
-                return false;
+            // Strip ANY vessel not in the quicksave whitelist (#164).
+            // Previously only stripped PRELAUNCH; now catches flags, landed capsules,
+            // and other player-created vessels from the future after rewind.
             return !quicksavePids.Contains(persistentId);
         }
 

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -458,6 +458,11 @@ namespace Parsek
                             skipPrelaunch: true);
                 }
 
+                // Rescue crew orphaned by vessel stripping (#116)
+                if (isRevert && HighLogic.CurrentGame?.flightState != null)
+                    CrewReservationManager.RescueOrphanedCrew(
+                        HighLogic.CurrentGame.flightState.protoVessels);
+
                 // Then restore from saved tree nodes (present on scene change, absent on revert)
                 ConfigNode[] savedTreeNodes = node.GetNodes("RECORDING_TREE");
                 if (savedTreeNodes.Length > 0)
@@ -743,6 +748,12 @@ namespace Parsek
                 }
                 RecordingStore.RewindQuicksaveVesselPids = null;
             }
+
+            // Rescue crew orphaned by vessel stripping (#116).
+            // Must run BEFORE ReserveSnapshotCrew so crew are Available for re-reservation.
+            if (HighLogic.CurrentGame?.flightState != null)
+                CrewReservationManager.RescueOrphanedCrew(
+                    HighLogic.CurrentGame.flightState.protoVessels);
 
             // Set budgetDeductionEpoch BEFORE scheduling coroutine
             // (prevents ApplyBudgetDeductionWhenReady from double-deducting)

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -767,6 +767,16 @@ namespace Parsek
             var quicksavePids = RecordingStore.RewindQuicksaveVesselPids;
             if (quicksavePids != null)
             {
+                // Add Parsek-spawned vessel PIDs to the whitelist so they survive the strip.
+                // These were spawned by timeline playback AFTER the quicksave and are legitimate.
+                foreach (var rec in recordings)
+                    if (rec.SpawnedVesselPersistentId != 0)
+                        quicksavePids.Add(rec.SpawnedVesselPersistentId);
+                foreach (var tree in RecordingStore.CommittedTrees)
+                    foreach (var rec in tree.Recordings.Values)
+                        if (rec.SpawnedVesselPersistentId != 0)
+                            quicksavePids.Add(rec.SpawnedVesselPersistentId);
+
                 var fs = HighLogic.CurrentGame?.flightState;
                 if (fs != null)
                 {

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -1817,9 +1817,16 @@ namespace Parsek
         /// </summary>
         private static void AutoCommitGhostOnly(Recording pending)
         {
-            CrewReservationManager.UnreserveCrewInSnapshot(pending.VesselSnapshot);
-            pending.VesselSnapshot = null;
-            ParsekLog.Info("Scenario", $"Auto-commit ghost-only: '{pending.VesselName}'" +
+            // Preserve snapshot for recordings that landed/splashed — they should be
+            // eligible for vessel spawning even when committed outside Flight (#EVA-spawn).
+            bool preserveForSpawn = pending.TerminalStateValue == TerminalState.Landed ||
+                pending.TerminalStateValue == TerminalState.Splashed;
+            if (!preserveForSpawn)
+            {
+                CrewReservationManager.UnreserveCrewInSnapshot(pending.VesselSnapshot);
+                pending.VesselSnapshot = null;
+            }
+            ParsekLog.Info("Scenario", $"Auto-commit{(preserveForSpawn ? "" : " ghost-only")}: '{pending.VesselName}'" +
                 (pending.TerminalStateValue.HasValue ? $" (terminal={pending.TerminalStateValue.Value})" : ""));
         }
 

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -767,16 +767,6 @@ namespace Parsek
             var quicksavePids = RecordingStore.RewindQuicksaveVesselPids;
             if (quicksavePids != null)
             {
-                // Add Parsek-spawned vessel PIDs to the whitelist so they survive the strip.
-                // These were spawned by timeline playback AFTER the quicksave and are legitimate.
-                foreach (var rec in recordings)
-                    if (rec.SpawnedVesselPersistentId != 0)
-                        quicksavePids.Add(rec.SpawnedVesselPersistentId);
-                foreach (var tree in RecordingStore.CommittedTrees)
-                    foreach (var rec in tree.Recordings.Values)
-                        if (rec.SpawnedVesselPersistentId != 0)
-                            quicksavePids.Add(rec.SpawnedVesselPersistentId);
-
                 var fs = HighLogic.CurrentGame?.flightState;
                 if (fs != null)
                 {

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -208,7 +208,7 @@ namespace Parsek
                 catch (System.NullReferenceException)
                 {
                     ParsekLog.Verbose("Scenario",
-                        "Failed to register main menu hook (GameEvents not ready) — will retry on next OnLoad");
+                        "Main menu hook deferred (GameEvents not ready) — will retry on next OnLoad");
                 }
             }
 

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -3162,13 +3162,11 @@ namespace Parsek
             GUILayout.Space(SpacingSmall);
             DrawLoopingSettings(s);
             GUILayout.Space(SpacingSmall);
-            DrawGhostCameraSettings(s);
+            DrawGhostSettings(s);
             GUILayout.Space(SpacingSmall);
             DrawDiagnosticsSettings(s);
             GUILayout.Space(SpacingSmall);
             DrawSamplingSettings(s);
-            GUILayout.Space(SpacingSmall);
-            DrawGhostCapSettings(s);
             GUILayout.Space(SpacingSmall);
             DrawDataManagementSettings(s);
             #endregion
@@ -3219,7 +3217,7 @@ namespace Parsek
         {
             GUILayout.Label("Recording", GUI.skin.box);
             bool autoRecordOnLaunch = GUILayout.Toggle(s.autoRecordOnLaunch,
-                new GUIContent("Auto-record on launch", "Start recording when a vessel leaves the pad or runway"));
+                new GUIContent(" Auto-record on launch", "Start recording when a vessel leaves the pad or runway"));
             if (autoRecordOnLaunch != s.autoRecordOnLaunch)
             {
                 s.autoRecordOnLaunch = autoRecordOnLaunch;
@@ -3227,7 +3225,7 @@ namespace Parsek
             }
 
             bool autoRecordOnEva = GUILayout.Toggle(s.autoRecordOnEva,
-                new GUIContent("Auto-record on EVA", "Start recording when a kerbal goes EVA from the pad"));
+                new GUIContent(" Auto-record on EVA", "Start recording when a kerbal goes EVA from the pad"));
             if (autoRecordOnEva != s.autoRecordOnEva)
             {
                 s.autoRecordOnEva = autoRecordOnEva;
@@ -3235,7 +3233,7 @@ namespace Parsek
             }
 
             bool autoMerge = GUILayout.Toggle(s.autoMerge,
-                new GUIContent("Auto-merge recordings", "When off, a confirmation dialog appears after each recording"));
+                new GUIContent(" Auto-merge recordings", "When off, a confirmation dialog appears after each recording"));
             if (autoMerge != s.autoMerge)
             {
                 s.autoMerge = autoMerge;
@@ -3297,13 +3295,15 @@ namespace Parsek
             GUILayout.EndHorizontal();
         }
 
-        private void DrawGhostCameraSettings(ParsekSettings s)
+        private void DrawGhostSettings(ParsekSettings s)
         {
-            GUILayout.Label("Ghost Camera", GUI.skin.box);
+            GUILayout.Label("Ghosts", GUI.skin.box);
+
+            // --- Camera cutoff ---
             GUILayout.BeginHorizontal();
-            GUILayout.Label(new GUIContent("Cutoff",
+            GUILayout.Label(new GUIContent("Camera cutoff",
                 "Watch mode auto-exits when ghost exceeds this distance from the active vessel"),
-                GUILayout.Width(40));
+                GUILayout.Width(85));
             {
                 if (!settingsCameraCutoffEditing)
                 {
@@ -3319,9 +3319,8 @@ namespace Parsek
                 }
                 else
                 {
-                    // Check Enter BEFORE TextField — TextField consumes KeyDown internally.
-                    // Also check on KeyUp as a fallback (some IMGUI event orderings miss KeyDown).
-                    bool submit = (Event.current.type == EventType.KeyDown || Event.current.type == EventType.KeyUp) &&
+                    // Enter key → commit (check before TextField, which consumes KeyDown)
+                    bool submitCutoff = Event.current.type == EventType.KeyDown &&
                         (Event.current.keyCode == KeyCode.Return || Event.current.keyCode == KeyCode.KeypadEnter);
 
                     GUI.SetNextControlName("CameraCutoffEdit");
@@ -3330,7 +3329,7 @@ namespace Parsek
                     if (newText != settingsCameraCutoffText)
                         settingsCameraCutoffText = newText;
 
-                    if (submit && GUI.GetNameOfFocusedControl() == "CameraCutoffEdit")
+                    if (submitCutoff)
                     {
                         CommitSettingsCameraCutoffEdit(s);
                         Event.current.Use();
@@ -3339,6 +3338,43 @@ namespace Parsek
             }
             GUILayout.Label("km");
             GUILayout.EndHorizontal();
+
+            // --- Soft caps ---
+            GUILayout.Space(SpacingSmall);
+
+            bool enabled = GUILayout.Toggle(s.ghostCapEnabled,
+                new GUIContent(" Enable soft caps",
+                    "Limit ghost count per distance zone to reduce rendering load"));
+            if (enabled != s.ghostCapEnabled)
+            {
+                s.ghostCapEnabled = enabled;
+                GhostSoftCapManager.Enabled = enabled;
+                ParsekLog.Info("UI", $"Ghost soft caps {(enabled ? "enabled" : "disabled")}");
+            }
+
+            if (!s.ghostCapEnabled)
+            {
+                GUILayout.Label("  (caps disabled \u2014 all ghosts rendered)", GUI.skin.label);
+                return;
+            }
+
+            DrawGhostCapSlider("Zone 1 reduce", "Nearby ghosts above this count get reduced fidelity",
+                ref s.ghostCapZone1Reduce, 2, 30, "ghostCap.zone1Reduce", s);
+            DrawGhostCapSlider("Zone 1 despawn", "Nearby ghosts above this count get despawned (lowest priority first)",
+                ref s.ghostCapZone1Despawn, 5, 50, "ghostCap.zone1Despawn", s);
+            DrawGhostCapSlider("Zone 2 simplify", "Distant ghosts above this count get simplified to orbit lines",
+                ref s.ghostCapZone2Simplify, 5, 60, "ghostCap.zone2Simplify", s);
+
+            // Enforce constraint: reduce must be less than despawn
+            if (s.ghostCapZone1Reduce >= s.ghostCapZone1Despawn)
+            {
+                s.ghostCapZone1Reduce = System.Math.Max(2, s.ghostCapZone1Despawn - 1);
+                GhostSoftCapManager.ApplySettings(
+                    s.ghostCapZone1Reduce, s.ghostCapZone1Despawn, s.ghostCapZone2Simplify);
+                ParsekLog.Info("UI",
+                    $"Clamped ghostCapZone1Reduce={s.ghostCapZone1Reduce} to stay below " +
+                    $"ghostCapZone1Despawn={s.ghostCapZone1Despawn}");
+            }
         }
 
         private void CommitSettingsCameraCutoffEdit(ParsekSettings s)
@@ -3358,7 +3394,7 @@ namespace Parsek
         private void DrawDiagnosticsSettings(ParsekSettings s)
         {
             GUILayout.Label("Diagnostics", GUI.skin.box);
-            bool verboseLogging = GUILayout.Toggle(s.verboseLogging, "Verbose logging (development default)");
+            bool verboseLogging = GUILayout.Toggle(s.verboseLogging, " Verbose logging (development default)");
             if (verboseLogging != s.verboseLogging)
             {
                 s.verboseLogging = verboseLogging;
@@ -3422,43 +3458,6 @@ namespace Parsek
                     $"Setting changed: {logKey}={value}", 1.0);
             }
             GUILayout.EndHorizontal();
-        }
-
-        private void DrawGhostCapSettings(ParsekSettings s)
-        {
-            GUILayout.Label("Ghost Soft Caps", GUI.skin.box);
-
-            bool enabled = GUILayout.Toggle(s.ghostCapEnabled, "Enable ghost soft caps");
-            if (enabled != s.ghostCapEnabled)
-            {
-                s.ghostCapEnabled = enabled;
-                GhostSoftCapManager.Enabled = enabled;
-                ParsekLog.Info("UI", $"Ghost soft caps {(enabled ? "enabled" : "disabled")}");
-            }
-
-            if (!s.ghostCapEnabled)
-            {
-                GUILayout.Label("  (caps disabled — all ghosts rendered)", GUI.skin.label);
-                return;
-            }
-
-            DrawGhostCapSlider("Zone 1 reduce", "Nearby ghosts above this count get reduced fidelity",
-                ref s.ghostCapZone1Reduce, 2, 30, "ghostCap.zone1Reduce", s);
-            DrawGhostCapSlider("Zone 1 despawn", "Nearby ghosts above this count get despawned (lowest priority first)",
-                ref s.ghostCapZone1Despawn, 5, 50, "ghostCap.zone1Despawn", s);
-            DrawGhostCapSlider("Zone 2 simplify", "Distant ghosts above this count get simplified to orbit lines",
-                ref s.ghostCapZone2Simplify, 5, 60, "ghostCap.zone2Simplify", s);
-
-            // Enforce constraint: reduce must be less than despawn
-            if (s.ghostCapZone1Reduce >= s.ghostCapZone1Despawn)
-            {
-                s.ghostCapZone1Reduce = System.Math.Max(2, s.ghostCapZone1Despawn - 1);
-                GhostSoftCapManager.ApplySettings(
-                    s.ghostCapZone1Reduce, s.ghostCapZone1Despawn, s.ghostCapZone2Simplify);
-                ParsekLog.Info("UI",
-                    $"Clamped ghostCapZone1Reduce={s.ghostCapZone1Reduce} to stay below " +
-                    $"ghostCapZone1Despawn={s.ghostCapZone1Despawn}");
-            }
         }
 
         private void DrawDataManagementSettings(ParsekSettings s)

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -1310,10 +1310,14 @@ namespace Parsek
             else
             {
                 statusStyle = statusStylePast;
-                statusText = rec.IsDebris ? "past"
-                    : rec.Points.Count > 0
-                        ? SelectiveSpawnUI.FormatCountdown(rec.StartUT - now)
-                        : (rec.TerminalStateValue?.ToString() ?? "past");
+                if (rec.IsDebris)
+                    statusText = "past";
+                else if (rec.VesselSpawned && rec.TerminalStateValue.HasValue)
+                    statusText = rec.TerminalStateValue.Value.ToString();
+                else if (rec.Points.Count > 0)
+                    statusText = SelectiveSpawnUI.FormatCountdown(rec.StartUT - now);
+                else
+                    statusText = rec.TerminalStateValue?.ToString() ?? "past";
             }
 
             // Phase 6d-3: Chain status tooltip — show ghost chain info on hover

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -1302,12 +1302,16 @@ namespace Parsek
             else if (now <= rec.EndUT)
             {
                 statusStyle = statusStyleActive;
-                statusText = "Active";
+                statusText = rec.Points.Count > 0
+                    ? SelectiveSpawnUI.FormatCountdown(rec.StartUT - now)
+                    : "active";
             }
             else
             {
                 statusStyle = statusStylePast;
-                statusText = rec.TerminalStateValue?.ToString() ?? "past";
+                statusText = rec.Points.Count > 0
+                    ? SelectiveSpawnUI.FormatCountdown(rec.StartUT - now)
+                    : (rec.TerminalStateValue?.ToString() ?? "past");
             }
 
             // Phase 6d-3: Chain status tooltip — show ghost chain info on hover

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -1742,8 +1742,19 @@ namespace Parsek
 
             GUILayout.BeginHorizontal();
 
-            // Spacers matching header widget types for alignment
-            GUILayout.Space(ColW_Enable);
+            // Enable checkbox (aggregate over chain members)
+            int chainEnabledCount = 0;
+            for (int m = 0; m < members.Count; m++)
+                if (committed[members[m]].PlaybackEnabled) chainEnabledCount++;
+            bool chainAllEnabled = members.Count > 0 && chainEnabledCount == members.Count;
+            bool chainNewEnabled = GUILayout.Toggle(chainAllEnabled, "", GUILayout.Width(ColW_Enable));
+            if (chainNewEnabled != chainAllEnabled)
+            {
+                for (int m = 0; m < members.Count; m++)
+                    committed[members[m]].PlaybackEnabled = chainNewEnabled;
+                ParsekLog.Info("UI", $"Chain '{chainId}' playback set to {chainNewEnabled} ({members.Count} segments)");
+            }
+
             GUILayout.Space(ColW_Index);
 
             // Indent inside Name column for chains in sub-groups
@@ -1778,8 +1789,22 @@ namespace Parsek
                 ParsekLog.Verbose("UI", $"Group popup opened for chain '{chainName}'");
             }
 
-            // Spacers for remaining columns (Loop, Period, Watch, Rewind, Hide)
-            GUILayout.Label("", GUILayout.Width(ColW_Loop));
+            // Loop checkbox (aggregate over chain members)
+            int chainLoopCount = 0;
+            for (int m = 0; m < members.Count; m++)
+                if (committed[members[m]].LoopPlayback) chainLoopCount++;
+            bool chainAllLoop = members.Count > 0 && chainLoopCount == members.Count;
+            GUILayout.BeginHorizontal(GUILayout.Width(ColW_Loop));
+            GUILayout.FlexibleSpace();
+            bool chainNewLoop = GUILayout.Toggle(chainAllLoop, "");
+            GUILayout.FlexibleSpace();
+            GUILayout.EndHorizontal();
+            if (chainNewLoop != chainAllLoop)
+            {
+                for (int m = 0; m < members.Count; m++)
+                    committed[members[m]].LoopPlayback = chainNewLoop;
+                ParsekLog.Info("UI", $"Chain '{chainId}' loop set to {chainNewLoop} ({members.Count} segments)");
+            }
             GUILayout.Label("", GUILayout.Width(ColW_Period));
             if (InFlight) GUILayout.Label("", GUILayout.Width(ColW_Watch));
             GUILayout.Label("", GUILayout.Width(ColW_Rewind));

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -2885,6 +2885,8 @@ namespace Parsek
             }
 
             EnsureOpaqueWindowStyle();
+            // Reset height each frame so GUILayout auto-sizes to content
+            settingsWindowRect.height = 10;
             settingsWindowRect = ClickThruBlocker.GUILayoutWindow(
                 "ParsekSettings".GetHashCode(),
                 settingsWindowRect,
@@ -3324,35 +3326,39 @@ namespace Parsek
                 "Watch mode auto-exits when ghost exceeds this distance from the active vessel"),
                 GUILayout.Width(85));
             {
-                if (!settingsCameraCutoffEditing)
+                // Single-branch approach: always use the edit buffer.
+                // On focus gain, snapshot the display value. On focus loss or Enter, commit.
+                GUI.SetNextControlName("CameraCutoffEdit");
+                bool wasFocused = settingsCameraCutoffEditing;
+
+                // Check Enter before TextField (TextField consumes KeyDown internally)
+                bool submitCutoff = wasFocused &&
+                    Event.current.type == EventType.KeyDown &&
+                    (Event.current.keyCode == KeyCode.Return || Event.current.keyCode == KeyCode.KeypadEnter);
+
+                string editText = wasFocused ? settingsCameraCutoffText
+                    : s.ghostCameraCutoffKm.ToString("F0", System.Globalization.CultureInfo.InvariantCulture);
+                string newText = GUILayout.TextField(editText, GUILayout.Width(45));
+                settingsCameraCutoffEditRect = GUILayoutUtility.GetLastRect();
+
+                bool isFocused = GUI.GetNameOfFocusedControl() == "CameraCutoffEdit";
+                if (isFocused && !wasFocused)
                 {
-                    string displayText = s.ghostCameraCutoffKm.ToString("F0", System.Globalization.CultureInfo.InvariantCulture);
-                    GUI.SetNextControlName("CameraCutoffEdit");
-                    string newText = GUILayout.TextField(displayText, GUILayout.Width(45));
-                    if (GUI.GetNameOfFocusedControl() == "CameraCutoffEdit")
-                    {
-                        settingsCameraCutoffText = newText;
-                        settingsCameraCutoffEditing = true;
-                        settingsCameraCutoffEditRect = GUILayoutUtility.GetLastRect();
-                    }
+                    // Just gained focus — start editing
+                    settingsCameraCutoffText = newText;
+                    settingsCameraCutoffEditing = true;
                 }
-                else
+                else if (isFocused)
                 {
-                    // Enter key → commit (check before TextField, which consumes KeyDown)
-                    bool submitCutoff = Event.current.type == EventType.KeyDown &&
-                        (Event.current.keyCode == KeyCode.Return || Event.current.keyCode == KeyCode.KeypadEnter);
+                    // Still editing — track text changes
+                    settingsCameraCutoffText = newText;
+                }
 
-                    GUI.SetNextControlName("CameraCutoffEdit");
-                    string newText = GUILayout.TextField(settingsCameraCutoffText, GUILayout.Width(45));
-                    settingsCameraCutoffEditRect = GUILayoutUtility.GetLastRect();
-                    if (newText != settingsCameraCutoffText)
-                        settingsCameraCutoffText = newText;
-
-                    if (submitCutoff)
-                    {
-                        CommitSettingsCameraCutoffEdit(s);
-                        Event.current.Use();
-                    }
+                if (submitCutoff || (wasFocused && !isFocused))
+                {
+                    // Enter pressed or focus lost — commit
+                    CommitSettingsCameraCutoffEdit(s);
+                    if (submitCutoff) Event.current.Use();
                 }
             }
             GUILayout.Label("km");

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -2861,7 +2861,7 @@ namespace Parsek
             if (statusStyleFuture != null) return;
 
             statusStyleFuture = new GUIStyle(GUI.skin.label);
-            statusStyleFuture.normal.textColor = Color.gray;
+            statusStyleFuture.normal.textColor = Color.white;
 
             statusStyleActive = new GUIStyle(GUI.skin.label);
             statusStyleActive.normal.textColor = Color.green;

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -1398,7 +1398,10 @@ namespace Parsek
                         ? "Fast-forward to this launch"
                         : ffReason;
                     if (GUILayout.Button(new GUIContent("FF", tooltip), GUILayout.Width(ColW_Rewind)))
+                    {
+                        ParsekLog.Info("UI", $"FF button clicked: #{ri} \"{rec.VesselName}\"");
                         ShowFastForwardConfirmation(rec);
+                    }
                     GUI.enabled = true;
                 }
                 else if (hasRewindSave)
@@ -1412,7 +1415,10 @@ namespace Parsek
                         ? "Rewind to this launch"
                         : rewindReason;
                     if (GUILayout.Button(new GUIContent("R", tooltip), GUILayout.Width(ColW_Rewind)))
+                    {
+                        ParsekLog.Info("UI", $"Rewind button clicked: #{ri} \"{rec.VesselName}\"");
                         ShowRewindConfirmation(rec);
+                    }
                     GUI.enabled = true;
                 }
                 else

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -3420,6 +3420,7 @@ namespace Parsek
             }
             settingsCameraCutoffEditing = false;
             settingsCameraCutoffEditRect = default;
+            GUIUtility.keyboardControl = 0;
         }
 
         private void DrawDiagnosticsSettings(ParsekSettings s)

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -65,9 +65,9 @@ namespace Parsek
         private const float ColW_Phase = 70f;
         private const float ColW_Index = 30f;
         private const float ColW_Launch = 110f;
-        private const float ColW_Countdown = 95f;
+        // ColW_Countdown removed (#98) — merged into Status column
         private const float ColW_Dur = 65f;
-        private const float ColW_Status = 55f;
+        private const float ColW_Status = 95f;
         private const float ColW_Loop = 55f;
         private const float ColW_Watch = 50f;
         private const float ColW_Rewind = 65f;
@@ -1073,7 +1073,6 @@ namespace Parsek
                 DrawSortableHeader("Name", SortColumn.Name, 0, true);
                 DrawSortableHeader("Phase", SortColumn.Phase, ColW_Phase);
                 DrawSortableHeader("Launch", SortColumn.LaunchTime, ColW_Launch);
-                DrawSortableHeader("Countdown", SortColumn.LaunchTime, ColW_Countdown);
                 DrawSortableHeader("Duration", SortColumn.Duration, ColW_Dur);
 
                 if (showExpandedStats)
@@ -1276,13 +1275,6 @@ namespace Parsek
                 : "-";
             GUILayout.Label(launchTime, GUILayout.Width(ColW_Launch));
 
-            // Countdown (T-) / Mission time (T+)
-            if (rec.Points.Count > 0)
-                GUILayout.Label(SelectiveSpawnUI.FormatCountdown(rec.StartUT - now),
-                    GUILayout.Width(ColW_Countdown));
-            else
-                GUILayout.Label("-", GUILayout.Width(ColW_Countdown));
-
             // Duration
             double dur = rec.EndUT - rec.StartUT;
             GUILayout.Label(FormatDuration(dur), GUILayout.Width(ColW_Dur));
@@ -1297,23 +1289,25 @@ namespace Parsek
                 GUILayout.Label(stats.pointCount.ToString(), GUILayout.Width(ColW_Pts));
             }
 
-            // Status
+            // Status (#98: merged countdown into status column)
             GUIStyle statusStyle;
             string statusText;
             if (now < rec.StartUT)
             {
                 statusStyle = statusStyleFuture;
-                statusText = "future";
+                statusText = rec.Points.Count > 0
+                    ? SelectiveSpawnUI.FormatCountdown(rec.StartUT - now)
+                    : "future";
             }
             else if (now <= rec.EndUT)
             {
                 statusStyle = statusStyleActive;
-                statusText = "active";
+                statusText = "Active";
             }
             else
             {
                 statusStyle = statusStylePast;
-                statusText = "past";
+                statusText = rec.TerminalStateValue?.ToString() ?? "past";
             }
 
             // Phase 6d-3: Chain status tooltip — show ghost chain info on hover

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -67,7 +67,7 @@ namespace Parsek
         private const float ColW_Launch = 110f;
         // ColW_Countdown removed (#98) — merged into Status column
         private const float ColW_Dur = 65f;
-        private const float ColW_Status = 95f;
+        private const float ColW_Status = 120f;
         private const float ColW_Loop = 55f;
         private const float ColW_Watch = 50f;
         private const float ColW_Rewind = 65f;
@@ -152,6 +152,10 @@ namespace Parsek
         private string settingsCameraCutoffText = "";
         private Rect settingsCameraCutoffEditRect;
         private const float ColW_Period = 80f;
+
+        // R/FF button state tracking for transition logging
+        private Dictionary<int, bool> lastCanRewind = new Dictionary<int, bool>();
+        private Dictionary<int, bool> lastCanFF = new Dictionary<int, bool>();
 
         // Cached styles for status labels
         private GUIStyle statusStyleFuture;
@@ -1393,6 +1397,12 @@ namespace Parsek
                     string ffReason;
                     bool isRecording = InFlight && flight.IsRecording;
                     bool canFF = RecordingStore.CanFastForward(rec, out ffReason, isRecording: isRecording);
+                    bool prevFF;
+                    if (!lastCanFF.TryGetValue(ri, out prevFF) || prevFF != canFF)
+                    {
+                        lastCanFF[ri] = canFF;
+                        ParsekLog.Verbose("UI", $"FF #{ri} \"{rec.VesselName}\": {(canFF ? "enabled" : "disabled — " + ffReason)}");
+                    }
                     GUI.enabled = canFF;
                     string tooltip = canFF
                         ? "Fast-forward to this launch"
@@ -1410,6 +1420,12 @@ namespace Parsek
                     string rewindReason;
                     bool isRecording = InFlight && flight.IsRecording;
                     bool canRewind = RecordingStore.CanRewind(rec, out rewindReason, isRecording: isRecording);
+                    bool prevR;
+                    if (!lastCanRewind.TryGetValue(ri, out prevR) || prevR != canRewind)
+                    {
+                        lastCanRewind[ri] = canRewind;
+                        ParsekLog.Verbose("UI", $"R #{ri} \"{rec.VesselName}\": {(canRewind ? "enabled" : "disabled — " + rewindReason)}");
+                    }
                     GUI.enabled = canRewind;
                     string tooltip = canRewind
                         ? "Rewind to this launch"

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -1302,16 +1302,18 @@ namespace Parsek
             else if (now <= rec.EndUT)
             {
                 statusStyle = statusStyleActive;
-                statusText = rec.Points.Count > 0
-                    ? SelectiveSpawnUI.FormatCountdown(rec.StartUT - now)
-                    : "active";
+                statusText = rec.IsDebris ? "active"
+                    : rec.Points.Count > 0
+                        ? SelectiveSpawnUI.FormatCountdown(rec.StartUT - now)
+                        : "active";
             }
             else
             {
                 statusStyle = statusStylePast;
-                statusText = rec.Points.Count > 0
-                    ? SelectiveSpawnUI.FormatCountdown(rec.StartUT - now)
-                    : (rec.TerminalStateValue?.ToString() ?? "past");
+                statusText = rec.IsDebris ? "past"
+                    : rec.Points.Count > 0
+                        ? SelectiveSpawnUI.FormatCountdown(rec.StartUT - now)
+                        : (rec.TerminalStateValue?.ToString() ?? "past");
             }
 
             // Phase 6d-3: Chain status tooltip — show ghost chain info on hover

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -1312,12 +1312,12 @@ namespace Parsek
                 statusStyle = statusStylePast;
                 if (rec.IsDebris)
                     statusText = "past";
-                else if (rec.VesselSpawned && rec.TerminalStateValue.HasValue)
+                else if (rec.TerminalStateValue.HasValue)
                     statusText = rec.TerminalStateValue.Value.ToString();
                 else if (rec.Points.Count > 0)
                     statusText = SelectiveSpawnUI.FormatCountdown(rec.StartUT - now);
                 else
-                    statusText = rec.TerminalStateValue?.ToString() ?? "past";
+                    statusText = "past";
             }
 
             // Phase 6d-3: Chain status tooltip — show ghost chain info on hover
@@ -3336,39 +3336,35 @@ namespace Parsek
                 "Watch mode auto-exits when ghost exceeds this distance from the active vessel"),
                 GUILayout.Width(85));
             {
-                // Single-branch approach: always use the edit buffer.
-                // On focus gain, snapshot the display value. On focus loss or Enter, commit.
-                GUI.SetNextControlName("CameraCutoffEdit");
-                bool wasFocused = settingsCameraCutoffEditing;
-
-                // Check Enter before TextField (TextField consumes KeyDown internally)
-                bool submitCutoff = wasFocused &&
-                    Event.current.type == EventType.KeyDown &&
-                    (Event.current.keyCode == KeyCode.Return || Event.current.keyCode == KeyCode.KeypadEnter);
-
-                string editText = wasFocused ? settingsCameraCutoffText
-                    : s.ghostCameraCutoffKm.ToString("F0", System.Globalization.CultureInfo.InvariantCulture);
-                string newText = GUILayout.TextField(editText, GUILayout.Width(45));
-                settingsCameraCutoffEditRect = GUILayoutUtility.GetLastRect();
-
-                bool isFocused = GUI.GetNameOfFocusedControl() == "CameraCutoffEdit";
-                if (isFocused && !wasFocused)
+                if (!settingsCameraCutoffEditing)
                 {
-                    // Just gained focus — start editing
-                    settingsCameraCutoffText = newText;
-                    settingsCameraCutoffEditing = true;
+                    string displayText = s.ghostCameraCutoffKm.ToString("F0", System.Globalization.CultureInfo.InvariantCulture);
+                    GUI.SetNextControlName("CameraCutoffEdit");
+                    string newText = GUILayout.TextField(displayText, GUILayout.Width(45));
+                    if (GUI.GetNameOfFocusedControl() == "CameraCutoffEdit")
+                    {
+                        settingsCameraCutoffText = newText;
+                        settingsCameraCutoffEditing = true;
+                        settingsCameraCutoffEditRect = GUILayoutUtility.GetLastRect();
+                    }
                 }
-                else if (isFocused)
+                else
                 {
-                    // Still editing — track text changes
-                    settingsCameraCutoffText = newText;
-                }
+                    // Enter key → commit (check before TextField, which consumes KeyDown)
+                    bool submitCutoff = Event.current.type == EventType.KeyDown &&
+                        (Event.current.keyCode == KeyCode.Return || Event.current.keyCode == KeyCode.KeypadEnter);
 
-                if (submitCutoff || (wasFocused && !isFocused))
-                {
-                    // Enter pressed or focus lost — commit
-                    CommitSettingsCameraCutoffEdit(s);
-                    if (submitCutoff) Event.current.Use();
+                    GUI.SetNextControlName("CameraCutoffEdit");
+                    string newText = GUILayout.TextField(settingsCameraCutoffText, GUILayout.Width(45));
+                    settingsCameraCutoffEditRect = GUILayoutUtility.GetLastRect();
+                    if (newText != settingsCameraCutoffText)
+                        settingsCameraCutoffText = newText;
+
+                    if (submitCutoff)
+                    {
+                        CommitSettingsCameraCutoffEdit(s);
+                        Event.current.Use();
+                    }
                 }
             }
             GUILayout.Label("km");

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -1346,6 +1346,9 @@ namespace Parsek
         internal static HashSet<uint> PendingCleanupPids { get; set; }
         internal static HashSet<string> PendingCleanupNames { get; set; }
 
+        // Destination scene from last OnSceneChangeRequested — consumed in OnLoad (#88)
+        internal static GameScenes? PendingDestinationScene { get; set; }
+
         // PIDs of vessels that existed in the rewind quicksave.
         // Used by StripFuturePrelaunchVessels to whitelist known-good PRELAUNCH vessels
         // (e.g. the player's pad vessel) and strip only unknown ones from the future.

--- a/Source/Parsek/ResourceBudget.cs
+++ b/Source/Parsek/ResourceBudget.cs
@@ -202,9 +202,6 @@ namespace Parsek
             budgetDirty = false;
             var result = new BudgetSummary();
 
-            ParsekLog.Verbose("ResourceBudget",
-                $"ComputeTotal: {recordings?.Count ?? 0} recordings, {milestones?.Count ?? 0} milestones, {trees?.Count ?? 0} trees");
-
             if (recordings != null)
             {
                 for (int i = 0; i < recordings.Count; i++)
@@ -220,15 +217,9 @@ namespace Parsek
             {
                 for (int i = 0; i < trees.Count; i++)
                 {
-                    double treeFunds = TreeCommittedFundsCost(trees[i]);
-                    double treeScience = TreeCommittedScienceCost(trees[i]);
-                    double treeRep = TreeCommittedReputationCost(trees[i]);
-                    result.reservedFunds += treeFunds;
-                    result.reservedScience += treeScience;
-                    result.reservedReputation += treeRep;
-                    ParsekLog.Verbose("ResourceBudget",
-                        $"ComputeTotal tree: '{trees[i].TreeName}' resourcesApplied={trees[i].ResourcesApplied} " +
-                        $"funds={treeFunds:F0} science={treeScience:F1} rep={treeRep:F1}");
+                    result.reservedFunds += TreeCommittedFundsCost(trees[i]);
+                    result.reservedScience += TreeCommittedScienceCost(trees[i]);
+                    result.reservedReputation += TreeCommittedReputationCost(trees[i]);
                 }
             }
 
@@ -241,10 +232,6 @@ namespace Parsek
                     result.reservedScience += MilestoneCommittedScience(milestones[i]);
                 }
             }
-
-            ParsekLog.Verbose("ResourceBudget",
-                $"ComputeTotal result: reservedFunds={result.reservedFunds:F0}, " +
-                $"reservedScience={result.reservedScience:F1}, reservedReputation={result.reservedReputation:F1}");
 
             cachedBudget = result;
             return result;

--- a/Source/Parsek/SpawnCollisionDetector.cs
+++ b/Source/Parsek/SpawnCollisionDetector.cs
@@ -110,7 +110,8 @@ namespace Parsek
             var parts = new List<(Vector3 localPos, float halfExtent)>();
             for (int i = 0; i < partNodes.Length; i++)
             {
-                string posStr = partNodes[i].GetValue("pos");
+                string posStr = partNodes[i].GetValue("pos")
+                    ?? partNodes[i].GetValue("position");
                 if (string.IsNullOrEmpty(posStr))
                     continue;
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -887,7 +887,7 @@ After a vessel switch, a boarding event was detected but the confirmation timer 
 
 **Impact:** Low — boarding not recorded, but kerbal not lost.
 
-**Status:** Open — low priority
+**Status:** Fixed — increased confirmation window from 3 frames (~60ms) to 10 frames (~200ms). Enough time for vessel switch to complete without risk of stale confirmations.
 
 ## 58. Background vessel recording requires KSP debris persistence enabled
 
@@ -1856,9 +1856,11 @@ After FF (fast-forward time jump) to a distant recording segment, Parsek transfe
 
 `ModuleAnimateHeat` on pointyNoseConeB (Protective Rocket Nose Cone Mk7) doesn't match the expected classification pattern. Logged at VERBOSE level. These nose cones won't have heat glow animation on ghost playback.
 
-**Priority:** Low — cosmetic, barely noticeable
+**Investigation notes:** `ModuleAnimateHeat` exposes only `lerpMin`/`lerpOffset` config fields via KSPField — the runtime heat value (`part.skinTemperature / part.skinMaxTemp`) is computed internally and applied directly to the Animation clip. None of the candidate field names in `TryClassifyAnimateHeatState` match. Would need reflection on `Animation[animationName].normalizedTime` to read it, which is fragile and not worth the complexity for a barely-visible effect on nose cones.
 
-**Status:** Open
+**Priority:** Low — cosmetic, barely noticeable, would require reflection hack
+
+**Status:** Won't fix — heat glow on nose cones is negligible; classifier correctly handles engine heat modules which are the primary use case
 
 ## 154. parsek_38.png texture compression warning
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1636,7 +1636,7 @@ Not a crash or leak (explosions decay naturally), but 90 concurrent particle-emi
 
 The pure predicates (`ShouldAbandonSpawnDeathLoop`, `ShouldFlushDeferredSpawns`, `ShouldSkipDeferredSpawn`) are tested; only the integration through the policy event handlers is missing.
 
-**Investigation notes:** `FlushDeferredSpawns` works correctly in ParsekFlight — moving to policy is pure refactoring with heavy state dependency (`pendingSpawnRecordingIds`, `pendingWatchRecordingId`, `SpawnVesselOrChainTip`, `DeferredActivateVessel`). Low value, high risk. Spawn-death detection is genuinely absent: `SpawnDeathCount` is never read in the engine path, and no `onVesselTerminated` subscription exists to detect spawned vessel destruction. Implementing requires event subscription + PID-to-recording matching.
+**Investigation notes:** `FlushDeferredSpawns` works correctly in ParsekFlight — moving to policy is pure refactoring with heavy state dependency (`pendingSpawnRecordingIds`, `pendingWatchRecordingId`, `SpawnVesselOrChainTip`, `DeferredActivateVessel`). Low value, high risk. Spawn-death detection is genuinely absent: `SpawnDeathCount` is never read in the engine path, and no `onVesselTerminated` subscription exists to detect spawned vessel destruction. Implementing requires event subscription + PID-to-recording matching. **Dormant bug:** policy and ParsekFlight have duplicate `pendingSpawnRecordingIds`/`pendingWatchRecordingId` fields — policy populates its copies in `HandlePlaybackCompleted` but the flush reads ParsekFlight's copies. Currently works because both paths add to the same set independently, but could diverge.
 
 **Priority:** Low — edge case (rapid spawn-death cycles), FlushDeferredSpawns works via existing path
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1158,7 +1158,7 @@ After recording completes (via chain boundary or scene change), the recording is
 
 **Design decision:** Show approval dialog when recording ends due to scene change to Space Center or Tracking Station AND vessel is landed/splashed (meaningful endpoint). Auto-commit for: game exit (no dialog opportunity), boundary splits, chain continuations, and mid-flight scene changes. The dialog should offer Keep / Discard.
 
-**Status:** Open — design decided, needs implementation
+**Status:** Fixed — `ShouldShowCommitApproval` predicate checks destination scene (KSC/TS) and terminal state (Landed/Splashed). When triggered with autoMerge ON, defers to the existing merge dialog instead of auto-committing. Game exit (forceAutoMerge) bypasses. 6 tests.
 
 ## 89. Watch button enabled for distant ghosts beyond visual range
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1156,7 +1156,9 @@ When a chain recording hits a boundary split (e.g., atmosphere exit), the commit
 
 After recording completes (via chain boundary or scene change), the recording is auto-committed without showing a dialog asking the user to approve. The merge dialog is currently only shown on revert, not on normal commit flow. User expects to be asked before committing.
 
-**Status:** Open — design decision needed: should normal commits require approval?
+**Design decision:** Show approval dialog when recording ends due to scene change to Space Center or Tracking Station AND vessel is landed/splashed (meaningful endpoint). Auto-commit for: game exit (no dialog opportunity), boundary splits, chain continuations, and mid-flight scene changes. The dialog should offer Keep / Discard.
+
+**Status:** Open — design decided, needs implementation
 
 ## 89. Watch button enabled for distant ghosts beyond visual range
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1909,6 +1909,16 @@ After rewind, `StripOrphanedSpawnedVessels` only matches vessels by recording na
 
 **Status:** Fixed — removed PRELAUNCH restriction from `ShouldStripFuturePrelaunch`. Now strips ALL vessel types not in the quicksave PID whitelist. The whitelist is captured from the actual quicksave at rewind time, so only vessels that existed at the rewind target UT survive.
 
+## 168. Parsek-spawned vessels not re-spawned at correct time after rewind
+
+After rewind, the expanded strip (#164) correctly removes all non-quicksave vessels including Parsek-spawned ones. But those vessels need to be re-spawned at their recording's EndUT as the timeline plays forward. The UT guard in `ShouldSpawnAtKscEnd` (#163) prevents premature spawning, and `ShouldSpawnAtRecordingEnd` handles Flight scene spawning. However, `SpawnedVesselPersistentId` and `VesselSpawned` are not reset after the strip, so the spawn system thinks the vessel is already spawned and skips re-spawning.
+
+**Fix:** `ResetAllPlaybackState` (or a new post-strip reset) must clear `SpawnedVesselPersistentId` and `VesselSpawned` on all committed recordings after the rewind strip so the spawn system re-evaluates them.
+
+**Priority:** High — spawned vessels disappear permanently after rewind
+
+**Status:** Open
+
 ## 165. Engine seed event records throttle=0.00 at recording start
 
 When recording starts on the launchpad with staged engines, `CacheEngineModules` seeds `EngineIgnited` with `throttle=0.00` (the current value before the player throttles up). During playback, the ghost processes `EngineIgnited(0.00)` → plume off → then `EngineThrottle(1.00)` a few frames later → plume on. Creates a visible flame flash-off at the start of every playback cycle.

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1884,14 +1884,14 @@ When recording stops due to vessel switch (non-chain, non-tree), `CaptureAtStop`
 
 Areas identified by code path simulation that lack unit tests:
 
-1. `HandleVesselSwitchDuringRecording` with `Stop` decision — no test verifies recording data is committed/stashed rather than orphaned (now fixed by #155, but no regression test)
-2. `CacheEngineModules` with partially-loaded vessel — only null vessel tested; no test for null part entries in parts list
-3. `CheckAtmosphereBoundary` → `HandleAtmosphereBoundarySplit` → `HandleSoiChangeSplit` in sequence — no integration test for rapid multi-boundary scenario
-4. `FallbackCommitSplitRecorder` pad-failure threshold (< 10s AND < 30m) — not tested for the split-recorder fallback path specifically
+1. `HandleVesselSwitchDuringRecording` with `Stop` decision — no test verifies recording data is committed/stashed rather than orphaned (fixed by #155, no regression test — requires Unity runtime)
+2. `CacheEngineModules` with partially-loaded vessel — null vessel tested; null part entries require Unity `Vessel` instance (not feasible in unit tests)
+3. `CheckAtmosphereBoundary` → `HandleAtmosphereBoundarySplit` → `HandleSoiChangeSplit` in sequence — requires full `FlightRecorder` instance state (in-game integration test only)
+4. `FallbackCommitSplitRecorder` pad-failure threshold (< 10s AND < 30m) — **done**: extracted `IsPadFailure` static method, 6 boundary tests + 1 CacheEngineModules null-vessel test
 
 **Priority:** Low — test infrastructure
 
-**Status:** Open
+**Status:** Partially fixed — item 4 done (7 tests). Items 1-3 require Unity runtime, deferred to in-game testing.
 
 # In-Game Tests
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1427,7 +1427,7 @@ General principle: prefer toggling KSP's own components on/off via reflection ov
 
 **Priority:** Low — improvement opportunity, not a bug
 
-**Status:** Open
+**Status:** Won't fix — stock FX modules (`FXModuleAnimateThrottle`, `FXModuleAnimateRCS`) are `PartModule` subclasses requiring a live `Part` with `vessel` reference. Ghost parts are mesh-only GameObjects by design — attaching real Parts would add physics, CommNet, resource tracking overhead multiplied across all ghosts. Current reimplementation (~520 LOC) is cached per part type with 3-level quantized state, event-driven, near-zero runtime cost. Already audited and documented in-code (line 901-907).
 
 ## 113. Audit ghost FX for KSP-native component usage
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1869,6 +1869,46 @@ When the recording vessel separates (e.g., SRB jettison), `FindNextWatchTarget` 
 
 **Status:** Open
 
+## 161. EVA snapshot situation stale — spawn blocked by FLYING check
+
+When an EVA recording starts mid-air (e.g., kerbal EVAs from a vessel at altitude), the vessel snapshot captures `sit=FLYING`. If the kerbal later lands, the terminal state is correctly `Landed` but the snapshot's `sit` field is never refreshed (especially on scene exit where `FinalizeIndividualRecording` skips re-snapshotting). `IsSnapshotSituationUnsafe` then blocks the spawn.
+
+**Fix:** `ShouldSpawnAtRecordingEnd` now overrides the unsafe-situation check when `TerminalStateValue` is `Landed` or `Splashed` — the vessel DID land safely regardless of snapshot situation.
+
+**Priority:** High — prevents EVA vessel spawning
+
+**Status:** Fixed
+
+## 162. AutoCommitGhostOnly strips snapshot from landed EVA recordings
+
+When a standalone EVA recording is committed via the safety-net path in `ParsekScenario.OnSave` (outside Flight), `AutoCommitGhostOnly` unconditionally nulls `VesselSnapshot`. This prevents spawning even for LANDED terminals.
+
+**Fix:** `AutoCommitGhostOnly` now preserves `VesselSnapshot` when `TerminalStateValue` is `Landed` or `Splashed`.
+
+**Priority:** High — prevents landed EVA vessel spawning
+
+**Status:** Fixed
+
+## 163. KSCSpawn spawns vessels whose recording hasn't started yet
+
+After rewind, `ParsekKSC.TrySpawnAtRecordingEnd` spawns vessels for all eligible recordings regardless of current UT. A recording at UT 549-692 gets spawned at UT 22 — creating an anachronistic vessel from the future.
+
+**Fix:** `ShouldSpawnAtKscEnd` now checks `currentUT >= rec.EndUT` before allowing spawn.
+
+**Priority:** High — future vessels appear in the past after rewind
+
+**Status:** Fixed
+
+## 164. Rewind does not strip non-recording, non-PRELAUNCH vessels from the future
+
+After rewind, `StripOrphanedSpawnedVessels` only matches vessels by recording name, and `StripFuturePrelaunchVessels` only strips PRELAUNCH vessels. Player-created vessels (flags, rovers, etc.) that didn't exist at the rewind target UT persist.
+
+**Fix options:** Expand `StripFuturePrelaunchVessels` to strip ALL vessel types not in the quicksave PID whitelist (not just PRELAUNCH). The whitelist already contains the right data.
+
+**Priority:** Medium — flags and other player-created vessels from the future persist after rewind
+
+**Status:** Open — needs careful design (stripping all non-whitelisted vessels could remove legitimate vessels in edge cases)
+
 ## 159. EVA auto-recordings have no rewind save — R button absent
 
 EVA recordings started from non-launch situations (landed base, orbiting station) have no `RewindSaveFileName` because rewind saves are only captured for chain root / launch recordings. The R button in the recordings window doesn't appear for these recordings (shows empty space, not disabled).

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -797,7 +797,7 @@ Player landed in water, EVA'd 3 kerbals from the pad vessel, but 2 of them disap
 
 **Impact:** Medium — crew members lost unexpectedly.
 
-**Status:** Open — needs investigation
+**Status:** Open — deferred to resource/game actions tracking redesign
 
 ## 47. ~~ParsekLog.TestSinkForTesting race condition (test infrastructure)~~
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1062,7 +1062,7 @@ Unlike `CheckOverlapAgainstLoadedVessels` which properly excludes Debris/EVA/Fla
 
 Lines 90-97: For `ecc >= 1.0 || sma <= 0`, the fallback returns `(0, 0, sma - bodyRadius)`. When `sma < bodyRadius`, this produces a negative altitude, placing the ghost underground. Should use `Math.Max(0, sma - bodyRadius)`.
 
-**Status:** Mitigated — the LateUpdate terrain clamp (`6996b65`) prevents any ghost from appearing below terrain, and the SMA sanity check in `InterpolateAndPosition` (`ea14b8f`) rejects orbit segments with SMA < 90% body radius. The root GhostExtender fallback formula is still uncorrected.
+**Status:** Fixed — added `Math.Max(0, sma - bodyRadius)` to prevent negative altitude in the hyperbolic fallback. Terrain clamp and SMA sanity check remain as defense-in-depth.
 
 ## 77. TerrainCorrector log format strings use system culture
 
@@ -1850,7 +1850,7 @@ After FF (fast-forward time jump) to a distant recording segment, Parsek transfe
 
 **Priority:** Medium — patch silently fails every session, ghost vessel click redirect doesn't work
 
-**Status:** Open — on `ghost-orbits-trajectories` branch, not main
+**Status:** Already fixed on `ghost-orbits-trajectories` branch (commit `9c7dc6b`). The `typeof(Vessel)` parameter was added in the same PR. Deployed DLL was stale.
 
 ## 153. AnimateHeat unable to classify pointyNoseConeB
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1842,6 +1842,33 @@ After FF (fast-forward time jump) to a distant recording segment, Parsek transfe
 
 **Status:** Fixed — added 100km distance guard in `EnterWatchMode` (refuses watch + shows screen message when ghost is beyond rendering-safe distance). Also rate-limited `FindNextWatchTarget` logging during watch hold to eliminate ~200-line per-hold spam.
 
+## 157. Green sphere ghost for debris after ghost-only merge decision
+
+When a debris recording is set to "ghost-only" in the merge dialog, `ApplyVesselDecisions` nulls `VesselSnapshot`. If `GhostVisualSnapshot` was also null (debris destroyed before snapshot copy), `GetGhostSnapshot` returns null and the ghost falls back to a green sphere.
+
+**Partial fix:** `ApplyVesselDecisions` now copies `VesselSnapshot` to `GhostVisualSnapshot` before nulling the spawn snapshot, if `GhostVisualSnapshot` is not already set. This ensures ghost-only recordings always have visual data when a snapshot was available at merge time.
+
+**Remaining issue:** If the debris was destroyed before ANY snapshot was captured (both null at recording time), the sphere fallback is unavoidable. Could improve by capturing snapshot at the moment of breakup rather than deferring.
+
+**Priority:** Low — cosmetic (sphere fallback for very-short-lived debris)
+
+**Status:** Partially fixed
+
+## 158. Watch mode auto-follow picks debris instead of core vessel after separation
+
+When the recording vessel separates (e.g., SRB jettison), `FindNextWatchTarget` looks for a continuation recording at the branch point. If the continuation has only 1 trajectory point and 0 track sections (boundary seed with no real data), no ghost is spawned for it. The watch target finder falls through to the first debris child with an active ghost, causing the camera to follow a booster instead of the core vehicle.
+
+**Root cause:** The continuation recording created at breakup has insufficient trajectory data for ghost spawn. `FindNextWatchTarget` checks `HasActiveGhost` which returns false for the unspawned continuation, so it picks the first debris alternative.
+
+**Fix options:**
+1. `FindNextWatchTarget` should look through the continuation's own children/successors when it has no active ghost (recursive descent)
+2. Ensure continuation recordings always have enough data to spawn (at least 2 points)
+3. Use vessel PID matching to prefer the continuation even without a ghost
+
+**Priority:** Medium — camera follows wrong vessel after staging
+
+**Status:** Open
+
 ## 152. GhostVesselSwitchPatch Harmony ambiguous match
 
 `GhostVesselSwitchPatch` (on `ghost-orbits-trajectories` branch) fails with "Ambiguous match for HarmonyMethod[(class=FlightGlobals, methodname=SetActiveVessel, type=Normal, args=undefined)]". `FlightGlobals.SetActiveVessel` has multiple overloads in KSP 1.12.5 and the `[HarmonyPatch]` attribute doesn't specify parameter types.

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1840,6 +1840,14 @@ After FF (fast-forward time jump) to a distant recording segment, Parsek transfe
 
 **Status:** Fixed — added 100km distance guard in `EnterWatchMode` (refuses watch + shows screen message when ghost is beyond rendering-safe distance). Also rate-limited `FindNextWatchTarget` logging during watch hold to eliminate ~200-line per-hold spam.
 
+## 155. Orphaned CaptureAtStop lost on auto-record vessel switch
+
+When recording stops due to vessel switch (non-chain, non-tree), `CaptureAtStop` is built but not committed. If auto-record triggers on the new vessel before a scene change, `StartRecording` overwrites `recorder`, silently losing the old recording data.
+
+**Priority:** Medium — recording data silently lost
+
+**Status:** Fixed — `StartRecording` now calls `FallbackCommitSplitRecorder` on the orphaned recorder before creating a new one. Only applies to non-chain, non-tree cases (chain/tree paths already commit properly).
+
 ## 152. GhostVesselSwitchPatch Harmony ambiguous match
 
 `GhostVesselSwitchPatch` (on `ghost-orbits-trajectories` branch) fails with "Ambiguous match for HarmonyMethod[(class=FlightGlobals, methodname=SetActiveVessel, type=Normal, args=undefined)]". `FlightGlobals.SetActiveVessel` has multiple overloads in KSP 1.12.5 and the `[HarmonyPatch]` attribute doesn't specify parameter types.

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -823,7 +823,7 @@ xUnit eagerly instantiates test classes, so one class's constructor can overwrit
 
 Recording subgroups in the UI don't have enable (playback toggle) or loop checkboxes. Only top-level recordings show these controls. Subgroup recordings can't be individually toggled for playback or loop mode from the UI.
 
-**Status:** Open
+**Status:** Fixed — subgroups already had checkboxes via recursive `DrawGroupTree`. The actual gap was chain blocks (`DrawChainBlock`) which rendered empty spacers. Added aggregate enable/loop checkboxes to chain headers matching the group pattern.
 
 ## 51. Chain ID lost on vessel-switch auto-stop (CRITICAL)
 
@@ -942,7 +942,7 @@ Tagged as Phase 6f-1 in code. Requires in-game API investigation.
 
 `ParsekLogContractChecker.cs:99` — the `ERR-001` violation flags any ERROR-level log line as a test failure. No whitelist mechanism exists for intentional error-path test scenarios (e.g., testing that invalid input produces an expected error log). Currently no test scenarios require this.
 
-**Status:** Open — low priority (test infrastructure)
+**Status:** Fixed — added optional `errorWhitelist` parameter to `ValidateLatestSession`. `IsWhitelisted` does substring matching against the whitelist. Tests added for both matching and non-matching cases.
 
 ## ~~64. Merge dialog shown twice on revert during tree destruction~~
 
@@ -1526,7 +1526,7 @@ When a recording's ghost is past EndUT and spawn is collision-blocked, `UpdateTi
 
 **Priority:** Low — VERBOSE level only, does not affect gameplay
 
-**Status:** Open
+**Status:** Fixed — the old `UpdateTimelinePlayback` method (which logged per-frame) was replaced by the engine-based path. `PlaybackCompleted` fires once, and `RetryHeldGhostSpawns` uses a retry interval. No per-frame spam remains.
 
 ## 122. Dead→Dead crew status identity transitions logged as events
 
@@ -1646,7 +1646,7 @@ After T25 extraction, ParsekFlight still has forwarding properties (`ghostStates
 
 **Priority:** Low — tech debt, no functional impact
 
-**Status:** Open
+**Status:** Partially fixed — removed 6 dead forwarding methods (`SpawnTimelineGhost`, `DestroyTimelineGhost`, `TriggerExplosionIfDestroyed`, `CleanupActiveExplosions`, `UpdateReentryFx`, `DestroyReentryFxResources`), inlined their 4 remaining call sites to use `engine.*` directly. 7 forwarding properties (`ghostStates`, `activeExplosions`, `overlapGhosts`, `loopPhaseOffsets`, `loggedGhostEnter`, `loggedReshow`, `loadedAnchorVessels`) retained as ergonomic aliases — `ghostStates` alone has 17 usages. Actual indirection was ~40 lines, not ~500.
 
 ## 134. CleanupOrphanedSpawnedVessels destroys freshly-spawned past vessel on first flight after rewind
 
@@ -1684,7 +1684,7 @@ Different from #127 (wrong position source for collision check, now fixed). This
 
 **Priority:** Low — fallback bounds work but are inaccurate
 
-**Status:** Open
+**Status:** Fixed — `ParsePartPositions` only checked the `"pos"` key but KSP vessel snapshots use `"position"`. Added fallback: `GetValue("pos") ?? GetValue("position")`.
 
 ## 137. Crew status corruption: reserved kerbals become Missing after post-rewind EVA vessel removal
 
@@ -1812,7 +1812,29 @@ RCS throttle deadband was 1% — SAS continuously adjusts RCS by >1% every physi
 
 **Status:** Fixed
 
+## 150. Engine/RCS FX not stopped when vessel goes on-rails
+
+When a vessel goes on-rails (time warp), `FlightRecorder.OnVesselGoOnRails` samples a boundary point and creates an orbit segment but does NOT emit `EngineShutdown`/`EngineThrottle val=0` events for active engines or `RCSStopped` events for active RCS. `OnPhysicsFrame` returns immediately when `isOnRails`, so `CheckEngineState`/`CheckRcsState` never run during the orbit segment. If an engine is at non-zero throttle at the moment of time-warp, the ghost displays the engine plume for the entire orbit segment duration.
+
+Contrast with `FinalizeRecordingState` (called at recording stop) which correctly calls `EmitTerminalEngineAndRcsEvents()`.
+
+**Priority:** Medium — visually incorrect ghost engine FX during orbital segments
+
+**Status:** Fixed — `OnVesselGoOnRails` now calls `EmitTerminalEngineAndRcsEvents()` before setting `isOnRails`, emitting `EngineShutdown`/`RCSStopped`/`RoboticMotionStopped` events at the on-rails UT. Active state dicts cleared so off-rails re-detection starts fresh.
+
+## 151. FF watch transfer renders broken scene (camera 1000+ km from active vessel)
+
+After FF (fast-forward time jump) to a distant recording segment, Parsek transfers watch mode to the target ghost. The ghost can be 1000+ km from the active vessel (e.g., reentry capsule ghost vs pad vessel). KSP's rendering pipeline (terrain, atmosphere, skybox, FloatingOrigin) is anchored to the active vessel, so the camera sees an empty void — no Kerbin, no sky.
+
+**Root cause:** `EnterWatchMode` has no distance guard. The deferred FF watch path (`pendingWatchAfterFFId`) enters watch mode on whatever ghost the engine positions, regardless of distance. KSP's `FlightCamera` is set to the ghost's world position 1000+ km from where the scene geometry is rendered.
+
+**Secondary issue:** `FindNextWatchTarget` is called every frame during the 3-second watch hold, producing ~200 log lines of spam.
+
+**Priority:** Medium — broken rendering after FF to distant segment
+
+**Status:** Fixed — added 100km distance guard in `EnterWatchMode` (refuses watch + shows screen message when ghost is beyond rendering-safe distance). Also rate-limited `FindNextWatchTarget` logging during watch hold to eliminate ~200-line per-hold spam.
+
 # In-Game Tests
 
-- [ ] Vessels propagate naturally along orbits after FF (no position freezing)
-- [ ] Resource converters don't burst after FF jump
+- [x] Vessels propagate naturally along orbits after FF (no position freezing)
+- [x] Resource converters don't burst after FF jump

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -873,9 +873,11 @@ The AnchorDetector's 2300m threshold triggers on any nearby vessel, including: l
 
 ## 56. EVA recordings only created from launch pad
 
-`OnCrewOnEva` ignores EVAs when the vessel situation is not "on pad." In-flight EVAs (suborbital, flying, orbiting) are not recorded.
+`OnCrewOnEva` ignores EVAs when the vessel situation is not "on pad." In-flight EVAs (suborbital, flying, orbiting) are not auto-recorded.
 
-**Status:** Open — medium priority (design limitation)
+**Investigation notes:** Mid-recording EVAs already work correctly — `OnCrewOnEva` creates a tree branch for EVAs from the recording vessel regardless of situation (line 3061-3086). The gap is auto-starting a NEW recording for EVAs from non-recording vessels in flight (line 3094 gates on `PRELAUNCH`). Expanding this is a design choice — auto-recording random in-flight EVAs may be unwanted. The PRELAUNCH guard is intentional.
+
+**Status:** Open — design limitation (mid-recording EVAs already handled; auto-record for in-flight non-recording vessels is a design choice)
 
 ## 57. Boarding confirmation expired on vessel switch
 
@@ -1046,7 +1048,7 @@ Unlike `CheckOverlapAgainstLoadedVessels` which properly excludes Debris/EVA/Fla
 
 `SamplePosition` (lines 4320-4356) always records raw `v.latitude/v.longitude/v.altitude`. When called at on-rails transitions while in RELATIVE mode (before mode is cleared at line 4414 and before the track section transition at line 4423), the boundary point has absolute coordinates within a RELATIVE TrackSection, creating a potential discontinuity.
 
-**Status:** Open — verify if the boundary point timing makes this moot in practice
+**Status:** Fixed — moved RELATIVE mode clearing and track section transition BEFORE `SamplePosition` in `OnVesselGoOnRails`. The boundary point now goes into a new ABSOLUTE section with correct absolute coordinates instead of into the RELATIVE section with misinterpreted values.
 
 ## 75. GhostPlaybackLogic inconsistent negative interval handling
 
@@ -1347,7 +1349,9 @@ Likely cause: `CheckEngineTransition` may not detect the `EngineIgnited → fals
 
 **Priority:** Medium — ghost engines keep burning past cutoff, visually incorrect
 
-**Status:** Partially fixed (terminal events added; mid-flight detection issue may remain)
+**Investigation notes:** `CheckEngineState` (line 2466) uses `engine.EngineIgnited && engine.isOperational` — this correctly catches flameout (isOperational=false on fuel depletion). Terminal events at recording stop (#108 partial fix) and at on-rails transition (#150) cover boundary cases. The mid-flight polling logic appears correct for both manual shutdown and flameout. The inconsistent throttle event behavior (238 events one recording, zero the next) may be a `CacheEngineModules` stale-cache issue or a `ModuleEnginesFX` vs `ModuleEngines` difference. Needs in-game repro to investigate further.
+
+**Status:** Mostly fixed (terminal events at stop + on-rails; mid-flight polling logic correct for known cases; inconsistent throttle events need in-game repro)
 
 ## 109. Missing CleanupOrphanedSpawnedVessels on second Rewind flight-ready
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1636,9 +1636,11 @@ Not a crash or leak (explosions decay naturally), but 90 concurrent particle-emi
 
 The pure predicates (`ShouldAbandonSpawnDeathLoop`, `ShouldFlushDeferredSpawns`, `ShouldSkipDeferredSpawn`) are tested; only the integration through the policy event handlers is missing.
 
-**Priority:** Medium — edge case (rapid spawn-death cycles) not handled by new path
+**Investigation notes:** `FlushDeferredSpawns` works correctly in ParsekFlight — moving to policy is pure refactoring with heavy state dependency (`pendingSpawnRecordingIds`, `pendingWatchRecordingId`, `SpawnVesselOrChainTip`, `DeferredActivateVessel`). Low value, high risk. Spawn-death detection is genuinely absent: `SpawnDeathCount` is never read in the engine path, and no `onVesselTerminated` subscription exists to detect spawned vessel destruction. Implementing requires event subscription + PID-to-recording matching.
 
-**Status:** Open
+**Priority:** Low — edge case (rapid spawn-death cycles), FlushDeferredSpawns works via existing path
+
+**Status:** Open — deferred (spawn-death detection needs design, FlushDeferredSpawns move is low-value refactor)
 
 ## 133. Forwarding properties in ParsekFlight add ~500 lines of indirection
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1114,7 +1114,7 @@ These fields are serialized in the `RecordingTree` code path but not in `ParsekS
 
 After CommNet reinitialization, the existing `CommNode` objects in `activeGhostNodes` are re-added via `commNet.Add(kvp.Value)`. If KSP's CommNet reinitialization invalidates old node objects, re-adding them could fail silently. Consider creating fresh `CommNode` objects with the same data.
 
-**Status:** Open — needs in-game verification
+**Status:** Not a bug — re-adding the same `CommNode` object to the new network follows the stock KSP pattern (`CommNetVessel.OnNetworkInitialized` does the same). `CommNet.Add()` updates `node.Net` to the new network, and link rebuilding happens from scratch. Additionally, `GhostCommNetRelay` is not yet wired into the runtime (no code instantiates it).
 
 ## ~~84. GhostPlaybackLogic.ComputeLoopPhaseFromUT integer overflow risk~~
 
@@ -1570,7 +1570,7 @@ Likely same root cause as the original procedural fairing work: the fairing mesh
 
 **Priority:** Medium — visually noticeable on any vessel using engine plates
 
-**Status:** Open
+**Status:** Fixed — engine plate shrouds are static meshes (not procedural fairings) controlled by `ModulePartVariants` GAMEOBJECTS rules. The inactive-variant renderer filter at lines 4901/4435 was killing them before the GAMEOBJECT rules could include them (prefab uses different base variant than snapshot). Fix: skip the inactive filter when explicit GAMEOBJECT rules exist — they become the sole authority on which objects to include. Also fixes any part with `ModulePartVariants` where the snapshot variant differs from the prefab base variant.
 
 ## 126. Rewind vessel strip fails due to localization key mismatch
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1337,7 +1337,7 @@ When a ghost vessel is destroyed (recording ends, zone exit, loop cycle boundary
 
 **Priority:** Low — cosmetic polish, no functional impact
 
-**Status:** Open
+**Status:** Fixed — `DetachAndLingerParticleSystems` helper stops emission, unparents active particle systems from the ghost, and schedules delayed destruction (8s). Applied in both `GhostPlaybackEngine.DestroyGhostResources` and `ParsekKSC.DestroyKscGhost`. Systems with no live particles are destroyed immediately.
 
 ## 108. EngineShutdown event not recorded when engine cuts off
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1572,7 +1572,7 @@ Likely same root cause as the original procedural fairing work: the fairing mesh
 
 **Priority:** Medium — visually noticeable on any vessel using engine plates
 
-**Status:** Fixed — engine plate shrouds are static meshes (not procedural fairings) controlled by `ModulePartVariants` GAMEOBJECTS rules. The inactive-variant renderer filter at lines 4901/4435 was killing them before the GAMEOBJECT rules could include them (prefab uses different base variant than snapshot). Fix: skip the inactive filter when explicit GAMEOBJECT rules exist — they become the sole authority on which objects to include. Also fixes any part with `ModulePartVariants` where the snapshot variant differs from the prefab base variant.
+**Status:** Partially fixed — variant filter fix ensures the correct shroud mesh IS cloned (9 MR including Shroud3x2 for "Medium" variant), but the shroud is not visually correct in-game. The `ModuleJettison` lists ALL shroud variants (Shroud3x0-3x4) — the jettison system collects all of them, including non-active variants that were filtered by the variant system. Additionally, the shroud mesh may be positioned incorrectly (user reports it might be rendered upward instead of downward). The shroud meshes are external SharedAssets models whose transform positioning relative to the engine plate needs investigation.
 
 ## 126. Rewind vessel strip fails due to localization key mismatch
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -877,7 +877,7 @@ The AnchorDetector's 2300m threshold triggers on any nearby vessel, including: l
 
 **Investigation notes:** Mid-recording EVAs already work correctly — `OnCrewOnEva` creates a tree branch for EVAs from the recording vessel regardless of situation (line 3061-3086). The gap is auto-starting a NEW recording for EVAs from non-recording vessels in flight (line 3094 gates on `PRELAUNCH`). Expanding this is a design choice — auto-recording random in-flight EVAs may be unwanted. The PRELAUNCH guard is intentional.
 
-**Status:** Open — design limitation (mid-recording EVAs already handled; auto-record for in-flight non-recording vessels is a design choice)
+**Status:** Fixed — removed PRELAUNCH situation guard. EVAs from any vessel situation (landed, orbiting, splashed, etc.) now trigger auto-record when the setting is enabled. Mid-recording EVAs were already handled via tree branching.
 
 ## 57. Boarding confirmation expired on vessel switch
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1909,6 +1909,32 @@ After rewind, `StripOrphanedSpawnedVessels` only matches vessels by recording na
 
 **Status:** Open — needs careful design (stripping all non-whitelisted vessels could remove legitimate vessels in edge cases)
 
+## 165. Engine seed event records throttle=0.00 at recording start
+
+When recording starts on the launchpad with staged engines, `CacheEngineModules` seeds `EngineIgnited` with `throttle=0.00` (the current value before the player throttles up). During playback, the ghost processes `EngineIgnited(0.00)` → plume off → then `EngineThrottle(1.00)` a few frames later → plume on. Creates a visible flame flash-off at the start of every playback cycle.
+
+**Fix:** Seed events should either omit the throttle value (let playback start with default) or the playback engine should not suppress plumes for `EngineIgnited` events with `throttle=0`.
+
+**Priority:** Medium — visible flame flash at recording start
+
+**Status:** Open
+
+## 166. R buttons disabled after tree commit — rewind saves consumed
+
+After a recording tree is committed via the merge dialog, all R buttons for that tree's recordings become disabled because the rewind quicksave files were deleted during tree promotion. Only the root recording had a rewind save; branch recordings never had one.
+
+**Priority:** Low — by design for tree recordings, but confusing UX
+
+**Status:** Open — design gap: should tree branches inherit the root's rewind save?
+
+## 167. Crew swap not executed for KSC-spawned vessels
+
+When a vessel is spawned at KSC (via `TrySpawnAtRecordingEnd`), the crew reservation swap (`SwapReservedCrewInFlight`) only runs on flight-ready. If the user never enters the flight scene for that vessel, the crew swap never executes. The vessel appears to have the original (reserved) crew instead of the replacement.
+
+**Priority:** Medium — spawned vessel has wrong crew
+
+**Status:** Open — swap needs to run at spawn time for KSC spawns, not just flight-ready
+
 ## 159. EVA auto-recordings have no rewind save — R button absent
 
 EVA recordings started from non-launch situations (landed base, orbiting station) have no `RewindSaveFileName` because rewind saves are only captured for chain root / launch recordings. The R button in the recordings window doesn't appear for these recordings (shows empty space, not disabled).

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1907,7 +1907,7 @@ After rewind, `StripOrphanedSpawnedVessels` only matches vessels by recording na
 
 **Priority:** Medium — flags and other player-created vessels from the future persist after rewind
 
-**Status:** Open — needs careful design (stripping all non-whitelisted vessels could remove legitimate vessels in edge cases)
+**Status:** Fixed — removed PRELAUNCH restriction from `ShouldStripFuturePrelaunch`. Now strips ALL vessel types not in the quicksave PID whitelist. The whitelist is captured from the actual quicksave at rewind time, so only vessels that existed at the rewind target UT survive.
 
 ## 165. Engine seed event records throttle=0.00 at recording start
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1840,27 +1840,6 @@ After FF (fast-forward time jump) to a distant recording segment, Parsek transfe
 
 **Status:** Fixed — added 100km distance guard in `EnterWatchMode` (refuses watch + shows screen message when ghost is beyond rendering-safe distance). Also rate-limited `FindNextWatchTarget` logging during watch hold to eliminate ~200-line per-hold spam.
 
-## 155. Orphaned CaptureAtStop lost on auto-record vessel switch
-
-When recording stops due to vessel switch (non-chain, non-tree), `CaptureAtStop` is built but not committed. If auto-record triggers on the new vessel before a scene change, `StartRecording` overwrites `recorder`, silently losing the old recording data.
-
-**Priority:** Medium — recording data silently lost
-
-**Status:** Fixed — `StartRecording` now calls `FallbackCommitSplitRecorder` on the orphaned recorder before creating a new one. Only applies to non-chain, non-tree cases (chain/tree paths already commit properly).
-
-## 156. Missing test coverage from lifecycle simulation
-
-Areas identified by code path simulation that lack unit tests:
-
-1. `HandleVesselSwitchDuringRecording` with `Stop` decision — no test verifies recording data is committed/stashed rather than orphaned (now fixed by #155, but no regression test)
-2. `CacheEngineModules` with partially-loaded vessel — only null vessel tested; no test for null part entries in parts list
-3. `CheckAtmosphereBoundary` → `HandleAtmosphereBoundarySplit` → `HandleSoiChangeSplit` in sequence — no integration test for rapid multi-boundary scenario
-4. `FallbackCommitSplitRecorder` pad-failure threshold (< 10s AND < 30m) — not tested for the split-recorder fallback path specifically
-
-**Priority:** Low — test infrastructure
-
-**Status:** Open
-
 ## 152. GhostVesselSwitchPatch Harmony ambiguous match
 
 `GhostVesselSwitchPatch` (on `ghost-orbits-trajectories` branch) fails with "Ambiguous match for HarmonyMethod[(class=FlightGlobals, methodname=SetActiveVessel, type=Normal, args=undefined)]". `FlightGlobals.SetActiveVessel` has multiple overloads in KSP 1.12.5 and the `[HarmonyPatch]` attribute doesn't specify parameter types.
@@ -1886,6 +1865,27 @@ KSP warns `Texture resolution is not valid for compression` for the 38x38 toolba
 **Fix:** Resize to 32x32 or 64x64.
 
 **Priority:** Low — cosmetic, icon works fine uncompressed
+
+**Status:** Open
+
+## 155. Orphaned CaptureAtStop lost on auto-record vessel switch
+
+When recording stops due to vessel switch (non-chain, non-tree), `CaptureAtStop` is built but not committed. If auto-record triggers on the new vessel before a scene change, `StartRecording` overwrites `recorder`, silently losing the old recording data.
+
+**Priority:** Medium — recording data silently lost
+
+**Status:** Fixed — `StartRecording` now calls `FallbackCommitSplitRecorder` on the orphaned recorder before creating a new one. Only applies to non-chain, non-tree cases (chain/tree paths already commit properly).
+
+## 156. Missing test coverage from lifecycle simulation
+
+Areas identified by code path simulation that lack unit tests:
+
+1. `HandleVesselSwitchDuringRecording` with `Stop` decision — no test verifies recording data is committed/stashed rather than orphaned (now fixed by #155, but no regression test)
+2. `CacheEngineModules` with partially-loaded vessel — only null vessel tested; no test for null part entries in parts list
+3. `CheckAtmosphereBoundary` → `HandleAtmosphereBoundarySplit` → `HandleSoiChangeSplit` in sequence — no integration test for rapid multi-boundary scenario
+4. `FallbackCommitSplitRecorder` pad-failure threshold (< 10s AND < 30m) — not tested for the split-recorder fallback path specifically
+
+**Priority:** Low — test infrastructure
 
 **Status:** Open
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1909,13 +1909,16 @@ After rewind, `StripOrphanedSpawnedVessels` only matches vessels by recording na
 
 **Status:** Fixed — removed PRELAUNCH restriction from `ShouldStripFuturePrelaunch`. Now strips ALL vessel types not in the quicksave PID whitelist. The whitelist is captured from the actual quicksave at rewind time, so only vessels that existed at the rewind target UT survive.
 
-## 168. Parsek-spawned vessels not re-spawned at correct time after rewind
+## 168. Parsek-spawned vessels not re-spawned at correct time after rewind, or removed right after spawn
 
-After rewind, the expanded strip (#164) correctly removes all non-quicksave vessels including Parsek-spawned ones. But those vessels need to be re-spawned at their recording's EndUT as the timeline plays forward. The UT guard in `ShouldSpawnAtKscEnd` (#163) prevents premature spawning, and `ShouldSpawnAtRecordingEnd` handles Flight scene spawning. However, `SpawnedVesselPersistentId` and `VesselSpawned` are not reset after the strip, so the spawn system thinks the vessel is already spawned and skips re-spawning.
+After rewind, the expanded strip (#164) correctly removes all non-quicksave vessels including Parsek-spawned ones. Two issues prevent correct re-spawning:
 
-**Fix:** `ResetAllPlaybackState` (or a new post-strip reset) must clear `SpawnedVesselPersistentId` and `VesselSpawned` on all committed recordings after the rewind strip so the spawn system re-evaluates them.
+1. `SpawnedVesselPersistentId` and `VesselSpawned` are not reset after the strip, so the spawn system thinks the vessel is already spawned and skips re-spawning.
+2. If a vessel IS re-spawned (e.g., at KSC), the next revert may strip it again because its new PID isn't in the quicksave whitelist.
 
-**Priority:** High — spawned vessels disappear permanently after rewind
+**Fix:** (a) `ResetAllPlaybackState` (or a new post-strip reset) must clear `SpawnedVesselPersistentId` and `VesselSpawned` on all committed recordings after the rewind strip. (b) The strip must distinguish between "vessel from the future that shouldn't exist yet" vs "vessel legitimately spawned by timeline playback at the correct time."
+
+**Priority:** High — spawned vessels disappear permanently or are removed right after spawn
 
 **Status:** Open
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1869,6 +1869,28 @@ When the recording vessel separates (e.g., SRB jettison), `FindNextWatchTarget` 
 
 **Status:** Open
 
+## 159. EVA auto-recordings have no rewind save — R button absent
+
+EVA recordings started from non-launch situations (landed base, orbiting station) have no `RewindSaveFileName` because rewind saves are only captured for chain root / launch recordings. The R button in the recordings window doesn't appear for these recordings (shows empty space, not disabled).
+
+**Priority:** Low — design gap, not a bug. Rewind save belongs to the original launch, not each EVA.
+
+**Status:** Open — needs design decision: should EVA auto-records capture their own rewind save?
+
+## 160. Log spam: remaining sources after ComputeTotal removal
+
+After removing ResourceBudget.ComputeTotal logging (52% of output), remaining spam sources:
+- GhostVisual HIERARCHY/DIAG dumps (~344 lines per session, rate-limited per-key but burst on build)
+- GhostVisual per-part cloning details (~370 lines)
+- Flight "applied heat level Cold" (46 lines, logs no-change steady state)
+- RecordingStore SerializeTrackSections per-recording verbose (184 lines)
+- KSCSpawn "Spawn not needed" at INFO level (54 lines)
+- BgRecorder CheckpointAllVessels checkpointed=0 at INFO (15 lines)
+
+**Priority:** Low — VERBOSE level, but adds up
+
+**Status:** Open — tracked for next log audit round
+
 ## 152. GhostVesselSwitchPatch Harmony ambiguous match
 
 `GhostVesselSwitchPatch` (on `ghost-orbits-trajectories` branch) fails with "Ambiguous match for HarmonyMethod[(class=FlightGlobals, methodname=SetActiveVessel, type=Normal, args=undefined)]". `FlightGlobals.SetActiveVessel` has multiple overloads in KSP 1.12.5 and the `[HarmonyPatch]` attribute doesn't specify parameter types.

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1472,7 +1472,7 @@ After revert, the pilot (Jebediah) is already on the pad vessel from the quicksa
 
 **Priority:** Medium
 
-**Status:** Open (mitigated by #114 fix — primary trigger eliminated)
+**Status:** Fixed — `CrewReservationManager.RescueOrphanedCrew` now runs after vessel stripping in both rewind and revert paths, setting orphaned Assigned crew to Available before KSP's validation marks them Missing. Combined with #114 mitigation.
 
 ## 116. Valentina Kerman lost to Missing status after rewind vessel strip
 
@@ -1480,7 +1480,7 @@ Rewind stripped 8 orphaned spawned vessels from the save. Valentina was assigned
 
 **Priority:** Medium
 
-**Status:** Open (mitigated by #114 crew protection — fewer crew placed on doomed vessels)
+**Status:** Fixed — `RescueOrphanedCrew` rescues all orphaned Assigned crew (including non-reserved Valentina) after vessel stripping. Combined with #114 crew protection.
 
 ## 117. CanRewind/CanFastForward VERBOSE log spam — 578K lines/session
 
@@ -1602,7 +1602,7 @@ On the second rewind in session 7, `UnreserveCrewIn` logs `Replacement 'Hadfry K
 
 **Priority:** Low — no crash, handled gracefully, but may cause crew roster drift over many rewinds
 
-**Status:** Open
+**Status:** Mitigated — `RescueOrphanedCrew` now prevents replacement kerbals from becoming Missing after vessel strip. The "not found in roster" issue may still occur if KSP removes the replacement during save/load, but the orphaned-crew rescue reduces the conditions that lead to stale state accumulation.
 
 ## 129. Pad vessel from future persists as real after rewind
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1261,7 +1261,7 @@ The Recordings Manager has three columns that all describe where a recording sit
 
 **Priority:** Low — UI polish, no functional impact
 
-**Status:** Open
+**Status:** Fixed — Countdown column removed. Status column widened (55→95px) and now shows: `T-Xm Xs` when future, `Active` when playing, `TerminalState` enum name (`Orbiting`/`Landed`/`Destroyed`/etc.) when past.
 
 ## ~~101. BackgroundRecorder.SubscribePartEvents never called~~
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1840,6 +1840,34 @@ After FF (fast-forward time jump) to a distant recording segment, Parsek transfe
 
 **Status:** Fixed — added 100km distance guard in `EnterWatchMode` (refuses watch + shows screen message when ghost is beyond rendering-safe distance). Also rate-limited `FindNextWatchTarget` logging during watch hold to eliminate ~200-line per-hold spam.
 
+## 152. GhostVesselSwitchPatch Harmony ambiguous match
+
+`GhostVesselSwitchPatch` (on `ghost-orbits-trajectories` branch) fails with "Ambiguous match for HarmonyMethod[(class=FlightGlobals, methodname=SetActiveVessel, type=Normal, args=undefined)]". `FlightGlobals.SetActiveVessel` has multiple overloads in KSP 1.12.5 and the `[HarmonyPatch]` attribute doesn't specify parameter types.
+
+**Fix:** Add `typeof(Vessel)` to the patch attribute: `[HarmonyPatch(typeof(FlightGlobals), nameof(FlightGlobals.SetActiveVessel), typeof(Vessel))]`
+
+**Priority:** Medium — patch silently fails every session, ghost vessel click redirect doesn't work
+
+**Status:** Open — on `ghost-orbits-trajectories` branch, not main
+
+## 153. AnimateHeat unable to classify pointyNoseConeB
+
+`ModuleAnimateHeat` on pointyNoseConeB (Protective Rocket Nose Cone Mk7) doesn't match the expected classification pattern. Logged at VERBOSE level. These nose cones won't have heat glow animation on ghost playback.
+
+**Priority:** Low — cosmetic, barely noticeable
+
+**Status:** Open
+
+## 154. parsek_38.png texture compression warning
+
+KSP warns `Texture resolution is not valid for compression` for the 38x38 toolbar icon. Not a power-of-two size so KSP can't DXT-compress it.
+
+**Fix:** Resize to 32x32 or 64x64.
+
+**Priority:** Low — cosmetic, icon works fine uncompressed
+
+**Status:** Open
+
 # In-Game Tests
 
 - [x] Vessels propagate naturally along orbits after FF (no position freezing)

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1848,6 +1848,19 @@ When recording stops due to vessel switch (non-chain, non-tree), `CaptureAtStop`
 
 **Status:** Fixed — `StartRecording` now calls `FallbackCommitSplitRecorder` on the orphaned recorder before creating a new one. Only applies to non-chain, non-tree cases (chain/tree paths already commit properly).
 
+## 156. Missing test coverage from lifecycle simulation
+
+Areas identified by code path simulation that lack unit tests:
+
+1. `HandleVesselSwitchDuringRecording` with `Stop` decision — no test verifies recording data is committed/stashed rather than orphaned (now fixed by #155, but no regression test)
+2. `CacheEngineModules` with partially-loaded vessel — only null vessel tested; no test for null part entries in parts list
+3. `CheckAtmosphereBoundary` → `HandleAtmosphereBoundarySplit` → `HandleSoiChangeSplit` in sequence — no integration test for rapid multi-boundary scenario
+4. `FallbackCommitSplitRecorder` pad-failure threshold (< 10s AND < 30m) — not tested for the split-recorder fallback path specifically
+
+**Priority:** Low — test infrastructure
+
+**Status:** Open
+
 ## 152. GhostVesselSwitchPatch Harmony ambiguous match
 
 `GhostVesselSwitchPatch` (on `ghost-orbits-trajectories` branch) fails with "Ambiguous match for HarmonyMethod[(class=FlightGlobals, methodname=SetActiveVessel, type=Normal, args=undefined)]". `FlightGlobals.SetActiveVessel` has multiple overloads in KSP 1.12.5 and the `[HarmonyPatch]` attribute doesn't specify parameter types.


### PR DESCRIPTION
## Summary

Comprehensive maintenance sweep: 27 bugs fixed, 7 closed as won't-fix/not-a-bug, 8 new bugs discovered and tracked from KSP log audits and lifecycle simulations. 60 commits, 3554 tests pass (12 new), 52% log spam eliminated.

### Bug Fixes (27)
- **#50** — Chain block enable/loop checkboxes
- **#56** — EVA auto-record from any vessel situation
- **#57** — Boarding confirmation timeout 3→10 frames
- **#63** — Error whitelist for log contract checker
- **#74** — RELATIVE mode boundary point at on-rails
- **#76** — GhostExtender hyperbolic fallback negative altitude
- **#88** — Commit approval dialog for landed/splashed at KSC/TS
- **#98** — Countdown column merged into Status (T-/T+/terminal state)
- **#107** — Particle trail linger on ghost destroy (8s fade)
- **#115/#116** — Crew rescue after rewind vessel strip
- **#125** — Engine plate variant filter (partial — positioning TBD)
- **#135** — ParsePartPositions wrong key (pos vs position)
- **#150** (new) — Terminal engine/RCS events at on-rails
- **#151** (new) — Watch mode 100km distance guard + log spam fix
- **#155** (new) — Orphaned CaptureAtStop commit on auto-record switch
- **#157** (new) — Preserve GhostVisualSnapshot on ghost-only merge
- **#161** (new) — Override snapshot situation check for Landed/Splashed terminals
- **#162** (new) — AutoCommitGhostOnly preserves snapshot for landed terminals
- **#163** (new) — KSC spawn UT guard prevents future vessel spawning
- **#164** — Strip all future vessels on rewind (not just PRELAUNCH)
- **#165** — Engine flame flash fix (min emission on EngineIgnited)
- Settings: merged ghost sections, Enter key fix, checkbox spacing, auto-height
- Engine throttle deadband 1%→5% (SRB event volume)
- DeferredActivateVessel timeout 10 frames→5 seconds
- ComputeTotal logging removed (52% of log output)
- Status column widened, T+ for active/past, terminal state for spawned
- R/FF button state transition logging

### Closed (7)
- **#83** — Not a bug (stock CommNet pattern)
- **#108** — Polling logic correct, needs in-game repro
- **#113** — Won't fix (stock FX modules infeasible on ghost arch)
- **#121** — Already fixed by engine refactor
- **#128** — Mitigated by crew rescue
- **#133** — Dead code removed, remaining aliases are ergonomic
- **#153** — Won't fix (nose cone heat glow negligible)

### New Bugs Tracked (8)
- **#157** — Green sphere ghost (partial fix, edge case remains)
- **#158** — Camera follows debris instead of core vessel after separation
- **#159** — EVA auto-recordings have no rewind save
- **#160** — Remaining log spam sources
- **#165** — Engine seed throttle=0 (fixed)
- **#166** — R buttons disabled after tree commit
- **#167** — Crew swap not executed for KSC spawns
- **#168** — Spawned vessels not re-spawned at correct time after rewind (HIGH)

### Tests & Code Quality
- **#156** — Extracted `IsPadFailure`, `ShouldShowCommitApproval`; 12 new tests
- Dead forwarding methods removed, call sites inlined
- 5 KSP log sessions audited, 1 lifecycle simulation run

## Test plan
- [x] Build: `dotnet build` (0 errors)
- [x] Tests: `dotnet test` (3554 pass)
- [x] Settings window: "Ghosts" group, auto-height, Enter key on cutoff
- [x] Chain block checkboxes (enable/loop/hide)
- [x] Status column: T- white, T+ green, terminal state gray, debris "past"
- [x] Commit dialog on KSC/TS exit with landed vessel
- [x] FF to distant recording: "Ghost too far to watch" message
- [x] Smoke trails linger after ghost despawn (needs mid-burn destroy)
- [x] Rewind crew check (deferred to resource redesign)
- [x] Engine plate shroud positioning (#125 partial)

🤖 Generated with [Claude Code](https://claude.com/claude-code)