### PR TITLE
Fix #196: Position ghost icon popup at cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,15 +28,11 @@ Dev notes: technical narratives for the fixes below live in `docs/dev/todo-and-k
 - `#262` Diagnostics storage scan no longer emits "Missing sidecar file" warnings for recordings that legitimately have null snapshots.
 - `#264` follow-up: `StripEvaLadderState` no longer writes an invalid literal to the EVA FSM `state` field.
 - `#256` Capped slow-motion trajectory sampling so EVA-on-surface recordings no longer accumulate one point per physics frame; new `Min sample interval` slider in Settings (default 0.2 s).
-
 - `#285` Background vessel splits no longer create empty parent-continuation recordings when the parent vessel is already destroyed.
-
-### Bug Fixes
-
-- **Fix ghost icon popup appearing at screen center instead of near cursor (#196).** Matched KSP's stock `MapContextMenu` positioning pattern: (0,0) anchors, forced layout rebuild, and `AnchorOffset` so the menu opens below the click point.
 
 ### Bug Fixes — Kerbal X Mun-flyby playtest (2026-04-10)
 
+- **Fix ghost icon popup appearing at screen center instead of near cursor (#196).** Matched KSP's stock `MapContextMenu` positioning pattern: (0,0) anchors, forced layout rebuild, and `AnchorOffset` so the menu opens below the click point.
 - `#288` Ghost map icons now appear immediately after re-entry from orbit instead of requiring W (Watch) to be pressed first. The terminal orbit cache is now eagerly populated when recordings are loaded from disk.
 - `#289` End-of-mission spawn-at-end now correctly materializes splashed-down vessels and EVA kerbals after a rewind+merge. Vessel snapshots are refreshed on scene exit when the recording reached a stable terminal state, and the fresh snapshot is force-written to its sidecar so it survives the next OnLoad.
 - `#292` F9 quickload after a Tree Merge no longer silently drops recordings created during the merge. The quicksave is now refreshed automatically when the user clicks "Merge to Timeline".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ Dev notes: technical narratives for the fixes below live in `docs/dev/todo-and-k
 
 - `#285` Background vessel splits no longer create empty parent-continuation recordings when the parent vessel is already destroyed.
 
+### Bug Fixes
+
+- **Fix ghost icon popup appearing at screen center instead of near cursor (#196).** Matched KSP's stock `MapContextMenu` positioning pattern: (0,0) anchors, forced layout rebuild, and `AnchorOffset` so the menu opens below the click point.
+
 ### Bug Fixes — Kerbal X Mun-flyby playtest (2026-04-10)
 
 - `#288` Ghost map icons now appear immediately after re-entry from orbit instead of requiring W (Watch) to be pressed first. The terminal orbit cache is now eagerly populated when recordings are loaded from disk.

--- a/Source/Parsek/Patches/GhostVesselLoadPatch.cs
+++ b/Source/Parsek/Patches/GhostVesselLoadPatch.cs
@@ -1,7 +1,9 @@
 using System.Reflection;
 using CommNet;
 using HarmonyLib;
+using KSP.UI.Screens.Mapview;
 using UnityEngine;
+using UnityEngine.UI;
 
 namespace Parsek.Patches
 {
@@ -110,35 +112,35 @@ namespace Parsek.Patches
                 }, dismissOnSelect: true)
             };
 
-            // Anchors at (0.5,0.5) = screen center. SpawnPopupDialog forces
-            // localPosition=zero, placing the dialog at center. We then offset
-            // via CanvasUtil.ScreenToUISpacePos which converts screen pixels to
-            // canvas-center-relative coordinates (matching the 0.5/0.5 anchor).
+            // Anchors at (0,0) — matches KSP's MapContextMenu pattern (#196).
+            // SpawnPopupDialog forces localPosition=zero after setting anchors;
+            // we reposition immediately after using the same approach as stock.
             currentGhostMenu = PopupDialog.SpawnPopupDialog(
-                new Vector2(0.5f, 0.5f), new Vector2(0.5f, 0.5f),
+                Vector2.zero, Vector2.zero,
                 new MultiOptionDialog("GhostIconMenu", "", vesselName,
                     HighLogic.UISkin, 160f, options),
                 persistAcrossScenes: false, skin: HighLogic.UISkin);
 
-            // Reposition to mouse cursor using KSP's canvas coordinate conversion
+            // Reposition to mouse cursor (#196) — mirrors MapContextMenu.SetupTransform:
+            // force layout rebuild first so the popup has its final size, then convert
+            // screen coords to canvas-local and offset downward so menu opens below cursor.
             if (currentGhostMenu != null)
             {
+                currentGhostMenu.SetDraggable(false);
                 var rt = currentGhostMenu.GetComponent<RectTransform>();
-                if (rt != null && rt.parent != null)
+                if (rt != null)
                 {
-                    // ScreenToUISpacePos converts screen pixels to canvas-local coords
-                    // where (0,0) = canvas center — matches our (0.5,0.5) anchor
-                    bool zPositive;
-                    var canvasRect = rt.parent.GetComponent<RectTransform>()
-                                    ?? rt.root.GetComponent<RectTransform>();
+                    LayoutRebuilder.ForceRebuildLayoutImmediate(rt);
+                    RectTransform canvasRect = MapViewCanvasUtil.MapViewCanvasRect;
                     if (canvasRect != null)
                     {
                         Vector3 uiPos = CanvasUtil.ScreenToUISpacePos(
-                            Input.mousePosition, canvasRect, out zPositive);
+                            Input.mousePosition, canvasRect, out bool zPositive);
+                        uiPos = CanvasUtil.AnchorOffset(uiPos, rt, Vector2.down);
                         rt.localPosition = uiPos;
                         ParsekLog.Verbose("GhostMap",
-                            $"Popup repositioned: screen=({Input.mousePosition.x:F0},{Input.mousePosition.y:F0}) " +
-                            $"canvas=({uiPos.x:F0},{uiPos.y:F0}) canvasSize=({canvasRect.sizeDelta.x:F0},{canvasRect.sizeDelta.y:F0})");
+                            $"Popup positioned at cursor: screen=({Input.mousePosition.x:F0},{Input.mousePosition.y:F0}) " +
+                            $"canvas=({uiPos.x:F0},{uiPos.y:F0})");
                     }
                 }
             }

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -644,11 +644,15 @@ After booster separation, 3 of 4 boosters correctly have W disabled, but one sta
 
 **Status:** Fixed
 
-## 196. Ghost icon popup window should appear next to cursor
+## ~~196. Ghost icon popup window should appear next to cursor~~
 
 The popup spawned via `PopupDialog.SpawnPopupDialog` consistently appears at screen center despite attempts to reposition. KSP's `SpawnPopupDialog` forces `localPosition=Vector3.zero` after anchor setup. Need to use the same approach as KSP's `MapContextMenu`: anchor at (0,0), then set `localPosition` via `CanvasUtil.ScreenToUISpacePos`.
 
-**Status:** TODO — deferred
+**Root cause:** Three compounding issues: (1) anchors at (0.5, 0.5) meant `localPosition=zero` placed the popup at screen center, and subsequent positioning was relative to center instead of a stable origin. (2) Missing `LayoutRebuilder.ForceRebuildLayoutImmediate` — without forcing layout completion before setting position, Unity's end-of-frame layout pass could reset the position. (3) Wrong canvas rect — code used the PopupDialogCanvas parent rect instead of `MapViewCanvasUtil.MapViewCanvasRect` (the main UI canvas), and missed `CanvasUtil.AnchorOffset` to push the menu below the click point.
+
+**Fix:** Matched KSP's stock `MapContextMenu.SetupTransform` pattern: (0,0) anchors, `SetDraggable(false)`, `ForceRebuildLayoutImmediate` before positioning, `ScreenToUISpacePos` with `MapViewCanvasUtil.MapViewCanvasRect`, `AnchorOffset` with `Vector2.down` so the menu opens below the cursor. Edge-clamping (popup near screen edge) is a known cosmetic limitation matching stock behavior — not addressed here.
+
+**Status:** Fixed
 
 ## ~~203. Green dot ghost markers at wrong positions near Mun after scene reload~~
 


### PR DESCRIPTION
## Summary

- Ghost icon context menu (Focus / Set As Target / Watch) in map view now appears next to the mouse cursor instead of at screen center
- Matched KSP's stock `MapContextMenu.SetupTransform` positioning pattern: `(0,0)` anchors, `ForceRebuildLayoutImmediate`, `MapViewCanvasUtil.MapViewCanvasRect`, and `AnchorOffset(Vector2.down)`
- Root cause: three compounding issues — wrong anchors `(0.5,0.5)`, missing layout rebuild, wrong canvas rect

## Test plan

- [x] Open map view in flight, click a ghost vessel icon — popup should appear at/below the cursor, not at screen center
- [x] Click multiple ghost icons in sequence — each popup should dismiss the previous and appear at the new cursor position
- [x] Click outside the popup — should dismiss
- [x] Verify Focus, Set As Target, Watch buttons still work correctly
- [x] `dotnet test` — 5473 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)