### PR TITLE
Add Parsek.version file and UI version display (T1, T2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to Parsek are documented here.
 
 ## 0.6.0
 
+### Release & Distribution
+
+- **Parsek.version file (T1).** Added `GameData/Parsek/Parsek.version` for AVC and CKAN version detection. Auto-copied to KSP GameData on build.
+- **UI version display (T2).** Version label ("v0.6.0") shown at the bottom of the main Parsek window, read from AssemblyVersion at runtime.
+
 ### Game Actions & Resources System
 
 Full career-mode resource tracking across the rewind timeline. Science, funds, reputation, milestones, contracts, kerbals, facilities, and strategies are now recorded, reconciled on rewind, and patched back into KSP's singletons.

--- a/GameData/Parsek/Parsek.version
+++ b/GameData/Parsek/Parsek.version
@@ -1,0 +1,8 @@
+{
+    "NAME": "Parsek",
+    "URL": "https://raw.githubusercontent.com/vl3c/Parsek/main/GameData/Parsek/Parsek.version",
+    "VERSION": { "MAJOR": 0, "MINOR": 6, "PATCH": 0 },
+    "KSP_VERSION": { "MAJOR": 1, "MINOR": 12, "PATCH": 5 },
+    "KSP_VERSION_MIN": { "MAJOR": 1, "MINOR": 12, "PATCH": 0 },
+    "KSP_VERSION_MAX": { "MAJOR": 1, "MINOR": 12, "PATCH": 99 }
+}

--- a/Source/Parsek/Parsek.csproj
+++ b/Source/Parsek/Parsek.csproj
@@ -74,6 +74,7 @@
     <MakeDir Directories="$(KSPDir)\GameData\Parsek\Plugins" />
     <Copy SourceFiles="$(OutputPath)Parsek.dll" DestinationFolder="$(KSPDir)\GameData\Parsek\Plugins" ContinueOnError="true" />
     <Copy SourceFiles="$(OutputPath)Parsek.pdb" DestinationFolder="$(KSPDir)\GameData\Parsek\Plugins" Condition="Exists('$(OutputPath)Parsek.pdb')" ContinueOnError="true" />
+    <Copy SourceFiles="$(MSBuildProjectDirectory)\..\..\GameData\Parsek\Parsek.version" DestinationFolder="$(KSPDir)\GameData\Parsek" ContinueOnError="true" />
     <Message Text="Copied to $(KSPDir)\GameData\Parsek\Plugins" Importance="high" />
   </Target>
 

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -212,6 +212,11 @@ namespace Parsek
 
         private BudgetSummary cachedBudget = default(BudgetSummary);
 
+        private static readonly string VersionLabel = "v" +
+            System.Reflection.Assembly.GetExecutingAssembly().GetName().Version.ToString(3);
+
+        private GUIStyle versionStyle;
+
         public ParsekUI(ParsekFlight flight)
         {
             this.flight = flight;
@@ -289,6 +294,19 @@ namespace Parsek
                 showSettingsWindow = !showSettingsWindow;
                 ParsekLog.Verbose("UI", $"Settings window toggled: {(showSettingsWindow ? "open" : "closed")}");
             }
+
+            // --- Version footer ---
+            GUILayout.Space(SpacingSmall);
+            if (versionStyle == null)
+            {
+                versionStyle = new GUIStyle(GUI.skin.label)
+                {
+                    fontSize = 10,
+                    alignment = TextAnchor.MiddleRight,
+                    normal = { textColor = new Color(1f, 1f, 1f, 0.4f) }
+                };
+            }
+            GUILayout.Label(VersionLabel, versionStyle);
 
             GUILayout.EndVertical();
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -12,8 +12,6 @@ Added `GameData/Parsek/Parsek.version` (v0.6.0) with AVC/CKAN fields. Post-build
 
 Right-aligned "v0.6.0" label at the bottom of the main Parsek window, read from AssemblyVersion at runtime. Subtle 40% opacity, 10pt font.
 
-**Priority:** Should-do for 0.5.1
-
 ### T3. CKAN metadata
 
 Create a `.netkan` file or submit to CKAN indexer so users can install Parsek via CKAN. Requires a stable release URL pattern.

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -4,26 +4,13 @@
 
 ## TODO — Release & Distribution
 
-### T1. Add Parsek.version file (KSP mod convention)
+### ~~T1. Add Parsek.version file (KSP mod convention)~~ DONE
 
-Standard `.version` file enables AVC (Add-on Version Checker) and CKAN to detect available updates. Place in `GameData/Parsek/Parsek.version`.
+Added `GameData/Parsek/Parsek.version` (v0.6.0) with AVC/CKAN fields. Post-build copies it to KSP GameData alongside the DLL.
 
-```json
-{
-    "NAME": "Parsek",
-    "URL": "https://raw.githubusercontent.com/vl3c/Parsek/main/GameData/Parsek/Parsek.version",
-    "VERSION": { "MAJOR": 0, "MINOR": 5, "PATCH": 0 },
-    "KSP_VERSION": { "MAJOR": 1, "MINOR": 12, "PATCH": 5 },
-    "KSP_VERSION_MIN": { "MAJOR": 1, "MINOR": 12, "PATCH": 0 },
-    "KSP_VERSION_MAX": { "MAJOR": 1, "MINOR": 12, "PATCH": 99 }
-}
-```
+### ~~T2. UI version display~~ DONE
 
-**Priority:** Should-do for 0.5.1
-
-### T2. UI version display
-
-Show "Parsek v0.5.0" somewhere in the main Parsek window (title bar or footer). Currently the version is only in `AssemblyInfo.cs` and not visible to the player.
+Right-aligned "v0.6.0" label at the bottom of the main Parsek window, read from AssemblyVersion at runtime. Subtle 40% opacity, 10pt font.
 
 **Priority:** Should-do for 0.5.1
 


### PR DESCRIPTION
## Summary
- **T1:** Add `GameData/Parsek/Parsek.version` for AVC/CKAN version detection, auto-copied to KSP GameData on build
- **T2:** Show "v0.6.0" footer label in the main Parsek window (right-aligned, 10pt, subtle opacity), read from AssemblyVersion at runtime
- Mark T1/T2 done in todo, add changelog entries

## Test plan
- [x] `dotnet build` succeeds, `Parsek.version` copied to KSP GameData
- [x] 4605 tests pass
- [ ] In-game: verify version label visible at bottom of main Parsek window
- [ ] In-game: verify AVC detects `Parsek.version` (if AVC installed)