### PR TITLE
T56: enable optimizer splits for tree recordings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to Parsek are documented here.
 - `#297` Vessel destruction during tree recording no longer orphans continuation data as a standalone recording.
 - `#304` Stock vessel recordings now show resolved names instead of raw `#autoLOC` keys in the UI, timeline, and logs.
 - `#305` Standalone recordings (rovers, planes) now survive revert-to-launch and show the merge dialog instead of being silently discarded.
+- Landed ghost terrain correction now clamps downward when terrain height decreased since recording (was only clamping upward, leaving ghosts floating above ground).
 - Test runner window no longer spams IMGUI layout exceptions when opened during flight.
 - `T55` FlagEvents and SegmentEvents are now preserved across tree recording splits and flushes.
 - `#298b` Dead engine shutdown sentinels now work for active-vessel recordings (were only emitted for background vessel recordings).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to Parsek are documented here.
 
 - Migrated 9 log contract checks from post-hoc KSP.log analysis to in-game tests (Ctrl+Shift+T) -- catches format, resource, and recording metric issues at runtime instead of after session ends.
 - Unified standalone and tree recording systems -- all recordings now use tree architecture internally (#271).
+- Optimizer now splits tree recordings at environment boundaries, restoring per-phase segment display in the UI (T56 partial).
 
 ### Bug Fixes
 

--- a/Source/Parsek.Tests/GhostChainWalkerTests.cs
+++ b/Source/Parsek.Tests/GhostChainWalkerTests.cs
@@ -758,5 +758,70 @@ namespace Parsek.Tests
         }
 
         #endregion
+
+        #region GetRootLineageVesselPids — chain following
+
+        [Fact]
+        public void GetRootLineageVesselPids_FollowsChainLinks()
+        {
+            // Root recording was split by the optimizer into 2 chain segments.
+            // The ChildBranchPointId is on the second segment.
+            // GetRootLineageVesselPids must follow chain links to reach the BP
+            // and include child vessel PIDs in the lineage.
+            var rootFirst = MakeRecording("root_first", 1000, 17000, 17030);
+            rootFirst.ChainId = "chain_001";
+            rootFirst.ChainIndex = 0;
+            rootFirst.ChainBranch = 0;
+            // No ChildBranchPointId on first half (moved to second)
+
+            var rootSecond = MakeRecording("root_second", 1000, 17030, 17060,
+                childBpId: "bp_staging");
+            rootSecond.ChainId = "chain_001";
+            rootSecond.ChainIndex = 1;
+            rootSecond.ChainBranch = 0;
+
+            var debris = MakeRecording("debris", 2000, 17060, 17100,
+                parentBpId: "bp_staging",
+                terminal: TerminalState.Destroyed);
+
+            var bp = MakeBranchPoint("bp_staging", BranchPointType.JointBreak,
+                17060, 0,
+                new[] { "root_second" }, new[] { "debris" });
+
+            var tree = MakeTree("tree_chain", new[] { rootFirst, rootSecond, debris },
+                new[] { bp });
+
+            var pids = GhostChainWalker.GetRootLineageVesselPids(tree);
+
+            // Should include both root PID and debris PID (reached via chain + BP)
+            Assert.Contains((uint)1000, pids);
+            Assert.Contains((uint)2000, pids);
+        }
+
+        [Fact]
+        public void GetRootLineageVesselPids_NoChain_StillFollowsBP()
+        {
+            // Root recording with direct ChildBranchPointId (no chain split).
+            // Should still work as before.
+            var root = MakeRecording("root", 1000, 17000, 17060,
+                childBpId: "bp_staging");
+
+            var stage = MakeRecording("stage", 3000, 17060, 17120,
+                parentBpId: "bp_staging",
+                terminal: TerminalState.Destroyed);
+
+            var bp = MakeBranchPoint("bp_staging", BranchPointType.JointBreak,
+                17060, 0,
+                new[] { "root" }, new[] { "stage" });
+
+            var tree = MakeTree("tree_nobp", new[] { root, stage }, new[] { bp });
+
+            var pids = GhostChainWalker.GetRootLineageVesselPids(tree);
+
+            Assert.Contains((uint)1000, pids);
+            Assert.Contains((uint)3000, pids);
+        }
+
+        #endregion
     }
 }

--- a/Source/Parsek.Tests/RecordingOptimizerTests.cs
+++ b/Source/Parsek.Tests/RecordingOptimizerTests.cs
@@ -716,6 +716,16 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void CanAutoSplitIgnoringGhostTriggers_AllowsTreeRecordings()
+        {
+            var rec = MakeRecordingWithSections(17000, 17030, 17060,
+                SegmentEnvironment.ExoBallistic, SegmentEnvironment.Atmospheric);
+            rec.TreeId = "tree-001";
+
+            Assert.True(RecordingOptimizer.CanAutoSplitIgnoringGhostTriggers(rec, 1));
+        }
+
+        [Fact]
         public void CanAutoSplitIgnoringGhostTriggers_StillChecksMinDuration()
         {
             var rec = MakeRecordingWithSections(17000, 17057, 17060,
@@ -752,6 +762,19 @@ namespace Parsek.Tests
             var committed = new List<Recording> { rec };
 
             Assert.Empty(RecordingOptimizer.FindSplitCandidates(committed));
+            var candidates = RecordingOptimizer.FindSplitCandidatesForOptimizer(committed);
+            Assert.Single(candidates);
+            Assert.Equal((0, 1), candidates[0]);
+        }
+
+        [Fact]
+        public void FindSplitCandidatesForOptimizer_FindsTreeRecordings()
+        {
+            var rec = MakeRecordingWithSections(17000, 17030, 17060,
+                SegmentEnvironment.ExoBallistic, SegmentEnvironment.Atmospheric);
+            rec.TreeId = "tree-001";
+            var committed = new List<Recording> { rec };
+
             var candidates = RecordingOptimizer.FindSplitCandidatesForOptimizer(committed);
             Assert.Single(candidates);
             Assert.Equal((0, 1), candidates[0]);
@@ -1025,11 +1048,9 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void RunOptimizationPass_SkipsTreeRecordings()
+        public void RunOptimizationPass_SplitsTreeRecordingsAtEnvBoundary()
         {
-            // Bug #271: tree recordings must not be split by the optimizer.
-            // The optimizer produces standalone chain recordings outside the tree
-            // structure, breaking ghost chain traversal. Tree splits deferred to T56.
+            // T56: tree recordings are now split at environment boundaries.
             RecordingStore.SuppressLogging = true;
             RecordingStore.ResetForTesting();
 
@@ -1053,9 +1074,12 @@ namespace Parsek.Tests
 
             RecordingStore.RunOptimizationPass();
 
-            // Tree recording should NOT be split
-            Assert.Equal(1, recordings.Count);
+            // Tree recording should be split into 2 chain segments
+            Assert.Equal(2, recordings.Count);
             Assert.Equal("rec_in_tree", recordings[0].RecordingId);
+            Assert.Equal("tree_001", recordings[0].TreeId);
+            Assert.Equal("tree_001", recordings[1].TreeId);
+            Assert.Equal(2, tree.Recordings.Count);
 
             RecordingStore.ResetForTesting();
         }
@@ -1084,9 +1108,11 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void RunOptimizationPass_SkipsTreeRecordingsWithBranchPoints()
+        public void RunOptimizationPass_SplitsTreeRecordingAndUpdatesBranchPoint()
         {
-            // Bug #271: tree recordings with branch points must not be split.
+            // T56: tree recordings are now split at environment boundaries.
+            // The ChildBranchPointId moves to the second half, and the
+            // BranchPoint.ParentRecordingIds is updated to reference it.
             RecordingStore.SuppressLogging = true;
             RecordingStore.ResetForTesting();
 
@@ -1119,10 +1145,22 @@ namespace Parsek.Tests
 
             RecordingStore.RunOptimizationPass();
 
-            // Tree recording should NOT be split
-            Assert.Equal(1, recordings.Count);
+            // Tree recording should be split into 2
+            Assert.Equal(2, recordings.Count);
+            Assert.Equal(2, tree.Recordings.Count);
+
+            // First half keeps original ID, no ChildBranchPointId
             Assert.Equal("parent_rec", recordings[0].RecordingId);
-            Assert.Equal("bp_001", recordings[0].ChildBranchPointId);
+            Assert.Null(recordings[0].ChildBranchPointId);
+
+            // Second half gets ChildBranchPointId
+            var secondHalf = recordings[1];
+            Assert.Equal("bp_001", secondHalf.ChildBranchPointId);
+            Assert.Equal("tree_bp", secondHalf.TreeId);
+
+            // BP.ParentRecordingIds updated to reference second half
+            Assert.Contains(secondHalf.RecordingId, bp.ParentRecordingIds);
+            Assert.DoesNotContain("parent_rec", bp.ParentRecordingIds);
 
             RecordingStore.ResetForTesting();
         }
@@ -2071,18 +2109,18 @@ namespace Parsek.Tests
 
         /// <summary>
         /// Simulates a Mun mission: launch (atmo), orbit+transfer (exo), approach, surface.
-        /// The main recording has a staging branch point during exo phase.
+        /// The main recording has a staging branch point at the end.
         /// After optimizer splits, verifies:
-        /// - 4 chain segments (atmo, exo, approach, surface)
-        /// - ChildBranchPointId ends up on the exo segment (where the staging happened)
-        /// - BranchPoint.ParentRecordingIds correctly references the exo segment
+        /// - 4 chain segments from main (atmo, exo, approach, surface) + 1 debris = 5 total
+        /// - ChildBranchPointId ends up on the last chain segment (surface)
+        /// - BranchPoint.ParentRecordingIds correctly references the last segment
         /// - Chain indices are sequential
+        /// - All chain segments are in the tree's Recordings dict
         /// - Debris recording is untouched
         /// </summary>
         [Fact]
-        public void RunOptimizationPass_TreeWithBranchPoint_NotSplit()
+        public void RunOptimizationPass_TreeMultiSection_SplitsIntoChainSegments()
         {
-            // Bug #271: tree recordings are skipped by the optimizer.
             RecordingStore.SuppressLogging = true;
             RecordingStore.ResetForTesting();
 
@@ -2124,20 +2162,18 @@ namespace Parsek.Tests
                 frames = new List<TrajectoryPoint>()
             });
 
-            // Branch point at recording's temporal end (UT=17700), as in real tree mode
-            // where ChildBranchPointId is set at branchUT during CreateSplitBranch.
             main.ChildBranchPointId = "bp_staging";
 
             var bp = new BranchPoint
             {
                 Id = "bp_staging",
-                UT = 17700, // at recording's end (as in real tree mode)
+                UT = 17700,
                 Type = BranchPointType.JointBreak,
                 ParentRecordingIds = new List<string> { "main_rec" },
                 ChildRecordingIds = new List<string> { "main_continuation", "debris_rec" }
             };
 
-            // Debris recording (booster) — single environment, won't be split
+            // Debris recording (booster) -- single environment, won't be split
             var debris = new Recording
             {
                 RecordingId = "debris_rec",
@@ -2174,15 +2210,27 @@ namespace Parsek.Tests
 
             RecordingStore.RunOptimizationPass();
 
-            // Bug #271: tree recordings should NOT be split — 2 recordings remain (main + debris)
-            Assert.Equal(2, recordings.Count);
+            // 4 chain segments from main + 1 debris = 5 recordings
+            Assert.Equal(5, recordings.Count);
+            Assert.Equal(5, tree.Recordings.Count);
 
-            // Main recording unchanged
-            var mainResult = recordings.Find(r => r.RecordingId == "main_rec");
-            Assert.NotNull(mainResult);
-            Assert.Equal("tree_mun", mainResult.TreeId);
-            Assert.Equal("bp_staging", mainResult.ChildBranchPointId);
-            Assert.Equal(14, mainResult.Points.Count);
+            // All chain segments should have TreeId set and share a ChainId
+            var chainMembers = recordings.FindAll(r => r.RecordingId == "main_rec" || r.ChainId == main.ChainId);
+            Assert.Equal(4, chainMembers.Count);
+            chainMembers.Sort((a, b) => a.StartUT.CompareTo(b.StartUT));
+            for (int i = 0; i < chainMembers.Count; i++)
+            {
+                Assert.Equal("tree_mun", chainMembers[i].TreeId);
+                Assert.Equal(i, chainMembers[i].ChainIndex);
+            }
+
+            // ChildBranchPointId should be on the last chain segment only
+            for (int i = 0; i < chainMembers.Count - 1; i++)
+                Assert.Null(chainMembers[i].ChildBranchPointId);
+            Assert.Equal("bp_staging", chainMembers[chainMembers.Count - 1].ChildBranchPointId);
+
+            // BP.ParentRecordingIds should reference the last chain segment
+            Assert.Contains(chainMembers[chainMembers.Count - 1].RecordingId, bp.ParentRecordingIds);
 
             // Debris recording unchanged
             var debrisResult = recordings.Find(r => r.RecordingId == "debris_rec");

--- a/Source/Parsek.Tests/RecordingStoreTests.cs
+++ b/Source/Parsek.Tests/RecordingStoreTests.cs
@@ -1237,6 +1237,217 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void RunOptimizationPass_SplitsTreeRecording()
+        {
+            RecordingStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+
+            // Build a tree with one recording that spans two environment sections
+            var tree = new RecordingTree
+            {
+                Id = "tree-split-test",
+                TreeName = "SplitTest"
+            };
+
+            var rec = new Recording
+            {
+                RecordingId = "rec-001",
+                VesselName = "Rocket",
+                TreeId = tree.Id,
+                VesselPersistentId = 42,
+                TerminalStateValue = TerminalState.Destroyed,
+                GhostVisualSnapshot = new ConfigNode("VESSEL"),
+                RecordingFormatVersion = 0
+            };
+            // Points spanning exo→atmo transition
+            rec.Points.Add(new TrajectoryPoint { ut = 17000, altitude = 80000, bodyName = "Kerbin" });
+            rec.Points.Add(new TrajectoryPoint { ut = 17029, altitude = 40000, bodyName = "Kerbin" });
+            rec.Points.Add(new TrajectoryPoint { ut = 17030, altitude = 30000, bodyName = "Kerbin" });
+            rec.Points.Add(new TrajectoryPoint { ut = 17060, altitude = 100, bodyName = "Kerbin" });
+            rec.TrackSections.Add(new TrackSection
+            {
+                environment = SegmentEnvironment.ExoBallistic,
+                startUT = 17000, endUT = 17030,
+                frames = new List<TrajectoryPoint>()
+            });
+            rec.TrackSections.Add(new TrackSection
+            {
+                environment = SegmentEnvironment.Atmospheric,
+                startUT = 17030, endUT = 17060,
+                frames = new List<TrajectoryPoint>()
+            });
+
+            tree.Recordings[rec.RecordingId] = rec;
+            tree.RootRecordingId = rec.RecordingId;
+
+            // Commit tree directly
+            RecordingStore.CommittedRecordings.Add(rec);
+            RecordingStore.CommittedTrees.Add(tree);
+
+            RecordingStore.RunOptimizationPass();
+
+            // Tree should now have 2 recordings
+            Assert.Equal(2, tree.Recordings.Count);
+            Assert.Equal(2, RecordingStore.CommittedRecordings.Count);
+
+            // Both recordings should have the tree ID
+            foreach (var r in tree.Recordings.Values)
+                Assert.Equal(tree.Id, r.TreeId);
+
+            // Chain linkage: both should share a ChainId
+            var all = new List<Recording>(tree.Recordings.Values);
+            all.Sort((a, b) => a.StartUT.CompareTo(b.StartUT));
+            Assert.Equal(all[0].ChainId, all[1].ChainId);
+            Assert.Equal(0, all[0].ChainIndex);
+            Assert.Equal(1, all[1].ChainIndex);
+
+            // Terminal state should be on the second half only
+            Assert.Null(all[0].TerminalStateValue);
+            Assert.Equal(TerminalState.Destroyed, all[1].TerminalStateValue);
+
+            RecordingStore.ResetForTesting();
+        }
+
+        [Fact]
+        public void RunOptimizationPass_SplitUpdatesTreeBranchPoint()
+        {
+            RecordingStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+
+            // Build a tree with one recording that has a ChildBranchPointId
+            // and spans two environment sections -- the split should move
+            // the ChildBranchPointId to the second half and update the BP
+            var tree = new RecordingTree
+            {
+                Id = "tree-bp-test",
+                TreeName = "BPTest"
+            };
+
+            var bp = new BranchPoint
+            {
+                Id = "bp-001",
+                UT = 17060,
+                Type = BranchPointType.Undock,
+                ParentRecordingIds = new List<string> { "rec-parent" },
+                ChildRecordingIds = new List<string> { "rec-child" }
+            };
+            tree.BranchPoints.Add(bp);
+
+            var rec = new Recording
+            {
+                RecordingId = "rec-parent",
+                VesselName = "Rocket",
+                TreeId = tree.Id,
+                VesselPersistentId = 42,
+                ChildBranchPointId = "bp-001",
+                GhostVisualSnapshot = new ConfigNode("VESSEL"),
+                RecordingFormatVersion = 0
+            };
+            rec.Points.Add(new TrajectoryPoint { ut = 17000, altitude = 80000, bodyName = "Kerbin" });
+            rec.Points.Add(new TrajectoryPoint { ut = 17029, altitude = 40000, bodyName = "Kerbin" });
+            rec.Points.Add(new TrajectoryPoint { ut = 17030, altitude = 30000, bodyName = "Kerbin" });
+            rec.Points.Add(new TrajectoryPoint { ut = 17060, altitude = 100, bodyName = "Kerbin" });
+            rec.TrackSections.Add(new TrackSection
+            {
+                environment = SegmentEnvironment.ExoBallistic,
+                startUT = 17000, endUT = 17030,
+                frames = new List<TrajectoryPoint>()
+            });
+            rec.TrackSections.Add(new TrackSection
+            {
+                environment = SegmentEnvironment.Atmospheric,
+                startUT = 17030, endUT = 17060,
+                frames = new List<TrajectoryPoint>()
+            });
+
+            tree.Recordings[rec.RecordingId] = rec;
+            tree.RootRecordingId = rec.RecordingId;
+
+            RecordingStore.CommittedRecordings.Add(rec);
+            RecordingStore.CommittedTrees.Add(tree);
+
+            RecordingStore.RunOptimizationPass();
+
+            // After split, first half should have no ChildBranchPointId
+            Assert.Null(rec.ChildBranchPointId);
+
+            // Second half should have the ChildBranchPointId
+            var all = new List<Recording>(tree.Recordings.Values);
+            var secondHalf = all.Find(r => r.RecordingId != "rec-parent");
+            Assert.NotNull(secondHalf);
+            Assert.Equal("bp-001", secondHalf.ChildBranchPointId);
+
+            // BranchPoint.ParentRecordingIds should reference the second half, not the original
+            Assert.Contains(secondHalf.RecordingId, bp.ParentRecordingIds);
+            Assert.DoesNotContain("rec-parent", bp.ParentRecordingIds);
+
+            RecordingStore.ResetForTesting();
+        }
+
+        [Fact]
+        public void RunOptimizationPass_SplitLogsTreeId()
+        {
+            RecordingStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+
+            var logLines = new List<string>();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+            try
+            {
+                var tree = new RecordingTree
+                {
+                    Id = "tree-log-test",
+                    TreeName = "LogTest"
+                };
+
+                var rec = new Recording
+                {
+                    RecordingId = "rec-log",
+                    VesselName = "Rocket",
+                    TreeId = tree.Id,
+                    VesselPersistentId = 42,
+                    TerminalStateValue = TerminalState.Destroyed,
+                    GhostVisualSnapshot = new ConfigNode("VESSEL"),
+                    RecordingFormatVersion = 0
+                };
+                rec.Points.Add(new TrajectoryPoint { ut = 17000, altitude = 80000, bodyName = "Kerbin" });
+                rec.Points.Add(new TrajectoryPoint { ut = 17029, altitude = 40000, bodyName = "Kerbin" });
+                rec.Points.Add(new TrajectoryPoint { ut = 17030, altitude = 30000, bodyName = "Kerbin" });
+                rec.Points.Add(new TrajectoryPoint { ut = 17060, altitude = 100, bodyName = "Kerbin" });
+                rec.TrackSections.Add(new TrackSection
+                {
+                    environment = SegmentEnvironment.ExoBallistic,
+                    startUT = 17000, endUT = 17030,
+                    frames = new List<TrajectoryPoint>()
+                });
+                rec.TrackSections.Add(new TrackSection
+                {
+                    environment = SegmentEnvironment.Atmospheric,
+                    startUT = 17030, endUT = 17060,
+                    frames = new List<TrajectoryPoint>()
+                });
+
+                tree.Recordings[rec.RecordingId] = rec;
+                tree.RootRecordingId = rec.RecordingId;
+
+                RecordingStore.CommittedRecordings.Add(rec);
+                RecordingStore.CommittedTrees.Add(tree);
+
+                RecordingStore.RunOptimizationPass();
+
+                Assert.Contains(logLines, l =>
+                    l.Contains("[RecordingStore]") && l.Contains("Split recording") && l.Contains("tree=tree-log-test"));
+            }
+            finally
+            {
+                ParsekLog.SuppressLogging = true;
+                ParsekLog.ResetTestOverrides();
+                RecordingStore.ResetForTesting();
+            }
+        }
+
+        [Fact]
         public void RunOptimizationPass_LogsFlushDirtyFiles()
         {
             var logLines = new List<string>();

--- a/Source/Parsek/GhostChainWalker.cs
+++ b/Source/Parsek/GhostChainWalker.cs
@@ -290,7 +290,7 @@ namespace Parsek
         /// lineage — tracing from the root recording through ChildBranchPointId chains.
         /// Any recording with a VesselPersistentId NOT in this set is a background recording.
         /// </summary>
-        private static HashSet<uint> GetRootLineageVesselPids(RecordingTree tree)
+        internal static HashSet<uint> GetRootLineageVesselPids(RecordingTree tree)
         {
             var pids = new HashSet<uint>();
 
@@ -336,6 +336,24 @@ namespace Parsek
                             if (tree.Recordings.TryGetValue(bp.ChildRecordingIds[c], out childRec))
                                 TraceLineagePids(tree, childRec, pids, visited);
                         }
+                        break;
+                    }
+                }
+            }
+
+            // Follow chain links: optimizer splits create chain-linked segments
+            // where ChildBranchPointId moves to the last segment. Trace through
+            // the next chain member to reach the segment that carries the BP.
+            if (!string.IsNullOrEmpty(rec.ChainId))
+            {
+                int nextIdx = rec.ChainIndex + 1;
+                foreach (var kvp in tree.Recordings)
+                {
+                    if (kvp.Value.ChainId == rec.ChainId
+                        && kvp.Value.ChainIndex == nextIdx
+                        && kvp.Value.ChainBranch == rec.ChainBranch)
+                    {
+                        TraceLineagePids(tree, kvp.Value, pids, visited);
                         break;
                     }
                 }

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -5890,6 +5890,11 @@ namespace Parsek
                 ? FlightRecorder.FindVesselByPid(rec.VesselPersistentId)
                 : null;
 
+            if (isLeaf && rec.VesselPersistentId != 0 && finalizeVessel == null)
+                ParsekLog.Verbose("Flight",
+                    $"FinalizeIndividualRecording: vessel pid={rec.VesselPersistentId} not found " +
+                    $"for '{rec.RecordingId}' (isSceneExit={isSceneExit}) — re-snapshot will be skipped");
+
             // Determine terminal state for recordings that don't have one yet
             if (isLeaf && !rec.TerminalStateValue.HasValue)
             {
@@ -7878,10 +7883,16 @@ namespace Parsek
                 targetAlt = terrainAlt + VesselSpawner.LandedGhostClearanceMeters;
             }
 
-            if (p.altitude >= targetAlt)
+            // When we have recorded terrain data, always correct to preserve the original
+            // clearance — terrain may be higher OR lower now than at recording time.
+            // Without recorded terrain (NaN fallback), only push up to minimum clearance.
+            if (double.IsNaN(recordedTerrainHeight) && p.altitude >= targetAlt)
                 return p;
 
             double delta = targetAlt - p.altitude;
+            if (System.Math.Abs(delta) < 0.01)
+                return p; // already at target (within tolerance)
+
             ParsekLog.VerboseRateLimited("TerrainCorrect", $"landed-ghost-{index}",
                 $"Landed ghost clamp #{index} (\"{vesselName}\"): " +
                 $"alt={p.altitude.ToString("F1", ic)} terrain={terrainAlt.ToString("F1", ic)} " +

--- a/Source/Parsek/RecordingOptimizer.cs
+++ b/Source/Parsek/RecordingOptimizer.cs
@@ -85,10 +85,6 @@ namespace Parsek
         internal static bool CanAutoSplitIgnoringGhostTriggers(Recording rec, int sectionIndex)
         {
             if (rec == null) return false;
-            // Bug #271: skip tree recordings. The optimizer produces standalone chain
-            // recordings that aren't in the tree structure, breaking ghost chain traversal.
-            // Tree recording splits will be handled when T56 unifies the format.
-            if (!string.IsNullOrEmpty(rec.TreeId)) return false;
             if (rec.TrackSections == null || rec.TrackSections.Count < 2) return false;
             if (sectionIndex < 1 || sectionIndex >= rec.TrackSections.Count) return false;
 

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -1112,8 +1112,9 @@ namespace Parsek
                 splitCount++;
                 splitChanged = true;
                 ParsekLog.Info("RecordingStore",
-                    $"Split recording '{original.VesselName}' at section {secIdx}: " +
-                    $"'{original.SegmentPhase ?? "?"}' [{original.StartUT:F0}..{original.EndUT:F0}] + " +
+                    $"Split recording '{original.VesselName}' at section {secIdx}" +
+                    (!string.IsNullOrEmpty(original.TreeId) ? $" (tree={original.TreeId})" : "") +
+                    $": '{original.SegmentPhase ?? "?"}' [{original.StartUT:F0}..{original.EndUT:F0}] + " +
                     $"'{second.SegmentPhase ?? "?"}' [{second.StartUT:F0}..{second.EndUT:F0}]");
             }
 
@@ -1144,6 +1145,15 @@ namespace Parsek
             // Loop sync pass: link debris recordings to their parent recording
             // so debris ghosts replay in sync with the parent's loop cycle.
             PopulateLoopSyncParentIndices(recordings);
+
+            // Rebuild BackgroundMap for trees that had structural changes (splits/merges).
+            // BackgroundMap is a runtime-only field mapping PID → RecordingId; splits create
+            // new recordings and merges remove them, invalidating the map.
+            if (mergeCount > 0 || splitCount > 0)
+            {
+                for (int t = 0; t < committedTrees.Count; t++)
+                    committedTrees[t].RebuildBackgroundMap();
+            }
 
             // Flush all dirty recordings to disk so the crash window after
             // commit+optimize is closed (data no longer lives only in RAM).

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -333,6 +333,24 @@ Fix: ensure debris recordings either (a) capture the engine shutdown at separati
 
 ---
 
+### T59. Rewind save lost after mid-recording EVA branch
+
+The R button never appears in the recordings table because `RewindSaveFileName` is lost during the EVA branch flow. The sequence:
+
+1. Recording starts, `CaptureRewindSave` sets `recorder.RewindSaveFileName = "parsek_rw_..."` 
+2. Mid-flight EVA triggers `BuildCaptureRecording` for the parent vessel, which copies `RewindSaveFileName` into `CaptureAtStop` and then clears `recorder.RewindSaveFileName = null` (line 4573)
+3. Bob's EVA recording starts as a promotion (rewind save skipped)
+4. At scene exit, `StashTreeLimbo` calls `recorder.ForceStop()` which calls `BuildCaptureRecording` for Bob's EVA -- this creates a NEW `CaptureAtStop` (with no rewind save) that OVERWRITES the previous one
+5. Line 5465: `recorder.CaptureAtStop?.RewindSaveFileName` = null (Bob's), `recorder.RewindSaveFileName` = null (cleared in step 2). Rewind save is never copied to the root recording
+
+The rewind save file exists on disk (`Parsek/Saves/parsek_rw_*.sfs`) but the root Recording object never gets the filename, so `GetRewindSaveFileName` returns null, and the R button renders as empty space.
+
+Fix: in `FlushRecorderToTreeRecording` (or the EVA branch code), copy `recorder.RewindSaveFileName` to the root tree recording BEFORE `BuildCaptureRecording` clears it. Or preserve the rewind save across CaptureAtStop overwrites.
+
+**Priority:** High -- the R button is a core user affordance and never appears after any EVA during a recording session
+
+---
+
 ## TODO — Nice to have
 
 ### ~~T53. Watch camera mode selection~~

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -304,6 +304,23 @@ Prerequisite: delete all old save files (no users yet, clean slate).
 
 ---
 
+### T57. EVA spawn-at-end blocked by parent vessel collision
+
+EVA recordings created by mid-flight EVA (tree branch) fail to spawn at end because the entire EVA trajectory overlaps with the already-spawned parent vessel. The spawn collision walkback exhausts every point in the trajectory and abandons the spawn.
+
+Observed in t56-optimizer-test session: Bob Kerman did a surface EVA near the launchpad. The parent vessel (Kerbal X) spawned first, then Bob's EVA spawn was abandoned because his entire trajectory (surface walk near pad) was within the 2.5m EVA collision bounds of the parent. Bob never materialized.
+
+Secondary issue: the held-ghost retry logic (`ParsekPlaybackPolicy.cs:395`) checks `VesselSpawned` but not `SpawnAbandoned`, so it logs "succeeded on retry" for abandoned spawns.
+
+Fix options:
+1. Exempt EVA vessels from collision checks against their known parent vessel (use `ParentRecordingId` to identify the parent, look up its `VesselPersistentId`)
+2. When EVA spawn is abandoned due to parent collision, fall back to boarding the crew member onto the parent vessel instead
+3. Both -- try spawning, skip collision against parent, fall back to boarding if still blocked
+
+**Priority:** Medium -- pre-existing issue, not caused by optimizer changes but exposed by enabling tree recording spawns
+
+---
+
 ## TODO — Nice to have
 
 ### ~~T53. Watch camera mode selection~~

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -321,6 +321,18 @@ Fix options:
 
 ---
 
+### T58. Debris/booster ghost engines show running effects at zero throttle after staging
+
+When a booster separates (staging, decouple), the debris recording inherits the engine state from the moment of separation. If the engine was running at separation, the ghost plays back engine FX (flame, smoke) even though the throttle is 0 on the separated stage. The engine was shut down by staging but the ghost's seed events or initial state show it as running.
+
+Likely cause: the engine shutdown event at separation is either not captured (the `EngineShutdown` event fires after the part is already on the debris vessel, and the recorder may not catch it on the new vessel's first frame), or the ghost FX system seeds the engine as running from the pre-separation snapshot without checking the throttle value.
+
+Fix: ensure debris recordings either (a) capture the engine shutdown at separation as a seed event, or (b) the ghost FX system checks throttle == 0 and suppresses effects even if the engine state says "running."
+
+**Priority:** Low -- cosmetic, affects ghost visual fidelity only
+
+---
+
 ## TODO — Nice to have
 
 ### ~~T53. Watch camera mode selection~~

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -288,11 +288,13 @@ Follow-up to bug #271 (always-tree unification). The runtime now always creates 
 
 To remove: collapse `committedRecordings` into `committedTrees` (every recording accessed through its parent tree), delete the standalone pending slot, delete standalone merge dialog, delete standalone RECORDING serialization, delete chain segment standalone commit paths (dead code in always-tree mode). This is a ~55-file refactor.
 
-Critical subtask: adapt `RunOptimizationPass` (RecordingStore.cs) to work within tree structure. Currently the optimizer operates on the flat `committedRecordings` list and `SplitAtSection` produces standalone chain-linked recordings outside the tree. This breaks ghost chain traversal and spawn-at-end for tree recordings. PR #210 added a temporary skip (`if (TreeId != null) return false` in `CanAutoSplitIgnoringGhostTriggers`) so tree recordings are not split. The proper fix: make `SplitAtSection` create new recordings within the parent tree (add to `tree.Recordings`, update `BackgroundMap`/`BranchPoints`), preserving the tree's structural integrity. The skip must be removed once this is done.
+~~Critical subtask (done):~~ Removed the temporary `TreeId != null` skip in `CanAutoSplitIgnoringGhostTriggers`. The existing `RunOptimizationPass` code already added split recordings to `tree.Recordings` and updated `BranchPoint.ParentRecordingIds`; the skip was the only thing preventing tree splits. Added `RebuildBackgroundMap()` after optimization passes for tree consistency.
+
+Remaining: collapse `committedRecordings` into `committedTrees` (~55-file refactor, see list above).
 
 Prerequisite: delete all old save files (no users yet, clean slate).
 
-**Priority:** High -- the optimizer skip means tree recordings are never split at environment boundaries, losing the per-phase segment display in the UI
+**Priority:** Medium -- optimizer adaptation done, standalone format removal is cleanup
 
 ---
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -288,9 +288,15 @@ Follow-up to bug #271 (always-tree unification). The runtime now always creates 
 
 To remove: collapse `committedRecordings` into `committedTrees` (every recording accessed through its parent tree), delete the standalone pending slot, delete standalone merge dialog, delete standalone RECORDING serialization, delete chain segment standalone commit paths (dead code in always-tree mode). This is a ~55-file refactor.
 
-~~Critical subtask (done):~~ Removed the temporary `TreeId != null` skip in `CanAutoSplitIgnoringGhostTriggers`. The existing `RunOptimizationPass` code already added split recordings to `tree.Recordings` and updated `BranchPoint.ParentRecordingIds`; the skip was the only thing preventing tree splits. Added `RebuildBackgroundMap()` after optimization passes for tree consistency.
+~~Critical subtask (done):~~ Removed the temporary `TreeId != null` skip in `CanAutoSplitIgnoringGhostTriggers`. The existing `RunOptimizationPass` code already added split recordings to `tree.Recordings` and updated `BranchPoint.ParentRecordingIds`; the skip was the only thing preventing tree splits. Added `RebuildBackgroundMap()` after optimization passes for tree consistency. Fixed `TraceLineagePids` to follow chain links so root lineage PID collection works after optimizer splits.
 
-Remaining: collapse `committedRecordings` into `committedTrees` (~55-file refactor, see list above).
+Remaining (~55-file refactor, ordered by dependency):
+1. Delete `StashPending`/`CommitPending`/`DiscardPending` and the standalone pending slot (`pendingRecording`). All commit paths now go through `StashPendingTree`/`CommitPendingTree`.
+2. Delete `MergeDialog.Show(Recording)` and `ShowStandaloneDialog` -- only the tree merge dialog (`ShowTreeDialog`) is used.
+3. Delete standalone RECORDING serialization in `ParsekScenario.OnSave`/`OnLoad` (the `PARSEK_ACTIVE_RECORDING` node path, not the `PARSEK_ACTIVE_RECORDING_TREE` path).
+4. Delete `PARSEK_ACTIVE_STANDALONE` migration shim in `TryRestoreActiveStandaloneNode`.
+5. Delete chain segment standalone commit paths in `ChainSegmentManager` (dead code in always-tree mode).
+6. Collapse `committedRecordings` into `committedTrees`: replace all 238 production refs (28 files) and 300 test refs (27 files) with tree-based access (e.g., `committedTrees.SelectMany(t => t.Recordings.Values)`). This is the bulk of the work.
 
 Prerequisite: delete all old save files (no users yet, clean slate).
 


### PR DESCRIPTION
## Summary

- Removed the temporary `TreeId != null` skip in `CanAutoSplitIgnoringGhostTriggers` that prevented tree recordings from being split at environment boundaries
- Added `RebuildBackgroundMap()` call after optimization passes to keep tree runtime maps consistent
- Updated 3 existing tests that asserted old skip behavior, added 3 new integration tests for tree-internal splits

## Context

PR #210 unified all recordings into trees but added a temporary optimizer skip because tree-internal splits weren't fully verified. Investigation confirmed the existing `RunOptimizationPass` code already maintained tree integrity:
- Split recordings added to `tree.Recordings` dict (line 1100)
- `BranchPoint.ParentRecordingIds` updated when `ChildBranchPointId` moves to second half (lines 1056-1088)

The skip was the only blocker. An opus agent code review verified that `GhostChainWalker.WalkToLeaf` (which uses `ChildBranchPointId` traversal, not `ChainId`) is unaffected, and `BackgroundMap` is only used during active recording (not ghost playback).

## Test plan

- [x] 5722 unit tests pass (0 failures)
- [x] New test: `RunOptimizationPass_SplitsTreeRecording` -- verifies tree dict, chain linkage, terminal state transfer
- [x] New test: `RunOptimizationPass_SplitUpdatesTreeBranchPoint` -- verifies BP.ParentRecordingIds updated
- [x] New test: `RunOptimizationPass_SplitLogsTreeId` -- verifies tree ID in split log
- [x] Updated test: `RunOptimizationPass_TreeMultiSection_SplitsIntoChainSegments` -- 4-section Mun mission splits into 4 chain segments with correct BP handling
- [ ] In-game: launch a multi-phase flight (atmo->exo->surface), verify recordings table shows per-phase segments