### PR TITLE
Add recording observability (Phase 11.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ All notable changes to Parsek are documented here.
 
 - **Ghost positional audio.** Ghost vessels now emit 3D positional engine sounds — hear rockets in the distance, decoupler pops on staging, and explosions on impact. Sound fades naturally with distance via Unity spatial audio and attenuates through the atmosphere (silent in vacuum). Engine clip selection uses a built-in preset map based on propellant type and thrust class (liquid/solid/ion/jet). One-shot sounds for decouple and explosion events. Ghost audio volume slider in Settings (default 100%). Capped at 4 AudioSources per ghost. Audio muted during high time warp, for overlap ghosts, and for soft-cap-reduced ghosts. Compatible with RocketSoundEnhancement (RSE).
 
+### Observability (Phase 11.5)
+
+- **Diagnostics report.** Full metrics snapshot accessible via in-game test runner (Ctrl+Shift+T) or Settings > Diagnostics button. Reports storage breakdown per recording (file sizes, bytes/sec efficiency), memory estimate, playback/recording frame budgets with rolling averages, save/load timing, and health counters (waypoint cache hit rate, snapshot spikes, spawn failures, ghost builds/destroys, GC gen0). Simultaneously dumps to KSP.log.
+- **Per-recording storage tooltip.** Hover over a recording in the Recordings Manager to see file sizes (trajectory, vessel snapshot, ghost snapshot) and storage efficiency.
+- **Automatic budget warnings.** KSP.log emits `[WARN]` when playback exceeds 8ms/frame or recording exceeds 4ms/frame, rate-limited to once per 30 seconds. Scene load, save/load timing, and recording start/stop logged at Verbose level.
+- **Recording growth rate.** Points/sec, events/sec, and projected file size tracked during active recording.
+- **`ParsekLog.WarnRateLimited`.** New logging API for rate-limited warnings that emit unconditionally (not gated by verbose setting).
+
 ### Maintenance
 
 - **Bump version to 0.7.2.**

--- a/Source/Parsek.Tests/DiagnosticsIntegrationTests.cs
+++ b/Source/Parsek.Tests/DiagnosticsIntegrationTests.cs
@@ -1,0 +1,616 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Integration tests using real Recording objects, and edge case tests
+    /// for diagnostics computation. Guards against regressions in memory estimation,
+    /// snapshot caching, storage breakdown, and edge conditions (zero division,
+    /// empty buffers, missing files, counter resets).
+    /// </summary>
+    [Collection("Sequential")]
+    public class DiagnosticsIntegrationTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public DiagnosticsIntegrationTests()
+        {
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+            ParsekLog.VerboseOverrideForTesting = true;
+            RecordingStore.SuppressLogging = true;
+            DiagnosticsState.ResetForTesting();
+            DiagnosticsComputation.ResetForTesting();
+            RecordingStore.ResetForTesting();
+        }
+
+        public void Dispose()
+        {
+            DiagnosticsState.ResetForTesting();
+            DiagnosticsComputation.ResetForTesting();
+            RecordingStore.ResetForTesting();
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+            RecordingStore.SuppressLogging = true;
+        }
+
+        // Helper: creates a Recording with a known number of points, events, and orbit segments.
+        private static Recording BuildRecordingWithCounts(
+            string name, int pointCount, int eventCount, int segmentCount,
+            double startUT = 100.0, double utStep = 1.0,
+            bool withSnapshots = false)
+        {
+            var rec = new Recording { VesselName = name };
+            for (int i = 0; i < pointCount; i++)
+                rec.Points.Add(new TrajectoryPoint { ut = startUT + i * utStep, bodyName = "Kerbin" });
+            for (int i = 0; i < eventCount; i++)
+                rec.PartEvents.Add(new PartEvent { ut = startUT + i * utStep });
+            for (int i = 0; i < segmentCount; i++)
+                rec.OrbitSegments.Add(new OrbitSegment { startUT = startUT, endUT = startUT + 100 });
+
+            if (withSnapshots)
+            {
+                rec.VesselSnapshot = new ConfigNode("VESSEL");
+                rec.GhostVisualSnapshot = new ConfigNode("GHOST");
+            }
+
+            return rec;
+        }
+
+        // =====================================================================
+        // Integration test 1: Memory estimate from loaded recordings
+        // Guards against: incorrect iteration over CommittedRecordings, wrong
+        // multipliers in memory estimation formula, double-counting.
+        // =====================================================================
+
+        [Fact]
+        public void MemoryEstimate_FromLoadedRecordings()
+        {
+            // Build 3 recordings with known counts
+            var rec1 = BuildRecordingWithCounts("Alpha", pointCount: 500, eventCount: 20, segmentCount: 3, withSnapshots: true);
+            var rec2 = BuildRecordingWithCounts("Beta", pointCount: 300, eventCount: 10, segmentCount: 1, withSnapshots: true);
+            var rec3 = BuildRecordingWithCounts("Gamma", pointCount: 200, eventCount: 5, segmentCount: 0, withSnapshots: false);
+
+            RecordingStore.AddCommittedForTesting(rec1);
+            RecordingStore.AddCommittedForTesting(rec2);
+            RecordingStore.AddCommittedForTesting(rec3);
+
+            DiagnosticsComputation.ClockSource = () => 2000.0;
+            var snap = DiagnosticsComputation.ComputeSnapshot(500.0);
+
+            int expectedPts = 500 + 300 + 200;
+            int expectedEvts = 20 + 10 + 5;
+            int expectedSegs = 3 + 1 + 0;
+            int expectedSnaps = 2; // rec1 and rec2 have both snapshots; rec3 has neither
+
+            Assert.Equal(expectedPts, snap.loadedTrajectoryPoints);
+            Assert.Equal(expectedEvts, snap.loadedPartEvents);
+            Assert.Equal(expectedSegs, snap.loadedOrbitSegments);
+            Assert.Equal(expectedSnaps, snap.loadedSnapshotCount);
+            Assert.Equal(3, snap.recordingCount);
+
+            long expectedMemory = (long)expectedPts * 136L
+                                + (long)expectedEvts * 88L
+                                + (long)expectedSegs * 120L
+                                + (long)expectedSnaps * 8192L;
+            Assert.Equal(expectedMemory, snap.estimatedMemoryBytes);
+        }
+
+        // =====================================================================
+        // Integration test 2: Snapshot cache returns stale within TTL
+        // Guards against: TTL comparison inverted (< vs >), cache not populated.
+        // =====================================================================
+
+        [Fact]
+        public void SnapshotCache_ReturnsStaleWithinTTL()
+        {
+            var rec = BuildRecordingWithCounts("Cached", pointCount: 100, eventCount: 5, segmentCount: 1);
+            RecordingStore.AddCommittedForTesting(rec);
+
+            DiagnosticsComputation.ClockSource = () => 1000.0;
+
+            // Compute at UT=100
+            var snap1 = DiagnosticsComputation.GetOrComputeSnapshot(100.0);
+            Assert.True(DiagnosticsState.hasCachedSnapshot);
+            Assert.Equal(100.0, DiagnosticsState.cachedSnapshotUT);
+            Assert.Equal(100, snap1.loadedTrajectoryPoints);
+
+            // Add another recording (this would change the result if recomputed)
+            var rec2 = BuildRecordingWithCounts("New", pointCount: 50, eventCount: 2, segmentCount: 0);
+            RecordingStore.AddCommittedForTesting(rec2);
+
+            // Call at UT=101 (within 2s TTL)
+            var snap2 = DiagnosticsComputation.GetOrComputeSnapshot(101.0);
+
+            // Should return cached snapshot, so recording count is still 1
+            // (the second recording added after the snapshot was computed)
+            Assert.Equal(100.0, DiagnosticsState.cachedSnapshotUT);
+            Assert.Equal(100, snap2.loadedTrajectoryPoints);
+        }
+
+        // =====================================================================
+        // Integration test 3: Snapshot cache recomputes after TTL
+        // Guards against: cache never invalidated, stale data persisting forever.
+        // =====================================================================
+
+        [Fact]
+        public void SnapshotCache_RecomputesAfterTTL()
+        {
+            var rec = BuildRecordingWithCounts("Initial", pointCount: 100, eventCount: 5, segmentCount: 1);
+            RecordingStore.AddCommittedForTesting(rec);
+
+            DiagnosticsComputation.ClockSource = () => 1000.0;
+
+            // Compute at UT=100
+            var snap1 = DiagnosticsComputation.GetOrComputeSnapshot(100.0);
+            Assert.Equal(100, snap1.loadedTrajectoryPoints);
+
+            // Add another recording
+            var rec2 = BuildRecordingWithCounts("Added", pointCount: 75, eventCount: 3, segmentCount: 0);
+            RecordingStore.AddCommittedForTesting(rec2);
+
+            // Call at UT=103 (past 2s TTL)
+            var snap2 = DiagnosticsComputation.GetOrComputeSnapshot(103.0);
+
+            // Should have recomputed, now including both recordings
+            Assert.Equal(103.0, DiagnosticsState.cachedSnapshotUT);
+            Assert.Equal(175, snap2.loadedTrajectoryPoints); // 100 + 75
+            Assert.Equal(2, snap2.recordingCount);
+        }
+
+        // =====================================================================
+        // Integration test 4: Storage breakdown cache returns stale within 5s TTL
+        // Guards against: per-recording storage cache TTL wrong, cache miss on repeat hover.
+        // =====================================================================
+
+        [Fact]
+        public void StorageBreakdownCache_ReturnsStaleWithinTTL()
+        {
+            var rec = BuildRecordingWithCounts("Hoverable", pointCount: 50, eventCount: 2, segmentCount: 0);
+            rec.RecordingId = "test-hover-rec";
+
+            // First call at UT=200 computes and caches
+            var bd1 = DiagnosticsComputation.GetCachedStorageBreakdown(rec, 200.0);
+            Assert.Equal("test-hover-rec", bd1.recordingId);
+            Assert.Equal(50, bd1.pointCount);
+
+            // Second call at UT=203 (within 5s TTL) should return cached
+            // Modify the recording's point count to detect if recomputation happens
+            rec.Points.Add(new TrajectoryPoint { ut = 999 });
+            var bd2 = DiagnosticsComputation.GetCachedStorageBreakdown(rec, 203.0);
+
+            // Still returns the cached version with 50 points (not 51)
+            Assert.Equal(50, bd2.pointCount);
+
+            // Third call at UT=206 (past 5s TTL) should recompute
+            var bd3 = DiagnosticsComputation.GetCachedStorageBreakdown(rec, 206.0);
+            Assert.Equal(51, bd3.pointCount);
+        }
+
+        // =====================================================================
+        // Edge case E1: No recordings exist, clean zeros
+        // Guards against: null reference when iterating empty list, NaN in
+        // estimation, non-zero defaults.
+        // =====================================================================
+
+        [Fact]
+        public void E1_NoRecordings_CleanZeros()
+        {
+            DiagnosticsComputation.ClockSource = () => 1000.0;
+            var snap = DiagnosticsComputation.ComputeSnapshot(50.0);
+
+            Assert.Equal(0, snap.recordingCount);
+            Assert.Equal(0L, snap.totalStorageBytes);
+            Assert.Equal(0, snap.loadedTrajectoryPoints);
+            Assert.Equal(0, snap.loadedPartEvents);
+            Assert.Equal(0, snap.loadedOrbitSegments);
+            Assert.Equal(0, snap.loadedSnapshotCount);
+            Assert.Equal(0L, snap.estimatedMemoryBytes);
+            Assert.Equal(0, snap.activeGhostCount);
+            Assert.NotNull(snap.perRecording);
+            Assert.Empty(snap.perRecording);
+
+            // Format report should not crash and should show zeros
+            string report = DiagnosticsComputation.FormatReport(snap);
+            Assert.Contains("0 B total, 0 recordings", report);
+            Assert.Contains("0 pts", report);
+            Assert.DoesNotContain("NaN", report);
+            Assert.DoesNotContain("Infinity", report);
+        }
+
+        // =====================================================================
+        // Edge case E4: Missing sidecar file returns graceful zero
+        // Guards against: exception on missing file crashing diagnostics, non-zero
+        // size returned for non-existent files.
+        // In unit tests, KSP path resolution is unavailable so SafeResolvePath
+        // returns null. This tests that the entire pipeline handles null paths
+        // gracefully (0 bytes, no crash).
+        // =====================================================================
+
+        [Fact]
+        public void E4_MissingSidecarFile_GracefulZero()
+        {
+            // Create a recording with a valid ID but no actual files on disk.
+            // In a test environment, RecordingPaths.ResolveSaveScopedPath throws
+            // because KSPUtil/HighLogic aren't available. SafeResolvePath catches
+            // the exception and returns null. SafeGetFileSize returns 0 for null paths.
+            var rec = BuildRecordingWithCounts("NoFiles", pointCount: 100, eventCount: 5, segmentCount: 2);
+            rec.RecordingId = "missing-sidecar-test";
+
+            var bd = DiagnosticsComputation.ComputeStorageBreakdown(rec);
+
+            Assert.Equal(0L, bd.trajectoryFileBytes);
+            Assert.Equal(0L, bd.vesselSnapshotBytes);
+            Assert.Equal(0L, bd.ghostSnapshotBytes);
+            Assert.Equal(0L, bd.geometryFileBytes);
+            Assert.Equal(0L, bd.totalBytes);
+            // Metadata counts should still be populated from the recording object
+            Assert.Equal(100, bd.pointCount);
+            Assert.Equal(5, bd.partEventCount);
+            Assert.Equal(2, bd.orbitSegmentCount);
+        }
+
+        // =====================================================================
+        // Edge case E4 variant: null recording returns default struct
+        // Guards against: null dereference in ComputeStorageBreakdown.
+        // =====================================================================
+
+        [Fact]
+        public void E4_NullRecording_ReturnsDefaultBreakdown()
+        {
+            var bd = DiagnosticsComputation.ComputeStorageBreakdown(null);
+
+            Assert.Equal(0L, bd.totalBytes);
+            Assert.Equal(0, bd.pointCount);
+            Assert.Null(bd.recordingId);
+        }
+
+        // =====================================================================
+        // Edge case E4 variant: empty recording ID returns graceful zero
+        // Guards against: empty string passed to RecordingPaths causing exception.
+        // =====================================================================
+
+        [Fact]
+        public void E4_EmptyRecordingId_GracefulZero()
+        {
+            var rec = new Recording { VesselName = "EmptyId", RecordingId = "" };
+
+            var bd = DiagnosticsComputation.ComputeStorageBreakdown(rec);
+
+            Assert.Equal(0L, bd.totalBytes);
+            Assert.Equal("", bd.recordingId);
+        }
+
+        // =====================================================================
+        // Edge case E10: Empty rolling buffer shows "N/A" in format report
+        // Guards against: misleading "0.0 ms" shown when no data exists,
+        // empty buffer causing division by zero in ComputeStats.
+        // =====================================================================
+
+        [Fact]
+        public void E10_EmptyRollingBuffer_FormatShowsNA()
+        {
+            // Rolling buffer is empty after ResetForTesting
+            Assert.True(DiagnosticsState.playbackFrameHistory.IsEmpty);
+
+            var snap = new MetricSnapshot
+            {
+                perRecording = new StorageBreakdown[0]
+            };
+
+            string report = DiagnosticsComputation.FormatReport(snap);
+
+            Assert.Contains("Playback budget: N/A", report);
+            // Playback budget line must not show "0.0 ms avg" which would be misleading.
+            // (Recording budget line legitimately shows "0.0 ms avg" since that's raw data, not rolling.)
+            Assert.DoesNotContain("Playback budget: 0.0 ms avg", report);
+        }
+
+        // =====================================================================
+        // Edge case: Duration zero recording, bytesPerSecond must be 0.0
+        // Guards against: division by zero producing NaN or Infinity when
+        // StartUT == EndUT (instantaneous recording, e.g. single-frame).
+        // =====================================================================
+
+        [Fact]
+        public void DurationZero_BytesPerSecondZero()
+        {
+            // Create a recording where StartUT == EndUT (single point)
+            var rec = new Recording { VesselName = "Instant" };
+            rec.Points.Add(new TrajectoryPoint { ut = 500.0 });
+
+            // Verify StartUT == EndUT
+            Assert.Equal(rec.StartUT, rec.EndUT);
+
+            var bd = DiagnosticsComputation.ComputeStorageBreakdown(rec);
+
+            Assert.Equal(0.0, bd.durationSeconds);
+            Assert.Equal(0.0, bd.bytesPerSecond);
+            Assert.False(double.IsNaN(bd.bytesPerSecond));
+            Assert.False(double.IsInfinity(bd.bytesPerSecond));
+        }
+
+        // =====================================================================
+        // Edge case: Growth rate with zero elapsed time
+        // Guards against: NaN/Infinity in pointsPerSecond and eventsPerSecond
+        // when recording has just started (elapsedSeconds == 0).
+        // =====================================================================
+
+        [Fact]
+        public void GrowthRate_ZeroElapsed_NoNaN()
+        {
+            DiagnosticsState.activeGrowthRate = new RecordingGrowthRate
+            {
+                totalPoints = 1,
+                totalEvents = 0,
+                elapsedSeconds = 0.0,
+                pointsPerSecond = 0.0,  // caller must set this safely
+                eventsPerSecond = 0.0
+            };
+            DiagnosticsState.hasActiveGrowthRate = true;
+
+            // Verify the struct values are safe
+            Assert.Equal(0.0, DiagnosticsState.activeGrowthRate.pointsPerSecond);
+            Assert.Equal(0.0, DiagnosticsState.activeGrowthRate.eventsPerSecond);
+            Assert.False(double.IsNaN(DiagnosticsState.activeGrowthRate.pointsPerSecond));
+            Assert.False(double.IsInfinity(DiagnosticsState.activeGrowthRate.pointsPerSecond));
+            Assert.False(double.IsNaN(DiagnosticsState.activeGrowthRate.eventsPerSecond));
+            Assert.False(double.IsInfinity(DiagnosticsState.activeGrowthRate.eventsPerSecond));
+
+            // Also verify FormatReport handles this without crash
+            var snap = new MetricSnapshot { perRecording = new StorageBreakdown[0] };
+            string report = DiagnosticsComputation.FormatReport(snap);
+            Assert.DoesNotContain("NaN", report);
+            Assert.DoesNotContain("Infinity", report);
+            Assert.Contains("(active)", report);
+        }
+
+        // =====================================================================
+        // Edge case: Health counter reset clears all counters
+        // Guards against: new counter fields added to HealthCounters but
+        // omitted from Reset(), leaving stale data across scenes.
+        // =====================================================================
+
+        [Fact]
+        public void HealthCounterReset_ClearsAll()
+        {
+            // Set every counter to a non-zero value
+            DiagnosticsState.health.waypointCacheHits = 100;
+            DiagnosticsState.health.waypointCacheMisses = 50;
+            DiagnosticsState.health.snapshotRefreshSpikes = 10;
+            DiagnosticsState.health.spawnFailures = 7;
+            DiagnosticsState.health.spawnRetries = 3;
+            DiagnosticsState.health.softCapActivations = 5;
+            DiagnosticsState.health.softCapDespawns = 12;
+            DiagnosticsState.health.ghostBuildsThisSession = 25;
+            DiagnosticsState.health.ghostDestroysThisSession = 20;
+            DiagnosticsState.health.gcGen0Baseline = 999;
+
+            DiagnosticsState.health.Reset();
+
+            Assert.Equal(0, DiagnosticsState.health.waypointCacheHits);
+            Assert.Equal(0, DiagnosticsState.health.waypointCacheMisses);
+            Assert.Equal(0, DiagnosticsState.health.snapshotRefreshSpikes);
+            Assert.Equal(0, DiagnosticsState.health.spawnFailures);
+            Assert.Equal(0, DiagnosticsState.health.spawnRetries);
+            Assert.Equal(0, DiagnosticsState.health.softCapActivations);
+            Assert.Equal(0, DiagnosticsState.health.softCapDespawns);
+            Assert.Equal(0, DiagnosticsState.health.ghostBuildsThisSession);
+            Assert.Equal(0, DiagnosticsState.health.ghostDestroysThisSession);
+            // gcGen0Baseline should be current GC count, not zero or the old value
+            Assert.Equal(GC.CollectionCount(0), DiagnosticsState.health.gcGen0Baseline);
+            Assert.NotEqual(999, DiagnosticsState.health.gcGen0Baseline);
+        }
+
+        // =====================================================================
+        // Edge case: Cache hit rate with zero lookups shows "N/A"
+        // Guards against: division by zero producing "NaN%" in report,
+        // or crash when totalLookups == 0.
+        // =====================================================================
+
+        [Fact]
+        public void CacheHitRate_ZeroLookups_ShowsNA()
+        {
+            DiagnosticsState.health.waypointCacheHits = 0;
+            DiagnosticsState.health.waypointCacheMisses = 0;
+
+            var snap = new MetricSnapshot
+            {
+                perRecording = new StorageBreakdown[0]
+            };
+
+            string report = DiagnosticsComputation.FormatReport(snap);
+
+            Assert.Contains("cache N/A hit", report);
+            Assert.Contains("0 miss of 0 lookups", report);
+            Assert.DoesNotContain("NaN", report);
+            Assert.DoesNotContain("Infinity", report);
+        }
+
+        // =====================================================================
+        // Integration: Memory estimate with zero-count recording
+        // Guards against: recordings with empty Points/Events/Segments lists
+        // causing null dereference or incorrect totals.
+        // =====================================================================
+
+        [Fact]
+        public void MemoryEstimate_EmptyRecording_ContributesZero()
+        {
+            // Add a completely empty recording (no points, events, or segments)
+            var emptyRec = new Recording { VesselName = "Empty" };
+            RecordingStore.AddCommittedForTesting(emptyRec);
+
+            // Add a recording with data
+            var dataRec = BuildRecordingWithCounts("HasData", pointCount: 50, eventCount: 10, segmentCount: 2);
+            RecordingStore.AddCommittedForTesting(dataRec);
+
+            DiagnosticsComputation.ClockSource = () => 1000.0;
+            var snap = DiagnosticsComputation.ComputeSnapshot(100.0);
+
+            // Empty recording contributes nothing to memory
+            Assert.Equal(50, snap.loadedTrajectoryPoints);
+            Assert.Equal(10, snap.loadedPartEvents);
+            Assert.Equal(2, snap.loadedOrbitSegments);
+            Assert.Equal(2, snap.recordingCount);
+
+            long expectedMemory = 50L * 136 + 10L * 88 + 2L * 120;
+            Assert.Equal(expectedMemory, snap.estimatedMemoryBytes);
+        }
+
+        // =====================================================================
+        // Integration: Snapshot includes both vessel+ghost snapshots for counting
+        // Guards against: counting recordings where only VesselSnapshot is set
+        // but GhostVisualSnapshot is null (or vice versa).
+        // =====================================================================
+
+        [Fact]
+        public void SnapshotCount_RequiresBothVesselAndGhostSnapshot()
+        {
+            var recBoth = new Recording { VesselName = "Both" };
+            recBoth.VesselSnapshot = new ConfigNode("V");
+            recBoth.GhostVisualSnapshot = new ConfigNode("G");
+            RecordingStore.AddCommittedForTesting(recBoth);
+
+            var recVesselOnly = new Recording { VesselName = "VesselOnly" };
+            recVesselOnly.VesselSnapshot = new ConfigNode("V2");
+            RecordingStore.AddCommittedForTesting(recVesselOnly);
+
+            var recGhostOnly = new Recording { VesselName = "GhostOnly" };
+            recGhostOnly.GhostVisualSnapshot = new ConfigNode("G2");
+            RecordingStore.AddCommittedForTesting(recGhostOnly);
+
+            var recNeither = new Recording { VesselName = "Neither" };
+            RecordingStore.AddCommittedForTesting(recNeither);
+
+            DiagnosticsComputation.ClockSource = () => 1000.0;
+            var snap = DiagnosticsComputation.ComputeSnapshot(100.0);
+
+            // Only the recording with BOTH snapshots counts
+            Assert.Equal(1, snap.loadedSnapshotCount);
+            Assert.Equal(4, snap.recordingCount);
+        }
+
+        // =====================================================================
+        // Integration: Full FormatReport with multiple recordings
+        // Guards against: report generation crashing with multiple per-recording
+        // lines, index formatting errors, large data values.
+        // =====================================================================
+
+        [Fact]
+        public void FormatReport_MultipleRecordings_AllListed()
+        {
+            var rec1 = BuildRecordingWithCounts("Alpha", pointCount: 1000, eventCount: 50, segmentCount: 3);
+            var rec2 = BuildRecordingWithCounts("Beta", pointCount: 2000, eventCount: 100, segmentCount: 5);
+            RecordingStore.AddCommittedForTesting(rec1);
+            RecordingStore.AddCommittedForTesting(rec2);
+
+            DiagnosticsComputation.ClockSource = () => 1000.0;
+            var snap = DiagnosticsComputation.ComputeSnapshot(100.0);
+            string report = DiagnosticsComputation.FormatReport(snap);
+
+            Assert.Contains("2 recordings", report);
+            Assert.Contains("rec[0]", report);
+            Assert.Contains("rec[1]", report);
+            Assert.Contains("\"Alpha\"", report);
+            Assert.Contains("\"Beta\"", report);
+            Assert.Contains("1000 pts", report);
+            Assert.Contains("2000 pts", report);
+            Assert.Contains("3000 pts", report); // total across both
+        }
+
+        // =====================================================================
+        // Edge case: Negative duration clamped to zero
+        // Guards against: EndUT < StartUT (should not happen but defensive guard)
+        // producing negative duration or negative bytesPerSecond.
+        // =====================================================================
+
+        [Fact]
+        public void NegativeDuration_ClampedToZero()
+        {
+            var rec = new Recording { VesselName = "Backwards" };
+            // Use explicit UT range where end < start (should never happen but defensive)
+            rec.ExplicitStartUT = 200.0;
+            rec.ExplicitEndUT = 100.0;
+
+            var bd = DiagnosticsComputation.ComputeStorageBreakdown(rec);
+
+            // Duration should be clamped to 0, not negative
+            Assert.Equal(0.0, bd.durationSeconds);
+            Assert.Equal(0.0, bd.bytesPerSecond);
+            Assert.False(double.IsNaN(bd.bytesPerSecond));
+        }
+
+        // =====================================================================
+        // Edge case: DiagnosticsState.ResetSessionCounters invalidates snapshot cache
+        // Guards against: stale snapshot surviving a scene load reset.
+        // =====================================================================
+
+        [Fact]
+        public void ResetSessionCounters_InvalidatesSnapshotCache()
+        {
+            DiagnosticsComputation.ClockSource = () => 1000.0;
+
+            // Populate a cached snapshot
+            var rec = BuildRecordingWithCounts("Cached", pointCount: 100, eventCount: 5, segmentCount: 1);
+            RecordingStore.AddCommittedForTesting(rec);
+            DiagnosticsComputation.ComputeSnapshot(100.0);
+            Assert.True(DiagnosticsState.hasCachedSnapshot);
+
+            // Simulate scene load
+            DiagnosticsState.ResetSessionCounters();
+
+            // Cache should be invalidated
+            Assert.False(DiagnosticsState.hasCachedSnapshot);
+            Assert.Equal(0.0, DiagnosticsState.cachedSnapshotUT);
+        }
+
+        // =====================================================================
+        // Integration: RunDiagnosticsReport produces complete output and logs it
+        // Guards against: report generation producing empty string, or log lines
+        // not being emitted.
+        // =====================================================================
+
+        [Fact]
+        public void RunDiagnosticsReport_ProducesCompleteOutput()
+        {
+            var rec = BuildRecordingWithCounts("Diagnostic", pointCount: 200, eventCount: 15, segmentCount: 2);
+            RecordingStore.AddCommittedForTesting(rec);
+
+            DiagnosticsComputation.ClockSource = () => 1000.0;
+
+            string report = DiagnosticsComputation.RunDiagnosticsReport();
+
+            Assert.Contains("===== DIAGNOSTICS REPORT =====", report);
+            Assert.Contains("===== END REPORT =====", report);
+            Assert.Contains("1 recordings", report);
+            Assert.Contains("200 pts", report);
+
+            // Verify lines were also sent to log
+            Assert.Contains(logLines, l => l.Contains("[INFO]") && l.Contains("DIAGNOSTICS REPORT"));
+            Assert.Contains(logLines, l => l.Contains("[INFO]") && l.Contains("END REPORT"));
+        }
+
+        // =====================================================================
+        // Edge case: StorageBreakdown with valid duration computes bytesPerSecond
+        // Guards against: correct division when duration > 0 and totalBytes > 0.
+        // =====================================================================
+
+        [Fact]
+        public void StorageBreakdown_ValidDuration_ComputesBytesPerSecond()
+        {
+            var rec = new Recording { VesselName = "Timed" };
+            rec.Points.Add(new TrajectoryPoint { ut = 100.0 });
+            rec.Points.Add(new TrajectoryPoint { ut = 200.0 });
+
+            var bd = DiagnosticsComputation.ComputeStorageBreakdown(rec);
+
+            Assert.Equal(100.0, bd.durationSeconds);
+            // totalBytes is 0 (no files on disk in test), so bytesPerSecond is 0
+            Assert.Equal(0.0, bd.bytesPerSecond);
+            Assert.False(double.IsNaN(bd.bytesPerSecond));
+        }
+    }
+}

--- a/Source/Parsek.Tests/DiagnosticsStateTests.cs
+++ b/Source/Parsek.Tests/DiagnosticsStateTests.cs
@@ -319,4 +319,405 @@ namespace Parsek.Tests
     }
 
     #endregion
+
+    #region DiagnosticsComputation
+
+    [Collection("Sequential")]
+    public class DiagnosticsComputationTests : IDisposable
+    {
+        public DiagnosticsComputationTests()
+        {
+            ParsekLog.SuppressLogging = true;
+            RecordingStore.SuppressLogging = true;
+            DiagnosticsState.ResetForTesting();
+            DiagnosticsComputation.ResetForTesting();
+            RecordingStore.ResetForTesting();
+        }
+
+        public void Dispose()
+        {
+            DiagnosticsState.ResetForTesting();
+            DiagnosticsComputation.ResetForTesting();
+            RecordingStore.ResetForTesting();
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+        }
+
+        // --- FormatBytes ---
+
+        [Fact]
+        public void FormatBytes_Zero()
+        {
+            Assert.Equal("0 B", DiagnosticsComputation.FormatBytes(0));
+        }
+
+        [Fact]
+        public void FormatBytes_Bytes()
+        {
+            Assert.Equal("512 B", DiagnosticsComputation.FormatBytes(512));
+        }
+
+        [Fact]
+        public void FormatBytes_Kilobytes()
+        {
+            // 1536 bytes = 1.5 KB
+            Assert.Equal("1.5 KB", DiagnosticsComputation.FormatBytes(1536));
+        }
+
+        [Fact]
+        public void FormatBytes_Megabytes()
+        {
+            // 12.4 MB = 12.4 * 1024 * 1024 = 13,002,342.4 bytes
+            long bytes = (long)(12.4 * 1024 * 1024);
+            string result = DiagnosticsComputation.FormatBytes(bytes);
+            Assert.Contains("MB", result);
+            Assert.StartsWith("12.4", result);
+        }
+
+        [Fact]
+        public void FormatBytes_Gigabytes()
+        {
+            // 2.1 GB = 2.1 * 1024^3
+            long bytes = (long)(2.1 * 1024 * 1024 * 1024);
+            string result = DiagnosticsComputation.FormatBytes(bytes);
+            Assert.Contains("GB", result);
+            Assert.StartsWith("2.1", result);
+        }
+
+        // --- FormatDuration ---
+
+        [Fact]
+        public void FormatDuration_Zero()
+        {
+            Assert.Equal("0s", DiagnosticsComputation.FormatDuration(0.0));
+        }
+
+        [Fact]
+        public void FormatDuration_Seconds()
+        {
+            Assert.Equal("45s", DiagnosticsComputation.FormatDuration(45.0));
+        }
+
+        [Fact]
+        public void FormatDuration_MinutesAndSeconds()
+        {
+            // 12 * 60 + 34 = 754 seconds
+            Assert.Equal("12m 34s", DiagnosticsComputation.FormatDuration(754.0));
+        }
+
+        // --- FormatReport ---
+
+        [Fact]
+        public void FormatReport_KnownValues()
+        {
+            // Set up health counters for known values
+            DiagnosticsState.health.waypointCacheHits = 1488;
+            DiagnosticsState.health.waypointCacheMisses = 12;
+            DiagnosticsState.health.snapshotRefreshSpikes = 2;
+            DiagnosticsState.health.spawnFailures = 0;
+            DiagnosticsState.health.ghostBuildsThisSession = 14;
+            DiagnosticsState.health.gcGen0Baseline = GC.CollectionCount(0);
+
+            // Put data in the rolling buffer so it doesn't show N/A
+            DiagnosticsState.playbackFrameHistory.Append(100.0, 1800); // 1.8 ms
+            DiagnosticsState.playbackFrameHistory.Append(101.0, 3200); // 3.2 ms
+            DiagnosticsComputation.ClockSource = () => 101.0;
+
+            var bd = new StorageBreakdown
+            {
+                recordingId = "test-1",
+                vesselName = "Mun Landing",
+                totalBytes = 2 * 1024 * 1024, // 2.0 MB
+                pointCount = 8432,
+                partEventCount = 47,
+                orbitSegmentCount = 2,
+                durationSeconds = 754.0, // 12m 34s
+                bytesPerSecond = 2.0 * 1024 * 1024 / 754.0
+            };
+
+            var snap = new MetricSnapshot
+            {
+                totalStorageBytes = 12 * 1024 * 1024, // ~12.0 MB
+                recordingCount = 1,
+                perRecording = new[] { bd },
+                loadedTrajectoryPoints = 47200,
+                loadedPartEvents = 312,
+                loadedOrbitSegments = 18,
+                loadedSnapshotCount = 46,
+                estimatedMemoryBytes = 47200L * 136 + 312L * 88 + 18L * 120 + 46L * 8192,
+                activeGhostCount = 8,
+                zone1GhostCount = 3,
+                zone2GhostCount = 5,
+                lastPlaybackBudget = new FrameBudget { warpRate = 1.0f },
+                lastSaveTiming = new SaveLoadTiming { totalMilliseconds = 120, dirtyRecordingsWritten = 3 },
+                lastLoadTiming = new SaveLoadTiming { totalMilliseconds = 340, recordingsProcessed = 23 }
+            };
+
+            string report = DiagnosticsComputation.FormatReport(snap);
+
+            Assert.Contains("===== DIAGNOSTICS REPORT =====", report);
+            Assert.Contains("===== END REPORT =====", report);
+            Assert.Contains("12.0 MB total, 1 recordings", report);
+            Assert.Contains("\"Mun Landing\"", report);
+            Assert.Contains("8432 pts", report);
+            Assert.Contains("47 evts", report);
+            Assert.Contains("2 segs", report);
+            Assert.Contains("12m 34s", report);
+            Assert.Contains("47200 pts", report);
+            Assert.Contains("312 evts", report);
+            Assert.Contains("18 segs", report);
+            Assert.Contains("46 snapshots", report);
+            Assert.Contains("Ghosts: 8 active (z1:3 z2:5)", report);
+            Assert.Contains("Playback budget:", report);
+            Assert.Contains("ms avg", report);
+            Assert.Contains("ms peak", report);
+            Assert.Contains("Save: 120 ms last (3 dirty)", report);
+            Assert.Contains("Load: 340 ms last (23 total)", report);
+            Assert.Contains("cache", report);
+            Assert.Contains("GC gen0:", report);
+        }
+
+        [Fact]
+        public void FormatReport_EmptyRollingBuffer()
+        {
+            // Rolling buffer is empty by default after reset
+            var snap = new MetricSnapshot
+            {
+                perRecording = new StorageBreakdown[0]
+            };
+
+            string report = DiagnosticsComputation.FormatReport(snap);
+
+            Assert.Contains("Playback budget: N/A", report);
+        }
+
+        [Fact]
+        public void FormatReport_ZeroDuration()
+        {
+            var bd = new StorageBreakdown
+            {
+                recordingId = "zero-dur",
+                vesselName = "Zero",
+                totalBytes = 1024,
+                pointCount = 10,
+                partEventCount = 0,
+                orbitSegmentCount = 0,
+                durationSeconds = 0.0,
+                bytesPerSecond = 0.0
+            };
+
+            var snap = new MetricSnapshot
+            {
+                totalStorageBytes = 1024,
+                recordingCount = 1,
+                perRecording = new[] { bd }
+            };
+
+            string report = DiagnosticsComputation.FormatReport(snap);
+
+            // Should not contain NaN or Infinity
+            Assert.DoesNotContain("NaN", report);
+            Assert.DoesNotContain("Infinity", report);
+            // bytesPerSecond is 0.0 so formatted as "0 B/s"
+            Assert.Contains("0 B/s", report);
+            // Duration should show "0s"
+            Assert.Contains("0s", report);
+        }
+
+        [Fact]
+        public void FormatReport_NoRecordings()
+        {
+            var snap = new MetricSnapshot
+            {
+                totalStorageBytes = 0,
+                recordingCount = 0,
+                perRecording = new StorageBreakdown[0]
+            };
+
+            string report = DiagnosticsComputation.FormatReport(snap);
+
+            Assert.Contains("0 B total, 0 recordings", report);
+        }
+
+        [Fact]
+        public void MemoryEstimation_Formula()
+        {
+            // 100 pts + 10 evts + 5 segs + 2 snaps
+            // = 100*136 + 10*88 + 5*120 + 2*8192 = 13600 + 880 + 600 + 16384 = 31464
+            var rec = new Recording
+            {
+                VesselName = "TestVessel"
+            };
+            for (int i = 0; i < 100; i++)
+                rec.Points.Add(new TrajectoryPoint { ut = i });
+            for (int i = 0; i < 10; i++)
+                rec.PartEvents.Add(new PartEvent());
+            for (int i = 0; i < 5; i++)
+                rec.OrbitSegments.Add(new OrbitSegment());
+            // 2 snapshots: set VesselSnapshot + GhostVisualSnapshot (both non-null)
+            rec.VesselSnapshot = new ConfigNode("VESSEL");
+            rec.GhostVisualSnapshot = new ConfigNode("GHOST");
+
+            RecordingStore.AddCommittedForTesting(rec);
+
+            // Build a second recording with a snapshot too
+            var rec2 = new Recording { VesselName = "TestVessel2" };
+            rec2.VesselSnapshot = new ConfigNode("VESSEL2");
+            rec2.GhostVisualSnapshot = new ConfigNode("GHOST2");
+            RecordingStore.AddCommittedForTesting(rec2);
+
+            DiagnosticsComputation.ClockSource = () => 1000.0;
+            var snap = DiagnosticsComputation.ComputeSnapshot(100.0);
+
+            // 100 pts, 10 evts, 5 segs, 2 snapshots (both recordings have both snapshots)
+            long expected = 100L * 136 + 10L * 88 + 5L * 120 + 2L * 8192;
+            Assert.Equal(expected, snap.estimatedMemoryBytes);
+            Assert.Equal(100, snap.loadedTrajectoryPoints);
+            Assert.Equal(10, snap.loadedPartEvents);
+            Assert.Equal(5, snap.loadedOrbitSegments);
+            Assert.Equal(2, snap.loadedSnapshotCount);
+        }
+
+        [Fact]
+        public void CacheHitRate_ZeroLookups()
+        {
+            // Zero cache hits and misses
+            DiagnosticsState.health.waypointCacheHits = 0;
+            DiagnosticsState.health.waypointCacheMisses = 0;
+
+            var snap = new MetricSnapshot
+            {
+                perRecording = new StorageBreakdown[0]
+            };
+
+            string report = DiagnosticsComputation.FormatReport(snap);
+
+            // Should show "N/A" for hit rate, not division by zero
+            Assert.Contains("cache N/A hit", report);
+            Assert.DoesNotContain("NaN", report);
+            Assert.DoesNotContain("Infinity", report);
+        }
+
+        [Fact]
+        public void GrowthRate_ZeroElapsed()
+        {
+            // A growth rate with zero elapsed shouldn't cause NaN
+            DiagnosticsState.activeGrowthRate = new RecordingGrowthRate
+            {
+                totalPoints = 1,
+                totalEvents = 0,
+                elapsedSeconds = 0.0,
+                pointsPerSecond = 0.0,
+                eventsPerSecond = 0.0
+            };
+            DiagnosticsState.hasActiveGrowthRate = true;
+
+            var snap = new MetricSnapshot
+            {
+                perRecording = new StorageBreakdown[0]
+            };
+
+            string report = DiagnosticsComputation.FormatReport(snap);
+
+            // Should not crash or contain NaN
+            Assert.DoesNotContain("NaN", report);
+            Assert.DoesNotContain("Infinity", report);
+            // Recording budget should show "(active)" because hasActiveGrowthRate is true
+            Assert.Contains("(active)", report);
+        }
+
+        [Fact]
+        public void ComputeSnapshot_NoRecordings_Zeros()
+        {
+            // Empty RecordingStore
+            DiagnosticsComputation.ClockSource = () => 1000.0;
+            var snap = DiagnosticsComputation.ComputeSnapshot(100.0);
+
+            Assert.Equal(0, snap.recordingCount);
+            Assert.Equal(0L, snap.totalStorageBytes);
+            Assert.Equal(0, snap.loadedTrajectoryPoints);
+            Assert.Equal(0, snap.loadedPartEvents);
+            Assert.Equal(0, snap.loadedOrbitSegments);
+            Assert.Equal(0, snap.loadedSnapshotCount);
+            Assert.Equal(0L, snap.estimatedMemoryBytes);
+            Assert.NotNull(snap.perRecording);
+            Assert.Empty(snap.perRecording);
+        }
+
+        [Fact]
+        public void GetOrComputeSnapshot_ReturnsCachedWithinTTL()
+        {
+            DiagnosticsComputation.ClockSource = () => 1000.0;
+
+            // First call computes
+            var snap1 = DiagnosticsComputation.GetOrComputeSnapshot(100.0);
+            Assert.True(DiagnosticsState.hasCachedSnapshot);
+
+            // Second call within TTL (2.0s) returns cached
+            var snap2 = DiagnosticsComputation.GetOrComputeSnapshot(101.0);
+            Assert.Equal(100.0, DiagnosticsState.cachedSnapshotUT);
+
+            // Still cached because 101 - 100 = 1.0 < 2.0 TTL
+            Assert.Equal(snap1.loadedTrajectoryPoints, snap2.loadedTrajectoryPoints);
+        }
+
+        [Fact]
+        public void GetOrComputeSnapshot_RecomputesAfterTTL()
+        {
+            DiagnosticsComputation.ClockSource = () => 1000.0;
+
+            var snap1 = DiagnosticsComputation.GetOrComputeSnapshot(100.0);
+
+            // Now commit a recording
+            var rec = new Recording { VesselName = "New" };
+            for (int i = 0; i < 50; i++)
+                rec.Points.Add(new TrajectoryPoint { ut = i });
+            RecordingStore.AddCommittedForTesting(rec);
+
+            // Compute after TTL expires (100 + 2.1 > 2.0 TTL)
+            var snap2 = DiagnosticsComputation.GetOrComputeSnapshot(102.1);
+
+            // Should have recomputed with the new recording's data
+            Assert.Equal(50, snap2.loadedTrajectoryPoints);
+        }
+
+        [Fact]
+        public void FormatReport_RecordingBudget_InactiveWhenNoGrowthRate()
+        {
+            DiagnosticsState.hasActiveGrowthRate = false;
+
+            var snap = new MetricSnapshot
+            {
+                perRecording = new StorageBreakdown[0]
+            };
+
+            string report = DiagnosticsComputation.FormatReport(snap);
+            Assert.Contains("(inactive)", report);
+        }
+
+        [Fact]
+        public void FormatReport_HealthSection_WithHits()
+        {
+            DiagnosticsState.health.waypointCacheHits = 990;
+            DiagnosticsState.health.waypointCacheMisses = 10;
+            DiagnosticsState.health.snapshotRefreshSpikes = 3;
+            DiagnosticsState.health.spawnFailures = 1;
+            DiagnosticsState.health.ghostBuildsThisSession = 20;
+
+            var snap = new MetricSnapshot
+            {
+                perRecording = new StorageBreakdown[0]
+            };
+
+            string report = DiagnosticsComputation.FormatReport(snap);
+
+            Assert.Contains("cache 99.0% hit", report);
+            Assert.Contains("10 miss of 1000 lookups", report);
+            Assert.Contains("spikes 3", report);
+            Assert.Contains("spawn fail 1", report);
+            Assert.Contains("builds 20", report);
+        }
+    }
+
+    #endregion
 }

--- a/Source/Parsek.Tests/DiagnosticsStateTests.cs
+++ b/Source/Parsek.Tests/DiagnosticsStateTests.cs
@@ -316,6 +316,60 @@ namespace Parsek.Tests
             Assert.False(DiagnosticsState.hasCachedSnapshot);
             Assert.Equal(0.0, DiagnosticsState.cachedSnapshotUT);
         }
+
+        [Fact]
+        public void WaypointCache_SequentialAccess_CountsAsHit()
+        {
+            // Build a trajectory with 10 points at UT 0,1,2,...,9
+            var points = new List<TrajectoryPoint>();
+            for (int i = 0; i < 10; i++)
+                points.Add(new TrajectoryPoint { ut = i });
+
+            int cachedIndex = 0;
+
+            // Sequential lookups: UT 0.5, 1.5, 2.5, ... should all be cache hits
+            // (first call seeds the cache, subsequent calls hit cached or next-index)
+            for (int i = 0; i < 8; i++)
+            {
+                TrajectoryMath.FindWaypointIndex(points, ref cachedIndex, i + 0.5);
+            }
+
+            Assert.True(DiagnosticsState.health.waypointCacheHits > 0,
+                $"Expected cache hits > 0, got {DiagnosticsState.health.waypointCacheHits}");
+            Assert.Equal(0, DiagnosticsState.health.waypointCacheMisses);
+        }
+
+        [Fact]
+        public void WaypointCache_RandomJump_CountsAsMiss()
+        {
+            // Build a trajectory with 20 points at UT 0,1,2,...,19
+            var points = new List<TrajectoryPoint>();
+            for (int i = 0; i < 20; i++)
+                points.Add(new TrajectoryPoint { ut = i });
+
+            int cachedIndex = 0;
+
+            // First call at UT 0.5 seeds the cache (binary search = miss)
+            TrajectoryMath.FindWaypointIndex(points, ref cachedIndex, 0.5);
+
+            // Jump far away — cached index 0 won't cover UT 15.5, nor will index 1
+            TrajectoryMath.FindWaypointIndex(points, ref cachedIndex, 15.5);
+
+            Assert.True(DiagnosticsState.health.waypointCacheMisses > 0,
+                $"Expected cache misses > 0, got {DiagnosticsState.health.waypointCacheMisses}");
+        }
+
+        [Fact]
+        public void WaypointCache_Reset_ZeroesBoth()
+        {
+            DiagnosticsState.health.waypointCacheHits = 42;
+            DiagnosticsState.health.waypointCacheMisses = 7;
+
+            DiagnosticsState.health.Reset();
+
+            Assert.Equal(0, DiagnosticsState.health.waypointCacheHits);
+            Assert.Equal(0, DiagnosticsState.health.waypointCacheMisses);
+        }
     }
 
     #endregion

--- a/Source/Parsek.Tests/DiagnosticsStateTests.cs
+++ b/Source/Parsek.Tests/DiagnosticsStateTests.cs
@@ -1,0 +1,322 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    #region WarnRateLimited
+
+    [Collection("Sequential")]
+    public class WarnRateLimitedTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public WarnRateLimitedTests()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+        }
+
+        [Fact]
+        public void EmitsAtWarnLevel_EvenWhenVerboseDisabled()
+        {
+            ParsekLog.VerboseOverrideForTesting = false;
+
+            ParsekLog.WarnRateLimited("Budget", "over", "exceeded threshold", 5.0);
+
+            Assert.Single(logLines);
+            Assert.Contains("[WARN]", logLines[0]);
+            Assert.Contains("[Budget]", logLines[0]);
+            Assert.Contains("exceeded threshold", logLines[0]);
+        }
+
+        [Fact]
+        public void RateLimits_SecondCallSuppressed()
+        {
+            double now = 1000.0;
+            ParsekLog.ClockOverrideForTesting = () => now;
+
+            ParsekLog.WarnRateLimited("Budget", "cap", "over budget", 5.0);
+            now = 1001.0;
+            ParsekLog.WarnRateLimited("Budget", "cap", "over budget", 5.0);
+
+            Assert.Single(logLines);
+        }
+
+        [Fact]
+        public void EmitsAfterIntervalPasses()
+        {
+            double now = 1000.0;
+            ParsekLog.ClockOverrideForTesting = () => now;
+
+            ParsekLog.WarnRateLimited("Budget", "cap", "over budget", 2.0);
+
+            // Two suppressed calls
+            now = 1000.5;
+            ParsekLog.WarnRateLimited("Budget", "cap", "over budget", 2.0);
+            now = 1001.0;
+            ParsekLog.WarnRateLimited("Budget", "cap", "over budget", 2.0);
+
+            // Past the interval
+            now = 1002.1;
+            ParsekLog.WarnRateLimited("Budget", "cap", "over budget", 2.0);
+
+            Assert.Equal(2, logLines.Count);
+            Assert.Contains("[WARN]", logLines[0]);
+            Assert.DoesNotContain("suppressed", logLines[0]);
+            Assert.Contains("[WARN]", logLines[1]);
+            Assert.Contains("suppressed=2", logLines[1]);
+        }
+
+        [Fact]
+        public void DifferentKeys_IndependentRateLimiting()
+        {
+            double now = 1000.0;
+            ParsekLog.ClockOverrideForTesting = () => now;
+
+            ParsekLog.WarnRateLimited("Budget", "a", "warning A", 5.0);
+            ParsekLog.WarnRateLimited("Budget", "b", "warning B", 5.0);
+
+            Assert.Equal(2, logLines.Count);
+            Assert.Contains("warning A", logLines[0]);
+            Assert.Contains("warning B", logLines[1]);
+        }
+    }
+
+    #endregion
+
+    #region RollingTimingBuffer
+
+    public class RollingTimingBufferTests
+    {
+        [Fact]
+        public void Append_SingleEntry_CountIsOne()
+        {
+            var buf = new RollingTimingBuffer();
+
+            buf.Append(1.0, 500);
+
+            Assert.Equal(1, buf.Count);
+            Assert.False(buf.IsEmpty);
+        }
+
+        [Fact]
+        public void ComputeStats_KnownSequence()
+        {
+            var buf = new RollingTimingBuffer();
+            // Append [1000, 2000, 3000, 1500, 2500] microseconds at timestamps 0-4
+            buf.Append(0.0, 1000);
+            buf.Append(1.0, 2000);
+            buf.Append(2.0, 3000);
+            buf.Append(3.0, 1500);
+            buf.Append(4.0, 2500);
+
+            buf.ComputeStats(4.0, 10.0, out double avgMs, out double peakMs, out double window);
+
+            // avg = (1000+2000+3000+1500+2500)/5 = 10000/5 = 2000 microseconds = 2.0 ms
+            Assert.Equal(2.0, avgMs, 6);
+            // peak = 3000 microseconds = 3.0 ms
+            Assert.Equal(3.0, peakMs, 6);
+            // window = 4.0 - 0.0 = 4.0
+            Assert.Equal(4.0, window, 6);
+        }
+
+        [Fact]
+        public void ComputeStats_WindowEviction()
+        {
+            var buf = new RollingTimingBuffer();
+            // Append entries at t=0,1,2,3,4,5,6 with 100us each
+            for (int i = 0; i <= 6; i++)
+                buf.Append(i, 100);
+
+            // Compute with window=3s at t=6 => windowStart=3.0
+            // Only entries at t=3,4,5,6 should be included (4 entries)
+            buf.ComputeStats(6.0, 3.0, out double avgMs, out double peakMs, out double window);
+
+            // avg = 100us = 0.1ms for all entries
+            Assert.Equal(0.1, avgMs, 6);
+            Assert.Equal(0.1, peakMs, 6);
+            // window = 6.0 - 3.0 = 3.0
+            Assert.Equal(3.0, window, 6);
+        }
+
+        [Fact]
+        public void ComputeStats_EmptyBuffer()
+        {
+            var buf = new RollingTimingBuffer();
+
+            buf.ComputeStats(5.0, 10.0, out double avgMs, out double peakMs, out double window);
+
+            Assert.Equal(0.0, avgMs);
+            Assert.Equal(0.0, peakMs);
+            Assert.Equal(0.0, window);
+        }
+
+        [Fact]
+        public void Reset_ClearsBuffer()
+        {
+            var buf = new RollingTimingBuffer();
+            buf.Append(1.0, 100);
+            buf.Append(2.0, 200);
+
+            buf.Reset();
+
+            Assert.True(buf.IsEmpty);
+            Assert.Equal(0, buf.Count);
+        }
+
+        [Fact]
+        public void Append_FullBuffer_OverwritesOldest()
+        {
+            var buf = new RollingTimingBuffer();
+
+            // Fill all 1024 entries
+            for (int i = 0; i < 1024; i++)
+                buf.Append(i, 100);
+
+            Assert.Equal(1024, buf.Count);
+
+            // One more — should overwrite oldest, count stays 1024
+            buf.Append(1024, 9999);
+            Assert.Equal(1024, buf.Count);
+
+            // Verify the newest entry is included in stats
+            buf.ComputeStats(1024, 0.5, out double avgMs, out double peakMs, out _);
+            // Only entry at t=1024 (within 0.5s window from 1024)
+            Assert.Equal(9.999, peakMs, 3); // 9999 us = 9.999 ms
+        }
+    }
+
+    #endregion
+
+    #region HealthCounters
+
+    public class HealthCountersTests
+    {
+        [Fact]
+        public void Reset_ZerosAllFields()
+        {
+            var h = new HealthCounters();
+            h.waypointCacheHits = 10;
+            h.waypointCacheMisses = 5;
+            h.snapshotRefreshSpikes = 3;
+            h.spawnFailures = 2;
+            h.spawnRetries = 1;
+            h.softCapActivations = 4;
+            h.softCapDespawns = 2;
+            h.ghostBuildsThisSession = 7;
+            h.ghostDestroysThisSession = 6;
+
+            h.Reset();
+
+            Assert.Equal(0, h.waypointCacheHits);
+            Assert.Equal(0, h.waypointCacheMisses);
+            Assert.Equal(0, h.snapshotRefreshSpikes);
+            Assert.Equal(0, h.spawnFailures);
+            Assert.Equal(0, h.spawnRetries);
+            Assert.Equal(0, h.softCapActivations);
+            Assert.Equal(0, h.softCapDespawns);
+            Assert.Equal(0, h.ghostBuildsThisSession);
+            Assert.Equal(0, h.ghostDestroysThisSession);
+            // gcGen0Baseline should be set to current GC count, not zero
+            Assert.Equal(GC.CollectionCount(0), h.gcGen0Baseline);
+        }
+    }
+
+    #endregion
+
+    #region DiagnosticsState
+
+    [Collection("Sequential")]
+    public class DiagnosticsStateTests : IDisposable
+    {
+        public DiagnosticsStateTests()
+        {
+            ParsekLog.SuppressLogging = true;
+            DiagnosticsState.ResetForTesting();
+        }
+
+        public void Dispose()
+        {
+            DiagnosticsState.ResetForTesting();
+            ParsekLog.ResetTestOverrides();
+        }
+
+        [Fact]
+        public void ResetSessionCounters_ClearsEverything()
+        {
+            // Set various fields to non-default values
+            DiagnosticsState.health.waypointCacheHits = 50;
+            DiagnosticsState.health.spawnFailures = 3;
+            DiagnosticsState.playbackFrameHistory.Append(1.0, 500);
+            DiagnosticsState.playbackFrameHistory.Append(2.0, 600);
+            DiagnosticsState.playbackBudget = new FrameBudget { totalMicroseconds = 999 };
+            DiagnosticsState.recordingBudget = new FrameBudget { ghostsProcessed = 5 };
+            DiagnosticsState.hasCachedSnapshot = true;
+
+            DiagnosticsState.ResetSessionCounters();
+
+            // Health counters are zeroed (except gcGen0Baseline)
+            Assert.Equal(0, DiagnosticsState.health.waypointCacheHits);
+            Assert.Equal(0, DiagnosticsState.health.spawnFailures);
+            Assert.Equal(GC.CollectionCount(0), DiagnosticsState.health.gcGen0Baseline);
+
+            // Rolling buffer is empty
+            Assert.True(DiagnosticsState.playbackFrameHistory.IsEmpty);
+
+            // Frame budgets are default
+            Assert.Equal(0, DiagnosticsState.playbackBudget.totalMicroseconds);
+            Assert.Equal(0, DiagnosticsState.recordingBudget.ghostsProcessed);
+
+            // Snapshot cache invalidated
+            Assert.False(DiagnosticsState.hasCachedSnapshot);
+        }
+
+        [Fact]
+        public void ResetForTesting_ClearsAllState()
+        {
+            // Set everything to non-default
+            DiagnosticsState.health.ghostBuildsThisSession = 10;
+            DiagnosticsState.playbackFrameHistory.Append(1.0, 100);
+            DiagnosticsState.activeGrowthRate = new RecordingGrowthRate { totalPoints = 42 };
+            DiagnosticsState.hasActiveGrowthRate = true;
+            DiagnosticsState.hasCachedSnapshot = true;
+            DiagnosticsState.cachedSnapshotUT = 999.0;
+            DiagnosticsState.storageBreakdownCache["test"] = (new StorageBreakdown(), 1.0);
+            DiagnosticsState.avgBytesPerPoint = 200.0;
+
+            DiagnosticsState.ResetForTesting();
+
+            // All fields back to defaults
+            Assert.Equal(0, DiagnosticsState.health.ghostBuildsThisSession);
+            Assert.True(DiagnosticsState.playbackFrameHistory.IsEmpty);
+            Assert.Equal(0, DiagnosticsState.activeGrowthRate.totalPoints);
+            Assert.False(DiagnosticsState.hasActiveGrowthRate);
+            Assert.False(DiagnosticsState.hasCachedSnapshot);
+            Assert.Equal(0.0, DiagnosticsState.cachedSnapshotUT);
+            Assert.Empty(DiagnosticsState.storageBreakdownCache);
+            Assert.Equal(85.0, DiagnosticsState.avgBytesPerPoint);
+        }
+
+        [Fact]
+        public void InvalidateSnapshotCache_ClearsFlag()
+        {
+            DiagnosticsState.hasCachedSnapshot = true;
+            DiagnosticsState.cachedSnapshotUT = 500.0;
+
+            DiagnosticsState.InvalidateSnapshotCache();
+
+            Assert.False(DiagnosticsState.hasCachedSnapshot);
+            Assert.Equal(0.0, DiagnosticsState.cachedSnapshotUT);
+        }
+    }
+
+    #endregion
+}

--- a/Source/Parsek.Tests/ObservabilityLoggingTests.cs
+++ b/Source/Parsek.Tests/ObservabilityLoggingTests.cs
@@ -1,0 +1,351 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Log assertion tests for observability instrumentation.
+    /// Verifies that the correct log lines are emitted at the correct levels
+    /// for budget threshold warnings, scene load snapshots, and diagnostics reports.
+    /// </summary>
+    [Collection("Sequential")]
+    public class ObservabilityLoggingTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public ObservabilityLoggingTests()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+            ParsekLog.VerboseOverrideForTesting = true;
+            DiagnosticsState.ResetForTesting();
+            DiagnosticsComputation.ResetForTesting();
+            RecordingStore.SuppressLogging = false;
+            RecordingStore.ResetForTesting();
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+            RecordingStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+            DiagnosticsState.ResetForTesting();
+            DiagnosticsComputation.ResetForTesting();
+        }
+
+        #region Playback Budget Threshold
+
+        [Fact]
+        public void PlaybackBudgetWarning_AboveThreshold_EmitsWarn()
+        {
+            // 10ms > 8ms threshold
+            DiagnosticsComputation.CheckPlaybackBudgetThreshold(10000, 5, 1.0f);
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[WARN]") &&
+                l.Contains("[Diagnostics]") &&
+                l.Contains("Playback frame budget exceeded"));
+        }
+
+        [Fact]
+        public void PlaybackBudgetWarning_AboveThreshold_IncludesGhostCountAndWarp()
+        {
+            DiagnosticsComputation.CheckPlaybackBudgetThreshold(12000, 7, 4.0f);
+
+            var warnLine = logLines.FirstOrDefault(l =>
+                l.Contains("[WARN]") && l.Contains("Playback frame budget exceeded"));
+            Assert.NotNull(warnLine);
+            Assert.Contains("7 ghosts", warnLine);
+            Assert.Contains("warp: 4x", warnLine);
+            Assert.Contains("12.0ms", warnLine);
+        }
+
+        [Fact]
+        public void PlaybackBudgetWarning_BelowThreshold_NoWarn()
+        {
+            // 3ms < 8ms threshold
+            DiagnosticsComputation.CheckPlaybackBudgetThreshold(3000, 2, 1.0f);
+
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("[WARN]") && l.Contains("Playback frame budget exceeded"));
+        }
+
+        [Fact]
+        public void PlaybackBudgetWarning_ExactlyAtThreshold_NoWarn()
+        {
+            // 8.0ms is not > 8.0ms, so no warning
+            DiagnosticsComputation.CheckPlaybackBudgetThreshold(8000, 3, 1.0f);
+
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("[WARN]") && l.Contains("Playback frame budget exceeded"));
+        }
+
+        #endregion
+
+        #region Recording Budget Threshold
+
+        [Fact]
+        public void RecordingBudgetWarning_AboveThreshold_EmitsWarn()
+        {
+            // 5ms > 4ms threshold
+            DiagnosticsComputation.CheckRecordingBudgetThreshold(5000, "TestRocket");
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[WARN]") &&
+                l.Contains("[Diagnostics]") &&
+                l.Contains("Recording frame exceeded budget"));
+        }
+
+        [Fact]
+        public void RecordingBudgetWarning_AboveThreshold_IncludesVesselName()
+        {
+            DiagnosticsComputation.CheckRecordingBudgetThreshold(6000, "Mun Lander");
+
+            var warnLine = logLines.FirstOrDefault(l =>
+                l.Contains("[WARN]") && l.Contains("Recording frame exceeded budget"));
+            Assert.NotNull(warnLine);
+            Assert.Contains("Mun Lander", warnLine);
+            Assert.Contains("6.00ms", warnLine);
+        }
+
+        [Fact]
+        public void RecordingBudgetWarning_BelowThreshold_NoWarn()
+        {
+            // 2ms < 4ms threshold
+            DiagnosticsComputation.CheckRecordingBudgetThreshold(2000, "TestRocket");
+
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("[WARN]") && l.Contains("Recording frame exceeded budget"));
+        }
+
+        [Fact]
+        public void RecordingBudgetWarning_NullVesselName_NoException()
+        {
+            DiagnosticsComputation.CheckRecordingBudgetThreshold(5000, null);
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[WARN]") && l.Contains("Recording frame exceeded budget"));
+        }
+
+        #endregion
+
+        #region Scene Load Snapshot
+
+        [Fact]
+        public void SceneLoadSnapshot_EmitsVerbose_WithCounts()
+        {
+            // Add some committed recordings with data
+            var rec = new Recording { VesselName = "TestVessel" };
+            for (int i = 0; i < 50; i++)
+                rec.Points.Add(new TrajectoryPoint { ut = i });
+            for (int i = 0; i < 5; i++)
+                rec.PartEvents.Add(new PartEvent());
+            RecordingStore.AddCommittedForTesting(rec);
+
+            DiagnosticsComputation.EmitSceneLoadSnapshot(1, "FLIGHT");
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[VERBOSE]") &&
+                l.Contains("[Diagnostics]") &&
+                l.Contains("Scene load complete (FLIGHT)"));
+
+            var snapLine = logLines.FirstOrDefault(l =>
+                l.Contains("Scene load complete"));
+            Assert.NotNull(snapLine);
+            Assert.Contains("1 recordings", snapLine);
+            Assert.Contains("50 pts", snapLine);
+            Assert.Contains("5 evts", snapLine);
+        }
+
+        [Fact]
+        public void SceneLoadSnapshot_NoRecordings_EmitsZeros()
+        {
+            DiagnosticsComputation.EmitSceneLoadSnapshot(0, "SPACECENTER");
+
+            var snapLine = logLines.FirstOrDefault(l =>
+                l.Contains("Scene load complete"));
+            Assert.NotNull(snapLine);
+            Assert.Contains("0 recordings", snapLine);
+            Assert.Contains("0 pts", snapLine);
+            Assert.Contains("0 B memory est", snapLine);
+        }
+
+        [Fact]
+        public void SceneLoadSnapshot_IncludesGhostCount()
+        {
+            // Ghost count comes from playbackBudget.ghostsProcessed
+            DiagnosticsState.playbackBudget.ghostsProcessed = 3;
+
+            DiagnosticsComputation.EmitSceneLoadSnapshot(0, "FLIGHT");
+
+            var snapLine = logLines.FirstOrDefault(l =>
+                l.Contains("Scene load complete"));
+            Assert.NotNull(snapLine);
+            Assert.Contains("3 ghosts", snapLine);
+        }
+
+        [Fact]
+        public void SceneLoadSnapshot_NullSceneName_ShowsQuestionMark()
+        {
+            DiagnosticsComputation.EmitSceneLoadSnapshot(0, null);
+
+            var snapLine = logLines.FirstOrDefault(l =>
+                l.Contains("Scene load complete"));
+            Assert.NotNull(snapLine);
+            Assert.Contains("(?)", snapLine);
+        }
+
+        #endregion
+
+        #region FormatReport All Sections Present
+
+        [Fact]
+        public void FormatReport_AllSectionsPresent()
+        {
+            // Set up known state
+            DiagnosticsState.health.waypointCacheHits = 100;
+            DiagnosticsState.health.waypointCacheMisses = 5;
+            DiagnosticsState.health.ghostBuildsThisSession = 10;
+            DiagnosticsState.playbackFrameHistory.Append(100.0, 2000);
+            DiagnosticsComputation.ClockSource = () => 100.0;
+
+            var snap = new MetricSnapshot
+            {
+                totalStorageBytes = 1024 * 1024,
+                recordingCount = 2,
+                perRecording = new[]
+                {
+                    new StorageBreakdown
+                    {
+                        recordingId = "a", vesselName = "Alpha",
+                        totalBytes = 512 * 1024, pointCount = 100,
+                        partEventCount = 10, orbitSegmentCount = 1,
+                        durationSeconds = 60.0, bytesPerSecond = 512 * 1024 / 60.0
+                    },
+                    new StorageBreakdown
+                    {
+                        recordingId = "b", vesselName = "Beta",
+                        totalBytes = 512 * 1024, pointCount = 200,
+                        partEventCount = 20, orbitSegmentCount = 2,
+                        durationSeconds = 120.0, bytesPerSecond = 512 * 1024 / 120.0
+                    }
+                },
+                loadedTrajectoryPoints = 300,
+                loadedPartEvents = 30,
+                loadedOrbitSegments = 3,
+                loadedSnapshotCount = 4,
+                estimatedMemoryBytes = 300L * 136 + 30L * 88 + 3L * 120 + 4L * 8192,
+                activeGhostCount = 5,
+                zone1GhostCount = 2,
+                zone2GhostCount = 3,
+                lastPlaybackBudget = new FrameBudget { warpRate = 1.0f },
+                lastSaveTiming = new SaveLoadTiming { totalMilliseconds = 50, dirtyRecordingsWritten = 1 },
+                lastLoadTiming = new SaveLoadTiming { totalMilliseconds = 100, recordingsProcessed = 2 }
+            };
+
+            string report = DiagnosticsComputation.FormatReport(snap);
+
+            // All required sections
+            Assert.Contains("===== DIAGNOSTICS REPORT =====", report);
+            Assert.Contains("===== END REPORT =====", report);
+            Assert.Contains("Storage:", report);
+            Assert.Contains("Memory:", report);
+            Assert.Contains("Ghosts:", report);
+            Assert.Contains("Playback budget:", report);
+            Assert.Contains("Recording budget:", report);
+            Assert.Contains("Save:", report);
+            Assert.Contains("Load:", report);
+            Assert.Contains("Health:", report);
+            Assert.Contains("GC gen0:", report);
+        }
+
+        #endregion
+
+        #region WarnRateLimited Suppression
+
+        [Fact]
+        public void WarnRateLimited_RespectsInterval_SecondCallSuppressed()
+        {
+            double now = 5000.0;
+            ParsekLog.ClockOverrideForTesting = () => now;
+
+            // First call emits
+            ParsekLog.WarnRateLimited("Test", "key1", "budget warning", 30.0);
+            Assert.Single(logLines);
+            Assert.Contains("[WARN]", logLines[0]);
+
+            // Second call within 30s is suppressed
+            now = 5010.0;
+            ParsekLog.WarnRateLimited("Test", "key1", "budget warning", 30.0);
+            Assert.Single(logLines); // still only 1 line
+
+            // Third call after 30s emits again
+            now = 5031.0;
+            ParsekLog.WarnRateLimited("Test", "key1", "budget warning", 30.0);
+            Assert.Equal(2, logLines.Count);
+            Assert.Contains("suppressed=1", logLines[1]);
+        }
+
+        #endregion
+
+        #region Recording Growth Rate Logging
+
+        [Fact]
+        public void RecordingGrowthRate_FormatMatchesExpected()
+        {
+            // Simulate what FinalizeRecordingState logs
+            var gr = new RecordingGrowthRate
+            {
+                totalPoints = 500,
+                totalEvents = 25,
+                elapsedSeconds = 30.0,
+                pointsPerSecond = 500.0 / 30.0,
+                eventsPerSecond = 25.0 / 30.0,
+                estimatedFinalBytes = 42500
+            };
+
+            ParsekLog.Verbose("Diagnostics",
+                string.Format(System.Globalization.CultureInfo.InvariantCulture,
+                    "Recording growth rate at stop: {0} points, {1} events, {2:F1}s elapsed, " +
+                    "{3:F2} pts/s, {4:F2} evts/s, est {5} bytes",
+                    gr.totalPoints, gr.totalEvents, gr.elapsedSeconds,
+                    gr.pointsPerSecond, gr.eventsPerSecond, gr.estimatedFinalBytes));
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[VERBOSE]") &&
+                l.Contains("[Diagnostics]") &&
+                l.Contains("Recording growth rate at stop"));
+
+            var growthLine = logLines.FirstOrDefault(l =>
+                l.Contains("Recording growth rate at stop"));
+            Assert.NotNull(growthLine);
+            Assert.Contains("500 points", growthLine);
+            Assert.Contains("25 events", growthLine);
+            Assert.Contains("30.0s elapsed", growthLine);
+            Assert.Contains("pts/s", growthLine);
+            Assert.Contains("evts/s", growthLine);
+        }
+
+        #endregion
+
+        #region Budget Threshold Constants
+
+        [Fact]
+        public void PlaybackBudgetThreshold_Is8ms()
+        {
+            Assert.Equal(8.0, DiagnosticsComputation.PlaybackBudgetThresholdMs);
+        }
+
+        [Fact]
+        public void RecordingBudgetThreshold_Is4ms()
+        {
+            Assert.Equal(4.0, DiagnosticsComputation.RecordingBudgetThresholdMs);
+        }
+
+        #endregion
+    }
+}

--- a/Source/Parsek.Tests/PositionFormatTests.cs
+++ b/Source/Parsek.Tests/PositionFormatTests.cs
@@ -1,0 +1,157 @@
+using Xunit;
+
+namespace Parsek.Tests
+{
+    public class PositionFormatTests
+    {
+        [Fact]
+        public void FormatStartPosition_LaunchSiteAndBody()
+        {
+            var rec = new Recording
+            {
+                LaunchSiteName = "LaunchPad",
+                StartBiome = "Shores",
+                StartBodyName = "Kerbin"
+            };
+            Assert.Equal("LaunchPad, Kerbin", RecordingsTableUI.FormatStartPosition(rec));
+        }
+
+        [Fact]
+        public void FormatStartPosition_LaunchSiteOnly_WhenNoBody()
+        {
+            var rec = new Recording { LaunchSiteName = "LaunchPad" };
+            Assert.Equal("LaunchPad", RecordingsTableUI.FormatStartPosition(rec));
+        }
+
+        [Fact]
+        public void FormatStartPosition_BiomeAndBody_WhenNoLaunchSite()
+        {
+            var rec = new Recording
+            {
+                StartBiome = "Highlands",
+                StartBodyName = "Mun"
+            };
+            Assert.Equal("Highlands, Mun", RecordingsTableUI.FormatStartPosition(rec));
+        }
+
+        [Fact]
+        public void FormatStartPosition_BodyOnly_WhenNoBiome()
+        {
+            var rec = new Recording { StartBodyName = "Kerbin" };
+            Assert.Equal("Kerbin", RecordingsTableUI.FormatStartPosition(rec));
+        }
+
+        [Fact]
+        public void FormatStartPosition_Dash_WhenEmpty()
+        {
+            var rec = new Recording();
+            Assert.Equal("-", RecordingsTableUI.FormatStartPosition(rec));
+        }
+
+        [Fact]
+        public void FormatEndPosition_Orbiting_WithBody()
+        {
+            var rec = new Recording
+            {
+                TerminalStateValue = TerminalState.Orbiting,
+                TerminalOrbitBody = "Mun"
+            };
+            Assert.Equal("Orbiting Mun", RecordingsTableUI.FormatEndPosition(rec));
+        }
+
+        [Fact]
+        public void FormatEndPosition_Docked_WithBody()
+        {
+            var rec = new Recording
+            {
+                TerminalStateValue = TerminalState.Docked,
+                TerminalOrbitBody = "Kerbin"
+            };
+            Assert.Equal("Docked, Kerbin", RecordingsTableUI.FormatEndPosition(rec));
+        }
+
+        [Fact]
+        public void FormatEndPosition_Landed_BiomeAndBody()
+        {
+            var rec = new Recording
+            {
+                TerminalStateValue = TerminalState.Landed,
+                EndBiome = "Midlands",
+                TerminalOrbitBody = "Mun"
+            };
+            Assert.Equal("Midlands, Mun", RecordingsTableUI.FormatEndPosition(rec));
+        }
+
+        [Fact]
+        public void FormatEndPosition_Splashed_BodyOnly()
+        {
+            var rec = new Recording
+            {
+                TerminalStateValue = TerminalState.Splashed,
+                StartBodyName = "Kerbin"
+            };
+            Assert.Equal("Kerbin", RecordingsTableUI.FormatEndPosition(rec));
+        }
+
+        [Fact]
+        public void FormatEndPosition_Destroyed_WithBody()
+        {
+            var rec = new Recording
+            {
+                TerminalStateValue = TerminalState.Destroyed,
+                StartBodyName = "Kerbin"
+            };
+            Assert.Equal("Destroyed, Kerbin", RecordingsTableUI.FormatEndPosition(rec));
+        }
+
+        [Fact]
+        public void FormatEndPosition_SubOrbital_NoBody()
+        {
+            var rec = new Recording
+            {
+                TerminalStateValue = TerminalState.SubOrbital
+            };
+            Assert.Equal("SubOrbital", RecordingsTableUI.FormatEndPosition(rec));
+        }
+
+        [Fact]
+        public void FormatEndPosition_NoTerminalState_ReturnsDash()
+        {
+            var rec = new Recording();
+            Assert.Equal("-", RecordingsTableUI.FormatEndPosition(rec));
+        }
+
+        [Fact]
+        public void FormatEndPosition_Landed_FallsBackToStartBody()
+        {
+            var rec = new Recording
+            {
+                TerminalStateValue = TerminalState.Landed,
+                EndBiome = "Shores",
+                StartBodyName = "Kerbin"
+            };
+            Assert.Equal("Shores, Kerbin", RecordingsTableUI.FormatEndPosition(rec));
+        }
+
+        [Fact]
+        public void FormatEndPosition_Boarded_IgnoresBody()
+        {
+            var rec = new Recording
+            {
+                TerminalStateValue = TerminalState.Boarded,
+                StartBodyName = "Kerbin"
+            };
+            Assert.Equal("Boarded", RecordingsTableUI.FormatEndPosition(rec));
+        }
+
+        [Fact]
+        public void FormatEndPosition_Orbiting_NoBody()
+        {
+            var rec = new Recording
+            {
+                TerminalStateValue = TerminalState.Orbiting
+            };
+            Assert.Equal("Orbiting", RecordingsTableUI.FormatEndPosition(rec));
+        }
+    }
+}

--- a/Source/Parsek/Diagnostics/DiagnosticsComputation.cs
+++ b/Source/Parsek/Diagnostics/DiagnosticsComputation.cs
@@ -393,13 +393,14 @@ namespace Parsek
                 hitRateStr = "N/A";
             }
             sb.AppendFormat(Inv,
-                "Health: cache {0} hit ({1} miss of {2} lookups), spikes {3}, spawn fail {4}, builds {5}",
+                "Health: cache {0} hit ({1} miss of {2} lookups), spikes {3}, spawn fail {4}, builds {5} destroys {6}",
                 hitRateStr,
                 h.waypointCacheMisses,
                 totalLookups,
                 h.snapshotRefreshSpikes,
                 h.spawnFailures,
-                h.ghostBuildsThisSession);
+                h.ghostBuildsThisSession,
+                h.ghostDestroysThisSession);
             sb.AppendLine();
 
             // GC gen0

--- a/Source/Parsek/Diagnostics/DiagnosticsComputation.cs
+++ b/Source/Parsek/Diagnostics/DiagnosticsComputation.cs
@@ -1,0 +1,457 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Text;
+
+namespace Parsek
+{
+    /// <summary>
+    /// Computes diagnostics metrics and formats the human-readable diagnostics report.
+    /// All methods are static. File-system access is on-demand only (never per-frame).
+    /// All numeric formatting uses InvariantCulture.
+    /// </summary>
+    internal static class DiagnosticsComputation
+    {
+        /// <summary>
+        /// Clock source for wall-time in ComputeStats calls.
+        /// Defaults to DateTime.UtcNow ticks. Override in tests for deterministic time.
+        /// </summary>
+        internal static Func<double> ClockSource;
+
+        private static readonly CultureInfo Inv = CultureInfo.InvariantCulture;
+
+        private static double GetWallTimestamp()
+        {
+            if (ClockSource != null)
+                return ClockSource();
+
+            // Fallback: use DateTime since we can't rely on UnityEngine.Time in tests
+            return (DateTime.UtcNow - new DateTime(1970, 1, 1)).TotalSeconds;
+        }
+
+        // ------------------------------------------------------------------
+        // FormatBytes
+        // ------------------------------------------------------------------
+
+        /// <summary>
+        /// Formats a byte count as a human-readable string: "0 B", "1.2 KB", "3.4 MB", "5.6 GB".
+        /// 1 KB = 1024 bytes. Uses InvariantCulture.
+        /// </summary>
+        internal static string FormatBytes(long bytes)
+        {
+            if (bytes < 0) bytes = 0;
+
+            if (bytes < 1024L)
+                return string.Format(Inv, "{0} B", bytes);
+
+            if (bytes < 1024L * 1024L)
+                return string.Format(Inv, "{0:F1} KB", bytes / 1024.0);
+
+            if (bytes < 1024L * 1024L * 1024L)
+                return string.Format(Inv, "{0:F1} MB", bytes / (1024.0 * 1024.0));
+
+            return string.Format(Inv, "{0:F1} GB", bytes / (1024.0 * 1024.0 * 1024.0));
+        }
+
+        // ------------------------------------------------------------------
+        // FormatDuration
+        // ------------------------------------------------------------------
+
+        /// <summary>
+        /// Formats seconds as "12m 34s". Zero or negative durations return "0s".
+        /// </summary>
+        internal static string FormatDuration(double seconds)
+        {
+            if (seconds <= 0.0 || double.IsNaN(seconds) || double.IsInfinity(seconds))
+                return "0s";
+
+            int totalSec = (int)Math.Floor(seconds);
+            int m = totalSec / 60;
+            int s = totalSec % 60;
+
+            if (m > 0)
+                return string.Format(Inv, "{0}m {1:D2}s", m, s);
+
+            return string.Format(Inv, "{0}s", s);
+        }
+
+        // ------------------------------------------------------------------
+        // ComputeStorageBreakdown
+        // ------------------------------------------------------------------
+
+        /// <summary>
+        /// Computes per-recording storage breakdown by stat-ing sidecar files on disk.
+        /// IMPORTANT: accesses file system. Call on-demand only, never per-frame.
+        /// </summary>
+        internal static StorageBreakdown ComputeStorageBreakdown(Recording rec)
+        {
+            var bd = new StorageBreakdown();
+            if (rec == null) return bd;
+
+            bd.recordingId = rec.RecordingId ?? "";
+            bd.vesselName = rec.VesselName ?? "";
+            bd.pointCount = rec.Points != null ? rec.Points.Count : 0;
+            bd.partEventCount = rec.PartEvents != null ? rec.PartEvents.Count : 0;
+            bd.orbitSegmentCount = rec.OrbitSegments != null ? rec.OrbitSegments.Count : 0;
+            bd.durationSeconds = rec.EndUT - rec.StartUT;
+            if (bd.durationSeconds < 0.0 || double.IsNaN(bd.durationSeconds))
+                bd.durationSeconds = 0.0;
+
+            // Resolve file paths via RecordingPaths
+            string precPath = SafeResolvePath(RecordingPaths.BuildTrajectoryRelativePath(rec.RecordingId));
+            string vesselPath = SafeResolvePath(RecordingPaths.BuildVesselSnapshotRelativePath(rec.RecordingId));
+            string ghostPath = SafeResolvePath(RecordingPaths.BuildGhostSnapshotRelativePath(rec.RecordingId));
+            string geomPath = SafeResolvePath(RecordingPaths.BuildGhostGeometryRelativePath(rec.RecordingId));
+
+            bd.trajectoryFileBytes = SafeGetFileSize(precPath);
+            bd.vesselSnapshotBytes = SafeGetFileSize(vesselPath);
+            bd.ghostSnapshotBytes = SafeGetFileSize(ghostPath);
+            bd.geometryFileBytes = SafeGetFileSize(geomPath);
+            bd.totalBytes = bd.trajectoryFileBytes + bd.vesselSnapshotBytes
+                          + bd.ghostSnapshotBytes + bd.geometryFileBytes;
+
+            bd.bytesPerSecond = bd.durationSeconds > 0.0
+                ? bd.totalBytes / bd.durationSeconds
+                : 0.0;
+
+            return bd;
+        }
+
+        /// <summary>
+        /// Resolves a relative recording path to an absolute path.
+        /// Returns null if KSP context is unavailable (e.g., in unit tests).
+        /// </summary>
+        private static string SafeResolvePath(string relativePath)
+        {
+            try
+            {
+                return RecordingPaths.ResolveSaveScopedPath(relativePath);
+            }
+            catch
+            {
+                // KSPUtil / HighLogic may not be available in tests
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Gets file size in bytes. Returns 0 if file doesn't exist or path is null.
+        /// Logs a warning for missing files when path is non-null.
+        /// </summary>
+        private static long SafeGetFileSize(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+                return 0;
+
+            try
+            {
+                var fi = new FileInfo(path);
+                if (!fi.Exists)
+                {
+                    ParsekLog.Warn("Diagnostics", $"Missing sidecar file during storage scan: {path}");
+                    return 0;
+                }
+                return fi.Length;
+            }
+            catch (Exception ex)
+            {
+                ParsekLog.Warn("Diagnostics", $"Error reading file size for '{path}': {ex.Message}");
+                return 0;
+            }
+        }
+
+        // ------------------------------------------------------------------
+        // GetCachedStorageBreakdown
+        // ------------------------------------------------------------------
+
+        /// <summary>
+        /// Returns cached StorageBreakdown if within 5s TTL, otherwise computes and caches.
+        /// </summary>
+        internal static StorageBreakdown GetCachedStorageBreakdown(Recording rec, double currentUT)
+        {
+            if (rec == null) return default;
+
+            string id = rec.RecordingId ?? "";
+            if (DiagnosticsState.storageBreakdownCache.TryGetValue(id, out var cached))
+            {
+                if ((currentUT - cached.cachedUT) < DiagnosticsState.StorageBreakdownCacheTtlSeconds)
+                    return cached.breakdown;
+            }
+
+            var bd = ComputeStorageBreakdown(rec);
+            DiagnosticsState.storageBreakdownCache[id] = (bd, currentUT);
+            return bd;
+        }
+
+        // ------------------------------------------------------------------
+        // ComputeSnapshot
+        // ------------------------------------------------------------------
+
+        /// <summary>
+        /// Computes a full MetricSnapshot from current system state.
+        /// Safe to call when systems are partially unavailable (tests, early startup).
+        /// </summary>
+        internal static MetricSnapshot ComputeSnapshot(double currentUT)
+        {
+            var snap = new MetricSnapshot();
+
+            // --- Storage + Memory: iterate committed recordings ---
+            var recordings = RecordingStore.CommittedRecordings;
+            int recCount = recordings != null ? recordings.Count : 0;
+            snap.recordingCount = recCount;
+
+            var breakdowns = new StorageBreakdown[recCount];
+            long totalStorage = 0;
+            int totalPts = 0, totalEvts = 0, totalSegs = 0, totalSnaps = 0;
+
+            for (int i = 0; i < recCount; i++)
+            {
+                var rec = recordings[i];
+                if (rec == null) continue;
+
+                // Storage breakdown (cached per-recording)
+                breakdowns[i] = GetCachedStorageBreakdown(rec, currentUT);
+                totalStorage += breakdowns[i].totalBytes;
+
+                // Memory counts
+                totalPts += rec.Points != null ? rec.Points.Count : 0;
+                totalEvts += rec.PartEvents != null ? rec.PartEvents.Count : 0;
+                totalSegs += rec.OrbitSegments != null ? rec.OrbitSegments.Count : 0;
+
+                // Snapshot count: recordings with non-null VesselSnapshot AND GhostVisualSnapshot
+                if (rec.VesselSnapshot != null && rec.GhostVisualSnapshot != null)
+                    totalSnaps++;
+            }
+
+            snap.perRecording = breakdowns;
+            snap.totalStorageBytes = totalStorage;
+
+            snap.loadedTrajectoryPoints = totalPts;
+            snap.loadedPartEvents = totalEvts;
+            snap.loadedOrbitSegments = totalSegs;
+            snap.loadedSnapshotCount = totalSnaps;
+
+            // Memory estimation formula from design doc
+            snap.estimatedMemoryBytes = (long)totalPts * 136L
+                                      + (long)totalEvts * 88L
+                                      + (long)totalSegs * 120L
+                                      + (long)totalSnaps * 8192L;
+
+            // --- Ghost state: read from DiagnosticsState (populated by engine in Phase 3) ---
+            snap.activeGhostCount = DiagnosticsState.playbackBudget.ghostsProcessed;
+            // Zone/softcap details will be filled in Phase 3 engine instrumentation.
+            // For now, read whatever is in DiagnosticsState fields — they default to 0.
+
+            // --- Timing: raw last-frame budgets ---
+            snap.lastPlaybackBudget = DiagnosticsState.playbackBudget;
+            snap.lastRecordingBudget = DiagnosticsState.recordingBudget;
+
+            // --- Timing: rolling stats ---
+            double wallTs = GetWallTimestamp();
+            DiagnosticsState.playbackFrameHistory.ComputeStats(
+                wallTs, 4.0,
+                out snap.playbackAvgTotalMs,
+                out snap.playbackPeakTotalMs,
+                out snap.playbackWindowDurationSeconds);
+
+            // --- Save/load timing ---
+            snap.lastSaveTiming = DiagnosticsState.lastSaveTiming;
+            snap.lastLoadTiming = DiagnosticsState.lastLoadTiming;
+
+            // Cache the snapshot
+            DiagnosticsState.cachedSnapshot = snap;
+            DiagnosticsState.hasCachedSnapshot = true;
+            DiagnosticsState.cachedSnapshotUT = currentUT;
+
+            return snap;
+        }
+
+        // ------------------------------------------------------------------
+        // GetOrComputeSnapshot
+        // ------------------------------------------------------------------
+
+        /// <summary>
+        /// Returns cached MetricSnapshot if within TTL, otherwise computes fresh.
+        /// </summary>
+        internal static MetricSnapshot GetOrComputeSnapshot(double currentUT)
+        {
+            if (DiagnosticsState.hasCachedSnapshot
+                && (currentUT - DiagnosticsState.cachedSnapshotUT) < DiagnosticsState.SnapshotCacheTtlSeconds)
+            {
+                return DiagnosticsState.cachedSnapshot;
+            }
+
+            return ComputeSnapshot(currentUT);
+        }
+
+        // ------------------------------------------------------------------
+        // FormatReport
+        // ------------------------------------------------------------------
+
+        /// <summary>
+        /// Formats a MetricSnapshot into the multi-line diagnostics report.
+        /// All numbers use InvariantCulture. Empty rolling buffer shows "N/A".
+        /// </summary>
+        internal static string FormatReport(MetricSnapshot snapshot)
+        {
+            var sb = new StringBuilder(2048);
+
+            // Header
+            sb.AppendLine("===== DIAGNOSTICS REPORT =====");
+
+            // Storage summary
+            sb.AppendFormat(Inv, "Storage: {0} total, {1} recordings",
+                FormatBytes(snapshot.totalStorageBytes), snapshot.recordingCount);
+            sb.AppendLine();
+
+            // Per-recording lines
+            if (snapshot.perRecording != null)
+            {
+                for (int i = 0; i < snapshot.perRecording.Length; i++)
+                {
+                    var r = snapshot.perRecording[i];
+                    sb.AppendFormat(Inv,
+                        "  rec[{0}] \"{1}\" \u2014 {2} ({3} pts, {4} evts, {5} segs) {6} {7}/s",
+                        i,
+                        r.vesselName ?? "",
+                        FormatBytes(r.totalBytes),
+                        r.pointCount,
+                        r.partEventCount,
+                        r.orbitSegmentCount,
+                        FormatDuration(r.durationSeconds),
+                        FormatBytes((long)r.bytesPerSecond));
+                    sb.AppendLine();
+                }
+            }
+
+            // Memory
+            sb.AppendFormat(Inv,
+                "Memory: ~{0} est ({1} pts, {2} evts, {3} segs, {4} snapshots)",
+                FormatBytes(snapshot.estimatedMemoryBytes),
+                snapshot.loadedTrajectoryPoints,
+                snapshot.loadedPartEvents,
+                snapshot.loadedOrbitSegments,
+                snapshot.loadedSnapshotCount);
+            sb.AppendLine();
+
+            // Ghosts
+            sb.AppendFormat(Inv,
+                "Ghosts: {0} active (z1:{1} z2:{2}), {3} reduced, {4} simplified",
+                snapshot.activeGhostCount,
+                snapshot.zone1GhostCount,
+                snapshot.zone2GhostCount,
+                snapshot.softCapReducedCount,
+                snapshot.softCapSimplifiedCount);
+            sb.AppendLine();
+
+            // Playback budget
+            bool hasPlaybackData = DiagnosticsState.playbackFrameHistory != null
+                                && !DiagnosticsState.playbackFrameHistory.IsEmpty;
+            if (hasPlaybackData)
+            {
+                sb.AppendFormat(Inv,
+                    "Playback budget: {0} ms avg, {1} ms peak ({2}s window), warp: {3}x",
+                    snapshot.playbackAvgTotalMs.ToString("F1", Inv),
+                    snapshot.playbackPeakTotalMs.ToString("F1", Inv),
+                    snapshot.playbackWindowDurationSeconds.ToString("F1", Inv),
+                    snapshot.lastPlaybackBudget.warpRate.ToString("F0", Inv));
+            }
+            else
+            {
+                sb.Append("Playback budget: N/A");
+            }
+            sb.AppendLine();
+
+            // Recording budget
+            bool recordingActive = DiagnosticsState.hasActiveGrowthRate;
+            sb.AppendFormat(Inv,
+                "Recording budget: {0} ms avg {1}",
+                (snapshot.lastRecordingBudget.totalMicroseconds / 1000.0).ToString("F1", Inv),
+                recordingActive ? "(active)" : "(inactive)");
+            sb.AppendLine();
+
+            // Save/Load
+            sb.AppendFormat(Inv,
+                "Save: {0} ms last ({1} dirty) | Load: {2} ms last ({3} total)",
+                snapshot.lastSaveTiming.totalMilliseconds,
+                snapshot.lastSaveTiming.dirtyRecordingsWritten,
+                snapshot.lastLoadTiming.totalMilliseconds,
+                snapshot.lastLoadTiming.recordingsProcessed);
+            sb.AppendLine();
+
+            // Health
+            var h = DiagnosticsState.health;
+            int totalLookups = h.waypointCacheHits + h.waypointCacheMisses;
+            string hitRateStr;
+            if (totalLookups > 0)
+            {
+                double hitRate = (h.waypointCacheHits / (double)totalLookups) * 100.0;
+                hitRateStr = hitRate.ToString("F1", Inv) + "%";
+            }
+            else
+            {
+                hitRateStr = "N/A";
+            }
+            sb.AppendFormat(Inv,
+                "Health: cache {0} hit ({1} miss of {2} lookups), spikes {3}, spawn fail {4}, builds {5}",
+                hitRateStr,
+                h.waypointCacheMisses,
+                totalLookups,
+                h.snapshotRefreshSpikes,
+                h.spawnFailures,
+                h.ghostBuildsThisSession);
+            sb.AppendLine();
+
+            // GC gen0
+            int gcDelta = GC.CollectionCount(0) - h.gcGen0Baseline;
+            sb.AppendFormat(Inv, "GC gen0: +{0} collections this session", gcDelta);
+            sb.AppendLine();
+
+            // Footer
+            sb.Append("===== END REPORT =====");
+
+            return sb.ToString();
+        }
+
+        // ------------------------------------------------------------------
+        // RunDiagnosticsReport
+        // ------------------------------------------------------------------
+
+        /// <summary>
+        /// Computes full snapshot, formats report, logs each line to KSP.log, returns full string.
+        /// </summary>
+        internal static string RunDiagnosticsReport()
+        {
+            double currentUT = 0.0;
+            try
+            {
+                // Try to read game UT if available
+                var recordings = RecordingStore.CommittedRecordings;
+                if (recordings != null && recordings.Count > 0)
+                    currentUT = recordings[recordings.Count - 1].EndUT;
+            }
+            catch { /* not available outside KSP */ }
+
+            var snapshot = ComputeSnapshot(currentUT);
+            string report = FormatReport(snapshot);
+
+            // Log each line individually so each gets the [Parsek][INFO][Diagnostics] prefix
+            string[] lines = report.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
+            for (int i = 0; i < lines.Length; i++)
+            {
+                if (!string.IsNullOrEmpty(lines[i]))
+                    ParsekLog.Info("Diagnostics", lines[i]);
+            }
+
+            return report;
+        }
+
+        /// <summary>
+        /// Reset test-only state. Call from test cleanup.
+        /// </summary>
+        internal static void ResetForTesting()
+        {
+            ClockSource = null;
+        }
+    }
+}

--- a/Source/Parsek/Diagnostics/DiagnosticsComputation.cs
+++ b/Source/Parsek/Diagnostics/DiagnosticsComputation.cs
@@ -446,6 +446,93 @@ namespace Parsek
             return report;
         }
 
+        // ------------------------------------------------------------------
+        // Budget threshold checks (testable static methods)
+        // ------------------------------------------------------------------
+
+        /// <summary>
+        /// Playback budget warning threshold in milliseconds.
+        /// At 60 FPS, a frame is 16.6ms — 8ms is about half the budget.
+        /// </summary>
+        internal const double PlaybackBudgetThresholdMs = 8.0;
+
+        /// <summary>
+        /// Recording budget warning threshold in milliseconds.
+        /// </summary>
+        internal const double RecordingBudgetThresholdMs = 4.0;
+
+        /// <summary>
+        /// Checks the playback budget and emits a rate-limited WARN if exceeded.
+        /// Called by GhostPlaybackEngine after each frame. Pure static, testable.
+        /// </summary>
+        internal static void CheckPlaybackBudgetThreshold(long totalMicroseconds, int ghostsProcessed, float warpRate)
+        {
+            double totalMs = totalMicroseconds / 1000.0;
+            if (totalMs > PlaybackBudgetThresholdMs)
+            {
+                ParsekLog.WarnRateLimited("Diagnostics", "playback-budget",
+                    string.Format(Inv,
+                        "Playback frame budget exceeded: {0}ms ({1} ghosts, warp: {2}x)",
+                        totalMs.ToString("F1", Inv), ghostsProcessed, warpRate.ToString("F0", Inv)),
+                    30.0);
+            }
+        }
+
+        /// <summary>
+        /// Checks the recording budget and emits a rate-limited WARN if exceeded.
+        /// Called by PhysicsFramePatch after each physics frame. Pure static, testable.
+        /// </summary>
+        internal static void CheckRecordingBudgetThreshold(long totalMicroseconds, string vesselName)
+        {
+            double totalMs = totalMicroseconds / 1000.0;
+            if (totalMs > RecordingBudgetThresholdMs)
+            {
+                ParsekLog.WarnRateLimited("Diagnostics", "recording-budget",
+                    string.Format(Inv,
+                        "Recording frame exceeded budget: {0}ms for vessel \"{1}\"",
+                        totalMs.ToString("F2", Inv), vesselName ?? "?"),
+                    30.0);
+            }
+        }
+
+        // ------------------------------------------------------------------
+        // EmitSceneLoadSnapshot
+        // ------------------------------------------------------------------
+
+        /// <summary>
+        /// Emits a one-shot Verbose log line with memory snapshot and ghost count after scene load.
+        /// Designed for once-per-scene-load usage — no rate limiting needed.
+        /// Pure static method, testable without Unity.
+        /// </summary>
+        internal static void EmitSceneLoadSnapshot(int recordingCount, string sceneName)
+        {
+            var recordings = RecordingStore.CommittedRecordings;
+            int totalPts = 0, totalEvts = 0, totalSegs = 0;
+            if (recordings != null)
+            {
+                for (int i = 0; i < recordings.Count; i++)
+                {
+                    var rec = recordings[i];
+                    if (rec == null) continue;
+                    totalPts += rec.Points != null ? rec.Points.Count : 0;
+                    totalEvts += rec.PartEvents != null ? rec.PartEvents.Count : 0;
+                    totalSegs += rec.OrbitSegments != null ? rec.OrbitSegments.Count : 0;
+                }
+            }
+
+            long estimatedMemory = (long)totalPts * 136L + (long)totalEvts * 88L + (long)totalSegs * 120L;
+            int ghostCount = DiagnosticsState.playbackBudget.ghostsProcessed;
+
+            ParsekLog.Verbose("Diagnostics",
+                string.Format(Inv,
+                    "Scene load complete ({0}): {1} recordings, ~{2} memory est ({3} pts, {4} evts, {5} segs), {6} ghosts",
+                    sceneName ?? "?",
+                    recordingCount,
+                    FormatBytes(estimatedMemory),
+                    totalPts, totalEvts, totalSegs,
+                    ghostCount));
+        }
+
         /// <summary>
         /// Reset test-only state. Call from test cleanup.
         /// </summary>

--- a/Source/Parsek/Diagnostics/DiagnosticsState.cs
+++ b/Source/Parsek/Diagnostics/DiagnosticsState.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+
+namespace Parsek
+{
+    /// <summary>
+    /// Central holder for all observability state. Static class, survives scene changes.
+    /// Metrics are read-only observations — they never change behavior.
+    /// No serialization; diagnostics state is ephemeral.
+    /// </summary>
+    internal static class DiagnosticsState
+    {
+        // Live frame budgets (updated every frame by Stopwatch instrumentation)
+        internal static FrameBudget playbackBudget;
+        internal static FrameBudget recordingBudget;
+
+        // Rolling average history (pre-allocated ring buffer, time-based window)
+        internal static RollingTimingBuffer playbackFrameHistory = new RollingTimingBuffer();
+
+        // Growth rate (only valid during active recording)
+        internal static RecordingGrowthRate activeGrowthRate;
+        internal static bool hasActiveGrowthRate;
+
+        // Health counters (reset per scene load)
+        internal static HealthCounters health;
+
+        // Snapshot cache (computed on demand, cached briefly)
+        internal static MetricSnapshot cachedSnapshot;
+        internal static bool hasCachedSnapshot;
+        internal static double cachedSnapshotUT;
+        internal const double SnapshotCacheTtlSeconds = 2.0;
+
+        // Per-recording storage cache (computed on hover, cached per-recording)
+        internal static Dictionary<string, (StorageBreakdown breakdown, double cachedUT)> storageBreakdownCache
+            = new Dictionary<string, (StorageBreakdown, double)>();
+        internal const double StorageBreakdownCacheTtlSeconds = 5.0;
+
+        // Average bytes per trajectory point — bootstrapped from real data when available
+        internal static double avgBytesPerPoint = 85.0;
+
+        /// <summary>
+        /// Reset session-scoped counters. Called on scene load.
+        /// Resets health counters, rolling buffer, and invalidates snapshot cache.
+        /// Captures GC gen0 baseline.
+        /// </summary>
+        internal static void ResetSessionCounters()
+        {
+            health.Reset();
+            playbackFrameHistory.Reset();
+            playbackBudget = default;
+            recordingBudget = default;
+            InvalidateSnapshotCache();
+        }
+
+        /// <summary>
+        /// Invalidate the cached MetricSnapshot, forcing recomputation on next request.
+        /// </summary>
+        internal static void InvalidateSnapshotCache()
+        {
+            hasCachedSnapshot = false;
+            cachedSnapshotUT = 0.0;
+        }
+
+        /// <summary>
+        /// Reset all state for unit testing. Prevents cross-test contamination.
+        /// </summary>
+        internal static void ResetForTesting()
+        {
+            playbackBudget = default;
+            recordingBudget = default;
+            playbackFrameHistory.Reset();
+            activeGrowthRate = default;
+            hasActiveGrowthRate = false;
+            health = default;
+            hasCachedSnapshot = false;
+            cachedSnapshotUT = 0.0;
+            cachedSnapshot = default;
+            storageBreakdownCache.Clear();
+            avgBytesPerPoint = 85.0;
+        }
+    }
+}

--- a/Source/Parsek/Diagnostics/DiagnosticsState.cs
+++ b/Source/Parsek/Diagnostics/DiagnosticsState.cs
@@ -20,6 +20,10 @@ namespace Parsek
         internal static RecordingGrowthRate activeGrowthRate;
         internal static bool hasActiveGrowthRate;
 
+        // Save/load timing (updated on each OnSave/OnLoad)
+        internal static SaveLoadTiming lastSaveTiming;
+        internal static SaveLoadTiming lastLoadTiming;
+
         // Health counters (reset per scene load)
         internal static HealthCounters health;
 
@@ -67,6 +71,8 @@ namespace Parsek
         {
             playbackBudget = default;
             recordingBudget = default;
+            lastSaveTiming = default;
+            lastLoadTiming = default;
             playbackFrameHistory.Reset();
             activeGrowthRate = default;
             hasActiveGrowthRate = false;

--- a/Source/Parsek/Diagnostics/DiagnosticsStructs.cs
+++ b/Source/Parsek/Diagnostics/DiagnosticsStructs.cs
@@ -1,0 +1,130 @@
+namespace Parsek
+{
+    /// <summary>
+    /// Per-frame timing breakdown for playback or recording.
+    /// Raw timing only — rolling stats are computed from RollingTimingBuffer at read time.
+    /// </summary>
+    internal struct FrameBudget
+    {
+        public long totalMicroseconds;
+        public long spawnMicroseconds;
+        public int ghostsProcessed;
+        public float warpRate;
+    }
+
+    /// <summary>
+    /// Timing for a single OnSave or OnLoad operation.
+    /// </summary>
+    internal struct SaveLoadTiming
+    {
+        public long totalMilliseconds;
+        public int recordingsProcessed;
+        public int dirtyRecordingsWritten;
+    }
+
+    /// <summary>
+    /// Per-recording storage detail. Computed by reading file sizes on disk.
+    /// </summary>
+    internal struct StorageBreakdown
+    {
+        public string recordingId;
+        public string vesselName;
+        public long trajectoryFileBytes;
+        public long vesselSnapshotBytes;
+        public long ghostSnapshotBytes;
+        public long geometryFileBytes;
+        public long totalBytes;
+        public int pointCount;
+        public int partEventCount;
+        public int orbitSegmentCount;
+        public double durationSeconds;
+        public double bytesPerSecond;
+    }
+
+    /// <summary>
+    /// Point-in-time snapshot of all observability metrics.
+    /// Computed on demand, cached briefly in DiagnosticsState.
+    /// </summary>
+    internal struct MetricSnapshot
+    {
+        // Storage
+        public long totalStorageBytes;
+        public int recordingCount;
+        public StorageBreakdown[] perRecording;
+
+        // Memory
+        public int loadedTrajectoryPoints;
+        public int loadedPartEvents;
+        public int loadedOrbitSegments;
+        public int loadedSnapshotCount;
+        public long estimatedMemoryBytes;
+
+        // Ghost state
+        public int activeGhostCount;
+        public int activeOverlapGhostCount;
+        public int zone1GhostCount;
+        public int zone2GhostCount;
+        public int softCapReducedCount;
+        public int softCapSimplifiedCount;
+        public bool softCapsEnabled;
+
+        // Timing — raw last-frame budgets
+        public FrameBudget lastPlaybackBudget;
+        public FrameBudget lastRecordingBudget;
+
+        // Timing — rolling stats computed at snapshot time
+        public double playbackAvgTotalMs;
+        public double playbackPeakTotalMs;
+        public double playbackWindowDurationSeconds;
+
+        // Save/load
+        public SaveLoadTiming lastSaveTiming;
+        public SaveLoadTiming lastLoadTiming;
+    }
+
+    /// <summary>
+    /// Live growth metrics during active recording.
+    /// Updated per sampling event in FlightRecorder.
+    /// </summary>
+    internal struct RecordingGrowthRate
+    {
+        public double pointsPerSecond;
+        public double eventsPerSecond;
+        public long estimatedFinalBytes;
+        public double elapsedSeconds;
+        public int totalPoints;
+        public int totalEvents;
+    }
+
+    /// <summary>
+    /// Session-level counters for anomalies and operational health.
+    /// Reset per scene load via DiagnosticsState.ResetSessionCounters().
+    /// </summary>
+    internal struct HealthCounters
+    {
+        public int waypointCacheHits;
+        public int waypointCacheMisses;
+        public int snapshotRefreshSpikes;
+        public int spawnFailures;
+        public int spawnRetries;
+        public int softCapActivations;
+        public int softCapDespawns;
+        public int ghostBuildsThisSession;
+        public int ghostDestroysThisSession;
+        public int gcGen0Baseline;
+
+        public void Reset()
+        {
+            waypointCacheHits = 0;
+            waypointCacheMisses = 0;
+            snapshotRefreshSpikes = 0;
+            spawnFailures = 0;
+            spawnRetries = 0;
+            softCapActivations = 0;
+            softCapDespawns = 0;
+            ghostBuildsThisSession = 0;
+            ghostDestroysThisSession = 0;
+            gcGen0Baseline = System.GC.CollectionCount(0);
+        }
+    }
+}

--- a/Source/Parsek/Diagnostics/RollingTimingBuffer.cs
+++ b/Source/Parsek/Diagnostics/RollingTimingBuffer.cs
@@ -1,0 +1,114 @@
+namespace Parsek
+{
+    /// <summary>
+    /// Pre-allocated ring buffer for frame timing history.
+    /// Stores (wallTimestamp, microseconds) pairs. No allocations after construction.
+    /// Capacity: 1024 entries (enough for 4s at 240fps).
+    /// </summary>
+    internal class RollingTimingBuffer
+    {
+        private const int Capacity = 1024;
+
+        private readonly double[] timestamps;
+        private readonly long[] microseconds;
+        private int head;
+        private int tail;
+        private int count;
+
+        public RollingTimingBuffer()
+        {
+            timestamps = new double[Capacity];
+            microseconds = new long[Capacity];
+            head = 0;
+            tail = 0;
+            count = 0;
+        }
+
+        public int Count => count;
+
+        public bool IsEmpty => count == 0;
+
+        /// <summary>
+        /// Append a timing entry. If the buffer is full, overwrites the oldest entry.
+        /// </summary>
+        public void Append(double wallTimestamp, long microseconds)
+        {
+            this.timestamps[tail] = wallTimestamp;
+            this.microseconds[tail] = microseconds;
+            tail = (tail + 1) % Capacity;
+
+            if (count < Capacity)
+            {
+                count++;
+            }
+            else
+            {
+                // Buffer full — oldest entry overwritten, advance head
+                head = (head + 1) % Capacity;
+            }
+        }
+
+        /// <summary>
+        /// Compute rolling average and peak over entries within windowSeconds of currentTimestamp.
+        /// Scans from newest to oldest, stops when entry is older than the window.
+        /// Output values are in milliseconds (converted from stored microseconds).
+        /// Empty buffer or no entries in window: avgMs=0, peakMs=0, actualWindowDuration=0.
+        /// </summary>
+        public void ComputeStats(double currentTimestamp, double windowSeconds,
+            out double avgMs, out double peakMs, out double actualWindowDuration)
+        {
+            avgMs = 0.0;
+            peakMs = 0.0;
+            actualWindowDuration = 0.0;
+
+            if (count == 0)
+                return;
+
+            double windowStart = currentTimestamp - windowSeconds;
+            long sumMicroseconds = 0;
+            long maxMicroseconds = 0;
+            int entriesInWindow = 0;
+            double oldestInWindow = currentTimestamp;
+            double newestInWindow = 0.0;
+
+            // Scan from newest to oldest
+            for (int i = 0; i < count; i++)
+            {
+                int idx = (tail - 1 - i + Capacity) % Capacity;
+                double ts = timestamps[idx];
+
+                if (ts < windowStart)
+                    break;
+
+                long us = this.microseconds[idx];
+                sumMicroseconds += us;
+                if (us > maxMicroseconds)
+                    maxMicroseconds = us;
+
+                if (ts < oldestInWindow)
+                    oldestInWindow = ts;
+                if (ts > newestInWindow)
+                    newestInWindow = ts;
+
+                entriesInWindow++;
+            }
+
+            if (entriesInWindow == 0)
+                return;
+
+            avgMs = (sumMicroseconds / (double)entriesInWindow) / 1000.0;
+            peakMs = maxMicroseconds / 1000.0;
+            actualWindowDuration = newestInWindow - oldestInWindow;
+        }
+
+        /// <summary>
+        /// Reset the buffer to empty state.
+        /// </summary>
+        public void Reset()
+        {
+            head = 0;
+            tail = 0;
+            count = 0;
+        }
+    }
+}

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -4028,7 +4028,11 @@ namespace Parsek
             DiagnosticsState.hasActiveGrowthRate = true;
             BootstrapAvgBytesPerPoint();
 
-            ParsekLog.Info("Recorder", $"Recording started (physics-frame sampling{(isPromotion ? ", promotion" : "")})");
+            int partCount = v.parts != null ? v.parts.Count : 0;
+            ParsekLog.Info("Recorder",
+                string.Format(CultureInfo.InvariantCulture,
+                    "Recording started: vessel=\"{0}\", parts={1}, points=0{2}",
+                    v.vesselName, partCount, isPromotion ? ", promotion" : ""));
             if (!isPromotion)
                 ParsekLog.ScreenMessage("Recording STARTED", 2f);
         }

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using KSP.UI.Screens;
 using UnityEngine;
@@ -4022,6 +4023,11 @@ namespace Parsek
 
             SubscribePartEvents();
 
+            // Initialize diagnostics growth rate tracking
+            DiagnosticsState.activeGrowthRate = default;
+            DiagnosticsState.hasActiveGrowthRate = true;
+            BootstrapAvgBytesPerPoint();
+
             ParsekLog.Info("Recorder", $"Recording started (physics-frame sampling{(isPromotion ? ", promotion" : "")})");
             if (!isPromotion)
                 ParsekLog.ScreenMessage("Recording STARTED", 2f);
@@ -4437,6 +4443,19 @@ namespace Parsek
             UnsubscribePartEvents();
             IsRecording = false;
 
+            // Finalize diagnostics growth rate tracking
+            if (DiagnosticsState.hasActiveGrowthRate)
+            {
+                var finalGr = DiagnosticsState.activeGrowthRate;
+                ParsekLog.Verbose("Diagnostics",
+                    string.Format(CultureInfo.InvariantCulture,
+                        "Recording growth rate at stop: {0} points, {1} events, {2:F1}s elapsed, " +
+                        "{3:F2} pts/s, {4:F2} evts/s, est {5} bytes",
+                        finalGr.totalPoints, finalGr.totalEvents, finalGr.elapsedSeconds,
+                        finalGr.pointsPerSecond, finalGr.eventsPerSecond, finalGr.estimatedFinalBytes));
+                DiagnosticsState.hasActiveGrowthRate = false;
+            }
+
             // Optionally emit terminal shutdown events for engines/RCS/robotics still active (bug #108)
             if (emitTerminalEvents)
             {
@@ -4807,6 +4826,28 @@ namespace Parsek
             }
 
             RefreshBackupSnapshot(v, "periodic");
+
+            // Update diagnostics growth rate
+            if (DiagnosticsState.hasActiveGrowthRate)
+            {
+                var gr = DiagnosticsState.activeGrowthRate;
+                gr.totalPoints = Recording.Count;
+                gr.totalEvents = PartEvents.Count;
+                double startUT = Recording.Count > 0 ? Recording[0].ut : point.ut;
+                gr.elapsedSeconds = point.ut - startUT;
+                if (gr.elapsedSeconds > 0)
+                {
+                    gr.pointsPerSecond = gr.totalPoints / gr.elapsedSeconds;
+                    gr.eventsPerSecond = gr.totalEvents / gr.elapsedSeconds;
+                }
+                else
+                {
+                    gr.pointsPerSecond = 0;
+                    gr.eventsPerSecond = 0;
+                }
+                gr.estimatedFinalBytes = (long)(gr.totalPoints * DiagnosticsState.avgBytesPerPoint + gr.totalEvents * 40);
+                DiagnosticsState.activeGrowthRate = gr;
+            }
 
             if (Recording.Count % 10 == 0)
             {
@@ -5295,7 +5336,8 @@ namespace Parsek
 
             if (elapsedMs >= snapshotPerfLogThresholdMs)
             {
-                ParsekLog.Verbose("Recorder", 
+                DiagnosticsState.health.snapshotRefreshSpikes++;
+                ParsekLog.Verbose("Recorder",
                     $"Snapshot backup cost ({reason}): {elapsedMs:F1}ms " +
                     $"pid={vessel.persistentId}, points={Recording.Count}");
             }
@@ -5307,6 +5349,71 @@ namespace Parsek
             if (force) return true;
             if (lastSnapshotRefreshUT == double.MinValue) return true;
             return currentUT - lastSnapshotRefreshUT >= intervalUT;
+        }
+
+        /// <summary>
+        /// Bootstraps DiagnosticsState.avgBytesPerPoint from committed recordings' .prec files.
+        /// Called once at recording start. If no committed recordings exist, keeps the default (85).
+        /// </summary>
+        private static void BootstrapAvgBytesPerPoint()
+        {
+            try
+            {
+                var committed = RecordingStore.CommittedRecordings;
+                if (committed == null || committed.Count == 0)
+                {
+                    ParsekLog.Verbose("Diagnostics", "avgBytesPerPoint bootstrap: no committed recordings, using default 85");
+                    return;
+                }
+
+                long totalBytes = 0;
+                int totalPoints = 0;
+                int filesChecked = 0;
+
+                for (int i = 0; i < committed.Count; i++)
+                {
+                    var rec = committed[i];
+                    if (rec == null || rec.Points == null || rec.Points.Count == 0)
+                        continue;
+
+                    string relativePath = RecordingPaths.BuildTrajectoryRelativePath(rec.RecordingId);
+                    string fullPath = RecordingPaths.ResolveSaveScopedPath(relativePath);
+                    if (string.IsNullOrEmpty(fullPath))
+                        continue;
+
+                    try
+                    {
+                        var fi = new FileInfo(fullPath);
+                        if (fi.Exists)
+                        {
+                            totalBytes += fi.Length;
+                            totalPoints += rec.Points.Count;
+                            filesChecked++;
+                        }
+                    }
+                    catch
+                    {
+                        // Skip files that can't be stat'd
+                    }
+                }
+
+                if (totalPoints > 0)
+                {
+                    DiagnosticsState.avgBytesPerPoint = (double)totalBytes / totalPoints;
+                    ParsekLog.Verbose("Diagnostics",
+                        string.Format(CultureInfo.InvariantCulture,
+                            "avgBytesPerPoint bootstrapped: {0:F1} bytes/pt from {1} files ({2} bytes, {3} points)",
+                            DiagnosticsState.avgBytesPerPoint, filesChecked, totalBytes, totalPoints));
+                }
+                else
+                {
+                    ParsekLog.Verbose("Diagnostics", "avgBytesPerPoint bootstrap: no .prec files found, using default 85");
+                }
+            }
+            catch (Exception ex)
+            {
+                ParsekLog.Verbose("Diagnostics", $"avgBytesPerPoint bootstrap failed: {ex.Message}");
+            }
         }
 
         internal static VesselSwitchDecision DecideOnVesselSwitch(

--- a/Source/Parsek/GhostPlaybackEngine.cs
+++ b/Source/Parsek/GhostPlaybackEngine.cs
@@ -145,6 +145,8 @@ namespace Parsek
 
             // Diagnostics: start total frame timing
             updateStopwatch.Restart();
+            // Reset spawn timer to zero — Start()/Stop() pairs inside SpawnGhost
+            // accumulate across multiple spawns per frame (Start resumes, not resets)
             spawnStopwatch.Reset();
             long spawnMicroseconds = 0;
             int ghostsProcessed = 0;

--- a/Source/Parsek/GhostPlaybackEngine.cs
+++ b/Source/Parsek/GhostPlaybackEngine.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using UnityEngine;
 
 namespace Parsek
@@ -57,6 +58,10 @@ namespace Parsek
         // Per-frame batch counters (avoid per-ghost log spam)
         private int frameSpawnCount;
         private int frameDestroyCount;
+
+        // Diagnostics: reusable Stopwatches (allocated once, no per-frame GC)
+        private readonly Stopwatch updateStopwatch = new Stopwatch();
+        private readonly Stopwatch spawnStopwatch = new Stopwatch();
 
         // Deferred event lists (reused per frame to avoid GC allocation)
         private readonly List<PlaybackCompletedEvent> deferredCompletedEvents = new List<PlaybackCompletedEvent>();
@@ -129,6 +134,12 @@ namespace Parsek
             frameSpawnCount = 0;
             frameDestroyCount = 0;
 
+            // Diagnostics: start total frame timing
+            updateStopwatch.Restart();
+            spawnStopwatch.Reset();
+            long spawnMicroseconds = 0;
+            int ghostsProcessed = 0;
+
             for (int i = 0; i < trajectories.Count; i++)
             {
                 var traj = trajectories[i];
@@ -157,6 +168,7 @@ namespace Parsek
                 GhostPlaybackState state;
                 ghostStates.TryGetValue(i, out state);
                 bool ghostActive = state != null && state.ghost != null;
+                if (ghostActive) ghostsProcessed++;
 
                 // === Loop dispatch (before main rendering) ===
                 if (ShouldLoopPlayback(traj))
@@ -299,6 +311,28 @@ namespace Parsek
 
             for (int i = 0; i < deferredCompletedEvents.Count; i++)
                 OnPlaybackCompleted?.Invoke(deferredCompletedEvents[i]);
+
+            // Diagnostics: stop total frame timing and write results
+            updateStopwatch.Stop();
+            long totalMicroseconds = updateStopwatch.ElapsedTicks * 1000000L / Stopwatch.Frequency;
+            spawnMicroseconds = spawnStopwatch.ElapsedTicks * 1000000L / Stopwatch.Frequency;
+
+            DiagnosticsState.playbackBudget.totalMicroseconds = totalMicroseconds;
+            DiagnosticsState.playbackBudget.spawnMicroseconds = spawnMicroseconds;
+            DiagnosticsState.playbackBudget.ghostsProcessed = ghostsProcessed;
+            DiagnosticsState.playbackBudget.warpRate = ctx.warpRate;
+
+            DiagnosticsState.playbackFrameHistory.Append(
+                Time.realtimeSinceStartup, totalMicroseconds);
+
+            // Budget threshold warning (8ms = half of 16.6ms frame budget at 60fps)
+            double totalMs = totalMicroseconds / 1000.0;
+            if (totalMs > 8.0)
+            {
+                ParsekLog.WarnRateLimited("Diagnostics", "playback-budget",
+                    $"Playback frame budget exceeded: {totalMs.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)}ms " +
+                    $"({ghostsProcessed} ghosts, warp: {ctx.warpRate.ToString("F0", System.Globalization.CultureInfo.InvariantCulture)}x)", 30.0);
+            }
         }
 
         /// <summary>
@@ -482,6 +516,7 @@ namespace Parsek
                             $"SoftCap triggered: zone1={cachedZone1Ghosts.Count} zone2={cachedZone2Ghosts.Count} " +
                             $"actions={capActions.Count}");
                         softCapTriggeredThisFrame = true;
+                        DiagnosticsState.health.softCapActivations++;
                     }
 
                     foreach (var capKvp in capActions)
@@ -502,6 +537,7 @@ namespace Parsek
                                     ? trajectories[capIdx] : null;
                                 DestroyGhost(capIdx, capTraj, reason: "soft cap despawn");
                                 softCapSuppressed.Add(capIdx);
+                                DiagnosticsState.health.softCapDespawns++;
                                 break;
                             case GhostCapAction.SimplifyToOrbitLine:
                                 GhostPlaybackState simplifyState;
@@ -1403,6 +1439,7 @@ namespace Parsek
                 return;
             }
 
+            spawnStopwatch.Start();
             frameSpawnCount++;
             completedEventFired.Remove(index); // Reset dedup for time-jump backward
 
@@ -1467,6 +1504,9 @@ namespace Parsek
                 $"Ghost #{index} \"{traj?.VesselName}\" spawned ({buildType}, " +
                 $"parts={state.partTree?.Count ?? 0} engines={state.engineInfos?.Count ?? 0} " +
                 $"rcs={state.rcsInfos?.Count ?? 0})", 1.0);
+
+            spawnStopwatch.Stop();
+            DiagnosticsState.health.ghostBuildsThisSession++;
         }
 
         /// <summary>
@@ -1547,6 +1587,7 @@ namespace Parsek
             ghostStates.Remove(index);
             loopPhaseOffsets.Remove(index);
             completedEventFired.Remove(index);
+            DiagnosticsState.health.ghostDestroysThisSession++;
         }
 
         /// <summary>

--- a/Source/Parsek/GhostPlaybackEngine.cs
+++ b/Source/Parsek/GhostPlaybackEngine.cs
@@ -326,13 +326,7 @@ namespace Parsek
                 Time.realtimeSinceStartup, totalMicroseconds);
 
             // Budget threshold warning (8ms = half of 16.6ms frame budget at 60fps)
-            double totalMs = totalMicroseconds / 1000.0;
-            if (totalMs > 8.0)
-            {
-                ParsekLog.WarnRateLimited("Diagnostics", "playback-budget",
-                    $"Playback frame budget exceeded: {totalMs.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)}ms " +
-                    $"({ghostsProcessed} ghosts, warp: {ctx.warpRate.ToString("F0", System.Globalization.CultureInfo.InvariantCulture)}x)", 30.0);
-            }
+            DiagnosticsComputation.CheckPlaybackBudgetThreshold(totalMicroseconds, ghostsProcessed, ctx.warpRate);
         }
 
         /// <summary>
@@ -512,9 +506,9 @@ namespace Parsek
                 {
                     if (!softCapTriggeredThisFrame)
                     {
-                        ParsekLog.Info("Engine",
-                            $"SoftCap triggered: zone1={cachedZone1Ghosts.Count} zone2={cachedZone2Ghosts.Count} " +
-                            $"actions={capActions.Count}");
+                        ParsekLog.VerboseRateLimited("Diagnostics", "soft-cap-activation",
+                            $"Soft cap activation: zone1={cachedZone1Ghosts.Count} zone2={cachedZone2Ghosts.Count} " +
+                            $"actions={capActions.Count}", 30.0);
                         softCapTriggeredThisFrame = true;
                         DiagnosticsState.health.softCapActivations++;
                     }

--- a/Source/Parsek/GhostPlaybackEngine.cs
+++ b/Source/Parsek/GhostPlaybackEngine.cs
@@ -114,10 +114,19 @@ namespace Parsek
             TrajectoryPlaybackFlags[] flags,
             FrameContext ctx)
         {
-            if (trajectories == null || trajectories.Count == 0) return;
-            if (positioner == null) return; // Not yet wired (Phase 7)
+            if (trajectories == null || trajectories.Count == 0)
+            {
+                DiagnosticsState.playbackBudget = default;
+                return;
+            }
+            if (positioner == null)
+            {
+                DiagnosticsState.playbackBudget = default;
+                return; // Not yet wired (Phase 7)
+            }
             if (flags == null || flags.Length < trajectories.Count)
             {
+                DiagnosticsState.playbackBudget = default;
                 ParsekLog.Warn("Engine", $"UpdatePlayback: flags array mismatch (flags={flags?.Length ?? 0} trajectories={trajectories.Count})");
                 return;
             }

--- a/Source/Parsek/InGameTests/DiagnosticsTests.cs
+++ b/Source/Parsek/InGameTests/DiagnosticsTests.cs
@@ -1,0 +1,101 @@
+namespace Parsek.InGameTests
+{
+    /// <summary>
+    /// In-game tests for the diagnostics/observability system.
+    /// Verifies ComputeSnapshot and FormatReport produce sane output in a live KSP environment.
+    /// </summary>
+    public static class DiagnosticsTests
+    {
+        [InGameTest(Category = "Diagnostics", Scene = GameScenes.FLIGHT,
+            Description = "DiagnosticsComputation.FormatReport produces a report with all expected sections")]
+        public static void DiagnosticsReportProducesOutput()
+        {
+            double ut = Planetarium.GetUniversalTime();
+            var snapshot = DiagnosticsComputation.ComputeSnapshot(ut);
+            string report = DiagnosticsComputation.FormatReport(snapshot);
+
+            InGameAssert.IsNotNull(report, "FormatReport returned null");
+            InGameAssert.Contains(report, "DIAGNOSTICS REPORT", "Report missing header");
+            InGameAssert.Contains(report, "Storage:", "Report missing Storage section");
+            InGameAssert.Contains(report, "Memory:", "Report missing Memory section");
+            InGameAssert.Contains(report, "Playback budget:", "Report missing Playback section");
+            InGameAssert.Contains(report, "Health:", "Report missing Health section");
+            InGameAssert.Contains(report, "END REPORT", "Report missing footer");
+
+            ParsekLog.Verbose("TestRunner",
+                $"Diagnostics report produced {report.Length} chars with all expected sections");
+        }
+
+        [InGameTest(Category = "Diagnostics", Scene = GameScenes.FLIGHT,
+            Description = "ComputeSnapshot ghost count is non-negative")]
+        public static void DiagnosticsGhostCountNonNegative()
+        {
+            double ut = Planetarium.GetUniversalTime();
+            var snapshot = DiagnosticsComputation.ComputeSnapshot(ut);
+
+            InGameAssert.IsTrue(snapshot.lastPlaybackBudget.ghostsProcessed >= 0,
+                $"Ghost count should be non-negative, was {snapshot.lastPlaybackBudget.ghostsProcessed}");
+            InGameAssert.IsTrue(snapshot.activeGhostCount >= 0,
+                $"Active ghost count should be non-negative, was {snapshot.activeGhostCount}");
+
+            ParsekLog.Verbose("TestRunner",
+                $"Ghost counts: processed={snapshot.lastPlaybackBudget.ghostsProcessed}, active={snapshot.activeGhostCount}");
+        }
+
+        [InGameTest(Category = "Diagnostics",
+            Description = "Storage breakdown values are non-negative")]
+        public static void StorageBreakdownNonNegative()
+        {
+            double ut = 0.0;
+            try { ut = Planetarium.GetUniversalTime(); }
+            catch { /* not in flight */ }
+
+            var snapshot = DiagnosticsComputation.ComputeSnapshot(ut);
+
+            InGameAssert.IsTrue(snapshot.totalStorageBytes >= 0,
+                $"Total storage should be non-negative, was {snapshot.totalStorageBytes}");
+            InGameAssert.IsTrue(snapshot.recordingCount >= 0,
+                $"Recording count should be non-negative, was {snapshot.recordingCount}");
+            InGameAssert.IsTrue(snapshot.estimatedMemoryBytes >= 0,
+                $"Estimated memory should be non-negative, was {snapshot.estimatedMemoryBytes}");
+
+            ParsekLog.Verbose("TestRunner",
+                $"Storage: {DiagnosticsComputation.FormatBytes(snapshot.totalStorageBytes)}, " +
+                $"{snapshot.recordingCount} recordings, " +
+                $"~{DiagnosticsComputation.FormatBytes(snapshot.estimatedMemoryBytes)} memory");
+        }
+
+        [InGameTest(Category = "Diagnostics",
+            Description = "RunDiagnosticsReport executes without throwing")]
+        public static void RunDiagnosticsReportDoesNotThrow()
+        {
+            string report = DiagnosticsComputation.RunDiagnosticsReport();
+
+            InGameAssert.IsNotNull(report, "RunDiagnosticsReport returned null");
+            InGameAssert.IsTrue(report.Length > 0, "RunDiagnosticsReport returned empty string");
+
+            ParsekLog.Verbose("TestRunner",
+                $"RunDiagnosticsReport completed, {report.Length} chars");
+        }
+
+        [InGameTest(Category = "Diagnostics",
+            Description = "Recording count in snapshot matches RecordingStore")]
+        public static void RecordingCountMatchesStore()
+        {
+            var recordings = RecordingStore.CommittedRecordings;
+            int storeCount = recordings != null ? recordings.Count : 0;
+
+            double ut = 0.0;
+            try { ut = Planetarium.GetUniversalTime(); }
+            catch { /* not in flight */ }
+
+            var snapshot = DiagnosticsComputation.ComputeSnapshot(ut);
+
+            InGameAssert.AreEqual(storeCount, snapshot.recordingCount,
+                $"Snapshot recording count ({snapshot.recordingCount}) != RecordingStore count ({storeCount})");
+
+            ParsekLog.Verbose("TestRunner",
+                $"Recording count consistent: store={storeCount}, snapshot={snapshot.recordingCount}");
+        }
+    }
+}

--- a/Source/Parsek/ParsekLog.cs
+++ b/Source/Parsek/ParsekLog.cs
@@ -117,6 +117,53 @@ namespace Parsek
             rateLimitStateByKey[compositeKey] = state;
         }
 
+        /// <summary>
+        /// Rate-limited warning. Same throttling as VerboseRateLimited but emits at WARN level
+        /// unconditionally (not gated on IsVerboseEnabled). Used for budget threshold warnings
+        /// that should be visible even when verbose logging is disabled.
+        /// </summary>
+        public static void WarnRateLimited(
+            string subsystem,
+            string key,
+            string message,
+            double minIntervalSeconds = DefaultRateLimitSeconds)
+        {
+            if (string.IsNullOrEmpty(key))
+            {
+                Warn(subsystem, message);
+                return;
+            }
+
+            string compositeKey = $"W|{subsystem}|{key}";
+            double now = GetLogClockSeconds();
+            if (!rateLimitStateByKey.TryGetValue(compositeKey, out var state))
+            {
+                rateLimitStateByKey[compositeKey] = new RateLimitState
+                {
+                    lastEmitSeconds = now,
+                    suppressedCount = 0
+                };
+                Warn(subsystem, message);
+                return;
+            }
+
+            if ((now - state.lastEmitSeconds) >= minIntervalSeconds)
+            {
+                string suffix = state.suppressedCount > 0
+                    ? $" | suppressed={state.suppressedCount}"
+                    : string.Empty;
+                Warn(subsystem, $"{message}{suffix}");
+                state.lastEmitSeconds = now;
+                state.suppressedCount = 0;
+            }
+            else
+            {
+                state.suppressedCount++;
+            }
+
+            rateLimitStateByKey[compositeKey] = state;
+        }
+
         private static double GetLogClockSeconds()
         {
             if (ClockOverrideForTesting != null)

--- a/Source/Parsek/ParsekPlaybackPolicy.cs
+++ b/Source/Parsek/ParsekPlaybackPolicy.cs
@@ -299,6 +299,7 @@ namespace Parsek
                         // If spawn was blocked, hold the ghost (#96)
                         if (!spawned && evt.GhostWasActive)
                         {
+                            DiagnosticsState.health.spawnFailures++;
                             heldGhosts[evt.Index] = new HeldGhostInfo
                             {
                                 holdStartTime = Time.time,
@@ -387,6 +388,7 @@ namespace Parsek
                 {
                     case HeldGhostAction.RetrySpawn:
                         // Recording is valid and not yet spawned — retry
+                        DiagnosticsState.health.spawnRetries++;
                         if (retryTimeUpdates == null) retryTimeUpdates = new List<KeyValuePair<int, float>>();
                         retryTimeUpdates.Add(new KeyValuePair<int, float>(index, now));
                         host.SpawnVesselOrChainTipFromPolicy(committed[index], index);

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -259,6 +259,7 @@ namespace Parsek
         {
             DiagnosticsState.ResetSessionCounters();
             var sw = Stopwatch.StartNew();
+            int loadedRecordingCount = 0;
             try
             {
                 // Reset deferred dialog flag and clear input lock (dialog may have been
@@ -267,6 +268,7 @@ namespace Parsek
                 InputLockManager.RemoveControlLock("ParsekMergeDialog");
 
                 var recordings = RecordingStore.CommittedRecordings;
+                loadedRecordingCount = recordings.Count;
 
                 RegisterMainMenuHook();
                 DetectSaveFolderChange();
@@ -722,8 +724,8 @@ namespace Parsek
             }
             finally
             {
-                if (sw.IsRunning)
-                    sw.Stop();
+                // Always capture timing, even on exception (matches OnSave pattern)
+                WriteLoadTiming(sw, loadedRecordingCount);
             }
         }
 

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -300,6 +300,7 @@ namespace Parsek
                     {
                         HandleRewindOnLoad(node, recordings);
                         WriteLoadTiming(sw, recordings.Count);
+                        DiagnosticsComputation.EmitSceneLoadSnapshot(recordings.Count, HighLogic.LoadedScene.ToString());
                         return;
                     }
 
@@ -585,6 +586,7 @@ namespace Parsek
                     LedgerOrchestrator.RecalculateAndPatch();
                     ParsekLog.Info("Scenario", $"{(isRevert ? "Revert" : "Scene change")} — preserving {recordings.Count} session recordings");
                     WriteLoadTiming(sw, recordings.Count);
+                    DiagnosticsComputation.EmitSceneLoadSnapshot(recordings.Count, HighLogic.LoadedScene.ToString());
                     return;
                 }
 
@@ -723,6 +725,9 @@ namespace Parsek
                 }
 
                 WriteLoadTiming(sw, recordings.Count);
+
+                // Scene load memory snapshot (once per load, after all recordings are loaded)
+                DiagnosticsComputation.EmitSceneLoadSnapshot(recordings.Count, HighLogic.LoadedScene.ToString());
             }
             finally
             {

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -30,6 +30,8 @@ namespace Parsek
         public override void OnSave(ConfigNode node)
         {
             var sw = Stopwatch.StartNew();
+            int recordingCount = 0;
+            int dirtyCount = 0;
             try
             {
                 SafetyNetAutoCommitPending();
@@ -50,10 +52,10 @@ namespace Parsek
                 node.RemoveNodes("RECORDING");
 
                 var recordings = RecordingStore.CommittedRecordings;
+                recordingCount = recordings.Count;
                 ParsekLog.Info("Scenario", $"OnSave: saving {recordings.Count} committed recordings, epoch={MilestoneStore.CurrentEpoch}");
 
                 // Count dirty recordings before save (SaveRecordingFiles clears FilesDirty)
-                int dirtyCount = 0;
                 for (int i = 0; i < recordings.Count; i++)
                 {
                     if (recordings[i].FilesDirty)
@@ -82,23 +84,12 @@ namespace Parsek
                 }
 
                 lastOnSaveScene = HighLogic.LoadedScene;
-
-                sw.Stop();
-                DiagnosticsState.lastSaveTiming = new SaveLoadTiming
-                {
-                    totalMilliseconds = sw.ElapsedMilliseconds,
-                    recordingsProcessed = recordings.Count,
-                    dirtyRecordingsWritten = dirtyCount
-                };
-                ParsekLog.Verbose("Diagnostics",
-                    string.Format(CultureInfo.InvariantCulture,
-                        "OnSave: {0}ms ({1} dirty of {2})",
-                        sw.ElapsedMilliseconds, dirtyCount, recordings.Count));
             }
             finally
             {
                 if (sw.IsRunning)
                     sw.Stop();
+                WriteSaveTiming(sw, recordingCount, dirtyCount);
             }
         }
 
@@ -872,6 +863,26 @@ namespace Parsek
                 string.Format(CultureInfo.InvariantCulture,
                     "OnLoad: {0}ms ({1} recordings)",
                     sw.ElapsedMilliseconds, recordingCount));
+        }
+
+        /// <summary>
+        /// Writes OnSave timing to DiagnosticsState and logs a summary.
+        /// Called from the finally block of OnSave to ensure timing is captured
+        /// even if an exception occurs during the save process.
+        /// </summary>
+        private static void WriteSaveTiming(Stopwatch sw, int recordingCount, int dirtyCount)
+        {
+            sw.Stop();
+            DiagnosticsState.lastSaveTiming = new SaveLoadTiming
+            {
+                totalMilliseconds = sw.ElapsedMilliseconds,
+                recordingsProcessed = recordingCount,
+                dirtyRecordingsWritten = dirtyCount
+            };
+            ParsekLog.Verbose("Diagnostics",
+                string.Format(CultureInfo.InvariantCulture,
+                    "OnSave: {0}ms ({1} dirty of {2})",
+                    sw.ElapsedMilliseconds, dirtyCount, recordingCount));
         }
 
         /// <summary>

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using UnityEngine;
 
@@ -28,39 +29,77 @@ namespace Parsek
 
         public override void OnSave(ConfigNode node)
         {
-            SafetyNetAutoCommitPending();
-
-            // Diagnostic: detect if HighLogic.SaveFolder changed since this scenario loaded.
-            // Under normal KSP flow OnSave fires before the folder changes, but if it doesn't,
-            // file writes (SaveRecordingFiles, GameStateStore, MilestoneStore) would target
-            // the wrong save directory.
-            string currentSaveFolder = HighLogic.SaveFolder;
-            if (IsSaveFolderMismatch(scenarioSaveFolder, currentSaveFolder))
+            var sw = Stopwatch.StartNew();
+            try
             {
-                ParsekLog.Warn("Scenario",
-                    $"OnSave: save folder mismatch — loaded for '{scenarioSaveFolder}' " +
-                    $"but current is '{currentSaveFolder}'. Data may write to wrong save directory.");
+                SafetyNetAutoCommitPending();
+
+                // Diagnostic: detect if HighLogic.SaveFolder changed since this scenario loaded.
+                // Under normal KSP flow OnSave fires before the folder changes, but if it doesn't,
+                // file writes (SaveRecordingFiles, GameStateStore, MilestoneStore) would target
+                // the wrong save directory.
+                string currentSaveFolder = HighLogic.SaveFolder;
+                if (IsSaveFolderMismatch(scenarioSaveFolder, currentSaveFolder))
+                {
+                    ParsekLog.Warn("Scenario",
+                        $"OnSave: save folder mismatch — loaded for '{scenarioSaveFolder}' " +
+                        $"but current is '{currentSaveFolder}'. Data may write to wrong save directory.");
+                }
+
+                // Clear any existing recording nodes
+                node.RemoveNodes("RECORDING");
+
+                var recordings = RecordingStore.CommittedRecordings;
+                ParsekLog.Info("Scenario", $"OnSave: saving {recordings.Count} committed recordings, epoch={MilestoneStore.CurrentEpoch}");
+
+                // Count dirty recordings before save (SaveRecordingFiles clears FilesDirty)
+                int dirtyCount = 0;
+                for (int i = 0; i < recordings.Count; i++)
+                {
+                    if (recordings[i].FilesDirty)
+                        dirtyCount++;
+                }
+                var committedTrees = RecordingStore.CommittedTrees;
+                for (int t = 0; t < committedTrees.Count; t++)
+                {
+                    foreach (var rec in committedTrees[t].Recordings.Values)
+                    {
+                        if (rec.FilesDirty)
+                            dirtyCount++;
+                    }
+                }
+
+                SaveStandaloneRecordings(node, recordings);
+                SaveTreeRecordings(node);
+                PersistGameStateAndMilestones(node);
+
+                // Strip ghost map ProtoVessels — they are transient and reconstructed on load
+                if (GhostMapPresence.ghostMapVesselPids.Count > 0)
+                {
+                    var flightState = HighLogic.CurrentGame?.flightState;
+                    if (flightState != null)
+                        GhostMapPresence.StripFromSave(flightState);
+                }
+
+                lastOnSaveScene = HighLogic.LoadedScene;
+
+                sw.Stop();
+                DiagnosticsState.lastSaveTiming = new SaveLoadTiming
+                {
+                    totalMilliseconds = sw.ElapsedMilliseconds,
+                    recordingsProcessed = recordings.Count,
+                    dirtyRecordingsWritten = dirtyCount
+                };
+                ParsekLog.Verbose("Diagnostics",
+                    string.Format(CultureInfo.InvariantCulture,
+                        "OnSave: {0}ms ({1} dirty of {2})",
+                        sw.ElapsedMilliseconds, dirtyCount, recordings.Count));
             }
-
-            // Clear any existing recording nodes
-            node.RemoveNodes("RECORDING");
-
-            var recordings = RecordingStore.CommittedRecordings;
-            ParsekLog.Info("Scenario", $"OnSave: saving {recordings.Count} committed recordings, epoch={MilestoneStore.CurrentEpoch}");
-
-            SaveStandaloneRecordings(node, recordings);
-            SaveTreeRecordings(node);
-            PersistGameStateAndMilestones(node);
-
-            // Strip ghost map ProtoVessels — they are transient and reconstructed on load
-            if (GhostMapPresence.ghostMapVesselPids.Count > 0)
+            finally
             {
-                var flightState = HighLogic.CurrentGame?.flightState;
-                if (flightState != null)
-                    GhostMapPresence.StripFromSave(flightState);
+                if (sw.IsRunning)
+                    sw.Stop();
             }
-
-            lastOnSaveScene = HighLogic.LoadedScene;
         }
 
         /// <summary>
@@ -227,454 +266,468 @@ namespace Parsek
 
         public override void OnLoad(ConfigNode node)
         {
-            // Reset deferred dialog flag and clear input lock (dialog may have been
-            // destroyed by scene change without the user clicking a button)
-            mergeDialogPending = false;
-            InputLockManager.RemoveControlLock("ParsekMergeDialog");
-
-            var recordings = RecordingStore.CommittedRecordings;
-
-            RegisterMainMenuHook();
-            DetectSaveFolderChange();
-            LoadCrewAndGroupState(node);
-
-            // Game state recorder lifecycle — re-subscribe on every OnLoad (handles reverts)
-            stateRecorder?.Unsubscribe();
-            if (!initialLoadDone)
-                LoadExternalFilesAndRestoreEpoch(node);
-            stateRecorder = new GameStateRecorder();
-            stateRecorder.SeedFacilityCacheFromCurrentState();
-            stateRecorder.Subscribe();
-
-            SubscribeVesselLifecycleEvents();
-            CaptureInitialBaseline();
-
-            if (initialLoadDone)
+            DiagnosticsState.ResetSessionCounters();
+            var sw = Stopwatch.StartNew();
+            try
             {
-                // Go-back detection: must be BEFORE revert detection and BEFORE any
-                // .sfs data loading. In-memory state is the source of truth.
-                if (RewindContext.IsRewinding)
+                // Reset deferred dialog flag and clear input lock (dialog may have been
+                // destroyed by scene change without the user clicking a button)
+                mergeDialogPending = false;
+                InputLockManager.RemoveControlLock("ParsekMergeDialog");
+
+                var recordings = RecordingStore.CommittedRecordings;
+
+                RegisterMainMenuHook();
+                DetectSaveFolderChange();
+                LoadCrewAndGroupState(node);
+
+                // Game state recorder lifecycle — re-subscribe on every OnLoad (handles reverts)
+                stateRecorder?.Unsubscribe();
+                if (!initialLoadDone)
+                    LoadExternalFilesAndRestoreEpoch(node);
+                stateRecorder = new GameStateRecorder();
+                stateRecorder.SeedFacilityCacheFromCurrentState();
+                stateRecorder.Subscribe();
+
+                SubscribeVesselLifecycleEvents();
+                CaptureInitialBaseline();
+
+                if (initialLoadDone)
                 {
-                    HandleRewindOnLoad(node, recordings);
-                    return;
-                }
-
-                // Detect revert vs scene change. On a revert, the quicksave is older:
-                // its epoch is lower (after a prior revert bumped it) or it has fewer
-                // recordings (new ones were committed since launch). On a scene change,
-                // the most recent OnSave wrote the current epoch and recording count.
-                ConfigNode[] savedRecNodes = node.GetNodes("RECORDING");
-                uint savedEpoch = 0;
-                string savedEpochStr = node.GetValue("milestoneEpoch");
-                if (savedEpochStr != null)
-                    uint.TryParse(savedEpochStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out savedEpoch);
-
-                // Count tree recordings from saved tree nodes for accurate revert detection.
-                // Tree recordings are in committedRecordings but NOT in standalone RECORDING nodes.
-                ConfigNode[] savedTreeNodesForRevert = node.GetNodes("RECORDING_TREE");
-                int savedTreeRecCount = 0;
-                for (int t = 0; t < savedTreeNodesForRevert.Length; t++)
-                    savedTreeRecCount += savedTreeNodesForRevert[t].GetNodes("RECORDING").Length;
-                int totalSavedRecCount = savedRecNodes.Length + savedTreeRecCount;
-
-                // FLIGHT→FLIGHT is usually a revert (Revert to Launch or quickload),
-                // but vessel switching also triggers FLIGHT→FLIGHT scene reloads.
-                bool isFlightToFlight = lastOnSaveScene == GameScenes.FLIGHT
-                                        && HighLogic.LoadedScene == GameScenes.FLIGHT;
-                bool isVesselSwitch = isFlightToFlight && vesselSwitchPending;
-                vesselSwitchPending = false; // consume the flag
-
-                bool isRevert = !isVesselSwitch
-                                && (savedEpoch < MilestoneStore.CurrentEpoch
-                                    || totalSavedRecCount < recordings.Count
-                                    || isFlightToFlight);
-                ParsekLog.Verbose("Scenario",
-                    $"OnLoad: revert detection — savedEpoch={savedEpoch}, currentEpoch={MilestoneStore.CurrentEpoch}, " +
-                    $"savedRecNodes={savedRecNodes.Length}, savedTreeRecs={savedTreeRecCount}, " +
-                    $"memoryRecordings={recordings.Count}, lastOnSaveScene={lastOnSaveScene}, " +
-                    $"isFlightToFlight={isFlightToFlight}, isVesselSwitch={isVesselSwitch}, isRevert={isRevert}");
-
-                // Collect spawned vessel PIDs + names BEFORE restore resets them.
-                // Only on revert — on normal scene changes the spawned vessels are
-                // legitimate and must not be cleaned up.
-                // Guard: if cleanup data was already set by a prior rewind path,
-                // do NOT overwrite — the rewind path's data is authoritative.
-                // (After rewind, ResetAllPlaybackState zeros spawn tracking, so
-                // CollectSpawnedVesselInfo returns empty here and would clobber
-                // the rewind data with null.)
-                if (isRevert)
-                {
-                    bool alreadyHasCleanupData = RecordingStore.PendingCleanupPids != null
-                                                  || RecordingStore.PendingCleanupNames != null;
-                    if (alreadyHasCleanupData)
+                    // Go-back detection: must be BEFORE revert detection and BEFORE any
+                    // .sfs data loading. In-memory state is the source of truth.
+                    if (RewindContext.IsRewinding)
                     {
-                        ParsekLog.Info("Scenario",
-                            $"OnLoad: revert path skipping cleanup collection — " +
-                            $"already set ({RecordingStore.PendingCleanupPids?.Count ?? 0} pid(s), " +
-                            $"{RecordingStore.PendingCleanupNames?.Count ?? 0} name(s)) from prior rewind/revert");
-                    }
-                    else
-                    {
-                        var info = RecordingStore.CollectSpawnedVesselInfo();
-                        var spawnedPids = info.pids.Count > 0 ? info.pids : null;
-                        var spawnedNames = info.names.Count > 0 ? info.names : null;
-                        RecordingStore.PendingCleanupPids = spawnedPids;
-                        RecordingStore.PendingCleanupNames = spawnedNames;
-                        ParsekLog.Verbose("Scenario",
-                            $"OnLoad: revert cleanup collected — " +
-                            $"{spawnedPids?.Count ?? 0} pid(s), {spawnedNames?.Count ?? 0} name(s)");
+                        HandleRewindOnLoad(node, recordings);
+                        WriteLoadTiming(sw, recordings.Count);
+                        return;
                     }
 
-                    // Clear pending tree/recording from a PREVIOUS flight — dialog was shown
-                    // but user reverted before acting on it. Prevents OnFlightReady fallback
-                    // from showing the dialog again (#64).
-                    // However, if the pending was stashed during THIS scene transition
-                    // (OnSceneChangeRequested → StashPending/StashPendingTree), it is fresh
-                    // and must survive so OnFlightReady can show the merge dialog.
-                    if (RecordingStore.PendingStashedThisTransition)
+                    // Detect revert vs scene change. On a revert, the quicksave is older:
+                    // its epoch is lower (after a prior revert bumped it) or it has fewer
+                    // recordings (new ones were committed since launch). On a scene change,
+                    // the most recent OnSave wrote the current epoch and recording count.
+                    ConfigNode[] savedRecNodes = node.GetNodes("RECORDING");
+                    uint savedEpoch = 0;
+                    string savedEpochStr = node.GetValue("milestoneEpoch");
+                    if (savedEpochStr != null)
+                        uint.TryParse(savedEpochStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out savedEpoch);
+
+                    // Count tree recordings from saved tree nodes for accurate revert detection.
+                    // Tree recordings are in committedRecordings but NOT in standalone RECORDING nodes.
+                    ConfigNode[] savedTreeNodesForRevert = node.GetNodes("RECORDING_TREE");
+                    int savedTreeRecCount = 0;
+                    for (int t = 0; t < savedTreeNodesForRevert.Length; t++)
+                        savedTreeRecCount += savedTreeNodesForRevert[t].GetNodes("RECORDING").Length;
+                    int totalSavedRecCount = savedRecNodes.Length + savedTreeRecCount;
+
+                    // FLIGHT→FLIGHT is usually a revert (Revert to Launch or quickload),
+                    // but vessel switching also triggers FLIGHT→FLIGHT scene reloads.
+                    bool isFlightToFlight = lastOnSaveScene == GameScenes.FLIGHT
+                                            && HighLogic.LoadedScene == GameScenes.FLIGHT;
+                    bool isVesselSwitch = isFlightToFlight && vesselSwitchPending;
+                    vesselSwitchPending = false; // consume the flag
+
+                    bool isRevert = !isVesselSwitch
+                                    && (savedEpoch < MilestoneStore.CurrentEpoch
+                                        || totalSavedRecCount < recordings.Count
+                                        || isFlightToFlight);
+                    ParsekLog.Verbose("Scenario",
+                        $"OnLoad: revert detection — savedEpoch={savedEpoch}, currentEpoch={MilestoneStore.CurrentEpoch}, " +
+                        $"savedRecNodes={savedRecNodes.Length}, savedTreeRecs={savedTreeRecCount}, " +
+                        $"memoryRecordings={recordings.Count}, lastOnSaveScene={lastOnSaveScene}, " +
+                        $"isFlightToFlight={isFlightToFlight}, isVesselSwitch={isVesselSwitch}, isRevert={isRevert}");
+
+                    // Collect spawned vessel PIDs + names BEFORE restore resets them.
+                    // Only on revert — on normal scene changes the spawned vessels are
+                    // legitimate and must not be cleaned up.
+                    // Guard: if cleanup data was already set by a prior rewind path,
+                    // do NOT overwrite — the rewind path's data is authoritative.
+                    // (After rewind, ResetAllPlaybackState zeros spawn tracking, so
+                    // CollectSpawnedVesselInfo returns empty here and would clobber
+                    // the rewind data with null.)
+                    if (isRevert)
                     {
-                        ParsekLog.Info("Scenario",
-                            "Revert: keeping freshly-stashed pending (stashed this transition) — " +
-                            $"tree={RecordingStore.HasPendingTree}, standalone={RecordingStore.HasPending}");
-                        RecordingStore.PendingStashedThisTransition = false;
-                    }
-                    else
-                    {
-                        if (RecordingStore.HasPendingTree)
+                        bool alreadyHasCleanupData = RecordingStore.PendingCleanupPids != null
+                                                      || RecordingStore.PendingCleanupNames != null;
+                        if (alreadyHasCleanupData)
                         {
-                            ParsekLog.Info("Scenario", "Clearing orphaned pending tree on revert (stale from previous flight)");
-                            RecordingStore.DiscardPendingTree();
+                            ParsekLog.Info("Scenario",
+                                $"OnLoad: revert path skipping cleanup collection — " +
+                                $"already set ({RecordingStore.PendingCleanupPids?.Count ?? 0} pid(s), " +
+                                $"{RecordingStore.PendingCleanupNames?.Count ?? 0} name(s)) from prior rewind/revert");
                         }
-                        if (RecordingStore.HasPending)
+                        else
                         {
-                            ParsekLog.Info("Scenario", "Clearing orphaned pending recording on revert (stale from previous flight)");
-                            RecordingStore.DiscardPending();
+                            var info = RecordingStore.CollectSpawnedVesselInfo();
+                            var spawnedPids = info.pids.Count > 0 ? info.pids : null;
+                            var spawnedNames = info.names.Count > 0 ? info.names : null;
+                            RecordingStore.PendingCleanupPids = spawnedPids;
+                            RecordingStore.PendingCleanupNames = spawnedNames;
+                            ParsekLog.Verbose("Scenario",
+                                $"OnLoad: revert cleanup collected — " +
+                                $"{spawnedPids?.Count ?? 0} pid(s), {spawnedNames?.Count ?? 0} name(s)");
                         }
-                    }
-                }
 
-                // Restore mutable state from save. On revert the launch quicksave has
-                // no spawnedPid / lastResIdx, so they naturally reset.
-                // On non-revert scene changes (e.g. tracking station → flight) the
-                // save preserves these, preventing duplicate spawns and ghost replays.
-                // NOTE: This loop only covers standalone recordings (not tree recordings).
-                // Tree recordings get their mutable state from RECORDING_TREE nodes below.
-                // Match by recordingId (not positional index) — the saved RECORDING nodes
-                // may be from a stale quicksave with a different number/order of recordings
-                // than the current in-memory list (e.g. after clear-all + re-record).
-                RestoreStandaloneMutableState(recordings, savedRecNodes);
-
-                // Restore tree recording mutable state from RECORDING_TREE nodes.
-                // First, reset ALL tree recordings to defaults. On revert, the launch
-                // quicksave has no tree nodes so this reset is the only thing that runs,
-                // ensuring VesselSpawned/SpawnedPid/etc. don't carry over from the
-                // committed flight (whose vessels were undone by the revert).
-                // On scene change, the reset is overwritten by the saved values below.
-                for (int i = 0; i < recordings.Count; i++)
-                {
-                    if (!recordings[i].IsTreeRecording) continue;
-
-                    RecordingStore.RollbackContinuationData(recordings[i]);
-                    ClearPostSpawnTerminalState(recordings[i], "tree recording");
-
-                    recordings[i].VesselSpawned = false;
-                    recordings[i].SpawnAttempts = 0;
-                    recordings[i].SpawnDeathCount = 0;
-                    recordings[i].SpawnedVesselPersistentId = 0;
-
-                    recordings[i].LastAppliedResourceIndex = -1;
-                }
-
-                // Strip orphaned spawned vessels from flightState on revert.
-                // These vessels were spawned by Parsek in a previous flight but their
-                // tracking was lost when spawn flags were reset. Without stripping,
-                // they contaminate the next launch quicksave and persist across reverts.
-                // Use RecordingStore.PendingCleanupNames as the authoritative source —
-                // the local collection may have been skipped by the guard above.
-                var cleanupNames = RecordingStore.PendingCleanupNames;
-                if (isRevert && cleanupNames != null && cleanupNames.Count > 0)
-                {
-                    var flightState = HighLogic.CurrentGame?.flightState;
-                    if (flightState != null)
-                        StripOrphanedSpawnedVessels(flightState.protoVessels, cleanupNames,
-                            skipPrelaunch: true);
-                }
-
-                // Rescue crew orphaned by vessel stripping (#116)
-                if (isRevert && HighLogic.CurrentGame?.flightState != null)
-                    CrewReservationManager.RescueOrphanedCrew(
-                        HighLogic.CurrentGame.flightState.protoVessels);
-
-                // Then restore from saved tree nodes (present on scene change, absent on revert)
-                ConfigNode[] savedTreeNodes = node.GetNodes("RECORDING_TREE");
-                if (savedTreeNodes.Length > 0)
-                {
-                    // Rebuild tree mutable state from saved tree nodes
-                    foreach (var savedTreeNode in savedTreeNodes)
-                    {
-                        ConfigNode[] savedTreeRecNodes = savedTreeNode.GetNodes("RECORDING");
-                        foreach (var savedTreeRecNode in savedTreeRecNodes)
+                        // Clear pending tree/recording from a PREVIOUS flight — dialog was shown
+                        // but user reverted before acting on it. Prevents OnFlightReady fallback
+                        // from showing the dialog again (#64).
+                        // However, if the pending was stashed during THIS scene transition
+                        // (OnSceneChangeRequested → StashPending/StashPendingTree), it is fresh
+                        // and must survive so OnFlightReady can show the merge dialog.
+                        if (RecordingStore.PendingStashedThisTransition)
                         {
-                            string savedRecId = savedTreeRecNode.GetValue("recordingId");
-                            if (string.IsNullOrEmpty(savedRecId)) continue;
-
-                            // Find the in-memory recording by ID and restore mutable state
-                            for (int i = 0; i < recordings.Count; i++)
+                            ParsekLog.Info("Scenario",
+                                "Revert: keeping freshly-stashed pending (stashed this transition) — " +
+                                $"tree={RecordingStore.HasPendingTree}, standalone={RecordingStore.HasPending}");
+                            RecordingStore.PendingStashedThisTransition = false;
+                        }
+                        else
+                        {
+                            if (RecordingStore.HasPendingTree)
                             {
-                                if (recordings[i].RecordingId == savedRecId)
+                                ParsekLog.Info("Scenario", "Clearing orphaned pending tree on revert (stale from previous flight)");
+                                RecordingStore.DiscardPendingTree();
+                            }
+                            if (RecordingStore.HasPending)
+                            {
+                                ParsekLog.Info("Scenario", "Clearing orphaned pending recording on revert (stale from previous flight)");
+                                RecordingStore.DiscardPending();
+                            }
+                        }
+                    }
+
+                    // Restore mutable state from save. On revert the launch quicksave has
+                    // no spawnedPid / lastResIdx, so they naturally reset.
+                    // On non-revert scene changes (e.g. tracking station → flight) the
+                    // save preserves these, preventing duplicate spawns and ghost replays.
+                    // NOTE: This loop only covers standalone recordings (not tree recordings).
+                    // Tree recordings get their mutable state from RECORDING_TREE nodes below.
+                    // Match by recordingId (not positional index) — the saved RECORDING nodes
+                    // may be from a stale quicksave with a different number/order of recordings
+                    // than the current in-memory list (e.g. after clear-all + re-record).
+                    RestoreStandaloneMutableState(recordings, savedRecNodes);
+
+                    // Restore tree recording mutable state from RECORDING_TREE nodes.
+                    // First, reset ALL tree recordings to defaults. On revert, the launch
+                    // quicksave has no tree nodes so this reset is the only thing that runs,
+                    // ensuring VesselSpawned/SpawnedPid/etc. don't carry over from the
+                    // committed flight (whose vessels were undone by the revert).
+                    // On scene change, the reset is overwritten by the saved values below.
+                    for (int i = 0; i < recordings.Count; i++)
+                    {
+                        if (!recordings[i].IsTreeRecording) continue;
+
+                        RecordingStore.RollbackContinuationData(recordings[i]);
+                        ClearPostSpawnTerminalState(recordings[i], "tree recording");
+
+                        recordings[i].VesselSpawned = false;
+                        recordings[i].SpawnAttempts = 0;
+                        recordings[i].SpawnDeathCount = 0;
+                        recordings[i].SpawnedVesselPersistentId = 0;
+
+                        recordings[i].LastAppliedResourceIndex = -1;
+                    }
+
+                    // Strip orphaned spawned vessels from flightState on revert.
+                    // These vessels were spawned by Parsek in a previous flight but their
+                    // tracking was lost when spawn flags were reset. Without stripping,
+                    // they contaminate the next launch quicksave and persist across reverts.
+                    // Use RecordingStore.PendingCleanupNames as the authoritative source —
+                    // the local collection may have been skipped by the guard above.
+                    var cleanupNames = RecordingStore.PendingCleanupNames;
+                    if (isRevert && cleanupNames != null && cleanupNames.Count > 0)
+                    {
+                        var flightState = HighLogic.CurrentGame?.flightState;
+                        if (flightState != null)
+                            StripOrphanedSpawnedVessels(flightState.protoVessels, cleanupNames,
+                                skipPrelaunch: true);
+                    }
+
+                    // Rescue crew orphaned by vessel stripping (#116)
+                    if (isRevert && HighLogic.CurrentGame?.flightState != null)
+                        CrewReservationManager.RescueOrphanedCrew(
+                            HighLogic.CurrentGame.flightState.protoVessels);
+
+                    // Then restore from saved tree nodes (present on scene change, absent on revert)
+                    ConfigNode[] savedTreeNodes = node.GetNodes("RECORDING_TREE");
+                    if (savedTreeNodes.Length > 0)
+                    {
+                        // Rebuild tree mutable state from saved tree nodes
+                        foreach (var savedTreeNode in savedTreeNodes)
+                        {
+                            ConfigNode[] savedTreeRecNodes = savedTreeNode.GetNodes("RECORDING");
+                            foreach (var savedTreeRecNode in savedTreeRecNodes)
+                            {
+                                string savedRecId = savedTreeRecNode.GetValue("recordingId");
+                                if (string.IsNullOrEmpty(savedRecId)) continue;
+
+                                // Find the in-memory recording by ID and restore mutable state
+                                for (int i = 0; i < recordings.Count; i++)
                                 {
-                                    string pidStr = savedTreeRecNode.GetValue("spawnedPid");
-                                    uint savedPid = 0;
-                                    if (pidStr != null)
-                                        uint.TryParse(pidStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out savedPid);
-                                    recordings[i].SpawnedVesselPersistentId = savedPid;
+                                    if (recordings[i].RecordingId == savedRecId)
+                                    {
+                                        string pidStr = savedTreeRecNode.GetValue("spawnedPid");
+                                        uint savedPid = 0;
+                                        if (pidStr != null)
+                                            uint.TryParse(pidStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out savedPid);
+                                        recordings[i].SpawnedVesselPersistentId = savedPid;
 
-                                    string resIdxStr = savedTreeRecNode.GetValue("lastResIdx");
-                                    int resIdx = -1;
-                                    if (resIdxStr != null)
-                                        int.TryParse(resIdxStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out resIdx);
-                                    recordings[i].LastAppliedResourceIndex = resIdx;
+                                        string resIdxStr = savedTreeRecNode.GetValue("lastResIdx");
+                                        int resIdx = -1;
+                                        if (resIdxStr != null)
+                                            int.TryParse(resIdxStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out resIdx);
+                                        recordings[i].LastAppliedResourceIndex = resIdx;
 
-                                    break;
+                                        break;
+                                    }
                                 }
                             }
                         }
                     }
-                }
 
-                // Reconcile spawn state after all restore + strip operations (#168).
-                // If a recording's SpawnedVesselPersistentId points to a vessel that was
-                // stripped, reset the PID so the vessel can be re-spawned at the correct time.
-                if (isRevert)
-                {
-                    var flightStateForReconcile = HighLogic.CurrentGame?.flightState;
-                    if (flightStateForReconcile != null)
-                        ReconcileSpawnStateAfterStrip(flightStateForReconcile.protoVessels, recordings);
-                }
-
-                if (isRevert)
-                {
-                    // Restore milestone mutable state from .sfs and increment epoch.
-                    // resetUnmatched: true — milestones created after the launch quicksave
-                    // (not in the saved state) must be reset to unreplayed (-1).
-                    MilestoneStore.RestoreMutableState(node, resetUnmatched: true);
-                    MilestoneStore.CurrentEpoch++;
-                    ParsekLog.Info("Scenario", $"Milestone epoch incremented to {MilestoneStore.CurrentEpoch} on revert");
-
-                    // Schedule committed resource deduction (singletons may not be ready yet)
-                    ParsekLog.Verbose("Scenario", "Scheduling budget deduction coroutine (singletons may not be ready yet)");
-
-                    StartCoroutine(ApplyBudgetDeductionWhenReady());
-                }
-                else
-                {
-                    // Scene change — restore milestone state without resetting unmatched.
-                    MilestoneStore.RestoreMutableState(node);
-                    ParsekLog.Verbose("Scenario", "Scene change — milestone state restored (resetUnmatched=false)");
-                }
-
-                // Handle pending recordings on non-revert scene exits to non-flight scenes.
-                // Always auto-commit on main menu (game is being unloaded, dialog would be meaningless).
-                bool forceAutoMerge = HighLogic.LoadedScene == GameScenes.MAINMENU;
-                if (!isRevert && HighLogic.LoadedScene != GameScenes.FLIGHT)
-                {
-                    if (IsAutoMerge || forceAutoMerge)
+                    // Reconcile spawn state after all restore + strip operations (#168).
+                    // If a recording's SpawnedVesselPersistentId points to a vessel that was
+                    // stripped, reset the PID so the vessel can be re-spawned at the correct time.
+                    if (isRevert)
                     {
-                        // Check if commit approval dialog should be shown (#88):
-                        // landed/splashed vessel going to KSC or Tracking Station
-                        var destScene = RecordingStore.PendingDestinationScene;
-                        TerminalState? termState = null;
-                        if (RecordingStore.HasPending)
-                            termState = RecordingStore.Pending.TerminalStateValue;
-                        else if (RecordingStore.HasPendingTree)
-                        {
-                            // Find root recording's terminal state from tree
-                            Recording rootRec;
-                            if (RecordingStore.PendingTree.Recordings.TryGetValue(
-                                RecordingStore.PendingTree.RootRecordingId, out rootRec))
-                                termState = rootRec.TerminalStateValue;
-                        }
-                        bool showApproval = !forceAutoMerge && destScene.HasValue &&
-                            GhostPlaybackLogic.ShouldShowCommitApproval(destScene.Value, termState);
-                        RecordingStore.PendingDestinationScene = null;
+                        var flightStateForReconcile = HighLogic.CurrentGame?.flightState;
+                        if (flightStateForReconcile != null)
+                            ReconcileSpawnStateAfterStrip(flightStateForReconcile.protoVessels, recordings);
+                    }
 
-                        if (showApproval && !mergeDialogPending)
+                    if (isRevert)
+                    {
+                        // Restore milestone mutable state from .sfs and increment epoch.
+                        // resetUnmatched: true — milestones created after the launch quicksave
+                        // (not in the saved state) must be reset to unreplayed (-1).
+                        MilestoneStore.RestoreMutableState(node, resetUnmatched: true);
+                        MilestoneStore.CurrentEpoch++;
+                        ParsekLog.Info("Scenario", $"Milestone epoch incremented to {MilestoneStore.CurrentEpoch} on revert");
+
+                        // Schedule committed resource deduction (singletons may not be ready yet)
+                        ParsekLog.Verbose("Scenario", "Scheduling budget deduction coroutine (singletons may not be ready yet)");
+
+                        StartCoroutine(ApplyBudgetDeductionWhenReady());
+                    }
+                    else
+                    {
+                        // Scene change — restore milestone state without resetting unmatched.
+                        MilestoneStore.RestoreMutableState(node);
+                        ParsekLog.Verbose("Scenario", "Scene change — milestone state restored (resetUnmatched=false)");
+                    }
+
+                    // Handle pending recordings on non-revert scene exits to non-flight scenes.
+                    // Always auto-commit on main menu (game is being unloaded, dialog would be meaningless).
+                    bool forceAutoMerge = HighLogic.LoadedScene == GameScenes.MAINMENU;
+                    if (!isRevert && HighLogic.LoadedScene != GameScenes.FLIGHT)
+                    {
+                        if (IsAutoMerge || forceAutoMerge)
                         {
-                            // Defer to approval dialog instead of auto-committing
+                            // Check if commit approval dialog should be shown (#88):
+                            // landed/splashed vessel going to KSC or Tracking Station
+                            var destScene = RecordingStore.PendingDestinationScene;
+                            TerminalState? termState = null;
+                            if (RecordingStore.HasPending)
+                                termState = RecordingStore.Pending.TerminalStateValue;
+                            else if (RecordingStore.HasPendingTree)
+                            {
+                                // Find root recording's terminal state from tree
+                                Recording rootRec;
+                                if (RecordingStore.PendingTree.Recordings.TryGetValue(
+                                    RecordingStore.PendingTree.RootRecordingId, out rootRec))
+                                    termState = rootRec.TerminalStateValue;
+                            }
+                            bool showApproval = !forceAutoMerge && destScene.HasValue &&
+                                GhostPlaybackLogic.ShouldShowCommitApproval(destScene.Value, termState);
+                            RecordingStore.PendingDestinationScene = null;
+
+                            if (showApproval && !mergeDialogPending)
+                            {
+                                // Defer to approval dialog instead of auto-committing
+                                mergeDialogPending = true;
+                                StartCoroutine(ShowDeferredMergeDialog());
+                                ParsekLog.Info("Scenario",
+                                    "Commit approval deferred: vessel landed/splashed at KSC/TS exit");
+                            }
+                            else
+                            {
+                                // autoMerge ON: auto-commit ghost-only (existing behavior)
+                                if (RecordingStore.HasPending)
+                                {
+                                    AutoCommitGhostOnly(RecordingStore.Pending);
+                                    string recId = RecordingStore.Pending.RecordingId;
+                                    double startUT = RecordingStore.Pending.StartUT;
+                                    double endUT = RecordingStore.Pending.EndUT;
+                                    RecordingStore.CommitPending();
+                                    LedgerOrchestrator.OnRecordingCommitted(recId, startUT, endUT);
+                                    ScreenMessages.PostScreenMessage("[Parsek] Recording committed to timeline", 5f);
+                                }
+                                if (RecordingStore.HasPendingTree)
+                                {
+                                    AutoCommitTreeGhostOnly(RecordingStore.PendingTree);
+                                    var treeToCommit = RecordingStore.PendingTree;
+                                    RecordingStore.CommitPendingTree();
+                                    LedgerOrchestrator.NotifyLedgerTreeCommitted(treeToCommit);
+                                    ScreenMessages.PostScreenMessage("[Parsek] Tree recording committed to timeline", 5f);
+                                }
+                                RecordingStore.RunOptimizationPass();
+                            }
+                        }
+                        else if ((RecordingStore.HasPending || RecordingStore.HasPendingTree) && !mergeDialogPending)
+                        {
+                            // autoMerge OFF: defer to merge dialog in the new scene
                             mergeDialogPending = true;
                             StartCoroutine(ShowDeferredMergeDialog());
-                            ParsekLog.Info("Scenario",
-                                "Commit approval deferred: vessel landed/splashed at KSC/TS exit");
-                        }
-                        else
-                        {
-                            // autoMerge ON: auto-commit ghost-only (existing behavior)
-                            if (RecordingStore.HasPending)
-                            {
-                                AutoCommitGhostOnly(RecordingStore.Pending);
-                                string recId = RecordingStore.Pending.RecordingId;
-                                double startUT = RecordingStore.Pending.StartUT;
-                                double endUT = RecordingStore.Pending.EndUT;
-                                RecordingStore.CommitPending();
-                                LedgerOrchestrator.OnRecordingCommitted(recId, startUT, endUT);
-                                ScreenMessages.PostScreenMessage("[Parsek] Recording committed to timeline", 5f);
-                            }
-                            if (RecordingStore.HasPendingTree)
-                            {
-                                AutoCommitTreeGhostOnly(RecordingStore.PendingTree);
-                                var treeToCommit = RecordingStore.PendingTree;
-                                RecordingStore.CommitPendingTree();
-                                LedgerOrchestrator.NotifyLedgerTreeCommitted(treeToCommit);
-                                ScreenMessages.PostScreenMessage("[Parsek] Tree recording committed to timeline", 5f);
-                            }
-                            RecordingStore.RunOptimizationPass();
                         }
                     }
-                    else if ((RecordingStore.HasPending || RecordingStore.HasPendingTree) && !mergeDialogPending)
+
+                    LedgerOrchestrator.RecalculateAndPatch();
+                    ParsekLog.Info("Scenario", $"{(isRevert ? "Revert" : "Scene change")} — preserving {recordings.Count} session recordings");
+                    WriteLoadTiming(sw, recordings.Count);
+                    return;
+                }
+
+                initialLoadDone = true;
+
+                DiscardStalePendingState();
+
+                recordings.Clear();
+
+                ConfigNode[] recNodes = node.GetNodes("RECORDING");
+                ScenarioLog($"[Parsek Scenario] Loading {recNodes.Length} committed recordings");
+
+                LoadStandaloneRecordingsFromNodes(recNodes, recordings);
+
+                // Validate chain integrity before any playback
+                RecordingStore.ValidateChains();
+
+                LoadRecordingTrees(node, recordings);
+
+                // Clean orphaned sidecar files (recordings deleted in previous sessions)
+                RecordingStore.CleanOrphanFiles();
+
+                // Restore milestone mutable state (LastReplayedEventIndex) from .sfs
+                MilestoneStore.RestoreMutableState(node);
+
+                // Reconcile ledger against loaded recordings (prunes orphaned actions, recalculates)
+                var validIds = new System.Collections.Generic.HashSet<string>();
+                for (int v = 0; v < recordings.Count; v++)
+                {
+                    if (!string.IsNullOrEmpty(recordings[v].RecordingId))
+                        validIds.Add(recordings[v].RecordingId);
+                }
+                double reconcileUT = Planetarium.GetUniversalTime();
+                LedgerOrchestrator.OnKspLoad(validIds, reconcileUT);
+
+                // Schedule deferred seeding: during OnLoad, Funding/R&D/Reputation singletons
+                // may exist but have not loaded their save data yet (KSP loads scenarios in
+                // parallel). The deferred coroutine waits for singletons to be ready, then
+                // seeds initial balances and recalculates so the ledger has correct values.
+                StartCoroutine(DeferredSeedAndRecalculate());
+
+                // Diagnostic summary of loaded recordings with UT context
+                double loadUT = Planetarium.GetUniversalTime();
+                ParsekLog.Info("Scenario", $"Scenario load summary — UT: {loadUT:F0}, {recordings.Count} recording(s)");
+                for (int i = 0; i < recordings.Count; i++)
+                {
+                    var loadedRec = recordings[i];
+                    double duration = loadedRec.EndUT - loadedRec.StartUT;
+                    string status;
+                    if (loadUT < loadedRec.StartUT)
+                        status = $"future (starts in {loadedRec.StartUT - loadUT:F0}s)";
+                    else if (loadUT <= loadedRec.EndUT && duration > 0)
+                        status = $"IN PROGRESS ({(loadUT - loadedRec.StartUT) / duration * 100:F0}%)";
+                    else if (loadUT <= loadedRec.EndUT)
+                        status = "IN PROGRESS";
+                    else
+                        status = "past";
+                    ParsekLog.Verbose("Scenario", $"  #{i}: \"{loadedRec.VesselName}\" — {status}");
+                }
+
+                if (CrewReservationManager.CrewReplacements.Count > 0)
+                {
+                    ParsekLog.Info("Scenario", $"Crew reservations active ({CrewReservationManager.CrewReplacements.Count}):");
+                    foreach (var kvp in CrewReservationManager.CrewReplacements)
+                        ParsekLog.Info("Scenario", $"  {kvp.Key} -> replacement: {kvp.Value}");
+                }
+
+                // Run recording optimization pass (merge redundant segments, split monolithic ones)
+                RecordingStore.RunOptimizationPass();
+
+                // Auto-unreserve crew for recordings whose EndUT has already passed
+                // but vessel was never spawned. Skip at SpaceCenter — ParsekKSC now
+                // handles spawning there (bug #99), so nulling the snapshot here would
+                // pre-empt the KSC spawn.
+                double currentUT = Planetarium.GetUniversalTime();
+                if (HighLogic.LoadedScene != GameScenes.SPACECENTER)
+                {
+                    for (int i = 0; i < recordings.Count; i++)
                     {
-                        // autoMerge OFF: defer to merge dialog in the new scene
+                        var rec = recordings[i];
+                        if (rec.LoopPlayback) continue;
+                        if (rec.VesselSnapshot != null && !rec.VesselSpawned && currentUT > rec.EndUT)
+                        {
+                            CrewReservationManager.UnreserveCrewInSnapshot(rec.VesselSnapshot);
+                            rec.VesselSnapshot = null;
+                            rec.VesselSpawned = true;
+                            ScenarioLog($"[Parsek Scenario] Auto-unreserved crew for recording #{i} " +
+                                $"({rec.VesselName}) — EndUT passed without spawn");
+                        }
+                    }
+                }
+
+                // Handle pending recordings outside Flight (Esc > Abort Mission → Space Center path).
+                // Always auto-commit on main menu (game is being unloaded).
+                if (HighLogic.LoadedScene != GameScenes.FLIGHT &&
+                    (RecordingStore.HasPending || RecordingStore.HasPendingTree))
+                {
+                    if (IsAutoMerge || HighLogic.LoadedScene == GameScenes.MAINMENU)
+                    {
+                        // autoMerge ON: auto-commit ghost-only
+                        if (RecordingStore.HasPending)
+                        {
+                            var pending = RecordingStore.Pending;
+                            if (pending.VesselSnapshot != null)
+                                CrewReservationManager.UnreserveCrewInSnapshot(pending.VesselSnapshot);
+                            pending.VesselSnapshot = null;
+                            string recId = pending.RecordingId;
+                            double startUT = pending.StartUT;
+                            double endUT = pending.EndUT;
+                            RecordingStore.CommitPending();
+                            LedgerOrchestrator.OnRecordingCommitted(recId, startUT, endUT);
+                            ScenarioLog($"[Parsek Scenario] Auto-committed pending recording outside Flight " +
+                                $"(scene: {HighLogic.LoadedScene})");
+                        }
+                        if (RecordingStore.HasPendingTree)
+                        {
+                            var pt = RecordingStore.PendingTree;
+                            foreach (var rec in pt.Recordings.Values)
+                            {
+                                if (rec.VesselSnapshot != null)
+                                    CrewReservationManager.UnreserveCrewInSnapshot(rec.VesselSnapshot);
+                                rec.VesselSnapshot = null;
+                            }
+                            RecordingStore.CommitPendingTree();
+                            LedgerOrchestrator.NotifyLedgerTreeCommitted(pt);
+                            ScenarioLog($"[Parsek Scenario] Auto-committed pending tree outside Flight " +
+                                $"(scene: {HighLogic.LoadedScene})");
+                        }
+                    }
+                    else if (!mergeDialogPending)
+                    {
+                        // autoMerge OFF: defer to merge dialog
                         mergeDialogPending = true;
                         StartCoroutine(ShowDeferredMergeDialog());
                     }
                 }
 
-                LedgerOrchestrator.RecalculateAndPatch();
-                ParsekLog.Info("Scenario", $"{(isRevert ? "Revert" : "Scene change")} — preserving {recordings.Count} session recordings");
-                return;
+                WriteLoadTiming(sw, recordings.Count);
             }
-
-            initialLoadDone = true;
-
-            DiscardStalePendingState();
-
-            recordings.Clear();
-
-            ConfigNode[] recNodes = node.GetNodes("RECORDING");
-            ScenarioLog($"[Parsek Scenario] Loading {recNodes.Length} committed recordings");
-
-            LoadStandaloneRecordingsFromNodes(recNodes, recordings);
-
-            // Validate chain integrity before any playback
-            RecordingStore.ValidateChains();
-
-            LoadRecordingTrees(node, recordings);
-
-            // Clean orphaned sidecar files (recordings deleted in previous sessions)
-            RecordingStore.CleanOrphanFiles();
-
-            // Restore milestone mutable state (LastReplayedEventIndex) from .sfs
-            MilestoneStore.RestoreMutableState(node);
-
-            // Reconcile ledger against loaded recordings (prunes orphaned actions, recalculates)
-            var validIds = new System.Collections.Generic.HashSet<string>();
-            for (int v = 0; v < recordings.Count; v++)
+            finally
             {
-                if (!string.IsNullOrEmpty(recordings[v].RecordingId))
-                    validIds.Add(recordings[v].RecordingId);
-            }
-            double reconcileUT = Planetarium.GetUniversalTime();
-            LedgerOrchestrator.OnKspLoad(validIds, reconcileUT);
-
-            // Schedule deferred seeding: during OnLoad, Funding/R&D/Reputation singletons
-            // may exist but have not loaded their save data yet (KSP loads scenarios in
-            // parallel). The deferred coroutine waits for singletons to be ready, then
-            // seeds initial balances and recalculates so the ledger has correct values.
-            StartCoroutine(DeferredSeedAndRecalculate());
-
-            // Diagnostic summary of loaded recordings with UT context
-            double loadUT = Planetarium.GetUniversalTime();
-            ParsekLog.Info("Scenario", $"Scenario load summary — UT: {loadUT:F0}, {recordings.Count} recording(s)");
-            for (int i = 0; i < recordings.Count; i++)
-            {
-                var loadedRec = recordings[i];
-                double duration = loadedRec.EndUT - loadedRec.StartUT;
-                string status;
-                if (loadUT < loadedRec.StartUT)
-                    status = $"future (starts in {loadedRec.StartUT - loadUT:F0}s)";
-                else if (loadUT <= loadedRec.EndUT && duration > 0)
-                    status = $"IN PROGRESS ({(loadUT - loadedRec.StartUT) / duration * 100:F0}%)";
-                else if (loadUT <= loadedRec.EndUT)
-                    status = "IN PROGRESS";
-                else
-                    status = "past";
-                ParsekLog.Verbose("Scenario", $"  #{i}: \"{loadedRec.VesselName}\" — {status}");
-            }
-
-            if (CrewReservationManager.CrewReplacements.Count > 0)
-            {
-                ParsekLog.Info("Scenario", $"Crew reservations active ({CrewReservationManager.CrewReplacements.Count}):");
-                foreach (var kvp in CrewReservationManager.CrewReplacements)
-                    ParsekLog.Info("Scenario", $"  {kvp.Key} -> replacement: {kvp.Value}");
-            }
-
-            // Run recording optimization pass (merge redundant segments, split monolithic ones)
-            RecordingStore.RunOptimizationPass();
-
-            // Auto-unreserve crew for recordings whose EndUT has already passed
-            // but vessel was never spawned. Skip at SpaceCenter — ParsekKSC now
-            // handles spawning there (bug #99), so nulling the snapshot here would
-            // pre-empt the KSC spawn.
-            double currentUT = Planetarium.GetUniversalTime();
-            if (HighLogic.LoadedScene != GameScenes.SPACECENTER)
-            {
-                for (int i = 0; i < recordings.Count; i++)
-                {
-                    var rec = recordings[i];
-                    if (rec.LoopPlayback) continue;
-                    if (rec.VesselSnapshot != null && !rec.VesselSpawned && currentUT > rec.EndUT)
-                    {
-                        CrewReservationManager.UnreserveCrewInSnapshot(rec.VesselSnapshot);
-                        rec.VesselSnapshot = null;
-                        rec.VesselSpawned = true;
-                        ScenarioLog($"[Parsek Scenario] Auto-unreserved crew for recording #{i} " +
-                            $"({rec.VesselName}) — EndUT passed without spawn");
-                    }
-                }
-            }
-
-            // Handle pending recordings outside Flight (Esc > Abort Mission → Space Center path).
-            // Always auto-commit on main menu (game is being unloaded).
-            if (HighLogic.LoadedScene != GameScenes.FLIGHT &&
-                (RecordingStore.HasPending || RecordingStore.HasPendingTree))
-            {
-                if (IsAutoMerge || HighLogic.LoadedScene == GameScenes.MAINMENU)
-                {
-                    // autoMerge ON: auto-commit ghost-only
-                    if (RecordingStore.HasPending)
-                    {
-                        var pending = RecordingStore.Pending;
-                        if (pending.VesselSnapshot != null)
-                            CrewReservationManager.UnreserveCrewInSnapshot(pending.VesselSnapshot);
-                        pending.VesselSnapshot = null;
-                        string recId = pending.RecordingId;
-                        double startUT = pending.StartUT;
-                        double endUT = pending.EndUT;
-                        RecordingStore.CommitPending();
-                        LedgerOrchestrator.OnRecordingCommitted(recId, startUT, endUT);
-                        ScenarioLog($"[Parsek Scenario] Auto-committed pending recording outside Flight " +
-                            $"(scene: {HighLogic.LoadedScene})");
-                    }
-                    if (RecordingStore.HasPendingTree)
-                    {
-                        var pt = RecordingStore.PendingTree;
-                        foreach (var rec in pt.Recordings.Values)
-                        {
-                            if (rec.VesselSnapshot != null)
-                                CrewReservationManager.UnreserveCrewInSnapshot(rec.VesselSnapshot);
-                            rec.VesselSnapshot = null;
-                        }
-                        RecordingStore.CommitPendingTree();
-                        LedgerOrchestrator.NotifyLedgerTreeCommitted(pt);
-                        ScenarioLog($"[Parsek Scenario] Auto-committed pending tree outside Flight " +
-                            $"(scene: {HighLogic.LoadedScene})");
-                    }
-                }
-                else if (!mergeDialogPending)
-                {
-                    // autoMerge OFF: defer to merge dialog
-                    mergeDialogPending = true;
-                    StartCoroutine(ShowDeferredMergeDialog());
-                }
+                if (sw.IsRunning)
+                    sw.Stop();
             }
         }
 
@@ -794,6 +847,26 @@ namespace Parsek
                 $"OnLoad: rewind complete at UT {RewindContext.RewindUT}. " +
                 $"Timeline: {recordings.Count} recordings");
             RewindContext.EndRewind();
+        }
+
+        /// <summary>
+        /// Writes OnLoad timing to DiagnosticsState and logs a summary.
+        /// Called at every exit point of OnLoad to ensure timing is captured
+        /// regardless of which code path (rewind, revert, scene change, initial load).
+        /// </summary>
+        private static void WriteLoadTiming(Stopwatch sw, int recordingCount)
+        {
+            sw.Stop();
+            DiagnosticsState.lastLoadTiming = new SaveLoadTiming
+            {
+                totalMilliseconds = sw.ElapsedMilliseconds,
+                recordingsProcessed = recordingCount,
+                dirtyRecordingsWritten = 0
+            };
+            ParsekLog.Verbose("Diagnostics",
+                string.Format(CultureInfo.InvariantCulture,
+                    "OnLoad: {0}ms ({1} recordings)",
+                    sw.ElapsedMilliseconds, recordingCount));
         }
 
         /// <summary>

--- a/Source/Parsek/Patches/PhysicsFramePatch.cs
+++ b/Source/Parsek/Patches/PhysicsFramePatch.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Globalization;
 using HarmonyLib;
 using UnityEngine;
 
@@ -65,15 +64,7 @@ namespace Parsek.Patches
                     long elapsedUs = recordingStopwatch.ElapsedTicks * 1000000L / Stopwatch.Frequency;
                     DiagnosticsState.recordingBudget.totalMicroseconds = elapsedUs;
 
-                    double totalMs = elapsedUs / 1000.0;
-                    if (totalMs > 4.0)
-                    {
-                        ParsekLog.WarnRateLimited("Diagnostics", "recording-budget",
-                            string.Format(CultureInfo.InvariantCulture,
-                                "Recording frame exceeded budget: {0:F2}ms for vessel \"{1}\"",
-                                totalMs, v.vesselName),
-                            30.0);
-                    }
+                    DiagnosticsComputation.CheckRecordingBudgetThreshold(elapsedUs, v.vesselName);
                 }
             }
 

--- a/Source/Parsek/Patches/PhysicsFramePatch.cs
+++ b/Source/Parsek/Patches/PhysicsFramePatch.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+using System.Globalization;
 using HarmonyLib;
 using UnityEngine;
 
@@ -25,6 +27,8 @@ namespace Parsek.Patches
         /// for non-active vessels in the tree.
         /// </summary>
         internal static BackgroundRecorder BackgroundRecorderInstance;
+
+        private static readonly Stopwatch recordingStopwatch = new Stopwatch();
 
         static void Postfix(VesselPrecalculate __instance)
         {
@@ -54,7 +58,22 @@ namespace Parsek.Patches
                 }
                 else if (__instance.gameObject == v.gameObject)
                 {
+                    recordingStopwatch.Restart();
                     ActiveRecorder.OnPhysicsFrame(v);
+                    recordingStopwatch.Stop();
+
+                    long elapsedUs = recordingStopwatch.ElapsedTicks * 1000000L / Stopwatch.Frequency;
+                    DiagnosticsState.recordingBudget.totalMicroseconds = elapsedUs;
+
+                    double totalMs = elapsedUs / 1000.0;
+                    if (totalMs > 4.0)
+                    {
+                        ParsekLog.WarnRateLimited("Diagnostics", "recording-budget",
+                            string.Format(CultureInfo.InvariantCulture,
+                                "Recording frame exceeded budget: {0:F2}ms for vessel \"{1}\"",
+                                totalMs, v.vesselName),
+                            30.0);
+                    }
                 }
             }
 

--- a/Source/Parsek/TrajectoryMath.cs
+++ b/Source/Parsek/TrajectoryMath.cs
@@ -134,6 +134,7 @@ namespace Parsek
                 if (points[cachedIndex].ut <= targetUT &&
                     points[cachedIndex + 1].ut > targetUT)
                 {
+                    DiagnosticsState.health.waypointCacheHits++;
                     return cachedIndex;
                 }
 
@@ -143,6 +144,7 @@ namespace Parsek
                     points[nextIndex + 1].ut > targetUT)
                 {
                     cachedIndex = nextIndex;
+                    DiagnosticsState.health.waypointCacheHits++;
                     return nextIndex;
                 }
             }
@@ -158,6 +160,7 @@ namespace Parsek
                 if (points[mid].ut <= targetUT && points[mid + 1].ut > targetUT)
                 {
                     cachedIndex = mid;
+                    DiagnosticsState.health.waypointCacheMisses++;
                     return mid;
                 }
                 else if (points[mid].ut > targetUT)
@@ -176,6 +179,7 @@ namespace Parsek
                 if (points[i].ut <= targetUT && points[i + 1].ut > targetUT)
                 {
                     cachedIndex = i;
+                    DiagnosticsState.health.waypointCacheMisses++;
                     ParsekLog.VerboseRateLimited("TrajectoryMath", "waypoint-linear-fallback-hit",
                         $"Linear fallback used for targetUT={targetUT:F3}, idx={i}", 5.0);
                     return i;

--- a/Source/Parsek/UI/RecordingsTableUI.cs
+++ b/Source/Parsek/UI/RecordingsTableUI.cs
@@ -106,6 +106,8 @@ namespace Parsek
         private const float ColW_MaxSpd = 65f;
         private const float ColW_Dist = 65f;
         private const float ColW_Pts = 35f;
+        private const float ColW_StartPos = 120f;
+        private const float ColW_EndPos = 120f;
 
         // Loop period editing — buffer used while text field is focused
         private int loopPeriodFocusedRi = -1;
@@ -377,6 +379,8 @@ namespace Parsek
                 GUILayout.Label("MaxSpd", GUILayout.Width(ColW_MaxSpd));
                 GUILayout.Label("Dist", GUILayout.Width(ColW_Dist));
                 GUILayout.Label("Pts", GUILayout.Width(ColW_Pts));
+                GUILayout.Label("Start", GUILayout.Width(ColW_StartPos));
+                GUILayout.Label("End", GUILayout.Width(ColW_EndPos));
             }
 
             DrawSortableHeader("Status", SortColumn.Status, ColW_Status);
@@ -443,8 +447,8 @@ namespace Parsek
                 {
                     showExpandedStats = !showExpandedStats;
                     ParsekLog.Verbose("UI", $"Recordings Stats toggled: {(showExpandedStats ? "expanded" : "collapsed")}");
-                    if (showExpandedStats && recordingsWindowRect.width < 1324f)
-                        recordingsWindowRect.width = 1324f;
+                    if (showExpandedStats && recordingsWindowRect.width < 1564f)
+                        recordingsWindowRect.width = 1564f;
                     else if (!showExpandedStats)
                         recordingsWindowRect.width = 1106f;
                 }
@@ -689,6 +693,8 @@ namespace Parsek
                 GUILayout.Label(FormatSpeed(stats.maxSpeed), GUILayout.Width(ColW_MaxSpd));
                 GUILayout.Label(FormatDistance(stats.distanceTravelled), GUILayout.Width(ColW_Dist));
                 GUILayout.Label(stats.pointCount.ToString(), GUILayout.Width(ColW_Pts));
+                GUILayout.Label(FormatStartPosition(rec), GUILayout.Width(ColW_StartPos));
+                GUILayout.Label(FormatEndPosition(rec), GUILayout.Width(ColW_EndPos));
             }
 
             // Status (#98: merged countdown into status column)
@@ -1050,6 +1056,8 @@ namespace Parsek
                 GUILayout.Label("", GUILayout.Width(ColW_MaxSpd));
                 GUILayout.Label("", GUILayout.Width(ColW_Dist));
                 GUILayout.Label("", GUILayout.Width(ColW_Pts));
+                GUILayout.Label("", GUILayout.Width(ColW_StartPos));
+                GUILayout.Label("", GUILayout.Width(ColW_EndPos));
             }
 
             // Status (closest active T- among descendants)
@@ -1331,6 +1339,8 @@ namespace Parsek
                 GUILayout.Label("", GUILayout.Width(ColW_MaxSpd));
                 GUILayout.Label("", GUILayout.Width(ColW_Dist));
                 GUILayout.Label("", GUILayout.Width(ColW_Pts));
+                GUILayout.Label("", GUILayout.Width(ColW_StartPos));
+                GUILayout.Label("", GUILayout.Width(ColW_EndPos));
             }
 
             // Status (closest active among chain members)
@@ -1814,6 +1824,65 @@ namespace Parsek
             if (meters < 1000) return $"{(int)meters}m";
             if (meters < 1000000) return (meters / 1000).ToString("F1", System.Globalization.CultureInfo.InvariantCulture) + "km";
             return (meters / 1000000).ToString("F1", System.Globalization.CultureInfo.InvariantCulture) + "Mm";
+        }
+
+        /// <summary>
+        /// Formats the recording start position for the expanded stats column.
+        /// Matches timeline style: "from {site} on {body}", "at {biome} on {body}", "on {body}".
+        /// </summary>
+        internal static string FormatStartPosition(Recording rec)
+        {
+            if (!string.IsNullOrEmpty(rec.LaunchSiteName) && !string.IsNullOrEmpty(rec.StartBodyName))
+                return rec.LaunchSiteName + ", " + rec.StartBodyName;
+            if (!string.IsNullOrEmpty(rec.LaunchSiteName))
+                return rec.LaunchSiteName;
+            if (!string.IsNullOrEmpty(rec.StartBiome) && !string.IsNullOrEmpty(rec.StartBodyName))
+                return rec.StartBiome + ", " + rec.StartBodyName;
+            if (!string.IsNullOrEmpty(rec.StartBodyName))
+                return rec.StartBodyName;
+            return "-";
+        }
+
+        /// <summary>
+        /// Formats the recording end position for the expanded stats column.
+        /// Matches timeline style: "{biome}, {body}" for surface, "Orbiting {body}" for orbital.
+        /// </summary>
+        internal static string FormatEndPosition(Recording rec)
+        {
+            if (!rec.TerminalStateValue.HasValue)
+                return "-";
+
+            string body = rec.TerminalOrbitBody;
+            if (string.IsNullOrEmpty(body) && !string.IsNullOrEmpty(rec.StartBodyName))
+                body = rec.StartBodyName;
+
+            switch (rec.TerminalStateValue.Value)
+            {
+                case TerminalState.Orbiting:
+                    return !string.IsNullOrEmpty(body) ? "Orbiting " + body : "Orbiting";
+                case TerminalState.Docked:
+                    return !string.IsNullOrEmpty(body) ? "Docked, " + body : "Docked";
+
+                case TerminalState.Landed:
+                case TerminalState.Splashed:
+                    if (!string.IsNullOrEmpty(rec.EndBiome) && !string.IsNullOrEmpty(body))
+                        return rec.EndBiome + ", " + body;
+                    if (!string.IsNullOrEmpty(body))
+                        return body;
+                    return rec.TerminalStateValue.Value.ToString();
+
+                case TerminalState.Destroyed:
+                    return !string.IsNullOrEmpty(body) ? "Destroyed, " + body : "Destroyed";
+                case TerminalState.Recovered:
+                    return !string.IsNullOrEmpty(body) ? "Recovered, " + body : "Recovered";
+                case TerminalState.SubOrbital:
+                    return !string.IsNullOrEmpty(body) ? "SubOrbital, " + body : "SubOrbital";
+                case TerminalState.Boarded:
+                    return "Boarded";
+
+                default:
+                    return "-";
+            }
         }
 
         /// <summary>

--- a/Source/Parsek/UI/RecordingsTableUI.cs
+++ b/Source/Parsek/UI/RecordingsTableUI.cs
@@ -2109,6 +2109,20 @@ namespace Parsek
             if (stats.maxRange > 0)
                 text += $"\nMax Range: {FormatDistance(stats.maxRange)}";
 
+            // Storage breakdown (cached, no per-frame I/O)
+            double currentUT = 0.0;
+            try { currentUT = Planetarium.GetUniversalTime(); }
+            catch { /* not available outside KSP */ }
+            var storage = DiagnosticsComputation.GetCachedStorageBreakdown(rec, currentUT);
+            if (storage.totalBytes > 0)
+            {
+                text += $"\nStorage: {DiagnosticsComputation.FormatBytes(storage.totalBytes)}" +
+                    $" (trajectory: {DiagnosticsComputation.FormatBytes(storage.trajectoryFileBytes)}" +
+                    $", vessel: {DiagnosticsComputation.FormatBytes(storage.vesselSnapshotBytes)}" +
+                    $", ghost: {DiagnosticsComputation.FormatBytes(storage.ghostSnapshotBytes)})";
+                text += $"\nEfficiency: {DiagnosticsComputation.FormatBytes((long)storage.bytesPerSecond)}/s of flight time";
+            }
+
             EnsureTooltipStyle();
 
             GUIContent content = new GUIContent(text);

--- a/Source/Parsek/UI/SettingsWindowUI.cs
+++ b/Source/Parsek/UI/SettingsWindowUI.cs
@@ -379,6 +379,13 @@ namespace Parsek
             {
                 parentUI.ToggleTestRunner();
             }
+
+            if (GUILayout.Button(new GUIContent("Run Diagnostics Report",
+                "Compute full diagnostics snapshot and dump report to KSP.log")))
+            {
+                ParsekLog.Info("UI", "Run Diagnostics Report button clicked");
+                DiagnosticsComputation.RunDiagnosticsReport();
+            }
         }
 
         private void DrawSamplingSettings(ParsekSettings s)

--- a/docs/dev/parsek-observability-design.md
+++ b/docs/dev/parsek-observability-design.md
@@ -1,0 +1,578 @@
+# Design: Recording Observability
+
+## Problem
+
+Parsek accumulates recordings over a career — trajectory points, part events, orbit segments, vessel snapshots, ghost meshes. As the player progresses through dozens of missions, the system's disk footprint, memory usage, and per-frame playback cost grow without any visibility. There is no way to answer basic questions: "How much disk space is Parsek using? Which recording is the largest? Is playback costing me framerate? How fast is this recording growing?"
+
+Before any optimization work (Phase 11.5's second half), we need instrumentation. You can't optimize what you can't measure. This phase adds observability — metrics collection, in-game diagnostics, and structured logging — without changing any existing behavior.
+
+## Terminology
+
+- **Metric** — a named numeric value collected at runtime (e.g., `playback.frame_ms`, `storage.total_bytes`)
+- **Gauge** — a metric that reflects current state (ghost count, memory estimate). Sampled on demand.
+- **Counter** — a metric that accumulates over time (spawn count, cache misses). Reset per scene load.
+- **Diagnostics report** — a full snapshot of all metrics, rendered in the in-game test runner window (Ctrl+Shift+T) alongside test results, and simultaneously dumped to KSP.log.
+
+## Mental Model
+
+Observability is structured around five domains, each answering a different question:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    OBSERVABILITY                         │
+│                                                         │
+│  ┌───────────┐  ┌───────────┐  ┌────────────────────┐  │
+│  │  STORAGE   │  │  MEMORY   │  │  PLAYBACK BUDGET   │  │
+│  │            │  │           │  │                     │  │
+│  │ How much   │  │ How much  │  │ How much frame     │  │
+│  │ disk space │  │ RAM right │  │ time does ghost     │  │
+│  │ per save?  │  │ now?      │  │ playback consume?   │  │
+│  └───────────┘  └───────────┘  └────────────────────┘  │
+│                                                         │
+│  ┌────────────────────┐  ┌────────────────────────┐     │
+│  │  RECORDING BUDGET   │  │  SAVE/LOAD BUDGET      │     │
+│  │                     │  │                         │     │
+│  │ How much frame      │  │ How long do save/load   │     │
+│  │ time does active    │  │ operations take?        │     │
+│  │ recording consume?  │  │                         │     │
+│  └────────────────────┘  └────────────────────────┘     │
+│                                                         │
+│  Surfaced via:                                          │
+│  - Diagnostics report (in-game test runner window)      │
+│  - KSP.log (structured, rate-limited, no spam)          │
+│  - Per-recording tooltip (Recordings Manager)           │
+└─────────────────────────────────────────────────────────┘
+```
+
+Metrics are **read-only observations**. They never change behavior, never gate decisions, never alter playback. They exist purely to make the system's resource consumption visible.
+
+## Data Model
+
+### MetricSnapshot (struct)
+
+Holds a point-in-time reading of all metrics. Computed on demand (not accumulated per-frame).
+
+```
+MetricSnapshot
+  // Storage (computed by scanning file system)
+  long    totalStorageBytes          // all Parsek files in save
+  int     recordingCount             // committed recordings
+  StorageBreakdown[] perRecording    // per-recording detail
+
+  // Memory (computed from in-memory state)
+  int     loadedTrajectoryPoints     // sum across all recordings
+  int     loadedPartEvents           // sum across all recordings
+  int     loadedOrbitSegments        // sum across all recordings
+  int     loadedSnapshotCount        // vessel + ghost snapshots in memory
+  long    estimatedMemoryBytes       // rough estimate from counts × per-item size
+  // Estimation formula (bytes):
+  //   points × 136   (76 struct + 8 list ref + ~50 string heap; bodyName may be interned)
+  //   events × 88    (32 struct + 8 list ref + ~48 string heap for partName)
+  //   segments × 120 (108 struct + 8 list ref; bodyName likely interned across segment)
+  //   snapshots × 8192  (ConfigNode tree, rough average)
+
+  // Ghost state (computed by iterating GhostPlaybackEngine.ghostStates values)
+  // Zone counts derived by reading each GhostPlaybackState.currentZone field.
+  // Do NOT read cachedZone1Ghosts/cachedZone2Ghosts — those are transient soft-cap evaluation lists.
+  int     activeGhostCount           // ghostStates.Count
+  int     activeOverlapGhostCount    // sum of overlapGhosts list counts
+  int     zone1GhostCount            // count of ghosts where currentZone == Physics
+  int     zone2GhostCount            // count of ghosts where currentZone == Visual
+  int     softCapReducedCount        // ghosts where fidelityReduced == true (0 if soft caps disabled)
+  int     softCapSimplifiedCount     // ghosts where simplified == true (0 if soft caps disabled)
+  bool    softCapsEnabled            // GhostSoftCapManager.Enabled — report shows "disabled" when false
+
+  // Timing (from FrameBudget)
+  FrameBudget lastPlaybackBudget     // most recent playback frame timing
+  FrameBudget lastRecordingBudget    // most recent recording frame timing
+  SaveLoadTiming lastSaveTiming      // most recent OnSave timing
+  SaveLoadTiming lastLoadTiming      // most recent OnLoad timing
+```
+
+### StorageBreakdown (struct)
+
+Per-recording storage detail. Computed by reading file sizes on disk.
+
+```
+StorageBreakdown
+  string  recordingId
+  string  vesselName
+  long    trajectoryFileBytes        // .prec
+  long    vesselSnapshotBytes        // _vessel.craft
+  long    ghostSnapshotBytes         // _ghost.craft
+  long    geometryFileBytes          // .pcrf (if exists)
+  long    totalBytes                 // sum of above
+  int     pointCount                 // from recording metadata
+  int     partEventCount
+  int     orbitSegmentCount
+  double  durationSeconds            // EndUT - StartUT
+  double  bytesPerSecond             // totalBytes / durationSeconds
+```
+
+### FrameBudget (struct)
+
+Per-frame timing breakdown. Updated every frame via Stopwatch instrumentation.
+
+```
+FrameBudget
+  // Raw timing from most recent frame (microseconds)
+  long    totalMicroseconds          // wall time for entire update pass
+  long    positioningMicroseconds    // interpolation + world placement
+  long    partEventMicroseconds      // part event scanning + application
+  long    fxUpdateMicroseconds       // engine/RCS/reentry particle updates
+  long    zoneEvalMicroseconds       // zone distance checks + soft cap eval
+  long    spawnMicroseconds          // ghost build cost in THIS frame (0 if no spawns this frame)
+  int     ghostsProcessed            // how many ghosts were updated this frame
+  float   warpRate                   // TimeWarp.CurrentRate at measurement time
+
+  // Rolling statistics (time-based, last 4 seconds)
+  double  avgTotalMs                 // rolling average of totalMicroseconds
+  double  peakTotalMs                // max over rolling window
+  double  windowDurationSeconds      // actual time span of the window
+```
+
+### SaveLoadTiming (struct)
+
+Timing for save/load operations. Updated on each OnSave/OnLoad.
+
+```
+SaveLoadTiming
+  long    totalMilliseconds          // wall time for entire operation
+  long    serializationMs            // ConfigNode serialization/parsing
+  long    fileIoMs                   // disk read/write
+  // Gap between (serializationMs + fileIoMs) and totalMilliseconds is expected —
+  // it's validation, logging, bookkeeping, and other overhead. Not separately tracked.
+  int     recordingsProcessed        // how many recordings touched
+  int     dirtyRecordingsWritten     // how many had FilesDirty=true (save only)
+```
+
+### RecordingGrowthRate (struct)
+
+Live growth metrics during active recording. Updated per sampling event in FlightRecorder.
+
+```
+RecordingGrowthRate
+  double  pointsPerSecond            // points added / elapsed time
+  double  eventsPerSecond            // part events / elapsed time
+  long    estimatedFinalBytes        // projected file size at current rate
+  double  elapsedSeconds             // recording duration so far
+  int     totalPoints                // points so far
+  int     totalEvents                // events so far
+```
+
+### HealthCounters (static counters, reset per scene load)
+
+Session-level counters for anomalies and operational health.
+
+```
+HealthCounters (static)
+  int     waypointCacheHits          // FindWaypointIndex: exact cached index OR cachedIndex+1 hit
+  int     waypointCacheMisses        // FindWaypointIndex: binary search fallback (neither cached nor next)
+  int     snapshotRefreshSpikes      // snapshot refreshes > 25ms
+  int     spawnFailures              // ghost spawn blocked (collision, etc.)
+  int     spawnRetries               // ghost spawn retry attempts
+  int     softCapActivations         // times soft cap threshold was reached
+  int     softCapDespawns            // cumulative ghosts despawned by soft cap
+  int     ghostBuildsThisSession     // total ghost mesh builds
+  int     ghostDestroysThisSession   // total ghost mesh destroys
+  int     gcGen0Baseline             // GC.CollectionCount(0) captured at scene load
+  // Report computes delta: GC.CollectionCount(0) - gcGen0Baseline (derived, not incremented)
+```
+
+### DiagnosticsState (singleton)
+
+Central holder for all observability state. Lives as a static class, survives scene changes.
+
+```
+DiagnosticsState (static class)
+  // Live frame budgets (updated every frame)
+  FrameBudget       playbackBudget
+  FrameBudget       recordingBudget
+
+  // Rolling averages (pre-allocated ring buffer, time-based 4-second window)
+  // Fixed-size array of (wallTimestamp, microseconds) pairs, pre-allocated at init.
+  // Size: 1024 entries (enough for 4s at 240fps). Head/tail indices wrap via modulo.
+  // On append: write at tail, advance tail. On read: skip entries older than 4s from head.
+  // Zero allocation after init — no List/Queue growth, no GC pressure.
+  RollingTimingBuffer playbackFrameHistory
+
+  // Growth rate (only during active recording)
+  RecordingGrowthRate activeGrowthRate
+  bool              hasActiveGrowthRate     // false when not recording
+
+  // Health counters
+  HealthCounters    health
+
+  // Snapshot (computed on demand, cached briefly)
+  MetricSnapshot    cachedSnapshot
+  bool              hasCachedSnapshot       // avoids Nullable boxing of struct with array fields
+  double            cachedSnapshotUT        // UT when snapshot was last computed
+  double            snapshotCacheTtlSeconds = 2.0
+
+  // Methods
+  MetricSnapshot    ComputeSnapshot()       // full computation, caches result
+  MetricSnapshot    GetOrComputeSnapshot()  // returns cached if fresh
+  void              ResetSessionCounters()  // called on scene load
+  string            FormatReport()          // human-readable full dump
+```
+
+No serialization. Diagnostics state is ephemeral — it exists only during a game session. Nothing persists to save files.
+
+## Behavior
+
+### Metric Collection
+
+**Storage metrics** are computed on demand (not continuously), triggered by:
+1. Running the diagnostics report (via test runner or Settings button)
+2. Hovering over a recording's tooltip in the Recordings Manager
+
+The computation iterates `RecordingStore.CommittedRecordings` for recording IDs (in-memory, fast), then stats the corresponding sidecar files on disk via `RecordingPaths`. No directory scanning — the ID list is authoritative. This is I/O but infrequent — only when the developer explicitly requests diagnostics.
+
+**Memory metrics** are computed on demand from in-memory state:
+- Iterate `RecordingStore.CommittedRecordings`, sum point/event/segment counts
+- Read `GhostPlaybackEngine.ghostStates.Count` and zone counts
+- Estimate memory: `points × 136 + events × 88 + segments × 120 + snapshots × 8192` (see estimation formula in MetricSnapshot)
+
+These are cheap in-memory traversals but still on-demand, not per-frame.
+
+**Playback frame budget** is collected every frame inside `GhostPlaybackEngine.UpdatePlayback()`:
+1. Start outer Stopwatch before the ghost loop
+2. Start/stop inner Stopwatches around each subsection (positioning, part events, FX, zone eval)
+3. After the loop: write timing into `DiagnosticsState.playbackBudget`
+4. Append (timestamp, total) to time-based rolling buffer
+5. Evict entries older than 4 seconds, recompute rolling average/peak
+
+The Stopwatch overhead is ~50ns per Start/Stop call. With 6 measurement pairs per frame (1 outer + 5 inner subsections = 12 Start/Stop calls), that's ~600ns — negligible vs. the ~1-5ms playback cost being measured.
+
+**Recording frame budget** is collected every physics frame inside the Harmony postfix (`PhysicsFramePatch`):
+1. Start outer Stopwatch before sampling logic
+2. Stop after all polling + point recording completes
+3. Write timing into `DiagnosticsState.recordingBudget`
+
+Only one Stopwatch (outer total) for recording — the inner polling breakdown is not individually timed in v1. If the total is unexpectedly high, individual Check* methods can be timed in a targeted investigation.
+
+**Recording growth rate** is updated each time a point is recorded:
+1. Increment point count
+2. If events were emitted this frame, increment event count
+3. Recompute rates: `pointsPerSecond = totalPoints / elapsedSeconds`
+4. Estimate final size: `estimatedFinalBytes = (totalPoints × avgBytesPerPoint) + (totalEvents × avgBytesPerEvent)`
+5. `avgBytesPerPoint` is computed once at recording start (not per-frame — no I/O in the hot path). If committed recordings exist, it's `totalPrecFileSize / totalPointCount` across all recordings. Falls back to 85 bytes if no committed recordings exist yet (first flight). Cached in `DiagnosticsState` and recomputed only when a new recording is committed.
+
+**Save/Load timing** wraps the existing OnSave/OnLoad with Stopwatch:
+1. Start Stopwatch at OnSave/OnLoad entry
+2. Track inner timing around file I/O vs. ConfigNode operations
+3. Store result in `DiagnosticsState.lastSaveTiming` / `lastLoadTiming`
+
+**Health counters** are incremented at the point of occurrence:
+- `FindWaypointIndex`: three paths exist — (a) exact cached index hit, (b) cachedIndex+1 hit (sequential playback), (c) binary search fallback. Paths (a) and (b) both increment `cacheHits`; path (c) increments `cacheMisses`. The counter increment is a single `++` at each return site — no allocation, no branching beyond what already exists.
+- `RefreshBackupSnapshot`: increment `snapshotRefreshSpikes` when elapsed > threshold
+- Ghost spawn logic: increment `spawnFailures` / `spawnRetries` on those code paths
+- Soft cap evaluation: increment `softCapActivations` when threshold exceeded
+- Ghost build/destroy: increment counters in `BuildGhostFromSnapshot` / destroy paths
+
+All counters are simple `Interlocked.Increment` or plain `++` (single-threaded Unity). Reset on scene load via `DiagnosticsState.ResetSessionCounters()`.
+
+### UI: Diagnostics Report (In-Game Test Runner Window)
+
+The diagnostics report is surfaced through the existing in-game test runner window (Ctrl+Shift+T), alongside test results. A new "Run Diagnostics" button (or automatic inclusion when running all tests) computes the full snapshot and renders it as a results section in the test runner output. The report is simultaneously dumped to KSP.log.
+
+This reuses the existing infrastructure — the test runner already handles result rendering, scrolling, and export to `parsek-test-results.txt`. Diagnostics entries appear as a "Diagnostics" category in the results, formatted identically to test results (pass/fail/info lines).
+
+The Settings > Diagnostics section gains only one new button: **[Run Diagnostics Report]**, which opens the test runner window with the diagnostics category pre-selected.
+
+### UI: Per-Recording Tooltip (Recordings Manager)
+
+Hovering over a recording in the Recordings Manager shows a tooltip with storage details:
+
+```
+Mun Landing
+Duration: 12m 34s | Points: 8,432 | Events: 47
+Storage: 2.1 MB (trajectory: 1.8 MB, vessel: 180 KB, ghost: 120 KB)
+Efficiency: 2.8 KB/s of flight time
+```
+
+The tooltip data is computed lazily (on hover) by calling `DiagnosticsState.ComputeStorageBreakdown(recordingId)`. File sizes are cached per-recording for 5 seconds (separate from the full MetricSnapshot cache at 2s TTL) to avoid repeated stat calls while the mouse moves within the same row.
+
+### Diagnostics Report Format
+
+The report is rendered in the test runner window AND written to KSP.log via `ParsekLog.Info`:
+
+```
+[Parsek][INFO][Diagnostics] ===== DIAGNOSTICS REPORT =====
+[Parsek][INFO][Diagnostics] Storage: 12.4 MB total, 23 recordings
+[Parsek][INFO][Diagnostics]   rec[0] "Mun Landing" — 2.1 MB (8432 pts, 47 evts, 2 segs) 12m34s 2.8 KB/s
+[Parsek][INFO][Diagnostics]   rec[1] "KSC Hopper" — 0.3 MB (1204 pts, 12 evts, 0 segs) 2m01s 2.5 KB/s
+[Parsek][INFO][Diagnostics]   ...
+[Parsek][INFO][Diagnostics] Memory: ~6.8 MB est (47200 pts, 312 evts, 18 segs, 46 snapshots)
+[Parsek][INFO][Diagnostics] Ghosts: 8 active (z1:3 z2:5), 0 reduced, 0 simplified
+[Parsek][INFO][Diagnostics] Playback budget: 1.8 ms avg, 3.2 ms peak (4.0s window), warp: 1x
+[Parsek][INFO][Diagnostics]   Position: 0.6 ms | Events: 0.1 ms | FX: 0.8 ms | Zone: 0.3 ms
+[Parsek][INFO][Diagnostics] Recording budget: 0.4 ms avg (active)
+[Parsek][INFO][Diagnostics] Save: 120 ms last (3 dirty) | Load: 340 ms last (23 total)
+[Parsek][INFO][Diagnostics] Health: cache 99.2% hit (12 miss of 1500 lookups), spikes 2, spawn fail 0, builds 14
+[Parsek][INFO][Diagnostics] GC gen0: +12 collections this session
+[Parsek][INFO][Diagnostics] ===== END REPORT =====
+```
+
+This is the primary tool for bug reports and performance investigations. Open the test runner (Ctrl+Shift+T), run diagnostics, and the report appears alongside test results. The same data goes to KSP.log and the exported `parsek-test-results.txt` file.
+
+### Automatic Logging (KSP.log)
+
+For ongoing/live observability, KSP.log is the right channel. The key constraint is **no log spam** — every automatic log line must be either one-shot (fires once) or aggressively rate-limited.
+
+| Trigger | What's logged | Level | Rate limiting |
+|---------|--------------|-------|---------------|
+| Scene load complete | Memory snapshot + ghost count | Verbose | Once per scene |
+| OnSave complete | Save timing + dirty count | Verbose | Once per save |
+| OnLoad complete | Load timing + recording count | Verbose | Once per load |
+| Recording start | Initial state (point count = 0, vessel part count) | Verbose | Once |
+| Recording stop | Final growth rate, total points/events, estimated file size | Verbose | Once |
+| Soft cap activation | Which threshold, how many ghosts affected | Verbose | VerboseRateLimited, 30s |
+| Playback budget > 8ms | Total ms + breakdown + ghost count + warp rate | Warn | VerboseRateLimited, 30s |
+| Recording budget > 4ms | Total ms + vessel name + part count | Warn | VerboseRateLimited, 30s |
+
+**No per-frame logging.** Frame budgets accumulate silently into rolling stats. Only threshold breaches emit log lines, and those are rate-limited to at most once per 30 seconds. Health counters are never individually logged — they appear only in the on-demand diagnostics report.
+
+**API addition required:** `ParsekLog.WarnRateLimited(subsystem, key, message, minIntervalSeconds)` — same rate-limiting logic as `VerboseRateLimited` but emits at Warn level (unconditional, not gated by `IsVerboseEnabled`). Needed for budget threshold warnings that should be visible even with verbose logging disabled.
+
+The warning thresholds (8ms playback, 4ms recording) are chosen to flag potential framerate impact. At 60 FPS, a frame is 16.6ms. Spending half the frame budget on Parsek is worth a warning. These thresholds are constants, not settings — they're for developer diagnostics, not player configuration.
+
+All formatted numbers use `InvariantCulture` (the project has a known locale bug with comma-decimal systems — see MEMORY.md).
+
+## Edge Cases
+
+### E1. No recordings exist
+- Storage: "0 bytes, 0 recordings"
+- Memory: "0 points loaded"
+- Frame budget: playback shows 0.0ms (no ghosts to process)
+- Growth rate: hidden (no active recording)
+- No errors, no warnings. Clean display of zeros.
+
+### E2. Very large recording (100K+ points)
+- Storage breakdown computes correctly (just larger numbers)
+- Memory estimate reflects the large point count
+- File size scan is still fast (single stat call per file)
+- Per-recording tooltip shows the large numbers without truncation
+- Handled: display uses `FormatBytes()` helper (KB/MB/GB auto-scaling)
+
+### E3. Many recordings (50+)
+- Storage scan iterates all files — could take 50-100ms on SSD, up to 1-2s on cold HDD (200 stat calls × 5-10ms)
+- Mitigated: scan is on-demand + cached for 2 seconds. First-open latency is acceptable since the user explicitly requested the report.
+- Diagnostics report logs all 50 recordings (acceptable for a log dump)
+- If the scan takes >500ms, log a warning: `[Parsek][WARN][Diagnostics] Storage scan took {elapsed}ms — consider SSD for faster diagnostics`
+
+### E4. Sidecar file missing (deleted externally)
+- `StorageBreakdown` reports 0 bytes for the missing file
+- Total still sums correctly (other files counted)
+- Log warning: "Missing sidecar file: {path}"
+- No crash, no error dialog. Graceful degradation.
+
+### E5. Recording in progress during diagnostics
+- Storage metrics exclude the in-progress recording (not yet committed, no sidecar files)
+- Memory metrics include it (points are in memory)
+- Growth rate section shows the in-progress recording's stats
+- Frame budget includes the recording cost
+
+### E6. Scene transitions
+- `HealthCounters` reset on scene load (they're session-scoped)
+- `FrameBudget` rolling history resets on scene load
+- `cachedSnapshot` invalidated on scene load
+- `activeGrowthRate` cleared when recording stops
+
+### E7. Stopwatch overhead in hot path
+- Total Stopwatch overhead: ~600ns per frame (6 measurement pairs × 2 calls × ~50ns each)
+- Frame budget being measured: ~1-5ms
+- Overhead is 0.012-0.06% of measured value — negligible
+- Stopwatch is always running (no toggle). The cost of checking a toggle would be similar to the Stopwatch itself.
+
+### E8. Thread safety
+- All metrics are written from Unity's main thread (physics and Update callbacks)
+- No concurrent writes. Plain field assignment is sufficient.
+- No locks, no Interlocked. Single-threaded Unity model.
+
+### E9. Diagnostics during time warp
+- At high warp (1000x+), playback budget will be low (ghosts suppressed) but recording growth rate may be very high
+- The warp rate is captured in FrameBudget, so the report shows context: "Playback: 0.3 ms avg, warp: 1000x"
+- This is technically correct behavior — warp suppression is working. No special handling needed.
+
+### E10. First frame after scene load
+- Rolling history is empty. `avgTotalMs` returns 0.0, `peakTotalMs` returns 0.0.
+- Report labels this as "N/A" if the rolling buffer has zero entries, to avoid showing misleading zeros when ghosts are clearly active.
+- After one frame, real data populates.
+
+### E11. Diagnostics report during high ghost count
+- Storage scan is cached, not recomputed per frame
+- Memory/ghost counts are direct field reads from DiagnosticsState (no computation on draw)
+- Frame budget reads the last-computed rolling average
+- UI draw cost is minimal (text labels only, no graphs)
+
+## What Doesn't Change
+
+- **Recording behavior** — no changes to adaptive sampling, part polling, event generation, or snapshot refresh. We're measuring, not modifying.
+- **Playback behavior** — no changes to ghost positioning, FX, zone evaluation, or soft caps. Stopwatches wrap existing code without altering it.
+- **Save/load format** — no new fields serialized. Diagnostics state is ephemeral.
+- **Existing logging** — all existing log lines remain. New observability logging is additive.
+- **Settings persistence** — no new persistent settings. The diagnostics report is on-demand only.
+- **Performance** — Stopwatch overhead is ~600ns/frame. No allocations in the hot path (pre-allocated ring buffer for rolling stats). Storage scan is on-demand only.
+
+## Out of Scope
+
+This design covers **observability only** — measurement, reporting, and diagnostics. The following are explicitly deferred to Phase 11.5's optimization half, after measurement data is collected:
+
+- Shorter key names in .prec serialization
+- Compact numeric encoding
+- Vessel snapshot deduplication
+- Part event name deduplication
+- Trajectory point thinning
+- Optional gzip compression for sidecar files
+- Lazy loading of trajectory data
+- LOD culling for distant ghost meshes (T6)
+- Ghost mesh unloading outside active time range (T7)
+- Particle system pooling for engine/RCS FX (T8)
+
+The observability phase produces the data that tells us which of these optimizations actually matter.
+
+## Backward Compatibility
+
+No compatibility concerns. This feature:
+- Adds no new serialized fields
+- Changes no save file format
+- Changes no recording format
+- Adds no new ConfigNode keys
+- Is purely additive runtime instrumentation
+
+A save created without observability loads identically. A save created with observability loads identically on a version without it (no persisted state to miss).
+
+## Diagnostic Logging
+
+### Collection layer
+- **Stopwatch wrapping**: when a Stopwatch measurement completes, log the raw value only if it exceeds a threshold (8ms playback, 4ms recording, 100ms save/load). Below threshold: silent accumulation into rolling stats. Above: `[Parsek][WARN][Diagnostics] Playback frame budget exceeded: {total}ms ({ghostCount} ghosts) — position:{pos}ms events:{evt}ms fx:{fx}ms zone:{zone}ms`
+- **Health counter increments**: each counter increment is NOT individually logged (too noisy). Counters appear in the periodic report and on-demand dump.
+- **Storage scan**: `[Parsek][VERBOSE][Diagnostics] Storage scan: {totalMB} MB across {count} recordings ({elapsedMs}ms)` — logged once per scan.
+
+### UI layer
+- **Report requested**: `[Parsek][INFO][Diagnostics] Full diagnostics report requested` followed by the multi-line report
+
+### Decision points
+- **Cache hit/miss**: when `GetOrComputeSnapshot()` returns cached vs. recomputes: `[Parsek][VERBOSE][Diagnostics] Snapshot cache {hit|miss}, age={age}s` (rate-limited, 5s)
+- **Warning threshold**: when playback or recording exceeds budget: warns with full breakdown (see above)
+- **Missing file during scan**: `[Parsek][WARN][Diagnostics] Missing sidecar file during storage scan: {path}` — per-file, not rate-limited (infrequent event)
+
+## Test Plan
+
+### Unit tests (DiagnosticsStateTests.cs)
+
+**Rolling average computation**
+- Input: sequence of frame timings [1000, 2000, 3000, 1500, 2500]
+- Expected: avg = 2000, peak = 3000
+- Fails if: rolling buffer indexing is wrong, or peak doesn't track maximum
+
+**Storage breakdown computation**
+- Input: mock file sizes via injected path resolver
+- Expected: correct per-recording totals, correct bytes-per-second calculation
+- Fails if: file size summation is wrong, or duration=0 causes divide-by-zero
+
+**Memory estimation**
+- Input: recordings with known point/event/segment counts
+- Expected: estimate = `points × 136 + events × 88 + segments × 120 + snapshots × 8192`
+- Fails if: multipliers are wrong or counts are misread
+
+**Health counter reset**
+- Input: increment several counters, then call `ResetSessionCounters()`
+- Expected: all counters back to 0
+- Fails if: a new counter is added but not included in reset
+
+**Growth rate calculation**
+- Input: 100 points over 10 seconds, 5 events
+- Expected: 10.0 pts/s, 0.5 evts/s
+- Fails if: rate computation uses wrong divisor
+
+**Growth rate at recording start (zero elapsed)**
+- Input: 1 point at elapsedSeconds = 0.0
+- Expected: pointsPerSecond = 0.0, eventsPerSecond = 0.0 (not NaN, not Infinity)
+- Fails if: division by zero not guarded at recording start
+
+**Snapshot cache TTL**
+- Input: compute snapshot, wait 1s (< TTL), call GetOrCompute
+- Expected: returns cached (no recompute)
+- Input: compute snapshot, wait 3s (> TTL), call GetOrCompute
+- Expected: recomputes
+- Fails if: cache TTL comparison is wrong direction (< vs >)
+
+**Format report**
+- Input: MetricSnapshot with known values
+- Expected: formatted string contains "12.4 MB", "23 recordings", correct per-recording lines
+- Fails if: formatting is wrong (wrong units, missing values, locale issues)
+
+### Log assertion tests (ObservabilityLoggingTests.cs)
+
+**Budget warning threshold**
+- Input: set playback budget to 10ms (> 8ms threshold)
+- Expected: log contains `[WARN][Diagnostics] Playback frame budget exceeded`
+- Fails if: threshold check is wrong direction, or message not emitted
+
+**Budget below threshold — no warning**
+- Input: set playback budget to 3ms (< 8ms threshold)
+- Expected: log does NOT contain `[WARN]`
+- Fails if: threshold check triggers false positive
+
+**Diagnostics report format**
+- Input: call FormatReport() with known state, capture via TestSink
+- Expected: log contains `===== DIAGNOSTICS REPORT =====`, all sections present, numbers match input
+- Fails if: report format changes or sections are missing
+
+**Storage scan logging**
+- Input: trigger storage scan
+- Expected: log contains `[VERBOSE][Diagnostics] Storage scan:`
+- Fails if: scan completes without logging
+
+### Integration tests (using RecordingBuilder)
+
+**Storage breakdown from synthetic recording**
+- Input: RecordingBuilder with 1000 points, 20 events, 2 orbit segments, written to temp directory as v3 sidecar files
+- Expected: StorageBreakdown.totalBytes matches sum of actual file sizes on disk
+- Fails if: file path resolution is wrong, or size counting misses a file type
+
+**Memory estimate from loaded recordings**
+- Input: build 3 synthetic recordings, load into RecordingStore
+- Expected: MetricSnapshot.loadedTrajectoryPoints = sum of all three recordings' point counts
+- Fails if: iteration over CommittedRecordings misses recordings or double-counts
+
+### Edge case tests
+
+**Missing sidecar file (E4)**
+- Input: recording with valid metadata but deleted .prec file
+- Expected: StorageBreakdown.trajectoryFileBytes = 0, totalBytes = sum of remaining files, warning logged
+- Fails if: missing file causes exception instead of graceful 0
+
+**First frame / empty rolling buffer (E10)**
+- Input: call FormatReport() with empty rolling history
+- Expected: playback budget line shows "N/A" not "0.0 ms"
+- Fails if: empty buffer treated as zero instead of absent
+
+**Duration zero recording (divide-by-zero guard)**
+- Input: recording with StartUT == EndUT
+- Expected: bytesPerSecond = 0.0 (not NaN, not Infinity)
+- Fails if: division by zero not guarded
+
+### In-game tests (RuntimeTests.cs)
+
+**Diagnostics report produces output**
+- Run diagnostics report via test runner
+- Assert result contains "DIAGNOSTICS REPORT", "Storage:", "Memory:", "Playback budget:"
+- Fails if: report generation crashes or produces empty output
+
+**Diagnostics report data matches live state**
+- Run diagnostics report in flight with active ghosts
+- Assert ghost count in report matches GhostPlaybackEngine.ghostStates.Count
+- Fails if: report reads stale or wrong data source
+
+**Recording growth rate updates during flight**
+- Start recording, wait 3 seconds, read growth rate
+- Assert pointsPerSecond > 0
+- Fails if: growth rate not connected to FlightRecorder's point emission
+
+**Storage breakdown resolves real sidecar files**
+- With committed recordings, run storage breakdown
+- Assert at least one recording has trajectoryFileBytes > 0
+- Fails if: file path resolution is broken in live KSP environment


### PR DESCRIPTION
## Summary

- Adds measurement-only instrumentation across five domains: storage, memory, playback frame budget, recording frame budget, and save/load timing
- Diagnostics report surfaced through in-game test runner (Ctrl+Shift+T) and dumped to KSP.log
- Per-recording storage tooltip in Recordings Manager (hover to see file sizes and efficiency)
- No behavioral changes — purely additive observability for identifying optimization targets

## What's instrumented

| Domain | What's measured | Where it's reported |
|--------|----------------|-------------------|
| Storage | Per-recording file sizes (.prec, _vessel.craft, _ghost.craft), bytes/sec efficiency | Diagnostics report, recording tooltip |
| Memory | Loaded trajectory points, part events, orbit segments, estimated footprint | Diagnostics report |
| Playback budget | Total frame time + spawn cost, 4s rolling average, 8ms threshold warning | Diagnostics report, KSP.log (warn) |
| Recording budget | Physics frame time, 4ms threshold warning, growth rate (pts/sec, events/sec) | Diagnostics report, KSP.log (warn) |
| Save/Load | Total ms, recording counts, dirty counts | Diagnostics report, KSP.log (verbose) |
| Health | Waypoint cache hit rate, snapshot spikes, spawn failures/retries, soft cap activations, GC gen0, ghost builds/destroys | Diagnostics report |

## Files

**7 new files:** `Diagnostics/` (4 files: structs, rolling buffer, state, computation), `InGameTests/DiagnosticsTests.cs`, 3 test files (74 xUnit + 5 in-game tests)

**10 modified files:** `ParsekLog.cs` (WarnRateLimited), `TrajectoryMath.cs` (cache counters), `GhostPlaybackEngine.cs` (Stopwatch + health counters), `FlightRecorder.cs` (growth rate + spike counter), `PhysicsFramePatch.cs` (recording timing), `ParsekScenario.cs` (save/load timing + session reset), `ParsekPlaybackPolicy.cs` (spawn failure counters), `SettingsWindowUI.cs` (report button), `RecordingsTableUI.cs` (tooltip)

## Design

Full design doc at `docs/dev/parsek-observability-design.md` — went through two review cycles before implementation.

## Test plan

- [x] 79 new tests (5166 total, 0 failures)
- [x] Unit tests for all data structures, rolling buffer, formatting, cache TTL
- [x] Log assertion tests for budget threshold warnings
- [x] Integration tests with RecordingBuilder for storage breakdown and memory estimation
- [x] Edge case tests: empty state, missing files, zero duration, zero elapsed, NaN guards
- [x] 5 in-game runtime tests for live KSP environment
- [x] Manual playtesting: inject synthetics, fly missions, verify diagnostics report output


🤖 Generated with [Claude Code](https://claude.com/claude-code)