### PR TITLE
Bump Parsek.version to 0.7.1

### DIFF
--- a/GameData/Parsek/Parsek.version
+++ b/GameData/Parsek/Parsek.version
@@ -1,7 +1,7 @@
 {
     "NAME": "Parsek",
     "URL": "https://raw.githubusercontent.com/vl3c/Parsek/main/GameData/Parsek/Parsek.version",
-    "VERSION": { "MAJOR": 0, "MINOR": 7, "PATCH": 0 },
+    "VERSION": { "MAJOR": 0, "MINOR": 7, "PATCH": 1 },
     "KSP_VERSION": { "MAJOR": 1, "MINOR": 12, "PATCH": 5 },
     "KSP_VERSION_MIN": { "MAJOR": 1, "MINOR": 12, "PATCH": 0 },
     "KSP_VERSION_MAX": { "MAJOR": 1, "MINOR": 12, "PATCH": 99 }


### PR DESCRIPTION
## Summary

- Bump `Parsek.version` from 0.7.0 to 0.7.1 to match `AssemblyInfo.cs`

## Test plan

- [x] Version file valid JSON
- [x] Matches AssemblyInfo.cs version