### PR TITLE
T34: ChainSegmentManager unit tests + TODO cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to Parsek are documented here.
 
 ---
 
+## 0.6.1
+
+### Tests
+
+- **ChainSegmentManager unit tests (T34).** 16 new tests covering `SampleContinuationVessel` guard paths (pid=0 early return, stale/negative index → stop callback), `UpdateContinuationSampling`/`UpdateUndockContinuationSampling` wrappers (no-op and stale-index propagation), `StopAllContinuations` branching (neither/one/both active, chain identity preservation), and `RefreshContinuationSnapshotCore` guards (pid=0, negative recIdx, stale recIdx). Total: 46 tests for ChainSegmentManager (up from 30).
+
+### Documentation
+
+- **TODO cleanup.** Marked T17 (game actions redesign), T25/D20 (playback engine extraction), T28/D2 (commit-pattern dedup), T32 (test audit), T34 (ChainSegmentManager tests), T41 (suborbital orbit line), and T41b (atmosphere on-rails skip) as done.
+
+---
+
 ## 0.6.0
 
 ### Ghost Playback

--- a/Source/Parsek.Tests/ChainSegmentManagerTests.cs
+++ b/Source/Parsek.Tests/ChainSegmentManagerTests.cs
@@ -585,5 +585,314 @@ namespace Parsek.Tests
         }
 
         #endregion
+
+        #region SampleContinuationVessel guard paths
+
+        [Fact]
+        public void SampleContinuationVessel_PidZero_ReturnsImmediately()
+        {
+            var csm = new ChainSegmentManager();
+            uint pid = 0;
+            int recIdx = 5;
+            var lastVel = new Vector3(1, 2, 3);
+            double lastUT = 100.0;
+            bool stopCalled = false;
+
+            csm.SampleContinuationVessel(
+                pid, ref recIdx, ref lastVel, ref lastUT,
+                _ => stopCalled = true, "test");
+
+            Assert.False(stopCalled);
+            // ref params unchanged
+            Assert.Equal(5, recIdx);
+            Assert.Equal(new Vector3(1, 2, 3), lastVel);
+            Assert.Equal(100.0, lastUT);
+        }
+
+        [Fact]
+        public void SampleContinuationVessel_NegativeRecIdx_CallsStopWithStaleIndex()
+        {
+            var csm = new ChainSegmentManager();
+            uint pid = 42;
+            int recIdx = -1;
+            var lastVel = Vector3.zero;
+            double lastUT = -1;
+            string stopReason = null;
+
+            csm.SampleContinuationVessel(
+                pid, ref recIdx, ref lastVel, ref lastUT,
+                reason => stopReason = reason, "test");
+
+            Assert.Equal("stale index", stopReason);
+        }
+
+        [Fact]
+        public void SampleContinuationVessel_RecIdxBeyondCount_CallsStopWithStaleIndex()
+        {
+            RecordingStore.ResetForTesting();
+            // CommittedRecordings is empty (count=0), so recIdx=0 is already beyond
+            var csm = new ChainSegmentManager();
+            uint pid = 42;
+            int recIdx = 0;
+            var lastVel = Vector3.zero;
+            double lastUT = -1;
+            string stopReason = null;
+
+            csm.SampleContinuationVessel(
+                pid, ref recIdx, ref lastVel, ref lastUT,
+                reason => stopReason = reason, "test");
+
+            Assert.Equal("stale index", stopReason);
+            RecordingStore.ResetForTesting();
+        }
+
+        [Fact]
+        public void SampleContinuationVessel_RecIdxLargeValue_CallsStopWithStaleIndex()
+        {
+            RecordingStore.ResetForTesting();
+            var csm = new ChainSegmentManager();
+            uint pid = 99;
+            int recIdx = 999;
+            var lastVel = Vector3.zero;
+            double lastUT = -1;
+            string stopReason = null;
+
+            csm.SampleContinuationVessel(
+                pid, ref recIdx, ref lastVel, ref lastUT,
+                reason => stopReason = reason, "test");
+
+            Assert.Equal("stale index", stopReason);
+            RecordingStore.ResetForTesting();
+        }
+
+        [Fact]
+        public void UpdateContinuationSampling_PidZero_NoOp()
+        {
+            var csm = new ChainSegmentManager();
+            // Default state: ContinuationVesselPid = 0
+            Assert.Equal(0u, csm.ContinuationVesselPid);
+
+            logLines.Clear();
+            csm.UpdateContinuationSampling();
+
+            // Should return immediately — no stop logged, no crash
+            Assert.DoesNotContain(logLines, l => l.Contains("stale index"));
+            Assert.Equal(0u, csm.ContinuationVesselPid);
+        }
+
+        [Fact]
+        public void UpdateUndockContinuationSampling_PidZero_NoOp()
+        {
+            var csm = new ChainSegmentManager();
+            Assert.Equal(0u, csm.UndockContinuationPid);
+
+            logLines.Clear();
+            csm.UpdateUndockContinuationSampling();
+
+            Assert.DoesNotContain(logLines, l => l.Contains("stale index"));
+            Assert.Equal(0u, csm.UndockContinuationPid);
+        }
+
+        [Fact]
+        public void UpdateContinuationSampling_StaleIdx_StopsContinuation()
+        {
+            RecordingStore.ResetForTesting();
+            var csm = new ChainSegmentManager();
+            csm.ContinuationVesselPid = 42;
+            csm.ContinuationRecordingIdx = 5; // beyond empty list
+
+            logLines.Clear();
+            csm.UpdateContinuationSampling();
+
+            // SampleContinuationVessel calls StopContinuation("stale index")
+            Assert.Equal(0u, csm.ContinuationVesselPid);
+            Assert.Equal(-1, csm.ContinuationRecordingIdx);
+            Assert.Contains(logLines, l =>
+                l.Contains("Continuation stopped") && l.Contains("stale index"));
+            RecordingStore.ResetForTesting();
+        }
+
+        [Fact]
+        public void UpdateUndockContinuationSampling_StaleIdx_StopsUndockContinuation()
+        {
+            RecordingStore.ResetForTesting();
+            var csm = new ChainSegmentManager();
+            csm.UndockContinuationPid = 99;
+            csm.UndockContinuationRecIdx = 10; // beyond empty list
+
+            logLines.Clear();
+            csm.UpdateUndockContinuationSampling();
+
+            Assert.Equal(0u, csm.UndockContinuationPid);
+            Assert.Equal(-1, csm.UndockContinuationRecIdx);
+            Assert.Contains(logLines, l =>
+                l.Contains("Undock continuation stopped") && l.Contains("stale index"));
+            RecordingStore.ResetForTesting();
+        }
+
+        #endregion
+
+        #region StopAllContinuations branching
+
+        [Fact]
+        public void StopAllContinuations_NeitherActive_NoChanges()
+        {
+            var csm = new ChainSegmentManager();
+            PopulateAllFields(csm);
+            // Set both pids to 0 (inactive) but keep other fields populated
+            csm.ContinuationVesselPid = 0;
+            csm.UndockContinuationPid = 0;
+
+            logLines.Clear();
+            csm.StopAllContinuations("test");
+
+            // Neither Stop method called — no log entries for stops
+            Assert.DoesNotContain(logLines, l => l.Contains("Continuation stopped"));
+            Assert.DoesNotContain(logLines, l => l.Contains("Undock continuation stopped"));
+            // Fields that were set before remain (StopAllContinuations only calls Stop if pid != 0)
+            Assert.Equal(3, csm.ContinuationRecordingIdx);
+            Assert.Equal(7, csm.UndockContinuationRecIdx);
+        }
+
+        [Fact]
+        public void StopAllContinuations_OnlyContinuationActive_StopsOnlyThat()
+        {
+            var csm = new ChainSegmentManager();
+            csm.ContinuationVesselPid = 42;
+            csm.ContinuationRecordingIdx = -1; // sentinel — RefreshSnapshot returns early
+            csm.UndockContinuationPid = 0;
+            csm.UndockContinuationRecIdx = 7;
+
+            logLines.Clear();
+            csm.StopAllContinuations("test-reason");
+
+            // Continuation stopped
+            Assert.Equal(0u, csm.ContinuationVesselPid);
+            Assert.Contains(logLines, l =>
+                l.Contains("Continuation stopped") && l.Contains("test-reason"));
+            // Undock NOT stopped (pid was 0)
+            Assert.DoesNotContain(logLines, l => l.Contains("Undock continuation stopped"));
+            Assert.Equal(7, csm.UndockContinuationRecIdx);
+        }
+
+        [Fact]
+        public void StopAllContinuations_OnlyUndockActive_StopsOnlyThat()
+        {
+            var csm = new ChainSegmentManager();
+            csm.ContinuationVesselPid = 0;
+            csm.ContinuationRecordingIdx = 3;
+            csm.UndockContinuationPid = 99;
+            csm.UndockContinuationRecIdx = -1; // sentinel — RefreshSnapshot returns early
+
+            logLines.Clear();
+            csm.StopAllContinuations("test-reason");
+
+            // Undock stopped
+            Assert.Equal(0u, csm.UndockContinuationPid);
+            Assert.Contains(logLines, l =>
+                l.Contains("Undock continuation stopped") && l.Contains("test-reason"));
+            // Continuation NOT stopped
+            Assert.DoesNotContain(logLines, l => l.Contains("Continuation stopped"));
+            Assert.Equal(3, csm.ContinuationRecordingIdx);
+        }
+
+        [Fact]
+        public void StopAllContinuations_BothActive_StopsBoth()
+        {
+            var csm = new ChainSegmentManager();
+            csm.ContinuationVesselPid = 42;
+            csm.ContinuationRecordingIdx = -1; // sentinel — RefreshSnapshot returns early
+            csm.UndockContinuationPid = 99;
+            csm.UndockContinuationRecIdx = -1; // sentinel — RefreshSnapshot returns early
+
+            logLines.Clear();
+            csm.StopAllContinuations("both-stop");
+
+            Assert.Equal(0u, csm.ContinuationVesselPid);
+            Assert.Equal(0u, csm.UndockContinuationPid);
+            Assert.Contains(logLines, l =>
+                l.Contains("Continuation stopped") && l.Contains("both-stop"));
+            Assert.Contains(logLines, l =>
+                l.Contains("Undock continuation stopped") && l.Contains("both-stop"));
+        }
+
+        [Fact]
+        public void StopAllContinuations_BothActive_PreservesChainIdentity()
+        {
+            var csm = new ChainSegmentManager();
+            PopulateAllFields(csm);
+            csm.ContinuationRecordingIdx = -1; // sentinel for safe refresh
+            csm.UndockContinuationRecIdx = -1;
+
+            csm.StopAllContinuations("cleanup");
+
+            // Chain identity untouched
+            Assert.Equal("chain-abc123", csm.ActiveChainId);
+            Assert.Equal(5, csm.ActiveChainNextIndex);
+            Assert.Equal("prev-xyz", csm.ActiveChainPrevId);
+            Assert.Equal("Jebediah Kerman", csm.ActiveChainCrewName);
+            // Pending untouched
+            Assert.True(csm.PendingContinuation);
+        }
+
+        #endregion
+
+        #region RefreshContinuationSnapshotCore guard paths
+
+        [Fact]
+        public void RefreshContinuationSnapshotCore_PidZero_ReturnsImmediately()
+        {
+            var csm = new ChainSegmentManager();
+            bool getCalled = false;
+            bool setCalled = false;
+            bool stopCalled = false;
+
+            csm.RefreshContinuationSnapshotCore(
+                0, 5, _ => stopCalled = true,
+                _ => { getCalled = true; return null; },
+                (_, __) => setCalled = true,
+                "test");
+
+            Assert.False(stopCalled);
+            Assert.False(getCalled);
+            Assert.False(setCalled);
+        }
+
+        [Fact]
+        public void RefreshContinuationSnapshotCore_NegativeRecIdx_ReturnsImmediately()
+        {
+            var csm = new ChainSegmentManager();
+            bool stopCalled = false;
+
+            csm.RefreshContinuationSnapshotCore(
+                42, -1, _ => stopCalled = true,
+                _ => null, (_, __) => { },
+                "test");
+
+            Assert.False(stopCalled);
+        }
+
+        [Fact]
+        public void RefreshContinuationSnapshotCore_StaleRecIdx_CallsStop()
+        {
+            RecordingStore.ResetForTesting();
+            var csm = new ChainSegmentManager();
+            string stopReason = null;
+
+            csm.RefreshContinuationSnapshotCore(
+                42, 999, reason => stopReason = reason,
+                _ => null, (_, __) => { },
+                "test");
+
+            Assert.Equal("stale index in snapshot refresh", stopReason);
+            RecordingStore.ResetForTesting();
+        }
+
+        #endregion
+
+        // Note: CommitSegmentCore and all public commit methods (CommitBoundarySplit,
+        // CommitChainSegment, CommitDockUndockSegment, CommitVesselSwitchTermination)
+        // cannot be unit-tested because they hit FlightGlobals.ActiveVessel which has
+        // a static initializer that requires Unity runtime (Quaternion.Euler).
     }
 }

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -108,14 +108,9 @@ KSP's inertial reference frame may drift over very long time warp. Could cause g
 
 ## TODO — Code Quality
 
-### T17. Game actions recording redesign (Phase 8)
+### ~~T17. Game actions recording redesign (Phase 8)~~ DONE
 
-Redesign milestone capture, resource budgeting, and action replay validated per game mode: sandbox (no resources), science (science only), career (full). See roadmap Phase 8.
-
-**Priority:** High — correctness across game modes
-
-**Phase 8 subtask progress:**
-- Task 36 (KSP MIA Respawn Handling, D7): DONE — `KerbalsModule.ApplyToRoster()` Step 3 sets every reserved kerbal to `Assigned` on each recalculation, overriding KSP's MIA respawn. 5 tests in `KerbalReservationTests.MiaRespawnOverride_*`.
+Full ledger-based game actions system shipped in v0.6.0. 7 resource modules (Science, Funds, Reputation, Milestones, Contracts, Facilities, Strategies), KspStatePatcher, contract deadline failures, kerbal rescue detection, game state event recording, milestone path qualification, strategy commitment rates, warp facility patching. 4621 tests. See CHANGELOG 0.6.0 "Game Actions & Resources System" and "Kerbal Lifecycle Management" sections.
 
 ### T18. Log contract checker error whitelist (bug #63)
 
@@ -155,9 +150,9 @@ Items identified during refactor-2 (March 2026) but deferred because they requir
 
 A broader refactor-3 audit (March 2026) identified additional structural opportunities beyond these deferred items. Full analysis in [refactor-3-audit.md](plans/refactor-3-audit.md).
 
-### T25. ParsekFlight TimelinePlaybackController extraction (D20)
+### ~~T25. ParsekFlight TimelinePlaybackController extraction (D20)~~ DONE
 
-**Status: DONE** — Completed as GhostPlaybackEngine (1553 lines) + ParsekPlaybackPolicy (192 lines) + IPlaybackTrajectory/IGhostPositioner/GhostPlaybackEvents interfaces. ParsekFlight reduced from ~9900 to 8657 lines. Engine has zero Recording references, accesses trajectories via IPlaybackTrajectory interface only. D5 and D8 now done (PR #85). D2 done (T28, CommitSegmentCore extracted).
+Completed as GhostPlaybackEngine (1553 lines) + ParsekPlaybackPolicy (192 lines) + IPlaybackTrajectory/IGhostPositioner/GhostPlaybackEvents interfaces. ParsekFlight reduced from ~9900 to 8657 lines. Engine has zero Recording references, accesses trajectories via IPlaybackTrajectory interface only. D5 and D8 now done (PR #85). D2 done (T28, CommitSegmentCore extracted).
 
 ### ~~T26. ParsekFlight ChainSegmentManager extraction (D21)~~ DONE
 
@@ -167,9 +162,9 @@ Phase 1 (state isolation): 16 chain state fields moved to ChainSegmentManager. ~
 
 Extracted `SampleAnimationStates` core method with `AnimLookup` enum + `FindAnimation` resolver. 4 methods reduced to thin wrappers, 4 caches consolidated into 1 `animationSampleCache`. Net -139 lines.
 
-### T28. ParsekFlight commit-pattern dedup (D2)
+### ~~T28. ParsekFlight commit-pattern dedup (D2)~~ DONE
 
-~~Unify `CommitChainSegment`, `CommitDockUndockSegment`, `CommitBoundarySplit`, `HandleVesselSwitchChainTermination`.~~ **DONE** — `CommitSegmentCore` extracts shared stash/tag/commit/advance pattern. All 4 commit methods now delegate to CommitSegmentCore via `Action<Recording>` callback. CommitSegmentCore handles nullable CaptureAtStop for boundary splits.
+`CommitSegmentCore` extracts shared stash/tag/commit/advance pattern. All 4 commit methods (`CommitChainSegment`, `CommitDockUndockSegment`, `CommitBoundarySplit`, `HandleVesselSwitchChainTermination`) now delegate to CommitSegmentCore via `Action<Recording>` callback. CommitSegmentCore handles nullable CaptureAtStop for boundary splits.
 
 ### T29. BackgroundRecorder Check*State polling dedup (D11)
 
@@ -187,7 +182,7 @@ Extracted `HandleResizeDrag` and `DrawResizeHandle` static helpers. 4 drag block
 
 **Priority:** Low — moderate savings, moderate risk
 
-### T32. Deep test suite audit — DONE (audit + fixes), edge cases deferred
+### ~~T32. Deep test suite audit~~ DONE (audit + fixes), edge cases deferred
 
 Audit completed: 110 test files (~55k lines) reviewed by 9 Opus subagents, independently reviewed. Fixes applied: 43 files changed, +170/-1182 lines.
 
@@ -205,11 +200,9 @@ Remaining edge case gaps (P3, not addressed):
 
 Added 5 accessor methods (`AddHiddenGroup`, `RemoveHiddenGroup`, `IsGroupHidden`, `TryGetGroupParent`, `HasGroupParent`). Migrated all ~20 ParsekUI.cs direct field accesses to use accessors and read-only properties. Tests retain direct field access for setup (pragmatic — encapsulation targets production coupling).
 
-### T34. ChainSegmentManager unit tests
+### ~~T34. ChainSegmentManager unit tests~~ DONE
 
-ChainSegmentManager has no dedicated test file. Pure state-machine methods (`ClearAll`, `ClearChainIdentity`, `StopContinuation`, `StopUndockContinuation`) and the commit abort paths are testable without Unity. Continuation sampling logic (`SampleContinuationVessel`) would need mocking for `FlightRecorder.FindVesselByPid` and `RecordingStore`.
-
-**Priority:** Medium — new class with non-trivial state transitions
+46 tests in `ChainSegmentManagerTests.cs`. Covers: all state-machine methods (ClearAll, ClearChainIdentity, StopContinuation, StopUndockContinuation), field isolation, sentinel values, idempotency, logging. Also covers `SampleContinuationVessel` guard paths (pid=0 early return, stale index), `UpdateContinuationSampling`/`UpdateUndockContinuationSampling` wrappers (no-op and stale-index-stop paths), `StopAllContinuations` branching (neither/one/both active, identity preservation), `RefreshContinuationSnapshotCore` guards (pid=0, negative recIdx, stale recIdx). Commit methods cannot be unit-tested (FlightGlobals static initializer requires Unity runtime).
 
 ### T35. ChainSegmentManager field encapsulation
 
@@ -247,17 +240,15 @@ Ghost orbit lines look identical to real vessel orbit lines. Should have a disti
 
 **Priority:** Low — cosmetic, functional without it
 
-### T41. Ghost orbit line for suborbital recordings
+### ~~T41. Ghost orbit line for suborbital recordings~~ DONE
 
 Suborbital recordings were excluded from ghost map presence — no orbit line during playback. Now relaxed: HandleGhostCreated allows SubOrbital terminal state through. Two paths: (1) recordings with orbit segments use the existing deferred mechanism, (2) physics-only recordings construct the orbit from interpolated state vectors when altitude > 1500m and speed > 60 m/s. Hysteresis thresholds (remove at alt < 500m or speed < 30 m/s) prevent create/destroy churn. RELATIVE-frame recordings are guarded against. Tracking station still excludes SubOrbital.
 
 **Status:** Fixed (0.6.0)
 
-### T41b. Skip orbit segment recording during in-atmosphere on-rails
+### ~~T41b. Skip orbit segment recording during in-atmosphere on-rails~~ DONE
 
-When the player time-warps during atmospheric reentry, KSP puts the vessel on-rails and the recorder creates an orbit segment with Keplerian elements (no drag). During playback, the ghost follows this dragless arc instead of the real trajectory. Surface clamp (PR #113) prevents underground tunneling, but the position is approximate. Fix: in FlightRecorder's `onVesselGoOnRails` handler, check `v.mainBody.atmosphere && v.altitude < v.mainBody.atmosphereDepth` — if below atmosphere, skip orbit segment creation. Point interpolation will lerp across the gap during playback.
-
-**Priority:** Medium — affects any recording where the player warped through atmospheric flight
+Fixed in v0.6.0 (PR #116). Added `ShouldSkipOrbitSegmentForAtmosphere` check in FlightRecorder (`OnVesselGoOnRails` + `StartRecording` on-rails init) and BackgroundRecorder (`InitializeOnRailsState`). When below atmosphere, orbit segment creation is skipped. Point interpolation lerps across the gap.
 
 ### T42. Convert KerbalsModule to IResourceModule
 


### PR DESCRIPTION
## Summary
- 16 new tests for ChainSegmentManager guard/abort paths: `SampleContinuationVessel` guards (pid=0, stale index), `StopAllContinuations` branching (neither/one/both), `RefreshContinuationSnapshotCore` guards, `Update*Sampling` wrapper no-ops. Total: 46 tests (up from 30).
- Marked 7 TODO items as done: T17 (game actions), T25/D20 (engine extraction), T28/D2 (commit dedup), T32 (test audit), T34 (this PR), T41 (suborbital orbit line), T41b (atmosphere on-rails skip).
- Added 0.6.1 changelog section.

## Test plan
- [x] `dotnet test --filter ChainSegmentManager` — 46 pass
- [x] Full suite — 4738 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)