### PR TITLE
T38: Filter trivial debris from breakup recordings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to Parsek are documented here.
 
 - **Watch mode for distant ghosts (T39).** Watch button is no longer disabled for ghosts beyond the 120km visual rendering zone. The zone boundary is about rendering from the active vessel's camera — irrelevant for watch mode which moves the camera to the ghost. The only limit is now the user-configurable `ghostCameraCutoffKm` setting (default 300km).
 
+### Recording
+
+- **Debris recording filtering (T38).** Trivial crash fragments (single struts, panels, shroud pieces) are no longer recorded during breakup events. `ShouldRecordDebris` filters debris before Recording creation — vessels with fewer than 3 parts AND less than 0.5 tons are skipped entirely (no BackgroundRecorder tracking, no per-frame sampling). Spent boosters and multi-part stages pass the filter.
+
 ### Tests
 
 - **ChainSegmentManager unit tests (T34).** 16 new tests covering `SampleContinuationVessel` guard paths (pid=0 early return, stale/negative index → stop callback), `UpdateContinuationSampling`/`UpdateUndockContinuationSampling` wrappers (no-op and stale-index propagation), `StopAllContinuations` branching (neither/one/both active, chain identity preservation), and `RefreshContinuationSnapshotCore` guards (pid=0, negative recIdx, stale recIdx). Total: 46 tests for ChainSegmentManager (up from 30).

--- a/Source/Parsek.Tests/DebrisFilterTests.cs
+++ b/Source/Parsek.Tests/DebrisFilterTests.cs
@@ -1,0 +1,71 @@
+using Xunit;
+
+namespace Parsek.Tests
+{
+    public class DebrisFilterTests
+    {
+        // ShouldRecordDebris thresholds: partCount >= 3 OR mass >= 0.5t
+
+        [Fact]
+        public void SinglePartLowMass_NotRecorded()
+        {
+            Assert.False(ParsekFlight.ShouldRecordDebris(1, 0.1f));
+        }
+
+        [Fact]
+        public void TwoPartsLowMass_NotRecorded()
+        {
+            Assert.False(ParsekFlight.ShouldRecordDebris(2, 0.3f));
+        }
+
+        [Fact]
+        public void ZeroPartsZeroMass_NotRecorded()
+        {
+            Assert.False(ParsekFlight.ShouldRecordDebris(0, 0f));
+        }
+
+        [Fact]
+        public void ThreeParts_Recorded()
+        {
+            // Meets part count threshold even with low mass
+            Assert.True(ParsekFlight.ShouldRecordDebris(3, 0.1f));
+        }
+
+        [Fact]
+        public void ManyParts_Recorded()
+        {
+            Assert.True(ParsekFlight.ShouldRecordDebris(10, 0.01f));
+        }
+
+        [Fact]
+        public void HeavySinglePart_Recorded()
+        {
+            // Meets mass threshold even with one part (e.g., spent SRB)
+            Assert.True(ParsekFlight.ShouldRecordDebris(1, 0.5f));
+        }
+
+        [Fact]
+        public void HeavyMultiPart_Recorded()
+        {
+            Assert.True(ParsekFlight.ShouldRecordDebris(5, 2.0f));
+        }
+
+        [Fact]
+        public void JustBelowBothThresholds_NotRecorded()
+        {
+            Assert.False(ParsekFlight.ShouldRecordDebris(2, 0.49f));
+        }
+
+        [Fact]
+        public void AtExactMassThreshold_Recorded()
+        {
+            Assert.True(ParsekFlight.ShouldRecordDebris(1, 0.5f));
+        }
+
+        [Fact]
+        public void AtExactPartThreshold_Recorded()
+        {
+            Assert.True(ParsekFlight.ShouldRecordDebris(3, 0f));
+        }
+    }
+}

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -1481,6 +1481,30 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Determines whether a debris vessel is significant enough to record.
+        /// Filters out trivial crash fragments (single struts, panels, shroud pieces)
+        /// while keeping meaningful debris like spent boosters and stages.
+        /// </summary>
+        internal static bool ShouldRecordDebris(Vessel v)
+        {
+            if (v == null) return false;
+            int partCount = v.parts?.Count ?? 0;
+            float mass = (float)v.totalMass;
+            return ShouldRecordDebris(partCount, mass);
+        }
+
+        /// <summary>
+        /// Pure testable overload: debris is significant if it has at least
+        /// 3 parts OR at least 0.5 tons of mass.
+        /// </summary>
+        internal static bool ShouldRecordDebris(int partCount, float mass)
+        {
+            const int MinPartCount = 3;
+            const float MinMassTons = 0.5f;
+            return partCount >= MinPartCount || mass >= MinMassTons;
+        }
+
+        /// <summary>
         /// Appends captured trajectory data (points, orbit segments, part events, track sections)
         /// from a source recording into the target, sorts part events by UT, and sets the target's
         /// ExplicitEndUT. If source is null, only ExplicitEndUT is set.
@@ -2499,10 +2523,18 @@ namespace Parsek
             if (debrisPids != null && debrisPids.Count > 0)
             {
                 double debrisExpiryUT = breakupBp.UT + BackgroundRecorder.DebrisTTLSeconds;
+                int skippedDebris = 0;
                 for (int i = 0; i < debrisPids.Count; i++)
                 {
                     uint pid = debrisPids[i];
                     Vessel debrisVessel = FlightRecorder.FindVesselByPid(pid);
+
+                    if (debrisVessel != null && !ShouldRecordDebris(debrisVessel))
+                    {
+                        skippedDebris++;
+                        continue;
+                    }
+
                     string childRecId = Guid.NewGuid().ToString("N");
                     string vesselName = Recording.ResolveLocalizedName(debrisVessel?.vesselName) ?? "Debris";
 
@@ -2544,6 +2576,10 @@ namespace Parsek
                         $"name='{vesselName}', recId={childRecId}, " +
                         $"alive={debrisVessel != null}");
                 }
+                if (skippedDebris > 0)
+                    ParsekLog.Info("Coalescer",
+                        $"ProcessBreakupEvent: skipped {skippedDebris} trivial debris " +
+                        $"(below mass/part threshold)");
             }
 
             ParsekLog.Info("Coalescer",
@@ -2640,14 +2676,22 @@ namespace Parsek
             activeTree.BranchPoints.Add(breakupBp);
             rootRec.ChildBranchPointId = breakupBp.Id;
 
-            // 7. Create debris child recordings
+            // 7. Create debris child recordings (skip trivial fragments)
             var debrisPids = crashCoalescer.LastEmittedDebrisPids;
             if (debrisPids != null)
             {
+                int skippedDebris = 0;
                 for (int i = 0; i < debrisPids.Count; i++)
                 {
                     uint pid = debrisPids[i];
                     Vessel debrisVessel = FlightRecorder.FindVesselByPid(pid);
+
+                    if (debrisVessel != null && !ShouldRecordDebris(debrisVessel))
+                    {
+                        skippedDebris++;
+                        continue;
+                    }
+
                     string childRecId = Guid.NewGuid().ToString("N");
                     string vesselName = Recording.ResolveLocalizedName(debrisVessel?.vesselName) ?? "Debris";
 
@@ -2683,6 +2727,10 @@ namespace Parsek
                         $"name='{vesselName}', recId={childRecId}, " +
                         $"alive={debrisVessel != null}");
                 }
+                if (skippedDebris > 0)
+                    ParsekLog.Info("Coalescer",
+                        $"PromoteToTreeForBreakup: skipped {skippedDebris} trivial debris " +
+                        $"(below mass/part threshold)");
             }
 
             // 8. Create controlled child recordings (same pattern, IsDebris = false, no TTL)

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -2519,11 +2519,11 @@ namespace Parsek
             }
 
             // Also create debris child recordings for new debris from this breakup
+            int skippedDebris = 0;
             var debrisPids = crashCoalescer.LastEmittedDebrisPids;
             if (debrisPids != null && debrisPids.Count > 0)
             {
                 double debrisExpiryUT = breakupBp.UT + BackgroundRecorder.DebrisTTLSeconds;
-                int skippedDebris = 0;
                 for (int i = 0; i < debrisPids.Count; i++)
                 {
                     uint pid = debrisPids[i];
@@ -2576,16 +2576,13 @@ namespace Parsek
                         $"name='{vesselName}', recId={childRecId}, " +
                         $"alive={debrisVessel != null}");
                 }
-                if (skippedDebris > 0)
-                    ParsekLog.Info("Coalescer",
-                        $"ProcessBreakupEvent: skipped {skippedDebris} trivial debris " +
-                        $"(below mass/part threshold)");
             }
 
             ParsekLog.Info("Coalescer",
                 $"ProcessBreakupEvent: BREAKUP attached to tree={activeTree.Id}, " +
                 $"parentRec={activeRecId}, bpId={breakupBp.Id}, " +
                 $"cause={breakupBp.BreakupCause}, debris={breakupBp.DebrisCount}, " +
+                $"skippedTrivial={skippedDebris}, " +
                 $"duration={breakupBp.BreakupDuration:F3}s");
         }
 
@@ -2677,10 +2674,10 @@ namespace Parsek
             rootRec.ChildBranchPointId = breakupBp.Id;
 
             // 7. Create debris child recordings (skip trivial fragments)
+            int skippedDebris = 0;
             var debrisPids = crashCoalescer.LastEmittedDebrisPids;
             if (debrisPids != null)
             {
-                int skippedDebris = 0;
                 for (int i = 0; i < debrisPids.Count; i++)
                 {
                     uint pid = debrisPids[i];
@@ -2727,10 +2724,6 @@ namespace Parsek
                         $"name='{vesselName}', recId={childRecId}, " +
                         $"alive={debrisVessel != null}");
                 }
-                if (skippedDebris > 0)
-                    ParsekLog.Info("Coalescer",
-                        $"PromoteToTreeForBreakup: skipped {skippedDebris} trivial debris " +
-                        $"(below mass/part threshold)");
             }
 
             // 8. Create controlled child recordings (same pattern, IsDebris = false, no TTL)
@@ -2837,6 +2830,7 @@ namespace Parsek
                 $"PromoteToTreeForBreakup: standalone recording promoted to tree. " +
                 $"tree={treeId}, root={rootRecId}, " +
                 $"debris={debrisPids?.Count ?? 0} (alive={debrisAlive}), " +
+                $"skippedTrivial={skippedDebris}, " +
                 $"controlled={controlledPids?.Count ?? 0}, " +
                 $"breakup={breakupBp.Id}");
         }

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -220,11 +220,9 @@ In the showcase part list, the kerbal holding a flag is not at the same height a
 
 **Priority:** Low — cosmetic
 
-### T38. Debris recording filtering
+### ~~T38. Debris recording filtering~~ DONE
 
-Currently every breakup piece (including tiny debris fragments) gets its own background recording. A 17-debris breakup produces 17 separate recordings cluttering the UI. Should filter by vessel type/mass/part count and only record meaningful stages and boosters, not every small debris fragment.
-
-**Priority:** Medium — user experience, UI clutter
+Added `ShouldRecordDebris` filter in `ProcessBreakupEvent` and `PromoteToTreeForBreakup`. Debris vessels below both thresholds (< 3 parts AND < 0.5 tons) are skipped before Recording creation — no BackgroundRecorder tracking, no per-frame sampling. Spent boosters and stages pass the filter; single struts, panels, and shroud fragments are skipped. 10 unit tests.
 
 ### ~~T39. Watch mode for distant ghosts (post-separation stages)~~ DONE
 


### PR DESCRIPTION
## Summary
- Added `ShouldRecordDebris(partCount, mass)` filter: debris with < 3 parts AND < 0.5t mass is skipped
- Applied in both `ProcessBreakupEvent` and `PromoteToTreeForBreakup` before Recording creation
- Trivial fragments (single struts, panels, shroud pieces) get no Recording, no BackgroundRecorder tracking, no per-frame sampling
- Spent boosters (heavy, multi-part) and stages pass the filter
- Batch summary log when debris is skipped

## Test plan
- [x] 10 unit tests for `ShouldRecordDebris` boundary cases
- [x] Full suite — 4747 pass
- [x] In-game: stage separation with SRBs — boosters recorded, small fragments skipped
- [x] In-game: crash breakup — verify most fragments skipped, UI not cluttered

🤖 Generated with [Claude Code](https://claude.com/claude-code)