### PR TITLE
Quickload-resume recording (Bug C / H / I)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,27 @@ All notable changes to Parsek are documented here.
 - **Fix ghost audio not muted when KSP pause menu (ESC) is open.** Ghost `AudioSource`s had no pause handling — engine sounds continued playing during the ESC menu. Subscribe to `GameEvents.onGamePause` / `onGameUnpause` in `ParsekFlight`, call new `GhostPlaybackEngine.PauseAllGhostAudio` / `UnpauseAllGhostAudio` which iterate all primary + overlap ghost states. New `GhostPlaybackLogic.PauseAllAudio` / `UnpauseAllAudio` use `AudioSource.Pause()` / `.UnPause()` (preserves playback position, unlike the existing `MuteAllAudio` which calls `Stop()`).
 - **Fix ghost camera cutoff not persisted across rewind or KSP restart.** `ParsekSettings` lives inside KSP's `GameParameters`, which get reset on every quickload (including `parsek_rw_*` rewinds). User-set values for `ghostCameraCutoffKm` were lost on every rewind. New `ParsekSettingsPersistence` store writes user changes to `GameData/Parsek/PluginData/settings.cfg` (KSP convention for runtime mod state — excluded from ModuleManager's patch cache) and reads them back in `ParsekScenario.OnLoad` immediately after the settings node is available. Survives rewind, save/load, scene transitions, and KSP session restart.
 
+#### Quickload-resume recording (Bug C + cascading H, I)
+
+Observed in the 2026-04-09 KerbalX playtest: quicksave + quickload during an active recording fragmented the mission across multiple unlinked recordings, produced partial ghost orbits (Bug H), and scattered crew across orphan recordings (Bug I). Both H and I are cascading effects of the same root cause — the tree was being prematurely finalized on every FLIGHT→FLIGHT scene reload.
+
+Three compounding defects:
+
+- **`ParsekFlight.FinalizeTreeOnSceneChange` called `CommitTreeRevert` on any FLIGHT→FLIGHT reload**, finalizing the active tree before `OnLoad` could distinguish revert from quickload.
+- **`ParsekScenario.OnSave` never serialized the active tree**, so even if we refused to commit in memory, the scene reload would lose it.
+- **`ParsekScenario.OnLoad`'s `isRevert` condition conflated FLIGHT→FLIGHT with revert** via `|| isFlightToFlight`.
+
+Atomic fix (landed together — the intermediate states are all broken):
+
+- New `PendingTreeState` enum `{Finalized, Limbo}` on the existing `pendingTree` slot. Stash-as-Limbo preserves the tree data without finalization; `OnLoad` decides between restore-and-resume (quickload) and finalize-and-commit (revert or vessel switch).
+- `OnSave` writes the active tree as a `RECORDING_TREE` node flagged `isActive=True`, gated on `LoadedScene == FLIGHT && activeTree && recorder`. Recorder buffers are flushed into the tree before serialization. Resume hint (rewind save filename) serialized alongside.
+- `OnLoad` runs new `TryRestoreActiveTreeNode` after `ParsekSettingsPersistence.ApplyTo` but before revert detection; stashes the loaded active tree into pending-Limbo. Dedupes against `committedTrees` to handle the in-flight → TS commit → quickload edge case. Runs on both `initialLoadDone=true` (in-session quickload) and `initialLoadDone=false` (cold-start "Resume Saved Game") branches.
+- Removed `|| isFlightToFlight` from the `isRevert` condition — only epoch regression or count regression count as revert indicators now.
+- New `StashActiveTreeAsPendingLimbo` replaces `CommitTreeRevert` on the FLIGHT→FLIGHT path. Flushes recorder buffers, finalizes background orbit segments, aborts any `pendingSplitRecorder` (continuation windows can't survive scene reload cleanly), then stashes as Limbo without setting terminal state.
+- New `RestoreActiveTreeFromPending` coroutine runs from `OnFlightReady`: 3-second vessel name match, EVA-boarded-parent fallback (walks `ParentRecordingId` up to 5 levels), PID remap, fresh `FlightRecorder` attached to the restored tree, `StartRecording(isPromotion: true)` relies on the Bug A seed-event skip to avoid duplicate events at the quickload UT. Non-destructive `PopPendingTree` preserves sidecar files.
+- New `FlightRecorder.LastRecordedAltitude` cache so `HandleSoiAutoSplit` can classify `fromPhase` correctly even after `FlushRecorderIntoActiveTreeForSerialization` clears the `Recording` buffer mid-flight. Updated by `CommitRecordedPoint`, `SamplePosition`, and `InsertBoundaryAnchorAndSnapshot` (for chain continuation anchors).
+- Vessel-switch scene reloads route through `FinalizePendingLimboTreeForRevert` to match mainline behavior — the new active vessel by definition can't match the tree's recorded vessel by name, so restoring would trap in the 3-second wait. Proper tree-preservation-on-switch is a follow-up (#266).
+
 ### Bug Fixes (Mun Mission Playtest)
 
 - **Fix ProtoVessel permanently lost in orbit segment gap (#244).** `CheckPendingMapVessels` removed the ProtoVessel when `FindOrbitSegment` returned null during a gap between segments (normal during burns) and never re-queued it. The ghost stayed icon-only for the entire Kerbin→Mun transfer. Now checks for future segments and re-queues to `pendingMapVessels`.

--- a/Source/Parsek.Tests/QuickloadResumeTests.cs
+++ b/Source/Parsek.Tests/QuickloadResumeTests.cs
@@ -285,6 +285,49 @@ namespace Parsek.Tests
             Assert.Equal(PendingTreeState.Limbo, RecordingStore.PendingTreeStateValue);
         }
 
+        [Fact]
+        public void TryRestoreActiveTreeNode_ParsesResumeHints()
+        {
+            var scenarioNode = new ConfigNode("PARSEK_SCENARIO");
+            var activeNode = scenarioNode.AddNode("RECORDING_TREE");
+            var activeTree = MakeTree("in_flight", "Mun Return", 1);
+            activeTree.Save(activeNode);
+            activeNode.AddValue("isActive", "True");
+            activeNode.AddValue("resumeRewindSave", "parsek_rw_abc123");
+            activeNode.AddValue("resumeBoundaryAnchorUT", "12345.67");
+
+            bool result = ParsekScenario.TryRestoreActiveTreeNode(scenarioNode);
+
+            Assert.True(result);
+            Assert.Equal("parsek_rw_abc123", ParsekScenario.pendingActiveTreeResumeRewindSave);
+            Assert.Equal(12345.67, ParsekScenario.pendingActiveTreeResumeBoundaryAnchorUT, 2);
+
+            // Cleanup for subsequent tests
+            ParsekScenario.pendingActiveTreeResumeRewindSave = null;
+            ParsekScenario.pendingActiveTreeResumeBoundaryAnchorUT = double.NaN;
+        }
+
+        [Fact]
+        public void TryRestoreActiveTreeNode_NoResumeHints_ClearsStaleValues()
+        {
+            // Pre-populate stale resume hints from a prior restore
+            ParsekScenario.pendingActiveTreeResumeRewindSave = "stale_save";
+            ParsekScenario.pendingActiveTreeResumeBoundaryAnchorUT = 999.0;
+
+            var scenarioNode = new ConfigNode("PARSEK_SCENARIO");
+            var activeNode = scenarioNode.AddNode("RECORDING_TREE");
+            var activeTree = MakeTree("in_flight", "Pad Walk", 1);
+            activeTree.Save(activeNode);
+            activeNode.AddValue("isActive", "True");
+            // No resumeRewindSave / resumeBoundaryAnchorUT
+
+            ParsekScenario.TryRestoreActiveTreeNode(scenarioNode);
+
+            // Rewind save becomes null (no key present), anchor UT becomes NaN
+            Assert.Null(ParsekScenario.pendingActiveTreeResumeRewindSave);
+            Assert.True(double.IsNaN(ParsekScenario.pendingActiveTreeResumeBoundaryAnchorUT));
+        }
+
         // ============================================================
         // isRevert logic: removal of || isFlightToFlight clause
         // ============================================================

--- a/Source/Parsek.Tests/QuickloadResumeTests.cs
+++ b/Source/Parsek.Tests/QuickloadResumeTests.cs
@@ -286,7 +286,7 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void TryRestoreActiveTreeNode_ParsesResumeHints()
+        public void TryRestoreActiveTreeNode_ParsesResumeRewindSave()
         {
             var scenarioNode = new ConfigNode("PARSEK_SCENARIO");
             var activeNode = scenarioNode.AddNode("RECORDING_TREE");
@@ -294,38 +294,124 @@ namespace Parsek.Tests
             activeTree.Save(activeNode);
             activeNode.AddValue("isActive", "True");
             activeNode.AddValue("resumeRewindSave", "parsek_rw_abc123");
-            activeNode.AddValue("resumeBoundaryAnchorUT", "12345.67");
 
             bool result = ParsekScenario.TryRestoreActiveTreeNode(scenarioNode);
 
             Assert.True(result);
             Assert.Equal("parsek_rw_abc123", ParsekScenario.pendingActiveTreeResumeRewindSave);
-            Assert.Equal(12345.67, ParsekScenario.pendingActiveTreeResumeBoundaryAnchorUT, 2);
 
             // Cleanup for subsequent tests
             ParsekScenario.pendingActiveTreeResumeRewindSave = null;
-            ParsekScenario.pendingActiveTreeResumeBoundaryAnchorUT = double.NaN;
         }
 
         [Fact]
-        public void TryRestoreActiveTreeNode_NoResumeHints_ClearsStaleValues()
+        public void TryRestoreActiveTreeNode_NoResumeRewindSave_ClearsStaleValue()
         {
-            // Pre-populate stale resume hints from a prior restore
+            // Pre-populate a stale resume hint from a prior restore
             ParsekScenario.pendingActiveTreeResumeRewindSave = "stale_save";
-            ParsekScenario.pendingActiveTreeResumeBoundaryAnchorUT = 999.0;
 
             var scenarioNode = new ConfigNode("PARSEK_SCENARIO");
             var activeNode = scenarioNode.AddNode("RECORDING_TREE");
             var activeTree = MakeTree("in_flight", "Pad Walk", 1);
             activeTree.Save(activeNode);
             activeNode.AddValue("isActive", "True");
-            // No resumeRewindSave / resumeBoundaryAnchorUT
+            // No resumeRewindSave key
 
             ParsekScenario.TryRestoreActiveTreeNode(scenarioNode);
 
-            // Rewind save becomes null (no key present), anchor UT becomes NaN
+            // Value becomes null (no key present)
             Assert.Null(ParsekScenario.pendingActiveTreeResumeRewindSave);
-            Assert.True(double.IsNaN(ParsekScenario.pendingActiveTreeResumeBoundaryAnchorUT));
+        }
+
+        [Fact]
+        public void TryRestoreActiveTreeNode_DoesNotWriteDeadBoundaryAnchorUT()
+        {
+            // BoundaryAnchor can't round-trip (needs full TrajectoryPoint, not just UT),
+            // so we removed the resumeBoundaryAnchorUT serialization and parsing. This
+            // test documents that a save with a legacy resumeBoundaryAnchorUT key from
+            // an older build is simply ignored, not parsed back into anything.
+            var scenarioNode = new ConfigNode("PARSEK_SCENARIO");
+            var activeNode = scenarioNode.AddNode("RECORDING_TREE");
+            var activeTree = MakeTree("in_flight", "Legacy Save", 1);
+            activeTree.Save(activeNode);
+            activeNode.AddValue("isActive", "True");
+            activeNode.AddValue("resumeBoundaryAnchorUT", "99999.99"); // legacy key
+
+            bool result = ParsekScenario.TryRestoreActiveTreeNode(scenarioNode);
+
+            Assert.True(result);
+            // The active tree is still restored; we just don't try to parse the anchor.
+            Assert.Equal("Legacy Save", RecordingStore.PendingTree.TreeName);
+        }
+
+        [Fact]
+        public void TryRestoreActiveTreeNode_DedupeCommittedTreeById()
+        {
+            // Reviewer edge case: flight → quicksave (writes isActive=True) →
+            // exit to TS (commits tree into committedTrees) → quickload.
+            // In-memory committedTrees still has the T3 version, disk save has the
+            // T2 active version. Without dedupe, next OnSave writes the tree twice
+            // with the same id. TryRestoreActiveTreeNode must remove the committed
+            // copy before stashing the active copy.
+            var committedTree = MakeTree("tree_x", "Duplicate Id", 2);
+            RecordingStore.CommitTree(committedTree);
+            Assert.Contains(committedTree, RecordingStore.CommittedTrees);
+
+            // Build a save node with an isActive=True tree using the SAME id
+            var scenarioNode = new ConfigNode("PARSEK_SCENARIO");
+            var activeNode = scenarioNode.AddNode("RECORDING_TREE");
+            var activeTree = MakeTree("tree_x", "Duplicate Id (active)", 2);
+            activeTree.Save(activeNode);
+            activeNode.AddValue("isActive", "True");
+
+            ParsekScenario.TryRestoreActiveTreeNode(scenarioNode);
+
+            // Committed copy should be gone; pending-Limbo holds the active version.
+            Assert.DoesNotContain(
+                RecordingStore.CommittedTrees,
+                t => t.Id == "tree_x");
+            Assert.Equal("Duplicate Id (active)", RecordingStore.PendingTree.TreeName);
+            Assert.Equal(PendingTreeState.Limbo, RecordingStore.PendingTreeStateValue);
+        }
+
+        [Fact]
+        public void LastRecordedAltitude_DefaultsToNaN()
+        {
+            // LastRecordedAltitude caches the last committed point's altitude so
+            // HandleSoiAutoSplit can read it even after FlushRecorderIntoActiveTreeForSerialization
+            // clears the Recording buffer. The default is NaN (no points recorded yet),
+            // which HandleSoiAutoSplit treats as "exo" (no altitude → fall through to
+            // the default phase classification).
+            var recorder = new FlightRecorder();
+            Assert.True(double.IsNaN(recorder.LastRecordedAltitude));
+        }
+
+        [Fact]
+        public void TryRestoreActiveTreeNode_NoOverwriteWarningOnExpectedOverwrite()
+        {
+            // StashActiveTreeAsPendingLimbo stashes the in-memory (future-timeline) tree
+            // at OnSceneChangeRequested time. Then TryRestoreActiveTreeNode loads the
+            // fresh disk version and stashes it. Without the PopPendingTree call,
+            // StashPendingTree's overwrite-warning log fires on every successful
+            // quickload. With the fix, TryRestoreActiveTreeNode pops first, then stashes
+            // silently.
+            var staleInMemoryTree = MakeTree("tree_y", "Stale In-Memory", 1);
+            RecordingStore.StashPendingTree(staleInMemoryTree, PendingTreeState.Limbo);
+
+            logLines.Clear();
+
+            var scenarioNode = new ConfigNode("PARSEK_SCENARIO");
+            var activeNode = scenarioNode.AddNode("RECORDING_TREE");
+            var diskTree = MakeTree("tree_y", "Disk Version", 1);
+            diskTree.Save(activeNode);
+            activeNode.AddValue("isActive", "True");
+
+            ParsekScenario.TryRestoreActiveTreeNode(scenarioNode);
+
+            Assert.Equal("Disk Version", RecordingStore.PendingTree.TreeName);
+            // No "overwriting existing pending tree" warning on the expected-overwrite path
+            Assert.DoesNotContain(logLines,
+                l => l.Contains("overwriting existing pending tree"));
         }
 
         // ============================================================
@@ -397,6 +483,41 @@ namespace Parsek.Tests
             return !isVesselSwitch
                 && (savedEpoch < currentEpoch
                     || totalSavedRecCount < memoryRecordingsCount);
+        }
+
+        /// <summary>
+        /// Mirrors the Limbo-dispatch decision in ParsekScenario.OnLoad. Returns
+        /// true if the tree should be finalized-and-committed, false if it should
+        /// be deferred to the restore coroutine for quickload-resume.
+        /// </summary>
+        private static bool ComputeShouldFinalizeOnDispatch(bool isRevert, bool isVesselSwitch)
+        {
+            return isRevert || isVesselSwitch;
+        }
+
+        [Fact]
+        public void LimboDispatch_Revert_Finalizes()
+        {
+            Assert.True(ComputeShouldFinalizeOnDispatch(isRevert: true, isVesselSwitch: false));
+        }
+
+        [Fact]
+        public void LimboDispatch_VesselSwitch_Finalizes()
+        {
+            // Vessel switch path: the new active vessel is by definition different from
+            // the tree's recorded vessel, so RestoreActiveTreeFromPending's name-match
+            // would fail. We match mainline's CommitTreeRevert behavior instead (finalize
+            // on vessel switch) until tree-preservation-on-switch is implemented as a
+            // follow-up.
+            Assert.True(ComputeShouldFinalizeOnDispatch(isRevert: false, isVesselSwitch: true));
+        }
+
+        [Fact]
+        public void LimboDispatch_Quickload_DefersToResume()
+        {
+            // Quickload / cold-start resume: tree should be restored-and-resumed,
+            // not finalized.
+            Assert.False(ComputeShouldFinalizeOnDispatch(isRevert: false, isVesselSwitch: false));
         }
 
         // ============================================================

--- a/Source/Parsek.Tests/QuickloadResumeTests.cs
+++ b/Source/Parsek.Tests/QuickloadResumeTests.cs
@@ -1,0 +1,390 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Unit tests for the quickload-resume recording pipeline (Bug C fix).
+    /// Covers:
+    /// - <see cref="PendingTreeState"/> transitions
+    /// - <see cref="RecordingStore.StashPendingTree(RecordingTree, PendingTreeState)"/>
+    /// - <see cref="RecordingStore.PopPendingTree"/> (non-destructive pop)
+    /// - <see cref="RecordingStore.MarkPendingTreeFinalized"/>
+    /// - ScenarioWriter round-trip of an active tree flagged with isActive=True
+    /// - <see cref="ParsekScenario.IsActiveTreeNode"/> dispatch
+    ///
+    /// End-to-end testing (OnSave → scene reload → OnLoad → resume coroutine)
+    /// requires Unity runtime and is covered by in-game tests, not here.
+    /// </summary>
+    [Collection("Sequential")]
+    public class QuickloadResumeTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public QuickloadResumeTests()
+        {
+            RecordingStore.ResetForTesting();
+            MilestoneStore.ResetForTesting();
+            ParsekLog.ResetTestOverrides();
+
+            // Enable logging through the test sink (matches TreeLogVerificationTests pattern)
+            RecordingStore.SuppressLogging = false;
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.VerboseOverrideForTesting = true;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+
+            // Suppress side effects that would crash outside Unity
+            GameStateStore.SuppressLogging = true;
+        }
+
+        public void Dispose()
+        {
+            RecordingStore.ResetForTesting();
+            MilestoneStore.ResetForTesting();
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+            RecordingStore.SuppressLogging = true;
+        }
+
+        // ============================================================
+        // PendingTreeState transitions
+        // ============================================================
+
+        [Fact]
+        public void DefaultState_IsFinalized()
+        {
+            Assert.Equal(PendingTreeState.Finalized, RecordingStore.PendingTreeStateValue);
+        }
+
+        [Fact]
+        public void StashPendingTree_DefaultsToFinalized()
+        {
+            var tree = MakeTree("tree_a", "Launch", 2);
+            RecordingStore.StashPendingTree(tree);
+            Assert.Equal(PendingTreeState.Finalized, RecordingStore.PendingTreeStateValue);
+            Assert.Same(tree, RecordingStore.PendingTree);
+        }
+
+        [Fact]
+        public void StashPendingTree_WithLimboState_IsLimbo()
+        {
+            var tree = MakeTree("tree_a", "Launch", 2);
+            RecordingStore.StashPendingTree(tree, PendingTreeState.Limbo);
+            Assert.Equal(PendingTreeState.Limbo, RecordingStore.PendingTreeStateValue);
+            Assert.Contains(logLines, l => l.Contains("state=Limbo"));
+        }
+
+        [Fact]
+        public void StashPendingTree_Overwriting_LogsWarning()
+        {
+            var first = MakeTree("first", "First", 1);
+            var second = MakeTree("second", "Second", 1);
+            RecordingStore.StashPendingTree(first, PendingTreeState.Limbo);
+            logLines.Clear();
+
+            RecordingStore.StashPendingTree(second, PendingTreeState.Finalized);
+
+            Assert.Same(second, RecordingStore.PendingTree);
+            Assert.Equal(PendingTreeState.Finalized, RecordingStore.PendingTreeStateValue);
+            Assert.Contains(logLines,
+                l => l.Contains("overwriting existing pending tree") && l.Contains("'First'"));
+        }
+
+        [Fact]
+        public void MarkPendingTreeFinalized_FlipsLimboToFinalized()
+        {
+            var tree = MakeTree("tree_a", "Mun", 2);
+            RecordingStore.StashPendingTree(tree, PendingTreeState.Limbo);
+            logLines.Clear();
+
+            RecordingStore.MarkPendingTreeFinalized();
+
+            Assert.Equal(PendingTreeState.Finalized, RecordingStore.PendingTreeStateValue);
+            Assert.Contains(logLines, l => l.Contains("Limbo → Finalized"));
+        }
+
+        [Fact]
+        public void MarkPendingTreeFinalized_OnAlreadyFinalized_NoOp()
+        {
+            var tree = MakeTree("tree_a", "Mun", 2);
+            RecordingStore.StashPendingTree(tree, PendingTreeState.Finalized);
+            logLines.Clear();
+
+            RecordingStore.MarkPendingTreeFinalized();
+
+            Assert.Equal(PendingTreeState.Finalized, RecordingStore.PendingTreeStateValue);
+            // No Limbo → Finalized log line since no transition happened
+            Assert.DoesNotContain(logLines, l => l.Contains("Limbo → Finalized"));
+        }
+
+        [Fact]
+        public void MarkPendingTreeFinalized_NoPendingTree_NoOp()
+        {
+            RecordingStore.MarkPendingTreeFinalized();
+            Assert.Equal(PendingTreeState.Finalized, RecordingStore.PendingTreeStateValue);
+            Assert.Null(RecordingStore.PendingTree);
+        }
+
+        // ============================================================
+        // PopPendingTree non-destructive behavior
+        // ============================================================
+
+        [Fact]
+        public void PopPendingTree_ReturnsTreeAndClearsSlot()
+        {
+            var tree = MakeTree("tree_a", "Mun", 2);
+            RecordingStore.StashPendingTree(tree, PendingTreeState.Limbo);
+
+            var popped = RecordingStore.PopPendingTree();
+
+            Assert.Same(tree, popped);
+            Assert.Null(RecordingStore.PendingTree);
+            Assert.Equal(PendingTreeState.Finalized, RecordingStore.PendingTreeStateValue);
+        }
+
+        [Fact]
+        public void PopPendingTree_NoTree_ReturnsNull()
+        {
+            var popped = RecordingStore.PopPendingTree();
+            Assert.Null(popped);
+        }
+
+        // ============================================================
+        // Discard and Clear reset state
+        // ============================================================
+
+        [Fact]
+        public void DiscardPendingTree_ResetsStateToFinalized()
+        {
+            var tree = MakeTree("tree_a", "Mun", 2);
+            RecordingStore.StashPendingTree(tree, PendingTreeState.Limbo);
+            RecordingStore.DiscardPendingTree();
+            Assert.Null(RecordingStore.PendingTree);
+            Assert.Equal(PendingTreeState.Finalized, RecordingStore.PendingTreeStateValue);
+        }
+
+        [Fact]
+        public void CommitPendingTree_ResetsStateToFinalized()
+        {
+            var tree = MakeTree("tree_a", "Mun", 2);
+            // CommitTree needs file writes which fail outside Unity, so this test
+            // only verifies the guard path (no pending tree → no-op)
+            RecordingStore.ResetForTesting();
+            RecordingStore.CommitPendingTree();
+            Assert.Equal(PendingTreeState.Finalized, RecordingStore.PendingTreeStateValue);
+        }
+
+        [Fact]
+        public void Clear_ResetsStateToFinalized()
+        {
+            var tree = MakeTree("tree_a", "Mun", 2);
+            RecordingStore.StashPendingTree(tree, PendingTreeState.Limbo);
+            RecordingStore.Clear();
+            Assert.Null(RecordingStore.PendingTree);
+            Assert.Equal(PendingTreeState.Finalized, RecordingStore.PendingTreeStateValue);
+        }
+
+        // ============================================================
+        // IsActiveTreeNode dispatch
+        // ============================================================
+
+        [Fact]
+        public void IsActiveTreeNode_NullNode_ReturnsFalse()
+        {
+            Assert.False(ParsekScenario.IsActiveTreeNode(null));
+        }
+
+        [Fact]
+        public void IsActiveTreeNode_MissingFlag_ReturnsFalse()
+        {
+            var node = new ConfigNode("RECORDING_TREE");
+            node.AddValue("id", "tree_x");
+            Assert.False(ParsekScenario.IsActiveTreeNode(node));
+        }
+
+        [Fact]
+        public void IsActiveTreeNode_FlagFalse_ReturnsFalse()
+        {
+            var node = new ConfigNode("RECORDING_TREE");
+            node.AddValue("isActive", "False");
+            Assert.False(ParsekScenario.IsActiveTreeNode(node));
+        }
+
+        [Fact]
+        public void IsActiveTreeNode_FlagTrue_ReturnsTrue()
+        {
+            var node = new ConfigNode("RECORDING_TREE");
+            node.AddValue("isActive", "True");
+            Assert.True(ParsekScenario.IsActiveTreeNode(node));
+        }
+
+        [Fact]
+        public void IsActiveTreeNode_FlagTrueMixedCase_ReturnsTrue()
+        {
+            var node = new ConfigNode("RECORDING_TREE");
+            node.AddValue("isActive", "true");
+            Assert.True(ParsekScenario.IsActiveTreeNode(node));
+        }
+
+        // ============================================================
+        // TryRestoreActiveTreeNode end-to-end (parse → stash as Limbo)
+        // ============================================================
+
+        [Fact]
+        public void TryRestoreActiveTreeNode_NoActiveTreeInSave_ReturnsFalseAndLeavesPendingEmpty()
+        {
+            var scenarioNode = new ConfigNode("PARSEK_SCENARIO");
+            // Add a committed (non-active) tree to verify it's NOT stashed as Limbo
+            var committedTreeNode = scenarioNode.AddNode("RECORDING_TREE");
+            var committedTree = MakeTree("committed", "Launched", 2);
+            committedTree.Save(committedTreeNode);
+
+            bool result = ParsekScenario.TryRestoreActiveTreeNode(scenarioNode);
+
+            Assert.False(result);
+            Assert.Null(RecordingStore.PendingTree);
+            Assert.Equal(PendingTreeState.Finalized, RecordingStore.PendingTreeStateValue);
+        }
+
+        [Fact]
+        public void TryRestoreActiveTreeNode_WithActiveTree_StashesAsLimbo()
+        {
+            var scenarioNode = new ConfigNode("PARSEK_SCENARIO");
+            var activeTreeNode = scenarioNode.AddNode("RECORDING_TREE");
+            var activeTree = MakeTree("in_flight", "Launching", 2);
+            activeTree.Save(activeTreeNode);
+            activeTreeNode.AddValue("isActive", "True");
+
+            bool result = ParsekScenario.TryRestoreActiveTreeNode(scenarioNode);
+
+            Assert.True(result);
+            Assert.NotNull(RecordingStore.PendingTree);
+            Assert.Equal("Launching", RecordingStore.PendingTree.TreeName);
+            Assert.Equal(PendingTreeState.Limbo, RecordingStore.PendingTreeStateValue);
+        }
+
+        [Fact]
+        public void TryRestoreActiveTreeNode_SkipsCommittedTreeStashesActiveTree()
+        {
+            var scenarioNode = new ConfigNode("PARSEK_SCENARIO");
+            // Committed tree first (no isActive flag)
+            var committedNode = scenarioNode.AddNode("RECORDING_TREE");
+            var committedTree = MakeTree("committed", "Prior Mission", 3);
+            committedTree.Save(committedNode);
+            // Then the active tree
+            var activeNode = scenarioNode.AddNode("RECORDING_TREE");
+            var activeTree = MakeTree("in_flight", "Current Mission", 2);
+            activeTree.Save(activeNode);
+            activeNode.AddValue("isActive", "True");
+
+            bool result = ParsekScenario.TryRestoreActiveTreeNode(scenarioNode);
+
+            Assert.True(result);
+            Assert.Equal("Current Mission", RecordingStore.PendingTree.TreeName);
+            Assert.Equal(PendingTreeState.Limbo, RecordingStore.PendingTreeStateValue);
+        }
+
+        // ============================================================
+        // isRevert logic: removal of || isFlightToFlight clause
+        // ============================================================
+
+        [Fact]
+        public void IsRevert_EpochDecreased_IsTrue()
+        {
+            // Pure logic test of the isRevert condition after fix (no FLIGHT→FLIGHT clause)
+            bool isRevert = ComputeIsRevert(
+                isVesselSwitch: false,
+                savedEpoch: 5,
+                currentEpoch: 6,
+                totalSavedRecCount: 10,
+                memoryRecordingsCount: 10);
+            Assert.True(isRevert);
+        }
+
+        [Fact]
+        public void IsRevert_CountDecreased_IsTrue()
+        {
+            bool isRevert = ComputeIsRevert(
+                isVesselSwitch: false,
+                savedEpoch: 5,
+                currentEpoch: 5,
+                totalSavedRecCount: 8,
+                memoryRecordingsCount: 10);
+            Assert.True(isRevert);
+        }
+
+        [Fact]
+        public void IsRevert_QuickloadSameEpochSameCount_IsFalse()
+        {
+            // Quickload: both epoch and count match the memory state (since quicksave
+            // captured both at the current moment).
+            bool isRevert = ComputeIsRevert(
+                isVesselSwitch: false,
+                savedEpoch: 5,
+                currentEpoch: 5,
+                totalSavedRecCount: 10,
+                memoryRecordingsCount: 10);
+            Assert.False(isRevert);
+        }
+
+        [Fact]
+        public void IsRevert_VesselSwitch_IsFalseEvenIfEpochRegresses()
+        {
+            // Vessel switch flag suppresses isRevert regardless of other indicators
+            // (defensive — in practice vessel switches preserve epoch/count anyway)
+            bool isRevert = ComputeIsRevert(
+                isVesselSwitch: true,
+                savedEpoch: 4,
+                currentEpoch: 6,
+                totalSavedRecCount: 5,
+                memoryRecordingsCount: 10);
+            Assert.False(isRevert);
+        }
+
+        /// <summary>
+        /// Mirrors the isRevert computation in ParsekScenario.OnLoad after the fix
+        /// (removal of the || isFlightToFlight clause). Kept here as a pure function
+        /// so it can be unit-tested without needing a full ParsekScenario instance.
+        /// </summary>
+        private static bool ComputeIsRevert(
+            bool isVesselSwitch, uint savedEpoch, uint currentEpoch,
+            int totalSavedRecCount, int memoryRecordingsCount)
+        {
+            return !isVesselSwitch
+                && (savedEpoch < currentEpoch
+                    || totalSavedRecCount < memoryRecordingsCount);
+        }
+
+        // ============================================================
+        // Test helpers
+        // ============================================================
+
+        private static RecordingTree MakeTree(string id, string name, int recordingCount)
+        {
+            var tree = new RecordingTree
+            {
+                Id = id,
+                TreeName = name,
+                RootRecordingId = "root_" + id,
+                ActiveRecordingId = "root_" + id,
+            };
+            for (int i = 0; i < recordingCount; i++)
+            {
+                string recId = i == 0 ? "root_" + id : $"child_{id}_{i}";
+                var rec = new Recording
+                {
+                    RecordingId = recId,
+                    VesselName = $"{name} #{i}",
+                    TreeId = id,
+                    ExplicitStartUT = 100 + i * 10,
+                    ExplicitEndUT = 110 + i * 10,
+                };
+                rec.Points.Add(new TrajectoryPoint { ut = rec.ExplicitStartUT });
+                rec.Points.Add(new TrajectoryPoint { ut = rec.ExplicitEndUT });
+                tree.Recordings[recId] = rec;
+            }
+            return tree;
+        }
+    }
+}

--- a/Source/Parsek.Tests/TreeLogVerificationTests.cs
+++ b/Source/Parsek.Tests/TreeLogVerificationTests.cs
@@ -88,7 +88,7 @@ namespace Parsek.Tests
             RecordingStore.StashPendingTree(tree);
 
             Assert.Contains(capturedLines,
-                line => line.Contains("Stashed pending tree 'Mun Mission' (3 recordings)"));
+                line => line.Contains("Stashed pending tree 'Mun Mission' (3 recordings, state=Finalized)"));
         }
 
         // ============================================================

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -4241,6 +4241,12 @@ namespace Parsek
                 Recording.Add(anchor);
                 lastRecordedUT = anchorUT;
                 lastRecordedVelocity = anchor.velocity;
+                // Mirror lastRecordedVelocity: the anchor is a full TrajectoryPoint with
+                // an altitude field, and HandleSoiAutoSplit's "approach vs exo" decision
+                // reads LastRecordedAltitude. Without this, a chain continuation that
+                // hits an SOI split before the first live sample would misclassify the
+                // fromPhase as "exo" (because the cached altitude is still NaN).
+                LastRecordedAltitude = anchor.altitude;
                 BoundaryAnchor = null;
                 ParsekLog.Verbose("Recorder", $"Boundary anchor inserted at UT {anchorUT:F3}");
             }

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -161,7 +161,21 @@ namespace Parsek
         public double PreLaunchFunds { get; private set; }
         public double PreLaunchScience { get; private set; }
         public float PreLaunchReputation { get; private set; }
-        public string RewindSaveFileName { get; internal set; }
+        public string RewindSaveFileName { get; private set; }
+
+        /// <summary>
+        /// Sets <see cref="RewindSaveFileName"/> from the quickload-resume restore path,
+        /// logging the transition with a reason so the state change is visible in KSP.log.
+        /// The normal recording-start path uses <see cref="CaptureRewindSave"/> which
+        /// writes the field directly; this setter exists only for restore.
+        /// </summary>
+        internal void SetRewindSaveFileNameForRestore(string fileName, string reason)
+        {
+            string prev = RewindSaveFileName;
+            RewindSaveFileName = fileName;
+            ParsekLog.Info("Recorder",
+                $"RewindSaveFileName set for restore: '{prev ?? "<null>"}' → '{fileName ?? "<null>"}' ({reason})");
+        }
         public double RewindReservedFunds { get; private set; }
         public double RewindReservedScience { get; private set; }
         public float RewindReservedRep { get; private set; }
@@ -192,6 +206,16 @@ namespace Parsek
         internal const float AnimateHeatColdThreshold = 0.10f;
         private double lastRecordedUT = -1;
         private Vector3 lastRecordedVelocity;
+
+        /// <summary>
+        /// Altitude (m) of the most recently committed point. Double.NaN until the
+        /// first point is recorded. Exposed so callers (e.g. HandleSoiAutoSplit in
+        /// ParsekFlight) can read the "last known altitude" without depending on
+        /// the Recording buffer being populated — the buffer is cleared by
+        /// FlushRecorderIntoActiveTreeForSerialization on every OnSave while
+        /// IsRecording stays true.
+        /// </summary>
+        internal double LastRecordedAltitude { get; private set; } = double.NaN;
         private ConfigNode lastGoodVesselSnapshot;
         private ConfigNode initialGhostVisualSnapshot;
         private double lastSnapshotRefreshUT = double.MinValue;
@@ -4143,6 +4167,7 @@ namespace Parsek
             RecordingStartedAsEva = v.isEVA;
             lastRecordedUT = -1;
             lastRecordedVelocity = Vector3.zero;
+            LastRecordedAltitude = double.NaN;
 
             hasPersistentRotation = AssemblyLoader.loadedAssemblies.Any(
                 a => a.name == "PersistentRotation");
@@ -4867,6 +4892,7 @@ namespace Parsek
             Recording.Add(point);
             lastRecordedUT = point.ut;
             lastRecordedVelocity = point.velocity;
+            LastRecordedAltitude = point.altitude;
 
             // Dual-write: flat Points list + current TrackSection
             if (trackSectionActive && currentTrackSection.frames != null)
@@ -5026,6 +5052,7 @@ namespace Parsek
             Recording.Add(point);
             lastRecordedUT = point.ut;
             lastRecordedVelocity = point.velocity;
+            LastRecordedAltitude = point.altitude;
             ParsekLog.Verbose("Recorder", $"Boundary point sampled at UT={point.ut:F1}");
 
             // Dual-write: flat Points list + current TrackSection

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -161,7 +161,7 @@ namespace Parsek
         public double PreLaunchFunds { get; private set; }
         public double PreLaunchScience { get; private set; }
         public float PreLaunchReputation { get; private set; }
-        public string RewindSaveFileName { get; private set; }
+        public string RewindSaveFileName { get; internal set; }
         public double RewindReservedFunds { get; private set; }
         public double RewindReservedScience { get; private set; }
         public float RewindReservedRep { get; private set; }

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -4551,9 +4551,15 @@ namespace Parsek
                 fromPhase = "exo"; // was in space around atmospheric body
             else if (fromCB != null)
             {
+                // Use LastRecordedAltitude (cached field) instead of peeking at the
+                // Recording buffer. The buffer can legitimately be empty here because
+                // FlushRecorderIntoActiveTreeForSerialization clears it on every OnSave
+                // while IsRecording stays true. The cached field is updated every
+                // CommitRecordedPoint / SamplePosition, so it reflects the true last
+                // altitude regardless of whether a flush happened since.
                 double threshold = FlightRecorder.ComputeApproachAltitude(fromCB);
-                fromPhase = recorder.Recording.Count > 0 &&
-                    recorder.Recording[recorder.Recording.Count - 1].altitude < threshold
+                fromPhase = !double.IsNaN(recorder.LastRecordedAltitude)
+                    && recorder.LastRecordedAltitude < threshold
                     ? "approach" : "exo";
             }
             else
@@ -5305,14 +5311,16 @@ namespace Parsek
             // Restore recorder state persisted in the PARSEK_ACTIVE_TREE node
             if (!string.IsNullOrEmpty(ParsekScenario.pendingActiveTreeResumeRewindSave))
             {
-                recorder.RewindSaveFileName = ParsekScenario.pendingActiveTreeResumeRewindSave;
+                recorder.SetRewindSaveFileNameForRestore(
+                    ParsekScenario.pendingActiveTreeResumeRewindSave,
+                    "quickload-resume from PARSEK_ACTIVE_TREE");
                 ParsekScenario.pendingActiveTreeResumeRewindSave = null;
             }
-            // BoundaryAnchor UT is informational only — the TrajectoryPoint struct needs
-            // the full state, which we don't serialize. Skip restoring it; the worst case
-            // is a single extra boundary point on the next chain continuation, which is
-            // benign compared to losing the entire resume.
-            ParsekScenario.pendingActiveTreeResumeBoundaryAnchorUT = double.NaN;
+            // BoundaryAnchor is NOT restored — only the UT could round-trip through the
+            // save node, and reconstructing a TrajectoryPoint from a bare UT is not
+            // possible (needs lat/lon/alt/rotation/velocity). Leaving BoundaryAnchor
+            // unset produces one extra boundary point on the next chain continuation,
+            // which is benign. See SaveActiveTreeIfAny for the write-side comment.
 
             // Start recording as a promotion (isPromotion: true) so the Bug A seed-event
             // skip kicks in — no duplicate DeployableExtended / LightOn / etc. events at

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -5212,16 +5212,49 @@ namespace Parsek
                 $"RestoreActiveTreeFromPending: waiting for vessel '{targetName}' to load " +
                 $"(activeRecId={activeRecId})");
 
-            // Wait up to 3 seconds for the current active vessel to match by name
+            // Wait up to 3 seconds for the current active vessel to match by name.
+            // Primary match = active recording's vessel name.
+            // Fallback (edge case 3): if the active recording was an EVA kerbal who got
+            // boarded between quicksave and quickload, match against the parent recording's
+            // vessel by walking ParentRecordingId up the EVA chain.
+            Recording matchedRec = activeRec;
+            string matchedRecId = activeRecId;
             float deadline = UnityEngine.Time.time + 3f;
             Vessel matched = null;
             while (UnityEngine.Time.time < deadline)
             {
                 var v = FlightGlobals.ActiveVessel;
-                if (v != null && v.vesselName == targetName)
+                if (v != null)
                 {
-                    matched = v;
-                    break;
+                    // Primary: active recording vessel name
+                    if (v.vesselName == targetName)
+                    {
+                        matched = v;
+                        break;
+                    }
+                    // Fallback: walk ParentRecordingId chain and try each parent's vessel name
+                    Recording probe = activeRec;
+                    int walkDepth = 0;
+                    while (walkDepth < 5 && !string.IsNullOrEmpty(probe?.ParentRecordingId))
+                    {
+                        if (!tree.Recordings.TryGetValue(probe.ParentRecordingId, out probe))
+                            break;
+                        if (probe != null && v.vesselName == probe.VesselName)
+                        {
+                            matched = v;
+                            matchedRec = probe;
+                            matchedRecId = probe.RecordingId;
+                            ParsekLog.Info("Flight",
+                                $"RestoreActiveTreeFromPending: fallback match — active vessel '{v.vesselName}' " +
+                                $"matches parent recording '{matchedRecId}' (original active was '{targetName}', " +
+                                $"EVA kerbal likely boarded between F5 and F9)");
+                            // Flip the tree's active-recording pointer to the parent
+                            tree.ActiveRecordingId = matchedRecId;
+                            break;
+                        }
+                        walkDepth++;
+                    }
+                    if (matched != null) break;
                 }
                 yield return null;
             }
@@ -5229,10 +5262,14 @@ namespace Parsek
             if (matched == null)
             {
                 ParsekLog.Warn("Flight",
-                    $"RestoreActiveTreeFromPending: vessel '{targetName}' not active within 3s — " +
-                    $"leaving tree in Limbo (user can trigger merge dialog via scene exit)");
+                    $"RestoreActiveTreeFromPending: vessel '{targetName}' (and no EVA parent fallback) " +
+                    "not active within 3s — leaving tree in Limbo (user can trigger merge dialog via scene exit)");
                 yield break;
             }
+
+            // After a parent-fallback match, the rest of the coroutine uses matchedRec/matchedRecId
+            activeRec = matchedRec;
+            activeRecId = matchedRecId;
 
             // PID remap: KSP may have regenerated the persistentId across quickload.
             // Tree.BackgroundMap is keyed by PID, so update any old-PID entries too.

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -149,6 +149,91 @@ namespace Parsek
         // Recording tree mode (null when not in tree mode)
         private RecordingTree activeTree;
 
+        /// <summary>
+        /// Read-only access to the currently-active recording tree, for ParsekScenario.OnSave
+        /// to serialize as a PARSEK_ACTIVE_TREE-flagged node (quickload-resume support).
+        /// Null when not in tree mode.
+        /// </summary>
+        internal RecordingTree ActiveTreeForSerialization => activeTree;
+
+        /// <summary>
+        /// Read-only access to the current active recorder, for ParsekScenario.OnSave
+        /// to check whether serialization of the active tree is appropriate and to flush
+        /// buffered recorder data into the tree before writing.
+        /// </summary>
+        internal FlightRecorder ActiveRecorderForSerialization => recorder;
+
+        /// <summary>
+        /// Flushes the active recorder's buffered points/events into the active tree's
+        /// current recording, WITHOUT stopping the recorder or clearing its state. Called
+        /// by <see cref="ParsekScenario.OnSave"/> via <c>SaveActiveTreeIfAny</c> so the
+        /// serialized active tree reflects the latest in-flight data.
+        ///
+        /// Unlike <see cref="FlushRecorderToTreeRecording"/> which also sets
+        /// <c>IsRecording = false</c>, this variant leaves the recorder running so the
+        /// user's current flight continues uninterrupted after the save completes.
+        /// The recorder's buffers are cleared so subsequent frames don't re-flush the
+        /// same data on the next save.
+        /// </summary>
+        internal void FlushRecorderIntoActiveTreeForSerialization()
+        {
+            if (recorder == null || activeTree == null) return;
+
+            string recId = activeTree.ActiveRecordingId;
+            if (recId == null)
+            {
+                ParsekLog.Verbose("Flight",
+                    "FlushRecorderIntoActiveTreeForSerialization: no active recording id in tree — skipping");
+                return;
+            }
+
+            if (!activeTree.Recordings.TryGetValue(recId, out var treeRec))
+            {
+                ParsekLog.Warn("Flight",
+                    $"FlushRecorderIntoActiveTreeForSerialization: active recording id '{recId}' not found in tree");
+                return;
+            }
+
+            int prevPointCount = treeRec.Points.Count;
+            int prevEventCount = treeRec.PartEvents.Count;
+
+            // Append buffered data from the live recorder into the tree recording
+            treeRec.Points.AddRange(recorder.Recording);
+            treeRec.OrbitSegments.AddRange(recorder.OrbitSegments);
+            treeRec.PartEvents.AddRange(recorder.PartEvents);
+            treeRec.FlagEvents.AddRange(recorder.FlagEvents);
+            treeRec.TrackSections.AddRange(recorder.TrackSections);
+
+            // Sort events chronologically — mixed sources can produce out-of-order data
+            treeRec.PartEvents.Sort((a, b) => a.ut.CompareTo(b.ut));
+            treeRec.FlagEvents.Sort((a, b) => a.ut.CompareTo(b.ut));
+
+            // Populate VesselPersistentId if not already set
+            if (treeRec.VesselPersistentId == 0 && recorder.RecordingVesselId != 0)
+                treeRec.VesselPersistentId = recorder.RecordingVesselId;
+
+            // Mark tree recording dirty so the sidecar file is rewritten
+            treeRec.FilesDirty = true;
+
+            // Clear the recorder's buffers so subsequent saves don't re-flush the same data.
+            // The recorder stays IsRecording=true and will append new frames as they come in.
+            int flushedPoints = recorder.Recording.Count;
+            int flushedEvents = recorder.PartEvents.Count;
+            recorder.Recording.Clear();
+            recorder.OrbitSegments.Clear();
+            recorder.PartEvents.Clear();
+            recorder.FlagEvents.Clear();
+            recorder.TrackSections.Clear();
+
+            ParsekLog.Verbose("Flight",
+                $"Flushed recorder→active-tree '{recId}' for serialization: " +
+                $"{flushedPoints} points, {flushedEvents} part events " +
+                $"(tree recording now has {treeRec.Points.Count} points " +
+                $"(+{treeRec.Points.Count - prevPointCount}), " +
+                $"{treeRec.PartEvents.Count} part events " +
+                $"(+{treeRec.PartEvents.Count - prevEventCount}))");
+        }
+
         // Debris persistence enforcement: saved original value when Parsek overrides it
         private const int MinDebrisForRecording = 10;
         private int savedMaxPersistentDebris = -1;
@@ -803,8 +888,12 @@ namespace Parsek
 
             if (scene == GameScenes.FLIGHT)
             {
-                // Revert: preserve snapshots for merge dialog
-                CommitTreeRevert(commitUT);
+                // FLIGHT→FLIGHT: the player quickloaded, reverted, or vessel-switched
+                // into a scene reload. We can't tell which until ParsekScenario.OnLoad
+                // runs. Stash the tree WITHOUT finalization; OnLoad's revert detection
+                // dispatch will either restore-and-resume (quickload) or finalize-and-commit
+                // (revert). See docs/dev/plans/quickload-resume-recording.md (Bug C).
+                StashActiveTreeAsPendingLimbo(commitUT);
             }
             else if (!ParsekScenario.IsAutoMerge)
             {
@@ -3712,6 +3801,17 @@ namespace Parsek
                 Patches.FlightResultsPatch.ReplayFlightResults();
             }
 
+            // Quickload-resume: ParsekScenario.OnLoad detected a pending-Limbo tree on
+            // the !isRevert branch and deferred restore to this point. Starts a coroutine
+            // that matches the active vessel by name, wires a fresh recorder to the
+            // restored tree, and resumes recording via StartRecording(isPromotion: true)
+            // so bug A's seed-event skip prevents duplicate events at the quickload UT.
+            if (ParsekScenario.ScheduleActiveTreeRestoreOnFlightReady)
+            {
+                ParsekScenario.ScheduleActiveTreeRestoreOnFlightReady = false;
+                StartCoroutine(RestoreActiveTreeFromPending());
+            }
+
             ResetFlightReadyState();
 
             // Belt-and-suspenders: recover orphaned spawned vessels that survived
@@ -5067,6 +5167,216 @@ namespace Parsek
 
             ParsekLog.Info("Flight",
                 $"CommitTreeRevert: stashed pending tree '{activeTree.TreeName}' with snapshots preserved");
+        }
+
+        /// <summary>
+        /// Quickload-resume path (Bug C fix). Waits for the active vessel to load,
+        /// matches it by name against the pending-Limbo tree's active recording,
+        /// updates the tree's vessel PID (KSP can regenerate PIDs across quickload),
+        /// constructs a fresh <see cref="FlightRecorder"/>, and calls
+        /// <c>StartRecording(isPromotion: true)</c> so recording resumes appending to
+        /// the same chain segment that was active at quicksave time.
+        ///
+        /// <para>The <c>isPromotion: true</c> flag invokes bug A's seed-event skip
+        /// so no duplicate DeployableExtended / LightOn / etc. events fire at the
+        /// quickload UT.</para>
+        ///
+        /// <para>If the vessel can't be found within 3 seconds (name change, EVA
+        /// boarded between save and load, etc.), the tree is left in pending-Limbo
+        /// and a warning logged. The player can manually trigger the merge dialog
+        /// via scene exit if they want to commit it as-is.</para>
+        /// </summary>
+        IEnumerator RestoreActiveTreeFromPending()
+        {
+            if (!RecordingStore.HasPendingTree
+                || RecordingStore.PendingTreeStateValue != PendingTreeState.Limbo)
+            {
+                ParsekLog.Verbose("Flight",
+                    "RestoreActiveTreeFromPending: no pending-Limbo tree, skipping");
+                yield break;
+            }
+
+            var tree = RecordingStore.PendingTree;
+            string activeRecId = tree.ActiveRecordingId;
+            if (string.IsNullOrEmpty(activeRecId)
+                || !tree.Recordings.TryGetValue(activeRecId, out var activeRec))
+            {
+                ParsekLog.Warn("Flight",
+                    $"RestoreActiveTreeFromPending: pending tree '{tree.TreeName}' has no resolvable " +
+                    $"activeRecordingId — leaving in Limbo");
+                yield break;
+            }
+
+            string targetName = activeRec.VesselName;
+            ParsekLog.Info("Flight",
+                $"RestoreActiveTreeFromPending: waiting for vessel '{targetName}' to load " +
+                $"(activeRecId={activeRecId})");
+
+            // Wait up to 3 seconds for the current active vessel to match by name
+            float deadline = UnityEngine.Time.time + 3f;
+            Vessel matched = null;
+            while (UnityEngine.Time.time < deadline)
+            {
+                var v = FlightGlobals.ActiveVessel;
+                if (v != null && v.vesselName == targetName)
+                {
+                    matched = v;
+                    break;
+                }
+                yield return null;
+            }
+
+            if (matched == null)
+            {
+                ParsekLog.Warn("Flight",
+                    $"RestoreActiveTreeFromPending: vessel '{targetName}' not active within 3s — " +
+                    $"leaving tree in Limbo (user can trigger merge dialog via scene exit)");
+                yield break;
+            }
+
+            // PID remap: KSP may have regenerated the persistentId across quickload.
+            // Tree.BackgroundMap is keyed by PID, so update any old-PID entries too.
+            uint oldPid = activeRec.VesselPersistentId;
+            uint newPid = matched.persistentId;
+            if (oldPid != newPid)
+            {
+                activeRec.VesselPersistentId = newPid;
+                if (oldPid != 0 && tree.BackgroundMap.TryGetValue(oldPid, out var bgRecId))
+                {
+                    tree.BackgroundMap.Remove(oldPid);
+                    if (bgRecId != activeRecId)
+                        tree.BackgroundMap[newPid] = bgRecId;
+                }
+                ParsekLog.Info("Flight",
+                    $"RestoreActiveTreeFromPending: PID remap {oldPid} → {newPid} for '{targetName}'");
+            }
+
+            // Pop the tree out of pending-Limbo (non-destructive — preserves sidecar files)
+            // and re-install as the live active tree.
+            activeTree = RecordingStore.PopPendingTree();
+            if (activeTree == null)
+            {
+                ParsekLog.Warn("Flight",
+                    "RestoreActiveTreeFromPending: PopPendingTree returned null after we verified the tree exists");
+                yield break;
+            }
+
+            // Construct a fresh FlightRecorder pointed at the restored tree.
+            recorder = new FlightRecorder();
+            recorder.ActiveTree = activeTree;
+
+            // Restore recorder state persisted in the PARSEK_ACTIVE_TREE node
+            if (!string.IsNullOrEmpty(ParsekScenario.pendingActiveTreeResumeRewindSave))
+            {
+                recorder.RewindSaveFileName = ParsekScenario.pendingActiveTreeResumeRewindSave;
+                ParsekScenario.pendingActiveTreeResumeRewindSave = null;
+            }
+            // BoundaryAnchor UT is informational only — the TrajectoryPoint struct needs
+            // the full state, which we don't serialize. Skip restoring it; the worst case
+            // is a single extra boundary point on the next chain continuation, which is
+            // benign compared to losing the entire resume.
+            ParsekScenario.pendingActiveTreeResumeBoundaryAnchorUT = double.NaN;
+
+            // Start recording as a promotion (isPromotion: true) so the Bug A seed-event
+            // skip kicks in — no duplicate DeployableExtended / LightOn / etc. events at
+            // the quickload UT. The new recorder's buffers start empty and will append
+            // to activeTree.Recordings[activeRecId] on the next chain boundary or
+            // scene exit flush.
+            recorder.StartRecording(isPromotion: true);
+            if (!recorder.IsRecording)
+            {
+                ParsekLog.Warn("Flight",
+                    $"RestoreActiveTreeFromPending: StartRecording returned IsRecording=false for " +
+                    $"'{targetName}' — restore incomplete");
+                yield break;
+            }
+
+            // Re-attach the BackgroundRecorder for the tree
+            if (backgroundRecorder == null)
+            {
+                backgroundRecorder = new BackgroundRecorder(activeTree);
+                backgroundRecorder.SubscribePartEvents();
+                Patches.PhysicsFramePatch.BackgroundRecorderInstance = backgroundRecorder;
+            }
+
+            ParsekLog.Info("Flight",
+                $"RestoreActiveTreeFromPending: resumed recording tree '{activeTree.TreeName}' " +
+                $"activeRec='{activeRecId}' vessel='{targetName}' pid={newPid} at UT={Planetarium.GetUniversalTime():F1}");
+        }
+
+        /// <summary>
+        /// Flight→Flight stash path (Bug C fix): stashes the active tree into the
+        /// pending-Limbo slot WITHOUT finalizing terminal state. ParsekScenario.OnLoad
+        /// decides, based on revert vs quickload detection, whether to finalize-and-commit
+        /// (real revert) or restore-and-resume (quickload / vessel switch).
+        ///
+        /// <para>Flushes recorder buffers into the tree so no trajectory data is lost.
+        /// Closes background orbit segments. Aborts any pending split (continuation
+        /// window state cannot survive a scene reload cleanly — edge case #4 in the
+        /// design doc).</para>
+        /// </summary>
+        void StashActiveTreeAsPendingLimbo(double commitUT)
+        {
+            if (activeTree == null) return;
+
+            ParsekLog.Info("Flight",
+                $"StashActiveTreeAsPendingLimbo: stashing tree '{activeTree.TreeName}' at UT={commitUT:F1} " +
+                $"(activeRecId={activeTree.ActiveRecordingId ?? "<null>"})");
+
+            // Flush active recorder's buffered points/events into the active tree's
+            // current recording, without setting terminal state. FinalizeRecorderForLimbo
+            // is a minimal version of FinalizeTreeRecordings that stops at flushing.
+            if (recorder != null)
+            {
+                if (recorder.IsRecording)
+                {
+                    if (recorder.IsBackgrounded)
+                        recorder.IsRecording = false;
+                    else
+                        recorder.ForceStop();
+                }
+                FlushRecorderToTreeRecording(recorder, activeTree);
+
+                // Copy rewind save filename to the tree's root recording so the R button
+                // still works after a potential future revert on this tree.
+                string rewindSave = recorder.CaptureAtStop?.RewindSaveFileName
+                    ?? recorder.RewindSaveFileName;
+                if (!string.IsNullOrEmpty(rewindSave)
+                    && !string.IsNullOrEmpty(activeTree.RootRecordingId))
+                {
+                    if (activeTree.Recordings.TryGetValue(activeTree.RootRecordingId, out var rootRec))
+                    {
+                        rootRec.RewindSaveFileName = rewindSave;
+                    }
+                }
+            }
+
+            // Close background recorder orbit segments and flush their data into tree
+            // recordings. Does NOT set terminal state.
+            if (backgroundRecorder != null)
+                backgroundRecorder.FinalizeAllForCommit(commitUT);
+
+            // Abort any pending split (undock / EVA / joint break continuation window).
+            // The continuation state cannot survive a scene reload cleanly — if the
+            // split was real, the debris vessel exists in the saved scene and will be
+            // rediscovered via normal OnVesselCreate events on resume.
+            if (pendingSplitRecorder != null)
+            {
+                ParsekLog.Info("Flight",
+                    $"StashActiveTreeAsPendingLimbo: discarding pendingSplitRecorder " +
+                    $"(recId={pendingSplitRecorder.CaptureAtStop?.RecordingId ?? "<null>"}) — " +
+                    "continuation window cannot survive scene reload");
+                pendingSplitRecorder = null;
+                pendingSplitInProgress = false;
+            }
+
+            // Stash as pending-Limbo. NO FinalizeTreeRecordings — terminal state deferred
+            // to OnLoad's dispatch once it knows whether this is a revert or a quickload.
+            RecordingStore.StashPendingTree(activeTree, PendingTreeState.Limbo);
+
+            ParsekLog.Info("Flight",
+                $"StashActiveTreeAsPendingLimbo: stashed tree '{activeTree.TreeName}' as Limbo " +
+                $"({activeTree.Recordings.Count} recording(s)) — OnLoad will dispatch");
         }
 
         /// <summary>

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -542,9 +542,15 @@ namespace Parsek
                     ConfigNode[] savedTreeNodes = node.GetNodes("RECORDING_TREE");
                     if (savedTreeNodes.Length > 0)
                     {
-                        // Rebuild tree mutable state from saved tree nodes
+                        // Rebuild tree mutable state from saved tree nodes.
+                        // Skip active-tree (in-flight) marker nodes: their recordings live
+                        // in pending-Limbo and are not in `recordings` (the committed list).
+                        // Matching against `recordings` would harmlessly fail today, but
+                        // the defensive skip avoids future refactors conflating the two.
                         foreach (var savedTreeNode in savedTreeNodes)
                         {
+                            if (IsActiveTreeNode(savedTreeNode)) continue;
+
                             ConfigNode[] savedTreeRecNodes = savedTreeNode.GetNodes("RECORDING");
                             foreach (var savedTreeRecNode in savedTreeRecNodes)
                             {
@@ -721,6 +727,25 @@ namespace Parsek
                 RecordingStore.ValidateChains();
 
                 LoadRecordingTrees(node, recordings);
+
+                // Cold-start active-tree restore (quickload-resume cold path).
+                // When the player quits KSP mid-flight and later relaunches + "Resume Saved
+                // Game", OnLoad runs with initialLoadDone=false and falls through to this
+                // block. TryRestoreActiveTreeNode here picks up any isActive=True tree
+                // from the save and stashes it into pending-Limbo so OnFlightReady's
+                // restore coroutine can resume recording — same path used by in-session
+                // quickload. Without this, cold-start resume silently drops the active
+                // tree and the player's in-progress mission fragments just like the
+                // original Bug C scenario.
+                if (TryRestoreActiveTreeNode(node))
+                {
+                    // Flag the coroutine to run on OnFlightReady so the active vessel is
+                    // available for name matching. Cold start always lands in flight for
+                    // a "Resume" action, so OnFlightReady will fire.
+                    ScheduleActiveTreeRestoreOnFlightReady = true;
+                    ParsekLog.Info("Scenario",
+                        "OnLoad: cold-start active tree detected — deferred to OnFlightReady for resume");
+                }
 
                 // Clean orphaned sidecar files (recordings deleted in previous sessions)
                 RecordingStore.CleanOrphanFiles();

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -219,12 +219,15 @@ namespace Parsek
             activeTree.Save(treeNode);
             treeNode.AddValue("isActive", "True");
 
-            // Persist recorder state needed to resume after quickload
+            // Persist recorder state needed to resume after quickload.
+            // NOTE: BoundaryAnchor is a TrajectoryPoint struct with lat/lon/alt/rotation/
+            // velocity, and serializing just the UT is insufficient to reconstruct it on
+            // restore — RestoreActiveTreeFromPending explicitly leaves BoundaryAnchor
+            // unset. Either serialize the full TrajectoryPoint or don't write anything;
+            // we chose the latter because a missing anchor just produces one extra
+            // boundary point on the next chain continuation, which is benign.
             if (!string.IsNullOrEmpty(recorder.RewindSaveFileName))
                 treeNode.AddValue("resumeRewindSave", recorder.RewindSaveFileName);
-            if (recorder.BoundaryAnchor.HasValue)
-                treeNode.AddValue("resumeBoundaryAnchorUT",
-                    recorder.BoundaryAnchor.Value.ut.ToString("R", CultureInfo.InvariantCulture));
 
             ParsekLog.Info("Scenario",
                 $"OnSave: wrote ACTIVE tree '{activeTree.TreeName}' ({activeRecCount} recording(s), " +
@@ -614,23 +617,38 @@ namespace Parsek
 
                     // Dispatch pending-Limbo trees (Bug C fix: quickload-resume).
                     // The tree was stashed without finalization in StashActiveTreeAsPendingLimbo.
-                    // Based on revert detection we now either finalize it (real revert)
-                    // or schedule a restore-and-resume coroutine (quickload / vessel switch).
+                    // Based on revert detection + vessel-switch flag, we now either
+                    // finalize it (real revert OR vessel switch) or schedule a
+                    // restore-and-resume coroutine (quickload).
                     if (RecordingStore.HasPendingTree
                         && RecordingStore.PendingTreeStateValue == PendingTreeState.Limbo)
                     {
-                        if (isRevert)
+                        if (isRevert || isVesselSwitch)
                         {
                             // Real revert: finalize the Limbo tree with a minimal static
-                            // finalization (vessel refs are gone, so terminal states fall
-                            // back to Destroyed with PopulateTerminalOrbitFromLastSegment).
-                            // Then flip state to Finalized so the existing auto-commit /
-                            // merge-dialog path handles it as before.
+                            // finalization (vessel refs are gone by this point, so terminal
+                            // states fall back to Destroyed + PopulateTerminalOrbitFromLastSegment).
+                            //
+                            // Vessel switch: the player moved focus to a different vessel.
+                            // The name-match in RestoreActiveTreeFromPending would fail
+                            // (the new active vessel is by definition not the tree's
+                            // recorded vessel), and the tree would be orphaned in Limbo.
+                            // Match mainline CommitTreeRevert behavior: finalize on vessel
+                            // switch. A future improvement could preserve the tree by
+                            // moving it to BackgroundMap + keeping it in committedTrees,
+                            // but that requires more vessel-switch-specific plumbing —
+                            // tracked as a follow-up in the design doc's "Risks" section.
                             FinalizePendingLimboTreeForRevert();
+                            if (isVesselSwitch && !isRevert)
+                            {
+                                ParsekLog.Info("Scenario",
+                                    "OnLoad: Limbo tree finalized on vessel switch " +
+                                    "(matches mainline behavior; tree-preservation-on-switch is a follow-up)");
+                            }
                         }
                         else
                         {
-                            // Quickload / vessel switch: defer restore to OnFlightReady.
+                            // Quickload or cold-start resume: defer restore to OnFlightReady.
                             // ParsekFlight.RestoreActiveTreeFromPending picks up the
                             // pending-Limbo tree and wires a fresh recorder to it.
                             ScheduleActiveTreeRestoreOnFlightReady = true;
@@ -1340,24 +1358,30 @@ namespace Parsek
                 foreach (var rec in tree.Recordings.Values)
                     RecordingStore.LoadRecordingFiles(rec);
 
+                // If the same tree id is already in committedTrees (e.g. the player
+                // quicksaved in flight, then exited to TS which committed the tree, then
+                // quickloaded — the in-memory committedTrees retains the T3 version even
+                // though the save file has the T2 active version), remove the committed
+                // copy so the active version is the single source of truth. Otherwise
+                // the next OnSave would write the tree twice with the same id.
+                RemoveCommittedTreeById(tree.Id);
+
+                // Pop any existing pending tree silently — StashActiveTreeAsPendingLimbo
+                // stashed the in-memory (future-timeline) version at OnSceneChangeRequested
+                // time; we want the freshly-loaded disk version (matches the quicksave UT
+                // the user is rewinding to). PopPendingTree is non-destructive (doesn't
+                // delete sidecar files), and avoids the "overwriting existing pending tree"
+                // warning on the expected-overwrite quickload path.
+                RecordingStore.PopPendingTree();
+
                 // Stash into pending-limbo — OnLoad's revert-detection dispatch decides
                 // the final disposition (restore-and-resume OR finalize-and-commit).
                 RecordingStore.StashPendingTree(tree, PendingTreeState.Limbo);
 
-                // Read resume hints back into pendingActiveTreeResumeHints for the
-                // restore coroutine
+                // Read resume hints for the restore coroutine (rewind save filename only;
+                // BoundaryAnchor can't round-trip because we only have the UT, not the
+                // full TrajectoryPoint state — restore leaves it unset).
                 pendingActiveTreeResumeRewindSave = treeNodes[t].GetValue("resumeRewindSave");
-                string anchorUTStr = treeNodes[t].GetValue("resumeBoundaryAnchorUT");
-                if (!string.IsNullOrEmpty(anchorUTStr)
-                    && double.TryParse(anchorUTStr, NumberStyles.Float, CultureInfo.InvariantCulture,
-                        out double anchorUT))
-                {
-                    pendingActiveTreeResumeBoundaryAnchorUT = anchorUT;
-                }
-                else
-                {
-                    pendingActiveTreeResumeBoundaryAnchorUT = double.NaN;
-                }
 
                 ParsekLog.Info("Scenario",
                     $"TryRestoreActiveTreeNode: stashed active tree '{tree.TreeName}' " +
@@ -1368,10 +1392,38 @@ namespace Parsek
             return false;
         }
 
+        /// <summary>
+        /// Removes a committed tree from <see cref="RecordingStore.CommittedTrees"/>
+        /// (and its recordings from the flat committed list) if a tree with the given id
+        /// exists. Used by the active-tree restore path to prevent duplicate-id collisions
+        /// when a prior TS/SPC commit left the tree in committedTrees at the same time
+        /// the disk save had it flagged active.
+        /// </summary>
+        private static void RemoveCommittedTreeById(string treeId)
+        {
+            if (string.IsNullOrEmpty(treeId)) return;
+
+            var committed = RecordingStore.CommittedTrees;
+            for (int i = committed.Count - 1; i >= 0; i--)
+            {
+                if (committed[i].Id != treeId) continue;
+
+                var stale = committed[i];
+                // Remove the tree's recordings from the flat CommittedRecordings list
+                var flatList = RecordingStore.CommittedRecordings;
+                foreach (var rec in stale.Recordings.Values)
+                    flatList.Remove(rec);
+
+                committed.RemoveAt(i);
+                ParsekLog.Info("Scenario",
+                    $"RemoveCommittedTreeById: removed stale committed copy of tree '{stale.TreeName}' " +
+                    $"(id={treeId}, {stale.Recordings.Count} recording(s)) — active-tree restore takes precedence");
+            }
+        }
+
         // Resume hints parsed from PARSEK_ACTIVE_TREE node, consumed by ParsekFlight
         // when it constructs the new recorder during the restore coroutine.
         internal static string pendingActiveTreeResumeRewindSave;
-        internal static double pendingActiveTreeResumeBoundaryAnchorUT = double.NaN;
 
         /// <summary>
         /// Signal to <see cref="ParsekFlight.OnFlightReady"/> that a pending-Limbo tree

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -127,7 +127,11 @@ namespace Parsek
 
         /// <summary>
         /// Saves committed recording trees to RECORDING_TREE ConfigNodes and writes
-        /// bulk data to external files for recordings whose data changed.
+        /// bulk data to external files for recordings whose data changed. Also writes
+        /// the currently-active (in-flight) tree as a RECORDING_TREE with isActive=True
+        /// when the save is taken during flight with an active recorder, so quickload
+        /// can resume recording instead of finalizing the mission (see
+        /// <c>docs/dev/plans/quickload-resume-recording.md</c>).
         /// </summary>
         private static void SaveTreeRecordings(ConfigNode node)
         {
@@ -162,6 +166,69 @@ namespace Parsek
                     $"Saved {committedTrees.Count} trees ({treeRecCount} recordings): {treeTotalPoints} points, " +
                     $"{treeTotalOrbitSegments} orbit segments, {treeTotalPartEvents} part events, " +
                     $"{treeWithTrackSections} with track sections, {treeWithSnapshots} with snapshots");
+
+            SaveActiveTreeIfAny(node);
+        }
+
+        /// <summary>
+        /// Writes the currently-active (in-flight) recording tree as an extra RECORDING_TREE
+        /// ConfigNode marked with <c>isActive=True</c>, plus any recorder state needed to
+        /// resume on quickload (chain id, boundary anchor UT, rewind save filename).
+        /// <para>
+        /// Guarded: only writes when <c>LoadedScene == FLIGHT</c>, <c>ParsekFlight.Instance</c>
+        /// has a live active tree, and a recorder exists. Any other scene (KSC, TS, Main Menu)
+        /// has no in-flight recording to preserve and would emit a stale stub.
+        /// </para>
+        /// </summary>
+        private static void SaveActiveTreeIfAny(ConfigNode node)
+        {
+            if (HighLogic.LoadedScene != GameScenes.FLIGHT) return;
+
+            var flight = ParsekFlight.Instance;
+            if (flight == null) return;
+
+            var activeTree = flight.ActiveTreeForSerialization;
+            if (activeTree == null) return;
+
+            var recorder = flight.ActiveRecorderForSerialization;
+            if (recorder == null) return;
+
+            // Flush recorder's buffered data into the active tree's current recording
+            // before serializing. Otherwise the on-disk tree misses points/events that
+            // were captured since the last chain boundary.
+            try
+            {
+                flight.FlushRecorderIntoActiveTreeForSerialization();
+            }
+            catch (System.Exception ex)
+            {
+                ParsekLog.Warn("Scenario",
+                    $"SaveActiveTreeIfAny: flush failed ({ex.Message}) — active tree will be written with stale recorder data");
+            }
+
+            // Persist bulk data for active-tree recordings (same pattern as committed trees)
+            int activeRecCount = 0;
+            foreach (var rec in activeTree.Recordings.Values)
+            {
+                if (rec.FilesDirty && !RecordingStore.SaveRecordingFiles(rec))
+                    ScenarioLog($"[Parsek Scenario] WARNING: File write failed for active tree recording '{rec.VesselName}'");
+                activeRecCount++;
+            }
+
+            ConfigNode treeNode = node.AddNode("RECORDING_TREE");
+            activeTree.Save(treeNode);
+            treeNode.AddValue("isActive", "True");
+
+            // Persist recorder state needed to resume after quickload
+            if (!string.IsNullOrEmpty(recorder.RewindSaveFileName))
+                treeNode.AddValue("resumeRewindSave", recorder.RewindSaveFileName);
+            if (recorder.BoundaryAnchor.HasValue)
+                treeNode.AddValue("resumeBoundaryAnchorUT",
+                    recorder.BoundaryAnchor.Value.ut.ToString("R", CultureInfo.InvariantCulture));
+
+            ParsekLog.Info("Scenario",
+                $"OnSave: wrote ACTIVE tree '{activeTree.TreeName}' ({activeRecCount} recording(s), " +
+                $"activeRecId={activeTree.ActiveRecordingId ?? "<null>"}) for quickload resume");
         }
 
         /// <summary>
@@ -304,6 +371,15 @@ namespace Parsek
                         return;
                     }
 
+                    // Restore an in-flight tree from the save file (if OnSave wrote one).
+                    // This stashes it into the pending-Limbo slot so the revert-detection
+                    // dispatch below can decide between "restore and resume" (quickload)
+                    // and "finalize and commit" (real revert).
+                    // Runs AFTER ParsekSettingsPersistence.ApplyTo so restored settings
+                    // affect the rest of OnLoad, but BEFORE revert detection so the
+                    // pending slot is populated when it runs.
+                    TryRestoreActiveTreeNode(node);
+
                     // Detect revert vs scene change. On a revert, the quicksave is older:
                     // its epoch is lower (after a prior revert bumped it) or it has fewer
                     // recordings (new ones were committed since launch). On a scene change,
@@ -316,14 +392,21 @@ namespace Parsek
 
                     // Count tree recordings from saved tree nodes for accurate revert detection.
                     // Tree recordings are in committedRecordings but NOT in standalone RECORDING nodes.
+                    // Skip active-tree (in-flight) marker nodes — they're not "committed" recordings.
                     ConfigNode[] savedTreeNodesForRevert = node.GetNodes("RECORDING_TREE");
                     int savedTreeRecCount = 0;
                     for (int t = 0; t < savedTreeNodesForRevert.Length; t++)
+                    {
+                        if (IsActiveTreeNode(savedTreeNodesForRevert[t])) continue;
                         savedTreeRecCount += savedTreeNodesForRevert[t].GetNodes("RECORDING").Length;
+                    }
                     int totalSavedRecCount = savedRecNodes.Length + savedTreeRecCount;
 
-                    // FLIGHT→FLIGHT is usually a revert (Revert to Launch or quickload),
-                    // but vessel switching also triggers FLIGHT→FLIGHT scene reloads.
+                    // FLIGHT→FLIGHT can be a revert, a quickload, or a vessel switch.
+                    // We distinguish by epoch/count comparison — the FLIGHT→FLIGHT boolean
+                    // alone is no longer a revert indicator. Quickloads preserve both epoch
+                    // and count (since the quicksave captured the current state), while
+                    // reverts regress at least one of them.
                     bool isFlightToFlight = lastOnSaveScene == GameScenes.FLIGHT
                                             && HighLogic.LoadedScene == GameScenes.FLIGHT;
                     bool isVesselSwitch = isFlightToFlight && vesselSwitchPending;
@@ -331,13 +414,18 @@ namespace Parsek
 
                     bool isRevert = !isVesselSwitch
                                     && (savedEpoch < MilestoneStore.CurrentEpoch
-                                        || totalSavedRecCount < recordings.Count
-                                        || isFlightToFlight);
+                                        || totalSavedRecCount < recordings.Count);
                     ParsekLog.Verbose("Scenario",
                         $"OnLoad: revert detection — savedEpoch={savedEpoch}, currentEpoch={MilestoneStore.CurrentEpoch}, " +
                         $"savedRecNodes={savedRecNodes.Length}, savedTreeRecs={savedTreeRecCount}, " +
                         $"memoryRecordings={recordings.Count}, lastOnSaveScene={lastOnSaveScene}, " +
-                        $"isFlightToFlight={isFlightToFlight}, isVesselSwitch={isVesselSwitch}, isRevert={isRevert}");
+                        $"isFlightToFlight={isFlightToFlight}, isVesselSwitch={isVesselSwitch}, isRevert={isRevert}, " +
+                        $"pendingTreeState={RecordingStore.PendingTreeStateValue}");
+                    if (isFlightToFlight && !isRevert && !isVesselSwitch)
+                    {
+                        ParsekLog.Info("Scenario",
+                            "OnLoad: FLIGHT→FLIGHT without revert indicators — treating as quickload / scene reload, not revert");
+                    }
 
                     // Collect spawned vessel PIDs + names BEFORE restore resets them.
                     // Only on revert — on normal scene changes the spawned vessels are
@@ -516,6 +604,34 @@ namespace Parsek
                         // Scene change — restore milestone state without resetting unmatched.
                         MilestoneStore.RestoreMutableState(node);
                         ParsekLog.Verbose("Scenario", "Scene change — milestone state restored (resetUnmatched=false)");
+                    }
+
+                    // Dispatch pending-Limbo trees (Bug C fix: quickload-resume).
+                    // The tree was stashed without finalization in StashActiveTreeAsPendingLimbo.
+                    // Based on revert detection we now either finalize it (real revert)
+                    // or schedule a restore-and-resume coroutine (quickload / vessel switch).
+                    if (RecordingStore.HasPendingTree
+                        && RecordingStore.PendingTreeStateValue == PendingTreeState.Limbo)
+                    {
+                        if (isRevert)
+                        {
+                            // Real revert: finalize the Limbo tree with a minimal static
+                            // finalization (vessel refs are gone, so terminal states fall
+                            // back to Destroyed with PopulateTerminalOrbitFromLastSegment).
+                            // Then flip state to Finalized so the existing auto-commit /
+                            // merge-dialog path handles it as before.
+                            FinalizePendingLimboTreeForRevert();
+                        }
+                        else
+                        {
+                            // Quickload / vessel switch: defer restore to OnFlightReady.
+                            // ParsekFlight.RestoreActiveTreeFromPending picks up the
+                            // pending-Limbo tree and wires a fresh recorder to it.
+                            ScheduleActiveTreeRestoreOnFlightReady = true;
+                            ParsekLog.Info("Scenario",
+                                $"OnLoad: pending-Limbo tree '{RecordingStore.PendingTree?.TreeName}' " +
+                                "deferred to OnFlightReady for quickload-resume");
+                        }
                     }
 
                     // Handle pending recordings on non-revert scene exits to non-flight scenes.
@@ -1107,9 +1223,21 @@ namespace Parsek
                 int treeTotalPartEvents = 0;
                 int treeWithTrackSections = 0;
                 int treeWithSnapshots = 0;
+                int activeTreeCount = 0;
                 for (int t = 0; t < treeNodes.Length; t++)
                 {
-                    var tree = RecordingTree.Load(treeNodes[t]);
+                    var treeNode = treeNodes[t];
+
+                    // Active-tree marker: these go into the pending-limbo slot, NOT into
+                    // committedTrees. TryRestoreActiveTreeNode earlier in OnLoad may have
+                    // already consumed this node, so skip it here either way.
+                    if (IsActiveTreeNode(treeNode))
+                    {
+                        activeTreeCount++;
+                        continue;
+                    }
+
+                    var tree = RecordingTree.Load(treeNode);
 
                     // Load bulk data from external files for each recording in the tree
                     foreach (var rec in tree.Recordings.Values)
@@ -1135,10 +1263,131 @@ namespace Parsek
                         $"{tree.Recordings.Count} recordings, {tree.BranchPoints.Count} branch points");
                 }
                 ParsekLog.Verbose("Scenario",
-                    $"Loaded {treeNodes.Length} trees ({treeRecCount} recordings): {treeTotalPoints} points, " +
+                    $"Loaded {treeNodes.Length} tree nodes ({treeRecCount} committed recordings + " +
+                    $"{activeTreeCount} active-tree marker(s)): {treeTotalPoints} points, " +
                     $"{treeTotalOrbitSegments} orbit segments, {treeTotalPartEvents} part events, " +
                     $"{treeWithTrackSections} with track sections, {treeWithSnapshots} with snapshots");
             }
+        }
+
+        /// <summary>
+        /// Returns true if a RECORDING_TREE ConfigNode represents an active (in-flight)
+        /// tree written by <c>SaveActiveTreeIfAny</c>, distinguished by the
+        /// <c>isActive=True</c> key.
+        /// </summary>
+        internal static bool IsActiveTreeNode(ConfigNode treeNode)
+        {
+            if (treeNode == null) return false;
+            string val = treeNode.GetValue("isActive");
+            return !string.IsNullOrEmpty(val)
+                && bool.TryParse(val, out bool isActive) && isActive;
+        }
+
+        /// <summary>
+        /// Attempts to restore an active (in-flight) recording tree from the save node
+        /// into the pending-limbo slot. Called from OnLoad immediately after settings
+        /// persistence and before revert detection, so the revert-detection logic can
+        /// decide whether to restore-and-resume (quickload) or finalize-and-commit
+        /// (real revert).
+        ///
+        /// <para>Skipped when rewinding — <see cref="RewindContext.IsRewinding"/> means
+        /// the load is Parsek's own rewind flow which explicitly resets playback state.</para>
+        ///
+        /// Returns true if an active tree was found and stashed as Limbo.
+        /// </summary>
+        internal static bool TryRestoreActiveTreeNode(ConfigNode node)
+        {
+            if (node == null) return false;
+            if (RewindContext.IsRewinding)
+            {
+                ParsekLog.Verbose("Scenario",
+                    "TryRestoreActiveTreeNode: skipped (rewind in progress — active tree deliberately discarded)");
+                return false;
+            }
+
+            ConfigNode[] treeNodes = node.GetNodes("RECORDING_TREE");
+            for (int t = 0; t < treeNodes.Length; t++)
+            {
+                if (!IsActiveTreeNode(treeNodes[t])) continue;
+
+                var tree = RecordingTree.Load(treeNodes[t]);
+                // Hydrate bulk data from sidecar files for each recording
+                foreach (var rec in tree.Recordings.Values)
+                    RecordingStore.LoadRecordingFiles(rec);
+
+                // Stash into pending-limbo — OnLoad's revert-detection dispatch decides
+                // the final disposition (restore-and-resume OR finalize-and-commit).
+                RecordingStore.StashPendingTree(tree, PendingTreeState.Limbo);
+
+                // Read resume hints back into pendingActiveTreeResumeHints for the
+                // restore coroutine
+                pendingActiveTreeResumeRewindSave = treeNodes[t].GetValue("resumeRewindSave");
+                string anchorUTStr = treeNodes[t].GetValue("resumeBoundaryAnchorUT");
+                if (!string.IsNullOrEmpty(anchorUTStr)
+                    && double.TryParse(anchorUTStr, NumberStyles.Float, CultureInfo.InvariantCulture,
+                        out double anchorUT))
+                {
+                    pendingActiveTreeResumeBoundaryAnchorUT = anchorUT;
+                }
+                else
+                {
+                    pendingActiveTreeResumeBoundaryAnchorUT = double.NaN;
+                }
+
+                ParsekLog.Info("Scenario",
+                    $"TryRestoreActiveTreeNode: stashed active tree '{tree.TreeName}' " +
+                    $"({tree.Recordings.Count} recording(s), activeRecId={tree.ActiveRecordingId ?? "<null>"}) " +
+                    $"into pending-Limbo slot for revert-detection dispatch");
+                return true;
+            }
+            return false;
+        }
+
+        // Resume hints parsed from PARSEK_ACTIVE_TREE node, consumed by ParsekFlight
+        // when it constructs the new recorder during the restore coroutine.
+        internal static string pendingActiveTreeResumeRewindSave;
+        internal static double pendingActiveTreeResumeBoundaryAnchorUT = double.NaN;
+
+        /// <summary>
+        /// Signal to <see cref="ParsekFlight.OnFlightReady"/> that a pending-Limbo tree
+        /// is waiting for the restore-and-resume path. Set by OnLoad when it detects
+        /// quickload / vessel-switch (not revert) with a Limbo-state tree.
+        /// </summary>
+        internal static bool ScheduleActiveTreeRestoreOnFlightReady;
+
+        /// <summary>
+        /// Minimal static finalization for a Limbo tree on the revert path. Sets
+        /// terminal state to Destroyed on leaf recordings without existing terminal
+        /// state, and calls PopulateTerminalOrbitFromLastSegment as a fallback orbit
+        /// source (vessel refs are gone by OnLoad time on a revert, so live capture
+        /// is impossible — this matches the pre-fix CommitTreeRevert behavior for
+        /// orbital debris).
+        ///
+        /// After finalization, flips the pending tree state from Limbo to Finalized
+        /// so the existing auto-commit / merge-dialog path handles it normally.
+        /// </summary>
+        private static void FinalizePendingLimboTreeForRevert()
+        {
+            var tree = RecordingStore.PendingTree;
+            if (tree == null) return;
+
+            int finalized = 0;
+            foreach (var kvp in tree.Recordings)
+            {
+                var rec = kvp.Value;
+                bool isLeaf = rec.ChildBranchPointId == null;
+                if (!isLeaf) continue;
+                if (rec.TerminalStateValue.HasValue) continue;
+
+                rec.TerminalStateValue = TerminalState.Destroyed;
+                ParsekFlight.PopulateTerminalOrbitFromLastSegment(rec);
+                finalized++;
+            }
+
+            RecordingStore.MarkPendingTreeFinalized();
+            ParsekLog.Info("Scenario",
+                $"FinalizePendingLimboTreeForRevert: finalized {finalized} leaf recording(s) in " +
+                $"tree '{tree.TreeName}' — transitioned Limbo → Finalized");
         }
 
         #region Deferred Merge Dialog

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -8,6 +8,31 @@ using UnityEngine;
 namespace Parsek
 {
     /// <summary>
+    /// State of the pending tree slot in <see cref="RecordingStore"/>.
+    /// Determines how <see cref="ParsekScenario.OnLoad"/> dispatches the pending tree
+    /// after revert detection runs.
+    /// </summary>
+    public enum PendingTreeState
+    {
+        /// <summary>
+        /// Tree has been through <c>FinalizeTreeRecordings</c>: terminal state set,
+        /// terminal orbit / position captured, snapshots preserved for the merge dialog.
+        /// Legacy behavior — this is what <see cref="RecordingStore.StashPendingTree"/>
+        /// produced before the quickload-resume redesign.
+        /// </summary>
+        Finalized = 0,
+
+        /// <summary>
+        /// Tree is still "in-flight": recorder field references were torn down because
+        /// the scene is unloading, but no terminal state was set. OnLoad decides based
+        /// on revert detection whether to finalize-then-commit (true revert) or
+        /// restore-and-resume (quickload / vessel switch).
+        /// See <c>docs/dev/plans/quickload-resume-recording.md</c>.
+        /// </summary>
+        Limbo = 1,
+    }
+
+    /// <summary>
     /// Static holder for recording data that survives scene changes.
     /// Static fields persist across scene loads within a KSP session.
     /// Save/load persistence is handled separately by ParsekScenario.
@@ -98,6 +123,11 @@ namespace Parsek
 
         // Pending tree awaiting merge dialog (Task 8) or auto-commit
         private static RecordingTree pendingTree;
+        // State of the pending tree slot. Finalized = legacy behavior (tree has terminal
+        // state, snapshots, ready to commit). Limbo = new quickload-resume path: tree is
+        // still "in-flight", untriaged, waiting for OnLoad to decide revert-vs-quickload.
+        // See docs/dev/plans/quickload-resume-recording.md.
+        private static PendingTreeState pendingTreeState = PendingTreeState.Finalized;
 
         public static bool HasPending => pendingRecording != null;
         public static Recording Pending => pendingRecording;
@@ -105,6 +135,7 @@ namespace Parsek
         public static List<RecordingTree> CommittedTrees => committedTrees;
         public static bool HasPendingTree => pendingTree != null;
         public static RecordingTree PendingTree => pendingTree;
+        public static PendingTreeState PendingTreeStateValue => pendingTreeState;
 
         public static void StashPending(List<TrajectoryPoint> points, string vesselName,
             List<OrbitSegment> orbitSegments = null,
@@ -272,6 +303,7 @@ namespace Parsek
                 DeleteRecordingFiles(pendingRecording);
             pendingRecording = null;
             pendingTree = null;
+            pendingTreeState = PendingTreeState.Finalized;
             ClearCommitted();
             Log("[Parsek] All recordings cleared");
         }
@@ -488,15 +520,34 @@ namespace Parsek
         }
 
         /// <summary>
-        /// Stashes a finalized tree as pending (for merge dialog on revert).
+        /// Stashes a tree as pending with <see cref="PendingTreeState.Finalized"/>.
+        /// Legacy behavior — the tree has already been through
+        /// <c>FinalizeTreeRecordings</c> and is ready for the merge dialog or auto-commit.
         /// </summary>
         public static void StashPendingTree(RecordingTree tree)
+            => StashPendingTree(tree, PendingTreeState.Finalized);
+
+        /// <summary>
+        /// Stashes a tree as pending with an explicit state.
+        /// <see cref="PendingTreeState.Finalized"/> is the legacy path (terminal state set,
+        /// snapshots preserved). <see cref="PendingTreeState.Limbo"/> is the quickload-resume
+        /// path — tree is still in-flight, recorder was torn down without finalization, and
+        /// OnLoad will decide whether to restore-and-resume or finalize-then-commit.
+        /// </summary>
+        public static void StashPendingTree(RecordingTree tree, PendingTreeState state)
         {
+            if (pendingTree != null)
+            {
+                ParsekLog.Warn("RecordingStore",
+                    $"StashPendingTree({state}): overwriting existing pending tree " +
+                    $"'{pendingTree.TreeName}' (state={pendingTreeState}) with '{tree?.TreeName ?? "<null>"}'");
+            }
             pendingTree = tree;
+            pendingTreeState = state;
             if (tree != null)
             {
                 PendingStashedThisTransition = true;
-                Log($"[Parsek] Stashed pending tree '{tree.TreeName}' ({tree.Recordings.Count} recordings)");
+                Log($"[Parsek] Stashed pending tree '{tree.TreeName}' ({tree.Recordings.Count} recordings, state={state})");
             }
         }
 
@@ -513,6 +564,7 @@ namespace Parsek
 
             CommitTree(pendingTree);
             pendingTree = null;
+            pendingTreeState = PendingTreeState.Finalized;
         }
 
         /// <summary>
@@ -529,8 +581,43 @@ namespace Parsek
             foreach (var rec in pendingTree.Recordings.Values)
                 DeleteRecordingFiles(rec);
             GameStateRecorder.PendingScienceSubjects.Clear();
-            Log($"[Parsek] Discarded pending tree '{pendingTree.TreeName}'");
+            Log($"[Parsek] Discarded pending tree '{pendingTree.TreeName}' (state={pendingTreeState})");
             pendingTree = null;
+            pendingTreeState = PendingTreeState.Finalized;
+        }
+
+        /// <summary>
+        /// Marks the pending tree's state as Finalized after the revert-detection dispatch
+        /// has run FinalizeTreeRecordings on a previously-Limbo tree. Called by
+        /// ParsekScenario.OnLoad on the Limbo + isRevert path before the auto-commit /
+        /// merge dialog flow runs.
+        /// </summary>
+        internal static void MarkPendingTreeFinalized()
+        {
+            if (pendingTree == null) return;
+            if (pendingTreeState == PendingTreeState.Finalized) return;
+            pendingTreeState = PendingTreeState.Finalized;
+            ParsekLog.Info("RecordingStore",
+                $"Pending tree '{pendingTree.TreeName}' transitioned Limbo → Finalized");
+        }
+
+        /// <summary>
+        /// Removes the pending tree from the slot WITHOUT deleting its sidecar files or
+        /// clearing pending science subjects. Returns the tree so the caller can take
+        /// ownership (typically to re-install as the active tree during quickload-resume).
+        /// Unlike <see cref="DiscardPendingTree"/>, this is non-destructive — the caller
+        /// is responsible for the tree's lifetime after popping.
+        /// </summary>
+        internal static RecordingTree PopPendingTree()
+        {
+            var tree = pendingTree;
+            pendingTree = null;
+            pendingTreeState = PendingTreeState.Finalized;
+            if (tree != null)
+            {
+                Log($"[Parsek] Popped pending tree '{tree.TreeName}' (caller takes ownership, files preserved)");
+            }
+            return tree;
         }
 
         /// <summary>
@@ -1369,6 +1456,7 @@ namespace Parsek
             committedRecordings.Clear();
             committedTrees.Clear();
             pendingTree = null;
+            pendingTreeState = PendingTreeState.Finalized;
             SceneEntryActiveVesselPid = 0;
             RewindContext.ResetForTesting();
             RewindUTAdjustmentPending = false;

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -705,6 +705,48 @@ xUnit can't exercise any code path that touches `UnityEngine.AudioSource` (direc
 
 **Priority:** Low — the code paths are simple enough that review caught the issues in commit 77bce7c, and the production playtest will exercise them end-to-end. In-game tests harden against future regressions.
 
+## 266. Tree-preservation on vessel switch (quickload-resume follow-up)
+
+PR #160 routes `isVesselSwitch` through `FinalizePendingLimboTreeForRevert` to match mainline behavior, but the ideal outcome on a vessel switch (user clicks a distant vessel triggering FLIGHT→FLIGHT scene reload) is to keep the active tree alive with the old vessel backgrounded, so the mission doesn't fragment.
+
+**Fix plan:** On `Limbo + isVesselSwitch`, instead of finalizing the tree, move the old active recording's PID into `tree.BackgroundMap`, leave the tree in place (not stashed), install it back as `ParsekFlight.activeTree`, and start a fresh recorder only if the new active vessel has its own recording context. The next vessel switch back to the old vessel triggers `PromoteFromBackground` via the existing in-session switch path. Requires careful handling of the background recorder subscription lifecycle.
+
+**Priority:** Medium — better than finalizing but not a regression, so can wait
+
+## 267. Quickload-resume: restore coroutine reentrancy guard
+
+The `ScheduleActiveTreeRestoreOnFlightReady` flag and the `RestoreActiveTreeFromPending` coroutine (`ParsekFlight.cs`) don't have a re-entry guard. If `onVesselChange` or another reactive handler mutates `activeTree` or the pending tree during the coroutine's 3-second vessel wait, the restore could see inconsistent state. Documented in the design doc's Risks section.
+
+**Fix plan:** Add `static bool restoringActiveTree` guard on `ParsekFlight`. Set at coroutine start, clear on completion or failure. `onVesselChange` / `OnVesselSwitchComplete` handlers check the flag and skip tree mutations while the restore is running. Also consider using a one-shot check in `RestoreActiveTreeFromPending` that refuses to run if `activeTree != null` when it enters (meaning someone beat it to the slot).
+
+**Priority:** Low — no reported issue yet, but prevents a hard-to-diagnose race
+
+## 268. Quickload-resume: snapshot preservation through revert finalization
+
+The old `CommitTreeRevert` preserved vessel snapshots so the merge dialog could offer respawn. `FinalizePendingLimboTreeForRevert` (PR #160) does not — by OnLoad time the vessel refs are gone and we fall back to whatever snapshots were stashed before the scene reload, which may be stale or null. Affects autoMerge=off + revert + dialog-driven respawn.
+
+**Fix plan:** Capture a live snapshot of the active vessel inside `StashActiveTreeAsPendingLimbo` (which runs during `OnSceneChangeRequested`, while the vessel is still referenceable), and attach it to the tree's active recording so the merge dialog can use it if the Limbo tree takes the finalize path. Costs one snapshot copy per scene reload but preserves the existing UX.
+
+**Priority:** Low — regression only visible on autoMerge=off reverts, assess after playtest
+
+## 269. In-game test coverage for quickload-resume flow
+
+PR #160 ships with 29 unit tests covering static state transitions, dispatch decisions, and isolated predicates, but the full scenario — quicksave → scene reload → quickload → restore coroutine → resumed recording appends to same chain segment — can only run inside live KSP.
+
+**Fix plan:** Add an `InGameTests/RuntimeTests.cs` category `[InGameTest(Category = "QuickloadResume", Scene = GameScenes.FLIGHT)]` covering: (1) quickload mid-recording resumes with same `activeRecordingId` and points match pre-F5 UT; (2) real revert finalizes the tree (merge dialog if autoMerge off); (3) vessel switch finalizes the tree (temporary — update when #266 lands); (4) double-F9 idempotency; (5) quickload into a non-flight scene does not try to restore; (6) rewind path (via R button) does not conflict with restore; (7) cold-start "resume saved game" triggers restore via OnFlightReady.
+
+**Priority:** Medium — the Unity-dependent gaps in PR #160's unit tests should close before the next major refactor
+
+## 270. Sidecar file (.prec) version staleness across save points
+
+Latent pre-existing architectural limitation of the v3 external sidecar format: sidecar files (`saves/<save>/Parsek/Recordings/*.prec`) are shared across ALL save points for a given save slot. If the player quicksaves in flight at T2, exits to TS at T3 (which rewrites the sidecars with T3 data), then quickloads the T2 save, the .sfs loads the T2 active tree metadata but `LoadRecordingFiles` hydrates from T3 sidecars on disk — a mismatch.
+
+Not introduced by PR #160, but PR #160's quickload-resume path makes it more reachable (previously, quickloading between scene changes always finalized the tree, so the tree was effectively "new" each time).
+
+**Fix plan (long-term):** version sidecar files per save point — stamp each `.prec` with the save epoch or a hash, refuse to load mismatched versions. Alternatively, never rewrite sidecars for committed trees; treat them as immutable.
+
+**Priority:** Low — rare user workflow (quicksave in flight + exit to TS + quickload), and the worst case is playback inconsistency, not data loss. Flag again if it bites during playtest.
+
 ---
 
 # In-Game Tests


### PR DESCRIPTION
## Summary

Fixes the root cause of the quicksave+quickload breakage observed in the 2026-04-09 KerbalX playtest (Bug C), plus its two cascading effects:

- **Bug C** — quicksave + quickload during an active recording fragments the mission: tree commits prematurely, ~2 minutes of untracked flight until the user manually restarts recording, crew scattered across unlinked standalone recordings.
- **Bug H** — ghost orbits are partial arcs (vessel disappears mid-flight) because the committed tree only has trajectory up to the quicksave UT.
- **Bug I** — wrong crew spawns at mission end because the original crew was captured into orphan recordings.

Both H and I resolve automatically when C is fixed.

## Design

Full design doc added at `docs/dev/plans/quickload-resume-recording.md` — design was reviewed by a clean Opus agent before implementation, and the implementation was reviewed by another clean Opus agent after.

### Three compounding defects

- **C1** — `ParsekFlight.FinalizeTreeOnSceneChange` called `CommitTreeRevert` on every FLIGHT→FLIGHT reload (including quickloads), finalizing the active tree **before** OnLoad could distinguish revert from quickload.
- **C2** — `ParsekScenario.OnSave` only persisted committed recordings; the active tree was never serialized, so even if we refused to commit, the scene reload would still lose the data.
- **C3** — `ParsekScenario.OnLoad`'s `isRevert` condition conflated FLIGHT→FLIGHT with revert via `|| isFlightToFlight`, making quickloads look like reverts.

### Fix (atomic)

All three plus the new machinery land together (see design doc's "Why atomic" section — intermediate states are all broken).

- **New `PendingTreeState` enum** `{Finalized, Limbo}` on the existing `pendingTree` slot (reviewer pushed back on a separate `limboTree` slot — consolidated into a state flag instead).
- **`StashActiveTreeAsPendingLimbo`** replaces `CommitTreeRevert` on the FLIGHT→FLIGHT path. Flushes recorder buffers into the tree, aborts any `pendingSplitRecorder`, stashes as Limbo without finalizing terminal state.
- **`SaveActiveTreeIfAny`** writes the active tree as an additional `RECORDING_TREE` node flagged `isActive=True`, guarded on `FLIGHT && activeTree && recorder`.
- **`TryRestoreActiveTreeNode`** in OnLoad (after settings apply, before revert detection) parses the active-tree node back into pending-Limbo.
- **`isRevert` cleanup**: removed `|| isFlightToFlight` clause.
- **Dispatch**: Limbo + `isRevert` → `FinalizePendingLimboTreeForRevert` + auto-commit path; Limbo + `!isRevert` → schedule `RestoreActiveTreeFromPending` coroutine for OnFlightReady.
- **`RestoreActiveTreeFromPending`** coroutine: 3-second vessel name-match, EVA-boarded parent fallback (walks `ParentRecordingId` up to 5 levels), PID remap, `PopPendingTree` (non-destructive), `StartRecording(isPromotion: true)` — relies on the Bug A fix already in `fix/playtest-failures` for seed-event skip.
- **Cold-start path**: TryRestoreActiveTreeNode also runs in the `initialLoadDone=false` branch so a fresh KSP launch loading a save with an in-flight tree resumes correctly.

## Commits

- `df78255` Design doc (reviewed by clean Opus agent; review feedback merged into doc before implementation started)
- `d1705bd` Atomic Step 1: core plumbing (5 files, 662+ insertions)
- `82a0c58` Post-implementation review fixes: cold-start restore, EVA-boarded fallback, defensive active-tree skip

## Test plan

- [x] 26 new `QuickloadResumeTests` unit tests covering `PendingTreeState` transitions, `PopPendingTree`, `IsActiveTreeNode`, `TryRestoreActiveTreeNode` dispatch, resume-hint parsing, and `isRevert` logic after the clause removal
- [x] Full xUnit suite: 5233 pass (5207 baseline + 26 new)
- [x] Clean build (0 warnings)
- [ ] **In-game playtest** — the primary validation. Need to run through the 2026-04-09 KerbalX scenario end-to-end:
  - Launch KerbalX, quicksave during ascent, quickload → recording should resume appending to the same chain segment (same `recId`, points at last kept UT ≤ quicksave UT)
  - Revert to Launch during recording → tree finalized normally, merge dialog appears if autoMerge off
  - Vessel switch during recording → tree survives, old vessel's recording moved to BackgroundMap
  - Quickload mid-chain-continuation (undock window) → `pendingSplitRecorder` aborted cleanly
  - Quickload → quickload → verify idempotent
  - Quit KSP mid-flight, relaunch, Resume Saved Game → cold-start restore path
- [ ] In-game tests under `InGameTests/RuntimeTests.cs` — deferred to a follow-up commit once the above manual playtest validates the infrastructure

## Known deferred items

Flagged by the post-implementation review, deferred because they need design discussion rather than quick fixes:

1. **Snapshot preservation through revert finalization.** The old `CommitTreeRevert` preserved vessel snapshots so the merge dialog could offer spawning. `FinalizePendingLimboTreeForRevert` doesn't — by OnLoad time, vessel refs are gone, so we fall back to whatever snapshots were in the tree when OnSave wrote them. Potential regression for autoMerge=off + revert + dialog-driven respawn. Assessing after playtest.
2. **`restoring` reentrancy flag.** `onVesselChange` fires when the quickloaded scene finishes loading, potentially mutating tree state during the 3-second wait window in the restore coroutine. Needs a guard flag. Tracked as a follow-up.
3. **Multi-tree hard assertion.** `StashPendingTree(Limbo)` currently warns+overwrites when a prior pending tree exists; the design called for a harder fail. Acceptable per "fail loud" principle; can strengthen if it becomes a real problem.

## Stacked on

This PR is stacked on top of [#159](https://github.com/vl3c/Parsek/pull/159) (`fix/playtest-failures`), which contains the Group 1 fixes (A, D, F + the Bug A seed-event skip that this PR's resume path depends on). Target branch is set to `fix/playtest-failures`; after that merges, this will rebase onto `main` for the final merge.