### PR TITLE
Fix #298b: FlightRecorder missing allEngineKeys for dead engine sentinels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to Parsek are documented here.
 - `#241` Ghost parts with the base/default color variant (e.g., BlackAndWhite fuel tanks) no longer show the wrong variant texture (was Orange).
 - `#297` Vessel destruction during tree recording no longer orphans continuation data as a standalone recording.
 - `T55` FlagEvents and SegmentEvents are now preserved across tree recording splits and flushes.
+- `#298b` Dead engine shutdown sentinels now work for active-vessel recordings (were only emitted for background vessel recordings).
 
 ### New Features
 

--- a/Source/Parsek.Tests/SeedEventTests.cs
+++ b/Source/Parsek.Tests/SeedEventTests.cs
@@ -569,6 +569,69 @@ namespace Parsek.Tests
             Assert.Contains(logLines, l => l.Contains("Skipped 1 zero-throttle engine seed"));
         }
 
+        [Fact]
+        public void EmitSeedEvents_DeadEngine_InAllButNotActive_EmitsShutdownSentinel()
+        {
+            // #298: allEngineKeys tracks all engine modules on the vessel.
+            // Engines present but NOT in activeEngineKeys get EngineShutdown sentinels
+            // to prevent the playback Count==0 auto-start heuristic from firing.
+            var sets = MakeEmptySets();
+            uint pidActive = 5100u;
+            uint pidDead = 5200u;
+            ulong keyActive = FlightRecorder.EncodeEngineKey(pidActive, 0);
+            ulong keyDead = FlightRecorder.EncodeEngineKey(pidDead, 0);
+            sets.activeEngineKeys.Add(keyActive);
+            sets.allEngineKeys.Add(keyActive);
+            sets.allEngineKeys.Add(keyDead); // present but not active
+            sets.lastThrottle[keyActive] = 0.8f;
+            var names = new Dictionary<uint, string>
+            {
+                { pidActive, "mainEngine" },
+                { pidDead, "depletedBooster" },
+            };
+
+            var result = PartStateSeeder.EmitSeedEvents(sets, names, 21000.0, "Test");
+
+            var ignited = result.FindAll(e => e.eventType == PartEventType.EngineIgnited);
+            var shutdown = result.FindAll(e => e.eventType == PartEventType.EngineShutdown);
+            Assert.Single(ignited);
+            Assert.Equal(pidActive, ignited[0].partPersistentId);
+            Assert.Single(shutdown);
+            Assert.Equal(pidDead, shutdown[0].partPersistentId);
+            Assert.Contains(logLines, l => l.Contains("EngineShutdown sentinel"));
+        }
+
+        [Fact]
+        public void EmitSeedEvents_AllEnginesActive_NoShutdownSentinels()
+        {
+            // When all engines in allEngineKeys are also in activeEngineKeys,
+            // no shutdown sentinels should be emitted.
+            var sets = MakeEmptySets();
+            uint pid = 5300u;
+            ulong key = FlightRecorder.EncodeEngineKey(pid, 0);
+            sets.activeEngineKeys.Add(key);
+            sets.allEngineKeys.Add(key);
+            sets.lastThrottle[key] = 1.0f;
+            var names = new Dictionary<uint, string> { { pid, "onlyEngine" } };
+
+            var result = PartStateSeeder.EmitSeedEvents(sets, names, 22000.0, "Test");
+
+            Assert.Single(result.FindAll(e => e.eventType == PartEventType.EngineIgnited));
+            Assert.Empty(result.FindAll(e => e.eventType == PartEventType.EngineShutdown));
+        }
+
+        [Fact]
+        public void EmitSeedEvents_EmptyAllEngineKeys_NoSentinels()
+        {
+            // When allEngineKeys is empty (no engines on vessel), no sentinels emitted.
+            var sets = MakeEmptySets();
+            var names = new Dictionary<uint, string>();
+
+            var result = PartStateSeeder.EmitSeedEvents(sets, names, 23000.0, "Test");
+
+            Assert.Empty(result.FindAll(e => e.eventType == PartEventType.EngineShutdown));
+        }
+
         #endregion
 
         #region ShouldSkipZeroThrottleEngineSeed — pure method (#165)
@@ -722,6 +785,7 @@ namespace Parsek.Tests
                 deployedRobotArmScannerModules = new HashSet<ulong>(),
                 animateHeatLevels = new Dictionary<ulong, HeatLevel>(),
                 activeEngineKeys = new HashSet<ulong>(),
+                allEngineKeys = new HashSet<ulong>(),
                 lastThrottle = new Dictionary<ulong, float>(),
                 activeRcsKeys = new HashSet<ulong>(),
                 lastRcsThrottle = new Dictionary<ulong, float>(),

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -69,6 +69,7 @@ namespace Parsek
         // Engine state tracking (key = EncodeEngineKey(pid, moduleIndex))
         private List<(Part part, ModuleEngines engine, int moduleIndex)> cachedEngines;
         private HashSet<ulong> activeEngineKeys;
+        private HashSet<ulong> allEngineKeys = new HashSet<ulong>();
         private Dictionary<ulong, float> lastThrottle;
         private HashSet<ulong> loggedEngineModuleKeys = new HashSet<ulong>();
 
@@ -4430,6 +4431,7 @@ namespace Parsek
             loggedFairingReadFailures.Clear();
             cachedEngines = CacheEngineModules(v);
             activeEngineKeys = new HashSet<ulong>();
+            allEngineKeys = new HashSet<ulong>();
             lastThrottle = new Dictionary<ulong, float>();
             loggedEngineModuleKeys.Clear();
             cachedRcsModules = CacheRcsModules(v);
@@ -4502,6 +4504,7 @@ namespace Parsek
                 deployedRobotArmScannerModules = deployedRobotArmScannerModules,
                 animateHeatLevels = animateHeatLevels,
                 activeEngineKeys = activeEngineKeys,
+                allEngineKeys = allEngineKeys,
                 lastThrottle = lastThrottle,
                 activeRcsKeys = activeRcsKeys,
                 lastRcsThrottle = lastRcsThrottle,

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -7,6 +7,24 @@ Entries 272–303 (78 bugs, 6 TODOs — mostly resolved) archived in `done/todo-
 
 # Known Bugs
 
+## ~~298b. FlightRecorder missing allEngineKeys -- #298 dead engine sentinels only work for BackgroundRecorder~~
+
+`PartStateSeeder.EmitEngineSeedEvents` emits `EngineShutdown` sentinels for dead engines
+using `sets.allEngineKeys` (#298). `BackgroundRecorder.BuildPartTrackingSetsFromState` sets
+`allEngineKeys = state.allEngineKeys`, but `FlightRecorder.BuildCurrentTrackingSets` omits it
+entirely. FlightRecorder has no `allEngineKeys` field, so `SeedEngines` populates it on a
+temporary `PartTrackingSets` that is immediately discarded. The subsequent `EmitSeedEvents`
+call creates a new set with an empty `allEngineKeys`, emitting zero sentinels.
+
+**Fix:** Add `private HashSet<ulong> allEngineKeys` to FlightRecorder and include it in
+`BuildCurrentTrackingSets`. `SeedEngines` will then populate FlightRecorder's own set
+(same reference pattern as `activeEngineKeys`), and the follow-up `EmitSeedEvents` will
+see the populated set and emit the sentinels.
+
+**Status:** ~~Fixed~~
+
+---
+
 ## ~~297. FallbackCommitSplitRecorder orphans tree continuation data as standalone recording~~
 
 When a vessel is destroyed during tree recording and the split recorder can't resume,


### PR DESCRIPTION
## Summary
- `FlightRecorder.BuildCurrentTrackingSets` omitted `allEngineKeys`, so `EmitEngineSeedEvents` never emitted `EngineShutdown` sentinels for active-vessel recordings
- Added `allEngineKeys` field to FlightRecorder, included it in `BuildCurrentTrackingSets`, reset in `ResetPartEventTrackingState`
- BackgroundRecorder already had this field -- parity restored

## Test plan
- [x] `dotnet build` clean
- [x] `dotnet test` all 5607 tests pass (3 new sentinel tests added)
- [ ] In-game: record a vessel with depleted engines (staged boosters), verify ghost playback does not show orphan plumes on dead engines