### PR TITLE
Fix #241: ghost base variant falls through to wrong texture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Parsek are documented here.
 
 ## 0.7.3
 
+### Bug Fixes
+
+- `#241` Ghost parts with the base/default color variant (e.g., BlackAndWhite fuel tanks) no longer show the wrong variant texture (was Orange).
+
 ---
 
 ## 0.7.2

--- a/Source/Parsek.Tests/VariantTextureTests.cs
+++ b/Source/Parsek.Tests/VariantTextureTests.cs
@@ -296,6 +296,144 @@ namespace Parsek.Tests
 
         #endregion
 
+        #region MatchVariantNode
+
+        private static ConfigNode BuildRockomax16VariantConfig()
+        {
+            // Mirrors Rockomax16.cfg: base variant is BlackAndWhite (implicit),
+            // two explicit VARIANT nodes: Orange and ESA.
+            var module = new ConfigNode("MODULE");
+            module.AddValue("name", "ModulePartVariants");
+            module.AddValue("baseThemeName", "BlackAndWhite");
+
+            var orange = module.AddNode("VARIANT");
+            orange.AddValue("name", "Orange");
+            var orangeTex = orange.AddNode("TEXTURE");
+            orangeTex.AddValue("mainTextureURL", "Squad/Parts/FuelTank/rockomax_16_O");
+
+            var esa = module.AddNode("VARIANT");
+            esa.AddValue("name", "ESA");
+            var esaTex = esa.AddNode("TEXTURE");
+            esaTex.AddValue("mainTextureURL", "Squad/Parts/FuelTank/rockomax_16_ESA");
+
+            return module;
+        }
+
+        [Fact]
+        public void MatchVariantNode_SnapshotNameMatchesVariant_ReturnsTrue()
+        {
+            var config = BuildRockomax16VariantConfig();
+
+            bool result = GhostVisualBuilder.MatchVariantNode(
+                config, "Orange", variantFromSnapshot: true,
+                out ConfigNode node, out string name, out string path);
+
+            Assert.True(result);
+            Assert.Equal("Orange", name);
+            Assert.Equal("snapshot", path);
+            Assert.NotNull(node);
+        }
+
+        [Fact]
+        public void MatchVariantNode_SnapshotNameMatchesVariant_CaseInsensitive()
+        {
+            var config = BuildRockomax16VariantConfig();
+
+            bool result = GhostVisualBuilder.MatchVariantNode(
+                config, "orange", variantFromSnapshot: true,
+                out ConfigNode node, out string name, out string path);
+
+            Assert.True(result);
+            Assert.Equal("Orange", name);
+            Assert.Equal("snapshot", path);
+        }
+
+        [Fact]
+        public void MatchVariantNode_SnapshotNameNotInVariants_ReturnsFalse_BaseImplicit()
+        {
+            // This is the bug #241 scenario: snapshot says "Basic" (the implicit base
+            // variant display name) but no VARIANT node is named "Basic".
+            var config = BuildRockomax16VariantConfig();
+
+            bool result = GhostVisualBuilder.MatchVariantNode(
+                config, "Basic", variantFromSnapshot: true,
+                out ConfigNode node, out string name, out string path);
+
+            Assert.False(result);
+            Assert.Null(node);
+            Assert.Equal("Basic", name);
+            Assert.Equal("base-implicit", path);
+        }
+
+        [Fact]
+        public void MatchVariantNode_EmptySnapshotName_FallsThrough_ReturnsFirstVariant()
+        {
+            // When snapshot has no variant name, fall through to first VARIANT node.
+            var config = BuildRockomax16VariantConfig();
+
+            bool result = GhostVisualBuilder.MatchVariantNode(
+                config, null, variantFromSnapshot: false,
+                out ConfigNode node, out string name, out string path);
+
+            Assert.True(result);
+            Assert.Equal("Orange", name);
+            Assert.Equal("first-fallback", path);
+        }
+
+        [Fact]
+        public void MatchVariantNode_BaseVariantConfigured_MatchesBaseVariant()
+        {
+            // When baseVariant is set and no snapshot name, should match the base variant.
+            var module = new ConfigNode("MODULE");
+            module.AddValue("name", "ModulePartVariants");
+            module.AddValue("baseVariant", "White");
+
+            var orange = module.AddNode("VARIANT");
+            orange.AddValue("name", "Orange");
+            var white = module.AddNode("VARIANT");
+            white.AddValue("name", "White");
+
+            bool result = GhostVisualBuilder.MatchVariantNode(
+                module, null, variantFromSnapshot: false,
+                out ConfigNode node, out string name, out string path);
+
+            Assert.True(result);
+            Assert.Equal("White", name);
+            Assert.Equal("base", path);
+        }
+
+        [Fact]
+        public void MatchVariantNode_RuntimeNameNotInVariants_StillFallsThrough()
+        {
+            // When the name comes from runtime fields (not snapshot), an unmatched name
+            // should still fall through to baseVariant/first-variant — runtime fields are
+            // less authoritative than snapshot.
+            var config = BuildRockomax16VariantConfig();
+
+            bool result = GhostVisualBuilder.MatchVariantNode(
+                config, "SomeRuntimeName", variantFromSnapshot: false,
+                out ConfigNode node, out string name, out string path);
+
+            Assert.True(result);
+            Assert.Equal("Orange", name);
+            Assert.Equal("first-fallback", path);
+        }
+
+        [Fact]
+        public void MatchVariantNode_NoVariantNodes_ReturnsFalse()
+        {
+            var module = new ConfigNode("MODULE");
+            module.AddValue("name", "ModulePartVariants");
+
+            bool result = GhostVisualBuilder.MatchVariantNode(
+                module, "Orange", variantFromSnapshot: true,
+                out ConfigNode node, out string name, out string path);
+
+            Assert.False(result);
+        }
+
+        #endregion
+
         #region VariantTextureRule struct — TEXTURE ConfigNode parsing
 
         [Fact]

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -2814,6 +2814,24 @@ namespace Parsek
                 }
             }
 
+            return MatchVariantNode(variantModuleConfig, requestedVariantName, variantFromSnapshot,
+                out selectedVariantNode, out selectedVariantName, out resolutionPath);
+        }
+
+        /// <summary>
+        /// Pure matching logic: given the variant MODULE config and a requested variant name,
+        /// find the matching VARIANT node. Extracted for unit testability.
+        /// </summary>
+        internal static bool MatchVariantNode(
+            ConfigNode variantModuleConfig,
+            string requestedVariantName, bool variantFromSnapshot,
+            out ConfigNode selectedVariantNode, out string selectedVariantName,
+            out string resolutionPath)
+        {
+            selectedVariantNode = null;
+            selectedVariantName = null;
+            resolutionPath = null;
+
             string baseVariantName = FirstNonEmptyConfigValue(variantModuleConfig, "baseVariant");
             ConfigNode[] variantNodes = variantModuleConfig.GetNodes("VARIANT");
             if (variantNodes == null || variantNodes.Length == 0)
@@ -2841,6 +2859,18 @@ namespace Parsek
                     resolutionPath = variantFromSnapshot ? "snapshot" : "runtime";
                     break;
                 }
+            }
+
+            // If the snapshot explicitly named a variant that doesn't match any VARIANT
+            // node, this is the implicit base variant (e.g., KSP stores "Basic" as the
+            // display name for the MODULE-level default appearance). The prefab already
+            // has the correct base textures/geometry — return false so callers skip
+            // variant rule application rather than falling through to variantNodes[0].
+            if (selectedVariantNode == null && variantFromSnapshot)
+            {
+                selectedVariantName = requestedVariantName;
+                resolutionPath = "base-implicit";
+                return false;
             }
 
             if (selectedVariantNode == null && !string.IsNullOrEmpty(baseLower))
@@ -5208,6 +5238,12 @@ namespace Parsek
                 ParsekLog.VerboseRateLimited("GhostVisual", $"variant_fb_{partName}",
                     $"  Variant fallback: no active variant renderers and no GAMEOBJECT rules " +
                     $"— including all renderers (active MR={activeMR}, active SMR={activeSMR})", 60.0);
+            }
+            if (hasPartVariants && variantResolutionPath == "base-implicit")
+            {
+                ParsekLog.VerboseRateLimited("GhostVisual", $"variant_base_{partName}",
+                    $"  Variant '{selectedVariantName}' not in VARIANT nodes " +
+                    $"— using base variant (prefab default materials)", 60.0);
             }
 
             // Name by persistentId for O(1) lookup during playback; fall back to part name

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -83,11 +83,11 @@ Intermediate tree recordings with 0 trajectory points but non-null VesselSnapsho
 
 ---
 
-## 241. Ghost fuel tanks have wrong color variant
+## ~~241. Ghost fuel tanks have wrong color variant~~
 
-Some fuel tanks on ghost vessels display with the wrong color/texture variant during playback. The ghost visual builder clones the prefab model, but KSP fuel tanks can have multiple texture variants (e.g., Orange, White, Gray via `ModulePartVariants`). The variant selection from the vessel snapshot may not be applied to the ghost clone.
+Parts whose base/default variant is implicit (not a VARIANT node) showed the wrong color. KSP stores the base variant's display name (e.g., "Basic") as `moduleVariantName`, but no VARIANT node has that name — `TryFindSelectedVariantNode` fell through to `variantNodes[0]` (e.g., Orange) instead of keeping the prefab default. Fix: `MatchVariantNode` returns false when the snapshot names a variant with no matching VARIANT node, so callers skip variant rule application and the prefab's base materials are preserved.
 
-**Priority:** Low — cosmetic, ghost shape is correct
+**Fix:** PR #198
 
 ---
 


### PR DESCRIPTION
## Summary

- Ghost parts with implicit base variants (e.g., `Rockomax16.BW` default BlackAndWhite) were rendered with the wrong texture variant (Orange). KSP stores the base variant display name ("Basic") as `moduleVariantName`, but no VARIANT node matches — `TryFindSelectedVariantNode` fell through to `variantNodes[0]`.
- Extract `MatchVariantNode` from `TryFindSelectedVariantNode` for unit testability. When the snapshot names a variant with no matching VARIANT node, return false so callers skip variant rule application and the prefab's base materials are preserved.
- 7 new tests covering: exact match, case-insensitive match, base-implicit (the bug), empty snapshot fallthrough, baseVariant config, runtime name fallthrough, no-variant-nodes guard.

## Test plan

- [x] All 5585 unit tests pass
- [x] 7 new `MatchVariantNode` tests cover the fix and regression paths
- [x] In-game: launch KerbalX, record, play back ghost — upper stage fuel tank should be BlackAndWhite, not Orange
- [x] In-game: verify Orange-variant parts still show Orange on ghost

🤖 Generated with [Claude Code](https://claude.com/claude-code)