### PR TITLE
Reset recording format to version 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Parsek are documented here.
 
 ## 0.6.0
 
+### Format Reset
+
+- **Recording format reset to version 0 (PR #114).** Clean break: reset `CurrentRecordingFormatVersion` from 7 to 0. Removed all legacy format migration code (v4→v5 rotation conversion, `SyncVersionFromPrecFile`, `CorrectForBodyRotation`), the `surfaceRelativeRotation` version-branching (all rotation is now unconditionally surface-relative), ghost geometry legacy fields (`GhostGeometryVersion`, `GhostGeometryCaptureStrategy`, `GhostGeometryProbeStatus`), and the `loopPauseSeconds` field-rename fallback. -500 lines. No behavioral change — all removed code paths were already dead (no users with old-format recordings exist).
+
 ### Release & Distribution
 
 - **Parsek.version file (T1).** Added `GameData/Parsek/Parsek.version` for AVC and CKAN version detection. Auto-copied to KSP GameData on build.

--- a/Source/Parsek.Tests/Fixtures/DefaultCareer/persistent.sfs
+++ b/Source/Parsek.Tests/Fixtures/DefaultCareer/persistent.sfs
@@ -1651,7 +1651,7 @@ GAME
 		RECORDING
 		{
 			recordingId = a8d8257d67074fb5a3019835ad98b940
-			recordingFormatVersion = 5
+			recordingFormatVersion = 0
 			loopPlayback = True
 			loopIntervalSeconds = -11
 			preLaunchFunds = 167663.56045532227
@@ -1672,7 +1672,7 @@ GAME
 		RECORDING
 		{
 			recordingId = 27453fa1bb54418d88c66a4c37ac353e
-			recordingFormatVersion = 5
+			recordingFormatVersion = 0
 			loopPlayback = True
 			loopIntervalSeconds = -10
 			preLaunchFunds = 167663.55947875977
@@ -1693,7 +1693,7 @@ GAME
 		RECORDING
 		{
 			recordingId = 19af059a51f54e5a8ec50a51d4fef5de
-			recordingFormatVersion = 5
+			recordingFormatVersion = 0
 			loopPlayback = True
 			loopIntervalSeconds = -20
 			preLaunchFunds = 167663.55947875977
@@ -1714,7 +1714,7 @@ GAME
 		RECORDING
 		{
 			recordingId = 0529a6dc73e84bc5b1363b339ed6ae41
-			recordingFormatVersion = 5
+			recordingFormatVersion = 0
 			loopPlayback = True
 			loopIntervalSeconds = 10
 			preLaunchFunds = 153663.55947875977
@@ -1735,7 +1735,7 @@ GAME
 		RECORDING
 		{
 			recordingId = b5c17c46e61b4ae8bee24c84ace61e80
-			recordingFormatVersion = 5
+			recordingFormatVersion = 0
 			loopPlayback = True
 			loopIntervalSeconds = 10
 			preLaunchFunds = 167663.55947875977
@@ -1756,7 +1756,7 @@ GAME
 		RECORDING
 		{
 			recordingId = a20373eea78e4475883bf918d0bdf782
-			recordingFormatVersion = 5
+			recordingFormatVersion = 0
 			loopPlayback = True
 			loopIntervalSeconds = 10
 			preLaunchFunds = 161868.42633056641
@@ -1777,7 +1777,7 @@ GAME
 		RECORDING
 		{
 			recordingId = 7cf806dc28614815bae23b8ed141da90
-			recordingFormatVersion = 5
+			recordingFormatVersion = 0
 			loopPlayback = True
 			loopIntervalSeconds = 10
 			preLaunchFunds = 150828.42535400391
@@ -1798,7 +1798,7 @@ GAME
 		RECORDING
 		{
 			recordingId = 74449492df524d89a44bec5370a4a6d8
-			recordingFormatVersion = 5
+			recordingFormatVersion = 0
 			loopPlayback = True
 			loopIntervalSeconds = 10
 			preLaunchFunds = 139788.42437744141
@@ -1819,7 +1819,7 @@ GAME
 		RECORDING
 		{
 			recordingId = 99724b73424c4189a1a6242b598af957
-			recordingFormatVersion = 5
+			recordingFormatVersion = 0
 			loopPlayback = True
 			loopIntervalSeconds = 10
 			preLaunchFunds = 128748.42340087891

--- a/Source/Parsek.Tests/FormatVersionTests.cs
+++ b/Source/Parsek.Tests/FormatVersionTests.cs
@@ -5,8 +5,7 @@ using Xunit;
 namespace Parsek.Tests
 {
     /// <summary>
-    /// Tests for recording format version 6 bump and the backward compatibility
-    /// playback gate (TrackSections present in v6, absent in v5).
+    /// Tests for recording format version and the TrackSections playback gate.
     /// </summary>
     [Collection("Sequential")]
     public class FormatVersionTests
@@ -25,9 +24,9 @@ namespace Parsek.Tests
         #region Version constants
 
         [Fact]
-        public void CurrentRecordingFormatVersion_Is7()
+        public void CurrentRecordingFormatVersion_Is0()
         {
-            Assert.Equal(7, RecordingStore.CurrentRecordingFormatVersion);
+            Assert.Equal(0, RecordingStore.CurrentRecordingFormatVersion);
         }
 
         [Fact]
@@ -39,50 +38,17 @@ namespace Parsek.Tests
 
         #endregion
 
-        #region v5 backward compat: loads with empty TrackSections and SegmentEvents
+        #region Recording with TrackSections loads correctly
 
         [Fact]
-        public void V5Recording_PointsOnly_LoadsWithEmptyTrackSectionsAndSegmentEvents()
-        {
-            // Simulate a v5 .prec file: POINT nodes only, no TRACK_SECTION or SEGMENT_EVENT
-            var precNode = new ConfigNode("PARSEK_RECORDING");
-            precNode.AddValue("version", "5");
-            precNode.AddValue("recordingId", "v5_legacy_test");
-
-            AddMinimalPoint(precNode, 17000.0);
-            AddMinimalPoint(precNode, 17010.0);
-            AddMinimalPoint(precNode, 17020.0);
-
-            var rec = new Recording();
-            rec.RecordingId = "v5_legacy_test";
-            rec.RecordingFormatVersion = 5;
-            RecordingStore.DeserializeTrajectoryFrom(precNode, rec);
-
-            // Points loaded normally
-            Assert.Equal(3, rec.Points.Count);
-            Assert.Equal(17000.0, rec.Points[0].ut);
-            Assert.Equal(17020.0, rec.Points[2].ut);
-
-            // No TrackSections or SegmentEvents in v5
-            Assert.Empty(rec.TrackSections);
-            Assert.Empty(rec.SegmentEvents);
-        }
-
-        #endregion
-
-        #region v6 recording: loads with populated TrackSections
-
-        [Fact]
-        public void V6Recording_WithTrackSections_LoadsPopulatedTrackSections()
+        public void Recording_WithTrackSections_LoadsPopulatedTrackSections()
         {
             var precNode = new ConfigNode("PARSEK_RECORDING");
-            precNode.AddValue("version", "6");
-            precNode.AddValue("recordingId", "v6_track_test");
+            precNode.AddValue("version", "0");
+            precNode.AddValue("recordingId", "track_test");
 
-            // Legacy points (may coexist with TrackSections during transition)
             AddMinimalPoint(precNode, 17000.0);
 
-            // Add a TRACK_SECTION node
             var tsNode = precNode.AddNode("TRACK_SECTION");
             tsNode.AddValue("env", "0");  // Atmospheric
             tsNode.AddValue("ref", "0");  // Absolute
@@ -90,7 +56,6 @@ namespace Parsek.Tests
             tsNode.AddValue("endUT", "17050");
             tsNode.AddValue("sampleRate", "10");
 
-            // Add a frame inside the track section
             var frameNode = tsNode.AddNode("POINT");
             frameNode.AddValue("ut", "17000");
             frameNode.AddValue("lat", "-0.097");
@@ -104,18 +69,15 @@ namespace Parsek.Tests
             frameNode.AddValue("funds", "0"); frameNode.AddValue("science", "0");
             frameNode.AddValue("rep", "0");
 
-            // Add a SEGMENT_EVENT
             var seNode = precNode.AddNode("SEGMENT_EVENT");
             seNode.AddValue("ut", "17030");
             seNode.AddValue("type", "0");  // ControllerChange
             seNode.AddValue("details", "stage 1 sep");
 
             var rec = new Recording();
-            rec.RecordingId = "v6_track_test";
-            rec.RecordingFormatVersion = 6;
+            rec.RecordingId = "track_test";
             RecordingStore.DeserializeTrajectoryFrom(precNode, rec);
 
-            // TrackSections populated
             Assert.Single(rec.TrackSections);
             Assert.Equal(SegmentEnvironment.Atmospheric, rec.TrackSections[0].environment);
             Assert.Equal(ReferenceFrame.Absolute, rec.TrackSections[0].referenceFrame);
@@ -123,7 +85,6 @@ namespace Parsek.Tests
             Assert.Equal(17050.0, rec.TrackSections[0].endUT);
             Assert.Single(rec.TrackSections[0].frames);
 
-            // SegmentEvents populated
             Assert.Single(rec.SegmentEvents);
             Assert.Equal(17030.0, rec.SegmentEvents[0].ut);
             Assert.Equal(SegmentEventType.ControllerChange, rec.SegmentEvents[0].type);
@@ -132,36 +93,32 @@ namespace Parsek.Tests
 
         #endregion
 
-        #region Playback gate: TrackSections.Count distinguishes v5 from v6
+        #region Playback gate: TrackSections.Count > 0
 
         [Fact]
-        public void PlaybackGate_V5Recording_TrackSectionsEmpty()
+        public void PlaybackGate_NoTrackSections_False()
         {
-            // Build a v5 recording with only Points
             var precNode = new ConfigNode("PARSEK_RECORDING");
-            precNode.AddValue("version", "5");
-            precNode.AddValue("recordingId", "v5_gate_test");
+            precNode.AddValue("version", "0");
+            precNode.AddValue("recordingId", "gate_test");
 
             AddMinimalPoint(precNode, 17000.0);
             AddMinimalPoint(precNode, 17010.0);
 
             var rec = new Recording();
-            rec.RecordingId = "v5_gate_test";
-            rec.RecordingFormatVersion = 5;
+            rec.RecordingId = "gate_test";
             RecordingStore.DeserializeTrajectoryFrom(precNode, rec);
 
-            // Playback gate: v5 recordings have no TrackSections
             bool useTrackSections = rec.TrackSections.Count > 0;
             Assert.False(useTrackSections);
         }
 
         [Fact]
-        public void PlaybackGate_V6Recording_WithTrackSections_True()
+        public void PlaybackGate_WithTrackSections_True()
         {
-            // Build a v6 recording with a TrackSection
             var precNode = new ConfigNode("PARSEK_RECORDING");
-            precNode.AddValue("version", "6");
-            precNode.AddValue("recordingId", "v6_gate_test");
+            precNode.AddValue("version", "0");
+            precNode.AddValue("recordingId", "gate_test_ts");
 
             var tsNode = precNode.AddNode("TRACK_SECTION");
             tsNode.AddValue("env", "0");
@@ -171,11 +128,9 @@ namespace Parsek.Tests
             tsNode.AddValue("sampleRate", "10");
 
             var rec = new Recording();
-            rec.RecordingId = "v6_gate_test";
-            rec.RecordingFormatVersion = 6;
+            rec.RecordingId = "gate_test_ts";
             RecordingStore.DeserializeTrajectoryFrom(precNode, rec);
 
-            // Playback gate: v6 recordings have TrackSections
             bool useTrackSections = rec.TrackSections.Count > 0;
             Assert.True(useTrackSections);
         }
@@ -185,7 +140,7 @@ namespace Parsek.Tests
         #region RecordingBuilder version default
 
         [Fact]
-        public void RecordingBuilder_DefaultVersion_Is7()
+        public void RecordingBuilder_DefaultVersion_Is0()
         {
             var builder = new Parsek.Tests.Generators.RecordingBuilder("TestVessel");
             builder.AddPoint(17000, 0, 0, 100);
@@ -193,24 +148,24 @@ namespace Parsek.Tests
 
             var trajectoryNode = builder.BuildTrajectoryNode();
             string version = trajectoryNode.GetValue("version");
-            Assert.Equal("7", version);
+            Assert.Equal("0", version);
         }
 
         [Fact]
-        public void RecordingBuilder_WithFormatVersion5_WritesVersion5()
+        public void RecordingBuilder_WithCustomFormatVersion_WritesCustomVersion()
         {
             var builder = new Parsek.Tests.Generators.RecordingBuilder("TestVessel");
-            builder.WithFormatVersion(5);
+            builder.WithFormatVersion(42);
             builder.AddPoint(17000, 0, 0, 100);
             builder.AddPoint(17010, 0, 0, 200);
 
             var trajectoryNode = builder.BuildTrajectoryNode();
             string version = trajectoryNode.GetValue("version");
-            Assert.Equal("5", version);
+            Assert.Equal("42", version);
 
             var metadataNode = builder.BuildV3Metadata();
             string metaVersion = metadataNode.GetValue("recordingFormatVersion");
-            Assert.Equal("5", metaVersion);
+            Assert.Equal("42", metaVersion);
         }
 
         #endregion

--- a/Source/Parsek.Tests/Generators/RecordingBuilder.cs
+++ b/Source/Parsek.Tests/Generators/RecordingBuilder.cs
@@ -42,7 +42,7 @@ namespace Parsek.Tests.Generators
         private float defaultRotX, defaultRotY, defaultRotZ;
         private float defaultRotW = 1;
         private bool hasDefaultRotation;
-        private int formatVersion = 7;
+        private int formatVersion = 0;
 
         public RecordingBuilder(string vesselName)
         {

--- a/Source/Parsek.Tests/MockTrajectory.cs
+++ b/Source/Parsek.Tests/MockTrajectory.cs
@@ -14,7 +14,7 @@ namespace Parsek.Tests
         public List<TrackSection> TrackSections { get; set; } = new List<TrackSection>();
         public double StartUT => Points.Count > 0 ? Points[0].ut : 0;
         public double EndUT => Points.Count > 0 ? Points[Points.Count - 1].ut : 0;
-        public int RecordingFormatVersion { get; set; } = 6;
+        public int RecordingFormatVersion { get; set; } = 0;
         public List<PartEvent> PartEvents { get; set; } = new List<PartEvent>();
         public List<FlagEvent> FlagEvents { get; set; } = new List<FlagEvent>();
         public ConfigNode GhostVisualSnapshot { get; set; }

--- a/Source/Parsek.Tests/PlaybackTrajectoryTests.cs
+++ b/Source/Parsek.Tests/PlaybackTrajectoryTests.cs
@@ -118,9 +118,9 @@ namespace Parsek.Tests
         public void Recording_RecordingFormatVersion_Matches()
         {
             var rec = new Recording();
-            rec.RecordingFormatVersion = 6;
+            rec.RecordingFormatVersion = 0;
             IPlaybackTrajectory traj = rec;
-            Assert.Equal(6, traj.RecordingFormatVersion);
+            Assert.Equal(0, traj.RecordingFormatVersion);
         }
 
         [Fact]
@@ -312,7 +312,7 @@ namespace Parsek.Tests
         {
             var mock = new MockTrajectory
             {
-                RecordingFormatVersion = 5,
+                RecordingFormatVersion = 0,
                 VesselName = "Probe",
                 LoopPlayback = true,
                 LoopIntervalSeconds = -15,
@@ -327,7 +327,7 @@ namespace Parsek.Tests
             };
 
             IPlaybackTrajectory traj = mock;
-            Assert.Equal(5, traj.RecordingFormatVersion);
+            Assert.Equal(0, traj.RecordingFormatVersion);
             Assert.Equal("Probe", traj.VesselName);
             Assert.True(traj.LoopPlayback);
             Assert.Equal(-15, traj.LoopIntervalSeconds, 6);

--- a/Source/Parsek.Tests/RecordingBuilderV6Tests.cs
+++ b/Source/Parsek.Tests/RecordingBuilderV6Tests.cs
@@ -518,7 +518,7 @@ namespace Parsek.Tests
             Assert.Equal("True", metadata.GetValue("isDebris"));
 
             // Format version
-            Assert.Equal("7", metadata.GetValue("recordingFormatVersion"));
+            Assert.Equal("0", metadata.GetValue("recordingFormatVersion"));
         }
 
         [Fact]

--- a/Source/Parsek.Tests/RecordingOptimizerTests.cs
+++ b/Source/Parsek.Tests/RecordingOptimizerTests.cs
@@ -956,11 +956,11 @@ namespace Parsek.Tests
         {
             var rec = MakeRecordingWithSections(17000, 17030, 17060,
                 SegmentEnvironment.ExoBallistic, SegmentEnvironment.Atmospheric);
-            rec.RecordingFormatVersion = 7;
+            rec.RecordingFormatVersion = 0;
 
             var second = RecordingOptimizer.SplitAtSection(rec, 1);
 
-            Assert.Equal(7, second.RecordingFormatVersion);
+            Assert.Equal(0, second.RecordingFormatVersion);
         }
 
         #endregion

--- a/Source/Parsek.Tests/RecordingStoreTests.cs
+++ b/Source/Parsek.Tests/RecordingStoreTests.cs
@@ -241,11 +241,11 @@ namespace Parsek.Tests
                 points,
                 "Ship",
                 recordingId: "fixedid",
-                recordingFormatVersion: 7);
+                recordingFormatVersion: 0);
 
             Assert.True(RecordingStore.HasPending);
             Assert.Equal("fixedid", RecordingStore.Pending.RecordingId);
-            Assert.Equal(7, RecordingStore.Pending.RecordingFormatVersion);
+            Assert.Equal(0, RecordingStore.Pending.RecordingFormatVersion);
         }
 
         [Fact]
@@ -258,7 +258,7 @@ namespace Parsek.Tests
             var source = new Recording
             {
                 RecordingId = "abc",
-                RecordingFormatVersion = 9,
+                RecordingFormatVersion = 0,
                 VesselSnapshot = vesselSnapshot,
                 GhostVisualSnapshot = ghostSnapshot,
                 DistanceFromLaunch = 123,
@@ -279,7 +279,7 @@ namespace Parsek.Tests
             target.ApplyPersistenceArtifactsFrom(source);
 
             Assert.Equal("abc", target.RecordingId);
-            Assert.Equal(9, target.RecordingFormatVersion);
+            Assert.Equal(0, target.RecordingFormatVersion);
             Assert.NotNull(target.VesselSnapshot);
             Assert.NotNull(target.GhostVisualSnapshot);
             Assert.Equal("Vessel A", target.VesselSnapshot.GetValue("name"));
@@ -296,46 +296,13 @@ namespace Parsek.Tests
             Assert.Equal("Mun", target.OrbitSegments[0].bodyName);
         }
 
-        /// <summary>
-        /// Verifies that legacy ghost geometry fields populated on the source recording
-        /// are NOT propagated to the target. Catches regressions if someone re-adds
-        /// ghost geometry copying to ApplyPersistenceArtifactsFrom.
-        /// </summary>
-        [Fact]
-        public void ApplyPersistenceArtifactsFrom_DoesNotCopyLegacyGhostGeometryFields()
-        {
-            var source = new Recording
-            {
-                RecordingId = "src",
-                // Simulate a legacy recording that had ghost geometry fields populated
-                GhostGeometryRelativePath = "Parsek/Recordings/src.pcrf",
-                GhostGeometryAvailable = true,
-                GhostGeometryCaptureError = "none",
-                GhostGeometryCaptureStrategy = "live_hierarchy_probe_v1",
-                GhostGeometryProbeStatus = "ready_for_hierarchy_clone",
-                GhostGeometryVersion = 5,
-            };
-            source.Points.AddRange(MakePoints(3));
-
-            var target = new Recording { VesselName = "Target", Points = MakePoints(2) };
-            target.ApplyPersistenceArtifactsFrom(source);
-
-            // Ghost geometry fields must NOT transfer — they are dead legacy fields
-            Assert.Null(target.GhostGeometryRelativePath);
-            Assert.False(target.GhostGeometryAvailable);
-            Assert.Null(target.GhostGeometryCaptureError);
-            Assert.Null(target.GhostGeometryCaptureStrategy);
-            Assert.Null(target.GhostGeometryProbeStatus);
-            Assert.Equal(1, target.GhostGeometryVersion); // default, not copied from source
-        }
-
         [Fact]
         public void RecordingMetadata_SaveLoad_RoundTrip()
         {
             var source = new Recording
             {
                 RecordingId = "meta123",
-                RecordingFormatVersion = 12,
+                RecordingFormatVersion = 0,
                 LoopPlayback = true,
                 LoopIntervalSeconds = 2.5,
             };
@@ -347,15 +314,10 @@ namespace Parsek.Tests
             ParsekScenario.LoadRecordingMetadata(node, loaded);
 
             Assert.Equal("meta123", loaded.RecordingId);
-            Assert.Equal(12, loaded.RecordingFormatVersion);
+            Assert.Equal(0, loaded.RecordingFormatVersion);
             Assert.True(loaded.LoopPlayback);
             Assert.Equal(2.5, loaded.LoopIntervalSeconds);
 
-            // Ghost geometry fields are no longer serialized on save
-            Assert.Null(node.GetValue("ghostGeometryVersion"));
-            Assert.Null(node.GetValue("ghostGeometryStrategy"));
-            Assert.Null(node.GetValue("ghostGeometryPath"));
-            Assert.Null(node.GetValue("ghostGeometryAvailable"));
         }
 
         [Fact]
@@ -431,29 +393,6 @@ namespace Parsek.Tests
             ParsekScenario.LoadRecordingMetadata(node, loaded);
 
             Assert.False(loaded.Hidden);
-        }
-
-        [Fact]
-        public void RecordingMetadata_BackwardCompat_LoadsLegacyGhostGeometryFields()
-        {
-            // Legacy save files may contain ghost geometry fields — verify they deserialize
-            // without error (backward compat) even though they're no longer written.
-            var node = new ConfigNode("RECORDING");
-            node.AddValue("recordingId", "legacy-rec");
-            node.AddValue("ghostGeometryVersion", "8");
-            node.AddValue("ghostGeometryStrategy", "live_hierarchy_probe_v1");
-            node.AddValue("ghostGeometryProbeStatus", "ready_for_hierarchy_clone");
-            node.AddValue("ghostGeometryPath", "Parsek/Recordings/legacy.pcrf");
-            node.AddValue("ghostGeometryAvailable", "True");
-            node.AddValue("ghostGeometryError", "none");
-
-            var loaded = new Recording();
-            ParsekScenario.LoadRecordingMetadata(node, loaded);
-
-            Assert.Equal("legacy-rec", loaded.RecordingId);
-            Assert.Equal(8, loaded.GhostGeometryVersion);
-            Assert.Equal("Parsek/Recordings/legacy.pcrf", loaded.GhostGeometryRelativePath);
-            Assert.True(loaded.GhostGeometryAvailable);
         }
 
         [Fact]
@@ -1139,56 +1078,6 @@ namespace Parsek.Tests
             // Duration is locale-formatted ("45.3" or "45,3"), just check it contains "45"
             Assert.Contains("45", msg);
             Assert.Contains("Duration:", msg);
-        }
-
-        [Fact]
-        public void SyncVersionFromPrecFile_UpgradesStaleMetadata()
-        {
-            var rec = new Recording
-            {
-                RecordingId = "synctest",
-                RecordingFormatVersion = 4
-            };
-
-            var precNode = new ConfigNode("PARSEK_RECORDING");
-            precNode.AddValue("version", "5");
-
-            RecordingStore.SyncVersionFromPrecFile(precNode, rec);
-
-            Assert.Equal(5, rec.RecordingFormatVersion);
-        }
-
-        [Fact]
-        public void SyncVersionFromPrecFile_DoesNotDowngrade()
-        {
-            var rec = new Recording
-            {
-                RecordingId = "synctest",
-                RecordingFormatVersion = 5
-            };
-
-            var precNode = new ConfigNode("PARSEK_RECORDING");
-            precNode.AddValue("version", "4");
-
-            RecordingStore.SyncVersionFromPrecFile(precNode, rec);
-
-            Assert.Equal(5, rec.RecordingFormatVersion);
-        }
-
-        [Fact]
-        public void SyncVersionFromPrecFile_NoVersionField_NoChange()
-        {
-            var rec = new Recording
-            {
-                RecordingId = "synctest",
-                RecordingFormatVersion = 4
-            };
-
-            var precNode = new ConfigNode("PARSEK_RECORDING");
-
-            RecordingStore.SyncVersionFromPrecFile(precNode, rec);
-
-            Assert.Equal(4, rec.RecordingFormatVersion);
         }
 
         // --- Stationary point trimming tests ---

--- a/Source/Parsek.Tests/RecordingTreeTests.cs
+++ b/Source/Parsek.Tests/RecordingTreeTests.cs
@@ -902,63 +902,6 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void RecordingTree_SaveRecordingInto_DoesNotWriteGhostGeometryFields()
-        {
-            var rec = new Recording
-            {
-                RecordingId = "rec_no_geom",
-                VesselName = "TestShip",
-                RecordingFormatVersion = 5,
-                // Simulate legacy fields being populated (e.g., from deserialization)
-                GhostGeometryVersion = 8,
-                GhostGeometryRelativePath = "Parsek/Recordings/rec_no_geom.pcrf",
-                GhostGeometryAvailable = true,
-                GhostGeometryCaptureError = "none",
-                GhostGeometryCaptureStrategy = "live_hierarchy_probe_v1",
-                GhostGeometryProbeStatus = "ready_for_hierarchy_clone",
-            };
-
-            var node = new ConfigNode("RECORDING");
-            RecordingTree.SaveRecordingInto(node, rec);
-
-            // Ghost geometry fields must NOT be written
-            Assert.Null(node.GetValue("ghostGeometryVersion"));
-            Assert.Null(node.GetValue("ghostGeometryStrategy"));
-            Assert.Null(node.GetValue("ghostGeometryProbeStatus"));
-            Assert.Null(node.GetValue("ghostGeometryPath"));
-            Assert.Null(node.GetValue("ghostGeometryAvailable"));
-            Assert.Null(node.GetValue("ghostGeometryError"));
-
-            // Core fields should still be written
-            Assert.Equal("rec_no_geom", node.GetValue("recordingId"));
-            Assert.Equal("5", node.GetValue("recordingFormatVersion"));
-        }
-
-        [Fact]
-        public void RecordingTree_LoadRecordingFrom_StillReadsLegacyGhostGeometryFields()
-        {
-            // Legacy tree save files may contain ghost geometry fields — backward compat
-            var node = new ConfigNode("RECORDING");
-            node.AddValue("recordingId", "legacy_tree_rec");
-            node.AddValue("vesselName", "LegacyShip");
-            node.AddValue("ghostGeometryVersion", "3");
-            node.AddValue("ghostGeometryStrategy", "live_hierarchy_probe_v1");
-            node.AddValue("ghostGeometryProbeStatus", "ready_for_hierarchy_clone");
-            node.AddValue("ghostGeometryPath", "Parsek/Recordings/legacy.pcrf");
-            node.AddValue("ghostGeometryAvailable", "True");
-            node.AddValue("ghostGeometryError", "none");
-
-            var rec = new Recording();
-            RecordingTree.LoadRecordingFrom(node, rec);
-
-            // Fields should be populated from the legacy data
-            Assert.Equal(3, rec.GhostGeometryVersion);
-            Assert.Equal("Parsek/Recordings/legacy.pcrf", rec.GhostGeometryRelativePath);
-            Assert.True(rec.GhostGeometryAvailable);
-            Assert.Equal("none", rec.GhostGeometryCaptureError);
-        }
-
-        [Fact]
         public void BranchPoint_EmptyParentChildLists_HandleGracefully()
         {
             var bp = new BranchPoint
@@ -1137,13 +1080,9 @@ namespace Parsek.Tests
             recNode.AddValue("recordingId", "rec_fwd");
             recNode.AddValue("vesselName", "Future Ship");
             recNode.AddValue("vesselPersistentId", "999");
-            recNode.AddValue("recordingFormatVersion", "4");
-            recNode.AddValue("ghostGeometryVersion", "1");
+            recNode.AddValue("recordingFormatVersion", "0");
             recNode.AddValue("loopPlayback", "False");
             recNode.AddValue("loopIntervalSeconds", "10");
-            recNode.AddValue("ghostGeometryStrategy", "stub_v1");
-            recNode.AddValue("ghostGeometryProbeStatus", "unknown");
-            recNode.AddValue("ghostGeometryAvailable", "False");
             recNode.AddValue("lastResIdx", "-1");
             recNode.AddValue("pointCount", "0");
 

--- a/Source/Parsek.Tests/SyntheticRecordingTests.cs
+++ b/Source/Parsek.Tests/SyntheticRecordingTests.cs
@@ -91,7 +91,7 @@ namespace Parsek.Tests
         // Reentry South:     +0s   to +90s   (90s looped ghost, reentry FX)
 
         // Approximate "upright on surface" rotation at KSC for UT ~17000.
-        // Surface-relative rotation for upright vessel at KSC pad (v5 format).
+        // Surface-relative rotation for upright vessel at KSC pad.
         // Captured empirically from v.srfRelRotation in KSP runtime.
         private const float KscRotX = -0.7009714f, KscRotY = -0.09230039f, KscRotZ = -0.09728389f, KscRotW = 0.7004681f;
 
@@ -2908,7 +2908,7 @@ namespace Parsek.Tests
             // Has metadata
             Assert.Equal("Test Vessel", v3Node.GetValue("vesselName"));
             Assert.Equal("abc123", v3Node.GetValue("recordingId"));
-            Assert.Equal("7", v3Node.GetValue("recordingFormatVersion"));
+            Assert.Equal("0", v3Node.GetValue("recordingFormatVersion"));
             Assert.Equal("2", v3Node.GetValue("pointCount"));
 
             // No inline bulk data
@@ -2946,7 +2946,7 @@ namespace Parsek.Tests
             var trajNode = builder.BuildTrajectoryNode();
 
             Assert.Equal("PARSEK_RECORDING", trajNode.name);
-            Assert.Equal("7", trajNode.GetValue("version"));
+            Assert.Equal("0", trajNode.GetValue("version"));
             Assert.Equal("abc123", trajNode.GetValue("recordingId"));
             Assert.Equal(2, trajNode.GetNodes("POINT").Length);
             Assert.Single(trajNode.GetNodes("ORBIT_SEGMENT"));
@@ -2954,19 +2954,19 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void RecordingBuilder_WithFormatVersion4_PreservesV4()
+        public void RecordingBuilder_WithCustomFormatVersion_PreservesVersion()
         {
-            var builder = new RecordingBuilder("V4 Test")
-                .WithRecordingId("v4test")
-                .WithFormatVersion(4)
+            var builder = new RecordingBuilder("Custom Version Test")
+                .WithRecordingId("customvertest")
+                .WithFormatVersion(42)
                 .AddPoint(100, 0, 0, 0)
                 .AddPoint(103, 0.1, 0.1, 100);
 
             var trajNode = builder.BuildTrajectoryNode();
-            Assert.Equal("4", trajNode.GetValue("version"));
+            Assert.Equal("42", trajNode.GetValue("version"));
 
             var metaNode = builder.BuildV3Metadata();
-            Assert.Equal("4", metaNode.GetValue("recordingFormatVersion"));
+            Assert.Equal("42", metaNode.GetValue("recordingFormatVersion"));
         }
 
         [Fact]
@@ -2978,7 +2978,7 @@ namespace Parsek.Tests
             var scenarioNode = writer.BuildScenarioNode();
             var recNode = scenarioNode.GetNodes("RECORDING")[0];
 
-            Assert.Equal("7", recNode.GetValue("recordingFormatVersion"));
+            Assert.Equal("0", recNode.GetValue("recordingFormatVersion"));
             Assert.Equal("KSC Hopper", recNode.GetValue("vesselName"));
             Assert.Empty(recNode.GetNodes("POINT"));
             Assert.Null(recNode.GetNode("VESSEL_SNAPSHOT"));
@@ -5527,7 +5527,7 @@ namespace Parsek.Tests
 
                     // v3: no inline trajectory POINT data in .sfs
                     // (BRANCH_POINT nodes in RECORDING_TREE are expected)
-                    Assert.Contains("recordingFormatVersion = 7", content);
+                    Assert.Contains("recordingFormatVersion = 0", content);
                     var scenarioSection = content.Substring(
                         content.IndexOf("name = ParsekScenario"),
                         content.IndexOf("FLIGHTSTATE") - content.IndexOf("name = ParsekScenario"));

--- a/Source/Parsek.Tests/TreeCommitTests.cs
+++ b/Source/Parsek.Tests/TreeCommitTests.cs
@@ -451,13 +451,9 @@ namespace Parsek.Tests
 
             node.AddValue("lastResIdx", "7");
             node.AddValue("pointCount", "10");
-            node.AddValue("recordingFormatVersion", "4");
-            node.AddValue("ghostGeometryVersion", "1");
+            node.AddValue("recordingFormatVersion", "0");
             node.AddValue("loopPlayback", "False");
             node.AddValue("loopIntervalSeconds", "10");
-            node.AddValue("ghostGeometryStrategy", "stub_v1");
-            node.AddValue("ghostGeometryProbeStatus", "unknown");
-            node.AddValue("ghostGeometryAvailable", "False");
 
             var rec = new Recording();
             RecordingTree.LoadRecordingFrom(node, rec);

--- a/Source/Parsek/FlagEvent.cs
+++ b/Source/Parsek/FlagEvent.cs
@@ -10,7 +10,7 @@ namespace Parsek
         public double latitude;
         public double longitude;
         public double altitude;
-        public float rotX, rotY, rotZ, rotW; // surface-relative rotation (v5)
+        public float rotX, rotY, rotZ, rotW; // surface-relative rotation
         public string bodyName;       // body the flag is on
 
         public override string ToString()

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -33,7 +33,7 @@ namespace Parsek
         public List<SegmentEvent> SegmentEvents { get; } = new List<SegmentEvent>();
         public List<TrackSection> TrackSections { get; } = new List<TrackSection>();
 
-        // Environment tracking (v6+)
+        // Environment tracking
         private EnvironmentHysteresis environmentHysteresis;
         private TrackSection currentTrackSection;
         private bool trackSectionActive;
@@ -4017,7 +4017,7 @@ namespace Parsek
                 $"inAtmo={wasInAtmosphere}, hasAtmo={v.mainBody?.atmosphere}, alt={v.altitude:F0}m" +
                 $", altThreshold={currentAltitudeThreshold:F0}m, aboveThreshold={wasAboveAltitudeThreshold}");
 
-            // Initialize environment tracking (v6+)
+            // Initialize environment tracking
             TrackSections.Clear();
             var initialEnv = ClassifyCurrentEnvironment(v);
             environmentHysteresis = new EnvironmentHysteresis(initialEnv);
@@ -4280,7 +4280,7 @@ namespace Parsek
                 }
             }
 
-            // Close final TrackSection (v6+)
+            // Close final TrackSection
             CloseCurrentTrackSection(Planetarium.GetUniversalTime());
 
             // Clear RELATIVE mode state
@@ -4541,7 +4541,7 @@ namespace Parsek
             CheckFairingState(v);
             CheckRoboticState(v);
 
-            // Environment tracking (v6+) — runs every physics frame regardless of adaptive sampling
+            // Environment tracking — runs every physics frame regardless of adaptive sampling
             if (environmentHysteresis != null)
             {
                 var rawEnv = ClassifyCurrentEnvironment(v);
@@ -4627,7 +4627,7 @@ namespace Parsek
             lastRecordedUT = point.ut;
             lastRecordedVelocity = point.velocity;
 
-            // Dual-write: flat Points list (backward compat) + current TrackSection (v6+)
+            // Dual-write: flat Points list + current TrackSection
             if (trackSectionActive && currentTrackSection.frames != null)
             {
                 currentTrackSection.frames.Add(point);
@@ -4687,7 +4687,7 @@ namespace Parsek
             lastRecordedVelocity = point.velocity;
             ParsekLog.Verbose("Recorder", $"Boundary point sampled at UT={point.ut:F1}");
 
-            // Dual-write: flat Points list (backward compat) + current TrackSection (v6+)
+            // Dual-write: flat Points list + current TrackSection
             if (trackSectionActive && currentTrackSection.frames != null)
             {
                 currentTrackSection.frames.Add(point);
@@ -5004,7 +5004,7 @@ namespace Parsek
                 isOnRails = false;
             }
 
-            // Close current TrackSection before backgrounding (v6+)
+            // Close current TrackSection before backgrounding
             CloseCurrentTrackSection(Planetarium.GetUniversalTime());
 
             // Start a new orbit segment for the background phase.

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -105,9 +105,6 @@ namespace Parsek
             // SinglePoint fields (also used body/lat/lon/alt from "before")
             // (uses bodyBefore, latBefore, lonBefore, altBefore, pointUT, interpolatedRot)
 
-            // v5+: rotation is surface-relative (multiply by body rotation at playback)
-            // v4:  rotation is world-space (use CorrectForBodyRotation time-delta correction)
-            public bool surfaceRelativeRotation;
 
             // Orbit fields
             public int orbitCacheKey;
@@ -467,9 +464,7 @@ namespace Parsek
                             e.latAfter, e.lonAfter, e.altAfter);
                         Vector3d pos = Vector3d.Lerp(posBefore, posAfter, e.t);
                         e.ghost.transform.position = pos;
-                        e.ghost.transform.rotation = e.surfaceRelativeRotation
-                            ? e.bodyBefore.bodyTransform.rotation * e.interpolatedRot
-                            : CorrectForBodyRotation(e.bodyBefore, e.pointUT, e.interpolatedRot);
+                        e.ghost.transform.rotation = e.bodyBefore.bodyTransform.rotation * e.interpolatedRot;
                         break;
                     }
                     case GhostPosMode.SinglePoint:
@@ -478,9 +473,7 @@ namespace Parsek
                         Vector3d pos = e.bodyBefore.GetWorldSurfacePosition(
                             e.latBefore, e.lonBefore, e.altBefore);
                         e.ghost.transform.position = pos;
-                        e.ghost.transform.rotation = e.surfaceRelativeRotation
-                            ? e.bodyBefore.bodyTransform.rotation * e.interpolatedRot
-                            : CorrectForBodyRotation(e.bodyBefore, e.pointUT, e.interpolatedRot);
+                        e.ghost.transform.rotation = e.bodyBefore.bodyTransform.rotation * e.interpolatedRot;
                         break;
                     }
                     case GhostPosMode.Orbit:
@@ -3510,7 +3503,7 @@ namespace Parsek
             Vessel flagVessel = flagSite.vessel;
             CelestialBody body = flagVessel.mainBody;
 
-            // Compute surface-relative rotation (v5 format)
+            // Compute surface-relative rotation
             Quaternion worldRot = flagVessel.transform.rotation;
             Quaternion surfRot = Quaternion.Inverse(body.bodyTransform.rotation) * worldRot;
 
@@ -3611,16 +3604,6 @@ namespace Parsek
             {
                 ParsekLog.Warn("Flight", "FlightResults safety net: replaying suppressed results on OnFlightReady");
                 Patches.FlightResultsPatch.ReplayFlightResults();
-            }
-
-            // Auto-migrate v4 recordings to v5 (world-space → surface-relative rotation)
-            if (FlightGlobals.Bodies != null && FlightGlobals.Bodies.Count > 0)
-            {
-                foreach (var rec in RecordingStore.CommittedRecordings)
-                {
-                    if (rec.RecordingFormatVersion < 5 && rec.Points.Count > 0)
-                        RecordingStore.MigrateV4ToV5(rec);
-                }
             }
 
             ResetFlightReadyState();
@@ -3840,8 +3823,7 @@ namespace Parsek
 
         /// <summary>
         /// Resets all transient state on flight ready: background recorder, tree, chain,
-        /// split detection, dock/undock, merge detection. Called at the start of OnFlightReady
-        /// after v4-to-v5 migration.
+        /// split detection, dock/undock, merge detection. Called at the start of OnFlightReady.
         /// </summary>
         private void ResetFlightReadyState()
         {
@@ -5481,7 +5463,7 @@ namespace Parsek
                         : SurfaceSituation.Landed
                 };
 
-                // Capture terrain height for terrain correction on spawn (v7+)
+                // Capture terrain height for terrain correction on spawn
                 if (vessel.mainBody != null)
                 {
                     rec.TerrainHeightAtEnd = vessel.mainBody.TerrainAltitude(vessel.latitude, vessel.longitude);
@@ -5684,12 +5666,11 @@ namespace Parsek
             }
 
             InterpolationResult interpResult;
-            bool srfRel = previewRecording != null && previewRecording.RecordingFormatVersion >= 5;
             bool surfaceSkip = previewRecording != null &&
                 TrajectoryMath.IsSurfaceAtUT(previewRecording.TrackSections, recordingTime);
             InterpolateAndPosition(ghostObject, recording, orbitSegments,
                 ref lastPlaybackIndex, recordingTime, 10000, out interpResult,
-                surfaceRelativeRotation: srfRel, skipOrbitSegments: surfaceSkip);
+                skipOrbitSegments: surfaceSkip);
 
             if (previewGhostState != null && previewRecording != null)
             {
@@ -5834,11 +5815,10 @@ namespace Parsek
                 if (bgRec != null && bgRec.Points.Count > 0)
                 {
                     // Position from trajectory points (same interpolation as existing ghost positioning)
-                    bool srfRel = bgRec.RecordingFormatVersion >= 5;
                     bool surfaceSkip = TrajectoryMath.IsSurfaceAtUT(bgRec.TrackSections, currentUT);
                     InterpolateAndPosition(info.ghostGO, bgRec.Points, bgRec.OrbitSegments,
                         ref chain.CachedTrajectoryIndex, currentUT, (int)(chain.OriginalVesselPid * 10000),
-                        out _, surfaceRelativeRotation: srfRel, skipOrbitSegments: surfaceSkip);
+                        out _, skipOrbitSegments: surfaceSkip);
 
                     // Update ghost map ProtoVessel orbit if segment changed
                     UpdateChainGhostOrbitIfNeeded(chain, bgRec.OrbitSegments, currentUT);
@@ -7200,7 +7180,7 @@ namespace Parsek
 
                 // Position ghost at first trajectory point so camera targets the pad
                 if (rec.Points != null && rec.Points.Count > 0)
-                    PositionGhostAt(gs.ghost, rec.Points[0], rec.RecordingFormatVersion >= 5);
+                    PositionGhostAt(gs.ghost, rec.Points[0]);
 
                 ParsekLog.Info("CameraFollow",
                     string.Format(CultureInfo.InvariantCulture,
@@ -7584,11 +7564,10 @@ namespace Parsek
         {
             if (state?.ghost == null || traj?.Points == null) return;
             int playbackIdx = state.playbackIndex;
-            bool srfRel = traj.RecordingFormatVersion >= 5;
             bool surfaceSkip = TrajectoryMath.IsSurfaceAtUT(traj.TrackSections, ut);
             InterpolationResult interpResult;
             InterpolateAndPosition(state.ghost, traj.Points, traj.OrbitSegments,
-                ref playbackIdx, ut, index * 10000, out interpResult, srfRel, surfaceSkip);
+                ref playbackIdx, ut, index * 10000, out interpResult, skipOrbitSegments: surfaceSkip);
             state.SetInterpolated(interpResult);
             state.playbackIndex = playbackIdx;
         }
@@ -7615,8 +7594,7 @@ namespace Parsek
             GhostPlaybackState state, TrajectoryPoint point)
         {
             if (state?.ghost == null) return;
-            bool srfRel = traj != null && traj.RecordingFormatVersion >= 5;
-            PositionGhostAt(state.ghost, point, srfRel);
+            PositionGhostAt(state.ghost, point);
         }
 
         void IGhostPositioner.PositionAtSurface(int index, IPlaybackTrajectory traj,
@@ -7641,7 +7619,6 @@ namespace Parsek
         {
             if (state?.ghost == null || traj == null) return;
             int playbackIdx = state.playbackIndex;
-            bool srfRel = traj.RecordingFormatVersion >= 5;
             bool useAnchor = GhostPlaybackLogic.ShouldUseLoopAnchor(traj);
             if (useAnchor && !GhostPlaybackLogic.ValidateLoopAnchor(traj.LoopAnchorVesselId))
             {
@@ -7654,7 +7631,7 @@ namespace Parsek
             }
             InterpolationResult interpResult;
             PositionLoopGhost(state.ghost, traj, ref playbackIdx, ut,
-                index, index * 10000, srfRel, useAnchor, out interpResult);
+                index, index * 10000, useAnchor, out interpResult);
             state.SetInterpolated(interpResult);
             state.playbackIndex = playbackIdx;
         }
@@ -7677,7 +7654,7 @@ namespace Parsek
 
         // CreateGhostSphere moved to GhostVisualBuilder.CreateGhostSphere (T25 Phase 4 prep)
 
-        void InterpolateAndPosition(GameObject ghost, List<TrajectoryPoint> points, ref int cachedIndex, double targetUT, out InterpolationResult interpResult, bool surfaceRelativeRotation = false)
+        void InterpolateAndPosition(GameObject ghost, List<TrajectoryPoint> points, ref int cachedIndex, double targetUT, out InterpolationResult interpResult)
         {
             TrajectoryPoint before, after;
             float t;
@@ -7693,7 +7670,7 @@ namespace Parsek
                     ghost.SetActive(false);
                     return;
                 }
-                PositionGhostAt(ghost, before, surfaceRelativeRotation);
+                PositionGhostAt(ghost, before);
                 interpResult = new InterpolationResult(before.velocity, before.bodyName, before.altitude);
                 return;
             }
@@ -7701,7 +7678,7 @@ namespace Parsek
             // Degenerate segment (t == 0 from zero-duration segment)
             if (t == 0f && before.ut == after.ut)
             {
-                PositionGhostAt(ghost, before, surfaceRelativeRotation);
+                PositionGhostAt(ghost, before);
                 interpResult = new InterpolationResult(before.velocity, before.bodyName, before.altitude);
                 return;
             }
@@ -7734,9 +7711,7 @@ namespace Parsek
             }
 
             ghost.transform.position = interpolatedPos;
-            ghost.transform.rotation = surfaceRelativeRotation
-                ? bodyBefore.bodyTransform.rotation * interpolatedRot
-                : CorrectForBodyRotation(bodyBefore, targetUT, interpolatedRot);
+            ghost.transform.rotation = bodyBefore.bodyTransform.rotation * interpolatedRot;
 
             // Register for LateUpdate re-positioning after FloatingOrigin shift
             ghostPosEntries.Add(new GhostPosEntry
@@ -7750,7 +7725,6 @@ namespace Parsek
                 t = t,
                 pointUT = targetUT,
                 interpolatedRot = interpolatedRot,
-                surfaceRelativeRotation = surfaceRelativeRotation
             });
 
             interpResult = new InterpolationResult(
@@ -7765,19 +7739,8 @@ namespace Parsek
             return TrajectoryMath.FindWaypointIndex(recording, ref lastPlaybackIndex, targetUT);
         }
 
-        /// <summary>
-        /// Legacy v4 fallback — returns storedRot unchanged.
-        /// KSP's world frame co-rotates with the body surface, so world-space
-        /// rotations are already valid at any UT. The old time-delta correction
-        /// was incorrect and has been removed. All v4 recordings are auto-migrated
-        /// to v5 at flight-scene load; this path only executes if migration failed.
-        /// </summary>
-        static Quaternion CorrectForBodyRotation(CelestialBody body, double pointUT, Quaternion storedRot)
-        {
-            return storedRot;
-        }
 
-        void PositionGhostAt(GameObject ghost, TrajectoryPoint point, bool surfaceRelativeRotation = false)
+        void PositionGhostAt(GameObject ghost, TrajectoryPoint point)
         {
             CelestialBody body = FlightGlobals.Bodies.Find(b => b.name == point.bodyName);
             if (body == null)
@@ -7792,9 +7755,7 @@ namespace Parsek
 
             Quaternion sanitized = TrajectoryMath.SanitizeQuaternion(point.rotation);
             ghost.transform.position = worldPos;
-            ghost.transform.rotation = surfaceRelativeRotation
-                ? body.bodyTransform.rotation * sanitized
-                : CorrectForBodyRotation(body, point.ut, sanitized);
+            ghost.transform.rotation = body.bodyTransform.rotation * sanitized;
 
             // Register for LateUpdate re-positioning after FloatingOrigin shift
             ghostPosEntries.Add(new GhostPosEntry
@@ -7805,7 +7766,6 @@ namespace Parsek
                 latBefore = point.latitude, lonBefore = point.longitude, altBefore = point.altitude,
                 pointUT = point.ut,
                 interpolatedRot = sanitized,
-                surfaceRelativeRotation = surfaceRelativeRotation
             });
         }
 
@@ -8021,7 +7981,6 @@ namespace Parsek
             double loopUT,
             int recIdx,
             int ghostIdSalt,
-            bool srfRel,
             bool useAnchor,
             out InterpolationResult interpResult)
         {
@@ -8049,8 +8008,7 @@ namespace Parsek
 
             // Absolute positioning fallback
             InterpolateAndPosition(ghost, rec.Points, rec.OrbitSegments,
-                ref playbackIdx, loopUT, ghostIdSalt, out interpResult,
-                surfaceRelativeRotation: srfRel);
+                ref playbackIdx, loopUT, ghostIdSalt, out interpResult);
         }
 
         /// <summary>
@@ -8219,8 +8177,7 @@ namespace Parsek
 
         void InterpolateAndPosition(GameObject ghost, List<TrajectoryPoint> points,
             List<OrbitSegment> segments, ref int cachedIndex, double targetUT, int orbitCacheBase,
-            out InterpolationResult interpResult, bool surfaceRelativeRotation = false,
-            bool skipOrbitSegments = false)
+            out InterpolationResult interpResult, bool skipOrbitSegments = false)
         {
             // Check orbit segments first (unless suppressed for surface vehicles)
             if (!skipOrbitSegments && segments != null && segments.Count > 0)
@@ -8264,7 +8221,7 @@ namespace Parsek
             }
 
             // Fall through to point-based interpolation
-            InterpolateAndPosition(ghost, points, ref cachedIndex, targetUT, out interpResult, surfaceRelativeRotation);
+            InterpolateAndPosition(ghost, points, ref cachedIndex, targetUT, out interpResult);
         }
 
         #endregion

--- a/Source/Parsek/ParsekKSC.cs
+++ b/Source/Parsek/ParsekKSC.cs
@@ -253,8 +253,7 @@ namespace Parsek
 
                 InterpolateAndPositionKsc(
                     state.ghost, rec.Points,
-                    ref state.playbackIndex, targetUT,
-                    rec.RecordingFormatVersion >= 5);
+                    ref state.playbackIndex, targetUT);
 
                 // Distance culling: skip expensive part events for ghosts too far from camera
                 if (IsGhostInCullRange(state.ghost))
@@ -339,8 +338,6 @@ namespace Parsek
                 kscOverlapGhosts[recIdx] = overlaps;
             }
 
-            bool srfRel = rec.RecordingFormatVersion >= 5;
-
             // --- Primary ghost = newest cycle (lastCycle) ---
             // primaryActive already guarantees primaryState != null && ghost != null
             bool primaryCycleChanged = !primaryActive
@@ -375,7 +372,7 @@ namespace Parsek
                 double loopUT = rec.StartUT + phase;
 
                 InterpolateAndPositionKsc(primaryState.ghost, rec.Points,
-                    ref primaryState.playbackIndex, loopUT, srfRel);
+                    ref primaryState.playbackIndex, loopUT);
 
                 if (IsGhostInCullRange(primaryState.ghost))
                 {
@@ -410,7 +407,7 @@ namespace Parsek
                     // Cycle expired — position at end, explode, destroy
                     if (rec.Points.Count > 0)
                         PositionGhostAtPoint(ovState.ghost,
-                            rec.Points[rec.Points.Count - 1], srfRel);
+                            rec.Points[rec.Points.Count - 1]);
                     TriggerExplosionIfDestroyed(ovState, rec, recIdx);
                     ParsekLog.Verbose("KSCGhost",
                         $"Ghost #{recIdx} overlap cycle={cycle} expired, destroying");
@@ -423,7 +420,7 @@ namespace Parsek
                 double loopUT = rec.StartUT + phase;
 
                 InterpolateAndPositionKsc(ovState.ghost, rec.Points,
-                    ref ovState.playbackIndex, loopUT, srfRel);
+                    ref ovState.playbackIndex, loopUT);
 
                 if (IsGhostInCullRange(ovState.ghost))
                 {
@@ -531,8 +528,7 @@ namespace Parsek
         /// </summary>
         internal void InterpolateAndPositionKsc(
             GameObject ghost, List<TrajectoryPoint> points,
-            ref int cachedIndex, double targetUT,
-            bool surfaceRelativeRotation)
+            ref int cachedIndex, double targetUT)
         {
             TrajectoryPoint before, after;
             float t;
@@ -547,14 +543,14 @@ namespace Parsek
                     ghost.SetActive(false);
                     return;
                 }
-                PositionGhostAtPoint(ghost, before, surfaceRelativeRotation);
+                PositionGhostAtPoint(ghost, before);
                 return;
             }
 
             // Degenerate segment (t == 0 from zero-duration segment)
             if (t == 0f && before.ut == after.ut)
             {
-                PositionGhostAtPoint(ghost, before, surfaceRelativeRotation);
+                PositionGhostAtPoint(ghost, before);
                 return;
             }
 
@@ -592,18 +588,13 @@ namespace Parsek
             }
 
             ghost.transform.position = interpolatedPos;
-            // Uses bodyBefore's transform for rotation (not interpolated between bodies).
-            // Negligible for KSC: both points are Kerbin, body rotation is constant.
-            ghost.transform.rotation = surfaceRelativeRotation
-                ? bodyBefore.bodyTransform.rotation * interpolatedRot
-                : interpolatedRot;
+            ghost.transform.rotation = bodyBefore.bodyTransform.rotation * interpolatedRot;
         }
 
         /// <summary>
         /// Position ghost at a single trajectory point (no interpolation).
         /// </summary>
-        void PositionGhostAtPoint(GameObject ghost, TrajectoryPoint point,
-            bool surfaceRelativeRotation)
+        void PositionGhostAtPoint(GameObject ghost, TrajectoryPoint point)
         {
             if (point.bodyName != "Kerbin")
             {
@@ -619,9 +610,7 @@ namespace Parsek
 
             Quaternion sanitized = TrajectoryMath.SanitizeQuaternion(point.rotation);
             ghost.transform.position = worldPos;
-            ghost.transform.rotation = surfaceRelativeRotation
-                ? body.bodyTransform.rotation * sanitized
-                : sanitized;
+            ghost.transform.rotation = body.bodyTransform.rotation * sanitized;
 
             if (!ghost.activeSelf) ghost.SetActive(true);
         }

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -1231,7 +1231,7 @@ namespace Parsek
                         rec.VesselPersistentId = vpid;
                 }
 
-                // Restore terrain height at recording end (v7+)
+                // Restore terrain height at recording end
                 string thtStr = recNode.GetValue("terrainHeightAtEnd");
                 if (thtStr != null)
                 {
@@ -1302,7 +1302,7 @@ namespace Parsek
                         rec.IsDebris = isDebris;
                 }
 
-                // Restore controller info (v6+)
+                // Restore controller info
                 ConfigNode[] ctrlNodes = recNode.GetNodes("CONTROLLER");
                 if (ctrlNodes.Length > 0)
                 {
@@ -1646,7 +1646,7 @@ namespace Parsek
                 if (rec.VesselPersistentId != 0)
                     recNode.AddValue("vesselPersistentId", rec.VesselPersistentId.ToString(CultureInfo.InvariantCulture));
 
-                // Persist terrain height at recording end (v7+)
+                // Persist terrain height at recording end
                 if (!double.IsNaN(rec.TerrainHeightAtEnd))
                     recNode.AddValue("terrainHeightAtEnd", rec.TerrainHeightAtEnd.ToString("R", CultureInfo.InvariantCulture));
 
@@ -1676,7 +1676,7 @@ namespace Parsek
                 if (rec.IsDebris)
                     recNode.AddValue("isDebris", rec.IsDebris.ToString());
 
-                // Persist controller info (v6+)
+                // Persist controller info
                 if (rec.Controllers != null)
                 {
                     for (int i = 0; i < rec.Controllers.Count; i++)
@@ -1772,14 +1772,6 @@ namespace Parsek
                     rec.RecordingFormatVersion = formatVersion;
             }
 
-            string geomVersionStr = recNode.GetValue("ghostGeometryVersion");
-            if (geomVersionStr != null)
-            {
-                int geomVersion;
-                if (int.TryParse(geomVersionStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out geomVersion))
-                    rec.GhostGeometryVersion = geomVersion;
-            }
-
             string loopPlaybackStr = recNode.GetValue("loopPlayback");
             if (loopPlaybackStr != null)
             {
@@ -1788,8 +1780,7 @@ namespace Parsek
                     rec.LoopPlayback = loopPlayback;
             }
 
-            string loopIntervalStr = recNode.GetValue("loopIntervalSeconds")
-                                  ?? recNode.GetValue("loopPauseSeconds"); // migration fallback
+            string loopIntervalStr = recNode.GetValue("loopIntervalSeconds");
             if (loopIntervalStr != null)
             {
                 double loopIntervalSeconds;
@@ -1834,12 +1825,6 @@ namespace Parsek
                 rec.LoopAnchorBodyName = loopAnchorBodyNameStr;
 
             rec.GhostGeometryRelativePath = recNode.GetValue("ghostGeometryPath");
-            string strategy = recNode.GetValue("ghostGeometryStrategy");
-            if (!string.IsNullOrEmpty(strategy))
-                rec.GhostGeometryCaptureStrategy = strategy;
-            string probeStatus = recNode.GetValue("ghostGeometryProbeStatus");
-            if (!string.IsNullOrEmpty(probeStatus))
-                rec.GhostGeometryProbeStatus = probeStatus;
             string geomAvailableStr = recNode.GetValue("ghostGeometryAvailable");
             if (geomAvailableStr != null)
             {

--- a/Source/Parsek/Recording.cs
+++ b/Source/Parsek/Recording.cs
@@ -18,7 +18,6 @@ namespace Parsek
     {
         public string RecordingId = Guid.NewGuid().ToString("N");
         public int RecordingFormatVersion = RecordingStore.CurrentRecordingFormatVersion;
-        public int GhostGeometryVersion = 1; // Legacy field, kept for deserialization backward compat
         public List<TrajectoryPoint> Points = new List<TrajectoryPoint>();
         public List<OrbitSegment> OrbitSegments = new List<OrbitSegment>();
         public List<PartEvent> PartEvents = new List<PartEvent>();
@@ -27,7 +26,7 @@ namespace Parsek
         public List<TrackSection> TrackSections = new List<TrackSection>();
 
         // Controller parts at segment start (for identity tracking)
-        public List<ControllerInfo> Controllers;  // null = not set (legacy recording)
+        public List<ControllerInfo> Controllers;  // null = not set (no controller data)
 
         // True if vessel has no controller parts (debris). Minimal recording only.
         public bool IsDebris;
@@ -71,8 +70,6 @@ namespace Parsek
         public string GhostGeometryRelativePath;
         public bool GhostGeometryAvailable;
         public string GhostGeometryCaptureError;
-        public string GhostGeometryCaptureStrategy; // Legacy field, kept for deserialization
-        public string GhostGeometryProbeStatus;    // Legacy field, kept for deserialization
 
         // --- Tree linkage (null for legacy/standalone recordings) ---
         public string TreeId;                          // null = standalone (pre-tree recording)
@@ -96,7 +93,7 @@ namespace Parsek
         public SurfacePosition? TerminalPosition;      // null if not landed/splashed
 
         // Terrain height at recording end (for terrain correction on spawn)
-        // NaN = not set (pre-v7 recording or non-surface terminal state)
+        // NaN = not set (non-surface terminal state)
         public double TerrainHeightAtEnd = double.NaN;
 
         // Antenna specifications for CommNet ghost relay registration (Phase 6f)

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -14,9 +14,8 @@ namespace Parsek
     /// </summary>
     public static class RecordingStore
     {
-        public const int CurrentRecordingFormatVersion = 7;
-        // v7: Added TerrainHeightAtEnd for surface spawn terrain correction
-        // v6: Added SegmentEvents, TrackSections, ControllerInfo, extended BranchPoint types
+        public const int CurrentRecordingFormatVersion = 0;
+        // v0: initial release format
 
         // When true, suppresses logging calls (for unit testing outside Unity)
         internal static bool SuppressLogging;
@@ -2809,11 +2808,6 @@ namespace Parsek
                     return false;
                 }
 
-                // Sync format version from .prec file (authoritative for data format).
-                // Prevents double-migration when .sfs metadata is stale (e.g., quicksave
-                // made before an in-flight v4→v5 migration updated the persistent save).
-                SyncVersionFromPrecFile(precNode, rec);
-
                 DeserializeTrajectoryFrom(precNode, rec);
 
                 // Load _vessel.craft — ConfigNode.Load returns the snapshot directly
@@ -2847,79 +2841,6 @@ namespace Parsek
                 Log($"[Parsek] Failed to load recording files for {rec.RecordingId}: {ex.Message}");
                 return false;
             }
-        }
-
-        /// <summary>
-        /// Syncs RecordingFormatVersion from the .prec file's version field.
-        /// The .prec file is authoritative for data format; if its version is higher
-        /// than the .sfs metadata, the recording's version is updated to match.
-        /// </summary>
-        internal static void SyncVersionFromPrecFile(ConfigNode precNode, Recording rec)
-        {
-            string fileVersion = precNode.GetValue("version");
-            if (fileVersion == null) return;
-
-            int precVersion;
-            if (int.TryParse(fileVersion, NumberStyles.Integer,
-                    CultureInfo.InvariantCulture, out precVersion)
-                && precVersion > rec.RecordingFormatVersion)
-            {
-                Log($"Version sync: {rec.RecordingId} .sfs says v{rec.RecordingFormatVersion} but .prec says v{precVersion} — updating");
-                rec.RecordingFormatVersion = precVersion;
-            }
-        }
-
-        /// <summary>
-        /// Migrates a v4 recording's rotation data from world-space to surface-relative (v5).
-        /// Must be called when CelestialBody data is available (flight scene).
-        /// KSP's world frame co-rotates with the parent body, so bodyTransform.rotation
-        /// represents axial tilt only (time-invariant). Migration is simply
-        /// surfaceRelRot = Inverse(bodyRot) * worldRot — no time delta needed.
-        /// </summary>
-        internal static bool MigrateV4ToV5(Recording rec)
-        {
-            if (rec == null || rec.RecordingFormatVersion >= 5 || rec.Points.Count == 0)
-                return false;
-
-            string lastBody = null;
-            CelestialBody body = null;
-            Quaternion invBodyRot = Quaternion.identity;
-
-            int converted = 0;
-            for (int i = 0; i < rec.Points.Count; i++)
-            {
-                var pt = rec.Points[i];
-
-                // Cache body lookup
-                if (pt.bodyName != lastBody)
-                {
-                    body = FlightGlobals.Bodies.Find(b => b.name == pt.bodyName);
-                    lastBody = pt.bodyName;
-                    if (body != null)
-                    {
-                        // KSP's world frame co-rotates with the body surface.
-                        // body.bodyTransform.rotation represents axial tilt only,
-                        // NOT spin — so it's essentially constant over time.
-                        // surfaceRelRot = Inverse(bodyRot) * worldRot. No time delta needed.
-                        invBodyRot = Quaternion.Inverse(body.bodyTransform.rotation);
-                    }
-                }
-
-                if (body == null) continue;
-
-                pt.rotation = invBodyRot * pt.rotation;
-                rec.Points[i] = pt;
-                converted++;
-            }
-
-            if (converted == 0) return false;
-
-            rec.RecordingFormatVersion = 5;
-
-            // Save the migrated .prec file
-            bool saved = SaveRecordingFiles(rec);
-            Log($"Migrated recording {rec.RecordingId} from v4→v5: {converted} points converted, saved={saved}");
-            return saved;
         }
 
         private static void SafeWriteConfigNode(ConfigNode node, string path)

--- a/Source/Parsek/RecordingTree.cs
+++ b/Source/Parsek/RecordingTree.cs
@@ -223,7 +223,7 @@ namespace Parsek
                 SurfacePosition.SaveInto(tpNode, rec.TerminalPosition.Value);
             }
 
-            // Terrain height at recording end (v7+)
+            // Terrain height at recording end
             if (!double.IsNaN(rec.TerrainHeightAtEnd))
                 recNode.AddValue("terrainHeightAtEnd", rec.TerrainHeightAtEnd.ToString("R", ic));
 
@@ -325,7 +325,7 @@ namespace Parsek
                 for (int g = 0; g < rec.RecordingGroups.Count; g++)
                     recNode.AddValue("recordingGroup", rec.RecordingGroups[g]);
 
-            // Controller info (v6+)
+            // Controller info
             if (rec.Controllers != null)
             {
                 for (int i = 0; i < rec.Controllers.Count; i++)
@@ -407,7 +407,7 @@ namespace Parsek
             if (tpNode != null)
                 rec.TerminalPosition = SurfacePosition.LoadFrom(tpNode);
 
-            // Terrain height at recording end (v7+)
+            // Terrain height at recording end
             string thtStr = recNode.GetValue("terrainHeightAtEnd");
             if (thtStr != null)
             {
@@ -454,14 +454,6 @@ namespace Parsek
                     rec.RecordingFormatVersion = formatVersion;
             }
 
-            string geomVersionStr = recNode.GetValue("ghostGeometryVersion");
-            if (geomVersionStr != null)
-            {
-                int geomVersion;
-                if (int.TryParse(geomVersionStr, NumberStyles.Integer, ic, out geomVersion))
-                    rec.GhostGeometryVersion = geomVersion;
-            }
-
             string loopPlaybackStr = recNode.GetValue("loopPlayback");
             if (loopPlaybackStr != null)
             {
@@ -470,8 +462,7 @@ namespace Parsek
                     rec.LoopPlayback = loopPlayback;
             }
 
-            string loopIntervalStr = recNode.GetValue("loopIntervalSeconds")
-                                   ?? recNode.GetValue("loopPauseSeconds"); // migration fallback
+            string loopIntervalStr = recNode.GetValue("loopIntervalSeconds");
             if (loopIntervalStr != null)
             {
                 double loopIntervalSeconds;
@@ -607,12 +598,6 @@ namespace Parsek
 
             // Ghost geometry metadata
             rec.GhostGeometryRelativePath = recNode.GetValue("ghostGeometryPath");
-            string strategy = recNode.GetValue("ghostGeometryStrategy");
-            if (!string.IsNullOrEmpty(strategy))
-                rec.GhostGeometryCaptureStrategy = strategy;
-            string probeStatus = recNode.GetValue("ghostGeometryProbeStatus");
-            if (!string.IsNullOrEmpty(probeStatus))
-                rec.GhostGeometryProbeStatus = probeStatus;
             string geomAvailableStr = recNode.GetValue("ghostGeometryAvailable");
             if (geomAvailableStr != null)
             {
@@ -655,7 +640,7 @@ namespace Parsek
                 rec.RecordingGroups = new List<string>(recGroups);
             }
 
-            // Controller info (v6+)
+            // Controller info
             ConfigNode[] ctrlNodes = recNode.GetNodes("CONTROLLER");
             if (ctrlNodes.Length > 0)
             {

--- a/Source/Parsek/TerrainCorrector.cs
+++ b/Source/Parsek/TerrainCorrector.cs
@@ -70,7 +70,7 @@ namespace Parsek
         /// 2. recordedTerrainHeight is a valid number (not NaN).
         ///
         /// Returns false for orbital/sub-orbital recordings, destroyed/recovered
-        /// vessels, or recordings that lack terrain height data (pre-v7, NaN default).
+        /// vessels, or recordings that lack terrain height data (NaN default).
         /// </summary>
         internal static bool ShouldCorrectTerrain(
             TerminalState? terminalState,


### PR DESCRIPTION
## Summary
- Reset `CurrentRecordingFormatVersion` from 7 to 0 (clean break — no users yet)
- Remove all legacy format migration code (v4→v5 rotation, `SyncVersionFromPrecFile`, `CorrectForBodyRotation`)
- Remove `surfaceRelativeRotation` branching — all rotation is now always surface-relative
- Remove ghost geometry legacy fields (`GhostGeometryVersion`, `GhostGeometryCaptureStrategy`, `GhostGeometryProbeStatus`)
- Remove `loopPauseSeconds` migration fallback
- Clean up all stale version comments (`(v6+)`, `(v7+)`, `pre-v7`, etc.)
- **-500 lines across 20 files, 4679 tests pass**

## What's kept
- `RecordingFormatVersion` field on `Recording` and `IPlaybackTrajectory` (future versioning)
- Serialization of `recordingFormatVersion` in .sfs/.prec files
- Live ghost geometry fields (`GhostGeometryRelativePath`, `GhostGeometryAvailable`, `GhostGeometryCaptureError`)

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 4679 passed
- [x] Grep verification: zero hits for `MigrateV4`, `CorrectForBodyRotation`, `surfaceRelativeRotation`, `loopPauseSeconds`, `GhostGeometryVersion`, `(v6+)`, `(v7+)`, `pre-v7`
- [x] Note: `convert_v4_rotations.py` in outer repo root not tracked by this worktree — delete separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)