### PR TITLE
Fix #167: apply crew swap at KSC spawn time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ All notable changes to Parsek are documented here.
 - **Fix #163: KSC spawns vessels from the future after rewind.** `ShouldSpawnAtKscEnd` now checks `currentUT >= EndUT`.
 - **Fix #165: Engine flame flash on ignition.** `EngineIgnited` with throttle=0 now uses min 0.01 emission.
 - **Fix #164: Strip all future vessels on rewind, not just PRELAUNCH.** Flags, landed capsules, and other player-created vessels from the future now removed after rewind.
+- **Fix #167: Crew swap not executed for KSC-spawned vessels.** `SwapReservedCrewInFlight` only runs in flight scene — KSC spawns via `TrySpawnAtRecordingEnd` never swapped reserved crew. Added `SwapReservedCrewInSnapshot` to replace reserved crew names directly in the snapshot ConfigNode before spawning.
 - **DeferredActivateVessel timeout increased** from 10 frames to 5 seconds. Distant spawned vessels (37km+) couldn't load in 10 frames.
 - **ComputeTotal logging removed.** Eliminated 52% of all Parsek log output (pure computation was logging every UI frame).
 - **Status column widened** (95→120px) for longer T+ timestamps.

--- a/Source/Parsek.Tests/KscCrewSwapTests.cs
+++ b/Source/Parsek.Tests/KscCrewSwapTests.cs
@@ -103,6 +103,8 @@ namespace Parsek.Tests
             var crew = CrewReservationManager.ExtractCrewFromSnapshot(snapshot);
             Assert.Single(crew);
             Assert.Equal("Kirrim Kerman", crew[0]);
+            Assert.Contains(logLines, l => l.Contains("[CrewReservation]") && l.Contains("Snapshot swap: 'Jebediah Kerman' -> 'Kirrim Kerman'"));
+            Assert.Contains(logLines, l => l.Contains("[CrewReservation]") && l.Contains("Snapshot crew swap complete: 1 name(s) replaced"));
         }
 
         [Fact]
@@ -175,6 +177,9 @@ namespace Parsek.Tests
             Assert.Equal("Kirrim Kerman", crew[0]);
             Assert.Equal("Agasel Kerman", crew[1]);
             Assert.Equal("Bill Kerman", crew[2]);
+            Assert.Contains(logLines, l => l.Contains("Snapshot swap:") && l.Contains("PART[0]"));
+            Assert.Contains(logLines, l => l.Contains("Snapshot swap:") && l.Contains("PART[1]"));
+            Assert.Contains(logLines, l => l.Contains("Snapshot crew swap complete: 2 name(s) replaced"));
         }
 
         [Fact]

--- a/Source/Parsek.Tests/KscCrewSwapTests.cs
+++ b/Source/Parsek.Tests/KscCrewSwapTests.cs
@@ -1,0 +1,273 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Tests for bug #167: crew swap not executed for KSC-spawned vessels.
+    /// SwapReservedCrewInSnapshot is the pure method that replaces reserved
+    /// crew names in a vessel snapshot ConfigNode before spawning at KSC.
+    /// </summary>
+    [Collection("Sequential")]
+    public class KscCrewSwapTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public KscCrewSwapTests()
+        {
+            RecordingStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+            CrewReservationManager.ResetReplacementsForTesting();
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+            RecordingStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+            CrewReservationManager.ResetReplacementsForTesting();
+        }
+
+        #region SwapReservedCrewInSnapshot — basic cases
+
+        [Fact]
+        public void SwapReservedCrewInSnapshot_NullSnapshot_ReturnsZero()
+        {
+            var replacements = new Dictionary<string, string> { { "Jeb", "Kirrim" } };
+
+            int result = CrewReservationManager.SwapReservedCrewInSnapshot(null, replacements);
+
+            Assert.Equal(0, result);
+        }
+
+        [Fact]
+        public void SwapReservedCrewInSnapshot_NullReplacements_ReturnsZero()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            var part = snapshot.AddNode("PART");
+            part.AddValue("crew", "Jeb");
+
+            int result = CrewReservationManager.SwapReservedCrewInSnapshot(snapshot, null);
+
+            Assert.Equal(0, result);
+        }
+
+        [Fact]
+        public void SwapReservedCrewInSnapshot_EmptyReplacements_ReturnsZero()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            var part = snapshot.AddNode("PART");
+            part.AddValue("crew", "Jeb");
+            var replacements = new Dictionary<string, string>();
+
+            int result = CrewReservationManager.SwapReservedCrewInSnapshot(snapshot, replacements);
+
+            Assert.Equal(0, result);
+        }
+
+        [Fact]
+        public void SwapReservedCrewInSnapshot_NoPartsWithCrew_ReturnsZero()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            snapshot.AddNode("PART"); // part with no crew
+            var replacements = new Dictionary<string, string> { { "Jeb", "Kirrim" } };
+
+            int result = CrewReservationManager.SwapReservedCrewInSnapshot(snapshot, replacements);
+
+            Assert.Equal(0, result);
+        }
+
+        #endregion
+
+        #region SwapReservedCrewInSnapshot — single crew swap
+
+        [Fact]
+        public void SwapReservedCrewInSnapshot_SingleCrewMatch_SwapsAndReturnsOne()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            var part = snapshot.AddNode("PART");
+            part.AddValue("crew", "Jebediah Kerman");
+            var replacements = new Dictionary<string, string>
+            {
+                { "Jebediah Kerman", "Kirrim Kerman" }
+            };
+
+            int result = CrewReservationManager.SwapReservedCrewInSnapshot(snapshot, replacements);
+
+            Assert.Equal(1, result);
+            var crew = CrewReservationManager.ExtractCrewFromSnapshot(snapshot);
+            Assert.Single(crew);
+            Assert.Equal("Kirrim Kerman", crew[0]);
+        }
+
+        [Fact]
+        public void SwapReservedCrewInSnapshot_NoMatch_LeavesCrewUnchanged()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            var part = snapshot.AddNode("PART");
+            part.AddValue("crew", "Bob Kerman");
+            var replacements = new Dictionary<string, string>
+            {
+                { "Jebediah Kerman", "Kirrim Kerman" }
+            };
+
+            int result = CrewReservationManager.SwapReservedCrewInSnapshot(snapshot, replacements);
+
+            Assert.Equal(0, result);
+            var crew = CrewReservationManager.ExtractCrewFromSnapshot(snapshot);
+            Assert.Single(crew);
+            Assert.Equal("Bob Kerman", crew[0]);
+        }
+
+        #endregion
+
+        #region SwapReservedCrewInSnapshot — multi-crew scenarios
+
+        [Fact]
+        public void SwapReservedCrewInSnapshot_MultipleCrewInSamePart_SwapsOnlyMatches()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            var part = snapshot.AddNode("PART");
+            part.AddValue("crew", "Jebediah Kerman");
+            part.AddValue("crew", "Bill Kerman");
+            part.AddValue("crew", "Bob Kerman");
+            var replacements = new Dictionary<string, string>
+            {
+                { "Jebediah Kerman", "Kirrim Kerman" },
+                { "Bob Kerman", "Agasel Kerman" }
+            };
+
+            int result = CrewReservationManager.SwapReservedCrewInSnapshot(snapshot, replacements);
+
+            Assert.Equal(2, result);
+            var crew = CrewReservationManager.ExtractCrewFromSnapshot(snapshot);
+            Assert.Equal(3, crew.Count);
+            Assert.Equal("Kirrim Kerman", crew[0]);
+            Assert.Equal("Bill Kerman", crew[1]);
+            Assert.Equal("Agasel Kerman", crew[2]);
+        }
+
+        [Fact]
+        public void SwapReservedCrewInSnapshot_MultiplePartsWithCrew_SwapsAcrossParts()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            var pod = snapshot.AddNode("PART");
+            pod.AddValue("crew", "Jebediah Kerman");
+            var lab = snapshot.AddNode("PART");
+            lab.AddValue("crew", "Valentina Kerman");
+            lab.AddValue("crew", "Bill Kerman");
+            var replacements = new Dictionary<string, string>
+            {
+                { "Jebediah Kerman", "Kirrim Kerman" },
+                { "Valentina Kerman", "Agasel Kerman" }
+            };
+
+            int result = CrewReservationManager.SwapReservedCrewInSnapshot(snapshot, replacements);
+
+            Assert.Equal(2, result);
+            var crew = CrewReservationManager.ExtractCrewFromSnapshot(snapshot);
+            Assert.Equal(3, crew.Count);
+            Assert.Equal("Kirrim Kerman", crew[0]);
+            Assert.Equal("Agasel Kerman", crew[1]);
+            Assert.Equal("Bill Kerman", crew[2]);
+        }
+
+        [Fact]
+        public void SwapReservedCrewInSnapshot_AllCrewSwapped_ReturnsCorrectCount()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            var part = snapshot.AddNode("PART");
+            part.AddValue("crew", "Jebediah Kerman");
+            part.AddValue("crew", "Valentina Kerman");
+            var replacements = new Dictionary<string, string>
+            {
+                { "Jebediah Kerman", "Kirrim Kerman" },
+                { "Valentina Kerman", "Agasel Kerman" }
+            };
+
+            int result = CrewReservationManager.SwapReservedCrewInSnapshot(snapshot, replacements);
+
+            Assert.Equal(2, result);
+            var crew = CrewReservationManager.ExtractCrewFromSnapshot(snapshot);
+            Assert.Equal(2, crew.Count);
+            Assert.Equal("Kirrim Kerman", crew[0]);
+            Assert.Equal("Agasel Kerman", crew[1]);
+        }
+
+        #endregion
+
+        #region SwapReservedCrewInSnapshot — order preservation
+
+        [Fact]
+        public void SwapReservedCrewInSnapshot_PreservesCrewOrder()
+        {
+            // Verify that non-swapped crew retain their original order
+            var snapshot = new ConfigNode("VESSEL");
+            var part = snapshot.AddNode("PART");
+            part.AddValue("crew", "Alice");
+            part.AddValue("crew", "Bob");
+            part.AddValue("crew", "Charlie");
+            part.AddValue("crew", "Dave");
+            var replacements = new Dictionary<string, string>
+            {
+                { "Bob", "Xavier" },
+                { "Dave", "Zara" }
+            };
+
+            CrewReservationManager.SwapReservedCrewInSnapshot(snapshot, replacements);
+
+            var crew = CrewReservationManager.ExtractCrewFromSnapshot(snapshot);
+            Assert.Equal(4, crew.Count);
+            Assert.Equal("Alice", crew[0]);
+            Assert.Equal("Xavier", crew[1]);
+            Assert.Equal("Charlie", crew[2]);
+            Assert.Equal("Zara", crew[3]);
+        }
+
+        #endregion
+
+        #region SwapReservedCrewInSnapshot — empty snapshot edge case
+
+        [Fact]
+        public void SwapReservedCrewInSnapshot_EmptySnapshot_ReturnsZero()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            var replacements = new Dictionary<string, string>
+            {
+                { "Jebediah Kerman", "Kirrim Kerman" }
+            };
+
+            int result = CrewReservationManager.SwapReservedCrewInSnapshot(snapshot, replacements);
+
+            Assert.Equal(0, result);
+        }
+
+        [Fact]
+        public void SwapReservedCrewInSnapshot_MixedPartsCrewAndNoCrew_OnlySwapsCrewedParts()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            snapshot.AddNode("PART"); // engine — no crew
+            var pod = snapshot.AddNode("PART");
+            pod.AddValue("crew", "Jebediah Kerman");
+            snapshot.AddNode("PART"); // tank — no crew
+            var replacements = new Dictionary<string, string>
+            {
+                { "Jebediah Kerman", "Kirrim Kerman" }
+            };
+
+            int result = CrewReservationManager.SwapReservedCrewInSnapshot(snapshot, replacements);
+
+            Assert.Equal(1, result);
+            var crew = CrewReservationManager.ExtractCrewFromSnapshot(snapshot);
+            Assert.Single(crew);
+            Assert.Equal("Kirrim Kerman", crew[0]);
+        }
+
+        #endregion
+    }
+}

--- a/Source/Parsek/CrewReservationManager.cs
+++ b/Source/Parsek/CrewReservationManager.cs
@@ -547,6 +547,54 @@ namespace Parsek
             return crew;
         }
 
+        /// <summary>
+        /// Pure method: swaps reserved crew names in a vessel snapshot ConfigNode,
+        /// replacing each reserved original name with its replacement name.
+        /// Used for KSC spawns where SwapReservedCrewInFlight cannot run
+        /// (no loaded vessel / no flight scene). Bug #167.
+        /// Returns the number of crew names swapped.
+        /// </summary>
+        internal static int SwapReservedCrewInSnapshot(
+            ConfigNode snapshot, IReadOnlyDictionary<string, string> replacements)
+        {
+            if (snapshot == null || replacements == null || replacements.Count == 0)
+                return 0;
+
+            int swapCount = 0;
+
+            foreach (ConfigNode partNode in snapshot.GetNodes("PART"))
+            {
+                string[] crewNames = partNode.GetValues("crew");
+                if (crewNames.Length == 0) continue;
+
+                bool anySwapped = false;
+                var updated = new List<string>(crewNames.Length);
+
+                for (int i = 0; i < crewNames.Length; i++)
+                {
+                    if (replacements.TryGetValue(crewNames[i], out string replacementName))
+                    {
+                        updated.Add(replacementName);
+                        anySwapped = true;
+                        swapCount++;
+                    }
+                    else
+                    {
+                        updated.Add(crewNames[i]);
+                    }
+                }
+
+                if (anySwapped)
+                {
+                    partNode.RemoveValues("crew");
+                    for (int i = 0; i < updated.Count; i++)
+                        partNode.AddValue("crew", updated[i]);
+                }
+            }
+
+            return swapCount;
+        }
+
         #endregion
 
         #region Testing & Serialization

--- a/Source/Parsek/CrewReservationManager.cs
+++ b/Source/Parsek/CrewReservationManager.cs
@@ -561,11 +561,12 @@ namespace Parsek
                 return 0;
 
             int swapCount = 0;
+            int partIndex = 0;
 
             foreach (ConfigNode partNode in snapshot.GetNodes("PART"))
             {
                 string[] crewNames = partNode.GetValues("crew");
-                if (crewNames.Length == 0) continue;
+                if (crewNames.Length == 0) { partIndex++; continue; }
 
                 bool anySwapped = false;
                 var updated = new List<string>(crewNames.Length);
@@ -574,6 +575,8 @@ namespace Parsek
                 {
                     if (replacements.TryGetValue(crewNames[i], out string replacementName))
                     {
+                        ParsekLog.Verbose("CrewReservation",
+                            $"Snapshot swap: '{crewNames[i]}' -> '{replacementName}' in PART[{partIndex}]");
                         updated.Add(replacementName);
                         anySwapped = true;
                         swapCount++;
@@ -590,7 +593,13 @@ namespace Parsek
                     for (int i = 0; i < updated.Count; i++)
                         partNode.AddValue("crew", updated[i]);
                 }
+
+                partIndex++;
             }
+
+            if (swapCount > 0)
+                ParsekLog.Verbose("CrewReservation",
+                    $"Snapshot crew swap complete: {swapCount} name(s) replaced across {partIndex} part(s)");
 
             return swapCount;
         }

--- a/Source/Parsek/ParsekKSC.cs
+++ b/Source/Parsek/ParsekKSC.cs
@@ -790,7 +790,27 @@ namespace Parsek
 
             try
             {
-                uint spawnedPid = VesselSpawner.RespawnVessel(rec.VesselSnapshot);
+                // Bug #167: Apply crew swap on a snapshot copy before spawning.
+                // In KSC scene, SwapReservedCrewInFlight cannot run (no loaded vessel),
+                // so we swap reserved crew names directly in the snapshot.
+                ConfigNode spawnSnapshot = rec.VesselSnapshot;
+                var replacements = CrewReservationManager.CrewReplacements;
+                if (replacements.Count > 0)
+                {
+                    spawnSnapshot = rec.VesselSnapshot.CreateCopy();
+                    int swapped = CrewReservationManager.SwapReservedCrewInSnapshot(
+                        spawnSnapshot, replacements);
+                    if (swapped > 0)
+                        ParsekLog.Info("KSCSpawn",
+                            $"Crew swap applied to snapshot for #{recIdx} \"{rec.VesselName}\": " +
+                            $"{swapped} crew replaced before spawn");
+                    else
+                        ParsekLog.Verbose("KSCSpawn",
+                            $"Crew swap: {replacements.Count} reservation(s) exist but " +
+                            $"no matches in snapshot for #{recIdx} \"{rec.VesselName}\"");
+                }
+
+                uint spawnedPid = VesselSpawner.RespawnVessel(spawnSnapshot);
                 if (spawnedPid != 0)
                 {
                     rec.VesselSpawned = true;

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1946,7 +1946,11 @@ When a vessel is spawned at KSC (via `TrySpawnAtRecordingEnd`), the crew reserva
 
 **Priority:** Medium — spawned vessel has wrong crew
 
-**Status:** Open — swap needs to run at spawn time for KSC spawns, not just flight-ready
+**Root cause:** `SwapReservedCrewInFlight` operates on a loaded `Vessel` (FlightGlobals.ActiveVessel) which does not exist in KSC scene. KSC spawns via `TrySpawnAtRecordingEnd` call `RespawnVessel` directly, which unreserves crew but does not swap them with replacements.
+
+**Fix:** Added `CrewReservationManager.SwapReservedCrewInSnapshot` — a pure static method that replaces reserved crew names with their replacement names directly in the vessel snapshot ConfigNode. `TrySpawnAtRecordingEnd` now creates a snapshot copy, applies the swap, and passes the modified copy to `RespawnVessel`. This ensures KSC-spawned vessels have the correct (replacement) crew regardless of whether the player enters the flight scene.
+
+**Status:** Fixed
 
 ## 159. EVA auto-recordings have no rewind save — R button absent
 


### PR DESCRIPTION
## Summary
- `SwapReservedCrewInFlight` only runs in flight scene — KSC-spawned vessels kept the original (reserved) crew instead of replacements
- Added `CrewReservationManager.SwapReservedCrewInSnapshot` — pure static method that replaces crew names directly in the ConfigNode
- `TrySpawnAtRecordingEnd` now creates a snapshot copy, applies the swap, and passes the modified copy to `RespawnVessel`

## Test plan
- [x] 3569 unit tests pass (12 new crew swap tests)
- [ ] In-game: record EVA → go to KSC → verify spawned vessel has replacement crew (not reserved original)
- [ ] In-game: verify non-EVA KSC spawns still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)