### PR TITLE
Add sortable Site column, rename Stats to Info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to Parsek are documented here.
 
 ## 0.7.3
 
+- Sortable "Site" column in the Recordings Manager — sorts by launch site name with UT tiebreak within the same site.
+- Renamed the expanded-stats toggle button from "Stats" to "Info".
+
 ---
 
 ## 0.7.2

--- a/Source/Parsek.Tests/RecordingsTableUITests.cs
+++ b/Source/Parsek.Tests/RecordingsTableUITests.cs
@@ -760,5 +760,113 @@ namespace Parsek.Tests
 
             Assert.DoesNotContain("chain-g", rootChainIds);
         }
+
+        // ── LaunchSite sorting ──
+
+        private static Recording MakeRecWithSite(double startUT, double endUT, string site, string name = "Test")
+        {
+            var rec = MakeRec(startUT, endUT, name);
+            rec.LaunchSiteName = site;
+            return rec;
+        }
+
+        [Fact]
+        public void CompareRecordings_LaunchSite_SortsBySiteName()
+        {
+            var ra = MakeRecWithSite(100, 200, "Runway");
+            var rb = MakeRecWithSite(100, 200, "LaunchPad");
+            int cmp = ParsekUI.CompareRecordings(ra, rb,
+                ParsekUI.SortColumn.LaunchSite, true, 0);
+            Assert.True(cmp > 0); // Runway > LaunchPad alphabetically
+        }
+
+        [Fact]
+        public void CompareRecordings_LaunchSite_SameSite_TiebreaksByUT()
+        {
+            var ra = MakeRecWithSite(300, 400, "LaunchPad");
+            var rb = MakeRecWithSite(100, 200, "LaunchPad");
+            int cmp = ParsekUI.CompareRecordings(ra, rb,
+                ParsekUI.SortColumn.LaunchSite, true, 0);
+            Assert.True(cmp > 0); // Same site, ra has later StartUT
+        }
+
+        [Fact]
+        public void CompareRecordings_LaunchSite_NullSite_SortsBeforeNamed()
+        {
+            var ra = MakeRec(100, 200); // no site (null)
+            var rb = MakeRecWithSite(100, 200, "LaunchPad");
+            int cmp = ParsekUI.CompareRecordings(ra, rb,
+                ParsekUI.SortColumn.LaunchSite, true, 0);
+            Assert.True(cmp < 0); // "" < "LaunchPad"
+        }
+
+        [Fact]
+        public void CompareRecordings_LaunchSite_CaseInsensitive()
+        {
+            var ra = MakeRecWithSite(100, 200, "launchpad");
+            var rb = MakeRecWithSite(100, 200, "LaunchPad");
+            int cmp = ParsekUI.CompareRecordings(ra, rb,
+                ParsekUI.SortColumn.LaunchSite, true, 0);
+            // Same site name (case-insensitive), same UT → tiebreak returns 0
+            Assert.Equal(0, cmp);
+        }
+
+        [Fact]
+        public void CompareRecordings_LaunchSite_Descending_ReversesOrder()
+        {
+            var ra = MakeRecWithSite(100, 200, "LaunchPad");
+            var rb = MakeRecWithSite(100, 200, "Runway");
+            int ascCmp = ParsekUI.CompareRecordings(ra, rb,
+                ParsekUI.SortColumn.LaunchSite, true, 0);
+            int descCmp = ParsekUI.CompareRecordings(ra, rb,
+                ParsekUI.SortColumn.LaunchSite, false, 0);
+            Assert.Equal(-ascCmp, descCmp);
+        }
+
+        [Fact]
+        public void BuildSortedIndices_LaunchSite_GroupsBySiteThenUT()
+        {
+            var committed = new List<Recording>
+            {
+                MakeRecWithSite(200, 300, "Runway", "R2"),
+                MakeRecWithSite(100, 200, "LaunchPad", "L1"),
+                MakeRecWithSite(300, 400, "LaunchPad", "L2"),
+                MakeRecWithSite(100, 200, "Runway", "R1")
+            };
+            var indices = ParsekUI.BuildSortedIndices(committed,
+                ParsekUI.SortColumn.LaunchSite, true, 0);
+            // Expected order: LaunchPad(UT=100), LaunchPad(UT=300), Runway(UT=100), Runway(UT=200)
+            Assert.Equal(1, indices[0]); // L1 (LaunchPad, UT=100)
+            Assert.Equal(2, indices[1]); // L2 (LaunchPad, UT=300)
+            Assert.Equal(3, indices[2]); // R1 (Runway, UT=100)
+            Assert.Equal(0, indices[3]); // R2 (Runway, UT=200)
+        }
+
+        [Fact]
+        public void GetRecordingSortKey_LaunchSite_ReturnsRowFallback()
+        {
+            var rec = MakeRecWithSite(100, 200, "LaunchPad");
+            double key = ParsekUI.GetRecordingSortKey(rec, ParsekUI.SortColumn.LaunchSite, 0, 7);
+            Assert.Equal(7, key); // string-based column, returns rowFallback
+        }
+
+        [Fact]
+        public void GetChainSortKey_LaunchSite_ReturnsZero()
+        {
+            var committed = new List<Recording> { MakeRecWithSite(100, 200, "LaunchPad") };
+            var members = new List<int> { 0 };
+            double key = ParsekUI.GetChainSortKey(members, committed,
+                ParsekUI.SortColumn.LaunchSite, 0);
+            Assert.Equal(0, key);
+        }
+
+        [Fact]
+        public void GetGroupSortKey_LaunchSite_ReturnsZero()
+        {
+            var committed = new List<Recording> { MakeRecWithSite(100, 200, "LaunchPad") };
+            double key = ParsekUI.GetGroupSortKey(new HashSet<int> { 0 }, committed,
+                ParsekUI.SortColumn.LaunchSite, 0);
+            Assert.Equal(0, key);
+        }
     }
 }

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -1721,6 +1721,16 @@ namespace Parsek
             if (treeRec.VesselPersistentId == 0 && rec.RecordingVesselId != 0)
                 treeRec.VesselPersistentId = rec.RecordingVesselId;
 
+            // Copy Phase 10 location fields if not already set on the tree recording
+            if (string.IsNullOrEmpty(treeRec.StartBodyName))
+                treeRec.StartBodyName = rec.StartBodyName;
+            if (string.IsNullOrEmpty(treeRec.StartBiome))
+                treeRec.StartBiome = rec.StartBiome;
+            if (string.IsNullOrEmpty(treeRec.StartSituation))
+                treeRec.StartSituation = rec.StartSituation;
+            if (string.IsNullOrEmpty(treeRec.LaunchSiteName))
+                treeRec.LaunchSiteName = rec.LaunchSiteName;
+
             // Set IsRecording = false to prevent dangling active state
             rec.IsRecording = false;
             rec.TransitionToBackgroundPending = false;
@@ -2050,6 +2060,10 @@ namespace Parsek
                     rootRec.RewindReservedFunds = splitRecorder.CaptureAtStop.RewindReservedFunds;
                     rootRec.RewindReservedScience = splitRecorder.CaptureAtStop.RewindReservedScience;
                     rootRec.RewindReservedRep = splitRecorder.CaptureAtStop.RewindReservedRep;
+                    rootRec.StartBodyName = splitRecorder.CaptureAtStop.StartBodyName;
+                    rootRec.StartBiome = splitRecorder.CaptureAtStop.StartBiome;
+                    rootRec.StartSituation = splitRecorder.CaptureAtStop.StartSituation;
+                    rootRec.LaunchSiteName = splitRecorder.CaptureAtStop.LaunchSiteName;
                     if (rootRec.Points.Count > 0)
                         rootRec.ExplicitStartUT = rootRec.Points[0].ut;
                     // Mark dirty so the captured trajectory reaches disk on the
@@ -3169,6 +3183,10 @@ namespace Parsek
             rootRec.RewindReservedFunds = cap.RewindReservedFunds;
             rootRec.RewindReservedScience = cap.RewindReservedScience;
             rootRec.RewindReservedRep = cap.RewindReservedRep;
+            rootRec.StartBodyName = cap.StartBodyName;
+            rootRec.StartBiome = cap.StartBiome;
+            rootRec.StartSituation = cap.StartSituation;
+            rootRec.LaunchSiteName = cap.LaunchSiteName;
             if (rootRec.Points.Count > 0)
                 rootRec.ExplicitStartUT = rootRec.Points[0].ut;
             // Mark dirty so the next OnSave persists the captured data to disk.

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -539,7 +539,7 @@ namespace Parsek
                 out grpToRecs, out chainToRecs, out grpChildren, out rootGrps, out rootChainIds);
         }
 
-        internal enum SortColumn { Index, Phase, Name, LaunchTime, Duration, Status }
+        internal enum SortColumn { Index, Phase, Name, LaunchTime, Duration, Status, LaunchSite }
 
         internal static int GetStatusOrder(Recording rec, double now)
             => RecordingsTableUI.GetStatusOrder(rec, now);

--- a/Source/Parsek/UI/RecordingsTableUI.cs
+++ b/Source/Parsek/UI/RecordingsTableUI.cs
@@ -36,6 +36,7 @@ namespace Parsek
         private const float ColW_Watch = 50f;
         private const float ColW_Rewind = 65f;
         private const float ColW_Hide = 50f;
+        private const float ColW_Site = 90f;
         private const float ColW_Group = 50f;
 
         // Reusable per-frame buffers (avoid allocation each frame)
@@ -77,7 +78,7 @@ namespace Parsek
         private GUIStyle phaseStyleApproach;
 
         // Sort state
-        internal enum SortColumn { Index, Phase, Name, LaunchTime, Duration, Status }
+        internal enum SortColumn { Index, Phase, Name, LaunchTime, Duration, Status, LaunchSite }
         private SortColumn sortColumn = SortColumn.LaunchTime;
         private bool sortAscending = true;
 
@@ -463,6 +464,7 @@ namespace Parsek
             DrawSortableHeader("#", SortColumn.Index, ColW_Index);
             DrawSortableHeader("Name", SortColumn.Name, 0, true);
             DrawSortableHeader("Phase", SortColumn.Phase, ColW_Phase);
+            DrawSortableHeader("Site", SortColumn.LaunchSite, ColW_Site);
             DrawSortableHeader("Launch", SortColumn.LaunchTime, ColW_Launch);
             DrawSortableHeader("Duration", SortColumn.Duration, ColW_Dur);
 
@@ -535,11 +537,11 @@ namespace Parsek
 
             if (committed.Count > 0)
             {
-                string statsLabel = showExpandedStats ? "Stats \u25c0" : "Stats \u25b6";
+                string statsLabel = showExpandedStats ? "Info \u25c0" : "Info \u25b6";
                 if (GUILayout.Button(statsLabel, GUILayout.Width(65)))
                 {
                     showExpandedStats = !showExpandedStats;
-                    ParsekLog.Verbose("UI", $"Recordings Stats toggled: {(showExpandedStats ? "expanded" : "collapsed")}");
+                    ParsekLog.Verbose("UI", $"Recordings Info toggled: {(showExpandedStats ? "expanded" : "collapsed")}");
                     if (showExpandedStats && recordingsWindowRect.width < 1564f)
                         recordingsWindowRect.width = 1564f;
                     else if (!showExpandedStats)
@@ -659,10 +661,14 @@ namespace Parsek
                     {
                         if (!seenChains.Add(rec.ChainId)) continue;
                         var members = chainToRecs[rec.ChainId];
+                        var firstRec = members.Count > 0 ? committed[members[0]] : null;
+                        string cSortName = sortColumn == SortColumn.LaunchSite
+                            ? (firstRec?.LaunchSiteName ?? "")
+                            : (firstRec != null ? firstRec.VesselName : "");
                         rootItems.Add(new RootDrawItem
                         {
                             SortKey = GetChainSortKey(members, committed, sortColumn, now),
-                            SortName = members.Count > 0 ? committed[members[0]].VesselName : "",
+                            SortName = cSortName,
                             ItemType = RootItemType.Chain,
                             ChainId = rec.ChainId,
                             RecIdx = -1
@@ -670,10 +676,13 @@ namespace Parsek
                     }
                     else if (string.IsNullOrEmpty(rec.ChainId))
                     {
+                        string rSortName = sortColumn == SortColumn.LaunchSite
+                            ? (rec.LaunchSiteName ?? "")
+                            : (string.IsNullOrEmpty(rec.VesselName) ? "Untitled" : rec.VesselName);
                         rootItems.Add(new RootDrawItem
                         {
                             SortKey = GetRecordingSortKey(rec, sortColumn, now, row),
-                            SortName = string.IsNullOrEmpty(rec.VesselName) ? "Untitled" : rec.VesselName,
+                            SortName = rSortName,
                             ItemType = RootItemType.Recording,
                             RecIdx = ri
                         });
@@ -686,7 +695,7 @@ namespace Parsek
                 rootItems.Sort((a, b) =>
                 {
                     int cmp;
-                    if (col == SortColumn.Name || col == SortColumn.Phase)
+                    if (col == SortColumn.Name || col == SortColumn.Phase || col == SortColumn.LaunchSite)
                         cmp = string.Compare(a.SortName, b.SortName,
                             StringComparison.OrdinalIgnoreCase);
                     else
@@ -777,6 +786,9 @@ namespace Parsek
             {
                 GUILayout.Label("", GUILayout.Width(ColW_Phase));
             }
+
+            // Site (launch site name)
+            GUILayout.Label(rec.LaunchSiteName ?? "", GUILayout.Width(ColW_Site));
 
             // Launch Time
             string launchTime = rec.Points.Count > 0
@@ -1178,6 +1190,9 @@ namespace Parsek
             // Phase placeholder (groups have no phase)
             GUILayout.Label("", GUILayout.Width(ColW_Phase));
 
+            // Site placeholder (groups have no single site)
+            GUILayout.Label("", GUILayout.Width(ColW_Site));
+
             // Launch time (earliest among descendants)
             double grpEarliest = GetGroupEarliestStartUT(descendants, committed);
             string grpLaunchText = (memberCount > 0 && grpEarliest < double.MaxValue)
@@ -1521,6 +1536,10 @@ namespace Parsek
 
             // Phase placeholder (chains have no single phase)
             GUILayout.Label("", GUILayout.Width(ColW_Phase));
+
+            // Site (first member's launch site)
+            string chainSite = members.Count > 0 ? committed[members[0]].LaunchSiteName : null;
+            GUILayout.Label(chainSite ?? "", GUILayout.Width(ColW_Site));
 
             // Launch time (earliest among chain members)
             GUILayout.Label(chainStart < double.MaxValue
@@ -1902,7 +1921,7 @@ namespace Parsek
                 case SortColumn.LaunchTime: return rec.StartUT;
                 case SortColumn.Duration: return rec.EndUT - rec.StartUT;
                 case SortColumn.Status: return GetStatusOrder(rec, now);
-                default: return rowFallback;
+                default: return rowFallback; // Index, Name, Phase, LaunchSite — string-based, handled externally
             }
         }
 
@@ -1945,7 +1964,7 @@ namespace Parsek
                     return best;
                 }
                 default:
-                    return 0; // Name/Phase/Index: handled via string comparison externally
+                    return 0; // Name/Phase/Index/LaunchSite: handled via string comparison externally
             }
         }
 
@@ -1977,6 +1996,13 @@ namespace Parsek
                     break;
                 case SortColumn.Status:
                     cmp = GetStatusOrder(ra, now).CompareTo(GetStatusOrder(rb, now));
+                    break;
+                case SortColumn.LaunchSite:
+                    string sa = ra.LaunchSiteName ?? "";
+                    string sb = rb.LaunchSiteName ?? "";
+                    cmp = string.Compare(sa, sb, StringComparison.OrdinalIgnoreCase);
+                    if (cmp == 0)
+                        cmp = ra.StartUT.CompareTo(rb.StartUT);
                     break;
             }
             return ascending ? cmp : -cmp;
@@ -2324,6 +2350,7 @@ namespace Parsek
                 }
                 case SortColumn.Name:
                 case SortColumn.Phase:
+                case SortColumn.LaunchSite:
                     return 0; // sorted by string comparison externally
                 case SortColumn.Index:
                 default:

--- a/Source/Parsek/UI/RecordingsTableUI.cs
+++ b/Source/Parsek/UI/RecordingsTableUI.cs
@@ -542,10 +542,10 @@ namespace Parsek
                 {
                     showExpandedStats = !showExpandedStats;
                     ParsekLog.Verbose("UI", $"Recordings Info toggled: {(showExpandedStats ? "expanded" : "collapsed")}");
-                    if (showExpandedStats && recordingsWindowRect.width < 1564f)
-                        recordingsWindowRect.width = 1564f;
+                    if (showExpandedStats && recordingsWindowRect.width < 1654f)
+                        recordingsWindowRect.width = 1654f;
                     else if (!showExpandedStats)
-                        recordingsWindowRect.width = 1106f;
+                        recordingsWindowRect.width = 1196f;
                 }
             }
 

--- a/Source/Parsek/UI/RecordingsTableUI.cs
+++ b/Source/Parsek/UI/RecordingsTableUI.cs
@@ -274,7 +274,7 @@ namespace Parsek
                 recordingsWindowRect = new Rect(
                     mainWindowRect.x + mainWindowRect.width + 10,
                     mainWindowRect.y,
-                    1106, recHeight);
+                    1196, recHeight);
                 var ic = System.Globalization.CultureInfo.InvariantCulture;
                 ParsekLog.Verbose("UI", $"Recordings window initial position: x={recordingsWindowRect.x.ToString("F0", ic)} y={recordingsWindowRect.y.ToString("F0", ic)}");
             }

--- a/Source/Parsek/UI/RecordingsTableUI.cs
+++ b/Source/Parsek/UI/RecordingsTableUI.cs
@@ -1190,8 +1190,10 @@ namespace Parsek
             // Phase placeholder (groups have no phase)
             GUILayout.Label("", GUILayout.Width(ColW_Phase));
 
-            // Site placeholder (groups have no single site)
-            GUILayout.Label("", GUILayout.Width(ColW_Site));
+            // Site (from main/root recording if available)
+            int grpMainIdx = FindGroupMainRecordingIndex(descendants, committed);
+            string grpSite = grpMainIdx >= 0 ? committed[grpMainIdx].LaunchSiteName : null;
+            GUILayout.Label(grpSite ?? "", GUILayout.Width(ColW_Site));
 
             // Launch time (earliest among descendants)
             double grpEarliest = GetGroupEarliestStartUT(descendants, committed);

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -200,11 +200,9 @@ Allow the player to change the camera mode during ghost watch playback. Currentl
 
 **Priority:** Nice-to-have
 
-### T54. Timeline spawn entries should show landing location
+### ~~T54. Timeline spawn entries should show landing location~~
 
-Some timeline "Spawn:" lines show generic "Landed" without specifying where. Should include biome and body context when available, matching the recordings table End column format.
-
-**Priority:** Low — timeline display completeness
+Already implemented — `GetVesselSpawnText()` in `TimelineEntryDisplay.cs` includes biome and body via `InjectBiomeIntoSituation()`. Launch entries also include launch site name via `GetRecordingStartText()`.
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -148,20 +148,7 @@ Unified chronological view of all committed career events, replacing the Game Ac
 
 **Data model:** 26 entry types (2 recording lifecycle + 23 game actions + 1 legacy). `TimelineBuilder` with 3 collectors + stable UT sort. `IsPlayerAction` classification. Game-mode aware (career/science/sandbox). 4870 tests passing (53 timeline-specific).
 
----
-
-## ~~Phase 10: Location Context~~ *(complete)*
-
-Recordings become location-aware. Each recording knows where it started and ended — body, biome, situation, coordinates, and stock launch site name.
-
-- ~~Biome captured at recording start and end via `ScienceUtil.GetExperimentBiome`~~
-- ~~Vessel situation at recording start (not just end)~~
-- ~~Stock launch site name from `FlightDriver.LaunchSiteName` (Launch Pad, Runway, Making History DLC sites)~~
-- ~~Timeline shows "Launch: Vessel from Launch Pad on Kerbin" and "Spawn: Vessel (Landed at Midlands on Mun)"~~
-- ~~UI grouping and filtering by launch site in the Recordings Manager~~ *(sortable Site column with UT tiebreak)*
-- Prerequisite for logistics routes (Phase 12) and async multiplayer (Phase 13)
-
-Small, additive feature. A few metadata fields at recording start and end.
+**Location context:** Recordings become location-aware — body, biome, situation, and stock launch site name captured at recording start and end. Timeline shows location-enriched entries ("Launch: Vessel from Launch Pad on Kerbin", "Spawn: Vessel (Landed at Midlands on Mun)"). Sortable Site column in Recordings Manager with UT tiebreak. Prerequisite for logistics routes and async multiplayer.
 
 ---
 
@@ -296,7 +283,7 @@ Phase 9: Timeline (v0.7 ✓)
     │  significance tiers, filtering, rewind from timeline
     │
     ▼
-Phase 10: Location Context (complete)
+Phase 10: Location Context (v0.7)
     │  Recordings know WHERE they start/end (body, biome, situation)
     │
     ▼

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -158,7 +158,7 @@ Recordings become location-aware. Each recording knows where it started and ende
 - Vessel situation at recording start (not just end)
 - Stock launch site name from `FlightDriver.LaunchSiteName` (Launch Pad, Runway, Making History DLC sites)
 - Timeline shows "Launch: Vessel from Launch Pad on Kerbin" and "Spawn: Vessel (Landed at Midlands on Mun)"
-- UI grouping and filtering by launch site in the Recordings Manager
+- ~~UI grouping and filtering by launch site in the Recordings Manager~~ *(done — sortable Site column with UT tiebreak)*
 - Prerequisite for logistics routes (Phase 12) and async multiplayer (Phase 13)
 
 Small, additive feature. A few metadata fields at recording start and end.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -150,15 +150,15 @@ Unified chronological view of all committed career events, replacing the Game Ac
 
 ---
 
-## Phase 10: Location Context
+## ~~Phase 10: Location Context~~ *(complete)*
 
 Recordings become location-aware. Each recording knows where it started and ended — body, biome, situation, coordinates, and stock launch site name.
 
-- Biome captured at recording start and end via `ScienceUtil.GetExperimentBiome`
-- Vessel situation at recording start (not just end)
-- Stock launch site name from `FlightDriver.LaunchSiteName` (Launch Pad, Runway, Making History DLC sites)
-- Timeline shows "Launch: Vessel from Launch Pad on Kerbin" and "Spawn: Vessel (Landed at Midlands on Mun)"
-- ~~UI grouping and filtering by launch site in the Recordings Manager~~ *(done — sortable Site column with UT tiebreak)*
+- ~~Biome captured at recording start and end via `ScienceUtil.GetExperimentBiome`~~
+- ~~Vessel situation at recording start (not just end)~~
+- ~~Stock launch site name from `FlightDriver.LaunchSiteName` (Launch Pad, Runway, Making History DLC sites)~~
+- ~~Timeline shows "Launch: Vessel from Launch Pad on Kerbin" and "Spawn: Vessel (Landed at Midlands on Mun)"~~
+- ~~UI grouping and filtering by launch site in the Recordings Manager~~ *(sortable Site column with UT tiebreak)*
 - Prerequisite for logistics routes (Phase 12) and async multiplayer (Phase 13)
 
 Small, additive feature. A few metadata fields at recording start and end.
@@ -296,7 +296,7 @@ Phase 9: Timeline (v0.7 ✓)
     │  significance tiers, filtering, rewind from timeline
     │
     ▼
-Phase 10: Location Context
+Phase 10: Location Context ✓
     │  Recordings know WHERE they start/end (body, biome, situation)
     │
     ▼

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -296,7 +296,7 @@ Phase 9: Timeline (v0.7 ✓)
     │  significance tiers, filtering, rewind from timeline
     │
     ▼
-Phase 10: Location Context ✓
+Phase 10: Location Context (complete)
     │  Recordings know WHERE they start/end (body, biome, situation)
     │
     ▼


### PR DESCRIPTION
## Summary
- Adds a sortable **Site** column to the Recordings Manager that displays `LaunchSiteName` and sorts by site name (case-insensitive) with UT tiebreak for recordings at the same location
- Renames the expanded-stats toggle button from "Stats" to "Info"
- Increases recordings window width by 90px (collapsed 1106->1196, expanded 1564->1654, initial 1106->1196)
- Strikes T54 (timeline spawn entries already show landing location)
- Moves Phase 10 (Location Context) into the v0.7 Completed section on roadmap

## Test plan
- [x] 9 unit tests for LaunchSite sorting (comparison, tiebreak, null handling, case-insensitive, descending, BuildSortedIndices, sort key fallbacks)
- [x] All 5587 tests pass
- [x] In-game: verify Site column displays correctly, click header to sort, verify UT tiebreak within same site