### PR TITLE
Fix R button missing on tree branch recordings (#159, #166)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to Parsek are documented here.
 - **Fix ghost map markers missing / wrong positions after save/load (#203).** `SaveRecordingMetadata` / `LoadRecordingMetadata` (standalone recordings) never serialized the 8 terminal orbit fields. After save/load, all standalone recordings had `TerminalOrbitBody = null`, so `HasOrbitData` returned false and no ghost map ProtoVessels could be created. Tree recordings were unaffected (separate serialization path). Now serialized in both paths.
 - **Fix tree root recording showing T+ countdown instead of terminal state (#186).** Continuation sampling extends a committed recording's `EndUT` past current time, causing the status column to show "T+5m 23s" instead of "Landed". Now checks `TerminalStateValue` in all three status paths (row display, group aggregate, sort key). Group status also shows the best non-debris terminal state instead of generic "past".
 - **Fix green sphere fallback for debris ghosts with no snapshot (#232).** Debris from mid-air booster collisions had no vessel snapshot, causing distracting green spheres during watch mode playback. Now skips ghost creation entirely for snapshotless debris. Non-debris keeps sphere fallback as safety net.
+- **Fix R (rewind) button missing on tree branch recordings (#159, #166).** Tree branch recordings (EVA kerbals, decoupled stages) had no `RewindSaveFileName` because rewind saves are only captured at launch. Added tree-aware lookup: `GetRewindRecording` resolves through the tree root so branches can rewind to the original launch point. `InitiateRewind` and `ShowRewindConfirmation` now use the owner recording's fields for correct vessel stripping, UT display, and future-recording count.
 
 ### Spawn System Hardening
 
@@ -43,7 +44,7 @@ All notable changes to Parsek are documented here.
 
 ### Tests
 
-- 106 new test cases. 5041 total passing.
+- 118 new test cases. 5053 total passing.
 
 ### Location Context (Phase 10)
 

--- a/Source/Parsek.Tests/RewindTreeLookupTests.cs
+++ b/Source/Parsek.Tests/RewindTreeLookupTests.cs
@@ -1,0 +1,270 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Tests for tree-aware rewind save lookup: GetRewindRecording, GetRewindSaveFileName,
+    /// and CanRewind resolving through tree roots for branch recordings.
+    /// </summary>
+    [Collection("Sequential")]
+    public class RewindTreeLookupTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public RewindTreeLookupTests()
+        {
+            RecordingStore.SuppressLogging = false;
+            RecordingStore.ResetForTesting();
+            MilestoneStore.ResetForTesting();
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+            RecordingStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+            MilestoneStore.ResetForTesting();
+        }
+
+        private static RecordingTree BuildTree(string treeId, string rootId,
+            string rootRewindSave, params (string id, string name)[] branches)
+        {
+            var tree = new RecordingTree
+            {
+                Id = treeId,
+                TreeName = "TestTree",
+                RootRecordingId = rootId
+            };
+
+            var rootRec = new Recording
+            {
+                RecordingId = rootId,
+                TreeId = treeId,
+                VesselName = "RootVessel",
+                RewindSaveFileName = rootRewindSave,
+                RewindReservedFunds = 100,
+                RewindReservedScience = 10,
+                RewindReservedRep = 5
+            };
+            tree.Recordings[rootId] = rootRec;
+
+            foreach (var (id, name) in branches)
+            {
+                tree.Recordings[id] = new Recording
+                {
+                    RecordingId = id,
+                    TreeId = treeId,
+                    VesselName = name
+                    // No RewindSaveFileName — branches don't own one
+                };
+            }
+
+            return tree;
+        }
+
+        #region GetRewindSaveFileName
+
+        [Fact]
+        public void GetRewindSaveFileName_DirectSave_ReturnsSave()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "standalone",
+                RewindSaveFileName = "parsek_rw_abc123"
+            };
+            var trees = new List<RecordingTree>();
+
+            string result = RecordingStore.GetRewindSaveFileName(rec);
+
+            Assert.Equal("parsek_rw_abc123", result);
+        }
+
+        [Fact]
+        public void GetRewindSaveFileName_NoSaveNoTree_ReturnsNull()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "orphan",
+                VesselName = "NoSave"
+            };
+
+            string result = RecordingStore.GetRewindSaveFileName(rec);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetRewindSaveFileName_TreeBranch_ReturnsRootSave()
+        {
+            var tree = BuildTree("tree1", "root1", "parsek_rw_root",
+                ("branch1", "EVAKerbal"));
+            RecordingStore.AddCommittedTreeForTesting(tree);
+
+            var branch = tree.Recordings["branch1"];
+
+            string result = RecordingStore.GetRewindSaveFileName(branch);
+
+            Assert.Equal("parsek_rw_root", result);
+        }
+
+        [Fact]
+        public void GetRewindSaveFileName_TreeBranchRootHasNoSave_ReturnsNull()
+        {
+            var tree = BuildTree("tree2", "root2", null,
+                ("branch2", "EVAKerbal"));
+            RecordingStore.AddCommittedTreeForTesting(tree);
+
+            var branch = tree.Recordings["branch2"];
+
+            string result = RecordingStore.GetRewindSaveFileName(branch);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetRewindSaveFileName_TreeNotFound_ReturnsNull()
+        {
+            // Recording has TreeId but no matching tree in committed list
+            var rec = new Recording
+            {
+                RecordingId = "orphanBranch",
+                TreeId = "nonExistentTree"
+            };
+
+            string result = RecordingStore.GetRewindSaveFileName(rec);
+
+            Assert.Null(result);
+        }
+
+        #endregion
+
+        #region GetRewindRecording
+
+        [Fact]
+        public void GetRewindRecording_TreeBranch_ReturnsRootRecording()
+        {
+            var tree = BuildTree("tree3", "root3", "parsek_rw_r3",
+                ("branch3", "DecoupledStage"));
+            RecordingStore.AddCommittedTreeForTesting(tree);
+
+            var branch = tree.Recordings["branch3"];
+            var rootRec = tree.Recordings["root3"];
+
+            Recording result = RecordingStore.GetRewindRecording(branch);
+
+            Assert.Same(rootRec, result);
+        }
+
+        [Fact]
+        public void GetRewindRecording_MultipleTrees_FindsCorrectTree()
+        {
+            var tree1 = BuildTree("treeA", "rootA", "parsek_rw_A",
+                ("branchA", "VesselA"));
+            var tree2 = BuildTree("treeB", "rootB", "parsek_rw_B",
+                ("branchB", "VesselB"));
+            RecordingStore.AddCommittedTreeForTesting(tree1);
+            RecordingStore.AddCommittedTreeForTesting(tree2);
+
+            var branchB = tree2.Recordings["branchB"];
+
+            Recording result = RecordingStore.GetRewindRecording(branchB);
+
+            Assert.Same(tree2.Recordings["rootB"], result);
+            Assert.Equal("parsek_rw_B", result.RewindSaveFileName);
+        }
+
+        [Fact]
+        public void GetRewindRecording_DirectSave_ReturnsSelf()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "self",
+                RewindSaveFileName = "parsek_rw_self"
+            };
+
+            Recording result = RecordingStore.GetRewindRecording(rec);
+
+            Assert.Same(rec, result);
+        }
+
+        [Fact]
+        public void GetRewindRecording_NullRecording_ReturnsNull()
+        {
+            Recording result = RecordingStore.GetRewindRecording(null);
+
+            Assert.Null(result);
+        }
+
+        #endregion
+
+        #region CanRewind tree integration
+
+        [Fact]
+        public void CanRewind_TreeBranch_ResolvesViaRoot()
+        {
+            // CanRewind checks file existence via KSP API (not available in unit tests).
+            // Verify that the tree-aware lookup resolves the save filename, then confirm
+            // CanRewind would get past the "No rewind save available" guard by checking
+            // GetRewindSaveFileName directly — the file existence check is covered by
+            // existing integration tests.
+            var tree = BuildTree("tree4", "root4", "parsek_rw_r4",
+                ("branch4", "BranchVessel"));
+            RecordingStore.AddCommittedTreeForTesting(tree);
+
+            var branch = tree.Recordings["branch4"];
+
+            // Branch has no direct save, but GetRewindSaveFileName resolves through root
+            string resolvedSave = RecordingStore.GetRewindSaveFileName(branch);
+            Assert.Equal("parsek_rw_r4", resolvedSave);
+
+            // Without tree lookup, branch would have no save
+            Assert.Null(branch.RewindSaveFileName);
+        }
+
+        [Fact]
+        public void CanRewind_NoBranchNoSave_ReturnsNoSaveAvailable()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "nosave",
+                VesselName = "NoSaveVessel"
+            };
+
+            string reason;
+            bool result = RecordingStore.CanRewind(rec, out reason, isRecording: false);
+
+            Assert.False(result);
+            Assert.Equal("No rewind save available", reason);
+        }
+
+        #endregion
+
+        #region Logging
+
+        [Fact]
+        public void GetRewindRecording_TreeBranch_NoExtraLogging()
+        {
+            // The lookup helpers are called per-frame by the UI, so they must not
+            // produce log output on every call.
+            var tree = BuildTree("tree5", "root5", "parsek_rw_r5",
+                ("branch5", "LogTestBranch"));
+            var trees = new List<RecordingTree> { tree };
+
+            var branch = tree.Recordings["branch5"];
+            logLines.Clear();
+
+            RecordingStore.GetRewindRecording(branch, trees);
+
+            // Lookup helpers should not log (per-frame hot path)
+            Assert.Empty(logLines);
+        }
+
+        #endregion
+    }
+}

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -1395,6 +1395,14 @@ namespace Parsek
             committedRecordings.Add(rec);
         }
 
+        /// <summary>
+        /// Adds a tree directly to committed trees. For unit tests only.
+        /// </summary>
+        internal static void AddCommittedTreeForTesting(RecordingTree tree)
+        {
+            committedTrees.Add(tree);
+        }
+
         internal static void DeleteRecordingFiles(Recording rec)
         {
             if (rec == null)
@@ -1766,6 +1774,60 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Returns the recording that owns the rewind save for the given recording.
+        /// For standalone recordings this is the recording itself; for tree branches
+        /// it is the tree root (which captured the quicksave at launch).
+        /// Returns null if no rewind save is available.
+        /// </summary>
+        internal static Recording GetRewindRecording(Recording rec)
+        {
+            return GetRewindRecording(rec, committedTrees);
+        }
+
+        /// <summary>
+        /// Parameterized overload for testability.
+        /// </summary>
+        internal static Recording GetRewindRecording(Recording rec, List<RecordingTree> trees)
+        {
+            if (rec == null) return null;
+
+            // Direct owner: recording has its own rewind save
+            if (!string.IsNullOrEmpty(rec.RewindSaveFileName))
+                return rec;
+
+            // Tree branch: look up root recording's rewind save
+            if (!string.IsNullOrEmpty(rec.TreeId) && trees != null)
+            {
+                for (int i = 0; i < trees.Count; i++)
+                {
+                    if (trees[i].Id == rec.TreeId)
+                    {
+                        Recording rootRec;
+                        if (!string.IsNullOrEmpty(trees[i].RootRecordingId) &&
+                            trees[i].Recordings.TryGetValue(trees[i].RootRecordingId, out rootRec) &&
+                            !string.IsNullOrEmpty(rootRec.RewindSaveFileName))
+                        {
+                            return rootRec;
+                        }
+                        break; // Found tree but root has no save
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Convenience wrapper: returns the rewind save filename for a recording,
+        /// resolving through the tree root if needed. Returns null if unavailable.
+        /// </summary>
+        internal static string GetRewindSaveFileName(Recording rec)
+        {
+            var owner = GetRewindRecording(rec);
+            return owner?.RewindSaveFileName;
+        }
+
+        /// <summary>
         /// Checks whether the player can rewind to a given recording's launch point.
         /// </summary>
         internal static bool CanRewind(Recording rec, out string reason, bool isRecording)
@@ -1777,7 +1839,9 @@ namespace Parsek
                 return false;
             }
 
-            if (string.IsNullOrEmpty(rec.RewindSaveFileName))
+            // Resolve rewind save through tree root if needed
+            string resolvedSave = GetRewindSaveFileName(rec);
+            if (string.IsNullOrEmpty(resolvedSave))
             {
                 reason = "No rewind save available";
                 // Per-frame logging removed (was 3.7% of all log output); reason returned to caller
@@ -1807,7 +1871,7 @@ namespace Parsek
 
             // Verify the save file exists
             string savePath = RecordingPaths.ResolveSaveScopedPath(
-                RecordingPaths.BuildRewindSaveRelativePath(rec.RewindSaveFileName));
+                RecordingPaths.BuildRewindSaveRelativePath(resolvedSave));
             if (string.IsNullOrEmpty(savePath) || !File.Exists(savePath))
             {
                 reason = "Rewind save file missing";
@@ -1887,22 +1951,40 @@ namespace Parsek
         /// </summary>
         internal static void InitiateRewind(Recording rec)
         {
+            // Resolve the rewind save owner — may be the tree root for branch recordings.
+            // All save-related fields (filename, resources, UT) come from the owner,
+            // since the quicksave was captured at the owner's launch.
+            var owner = GetRewindRecording(rec);
+            if (owner == null)
+            {
+                if (!SuppressLogging)
+                    ParsekLog.Error("Rewind",
+                        $"InitiateRewind: no rewind owner for '{rec.VesselName}' (id={rec.RecordingId})");
+                return;
+            }
+
+            bool isTreeBranch = owner != rec;
+            if (isTreeBranch && !SuppressLogging)
+                ParsekLog.Info("Rewind",
+                    $"Rewind via tree root: branch '{rec.VesselName}' -> root '{owner.VesselName}' " +
+                    $"save={owner.RewindSaveFileName}");
+
             var reserved = new BudgetSummary
             {
-                reservedFunds = rec.RewindReservedFunds,
-                reservedScience = rec.RewindReservedScience,
-                reservedReputation = rec.RewindReservedRep
+                reservedFunds = owner.RewindReservedFunds,
+                reservedScience = owner.RewindReservedScience,
+                reservedReputation = owner.RewindReservedRep
             };
 
-            // Baseline resources from the recording's pre-launch snapshot.
+            // Baseline resources from the owner's pre-launch snapshot.
             // The rewind save was captured at the same moment as PreLaunch values.
-            RewindContext.BeginRewind(rec.StartUT, reserved,
-                rec.PreLaunchFunds, rec.PreLaunchScience, rec.PreLaunchReputation);
+            RewindContext.BeginRewind(owner.StartUT, reserved,
+                owner.PreLaunchFunds, owner.PreLaunchScience, owner.PreLaunchReputation);
 
             if (!SuppressLogging)
                 ParsekLog.Info("Rewind",
-                    $"Rewind initiated to UT {rec.StartUT} " +
-                    $"(save: {rec.RewindSaveFileName})");
+                    $"Rewind initiated to UT {owner.StartUT} " +
+                    $"(save: {owner.RewindSaveFileName})");
 
             string tempCopyName = null;
             try
@@ -1913,8 +1995,8 @@ namespace Parsek
                     HighLogic.SaveFolder ?? "");
 
                 string sourcePath = Path.Combine(savesDir,
-                    RecordingPaths.BuildRewindSaveRelativePath(rec.RewindSaveFileName));
-                tempCopyName = rec.RewindSaveFileName;
+                    RecordingPaths.BuildRewindSaveRelativePath(owner.RewindSaveFileName));
+                tempCopyName = owner.RewindSaveFileName;
                 string tempPath = Path.Combine(savesDir, tempCopyName + ".sfs");
 
                 // Copy from Parsek/Saves/ to root saves dir
@@ -1925,24 +2007,25 @@ namespace Parsek
                 // 2. Wind back UT by 10 seconds so the player can reach the pad before launch
                 const double rewindLeadTime = 10.0;
 
-                // Collect all vessel names to strip in a single file I/O pass
-                var stripNames = new HashSet<string> { rec.VesselName };
-                if (!string.IsNullOrEmpty(rec.ChainId))
+                // Collect all vessel names to strip — use owner's identity since the
+                // quicksave contains the owner's vessel (not the branch's).
+                var stripNames = new HashSet<string> { owner.VesselName };
+                if (!string.IsNullOrEmpty(owner.ChainId))
                 {
                     // EVA child recordings have different vessel names (the kerbal's name)
                     // and would otherwise survive the strip
                     foreach (var committed in committedRecordings)
                     {
-                        if (committed.ChainId == rec.ChainId &&
+                        if (committed.ChainId == owner.ChainId &&
                             !string.IsNullOrEmpty(committed.EvaCrewName) &&
-                            committed.VesselName != rec.VesselName)
+                            committed.VesselName != owner.VesselName)
                         {
                             stripNames.Add(committed.VesselName);
                         }
                     }
                     if (stripNames.Count > 1 && !SuppressLogging)
                         ParsekLog.Info("Rewind",
-                            $"Rewind strip includes {stripNames.Count - 1} EVA child vessel name(s) from chain '{rec.ChainId}'");
+                            $"Rewind strip includes {stripNames.Count - 1} EVA child vessel name(s) from chain '{owner.ChainId}'");
                 }
                 // Collect spawned vessel PIDs for PID-based stripping (belt-and-suspenders
                 // alongside name matching — catches renamed vessels or debris)
@@ -1960,7 +2043,7 @@ namespace Parsek
                     ResetRewindFlags();
                     if (!SuppressLogging)
                         ParsekLog.Error("Rewind",
-                            $"Rewind failed: LoadGame returned null for save '{rec.RewindSaveFileName}'. " +
+                            $"Rewind failed: LoadGame returned null for save '{owner.RewindSaveFileName}'. " +
                             $"Flags reset: IsRewinding={IsRewinding}, RewindUT={RewindUT}, RewindAdjustedUT={RewindAdjustedUT}");
                     return;
                 }
@@ -1978,7 +2061,7 @@ namespace Parsek
 
                 if (!SuppressLogging)
                     ParsekLog.Info("Rewind",
-                        $"Rewind: loading save '{rec.RewindSaveFileName}' into SpaceCenter");
+                        $"Rewind: loading save '{owner.RewindSaveFileName}' into SpaceCenter");
             }
             catch (Exception ex)
             {

--- a/Source/Parsek/UI/RecordingsTableUI.cs
+++ b/Source/Parsek/UI/RecordingsTableUI.cs
@@ -787,7 +787,7 @@ namespace Parsek
             {
                 bool isFuture = now < rec.StartUT;
                 bool isActive = now >= rec.StartUT && now <= rec.EndUT;
-                bool hasRewindSave = !string.IsNullOrEmpty(rec.RewindSaveFileName);
+                bool hasRewindSave = !string.IsNullOrEmpty(RecordingStore.GetRewindSaveFileName(rec));
                 if (isFuture)
                 {
                     // Future recording: FF button advances UT to recording start
@@ -1138,7 +1138,7 @@ namespace Parsek
             {
                 var mainRec = committed[mainIdx];
                 bool isFuture = now < mainRec.StartUT;
-                bool hasRewindSave = !string.IsNullOrEmpty(mainRec.RewindSaveFileName);
+                bool hasRewindSave = !string.IsNullOrEmpty(RecordingStore.GetRewindSaveFileName(mainRec));
                 bool isRecording = parentUI.InFlightMode && flight.IsRecording;
 
                 if (isFuture)
@@ -1518,18 +1518,26 @@ namespace Parsek
 
         internal void ShowRewindConfirmation(Recording rec)
         {
-            int futureCount = RecordingStore.CountFutureRecordings(rec.StartUT);
+            // Resolve the rewind save owner — may be the tree root for branch recordings.
+            var owner = RecordingStore.GetRewindRecording(rec) ?? rec;
+            bool isTreeBranch = owner != rec;
+
+            int futureCount = RecordingStore.CountFutureRecordings(owner.StartUT);
             string futureText = futureCount > 0
                 ? $"\n\n{futureCount} recording(s) after this launch will replay as ghosts."
                 : "";
 
             var ic = System.Globalization.CultureInfo.InvariantCulture;
-            string launchDate = KSPUtil.PrintDateCompact(rec.StartUT, true);
-            string message = $"Rewind to \"{rec.VesselName}\" launch at {launchDate}?" +
+            string launchDate = KSPUtil.PrintDateCompact(owner.StartUT, true);
+            string branchNote = isTreeBranch
+                ? $"\n(from branch \"{rec.VesselName}\")"
+                : "";
+            string message = $"Rewind to \"{owner.VesselName}\" launch at {launchDate}?" +
+                branchNote +
                 futureText +
                 "\n\nAny uncommitted progress will be lost.";
 
-            var capturedRec = rec;
+            var capturedOwner = owner;
             PopupDialog.SpawnPopupDialog(
                 new Vector2(0.5f, 0.5f),
                 new Vector2(0.5f, 0.5f),
@@ -1541,8 +1549,8 @@ namespace Parsek
                     new DialogGUIButton("Rewind", () =>
                     {
                         ParsekLog.Info("Rewind",
-                            $"User confirmed rewind to \"{capturedRec.VesselName}\" at UT {capturedRec.StartUT}");
-                        RecordingStore.InitiateRewind(capturedRec);
+                            $"User confirmed rewind to \"{capturedOwner.VesselName}\" at UT {capturedOwner.StartUT}");
+                        RecordingStore.InitiateRewind(capturedOwner);
                     }),
                     new DialogGUIButton("Cancel", () =>
                     {

--- a/Source/Parsek/UI/RecordingsTableUI.cs
+++ b/Source/Parsek/UI/RecordingsTableUI.cs
@@ -1519,7 +1519,8 @@ namespace Parsek
         internal void ShowRewindConfirmation(Recording rec)
         {
             // Resolve the rewind save owner — may be the tree root for branch recordings.
-            var owner = RecordingStore.GetRewindRecording(rec) ?? rec;
+            var owner = RecordingStore.GetRewindRecording(rec);
+            if (owner == null) return;
             bool isTreeBranch = owner != rec;
 
             int futureCount = RecordingStore.CountFutureRecordings(owner.StartUT);
@@ -1527,7 +1528,6 @@ namespace Parsek
                 ? $"\n\n{futureCount} recording(s) after this launch will replay as ghosts."
                 : "";
 
-            var ic = System.Globalization.CultureInfo.InvariantCulture;
             string launchDate = KSPUtil.PrintDateCompact(owner.StartUT, true);
             string branchNote = isTreeBranch
                 ? $"\n(from branch \"{rec.VesselName}\")"

--- a/Source/Parsek/UI/TimelineWindowUI.cs
+++ b/Source/Parsek/UI/TimelineWindowUI.cs
@@ -473,7 +473,7 @@ namespace Parsek
                         }
                         GUI.enabled = true;
                     }
-                    else if (!string.IsNullOrEmpty(rec.RewindSaveFileName))
+                    else if (!string.IsNullOrEmpty(RecordingStore.GetRewindSaveFileName(rec)))
                     {
                         // Past/active recording: Rewind button
                         string rewindReason;

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -169,13 +169,9 @@ When a debris recording is set to "ghost-only" in the merge dialog, `ApplyVessel
 
 **Status:** Fixed
 
-## 159. EVA auto-recordings have no rewind save — R button absent
+## 159. ~~EVA auto-recordings have no rewind save — R button absent~~
 
-EVA recordings started from non-launch situations (landed base, orbiting station) have no `RewindSaveFileName` because rewind saves are only captured for chain root / launch recordings. The R button in the recordings window doesn't appear for these recordings.
-
-**Priority:** Low — design gap, not a bug. Rewind save belongs to the original launch, not each EVA.
-
-**Status:** Open — needs design decision: should EVA auto-records capture their own rewind save?
+**Status:** Resolved — tree-aware rewind lookup: branch recordings resolve the rewind save through the tree root via `RecordingStore.GetRewindRecording()`. R button now appears for all tree members.
 
 ## 160. Log spam: remaining sources after ComputeTotal removal
 
@@ -191,13 +187,9 @@ After removing ResourceBudget.ComputeTotal logging (52% of output), remaining sp
 
 **Status:** Open
 
-## 166. R buttons disabled after tree commit — rewind saves consumed
+## 166. ~~R buttons disabled after tree commit — rewind saves consumed~~
 
-After a recording tree is committed via the merge dialog, all R buttons for that tree's recordings become disabled because the rewind quicksave files were deleted during tree promotion. Only the root recording had a rewind save; branch recordings never had one.
-
-**Priority:** Low — by design for tree recordings, but confusing UX
-
-**Status:** Open — design gap: should tree branches inherit the root's rewind save?
+**Status:** Resolved — same fix as #159. Tree branches now resolve the root's rewind save via `RecordingStore.GetRewindRecording()`. `InitiateRewind` and `ShowRewindConfirmation` use the owner recording's fields for correct vessel stripping and UT display.
 
 ## ~~185. Investigate spawning idle vessels earlier or trimming recording tail~~
 


### PR DESCRIPTION
## Summary

- Tree branch recordings (EVA kerbals, decoupled stages) had no rewind save — the R button was absent. Added tree-aware lookup so branches resolve through the tree root's rewind save.
- `InitiateRewind` and `ShowRewindConfirmation` now use the owner (root) recording's fields for vessel stripping, UT display, and future-recording count.
- Resolves todo items #159 and #166.

## Changes

- **RecordingStore.cs**: Added `GetRewindRecording` (resolves rewind save owner through tree root), `GetRewindSaveFileName` (convenience wrapper), `AddCommittedTreeForTesting`. Updated `CanRewind` and `InitiateRewind` to use resolved owner.
- **RecordingsTableUI.cs**: Updated `hasRewindSave` checks and `ShowRewindConfirmation` to resolve owner, show correct launch date/vessel name, pass owner to `InitiateRewind`.
- **TimelineWindowUI.cs**: Updated `hasRewindSave` check.
- **RewindTreeLookupTests.cs**: 12 new tests covering direct save, tree branch resolution, multiple trees, null cases, logging silence.

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 5053 passing, 0 failures
- [ ] In-game: create a tree (EVA from vessel on pad), commit, verify R button on both root and branch, rewind from branch loads correct save

🤖 Generated with [Claude Code](https://claude.com/claude-code)