### PR TITLE
Add group columns and sorted interleaving in recordings window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ All notable changes to Parsek are documented here.
 - **T98: Loop range fields.** New `LoopStartUT`/`LoopEndUT` fields on Recording narrow the loop range. Engine (`TryComputeLoopPlaybackUT`, `ShouldLoopPlayback`), save/load (both paths), and `CanAutoMerge` updated. Backward compatible (NaN defaults = existing behavior).
 - **T98: Policy modularity refactor.** Migrated scattered `TreeId != null` / `ChainId != null` policy checks to `IsTreeRecording` / `IsChainRecording` / `ManagesOwnResources` query properties. Extracted `ClassifyVesselDestruction` and `ShouldSuppressBoundarySplit` as testable static methods.
 
+- **Group header columns in recordings window.** Groups now display Launch (earliest member StartUT), Duration (sum of member durations), and Status (closest active T- countdown) columns. Groups participate in column-based sorting alongside chains and standalone recordings instead of always rendering first. Six `internal static` helpers extracted for testability with 27 unit tests.
+- **Fix #176: Group hide checkbox misaligned when expanded stats visible.** Group rows were missing spacers for the MaxAlt/MaxSpd/Dist/Pts columns, causing the trailing Hide checkbox to shift out of alignment when the Stats panel was open.
+
 ### Bug Fixes
 
 - **Fix #175: EVA kerbal spawns at recording start position instead of endpoint.** EVA vessel snapshots are captured at EVA start (kerbal on the pod's ladder), but the kerbal walks elsewhere during the recording. On spawn, the snapshot's baked-in lat/lon/alt placed the kerbal on top of the parent vessel, grabbing its ladder and triggering KSP's "Kerbals on a ladder — cannot save" error. `ResolveSpawnPosition` now routes EVA recordings to the trajectory endpoint; `OverrideSnapshotPosition` patches the snapshot before `RespawnVessel`.

--- a/Source/Parsek.Tests/GroupAggregateTests.cs
+++ b/Source/Parsek.Tests/GroupAggregateTests.cs
@@ -1,0 +1,371 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Tests for group aggregate methods: GetGroupEarliestStartUT, GetGroupTotalDuration,
+    /// GetGroupStatus, GetGroupSortKey, GetRecordingSortKey, GetChainSortKey.
+    /// </summary>
+    [Collection("Sequential")]
+    public class GroupAggregateTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public GroupAggregateTests()
+        {
+            RecordingStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+            MilestoneStore.SuppressLogging = true;
+            MilestoneStore.ResetForTesting();
+            GameStateStore.SuppressLogging = true;
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+            GroupHierarchyStore.ResetGroupsForTesting();
+            CrewReservationManager.ResetReplacementsForTesting();
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+            RecordingStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+            MilestoneStore.ResetForTesting();
+            GroupHierarchyStore.ResetGroupsForTesting();
+            CrewReservationManager.ResetReplacementsForTesting();
+        }
+
+        private static Recording MakeRec(double startUT, double endUT, string name = "Test")
+        {
+            var rec = new Recording
+            {
+                VesselName = name,
+            };
+            // StartUT/EndUT derived from Points[0].ut and Points[last].ut
+            rec.Points.Add(new TrajectoryPoint { ut = startUT });
+            if (endUT > startUT)
+                rec.Points.Add(new TrajectoryPoint { ut = endUT });
+            return rec;
+        }
+
+        // ── GetGroupEarliestStartUT ──
+
+        [Fact]
+        public void EarliestStartUT_EmptyDescendants_ReturnsMaxValue()
+        {
+            var descendants = new HashSet<int>();
+            var committed = new List<Recording>();
+            double result = ParsekUI.GetGroupEarliestStartUT(descendants, committed);
+            Assert.Equal(double.MaxValue, result);
+        }
+
+        [Fact]
+        public void EarliestStartUT_SingleRecording_ReturnsItsStartUT()
+        {
+            var committed = new List<Recording> { MakeRec(100, 200) };
+            var descendants = new HashSet<int> { 0 };
+            double result = ParsekUI.GetGroupEarliestStartUT(descendants, committed);
+            Assert.Equal(100, result);
+        }
+
+        [Fact]
+        public void EarliestStartUT_MultipleRecordings_ReturnsEarliest()
+        {
+            var committed = new List<Recording>
+            {
+                MakeRec(300, 400),
+                MakeRec(100, 200),
+                MakeRec(200, 300)
+            };
+            var descendants = new HashSet<int> { 0, 1, 2 };
+            double result = ParsekUI.GetGroupEarliestStartUT(descendants, committed);
+            Assert.Equal(100, result);
+        }
+
+        // ── GetGroupTotalDuration ──
+
+        [Fact]
+        public void TotalDuration_EmptyDescendants_ReturnsZero()
+        {
+            var descendants = new HashSet<int>();
+            var committed = new List<Recording>();
+            double result = ParsekUI.GetGroupTotalDuration(descendants, committed);
+            Assert.Equal(0, result);
+        }
+
+        [Fact]
+        public void TotalDuration_SumsDurations()
+        {
+            var committed = new List<Recording>
+            {
+                MakeRec(100, 150),  // 50s
+                MakeRec(200, 280),  // 80s
+                MakeRec(300, 310)   // 10s
+            };
+            var descendants = new HashSet<int> { 0, 1, 2 };
+            double result = ParsekUI.GetGroupTotalDuration(descendants, committed);
+            Assert.Equal(140, result);
+        }
+
+        [Fact]
+        public void TotalDuration_SkipsNegativeDurations()
+        {
+            var committed = new List<Recording>
+            {
+                MakeRec(100, 50),   // -50s, skipped
+                MakeRec(200, 300)   // 100s
+            };
+            var descendants = new HashSet<int> { 0, 1 };
+            double result = ParsekUI.GetGroupTotalDuration(descendants, committed);
+            Assert.Equal(100, result);
+        }
+
+        // ── GetGroupStatus ──
+
+        [Fact]
+        public void GroupStatus_EmptyDescendants_ReturnsDash()
+        {
+            var descendants = new HashSet<int>();
+            var committed = new List<Recording>();
+            string text;
+            int order;
+            ParsekUI.GetGroupStatus(descendants, committed, 500, out text, out order);
+            Assert.Equal("-", text);
+            Assert.Equal(2, order);
+        }
+
+        [Fact]
+        public void GroupStatus_AllFuture_ReturnsClosestFuture()
+        {
+            var committed = new List<Recording>
+            {
+                MakeRec(1000, 1100),
+                MakeRec(800, 900)
+            };
+            var descendants = new HashSet<int> { 0, 1 };
+            string text;
+            int order;
+            ParsekUI.GetGroupStatus(descendants, committed, 500, out text, out order);
+            Assert.Equal(0, order); // future
+            // Should show countdown for the closer future recording (800)
+            Assert.Contains("T-", text);
+        }
+
+        [Fact]
+        public void GroupStatus_ActivePreferredOverFuture()
+        {
+            var committed = new List<Recording>
+            {
+                MakeRec(400, 600),  // active at now=500
+                MakeRec(800, 900)   // future
+            };
+            var descendants = new HashSet<int> { 0, 1 };
+            string text;
+            int order;
+            ParsekUI.GetGroupStatus(descendants, committed, 500, out text, out order);
+            Assert.Equal(1, order); // active
+            Assert.Contains("T+", text); // T+ since now > StartUT
+        }
+
+        [Fact]
+        public void GroupStatus_MultipleActive_ReturnsClosestToNow()
+        {
+            var committed = new List<Recording>
+            {
+                MakeRec(300, 600),  // active, delta from StartUT = 200
+                MakeRec(490, 600)   // active, delta from StartUT = 10 (closer)
+            };
+            var descendants = new HashSet<int> { 0, 1 };
+            string text;
+            int order;
+            ParsekUI.GetGroupStatus(descendants, committed, 500, out text, out order);
+            Assert.Equal(1, order); // active
+        }
+
+        [Fact]
+        public void GroupStatus_AllPast_ReturnsPast()
+        {
+            var committed = new List<Recording>
+            {
+                MakeRec(100, 200),
+                MakeRec(300, 400)
+            };
+            var descendants = new HashSet<int> { 0, 1 };
+            string text;
+            int order;
+            ParsekUI.GetGroupStatus(descendants, committed, 500, out text, out order);
+            Assert.Equal(2, order);
+            Assert.Equal("past", text);
+        }
+
+        // ── GetRecordingSortKey ──
+
+        [Fact]
+        public void RecordingSortKey_LaunchTime_ReturnsStartUT()
+        {
+            var rec = MakeRec(150, 300);
+            double key = ParsekUI.GetRecordingSortKey(rec, ParsekUI.SortColumn.LaunchTime, 0, 5);
+            Assert.Equal(150, key);
+        }
+
+        [Fact]
+        public void RecordingSortKey_Duration_ReturnsDuration()
+        {
+            var rec = MakeRec(100, 250);
+            double key = ParsekUI.GetRecordingSortKey(rec, ParsekUI.SortColumn.Duration, 0, 5);
+            Assert.Equal(150, key);
+        }
+
+        [Fact]
+        public void RecordingSortKey_Status_ReturnsStatusOrder()
+        {
+            var rec = MakeRec(100, 200);
+            double key = ParsekUI.GetRecordingSortKey(rec, ParsekUI.SortColumn.Status, 150, 5);
+            Assert.Equal(1, key); // active
+        }
+
+        [Fact]
+        public void RecordingSortKey_Index_ReturnsRowFallback()
+        {
+            var rec = MakeRec(100, 200);
+            double key = ParsekUI.GetRecordingSortKey(rec, ParsekUI.SortColumn.Index, 0, 7);
+            Assert.Equal(7, key);
+        }
+
+        // ── GetChainSortKey ──
+
+        [Fact]
+        public void ChainSortKey_LaunchTime_ReturnsEarliest()
+        {
+            var committed = new List<Recording>
+            {
+                MakeRec(300, 400),
+                MakeRec(100, 200),
+                MakeRec(200, 300)
+            };
+            var members = new List<int> { 0, 1, 2 };
+            double key = ParsekUI.GetChainSortKey(members, committed,
+                ParsekUI.SortColumn.LaunchTime, 0);
+            Assert.Equal(100, key);
+        }
+
+        [Fact]
+        public void ChainSortKey_Duration_ReturnsTotalDuration()
+        {
+            var committed = new List<Recording>
+            {
+                MakeRec(100, 150),  // 50s
+                MakeRec(200, 300)   // 100s
+            };
+            var members = new List<int> { 0, 1 };
+            double key = ParsekUI.GetChainSortKey(members, committed,
+                ParsekUI.SortColumn.Duration, 0);
+            Assert.Equal(150, key);
+        }
+
+        [Fact]
+        public void ChainSortKey_Status_ReturnsBestStatus()
+        {
+            var committed = new List<Recording>
+            {
+                MakeRec(100, 200),  // past at now=500
+                MakeRec(400, 600)   // active at now=500
+            };
+            var members = new List<int> { 0, 1 };
+            double key = ParsekUI.GetChainSortKey(members, committed,
+                ParsekUI.SortColumn.Status, 500);
+            Assert.Equal(1, key); // active is best
+        }
+
+        // ── GetGroupSortKey ──
+
+        [Fact]
+        public void GroupSortKey_EmptyDescendants_ReturnsMaxValue()
+        {
+            var descendants = new HashSet<int>();
+            var committed = new List<Recording>();
+            double key = ParsekUI.GetGroupSortKey(descendants, committed,
+                ParsekUI.SortColumn.LaunchTime, 0);
+            Assert.Equal(double.MaxValue, key);
+        }
+
+        [Fact]
+        public void GroupSortKey_LaunchTime_ReturnsEarliestStartUT()
+        {
+            var committed = new List<Recording>
+            {
+                MakeRec(300, 400),
+                MakeRec(100, 200)
+            };
+            var descendants = new HashSet<int> { 0, 1 };
+            double key = ParsekUI.GetGroupSortKey(descendants, committed,
+                ParsekUI.SortColumn.LaunchTime, 0);
+            Assert.Equal(100, key);
+        }
+
+        [Fact]
+        public void GroupSortKey_Duration_ReturnsTotalDuration()
+        {
+            var committed = new List<Recording>
+            {
+                MakeRec(100, 150),
+                MakeRec(200, 350)
+            };
+            var descendants = new HashSet<int> { 0, 1 };
+            double key = ParsekUI.GetGroupSortKey(descendants, committed,
+                ParsekUI.SortColumn.Duration, 0);
+            Assert.Equal(200, key); // 50 + 150
+        }
+
+        [Fact]
+        public void GroupSortKey_Status_ReturnsStatusOrder()
+        {
+            var committed = new List<Recording>
+            {
+                MakeRec(100, 200),  // past at now=500
+                MakeRec(400, 600)   // active at now=500
+            };
+            var descendants = new HashSet<int> { 0, 1 };
+            double key = ParsekUI.GetGroupSortKey(descendants, committed,
+                ParsekUI.SortColumn.Status, 500);
+            Assert.Equal(1, key); // active
+        }
+
+        [Fact]
+        public void GroupStatus_ActiveAndPast_NoFuture_ReturnsActive()
+        {
+            var committed = new List<Recording>
+            {
+                MakeRec(100, 200),  // past at now=500
+                MakeRec(400, 600)   // active at now=500
+            };
+            var descendants = new HashSet<int> { 0, 1 };
+            string text;
+            int order;
+            ParsekUI.GetGroupStatus(descendants, committed, 500, out text, out order);
+            Assert.Equal(1, order); // active wins over past
+        }
+
+        [Fact]
+        public void ChainSortKey_EmptyMembers_ReturnsDefaults()
+        {
+            var committed = new List<Recording>();
+            var members = new List<int>();
+
+            double launchKey = ParsekUI.GetChainSortKey(members, committed,
+                ParsekUI.SortColumn.LaunchTime, 0);
+            Assert.Equal(double.MaxValue, launchKey);
+
+            double durKey = ParsekUI.GetChainSortKey(members, committed,
+                ParsekUI.SortColumn.Duration, 0);
+            Assert.Equal(0, durKey);
+
+            double statusKey = ParsekUI.GetChainSortKey(members, committed,
+                ParsekUI.SortColumn.Status, 0);
+            Assert.Equal(2, statusKey); // past (default)
+        }
+    }
+}

--- a/Source/Parsek.Tests/GroupAggregateTests.cs
+++ b/Source/Parsek.Tests/GroupAggregateTests.cs
@@ -111,11 +111,13 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void TotalDuration_SkipsNegativeDurations()
+        public void TotalDuration_SkipsZeroDurationRecordings()
         {
+            // MakeRec(100, 50) produces a single-point recording (endUT <= startUT),
+            // so StartUT == EndUT == 100, giving duration 0 which is excluded.
             var committed = new List<Recording>
             {
-                MakeRec(100, 50),   // -50s, skipped
+                MakeRec(100, 50),   // 0s (single point), skipped
                 MakeRec(200, 300)   // 100s
             };
             var descendants = new HashSet<int> { 0, 1 };
@@ -366,6 +368,39 @@ namespace Parsek.Tests
             double statusKey = ParsekUI.GetChainSortKey(members, committed,
                 ParsekUI.SortColumn.Status, 0);
             Assert.Equal(2, statusKey); // past (default)
+        }
+
+        // ── Name sort key (string path) ──
+
+        [Fact]
+        public void GroupSortKey_Name_ReturnsZero()
+        {
+            // For Name sort, the numeric key is unused (string comparison is used instead).
+            // GetGroupSortKey returns 0 for Name column.
+            var committed = new List<Recording> { MakeRec(100, 200) };
+            var descendants = new HashSet<int> { 0 };
+            double key = ParsekUI.GetGroupSortKey(descendants, committed,
+                ParsekUI.SortColumn.Name, 0);
+            Assert.Equal(0, key);
+        }
+
+        [Fact]
+        public void RecordingSortKey_Name_ReturnsRowFallback()
+        {
+            // For Name/Phase, numeric key falls back to row position
+            var rec = MakeRec(100, 200, "Zulu");
+            double key = ParsekUI.GetRecordingSortKey(rec, ParsekUI.SortColumn.Name, 0, 3);
+            Assert.Equal(3, key); // row fallback
+        }
+
+        [Fact]
+        public void ChainSortKey_Name_ReturnsZero()
+        {
+            var committed = new List<Recording> { MakeRec(100, 200) };
+            var members = new List<int> { 0 };
+            double key = ParsekUI.GetChainSortKey(members, committed,
+                ParsekUI.SortColumn.Name, 0);
+            Assert.Equal(0, key);
         }
     }
 }

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -125,6 +125,21 @@ namespace Parsek
         internal enum SortColumn { Index, Phase, Name, LaunchTime, Duration, Status }
         private SortColumn sortColumn = SortColumn.Index;
         private bool sortAscending = true;
+
+        // Root-level draw item for unified sorting of groups, chains, and standalone recordings
+        private const int RootItem_Group = 0;
+        private const int RootItem_Chain = 1;
+        private const int RootItem_Recording = 2;
+
+        private struct RootDrawItem
+        {
+            public double SortKey;
+            public string SortName;
+            public int ItemType;       // RootItem_Group / RootItem_Chain / RootItem_Recording
+            public string GroupName;   // for groups
+            public string ChainId;     // for chains
+            public int RecIdx;         // for standalone recordings
+        }
         private int[] sortedIndices; // maps display row → CommittedRecordings index
         private int lastSortedCount = -1;
 
@@ -1154,37 +1169,91 @@ namespace Parsek
                     out grpToRecs, out chainToRecs, out grpChildren,
                     out rootGrps, out rootChainIds);
 
+                // ── Build unified sorted root items ──────────────────────
+                var rootItems = new List<RootDrawItem>();
+
+                // Add root groups
+                for (int g = 0; g < rootGrps.Count; g++)
+                {
+                    var desc = new HashSet<int>();
+                    CollectDescendantRecordings(rootGrps[g], grpToRecs, grpChildren, desc);
+                    rootItems.Add(new RootDrawItem
+                    {
+                        SortKey = GetGroupSortKey(desc, committed, sortColumn, now),
+                        SortName = rootGrps[g],
+                        ItemType = RootItem_Group,
+                        GroupName = rootGrps[g],
+                        RecIdx = -1
+                    });
+                }
+
+                // Add root chains and standalone recordings from sortedIndices
+                var seenChains = new HashSet<string>();
+                for (int row = 0; row < sortedIndices.Length; row++)
+                {
+                    int ri = sortedIndices[row];
+                    var rec = committed[ri];
+                    // Skip recordings that belong to groups (drawn inside group trees)
+                    if (rec.RecordingGroups != null && rec.RecordingGroups.Count > 0) continue;
+
+                    if (!string.IsNullOrEmpty(rec.ChainId) && rootChainIds.Contains(rec.ChainId))
+                    {
+                        if (!seenChains.Add(rec.ChainId)) continue;
+                        var members = chainToRecs[rec.ChainId];
+                        rootItems.Add(new RootDrawItem
+                        {
+                            SortKey = GetChainSortKey(members, committed, sortColumn, now),
+                            SortName = members.Count > 0 ? committed[members[0]].VesselName : "",
+                            ItemType = RootItem_Chain,
+                            ChainId = rec.ChainId,
+                            RecIdx = -1
+                        });
+                    }
+                    else if (string.IsNullOrEmpty(rec.ChainId))
+                    {
+                        rootItems.Add(new RootDrawItem
+                        {
+                            SortKey = GetRecordingSortKey(rec, sortColumn, now, row),
+                            SortName = string.IsNullOrEmpty(rec.VesselName) ? "Untitled" : rec.VesselName,
+                            ItemType = RootItem_Recording,
+                            RecIdx = ri
+                        });
+                    }
+                }
+
+                // Sort root items
+                var col = sortColumn;
+                var asc = sortAscending;
+                rootItems.Sort((a, b) =>
+                {
+                    int cmp;
+                    if (col == SortColumn.Name || col == SortColumn.Phase)
+                        cmp = string.Compare(a.SortName, b.SortName,
+                            System.StringComparison.OrdinalIgnoreCase);
+                    else
+                        cmp = a.SortKey.CompareTo(b.SortKey);
+                    return asc ? cmp : -cmp;
+                });
+
                 // ── Draw tree ─────────────────────────────────────────────
                 bool deleted = false;
 
-                // Root groups
-                for (int g = 0; g < rootGrps.Count && !deleted; g++)
-                    deleted = DrawGroupTree(rootGrps[g], 0, committed, now,
-                        grpToRecs, chainToRecs, grpChildren);
-
-                // Root chains
-                var drawnRootChains = new HashSet<string>();
-                for (int row = 0; row < sortedIndices.Length && !deleted; row++)
+                for (int i = 0; i < rootItems.Count && !deleted; i++)
                 {
-                    int ri = sortedIndices[row];
-                    var rec = committed[ri];
-                    if (string.IsNullOrEmpty(rec.ChainId) || !rootChainIds.Contains(rec.ChainId))
-                        continue;
-                    if (!drawnRootChains.Add(rec.ChainId)) continue;
-                    deleted = DrawChainBlock(rec.ChainId, chainToRecs[rec.ChainId],
-                        0, committed, now);
-                }
-
-                // Standalone recordings (no groups, no chain)
-                for (int row = 0; row < sortedIndices.Length && !deleted; row++)
-                {
-                    int ri = sortedIndices[row];
-                    var rec = committed[ri];
-                    if ((rec.RecordingGroups == null || rec.RecordingGroups.Count == 0) &&
-                        string.IsNullOrEmpty(rec.ChainId))
+                    var item = rootItems[i];
+                    switch (item.ItemType)
                     {
-                        if (DrawRecordingRow(ri, committed, now, 0f))
-                        { deleted = true; break; }
+                        case RootItem_Group:
+                            deleted = DrawGroupTree(item.GroupName, 0, committed, now,
+                                grpToRecs, chainToRecs, grpChildren);
+                            break;
+                        case RootItem_Chain:
+                            deleted = DrawChainBlock(item.ChainId,
+                                chainToRecs[item.ChainId], 0, committed, now);
+                            break;
+                        case RootItem_Recording:
+                            deleted = DrawRecordingRow(item.RecIdx, committed, now, 0f);
+                            break;
                     }
                 }
 
@@ -1637,6 +1706,38 @@ namespace Parsek
                     }
                 }
             }
+
+            // Phase placeholder (groups have no phase)
+            GUILayout.Label("", GUILayout.Width(ColW_Phase));
+
+            // Launch time (earliest among descendants)
+            double grpEarliest = GetGroupEarliestStartUT(descendants, committed);
+            string grpLaunchText = (memberCount > 0 && grpEarliest < double.MaxValue)
+                ? KSPUtil.PrintDateCompact(grpEarliest, true)
+                : "-";
+            GUILayout.Label(grpLaunchText, GUILayout.Width(ColW_Launch));
+
+            // Duration (sum of descendant durations)
+            double grpTotalDur = GetGroupTotalDuration(descendants, committed);
+            GUILayout.Label(FormatDuration(grpTotalDur), GUILayout.Width(ColW_Dur));
+
+            // Expanded stats spacers
+            if (showExpandedStats)
+            {
+                GUILayout.Label("", GUILayout.Width(ColW_MaxAlt));
+                GUILayout.Label("", GUILayout.Width(ColW_MaxSpd));
+                GUILayout.Label("", GUILayout.Width(ColW_Dist));
+                GUILayout.Label("", GUILayout.Width(ColW_Pts));
+            }
+
+            // Status (closest active T- among descendants)
+            string grpStatusText;
+            int grpStatusOrder;
+            GetGroupStatus(descendants, committed, now, out grpStatusText, out grpStatusOrder);
+            GUIStyle grpStatusStyle = grpStatusOrder == 0 ? statusStyleFuture
+                : grpStatusOrder == 1 ? statusStyleActive
+                : statusStylePast;
+            GUILayout.Label(grpStatusText, grpStatusStyle, GUILayout.Width(ColW_Status));
 
             // Group management buttons: G (assign parent) + X (disband) — share ColW_Group width
             float halfGroup = (ColW_Group - 4f) * 0.5f; // 4px for spacing between buttons
@@ -2545,6 +2646,61 @@ namespace Parsek
             return 2;                          // past
         }
 
+        /// <summary>
+        /// Sort key for a single recording based on the current sort column.
+        /// For Index/Phase sort, uses the row position to preserve sortedIndices order.
+        /// </summary>
+        internal static double GetRecordingSortKey(Recording rec, SortColumn column, double now, int rowFallback)
+        {
+            switch (column)
+            {
+                case SortColumn.LaunchTime: return rec.StartUT;
+                case SortColumn.Duration: return rec.EndUT - rec.StartUT;
+                case SortColumn.Status: return GetStatusOrder(rec, now);
+                default: return rowFallback;
+            }
+        }
+
+        /// <summary>
+        /// Sort key for a chain based on the current sort column.
+        /// Uses earliest StartUT for launch, sum for duration, etc.
+        /// </summary>
+        internal static double GetChainSortKey(List<int> members, List<Recording> committed,
+            SortColumn column, double now)
+        {
+            switch (column)
+            {
+                case SortColumn.LaunchTime:
+                {
+                    double earliest = double.MaxValue;
+                    for (int m = 0; m < members.Count; m++)
+                        if (committed[members[m]].StartUT < earliest)
+                            earliest = committed[members[m]].StartUT;
+                    return earliest;
+                }
+                case SortColumn.Duration:
+                {
+                    double total = 0;
+                    for (int m = 0; m < members.Count; m++)
+                        total += committed[members[m]].EndUT - committed[members[m]].StartUT;
+                    return total;
+                }
+                case SortColumn.Status:
+                {
+                    // Best (lowest) status order among members
+                    int best = 2;
+                    for (int m = 0; m < members.Count; m++)
+                    {
+                        int order = GetStatusOrder(committed[members[m]], now);
+                        if (order < best) best = order;
+                    }
+                    return best;
+                }
+                default:
+                    return 0; // Name/Phase/Index: handled via string comparison externally
+            }
+        }
+
         internal static int CompareRecordings(
             Recording ra, Recording rb,
             SortColumn column, bool ascending, double now)
@@ -2624,6 +2780,136 @@ namespace Parsek
             if (meters < 1000) return $"{(int)meters}m";
             if (meters < 1000000) return (meters / 1000).ToString("F1", System.Globalization.CultureInfo.InvariantCulture) + "km";
             return (meters / 1000000).ToString("F1", System.Globalization.CultureInfo.InvariantCulture) + "Mm";
+        }
+
+        /// <summary>
+        /// Returns the earliest StartUT among the given descendant recording indices.
+        /// Returns double.MaxValue if no descendants exist.
+        /// </summary>
+        internal static double GetGroupEarliestStartUT(HashSet<int> descendants, List<Recording> committed)
+        {
+            double earliest = double.MaxValue;
+            foreach (int idx in descendants)
+            {
+                double st = committed[idx].StartUT;
+                if (st < earliest) earliest = st;
+            }
+            return earliest;
+        }
+
+        /// <summary>
+        /// Returns the sum of durations (EndUT - StartUT) for all descendant recordings.
+        /// </summary>
+        internal static double GetGroupTotalDuration(HashSet<int> descendants, List<Recording> committed)
+        {
+            double total = 0;
+            foreach (int idx in descendants)
+            {
+                double dur = committed[idx].EndUT - committed[idx].StartUT;
+                if (dur > 0) total += dur;
+            }
+            return total;
+        }
+
+        /// <summary>
+        /// Returns the status text and style order (0=future, 1=active, 2=past) for a group,
+        /// based on the most relevant descendant: most recently activated (active with StartUT
+        /// closest to now) wins, then closest future, then past.
+        /// </summary>
+        internal static void GetGroupStatus(HashSet<int> descendants, List<Recording> committed,
+            double now, out string statusText, out int statusOrder)
+        {
+            // Find the best candidate: prefer active (closest T-), then future (closest), then past
+            double bestActiveDelta = double.MaxValue;   // smallest |now - StartUT| among active
+            double bestFutureDelta = double.MaxValue;   // smallest (StartUT - now) among future
+            int activeIdx = -1;
+            int futureIdx = -1;
+            bool anyPast = false;
+
+            foreach (int idx in descendants)
+            {
+                var rec = committed[idx];
+                if (now >= rec.StartUT && now <= rec.EndUT)
+                {
+                    // Active recording — prefer closest T- (= StartUT - now, which is negative;
+                    // we want the one closest to now, i.e., smallest |delta|)
+                    double delta = System.Math.Abs(rec.StartUT - now);
+                    if (delta < bestActiveDelta)
+                    {
+                        bestActiveDelta = delta;
+                        activeIdx = idx;
+                    }
+                }
+                else if (now < rec.StartUT)
+                {
+                    double delta = rec.StartUT - now;
+                    if (delta < bestFutureDelta)
+                    {
+                        bestFutureDelta = delta;
+                        futureIdx = idx;
+                    }
+                }
+                else
+                {
+                    anyPast = true;
+                }
+            }
+
+            if (activeIdx >= 0)
+            {
+                var rec = committed[activeIdx];
+                statusOrder = 1; // active
+                statusText = rec.Points.Count > 0
+                    ? SelectiveSpawnUI.FormatCountdown(rec.StartUT - now)
+                    : "active";
+            }
+            else if (futureIdx >= 0)
+            {
+                var rec = committed[futureIdx];
+                statusOrder = 0; // future
+                statusText = rec.Points.Count > 0
+                    ? SelectiveSpawnUI.FormatCountdown(rec.StartUT - now)
+                    : "future";
+            }
+            else if (anyPast)
+            {
+                statusOrder = 2;
+                statusText = "past";
+            }
+            else
+            {
+                statusOrder = 2;
+                statusText = "-";
+            }
+        }
+
+        /// <summary>
+        /// Computes a sort key for a group based on the current sort column.
+        /// Used to interleave groups with recordings in the sorted draw order.
+        /// </summary>
+        internal static double GetGroupSortKey(HashSet<int> descendants, List<Recording> committed,
+            SortColumn column, double now)
+        {
+            if (descendants.Count == 0) return double.MaxValue;
+
+            switch (column)
+            {
+                case SortColumn.LaunchTime:
+                    return GetGroupEarliestStartUT(descendants, committed);
+                case SortColumn.Duration:
+                    return GetGroupTotalDuration(descendants, committed);
+                case SortColumn.Status:
+                {
+                    string unused;
+                    int order;
+                    GetGroupStatus(descendants, committed, now, out unused, out order);
+                    return order;
+                }
+                case SortColumn.Name:
+                    return 0; // groups sort by name separately
+                default:
+                    return GetGroupEarliestStartUT(descendants, committed);
+            }
         }
 
         private RecordingStats GetOrComputeStats(Recording rec)

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -127,15 +127,13 @@ namespace Parsek
         private bool sortAscending = true;
 
         // Root-level draw item for unified sorting of groups, chains, and standalone recordings
-        private const int RootItem_Group = 0;
-        private const int RootItem_Chain = 1;
-        private const int RootItem_Recording = 2;
+        private enum RootItemType { Group, Chain, Recording }
 
         private struct RootDrawItem
         {
             public double SortKey;
             public string SortName;
-            public int ItemType;       // RootItem_Group / RootItem_Chain / RootItem_Recording
+            public RootItemType ItemType;
             public string GroupName;   // for groups
             public string ChainId;     // for chains
             public int RecIdx;         // for standalone recordings
@@ -1181,7 +1179,7 @@ namespace Parsek
                     {
                         SortKey = GetGroupSortKey(desc, committed, sortColumn, now),
                         SortName = rootGrps[g],
-                        ItemType = RootItem_Group,
+                        ItemType = RootItemType.Group,
                         GroupName = rootGrps[g],
                         RecIdx = -1
                     });
@@ -1204,7 +1202,7 @@ namespace Parsek
                         {
                             SortKey = GetChainSortKey(members, committed, sortColumn, now),
                             SortName = members.Count > 0 ? committed[members[0]].VesselName : "",
-                            ItemType = RootItem_Chain,
+                            ItemType = RootItemType.Chain,
                             ChainId = rec.ChainId,
                             RecIdx = -1
                         });
@@ -1215,7 +1213,7 @@ namespace Parsek
                         {
                             SortKey = GetRecordingSortKey(rec, sortColumn, now, row),
                             SortName = string.IsNullOrEmpty(rec.VesselName) ? "Untitled" : rec.VesselName,
-                            ItemType = RootItem_Recording,
+                            ItemType = RootItemType.Recording,
                             RecIdx = ri
                         });
                     }
@@ -1243,15 +1241,15 @@ namespace Parsek
                     var item = rootItems[i];
                     switch (item.ItemType)
                     {
-                        case RootItem_Group:
+                        case RootItemType.Group:
                             deleted = DrawGroupTree(item.GroupName, 0, committed, now,
                                 grpToRecs, chainToRecs, grpChildren);
                             break;
-                        case RootItem_Chain:
+                        case RootItemType.Chain:
                             deleted = DrawChainBlock(item.ChainId,
                                 chainToRecs[item.ChainId], 0, committed, now);
                             break;
-                        case RootItem_Recording:
+                        case RootItemType.Recording:
                             deleted = DrawRecordingRow(item.RecIdx, committed, now, 0f);
                             break;
                     }
@@ -2682,7 +2680,10 @@ namespace Parsek
                 {
                     double total = 0;
                     for (int m = 0; m < members.Count; m++)
-                        total += committed[members[m]].EndUT - committed[members[m]].StartUT;
+                    {
+                        double dur = committed[members[m]].EndUT - committed[members[m]].StartUT;
+                        if (dur > 0) total += dur;
+                    }
                     return total;
                 }
                 case SortColumn.Status:

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -2118,6 +2118,18 @@ When an EVA recording completes and Parsek spawns the real kerbal, the kerbal ap
 
 **Status:** Fixed
 
+## ~~176. Group hide checkbox misaligned when expanded stats columns visible~~
+
+Group header rows in the recordings window were missing `GUILayout.Label` spacers for the expanded stats columns (MaxAlt, MaxSpd, Dist, Pts). When the Stats panel was toggled on, the group row had fewer layout elements than recording rows, causing Unity's horizontal layout to compress or shift the trailing Hide checkbox out of alignment — in some cases making it invisible or unclickable.
+
+**Root cause:** `DrawGroupTree` emitted Phase→Name→G buttons→Loop→Period→Watch→Rewind→Hide but skipped the Phase/Launch/Duration/Stats/Status columns that recording rows include between Name and G. The expanded stats spacers (4 extra `GUILayout.Label` elements) were entirely absent.
+
+**Fix:** Added Phase spacer, Launch (earliest descendant StartUT), Duration (sum of descendant durations), expanded stats spacers (conditional on `showExpandedStats`), and Status (closest active T- countdown) columns to `DrawGroupTree`, matching the recording row column layout exactly.
+
+**Files:** `ParsekUI.cs` (`DrawGroupTree`)
+
+**Status:** Fixed
+
 # In-Game Tests
 
 - [x] Vessels propagate naturally along orbits after FF (no position freezing)


### PR DESCRIPTION
## Summary
- Groups now display **Launch** (earliest StartUT), **Duration** (sum of all member durations), and **Status** (closest active T- countdown) columns, matching the recording row layout
- Groups sort alongside chains and standalone recordings by the current sort column, instead of always appearing first
- Fix **hide checkbox misalignment** when expanded stats columns (MaxAlt, MaxSpd, Dist, Pts) are visible — added matching spacers to group rows
- Extracted 6 `internal static` helpers (`GetGroupEarliestStartUT`, `GetGroupTotalDuration`, `GetGroupStatus`, `GetGroupSortKey`, `GetRecordingSortKey`, `GetChainSortKey`) with `RootDrawItem` struct for unified sort
- 24 new unit tests covering all helpers with edge cases (empty groups, mixed active/future/past, empty chains, negative durations)

## Test plan
- [x] All 3859 tests pass (`dotnet test`)
- [ ] In-game: verify group rows show Launch, Duration, Status columns aligned with recording rows
- [ ] In-game: sort by Launch column — groups should interleave with recordings by their earliest member's launch time
- [ ] In-game: toggle expanded stats — group rows should remain aligned (hide checkbox visible)
- [ ] In-game: verify Status column shows active T+ for groups with active recordings, T- countdown for future-only groups

🤖 Generated with [Claude Code](https://claude.com/claude-code)