### PR TITLE
Fix timeline review issues: cache invalidation, allocations, overflow

### DIFF
--- a/Source/Parsek/GameActions/LedgerOrchestrator.cs
+++ b/Source/Parsek/GameActions/LedgerOrchestrator.cs
@@ -41,6 +41,13 @@ namespace Parsek
         private static int kscSequenceCounter;
 
         /// <summary>
+        /// Fired after RecalculateAndPatch completes — signals that timeline data
+        /// (recordings, ledger actions) may have changed. Subscribed by ParsekUI
+        /// to invalidate the TimelineWindowUI cache.
+        /// </summary>
+        internal static Action OnTimelineDataChanged;
+
+        /// <summary>
         /// Initialize modules and register with engine. Call once on game start.
         /// Idempotent — safe to call multiple times.
         /// </summary>
@@ -443,6 +450,8 @@ namespace Parsek
 
             ParsekLog.Info(Tag,
                 $"RecalculateAndPatch complete: {actions.Count} actions walked");
+
+            OnTimelineDataChanged?.Invoke();
         }
 
         /// <summary>
@@ -718,6 +727,7 @@ namespace Parsek
             kerbalsModule = null;
             RecalculationEngine.ClearModules();
             Ledger.ResetForTesting();
+            OnTimelineDataChanged = null;
             ParsekLog.Verbose(Tag, "ResetForTesting: all state cleared");
         }
 

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -81,6 +81,7 @@ namespace Parsek
             this.timelineUI = new TimelineWindowUI(this);
             this.testRunnerUI = new TestRunnerUI(this);
             this.settingsUI = new SettingsWindowUI(this);
+            LedgerOrchestrator.OnTimelineDataChanged += OnTimelineDataChanged;
         }
 
         public ParsekUI(UIMode mode)
@@ -92,6 +93,12 @@ namespace Parsek
             this.timelineUI = new TimelineWindowUI(this);
             this.testRunnerUI = new TestRunnerUI(this);
             this.settingsUI = new SettingsWindowUI(this);
+            LedgerOrchestrator.OnTimelineDataChanged += OnTimelineDataChanged;
+        }
+
+        private void OnTimelineDataChanged()
+        {
+            timelineUI.InvalidateCache();
         }
 
         private const float SpacingSmall = 3f;
@@ -699,6 +706,7 @@ namespace Parsek
 
         public void Cleanup()
         {
+            LedgerOrchestrator.OnTimelineDataChanged -= OnTimelineDataChanged;
             recordingsTableUI.ReleaseInputLock();
             timelineUI.ReleaseInputLock();
             settingsUI.ReleaseInputLock();

--- a/Source/Parsek/Timeline/TimelineBuilder.cs
+++ b/Source/Parsek/Timeline/TimelineBuilder.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
 
 namespace Parsek
@@ -23,37 +22,38 @@ namespace Parsek
             IReadOnlyList<Milestone> milestones,
             uint currentEpoch)
         {
+            // Build recording-id to vessel-name lookup once, shared by both collectors
+            var vesselNameById = new Dictionary<string, string>();
+            for (int i = 0; i < committedRecordings.Count; i++)
+            {
+                var r = committedRecordings[i];
+                if (!string.IsNullOrEmpty(r.RecordingId))
+                    vesselNameById[r.RecordingId] = r.VesselName;
+            }
+
             var entries = new List<TimelineEntry>();
 
-            int recordingCount = CollectRecordingEntries(committedRecordings, entries);
-            int actionCount = CollectGameActionEntries(committedRecordings, ledgerActions, entries);
+            int recordingCount = CollectRecordingEntries(committedRecordings, vesselNameById, entries);
+            int actionCount = CollectGameActionEntries(ledgerActions, vesselNameById, entries);
             int legacyCount = CollectLegacyEntries(milestones, currentEpoch, entries);
 
-            var sorted = entries.OrderBy(e => e.UT).ToList();
+            entries.Sort((a, b) => a.UT.CompareTo(b.UT));
 
             ParsekLog.Verbose("Timeline",
-                $"Build complete: {sorted.Count} entries ({recordingCount} recording, {actionCount} action, {legacyCount} legacy)");
+                $"Build complete: {entries.Count} entries ({recordingCount} recording, {actionCount} action, {legacyCount} legacy)");
 
-            return sorted;
+            return entries;
         }
 
         // ---- Recording Collector ----
 
         private static int CollectRecordingEntries(
             IReadOnlyList<Recording> recordings,
+            Dictionary<string, string> vesselNameById,
             List<TimelineEntry> entries)
         {
             int count = 0;
             int hiddenSkipped = 0;
-
-            // Build recording-id to vessel-name lookup for parent resolution (EVA)
-            var vesselNameById = new Dictionary<string, string>();
-            for (int i = 0; i < recordings.Count; i++)
-            {
-                var r = recordings[i];
-                if (!string.IsNullOrEmpty(r.RecordingId))
-                    vesselNameById[r.RecordingId] = r.VesselName;
-            }
 
             for (int i = 0; i < recordings.Count; i++)
             {
@@ -155,19 +155,10 @@ namespace Parsek
         // ---- Game Action Collector ----
 
         private static int CollectGameActionEntries(
-            IReadOnlyList<Recording> committedRecordings,
             IReadOnlyList<GameAction> ledgerActions,
+            Dictionary<string, string> vesselNameById,
             List<TimelineEntry> entries)
         {
-            // Build recording-id to vessel-name lookup
-            var vesselNamesByRecordingId = new Dictionary<string, string>();
-            for (int i = 0; i < committedRecordings.Count; i++)
-            {
-                var rec = committedRecordings[i];
-                if (!string.IsNullOrEmpty(rec.RecordingId))
-                    vesselNamesByRecordingId[rec.RecordingId] = rec.VesselName;
-            }
-
             int count = 0;
             for (int i = 0; i < ledgerActions.Count; i++)
             {
@@ -182,7 +173,7 @@ namespace Parsek
                 // Resolve vessel name from recording ID
                 string vesselName = null;
                 if (!string.IsNullOrEmpty(action.RecordingId))
-                    vesselNamesByRecordingId.TryGetValue(action.RecordingId, out vesselName);
+                    vesselNameById.TryGetValue(action.RecordingId, out vesselName);
 
                 // Skip EVA self-assignment: kerbal assigned to their own EVA vessel
                 if (action.Type == GameActionType.KerbalAssignment &&

--- a/Source/Parsek/Timeline/TimelineEntryDisplay.cs
+++ b/Source/Parsek/Timeline/TimelineEntryDisplay.cs
@@ -107,15 +107,15 @@ namespace Parsek
             if (seconds <= 0) return "";
 
             // KSP uses 6-hour days, 426-day years (Kerbin calendar)
-            int totalSeconds = (int)seconds;
-            int s = totalSeconds % 60;
-            int totalMinutes = totalSeconds / 60;
-            int m = totalMinutes % 60;
-            int totalHours = totalMinutes / 60;
-            int h = totalHours % 6;       // KSP day = 6 hours
-            int totalDays = totalHours / 6;
-            int d = totalDays % 426;       // KSP year = 426 days
-            int y = totalDays / 426;
+            long totalSeconds = (long)seconds;
+            long s = totalSeconds % 60;
+            long totalMinutes = totalSeconds / 60;
+            long m = totalMinutes % 60;
+            long totalHours = totalMinutes / 60;
+            long h = totalHours % 6;       // KSP day = 6 hours
+            long totalDays = totalHours / 6;
+            long d = totalDays % 426;       // KSP year = 426 days
+            long y = totalDays / 426;
 
             var parts = new System.Collections.Generic.List<string>(5);
             if (y > 0) parts.Add($"{y}y");

--- a/Source/Parsek/UI/TimelineWindowUI.cs
+++ b/Source/Parsek/UI/TimelineWindowUI.cs
@@ -23,6 +23,7 @@ namespace Parsek
         private bool timelineWindowHasInputLock;
         private const string TimelineInputLockId = "Parsek_TimelineWindow";
         private Rect lastTimelineWindowRect;
+        private static readonly List<string> EmptyStringList = new List<string>();
         private const float MinWindowWidth = 350f;
         private const float MinWindowHeight = 150f;
         private const float ApproxRowHeight = 20f;
@@ -521,7 +522,7 @@ namespace Parsek
 
         private void DrawRetiredKerbalsSection()
         {
-            var retiredKerbals = cachedRetiredKerbals ?? new List<string>();
+            var retiredKerbals = cachedRetiredKerbals ?? (IReadOnlyList<string>)EmptyStringList;
             if (retiredKerbals.Count > 0)
             {
                 if (retiredKerbals.Count != lastRetiredKerbalCount)

--- a/Source/Parsek/UI/TimelineWindowUI.cs
+++ b/Source/Parsek/UI/TimelineWindowUI.cs
@@ -53,6 +53,16 @@ namespace Parsek
 
         private int lastRetiredKerbalCount = -1;
 
+        // Cached retired kerbals list — refreshed on cache rebuild
+        private IReadOnlyList<string> cachedRetiredKerbals;
+
+        // Cached stats text — refreshed on cache rebuild or filter change
+        private string cachedStatsText;
+        private bool filterDirty = true;
+
+        // Cached recording lookup by ID — refreshed on cache rebuild
+        private Dictionary<string, Recording> recordingById;
+
         public bool IsOpen
         {
             get { return showTimelineWindow; }
@@ -137,6 +147,10 @@ namespace Parsek
         public void InvalidateCache()
         {
             timelineDirty = true;
+            filterDirty = true;
+            cachedRetiredKerbals = null;
+            cachedStatsText = null;
+            recordingById = null;
             ParsekLog.Verbose("Timeline", "Cache invalidated");
         }
 
@@ -194,7 +208,26 @@ namespace Parsek
                     MilestoneStore.Milestones,
                     MilestoneStore.CurrentEpoch);
                 timelineDirty = false;
-                ParsekLog.Verbose("Timeline", $"Cache rebuilt: {cachedTimeline.Count} entries");
+                filterDirty = true;
+
+                // Rebuild recording lookup cache
+                var recordings = RecordingStore.CommittedRecordings;
+                recordingById = new Dictionary<string, Recording>(recordings.Count);
+                for (int i = 0; i < recordings.Count; i++)
+                {
+                    var r = recordings[i];
+                    if (!string.IsNullOrEmpty(r.RecordingId))
+                        recordingById[r.RecordingId] = r;
+                }
+
+                // Refresh retired kerbals cache
+                cachedRetiredKerbals = LedgerOrchestrator.Kerbals?.GetRetiredKerbals()
+                    ?? new List<string>();
+
+                ParsekLog.Verbose("Timeline",
+                    $"Cache rebuilt: {cachedTimeline.Count} entries, " +
+                    $"{recordingById.Count} recordings indexed, " +
+                    $"{cachedRetiredKerbals.Count} retired kerbals");
             }
 
             // Zone 3: Entry List
@@ -206,27 +239,31 @@ namespace Parsek
             GUILayout.FlexibleSpace();
 
             // Stats footer — count only visible (filtered) entries
-            int recCount = 0;
-            int playerActionCount = 0;
-            int eventCount = 0;
-            if (cachedTimeline != null)
+            if (filterDirty || cachedStatsText == null)
             {
-                for (int i = 0; i < cachedTimeline.Count; i++)
+                int recCount = 0;
+                int playerActionCount = 0;
+                int eventCount = 0;
+                if (cachedTimeline != null)
                 {
-                    var e = cachedTimeline[i];
-                    if (!IsEntryVisible(e)) continue;
-                    if (e.Type == TimelineEntryType.RecordingStart) recCount++;
-                    else if (e.Source == TimelineSource.Recording) continue;
-                    else if (e.IsPlayerAction) playerActionCount++;
-                    else eventCount++;
+                    for (int i = 0; i < cachedTimeline.Count; i++)
+                    {
+                        var e = cachedTimeline[i];
+                        if (!IsEntryVisible(e)) continue;
+                        if (e.Source == TimelineSource.Recording) recCount++;
+                        else if (e.IsPlayerAction) playerActionCount++;
+                        else eventCount++;
+                    }
                 }
-            }
 
-            var stats = new System.Text.StringBuilder();
-            stats.Append($"{recCount} Recording{(recCount == 1 ? "" : "s")}");
-            stats.Append($", {playerActionCount} Action{(playerActionCount == 1 ? "" : "s")}");
-            stats.Append($", {eventCount} Event{(eventCount == 1 ? "" : "s")}");
-            GUILayout.Label(stats.ToString(), timelineGrayStyle);
+                var stats = new System.Text.StringBuilder();
+                stats.Append($"{recCount} Recording{(recCount == 1 ? "" : "s")}");
+                stats.Append($", {playerActionCount} Action{(playerActionCount == 1 ? "" : "s")}");
+                stats.Append($", {eventCount} Event{(eventCount == 1 ? "" : "s")}");
+                cachedStatsText = stats.ToString();
+                filterDirty = false;
+            }
+            GUILayout.Label(cachedStatsText, timelineGrayStyle);
 
             if (GUILayout.Button("Close"))
             {
@@ -252,11 +289,13 @@ namespace Parsek
             if (GUILayout.Toggle(overviewActive, "Overview", toggleButtonStyle, GUILayout.Width(80)) && !overviewActive)
             {
                 showDetail = false;
+                filterDirty = true;
                 ParsekLog.Verbose("UI", "Timeline filter: Overview");
             }
             if (GUILayout.Toggle(detailActive, "Detail", toggleButtonStyle, GUILayout.Width(70)) && !detailActive)
             {
                 showDetail = true;
+                filterDirty = true;
                 ParsekLog.Verbose("UI", "Timeline filter: Detail");
             }
 
@@ -267,6 +306,7 @@ namespace Parsek
             if (newShowRec != showRecordingEntries)
             {
                 showRecordingEntries = newShowRec;
+                filterDirty = true;
                 ParsekLog.Verbose("UI", $"Timeline source toggle: Recordings={showRecordingEntries}");
             }
 
@@ -274,6 +314,7 @@ namespace Parsek
             if (newShowAct != showActionEntries)
             {
                 showActionEntries = newShowAct;
+                filterDirty = true;
                 ParsekLog.Verbose("UI", $"Timeline source toggle: Actions={showActionEntries}");
             }
 
@@ -281,6 +322,7 @@ namespace Parsek
             if (newShowEvt != showEventEntries)
             {
                 showEventEntries = newShowEvt;
+                filterDirty = true;
                 ParsekLog.Verbose("UI", $"Timeline source toggle: Events={showEventEntries}");
             }
 
@@ -468,20 +510,18 @@ namespace Parsek
             return timelineWhiteStyle;
         }
 
-        private static Recording FindRecordingById(string recordingId)
+        private Recording FindRecordingById(string recordingId)
         {
-            var recordings = RecordingStore.CommittedRecordings;
-            for (int i = 0; i < recordings.Count; i++)
-            {
-                if (recordings[i].RecordingId == recordingId)
-                    return recordings[i];
-            }
-            return null;
+            if (recordingById == null || string.IsNullOrEmpty(recordingId))
+                return null;
+            Recording rec;
+            recordingById.TryGetValue(recordingId, out rec);
+            return rec;
         }
 
         private void DrawRetiredKerbalsSection()
         {
-            var retiredKerbals = LedgerOrchestrator.Kerbals?.GetRetiredKerbals() ?? new List<string>();
+            var retiredKerbals = cachedRetiredKerbals ?? new List<string>();
             if (retiredKerbals.Count > 0)
             {
                 if (retiredKerbals.Count != lastRetiredKerbalCount)


### PR DESCRIPTION
## Summary

Fixes critical and high-priority issues from PR #137 review.

### Critical: Wire InvalidateCache
- `LedgerOrchestrator.OnTimelineDataChanged` callback fires at end of `RecalculateAndPatch()` — the central funnel for all timeline data mutations (commit, rewind, KSC spending, game load, warp exit)
- `ParsekUI` subscribes/unsubscribes, forwards to `TimelineWindowUI.InvalidateCache()`
- Scene changes already handled (new instance starts dirty)

### High: Per-frame allocations
- **Deduplicated vesselNameById dictionary** — built once in `Build()`, passed to both collectors (was built independently in each)
- **In-place sort** — `entries.Sort()` replaces `OrderBy().ToList()` (zero extra allocations)
- **Cached retired kerbals** — fetched on cache rebuild, not every frame
- **Cached stats text** — rebuilt only when filters change (`filterDirty` flag)
- **Cached recording lookup** — `Dictionary<string, Recording>` for O(1) `FindRecordingById` (was O(N) per row)

### Medium
- **FormatDuration overflow** — `int` → `long` for durations > 68 years
- **VesselSpawn footer count** — counts all Recording-source entries (was skipping VesselSpawn via early `continue`)

## Test plan
- [x] 4875 tests pass (no new tests — fixes are wiring/allocation changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)