### PR TITLE
Fix T57/T58/T59: EVA spawn, debris engine FX, rewind save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ All notable changes to Parsek are documented here.
 - Test runner window no longer spams IMGUI layout exceptions when opened during flight.
 - `T55` FlagEvents and SegmentEvents are now preserved across tree recording splits and flushes.
 - `#298b` Dead engine shutdown sentinels now work for active-vessel recordings (were only emitted for background vessel recordings).
+- `T59` Rewind (R button) now works after mid-recording EVA -- rewind save filename and budget are copied to the tree root at branch time.
+- `T58` Debris ghost engines no longer show running FX at zero throttle after staging -- inherited engine state respects the child vessel's operational assessment.
+- `T57` EVA recordings now spawn at end instead of being abandoned -- parent vessel is exempt from collision checks during EVA walkback.
 
 ### New Features
 

--- a/Source/Parsek.Tests/BackgroundRecorderTests.cs
+++ b/Source/Parsek.Tests/BackgroundRecorderTests.cs
@@ -1095,6 +1095,121 @@ namespace Parsek.Tests
             }
         }
 
+        [Fact]
+        public void MergeInheritedEngineState_NonOperationalOnChild_SkippedT58()
+        {
+            // T58: Parent had engine running at 0.8, child has the engine part (in allEngineKeys)
+            // but SeedEngines determined it's non-operational (not in activeEngineKeys).
+            // This happens after staging when fuel is severed. Should NOT inherit.
+            ulong key = FlightRecorder.EncodeEngineKey(500, 0);
+            var inherited = new InheritedEngineState
+            {
+                activeEngineKeys = new HashSet<ulong> { key },
+                engineThrottles = new Dictionary<ulong, float> { { key, 0.8f } }
+            };
+            var activeEngineKeys = new HashSet<ulong>(); // NOT seeded (non-operational)
+            var lastThrottle = new Dictionary<ulong, float>();
+            var activeRcsKeys = new HashSet<ulong>();
+            var lastRcsThrottle = new Dictionary<ulong, float>();
+            var childPartPids = new HashSet<uint> { 500 };
+            var allEngineKeys = new HashSet<ulong> { key }; // SeedEngines found it, but not operational
+
+            int merged = BackgroundRecorder.MergeInheritedEngineState(
+                inherited, activeEngineKeys, lastThrottle,
+                activeRcsKeys, lastRcsThrottle, childPartPids, allEngineKeys);
+
+            Assert.Equal(0, merged);
+            Assert.DoesNotContain(key, activeEngineKeys);
+            Assert.False(lastThrottle.ContainsKey(key));
+        }
+
+        [Fact]
+        public void MergeInheritedEngineState_NotInAllEngineKeys_StillMergedT58()
+        {
+            // Engine not found by SeedEngines at all (KSP timing) — should still inherit.
+            ulong key = FlightRecorder.EncodeEngineKey(500, 0);
+            var inherited = new InheritedEngineState
+            {
+                activeEngineKeys = new HashSet<ulong> { key },
+                engineThrottles = new Dictionary<ulong, float> { { key, 0.8f } }
+            };
+            var activeEngineKeys = new HashSet<ulong>();
+            var lastThrottle = new Dictionary<ulong, float>();
+            var activeRcsKeys = new HashSet<ulong>();
+            var lastRcsThrottle = new Dictionary<ulong, float>();
+            var childPartPids = new HashSet<uint> { 500 };
+            var allEngineKeys = new HashSet<ulong>(); // SeedEngines didn't find this engine at all
+
+            int merged = BackgroundRecorder.MergeInheritedEngineState(
+                inherited, activeEngineKeys, lastThrottle,
+                activeRcsKeys, lastRcsThrottle, childPartPids, allEngineKeys);
+
+            Assert.Equal(1, merged);
+            Assert.Contains(key, activeEngineKeys);
+            Assert.Equal(0.8f, lastThrottle[key]);
+        }
+
+        [Fact]
+        public void MergeInheritedEngineState_NullAllEngineKeys_BackwardCompatT58()
+        {
+            // allEngineKeys=null (backward compat) — should merge like before.
+            ulong key = FlightRecorder.EncodeEngineKey(500, 0);
+            var inherited = new InheritedEngineState
+            {
+                activeEngineKeys = new HashSet<ulong> { key },
+                engineThrottles = new Dictionary<ulong, float> { { key, 0.7f } }
+            };
+            var activeEngineKeys = new HashSet<ulong>();
+            var lastThrottle = new Dictionary<ulong, float>();
+            var activeRcsKeys = new HashSet<ulong>();
+            var lastRcsThrottle = new Dictionary<ulong, float>();
+            var childPartPids = new HashSet<uint> { 500 };
+
+            int merged = BackgroundRecorder.MergeInheritedEngineState(
+                inherited, activeEngineKeys, lastThrottle,
+                activeRcsKeys, lastRcsThrottle, childPartPids, allEngineKeys: null);
+
+            Assert.Equal(1, merged);
+            Assert.Contains(key, activeEngineKeys);
+        }
+
+        [Fact]
+        public void MergeInheritedEngineState_NonOperationalLogs_T58()
+        {
+            var logLines = new List<string>();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+            try
+            {
+                ulong key = FlightRecorder.EncodeEngineKey(500, 0);
+                var inherited = new InheritedEngineState
+                {
+                    activeEngineKeys = new HashSet<ulong> { key },
+                    engineThrottles = new Dictionary<ulong, float> { { key, 0.8f } }
+                };
+                var activeEngineKeys = new HashSet<ulong>();
+                var lastThrottle = new Dictionary<ulong, float>();
+                var activeRcsKeys = new HashSet<ulong>();
+                var lastRcsThrottle = new Dictionary<ulong, float>();
+                var childPartPids = new HashSet<uint> { 500 };
+                var allEngineKeys = new HashSet<ulong> { key };
+
+                BackgroundRecorder.MergeInheritedEngineState(
+                    inherited, activeEngineKeys, lastThrottle,
+                    activeRcsKeys, lastRcsThrottle, childPartPids, allEngineKeys);
+
+                Assert.Contains(logLines, l =>
+                    l.Contains("[BgRecorder]") &&
+                    l.Contains("non-operational on child") &&
+                    l.Contains("T58"));
+            }
+            finally
+            {
+                ParsekLog.ResetTestOverrides();
+                ParsekLog.SuppressLogging = true;
+            }
+        }
+
         #endregion
     }
 }

--- a/Source/Parsek.Tests/CopyRewindSaveToRootTests.cs
+++ b/Source/Parsek.Tests/CopyRewindSaveToRootTests.cs
@@ -1,0 +1,255 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Tests for ParsekFlight.CopyRewindSaveToRoot — ensures rewind save filename
+    /// and reserved budget are copied from CaptureAtStop to the tree root recording.
+    /// Bug T59: EVA branch recordings lost the rewind save because the EVA recorder
+    /// never captures one; the parent's CaptureAtStop is the only source.
+    /// </summary>
+    [Collection("Sequential")]
+    public class CopyRewindSaveToRootTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public CopyRewindSaveToRootTests()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+        }
+
+        private static RecordingTree MakeTree(string rootRewindSave = null,
+            double rootRewindFunds = 0, double rootRewindSci = 0, float rootRewindRep = 0)
+        {
+            string treeId = Guid.NewGuid().ToString("N");
+            string rootId = Guid.NewGuid().ToString("N");
+            var tree = new RecordingTree
+            {
+                Id = treeId,
+                TreeName = "TestTree",
+                RootRecordingId = rootId
+            };
+            tree.Recordings[rootId] = new Recording
+            {
+                RecordingId = rootId,
+                TreeId = treeId,
+                VesselName = "Root",
+                RewindSaveFileName = rootRewindSave,
+                RewindReservedFunds = rootRewindFunds,
+                RewindReservedScience = rootRewindSci,
+                RewindReservedRep = rootRewindRep
+            };
+            return tree;
+        }
+
+        private static Recording MakeCaptureAtStop(string rewindSave,
+            double funds = 1000, double sci = 50, float rep = 25,
+            double preFunds = 500, double preSci = 20, float preRep = 10)
+        {
+            return new Recording
+            {
+                RecordingId = Guid.NewGuid().ToString("N"),
+                RewindSaveFileName = rewindSave,
+                RewindReservedFunds = funds,
+                RewindReservedScience = sci,
+                RewindReservedRep = rep,
+                PreLaunchFunds = preFunds,
+                PreLaunchScience = preSci,
+                PreLaunchReputation = preRep
+            };
+        }
+
+        [Fact]
+        public void CopiesRewindSave_FromCaptureAtStop_ToEmptyRoot()
+        {
+            var tree = MakeTree();
+            var capture = MakeCaptureAtStop("parsek_rw_test123");
+
+            ParsekFlight.CopyRewindSaveToRoot(tree, capture, logTag: "Test");
+
+            var root = tree.Recordings[tree.RootRecordingId];
+            Assert.Equal("parsek_rw_test123", root.RewindSaveFileName);
+        }
+
+        [Fact]
+        public void CopiesReservedBudget_FromCaptureAtStop_ToEmptyRoot()
+        {
+            var tree = MakeTree();
+            var capture = MakeCaptureAtStop("parsek_rw_x", funds: 2000, sci: 100, rep: 50);
+
+            ParsekFlight.CopyRewindSaveToRoot(tree, capture);
+
+            var root = tree.Recordings[tree.RootRecordingId];
+            Assert.Equal(2000, root.RewindReservedFunds);
+            Assert.Equal(100, root.RewindReservedScience);
+            Assert.Equal(50, root.RewindReservedRep);
+        }
+
+        [Fact]
+        public void CopiesPreLaunchBudget_FromCaptureAtStop_ToEmptyRoot()
+        {
+            var tree = MakeTree();
+            var capture = MakeCaptureAtStop("parsek_rw_x", preFunds: 800, preSci: 30, preRep: 15);
+
+            ParsekFlight.CopyRewindSaveToRoot(tree, capture);
+
+            var root = tree.Recordings[tree.RootRecordingId];
+            Assert.Equal(800, root.PreLaunchFunds);
+            Assert.Equal(30, root.PreLaunchScience);
+            Assert.Equal(15, root.PreLaunchReputation);
+        }
+
+        [Fact]
+        public void DoesNotOverwrite_ExistingRootRewindSave()
+        {
+            var tree = MakeTree(rootRewindSave: "parsek_rw_original");
+            var capture = MakeCaptureAtStop("parsek_rw_new");
+
+            ParsekFlight.CopyRewindSaveToRoot(tree, capture);
+
+            var root = tree.Recordings[tree.RootRecordingId];
+            Assert.Equal("parsek_rw_original", root.RewindSaveFileName);
+        }
+
+        [Fact]
+        public void DoesNotOverwrite_ExistingReservedBudget()
+        {
+            var tree = MakeTree(rootRewindFunds: 999, rootRewindSci: 88, rootRewindRep: 7);
+            var capture = MakeCaptureAtStop("parsek_rw_x", funds: 2000, sci: 100, rep: 50);
+
+            // Root already has a rewind save set via the tree builder — set it explicitly
+            tree.Recordings[tree.RootRecordingId].RewindSaveFileName = "parsek_rw_existing";
+            ParsekFlight.CopyRewindSaveToRoot(tree, capture);
+
+            var root = tree.Recordings[tree.RootRecordingId];
+            Assert.Equal(999, root.RewindReservedFunds);
+            Assert.Equal(88, root.RewindReservedScience);
+            Assert.Equal(7, root.RewindReservedRep);
+        }
+
+        [Fact]
+        public void UsesRecorderFallback_WhenCaptureAtStopIsNull()
+        {
+            var tree = MakeTree();
+
+            ParsekFlight.CopyRewindSaveToRoot(tree, captureAtStop: null,
+                recorderFallbackSave: "parsek_rw_fallback");
+
+            var root = tree.Recordings[tree.RootRecordingId];
+            Assert.Equal("parsek_rw_fallback", root.RewindSaveFileName);
+        }
+
+        [Fact]
+        public void UsesRecorderFallback_WhenCaptureHasNoSave()
+        {
+            var tree = MakeTree();
+            var capture = MakeCaptureAtStop(rewindSave: null);
+
+            ParsekFlight.CopyRewindSaveToRoot(tree, capture,
+                recorderFallbackSave: "parsek_rw_fallback");
+
+            var root = tree.Recordings[tree.RootRecordingId];
+            Assert.Equal("parsek_rw_fallback", root.RewindSaveFileName);
+        }
+
+        [Fact]
+        public void NoOp_WhenTreeIsNull()
+        {
+            var capture = MakeCaptureAtStop("parsek_rw_x");
+            // Should not throw
+            ParsekFlight.CopyRewindSaveToRoot(null, capture);
+        }
+
+        [Fact]
+        public void NoOp_WhenNoRootRecordingId()
+        {
+            var tree = new RecordingTree { Id = "t", RootRecordingId = null };
+            var capture = MakeCaptureAtStop("parsek_rw_x");
+
+            ParsekFlight.CopyRewindSaveToRoot(tree, capture);
+            // No exception, no-op
+        }
+
+        [Fact]
+        public void NoOp_WhenBothSourcesHaveNoSave()
+        {
+            var tree = MakeTree();
+            var capture = MakeCaptureAtStop(rewindSave: null);
+
+            ParsekFlight.CopyRewindSaveToRoot(tree, capture, recorderFallbackSave: null);
+
+            var root = tree.Recordings[tree.RootRecordingId];
+            Assert.Null(root.RewindSaveFileName);
+        }
+
+        [Fact]
+        public void LogsWhenRewindSaveCopied()
+        {
+            var tree = MakeTree();
+            var capture = MakeCaptureAtStop("parsek_rw_logged");
+            logLines.Clear();
+
+            ParsekFlight.CopyRewindSaveToRoot(tree, capture, logTag: "TestTag");
+
+            Assert.Contains(logLines, l => l.Contains("[Flight]") && l.Contains("TestTag")
+                && l.Contains("parsek_rw_logged"));
+        }
+
+        [Fact]
+        public void EvaBranchScenario_RewindSavePreservedOnRoot()
+        {
+            // Simulate the EVA branch flow that caused T59:
+            // 1. Root recording created with no rewind save (always-tree mode)
+            // 2. Parent recorder builds CaptureAtStop with the rewind save
+            // 3. CreateSplitBranch calls CopyRewindSaveToRoot
+            // 4. EVA recorder takes over (no rewind save)
+            // 5. At commit, GetRewindRecording resolves through root
+
+            var tree = MakeTree();
+            var parentCapture = MakeCaptureAtStop("parsek_rw_eva_parent",
+                funds: 5000, sci: 200, rep: 80,
+                preFunds: 3000, preSci: 150, preRep: 60);
+
+            // Step 3: split copies rewind to root
+            ParsekFlight.CopyRewindSaveToRoot(tree, parentCapture, logTag: "CreateSplitBranch");
+
+            // Add EVA branch child (no rewind save)
+            string evaChildId = Guid.NewGuid().ToString("N");
+            tree.Recordings[evaChildId] = new Recording
+            {
+                RecordingId = evaChildId,
+                TreeId = tree.Id,
+                VesselName = "Bob Kerman",
+                EvaCrewName = "Bob Kerman",
+                ParentRecordingId = tree.RootRecordingId
+            };
+
+            // Step 5: verify rewind resolves for the EVA child
+            var root = tree.Recordings[tree.RootRecordingId];
+            Assert.Equal("parsek_rw_eva_parent", root.RewindSaveFileName);
+            Assert.Equal(5000, root.RewindReservedFunds);
+            Assert.Equal(200, root.RewindReservedScience);
+            Assert.Equal(80, root.RewindReservedRep);
+            Assert.Equal(3000, root.PreLaunchFunds);
+            Assert.Equal(150, root.PreLaunchScience);
+            Assert.Equal(60, root.PreLaunchReputation);
+
+            // GetRewindRecording should resolve EVA child -> root
+            var trees = new List<RecordingTree> { tree };
+            var evaChild = tree.Recordings[evaChildId];
+            var resolved = RecordingStore.GetRewindRecording(evaChild, trees);
+            Assert.Same(root, resolved);
+            Assert.Equal("parsek_rw_eva_parent", resolved.RewindSaveFileName);
+        }
+    }
+}

--- a/Source/Parsek.Tests/ResolveParentVesselPidTests.cs
+++ b/Source/Parsek.Tests/ResolveParentVesselPidTests.cs
@@ -1,0 +1,234 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Tests for VesselSpawner.ResolveParentVesselPid — resolves the parent recording's
+    /// VesselPersistentId for EVA collision exemption during spawn.
+    /// Bug T57: EVA recordings fail to spawn because their entire trajectory overlaps
+    /// with the already-spawned parent vessel.
+    /// </summary>
+    [Collection("Sequential")]
+    public class ResolveParentVesselPidTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public ResolveParentVesselPidTests()
+        {
+            RecordingStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+            MilestoneStore.ResetForTesting();
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+            RecordingStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+            MilestoneStore.ResetForTesting();
+        }
+
+        [Fact]
+        public void ResolvesParentPid_FromCommittedTree()
+        {
+            string treeId = Guid.NewGuid().ToString("N");
+            string parentId = Guid.NewGuid().ToString("N");
+            string evaId = Guid.NewGuid().ToString("N");
+
+            var tree = new RecordingTree
+            {
+                Id = treeId,
+                TreeName = "KerbalX",
+                RootRecordingId = parentId
+            };
+            tree.Recordings[parentId] = new Recording
+            {
+                RecordingId = parentId,
+                TreeId = treeId,
+                VesselName = "Kerbal X",
+                VesselPersistentId = 12345
+            };
+            tree.Recordings[evaId] = new Recording
+            {
+                RecordingId = evaId,
+                TreeId = treeId,
+                VesselName = "Bob Kerman",
+                EvaCrewName = "Bob Kerman",
+                ParentRecordingId = parentId
+            };
+            RecordingStore.AddCommittedTreeForTesting(tree);
+
+            uint pid = VesselSpawner.ResolveParentVesselPid(tree.Recordings[evaId]);
+
+            Assert.Equal(12345u, pid);
+        }
+
+        [Fact]
+        public void ReturnsZero_WhenNoParentRecordingId()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "eva1",
+                TreeId = "tree1",
+                EvaCrewName = "Bob",
+                ParentRecordingId = null
+            };
+
+            uint pid = VesselSpawner.ResolveParentVesselPid(rec);
+
+            Assert.Equal(0u, pid);
+        }
+
+        [Fact]
+        public void ReturnsZero_WhenNoTreeId()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "eva1",
+                TreeId = null,
+                EvaCrewName = "Bob",
+                ParentRecordingId = "parent1"
+            };
+
+            uint pid = VesselSpawner.ResolveParentVesselPid(rec);
+
+            Assert.Equal(0u, pid);
+        }
+
+        [Fact]
+        public void ReturnsZero_WhenTreeNotFound()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "eva1",
+                TreeId = "nonexistent",
+                EvaCrewName = "Bob",
+                ParentRecordingId = "parent1"
+            };
+
+            uint pid = VesselSpawner.ResolveParentVesselPid(rec);
+
+            Assert.Equal(0u, pid);
+        }
+
+        [Fact]
+        public void ReturnsZero_WhenParentRecordingNotInTree()
+        {
+            string treeId = Guid.NewGuid().ToString("N");
+            string rootId = Guid.NewGuid().ToString("N");
+            string evaId = Guid.NewGuid().ToString("N");
+
+            var tree = new RecordingTree
+            {
+                Id = treeId,
+                TreeName = "KerbalX",
+                RootRecordingId = rootId
+            };
+            tree.Recordings[rootId] = new Recording
+            {
+                RecordingId = rootId,
+                TreeId = treeId,
+                VesselName = "Kerbal X",
+                VesselPersistentId = 12345
+            };
+            RecordingStore.AddCommittedTreeForTesting(tree);
+
+            var eva = new Recording
+            {
+                RecordingId = evaId,
+                TreeId = treeId,
+                EvaCrewName = "Bob",
+                ParentRecordingId = "doesNotExist"
+            };
+
+            uint pid = VesselSpawner.ResolveParentVesselPid(eva);
+
+            Assert.Equal(0u, pid);
+        }
+
+        [Fact]
+        public void ReturnsZero_WhenParentHasNoPid()
+        {
+            string treeId = Guid.NewGuid().ToString("N");
+            string parentId = Guid.NewGuid().ToString("N");
+            string evaId = Guid.NewGuid().ToString("N");
+
+            var tree = new RecordingTree
+            {
+                Id = treeId,
+                TreeName = "KerbalX",
+                RootRecordingId = parentId
+            };
+            tree.Recordings[parentId] = new Recording
+            {
+                RecordingId = parentId,
+                TreeId = treeId,
+                VesselName = "Kerbal X",
+                VesselPersistentId = 0 // no PID
+            };
+            tree.Recordings[evaId] = new Recording
+            {
+                RecordingId = evaId,
+                TreeId = treeId,
+                VesselName = "Bob Kerman",
+                EvaCrewName = "Bob Kerman",
+                ParentRecordingId = parentId
+            };
+            RecordingStore.AddCommittedTreeForTesting(tree);
+
+            uint pid = VesselSpawner.ResolveParentVesselPid(tree.Recordings[evaId]);
+
+            Assert.Equal(0u, pid);
+        }
+
+        [Fact]
+        public void ReturnsZero_WhenNullRecording()
+        {
+            uint pid = VesselSpawner.ResolveParentVesselPid(null);
+            Assert.Equal(0u, pid);
+        }
+
+        [Fact]
+        public void LogsParentResolution()
+        {
+            string treeId = Guid.NewGuid().ToString("N");
+            string parentId = Guid.NewGuid().ToString("N");
+            string evaId = Guid.NewGuid().ToString("N");
+
+            var tree = new RecordingTree
+            {
+                Id = treeId,
+                TreeName = "KerbalX",
+                RootRecordingId = parentId
+            };
+            tree.Recordings[parentId] = new Recording
+            {
+                RecordingId = parentId,
+                TreeId = treeId,
+                VesselName = "Kerbal X",
+                VesselPersistentId = 99999
+            };
+            tree.Recordings[evaId] = new Recording
+            {
+                RecordingId = evaId,
+                TreeId = treeId,
+                VesselName = "Bob Kerman",
+                EvaCrewName = "Bob Kerman",
+                ParentRecordingId = parentId
+            };
+            RecordingStore.AddCommittedTreeForTesting(tree);
+            logLines.Clear();
+
+            VesselSpawner.ResolveParentVesselPid(tree.Recordings[evaId]);
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[Spawner]") && l.Contains("T57") && l.Contains("99999"));
+        }
+    }
+}

--- a/Source/Parsek/BackgroundRecorder.cs
+++ b/Source/Parsek/BackgroundRecorder.cs
@@ -1662,7 +1662,7 @@ namespace Parsek
                 int merged = MergeInheritedEngineState(inherited,
                     state.activeEngineKeys, state.lastThrottle,
                     state.activeRcsKeys, state.lastRcsThrottle,
-                    childPartPids);
+                    childPartPids, state.allEngineKeys);
                 if (merged > 0)
                     ParsekLog.Info("BgRecorder",
                         $"Merged {merged} inherited engine/RCS key(s) for pid={vesselPid} recId={recordingId} (#298)");
@@ -1827,11 +1827,13 @@ namespace Parsek
             Dictionary<ulong, float> targetLastThrottle,
             HashSet<ulong> targetActiveRcsKeys,
             Dictionary<ulong, float> targetLastRcsThrottle,
-            HashSet<uint> childPartPids)
+            HashSet<uint> childPartPids,
+            HashSet<ulong> allEngineKeys = null)
         {
             if (!inherited.HasValue) return 0;
             var inh = inherited.Value;
             int merged = 0;
+            int skippedNonOperational = 0;
 
             if (inh.activeEngineKeys != null)
             {
@@ -1867,6 +1869,20 @@ namespace Parsek
                         continue;
                     }
 
+                    // T58: SeedEngines adds ALL engines to allEngineKeys (operational or not).
+                    // If the key is in allEngineKeys but NOT in activeEngineKeys, SeedEngines
+                    // found the engine but it's non-operational (fuel severed, flameout after
+                    // staging). Don't override with inherited state — the child's assessment
+                    // is correct. Only inherit when the engine wasn't found at all (timing).
+                    if (allEngineKeys != null && allEngineKeys.Contains(key))
+                    {
+                        skippedNonOperational++;
+                        ParsekLog.Verbose("BgRecorder",
+                            $"Inherited engine skipped (non-operational on child): pid={pid} midx={midx} " +
+                            $"inhThrottle={inhThrottle:F2} (T58)");
+                        continue;
+                    }
+
                     targetActiveEngineKeys.Add(key);
                     targetLastThrottle[key] = inhThrottle;
                     merged++;
@@ -1874,6 +1890,10 @@ namespace Parsek
                         $"Inherited engine key merged: pid={pid} midx={midx} throttle={inhThrottle:F2} (#298)");
                 }
             }
+
+            if (skippedNonOperational > 0)
+                ParsekLog.Info("BgRecorder",
+                    $"Skipped {skippedNonOperational} inherited engine(s) — non-operational on child (T58)");
 
             if (inh.activeRcsKeys != null)
             {

--- a/Source/Parsek/EngineFxBuilder.cs
+++ b/Source/Parsek/EngineFxBuilder.cs
@@ -44,13 +44,14 @@ namespace Parsek
         /// the first emission and speed curves found.
         /// </summary>
         private static void ScanEffectsModelFxEntries(
-            ConfigNode[] effectGroups,
-            List<(string nodeType, string transformName, string modelName, Vector3 localPos, Quaternion localRot)> modelFxEntries,
+            ConfigNode[] effectGroups, string[] effectGroupNames,
+            List<(string nodeType, string transformName, string modelName, Vector3 localPos, Quaternion localRot, string groupName)> modelFxEntries,
             ref FloatCurve emissionCurve,
             ref FloatCurve speedCurve)
         {
             for (int g = 0; g < effectGroups.Length; g++)
             {
+                string groupName = g < effectGroupNames.Length ? effectGroupNames[g] : "?";
                 for (int n = 0; n < EngineModelNodeTypes.Length; n++)
                 {
                     string nodeType = EngineModelNodeTypes[n];
@@ -77,7 +78,7 @@ namespace Parsek
                                 }
                             }
 
-                            modelFxEntries.Add((nodeType, transformName, modelName ?? "", mmpLocalPos, mmpLocalRot));
+                            modelFxEntries.Add((nodeType, transformName, modelName ?? "", mmpLocalPos, mmpLocalRot, groupName));
 
                             if (emissionCurve == null)
                             {
@@ -106,11 +107,12 @@ namespace Parsek
         /// Skips flameout/sparks/debris prefabs -- only wants running FX.
         /// </summary>
         private static void ScanEffectsPrefabParticleEntries(
-            ConfigNode[] effectGroups,
-            List<(string prefabName, string transformName, Vector3 localOffset, Quaternion localRotation, bool hasLocalRotation)> prefabFxEntries)
+            ConfigNode[] effectGroups, string[] effectGroupNames,
+            List<(string prefabName, string transformName, Vector3 localOffset, Quaternion localRotation, bool hasLocalRotation, string groupName)> prefabFxEntries)
         {
             for (int g = 0; g < effectGroups.Length; g++)
             {
+                string groupName = g < effectGroupNames.Length ? effectGroupNames[g] : "?";
                 ConfigNode[] ppNodes = effectGroups[g].GetNodes("PREFAB_PARTICLE");
                 for (int pp = 0; pp < ppNodes.Length; pp++)
                 {
@@ -133,7 +135,7 @@ namespace Parsek
                     string rotStr = ppNodes[pp].GetValue("localRotation");
                     bool hasLocalRot = GhostVisualBuilder.TryParseFxLocalRotation(rotStr, out localRot);
 
-                    prefabFxEntries.Add((prefabName, transformName, localOffset, localRot, hasLocalRot));
+                    prefabFxEntries.Add((prefabName, transformName, localOffset, localRot, hasLocalRot, groupName));
                 }
             }
         }
@@ -261,7 +263,7 @@ namespace Parsek
         /// and parents them to the ghost's mirrored transform hierarchy.
         /// </summary>
         private static void ProcessEngineModelFxEntries(
-            List<(string nodeType, string transformName, string modelName, Vector3 localPos, Quaternion localRot)> modelFxEntries,
+            List<(string nodeType, string transformName, string modelName, Vector3 localPos, Quaternion localRot, string groupName)> modelFxEntries,
             Part prefab, EngineGhostInfo info,
             string partName, int moduleIndex,
             Transform modelRoot, Transform ghostModelNode,
@@ -269,7 +271,7 @@ namespace Parsek
         {
             for (int f = 0; f < modelFxEntries.Count; f++)
             {
-                var (nodeType, transformName, modelName, mmpLocalPos, mmpLocalRot) = modelFxEntries[f];
+                var (nodeType, transformName, modelName, mmpLocalPos, mmpLocalRot, groupName) = modelFxEntries[f];
 
                 var fxTransforms = GhostVisualBuilder.FindTransformsRecursive(prefab.transform, transformName);
                 for (int t = 0; t < fxTransforms.Count; t++)
@@ -309,10 +311,15 @@ namespace Parsek
                                 Vector3 srcFwd = srcFxTransform.forward;
                                 Vector3 srcUp = srcFxTransform.up;
                                 Quaternion srcLocalRot = srcFxTransform.localRotation;
+                                // #242 diag: log effect group + final FX direction for smoke/flame comparison
+                                Vector3 fxFwd = fxInstance.transform.forward;
+                                Vector3 fxUp = fxInstance.transform.up;
                                 ParsekLog.Verbose("EngineFx", $"cloned: '{partName}' midx={moduleIndex} " +
-                                    $"type={nodeType} transform='{transformName}' model='{modelName}' " +
+                                    $"group='{groupName}' type={nodeType} transform='{transformName}' model='{modelName}' " +
                                     $"systems={addedSystems} " +
-                                    $"srcLocalRot={srcLocalRot} srcFwd={srcFwd} srcUp={srcUp}");
+                                    $"cfgRot={mmpLocalRot.eulerAngles} " +
+                                    $"srcLocalRot={srcLocalRot.eulerAngles} srcFwd={srcFwd} srcUp={srcUp} " +
+                                    $"fxFwd={fxFwd} fxUp={fxUp}");
                             }
                             else
                             {
@@ -334,7 +341,7 @@ namespace Parsek
         /// ghost's mirrored transform hierarchy. Handles special cases like RAPIER white flame scaling.
         /// </summary>
         private static void ProcessEnginePrefabFxEntries(
-            List<(string prefabName, string transformName, Vector3 localOffset, Quaternion localRotation, bool hasLocalRotation)> prefabFxEntries,
+            List<(string prefabName, string transformName, Vector3 localOffset, Quaternion localRotation, bool hasLocalRotation, string groupName)> prefabFxEntries,
             Part prefab, EngineGhostInfo info,
             string partName, int moduleIndex,
             Transform modelRoot, Transform ghostModelNode,
@@ -342,7 +349,7 @@ namespace Parsek
         {
             for (int f = 0; f < prefabFxEntries.Count; f++)
             {
-                var (prefabName, transformName, localOffset, localRot, hasLocalRot) = prefabFxEntries[f];
+                var (prefabName, transformName, localOffset, localRot, hasLocalRot, groupName) = prefabFxEntries[f];
                 string normalizedPrefabName = GhostVisualBuilder.NormalizeFxPrefabName(prefabName);
                 bool isRapierWhiteFlame =
                     string.Equals(partName, "RAPIER", System.StringComparison.OrdinalIgnoreCase) &&
@@ -406,8 +413,14 @@ namespace Parsek
                         GhostVisualBuilder.LogFxInstancePlacementDiagnostic(partName, moduleIndex, "PREFAB_PARTICLE", transformName,
                             prefabName, prefab.transform, ghostModelNode, srcFxTransform, ghostFxParent,
                             fxInstance.transform, localOffset, localRot, hasLocalRot);
+                        // #242 diag: log effect group + final FX direction for smoke/flame comparison
+                        Vector3 pfxFwd = fxInstance.transform.forward;
+                        Vector3 pfxUp = fxInstance.transform.up;
                         ParsekLog.Verbose("EngineFx", $"(prefab): '{partName}' midx={moduleIndex} " +
-                            $"transform='{transformName}' prefab='{prefabName}' systems={addedSystems}");
+                            $"group='{groupName}' transform='{transformName}' prefab='{prefabName}' " +
+                            $"systems={addedSystems} " +
+                            $"cfgRot={localRot.eulerAngles} hasCfgRot={hasLocalRot} " +
+                            $"fxFwd={pfxFwd} fxUp={pfxUp}");
                     }
                     else
                     {
@@ -479,21 +492,27 @@ namespace Parsek
                 ConfigNode effectsNode = partConfig.GetNode("EFFECTS");
 
                 // Scan EFFECTS for particle FX entries (MODEL_MULTI_PARTICLE, MODEL_PARTICLE, PREFAB_PARTICLE)
-                var modelFxEntries = new List<(string nodeType, string transformName, string modelName, Vector3 localPos, Quaternion localRot)>();
+                var modelFxEntries = new List<(string nodeType, string transformName, string modelName, Vector3 localPos, Quaternion localRot, string groupName)>();
                 var prefabFxEntries = new List<(
                     string prefabName,
                     string transformName,
                     Vector3 localOffset,
                     Quaternion localRotation,
-                    bool hasLocalRotation)>();
+                    bool hasLocalRotation,
+                    string groupName)>();
                 FloatCurve emissionCurve = null;
                 FloatCurve speedCurve = null;
 
                 if (effectsNode != null)
                 {
                     ConfigNode[] effectGroups = effectsNode.GetNodes();
-                    ScanEffectsModelFxEntries(effectGroups, modelFxEntries, ref emissionCurve, ref speedCurve);
-                    ScanEffectsPrefabParticleEntries(effectGroups, prefabFxEntries);
+                    // #242 diag: extract group names so we can log which EFFECTS group
+                    // each FX entry came from (running, power_open, engage, etc.)
+                    string[] effectGroupNames = new string[effectGroups.Length];
+                    for (int eg = 0; eg < effectGroups.Length; eg++)
+                        effectGroupNames[eg] = effectGroups[eg].name ?? "?";
+                    ScanEffectsModelFxEntries(effectGroups, effectGroupNames, modelFxEntries, ref emissionCurve, ref speedCurve);
+                    ScanEffectsPrefabParticleEntries(effectGroups, effectGroupNames, prefabFxEntries);
                 }
 
                 var namedTransformCache = new Dictionary<string, List<Transform>>(System.StringComparer.OrdinalIgnoreCase);
@@ -596,7 +615,7 @@ namespace Parsek
                         defaultOffset,
                         matchFxTransformAlias);
 
-                    prefabFxEntries.Add((prefabName, fallbackTransform, fallbackOffset, localRotation, hasLocalRotation));
+                    prefabFxEntries.Add((prefabName, fallbackTransform, fallbackOffset, localRotation, hasLocalRotation, "fallback"));
                     string rotationSuffix = hasLocalRotation ? $" rot={localRotation.eulerAngles}" : "";
                     ParsekLog.Verbose("EngineFx", $"fallback: '{partName}' midx={moduleIndex} " +
                         $"added {description} on '{fallbackTransform}' offset={fallbackOffset}{rotationSuffix}");
@@ -697,9 +716,9 @@ namespace Parsek
                     }
 
                     prefabFxEntries.Add(("fx_smokeTrail_medium",
-                        kickbackTransform, kickbackOffset, kickbackThumperLocalRot, true));
+                        kickbackTransform, kickbackOffset, kickbackThumperLocalRot, true, "fallback"));
                     prefabFxEntries.Add(("fx_exhaustFlame_yellow",
-                        kickbackTransform, kickbackOffset, kickbackThumperLocalRot, true));
+                        kickbackTransform, kickbackOffset, kickbackThumperLocalRot, true, "fallback"));
                     ParsekLog.Verbose("EngineFx", $"fallback: '{partName}' midx={moduleIndex} " +
                         $"forced Thumper-style plume on '{kickbackTransform}' offset={kickbackOffset} " +
                         $"rot={kickbackThumperLocalRot.eulerAngles} hasRot=true " +
@@ -762,8 +781,8 @@ namespace Parsek
                         matchFxTransformAlias: false);
                     Quaternion rhinoPlumeRotation = Quaternion.Euler(-90f, 0f, 0f);
 
-                    prefabFxEntries.Add(("fx_smokeTrail_light", rhinoTransform, rhinoOffset, rhinoPlumeRotation, true));
-                    prefabFxEntries.Add(("fx_exhaustFlame_yellow_medium", rhinoTransform, rhinoOffset, rhinoPlumeRotation, true));
+                    prefabFxEntries.Add(("fx_smokeTrail_light", rhinoTransform, rhinoOffset, rhinoPlumeRotation, true, "fallback"));
+                    prefabFxEntries.Add(("fx_exhaustFlame_yellow_medium", rhinoTransform, rhinoOffset, rhinoPlumeRotation, true, "fallback"));
                     ParsekLog.Verbose("EngineFx", $"fallback: '{partName}' midx={moduleIndex} " +
                         $"forced compact Mainsail-like plume on '{rhinoTransform}' offset={rhinoOffset} " +
                         $"(removed MODEL={removedRhinoModelFx}, PREFAB={removedRhinoPrefabs})");
@@ -849,7 +868,7 @@ namespace Parsek
                                 fallbackTransform = engine.thrustVectorTransformName;
                         }
 
-                        prefabFxEntries.Add(("fx_exhaustFlame_blue", fallbackTransform, fallbackOffset, fallbackRotation, fallbackHasLocalRotation));
+                        prefabFxEntries.Add(("fx_exhaustFlame_blue", fallbackTransform, fallbackOffset, fallbackRotation, fallbackHasLocalRotation, "fallback"));
                         ParsekLog.Verbose("EngineFx", $"fallback: '{partName}' midx={moduleIndex} " +
                             $"added Skipper-style blue flame prefab on '{fallbackTransform}' offset={fallbackOffset} rot={fallbackRotation.eulerAngles}");
                     }
@@ -906,7 +925,7 @@ namespace Parsek
                     }
 
                     prefabFxEntries.Add(("fx_smokeTrail_large", rapierSmokeTransform, rapierSmokeOffset,
-                        rapierSmokeRotation, rapierSmokeHasLocalRotation));
+                        rapierSmokeRotation, rapierSmokeHasLocalRotation, "fallback"));
                     ParsekLog.Verbose("EngineFx", $"fallback: '{partName}' midx={moduleIndex} " +
                         $"replaced {removedRapierSmoke} smoke entries with Vector-style smoke on '{rapierSmokeTransform}' " +
                         $"offset={rapierSmokeOffset} rot={rapierSmokeRotation.eulerAngles}");
@@ -940,7 +959,7 @@ namespace Parsek
                         }
 
                         Quaternion flameRotation = Quaternion.Euler(-90f, 0f, 0f);
-                        prefabFxEntries.Add(("fx_exhaustFlame_white", flameTransform, flameOffset, flameRotation, true));
+                        prefabFxEntries.Add(("fx_exhaustFlame_white", flameTransform, flameOffset, flameRotation, true, "fallback"));
                         ParsekLog.Verbose("EngineFx", $"fallback: '{partName}' midx={moduleIndex} " +
                             $"added Vector-style white flame on '{flameTransform}' offset={flameOffset} rot={flameRotation.eulerAngles}");
                     }

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -1445,6 +1445,54 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Copies the rewind save filename and reserved budget from a CaptureAtStop (or
+        /// recorder fallback) to the tree's root recording. Called from every flush/commit
+        /// site so the R button and rewind budget resolve correctly regardless of which
+        /// child recorder is active at commit time.
+        /// T59: without this, EVA branch recordings lose the rewind save because the EVA
+        /// recorder never captures one — the parent's CaptureAtStop is the only source.
+        /// </summary>
+        internal static void CopyRewindSaveToRoot(RecordingTree tree, Recording captureAtStop,
+            string recorderFallbackSave = null, string logTag = null)
+        {
+            if (tree == null || string.IsNullOrEmpty(tree.RootRecordingId)) return;
+
+            string rewindSave = captureAtStop?.RewindSaveFileName ?? recorderFallbackSave;
+            if (string.IsNullOrEmpty(rewindSave)) return;
+
+            Recording rootRec;
+            if (!tree.Recordings.TryGetValue(tree.RootRecordingId, out rootRec)) return;
+
+            // Only set if root doesn't already have a rewind save (first recorder wins)
+            if (string.IsNullOrEmpty(rootRec.RewindSaveFileName))
+            {
+                rootRec.RewindSaveFileName = rewindSave;
+                ParsekLog.Info("Flight",
+                    $"{logTag ?? "CopyRewindSaveToRoot"}: copied rewind save '{rewindSave}' " +
+                    $"to root recording '{tree.RootRecordingId}'");
+            }
+
+            // Copy reserved budget if not already set (same first-wins rule).
+            // InitiateRewind reads these from the root recording via GetRewindRecording.
+            if (captureAtStop != null && rootRec.RewindReservedFunds == 0
+                && rootRec.RewindReservedScience == 0 && rootRec.RewindReservedRep == 0)
+            {
+                rootRec.RewindReservedFunds = captureAtStop.RewindReservedFunds;
+                rootRec.RewindReservedScience = captureAtStop.RewindReservedScience;
+                rootRec.RewindReservedRep = captureAtStop.RewindReservedRep;
+            }
+
+            // Copy pre-launch budget if not already set.
+            if (captureAtStop != null && rootRec.PreLaunchFunds == 0
+                && rootRec.PreLaunchScience == 0 && rootRec.PreLaunchReputation == 0)
+            {
+                rootRec.PreLaunchFunds = captureAtStop.PreLaunchFunds;
+                rootRec.PreLaunchScience = captureAtStop.PreLaunchScience;
+                rootRec.PreLaunchReputation = captureAtStop.PreLaunchReputation;
+            }
+        }
+
+        /// <summary>
         /// Creates a new FlightRecorder for the promoted vessel, starts recording with
         /// isPromotion=true, updates activeTree state.
         /// </summary>
@@ -1800,6 +1848,14 @@ namespace Parsek
                         $"CreateSplitBranch: copied VesselSnapshot to parent '{parentRecordingId}' " +
                         "from CaptureAtStop (always-tree root had no snapshot)");
                 }
+
+                // T59: Copy rewind save from split recorder's CaptureAtStop to the root
+                // recording. BuildCaptureRecording (FlightRecorder line 4562) copies the
+                // filename into CaptureAtStop then clears it on the recorder (line 4573).
+                // After the split, the new child recorder never has the rewind save, so
+                // FinalizeTreeRecordings / StashActiveTreeAsPendingLimbo can't find it.
+                // Copying here preserves it for the R button and rewind budget.
+                CopyRewindSaveToRoot(activeTree, splitRecorder.CaptureAtStop);
             }
 
             // Set ChildBranchPointId on parent
@@ -5460,18 +5516,10 @@ namespace Parsek
                 }
                 FlushRecorderToTreeRecording(recorder, activeTree);
 
-                // Copy rewind save filename to the tree's root recording so the R button
-                // still works after a potential future revert on this tree.
-                string rewindSave = recorder.CaptureAtStop?.RewindSaveFileName
-                    ?? recorder.RewindSaveFileName;
-                if (!string.IsNullOrEmpty(rewindSave)
-                    && !string.IsNullOrEmpty(activeTree.RootRecordingId))
-                {
-                    if (activeTree.Recordings.TryGetValue(activeTree.RootRecordingId, out var rootRec))
-                    {
-                        rootRec.RewindSaveFileName = rewindSave;
-                    }
-                }
+                // Copy rewind save to the root recording so the R button works after revert.
+                CopyRewindSaveToRoot(activeTree, recorder.CaptureAtStop,
+                    recorderFallbackSave: recorder.RewindSaveFileName,
+                    logTag: "StashTreeLimbo");
             }
 
             // Close background recorder orbit segments and flush their data into tree
@@ -5656,18 +5704,10 @@ namespace Parsek
                 }
                 FlushRecorderToTreeRecording(recorder, activeTree);
 
-                // Copy rewind save filename to the tree's root recording so the R button
-                // still works after a potential future revert on this tree.
-                string rewindSave = recorder.CaptureAtStop?.RewindSaveFileName
-                    ?? recorder.RewindSaveFileName;
-                if (!string.IsNullOrEmpty(rewindSave)
-                    && !string.IsNullOrEmpty(activeTree.RootRecordingId))
-                {
-                    if (activeTree.Recordings.TryGetValue(activeTree.RootRecordingId, out var rootRec))
-                    {
-                        rootRec.RewindSaveFileName = rewindSave;
-                    }
-                }
+                // Copy rewind save + reserved budget to the root recording.
+                CopyRewindSaveToRoot(activeTree, recorder.CaptureAtStop,
+                    recorderFallbackSave: recorder.RewindSaveFileName,
+                    logTag: "MergeCommitFlush");
 
                 oldVesselPid = recorder.RecordingVesselId;
             }
@@ -5779,22 +5819,10 @@ namespace Parsek
                 }
                 FlushRecorderToTreeRecording(recorder, tree);
 
-                // Copy rewind save filename to the tree's root recording.
-                // BuildCaptureRecording clears recorder.RewindSaveFileName after capture,
-                // so we check CaptureAtStop first (has the captured copy), then recorder.
-                string rewindSave = recorder.CaptureAtStop?.RewindSaveFileName
-                    ?? recorder.RewindSaveFileName;
-                if (!string.IsNullOrEmpty(rewindSave)
-                    && !string.IsNullOrEmpty(tree.RootRecordingId))
-                {
-                    Recording rootRec;
-                    if (tree.Recordings.TryGetValue(tree.RootRecordingId, out rootRec))
-                    {
-                        rootRec.RewindSaveFileName = rewindSave;
-                        ParsekLog.Info("Flight",
-                            $"FinalizeTreeRecordings: copied rewind save '{rewindSave}' to root recording '{tree.RootRecordingId}'");
-                    }
-                }
+                // Copy rewind save + reserved budget to the root recording.
+                CopyRewindSaveToRoot(tree, recorder.CaptureAtStop,
+                    recorderFallbackSave: recorder.RewindSaveFileName,
+                    logTag: "FinalizeTreeRecordings");
             }
 
             // 2. Finalize background recorder (close orbit segments, flush data)

--- a/Source/Parsek/SpawnCollisionDetector.cs
+++ b/Source/Parsek/SpawnCollisionDetector.cs
@@ -523,7 +523,8 @@ namespace Parsek
         {
             ParsekLog.Verbose(Tag,
                 $"CheckOverlapAgainstLoadedVessels: checking spawn at ({spawnWorldPos.x.ToString("F0", IC)},{spawnWorldPos.y.ToString("F0", IC)},{spawnWorldPos.z.ToString("F0", IC)}) " +
-                $"padding={padding.ToString("F1", IC)}m against {FlightGlobals.Vessels.Count} vessels, skipActiveVessel={skipActiveVessel}");
+                $"padding={padding.ToString("F1", IC)}m against {FlightGlobals.Vessels.Count} vessels, skipActiveVessel={skipActiveVessel}" +
+                (exemptVesselPid != 0 ? $", exemptPid={exemptVesselPid} (T57)" : ""));
 
             bool anyOverlap = false;
             float closestDist = float.MaxValue;
@@ -537,7 +538,7 @@ namespace Parsek
                 if (GhostMapPresence.IsGhostMapVessel(other.persistentId)) continue;
 
                 // Skip player's own vessel — shouldn't block non-EVA spawns.
-                // EVA spawns need to detect the active vessel (active vessel) as a
+                // EVA spawns need to detect the active vessel (parent rocket) as a
                 // blocker so the walkback can find a clear position (#291), UNLESS
                 // it's the EVA's parent vessel (#T57).
                 if (skipActiveVessel && other == FlightGlobals.ActiveVessel) continue;
@@ -545,7 +546,13 @@ namespace Parsek
                 // T57: skip the EVA's parent vessel — the EVA trajectory is always
                 // adjacent to the parent, so without exemption the entire walkback
                 // is exhausted and the spawn is abandoned.
-                if (exemptVesselPid != 0 && other.persistentId == exemptVesselPid) continue;
+                if (exemptVesselPid != 0 && other.persistentId == exemptVesselPid)
+                {
+                    ParsekLog.Verbose(Tag,
+                        $"Skipping exempt parent vessel '{Recording.ResolveLocalizedName(other.vesselName)}' " +
+                        $"(pid={other.persistentId}) for EVA collision check (T57)");
+                    continue;
+                }
 
                 // Skip non-significant vessel types that shouldn't block spawns
                 if (ShouldSkipVesselType(other.vesselType))

--- a/Source/Parsek/SpawnCollisionDetector.cs
+++ b/Source/Parsek/SpawnCollisionDetector.cs
@@ -518,7 +518,8 @@ namespace Parsek
         /// overlapping vessel's info, or overlap=false if no overlap found.
         /// </summary>
         internal static (bool overlap, float closestDistance, string blockerName, Vessel blockerVessel) CheckOverlapAgainstLoadedVessels(
-            Vector3d spawnWorldPos, Bounds spawnBounds, float padding, bool skipActiveVessel = true)
+            Vector3d spawnWorldPos, Bounds spawnBounds, float padding, bool skipActiveVessel = true,
+            uint exemptVesselPid = 0)
         {
             ParsekLog.Verbose(Tag,
                 $"CheckOverlapAgainstLoadedVessels: checking spawn at ({spawnWorldPos.x.ToString("F0", IC)},{spawnWorldPos.y.ToString("F0", IC)},{spawnWorldPos.z.ToString("F0", IC)}) " +
@@ -536,9 +537,15 @@ namespace Parsek
                 if (GhostMapPresence.IsGhostMapVessel(other.persistentId)) continue;
 
                 // Skip player's own vessel — shouldn't block non-EVA spawns.
-                // EVA spawns need to detect the parent vessel (active vessel) as a
-                // blocker so the walkback can find a clear position. (#291)
+                // EVA spawns need to detect the active vessel (active vessel) as a
+                // blocker so the walkback can find a clear position (#291), UNLESS
+                // it's the EVA's parent vessel (#T57).
                 if (skipActiveVessel && other == FlightGlobals.ActiveVessel) continue;
+
+                // T57: skip the EVA's parent vessel — the EVA trajectory is always
+                // adjacent to the parent, so without exemption the entire walkback
+                // is exhausted and the spawn is abandoned.
+                if (exemptVesselPid != 0 && other.persistentId == exemptVesselPid) continue;
 
                 // Skip non-significant vessel types that shouldn't block spawns
                 if (ShouldSkipVesselType(other.vesselType))

--- a/Source/Parsek/VesselSpawner.cs
+++ b/Source/Parsek/VesselSpawner.cs
@@ -408,6 +408,56 @@ namespace Parsek
             }
         }
 
+        /// <summary>
+        /// T57: Resolves the parent recording's VesselPersistentId for EVA collision
+        /// exemption. Searches committed trees for the parent recording by ParentRecordingId.
+        /// Returns 0 if no parent found. Pure lookup, no side effects.
+        /// </summary>
+        internal static uint ResolveParentVesselPid(Recording rec)
+        {
+            if (rec == null || string.IsNullOrEmpty(rec.ParentRecordingId)
+                || string.IsNullOrEmpty(rec.TreeId))
+                return 0;
+
+            var trees = RecordingStore.CommittedTrees;
+            for (int i = 0; i < trees.Count; i++)
+            {
+                if (trees[i].Id != rec.TreeId) continue;
+                Recording parentRec;
+                if (trees[i].Recordings.TryGetValue(rec.ParentRecordingId, out parentRec))
+                {
+                    if (parentRec.VesselPersistentId != 0)
+                    {
+                        ParsekLog.Verbose("Spawner",
+                            $"ResolveParentVesselPid: EVA '{rec.VesselName}' parent='{parentRec.VesselName}' " +
+                            $"pid={parentRec.VesselPersistentId} (T57 exemption)");
+                        return parentRec.VesselPersistentId;
+                    }
+                }
+                break;
+            }
+
+            // Also check the pending tree (active recording in flight)
+            var pendingTree = RecordingStore.PendingTree;
+            if (pendingTree != null && pendingTree.Id == rec.TreeId)
+            {
+                Recording parentRec;
+                if (pendingTree.Recordings.TryGetValue(rec.ParentRecordingId, out parentRec)
+                    && parentRec.VesselPersistentId != 0)
+                {
+                    ParsekLog.Verbose("Spawner",
+                        $"ResolveParentVesselPid: EVA '{rec.VesselName}' parent='{parentRec.VesselName}' " +
+                        $"pid={parentRec.VesselPersistentId} (from pending tree, T57)");
+                    return parentRec.VesselPersistentId;
+                }
+            }
+
+            ParsekLog.Verbose("Spawner",
+                $"ResolveParentVesselPid: no parent found for EVA '{rec.VesselName}' " +
+                $"(parentId={rec.ParentRecordingId}, treeId={rec.TreeId})");
+            return 0;
+        }
+
         public static void SpawnOrRecoverIfTooClose(Recording rec, int index)
         {
             const int maxSpawnAttempts = 3;
@@ -451,8 +501,12 @@ namespace Parsek
             Vector3d spawnPos = body.GetWorldSurfacePosition(spawnLat, spawnLon, spawnAlt);
 
             bool isEva = !string.IsNullOrEmpty(rec.EvaCrewName);
+            // T57: resolve parent vessel PID for EVA collision exemption.
+            // EVA trajectories overlap the parent vessel for their entire length;
+            // without exemption, walkback exhausts all points and abandons the spawn.
+            uint exemptPid = isEva ? ResolveParentVesselPid(rec) : 0;
             var collision = CheckSpawnCollisions(rec, index, isEva, body,
-                spawnLat, spawnLon, spawnAlt, spawnPos);
+                spawnLat, spawnLon, spawnAlt, spawnPos, exemptPid);
             if (collision.blocked) return;
             // Walkback may have rewritten the spawn coordinates (#264)
             spawnLat = collision.lat;
@@ -644,7 +698,8 @@ namespace Parsek
         /// </summary>
         private static (bool blocked, double lat, double lon, double alt, Vector3d pos) CheckSpawnCollisions(
             Recording rec, int index, bool isEva, CelestialBody body,
-            double spawnLat, double spawnLon, double spawnAlt, Vector3d spawnPos)
+            double spawnLat, double spawnLon, double spawnAlt, Vector3d spawnPos,
+            uint exemptVesselPid = 0)
         {
             // KSC exclusion zone — block spawn near the launch pad to prevent collisions
             // with KSC infrastructure that isn't in FlightGlobals.Vessels. (#170)
@@ -689,7 +744,8 @@ namespace Parsek
             // to avoid the player's vessel blocking its own recording's spawn.
             bool skipActive = !isEva;
             var (overlap, overlapDist, blockerName, blockerVessel) =
-                SpawnCollisionDetector.CheckOverlapAgainstLoadedVessels(spawnPos, spawnBounds, 5f, skipActive);
+                SpawnCollisionDetector.CheckOverlapAgainstLoadedVessels(
+                    spawnPos, spawnBounds, 5f, skipActive, exemptVesselPid);
             if (overlap)
             {
                 // Precedence: duplicate-blocker-recovery FIRST (#112), walkback SECOND (#264).
@@ -713,7 +769,8 @@ namespace Parsek
 
                     // Re-check overlap after recovery — another vessel may still block
                     var (stillOverlap, recheckDist, recheckName, _) =
-                        SpawnCollisionDetector.CheckOverlapAgainstLoadedVessels(spawnPos, spawnBounds, 5f, skipActive);
+                        SpawnCollisionDetector.CheckOverlapAgainstLoadedVessels(
+                            spawnPos, spawnBounds, 5f, skipActive, exemptVesselPid);
                     if (!stillOverlap)
                     {
                         // Blocker removed, no other overlap — fall through to spawn at original position
@@ -731,7 +788,8 @@ namespace Parsek
                 {
                     double walkLat, walkLon, walkAlt;
                     bool walked = TryWalkbackForEndOfRecordingSpawn(
-                        rec, index, spawnBounds, body, out walkLat, out walkLon, out walkAlt);
+                        rec, index, spawnBounds, body, out walkLat, out walkLon, out walkAlt,
+                        exemptVesselPid);
                     if (walked)
                     {
                         Vector3d walkPos = body.GetWorldSurfacePosition(walkLat, walkLon, walkAlt);
@@ -787,7 +845,8 @@ namespace Parsek
         /// </summary>
         internal static bool TryWalkbackForEndOfRecordingSpawn(
             Recording rec, int index, Bounds spawnBounds, CelestialBody body,
-            out double walkLat, out double walkLon, out double walkAlt)
+            out double walkLat, out double walkLon, out double walkAlt,
+            uint exemptVesselPid = 0)
         {
             walkLat = 0;
             walkLon = 0;
@@ -810,7 +869,7 @@ namespace Parsek
                 worldPos =>
                 {
                     var (ov, _, _, _) = SpawnCollisionDetector.CheckOverlapAgainstLoadedVessels(
-                        worldPos, spawnBounds, 5f, skipActive);
+                        worldPos, spawnBounds, 5f, skipActive, exemptVesselPid);
                     return ov;
                 });
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -74,13 +74,13 @@ sets terminal state and metadata. Standalone path only runs when not in tree mod
 
 ---
 
-## 296. EVA kerbal who planted flag did not appear after spawn
+## ~~296. EVA kerbal who planted flag did not appear after spawn~~
 
-Log shows KSCSpawn successfully spawned the EVA kerbal (Bill Kerman, pid=484546861), but the user reports not seeing it. Likely post-spawn physics destruction — EVA kerbals are fragile and can be killed by terrain collision or slope bounce.
+Log shows KSCSpawn successfully spawned the EVA kerbal (Bill Kerman, pid=484546861), but the user reports not seeing it. Originally attributed to post-spawn physics destruction.
 
-**Investigation:** Enhanced spawn logging to include lat/lon/alt/sit for all spawn paths (KSCSpawn, SpawnAtPosition, RespawnVessel fallback). The existing `RunSpawnDeathChecks` in `ParsekPlaybackPolicy` already detects and logs spawn-death cycles. Next playtest should reveal whether the kerbal is destroyed post-spawn.
+**Likely duplicate of T57.** The scenario is identical: surface EVA near the launchpad, parent vessel already spawned, kerbal never materialized. The "successfully spawned" log was misleading -- `VesselSpawned = true` is set for abandoned spawns too (prevents vessel-gone reset). T57's fix (exempt parent vessel from EVA collision checks) addresses the root cause. Verify in next playtest.
 
-**Status:** Investigation logging added. Root cause TBD — needs next playtest data.
+**Status:** ~~Closed as likely duplicate of T57.~~
 
 ---
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -304,50 +304,35 @@ Prerequisite: delete all old save files (no users yet, clean slate).
 
 ---
 
-### T57. EVA spawn-at-end blocked by parent vessel collision
+### ~~T57. EVA spawn-at-end blocked by parent vessel collision~~
 
 EVA recordings created by mid-flight EVA (tree branch) fail to spawn at end because the entire EVA trajectory overlaps with the already-spawned parent vessel. The spawn collision walkback exhausts every point in the trajectory and abandons the spawn.
 
-Observed in t56-optimizer-test session: Bob Kerman did a surface EVA near the launchpad. The parent vessel (Kerbal X) spawned first, then Bob's EVA spawn was abandoned because his entire trajectory (surface walk near pad) was within the 2.5m EVA collision bounds of the parent. Bob never materialized.
+**Fix:** Added `exemptVesselPid` parameter to `CheckOverlapAgainstLoadedVessels` and threaded it through `CheckSpawnCollisions` and `TryWalkbackForEndOfRecordingSpawn`. New `ResolveParentVesselPid` resolves the parent recording's `VesselPersistentId` via `ParentRecordingId`. EVA spawns skip the parent vessel during collision walkback while still detecting other vessels.
 
-Secondary issue: the held-ghost retry logic (`ParsekPlaybackPolicy.cs:395`) checks `VesselSpawned` but not `SpawnAbandoned`, so it logs "succeeded on retry" for abandoned spawns.
-
-Fix options:
-1. Exempt EVA vessels from collision checks against their known parent vessel (use `ParentRecordingId` to identify the parent, look up its `VesselPersistentId`)
-2. When EVA spawn is abandoned due to parent collision, fall back to boarding the crew member onto the parent vessel instead
-3. Both -- try spawning, skip collision against parent, fall back to boarding if still blocked
-
-**Priority:** Medium -- pre-existing issue, not caused by optimizer changes but exposed by enabling tree recording spawns
+**Status:** ~~Fixed~~
 
 ---
 
-### T58. Debris/booster ghost engines show running effects at zero throttle after staging
+### ~~T58. Debris/booster ghost engines show running effects at zero throttle after staging~~
 
-When a booster separates (staging, decouple), the debris recording inherits the engine state from the moment of separation. If the engine was running at separation, the ghost plays back engine FX (flame, smoke) even though the throttle is 0 on the separated stage. The engine was shut down by staging but the ghost's seed events or initial state show it as running.
+When a booster separates (staging, decouple), the debris recording inherits the engine state from the moment of separation. If the engine was running at separation, the ghost plays back engine FX (flame, smoke) even though the throttle is 0 on the separated stage.
 
-Likely cause: the engine shutdown event at separation is either not captured (the `EngineShutdown` event fires after the part is already on the debris vessel, and the recorder may not catch it on the new vessel's first frame), or the ghost FX system seeds the engine as running from the pre-separation snapshot without checking the throttle value.
+**Root cause:** `MergeInheritedEngineState` added inherited engines to the child's `activeEngineKeys` even when `SeedEngines` had already found the engine part but determined it was non-operational (fuel severed by decoupling). The check at line 1870 only verified the key wasn't in `activeEngineKeys`, not whether `SeedEngines` had already assessed the engine.
 
-Fix: ensure debris recordings either (a) capture the engine shutdown at separation as a seed event, or (b) the ghost FX system checks throttle == 0 and suppresses effects even if the engine state says "running."
+**Fix:** Added `allEngineKeys` parameter to `MergeInheritedEngineState`. `SeedEngines` adds ALL engine parts (operational or not) to `allEngineKeys`. If an inherited engine key is in `allEngineKeys` but not `activeEngineKeys`, the child vessel has the engine but it's non-operational -- skip inheritance. Only inherit when the engine wasn't found by `SeedEngines` at all (KSP timing issue).
 
-**Priority:** Low -- cosmetic, affects ghost visual fidelity only
+**Status:** ~~Fixed~~
 
 ---
 
-### T59. Rewind save lost after mid-recording EVA branch
+### ~~T59. Rewind save lost after mid-recording EVA branch~~
 
-The R button never appears in the recordings table because `RewindSaveFileName` is lost during the EVA branch flow. The sequence:
+The R button never appears in the recordings table because `RewindSaveFileName` is lost during the EVA branch flow. `BuildCaptureRecording` copies the filename into `CaptureAtStop` then clears the recorder field. The EVA child recorder never captures one. At commit, only the current (EVA) recorder is checked -- both sources are null.
 
-1. Recording starts, `CaptureRewindSave` sets `recorder.RewindSaveFileName = "parsek_rw_..."` 
-2. Mid-flight EVA triggers `BuildCaptureRecording` for the parent vessel, which copies `RewindSaveFileName` into `CaptureAtStop` and then clears `recorder.RewindSaveFileName = null` (line 4573)
-3. Bob's EVA recording starts as a promotion (rewind save skipped)
-4. At scene exit, `StashTreeLimbo` calls `recorder.ForceStop()` which calls `BuildCaptureRecording` for Bob's EVA -- this creates a NEW `CaptureAtStop` (with no rewind save) that OVERWRITES the previous one
-5. Line 5465: `recorder.CaptureAtStop?.RewindSaveFileName` = null (Bob's), `recorder.RewindSaveFileName` = null (cleared in step 2). Rewind save is never copied to the root recording
+**Fix:** Extracted `CopyRewindSaveToRoot` (ParsekFlight, internal static) that copies `RewindSaveFileName`, reserved budget (funds/science/rep), and pre-launch budget from a `CaptureAtStop` to the tree's root recording. Called from four sites: `CreateSplitBranch` (the primary T59 fix -- copies at branch time before the EVA recorder takes over), `FinalizeTreeRecordings`, `StashActiveTreeAsPendingLimbo`, and `MergeCommitFlush`. First-wins semantics: root fields are only set if currently empty.
 
-The rewind save file exists on disk (`Parsek/Saves/parsek_rw_*.sfs`) but the root Recording object never gets the filename, so `GetRewindSaveFileName` returns null, and the R button renders as empty space.
-
-Fix: in `FlushRecorderToTreeRecording` (or the EVA branch code), copy `recorder.RewindSaveFileName` to the root tree recording BEFORE `BuildCaptureRecording` clears it. Or preserve the rewind save across CaptureAtStop overwrites.
-
-**Priority:** High -- the R button is a core user affordance and never appears after any EVA during a recording session
+**Status:** ~~Fixed~~
 
 ---
 


### PR DESCRIPTION
## Summary

- **T59 (High):** Rewind save (R button) now works after mid-recording EVA -- `CopyRewindSaveToRoot` copies filename + reserved budget from the split recorder's CaptureAtStop to the tree root at branch time, before the EVA recorder takes over
- **T58 (Low):** Debris ghost engines no longer show running FX at zero throttle after staging -- `MergeInheritedEngineState` checks `allEngineKeys` to distinguish non-operational engines (fuel severed by decoupling) from KSP-timing misses
- **T57 (Medium):** EVA recordings now spawn at end instead of being abandoned -- `exemptVesselPid` parameter threaded through collision checks, resolved via `ResolveParentVesselPid` from `ParentRecordingId`

## Test plan

- [x] 24 new unit tests (12 CopyRewindSaveToRoot, 4 MergeInheritedEngineState, 8 ResolveParentVesselPid) -- all pass
- [x] Full suite: 5748 pass, 0 fail
- [ ] In-game: launch Kerbal X, EVA mid-flight, revert -- R button should appear in recordings table
- [ ] In-game: staging with booster separation -- debris ghost should not show engine flames
- [ ] In-game: EVA near launchpad, commit recording -- EVA kerbal should spawn at end position