### PR TITLE
Fix #291 + todo strikethrough cleanup + CHANGELOG consolidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,26 +21,16 @@ Dev notes: technical narratives for the fixes below live in `docs/dev/todo-and-k
 - Automatic rate-limited `[WARN]` when playback exceeds 8ms/frame or recording exceeds 4ms/frame.
 - New `ParsekLog.WarnRateLimited` API.
 
-### Maintenance
+### Bug Fixes & Maintenance
 
-- `#260` Removed dead `.pcrf` ghost geometry scaffolding — eliminates ~52 spurious "Missing sidecar file" warnings per diagnostics scan.
-- `#261` Diagnostics report now shows `Playback budget: N/A` when the rolling buffer has no in-window entries, instead of `0.0 ms avg`.
-- `#262` Diagnostics storage scan no longer emits "Missing sidecar file" warnings for recordings that legitimately have null snapshots.
-- `#264` follow-up: `StripEvaLadderState` no longer writes an invalid literal to the EVA FSM `state` field.
-- `#256` Capped slow-motion trajectory sampling so EVA-on-surface recordings no longer accumulate one point per physics frame; new `Min sample interval` slider in Settings (default 0.2 s).
-
-### Bug Fixes — Kerbal X Mun-flyby playtest (2026-04-10)
-
-- `#288` Ghost map icons now appear immediately after re-entry from orbit instead of requiring W (Watch) to be pressed first. The terminal orbit cache is now eagerly populated when recordings are loaded from disk.
-- `#289` End-of-mission spawn-at-end now correctly materializes splashed-down vessels and EVA kerbals after a rewind+merge. Vessel snapshots are refreshed on scene exit when the recording reached a stable terminal state, and the fresh snapshot is force-written to its sidecar so it survives the next OnLoad.
-- `#292` F9 quickload after a Tree Merge no longer silently drops recordings created during the merge. The quicksave is now refreshed automatically when the user clicks "Merge to Timeline".
-
-### Bug Fixes — KerbalX + Butterfly Rover playtest (2026-04-09)
-
+- `#291` EVA spawn walkback now correctly detects the active vessel (parent rocket) as a blocker, so kerbals walk back to a clear position instead of spawning on top of their parent vessel.
+- `#288` Ghost map icons now appear immediately after re-entry from orbit instead of requiring W (Watch) to be pressed first.
+- `#289` End-of-mission spawn-at-end now correctly materializes splashed-down vessels and EVA kerbals after a rewind+merge.
+- `#292` F9 quickload after a Tree Merge no longer silently drops recordings created during the merge.
 - `#287` Ghost engine flames on multi-stage rockets (Kerbal X Mainsail + boosters) no longer turn off permanently after booster staging.
 - `#278` EVA kerbals walking at the moment of revert/vessel-switch are now correctly classified Landed instead of Destroyed, so the merge dialog can spawn them at end of recording.
-- `#277` Stand-in crew is now placed correctly when a launch crew member was on EVA at merge time. Previously the EVA'd kerbal's stand-in was hired but never seated, leaving the command pod with the wrong roster.
-- `#284` Background debris recording capped at primary debris only — fragments of crashing boosters no longer spawn their own recordings. Cuts the recording count from ~25 to ~4-6 entries per Kerbal X launch.
+- `#277` Stand-in crew is now placed correctly when a launch crew member was on EVA at merge time.
+- `#284` Background debris recording capped at primary debris only — cuts the recording count from ~25 to ~4-6 entries per Kerbal X launch.
 - `#282` Landed ghost vessels and end-of-recording respawned vessels no longer clip into terrain.
 - `#280` Background debris recordings now persist their trajectory data across scene reloads.
 - `#281` Decouple events on mixed-symmetry stages are no longer lost when a terminal-event collision occurs at the same physics frame.
@@ -51,20 +41,8 @@ Dev notes: technical narratives for the fixes below live in `docs/dev/todo-and-k
 - `#275` Watch buttons in the Recordings Manager now show explanatory tooltips for every disabled state.
 - `#264` EVA kerbals spawn at their exact recorded walked position instead of on top of the parent vessel.
 - `#263` Ghost boosters are no longer left visible on the ghost after a symmetry-group decouple.
-- `#259` Orbital recordings now capture `TerminalOrbitBody` on every terminal-state path.
-- `#258` Non-chronological trajectory points from quickload mid-recording are trimmed.
-- `#257` Hyperbolic escape orbits no longer fail the `OrbitSegmentBodiesValid` in-game test.
-- Rover recordings no longer include a boring tail of stale chain-promotion seed events.
-- Ghost audio now mutes when the ESC pause menu is open.
-- Ghost camera cutoff persists across rewind and KSP restarts.
-
-### Bug Fixes — Quickload-resume recording (Bugs C, H, I) — PR #160
-
-- Quicksave + quickload during an active recording no longer fragments the mission, produces partial ghost orbits, or scatters crew across orphan recordings.
 - `#266` Switching to a distant vessel via the Tracking Station now preserves the in-progress mission tree instead of finalizing it on scene reload.
-
-### Bug Fixes — Mun Mission playtest
-
+- Quicksave + quickload during an active recording no longer fragments the mission, produces partial ghost orbits, or scatters crew across orphan recordings.
 - `#244` Ghost no longer stays icon-only for the entire Kerbin→Mun transfer.
 - `#246` EVA on an airless body no longer generates multiple "approach" segments.
 - `#248` EVA boarding is no longer misclassified as vessel destruction.
@@ -75,16 +53,24 @@ Dev notes: technical narratives for the fixes below live in `docs/dev/todo-and-k
 - `#249` Planted flags are now visible during ghost playback when the ghost is in the Beyond zone.
 - `#251` Recording phase label now updates after SOI change.
 - `#255` Engine FX no longer killed during ghost playback after a false-alarm booster decouple.
+- `#259` Orbital recordings now capture `TerminalOrbitBody` on every terminal-state path.
+- `#258` Non-chronological trajectory points from quickload mid-recording are trimmed.
+- `#257` Hyperbolic escape orbits no longer fail the `OrbitSegmentBodiesValid` in-game test.
+- `#260` Removed dead `.pcrf` ghost geometry scaffolding.
+- `#261` Diagnostics playback budget shows `N/A` instead of `0.0 ms` when no data available.
+- `#262` Diagnostics storage scan no longer warns about recordings with null snapshots.
+- `#264` follow-up: `StripEvaLadderState` no longer writes an invalid literal to the EVA FSM `state` field.
+- `#256` Capped slow-motion trajectory sampling; new `Min sample interval` slider in Settings (default 0.2 s).
+- `#252` Group hide checkbox now toggles all member recordings.
 - Ghost orbit line now suppressed below atmosphere for segment-based ghosts.
-
-### Maintenance
-
-- Bump version to 0.7.2.
+- Rover recordings no longer include stale chain-promotion seed events.
+- Ghost audio now mutes when the ESC pause menu is open.
+- Ghost camera cutoff persists across rewind and KSP restarts.
 - Closed `#156` (lifecycle test coverage — decision logic already extracted to pure/static methods with full coverage).
 - Closed `#188` (spawned surface vessels in map view are real KSP vessels, expected).
 - Deferred `#189b` (ghost escape orbit line) to Phase 11.5.
 - Deferred `T43` (mod compatibility testing) to the last phase of the roadmap.
-- UI: group hide checkbox now toggles all member recordings (`#252`).
+- Bump version to 0.7.2.
 
 ### In-Game Tests added
 

--- a/Source/Parsek/SpawnCollisionDetector.cs
+++ b/Source/Parsek/SpawnCollisionDetector.cs
@@ -518,11 +518,11 @@ namespace Parsek
         /// overlapping vessel's info, or overlap=false if no overlap found.
         /// </summary>
         internal static (bool overlap, float closestDistance, string blockerName, Vessel blockerVessel) CheckOverlapAgainstLoadedVessels(
-            Vector3d spawnWorldPos, Bounds spawnBounds, float padding)
+            Vector3d spawnWorldPos, Bounds spawnBounds, float padding, bool skipActiveVessel = true)
         {
             ParsekLog.Verbose(Tag,
                 $"CheckOverlapAgainstLoadedVessels: checking spawn at ({spawnWorldPos.x.ToString("F0", IC)},{spawnWorldPos.y.ToString("F0", IC)},{spawnWorldPos.z.ToString("F0", IC)}) " +
-                $"padding={padding.ToString("F1", IC)}m against {FlightGlobals.Vessels.Count} vessels");
+                $"padding={padding.ToString("F1", IC)}m against {FlightGlobals.Vessels.Count} vessels skipActiveVessel={skipActiveVessel}");
 
             bool anyOverlap = false;
             float closestDist = float.MaxValue;
@@ -535,8 +535,10 @@ namespace Parsek
                 if (!other.loaded) continue;
                 if (GhostMapPresence.IsGhostMapVessel(other.persistentId)) continue;
 
-                // Skip player's own vessel — shouldn't block spawns
-                if (other == FlightGlobals.ActiveVessel) continue;
+                // Skip player's own vessel — shouldn't block non-EVA spawns.
+                // EVA spawns need to detect the parent vessel (active vessel) as a
+                // blocker so the walkback can find a clear position. (#291)
+                if (skipActiveVessel && other == FlightGlobals.ActiveVessel) continue;
 
                 // Skip non-significant vessel types that shouldn't block spawns
                 if (ShouldSkipVesselType(other.vesselType))

--- a/Source/Parsek/SpawnCollisionDetector.cs
+++ b/Source/Parsek/SpawnCollisionDetector.cs
@@ -522,7 +522,7 @@ namespace Parsek
         {
             ParsekLog.Verbose(Tag,
                 $"CheckOverlapAgainstLoadedVessels: checking spawn at ({spawnWorldPos.x.ToString("F0", IC)},{spawnWorldPos.y.ToString("F0", IC)},{spawnWorldPos.z.ToString("F0", IC)}) " +
-                $"padding={padding.ToString("F1", IC)}m against {FlightGlobals.Vessels.Count} vessels skipActiveVessel={skipActiveVessel}");
+                $"padding={padding.ToString("F1", IC)}m against {FlightGlobals.Vessels.Count} vessels, skipActiveVessel={skipActiveVessel}");
 
             bool anyOverlap = false;
             float closestDist = float.MaxValue;

--- a/Source/Parsek/VesselSpawner.cs
+++ b/Source/Parsek/VesselSpawner.cs
@@ -490,8 +490,12 @@ namespace Parsek
                 ParsekLog.VerboseRateLimited("Spawner", "eva-bounds-" + index,
                     $"CheckSpawnCollisions: EVA bounds={spawnBounds.size} for #{index} ({rec.VesselName})");
             }
+            // EVA spawns must detect the active vessel (parent rocket) as a blocker
+            // so walkback can find a clear position (#291). Non-EVA spawns skip it
+            // to avoid the player's vessel blocking its own recording's spawn.
+            bool skipActive = !isEva;
             var (overlap, overlapDist, blockerName, blockerVessel) =
-                SpawnCollisionDetector.CheckOverlapAgainstLoadedVessels(spawnPos, spawnBounds, 5f);
+                SpawnCollisionDetector.CheckOverlapAgainstLoadedVessels(spawnPos, spawnBounds, 5f, skipActive);
             if (overlap)
             {
                 // Precedence: duplicate-blocker-recovery FIRST (#112), walkback SECOND (#264).
@@ -515,7 +519,7 @@ namespace Parsek
 
                     // Re-check overlap after recovery — another vessel may still block
                     var (stillOverlap, recheckDist, recheckName, _) =
-                        SpawnCollisionDetector.CheckOverlapAgainstLoadedVessels(spawnPos, spawnBounds, 5f);
+                        SpawnCollisionDetector.CheckOverlapAgainstLoadedVessels(spawnPos, spawnBounds, 5f, skipActive);
                     if (!stillOverlap)
                     {
                         // Blocker removed, no other overlap — fall through to spawn at original position
@@ -602,6 +606,8 @@ namespace Parsek
                 return false;
             }
 
+            // EVA spawns must detect the active vessel as a blocker (#291)
+            bool skipActive = string.IsNullOrEmpty(rec.EvaCrewName);
             var walkResult = SpawnCollisionDetector.WalkbackAlongTrajectorySubdivided(
                 rec.Points,
                 body.Radius,
@@ -610,7 +616,7 @@ namespace Parsek
                 worldPos =>
                 {
                     var (ov, _, _, _) = SpawnCollisionDetector.CheckOverlapAgainstLoadedVessels(
-                        worldPos, spawnBounds, 5f);
+                        worldPos, spawnBounds, 5f, skipActive);
                     return ov;
                 });
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -41,7 +41,7 @@ Recommended: combine (1) for prevention + (2) for recovery of saves already affe
 
 ---
 
-## 291. In-game test failure: `FlightIntegrationTests.EvaSpawnWalkbackOnOverlap`
+## ~~291. In-game test failure: `FlightIntegrationTests.EvaSpawnWalkbackOnOverlap`~~
 
 `parsek-test-results.txt` (run 2026-04-10 01:05:19, scene FLIGHT) reports:
 
@@ -50,13 +50,13 @@ FAIL  FlightIntegrationTests.EvaSpawnWalkbackOnOverlap (48.5ms)
       Expected 'WalkbackSubdivided: cleared' log line during spawn
 ```
 
-The test expects an EVA-spawned ghost to log `WalkbackSubdivided: cleared` when its position overlaps with another ghost. Either the walkback subdivision code path isn't running, OR the log line was renamed/removed and the test wasn't updated.
+The test places the EVA trajectory endpoint on top of the active vessel, expecting the walkback to detect the overlap and walk backward. But `CheckOverlapAgainstLoadedVessels` unconditionally skipped `FlightGlobals.ActiveVessel` (line 539), so no overlap was detected, walkback never triggered, and the log assertion failed. The kerbal spawned directly on the parent vessel and KSP physics pushed them apart, which is why the distance assertions still passed.
 
-Total: 117 / Passed: 98 / Failed: 1 / Skipped: 16. All other categories pass.
+**Root cause:** `CheckOverlapAgainstLoadedVessels` had an unconditional `if (other == FlightGlobals.ActiveVessel) continue;` skip. For non-EVA spawns this is correct (the player's vessel shouldn't block its own recording's spawn). For EVA spawns, the active vessel IS the parent rocket — the most common overlap target.
 
-**Investigation needed**: read `FlightIntegrationTests.EvaSpawnWalkbackOnOverlap` source, check the spawn walkback subdivision path in `ParsekPlaybackPolicy` / `VesselSpawner`, see whether the expected log line is still emitted.
+**Fix:** Added `bool skipActiveVessel = true` parameter to `CheckOverlapAgainstLoadedVessels`. `VesselSpawner.CheckSpawnCollisions` passes `skipActiveVessel: false` when `isEva` is true (initial check + post-recovery re-check). `TryWalkbackForEndOfRecordingSpawn` also passes `skipActiveVessel: false` for EVA recordings in the per-sub-step overlap lambda. All other callers (VesselGhoster, in-game tests) use the default `true` — no behavior change.
 
-**Status**: Open.
+**Status**: Fixed.
 
 ---
 
@@ -329,7 +329,7 @@ Source: `SessionMerger.MergeTree`'s diagnostic that compares the last frame of s
 
 ---
 
-## 286. Full-tree crash leaves nothing to continue with — `CanPersistVessel` blocks all `Destroyed` leaves
+## 286. Full-tree crash leaves nothing to continue with — `CanPersistVessel` blocks all `Destroyed` leaves (largely mitigated)
 
 Surfaced as the user-facing complaint behind bug #278 ("nothing to continue playing with after a crash recording"). #278's snapshot-loss fix restores the in-memory `hasSnapshot=True` state for background-split debris, but the merge dialog's `CanPersistVessel` predicate at `MergeDialog.cs:450-467` hard-blocks any leaf whose `TerminalStateValue ∈ {Destroyed, Recovered, Docked, Boarded}` regardless of snapshot availability. When the player crashes the entire launch tree (root vessel + all debris destroyed), every leaf falls into one of those gated states, the merge dialog reports `spawnable=0`, and no vessel ends up on the surface for the player to continue with.
 
@@ -346,7 +346,9 @@ Bob Kerman EVA in the 2026-04-09 playtest log line 11548 illustrates the gating 
 - For option (a), enumerate the failure modes: what if the F5 is from a different vessel, a different scene, or there's no F5 at all?
 - For option (b), enumerate the safety net: terrain clamping, orbital validity checks, attitude reset, fuel restoration. This is a lot of new code.
 
-**Priority:** Medium. The user explicitly raised this as the headline complaint behind #278. #278's fix closes the technical bug but does not resolve the user complaint. Reaching a decision is more important than the implementation effort.
+**Update (2026-04-10 investigation):** The `spawnable=0` cases in the 2026-04-09 playtests were primarily caused by #278's blanket `Destroyed` stamping, not by a true all-crash scenario. With #278 fixed (PR #173/#176 — `FinalizeIndividualRecording` now uses real vessel `situation`) and #284 shipped (PR #173 — cascade cap reduces debris from ~25 to ~4-6), the current KSP.log shows `spawnable=6-8` for the same Kerbal X launch. Debris that is still SubOrbital at merge time is now correctly labeled `canPersist=True`. The remaining edge case is a genuine full-tree crash where ALL parts are destroyed before merge — rare in practice and arguably correct behavior (`spawnable=0` when everything is truly gone).
+
+**Priority:** Low (downgraded from Medium). The original user complaint is resolved by #278/#284. The remaining scenario (everything truly destroyed) is a design decision for option (c) UX messaging, not an urgent fix.
 
 ---
 
@@ -525,7 +527,7 @@ Engine plates (`EnginePlate1` etc.) have protective covers (interstage fairings)
 
 **Status:** Fixed
 
-## 132. Policy RunSpawnDeathChecks and FlushDeferredSpawns are TODO stubs
+## ~~132. Policy RunSpawnDeathChecks and FlushDeferredSpawns are TODO stubs~~
 
 `RunSpawnDeathChecks()` now iterates committed recordings each frame, checks if spawned vessel PIDs still exist via `FlightRecorder.FindVesselByPid`, increments `SpawnDeathCount` on death, and either resets for re-spawn or abandons after `MaxSpawnDeathCycles`. New pure predicate `ShouldCheckForSpawnDeath` in `GhostPlaybackLogic`.
 
@@ -533,7 +535,7 @@ Engine plates (`EnginePlate1` etc.) have protective covers (interstage fairings)
 
 **Status:** Fixed
 
-## 133. Forwarding properties in ParsekFlight add ~500 lines of indirection
+## ~~133. Forwarding properties in ParsekFlight add ~500 lines of indirection~~
 
 After T25 extraction, ParsekFlight still has forwarding properties (`ghostStates => engine.ghostStates`, `overlapGhosts => engine.overlapGhosts`, etc.) and bridge methods that external callers (scene change, camera follow, delete, preview) use.
 
@@ -666,7 +668,7 @@ Two compounding issues: (1) `TerminalOrbitBody` is null on all recordings at loa
 
 **Status:** Fixed
 
-## 218. Crash breakup debris not recorded when recorder tears down before coalescer
+## ~~218. Crash breakup debris not recorded when recorder tears down before coalescer~~
 
 When a vessel crashes during an active recording, the recorder is stopped and committed before the coalescer's 0.5s window elapses. By the time the coalescer emits the BREAKUP event, there is no active tree or recorder to attach it to. The main vessel recording is saved but the crash debris tree structure is lost.
 
@@ -1026,7 +1028,7 @@ The adaptive sampler had no minimum interval floor, only a max-interval backstop
 
 **Status:** Fixed
 
-## 257. Orbit segment with negative SMA (hyperbolic escape)
+## ~~257. Orbit segment with negative SMA (hyperbolic escape)~~
 
 In-game test `OrbitSegmentBodiesValid` fails: "Orbit segment for 'Mun' has non-positive SMA=-931047.895195401". Negative SMA is physically correct for hyperbolic orbits (eccentricity > 1) but the test asserts positive SMA.
 
@@ -1036,7 +1038,7 @@ In-game test `OrbitSegmentBodiesValid` fails: "Orbit segment for 'Mun' has non-p
 
 **Status:** Fixed
 
-## 258. Non-chronological trajectory points in recording
+## ~~258. Non-chronological trajectory points in recording~~
 
 In-game test `CommittedRecordingsHaveValidData` fails: recording `ab105395ae5547b0b70c1eb9bb41ca9f` (Bob Kerman EVA) has point 159 UT going backward by ~33 seconds. Trajectory points should be monotonically increasing in UT.
 
@@ -1046,7 +1048,7 @@ In-game test `CommittedRecordingsHaveValidData` fails: recording `ab105395ae5547
 
 **Status:** Fixed (prospective — existing corrupted recording data will still fail; fix prevents recurrence)
 
-## 259. Orbital recordings missing TerminalOrbitBody
+## ~~259. Orbital recordings missing TerminalOrbitBody~~
 
 In-game test `OrbitalRecordingsHaveTerminalOrbit` reports 4 orbital recordings without `TerminalOrbitBody` set. This is a regression guard for #203/#219.
 


### PR DESCRIPTION
## Summary
- **#291 fix**: `CheckOverlapAgainstLoadedVessels` unconditionally skipped active vessel, preventing EVA walkback from detecting the parent rocket as a blocker. Added `skipActiveVessel` parameter; EVA spawns now include the active vessel in overlap checks.
- **6 missing strikethroughs**: #132, #133, #218, #257, #258, #259 all had `Status: Fixed` but headers lacked `~~strikethrough~~`.
- **#286 investigation update**: largely mitigated by #278/#284, downgraded to Low priority.
- **CHANGELOG**: merged separate Bug Fixes subsections and both Maintenance sections into a single `Bug Fixes & Maintenance` section.

## Test plan
- [x] All 5470 unit tests pass
- [ ] In-game: run `EvaSpawnWalkbackOnOverlap` via Ctrl+Shift+T — should now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)