### PR TITLE
Fix destroyed EVA kerbals, blocked rewind, and crew reservation (#295-297)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,9 +41,12 @@ Dev notes: technical narratives for the fixes below live in `docs/dev/todo-and-k
 - `#288` Ghost map icons now appear immediately after re-entry from orbit instead of requiring W (Watch) to be pressed first.
 - `#289` End-of-mission spawn-at-end now correctly materializes splashed-down vessels and EVA kerbals after a rewind+merge.
 - `#292` F9 quickload after a Tree Merge no longer silently drops recordings created during the merge.
-- `#290` Pending Limbo tree no longer discarded on revert — fixes lost debris recordings and missing proto vessels after merge-then-revert.
-- `#290` Ghost engine skirt/shroud now hidden at build time when the snapshot shows the shroud was already jettisoned.
-- `#290` Ghost map icon no longer flickers during time warp — zone warp exemption threshold lowered from >4x to >1x, and ghost warp suppression is now skipped in map view so icons stay visible at any warp speed.
+- `#295` Rewind buttons no longer blocked by "Merge or discard pending recording first" after a tree merge — pending standalone recordings are auto-committed.
+- `#296` EVA kerbal crew end states now correctly inferred (previously showed Unknown with infinite reservation because snapshot crew extraction fails for EVA vessels).
+- `#297` Phantom terrain crash detection: EVA kerbals destroyed by KSP's pack-time terrain collision within 5s of a safe (Landed/Splashed) state are classified as Landed instead of Destroyed.
+- `#290a` Pending Limbo tree no longer discarded on revert — fixes lost debris recordings and missing proto vessels after merge-then-revert.
+- `#290b` Ghost engine skirt/shroud now hidden at build time when the snapshot shows the shroud was already jettisoned.
+- `#290c` Ghost map icon no longer flickers during time warp — zone warp exemption threshold lowered from >4x to >1x, and ghost warp suppression is now skipped in map view so icons stay visible at any warp speed.
 - `#287` Ghost engine flames on multi-stage rockets (Kerbal X Mainsail + boosters) no longer turn off permanently after booster staging.
 - `#278` EVA kerbals walking at the moment of revert/vessel-switch are now correctly classified Landed instead of Destroyed, so the merge dialog can spawn them at end of recording.
 - `#277` Stand-in crew is now placed correctly when a launch crew member was on EVA at merge time.

--- a/Source/Parsek.Tests/FlightRecorderExtractedTests.cs
+++ b/Source/Parsek.Tests/FlightRecorderExtractedTests.cs
@@ -529,5 +529,82 @@ namespace Parsek.Tests
         }
 
         #endregion
+
+        #region IsPhantomTerrainCrash
+
+        [Fact]
+        public void PhantomCrash_LandedEvaPacked_ReturnsTrue()
+        {
+            bool result = ParsekFlight.IsPhantomTerrainCrash(
+                "Bill Kerman", packUT: 100.0, destructionUT: 101.5,
+                Vessel.Situations.LANDED);
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void PhantomCrash_SplashedEvaPacked_ReturnsTrue()
+        {
+            bool result = ParsekFlight.IsPhantomTerrainCrash(
+                "Bill Kerman", packUT: 100.0, destructionUT: 103.0,
+                Vessel.Situations.SPLASHED);
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void PhantomCrash_FlyingPrePack_ReturnsFalse()
+        {
+            bool result = ParsekFlight.IsPhantomTerrainCrash(
+                "Bill Kerman", packUT: 100.0, destructionUT: 101.0,
+                Vessel.Situations.FLYING);
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void PhantomCrash_NonEva_ReturnsFalse()
+        {
+            bool result = ParsekFlight.IsPhantomTerrainCrash(
+                null, packUT: 100.0, destructionUT: 101.0,
+                Vessel.Situations.LANDED);
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void PhantomCrash_EmptyEvaName_ReturnsFalse()
+        {
+            bool result = ParsekFlight.IsPhantomTerrainCrash(
+                "", packUT: 100.0, destructionUT: 101.0,
+                Vessel.Situations.LANDED);
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void PhantomCrash_ElapsedOverThreshold_ReturnsFalse()
+        {
+            bool result = ParsekFlight.IsPhantomTerrainCrash(
+                "Bill Kerman", packUT: 100.0, destructionUT: 106.0,
+                Vessel.Situations.LANDED);
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void PhantomCrash_ExactlyAtThreshold_ReturnsFalse()
+        {
+            // 5.0s is the boundary — >= 5.0 should return false
+            bool result = ParsekFlight.IsPhantomTerrainCrash(
+                "Bill Kerman", packUT: 100.0, destructionUT: 105.0,
+                Vessel.Situations.LANDED);
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void PhantomCrash_JustUnderThreshold_ReturnsTrue()
+        {
+            bool result = ParsekFlight.IsPhantomTerrainCrash(
+                "Bill Kerman", packUT: 100.0, destructionUT: 104.99,
+                Vessel.Situations.LANDED);
+            Assert.True(result);
+        }
+
+        #endregion
     }
 }

--- a/Source/Parsek.Tests/KerbalEndStateTests.cs
+++ b/Source/Parsek.Tests/KerbalEndStateTests.cs
@@ -482,5 +482,78 @@ namespace Parsek.Tests
         }
 
         #endregion
+
+        #region PopulateCrewEndStates — EVA fallback
+
+        [Fact]
+        public void PopulateCrewEndStates_EvaKerbalDestroyed_InfersDead()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "eva-bill",
+                VesselName = "Bill Kerman",
+                EvaCrewName = "Bill Kerman",
+                TerminalStateValue = TerminalState.Destroyed,
+                // No crew in GhostVisualSnapshot (EVA ConfigNode has no PART/crew)
+                GhostVisualSnapshot = new ConfigNode("VESSEL"),
+            };
+
+            KerbalsModule.PopulateCrewEndStates(rec);
+
+            Assert.NotNull(rec.CrewEndStates);
+            Assert.True(rec.CrewEndStates.ContainsKey("Bill Kerman"));
+            Assert.Equal(KerbalEndState.Dead, rec.CrewEndStates["Bill Kerman"]);
+            Assert.Contains(logLines, l => l.Contains("Bill Kerman") && l.Contains("Dead"));
+        }
+
+        [Fact]
+        public void PopulateCrewEndStates_EvaKerbalLanded_InfersAboard()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "eva-bill-landed",
+                VesselName = "Bill Kerman",
+                EvaCrewName = "Bill Kerman",
+                TerminalStateValue = TerminalState.Landed,
+                GhostVisualSnapshot = new ConfigNode("VESSEL"),
+                // VesselSnapshot with the kerbal "still aboard" (in snapshot = aboard)
+                VesselSnapshot = MakeSnapshotWithCrew("Bill Kerman"),
+            };
+
+            KerbalsModule.PopulateCrewEndStates(rec);
+
+            Assert.NotNull(rec.CrewEndStates);
+            Assert.True(rec.CrewEndStates.ContainsKey("Bill Kerman"));
+            Assert.Equal(KerbalEndState.Aboard, rec.CrewEndStates["Bill Kerman"]);
+        }
+
+        [Fact]
+        public void PopulateCrewEndStates_NoEvaCrewName_SkipsEmptyCrew()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "no-eva",
+                VesselName = "Mystery Ship",
+                // No EvaCrewName, no crew in snapshot
+                GhostVisualSnapshot = new ConfigNode("VESSEL"),
+            };
+
+            KerbalsModule.PopulateCrewEndStates(rec);
+
+            Assert.Null(rec.CrewEndStates);
+            Assert.Contains(logLines, l => l.Contains("no crew in ghost snapshot"));
+        }
+
+        private static ConfigNode MakeSnapshotWithCrew(params string[] crewNames)
+        {
+            var vessel = new ConfigNode("VESSEL");
+            var part = new ConfigNode("PART");
+            foreach (var name in crewNames)
+                part.AddValue("crew", name);
+            vessel.AddNode(part);
+            return vessel;
+        }
+
+        #endregion
     }
 }

--- a/Source/Parsek.Tests/RecordingOptimizerTests.cs
+++ b/Source/Parsek.Tests/RecordingOptimizerTests.cs
@@ -2282,5 +2282,37 @@ namespace Parsek.Tests
         }
 
         #endregion
+
+        #region SplitAtSection — EVA field propagation
+
+        [Fact]
+        public void SplitAtSection_PropagatesEvaCrewName()
+        {
+            var rec = MakeRecordingWithSections(17000, 17030, 17060,
+                SegmentEnvironment.SurfaceMobile, SegmentEnvironment.Atmospheric);
+            rec.EvaCrewName = "Bill Kerman";
+            rec.ParentRecordingId = "parent-abc";
+            var second = RecordingOptimizer.SplitAtSection(rec, 1);
+
+            Assert.Equal("Bill Kerman", rec.EvaCrewName);
+            Assert.Equal("Bill Kerman", second.EvaCrewName);
+            Assert.Equal("parent-abc", rec.ParentRecordingId);
+            Assert.Equal("parent-abc", second.ParentRecordingId);
+        }
+
+        [Fact]
+        public void SplitAtSection_NullEvaFieldsStayNull()
+        {
+            var rec = MakeRecordingWithSections(17000, 17030, 17060,
+                SegmentEnvironment.SurfaceMobile, SegmentEnvironment.Atmospheric);
+            var second = RecordingOptimizer.SplitAtSection(rec, 1);
+
+            Assert.Null(rec.EvaCrewName);
+            Assert.Null(second.EvaCrewName);
+            Assert.Null(rec.ParentRecordingId);
+            Assert.Null(second.ParentRecordingId);
+        }
+
+        #endregion
     }
 }

--- a/Source/Parsek/GameActions/LedgerOrchestrator.cs
+++ b/Source/Parsek/GameActions/LedgerOrchestrator.cs
@@ -114,7 +114,7 @@ namespace Parsek
             // 3b. Populate crew end states before action creation so KerbalEndStateField is correct
             var recForEndStates = FindRecordingById(recordingId);
             if (recForEndStates != null && recForEndStates.CrewEndStates == null
-                && recForEndStates.VesselSnapshot != null)
+                && (recForEndStates.VesselSnapshot != null || !string.IsNullOrEmpty(recForEndStates.EvaCrewName)))
                 KerbalsModule.PopulateCrewEndStates(recForEndStates);
 
             // 3c. Generate KerbalAssignment actions from vessel crew data
@@ -356,6 +356,9 @@ namespace Parsek
             // Prefer GhostVisualSnapshot (recording-start crew), fall back to VesselSnapshot
             var snapshot = rec.GhostVisualSnapshot ?? rec.VesselSnapshot;
             var names = CrewReservationManager.ExtractCrewFromSnapshot(snapshot);
+            // EVA fallback: snapshot crew extraction returns empty for EVA vessels
+            if (names.Count == 0 && !string.IsNullOrEmpty(rec.EvaCrewName))
+                names.Add(rec.EvaCrewName);
             if (names.Count == 0) return result;
 
             for (int i = 0; i < names.Count; i++)

--- a/Source/Parsek/KerbalsModule.cs
+++ b/Source/Parsek/KerbalsModule.cs
@@ -373,6 +373,12 @@ namespace Parsek
             // Extract starting crew from ghost visual snapshot (recording-start state)
             var startingCrew = CrewReservationManager.ExtractCrewFromSnapshot(rec.GhostVisualSnapshot);
 
+            // EVA kerbals: the vessel IS the kerbal. Snapshot crew extraction returns
+            // empty because EVA ConfigNode structure has no PART/crew values.
+            // Fall back to the EvaCrewName field set at branch time.
+            if (startingCrew.Count == 0 && !string.IsNullOrEmpty(rec.EvaCrewName))
+                startingCrew.Add(rec.EvaCrewName);
+
             if (startingCrew.Count == 0)
             {
                 ParsekLog.Verbose(Tag,

--- a/Source/Parsek/MergeDialog.cs
+++ b/Source/Parsek/MergeDialog.cs
@@ -365,6 +365,21 @@ namespace Parsek
                         "merge dialog Tree Merge", tree.Recordings.Count);
                     LedgerOrchestrator.NotifyLedgerTreeCommitted(tree);
                     CrewReservationManager.SwapReservedCrewInFlight();
+
+                    // Auto-commit any pending standalone recording so it doesn't
+                    // block rewind with "Merge or discard pending recording first".
+                    if (RecordingStore.HasPending)
+                    {
+                        ParsekScenario.AutoCommitGhostOnly(RecordingStore.Pending);
+                        string saRecId = RecordingStore.Pending.RecordingId;
+                        double saStartUT = RecordingStore.Pending.StartUT;
+                        double saEndUT = RecordingStore.Pending.EndUT;
+                        RecordingStore.CommitPending();
+                        LedgerOrchestrator.OnRecordingCommitted(saRecId, saStartUT, saEndUT);
+                        ParsekLog.Info("MergeDialog",
+                            $"Auto-committed pending standalone '{saRecId}' during tree merge");
+                    }
+
                     ClearPendingFlag();
                     ReplayFlightResultsIfPending();
                     OnTreeCommitted?.Invoke();

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -304,6 +304,7 @@ namespace Parsek
 
         // Phantom terrain crash detection: tracks pre-pack vessel state.
         // Key: vessel PID, Value: (packUT, pre-pack situation).
+        const double PhantomCrashWindowSeconds = 5.0;
         readonly Dictionary<uint, (double packUT, Vessel.Situations situation)> packStates
             = new Dictionary<uint, (double, Vessel.Situations)>();
 
@@ -781,6 +782,7 @@ namespace Parsek
             }
 
             UnregisterGameEvents();
+            packStates.Clear();
 
             // Restore debris persistence if still overridden
             RestoreDebrisPersistence();
@@ -3335,7 +3337,7 @@ namespace Parsek
                         || prePackSituation == Vessel.Situations.SPLASHED;
             if (!wasSafe) return false;
             double elapsed = destructionUT - packUT;
-            return elapsed >= 0 && elapsed < 5.0;
+            return elapsed >= 0 && elapsed < PhantomCrashWindowSeconds;
         }
 
         /// <summary>

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -302,6 +302,11 @@ namespace Parsek
         // Docking race condition guard (Task 5 sets, Task 6 checks)
         internal HashSet<uint> dockingInProgress = new HashSet<uint>();
 
+        // Phantom terrain crash detection: tracks pre-pack vessel state.
+        // Key: vessel PID, Value: (packUT, pre-pack situation).
+        readonly Dictionary<uint, (double packUT, Vessel.Situations situation)> packStates
+            = new Dictionary<uint, (double, Vessel.Situations)>();
+
         // Tree destruction merge dialog guard (prevents duplicate coroutines)
         private bool treeDestructionDialogPending;
 
@@ -3318,6 +3323,22 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Pure decision method: detects phantom terrain crashes. KSP sometimes crashes
+        /// EVA vessels through terrain during pack/unload. Returns true if the vessel was
+        /// in a safe situation (LANDED/SPLASHED) when packed and was destroyed within 5s.
+        /// </summary>
+        internal static bool IsPhantomTerrainCrash(
+            string evaCrewName, double packUT, double destructionUT, Vessel.Situations prePackSituation)
+        {
+            if (string.IsNullOrEmpty(evaCrewName)) return false;
+            bool wasSafe = prePackSituation == Vessel.Situations.LANDED
+                        || prePackSituation == Vessel.Situations.SPLASHED;
+            if (!wasSafe) return false;
+            double elapsed = destructionUT - packUT;
+            return elapsed >= 0 && elapsed < 5.0;
+        }
+
+        /// <summary>
         /// Pure decision method: if the vessel was destroyed during recording, ensures
         /// TerminalStateValue is Destroyed regardless of what situation-based inference produced.
         /// Returns true if the terminal state was overridden.
@@ -3469,7 +3490,37 @@ namespace Parsek
                 yield break;
             }
 
-            ApplyTerminalDestruction(pending, rec);
+            // Phantom terrain crash detection: KSP sometimes crashes EVA vessels
+            // through terrain during pack/unload. Detect by checking if the vessel
+            // was in a safe situation (LANDED/SPLASHED) when packed and was destroyed
+            // within a short time window. Override Destroyed → Landed/Splashed.
+            bool isPhantomCrash = false;
+            if (!string.IsNullOrEmpty(rec.EvaCrewName))
+            {
+                (double packUT, Vessel.Situations preSit) packState;
+                if (packStates.TryGetValue(pending.vesselPid, out packState))
+                {
+                    isPhantomCrash = IsPhantomTerrainCrash(
+                        rec.EvaCrewName, packState.packUT, pending.capturedUT, packState.preSit);
+                    if (isPhantomCrash)
+                    {
+                        var safeTerm = packState.preSit == Vessel.Situations.LANDED
+                            ? TerminalState.Landed : TerminalState.Splashed;
+                        ParsekLog.Warn("Flight",
+                            $"Suspected phantom terrain crash for EVA '{rec.VesselName}': " +
+                            $"was {packState.preSit}, packed {pending.capturedUT - packState.packUT:F1}s " +
+                            $"before destruction. Using {safeTerm} instead of Destroyed");
+                        rec.TerminalStateValue = safeTerm;
+                        rec.ExplicitEndUT = pending.capturedUT;
+                        ApplyTerminalData(pending, rec);
+                    }
+                }
+            }
+
+            if (!isPhantomCrash)
+                ApplyTerminalDestruction(pending, rec);
+
+            packStates.Remove(pending.vesselPid);
             activeTree.BackgroundMap.Remove(pending.vesselPid);
 
             if (!string.IsNullOrEmpty(rec.EvaCrewName))
@@ -3633,6 +3684,9 @@ namespace Parsek
         void OnVesselGoOnRails(Vessel v)
         {
             if (v != null && GhostMapPresence.IsGhostMapVessel(v.persistentId)) return;
+            // Track pre-pack vessel state for phantom terrain crash detection
+            if (v != null)
+                packStates[v.persistentId] = (Planetarium.GetUniversalTime(), v.situation);
             recorder?.OnVesselGoOnRails(v);
             backgroundRecorder?.OnBackgroundVesselGoOnRails(v);
         }
@@ -3640,7 +3694,7 @@ namespace Parsek
         void OnVesselGoOffRails(Vessel v)
         {
             if (v != null && GhostMapPresence.IsGhostMapVessel(v.persistentId)) return;
-
+            if (v != null) packStates.Remove(v.persistentId);
             recorder?.OnVesselGoOffRails(v);
             backgroundRecorder?.OnBackgroundVesselGoOffRails(v);
         }

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -3129,7 +3129,7 @@ namespace Parsek
         /// Prepares a standalone pending recording for ghost-only commit (no vessel spawn).
         /// Nulls vessel snapshot and unreserves crew. Call RecordingStore.CommitPending() after this.
         /// </summary>
-        private static void AutoCommitGhostOnly(Recording pending)
+        internal static void AutoCommitGhostOnly(Recording pending)
         {
             // Preserve snapshot for recordings that landed/splashed — they should be
             // eligible for vessel spawning even when committed outside Flight (#EVA-spawn).

--- a/Source/Parsek/RecordingOptimizer.cs
+++ b/Source/Parsek/RecordingOptimizer.cs
@@ -476,6 +476,9 @@ namespace Parsek
             second.RecordingFormatVersion = original.RecordingFormatVersion;
             // Both halves are the same vessel — share Generation. (#284)
             second.Generation = original.Generation;
+            // EVA linkage: both halves represent the same EVA kerbal
+            second.EvaCrewName = original.EvaCrewName;
+            second.ParentRecordingId = original.ParentRecordingId;
 
             // 12. Invalidate cached stats
             original.CachedStats = null;

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -4,6 +4,26 @@ Previous entries (225 bugs, 51 TODOs — mostly resolved) archived in `done/todo
 
 ---
 
+## ~~295. Pending standalone recording blocks all rewind buttons after tree merge~~
+
+Surfaced by the 2026-04-10 KerbalX playtest (save s35). After a tree merge, a standalone EVA recording (Jebediah Kerman) remained in the pending slot. `RecordingStore.CanRewind()` unconditionally blocks when `HasPending` is true, disabling all R buttons with "Merge or discard pending recording first". The auto-commit safety net in `ParsekScenario.SafetyNetAutoCommitPending()` only ran at OnSave time (50s later, on game pause to exit).
+
+**Fix:** In `MergeDialog.cs` tree merge button handler, auto-commit any pending standalone recording immediately after `CommitPendingTree()`, following the `AutoCommitGhostOnly` + `CommitPending` + `LedgerOrchestrator.OnRecordingCommitted` pattern. Made `AutoCommitGhostOnly` `internal static` in ParsekScenario.
+
+## ~~296. EVA kerbal crew end states not inferred — permanent reservation~~
+
+EVA kerbal recordings have no extractable crew in their ConfigNode snapshots (`ExtractCrewFromSnapshot` reads PART/crew values, which EVA snapshots don't have). `PopulateCrewEndStates` skipped these recordings entirely, leaving `CrewEndStates = null`. Consequences: crew reservation set to endUT=Infinity (Unknown), kerbal permanently reserved.
+
+Additionally, `RecordingOptimizer.SplitAtSection` did not propagate `EvaCrewName` or `ParentRecordingId` to the second half, so after an optimizer split the tip recording lost its EVA identity.
+
+**Fix:** (1) Propagate `EvaCrewName` and `ParentRecordingId` in `SplitAtSection`. (2) Add EVA fallback in `KerbalsModule.PopulateCrewEndStates`: if snapshot crew is empty and `rec.EvaCrewName` is set, use it as the crew member. (3) Relax `VesselSnapshot != null` guard in `LedgerOrchestrator.OnRecordingCommitted` to also allow EVA recordings. (4) Add same EVA fallback in `LedgerOrchestrator.ExtractCrewFromRecording`.
+
+## ~~297. Phantom terrain crash kills EVA kerbal on vessel switch~~
+
+KSP's terrain collision detection sometimes falsely destroys EVA vessels during pack/unload. When the user switched vessel focus away from Bill Kerman, KSP packed the EVA vessel and within 0.6s reported "crashed through terrain". Parsek correctly processed KSP's `onVesselWillDestroy` and set `terminal=Destroyed`, but the crash was spurious.
+
+**Fix:** Track pre-pack vessel situation in `ParsekFlight.packStates` dictionary (populated at `OnVesselGoOnRails`, cleaned at `OnVesselGoOffRails`). In `DeferredDestructionCheck`, before applying terminal destruction, check if the vessel is an EVA kerbal that was in a safe situation (LANDED/SPLASHED) when packed and was destroyed within 5s. If so, override terminal state to Landed/Splashed instead of Destroyed. Pure static `IsPhantomTerrainCrash` method extracted for testability.
+
 ## ~~294. F5/F9 during standalone recording loses all in-progress data~~
 
 Surfaced by the 2026-04-10 engine-plume-bug playtest (`logs/2026-04-10_engine-plume-bug/KSP.log`). After F9 quickload during the Halger Kerman EVA standalone recording, the pending recording was discarded by `DiscardStashedOnQuickload` and no new recording started. 28 seconds of EVA walk lost.


### PR DESCRIPTION
## Summary

Three bugs from the 2026-04-10 KerbalX playtest (save s35) where EVA kerbals showed as "Destroyed", rewind buttons were blocked, and crew reservations were infinite.

- **#295** Pending standalone recording blocks all rewind buttons after tree merge — auto-commit in MergeDialog tree merge handler
- **#296** EVA kerbal crew end states not inferred — EvaCrewName fallback in PopulateCrewEndStates + SplitAtSection propagation
- **#297** Phantom terrain crash kills EVA kerbal on vessel switch — pre-pack situation tracking + 5s heuristic override

## Test plan

- [x] 13 new unit tests (phantom crash heuristic, EVA crew inference, SplitAtSection propagation)
- [x] 5522 tests pass, 0 failures
- [ ] In-game: KerbalX launch → EVA both kerbals → switch vessels → KSC → merge → verify rewind available, Bill not Destroyed, crew reservation finite

🤖 Generated with [Claude Code](https://claude.com/claude-code)