### PR TITLE
T45: Add HasOrbitSegments to IPlaybackTrajectory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to Parsek are documented here.
 - **Pass 3A: SafeWriteConfigNode deduplicated.** Four independent safe-write implementations (Ledger, RecordingStore, GameStateStore, MilestoneStore) consolidated into shared `FileIOUtils.SafeWriteConfigNode`. MilestoneStore gains error handling it previously lacked.
 - **Pass 3B: SuppressionGuard struct.** 10 manual try/finally suppression-flag blocks across 4 files replaced with `IDisposable` `SuppressionGuard` struct (Crew, Resources, ResourcesAndReplay factories).
 - **Pass 3C: ParsekUI window extractions.** Three self-contained windows extracted from ParsekUI (4,773 → 3,698 lines): `UI/GroupPickerUI` (373 lines), `UI/SpawnControlUI` (321 lines), `UI/ActionsWindowUI` (500 lines).
+- **T45: `HasOrbitSegments` added to `IPlaybackTrajectory` interface.** 13 inline `OrbitSegments != null && .Count > 0` checks replaced across 6 files. `MockTrajectory` updated.
 - 4,766 tests pass throughout. Zero logic changes.
 
 ### Tests

--- a/Source/Parsek.Tests/MockTrajectory.cs
+++ b/Source/Parsek.Tests/MockTrajectory.cs
@@ -11,6 +11,7 @@ namespace Parsek.Tests
     {
         public List<TrajectoryPoint> Points { get; set; } = new List<TrajectoryPoint>();
         public List<OrbitSegment> OrbitSegments { get; set; } = new List<OrbitSegment>();
+        public bool HasOrbitSegments => OrbitSegments != null && OrbitSegments.Count > 0;
         public List<TrackSection> TrackSections { get; set; } = new List<TrackSection>();
         public double StartUT => Points.Count > 0 ? Points[0].ut : 0;
         public double EndUT => Points.Count > 0 ? Points[Points.Count - 1].ut : 0;

--- a/Source/Parsek/GhostMapPresence.cs
+++ b/Source/Parsek/GhostMapPresence.cs
@@ -512,7 +512,7 @@ namespace Parsek
                 {
                     v = CreateGhostVesselForRecording(i, rec);
                 }
-                else if (rec.OrbitSegments != null && rec.OrbitSegments.Count > 0)
+                else if (rec.HasOrbitSegments)
                 {
                     OrbitSegment? seg = TrajectoryMath.FindOrbitSegment(rec.OrbitSegments, currentUT);
                     if (seg.HasValue)
@@ -789,7 +789,7 @@ namespace Parsek
                 return (true, null);
 
             // Orbit segments: find the one matching currentUT
-            if (rec.OrbitSegments != null && rec.OrbitSegments.Count > 0)
+            if (rec.HasOrbitSegments)
             {
                 OrbitSegment? seg = TrajectoryMath.FindOrbitSegment(rec.OrbitSegments, currentUT);
                 if (seg.HasValue)
@@ -839,7 +839,7 @@ namespace Parsek
                 {
                     v = CreateGhostVesselForRecording(i, rec);
                 }
-                else if (rec.OrbitSegments != null && rec.OrbitSegments.Count > 0)
+                else if (rec.HasOrbitSegments)
                 {
                     OrbitSegment? seg = TrajectoryMath.FindOrbitSegment(rec.OrbitSegments, currentUT);
                     if (seg.HasValue)

--- a/Source/Parsek/GhostPlaybackEngine.cs
+++ b/Source/Parsek/GhostPlaybackEngine.cs
@@ -146,7 +146,7 @@ namespace Parsek
                 }
 
                 bool hasPoints = traj.Points != null && traj.Points.Count >= 2;
-                bool hasOrbitData = traj.OrbitSegments != null && traj.OrbitSegments.Count > 0;
+                bool hasOrbitData = traj.HasOrbitSegments;
                 bool hasSurfaceData = traj.SurfacePos.HasValue;
                 if (!hasPoints && !hasOrbitData && !hasSurfaceData) continue;
 

--- a/Source/Parsek/IPlaybackTrajectory.cs
+++ b/Source/Parsek/IPlaybackTrajectory.cs
@@ -15,6 +15,7 @@ namespace Parsek
         // === Trajectory data ===
         List<TrajectoryPoint> Points { get; }
         List<OrbitSegment> OrbitSegments { get; }
+        bool HasOrbitSegments { get; }
         List<TrackSection> TrackSections { get; }
         double StartUT { get; }
         double EndUT { get; }

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -5856,7 +5856,7 @@ namespace Parsek
                     var rec = committed[i];
                     if (rec.VesselPersistentId != chain.OriginalVesselPid) continue;
 
-                    if (rec.OrbitSegments != null && rec.OrbitSegments.Count > 0)
+                    if (rec.HasOrbitSegments)
                     {
                         PositionGhostFromOrbitOnly(ghostGO, rec, currentUT,
                             (int)(chain.OriginalVesselPid * 10000));
@@ -7542,7 +7542,7 @@ namespace Parsek
             if (isWatchedGhost)
             {
                 float cutoffKm = ParsekSettings.Current?.ghostCameraCutoffKm ?? 300f;
-                bool hasOrbitalSegments = rec.OrbitSegments != null && rec.OrbitSegments.Count > 0;
+                bool hasOrbitalSegments = rec.HasOrbitSegments;
                 if (GhostPlaybackLogic.ShouldExitWatchForCutoff(ghostDistance, cutoffKm, hasOrbitalSegments))
                 {
                     ParsekLog.Info("Zone",
@@ -7567,7 +7567,7 @@ namespace Parsek
             // #171: During warp, exempt orbital ghosts from zone hiding — they travel far
             // from the player and would complete playback while invisible.
             if (shouldHideMesh && GhostPlaybackLogic.ShouldExemptFromZoneHide(
-                    TimeWarp.CurrentRate, rec.OrbitSegments != null && rec.OrbitSegments.Count > 0))
+                    TimeWarp.CurrentRate, rec.HasOrbitSegments))
             {
                 shouldHideMesh = false;
                 ParsekLog.VerboseRateLimited("Zone", $"warp-zone-exempt-{recIdx}",

--- a/Source/Parsek/ParsekPlaybackPolicy.cs
+++ b/Source/Parsek/ParsekPlaybackPolicy.cs
@@ -451,7 +451,7 @@ namespace Parsek
             // Accept recordings with terminal orbit data, orbit segments, or trajectory
             // points (physics-only suborbital recordings have points but no orbit data).
             bool hasOrbitData = GhostMapPresence.HasOrbitData(evt.Trajectory);
-            bool hasOrbitSegments = evt.Trajectory.OrbitSegments != null && evt.Trajectory.OrbitSegments.Count > 0;
+            bool hasOrbitSegments = evt.Trajectory.HasOrbitSegments;
             bool hasPoints = evt.Trajectory.Points != null && evt.Trajectory.Points.Count > 0;
             if (!hasOrbitData && !hasOrbitSegments && !hasPoints)
                 return;
@@ -568,7 +568,7 @@ namespace Parsek
                     }
 
                     // Path B: state-vector-based (new — physics-only suborbital)
-                    if (traj.OrbitSegments == null || traj.OrbitSegments.Count == 0)
+                    if (!traj.HasOrbitSegments)
                     {
                         if (traj.Points == null || traj.Points.Count == 0) continue;
                         if (IsInRelativeFrame(traj, currentUT)) continue;
@@ -655,7 +655,7 @@ namespace Parsek
                 if (idx < 0 || idx >= committed.Count) continue;
 
                 var rec = committed[idx];
-                if (rec.OrbitSegments == null || rec.OrbitSegments.Count == 0) continue;
+                if (!rec.HasOrbitSegments) continue;
 
                 OrbitSegment? seg = TrajectoryMath.FindOrbitSegment(rec.OrbitSegments, currentUT);
 
@@ -745,7 +745,7 @@ namespace Parsek
         /// </summary>
         internal static bool StartsInOrbit(IPlaybackTrajectory traj, double ut)
         {
-            if (traj.OrbitSegments == null || traj.OrbitSegments.Count == 0)
+            if (!traj.HasOrbitSegments)
                 return false;
             // If recording has no trajectory points, it's orbit-only
             if (traj.Points == null || traj.Points.Count == 0)

--- a/Source/Parsek/ParsekTrackingStation.cs
+++ b/Source/Parsek/ParsekTrackingStation.cs
@@ -79,7 +79,7 @@ namespace Parsek
                     continue;
 
                 // Skip if currently in an orbit segment (ProtoVessel handles that)
-                if (rec.OrbitSegments != null
+                if (rec.HasOrbitSegments
                     && TrajectoryMath.FindOrbitSegment(rec.OrbitSegments, currentUT).HasValue)
                     continue;
 

--- a/Source/Parsek/RecordingOptimizer.cs
+++ b/Source/Parsek/RecordingOptimizer.cs
@@ -236,7 +236,7 @@ namespace Parsek
                 target.TrackSections.AddRange(absorbed.TrackSections);
 
             // 5. Merge OrbitSegments
-            if (absorbed.OrbitSegments != null && absorbed.OrbitSegments.Count > 0)
+            if (absorbed.HasOrbitSegments)
                 target.OrbitSegments.AddRange(absorbed.OrbitSegments);
 
             // 6. Union FlagEvents
@@ -377,7 +377,7 @@ namespace Parsek
             original.TrackSections.RemoveRange(sectionIndex, original.TrackSections.Count - sectionIndex);
 
             // 7. Partition OrbitSegments by UT
-            if (original.OrbitSegments != null && original.OrbitSegments.Count > 0)
+            if (original.HasOrbitSegments)
             {
                 second.OrbitSegments = new List<OrbitSegment>();
                 for (int i = original.OrbitSegments.Count - 1; i >= 0; i--)

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -102,11 +102,9 @@ KSP's inertial reference frame may drift over very long time warp. Could cause g
 
 ## TODO — Code Quality
 
-### T45. Add `HasOrbitSegments` to `IPlaybackTrajectory` interface
+### ~~T45. Add `HasOrbitSegments` to `IPlaybackTrajectory` interface~~ DONE
 
-`Recording.HasOrbitSegments` property was added in PR #125, but `IPlaybackTrajectory` still requires the inline `rec.OrbitSegments != null && rec.OrbitSegments.Count > 0` pattern. ~9 callsites across the codebase use this pattern. Adding it to the interface would unify all of them, but touches the standalone ghost mod boundary — defer until the interface next changes.
-
-**Priority:** Low — cosmetic DRY cleanup
+Added `bool HasOrbitSegments { get; }` to `IPlaybackTrajectory`. Replaced 13 inline `OrbitSegments != null && .Count > 0` checks across `GhostPlaybackEngine`, `ParsekPlaybackPolicy`, `GhostMapPresence`, `ParsekFlight`, and `RecordingOptimizer`. Also implemented on `MockTrajectory` in tests.
 
 ### ~~T17. Game actions recording redesign (Phase 8)~~ DONE
 


### PR DESCRIPTION
## Summary

- Add `bool HasOrbitSegments { get; }` to `IPlaybackTrajectory` interface
- Replace 13 inline `OrbitSegments != null && .Count > 0` checks across 6 files (`GhostPlaybackEngine`, `ParsekPlaybackPolicy`, `GhostMapPresence`, `ParsekFlight`, `RecordingOptimizer`) with the property
- Implement on `MockTrajectory` in tests

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 4766 passed
- [x] Verify no remaining inline orbit-segment null checks: `grep -r "OrbitSegments != null" Source/Parsek/` returns only `Recording.cs` definition

🤖 Generated with [Claude Code](https://claude.com/claude-code)