### PR TITLE
Fix EVA spawn position: use trajectory endpoint instead of snapshot start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- **Fix #175: EVA kerbal spawns at recording start position instead of endpoint.** EVA vessel snapshots are captured at EVA start (kerbal on the pod's ladder), but the kerbal walks elsewhere during the recording. On spawn, the snapshot's baked-in lat/lon/alt placed the kerbal on top of the parent vessel, grabbing its ladder and triggering KSP's "Kerbals on a ladder — cannot save" error. `ResolveSpawnPosition` now routes EVA recordings to the trajectory endpoint; `OverrideSnapshotPosition` patches the snapshot before `RespawnVessel`.
 - **Fix #171: Orbital ghost disappears during 50x time warp.** During warp >4x, ghosts with orbital segments are now exempt from zone-based mesh hiding (`ShouldExemptFromZoneHide` in `GhostPlaybackLogic`). Prevents orbital ghosts from completing playback while invisible in the Beyond zone.
 - **Fix #172: Ghost destruction reason logged as "unknown".** `RetryHeldGhostSpawns` now passes per-action reason strings to `DestroyGhost`: `"held-spawn-succeeded"`, `"held-already-spawned"`, `"held-spawn-timeout"`, `"held-invalid-index"`.
 - **Fix #173: Zero-point debris leaf recordings saved from same-frame destruction.** Added `PruneZeroPointLeaves` step in `FinalizeTreeRecordings` — removes leaf recordings with zero trajectory points, no orbit segments, and no surface position. Prevents `.prec` sidecar files and tree nodes for instantly-destroyed debris.

--- a/Source/Parsek.Tests/SpawnSafetyNetTests.cs
+++ b/Source/Parsek.Tests/SpawnSafetyNetTests.cs
@@ -741,5 +741,101 @@ namespace Parsek.Tests
         }
 
         #endregion
+
+        #region OverrideSnapshotPosition (EVA spawn fix)
+
+        [Fact]
+        public void OverrideSnapshotPosition_UpdatesLatLonAlt()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            snapshot.AddValue("lat", "1.0");
+            snapshot.AddValue("lon", "2.0");
+            snapshot.AddValue("alt", "3.0");
+
+            VesselSpawner.OverrideSnapshotPosition(snapshot, 10.5, 20.5, 30.5, 0, "Test");
+
+            Assert.Equal("10.5", snapshot.GetValue("lat"));
+            Assert.Equal("20.5", snapshot.GetValue("lon"));
+            Assert.Equal("30.5", snapshot.GetValue("alt"));
+        }
+
+        [Fact]
+        public void OverrideSnapshotPosition_CreatesValuesWhenMissing()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+
+            VesselSpawner.OverrideSnapshotPosition(snapshot, 10.5, 20.5, 30.5, 0, "Test");
+
+            Assert.Equal("10.5", snapshot.GetValue("lat"));
+            Assert.Equal("20.5", snapshot.GetValue("lon"));
+            Assert.Equal("30.5", snapshot.GetValue("alt"));
+        }
+
+        [Fact]
+        public void OverrideSnapshotPosition_NullSnapshot_NoThrow()
+        {
+            VesselSpawner.OverrideSnapshotPosition(null, 10.5, 20.5, 30.5, 0, "Test");
+            // No exception = pass
+        }
+
+        [Fact]
+        public void OverrideSnapshotPosition_LogsOverride()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            snapshot.AddValue("lat", "1.0");
+            snapshot.AddValue("lon", "2.0");
+            snapshot.AddValue("alt", "3.0");
+
+            VesselSpawner.OverrideSnapshotPosition(snapshot, 10.5, 20.5, 30.5, 7, "Jeb");
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[Spawner]") && l.Contains("EVA spawn position override") && l.Contains("Jeb"));
+        }
+
+        [Fact]
+        public void ResolveSpawnPosition_EvaVessel_UsesTrajectoryEndpoint()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            snapshot.AddValue("lat", "1.0");
+            snapshot.AddValue("lon", "2.0");
+            snapshot.AddValue("alt", "3.0");
+
+            var rec = new Recording
+            {
+                VesselSnapshot = snapshot,
+                EvaCrewName = "Jebediah Kerman"
+            };
+
+            var lastPt = new TrajectoryPoint { latitude = 10.0, longitude = 20.0, altitude = 30.0 };
+            VesselSpawner.ResolveSpawnPosition(rec, 0, lastPt, out double lat, out double lon, out double alt);
+
+            Assert.Equal(10.0, lat);
+            Assert.Equal(20.0, lon);
+            Assert.Equal(30.0, alt);
+        }
+
+        [Fact]
+        public void ResolveSpawnPosition_NonEvaVessel_UsesSnapshotPosition()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            snapshot.AddValue("lat", "1.0");
+            snapshot.AddValue("lon", "2.0");
+            snapshot.AddValue("alt", "3.0");
+
+            var rec = new Recording
+            {
+                VesselSnapshot = snapshot,
+                EvaCrewName = null
+            };
+
+            var lastPt = new TrajectoryPoint { latitude = 10.0, longitude = 20.0, altitude = 30.0 };
+            VesselSpawner.ResolveSpawnPosition(rec, 0, lastPt, out double lat, out double lon, out double alt);
+
+            Assert.Equal(1.0, lat);
+            Assert.Equal(2.0, lon);
+            Assert.Equal(3.0, alt);
+        }
+
+        #endregion
     }
 }

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -786,7 +786,7 @@ namespace Parsek
                     int prelaunchStripped = StripFuturePrelaunchVessels(fs.protoVessels, quicksavePids);
                     if (prelaunchStripped > 0)
                         ParsekLog.Info("Rewind",
-                            $"Stripped {prelaunchStripped} future PRELAUNCH vessel(s)");
+                            $"Stripped {prelaunchStripped} future vessel(s) not in quicksave whitelist");
                 }
                 RecordingStore.RewindQuicksaveVesselPids = null;
             }

--- a/Source/Parsek/VesselSpawner.cs
+++ b/Source/Parsek/VesselSpawner.cs
@@ -308,6 +308,17 @@ namespace Parsek
             // Reset collision block counter on successful spawn path
             rec.CollisionBlockCount = 0;
 
+            // EVA spawn position fix: update the snapshot's lat/lon/alt to the recording
+            // endpoint. The snapshot was captured at EVA start (kerbal on the pod's ladder),
+            // but the kerbal walked to a different location during the recording. Without
+            // this override, the kerbal spawns on top of the parent vessel and grabs its
+            // ladder, triggering KSP's "Kerbals on a ladder — cannot save" error.
+            if (isEva && rec.VesselSnapshot != null)
+            {
+                OverrideSnapshotPosition(rec.VesselSnapshot, spawnLat, spawnLon, spawnAlt,
+                    index, rec.VesselName);
+            }
+
             // Dead crew guard: if ALL crew in the snapshot are dead, abandon spawn.
             // Spawning a crewless command pod is worse than not spawning at all. (#170)
             // Individual dead crew are already removed by RespawnVessel.RemoveDeadCrewFromSnapshot;
@@ -346,13 +357,27 @@ namespace Parsek
         }
 
         /// <summary>
-        /// Resolve spawn position from vessel snapshot lat/lon/alt, falling back to
-        /// trajectory endpoint if snapshot lacks position data (#127).
+        /// Resolve spawn position. EVA vessels always use the trajectory endpoint
+        /// (the snapshot position is from EVA start, not where the kerbal walked to).
+        /// Non-EVA vessels use the snapshot lat/lon/alt, falling back to the trajectory
+        /// endpoint if snapshot lacks position data (#127).
         /// </summary>
-        private static void ResolveSpawnPosition(Recording rec, int index,
+        internal static void ResolveSpawnPosition(Recording rec, int index,
             TrajectoryPoint lastPt, out double lat, out double lon, out double alt)
         {
             lat = 0; lon = 0; alt = 0;
+
+            // EVA vessels: always use trajectory endpoint. The snapshot position is from
+            // EVA start (kerbal on the pod's ladder), not where they ended up.
+            bool isEva = !string.IsNullOrEmpty(rec.EvaCrewName);
+            if (isEva)
+            {
+                lat = lastPt.latitude;
+                lon = lastPt.longitude;
+                alt = lastPt.altitude;
+                return;
+            }
+
             bool hasSnapshotPos = TryGetSnapshotDouble(rec.VesselSnapshot, "lat", out lat)
                                && TryGetSnapshotDouble(rec.VesselSnapshot, "lon", out lon)
                                && TryGetSnapshotDouble(rec.VesselSnapshot, "alt", out alt);
@@ -733,6 +758,33 @@ namespace Parsek
                 $"Corrected unsafe snapshot situation: {currentSit} -> {corrected} " +
                 $"(terminal={terminalState}) — prevents on-rails pressure destruction (#169)");
             return true;
+        }
+
+        /// <summary>
+        /// Overrides the snapshot's lat/lon/alt with the given endpoint coordinates.
+        /// Used for EVA vessels whose snapshot was captured at EVA start (on the pod's
+        /// ladder) but need to spawn at the recording endpoint (where the kerbal walked to).
+        /// Modifies the snapshot in-place.
+        /// </summary>
+        internal static void OverrideSnapshotPosition(ConfigNode snapshot,
+            double lat, double lon, double alt, int index, string vesselName)
+        {
+            if (snapshot == null) return;
+
+            string oldLat = snapshot.GetValue("lat") ?? "?";
+            string oldLon = snapshot.GetValue("lon") ?? "?";
+
+            string newLat = lat.ToString("R", CultureInfo.InvariantCulture);
+            string newLon = lon.ToString("R", CultureInfo.InvariantCulture);
+            string newAlt = alt.ToString("R", CultureInfo.InvariantCulture);
+
+            snapshot.SetValue("lat", newLat, true);
+            snapshot.SetValue("lon", newLon, true);
+            snapshot.SetValue("alt", newAlt, true);
+
+            ParsekLog.Info("Spawner",
+                $"EVA spawn position override for #{index} ({vesselName}): " +
+                $"({oldLat},{oldLon}) → ({newLat},{newLon}) alt={newAlt}");
         }
 
         /// <summary>

--- a/Source/Parsek/VesselSpawner.cs
+++ b/Source/Parsek/VesselSpawner.cs
@@ -358,7 +358,7 @@ namespace Parsek
 
         /// <summary>
         /// Resolve spawn position. EVA vessels always use the trajectory endpoint
-        /// (the snapshot position is from EVA start, not where the kerbal walked to).
+        /// (the snapshot position is from EVA start, not where the kerbal walked to — #175).
         /// Non-EVA vessels use the snapshot lat/lon/alt, falling back to the trajectory
         /// endpoint if snapshot lacks position data (#127).
         /// </summary>
@@ -367,14 +367,16 @@ namespace Parsek
         {
             lat = 0; lon = 0; alt = 0;
 
-            // EVA vessels: always use trajectory endpoint. The snapshot position is from
-            // EVA start (kerbal on the pod's ladder), not where they ended up.
+            // EVA vessels: always use trajectory endpoint (#175). The snapshot position is
+            // from EVA start (kerbal on the pod's ladder), not where they ended up.
             bool isEva = !string.IsNullOrEmpty(rec.EvaCrewName);
             if (isEva)
             {
                 lat = lastPt.latitude;
                 lon = lastPt.longitude;
                 alt = lastPt.altitude;
+                ParsekLog.Verbose("Spawner",
+                    $"EVA spawn #{index} ({rec.VesselName}): using trajectory endpoint for position");
                 return;
             }
 
@@ -773,6 +775,7 @@ namespace Parsek
 
             string oldLat = snapshot.GetValue("lat") ?? "?";
             string oldLon = snapshot.GetValue("lon") ?? "?";
+            string oldAlt = snapshot.GetValue("alt") ?? "?";
 
             string newLat = lat.ToString("R", CultureInfo.InvariantCulture);
             string newLon = lon.ToString("R", CultureInfo.InvariantCulture);
@@ -784,7 +787,7 @@ namespace Parsek
 
             ParsekLog.Info("Spawner",
                 $"EVA spawn position override for #{index} ({vesselName}): " +
-                $"({oldLat},{oldLon}) → ({newLat},{newLon}) alt={newAlt}");
+                $"({oldLat},{oldLon},{oldAlt}) → ({newLat},{newLon},{newAlt})");
         }
 
         /// <summary>

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -2102,6 +2102,22 @@ When a breakup creates debris fragments that are destroyed within the same physi
 
 **Status:** Fixed
 
+## ~~175. EVA kerbal spawns at recording start position instead of endpoint~~
+
+When an EVA recording completes and Parsek spawns the real kerbal, the kerbal appears at the snapshot's lat/lon/alt (captured at EVA start, MET=0.04s — kerbal still on the pod's ladder) instead of the trajectory endpoint (where they walked to). This places the kerbal on top of the parent vessel, causing it to grab the parent's ladder. KSP then blocks all saves with "There are Kerbals on a ladder. Cannot save."
+
+**Root cause:** `SpawnOrRecoverIfTooClose` calls `RespawnVessel(rec.VesselSnapshot)` which uses the snapshot's baked-in position. For non-EVA landed vessels the snapshot position equals the endpoint (vessel doesn't move), but for EVA kerbals the snapshot position is where they EVA'd from, not where they walked to.
+
+**Fix:** Two changes:
+1. `ResolveSpawnPosition` now routes EVA recordings (non-null `EvaCrewName`) to the trajectory endpoint unconditionally, bypassing the snapshot position.
+2. `OverrideSnapshotPosition` patches the snapshot's lat/lon/alt to the resolved endpoint before `RespawnVessel`, so the `ProtoVessel` constructor reads the correct coordinates.
+
+6 unit tests.
+
+**Files:** `VesselSpawner.cs`, `SpawnSafetyNetTests.cs`
+
+**Status:** Fixed
+
 # In-Game Tests
 
 - [x] Vessels propagate naturally along orbits after FF (no position freezing)


### PR DESCRIPTION
## Summary
- **EVA kerbal spawns at recording endpoint** instead of snapshot start position. The snapshot was captured at EVA start (kerbal on the pod's ladder), placing the kerbal on top of the parent vessel on spawn. This caused the kerbal to grab the parent vessel's ladder, triggering KSP's "Kerbals on a ladder — cannot save" error.
- **`ResolveSpawnPosition`** now routes EVA recordings to the trajectory endpoint unconditionally; `OverrideSnapshotPosition` patches the snapshot lat/lon/alt before `RespawnVessel`.
- **Log message fix**: `StripFuturePrelaunchVessels` log corrected from "future PRELAUNCH vessel(s)" to "future vessel(s) not in quicksave whitelist" (code was expanded by #164 but log was stale).

## Test plan
- [x] 3835 tests pass (6 new: `OverrideSnapshotPosition` value update, missing values, null safety, log assertion; `ResolveSpawnPosition` EVA vs non-EVA path)
- [x] Build succeeds
- [x] Reviewed by clean opus agent — locale bug in log message caught and fixed
- [ ] In-game: launch vessel with EVA recording, time warp past completion, verify EVA kerbal spawns at walked-to position (not on parent vessel's ladder)
- [ ] In-game: verify no "Kerbals on a ladder" save error after EVA spawn

🤖 Generated with [Claude Code](https://claude.com/claude-code)