### PR TITLE
T53: Horizon-locked watch camera mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Parsek are documented here.
 
 ## 0.7.3
 
+### New Features
+
+- Watch camera mode: press V during ghost watch to toggle between free orbit and horizon-locked (ground always at screen bottom). Auto-selects horizon-locked near planetary surfaces, free in orbit.
+
 ---
 
 ## 0.7.2

--- a/Source/Parsek.Tests/HorizonCameraTests.cs
+++ b/Source/Parsek.Tests/HorizonCameraTests.cs
@@ -165,6 +165,23 @@ namespace Parsek.Tests
                 $"Should fall back to lastForward when velocity is pure vertical, got {forward}");
         }
 
+        [Fact]
+        public void ComputeHorizonForward_LastForwardAlignedWithUp_FallsToArbitrary()
+        {
+            // lastForward parallel to up — its horizon projection is zero,
+            // should trigger the arbitrary perpendicular fallback
+            Vector3 up = Vector3.up;
+            Vector3 velocity = Vector3.zero;
+            Vector3 lastForward = Vector3.up; // aligned with up
+
+            Vector3 forward = ParsekFlight.ComputeHorizonForward(up, velocity, lastForward);
+
+            Assert.True(forward.sqrMagnitude > 0.9f,
+                $"Forward should be valid, got magnitude {forward.magnitude}");
+            Assert.True(Mathf.Abs(Vector3.Dot(forward, up)) < 0.01f,
+                $"Forward should be perpendicular to up, got dot={Vector3.Dot(forward, up)}");
+        }
+
         #endregion
 
         // Note: ComputeHorizonRotation and CompensateCameraAngles depend on

--- a/Source/Parsek.Tests/HorizonCameraTests.cs
+++ b/Source/Parsek.Tests/HorizonCameraTests.cs
@@ -1,0 +1,174 @@
+using UnityEngine;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    public class HorizonCameraTests
+    {
+        #region ShouldAutoHorizonLock
+
+        [Fact]
+        public void ShouldAutoHorizonLock_AtmosphericBody_BelowAtmosphere_ReturnsTrue()
+        {
+            Assert.True(ParsekFlight.ShouldAutoHorizonLock(
+                hasAtmosphere: true, atmosphereDepth: 70000, altitude: 30000));
+        }
+
+        [Fact]
+        public void ShouldAutoHorizonLock_AtmosphericBody_AboveAtmosphere_ReturnsFalse()
+        {
+            Assert.False(ParsekFlight.ShouldAutoHorizonLock(
+                hasAtmosphere: true, atmosphereDepth: 70000, altitude: 80000));
+        }
+
+        [Fact]
+        public void ShouldAutoHorizonLock_AtmosphericBody_AtThreshold_ReturnsFalse()
+        {
+            Assert.False(ParsekFlight.ShouldAutoHorizonLock(
+                hasAtmosphere: true, atmosphereDepth: 70000, altitude: 70000));
+        }
+
+        [Fact]
+        public void ShouldAutoHorizonLock_AirlessBody_Below50km_ReturnsTrue()
+        {
+            Assert.True(ParsekFlight.ShouldAutoHorizonLock(
+                hasAtmosphere: false, atmosphereDepth: 0, altitude: 10000));
+        }
+
+        [Fact]
+        public void ShouldAutoHorizonLock_AirlessBody_Above50km_ReturnsFalse()
+        {
+            Assert.False(ParsekFlight.ShouldAutoHorizonLock(
+                hasAtmosphere: false, atmosphereDepth: 0, altitude: 60000));
+        }
+
+        [Fact]
+        public void ShouldAutoHorizonLock_AirlessBody_AtThreshold_ReturnsFalse()
+        {
+            Assert.False(ParsekFlight.ShouldAutoHorizonLock(
+                hasAtmosphere: false, atmosphereDepth: 0, altitude: 50000));
+        }
+
+        [Fact]
+        public void ShouldAutoHorizonLock_ZeroAltitude_ReturnsTrue()
+        {
+            Assert.True(ParsekFlight.ShouldAutoHorizonLock(
+                hasAtmosphere: true, atmosphereDepth: 70000, altitude: 0));
+        }
+
+        #endregion
+
+        #region ComputeHorizonForward
+
+        [Fact]
+        public void ComputeHorizonForward_NormalVelocity_ForwardOnHorizon()
+        {
+            Vector3 up = Vector3.up;
+            Vector3 velocity = new Vector3(100, 0, 0); // moving east
+
+            Vector3 forward = ParsekFlight.ComputeHorizonForward(up, velocity, Vector3.forward);
+
+            // Forward should point east (velocity is already on horizon)
+            Assert.True(Vector3.Dot(forward, Vector3.right) > 0.99f,
+                $"Forward should point east, got {forward}");
+        }
+
+        [Fact]
+        public void ComputeHorizonForward_VelocityWithVerticalComponent_ProjectsToHorizon()
+        {
+            Vector3 up = Vector3.up;
+            Vector3 velocity = new Vector3(100, 50, 0); // ascending east
+
+            Vector3 forward = ParsekFlight.ComputeHorizonForward(up, velocity, Vector3.forward);
+
+            // Forward should be on horizon plane (Y component ~0)
+            Assert.True(Mathf.Abs(forward.y) < 0.01f,
+                $"Forward should be on horizon (Y=0), got Y={forward.y}");
+            Assert.True(forward.x > 0.99f,
+                $"Forward should point east after projection, got {forward}");
+        }
+
+        [Fact]
+        public void ComputeHorizonForward_NearZeroVelocity_FallsBackToLastForward()
+        {
+            Vector3 up = Vector3.up;
+            Vector3 velocity = new Vector3(0.001f, 0, 0); // nearly stopped
+            Vector3 lastForward = Vector3.forward;         // was heading north
+
+            Vector3 forward = ParsekFlight.ComputeHorizonForward(up, velocity, lastForward);
+
+            // Should fall back to lastForward (north)
+            Assert.True(Vector3.Dot(forward, Vector3.forward) > 0.99f,
+                $"Should fall back to lastForward (north), got {forward}");
+        }
+
+        [Fact]
+        public void ComputeHorizonForward_ZeroVelocityAndZeroLastForward_PicksArbitrary()
+        {
+            Vector3 up = Vector3.up;
+            Vector3 velocity = Vector3.zero;
+            Vector3 lastForward = Vector3.zero;
+
+            Vector3 forward = ParsekFlight.ComputeHorizonForward(up, velocity, lastForward);
+
+            // Should pick some valid forward (not zero, perpendicular to up)
+            Assert.True(forward.sqrMagnitude > 0.9f,
+                $"Forward should be normalized, got magnitude {forward.magnitude}");
+            Assert.True(Mathf.Abs(Vector3.Dot(forward, up)) < 0.01f,
+                $"Forward should be perpendicular to up, got dot={Vector3.Dot(forward, up)}");
+        }
+
+        [Fact]
+        public void ComputeHorizonForward_ArbitraryUpAxis_OutputPerpendicular()
+        {
+            Vector3 up = new Vector3(0.5f, 0.7f, 0.5f).normalized;
+            Vector3 velocity = new Vector3(10, 5, -3);
+
+            Vector3 forward = ParsekFlight.ComputeHorizonForward(up, velocity, Vector3.forward);
+
+            // Forward should be perpendicular to up
+            float dot = Mathf.Abs(Vector3.Dot(forward, up));
+            Assert.True(dot < 0.01f,
+                $"Forward should be perpendicular to up, got dot={dot}");
+            Assert.True(Mathf.Abs(forward.magnitude - 1f) < 0.01f,
+                $"Forward should be normalized, got magnitude={forward.magnitude}");
+        }
+
+        [Fact]
+        public void ComputeHorizonForward_UpAlignedWithRight_FallbackWorks()
+        {
+            // Edge case: up = (1,0,0), Cross(up, right) = zero
+            Vector3 up = Vector3.right;
+            Vector3 velocity = Vector3.zero;
+            Vector3 lastForward = Vector3.zero;
+
+            Vector3 forward = ParsekFlight.ComputeHorizonForward(up, velocity, lastForward);
+
+            // Should produce valid forward via Cross(up, forward) fallback
+            Assert.True(forward.sqrMagnitude > 0.9f,
+                $"Forward should be valid even when up=right, got {forward}");
+            Assert.True(Mathf.Abs(Vector3.Dot(forward, up)) < 0.01f,
+                $"Forward should be perpendicular to up, got dot={Vector3.Dot(forward, up)}");
+        }
+
+        [Fact]
+        public void ComputeHorizonForward_PureVerticalVelocity_FallsBackToLastForward()
+        {
+            // Velocity pointing straight up — projection onto horizon = zero
+            Vector3 up = Vector3.up;
+            Vector3 velocity = new Vector3(0, 200, 0);
+            Vector3 lastForward = new Vector3(0, 0, 1);
+
+            Vector3 forward = ParsekFlight.ComputeHorizonForward(up, velocity, lastForward);
+
+            Assert.True(Vector3.Dot(forward, Vector3.forward) > 0.99f,
+                $"Should fall back to lastForward when velocity is pure vertical, got {forward}");
+        }
+
+        #endregion
+
+        // Note: ComputeHorizonRotation and CompensateCameraAngles depend on
+        // Quaternion.LookRotation / Quaternion.Euler / Quaternion.Inverse which are
+        // native Unity methods — tested via in-game tests in RuntimeTests.cs.
+    }
+}

--- a/Source/Parsek/GhostPlaybackEngine.cs
+++ b/Source/Parsek/GhostPlaybackEngine.cs
@@ -1498,11 +1498,15 @@ namespace Parsek
             var cameraPivotObj = new GameObject("cameraPivot");
             cameraPivotObj.transform.SetParent(ghost.transform, false);
 
+            var horizonProxyObj = new GameObject("horizonProxy");
+            horizonProxyObj.transform.SetParent(cameraPivotObj.transform, false);
+
             var state = new GhostPlaybackState
             {
                 vesselName = traj?.VesselName ?? "Unknown",
                 ghost = ghost,
                 cameraPivot = cameraPivotObj.transform,
+                horizonProxy = horizonProxyObj.transform,
                 playbackIndex = 0,
                 partEventIndex = 0,
                 partTree = GhostVisualBuilder.BuildPartSubtreeMap(GhostVisualBuilder.GetGhostSnapshot(traj))

--- a/Source/Parsek/GhostPlaybackState.cs
+++ b/Source/Parsek/GhostPlaybackState.cs
@@ -46,9 +46,11 @@ namespace Parsek
         public List<Renderer> fidelityDisabledRenderers; // renderers disabled by ReduceFidelity (for precise restore)
         public bool simplified;          // true when SimplifyToOrbitLine soft cap hid the ghost mesh
         public Transform cameraPivot; // child of ghost; centroid of active parts — camera targets this
+        public Transform horizonProxy; // child of cameraPivot; horizon-aligned rotation for locked camera mode
         public Vector3 lastInterpolatedVelocity;
         public string lastInterpolatedBodyName;
         public double lastInterpolatedAltitude;
+        public Vector3 lastValidHorizonForward; // fallback forward direction when velocity near zero
         public RenderingZone currentZone = RenderingZone.Physics; // distance-based rendering zone
         public double lastDistance; // meters from active vessel, updated per frame in ApplyZonePolicy
         public int flagEventIndex;               // tracks which flags have been spawned

--- a/Source/Parsek/InGameTests/RuntimeTests.cs
+++ b/Source/Parsek/InGameTests/RuntimeTests.cs
@@ -454,6 +454,106 @@ namespace Parsek.InGameTests
             InGameAssert.IsGreaterThan(found, 0,
                 "At least one stock part should resolve via PartLoader");
         }
+
+        [InGameTest(Category = "GhostPlayback", Scene = GameScenes.FLIGHT,
+            Description = "Ghost horizonProxy exists as child of cameraPivot")]
+        public void HorizonProxyTransformExists()
+        {
+            // Build a minimal ghost from a committed recording to verify
+            // the horizonProxy transform is created alongside cameraPivot
+            var committed = RecordingStore.CommittedRecordings;
+            if (committed.Count == 0)
+            {
+                ParsekLog.Info("TestRunner", "No committed recordings — skipping HorizonProxyTransformExists");
+                return;
+            }
+
+            var traj = committed[0] as IPlaybackTrajectory;
+            var engine = ParsekFlight.Instance?.Engine;
+            InGameAssert.IsNotNull(engine, "GhostPlaybackEngine should be available in flight");
+
+            // Check if any ghost state has horizonProxy
+            bool anyGhostChecked = false;
+            foreach (var kvp in engine.ghostStates)
+            {
+                var state = kvp.Value;
+                if (state?.cameraPivot == null) continue;
+                anyGhostChecked = true;
+
+                InGameAssert.IsNotNull(state.horizonProxy,
+                    $"Ghost #{kvp.Key} should have horizonProxy");
+                InGameAssert.IsTrue(state.horizonProxy.parent == state.cameraPivot,
+                    $"Ghost #{kvp.Key} horizonProxy should be child of cameraPivot");
+                InGameAssert.IsTrue(state.horizonProxy.localPosition == Vector3.zero,
+                    $"Ghost #{kvp.Key} horizonProxy should be at local origin");
+            }
+
+            if (!anyGhostChecked)
+                ParsekLog.Info("TestRunner", "No active ghosts with cameraPivot — structural check deferred");
+        }
+
+        [InGameTest(Category = "GhostPlayback", Scene = GameScenes.FLIGHT,
+            Description = "ComputeHorizonRotation produces valid rotation near Kerbin surface")]
+        public void HorizonRotationNearSurface()
+        {
+            // Use a realistic Kerbin surface scenario
+            Vector3 up = Vector3.up;
+            Vector3 velocity = new Vector3(200, 10, 0); // moving east, slight ascent
+
+            var (rotation, forward) = WatchModeController.ComputeHorizonRotation(up, velocity, Vector3.forward);
+
+            // Forward should be on horizon plane
+            InGameAssert.IsTrue(Mathf.Abs(forward.y) < 0.01f,
+                $"Forward should be on horizon, got Y={forward.y}");
+
+            // Rotation's up should match input up
+            Vector3 rotUp = rotation * Vector3.up;
+            float upDot = Vector3.Dot(rotUp, up);
+            InGameAssert.IsTrue(upDot > 0.99f,
+                $"Rotation up should match radial, got dot={upDot}");
+
+            // Rotation's forward should match computed forward
+            Vector3 rotFwd = rotation * Vector3.forward;
+            float fwdDot = Vector3.Dot(rotFwd, forward);
+            InGameAssert.IsTrue(fwdDot > 0.99f,
+                $"Rotation forward should match horizon forward, got dot={fwdDot}");
+        }
+
+        [InGameTest(Category = "GhostPlayback", Scene = GameScenes.FLIGHT,
+            Description = "CompensateCameraAngles preserves world direction across rotation change")]
+        public void CameraAngleCompensationPreservesDirection()
+        {
+            Quaternion oldRot = Quaternion.identity;
+            Quaternion newRot = Quaternion.Euler(0, 90, 0);
+            float origPitch = 15f;
+            float origHdg = 30f;
+
+            // World direction from old frame
+            float pRad = origPitch * Mathf.Deg2Rad;
+            float hRad = origHdg * Mathf.Deg2Rad;
+            Vector3 localDir = new Vector3(
+                Mathf.Sin(hRad) * Mathf.Cos(pRad),
+                Mathf.Sin(pRad),
+                Mathf.Cos(hRad) * Mathf.Cos(pRad));
+            Vector3 worldDir = oldRot * localDir;
+
+            // Compensate
+            var (newPitch, newHdg) = WatchModeController.CompensateCameraAngles(
+                oldRot, newRot, origPitch, origHdg);
+
+            // World direction from new frame
+            float npRad = newPitch * Mathf.Deg2Rad;
+            float nhRad = newHdg * Mathf.Deg2Rad;
+            Vector3 newLocalDir = new Vector3(
+                Mathf.Sin(nhRad) * Mathf.Cos(npRad),
+                Mathf.Sin(npRad),
+                Mathf.Cos(nhRad) * Mathf.Cos(npRad));
+            Vector3 newWorldDir = newRot * newLocalDir;
+
+            float dot = Vector3.Dot(worldDir.normalized, newWorldDir.normalized);
+            InGameAssert.IsTrue(dot > 0.99f,
+                $"World direction should be preserved, got dot={dot}");
+        }
     }
 
     /// <summary>

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -5214,6 +5214,13 @@ namespace Parsek
                 watchMode.ExitWatchMode();
             }
 
+            // V — Toggle watch camera mode (Free / Horizon-Locked)
+            // Stock V (camera mode switch) is blocked by CAMERAMODES control lock during watch
+            if (watchMode.IsWatchingGhost && Input.GetKeyDown(KeyCode.V))
+            {
+                watchMode.ToggleCameraMode();
+            }
+
         }
 
         #endregion
@@ -8265,6 +8272,16 @@ namespace Parsek
         internal static (int newIndex, string newId) ComputeWatchIndexAfterDelete(
             int watchedIndex, string watchedId, int deletedIndex, List<Recording> recordings) =>
             WatchModeController.ComputeWatchIndexAfterDelete(watchedIndex, watchedId, deletedIndex, recordings);
+        internal static bool ShouldAutoHorizonLock(bool hasAtmosphere, double atmosphereDepth, double altitude) =>
+            WatchModeController.ShouldAutoHorizonLock(hasAtmosphere, atmosphereDepth, altitude);
+        internal static Vector3 ComputeHorizonForward(Vector3 up, Vector3 velocity, Vector3 lastForward) =>
+            WatchModeController.ComputeHorizonForward(up, velocity, lastForward);
+        internal static (Quaternion rotation, Vector3 forward) ComputeHorizonRotation(
+            Vector3 up, Vector3 velocity, Vector3 lastForward) =>
+            WatchModeController.ComputeHorizonRotation(up, velocity, lastForward);
+        internal static (float pitch, float hdg) CompensateCameraAngles(
+            Quaternion oldTargetRot, Quaternion newTargetRot, float pitch, float hdg) =>
+            WatchModeController.CompensateCameraAngles(oldTargetRot, newTargetRot, pitch, hdg);
 
         IEnumerator DeferredActivateVessel(uint pid)
         {

--- a/Source/Parsek/WatchModeController.cs
+++ b/Source/Parsek/WatchModeController.cs
@@ -791,6 +791,9 @@ namespace Parsek
             float preservedDistance = savedCameraDistance;
             float preservedPitch = savedCameraPitch;
             float preservedHeading = savedCameraHeading;
+            // Preserve camera mode across chain transfers — user's V toggle should stick
+            var preservedCameraMode = currentCameraMode;
+            bool preservedModeOverride = userModeOverride;
 
             // Switch watch mode: exit old (preserving camera position), enter new
             ExitWatchMode(skipCameraRestore: true);
@@ -804,6 +807,8 @@ namespace Parsek
             savedCameraDistance = preservedDistance;
             savedCameraPitch = preservedPitch;
             savedCameraHeading = preservedHeading;
+            currentCameraMode = preservedCameraMode;
+            userModeOverride = preservedModeOverride;
 
             var segTarget = GetWatchTarget(gs.cameraPivot) ?? gs.ghost.transform;
             FlightCamera.fetch.SetTargetTransform(segTarget);

--- a/Source/Parsek/WatchModeController.cs
+++ b/Source/Parsek/WatchModeController.cs
@@ -5,6 +5,8 @@ using UnityEngine;
 
 namespace Parsek
 {
+    internal enum WatchCameraMode { Free, HorizonLocked }
+
     /// <summary>
     /// Owns camera-follow (watch mode) state and methods.
     /// Extracted from ParsekFlight to isolate watch-mode lifecycle.
@@ -37,6 +39,10 @@ namespace Parsek
         private float savedPivotSharpness = 0.5f;
         private int watchNoTargetFrames;               // consecutive frames with no valid camera target (safety net)
 
+        // Horizon-locked camera mode state
+        private WatchCameraMode currentCameraMode = WatchCameraMode.Free;
+        private bool userModeOverride;  // true when user pressed toggle; cleared on EnterWatchMode
+
         // Lazy-initialized GUI styles for the watch mode overlay
         private GUIStyle watchOverlayStyle;
         private GUIStyle watchOverlayHintStyle;
@@ -50,6 +56,7 @@ namespace Parsek
 
         internal bool IsWatchingGhost => watchedRecordingIndex >= 0;
         internal int WatchedRecordingIndex => watchedRecordingIndex;
+        internal WatchCameraMode CurrentCameraMode => currentCameraMode;
 
         // === Camera event handlers for engine loop/overlap cycle transitions ===
 
@@ -94,7 +101,7 @@ namespace Parsek
                 case CameraActionType.RetargetToNewGhost:
                     if (watchedOverlapCycleIndex == -1 && evt.GhostPivot != null && FlightCamera.fetch != null)
                     {
-                        FlightCamera.fetch.SetTargetTransform(evt.GhostPivot);
+                        FlightCamera.fetch.SetTargetTransform(GetWatchTarget(evt.GhostPivot));
                         watchedOverlapCycleIndex = evt.NewCycleIndex;
                         // Clean up the bridge anchor now that camera is on the new ghost
                         if (overlapCameraAnchor != null) { UnityEngine.Object.Destroy(overlapCameraAnchor); overlapCameraAnchor = null; }
@@ -114,7 +121,7 @@ namespace Parsek
                 case CameraActionType.RetargetToNewGhost:
                     if (watchedOverlapCycleIndex == -1 && evt.GhostPivot != null && FlightCamera.fetch != null)
                     {
-                        FlightCamera.fetch.SetTargetTransform(evt.GhostPivot);
+                        FlightCamera.fetch.SetTargetTransform(GetWatchTarget(evt.GhostPivot));
                         watchedOverlapCycleIndex = evt.NewCycleIndex;
                         if (overlapCameraAnchor != null) { UnityEngine.Object.Destroy(overlapCameraAnchor); overlapCameraAnchor = null; }
                         ParsekLog.Info("CameraFollow",
@@ -224,11 +231,13 @@ namespace Parsek
             GUI.DrawTexture(bgRect, Texture2D.whiteTexture);
             GUI.color = Color.white;
 
+            string modeLabel = currentCameraMode == WatchCameraMode.HorizonLocked
+                ? " [Horizon]" : " [Free]";
             string title = string.IsNullOrEmpty(distText)
-                ? "Watching: " + vesselName
-                : "Watching: " + vesselName + "  (" + distText + ")";
+                ? "Watching: " + vesselName + modeLabel
+                : "Watching: " + vesselName + "  (" + distText + ")" + modeLabel;
             GUI.Label(new Rect(x, y + 5, boxW, 22f), title, watchOverlayStyle);
-            GUI.Label(new Rect(x, y + 27, boxW, 18f), "Press [ or ] to return to vessel", watchOverlayHintStyle);
+            GUI.Label(new Rect(x, y + 27, boxW, 18f), "[ ] return  |  V toggle camera", watchOverlayHintStyle);
         }
 
         /// <summary>
@@ -305,6 +314,10 @@ namespace Parsek
             watchedRecordingId = committed[index].RecordingId;
             watchStartTime = Time.time;
 
+            // Reset camera mode state for new watch session
+            userModeOverride = false;
+            currentCameraMode = WatchCameraMode.Free; // auto-detect will set this on first frame
+
             // If the ghost is currently beyond visual range and the recording loops,
             // reset the loop phase so the ghost starts from the beginning of the recording
             // (at the pad) instead of wherever it is mid-flight (e.g. near the Mun).
@@ -324,8 +337,8 @@ namespace Parsek
             // Disable KSP's internal pivot tracking -- we drive the camera manually
             FlightCamera.fetch.pivotTranslateSharpness = 0f;
 
-            // Point camera at ghost (use cameraPivot -- centroid of active parts)
-            var watchTarget = gs.cameraPivot ?? gs.ghost.transform;
+            // Point camera at ghost (use cameraPivot or horizonProxy based on mode)
+            var watchTarget = GetWatchTarget(gs.cameraPivot) ?? gs.ghost.transform;
             FlightCamera.fetch.SetTargetTransform(watchTarget);
             FlightCamera.fetch.SetDistance(50f);  // override [75,400] entry clamp
             watchedOverlapCycleIndex = gs.loopCycleIndex; // track which cycle we're following
@@ -451,6 +464,8 @@ namespace Parsek
             savedCameraHeading = 0f;
             watchEndHoldUntilRealTime = -1;
             watchNoTargetFrames = 0;
+            currentCameraMode = WatchCameraMode.Free;
+            userModeOverride = false;
         }
 
         /// <summary>
@@ -477,6 +492,212 @@ namespace Parsek
 
                 default:
                     return false;
+            }
+        }
+
+        // === Horizon-locked camera mode — pure static methods ===
+
+        /// <summary>
+        /// Determines whether the camera should auto-select horizon-locked mode
+        /// based on altitude relative to the body's atmosphere or surface threshold.
+        /// </summary>
+        internal static bool ShouldAutoHorizonLock(bool hasAtmosphere, double atmosphereDepth, double altitude)
+        {
+            double threshold = hasAtmosphere ? atmosphereDepth : 50000.0;
+            return altitude < threshold;
+        }
+
+        /// <summary>
+        /// Computes the horizon-plane forward direction from velocity and up vector.
+        /// Projects velocity onto the horizon plane (perpendicular to up). Falls back
+        /// to lastForward when velocity is near zero, then to an arbitrary perpendicular.
+        /// Pure vector math — testable outside Unity runtime.
+        /// </summary>
+        internal static Vector3 ComputeHorizonForward(Vector3 up, Vector3 velocity, Vector3 lastForward)
+        {
+            Vector3 forward = Vector3.ProjectOnPlane(velocity, up);
+            if (forward.sqrMagnitude < 0.01f)
+            {
+                forward = Vector3.ProjectOnPlane(lastForward, up);
+                if (forward.sqrMagnitude < 0.0001f)
+                {
+                    forward = Vector3.Cross(up, Vector3.right);
+                    if (forward.sqrMagnitude < 0.0001f)
+                        forward = Vector3.Cross(up, Vector3.forward);
+                }
+            }
+            forward.Normalize();
+            return forward;
+        }
+
+        /// <summary>
+        /// Computes the horizon-aligned rotation for the camera proxy.
+        /// Wraps ComputeHorizonForward with Quaternion.LookRotation.
+        /// </summary>
+        internal static (Quaternion rotation, Vector3 forward) ComputeHorizonRotation(
+            Vector3 up, Vector3 velocity, Vector3 lastForward)
+        {
+            Vector3 forward = ComputeHorizonForward(up, velocity, lastForward);
+            return (Quaternion.LookRotation(forward, up), forward);
+        }
+
+        /// <summary>
+        /// Compensates camPitch/camHdg when switching the camera target between
+        /// transforms with different rotations, preventing a visual snap.
+        /// Decomposes the current camera orbit direction from the old frame
+        /// into equivalent angles in the new frame.
+        /// </summary>
+        internal static (float pitch, float hdg) CompensateCameraAngles(
+            Quaternion oldTargetRot, Quaternion newTargetRot, float pitch, float hdg)
+        {
+            // Convert current pitch/hdg to a direction vector in world space
+            // FlightCamera: pitch = elevation (degrees), hdg = azimuth (degrees)
+            // Camera orbits at (hdg, pitch) relative to the target's local frame
+            float pitchRad = pitch * Mathf.Deg2Rad;
+            float hdgRad = hdg * Mathf.Deg2Rad;
+
+            // Spherical to local direction (KSP convention: Y=up, Z=forward, X=right)
+            Vector3 localDir = new Vector3(
+                Mathf.Sin(hdgRad) * Mathf.Cos(pitchRad),
+                Mathf.Sin(pitchRad),
+                Mathf.Cos(hdgRad) * Mathf.Cos(pitchRad));
+
+            // Transform to world space via old target, then back to new target's local space
+            Vector3 worldDir = oldTargetRot * localDir;
+            Vector3 newLocalDir = Quaternion.Inverse(newTargetRot) * worldDir;
+
+            // Decompose back to pitch/hdg
+            float newPitch = Mathf.Asin(Mathf.Clamp(newLocalDir.y, -1f, 1f)) * Mathf.Rad2Deg;
+            float newHdg = Mathf.Atan2(newLocalDir.x, newLocalDir.z) * Mathf.Rad2Deg;
+
+            return (newPitch, newHdg);
+        }
+
+        // === Horizon-locked camera mode — instance methods ===
+
+        /// <summary>
+        /// Resolves the CelestialBody for the watched ghost, reusing the
+        /// ghost's cached audio body lookup to avoid per-frame linear scan.
+        /// </summary>
+        private CelestialBody ResolveBody(GhostPlaybackState state)
+        {
+            string bodyName = state.lastInterpolatedBodyName;
+            if (string.IsNullOrEmpty(bodyName)) return null;
+            if (state.cachedAudioBody != null && state.cachedAudioBodyName == bodyName)
+                return state.cachedAudioBody;
+            var body = FlightGlobals.Bodies?.Find(b => b.name == bodyName);
+            if (body != null)
+            {
+                state.cachedAudioBody = body;
+                state.cachedAudioBodyName = bodyName;
+            }
+            return body;
+        }
+
+        /// <summary>
+        /// Returns the correct camera target transform based on current mode.
+        /// For cameraPivot transforms with a horizonProxy child, returns horizonProxy
+        /// when in HorizonLocked mode. For anchor transforms (no children), returns
+        /// the anchor itself (Free mode during explosion/bridge holds).
+        /// </summary>
+        private Transform GetWatchTarget(Transform cameraPivot)
+        {
+            if (currentCameraMode != WatchCameraMode.HorizonLocked || cameraPivot == null)
+                return cameraPivot;
+            var proxy = cameraPivot.Find("horizonProxy");
+            return proxy != null ? proxy : cameraPivot;
+        }
+
+        /// <summary>
+        /// Switches the FlightCamera target between cameraPivot and horizonProxy
+        /// based on current mode, with pitch/heading compensation to prevent snap.
+        /// </summary>
+        private void ApplyCameraTarget(GhostPlaybackState state)
+        {
+            if (FlightCamera.fetch == null || state == null) return;
+            Transform oldTarget = FlightCamera.fetch.Target;
+            Transform newTarget = currentCameraMode == WatchCameraMode.HorizonLocked
+                ? (state.horizonProxy ?? state.cameraPivot)
+                : state.cameraPivot;
+            if (newTarget == null) newTarget = state.cameraPivot;
+            if (newTarget == null || newTarget == oldTarget) return;
+
+            // Compensate pitch/heading to prevent visual snap on mode switch
+            Quaternion oldRot = oldTarget != null ? oldTarget.rotation : Quaternion.identity;
+            Quaternion newRot = newTarget.rotation;
+            var (newPitch, newHdg) = CompensateCameraAngles(
+                oldRot, newRot, FlightCamera.fetch.camPitch, FlightCamera.fetch.camHdg);
+
+            FlightCamera.fetch.SetTargetTransform(newTarget);
+            FlightCamera.fetch.camPitch = newPitch;
+            FlightCamera.fetch.camHdg = newHdg;
+        }
+
+        /// <summary>
+        /// Toggles between Free and HorizonLocked camera modes.
+        /// Sets userModeOverride to prevent auto-switching.
+        /// </summary>
+        internal void ToggleCameraMode()
+        {
+            if (watchedRecordingIndex < 0) return;
+
+            var state = FindWatchedGhostState();
+            if (state == null) return;
+
+            userModeOverride = true;
+            currentCameraMode = currentCameraMode == WatchCameraMode.Free
+                ? WatchCameraMode.HorizonLocked
+                : WatchCameraMode.Free;
+
+            ApplyCameraTarget(state);
+
+            ParsekLog.Info("CameraFollow",
+                $"Watch camera mode toggled to {currentCameraMode} (user override)");
+            ParsekLog.ScreenMessage(
+                currentCameraMode == WatchCameraMode.HorizonLocked
+                    ? "Camera: Horizon Locked"
+                    : "Camera: Free",
+                2f);
+        }
+
+        /// <summary>
+        /// Updates the horizonProxy rotation and auto-detects camera mode each frame.
+        /// Called from UpdateWatchCamera after the camera position is driven.
+        /// </summary>
+        private void UpdateHorizonProxy(GhostPlaybackState state)
+        {
+            if (state.horizonProxy == null) return;
+
+            CelestialBody body = ResolveBody(state);
+
+            // Auto-detect mode (unless user overrode)
+            if (!userModeOverride && body != null)
+            {
+                bool shouldLock = ShouldAutoHorizonLock(
+                    body.atmosphere, body.atmosphereDepth, state.lastInterpolatedAltitude);
+                var autoMode = shouldLock ? WatchCameraMode.HorizonLocked : WatchCameraMode.Free;
+                if (autoMode != currentCameraMode)
+                {
+                    currentCameraMode = autoMode;
+                    ApplyCameraTarget(state);
+                    ParsekLog.Info("CameraFollow",
+                        string.Format(CultureInfo.InvariantCulture,
+                            "Watch camera auto-switched to {0} (alt={1:F0}m, body={2})",
+                            currentCameraMode, state.lastInterpolatedAltitude,
+                            state.lastInterpolatedBodyName));
+                }
+            }
+
+            // Always update horizonProxy rotation (keeps it ready for smooth switch)
+            if (body != null && state.cameraPivot != null)
+            {
+                Vector3 ghostPos = state.cameraPivot.position;
+                Vector3 up = (ghostPos - body.position).normalized;
+
+                var (rotation, forward) = ComputeHorizonRotation(
+                    up, state.lastInterpolatedVelocity, state.lastValidHorizonForward);
+                state.horizonProxy.rotation = rotation;
+                state.lastValidHorizonForward = forward;
             }
         }
 
@@ -584,7 +805,7 @@ namespace Parsek
             savedCameraPitch = preservedPitch;
             savedCameraHeading = preservedHeading;
 
-            var segTarget = gs.cameraPivot ?? gs.ghost.transform;
+            var segTarget = GetWatchTarget(gs.cameraPivot) ?? gs.ghost.transform;
             FlightCamera.fetch.SetTargetTransform(segTarget);
             InputLockManager.SetControlLock(WatchModeLockMask, WatchModeLockId);
             ParsekLog.Verbose("CameraFollow",
@@ -694,6 +915,9 @@ namespace Parsek
 
             // Drive camera orbit center to the cameraPivot's world position
             FlightCamera.fetch.transform.parent.position = state.cameraPivot.position;
+
+            // Update horizon proxy rotation and auto-detect camera mode
+            UpdateHorizonProxy(state);
         }
 
         /// <summary>
@@ -799,7 +1023,7 @@ namespace Parsek
                         state = primary;
                         watchedOverlapCycleIndex = primary.loopCycleIndex;
                         if (FlightCamera.fetch != null)
-                            FlightCamera.fetch.SetTargetTransform(primary.cameraPivot);
+                            FlightCamera.fetch.SetTargetTransform(GetWatchTarget(primary.cameraPivot));
                         ParsekLog.Info("CameraFollow",
                             $"Watched cycle lost \u2014 falling back to primary cycle={primary.loopCycleIndex}");
                     }
@@ -836,7 +1060,7 @@ namespace Parsek
                     && ghostStates.TryGetValue(watchedRecordingIndex, out primary)
                     && primary != null && primary.ghost != null)
                 {
-                    var target = primary.cameraPivot ?? primary.ghost.transform;
+                    var target = GetWatchTarget(primary.cameraPivot) ?? primary.ghost.transform;
                     FlightCamera.fetch.SetTargetTransform(target);
                     watchedOverlapCycleIndex = primary.loopCycleIndex;
                     watchNoTargetFrames = 0;
@@ -918,7 +1142,7 @@ namespace Parsek
             GhostPlaybackState ws;
             if (ghostStates.TryGetValue(watchedRecordingIndex, out ws) && ws != null && ws.ghost != null)
             {
-                var target = ws.cameraPivot ?? ws.ghost.transform;
+                var target = GetWatchTarget(ws.cameraPivot) ?? ws.ghost.transform;
                 FlightCamera.fetch.SetTargetTransform(target);
                 ParsekLog.Info("CameraFollow",
                     $"onVesselChange re-target: ghost #{watchedRecordingIndex}" +

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -194,11 +194,9 @@ Test game actions system with popular mods: CustomBarnKit (non-standard facility
 
 ## TODO — Nice to have
 
-### T53. Watch camera mode selection
+### ~~T53. Watch camera mode selection~~
 
-Allow the player to change the camera mode during ghost watch playback. Currently the camera is always fixed-orientation relative to the ghost. A mode where the ground is oriented at the bottom of the screen (horizon-locked) would be more intuitive for atmospheric flight and surface operations.
-
-**Priority:** Nice-to-have
+**Done.** V key toggles between Free and Horizon-Locked during watch mode. Auto-selects horizon-locked below atmosphere (or 50km on airless bodies), free above. horizonProxy child transform on cameraPivot provides the rotated reference frame; pitch/heading compensation prevents visual snap on mode switch.
 
 ### T54. Timeline spawn entries should show landing location
 


### PR DESCRIPTION
## Summary

- Adds horizon-locked camera mode for ghost watch playback — ground stays at screen bottom, velocity direction becomes forward
- V key toggles between Free and Horizon-Locked during watch mode (stock V is blocked by existing CAMERAMODES control lock)
- Auto-detects mode based on altitude: horizon-locked below atmosphere (or 50km on airless bodies), free in orbit
- Camera pitch/heading compensation on mode switch prevents visual snap
- Overlay shows current mode indicator and key hint

## Implementation

horizonProxy child transform of cameraPivot provides the rotated reference frame. FlightCamera targets either cameraPivot (Free) or horizonProxy (HorizonLocked). All existing SetTargetTransform retarget calls routed through GetWatchTarget() helper. Anchor/hold transforms (no horizonProxy child) naturally stay in Free mode.

## Test plan

- [x] 15 unit tests pass (ShouldAutoHorizonLock + ComputeHorizonForward)
- [x] 3 new in-game tests pass (horizonProxy existence, rotation correctness, angle compensation)
- [x] All 5620 tests pass (15 new + merged main)
- [x] In-game: auto-detection fires on enter — HorizonLocked at 842m on Kerbin
- [x] In-game: V toggle works — multiple toggles logged, overlay updates
- [x] In-game: clean exit with [ or ]

🤖 Generated with [Claude Code](https://claude.com/claude-code)