### PR TITLE
T97: Recording segmentation for selective looping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Parsek are documented here.
 
 ---
 
+## 0.5.4
+
+### Features
+
+- **T97: Altitude-based chain splits for airless bodies.** Recordings auto-split when crossing the approach altitude threshold on bodies without atmosphere (Mun, Minmus, Tylo, etc.). Uses KSP's native `timeWarpAltitudeLimits[4]` (100x warp limit) as the threshold, with `body.Radius * 0.15` as fallback. Enables selective looping of landing approaches without looping orbital coasts.
+- **T97: "approach" phase tagging.** Airless body segments below the threshold are tagged `"approach"` (sky blue in UI) instead of `"space"`. All phase tagging sites updated.
+- **T97: TrackSection altitude metadata.** Min/max altitude tracked per TrackSection during recording. Serialized as sparse keys, backward compatible with existing saves.
+- **T97: Recording optimization pass.** Automatic housekeeping merges redundant consecutive chain segments on save load (same phase, same body, no branch points, no ghosting triggers, no user-modified settings).
+
+---
+
 ## 0.5.3
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to Parsek are documented here.
 
 ---
 
-## 0.5.4
+## 0.5.3
 
 ### Features
 
@@ -12,10 +12,6 @@ All notable changes to Parsek are documented here.
 - **T97: "approach" phase tagging.** Airless body segments below the threshold are tagged `"approach"` (sky blue in UI) instead of `"space"`. All phase tagging sites updated.
 - **T97: TrackSection altitude metadata.** Min/max altitude tracked per TrackSection during recording. Serialized as sparse keys, backward compatible with existing saves.
 - **T97: Recording optimization pass.** Automatic housekeeping merges redundant consecutive chain segments on save load (same phase, same body, no branch points, no ghosting triggers, no user-modified settings).
-
----
-
-## 0.5.3
 
 ### Bug Fixes
 

--- a/Source/Parsek.Tests/AltitudeSplitExtendedTests.cs
+++ b/Source/Parsek.Tests/AltitudeSplitExtendedTests.cs
@@ -1,0 +1,161 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    [Collection("Sequential")]
+    public class AltitudeSplitExtendedTests : System.IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public AltitudeSplitExtendedTests()
+        {
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+        }
+
+        // --- Simulated Mun descent: points from 100km down to 0km ---
+
+        [Fact]
+        public void SimulatedMunDescent_SplitsAtThreshold()
+        {
+            // Mun: radius 200km, threshold = 30km
+            double threshold = FlightRecorder.ComputeApproachAltitude(200000);
+            Assert.Equal(30000, threshold);
+
+            // Simulate descent: check each 5km step
+            bool wasAbove = true;
+            bool pending = false;
+            double pendingUT = 0;
+            double splitUT = -1;
+
+            for (double alt = 100000; alt >= 0; alt -= 5000)
+            {
+                double ut = (100000 - alt) / 1000; // 1 km/s descent, UT from 0 to 100
+
+                bool nowAbove = alt >= threshold;
+                if (nowAbove != wasAbove && !pending)
+                {
+                    // Start hysteresis timer
+                    pending = true;
+                    pendingUT = ut;
+                }
+
+                if (pending && FlightRecorder.ShouldSplitAtAltitudeBoundary(
+                    alt, threshold, wasAbove, pending, pendingUT, ut))
+                {
+                    splitUT = ut;
+                    break;
+                }
+            }
+
+            // Should have split somewhere around 30km - hysteresisMeters
+            Assert.True(splitUT > 0, "Expected split during Mun descent");
+            // At 5km steps, we cross 30km at alt=25000 (step past by 5000m > 1000m hysteresis)
+            // Timer started at alt=25000 (ut=75), confirmed at alt=20000 (ut=80) — 5s elapsed > 3s hysteresis
+            Assert.True(splitUT <= 85, $"Split should occur within ~85s, got {splitUT}");
+        }
+
+        [Fact]
+        public void SimulatedMunAscent_SplitsAtThreshold()
+        {
+            double threshold = FlightRecorder.ComputeApproachAltitude(200000);
+
+            bool wasAbove = false; // start below threshold
+            bool pending = false;
+            double pendingUT = 0;
+            double splitUT = -1;
+
+            for (double alt = 0; alt <= 100000; alt += 5000)
+            {
+                double ut = alt / 1000;
+
+                bool nowAbove = alt >= threshold;
+                if (nowAbove != wasAbove && !pending)
+                {
+                    pending = true;
+                    pendingUT = ut;
+                }
+
+                if (pending && FlightRecorder.ShouldSplitAtAltitudeBoundary(
+                    alt, threshold, wasAbove, pending, pendingUT, ut))
+                {
+                    splitUT = ut;
+                    break;
+                }
+            }
+
+            Assert.True(splitUT > 0, "Expected split during Mun ascent");
+        }
+
+        // --- Stock airless body threshold coverage ---
+
+        [Theory]
+        [InlineData(200000, 30000)]      // Mun
+        [InlineData(60000, 9000)]         // Minmus
+        [InlineData(600000, 90000)]       // Tylo
+        [InlineData(13000, 5000)]         // Gilly (floor clamp)
+        [InlineData(130000, 19500)]       // Ike
+        [InlineData(138000, 20700)]       // Dres
+        [InlineData(250000, 37500)]       // Moho
+        [InlineData(210000, 31500)]       // Eeloo
+        [InlineData(65000, 9750)]         // Bop
+        [InlineData(44000, 6600)]         // Pol
+        public void StockAirlessBodies_ThresholdValues(double bodyRadius, double expectedThreshold)
+        {
+            double threshold = FlightRecorder.ComputeApproachAltitude(bodyRadius);
+            Assert.Equal(expectedThreshold, threshold);
+        }
+
+        // --- Log assertion: altitude boundary confirmed ---
+
+        [Fact]
+        public void AltitudeBoundaryConfirmed_LogsCorrectly()
+        {
+            // Direct test of the pure method — it doesn't log (instance method does).
+            // Verify the FlightRecorder constructor creates valid initial state for altitude fields.
+            var recorder = new FlightRecorder();
+            Assert.False(recorder.AltitudeBoundaryCrossed);
+            Assert.False(recorder.DescendedBelowThreshold);
+        }
+
+        // --- Phase tagging for "approach" label ---
+
+        [Fact]
+        public void GetSegmentPhaseLabel_ApproachPhase()
+        {
+            var rec = new Recording
+            {
+                SegmentPhase = "approach",
+                SegmentBodyName = "Mun"
+            };
+            Assert.Equal("Mun approach", RecordingStore.GetSegmentPhaseLabel(rec));
+        }
+
+        [Fact]
+        public void GetSegmentPhaseLabel_ApproachWithoutBody()
+        {
+            var rec = new Recording { SegmentPhase = "approach" };
+            Assert.Equal("approach", RecordingStore.GetSegmentPhaseLabel(rec));
+        }
+
+        // --- ClearBoundaryFlags clears altitude state ---
+
+        [Fact]
+        public void ClearBoundaryFlags_ClearsAltitudeState()
+        {
+            var recorder = new FlightRecorder();
+            // Can't set the properties directly (private set), but verify they default to false
+            // and ClearBoundaryFlags doesn't throw
+            recorder.ClearBoundaryFlags();
+            Assert.False(recorder.AltitudeBoundaryCrossed);
+            Assert.False(recorder.DescendedBelowThreshold);
+
+            Assert.Contains(logLines, l => l.Contains("Boundary flags cleared"));
+        }
+    }
+}

--- a/Source/Parsek.Tests/AltitudeSplitTests.cs
+++ b/Source/Parsek.Tests/AltitudeSplitTests.cs
@@ -1,0 +1,211 @@
+using Xunit;
+
+namespace Parsek.Tests
+{
+    [Collection("Sequential")]
+    public class AltitudeSplitTests
+    {
+        // Mun: radius 200km, threshold = 200000 * 0.15 = 30000m
+        private const double MunRadius = 200000.0;
+        private const double MunThreshold = 30000.0;
+
+        [Fact]
+        public void ZeroThreshold_ReturnsFalse()
+        {
+            bool result = FlightRecorder.ShouldSplitAtAltitudeBoundary(
+                altitude: 10000, threshold: 0,
+                wasAbove: true, pendingCross: true, pendingUT: 0, currentUT: 10);
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void NegativeThreshold_ReturnsFalse()
+        {
+            bool result = FlightRecorder.ShouldSplitAtAltitudeBoundary(
+                altitude: 10000, threshold: -1000,
+                wasAbove: true, pendingCross: true, pendingUT: 0, currentUT: 10);
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void SameSide_AboveThreshold_ReturnsFalse()
+        {
+            // Still above threshold, no boundary crossed
+            bool result = FlightRecorder.ShouldSplitAtAltitudeBoundary(
+                altitude: 50000, threshold: MunThreshold,
+                wasAbove: true, pendingCross: true, pendingUT: 0, currentUT: 10);
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void SameSide_BelowThreshold_ReturnsFalse()
+        {
+            // Still below threshold, no boundary crossed
+            bool result = FlightRecorder.ShouldSplitAtAltitudeBoundary(
+                altitude: 10000, threshold: MunThreshold,
+                wasAbove: false, pendingCross: true, pendingUT: 0, currentUT: 10);
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void CrossedButNotFarEnough_ReturnsFalse()
+        {
+            // Descended below threshold by only 100m (default hysteresis for 30km threshold = max(1000, 600) = 1000m)
+            bool result = FlightRecorder.ShouldSplitAtAltitudeBoundary(
+                altitude: MunThreshold - 100, threshold: MunThreshold,
+                wasAbove: true, pendingCross: true, pendingUT: 0, currentUT: 10);
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void CrossedFarButNotLongEnough_ReturnsFalse()
+        {
+            // Past 2000m below threshold but timer not started (pendingCross = false)
+            bool result = FlightRecorder.ShouldSplitAtAltitudeBoundary(
+                altitude: MunThreshold - 2000, threshold: MunThreshold,
+                wasAbove: true, pendingCross: false, pendingUT: 0, currentUT: 10);
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void CrossedFarAndLongEnough_Descending_ReturnsTrue()
+        {
+            // Descending below threshold: was above, now 2000m below, 5s elapsed
+            bool result = FlightRecorder.ShouldSplitAtAltitudeBoundary(
+                altitude: MunThreshold - 2000, threshold: MunThreshold,
+                wasAbove: true, pendingCross: true, pendingUT: 100, currentUT: 105);
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void CrossedFarAndLongEnough_Ascending_ReturnsTrue()
+        {
+            // Ascending above threshold: was below, now 2000m above, 5s elapsed
+            bool result = FlightRecorder.ShouldSplitAtAltitudeBoundary(
+                altitude: MunThreshold + 2000, threshold: MunThreshold,
+                wasAbove: false, pendingCross: true, pendingUT: 100, currentUT: 105);
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void HysteresisTimeNotMet_ReturnsFalse()
+        {
+            // Only 2s elapsed, need 3s
+            bool result = FlightRecorder.ShouldSplitAtAltitudeBoundary(
+                altitude: MunThreshold - 2000, threshold: MunThreshold,
+                wasAbove: true, pendingCross: true, pendingUT: 100, currentUT: 102);
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void ExactlyAtHysteresisThreshold_ReturnsTrue()
+        {
+            // Exactly 3s elapsed, exactly 1000m past boundary
+            bool result = FlightRecorder.ShouldSplitAtAltitudeBoundary(
+                altitude: MunThreshold - 1000, threshold: MunThreshold,
+                wasAbove: true, pendingCross: true, pendingUT: 100, currentUT: 103);
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void CustomHysteresis_Respected()
+        {
+            // Custom: 1s time, 500m distance
+            bool result = FlightRecorder.ShouldSplitAtAltitudeBoundary(
+                altitude: MunThreshold - 600, threshold: MunThreshold,
+                wasAbove: true, pendingCross: true, pendingUT: 100, currentUT: 101.5,
+                hysteresisSeconds: 1.0, hysteresisMeters: 500.0);
+            Assert.True(result);
+
+            // Same custom, but not enough distance
+            bool result2 = FlightRecorder.ShouldSplitAtAltitudeBoundary(
+                altitude: MunThreshold - 400, threshold: MunThreshold,
+                wasAbove: true, pendingCross: true, pendingUT: 100, currentUT: 101.5,
+                hysteresisSeconds: 1.0, hysteresisMeters: 500.0);
+            Assert.False(result2);
+        }
+
+        // --- ComputeApproachAltitude tests ---
+
+        [Fact]
+        public void ComputeApproachAltitude_MunRadius()
+        {
+            // 200km * 0.15 = 30km
+            double threshold = FlightRecorder.ComputeApproachAltitude(200000);
+            Assert.Equal(30000, threshold);
+        }
+
+        [Fact]
+        public void ComputeApproachAltitude_MinmusRadius()
+        {
+            // 60km * 0.15 = 9km (above floor)
+            double threshold = FlightRecorder.ComputeApproachAltitude(60000);
+            Assert.Equal(9000, threshold);
+        }
+
+        [Fact]
+        public void ComputeApproachAltitude_GillyRadius_FloorClamp()
+        {
+            // 13km * 0.15 = 1950m, clamped to 5000m floor
+            double threshold = FlightRecorder.ComputeApproachAltitude(13000);
+            Assert.Equal(5000, threshold);
+        }
+
+        [Fact]
+        public void ComputeApproachAltitude_TyloRadius()
+        {
+            // 600km * 0.15 = 90km
+            double threshold = FlightRecorder.ComputeApproachAltitude(600000);
+            Assert.Equal(90000, threshold);
+        }
+
+        [Fact]
+        public void ComputeApproachAltitude_HugeBody_CeilingClamp()
+        {
+            // 2000km * 0.15 = 300km, clamped to 200km ceiling
+            double threshold = FlightRecorder.ComputeApproachAltitude(2000000);
+            Assert.Equal(200000, threshold);
+        }
+
+        [Fact]
+        public void ComputeApproachAltitude_IkeRadius()
+        {
+            // 130km * 0.15 = 19.5km
+            double threshold = FlightRecorder.ComputeApproachAltitude(130000);
+            Assert.Equal(19500, threshold);
+        }
+
+        [Fact]
+        public void ComputeApproachAltitude_MohoRadius()
+        {
+            // 250km * 0.15 = 37.5km
+            double threshold = FlightRecorder.ComputeApproachAltitude(250000);
+            Assert.Equal(37500, threshold);
+        }
+
+        [Fact]
+        public void ComputeApproachAltitude_EelooRadius()
+        {
+            // 210km * 0.15 = 31.5km
+            double threshold = FlightRecorder.ComputeApproachAltitude(210000);
+            Assert.Equal(31500, threshold);
+        }
+
+        [Fact]
+        public void HysteresisMeters_ScalesWithThreshold()
+        {
+            // For a large threshold (90km), default hysteresis = max(1000, 90000*0.02) = 1800m
+            // Crossing by 1500m should NOT be enough
+            bool result = FlightRecorder.ShouldSplitAtAltitudeBoundary(
+                altitude: 90000 - 1500, threshold: 90000,
+                wasAbove: true, pendingCross: true, pendingUT: 100, currentUT: 105);
+            Assert.False(result);
+
+            // Crossing by 2000m should be enough
+            bool result2 = FlightRecorder.ShouldSplitAtAltitudeBoundary(
+                altitude: 90000 - 2000, threshold: 90000,
+                wasAbove: true, pendingCross: true, pendingUT: 100, currentUT: 105);
+            Assert.True(result2);
+        }
+    }
+}

--- a/Source/Parsek.Tests/RecordingOptimizerTests.cs
+++ b/Source/Parsek.Tests/RecordingOptimizerTests.cs
@@ -487,6 +487,18 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void SplitAtSection_SurfaceTaggedAsSurface()
+        {
+            var rec = MakeRecordingWithSections(17000, 17030, 17060,
+                SegmentEnvironment.ExoBallistic, SegmentEnvironment.SurfaceStationary);
+            rec.SegmentBodyName = "Mun";
+            var second = RecordingOptimizer.SplitAtSection(rec, 1);
+
+            Assert.Equal("exo", rec.SegmentPhase);
+            Assert.Equal("surface", second.SegmentPhase);
+        }
+
+        [Fact]
         public void SplitAtSection_BothHalvesHaveValidUTRanges()
         {
             var rec = MakeRecordingWithSections(17000, 17030, 17060,

--- a/Source/Parsek.Tests/RecordingOptimizerTests.cs
+++ b/Source/Parsek.Tests/RecordingOptimizerTests.cs
@@ -536,5 +536,86 @@ namespace Parsek.Tests
         }
 
         #endregion
+
+        #region RunOptimizationPass integration
+
+        [Fact]
+        public void RunOptimizationPass_MergesThreeExoSegments()
+        {
+            RecordingStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+
+            // Commit 3 consecutive exo segments in the same chain
+            var a = MakeChainSegment("chain1", 0, startUT: 17000, endUT: 17030);
+            var b = MakeChainSegment("chain1", 1, startUT: 17030, endUT: 17060);
+            var c = MakeChainSegment("chain1", 2, startUT: 17060, endUT: 17090);
+
+            var recordings = RecordingStore.CommittedRecordings;
+            recordings.Add(a);
+            recordings.Add(b);
+            recordings.Add(c);
+
+            RecordingStore.RunOptimizationPass();
+
+            // Should be merged into 1 recording
+            Assert.Single(recordings);
+            Assert.Equal(0, recordings[0].ChainIndex);
+            Assert.Equal(6, recordings[0].Points.Count); // 2+2+2
+            Assert.Equal(17000, recordings[0].StartUT);
+            Assert.Equal(17090, recordings[0].EndUT);
+
+            RecordingStore.ResetForTesting();
+        }
+
+        [Fact]
+        public void RunOptimizationPass_SkipsUserModifiedSegments()
+        {
+            RecordingStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+
+            var a = MakeChainSegment("chain1", 0, startUT: 17000, endUT: 17030);
+            var b = MakeChainSegment("chain1", 1, startUT: 17030, endUT: 17060);
+            b.LoopPlayback = true; // user enabled loop — blocks merge
+            var c = MakeChainSegment("chain1", 2, startUT: 17060, endUT: 17090);
+
+            var recordings = RecordingStore.CommittedRecordings;
+            recordings.Add(a);
+            recordings.Add(b);
+            recordings.Add(c);
+
+            RecordingStore.RunOptimizationPass();
+
+            // No merges should occur (b blocks both pairs)
+            Assert.Equal(3, recordings.Count);
+
+            RecordingStore.ResetForTesting();
+        }
+
+        [Fact]
+        public void RunOptimizationPass_MergesDifferentChainsSeparately()
+        {
+            RecordingStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+
+            var a1 = MakeChainSegment("chain1", 0, startUT: 17000, endUT: 17030);
+            var a2 = MakeChainSegment("chain1", 1, startUT: 17030, endUT: 17060);
+            var b1 = MakeChainSegment("chain2", 0, phase: "approach", startUT: 17000, endUT: 17020);
+            var b2 = MakeChainSegment("chain2", 1, phase: "approach", startUT: 17020, endUT: 17040);
+
+            var recordings = RecordingStore.CommittedRecordings;
+            recordings.Add(a1);
+            recordings.Add(a2);
+            recordings.Add(b1);
+            recordings.Add(b2);
+
+            RecordingStore.RunOptimizationPass();
+
+            // Both chains should be merged independently → 2 recordings
+            Assert.Equal(2, recordings.Count);
+
+            RecordingStore.ResetForTesting();
+        }
+
+        #endregion
     }
 }

--- a/Source/Parsek.Tests/RecordingOptimizerTests.cs
+++ b/Source/Parsek.Tests/RecordingOptimizerTests.cs
@@ -1,0 +1,540 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    [Collection("Sequential")]
+    public class RecordingOptimizerTests : System.IDisposable
+    {
+        public RecordingOptimizerTests()
+        {
+            ParsekLog.SuppressLogging = true;
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+        }
+
+        #region Helpers
+
+        private static Recording MakeChainSegment(string chainId, int chainIndex,
+            string phase = "exo", string body = "Mun", double startUT = 17000, double endUT = 17060)
+        {
+            var rec = new Recording
+            {
+                ChainId = chainId,
+                ChainIndex = chainIndex,
+                ChainBranch = 0,
+                SegmentPhase = phase,
+                SegmentBodyName = body,
+                LoopPlayback = false,
+                PlaybackEnabled = true,
+                Hidden = false,
+                LoopIntervalSeconds = 10.0,
+                LoopAnchorVesselId = 0,
+            };
+            rec.Points.Add(new TrajectoryPoint { ut = startUT, altitude = 50000 });
+            rec.Points.Add(new TrajectoryPoint { ut = endUT, altitude = 50000 });
+            return rec;
+        }
+
+        private static Recording MakeRecordingWithSections(double startUT, double midUT, double endUT,
+            SegmentEnvironment env1, SegmentEnvironment env2)
+        {
+            var rec = new Recording();
+            rec.Points.Add(new TrajectoryPoint { ut = startUT, altitude = 80000 });
+            rec.Points.Add(new TrajectoryPoint { ut = midUT - 1, altitude = 40000 });
+            rec.Points.Add(new TrajectoryPoint { ut = midUT, altitude = 30000 });
+            rec.Points.Add(new TrajectoryPoint { ut = endUT, altitude = 100 });
+
+            rec.TrackSections.Add(new TrackSection
+            {
+                environment = env1,
+                startUT = startUT,
+                endUT = midUT,
+                frames = new List<TrajectoryPoint>()
+            });
+            rec.TrackSections.Add(new TrackSection
+            {
+                environment = env2,
+                startUT = midUT,
+                endUT = endUT,
+                frames = new List<TrajectoryPoint>()
+            });
+            return rec;
+        }
+
+        #endregion
+
+        #region CanAutoMerge
+
+        [Fact]
+        public void CanAutoMerge_SamePhase_DefaultSettings_ReturnsTrue()
+        {
+            var a = MakeChainSegment("chain1", 0);
+            var b = MakeChainSegment("chain1", 1);
+            Assert.True(RecordingOptimizer.CanAutoMerge(a, b));
+        }
+
+        [Fact]
+        public void CanAutoMerge_DifferentPhase_ReturnsFalse()
+        {
+            var a = MakeChainSegment("chain1", 0, phase: "exo");
+            var b = MakeChainSegment("chain1", 1, phase: "approach");
+            Assert.False(RecordingOptimizer.CanAutoMerge(a, b));
+        }
+
+        [Fact]
+        public void CanAutoMerge_DifferentBody_ReturnsFalse()
+        {
+            var a = MakeChainSegment("chain1", 0, body: "Mun");
+            var b = MakeChainSegment("chain1", 1, body: "Minmus");
+            Assert.False(RecordingOptimizer.CanAutoMerge(a, b));
+        }
+
+        [Fact]
+        public void CanAutoMerge_LoopEnabled_ReturnsFalse()
+        {
+            var a = MakeChainSegment("chain1", 0);
+            var b = MakeChainSegment("chain1", 1);
+            a.LoopPlayback = true;
+            Assert.False(RecordingOptimizer.CanAutoMerge(a, b));
+        }
+
+        [Fact]
+        public void CanAutoMerge_PlaybackDisabled_ReturnsFalse()
+        {
+            var a = MakeChainSegment("chain1", 0);
+            var b = MakeChainSegment("chain1", 1);
+            b.PlaybackEnabled = false;
+            Assert.False(RecordingOptimizer.CanAutoMerge(a, b));
+        }
+
+        [Fact]
+        public void CanAutoMerge_Hidden_ReturnsFalse()
+        {
+            var a = MakeChainSegment("chain1", 0);
+            var b = MakeChainSegment("chain1", 1);
+            a.Hidden = true;
+            Assert.False(RecordingOptimizer.CanAutoMerge(a, b));
+        }
+
+        [Fact]
+        public void CanAutoMerge_CustomLoopInterval_ReturnsFalse()
+        {
+            var a = MakeChainSegment("chain1", 0);
+            var b = MakeChainSegment("chain1", 1);
+            b.LoopIntervalSeconds = 30.0;
+            Assert.False(RecordingOptimizer.CanAutoMerge(a, b));
+        }
+
+        [Fact]
+        public void CanAutoMerge_AnchorSet_ReturnsFalse()
+        {
+            var a = MakeChainSegment("chain1", 0);
+            var b = MakeChainSegment("chain1", 1);
+            a.LoopAnchorVesselId = 12345;
+            Assert.False(RecordingOptimizer.CanAutoMerge(a, b));
+        }
+
+        [Fact]
+        public void CanAutoMerge_DifferentGroups_ReturnsFalse()
+        {
+            var a = MakeChainSegment("chain1", 0);
+            var b = MakeChainSegment("chain1", 1);
+            a.RecordingGroups = new List<string> { "GroupA" };
+            Assert.False(RecordingOptimizer.CanAutoMerge(a, b));
+        }
+
+        [Fact]
+        public void CanAutoMerge_SameGroups_ReturnsTrue()
+        {
+            var a = MakeChainSegment("chain1", 0);
+            var b = MakeChainSegment("chain1", 1);
+            a.RecordingGroups = new List<string> { "GroupA" };
+            b.RecordingGroups = new List<string> { "GroupA" };
+            Assert.True(RecordingOptimizer.CanAutoMerge(a, b));
+        }
+
+        [Fact]
+        public void CanAutoMerge_BranchPointBetween_ReturnsFalse()
+        {
+            var a = MakeChainSegment("chain1", 0);
+            var b = MakeChainSegment("chain1", 1);
+            a.ChildBranchPointId = "bp_001";
+            Assert.False(RecordingOptimizer.CanAutoMerge(a, b));
+        }
+
+        [Fact]
+        public void CanAutoMerge_HasGhostingTriggerEvents_ReturnsFalse()
+        {
+            var a = MakeChainSegment("chain1", 0);
+            var b = MakeChainSegment("chain1", 1);
+            a.PartEvents.Add(new PartEvent { eventType = PartEventType.FairingJettisoned, ut = 17010 });
+            Assert.False(RecordingOptimizer.CanAutoMerge(a, b));
+        }
+
+        [Fact]
+        public void CanAutoMerge_DifferentChain_ReturnsFalse()
+        {
+            var a = MakeChainSegment("chain1", 0);
+            var b = MakeChainSegment("chain2", 1);
+            Assert.False(RecordingOptimizer.CanAutoMerge(a, b));
+        }
+
+        [Fact]
+        public void CanAutoMerge_NonConsecutiveIndex_ReturnsFalse()
+        {
+            var a = MakeChainSegment("chain1", 0);
+            var b = MakeChainSegment("chain1", 2); // gap
+            Assert.False(RecordingOptimizer.CanAutoMerge(a, b));
+        }
+
+        [Fact]
+        public void CanAutoMerge_NonZeroBranch_ReturnsFalse()
+        {
+            var a = MakeChainSegment("chain1", 0);
+            var b = MakeChainSegment("chain1", 1);
+            b.ChainBranch = 1;
+            Assert.False(RecordingOptimizer.CanAutoMerge(a, b));
+        }
+
+        [Fact]
+        public void CanAutoMerge_NullInputs_ReturnsFalse()
+        {
+            Assert.False(RecordingOptimizer.CanAutoMerge(null, new Recording()));
+            Assert.False(RecordingOptimizer.CanAutoMerge(new Recording(), null));
+        }
+
+        #endregion
+
+        #region CanAutoSplit
+
+        [Fact]
+        public void CanAutoSplit_NoGhostingTriggers_ReturnsTrue()
+        {
+            var rec = MakeRecordingWithSections(17000, 17030, 17060,
+                SegmentEnvironment.ExoBallistic, SegmentEnvironment.ExoPropulsive);
+            Assert.True(RecordingOptimizer.CanAutoSplit(rec, 1));
+        }
+
+        [Fact]
+        public void CanAutoSplit_HasGhostingTriggers_ReturnsFalse()
+        {
+            var rec = MakeRecordingWithSections(17000, 17030, 17060,
+                SegmentEnvironment.ExoBallistic, SegmentEnvironment.ExoPropulsive);
+            rec.PartEvents.Add(new PartEvent { eventType = PartEventType.Decoupled, ut = 17010 });
+            Assert.False(RecordingOptimizer.CanAutoSplit(rec, 1));
+        }
+
+        [Fact]
+        public void CanAutoSplit_HalfTooShort_ReturnsFalse()
+        {
+            // Second half only 3s
+            var rec = MakeRecordingWithSections(17000, 17057, 17060,
+                SegmentEnvironment.ExoBallistic, SegmentEnvironment.ExoPropulsive);
+            Assert.False(RecordingOptimizer.CanAutoSplit(rec, 1));
+        }
+
+        [Fact]
+        public void CanAutoSplit_SingleSection_ReturnsFalse()
+        {
+            var rec = new Recording();
+            rec.Points.Add(new TrajectoryPoint { ut = 17000 });
+            rec.Points.Add(new TrajectoryPoint { ut = 17060 });
+            rec.TrackSections.Add(new TrackSection
+            {
+                environment = SegmentEnvironment.Atmospheric,
+                startUT = 17000, endUT = 17060,
+                frames = new List<TrajectoryPoint>()
+            });
+            Assert.False(RecordingOptimizer.CanAutoSplit(rec, 1));
+        }
+
+        [Fact]
+        public void CanAutoSplit_IndexOutOfRange_ReturnsFalse()
+        {
+            var rec = MakeRecordingWithSections(17000, 17030, 17060,
+                SegmentEnvironment.ExoBallistic, SegmentEnvironment.ExoPropulsive);
+            Assert.False(RecordingOptimizer.CanAutoSplit(rec, 0)); // can't split before first
+            Assert.False(RecordingOptimizer.CanAutoSplit(rec, 2)); // out of range
+        }
+
+        [Fact]
+        public void CanAutoSplit_NullRecording_ReturnsFalse()
+        {
+            Assert.False(RecordingOptimizer.CanAutoSplit(null, 1));
+        }
+
+        #endregion
+
+        #region FindMergeCandidates
+
+        [Fact]
+        public void FindMergeCandidates_ThreeExoSegments_ReturnsTwoPairs()
+        {
+            var committed = new List<Recording>
+            {
+                MakeChainSegment("chain1", 0, startUT: 17000, endUT: 17060),
+                MakeChainSegment("chain1", 1, startUT: 17060, endUT: 17120),
+                MakeChainSegment("chain1", 2, startUT: 17120, endUT: 17180),
+            };
+
+            var candidates = RecordingOptimizer.FindMergeCandidates(committed);
+            Assert.Equal(2, candidates.Count);
+            Assert.Equal((0, 1), candidates[0]);
+            Assert.Equal((1, 2), candidates[1]);
+        }
+
+        [Fact]
+        public void FindMergeCandidates_MixedPhases_OnlyMatchingPairs()
+        {
+            var committed = new List<Recording>
+            {
+                MakeChainSegment("chain1", 0, phase: "exo", startUT: 17000, endUT: 17060),
+                MakeChainSegment("chain1", 1, phase: "approach", startUT: 17060, endUT: 17120),
+                MakeChainSegment("chain1", 2, phase: "approach", startUT: 17120, endUT: 17180),
+            };
+
+            var candidates = RecordingOptimizer.FindMergeCandidates(committed);
+            Assert.Single(candidates);
+            Assert.Equal((1, 2), candidates[0]);
+        }
+
+        [Fact]
+        public void FindMergeCandidates_EmptyList_ReturnsEmpty()
+        {
+            Assert.Empty(RecordingOptimizer.FindMergeCandidates(new List<Recording>()));
+        }
+
+        [Fact]
+        public void FindMergeCandidates_NoChain_ReturnsEmpty()
+        {
+            var committed = new List<Recording>
+            {
+                new Recording { SegmentPhase = "exo" },
+                new Recording { SegmentPhase = "exo" },
+            };
+            Assert.Empty(RecordingOptimizer.FindMergeCandidates(committed));
+        }
+
+        #endregion
+
+        #region FindSplitCandidates
+
+        [Fact]
+        public void FindSplitCandidates_EnvironmentChange_ReturnsSplit()
+        {
+            var rec = MakeRecordingWithSections(17000, 17030, 17060,
+                SegmentEnvironment.ExoBallistic, SegmentEnvironment.ExoPropulsive);
+            var committed = new List<Recording> { rec };
+
+            var candidates = RecordingOptimizer.FindSplitCandidates(committed);
+            Assert.Single(candidates);
+            Assert.Equal((0, 1), candidates[0]);
+        }
+
+        [Fact]
+        public void FindSplitCandidates_SameEnvironment_ReturnsEmpty()
+        {
+            var rec = MakeRecordingWithSections(17000, 17030, 17060,
+                SegmentEnvironment.ExoBallistic, SegmentEnvironment.ExoBallistic);
+            var committed = new List<Recording> { rec };
+
+            Assert.Empty(RecordingOptimizer.FindSplitCandidates(committed));
+        }
+
+        #endregion
+
+        #region MergeInto
+
+        [Fact]
+        public void MergeInto_ConcatenatesPoints()
+        {
+            var a = MakeChainSegment("c1", 0, startUT: 17000, endUT: 17030);
+            var b = MakeChainSegment("c1", 1, startUT: 17030, endUT: 17060);
+            RecordingOptimizer.MergeInto(a, b);
+            Assert.Equal(4, a.Points.Count); // 2 + 2
+            Assert.Equal(17000, a.Points[0].ut);
+            Assert.Equal(17060, a.Points[3].ut);
+        }
+
+        [Fact]
+        public void MergeInto_MergesPartEvents_Sorted()
+        {
+            var a = MakeChainSegment("c1", 0, startUT: 17000, endUT: 17030);
+            var b = MakeChainSegment("c1", 1, startUT: 17030, endUT: 17060);
+            a.PartEvents.Add(new PartEvent { ut = 17020, eventType = PartEventType.LightOn });
+            b.PartEvents.Add(new PartEvent { ut = 17010, eventType = PartEventType.LightOff });
+            RecordingOptimizer.MergeInto(a, b);
+            Assert.Equal(2, a.PartEvents.Count);
+            Assert.True(a.PartEvents[0].ut <= a.PartEvents[1].ut);
+        }
+
+        [Fact]
+        public void MergeInto_InheritsVesselSnapshot_WhenAbsorbedIsChainTip()
+        {
+            var a = MakeChainSegment("c1", 0);
+            var b = MakeChainSegment("c1", 1);
+            a.VesselSnapshot = null; // mid-chain
+            b.VesselSnapshot = new ConfigNode("VESSEL");
+            RecordingOptimizer.MergeInto(a, b);
+            Assert.NotNull(a.VesselSnapshot);
+        }
+
+        [Fact]
+        public void MergeInto_KeepsNullSnapshot_WhenAbsorbedIsMidChain()
+        {
+            var a = MakeChainSegment("c1", 0);
+            var b = MakeChainSegment("c1", 1);
+            a.VesselSnapshot = null;
+            b.VesselSnapshot = null;
+            RecordingOptimizer.MergeInto(a, b);
+            Assert.Null(a.VesselSnapshot);
+        }
+
+        [Fact]
+        public void MergeInto_InheritsTerminalState()
+        {
+            var a = MakeChainSegment("c1", 0);
+            var b = MakeChainSegment("c1", 1);
+            b.TerminalStateValue = TerminalState.Landed;
+            RecordingOptimizer.MergeInto(a, b);
+            Assert.Equal(TerminalState.Landed, a.TerminalStateValue);
+        }
+
+        [Fact]
+        public void MergeInto_InvalidatesGhostGeometry()
+        {
+            var a = MakeChainSegment("c1", 0);
+            a.GhostGeometryAvailable = true;
+            a.GhostGeometryRelativePath = "old/path.pcrf";
+            var b = MakeChainSegment("c1", 1);
+            RecordingOptimizer.MergeInto(a, b);
+            Assert.False(a.GhostGeometryAvailable);
+            Assert.Null(a.GhostGeometryRelativePath);
+        }
+
+        [Fact]
+        public void MergeInto_ClearsExplicitUTRanges()
+        {
+            var a = MakeChainSegment("c1", 0);
+            a.ExplicitStartUT = 17000;
+            a.ExplicitEndUT = 17030;
+            var b = MakeChainSegment("c1", 1);
+            RecordingOptimizer.MergeInto(a, b);
+            Assert.True(double.IsNaN(a.ExplicitStartUT));
+            Assert.True(double.IsNaN(a.ExplicitEndUT));
+        }
+
+        #endregion
+
+        #region SplitAtSection
+
+        [Fact]
+        public void SplitAtSection_PartitionsPoints()
+        {
+            var rec = MakeRecordingWithSections(17000, 17030, 17060,
+                SegmentEnvironment.ExoBallistic, SegmentEnvironment.ExoPropulsive);
+            int originalCount = rec.Points.Count;
+            var second = RecordingOptimizer.SplitAtSection(rec, 1);
+
+            Assert.True(rec.Points.Count > 0);
+            Assert.True(second.Points.Count > 0);
+            Assert.Equal(originalCount, rec.Points.Count + second.Points.Count);
+            Assert.True(rec.Points[rec.Points.Count - 1].ut < second.Points[0].ut);
+        }
+
+        [Fact]
+        public void SplitAtSection_PartitionsSections()
+        {
+            var rec = MakeRecordingWithSections(17000, 17030, 17060,
+                SegmentEnvironment.ExoBallistic, SegmentEnvironment.ExoPropulsive);
+            var second = RecordingOptimizer.SplitAtSection(rec, 1);
+
+            Assert.Single(rec.TrackSections);
+            Assert.Single(second.TrackSections);
+            Assert.Equal(SegmentEnvironment.ExoBallistic, rec.TrackSections[0].environment);
+            Assert.Equal(SegmentEnvironment.ExoPropulsive, second.TrackSections[0].environment);
+        }
+
+        [Fact]
+        public void SplitAtSection_ClonesSnapshot()
+        {
+            var rec = MakeRecordingWithSections(17000, 17030, 17060,
+                SegmentEnvironment.ExoBallistic, SegmentEnvironment.ExoPropulsive);
+            rec.GhostVisualSnapshot = new ConfigNode("VESSEL");
+            var second = RecordingOptimizer.SplitAtSection(rec, 1);
+
+            Assert.NotNull(rec.GhostVisualSnapshot);
+            Assert.NotNull(second.GhostVisualSnapshot);
+            // Should be separate instances
+            Assert.NotSame(rec.GhostVisualSnapshot, second.GhostVisualSnapshot);
+        }
+
+        [Fact]
+        public void SplitAtSection_TagsPhaseFromEnvironment()
+        {
+            var rec = MakeRecordingWithSections(17000, 17030, 17060,
+                SegmentEnvironment.ExoBallistic, SegmentEnvironment.Atmospheric);
+            rec.SegmentBodyName = "Kerbin";
+            var second = RecordingOptimizer.SplitAtSection(rec, 1);
+
+            Assert.Equal("exo", rec.SegmentPhase);
+            Assert.Equal("atmo", second.SegmentPhase);
+            Assert.Equal("Kerbin", second.SegmentBodyName);
+        }
+
+        [Fact]
+        public void SplitAtSection_BothHalvesHaveValidUTRanges()
+        {
+            var rec = MakeRecordingWithSections(17000, 17030, 17060,
+                SegmentEnvironment.ExoBallistic, SegmentEnvironment.ExoPropulsive);
+            var second = RecordingOptimizer.SplitAtSection(rec, 1);
+
+            Assert.True(rec.StartUT < rec.EndUT);
+            Assert.True(second.StartUT < second.EndUT);
+            Assert.True(rec.EndUT <= second.StartUT);
+        }
+
+        #endregion
+
+        #region ReindexChain
+
+        [Fact]
+        public void ReindexChain_AfterMerge_IndicesSequential()
+        {
+            var committed = new List<Recording>
+            {
+                MakeChainSegment("c1", 0, startUT: 17000, endUT: 17030),
+                // index 1 was merged into 0, so index 2 is now at position 1
+                MakeChainSegment("c1", 2, startUT: 17060, endUT: 17090),
+            };
+            RecordingOptimizer.ReindexChain(committed, "c1");
+            Assert.Equal(0, committed[0].ChainIndex);
+            Assert.Equal(1, committed[1].ChainIndex);
+        }
+
+        [Fact]
+        public void ReindexChain_PreservesChainBranch()
+        {
+            var committed = new List<Recording>
+            {
+                MakeChainSegment("c1", 0, startUT: 17000, endUT: 17030),
+                MakeChainSegment("c1", 5, startUT: 17060, endUT: 17090), // gap
+            };
+            // Add a branch-1 recording — should not be re-indexed
+            var branch = MakeChainSegment("c1", 0, startUT: 17030, endUT: 17060);
+            branch.ChainBranch = 1;
+            committed.Add(branch);
+
+            RecordingOptimizer.ReindexChain(committed, "c1");
+            Assert.Equal(0, committed[0].ChainIndex);
+            Assert.Equal(1, committed[1].ChainIndex);
+            Assert.Equal(0, committed[2].ChainIndex); // branch-1 untouched
+        }
+
+        #endregion
+    }
+}

--- a/Source/Parsek.Tests/TrackSectionSerializationTests.cs
+++ b/Source/Parsek.Tests/TrackSectionSerializationTests.cs
@@ -583,6 +583,80 @@ namespace Parsek.Tests
             Assert.Empty(node.GetNodes("TRACK_SECTION"));
         }
 
+        [Fact]
+        public void AltitudeMetadata_RoundTrip()
+        {
+            var tracks = new List<TrackSection>
+            {
+                new TrackSection
+                {
+                    environment = SegmentEnvironment.Atmospheric,
+                    referenceFrame = ReferenceFrame.Absolute,
+                    startUT = 17000, endUT = 17060,
+                    frames = new List<TrajectoryPoint>(),
+                    checkpoints = new List<OrbitSegment>(),
+                    minAltitude = 500f,
+                    maxAltitude = 72000f
+                }
+            };
+
+            var node = new ConfigNode("TEST");
+            RecordingStore.SerializeTrackSections(node, tracks);
+
+            var loaded = new List<TrackSection>();
+            RecordingStore.DeserializeTrackSections(node, loaded);
+
+            Assert.Single(loaded);
+            Assert.Equal(500f, loaded[0].minAltitude);
+            Assert.Equal(72000f, loaded[0].maxAltitude);
+        }
+
+        [Fact]
+        public void AltitudeMetadata_LegacyMissing_DefaultsToNaN()
+        {
+            // Simulate a legacy TRACK_SECTION without minAlt/maxAlt
+            var node = new ConfigNode("TEST");
+            var tsNode = node.AddNode("TRACK_SECTION");
+            tsNode.AddValue("env", "0"); // Atmospheric
+            tsNode.AddValue("ref", "0"); // Absolute
+            tsNode.AddValue("startUT", "17000");
+            tsNode.AddValue("endUT", "17060");
+            // No minAlt/maxAlt keys
+
+            var loaded = new List<TrackSection>();
+            RecordingStore.DeserializeTrackSections(node, loaded);
+
+            Assert.Single(loaded);
+            Assert.True(float.IsNaN(loaded[0].minAltitude));
+            Assert.True(float.IsNaN(loaded[0].maxAltitude));
+        }
+
+        [Fact]
+        public void AltitudeMetadata_NaN_NotSerialized()
+        {
+            // TrackSection with NaN altitude (not tracked) should not write minAlt/maxAlt
+            var tracks = new List<TrackSection>
+            {
+                new TrackSection
+                {
+                    environment = SegmentEnvironment.ExoBallistic,
+                    referenceFrame = ReferenceFrame.OrbitalCheckpoint,
+                    startUT = 17000, endUT = 17300,
+                    frames = new List<TrajectoryPoint>(),
+                    checkpoints = new List<OrbitSegment>(),
+                    minAltitude = float.NaN,
+                    maxAltitude = float.NaN
+                }
+            };
+
+            var node = new ConfigNode("TEST");
+            RecordingStore.SerializeTrackSections(node, tracks);
+
+            var tsNode = node.GetNodes("TRACK_SECTION")[0];
+            Assert.Null(tsNode.GetValue("minAlt"));
+            Assert.Null(tsNode.GetValue("maxAlt"));
+        }
+
         #endregion
     }
 }

--- a/Source/Parsek/ChainSegmentManager.cs
+++ b/Source/Parsek/ChainSegmentManager.cs
@@ -598,7 +598,7 @@ namespace Parsek
                             pending.SegmentPhase = recordedVessel.altitude < recordedVessel.mainBody.atmosphereDepth ? "atmo" : "exo";
                         else
                         {
-                            double threshold = FlightRecorder.ComputeApproachAltitude(recordedVessel.mainBody.Radius);
+                            double threshold = FlightRecorder.ComputeApproachAltitude(recordedVessel.mainBody);
                             pending.SegmentPhase = recordedVessel.altitude < threshold ? "approach" : "exo";
                         }
 

--- a/Source/Parsek/ChainSegmentManager.cs
+++ b/Source/Parsek/ChainSegmentManager.cs
@@ -597,7 +597,10 @@ namespace Parsek
                         if (recordedVessel.mainBody.atmosphere)
                             pending.SegmentPhase = recordedVessel.altitude < recordedVessel.mainBody.atmosphereDepth ? "atmo" : "exo";
                         else
-                            pending.SegmentPhase = "space";
+                        {
+                            double threshold = FlightRecorder.ComputeApproachAltitude(recordedVessel.mainBody.Radius);
+                            pending.SegmentPhase = recordedVessel.altitude < threshold ? "approach" : "exo";
+                        }
 
                         pending.SceneExitSituation = (int)recordedVessel.situation;
                         pending.TerminalStateValue =

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -3338,6 +3338,8 @@ namespace Parsek
         /// Prefers KSP's timeWarpAltitudeLimits[4] (100x warp limit) when available — this is
         /// KSP's own definition of "close enough that fast warp is dangerous" and adapts to modded
         /// planets automatically. Falls back to body.Radius * 0.15 clamped to [5000, 200000].
+        /// WARNING: Callers must check body.atmosphere first — this method does not guard against
+        /// atmospheric bodies (which use atmosphere boundary splits instead).
         /// </summary>
         internal static double ComputeApproachAltitude(CelestialBody body)
         {
@@ -3482,6 +3484,7 @@ namespace Parsek
             if (!IsRecording || isOnRails) return;
             if (v == null || v.mainBody == null) return;
             if (v.mainBody.atmosphere) return; // atmospheric bodies use atmosphere boundary split
+            if (currentAltitudeThreshold <= 0) return; // no threshold computed (defensive)
 
             double altitude = v.altitude;
             double currentUT = Planetarium.GetUniversalTime();

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -3697,12 +3697,25 @@ namespace Parsek
                 startUT = ut,
                 source = source,
                 frames = new List<TrajectoryPoint>(),
-                checkpoints = new List<OrbitSegment>()
+                checkpoints = new List<OrbitSegment>(),
+                minAltitude = float.NaN,
+                maxAltitude = float.NaN
             };
             trackSectionActive = true;
             ParsekLog.Info("Recorder",
                 $"TrackSection started: env={env} ref={refFrame} source={source} " +
                 $"at UT={ut.ToString("F2", CultureInfo.InvariantCulture)}");
+        }
+
+        /// <summary>
+        /// Updates min/max altitude on the current TrackSection.
+        /// </summary>
+        private void UpdateTrackSectionAltitude(float altitude)
+        {
+            if (float.IsNaN(currentTrackSection.minAltitude) || altitude < currentTrackSection.minAltitude)
+                currentTrackSection.minAltitude = altitude;
+            if (float.IsNaN(currentTrackSection.maxAltitude) || altitude > currentTrackSection.maxAltitude)
+                currentTrackSection.maxAltitude = altitude;
         }
 
         /// <summary>
@@ -4604,6 +4617,7 @@ namespace Parsek
             if (trackSectionActive && currentTrackSection.frames != null)
             {
                 currentTrackSection.frames.Add(point);
+                UpdateTrackSectionAltitude((float)point.altitude);
             }
 
             RefreshBackupSnapshot(v, "periodic");
@@ -4663,6 +4677,7 @@ namespace Parsek
             if (trackSectionActive && currentTrackSection.frames != null)
             {
                 currentTrackSection.frames.Add(point);
+                UpdateTrackSectionAltitude((float)point.altitude);
             }
         }
 

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -3335,6 +3335,23 @@ namespace Parsek
 
         /// <summary>
         /// Returns the approach altitude threshold for an airless body.
+        /// Prefers KSP's timeWarpAltitudeLimits[4] (100x warp limit) when available — this is
+        /// KSP's own definition of "close enough that fast warp is dangerous" and adapts to modded
+        /// planets automatically. Falls back to body.Radius * 0.15 clamped to [5000, 200000].
+        /// </summary>
+        internal static double ComputeApproachAltitude(CelestialBody body)
+        {
+            if (body != null && body.timeWarpAltitudeLimits != null
+                && body.timeWarpAltitudeLimits.Length > 4
+                && body.timeWarpAltitudeLimits[4] > 0)
+            {
+                return body.timeWarpAltitudeLimits[4];
+            }
+            return ComputeApproachAltitude(body != null ? body.Radius : 0);
+        }
+
+        /// <summary>
+        /// Radius-only fallback for tests and contexts without a CelestialBody reference.
         /// body.Radius * 0.15, clamped to [5000, 200000] meters.
         /// </summary>
         internal static double ComputeApproachAltitude(double bodyRadius)
@@ -3523,7 +3540,7 @@ namespace Parsek
             }
             else
             {
-                currentAltitudeThreshold = ComputeApproachAltitude(v.mainBody.Radius);
+                currentAltitudeThreshold = ComputeApproachAltitude(v.mainBody);
                 wasAboveAltitudeThreshold = v.altitude >= currentAltitudeThreshold;
             }
             altitudeBoundaryPending = false;

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -3344,7 +3344,7 @@ namespace Parsek
         internal static double ComputeApproachAltitude(CelestialBody body)
         {
             if (body != null && body.timeWarpAltitudeLimits != null
-                && body.timeWarpAltitudeLimits.Length > 4
+                && body.timeWarpAltitudeLimits.Length >= 5
                 && body.timeWarpAltitudeLimits[4] > 0)
             {
                 return body.timeWarpAltitudeLimits[4];

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -138,6 +138,9 @@ namespace Parsek
             AtmosphereBoundaryCrossed = false;
             EnteredAtmosphere = false;
             atmosphereBoundaryPending = false;
+            AltitudeBoundaryCrossed = false;
+            DescendedBelowThreshold = false;
+            altitudeBoundaryPending = false;
             SoiChangePending = false;
             SoiChangeFromBody = null;
             ParsekLog.Verbose("Recorder", "Boundary flags cleared (tree mode bypass)");
@@ -197,6 +200,14 @@ namespace Parsek
         private double atmosphereBoundaryPendingUT;
         public bool AtmosphereBoundaryCrossed { get; private set; }
         public bool EnteredAtmosphere { get; private set; }
+
+        // Altitude boundary detection (airless bodies)
+        private bool wasAboveAltitudeThreshold;
+        private bool altitudeBoundaryPending;
+        private double altitudeBoundaryPendingUT;
+        private double currentAltitudeThreshold;
+        public bool AltitudeBoundaryCrossed { get; private set; }
+        public bool DescendedBelowThreshold { get; private set; }
 
         // SOI change detection
         public bool SoiChangePending { get; private set; }
@@ -3323,6 +3334,52 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Returns the approach altitude threshold for an airless body.
+        /// body.Radius * 0.15, clamped to [5000, 200000] meters.
+        /// </summary>
+        internal static double ComputeApproachAltitude(double bodyRadius)
+        {
+            double raw = bodyRadius * 0.15;
+            if (raw < 5000.0) return 5000.0;
+            if (raw > 200000.0) return 200000.0;
+            return raw;
+        }
+
+        /// <summary>
+        /// Pure testable function: determines whether a recording should split at the altitude boundary
+        /// on an airless body. Mirrors ShouldSplitAtAtmosphereBoundary.
+        /// Requires both sustained time (hysteresisSeconds) AND distance beyond boundary.
+        /// If hysteresisMeters is negative, it is computed as max(1000, threshold * 0.02).
+        /// </summary>
+        internal static bool ShouldSplitAtAltitudeBoundary(
+            double altitude, double threshold, bool wasAbove,
+            bool pendingCross, double pendingUT, double currentUT,
+            double hysteresisSeconds = 3.0, double hysteresisMeters = -1.0)
+        {
+            if (threshold <= 0) return false;
+
+            if (hysteresisMeters < 0)
+                hysteresisMeters = Math.Max(1000.0, threshold * 0.02);
+
+            bool nowAbove = altitude >= threshold;
+            if (nowAbove == wasAbove)
+                return false; // no boundary crossed
+
+            // Check distance beyond boundary
+            double distBeyond = nowAbove
+                ? (altitude - threshold)
+                : (threshold - altitude);
+            if (distBeyond < hysteresisMeters)
+                return false; // not far enough past boundary
+
+            // Check sustained time
+            if (!pendingCross)
+                return false; // first detection — caller should start the timer
+
+            return (currentUT - pendingUT) >= hysteresisSeconds;
+        }
+
+        /// <summary>
         /// Called every physics frame to detect atmosphere boundary crossings.
         /// Sets AtmosphereBoundaryCrossed and EnteredAtmosphere when confirmed.
         /// </summary>
@@ -3395,6 +3452,88 @@ namespace Parsek
                     $"inAtmo={wasInAtmosphere} (was {oldState}), " +
                     $"hasAtmo={v.mainBody.atmosphere}, alt={v.altitude:F0}m" +
                     (v.mainBody.atmosphere ? $", atmoDepth={v.mainBody.atmosphereDepth:F0}m" : ""));
+            }
+        }
+
+        /// <summary>
+        /// Called every physics frame to detect altitude boundary crossings on airless bodies.
+        /// Sets AltitudeBoundaryCrossed and DescendedBelowThreshold when confirmed.
+        /// Mirrors CheckAtmosphereBoundary.
+        /// </summary>
+        public void CheckAltitudeBoundary(Vessel v)
+        {
+            if (!IsRecording || isOnRails) return;
+            if (v == null || v.mainBody == null) return;
+            if (v.mainBody.atmosphere) return; // atmospheric bodies use atmosphere boundary split
+
+            double altitude = v.altitude;
+            double currentUT = Planetarium.GetUniversalTime();
+            bool nowAbove = altitude >= currentAltitudeThreshold;
+
+            if (nowAbove == wasAboveAltitudeThreshold)
+            {
+                // No boundary — reset pending if we drifted back
+                if (altitudeBoundaryPending)
+                    ParsekLog.Verbose("Recorder", $"Altitude boundary pending reset — drifted back to same side (above={nowAbove})");
+                altitudeBoundaryPending = false;
+                return;
+            }
+
+            // Boundary detected — check hysteresis
+            if (!altitudeBoundaryPending)
+            {
+                // Start the timer
+                altitudeBoundaryPending = true;
+                altitudeBoundaryPendingUT = currentUT;
+                ParsekLog.Verbose("Recorder", $"Altitude boundary detected — starting hysteresis timer " +
+                    $"(body={v.mainBody.name}, {(nowAbove ? "ascending" : "descending")}, alt={altitude:F0}m, threshold={currentAltitudeThreshold:F0}m)");
+                return;
+            }
+
+            if (ShouldSplitAtAltitudeBoundary(
+                altitude, currentAltitudeThreshold, wasAboveAltitudeThreshold,
+                altitudeBoundaryPending, altitudeBoundaryPendingUT, currentUT))
+            {
+                // Confirmed crossing — force-sample a boundary point to ensure >= 2 points
+                SamplePosition(v);
+
+                AltitudeBoundaryCrossed = true;
+                DescendedBelowThreshold = !nowAbove;
+                wasAboveAltitudeThreshold = nowAbove;
+                altitudeBoundaryPending = false;
+                ParsekLog.Info("Recorder", $"Altitude boundary confirmed: {(nowAbove ? "ascended above" : "descended below")} " +
+                    $"threshold on {v.mainBody.name} at alt {altitude:F0}m " +
+                    $"(threshold={currentAltitudeThreshold:F0}m, hysteresis: {(currentUT - altitudeBoundaryPendingUT):F1}s, " +
+                    $"{Math.Abs(altitude - currentAltitudeThreshold):F0}m past boundary)");
+            }
+        }
+
+        /// <summary>
+        /// Reseeds altitude state from current vessel. Call on SOI change, off-rails, and recording start.
+        /// Mirrors ReseedAtmosphereState.
+        /// </summary>
+        private void ReseedAltitudeState(Vessel v)
+        {
+            bool oldState = wasAboveAltitudeThreshold;
+            if (v == null || v.mainBody == null || v.mainBody.atmosphere)
+            {
+                // Atmospheric body or null — altitude split not applicable
+                wasAboveAltitudeThreshold = true;
+                currentAltitudeThreshold = 0;
+            }
+            else
+            {
+                currentAltitudeThreshold = ComputeApproachAltitude(v.mainBody.Radius);
+                wasAboveAltitudeThreshold = v.altitude >= currentAltitudeThreshold;
+            }
+            altitudeBoundaryPending = false;
+            AltitudeBoundaryCrossed = false;
+            DescendedBelowThreshold = false;
+            if (v?.mainBody != null)
+            {
+                ParsekLog.Verbose("Recorder", $"Altitude state reseeded: body={v.mainBody.name}, " +
+                    $"aboveThreshold={wasAboveAltitudeThreshold} (was {oldState}), " +
+                    $"threshold={currentAltitudeThreshold:F0}m, alt={v.altitude:F0}m");
             }
         }
 
@@ -3829,8 +3968,13 @@ namespace Parsek
             EnteredAtmosphere = false;
             SoiChangePending = false;
             SoiChangeFromBody = null;
+
+            // Seed altitude boundary state (airless bodies)
+            ReseedAltitudeState(v);
+
             ParsekLog.Verbose("Recorder", $"Boundary detection initialized: body={v.mainBody?.name}, " +
-                $"inAtmo={wasInAtmosphere}, hasAtmo={v.mainBody?.atmosphere}, alt={v.altitude:F0}m");
+                $"inAtmo={wasInAtmosphere}, hasAtmo={v.mainBody?.atmosphere}, alt={v.altitude:F0}m" +
+                $", altThreshold={currentAltitudeThreshold:F0}m, aboveThreshold={wasAboveAltitudeThreshold}");
 
             // Initialize environment tracking (v6+)
             TrackSections.Clear();
@@ -4333,8 +4477,9 @@ namespace Parsek
                     return;
             }
 
-            // Check atmosphere boundary (before part state polling)
+            // Check atmosphere / altitude boundary (before part state polling)
             CheckAtmosphereBoundary(v);
+            CheckAltitudeBoundary(v);
 
             // Poll parachute, jettison, engine, RCS, and deployable state every physics frame (before adaptive sampling skip)
             CheckParachuteState(v);
@@ -4680,8 +4825,9 @@ namespace Parsek
             // discontinuity in the ghost at this transition — acceptable.
             SamplePosition(v);
 
-            // Reseed atmosphere state for the current body
+            // Reseed atmosphere and altitude state for the current body
             ReseedAtmosphereState(v);
+            ReseedAltitudeState(v);
 
             ParsekLog.Verbose("Recorder", $"Vessel went off rails — orbit segment closed " +
                 $"(UT {currentOrbitSegment.startUT:F0}-{currentOrbitSegment.endUT:F0})");
@@ -4718,8 +4864,9 @@ namespace Parsek
             // A spinning vessel crossing an SOI boundary will use orbital-frame rotation (not spin-forward)
             // for the new segment. This is an acceptable v1 limitation.
 
-            // Reseed atmosphere state for the new body
+            // Reseed atmosphere and altitude state for the new body
             ReseedAtmosphereState(v);
+            ReseedAltitudeState(v);
 
             // Flag for ParsekFlight to trigger chain split in Update()
             SoiChangePending = true;

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -385,6 +385,7 @@ namespace Parsek
             HandleVesselSwitchChainTermination();
 
             HandleAtmosphereBoundarySplit();
+            HandleAltitudeBoundarySplit();
             HandleSoiChangeSplit();
             HandleTreeBackgroundFlush();
 
@@ -1474,7 +1475,10 @@ namespace Parsek
                     if (v.mainBody.atmosphere)
                         pending.SegmentPhase = v.altitude < v.mainBody.atmosphereDepth ? "atmo" : "exo";
                     else
-                        pending.SegmentPhase = "space";
+                    {
+                        double threshold = FlightRecorder.ComputeApproachAltitude(v.mainBody.Radius);
+                        pending.SegmentPhase = v.altitude < threshold ? "approach" : "exo";
+                    }
                 }
             }
         }
@@ -4232,15 +4236,62 @@ namespace Parsek
 
             string fromBody = recorder.SoiChangeFromBody ?? "Unknown";
             string toBody = FlightGlobals.ActiveVessel?.mainBody?.name ?? "Unknown";
-            // Completed segment was at fromBody — tag as "exo" if it has atmosphere, "space" otherwise
+            // Completed segment was at fromBody — tag based on atmosphere/altitude
             CelestialBody fromCB = FlightGlobals.Bodies?.Find(b => b.name == fromBody);
-            string fromPhase = (fromCB != null && fromCB.atmosphere) ? "exo" : "space";
+            string fromPhase;
+            if (fromCB != null && fromCB.atmosphere)
+                fromPhase = "exo"; // was in space around atmospheric body
+            else if (fromCB != null)
+            {
+                double threshold = FlightRecorder.ComputeApproachAltitude(fromCB.Radius);
+                fromPhase = recorder.Recording.Count > 0 &&
+                    recorder.Recording[recorder.Recording.Count - 1].altitude < threshold
+                    ? "approach" : "exo";
+            }
+            else
+                fromPhase = "exo";
             ParsekLog.Info("Flight", $"SOI auto-split triggered: {fromBody} ({fromPhase}) \u2192 {toBody} " +
                 $"(chain={chainManager.ActiveChainId ?? "(new)"}, points={recorder.Recording.Count})");
             CommitBoundaryAndRestart(fromPhase, fromBody,
                 $"Recording continues after SOI change " +
                     $"({fromBody} \u2192 {toBody}, chain={chainManager.ActiveChainId}, idx={chainManager.ActiveChainNextIndex})",
                 $"Recording continues (entering {toBody} SOI)");
+        }
+
+        /// <summary>
+        /// Handles altitude boundary auto-split when crossing the approach altitude threshold
+        /// on an airless body. Commits the current segment, restarts recording in the new phase.
+        /// Mirrors HandleAtmosphereBoundarySplit.
+        /// </summary>
+        private void HandleAltitudeBoundarySplit()
+        {
+            if (recorder == null || !recorder.IsRecording || !recorder.AltitudeBoundaryCrossed)
+                return;
+
+            // Bug #87: In tree mode, boundary splits must not commit standalone chain segments.
+            if (activeTree != null)
+            {
+                string skipPhase = recorder.DescendedBelowThreshold ? "approach" : "exo";
+                string skipBody = FlightGlobals.ActiveVessel?.mainBody?.name ?? "Unknown";
+                ParsekLog.Info("Flight", $"Altitude boundary suppressed in tree mode: " +
+                    $"{skipBody} entering {skipPhase} (tree={activeTree.Id}, " +
+                    $"activeRec={activeTree.ActiveRecordingId})");
+                recorder.ClearBoundaryFlags();
+                return;
+            }
+
+            // Completed phase is the one we just left:
+            // descended below threshold = completed "exo" segment
+            // ascended above threshold = completed "approach" segment
+            string phase = recorder.DescendedBelowThreshold ? "exo" : "approach";
+            string newPhase = recorder.DescendedBelowThreshold ? "approach" : "exo";
+            string bodyName = FlightGlobals.ActiveVessel?.mainBody?.name ?? "Unknown";
+            ParsekLog.Info("Flight", $"Altitude auto-split triggered: {bodyName} {phase}\u2192{newPhase} " +
+                $"(chain={chainManager.ActiveChainId ?? "(new)"}, points={recorder.Recording.Count})");
+            CommitBoundaryAndRestart(phase, bodyName,
+                $"Recording continues after altitude boundary " +
+                    $"(chain={chainManager.ActiveChainId}, idx={chainManager.ActiveChainNextIndex}, {bodyName} {phase}\u2192{newPhase})",
+                $"Recording continues ({(newPhase == "approach" ? "entering approach zone" : "leaving approach zone")})");
         }
 
         /// <summary>
@@ -4564,7 +4615,10 @@ namespace Parsek
                     if (v.mainBody.atmosphere)
                         recorder.CaptureAtStop.SegmentPhase = v.altitude < v.mainBody.atmosphereDepth ? "atmo" : "exo";
                     else
-                        recorder.CaptureAtStop.SegmentPhase = "space";
+                    {
+                        double threshold = FlightRecorder.ComputeApproachAltitude(v.mainBody.Radius);
+                        recorder.CaptureAtStop.SegmentPhase = v.altitude < threshold ? "approach" : "exo";
+                    }
                     ParsekLog.Verbose("Flight", $"Final segment tagged (StopRecording): " +
                         $"{recorder.CaptureAtStop.SegmentBodyName} {recorder.CaptureAtStop.SegmentPhase}");
                 }

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -1476,7 +1476,7 @@ namespace Parsek
                         pending.SegmentPhase = v.altitude < v.mainBody.atmosphereDepth ? "atmo" : "exo";
                     else
                     {
-                        double threshold = FlightRecorder.ComputeApproachAltitude(v.mainBody.Radius);
+                        double threshold = FlightRecorder.ComputeApproachAltitude(v.mainBody);
                         pending.SegmentPhase = v.altitude < threshold ? "approach" : "exo";
                     }
                 }
@@ -4243,7 +4243,7 @@ namespace Parsek
                 fromPhase = "exo"; // was in space around atmospheric body
             else if (fromCB != null)
             {
-                double threshold = FlightRecorder.ComputeApproachAltitude(fromCB.Radius);
+                double threshold = FlightRecorder.ComputeApproachAltitude(fromCB);
                 fromPhase = recorder.Recording.Count > 0 &&
                     recorder.Recording[recorder.Recording.Count - 1].altitude < threshold
                     ? "approach" : "exo";
@@ -4616,7 +4616,7 @@ namespace Parsek
                         recorder.CaptureAtStop.SegmentPhase = v.altitude < v.mainBody.atmosphereDepth ? "atmo" : "exo";
                     else
                     {
-                        double threshold = FlightRecorder.ComputeApproachAltitude(v.mainBody.Radius);
+                        double threshold = FlightRecorder.ComputeApproachAltitude(v.mainBody);
                         recorder.CaptureAtStop.SegmentPhase = v.altitude < threshold ? "approach" : "exo";
                     }
                     ParsekLog.Verbose("Flight", $"Final segment tagged (StopRecording): " +

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -634,6 +634,9 @@ namespace Parsek
                     ParsekLog.Info("Scenario", $"  {kvp.Key} -> replacement: {kvp.Value}");
             }
 
+            // Run recording optimization pass (merge redundant segments, split monolithic ones)
+            RecordingStore.RunOptimizationPass();
+
             // Auto-unreserve crew for recordings whose EndUT has already passed
             // but vessel was never spawned. Skip at SpaceCenter — ParsekKSC now
             // handles spawning there (bug #99), so nulling the snapshot here would

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -119,6 +119,7 @@ namespace Parsek
         private GUIStyle phaseStyleAtmo;
         private GUIStyle phaseStyleExo;
         private GUIStyle phaseStyleSpace;
+        private GUIStyle phaseStyleApproach;
 
         // Sort state
         internal enum SortColumn { Index, Phase, Name, LaunchTime, Duration, Status }
@@ -1011,6 +1012,9 @@ namespace Parsek
 
             phaseStyleSpace = new GUIStyle(GUI.skin.label);
             phaseStyleSpace.normal.textColor = new Color(0.2f, 1f, 0.6f); // lime green
+
+            phaseStyleApproach = new GUIStyle(GUI.skin.label);
+            phaseStyleApproach.normal.textColor = new Color(0.4f, 0.7f, 1f); // sky blue
         }
 
         private void DrawRecordingsWindow(int windowID)
@@ -1260,6 +1264,7 @@ namespace Parsek
             {
                 GUIStyle phaseStyle;
                 if (rec.SegmentPhase == "atmo") phaseStyle = phaseStyleAtmo;
+                else if (rec.SegmentPhase == "approach") phaseStyle = phaseStyleApproach;
                 else if (rec.SegmentPhase == "space") phaseStyle = phaseStyleSpace;
                 else phaseStyle = phaseStyleExo;
                 GUILayout.Label(phaseLabel, phaseStyle, GUILayout.Width(ColW_Phase));

--- a/Source/Parsek/Recording.cs
+++ b/Source/Parsek/Recording.cs
@@ -41,7 +41,7 @@ namespace Parsek
         public List<string> RecordingGroups;
 
         // Atmosphere segment metadata
-        public string SegmentPhase;      // "atmo" or "exo" (null = untagged/legacy)
+        public string SegmentPhase;      // "atmo", "exo", or "approach" (null = untagged/legacy)
         public string SegmentBodyName;   // body name at split point (e.g., "Kerbin", "Duna")
         public bool PlaybackEnabled = true;  // false = skip ghost during playback
         public bool Hidden;                  // true = hidden from recordings list (unless Show Hidden is on)

--- a/Source/Parsek/RecordingOptimizer.cs
+++ b/Source/Parsek/RecordingOptimizer.cs
@@ -1,0 +1,424 @@
+using System.Collections.Generic;
+
+namespace Parsek
+{
+    /// <summary>
+    /// Pure static logic for recording optimization: merge redundant segments,
+    /// split monolithic recordings at TrackSection boundaries.
+    /// All methods are internal static for direct testability.
+    /// </summary>
+    internal static class RecordingOptimizer
+    {
+        /// <summary>
+        /// Can two consecutive chain segments be auto-merged?
+        /// Returns false if any user-intent signal differs from defaults,
+        /// if they have different phases/bodies, if a branch point separates them,
+        /// or if either has ghosting-trigger part events (snapshot would be wrong).
+        /// </summary>
+        internal static bool CanAutoMerge(Recording a, Recording b)
+        {
+            if (a == null || b == null) return false;
+
+            // Must be in the same chain, consecutive, primary branch
+            if (string.IsNullOrEmpty(a.ChainId) || a.ChainId != b.ChainId) return false;
+            if (a.ChainIndex < 0 || b.ChainIndex < 0) return false;
+            if (b.ChainIndex != a.ChainIndex + 1) return false;
+            if (a.ChainBranch != 0 || b.ChainBranch != 0) return false;
+
+            // No branch point between them
+            if (!string.IsNullOrEmpty(a.ChildBranchPointId)) return false;
+
+            // Same phase and body
+            if (a.SegmentPhase != b.SegmentPhase) return false;
+            if (a.SegmentBodyName != b.SegmentBodyName) return false;
+
+            // Neither has ghosting-trigger events (snapshot would be wrong for merged recording)
+            if (GhostingTriggerClassifier.HasGhostingTriggerEvents(a)) return false;
+            if (GhostingTriggerClassifier.HasGhostingTriggerEvents(b)) return false;
+
+            // User intent: any non-default setting blocks merge
+            if (a.LoopPlayback || b.LoopPlayback) return false;
+            if (!a.PlaybackEnabled || !b.PlaybackEnabled) return false;
+            if (a.Hidden || b.Hidden) return false;
+            if (a.LoopIntervalSeconds != 10.0 || b.LoopIntervalSeconds != 10.0) return false;
+            if (a.LoopAnchorVesselId != 0 || b.LoopAnchorVesselId != 0) return false;
+
+            // Different recording groups = user organized them differently
+            if (!GroupsEqual(a.RecordingGroups, b.RecordingGroups)) return false;
+
+            return true;
+        }
+
+        /// <summary>
+        /// Can a recording be auto-split at the given TrackSection boundary?
+        /// Returns false if ghosting-trigger events exist anywhere (snapshot
+        /// would be invalid for the second half), if the split would create
+        /// too-short halves, or if the section index is out of range.
+        /// </summary>
+        internal static bool CanAutoSplit(Recording rec, int sectionIndex)
+        {
+            if (rec == null) return false;
+            if (rec.TrackSections == null || rec.TrackSections.Count < 2) return false;
+            if (sectionIndex < 1 || sectionIndex >= rec.TrackSections.Count) return false;
+
+            // No ghosting triggers anywhere — snapshot is valid for both halves
+            if (GhostingTriggerClassifier.HasGhostingTriggerEvents(rec)) return false;
+
+            // Both halves must be longer than 5 seconds
+            double splitUT = rec.TrackSections[sectionIndex].startUT;
+            double firstHalfDuration = splitUT - rec.StartUT;
+            double secondHalfDuration = rec.EndUT - splitUT;
+            if (firstHalfDuration < 5.0 || secondHalfDuration < 5.0) return false;
+
+            return true;
+        }
+
+        /// <summary>
+        /// Scans committed recordings for consecutive chain segments that can be merged.
+        /// Returns pairs of indices (a, b) where b can be merged into a.
+        /// </summary>
+        internal static List<(int, int)> FindMergeCandidates(List<Recording> committed)
+        {
+            var candidates = new List<(int, int)>();
+            if (committed == null || committed.Count < 2) return candidates;
+
+            // Build chain index: chainId → list of (commitIndex, chainIndex) sorted by chainIndex
+            var chainMembers = new Dictionary<string, List<(int commitIdx, int chainIdx)>>();
+            for (int i = 0; i < committed.Count; i++)
+            {
+                var rec = committed[i];
+                if (string.IsNullOrEmpty(rec.ChainId) || rec.ChainIndex < 0) continue;
+                if (rec.ChainBranch != 0) continue;
+
+                List<(int, int)> members;
+                if (!chainMembers.TryGetValue(rec.ChainId, out members))
+                {
+                    members = new List<(int, int)>();
+                    chainMembers[rec.ChainId] = members;
+                }
+                members.Add((i, rec.ChainIndex));
+            }
+
+            foreach (var kvp in chainMembers)
+            {
+                var members = kvp.Value;
+                members.Sort((x, y) => x.chainIdx.CompareTo(y.chainIdx));
+
+                for (int m = 0; m < members.Count - 1; m++)
+                {
+                    int idxA = members[m].commitIdx;
+                    int idxB = members[m + 1].commitIdx;
+                    if (CanAutoMerge(committed[idxA], committed[idxB]))
+                        candidates.Add((idxA, idxB));
+                }
+            }
+
+            return candidates;
+        }
+
+        /// <summary>
+        /// Scans committed recordings for monolithic recordings that can be split
+        /// at TrackSection boundaries where the environment changes.
+        /// Returns (commitIndex, sectionIndex) pairs.
+        /// </summary>
+        internal static List<(int, int)> FindSplitCandidates(List<Recording> committed)
+        {
+            var candidates = new List<(int, int)>();
+            if (committed == null) return candidates;
+
+            for (int i = 0; i < committed.Count; i++)
+            {
+                var rec = committed[i];
+                if (rec.TrackSections == null || rec.TrackSections.Count < 2) continue;
+
+                for (int s = 1; s < rec.TrackSections.Count; s++)
+                {
+                    // Only split where environment changes
+                    if (rec.TrackSections[s].environment == rec.TrackSections[s - 1].environment)
+                        continue;
+
+                    if (CanAutoSplit(rec, s))
+                    {
+                        candidates.Add((i, s));
+                        break; // One split per recording per pass (re-scan after split)
+                    }
+                }
+            }
+
+            return candidates;
+        }
+
+        /// <summary>
+        /// Compares two RecordingGroups lists for equality.
+        /// Both null/empty = equal. Both non-null = same elements.
+        /// </summary>
+        /// <summary>
+        /// Merges recording B into recording A (A absorbs B).
+        /// Points, events, sections, and orbit segments are concatenated.
+        /// Returns B's RecordingId (caller deletes files + removes from store).
+        /// </summary>
+        internal static string MergeInto(Recording target, Recording absorbed)
+        {
+            // 1. Concatenate Points (already UT-ordered within each recording)
+            if (absorbed.Points != null && absorbed.Points.Count > 0)
+                target.Points.AddRange(absorbed.Points);
+
+            // 2. Merge + re-sort PartEvents by UT
+            if (absorbed.PartEvents != null && absorbed.PartEvents.Count > 0)
+            {
+                target.PartEvents.AddRange(absorbed.PartEvents);
+                target.PartEvents.Sort((a, b) => a.ut.CompareTo(b.ut));
+            }
+
+            // 3. Merge + re-sort SegmentEvents by UT
+            if (absorbed.SegmentEvents != null && absorbed.SegmentEvents.Count > 0)
+            {
+                target.SegmentEvents.AddRange(absorbed.SegmentEvents);
+                target.SegmentEvents.Sort((a, b) => a.ut.CompareTo(b.ut));
+            }
+
+            // 4. Concatenate TrackSections
+            if (absorbed.TrackSections != null && absorbed.TrackSections.Count > 0)
+                target.TrackSections.AddRange(absorbed.TrackSections);
+
+            // 5. Merge OrbitSegments
+            if (absorbed.OrbitSegments != null && absorbed.OrbitSegments.Count > 0)
+                target.OrbitSegments.AddRange(absorbed.OrbitSegments);
+
+            // 6. Union FlagEvents
+            if (absorbed.FlagEvents != null && absorbed.FlagEvents.Count > 0)
+            {
+                if (target.FlagEvents == null)
+                    target.FlagEvents = new List<FlagEvent>();
+                target.FlagEvents.AddRange(absorbed.FlagEvents);
+            }
+
+            // 7. VesselSnapshot: if absorbed was chain tip (non-null), target inherits it
+            if (absorbed.VesselSnapshot != null)
+                target.VesselSnapshot = absorbed.VesselSnapshot;
+
+            // 8. TerminalState: absorbed is the later segment, inherit its terminal state
+            if (absorbed.TerminalStateValue.HasValue)
+                target.TerminalStateValue = absorbed.TerminalStateValue;
+
+            // 9. Clear explicit UT ranges (Points now cover the full range)
+            target.ExplicitStartUT = double.NaN;
+            target.ExplicitEndUT = double.NaN;
+
+            // 10. Controllers: keep target's if present, else inherit
+            if (target.Controllers == null && absorbed.Controllers != null)
+                target.Controllers = absorbed.Controllers;
+
+            // 11. AntennaSpecs: keep target's if present, else inherit
+            if (target.AntennaSpecs == null && absorbed.AntennaSpecs != null)
+                target.AntennaSpecs = absorbed.AntennaSpecs;
+
+            // 12. Invalidate ghost geometry (covers only first half's vessel config)
+            target.GhostGeometryAvailable = false;
+            target.GhostGeometryRelativePath = null;
+
+            // 13. Invalidate cached stats
+            target.CachedStats = null;
+            target.CachedStatsPointCount = 0;
+
+            ParsekLog.Info("Optimizer",
+                $"MergeInto: absorbed {absorbed.RecordingId} into {target.RecordingId} " +
+                $"(target now has {target.Points.Count} points, {target.TrackSections.Count} sections)");
+
+            return absorbed.RecordingId;
+        }
+
+        /// <summary>
+        /// Splits a recording at the given TrackSection boundary index.
+        /// Returns the new Recording (second half). The original is mutated to keep the first half.
+        /// Caller must assign chain linkage, save files, and add to store.
+        /// </summary>
+        internal static Recording SplitAtSection(Recording original, int sectionIndex)
+        {
+            double splitUT = original.TrackSections[sectionIndex].startUT;
+
+            var second = new Recording();
+
+            // 1-2. Partition Points by UT
+            int splitPointIdx = 0;
+            for (int i = 0; i < original.Points.Count; i++)
+            {
+                if (original.Points[i].ut >= splitUT) { splitPointIdx = i; break; }
+            }
+            second.Points = new List<TrajectoryPoint>(
+                original.Points.GetRange(splitPointIdx, original.Points.Count - splitPointIdx));
+            original.Points.RemoveRange(splitPointIdx, original.Points.Count - splitPointIdx);
+
+            // 3. Partition PartEvents by UT
+            PartitionByUT(original.PartEvents, second.PartEvents, splitUT,
+                (e) => e.ut, (list, items) => list.AddRange(items));
+
+            // 4. Partition SegmentEvents by UT
+            PartitionSegmentEvents(original.SegmentEvents, second.SegmentEvents, splitUT);
+
+            // 5. Partition FlagEvents by UT
+            if (original.FlagEvents != null)
+            {
+                second.FlagEvents = new List<FlagEvent>();
+                PartitionFlagEvents(original.FlagEvents, second.FlagEvents, splitUT);
+            }
+
+            // 6. Partition TrackSections
+            second.TrackSections = new List<TrackSection>(
+                original.TrackSections.GetRange(sectionIndex, original.TrackSections.Count - sectionIndex));
+            original.TrackSections.RemoveRange(sectionIndex, original.TrackSections.Count - sectionIndex);
+
+            // 7. Partition OrbitSegments by UT
+            if (original.OrbitSegments != null && original.OrbitSegments.Count > 0)
+            {
+                second.OrbitSegments = new List<OrbitSegment>();
+                for (int i = original.OrbitSegments.Count - 1; i >= 0; i--)
+                {
+                    if (original.OrbitSegments[i].startUT >= splitUT)
+                    {
+                        second.OrbitSegments.Insert(0, original.OrbitSegments[i]);
+                        original.OrbitSegments.RemoveAt(i);
+                    }
+                }
+            }
+
+            // 8. Clone GhostVisualSnapshot (safe: CanAutoSplit ensures no ghosting triggers)
+            if (original.GhostVisualSnapshot != null)
+                second.GhostVisualSnapshot = original.GhostVisualSnapshot.CreateCopy();
+
+            // 9. Tag SegmentPhase from environment
+            if (second.TrackSections.Count > 0)
+            {
+                var env = second.TrackSections[0].environment;
+                second.SegmentPhase = EnvironmentToPhase(env);
+            }
+            if (original.TrackSections.Count > 0)
+            {
+                var env = original.TrackSections[0].environment;
+                original.SegmentPhase = EnvironmentToPhase(env);
+            }
+
+            second.SegmentBodyName = original.SegmentBodyName;
+
+            // 10. Invalidate ghost geometry on both
+            original.GhostGeometryAvailable = false;
+            original.GhostGeometryRelativePath = null;
+            second.GhostGeometryAvailable = false;
+
+            // 11. Invalidate cached stats
+            original.CachedStats = null;
+            original.CachedStatsPointCount = 0;
+
+            // 12. Clear explicit UT on both (Points define the range)
+            original.ExplicitStartUT = double.NaN;
+            original.ExplicitEndUT = double.NaN;
+            second.ExplicitStartUT = double.NaN;
+            second.ExplicitEndUT = double.NaN;
+
+            ParsekLog.Info("Optimizer",
+                $"SplitAtSection: split {original.RecordingId} at UT={splitUT:F1} " +
+                $"(first: {original.Points.Count} pts/{original.TrackSections.Count} sections, " +
+                $"second: {second.Points.Count} pts/{second.TrackSections.Count} sections)");
+
+            return second;
+        }
+
+        /// <summary>
+        /// Re-indexes ChainIndex for all branch-0 recordings with the given ChainId.
+        /// Sorts by StartUT, assigns sequential indices starting from 0.
+        /// </summary>
+        internal static void ReindexChain(List<Recording> committed, string chainId)
+        {
+            if (committed == null || string.IsNullOrEmpty(chainId)) return;
+
+            var members = new List<Recording>();
+            for (int i = 0; i < committed.Count; i++)
+            {
+                if (committed[i].ChainId == chainId && committed[i].ChainBranch == 0)
+                    members.Add(committed[i]);
+            }
+
+            members.Sort((a, b) => a.StartUT.CompareTo(b.StartUT));
+            for (int i = 0; i < members.Count; i++)
+                members[i].ChainIndex = i;
+
+            ParsekLog.Verbose("Optimizer",
+                $"ReindexChain: chainId={chainId}, {members.Count} branch-0 members re-indexed");
+        }
+
+        #region Private helpers
+
+        private static string EnvironmentToPhase(SegmentEnvironment env)
+        {
+            switch (env)
+            {
+                case SegmentEnvironment.Atmospheric: return "atmo";
+                case SegmentEnvironment.SurfaceMobile:
+                case SegmentEnvironment.SurfaceStationary: return "approach";
+                default: return "exo";
+            }
+        }
+
+        private static void PartitionByUT(List<PartEvent> source, List<PartEvent> target,
+            double splitUT, System.Func<PartEvent, double> getUT,
+            System.Action<List<PartEvent>, List<PartEvent>> addRange)
+        {
+            if (source == null) return;
+            var toMove = new List<PartEvent>();
+            for (int i = source.Count - 1; i >= 0; i--)
+            {
+                if (source[i].ut >= splitUT)
+                {
+                    toMove.Insert(0, source[i]);
+                    source.RemoveAt(i);
+                }
+            }
+            target.AddRange(toMove);
+        }
+
+        private static void PartitionSegmentEvents(List<SegmentEvent> source,
+            List<SegmentEvent> target, double splitUT)
+        {
+            if (source == null) return;
+            for (int i = source.Count - 1; i >= 0; i--)
+            {
+                if (source[i].ut >= splitUT)
+                {
+                    target.Insert(0, source[i]);
+                    source.RemoveAt(i);
+                }
+            }
+        }
+
+        private static void PartitionFlagEvents(List<FlagEvent> source,
+            List<FlagEvent> target, double splitUT)
+        {
+            if (source == null) return;
+            for (int i = source.Count - 1; i >= 0; i--)
+            {
+                if (source[i].ut >= splitUT)
+                {
+                    target.Insert(0, source[i]);
+                    source.RemoveAt(i);
+                }
+            }
+        }
+
+        private static bool GroupsEqual(List<string> a, List<string> b)
+        {
+            bool aEmpty = a == null || a.Count == 0;
+            bool bEmpty = b == null || b.Count == 0;
+            if (aEmpty && bEmpty) return true;
+            if (aEmpty != bEmpty) return false;
+
+            if (a.Count != b.Count) return false;
+            for (int i = 0; i < a.Count; i++)
+            {
+                if (a[i] != b[i]) return false;
+            }
+            return true;
+        }
+
+        #endregion
+    }
+}

--- a/Source/Parsek/RecordingOptimizer.cs
+++ b/Source/Parsek/RecordingOptimizer.cs
@@ -149,7 +149,6 @@ namespace Parsek
         }
 
         /// <summary>
-        /// <summary>
         /// Merges recording B into recording A (A absorbs B).
         /// Points, events, sections, and orbit segments are concatenated.
         /// Returns B's RecordingId (caller deletes files + removes from store).
@@ -347,16 +346,14 @@ namespace Parsek
         /// <summary>
         /// Maps a SegmentEnvironment to a phase tag for post-split recordings.
         /// Only used by SplitAtSection — not a general-purpose mapping.
-        /// Surface and propulsive environments near-surface map to "approach" (airless body near-surface).
-        /// Atmospheric maps to "atmo". Everything else maps to "exo".
         /// </summary>
         private static string EnvironmentToPhase(SegmentEnvironment env)
         {
             switch (env)
             {
                 case SegmentEnvironment.Atmospheric: return "atmo";
-                case SegmentEnvironment.SurfaceMobile:
-                case SegmentEnvironment.SurfaceStationary: return "approach";
+                case SegmentEnvironment.SurfaceMobile: return "surface";
+                case SegmentEnvironment.SurfaceStationary: return "surface";
                 default: return "exo";
             }
         }

--- a/Source/Parsek/RecordingOptimizer.cs
+++ b/Source/Parsek/RecordingOptimizer.cs
@@ -149,9 +149,6 @@ namespace Parsek
         }
 
         /// <summary>
-        /// Compares two RecordingGroups lists for equality.
-        /// Both null/empty = equal. Both non-null = same elements.
-        /// </summary>
         /// <summary>
         /// Merges recording B into recording A (A absorbs B).
         /// Points, events, sections, and orbit segments are concatenated.
@@ -250,8 +247,7 @@ namespace Parsek
             original.Points.RemoveRange(splitPointIdx, original.Points.Count - splitPointIdx);
 
             // 3. Partition PartEvents by UT
-            PartitionByUT(original.PartEvents, second.PartEvents, splitUT,
-                (e) => e.ut, (list, items) => list.AddRange(items));
+            PartitionPartEvents(original.PartEvents, second.PartEvents, splitUT);
 
             // 4. Partition SegmentEvents by UT
             PartitionSegmentEvents(original.SegmentEvents, second.SegmentEvents, splitUT);
@@ -348,6 +344,12 @@ namespace Parsek
 
         #region Private helpers
 
+        /// <summary>
+        /// Maps a SegmentEnvironment to a phase tag for post-split recordings.
+        /// Only used by SplitAtSection — not a general-purpose mapping.
+        /// Surface and propulsive environments near-surface map to "approach" (airless body near-surface).
+        /// Atmospheric maps to "atmo". Everything else maps to "exo".
+        /// </summary>
         private static string EnvironmentToPhase(SegmentEnvironment env)
         {
             switch (env)
@@ -359,21 +361,18 @@ namespace Parsek
             }
         }
 
-        private static void PartitionByUT(List<PartEvent> source, List<PartEvent> target,
-            double splitUT, System.Func<PartEvent, double> getUT,
-            System.Action<List<PartEvent>, List<PartEvent>> addRange)
+        private static void PartitionPartEvents(List<PartEvent> source,
+            List<PartEvent> target, double splitUT)
         {
             if (source == null) return;
-            var toMove = new List<PartEvent>();
             for (int i = source.Count - 1; i >= 0; i--)
             {
                 if (source[i].ut >= splitUT)
                 {
-                    toMove.Insert(0, source[i]);
+                    target.Insert(0, source[i]);
                     source.RemoveAt(i);
                 }
             }
-            target.AddRange(toMove);
         }
 
         private static void PartitionSegmentEvents(List<SegmentEvent> source,

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -789,6 +789,72 @@ namespace Parsek
             return rec.SegmentPhase;
         }
 
+        // ─── Recording optimization ─────────────────────────────────────────
+
+        /// <summary>
+        /// Runs the optimization pass: find merge candidates among committed recordings,
+        /// execute merges, re-index chains. Called on save load after migrations.
+        /// Merge-only for now; split support deferred (requires file I/O for new sidecar files).
+        /// </summary>
+        internal static void RunOptimizationPass()
+        {
+            var recordings = CommittedRecordings;
+            if (recordings == null || recordings.Count < 2)
+            {
+                ParsekLog.Verbose("RecordingStore", "Optimization pass: skipped (< 2 recordings)");
+                return;
+            }
+
+            int mergeCount = 0;
+            // Iterate merge passes until no more candidates (merging may create new adjacent pairs)
+            bool changed = true;
+            while (changed)
+            {
+                changed = false;
+                var candidates = RecordingOptimizer.FindMergeCandidates(recordings);
+                if (candidates.Count == 0) break;
+
+                // Process first candidate only per pass (indices shift after removal)
+                var (idxA, idxB) = candidates[0];
+                var target = recordings[idxA];
+                var absorbed = recordings[idxB];
+
+                string absorbedId = RecordingOptimizer.MergeInto(target, absorbed);
+                string chainId = target.ChainId;
+
+                // Remove absorbed recording from committed list
+                recordings.RemoveAt(idxB);
+
+                // Delete absorbed recording's sidecar files
+                try { DeleteRecordingFiles(absorbed); }
+                catch (System.Exception ex)
+                {
+                    ParsekLog.Warn("RecordingStore",
+                        $"Optimization: failed to delete files for merged recording {absorbedId}: {ex.Message}");
+                }
+
+                // Save updated target recording files
+                try { SaveRecordingFiles(target); }
+                catch (System.Exception ex)
+                {
+                    ParsekLog.Warn("RecordingStore",
+                        $"Optimization: failed to save updated recording {target.RecordingId}: {ex.Message}");
+                }
+
+                // Re-index the chain
+                if (!string.IsNullOrEmpty(chainId))
+                    RecordingOptimizer.ReindexChain(recordings, chainId);
+
+                mergeCount++;
+                changed = true;
+            }
+
+            if (mergeCount > 0)
+                ParsekLog.Info("RecordingStore", $"Optimization pass: merged {mergeCount} segment pair(s)");
+            else
+                ParsekLog.Verbose("RecordingStore", "Optimization pass: no merge candidates found");
+        }
+
         // ─── Group management helpers ────────────────────────────────────────
 
         /// <summary>

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -806,9 +806,10 @@ namespace Parsek
             }
 
             int mergeCount = 0;
+            const int maxMergesPerPass = 50;
             // Iterate merge passes until no more candidates (merging may create new adjacent pairs)
             bool changed = true;
-            while (changed)
+            while (changed && mergeCount < maxMergesPerPass)
             {
                 changed = false;
                 var candidates = RecordingOptimizer.FindMergeCandidates(recordings);
@@ -849,7 +850,10 @@ namespace Parsek
                 changed = true;
             }
 
-            if (mergeCount > 0)
+            if (mergeCount >= maxMergesPerPass)
+                ParsekLog.Warn("RecordingStore",
+                    $"Optimization pass: hit merge cap ({maxMergesPerPass}), some candidates may remain");
+            else if (mergeCount > 0)
                 ParsekLog.Info("RecordingStore", $"Optimization pass: merged {mergeCount} segment pair(s)");
             else
                 ParsekLog.Verbose("RecordingStore", "Optimization pass: no merge candidates found");

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -2218,6 +2218,12 @@ namespace Parsek
                 if (track.boundaryDiscontinuityMeters > 0f)
                     tsNode.AddValue("bdisc", track.boundaryDiscontinuityMeters.ToString("R", ic));
 
+                // Altitude range: sparse — only write when tracked (non-NaN)
+                if (!float.IsNaN(track.minAltitude))
+                    tsNode.AddValue("minAlt", track.minAltitude.ToString("R", ic));
+                if (!float.IsNaN(track.maxAltitude))
+                    tsNode.AddValue("maxAlt", track.maxAltitude.ToString("R", ic));
+
                 if (track.anchorVesselId != 0)
                     tsNode.AddValue("anchorPid", track.anchorVesselId.ToString(ic));
 
@@ -2329,6 +2335,13 @@ namespace Parsek
                 float bdisc;
                 if (float.TryParse(tsNode.GetValue("bdisc"), ns, ic, out bdisc))
                     section.boundaryDiscontinuityMeters = bdisc;
+
+                // Altitude range: defaults to NaN when absent (legacy recordings)
+                float minAlt, maxAlt;
+                section.minAltitude = float.TryParse(tsNode.GetValue("minAlt"), ns, ic, out minAlt)
+                    ? minAlt : float.NaN;
+                section.maxAltitude = float.TryParse(tsNode.GetValue("maxAlt"), ns, ic, out maxAlt)
+                    ? maxAlt : float.NaN;
 
                 uint anchorPid;
                 if (uint.TryParse(tsNode.GetValue("anchorPid"), NumberStyles.Integer, ic, out anchorPid))

--- a/Source/Parsek/TrackSection.cs
+++ b/Source/Parsek/TrackSection.cs
@@ -58,16 +58,20 @@ namespace Parsek
         public float sampleRateHz;              // Actual recording sample rate
         public TrackSectionSource source;       // Data provenance (for diagnostics)
         public float boundaryDiscontinuityMeters; // Position gap at section start vs previous section end (0 = no gap)
+        public float minAltitude;              // Minimum altitude during this section (NaN = not set)
+        public float maxAltitude;              // Maximum altitude during this section (NaN = not set)
 
         public override string ToString()
         {
             var ic = CultureInfo.InvariantCulture;
             int frameCount = frames?.Count ?? 0;
             int checkpointCount = checkpoints?.Count ?? 0;
+            string altRange = !float.IsNaN(minAltitude) && !float.IsNaN(maxAltitude)
+                ? $" alt=[{minAltitude.ToString("F0", ic)},{maxAltitude.ToString("F0", ic)}]" : "";
             return $"TrackSection env={environment} ref={referenceFrame} " +
                    $"ut=[{startUT.ToString("F2", ic)},{endUT.ToString("F2", ic)}] frames={frameCount} " +
                    $"checkpoints={checkpointCount} " +
-                   $"src={source} bdisc={boundaryDiscontinuityMeters.ToString("F2", ic)}";
+                   $"src={source} bdisc={boundaryDiscontinuityMeters.ToString("F2", ic)}{altRange}";
         }
     }
 }

--- a/docs/dev/plans/t97-selective-looping.md
+++ b/docs/dev/plans/t97-selective-looping.md
@@ -1,0 +1,772 @@
+# T97: Recording Segmentation for Selective Looping
+
+## Goal
+
+Make the KSP world feel alive by looping the visually interesting parts of flights (takeoffs, landings, station approaches) while skipping boring parts (long orbital coasts). Use the existing segmentation and per-segment loop toggle — no new loop mechanics, no new UI features.
+
+---
+
+## Existing Infrastructure
+
+### What already works
+
+1. **Chain splits at atmosphere boundary** — recordings auto-split into separate chain segments at atmosphere entry/exit. Each segment gets `SegmentPhase = "atmo"/"exo"/"space"` and its own `LoopPlayback` toggle.
+
+2. **Per-recording loop control** — `Recording.LoopPlayback`, `LoopIntervalSeconds`, `LoopAnchorVesselId`. The engine remaps current UT cyclically. Each chain segment is a full Recording that loops independently.
+
+3. **Per-segment ghost snapshots** — each chain segment captures its own `GhostVisualSnapshot` at segment start. No part-event fast-forward needed because each segment's ghost is built from its own snapshot.
+
+4. **Per-segment part events** — each segment has its own `PartEvents` list covering only that segment's time range. No cross-segment state to reconstruct.
+
+5. **TrackSection classification** — within each recording, trajectory data is tagged with `SegmentEnvironment` (Atmospheric, ExoPropulsive, ExoBallistic, SurfaceMobile, SurfaceStationary) and `ReferenceFrame`. This data is available even when chain splits don't happen.
+
+6. **SOI change splits** — recordings split at SOI transitions (entering/leaving a body's sphere of influence).
+
+### What this means
+
+For atmospheric bodies, selective looping already works:
+```
+Kerbin launch → [atmo-ascent] [exo-transit] [atmo-descent] [surface]
+                  ↑ loop=on                    ↑ loop=on
+```
+The player enables loop on the atmospheric segments, disables on the transit. Each segment is its own recording with its own snapshot. No new mechanics needed.
+
+### Current loop flow (unchanged by this plan)
+
+```
+GhostPlaybackEngine.UpdateGhostStates
+  -> for each trajectory:
+     -> if ShouldLoopPlayback(traj):
+        -> TryComputeLoopPlaybackUT(traj, currentUT, ...)
+           -> cycleDuration = (EndUT - StartUT) + intervalSeconds
+           -> loopUT = StartUT + (elapsed % cycleDuration)
+```
+
+---
+
+## Problem 1: Airless Bodies Have No Natural Split Boundary
+
+On Kerbin, the atmosphere edge at ~70km creates a natural chain split. On the Mun (no atmosphere), a deorbit-and-land recording is one monolithic piece. The player can't loop just the landing because it was never split out.
+
+### Existing signals on airless bodies
+
+| Signal | Already captured? | Where | Notes |
+|--------|-------------------|-------|-------|
+| ExoBallistic→ExoPropulsive | Yes | TrackSection boundary | First descent burn |
+| ExoPropulsive→SurfaceMobile | Yes | TrackSection boundary | Touchdown |
+| SOI entry | Yes | Chain split | Too far out (Mun SOI = 2,429 km) |
+| Altitude threshold | No | Needs new detector | Analogous to atmosphere boundary |
+
+### Solution: Altitude-based chain split for airless bodies
+
+Add a new boundary detector parallel to `CheckAtmosphereBoundary`: **`CheckAltitudeBoundary`** for bodies without atmosphere. When altitude crosses a threshold, trigger a chain split exactly like the atmosphere boundary does.
+
+This reuses the entire existing split infrastructure:
+- `FlightRecorder` detects the crossing (with hysteresis, like atmosphere)
+- `ParsekFlight.HandleAltitudeBoundarySplit` commits the segment (parallel to `HandleAtmosphereBoundarySplit`)
+- `ChainSegmentManager.CommitBoundarySplit` creates the new chain segment
+- New segment gets its own `GhostVisualSnapshot`, `PartEvents`, `LoopPlayback` toggle
+
+#### Threshold formula
+
+`approachAltitude = body.Radius * 0.15` clamped to `[5_000, 200_000]` meters.
+
+| Body | Radius | Threshold |
+|------|--------|-----------|
+| Mun | 200 km | 30 km |
+| Minmus | 60 km | 9 km |
+| Tylo | 600 km | 90 km |
+| Gilly | 13 km | 5 km (clamped) |
+| Ike | 130 km | 19.5 km |
+| Dres | 138 km | 20.7 km |
+| Moho | 250 km | 37.5 km |
+| Eeloo | 210 km | 31.5 km |
+
+These are visually reasonable — low enough that terrain fills the screen, high enough to capture the interesting descent phase including suicide burns.
+
+#### SegmentPhase tagging
+
+Atmosphere splits tag segments as `"atmo"` / `"exo"`. Altitude splits on airless bodies tag as:
+- `"approach"` — below the altitude threshold (descent/ascent near surface)
+- `"exo"` — above the threshold (orbital operations)
+
+#### Hysteresis
+
+Same pattern as atmosphere boundary: require both sustained time (3s) and distance beyond boundary (1 km minimum, or a fraction of the threshold) before confirming. This prevents splits from altitude oscillation near the threshold.
+
+#### Tree mode consideration
+
+Current atmosphere splits are suppressed in tree mode (Bug #87) because chain splits were creating orphan segments. The same suppression would apply to altitude splits. TrackSections still record the transitions internally. If tree mode needs selective looping, that's a separate future concern (could post-process TrackSections into segments after recording ends).
+
+---
+
+## Problem 2: Too Many Segments in the UI
+
+A full Kerbin-to-Mun mission might produce:
+```
+[Kerbin atmo ascent] [Kerbin exo] [Mun SOI exo] [Mun approach] [Mun surface]
+```
+
+That's 5 chain segments in the recordings list for what the player thinks of as "one mission." The existing `RecordingGroups` and `ChainId` grouping helps, but the segments are still individual list entries.
+
+### Solution: Logical grouping via chain structure (no data merge)
+
+Sequential chain segments (same `ChainId`, consecutive `ChainIndex`, no branching) are already linked. The UI can present them as a collapsible group:
+
+```
+▼ Mun Landing Mission (5 segments)              [Loop: partial]
+    Kerbin atmo ascent     00:03:42   Loop ✓
+    Kerbin exo             00:12:15   Loop ✗
+    Mun SOI exo            00:08:30   Loop ✗
+    Mun approach           00:02:10   Loop ✓
+    Mun surface            00:00:45   Loop ✓
+```
+
+**No new data model needed.** The chain structure (`ChainId`, `ChainIndex`, `ChainBranch`) already provides the grouping. The only change is UI presentation:
+- Group segments with same `ChainId` and `ChainBranch == 0` under a collapsible header
+- Show aggregate duration and a summary loop indicator ("partial" = some segments loop)
+- Bulk toggle: click the group loop indicator to enable/disable loop on all segments
+
+This is the "super-segment" abstraction — it's a UI grouping over existing chain segments, not a new data structure. The recordings stay independent, each with their own snapshot, part events, and loop settings.
+
+### Branching chains
+
+When a chain branches (docking, undocking, EVA), the branch point is a natural group boundary. Each branch gets its own collapsible group. This matches the user's intuition: "merge segments up to branching/branch merge points."
+
+```
+▼ Station Resupply (3 segments, branch 0)
+    Kerbin atmo ascent     Loop ✓
+    Kerbin exo transit     Loop ✗
+    Station approach       Loop ✓
+  ├─ Branch 1: Booster recovery (2 segments)
+  │   Booster descent      Loop ✓
+  │   Booster splashdown   Loop ✓
+```
+
+---
+
+## Detailed Implementation Tasks
+
+### Phase 1: Airless body altitude split
+
+Dependencies: none. Mirrors the existing atmosphere boundary pattern exactly.
+
+---
+
+**Task 1.1: Pure static methods + unit tests**
+
+Files: `FlightRecorder.cs`, new `AltitudeSplitTests.cs`
+
+Add two `internal static` methods to `FlightRecorder`:
+
+```csharp
+/// Returns the approach altitude threshold for an airless body.
+/// body.Radius * 0.15, clamped to [5000, 200000] meters.
+internal static double ComputeApproachAltitude(double bodyRadius)
+
+/// Pure decision: should the recording split at the altitude boundary?
+/// Mirrors ShouldSplitAtAtmosphereBoundary (line 3300).
+/// Parameters: altitude, threshold, wasAbove, pending, pendingUT, currentUT,
+///   hysteresisSeconds (default 3.0), hysteresisMeters (default max(1000, threshold*0.02))
+internal static bool ShouldSplitAtAltitudeBoundary(
+    double altitude, double threshold, bool wasAbove,
+    bool pendingCross, double pendingUT, double currentUT,
+    double hysteresisSeconds = 3.0, double hysteresisMeters = -1)
+```
+
+If `hysteresisMeters < 0`, compute as `Math.Max(1000, threshold * 0.02)`.
+
+Guard: if `threshold <= 0`, return false (body without a computed threshold — shouldn't happen, but defensive).
+
+Tests in `AltitudeSplitTests.cs` (mirror `AtmosphereSplitTests.cs` pattern):
+- `ZeroThreshold_ReturnsFalse` — guard for degenerate input
+- `SameSide_ReturnsFalse` — still above threshold, no boundary crossed
+- `CrossedButNotFarEnough_ReturnsFalse` — just barely past threshold
+- `CrossedFarButNotLongEnough_ReturnsFalse` — pendingCross = false
+- `CrossedFarAndLongEnough_Descending_ReturnsTrue` — descending below threshold, hysteresis met
+- `CrossedFarAndLongEnough_Ascending_ReturnsTrue` — ascending above threshold
+- `ComputeApproachAltitude_MunRadius` — 200km → 30km
+- `ComputeApproachAltitude_GillyRadius` — 13km → 5km (floor clamp)
+- `ComputeApproachAltitude_TyloRadius` — 600km → 90km
+- `ComputeApproachAltitude_HugeBody` — 2000km → 200km (ceiling clamp)
+- `HysteresisMeters_ScalesWithThreshold` — verify default hysteresis = max(1000, threshold*0.02)
+
+Done condition: `dotnet test --filter AltitudeSplit` passes.
+
+---
+
+**Task 1.2: Stateful detector in FlightRecorder**
+
+Files: `FlightRecorder.cs`
+
+Add instance state (parallel to atmosphere boundary fields at line 194-199):
+
+```csharp
+// Altitude boundary detection (airless bodies)
+private bool wasAboveAltitudeThreshold;
+private bool altitudeBoundaryPending;
+private double altitudeBoundaryPendingUT;
+private double currentAltitudeThreshold; // Computed once per body in ReseedAltitudeState
+public bool AltitudeBoundaryCrossed { get; private set; }
+public bool DescendedBelowThreshold { get; private set; } // true = entering approach zone
+```
+
+Add methods:
+
+```csharp
+/// Called every physics frame. Mirrors CheckAtmosphereBoundary (line 3329).
+/// Guard: if (!IsRecording || isOnRails) return;
+/// Guard: if (v.mainBody.atmosphere) return; // atmospheric bodies use atmosphere split
+public void CheckAltitudeBoundary(Vessel v)
+
+/// Reseeds altitude state. Mirrors ReseedAtmosphereState (line 3379).
+/// Computes threshold, sets wasAboveAltitudeThreshold, clears pending.
+private void ReseedAltitudeState(Vessel v)
+```
+
+Integration points:
+- **Recording start** (line ~3824): after atmosphere state seeding, seed altitude state. Add `ReseedAltitudeState(v)` or inline equivalent.
+- **`ClearBoundaryFlags`** (line 136): add `AltitudeBoundaryCrossed = false; DescendedBelowThreshold = false; altitudeBoundaryPending = false;`
+- **Off-rails handler** (line ~4657, where `ReseedAtmosphereState` is called): add `ReseedAltitudeState(v)` call
+- **SOI change handler** (line ~4695, where `ReseedAtmosphereState` is called): add `ReseedAltitudeState(v)` call
+- **OnPhysicsFrame** (line ~4337, right after `CheckAtmosphereBoundary(v)`): add `CheckAltitudeBoundary(v)` call. NOTE: this call site is in FlightRecorder, not ParsekFlight. The detector runs in the Harmony postfix patch, same as the atmosphere check.
+
+Done condition: builds, altitude state is seeded/cleared alongside atmosphere state.
+
+Test: `CheckAltitudeBoundary_AtmosphericBody_Skipped` — verify the `v.mainBody.atmosphere` guard returns early on atmospheric bodies.
+
+---
+
+**Task 1.3: Handler in ParsekFlight**
+
+Files: `ParsekFlight.cs`
+
+Add `HandleAltitudeBoundarySplit` (parallel to `HandleAtmosphereBoundarySplit` at line 4187):
+
+```csharp
+/// Mirrors HandleAtmosphereBoundarySplit exactly.
+/// Guards: recorder null, not recording, AltitudeBoundaryCrossed not set.
+/// Tree mode suppression: if (activeTree != null) { clear flags, return; }
+/// Phase tagging: completed phase = DescendedBelowThreshold ? "exo" : "approach"
+///   (descending below = completing exo segment; ascending above = completing approach segment)
+private void HandleAltitudeBoundarySplit()
+```
+
+NOTE: The detector call (`CheckAltitudeBoundary`) is wired in Task 1.2 (FlightRecorder.OnPhysicsFrame). This task only adds the handler that reacts to the flag.
+
+Add `HandleAltitudeBoundarySplit()` call at line 391, right after `HandleAtmosphereBoundarySplit()`:
+```csharp
+HandleAtmosphereBoundarySplit();
+HandleAltitudeBoundarySplit();   // NEW
+HandleSoiChangeSplit();
+```
+
+Done condition: builds. Altitude boundary crossings on airless bodies trigger chain splits.
+
+---
+
+**Task 1.4: Phase tagging updates**
+
+Files: `ParsekFlight.cs`, `ChainSegmentManager.cs`, `RecordingStore.cs`, `ParsekUI.cs`
+
+1. **`TagSegmentPhaseIfMissing`** (ParsekFlight.cs line 1469): Currently tags airless bodies as `"space"`. Change to use altitude threshold:
+   ```csharp
+   // Was: pending.SegmentPhase = "space";
+   // Now:
+   double threshold = FlightRecorder.ComputeApproachAltitude(v.mainBody.Radius);
+   pending.SegmentPhase = v.altitude < threshold ? "approach" : "exo";
+   ```
+   Apply same change at all `"space"` tagging sites in ParsekFlight.cs (lines ~1479, ~4564).
+
+2. **`CommitVesselSwitchTermination`** (ChainSegmentManager.cs line 600): Same change — replace `"space"` with altitude-aware tagging for airless bodies.
+
+3. **`HandleSoiChangeSplit`** (ParsekFlight.cs line ~4244): Currently tags the completed segment as `"space"` for airless departing bodies:
+   ```csharp
+   // Was: string fromPhase = (fromCB != null && fromCB.atmosphere) ? "exo" : "space";
+   // Now: for airless bodies, use altitude threshold to distinguish approach vs exo
+   ```
+
+3. **`GetSegmentPhaseLabel`** (RecordingStore.cs line 784): No change needed — it just concatenates body name + phase string. `"Mun approach"` works.
+
+4. **UI phase styling** (ParsekUI.cs line 1263): Add "approach" style. Currently has `phaseStyleAtmo` (orange) and `phaseStyleSpace` (lime green). Add:
+   ```csharp
+   private GUIStyle phaseStyleApproach; // e.g., sky blue
+   // In InitStyles:
+   phaseStyleApproach = new GUIStyle(GUI.skin.label);
+   phaseStyleApproach.normal.textColor = new Color(0.4f, 0.7f, 1f); // sky blue
+   // In phase switch:
+   else if (rec.SegmentPhase == "approach") phaseStyle = phaseStyleApproach;
+   ```
+
+Done condition: builds, "approach" phase appears with distinct color in UI.
+
+---
+
+**Task 1.5: Integration test — synthetic Mun landing**
+
+Files: new `AltitudeSplitIntegrationTests.cs`, possibly `Generators/RecordingBuilder.cs`
+
+Test that simulates a Mun landing recording by:
+1. Building a recording with points that descend from 100km to 0km altitude around Mun (radius 200km, no atmosphere)
+2. Calling `ShouldSplitAtAltitudeBoundary` at each point to verify it fires at ~30km
+3. Verifying the phase tagging: segment above 30km = "exo", segment below = "approach"
+
+Also test:
+- `ComputeApproachAltitude` for all stock airless bodies (Mun, Minmus, Tylo, Gilly, Ike, Dres, Moho, Eeloo, Bop, Pol)
+- Log assertions: verify boundary detection logs match atmosphere boundary log pattern
+
+Done condition: all tests pass.
+
+---
+
+### Phase 2: UI bulk loop toggle on chain headers
+
+Dependencies: Phase 1 (so "approach" segments exist to toggle).
+
+---
+
+**Task 2.1: Bulk loop toggle + partial indicator**
+
+Files: `ParsekUI.cs`
+
+In `DrawChainBlock` (line 1730), replace the empty loop spacer (line 1782) with a functional toggle:
+
+1. Scan chain members for loop state:
+   ```csharp
+   int loopOn = 0, loopOff = 0;
+   for (int m = 0; m < members.Count; m++)
+   {
+       if (committed[members[m]].LoopPlayback) loopOn++;
+       else loopOff++;
+   }
+   bool allLoop = loopOff == 0;
+   bool noLoop = loopOn == 0;
+   bool partial = !allLoop && !noLoop;
+   ```
+
+2. Draw toggle button:
+   - Label: `"L"` (matches per-recording loop column)
+   - Color: green if all, yellow if partial, default if none
+   - Click action: if none or partial → turn all ON (encourage looping); if all on → turn all OFF
+   - Log: `"Chain '{name}' bulk loop toggled: {oldState} → {newState} ({count} segments)"`
+
+3. Replace the empty period spacer (line 1783) with aggregate info or leave as spacer.
+
+Done condition: builds, clicking chain header L button toggles loop on all member segments.
+
+---
+
+### Phase 3 (optional): TrackSection altitude metadata
+
+Dependencies: none (independent of Phase 1-2).
+
+---
+
+**Task 3.1: Add min/max altitude fields to TrackSection**
+
+Files: `TrackSection.cs`, `FlightRecorder.cs`, `RecordingStore.cs`
+
+1. Add to `TrackSection` struct:
+   ```csharp
+   public float minAltitude;  // NaN = not set (legacy recording)
+   public float maxAltitude;  // NaN = not set
+   ```
+   Initialize to `float.NaN` in `StartNewTrackSection`.
+
+2. In `FlightRecorder`, when adding a point to `currentTrackSection.frames` (lines 4442-4444, 4500-4503):
+   ```csharp
+   float alt = (float)point.altitude;
+   if (float.IsNaN(currentTrackSection.minAltitude) || alt < currentTrackSection.minAltitude)
+       currentTrackSection.minAltitude = alt;
+   if (float.IsNaN(currentTrackSection.maxAltitude) || alt > currentTrackSection.maxAltitude)
+       currentTrackSection.maxAltitude = alt;
+   ```
+
+3. Serialization in `RecordingStore`: add `minAlt` / `maxAlt` values to TRACK_SECTION ConfigNode. On load, default to `float.NaN` if absent (backward compat — no format version bump needed since NaN sentinel handles missing fields).
+
+4. Update `TrackSection.ToString()` to include altitude range when non-NaN.
+
+Test: round-trip serialization test — write TrackSection with altitude data, reload, verify values preserved. Also test loading a legacy TrackSection without altitude fields → NaN defaults.
+
+Done condition: `dotnet test` passes, altitude metadata recorded during flight.
+
+---
+
+### Phase 4: Recording optimization pass
+
+Dependencies: Phase 1 (for "approach" segments to exist). Phase 3 optional but nice for merge heuristics.
+
+---
+
+**Task 4.1: Pure merge/split decision logic**
+
+Files: new `RecordingOptimizer.cs`, new `RecordingOptimizerTests.cs`
+
+All methods `internal static` for testability:
+
+```csharp
+/// Can these two consecutive chain segments be auto-merged?
+/// Returns false if any user-intent signal differs from default.
+internal static bool CanAutoMerge(Recording a, Recording b)
+
+/// Can this recording be auto-split at the given TrackSection boundary?
+/// Returns false if any ghosting-trigger part events exist anywhere in the recording.
+internal static bool CanAutoSplit(Recording rec, int sectionIndex)
+
+/// Returns the list of merge opportunities: pairs of (indexA, indexB) in the committed list.
+internal static List<(int, int)> FindMergeCandidates(List<Recording> committed)
+
+/// Returns the list of split opportunities: (index, sectionIndex) pairs.
+internal static List<(int, int)> FindSplitCandidates(List<Recording> committed)
+```
+
+`CanAutoMerge` checks (all must be true):
+- Same `ChainId`, sequential `ChainIndex`, both `ChainBranch == 0`
+- No branch point between them (`ChildBranchPointId` on A is null)
+- Same `SegmentPhase`
+- Same `SegmentBodyName`
+- Neither has ghosting-trigger part events
+- Neither has any user-modified setting:
+  - `LoopPlayback == false` on both
+  - `PlaybackEnabled == true` on both
+  - `Hidden == false` on both
+  - `LoopIntervalSeconds == 10.0` (default) on both
+  - `LoopAnchorVesselId == 0` on both
+  - `RecordingGroups` null or empty on both (or identical)
+  - (Future: if a `ManuallyCreated` flag is added, never merge those. Not implemented in v1.)
+
+`CanAutoSplit` checks:
+- Recording has TrackSections with `Count >= 2`
+- `sectionIndex` is in range `[1, Count-1]` (can't split before first or after last)
+- No ghosting-trigger part events anywhere in the recording
+- No ghosting-trigger segment events anywhere in the recording
+- Both halves would have `>= 1` TrackSection
+- Both halves would be longer than 5 seconds
+
+Tests:
+- `CanAutoMerge_SamePhase_DefaultSettings_ReturnsTrue`
+- `CanAutoMerge_DifferentPhase_ReturnsFalse`
+- `CanAutoMerge_LoopEnabled_ReturnsFalse`
+- `CanAutoMerge_PlaybackDisabled_ReturnsFalse`
+- `CanAutoMerge_Hidden_ReturnsFalse`
+- `CanAutoMerge_CustomLoopInterval_ReturnsFalse`
+- `CanAutoMerge_AnchorSet_ReturnsFalse`
+- `CanAutoMerge_DifferentGroups_ReturnsFalse`
+- `CanAutoMerge_HasGhostingTriggerEvents_ReturnsFalse`
+- `CanAutoMerge_BranchPointBetween_ReturnsFalse`
+- `CanAutoMerge_DifferentBody_ReturnsFalse`
+- `CanAutoSplit_NoGhostingTriggers_ReturnsTrue`
+- `CanAutoSplit_HasGhostingTriggers_ReturnsFalse`
+- `CanAutoSplit_HalfTooShort_ReturnsFalse`
+- `FindMergeCandidates_ThreeExoSegments_ReturnsTwoPairs`
+
+Done condition: all tests pass.
+
+---
+
+**Task 4.2: Merge execution**
+
+Files: `RecordingOptimizer.cs`, `RecordingOptimizerTests.cs`
+
+```csharp
+/// Merges recording B into recording A (A absorbs B).
+/// A's Points, PartEvents, SegmentEvents, TrackSections, OrbitSegments, FlagEvents
+/// are extended with B's data. A's EndUT updated. B is marked for deletion.
+/// Returns B's RecordingId (caller deletes files + removes from store).
+internal static string MergeInto(Recording target, Recording absorbed)
+```
+
+Steps:
+1. Concatenate Points (already UT-ordered)
+2. Merge + re-sort PartEvents by UT
+3. Merge + re-sort SegmentEvents by UT
+4. Concatenate TrackSections
+5. Merge OrbitSegments
+6. Union FlagEvents
+7. If absorbed had non-null VesselSnapshot (was chain tip), target inherits it
+8. If absorbed had non-null TerminalStateValue, target inherits it (absorbed was the later segment)
+9. Clear ExplicitStartUT/ExplicitEndUT to NaN on target (Points now cover the full range)
+10. If absorbed had Controllers, merge (or keep target's if both non-null)
+11. If absorbed had AntennaSpecs, merge (or keep target's if both non-null)
+12. Invalidate GhostGeometry: set target's `GhostGeometryAvailable = false`, clear `GhostGeometryRelativePath` (geometry covers only the first half's vessel config — must be regenerated)
+13. Invalidate target's CachedStats
+
+Test:
+- `MergeInto_ConcatenatesPoints` — verify points from both recordings in order
+- `MergeInto_MergesPartEvents_Sorted` — verify part events re-sorted by UT
+- `MergeInto_InheritsVesselSnapshot_WhenAbsorbedIsChainTip`
+- `MergeInto_KeepsNullSnapshot_WhenAbsorbedIsMidChain`
+- `MergeInto_InheritsTerminalState`
+- `MergeInto_InvalidatesGhostGeometry`
+- `MergeInto_ClearsExplicitUTRanges`
+
+Done condition: all tests pass.
+
+---
+
+**Task 4.3: Split execution**
+
+Files: `RecordingOptimizer.cs`, `RecordingOptimizerTests.cs`
+
+```csharp
+/// Splits a recording at the given TrackSection boundary index.
+/// Returns the new Recording (second half). The original is mutated to keep the first half.
+/// Caller must assign chain linkage, save files, add to store.
+internal static Recording SplitAtSection(Recording original, int sectionIndex)
+```
+
+Steps:
+1. Determine split UT from `TrackSections[sectionIndex].startUT`
+2. Partition Points by UT
+3. Partition PartEvents, SegmentEvents, FlagEvents by UT
+4. Partition TrackSections: first half = `[0, sectionIndex)`, second half = `[sectionIndex, Count)`
+5. Partition OrbitSegments by UT
+6. Clone GhostVisualSnapshot to new recording (safe because `CanAutoSplit` only permits splits when NO ghosting-trigger part events exist anywhere in the recording — the vessel looks identical throughout, so the snapshot is valid for both halves)
+7. New recording gets new RecordingId
+8. Tag SegmentPhase on both halves from their first TrackSection's environment
+9. Update both recordings' UT ranges
+10. Invalidate GhostGeometry on both halves: `GhostGeometryAvailable = false`, clear `GhostGeometryRelativePath`. Caller (Task 4.5) must write new `.pcrf` files for each half, or leave geometry unavailable for regeneration on next playback.
+11. Invalidate CachedStats on both
+
+Test:
+- `SplitAtSection_PartitionsPoints` — correct points in each half
+- `SplitAtSection_PartitionsPartEvents`
+- `SplitAtSection_ClonesSnapshot`
+- `SplitAtSection_TagsPhaseFromEnvironment`
+- `SplitAtSection_BothHalvesHaveValidUTRanges`
+
+Done condition: all tests pass.
+
+---
+
+**Task 4.4: Chain re-indexing helper**
+
+Files: `RecordingOptimizer.cs` (or `RecordingStore.cs`), tests
+
+```csharp
+/// Re-indexes ChainIndex for all recordings with the given ChainId.
+/// Sorts by StartUT, assigns sequential indices starting from 0.
+internal static void ReindexChain(List<Recording> committed, string chainId)
+```
+
+Test:
+- `ReindexChain_AfterMerge_IndicesSequential`
+- `ReindexChain_AfterSplit_IndicesSequential`
+- `ReindexChain_PreservesChainBranch` — only re-indexes branch 0
+
+Done condition: all tests pass.
+
+---
+
+**Task 4.5: Orchestration + file I/O**
+
+Files: `RecordingStore.cs`, `ParsekScenario.cs`
+
+Add to RecordingStore:
+```csharp
+/// Runs the optimization pass: find merge/split candidates, execute, clean up files.
+/// Called on save load (after migrations) and optionally on recording commit.
+internal static void RunOptimizationPass()
+```
+
+Flow:
+1. `FindMergeCandidates` → for each pair, `MergeInto` + `ReindexChain` + `DeleteRecordingFiles` for absorbed
+2. `FindSplitCandidates` → for each, `SplitAtSection` + assign chain linkage + `SaveRecordingFiles` + `ReindexChain`
+3. Log summary: `"Optimization pass: merged {n} pairs, split {m} recordings"`
+
+Integration:
+- Call from `ParsekScenario.OnLoad` after existing migration passes
+- Optionally call from `CommitBoundarySplit` (merge check: does the newly committed segment merge with its predecessor?)
+
+Guard: `RecordingStore.SuppressLogging` for test compatibility.
+
+Test: end-to-end with synthetic recordings — create 3 consecutive "exo" segments, run optimization, verify merged into 1.
+
+Done condition: `dotnet test` passes, optimization runs on load without errors.
+
+---
+
+## What We're NOT Doing
+
+- **No sub-range looping within a recording.** Each recording loops as a whole or not at all. Segmentation provides the granularity.
+- **No new UI features for segment selection.** Existing per-recording loop toggle is sufficient.
+- **No new playback engine changes.** `TryComputeLoopPlaybackUT` stays the same.
+- **No data merging of chain segments.** Segments stay as independent recordings. Grouping is UI-only.
+- **No part-event fast-forward.** Each segment has its own snapshot — no cross-segment state reconstruction needed.
+
+---
+
+## Why This Is Better Than Sub-Range Looping
+
+| Concern | Segmentation approach | Sub-range looping approach |
+|---------|----------------------|---------------------------|
+| Playback engine changes | None | New two-phase cycle math |
+| Part event state | Each segment has own snapshot | Need fast-forward or per-section cache |
+| Ghost visual state | Each segment has own snapshot | Need mid-recording snapshot or rebuild |
+| Overlap ghost behavior | Each segment is independent | Different-length cycles create mismatches |
+| Format migration | Minimal (altitude fields) | New loop range fields + section index stability |
+| UI changes | Collapsible grouping only | Segment selection UI needed |
+| Testing surface | One new boundary detector | New loop math + state management |
+| Backward compatibility | Fully compatible | New fields on Recording + IPlaybackTrajectory |
+
+---
+
+## Phase 4: Recording Optimization Pass (Merge / Split Housekeeping)
+
+An automatic post-recording optimization pass that merges or splits chain segments to produce clean, useful segmentation. Runs as housekeeping — no player interaction needed.
+
+### Merge: consolidate redundant segments
+
+Two or more consecutive chain segments can be merged when:
+- Same `ChainId`, sequential `ChainIndex`, `ChainBranch == 0`
+- No branch point between them (no docking/undocking/EVA at the boundary)
+- Same or compatible `SegmentPhase` (e.g., two adjacent "exo" segments)
+
+Merge operation:
+1. Concatenate `Points` lists (already UT-ordered)
+2. Merge `PartEvents` lists (re-sort by UT)
+3. Merge `SegmentEvents` lists
+4. Concatenate `TrackSections` lists
+5. Merge `OrbitSegments` lists
+6. Use first segment's `GhostVisualSnapshot` (vessel looked like this at the start of the combined segment)
+7. `VesselSnapshot`: mid-chain segments have `VesselSnapshot = null` (ghost-only). If the absorbed segment was the final chain segment (non-null `VesselSnapshot`), the merged result inherits it (merged result is now the chain tip). Otherwise stays null.
+8. Union `FlagEvents`
+9. Adopt first segment's `RecordingId`, update UT ranges
+10. Re-index `ChainIndex` for remaining segments in the chain
+11. Delete absorbed segment's sidecar files (`.prec`, `_ghost.craft`, `.pcrf`)
+12. Save merged segment's updated sidecar files
+
+**Use cases:**
+- Multiple "exo" segments created by SOI transitions (Kerbin exo → Mun SOI exo → they're both just "transit in space")
+- Brief atmosphere oscillation during aerobraking creating tiny segments
+- On-rails / off-rails cycling during time warp creating redundant ExoBallistic segments
+- Any sequential segments where the player would never want different loop settings
+
+**Merge policy (automatic) — user intent is sacred:**
+
+Hard constraints (never merge if any of these are true):
+- Either segment has ghosting-trigger part events (`GhostingTriggerClassifier.HasGhostingTriggerEvents`) — ghost snapshot would be wrong for the second half
+- Different `SegmentPhase` (don't merge "atmo" with "exo" or "approach" with "exo")
+- Different `SegmentBodyName` (preserve body-awareness)
+- Branch point between them (docking, undocking, EVA at the boundary)
+- Either segment has **any user-modified setting** that differs from defaults:
+  - `LoopPlayback = true` on either segment (player chose to loop this specific segment)
+  - `PlaybackEnabled = false` on either segment (player chose to hide this segment)
+  - `Hidden = true` on either segment
+  - `LoopIntervalSeconds` differs from default (player tuned the loop timing)
+  - `LoopAnchorVesselId != 0` on either segment (player configured anchor)
+  - Different `RecordingGroups` membership (player organized them differently)
+- Either segment was created by a future manual split operation (needs a `ManuallyCreated` flag or similar — segments the player explicitly created should never be auto-merged back)
+
+Soft constraints (prefer not to merge):
+- Minimum segment duration guard: prefer merging tiny segments (< 10s) into neighbors over merging two substantial segments
+- Merge the smaller segment into the larger, not vice versa
+
+**The principle: if the player has touched a segment's settings in any way, that segment is off-limits for auto-merge. Only merge segments that are in pristine default state.**
+
+### Split: break apart segments at TrackSection boundaries
+
+Split a single recording into chain segments at internal TrackSection boundaries. More constrained than merge because each new segment needs a valid ghost snapshot.
+
+**Split is safe when:**
+- No ghosting-trigger part events exist across the split boundary (vessel visual state hasn't changed — `GhostingTriggerClassifier.HasGhostingTriggerEvents` can be adapted to check a UT range)
+- The existing `GhostVisualSnapshot` is reusable for both halves (same vessel configuration)
+
+**Split is NOT safe when:**
+- Part events between the recording start and the split point changed vessel geometry (fairings jettisoned, stages separated, etc.)
+- The second half would need a different ghost snapshot than the first half
+
+**Split operation (when safe):**
+1. Create new Recording for the second half
+2. Partition `Points` at the split UT
+3. Partition `PartEvents`, `SegmentEvents`, `FlagEvents` by UT
+4. Partition `TrackSections` at the boundary
+5. Partition `OrbitSegments` by UT
+6. Clone `GhostVisualSnapshot` to the new segment (safe because the policy restricts splitting to recordings with no ghosting-trigger part events anywhere — the vessel looks the same throughout, so the snapshot is valid for both halves)
+7. Assign chain linkage (`ChainId`, `ChainIndex`, `ChainBranch`)
+8. Tag `SegmentPhase` based on the TrackSection environment at the split point
+9. Write new sidecar files, update existing segment's files
+
+**Use cases:**
+- Tree-mode recordings that suppressed chain splits: after recording ends, post-process to split at TrackSection boundaries where it's safe
+- Legacy monolithic recordings from before altitude splits were added
+- Recordings where the player wants finer-grained loop control than was captured at recording time
+
+**Split policy (automatic):**
+- Only split at TrackSection boundaries where `SegmentEnvironment` changes
+- Only split when no ghosting-trigger part events exist in the recording (simple case first)
+- Never split segments shorter than a minimum duration (e.g., < 5s)
+
+### When does the optimization pass run?
+
+- **On recording commit** (`StopRecording` / `CommitBoundarySplit`): merge pass checks if the newly committed segment should merge with its predecessor
+- **On save load** (`ParsekScenario.OnLoad`): one-time pass over all recordings to merge redundant segments. Runs after v2→v3 / v4→v5 migrations.
+- **On explicit player action** (future): "Optimize Recordings" button in settings, for players who want to clean up legacy saves
+
+### Implementation
+
+**Files to modify:**
+- New file: `RecordingOptimizer.cs` — pure static methods for merge/split logic
+  - `CanMergeSegments(Recording a, Recording b) → bool` — pure, testable
+  - `MergeSegments(Recording target, Recording absorbed) → void` — mutates target, returns absorbed ID for deletion
+  - `CanSplitAtTrackSection(Recording rec, int sectionIndex) → bool` — checks part event safety
+  - `SplitAtTrackSection(Recording rec, int sectionIndex) → Recording` — returns new segment
+
+- `RecordingStore.cs` — orchestration: find merge/split candidates, execute, update indices
+  - `RunOptimizationPass(List<Recording> recordings)` — scans for merge/split opportunities, executes
+  - File I/O: delete absorbed segment files, write new split segment files
+
+- `ChainSegmentManager.cs` — `ReindexChain(string chainId)` helper to fix chain indices after merge/split
+
+- `ParsekScenario.cs` — call optimization pass on load
+
+**Tests:**
+- `CanMergeSegments` — same phase/different phase, branch points, loop settings, body changes
+- `MergeSegments` — point concatenation, event merging, UT range updates, chain re-indexing
+- `CanSplitAtTrackSection` — with/without ghosting triggers, minimum duration
+- `SplitAtTrackSection` — point partitioning, event partitioning, snapshot cloning
+- Round-trip: merge then verify the merged recording plays back identically to the original sequence
+
+---
+
+## Review-Informed Updates
+
+### Changes from first review (now incorporated)
+
+1. **Lower altitude floor clamp to 5,000 m** (from 10,000 m). 10 km on Gilly (13 km radius) is 0.77 body-radii — disproportionately high. 5 km is 0.38 body-radii, still generous.
+
+2. **Do NOT make altitude threshold a setting.** An opinionated default (`body.Radius * 0.15` clamped `[5_000, 200_000]`) is better than exposing a tunable that requires orbital mechanics knowledge.
+
+3. **`ClearBoundaryFlags` must also clear altitude state.** Add to Phase 1 file change list.
+
+4. **`TagSegmentPhaseIfMissing` and `CommitVesselSwitchTermination` need "approach" handling.** Currently tags airless bodies as `"space"` unconditionally — must distinguish `"approach"` vs `"exo"` based on altitude.
+
+5. **UI phase styling for "approach".** Needs distinct color in `ParsekUI.cs` (alongside existing "atmo" and "space" styles).
+
+6. **Recording-start seeding.** `wasAboveAltitudeThreshold` must be seeded in `StartRecording`, not just on SOI change.
+
+7. **Phase 2 scope clarification.** Chain grouping already exists in `DrawChainBlock`. Phase 2 is: add bulk loop toggle to existing chain header + "partial" loop indicator. Not building grouping from scratch.
+
+8. **Auto-enable `LoopPlayback` for "approach" and "atmo" segments.** Consider setting `LoopPlayback = true` at commit time for segments tagged "approach" or "atmo". Changes the UX from "opt-in to loop interesting segments" to "opt-out of looping boring segments." One-line change in segment commit logic.
+
+9. **No existing recordings can be retroactively split.** Monolithic Mun landings from before this feature require re-recording. Acceptable, but the Phase 4 optimization pass (split) addresses this for cases where no part events cross the boundary.
+
+---
+
+## Open Questions
+
+1. **Altitude threshold tuning.** `body.Radius * 0.15` clamped to `[5_000, 200_000]` is the default. May need adjustment after in-game testing. Do not make it a setting.
+
+2. **Tree mode.** Altitude splits are suppressed in tree mode (same as atmosphere splits). If tree-mode recordings need selective looping, that's a future concern — Phase 4 split could post-process them.
+
+3. **Multiple altitude crossings.** Hysteresis + minimum segment guard handles this. If a vessel does 5 low passes, 5 segments is correct (each independently loopable). Phase 4 merge can consolidate redundant ones if needed.
+
+4. **Ascending vs descending.** Tag `"approach"` for descending below threshold, `"exo"` for ascending above. Mirrors atmosphere boundary convention (name the completed segment).
+
+5. **Auto-loop default.** Should "approach" and "atmo" segments auto-enable `LoopPlayback`? Dramatically improves out-of-box experience but changes existing behavior for atmosphere splits.
+
+6. **Optimization pass performance.** On save load with many recordings, the merge/split scan should be bounded. O(n) scan with O(1) per-pair merge check is fine. Avoid O(n^2) patterns.
+
+7. **`ManuallyCreated` flag.** Phase 4 merge needs a way to identify segments the player explicitly created (via future manual split). Auto-merge must never recombine these. Could be a bool on Recording, or inferred from the absence of a boundary-split origin marker.
+
+8. **Hysteresis distance scaling for altitude boundary.** The atmosphere boundary uses a fixed 1000m distance. For altitude splits, consider scaling: `max(1000, threshold * 0.02)`. On Gilly (5km threshold), 1km is 20% of the threshold — generous. On Tylo (90km threshold), 1km is negligible. Scaling keeps the hysteresis proportionate.

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1229,7 +1229,7 @@ Recordings currently capture entire flights as monolithic units. For effective l
 
 **Priority:** Medium — quality-of-life for players building complex multi-mission scenes
 
-**Status:** Open
+**Status:** Implemented — altitude-based chain splits for airless bodies using KSP's `timeWarpAltitudeLimits[4]` (100x warp limit) as the approach threshold. Recordings auto-split when crossing the threshold, creating separate chain segments with `"approach"` / `"exo"` phase tags. Each segment has its own ghost snapshot and loop toggle, enabling selective looping of interesting portions (landings, approaches) without looping orbital coasts. TrackSection altitude metadata (min/max) recorded for future heuristics. Automatic recording optimization pass merges redundant consecutive chain segments on save load (same phase, same body, no branch points, no user-modified settings). Phase 2 (bulk loop toggle on chain headers) was implemented separately in the settings-ui-polish branch.
 
 ## 98. Deleting and recreating a save with the same name leaks old recordings
 


### PR DESCRIPTION
## Summary

- **Altitude-based chain splits for airless bodies** — recordings auto-split when crossing the approach altitude threshold on bodies without atmosphere (Mun, Minmus, Tylo, etc.). Uses KSP's native `timeWarpAltitudeLimits[4]` (100x warp limit) as the threshold, falling back to `body.Radius * 0.15` when unavailable. Mirrors the existing atmosphere boundary split pattern exactly.
- **"approach" phase tagging** — airless body segments below the threshold are tagged `"approach"` (sky blue in UI) instead of the old `"space"`. All 4 tagging sites updated (TagSegmentPhaseIfMissing, CommitVesselSwitchTermination, HandleSoiChangeSplit, StopRecording fallback).
- **TrackSection altitude metadata** — min/max altitude tracked per TrackSection during recording. Serialized as sparse `minAlt`/`maxAlt` keys (NaN sentinel for legacy recordings, no format version bump).
- **Recording optimization pass** — automatic housekeeping that merges redundant consecutive chain segments (same phase, same body, no branch points, no ghosting triggers, no user-modified settings). Runs on save load after recording deserialization. User intent is sacred: any non-default setting (loop, hidden, disabled, custom interval, anchor, groups) blocks merge.
- **Design plan** — full T97 plan document with investigation, options analysis, 3 opus reviews incorporated.

## Test plan

- [x] 64 new tests (3638 total, 0 failures)
- [x] `AltitudeSplitTests` — pure logic: threshold formula, hysteresis, boundary conditions, all stock airless bodies
- [x] `AltitudeSplitExtendedTests` — simulated Mun descent/ascent, phase label formatting, boundary flag clearing
- [x] `RecordingOptimizerTests` — CanAutoMerge (16 cases), CanAutoSplit (6 cases), FindMergeCandidates, FindSplitCandidates, MergeInto (7 cases), SplitAtSection (5 cases), ReindexChain (2 cases)
- [x] `TrackSectionSerializationTests` — altitude metadata round-trip, legacy NaN defaults, NaN not serialized
- [x] In-game: record a Mun landing, verify chain split at approach altitude
- [x] In-game: verify "approach" phase label with sky blue color in recordings manager
- [x] In-game: verify optimization pass merges redundant exo segments on save reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)