### PR TITLE
Fix #287: Ghost engine flames stay off after booster staging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Dev notes: technical narratives for the fixes below live in `docs/dev/todo-and-k
 
 ### Bug Fixes — KerbalX + Butterfly Rover playtest (2026-04-09)
 
+- `#287` Ghost engine flames on multi-stage rockets (Kerbal X Mainsail + boosters) no longer turn off permanently after booster staging.
 - `#278` EVA kerbals walking at the moment of revert/vessel-switch are now correctly classified Landed instead of Destroyed, so the merge dialog can spawn them at end of recording.
 - `#277` Stand-in crew is now placed correctly when a launch crew member was on EVA at merge time. Previously the EVA'd kerbal's stand-in was hired but never seated, leaving the command pod with the wrong roster.
 - `#284` Background debris recording capped at primary debris only — fragments of crashing boosters no longer spawn their own recordings. Cuts the recording count from ~25 to ~4-6 entries per Kerbal X launch.

--- a/Source/Parsek.Tests/Bug287TerminalCleanupTests.cs
+++ b/Source/Parsek.Tests/Bug287TerminalCleanupTests.cs
@@ -1,0 +1,357 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Tests for bug #287 — spurious terminal EngineShutdown events surviving into committed
+    /// recordings and leaving ghost engine FX permanently off after booster staging.
+    ///
+    /// Root cause: <c>ResumeAfterFalseAlarm</c>'s index-based <c>RemoveRange</c> was brittle
+    /// against any code path that reordered or appended PartEvents between
+    /// <c>StopRecordingForChainBoundary</c> and the resume call — particularly the four
+    /// unstable <c>List&lt;T&gt;.Sort((a,b) =&gt; a.ut.CompareTo(b.ut))</c> call sites in
+    /// flush/merge paths. The fix switches to content-based removal: FinalizeRecordingState
+    /// now saves the exact terminal events it emitted, and ResumeAfterFalseAlarm removes
+    /// them by matching (ut, pid, eventType, moduleIndex).
+    ///
+    /// Manifests in the 2026-04-09 Kerbal X playtest
+    /// (<c>logs/2026-04-09_1117_kerbalx-rover</c>): committed recording
+    /// <c>db2e7ab62c6847e0b439237a41172602.prec</c> had terminal EngineShutdown events at
+    /// UT 72.40, 87.94, and 104.86 for pids that <em>should</em> have been removed by
+    /// ResumeAfterFalseAlarm per the log (<c>removed 5 / 3 / 3 orphaned terminal event(s)</c>)
+    /// but survived into the saved .prec file. During playback, pid=2527095907's engine
+    /// flame went off at UT 87.94 and never came back because no subsequent EngineIgnited
+    /// event followed.
+    /// </summary>
+    [Collection("Sequential")]
+    public class Bug287TerminalCleanupTests
+    {
+        [Fact]
+        public void FindTerminalEventIndex_EmptyList_ReturnsMinusOne()
+        {
+            var target = new PartEvent
+            {
+                ut = 10.0,
+                partPersistentId = 42,
+                eventType = PartEventType.EngineShutdown,
+                moduleIndex = 0
+            };
+            Assert.Equal(-1, FlightRecorder.FindTerminalEventIndex(null, target));
+            Assert.Equal(-1, FlightRecorder.FindTerminalEventIndex(new List<PartEvent>(), target));
+        }
+
+        [Fact]
+        public void FindTerminalEventIndex_MatchByTuple_IgnoresPartName()
+        {
+            var list = new List<PartEvent>
+            {
+                new PartEvent { ut = 5.0, partPersistentId = 10, eventType = PartEventType.EngineIgnited, moduleIndex = 0, partName = "liquidEngine2" },
+                new PartEvent { ut = 10.0, partPersistentId = 42, eventType = PartEventType.EngineShutdown, moduleIndex = 0, partName = "unknown" },
+                new PartEvent { ut = 15.0, partPersistentId = 10, eventType = PartEventType.EngineShutdown, moduleIndex = 0, partName = "liquidEngine2" }
+            };
+            var target = new PartEvent
+            {
+                ut = 10.0,
+                partPersistentId = 42,
+                eventType = PartEventType.EngineShutdown,
+                moduleIndex = 0,
+                partName = "unknown"
+            };
+            Assert.Equal(1, FlightRecorder.FindTerminalEventIndex(list, target));
+        }
+
+        [Fact]
+        public void FindTerminalEventIndex_NoMatch_ReturnsMinusOne()
+        {
+            var list = new List<PartEvent>
+            {
+                new PartEvent { ut = 5.0, partPersistentId = 10, eventType = PartEventType.EngineIgnited, moduleIndex = 0 },
+                new PartEvent { ut = 10.0, partPersistentId = 42, eventType = PartEventType.Decoupled, moduleIndex = 0 }
+            };
+            var target = new PartEvent
+            {
+                ut = 10.0,
+                partPersistentId = 42,
+                eventType = PartEventType.EngineShutdown, // different type
+                moduleIndex = 0
+            };
+            Assert.Equal(-1, FlightRecorder.FindTerminalEventIndex(list, target));
+        }
+
+        [Fact]
+        public void FindTerminalEventIndex_MatchesFirstOccurrence()
+        {
+            var list = new List<PartEvent>
+            {
+                new PartEvent { ut = 5.0, partPersistentId = 10, eventType = PartEventType.EngineShutdown, moduleIndex = 0 },
+                new PartEvent { ut = 5.0, partPersistentId = 10, eventType = PartEventType.EngineShutdown, moduleIndex = 0 } // duplicate
+            };
+            var target = new PartEvent
+            {
+                ut = 5.0,
+                partPersistentId = 10,
+                eventType = PartEventType.EngineShutdown,
+                moduleIndex = 0
+            };
+            Assert.Equal(0, FlightRecorder.FindTerminalEventIndex(list, target));
+        }
+
+        /// <summary>
+        /// Simulates the 2026-04-09 Kerbal X false-alarm path: the recorder has 2 decouples
+        /// at UT 87.94, FinalizeRecordingState appends 3 terminal EngineShutdowns, then
+        /// ResumeAfterFalseAlarm should remove exactly those 3 terminals by content match,
+        /// leaving the 2 decouples intact.
+        /// </summary>
+        [Fact]
+        public void ResumeAfterFalseAlarm_ContentBasedRemoval_PreservesDecouplesAndRemovesTerminals()
+        {
+            // Trigger TestSinkForTesting so the sink swallows Debug.Log calls in a non-Unity
+            // test context (mirrors RewindLoggingTests pattern).
+            var logLines = new List<string>();
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+            try
+            {
+                var rec = new FlightRecorder();
+
+                // 2 real decouples at UT 87.94 (from OnPartJointBreak)
+                rec.PartEvents.Add(new PartEvent
+                {
+                    ut = 87.94,
+                    partPersistentId = 3027027466,
+                    eventType = PartEventType.Decoupled,
+                    partName = "radialDecoupler1-2"
+                });
+                rec.PartEvents.Add(new PartEvent
+                {
+                    ut = 87.94,
+                    partPersistentId = 2130796824,
+                    eventType = PartEventType.Decoupled,
+                    partName = "radialDecoupler1-2"
+                });
+
+                // Simulate FinalizeRecordingState appending 3 terminal engine shutdowns.
+                // We call EmitTerminalEngineAndRcsEvents directly to get the real events,
+                // then save them via reflection to lastEmittedTerminalEvents. This mirrors
+                // the production flow where FinalizeRecordingState saves the reference.
+                var activeEngines = new HashSet<ulong>
+                {
+                    FlightRecorder.EncodeEngineKey(2485666303, 0),
+                    FlightRecorder.EncodeEngineKey(2527095907, 0),
+                    FlightRecorder.EncodeEngineKey(1282749119, 0)
+                };
+                var terminals = FlightRecorder.EmitTerminalEngineAndRcsEvents(
+                    activeEngines, null, null, null, 87.94, "Recorder");
+                rec.PartEvents.AddRange(terminals);
+
+                // Assign to lastEmittedTerminalEvents via reflection so we can call
+                // RemoveLastEmittedTerminals without going through StopRecordingForChainBoundary
+                var field = typeof(FlightRecorder).GetField(
+                    "lastEmittedTerminalEvents",
+                    System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+                Assert.NotNull(field);
+                field.SetValue(rec, terminals);
+
+                Assert.Equal(5, rec.PartEvents.Count); // 2 decouples + 3 terminals
+
+                int removed = rec.RemoveLastEmittedTerminals();
+                Assert.Equal(3, removed);
+
+                // Only the 2 real decouples remain
+                Assert.Equal(2, rec.PartEvents.Count);
+                Assert.All(rec.PartEvents, e => Assert.Equal(PartEventType.Decoupled, e.eventType));
+                Assert.Contains(rec.PartEvents, e => e.partPersistentId == 3027027466);
+                Assert.Contains(rec.PartEvents, e => e.partPersistentId == 2130796824);
+
+                // No surviving terminal engine shutdowns (the #287 smoking gun)
+                Assert.DoesNotContain(rec.PartEvents, e =>
+                    e.eventType == PartEventType.EngineShutdown && e.partName == "unknown");
+            }
+            finally
+            {
+                ParsekLog.ResetTestOverrides();
+            }
+        }
+
+        /// <summary>
+        /// Critical regression guard: even if an unstable sort reorders the PartEvents list
+        /// so the terminal shutdowns land in arbitrary positions, content-based removal
+        /// still finds and removes exactly the right events.
+        /// </summary>
+        [Fact]
+        public void RemoveLastEmittedTerminals_SurvivesUnstableSortReordering()
+        {
+            var logLines = new List<string>();
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+            try
+            {
+                var rec = new FlightRecorder();
+
+                // Pre-terminal: 2 decouples at UT 26.08
+                rec.PartEvents.Add(new PartEvent
+                {
+                    ut = 26.08,
+                    partPersistentId = 2057942744,
+                    eventType = PartEventType.Decoupled,
+                    partName = "radialDecoupler1-2"
+                });
+                rec.PartEvents.Add(new PartEvent
+                {
+                    ut = 26.08,
+                    partPersistentId = 1009856088,
+                    eventType = PartEventType.Decoupled,
+                    partName = "radialDecoupler1-2"
+                });
+
+                // Simulate FinalizeRecordingState adding 5 terminals at UT 26.08
+                var activeEngines = new HashSet<ulong>();
+                for (uint i = 0; i < 5; i++)
+                    activeEngines.Add(FlightRecorder.EncodeEngineKey(2000 + i, 0));
+                var terminals = FlightRecorder.EmitTerminalEngineAndRcsEvents(
+                    activeEngines, null, null, null, 26.08, "Recorder");
+                rec.PartEvents.AddRange(terminals);
+
+                var field = typeof(FlightRecorder).GetField(
+                    "lastEmittedTerminalEvents",
+                    System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+                field.SetValue(rec, terminals);
+
+                // SIMULATE UNSTABLE SORT: shuffle the PartEvents list into an adversarial order
+                // where a terminal is BEFORE a decouple (as the 2026-04-09 Kerbal X playtest
+                // recording showed for UT 72.40).
+                var shuffled = new List<PartEvent>
+                {
+                    rec.PartEvents[3], // terminal
+                    rec.PartEvents[0], // decouple
+                    rec.PartEvents[4], // terminal
+                    rec.PartEvents[1], // decouple
+                    rec.PartEvents[5], // terminal
+                    rec.PartEvents[2], // terminal (was terminals[0])
+                    rec.PartEvents[6]  // terminal
+                };
+                rec.PartEvents.Clear();
+                rec.PartEvents.AddRange(shuffled);
+
+                int removed = rec.RemoveLastEmittedTerminals();
+                Assert.Equal(5, removed);
+
+                // Only the 2 real decouples remain, in their original identity
+                Assert.Equal(2, rec.PartEvents.Count);
+                Assert.Contains(rec.PartEvents, e =>
+                    e.eventType == PartEventType.Decoupled && e.partPersistentId == 2057942744);
+                Assert.Contains(rec.PartEvents, e =>
+                    e.eventType == PartEventType.Decoupled && e.partPersistentId == 1009856088);
+                Assert.DoesNotContain(rec.PartEvents, e =>
+                    e.eventType == PartEventType.EngineShutdown);
+            }
+            finally
+            {
+                ParsekLog.ResetTestOverrides();
+            }
+        }
+
+        /// <summary>
+        /// Regression guard for the root-cause scenario from 2026-04-09 Kerbal X
+        /// playtest (<c>logs/2026-04-09_1117_kerbalx-rover</c>): two sources of PartEvents
+        /// merged into one recording — a tree root containing terminal Shutdowns at UT 72.94
+        /// plus a continuing recording's seed EngineIgnited events at the same UT. After a
+        /// stable sort, playback iterating in order sees Shutdown-then-Ignited and leaves
+        /// engines ON. If an unstable sort scrambles them, playback can see
+        /// Ignited-then-Shutdown and leave engines OFF.
+        /// </summary>
+        [Fact]
+        public void StableSort_TreeMergeAtSameUT_KeepsShutdownsBeforeIgnitedSeeds()
+        {
+            var treeRootEvents = new List<PartEvent>
+            {
+                // 5 terminal shutdowns from tree promotion at UT 72.94
+                new PartEvent { ut = 72.94, partPersistentId = 2485666303, eventType = PartEventType.EngineShutdown, partName = "unknown", moduleIndex = 0 },
+                new PartEvent { ut = 72.94, partPersistentId = 2527095907, eventType = PartEventType.EngineShutdown, partName = "unknown", moduleIndex = 0 },
+                new PartEvent { ut = 72.94, partPersistentId = 1282749119, eventType = PartEventType.EngineShutdown, partName = "unknown", moduleIndex = 0 },
+                new PartEvent { ut = 72.94, partPersistentId = 1782153286, eventType = PartEventType.EngineShutdown, partName = "unknown", moduleIndex = 0 },
+                new PartEvent { ut = 72.94, partPersistentId = 3609199354, eventType = PartEventType.EngineShutdown, partName = "unknown", moduleIndex = 0 }
+            };
+            var continuingSeedEvents = new List<PartEvent>
+            {
+                // 5 seed EngineIgnited events at the same UT
+                new PartEvent { ut = 72.94, partPersistentId = 2485666303, eventType = PartEventType.EngineIgnited, partName = "liquidEngineMainsail.v2", value = 1.0f, moduleIndex = 0 },
+                new PartEvent { ut = 72.94, partPersistentId = 2527095907, eventType = PartEventType.EngineIgnited, partName = "liquidEngine2", value = 1.0f, moduleIndex = 0 },
+                new PartEvent { ut = 72.94, partPersistentId = 1282749119, eventType = PartEventType.EngineIgnited, partName = "liquidEngine2", value = 1.0f, moduleIndex = 0 },
+                new PartEvent { ut = 72.94, partPersistentId = 1782153286, eventType = PartEventType.EngineIgnited, partName = "liquidEngine2", value = 1.0f, moduleIndex = 0 },
+                new PartEvent { ut = 72.94, partPersistentId = 3609199354, eventType = PartEventType.EngineIgnited, partName = "liquidEngine2", value = 1.0f, moduleIndex = 0 }
+            };
+
+            // Merge: tree root events first (as they're appended first at flush time), then seeds
+            var merged = new List<PartEvent>();
+            merged.AddRange(treeRootEvents);
+            merged.AddRange(continuingSeedEvents);
+
+            var sorted = FlightRecorder.StableSortPartEventsByUT(merged);
+
+            Assert.Equal(10, sorted.Count);
+
+            // All 5 Shutdowns must come before all 5 Ignited events so playback leaves
+            // engines ON at the end of this UT batch.
+            int lastShutdownIdx = -1;
+            int firstIgnitedIdx = -1;
+            for (int i = 0; i < sorted.Count; i++)
+            {
+                if (sorted[i].eventType == PartEventType.EngineShutdown) lastShutdownIdx = i;
+                if (firstIgnitedIdx < 0 && sorted[i].eventType == PartEventType.EngineIgnited) firstIgnitedIdx = i;
+            }
+
+            Assert.True(lastShutdownIdx >= 0, "Expected at least one Shutdown in sorted output");
+            Assert.True(firstIgnitedIdx >= 0, "Expected at least one Ignited in sorted output");
+            Assert.True(lastShutdownIdx < firstIgnitedIdx,
+                $"Stable sort violated: last Shutdown at {lastShutdownIdx} came AFTER first Ignited at {firstIgnitedIdx}. " +
+                "This would cause engine FX to turn off permanently in playback after staging (bug #287).");
+        }
+
+        [Fact]
+        public void StableSortPartEventsByUT_Static_NullInput_ReturnsEmptyList()
+        {
+            // The static helper must return a NEW list (never the same reference as input)
+            // so callers can safely Clear the source before copying back. Null input
+            // returns an empty list rather than null to keep caller code branch-free.
+            var result = FlightRecorder.StableSortPartEventsByUT(null);
+            Assert.NotNull(result);
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void StableSortPartEventsByUT_Static_SingleElement_ReturnsNewList()
+        {
+            var input = new List<PartEvent>
+            {
+                new PartEvent { ut = 5.0, partPersistentId = 1 }
+            };
+            var result = FlightRecorder.StableSortPartEventsByUT(input);
+            Assert.Single(result);
+            // Must be a separate list so caller can Clear input without losing result
+            Assert.NotSame(input, result);
+        }
+
+        [Fact]
+        public void StableSortPartEventsByUT_Static_ClearThenCopyBack_WorksWithSmallLists()
+        {
+            // Regression guard for the aliasing bug caught by AppendCapturedDataTests
+            // on the first fix iteration: if the helper returned the same reference for
+            // small lists, callers doing
+            //   var sorted = StableSortPartEventsByUT(list);
+            //   list.Clear();
+            //   list.AddRange(sorted);
+            // would silently lose all data.
+            var list = new List<PartEvent>
+            {
+                new PartEvent { ut = 10.0, partPersistentId = 1, partName = "original" }
+            };
+            var sorted = FlightRecorder.StableSortPartEventsByUT(list);
+            list.Clear();
+            list.AddRange(sorted);
+
+            Assert.Single(list);
+            Assert.Equal(1u, list[0].partPersistentId);
+            Assert.Equal("original", list[0].partName);
+        }
+    }
+}

--- a/Source/Parsek.Tests/Bug287TerminalCleanupTests.cs
+++ b/Source/Parsek.Tests/Bug287TerminalCleanupTests.cs
@@ -9,7 +9,7 @@ namespace Parsek.Tests
     ///
     /// Root cause: <c>ResumeAfterFalseAlarm</c>'s index-based <c>RemoveRange</c> was brittle
     /// against any code path that reordered or appended PartEvents between
-    /// <c>StopRecordingForChainBoundary</c> and the resume call — particularly the four
+    /// <c>StopRecordingForChainBoundary</c> and the resume call — particularly the five
     /// unstable <c>List&lt;T&gt;.Sort((a,b) =&gt; a.ut.CompareTo(b.ut))</c> call sites in
     /// flush/merge paths. The fix switches to content-based removal: FinalizeRecordingState
     /// now saves the exact terminal events it emitted, and ResumeAfterFalseAlarm removes
@@ -130,10 +130,10 @@ namespace Parsek.Tests
                     partName = "radialDecoupler1-2"
                 });
 
-                // Simulate FinalizeRecordingState appending 3 terminal engine shutdowns.
-                // We call EmitTerminalEngineAndRcsEvents directly to get the real events,
-                // then save them via reflection to lastEmittedTerminalEvents. This mirrors
-                // the production flow where FinalizeRecordingState saves the reference.
+                // Simulate FinalizeRecordingState appending 3 terminal engine shutdowns by
+                // calling EmitTerminalEngineAndRcsEvents directly, appending to PartEvents,
+                // and stashing the reference in lastEmittedTerminalEvents (internal field
+                // — InternalsVisibleTo(Parsek.Tests) grants direct access, no reflection).
                 var activeEngines = new HashSet<ulong>
                 {
                     FlightRecorder.EncodeEngineKey(2485666303, 0),
@@ -143,14 +143,7 @@ namespace Parsek.Tests
                 var terminals = FlightRecorder.EmitTerminalEngineAndRcsEvents(
                     activeEngines, null, null, null, 87.94, "Recorder");
                 rec.PartEvents.AddRange(terminals);
-
-                // Assign to lastEmittedTerminalEvents via reflection so we can call
-                // RemoveLastEmittedTerminals without going through StopRecordingForChainBoundary
-                var field = typeof(FlightRecorder).GetField(
-                    "lastEmittedTerminalEvents",
-                    System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
-                Assert.NotNull(field);
-                field.SetValue(rec, terminals);
+                rec.lastEmittedTerminalEvents = terminals;
 
                 Assert.Equal(5, rec.PartEvents.Count); // 2 decouples + 3 terminals
 
@@ -211,10 +204,8 @@ namespace Parsek.Tests
                     activeEngines, null, null, null, 26.08, "Recorder");
                 rec.PartEvents.AddRange(terminals);
 
-                var field = typeof(FlightRecorder).GetField(
-                    "lastEmittedTerminalEvents",
-                    System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
-                field.SetValue(rec, terminals);
+                // Direct access via internal (InternalsVisibleTo(Parsek.Tests))
+                rec.lastEmittedTerminalEvents = terminals;
 
                 // SIMULATE UNSTABLE SORT: shuffle the PartEvents list into an adversarial order
                 // where a terminal is BEFORE a decouple (as the 2026-04-09 Kerbal X playtest

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -118,17 +118,13 @@ namespace Parsek
         // Joint break split detection: set by OnPartJointBreak, consumed by ParsekFlight.Update()
         public bool HasPendingJointBreakCheck { get; private set; }
 
-        // Saved PartEvents count before chain boundary stop — used by ResumeAfterFalseAlarm
-        // to truncate orphaned terminal events added by FinalizeRecordingState.
-        private int partEventCountBeforeChainStop = -1;
-
         // Exact terminal events appended by the most recent FinalizeRecordingState call with
         // emitTerminalEvents=true. ResumeAfterFalseAlarm uses this list to remove the orphaned
         // terminals by content-matching rather than index arithmetic. Index-based removal
-        // (see #255/#263/#281) is brittle across unstable sort paths (flush/merge) and any
-        // code path that appends events between stop and resume — it has caused spurious
-        // terminal Shutdowns to survive into committed recordings (#287).
-        private List<PartEvent> lastEmittedTerminalEvents;
+        // (see #255/#263/#281) was brittle across unstable sort paths (flush/merge) and any
+        // code path that appends events between stop and resume — it caused spurious terminal
+        // Shutdowns to survive into committed recordings (#287).
+        internal List<PartEvent> lastEmittedTerminalEvents;
 
         /// <summary>
         /// Consumes the pending joint break flag, returning whether a check was pending.
@@ -4633,24 +4629,18 @@ namespace Parsek
                 lastEmittedTerminalEvents = null;
             }
 
-            // Sort part/flag events chronologically (mixed event sources may produce
-            // non-chronological order). PartEvents MUST use a STABLE sort so that
-            // same-UT events retain their insertion order: bug #281 showed that an
-            // unstable List<T>.Sort can shuffle decouple events (OnPartJointBreak,
-            // added first) into the terminal-event range (FinalizeRecordingState
-            // appends, added second) when they share a physics-frame UT — and then
-            // ResumeAfterFalseAlarm's index-based RemoveRange would wrongly drop the
-            // decouples along with the terminals. LINQ OrderBy is stable; List<T>.Sort
-            // is not.
+            // Sort part/flag events chronologically with STABLE semantics so same-UT
+            // events retain their insertion order. See #263/#287 for the root-cause
+            // narrative — LINQ OrderBy is stable; List<T>.Sort(Comparison) is not.
             StableSortPartEventsByUT();
 
-            // FlagEvents can use the standard unstable sort: there is no analogous
-            // index-based removal path for flags (ResumeAfterFalseAlarm only touches
-            // PartEvents), and flag events are rare enough that same-UT ties are
-            // extremely unlikely. If either invariant changes — flags getting a
-            // rollback path, or high-frequency flag emission — switch this to the
-            // stable helper pattern and add an equivalent regression test.
-            FlagEvents.Sort((a, b) => a.ut.CompareTo(b.ut));
+            // FlagEvents also uses stable sort for consistency — bug #287 established
+            // that every flush/merge site should use stable semantics so future code
+            // that adds a rollback path or high-frequency flag emission cannot silently
+            // regress on same-UT ordering.
+            var sortedFlags = StableSortByUT(FlagEvents, e => e.ut);
+            FlagEvents.Clear();
+            FlagEvents.AddRange(sortedFlags);
         }
 
         /// <summary>
@@ -4661,7 +4651,8 @@ namespace Parsek
         /// </summary>
         internal void StableSortPartEventsByUT()
         {
-            if (PartEvents.Count < 2) return;
+            // The static helper handles 0/1-element lists by returning a new empty/copy
+            // list — Clear+AddRange stays safe for those cases, no need for a short-circuit.
             var sorted = StableSortPartEventsByUT(PartEvents);
             PartEvents.Clear();
             PartEvents.AddRange(sorted);
@@ -4678,9 +4669,22 @@ namespace Parsek
         /// </summary>
         internal static List<PartEvent> StableSortPartEventsByUT(List<PartEvent> events)
         {
-            if (events == null) return new List<PartEvent>();
-            if (events.Count < 2) return new List<PartEvent>(events);
-            return events.OrderBy(e => e.ut).ToList();
+            return StableSortByUT(events, e => e.ut);
+        }
+
+        /// <summary>
+        /// Generic stable UT-sort helper for any event type with a UT double. Returns a NEW
+        /// list (never the same reference as input) so callers can safely Clear+AddRange.
+        /// Uses LINQ <c>OrderBy</c> which is documented stable — same-UT events keep their
+        /// insertion order. Used for <see cref="FlagEvent"/> and <see cref="SegmentEvent"/>
+        /// sorts at flush/merge sites so the sort semantics stay consistent with the
+        /// <see cref="PartEvent"/> path and future same-UT hazards cannot silently regress.
+        /// </summary>
+        internal static List<T> StableSortByUT<T>(List<T> list, System.Func<T, double> utSelector)
+        {
+            if (list == null) return new List<T>();
+            if (list.Count < 2) return new List<T>(list);
+            return list.OrderBy(utSelector).ToList();
         }
 
         /// <summary>
@@ -4779,20 +4783,9 @@ namespace Parsek
         /// </summary>
         public void StopRecordingForChainBoundary()
         {
-            // Save state before finalization so ResumeAfterFalseAlarm can undo terminal events.
-            //
-            // Invariant (bug #281): this index-based save-point relies on
-            // FinalizeRecordingState using a STABLE sort when it re-orders PartEvents.
-            // Terminal events are emitted at `Planetarium.GetUniversalTime()` during
-            // the finalize call, so every pre-stop PartEvent has `ut <= terminalUT`.
-            // A stable sort keeps pre-stop entries before same-UT terminals, which
-            // means ResumeAfterFalseAlarm's `RemoveRange(partEventCountBeforeChainStop,
-            // N)` only touches the terminals. If any future code path ever inserts a
-            // pre-stop event at ut > terminalUT (e.g., a look-ahead predictor), this
-            // invariant breaks and the index-based save-point stops working — migrate
-            // to content-based terminal removal at that point.
-            partEventCountBeforeChainStop = PartEvents.Count;
-
+            // FinalizeRecordingState stashes the exact terminal events it emits in
+            // lastEmittedTerminalEvents; ResumeAfterFalseAlarm uses that list to remove
+            // them by content-match if this stop turns out to be a false alarm (#287).
             FinalizeRecordingState(
                 emitTerminalEvents: true,
                 clearRelativeMode: true,
@@ -4854,7 +4847,6 @@ namespace Parsek
                     $"ResumeAfterFalseAlarm: removed {contentRemoved} orphaned terminal event(s) " +
                     $"(PartEvents count: {PartEvents.Count})");
             }
-            partEventCountBeforeChainStop = -1;
 
             // Restore rewind save from CaptureAtStop — StopRecordingForChainBoundary
             // cleared RewindSaveFileName after copying it to CaptureAtStop, so if we

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -122,6 +122,14 @@ namespace Parsek
         // to truncate orphaned terminal events added by FinalizeRecordingState.
         private int partEventCountBeforeChainStop = -1;
 
+        // Exact terminal events appended by the most recent FinalizeRecordingState call with
+        // emitTerminalEvents=true. ResumeAfterFalseAlarm uses this list to remove the orphaned
+        // terminals by content-matching rather than index arithmetic. Index-based removal
+        // (see #255/#263/#281) is brittle across unstable sort paths (flush/merge) and any
+        // code path that appends events between stop and resume — it has caused spurious
+        // terminal Shutdowns to survive into committed recordings (#287).
+        private List<PartEvent> lastEmittedTerminalEvents;
+
         /// <summary>
         /// Consumes the pending joint break flag, returning whether a check was pending.
         /// </summary>
@@ -4615,6 +4623,14 @@ namespace Parsek
                     activeEngineKeys, activeRcsKeys, activeRoboticKeys,
                     lastRoboticPosition, terminalUT, "Recorder");
                 PartEvents.AddRange(terminalEvts);
+                // Save the exact terminal events so ResumeAfterFalseAlarm can remove them
+                // by content-match (#287). Index-based RemoveRange is brittle across unstable
+                // sort paths and any code path that appends events between stop and resume.
+                lastEmittedTerminalEvents = terminalEvts;
+            }
+            else
+            {
+                lastEmittedTerminalEvents = null;
             }
 
             // Sort part/flag events chronologically (mixed event sources may produce
@@ -4646,9 +4662,91 @@ namespace Parsek
         internal void StableSortPartEventsByUT()
         {
             if (PartEvents.Count < 2) return;
-            var sorted = PartEvents.OrderBy(e => e.ut).ToList();
+            var sorted = StableSortPartEventsByUT(PartEvents);
             PartEvents.Clear();
             PartEvents.AddRange(sorted);
+        }
+
+        /// <summary>
+        /// Static helper for stable UT-sorting of a <see cref="PartEvent"/> list. Returns a
+        /// new list with equal-UT events in their original insertion order. Call sites that
+        /// merge multiple event sources (tree flushes, session merger, recording optimizer)
+        /// must use this instead of <c>List&lt;T&gt;.Sort(Comparison)</c> to preserve the
+        /// terminal-vs-ignited ordering at chain boundaries (#263, #287).
+        /// Always returns a NEW list (even for null/small inputs) so callers can safely
+        /// Clear the source list before copying back, without aliasing issues.
+        /// </summary>
+        internal static List<PartEvent> StableSortPartEventsByUT(List<PartEvent> events)
+        {
+            if (events == null) return new List<PartEvent>();
+            if (events.Count < 2) return new List<PartEvent>(events);
+            return events.OrderBy(e => e.ut).ToList();
+        }
+
+        /// <summary>
+        /// Removes the exact terminal events saved by the most recent FinalizeRecordingState
+        /// call from <see cref="PartEvents"/> by content-matching on (ut, pid, eventType,
+        /// moduleIndex). Robust against sort reordering — unlike the index-based RemoveRange
+        /// it replaces (#287). Returns the number of terminal events removed.
+        /// </summary>
+        internal int RemoveLastEmittedTerminals()
+        {
+            if (lastEmittedTerminalEvents == null || lastEmittedTerminalEvents.Count == 0)
+                return 0;
+
+            int removed = 0;
+            int notFound = 0;
+            for (int i = 0; i < lastEmittedTerminalEvents.Count; i++)
+            {
+                var target = lastEmittedTerminalEvents[i];
+                int idx = FindTerminalEventIndex(PartEvents, target);
+                if (idx >= 0)
+                {
+                    PartEvents.RemoveAt(idx);
+                    removed++;
+                }
+                else
+                {
+                    notFound++;
+                }
+            }
+
+            if (notFound > 0)
+            {
+                ParsekLog.Warn("Recorder",
+                    $"RemoveLastEmittedTerminals: {notFound} terminal event(s) not found in PartEvents " +
+                    $"(expected {lastEmittedTerminalEvents.Count}, removed {removed}) — possible race " +
+                    $"condition with intervening flush/sort");
+            }
+
+            lastEmittedTerminalEvents = null;
+            return removed;
+        }
+
+        /// <summary>
+        /// Pure helper: finds the index of the first <see cref="PartEvent"/> in
+        /// <paramref name="list"/> that matches <paramref name="target"/> by
+        /// (ut, partPersistentId, eventType, moduleIndex). Returns -1 if not found.
+        /// Ignores <c>partName</c> and <c>value</c> because terminal events stamp
+        /// <c>partName="unknown"</c> while a natural event with the same (ut, pid, type,
+        /// midx) tuple would not realistically coexist in the list (the active-key set
+        /// gates both emission sites).
+        /// </summary>
+        internal static int FindTerminalEventIndex(List<PartEvent> list, PartEvent target)
+        {
+            if (list == null) return -1;
+            for (int i = 0; i < list.Count; i++)
+            {
+                var e = list[i];
+                if (e.ut == target.ut
+                    && e.partPersistentId == target.partPersistentId
+                    && e.eventType == target.eventType
+                    && e.moduleIndex == target.moduleIndex)
+                {
+                    return i;
+                }
+            }
+            return -1;
         }
 
         public void StopRecording()
@@ -4742,12 +4840,18 @@ namespace Parsek
             // StopRecordingForChainBoundary emits EngineShutdown/RCSStop events for all
             // active engines. If the split turns out to be a false alarm (debris only),
             // these events are wrong — the engines are still running.
-            if (partEventCountBeforeChainStop >= 0 && partEventCountBeforeChainStop < PartEvents.Count)
+            //
+            // Content-based removal (#287): we match each saved terminal event against
+            // PartEvents by (ut, pid, type, midx) and remove the matching entry. This is
+            // robust across unstable sort paths and any code that appends events between
+            // stop and resume — index-based RemoveRange was brittle and left spurious
+            // terminal Shutdowns in committed recordings, causing engine FX to turn off
+            // permanently after booster staging (bug #287 2026-04-09 Kerbal X playtest).
+            int contentRemoved = RemoveLastEmittedTerminals();
+            if (contentRemoved > 0)
             {
-                int removed = PartEvents.Count - partEventCountBeforeChainStop;
-                PartEvents.RemoveRange(partEventCountBeforeChainStop, removed);
                 ParsekLog.Info("Recorder",
-                    $"ResumeAfterFalseAlarm: removed {removed} orphaned terminal event(s) " +
+                    $"ResumeAfterFalseAlarm: removed {contentRemoved} orphaned terminal event(s) " +
                     $"(PartEvents count: {PartEvents.Count})");
             }
             partEventCountBeforeChainStop = -1;

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -224,8 +224,13 @@ namespace Parsek
             treeRec.FlagEvents.AddRange(recorder.FlagEvents);
             treeRec.TrackSections.AddRange(recorder.TrackSections);
 
-            // Sort events chronologically — mixed sources can produce out-of-order data
-            treeRec.PartEvents.Sort((a, b) => a.ut.CompareTo(b.ut));
+            // Sort events chronologically — mixed sources can produce out-of-order data.
+            // PartEvents MUST use a STABLE sort so same-UT terminal Shutdowns stay before
+            // continuation seed EngineIgnited events (#287). LINQ OrderBy is stable;
+            // List<T>.Sort(Comparison) is not.
+            var sortedPartEvents = FlightRecorder.StableSortPartEventsByUT(treeRec.PartEvents);
+            treeRec.PartEvents.Clear();
+            treeRec.PartEvents.AddRange(sortedPartEvents);
             treeRec.FlagEvents.Sort((a, b) => a.ut.CompareTo(b.ut));
 
             // Populate VesselPersistentId if not already set
@@ -1608,8 +1613,12 @@ namespace Parsek
             treeRec.FlagEvents.AddRange(rec.FlagEvents);
             treeRec.TrackSections.AddRange(rec.TrackSections);
 
-            // Sort part/flag events chronologically (mixed event sources may produce non-chronological order)
-            treeRec.PartEvents.Sort((a, b) => a.ut.CompareTo(b.ut));
+            // Sort part/flag events chronologically. PartEvents MUST use a STABLE sort so
+            // same-UT events retain their insertion order — critical for terminal-vs-ignited
+            // ordering across tree promotion boundaries (#287).
+            var sortedPartEventsFlush = FlightRecorder.StableSortPartEventsByUT(treeRec.PartEvents);
+            treeRec.PartEvents.Clear();
+            treeRec.PartEvents.AddRange(sortedPartEventsFlush);
             treeRec.FlagEvents.Sort((a, b) => a.ut.CompareTo(b.ut));
 
             // Mark dirty so the next OnSave persists the flushed data to disk.
@@ -1740,7 +1749,10 @@ namespace Parsek
                 target.OrbitSegments.AddRange(source.OrbitSegments);
                 target.PartEvents.AddRange(source.PartEvents);
                 target.TrackSections.AddRange(source.TrackSections);
-                target.PartEvents.Sort((a, b) => a.ut.CompareTo(b.ut));
+                // STABLE sort: same-UT events preserve insertion order (#287).
+                var sortedAppend = FlightRecorder.StableSortPartEventsByUT(target.PartEvents);
+                target.PartEvents.Clear();
+                target.PartEvents.AddRange(sortedAppend);
                 // Mark dirty so the next OnSave persists the appended data to
                 // the .prec sidecar. Without this, data lives only in memory
                 // and is lost on scene reload (see Recording.MarkFilesDirty

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -227,11 +227,14 @@ namespace Parsek
             // Sort events chronologically — mixed sources can produce out-of-order data.
             // PartEvents MUST use a STABLE sort so same-UT terminal Shutdowns stay before
             // continuation seed EngineIgnited events (#287). LINQ OrderBy is stable;
-            // List<T>.Sort(Comparison) is not.
+            // List<T>.Sort(Comparison) is not. FlagEvents uses the same stable pattern
+            // for consistency across every flush/merge site.
             var sortedPartEvents = FlightRecorder.StableSortPartEventsByUT(treeRec.PartEvents);
             treeRec.PartEvents.Clear();
             treeRec.PartEvents.AddRange(sortedPartEvents);
-            treeRec.FlagEvents.Sort((a, b) => a.ut.CompareTo(b.ut));
+            var sortedFlagEvents = FlightRecorder.StableSortByUT(treeRec.FlagEvents, e => e.ut);
+            treeRec.FlagEvents.Clear();
+            treeRec.FlagEvents.AddRange(sortedFlagEvents);
 
             // Populate VesselPersistentId if not already set
             if (treeRec.VesselPersistentId == 0 && recorder.RecordingVesselId != 0)
@@ -1615,11 +1618,14 @@ namespace Parsek
 
             // Sort part/flag events chronologically. PartEvents MUST use a STABLE sort so
             // same-UT events retain their insertion order — critical for terminal-vs-ignited
-            // ordering across tree promotion boundaries (#287).
+            // ordering across tree promotion boundaries (#287). FlagEvents uses the same
+            // stable pattern for consistency across every flush/merge site.
             var sortedPartEventsFlush = FlightRecorder.StableSortPartEventsByUT(treeRec.PartEvents);
             treeRec.PartEvents.Clear();
             treeRec.PartEvents.AddRange(sortedPartEventsFlush);
-            treeRec.FlagEvents.Sort((a, b) => a.ut.CompareTo(b.ut));
+            var sortedFlagEventsFlush = FlightRecorder.StableSortByUT(treeRec.FlagEvents, e => e.ut);
+            treeRec.FlagEvents.Clear();
+            treeRec.FlagEvents.AddRange(sortedFlagEventsFlush);
 
             // Mark dirty so the next OnSave persists the flushed data to disk.
             // Without this, the in-memory points are lost on scene reload.

--- a/Source/Parsek/RecordingOptimizer.cs
+++ b/Source/Parsek/RecordingOptimizer.cs
@@ -220,11 +220,15 @@ namespace Parsek
             if (absorbed.Points != null && absorbed.Points.Count > 0)
                 target.Points.AddRange(absorbed.Points);
 
-            // 2. Merge + re-sort PartEvents by UT
+            // 2. Merge + re-sort PartEvents by UT.
+            // STABLE sort: same-UT events preserve insertion order so terminal Shutdowns
+            // stay before continuation seed EngineIgnited events (#287).
             if (absorbed.PartEvents != null && absorbed.PartEvents.Count > 0)
             {
                 target.PartEvents.AddRange(absorbed.PartEvents);
-                target.PartEvents.Sort((a, b) => a.ut.CompareTo(b.ut));
+                var sortedMerge = FlightRecorder.StableSortPartEventsByUT(target.PartEvents);
+                target.PartEvents.Clear();
+                target.PartEvents.AddRange(sortedMerge);
             }
 
             // 3. Merge + re-sort SegmentEvents by UT

--- a/Source/Parsek/RecordingOptimizer.cs
+++ b/Source/Parsek/RecordingOptimizer.cs
@@ -231,11 +231,14 @@ namespace Parsek
                 target.PartEvents.AddRange(sortedMerge);
             }
 
-            // 3. Merge + re-sort SegmentEvents by UT
+            // 3. Merge + re-sort SegmentEvents by UT with STABLE semantics for consistency
+            // with the PartEvents path (#287) — same-UT events keep their insertion order.
             if (absorbed.SegmentEvents != null && absorbed.SegmentEvents.Count > 0)
             {
                 target.SegmentEvents.AddRange(absorbed.SegmentEvents);
-                target.SegmentEvents.Sort((a, b) => a.ut.CompareTo(b.ut));
+                var sortedSegs = FlightRecorder.StableSortByUT(target.SegmentEvents, e => e.ut);
+                target.SegmentEvents.Clear();
+                target.SegmentEvents.AddRange(sortedSegs);
             }
 
             // 4. Concatenate TrackSections

--- a/Source/Parsek/SessionMerger.cs
+++ b/Source/Parsek/SessionMerger.cs
@@ -409,7 +409,9 @@ namespace Parsek
 
         /// <summary>
         /// Merges two PartEvent lists, deduplicating by (ut, partPersistentId, eventType)
-        /// and sorting by UT.
+        /// and sorting by UT with stable semantics so same-UT events keep their insertion
+        /// order — critical for terminal Shutdowns at chain boundaries to stay before
+        /// continuation seed EngineIgnited events (#287).
         /// </summary>
         internal static List<PartEvent> MergePartEvents(List<PartEvent> eventsA, List<PartEvent> eventsB)
         {
@@ -419,7 +421,7 @@ namespace Parsek
             AddEventsWithDedup(merged, seen, eventsA);
             AddEventsWithDedup(merged, seen, eventsB);
 
-            merged.Sort((a, b) => a.ut.CompareTo(b.ut));
+            merged = FlightRecorder.StableSortPartEventsByUT(merged);
 
             ParsekLog.Verbose(Tag,
                 $"MergePartEvents: inputA={eventsA?.Count ?? 0} inputB={eventsB?.Count ?? 0} " +

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -43,7 +43,7 @@ All 5466 tests pass.
 
 **Observability:** `ResumeAfterFalseAlarm`'s log line continues to report the number removed. A new `Warn` fires if any saved terminal isn't found in `PartEvents` at resume time (`RemoveLastEmittedTerminals: N terminal event(s) not found`) — that's a canary for any future race condition that manages to drop a terminal between emit and resume.
 
-**Follow-up note:** The existing `StopRecordingForChainBoundary.partEventCountBeforeChainStop` field is now unused for its original purpose but kept as-is (not removed in this PR) for potential future use as a "where did the terminals originally land" reference point. Bug #281's `StableSortPartEventsByUT` instance method is preserved and still called from `FinalizeRecordingState`.
+**Cleanup:** The old `partEventCountBeforeChainStop` private field + its 10-line bug #281 invariant comment in `StopRecordingForChainBoundary` were deleted — content-based removal obviates them and the stale comment was actively misleading. Bug #281's `StableSortPartEventsByUT` instance method is preserved and still called from `FinalizeRecordingState`. `FlagEvents` and `SegmentEvents` sort sites were also converted to stable via a new generic `FlightRecorder.StableSortByUT<T>(list, utSelector)` helper so every flush/merge site uses the same ordering semantics.
 
 **Status:** Fixed
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -4,6 +4,51 @@ Previous entries (225 bugs, 51 TODOs — mostly resolved) archived in `done/todo
 
 ---
 
+## ~~287. Spurious terminal EngineShutdown events survive into committed recordings — ghost engine flames go off permanently after booster staging~~
+
+Surfaced by the 2026-04-09 Kerbal X playtest (`logs/2026-04-09_1117_kerbalx-rover`). The user reported that the ghost's KerbalX engine flames (Mainsail + booster liquidEngine2) turned off after staging the boosters and never came back, even though in reality the Mainsail kept burning through orbit insertion.
+
+**Evidence from committed recording `db2e7ab62c6847e0b439237a41172602.prec`:**
+- UT 72.40: `EngineShutdown pid=1782153286 part=unknown` (a liquidEngine2 booster that shouldn't be shutdown yet)
+- UT 87.94: `EngineShutdown pid=2527095907 part=unknown` (booster engine, still running at this UT in reality)
+- UT 104.86: `EngineShutdown pid=2527095907 part=unknown` (same pid, same spurious shutdown pattern)
+
+Each spurious Shutdown is accompanied by a `Decoupled` event from `OnPartJointBreak` at the same UT — but the file is missing one of the paired Decoupleds that the log confirms was emitted. So each boundary shows: 1 real Decoupled + 1 spurious terminal (with 1 Decoupled + 2 terminals missing/extra). The terminal event (with `part="unknown"`) is the smoking gun: only `EmitTerminalEngineAndRcsEvents` in `FlightRecorder.cs` stamps `partName="unknown"` as a literal.
+
+**Log verification:** `ResumeAfterFalseAlarm: removed 5/3/3 orphaned terminal event(s)` at lines 9290, 9494, 9663 of the KSP.log say the terminals WERE removed from the live recorder at each boundary. Yet the saved `.prec` file still has one per boundary.
+
+**Root cause:** `ResumeAfterFalseAlarm`'s index-based `PartEvents.RemoveRange(partEventCountBeforeChainStop, N)` was brittle against any code path that reordered the list between `StopRecordingForChainBoundary` and the resume call. Five call sites used the unstable `List<T>.Sort((a, b) => a.ut.CompareTo(b.ut))` pattern during flush/merge:
+1. `ParsekFlight.FlushRecorderIntoActiveTreeForSerialization` (line 228)
+2. `ParsekFlight.FlushRecorderToTreeRecording` (line 1612)
+3. `ParsekFlight.AppendCapturedDataToRecording` (line 1743)
+4. `RecordingOptimizer.MergeInto` (line 227)
+5. `SessionMerger.MergePartEvents` (line 422)
+
+When the tree root's events were merged with continuation recorder events at OnSave / MergeTree / commit time, an unstable sort could scramble same-UT events. In the Kerbal X case, a terminal Shutdown at UT 72.94 from the tree root and a seed EngineIgnited at the same UT from the continuation could end up in `Ignited-then-Shutdown` order in the committed `.prec`, leaving playback's `ApplyPartEvents` to call `SetEngineEmission(0f)` as the final event at that UT — flame OFF.
+
+**Fix (two prongs):**
+
+1. **Content-based terminal removal** — `FinalizeRecordingState` now saves the exact terminal events it emitted in a new private `lastEmittedTerminalEvents` field. `ResumeAfterFalseAlarm` calls a new `RemoveLastEmittedTerminals()` helper that matches each saved event against `PartEvents` by `(ut, pid, eventType, moduleIndex)` and removes the matching entry. Robust against any sort reordering or intervening append, because removal is by content not position. New `FlightRecorder.FindTerminalEventIndex(list, target)` pure helper does the (ut, pid, type, midx) tuple match.
+
+2. **Stable sort at all merge sites** — new `FlightRecorder.StableSortPartEventsByUT(List<PartEvent>)` static overload returns a NEW list via LINQ `OrderBy` (stable). All five call sites above replaced their `List<T>.Sort` with this helper. Clear+AddRange pattern: `var sorted = StableSortPartEventsByUT(target.PartEvents); target.PartEvents.Clear(); target.PartEvents.AddRange(sorted);`. The static helper is careful to always return a NEW list (even for null/single-element inputs) to prevent aliasing when callers do the Clear+AddRange dance.
+
+**Tests (`Bug287TerminalCleanupTests.cs`, 10 new xUnit tests):**
+- `FindTerminalEventIndex_EmptyList_ReturnsMinusOne` / `MatchByTuple_IgnoresPartName` / `NoMatch_ReturnsMinusOne` / `MatchesFirstOccurrence`
+- `ResumeAfterFalseAlarm_ContentBasedRemoval_PreservesDecouplesAndRemovesTerminals` — end-to-end: 2 decouples + 3 terminals → 2 decouples remain
+- `RemoveLastEmittedTerminals_SurvivesUnstableSortReordering` — adversarial shuffle proves content-based removal works even when the list is scrambled
+- `StableSort_TreeMergeAtSameUT_KeepsShutdownsBeforeIgnitedSeeds` — regression guard for the exact 2026-04-09 scenario (5 tree-root terminal Shutdowns + 5 continuation seed Ignited events all at UT 72.94)
+- `StableSortPartEventsByUT_Static_NullInput_ReturnsEmptyList` / `SingleElement_ReturnsNewList` / `ClearThenCopyBack_WorksWithSmallLists` — aliasing regression guard (caught by `AppendCapturedDataTests` on the first fix iteration)
+
+All 5466 tests pass.
+
+**Observability:** `ResumeAfterFalseAlarm`'s log line continues to report the number removed. A new `Warn` fires if any saved terminal isn't found in `PartEvents` at resume time (`RemoveLastEmittedTerminals: N terminal event(s) not found`) — that's a canary for any future race condition that manages to drop a terminal between emit and resume.
+
+**Follow-up note:** The existing `StopRecordingForChainBoundary.partEventCountBeforeChainStop` field is now unused for its original purpose but kept as-is (not removed in this PR) for potential future use as a "where did the terminals originally land" reference point. Bug #281's `StableSortPartEventsByUT` instance method is preserved and still called from `FinalizeRecordingState`.
+
+**Status:** Fixed
+
+---
+
 ## ~~284. Cascading background-vessel splits create recordings for fragments-of-fragments (and tiny single-part debris)~~
 
 Surfaced by the post-PR-#167 Kerbal X investigation (worktree `Parsek-investigations`, branch `investigation/post-167-followups`). One Kerbal X launch produced **25 debris-related recording entries**: 15 real BgRecorder child recordings (most for single-part vessels living < 0.1 s) plus 10 empty-placeholder recordings (matching #285, originally tracked as #282 before the merge collision with PR #172).


### PR DESCRIPTION
## Summary

- Terminal `EngineShutdown` events (`part=\"unknown\"`) were surviving `ResumeAfterFalseAlarm`'s cleanup and ending up in committed recordings, causing ghost engine FX to turn off permanently after booster staging during playback. Observed in the 2026-04-09 Kerbal X playtest (`logs/2026-04-09_1117_kerbalx-rover`).
- **Root cause**: `ResumeAfterFalseAlarm`'s index-based `PartEvents.RemoveRange(partEventCountBeforeChainStop, N)` was brittle against five unstable `List<T>.Sort((a,b) => a.ut.CompareTo(b.ut))` call sites in flush/merge paths (`ParsekFlight` × 3, `RecordingOptimizer.MergeInto`, `SessionMerger.MergePartEvents`). An unstable sort could scramble same-UT events so a Shutdown ended up in an unexpected position, and the index-based removal would either leave the terminal in place or remove the wrong event.
- **Fix (two prongs)**:
  1. Content-based terminal removal — `FinalizeRecordingState` saves the exact terminal events it emitted; `ResumeAfterFalseAlarm` calls new `RemoveLastEmittedTerminals()` which matches each saved event against `PartEvents` by `(ut, pid, eventType, moduleIndex)` via new `FindTerminalEventIndex` helper. Robust against any sort reordering.
  2. Stable sort at all merge sites — new `FlightRecorder.StableSortPartEventsByUT(List<PartEvent>)` static overload wraps LINQ `OrderBy` (stable) and always returns a new list to prevent aliasing. All five `List.Sort` sites replaced with the Clear+AddRange pattern.

## Evidence

Committed recording `db2e7ab62c6847e0b439237a41172602.prec` had terminal `EngineShutdown` events with `part=\"unknown\"` at UT 72.40, 87.94, and 104.86 — and the KSP.log explicitly said they were removed (`ResumeAfterFalseAlarm: removed 5/3/3 orphaned terminal event(s)`). For pid=2527095907, no subsequent `EngineIgnited` event followed the 87.94 terminal, so its flame stayed off for the rest of playback. Tracked as bug #287 in `docs/dev/todo-and-known-bugs.md`.

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — all 5466 tests pass (up from 5456)
- [x] 10 new xUnit tests in `Bug287TerminalCleanupTests.cs`:
  - 4 pure `FindTerminalEventIndex` tests (null/empty/match/miss/first-occurrence)
  - `ResumeAfterFalseAlarm_ContentBasedRemoval_PreservesDecouplesAndRemovesTerminals` — end-to-end with real `EmitTerminalEngineAndRcsEvents`
  - `RemoveLastEmittedTerminals_SurvivesUnstableSortReordering` — adversarial shuffle proves content-based removal works even when the list is scrambled
  - `StableSort_TreeMergeAtSameUT_KeepsShutdownsBeforeIgnitedSeeds` — regression guard for the exact 2026-04-09 scenario
  - 3 aliasing regression guards (null → empty list, single element → new list, Clear+AddRange with small lists)
- [ ] In-game playtest with Kerbal X: stage all 6 boosters, watch ghost, verify Mainsail + booster flames stay lit through each staging event