### PR TITLE
Phase 11: Inventory + Crew Manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to Parsek are documented here.
 - Renamed the expanded-stats toggle button from "Stats" to "Info".
 - Resource snapshots: recordings capture physical resource manifests (LF, Ox, Ore, etc.) at start and end. Hover tooltip in Recordings Manager shows resource changes per recording. Prerequisite for logistics routes.
 - Inventory manifests: recordings capture stored inventory items (count, slots) at start and end. Hover tooltip shows inventory changes per recording.
+- Crew manifests: recordings capture crew by trait (Pilot/Scientist/Engineer/Tourist) at start and end. Hover tooltip shows crew changes per recording.
 - Dock target vessel PID captured at chain boundaries for future route endpoint identification.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to Parsek are documented here.
 - Sortable "Site" column in the Recordings Manager — sorts by launch site name with UT tiebreak within the same site.
 - Renamed the expanded-stats toggle button from "Stats" to "Info".
 - Resource snapshots: recordings capture physical resource manifests (LF, Ox, Ore, etc.) at start and end. Hover tooltip in Recordings Manager shows resource changes per recording. Prerequisite for logistics routes.
+- Inventory manifests: recordings capture stored inventory items (count, slots) at start and end. Hover tooltip shows inventory changes per recording.
 - Dock target vessel PID captured at chain boundaries for future route endpoint identification.
 
 ---

--- a/Source/Parsek.Tests/CrewManifestSerializationTests.cs
+++ b/Source/Parsek.Tests/CrewManifestSerializationTests.cs
@@ -1,0 +1,237 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    [Collection("Sequential")]
+    public class CrewManifestSerializationTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public CrewManifestSerializationTests()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.VerboseOverrideForTesting = true;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+            RecordingStore.SuppressLogging = true;
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+            RecordingStore.SuppressLogging = false;
+        }
+
+        [Fact]
+        public void RoundTrip_BothStartAndEnd()
+        {
+            var rec = new Recording();
+            rec.RecordingId = "test-crew-both";
+            rec.StartCrew = new Dictionary<string, int>
+            {
+                ["Pilot"] = 1,
+                ["Engineer"] = 2
+            };
+            rec.EndCrew = new Dictionary<string, int>
+            {
+                ["Pilot"] = 1,
+                ["Engineer"] = 0
+            };
+
+            var node = new ConfigNode("RECORDING");
+            RecordingStore.SerializeCrewManifest(node, rec);
+
+            var loaded = new Recording();
+            loaded.RecordingId = "test-crew-both";
+            RecordingStore.DeserializeCrewManifest(node, loaded);
+
+            Assert.NotNull(loaded.StartCrew);
+            Assert.NotNull(loaded.EndCrew);
+            Assert.Equal(2, loaded.StartCrew.Count);
+            Assert.Equal(2, loaded.EndCrew.Count);
+
+            Assert.Equal(1, loaded.StartCrew["Pilot"]);
+            Assert.Equal(2, loaded.StartCrew["Engineer"]);
+            Assert.Equal(1, loaded.EndCrew["Pilot"]);
+            Assert.Equal(0, loaded.EndCrew["Engineer"]);
+
+            Assert.Contains(logLines, l => l.Contains("[RecordingStore]") && l.Contains("wrote 2 trait(s)"));
+            Assert.Contains(logLines, l => l.Contains("[RecordingStore]") && l.Contains("loaded=2") && l.Contains("skipped=0"));
+        }
+
+        [Fact]
+        public void RoundTrip_StartOnly()
+        {
+            var rec = new Recording();
+            rec.RecordingId = "test-crew-start";
+            rec.StartCrew = new Dictionary<string, int>
+            {
+                ["Pilot"] = 1,
+                ["Scientist"] = 1
+            };
+            rec.EndCrew = null;
+
+            var node = new ConfigNode("RECORDING");
+            RecordingStore.SerializeCrewManifest(node, rec);
+
+            var loaded = new Recording();
+            loaded.RecordingId = "test-crew-start";
+            RecordingStore.DeserializeCrewManifest(node, loaded);
+
+            Assert.NotNull(loaded.StartCrew);
+            Assert.Null(loaded.EndCrew);
+            Assert.Equal(1, loaded.StartCrew["Pilot"]);
+            Assert.Equal(1, loaded.StartCrew["Scientist"]);
+        }
+
+        [Fact]
+        public void RoundTrip_NullBoth_NoNodeWritten()
+        {
+            var rec = new Recording();
+            rec.RecordingId = "test-crew-null";
+            rec.StartCrew = null;
+            rec.EndCrew = null;
+
+            var node = new ConfigNode("RECORDING");
+            RecordingStore.SerializeCrewManifest(node, rec);
+
+            Assert.Null(node.GetNode("CREW_MANIFEST"));
+        }
+
+        [Fact]
+        public void RoundTrip_ViaTree()
+        {
+            var rec = new Recording();
+            rec.RecordingId = "test-crew-tree";
+            rec.StartCrew = new Dictionary<string, int>
+            {
+                ["Pilot"] = 2
+            };
+            rec.EndCrew = new Dictionary<string, int>
+            {
+                ["Pilot"] = 1
+            };
+
+            var node = new ConfigNode("RECORDING");
+            RecordingTree.SaveRecordingResourceAndState(node, rec);
+
+            var loaded = new Recording();
+            loaded.RecordingId = "test-crew-tree";
+            RecordingTree.LoadRecordingResourceAndState(node, loaded);
+
+            Assert.NotNull(loaded.StartCrew);
+            Assert.NotNull(loaded.EndCrew);
+            Assert.Equal(2, loaded.StartCrew["Pilot"]);
+            Assert.Equal(1, loaded.EndCrew["Pilot"]);
+        }
+
+        [Fact]
+        public void LegacyRecording_NoNode_NullFields()
+        {
+            var node = new ConfigNode("RECORDING");
+            // No CREW_MANIFEST node — simulates legacy recording
+
+            var loaded = new Recording();
+            loaded.RecordingId = "test-crew-legacy";
+            RecordingStore.DeserializeCrewManifest(node, loaded);
+
+            Assert.Null(loaded.StartCrew);
+            Assert.Null(loaded.EndCrew);
+        }
+
+        [Fact]
+        public void RoundTrip_EndOnly()
+        {
+            var rec = new Recording();
+            rec.RecordingId = "test-crew-end";
+            rec.StartCrew = null;
+            rec.EndCrew = new Dictionary<string, int>
+            {
+                ["Pilot"] = 1
+            };
+
+            var node = new ConfigNode("RECORDING");
+            RecordingStore.SerializeCrewManifest(node, rec);
+
+            var loaded = new Recording();
+            loaded.RecordingId = "test-crew-end";
+            RecordingStore.DeserializeCrewManifest(node, loaded);
+
+            Assert.Null(loaded.StartCrew);
+            Assert.NotNull(loaded.EndCrew);
+            Assert.Equal(1, loaded.EndCrew["Pilot"]);
+        }
+
+        [Fact]
+        public void RoundTrip_EmptyDicts_NoNodeWritten()
+        {
+            var rec = new Recording();
+            rec.RecordingId = "test-crew-empty";
+            rec.StartCrew = new Dictionary<string, int>();
+            rec.EndCrew = new Dictionary<string, int>();
+
+            var node = new ConfigNode("RECORDING");
+            RecordingStore.SerializeCrewManifest(node, rec);
+
+            Assert.Null(node.GetNode("CREW_MANIFEST"));
+        }
+
+        [Fact]
+        public void RoundTrip_AsymmetricKeys()
+        {
+            var rec = new Recording();
+            rec.RecordingId = "test-crew-asym";
+            rec.StartCrew = new Dictionary<string, int>
+            {
+                ["Pilot"] = 2,
+                ["Engineer"] = 1
+            };
+            rec.EndCrew = new Dictionary<string, int>
+            {
+                ["Pilot"] = 1,
+                ["Tourist"] = 1
+            };
+
+            var node = new ConfigNode("RECORDING");
+            RecordingStore.SerializeCrewManifest(node, rec);
+
+            var loaded = new Recording();
+            loaded.RecordingId = "test-crew-asym";
+            RecordingStore.DeserializeCrewManifest(node, loaded);
+
+            Assert.Equal(2, loaded.StartCrew.Count);
+            Assert.Equal(2, loaded.EndCrew.Count);
+            Assert.True(loaded.StartCrew.ContainsKey("Pilot"));
+            Assert.True(loaded.StartCrew.ContainsKey("Engineer"));
+            Assert.True(loaded.EndCrew.ContainsKey("Pilot"));
+            Assert.True(loaded.EndCrew.ContainsKey("Tourist"));
+            Assert.False(loaded.StartCrew.ContainsKey("Tourist"));
+            Assert.False(loaded.EndCrew.ContainsKey("Engineer"));
+        }
+
+        [Fact]
+        public void MalformedTrait_Skipped()
+        {
+            var node = new ConfigNode("RECORDING");
+            var manifest = node.AddNode("CREW_MANIFEST");
+            var good = manifest.AddNode("TRAIT");
+            good.AddValue("name", "Pilot");
+            good.AddValue("startCount", "2");
+            var bad = manifest.AddNode("TRAIT");
+            bad.AddValue("name", "");
+            bad.AddValue("startCount", "1");
+
+            var loaded = new Recording();
+            loaded.RecordingId = "test-crew-malformed";
+            RecordingStore.DeserializeCrewManifest(node, loaded);
+
+            Assert.NotNull(loaded.StartCrew);
+            Assert.Single(loaded.StartCrew);
+            Assert.Equal(2, loaded.StartCrew["Pilot"]);
+            Assert.Contains(logLines, l => l.Contains("loaded=1") && l.Contains("skipped=1"));
+        }
+    }
+}

--- a/Source/Parsek.Tests/CrewManifestTests.cs
+++ b/Source/Parsek.Tests/CrewManifestTests.cs
@@ -1,0 +1,264 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    [Collection("Sequential")]
+    public class CrewManifestTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public CrewManifestTests()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.VerboseOverrideForTesting = true;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+        }
+
+        #region Helper — build vessel ConfigNodes with crew
+
+        private static ConfigNode MakePartWithCrew(params string[] crewNames)
+        {
+            var part = new ConfigNode("PART");
+            part.AddValue("name", "testPart");
+            foreach (var name in crewNames)
+                part.AddValue("crew", name);
+            return part;
+        }
+
+        private static ConfigNode MakeVessel(params ConfigNode[] parts)
+        {
+            var vessel = new ConfigNode("VESSEL");
+            foreach (var p in parts)
+                vessel.AddNode(p);
+            return vessel;
+        }
+
+        #endregion
+
+        #region T11-CREW — ExtractCrewManifest
+
+        [Fact]
+        public void ExtractCrewManifest_NullInput_ReturnsNull()
+        {
+            var result = VesselSpawner.ExtractCrewManifest(null);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void ExtractCrewManifest_NoCrew_ReturnsNull()
+        {
+            var part = new ConfigNode("PART");
+            part.AddValue("name", "fuelTank");
+            var vessel = MakeVessel(part);
+
+            var result = VesselSpawner.ExtractCrewManifest(vessel);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void ExtractCrewManifest_SingleCrew_WithResolver()
+        {
+            var vessel = MakeVessel(MakePartWithCrew("Jeb Kerman"));
+
+            var result = VesselSpawner.ExtractCrewManifest(vessel, name => "Pilot");
+
+            Assert.NotNull(result);
+            Assert.Single(result);
+            Assert.Equal(1, result["Pilot"]);
+            Assert.Contains(logLines, l => l.Contains("[Spawner]") && l.Contains("1 crew"));
+        }
+
+        [Fact]
+        public void ExtractCrewManifest_MultipleCrew_SameTraitSummed()
+        {
+            var vessel = MakeVessel(
+                MakePartWithCrew("Jeb Kerman", "Val Kerman", "Bob Kerman"));
+
+            var result = VesselSpawner.ExtractCrewManifest(vessel, name => "Pilot");
+
+            Assert.NotNull(result);
+            Assert.Single(result);
+            Assert.Equal(3, result["Pilot"]);
+        }
+
+        [Fact]
+        public void ExtractCrewManifest_MultipleCrew_DifferentTraits()
+        {
+            var vessel = MakeVessel(
+                MakePartWithCrew("Jeb Kerman", "Bob Kerman", "Bill Kerman"));
+
+            var resolver = new Func<string, string>(name =>
+            {
+                if (name == "Jeb Kerman") return "Pilot";
+                if (name == "Bob Kerman") return "Scientist";
+                if (name == "Bill Kerman") return "Engineer";
+                return "Pilot";
+            });
+
+            var result = VesselSpawner.ExtractCrewManifest(vessel, resolver);
+
+            Assert.NotNull(result);
+            Assert.Equal(3, result.Count);
+            Assert.Equal(1, result["Pilot"]);
+            Assert.Equal(1, result["Scientist"]);
+            Assert.Equal(1, result["Engineer"]);
+        }
+
+        [Fact]
+        public void ExtractCrewManifest_DefaultResolver_FallbackToPilot()
+        {
+            // Outside KSP runtime, FindTraitForKerbal falls back to "Pilot"
+            var vessel = MakeVessel(
+                MakePartWithCrew("Jeb Kerman", "Bob Kerman"));
+
+            var result = VesselSpawner.ExtractCrewManifest(vessel);
+
+            Assert.NotNull(result);
+            Assert.Single(result);
+            Assert.Equal(2, result["Pilot"]);
+        }
+
+        [Fact]
+        public void ExtractCrewManifest_EmptyCrewValue_Skipped()
+        {
+            var part = new ConfigNode("PART");
+            part.AddValue("name", "testPart");
+            part.AddValue("crew", "");
+            part.AddValue("crew", "Jeb Kerman");
+            var vessel = MakeVessel(part);
+
+            var result = VesselSpawner.ExtractCrewManifest(vessel, name => "Pilot");
+
+            Assert.NotNull(result);
+            Assert.Equal(1, result["Pilot"]);
+        }
+
+        [Fact]
+        public void ExtractCrewManifest_MultiplePartsWithCrew()
+        {
+            var vessel = MakeVessel(
+                MakePartWithCrew("Jeb Kerman"),
+                MakePartWithCrew("Bob Kerman"));
+
+            var resolver = new Func<string, string>(name =>
+                name == "Jeb Kerman" ? "Pilot" : "Scientist");
+
+            var result = VesselSpawner.ExtractCrewManifest(vessel, resolver);
+
+            Assert.NotNull(result);
+            Assert.Equal(2, result.Count);
+            Assert.Equal(1, result["Pilot"]);
+            Assert.Equal(1, result["Scientist"]);
+            Assert.Contains(logLines, l => l.Contains("2 crew") && l.Contains("2 trait(s)"));
+        }
+
+        [Fact]
+        public void ExtractCrewManifest_NoParts_ReturnsNull()
+        {
+            var vessel = new ConfigNode("VESSEL");
+
+            var result = VesselSpawner.ExtractCrewManifest(vessel);
+
+            Assert.Null(result);
+        }
+
+        #endregion
+
+        #region T11-CREW — ComputeCrewDelta
+
+        [Fact]
+        public void ComputeCrewDelta_BothNull_ReturnsNull()
+        {
+            var delta = CrewManifest.ComputeCrewDelta(null, null);
+
+            Assert.Null(delta);
+        }
+
+        [Fact]
+        public void ComputeCrewDelta_NormalTransfer()
+        {
+            var start = new Dictionary<string, int>
+            {
+                ["Pilot"] = 2,
+                ["Engineer"] = 1
+            };
+            var end = new Dictionary<string, int>
+            {
+                ["Pilot"] = 1,
+                ["Engineer"] = 0
+            };
+
+            var delta = CrewManifest.ComputeCrewDelta(start, end);
+
+            Assert.NotNull(delta);
+            Assert.Equal(-1, delta["Pilot"]);
+            Assert.Equal(-1, delta["Engineer"]);
+        }
+
+        [Fact]
+        public void ComputeCrewDelta_StartNull()
+        {
+            var end = new Dictionary<string, int>
+            {
+                ["Pilot"] = 2,
+                ["Scientist"] = 1
+            };
+
+            var delta = CrewManifest.ComputeCrewDelta(null, end);
+
+            Assert.NotNull(delta);
+            Assert.Equal(2, delta["Pilot"]);
+            Assert.Equal(1, delta["Scientist"]);
+        }
+
+        [Fact]
+        public void ComputeCrewDelta_EndNull()
+        {
+            var start = new Dictionary<string, int>
+            {
+                ["Pilot"] = 2,
+                ["Scientist"] = 1
+            };
+
+            var delta = CrewManifest.ComputeCrewDelta(start, null);
+
+            Assert.NotNull(delta);
+            Assert.Equal(-2, delta["Pilot"]);
+            Assert.Equal(-1, delta["Scientist"]);
+        }
+
+        [Fact]
+        public void ComputeCrewDelta_Unchanged()
+        {
+            var start = new Dictionary<string, int>
+            {
+                ["Pilot"] = 1,
+                ["Scientist"] = 1
+            };
+            var end = new Dictionary<string, int>
+            {
+                ["Pilot"] = 1,
+                ["Scientist"] = 1
+            };
+
+            var delta = CrewManifest.ComputeCrewDelta(start, end);
+
+            Assert.NotNull(delta);
+            Assert.Equal(0, delta["Pilot"]);
+            Assert.Equal(0, delta["Scientist"]);
+        }
+
+        #endregion
+    }
+}

--- a/Source/Parsek.Tests/FormatCrewManifestTests.cs
+++ b/Source/Parsek.Tests/FormatCrewManifestTests.cs
@@ -1,0 +1,108 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    public class FormatCrewManifestTests
+    {
+        [Fact]
+        public void BothNull_ReturnsNull()
+        {
+            var result = RecordingsTableUI.FormatCrewManifest(null, null);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void StartOnly_ShowsStartFormat()
+        {
+            var start = new Dictionary<string, int>
+            {
+                ["Pilot"] = 1,
+                ["Engineer"] = 2
+            };
+
+            var result = RecordingsTableUI.FormatCrewManifest(start, null);
+
+            Assert.NotNull(result);
+            Assert.StartsWith("Crew at start:", result);
+            Assert.Contains("Pilot: 1", result);
+            Assert.Contains("Engineer: 2", result);
+        }
+
+        [Fact]
+        public void BothStartAndEnd_ShowsDeltaFormat()
+        {
+            var start = new Dictionary<string, int>
+            {
+                ["Pilot"] = 1,
+                ["Engineer"] = 2
+            };
+            var end = new Dictionary<string, int>
+            {
+                ["Pilot"] = 1,
+                ["Engineer"] = 0
+            };
+
+            var result = RecordingsTableUI.FormatCrewManifest(start, end);
+
+            Assert.NotNull(result);
+            Assert.StartsWith("Crew:", result);
+            Assert.Contains("Pilot: 1 \u2192 1 (+0)", result);
+            Assert.Contains("Engineer: 2 \u2192 0 (-2)", result);
+        }
+
+        [Fact]
+        public void Unchanged_ZeroDelta()
+        {
+            var start = new Dictionary<string, int>
+            {
+                ["Pilot"] = 1
+            };
+            var end = new Dictionary<string, int>
+            {
+                ["Pilot"] = 1
+            };
+
+            var result = RecordingsTableUI.FormatCrewManifest(start, end);
+
+            Assert.NotNull(result);
+            Assert.Contains("Pilot: 1 \u2192 1 (+0)", result);
+        }
+
+        [Fact]
+        public void SingleTrait()
+        {
+            var start = new Dictionary<string, int>
+            {
+                ["Pilot"] = 3
+            };
+
+            var result = RecordingsTableUI.FormatCrewManifest(start, null);
+
+            Assert.NotNull(result);
+            Assert.Contains("Pilot: 3", result);
+            // Only one trait line + header
+            var lines = result.Split('\n');
+            Assert.Equal(2, lines.Length);
+        }
+
+        [Fact]
+        public void GainedCrew_PositiveDelta()
+        {
+            var start = new Dictionary<string, int>
+            {
+                ["Pilot"] = 0
+            };
+            var end = new Dictionary<string, int>
+            {
+                ["Pilot"] = 2
+            };
+
+            var result = RecordingsTableUI.FormatCrewManifest(start, end);
+
+            Assert.NotNull(result);
+            Assert.Contains("Pilot: 0 \u2192 2 (+2)", result);
+        }
+    }
+}

--- a/Source/Parsek.Tests/FormatInventoryManifestTests.cs
+++ b/Source/Parsek.Tests/FormatInventoryManifestTests.cs
@@ -48,8 +48,8 @@ namespace Parsek.Tests
 
             Assert.NotNull(result);
             Assert.StartsWith("Inventory:", result);
-            Assert.Contains("solarPanels5: 4 -> 0 (-4)", result);
-            Assert.Contains("batteryPack: 2 -> 0 (-2)", result);
+            Assert.Contains("solarPanels5: 4 \u2192 0 (-4)", result);
+            Assert.Contains("batteryPack: 2 \u2192 0 (-2)", result);
         }
 
         [Fact]
@@ -84,7 +84,7 @@ namespace Parsek.Tests
             var result = RecordingsTableUI.FormatInventoryManifest(start, end);
 
             Assert.NotNull(result);
-            Assert.Contains("batteryPack: 2 -> 2 (+0)", result);
+            Assert.Contains("batteryPack: 2 \u2192 2 (+0)", result);
         }
     }
 }

--- a/Source/Parsek.Tests/FormatInventoryManifestTests.cs
+++ b/Source/Parsek.Tests/FormatInventoryManifestTests.cs
@@ -1,0 +1,90 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    public class FormatInventoryManifestTests
+    {
+        [Fact]
+        public void BothNull_ReturnsNull()
+        {
+            var result = RecordingsTableUI.FormatInventoryManifest(null, null);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void StartOnly_ShowsStartFormat()
+        {
+            var start = new Dictionary<string, InventoryItem>
+            {
+                ["solarPanels5"] = new InventoryItem { count = 4, slotsTaken = 4 },
+                ["batteryPack"] = new InventoryItem { count = 2, slotsTaken = 2 }
+            };
+
+            var result = RecordingsTableUI.FormatInventoryManifest(start, null);
+
+            Assert.NotNull(result);
+            Assert.StartsWith("Inventory at start:", result);
+            Assert.Contains("solarPanels5: 4", result);
+            Assert.Contains("batteryPack: 2", result);
+        }
+
+        [Fact]
+        public void BothStartAndEnd_ShowsDeltaFormat()
+        {
+            var start = new Dictionary<string, InventoryItem>
+            {
+                ["solarPanels5"] = new InventoryItem { count = 4, slotsTaken = 4 },
+                ["batteryPack"] = new InventoryItem { count = 2, slotsTaken = 2 }
+            };
+            var end = new Dictionary<string, InventoryItem>
+            {
+                ["solarPanels5"] = new InventoryItem { count = 0, slotsTaken = 0 },
+                ["batteryPack"] = new InventoryItem { count = 0, slotsTaken = 0 }
+            };
+
+            var result = RecordingsTableUI.FormatInventoryManifest(start, end);
+
+            Assert.NotNull(result);
+            Assert.StartsWith("Inventory:", result);
+            Assert.Contains("solarPanels5: 4 -> 0 (-4)", result);
+            Assert.Contains("batteryPack: 2 -> 0 (-2)", result);
+        }
+
+        [Fact]
+        public void SingleItem()
+        {
+            var start = new Dictionary<string, InventoryItem>
+            {
+                ["solarPanels5"] = new InventoryItem { count = 4, slotsTaken = 4 }
+            };
+
+            var result = RecordingsTableUI.FormatInventoryManifest(start, null);
+
+            Assert.NotNull(result);
+            Assert.Contains("solarPanels5: 4", result);
+            // Only one item line + header
+            var lines = result.Split('\n');
+            Assert.Equal(2, lines.Length);
+        }
+
+        [Fact]
+        public void Unchanged_ZeroDelta()
+        {
+            var start = new Dictionary<string, InventoryItem>
+            {
+                ["batteryPack"] = new InventoryItem { count = 2, slotsTaken = 2 }
+            };
+            var end = new Dictionary<string, InventoryItem>
+            {
+                ["batteryPack"] = new InventoryItem { count = 2, slotsTaken = 2 }
+            };
+
+            var result = RecordingsTableUI.FormatInventoryManifest(start, end);
+
+            Assert.NotNull(result);
+            Assert.Contains("batteryPack: 2 -> 2 (+0)", result);
+        }
+    }
+}

--- a/Source/Parsek.Tests/InventoryManifestSerializationTests.cs
+++ b/Source/Parsek.Tests/InventoryManifestSerializationTests.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    [Collection("Sequential")]
+    public class InventoryManifestSerializationTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public InventoryManifestSerializationTests()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.VerboseOverrideForTesting = true;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+            RecordingStore.SuppressLogging = true;
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+            RecordingStore.SuppressLogging = false;
+        }
+
+        [Fact]
+        public void RoundTrip_BothStartAndEnd()
+        {
+            var rec = new Recording();
+            rec.RecordingId = "test-inv-both";
+            rec.StartInventory = new Dictionary<string, InventoryItem>
+            {
+                ["solarPanels5"] = new InventoryItem { count = 4, slotsTaken = 4 },
+                ["batteryPack"] = new InventoryItem { count = 2, slotsTaken = 2 }
+            };
+            rec.EndInventory = new Dictionary<string, InventoryItem>
+            {
+                ["solarPanels5"] = new InventoryItem { count = 0, slotsTaken = 0 },
+                ["batteryPack"] = new InventoryItem { count = 0, slotsTaken = 0 }
+            };
+
+            var node = new ConfigNode("RECORDING");
+            RecordingStore.SerializeInventoryManifest(node, rec);
+
+            var loaded = new Recording();
+            loaded.RecordingId = "test-inv-both";
+            RecordingStore.DeserializeInventoryManifest(node, loaded);
+
+            Assert.NotNull(loaded.StartInventory);
+            Assert.NotNull(loaded.EndInventory);
+            Assert.Equal(2, loaded.StartInventory.Count);
+            Assert.Equal(2, loaded.EndInventory.Count);
+
+            Assert.Equal(4, loaded.StartInventory["solarPanels5"].count);
+            Assert.Equal(4, loaded.StartInventory["solarPanels5"].slotsTaken);
+            Assert.Equal(0, loaded.EndInventory["solarPanels5"].count);
+            Assert.Equal(0, loaded.EndInventory["solarPanels5"].slotsTaken);
+
+            Assert.Equal(2, loaded.StartInventory["batteryPack"].count);
+            Assert.Equal(2, loaded.StartInventory["batteryPack"].slotsTaken);
+            Assert.Equal(0, loaded.EndInventory["batteryPack"].count);
+            Assert.Equal(0, loaded.EndInventory["batteryPack"].slotsTaken);
+
+            Assert.Contains(logLines, l => l.Contains("[RecordingStore]") && l.Contains("wrote 2 item(s)"));
+            Assert.Contains(logLines, l => l.Contains("[RecordingStore]") && l.Contains("loaded=2") && l.Contains("skipped=0"));
+        }
+
+        [Fact]
+        public void RoundTrip_StartOnly()
+        {
+            var rec = new Recording();
+            rec.RecordingId = "test-inv-start";
+            rec.StartInventory = new Dictionary<string, InventoryItem>
+            {
+                ["solarPanels5"] = new InventoryItem { count = 4, slotsTaken = 4 }
+            };
+            rec.EndInventory = null;
+
+            var node = new ConfigNode("RECORDING");
+            RecordingStore.SerializeInventoryManifest(node, rec);
+
+            var loaded = new Recording();
+            loaded.RecordingId = "test-inv-start";
+            RecordingStore.DeserializeInventoryManifest(node, loaded);
+
+            Assert.NotNull(loaded.StartInventory);
+            Assert.Null(loaded.EndInventory);
+            Assert.Equal(4, loaded.StartInventory["solarPanels5"].count);
+            Assert.Equal(4, loaded.StartInventory["solarPanels5"].slotsTaken);
+        }
+
+        [Fact]
+        public void RoundTrip_NullBoth_NoNodeWritten()
+        {
+            var rec = new Recording();
+            rec.RecordingId = "test-inv-null";
+            rec.StartInventory = null;
+            rec.EndInventory = null;
+
+            var node = new ConfigNode("RECORDING");
+            RecordingStore.SerializeInventoryManifest(node, rec);
+
+            Assert.Null(node.GetNode("INVENTORY_MANIFEST"));
+        }
+
+        [Fact]
+        public void RoundTrip_ViaTree()
+        {
+            var rec = new Recording();
+            rec.RecordingId = "test-inv-tree";
+            rec.StartInventory = new Dictionary<string, InventoryItem>
+            {
+                ["solarPanels5"] = new InventoryItem { count = 4, slotsTaken = 4 }
+            };
+            rec.EndInventory = new Dictionary<string, InventoryItem>
+            {
+                ["solarPanels5"] = new InventoryItem { count = 0, slotsTaken = 0 }
+            };
+
+            var node = new ConfigNode("RECORDING");
+            RecordingTree.SaveRecordingResourceAndState(node, rec);
+
+            var loaded = new Recording();
+            loaded.RecordingId = "test-inv-tree";
+            RecordingTree.LoadRecordingResourceAndState(node, loaded);
+
+            Assert.NotNull(loaded.StartInventory);
+            Assert.NotNull(loaded.EndInventory);
+            Assert.Equal(4, loaded.StartInventory["solarPanels5"].count);
+            Assert.Equal(0, loaded.EndInventory["solarPanels5"].count);
+        }
+
+        [Fact]
+        public void InventorySlots_RoundTrip()
+        {
+            var rec = new Recording();
+            rec.RecordingId = "test-inv-slots";
+            rec.StartInventorySlots = 8;
+            rec.EndInventorySlots = 12;
+            // Also set inventory dicts so both paths exercise
+            rec.StartInventory = new Dictionary<string, InventoryItem>
+            {
+                ["batteryPack"] = new InventoryItem { count = 2, slotsTaken = 2 }
+            };
+
+            // Test via ParsekScenario path
+            var node = new ConfigNode("RECORDING");
+            ParsekScenario.SaveRecordingMetadata(node, rec);
+
+            var loaded = new Recording();
+            loaded.RecordingId = "test-inv-slots";
+            ParsekScenario.LoadRecordingMetadata(node, loaded);
+
+            Assert.Equal(8, loaded.StartInventorySlots);
+            Assert.Equal(12, loaded.EndInventorySlots);
+
+            // Test via RecordingTree path
+            var treeNode = new ConfigNode("RECORDING");
+            RecordingTree.SaveRecordingResourceAndState(treeNode, rec);
+
+            var treeLoaded = new Recording();
+            treeLoaded.RecordingId = "test-inv-slots-tree";
+            RecordingTree.LoadRecordingResourceAndState(treeNode, treeLoaded);
+
+            Assert.Equal(8, treeLoaded.StartInventorySlots);
+            Assert.Equal(12, treeLoaded.EndInventorySlots);
+        }
+
+        [Fact]
+        public void LegacyRecording_NoNode_NullFields()
+        {
+            var node = new ConfigNode("RECORDING");
+            // No INVENTORY_MANIFEST node — simulates legacy recording
+
+            var loaded = new Recording();
+            loaded.RecordingId = "test-inv-legacy";
+            RecordingStore.DeserializeInventoryManifest(node, loaded);
+
+            Assert.Null(loaded.StartInventory);
+            Assert.Null(loaded.EndInventory);
+        }
+    }
+}

--- a/Source/Parsek.Tests/InventoryManifestSerializationTests.cs
+++ b/Source/Parsek.Tests/InventoryManifestSerializationTests.cs
@@ -170,6 +170,99 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void RoundTrip_EndOnly()
+        {
+            var rec = new Recording();
+            rec.RecordingId = "test-inv-end";
+            rec.StartInventory = null;
+            rec.EndInventory = new Dictionary<string, InventoryItem>
+            {
+                ["solarPanels5"] = new InventoryItem { count = 2, slotsTaken = 2 }
+            };
+
+            var node = new ConfigNode("RECORDING");
+            RecordingStore.SerializeInventoryManifest(node, rec);
+
+            var loaded = new Recording();
+            loaded.RecordingId = "test-inv-end";
+            RecordingStore.DeserializeInventoryManifest(node, loaded);
+
+            Assert.Null(loaded.StartInventory);
+            Assert.NotNull(loaded.EndInventory);
+            Assert.Equal(2, loaded.EndInventory["solarPanels5"].count);
+        }
+
+        [Fact]
+        public void RoundTrip_EmptyDicts_NoNodeWritten()
+        {
+            var rec = new Recording();
+            rec.RecordingId = "test-inv-empty";
+            rec.StartInventory = new Dictionary<string, InventoryItem>();
+            rec.EndInventory = new Dictionary<string, InventoryItem>();
+
+            var node = new ConfigNode("RECORDING");
+            RecordingStore.SerializeInventoryManifest(node, rec);
+
+            Assert.Null(node.GetNode("INVENTORY_MANIFEST"));
+        }
+
+        [Fact]
+        public void RoundTrip_AsymmetricKeys()
+        {
+            var rec = new Recording();
+            rec.RecordingId = "test-inv-asym";
+            rec.StartInventory = new Dictionary<string, InventoryItem>
+            {
+                ["solarPanels5"] = new InventoryItem { count = 4, slotsTaken = 4 },
+                ["batteryPack"] = new InventoryItem { count = 2, slotsTaken = 2 }
+            };
+            rec.EndInventory = new Dictionary<string, InventoryItem>
+            {
+                ["solarPanels5"] = new InventoryItem { count = 1, slotsTaken = 1 },
+                ["sensorBarometer"] = new InventoryItem { count = 3, slotsTaken = 3 }
+            };
+
+            var node = new ConfigNode("RECORDING");
+            RecordingStore.SerializeInventoryManifest(node, rec);
+
+            var loaded = new Recording();
+            loaded.RecordingId = "test-inv-asym";
+            RecordingStore.DeserializeInventoryManifest(node, loaded);
+
+            Assert.Equal(2, loaded.StartInventory.Count);
+            Assert.Equal(2, loaded.EndInventory.Count);
+            Assert.True(loaded.StartInventory.ContainsKey("solarPanels5"));
+            Assert.True(loaded.StartInventory.ContainsKey("batteryPack"));
+            Assert.True(loaded.EndInventory.ContainsKey("solarPanels5"));
+            Assert.True(loaded.EndInventory.ContainsKey("sensorBarometer"));
+            Assert.False(loaded.StartInventory.ContainsKey("sensorBarometer"));
+            Assert.False(loaded.EndInventory.ContainsKey("batteryPack"));
+        }
+
+        [Fact]
+        public void MalformedItem_Skipped()
+        {
+            var node = new ConfigNode("RECORDING");
+            var manifest = node.AddNode("INVENTORY_MANIFEST");
+            var good = manifest.AddNode("ITEM");
+            good.AddValue("name", "solarPanels5");
+            good.AddValue("startCount", "4");
+            good.AddValue("startSlots", "4");
+            var bad = manifest.AddNode("ITEM");
+            bad.AddValue("name", "");
+            bad.AddValue("startCount", "2");
+
+            var loaded = new Recording();
+            loaded.RecordingId = "test-inv-malformed";
+            RecordingStore.DeserializeInventoryManifest(node, loaded);
+
+            Assert.NotNull(loaded.StartInventory);
+            Assert.Single(loaded.StartInventory);
+            Assert.Equal(4, loaded.StartInventory["solarPanels5"].count);
+            Assert.Contains(logLines, l => l.Contains("loaded=1") && l.Contains("skipped=1"));
+        }
+
+        [Fact]
         public void LegacyRecording_NoNode_NullFields()
         {
             var node = new ConfigNode("RECORDING");

--- a/Source/Parsek.Tests/InventoryManifestTests.cs
+++ b/Source/Parsek.Tests/InventoryManifestTests.cs
@@ -1,0 +1,360 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    [Collection("Sequential")]
+    public class InventoryManifestTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public InventoryManifestTests()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.VerboseOverrideForTesting = true;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+        }
+
+        #region Helper — build inventory ConfigNodes
+
+        private static ConfigNode MakeStoredPart(string partName, int? quantity = null)
+        {
+            var sp = new ConfigNode("STOREDPART");
+            if (partName != null)
+                sp.AddValue("partName", partName);
+            if (quantity.HasValue)
+                sp.AddValue("quantity", quantity.Value.ToString());
+            return sp;
+        }
+
+        private static ConfigNode MakeInventoryModule(int inventorySlots, params ConfigNode[] storedParts)
+        {
+            var module = new ConfigNode("MODULE");
+            module.AddValue("name", "ModuleInventoryPart");
+            module.AddValue("InventorySlots", inventorySlots.ToString());
+            var storedPartsNode = module.AddNode("STOREDPARTS");
+            foreach (var sp in storedParts)
+                storedPartsNode.AddNode(sp);
+            return module;
+        }
+
+        private static ConfigNode MakePart(params ConfigNode[] modules)
+        {
+            var part = new ConfigNode("PART");
+            part.AddValue("name", "testPart");
+            foreach (var m in modules)
+                part.AddNode(m);
+            return part;
+        }
+
+        private static ConfigNode MakeVessel(params ConfigNode[] parts)
+        {
+            var vessel = new ConfigNode("VESSEL");
+            foreach (var p in parts)
+                vessel.AddNode(p);
+            return vessel;
+        }
+
+        #endregion
+
+        #region T11-INV.2 — ExtractInventoryManifest
+
+        [Fact]
+        public void ExtractInventoryManifest_NullInput_ReturnsNull()
+        {
+            var result = VesselSpawner.ExtractInventoryManifest(null, out int totalSlots);
+
+            Assert.Null(result);
+            Assert.Equal(0, totalSlots);
+        }
+
+        [Fact]
+        public void ExtractInventoryManifest_NoInventoryModules_ReturnsNull()
+        {
+            var part = new ConfigNode("PART");
+            part.AddValue("name", "fuelTank");
+            var module = part.AddNode("MODULE");
+            module.AddValue("name", "ModuleFuelTank");
+            var vessel = MakeVessel(part);
+
+            var result = VesselSpawner.ExtractInventoryManifest(vessel, out int totalSlots);
+
+            Assert.Null(result);
+            Assert.Equal(0, totalSlots);
+        }
+
+        [Fact]
+        public void ExtractInventoryManifest_SingleItem()
+        {
+            var vessel = MakeVessel(
+                MakePart(
+                    MakeInventoryModule(9, MakeStoredPart("solarPanels5", 1))));
+
+            var result = VesselSpawner.ExtractInventoryManifest(vessel, out int totalSlots);
+
+            Assert.NotNull(result);
+            Assert.Single(result);
+            Assert.Equal(1, result["solarPanels5"].count);
+            Assert.Equal(1, result["solarPanels5"].slotsTaken);
+            Assert.Equal(9, totalSlots);
+            Assert.Contains(logLines, l => l.Contains("[Spawner]") && l.Contains("1 item type(s)"));
+        }
+
+        [Fact]
+        public void ExtractInventoryManifest_MultipleItems()
+        {
+            var vessel = MakeVessel(
+                MakePart(
+                    MakeInventoryModule(9,
+                        MakeStoredPart("solarPanels5", 1),
+                        MakeStoredPart("batteryPack", 1))));
+
+            var result = VesselSpawner.ExtractInventoryManifest(vessel, out int totalSlots);
+
+            Assert.NotNull(result);
+            Assert.Equal(2, result.Count);
+            Assert.Equal(1, result["solarPanels5"].count);
+            Assert.Equal(1, result["solarPanels5"].slotsTaken);
+            Assert.Equal(1, result["batteryPack"].count);
+            Assert.Equal(1, result["batteryPack"].slotsTaken);
+        }
+
+        [Fact]
+        public void ExtractInventoryManifest_SameItem_MultipleInventories_Summed()
+        {
+            var vessel = MakeVessel(
+                MakePart(
+                    MakeInventoryModule(4, MakeStoredPart("solarPanels5", 1))),
+                MakePart(
+                    MakeInventoryModule(4, MakeStoredPart("solarPanels5", 1))));
+
+            var result = VesselSpawner.ExtractInventoryManifest(vessel, out int totalSlots);
+
+            Assert.NotNull(result);
+            Assert.Single(result);
+            Assert.Equal(2, result["solarPanels5"].count);
+            Assert.Equal(2, result["solarPanels5"].slotsTaken);
+            Assert.Equal(8, totalSlots);
+        }
+
+        [Fact]
+        public void ExtractInventoryManifest_StackableItem_QuantityRespected()
+        {
+            var vessel = MakeVessel(
+                MakePart(
+                    MakeInventoryModule(9, MakeStoredPart("evaRepairKit", 3))));
+
+            var result = VesselSpawner.ExtractInventoryManifest(vessel, out int totalSlots);
+
+            Assert.NotNull(result);
+            Assert.Single(result);
+            Assert.Equal(3, result["evaRepairKit"].count);
+            Assert.Equal(1, result["evaRepairKit"].slotsTaken);
+        }
+
+        [Fact]
+        public void ExtractInventoryManifest_EmptyStoredParts_ReturnsNull()
+        {
+            // Module with empty STOREDPARTS node (no STOREDPART children)
+            var vessel = MakeVessel(
+                MakePart(
+                    MakeInventoryModule(9)));
+
+            var result = VesselSpawner.ExtractInventoryManifest(vessel, out int totalSlots);
+
+            Assert.Null(result);
+            Assert.Equal(0, totalSlots);
+        }
+
+        [Fact]
+        public void ExtractInventoryManifest_MissingPartName_Skipped()
+        {
+            var badItem = new ConfigNode("STOREDPART");
+            // No partName value
+            badItem.AddValue("quantity", "1");
+
+            var vessel = MakeVessel(
+                MakePart(
+                    MakeInventoryModule(9, badItem)));
+
+            var result = VesselSpawner.ExtractInventoryManifest(vessel, out int totalSlots);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void ExtractInventoryManifest_MissingQuantity_DefaultsOne()
+        {
+            var itemNoQty = MakeStoredPart("solarPanels5");
+
+            var vessel = MakeVessel(
+                MakePart(
+                    MakeInventoryModule(9, itemNoQty)));
+
+            var result = VesselSpawner.ExtractInventoryManifest(vessel, out int totalSlots);
+
+            Assert.NotNull(result);
+            Assert.Equal(1, result["solarPanels5"].count);
+            Assert.Equal(1, result["solarPanels5"].slotsTaken);
+        }
+
+        [Fact]
+        public void ExtractInventoryManifest_MultipleInventoryModulesOnOnePart()
+        {
+            var module1 = MakeInventoryModule(4, MakeStoredPart("solarPanels5", 1));
+            var module2 = MakeInventoryModule(4, MakeStoredPart("batteryPack", 2));
+            var vessel = MakeVessel(MakePart(module1, module2));
+
+            var result = VesselSpawner.ExtractInventoryManifest(vessel, out int totalSlots);
+
+            Assert.NotNull(result);
+            Assert.Equal(2, result.Count);
+            Assert.Equal(1, result["solarPanels5"].count);
+            Assert.Equal(2, result["batteryPack"].count);
+            Assert.Equal(8, totalSlots);
+            Assert.Contains(logLines, l => l.Contains("2 inventory module(s)"));
+        }
+
+        [Fact]
+        public void ExtractInventoryManifest_TotalInventorySlots_Summed()
+        {
+            var vessel = MakeVessel(
+                MakePart(
+                    MakeInventoryModule(9, MakeStoredPart("solarPanels5", 1))),
+                MakePart(
+                    MakeInventoryModule(6, MakeStoredPart("batteryPack", 1))));
+
+            var result = VesselSpawner.ExtractInventoryManifest(vessel, out int totalSlots);
+
+            Assert.NotNull(result);
+            Assert.Equal(15, totalSlots);
+            Assert.Contains(logLines, l => l.Contains("15 total slot(s)"));
+        }
+
+        #endregion
+
+        #region T11-INV.1 — ComputeInventoryDelta
+
+        [Fact]
+        public void ComputeInventoryDelta_BothNull_ReturnsNull()
+        {
+            var delta = InventoryManifest.ComputeInventoryDelta(null, null);
+
+            Assert.Null(delta);
+        }
+
+        [Fact]
+        public void ComputeInventoryDelta_NormalDelivery()
+        {
+            var start = new Dictionary<string, InventoryItem>
+            {
+                ["solarPanels5"] = new InventoryItem { count = 4, slotsTaken = 4 }
+            };
+            var end = new Dictionary<string, InventoryItem>
+            {
+                ["solarPanels5"] = new InventoryItem { count = 0, slotsTaken = 0 }
+            };
+
+            var delta = InventoryManifest.ComputeInventoryDelta(start, end);
+
+            Assert.NotNull(delta);
+            Assert.Equal(-4, delta["solarPanels5"].count);
+            Assert.Equal(-4, delta["solarPanels5"].slotsTaken);
+        }
+
+        [Fact]
+        public void ComputeInventoryDelta_ItemGained()
+        {
+            var start = new Dictionary<string, InventoryItem>();
+            var end = new Dictionary<string, InventoryItem>
+            {
+                ["batteryPack"] = new InventoryItem { count = 3, slotsTaken = 3 }
+            };
+
+            var delta = InventoryManifest.ComputeInventoryDelta(start, end);
+
+            Assert.NotNull(delta);
+            Assert.Equal(3, delta["batteryPack"].count);
+            Assert.Equal(3, delta["batteryPack"].slotsTaken);
+        }
+
+        [Fact]
+        public void ComputeInventoryDelta_Unchanged()
+        {
+            var start = new Dictionary<string, InventoryItem>
+            {
+                ["solarPanels5"] = new InventoryItem { count = 2, slotsTaken = 2 }
+            };
+            var end = new Dictionary<string, InventoryItem>
+            {
+                ["solarPanels5"] = new InventoryItem { count = 2, slotsTaken = 2 }
+            };
+
+            var delta = InventoryManifest.ComputeInventoryDelta(start, end);
+
+            Assert.NotNull(delta);
+            Assert.Equal(0, delta["solarPanels5"].count);
+            Assert.Equal(0, delta["solarPanels5"].slotsTaken);
+        }
+
+        [Fact]
+        public void ComputeInventoryDelta_StartNull()
+        {
+            var end = new Dictionary<string, InventoryItem>
+            {
+                ["solarPanels5"] = new InventoryItem { count = 4, slotsTaken = 4 }
+            };
+
+            var delta = InventoryManifest.ComputeInventoryDelta(null, end);
+
+            Assert.NotNull(delta);
+            Assert.Equal(4, delta["solarPanels5"].count);
+            Assert.Equal(4, delta["solarPanels5"].slotsTaken);
+        }
+
+        [Fact]
+        public void ComputeInventoryDelta_EndNull()
+        {
+            var start = new Dictionary<string, InventoryItem>
+            {
+                ["solarPanels5"] = new InventoryItem { count = 4, slotsTaken = 4 }
+            };
+
+            var delta = InventoryManifest.ComputeInventoryDelta(start, null);
+
+            Assert.NotNull(delta);
+            Assert.Equal(-4, delta["solarPanels5"].count);
+            Assert.Equal(-4, delta["solarPanels5"].slotsTaken);
+        }
+
+        [Fact]
+        public void ComputeInventoryDelta_SlotDelta_Tracked()
+        {
+            // Stackable items: count changes but slotsTaken stays the same
+            var start = new Dictionary<string, InventoryItem>
+            {
+                ["evaRepairKit"] = new InventoryItem { count = 5, slotsTaken = 2 }
+            };
+            var end = new Dictionary<string, InventoryItem>
+            {
+                ["evaRepairKit"] = new InventoryItem { count = 2, slotsTaken = 1 }
+            };
+
+            var delta = InventoryManifest.ComputeInventoryDelta(start, end);
+
+            Assert.NotNull(delta);
+            Assert.Equal(-3, delta["evaRepairKit"].count);
+            Assert.Equal(-1, delta["evaRepairKit"].slotsTaken);
+        }
+
+        #endregion
+    }
+}

--- a/Source/Parsek/BackgroundRecorder.cs
+++ b/Source/Parsek/BackgroundRecorder.cs
@@ -637,11 +637,13 @@ namespace Parsek
                     int bgChildInvSlots;
                     child.StartInventory = VesselSpawner.ExtractInventoryManifest(child.VesselSnapshot, out bgChildInvSlots);
                     child.StartInventorySlots = bgChildInvSlots;
+                    child.StartCrew = VesselSpawner.ExtractCrewManifest(child.VesselSnapshot);
                     ParsekLog.Verbose("BgRecorder",
                         $"Captured snapshot for child vessel: pid={child.VesselPersistentId} " +
                         $"name='{child.VesselName}' hasSnapshot={child.VesselSnapshot != null} " +
                         $"startResources={child.StartResources?.Count ?? 0} type(s) " +
-                        $"startInventory={child.StartInventory?.Count ?? 0} item(s)");
+                        $"startInventory={child.StartInventory?.Count ?? 0} item(s) " +
+                        $"startCrew={child.StartCrew?.Count ?? 0} trait(s)");
                 }
                 else
                 {

--- a/Source/Parsek/BackgroundRecorder.cs
+++ b/Source/Parsek/BackgroundRecorder.cs
@@ -634,10 +634,14 @@ namespace Parsek
                     child.GhostVisualSnapshot = child.VesselSnapshot != null
                         ? child.VesselSnapshot.CreateCopy() : null;
                     child.StartResources = VesselSpawner.ExtractResourceManifest(child.VesselSnapshot);
+                    int bgChildInvSlots;
+                    child.StartInventory = VesselSpawner.ExtractInventoryManifest(child.VesselSnapshot, out bgChildInvSlots);
+                    child.StartInventorySlots = bgChildInvSlots;
                     ParsekLog.Verbose("BgRecorder",
                         $"Captured snapshot for child vessel: pid={child.VesselPersistentId} " +
                         $"name='{child.VesselName}' hasSnapshot={child.VesselSnapshot != null} " +
-                        $"startResources={child.StartResources?.Count ?? 0} type(s)");
+                        $"startResources={child.StartResources?.Count ?? 0} type(s) " +
+                        $"startInventory={child.StartInventory?.Count ?? 0} item(s)");
                 }
                 else
                 {

--- a/Source/Parsek/CrewManifest.cs
+++ b/Source/Parsek/CrewManifest.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+
+namespace Parsek
+{
+    /// <summary>
+    /// Pure static helpers for crew manifest comparison.
+    /// Crew manifests are Dictionary&lt;string, int&gt; (trait name → count).
+    /// </summary>
+    internal static class CrewManifest
+    {
+        /// <summary>
+        /// Compute per-trait delta between start and end crew manifests.
+        /// Positive = gained, negative = lost.
+        /// Returns null if both inputs are null.
+        /// </summary>
+        internal static Dictionary<string, int> ComputeCrewDelta(
+            Dictionary<string, int> start,
+            Dictionary<string, int> end)
+        {
+            if (start == null && end == null) return null;
+
+            var delta = new Dictionary<string, int>();
+
+            // Build merged key set from start ∪ end
+            var keys = new HashSet<string>();
+            if (start != null)
+                foreach (var k in start.Keys) keys.Add(k);
+            if (end != null)
+                foreach (var k in end.Keys) keys.Add(k);
+
+            foreach (var key in keys)
+            {
+                int startCount = 0;
+                int endCount = 0;
+
+                if (start != null && start.TryGetValue(key, out var sc))
+                    startCount = sc;
+                if (end != null && end.TryGetValue(key, out var ec))
+                    endCount = ec;
+
+                delta[key] = endCount - startCount;
+            }
+
+            return delta;
+        }
+    }
+}

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -264,6 +264,8 @@ namespace Parsek
         private ConfigNode lastGoodVesselSnapshot;
         private ConfigNode initialGhostVisualSnapshot;
         private Dictionary<string, ResourceAmount> pendingStartResources;
+        private Dictionary<string, InventoryItem> pendingStartInventory;
+        private int pendingStartInventorySlots;
         private double lastSnapshotRefreshUT = double.MinValue;
 
         // Boundary anchor: if set, inserted as the first point when recording starts.
@@ -4383,6 +4385,8 @@ namespace Parsek
             RefreshBackupSnapshot(v, "record_start", force: true);
             pendingStartResources = VesselSpawner.ExtractResourceManifest(lastGoodVesselSnapshot);
             ParsekLog.Verbose("Recorder", $"StartRecording: captured {pendingStartResources?.Count ?? 0} start resource type(s)");
+            pendingStartInventory = VesselSpawner.ExtractInventoryManifest(lastGoodVesselSnapshot, out pendingStartInventorySlots);
+            ParsekLog.Verbose("Recorder", $"StartRecording: captured {pendingStartInventory?.Count ?? 0} start inventory item type(s), {pendingStartInventorySlots} slot(s)");
             initialGhostVisualSnapshot = lastGoodVesselSnapshot != null
                 ? lastGoodVesselSnapshot.CreateCopy()
                 : VesselSpawner.TryBackupSnapshot(v);
@@ -4574,6 +4578,12 @@ namespace Parsek
             capture.StartResources = pendingStartResources;
             capture.EndResources = VesselSpawner.ExtractResourceManifest(capture.VesselSnapshot);
             ParsekLog.Verbose("Recorder", $"BuildCaptureRecording: captured {capture.EndResources?.Count ?? 0} end resource type(s)");
+            capture.StartInventory = pendingStartInventory;
+            capture.StartInventorySlots = pendingStartInventorySlots;
+            int endInvSlots;
+            capture.EndInventory = VesselSpawner.ExtractInventoryManifest(capture.VesselSnapshot, out endInvSlots);
+            capture.EndInventorySlots = endInvSlots;
+            ParsekLog.Verbose("Recorder", $"BuildCaptureRecording: captured {capture.EndInventory?.Count ?? 0} end inventory item type(s), {endInvSlots} slot(s)");
             capture.GhostVisualSnapshot = initialGhostVisualSnapshot != null
                 ? initialGhostVisualSnapshot.CreateCopy()
                 : (capture.VesselSnapshot != null ? capture.VesselSnapshot.CreateCopy() : null);

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -266,6 +266,7 @@ namespace Parsek
         private Dictionary<string, ResourceAmount> pendingStartResources;
         private Dictionary<string, InventoryItem> pendingStartInventory;
         private int pendingStartInventorySlots;
+        private Dictionary<string, int> pendingStartCrew;
         private double lastSnapshotRefreshUT = double.MinValue;
 
         // Boundary anchor: if set, inserted as the first point when recording starts.
@@ -4387,6 +4388,8 @@ namespace Parsek
             ParsekLog.Verbose("Recorder", $"StartRecording: captured {pendingStartResources?.Count ?? 0} start resource type(s)");
             pendingStartInventory = VesselSpawner.ExtractInventoryManifest(lastGoodVesselSnapshot, out pendingStartInventorySlots);
             ParsekLog.Verbose("Recorder", $"StartRecording: captured {pendingStartInventory?.Count ?? 0} start inventory item type(s), {pendingStartInventorySlots} slot(s)");
+            pendingStartCrew = VesselSpawner.ExtractCrewManifest(lastGoodVesselSnapshot);
+            ParsekLog.Verbose("Recorder", $"StartRecording: captured {pendingStartCrew?.Count ?? 0} start crew trait(s)");
             initialGhostVisualSnapshot = lastGoodVesselSnapshot != null
                 ? lastGoodVesselSnapshot.CreateCopy()
                 : VesselSpawner.TryBackupSnapshot(v);
@@ -4584,6 +4587,9 @@ namespace Parsek
             capture.EndInventory = VesselSpawner.ExtractInventoryManifest(capture.VesselSnapshot, out endInvSlots);
             capture.EndInventorySlots = endInvSlots;
             ParsekLog.Verbose("Recorder", $"BuildCaptureRecording: captured {capture.EndInventory?.Count ?? 0} end inventory item type(s), {endInvSlots} slot(s)");
+            capture.StartCrew = pendingStartCrew;
+            capture.EndCrew = VesselSpawner.ExtractCrewManifest(capture.VesselSnapshot);
+            ParsekLog.Verbose("Recorder", $"BuildCaptureRecording: captured {capture.EndCrew?.Count ?? 0} end crew trait(s)");
             capture.GhostVisualSnapshot = initialGhostVisualSnapshot != null
                 ? initialGhostVisualSnapshot.CreateCopy()
                 : (capture.VesselSnapshot != null ? capture.VesselSnapshot.CreateCopy() : null);

--- a/Source/Parsek/InventoryManifest.cs
+++ b/Source/Parsek/InventoryManifest.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Parsek
+{
+    /// <summary>
+    /// Per-item count and slot usage, summed across all inventory modules on a vessel.
+    /// Value type — dict indexer returns a copy; use read-modify-write for accumulation.
+    /// </summary>
+    internal struct InventoryItem
+    {
+        public int count;       // total quantity across all inventories on the vessel
+        public int slotsTaken;  // total inventory slots occupied by this item type
+
+        public override string ToString()
+        {
+            return string.Format(CultureInfo.InvariantCulture, "count={0} slots={1}", count, slotsTaken);
+        }
+    }
+
+    /// <summary>
+    /// Pure static helpers for inventory manifest comparison.
+    /// </summary>
+    internal static class InventoryManifest
+    {
+        /// <summary>
+        /// Compute per-item delta between start and end inventory manifests.
+        /// Positive count = gained, negative = consumed/transferred.
+        /// Returns null if both inputs are null.
+        /// </summary>
+        internal static Dictionary<string, InventoryItem> ComputeInventoryDelta(
+            Dictionary<string, InventoryItem> start,
+            Dictionary<string, InventoryItem> end)
+        {
+            if (start == null && end == null) return null;
+
+            var delta = new Dictionary<string, InventoryItem>();
+
+            // Build merged key set from start ∪ end
+            var keys = new HashSet<string>();
+            if (start != null)
+                foreach (var k in start.Keys) keys.Add(k);
+            if (end != null)
+                foreach (var k in end.Keys) keys.Add(k);
+
+            foreach (var key in keys)
+            {
+                int startCount = 0;
+                int startSlots = 0;
+                int endCount = 0;
+                int endSlots = 0;
+
+                if (start != null && start.TryGetValue(key, out var startItem))
+                {
+                    startCount = startItem.count;
+                    startSlots = startItem.slotsTaken;
+                }
+                if (end != null && end.TryGetValue(key, out var endItem))
+                {
+                    endCount = endItem.count;
+                    endSlots = endItem.slotsTaken;
+                }
+
+                delta[key] = new InventoryItem
+                {
+                    count = endCount - startCount,
+                    slotsTaken = endSlots - startSlots
+                };
+            }
+
+            return delta;
+        }
+    }
+}

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -3017,6 +3017,9 @@ namespace Parsek
                 childRec.StartInventorySlots = childInvSlots;
                 ParsekLog.Verbose("Coalescer",
                     $"CreateBreakupChildRecording: captured {childRec.StartInventory?.Count ?? 0} start inventory item type(s) for pid={pid}");
+                childRec.StartCrew = VesselSpawner.ExtractCrewManifest(childRec.VesselSnapshot ?? childRec.GhostVisualSnapshot);
+                ParsekLog.Verbose("Coalescer",
+                    $"CreateBreakupChildRecording: captured {childRec.StartCrew?.Count ?? 0} start crew trait(s) for pid={pid}");
             }
             else if (fallbackSnapshot != null)
             {
@@ -3027,6 +3030,7 @@ namespace Parsek
                 int fallbackInvSlots;
                 childRec.StartInventory = VesselSpawner.ExtractInventoryManifest(childRec.VesselSnapshot, out fallbackInvSlots);
                 childRec.StartInventorySlots = fallbackInvSlots;
+                childRec.StartCrew = VesselSpawner.ExtractCrewManifest(childRec.VesselSnapshot);
                 childRec.TerminalStateValue = TerminalState.Destroyed;
                 childRec.ExplicitEndUT = breakupBp.UT;
                 ParsekLog.Info("Coalescer",
@@ -3035,6 +3039,8 @@ namespace Parsek
                     $"CreateBreakupChildRecording: captured {childRec.StartResources?.Count ?? 0} start resource type(s) for pid={pid} (fallback)");
                 ParsekLog.Verbose("Coalescer",
                     $"CreateBreakupChildRecording: captured {childRec.StartInventory?.Count ?? 0} start inventory item type(s) for pid={pid} (fallback)");
+                ParsekLog.Verbose("Coalescer",
+                    $"CreateBreakupChildRecording: captured {childRec.StartCrew?.Count ?? 0} start crew trait(s) for pid={pid} (fallback)");
             }
             else
             {
@@ -3290,6 +3296,11 @@ namespace Parsek
             ParsekLog.Verbose("Coalescer",
                 $"PromoteToTreeForBreakup: inventory — start={rootRec.StartInventory?.Count ?? 0} item(s), " +
                 $"end={rootRec.EndInventory?.Count ?? 0} item(s)");
+            rootRec.StartCrew = cap.StartCrew;
+            rootRec.EndCrew = VesselSpawner.ExtractCrewManifest(rootRec.VesselSnapshot);
+            ParsekLog.Verbose("Coalescer",
+                $"PromoteToTreeForBreakup: crew — start={rootRec.StartCrew?.Count ?? 0} trait(s), " +
+                $"end={rootRec.EndCrew?.Count ?? 0} trait(s)");
             rootRec.RewindSaveFileName = cap.RewindSaveFileName;
             rootRec.RewindReservedFunds = cap.RewindReservedFunds;
             rootRec.RewindReservedScience = cap.RewindReservedScience;

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -3012,6 +3012,11 @@ namespace Parsek
                 childRec.StartResources = VesselSpawner.ExtractResourceManifest(childRec.VesselSnapshot ?? childRec.GhostVisualSnapshot);
                 ParsekLog.Verbose("Coalescer",
                     $"CreateBreakupChildRecording: captured {childRec.StartResources?.Count ?? 0} start resource type(s) for pid={pid}");
+                int childInvSlots;
+                childRec.StartInventory = VesselSpawner.ExtractInventoryManifest(childRec.VesselSnapshot ?? childRec.GhostVisualSnapshot, out childInvSlots);
+                childRec.StartInventorySlots = childInvSlots;
+                ParsekLog.Verbose("Coalescer",
+                    $"CreateBreakupChildRecording: captured {childRec.StartInventory?.Count ?? 0} start inventory item type(s) for pid={pid}");
             }
             else if (fallbackSnapshot != null)
             {
@@ -3019,12 +3024,17 @@ namespace Parsek
                 childRec.GhostVisualSnapshot = fallbackSnapshot;
                 childRec.VesselSnapshot = fallbackSnapshot.CreateCopy();
                 childRec.StartResources = VesselSpawner.ExtractResourceManifest(childRec.VesselSnapshot);
+                int fallbackInvSlots;
+                childRec.StartInventory = VesselSpawner.ExtractInventoryManifest(childRec.VesselSnapshot, out fallbackInvSlots);
+                childRec.StartInventorySlots = fallbackInvSlots;
                 childRec.TerminalStateValue = TerminalState.Destroyed;
                 childRec.ExplicitEndUT = breakupBp.UT;
                 ParsekLog.Info("Coalescer",
                     $"CreateBreakupChildRecording: using pre-captured snapshot for pid={pid} (vessel destroyed)");
                 ParsekLog.Verbose("Coalescer",
                     $"CreateBreakupChildRecording: captured {childRec.StartResources?.Count ?? 0} start resource type(s) for pid={pid} (fallback)");
+                ParsekLog.Verbose("Coalescer",
+                    $"CreateBreakupChildRecording: captured {childRec.StartInventory?.Count ?? 0} start inventory item type(s) for pid={pid} (fallback)");
             }
             else
             {
@@ -3272,6 +3282,14 @@ namespace Parsek
             ParsekLog.Verbose("Coalescer",
                 $"PromoteToTreeForBreakup: resources — start={rootRec.StartResources?.Count ?? 0} type(s), " +
                 $"end={rootRec.EndResources?.Count ?? 0} type(s)");
+            rootRec.StartInventory = cap.StartInventory;
+            rootRec.StartInventorySlots = cap.StartInventorySlots;
+            int promoteEndInvSlots;
+            rootRec.EndInventory = VesselSpawner.ExtractInventoryManifest(rootRec.VesselSnapshot, out promoteEndInvSlots);
+            rootRec.EndInventorySlots = promoteEndInvSlots;
+            ParsekLog.Verbose("Coalescer",
+                $"PromoteToTreeForBreakup: inventory — start={rootRec.StartInventory?.Count ?? 0} item(s), " +
+                $"end={rootRec.EndInventory?.Count ?? 0} item(s)");
             rootRec.RewindSaveFileName = cap.RewindSaveFileName;
             rootRec.RewindReservedFunds = cap.RewindReservedFunds;
             rootRec.RewindReservedScience = cap.RewindReservedScience;

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -3080,6 +3080,9 @@ namespace Parsek
             if (rec.EndInventorySlots != 0)
                 recNode.AddValue("endInvSlots", rec.EndInventorySlots.ToString(CultureInfo.InvariantCulture));
 
+            // Crew manifests (Phase 11)
+            RecordingStore.SerializeCrewManifest(recNode, rec);
+
             // Dock target vessel PID (Phase 11)
             if (rec.DockTargetVesselPid != 0)
                 recNode.AddValue("dockTargetPid", rec.DockTargetVesselPid.ToString(CultureInfo.InvariantCulture));
@@ -3270,6 +3273,9 @@ namespace Parsek
                 if (int.TryParse(endInvSlotsStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out endInvSlots))
                     rec.EndInventorySlots = endInvSlots;
             }
+
+            // Crew manifests (Phase 11)
+            RecordingStore.DeserializeCrewManifest(recNode, rec);
 
             // Dock target vessel PID (Phase 11)
             string dockTargetPidStr = recNode.GetValue("dockTargetPid");

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -3073,6 +3073,13 @@ namespace Parsek
             // Resource manifests (Phase 11)
             RecordingStore.SerializeResourceManifest(recNode, rec);
 
+            // Inventory manifests (Phase 11)
+            RecordingStore.SerializeInventoryManifest(recNode, rec);
+            if (rec.StartInventorySlots != 0)
+                recNode.AddValue("startInvSlots", rec.StartInventorySlots.ToString(CultureInfo.InvariantCulture));
+            if (rec.EndInventorySlots != 0)
+                recNode.AddValue("endInvSlots", rec.EndInventorySlots.ToString(CultureInfo.InvariantCulture));
+
             // Dock target vessel PID (Phase 11)
             if (rec.DockTargetVesselPid != 0)
                 recNode.AddValue("dockTargetPid", rec.DockTargetVesselPid.ToString(CultureInfo.InvariantCulture));
@@ -3246,6 +3253,23 @@ namespace Parsek
 
             // Resource manifests (Phase 11)
             RecordingStore.DeserializeResourceManifest(recNode, rec);
+
+            // Inventory manifests (Phase 11)
+            RecordingStore.DeserializeInventoryManifest(recNode, rec);
+            string startInvSlotsStr = recNode.GetValue("startInvSlots");
+            if (startInvSlotsStr != null)
+            {
+                int startInvSlots;
+                if (int.TryParse(startInvSlotsStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out startInvSlots))
+                    rec.StartInventorySlots = startInvSlots;
+            }
+            string endInvSlotsStr = recNode.GetValue("endInvSlots");
+            if (endInvSlotsStr != null)
+            {
+                int endInvSlots;
+                if (int.TryParse(endInvSlotsStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out endInvSlots))
+                    rec.EndInventorySlots = endInvSlots;
+            }
 
             // Dock target vessel PID (Phase 11)
             string dockTargetPidStr = recNode.GetValue("dockTargetPid");

--- a/Source/Parsek/Recording.cs
+++ b/Source/Parsek/Recording.cs
@@ -155,6 +155,11 @@ namespace Parsek
         public int StartInventorySlots;  // total inventory slot capacity at start (0 = no data / no inventory)
         public int EndInventorySlots;    // total inventory slot capacity at end
 
+        // Crew manifests (Phase 11) — per-trait crew count at recording start and end
+        // null = no data (legacy recording or no crew)
+        internal Dictionary<string, int> StartCrew;
+        internal Dictionary<string, int> EndCrew;
+
         // PID of vessel docked to at this segment's boundary (0 = not a dock segment)
         public uint DockTargetVesselPid;
 
@@ -336,6 +341,8 @@ namespace Parsek
             EndInventory = source.EndInventory;
             StartInventorySlots = source.StartInventorySlots;
             EndInventorySlots = source.EndInventorySlots;
+            StartCrew = source.StartCrew;
+            EndCrew = source.EndCrew;
             DockTargetVesselPid = source.DockTargetVesselPid;
 
             // Copy segment events and tracks if source has them

--- a/Source/Parsek/Recording.cs
+++ b/Source/Parsek/Recording.cs
@@ -148,6 +148,13 @@ namespace Parsek
         internal Dictionary<string, ResourceAmount> StartResources;
         internal Dictionary<string, ResourceAmount> EndResources;
 
+        // Inventory manifests (Phase 11) — per-item count/slots at recording start and end
+        // null = no data (legacy recording or no inventory items)
+        internal Dictionary<string, InventoryItem> StartInventory;
+        internal Dictionary<string, InventoryItem> EndInventory;
+        public int StartInventorySlots;  // total inventory slot capacity at start (0 = no data / no inventory)
+        public int EndInventorySlots;    // total inventory slot capacity at end
+
         // PID of vessel docked to at this segment's boundary (0 = not a dock segment)
         public uint DockTargetVesselPid;
 
@@ -325,6 +332,10 @@ namespace Parsek
                 ? new List<AntennaSpec>(source.AntennaSpecs) : null;
             StartResources = source.StartResources;
             EndResources = source.EndResources;
+            StartInventory = source.StartInventory;
+            EndInventory = source.EndInventory;
+            StartInventorySlots = source.StartInventorySlots;
+            EndInventorySlots = source.EndInventorySlots;
             DockTargetVesselPid = source.DockTargetVesselPid;
 
             // Copy segment events and tracks if source has them

--- a/Source/Parsek/RecordingOptimizer.cs
+++ b/Source/Parsek/RecordingOptimizer.cs
@@ -273,6 +273,11 @@ namespace Parsek
                 target.EndInventorySlots = absorbed.EndInventorySlots;
             // target.StartInventory intentionally unchanged — represents the earlier start
 
+            // Crew manifests: same pattern — absorbed end wins
+            if (absorbed.EndCrew != null)
+                target.EndCrew = absorbed.EndCrew;
+            // target.StartCrew intentionally unchanged — represents the earlier start
+
             // Dock target PID: absorbed wins if non-zero (dock may be in later segment)
             if (absorbed.DockTargetVesselPid != 0)
                 target.DockTargetVesselPid = absorbed.DockTargetVesselPid;
@@ -467,6 +472,12 @@ namespace Parsek
             original.EndInventorySlots = 0;
             // original.StartInventory unchanged (keeps the recording-start inventory)
             // second.StartInventory stays null (no snapshot at environment boundary)
+
+            // Crew manifests: same pattern — second half gets end
+            second.EndCrew = original.EndCrew;
+            original.EndCrew = null;
+            // original.StartCrew unchanged (keeps the recording-start crew)
+            // second.StartCrew stays null (no snapshot at environment boundary)
 
             second.TerminalStateValue = original.TerminalStateValue;
             original.TerminalStateValue = null;

--- a/Source/Parsek/RecordingOptimizer.cs
+++ b/Source/Parsek/RecordingOptimizer.cs
@@ -266,6 +266,13 @@ namespace Parsek
                 target.EndResources = absorbed.EndResources;
             // target.StartResources intentionally unchanged — represents the earlier start
 
+            // Inventory manifests: same pattern — absorbed end wins
+            if (absorbed.EndInventory != null)
+                target.EndInventory = absorbed.EndInventory;
+            if (absorbed.EndInventorySlots != 0)
+                target.EndInventorySlots = absorbed.EndInventorySlots;
+            // target.StartInventory intentionally unchanged — represents the earlier start
+
             // Dock target PID: absorbed wins if non-zero (dock may be in later segment)
             if (absorbed.DockTargetVesselPid != 0)
                 target.DockTargetVesselPid = absorbed.DockTargetVesselPid;
@@ -452,6 +459,14 @@ namespace Parsek
             original.EndResources = null;
             // original.StartResources unchanged (keeps the recording-start resources)
             // second.StartResources stays null (no snapshot at environment boundary)
+
+            // Inventory manifests: same pattern — second half gets end
+            second.EndInventory = original.EndInventory;
+            second.EndInventorySlots = original.EndInventorySlots;
+            original.EndInventory = null;
+            original.EndInventorySlots = 0;
+            // original.StartInventory unchanged (keeps the recording-start inventory)
+            // second.StartInventory stays null (no snapshot at environment boundary)
 
             second.TerminalStateValue = original.TerminalStateValue;
             original.TerminalStateValue = null;

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -3385,6 +3385,109 @@ namespace Parsek
                 $"DeserializeInventoryManifest: loaded={loaded} skipped={skipped} for recording={rec.RecordingId}");
         }
 
+        /// <summary>
+        /// Serializes StartCrew and EndCrew dictionaries into a CREW_MANIFEST
+        /// ConfigNode on the given parent. Each trait becomes a TRAIT child node with
+        /// name, startCount, endCount fields.
+        /// No-op if both StartCrew and EndCrew are null or empty.
+        /// </summary>
+        internal static void SerializeCrewManifest(ConfigNode parent, Recording rec)
+        {
+            bool hasStart = rec.StartCrew != null && rec.StartCrew.Count > 0;
+            bool hasEnd = rec.EndCrew != null && rec.EndCrew.Count > 0;
+            if (!hasStart && !hasEnd)
+                return;
+
+            ConfigNode manifestNode = parent.AddNode("CREW_MANIFEST");
+
+            // Build merged key set from StartCrew ∪ EndCrew
+            var keys = new HashSet<string>();
+            if (hasStart)
+                foreach (var k in rec.StartCrew.Keys) keys.Add(k);
+            if (hasEnd)
+                foreach (var k in rec.EndCrew.Keys) keys.Add(k);
+
+            int count = 0;
+            foreach (var name in keys)
+            {
+                ConfigNode traitNode = manifestNode.AddNode("TRAIT");
+                traitNode.AddValue("name", name);
+
+                if (hasStart && rec.StartCrew.TryGetValue(name, out var startCount))
+                {
+                    traitNode.AddValue("startCount", startCount.ToString(CultureInfo.InvariantCulture));
+                }
+
+                if (hasEnd && rec.EndCrew.TryGetValue(name, out var endCount))
+                {
+                    traitNode.AddValue("endCount", endCount.ToString(CultureInfo.InvariantCulture));
+                }
+
+                count++;
+            }
+
+            ParsekLog.Verbose("RecordingStore",
+                $"SerializeCrewManifest: wrote {count} trait(s) for recording={rec.RecordingId}");
+        }
+
+        /// <summary>
+        /// Deserializes StartCrew and EndCrew from a CREW_MANIFEST ConfigNode
+        /// on the given parent. Sets the dictionaries if entries are found, or leaves them null
+        /// if the node is absent (backward compatible with legacy recordings).
+        /// </summary>
+        internal static void DeserializeCrewManifest(ConfigNode parent, Recording rec)
+        {
+            ConfigNode manifestNode = parent.GetNode("CREW_MANIFEST");
+            if (manifestNode == null)
+                return;
+
+            ConfigNode[] traits = manifestNode.GetNodes("TRAIT");
+            if (traits.Length == 0)
+                return;
+
+            int loaded = 0;
+            int skipped = 0;
+
+            for (int i = 0; i < traits.Length; i++)
+            {
+                string name = traits[i].GetValue("name");
+                if (string.IsNullOrEmpty(name))
+                {
+                    skipped++;
+                    continue;
+                }
+
+                // Parse start fields (if present)
+                string startCountStr = traits[i].GetValue("startCount");
+                if (startCountStr != null)
+                {
+                    if (rec.StartCrew == null)
+                        rec.StartCrew = new Dictionary<string, int>();
+
+                    int startCount = 0;
+                    int.TryParse(startCountStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out startCount);
+                    rec.StartCrew[name] = startCount;
+                }
+
+                // Parse end fields (if present)
+                string endCountStr = traits[i].GetValue("endCount");
+                if (endCountStr != null)
+                {
+                    if (rec.EndCrew == null)
+                        rec.EndCrew = new Dictionary<string, int>();
+
+                    int endCount = 0;
+                    int.TryParse(endCountStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out endCount);
+                    rec.EndCrew[name] = endCount;
+                }
+
+                loaded++;
+            }
+
+            ParsekLog.Verbose("RecordingStore",
+                $"DeserializeCrewManifest: loaded={loaded} skipped={skipped} for recording={rec.RecordingId}");
+        }
+
         #endregion
 
         #region Recording File I/O

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -3268,6 +3268,123 @@ namespace Parsek
                 $"DeserializeResourceManifest: loaded={loaded} skipped={skipped} for recording={rec.RecordingId}");
         }
 
+        /// <summary>
+        /// Serializes StartInventory and EndInventory dictionaries into an INVENTORY_MANIFEST
+        /// ConfigNode on the given parent. Each item becomes an ITEM child node with
+        /// name, startCount, startSlots, endCount, endSlots fields.
+        /// No-op if both StartInventory and EndInventory are null or empty.
+        /// </summary>
+        internal static void SerializeInventoryManifest(ConfigNode parent, Recording rec)
+        {
+            bool hasStart = rec.StartInventory != null && rec.StartInventory.Count > 0;
+            bool hasEnd = rec.EndInventory != null && rec.EndInventory.Count > 0;
+            if (!hasStart && !hasEnd)
+                return;
+
+            ConfigNode manifestNode = parent.AddNode("INVENTORY_MANIFEST");
+
+            // Build merged key set from StartInventory ∪ EndInventory
+            var keys = new HashSet<string>();
+            if (hasStart)
+                foreach (var k in rec.StartInventory.Keys) keys.Add(k);
+            if (hasEnd)
+                foreach (var k in rec.EndInventory.Keys) keys.Add(k);
+
+            int count = 0;
+            foreach (var name in keys)
+            {
+                ConfigNode itemNode = manifestNode.AddNode("ITEM");
+                itemNode.AddValue("name", name);
+
+                if (hasStart && rec.StartInventory.TryGetValue(name, out var startItem))
+                {
+                    itemNode.AddValue("startCount", startItem.count.ToString(CultureInfo.InvariantCulture));
+                    itemNode.AddValue("startSlots", startItem.slotsTaken.ToString(CultureInfo.InvariantCulture));
+                }
+
+                if (hasEnd && rec.EndInventory.TryGetValue(name, out var endItem))
+                {
+                    itemNode.AddValue("endCount", endItem.count.ToString(CultureInfo.InvariantCulture));
+                    itemNode.AddValue("endSlots", endItem.slotsTaken.ToString(CultureInfo.InvariantCulture));
+                }
+
+                count++;
+            }
+
+            ParsekLog.Verbose("RecordingStore",
+                $"SerializeInventoryManifest: wrote {count} item(s) for recording={rec.RecordingId}");
+        }
+
+        /// <summary>
+        /// Deserializes StartInventory and EndInventory from an INVENTORY_MANIFEST ConfigNode
+        /// on the given parent. Sets the dictionaries if entries are found, or leaves them null
+        /// if the node is absent (backward compatible with legacy recordings).
+        /// </summary>
+        internal static void DeserializeInventoryManifest(ConfigNode parent, Recording rec)
+        {
+            ConfigNode manifestNode = parent.GetNode("INVENTORY_MANIFEST");
+            if (manifestNode == null)
+                return;
+
+            ConfigNode[] items = manifestNode.GetNodes("ITEM");
+            if (items.Length == 0)
+                return;
+
+            int loaded = 0;
+            int skipped = 0;
+
+            for (int i = 0; i < items.Length; i++)
+            {
+                string name = items[i].GetValue("name");
+                if (string.IsNullOrEmpty(name))
+                {
+                    skipped++;
+                    continue;
+                }
+
+                // Parse start fields (if present)
+                string startCountStr = items[i].GetValue("startCount");
+                string startSlotsStr = items[i].GetValue("startSlots");
+                if (startCountStr != null || startSlotsStr != null)
+                {
+                    if (rec.StartInventory == null)
+                        rec.StartInventory = new Dictionary<string, InventoryItem>();
+
+                    int startCount = 0;
+                    int startSlots = 0;
+                    if (startCountStr != null)
+                        int.TryParse(startCountStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out startCount);
+                    if (startSlotsStr != null)
+                        int.TryParse(startSlotsStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out startSlots);
+
+                    rec.StartInventory[name] = new InventoryItem { count = startCount, slotsTaken = startSlots };
+                }
+
+                // Parse end fields (if present)
+                string endCountStr = items[i].GetValue("endCount");
+                string endSlotsStr = items[i].GetValue("endSlots");
+                if (endCountStr != null || endSlotsStr != null)
+                {
+                    if (rec.EndInventory == null)
+                        rec.EndInventory = new Dictionary<string, InventoryItem>();
+
+                    int endCount = 0;
+                    int endSlots = 0;
+                    if (endCountStr != null)
+                        int.TryParse(endCountStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out endCount);
+                    if (endSlotsStr != null)
+                        int.TryParse(endSlotsStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out endSlots);
+
+                    rec.EndInventory[name] = new InventoryItem { count = endCount, slotsTaken = endSlots };
+                }
+
+                loaded++;
+            }
+
+            ParsekLog.Verbose("RecordingStore",
+                $"DeserializeInventoryManifest: loaded={loaded} skipped={skipped} for recording={rec.RecordingId}");
+        }
+
         #endregion
 
         #region Recording File I/O

--- a/Source/Parsek/RecordingTree.cs
+++ b/Source/Parsek/RecordingTree.cs
@@ -377,6 +377,9 @@ namespace Parsek
             if (rec.EndInventorySlots != 0)
                 recNode.AddValue("endInvSlots", rec.EndInventorySlots.ToString(ic));
 
+            // Crew manifests (Phase 11)
+            RecordingStore.SerializeCrewManifest(recNode, rec);
+
             // Dock target vessel PID (Phase 11)
             if (rec.DockTargetVesselPid != 0)
                 recNode.AddValue("dockTargetPid", rec.DockTargetVesselPid.ToString(ic));
@@ -740,6 +743,9 @@ namespace Parsek
                 if (int.TryParse(endInvSlotsStr, NumberStyles.Integer, ic, out endInvSlots))
                     rec.EndInventorySlots = endInvSlots;
             }
+
+            // Crew manifests (Phase 11)
+            RecordingStore.DeserializeCrewManifest(recNode, rec);
 
             // Dock target vessel PID (Phase 11)
             string dockTargetPidStr = recNode.GetValue("dockTargetPid");

--- a/Source/Parsek/RecordingTree.cs
+++ b/Source/Parsek/RecordingTree.cs
@@ -370,6 +370,13 @@ namespace Parsek
             // Resource manifests (Phase 11)
             RecordingStore.SerializeResourceManifest(recNode, rec);
 
+            // Inventory manifests (Phase 11)
+            RecordingStore.SerializeInventoryManifest(recNode, rec);
+            if (rec.StartInventorySlots != 0)
+                recNode.AddValue("startInvSlots", rec.StartInventorySlots.ToString(ic));
+            if (rec.EndInventorySlots != 0)
+                recNode.AddValue("endInvSlots", rec.EndInventorySlots.ToString(ic));
+
             // Dock target vessel PID (Phase 11)
             if (rec.DockTargetVesselPid != 0)
                 recNode.AddValue("dockTargetPid", rec.DockTargetVesselPid.ToString(ic));
@@ -716,6 +723,23 @@ namespace Parsek
 
             // Resource manifests (Phase 11)
             RecordingStore.DeserializeResourceManifest(recNode, rec);
+
+            // Inventory manifests (Phase 11)
+            RecordingStore.DeserializeInventoryManifest(recNode, rec);
+            string startInvSlotsStr = recNode.GetValue("startInvSlots");
+            if (startInvSlotsStr != null)
+            {
+                int startInvSlots;
+                if (int.TryParse(startInvSlotsStr, NumberStyles.Integer, ic, out startInvSlots))
+                    rec.StartInventorySlots = startInvSlots;
+            }
+            string endInvSlotsStr = recNode.GetValue("endInvSlots");
+            if (endInvSlotsStr != null)
+            {
+                int endInvSlots;
+                if (int.TryParse(endInvSlotsStr, NumberStyles.Integer, ic, out endInvSlots))
+                    rec.EndInventorySlots = endInvSlots;
+            }
 
             // Dock target vessel PID (Phase 11)
             string dockTargetPidStr = recNode.GetValue("dockTargetPid");

--- a/Source/Parsek/UI/RecordingsTableUI.cs
+++ b/Source/Parsek/UI/RecordingsTableUI.cs
@@ -2225,6 +2225,69 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Formats an inventory manifest for tooltip display.
+        /// If both start and end: "Inventory:\n  solarPanels5: 4 -> 0 (-4)"
+        /// If start only: "Inventory at start:\n  solarPanels5: 4"
+        /// If both null: returns null (no section shown).
+        /// </summary>
+        internal static string FormatInventoryManifest(
+            Dictionary<string, InventoryItem> start,
+            Dictionary<string, InventoryItem> end)
+        {
+            if (start == null && end == null)
+                return null;
+
+            // Merge keys from both dicts
+            var keys = new SortedSet<string>();
+            if (start != null)
+                foreach (var k in start.Keys) keys.Add(k);
+            if (end != null)
+                foreach (var k in end.Keys) keys.Add(k);
+
+            if (keys.Count == 0)
+                return null;
+
+            bool hasEnd = end != null;
+            var lines = new List<string>();
+            lines.Add(hasEnd ? "Inventory:" : "Inventory at start:");
+
+            foreach (var key in keys)
+            {
+                if (hasEnd)
+                {
+                    int startCount = 0;
+                    int endCount = 0;
+                    if (start != null && start.TryGetValue(key, out var startItem))
+                        startCount = startItem.count;
+                    if (end.TryGetValue(key, out var endItem))
+                        endCount = endItem.count;
+
+                    int delta = endCount - startCount;
+                    string sign = delta >= 0 ? "+" : "";
+                    lines.Add(string.Format(CultureInfo.InvariantCulture,
+                        "  {0}: {1} -> {2} ({3}{4})",
+                        key,
+                        startCount,
+                        endCount,
+                        sign,
+                        delta));
+                }
+                else
+                {
+                    // Start only — show count
+                    int count = 0;
+                    if (start.TryGetValue(key, out var item))
+                        count = item.count;
+                    lines.Add(string.Format(CultureInfo.InvariantCulture,
+                        "  {0}: {1}",
+                        key, count));
+                }
+            }
+
+            return string.Join("\n", lines);
+        }
+
+        /// <summary>
         /// Formats situation + biome + body into a compact location string.
         /// "Flying, Shores, Kerbin" or "Orbiting, Kerbin" or "Kerbin" etc.
         /// </summary>
@@ -2494,6 +2557,10 @@ namespace Parsek
             string resourceText = FormatResourceManifest(rec.StartResources, rec.EndResources);
             if (resourceText != null)
                 text += "\n" + resourceText;
+
+            string inventoryText = FormatInventoryManifest(rec.StartInventory, rec.EndInventory);
+            if (inventoryText != null)
+                text += "\n" + inventoryText;
 
             EnsureTooltipStyle();
 

--- a/Source/Parsek/UI/RecordingsTableUI.cs
+++ b/Source/Parsek/UI/RecordingsTableUI.cs
@@ -2265,7 +2265,7 @@ namespace Parsek
                     int delta = endCount - startCount;
                     string sign = delta >= 0 ? "+" : "";
                     lines.Add(string.Format(CultureInfo.InvariantCulture,
-                        "  {0}: {1} -> {2} ({3}{4})",
+                        "  {0}: {1} \u2192 {2} ({3}{4})",
                         key,
                         startCount,
                         endCount,

--- a/Source/Parsek/UI/RecordingsTableUI.cs
+++ b/Source/Parsek/UI/RecordingsTableUI.cs
@@ -2288,6 +2288,69 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Formats a crew manifest for tooltip display.
+        /// If both start and end: "Crew:\n  Pilot: 1 → 1 (+0)\n  Engineer: 2 → 0 (-2)"
+        /// If start only: "Crew at start:\n  Pilot: 1\n  Engineer: 2"
+        /// If both null: returns null (no section shown).
+        /// </summary>
+        internal static string FormatCrewManifest(
+            Dictionary<string, int> start,
+            Dictionary<string, int> end)
+        {
+            if (start == null && end == null)
+                return null;
+
+            // Merge keys from both dicts
+            var keys = new SortedSet<string>();
+            if (start != null)
+                foreach (var k in start.Keys) keys.Add(k);
+            if (end != null)
+                foreach (var k in end.Keys) keys.Add(k);
+
+            if (keys.Count == 0)
+                return null;
+
+            bool hasEnd = end != null;
+            var lines = new List<string>();
+            lines.Add(hasEnd ? "Crew:" : "Crew at start:");
+
+            foreach (var key in keys)
+            {
+                if (hasEnd)
+                {
+                    int startCount = 0;
+                    int endCount = 0;
+                    if (start != null && start.TryGetValue(key, out var sc))
+                        startCount = sc;
+                    if (end.TryGetValue(key, out var ec))
+                        endCount = ec;
+
+                    int delta = endCount - startCount;
+                    string sign = delta >= 0 ? "+" : "";
+                    lines.Add(string.Format(CultureInfo.InvariantCulture,
+                        "  {0}: {1} \u2192 {2} ({3}{4})",
+                        key,
+                        startCount,
+                        endCount,
+                        sign,
+                        delta));
+                }
+                else
+                {
+                    // Start only — show count
+                    int count = 0;
+                    if (start.TryGetValue(key, out var sc))
+                        count = sc;
+                    lines.Add(string.Format(CultureInfo.InvariantCulture,
+                        "  {0}: {1}",
+                        key, count));
+                }
+            }
+
+            return string.Join("\n", lines);
+        }
+
+        /// <summary>
         /// Formats situation + biome + body into a compact location string.
         /// "Flying, Shores, Kerbin" or "Orbiting, Kerbin" or "Kerbin" etc.
         /// </summary>
@@ -2561,6 +2624,10 @@ namespace Parsek
             string inventoryText = FormatInventoryManifest(rec.StartInventory, rec.EndInventory);
             if (inventoryText != null)
                 text += "\n" + inventoryText;
+
+            string crewText = FormatCrewManifest(rec.StartCrew, rec.EndCrew);
+            if (crewText != null)
+                text += "\n" + crewText;
 
             EnsureTooltipStyle();
 

--- a/Source/Parsek/VesselSpawner.cs
+++ b/Source/Parsek/VesselSpawner.cs
@@ -180,6 +180,52 @@ namespace Parsek
             return manifest;
         }
 
+        /// <summary>
+        /// Walk PART nodes in a vessel snapshot ConfigNode and return
+        /// a dictionary of crew traits (Pilot/Scientist/Engineer/Tourist) to counts.
+        /// Uses traitResolver if provided; otherwise falls back to KerbalsModule.FindTraitForKerbal.
+        /// Returns null if input is null, has no parts, or no crew found.
+        /// </summary>
+        internal static Dictionary<string, int> ExtractCrewManifest(
+            ConfigNode vesselSnapshot, Func<string, string> traitResolver = null)
+        {
+            if (vesselSnapshot == null) return null;
+
+            var parts = vesselSnapshot.GetNodes("PART");
+            if (parts.Length == 0) return null;
+
+            var manifest = new Dictionary<string, int>();
+            int crewCount = 0;
+
+            for (int i = 0; i < parts.Length; i++)
+            {
+                var crewValues = parts[i].GetValues("crew");
+                for (int j = 0; j < crewValues.Length; j++)
+                {
+                    string name = crewValues[j];
+                    if (string.IsNullOrEmpty(name)) continue;
+
+                    string trait = traitResolver != null
+                        ? traitResolver(name)
+                        : KerbalsModule.FindTraitForKerbal(name);
+
+                    if (manifest.ContainsKey(trait))
+                        manifest[trait] = manifest[trait] + 1;
+                    else
+                        manifest[trait] = 1;
+
+                    crewCount++;
+                }
+            }
+
+            if (manifest.Count == 0) return null;
+
+            ParsekLog.Verbose("Spawner",
+                $"ExtractCrewManifest: {crewCount} crew across {manifest.Count} trait(s) from {parts.Length} part(s)");
+
+            return manifest;
+        }
+
         public static uint RespawnVessel(ConfigNode vesselNode, HashSet<string> excludeCrew = null, bool preserveIdentity = false)
         {
             try

--- a/Source/Parsek/VesselSpawner.cs
+++ b/Source/Parsek/VesselSpawner.cs
@@ -99,6 +99,87 @@ namespace Parsek
             return manifest;
         }
 
+        /// <summary>
+        /// Walk PART > MODULE nodes in a vessel snapshot ConfigNode and return
+        /// a dictionary of stored inventory item names to summed count/slotsTaken.
+        /// Also outputs total inventory slot capacity across all ModuleInventoryPart modules.
+        /// Returns null if input is null, has no parts, or no inventory items found.
+        /// </summary>
+        internal static Dictionary<string, InventoryItem> ExtractInventoryManifest(
+            ConfigNode vesselSnapshot, out int totalInventorySlots)
+        {
+            totalInventorySlots = 0;
+
+            if (vesselSnapshot == null) return null;
+
+            var parts = vesselSnapshot.GetNodes("PART");
+            if (parts.Length == 0) return null;
+
+            var manifest = new Dictionary<string, InventoryItem>();
+            int moduleCount = 0;
+
+            for (int i = 0; i < parts.Length; i++)
+            {
+                var modules = parts[i].GetNodes("MODULE");
+                for (int j = 0; j < modules.Length; j++)
+                {
+                    if (modules[j].GetValue("name") != "ModuleInventoryPart") continue;
+                    moduleCount++;
+
+                    string slotsStr = modules[j].GetValue("InventorySlots");
+                    if (slotsStr != null)
+                    {
+                        if (int.TryParse(slotsStr, NumberStyles.Integer,
+                            CultureInfo.InvariantCulture, out int slots))
+                            totalInventorySlots += slots;
+                    }
+
+                    var storedPartsNode = modules[j].GetNode("STOREDPARTS");
+                    if (storedPartsNode == null) continue;
+
+                    var storedParts = storedPartsNode.GetNodes("STOREDPART");
+                    for (int k = 0; k < storedParts.Length; k++)
+                    {
+                        string partName = storedParts[k].GetValue("partName");
+                        if (string.IsNullOrEmpty(partName)) continue;
+
+                        int quantity = 1;
+                        string qtyStr = storedParts[k].GetValue("quantity");
+                        if (qtyStr != null)
+                        {
+                            if (int.TryParse(qtyStr, NumberStyles.Integer,
+                                CultureInfo.InvariantCulture, out int parsedQty))
+                                quantity = parsedQty;
+                        }
+
+                        if (manifest.ContainsKey(partName))
+                        {
+                            // Struct — indexer returns a copy. Read-modify-write.
+                            var item = manifest[partName];
+                            item.count += quantity;
+                            item.slotsTaken += 1;
+                            manifest[partName] = item;
+                        }
+                        else
+                        {
+                            manifest[partName] = new InventoryItem { count = quantity, slotsTaken = 1 };
+                        }
+                    }
+                }
+            }
+
+            if (manifest.Count == 0)
+            {
+                totalInventorySlots = 0;
+                return null;
+            }
+
+            ParsekLog.Verbose("Spawner",
+                $"ExtractInventoryManifest: {manifest.Count} item type(s), {totalInventorySlots} total slot(s) across {moduleCount} inventory module(s)");
+
+            return manifest;
+        }
+
         public static uint RespawnVessel(ConfigNode vesselNode, HashSet<string> excludeCrew = null, bool preserveIdentity = false)
         {
             try


### PR DESCRIPTION
## Summary
Implements the two remaining manifest types for Phase 11 Resource Snapshots:

**Inventory manifests (T11-INV):**
- InventoryItem struct (count + slotsTaken) + vessel-level totalInventorySlots
- ExtractInventoryManifest walks MODULE > STOREDPARTS > STOREDPART nodes
- Same boundary capture, serialization, and UI tooltip pattern as resources
- 33 tests (18 extraction/delta, 10 serialization, 5 formatting)

**Crew manifests (T11-CREW):**
- Dictionary<string, int> (trait name -> count): Pilot, Scientist, Engineer, Tourist
- ExtractCrewManifest with injectable trait resolver (testable without KSP runtime)
- Route delivery uses generic kerbals, separate from crew reservation system
- 27 tests (12 extraction/delta, 9 serialization, 6 formatting)

Both follow the resource manifest pattern exactly at all 8 boundary capture sites, 4 save/load sites, optimizer propagation, and ApplyPersistenceArtifactsFrom.

## Test plan
- [x] 33 inventory tests
- [x] 27 crew tests
- [x] Full suite: 5725 passing
- [ ] In-game playtest: verify tooltip shows inventory/crew data