### PR TITLE
Fix crash breakup debris lost before coalescer (#218)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,7 @@ All notable changes to Parsek are documented here.
 ### Bug Fixes
 
 - **Fix crash breakup debris not recorded when recorder tears down before coalescer (#218).** `ShowPostDestructionMergeDialog` stopped the recorder after one frame, but the crash coalescer's 0.5s window hadn't expired yet. By the time the BREAKUP event emitted, no recorder existed to attach it to. Now waits for the coalescer to finish before proceeding, with a 5s real-time timeout for safety. Continuation recorder marked `VesselDestroyedDuringRecording` after tree promotion to prevent tree dialog guard from incorrectly aborting.
-
-### Code Quality
-
-- **Remove dead forwarding properties (#133).** Removed unused `overlapGhosts` and `loopPhaseOffsets` private forwarding properties from ParsekFlight — zero internal callers, external code accesses `engine.*` directly.
-
+- **Fix spawn permanently blocked by duplicate vessel after rewind (#112).** After rewind, a quicksave-loaded duplicate of a spawned vessel could survive cleanup and permanently block the spawn position. Added defensive duplicate recovery in `CheckSpawnCollisions`: when a collision blocker's name matches the recording's vessel name, recover the blocker once then re-check. `DuplicateBlockerRecovered` flag prevents recovery loops. Also fixed pre-existing gap where `CollisionBlockCount`/`SpawnAbandoned` survived rewind (now reset by `ResetRecordingPlaybackFields`).
 - **Fix atmospheric ghost markers not appearing in Tracking Station (#240).** `OnGUI` had a terminal state filter that skipped non-Orbiting/non-Docked recordings, blocking atmospheric trajectory markers for SubOrbital, Destroyed, Recovered, and Landed recordings even during their active flight window. The UT range check already handles temporal visibility correctly. Extracted `ShouldDrawAtmosphericMarker` as testable pure method.
 - **Fix delayed proto-vessel ghost creation after merge dialog commit.** When a recording was committed via the merge/approval dialog while in the Tracking Station, proto-vessel ghosts took up to 2 seconds to appear (waiting for the lifecycle tick). Now detects committed recording count changes and forces an immediate lifecycle tick.
 - **Fix deferred spawn queue split-brain (#132).** `HandlePlaybackCompleted` in `ParsekPlaybackPolicy` added deferred spawn IDs to the policy's `pendingSpawnRecordingIds`, but `FlushDeferredSpawns` in `ParsekFlight` read from its own never-populated duplicate set. Deferred spawns during warp silently never flushed. Moved `FlushDeferredSpawns` to the policy, eliminated the duplicate fields.
@@ -30,6 +26,9 @@ All notable changes to Parsek are documented here.
 - **Fix green sphere fallback for debris ghosts with no snapshot (#232).** Debris from mid-air booster collisions had no vessel snapshot, causing distracting green spheres during watch mode playback. Now skips ghost creation entirely for snapshotless debris. Non-debris keeps sphere fallback as safety net.
 - **Fix continuation data persisting through revert (#95, items 3-5).** After EVA or undock, the continuation system appended trajectory points and overwrote snapshots on already-committed recordings. On revert/rewind, these mutations persisted — ghosts showed trajectory from an abandoned timeline. Fix: `ContinuationBoundaryIndex` tracks the commit-time point count; pre-continuation snapshots are backed up. On normal stop, the boundary is cleared (data baked as canonical). On revert, `RollbackContinuationData` truncates points and restores snapshots. All 8 stop sites audited: 5 bake (normal lifecycle transitions), 3 don't (vessel destroyed — revert undoes destruction).
 - **Fix R (rewind) button missing on tree branch recordings (#159, #166).** Tree branch recordings (EVA kerbals, decoupled stages) had no `RewindSaveFileName` because rewind saves are only captured at launch. Added tree-aware lookup: `GetRewindRecording` resolves through the tree root so branches can rewind to the original launch point. `InitiateRewind` and `ShowRewindConfirmation` now use the owner recording's fields for correct vessel stripping, UT display, and future-recording count.
+- **Fix timeline not refreshing after commits, rewinds, and KSC spending.** `LedgerOrchestrator.OnTimelineDataChanged` callback now wires to `TimelineWindowUI.InvalidateCache()`, ensuring the timeline view refreshes when data changes from commits, rewinds, time warp, KSC spending, and game load.
+- **Fix FormatDuration overflow for long careers.** Changed `int` → `long` to support durations exceeding 68 years.
+- **Fix timeline footer VesselSpawn count.** Footer now correctly counts all Recording-source entries instead of skipping VesselSpawn via early `continue`.
 
 ### Spawn System Hardening
 
@@ -47,7 +46,9 @@ All notable changes to Parsek are documented here.
 
 ### Code Quality
 
+- **Remove dead forwarding properties (#133).** Removed unused `overlapGhosts` and `loopPhaseOffsets` private forwarding properties from ParsekFlight — zero internal callers, external code accesses `engine.*` directly.
 - **Centralize time conversion system (#187).** Created `ParsekTimeFormat` static class as single source of truth for calendar-aware time formatting. `FormatDuration` (compact: "2d 3h"), `FormatDurationFull` (all units: "1y, 2d, 3h"), and `FormatCountdown` ("T-2d 3h 15m 5s") all respect `GameSettings.KERBIN_TIME`. Replaced 4 duplicate `FormatDuration` implementations (RecordingsTableUI, MergeDialog, TimelineEntryDisplay, ParsekUI) and moved calendar constants from SelectiveSpawnUI. MergeDialog now correctly shows days/years for long recordings.
+- **Timeline per-frame allocation cleanup.** Deduplicated vesselNameById dictionary, replaced `OrderBy().ToList()` with in-place `Sort()`, cached retired kerbals and stats text (rebuilt only on filter change), added `Dictionary<string, Recording>` for O(1) `FindRecordingById` lookup (was O(N) per row).
 
 ### Tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- **Fix crash breakup debris not recorded when recorder tears down before coalescer (#218).** `ShowPostDestructionMergeDialog` stopped the recorder after one frame, but the crash coalescer's 0.5s window hadn't expired yet. By the time the BREAKUP event emitted, no recorder existed to attach it to. Now waits for the coalescer to finish before proceeding, with a 5s real-time timeout for safety. Continuation recorder marked `VesselDestroyedDuringRecording` after tree promotion to prevent tree dialog guard from incorrectly aborting.
+
+### Code Quality
+
+- **Remove dead forwarding properties (#133).** Removed unused `overlapGhosts` and `loopPhaseOffsets` private forwarding properties from ParsekFlight — zero internal callers, external code accesses `engine.*` directly.
+
 - **Fix atmospheric ghost markers not appearing in Tracking Station (#240).** `OnGUI` had a terminal state filter that skipped non-Orbiting/non-Docked recordings, blocking atmospheric trajectory markers for SubOrbital, Destroyed, Recovered, and Landed recordings even during their active flight window. The UT range check already handles temporal visibility correctly. Extracted `ShouldDrawAtmosphericMarker` as testable pure method.
 - **Fix delayed proto-vessel ghost creation after merge dialog commit.** When a recording was committed via the merge/approval dialog while in the Tracking Station, proto-vessel ghosts took up to 2 seconds to appear (waiting for the lifecycle tick). Now detects committed recording count changes and forces an immediate lifecycle tick.
 - **Fix deferred spawn queue split-brain (#132).** `HandlePlaybackCompleted` in `ParsekPlaybackPolicy` added deferred spawn IDs to the policy's `pendingSpawnRecordingIds`, but `FlushDeferredSpawns` in `ParsekFlight` read from its own never-populated duplicate set. Deferred spawns during warp silently never flushed. Moved `FlushDeferredSpawns` to the policy, eliminated the duplicate fields.

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -63,7 +63,6 @@ namespace Parsek
         private Dictionary<int, GhostPlaybackState> ghostStates => engine.ghostStates;
         private List<GameObject> activeExplosions => engine.activeExplosions;
 
-
         // Cached TimelineGhosts dictionary — rebuilt once per frame on first access (T20)
         private Dictionary<int, GameObject> cachedTimelineGhosts = new Dictionary<int, GameObject>();
         private int cachedTimelineGhostsFrame = -1;
@@ -1048,7 +1047,7 @@ namespace Parsek
             // TickCrashCoalescer runs each Update frame. Once the 0.5s window expires,
             // it emits BREAKUP → ProcessBreakupEvent sees recorder alive →
             // PromoteToTreeForBreakup creates a tree with debris child recordings.
-            if (crashCoalescer.HasPendingBreakup)
+            if (crashCoalescer != null && crashCoalescer.HasPendingBreakup)
             {
                 ParsekLog.Info("Flight",
                     "ShowPostDestructionMergeDialog: waiting for crash coalescer");

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -62,8 +62,7 @@ namespace Parsek
         // so existing ParsekFlight code accesses engine-owned collections transparently.
         private Dictionary<int, GhostPlaybackState> ghostStates => engine.ghostStates;
         private List<GameObject> activeExplosions => engine.activeExplosions;
-        private Dictionary<int, List<GhostPlaybackState>> overlapGhosts => engine.overlapGhosts;
-        private Dictionary<int, double> loopPhaseOffsets => engine.loopPhaseOffsets;
+
 
         // Cached TimelineGhosts dictionary — rebuilt once per frame on first access (T20)
         private Dictionary<int, GameObject> cachedTimelineGhosts = new Dictionary<int, GameObject>();
@@ -1044,6 +1043,48 @@ namespace Parsek
             // The Harmony patch on FlightResultsDialog.Display suppresses KSP's
             // crash report until the merge dialog is resolved — no hardcoded delay needed.
             yield return null;
+
+            // (#218) Wait for crash coalescer before stopping recorder.
+            // TickCrashCoalescer runs each Update frame. Once the 0.5s window expires,
+            // it emits BREAKUP → ProcessBreakupEvent sees recorder alive →
+            // PromoteToTreeForBreakup creates a tree with debris child recordings.
+            if (crashCoalescer.HasPendingBreakup)
+            {
+                ParsekLog.Info("Flight",
+                    "ShowPostDestructionMergeDialog: waiting for crash coalescer");
+                float coalescerWaitStart = Time.unscaledTime;
+                while (crashCoalescer.HasPendingBreakup)
+                {
+                    if (Time.unscaledTime - coalescerWaitStart > 5f)
+                    {
+                        ParsekLog.Warn("Flight",
+                            "ShowPostDestructionMergeDialog: coalescer wait timed out (5s real-time)");
+                        crashCoalescer.Reset();
+                        break;
+                    }
+                    yield return null;
+                }
+
+                // PromoteToTreeForBreakup created a tree — hand off to tree handler.
+                // Mark continuation recorder as vessel-destroyed: PromoteToTreeForBreakup
+                // starts a new recorder that never saw OnVesselWillDestroy, so its
+                // VesselDestroyedDuringRecording is false. Without this,
+                // ShowPostDestructionTreeMergeDialog's guard would incorrectly abort.
+                if (activeTree != null)
+                {
+                    if (recorder != null)
+                        recorder.VesselDestroyedDuringRecording = true;
+                    ParsekLog.Info("Flight",
+                        "ShowPostDestructionMergeDialog: coalescer promoted to tree — " +
+                        "redirecting to tree destruction handler");
+                    treeDestructionDialogPending = true;
+                    StartCoroutine(ShowPostDestructionTreeMergeDialog());
+                    yield break;
+                }
+                // If activeTree is null, PromoteToTreeForBreakup failed (CaptureAtStop null)
+                // and FallbackCommitSplitRecorder handled the data. Fall through to existing
+                // guards — recorder-null or HasPending will exit cleanly.
+            }
 
             // Guard: only proceed if recorder still exists and vessel was destroyed
             if (recorder == null || !recorder.VesselDestroyedDuringRecording)

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -137,7 +137,7 @@ After T25 extraction, ParsekFlight still has forwarding properties (`ghostStates
 
 **Priority:** Low — tech debt, no functional impact
 
-**Status:** Partially fixed — removed 6 dead forwarding methods, inlined 4 remaining call sites. 7 forwarding properties retained as ergonomic aliases — `ghostStates` alone has 17 usages. Actual indirection was ~40 lines, not ~500.
+**Status:** Resolved — removed 6 dead forwarding methods, inlined 4 call sites, removed 2 dead private forwarding properties (`overlapGhosts`, `loopPhaseOffsets` — zero internal callers). 3 remaining properties (`ghostStates`, `activeExplosions`, `loadedAnchorVessels`) have active internal usages.
 
 ## ~~154. parsek_38.png texture compression warning~~
 
@@ -157,7 +157,7 @@ Areas identified by code path simulation that lack unit tests:
 
 **Priority:** Low — test infrastructure, requires Unity runtime
 
-**Status:** Partially fixed — item 4 done (7 tests). Items 1-3 deferred to in-game testing.
+**Status:** Partially fixed — item 4 done (7 tests). Items 1-3 deferred to in-game testing. Decision logic for items 1 and 3 extracted to static/pure methods and fully tested (`DecideOnVesselSwitch`, `ShouldSplitAtAtmosphereBoundary`). Only integration paths remain untestable without Unity runtime.
 
 ## ~~157. Green sphere ghost for debris after ghost-only merge decision~~
 
@@ -279,6 +279,10 @@ Two compounding issues: (1) `TerminalOrbitBody` is null on all recordings at loa
 When a vessel crashes during an active recording, the recorder is stopped and committed before the coalescer's 0.5s window elapses. By the time the coalescer emits the BREAKUP event, there is no active tree or recorder to attach it to. The main vessel recording is saved but the crash debris tree structure is lost.
 
 **Priority:** Low — the vessel recording itself is preserved; only debris ghosts are missing.
+
+**Fix:** `ShowPostDestructionMergeDialog` now waits for the crash coalescer's 0.5s window to expire before stopping the recorder. `TickCrashCoalescer` in Update() naturally emits the BREAKUP while the recorder is still alive, allowing `PromoteToTreeForBreakup` to create the tree with debris child recordings. A 5s real-time timeout (via `Time.unscaledTime`) prevents infinite wait if UT stops advancing (game pause). After tree creation, the continuation recorder is marked `VesselDestroyedDuringRecording = true` (it never saw the original `OnVesselWillDestroy` event) and control redirects to `ShowPostDestructionTreeMergeDialog`.
+
+**Status:** Fixed
 
 ## ~~219. Ghost creation fails for orbital debris chain ("no orbit data")~~
 


### PR DESCRIPTION
## Summary

- **Fix #218:** `ShowPostDestructionMergeDialog` now waits for the crash coalescer's 0.5s window to expire before stopping the recorder. The natural `TickCrashCoalescer` emission handles tree creation via `PromoteToTreeForBreakup` while the recorder is still alive. Includes 5s real-time timeout (UT stops on pause) and continuation recorder `VesselDestroyedDuringRecording` marking to prevent tree dialog guard from aborting.
- **Fix #133:** Remove dead `overlapGhosts` and `loopPhaseOffsets` private forwarding properties (zero internal callers).
- **Update #156:** Status updated — extractable decision logic already tested, remaining gaps genuinely require Unity runtime.

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 5064 passing
- [ ] In-game: record a flight, crash on pad → verify "waiting for crash coalescer" log appears → tree merge dialog shows → debris recordings present in committed tree
- [ ] In-game: normal vessel destruction (no crash) → verify no behavior change (coalescer wait skipped)