### PR TITLE
Bug #271: Unify standalone and tree recording systems (always-tree)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -54,7 +54,7 @@ Key source files and what they do - read the relevant one before modifying:
 - `IGhostPositioner.cs` - 8 positioning methods implemented by ParsekFlight, delegates world-space placement to the host scene
 - `GhostPlaybackEvents.cs` - lifecycle event types (PlaybackCompleted, LoopRestarted, OverlapExpired, CameraAction), TrajectoryPlaybackFlags, FrameContext
 - `ChainSegmentManager.cs` - chain segment state (active chain ID, continuation tracking, boundary anchors). Owns 16 fields previously scattered across ParsekFlight.
-- `FlightRecorder.cs` - recording state + sampling (called by Harmony patch)
+- `FlightRecorder.cs` - recording state + sampling (called by Harmony patch). Always-tree mode: every recording gets a RecordingTree (#271). `DecideOnVesselSwitch` has no Stop decision.
 - `ParsekUI.cs` - UI main window, map markers, and coordinator for extracted sub-windows
 - `UI/RecordingsTableUI.cs` - recordings table window (sort, rename, group tree, chain blocks, loop period editing)
 - `UI/SettingsWindowUI.cs` - settings window (recording, looping, ghost, diagnostics, sampling, data management)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to Parsek are documented here.
 ### Improvements
 
 - Migrated 9 log contract checks from post-hoc KSP.log analysis to in-game tests (Ctrl+Shift+T) -- catches format, resource, and recording metric issues at runtime instead of after session ends.
+- Unified standalone and tree recording systems -- all recordings now use tree architecture internally (#271).
 
 ### Bug Fixes
 

--- a/Source/Parsek.Tests/BackgroundSplitTests.cs
+++ b/Source/Parsek.Tests/BackgroundSplitTests.cs
@@ -762,7 +762,7 @@ namespace Parsek.Tests
         public void CreateBreakupChildRecording_PropagatesGeneration_Gen0Parent_ChildIsGen1()
         {
             // Active rocket (gen=0) crashes → debris children must be gen=1.
-            // Used by ProcessBreakupEvent and PromoteToTreeForBreakup.
+            // Used by ProcessBreakupEvent.
             var tree = new RecordingTree { Id = "t1", TreeName = "Test" };
             var bp = new BranchPoint { Id = "bp1", UT = 100 };
 

--- a/Source/Parsek.Tests/ChainTests.cs
+++ b/Source/Parsek.Tests/ChainTests.cs
@@ -65,17 +65,17 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void DecideOnVesselSwitch_VesselToOther_ReturnsStop()
+        public void DecideOnVesselSwitch_VesselToOther_ReturnsTransitionToBackground()
         {
             var result = FlightRecorder.DecideOnVesselSwitch(100, 200, false, false);
-            Assert.Equal(FlightRecorder.VesselSwitchDecision.Stop, result);
+            Assert.Equal(FlightRecorder.VesselSwitchDecision.TransitionToBackground, result);
         }
 
         [Fact]
-        public void DecideOnVesselSwitch_VesselToEva_NotStartedAsEva_ReturnsStop()
+        public void DecideOnVesselSwitch_VesselToEva_NotStartedAsEva_ReturnsTransitionToBackground()
         {
             var result = FlightRecorder.DecideOnVesselSwitch(100, 200, true, false);
-            Assert.Equal(FlightRecorder.VesselSwitchDecision.Stop, result);
+            Assert.Equal(FlightRecorder.VesselSwitchDecision.TransitionToBackground, result);
         }
 
         #endregion

--- a/Source/Parsek.Tests/DockUndockChainTests.cs
+++ b/Source/Parsek.Tests/DockUndockChainTests.cs
@@ -318,7 +318,7 @@ namespace Parsek.Tests
         {
             // undockSiblingPid = 0 should not affect the result
             var result = FlightRecorder.DecideOnVesselSwitch(100, 200, false, false, undockSiblingPid: 0);
-            Assert.Equal(FlightRecorder.VesselSwitchDecision.Stop, result);
+            Assert.Equal(FlightRecorder.VesselSwitchDecision.TransitionToBackground, result);
         }
 
         [Fact]
@@ -326,7 +326,7 @@ namespace Parsek.Tests
         {
             // Vessel switched to something that's NOT the sibling
             var result = FlightRecorder.DecideOnVesselSwitch(100, 300, false, false, undockSiblingPid: 200);
-            Assert.Equal(FlightRecorder.VesselSwitchDecision.Stop, result);
+            Assert.Equal(FlightRecorder.VesselSwitchDecision.TransitionToBackground, result);
         }
 
         [Fact]

--- a/Source/Parsek.Tests/FlightRecorderExtractedTests.cs
+++ b/Source/Parsek.Tests/FlightRecorderExtractedTests.cs
@@ -606,5 +606,45 @@ namespace Parsek.Tests
         }
 
         #endregion
+
+        #region DecideOnVesselSwitch — always-tree invariants (#271)
+
+        [Fact]
+        public void DecideOnVesselSwitch_AlwaysTree_TargetNotInBackground_ReturnsTransitionToBackground()
+        {
+            // With always-tree mode, activeTree is always non-null during recording.
+            // Switching to an untracked vessel should return TransitionToBackground (not Stop,
+            // which was removed in #271 phase 2).
+            var tree = new RecordingTree
+            {
+                Id = "tree_271",
+                TreeName = "Always Tree Test",
+                RootRecordingId = "root",
+                ActiveRecordingId = "active"
+            };
+            tree.Recordings["active"] = new Recording
+            {
+                RecordingId = "active",
+                VesselName = "Active Vessel",
+                VesselPersistentId = 100
+            };
+            // BackgroundMap is empty — target vessel 500 is not tracked
+            var result = FlightRecorder.DecideOnVesselSwitch(
+                100, 500, currentIsEva: false, recordingStartedAsEva: false, activeTree: tree);
+            Assert.Equal(FlightRecorder.VesselSwitchDecision.TransitionToBackground, result);
+        }
+
+        [Fact]
+        public void DecideOnVesselSwitch_SafetyFallback_NullTree_ReturnsTransitionToBackground()
+        {
+            // Safety fallback: with always-tree mode, activeTree should never be null during
+            // recording. But if it somehow is (defensive), the fallback must still return
+            // TransitionToBackground (not Stop, which was removed in #271 phase 2).
+            var result = FlightRecorder.DecideOnVesselSwitch(
+                100, 500, currentIsEva: false, recordingStartedAsEva: false, activeTree: null);
+            Assert.Equal(FlightRecorder.VesselSwitchDecision.TransitionToBackground, result);
+        }
+
+        #endregion
     }
 }

--- a/Source/Parsek.Tests/FlightRecorderExtractedTests.cs
+++ b/Source/Parsek.Tests/FlightRecorderExtractedTests.cs
@@ -45,10 +45,10 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void DecideOnVesselSwitch_DifferentPid_NonEva_NoTree_ReturnsStop()
+        public void DecideOnVesselSwitch_DifferentPid_NonEva_NoTree_ReturnsTransitionToBackground()
         {
             var result = FlightRecorder.DecideOnVesselSwitch(100, 200, false, false);
-            Assert.Equal(FlightRecorder.VesselSwitchDecision.Stop, result);
+            Assert.Equal(FlightRecorder.VesselSwitchDecision.TransitionToBackground, result);
         }
 
         [Fact]

--- a/Source/Parsek.Tests/Generators/RecordingBuilder.cs
+++ b/Source/Parsek.Tests/Generators/RecordingBuilder.cs
@@ -654,5 +654,72 @@ namespace Parsek.Tests.Generators
 
         /// <summary>Returns the rewind save file name (may be null).</summary>
         public string GetRewindSaveFileName() => rewindSaveFileName;
+
+        /// <summary>Returns the UT of the last point, or 0 if no points.</summary>
+        public double GetEndUT()
+        {
+            if (points.Count == 0) return 0;
+            var ic = CultureInfo.InvariantCulture;
+            double ut;
+            double.TryParse(points[points.Count - 1].GetValue("ut"), NumberStyles.Float, ic, out ut);
+            return ut;
+        }
+
+        /// <summary>Returns the format version.</summary>
+        public int GetFormatVersion() => formatVersion;
+
+        /// <summary>Returns whether loop playback is enabled.</summary>
+        public bool GetLoopPlayback() => loopPlayback;
+
+        /// <summary>Returns the loop interval in seconds.</summary>
+        public double GetLoopIntervalSeconds() => loopIntervalSeconds;
+
+        /// <summary>Returns the terminal state (null if not set).</summary>
+        public int? GetTerminalState() => terminalState;
+
+        /// <summary>Returns the terrain height at end.</summary>
+        public double GetTerrainHeightAtEnd() => terrainHeightAtEnd;
+
+        /// <summary>Returns the recording groups list.</summary>
+        public List<string> GetRecordingGroups() => recordingGroups;
+
+        /// <summary>Returns the segment phase (may be null).</summary>
+        public string GetSegmentPhase() => segmentPhase;
+
+        /// <summary>Returns the segment body name (may be null).</summary>
+        public string GetSegmentBodyName() => segmentBodyName;
+
+        /// <summary>Returns whether playback is enabled.</summary>
+        public bool GetPlaybackEnabled() => playbackEnabled;
+
+        /// <summary>Returns the chain ID (may be null).</summary>
+        public string GetChainId() => chainId;
+
+        /// <summary>Returns the chain index (-1 if not set).</summary>
+        public int GetChainIndex() => chainIndex;
+
+        /// <summary>Returns the chain branch (-1 if not set).</summary>
+        public int GetChainBranch() => chainBranch;
+
+        /// <summary>Returns the parent recording ID (may be null).</summary>
+        public string GetParentRecordingId() => parentRecordingId;
+
+        /// <summary>Returns the EVA crew name (may be null).</summary>
+        public string GetEvaCrewName() => evaCrewName;
+
+        /// <summary>Returns the rewind reserved funds.</summary>
+        public double GetRewindReservedFunds() => rewindReservedFunds;
+
+        /// <summary>Returns the rewind reserved science.</summary>
+        public double GetRewindReservedScience() => rewindReservedScience;
+
+        /// <summary>Returns the rewind reserved reputation.</summary>
+        public float GetRewindReservedRep() => rewindReservedRep;
+
+        /// <summary>Returns the controllers list (may be null).</summary>
+        public List<ControllerInfo> GetControllers() => controllers;
+
+        /// <summary>Returns whether this recording is debris.</summary>
+        public bool GetIsDebris() => isDebris;
     }
 }

--- a/Source/Parsek.Tests/Generators/ScenarioWriter.cs
+++ b/Source/Parsek.Tests/Generators/ScenarioWriter.cs
@@ -40,6 +40,105 @@ namespace Parsek.Tests.Generators
         }
 
         /// <summary>
+        /// Wraps a single RecordingBuilder into a RECORDING_TREE node and adds it
+        /// to the scenario. This is the always-tree equivalent of AddRecording:
+        /// each standalone recording becomes a single-recording tree.
+        /// Sidecar files (.prec, _vessel.craft, _ghost.craft) are also registered
+        /// for writing when WithV3Format is active.
+        /// </summary>
+        public ScenarioWriter AddRecordingAsTree(RecordingBuilder builder)
+        {
+            string recordingId = builder.GetRecordingId();
+            string treeId = "tree-" + recordingId;
+
+            // Build a Recording object from the builder's data
+            var rec = new Recording
+            {
+                RecordingId = recordingId,
+                VesselName = builder.GetVesselName(),
+                RecordingFormatVersion = builder.GetFormatVersion(),
+                VesselPersistentId = StableHashToUint(recordingId),
+                ExplicitStartUT = builder.GetStartUT(),
+                ExplicitEndUT = builder.GetEndUT(),
+                TreeId = treeId,
+                LoopPlayback = builder.GetLoopPlayback(),
+                LoopIntervalSeconds = builder.GetLoopIntervalSeconds(),
+                PlaybackEnabled = builder.GetPlaybackEnabled(),
+            };
+
+            // Terminal state
+            int? ts = builder.GetTerminalState();
+            if (ts.HasValue)
+                rec.TerminalStateValue = (TerminalState)ts.Value;
+
+            // Terrain height at end
+            double terrainH = builder.GetTerrainHeightAtEnd();
+            if (!double.IsNaN(terrainH))
+                rec.TerrainHeightAtEnd = terrainH;
+
+            // Recording groups
+            var groups = builder.GetRecordingGroups();
+            if (groups != null && groups.Count > 0)
+                rec.RecordingGroups = new List<string>(groups);
+
+            // Segment metadata
+            if (!string.IsNullOrEmpty(builder.GetSegmentPhase()))
+                rec.SegmentPhase = builder.GetSegmentPhase();
+            if (!string.IsNullOrEmpty(builder.GetSegmentBodyName()))
+                rec.SegmentBodyName = builder.GetSegmentBodyName();
+
+            // Chain linkage
+            if (!string.IsNullOrEmpty(builder.GetChainId()))
+                rec.ChainId = builder.GetChainId();
+            if (builder.GetChainIndex() >= 0)
+                rec.ChainIndex = builder.GetChainIndex();
+            if (builder.GetChainBranch() > 0)
+                rec.ChainBranch = builder.GetChainBranch();
+
+            // EVA linkage
+            if (!string.IsNullOrEmpty(builder.GetParentRecordingId()))
+                rec.ParentRecordingId = builder.GetParentRecordingId();
+            if (!string.IsNullOrEmpty(builder.GetEvaCrewName()))
+                rec.EvaCrewName = builder.GetEvaCrewName();
+
+            // Rewind save
+            if (!string.IsNullOrEmpty(builder.GetRewindSaveFileName()))
+            {
+                rec.RewindSaveFileName = builder.GetRewindSaveFileName();
+                rec.RewindReservedFunds = builder.GetRewindReservedFunds();
+                rec.RewindReservedScience = builder.GetRewindReservedScience();
+                rec.RewindReservedRep = builder.GetRewindReservedRep();
+            }
+
+            // Controllers
+            var controllers = builder.GetControllers();
+            if (controllers != null)
+                rec.Controllers = new List<ControllerInfo>(controllers);
+            rec.IsDebris = builder.GetIsDebris();
+
+            // Build the tree
+            var tree = new RecordingTree
+            {
+                Id = treeId,
+                TreeName = builder.GetVesselName(),
+                RootRecordingId = recordingId,
+                ActiveRecordingId = null  // committed trees have no active recording
+            };
+            tree.Recordings[recordingId] = rec;
+
+            // Serialize via RecordingTree.Save
+            var treeNode = new ConfigNode("RECORDING_TREE");
+            tree.Save(treeNode);
+            trees.Add(treeNode);
+
+            // Register for sidecar file writing (same as v3 standalone)
+            if (useV3Format)
+                v3Builders.Add(builder);
+
+            return this;
+        }
+
+        /// <summary>
         /// Adds a pre-built RECORDING_TREE ConfigNode to be emitted in the scenario.
         /// The node should be built via RecordingTree.Save().
         /// </summary>
@@ -332,6 +431,22 @@ namespace Parsek.Tests.Generators
             // Preserve original line ending style
             string sep = content.Contains("\r\n") ? "\r\n" : "\n";
             return string.Join(sep, result);
+        }
+
+        /// <summary>
+        /// Generates a stable uint from a string via FNV-1a hash.
+        /// Used to derive VesselPersistentId from recordingId for synthetic trees.
+        /// </summary>
+        private static uint StableHashToUint(string input)
+        {
+            uint hash = 2166136261;
+            for (int i = 0; i < input.Length; i++)
+            {
+                hash ^= input[i];
+                hash *= 16777619;
+            }
+            // Avoid 0 (which means "not set" for VesselPersistentId)
+            return hash == 0 ? 1u : hash;
         }
     }
 }

--- a/Source/Parsek.Tests/PlaytestFollowupTests.cs
+++ b/Source/Parsek.Tests/PlaytestFollowupTests.cs
@@ -10,7 +10,7 @@ namespace Parsek.Tests
     /// Regression tests for two bugs exposed by the 2026-04-09 playtest after
     /// PR #163 fixed the OnFlightReady ordering bug:
     ///
-    ///   1. FilesDirty was not set in PromoteToTreeForBreakup / CreateSplitBranch
+    ///   1. FilesDirty was not set in CreateSplitBranch
     ///      / AppendCapturedDataToRecording / FlushRecorderToTreeRecording /
     ///      ChainSegmentManager continuation sampling. Trajectory data sat in
     ///      memory and never reached the .prec sidecar file because SaveRecordingFiles
@@ -222,8 +222,6 @@ namespace Parsek.Tests
         /// correctness.
         /// </summary>
         [Theory]
-        [InlineData("ParsekFlight.cs", "void PromoteToTreeForBreakup(BranchPoint")]
-        [InlineData("ParsekFlight.cs", "void CreateSplitBranch(BranchPointType")]
         [InlineData("ParsekFlight.cs", "static void AppendCapturedDataToRecording(")]
         [InlineData("ParsekFlight.cs", "void FlushRecorderToTreeRecording(FlightRecorder")]
         [InlineData("ChainSegmentManager.cs", "void SampleContinuationVessel(")]

--- a/Source/Parsek.Tests/QuickloadDiscardTests.cs
+++ b/Source/Parsek.Tests/QuickloadDiscardTests.cs
@@ -316,46 +316,16 @@ namespace Parsek.Tests
             Assert.False(result);
         }
 
-        // ----- #305: PendingStandaloneState.Limbo preservation -----
-
         [Fact]
-        public void DiscardStashedOnQuickload_LimboStandalone_Preserved()
+        public void DiscardStashedOnQuickload_StandalonePending_AlwaysDiscarded()
         {
-            // Limbo standalone is the revert-to-launch carrier — must survive
-            // DiscardStashedOnQuickload (parallel to Limbo tree at line ~179).
+            // With always-tree mode, standalone pending is always discarded on quickload.
             var points = new List<TrajectoryPoint>
             {
                 new TrajectoryPoint { ut = 300.0 },
                 new TrajectoryPoint { ut = 350.0 },
             };
-            RecordingStore.StashPending(points, "Crater Crawler",
-                state: PendingStandaloneState.Limbo);
-            Assert.True(RecordingStore.HasPending);
-            Assert.Equal(PendingStandaloneState.Limbo, RecordingStore.PendingStandaloneStateValue);
-            Assert.True(RecordingStore.PendingStashedThisTransition);
-            logLines.Clear();
-
-            ParsekScenario.DiscardStashedOnQuickload(preChangeUT: 350.0, currentUT: 295.0);
-
-            Assert.True(RecordingStore.HasPending); // preserved
-            Assert.Equal(PendingStandaloneState.Limbo, RecordingStore.PendingStandaloneStateValue);
-            Assert.Contains(logLines, l =>
-                l.Contains("preserving Limbo standalone") && l.Contains("Crater Crawler"));
-            Assert.Contains(logLines, l =>
-                l.Contains("Quickload discard complete") && l.Contains("sa=0"));
-        }
-
-        [Fact]
-        public void DiscardStashedOnQuickload_FinalizedStandalone_StillDiscarded()
-        {
-            // Non-Limbo (Finalized) standalone stashed this transition: discard (existing behavior).
-            var points = new List<TrajectoryPoint>
-            {
-                new TrajectoryPoint { ut = 300.0 },
-                new TrajectoryPoint { ut = 350.0 },
-            };
-            RecordingStore.StashPending(points, "Kerbal X",
-                state: PendingStandaloneState.Finalized);
+            RecordingStore.StashPending(points, "Kerbal X");
             Assert.True(RecordingStore.HasPending);
             Assert.True(RecordingStore.PendingStashedThisTransition);
             logLines.Clear();
@@ -365,98 +335,6 @@ namespace Parsek.Tests
             Assert.False(RecordingStore.HasPending); // discarded
             Assert.Contains(logLines, l =>
                 l.Contains("discarded pending standalone") && l.Contains("Kerbal X"));
-        }
-
-        [Fact]
-        public void MarkPendingStandaloneFinalized_TransitionsFromLimbo()
-        {
-            var points = new List<TrajectoryPoint>
-            {
-                new TrajectoryPoint { ut = 300.0 },
-                new TrajectoryPoint { ut = 350.0 },
-            };
-            RecordingStore.StashPending(points, "Butterfly Rover",
-                state: PendingStandaloneState.Limbo);
-            Assert.Equal(PendingStandaloneState.Limbo, RecordingStore.PendingStandaloneStateValue);
-            logLines.Clear();
-
-            RecordingStore.MarkPendingStandaloneFinalized();
-
-            Assert.Equal(PendingStandaloneState.Finalized, RecordingStore.PendingStandaloneStateValue);
-            Assert.Contains(logLines, l =>
-                l.Contains("Limbo") && l.Contains("Finalized") && l.Contains("Butterfly Rover"));
-        }
-
-        [Fact]
-        public void MarkPendingStandaloneFinalized_NoPending_NoOp()
-        {
-            Assert.False(RecordingStore.HasPending);
-            logLines.Clear();
-
-            RecordingStore.MarkPendingStandaloneFinalized();
-
-            // No crash, no log output (null guard)
-            Assert.DoesNotContain(logLines, l => l.Contains("Finalized"));
-        }
-
-        [Fact]
-        public void StashPending_DefaultState_IsFinalized()
-        {
-            var points = new List<TrajectoryPoint>
-            {
-                new TrajectoryPoint { ut = 100.0 },
-                new TrajectoryPoint { ut = 200.0 },
-            };
-            RecordingStore.StashPending(points, "Test");
-            Assert.Equal(PendingStandaloneState.Finalized, RecordingStore.PendingStandaloneStateValue);
-        }
-
-        [Fact]
-        public void DiscardPending_ResetsStateToFinalized()
-        {
-            var points = new List<TrajectoryPoint>
-            {
-                new TrajectoryPoint { ut = 100.0 },
-                new TrajectoryPoint { ut = 200.0 },
-            };
-            RecordingStore.StashPending(points, "Test", state: PendingStandaloneState.Limbo);
-            Assert.Equal(PendingStandaloneState.Limbo, RecordingStore.PendingStandaloneStateValue);
-
-            RecordingStore.DiscardPending();
-
-            Assert.Equal(PendingStandaloneState.Finalized, RecordingStore.PendingStandaloneStateValue);
-        }
-
-        [Fact]
-        public void CommitPending_ResetsStateToFinalized()
-        {
-            var points = new List<TrajectoryPoint>
-            {
-                new TrajectoryPoint { ut = 100.0 },
-                new TrajectoryPoint { ut = 200.0 },
-            };
-            RecordingStore.StashPending(points, "Test", state: PendingStandaloneState.Limbo);
-            Assert.Equal(PendingStandaloneState.Limbo, RecordingStore.PendingStandaloneStateValue);
-
-            RecordingStore.CommitPending();
-
-            Assert.Equal(PendingStandaloneState.Finalized, RecordingStore.PendingStandaloneStateValue);
-        }
-
-        [Fact]
-        public void Clear_ResetsStateToFinalized()
-        {
-            var points = new List<TrajectoryPoint>
-            {
-                new TrajectoryPoint { ut = 100.0 },
-                new TrajectoryPoint { ut = 200.0 },
-            };
-            RecordingStore.StashPending(points, "Test", state: PendingStandaloneState.Limbo);
-            Assert.Equal(PendingStandaloneState.Limbo, RecordingStore.PendingStandaloneStateValue);
-
-            RecordingStore.Clear();
-
-            Assert.Equal(PendingStandaloneState.Finalized, RecordingStore.PendingStandaloneStateValue);
         }
 
         // ----- Helpers -----

--- a/Source/Parsek.Tests/QuickloadStandaloneTests.cs
+++ b/Source/Parsek.Tests/QuickloadStandaloneTests.cs
@@ -5,18 +5,12 @@ using Xunit;
 namespace Parsek.Tests
 {
     /// <summary>
-    /// Tests for standalone quickload-resume (#294) and the fallback pending tree
-    /// guard (#293). Companion to <see cref="QuickloadDiscardTests"/> (F9 discard path)
-    /// and <see cref="QuickloadResumeTests"/> (tree-mode resume path).
+    /// Tests for the PARSEK_ACTIVE_STANDALONE migration shim (#271 unification).
+    /// Old saves may contain a PARSEK_ACTIVE_STANDALONE node from pre-always-tree versions.
+    /// TryRestoreActiveStandaloneNode now converts these to a single-node RecordingTree
+    /// and routes through the tree restore path.
     ///
-    /// Bug #293: OnFlightReady's fallback check at line 4211 fires in the same frame
-    /// as the tree restore coroutine, auto-merging the tree and leaving no recorder.
-    /// Fix: guard the fallback with <c>restoringActiveTree</c>.
-    ///
-    /// Bug #294: Standalone recordings have no quickload-resume mechanism — F5 during
-    /// a standalone recording, then F9, discards the in-progress data with no recovery.
-    /// Fix: serialize active standalone recorder to PARSEK_ACTIVE_STANDALONE on F5,
-    /// restore on F9 via a coroutine mirroring the tree restore path.
+    /// Also verifies the fallback pending tree guard (#293).
     /// </summary>
     [Collection("Sequential")]
     public class QuickloadStandaloneTests : System.IDisposable
@@ -32,7 +26,8 @@ namespace Parsek.Tests
             ParsekLog.VerboseOverrideForTesting = true;
             ParsekLog.TestSinkForTesting = line => logLines.Add(line);
             GameStateStore.SuppressLogging = true;
-            ParsekScenario.ClearPendingActiveStandalone();
+            ParsekScenario.ScheduleActiveTreeRestoreOnFlightReady =
+                ParsekScenario.ActiveTreeRestoreMode.None;
         }
 
         public void Dispose()
@@ -41,10 +36,11 @@ namespace Parsek.Tests
             ParsekLog.ResetTestOverrides();
             ParsekLog.SuppressLogging = true;
             RecordingStore.SuppressLogging = true;
-            ParsekScenario.ClearPendingActiveStandalone();
+            ParsekScenario.ScheduleActiveTreeRestoreOnFlightReady =
+                ParsekScenario.ActiveTreeRestoreMode.None;
         }
 
-        // ───────── #293: Fallback guard tests ─────────
+        // --------- #293: Fallback guard tests ---------
 
         [Fact]
         public void RestoringActiveTree_Guard_IsStaticField()
@@ -53,7 +49,7 @@ namespace Parsek.Tests
             Assert.False(ParsekFlight.restoringActiveTree);
         }
 
-        // ───────── #294: TryRestoreActiveStandaloneNode tests ─────────
+        // --------- Migration shim: TryRestoreActiveStandaloneNode ---------
 
         [Fact]
         public void TryRestoreActiveStandaloneNode_NoNode_DoesNothing()
@@ -62,21 +58,30 @@ namespace Parsek.Tests
 
             ParsekScenario.TryRestoreActiveStandaloneNode(node);
 
-            Assert.False(ParsekScenario.ScheduleActiveStandaloneRestoreOnFlightReady);
-            Assert.Null(ParsekScenario.pendingActiveStandaloneRecording);
+            Assert.Equal(ParsekScenario.ActiveTreeRestoreMode.None,
+                ParsekScenario.ScheduleActiveTreeRestoreOnFlightReady);
+            Assert.Null(RecordingStore.PendingTree);
         }
 
         [Fact]
-        public void TryRestoreActiveStandaloneNode_ValidNode_SetsRestoreFlag()
+        public void TryRestoreActiveStandaloneNode_ValidNode_CreatesPendingTree()
         {
             var node = BuildStandaloneNode("Kerbal X", 42, 10, 3);
 
             ParsekScenario.TryRestoreActiveStandaloneNode(node);
 
-            Assert.True(ParsekScenario.ScheduleActiveStandaloneRestoreOnFlightReady);
-            Assert.NotNull(ParsekScenario.pendingActiveStandaloneRecording);
-            Assert.Equal("Kerbal X", ParsekScenario.pendingActiveStandaloneVesselName);
-            Assert.Equal(42u, ParsekScenario.pendingActiveStandaloneVesselPid);
+            Assert.Equal(ParsekScenario.ActiveTreeRestoreMode.Quickload,
+                ParsekScenario.ScheduleActiveTreeRestoreOnFlightReady);
+            Assert.NotNull(RecordingStore.PendingTree);
+            Assert.Equal("Kerbal X", RecordingStore.PendingTree.TreeName);
+            Assert.Equal(1, RecordingStore.PendingTree.Recordings.Count);
+
+            // The root recording should have the vessel data
+            var rootId = RecordingStore.PendingTree.RootRecordingId;
+            Assert.NotNull(rootId);
+            var rootRec = RecordingStore.PendingTree.Recordings[rootId];
+            Assert.Equal(42u, rootRec.VesselPersistentId);
+            Assert.Equal("Kerbal X", rootRec.VesselName);
         }
 
         [Fact]
@@ -86,7 +91,8 @@ namespace Parsek.Tests
 
             ParsekScenario.TryRestoreActiveStandaloneNode(node);
 
-            Assert.Equal(5, ParsekScenario.pendingActiveStandaloneRecording.Points.Count);
+            var rootId = RecordingStore.PendingTree.RootRecordingId;
+            Assert.Equal(5, RecordingStore.PendingTree.Recordings[rootId].Points.Count);
         }
 
         [Fact]
@@ -96,7 +102,8 @@ namespace Parsek.Tests
 
             ParsekScenario.TryRestoreActiveStandaloneNode(node);
 
-            Assert.Equal(2, ParsekScenario.pendingActiveStandaloneRecording.PartEvents.Count);
+            var rootId = RecordingStore.PendingTree.RootRecordingId;
+            Assert.Equal(2, RecordingStore.PendingTree.Recordings[rootId].PartEvents.Count);
         }
 
         [Fact]
@@ -108,7 +115,8 @@ namespace Parsek.Tests
 
             ParsekScenario.TryRestoreActiveStandaloneNode(node);
 
-            var rec = ParsekScenario.pendingActiveStandaloneRecording;
+            var rootId = RecordingStore.PendingTree.RootRecordingId;
+            var rec = RecordingStore.PendingTree.Recordings[rootId];
             Assert.Equal("Kerbin", rec.StartBodyName);
             Assert.Equal("Shores", rec.StartBiome);
             Assert.Equal("Flying", rec.StartSituation);
@@ -123,7 +131,7 @@ namespace Parsek.Tests
 
             ParsekScenario.TryRestoreActiveStandaloneNode(node);
 
-            Assert.Equal("parsek_rw_abc123", ParsekScenario.pendingActiveStandaloneRewindSave);
+            Assert.Equal("parsek_rw_abc123", ParsekScenario.pendingActiveTreeResumeRewindSave);
         }
 
         [Fact]
@@ -137,8 +145,8 @@ namespace Parsek.Tests
 
             ParsekScenario.TryRestoreActiveStandaloneNode(node);
 
-            Assert.False(ParsekScenario.ScheduleActiveStandaloneRestoreOnFlightReady);
-            Assert.Null(ParsekScenario.pendingActiveStandaloneRecording);
+            // Should not create a pending tree (tree restore takes precedence)
+            Assert.Null(RecordingStore.PendingTree);
             Assert.Contains(logLines, l => l.Contains("tree takes precedence"));
 
             // Cleanup
@@ -147,7 +155,7 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void TryRestoreActiveStandaloneNode_LogsRestoreData()
+        public void TryRestoreActiveStandaloneNode_LogsMigration()
         {
             var node = BuildStandaloneNode("Flea Rocket", 999, 8, 2);
 
@@ -155,73 +163,53 @@ namespace Parsek.Tests
 
             Assert.Contains(logLines, l =>
                 l.Contains("TryRestoreActiveStandaloneNode") &&
+                l.Contains("migrated") &&
                 l.Contains("Flea Rocket") &&
                 l.Contains("pid=999") &&
                 l.Contains("8 points") &&
                 l.Contains("2 events"));
         }
 
-        // ───────── ClearPendingActiveStandalone tests ─────────
-
-        [Fact]
-        public void ClearPendingActiveStandalone_ClearsAllFields()
-        {
-            // Set up some state
-            var node = BuildStandaloneNode("Test", 42, 3, 1);
-            ParsekScenario.TryRestoreActiveStandaloneNode(node);
-            Assert.True(ParsekScenario.ScheduleActiveStandaloneRestoreOnFlightReady);
-
-            ParsekScenario.ClearPendingActiveStandalone();
-
-            Assert.False(ParsekScenario.ScheduleActiveStandaloneRestoreOnFlightReady);
-            Assert.Null(ParsekScenario.pendingActiveStandaloneRecording);
-            Assert.Null(ParsekScenario.pendingActiveStandaloneVesselName);
-            Assert.Equal(0u, ParsekScenario.pendingActiveStandaloneVesselPid);
-            Assert.Null(ParsekScenario.pendingActiveStandaloneRewindSave);
-        }
-
-        // ───────── Serialization round-trip test ─────────
+        // --------- Serialization round-trip test ---------
 
         [Fact]
         public void SaveAndRestore_RoundTrip_PreservesTrajectoryData()
         {
-            // Build a PARSEK_ACTIVE_STANDALONE node with known data
             var node = BuildStandaloneNode("RoundTrip Vessel", 12345, 15, 4,
                 startBody: "Mun", startBiome: "Highlands",
                 startSituation: "SubOrbital", launchSite: "Launch Pad",
                 rewindSave: "parsek_rw_test");
 
-            // Restore it
             ParsekScenario.TryRestoreActiveStandaloneNode(node);
 
-            var rec = ParsekScenario.pendingActiveStandaloneRecording;
+            var tree = RecordingStore.PendingTree;
+            Assert.NotNull(tree);
+            var rootId = tree.RootRecordingId;
+            var rec = tree.Recordings[rootId];
             Assert.Equal(15, rec.Points.Count);
             Assert.Equal(4, rec.PartEvents.Count);
             Assert.Equal("Mun", rec.StartBodyName);
             Assert.Equal("Highlands", rec.StartBiome);
             Assert.Equal("SubOrbital", rec.StartSituation);
             Assert.Equal("Launch Pad", rec.LaunchSiteName);
-            Assert.Equal("RoundTrip Vessel", ParsekScenario.pendingActiveStandaloneVesselName);
-            Assert.Equal(12345u, ParsekScenario.pendingActiveStandaloneVesselPid);
-            Assert.Equal("parsek_rw_test", ParsekScenario.pendingActiveStandaloneRewindSave);
+            Assert.Equal("RoundTrip Vessel", rec.VesselName);
+            Assert.Equal(12345u, rec.VesselPersistentId);
+            Assert.Equal("parsek_rw_test", ParsekScenario.pendingActiveTreeResumeRewindSave);
         }
 
         [Fact]
-        public void DoubleF5_SecondOverwritesFirst()
+        public void MigratedTree_HasCorrectActiveRecordingId()
         {
-            // First "F5" — 5 points
-            var node1 = BuildStandaloneNode("Test", 100, 5, 0);
-            ParsekScenario.TryRestoreActiveStandaloneNode(node1);
-            Assert.Equal(5, ParsekScenario.pendingActiveStandaloneRecording.Points.Count);
+            var node = BuildStandaloneNode("Test", 100, 5, 0);
 
-            // Clear and simulate second "F5" — 10 points (overwrites via new OnLoad)
-            ParsekScenario.ClearPendingActiveStandalone();
-            var node2 = BuildStandaloneNode("Test", 100, 10, 0);
-            ParsekScenario.TryRestoreActiveStandaloneNode(node2);
-            Assert.Equal(10, ParsekScenario.pendingActiveStandaloneRecording.Points.Count);
+            ParsekScenario.TryRestoreActiveStandaloneNode(node);
+
+            var tree = RecordingStore.PendingTree;
+            Assert.NotNull(tree);
+            Assert.Equal(tree.RootRecordingId, tree.ActiveRecordingId);
         }
 
-        // ───────── Helper ─────────
+        // --------- Helper ---------
 
         /// <summary>
         /// Builds a SCENARIO ConfigNode containing a PARSEK_ACTIVE_STANDALONE child

--- a/Source/Parsek.Tests/RecorderStateObservabilityTests.cs
+++ b/Source/Parsek.Tests/RecorderStateObservabilityTests.cs
@@ -533,26 +533,9 @@ namespace Parsek.Tests
         // ----- Integration phase-sequence test (the EVA + F5 + F9 repro walk) -----
 
         [Fact]
-        public void RecState_PhaseSequence_StandaloneToTreePromotionToQuickloadResume()
+        public void RecState_PhaseSequence_TreeRecordingToQuickloadResume()
         {
-            // Phase 1: standalone recording in flight
-            var snap1 = RecorderStateSnapshot.CaptureFromParts(
-                activeTree: null,
-                recorder: new FlightRecorder(),
-                pendingTree: null,
-                pendingTreeState: PendingTreeState.Finalized,
-                pendingStandalone: null,
-                pendingSplitRecorder: null,
-                pendingSplitInProgress: false,
-                chain: new ChainSegmentManager(),
-                currentUT: 17000.0,
-                loadedScene: GameScenes.FLIGHT);
-            ParsekLog.RecState("start-standalone", snap1);
-
-            // Phase 2: F5 quicksave taken
-            ParsekLog.RecState("OnSave:pre", snap1);
-
-            // Phase 3: tree promotion (e.g. EVA → tree branch)
+            // Phase 1: always-tree recording in flight (tree created at recording start)
             var tree = new RecordingTree
             {
                 Id = "treeXYZABCDEF",
@@ -565,46 +548,45 @@ namespace Parsek.Tests
                 VesselName = "Bob",
                 TreeId = tree.Id,
             };
-            var snap2 = RecorderStateSnapshot.CaptureFromParts(
+            var snap1 = RecorderStateSnapshot.CaptureFromParts(
                 tree, new FlightRecorder { ActiveTree = tree },
                 null, PendingTreeState.Finalized, null, null, false,
                 new ChainSegmentManager(),
-                17050.0, GameScenes.FLIGHT);
-            ParsekLog.RecState("PromoteToTreeForBreakup:exit", snap2);
+                17000.0, GameScenes.FLIGHT);
+            ParsekLog.RecState("start-tree", snap1);
 
-            // Phase 4: another F5 quicksave (now in tree mode)
-            ParsekLog.RecState("OnSave:pre", snap2);
+            // Phase 2: F5 quicksave taken
+            ParsekLog.RecState("OnSave:pre", snap1);
 
-            // Phase 5: scene change → StashTreeLimbo
-            var snap3 = RecorderStateSnapshot.CaptureFromParts(
+            // Phase 3: scene change -> StashTreeLimbo
+            var snap2 = RecorderStateSnapshot.CaptureFromParts(
                 tree, null, null, PendingTreeState.Finalized, null, null, false,
                 new ChainSegmentManager(),
                 17051.0, GameScenes.FLIGHT);
-            ParsekLog.RecState("StashTreeLimbo:pre", snap3);
+            ParsekLog.RecState("StashTreeLimbo:pre", snap2);
 
-            // Phase 6: F9 quickload → OnLoad sees tree restored to pending-Limbo
-            var snap4 = RecorderStateSnapshot.CaptureFromParts(
+            // Phase 4: F9 quickload -> OnLoad sees tree restored to pending-Limbo
+            var snap3 = RecorderStateSnapshot.CaptureFromParts(
                 null, null, tree, PendingTreeState.Limbo, null, null, false, null,
                 17050.0, GameScenes.FLIGHT);
-            ParsekLog.RecState("TryRestoreActiveTreeNode:stashed", snap4);
-            ParsekLog.RecState("OnLoad:limbo-dispatched", snap4);
+            ParsekLog.RecState("TryRestoreActiveTreeNode:stashed", snap3);
+            ParsekLog.RecState("OnLoad:limbo-dispatched", snap3);
 
-            // Phase 7: restore coroutine
-            ParsekLog.RecState("Restore:start", snap4);
-            ParsekLog.RecState("Restore:matched", snap4);
+            // Phase 5: restore coroutine
+            ParsekLog.RecState("Restore:start", snap3);
+            ParsekLog.RecState("Restore:matched", snap3);
 
-            // Phase 8: post-restore — back to live tree mode
-            var snap5 = RecorderStateSnapshot.CaptureFromParts(
+            // Phase 6: post-restore -- back to live tree mode
+            var snap4 = RecorderStateSnapshot.CaptureFromParts(
                 tree, new FlightRecorder { ActiveTree = tree }, null, PendingTreeState.Finalized,
                 null, null, false, new ChainSegmentManager(),
                 17050.5, GameScenes.FLIGHT);
-            ParsekLog.RecState("Restore:after-start", snap5);
+            ParsekLog.RecState("Restore:after-start", snap4);
 
-            // Verify: all 10 phases logged in order with strictly increasing sequence numbers
-            Assert.Equal(10, logLines.Count);
+            // Verify: all 8 phases logged in order with strictly increasing sequence numbers
+            Assert.Equal(8, logLines.Count);
             string[] expectedPhases = {
-                "start-standalone", "OnSave:pre", "PromoteToTreeForBreakup:exit",
-                "OnSave:pre", "StashTreeLimbo:pre",
+                "start-tree", "OnSave:pre", "StashTreeLimbo:pre",
                 "TryRestoreActiveTreeNode:stashed", "OnLoad:limbo-dispatched",
                 "Restore:start", "Restore:matched", "Restore:after-start"
             };
@@ -614,20 +596,18 @@ namespace Parsek.Tests
             }
 
             // Mode transitions visible at expected points
-            Assert.Contains("mode=sa", logLines[0]);   // start standalone
-            Assert.Contains("mode=sa", logLines[1]);   // OnSave:pre still standalone
-            Assert.Contains("mode=tree", logLines[2]); // promoted
-            Assert.Contains("mode=tree", logLines[3]); // OnSave in tree mode
-            Assert.Contains("mode=tree", logLines[4]); // stash tree pre (recorder gone but activeTree still set)
-            Assert.Contains("mode=none", logLines[5]); // OnLoad: only pending tree
-            Assert.Contains("mode=none", logLines[6]); // OnLoad limbo dispatch
-            Assert.Contains("mode=none", logLines[7]); // Restore start
-            Assert.Contains("mode=none", logLines[8]); // Restore matched (still in pending)
-            Assert.Contains("mode=tree", logLines[9]); // Restore after-start (live again)
+            Assert.Contains("mode=tree", logLines[0]); // start tree
+            Assert.Contains("mode=tree", logLines[1]); // OnSave:pre in tree mode
+            Assert.Contains("mode=tree", logLines[2]); // stash tree pre (recorder gone but activeTree still set)
+            Assert.Contains("mode=none", logLines[3]); // OnLoad: only pending tree
+            Assert.Contains("mode=none", logLines[4]); // OnLoad limbo dispatch
+            Assert.Contains("mode=none", logLines[5]); // Restore start
+            Assert.Contains("mode=none", logLines[6]); // Restore matched (still in pending)
+            Assert.Contains("mode=tree", logLines[7]); // Restore after-start (live again)
 
             // pend.tree=Limbo visible during the limbo phases
-            Assert.Contains("pend.tree=treeXYZA:Limbo", logLines[5]);
-            Assert.Contains("pend.tree=treeXYZA:Limbo", logLines[8]);
+            Assert.Contains("pend.tree=treeXYZA:Limbo", logLines[3]);
+            Assert.Contains("pend.tree=treeXYZA:Limbo", logLines[6]);
         }
     }
 }

--- a/Source/Parsek.Tests/RecordingOptimizerTests.cs
+++ b/Source/Parsek.Tests/RecordingOptimizerTests.cs
@@ -1025,8 +1025,11 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void RunOptimizationPass_SplitPreservesTreeId()
+        public void RunOptimizationPass_SkipsTreeRecordings()
         {
+            // Bug #271: tree recordings must not be split by the optimizer.
+            // The optimizer produces standalone chain recordings outside the tree
+            // structure, breaking ghost chain traversal. Tree splits deferred to T56.
             RecordingStore.SuppressLogging = true;
             RecordingStore.ResetForTesting();
 
@@ -1050,10 +1053,9 @@ namespace Parsek.Tests
 
             RecordingStore.RunOptimizationPass();
 
-            Assert.Equal(2, recordings.Count);
-            Assert.Equal("tree_001", recordings[0].TreeId);
-            Assert.Equal("tree_001", recordings[1].TreeId);
-            Assert.True(tree.Recordings.ContainsKey(recordings[1].RecordingId));
+            // Tree recording should NOT be split
+            Assert.Equal(1, recordings.Count);
+            Assert.Equal("rec_in_tree", recordings[0].RecordingId);
 
             RecordingStore.ResetForTesting();
         }
@@ -1082,8 +1084,9 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void RunOptimizationPass_SplitUpdatesBranchPointParentRecordingIds()
+        public void RunOptimizationPass_SkipsTreeRecordingsWithBranchPoints()
         {
+            // Bug #271: tree recordings with branch points must not be split.
             RecordingStore.SuppressLogging = true;
             RecordingStore.ResetForTesting();
 
@@ -1116,11 +1119,10 @@ namespace Parsek.Tests
 
             RecordingStore.RunOptimizationPass();
 
-            Assert.Equal(2, recordings.Count);
-            Assert.Null(recordings[0].ChildBranchPointId);
-            Assert.Equal("bp_001", recordings[1].ChildBranchPointId);
-            Assert.Single(bp.ParentRecordingIds);
-            Assert.Equal(recordings[1].RecordingId, bp.ParentRecordingIds[0]);
+            // Tree recording should NOT be split
+            Assert.Equal(1, recordings.Count);
+            Assert.Equal("parent_rec", recordings[0].RecordingId);
+            Assert.Equal("bp_001", recordings[0].ChildBranchPointId);
 
             RecordingStore.ResetForTesting();
         }
@@ -2078,8 +2080,9 @@ namespace Parsek.Tests
         /// - Debris recording is untouched
         /// </summary>
         [Fact]
-        public void RunOptimizationPass_TreeWithBranchPoint_SplitsCorrectly()
+        public void RunOptimizationPass_TreeWithBranchPoint_NotSplit()
         {
+            // Bug #271: tree recordings are skipped by the optimizer.
             RecordingStore.SuppressLogging = true;
             RecordingStore.ResetForTesting();
 
@@ -2171,59 +2174,21 @@ namespace Parsek.Tests
 
             RecordingStore.RunOptimizationPass();
 
-            // Should have 5 recordings: 4 from main split + 1 debris
-            // (surface leaf may be trimmed to minimal window but still exists)
-            Assert.True(recordings.Count >= 4, $"Expected at least 4 recordings, got {recordings.Count}");
+            // Bug #271: tree recordings should NOT be split — 2 recordings remain (main + debris)
+            Assert.Equal(2, recordings.Count);
 
-            // Find the chain segments (exclude debris)
-            var chain = new List<Recording>();
-            for (int i = 0; i < recordings.Count; i++)
-            {
-                if (recordings[i].RecordingId != "debris_rec")
-                    chain.Add(recordings[i]);
-            }
-            Assert.Equal(4, chain.Count);
-
-            // Verify chain indices are sequential
-            chain.Sort((a, b) => a.StartUT.CompareTo(b.StartUT));
-            for (int i = 0; i < chain.Count; i++)
-                Assert.Equal(i, chain[i].ChainIndex);
-
-            // All chain segments share the same ChainId
-            string chainId = chain[0].ChainId;
-            Assert.False(string.IsNullOrEmpty(chainId));
-            for (int i = 1; i < chain.Count; i++)
-                Assert.Equal(chainId, chain[i].ChainId);
-
-            // Verify segment phases
-            Assert.Equal("atmo", chain[0].SegmentPhase);
-            Assert.Equal("exo", chain[1].SegmentPhase);
-            Assert.Equal("approach", chain[2].SegmentPhase);
-            Assert.Equal("surface", chain[3].SegmentPhase);
-
-            // ChildBranchPointId should be on the LAST chain segment (temporal end)
-            Assert.Null(chain[0].ChildBranchPointId);
-            Assert.Null(chain[1].ChildBranchPointId);
-            Assert.Null(chain[2].ChildBranchPointId);
-            Assert.Equal("bp_staging", chain[3].ChildBranchPointId);
-
-            // BranchPoint.ParentRecordingIds should reference the last chain segment
-            Assert.Single(bp.ParentRecordingIds);
-            Assert.Equal(chain[3].RecordingId, bp.ParentRecordingIds[0]);
-
-            // All chain segments have correct TreeId
-            for (int i = 0; i < chain.Count; i++)
-                Assert.Equal("tree_mun", chain[i].TreeId);
+            // Main recording unchanged
+            var mainResult = recordings.Find(r => r.RecordingId == "main_rec");
+            Assert.NotNull(mainResult);
+            Assert.Equal("tree_mun", mainResult.TreeId);
+            Assert.Equal("bp_staging", mainResult.ChildBranchPointId);
+            Assert.Equal(14, mainResult.Points.Count);
 
             // Debris recording unchanged
             var debrisResult = recordings.Find(r => r.RecordingId == "debris_rec");
             Assert.NotNull(debrisResult);
             Assert.True(debrisResult.IsDebris);
             Assert.Equal("bp_staging", debrisResult.ParentBranchPointId);
-
-            // Tree dict updated with new recordings
-            Assert.True(tree.Recordings.Count >= 5,
-                $"Tree should have at least 5 recordings, got {tree.Recordings.Count}");
 
             RecordingStore.ResetForTesting();
         }

--- a/Source/Parsek.Tests/RuntimePolicyTests.cs
+++ b/Source/Parsek.Tests/RuntimePolicyTests.cs
@@ -617,8 +617,10 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void ClassifyVesselDestruction_StandaloneMerge()
+        public void ClassifyVesselDestruction_NoTree_ReturnsNone()
         {
+            // With always-tree mode, hasActiveTree=false never happens during recording.
+            // StandaloneMerge was removed — this input now returns None.
             var mode = ParsekFlight.ClassifyVesselDestruction(
                 hasActiveTree: false,
                 isRecording: true,
@@ -626,7 +628,7 @@ namespace Parsek.Tests
                 isActiveVessel: true,
                 shouldDeferForTree: false,
                 treeDestructionDialogPending: false);
-            Assert.Equal(ParsekFlight.DestructionMode.StandaloneMerge, mode);
+            Assert.Equal(ParsekFlight.DestructionMode.None, mode);
         }
 
         [Fact]

--- a/Source/Parsek.Tests/RuntimePolicyTests.cs
+++ b/Source/Parsek.Tests/RuntimePolicyTests.cs
@@ -46,11 +46,11 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void DecideOnVesselSwitch_DifferentPidEva_StartedAsVessel_Stops()
+        public void DecideOnVesselSwitch_DifferentPidEva_StartedAsVessel_TransitionsToBackground()
         {
             var decision = FlightRecorder.DecideOnVesselSwitch(
                 10u, 11u, currentIsEva: true, recordingStartedAsEva: false);
-            Assert.Equal(FlightRecorder.VesselSwitchDecision.Stop, decision);
+            Assert.Equal(FlightRecorder.VesselSwitchDecision.TransitionToBackground, decision);
         }
 
         [Fact]
@@ -62,11 +62,11 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void DecideOnVesselSwitch_DifferentPidNonEva_Stops()
+        public void DecideOnVesselSwitch_DifferentPidNonEva_TransitionsToBackground()
         {
             var decision = FlightRecorder.DecideOnVesselSwitch(
                 10u, 11u, currentIsEva: false, recordingStartedAsEva: false);
-            Assert.Equal(FlightRecorder.VesselSwitchDecision.Stop, decision);
+            Assert.Equal(FlightRecorder.VesselSwitchDecision.TransitionToBackground, decision);
         }
 
         [Theory]

--- a/Source/Parsek.Tests/SyntheticRecordingTests.cs
+++ b/Source/Parsek.Tests/SyntheticRecordingTests.cs
@@ -5133,124 +5133,124 @@ namespace Parsek.Tests
             double baseUT = ReadUTFromSave(targetPath);
 
             var writer = new ScenarioWriter().WithV3Format();
-            writer.AddRecording(PadWalk(baseUT).WithLoopPlayback()
+            writer.AddRecordingAsTree(PadWalk(baseUT).WithLoopPlayback()
                 .WithRecordingGroup("Synthetic"));
 
             // Pad-launch recordings — with rewind saves
-            writer.AddRecording(KscHopper(baseUT).WithLoopPlayback()
+            writer.AddRecordingAsTree(KscHopper(baseUT).WithLoopPlayback()
                 .WithRewindSave("parsek_rw_hop001").WithRecordingGroup("Synthetic"));
-            writer.AddRecording(FleaFlight(baseUT).WithLoopPlayback()
+            writer.AddRecordingAsTree(FleaFlight(baseUT).WithLoopPlayback()
                 .WithRewindSave("parsek_rw_flea01").WithRecordingGroup("Synthetic"));
-            writer.AddRecording(SuborbitalArc(baseUT).WithLoopPlayback()
+            writer.AddRecordingAsTree(SuborbitalArc(baseUT).WithLoopPlayback()
                 .WithRewindSave("parsek_rw_subo01").WithRecordingGroup("Synthetic"));
-            writer.AddRecording(KscPadDestroyed(baseUT).WithLoopPlayback()
+            writer.AddRecordingAsTree(KscPadDestroyed(baseUT).WithLoopPlayback()
                 .WithRewindSave("parsek_rw_dest01").WithRecordingGroup("Synthetic"));
-            writer.AddRecording(Orbit1(baseUT).WithLoopPlayback()
+            writer.AddRecordingAsTree(Orbit1(baseUT).WithLoopPlayback()
                 .WithRewindSave("parsek_rw_orb001").WithRecordingGroup("Synthetic"));
-            writer.AddRecording(CloseSpawnConflict(baseUT).WithLoopPlayback()
+            writer.AddRecordingAsTree(CloseSpawnConflict(baseUT).WithLoopPlayback()
                 .WithRecordingGroup("Synthetic"));
-            writer.AddRecording(IslandProbe(baseUT).WithLoopPlayback()
+            writer.AddRecordingAsTree(IslandProbe(baseUT).WithLoopPlayback()
                 .WithRewindSave("parsek_rw_isle01").WithRecordingGroup("Synthetic"));
 
             var lightShowcases = LightShowcaseRecordings(baseUT);
             for (int i = 0; i < lightShowcases.Length; i++)
-                writer.AddRecording(lightShowcases[i]);
+                writer.AddRecordingAsTree(lightShowcases[i]);
 
             var deployableShowcases = DeployableShowcaseRecordings(baseUT);
             for (int i = 0; i < deployableShowcases.Length; i++)
-                writer.AddRecording(deployableShowcases[i]);
+                writer.AddRecordingAsTree(deployableShowcases[i]);
 
             var gearShowcases = GearShowcaseRecordings(baseUT);
             for (int i = 0; i < gearShowcases.Length; i++)
-                writer.AddRecording(gearShowcases[i]);
+                writer.AddRecordingAsTree(gearShowcases[i]);
 
             var cargoBayShowcases = CargoBayShowcaseRecordings(baseUT);
             for (int i = 0; i < cargoBayShowcases.Length; i++)
-                writer.AddRecording(cargoBayShowcases[i]);
+                writer.AddRecordingAsTree(cargoBayShowcases[i]);
 
             var engineShowcases = EngineShowcaseRecordings(baseUT);
             for (int i = 0; i < engineShowcases.Length; i++)
-                writer.AddRecording(engineShowcases[i]);
+                writer.AddRecordingAsTree(engineShowcases[i]);
 
             var ladderShowcases = LadderShowcaseRecordings(baseUT);
             for (int i = 0; i < ladderShowcases.Length; i++)
-                writer.AddRecording(ladderShowcases[i]);
+                writer.AddRecordingAsTree(ladderShowcases[i]);
 
             var rcsShowcases = RcsShowcaseRecordings(baseUT);
             for (int i = 0; i < rcsShowcases.Length; i++)
-                writer.AddRecording(rcsShowcases[i]);
+                writer.AddRecordingAsTree(rcsShowcases[i]);
 
             var fairingShowcases = FairingShowcaseRecordings(baseUT);
             for (int i = 0; i < fairingShowcases.Length; i++)
-                writer.AddRecording(fairingShowcases[i]);
+                writer.AddRecordingAsTree(fairingShowcases[i]);
 
             var radiatorShowcases = RadiatorShowcaseRecordings(baseUT);
             for (int i = 0; i < radiatorShowcases.Length; i++)
-                writer.AddRecording(radiatorShowcases[i]);
+                writer.AddRecordingAsTree(radiatorShowcases[i]);
 
             var drillShowcases = DrillShowcaseRecordings(baseUT);
             for (int i = 0; i < drillShowcases.Length; i++)
-                writer.AddRecording(drillShowcases[i]);
+                writer.AddRecordingAsTree(drillShowcases[i]);
 
             var deployedScienceShowcases = DeployedScienceShowcaseRecordings(baseUT);
             for (int i = 0; i < deployedScienceShowcases.Length; i++)
-                writer.AddRecording(deployedScienceShowcases[i]);
+                writer.AddRecordingAsTree(deployedScienceShowcases[i]);
             var animationGroupShowcases = AnimationGroupShowcaseRecordings(baseUT);
             for (int i = 0; i < animationGroupShowcases.Length; i++)
-                writer.AddRecording(animationGroupShowcases[i]);
+                writer.AddRecordingAsTree(animationGroupShowcases[i]);
             var parachuteShowcases = ParachuteShowcaseRecordings(baseUT);
             for (int i = 0; i < parachuteShowcases.Length; i++)
-                writer.AddRecording(parachuteShowcases[i]);
+                writer.AddRecordingAsTree(parachuteShowcases[i]);
             var specialDeployAnimationShowcases = SpecialDeployAnimationShowcaseRecordings(baseUT);
             for (int i = 0; i < specialDeployAnimationShowcases.Length; i++)
-                writer.AddRecording(specialDeployAnimationShowcases[i]);
+                writer.AddRecordingAsTree(specialDeployAnimationShowcases[i]);
             var jettisonShowcases = JettisonShowcaseRecordings(baseUT);
             for (int i = 0; i < jettisonShowcases.Length; i++)
-                writer.AddRecording(jettisonShowcases[i]);
+                writer.AddRecordingAsTree(jettisonShowcases[i]);
             var roboticsShowcases = RoboticsShowcaseRecordings(baseUT);
             for (int i = 0; i < roboticsShowcases.Length; i++)
-                writer.AddRecording(roboticsShowcases[i]);
+                writer.AddRecordingAsTree(roboticsShowcases[i]);
             var aeroSurfaceShowcases = AeroSurfaceShowcaseRecordings(baseUT);
             for (int i = 0; i < aeroSurfaceShowcases.Length; i++)
-                writer.AddRecording(aeroSurfaceShowcases[i]);
+                writer.AddRecordingAsTree(aeroSurfaceShowcases[i]);
             var robotArmScannerShowcases = RobotArmScannerShowcaseRecordings(baseUT);
             for (int i = 0; i < robotArmScannerShowcases.Length; i++)
-                writer.AddRecording(robotArmScannerShowcases[i]);
+                writer.AddRecordingAsTree(robotArmScannerShowcases[i]);
             var controlSurfaceShowcases = ControlSurfaceShowcaseRecordings(baseUT);
             for (int i = 0; i < controlSurfaceShowcases.Length; i++)
-                writer.AddRecording(controlSurfaceShowcases[i]);
+                writer.AddRecordingAsTree(controlSurfaceShowcases[i]);
             var wheelDynamicsShowcases = WheelDynamicsShowcaseRecordings(baseUT);
             for (int i = 0; i < wheelDynamicsShowcases.Length; i++)
-                writer.AddRecording(wheelDynamicsShowcases[i]);
+                writer.AddRecordingAsTree(wheelDynamicsShowcases[i]);
             var animateHeatShowcases = AnimateHeatShowcaseRecordings(baseUT);
             for (int i = 0; i < animateHeatShowcases.Length; i++)
-                writer.AddRecording(animateHeatShowcases[i]);
+                writer.AddRecordingAsTree(animateHeatShowcases[i]);
             var colorChangerShowcases = ColorChangerShowcaseRecordings(baseUT);
             for (int i = 0; i < colorChangerShowcases.Length; i++)
-                writer.AddRecording(colorChangerShowcases[i]);
-            writer.AddRecording(InventoryPlacementShowcaseRecording(baseUT));
-            writer.AddRecording(FlagPlantShowcaseRecording(baseUT));
+                writer.AddRecordingAsTree(colorChangerShowcases[i]);
+            writer.AddRecordingAsTree(InventoryPlacementShowcaseRecording(baseUT));
+            writer.AddRecordingAsTree(FlagPlantShowcaseRecording(baseUT));
 
             var chainSegments = EvaBoardChain(baseUT);
             chainSegments[0].WithRewindSave("parsek_rw_evab01");
             for (int i = 0; i < chainSegments.Length; i++)
-                writer.AddRecording(chainSegments[i].WithLoopPlayback().WithRecordingGroup("Synthetic"));
+                writer.AddRecordingAsTree(chainSegments[i].WithLoopPlayback().WithRecordingGroup("Synthetic"));
             var walkChainSegments = EvaWalkChain(baseUT);
             walkChainSegments[0].WithRewindSave("parsek_rw_walk01");
             for (int i = 0; i < walkChainSegments.Length; i++)
-                writer.AddRecording(walkChainSegments[i].WithLoopPlayback().WithRecordingGroup("Synthetic"));
+                writer.AddRecordingAsTree(walkChainSegments[i].WithLoopPlayback().WithRecordingGroup("Synthetic"));
             var atmoChainSegments = KerbinAscentChain(baseUT);
             atmoChainSegments[0].WithRewindSave("parsek_rw_atmo01");
             for (int i = 0; i < atmoChainSegments.Length; i++)
-                writer.AddRecording(atmoChainSegments[i].WithLoopPlayback().WithRecordingGroup("Synthetic"));
+                writer.AddRecordingAsTree(atmoChainSegments[i].WithLoopPlayback().WithRecordingGroup("Synthetic"));
             var munTransferSegments = KerbinMunTransfer(baseUT);
             munTransferSegments[0].WithRewindSave("parsek_rw_mun001");
             for (int i = 0; i < munTransferSegments.Length; i++)
-                writer.AddRecording(munTransferSegments[i].WithLoopPlayback().WithRecordingGroup("Synthetic"));
+                writer.AddRecordingAsTree(munTransferSegments[i].WithLoopPlayback().WithRecordingGroup("Synthetic"));
 
-            writer.AddRecording(ReentryEast(baseUT).WithLoopPlayback().WithRecordingGroup("Synthetic"));
-            writer.AddRecording(ReentryShallow(baseUT).WithLoopPlayback().WithRecordingGroup("Synthetic"));
-            writer.AddRecording(ReentrySouth(baseUT).WithLoopPlayback().WithRecordingGroup("Synthetic"));
+            writer.AddRecordingAsTree(ReentryEast(baseUT).WithLoopPlayback().WithRecordingGroup("Synthetic"));
+            writer.AddRecordingAsTree(ReentryShallow(baseUT).WithLoopPlayback().WithRecordingGroup("Synthetic"));
+            writer.AddRecordingAsTree(ReentrySouth(baseUT).WithLoopPlayback().WithRecordingGroup("Synthetic"));
 
             // Add synthetic game actions so the Actions window has visible entries
             AddSyntheticGameActions(writer, baseUT);

--- a/Source/Parsek.Tests/VesselSwitchTreeTests.cs
+++ b/Source/Parsek.Tests/VesselSwitchTreeTests.cs
@@ -71,11 +71,11 @@ namespace Parsek.Tests
         #region DecideOnVesselSwitch with tree parameter
 
         [Fact]
-        public void DecideOnVesselSwitch_NoTree_SameAsLegacy_Stop()
+        public void DecideOnVesselSwitch_NoTree_FallbackTransitionToBackground()
         {
-            // No tree active, different PIDs -> Stop (legacy behavior)
+            // No tree active, different PIDs -> TransitionToBackground (fallback)
             var result = FlightRecorder.DecideOnVesselSwitch(100, 200, false, false, 0, activeTree: null);
-            Assert.Equal(FlightRecorder.VesselSwitchDecision.Stop, result);
+            Assert.Equal(FlightRecorder.VesselSwitchDecision.TransitionToBackground, result);
         }
 
         [Fact]
@@ -149,9 +149,9 @@ namespace Parsek.Tests
         [Fact]
         public void DecideOnVesselSwitch_TreeNull_DoesNotCrash()
         {
-            // Explicit null tree -> legacy behavior (Stop)
+            // Explicit null tree -> fallback TransitionToBackground
             var result = FlightRecorder.DecideOnVesselSwitch(100, 200, false, false, 0, activeTree: null);
-            Assert.Equal(FlightRecorder.VesselSwitchDecision.Stop, result);
+            Assert.Equal(FlightRecorder.VesselSwitchDecision.TransitionToBackground, result);
         }
 
         #endregion
@@ -219,7 +219,7 @@ namespace Parsek.Tests
             // This verifies that existing callers using the old 5-parameter signature
             // still compile and produce correct results (activeTree defaults to null)
             var result = FlightRecorder.DecideOnVesselSwitch(100, 200, false, false);
-            Assert.Equal(FlightRecorder.VesselSwitchDecision.Stop, result);
+            Assert.Equal(FlightRecorder.VesselSwitchDecision.TransitionToBackground, result);
         }
 
         [Fact]

--- a/Source/Parsek/BackgroundRecorder.cs
+++ b/Source/Parsek/BackgroundRecorder.cs
@@ -793,8 +793,8 @@ namespace Parsek
 
         /// <summary>
         /// Sets the debris TTL expiry for an externally-created debris recording.
-        /// Called by ParsekFlight when promoting a standalone recording to a tree
-        /// and adding debris child recordings.
+        /// Called by ParsekFlight.ProcessBreakupEvent when adding debris child
+        /// recordings to the active tree.
         /// </summary>
         public void SetDebrisExpiry(uint vesselPid, double expiryUT)
         {

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -4762,8 +4762,8 @@ namespace Parsek
         /// content-matching logic as RemoveLastEmittedTerminals. Used by callers that
         /// need to clean terminals from a COPY of the recorder's events (e.g.,
         /// CaptureAtStop.PartEvents) rather than the recorder's own live list.
-        /// Bug #299 — PromoteToTreeForBreakup bakes CaptureAtStop BEFORE the caller
-        /// can call RemoveLastEmittedTerminals on the recorder's internal list.
+        /// Bug #299 — CaptureAtStop may bake terminals before the caller can call
+        /// RemoveLastEmittedTerminals on the recorder's internal list.
         /// </summary>
         internal static int RemoveTerminalsFromList(List<PartEvent> targetList, List<PartEvent> terminals)
         {

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -18,12 +18,11 @@ namespace Parsek
         {
             None,
             ContinueOnEva,
-            Stop,
-            ChainToVessel,  // EVA recording → boarded a vessel
+            ChainToVessel,  // EVA recording -> boarded a vessel
             DockMerge,      // Vessel absorbed into dock target (pid changed)
             UndockSwitch,   // Player switched to undocked sibling vessel
-            TransitionToBackground,   // active recording → background (orbit segment)
-            PromoteFromBackground     // background recording → active (resume physics sampling)
+            TransitionToBackground,   // active recording -> background (orbit segment)
+            PromoteFromBackground     // background recording -> active (resume physics sampling)
         }
 
         // Recording output
@@ -5963,7 +5962,9 @@ namespace Parsek
             if (activeTree != null)
                 return VesselSwitchDecision.TransitionToBackground;
 
-            return VesselSwitchDecision.Stop;
+            // Safety fallback: with always-tree mode, activeTree is never null during recording.
+            // If somehow reached, default to background transition rather than stopping.
+            return VesselSwitchDecision.TransitionToBackground;
         }
     }
 }

--- a/Source/Parsek/MergeDialog.cs
+++ b/Source/Parsek/MergeDialog.cs
@@ -509,6 +509,26 @@ namespace Parsek
                     $"hasSnapshot={leaf.VesselSnapshot != null} canPersist={canPersist}");
             }
 
+            // Bug #271: in always-tree mode with breakup-continuous design, the active
+            // recording may be non-leaf (it has ChildBranchPointId from breakup branches)
+            // but is still the main vessel's recording that should be spawnable. Include
+            // it in decisions if it wasn't already covered as a leaf.
+            if (!string.IsNullOrEmpty(tree.ActiveRecordingId)
+                && !decisions.ContainsKey(tree.ActiveRecordingId))
+            {
+                Recording activeRec;
+                if (tree.Recordings.TryGetValue(tree.ActiveRecordingId, out activeRec))
+                {
+                    bool canPersist = CanPersistVessel(activeRec);
+                    decisions[activeRec.RecordingId] = canPersist;
+                    ParsekLog.Verbose("MergeDialog",
+                        $"BuildDefaultVesselDecisions: active-nonleaf='{activeRec.RecordingId}' " +
+                        $"vessel='{activeRec.VesselName}' " +
+                        $"terminal={activeRec.TerminalStateValue?.ToString() ?? "null"} " +
+                        $"hasSnapshot={activeRec.VesselSnapshot != null} canPersist={canPersist}");
+                }
+            }
+
             return decisions;
         }
 

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -1788,6 +1788,18 @@ namespace Parsek
             if (activeTree.Recordings.TryGetValue(parentRecordingId, out parentRec))
             {
                 AppendCapturedDataToRecording(parentRec, splitRecorder.CaptureAtStop, branchUT);
+
+                // Bug #271: in always-tree mode, the root recording was created without
+                // a snapshot. Copy from CaptureAtStop on the first split so the ghost
+                // mesh has vessel geometry instead of the sphere fallback.
+                if (parentRec.VesselSnapshot == null && splitRecorder.CaptureAtStop?.VesselSnapshot != null)
+                {
+                    parentRec.VesselSnapshot = splitRecorder.CaptureAtStop.VesselSnapshot.CreateCopy();
+                    parentRec.MarkFilesDirty();
+                    ParsekLog.Info("Flight",
+                        $"CreateSplitBranch: copied VesselSnapshot to parent '{parentRecordingId}' " +
+                        "from CaptureAtStop (always-tree root had no snapshot)");
+                }
             }
 
             // Set ChildBranchPointId on parent

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -4753,6 +4753,17 @@ namespace Parsek
                     VesselName = activeTree.TreeName,
                     RecordingFormatVersion = RecordingStore.CurrentRecordingFormatVersion
                 };
+                // Capture GhostVisualSnapshot at recording start — the FULL vessel
+                // before any staging or breakup events. This is the snapshot used for
+                // ghost mesh rendering. VesselSnapshot is captured later at stop/split
+                // time and may reflect a reduced part count.
+                if (FlightGlobals.ActiveVessel != null)
+                {
+                    var startSnap = VesselSpawner.TryBackupSnapshot(FlightGlobals.ActiveVessel);
+                    if (startSnap != null)
+                        rootRec.GhostVisualSnapshot = startSnap;
+                }
+
                 activeTree.Recordings[rootRecId] = rootRec;
 
                 backgroundRecorder = new BackgroundRecorder(activeTree);
@@ -4761,7 +4772,8 @@ namespace Parsek
 
                 ParsekLog.Info("Flight",
                     $"Always-tree: created single-node tree id={treeId}, root={rootRecId}, " +
-                    $"vessel={activeTree.TreeName} (pid={vesselPid})");
+                    $"vessel={activeTree.TreeName} (pid={vesselPid}), " +
+                    $"ghostSnap={rootRec.GhostVisualSnapshot != null}");
             }
 
             // Propagate tree mode to new recorder so DecideOnVesselSwitch uses tree decisions

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -5696,6 +5696,10 @@ namespace Parsek
             // Preserve snapshots for stable-terminal recordings (Landed/Splashed/Orbiting)
             // so the snapshot's sit field survives the save→load round-trip and the
             // spawn-at-end safety check doesn't block with "snapshot situation unsafe". (#289)
+            //
+            // Bug #271: preserve GhostVisualSnapshot before nulling VesselSnapshot so ghost
+            // rendering still has vessel geometry. Without this, the ghost mesh builder falls
+            // back to the green sphere for any recording whose VesselSnapshot was nulled here.
             foreach (var rec in activeTree.Recordings.Values)
             {
                 bool keepForSpawn = rec.TerminalStateValue.HasValue
@@ -5703,7 +5707,11 @@ namespace Parsek
                         || rec.TerminalStateValue.Value == TerminalState.Splashed
                         || rec.TerminalStateValue.Value == TerminalState.Orbiting);
                 if (!keepForSpawn)
+                {
+                    if (rec.GhostVisualSnapshot == null && rec.VesselSnapshot != null)
+                        rec.GhostVisualSnapshot = rec.VesselSnapshot.CreateCopy();
                     rec.VesselSnapshot = null;
+                }
             }
 
             // Stash as pending tree -- auto-committed ghost-only by ParsekScenario.OnLoad

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -5352,6 +5352,51 @@ namespace Parsek
                 recorder.BoundaryAnchor = chainManager.PendingBoundaryAnchor;
                 chainManager.PendingBoundaryAnchor = null;
             }
+
+            // Bug #271: always-tree mode. When no tree exists and this is not a
+            // chain continuation, wrap the new recording in a single-node tree.
+            // This eliminates the standalone/tree dual-path architecture — every
+            // recording is a tree recording, even single-vessel flights.
+            if (activeTree == null && !isContinuation)
+            {
+                string treeId = Guid.NewGuid().ToString("N");
+                string rootRecId = Guid.NewGuid().ToString("N");
+                uint vesselPid = FlightGlobals.ActiveVessel?.persistentId ?? 0;
+
+                activeTree = new RecordingTree
+                {
+                    Id = treeId,
+                    TreeName = Recording.ResolveLocalizedName(
+                        FlightGlobals.ActiveVessel?.vesselName) ?? "Unknown",
+                    RootRecordingId = rootRecId,
+                    ActiveRecordingId = rootRecId
+                };
+
+                activeTree.PreTreeFunds = Funding.Instance != null ? Funding.Instance.Funds : 0;
+                activeTree.PreTreeScience = ResearchAndDevelopment.Instance != null
+                    ? ResearchAndDevelopment.Instance.Science : 0;
+                activeTree.PreTreeReputation = Reputation.Instance != null
+                    ? Reputation.Instance.reputation : 0;
+
+                var rootRec = new Recording
+                {
+                    RecordingId = rootRecId,
+                    TreeId = treeId,
+                    VesselPersistentId = vesselPid,
+                    VesselName = activeTree.TreeName,
+                    RecordingFormatVersion = RecordingStore.CurrentRecordingFormatVersion
+                };
+                activeTree.Recordings[rootRecId] = rootRec;
+
+                backgroundRecorder = new BackgroundRecorder(activeTree);
+                backgroundRecorder.SubscribePartEvents();
+                Patches.PhysicsFramePatch.BackgroundRecorderInstance = backgroundRecorder;
+
+                ParsekLog.Info("Flight",
+                    $"Always-tree: created single-node tree id={treeId}, root={rootRecId}, " +
+                    $"vessel={activeTree.TreeName} (pid={vesselPid})");
+            }
+
             // Propagate tree mode to new recorder so DecideOnVesselSwitch uses tree decisions
             if (activeTree != null)
                 recorder.ActiveTree = activeTree;
@@ -5359,6 +5404,16 @@ namespace Parsek
             if (!recorder.IsRecording)
             {
                 ParsekLog.Warn("Flight", $"StartRecording blocked: {DetermineRecordingBlockReason()}");
+                // Bug #271: clean up single-node tree created above if StartRecording failed
+                if (activeTree != null && activeTree.Recordings.Count <= 1
+                    && backgroundRecorder != null)
+                {
+                    backgroundRecorder.Shutdown();
+                    Patches.PhysicsFramePatch.BackgroundRecorderInstance = null;
+                    backgroundRecorder = null;
+                    activeTree = null;
+                    ParsekLog.Info("Flight", "Cleaned up single-node tree after StartRecording failure");
+                }
                 return;
             }
 

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -1757,7 +1757,7 @@ namespace Parsek
 
         /// <summary>
         /// Creates a tree branch for a vessel split event.
-        /// If no tree exists yet, wraps the current recording as the root node.
+        /// Requires an active tree (always present in always-tree mode).
         /// Creates two child recordings (active + background), wires up BackgroundRecorder,
         /// and starts a new FlightRecorder for the active child.
         /// </summary>
@@ -2644,9 +2644,9 @@ namespace Parsek
 
         /// <summary>
         /// Processes a BREAKUP branch point emitted by the crash coalescer.
-        /// If an active tree exists, adds the BREAKUP event as a terminal-like marker
-        /// on the current recording segment. If no tree exists but a recorder is active,
-        /// promotes the standalone recording into a tree to enable debris tracking.
+        /// Adds the BREAKUP event as a branch point on the active tree recording and
+        /// creates child recordings for debris and controlled vessels.
+        /// If no active tree exists, the breakup is not recorded.
         /// </summary>
         void ProcessBreakupEvent(BranchPoint breakupBp)
         {

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -5477,11 +5477,17 @@ namespace Parsek
             // (edge case: late OnLoad timing, non-FLIGHT destination), this pre-capture
             // ensures the merge dialog can still offer respawn for stable-terminal leaves.
             // Only fills null snapshots — does NOT overwrite existing ones.
+            //
+            // Bug #271: also capture for the active recording even if non-leaf. In
+            // always-tree mode with breakup-continuous design, the active recording
+            // may have ChildBranchPointId set but still needs a snapshot for spawn-at-end.
             int snapshotsCaptured = 0;
+            string activeRecId = activeTree.ActiveRecordingId;
             foreach (var kvp in activeTree.Recordings)
             {
                 var rec = kvp.Value;
-                if (rec.ChildBranchPointId != null) continue;
+                bool isActiveRec = rec.RecordingId == activeRecId;
+                if (rec.ChildBranchPointId != null && !isActiveRec) continue;
                 if (rec.VesselPersistentId == 0) continue;
 
                 Vessel v = FlightRecorder.FindVesselByPid(rec.VesselPersistentId);

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -2685,13 +2685,21 @@ namespace Parsek
             // The recording continues past breakup (breakup-continuous design), so the
             // spawn snapshot must show the surviving vessel, not the pre-breakup config.
             // Without this, spawning materializes the full pre-breakup rocket. (#224)
+            //
+            // Bug #271: in always-tree mode, the tree recording's trajectory points are
+            // still in the recorder buffer (not flushed to the Recording object), so
+            // SnapshotVessel's Points.Count==0 guard would skip the snapshot. Use
+            // TryBackupSnapshot directly — the distance calculation is not needed for
+            // a mid-flight snapshot refresh.
             Vessel activeVessel = FlightGlobals.ActiveVessel;
             if (activeVessel != null && activeVessel.persistentId == activeRec.VesselPersistentId)
             {
-                VesselSpawner.SnapshotVessel(activeRec, false);
+                var snap = VesselSpawner.TryBackupSnapshot(activeVessel);
+                if (snap != null)
+                    activeRec.VesselSnapshot = snap;
                 ParsekLog.Info("Coalescer",
                     $"ProcessBreakupEvent: refreshed VesselSnapshot post-breakup " +
-                    $"(parts={activeVessel.parts?.Count ?? 0})");
+                    $"(parts={activeVessel.parts?.Count ?? 0}, snapshot={snap != null})");
             }
 
             // Bug #298: snapshot active recorder's engine/RCS state for child recordings.

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -927,10 +927,6 @@ namespace Parsek
             if (activeTree != null)
                 FinalizeTreeOnSceneChange(scene);
 
-            // If we have recording data and are leaving flight, stash it
-            if (recorder != null && recorder.Recording.Count > 0)
-                StashPendingOnSceneChange();
-
             // Stop manual playback
             StopPlayback();
             DestroyAllTimelineGhosts();
@@ -1052,143 +1048,6 @@ namespace Parsek
             activeTree = null;
         }
 
-        private void StashPendingOnSceneChange()
-        {
-            ParsekLog.RecState("StashPendingOnSceneChange:entry", CaptureRecorderState());
-            bool wasDestroyed = recorder.VesselDestroyedDuringRecording;
-
-            // Stop recording if active
-            if (recorder.IsRecording)
-                recorder.ForceStop();
-
-            var captured = recorder.CaptureAtStop;
-            // #304: prefer CaptureAtStop.VesselName (already resolved by BuildCaptureRecording),
-            // resolve fallback to avoid raw #autoLOC keys in recording VesselName.
-            string vesselName = captured?.VesselName
-                ?? (FlightGlobals.ActiveVessel != null
-                    ? Recording.ResolveLocalizedName(FlightGlobals.ActiveVessel.vesselName)
-                    : "Unknown Vessel");
-
-            // #305: stash with Limbo state on FLIGHT->FLIGHT transitions so the recording
-            // survives DiscardStashedOnQuickload and can be dispatched by OnLoad (parallel
-            // to tree Limbo pattern). On non-FLIGHT destinations, use Finalized (existing behavior).
-            var stashState = RecordingStore.PendingDestinationScene == GameScenes.FLIGHT
-                ? PendingStandaloneState.Limbo
-                : PendingStandaloneState.Finalized;
-
-            RecordingStore.StashPending(
-                recorder.Recording,
-                vesselName,
-                recorder.OrbitSegments,
-                recordingId: captured != null ? captured.RecordingId : null,
-                recordingFormatVersion: captured != null ? (int?)captured.RecordingFormatVersion : null,
-                partEvents: recorder.PartEvents,
-                flagEvents: recorder.FlagEvents,
-                state: stashState);
-
-            // Use stop-time atomic capture when available; fallback to scene-change capture.
-            // ApplyPersistenceArtifactsFrom copies chain/ParentRecordingId/EvaCrewName from
-            // CaptureAtStop on the normal path (StopRecording tagged them there).
-            if (captured != null)
-            {
-                var pending = RecordingStore.Pending;
-                pending.ApplyPersistenceArtifactsFrom(captured);
-                pending.CopyStartLocationFrom(captured);
-                Log("Applied stop-time snapshot/geometry artifacts to pending recording");
-            }
-            else
-            {
-                ApplyFallbackSnapshotAndMetadata(wasDestroyed);
-            }
-
-            // Clear chain fields after both paths have consumed them
-            chainManager.ClearChainIdentity();
-
-            // Capture vessel situation + PersistentId on the pending recording.
-            CaptureSceneExitState(wasDestroyed);
-
-            recorder = null;
-            lastPlaybackIndex = 0;
-            ParsekLog.RecState("StashPendingOnSceneChange:post", CaptureRecorderState());
-        }
-
-        /// <summary>
-        /// Fallback snapshot path when CaptureAtStop is null (ForceStop).
-        /// Captures vessel snapshot, applies chain metadata, copies rewind fields,
-        /// and tags segment phase.
-        /// </summary>
-        private void ApplyFallbackSnapshotAndMetadata(bool wasDestroyed)
-        {
-            // Snapshot vessel for persistence across revert.
-            VesselSpawner.SnapshotVessel(
-                RecordingStore.Pending,
-                wasDestroyed,
-                destroyedFallbackSnapshot: recorder.InitialGhostVisualSnapshot ?? recorder.LastGoodVesselSnapshot);
-            RecordingStore.Pending.GhostVisualSnapshot = recorder.InitialGhostVisualSnapshot != null
-                ? recorder.InitialGhostVisualSnapshot.CreateCopy()
-                : (RecordingStore.Pending.VesselSnapshot != null
-                    ? RecordingStore.Pending.VesselSnapshot.CreateCopy()
-                    : null);
-
-            // Fallback path (ForceStop): CaptureAtStop is null, so
-            // ApplyPersistenceArtifactsFrom didn't run. Apply chain
-            // metadata directly from the active fields.
-            if (RecordingStore.HasPending)
-                chainManager.ApplyChainMetadataTo(RecordingStore.Pending);
-
-            // Copy rewind fields from recorder (ForceStop bypasses ApplyPersistenceArtifactsFrom)
-            if (RecordingStore.HasPending)
-            {
-                RecordingStore.Pending.RewindSaveFileName = recorder.RewindSaveFileName;
-                RecordingStore.Pending.RewindReservedFunds = recorder.RewindReservedFunds;
-                RecordingStore.Pending.RewindReservedScience = recorder.RewindReservedScience;
-                RecordingStore.Pending.RewindReservedRep = recorder.RewindReservedRep;
-            }
-
-            // Tag segment phase in fallback path
-            if (RecordingStore.HasPending && string.IsNullOrEmpty(RecordingStore.Pending.SegmentPhase))
-            {
-                TagSegmentPhaseIfMissing(RecordingStore.Pending, FlightGlobals.ActiveVessel);
-                if (!string.IsNullOrEmpty(RecordingStore.Pending.SegmentPhase))
-                    ParsekLog.Verbose("Flight", $"Final segment tagged (ForceStop): " +
-                        $"{RecordingStore.Pending.SegmentBodyName} {RecordingStore.Pending.SegmentPhase}");
-            }
-        }
-
-        /// <summary>
-        /// Captures vessel situation, PersistentId, and terminal state on the pending recording.
-        /// VesselPersistentId is a safety net; SceneExitSituation + TerminalState enable
-        /// auto-commit by ParsekScenario on non-revert scene exits.
-        /// </summary>
-        private void CaptureSceneExitState(bool wasDestroyed)
-        {
-            if (!RecordingStore.HasPending)
-                return;
-
-            RecordingStore.Pending.VesselPersistentId = recorder.RecordingVesselId;
-
-            if (FlightGlobals.ActiveVessel != null)
-            {
-                var sit = FlightGlobals.ActiveVessel.situation;
-                RecordingStore.Pending.SceneExitSituation = (int)sit;
-                RecordingStore.Pending.TerminalStateValue =
-                    RecordingTree.DetermineTerminalState((int)sit, FlightGlobals.ActiveVessel);
-                CaptureTerminalOrbit(RecordingStore.Pending, FlightGlobals.ActiveVessel);
-                CaptureTerminalPosition(RecordingStore.Pending, FlightGlobals.ActiveVessel);
-            }
-
-            // Fallback: if the vessel was destroyed during recording,
-            // override whatever situation-based terminal state was set.
-            // Covers two cases:
-            // 1. ActiveVessel null (building collision destroyed the only
-            //    vessel, triggering scene change before
-            //    ShowPostDestructionMergeDialog could run) — TerminalState is null.
-            // 2. ActiveVessel switched to debris/other vessel with a
-            //    non-Destroyed situation (e.g., LANDED) — TerminalState is
-            //    wrong (Landed instead of Destroyed).
-            ApplyDestroyedFallback(wasDestroyed, RecordingStore.Pending);
-        }
-
         void OnVesselWillDestroy(Vessel v)
         {
             if (v != null && GhostMapPresence.IsGhostMapVessel(v.persistentId)) return;
@@ -1243,9 +1102,6 @@ namespace Parsek
                     StartCoroutine(DeferredDestructionCheck(pending));
                     break;
                 }
-                case DestructionMode.StandaloneMerge:
-                    StartCoroutine(ShowPostDestructionMergeDialog());
-                    break;
                 case DestructionMode.TreeAllLeavesCheck:
                     treeDestructionDialogPending = true;
                     ParsekLog.Info("Flight", "Active vessel destroyed in tree mode — scheduling tree destruction check");
@@ -1277,177 +1133,6 @@ namespace Parsek
                     Log($"Undock continuation vessel destroyed (pid={chainManager.UndockContinuationPid})");
                 }
                 chainManager.StopUndockContinuation("vessel destroyed");
-            }
-        }
-
-        /// <summary>
-        /// Coroutine that shows a merge dialog after a vessel is destroyed during standalone recording.
-        /// Waits 2 seconds to avoid overlapping with mission results / flight log.
-        /// </summary>
-        IEnumerator ShowPostDestructionMergeDialog()
-        {
-            ParsekLog.RecState("ShowPostDestructionMergeDialog:entry", CaptureRecorderState());
-
-            // Wait one frame to let the destruction sequence complete.
-            // The Harmony patch on FlightResultsDialog.Display suppresses KSP's
-            // crash report until the merge dialog is resolved — no hardcoded delay needed.
-            yield return null;
-
-            // (#218) Wait for crash coalescer before stopping recorder.
-            // TickCrashCoalescer runs each Update frame. Once the 0.5s window expires,
-            // it emits BREAKUP → ProcessBreakupEvent sees recorder alive →
-            // PromoteToTreeForBreakup creates a tree with debris child recordings.
-            if (crashCoalescer != null && crashCoalescer.HasPendingBreakup)
-            {
-                ParsekLog.Info("Flight",
-                    "ShowPostDestructionMergeDialog: waiting for crash coalescer");
-                float coalescerWaitStart = Time.unscaledTime;
-                while (crashCoalescer.HasPendingBreakup)
-                {
-                    if (Time.unscaledTime - coalescerWaitStart > 5f)
-                    {
-                        ParsekLog.Warn("Flight",
-                            "ShowPostDestructionMergeDialog: coalescer wait timed out (5s real-time)");
-                        crashCoalescer.Reset();
-                        break;
-                    }
-                    yield return null;
-                }
-
-                // PromoteToTreeForBreakup created a tree — hand off to tree handler.
-                // Mark continuation recorder as vessel-destroyed: PromoteToTreeForBreakup
-                // starts a new recorder that never saw OnVesselWillDestroy, so its
-                // VesselDestroyedDuringRecording is false. Without this,
-                // ShowPostDestructionTreeMergeDialog's guard would incorrectly abort.
-                if (activeTree != null)
-                {
-                    if (recorder != null)
-                        recorder.VesselDestroyedDuringRecording = true;
-                    ParsekLog.Info("Flight",
-                        "ShowPostDestructionMergeDialog: coalescer promoted to tree — " +
-                        "redirecting to tree destruction handler");
-                    treeDestructionDialogPending = true;
-                    StartCoroutine(ShowPostDestructionTreeMergeDialog());
-                    yield break;
-                }
-                // If activeTree is null, PromoteToTreeForBreakup failed (CaptureAtStop null)
-                // and FallbackCommitSplitRecorder handled the data. Fall through to existing
-                // guards — recorder-null or HasPending will exit cleanly.
-            }
-
-            // Guard: only proceed if recorder still exists and vessel was destroyed
-            if (recorder == null || !recorder.VesselDestroyedDuringRecording)
-            {
-                ParsekLog.Warn("Flight", "ShowPostDestructionMergeDialog skipped: recorder null or vessel not destroyed");
-                yield break;
-            }
-
-            // Guard: only for standalone recordings (tree mode has its own handling)
-            if (activeTree != null)
-            {
-                ParsekLog.Warn("Flight", "ShowPostDestructionMergeDialog skipped: activeTree present (tree mode handles destruction)");
-                yield break;
-            }
-
-            if (recorder.Recording.Count == 0)
-            {
-                ParsekLog.Warn("Flight", "ShowPostDestructionMergeDialog skipped: recording count is 0");
-                yield break;
-            }
-
-            // Guard: if OnSceneChangeRequested already stashed a pending, don't double-stash
-            if (RecordingStore.HasPending)
-            {
-                ParsekLog.Warn("Flight", "ShowPostDestructionMergeDialog skipped: HasPending already set");
-                yield break;
-            }
-
-            Log("Post-destruction: stopping recorder and stashing pending recording");
-
-            // Stop recording
-            if (recorder.IsRecording)
-                recorder.ForceStop();
-
-            // #304: CaptureAtStop.VesselName is already resolved; resolve fallback too.
-            // #305: Finalized (not Limbo) — vessel destruction is a terminal event, the
-            // recording is complete and ready for the merge dialog regardless of scene target.
-            string vesselName = recorder.CaptureAtStop?.VesselName
-                ?? (FlightGlobals.ActiveVessel != null
-                    ? Recording.ResolveLocalizedName(FlightGlobals.ActiveVessel.vesselName)
-                    : "Unknown Vessel");
-
-            var captured = recorder.CaptureAtStop;
-            RecordingStore.StashPending(
-                recorder.Recording,
-                vesselName,
-                recorder.OrbitSegments,
-                recordingId: captured != null ? captured.RecordingId : null,
-                recordingFormatVersion: captured != null ? (int?)captured.RecordingFormatVersion : null,
-                partEvents: recorder.PartEvents,
-                flagEvents: recorder.FlagEvents);
-
-            if (captured != null)
-            {
-                RecordingStore.Pending.ApplyPersistenceArtifactsFrom(captured);
-                RecordingStore.Pending.StartBodyName = captured.StartBodyName;
-                RecordingStore.Pending.StartBiome = captured.StartBiome;
-                RecordingStore.Pending.StartSituation = captured.StartSituation;
-                RecordingStore.Pending.LaunchSiteName = captured.LaunchSiteName;
-            }
-            else
-            {
-                VesselSpawner.SnapshotVessel(
-                    RecordingStore.Pending,
-                    true, // destroyed
-                    destroyedFallbackSnapshot: recorder.InitialGhostVisualSnapshot ?? recorder.LastGoodVesselSnapshot);
-                RecordingStore.Pending.GhostVisualSnapshot = recorder.InitialGhostVisualSnapshot != null
-                    ? recorder.InitialGhostVisualSnapshot.CreateCopy()
-                    : null;
-
-                // Copy rewind fields from recorder (ForceStop bypasses ApplyPersistenceArtifactsFrom)
-                RecordingStore.Pending.RewindSaveFileName = recorder.RewindSaveFileName;
-                RecordingStore.Pending.RewindReservedFunds = recorder.RewindReservedFunds;
-                RecordingStore.Pending.RewindReservedScience = recorder.RewindReservedScience;
-                RecordingStore.Pending.RewindReservedRep = recorder.RewindReservedRep;
-            }
-
-            // Set terminal state
-            if (RecordingStore.HasPending)
-            {
-                RecordingStore.Pending.VesselPersistentId = recorder.RecordingVesselId;
-                RecordingStore.Pending.TerminalStateValue = TerminalState.Destroyed;
-            }
-
-            recorder = null;
-            lastPlaybackIndex = 0;
-
-            // Auto-discard pad failures: destroyed within 10s AND never moved far from spawn.
-            // Real crashes travel 30+ meters; pad failures stay near the pad.
-            if (RecordingStore.HasPending)
-            {
-                double flightDuration = RecordingStore.Pending.EndUT - RecordingStore.Pending.StartUT;
-                double maxDist = RecordingStore.Pending.MaxDistanceFromLaunch;
-                if (IsPadFailure(flightDuration, maxDist))
-                {
-                    Log($"Post-destruction: pad failure ({flightDuration:F1}s, {maxDist:F0}m) — auto-discarding");
-                    ScreenMessage("Recording discarded — pad failure", 3f);
-                    RecordingStore.DiscardPending();
-                    yield break;
-                }
-                if (IsIdleOnPad(maxDist))
-                {
-                    Log($"Post-destruction: idle on pad (maxDist={maxDist:F1}m) — auto-discarding");
-                    ScreenMessage("Recording discarded — vessel idle on pad", 3f);
-                    RecordingStore.DiscardPending();
-                    yield break;
-                }
-            }
-
-            // Show merge dialog
-            if (RecordingStore.HasPending)
-            {
-                Log("Post-destruction: commit or dialog");
-                CommitOrShowDialog(RecordingStore.Pending);
             }
         }
 
@@ -2088,96 +1773,21 @@ namespace Parsek
 
             var splitRecorder = pendingSplitRecorder;
 
-            // Determine parent recording ID
-            string parentRecordingId;
+            // Use the current active recording as parent
+            string parentRecordingId = activeTree.ActiveRecordingId;
 
-            // First split: create the tree and wrap current recording as root
-            if (activeTree == null)
+            if (parentRecordingId == null)
             {
-                string treeId = Guid.NewGuid().ToString("N");
-                string rootRecId = Guid.NewGuid().ToString("N");
-
-                activeTree = new RecordingTree
-                {
-                    Id = treeId,
-                    TreeName = splitRecorder.CaptureAtStop?.VesselName
-                               ?? Recording.ResolveLocalizedName(activeVessel?.vesselName) ?? "Unknown",
-                    RootRecordingId = rootRecId,
-                    ActiveRecordingId = null // will be set below
-                };
-
-                // Capture pre-tree resources from the recorder
-                activeTree.PreTreeFunds = splitRecorder.PreLaunchFunds;
-                activeTree.PreTreeScience = splitRecorder.PreLaunchScience;
-                activeTree.PreTreeReputation = splitRecorder.PreLaunchReputation;
-
-                // Create root recording from captured data
-                var rootRec = new Recording
-                {
-                    RecordingId = rootRecId,
-                    TreeId = treeId,
-                    VesselPersistentId = splitRecorder.RecordingVesselId,
-                    VesselName = splitRecorder.CaptureAtStop?.VesselName ?? "Unknown",
-                    ExplicitEndUT = branchUT
-                };
-
-                // Copy captured data into root recording
-                if (splitRecorder.CaptureAtStop != null)
-                {
-                    rootRec.Points = new List<TrajectoryPoint>(splitRecorder.CaptureAtStop.Points);
-                    rootRec.OrbitSegments = new List<OrbitSegment>(splitRecorder.CaptureAtStop.OrbitSegments);
-                    rootRec.PartEvents = new List<PartEvent>(splitRecorder.CaptureAtStop.PartEvents);
-                    rootRec.FlagEvents = new List<FlagEvent>(splitRecorder.CaptureAtStop.FlagEvents);
-                    rootRec.SegmentEvents = new List<SegmentEvent>(splitRecorder.CaptureAtStop.SegmentEvents);
-                    rootRec.TrackSections = new List<TrackSection>(splitRecorder.CaptureAtStop.TrackSections);
-                    rootRec.GhostVisualSnapshot = splitRecorder.CaptureAtStop.GhostVisualSnapshot;
-                    rootRec.VesselSnapshot = splitRecorder.CaptureAtStop.VesselSnapshot;
-                    rootRec.RewindSaveFileName = splitRecorder.CaptureAtStop.RewindSaveFileName;
-                    rootRec.RewindReservedFunds = splitRecorder.CaptureAtStop.RewindReservedFunds;
-                    rootRec.RewindReservedScience = splitRecorder.CaptureAtStop.RewindReservedScience;
-                    rootRec.RewindReservedRep = splitRecorder.CaptureAtStop.RewindReservedRep;
-                    rootRec.StartBodyName = splitRecorder.CaptureAtStop.StartBodyName;
-                    rootRec.StartBiome = splitRecorder.CaptureAtStop.StartBiome;
-                    rootRec.StartSituation = splitRecorder.CaptureAtStop.StartSituation;
-                    rootRec.LaunchSiteName = splitRecorder.CaptureAtStop.LaunchSiteName;
-                    if (rootRec.Points.Count > 0)
-                        rootRec.ExplicitStartUT = rootRec.Points[0].ut;
-                    // Mark dirty so the captured trajectory reaches disk on the
-                    // next OnSave. Mirror of the PromoteToTreeForBreakup fix —
-                    // same quickload-resume data-loss hole. See CHANGELOG
-                    // 2026-04-09 bug #273.
-                    rootRec.MarkFilesDirty();
-                }
-
-                activeTree.Recordings[rootRecId] = rootRec;
-                parentRecordingId = rootRecId;
-
-                // Create BackgroundRecorder
-                backgroundRecorder = new BackgroundRecorder(activeTree);
-                backgroundRecorder.SubscribePartEvents();
-                Patches.PhysicsFramePatch.BackgroundRecorderInstance = backgroundRecorder;
-
-                ParsekLog.Info("Flight", $"Tree created: id={treeId}, root={rootRecId}, " +
-                    $"vesselPid={splitRecorder.RecordingVesselId}");
+                ParsekLog.Warn("Flight", "CreateSplitBranch: no active recording in existing tree — aborting");
+                FallbackCommitSplitRecorder(splitRecorder);
+                return;
             }
-            else
+
+            // Flush captured data into the existing tree recording
+            Recording parentRec;
+            if (activeTree.Recordings.TryGetValue(parentRecordingId, out parentRec))
             {
-                // Subsequent split: use the current active recording as parent
-                parentRecordingId = activeTree.ActiveRecordingId;
-
-                if (parentRecordingId == null)
-                {
-                    ParsekLog.Warn("Flight", "CreateSplitBranch: no active recording in existing tree — aborting");
-                    FallbackCommitSplitRecorder(splitRecorder);
-                    return;
-                }
-
-                // Flush captured data into the existing tree recording
-                Recording parentRec;
-                if (activeTree.Recordings.TryGetValue(parentRecordingId, out parentRec))
-                {
-                    AppendCapturedDataToRecording(parentRec, splitRecorder.CaptureAtStop, branchUT);
-                }
+                AppendCapturedDataToRecording(parentRec, splitRecorder.CaptureAtStop, branchUT);
             }
 
             // Set ChildBranchPointId on parent
@@ -3042,13 +2652,8 @@ namespace Parsek
         {
             if (activeTree == null)
             {
-                if (recorder != null && recorder.IsRecording)
-                {
-                    PromoteToTreeForBreakup(breakupBp);
-                    return; // promotion handled everything including BREAKUP wiring
-                }
                 ParsekLog.Info("Coalescer",
-                    "ProcessBreakupEvent: no active tree and no active recorder — breakup not recorded. " +
+                    "ProcessBreakupEvent: no active tree — breakup not recorded. " +
                     $"cause={breakupBp.BreakupCause}, debris={breakupBp.DebrisCount}");
                 return;
             }
@@ -3095,7 +2700,7 @@ namespace Parsek
                 ? InheritedEngineState.FromRecorder(recorder) : null;
 
             // Create child recording segments for controlled children (vessels with probe
-            // cores that survive the breakup). Same pattern as PromoteToTreeForBreakup step 8.
+            // cores that survive the breakup).
             // These are NOT debris — they record indefinitely (no TTL) and can serve as
             // RELATIVE anchors during playback.
             var controlledChildren = crashCoalescer.LastEmittedControlledChildPids;
@@ -3168,253 +2773,6 @@ namespace Parsek
                 $"duration={breakupBp.BreakupDuration:F3}s");
         }
 
-        /// <summary>
-        /// Promotes a standalone recording to a tree when a BREAKUP fires without an active tree.
-        /// Stops the current recorder, creates a tree with root recording from CaptureAtStop,
-        /// creates a continuation recording for the active vessel, creates child recordings for
-        /// debris and controlled children, and starts a new FlightRecorder in tree mode.
-        /// </summary>
-        void PromoteToTreeForBreakup(BranchPoint breakupBp)
-        {
-            ParsekLog.RecState("PromoteToTreeForBreakup:entry", CaptureRecorderState());
-
-            // 1. Stop recorder to capture all accumulated data
-            recorder.StopRecordingForChainBoundary();
-            var splitRecorder = recorder;
-            recorder = null;
-
-            // Bug #298: snapshot parent engine/RCS state for child recordings.
-            // activeEngineKeys/lastThrottle survive StopRecordingForChainBoundary
-            // (FinalizeRecordingState does not clear them).
-            InheritedEngineState? splitEngineState = InheritedEngineState.FromRecorder(splitRecorder);
-            ParsekLog.Verbose("Coalescer",
-                $"PromoteToTreeForBreakup: inherited engine state snapshot: " +
-                $"engines={splitEngineState?.activeEngineKeys?.Count ?? 0} " +
-                $"rcs={splitEngineState?.activeRcsKeys?.Count ?? 0} " +
-                $"(null={!splitEngineState.HasValue})");
-
-            // Bug #299: remove terminal EngineShutdown/RCSStop events from CaptureAtStop.
-            // StopRecordingForChainBoundary bakes CaptureAtStop with terminals already in
-            // PartEvents. RemoveLastEmittedTerminals would clean the recorder's internal
-            // list, but CaptureAtStop.PartEvents is a separate copy. Remove from the copy
-            // directly using the saved lastEmittedTerminalEvents.
-            if (splitRecorder.CaptureAtStop != null && splitRecorder.lastEmittedTerminalEvents != null)
-            {
-                int cleanedTerminals = FlightRecorder.RemoveTerminalsFromList(
-                    splitRecorder.CaptureAtStop.PartEvents, splitRecorder.lastEmittedTerminalEvents);
-                if (cleanedTerminals > 0)
-                    ParsekLog.Info("Coalescer",
-                        $"PromoteToTreeForBreakup: removed {cleanedTerminals} terminal event(s) " +
-                        $"from CaptureAtStop (#299)");
-            }
-
-            if (splitRecorder.CaptureAtStop == null)
-            {
-                ParsekLog.Warn("Coalescer",
-                    "PromoteToTreeForBreakup: no CaptureAtStop data — cannot promote");
-                FallbackCommitSplitRecorder(splitRecorder);
-                return;
-            }
-
-            // 2. Create tree (same pattern as CreateSplitBranch lines 1483-1537)
-            string treeId = Guid.NewGuid().ToString("N");
-            string rootRecId = Guid.NewGuid().ToString("N");
-
-            activeTree = new RecordingTree
-            {
-                Id = treeId,
-                TreeName = splitRecorder.CaptureAtStop.VesselName
-                           ?? Recording.ResolveLocalizedName(FlightGlobals.ActiveVessel?.vesselName) ?? "Unknown",
-                RootRecordingId = rootRecId,
-                ActiveRecordingId = null // set below
-            };
-
-            activeTree.PreTreeFunds = splitRecorder.PreLaunchFunds;
-            activeTree.PreTreeScience = splitRecorder.PreLaunchScience;
-            activeTree.PreTreeReputation = splitRecorder.PreLaunchReputation;
-
-            ParsekLog.Info("Coalescer",
-                $"PromoteToTreeForBreakup: tree created: id={treeId}, name='{activeTree.TreeName}', " +
-                $"vesselPid={splitRecorder.RecordingVesselId}");
-
-            // 3. Create single recording from CaptureAtStop — serves as both root and
-            // active recording. The main vessel's trajectory is continuous through breakups;
-            // Decoupled part events handle visual changes (booster detach) during playback.
-            // This matches how ProcessBreakupEvent handles subsequent breakups (same recording
-            // keeps accumulating data, debris branch off as children).
-            var cap = splitRecorder.CaptureAtStop;
-            var rootRec = new Recording
-            {
-                RecordingId = rootRecId,
-                TreeId = treeId,
-                VesselPersistentId = splitRecorder.RecordingVesselId,
-                VesselName = cap.VesselName ?? "Unknown",
-            };
-
-            rootRec.Points = new List<TrajectoryPoint>(cap.Points);
-            rootRec.OrbitSegments = new List<OrbitSegment>(cap.OrbitSegments);
-            rootRec.PartEvents = new List<PartEvent>(cap.PartEvents);
-            rootRec.TrackSections = new List<TrackSection>(cap.TrackSections);
-            rootRec.FlagEvents = new List<FlagEvent>(cap.FlagEvents);
-            rootRec.SegmentEvents = new List<SegmentEvent>(cap.SegmentEvents);
-            // Use the pre-breakup snapshot — shows full vessel with boosters.
-            // Decoupled part events at breakupUT hide detached parts during playback.
-            rootRec.GhostVisualSnapshot = cap.GhostVisualSnapshot;
-            rootRec.VesselSnapshot = cap.VesselSnapshot;
-            rootRec.RewindSaveFileName = cap.RewindSaveFileName;
-            rootRec.RewindReservedFunds = cap.RewindReservedFunds;
-            rootRec.RewindReservedScience = cap.RewindReservedScience;
-            rootRec.RewindReservedRep = cap.RewindReservedRep;
-            rootRec.StartBodyName = cap.StartBodyName;
-            rootRec.StartBiome = cap.StartBiome;
-            rootRec.StartSituation = cap.StartSituation;
-            rootRec.LaunchSiteName = cap.LaunchSiteName;
-            if (rootRec.Points.Count > 0)
-                rootRec.ExplicitStartUT = rootRec.Points[0].ut;
-            // Mark dirty so the next OnSave persists the captured data to disk.
-            // This is load-bearing for quickload-resume: without it, the root
-            // recording never gets a .prec file written during in-flight saves,
-            // and on scene reload the freshly-loaded tree has 0 points for this
-            // recording. See CHANGELOG 2026-04-09 bug #273.
-            rootRec.MarkFilesDirty();
-
-            activeTree.Recordings[rootRecId] = rootRec;
-            activeTree.ActiveRecordingId = rootRecId;
-
-            ParsekLog.Info("Coalescer",
-                $"PromoteToTreeForBreakup: root recording created: id={rootRecId}, " +
-                $"points={rootRec.Points.Count}, partEvents={rootRec.PartEvents.Count}, " +
-                $"rewind={!string.IsNullOrEmpty(rootRec.RewindSaveFileName)}");
-
-            // 4. Wire BREAKUP into tree — root is the parent, debris are children.
-            // No separate continuation recording — the root continues accumulating data.
-            breakupBp.ParentRecordingIds.Add(rootRecId);
-            activeTree.BranchPoints.Add(breakupBp);
-            rootRec.ChildBranchPointId = breakupBp.Id;
-
-            // 7. Create debris child recordings (skip trivial fragments)
-            int skippedDebris = 0;
-            var debrisPids = crashCoalescer.LastEmittedDebrisPids;
-            if (debrisPids != null)
-            {
-                for (int i = 0; i < debrisPids.Count; i++)
-                {
-                    uint pid = debrisPids[i];
-                    Vessel debrisVessel = FlightRecorder.FindVesselByPid(pid);
-
-                    if (debrisVessel != null && !ShouldRecordDebris(debrisVessel))
-                    {
-                        skippedDebris++;
-                        continue;
-                    }
-
-                    ConfigNode preSnap = debrisVessel == null
-                        ? crashCoalescer.GetPreCapturedSnapshot(pid)
-                        : null;
-                    var childRec = CreateBreakupChildRecording(activeTree, breakupBp, pid, debrisVessel, true, "Debris", preSnap, parentGeneration: rootRec.Generation);
-
-                    ParsekLog.Info("Coalescer",
-                        $"PromoteToTreeForBreakup: debris child created: pid={pid}, " +
-                        $"name='{childRec.VesselName}', recId={childRec.RecordingId}, " +
-                        $"alive={debrisVessel != null}, preSnap={preSnap != null}");
-                }
-            }
-
-            // 8. Create controlled child recordings (same pattern, IsDebris = false, no TTL)
-            var controlledPids = crashCoalescer.LastEmittedControlledChildPids;
-            if (controlledPids != null)
-            {
-                for (int i = 0; i < controlledPids.Count; i++)
-                {
-                    uint pid = controlledPids[i];
-                    Vessel childVessel = FlightRecorder.FindVesselByPid(pid);
-                    ConfigNode ctrlSnap = childVessel == null
-                        ? crashCoalescer.GetPreCapturedSnapshot(pid)
-                        : null;
-                    var childRec = CreateBreakupChildRecording(activeTree, breakupBp, pid, childVessel, false, "Unknown", ctrlSnap, parentGeneration: rootRec.Generation);
-
-                    ParsekLog.Info("Coalescer",
-                        $"PromoteToTreeForBreakup: controlled child created: pid={pid}, " +
-                        $"name='{childRec.VesselName}', recId={childRec.RecordingId}, " +
-                        $"alive={childVessel != null}, preSnap={ctrlSnap != null}");
-                }
-            }
-
-            // 9. ActiveRecordingId already set to rootRecId above (step 3).
-            // RebuildBackgroundMap excludes the active recording from BackgroundMap.
-
-            // Create BackgroundRecorder
-            activeTree.RebuildBackgroundMap();
-            backgroundRecorder = new BackgroundRecorder(activeTree);
-            backgroundRecorder.SubscribePartEvents();
-            Patches.PhysicsFramePatch.BackgroundRecorderInstance = backgroundRecorder;
-
-            ParsekLog.Info("Coalescer",
-                $"PromoteToTreeForBreakup: BackgroundRecorder created, " +
-                $"backgroundMap={activeTree.BackgroundMap.Count} vessels");
-
-            // 10. Set debris TTL and notify BackgroundRecorder
-            double debrisExpiryUT = breakupBp.UT + BackgroundRecorder.DebrisTTLSeconds;
-            foreach (var kvp in activeTree.BackgroundMap)
-            {
-                uint bgPid = kvp.Key;
-                backgroundRecorder.OnVesselBackgrounded(bgPid, splitEngineState);
-
-                // Set TTL for debris recordings only
-                Recording bgRec;
-                if (activeTree.Recordings.TryGetValue(kvp.Value, out bgRec) && bgRec.IsDebris)
-                {
-                    backgroundRecorder.SetDebrisExpiry(bgPid, debrisExpiryUT);
-                }
-            }
-
-            // 11. Clear stale standalone state
-            chainManager.ClearChainIdentity();
-            // Bug #95: bake before stop — continuation data is canonical (promoted to tree)
-            if (chainManager.IsTrackingUndockContinuation)
-            {
-                if (chainManager.TryGetUndockContinuationRecording(out var undockRec))
-                    ChainSegmentManager.BakeContinuationData(undockRec);
-                chainManager.StopUndockContinuation("tree promotion");
-            }
-            if (chainManager.IsTrackingContinuation)
-            {
-                if (chainManager.TryGetContinuationRecording(out var contRec))
-                    ChainSegmentManager.BakeContinuationData(contRec);
-                chainManager.StopContinuation("tree promotion");
-            }
-
-            // 12. Start new FlightRecorder for continuation
-            recorder = new FlightRecorder();
-            recorder.ActiveTree = activeTree;
-            recorder.StartRecording(isPromotion: true);
-
-            if (!recorder.IsRecording)
-            {
-                ParsekLog.Warn("Coalescer",
-                    "PromoteToTreeForBreakup: StartRecording failed for continuation");
-                recorder = null;
-            }
-
-            // 13. Log the promotion
-            int debrisAlive = 0;
-            if (debrisPids != null)
-            {
-                for (int i = 0; i < debrisPids.Count; i++)
-                {
-                    if (FlightRecorder.FindVesselByPid(debrisPids[i]) != null) debrisAlive++;
-                }
-            }
-            ParsekLog.Info("Coalescer",
-                $"PromoteToTreeForBreakup: standalone recording promoted to tree. " +
-                $"tree={treeId}, root={rootRecId}, " +
-                $"debris={debrisPids?.Count ?? 0} (alive={debrisAlive}), " +
-                $"skippedTrivial={skippedDebris}, " +
-                $"controlled={controlledPids?.Count ?? 0}, " +
-                $"breakup={breakupBp.Id}");
-            ParsekLog.RecState("PromoteToTreeForBreakup:exit", CaptureRecorderState());
-        }
-
         #endregion
 
         #region Terminal Event Detection (Destruction)
@@ -3434,16 +2792,15 @@ namespace Parsek
             return backgroundMap.ContainsKey(vesselPid);
         }
 
-        internal enum DestructionMode { None, TreeDeferred, StandaloneMerge, TreeAllLeavesCheck }
+        internal enum DestructionMode { None, TreeDeferred, TreeAllLeavesCheck }
 
         /// <summary>
         /// Pure classification of vessel destruction handling mode.
         /// Matches the branching order in OnVesselWillDestroy: TreeDeferred is checked first,
-        /// then StandaloneMerge (non-tree), then TreeAllLeavesCheck (tree with active vessel).
+        /// then TreeAllLeavesCheck (tree with active vessel).
         ///
-        /// The original code had three independent if-blocks, but the branches are mutually
-        /// exclusive by design: TreeDeferred requires shouldDeferForTree (vessel in BackgroundMap),
-        /// while StandaloneMerge/TreeAllLeavesCheck require isActiveVessel. The active vessel
+        /// TreeDeferred requires shouldDeferForTree (vessel in BackgroundMap),
+        /// while TreeAllLeavesCheck requires isActiveVessel. The active vessel
         /// is never in BackgroundMap, so at most one branch fires.
         ///
         /// TreeAllLeavesCheck intentionally does not require isRecording — the original checked
@@ -3459,9 +2816,6 @@ namespace Parsek
         {
             if (hasActiveTree && shouldDeferForTree)
                 return DestructionMode.TreeDeferred;
-
-            if (!hasActiveTree && isRecording && vesselDestroyedDuringRecording && isActiveVessel)
-                return DestructionMode.StandaloneMerge;
 
             if (hasActiveTree && vesselDestroyedDuringRecording && isActiveVessel
                 && !treeDestructionDialogPending)
@@ -4367,13 +3721,6 @@ namespace Parsek
                     StartCoroutine(RestoreActiveTreeFromPending());
                 }
             }
-            // #294: Standalone quickload-resume — mutually exclusive with tree restore.
-            else if (ParsekScenario.ScheduleActiveStandaloneRestoreOnFlightReady)
-            {
-                ParsekScenario.ScheduleActiveStandaloneRestoreOnFlightReady = false;
-                StartCoroutine(RestoreActiveStandaloneFromPending());
-            }
-
             // Belt-and-suspenders: recover orphaned spawned vessels that survived
             // the protoVessel stripping in OnLoad (e.g., FLIGHT→FLIGHT revert where
             // SpaceCenter was never visited, or name change edge cases).
@@ -5581,109 +4928,6 @@ namespace Parsek
             Log("Recording cleared");
         }
 
-        public void CommitFlight()
-        {
-            ParsekLog.Info("Flight", $"CommitFlight called with {recorder?.Recording?.Count ?? 0} points");
-
-            // Guard: no recording data
-            if (recorder == null || recorder.Recording.Count < 2)
-            {
-                ParsekLog.ScreenMessage("No recording to commit", 2f);
-                return;
-            }
-
-            // Guard: mid-chain recordings can't be committed standalone
-            if (chainManager.ActiveChainId != null)
-            {
-                ParsekLog.ScreenMessage("Cannot commit mid-chain \u2014 finish or revert first", 2f);
-                Log("CommitFlight blocked: active chain in progress");
-                return;
-            }
-
-            // Stop recording if still active
-            if (recorder.IsRecording)
-                StopRecording();
-
-            // Stop any continuation sampling
-            chainManager.StopAllContinuations("commit flight");
-
-            var captured = recorder.CaptureAtStop;
-            // #304: prefer CaptureAtStop.VesselName (already resolved by BuildCaptureRecording),
-            // resolve fallback to avoid raw #autoLOC keys in recording VesselName.
-            string vesselName = captured?.VesselName
-                ?? (FlightGlobals.ActiveVessel != null
-                    ? Recording.ResolveLocalizedName(FlightGlobals.ActiveVessel.vesselName)
-                    : "Unknown Vessel");
-
-            // Stash as pending recording (reuses OnSceneChangeRequested pattern)
-            RecordingStore.StashPending(
-                recorder.Recording,
-                vesselName,
-                recorder.OrbitSegments,
-                recordingId: captured != null ? captured.RecordingId : null,
-                recordingFormatVersion: captured != null ? (int?)captured.RecordingFormatVersion : null,
-                partEvents: recorder.PartEvents,
-                flagEvents: recorder.FlagEvents);
-
-            if (!RecordingStore.HasPending)
-            {
-                Log("CommitFlight: StashPending rejected recording (too short?)");
-                return;
-            }
-
-            // Apply snapshot/geometry artifacts from stop-time capture
-            if (captured != null)
-            {
-                RecordingStore.Pending.ApplyPersistenceArtifactsFrom(captured);
-                RecordingStore.Pending.StartBodyName = captured.StartBodyName;
-                RecordingStore.Pending.StartBiome = captured.StartBiome;
-                RecordingStore.Pending.StartSituation = captured.StartSituation;
-                RecordingStore.Pending.LaunchSiteName = captured.LaunchSiteName;
-                Log("CommitFlight: applied stop-time artifacts");
-            }
-            else
-            {
-                // Fallback: capture vessel now
-                bool wasDestroyed = recorder.VesselDestroyedDuringRecording;
-                VesselSpawner.SnapshotVessel(
-                    RecordingStore.Pending,
-                    wasDestroyed,
-                    destroyedFallbackSnapshot: recorder.InitialGhostVisualSnapshot
-                        ?? recorder.LastGoodVesselSnapshot);
-                RecordingStore.Pending.GhostVisualSnapshot =
-                    recorder.InitialGhostVisualSnapshot != null
-                        ? recorder.InitialGhostVisualSnapshot.CreateCopy()
-                        : (RecordingStore.Pending.VesselSnapshot != null
-                            ? RecordingStore.Pending.VesselSnapshot.CreateCopy()
-                            : null);
-                Log("CommitFlight: captured vessel snapshot (fallback path)");
-            }
-
-            // Mark as non-revert commit:
-            // - VesselSpawned=true prevents duplicate spawn while vessel is in-game
-            // - SpawnedVesselPersistentId enables duplicate detection on save/load
-            // - LastAppliedResourceIndex prevents double-applying deltas
-            // All three reset naturally on "Revert to Launch" (launch quicksave has no RECORDING nodes)
-            var pending = RecordingStore.Pending;
-            pending.VesselSpawned = true;
-            pending.SpawnedVesselPersistentId = recorder.RecordingVesselId;
-            pending.LastAppliedResourceIndex = pending.Points.Count - 1;
-
-            // Commit to timeline
-            string recId = pending.RecordingId;
-            double startUT = pending.StartUT;
-            double endUT = pending.EndUT;
-            RecordingStore.CommitPending();
-            LedgerOrchestrator.OnRecordingCommitted(recId, startUT, endUT);
-
-            // Clear recorder state
-            recorder = null;
-            lastPlaybackIndex = 0;
-
-            Log($"CommitFlight: committed \"{vesselName}\" to timeline");
-            ParsekLog.ScreenMessage("Flight committed to timeline!", 3f);
-        }
-
         /// <summary>
         /// Commits the active recording tree from the Commit Flight button.
         /// Finalizes all recordings, spawns leaf vessels, reserves crew.
@@ -6121,121 +5365,6 @@ namespace Parsek
             }
 
             ParsekLog.RecState("RestoreSwitch:after-install", CaptureRecorderState());
-            } // try
-            finally
-            {
-                restoringActiveTree = false;
-            }
-        }
-
-        /// <summary>
-        /// #294: Standalone quickload-resume coroutine. Restores an active standalone
-        /// recording from the PARSEK_ACTIVE_STANDALONE data saved at F5 time. Waits
-        /// for the vessel to load, creates a new recorder, seeds it with the saved
-        /// trajectory data, and resumes recording.
-        /// Mirrors the tree restore pattern but is simpler — no BackgroundRecorder,
-        /// no BackgroundMap, no branch management.
-        /// Reuses <see cref="restoringActiveTree"/> guard to prevent interference from
-        /// OnVesselSwitchComplete, OnVesselWillDestroy, etc. during the yield window.
-        /// </summary>
-        IEnumerator RestoreActiveStandaloneFromPending()
-        {
-            restoringActiveTree = true;
-            try
-            {
-            ParsekLog.RecState("RestoreSA:start", CaptureRecorderState());
-
-            var savedRec = ParsekScenario.pendingActiveStandaloneRecording;
-            string targetName = ParsekScenario.pendingActiveStandaloneVesselName;
-            uint savedPid = ParsekScenario.pendingActiveStandaloneVesselPid;
-
-            if (savedRec == null)
-            {
-                ParsekLog.Verbose("Flight",
-                    "RestoreActiveStandaloneFromPending: no pending standalone data, skipping");
-                yield break;
-            }
-
-            ParsekLog.Info("Flight",
-                $"RestoreActiveStandaloneFromPending: waiting for vessel '{targetName}' to load " +
-                $"(savedPid={savedPid}, {savedRec.Points.Count} saved points)");
-
-            // Wait up to 3 seconds for the active vessel to match by name.
-            // Same timeout as the tree restore path.
-            float deadline = UnityEngine.Time.time + 3f;
-            Vessel matched = null;
-            while (UnityEngine.Time.time < deadline)
-            {
-                var v = FlightGlobals.ActiveVessel;
-                if (v != null && v.vesselName == targetName)
-                {
-                    matched = v;
-                    break;
-                }
-                yield return null;
-            }
-
-            if (matched == null)
-            {
-                ParsekLog.Warn("Flight",
-                    $"RestoreActiveStandaloneFromPending: vessel '{targetName}' not active within 3s " +
-                    "— abandoning standalone restore");
-                ParsekScenario.ClearPendingActiveStandalone();
-                yield break;
-            }
-
-            ParsekLog.RecState("RestoreSA:matched", CaptureRecorderState());
-
-            // Create a fresh recorder and start recording
-            recorder = new FlightRecorder();
-
-            // Restore rewind save filename before StartRecording (so CaptureRewindSave
-            // sees the existing name and preserves it)
-            if (!string.IsNullOrEmpty(ParsekScenario.pendingActiveStandaloneRewindSave))
-            {
-                recorder.SetRewindSaveFileNameForRestore(
-                    ParsekScenario.pendingActiveStandaloneRewindSave,
-                    "standalone quickload-resume from PARSEK_ACTIVE_STANDALONE");
-            }
-
-            recorder.StartRecording(isPromotion: true);
-            if (!recorder.IsRecording)
-            {
-                ParsekLog.Warn("Flight",
-                    $"RestoreActiveStandaloneFromPending: StartRecording returned IsRecording=false " +
-                    $"for '{targetName}' — restore incomplete");
-                ParsekScenario.ClearPendingActiveStandalone();
-                yield break;
-            }
-
-            // Prepend saved trajectory data into the recorder's buffers.
-            // StartRecording may have inserted a boundary anchor point — the saved data
-            // goes BEFORE it chronologically (InsertRange(0, ...) shifts existing entries).
-            recorder.Recording.InsertRange(0, savedRec.Points);
-            recorder.OrbitSegments.InsertRange(0, savedRec.OrbitSegments);
-            recorder.PartEvents.InsertRange(0, savedRec.PartEvents);
-            recorder.FlagEvents.InsertRange(0, savedRec.FlagEvents);
-            recorder.TrackSections.InsertRange(0, savedRec.TrackSections);
-            recorder.SegmentEvents.InsertRange(0, savedRec.SegmentEvents);
-
-            // Restore original start location from the saved data (StartRecording captured
-            // the quickload-time location which is wrong — we want the original launch location).
-            if (!string.IsNullOrEmpty(savedRec.StartBodyName))
-                recorder.SetStartLocationForRestore(
-                    savedRec.StartBodyName, savedRec.StartBiome,
-                    savedRec.StartSituation, savedRec.LaunchSiteName);
-
-            ParsekScenario.ClearPendingActiveStandalone();
-
-            ParsekLog.Info("Flight",
-                $"RestoreActiveStandaloneFromPending: resumed standalone recording " +
-                $"for '{targetName}' (pid={matched.persistentId}, " +
-                $"{recorder.Recording.Count} total points including {savedRec.Points.Count} restored) " +
-                $"at UT={Planetarium.GetUniversalTime():F1}");
-            ParsekLog.RecState("RestoreSA:after-start", CaptureRecorderState());
-
-            ParsekLog.Info("Flight", $"StartRecording succeeded: pid={matched.persistentId}, chainActive=False, tree=False");
-
             } // try
             finally
             {
@@ -6784,7 +5913,7 @@ namespace Parsek
             }
 
             // Backfill terminal orbit for recordings that had TerminalStateValue set early
-            // (CaptureSceneExitState, ChainSegmentManager, BackgroundRecorder) without
+            // (ChainSegmentManager, BackgroundRecorder) without
             // a corresponding CaptureTerminalOrbit call. (#203/#219 regression)
             if (isLeaf && string.IsNullOrEmpty(rec.TerminalOrbitBody)
                 && rec.TerminalStateValue.HasValue

--- a/Source/Parsek/ParsekLog.cs
+++ b/Source/Parsek/ParsekLog.cs
@@ -248,7 +248,7 @@ namespace Parsek
         /// </summary>
         /// <param name="phase">
         /// Short free-text tag identifying the call site (e.g. <c>"OnFlightReady"</c>,
-        /// <c>"PromoteToTreeForBreakup:exit"</c>). Always pass a string literal so the
+        /// <c>"OnSave:pre"</c>). Always pass a string literal so the
         /// tag is grep-stable across releases.
         /// </param>
         /// <param name="snap">Captured state to render.</param>

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -298,7 +298,6 @@ namespace Parsek
 
                 SaveStandaloneRecordings(node, recordings);
                 SaveTreeRecordings(node);
-                SaveActiveStandaloneIfAny(node);
                 PersistGameStateAndMilestones(node);
 
                 // Strip ghost map ProtoVessels — they are transient and reconstructed on load
@@ -506,70 +505,6 @@ namespace Parsek
         }
 
         /// <summary>
-        /// #294: Persists the active standalone recorder's buffer into a
-        /// PARSEK_ACTIVE_STANDALONE ConfigNode so F9 quickload can resume
-        /// from the F5 checkpoint instead of losing all in-progress data.
-        /// Mirrors the tree-mode pattern in <see cref="SaveActiveTreeIfAny"/>
-        /// but for standalone (non-tree) recordings.
-        /// The recorder's buffers are NOT cleared — unlike tree-mode flush,
-        /// the standalone recorder keeps running after F5. Data is deep-copied
-        /// into a temporary Recording for serialization.
-        /// </summary>
-        private static void SaveActiveStandaloneIfAny(ConfigNode node)
-        {
-            if (HighLogic.LoadedScene != GameScenes.FLIGHT) return;
-
-            var flight = ParsekFlight.Instance;
-            if (flight == null) return;
-
-            // Mutual exclusion: if tree mode is active, SaveActiveTreeIfAny handles it.
-            // Both should never coexist — standalone and tree are mutually exclusive.
-            if (flight.ActiveTreeForSerialization != null) return;
-
-            var recorder = flight.ActiveRecorderForSerialization;
-            if (recorder == null || !recorder.IsRecording) return;
-
-            // Deep-copy the recorder's buffers into a temporary Recording for serialization.
-            // We must NOT clear the recorder's buffers (unlike FlushRecorderIntoActiveTreeForSerialization)
-            // because the recorder keeps running after F5.
-            var tempRec = new Recording();
-            tempRec.Points.AddRange(recorder.Recording);
-            tempRec.OrbitSegments.AddRange(recorder.OrbitSegments);
-            tempRec.PartEvents.AddRange(recorder.PartEvents);
-            tempRec.FlagEvents.AddRange(recorder.FlagEvents);
-            tempRec.TrackSections.AddRange(recorder.TrackSections);
-            tempRec.SegmentEvents.AddRange(recorder.SegmentEvents);
-
-            ConfigNode saNode = node.AddNode("PARSEK_ACTIVE_STANDALONE");
-            saNode.AddValue("vesselName",
-                FlightGlobals.ActiveVessel != null ? FlightGlobals.ActiveVessel.vesselName : "");
-            saNode.AddValue("vesselPid",
-                recorder.RecordingVesselId.ToString(CultureInfo.InvariantCulture));
-
-            // Start location from the recorder (captured at original recording start)
-            if (!string.IsNullOrEmpty(recorder.StartBodyName))
-                saNode.AddValue("startBodyName", recorder.StartBodyName);
-            if (!string.IsNullOrEmpty(recorder.StartBiome))
-                saNode.AddValue("startBiome", recorder.StartBiome);
-            if (!string.IsNullOrEmpty(recorder.StartSituation))
-                saNode.AddValue("startSituation", recorder.StartSituation);
-            if (!string.IsNullOrEmpty(recorder.LaunchSiteName))
-                saNode.AddValue("launchSiteName", recorder.LaunchSiteName);
-
-            if (!string.IsNullOrEmpty(recorder.RewindSaveFileName))
-                saNode.AddValue("rewindSave", recorder.RewindSaveFileName);
-
-            // Serialize trajectory data inline (same format as .prec sidecar files)
-            RecordingStore.SerializeTrajectoryInto(saNode, tempRec);
-
-            ParsekLog.Info("Scenario",
-                $"SaveActiveStandaloneIfAny: serialized active standalone recorder " +
-                $"({tempRec.Points.Count} points, {tempRec.PartEvents.Count} events, " +
-                $"{tempRec.OrbitSegments.Count} orbit segs, {tempRec.TrackSections.Count} sections) " +
-                $"for quickload resume");
-        }
-
-        /// <summary>
         /// Persists crew state, group hierarchy, game state events, baselines,
         /// milestones, and ledger data to the save node and external files.
         /// </summary>
@@ -718,9 +653,8 @@ namespace Parsek
                     // affect the rest of OnLoad, but BEFORE revert detection so the
                     // pending slot is populated when it runs.
                     bool activeTreeRestoredFromSave = TryRestoreActiveTreeNode(node);
-                    // #294: Also check for an active standalone recording saved at F5 time.
-                    // Mutually exclusive with tree restore — TryRestoreActiveStandaloneNode
-                    // checks ScheduleActiveTreeRestoreOnFlightReady and skips if set.
+                    // Migration: check for legacy PARSEK_ACTIVE_STANDALONE from old saves.
+                    // Converts to a single-node RecordingTree and routes through tree restore.
                     TryRestoreActiveStandaloneNode(node);
                     ParsekLog.RecState("OnLoad:active-tree-restored", CaptureScenarioRecorderState());
 
@@ -1150,44 +1084,6 @@ namespace Parsek
                             ParsekLog.Info("Scenario",
                                 $"OnLoad: pending-Limbo tree '{RecordingStore.PendingTree?.TreeName}' " +
                                 "deferred to OnFlightReady for quickload-resume");
-                        }
-                    }
-
-                    // #305: Standalone Limbo dispatch — parallel to tree Limbo dispatch above.
-                    // Determines whether a Limbo standalone should be finalized for the merge
-                    // dialog (revert-to-launch) or discarded (F5/F9 resume takes over).
-                    if (RecordingStore.HasPending
-                        && RecordingStore.PendingStandaloneStateValue == PendingStandaloneState.Limbo)
-                    {
-                        ParsekLog.RecState("OnLoad:standalone-limbo-dispatched", CaptureScenarioRecorderState());
-                        if (isRevert)
-                        {
-                            // Real revert: finalize Limbo standalone for merge dialog.
-                            RecordingStore.MarkPendingStandaloneFinalized();
-                            ParsekLog.Info("Scenario",
-                                $"OnLoad: Limbo standalone '{RecordingStore.Pending?.VesselName}' " +
-                                "finalized for merge dialog (revert detected)");
-                        }
-                        else if (ScheduleActiveStandaloneRestoreOnFlightReady)
-                        {
-                            // F5/F9 mid-recording: the F5 save has PARSEK_ACTIVE_STANDALONE data that
-                            // TryRestoreActiveStandaloneNode will resume from. The Limbo standalone is
-                            // from after the F5 point (stale future data) — discard it.
-                            string saName = RecordingStore.Pending?.VesselName;
-                            RecordingStore.DiscardPending();
-                            ParsekLog.Info("Scenario",
-                                $"OnLoad: discarded Limbo standalone '{saName}' — " +
-                                "active-standalone restore scheduled from save");
-                        }
-                        else
-                        {
-                            // No revert detected AND no restore data: the loaded save has no
-                            // PARSEK_ACTIVE_STANDALONE, meaning the recording started after this
-                            // save point (revert-to-launch). Finalize for merge dialog.
-                            RecordingStore.MarkPendingStandaloneFinalized();
-                            ParsekLog.Info("Scenario",
-                                $"OnLoad: Limbo standalone '{RecordingStore.Pending?.VesselName}' " +
-                                "finalized for merge dialog (no active-standalone in loaded save)");
                         }
                     }
 
@@ -2036,46 +1932,18 @@ namespace Parsek
         /// </summary>
         internal static ActiveTreeRestoreMode ScheduleActiveTreeRestoreOnFlightReady;
 
-        // #294: Standalone quickload-resume state, parallel to the tree restore fields above.
-        // Populated by TryRestoreActiveStandaloneNode during OnLoad, consumed by
-        // ParsekFlight.RestoreActiveStandaloneFromPending coroutine on OnFlightReady.
-
         /// <summary>
-        /// Holds the deserialized PARSEK_ACTIVE_STANDALONE data between OnLoad and
-        /// OnFlightReady. Null when no standalone restore is pending.
-        /// </summary>
-        internal static Recording pendingActiveStandaloneRecording;
-
-        /// <summary>Vessel name from the saved standalone node, for matching on restore.</summary>
-        internal static string pendingActiveStandaloneVesselName;
-
-        /// <summary>Vessel PID from the saved standalone node, for PID remap on restore.</summary>
-        internal static uint pendingActiveStandaloneVesselPid;
-
-        /// <summary>Rewind save filename from the saved standalone node.</summary>
-        internal static string pendingActiveStandaloneRewindSave;
-
-        /// <summary>
-        /// Signal to <see cref="ParsekFlight.OnFlightReady"/> that a standalone
-        /// recording restore is pending. Set by OnLoad when it finds a
-        /// PARSEK_ACTIVE_STANDALONE node in the loaded save.
-        /// </summary>
-        internal static bool ScheduleActiveStandaloneRestoreOnFlightReady;
-
-        /// <summary>
-        /// #294: Extracts a PARSEK_ACTIVE_STANDALONE node from the loaded save and
-        /// stores its data for the standalone restore coroutine. Called from OnLoad
-        /// after tree restore logic. Mutually exclusive with active tree — both should
-        /// never coexist in a save.
+        /// Migration shim: converts a legacy PARSEK_ACTIVE_STANDALONE node from old saves
+        /// into a single-node RecordingTree and routes through the tree restore path.
+        /// New saves never write PARSEK_ACTIVE_STANDALONE (always-tree mode uses
+        /// PARSEK_ACTIVE_TREE exclusively).
         /// </summary>
         internal static void TryRestoreActiveStandaloneNode(ConfigNode node)
         {
             ConfigNode saNode = node.GetNode("PARSEK_ACTIVE_STANDALONE");
             if (saNode == null) return;
 
-            // Mutual exclusion check: if a tree restore is also scheduled, the tree wins.
-            // This shouldn't happen (standalone and tree are mutually exclusive at save time)
-            // but guard against corrupted saves.
+            // If a tree restore is already scheduled, the tree wins.
             if (ScheduleActiveTreeRestoreOnFlightReady != ActiveTreeRestoreMode.None)
             {
                 ParsekLog.Warn("Scenario",
@@ -2094,32 +1962,44 @@ namespace Parsek
             rec.StartSituation = saNode.GetValue("startSituation");
             rec.LaunchSiteName = saNode.GetValue("launchSiteName");
 
-            pendingActiveStandaloneRecording = rec;
-            pendingActiveStandaloneVesselName = saNode.GetValue("vesselName") ?? "";
-            uint.TryParse(saNode.GetValue("vesselPid"), NumberStyles.Integer, ic,
-                out pendingActiveStandaloneVesselPid);
-            pendingActiveStandaloneRewindSave = saNode.GetValue("rewindSave");
+            string vesselName = saNode.GetValue("vesselName") ?? "";
+            uint vesselPid = 0;
+            uint.TryParse(saNode.GetValue("vesselPid"), NumberStyles.Integer, ic, out vesselPid);
 
-            ScheduleActiveStandaloneRestoreOnFlightReady = true;
+            // Wrap the standalone data into a single-node RecordingTree
+            string treeId = Guid.NewGuid().ToString("N");
+            string rootRecId = Guid.NewGuid().ToString("N");
+
+            rec.RecordingId = rootRecId;
+            rec.TreeId = treeId;
+            rec.VesselPersistentId = vesselPid;
+            rec.VesselName = vesselName;
+            if (rec.Points.Count > 0)
+                rec.ExplicitStartUT = rec.Points[0].ut;
+
+            var tree = new RecordingTree
+            {
+                Id = treeId,
+                TreeName = vesselName,
+                RootRecordingId = rootRecId,
+                ActiveRecordingId = rootRecId,
+            };
+            tree.Recordings[rootRecId] = rec;
+
+            // Pop any existing pending tree, then stash the migrated tree
+            RecordingStore.PopPendingTree();
+            RecordingStore.StashPendingTree(tree, PendingTreeState.Limbo);
+
+            // Set resume hints
+            pendingActiveTreeResumeRewindSave = saNode.GetValue("rewindSave");
+
+            // Route through tree restore path
+            ScheduleActiveTreeRestoreOnFlightReady = ActiveTreeRestoreMode.Quickload;
 
             ParsekLog.Info("Scenario",
-                $"TryRestoreActiveStandaloneNode: loaded standalone restore data " +
-                $"(vessel='{pendingActiveStandaloneVesselName}', pid={pendingActiveStandaloneVesselPid}, " +
-                $"{rec.Points.Count} points, {rec.PartEvents.Count} events, " +
-                $"{rec.OrbitSegments.Count} orbit segs, {rec.TrackSections.Count} sections)");
-        }
-
-        /// <summary>
-        /// Clears all standalone restore pending state. Called after the restore
-        /// coroutine consumes the data, or when the restore is abandoned.
-        /// </summary>
-        internal static void ClearPendingActiveStandalone()
-        {
-            pendingActiveStandaloneRecording = null;
-            pendingActiveStandaloneVesselName = null;
-            pendingActiveStandaloneVesselPid = 0;
-            pendingActiveStandaloneRewindSave = null;
-            ScheduleActiveStandaloneRestoreOnFlightReady = false;
+                $"TryRestoreActiveStandaloneNode: migrated legacy standalone to tree " +
+                $"(vessel='{vesselName}', pid={vesselPid}, tree={treeId}, " +
+                $"{rec.Points.Count} points, {rec.PartEvents.Count} events)");
         }
 
         /// <summary>

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -1951,6 +1951,7 @@ namespace Parsek
             rec.TreeId = treeId;
             rec.VesselPersistentId = vesselPid;
             rec.VesselName = vesselName;
+            rec.RecordingFormatVersion = RecordingStore.CurrentRecordingFormatVersion;
             if (rec.Points.Count > 0)
                 rec.ExplicitStartUT = rec.Points[0].ut;
 

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -170,22 +170,10 @@ namespace Parsek
             {
                 string id = RecordingStore.Pending?.RecordingId;
                 string name = RecordingStore.Pending?.VesselName;
-                if (RecordingStore.PendingStandaloneStateValue != PendingStandaloneState.Limbo)
-                {
-                    // Non-Limbo standalone stashed this transition: discard (existing behavior).
-                    RecordingStore.DiscardPending();
-                    discardedSa = 1;
-                    ParsekLog.Info("Scenario",
-                        $"Quickload: discarded pending standalone '{name}' (id={id})");
-                }
-                else
-                {
-                    // #305: Limbo standalone preserved for OnLoad dispatch — parallel to
-                    // Limbo tree preservation below. OnLoad's Limbo dispatch block decides
-                    // whether to discard (F5/F9 resume) or finalize (revert-to-launch).
-                    ParsekLog.Info("Scenario",
-                        $"Quickload: preserving Limbo standalone '{name}' (id={id}) for OnLoad dispatch");
-                }
+                RecordingStore.DiscardPending();
+                discardedSa = 1;
+                ParsekLog.Info("Scenario",
+                    $"Quickload: discarded pending standalone '{name}' (id={id})");
             }
 
             if (RecordingStore.HasPendingTree
@@ -869,19 +857,8 @@ namespace Parsek
                             }
                             if (RecordingStore.HasPending)
                             {
-                                // #305: Limbo standalone preserved for dispatch (parallel
-                                // to Limbo tree check at lines above).
-                                if (RecordingStore.PendingStandaloneStateValue == PendingStandaloneState.Limbo)
-                                {
-                                    ParsekLog.Info("Scenario",
-                                        $"Revert: keeping pending Limbo standalone " +
-                                        $"'{RecordingStore.Pending?.VesselName}' — stashed for dispatch");
-                                }
-                                else
-                                {
-                                    ParsekLog.Info("Scenario", "Clearing orphaned pending recording on revert (stale from previous flight)");
-                                    RecordingStore.DiscardPending();
-                                }
+                                ParsekLog.Info("Scenario", "Clearing orphaned pending recording on revert (stale from previous flight)");
+                                RecordingStore.DiscardPending();
                             }
                         }
                     }

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -249,21 +249,16 @@ namespace Parsek
                 recordingsTableUI.ShowClearRecordingConfirmation();
             }
 
-            bool canCommitStandalone = !flight.IsRecording && !flight.IsPlaying
-                && flight.recording.Count >= 2 && !flight.HasActiveChain && !flight.HasActiveTree;
             bool canCommitTree = flight.HasActiveTree;
             bool stableSituation = FlightGlobals.ActiveVessel != null
                 && RecordingStore.IsStableState((int)FlightGlobals.ActiveVessel.situation);
-            GUI.enabled = (canCommitStandalone || canCommitTree) && stableSituation;
+            GUI.enabled = canCommitTree && stableSituation;
             if (GUILayout.Button(stableSituation
                 ? new GUIContent("Commit Recording to Timeline")
                 : new GUIContent("Commit Recording to Timeline", "Land or stop before committing.")))
             {
                 ParsekLog.Verbose("UI", "Commit Flight button clicked");
-                if (flight.HasActiveTree)
-                    flight.CommitTreeFlight();
-                else
-                    flight.CommitFlight();
+                flight.CommitTreeFlight();
             }
             GUI.enabled = true;
         }

--- a/Source/Parsek/RecordingOptimizer.cs
+++ b/Source/Parsek/RecordingOptimizer.cs
@@ -85,6 +85,10 @@ namespace Parsek
         internal static bool CanAutoSplitIgnoringGhostTriggers(Recording rec, int sectionIndex)
         {
             if (rec == null) return false;
+            // Bug #271: skip tree recordings. The optimizer produces standalone chain
+            // recordings that aren't in the tree structure, breaking ghost chain traversal.
+            // Tree recording splits will be handled when T56 unifies the format.
+            if (!string.IsNullOrEmpty(rec.TreeId)) return false;
             if (rec.TrackSections == null || rec.TrackSections.Count < 2) return false;
             if (sectionIndex < 1 || sectionIndex >= rec.TrackSections.Count) return false;
 

--- a/Source/Parsek/RecordingOptimizer.cs
+++ b/Source/Parsek/RecordingOptimizer.cs
@@ -396,7 +396,13 @@ namespace Parsek
                 }
             }
 
-            // 8. Clone GhostVisualSnapshot (safe: CanAutoSplit ensures no ghosting triggers)
+            // 8. Clone GhostVisualSnapshot (safe: CanAutoSplit ensures no ghosting triggers).
+            // Bug #271 safety net: if GhostVisualSnapshot is null but VesselSnapshot exists,
+            // create GhostVisualSnapshot from VesselSnapshot before transferring. Without this,
+            // the original half ends up with both fields null after step 10 transfers
+            // VesselSnapshot to the second half.
+            if (original.GhostVisualSnapshot == null && original.VesselSnapshot != null)
+                original.GhostVisualSnapshot = original.VesselSnapshot.CreateCopy();
             if (original.GhostVisualSnapshot != null)
                 second.GhostVisualSnapshot = original.GhostVisualSnapshot.CreateCopy();
 

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -47,30 +47,6 @@ namespace Parsek
     }
 
     /// <summary>
-    /// State of the pending standalone slot in <see cref="RecordingStore"/>.
-    /// Determines how <see cref="ParsekScenario.OnLoad"/> dispatches the pending
-    /// standalone after revert detection runs. Parallel to <see cref="PendingTreeState"/>.
-    /// </summary>
-    public enum PendingStandaloneState
-    {
-        /// <summary>
-        /// Standalone has been finalized: terminal state set, snapshots preserved,
-        /// ready for merge dialog. This is the default state — scene exits to KSC,
-        /// manual commits, and post-destruction paths all use Finalized.
-        /// </summary>
-        Finalized = 0,
-
-        /// <summary>
-        /// Standalone is still "in-flight": recorder was torn down because the scene
-        /// is unloading for a FLIGHT->FLIGHT transition (quickload or revert). OnLoad
-        /// decides based on the presence of PARSEK_ACTIVE_STANDALONE in the loaded save
-        /// whether to discard (F5/F9 resume takes over) or finalize for merge dialog
-        /// (revert-to-launch). Parallel to <see cref="PendingTreeState.Limbo"/>.
-        /// </summary>
-        Limbo = 1,
-    }
-
-    /// <summary>
     /// Static holder for recording data that survives scene changes.
     /// Static fields persist across scene loads within a KSP session.
     /// Save/load persistence is handled separately by ParsekScenario.
@@ -167,13 +143,8 @@ namespace Parsek
         // See docs/dev/plans/quickload-resume-recording.md.
         private static PendingTreeState pendingTreeState = PendingTreeState.Finalized;
 
-        // State of the pending standalone slot. Finalized = ready for merge dialog.
-        // Limbo = in-flight, stashed for FLIGHT->FLIGHT dispatch (parallel to pendingTreeState).
-        private static PendingStandaloneState pendingStandaloneState = PendingStandaloneState.Finalized;
-
         public static bool HasPending => pendingRecording != null;
         public static Recording Pending => pendingRecording;
-        public static PendingStandaloneState PendingStandaloneStateValue => pendingStandaloneState;
         public static List<Recording> CommittedRecordings => committedRecordings;
         public static List<RecordingTree> CommittedTrees => committedTrees;
         public static bool HasPendingTree => pendingTree != null;
@@ -187,8 +158,7 @@ namespace Parsek
             List<PartEvent> partEvents = null,
             List<FlagEvent> flagEvents = null,
             List<SegmentEvent> segmentEvents = null,
-            List<TrackSection> trackSections = null,
-            PendingStandaloneState state = PendingStandaloneState.Finalized)
+            List<TrackSection> trackSections = null)
         {
             if (points == null || points.Count < 2)
             {
@@ -275,8 +245,6 @@ namespace Parsek
                     : new List<TrackSection>(),
                 VesselName = vesselName
             };
-            pendingStandaloneState = state;
-
             PendingStashedThisTransition = true;
 
             Log($"[Parsek] Stashed pending recording: {points.Count} points, " +
@@ -310,7 +278,6 @@ namespace Parsek
             string recordingId = pendingRecording.RecordingId;
             double endUT = pendingRecording.EndUT;
             pendingRecording = null;
-            pendingStandaloneState = PendingStandaloneState.Finalized;
 
             // Capture a game state baseline at each commit (single funnel point)
             GameStateStore.CaptureBaselineIfNeeded();
@@ -332,7 +299,6 @@ namespace Parsek
 
             Log($"[Parsek] Discarded pending recording from {pendingRecording.VesselName}");
             pendingRecording = null;
-            pendingStandaloneState = PendingStandaloneState.Finalized;
         }
 
         public static void ClearCommitted()
@@ -351,7 +317,6 @@ namespace Parsek
             if (pendingRecording != null)
                 DeleteRecordingFiles(pendingRecording);
             pendingRecording = null;
-            pendingStandaloneState = PendingStandaloneState.Finalized;
             pendingTree = null;
             pendingTreeState = PendingTreeState.Finalized;
             ClearCommitted();
@@ -657,20 +622,6 @@ namespace Parsek
             pendingTreeState = PendingTreeState.Finalized;
             ParsekLog.Info("RecordingStore",
                 $"Pending tree '{pendingTree.TreeName}' transitioned Limbo → Finalized");
-        }
-
-        /// <summary>
-        /// Marks the pending standalone's state as Finalized after the Limbo dispatch
-        /// has decided to keep it for the merge dialog (revert-to-launch path).
-        /// Parallel to <see cref="MarkPendingTreeFinalized"/>.
-        /// </summary>
-        internal static void MarkPendingStandaloneFinalized()
-        {
-            if (pendingRecording == null) return;
-            if (pendingStandaloneState == PendingStandaloneState.Finalized) return;
-            pendingStandaloneState = PendingStandaloneState.Finalized;
-            ParsekLog.Info("RecordingStore",
-                $"Pending standalone '{pendingRecording.VesselName}' transitioned Limbo → Finalized");
         }
 
         /// <summary>
@@ -1588,7 +1539,6 @@ namespace Parsek
         internal static void ResetForTesting()
         {
             pendingRecording = null;
-            pendingStandaloneState = PendingStandaloneState.Finalized;
             committedRecordings.Clear();
             committedTrees.Clear();
             pendingTree = null;

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -276,6 +276,24 @@ and `FlushRecorderToTreeRecording`. Two new tests in `AppendCapturedDataTests.cs
 
 ---
 
+### T56. Remove standalone RECORDING format entirely
+
+Follow-up to bug #271 (always-tree unification). The runtime now always creates tree recordings, and the injector now produces RECORDING_TREE nodes for all synthetic recordings. But the codebase still supports the old standalone RECORDING format:
+
+- `RecordingStore.committedRecordings` list (238 refs across 28 production files, 300 refs across 27 test files)
+- `StashPending`/`CommitPending`/`DiscardPending` methods (used by ChainSegmentManager)
+- `MergeDialog.Show(Recording)` and `ShowStandaloneDialog` (used by chain commit and deferred split dialogs)
+- Standalone RECORDING serialization in `ParsekScenario.OnSave`/`OnLoad`
+- `PARSEK_ACTIVE_STANDALONE` migration shim in `TryRestoreActiveStandaloneNode`
+
+To remove: collapse `committedRecordings` into `committedTrees` (every recording accessed through its parent tree), delete the standalone pending slot, delete standalone merge dialog, delete standalone RECORDING serialization, delete chain segment standalone commit paths (dead code in always-tree mode). This is a ~55-file refactor.
+
+Prerequisite: delete all old save files (no users yet, clean slate).
+
+**Priority:** Medium -- the dual storage is confusing but not causing bugs since always-tree routes everything through the tree path at runtime
+
+---
+
 ## TODO — Nice to have
 
 ### ~~T53. Watch camera mode selection~~

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -286,7 +286,7 @@ Follow-up to bug #271 (always-tree unification). The runtime now always creates 
 - Standalone RECORDING serialization in `ParsekScenario.OnSave`/`OnLoad`
 - `PARSEK_ACTIVE_STANDALONE` migration shim in `TryRestoreActiveStandaloneNode`
 
-To remove: collapse `committedRecordings` into `committedTrees` (every recording accessed through its parent tree), delete the standalone pending slot, delete standalone merge dialog, delete standalone RECORDING serialization, delete chain segment standalone commit paths (dead code in always-tree mode). This is a ~55-file refactor.
+To remove: collapse `committedRecordings` into `committedTrees` (every recording accessed through its parent tree), delete the standalone pending slot, delete standalone merge dialog, delete standalone RECORDING serialization, delete chain segment standalone commit paths (dead code in always-tree mode). Also update `RunOptimizationPass` (RecordingStore.cs) -- it currently operates on the flat `committedRecordings` list and produces standalone chain-linked recordings on splits. After unification it should operate on tree recordings and keep output within tree structure. This is a ~55-file refactor.
 
 Prerequisite: delete all old save files (no users yet, clean slate).
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -178,28 +178,11 @@ Not introduced by PR #160, but PR #160's quickload-resume path makes it more rea
 
 ---
 
-## 271. Investigate unifying standalone and tree recorder modes
+## ~~271. Investigate unifying standalone and tree recorder modes~~
 
-Parsek currently has two recorder modes with divergent code paths:
+**Fix:** Always-tree mode -- `ParsekFlight.StartRecording` creates a single-node `RecordingTree` for every recording. Eliminated `StashPendingOnSceneChange`, `PromoteToTreeForBreakup`, `RestoreActiveStandaloneFromPending`, `ShowPostDestructionMergeDialog`, `CommitFlight`, `PendingStandaloneState`, `VesselSwitchDecision.Stop`. Chain system (`StashPending`/`CommitPending`) and standalone merge dialog retained for backward compat -- to be unified when chain system is removed.
 
-- **Standalone mode** — single `FlightRecorder`, flat `Recording` list, no `activeTree`. Scene-change path: `StashPendingOnSceneChange` in `ParsekFlight.cs`.
-- **Tree mode** — `activeTree` (`RecordingTree`) with multiple recordings, branches, chain continuations. Scene-change path: `FinalizeTreeOnSceneChange` → `StashActiveTreeAsPendingLimbo` / `CommitTreeSceneExit`.
-
-Parity bugs surface when a fix gets applied to one mode but not the other (observed with PR #160's quickload-resume: fix landed for tree mode only). Rule of thumb is now tracked as a memory/feedback item: any change to one mode must also be applied to the other until these are unified.
-
-**Investigate:** can the two modes be merged into a single unified architecture? Tree mode is structurally a superset of standalone — a standalone recording is effectively a single-recording tree with no branches. A unified mode might:
-- Always allocate a `RecordingTree` at recording start, even for trivial single-recording missions
-- Eliminate `StashPendingOnSceneChange` and route everything through the tree path
-- Delete the `pendingRecording` slot in favor of the pending-tree slot
-- Unify the merge dialog, commit paths, and save/load serialization
-
-Risks / open questions:
-- UI assumptions: does the recordings table distinguish "single recording" from "tree with one recording"? Any visual differences the player would notice?
-- Migration: what about existing saves with standalone pending recordings? Do they round-trip through a single-recording-tree form, or do we keep a migration shim?
-- Performance: trees carry more per-recording overhead (BranchPoints dict, BackgroundMap, TreeId lookups). Is that cost acceptable for trivial recordings?
-- Edge cases: non-flight scenes (KSC, TS) currently interact with both modes differently; verify the unified path covers them.
-
-**Priority:** Medium — not blocking any release, but every parity fix widens the surface. Unifying would collapse the maintenance cost at the root.
+**Status:** ~~Fixed~~
 
 ---
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -286,11 +286,13 @@ Follow-up to bug #271 (always-tree unification). The runtime now always creates 
 - Standalone RECORDING serialization in `ParsekScenario.OnSave`/`OnLoad`
 - `PARSEK_ACTIVE_STANDALONE` migration shim in `TryRestoreActiveStandaloneNode`
 
-To remove: collapse `committedRecordings` into `committedTrees` (every recording accessed through its parent tree), delete the standalone pending slot, delete standalone merge dialog, delete standalone RECORDING serialization, delete chain segment standalone commit paths (dead code in always-tree mode). Also update `RunOptimizationPass` (RecordingStore.cs) -- it currently operates on the flat `committedRecordings` list and produces standalone chain-linked recordings on splits. After unification it should operate on tree recordings and keep output within tree structure. This is a ~55-file refactor.
+To remove: collapse `committedRecordings` into `committedTrees` (every recording accessed through its parent tree), delete the standalone pending slot, delete standalone merge dialog, delete standalone RECORDING serialization, delete chain segment standalone commit paths (dead code in always-tree mode). This is a ~55-file refactor.
+
+Critical subtask: adapt `RunOptimizationPass` (RecordingStore.cs) to work within tree structure. Currently the optimizer operates on the flat `committedRecordings` list and `SplitAtSection` produces standalone chain-linked recordings outside the tree. This breaks ghost chain traversal and spawn-at-end for tree recordings. PR #210 added a temporary skip (`if (TreeId != null) return false` in `CanAutoSplitIgnoringGhostTriggers`) so tree recordings are not split. The proper fix: make `SplitAtSection` create new recordings within the parent tree (add to `tree.Recordings`, update `BackgroundMap`/`BranchPoints`), preserving the tree's structural integrity. The skip must be removed once this is done.
 
 Prerequisite: delete all old save files (no users yet, clean slate).
 
-**Priority:** Medium -- the dual storage is confusing but not causing bugs since always-tree routes everything through the tree path at runtime
+**Priority:** High -- the optimizer skip means tree recordings are never split at environment boundaries, losing the per-phase segment display in the UI
 
 ---
 


### PR DESCRIPTION
## Summary

- Every recording now starts as a tree recording, even single-vessel flights -- eliminates the standalone/tree dual-path architecture that caused recurring parity bugs (#160, #293, #294, #305)
- Deleted ~1150 lines of standalone-only code: StashPendingOnSceneChange, PromoteToTreeForBreakup, RestoreActiveStandaloneFromPending, ShowPostDestructionMergeDialog, CommitFlight, PendingStandaloneState, VesselSwitchDecision.Stop
- Migration shim: old saves with PARSEK_ACTIVE_STANDALONE are wrapped into a single-node tree and restored via the tree path
- Recording injector adapted to produce RECORDING_TREE nodes for all synthetic recordings
- GhostVisualSnapshot captured at recording start (full vessel before staging) for ghost mesh rendering
- Optimizer split pass skips tree recordings (temporary -- T56 will adapt the optimizer to work within tree structure)
- Non-leaf active recording included in merge dialog spawn decisions (breakup-continuous design)
- Chain system (StashPending/CommitPending) and standalone merge dialog retained for backward compat -- T56 will remove

## Test plan

- [x] 5717 unit tests pass (0 failures)
- [x] Start simple recording (no staging), revert -- merge dialog appears
- [x] Start recording, F5, fly, F9 -- recording resumes from checkpoint
- [x] Start recording, stage (decouple) -- tree branch created in existing tree
- [x] Start recording, exit to KSC -- auto-commit works
- [x] Start recording, vessel explodes mid-flight -- tree destruction dialog appears
- [x] Ghost mesh shows full vessel (not green sphere) from launch through staging
- [x] Verify logs: "Always-tree: created single-node tree" on every recording start
- [ ] Load old save with PARSEK_ACTIVE_STANDALONE -- migration restores as tree
- [ ] Spawn-at-end works for main vessel after revert with breakup events