### PR TITLE
Phase 11: Resource Snapshots

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -73,7 +73,8 @@ Key source files and what they do - read the relevant one before modifying:
 - `RecordingStore.cs` - static recording storage surviving scene changes
 - `GhostVisualBuilder.cs` - ghost mesh building from vessel snapshots
 - `TrajectoryMath.cs` - pure static math (sampling, interpolation, orbit search)
-- `VesselSpawner.cs` - vessel spawn/recover/snapshot utilities
+- `VesselSpawner.cs` - vessel spawn/recover/snapshot utilities, resource manifest extraction (`ExtractResourceManifest`)
+- `ResourceManifest.cs` - `ResourceAmount` struct and `ComputeResourceDelta` for per-resource change computation (Phase 11)
 - `MergeDialog.cs` - post-revert merge dialog
 - `GhostMapPresence.cs` - ProtoVessel lifecycle for ghost map presence: creates/destroys lightweight vessels for tracking station, orbit lines, targeting. Manages ghostMapVesselPids HashSet for O(1) guard checks across codebase.
 - `ParsekHarmony.cs` + `Patches/` - Harmony patcher + patches (PhysicsFrame, GhostVesselLoad, GhostCommNetVessel, GhostTrackingStation, FacilityUpgrade, FlightResults, ScienceSubject, TechResearch, CrewDialogFilter, KerbalDismissal, GhostOrbitLine)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to Parsek are documented here.
 - Watch camera mode: press V during ghost watch to toggle between free orbit and horizon-locked (ground always at screen bottom). Auto-selects horizon-locked near planetary surfaces, free in orbit.
 - Sortable "Site" column in the Recordings Manager — sorts by launch site name with UT tiebreak within the same site.
 - Renamed the expanded-stats toggle button from "Stats" to "Info".
+- Resource snapshots: recordings capture physical resource manifests (LF, Ox, Ore, etc.) at start and end. Hover tooltip in Recordings Manager shows resource changes per recording. Prerequisite for logistics routes.
+- Dock target vessel PID captured at chain boundaries for future route endpoint identification.
 
 ---
 

--- a/Source/Parsek.Tests/FormatResourceManifestTests.cs
+++ b/Source/Parsek.Tests/FormatResourceManifestTests.cs
@@ -1,0 +1,164 @@
+using System.Collections.Generic;
+using System.Globalization;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    public class FormatResourceManifestTests
+    {
+        [Fact]
+        public void BothNull_ReturnsNull()
+        {
+            var result = RecordingsTableUI.FormatResourceManifest(null, null);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void StartOnly_ShowsStartFormat()
+        {
+            var start = new Dictionary<string, ResourceAmount>
+            {
+                ["LiquidFuel"] = new ResourceAmount { amount = 3600, maxAmount = 3600 },
+                ["Oxidizer"] = new ResourceAmount { amount = 4400, maxAmount = 4400 }
+            };
+
+            var result = RecordingsTableUI.FormatResourceManifest(start, null);
+
+            Assert.NotNull(result);
+            Assert.StartsWith("Resources at start:", result);
+            Assert.Contains("LiquidFuel: 3600.0 / 3600.0", result);
+            Assert.Contains("Oxidizer: 4400.0 / 4400.0", result);
+        }
+
+        [Fact]
+        public void BothStartAndEnd_ShowsDeltaFormat()
+        {
+            var start = new Dictionary<string, ResourceAmount>
+            {
+                ["LiquidFuel"] = new ResourceAmount { amount = 3600, maxAmount = 3600 },
+                ["Oxidizer"] = new ResourceAmount { amount = 4400, maxAmount = 4400 }
+            };
+            var end = new Dictionary<string, ResourceAmount>
+            {
+                ["LiquidFuel"] = new ResourceAmount { amount = 200, maxAmount = 3600 },
+                ["Oxidizer"] = new ResourceAmount { amount = 244, maxAmount = 4400 }
+            };
+
+            var result = RecordingsTableUI.FormatResourceManifest(start, end);
+
+            Assert.NotNull(result);
+            Assert.StartsWith("Resources:", result);
+            Assert.Contains("LiquidFuel: 3600.0 \u2192 200.0 (-3400.0)", result);
+            Assert.Contains("Oxidizer: 4400.0 \u2192 244.0 (-4156.0)", result);
+        }
+
+        [Fact]
+        public void SingleResource()
+        {
+            var start = new Dictionary<string, ResourceAmount>
+            {
+                ["MonoPropellant"] = new ResourceAmount { amount = 30, maxAmount = 50 }
+            };
+
+            var result = RecordingsTableUI.FormatResourceManifest(start, null);
+
+            Assert.NotNull(result);
+            Assert.Contains("MonoPropellant: 30.0 / 50.0", result);
+            // Only one resource line + header
+            var lines = result.Split('\n');
+            Assert.Equal(2, lines.Length);
+        }
+
+        [Fact]
+        public void ManyResources_SortedAlphabetically()
+        {
+            var start = new Dictionary<string, ResourceAmount>
+            {
+                ["Oxidizer"] = new ResourceAmount { amount = 488, maxAmount = 488 },
+                ["Ablator"] = new ResourceAmount { amount = 200, maxAmount = 200 },
+                ["MonoPropellant"] = new ResourceAmount { amount = 30, maxAmount = 50 },
+                ["LiquidFuel"] = new ResourceAmount { amount = 400, maxAmount = 400 }
+            };
+
+            var result = RecordingsTableUI.FormatResourceManifest(start, null);
+
+            Assert.NotNull(result);
+            var lines = result.Split('\n');
+            Assert.Equal(5, lines.Length); // header + 4 resources
+            Assert.Contains("Ablator", lines[1]);
+            Assert.Contains("LiquidFuel", lines[2]);
+            Assert.Contains("MonoPropellant", lines[3]);
+            Assert.Contains("Oxidizer", lines[4]);
+        }
+
+        [Fact]
+        public void ResourceGained_PositiveDelta()
+        {
+            var start = new Dictionary<string, ResourceAmount>
+            {
+                ["Ore"] = new ResourceAmount { amount = 0, maxAmount = 1500 }
+            };
+            var end = new Dictionary<string, ResourceAmount>
+            {
+                ["Ore"] = new ResourceAmount { amount = 1500, maxAmount = 1500 }
+            };
+
+            var result = RecordingsTableUI.FormatResourceManifest(start, end);
+
+            Assert.NotNull(result);
+            Assert.Contains("Ore: 0.0 \u2192 1500.0 (+1500.0)", result);
+        }
+
+        [Fact]
+        public void ResourceConsumed_NegativeDelta()
+        {
+            var start = new Dictionary<string, ResourceAmount>
+            {
+                ["LiquidFuel"] = new ResourceAmount { amount = 3600, maxAmount = 3600 }
+            };
+            var end = new Dictionary<string, ResourceAmount>
+            {
+                ["LiquidFuel"] = new ResourceAmount { amount = 200, maxAmount = 3600 }
+            };
+
+            var result = RecordingsTableUI.FormatResourceManifest(start, end);
+
+            Assert.NotNull(result);
+            Assert.Contains("LiquidFuel: 3600.0 \u2192 200.0 (-3400.0)", result);
+        }
+
+        [Fact]
+        public void Unchanged_ZeroDelta()
+        {
+            var start = new Dictionary<string, ResourceAmount>
+            {
+                ["LiquidFuel"] = new ResourceAmount { amount = 400, maxAmount = 400 }
+            };
+            var end = new Dictionary<string, ResourceAmount>
+            {
+                ["LiquidFuel"] = new ResourceAmount { amount = 400, maxAmount = 400 }
+            };
+
+            var result = RecordingsTableUI.FormatResourceManifest(start, end);
+
+            Assert.NotNull(result);
+            Assert.Contains("LiquidFuel: 400.0 \u2192 400.0 (+0.0)", result);
+        }
+
+        [Fact]
+        public void EndOnly_ShowsDeltaWithZeroStart()
+        {
+            var end = new Dictionary<string, ResourceAmount>
+            {
+                ["Ore"] = new ResourceAmount { amount = 1500, maxAmount = 1500 }
+            };
+
+            var result = RecordingsTableUI.FormatResourceManifest(null, end);
+
+            Assert.NotNull(result);
+            Assert.StartsWith("Resources:", result);
+            Assert.Contains("Ore: 0.0 \u2192 1500.0 (+1500.0)", result);
+        }
+    }
+}

--- a/Source/Parsek.Tests/Generators/RecordingBuilder.cs
+++ b/Source/Parsek.Tests/Generators/RecordingBuilder.cs
@@ -37,6 +37,8 @@ namespace Parsek.Tests.Generators
         private float rewindReservedRep;
         private int? terminalState;
         private double terrainHeightAtEnd = double.NaN;
+        private Dictionary<string, ResourceAmount> startResources;
+        private Dictionary<string, ResourceAmount> endResources;
 
         // Default rotation for points that don't specify one explicitly
         private float defaultRotX, defaultRotY, defaultRotZ;
@@ -303,6 +305,18 @@ namespace Parsek.Tests.Generators
             return this;
         }
 
+        internal RecordingBuilder WithStartResources(Dictionary<string, ResourceAmount> resources)
+        {
+            startResources = resources;
+            return this;
+        }
+
+        internal RecordingBuilder WithEndResources(Dictionary<string, ResourceAmount> resources)
+        {
+            endResources = resources;
+            return this;
+        }
+
         // --- v6 TrackSection builder methods ---
 
         /// <summary>
@@ -542,7 +556,55 @@ namespace Parsek.Tests.Generators
             if (isDebris)
                 node.AddValue("isDebris", isDebris.ToString());
 
+            // Resource manifests (Phase 11)
+            SerializeResourceManifestInto(node);
+
             return node;
+        }
+
+        /// <summary>Returns the start resources dictionary (may be null).</summary>
+        internal Dictionary<string, ResourceAmount> GetStartResources() => startResources;
+
+        /// <summary>Returns the end resources dictionary (may be null).</summary>
+        internal Dictionary<string, ResourceAmount> GetEndResources() => endResources;
+
+        /// <summary>
+        /// Serializes StartResources/EndResources into a RESOURCE_MANIFEST node on parent,
+        /// matching the format used by RecordingStore.SerializeResourceManifest.
+        /// </summary>
+        private void SerializeResourceManifestInto(ConfigNode parent)
+        {
+            bool hasStart = startResources != null && startResources.Count > 0;
+            bool hasEnd = endResources != null && endResources.Count > 0;
+            if (!hasStart && !hasEnd)
+                return;
+
+            var ic = CultureInfo.InvariantCulture;
+            ConfigNode manifestNode = parent.AddNode("RESOURCE_MANIFEST");
+
+            var keys = new HashSet<string>();
+            if (hasStart)
+                foreach (var k in startResources.Keys) keys.Add(k);
+            if (hasEnd)
+                foreach (var k in endResources.Keys) keys.Add(k);
+
+            foreach (var name in keys)
+            {
+                ConfigNode resNode = manifestNode.AddNode("RESOURCE");
+                resNode.AddValue("name", name);
+
+                if (hasStart && startResources.TryGetValue(name, out var startRa))
+                {
+                    resNode.AddValue("startAmount", startRa.amount.ToString("R", ic));
+                    resNode.AddValue("startMax", startRa.maxAmount.ToString("R", ic));
+                }
+
+                if (hasEnd && endResources.TryGetValue(name, out var endRa))
+                {
+                    resNode.AddValue("endAmount", endRa.amount.ToString("R", ic));
+                    resNode.AddValue("endMax", endRa.maxAmount.ToString("R", ic));
+                }
+            }
         }
 
         /// <summary>Returns the vessel name.</summary>
@@ -648,6 +710,9 @@ namespace Parsek.Tests.Generators
                 RecordingStore.SerializeSegmentEvents(node, segmentEvents);
             if (trackSections.Count > 0)
                 RecordingStore.SerializeTrackSections(node, trackSections);
+
+            // Resource manifests (Phase 11)
+            SerializeResourceManifestInto(node);
 
             return node;
         }

--- a/Source/Parsek.Tests/Generators/VesselSnapshotBuilder.cs
+++ b/Source/Parsek.Tests/Generators/VesselSnapshotBuilder.cs
@@ -172,6 +172,23 @@ namespace Parsek.Tests.Generators
             return this;
         }
 
+        /// <summary>
+        /// Adds a RESOURCE node to the part at the given index.
+        /// </summary>
+        public VesselSnapshotBuilder AddResourceToPart(int partIndex, string name, double amount, double maxAmount)
+        {
+            var parts = partsContainer.GetNodes("PART");
+            if (partIndex < 0 || partIndex >= parts.Length)
+                throw new ArgumentOutOfRangeException(nameof(partIndex),
+                    $"Part index {partIndex} out of range (0..{parts.Length - 1})");
+
+            var resNode = parts[partIndex].AddNode("RESOURCE");
+            resNode.AddValue("name", name);
+            resNode.AddValue("amount", amount.ToString("R", IC));
+            resNode.AddValue("maxAmount", maxAmount.ToString("R", IC));
+            return this;
+        }
+
         private static string D(double v) => v.ToString("R", IC);
 
         public ConfigNode Build()

--- a/Source/Parsek.Tests/ResourceManifestSerializationTests.cs
+++ b/Source/Parsek.Tests/ResourceManifestSerializationTests.cs
@@ -1,0 +1,405 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    [Collection("Sequential")]
+    public class ResourceManifestSerializationTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public ResourceManifestSerializationTests()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.VerboseOverrideForTesting = true;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+            RecordingStore.SuppressLogging = true;
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+            RecordingStore.SuppressLogging = false;
+        }
+
+        #region Resource Manifest Round-Trip
+
+        [Fact]
+        public void RoundTrip_BothStartAndEnd()
+        {
+            var rec = new Recording();
+            rec.RecordingId = "test-both";
+            rec.StartResources = new Dictionary<string, ResourceAmount>
+            {
+                ["LiquidFuel"] = new ResourceAmount { amount = 3600, maxAmount = 3600 },
+                ["Oxidizer"] = new ResourceAmount { amount = 4400, maxAmount = 4400 }
+            };
+            rec.EndResources = new Dictionary<string, ResourceAmount>
+            {
+                ["LiquidFuel"] = new ResourceAmount { amount = 200, maxAmount = 3600 },
+                ["Oxidizer"] = new ResourceAmount { amount = 244, maxAmount = 4400 }
+            };
+
+            var node = new ConfigNode("RECORDING");
+            RecordingStore.SerializeResourceManifest(node, rec);
+
+            var loaded = new Recording();
+            loaded.RecordingId = "test-both";
+            RecordingStore.DeserializeResourceManifest(node, loaded);
+
+            Assert.NotNull(loaded.StartResources);
+            Assert.NotNull(loaded.EndResources);
+            Assert.Equal(2, loaded.StartResources.Count);
+            Assert.Equal(2, loaded.EndResources.Count);
+
+            Assert.Equal(3600.0, loaded.StartResources["LiquidFuel"].amount);
+            Assert.Equal(3600.0, loaded.StartResources["LiquidFuel"].maxAmount);
+            Assert.Equal(200.0, loaded.EndResources["LiquidFuel"].amount);
+            Assert.Equal(3600.0, loaded.EndResources["LiquidFuel"].maxAmount);
+
+            Assert.Equal(4400.0, loaded.StartResources["Oxidizer"].amount);
+            Assert.Equal(4400.0, loaded.StartResources["Oxidizer"].maxAmount);
+            Assert.Equal(244.0, loaded.EndResources["Oxidizer"].amount);
+            Assert.Equal(4400.0, loaded.EndResources["Oxidizer"].maxAmount);
+
+            Assert.Contains(logLines, l => l.Contains("[RecordingStore]") && l.Contains("wrote 2 resource(s)"));
+            Assert.Contains(logLines, l => l.Contains("[RecordingStore]") && l.Contains("loaded=2") && l.Contains("skipped=0"));
+        }
+
+        [Fact]
+        public void RoundTrip_StartOnly()
+        {
+            var rec = new Recording();
+            rec.RecordingId = "test-start";
+            rec.StartResources = new Dictionary<string, ResourceAmount>
+            {
+                ["LiquidFuel"] = new ResourceAmount { amount = 3600, maxAmount = 3600 }
+            };
+            rec.EndResources = null;
+
+            var node = new ConfigNode("RECORDING");
+            RecordingStore.SerializeResourceManifest(node, rec);
+
+            var loaded = new Recording();
+            loaded.RecordingId = "test-start";
+            RecordingStore.DeserializeResourceManifest(node, loaded);
+
+            Assert.NotNull(loaded.StartResources);
+            Assert.Null(loaded.EndResources);
+            Assert.Equal(3600.0, loaded.StartResources["LiquidFuel"].amount);
+        }
+
+        [Fact]
+        public void RoundTrip_EndOnly()
+        {
+            var rec = new Recording();
+            rec.RecordingId = "test-end";
+            rec.StartResources = null;
+            rec.EndResources = new Dictionary<string, ResourceAmount>
+            {
+                ["Ore"] = new ResourceAmount { amount = 1500, maxAmount = 1500 }
+            };
+
+            var node = new ConfigNode("RECORDING");
+            RecordingStore.SerializeResourceManifest(node, rec);
+
+            var loaded = new Recording();
+            loaded.RecordingId = "test-end";
+            RecordingStore.DeserializeResourceManifest(node, loaded);
+
+            Assert.Null(loaded.StartResources);
+            Assert.NotNull(loaded.EndResources);
+            Assert.Equal(1500.0, loaded.EndResources["Ore"].amount);
+        }
+
+        [Fact]
+        public void RoundTrip_NullBoth_NoNodeWritten()
+        {
+            var rec = new Recording();
+            rec.RecordingId = "test-null";
+            rec.StartResources = null;
+            rec.EndResources = null;
+
+            var node = new ConfigNode("RECORDING");
+            RecordingStore.SerializeResourceManifest(node, rec);
+
+            Assert.Null(node.GetNode("RESOURCE_MANIFEST"));
+        }
+
+        [Fact]
+        public void RoundTrip_EmptyDicts_NoNodeWritten()
+        {
+            var rec = new Recording();
+            rec.RecordingId = "test-empty";
+            rec.StartResources = new Dictionary<string, ResourceAmount>();
+            rec.EndResources = new Dictionary<string, ResourceAmount>();
+
+            var node = new ConfigNode("RECORDING");
+            RecordingStore.SerializeResourceManifest(node, rec);
+
+            Assert.Null(node.GetNode("RESOURCE_MANIFEST"));
+        }
+
+        [Fact]
+        public void RoundTrip_AsymmetricKeys()
+        {
+            var rec = new Recording();
+            rec.RecordingId = "test-asym";
+            rec.StartResources = new Dictionary<string, ResourceAmount>
+            {
+                ["LiquidFuel"] = new ResourceAmount { amount = 3600, maxAmount = 3600 },
+                ["Oxidizer"] = new ResourceAmount { amount = 4400, maxAmount = 4400 }
+            };
+            rec.EndResources = new Dictionary<string, ResourceAmount>
+            {
+                ["LiquidFuel"] = new ResourceAmount { amount = 200, maxAmount = 3600 },
+                ["Ore"] = new ResourceAmount { amount = 1500, maxAmount = 1500 }
+            };
+
+            var node = new ConfigNode("RECORDING");
+            RecordingStore.SerializeResourceManifest(node, rec);
+
+            var loaded = new Recording();
+            loaded.RecordingId = "test-asym";
+            RecordingStore.DeserializeResourceManifest(node, loaded);
+
+            Assert.NotNull(loaded.StartResources);
+            Assert.NotNull(loaded.EndResources);
+
+            // LiquidFuel: in both start and end
+            Assert.True(loaded.StartResources.ContainsKey("LiquidFuel"));
+            Assert.True(loaded.EndResources.ContainsKey("LiquidFuel"));
+
+            // Oxidizer: only in start
+            Assert.True(loaded.StartResources.ContainsKey("Oxidizer"));
+            Assert.False(loaded.EndResources.ContainsKey("Oxidizer"));
+
+            // Ore: only in end
+            Assert.False(loaded.StartResources.ContainsKey("Ore"));
+            Assert.True(loaded.EndResources.ContainsKey("Ore"));
+
+            // Merged key set = 3 resources
+            Assert.Contains(logLines, l => l.Contains("wrote 3 resource(s)"));
+        }
+
+        [Fact]
+        public void RoundTrip_Precision()
+        {
+            double precise = 3600.123456789;
+            var rec = new Recording();
+            rec.RecordingId = "test-precision";
+            rec.StartResources = new Dictionary<string, ResourceAmount>
+            {
+                ["LiquidFuel"] = new ResourceAmount { amount = precise, maxAmount = precise }
+            };
+            rec.EndResources = new Dictionary<string, ResourceAmount>
+            {
+                ["LiquidFuel"] = new ResourceAmount { amount = precise / 2, maxAmount = precise }
+            };
+
+            var node = new ConfigNode("RECORDING");
+            RecordingStore.SerializeResourceManifest(node, rec);
+
+            var loaded = new Recording();
+            loaded.RecordingId = "test-precision";
+            RecordingStore.DeserializeResourceManifest(node, loaded);
+
+            Assert.Equal(precise, loaded.StartResources["LiquidFuel"].amount);
+            Assert.Equal(precise, loaded.StartResources["LiquidFuel"].maxAmount);
+            Assert.Equal(precise / 2, loaded.EndResources["LiquidFuel"].amount);
+            Assert.Equal(precise, loaded.EndResources["LiquidFuel"].maxAmount);
+        }
+
+        [Fact]
+        public void LocaleSafety()
+        {
+            // Save under a comma-decimal locale, load under invariant
+            var rec = new Recording();
+            rec.RecordingId = "test-locale";
+            rec.StartResources = new Dictionary<string, ResourceAmount>
+            {
+                ["LiquidFuel"] = new ResourceAmount { amount = 1234.5678, maxAmount = 9999.1234 }
+            };
+
+            var node = new ConfigNode("RECORDING");
+
+            var savedCulture = Thread.CurrentThread.CurrentCulture;
+            try
+            {
+                // Simulate comma-decimal locale for serialization
+                Thread.CurrentThread.CurrentCulture = new CultureInfo("de-DE");
+                RecordingStore.SerializeResourceManifest(node, rec);
+
+                // Verify the node values use dots, not commas
+                var manifest = node.GetNode("RESOURCE_MANIFEST");
+                Assert.NotNull(manifest);
+                var resources = manifest.GetNodes("RESOURCE");
+                Assert.Single(resources);
+                string startAmountStr = resources[0].GetValue("startAmount");
+                Assert.DoesNotContain(",", startAmountStr);
+
+                // Load under invariant culture
+                Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+                var loaded = new Recording();
+                loaded.RecordingId = "test-locale";
+                RecordingStore.DeserializeResourceManifest(node, loaded);
+
+                Assert.Equal(1234.5678, loaded.StartResources["LiquidFuel"].amount);
+                Assert.Equal(9999.1234, loaded.StartResources["LiquidFuel"].maxAmount);
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = savedCulture;
+            }
+        }
+
+        [Fact]
+        public void LegacyRecording_NoNode_NullFields()
+        {
+            var node = new ConfigNode("RECORDING");
+            // No RESOURCE_MANIFEST node — simulates legacy recording
+
+            var loaded = new Recording();
+            loaded.RecordingId = "test-legacy";
+            RecordingStore.DeserializeResourceManifest(node, loaded);
+
+            Assert.Null(loaded.StartResources);
+            Assert.Null(loaded.EndResources);
+        }
+
+        [Fact]
+        public void MalformedResource_Skipped()
+        {
+            var node = new ConfigNode("RECORDING");
+            var manifest = node.AddNode("RESOURCE_MANIFEST");
+
+            // Valid resource
+            var validRes = manifest.AddNode("RESOURCE");
+            validRes.AddValue("name", "LiquidFuel");
+            validRes.AddValue("startAmount", "3600");
+            validRes.AddValue("startMax", "3600");
+
+            // Malformed: empty name
+            var badRes = manifest.AddNode("RESOURCE");
+            badRes.AddValue("name", "");
+            badRes.AddValue("startAmount", "100");
+            badRes.AddValue("startMax", "100");
+
+            // Malformed: missing name
+            var noNameRes = manifest.AddNode("RESOURCE");
+            noNameRes.AddValue("startAmount", "200");
+
+            var loaded = new Recording();
+            loaded.RecordingId = "test-malformed";
+            RecordingStore.DeserializeResourceManifest(node, loaded);
+
+            Assert.NotNull(loaded.StartResources);
+            Assert.Single(loaded.StartResources);
+            Assert.Equal(3600.0, loaded.StartResources["LiquidFuel"].amount);
+
+            Assert.Contains(logLines, l => l.Contains("loaded=1") && l.Contains("skipped=2"));
+        }
+
+        #endregion
+
+        #region DockTargetVesselPid Round-Trip
+
+        [Fact]
+        public void DockTargetVesselPid_RoundTrip_ViaScenario()
+        {
+            var rec = new Recording();
+            rec.RecordingId = "test-dock";
+            rec.DockTargetVesselPid = 12345;
+
+            var node = new ConfigNode("RECORDING");
+            ParsekScenario.SaveRecordingMetadata(node, rec);
+
+            var loaded = new Recording();
+            loaded.RecordingId = "test-dock";
+            ParsekScenario.LoadRecordingMetadata(node, loaded);
+
+            Assert.Equal(12345u, loaded.DockTargetVesselPid);
+        }
+
+        [Fact]
+        public void DockTargetVesselPid_LegacyRecording_DefaultsZero()
+        {
+            var node = new ConfigNode("RECORDING");
+            // No dockTargetPid value — simulates legacy recording
+
+            var loaded = new Recording();
+            loaded.RecordingId = "test-legacy-dock";
+            ParsekScenario.LoadRecordingMetadata(node, loaded);
+
+            Assert.Equal(0u, loaded.DockTargetVesselPid);
+        }
+
+        [Fact]
+        public void DockTargetVesselPid_ZeroNotWritten()
+        {
+            var rec = new Recording();
+            rec.RecordingId = "test-dock-zero";
+            rec.DockTargetVesselPid = 0;
+
+            var node = new ConfigNode("RECORDING");
+            ParsekScenario.SaveRecordingMetadata(node, rec);
+
+            Assert.Null(node.GetValue("dockTargetPid"));
+        }
+
+        [Fact]
+        public void DockTargetVesselPid_RoundTrip_ViaTree()
+        {
+            var rec = new Recording();
+            rec.RecordingId = "test-dock-tree";
+            rec.DockTargetVesselPid = 67890;
+
+            var node = new ConfigNode("RECORDING");
+            RecordingTree.SaveRecordingResourceAndState(node, rec);
+
+            var loaded = new Recording();
+            loaded.RecordingId = "test-dock-tree";
+            RecordingTree.LoadRecordingResourceAndState(node, loaded);
+
+            Assert.Equal(67890u, loaded.DockTargetVesselPid);
+        }
+
+        #endregion
+
+        #region Resource Manifest via Tree path
+
+        [Fact]
+        public void ResourceManifest_RoundTrip_ViaTree()
+        {
+            var rec = new Recording();
+            rec.RecordingId = "test-tree-res";
+            rec.StartResources = new Dictionary<string, ResourceAmount>
+            {
+                ["LiquidFuel"] = new ResourceAmount { amount = 3600, maxAmount = 3600 }
+            };
+            rec.EndResources = new Dictionary<string, ResourceAmount>
+            {
+                ["LiquidFuel"] = new ResourceAmount { amount = 200, maxAmount = 3600 }
+            };
+
+            var node = new ConfigNode("RECORDING");
+            RecordingTree.SaveRecordingResourceAndState(node, rec);
+
+            var loaded = new Recording();
+            loaded.RecordingId = "test-tree-res";
+            RecordingTree.LoadRecordingResourceAndState(node, loaded);
+
+            Assert.NotNull(loaded.StartResources);
+            Assert.NotNull(loaded.EndResources);
+            Assert.Equal(3600.0, loaded.StartResources["LiquidFuel"].amount);
+            Assert.Equal(200.0, loaded.EndResources["LiquidFuel"].amount);
+        }
+
+        #endregion
+    }
+}

--- a/Source/Parsek.Tests/ResourceManifestTests.cs
+++ b/Source/Parsek.Tests/ResourceManifestTests.cs
@@ -1,0 +1,439 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    [Collection("Sequential")]
+    public class ResourceManifestTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public ResourceManifestTests()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.VerboseOverrideForTesting = true;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+        }
+
+        #region Helper — build RESOURCE node
+
+        private static ConfigNode MakeResource(string name, double amount, double maxAmount)
+        {
+            var res = new ConfigNode("RESOURCE");
+            res.AddValue("name", name);
+            res.AddValue("amount", amount.ToString("R", CultureInfo.InvariantCulture));
+            res.AddValue("maxAmount", maxAmount.ToString("R", CultureInfo.InvariantCulture));
+            return res;
+        }
+
+        private static ConfigNode MakePart(params ConfigNode[] resources)
+        {
+            var part = new ConfigNode("PART");
+            part.AddValue("name", "testPart");
+            foreach (var r in resources)
+                part.AddNode(r);
+            return part;
+        }
+
+        private static ConfigNode MakeVessel(params ConfigNode[] parts)
+        {
+            var vessel = new ConfigNode("VESSEL");
+            foreach (var p in parts)
+                vessel.AddNode(p);
+            return vessel;
+        }
+
+        #endregion
+
+        #region T11.1 — ExtractResourceManifest
+
+        [Fact]
+        public void ExtractResourceManifest_NullInput_ReturnsNull()
+        {
+            var result = VesselSpawner.ExtractResourceManifest(null);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void ExtractResourceManifest_EmptyVessel_ReturnsNull()
+        {
+            var vessel = new ConfigNode("VESSEL");
+
+            var result = VesselSpawner.ExtractResourceManifest(vessel);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void ExtractResourceManifest_SinglePart_SingleResource()
+        {
+            var vessel = MakeVessel(
+                MakePart(MakeResource("LiquidFuel", 400, 400)));
+
+            var result = VesselSpawner.ExtractResourceManifest(vessel);
+
+            Assert.NotNull(result);
+            Assert.Single(result);
+            Assert.Equal(400.0, result["LiquidFuel"].amount);
+            Assert.Equal(400.0, result["LiquidFuel"].maxAmount);
+            Assert.Contains(logLines, l => l.Contains("[Spawner]") && l.Contains("1 resource type(s)") && l.Contains("1 part(s)"));
+        }
+
+        [Fact]
+        public void ExtractResourceManifest_SinglePart_MultipleResources()
+        {
+            var vessel = MakeVessel(
+                MakePart(
+                    MakeResource("LiquidFuel", 400, 400),
+                    MakeResource("Oxidizer", 488, 488)));
+
+            var result = VesselSpawner.ExtractResourceManifest(vessel);
+
+            Assert.NotNull(result);
+            Assert.Equal(2, result.Count);
+            Assert.Equal(400.0, result["LiquidFuel"].amount);
+            Assert.Equal(488.0, result["Oxidizer"].amount);
+        }
+
+        [Fact]
+        public void ExtractResourceManifest_MultipleParts_SameResource_Summed()
+        {
+            var vessel = MakeVessel(
+                MakePart(MakeResource("LiquidFuel", 400, 400)),
+                MakePart(MakeResource("LiquidFuel", 400, 400)),
+                MakePart(MakeResource("LiquidFuel", 400, 400)));
+
+            var result = VesselSpawner.ExtractResourceManifest(vessel);
+
+            Assert.NotNull(result);
+            Assert.Single(result);
+            Assert.Equal(1200.0, result["LiquidFuel"].amount);
+            Assert.Equal(1200.0, result["LiquidFuel"].maxAmount);
+            Assert.Contains(logLines, l => l.Contains("1 resource type(s)") && l.Contains("3 part(s)"));
+        }
+
+        [Fact]
+        public void ExtractResourceManifest_MultipleParts_MixedResources()
+        {
+            var vessel = MakeVessel(
+                MakePart(
+                    MakeResource("LiquidFuel", 400, 400),
+                    MakeResource("Oxidizer", 488, 488)),
+                MakePart(
+                    MakeResource("LiquidFuel", 200, 400),
+                    MakeResource("MonoPropellant", 30, 50)));
+
+            var result = VesselSpawner.ExtractResourceManifest(vessel);
+
+            Assert.NotNull(result);
+            Assert.Equal(3, result.Count);
+            Assert.Equal(600.0, result["LiquidFuel"].amount);
+            Assert.Equal(800.0, result["LiquidFuel"].maxAmount);
+            Assert.Equal(488.0, result["Oxidizer"].amount);
+            Assert.Equal(30.0, result["MonoPropellant"].amount);
+        }
+
+        [Fact]
+        public void ExtractResourceManifest_ZeroAmountResource_Included()
+        {
+            var vessel = MakeVessel(
+                MakePart(MakeResource("Ore", 0, 1500)));
+
+            var result = VesselSpawner.ExtractResourceManifest(vessel);
+
+            Assert.NotNull(result);
+            Assert.True(result.ContainsKey("Ore"));
+            Assert.Equal(0.0, result["Ore"].amount);
+            Assert.Equal(1500.0, result["Ore"].maxAmount);
+        }
+
+        [Fact]
+        public void ExtractResourceManifest_PartWithNoResources_Skipped()
+        {
+            var structuralPart = new ConfigNode("PART");
+            structuralPart.AddValue("name", "structuralPanel");
+
+            var vessel = MakeVessel(
+                structuralPart,
+                MakePart(MakeResource("LiquidFuel", 100, 100)));
+
+            var result = VesselSpawner.ExtractResourceManifest(vessel);
+
+            Assert.NotNull(result);
+            Assert.Single(result);
+            Assert.Equal(100.0, result["LiquidFuel"].amount);
+        }
+
+        [Fact]
+        public void ExtractResourceManifest_MissingAmountField_DefaultsZero()
+        {
+            var res = new ConfigNode("RESOURCE");
+            res.AddValue("name", "LiquidFuel");
+            // No amount or maxAmount values
+            var vessel = MakeVessel(MakePart(res));
+
+            var result = VesselSpawner.ExtractResourceManifest(vessel);
+
+            Assert.NotNull(result);
+            Assert.Equal(0.0, result["LiquidFuel"].amount);
+            Assert.Equal(0.0, result["LiquidFuel"].maxAmount);
+        }
+
+        [Fact]
+        public void ExtractResourceManifest_MalformedAmount_DefaultsZero()
+        {
+            var res = new ConfigNode("RESOURCE");
+            res.AddValue("name", "LiquidFuel");
+            res.AddValue("amount", "abc");
+            res.AddValue("maxAmount", "xyz");
+            var vessel = MakeVessel(MakePart(res));
+
+            var result = VesselSpawner.ExtractResourceManifest(vessel);
+
+            Assert.NotNull(result);
+            Assert.Equal(0.0, result["LiquidFuel"].amount);
+            Assert.Equal(0.0, result["LiquidFuel"].maxAmount);
+        }
+
+        [Fact]
+        public void ExtractResourceManifest_ElectricCharge_Excluded()
+        {
+            var vessel = MakeVessel(
+                MakePart(
+                    MakeResource("ElectricCharge", 150, 150),
+                    MakeResource("LiquidFuel", 400, 400)));
+
+            var result = VesselSpawner.ExtractResourceManifest(vessel);
+
+            Assert.NotNull(result);
+            Assert.False(result.ContainsKey("ElectricCharge"));
+            Assert.True(result.ContainsKey("LiquidFuel"));
+        }
+
+        [Fact]
+        public void ExtractResourceManifest_IntakeAir_Excluded()
+        {
+            var vessel = MakeVessel(
+                MakePart(
+                    MakeResource("IntakeAir", 1, 5),
+                    MakeResource("LiquidFuel", 400, 400)));
+
+            var result = VesselSpawner.ExtractResourceManifest(vessel);
+
+            Assert.NotNull(result);
+            Assert.False(result.ContainsKey("IntakeAir"));
+            Assert.True(result.ContainsKey("LiquidFuel"));
+        }
+
+        [Fact]
+        public void ExtractResourceManifest_Ablator_Included()
+        {
+            var vessel = MakeVessel(
+                MakePart(MakeResource("Ablator", 200, 200)));
+
+            var result = VesselSpawner.ExtractResourceManifest(vessel);
+
+            Assert.NotNull(result);
+            Assert.True(result.ContainsKey("Ablator"));
+            Assert.Equal(200.0, result["Ablator"].amount);
+        }
+
+        [Fact]
+        public void ExtractResourceManifest_RoundTrip_Precision()
+        {
+            double precise = 3600.123456789;
+            var vessel = MakeVessel(
+                MakePart(MakeResource("LiquidFuel", precise, precise)));
+
+            var result = VesselSpawner.ExtractResourceManifest(vessel);
+
+            Assert.NotNull(result);
+            Assert.Equal(precise, result["LiquidFuel"].amount);
+            Assert.Equal(precise, result["LiquidFuel"].maxAmount);
+        }
+
+        [Fact]
+        public void ExtractResourceManifest_VesselSnapshotBuilder_Integration()
+        {
+            // Build a vessel snapshot via VesselSnapshotBuilder, then add RESOURCE nodes
+            // to verify extraction works against a realistic snapshot structure.
+            var builder = Parsek.Tests.Generators.VesselSnapshotBuilder.ProbeShip("TestProbe");
+            var snapshot = builder.Build();
+
+            // Manually add RESOURCE nodes to the first PART
+            var parts = snapshot.GetNodes("PART");
+            Assert.True(parts.Length > 0, "VesselSnapshotBuilder should produce at least one PART");
+
+            var lfRes = MakeResource("LiquidFuel", 200, 400);
+            var oxRes = MakeResource("Oxidizer", 244, 488);
+            parts[0].AddNode(lfRes);
+            parts[0].AddNode(oxRes);
+
+            var result = VesselSpawner.ExtractResourceManifest(snapshot);
+
+            Assert.NotNull(result);
+            Assert.Equal(2, result.Count);
+            Assert.Equal(200.0, result["LiquidFuel"].amount);
+            Assert.Equal(400.0, result["LiquidFuel"].maxAmount);
+            Assert.Equal(244.0, result["Oxidizer"].amount);
+            Assert.Equal(488.0, result["Oxidizer"].maxAmount);
+        }
+
+        #endregion
+
+        #region T11.5 — ComputeResourceDelta
+
+        [Fact]
+        public void ComputeResourceDelta_NormalConsumption()
+        {
+            var start = new Dictionary<string, ResourceAmount>
+            {
+                ["LiquidFuel"] = new ResourceAmount { amount = 3600, maxAmount = 3600 }
+            };
+            var end = new Dictionary<string, ResourceAmount>
+            {
+                ["LiquidFuel"] = new ResourceAmount { amount = 200, maxAmount = 3600 }
+            };
+
+            var delta = ResourceManifest.ComputeResourceDelta(start, end);
+
+            Assert.NotNull(delta);
+            Assert.Equal(-3400.0, delta["LiquidFuel"]);
+        }
+
+        [Fact]
+        public void ComputeResourceDelta_ResourceGained()
+        {
+            var start = new Dictionary<string, ResourceAmount>
+            {
+                ["Ore"] = new ResourceAmount { amount = 0, maxAmount = 1500 }
+            };
+            var end = new Dictionary<string, ResourceAmount>
+            {
+                ["Ore"] = new ResourceAmount { amount = 1500, maxAmount = 1500 }
+            };
+
+            var delta = ResourceManifest.ComputeResourceDelta(start, end);
+
+            Assert.NotNull(delta);
+            Assert.Equal(1500.0, delta["Ore"]);
+        }
+
+        [Fact]
+        public void ComputeResourceDelta_MixedGainsAndLosses()
+        {
+            var start = new Dictionary<string, ResourceAmount>
+            {
+                ["LiquidFuel"] = new ResourceAmount { amount = 3600, maxAmount = 3600 },
+                ["Ore"] = new ResourceAmount { amount = 0, maxAmount = 1500 }
+            };
+            var end = new Dictionary<string, ResourceAmount>
+            {
+                ["LiquidFuel"] = new ResourceAmount { amount = 200, maxAmount = 3600 },
+                ["Ore"] = new ResourceAmount { amount = 1500, maxAmount = 1500 }
+            };
+
+            var delta = ResourceManifest.ComputeResourceDelta(start, end);
+
+            Assert.NotNull(delta);
+            Assert.Equal(-3400.0, delta["LiquidFuel"]);
+            Assert.Equal(1500.0, delta["Ore"]);
+        }
+
+        [Fact]
+        public void ComputeResourceDelta_ResourceOnlyInStart()
+        {
+            var start = new Dictionary<string, ResourceAmount>
+            {
+                ["LiquidFuel"] = new ResourceAmount { amount = 3600, maxAmount = 3600 }
+            };
+            var end = new Dictionary<string, ResourceAmount>();
+
+            var delta = ResourceManifest.ComputeResourceDelta(start, end);
+
+            Assert.NotNull(delta);
+            Assert.Equal(-3600.0, delta["LiquidFuel"]);
+        }
+
+        [Fact]
+        public void ComputeResourceDelta_ResourceOnlyInEnd()
+        {
+            var start = new Dictionary<string, ResourceAmount>();
+            var end = new Dictionary<string, ResourceAmount>
+            {
+                ["Ore"] = new ResourceAmount { amount = 1500, maxAmount = 1500 }
+            };
+
+            var delta = ResourceManifest.ComputeResourceDelta(start, end);
+
+            Assert.NotNull(delta);
+            Assert.Equal(1500.0, delta["Ore"]);
+        }
+
+        [Fact]
+        public void ComputeResourceDelta_Unchanged()
+        {
+            var start = new Dictionary<string, ResourceAmount>
+            {
+                ["LiquidFuel"] = new ResourceAmount { amount = 400, maxAmount = 400 }
+            };
+            var end = new Dictionary<string, ResourceAmount>
+            {
+                ["LiquidFuel"] = new ResourceAmount { amount = 400, maxAmount = 400 }
+            };
+
+            var delta = ResourceManifest.ComputeResourceDelta(start, end);
+
+            Assert.NotNull(delta);
+            Assert.Equal(0.0, delta["LiquidFuel"]);
+        }
+
+        [Fact]
+        public void ComputeResourceDelta_BothNull()
+        {
+            var delta = ResourceManifest.ComputeResourceDelta(null, null);
+
+            Assert.Null(delta);
+        }
+
+        [Fact]
+        public void ComputeResourceDelta_StartNull()
+        {
+            var end = new Dictionary<string, ResourceAmount>
+            {
+                ["LiquidFuel"] = new ResourceAmount { amount = 200, maxAmount = 3600 }
+            };
+
+            var delta = ResourceManifest.ComputeResourceDelta(null, end);
+
+            Assert.NotNull(delta);
+            Assert.Equal(200.0, delta["LiquidFuel"]);
+        }
+
+        [Fact]
+        public void ComputeResourceDelta_EndNull()
+        {
+            var start = new Dictionary<string, ResourceAmount>
+            {
+                ["LiquidFuel"] = new ResourceAmount { amount = 3600, maxAmount = 3600 }
+            };
+
+            var delta = ResourceManifest.ComputeResourceDelta(start, null);
+
+            Assert.NotNull(delta);
+            Assert.Equal(-3600.0, delta["LiquidFuel"]);
+        }
+
+        #endregion
+    }
+}

--- a/Source/Parsek.Tests/SyntheticRecordingTests.cs
+++ b/Source/Parsek.Tests/SyntheticRecordingTests.cs
@@ -211,10 +211,21 @@ namespace Parsek.Tests
             b.AddPartEvent(t + 50, 102222, 2, "parachuteSingle");      // ParachuteDeployed
 
             // Vessel spawn: FleaRocket with Bob — lands ~2km east of pad
-            b.WithVesselSnapshot(
-                VesselSnapshotBuilder.FleaRocket("Flea Flight", "Bob Kerman", pid: 22222222)
-                    .AsLanded(baseLat, baseLon + 0.0175, 77));
+            var snapshot = VesselSnapshotBuilder.FleaRocket("Flea Flight", "Bob Kerman", pid: 22222222)
+                .AddResourceToPart(1, "SolidFuel", 0, 227)   // SRB emptied after flight
+                .AsLanded(baseLat, baseLon + 0.0175, 77);
+            b.WithVesselSnapshot(snapshot);
             b.WithTerrainHeightAtEnd(65.0);
+
+            // Resource manifests: Flea has 227 SolidFuel at start, 0 at end
+            b.WithStartResources(new Dictionary<string, ResourceAmount>
+            {
+                { "SolidFuel", new ResourceAmount { amount = 227.0, maxAmount = 227.0 } }
+            });
+            b.WithEndResources(new Dictionary<string, ResourceAmount>
+            {
+                { "SolidFuel", new ResourceAmount { amount = 0.0, maxAmount = 227.0 } }
+            });
 
             return b;
         }

--- a/Source/Parsek/BackgroundRecorder.cs
+++ b/Source/Parsek/BackgroundRecorder.cs
@@ -633,9 +633,11 @@ namespace Parsek
                     child.VesselSnapshot = VesselSpawner.TryBackupSnapshot(childVessel);
                     child.GhostVisualSnapshot = child.VesselSnapshot != null
                         ? child.VesselSnapshot.CreateCopy() : null;
+                    child.StartResources = VesselSpawner.ExtractResourceManifest(child.VesselSnapshot);
                     ParsekLog.Verbose("BgRecorder",
                         $"Captured snapshot for child vessel: pid={child.VesselPersistentId} " +
-                        $"name='{child.VesselName}' hasSnapshot={child.VesselSnapshot != null}");
+                        $"name='{child.VesselName}' hasSnapshot={child.VesselSnapshot != null} " +
+                        $"startResources={child.StartResources?.Count ?? 0} type(s)");
                 }
                 else
                 {

--- a/Source/Parsek/ChainSegmentManager.cs
+++ b/Source/Parsek/ChainSegmentManager.cs
@@ -630,6 +630,17 @@ namespace Parsek
                     pending.ChainBranch = 0; // always primary path
                     pending.EvaCrewName = null; // vessel segment, not EVA
 
+                    // Capture dock target vessel PID for Phase 12 route analysis.
+                    // dockPortPid is actually the merged vessel PID (confusingly named) —
+                    // see ParsekFlight.HandleDockUndockCommitRestart where pendingDockMergedPid
+                    // (= data.to.vessel.persistentId) is passed as this parameter.
+                    if (type == PartEventType.Docked && dockPortPid != 0)
+                    {
+                        pending.DockTargetVesselPid = dockPortPid;
+                        ParsekLog.Verbose("Chain",
+                            $"CommitDockUndockSegment: captured dock target vessel pid={dockPortPid}");
+                    }
+
                     // Add dock/undock part event to the segment
                     if (segmentRecorder.Recording.Count > 0)
                     {

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -262,6 +262,7 @@ namespace Parsek
         internal double LastRecordedAltitude { get; private set; } = double.NaN;
         private ConfigNode lastGoodVesselSnapshot;
         private ConfigNode initialGhostVisualSnapshot;
+        private Dictionary<string, ResourceAmount> pendingStartResources;
         private double lastSnapshotRefreshUT = double.MinValue;
 
         // Boundary anchor: if set, inserted as the first point when recording starts.
@@ -4379,6 +4380,8 @@ namespace Parsek
                 ParsekLog.Verbose("Recorder", $"Boundary anchor inserted at UT {anchorUT:F3}");
             }
             RefreshBackupSnapshot(v, "record_start", force: true);
+            pendingStartResources = VesselSpawner.ExtractResourceManifest(lastGoodVesselSnapshot);
+            ParsekLog.Verbose("Recorder", $"StartRecording: captured {pendingStartResources?.Count ?? 0} start resource type(s)");
             initialGhostVisualSnapshot = lastGoodVesselSnapshot != null
                 ? lastGoodVesselSnapshot.CreateCopy()
                 : VesselSpawner.TryBackupSnapshot(v);
@@ -4565,6 +4568,9 @@ namespace Parsek
                 isDestroyed,
                 snapshotVessel,
                 destroyedFallbackSnapshot ?? lastGoodVesselSnapshot);
+            capture.StartResources = pendingStartResources;
+            capture.EndResources = VesselSpawner.ExtractResourceManifest(capture.VesselSnapshot);
+            ParsekLog.Verbose("Recorder", $"BuildCaptureRecording: captured {capture.EndResources?.Count ?? 0} end resource type(s)");
             capture.GhostVisualSnapshot = initialGhostVisualSnapshot != null
                 ? initialGhostVisualSnapshot.CreateCopy()
                 : (capture.VesselSnapshot != null ? capture.VesselSnapshot.CreateCopy() : null);

--- a/Source/Parsek/InGameTests/RuntimeTests.cs
+++ b/Source/Parsek/InGameTests/RuntimeTests.cs
@@ -2755,5 +2755,37 @@ namespace Parsek.InGameTests
                 $"Double-seed guard necessity verified: first={countAfterFirst} " +
                 $"after-double={rec.PartEvents.Count} events");
         }
+
+        // ======================= ResourceManifest (Phase 11) =======================
+
+        [InGameTest(Category = "ResourceManifest", Scene = GameScenes.FLIGHT,
+            Description = "ExtractResourceManifest returns valid manifest from live vessel snapshot")]
+        public void ExtractResourceManifest_LiveVessel_ReturnsNonNull()
+        {
+            // Get active vessel
+            var vessel = FlightGlobals.ActiveVessel;
+            InGameAssert.IsNotNull(vessel, "No active vessel in flight");
+
+            // Take snapshot (same path as recording system)
+            var snapshot = VesselSpawner.TryBackupSnapshot(vessel);
+            InGameAssert.IsNotNull(snapshot, "Failed to snapshot active vessel");
+
+            // Extract resource manifest
+            var manifest = VesselSpawner.ExtractResourceManifest(snapshot);
+            InGameAssert.IsNotNull(manifest, "Resource manifest is null — vessel has no non-EC/IntakeAir resources?");
+            InGameAssert.IsTrue(manifest.Count > 0, "Resource manifest is empty");
+
+            // Log what we found for diagnostic verification
+            foreach (var kvp in manifest)
+                ParsekLog.Verbose("TestRunner", $"ResourceManifest test: {kvp.Key} = {kvp.Value}");
+
+            // Verify ElectricCharge is excluded
+            InGameAssert.IsFalse(manifest.ContainsKey("ElectricCharge"), "ElectricCharge should be excluded from manifest");
+
+            // Verify at least one common resource exists (most vessels have fuel)
+            bool hasCommonResource = manifest.ContainsKey("LiquidFuel") || manifest.ContainsKey("SolidFuel")
+                || manifest.ContainsKey("MonoPropellant") || manifest.ContainsKey("Oxidizer");
+            InGameAssert.IsTrue(hasCommonResource, "No common fuel resource found — test vessel needs fuel");
+        }
     }
 }

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -2994,16 +2994,22 @@ namespace Parsek
                 ConfigNode snapshot = VesselSpawner.TryBackupSnapshot(vessel);
                 childRec.GhostVisualSnapshot = snapshot;
                 childRec.VesselSnapshot = snapshot != null ? snapshot.CreateCopy() : null;
+                childRec.StartResources = VesselSpawner.ExtractResourceManifest(childRec.VesselSnapshot ?? childRec.GhostVisualSnapshot);
+                ParsekLog.Verbose("Coalescer",
+                    $"CreateBreakupChildRecording: captured {childRec.StartResources?.Count ?? 0} start resource type(s) for pid={pid}");
             }
             else if (fallbackSnapshot != null)
             {
                 // Vessel destroyed during coalescing window — use pre-captured snapshot (#157)
                 childRec.GhostVisualSnapshot = fallbackSnapshot;
                 childRec.VesselSnapshot = fallbackSnapshot.CreateCopy();
+                childRec.StartResources = VesselSpawner.ExtractResourceManifest(childRec.VesselSnapshot);
                 childRec.TerminalStateValue = TerminalState.Destroyed;
                 childRec.ExplicitEndUT = breakupBp.UT;
                 ParsekLog.Info("Coalescer",
                     $"CreateBreakupChildRecording: using pre-captured snapshot for pid={pid} (vessel destroyed)");
+                ParsekLog.Verbose("Coalescer",
+                    $"CreateBreakupChildRecording: captured {childRec.StartResources?.Count ?? 0} start resource type(s) for pid={pid} (fallback)");
             }
             else
             {
@@ -3246,6 +3252,11 @@ namespace Parsek
             // Decoupled part events at breakupUT hide detached parts during playback.
             rootRec.GhostVisualSnapshot = cap.GhostVisualSnapshot;
             rootRec.VesselSnapshot = cap.VesselSnapshot;
+            rootRec.StartResources = cap.StartResources;
+            rootRec.EndResources = VesselSpawner.ExtractResourceManifest(rootRec.VesselSnapshot);
+            ParsekLog.Verbose("Coalescer",
+                $"PromoteToTreeForBreakup: resources — start={rootRec.StartResources?.Count ?? 0} type(s), " +
+                $"end={rootRec.EndResources?.Count ?? 0} type(s)");
             rootRec.RewindSaveFileName = cap.RewindSaveFileName;
             rootRec.RewindReservedFunds = cap.RewindReservedFunds;
             rootRec.RewindReservedScience = cap.RewindReservedScience;

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -3009,6 +3009,13 @@ namespace Parsek
             if (rec.Hidden)
                 recNode.AddValue("hidden", rec.Hidden.ToString());
 
+            // Resource manifests (Phase 11)
+            RecordingStore.SerializeResourceManifest(recNode, rec);
+
+            // Dock target vessel PID (Phase 11)
+            if (rec.DockTargetVesselPid != 0)
+                recNode.AddValue("dockTargetPid", rec.DockTargetVesselPid.ToString(CultureInfo.InvariantCulture));
+
         }
 
         /// <summary>
@@ -3174,6 +3181,18 @@ namespace Parsek
                 bool hidden;
                 if (bool.TryParse(hiddenStr, out hidden))
                     rec.Hidden = hidden;
+            }
+
+            // Resource manifests (Phase 11)
+            RecordingStore.DeserializeResourceManifest(recNode, rec);
+
+            // Dock target vessel PID (Phase 11)
+            string dockTargetPidStr = recNode.GetValue("dockTargetPid");
+            if (dockTargetPidStr != null)
+            {
+                uint dockTargetPid;
+                if (uint.TryParse(dockTargetPidStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out dockTargetPid))
+                    rec.DockTargetVesselPid = dockTargetPid;
             }
 
         }

--- a/Source/Parsek/Recording.cs
+++ b/Source/Parsek/Recording.cs
@@ -323,6 +323,9 @@ namespace Parsek
                 ? new List<string>(source.RecordingGroups) : null;
             AntennaSpecs = source.AntennaSpecs != null
                 ? new List<AntennaSpec>(source.AntennaSpecs) : null;
+            StartResources = source.StartResources;
+            EndResources = source.EndResources;
+            DockTargetVesselPid = source.DockTargetVesselPid;
 
             // Copy segment events and tracks if source has them
             if (source.SegmentEvents != null && source.SegmentEvents.Count > 0)

--- a/Source/Parsek/Recording.cs
+++ b/Source/Parsek/Recording.cs
@@ -143,6 +143,14 @@ namespace Parsek
         // null = not yet populated (legacy recording or pre-commit).
         public Dictionary<string, KerbalEndState> CrewEndStates;
 
+        // Resource manifests (Phase 11) — per-resource amount/capacity at recording start and end
+        // null = no data (legacy recording or not yet captured)
+        internal Dictionary<string, ResourceAmount> StartResources;
+        internal Dictionary<string, ResourceAmount> EndResources;
+
+        // PID of vessel docked to at this segment's boundary (0 = not a dock segment)
+        public uint DockTargetVesselPid;
+
         // Background recording: surface position for landed/splashed vessels
         public SurfacePosition? SurfacePos;            // null if not a background landed vessel
 

--- a/Source/Parsek/RecordingOptimizer.cs
+++ b/Source/Parsek/RecordingOptimizer.cs
@@ -261,6 +261,11 @@ namespace Parsek
             if (absorbed.VesselSnapshot != null)
                 target.VesselSnapshot = absorbed.VesselSnapshot;
 
+            // Resource manifests: absorbed recording's end resources win (later segment)
+            if (absorbed.EndResources != null)
+                target.EndResources = absorbed.EndResources;
+            // target.StartResources intentionally unchanged — represents the earlier start
+
             // 8. TerminalState: absorbed is the later segment, inherit its terminal state
             if (absorbed.TerminalStateValue.HasValue)
                 target.TerminalStateValue = absorbed.TerminalStateValue;
@@ -437,6 +442,12 @@ namespace Parsek
             // 10. Transfer terminal-state fields to second half (represents end-of-recording state)
             second.VesselSnapshot = original.VesselSnapshot;
             original.VesselSnapshot = null;
+
+            // Resource manifests: first half keeps start, second half gets end (moved with VesselSnapshot)
+            second.EndResources = original.EndResources;
+            original.EndResources = null;
+            // original.StartResources unchanged (keeps the recording-start resources)
+            // second.StartResources stays null (no snapshot at environment boundary)
 
             second.TerminalStateValue = original.TerminalStateValue;
             original.TerminalStateValue = null;

--- a/Source/Parsek/RecordingOptimizer.cs
+++ b/Source/Parsek/RecordingOptimizer.cs
@@ -266,6 +266,10 @@ namespace Parsek
                 target.EndResources = absorbed.EndResources;
             // target.StartResources intentionally unchanged — represents the earlier start
 
+            // Dock target PID: absorbed wins if non-zero (dock may be in later segment)
+            if (absorbed.DockTargetVesselPid != 0)
+                target.DockTargetVesselPid = absorbed.DockTargetVesselPid;
+
             // 8. TerminalState: absorbed is the later segment, inherit its terminal state
             if (absorbed.TerminalStateValue.HasValue)
                 target.TerminalStateValue = absorbed.TerminalStateValue;

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -3100,6 +3100,127 @@ namespace Parsek
 
         #endregion
 
+        #region Resource Manifest Serialization
+
+        /// <summary>
+        /// Serializes StartResources and EndResources dictionaries into a RESOURCE_MANIFEST
+        /// ConfigNode on the given parent. Each resource becomes a RESOURCE child node with
+        /// name, startAmount, startMax, endAmount, endMax fields.
+        /// No-op if both StartResources and EndResources are null or empty.
+        /// </summary>
+        internal static void SerializeResourceManifest(ConfigNode parent, Recording rec)
+        {
+            bool hasStart = rec.StartResources != null && rec.StartResources.Count > 0;
+            bool hasEnd = rec.EndResources != null && rec.EndResources.Count > 0;
+            if (!hasStart && !hasEnd)
+                return;
+
+            ConfigNode manifestNode = parent.AddNode("RESOURCE_MANIFEST");
+
+            // Build merged key set from StartResources ∪ EndResources
+            var keys = new HashSet<string>();
+            if (hasStart)
+                foreach (var k in rec.StartResources.Keys) keys.Add(k);
+            if (hasEnd)
+                foreach (var k in rec.EndResources.Keys) keys.Add(k);
+
+            int count = 0;
+            foreach (var name in keys)
+            {
+                ConfigNode resNode = manifestNode.AddNode("RESOURCE");
+                resNode.AddValue("name", name);
+
+                if (hasStart && rec.StartResources.TryGetValue(name, out var startRa))
+                {
+                    resNode.AddValue("startAmount", startRa.amount.ToString("R", CultureInfo.InvariantCulture));
+                    resNode.AddValue("startMax", startRa.maxAmount.ToString("R", CultureInfo.InvariantCulture));
+                }
+
+                if (hasEnd && rec.EndResources.TryGetValue(name, out var endRa))
+                {
+                    resNode.AddValue("endAmount", endRa.amount.ToString("R", CultureInfo.InvariantCulture));
+                    resNode.AddValue("endMax", endRa.maxAmount.ToString("R", CultureInfo.InvariantCulture));
+                }
+
+                count++;
+            }
+
+            ParsekLog.Verbose("RecordingStore",
+                $"SerializeResourceManifest: wrote {count} resource(s) for recording={rec.RecordingId}");
+        }
+
+        /// <summary>
+        /// Deserializes StartResources and EndResources from a RESOURCE_MANIFEST ConfigNode
+        /// on the given parent. Sets the dictionaries if entries are found, or leaves them null
+        /// if the node is absent (backward compatible with legacy recordings).
+        /// </summary>
+        internal static void DeserializeResourceManifest(ConfigNode parent, Recording rec)
+        {
+            ConfigNode manifestNode = parent.GetNode("RESOURCE_MANIFEST");
+            if (manifestNode == null)
+                return;
+
+            ConfigNode[] resources = manifestNode.GetNodes("RESOURCE");
+            if (resources.Length == 0)
+                return;
+
+            int loaded = 0;
+            int skipped = 0;
+
+            for (int i = 0; i < resources.Length; i++)
+            {
+                string name = resources[i].GetValue("name");
+                if (string.IsNullOrEmpty(name))
+                {
+                    skipped++;
+                    continue;
+                }
+
+                // Parse start fields (if present)
+                string startAmountStr = resources[i].GetValue("startAmount");
+                string startMaxStr = resources[i].GetValue("startMax");
+                if (startAmountStr != null || startMaxStr != null)
+                {
+                    if (rec.StartResources == null)
+                        rec.StartResources = new Dictionary<string, ResourceAmount>();
+
+                    double startAmount = 0;
+                    double startMax = 0;
+                    if (startAmountStr != null)
+                        double.TryParse(startAmountStr, NumberStyles.Float, CultureInfo.InvariantCulture, out startAmount);
+                    if (startMaxStr != null)
+                        double.TryParse(startMaxStr, NumberStyles.Float, CultureInfo.InvariantCulture, out startMax);
+
+                    rec.StartResources[name] = new ResourceAmount { amount = startAmount, maxAmount = startMax };
+                }
+
+                // Parse end fields (if present)
+                string endAmountStr = resources[i].GetValue("endAmount");
+                string endMaxStr = resources[i].GetValue("endMax");
+                if (endAmountStr != null || endMaxStr != null)
+                {
+                    if (rec.EndResources == null)
+                        rec.EndResources = new Dictionary<string, ResourceAmount>();
+
+                    double endAmount = 0;
+                    double endMax = 0;
+                    if (endAmountStr != null)
+                        double.TryParse(endAmountStr, NumberStyles.Float, CultureInfo.InvariantCulture, out endAmount);
+                    if (endMaxStr != null)
+                        double.TryParse(endMaxStr, NumberStyles.Float, CultureInfo.InvariantCulture, out endMax);
+
+                    rec.EndResources[name] = new ResourceAmount { amount = endAmount, maxAmount = endMax };
+                }
+
+                loaded++;
+            }
+
+            ParsekLog.Verbose("RecordingStore",
+                $"DeserializeResourceManifest: loaded={loaded} skipped={skipped} for recording={rec.RecordingId}");
+        }
+
+        #endregion
+
         #region Recording File I/O
 
         internal static bool SaveRecordingFiles(Recording rec)

--- a/Source/Parsek/RecordingTree.cs
+++ b/Source/Parsek/RecordingTree.cs
@@ -285,7 +285,7 @@ namespace Parsek
         /// Saves atmosphere segment metadata, pre-launch resources, rewind save metadata,
         /// mutable playback state, and UI grouping tags into a RECORDING ConfigNode.
         /// </summary>
-        private static void SaveRecordingResourceAndState(ConfigNode recNode, Recording rec)
+        internal static void SaveRecordingResourceAndState(ConfigNode recNode, Recording rec)
         {
             var ic = CultureInfo.InvariantCulture;
 
@@ -366,6 +366,13 @@ namespace Parsek
 
             // Crew end states (kerbals module)
             RecordingStore.SerializeCrewEndStates(recNode, rec);
+
+            // Resource manifests (Phase 11)
+            RecordingStore.SerializeResourceManifest(recNode, rec);
+
+            // Dock target vessel PID (Phase 11)
+            if (rec.DockTargetVesselPid != 0)
+                recNode.AddValue("dockTargetPid", rec.DockTargetVesselPid.ToString(ic));
         }
 
         internal static void LoadRecordingFrom(ConfigNode recNode, Recording rec)
@@ -563,7 +570,7 @@ namespace Parsek
         /// ghost geometry metadata, mutable playback state, and UI grouping tags from a
         /// RECORDING ConfigNode into the given Recording.
         /// </summary>
-        private static void LoadRecordingResourceAndState(ConfigNode recNode, Recording rec)
+        internal static void LoadRecordingResourceAndState(ConfigNode recNode, Recording rec)
         {
             var inv = NumberStyles.Float;
             var ic = CultureInfo.InvariantCulture;
@@ -706,6 +713,18 @@ namespace Parsek
 
             // Crew end states (kerbals module)
             RecordingStore.DeserializeCrewEndStates(recNode, rec);
+
+            // Resource manifests (Phase 11)
+            RecordingStore.DeserializeResourceManifest(recNode, rec);
+
+            // Dock target vessel PID (Phase 11)
+            string dockTargetPidStr = recNode.GetValue("dockTargetPid");
+            if (dockTargetPidStr != null)
+            {
+                uint dockTargetPid;
+                if (uint.TryParse(dockTargetPidStr, NumberStyles.Integer, ic, out dockTargetPid))
+                    rec.DockTargetVesselPid = dockTargetPid;
+            }
         }
 
         #endregion

--- a/Source/Parsek/ResourceManifest.cs
+++ b/Source/Parsek/ResourceManifest.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+
+namespace Parsek
+{
+    /// <summary>
+    /// Per-resource amount/capacity pair, summed across all parts of a vessel.
+    /// Value type — dict indexer returns a copy; use read-modify-write for accumulation.
+    /// </summary>
+    internal struct ResourceAmount
+    {
+        public double amount;
+        public double maxAmount;
+
+        public override string ToString()
+        {
+            return $"{amount:F1}/{maxAmount:F1}";
+        }
+    }
+
+    /// <summary>
+    /// Pure static helpers for resource manifest extraction and comparison.
+    /// </summary>
+    internal static class ResourceManifest
+    {
+        /// <summary>
+        /// Compute per-resource delta between start and end manifests.
+        /// Positive = gained, negative = consumed.
+        /// Returns null if both inputs are null.
+        /// </summary>
+        internal static Dictionary<string, double> ComputeResourceDelta(
+            Dictionary<string, ResourceAmount> start,
+            Dictionary<string, ResourceAmount> end)
+        {
+            if (start == null && end == null) return null;
+
+            var delta = new Dictionary<string, double>();
+
+            // Build merged key set from start ∪ end
+            var keys = new HashSet<string>();
+            if (start != null)
+                foreach (var k in start.Keys) keys.Add(k);
+            if (end != null)
+                foreach (var k in end.Keys) keys.Add(k);
+
+            foreach (var key in keys)
+            {
+                double startAmt = 0;
+                double endAmt = 0;
+
+                if (start != null && start.TryGetValue(key, out var startRa))
+                    startAmt = startRa.amount;
+                if (end != null && end.TryGetValue(key, out var endRa))
+                    endAmt = endRa.amount;
+
+                delta[key] = endAmt - startAmt;
+            }
+
+            return delta;
+        }
+    }
+}

--- a/Source/Parsek/ResourceManifest.cs
+++ b/Source/Parsek/ResourceManifest.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace Parsek
 {
@@ -13,7 +14,7 @@ namespace Parsek
 
         public override string ToString()
         {
-            return $"{amount:F1}/{maxAmount:F1}";
+            return string.Format(CultureInfo.InvariantCulture, "{0:F1}/{1:F1}", amount, maxAmount);
         }
     }
 

--- a/Source/Parsek/UI/RecordingsTableUI.cs
+++ b/Source/Parsek/UI/RecordingsTableUI.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
 using ClickThroughFix;
 using UnityEngine;
 
@@ -2156,6 +2158,73 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Formats a resource manifest for tooltip display.
+        /// If both start and end: "Resources:\n  LiquidFuel: 3600.0 → 200.0 (-3400.0)"
+        /// If start only: "Resources at start:\n  LiquidFuel: 3600.0 / 3600.0"
+        /// If both null: returns null (no section shown).
+        /// </summary>
+        internal static string FormatResourceManifest(
+            Dictionary<string, ResourceAmount> start,
+            Dictionary<string, ResourceAmount> end)
+        {
+            if (start == null && end == null)
+                return null;
+
+            // Merge keys from both dicts
+            var keys = new SortedSet<string>();
+            if (start != null)
+                foreach (var k in start.Keys) keys.Add(k);
+            if (end != null)
+                foreach (var k in end.Keys) keys.Add(k);
+
+            if (keys.Count == 0)
+                return null;
+
+            bool hasEnd = end != null;
+            var lines = new List<string>();
+            lines.Add(hasEnd ? "Resources:" : "Resources at start:");
+
+            foreach (var key in keys)
+            {
+                if (hasEnd)
+                {
+                    double startAmt = 0;
+                    double endAmt = 0;
+                    if (start != null && start.TryGetValue(key, out var startRa))
+                        startAmt = startRa.amount;
+                    if (end.TryGetValue(key, out var endRa))
+                        endAmt = endRa.amount;
+
+                    double delta = endAmt - startAmt;
+                    string sign = delta >= 0 ? "+" : "";
+                    lines.Add(string.Format(CultureInfo.InvariantCulture,
+                        "  {0}: {1:F1} \u2192 {2:F1} ({3}{4:F1})",
+                        key,
+                        startAmt,
+                        endAmt,
+                        sign,
+                        delta));
+                }
+                else
+                {
+                    // Start only — show amount / maxAmount
+                    double amt = 0;
+                    double max = 0;
+                    if (start.TryGetValue(key, out var ra))
+                    {
+                        amt = ra.amount;
+                        max = ra.maxAmount;
+                    }
+                    lines.Add(string.Format(CultureInfo.InvariantCulture,
+                        "  {0}: {1:F1} / {2:F1}",
+                        key, amt, max));
+                }
+            }
+
+            return string.Join("\n", lines);
+        }
+
+        /// <summary>
         /// Formats situation + biome + body into a compact location string.
         /// "Flying, Shores, Kerbin" or "Orbiting, Kerbin" or "Kerbin" etc.
         /// </summary>
@@ -2421,6 +2490,10 @@ namespace Parsek
                 }
             }
             catch { /* Non-KSP context or Planetarium unavailable */ }
+
+            string resourceText = FormatResourceManifest(rec.StartResources, rec.EndResources);
+            if (resourceText != null)
+                text += "\n" + resourceText;
 
             EnsureTooltipStyle();
 

--- a/Source/Parsek/VesselSpawner.cs
+++ b/Source/Parsek/VesselSpawner.cs
@@ -40,6 +40,65 @@ namespace Parsek
             }
         }
 
+        /// <summary>
+        /// Walk PART > RESOURCE nodes in a vessel snapshot ConfigNode and return
+        /// a dictionary of resource names to summed amount/maxAmount.
+        /// Excludes ElectricCharge and IntakeAir (noise, not meaningful cargo).
+        /// Returns null if input is null, has no parts, or no resources found.
+        /// </summary>
+        internal static Dictionary<string, ResourceAmount> ExtractResourceManifest(ConfigNode vesselSnapshot)
+        {
+            if (vesselSnapshot == null) return null;
+
+            var parts = vesselSnapshot.GetNodes("PART");
+            if (parts.Length == 0) return null;
+
+            var manifest = new Dictionary<string, ResourceAmount>();
+            int partCount = parts.Length;
+
+            for (int i = 0; i < parts.Length; i++)
+            {
+                var resources = parts[i].GetNodes("RESOURCE");
+                for (int j = 0; j < resources.Length; j++)
+                {
+                    string name = resources[j].GetValue("name");
+                    if (string.IsNullOrEmpty(name)) continue;
+                    if (name == "ElectricCharge" || name == "IntakeAir") continue;
+
+                    double amount = 0;
+                    double maxAmount = 0;
+                    string amountStr = resources[j].GetValue("amount");
+                    string maxStr = resources[j].GetValue("maxAmount");
+                    if (amountStr != null)
+                        double.TryParse(amountStr, System.Globalization.NumberStyles.Float,
+                            CultureInfo.InvariantCulture, out amount);
+                    if (maxStr != null)
+                        double.TryParse(maxStr, System.Globalization.NumberStyles.Float,
+                            CultureInfo.InvariantCulture, out maxAmount);
+
+                    if (manifest.ContainsKey(name))
+                    {
+                        // Struct — indexer returns a copy. Read-modify-write.
+                        var ra = manifest[name];
+                        ra.amount += amount;
+                        ra.maxAmount += maxAmount;
+                        manifest[name] = ra;
+                    }
+                    else
+                    {
+                        manifest[name] = new ResourceAmount { amount = amount, maxAmount = maxAmount };
+                    }
+                }
+            }
+
+            if (manifest.Count == 0) return null;
+
+            ParsekLog.Verbose("Spawner",
+                $"ExtractResourceManifest: {manifest.Count} resource type(s) from {partCount} part(s)");
+
+            return manifest;
+        }
+
         public static uint RespawnVessel(ConfigNode vesselNode, HashSet<string> excludeCrew = null, bool preserveIdentity = false)
         {
             try

--- a/docs/dev/plans/phase-11-resource-snapshots.md
+++ b/docs/dev/plans/phase-11-resource-snapshots.md
@@ -962,14 +962,90 @@ Inventory:
 
 **KIS (Kerbal Inventory System):** v1 targets stock ModuleInventoryPart only. KIS uses `ModuleKISInventory` with a different format. Invisible to extraction. KIS compatibility is Phase 15 territory.
 
-### Implementation order
+---
 
-Inventory tasks slot after the resource manifest tasks:
+## Extension: Crew Manifests
+
+### Goal
+
+Capture crew composition by trait (Pilot, Scientist, Engineer, Tourist) at recording start and end. A crew transport route delivers "2 engineers and 1 scientist" per cycle, not specific named kerbals. This is the third manifest type alongside resources and inventory.
+
+### Extraction
+
+Crew data is already in the vessel snapshot — each PART node has `crew` values listing kerbal names. The kerbal roster (`HighLogic.CurrentGame.CrewRoster`) maps each name to a `ProtoCrewMember` with a `trait` field (Pilot/Scientist/Engineer/Tourist).
+
+```csharp
+// In VesselSpawner.cs
+internal static Dictionary<string, int> ExtractCrewManifest(ConfigNode vesselSnapshot)
+```
+
+**Algorithm:**
+
+```
+Walk PART nodes, collect all crew values (kerbal names)
+For each name, look up trait from roster (or from the PART's ProtoCrewMember data)
+Group by trait, count per trait
+Return Dictionary<string, int>: { "Pilot": 1, "Engineer": 2, "Scientist": 1 }
+Return null if no crew found
+```
+
+**Alternative (no roster lookup):** The vessel snapshot's PART > CREW nodes may contain trait information directly. If so, extraction is pure ConfigNode walking without needing `CrewRoster`. Needs investigation — check if ProtoCrewMember trait is serialized in the PART's crew data.
+
+### Recording fields
+
+```csharp
+internal Dictionary<string, int> StartCrew;  // null = no data
+internal Dictionary<string, int> EndCrew;     // null = no data
+```
+
+Serialized as `CREW_MANIFEST` ConfigNode (same additive pattern):
+
+```
+CREW_MANIFEST
+{
+    TRAIT { name = Pilot  startCount = 1  endCount = 1 }
+    TRAIT { name = Engineer  startCount = 2  endCount = 0 }
+    TRAIT { name = Scientist  startCount = 1  endCount = 0 }
+}
+```
+
+### UI display
+
+```
+Crew:
+  Pilot: 1 → 1 (unchanged)
+  Engineer: 2 → 0 (-2)
+  Scientist: 1 → 0 (-1)
+```
+
+### Phase 12 implications
+
+Crew delivery is the most complex of the three manifest types because it interacts with Parsek's existing crew reservation system:
+
+- **Route delivers by trait, not name.** "Send 2 engineers" picks whoever's available at the origin. For KSC origins, this means available kerbals from the astronaut complex. For non-KSC origins, this means crew seated in origin vessels.
+- **Crew reservation must account for route demand.** If a route needs 2 engineers per cycle, those engineers need to be reserved (not assigned to other missions) before dispatch.
+- **Moving crew on unloaded vessels** means modifying `ProtoPartSnapshot` crew lists and updating `ProtoCrewMember.seatIdx`/`rosterStatus` — similar complexity to inventory delivery.
+
+**Recommendation:** Same as inventory — capture crew manifests in Phase 11, defer delivery to Phase 12 v1.1 or v2. Liquid resources first, then inventory, then crew. Each layer adds complexity to the route dispatch evaluation.
+
+### Edge cases
+
+**Tourist contracts:** Tourists are valid "crew type" cargo but have contract implications. A tourist transport route might interfere with active tourism contracts. v1: capture tourists in the manifest, let Phase 12 decide whether to include them in route automation.
+
+**Crew experience and level:** The manifest tracks trait and count, not level. A route requesting "2 engineers" gets whichever engineers are available, regardless of star level. Level-aware routing is v2.
+
+**Crew capacity:** Analogous to inventory slots — destination vessel needs empty seats. Capture `crewCapacity` (sum of part crew capacity) alongside the crew manifest for Phase 12 capacity checks.
+
+---
+
+### Implementation order (all three manifest types)
 
 ```
 T11.1 → T11.5 → T11.2 → T11.3 → T11.4  (resource manifests — done)
     ↓
 T11-INV.1 → T11-INV.2 → T11-INV.3 → T11-INV.4 → T11-INV.5  (inventory manifests)
+    ↓
+T11-CREW.1 → T11-CREW.2 → T11-CREW.3 → T11-CREW.4  (crew manifests)
 ```
 
-Each inventory task mirrors the corresponding resource task and follows the same patterns. Total new code: ~200 lines implementation + ~200 lines tests.
+Each manifest type mirrors the same pattern. Crew is lightest (simplest data model, smallest ConfigNode structure) but has the most complex Phase 12 delivery implications due to reservation system interaction.

--- a/docs/dev/plans/phase-11-resource-snapshots.md
+++ b/docs/dev/plans/phase-11-resource-snapshots.md
@@ -751,3 +751,225 @@ Each dispatch cycle:
 Phase 11 stays exactly as planned — it adds data fields and extraction functions, all within existing files. No `Logistics/` directory yet. No route concepts leak into the resource snapshot code.
 
 The modularity constraint for Phase 11 is: **`StartResources`/`EndResources` must be usable by code that has no knowledge of routes.** This is already the case — they're plain Dictionary fields on Recording, serialized as additive ConfigNode data, extracted by a pure function. The UI tooltip (T11.4) consumes them directly. Phase 12's `RouteManifestComputer` will consume them through the same public fields. No coupling.
+
+---
+
+## Extension: Inventory Manifests
+
+### Goal
+
+Extend resource snapshots to capture KSP 1.12 inventory contents — parts stored in `ModuleInventoryPart` cargo containers. Players carrying spare solar panels, batteries, or science instruments to a base should see the inventory transfer reflected in the recording, and Phase 12 should replicate it each cycle.
+
+The data is already in vessel snapshots (same situation as liquid resources before Phase 11). We just need to extract it.
+
+### KSP 1.12 inventory internals (confirmed via decompilation)
+
+**ConfigNode structure** (from `ModuleInventoryPart.OnSave`):
+
+```
+MODULE
+{
+    name = ModuleInventoryPart
+    InventorySlots = 9
+    packedVolumeLimit = 300
+    STOREDPARTS
+    {
+        STOREDPART
+        {
+            slotIndex = 0
+            partName = evaChute
+            quantity = 1
+            stackCapacity = 1
+            variantName =
+            PART
+            {
+                name = evaChute
+                persistentId = 2769214603
+                MODULE { name = ModuleCargoPart ... }
+                RESOURCE { name = EVA Propellant  amount = 5  maxAmount = 5 }
+            }
+        }
+        STOREDPART
+        {
+            slotIndex = 1
+            partName = solarPanels5
+            quantity = 1
+            stackCapacity = 1
+            variantName =
+            PART { ... }
+        }
+    }
+}
+```
+
+**Key facts:**
+- `StoredPart` class: `slotIndex` (int), `partName` (string, KSP dot-form), `quantity` (int, >1 for stacked items), `stackCapacity` (int), `variantName` (string).
+- `ModuleInventoryPart.storedParts`: `DictionaryValueList<int, StoredPart>` keyed by slot index.
+- `InventorySlots` controls slot count. `packedVolumeLimit` (liters) and `massLimit` (tons) are optional capacity constraints.
+- Stacking: only items with identical `partName` + `variantName` can share a slot. Controlled by `ModuleCargoPart.stackableQuantity` on the part cfg.
+- Each STOREDPART's inner PART node is a full ProtoPartSnapshot with its own RESOURCE nodes. Resources inside stored items are independent of vessel resource flow.
+- **Unloaded vessel access:** `ProtoPartModuleSnapshot.moduleValues.GetNode("STOREDPARTS")` → `GetNodes("STOREDPART")` → `GetValue("partName")`, `GetValue("quantity")`.
+- **Part name dot conversion applies:** stored `partName` uses KSP's runtime dot-form.
+
+### T11-INV.1 — Data model
+
+```csharp
+// New file: InventoryManifest.cs (mirrors ResourceManifest.cs)
+internal struct InventoryItem
+{
+    public int count;       // total quantity across all inventories on the vessel
+    public int slotsTaken;  // total inventory slots occupied by this item type
+}
+
+internal static class InventoryManifest
+{
+    internal static Dictionary<string, InventoryItem> ComputeInventoryDelta(
+        Dictionary<string, InventoryItem> start,
+        Dictionary<string, InventoryItem> end)
+    // Mirrors ComputeResourceDelta: merged keys, delta = endCount - startCount, endSlots - startSlots
+    // Returns InventoryItem with both count and slot deltas (Phase 12 needs slots for capacity checks)
+}
+```
+
+**Why `InventoryItem` has `slotsTaken`:** Phase 12 delivery needs to know if the destination has capacity. A destination with 2 free slots can accept 2 non-stackable panels but not 3. `slotsTaken` is the inventory analog of `maxAmount` in `ResourceAmount`.
+
+**Why the delta returns `InventoryItem` not `int`:** Phase 12 needs both count deltas (how many items to move) and slot deltas (how many destination slots are required). Delivering 4 non-stackable panels needs 4 slots; delivering 4 stackable EVA kits needs only 1 slot. Returning the full struct avoids Phase 12 re-deriving slot requirements from raw manifests.
+
+### T11-INV.2 — Extraction function
+
+```csharp
+// In VesselSpawner.cs (co-located with ExtractResourceManifest)
+internal static Dictionary<string, InventoryItem> ExtractInventoryManifest(ConfigNode vesselSnapshot)
+```
+
+**Algorithm:**
+
+```
+if vesselSnapshot is null → return null
+parts = vesselSnapshot.GetNodes("PART")
+if parts.Length == 0 → return null
+
+manifest = new Dictionary<string, InventoryItem>()
+for each PART node:
+    modules = partNode.GetNodes("MODULE")
+    for each MODULE node:
+        if moduleNode.GetValue("name") != "ModuleInventoryPart" → skip
+        storedPartsNode = moduleNode.GetNode("STOREDPARTS")
+        if storedPartsNode is null → skip
+        storedParts = storedPartsNode.GetNodes("STOREDPART")
+        for each STOREDPART node:
+            partName = storedPartNode.GetValue("partName")
+            if partName is null/empty → skip
+            quantity = int.TryParse(storedPartNode.GetValue("quantity"), default 1)
+            if manifest.ContainsKey(partName):
+                var item = manifest[partName]  // struct copy — read-modify-write
+                item.count += quantity
+                item.slotsTaken += 1
+                manifest[partName] = item
+            else:
+                manifest[partName] = new InventoryItem { count = quantity, slotsTaken = 1 }
+
+// Also accumulate total slot capacity across all inventory modules
+totalInventorySlots += int.TryParse(moduleNode.GetValue("InventorySlots"), default 0)
+
+return manifest.Count > 0 ? manifest : null
+// Caller stores totalInventorySlots in Recording.Start/EndInventorySlots
+```
+
+The function returns both the manifest dict and the total slot count (via out parameter or a return tuple).
+
+**Design notes:**
+- No item filtering (unlike resources where EC/IntakeAir are excluded). All inventory items are meaningful cargo.
+- Variants ignored for grouping — `partName` is the key. A white panel and gray panel both count as `solarPanels5`. Variant-aware delivery is v2.
+- Each STOREDPART = 1 slot. Stacked items (quantity > 1) occupy 1 slot with count = quantity.
+
+**Tests:**
+
+| Test | Input | Expected |
+|------|-------|----------|
+| `NullInput_ReturnsNull` | null | null |
+| `NoInventoryModules_ReturnsNull` | parts without ModuleInventoryPart | null |
+| `SingleItem` | 1 STOREDPART (solarPanel, qty 1) | { solarPanel: count=1, slots=1 } |
+| `MultipleItems` | 2 different STOREDPART nodes | both in manifest |
+| `SameItem_MultipleInventories_Summed` | solarPanel in two different parts' inventories | count+slots summed |
+| `StackableItem_QuantityRespected` | STOREDPART with quantity=3 | count=3, slotsTaken=1 |
+| `EmptyStoredParts_ReturnsNull` | ModuleInventoryPart with empty STOREDPARTS node | null |
+| `MissingPartName_Skipped` | STOREDPART with no partName | skipped |
+| `MissingQuantity_DefaultsOne` | STOREDPART with no quantity value | count=1 |
+| `MultipleInventoryModulesOnOnePart` | PART with two ModuleInventoryPart modules | items from both summed |
+
+### T11-INV.3 — Recording fields + serialization
+
+```csharp
+// Recording.cs — alongside StartResources/EndResources
+internal Dictionary<string, InventoryItem> StartInventory;  // null = no data
+internal Dictionary<string, InventoryItem> EndInventory;     // null = no data
+public int StartInventorySlots;  // total inventory slot capacity at start (0 = no data / no inventory)
+public int EndInventorySlots;    // total inventory slot capacity at end
+```
+
+`StartInventorySlots`/`EndInventorySlots` are vessel-level totals (sum of `InventorySlots` across all `ModuleInventoryPart` modules). Phase 12 uses `EndInventorySlots - sum(slotsTaken)` to check destination capacity. Analogous to how `ResourceAmount.maxAmount` enables capacity checks for liquids.
+
+**Serialization format:**
+
+```
+INVENTORY_MANIFEST
+{
+    ITEM { name = solarPanels5   startCount = 4  startSlots = 4  endCount = 0  endSlots = 0 }
+    ITEM { name = batteryPack    startCount = 2  startSlots = 2  endCount = 0  endSlots = 0 }
+}
+```
+
+Helpers `SerializeInventoryManifest`/`DeserializeInventoryManifest` in RecordingStore.cs, called from same 4 save/load sites immediately after the resource manifest helpers. Identical pattern (merged keys, conditional start/end fields, batch logging). Integer fields use `int.TryParse` with InvariantCulture.
+
+### T11-INV.4 — Capture at boundaries
+
+**Every site that captures resource manifests also captures inventory manifests.** Same snapshots, same moments, one additional extraction call per site. The capture table from T11.3 applies identically — just add `StartInventory`/`EndInventory` alongside `StartResources`/`EndResources` at each site. Also add to `ApplyPersistenceArtifactsFrom`.
+
+No new capture sites needed.
+
+### T11-INV.5 — UI display
+
+Extend tooltip after the Resources section:
+
+```
+Inventory:
+  solarPanels5: 4 → 0 (-4)
+  batteryPack: 2 → 0 (-2)
+```
+
+`FormatInventoryManifest` helper mirrors `FormatResourceManifest`. Uses KSP part display names if `PartLoader.getPartInfoByName(name)?.title` is available (graceful fallback to internal name).
+
+### Phase 12 implications
+
+**Inventory delivery is harder than liquid resource delivery:**
+- Liquid: modify `ProtoPartResourceSnapshot.amount` (one field write)
+- Inventory: construct and insert `STOREDPART` ConfigNodes into `ModuleInventoryPart` MODULE data on unloaded vessels (subtree construction)
+
+**Recommendation:** Phase 12 ships liquid-resource delivery first. Inventory delivery is a follow-on (v1.1) — the capture and analysis data is available from day one, the delivery mechanism is the risky part.
+
+**Stored item internal state:** When Phase 12 delivers inventory items to unloaded vessels, it must decide whether to deliver items with their captured internal state (e.g., a half-charged stored battery) or in pristine state. The recording's STOREDPART > PART snapshot preserves the exact state at recording time. v1 recommendation: deliver in pristine state (use `PartLoader.getPartInfoByName` to construct a fresh snapshot). Captured state is a v2 refinement.
+
+**Route data model extension** (Phase 12): `Route.InventoryDeliveryManifest` as `Dictionary<string, int>` alongside `DeliveryManifest`. Route validation: recording qualifies if resources OR inventory items decreased between dock and undock.
+
+### Edge cases
+
+**Volume limits:** v1 tracks slots only. Volume-precise delivery (`packedVolume` per item vs `packedVolumeLimit` per container) deferred to v2. Slots are an acceptable approximation.
+
+**Items with internal resources:** A stored fuel tank contains fuel inside its STOREDPART > PART > RESOURCE nodes. These resources are NOT captured in the resource manifest (they live inside STOREDPART, not directly under PART > RESOURCE). This is correct — stored items' internal resources are not part of the vessel's operational fuel supply.
+
+**EVA kerbal inventories:** EVA kerbals have ModuleInventoryPart. Extraction captures them naturally. No special handling.
+
+**KIS (Kerbal Inventory System):** v1 targets stock ModuleInventoryPart only. KIS uses `ModuleKISInventory` with a different format. Invisible to extraction. KIS compatibility is Phase 15 territory.
+
+### Implementation order
+
+Inventory tasks slot after the resource manifest tasks:
+
+```
+T11.1 → T11.5 → T11.2 → T11.3 → T11.4  (resource manifests — done)
+    ↓
+T11-INV.1 → T11-INV.2 → T11-INV.3 → T11-INV.4 → T11-INV.5  (inventory manifests)
+```
+
+Each inventory task mirrors the corresponding resource task and follows the same patterns. Total new code: ~200 lines implementation + ~200 lines tests.

--- a/docs/dev/plans/phase-11-resource-snapshots.md
+++ b/docs/dev/plans/phase-11-resource-snapshots.md
@@ -1020,19 +1020,19 @@ Crew:
 
 ### Phase 12 implications
 
-Crew delivery is the most complex of the three manifest types because it interacts with Parsek's existing crew reservation system:
+Crew transport routes use **generic kerbals** — completely separate from the named kerbals the player manages and from Parsek's crew reservation system. Route crew are anonymous, trait-typed units:
 
-- **Route delivers by trait, not name.** "Send 2 engineers" picks whoever's available at the origin. For KSC origins, this means available kerbals from the astronaut complex. For non-KSC origins, this means crew seated in origin vessels.
-- **Crew reservation must account for route demand.** If a route needs 2 engineers per cycle, those engineers need to be reserved (not assigned to other missions) before dispatch.
-- **Moving crew on unloaded vessels** means modifying `ProtoPartSnapshot` crew lists and updating `ProtoCrewMember.seatIdx`/`rosterStatus` — similar complexity to inventory delivery.
+- **Route delivers by trait, not name.** "Send 2 engineers" creates/assigns generic kerbals of the right trait. No interaction with the astronaut complex roster or crew reservation.
+- **Generic kerbal pool.** Route kerbals are a separate population — they don't appear in the astronaut complex, don't have experience progression, and don't compete with named kerbals for missions. They're logistical crew, not player-managed characters.
+- **Moving crew on unloaded vessels** means adding `crew` values to `ProtoPartSnapshot` nodes and creating `ProtoCrewMember` entries in the roster with the right trait. Simpler than inventory delivery (no ConfigNode subtree construction — just name strings and roster entries).
 
-**Recommendation:** Same as inventory — capture crew manifests in Phase 11, defer delivery to Phase 12 v1.1 or v2. Liquid resources first, then inventory, then crew. Each layer adds complexity to the route dispatch evaluation.
+**Recommendation:** Same as inventory — capture crew manifests in Phase 11, defer delivery to Phase 12 v1.1. Lighter implementation than inventory delivery since crew is name+trait, not complex ConfigNode subtrees.
 
 ### Edge cases
 
-**Tourist contracts:** Tourists are valid "crew type" cargo but have contract implications. A tourist transport route might interfere with active tourism contracts. v1: capture tourists in the manifest, let Phase 12 decide whether to include them in route automation.
+**Tourists:** Captured in the manifest as a trait type. Phase 12 can exclude them from route automation if desired (tourists are contract-bound, not generic logistics crew).
 
-**Crew experience and level:** The manifest tracks trait and count, not level. A route requesting "2 engineers" gets whichever engineers are available, regardless of star level. Level-aware routing is v2.
+**No experience or levels.** Generic route kerbals have no star level and no experience progression. They're logistical crew, not player-managed characters. If a player wants experienced crew at a base, they fly them manually.
 
 **Crew capacity:** Analogous to inventory slots — destination vessel needs empty seats. Capture `crewCapacity` (sum of part crew capacity) alongside the crew manifest for Phase 12 capacity checks.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -158,9 +158,9 @@ Recordings capture physical resource manifests at recording start and end.
 
 **Resource manifests (implemented):** `ExtractResourceManifest` walks vessel snapshot PART > RESOURCE nodes, sums by resource name. `StartResources`/`EndResources` fields on Recording, serialized as additive RESOURCE_MANIFEST ConfigNode. Captured at 8 boundary sites (recording start/stop, chain boundaries, breakup, background splits, optimizer splits/merges). EC and IntakeAir excluded (environmental noise). Dock target vessel PID (`DockTargetVesselPid`) captured at dock boundaries for route endpoint identification. Hover tooltip in Recordings Manager shows per-resource start-to-end with delta.
 
-**Inventory manifests (designed, not yet implemented):** KSP 1.12 `ModuleInventoryPart` items (stored parts in cargo containers). `ExtractInventoryManifest` walks MODULE > STOREDPARTS > STOREDPART nodes. `InventoryItem { count, slotsTaken }` struct + vessel-level `totalInventorySlots`. Same capture sites as resources.
+**Inventory manifests (implemented):** KSP 1.12 `ModuleInventoryPart` items (stored parts in cargo containers). `ExtractInventoryManifest` walks MODULE > STOREDPARTS > STOREDPART nodes. `InventoryItem { count, slotsTaken }` struct + vessel-level `totalInventorySlots`. Same capture sites as resources.
 
-**Crew manifests (designed, not yet implemented):** Crew composition by trait (Pilot/Scientist/Engineer/Tourist). Route delivery uses generic kerbals (separate from crew reservation system). Same capture pattern.
+**Crew manifests (implemented):** Crew composition by trait (Pilot/Scientist/Engineer/Tourist). Route delivery uses generic kerbals (separate from crew reservation system). Same capture pattern.
 
 ---
 
@@ -287,7 +287,7 @@ Phase 10: Location Context (v0.7 ✓)
     │  Recordings know WHERE they start/end (body, biome, situation)
     │
     ▼
-Phase 11: Resource Snapshots (resources done, inventory+crew designed)
+Phase 11: Resource Snapshots (done)
     |  Recordings know WHAT they carry
     │
     ▼

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -154,13 +154,13 @@ Unified chronological view of all committed career events, replacing the Game Ac
 
 ## Phase 11: Resource Snapshots
 
-Recordings capture physical resource inventories (ore, fuel, monoprop, etc.) at segment boundaries.
+Recordings capture physical resource manifests at recording start and end.
 
-- Resource snapshots at recording start, end, and key events (docking)
-- Uses KSP's resource API — any resource captured automatically, including modded resources
-- Event hook for external mods on recording completion
-- Simple built-in mode: on playback completion, transfer resources to nearest vessel within configurable range
-- Recordings Manager shows resource signatures ("this Minmus run carries 4000 units of ore")
+**Resource manifests (implemented):** `ExtractResourceManifest` walks vessel snapshot PART > RESOURCE nodes, sums by resource name. `StartResources`/`EndResources` fields on Recording, serialized as additive RESOURCE_MANIFEST ConfigNode. Captured at 8 boundary sites (recording start/stop, chain boundaries, breakup, background splits, optimizer splits/merges). EC and IntakeAir excluded (environmental noise). Dock target vessel PID (`DockTargetVesselPid`) captured at dock boundaries for route endpoint identification. Hover tooltip in Recordings Manager shows per-resource start-to-end with delta.
+
+**Inventory manifests (designed, not yet implemented):** KSP 1.12 `ModuleInventoryPart` items (stored parts in cargo containers). `ExtractInventoryManifest` walks MODULE > STOREDPARTS > STOREDPART nodes. `InventoryItem { count, slotsTaken }` struct + vessel-level `totalInventorySlots`. Same capture sites as resources.
+
+**Crew manifests (designed, not yet implemented):** Crew composition by trait (Pilot/Scientist/Engineer/Tourist). Route delivery uses generic kerbals (separate from crew reservation system). Same capture pattern.
 
 ---
 
@@ -283,12 +283,12 @@ Phase 9: Timeline (v0.7 ✓)
     │  significance tiers, filtering, rewind from timeline
     │
     ▼
-Phase 10: Location Context (v0.7)
+Phase 10: Location Context (v0.7 ✓)
     │  Recordings know WHERE they start/end (body, biome, situation)
     │
     ▼
-Phase 11: Resource Snapshots
-    │  Recordings know WHAT they carry
+Phase 11: Resource Snapshots (resources done, inventory+crew designed)
+    |  Recordings know WHAT they carry
     │
     ▼
 Phase 11.5: Recording Optimization & Observability


### PR DESCRIPTION
## Summary
- Recordings now capture physical resource manifests (LF, Ox, Ore, MonoProp, etc.) at recording start and end
- Resource tooltip in Recordings Manager shows per-resource start → end with delta
- Dock target vessel PID captured at chain boundaries (prerequisite for Phase 12 route endpoint identification)
- EC and IntakeAir excluded at extraction time (environmental noise, not meaningful cargo)
- 48 new tests (24 extraction/delta, 15 serialization, 9 UI formatting), 5668 total passing

### Implementation (6 tasks)
- **T11.1** ResourceAmount struct + ExtractResourceManifest (pure ConfigNode walker)
- **T11.5** ComputeResourceDelta (pure start-vs-end computation)
- **T11.2** Recording fields + serialization in both standalone and tree save paths
- **T11.6** DockTargetVesselPid field + capture in CommitDockUndockSegment
- **T11.3** Capture at 8 boundary sites (FlightRecorder, ChainSegmentManager, ParsekFlight, BackgroundRecorder, RecordingOptimizer, ApplyPersistenceArtifactsFrom)
- **T11.4** FormatResourceManifest tooltip in RecordingsTableUI

### New files
- `Source/Parsek/ResourceManifest.cs`
- `Source/Parsek.Tests/ResourceManifestTests.cs`
- `Source/Parsek.Tests/ResourceManifestSerializationTests.cs`
- `Source/Parsek.Tests/FormatResourceManifestTests.cs`

## Test plan
- [x] 24 extraction + delta tests (pure, no Unity)
- [x] 15 serialization round-trip tests (both save paths)
- [x] 9 UI formatting tests (pure)
- [x] Full suite: 5668 passing
- [ ] In-game playtest: verify tooltip shows resource data on a real flight recording