### PR TITLE
Fix Index sort scale mismatch for groups vs recordings

### DIFF
--- a/Source/Parsek.Tests/GroupAggregateTests.cs
+++ b/Source/Parsek.Tests/GroupAggregateTests.cs
@@ -402,5 +402,31 @@ namespace Parsek.Tests
                 ParsekUI.SortColumn.Name, 0);
             Assert.Equal(0, key);
         }
+
+        // ── Index sort key ──
+
+        [Fact]
+        public void GroupSortKey_Index_ReturnsNegativeOne()
+        {
+            // Groups get -1 for Index sort so they appear before recordings (row 0+)
+            var committed = new List<Recording> { MakeRec(17000, 17100) };
+            var descendants = new HashSet<int> { 0 };
+            double key = ParsekUI.GetGroupSortKey(descendants, committed,
+                ParsekUI.SortColumn.Index, 0);
+            Assert.Equal(-1, key);
+        }
+
+        [Fact]
+        public void IndexSort_GroupBeforeRecording()
+        {
+            // Groups (key=-1) should sort before recordings (key=row>=0)
+            var committed = new List<Recording> { MakeRec(17000, 17100) };
+            var descendants = new HashSet<int> { 0 };
+            double groupKey = ParsekUI.GetGroupSortKey(descendants, committed,
+                ParsekUI.SortColumn.Index, 0);
+            double recKey = ParsekUI.GetRecordingSortKey(committed[0],
+                ParsekUI.SortColumn.Index, 0, 0);
+            Assert.True(groupKey < recKey, "Group should sort before recording in Index sort");
+        }
     }
 }

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -2907,9 +2907,11 @@ namespace Parsek
                     return order;
                 }
                 case SortColumn.Name:
-                    return 0; // groups sort by name separately
+                case SortColumn.Phase:
+                    return 0; // sorted by string comparison externally
+                case SortColumn.Index:
                 default:
-                    return GetGroupEarliestStartUT(descendants, committed);
+                    return -1; // groups before recordings in insertion-order sort
             }
         }
 


### PR DESCRIPTION
## Summary
- Fix from PR #101 re-review: `GetGroupSortKey` used `GetGroupEarliestStartUT` (UT values ~17000+) for `SortColumn.Index`, while recordings used row positions (0, 1, 2...) and chains used 0 — incompatible scales causing groups to always sort last
- Groups now return `-1` for Index sort, placing them before recordings (row 0+), matching pre-interleaving behavior
- Also explicitly handle `SortColumn.Phase` (was falling through to the UT-based default)
- 2 new tests for Index sort key and ordering invariant

## Test plan
- [x] All 3864 tests pass
- [ ] In-game: sort recordings by `#` column — groups should appear before standalone recordings

🤖 Generated with [Claude Code](https://claude.com/claude-code)