### PR TITLE
Fix revert-to-launch misdetected as quickload on first flight (#300)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Dev notes: technical narratives for the fixes below live in `docs/dev/todo-and-k
 - `#282` Landed ghost vessels and end-of-recording respawned vessels no longer clip into terrain.
 - `#297` Map view now shows custom icons for all active ghost vessels, including atmospheric/landed ghosts beyond visual range.
 - `#295` Vessels that sit idle on the launch pad are now auto-discarded instead of triggering a merge dialog.
+- `#300` Revert-to-launch on a first flight no longer silently loses the recording — the merge dialog now appears correctly instead of the recording being mistaken for a quickload resume.
 - `#280` Background debris recordings now persist their trajectory data across scene reloads.
 - `#281` Decouple events on mixed-symmetry stages are no longer lost when a terminal-event collision occurs at the same physics frame.
 - `#272` F5/F9 no longer destroys the entire launch tree.

--- a/Source/Parsek.Tests/QuickloadResumeTests.cs
+++ b/Source/Parsek.Tests/QuickloadResumeTests.cs
@@ -590,50 +590,63 @@ namespace Parsek.Tests
         [Fact]
         public void HasOrphanedLimboTree_LimboStashedButNotRestoredFromSave_IsTrue_Bug300()
         {
-            // Simulates the revert-to-launch scenario: StashActiveTreeAsPendingLimbo
-            // put a tree into Limbo, but TryRestoreActiveTreeNode found nothing in the
-            // save file (returned false).
+            // Revert-to-launch scenario: StashActiveTreeAsPendingLimbo put a tree
+            // into Limbo, then TryRestoreActiveTreeNode scans the launch quicksave
+            // which has NO active tree → returns false → orphaned.
             var tree = MakeTree("tree_revert", "Kerbal X", 3);
             RecordingStore.StashPendingTree(tree, PendingTreeState.Limbo);
 
+            // Launch quicksave: no RECORDING_TREE with isActive=True
+            var launchSave = new ConfigNode("PARSEK_SCENARIO");
+            bool activeTreeRestoredFromSave = ParsekScenario.TryRestoreActiveTreeNode(launchSave);
+
+            Assert.False(activeTreeRestoredFromSave);
             bool hasOrphanedLimboTree = RecordingStore.HasPendingTree
                 && RecordingStore.PendingTreeStateValue == PendingTreeState.Limbo
-                && true; // !activeTreeRestoredFromSave (would be false from TryRestore)
+                && !activeTreeRestoredFromSave;
             Assert.True(hasOrphanedLimboTree);
         }
 
         [Fact]
         public void HasOrphanedLimboTree_LimboOverwrittenByRestore_IsFalse_Bug300()
         {
-            // Simulates the quickload (F5/F9) scenario: StashActiveTreeAsPendingLimbo
-            // put a tree into Limbo, then TryRestoreActiveTreeNode found the save-file
-            // version and overwrote it (returned true).
+            // Quickload (F5/F9) scenario: StashActiveTreeAsPendingLimbo put a tree
+            // into Limbo, then TryRestoreActiveTreeNode finds the save-file version
+            // (F5 save has isActive=True) → returns true → not orphaned.
             var tree = MakeTree("tree_ql", "Kerbal X", 3);
             RecordingStore.StashPendingTree(tree, PendingTreeState.Limbo);
 
-            // Simulate TryRestoreActiveTreeNode success: it pops the stale tree
-            // and re-stashes the save-file version as Limbo.
+            // F5 save: has RECORDING_TREE with isActive=True
+            var f5Save = new ConfigNode("PARSEK_SCENARIO");
+            var activeNode = f5Save.AddNode("RECORDING_TREE");
             var saveTree = MakeTree("tree_ql", "Kerbal X (save)", 3);
-            RecordingStore.PopPendingTree();
-            RecordingStore.StashPendingTree(saveTree, PendingTreeState.Limbo);
+            saveTree.Save(activeNode);
+            activeNode.AddValue("isActive", "True");
 
+            bool activeTreeRestoredFromSave = ParsekScenario.TryRestoreActiveTreeNode(f5Save);
+
+            Assert.True(activeTreeRestoredFromSave);
             bool hasOrphanedLimboTree = RecordingStore.HasPendingTree
                 && RecordingStore.PendingTreeStateValue == PendingTreeState.Limbo
-                && false; // !activeTreeRestoredFromSave (would be true)
+                && !activeTreeRestoredFromSave;
             Assert.False(hasOrphanedLimboTree);
         }
 
         [Fact]
         public void HasOrphanedLimboTree_FinalizedState_IsFalse_Bug300()
         {
-            // Finalized trees are committed scene-exit trees, not Limbo. The orphaned
-            // Limbo check should NOT fire for them.
+            // Finalized trees are committed scene-exit trees, not Limbo. Even when
+            // TryRestoreActiveTreeNode returns false, the Limbo state check rejects.
             var tree = MakeTree("tree_fin", "Committed Flight", 2);
             RecordingStore.StashPendingTree(tree, PendingTreeState.Finalized);
 
+            var emptySave = new ConfigNode("PARSEK_SCENARIO");
+            bool activeTreeRestoredFromSave = ParsekScenario.TryRestoreActiveTreeNode(emptySave);
+
+            Assert.False(activeTreeRestoredFromSave);
             bool hasOrphanedLimboTree = RecordingStore.HasPendingTree
                 && RecordingStore.PendingTreeStateValue == PendingTreeState.Limbo
-                && true; // !activeTreeRestoredFromSave
+                && !activeTreeRestoredFromSave;
             Assert.False(hasOrphanedLimboTree);
         }
 

--- a/Source/Parsek.Tests/QuickloadResumeTests.cs
+++ b/Source/Parsek.Tests/QuickloadResumeTests.cs
@@ -458,6 +458,71 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void IsRevert_OrphanedLimboTree_FlightToFlight_IsTrue_Bug300()
+        {
+            // Bug #300: first-ever flight, no prior commits. Epoch and count both
+            // zero on both sides. The orphaned Limbo tree (stashed from memory but
+            // NOT found in the save file) is the revert signal.
+            bool isRevert = ComputeIsRevert(
+                isVesselSwitch: false,
+                savedEpoch: 0,
+                currentEpoch: 0,
+                totalSavedRecCount: 0,
+                memoryRecordingsCount: 0,
+                isFlightToFlight: true,
+                hasOrphanedLimboTree: true);
+            Assert.True(isRevert);
+        }
+
+        [Fact]
+        public void IsRevert_OrphanedLimboTree_NotFlightToFlight_IsFalse_Bug300()
+        {
+            // Safety: orphaned Limbo tree should only trigger revert detection in
+            // FLIGHT→FLIGHT transitions, not on e.g. SPACECENTER→FLIGHT.
+            bool isRevert = ComputeIsRevert(
+                isVesselSwitch: false,
+                savedEpoch: 0,
+                currentEpoch: 0,
+                totalSavedRecCount: 0,
+                memoryRecordingsCount: 0,
+                isFlightToFlight: false,
+                hasOrphanedLimboTree: true);
+            Assert.False(isRevert);
+        }
+
+        [Fact]
+        public void IsRevert_LimboTreeRestoredFromSave_IsFalse_Bug300()
+        {
+            // Quickload (F5/F9): the save file contained the active tree, so
+            // TryRestoreActiveTreeNode returned true → hasOrphanedLimboTree=false.
+            // Should NOT be detected as a revert.
+            bool isRevert = ComputeIsRevert(
+                isVesselSwitch: false,
+                savedEpoch: 0,
+                currentEpoch: 0,
+                totalSavedRecCount: 0,
+                memoryRecordingsCount: 0,
+                isFlightToFlight: true,
+                hasOrphanedLimboTree: false);
+            Assert.False(isRevert);
+        }
+
+        [Fact]
+        public void IsRevert_OrphanedLimboTree_VesselSwitch_IsFalse_Bug300()
+        {
+            // Vessel switch suppresses revert even with an orphaned Limbo tree.
+            bool isRevert = ComputeIsRevert(
+                isVesselSwitch: true,
+                savedEpoch: 0,
+                currentEpoch: 0,
+                totalSavedRecCount: 0,
+                memoryRecordingsCount: 0,
+                isFlightToFlight: true,
+                hasOrphanedLimboTree: true);
+            Assert.False(isRevert);
+        }
+
+        [Fact]
         public void IsRevert_VesselSwitch_IsFalseEvenIfEpochRegresses()
         {
             // Vessel switch flag suppresses isRevert regardless of other indicators
@@ -472,17 +537,19 @@ namespace Parsek.Tests
         }
 
         /// <summary>
-        /// Mirrors the isRevert computation in ParsekScenario.OnLoad after the fix
-        /// (removal of the || isFlightToFlight clause). Kept here as a pure function
-        /// so it can be unit-tested without needing a full ParsekScenario instance.
+        /// Mirrors the isRevert computation in ParsekScenario.OnLoad after bug #300.
+        /// Kept here as a pure function so it can be unit-tested without needing a
+        /// full ParsekScenario instance.
         /// </summary>
         private static bool ComputeIsRevert(
             bool isVesselSwitch, uint savedEpoch, uint currentEpoch,
-            int totalSavedRecCount, int memoryRecordingsCount)
+            int totalSavedRecCount, int memoryRecordingsCount,
+            bool isFlightToFlight = false, bool hasOrphanedLimboTree = false)
         {
             return !isVesselSwitch
                 && (savedEpoch < currentEpoch
-                    || totalSavedRecCount < memoryRecordingsCount);
+                    || totalSavedRecCount < memoryRecordingsCount
+                    || (isFlightToFlight && hasOrphanedLimboTree));
         }
 
         /// <summary>
@@ -518,6 +585,75 @@ namespace Parsek.Tests
                 return LimboDispatchOutcome.VesselSwitchRestore;
             if (isVesselSwitch) return LimboDispatchOutcome.SafetyNetFinalize;
             return LimboDispatchOutcome.QuickloadRestore;
+        }
+
+        [Fact]
+        public void HasOrphanedLimboTree_LimboStashedButNotRestoredFromSave_IsTrue_Bug300()
+        {
+            // Simulates the revert-to-launch scenario: StashActiveTreeAsPendingLimbo
+            // put a tree into Limbo, but TryRestoreActiveTreeNode found nothing in the
+            // save file (returned false).
+            var tree = MakeTree("tree_revert", "Kerbal X", 3);
+            RecordingStore.StashPendingTree(tree, PendingTreeState.Limbo);
+
+            bool hasOrphanedLimboTree = RecordingStore.HasPendingTree
+                && RecordingStore.PendingTreeStateValue == PendingTreeState.Limbo
+                && true; // !activeTreeRestoredFromSave (would be false from TryRestore)
+            Assert.True(hasOrphanedLimboTree);
+        }
+
+        [Fact]
+        public void HasOrphanedLimboTree_LimboOverwrittenByRestore_IsFalse_Bug300()
+        {
+            // Simulates the quickload (F5/F9) scenario: StashActiveTreeAsPendingLimbo
+            // put a tree into Limbo, then TryRestoreActiveTreeNode found the save-file
+            // version and overwrote it (returned true).
+            var tree = MakeTree("tree_ql", "Kerbal X", 3);
+            RecordingStore.StashPendingTree(tree, PendingTreeState.Limbo);
+
+            // Simulate TryRestoreActiveTreeNode success: it pops the stale tree
+            // and re-stashes the save-file version as Limbo.
+            var saveTree = MakeTree("tree_ql", "Kerbal X (save)", 3);
+            RecordingStore.PopPendingTree();
+            RecordingStore.StashPendingTree(saveTree, PendingTreeState.Limbo);
+
+            bool hasOrphanedLimboTree = RecordingStore.HasPendingTree
+                && RecordingStore.PendingTreeStateValue == PendingTreeState.Limbo
+                && false; // !activeTreeRestoredFromSave (would be true)
+            Assert.False(hasOrphanedLimboTree);
+        }
+
+        [Fact]
+        public void HasOrphanedLimboTree_FinalizedState_IsFalse_Bug300()
+        {
+            // Finalized trees are committed scene-exit trees, not Limbo. The orphaned
+            // Limbo check should NOT fire for them.
+            var tree = MakeTree("tree_fin", "Committed Flight", 2);
+            RecordingStore.StashPendingTree(tree, PendingTreeState.Finalized);
+
+            bool hasOrphanedLimboTree = RecordingStore.HasPendingTree
+                && RecordingStore.PendingTreeStateValue == PendingTreeState.Limbo
+                && true; // !activeTreeRestoredFromSave
+            Assert.False(hasOrphanedLimboTree);
+        }
+
+        [Fact]
+        public void LimboDispatch_OrphanedLimboTree_RoutesToFinalize_Bug300()
+        {
+            // End-to-end dispatch: orphaned Limbo tree (revert) → isRevert=true → Finalize
+            bool isRevert = ComputeIsRevert(
+                isVesselSwitch: false,
+                savedEpoch: 0,
+                currentEpoch: 0,
+                totalSavedRecCount: 0,
+                memoryRecordingsCount: 0,
+                isFlightToFlight: true,
+                hasOrphanedLimboTree: true);
+            Assert.True(isRevert);
+
+            var outcome = ComputeLimboDispatch(isRevert, isVesselSwitch: false,
+                PendingTreeState.Limbo);
+            Assert.Equal(LimboDispatchOutcome.Finalize, outcome);
         }
 
         [Fact]

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -705,7 +705,7 @@ namespace Parsek
                     // Runs AFTER ParsekSettingsPersistence.ApplyTo so restored settings
                     // affect the rest of OnLoad, but BEFORE revert detection so the
                     // pending slot is populated when it runs.
-                    TryRestoreActiveTreeNode(node);
+                    bool activeTreeRestoredFromSave = TryRestoreActiveTreeNode(node);
                     // #294: Also check for an active standalone recording saved at F5 time.
                     // Mutually exclusive with tree restore — TryRestoreActiveStandaloneNode
                     // checks ScheduleActiveTreeRestoreOnFlightReady and skips if set.
@@ -807,15 +807,29 @@ namespace Parsek
                         isVesselSwitch = false;
                     }
 
+                    // Bug #300: on first-ever flight (no prior commits), epoch and
+                    // recording counts are both zero on both sides, so the classic
+                    // revert signals (savedEpoch < CurrentEpoch, savedRecCount <
+                    // memoryCount) are blind. The distinguishing signal is that
+                    // TryRestoreActiveTreeNode returned false (the launch quicksave
+                    // has no active tree) yet a Limbo tree persists from the
+                    // StashActiveTreeAsPendingLimbo call before this OnLoad.
+                    // Quickloads (F5/F9) always have an active tree in the save file
+                    // because OnSave writes it, so activeTreeRestoredFromSave=true.
+                    bool hasOrphanedLimboTree = RecordingStore.HasPendingTree
+                        && RecordingStore.PendingTreeStateValue == PendingTreeState.Limbo
+                        && !activeTreeRestoredFromSave;
                     bool isRevert = !isVesselSwitch
                                     && (savedEpoch < MilestoneStore.CurrentEpoch
-                                        || totalSavedRecCount < recordings.Count);
+                                        || totalSavedRecCount < recordings.Count
+                                        || (isFlightToFlight && hasOrphanedLimboTree));
                     ParsekLog.Verbose("Scenario",
                         $"OnLoad: revert detection — savedEpoch={savedEpoch}, currentEpoch={MilestoneStore.CurrentEpoch}, " +
                         $"savedRecNodes={savedRecNodes.Length}, savedTreeRecs={savedTreeRecCount}, " +
                         $"memoryRecordings={recordings.Count}, lastOnSaveScene={lastOnSaveScene}, " +
                         $"isFlightToFlight={isFlightToFlight}, isVesselSwitch={isVesselSwitch}, isRevert={isRevert}, " +
-                        $"pendingTreeState={RecordingStore.PendingTreeStateValue}");
+                        $"pendingTreeState={RecordingStore.PendingTreeStateValue}, " +
+                        $"activeTreeRestoredFromSave={activeTreeRestoredFromSave}, hasOrphanedLimboTree={hasOrphanedLimboTree}");
                     // Discard stashed-this-transition recordings on quickload (Bug A).
                     // Must run BEFORE the isRevert branch at line ~580, because the
                     // revert branch consumes PendingStashedThisTransition for its own

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -4,6 +4,16 @@ Previous entries (225 bugs, 51 TODOs — mostly resolved) archived in `done/todo
 
 ---
 
+## ~~300. Revert-to-launch on first flight misdetected as quickload — recording lost, unwanted auto-restart~~
+
+On first-ever flight (no prior commits), revert-to-launch was misdetected as a quickload (F5/F9). Root cause: the revert detection formula (`savedEpoch < CurrentEpoch || totalSavedRecCount < recordings.Count`) is blind when both sides are zero — epoch never incremented and no recordings were ever committed, so the launch quicksave and in-memory state look identical.
+
+Consequence: (1) the Limbo tree was routed to the quickload-resume path instead of the revert-finalize path, auto-restarting the recording without user action; (2) no merge dialog shown; (3) on exit to main menu the tree data was lost (no OnLoad fires for MAINMENU to dispatch the pending tree).
+
+Fix: capture `TryRestoreActiveTreeNode`'s return value (previously discarded). Compute `hasOrphanedLimboTree = HasPendingTree && state==Limbo && !activeTreeRestoredFromSave`. Add `(isFlightToFlight && hasOrphanedLimboTree)` as a third disjunct to `isRevert`. Signal is unambiguous: on quickloads the save file always has the active tree (OnSave writes it), while on reverts the launch quicksave predates the recording. File: `ParsekScenario.cs:810-825`.
+
+---
+
 ## ~~297. Map view icons for atmo/landed ghosts only appear with W (watch) button~~
 
 Atmospheric and landed ghost vessels had no icon in map view unless the user pressed W (watch recording). Two causes: (1) `HandleGhostCreated` skips ProtoVessel creation for `terminal=Landed`, so no native KSP icon exists; (2) ghost mesh hidden by zone distance (`ApplyZoneRenderingImpl`) causes `DrawMapMarkers` to skip the custom marker (the `activeSelf` check at line 672, added for #245/#247).


### PR DESCRIPTION
## Summary

- On first-ever flight (no prior commits), revert-to-launch was misdetected as a quickload because both epoch and recording counts were zero on both sides — the revert detection formula was blind
- Capture `TryRestoreActiveTreeNode`'s return value (previously discarded) to detect orphaned Limbo trees: quickloads always have the active tree in the save file, reverts don't
- Add `(isFlightToFlight && hasOrphanedLimboTree)` as a third disjunct to `isRevert`

Fixes three user-facing symptoms: (1) no merge dialog on revert, (2) recording data lost, (3) unwanted recording auto-restart after revert.

## Test plan

- [x] 8 new unit tests covering orphaned Limbo tree detection, quickload non-regression, vessel-switch non-regression, end-to-end dispatch routing
- [x] All 5525 existing tests pass
- [ ] In-game: launch Kerbal X on fresh save, fly until breakup, revert to launch → merge dialog should appear
- [ ] In-game: launch, F5, fly, F9 → recording should seamlessly resume (quickload path unchanged)


🤖 Generated with [Claude Code](https://claude.com/claude-code)