### PR TITLE
Fix #304 autoloc naming + #305 standalone recordings survive revert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to Parsek are documented here.
 
 - `#241` Ghost parts with the base/default color variant (e.g., BlackAndWhite fuel tanks) no longer show the wrong variant texture (was Orange).
 - `#297` Vessel destruction during tree recording no longer orphans continuation data as a standalone recording.
+- `#304` Stock vessel recordings now show resolved names instead of raw `#autoLOC` keys in the UI, timeline, and logs.
+- `#305` Standalone recordings (rovers, planes) now survive revert-to-launch and show the merge dialog instead of being silently discarded.
 - `T55` FlagEvents and SegmentEvents are now preserved across tree recording splits and flushes.
 
 ### New Features

--- a/Source/Parsek.Tests/QuickloadDiscardTests.cs
+++ b/Source/Parsek.Tests/QuickloadDiscardTests.cs
@@ -427,6 +427,38 @@ namespace Parsek.Tests
             Assert.Equal(PendingStandaloneState.Finalized, RecordingStore.PendingStandaloneStateValue);
         }
 
+        [Fact]
+        public void CommitPending_ResetsStateToFinalized()
+        {
+            var points = new List<TrajectoryPoint>
+            {
+                new TrajectoryPoint { ut = 100.0 },
+                new TrajectoryPoint { ut = 200.0 },
+            };
+            RecordingStore.StashPending(points, "Test", state: PendingStandaloneState.Limbo);
+            Assert.Equal(PendingStandaloneState.Limbo, RecordingStore.PendingStandaloneStateValue);
+
+            RecordingStore.CommitPending();
+
+            Assert.Equal(PendingStandaloneState.Finalized, RecordingStore.PendingStandaloneStateValue);
+        }
+
+        [Fact]
+        public void Clear_ResetsStateToFinalized()
+        {
+            var points = new List<TrajectoryPoint>
+            {
+                new TrajectoryPoint { ut = 100.0 },
+                new TrajectoryPoint { ut = 200.0 },
+            };
+            RecordingStore.StashPending(points, "Test", state: PendingStandaloneState.Limbo);
+            Assert.Equal(PendingStandaloneState.Limbo, RecordingStore.PendingStandaloneStateValue);
+
+            RecordingStore.Clear();
+
+            Assert.Equal(PendingStandaloneState.Finalized, RecordingStore.PendingStandaloneStateValue);
+        }
+
         // ----- Helpers -----
 
         private static RecordingTree MakeTree(string id, string name, int recordingCount)

--- a/Source/Parsek.Tests/QuickloadDiscardTests.cs
+++ b/Source/Parsek.Tests/QuickloadDiscardTests.cs
@@ -316,6 +316,117 @@ namespace Parsek.Tests
             Assert.False(result);
         }
 
+        // ----- #305: PendingStandaloneState.Limbo preservation -----
+
+        [Fact]
+        public void DiscardStashedOnQuickload_LimboStandalone_Preserved()
+        {
+            // Limbo standalone is the revert-to-launch carrier — must survive
+            // DiscardStashedOnQuickload (parallel to Limbo tree at line ~179).
+            var points = new List<TrajectoryPoint>
+            {
+                new TrajectoryPoint { ut = 300.0 },
+                new TrajectoryPoint { ut = 350.0 },
+            };
+            RecordingStore.StashPending(points, "Crater Crawler",
+                state: PendingStandaloneState.Limbo);
+            Assert.True(RecordingStore.HasPending);
+            Assert.Equal(PendingStandaloneState.Limbo, RecordingStore.PendingStandaloneStateValue);
+            Assert.True(RecordingStore.PendingStashedThisTransition);
+            logLines.Clear();
+
+            ParsekScenario.DiscardStashedOnQuickload(preChangeUT: 350.0, currentUT: 295.0);
+
+            Assert.True(RecordingStore.HasPending); // preserved
+            Assert.Equal(PendingStandaloneState.Limbo, RecordingStore.PendingStandaloneStateValue);
+            Assert.Contains(logLines, l =>
+                l.Contains("preserving Limbo standalone") && l.Contains("Crater Crawler"));
+            Assert.Contains(logLines, l =>
+                l.Contains("Quickload discard complete") && l.Contains("sa=0"));
+        }
+
+        [Fact]
+        public void DiscardStashedOnQuickload_FinalizedStandalone_StillDiscarded()
+        {
+            // Non-Limbo (Finalized) standalone stashed this transition: discard (existing behavior).
+            var points = new List<TrajectoryPoint>
+            {
+                new TrajectoryPoint { ut = 300.0 },
+                new TrajectoryPoint { ut = 350.0 },
+            };
+            RecordingStore.StashPending(points, "Kerbal X",
+                state: PendingStandaloneState.Finalized);
+            Assert.True(RecordingStore.HasPending);
+            Assert.True(RecordingStore.PendingStashedThisTransition);
+            logLines.Clear();
+
+            ParsekScenario.DiscardStashedOnQuickload(preChangeUT: 350.0, currentUT: 295.0);
+
+            Assert.False(RecordingStore.HasPending); // discarded
+            Assert.Contains(logLines, l =>
+                l.Contains("discarded pending standalone") && l.Contains("Kerbal X"));
+        }
+
+        [Fact]
+        public void MarkPendingStandaloneFinalized_TransitionsFromLimbo()
+        {
+            var points = new List<TrajectoryPoint>
+            {
+                new TrajectoryPoint { ut = 300.0 },
+                new TrajectoryPoint { ut = 350.0 },
+            };
+            RecordingStore.StashPending(points, "Butterfly Rover",
+                state: PendingStandaloneState.Limbo);
+            Assert.Equal(PendingStandaloneState.Limbo, RecordingStore.PendingStandaloneStateValue);
+            logLines.Clear();
+
+            RecordingStore.MarkPendingStandaloneFinalized();
+
+            Assert.Equal(PendingStandaloneState.Finalized, RecordingStore.PendingStandaloneStateValue);
+            Assert.Contains(logLines, l =>
+                l.Contains("Limbo") && l.Contains("Finalized") && l.Contains("Butterfly Rover"));
+        }
+
+        [Fact]
+        public void MarkPendingStandaloneFinalized_NoPending_NoOp()
+        {
+            Assert.False(RecordingStore.HasPending);
+            logLines.Clear();
+
+            RecordingStore.MarkPendingStandaloneFinalized();
+
+            // No crash, no log output (null guard)
+            Assert.DoesNotContain(logLines, l => l.Contains("Finalized"));
+        }
+
+        [Fact]
+        public void StashPending_DefaultState_IsFinalized()
+        {
+            var points = new List<TrajectoryPoint>
+            {
+                new TrajectoryPoint { ut = 100.0 },
+                new TrajectoryPoint { ut = 200.0 },
+            };
+            RecordingStore.StashPending(points, "Test");
+            Assert.Equal(PendingStandaloneState.Finalized, RecordingStore.PendingStandaloneStateValue);
+        }
+
+        [Fact]
+        public void DiscardPending_ResetsStateToFinalized()
+        {
+            var points = new List<TrajectoryPoint>
+            {
+                new TrajectoryPoint { ut = 100.0 },
+                new TrajectoryPoint { ut = 200.0 },
+            };
+            RecordingStore.StashPending(points, "Test", state: PendingStandaloneState.Limbo);
+            Assert.Equal(PendingStandaloneState.Limbo, RecordingStore.PendingStandaloneStateValue);
+
+            RecordingStore.DiscardPending();
+
+            Assert.Equal(PendingStandaloneState.Finalized, RecordingStore.PendingStandaloneStateValue);
+        }
+
         // ----- Helpers -----
 
         private static RecordingTree MakeTree(string id, string name, int recordingCount)

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -1061,20 +1061,30 @@ namespace Parsek
             if (recorder.IsRecording)
                 recorder.ForceStop();
 
-            string vesselName = FlightGlobals.ActiveVessel != null
-                ? FlightGlobals.ActiveVessel.vesselName
-                : "Unknown Vessel";
-
             var captured = recorder.CaptureAtStop;
+            // #304: prefer CaptureAtStop.VesselName (already resolved by BuildCaptureRecording),
+            // resolve fallback to avoid raw #autoLOC keys in recording VesselName.
+            string vesselName = captured?.VesselName
+                ?? (FlightGlobals.ActiveVessel != null
+                    ? Recording.ResolveLocalizedName(FlightGlobals.ActiveVessel.vesselName)
+                    : "Unknown Vessel");
+
+            // #305: stash with Limbo state on FLIGHT->FLIGHT transitions so the recording
+            // survives DiscardStashedOnQuickload and can be dispatched by OnLoad (parallel
+            // to tree Limbo pattern). On non-FLIGHT destinations, use Finalized (existing behavior).
+            var stashState = RecordingStore.PendingDestinationScene == GameScenes.FLIGHT
+                ? PendingStandaloneState.Limbo
+                : PendingStandaloneState.Finalized;
+
             RecordingStore.StashPending(
                 recorder.Recording,
                 vesselName,
                 recorder.OrbitSegments,
                 recordingId: captured != null ? captured.RecordingId : null,
                 recordingFormatVersion: captured != null ? (int?)captured.RecordingFormatVersion : null,
-
                 partEvents: recorder.PartEvents,
-                flagEvents: recorder.FlagEvents);
+                flagEvents: recorder.FlagEvents,
+                state: stashState);
 
             // Use stop-time atomic capture when available; fallback to scene-change capture.
             // ApplyPersistenceArtifactsFrom copies chain/ParentRecordingId/EvaCrewName from
@@ -1358,8 +1368,11 @@ namespace Parsek
             if (recorder.IsRecording)
                 recorder.ForceStop();
 
+            // #304: CaptureAtStop.VesselName is already resolved; resolve fallback too.
             string vesselName = recorder.CaptureAtStop?.VesselName
-                ?? (FlightGlobals.ActiveVessel != null ? FlightGlobals.ActiveVessel.vesselName : "Unknown Vessel");
+                ?? (FlightGlobals.ActiveVessel != null
+                    ? Recording.ResolveLocalizedName(FlightGlobals.ActiveVessel.vesselName)
+                    : "Unknown Vessel");
 
             var captured = recorder.CaptureAtStop;
             RecordingStore.StashPending(
@@ -5537,11 +5550,13 @@ namespace Parsek
             // Stop any continuation sampling
             chainManager.StopAllContinuations("commit flight");
 
-            string vesselName = FlightGlobals.ActiveVessel != null
-                ? FlightGlobals.ActiveVessel.vesselName
-                : "Unknown Vessel";
-
             var captured = recorder.CaptureAtStop;
+            // #304: prefer CaptureAtStop.VesselName (already resolved by BuildCaptureRecording),
+            // resolve fallback to avoid raw #autoLOC keys in recording VesselName.
+            string vesselName = captured?.VesselName
+                ?? (FlightGlobals.ActiveVessel != null
+                    ? Recording.ResolveLocalizedName(FlightGlobals.ActiveVessel.vesselName)
+                    : "Unknown Vessel");
 
             // Stash as pending recording (reuses OnSceneChangeRequested pattern)
             RecordingStore.StashPending(

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -1369,6 +1369,8 @@ namespace Parsek
                 recorder.ForceStop();
 
             // #304: CaptureAtStop.VesselName is already resolved; resolve fallback too.
+            // #305: Finalized (not Limbo) — vessel destruction is a terminal event, the
+            // recording is complete and ready for the merge dialog regardless of scene target.
             string vesselName = recorder.CaptureAtStop?.VesselName
                 ?? (FlightGlobals.ActiveVessel != null
                     ? Recording.ResolveLocalizedName(FlightGlobals.ActiveVessel.vesselName)

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -170,10 +170,22 @@ namespace Parsek
             {
                 string id = RecordingStore.Pending?.RecordingId;
                 string name = RecordingStore.Pending?.VesselName;
-                RecordingStore.DiscardPending();
-                discardedSa = 1;
-                ParsekLog.Info("Scenario",
-                    $"Quickload: discarded pending standalone '{name}' (id={id})");
+                if (RecordingStore.PendingStandaloneStateValue != PendingStandaloneState.Limbo)
+                {
+                    // Non-Limbo standalone stashed this transition: discard (existing behavior).
+                    RecordingStore.DiscardPending();
+                    discardedSa = 1;
+                    ParsekLog.Info("Scenario",
+                        $"Quickload: discarded pending standalone '{name}' (id={id})");
+                }
+                else
+                {
+                    // #305: Limbo standalone preserved for OnLoad dispatch — parallel to
+                    // Limbo tree preservation below. OnLoad's Limbo dispatch block decides
+                    // whether to discard (F5/F9 resume) or finalize (revert-to-launch).
+                    ParsekLog.Info("Scenario",
+                        $"Quickload: preserving Limbo standalone '{name}' (id={id}) for OnLoad dispatch");
+                }
             }
 
             if (RecordingStore.HasPendingTree
@@ -923,8 +935,19 @@ namespace Parsek
                             }
                             if (RecordingStore.HasPending)
                             {
-                                ParsekLog.Info("Scenario", "Clearing orphaned pending recording on revert (stale from previous flight)");
-                                RecordingStore.DiscardPending();
+                                // #305: Limbo standalone preserved for dispatch (parallel
+                                // to Limbo tree check at lines above).
+                                if (RecordingStore.PendingStandaloneStateValue == PendingStandaloneState.Limbo)
+                                {
+                                    ParsekLog.Info("Scenario",
+                                        $"Revert: keeping pending Limbo standalone " +
+                                        $"'{RecordingStore.Pending?.VesselName}' — stashed for dispatch");
+                                }
+                                else
+                                {
+                                    ParsekLog.Info("Scenario", "Clearing orphaned pending recording on revert (stale from previous flight)");
+                                    RecordingStore.DiscardPending();
+                                }
                             }
                         }
                     }
@@ -1127,6 +1150,44 @@ namespace Parsek
                             ParsekLog.Info("Scenario",
                                 $"OnLoad: pending-Limbo tree '{RecordingStore.PendingTree?.TreeName}' " +
                                 "deferred to OnFlightReady for quickload-resume");
+                        }
+                    }
+
+                    // #305: Standalone Limbo dispatch — parallel to tree Limbo dispatch above.
+                    // Determines whether a Limbo standalone should be finalized for the merge
+                    // dialog (revert-to-launch) or discarded (F5/F9 resume takes over).
+                    if (RecordingStore.HasPending
+                        && RecordingStore.PendingStandaloneStateValue == PendingStandaloneState.Limbo)
+                    {
+                        ParsekLog.RecState("OnLoad:standalone-limbo-dispatched", CaptureScenarioRecorderState());
+                        if (isRevert)
+                        {
+                            // Real revert: finalize Limbo standalone for merge dialog.
+                            RecordingStore.MarkPendingStandaloneFinalized();
+                            ParsekLog.Info("Scenario",
+                                $"OnLoad: Limbo standalone '{RecordingStore.Pending?.VesselName}' " +
+                                "finalized for merge dialog (revert detected)");
+                        }
+                        else if (ScheduleActiveStandaloneRestoreOnFlightReady)
+                        {
+                            // F5/F9 mid-recording: the F5 save has PARSEK_ACTIVE_STANDALONE data that
+                            // TryRestoreActiveStandaloneNode will resume from. The Limbo standalone is
+                            // from after the F5 point (stale future data) — discard it.
+                            string saName = RecordingStore.Pending?.VesselName;
+                            RecordingStore.DiscardPending();
+                            ParsekLog.Info("Scenario",
+                                $"OnLoad: discarded Limbo standalone '{saName}' — " +
+                                "active-standalone restore scheduled from save");
+                        }
+                        else
+                        {
+                            // No revert detected AND no restore data: the loaded save has no
+                            // PARSEK_ACTIVE_STANDALONE, meaning the recording started after this
+                            // save point (revert-to-launch). Finalize for merge dialog.
+                            RecordingStore.MarkPendingStandaloneFinalized();
+                            ParsekLog.Info("Scenario",
+                                $"OnLoad: Limbo standalone '{RecordingStore.Pending?.VesselName}' " +
+                                "finalized for merge dialog (no active-standalone in loaded save)");
                         }
                     }
 

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -47,6 +47,30 @@ namespace Parsek
     }
 
     /// <summary>
+    /// State of the pending standalone slot in <see cref="RecordingStore"/>.
+    /// Determines how <see cref="ParsekScenario.OnLoad"/> dispatches the pending
+    /// standalone after revert detection runs. Parallel to <see cref="PendingTreeState"/>.
+    /// </summary>
+    public enum PendingStandaloneState
+    {
+        /// <summary>
+        /// Standalone has been finalized: terminal state set, snapshots preserved,
+        /// ready for merge dialog. This is the default state — scene exits to KSC,
+        /// manual commits, and post-destruction paths all use Finalized.
+        /// </summary>
+        Finalized = 0,
+
+        /// <summary>
+        /// Standalone is still "in-flight": recorder was torn down because the scene
+        /// is unloading for a FLIGHT->FLIGHT transition (quickload or revert). OnLoad
+        /// decides based on the presence of PARSEK_ACTIVE_STANDALONE in the loaded save
+        /// whether to discard (F5/F9 resume takes over) or finalize for merge dialog
+        /// (revert-to-launch). Parallel to <see cref="PendingTreeState.Limbo"/>.
+        /// </summary>
+        Limbo = 1,
+    }
+
+    /// <summary>
     /// Static holder for recording data that survives scene changes.
     /// Static fields persist across scene loads within a KSP session.
     /// Save/load persistence is handled separately by ParsekScenario.
@@ -143,8 +167,13 @@ namespace Parsek
         // See docs/dev/plans/quickload-resume-recording.md.
         private static PendingTreeState pendingTreeState = PendingTreeState.Finalized;
 
+        // State of the pending standalone slot. Finalized = ready for merge dialog.
+        // Limbo = in-flight, stashed for FLIGHT->FLIGHT dispatch (parallel to pendingTreeState).
+        private static PendingStandaloneState pendingStandaloneState = PendingStandaloneState.Finalized;
+
         public static bool HasPending => pendingRecording != null;
         public static Recording Pending => pendingRecording;
+        public static PendingStandaloneState PendingStandaloneStateValue => pendingStandaloneState;
         public static List<Recording> CommittedRecordings => committedRecordings;
         public static List<RecordingTree> CommittedTrees => committedTrees;
         public static bool HasPendingTree => pendingTree != null;
@@ -158,7 +187,8 @@ namespace Parsek
             List<PartEvent> partEvents = null,
             List<FlagEvent> flagEvents = null,
             List<SegmentEvent> segmentEvents = null,
-            List<TrackSection> trackSections = null)
+            List<TrackSection> trackSections = null,
+            PendingStandaloneState state = PendingStandaloneState.Finalized)
         {
             if (points == null || points.Count < 2)
             {
@@ -245,6 +275,7 @@ namespace Parsek
                     : new List<TrackSection>(),
                 VesselName = vesselName
             };
+            pendingStandaloneState = state;
 
             PendingStashedThisTransition = true;
 
@@ -279,6 +310,7 @@ namespace Parsek
             string recordingId = pendingRecording.RecordingId;
             double endUT = pendingRecording.EndUT;
             pendingRecording = null;
+            pendingStandaloneState = PendingStandaloneState.Finalized;
 
             // Capture a game state baseline at each commit (single funnel point)
             GameStateStore.CaptureBaselineIfNeeded();
@@ -300,6 +332,7 @@ namespace Parsek
 
             Log($"[Parsek] Discarded pending recording from {pendingRecording.VesselName}");
             pendingRecording = null;
+            pendingStandaloneState = PendingStandaloneState.Finalized;
         }
 
         public static void ClearCommitted()
@@ -318,6 +351,7 @@ namespace Parsek
             if (pendingRecording != null)
                 DeleteRecordingFiles(pendingRecording);
             pendingRecording = null;
+            pendingStandaloneState = PendingStandaloneState.Finalized;
             pendingTree = null;
             pendingTreeState = PendingTreeState.Finalized;
             ClearCommitted();
@@ -623,6 +657,20 @@ namespace Parsek
             pendingTreeState = PendingTreeState.Finalized;
             ParsekLog.Info("RecordingStore",
                 $"Pending tree '{pendingTree.TreeName}' transitioned Limbo → Finalized");
+        }
+
+        /// <summary>
+        /// Marks the pending standalone's state as Finalized after the Limbo dispatch
+        /// has decided to keep it for the merge dialog (revert-to-launch path).
+        /// Parallel to <see cref="MarkPendingTreeFinalized"/>.
+        /// </summary>
+        internal static void MarkPendingStandaloneFinalized()
+        {
+            if (pendingRecording == null) return;
+            if (pendingStandaloneState == PendingStandaloneState.Finalized) return;
+            pendingStandaloneState = PendingStandaloneState.Finalized;
+            ParsekLog.Info("RecordingStore",
+                $"Pending standalone '{pendingRecording.VesselName}' transitioned Limbo → Finalized");
         }
 
         /// <summary>
@@ -1540,6 +1588,7 @@ namespace Parsek
         internal static void ResetForTesting()
         {
             pendingRecording = null;
+            pendingStandaloneState = PendingStandaloneState.Finalized;
             committedRecordings.Clear();
             committedTrees.Clear();
             pendingTree = null;

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -7,6 +7,34 @@ Entries 272–303 (78 bugs, 6 TODOs — mostly resolved) archived in `done/todo-
 
 # Known Bugs
 
+## ~~304. Raw #autoLOC keys in standalone recording vessel names~~
+
+**Observed in:** Sandbox (2026-04-10). Rovers and stock vessels launched from runway/island airfield showed `#autoLOC_501182` instead of "Crater Crawler" in the Recordings Manager, timeline entries, and log messages.
+
+**Root cause:** Three call sites read `FlightGlobals.ActiveVessel.vesselName` (which is a raw `#autoLOC_XXXX` key for stock vessels) and passed it to `RecordingStore.StashPending()` without calling `Recording.ResolveLocalizedName()`. `BuildCaptureRecording` (FlightRecorder.cs:4541) resolved the name correctly, but `StashPending` creates a new Recording object with whatever string is passed in, discarding the resolved name.
+
+**Fix:** In `StashPendingOnSceneChange`, `ShowPostDestructionMergeDialog`, and `CommitFlight`, prefer `CaptureAtStop.VesselName` (already resolved by `BuildCaptureRecording`) with `ResolveLocalizedName` on the fallback path.
+
+**Status:** Fixed
+
+---
+
+## ~~305. Standalone recordings lost on revert-to-launch~~
+
+**Observed in:** Sandbox (2026-04-10). Rover recordings from runway/island airfield were silently discarded on revert-to-launch. The user had to manually commit via the Commit Flight button instead of getting the merge dialog automatically. Tree recordings (rockets with staging) survived reverts via the Limbo state mechanism, but standalone recordings had no equivalent.
+
+**Root cause:** `DiscardStashedOnQuickload` (ParsekScenario.cs) unconditionally discards pending standalone recordings on any FLIGHT->FLIGHT transition with UT regression. Tree recordings survive because `PendingTreeState.Limbo` is explicitly preserved. Standalone recordings had no Limbo equivalent.
+
+**Fix:** Added `PendingStandaloneState` enum (parallel to `PendingTreeState`) with `Finalized` and `Limbo` values. `StashPendingOnSceneChange` assigns `Limbo` when the destination scene is FLIGHT. `DiscardStashedOnQuickload` preserves Limbo standalones (mirroring tree Limbo preservation). A new Limbo dispatch block in `OnLoad` (parallel to the tree Limbo dispatch) decides:
+- If `ScheduleActiveStandaloneRestoreOnFlightReady` is set (F5/F9 mid-recording): discard the stale Limbo standalone, let the restore resume from F5 data.
+- If no restore is scheduled (revert-to-launch): finalize the Limbo standalone for the merge dialog.
+
+Design aligned with bug #271 (standalone/tree unification) — the two modes now share symmetric state tracking.
+
+**Status:** Fixed
+
+---
+
 ## ~~297. FallbackCommitSplitRecorder orphans tree continuation data as standalone recording~~
 
 When a vessel is destroyed during tree recording and the split recorder can't resume,


### PR DESCRIPTION
## Summary

- **#304**: Stock vessel recordings (`#autoLOC_XXXX` keys) now show resolved human-readable names in the UI, timeline, and logs. Three `StashPending` call sites were reading `FlightGlobals.ActiveVessel.vesselName` raw; now prefer `CaptureAtStop.VesselName` (already resolved) with `ResolveLocalizedName` fallback.
- **#305**: Standalone recordings (rovers, planes launched from runway/island airfield) now survive revert-to-launch and show the merge dialog. Added `PendingStandaloneState` enum (parallel to `PendingTreeState`) with Limbo support -- mirrors the tree Limbo pattern to ease future unification (#271).

## Test plan

- [x] 7 new tests in `QuickloadDiscardTests.cs` (Limbo preservation, Finalized discard, state transitions, default state, reset)
- [x] All 5626 existing tests pass
- [ ] In-game: launch stock rover from runway, drive, revert-to-launch -> merge dialog shows with resolved name
- [ ] In-game: F5 mid-recording, F9 -> recording resumes from F5 point (Limbo discarded, restore takes over)
- [ ] In-game: launch from runway, drive to KSC -> deferred merge dialog shows (existing path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)