### PR TITLE
Fix watch camera cutting off on orbital ghosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Parsek are documented here.
 
 ## 0.6.1
 
+### Watch Mode
+
+- **Fix watch camera cutting off on orbital ghosts.** The 300km camera cutoff was unconditionally exiting watch mode when a ghost exceeded the distance — even for orbital recordings that naturally travel far during ascent/orbit. Orbital recordings (those with orbit segments) are now exempt from both the watch-exit cutoff and the Watch button distance gate. Also added missing log entry on individual recording Watch button clicks.
+
 ### Recording
 
 - **Close commit-to-save crash window (T15).** Recording data no longer lives only in RAM between commit and the next `OnSave()` cycle. New `FlushDirtyFiles()` writes `.prec`, `_vessel.craft`, and `_ghost.craft` to disk immediately on commit and again after the recording optimization pass (merge/split/trim). If the immediate write fails, `FilesDirty` stays true and `OnSave` retries as before — no behavior change in the failure path.

--- a/Source/Parsek.Tests/BugFixTests.cs
+++ b/Source/Parsek.Tests/BugFixTests.cs
@@ -963,6 +963,18 @@ namespace Parsek.Tests
             // Strict less-than: exactly at cutoff returns false
             Assert.False(GhostPlaybackLogic.IsWithinWatchRange(300000, 300));
         }
+
+        [Theory]
+        [InlineData(500000, 300, true, false)]   // orbital ghost 500km away — exempt, no exit
+        [InlineData(500000, 300, false, true)]   // non-orbital ghost 500km away — exit
+        [InlineData(100000, 300, true, false)]   // orbital ghost within cutoff — no exit
+        [InlineData(100000, 300, false, false)]  // non-orbital ghost within cutoff — no exit
+        [InlineData(300000, 300, true, false)]   // orbital at exact boundary — exempt
+        [InlineData(300000, 300, false, true)]   // non-orbital at exact boundary — exit
+        public void ShouldExitWatchForCutoff_OrbitalExemption(double distMeters, float cutoffKm, bool isOrbital, bool expected)
+        {
+            Assert.Equal(expected, GhostPlaybackLogic.ShouldExitWatchForCutoff(distMeters, cutoffKm, isOrbital));
+        }
     }
 
     #endregion

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -2391,6 +2391,16 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Orbital-aware version: orbital recordings are exempt from the cutoff
+        /// because they naturally travel far from the active vessel during ascent/orbit.
+        /// </summary>
+        internal static bool ShouldExitWatchForCutoff(double ghostDistanceMeters, float cutoffKm, bool isOrbitalRecording)
+        {
+            if (isOrbitalRecording) return false;
+            return ghostDistanceMeters >= cutoffKm * 1000.0;
+        }
+
+        /// <summary>
         /// Determines whether a ghost is within the camera cutoff distance
         /// (eligible for Watch button). Only checks distance against the
         /// user-configurable cutoff — zone is irrelevant because watch mode

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -6945,12 +6945,21 @@ namespace Parsek
         }
 
         /// <summary>
-        /// Returns true if the ghost at index is within the camera cutoff distance.
+        /// Returns true if the ghost at index is within the camera cutoff distance,
+        /// or if it's an orbital recording (exempt from cutoff — naturally travels far).
         /// </summary>
         internal bool IsGhostWithinVisualRange(int index)
         {
             GhostPlaybackState s;
             if (!ghostStates.TryGetValue(index, out s) || s == null) return false;
+            // Orbital recordings are always "in range" for watch purposes
+            var committed = RecordingStore.CommittedRecordings;
+            if (index >= 0 && index < committed.Count)
+            {
+                var rec = committed[index];
+                if (rec.OrbitSegments != null && rec.OrbitSegments.Count > 0)
+                    return true;
+            }
             float cutoffKm = ParsekSettings.Current?.ghostCameraCutoffKm ?? 300f;
             return GhostPlaybackLogic.IsWithinWatchRange(s.lastDistance, cutoffKm);
         }
@@ -7054,8 +7063,11 @@ namespace Parsek
             // Distance guard: KSP rendering breaks when camera is far from the active vessel
             // (FloatingOrigin, terrain, atmosphere, skybox are all anchored to active vessel).
             // Refuse watch if ghost is beyond the user's camera cutoff distance setting.
+            // Orbital ghosts are exempt — they naturally travel far during ascent/orbit.
+            var rec = committed[index];
+            bool isOrbitalRecording = rec.OrbitSegments != null && rec.OrbitSegments.Count > 0;
             float maxWatchKm = ParsekSettings.Current?.ghostCameraCutoffKm ?? 300f;
-            if (FlightGlobals.ActiveVessel != null && gs.ghost != null)
+            if (FlightGlobals.ActiveVessel != null && gs.ghost != null && !isOrbitalRecording)
             {
                 float distKm = (float)(Vector3d.Distance(
                     gs.ghost.transform.position, FlightGlobals.ActiveVessel.transform.position) / 1000.0);
@@ -7097,7 +7109,6 @@ namespace Parsek
             // If the ghost is currently beyond visual range and the recording loops,
             // reset the loop phase so the ghost starts from the beginning of the recording
             // (at the pad) instead of wherever it is mid-flight (e.g. near the Mun).
-            var rec = committed[index];
             if (gs.currentZone == RenderingZone.Beyond && ShouldLoopPlayback(rec))
             {
                 double currentUT = Planetarium.GetUniversalTime();
@@ -7444,11 +7455,13 @@ namespace Parsek
                 GhostPlaybackLogic.GetZoneRenderingPolicy(zone);
 
             // Ghost camera cutoff: exit watch mode when the watched ghost exceeds the
-            // user-configured cutoff distance, regardless of zone classification.
+            // user-configured cutoff distance. Orbital ghosts are exempt — they naturally
+            // travel far from the active vessel during ascent/orbit.
             if (isWatchedGhost)
             {
                 double cutoffMeters = (ParsekSettings.Current?.ghostCameraCutoffKm ?? 300f) * 1000.0;
-                if (ghostDistance >= cutoffMeters)
+                bool isOrbitalRecording = rec.OrbitSegments != null && rec.OrbitSegments.Count > 0;
+                if (ghostDistance >= cutoffMeters && !isOrbitalRecording)
                 {
                     ParsekLog.Info("Zone",
                         $"Ghost #{recIdx} \"{rec.VesselName}\" exceeded ghost camera cutoff " +
@@ -7456,6 +7469,15 @@ namespace Parsek
                         $"{cutoffMeters.ToString("F0", CultureInfo.InvariantCulture)}m) — exiting watch mode");
                     ExitWatchMode();
                     // Don't return — let zone rendering continue (ghost will be hidden if Beyond)
+                }
+                else if (ghostDistance >= cutoffMeters && isOrbitalRecording)
+                {
+                    // Orbital ghost beyond cutoff but watched — exempt from exit, exempt from hide
+                    shouldHideMesh = false;
+                    ParsekLog.VerboseRateLimited("Zone", $"watched-orbital-exempt-{recIdx}",
+                        $"Ghost #{recIdx} \"{rec.VesselName}\" beyond cutoff " +
+                        $"({ghostDistance.ToString("F0", CultureInfo.InvariantCulture)}m) but watched orbital ghost — exempt",
+                        5.0);
                 }
                 else if (shouldHideMesh)
                 {

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -6954,12 +6954,8 @@ namespace Parsek
             if (!ghostStates.TryGetValue(index, out s) || s == null) return false;
             // Orbital recordings are always "in range" for watch purposes
             var committed = RecordingStore.CommittedRecordings;
-            if (index >= 0 && index < committed.Count)
-            {
-                var rec = committed[index];
-                if (rec.OrbitSegments != null && rec.OrbitSegments.Count > 0)
-                    return true;
-            }
+            if (index >= 0 && index < committed.Count && committed[index].HasOrbitSegments)
+                return true;
             float cutoffKm = ParsekSettings.Current?.ghostCameraCutoffKm ?? 300f;
             return GhostPlaybackLogic.IsWithinWatchRange(s.lastDistance, cutoffKm);
         }
@@ -7065,9 +7061,8 @@ namespace Parsek
             // Refuse watch if ghost is beyond the user's camera cutoff distance setting.
             // Orbital ghosts are exempt — they naturally travel far during ascent/orbit.
             var rec = committed[index];
-            bool isOrbitalRecording = rec.OrbitSegments != null && rec.OrbitSegments.Count > 0;
             float maxWatchKm = ParsekSettings.Current?.ghostCameraCutoffKm ?? 300f;
-            if (FlightGlobals.ActiveVessel != null && gs.ghost != null && !isOrbitalRecording)
+            if (FlightGlobals.ActiveVessel != null && gs.ghost != null && !rec.HasOrbitSegments)
             {
                 float distKm = (float)(Vector3d.Distance(
                     gs.ghost.transform.position, FlightGlobals.ActiveVessel.transform.position) / 1000.0);
@@ -7459,33 +7454,25 @@ namespace Parsek
             // travel far from the active vessel during ascent/orbit.
             if (isWatchedGhost)
             {
-                double cutoffMeters = (ParsekSettings.Current?.ghostCameraCutoffKm ?? 300f) * 1000.0;
-                bool isOrbitalRecording = rec.OrbitSegments != null && rec.OrbitSegments.Count > 0;
-                if (ghostDistance >= cutoffMeters && !isOrbitalRecording)
+                float cutoffKm = ParsekSettings.Current?.ghostCameraCutoffKm ?? 300f;
+                bool hasOrbitalSegments = rec.OrbitSegments != null && rec.OrbitSegments.Count > 0;
+                if (GhostPlaybackLogic.ShouldExitWatchForCutoff(ghostDistance, cutoffKm, hasOrbitalSegments))
                 {
                     ParsekLog.Info("Zone",
                         $"Ghost #{recIdx} \"{rec.VesselName}\" exceeded ghost camera cutoff " +
                         $"({ghostDistance.ToString("F0", CultureInfo.InvariantCulture)}m > " +
-                        $"{cutoffMeters.ToString("F0", CultureInfo.InvariantCulture)}m) — exiting watch mode");
+                        $"{(cutoffKm * 1000.0).ToString("F0", CultureInfo.InvariantCulture)}m) — exiting watch mode");
                     ExitWatchMode();
                     // Don't return — let zone rendering continue (ghost will be hidden if Beyond)
                 }
-                else if (ghostDistance >= cutoffMeters && isOrbitalRecording)
-                {
-                    // Orbital ghost beyond cutoff but watched — exempt from exit, exempt from hide
-                    shouldHideMesh = false;
-                    ParsekLog.VerboseRateLimited("Zone", $"watched-orbital-exempt-{recIdx}",
-                        $"Ghost #{recIdx} \"{rec.VesselName}\" beyond cutoff " +
-                        $"({ghostDistance.ToString("F0", CultureInfo.InvariantCulture)}m) but watched orbital ghost — exempt",
-                        5.0);
-                }
                 else if (shouldHideMesh)
                 {
-                    // Within cutoff but in Beyond zone — exempt from hide (camera is at ghost)
+                    // Watched ghost in Beyond zone — exempt from hide (camera is at ghost)
                     shouldHideMesh = false;
+                    string reason = hasOrbitalSegments ? "watched orbital ghost" : "watched";
                     ParsekLog.VerboseRateLimited("Zone", $"watched-zone-exempt-{recIdx}",
                         $"Ghost #{recIdx} \"{rec.VesselName}\" beyond visual range " +
-                        $"({ghostDistance.ToString("F0", CultureInfo.InvariantCulture)}m) but watched — exempt from zone hide",
+                        $"({ghostDistance.ToString("F0", CultureInfo.InvariantCulture)}m) but {reason} — exempt from zone hide",
                         5.0);
                 }
             }

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -1535,11 +1535,11 @@ namespace Parsek
                 var watchContent = new GUIContent(watchLabel, watchTooltip);
                 if (GUILayout.Button(watchContent, GUILayout.Width(ColW_Watch)))
                 {
+                    ParsekLog.Info("UI", $"Recording #{ri} W button clicked: {(isWatching ? "exit" : "enter")} watch on \"{rec.VesselName}\"");
                     if (isWatching)
                         flight.ExitWatchMode();
                     else
                         flight.EnterWatchMode(ri);
-                    ParsekLog.Info("UI", $"Recording #{ri} W button: {(isWatching ? "exit" : "enter")} watch on \"{rec.VesselName}\"");
                 }
                 GUI.enabled = true;
             }

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -1539,6 +1539,7 @@ namespace Parsek
                         flight.ExitWatchMode();
                     else
                         flight.EnterWatchMode(ri);
+                    ParsekLog.Info("UI", $"Recording #{ri} W button: {(isWatching ? "exit" : "enter")} watch on \"{rec.VesselName}\"");
                 }
                 GUI.enabled = true;
             }

--- a/Source/Parsek/Recording.cs
+++ b/Source/Parsek/Recording.cs
@@ -20,6 +20,7 @@ namespace Parsek
         public int RecordingFormatVersion = RecordingStore.CurrentRecordingFormatVersion;
         public List<TrajectoryPoint> Points = new List<TrajectoryPoint>();
         public List<OrbitSegment> OrbitSegments = new List<OrbitSegment>();
+        public bool HasOrbitSegments => OrbitSegments != null && OrbitSegments.Count > 0;
         public List<PartEvent> PartEvents = new List<PartEvent>();
         public List<FlagEvent> FlagEvents = new List<FlagEvent>();
         public List<SegmentEvent> SegmentEvents = new List<SegmentEvent>();

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -2484,6 +2484,16 @@ Intermediate tree recordings with 0 trajectory points but non-null VesselSnapsho
 
 **Priority:** Low — performance optimization, no functional impact.
 
+## ~~221. Watch camera cuts off on orbital ghosts at 300km~~
+
+When watching an orbital stage ghost (e.g., Kerbal X second stage), the 300km camera cutoff unconditionally exits watch mode — even though the ghost naturally travels far during ascent/orbit. The Watch (W) button then becomes disabled (`IsGhostWithinVisualRange` uses the same cutoff), preventing the user from re-watching.
+
+**Log evidence:** `Ghost #1 "Kerbal X" exceeded ghost camera cutoff (300271m > 300000m) — exiting watch mode` while watching a looped KerbalX recording's orbital stage.
+
+**Root cause:** The zone cutoff at `ApplyZoneRenderingImpl` (and the `EnterWatchMode` distance guard and `IsGhostWithinVisualRange` button check) had no orbital exemption. Bug #89's fix correctly added the cutoff but didn't distinguish orbital vs surface/suborbital ghosts.
+
+**Fix (PR #125):** Orbital recordings (those with orbit segments) are exempt from the watch-exit cutoff (`ShouldExitWatchForCutoff` 3-arg overload), the `EnterWatchMode` distance gate, and the Watch button `IsGhostWithinVisualRange` check. Non-orbital ghosts (debris, surface) still respect the cutoff. Added `Recording.HasOrbitSegments` property and logging on individual W button clicks.
+
 # In-Game Tests
 
 - [x] Vessels propagate naturally along orbits after FF (no position freezing)


### PR DESCRIPTION
## Summary
- Orbital recordings (those with orbit segments) are now exempt from the 300km watch-exit cutoff, the EnterWatchMode distance gate, and the Watch button enable check — they naturally travel far during ascent/orbit
- Adds `ShouldExitWatchForCutoff(dist, cutoff, isOrbital)` overload to GhostPlaybackLogic for testability
- Adds missing log entry on individual recording Watch button clicks (was a logging gap vs the group W button)

## Root cause
KSP.log from a looped KerbalX recording showed `Ghost #1 "Kerbal X" exceeded ghost camera cutoff (300271m > 300000m) — exiting watch mode` — the orbital stage ghost was forcefully ejected from watch mode at 300km. The Watch button then became disabled (`IsGhostWithinVisualRange` also uses the cutoff), preventing the user from re-watching the orbital stage.

## Changes
| File | Change |
|------|--------|
| `ParsekFlight.cs` | Zone cutoff exempts orbital recordings; `EnterWatchMode` distance guard exempts orbital; `IsGhostWithinVisualRange` returns true for orbital recordings |
| `GhostPlaybackLogic.cs` | New `ShouldExitWatchForCutoff(dist, cutoff, isOrbital)` overload |
| `ParsekUI.cs` | Log entry on individual recording W button click |
| `BugFixTests.cs` | 6 new tests for orbital exemption logic |
| `CHANGELOG.md` | Watch Mode section added |

## Test plan
- [x] 4738 tests pass (4732 existing + 6 new orbital exemption tests)
- [ ] In-game: loop a KerbalX recording, watch the orbital stage — camera should NOT cut off at 300km
- [ ] In-game: Watch button for orbital stage should remain enabled regardless of distance
- [ ] In-game: non-orbital ghosts (debris, surface) should still respect the 300km cutoff

🤖 Generated with [Claude Code](https://claude.com/claude-code)