### PR TITLE
Fix #297: FallbackCommitSplitRecorder orphans tree continuation data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to Parsek are documented here.
 
 ## 0.7.3
 
+- `#297` Vessel destruction during tree recording no longer orphans continuation data as a standalone recording.
+
 ---
 
 ## 0.7.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to Parsek are documented here.
 ## 0.7.3
 
 - `#297` Vessel destruction during tree recording no longer orphans continuation data as a standalone recording.
+- `T55` FlagEvents and SegmentEvents are now preserved across tree recording splits and flushes.
 
 ---
 

--- a/Source/Parsek.Tests/AppendCapturedDataTests.cs
+++ b/Source/Parsek.Tests/AppendCapturedDataTests.cs
@@ -198,5 +198,45 @@ namespace Parsek.Tests
             Assert.Single(target.PartEvents);
             Assert.Single(target.TrackSections);
         }
+
+        [Fact]
+        public void FlagEvents_AppendedAndSorted()
+        {
+            // T55: FlagEvents were missing from AppendCapturedDataToRecording.
+            // Verifies they are now appended and stable-sorted by UT.
+            var target = new Recording();
+            target.FlagEvents.Add(new FlagEvent { ut = 100.0, flagSiteName = "Flag A" });
+
+            var source = new Recording();
+            source.Points.Add(MakePoint(50.0));
+            source.Points.Add(MakePoint(200.0));
+            source.FlagEvents.Add(new FlagEvent { ut = 50.0, flagSiteName = "Flag B" });
+
+            ParsekFlight.AppendCapturedDataToRecording(target, source, 200.0);
+
+            Assert.Equal(2, target.FlagEvents.Count);
+            Assert.Equal(50.0, target.FlagEvents[0].ut);
+            Assert.Equal(100.0, target.FlagEvents[1].ut);
+        }
+
+        [Fact]
+        public void SegmentEvents_AppendedAndSorted()
+        {
+            // T55: SegmentEvents were missing from AppendCapturedDataToRecording.
+            // Verifies they are now appended and stable-sorted by UT.
+            var target = new Recording();
+            target.SegmentEvents.Add(new SegmentEvent { ut = 200.0, type = SegmentEventType.PartDestroyed });
+
+            var source = new Recording();
+            source.Points.Add(MakePoint(100.0));
+            source.Points.Add(MakePoint(300.0));
+            source.SegmentEvents.Add(new SegmentEvent { ut = 100.0, type = SegmentEventType.TimeJump });
+
+            ParsekFlight.AppendCapturedDataToRecording(target, source, 300.0);
+
+            Assert.Equal(2, target.SegmentEvents.Count);
+            Assert.Equal(100.0, target.SegmentEvents[0].ut);
+            Assert.Equal(200.0, target.SegmentEvents[1].ut);
+        }
     }
 }

--- a/Source/Parsek.Tests/TryAppendCapturedToTreeTests.cs
+++ b/Source/Parsek.Tests/TryAppendCapturedToTreeTests.cs
@@ -167,6 +167,50 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void TreeMode_NonDestroyedVessel_DoesNotSetTerminalState()
+        {
+            var tree = MakeTree("root-001");
+            var captured = MakeCaptured(120.0, 180.0, destroyed: false);
+
+            bool result = ParsekFlight.TryAppendCapturedToTree(tree, captured);
+
+            Assert.True(result);
+            var rootRec = tree.Recordings["root-001"];
+            Assert.Null(rootRec.TerminalStateValue);
+            Assert.False(rootRec.VesselDestroyed);
+            Assert.Equal(5, rootRec.Points.Count);
+        }
+
+        [Fact]
+        public void TreeMode_AppendsPartEventsAndOrbitSegments()
+        {
+            var tree = MakeTree("root-001");
+            tree.Recordings["root-001"].PartEvents.Add(new PartEvent
+            {
+                ut = 105.0, partPersistentId = 100, eventType = PartEventType.EngineIgnited, partName = "engine",
+            });
+
+            var captured = MakeCaptured(120.0, 180.0);
+            captured.PartEvents.Add(new PartEvent
+            {
+                ut = 150.0, partPersistentId = 200, eventType = PartEventType.EngineShutdown, partName = "engine",
+            });
+            captured.OrbitSegments.Add(new OrbitSegment
+            {
+                startUT = 130.0, endUT = 170.0, bodyName = "Kerbin",
+            });
+
+            bool result = ParsekFlight.TryAppendCapturedToTree(tree, captured);
+
+            Assert.True(result);
+            var rootRec = tree.Recordings["root-001"];
+            Assert.Equal(2, rootRec.PartEvents.Count);
+            Assert.Equal(105.0, rootRec.PartEvents[0].ut); // sorted
+            Assert.Equal(150.0, rootRec.PartEvents[1].ut);
+            Assert.Single(rootRec.OrbitSegments);
+        }
+
+        [Fact]
         public void TreeMode_PreservesMaxDist_WhenCapturedIsSmaller()
         {
             var tree = MakeTree("root-001");

--- a/Source/Parsek.Tests/TryAppendCapturedToTreeTests.cs
+++ b/Source/Parsek.Tests/TryAppendCapturedToTreeTests.cs
@@ -1,0 +1,182 @@
+using System.Collections.Generic;
+using UnityEngine;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Tests for <see cref="ParsekFlight.TryAppendCapturedToTree"/>.
+    /// Bug #297: FallbackCommitSplitRecorder was tree-mode-unaware and orphaned
+    /// continuation trajectory data as ungrouped standalone recordings instead of
+    /// appending to the active tree recording.
+    /// </summary>
+    [Collection("Sequential")]
+    public class TryAppendCapturedToTreeTests : System.IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public TryAppendCapturedToTreeTests()
+        {
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+        }
+
+        private static TrajectoryPoint MakePoint(double ut)
+        {
+            return new TrajectoryPoint
+            {
+                ut = ut,
+                latitude = 0.0,
+                longitude = 0.0,
+                altitude = 100.0,
+                bodyName = "Kerbin",
+                rotation = Quaternion.identity,
+                velocity = Vector3.zero,
+            };
+        }
+
+        private static Recording MakeCaptured(double startUT, double endUT, bool destroyed = false, double maxDist = 500.0)
+        {
+            var rec = new Recording();
+            rec.Points.Add(MakePoint(startUT));
+            rec.Points.Add(MakePoint((startUT + endUT) / 2));
+            rec.Points.Add(MakePoint(endUT));
+            rec.VesselDestroyed = destroyed;
+            rec.MaxDistanceFromLaunch = maxDist;
+            rec.EndBiome = "Grasslands";
+            return rec;
+        }
+
+        private static RecordingTree MakeTree(string rootId, string activeId = null)
+        {
+            var tree = new RecordingTree
+            {
+                Id = "tree-001",
+                TreeName = "Test Vessel",
+                RootRecordingId = rootId,
+                ActiveRecordingId = activeId ?? rootId,
+            };
+            var rootRec = new Recording { RecordingId = rootId, VesselName = "Test Vessel" };
+            rootRec.Points.Add(MakePoint(100.0));
+            rootRec.Points.Add(MakePoint(110.0));
+            rootRec.EndBiome = "Shores";
+            rootRec.MaxDistanceFromLaunch = 200.0;
+            tree.Recordings[rootId] = rootRec;
+            return tree;
+        }
+
+        [Fact]
+        public void TreeMode_AppendsToActiveRecording()
+        {
+            var tree = MakeTree("root-001");
+            var captured = MakeCaptured(120.0, 180.0, destroyed: true, maxDist: 5000.0);
+
+            bool result = ParsekFlight.TryAppendCapturedToTree(tree, captured);
+
+            Assert.True(result);
+            var rootRec = tree.Recordings["root-001"];
+            // Original 2 points + 3 captured points = 5
+            Assert.Equal(5, rootRec.Points.Count);
+            Assert.Equal(TerminalState.Destroyed, rootRec.TerminalStateValue);
+            Assert.True(rootRec.VesselDestroyed);
+            Assert.Equal(5000.0, rootRec.MaxDistanceFromLaunch);
+            Assert.Equal("Grasslands", rootRec.EndBiome);
+            Assert.Equal(180.0, rootRec.ExplicitEndUT);
+            Assert.Contains(logLines, l => l.Contains("[Flight]") && l.Contains("TryAppendCapturedToTree: appended 3 points"));
+        }
+
+        [Fact]
+        public void TreeMode_FallsBackToRoot_WhenActiveIdNull()
+        {
+            var tree = MakeTree("root-001", activeId: null);
+            tree.ActiveRecordingId = null;
+            var captured = MakeCaptured(120.0, 180.0);
+
+            bool result = ParsekFlight.TryAppendCapturedToTree(tree, captured);
+
+            Assert.True(result);
+            Assert.Equal(5, tree.Recordings["root-001"].Points.Count);
+            Assert.Contains(logLines, l => l.Contains("appended 3 points to tree recording 'root-001'"));
+        }
+
+        [Fact]
+        public void TreeMode_ReturnsFalse_WhenRecordingNotFound()
+        {
+            var tree = MakeTree("root-001");
+            tree.ActiveRecordingId = "nonexistent-id";
+            var captured = MakeCaptured(120.0, 180.0);
+
+            bool result = ParsekFlight.TryAppendCapturedToTree(tree, captured);
+
+            Assert.False(result);
+            // Root recording should be untouched
+            Assert.Equal(2, tree.Recordings["root-001"].Points.Count);
+            Assert.Contains(logLines, l => l.Contains("not found in tree"));
+        }
+
+        [Fact]
+        public void TreeMode_ReturnsFalse_WhenTreeNull()
+        {
+            var captured = MakeCaptured(120.0, 180.0);
+
+            bool result = ParsekFlight.TryAppendCapturedToTree(null, captured);
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void TreeMode_ReturnsFalse_WhenCapturedTooShort()
+        {
+            var tree = MakeTree("root-001");
+            var captured = new Recording();
+            captured.Points.Add(MakePoint(120.0)); // Only 1 point
+
+            bool result = ParsekFlight.TryAppendCapturedToTree(tree, captured);
+
+            Assert.False(result);
+            Assert.Equal(2, tree.Recordings["root-001"].Points.Count);
+        }
+
+        [Fact]
+        public void TreeMode_DoesNotOverwriteSnapshots()
+        {
+            var tree = MakeTree("root-001");
+            var rootRec = tree.Recordings["root-001"];
+            var originalVesselSnap = new ConfigNode("VESSEL");
+            originalVesselSnap.AddValue("name", "original");
+            rootRec.VesselSnapshot = originalVesselSnap;
+            var originalGhostSnap = new ConfigNode("GHOST");
+            originalGhostSnap.AddValue("name", "original-ghost");
+            rootRec.GhostVisualSnapshot = originalGhostSnap;
+
+            var captured = MakeCaptured(120.0, 180.0);
+            var capturedSnap = new ConfigNode("VESSEL");
+            capturedSnap.AddValue("name", "captured");
+            captured.VesselSnapshot = capturedSnap;
+            captured.GhostVisualSnapshot = new ConfigNode("GHOST");
+
+            ParsekFlight.TryAppendCapturedToTree(tree, captured);
+
+            // Snapshots must not be overwritten — pre-breakup originals are better for ghost visuals
+            Assert.Same(originalVesselSnap, rootRec.VesselSnapshot);
+            Assert.Same(originalGhostSnap, rootRec.GhostVisualSnapshot);
+        }
+
+        [Fact]
+        public void TreeMode_PreservesMaxDist_WhenCapturedIsSmaller()
+        {
+            var tree = MakeTree("root-001");
+            tree.Recordings["root-001"].MaxDistanceFromLaunch = 10000.0;
+            var captured = MakeCaptured(120.0, 180.0, maxDist: 500.0);
+
+            ParsekFlight.TryAppendCapturedToTree(tree, captured);
+
+            // Should keep the larger existing value
+            Assert.Equal(10000.0, tree.Recordings["root-001"].MaxDistanceFromLaunch);
+        }
+    }
+}

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -1700,18 +1700,22 @@ namespace Parsek
             treeRec.OrbitSegments.AddRange(rec.OrbitSegments);
             treeRec.PartEvents.AddRange(rec.PartEvents);
             treeRec.FlagEvents.AddRange(rec.FlagEvents);
+            treeRec.SegmentEvents.AddRange(rec.SegmentEvents);
             treeRec.TrackSections.AddRange(rec.TrackSections);
 
-            // Sort part/flag events chronologically. PartEvents MUST use a STABLE sort so
+            // Sort part/flag/segment events chronologically. PartEvents MUST use a STABLE sort so
             // same-UT events retain their insertion order — critical for terminal-vs-ignited
-            // ordering across tree promotion boundaries (#287). FlagEvents uses the same
-            // stable pattern for consistency across every flush/merge site.
+            // ordering across tree promotion boundaries (#287). FlagEvents and SegmentEvents use
+            // the same stable pattern for consistency across every flush/merge site.
             var sortedPartEventsFlush = FlightRecorder.StableSortPartEventsByUT(treeRec.PartEvents);
             treeRec.PartEvents.Clear();
             treeRec.PartEvents.AddRange(sortedPartEventsFlush);
             var sortedFlagEventsFlush = FlightRecorder.StableSortByUT(treeRec.FlagEvents, e => e.ut);
             treeRec.FlagEvents.Clear();
             treeRec.FlagEvents.AddRange(sortedFlagEventsFlush);
+            var sortedSegEventsFlush = FlightRecorder.StableSortByUT(treeRec.SegmentEvents, e => e.ut);
+            treeRec.SegmentEvents.Clear();
+            treeRec.SegmentEvents.AddRange(sortedSegEventsFlush);
 
             // Mark dirty so the next OnSave persists the flushed data to disk.
             // Without this, the in-memory points are lost on scene reload.
@@ -1829,9 +1833,10 @@ namespace Parsek
         }
 
         /// <summary>
-        /// Appends captured trajectory data (points, orbit segments, part events, track sections)
-        /// from a source recording into the target, sorts part events by UT, and sets the target's
-        /// ExplicitEndUT. If source is null, only ExplicitEndUT is set.
+        /// Appends captured trajectory data (points, orbit segments, part events, flag events,
+        /// segment events, track sections) from a source recording into the target, sorts
+        /// part/flag/segment events by UT, and sets the target's ExplicitEndUT.
+        /// If source is null, only ExplicitEndUT is set.
         /// </summary>
         internal static void AppendCapturedDataToRecording(Recording target, Recording source, double endUT)
         {
@@ -1840,11 +1845,19 @@ namespace Parsek
                 target.Points.AddRange(source.Points);
                 target.OrbitSegments.AddRange(source.OrbitSegments);
                 target.PartEvents.AddRange(source.PartEvents);
+                target.FlagEvents.AddRange(source.FlagEvents);
+                target.SegmentEvents.AddRange(source.SegmentEvents);
                 target.TrackSections.AddRange(source.TrackSections);
                 // STABLE sort: same-UT events preserve insertion order (#287).
                 var sortedAppend = FlightRecorder.StableSortPartEventsByUT(target.PartEvents);
                 target.PartEvents.Clear();
                 target.PartEvents.AddRange(sortedAppend);
+                var sortedFlagAppend = FlightRecorder.StableSortByUT(target.FlagEvents, e => e.ut);
+                target.FlagEvents.Clear();
+                target.FlagEvents.AddRange(sortedFlagAppend);
+                var sortedSegAppend = FlightRecorder.StableSortByUT(target.SegmentEvents, e => e.ut);
+                target.SegmentEvents.Clear();
+                target.SegmentEvents.AddRange(sortedSegAppend);
                 // Mark dirty so the next OnSave persists the appended data to
                 // the .prec sidecar. Without this, data lives only in memory
                 // and is lost on scene reload (see Recording.MarkFilesDirty

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -1855,6 +1855,54 @@ namespace Parsek
         }
 
         /// <summary>
+        /// When in tree mode, appends captured split data to the active tree recording
+        /// instead of creating a standalone recording. Returns true if the data was
+        /// successfully appended, false to fall through to the standalone path.
+        /// Bug #297: FallbackCommitSplitRecorder was tree-mode-unaware and orphaned
+        /// continuation data as ungrouped standalone recordings.
+        /// </summary>
+        internal static bool TryAppendCapturedToTree(RecordingTree tree, Recording captured)
+        {
+            if (tree == null || captured == null || captured.Points.Count < 2)
+                return false;
+
+            string targetId = tree.ActiveRecordingId ?? tree.RootRecordingId;
+            if (targetId == null)
+            {
+                ParsekLog.Warn("Flight",
+                    "TryAppendCapturedToTree: no active or root recording id — falling through to standalone");
+                return false;
+            }
+
+            Recording targetRec;
+            if (!tree.Recordings.TryGetValue(targetId, out targetRec))
+            {
+                ParsekLog.Warn("Flight",
+                    $"TryAppendCapturedToTree: recording '{targetId}' not found in tree — falling through to standalone");
+                return false;
+            }
+
+            double endUT = captured.Points[captured.Points.Count - 1].ut;
+            AppendCapturedDataToRecording(targetRec, captured, endUT);
+
+            if (captured.VesselDestroyed)
+            {
+                targetRec.VesselDestroyed = true;
+                targetRec.TerminalStateValue = TerminalState.Destroyed;
+            }
+
+            if (captured.MaxDistanceFromLaunch > targetRec.MaxDistanceFromLaunch)
+                targetRec.MaxDistanceFromLaunch = captured.MaxDistanceFromLaunch;
+
+            targetRec.EndBiome = captured.EndBiome;
+
+            ParsekLog.Info("Flight",
+                $"TryAppendCapturedToTree: appended {captured.Points.Count} points to " +
+                $"tree recording '{targetId}' (destroyed={captured.VesselDestroyed})");
+            return true;
+        }
+
+        /// <summary>
         /// Tags the recording's SegmentPhase and SegmentBodyName based on the vessel's current
         /// body and altitude, if not already set. No-op if SegmentPhase is already non-empty
         /// or vessel/mainBody is null.
@@ -2314,6 +2362,12 @@ namespace Parsek
             if (splitRec?.CaptureAtStop == null) return;
 
             var captured = splitRec.CaptureAtStop;
+
+            // Bug #297: when in tree mode, append to the active tree recording
+            // instead of orphaning data as a standalone recording.
+            if (TryAppendCapturedToTree(activeTree, captured))
+                return;
+
             if (captured.Points.Count >= 2)
             {
                 RecordingStore.StashPending(

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -7,6 +7,27 @@ Entries 272–303 (78 bugs, 6 TODOs — mostly resolved) archived in `done/todo-
 
 # Known Bugs
 
+## 297. FallbackCommitSplitRecorder orphans tree continuation data as standalone recording
+
+When a vessel is destroyed during tree recording and the split recorder can't resume,
+`FallbackCommitSplitRecorder` stashes captured data as a standalone recording via
+`RecordingStore.StashPending`, ignoring the active tree. The tree root is truncated
+(missing post-breakup trajectory) and the continuation becomes an ungrouped standalone.
+
+Real-world repro: Kerbal X standalone recording promoted to tree at first breakup (root
+gets 47 points). More breakups add debris children, root continues recording (83 more
+points in buffer). Vessel crashes, joint break triggers `DeferredJointBreakCheck`,
+classified as WithinSegment, `ResumeSplitRecorder` detects vessel dead, calls
+`FallbackCommitSplitRecorder` which stashes 83-point continuation as standalone.
+
+**Fix:** Extracted `TryAppendCapturedToTree` -- when `activeTree != null`, appends captured
+data to the active tree recording (fallback to root) via `AppendCapturedDataToRecording`,
+sets terminal state and metadata. Standalone path only runs when not in tree mode.
+
+**Status:** ~~Fixed~~
+
+---
+
 ## 296. EVA kerbal who planted flag did not appear after spawn
 
 Log shows KSCSpawn successfully spawned the EVA kerbal (Bill Kerman, pid=484546861), but the user reports not seeing it. Likely post-spawn physics destruction — EVA kerbals are fragile and can be killed by terrain collision or slope bounce.

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -7,7 +7,7 @@ Entries 272–303 (78 bugs, 6 TODOs — mostly resolved) archived in `done/todo-
 
 # Known Bugs
 
-## 297. FallbackCommitSplitRecorder orphans tree continuation data as standalone recording
+## ~~297. FallbackCommitSplitRecorder orphans tree continuation data as standalone recording~~
 
 When a vessel is destroyed during tree recording and the split recorder can't resume,
 `FallbackCommitSplitRecorder` stashes captured data as a standalone recording via

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -213,6 +213,35 @@ Test game actions system with popular mods: CustomBarnKit (non-standard facility
 
 ---
 
+## TODO — Recording Data Integrity
+
+### T55. AppendCapturedDataToRecording does not copy FlagEvents or SegmentEvents
+
+`AppendCapturedDataToRecording` (ParsekFlight.cs:1836) appends Points, OrbitSegments,
+PartEvents, and TrackSections, but omits FlagEvents and SegmentEvents. By contrast,
+`FlushRecorderToTreeRecording` (ParsekFlight.cs:1675) correctly copies all six lists
+including FlagEvents with a stable sort.
+
+This is a pre-existing gap affecting all three call sites of `AppendCapturedDataToRecording`:
+- `CreateSplitBranch` line 2137 (merge parent recording with split data at breakup)
+- `CreateMergeBranch` line 2283 (merge parent recording with dock/board continuation)
+- `TryAppendCapturedToTree` line 1886 (bug #297 fix -- fallback append to tree)
+
+In practice, FlagEvents are rare (only emitted for flag planting, which is uncommon during
+breakup/dock/merge boundaries), and SegmentEvents are typically empty in `CaptureAtStop`
+because they are emitted into the recorder's PartEvents list, not the SegmentEvents list.
+So data loss from this gap is unlikely but possible.
+
+**Fix:** Add FlagEvents and SegmentEvents to `AppendCapturedDataToRecording`, using the same
+stable-sort pattern as `FlushRecorderToTreeRecording` (lines 1712-1714). For FlagEvents use
+`FlightRecorder.StableSortByUT(target.FlagEvents, e => e.ut)`. SegmentEvents have a `ut`
+field and should use the same pattern. Add tests to `AppendCapturedDataTests.cs` verifying
+both event types are appended and sorted.
+
+**Priority:** Low -- unlikely to cause visible data loss, but should be fixed for correctness
+
+---
+
 ## TODO — Nice to have
 
 ### T53. Watch camera mode selection

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -215,7 +215,7 @@ Test game actions system with popular mods: CustomBarnKit (non-standard facility
 
 ## TODO — Recording Data Integrity
 
-### T55. AppendCapturedDataToRecording does not copy FlagEvents or SegmentEvents
+### ~~T55. AppendCapturedDataToRecording does not copy FlagEvents or SegmentEvents~~
 
 `AppendCapturedDataToRecording` (ParsekFlight.cs:1836) appends Points, OrbitSegments,
 PartEvents, and TrackSections, but omits FlagEvents and SegmentEvents. By contrast,
@@ -238,7 +238,12 @@ stable-sort pattern as `FlushRecorderToTreeRecording` (lines 1712-1714). For Fla
 field and should use the same pattern. Add tests to `AppendCapturedDataTests.cs` verifying
 both event types are appended and sorted.
 
+**Fix:** Added FlagEvents and SegmentEvents (with stable sort) to both `AppendCapturedDataToRecording`
+and `FlushRecorderToTreeRecording`. Two new tests in `AppendCapturedDataTests.cs`.
+
 **Priority:** Low -- unlikely to cause visible data loss, but should be fixed for correctness
+
+**Status:** ~~Fixed~~
 
 ---
 


### PR DESCRIPTION
## Summary

- When a vessel is destroyed during tree recording and the split recorder can't resume, `FallbackCommitSplitRecorder` was unconditionally stashing captured data as a standalone recording via `RecordingStore.StashPending`, ignoring the active tree
- Extracts `TryAppendCapturedToTree` (internal static) that appends captured split data to the active tree recording, sets terminal state and metadata; standalone path only runs when not in tree mode
- 7 new unit tests, all 5585 pass

## Test plan

- [x] Verify `dotnet build` succeeds
- [x] Verify `dotnet test` passes (5585 tests)
- [ ] In-game: launch Kerbal X, let it break up and crash. Verify recordings table shows all data in one tree group (no orphaned standalone)
- [ ] In-game: verify rewind to the tree recording still works correctly