### PR TITLE
Fix deferred spawn split-brain and wire up spawn-death detection (#132)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- **Fix deferred spawn queue split-brain (#132).** `HandlePlaybackCompleted` in `ParsekPlaybackPolicy` added deferred spawn IDs to the policy's `pendingSpawnRecordingIds`, but `FlushDeferredSpawns` in `ParsekFlight` read from its own never-populated duplicate set. Deferred spawns during warp silently never flushed. Moved `FlushDeferredSpawns` to the policy, eliminated the duplicate fields.
+- **Wire up spawn-death detection (#132).** `RunSpawnDeathChecks` now runs before each engine update, detecting spawned vessels that died since last frame. Increments `SpawnDeathCount`, resets for re-spawn, or abandons after 3 cycles. Previously `SpawnDeathCount` was never incremented in the engine path.
 - **Fix mid-tree spawn entries at EVA/staging boundaries (#227).** When a kerbal EVA'd or a stage separated, the timeline showed a premature "Spawn: Kerbal X" at the branch time. Two-sided fix: (1) suppress parent spawn when a same-PID continuation child exists via new `HasSamePidTreeContinuation` helper, (2) allow tree-child leaf recordings to produce spawn entries. Breakup-only recordings (no same-PID continuation) correctly still spawn.
 - **Fix toolbar icon texture compression warning (#154).** Replaced 38x38 and 24x24 toolbar icons with 64x64 and 32x32 power-of-two versions. KSP can now DXT-compress the textures.
 - **Fix ghost creation failing for orbital debris ("no orbit data") (#219).** `CaptureTerminalOrbit` only ran when `FindVesselByPid` returned a live vessel. Orbital debris with 30s TTL was often destroyed by finalization time, leaving terminal orbit fields empty. `PopulateTerminalOrbitFromLastSegment` now recovers orbit data from the last `OrbitSegment`.

--- a/Source/Parsek.Tests/DeferredSpawnTests.cs
+++ b/Source/Parsek.Tests/DeferredSpawnTests.cs
@@ -101,5 +101,39 @@ namespace Parsek.Tests
         }
 
         #endregion
+
+        #region ShouldCheckForSpawnDeath
+
+        [Fact]
+        public void ShouldCheckForSpawnDeath_SpawnedWithPid_ReturnsTrue()
+        {
+            Assert.True(GhostPlaybackLogic.ShouldCheckForSpawnDeath(true, 42000, false));
+        }
+
+        [Fact]
+        public void ShouldCheckForSpawnDeath_NotSpawned_ReturnsFalse()
+        {
+            Assert.False(GhostPlaybackLogic.ShouldCheckForSpawnDeath(false, 42000, false));
+        }
+
+        [Fact]
+        public void ShouldCheckForSpawnDeath_ZeroPid_ReturnsFalse()
+        {
+            Assert.False(GhostPlaybackLogic.ShouldCheckForSpawnDeath(true, 0, false));
+        }
+
+        [Fact]
+        public void ShouldCheckForSpawnDeath_Abandoned_ReturnsFalse()
+        {
+            Assert.False(GhostPlaybackLogic.ShouldCheckForSpawnDeath(true, 42000, true));
+        }
+
+        [Fact]
+        public void ShouldCheckForSpawnDeath_NotSpawnedZeroPidAbandoned_ReturnsFalse()
+        {
+            Assert.False(GhostPlaybackLogic.ShouldCheckForSpawnDeath(false, 0, true));
+        }
+
+        #endregion
     }
 }

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -74,6 +74,16 @@ namespace Parsek
             return pendingWatchId != null && pendingWatchId == recordingId && spawnedPid != 0;
         }
 
+        /// <summary>
+        /// Pure decision: should this recording be checked for spawn-death (vessel spawned
+        /// then immediately destroyed)? Returns true when the recording has a live spawned
+        /// vessel that hasn't already been abandoned.
+        /// </summary>
+        internal static bool ShouldCheckForSpawnDeath(bool vesselSpawned, uint spawnedPid, bool spawnAbandoned)
+        {
+            return vesselSpawned && spawnedPid != 0 && !spawnAbandoned;
+        }
+
         internal static bool ShouldPauseTimelineResourceReplay(bool isRecording)
         {
             return isRecording;

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -6561,7 +6561,7 @@ namespace Parsek
             // Clear ParsekFlight-local diagnostic guards since indices shifted
             loggedOrbitSegments.Clear();
             loggedOrbitRotationSegments.Clear();
-            policy.pendingSpawnRecordingIds.Remove(rec.RecordingId);
+            policy.RemovePendingSpawn(rec.RecordingId);
 
             ParsekLog.ScreenMessage($"Recording '{rec.VesselName}' deleted", 2f);
         }

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -226,9 +226,7 @@ namespace Parsek
         private VesselGhoster vesselGhoster;
         private Dictionary<uint, GhostChain> activeGhostChains;
 
-        // Deferred spawn queue: recording IDs queued during warp, flushed when warp ends
-        private HashSet<string> pendingSpawnRecordingIds = new HashSet<string>();
-        private string pendingWatchRecordingId = null;  // recording ID that was in watch mode when deferred
+        // Deferred spawn queue moved to ParsekPlaybackPolicy (#132)
         private bool timelineResourceReplayPausedLogged = false;
         private bool wasWarpActive = false; // tracks previous warp state for exit detection
         private double warpStartUT = 0.0;  // UT when warp began — used for facility visual updates
@@ -6148,8 +6146,11 @@ namespace Parsek
             // Chain ghost positioning (independent of engine)
             PositionChainGhosts(currentUT);
 
-            // Flush deferred spawns from warp
-            FlushDeferredSpawns(committed);
+            // Pre-engine: detect spawned vessels that died since last frame (#132)
+            policy.RunSpawnDeathChecks();
+
+            // Flush deferred spawns from warp (policy owns the queue)
+            policy.FlushDeferredSpawns();
 
             if (committed.Count == 0) return;
 
@@ -6227,71 +6228,7 @@ namespace Parsek
         // UpdateTimelinePlayback removed (T25 Phase 9 — engine is primary path)
         // ValidateWatchedGhostStillActive moved to WatchModeController
 
-        private void FlushDeferredSpawns(List<Recording> committed)
-        {
-            if (!GhostPlaybackLogic.ShouldFlushDeferredSpawns(pendingSpawnRecordingIds.Count, IsAnyWarpActive()))
-                return;
-
-            int spawnedCount = 0;
-            int deferredOutOfBubble = 0;
-            var flushedIds = new List<string>();
-            Vector3d activeVesselPos = FlightGlobals.ActiveVessel != null
-                ? FlightGlobals.ActiveVessel.GetWorldPos3D()
-                : Vector3d.zero;
-
-            for (int i = 0; i < committed.Count; i++)
-            {
-                var rec = committed[i];
-                if (!pendingSpawnRecordingIds.Contains(rec.RecordingId)) continue;
-                if (GhostPlaybackLogic.ShouldSkipDeferredSpawn(rec.VesselSpawned, rec.VesselSnapshot != null))
-                {
-                    ParsekLog.Verbose("Flight", $"Deferred spawn skipped — #{i} \"{rec.VesselName}\" already spawned or no snapshot");
-                    flushedIds.Add(rec.RecordingId);
-                    continue;
-                }
-
-                // Physics-bubble scoping: skip out-of-bubble spawns (keep in queue)
-                if (FlightGlobals.ActiveVessel != null &&
-                    ShouldDeferSpawnOutsideBubble(rec, activeVesselPos))
-                {
-                    deferredOutOfBubble++;
-                    ParsekLog.Verbose("Flight",
-                        $"Deferred spawn kept in queue (outside physics bubble): #{i} \"{rec.VesselName}\"");
-                    continue;
-                }
-
-                ParsekLog.Info("Flight", $"Deferred spawn executing: #{i} \"{rec.VesselName}\" id={rec.RecordingId}");
-                SpawnVesselOrChainTip(rec, i);
-                spawnedCount++;
-                flushedIds.Add(rec.RecordingId);
-
-                // Restore camera follow if this recording was being watched when deferred
-                if (GhostPlaybackLogic.ShouldRestoreWatchMode(pendingWatchRecordingId, rec.RecordingId, rec.SpawnedVesselPersistentId))
-                {
-                    ParsekLog.Info("CameraFollow",
-                        $"Deferred watch: switching to spawned vessel pid={rec.SpawnedVesselPersistentId}");
-                    StartCoroutine(DeferredActivateVessel(rec.SpawnedVesselPersistentId));
-                }
-            }
-
-            // Remove flushed IDs, keep out-of-bubble spawns in queue
-            for (int j = 0; j < flushedIds.Count; j++)
-                pendingSpawnRecordingIds.Remove(flushedIds[j]);
-
-            if (deferredOutOfBubble > 0)
-            {
-                ParsekLog.Info("Flight",
-                    $"Warp ended — flushed {spawnedCount} deferred spawn(s), {deferredOutOfBubble} kept (outside bubble), {pendingSpawnRecordingIds.Count} remaining");
-            }
-            else
-            {
-                ParsekLog.Info("Flight", $"Warp ended — flushed {spawnedCount}/{spawnedCount + flushedIds.Count - spawnedCount} deferred spawn(s)");
-                pendingSpawnRecordingIds.Clear();
-            }
-
-            if (pendingSpawnRecordingIds.Count == 0)
-                pendingWatchRecordingId = null;
-        }
+        // FlushDeferredSpawns moved to ParsekPlaybackPolicy (#132)
 
         // EvaluateGhostSoftCaps removed (T25 Phase 9 — engine is primary path)
 
@@ -6559,10 +6496,6 @@ namespace Parsek
             notifiedSpawnRecordingIds.Clear();
             loggedRelativeStart.Clear();
             loggedAnchorNotFound.Clear();
-
-            // Policy state (still on ParsekFlight until Phase 6 moves it)
-            pendingSpawnRecordingIds.Clear();
-            pendingWatchRecordingId = null;
         }
 
         /// <summary>
@@ -6628,7 +6561,7 @@ namespace Parsek
             // Clear ParsekFlight-local diagnostic guards since indices shifted
             loggedOrbitSegments.Clear();
             loggedOrbitRotationSegments.Clear();
-            pendingSpawnRecordingIds.Remove(rec.RecordingId);
+            policy.pendingSpawnRecordingIds.Remove(rec.RecordingId);
 
             ParsekLog.ScreenMessage($"Recording '{rec.VesselName}' deleted", 2f);
         }

--- a/Source/Parsek/ParsekPlaybackPolicy.cs
+++ b/Source/Parsek/ParsekPlaybackPolicy.cs
@@ -58,19 +58,138 @@ namespace Parsek
         /// <summary>
         /// Pre-check: detect spawned vessels that died since last frame.
         /// Runs BEFORE engine.UpdatePlayback() so flags reflect current state.
+        /// If a spawned vessel's PID is no longer in FlightGlobals.Vessels, the
+        /// recording is either reset for re-spawn or abandoned after MaxSpawnDeathCycles.
         /// </summary>
         internal void RunSpawnDeathChecks()
         {
-            // TODO(#132): Move spawn-death detection from ParsekFlight
+            var committed = RecordingStore.CommittedRecordings;
+            if (committed.Count == 0) return;
+
+            int detected = 0;
+            int abandoned = 0;
+
+            for (int i = 0; i < committed.Count; i++)
+            {
+                var rec = committed[i];
+                if (!GhostPlaybackLogic.ShouldCheckForSpawnDeath(
+                        rec.VesselSpawned, rec.SpawnedVesselPersistentId, rec.SpawnAbandoned))
+                    continue;
+
+                // Vessel still alive — no action needed
+                if (FlightRecorder.FindVesselByPid(rec.SpawnedVesselPersistentId) != null)
+                    continue;
+
+                // Vessel died since last frame
+                rec.SpawnDeathCount++;
+                detected++;
+
+                if (VesselSpawner.ShouldAbandonSpawnDeathLoop(
+                        rec.SpawnDeathCount, VesselSpawner.MaxSpawnDeathCycles))
+                {
+                    rec.SpawnAbandoned = true;
+                    abandoned++;
+                    ParsekLog.Warn("Policy",
+                        $"Spawn-death loop abandoned: #{i} \"{rec.VesselName}\" " +
+                        $"pid={rec.SpawnedVesselPersistentId} deathCount={rec.SpawnDeathCount} " +
+                        $"— exceeded {VesselSpawner.MaxSpawnDeathCycles} max cycles");
+                }
+                else
+                {
+                    uint oldPid = rec.SpawnedVesselPersistentId;
+                    rec.VesselSpawned = false;
+                    rec.SpawnedVesselPersistentId = 0;
+                    rec.SpawnAttempts = 0;
+                    ParsekLog.Info("Policy",
+                        $"Spawn-death detected: #{i} \"{rec.VesselName}\" " +
+                        $"pid={oldPid} deathCount={rec.SpawnDeathCount} — reset for re-spawn");
+                }
+            }
+
+            if (detected > 0)
+                ParsekLog.Info("Policy",
+                    $"RunSpawnDeathChecks: {detected} death(s) detected, {abandoned} abandoned");
         }
 
         /// <summary>
         /// Flush deferred spawns that were queued during warp.
         /// Runs AFTER engine.UpdatePlayback() when warp ends.
+        /// Iterates committed recordings, spawns eligible vessels, skips
+        /// out-of-bubble spawns (kept in queue for next check).
         /// </summary>
-        internal void FlushDeferredSpawns(double currentUT, float warpRate)
+        internal void FlushDeferredSpawns()
         {
-            // TODO(#132): Move FlushDeferredSpawns from ParsekFlight
+            if (!GhostPlaybackLogic.ShouldFlushDeferredSpawns(
+                    pendingSpawnRecordingIds.Count,
+                    GhostPlaybackEngine.IsAnyWarpActiveFromGlobals()))
+                return;
+
+            var committed = RecordingStore.CommittedRecordings;
+            int spawnedCount = 0;
+            int deferredOutOfBubble = 0;
+            var flushedIds = new List<string>();
+            Vector3d activeVesselPos = FlightGlobals.ActiveVessel != null
+                ? FlightGlobals.ActiveVessel.GetWorldPos3D()
+                : Vector3d.zero;
+
+            for (int i = 0; i < committed.Count; i++)
+            {
+                var rec = committed[i];
+                if (!pendingSpawnRecordingIds.Contains(rec.RecordingId)) continue;
+                if (GhostPlaybackLogic.ShouldSkipDeferredSpawn(rec.VesselSpawned, rec.VesselSnapshot != null))
+                {
+                    ParsekLog.Verbose("Policy",
+                        $"Deferred spawn skipped — #{i} \"{rec.VesselName}\" already spawned or no snapshot");
+                    flushedIds.Add(rec.RecordingId);
+                    continue;
+                }
+
+                // Physics-bubble scoping: skip out-of-bubble spawns (keep in queue)
+                if (FlightGlobals.ActiveVessel != null &&
+                    ParsekFlight.ShouldDeferSpawnOutsideBubble(rec, activeVesselPos))
+                {
+                    deferredOutOfBubble++;
+                    ParsekLog.Verbose("Policy",
+                        $"Deferred spawn kept in queue (outside physics bubble): #{i} \"{rec.VesselName}\"");
+                    continue;
+                }
+
+                ParsekLog.Info("Policy",
+                    $"Deferred spawn executing: #{i} \"{rec.VesselName}\" id={rec.RecordingId}");
+                host.SpawnVesselOrChainTipFromPolicy(rec, i);
+                spawnedCount++;
+                flushedIds.Add(rec.RecordingId);
+
+                // Restore camera follow if this recording was being watched when deferred
+                if (GhostPlaybackLogic.ShouldRestoreWatchMode(
+                        pendingWatchRecordingId, rec.RecordingId, rec.SpawnedVesselPersistentId))
+                {
+                    ParsekLog.Info("Policy",
+                        $"Deferred watch: switching to spawned vessel pid={rec.SpawnedVesselPersistentId}");
+                    host.DeferredActivateVesselFromPolicy(rec.SpawnedVesselPersistentId);
+                }
+            }
+
+            // Remove flushed IDs, keep out-of-bubble spawns in queue
+            for (int j = 0; j < flushedIds.Count; j++)
+                pendingSpawnRecordingIds.Remove(flushedIds[j]);
+
+            if (deferredOutOfBubble > 0)
+            {
+                ParsekLog.Info("Policy",
+                    $"Warp ended — flushed {spawnedCount} deferred spawn(s), " +
+                    $"{deferredOutOfBubble} kept (outside bubble), " +
+                    $"{pendingSpawnRecordingIds.Count} remaining");
+            }
+            else
+            {
+                ParsekLog.Info("Policy",
+                    $"Warp ended — flushed {spawnedCount}/{flushedIds.Count} deferred spawn(s)");
+                pendingSpawnRecordingIds.Clear();
+            }
+
+            if (pendingSpawnRecordingIds.Count == 0)
+                pendingWatchRecordingId = null;
         }
 
         private void HandlePlaybackCompleted(PlaybackCompletedEvent evt)

--- a/Source/Parsek/ParsekPlaybackPolicy.cs
+++ b/Source/Parsek/ParsekPlaybackPolicy.cs
@@ -112,6 +112,14 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Removes a recording ID from the deferred spawn queue (e.g. on delete).
+        /// </summary>
+        internal void RemovePendingSpawn(string recordingId)
+        {
+            pendingSpawnRecordingIds.Remove(recordingId);
+        }
+
+        /// <summary>
         /// Flush deferred spawns that were queued during warp.
         /// Runs AFTER engine.UpdatePlayback() when warp ends.
         /// Iterates committed recordings, spawns eligible vessels, skips

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -128,15 +128,11 @@ Engine plates (`EnginePlate1` etc.) have protective covers (interstage fairings)
 
 ## 132. Policy RunSpawnDeathChecks and FlushDeferredSpawns are TODO stubs
 
-`ParsekPlaybackPolicy.RunSpawnDeathChecks()` and `FlushDeferredSpawns()` are placeholder stubs. The old path equivalents in `ParsekFlight.UpdateTimelinePlaybackViaEngine()` still call the original `FlushDeferredSpawns(committed)` directly, so deferred spawns work. But spawn-death detection (vessel dies immediately after spawning → re-spawn with death count tracking) is not wired through the policy yet.
+`RunSpawnDeathChecks()` now iterates committed recordings each frame, checks if spawned vessel PIDs still exist via `FlightRecorder.FindVesselByPid`, increments `SpawnDeathCount` on death, and either resets for re-spawn or abandons after `MaxSpawnDeathCycles`. New pure predicate `ShouldCheckForSpawnDeath` in `GhostPlaybackLogic`.
 
-The pure predicates (`ShouldAbandonSpawnDeathLoop`, `ShouldFlushDeferredSpawns`, `ShouldSkipDeferredSpawn`) are tested; only the integration through the policy event handlers is missing.
+`FlushDeferredSpawns()` moved from `ParsekFlight` to `ParsekPlaybackPolicy`, eliminating the split-brain bug where the policy populated its own `pendingSpawnRecordingIds` in `HandlePlaybackCompleted` but the flush read from ParsekFlight's never-populated duplicate set. The policy now owns the full lifecycle: queue during warp → flush when warp ends.
 
-**Investigation notes:** `FlushDeferredSpawns` works correctly in ParsekFlight — moving to policy is pure refactoring with heavy state dependency (`pendingSpawnRecordingIds`, `pendingWatchRecordingId`, `SpawnVesselOrChainTip`, `DeferredActivateVessel`). Low value, high risk. Spawn-death detection is genuinely absent: `SpawnDeathCount` is never read in the engine path, and no `onVesselTerminated` subscription exists to detect spawned vessel destruction. Implementing requires event subscription + PID-to-recording matching. **Dormant bug:** policy and ParsekFlight have duplicate `pendingSpawnRecordingIds`/`pendingWatchRecordingId` fields — policy populates its copies in `HandlePlaybackCompleted` but the flush reads ParsekFlight's copies. Currently works because both paths add to the same set independently, but could diverge.
-
-**Priority:** Low — edge case (rapid spawn-death cycles), FlushDeferredSpawns works via existing path
-
-**Status:** Open — deferred (spawn-death detection needs design, FlushDeferredSpawns move is low-value refactor)
+**Status:** Fixed
 
 ## 133. Forwarding properties in ParsekFlight add ~500 lines of indirection
 


### PR DESCRIPTION
## Summary

- **Fix deferred spawn queue split-brain:** `HandlePlaybackCompleted` in `ParsekPlaybackPolicy` added deferred spawn IDs to the policy's `pendingSpawnRecordingIds`, but `FlushDeferredSpawns` in `ParsekFlight` read from its own never-populated duplicate set. Deferred spawns during warp silently never flushed. Moved `FlushDeferredSpawns` to the policy, eliminated the duplicate fields.
- **Wire up spawn-death detection:** `RunSpawnDeathChecks` now runs before each engine update, detecting spawned vessels whose PIDs are no longer in `FlightGlobals.Vessels`. Increments `SpawnDeathCount`, resets for re-spawn, or abandons after `MaxSpawnDeathCycles` (3). Previously `SpawnDeathCount` was never incremented in the engine path.
- New pure predicate `ShouldCheckForSpawnDeath` in `GhostPlaybackLogic` with 5 unit tests.

## Test plan

- [x] 4989 unit tests pass
- [ ] In-game: record a flight, time warp past ghost end, verify vessel spawns after warp ends
- [ ] In-game: verify spawn-death loop detection with a vessel that crashes immediately after spawn (e.g. spawn on steep terrain)