### PR TITLE
T39: Allow watch mode for ghosts beyond 120km zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Parsek are documented here.
 
 ## 0.6.1
 
+### Ghost Playback
+
+- **Watch mode for distant ghosts (T39).** Watch button is no longer disabled for ghosts beyond the 120km visual rendering zone. The zone boundary is about rendering from the active vessel's camera — irrelevant for watch mode which moves the camera to the ghost. The only limit is now the user-configurable `ghostCameraCutoffKm` setting (default 300km).
+
 ### Tests
 
 - **ChainSegmentManager unit tests (T34).** 16 new tests covering `SampleContinuationVessel` guard paths (pid=0 early return, stale/negative index → stop callback), `UpdateContinuationSampling`/`UpdateUndockContinuationSampling` wrappers (no-op and stale-index propagation), `StopAllContinuations` branching (neither/one/both active, chain identity preservation), and `RefreshContinuationSnapshotCore` guards (pid=0, negative recIdx, stale recIdx). Total: 46 tests for ChainSegmentManager (up from 30).

--- a/Source/Parsek.Tests/BugFixTests.cs
+++ b/Source/Parsek.Tests/BugFixTests.cs
@@ -959,10 +959,16 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void IsWithinWatchRange_BeyondZone_AlwaysFalse()
+        public void IsWithinWatchRange_BeyondZone_WithinCutoff_True()
         {
-            // Beyond zone always returns false, even if distance < cutoff (shouldn't happen normally)
-            Assert.False(GhostPlaybackLogic.IsWithinWatchRange(RenderingZone.Beyond, 100000, 300));
+            // Beyond zone is irrelevant for watch mode — camera moves to ghost (T39)
+            Assert.True(GhostPlaybackLogic.IsWithinWatchRange(RenderingZone.Beyond, 100000, 300));
+        }
+
+        [Fact]
+        public void IsWithinWatchRange_BeyondZone_BeyondCutoff_False()
+        {
+            Assert.False(GhostPlaybackLogic.IsWithinWatchRange(RenderingZone.Beyond, 350000, 300));
         }
 
         [Fact]

--- a/Source/Parsek.Tests/BugFixTests.cs
+++ b/Source/Parsek.Tests/BugFixTests.cs
@@ -940,41 +940,28 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void IsWithinWatchRange_PhysicsZone_WithinCutoff_True()
+        public void IsWithinWatchRange_WithinCutoff_True()
         {
-            Assert.True(GhostPlaybackLogic.IsWithinWatchRange(RenderingZone.Physics, 1000, 300));
+            Assert.True(GhostPlaybackLogic.IsWithinWatchRange(1000, 300));
         }
 
         [Fact]
-        public void IsWithinWatchRange_VisualZone_WithinCutoff_True()
+        public void IsWithinWatchRange_WellWithinCutoff_True()
         {
-            Assert.True(GhostPlaybackLogic.IsWithinWatchRange(RenderingZone.Visual, 200000, 300));
+            Assert.True(GhostPlaybackLogic.IsWithinWatchRange(200000, 300));
         }
 
         [Fact]
-        public void IsWithinWatchRange_VisualZone_BeyondCutoff_False()
+        public void IsWithinWatchRange_BeyondCutoff_False()
         {
-            // Ghost is in Visual zone (< 1000km) but exceeds 300km cutoff
-            Assert.False(GhostPlaybackLogic.IsWithinWatchRange(RenderingZone.Visual, 350000, 300));
-        }
-
-        [Fact]
-        public void IsWithinWatchRange_BeyondZone_WithinCutoff_True()
-        {
-            // Beyond zone is irrelevant for watch mode — camera moves to ghost (T39)
-            Assert.True(GhostPlaybackLogic.IsWithinWatchRange(RenderingZone.Beyond, 100000, 300));
-        }
-
-        [Fact]
-        public void IsWithinWatchRange_BeyondZone_BeyondCutoff_False()
-        {
-            Assert.False(GhostPlaybackLogic.IsWithinWatchRange(RenderingZone.Beyond, 350000, 300));
+            Assert.False(GhostPlaybackLogic.IsWithinWatchRange(350000, 300));
         }
 
         [Fact]
         public void IsWithinWatchRange_AtExactCutoff_False()
         {
-            Assert.False(GhostPlaybackLogic.IsWithinWatchRange(RenderingZone.Visual, 300000, 300));
+            // Strict less-than: exactly at cutoff returns false
+            Assert.False(GhostPlaybackLogic.IsWithinWatchRange(300000, 300));
         }
     }
 

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -2396,7 +2396,7 @@ namespace Parsek
         /// user-configurable cutoff — zone is irrelevant because watch mode
         /// moves the camera to the ghost (T39).
         /// </summary>
-        internal static bool IsWithinWatchRange(RenderingZone zone, double distanceMeters, float cutoffKm)
+        internal static bool IsWithinWatchRange(double distanceMeters, float cutoffKm)
         {
             return distanceMeters < cutoffKm * 1000.0;
         }

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -2392,12 +2392,12 @@ namespace Parsek
 
         /// <summary>
         /// Determines whether a ghost is within the camera cutoff distance
-        /// (eligible for Watch button). Zone must not be Beyond AND distance
-        /// must be within the cutoff.
+        /// (eligible for Watch button). Only checks distance against the
+        /// user-configurable cutoff — zone is irrelevant because watch mode
+        /// moves the camera to the ghost (T39).
         /// </summary>
         internal static bool IsWithinWatchRange(RenderingZone zone, double distanceMeters, float cutoffKm)
         {
-            if (zone == RenderingZone.Beyond) return false;
             return distanceMeters < cutoffKm * 1000.0;
         }
 

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -7003,7 +7003,7 @@ namespace Parsek
             GhostPlaybackState s;
             if (!ghostStates.TryGetValue(index, out s) || s == null) return false;
             float cutoffKm = ParsekSettings.Current?.ghostCameraCutoffKm ?? 300f;
-            return GhostPlaybackLogic.IsWithinWatchRange(s.currentZone, s.lastDistance, cutoffKm);
+            return GhostPlaybackLogic.IsWithinWatchRange(s.lastDistance, cutoffKm);
         }
 
         /// <summary>

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -1530,7 +1530,7 @@ namespace Parsek
                 GUI.enabled = canWatch;
                 string watchLabel = isWatching ? "W*" : "W";
                 string watchTooltip = (hasGhost && !sameBody) ? "Ghost is on a different body"
-                    : (hasGhost && !inRange) ? "Ghost is beyond visual range"
+                    : (hasGhost && !inRange) ? "Ghost is beyond camera cutoff"
                     : "";
                 var watchContent = new GUIContent(watchLabel, watchTooltip);
                 if (GUILayout.Button(watchContent, GUILayout.Width(ColW_Watch)))

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -74,11 +74,9 @@ To implement properly: either rescale prefab Cap/Truss meshes from XSECTION data
 
 Implemented via ProtoVessel-based approach. Ghost chains with orbital data get lightweight ProtoVessels that provide automatic tracking station entries, orbit lines, map icons, and navigation targeting. 27 guard rails across 9 files, 4 Harmony patches (GoOffRails, CommNetVessel, SpaceTracking Fly/Delete/Recover). Orbit segment updates on SOI transitions. Soft cap despawn integration. 23 tests.
 
-### T12. EVA recording scope expansion (bug #56)
+### ~~T12. EVA recording scope expansion (bug #56)~~ DONE
 
-`OnCrewOnEva` only records EVAs from launch pad. In-flight EVAs (suborbital, flying, orbiting) are not recorded.
-
-**Priority:** Medium — design limitation
+Fixed in commit `ed19f03`. Removed PRELAUNCH situation guard from `OnCrewOnEva`. EVAs from any vessel situation (landed, orbiting, splashed, etc.) now trigger auto-record when the setting is enabled. Mid-recording EVAs were already handled via tree branching.
 
 ### T13. UI subgroup enable/loop checkboxes (bug #50)
 
@@ -228,11 +226,9 @@ Currently every breakup piece (including tiny debris fragments) gets its own bac
 
 **Priority:** Medium — user experience, UI clutter
 
-### T39. Watch mode for distant ghosts (post-separation stages)
+### ~~T39. Watch mode for distant ghosts (post-separation stages)~~ DONE
 
-After stage separation, the ghost for the continuation stage is at 40-120km altitude — beyond visual range (120km) from the pad. The Watch (W) button is disabled because the `inRange` check rejects Beyond-zone ghosts. The user expects to be able to watch all stages in sequence. Watch mode should teleport the camera to the ghost's location instead of requiring the ghost to be within visual range of the active vessel.
-
-**Priority:** High — core user experience for multi-stage flights
+Removed the `RenderingZone.Beyond` rejection from `IsWithinWatchRange`. The 120km zone boundary is about rendering from the active vessel's camera — irrelevant for watch mode which moves the camera to the ghost. The only limit is now `ghostCameraCutoffKm` (default 300km, user-configurable). The mesh-unhide exemption for watched Beyond-zone ghosts was already in place.
 
 ### T40. Ghost orbit line visual differentiation (Phase 4)
 


### PR DESCRIPTION
## Summary
- Removed `RenderingZone.Beyond` rejection from `IsWithinWatchRange` — the 120km zone boundary is about rendering from the active vessel camera, not watch mode which moves the camera to the ghost
- Watch button now only limited by `ghostCameraCutoffKm` (default 300km, user-configurable)
- Updated tooltip from "beyond visual range" to "beyond camera cutoff"
- Marked T12 (EVA recording scope) and T39 as done

## Test plan
- [x] `IsWithinWatchRange` tests updated — Beyond zone within cutoff now returns true
- [x] Full suite — 4739 pass
- [ ] In-game: launch multi-stage rocket, verify W button enabled for upper stage ghost at >120km

🤖 Generated with [Claude Code](https://claude.com/claude-code)