### PR TITLE
Ghost orbit line during suborbital coasting phases (T41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Parsek are documented here.
 
 ## 0.6.0
 
+### Ghost Playback
+
+- **Suborbital orbit line (T41).** Ghost orbit lines are now visible during suborbital coasting phases. Recordings with orbit segments show the ballistic arc when the ghost enters a coast phase; pure-physics recordings (no time warp) construct the orbit from interpolated state vectors once above 1500m altitude and 60 m/s. Hysteresis thresholds prevent orbit line flicker near threshold boundaries. Tracking station orbit lines remain restricted to stable orbital recordings.
+
 ### Release & Distribution
 
 - **Parsek.version file (T1).** Added `GameData/Parsek/Parsek.version` for AVC and CKAN version detection. Auto-copied to KSP GameData on build.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ All notable changes to Parsek are documented here.
 
 ### Ghost Playback
 
-- **Suborbital orbit line (T41).** Ghost orbit lines are now visible during suborbital coasting phases. Recordings with orbit segments show the ballistic arc when the ghost enters a coast phase; pure-physics recordings (no time warp) construct the orbit from interpolated state vectors once above 1500m altitude and 60 m/s. Hysteresis thresholds prevent orbit line flicker near threshold boundaries. Tracking station orbit lines remain restricted to stable orbital recordings.
+- **Suborbital orbit line (T41).** Ghost orbit lines are now visible during suborbital coasting phases. Recordings with orbit segments show the ballistic arc when the ghost enters a coast phase; pure-physics recordings (no time warp) construct the orbit from interpolated state vectors once above the atmosphere. Orbit line is atmosphere-aware: hidden below `body.atmosphereDepth` (70km on Kerbin) to avoid wild/flickering lines from atmospheric drag. On airless bodies, orbit line appears above 1500m. Hysteresis thresholds prevent flicker. Tracking station orbit lines remain restricted to stable orbital recordings.
+- **Ghost orbit line suppression (Harmony).** New `GhostOrbitLinePatch` postfix on `OrbitRendererBase.LateUpdate` hides the orbit line for ghost ProtoVessels below atmosphere while keeping the native KSP map icon visible. Also hides Ap/Pe/AN/DN markers when orbit line is hidden.
+- **Debris map markers hidden.** Debris ghost recordings no longer show green dot markers in map view.
 
 ### Release & Distribution
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to Parsek are documented here.
 - **Suborbital orbit line (T41).** Ghost orbit lines are now visible during suborbital coasting phases. Recordings with orbit segments show the ballistic arc when the ghost enters a coast phase; pure-physics recordings (no time warp) construct the orbit from interpolated state vectors once above the atmosphere. Orbit line is atmosphere-aware: hidden below `body.atmosphereDepth` (70km on Kerbin) to avoid wild/flickering lines from atmospheric drag. On airless bodies, orbit line appears above 1500m. Hysteresis thresholds prevent flicker. Tracking station orbit lines remain restricted to stable orbital recordings.
 - **Ghost orbit line suppression (Harmony).** New `GhostOrbitLinePatch` postfix on `OrbitRendererBase.LateUpdate` hides the orbit line for ghost ProtoVessels below atmosphere while keeping the native KSP map icon visible. Also hides Ap/Pe/AN/DN markers when orbit line is hidden.
 - **Debris map markers hidden.** Debris ghost recordings no longer show green dot markers in map view.
+- **Stock vessel type icons for ghost markers.** Ghost map markers now use KSP's actual vessel type icons (Ship, Probe, Rover, Station, Plane, etc.) from the orbit icon atlas instead of a plain green dot. Icons are color-tinted per vessel type. Falls back to a diamond shape before MapView initialization.
 
 ### Format Reset
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to Parsek are documented here.
 - **Ghost orbit line suppression (Harmony).** New `GhostOrbitLinePatch` postfix on `OrbitRendererBase.LateUpdate` hides the orbit line for ghost ProtoVessels below atmosphere while keeping the native KSP map icon visible. Also hides Ap/Pe/AN/DN markers when orbit line is hidden.
 - **Debris map markers hidden.** Debris ghost recordings no longer show green dot markers in map view.
 - **Stock vessel type icons for ghost markers.** Ghost map markers now use KSP's actual vessel type icons (Ship, Probe, Rover, Station, Plane, etc.) from the orbit icon atlas instead of a plain green dot. Icons are color-tinted per vessel type. Falls back to a diamond shape before MapView initialization.
+- **Ghost ProtoVessel pressure protection.** New `GhostCheckKillPatch` prevents KSP from destroying ghost ProtoVessels due to on-rails atmospheric pressure. Deorbit orbits pass through the atmosphere, triggering KSP's stock vessel destruction — if the map camera was focused on the ghost, this caused a NullRef cascade that broke scaled space rendering (planet disappeared, stuck exit).
+- **Ghost surface clamp.** Ghost mesh clamped to body surface when Keplerian orbit goes underground (deorbit orbits with sub-surface periapsis). Prevents ghost tunneling through the planet during orbit-only recording sections.
 
 ### Format Reset
 

--- a/Source/Parsek.Tests/GhostMapPresenceTests.cs
+++ b/Source/Parsek.Tests/GhostMapPresenceTests.cs
@@ -563,11 +563,13 @@ namespace Parsek.Tests
         }
 
         /// <summary>
-        /// SubOrbital terminal state should NOT get a ProtoVessel.
-        /// Suborbital trajectories show misleading orbit lines.
+        /// SubOrbital terminal state has valid orbit data (CaptureTerminalOrbit captures
+        /// it for SUB_ORBITAL/FLYING situations). This data is used for state-vector orbit
+        /// line display during flight playback. Tracking station filter (in
+        /// CreateGhostVesselsFromCommittedRecordings) separately excludes SubOrbital.
         /// </summary>
         [Fact]
-        public void TerminalFilter_SubOrbital_ShouldNotGetProtoVessel()
+        public void SubOrbital_HasOrbitData_ReturnsTrue()
         {
             var rec = new Recording
             {

--- a/Source/Parsek.Tests/InterpolatePointsTests.cs
+++ b/Source/Parsek.Tests/InterpolatePointsTests.cs
@@ -489,25 +489,25 @@ namespace Parsek.Tests
 
         #endregion
 
-        #region InterpolateAtUT
+        #region BracketPointAtUT
 
         [Fact]
-        public void InterpolateAtUT_EmptyList_ReturnsNull()
+        public void BracketPointAtUT_EmptyList_ReturnsNull()
         {
             var points = new List<TrajectoryPoint>();
             int cached = -1;
-            Assert.Null(TrajectoryMath.InterpolateAtUT(points, 100, ref cached));
+            Assert.Null(TrajectoryMath.BracketPointAtUT(points, 100, ref cached));
         }
 
         [Fact]
-        public void InterpolateAtUT_NullList_ReturnsNull()
+        public void BracketPointAtUT_NullList_ReturnsNull()
         {
             int cached = -1;
-            Assert.Null(TrajectoryMath.InterpolateAtUT(null, 100, ref cached));
+            Assert.Null(TrajectoryMath.BracketPointAtUT(null, 100, ref cached));
         }
 
         [Fact]
-        public void InterpolateAtUT_BeforeStart_ReturnsNull()
+        public void BracketPointAtUT_BeforeStart_ReturnsNull()
         {
             var points = new List<TrajectoryPoint>
             {
@@ -515,11 +515,11 @@ namespace Parsek.Tests
                 MakePoint(200, alt: 1000)
             };
             int cached = -1;
-            Assert.Null(TrajectoryMath.InterpolateAtUT(points, 50, ref cached));
+            Assert.Null(TrajectoryMath.BracketPointAtUT(points, 50, ref cached));
         }
 
         [Fact]
-        public void InterpolateAtUT_MidRange_ReturnsBracketPoint()
+        public void BracketPointAtUT_MidRange_ReturnsBracketPoint()
         {
             var points = new List<TrajectoryPoint>
             {
@@ -528,7 +528,7 @@ namespace Parsek.Tests
                 MakePoint(300, alt: 1500)
             };
             int cached = -1;
-            var result = TrajectoryMath.InterpolateAtUT(points, 150, ref cached);
+            var result = TrajectoryMath.BracketPointAtUT(points, 150, ref cached);
             Assert.NotNull(result);
             // Returns the lower bracket point (ut=100, alt=500)
             Assert.Equal(100.0, result.Value.ut);
@@ -536,7 +536,7 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void InterpolateAtUT_ExactPoint_ReturnsThatPoint()
+        public void BracketPointAtUT_ExactPoint_ReturnsThatPoint()
         {
             var points = new List<TrajectoryPoint>
             {
@@ -545,14 +545,14 @@ namespace Parsek.Tests
                 MakePoint(300, alt: 1500)
             };
             int cached = -1;
-            var result = TrajectoryMath.InterpolateAtUT(points, 200, ref cached);
+            var result = TrajectoryMath.BracketPointAtUT(points, 200, ref cached);
             Assert.NotNull(result);
             Assert.Equal(200.0, result.Value.ut);
             Assert.Equal(1000.0, result.Value.altitude);
         }
 
         [Fact]
-        public void InterpolateAtUT_PastEnd_ReturnsLastBracketPoint()
+        public void BracketPointAtUT_PastEnd_ReturnsLastPoint()
         {
             var points = new List<TrajectoryPoint>
             {
@@ -560,14 +560,15 @@ namespace Parsek.Tests
                 MakePoint(200, alt: 1000)
             };
             int cached = -1;
-            var result = TrajectoryMath.InterpolateAtUT(points, 999, ref cached);
+            var result = TrajectoryMath.BracketPointAtUT(points, 999, ref cached);
             Assert.NotNull(result);
-            // Past end: FindWaypointIndex returns Count-2=0, before = points[0]
-            Assert.Equal(100.0, result.Value.ut);
+            // Past end: t >= 1, returns upper bracket (last point)
+            Assert.Equal(200.0, result.Value.ut);
+            Assert.Equal(1000.0, result.Value.altitude);
         }
 
         [Fact]
-        public void InterpolateAtUT_SinglePoint_ReturnsNull()
+        public void BracketPointAtUT_SinglePoint_ReturnsNull()
         {
             // Single point → FindWaypointIndex returns -1 (needs at least 2 points)
             var points = new List<TrajectoryPoint>
@@ -575,11 +576,11 @@ namespace Parsek.Tests
                 MakePoint(100, alt: 500)
             };
             int cached = -1;
-            Assert.Null(TrajectoryMath.InterpolateAtUT(points, 100, ref cached));
+            Assert.Null(TrajectoryMath.BracketPointAtUT(points, 100, ref cached));
         }
 
         [Fact]
-        public void InterpolateAtUT_PreservesBodyName()
+        public void BracketPointAtUT_PreservesBodyName()
         {
             var points = new List<TrajectoryPoint>
             {
@@ -587,7 +588,7 @@ namespace Parsek.Tests
                 new TrajectoryPoint { ut = 200, altitude = 1000, bodyName = "Mun", rotation = Quaternion.identity }
             };
             int cached = -1;
-            var result = TrajectoryMath.InterpolateAtUT(points, 150, ref cached);
+            var result = TrajectoryMath.BracketPointAtUT(points, 150, ref cached);
             Assert.NotNull(result);
             Assert.Equal("Mun", result.Value.bodyName);
         }

--- a/Source/Parsek.Tests/InterpolatePointsTests.cs
+++ b/Source/Parsek.Tests/InterpolatePointsTests.cs
@@ -488,5 +488,110 @@ namespace Parsek.Tests
         }
 
         #endregion
+
+        #region InterpolateAtUT
+
+        [Fact]
+        public void InterpolateAtUT_EmptyList_ReturnsNull()
+        {
+            var points = new List<TrajectoryPoint>();
+            int cached = -1;
+            Assert.Null(TrajectoryMath.InterpolateAtUT(points, 100, ref cached));
+        }
+
+        [Fact]
+        public void InterpolateAtUT_NullList_ReturnsNull()
+        {
+            int cached = -1;
+            Assert.Null(TrajectoryMath.InterpolateAtUT(null, 100, ref cached));
+        }
+
+        [Fact]
+        public void InterpolateAtUT_BeforeStart_ReturnsNull()
+        {
+            var points = new List<TrajectoryPoint>
+            {
+                MakePoint(100, alt: 500),
+                MakePoint(200, alt: 1000)
+            };
+            int cached = -1;
+            Assert.Null(TrajectoryMath.InterpolateAtUT(points, 50, ref cached));
+        }
+
+        [Fact]
+        public void InterpolateAtUT_MidRange_ReturnsBracketPoint()
+        {
+            var points = new List<TrajectoryPoint>
+            {
+                MakePoint(100, alt: 500),
+                MakePoint(200, alt: 1000),
+                MakePoint(300, alt: 1500)
+            };
+            int cached = -1;
+            var result = TrajectoryMath.InterpolateAtUT(points, 150, ref cached);
+            Assert.NotNull(result);
+            // Returns the lower bracket point (ut=100, alt=500)
+            Assert.Equal(100.0, result.Value.ut);
+            Assert.Equal(500.0, result.Value.altitude);
+        }
+
+        [Fact]
+        public void InterpolateAtUT_ExactPoint_ReturnsThatPoint()
+        {
+            var points = new List<TrajectoryPoint>
+            {
+                MakePoint(100, alt: 500),
+                MakePoint(200, alt: 1000),
+                MakePoint(300, alt: 1500)
+            };
+            int cached = -1;
+            var result = TrajectoryMath.InterpolateAtUT(points, 200, ref cached);
+            Assert.NotNull(result);
+            Assert.Equal(200.0, result.Value.ut);
+            Assert.Equal(1000.0, result.Value.altitude);
+        }
+
+        [Fact]
+        public void InterpolateAtUT_PastEnd_ReturnsLastBracketPoint()
+        {
+            var points = new List<TrajectoryPoint>
+            {
+                MakePoint(100, alt: 500),
+                MakePoint(200, alt: 1000)
+            };
+            int cached = -1;
+            var result = TrajectoryMath.InterpolateAtUT(points, 999, ref cached);
+            Assert.NotNull(result);
+            // Past end: FindWaypointIndex returns Count-2=0, before = points[0]
+            Assert.Equal(100.0, result.Value.ut);
+        }
+
+        [Fact]
+        public void InterpolateAtUT_SinglePoint_ReturnsNull()
+        {
+            // Single point → FindWaypointIndex returns -1 (needs at least 2 points)
+            var points = new List<TrajectoryPoint>
+            {
+                MakePoint(100, alt: 500)
+            };
+            int cached = -1;
+            Assert.Null(TrajectoryMath.InterpolateAtUT(points, 100, ref cached));
+        }
+
+        [Fact]
+        public void InterpolateAtUT_PreservesBodyName()
+        {
+            var points = new List<TrajectoryPoint>
+            {
+                new TrajectoryPoint { ut = 100, altitude = 500, bodyName = "Mun", rotation = Quaternion.identity },
+                new TrajectoryPoint { ut = 200, altitude = 1000, bodyName = "Mun", rotation = Quaternion.identity }
+            };
+            int cached = -1;
+            var result = TrajectoryMath.InterpolateAtUT(points, 150, ref cached);
+            Assert.NotNull(result);
+            Assert.Equal("Mun", result.Value.bodyName);
+        }
+
+        #endregion
     }
 }

--- a/Source/Parsek.Tests/RuntimePolicyTests.cs
+++ b/Source/Parsek.Tests/RuntimePolicyTests.cs
@@ -892,5 +892,110 @@ namespace Parsek.Tests
         }
 
         #endregion
+
+        #region State-vector orbit thresholds
+
+        [Theory]
+        [InlineData(2000, 100, true)]    // Above both thresholds
+        [InlineData(1500.1, 60.1, true)] // Just above both thresholds
+        [InlineData(1500, 60, false)]    // At thresholds (not above)
+        [InlineData(1000, 100, false)]   // Below altitude threshold
+        [InlineData(2000, 50, false)]    // Below speed threshold
+        [InlineData(0, 0, false)]        // On the ground
+        public void ShouldCreateStateVectorOrbit_ThresholdBehavior(double alt, double speed, bool expected)
+        {
+            Assert.Equal(expected, ParsekPlaybackPolicy.ShouldCreateStateVectorOrbit(alt, speed));
+        }
+
+        [Theory]
+        [InlineData(100, 10, true)]      // Below both thresholds
+        [InlineData(499, 100, true)]     // Below altitude (OR logic)
+        [InlineData(2000, 29, true)]     // Below speed (OR logic)
+        [InlineData(500, 30, false)]     // At thresholds (not below)
+        [InlineData(1000, 60, false)]    // Above both removal thresholds
+        public void ShouldRemoveStateVectorOrbit_ThresholdBehavior(double alt, double speed, bool expected)
+        {
+            Assert.Equal(expected, ParsekPlaybackPolicy.ShouldRemoveStateVectorOrbit(alt, speed));
+        }
+
+        [Fact]
+        public void StateVectorThresholds_HysteresisGap_Exists()
+        {
+            // A vessel at 1000m and 50 m/s should NOT trigger create or remove
+            // (in the hysteresis dead zone between removal and creation thresholds)
+            Assert.False(ParsekPlaybackPolicy.ShouldCreateStateVectorOrbit(1000, 50));
+            Assert.False(ParsekPlaybackPolicy.ShouldRemoveStateVectorOrbit(1000, 50));
+        }
+
+        #endregion
+
+        #region RELATIVE frame guard
+
+        [Fact]
+        public void IsInRelativeFrame_NullTrackSections_ReturnsFalse()
+        {
+            var traj = new Recording { TrackSections = null };
+            Assert.False(ParsekPlaybackPolicy.IsInRelativeFrame(traj, 100));
+        }
+
+        [Fact]
+        public void IsInRelativeFrame_EmptyTrackSections_ReturnsFalse()
+        {
+            var traj = new Recording { TrackSections = new List<TrackSection>() };
+            Assert.False(ParsekPlaybackPolicy.IsInRelativeFrame(traj, 100));
+        }
+
+        [Fact]
+        public void IsInRelativeFrame_AbsoluteSection_ReturnsFalse()
+        {
+            var traj = new Recording
+            {
+                TrackSections = new List<TrackSection>
+                {
+                    new TrackSection
+                    {
+                        referenceFrame = ReferenceFrame.Absolute,
+                        startUT = 50, endUT = 200
+                    }
+                }
+            };
+            Assert.False(ParsekPlaybackPolicy.IsInRelativeFrame(traj, 100));
+        }
+
+        [Fact]
+        public void IsInRelativeFrame_RelativeSection_ReturnsTrue()
+        {
+            var traj = new Recording
+            {
+                TrackSections = new List<TrackSection>
+                {
+                    new TrackSection
+                    {
+                        referenceFrame = ReferenceFrame.Relative,
+                        startUT = 50, endUT = 200
+                    }
+                }
+            };
+            Assert.True(ParsekPlaybackPolicy.IsInRelativeFrame(traj, 100));
+        }
+
+        [Fact]
+        public void IsInRelativeFrame_UTOutsideSection_ReturnsFalse()
+        {
+            var traj = new Recording
+            {
+                TrackSections = new List<TrackSection>
+                {
+                    new TrackSection
+                    {
+                        referenceFrame = ReferenceFrame.Relative,
+                        startUT = 50, endUT = 200
+                    }
+                }
+            };
+            Assert.False(ParsekPlaybackPolicy.IsInRelativeFrame(traj, 300));
+        }
+
+        #endregion
     }
 }

--- a/Source/Parsek.Tests/RuntimePolicyTests.cs
+++ b/Source/Parsek.Tests/RuntimePolicyTests.cs
@@ -896,35 +896,48 @@ namespace Parsek.Tests
         #region State-vector orbit thresholds
 
         [Theory]
-        [InlineData(2000, 100, true)]    // Above both thresholds
-        [InlineData(1500.1, 60.1, true)] // Just above both thresholds
-        [InlineData(1500, 60, false)]    // At thresholds (not above)
-        [InlineData(1000, 100, false)]   // Below altitude threshold
-        [InlineData(2000, 50, false)]    // Below speed threshold
-        [InlineData(0, 0, false)]        // On the ground
-        public void ShouldCreateStateVectorOrbit_ThresholdBehavior(double alt, double speed, bool expected)
+        [InlineData(2000, 100, 0, true)]       // Airless body, above thresholds
+        [InlineData(1500.1, 60.1, 0, true)]    // Airless, just above thresholds
+        [InlineData(1500, 60, 0, false)]       // Airless, at thresholds (not above)
+        [InlineData(1000, 100, 0, false)]      // Airless, below altitude threshold
+        [InlineData(2000, 50, 0, false)]       // Airless, below speed threshold
+        [InlineData(0, 0, 0, false)]           // On the ground
+        [InlineData(80000, 2000, 70000, true)] // Kerbin, above atmosphere (70km)
+        [InlineData(60000, 2000, 70000, false)]// Kerbin, IN atmosphere — rejected
+        [InlineData(71000, 60.1, 70000, true)] // Kerbin, just above atmosphere
+        public void ShouldCreateStateVectorOrbit_ThresholdBehavior(double alt, double speed, double atmos, bool expected)
         {
-            Assert.Equal(expected, ParsekPlaybackPolicy.ShouldCreateStateVectorOrbit(alt, speed));
+            Assert.Equal(expected, ParsekPlaybackPolicy.ShouldCreateStateVectorOrbit(alt, speed, atmos));
         }
 
         [Theory]
-        [InlineData(100, 10, true)]      // Below both thresholds
-        [InlineData(499, 100, true)]     // Below altitude (OR logic)
-        [InlineData(2000, 29, true)]     // Below speed (OR logic)
-        [InlineData(500, 30, false)]     // At thresholds (not below)
-        [InlineData(1000, 60, false)]    // Above both removal thresholds
-        public void ShouldRemoveStateVectorOrbit_ThresholdBehavior(double alt, double speed, bool expected)
+        [InlineData(100, 10, 0, true)]         // Airless, below both thresholds
+        [InlineData(499, 100, 0, true)]        // Airless, below altitude (OR logic)
+        [InlineData(2000, 29, 0, true)]        // Airless, below speed (OR logic)
+        [InlineData(500, 30, 0, false)]        // Airless, at thresholds (not below)
+        [InlineData(1000, 60, 0, false)]       // Airless, above both removal thresholds
+        [InlineData(60000, 2000, 70000, true)] // Kerbin, IN atmosphere — immediate remove
+        [InlineData(80000, 2000, 70000, false)]// Kerbin, above atmosphere — keep
+        public void ShouldRemoveStateVectorOrbit_ThresholdBehavior(double alt, double speed, double atmos, bool expected)
         {
-            Assert.Equal(expected, ParsekPlaybackPolicy.ShouldRemoveStateVectorOrbit(alt, speed));
+            Assert.Equal(expected, ParsekPlaybackPolicy.ShouldRemoveStateVectorOrbit(alt, speed, atmos));
         }
 
         [Fact]
-        public void StateVectorThresholds_HysteresisGap_Exists()
+        public void StateVectorThresholds_HysteresisGap_AirlessBody()
         {
-            // A vessel at 1000m and 50 m/s should NOT trigger create or remove
-            // (in the hysteresis dead zone between removal and creation thresholds)
-            Assert.False(ParsekPlaybackPolicy.ShouldCreateStateVectorOrbit(1000, 50));
-            Assert.False(ParsekPlaybackPolicy.ShouldRemoveStateVectorOrbit(1000, 50));
+            // Airless body: vessel at 1000m and 50 m/s — in hysteresis dead zone
+            Assert.False(ParsekPlaybackPolicy.ShouldCreateStateVectorOrbit(1000, 50, 0));
+            Assert.False(ParsekPlaybackPolicy.ShouldRemoveStateVectorOrbit(1000, 50, 0));
+        }
+
+        [Fact]
+        public void StateVectorThresholds_AtmosphereOverridesAltitude()
+        {
+            // At 50km on Kerbin (atmos=70km): high speed, but IN atmosphere → no create
+            Assert.False(ParsekPlaybackPolicy.ShouldCreateStateVectorOrbit(50000, 2000, 70000));
+            // Same point triggers removal
+            Assert.True(ParsekPlaybackPolicy.ShouldRemoveStateVectorOrbit(50000, 2000, 70000));
         }
 
         #endregion

--- a/Source/Parsek/GhostMapPresence.cs
+++ b/Source/Parsek/GhostMapPresence.cs
@@ -26,6 +26,13 @@ namespace Parsek
         internal static readonly HashSet<uint> ghostMapVesselPids = new HashSet<uint>();
 
         /// <summary>
+        /// Ghost ProtoVessels whose native icon is currently suppressed by
+        /// GhostOrbitLinePatch (below atmosphere). DrawMapMarkers checks this
+        /// to draw our custom icon at the ghost mesh position instead.
+        /// </summary>
+        internal static readonly HashSet<uint> ghostsWithSuppressedIcon = new HashSet<uint>();
+
+        /// <summary>
         /// Map from chain PID (OriginalVesselPid) to the ghost Vessel object.
         /// Used for orbit updates, cleanup, and target transfer.
         /// </summary>
@@ -302,6 +309,7 @@ namespace Parsek
             }
 
             ghostMapVesselPids.Clear();
+            ghostsWithSuppressedIcon.Clear();
             vesselsByChainPid.Clear();
             vesselsByRecordingIndex.Clear();
             vesselPidToRecordingIndex.Clear();
@@ -690,11 +698,23 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Returns the persistentId of the ghost map vessel for a recording index, or 0 if none.
+        /// Used to check ghostsWithSuppressedIcon for the below-atmosphere icon handoff.
+        /// </summary>
+        internal static uint GetGhostVesselPidForRecording(int recordingIndex)
+        {
+            if (vesselsByRecordingIndex.TryGetValue(recordingIndex, out Vessel v))
+                return v.persistentId;
+            return 0;
+        }
+
+        /// <summary>
         /// Reset all state for testing (avoids Debug.Log crash outside Unity).
         /// </summary>
         internal static void ResetForTesting()
         {
             ghostMapVesselPids.Clear();
+            ghostsWithSuppressedIcon.Clear();
             vesselsByChainPid.Clear();
             vesselsByRecordingIndex.Clear();
             vesselPidToRecordingIndex.Clear();

--- a/Source/Parsek/GhostMapPresence.cs
+++ b/Source/Parsek/GhostMapPresence.cs
@@ -422,6 +422,104 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Create a ghost map ProtoVessel from interpolated trajectory state vectors.
+        /// Used for physics-only suborbital recordings that have no orbit segments.
+        /// Constructs a Keplerian orbit from position + velocity at the given UT.
+        /// </summary>
+        internal static Vessel CreateGhostVesselFromStateVectors(
+            int recordingIndex, IPlaybackTrajectory traj,
+            TrajectoryPoint point, double ut)
+        {
+            if (traj == null) return null;
+
+            if (vesselsByRecordingIndex.ContainsKey(recordingIndex))
+                return vesselsByRecordingIndex[recordingIndex];
+
+            CelestialBody body = FindBodyByName(point.bodyName);
+            if (body == null)
+            {
+                ParsekLog.Warn(Tag,
+                    string.Format(ic,
+                        "CreateGhostVesselFromStateVectors: body '{0}' not found for recording #{1}",
+                        point.bodyName, recordingIndex));
+                return null;
+            }
+
+            Vector3d worldPos = body.GetWorldSurfacePosition(point.latitude, point.longitude, point.altitude);
+            Vector3d vel = new Vector3d(point.velocity.x, point.velocity.y, point.velocity.z);
+
+            Orbit orbit = new Orbit();
+            orbit.UpdateFromStateVectors(worldPos, vel, body, ut);
+
+            string logContext = string.Format(ic,
+                "recording #{0} (state vectors alt={1:F0} spd={2:F1})",
+                recordingIndex, point.altitude, point.velocity.magnitude);
+            Vessel vessel = BuildAndLoadGhostProtoVesselCore(traj, orbit, body, logContext);
+            if (vessel != null)
+            {
+                vesselsByRecordingIndex[recordingIndex] = vessel;
+                vesselPidToRecordingIndex[vessel.persistentId] = recordingIndex;
+            }
+
+            return vessel;
+        }
+
+        /// <summary>
+        /// Update a ghost map ProtoVessel's orbit from interpolated trajectory state vectors.
+        /// Used for per-frame orbit updates of physics-only suborbital ghosts.
+        /// Handles SOI transitions (body change + orbit renderer rebuild).
+        /// </summary>
+        internal static void UpdateGhostOrbitFromStateVectors(
+            int recordingIndex, TrajectoryPoint point, double ut)
+        {
+            if (!vesselsByRecordingIndex.TryGetValue(recordingIndex, out Vessel vessel))
+                return;
+
+            if (vessel.orbitDriver == null)
+            {
+                ParsekLog.Warn(Tag,
+                    string.Format(ic,
+                        "UpdateGhostOrbitFromStateVectors: no OrbitDriver for recording #{0}",
+                        recordingIndex));
+                return;
+            }
+
+            CelestialBody body = FindBodyByName(point.bodyName);
+            if (body == null)
+            {
+                ParsekLog.Warn(Tag,
+                    string.Format(ic,
+                        "UpdateGhostOrbitFromStateVectors: body '{0}' not found for recording #{1}",
+                        point.bodyName, recordingIndex));
+                return;
+            }
+
+            // SOI transition handling (same pattern as ApplyOrbitToVessel)
+            bool soiChanged = vessel.orbitDriver.celestialBody != body;
+            if (soiChanged)
+            {
+                vessel.orbitDriver.celestialBody = body;
+                ParsekLog.Info(Tag,
+                    string.Format(ic,
+                        "SOI change for state-vector ghost #{0} — new body={1}",
+                        recordingIndex, body.name));
+            }
+
+            Vector3d worldPos = body.GetWorldSurfacePosition(point.latitude, point.longitude, point.altitude);
+            Vector3d vel = new Vector3d(point.velocity.x, point.velocity.y, point.velocity.z);
+
+            vessel.orbitDriver.orbit.UpdateFromStateVectors(worldPos, vel, body, ut);
+            vessel.orbitDriver.updateFromParameters();
+
+            if (soiChanged && vessel.orbitRenderer != null)
+            {
+                vessel.orbitRenderer.drawMode = OrbitRendererBase.DrawMode.REDRAW_AND_RECALCULATE;
+                vessel.orbitRenderer.enabled = false;
+                vessel.orbitRenderer.enabled = true;
+            }
+        }
+
+        /// <summary>
         /// Shared: apply an OrbitSegment's Keplerian elements to a ghost vessel's OrbitDriver.
         /// Handles body resolution, orbit construction, SOI transitions, and logging.
         /// </summary>

--- a/Source/Parsek/Parsek.csproj
+++ b/Source/Parsek/Parsek.csproj
@@ -31,6 +31,10 @@
       <HintPath>$(KSPDir)\KSP_x64_Data\Managed\UnityEngine.dll</HintPath>
       <Private>false</Private>
     </Reference>
+    <Reference Include="UnityEngine.UI">
+      <HintPath>$(KSPDir)\KSP_x64_Data\Managed\UnityEngine.UI.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
     <Reference Include="UnityEngine.CoreModule">
       <HintPath>$(KSPDir)\KSP_x64_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
       <Private>false</Private>

--- a/Source/Parsek/Parsek.csproj
+++ b/Source/Parsek/Parsek.csproj
@@ -23,6 +23,10 @@
       <HintPath>$(KSPDir)\KSP_x64_Data\Managed\Assembly-CSharp.dll</HintPath>
       <Private>false</Private>
     </Reference>
+    <Reference Include="Assembly-CSharp-firstpass">
+      <HintPath>$(KSPDir)\KSP_x64_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
     <Reference Include="UnityEngine">
       <HintPath>$(KSPDir)\KSP_x64_Data\Managed\UnityEngine.dll</HintPath>
       <Private>false</Private>

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -7803,6 +7803,22 @@ namespace Parsek
             }
 
             Vector3d worldPos = orbit.getPositionAtUT(ut);
+
+            // Surface clamp: if the Keplerian orbit goes underground (e.g., deorbit
+            // orbit with periapsis below surface), clamp to surface altitude. Prevents
+            // the ghost mesh from tunneling through the planet during atmospheric
+            // portions of orbit-only recording sections where no trajectory points exist.
+            if (body.atmosphere)
+            {
+                double orbitAlt = body.GetAltitude(worldPos);
+                if (orbitAlt < 0)
+                {
+                    double lat = body.GetLatitude(worldPos);
+                    double lon = body.GetLongitude(worldPos);
+                    worldPos = body.GetWorldSurfacePosition(lat, lon, 0);
+                }
+            }
+
             ghost.transform.position = worldPos;
 
             Vector3d velocity = orbit.getOrbitalVelocityAtUT(ut);

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -8205,34 +8205,6 @@ namespace Parsek
                         // Use segment index as cache key offset
                         int segIdx = segments.IndexOf(seg.Value);
                         int cacheKey = orbitCacheBase + segIdx;
-
-                        // Atmosphere check: if the Keplerian orbit position at this UT
-                        // is below the body's atmosphere, fall through to point interpolation.
-                        // Keplerian propagation ignores drag, so the orbit position diverges
-                        // from the recorded trajectory during atmospheric reentry.
-                        if (segBody != null && segBody.atmosphere)
-                        {
-                            Orbit atmoCheck;
-                            if (!orbitCache.TryGetValue(cacheKey, out atmoCheck))
-                            {
-                                atmoCheck = new Orbit(
-                                    seg.Value.inclination, seg.Value.eccentricity, seg.Value.semiMajorAxis,
-                                    seg.Value.longitudeOfAscendingNode, seg.Value.argumentOfPeriapsis,
-                                    seg.Value.meanAnomalyAtEpoch, seg.Value.epoch, segBody);
-                                orbitCache[cacheKey] = atmoCheck;
-                            }
-                            double orbitAlt = segBody.GetAltitude(atmoCheck.getPositionAtUT(targetUT));
-                            if (orbitAlt < segBody.atmosphereDepth)
-                            {
-                                int atmoKey = ~cacheKey;
-                                if (loggedOrbitSegments.Add(atmoKey))
-                                    Log($"Orbit segment skipped (below atmosphere): alt={orbitAlt:F0} < " +
-                                        $"atmoDepth={segBody.atmosphereDepth:F0}, falling through to point interpolation");
-                                // Fall through to point interpolation below
-                                goto pointInterpolation;
-                            }
-                        }
-
                         if (loggedOrbitSegments.Add(cacheKey))
                             Log($"Orbit segment activated: cache={cacheKey}, body={seg.Value.bodyName}, " +
                                 $"sma={seg.Value.semiMajorAxis:F0}, UT {seg.Value.startUT:F0}-{seg.Value.endUT:F0}");
@@ -8249,7 +8221,6 @@ namespace Parsek
             }
 
             // Fall through to point-based interpolation
-            pointInterpolation:
             InterpolateAndPosition(ghost, points, ref cachedIndex, targetUT, out interpResult);
         }
 

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -8205,6 +8205,34 @@ namespace Parsek
                         // Use segment index as cache key offset
                         int segIdx = segments.IndexOf(seg.Value);
                         int cacheKey = orbitCacheBase + segIdx;
+
+                        // Atmosphere check: if the Keplerian orbit position at this UT
+                        // is below the body's atmosphere, fall through to point interpolation.
+                        // Keplerian propagation ignores drag, so the orbit position diverges
+                        // from the recorded trajectory during atmospheric reentry.
+                        if (segBody != null && segBody.atmosphere)
+                        {
+                            Orbit atmoCheck;
+                            if (!orbitCache.TryGetValue(cacheKey, out atmoCheck))
+                            {
+                                atmoCheck = new Orbit(
+                                    seg.Value.inclination, seg.Value.eccentricity, seg.Value.semiMajorAxis,
+                                    seg.Value.longitudeOfAscendingNode, seg.Value.argumentOfPeriapsis,
+                                    seg.Value.meanAnomalyAtEpoch, seg.Value.epoch, segBody);
+                                orbitCache[cacheKey] = atmoCheck;
+                            }
+                            double orbitAlt = segBody.GetAltitude(atmoCheck.getPositionAtUT(targetUT));
+                            if (orbitAlt < segBody.atmosphereDepth)
+                            {
+                                int atmoKey = ~cacheKey;
+                                if (loggedOrbitSegments.Add(atmoKey))
+                                    Log($"Orbit segment skipped (below atmosphere): alt={orbitAlt:F0} < " +
+                                        $"atmoDepth={segBody.atmosphereDepth:F0}, falling through to point interpolation");
+                                // Fall through to point interpolation below
+                                goto pointInterpolation;
+                            }
+                        }
+
                         if (loggedOrbitSegments.Add(cacheKey))
                             Log($"Orbit segment activated: cache={cacheKey}, body={seg.Value.bodyName}, " +
                                 $"sma={seg.Value.semiMajorAxis:F0}, UT {seg.Value.startUT:F0}-{seg.Value.endUT:F0}");
@@ -8221,6 +8249,7 @@ namespace Parsek
             }
 
             // Fall through to point-based interpolation
+            pointInterpolation:
             InterpolateAndPosition(ghost, points, ref cachedIndex, targetUT, out interpResult);
         }
 

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -7805,18 +7805,15 @@ namespace Parsek
             Vector3d worldPos = orbit.getPositionAtUT(ut);
 
             // Surface clamp: if the Keplerian orbit goes underground (e.g., deorbit
-            // orbit with periapsis below surface), clamp to surface altitude. Prevents
-            // the ghost mesh from tunneling through the planet during atmospheric
-            // portions of orbit-only recording sections where no trajectory points exist.
-            if (body.atmosphere)
+            // orbit with periapsis below surface, or impact trajectory on airless body),
+            // clamp to surface altitude. Prevents the ghost mesh from tunneling through
+            // the planet during orbit-only recording sections where no trajectory points exist.
+            double orbitAlt = body.GetAltitude(worldPos);
+            if (orbitAlt < 0)
             {
-                double orbitAlt = body.GetAltitude(worldPos);
-                if (orbitAlt < 0)
-                {
-                    double lat = body.GetLatitude(worldPos);
-                    double lon = body.GetLongitude(worldPos);
-                    worldPos = body.GetWorldSurfacePosition(lat, lon, 0);
-                }
+                double lat = body.GetLatitude(worldPos);
+                double lon = body.GetLongitude(worldPos);
+                worldPos = body.GetWorldSurfacePosition(lat, lon, 0);
             }
 
             ghost.transform.position = worldPos;

--- a/Source/Parsek/ParsekPlaybackPolicy.cs
+++ b/Source/Parsek/ParsekPlaybackPolicy.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using UnityEngine;
 
 namespace Parsek
@@ -539,7 +540,7 @@ namespace Parsek
                         if (!stateVectorCachedIndices.ContainsKey(idx))
                             stateVectorCachedIndices[idx] = -1;
                         int cached = stateVectorCachedIndices[idx];
-                        TrajectoryPoint? pt = TrajectoryMath.InterpolateAtUT(traj.Points, currentUT, ref cached);
+                        TrajectoryPoint? pt = TrajectoryMath.BracketPointAtUT(traj.Points, currentUT, ref cached);
                         stateVectorCachedIndices[idx] = cached;
 
                         if (pt.HasValue && ShouldCreateStateVectorOrbit(pt.Value.altitude, pt.Value.velocity.magnitude))
@@ -590,9 +591,9 @@ namespace Parsek
                             pendingMapVessels.Remove(idx);
                             stateVectorOrbitTrajectories[idx] = traj;
 
-                            ParsekLog.Info("Policy",
-                                $"Created state-vector ghost map vessel for #{idx} \"{traj.VesselName}\" " +
-                                $"— alt={pt.altitude:F0} speed={pt.velocity.magnitude:F1}");
+                            ParsekLog.Info("Policy", string.Format(CultureInfo.InvariantCulture,
+                                "Created state-vector ghost map vessel for #{0} \"{1}\" — alt={2:F0} speed={3:F1}",
+                                idx, traj.VesselName, pt.altitude, pt.velocity.magnitude));
                         }
                     }
                 }
@@ -649,7 +650,7 @@ namespace Parsek
                     if (!stateVectorCachedIndices.ContainsKey(idx))
                         stateVectorCachedIndices[idx] = -1;
                     int cached = stateVectorCachedIndices[idx];
-                    TrajectoryPoint? pt = TrajectoryMath.InterpolateAtUT(traj.Points, currentUT, ref cached);
+                    TrajectoryPoint? pt = TrajectoryMath.BracketPointAtUT(traj.Points, currentUT, ref cached);
                     stateVectorCachedIndices[idx] = cached;
 
                     if (!pt.HasValue) continue;
@@ -659,9 +660,9 @@ namespace Parsek
                         GhostMapPresence.RemoveGhostVesselForRecording(idx, "below-state-vector-threshold");
                         if (toReDefer == null) toReDefer = new List<int>();
                         toReDefer.Add(idx);
-                        ParsekLog.Info("Policy",
-                            $"Removed state-vector ghost map vessel for #{idx} — " +
-                            $"alt={pt.Value.altitude:F0} speed={pt.Value.velocity.magnitude:F1} below threshold");
+                        ParsekLog.Info("Policy", string.Format(CultureInfo.InvariantCulture,
+                            "Removed state-vector ghost map vessel for #{0} — alt={1:F0} speed={2:F1} below threshold",
+                            idx, pt.Value.altitude, pt.Value.velocity.magnitude));
                         continue;
                     }
 
@@ -676,6 +677,8 @@ namespace Parsek
                         if (stateVectorOrbitTrajectories.TryGetValue(idx, out var traj))
                             pendingMapVessels[idx] = traj;
                         stateVectorOrbitTrajectories.Remove(idx);
+                        // stateVectorCachedIndices[idx] intentionally kept — avoids
+                        // O(n) re-scan if the ghost re-ascends above threshold.
                     }
                 }
             }

--- a/Source/Parsek/ParsekPlaybackPolicy.cs
+++ b/Source/Parsek/ParsekPlaybackPolicy.cs
@@ -393,6 +393,27 @@ namespace Parsek
         private readonly Dictionary<int, (string body, double sma, double ecc)> lastMapOrbitByIndex =
             new Dictionary<int, (string body, double sma, double ecc)>();
 
+        /// <summary>
+        /// State-vector orbit tracking: recording indices with physics-only suborbital
+        /// orbit lines (no orbit segments). Maps index → trajectory for re-defer.
+        /// </summary>
+        private readonly Dictionary<int, IPlaybackTrajectory> stateVectorOrbitTrajectories =
+            new Dictionary<int, IPlaybackTrajectory>();
+
+        /// <summary>
+        /// Per-recording cached waypoint indices for InterpolateAtUT calls (avoids
+        /// O(n) scan on every 0.5s orbit update).
+        /// </summary>
+        private readonly Dictionary<int, int> stateVectorCachedIndices =
+            new Dictionary<int, int>();
+
+        // Hysteresis thresholds for state-vector orbit creation/removal.
+        // Higher thresholds to create, lower to remove — prevents churn for borderline altitudes.
+        internal const double StateVectorCreateAltitude = 1500;   // meters
+        internal const double StateVectorCreateSpeed = 60;        // m/s
+        internal const double StateVectorRemoveAltitude = 500;    // meters
+        internal const double StateVectorRemoveSpeed = 30;        // m/s
+
         private void HandleGhostCreated(GhostLifecycleEvent evt)
         {
             if (evt.Trajectory == null || evt.Trajectory.IsDebris)
@@ -403,22 +424,26 @@ namespace Parsek
                 return;
             }
 
-            // Skip recordings with non-orbital terminal states (Destroyed, SubOrbital, Landed, etc.)
-            // but allow: terminal=null (intermediate chain segments), Orbiting, Docked.
+            // Skip recordings with non-orbital terminal states (Destroyed, Landed, etc.)
+            // but allow: terminal=null (intermediate chain segments), Orbiting, Docked,
+            // SubOrbital (ballistic arc orbit line during coast phases).
             var terminal = evt.Trajectory.TerminalStateValue;
             if (terminal.HasValue
                 && terminal.Value != TerminalState.Orbiting
-                && terminal.Value != TerminalState.Docked)
+                && terminal.Value != TerminalState.Docked
+                && terminal.Value != TerminalState.SubOrbital)
             {
                 ParsekLog.VerboseRateLimited("Policy", $"skip-map-terminal-{evt.Index}",
                     $"Skipped ghost map for #{evt.Index} \"{evt.Trajectory.VesselName}\" — terminal={terminal.Value}");
                 return;
             }
 
-            // Accept recordings with terminal orbit data OR orbit segments (intermediate
-            // chain segments have no terminal orbit but do have orbit segments from on-rails periods)
-            if (!GhostMapPresence.HasOrbitData(evt.Trajectory)
-                && (evt.Trajectory.OrbitSegments == null || evt.Trajectory.OrbitSegments.Count == 0))
+            // Accept recordings with terminal orbit data, orbit segments, or trajectory
+            // points (physics-only suborbital recordings have points but no orbit data).
+            bool hasOrbitData = GhostMapPresence.HasOrbitData(evt.Trajectory);
+            bool hasOrbitSegments = evt.Trajectory.OrbitSegments != null && evt.Trajectory.OrbitSegments.Count > 0;
+            bool hasPoints = evt.Trajectory.Points != null && evt.Trajectory.Points.Count > 0;
+            if (!hasOrbitData && !hasOrbitSegments && !hasPoints)
                 return;
 
             // Check if the ghost starts in an orbital segment (orbit-only recording
@@ -444,47 +469,105 @@ namespace Parsek
         }
 
         /// <summary>
-        /// Per-frame check for ghost map ProtoVessels. Handles two responsibilities:
+        /// Pure: should we create a state-vector orbit ProtoVessel at this altitude/speed?
+        /// Uses higher thresholds than removal to prevent create/destroy churn (hysteresis).
+        /// </summary>
+        internal static bool ShouldCreateStateVectorOrbit(double altitude, double speed)
+        {
+            return altitude > StateVectorCreateAltitude && speed > StateVectorCreateSpeed;
+        }
+
+        /// <summary>
+        /// Pure: should we remove a state-vector orbit ProtoVessel at this altitude/speed?
+        /// Uses lower thresholds than creation (hysteresis) — OR logic so either condition triggers.
+        /// </summary>
+        internal static bool ShouldRemoveStateVectorOrbit(double altitude, double speed)
+        {
+            return altitude < StateVectorRemoveAltitude || speed < StateVectorRemoveSpeed;
+        }
+
+        /// <summary>
+        /// Pure: is the recording in a RELATIVE reference frame at the given UT?
+        /// RELATIVE frames store dx/dy/dz offsets, not lat/lon/alt — state-vector
+        /// orbit construction would produce nonsense.
+        /// </summary>
+        internal static bool IsInRelativeFrame(IPlaybackTrajectory traj, double ut)
+        {
+            if (traj.TrackSections == null || traj.TrackSections.Count == 0)
+                return false;
+            int sectionIdx = TrajectoryMath.FindTrackSectionForUT(traj.TrackSections, ut);
+            return sectionIdx >= 0
+                && traj.TrackSections[sectionIdx].referenceFrame == ReferenceFrame.Relative;
+        }
+
+        /// <summary>
+        /// Per-frame check for ghost map ProtoVessels. Handles three responsibilities:
         /// 1. Creates deferred ProtoVessels when ghosts enter their first orbital segment
-        /// 2. Updates existing ProtoVessel orbits when ghosts traverse segment boundaries
+        /// 2. Creates state-vector orbit ProtoVessels for physics-only suborbital recordings
+        /// 3. Updates existing ProtoVessel orbits (segment-based and state-vector-based)
         /// </summary>
         internal void CheckPendingMapVessels(double currentUT)
         {
             // 1. Create deferred ProtoVessels for ghosts that just entered an orbital segment
+            //    OR for physics-only recordings that crossed the state-vector threshold.
             if (pendingMapVessels.Count > 0)
             {
-                // Capture index + segment together to avoid a second FindOrbitSegment call
-                List<KeyValuePair<int, OrbitSegment>> toCreate = null;
+                List<KeyValuePair<int, OrbitSegment>> toCreateFromSegment = null;
+                List<KeyValuePair<int, TrajectoryPoint>> toCreateFromStateVectors = null;
+
                 foreach (var kvp in pendingMapVessels)
                 {
-                    OrbitSegment? seg = TrajectoryMath.FindOrbitSegment(kvp.Value.OrbitSegments, currentUT);
+                    int idx = kvp.Key;
+                    IPlaybackTrajectory traj = kvp.Value;
+
+                    // Path A: orbit-segment-based (existing)
+                    OrbitSegment? seg = TrajectoryMath.FindOrbitSegment(traj.OrbitSegments, currentUT);
                     if (seg.HasValue)
                     {
-                        if (toCreate == null) toCreate = new List<KeyValuePair<int, OrbitSegment>>();
-                        toCreate.Add(new KeyValuePair<int, OrbitSegment>(kvp.Key, seg.Value));
+                        if (toCreateFromSegment == null)
+                            toCreateFromSegment = new List<KeyValuePair<int, OrbitSegment>>();
+                        toCreateFromSegment.Add(new KeyValuePair<int, OrbitSegment>(idx, seg.Value));
+                        continue;
+                    }
+
+                    // Path B: state-vector-based (new — physics-only suborbital)
+                    if (traj.OrbitSegments == null || traj.OrbitSegments.Count == 0)
+                    {
+                        if (traj.Points == null || traj.Points.Count == 0) continue;
+                        if (IsInRelativeFrame(traj, currentUT)) continue;
+
+                        if (!stateVectorCachedIndices.ContainsKey(idx))
+                            stateVectorCachedIndices[idx] = -1;
+                        int cached = stateVectorCachedIndices[idx];
+                        TrajectoryPoint? pt = TrajectoryMath.InterpolateAtUT(traj.Points, currentUT, ref cached);
+                        stateVectorCachedIndices[idx] = cached;
+
+                        if (pt.HasValue && ShouldCreateStateVectorOrbit(pt.Value.altitude, pt.Value.velocity.magnitude))
+                        {
+                            if (toCreateFromStateVectors == null)
+                                toCreateFromStateVectors = new List<KeyValuePair<int, TrajectoryPoint>>();
+                            toCreateFromStateVectors.Add(new KeyValuePair<int, TrajectoryPoint>(idx, pt.Value));
+                        }
                     }
                 }
 
-                if (toCreate != null)
+                // Apply segment-based creations
+                if (toCreateFromSegment != null)
                 {
-                    for (int i = 0; i < toCreate.Count; i++)
+                    for (int i = 0; i < toCreateFromSegment.Count; i++)
                     {
-                        int idx = toCreate[i].Key;
-                        OrbitSegment initialSeg = toCreate[i].Value;
+                        int idx = toCreateFromSegment[i].Key;
+                        OrbitSegment initialSeg = toCreateFromSegment[i].Value;
                         if (pendingMapVessels.TryGetValue(idx, out var traj))
                         {
-                            // Use terminal orbit if available, otherwise create from segment
-                            // (intermediate chain segments have orbit segments but no terminal orbit)
                             Vessel ghost = GhostMapPresence.HasOrbitData(traj)
                                 ? GhostMapPresence.CreateGhostVesselForRecording(idx, traj)
                                 : GhostMapPresence.CreateGhostVesselFromSegment(idx, traj, initialSeg);
                             pendingMapVessels.Remove(idx);
 
-                            // Update to the triggering segment's orbit (may differ from terminal)
                             if (ghost != null)
                                 GhostMapPresence.UpdateGhostOrbitForRecording(idx, initialSeg);
 
-                            // Seed segment tracking from the already-found segment (no second lookup)
                             lastMapOrbitByIndex[idx] = (initialSeg.bodyName, initialSeg.semiMajorAxis, initialSeg.eccentricity);
 
                             ParsekLog.Info("Policy",
@@ -493,17 +576,36 @@ namespace Parsek
                         }
                     }
                 }
+
+                // Apply state-vector-based creations
+                if (toCreateFromStateVectors != null)
+                {
+                    for (int i = 0; i < toCreateFromStateVectors.Count; i++)
+                    {
+                        int idx = toCreateFromStateVectors[i].Key;
+                        TrajectoryPoint pt = toCreateFromStateVectors[i].Value;
+                        if (pendingMapVessels.TryGetValue(idx, out var traj))
+                        {
+                            Vessel ghost = GhostMapPresence.CreateGhostVesselFromStateVectors(idx, traj, pt, currentUT);
+                            pendingMapVessels.Remove(idx);
+                            stateVectorOrbitTrajectories[idx] = traj;
+
+                            ParsekLog.Info("Policy",
+                                $"Created state-vector ghost map vessel for #{idx} \"{traj.VesselName}\" " +
+                                $"— alt={pt.altitude:F0} speed={pt.velocity.magnitude:F1}");
+                        }
+                    }
+                }
             }
 
-            // 2. Update orbits for existing recording-index ProtoVessels when segment changes.
-            // Rate-limited: orbit segment boundaries are infrequent, no need to scan per-frame.
+            // 2. Rate-limited orbit updates for existing ProtoVessels.
             if (UnityEngine.Time.time < nextMapOrbitUpdateTime) return;
             nextMapOrbitUpdateTime = UnityEngine.Time.time + MapOrbitUpdateIntervalSec;
 
             var committed = RecordingStore.CommittedRecordings;
             if (committed == null) return;
 
-            // Collect updates to apply after iteration (cannot modify dict during foreach)
+            // 2a. Segment-based orbit updates (existing)
             List<KeyValuePair<int, (string body, double sma, double ecc)>> orbitUpdates = null;
 
             foreach (var kvp in lastMapOrbitByIndex)
@@ -517,9 +619,6 @@ namespace Parsek
                 OrbitSegment? seg = TrajectoryMath.FindOrbitSegment(rec.OrbitSegments, currentUT);
                 if (!seg.HasValue) continue;
 
-                // Exact equality is intentional: stored segment values don't drift.
-                // A change means a different OrbitSegment, not floating-point accumulation.
-                // Includes eccentricity to catch inclination-change maneuvers at constant SMA.
                 if (seg.Value.bodyName == kvp.Value.body
                     && seg.Value.semiMajorAxis == kvp.Value.sma
                     && seg.Value.eccentricity == kvp.Value.ecc)
@@ -537,7 +636,49 @@ namespace Parsek
                     lastMapOrbitByIndex[orbitUpdates[i].Key] = orbitUpdates[i].Value;
             }
 
+            // 2b. State-vector orbit updates (new — physics-only suborbital)
+            if (stateVectorOrbitTrajectories.Count > 0)
+            {
+                List<int> toReDefer = null;
 
+                foreach (var kvp in stateVectorOrbitTrajectories)
+                {
+                    int idx = kvp.Key;
+                    IPlaybackTrajectory traj = kvp.Value;
+
+                    if (!stateVectorCachedIndices.ContainsKey(idx))
+                        stateVectorCachedIndices[idx] = -1;
+                    int cached = stateVectorCachedIndices[idx];
+                    TrajectoryPoint? pt = TrajectoryMath.InterpolateAtUT(traj.Points, currentUT, ref cached);
+                    stateVectorCachedIndices[idx] = cached;
+
+                    if (!pt.HasValue) continue;
+
+                    if (ShouldRemoveStateVectorOrbit(pt.Value.altitude, pt.Value.velocity.magnitude))
+                    {
+                        GhostMapPresence.RemoveGhostVesselForRecording(idx, "below-state-vector-threshold");
+                        if (toReDefer == null) toReDefer = new List<int>();
+                        toReDefer.Add(idx);
+                        ParsekLog.Info("Policy",
+                            $"Removed state-vector ghost map vessel for #{idx} — " +
+                            $"alt={pt.Value.altitude:F0} speed={pt.Value.velocity.magnitude:F1} below threshold");
+                        continue;
+                    }
+
+                    GhostMapPresence.UpdateGhostOrbitFromStateVectors(idx, pt.Value, currentUT);
+                }
+
+                if (toReDefer != null)
+                {
+                    for (int i = 0; i < toReDefer.Count; i++)
+                    {
+                        int idx = toReDefer[i];
+                        if (stateVectorOrbitTrajectories.TryGetValue(idx, out var traj))
+                            pendingMapVessels[idx] = traj;
+                        stateVectorOrbitTrajectories.Remove(idx);
+                    }
+                }
+            }
         }
 
         /// <summary>
@@ -565,6 +706,8 @@ namespace Parsek
             heldGhosts.Remove(evt.Index);
             pendingMapVessels.Remove(evt.Index);
             lastMapOrbitByIndex.Remove(evt.Index);
+            stateVectorOrbitTrajectories.Remove(evt.Index);
+            stateVectorCachedIndices.Remove(evt.Index);
 
             // Remove both recording-index and chain-based ghost map ProtoVessels
             var committed = RecordingStore.CommittedRecordings;
@@ -596,6 +739,8 @@ namespace Parsek
             heldGhosts.Clear();
             pendingMapVessels.Clear();
             lastMapOrbitByIndex.Clear();
+            stateVectorOrbitTrajectories.Clear();
+            stateVectorCachedIndices.Clear();
         }
 
         /// <summary>
@@ -612,6 +757,8 @@ namespace Parsek
             heldGhosts.Clear();
             pendingMapVessels.Clear();
             lastMapOrbitByIndex.Clear();
+            stateVectorOrbitTrajectories.Clear();
+            stateVectorCachedIndices.Clear();
             ParsekLog.Info("Policy", "ParsekPlaybackPolicy disposed and unsubscribed from 6 engine events");
         }
     }

--- a/Source/Parsek/ParsekPlaybackPolicy.cs
+++ b/Source/Parsek/ParsekPlaybackPolicy.cs
@@ -410,9 +410,11 @@ namespace Parsek
 
         // Hysteresis thresholds for state-vector orbit creation/removal.
         // Higher thresholds to create, lower to remove — prevents churn for borderline altitudes.
-        internal const double StateVectorCreateAltitude = 1500;   // meters
+        // On bodies with atmosphere, the atmosphere depth overrides these (orbit lines are
+        // only meaningful in vacuum — atmospheric drag makes the Keplerian approximation wild).
+        internal const double StateVectorCreateAltitude = 1500;   // meters (airless bodies only)
         internal const double StateVectorCreateSpeed = 60;        // m/s
-        internal const double StateVectorRemoveAltitude = 500;    // meters
+        internal const double StateVectorRemoveAltitude = 500;    // meters (airless bodies only)
         internal const double StateVectorRemoveSpeed = 30;        // m/s
 
         private void HandleGhostCreated(GhostLifecycleEvent evt)
@@ -471,20 +473,42 @@ namespace Parsek
 
         /// <summary>
         /// Pure: should we create a state-vector orbit ProtoVessel at this altitude/speed?
-        /// Uses higher thresholds than removal to prevent create/destroy churn (hysteresis).
+        /// On bodies with atmosphere, requires altitude above atmosphere (Keplerian orbits
+        /// are meaningless during atmospheric flight — drag makes them wild/flickering).
+        /// On airless bodies, uses the fixed altitude threshold.
         /// </summary>
-        internal static bool ShouldCreateStateVectorOrbit(double altitude, double speed)
+        internal static bool ShouldCreateStateVectorOrbit(double altitude, double speed, double atmosphereDepth)
         {
-            return altitude > StateVectorCreateAltitude && speed > StateVectorCreateSpeed;
+            double minAltitude = atmosphereDepth > 0 ? atmosphereDepth : StateVectorCreateAltitude;
+            return altitude > minAltitude && speed > StateVectorCreateSpeed;
         }
 
         /// <summary>
         /// Pure: should we remove a state-vector orbit ProtoVessel at this altitude/speed?
-        /// Uses lower thresholds than creation (hysteresis) — OR logic so either condition triggers.
+        /// On bodies with atmosphere, removes immediately when descending into atmosphere.
+        /// On airless bodies, uses lower hysteresis thresholds.
         /// </summary>
-        internal static bool ShouldRemoveStateVectorOrbit(double altitude, double speed)
+        internal static bool ShouldRemoveStateVectorOrbit(double altitude, double speed, double atmosphereDepth)
         {
+            if (atmosphereDepth > 0 && altitude < atmosphereDepth)
+                return true;
             return altitude < StateVectorRemoveAltitude || speed < StateVectorRemoveSpeed;
+        }
+
+        /// <summary>
+        /// Look up atmosphere depth for a body by name. Returns 0 for airless bodies or if
+        /// FlightGlobals is unavailable (test environment).
+        /// </summary>
+        internal static double GetAtmosphereDepth(string bodyName)
+        {
+            var bodies = FlightGlobals.Bodies;
+            if (bodies == null) return 0;
+            for (int i = 0; i < bodies.Count; i++)
+            {
+                if (bodies[i].name == bodyName && bodies[i].atmosphere)
+                    return bodies[i].atmosphereDepth;
+            }
+            return 0;
         }
 
         /// <summary>
@@ -543,7 +567,8 @@ namespace Parsek
                         TrajectoryPoint? pt = TrajectoryMath.BracketPointAtUT(traj.Points, currentUT, ref cached);
                         stateVectorCachedIndices[idx] = cached;
 
-                        if (pt.HasValue && ShouldCreateStateVectorOrbit(pt.Value.altitude, pt.Value.velocity.magnitude))
+                        double atmosCreate = pt.HasValue ? GetAtmosphereDepth(pt.Value.bodyName) : 0;
+                        if (pt.HasValue && ShouldCreateStateVectorOrbit(pt.Value.altitude, pt.Value.velocity.magnitude, atmosCreate))
                         {
                             if (toCreateFromStateVectors == null)
                                 toCreateFromStateVectors = new List<KeyValuePair<int, TrajectoryPoint>>();
@@ -655,7 +680,8 @@ namespace Parsek
 
                     if (!pt.HasValue) continue;
 
-                    if (ShouldRemoveStateVectorOrbit(pt.Value.altitude, pt.Value.velocity.magnitude))
+                    double atmosRemove = GetAtmosphereDepth(pt.Value.bodyName);
+                    if (ShouldRemoveStateVectorOrbit(pt.Value.altitude, pt.Value.velocity.magnitude, atmosRemove))
                     {
                         GhostMapPresence.RemoveGhostVesselForRecording(idx, "below-state-vector-threshold");
                         if (toReDefer == null) toReDefer = new List<int>();

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using ClickThroughFix;
+using KSP.UI.Screens.Mapview;
 using UnityEngine;
 
 namespace Parsek
@@ -23,7 +25,9 @@ namespace Parsek
 
         // Map view markers
         private GUIStyle mapMarkerStyle;
-        private Texture2D mapMarkerDiamond;
+        private Texture2D mapMarkerDiamond; // fallback when atlas unavailable
+        private static Texture2D vesselIconAtlas;
+        private static Dictionary<VesselType, Rect> vesselIconUVs;
 
         // Recordings window
         private bool showRecordingsWindow;
@@ -4104,7 +4108,10 @@ namespace Parsek
 
                 string ghostName = kvp.Key < committed.Count ? committed[kvp.Key].VesselName : "Ghost";
                 Color markerColor = GetGhostMarkerColor(kvp.Key, committed);
-                DrawMapMarkerAt(kvp.Value.transform.position, ghostName, markerColor);
+                VesselType vtype = kvp.Key < committed.Count
+                    ? GhostMapPresence.ResolveVesselType(committed[kvp.Key].VesselSnapshot)
+                    : VesselType.Ship;
+                DrawMapMarkerAt(kvp.Value.transform.position, ghostName, markerColor, vtype);
             }
         }
 
@@ -4151,7 +4158,8 @@ namespace Parsek
             }
         }
 
-        private void DrawMapMarkerAt(Vector3 worldPos, string label, Color color)
+        private void DrawMapMarkerAt(Vector3 worldPos, string label, Color color,
+            VesselType vtype = VesselType.Ship)
         {
             Vector3 screenPos;
             if (MapView.MapIsEnabled)
@@ -4171,11 +4179,24 @@ namespace Parsek
             float x = screenPos.x;
             float y = Screen.height - screenPos.y;
 
-            // Draw diamond marker (matches KSP's orbit icon shape)
+            // Draw vessel type icon from KSP atlas, or diamond fallback
             Color prevColor = GUI.color;
             GUI.color = color;
-            int iconSize = 16;
-            GUI.DrawTexture(new Rect(x - iconSize / 2, y - iconSize / 2, iconSize, iconSize), mapMarkerDiamond);
+            int iconSize = 20;
+            Rect uvRect;
+            if (vesselIconAtlas != null && vesselIconUVs != null
+                && vesselIconUVs.TryGetValue(vtype, out uvRect))
+            {
+                GUI.DrawTextureWithTexCoords(
+                    new Rect(x - iconSize / 2, y - iconSize / 2, iconSize, iconSize),
+                    vesselIconAtlas, uvRect);
+            }
+            else
+            {
+                GUI.DrawTexture(
+                    new Rect(x - iconSize / 2, y - iconSize / 2, iconSize, iconSize),
+                    mapMarkerDiamond);
+            }
             GUI.color = prevColor;
 
             // Draw vessel name label
@@ -4185,18 +4206,21 @@ namespace Parsek
 
         private void EnsureMapMarkerResources()
         {
+            // Try to load KSP's stock vessel icon atlas from the MapView prefab
+            if (vesselIconAtlas == null && MapView.fetch != null)
+                InitVesselTypeIcons();
+
+            // Fallback diamond texture (used when atlas unavailable)
             if (mapMarkerDiamond == null)
             {
-                // Generate a diamond (rotated square) texture matching KSP's orbit icon style
                 int size = 16;
                 mapMarkerDiamond = new Texture2D(size, size, TextureFormat.ARGB32, false);
                 float center = size / 2f;
-                float halfDiag = size / 2f - 1f; // diamond extends to 1px from edge
+                float halfDiag = size / 2f - 1f;
                 for (int py = 0; py < size; py++)
                 {
                     for (int px = 0; px < size; px++)
                     {
-                        // Diamond: |x - center| + |y - center| <= halfDiag
                         float manhattan = Mathf.Abs(px - center + 0.5f) + Mathf.Abs(py - center + 0.5f);
                         mapMarkerDiamond.SetPixel(px, py, manhattan <= halfDiag ? Color.white : Color.clear);
                     }
@@ -4211,6 +4235,62 @@ namespace Parsek
                 mapMarkerStyle.fontStyle = FontStyle.Bold;
                 mapMarkerStyle.alignment = TextAnchor.UpperCenter;
             }
+        }
+
+        private static void InitVesselTypeIcons()
+        {
+            vesselIconAtlas = MapView.OrbitIconsMap;
+            if (vesselIconAtlas == null) return;
+
+            var prefab = MapView.UINodePrefab;
+            if (prefab == null) return;
+
+            var fi = typeof(MapNode).GetField("iconSprites",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            if (fi == null)
+            {
+                ParsekLog.Warn("UI", "InitVesselTypeIcons: iconSprites field not found on MapNode");
+                vesselIconAtlas = null;
+                return;
+            }
+
+            var sprites = fi.GetValue(prefab) as Sprite[];
+            if (sprites == null || sprites.Length == 0)
+            {
+                ParsekLog.Warn("UI", "InitVesselTypeIcons: iconSprites is null or empty");
+                vesselIconAtlas = null;
+                return;
+            }
+
+            // VesselType → sprite index mapping from decompiled MapNode.GetIconIndex
+            var mapping = new Dictionary<VesselType, int>
+            {
+                { VesselType.Ship,        20 }, { VesselType.Probe,    18 },
+                { VesselType.Rover,       19 }, { VesselType.Station,   0 },
+                { VesselType.Plane,       23 }, { VesselType.Lander,   14 },
+                { VesselType.Base,         5 }, { VesselType.EVA,      13 },
+                { VesselType.Relay,       24 }, { VesselType.Debris,    7 },
+                { VesselType.SpaceObject, 21 },
+            };
+
+            float atlasW = vesselIconAtlas.width;
+            float atlasH = vesselIconAtlas.height;
+            vesselIconUVs = new Dictionary<VesselType, Rect>();
+
+            foreach (var kvp in mapping)
+            {
+                if (kvp.Value < sprites.Length && sprites[kvp.Value] != null)
+                {
+                    Rect texRect = sprites[kvp.Value].textureRect;
+                    vesselIconUVs[kvp.Key] = new Rect(
+                        texRect.x / atlasW, texRect.y / atlasH,
+                        texRect.width / atlasW, texRect.height / atlasH);
+                }
+            }
+
+            ParsekLog.Info("UI",
+                $"InitVesselTypeIcons: loaded {vesselIconUVs.Count} vessel type icons from atlas " +
+                $"({atlasW}x{atlasH}, {sprites.Length} sprites)");
         }
 
         /// <summary>

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -4094,8 +4094,15 @@ namespace Parsek
             foreach (var kvp in flight.TimelineGhosts)
             {
                 if (kvp.Value == null) continue;
+                // Skip if native KSP icon is active (ProtoVessel exists and icon not suppressed).
+                // When the Harmony patch suppresses the icon (below atmosphere), we draw
+                // our custom marker at the ghost mesh position instead.
                 if (GhostMapPresence.HasGhostVesselForRecording(kvp.Key))
-                    continue;
+                {
+                    uint ghostPid = GhostMapPresence.GetGhostVesselPidForRecording(kvp.Key);
+                    if (ghostPid == 0 || !GhostMapPresence.ghostsWithSuppressedIcon.Contains(ghostPid))
+                        continue; // native icon is active — skip our marker
+                }
                 if (kvp.Key < committed.Count)
                 {
                     if (committed[kvp.Key].IsDebris)
@@ -4179,20 +4186,21 @@ namespace Parsek
             float x = screenPos.x;
             float y = Screen.height - screenPos.y;
 
-            // Draw vessel type icon from KSP atlas, or diamond fallback
+            // Draw vessel type icon from KSP atlas (untinted — original icon colors)
             Color prevColor = GUI.color;
-            GUI.color = color;
             int iconSize = 20;
             Rect uvRect;
             if (vesselIconAtlas != null && vesselIconUVs != null
                 && vesselIconUVs.TryGetValue(vtype, out uvRect))
             {
+                GUI.color = Color.white;
                 GUI.DrawTextureWithTexCoords(
                     new Rect(x - iconSize / 2, y - iconSize / 2, iconSize, iconSize),
                     vesselIconAtlas, uvRect);
             }
             else
             {
+                GUI.color = color;
                 GUI.DrawTexture(
                     new Rect(x - iconSize / 2, y - iconSize / 2, iconSize, iconSize),
                     mapMarkerDiamond);
@@ -4201,7 +4209,7 @@ namespace Parsek
 
             // Draw vessel name label
             mapMarkerStyle.normal.textColor = color;
-            GUI.Label(new Rect(x - 75, y + iconSize / 2 + 2, 150, 20), label, mapMarkerStyle);
+            GUI.Label(new Rect(x - 75, y + iconSize / 2 + 2, 150, 20), "Ghost: " + label, mapMarkerStyle);
         }
 
         private void EnsureMapMarkerResources()

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -23,7 +23,7 @@ namespace Parsek
 
         // Map view markers
         private GUIStyle mapMarkerStyle;
-        private Texture2D mapMarkerTexture;
+        private Texture2D mapMarkerDiamond;
 
         // Recordings window
         private bool showRecordingsWindow;
@@ -4063,15 +4063,15 @@ namespace Parsek
             // Manual preview ghost
             if (flight.IsPlaying && flight.PreviewGhost != null)
             {
-                DrawMapMarkerAt(flight.PreviewGhost.transform.position, "Preview", Color.green);
+                DrawMapMarkerAt(flight.PreviewGhost.transform.position, "Preview",
+                    new Color(0.2f, 1f, 0.4f, 0.9f));
             }
 
             // Timeline ghosts — skip if a ghost map ProtoVessel exists for this index
-            // (the native KSP vessel icon replaces this dot and tracks the correct orbital position).
+            // (the native KSP vessel icon replaces this marker and tracks the correct orbital position).
             // Deduplicate per chain: during warp, multiple chain segments can be active
             // simultaneously. Only draw the marker for the highest-index (latest) ghost per chain.
             var committed = RecordingStore.CommittedRecordings;
-            Color ghostColor = new Color(0.2f, 1f, 0.4f, 0.9f);
 
             // First pass: find the highest active index per chain
             chainTipIndexBuffer.Clear();
@@ -4101,8 +4101,10 @@ namespace Parsek
                         && chainTipIndexBuffer.TryGetValue(chainId, out int tip) && kvp.Key != tip)
                         continue; // not the tip — skip duplicate
                 }
+
                 string ghostName = kvp.Key < committed.Count ? committed[kvp.Key].VesselName : "Ghost";
-                DrawMapMarkerAt(kvp.Value.transform.position, ghostName, ghostColor);
+                Color markerColor = GetGhostMarkerColor(kvp.Key, committed);
+                DrawMapMarkerAt(kvp.Value.transform.position, ghostName, markerColor);
             }
         }
 
@@ -4120,8 +4122,33 @@ namespace Parsek
             ReleaseActionsInputLock();
             ReleaseSettingsInputLock();
             ReleaseSpawnControlInputLock();
-            if (mapMarkerTexture != null)
-                UnityEngine.Object.Destroy(mapMarkerTexture);
+            if (mapMarkerDiamond != null)
+                UnityEngine.Object.Destroy(mapMarkerDiamond);
+        }
+
+        /// <summary>
+        /// Returns the orbit color for a ghost marker based on vessel type from the
+        /// recording snapshot. Matches KSP's own orbit color scheme.
+        /// </summary>
+        private static Color GetGhostMarkerColor(int index, System.Collections.Generic.IReadOnlyList<Recording> committed)
+        {
+            if (index < 0 || index >= committed.Count)
+                return new Color(0.63f, 0.63f, 0.63f); // grey fallback
+
+            VesselType vtype = GhostMapPresence.ResolveVesselType(committed[index].VesselSnapshot);
+            switch (vtype)
+            {
+                case VesselType.Ship:    return new Color(0.78f, 0.78f, 0.0f);  // yellow
+                case VesselType.Probe:   return new Color(0.84f, 0.46f, 0.0f);  // orange
+                case VesselType.Relay:   return new Color(0.41f, 0.67f, 0.0f);  // green
+                case VesselType.Rover:   return new Color(0.55f, 0.78f, 0.22f); // lime
+                case VesselType.Station: return new Color(0.0f, 0.63f, 0.90f);  // blue
+                case VesselType.Plane:   return new Color(0.63f, 0.46f, 0.78f); // purple
+                case VesselType.Lander:  return new Color(0.78f, 0.67f, 0.0f);  // gold
+                case VesselType.Base:    return new Color(0.22f, 0.67f, 0.67f); // teal
+                case VesselType.EVA:     return new Color(0.78f, 0.78f, 0.78f); // light grey
+                default:                 return new Color(0.63f, 0.63f, 0.63f); // grey
+            }
         }
 
         private void DrawMapMarkerAt(Vector3 worldPos, string label, Color color)
@@ -4144,34 +4171,37 @@ namespace Parsek
             float x = screenPos.x;
             float y = Screen.height - screenPos.y;
 
-            // Draw marker dot
+            // Draw diamond marker (matches KSP's orbit icon shape)
             Color prevColor = GUI.color;
             GUI.color = color;
-            GUI.DrawTexture(new Rect(x - 5, y - 5, 10, 10), mapMarkerTexture);
+            int iconSize = 16;
+            GUI.DrawTexture(new Rect(x - iconSize / 2, y - iconSize / 2, iconSize, iconSize), mapMarkerDiamond);
             GUI.color = prevColor;
 
             // Draw vessel name label
             mapMarkerStyle.normal.textColor = color;
-            GUI.Label(new Rect(x - 75, y + 7, 150, 20), label, mapMarkerStyle);
+            GUI.Label(new Rect(x - 75, y + iconSize / 2 + 2, 150, 20), label, mapMarkerStyle);
         }
 
         private void EnsureMapMarkerResources()
         {
-            if (mapMarkerTexture == null)
+            if (mapMarkerDiamond == null)
             {
-                int size = 10;
-                mapMarkerTexture = new Texture2D(size, size, TextureFormat.ARGB32, false);
+                // Generate a diamond (rotated square) texture matching KSP's orbit icon style
+                int size = 16;
+                mapMarkerDiamond = new Texture2D(size, size, TextureFormat.ARGB32, false);
                 float center = size / 2f;
-                float radius = size / 2f - 1f;
+                float halfDiag = size / 2f - 1f; // diamond extends to 1px from edge
                 for (int py = 0; py < size; py++)
                 {
                     for (int px = 0; px < size; px++)
                     {
-                        float dist = Mathf.Sqrt((px - center) * (px - center) + (py - center) * (py - center));
-                        mapMarkerTexture.SetPixel(px, py, dist <= radius ? Color.white : Color.clear);
+                        // Diamond: |x - center| + |y - center| <= halfDiag
+                        float manhattan = Mathf.Abs(px - center + 0.5f) + Mathf.Abs(py - center + 0.5f);
+                        mapMarkerDiamond.SetPixel(px, py, manhattan <= halfDiag ? Color.white : Color.clear);
                     }
                 }
-                mapMarkerTexture.Apply();
+                mapMarkerDiamond.Apply();
             }
 
             if (mapMarkerStyle == null)

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -4086,7 +4086,7 @@ namespace Parsek
                     chainTipIndexBuffer[chainId] = kvp.Key;
             }
 
-            // Second pass: draw markers, skipping non-tip chain members
+            // Second pass: draw markers, skipping non-tip chain members and debris
             foreach (var kvp in flight.TimelineGhosts)
             {
                 if (kvp.Value == null) continue;
@@ -4094,6 +4094,8 @@ namespace Parsek
                     continue;
                 if (kvp.Key < committed.Count)
                 {
+                    if (committed[kvp.Key].IsDebris)
+                        continue;
                     string chainId = committed[kvp.Key].ChainId;
                     if (!string.IsNullOrEmpty(chainId) && chainTipIndexBuffer.Count > 0
                         && chainTipIndexBuffer.TryGetValue(chainId, out int tip) && kvp.Key != tip)

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -4213,10 +4213,10 @@ namespace Parsek
                 }
 
                 string ghostName = kvp.Key < committed.Count ? committed[kvp.Key].VesselName : "Ghost";
-                Color markerColor = GetGhostMarkerColor(kvp.Key, committed);
                 VesselType vtype = kvp.Key < committed.Count
                     ? GhostMapPresence.ResolveVesselType(committed[kvp.Key].VesselSnapshot)
                     : VesselType.Ship;
+                Color markerColor = GetGhostMarkerColorForType(vtype);
                 DrawMapMarkerAt(kvp.Value.transform.position, ghostName, markerColor, vtype);
             }
         }
@@ -4240,15 +4240,11 @@ namespace Parsek
         }
 
         /// <summary>
-        /// Returns the orbit color for a ghost marker based on vessel type from the
-        /// recording snapshot. Matches KSP's own orbit color scheme.
+        /// Returns the orbit color for a ghost marker by vessel type.
+        /// Matches KSP's own orbit color scheme.
         /// </summary>
-        private static Color GetGhostMarkerColor(int index, System.Collections.Generic.IReadOnlyList<Recording> committed)
+        private static Color GetGhostMarkerColorForType(VesselType vtype)
         {
-            if (index < 0 || index >= committed.Count)
-                return new Color(0.63f, 0.63f, 0.63f); // grey fallback
-
-            VesselType vtype = GhostMapPresence.ResolveVesselType(committed[index].VesselSnapshot);
             switch (vtype)
             {
                 case VesselType.Ship:    return new Color(0.78f, 0.78f, 0.0f);  // yellow
@@ -4369,7 +4365,9 @@ namespace Parsek
                 return;
             }
 
-            // VesselType → sprite index mapping from decompiled MapNode.GetIconIndex
+            // VesselType → sprite index mapping from decompiled MapNode.GetIconIndex.
+            // KSP-version-dependent: indices may change if the atlas is reordered.
+            // Failure is graceful — falls back to diamond texture.
             var mapping = new Dictionary<VesselType, int>
             {
                 { VesselType.Ship,        20 }, { VesselType.Probe,    18 },

--- a/Source/Parsek/Patches/GhostOrbitLinePatch.cs
+++ b/Source/Parsek/Patches/GhostOrbitLinePatch.cs
@@ -37,6 +37,11 @@ namespace Parsek.Patches
             if (body == null)
                 return;
 
+            // Uses orbit-propagated altitude, not the ghost mesh altitude. The ghost mesh
+            // lives on a separate GameObject (engine's ghostStates) that this Harmony patch
+            // has no access to. Orbit altitude may diverge slightly from the ghost mesh
+            // during reentry (Keplerian vs drag-affected), but for the atmosphere boundary
+            // decision this is acceptable — the divergence is small near the boundary.
             if (body.atmosphere && __instance.vessel.orbit.altitude < body.atmosphereDepth)
             {
                 // Below atmosphere: hide orbit line AND native icon.

--- a/Source/Parsek/Patches/GhostOrbitLinePatch.cs
+++ b/Source/Parsek/Patches/GhostOrbitLinePatch.cs
@@ -1,0 +1,56 @@
+using HarmonyLib;
+
+namespace Parsek.Patches
+{
+    /// <summary>
+    /// Suppresses the orbit line for ghost map ProtoVessels when they are below the
+    /// atmosphere. The map icon (vessel type icon) stays visible because DrawNodes()
+    /// already ran before this postfix. The orbit line is only meaningful in vacuum —
+    /// atmospheric drag makes the Keplerian approximation produce wild/flickering lines.
+    ///
+    /// Architecture: OrbitRendererBase.LateUpdate calls DrawOrbit() then DrawNodes().
+    /// DrawOrbit sets OrbitLine.active = true and renders the line. DrawNodes renders
+    /// the vessel icon (MapNode). This postfix runs after both, setting OrbitLine.active
+    /// = false to suppress the line while the icon remains visible.
+    ///
+    /// Also hides Ap/Pe/AN/DN markers when the orbit line is hidden — they would float
+    /// in space with no line connecting them.
+    /// </summary>
+    [HarmonyPatch(typeof(OrbitRendererBase), "LateUpdate")]
+    internal static class GhostOrbitLinePatch
+    {
+        static void Postfix(OrbitRendererBase __instance)
+        {
+            if (__instance.vessel == null)
+                return;
+
+            if (!GhostMapPresence.IsGhostMapVessel(__instance.vessel.persistentId))
+                return;
+
+            var line = __instance.OrbitLine;
+            if (line == null)
+                return;
+
+            // Check if the ghost is below atmosphere — orbit line should be hidden.
+            // Uses the orbit-derived altitude (OrbitDriver propagation), which is
+            // approximately correct since we update the orbit every 0.5s.
+            CelestialBody body = __instance.vessel.orbitDriver?.celestialBody;
+            if (body == null)
+                return;
+
+            if (body.atmosphere && __instance.vessel.orbit.altitude < body.atmosphereDepth)
+            {
+                line.active = false;
+                // Show only the vessel icon, hide Ap/Pe/AN/DN (they float without a line)
+                __instance.drawIcons = OrbitRendererBase.DrawIcons.OBJ;
+            }
+            else
+            {
+                // Above atmosphere — ensure orbit line and full icons are enabled.
+                // DrawOrbit already set line.active = true, but drawIcons may be
+                // stale from a previous below-atmosphere frame.
+                __instance.drawIcons = OrbitRendererBase.DrawIcons.ALL;
+            }
+        }
+    }
+}

--- a/Source/Parsek/Patches/GhostOrbitLinePatch.cs
+++ b/Source/Parsek/Patches/GhostOrbitLinePatch.cs
@@ -3,18 +3,19 @@ using HarmonyLib;
 namespace Parsek.Patches
 {
     /// <summary>
-    /// Suppresses the orbit line for ghost map ProtoVessels when they are below the
-    /// atmosphere. The map icon (vessel type icon) stays visible because DrawNodes()
-    /// already ran before this postfix. The orbit line is only meaningful in vacuum —
-    /// atmospheric drag makes the Keplerian approximation produce wild/flickering lines.
+    /// Suppresses the orbit line AND native icon for ghost map ProtoVessels when
+    /// below atmosphere. The orbit line is meaningless during atmospheric flight
+    /// (drag makes Keplerian propagation diverge from recorded trajectory). The
+    /// native icon is also hidden because its position comes from OrbitDriver
+    /// propagation — which drifts far from the ghost mesh during reentry.
+    ///
+    /// When both are hidden, ParsekUI.DrawMapMarkers draws our custom vessel-type
+    /// icon at the ghost mesh position (always correct). Tracked via
+    /// GhostMapPresence.ghostsWithSuppressedIcon so DrawMapMarkers knows to draw.
     ///
     /// Architecture: OrbitRendererBase.LateUpdate calls DrawOrbit() then DrawNodes().
-    /// DrawOrbit sets OrbitLine.active = true and renders the line. DrawNodes renders
-    /// the vessel icon (MapNode). This postfix runs after both, setting OrbitLine.active
-    /// = false to suppress the line while the icon remains visible.
-    ///
-    /// Also hides Ap/Pe/AN/DN markers when the orbit line is hidden — they would float
-    /// in space with no line connecting them.
+    /// This postfix runs after both, suppressing the Vectrosity line and all MapNode
+    /// icons for ghost vessels below atmosphere.
     /// </summary>
     [HarmonyPatch(typeof(OrbitRendererBase), "LateUpdate")]
     internal static class GhostOrbitLinePatch
@@ -24,32 +25,33 @@ namespace Parsek.Patches
             if (__instance.vessel == null)
                 return;
 
-            if (!GhostMapPresence.IsGhostMapVessel(__instance.vessel.persistentId))
+            uint pid = __instance.vessel.persistentId;
+            if (!GhostMapPresence.IsGhostMapVessel(pid))
                 return;
 
             var line = __instance.OrbitLine;
             if (line == null)
                 return;
 
-            // Check if the ghost is below atmosphere — orbit line should be hidden.
-            // Uses the orbit-derived altitude (OrbitDriver propagation), which is
-            // approximately correct since we update the orbit every 0.5s.
             CelestialBody body = __instance.vessel.orbitDriver?.celestialBody;
             if (body == null)
                 return;
 
             if (body.atmosphere && __instance.vessel.orbit.altitude < body.atmosphereDepth)
             {
+                // Below atmosphere: hide orbit line AND native icon.
+                // The icon position tracks OrbitDriver propagation (Keplerian, no drag),
+                // which diverges from the ghost mesh (recorded trajectory with drag).
+                // Our custom DrawMapMarkers draws the correct icon at the ghost mesh pos.
                 line.active = false;
-                // Show only the vessel icon, hide Ap/Pe/AN/DN (they float without a line)
-                __instance.drawIcons = OrbitRendererBase.DrawIcons.OBJ;
+                __instance.drawIcons = OrbitRendererBase.DrawIcons.NONE;
+                GhostMapPresence.ghostsWithSuppressedIcon.Add(pid);
             }
             else
             {
-                // Above atmosphere — ensure orbit line and full icons are enabled.
-                // DrawOrbit already set line.active = true, but drawIcons may be
-                // stale from a previous below-atmosphere frame.
+                // Above atmosphere: show orbit line and all icons (vessel + Ap/Pe/AN/DN).
                 __instance.drawIcons = OrbitRendererBase.DrawIcons.ALL;
+                GhostMapPresence.ghostsWithSuppressedIcon.Remove(pid);
             }
         }
     }

--- a/Source/Parsek/Patches/GhostOrbitLinePatch.cs
+++ b/Source/Parsek/Patches/GhostOrbitLinePatch.cs
@@ -1,7 +1,26 @@
 using HarmonyLib;
+using UnityEngine;
 
 namespace Parsek.Patches
 {
+    /// <summary>
+    /// Prevents KSP from destroying ghost ProtoVessels due to on-rails atmospheric
+    /// pressure. Ghost ProtoVessels orbit through the atmosphere (e.g., deorbit orbit
+    /// with sub-surface periapsis). KSP's Vessel.CheckKill() destroys on-rails vessels
+    /// at > 1 kPa pressure. If the PlanetariumCamera is focused on the ghost, Die()
+    /// nulls the camera target → cascade of NullRefs → planet disappears.
+    /// </summary>
+    [HarmonyPatch(typeof(Vessel), "CheckKill")]
+    internal static class GhostCheckKillPatch
+    {
+        static bool Prefix(Vessel __instance)
+        {
+            if (GhostMapPresence.IsGhostMapVessel(__instance.persistentId))
+                return false; // skip CheckKill entirely for ghost vessels
+            return true;
+        }
+    }
+
     /// <summary>
     /// Suppresses the orbit line AND native icon for ghost map ProtoVessels when
     /// below atmosphere. The orbit line is meaningless during atmospheric flight

--- a/Source/Parsek/TrajectoryMath.cs
+++ b/Source/Parsek/TrajectoryMath.cs
@@ -408,16 +408,16 @@ namespace Parsek
         }
 
         /// <summary>
-        /// Returns the lower-bracket TrajectoryPoint at the given UT, or null if the
-        /// point list is empty or UT is before recording start. For UT past recording
-        /// end, returns the last valid bracket point (clamped).
+        /// Returns the nearest recorded TrajectoryPoint at the given UT, or null if the
+        /// point list is empty/null or UT is before recording start. For UT past recording
+        /// end, returns the last point. For mid-range UT, returns the lower bracket point.
         ///
         /// Uses the bracket point's recorded values directly (no interpolation) for
         /// orbit accuracy — same pattern as VesselSpawner. The bracket point represents
         /// the last sampled physics state, which produces a more physically correct orbit
         /// than interpolated values.
         /// </summary>
-        internal static TrajectoryPoint? InterpolateAtUT(
+        internal static TrajectoryPoint? BracketPointAtUT(
             List<TrajectoryPoint> points, double ut, ref int cachedIndex)
         {
             if (points == null || points.Count == 0)
@@ -433,8 +433,9 @@ namespace Parsek
                 return null;
             }
 
-            // Return the lower bracket point directly (not interpolated).
-            return before;
+            // Past end: t is clamped to 1 — return the upper bracket (last point).
+            // Mid-range: return the lower bracket (most recent sampled state).
+            return t >= 1f ? after : before;
         }
 
         internal static double InterpolateAltitude(double altBefore, double altAfter, float t)

--- a/Source/Parsek/TrajectoryMath.cs
+++ b/Source/Parsek/TrajectoryMath.cs
@@ -407,6 +407,36 @@ namespace Parsek
             return true;
         }
 
+        /// <summary>
+        /// Returns the lower-bracket TrajectoryPoint at the given UT, or null if the
+        /// point list is empty or UT is before recording start. For UT past recording
+        /// end, returns the last valid bracket point (clamped).
+        ///
+        /// Uses the bracket point's recorded values directly (no interpolation) for
+        /// orbit accuracy — same pattern as VesselSpawner. The bracket point represents
+        /// the last sampled physics state, which produces a more physically correct orbit
+        /// than interpolated values.
+        /// </summary>
+        internal static TrajectoryPoint? InterpolateAtUT(
+            List<TrajectoryPoint> points, double ut, ref int cachedIndex)
+        {
+            if (points == null || points.Count == 0)
+                return null;
+
+            bool found = InterpolatePoints(points, ref cachedIndex, ut,
+                out TrajectoryPoint before, out TrajectoryPoint after, out float t);
+
+            if (!found)
+            {
+                // InterpolatePoints returns false for empty list or UT before start.
+                // Empty already handled above, so this is UT before start → null.
+                return null;
+            }
+
+            // Return the lower bracket point directly (not interpolated).
+            return before;
+        }
+
         internal static double InterpolateAltitude(double altBefore, double altAfter, float t)
         {
             return altBefore + (altAfter - altBefore) * t;

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -247,11 +247,11 @@ Ghost orbit lines look identical to real vessel orbit lines. Should have a disti
 
 **Priority:** Low — cosmetic, functional without it
 
-### T41. Ghost orbit line persists during non-orbital playback phases
+### T41. Ghost orbit line for suborbital recordings
 
-When a recording-index ghost exits an orbital segment (e.g., atmospheric re-entry), the ghost map ProtoVessel's orbit line remains at the last segment's orbit. It should either disappear during non-orbital phases or be removed and re-created when the ghost re-enters an orbital segment.
+Suborbital recordings were excluded from ghost map presence — no orbit line during playback. Now relaxed: HandleGhostCreated allows SubOrbital terminal state through. Two paths: (1) recordings with orbit segments use the existing deferred mechanism, (2) physics-only recordings construct the orbit from interpolated state vectors when altitude > 1500m and speed > 60 m/s. Hysteresis thresholds (remove at alt < 500m or speed < 30 m/s) prevent create/destroy churn. RELATIVE-frame recordings are guarded against. Tracking station still excludes SubOrbital.
 
-**Priority:** Low — minor visual inconsistency, ghost mesh shows correct position
+**Status:** Fixed (0.6.0)
 
 ### T42. Convert KerbalsModule to IResourceModule
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -253,6 +253,12 @@ Suborbital recordings were excluded from ghost map presence — no orbit line du
 
 **Status:** Fixed (0.6.0)
 
+### T41b. Skip orbit segment recording during in-atmosphere on-rails
+
+When the player time-warps during atmospheric reentry, KSP puts the vessel on-rails and the recorder creates an orbit segment with Keplerian elements (no drag). During playback, the ghost follows this dragless arc instead of the real trajectory. Surface clamp (PR #113) prevents underground tunneling, but the position is approximate. Fix: in FlightRecorder's `onVesselGoOnRails` handler, check `v.mainBody.atmosphere && v.altitude < v.mainBody.atmosphereDepth` — if below atmosphere, skip orbit segment creation. Point interpolation will lerp across the gap during playback.
+
+**Priority:** Medium — affects any recording where the player warped through atmospheric flight
+
 ### T42. Convert KerbalsModule to IResourceModule
 
 KerbalsModule currently operates as a bridge outside the RecalculationEngine — it iterates recordings directly instead of consuming GameAction objects via the IResourceModule interface. The ledger already captures kerbal data as KerbalAssignment/KerbalHire/KerbalRescue/KerbalStandIn actions, but KerbalsModule ignores them and re-derives everything from recordings. Converting requires: (1) making KerbalsModule non-static (currently static class, can't implement interface), (2) rewriting Recalculate to consume actions instead of recordings, (3) routing 16+ direct `KerbalsModule.RecalculateAndApply()` call sites through `LedgerOrchestrator.RecalculateAndPatch()`. Wide blast radius, no functional gain — the bridge pattern works fine. Do this when there's already a reason to restructure KerbalsModule.

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -2421,6 +2421,14 @@ When a vessel goes on-rails (time warp) during atmospheric flight — typically 
 
 **Status:** Fixed (0.6.0, PR #116) — added `ShouldSkipOrbitSegmentForAtmosphere` check in FlightRecorder (`OnVesselGoOnRails` + `StartRecording` on-rails init) and BackgroundRecorder (`InitializeOnRailsState`). When below atmosphere, orbit segment creation is skipped. Point interpolation lerps across the gap, which is visually correct. No physics frame samples during on-rails (PhysicsFramePatch only fires for unpacked vessels), so the gap is expected.
 
+## 211. Ghost ProtoVessel destroyed by on-rails atmospheric pressure (planet disappears)
+
+KSP's `Vessel.CheckKill()` destroys on-rails vessels at > 1 kPa atmospheric pressure. Ghost ProtoVessels with deorbit orbits (periapsis below surface) pass through the atmosphere, triggering this check. If the `PlanetariumCamera` was focused on the ghost, `Die()` nulled the camera target → cascade of 174K+ NullReferenceExceptions in `ScaledSpaceFader`, `AtmosphereFromGround`, `Sun.LateUpdate` → planet rendering broke, game became unresponsive, exit screen stuck.
+
+**Root cause:** Ghost ProtoVessels were not protected against `Vessel.CheckKill()`. The existing `GhostVesselLoadPatch` prevented `GoOffRails` but not the separate pressure destruction path.
+
+**Status:** Fixed (0.6.0, PR #113) — new `GhostCheckKillPatch` Harmony prefix on `Vessel.CheckKill` returns false for ghost vessels, skipping the pressure check entirely.
+
 # In-Game Tests
 
 - [x] Vessels propagate naturally along orbits after FF (no position freezing)


### PR DESCRIPTION
## Summary

- Suborbital recordings now show orbit lines during flight-scene ghost playback above atmosphere
- Atmosphere-aware orbit line: hidden below `body.atmosphereDepth` via Harmony postfix on `OrbitRendererBase.LateUpdate`
- Stock KSP vessel type icons replace the old green dot map markers (loaded from MapView orbit icon atlas)
- Native icon suppressed below atmosphere; custom icon drawn at ghost mesh position (seamless handoff)
- Debris recordings hidden from map markers
- Ghost mesh clamped to surface when deorbit orbit goes underground (orbit-only recording sections)
- State-vector orbit construction for physics-only suborbital recordings (above atmosphere on airless bodies)
- Hysteresis thresholds prevent orbit line create/destroy churn

## Files changed

- `ParsekPlaybackPolicy.cs` — relaxed terminal filter, state-vector orbit path, atmosphere-aware thresholds
- `GhostMapPresence.cs` — state-vector orbit methods, icon suppression tracking, vessel PID lookup
- `GhostPlaybackEngine.cs` — no changes (engine layer untouched)
- `TrajectoryMath.cs` — `BracketPointAtUT` helper
- `ParsekFlight.cs` — surface clamp in `PositionGhostFromOrbit`
- `ParsekUI.cs` — stock icon atlas loading, vessel-type-colored markers, "Ghost:" label prefix
- `Patches/GhostOrbitLinePatch.cs` — new Harmony postfix hiding orbit line + icon below atmosphere
- `Parsek.csproj` — added Assembly-CSharp-firstpass and UnityEngine.UI references
- Tests — 31+ new tests (interpolation, thresholds, hysteresis, RELATIVE guard)
- `CHANGELOG.md`, `todo-and-known-bugs.md`

## Known limitation

Orbit-only recording sections (from time-warping through atmospheric reentry) use Keplerian orbit data that ignores drag. The ghost follows a ballistic arc instead of the drag-affected trajectory during these windows. Surface clamp prevents underground tunneling but position is approximate. Follow-up: skip orbit segment creation during in-atmosphere on-rails periods (recording-side fix).

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 4716 pass, 0 fail
- [x] In-game: orbit line visible above atmosphere during suborbital coast
- [x] In-game: orbit line hidden during atmospheric flight
- [x] In-game: stock vessel type icons on map markers
- [x] Tracking station: suborbital recordings excluded
- [x] In-game: verify reentry icon position with surface clamp