### PR TITLE
Surface W and R/FF buttons to recording group headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -484,6 +484,7 @@ Spawn safety hardening, ghost visual improvements, booster/debris tree recording
 - **Spawn abandon status** — spawn warnings show "walkback exhausted" / "spawn abandoned" status instead of silently retrying
 - **Watch exit key** — changed from Backspace (conflicts with KSP Abort action group) to `[` or `]` bracket keys (#124)
 - **Watch button guards** — disabled for out-of-range ghosts (tooltip: "Ghost is beyond visual range") and past recordings (#89, #90)
+- **Group-level W and R/FF buttons** — recording group headers now show Watch and Rewind/FastForward buttons targeting the group's main recording (earliest non-debris descendant), no need to expand groups to access these controls (#115)
 - **Watch overlay repositioned** — moved to left half of screen to avoid altimeter overlap
 
 ### Performance & Logging

--- a/Source/Parsek.Tests/GroupAggregateTests.cs
+++ b/Source/Parsek.Tests/GroupAggregateTests.cs
@@ -428,5 +428,63 @@ namespace Parsek.Tests
                 ParsekUI.SortColumn.Index, 0, 0);
             Assert.True(groupKey < recKey, "Group should sort before recording in Index sort");
         }
+
+        // ── FindGroupMainRecordingIndex ──
+
+        [Fact]
+        public void MainRecording_EmptyDescendants_ReturnsNegativeOne()
+        {
+            var descendants = new HashSet<int>();
+            var committed = new List<Recording>();
+            Assert.Equal(-1, ParsekUI.FindGroupMainRecordingIndex(descendants, committed));
+        }
+
+        [Fact]
+        public void MainRecording_SingleNonDebris_ReturnsThatIndex()
+        {
+            var committed = new List<Recording> { MakeRec(17000, 17100, "Vessel") };
+            var descendants = new HashSet<int> { 0 };
+            Assert.Equal(0, ParsekUI.FindGroupMainRecordingIndex(descendants, committed));
+        }
+
+        [Fact]
+        public void MainRecording_SingleDebris_ReturnsNegativeOne()
+        {
+            var rec = MakeRec(17000, 17100, "Stage");
+            rec.IsDebris = true;
+            var committed = new List<Recording> { rec };
+            var descendants = new HashSet<int> { 0 };
+            Assert.Equal(-1, ParsekUI.FindGroupMainRecordingIndex(descendants, committed));
+        }
+
+        [Fact]
+        public void MainRecording_AllDebris_ReturnsNegativeOne()
+        {
+            var d1 = MakeRec(17000, 17100, "Stage1"); d1.IsDebris = true;
+            var d2 = MakeRec(17050, 17150, "Stage2"); d2.IsDebris = true;
+            var committed = new List<Recording> { d1, d2 };
+            var descendants = new HashSet<int> { 0, 1 };
+            Assert.Equal(-1, ParsekUI.FindGroupMainRecordingIndex(descendants, committed));
+        }
+
+        [Fact]
+        public void MainRecording_MixedEarliestIsDebris_SkipsDebrisReturnsEarliestNonDebris()
+        {
+            var debris = MakeRec(17000, 17100, "Booster"); debris.IsDebris = true;
+            var main = MakeRec(17050, 17200, "Rocket");
+            var committed = new List<Recording> { debris, main };
+            var descendants = new HashSet<int> { 0, 1 };
+            Assert.Equal(1, ParsekUI.FindGroupMainRecordingIndex(descendants, committed));
+        }
+
+        [Fact]
+        public void MainRecording_MultipleNonDebris_ReturnsEarliest()
+        {
+            var later = MakeRec(17100, 17300, "Second");
+            var earlier = MakeRec(17000, 17200, "First");
+            var committed = new List<Recording> { later, earlier };
+            var descendants = new HashSet<int> { 0, 1 };
+            Assert.Equal(1, ParsekUI.FindGroupMainRecordingIndex(descendants, committed));
+        }
     }
 }

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -1851,10 +1851,85 @@ namespace Parsek
             // Period placeholder
             GUILayout.Label("", GUILayout.Width(ColW_Period));
 
-            // Spacers for Watch
-            if (InFlight) GUILayout.Label("", GUILayout.Width(ColW_Watch));
+            // Find the "main" (earliest non-debris) recording for group-level W and R/FF buttons
+            int mainIdx = FindGroupMainRecordingIndex(descendants, committed);
 
-            GUILayout.Label("", GUILayout.Width(ColW_Rewind));
+            // Watch button (flight only) — targets main recording's ghost
+            if (InFlight)
+            {
+                if (mainIdx >= 0)
+                {
+                    bool hasGhost = flight.HasActiveGhost(mainIdx);
+                    bool sameBody = flight.IsGhostOnSameBody(mainIdx);
+                    bool inRange = flight.IsGhostWithinVisualRange(mainIdx);
+                    bool isWatching = flight.WatchedRecordingIndex == mainIdx;
+                    bool canWatch = hasGhost && sameBody && inRange;
+
+                    GUI.enabled = canWatch;
+                    string watchLabel = isWatching ? "W*" : "W";
+                    string watchTooltip = (hasGhost && !sameBody) ? "Ghost is on a different body"
+                        : (hasGhost && !inRange) ? "Ghost is beyond visual range"
+                        : "";
+                    if (GUILayout.Button(new GUIContent(watchLabel, watchTooltip), GUILayout.Width(ColW_Watch)))
+                    {
+                        if (isWatching)
+                            flight.ExitWatchMode();
+                        else
+                            flight.EnterWatchMode(mainIdx);
+                        ParsekLog.Info("UI", $"Group '{groupName}' W button: {(isWatching ? "exit" : "enter")} watch on #{mainIdx} \"{committed[mainIdx].VesselName}\"");
+                    }
+                    GUI.enabled = true;
+                }
+                else
+                {
+                    GUILayout.Label("", GUILayout.Width(ColW_Watch));
+                }
+            }
+
+            // Rewind / Fast-forward button — targets main recording
+            // (per-recording row already logs enable/disable transitions for the same recording)
+            if (mainIdx >= 0)
+            {
+                var mainRec = committed[mainIdx];
+                bool isFuture = now < mainRec.StartUT;
+                bool hasRewindSave = !string.IsNullOrEmpty(mainRec.RewindSaveFileName);
+                bool isRecording = InFlight && flight != null && flight.IsRecording;
+
+                if (isFuture)
+                {
+                    string ffReason;
+                    bool canFF = RecordingStore.CanFastForward(mainRec, out ffReason, isRecording: isRecording);
+                    GUI.enabled = canFF;
+                    string tooltip = canFF ? "Fast-forward to this launch" : ffReason;
+                    if (GUILayout.Button(new GUIContent("FF", tooltip), GUILayout.Width(ColW_Rewind)))
+                    {
+                        ParsekLog.Info("UI", $"Group '{groupName}' FF button: #{mainIdx} \"{mainRec.VesselName}\"");
+                        ShowFastForwardConfirmation(mainRec);
+                    }
+                    GUI.enabled = true;
+                }
+                else if (hasRewindSave)
+                {
+                    string rewindReason;
+                    bool canRewind = RecordingStore.CanRewind(mainRec, out rewindReason, isRecording: isRecording);
+                    GUI.enabled = canRewind;
+                    string tooltip = canRewind ? "Rewind to this launch" : rewindReason;
+                    if (GUILayout.Button(new GUIContent("R", tooltip), GUILayout.Width(ColW_Rewind)))
+                    {
+                        ParsekLog.Info("UI", $"Group '{groupName}' R button: #{mainIdx} \"{mainRec.VesselName}\"");
+                        ShowRewindConfirmation(mainRec);
+                    }
+                    GUI.enabled = true;
+                }
+                else
+                {
+                    GUILayout.Label("", GUILayout.Width(ColW_Rewind));
+                }
+            }
+            else
+            {
+                GUILayout.Label("", GUILayout.Width(ColW_Rewind));
+            }
 
             // Hide group checkbox
             bool groupHidden = GroupHierarchyStore.IsGroupHidden(groupName);
@@ -2935,6 +3010,30 @@ namespace Parsek
                 if (dur > 0) total += dur;
             }
             return total;
+        }
+
+        /// <summary>
+        /// Returns the committed-list index of the "main" recording in a group:
+        /// the earliest non-debris descendant by StartUT.  Returns -1 when
+        /// the group is empty or contains only debris.
+        /// </summary>
+        internal static int FindGroupMainRecordingIndex(
+            HashSet<int> descendants, List<Recording> committed)
+        {
+            int bestIdx = -1;
+            double bestUT = double.MaxValue;
+            foreach (int idx in descendants)
+            {
+                if (idx < 0 || idx >= committed.Count) continue;
+                var rec = committed[idx];
+                if (rec.IsDebris) continue;
+                if (rec.StartUT < bestUT)
+                {
+                    bestUT = rec.StartUT;
+                    bestIdx = idx;
+                }
+            }
+            return bestIdx;
         }
 
         /// <summary>

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -1893,7 +1893,7 @@ namespace Parsek
                 var mainRec = committed[mainIdx];
                 bool isFuture = now < mainRec.StartUT;
                 bool hasRewindSave = !string.IsNullOrEmpty(mainRec.RewindSaveFileName);
-                bool isRecording = InFlight && flight != null && flight.IsRecording;
+                bool isRecording = InFlight && flight.IsRecording;
 
                 if (isFuture)
                 {


### PR DESCRIPTION
## Summary
- Group headers in the Recordings Window now show **W** (Watch) and **R/FF** (Rewind/FastForward) buttons targeting the group's "main" recording (earliest non-debris descendant by StartUT)
- Previously these columns were empty spacers at the group level — users had to expand groups and find the right recording to use W or R
- Groups with only debris or no recordings show spacers as before

## Implementation
- New `FindGroupMainRecordingIndex` helper (internal static, testable) finds the earliest non-debris recording in a group's descendants
- Group W button mirrors per-recording Watch logic (hasGhost, sameBody, inRange checks)
- Group R/FF button mirrors per-recording Rewind/FastForward logic (CanRewind/CanFastForward checks)
- 6 unit tests covering: empty, single non-debris, single debris, all debris, mixed, multiple non-debris

## Test plan
- [x] `dotnet build` — zero errors
- [x] `dotnet test` — 4685 pass, zero failures
- [ ] In-game: verify group W button follows main vessel ghost
- [ ] In-game: verify group R button rewinds to main vessel launch
- [ ] In-game: verify group FF button fast-forwards to main vessel launch
- [ ] In-game: verify all-debris group shows spacers (no buttons)