### PR TITLE
Fix 10 failing tests + v0.6 changelog + test audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ Full career-mode resource tracking across the rewind timeline. Science, funds, r
 
 ### Tests
 
-- **4535+ tests** (up from 2419 on main). 20 new test classes covering all game action modules, serialization round-trips, recalculation engine, kerbal reservation lifecycle, milestone patching, contract deadline injection, and ChainSegmentManager state management.
+- **4605 tests** (up from 2419 on main). 20 new test classes covering all game action modules, serialization round-trips, recalculation engine, kerbal reservation lifecycle, milestone patching, contract deadline injection, and ChainSegmentManager state management.
 
 ### Research & Documentation
 
@@ -97,25 +97,6 @@ Ghost vessels now appear in KSP's tracking station, show orbit lines in map view
 
 - **Group header columns in recordings window.** Groups now display Launch (earliest member StartUT), Duration (sum of member durations), and Status (closest active T- countdown) columns. Groups participate in column-based sorting alongside chains and standalone recordings instead of always rendering first. Six `internal static` helpers extracted for testability with 27 unit tests.
 - **Fix #176: Group hide checkbox misaligned when expanded stats visible.** Group rows were missing spacers for the MaxAlt/MaxSpd/Dist/Pts columns, causing the trailing Hide checkbox to shift out of alignment when the Stats panel was open.
-
-### Ghost Map Presence (bug #60)
-
-Ghost vessels now appear in KSP's tracking station, show orbit lines in map view, and can be targeted for rendezvous planning. Works for both ghost chain vessels and timeline playback ghosts.
-
-- **ProtoVessel-based map integration** — lightweight ProtoVessel (single `sensorBarometer` part) per ghost provides automatic tracking station entry, orbit line (OrbitRenderer), clickable map icon (MapObject), and navigation targeting (ITargetable). Created on chain init or engine ghost spawn, removed on resolve/destroy/rewind/scene cleanup, stripped from saves.
-- **Timeline playback + chain ghosts** — both recording-index ghosts (from the playback engine) and chain ghosts (from `VesselGhoster`) get ProtoVessels. Parallel tracking dicts with unified cleanup via `RemoveAllGhostPresenceForIndex`.
-- **Deferred orbit line creation** — recordings that start pre-orbital (launch-to-orbit) don't show orbit lines during atmospheric ascent. ProtoVessel created when ghost enters first orbital segment, with the current segment's orbit (not terminal orbit).
-- **Per-frame orbit segment tracking** — ghost ProtoVessel orbit updates as the ghost traverses segments (Hohmann transfers, SOI transitions). Both chain and recording-index ghosts use the same `ApplyOrbitToVessel`/`BuildOrbitFromSegment` helpers.
-- **Terminal state filtering** — only Orbiting/Docked recordings get orbit lines. Destroyed, SubOrbital, Landed, Splashed skip (misleading orbit). Debris always skipped.
-- **30 guard rails** across 10 source files — `IsGhostMapVessel(pid)` checks on all `FlightGlobals.Vessels` iteration sites and vessel GameEvent handlers.
-- **6 Harmony patches** — `Vessel.GoOffRails` (prevent physics loading), `CommNetVessel.OnStart` (prevent duplicate CommNet nodes), `FlightGlobals.SetActiveVessel` (redirect to watch mode), `SpaceTracking.FlyVessel`/`OnVesselDeleteConfirm`/`OnRecoverConfirm` (block tracking station actions with screen message, release input lock via `OnDialogDismiss`).
-- **Tracking station scene support** — `ParsekTrackingStation` addon creates ghost ProtoVessels from committed recordings when visiting tracking station directly.
-- **Soft cap integration** — `Despawn` removes ProtoVessel; `ReduceFidelity` and `SimplifyToOrbitLine` keep it (orbit line stays visible when mesh is hidden).
-- **Target transfer** — if ghost was the navigation target when chain resolves, the spawned vessel becomes the new target.
-- **VesselType mirroring** — ghost uses the original vessel's type from snapshot for correct filter placement.
-- **Green dot suppression** — `DrawMapMarkers` skips the old GUI overlay dot when a native KSP map icon exists for that ghost.
-- **Merge dialog re-evaluation** — `MergeDialog.OnTreeCommitted` callback triggers chain re-evaluation so ghost ProtoVessels are created immediately after commit+revert.
-- **46 tests** — PID tracking, HasOrbitData, ComputeGhostDisplayInfo, ResolveVesselType, terminal state filtering, debris filtering, StartsInOrbit, orbit segment tracking, log assertions.
 
 ### Bug Fixes
 
@@ -209,6 +190,7 @@ Ghost vessels now appear in KSP's tracking station, show orbit lines in map view
 - **Fix map marker camera in flight view.** `DrawMapMarkerAt` used `PlanetariumCamera` unconditionally — correct for map view but wrong for flight view. Now uses `FlightCamera` in flight view, `PlanetariumCamera` + ScaledSpace in map view.
 - **Default recordings sort: Launch time ascending.** Recordings window now defaults to chronological order (earliest launch at top) instead of index order.
 - **Ghost orbit lines for intermediate chain segments.** ProtoVessels and orbit lines now appear during every coast phase (transfer orbits, parking orbits), not just the terminal orbit. `CreateGhostVesselFromSegment` builds from OrbitSegment data when terminal orbit is unavailable.
+- **Fix: 10 tests failing due to FindObjectsOfType in KspStatePatcher.** `PatchDestructionState` called `UnityEngine.Object.FindObjectsOfType<DestructibleBuilding>()` which throws `SecurityException` outside Unity. `protoUpgradeables` is an empty dict (not null) in the test env, so `PatchFacilities` fell through to the Unity call. Added `SuppressUnityCallsForTesting` guard.
 
 ### Features
 

--- a/Source/Parsek.Tests/KspStatePatcherTests.cs
+++ b/Source/Parsek.Tests/KspStatePatcherTests.cs
@@ -25,10 +25,14 @@ namespace Parsek.Tests
             // Ensure suppression flags start clean
             GameStateRecorder.SuppressResourceEvents = false;
             GameStateRecorder.IsReplayingActions = false;
+
+            // FindObjectsOfType crashes outside Unity
+            KspStatePatcher.SuppressUnityCallsForTesting = true;
         }
 
         public void Dispose()
         {
+            KspStatePatcher.ResetForTesting();
             ParsekLog.ResetTestOverrides();
             ParsekLog.SuppressLogging = true;
             GameStateRecorder.SuppressResourceEvents = false;
@@ -178,16 +182,17 @@ namespace Parsek.Tests
         }
 
         // ================================================================
-        // PatchFacilities — destruction state with null DestructibleBuildings
+        // PatchFacilities — destruction state with no DestructibleBuildings
         // (Full integration testing of Demolish/Repair requires in-game verification
         //  since DestructibleBuilding is a Unity MonoBehaviour unavailable in tests)
         // ================================================================
 
         [Fact]
-        public void PatchFacilities_NullProtoUpgradeables_SkipsDestructionPatching()
+        public void PatchFacilities_WithFacilities_SkipsDestructionPatchingInTests()
         {
-            // ScenarioUpgradeableFacilities.protoUpgradeables is null in test environment.
-            // PatchFacilities should skip entirely (including destruction patching) without crashing.
+            // protoUpgradeables is an empty dict in the test environment (not null),
+            // so the level loop runs but finds nothing. Destruction patching is suppressed
+            // via SuppressUnityCallsForTesting (FindObjectsOfType crashes outside Unity).
             var module = new FacilitiesModule();
             module.ProcessAction(new GameAction
             {
@@ -200,7 +205,7 @@ namespace Parsek.Tests
             KspStatePatcher.PatchFacilities(module);
 
             Assert.Contains(logLines, l =>
-                l.Contains("[KspStatePatcher]") && l.Contains("protoUpgradeables is null"));
+                l.Contains("[KspStatePatcher]") && l.Contains("SuppressUnityCallsForTesting"));
         }
 
         // ================================================================

--- a/Source/Parsek.Tests/KspStatePatcherTests.cs
+++ b/Source/Parsek.Tests/KspStatePatcherTests.cs
@@ -188,7 +188,7 @@ namespace Parsek.Tests
         // ================================================================
 
         [Fact]
-        public void PatchFacilities_WithFacilities_SkipsDestructionPatchingInTests()
+        public void PatchFacilities_EmptyProtoUpgradeables_CompletesWithoutCrash()
         {
             // protoUpgradeables is an empty dict in the test environment (not null),
             // so the level loop runs but finds nothing. Destruction patching is suppressed

--- a/Source/Parsek.Tests/LedgerOrchestratorTests.cs
+++ b/Source/Parsek.Tests/LedgerOrchestratorTests.cs
@@ -16,12 +16,14 @@ namespace Parsek.Tests
             ParsekLog.TestSinkForTesting = line => logLines.Add(line);
 
             RecordingStore.SuppressLogging = true;
+            KspStatePatcher.SuppressUnityCallsForTesting = true;
             LedgerOrchestrator.ResetForTesting();
         }
 
         public void Dispose()
         {
             LedgerOrchestrator.ResetForTesting();
+            KspStatePatcher.ResetForTesting();
             RecordingStore.SuppressLogging = false;
             ParsekLog.ResetTestOverrides();
             ParsekLog.SuppressLogging = true;

--- a/Source/Parsek/GameActions/KspStatePatcher.cs
+++ b/Source/Parsek/GameActions/KspStatePatcher.cs
@@ -21,6 +21,12 @@ namespace Parsek
         private static readonly CultureInfo IC = CultureInfo.InvariantCulture;
 
         /// <summary>
+        /// When true, skips Unity-only API calls (FindObjectsOfType etc.) that crash outside the engine.
+        /// Set by test fixtures; reset via <see cref="ResetForTesting"/>.
+        /// </summary>
+        internal static bool SuppressUnityCallsForTesting;
+
+        /// <summary>
         /// Patches all KSP singletons from the given module states.
         /// Wraps the entire operation in suppression flags.
         /// </summary>
@@ -259,6 +265,13 @@ namespace Parsek
         internal static void PatchDestructionState(
             System.Collections.Generic.IReadOnlyDictionary<string, FacilitiesModule.FacilityState> allFacilities)
         {
+            if (SuppressUnityCallsForTesting)
+            {
+                ParsekLog.Verbose(Tag,
+                    "PatchDestructionState: SuppressUnityCallsForTesting — skipping");
+                return;
+            }
+
             var destructibles = UnityEngine.Object.FindObjectsOfType<DestructibleBuilding>();
             if (destructibles == null || destructibles.Length == 0)
             {
@@ -733,6 +746,11 @@ namespace Parsek
                 $"typeNotFound={typeNotFound.ToString(IC)}, " +
                 $"loadFailed={loadFailed.ToString(IC)}, " +
                 $"ledgerActive={activeIds.Count.ToString(IC)}");
+        }
+
+        internal static void ResetForTesting()
+        {
+            SuppressUnityCallsForTesting = false;
         }
     }
 }

--- a/docs/dev/plans/test-audit-v06.md
+++ b/docs/dev/plans/test-audit-v06.md
@@ -1,0 +1,137 @@
+# Test Audit — v0.6 (game-action-recording-redesign)
+
+**Date:** 2026-04-03
+**Scope:** 30 test files (21 new + 9 modified) added/changed in PR #106 (game-action-recording-redesign merge)
+**Method:** 4 parallel Opus subagents, each auditing a batch of 7-9 files across 6 categories
+**Prior audit:** T32 (2026-03-25, 110 files) — see `docs/dev/done/plans/task-32-test-audit.md`
+
+---
+
+## Executive Summary
+
+| Category | Finding Count | Severity |
+|---|---|---|
+| Always-passing / tautological tests | 3 | High |
+| Not testing production code | 9 | High |
+| Redundant/duplicate tests (cross-file) | 14 | Medium |
+| Test isolation issues | 2 | Medium |
+| Unused setup | 3 | Low |
+| Misleading names | 3 | Low |
+
+Overall quality is good — the majority of the ~2100 new tests call production code with meaningful assertions. The main pattern to address is cross-file duplicates in KerbalReservationTests (8 findings) and hand-written inline logic in BugFixTests/RewindLoggingTests that duplicates production serialization code.
+
+---
+
+## 1. Always-Passing / Tautological Tests (High Priority)
+
+| File | Test | Line | Issue |
+|---|---|---|---|
+| BugFixTests.cs | `VesselName_FallbackChain_UsesStateFirst` | 363 | Assigns `vesselName = "From State"` then asserts `state.vesselName ?? "Unknown"` equals `"From State"`. Tests C# `??` operator, not production code. |
+| BugFixTests.cs | `VesselName_FallbackChain_FallsToDefault` | 371 | Asserts `null ?? "Unknown"` equals `"Unknown"`. Tests C# null-coalescing operator. |
+| RewindContextTests.cs | `DelegateProperties_RecordingStore_MatchRewindContext` | 199 | `RecordingStore.IsRewinding` is a trivial pass-through (`=> RewindContext.IsRewinding`). Test asserts `RewindContext.X == RewindContext.X` via intermediary — tautological. |
+
+---
+
+## 2. Not Testing Production Code (High Priority)
+
+### Hand-written inline logic duplicating production code
+
+| File | Test | Line | Issue |
+|---|---|---|---|
+| RewindLoggingTests.cs | `RewindFields_SurviveSerializationRoundTrip` | 522 | Uses hand-written `SerializeRewindFields`/`DeserializeRewindFields` helpers (lines 479-519) that duplicate `ParsekScenario.OnSave`/`OnLoad`. Never calls actual production serialization. |
+| RewindLoggingTests.cs | `RewindFields_MissingInNode_DefaultGracefully` | 544 | Same hand-written helpers. |
+| RewindLoggingTests.cs | `RewindFields_NullSaveName_SkipsAllFields` | 558 | Same hand-written helpers. |
+| RewindLoggingTests.cs | `RewindFields_LocaleSafe_NoCommasInOutput` | 570 | Same hand-written helpers. |
+| RewindLoggingTests.cs | `ResourceCorrection_ResetsToBaseline_NotAbsoluteTarget` | 738 | Inline arithmetic `correction = baseline - currentFunds; result = currentFunds + correction` is tautologically `baseline`. No production correction method called. |
+| BugFixTests.cs | `FreshStash_SurvivesRevertGuard` | 852 | Calls `RecordingStore.StashPending` (production) but the revert guard logic is hand-written inline, duplicating `ParsekScenario.OnLoad`. |
+| BugFixTests.cs | `StaleStash_DiscardedByRevertGuard` | 877 | Same: hand-written revert guard duplicating production code. |
+| BugFixTests.cs | `FreshTreeStash_SurvivesRevertGuard` | 899 | Same pattern. |
+
+### Tests that never call the method their name implies
+
+| File | Test | Line | Issue |
+|---|---|---|---|
+| LedgerOrchestratorTests.cs | `OnRecordingCommitted_AddsActionsToLedger` | 106 | Never calls `OnRecordingCommitted`. Calls `Ledger.AddAction` directly. Comment admits "we can't call the full OnRecordingCommitted." |
+
+---
+
+## 3. Redundant/Duplicate Tests (Medium Priority)
+
+### KerbalReservationTests vs KerbalEndStateTests (8 cross-file duplicates)
+
+`KerbalReservationTests` contains a block of `InferCrewEndState_*` tests (lines 894-940) that are exact or near-exact duplicates of tests in `KerbalEndStateTests`. The EndState versions include log assertions; the Reservation versions do not.
+
+| KerbalReservationTests | KerbalEndStateTests | Notes |
+|---|---|---|
+| `InferCrewEndState_NullTerminalState_ReturnsUnknown` (894) | Same name (38) | Exact duplicate |
+| `InferCrewEndState_Destroyed_ReturnsDead` (901) | Same name (51) | Exact duplicate |
+| `InferCrewEndState_Recovered_ReturnsRecovered` (909) | Same name (64) | Exact duplicate |
+| `InferCrewEndState_LandedInSnapshot_ReturnsAboard` (917) | `OrbitingInSnapshot_ReturnsAboard` (77) | Same code branch (intact + in snapshot = Aboard) |
+| `InferCrewEndState_LandedNotInSnapshot_ReturnsDead` (925) | Same name (90) | Exact duplicate |
+| `InferCrewEndState_BoardedInSnapshot_ReturnsAboard` (932) | Same name (103) | Exact duplicate |
+| `InferCrewEndState_BoardedNotInSnapshot_ReturnsUnknown` (940) | `DockedNotInSnapshot_ReturnsUnknown` (116) | Same code path |
+| `IsManaged_ReservedKerbal_ReturnsTrue` (407) | KerbalDismissalTests:`IsManaged_ReservedKerbal_ReturnsTrue` (67) | Same core logic |
+
+### Other duplicates
+
+| Test A | Test B | Notes |
+|---|---|---|
+| KerbalReservationTests:`IsManaged_UnmanagedKerbal_ReturnsFalse` (418) | KerbalDismissalTests:`IsManaged_UnmanagedKerbal_ReturnsFalse` (107) | Same assertion |
+| KerbalReservationTests:`MiaRespawnOverride_DeadKerbal_SurvivesMultipleRecalculations` (799) | `MiaRespawnOverride_DeadKerbal_StaysReservedAcrossRecalculations` (733) | Same invariant, 5 loops vs 2 calls |
+| FundsModuleTests:`ContractFailPenalty_DeductsFromBalance` (748) | `ContractFail_DeductsPenalty` (355) | Same code path, different contract ID string |
+| FundsModuleTests:`ContractCancelPenalty_DeductsFromBalance` (757) | `ContractCancel_DeductsPenalty` (363) | Same code path, different contract ID string |
+| KspStatePatcherTests:`PatchScience_NullSingleton_SkipsPerSubjectPatching` (127) | `PatchScience_NullSingleton_DoesNotCrash` (47) | Same early-return path; extra subjects never reached |
+| RewindTests:`ResetForTesting_ClearsRewindFlags` (126) | RewindLoggingTests:`ResetForTesting_ClearsRewindAdjustedUT` (306) | Strict subset |
+
+---
+
+## 4. Test Isolation Issues (Medium Priority)
+
+| File | Line | Issue |
+|---|---|---|
+| BugFixTests.cs | 980 | `FindNextWatchTargetTests` inner class resets static state (`RecordingStore`, `MilestoneStore`, `GameStateStore`, `ParsekLog`) in constructor but does not implement `IDisposable`. State leaks on test failure. Every other class in the same file that touches static state has `IDisposable`. |
+| ScienceModuleTests.cs | 357 | `RecalculationWalk_RetroactivePriority` calls `RecalculationEngine.RegisterModule` but `Dispose()` does not call `RecalculationEngine.ClearModules()`. If the test fails between Register and the manual Clear at line 375, the module leaks. All other test classes touching RecalculationEngine clean up in Dispose. |
+| GameActionSerializationTests.cs | 7 | Missing `[Collection("Sequential")]`. The `UnknownActionType_DefaultsToZero` test sets `ParsekLog.SuppressLogging = true` (with finally-restore) but the class has no sequential collection, risking parallel state conflicts. |
+
+---
+
+## 5. Unused Setup (Low Priority)
+
+| File | Line | Issue |
+|---|---|---|
+| MilestonePatchingTests.cs | 31-32 | Constructor sets `GameStateRecorder.SuppressResourceEvents` and `IsReplayingActions` but no test reads or depends on these flags. |
+| KerbalEndStateTests.cs | 16 | `RecordingStore.SuppressLogging` and `ResetForTesting()` called but no test interacts with RecordingStore. |
+| BugFixTests.cs | 637 | `Bug122_CrewIdentityTransitionTests` captures `logLines` via `TestSinkForTesting` but no test asserts on log output. |
+
+---
+
+## 6. Misleading Names (Low Priority)
+
+| File | Test | Line | Issue |
+|---|---|---|---|
+| LedgerOrchestratorTests.cs | `OnRecordingCommitted_AddsActionsToLedger` | 106 | Never calls `OnRecordingCommitted` — calls `Ledger.AddAction` directly. |
+| LedgerOrchestratorTests.cs | `OnRecordingCommitted_LogsSummary` | 131 | Same: calls `RecalculateAndPatch`, not `OnRecordingCommitted`. |
+| MilestonePatchingTests.cs | `PatchMilestones_WithCreditedMilestones_LogsCountBeforeEarlyReturn` | 275 | Name says "logs count before early return" but assertion only checks `"ProgressTracking.Instance is null"` — no count verified. |
+| KerbalDismissalTests.cs | `IsManaged_RetiredKerbal_ReturnsTrue` | 86 | Creates two independently reserved kerbals — neither is "retired" in Parsek's sense (displaced stand-in). Tests independent reservation, not retirement. |
+
+---
+
+## Recommendations
+
+### P0 - Fix immediately
+1. **Delete 8 KerbalReservationTests `InferCrewEndState_*` duplicates** (lines 894-940) — KerbalEndStateTests already covers these with better assertions.
+2. **Delete 2 FundsModuleTests duplicates** (`ContractFailPenalty_DeductsFromBalance`, `ContractCancelPenalty_DeductsFromBalance`).
+
+### P1 - Fix soon
+3. **Add `IDisposable` to `FindNextWatchTargetTests`** (BugFixTests.cs:980).
+4. **Add `RecalculationEngine.ClearModules()` to `ScienceModuleTests.Dispose()`**.
+5. **Add `[Collection("Sequential")]` to `GameActionSerializationTests`**.
+6. **Rewrite RewindLoggingTests serialization tests** to call actual `ParsekScenario` serialization methods instead of hand-written helpers. Or delete if untestable without Unity.
+7. **Delete or rewrite 3 BugFixTests stash guard tests** (852, 877, 899) to call production revert-guard logic.
+
+### P2 - Fix when convenient
+8. **Delete tautological tests**: `VesselName_FallbackChain_*` (2), `DelegateProperties_RecordingStore_MatchRewindContext`.
+9. **Rename misleading tests**: `OnRecordingCommitted_*` → `Ledger_AddAction_*`, etc.
+10. **Remove unused setup** from MilestonePatchingTests, KerbalEndStateTests, Bug122 tests.
+11. **Delete `KerbalReservationTests.IsManaged_*` duplicates** (407, 418) — covered in KerbalDismissalTests.
+12. **Delete remaining same-file duplicates** (MiaRespawnOverride, PatchScience, RewindTests:ResetForTesting).


### PR DESCRIPTION
## Summary
- **Fix 10 failing tests**: `KspStatePatcher.PatchDestructionState` called `FindObjectsOfType<DestructibleBuilding>()` which crashes outside Unity. `protoUpgradeables` is an empty dict (not null) in tests, so `PatchFacilities` fell through to the Unity call. Added `SuppressUnityCallsForTesting` guard.
- **Changelog update**: Added test fix entry, updated count from 4535+ to 4605, removed duplicate Ghost Map Presence section.
- **v0.6 test audit**: 4 parallel Opus agents audited all 30 test files (21 new + 9 modified) from #106. 34 findings: 14 cross-file duplicates (8 in KerbalReservationTests), 9 not testing production code, 3 tautological, 2 isolation issues, 3 unused setup, 3 misleading names. Full report in `docs/dev/plans/test-audit-v06.md`.

## Test plan
- [x] All 4605 tests pass (0 failures, was 10)
- [x] Review audit findings and triage P0/P1 fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)