### PR TITLE
Fix #168: reconcile spawn state after vessel stripping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,11 @@ All notable changes to Parsek are documented here.
 
 ---
 
-## 0.5.4
+## 0.5.3
 
 ### Bug Fixes
 
 - **Fix #168: Spawned vessels not re-spawned after rewind/revert.** After vessel stripping on revert, `SpawnedVesselPersistentId` was restored from the save but pointed to a stripped vessel — blocking re-spawn permanently. Added `ReconcileSpawnStateAfterStrip` that checks surviving PIDs in flightState after all strip operations and resets spawn tracking for recordings whose vessel no longer exists.
-
----
-
-## 0.5.3
-
-### Bug Fixes
 
 - **Fix #72: GhostCommNetRelay antenna combination formula wrong for non-combinable strongest.** Extracted `ResolveCombinationExponent` pure method. When the overall strongest antenna is non-combinable, the combination exponent now comes from the strongest *combinable* antenna, matching KSP's actual formula.
 - **Fix #81: TrackSection struct shallow copy shares mutable list references.** Extracted `Recording.DeepCopyTrackSections` that creates independent `frames` and `checkpoints` lists for each copied TrackSection. Used in `ApplyPersistenceArtifactsFrom`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Parsek are documented here.
 
 ---
 
+## 0.5.4
+
+### Bug Fixes
+
+- **Fix #168: Spawned vessels not re-spawned after rewind/revert.** After vessel stripping on revert, `SpawnedVesselPersistentId` was restored from the save but pointed to a stripped vessel — blocking re-spawn permanently. Added `ReconcileSpawnStateAfterStrip` that checks surviving PIDs in flightState after all strip operations and resets spawn tracking for recordings whose vessel no longer exists.
+
+---
+
 ## 0.5.3
 
 ### Bug Fixes

--- a/Source/Parsek.Tests/SpawnStateReconciliationTests.cs
+++ b/Source/Parsek.Tests/SpawnStateReconciliationTests.cs
@@ -1,0 +1,250 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Tests for bug #168: spawned vessels not re-spawned after rewind because
+    /// SpawnedVesselPersistentId is not reset when the vessel is stripped.
+    /// ShouldResetSpawnState is the pure decision method.
+    /// ReconcileSpawnStateAfterStrip operates on Recording lists.
+    /// </summary>
+    [Collection("Sequential")]
+    public class SpawnStateReconciliationTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public SpawnStateReconciliationTests()
+        {
+            RecordingStore.SuppressLogging = false;
+            RecordingStore.ResetForTesting();
+            MilestoneStore.SuppressLogging = true;
+            MilestoneStore.ResetForTesting();
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+            RecordingStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+            MilestoneStore.ResetForTesting();
+        }
+
+        // --- ShouldResetSpawnState pure decision tests ---
+
+        [Fact]
+        public void ShouldResetSpawnState_PidZero_ReturnsFalse()
+        {
+            var surviving = new HashSet<uint> { 100, 200 };
+            Assert.False(ParsekScenario.ShouldResetSpawnState(0, surviving));
+        }
+
+        [Fact]
+        public void ShouldResetSpawnState_PidInSurvivingSet_ReturnsFalse()
+        {
+            var surviving = new HashSet<uint> { 100, 200, 300 };
+            Assert.False(ParsekScenario.ShouldResetSpawnState(200, surviving));
+        }
+
+        [Fact]
+        public void ShouldResetSpawnState_PidNotInSurvivingSet_ReturnsTrue()
+        {
+            var surviving = new HashSet<uint> { 100, 200 };
+            Assert.True(ParsekScenario.ShouldResetSpawnState(999, surviving));
+        }
+
+        [Fact]
+        public void ShouldResetSpawnState_NullSurvivingSet_ReturnsTrue()
+        {
+            Assert.True(ParsekScenario.ShouldResetSpawnState(100, null));
+        }
+
+        [Fact]
+        public void ShouldResetSpawnState_EmptySurvivingSet_ReturnsTrue()
+        {
+            Assert.True(ParsekScenario.ShouldResetSpawnState(100, new HashSet<uint>()));
+        }
+
+        // --- ReconcileSpawnStateAfterStrip tests (HashSet<uint> overload) ---
+
+        [Fact]
+        public void Reconcile_StrippedVessel_ResetsSpawnState()
+        {
+            var rec = new Recording
+            {
+                VesselName = "TestVessel",
+                SpawnedVesselPersistentId = 500,
+                VesselSpawned = true,
+                SpawnAttempts = 2,
+                SpawnDeathCount = 1
+            };
+            var recordings = new List<Recording> { rec };
+            var survivingPids = new HashSet<uint>(); // empty — all vessels stripped
+
+            int reconciled = ParsekScenario.ReconcileSpawnStateAfterStrip(survivingPids, recordings);
+
+            Assert.Equal(1, reconciled);
+            Assert.Equal(0u, rec.SpawnedVesselPersistentId);
+            Assert.False(rec.VesselSpawned);
+            Assert.Equal(0, rec.SpawnAttempts);
+            Assert.Equal(0, rec.SpawnDeathCount);
+            Assert.Contains(logLines, l =>
+                l.Contains("[Scenario]") && l.Contains("pid=500") && l.Contains("re-spawn"));
+        }
+
+        [Fact]
+        public void Reconcile_SurvivingVessel_PreservesSpawnState()
+        {
+            var rec = new Recording
+            {
+                VesselName = "TestVessel",
+                SpawnedVesselPersistentId = 100,
+                VesselSpawned = true
+            };
+            var recordings = new List<Recording> { rec };
+            var survivingPids = new HashSet<uint> { 100 };
+
+            int reconciled = ParsekScenario.ReconcileSpawnStateAfterStrip(survivingPids, recordings);
+
+            Assert.Equal(0, reconciled);
+            Assert.Equal(100u, rec.SpawnedVesselPersistentId);
+            Assert.True(rec.VesselSpawned);
+        }
+
+        [Fact]
+        public void Reconcile_NeverSpawned_NoChange()
+        {
+            var rec = new Recording
+            {
+                VesselName = "TestVessel",
+                SpawnedVesselPersistentId = 0,
+                VesselSpawned = false
+            };
+            var recordings = new List<Recording> { rec };
+
+            int reconciled = ParsekScenario.ReconcileSpawnStateAfterStrip(
+                new HashSet<uint>(), recordings);
+
+            Assert.Equal(0, reconciled);
+            Assert.Equal(0u, rec.SpawnedVesselPersistentId);
+            Assert.False(rec.VesselSpawned);
+        }
+
+        [Fact]
+        public void Reconcile_MixedRecordings_OnlyResetsStripped()
+        {
+            var recA = new Recording
+            {
+                VesselName = "Rocket A",
+                SpawnedVesselPersistentId = 100,
+                VesselSpawned = true
+            };
+            var recB = new Recording
+            {
+                VesselName = "Rocket B",
+                SpawnedVesselPersistentId = 200,
+                VesselSpawned = true
+            };
+            var recordings = new List<Recording> { recA, recB };
+            var survivingPids = new HashSet<uint> { 100 }; // only 100 survives
+
+            int reconciled = ParsekScenario.ReconcileSpawnStateAfterStrip(survivingPids, recordings);
+
+            Assert.Equal(1, reconciled);
+            Assert.Equal(100u, recA.SpawnedVesselPersistentId);
+            Assert.True(recA.VesselSpawned);
+            Assert.Equal(0u, recB.SpawnedVesselPersistentId);
+            Assert.False(recB.VesselSpawned);
+        }
+
+        [Fact]
+        public void Reconcile_NullRecordings_ReturnsZero()
+        {
+            Assert.Equal(0, ParsekScenario.ReconcileSpawnStateAfterStrip(
+                new HashSet<uint>(), null));
+        }
+
+        [Fact]
+        public void Reconcile_EmptyRecordings_ReturnsZero()
+        {
+            Assert.Equal(0, ParsekScenario.ReconcileSpawnStateAfterStrip(
+                new HashSet<uint>(), new List<Recording>()));
+        }
+
+        [Fact]
+        public void Reconcile_NullSurvivingPids_ResetsAllNonZeroPids()
+        {
+            var rec = new Recording
+            {
+                VesselName = "Test",
+                SpawnedVesselPersistentId = 42,
+                VesselSpawned = true
+            };
+            var recordings = new List<Recording> { rec };
+
+            int reconciled = ParsekScenario.ReconcileSpawnStateAfterStrip(
+                (HashSet<uint>)null, recordings);
+
+            Assert.Equal(1, reconciled);
+            Assert.Equal(0u, rec.SpawnedVesselPersistentId);
+            Assert.False(rec.VesselSpawned);
+        }
+
+        [Fact]
+        public void Reconcile_LogsSummary_WhenReconciled()
+        {
+            var rec = new Recording
+            {
+                VesselName = "Vessel",
+                SpawnedVesselPersistentId = 999,
+                VesselSpawned = true
+            };
+            var recordings = new List<Recording> { rec };
+
+            ParsekScenario.ReconcileSpawnStateAfterStrip(new HashSet<uint>(), recordings);
+
+            Assert.Contains(logLines, l =>
+                l.Contains("ReconcileSpawnStateAfterStrip") && l.Contains("reset 1 recording(s)"));
+        }
+
+        [Fact]
+        public void Reconcile_StrippedVessel_PreservesNonSpawnFields()
+        {
+            // LastAppliedResourceIndex is independent of vessel existence — must not be reset
+            var rec = new Recording
+            {
+                VesselName = "Test",
+                SpawnedVesselPersistentId = 500,
+                VesselSpawned = true,
+                LastAppliedResourceIndex = 42
+            };
+            var recordings = new List<Recording> { rec };
+
+            ParsekScenario.ReconcileSpawnStateAfterStrip(new HashSet<uint>(), recordings);
+
+            Assert.Equal(0u, rec.SpawnedVesselPersistentId);
+            Assert.False(rec.VesselSpawned);
+            Assert.Equal(42, rec.LastAppliedResourceIndex);
+        }
+
+        [Fact]
+        public void Reconcile_NoLogSummary_WhenNothingReconciled()
+        {
+            var rec = new Recording
+            {
+                VesselName = "Vessel",
+                SpawnedVesselPersistentId = 0
+            };
+            var recordings = new List<Recording> { rec };
+
+            ParsekScenario.ReconcileSpawnStateAfterStrip(new HashSet<uint>(), recordings);
+
+            Assert.DoesNotContain(logLines, l => l.Contains("ReconcileSpawnStateAfterStrip"));
+        }
+    }
+}

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -500,6 +500,16 @@ namespace Parsek
                     }
                 }
 
+                // Reconcile spawn state after all restore + strip operations (#168).
+                // If a recording's SpawnedVesselPersistentId points to a vessel that was
+                // stripped, reset the PID so the vessel can be re-spawned at the correct time.
+                if (isRevert)
+                {
+                    var flightStateForReconcile = HighLogic.CurrentGame?.flightState;
+                    if (flightStateForReconcile != null)
+                        ReconcileSpawnStateAfterStrip(flightStateForReconcile.protoVessels, recordings);
+                }
+
                 if (isRevert)
                 {
                     // Restore milestone mutable state from .sfs and increment epoch.
@@ -776,6 +786,15 @@ namespace Parsek
                             $"Stripped {prelaunchStripped} future PRELAUNCH vessel(s)");
                 }
                 RecordingStore.RewindQuicksaveVesselPids = null;
+            }
+
+            // Defense-in-depth: reconcile spawn state after all strips (#168).
+            // ResetAllPlaybackState already zeroed spawn PIDs, so this should be a no-op,
+            // but guards against any future code path that restores PIDs before the strip.
+            {
+                var fsReconcile = HighLogic.CurrentGame?.flightState;
+                if (fsReconcile != null)
+                    ReconcileSpawnStateAfterStrip(fsReconcile.protoVessels, recordings);
             }
 
             // Rescue crew orphaned by vessel stripping (#116).
@@ -1484,6 +1503,76 @@ namespace Parsek
             // Previously only stripped PRELAUNCH; now catches flags, landed capsules,
             // and other player-created vessels from the future after rewind.
             return !quicksavePids.Contains(persistentId);
+        }
+
+        /// <summary>
+        /// After vessel stripping, reconcile recording spawn state with the actual flightState.
+        /// If a recording's SpawnedVesselPersistentId points to a vessel that was stripped
+        /// (no longer in flightState), reset the spawn tracking so the vessel can be re-spawned
+        /// at the correct time. Without this, the PID dedup check in ShouldSpawnAtRecordingEnd
+        /// blocks respawning permanently (#168).
+        /// </summary>
+        internal static int ReconcileSpawnStateAfterStrip(
+            List<ProtoVessel> remainingVessels, List<Recording> recordings)
+        {
+            return ReconcileSpawnStateAfterStrip(CollectSurvivingPids(remainingVessels), recordings);
+        }
+
+        /// <summary>
+        /// Testable overload that takes pre-collected surviving PIDs.
+        /// </summary>
+        internal static int ReconcileSpawnStateAfterStrip(
+            HashSet<uint> survivingPids, List<Recording> recordings)
+        {
+            if (recordings == null || recordings.Count == 0)
+                return 0;
+
+            int reconciled = 0;
+            for (int i = 0; i < recordings.Count; i++)
+            {
+                if (ShouldResetSpawnState(recordings[i].SpawnedVesselPersistentId, survivingPids))
+                {
+                    uint oldPid = recordings[i].SpawnedVesselPersistentId;
+                    recordings[i].SpawnedVesselPersistentId = 0;
+                    recordings[i].VesselSpawned = false;
+                    recordings[i].SpawnAttempts = 0;
+                    recordings[i].SpawnDeathCount = 0;
+                    ParsekLog.Info("Scenario",
+                        $"Reconciled spawn state for recording #{i} \"{recordings[i].VesselName}\": " +
+                        $"pid={oldPid} no longer in flightState — reset for re-spawn");
+                    reconciled++;
+                }
+            }
+
+            if (reconciled > 0)
+                ParsekLog.Info("Scenario",
+                    $"ReconcileSpawnStateAfterStrip: reset {reconciled} recording(s) whose spawned vessel was stripped");
+
+            return reconciled;
+        }
+
+        /// <summary>
+        /// Pure decision: should this recording's spawn state be reset?
+        /// Returns true when spawnedPid is non-zero but not found in the surviving vessel set.
+        /// </summary>
+        internal static bool ShouldResetSpawnState(uint spawnedPid, HashSet<uint> survivingPids)
+        {
+            if (spawnedPid == 0)
+                return false;
+            return survivingPids == null || !survivingPids.Contains(spawnedPid);
+        }
+
+        /// <summary>
+        /// Collects persistent IDs from all remaining protoVessels.
+        /// </summary>
+        private static HashSet<uint> CollectSurvivingPids(List<ProtoVessel> protoVessels)
+        {
+            var pids = new HashSet<uint>();
+            if (protoVessels == null)
+                return pids;
+            for (int i = 0; i < protoVessels.Count; i++)
+                pids.Add(protoVessels[i].persistentId);
+            return pids;
         }
 
         private static void SaveStandaloneRecordings(ConfigNode node, List<Recording> recordings)

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1924,6 +1924,18 @@ After rewind, the expanded strip (#164) correctly removes all non-quicksave vess
 
 **Status:** Fixed
 
+## 169. EVA vessel spawned FLYING destroyed by on-rails pressure
+
+EVA vessels captured mid-flight had `sit=FLYING` in their VesselSnapshot. When terminal state was Landed, the spawn proceeded but KSP's on-rails pressure check killed the vessel and crew instantly (101.3 kPa at sea level). The crew were set to Dead.
+
+**Root cause:** The snapshot situation was recorded at capture time (mid-air EVA) and never corrected before spawn. KSP applies atmospheric pressure to FLYING vessels on-rails, which is fatal at low altitude.
+
+**Fix:** Added `ComputeCorrectedSituation` (pure decision method) and `CorrectUnsafeSnapshotSituation` (applies correction) that override FLYING/SUB_ORBITAL to LANDED/SPLASHED when terminal state indicates safe surface contact. Applied at all three spawn paths: flight queue spawn, KSC spawn, and tree leaf spawn.
+
+**Priority:** Critical — spawned EVA crew killed instantly, set to Dead
+
+**Status:** Fixed
+
 ## 165. Engine seed event records throttle=0.00 at recording start
 
 When recording starts on the launchpad with staged engines, `CacheEngineModules` seeds `EngineIgnited` with `throttle=0.00` (the current value before the player throttles up). During playback, the ghost processes `EngineIgnited(0.00)` → plume off → then `EngineThrottle(1.00)` a few frames later → plume on. Creates a visible flame flash-off at the start of every playback cycle.

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1924,18 +1924,6 @@ After rewind, the expanded strip (#164) correctly removes all non-quicksave vess
 
 **Status:** Fixed
 
-## 169. EVA vessel spawned FLYING destroyed by on-rails pressure
-
-EVA vessels captured mid-flight had `sit=FLYING` in their VesselSnapshot. When terminal state was Landed, the spawn proceeded but KSP's on-rails pressure check killed the vessel and crew instantly (101.3 kPa at sea level). The crew were set to Dead.
-
-**Root cause:** The snapshot situation was recorded at capture time (mid-air EVA) and never corrected before spawn. KSP applies atmospheric pressure to FLYING vessels on-rails, which is fatal at low altitude.
-
-**Fix:** Added `ComputeCorrectedSituation` (pure decision method) and `CorrectUnsafeSnapshotSituation` (applies correction) that override FLYING/SUB_ORBITAL to LANDED/SPLASHED when terminal state indicates safe surface contact. Applied at all three spawn paths: flight queue spawn, KSC spawn, and tree leaf spawn.
-
-**Priority:** Critical — spawned EVA crew killed instantly, set to Dead
-
-**Status:** Fixed
-
 ## 165. Engine seed event records throttle=0.00 at recording start
 
 When recording starts on the launchpad with staged engines, `CacheEngineModules` seeds `EngineIgnited` with `throttle=0.00` (the current value before the player throttles up). During playback, the ghost processes `EngineIgnited(0.00)` → plume off → then `EngineThrottle(1.00)` a few frames later → plume on. Creates a visible flame flash-off at the start of every playback cycle.

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1916,11 +1916,13 @@ After rewind, the expanded strip (#164) correctly removes all non-quicksave vess
 1. `SpawnedVesselPersistentId` and `VesselSpawned` are not reset after the strip, so the spawn system thinks the vessel is already spawned and skips re-spawning.
 2. If a vessel IS re-spawned (e.g., at KSC), the next revert may strip it again because its new PID isn't in the quicksave whitelist.
 
-**Fix:** (a) `ResetAllPlaybackState` (or a new post-strip reset) must clear `SpawnedVesselPersistentId` and `VesselSpawned` on all committed recordings after the rewind strip. (b) The strip must distinguish between "vessel from the future that shouldn't exist yet" vs "vessel legitimately spawned by timeline playback at the correct time."
+**Root cause:** On normal revert, `RestoreStandaloneMutableState` restores `SpawnedVesselPersistentId` from the quicksave (line 1390), then `StripOrphanedSpawnedVessels` strips the vessel by name from flightState. The vessel is gone but the PID persists on the recording. `ShouldSpawnAtRecordingEnd` checks `SpawnedVesselPersistentId != 0` (line 2119) and blocks respawning with "already spawned (pid=...)". Same issue on second rewind: new PID assigned on respawn is not in original quicksave whitelist → stripped on next revert, but PID restored from save → blocked again.
+
+**Fix:** Added `ReconcileSpawnStateAfterStrip` in `ParsekScenario`. After all strip operations (both `StripOrphanedSpawnedVessels` and `StripFuturePrelaunchVessels`), collects surviving PIDs from remaining `flightState.protoVessels` and resets `SpawnedVesselPersistentId`, `VesselSpawned`, `SpawnAttempts`, and `SpawnDeathCount` for any recording whose PID is no longer in the surviving set. Called on both normal revert path (after restore + strip) and rewind path (defense-in-depth after `ResetAllPlaybackState` + strips). Pure decision method `ShouldResetSpawnState` extracted for testability.
 
 **Priority:** High — spawned vessels disappear permanently or are removed right after spawn
 
-**Status:** Open
+**Status:** Fixed
 
 ## 165. Engine seed event records throttle=0.00 at recording start
 


### PR DESCRIPTION
## Summary
- After revert/rewind, `StripOrphanedSpawnedVessels` removes Parsek-spawned vessels from flightState, but `RestoreStandaloneMutableState` restores `SpawnedVesselPersistentId` from the quicksave. The PID dedup check in `ShouldSpawnAtRecordingEnd` then blocks re-spawning permanently.
- Added `ReconcileSpawnStateAfterStrip` — after all strip operations, collects surviving PIDs from flightState and resets spawn tracking for any recording whose vessel was stripped. Called on both normal revert and rewind paths.
- Pure `ShouldResetSpawnState` decision method extracted for testability. 15 new tests.

## Test plan
- [x] 3572 unit tests pass (15 new)
- [ ] In-game: record flight → spawn at end → revert → verify vessel re-spawns at correct time
- [ ] In-game: rewind → spawn → rewind again → verify vessel re-spawns (not blocked by stale PID)
- [ ] In-game: normal scene change (flight → tracking station → flight) → verify spawned vessels persist (not reset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)