### PR TITLE
Skip orbit segment when vessel goes on-rails in atmosphere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Full career-mode resource tracking across the rewind timeline. Science, funds, r
 - **Duplicate CrewStatusChanged events (#207).** KSP's delayed `onKerbalStatusChange` callbacks fired after the crew mutation suppression window closed, producing redundant `Assigned->Missing` events on every save cycle. Added `KerbalsModule.IsManaged` check to suppress status change noise for reserved/stand-in kerbals.
 - **Chain tip missing terminalState (#208).** In tree mode, the active recording is non-leaf (has debris branches) so `FinalizeIndividualRecording` skipped its terminalState. Added explicit terminalState determination for the active recording in `FinalizeTreeRecordings`, which the optimizer propagates to the chain tip via `SplitAtSection`.
 - **Looping chain crew release (#209).** Fixing the terminalState alone would free crew at the tip's EndUT while the ghost still loops. Added a `loopingChains` pre-scan in `KerbalsModule.Recalculate`: Recovered crews on chains with any looping segment keep `endUT=Infinity`. Disabling the loop correctly releases them.
+- **Ghost tunnels underground during atmospheric on-rails (#210, PR #116).** When a vessel went on-rails during atmospheric flight (e.g. reentry time warp), Keplerian orbit segments were recorded that ignore drag — the ghost dove through the planet. Added `ShouldSkipOrbitSegmentForAtmosphere` check: orbit segment creation is skipped when `altitude < atmosphereDepth`. Point interpolation lerps across the gap instead. Applies to FlightRecorder and BackgroundRecorder.
 
 ### Code Quality & Refactoring
 

--- a/Source/Parsek.Tests/FlightRecorderExtractedTests.cs
+++ b/Source/Parsek.Tests/FlightRecorderExtractedTests.cs
@@ -426,5 +426,36 @@ namespace Parsek.Tests
         }
 
         #endregion
+
+        #region ShouldSkipOrbitSegmentForAtmosphere
+
+        [Fact]
+        public void ShouldSkipOrbitSegment_BelowAtmosphere_ReturnsTrue()
+        {
+            // Kerbin: atmosphereDepth = 70000
+            Assert.True(FlightRecorder.ShouldSkipOrbitSegmentForAtmosphere(true, 50000, 70000));
+        }
+
+        [Fact]
+        public void ShouldSkipOrbitSegment_AboveAtmosphere_ReturnsFalse()
+        {
+            Assert.False(FlightRecorder.ShouldSkipOrbitSegmentForAtmosphere(true, 80000, 70000));
+        }
+
+        [Fact]
+        public void ShouldSkipOrbitSegment_NoAtmosphere_ReturnsFalse()
+        {
+            // Mun has no atmosphere
+            Assert.False(FlightRecorder.ShouldSkipOrbitSegmentForAtmosphere(false, 5000, 0));
+        }
+
+        [Fact]
+        public void ShouldSkipOrbitSegment_ExactlyAtBoundary_ReturnsFalse()
+        {
+            // At exactly atmosphereDepth, altitude is NOT below — no skip
+            Assert.False(FlightRecorder.ShouldSkipOrbitSegmentForAtmosphere(true, 70000, 70000));
+        }
+
+        #endregion
     }
 }

--- a/Source/Parsek/BackgroundRecorder.cs
+++ b/Source/Parsek/BackgroundRecorder.cs
@@ -1379,6 +1379,22 @@ namespace Parsek
                 ParsekLog.Verbose("BgRecorder", $"On-rails state initialized (landed): pid={vesselPid} " +
                     $"body={v.mainBody?.name} sit={v.situation}");
             }
+            else if (v.mainBody != null &&
+                     FlightRecorder.ShouldSkipOrbitSegmentForAtmosphere(
+                         v.mainBody.atmosphere, v.altitude, v.mainBody.atmosphereDepth))
+            {
+                // In atmosphere — Keplerian orbit ignores drag, skip orbit segment
+                state.hasOpenOrbitSegment = false;
+
+                Recording treeRec;
+                if (tree.Recordings.TryGetValue(recordingId, out treeRec))
+                {
+                    treeRec.ExplicitEndUT = ut;
+                }
+
+                ParsekLog.Verbose("BgRecorder", $"On-rails state initialized (atmosphere, skip orbit): pid={vesselPid} " +
+                    $"body={v.mainBody?.name} alt={v.altitude:F0} atmoDepth={v.mainBody.atmosphereDepth:F0}");
+            }
             else if (v.orbit != null)
             {
                 // Open orbit segment

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -3305,6 +3305,17 @@ namespace Parsek
         #region Atmosphere Boundary Detection
 
         /// <summary>
+        /// Pure testable function: determines whether an orbit segment should be skipped
+        /// because the vessel is below the atmosphere. Keplerian orbits ignore drag, so
+        /// an orbit segment recorded during atmospheric flight produces underground ghost paths.
+        /// </summary>
+        internal static bool ShouldSkipOrbitSegmentForAtmosphere(
+            bool bodyHasAtmosphere, double altitude, double atmosphereDepth)
+        {
+            return bodyHasAtmosphere && altitude < atmosphereDepth;
+        }
+
+        /// <summary>
         /// Pure testable function: determines whether a recording should split at the atmosphere boundary.
         /// Requires both sustained time (hysteresisSeconds) AND distance beyond boundary (hysteresisMeters).
         /// </summary>
@@ -4065,7 +4076,17 @@ namespace Parsek
                 // Take one boundary point first
                 SamplePosition(v);
 
-                InitializeOnRailsOrbitSegment(v, initialEnv);
+                // Skip orbit segment if below atmosphere — Keplerian orbit ignores drag
+                if (ShouldSkipOrbitSegmentForAtmosphere(v.mainBody.atmosphere, v.altitude, v.mainBody.atmosphereDepth))
+                {
+                    ParsekLog.Info("Recorder",
+                        $"Recording started on rails in atmosphere — skipping orbit segment " +
+                        $"(alt={v.altitude:F0}, atmoDepth={v.mainBody.atmosphereDepth:F0})");
+                }
+                else
+                {
+                    InitializeOnRailsOrbitSegment(v, initialEnv);
+                }
             }
 
             // Register the Harmony patch to call us each physics frame
@@ -4765,6 +4786,16 @@ namespace Parsek
             {
                 ParsekLog.Info("Recorder",
                     $"Vessel went on rails (surface, sit={v.situation}) — skipping orbit segment, position unchanged");
+                return;
+            }
+
+            // Layer 2: Vessels below atmosphere — Keplerian orbit ignores drag, producing
+            // underground trajectories during reentry/descent. Skip orbit segment; point
+            // interpolation will lerp across the gap, which is far better than an underground arc.
+            if (ShouldSkipOrbitSegmentForAtmosphere(v.mainBody.atmosphere, v.altitude, v.mainBody.atmosphereDepth))
+            {
+                ParsekLog.Info("Recorder",
+                    $"Vessel went on rails in atmosphere (alt={v.altitude:F0}, atmoDepth={v.mainBody.atmosphereDepth:F0}) — skipping orbit segment");
                 return;
             }
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -2407,6 +2407,14 @@ With bug #208 fixed, the chain tip gets `terminalState=Splashed` → `endState=R
 
 **Status:** Fixed (0.6.0) — `KerbalsModule.Recalculate` pre-scans for `loopingChains` set. When computing endUT for a Recovered crew member on a chain with any looping segment, endUT stays Infinity. Disabling the loop correctly releases them.
 
+## 210. Ghost tunnels underground when vessel goes on-rails in atmosphere
+
+When a vessel goes on-rails (time warp) during atmospheric flight — typically during reentry — FlightRecorder and BackgroundRecorder created Keplerian orbit segments. Keplerian orbits ignore drag, so the recorded trajectory curves through the planet's surface. During playback, the ghost follows this underground arc instead of the actual atmospheric path.
+
+**Root cause:** `OnVesselGoOnRails` and `InitializeOnRailsState` had a surface-vessel guard (LANDED/SPLASHED/PRELAUNCH) but no atmosphere guard. Any vessel with `situation=FLYING` or `SUB_ORBITAL` below `atmosphereDepth` would get an orbit segment.
+
+**Status:** Fixed (0.6.0, PR #116) — added `ShouldSkipOrbitSegmentForAtmosphere` check in FlightRecorder (`OnVesselGoOnRails` + `StartRecording` on-rails init) and BackgroundRecorder (`InitializeOnRailsState`). When below atmosphere, orbit segment creation is skipped. Point interpolation lerps across the gap, which is visually correct. No physics frame samples during on-rails (PhysicsFramePatch only fires for unpacked vessels), so the gap is expected.
+
 # In-Game Tests
 
 - [x] Vessels propagate naturally along orbits after FF (no position freezing)


### PR DESCRIPTION
## Summary
- When a vessel goes on-rails below atmosphere (e.g. reentry time warp), Keplerian orbit segments ignore drag and produce ghost trajectories that tunnel underground
- Skip orbit segment creation when `altitude < atmosphereDepth` — point interpolation lerps across the gap instead, which is visually correct
- Applies to FlightRecorder (`OnVesselGoOnRails` + `StartRecording` on-rails init) and BackgroundRecorder (`InitializeOnRailsState`)

## Test plan
- [ ] 4 unit tests for `ShouldSkipOrbitSegmentForAtmosphere` (below/above/no-atmosphere/boundary)
- [x] All 4689 existing tests pass
- [ ] In-game: record a suborbital flight, time-warp during reentry — ghost should lerp across the gap instead of diving underground

🤖 Generated with [Claude Code](https://claude.com/claude-code)