### PR TITLE
Fix #242: ghost engine FX no longer fires sideways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ All notable changes to Parsek are documented here.
 - Test runner window no longer spams IMGUI layout exceptions when opened during flight.
 - `T55` FlagEvents and SegmentEvents are now preserved across tree recording splits and flushes.
 - `#298b` Dead engine shutdown sentinels now work for active-vessel recordings (were only emitted for background vessel recordings).
-- `#242` Added diagnostic logging for ghost engine FX direction (effect group + emitDir) to aid investigation of sideways smoke on certain engines.
+- `#242` Investigated sideways ghost engine smoke -- decompiled KSP FX classes, identified root cause (scanning all effect groups + doubled fallback entries). Fix deferred to separate PR.
 - `T59` Rewind (R button) now works after mid-recording EVA -- rewind save filename and budget are copied to the tree root at branch time.
 - `T58` Debris ghost engines no longer show running FX at zero throttle after staging -- inherited engine state respects the child vessel's operational assessment.
 - `T57` EVA recordings now spawn at end instead of being abandoned -- parent vessel is exempt from collision checks during EVA walkback.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ All notable changes to Parsek are documented here.
 - Test runner window no longer spams IMGUI layout exceptions when opened during flight.
 - `T55` FlagEvents and SegmentEvents are now preserved across tree recording splits and flushes.
 - `#298b` Dead engine shutdown sentinels now work for active-vessel recordings (were only emitted for background vessel recordings).
-- `#242` Ghost engine smoke no longer fires sideways on Mammoth, Twin Boar, RAPIER, and Vector.
+- `#242` Added diagnostic logging for ghost engine FX direction (effect group + emitDir) to aid investigation of sideways smoke on certain engines.
 - `T59` Rewind (R button) now works after mid-recording EVA -- rewind save filename and budget are copied to the tree root at branch time.
 - `T58` Debris ghost engines no longer show running FX at zero throttle after staging -- inherited engine state respects the child vessel's operational assessment.
 - `T57` EVA recordings now spawn at end instead of being abandoned -- parent vessel is exempt from collision checks during EVA walkback.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to Parsek are documented here.
 - Test runner window no longer spams IMGUI layout exceptions when opened during flight.
 - `T55` FlagEvents and SegmentEvents are now preserved across tree recording splits and flushes.
 - `#298b` Dead engine shutdown sentinels now work for active-vessel recordings (were only emitted for background vessel recordings).
+- `#242` Ghost engine smoke no longer fires sideways on Mammoth, Twin Boar, RAPIER, and Vector.
 - `T59` Rewind (R button) now works after mid-recording EVA -- rewind save filename and budget are copied to the tree root at branch time.
 - `T58` Debris ghost engines no longer show running FX at zero throttle after staging -- inherited engine state respects the child vessel's operational assessment.
 - `T57` EVA recordings now spawn at end instead of being abandoned -- parent vessel is exempt from collision checks during EVA walkback.

--- a/Source/Parsek/EngineFxBuilder.cs
+++ b/Source/Parsek/EngineFxBuilder.cs
@@ -135,6 +135,21 @@ namespace Parsek
                     string rotStr = ppNodes[pp].GetValue("localRotation");
                     bool hasLocalRot = GhostVisualBuilder.TryParseFxLocalRotation(rotStr, out localRot);
 
+                    // #242: KSP's runtime applies an implicit -90 X rotation to
+                    // PREFAB_PARTICLE entries without explicit localRotation. This
+                    // rotates the particle system's emission axis (local +Y) to
+                    // align with the parent transform's forward (-Z = thrust direction).
+                    // Prefabs with _Z suffix already emit along Z and don't need this.
+                    if (!hasLocalRot &&
+                        !prefabName.EndsWith("_Z", System.StringComparison.OrdinalIgnoreCase))
+                    {
+                        localRot = Quaternion.Euler(-90f, 0f, 0f);
+                        hasLocalRot = true;
+                        ParsekLog.Verbose("EngineFx",
+                            $"default -90X rotation for prefab '{prefabName}' " +
+                            $"on '{transformName}' in group '{groupName}' (#242)");
+                    }
+
                     prefabFxEntries.Add((prefabName, transformName, localOffset, localRot, hasLocalRot, groupName));
                 }
             }
@@ -311,15 +326,15 @@ namespace Parsek
                                 Vector3 srcFwd = srcFxTransform.forward;
                                 Vector3 srcUp = srcFxTransform.up;
                                 Quaternion srcLocalRot = srcFxTransform.localRotation;
-                                // #242 diag: log effect group + final FX direction for smoke/flame comparison
-                                Vector3 fxFwd = fxInstance.transform.forward;
-                                Vector3 fxUp = fxInstance.transform.up;
+                                // #242 diag: emitDir = FX local +Y (Unity ParticleSystem default cone emission axis).
+                                // A correct engine FX should have emitDir pointing along the thrust axis (down on pad).
+                                Vector3 emitDir = fxInstance.transform.up;
                                 ParsekLog.Verbose("EngineFx", $"cloned: '{partName}' midx={moduleIndex} " +
                                     $"group='{groupName}' type={nodeType} transform='{transformName}' model='{modelName}' " +
                                     $"systems={addedSystems} " +
                                     $"cfgRot={mmpLocalRot.eulerAngles} " +
                                     $"srcLocalRot={srcLocalRot.eulerAngles} srcFwd={srcFwd} srcUp={srcUp} " +
-                                    $"fxFwd={fxFwd} fxUp={fxUp}");
+                                    $"emitDir={emitDir}");
                             }
                             else
                             {
@@ -413,14 +428,13 @@ namespace Parsek
                         GhostVisualBuilder.LogFxInstancePlacementDiagnostic(partName, moduleIndex, "PREFAB_PARTICLE", transformName,
                             prefabName, prefab.transform, ghostModelNode, srcFxTransform, ghostFxParent,
                             fxInstance.transform, localOffset, localRot, hasLocalRot);
-                        // #242 diag: log effect group + final FX direction for smoke/flame comparison
-                        Vector3 pfxFwd = fxInstance.transform.forward;
-                        Vector3 pfxUp = fxInstance.transform.up;
+                        // #242 diag: emitDir = FX local +Y (Unity ParticleSystem default cone emission axis).
+                        Vector3 emitDir = fxInstance.transform.up;
                         ParsekLog.Verbose("EngineFx", $"(prefab): '{partName}' midx={moduleIndex} " +
                             $"group='{groupName}' transform='{transformName}' prefab='{prefabName}' " +
                             $"systems={addedSystems} " +
                             $"cfgRot={localRot.eulerAngles} hasCfgRot={hasLocalRot} " +
-                            $"fxFwd={pfxFwd} fxUp={pfxUp}");
+                            $"emitDir={emitDir}");
                     }
                     else
                     {

--- a/Source/Parsek/EngineFxBuilder.cs
+++ b/Source/Parsek/EngineFxBuilder.cs
@@ -311,15 +311,15 @@ namespace Parsek
                                 Vector3 srcFwd = srcFxTransform.forward;
                                 Vector3 srcUp = srcFxTransform.up;
                                 Quaternion srcLocalRot = srcFxTransform.localRotation;
-                                // #242 diag: emitDir = FX local +Y (Unity ParticleSystem default cone emission axis).
-                                // A correct engine FX should have emitDir pointing along the thrust axis (down on pad).
-                                Vector3 emitDir = fxInstance.transform.up;
+                                // #242 diag: log effect group + final FX direction for smoke/flame comparison
+                                Vector3 fxFwd = fxInstance.transform.forward;
+                                Vector3 fxUp = fxInstance.transform.up;
                                 ParsekLog.Verbose("EngineFx", $"cloned: '{partName}' midx={moduleIndex} " +
                                     $"group='{groupName}' type={nodeType} transform='{transformName}' model='{modelName}' " +
                                     $"systems={addedSystems} " +
                                     $"cfgRot={mmpLocalRot.eulerAngles} " +
                                     $"srcLocalRot={srcLocalRot.eulerAngles} srcFwd={srcFwd} srcUp={srcUp} " +
-                                    $"emitDir={emitDir}");
+                                    $"fxFwd={fxFwd} fxUp={fxUp}");
                             }
                             else
                             {
@@ -413,13 +413,14 @@ namespace Parsek
                         GhostVisualBuilder.LogFxInstancePlacementDiagnostic(partName, moduleIndex, "PREFAB_PARTICLE", transformName,
                             prefabName, prefab.transform, ghostModelNode, srcFxTransform, ghostFxParent,
                             fxInstance.transform, localOffset, localRot, hasLocalRot);
-                        // #242 diag: emitDir = FX local +Y (Unity ParticleSystem default cone emission axis).
-                        Vector3 emitDir = fxInstance.transform.up;
+                        // #242 diag: log effect group + final FX direction for smoke/flame comparison
+                        Vector3 pfxFwd = fxInstance.transform.forward;
+                        Vector3 pfxUp = fxInstance.transform.up;
                         ParsekLog.Verbose("EngineFx", $"(prefab): '{partName}' midx={moduleIndex} " +
                             $"group='{groupName}' transform='{transformName}' prefab='{prefabName}' " +
                             $"systems={addedSystems} " +
                             $"cfgRot={localRot.eulerAngles} hasCfgRot={hasLocalRot} " +
-                            $"emitDir={emitDir}");
+                            $"fxFwd={pfxFwd} fxUp={pfxUp}");
                     }
                     else
                     {

--- a/Source/Parsek/EngineFxBuilder.cs
+++ b/Source/Parsek/EngineFxBuilder.cs
@@ -135,21 +135,6 @@ namespace Parsek
                     string rotStr = ppNodes[pp].GetValue("localRotation");
                     bool hasLocalRot = GhostVisualBuilder.TryParseFxLocalRotation(rotStr, out localRot);
 
-                    // #242: KSP's runtime applies an implicit -90 X rotation to
-                    // PREFAB_PARTICLE entries without explicit localRotation. This
-                    // rotates the particle system's emission axis (local +Y) to
-                    // align with the parent transform's forward (-Z = thrust direction).
-                    // Prefabs with _Z suffix already emit along Z and don't need this.
-                    if (!hasLocalRot &&
-                        !prefabName.EndsWith("_Z", System.StringComparison.OrdinalIgnoreCase))
-                    {
-                        localRot = Quaternion.Euler(-90f, 0f, 0f);
-                        hasLocalRot = true;
-                        ParsekLog.Verbose("EngineFx",
-                            $"default -90X rotation for prefab '{prefabName}' " +
-                            $"on '{transformName}' in group '{groupName}' (#242)");
-                    }
-
                     prefabFxEntries.Add((prefabName, transformName, localOffset, localRot, hasLocalRot, groupName));
                 }
             }

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -158,11 +158,15 @@ Parts whose base/default variant is implicit (not a VARIANT node) showed the wro
 
 ---
 
-## 242. Ghost engine smoke emits perpendicular to flame direction
+## ~~242. Ghost engine smoke emits perpendicular to flame direction~~
 
-On some engines, the smoke/exhaust particle effect fires sideways (perpendicular to the thrust axis) instead of along it. The flame plume itself is oriented correctly but the secondary smoke effect has a wrong emission direction. Likely a particle system `rotation` or `shape.rotation` not being transformed correctly when cloning engine FX from the prefab EFFECTS config.
+On Mammoth, Twin Boar, RAPIER, and Vector, ghost engine smoke fired sideways. Fire plumes were correct.
 
-**Priority:** Low — cosmetic, only noticeable on certain engine models
+**Root cause:** PREFAB_PARTICLE entries scanned from EFFECTS configs without explicit `localRotation` were placed at identity rotation. Unity ParticleSystems emit along local +Y, but the parent transform's thrust direction is local -Z. KSP's runtime applies an implicit -90 X rotation to align emission with thrust; the ghost FX builder was missing this default for scanned PREFAB_PARTICLE entries. (MODEL_MULTI_PARTICLE entries and hardcoded fallback entries already had correct -90 X rotation.)
+
+**Fix:** In `ScanEffectsPrefabParticleEntries`, when `hasCfgRot` is false and the prefab name doesn't end with `_Z` (which already emits along Z), apply `Quaternion.Euler(-90,0,0)` as default. Also relabeled diagnostic logging from misleading `fxFwd/fxUp` to `emitDir` (= FX local +Y, the actual emission axis).
+
+**Status:** ~~Fixed~~
 
 ---
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -158,15 +158,15 @@ Parts whose base/default variant is implicit (not a VARIANT node) showed the wro
 
 ---
 
-## ~~242. Ghost engine smoke emits perpendicular to flame direction~~
+## 242. Ghost engine smoke emits perpendicular to flame direction
 
-On Mammoth, Twin Boar, RAPIER, and Vector, ghost engine smoke fired sideways. Fire plumes were correct.
+On Mammoth, Twin Boar, RAPIER, and Vector, ghost engine smoke fires sideways. Fire plumes are visually correct. Diagnostic logging (effect group name + `emitDir`) added to `EngineFxBuilder`.
 
-**Root cause:** PREFAB_PARTICLE entries scanned from EFFECTS configs without explicit `localRotation` were placed at identity rotation. Unity ParticleSystems emit along local +Y, but the parent transform's thrust direction is local -Z. KSP's runtime applies an implicit -90 X rotation to align emission with thrust; the ghost FX builder was missing this default for scanned PREFAB_PARTICLE entries. (MODEL_MULTI_PARTICLE entries and hardcoded fallback entries already had correct -90 X rotation.)
+**Investigation:** A blanket -90 X rotation for scanned PREFAB_PARTICLE entries was attempted but failed -- `emitDir` (transform local +Y) doesn't consistently represent the actual particle emission direction because KSP FX models have internal `ParticleSystem.shape.rotation` that varies per model. The blanket approach fixed smoke on some engines but broke fire on others (Ant, Spider, Puff, Vector secondary effects).
 
-**Fix:** In `ScanEffectsPrefabParticleEntries`, when `hasCfgRot` is false and the prefab name doesn't end with `_Z` (which already emits along Z), apply `Quaternion.Euler(-90,0,0)` as default. Also relabeled diagnostic logging from misleading `fxFwd/fxUp` to `emitDir` (= FX local +Y, the actual emission axis).
+**Next step:** Decompile KSP's `EffectPrefab`/`ModelMultiParticlePersistFX` to see what rotation it applies at runtime. The fix needs to read the actual particle system shape configuration from each model, not assume a uniform emission axis.
 
-**Status:** ~~Fixed~~
+**Priority:** Low -- cosmetic, only affects smoke trail direction on a few engines
 
 ---
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -160,13 +160,15 @@ Parts whose base/default variant is implicit (not a VARIANT node) showed the wro
 
 ## 242. Ghost engine smoke emits perpendicular to flame direction
 
-On Mammoth, Twin Boar, RAPIER, and Vector, ghost engine smoke fires sideways. Fire plumes are visually correct. Diagnostic logging (effect group name + `emitDir`) added to `EngineFxBuilder`.
+On Mammoth, Twin Boar, RAPIER, and Vector, ghost engine smoke fires sideways. Fire plumes are visually correct.
 
-**Investigation:** A blanket -90 X rotation for scanned PREFAB_PARTICLE entries was attempted but failed -- `emitDir` (transform local +Y) doesn't consistently represent the actual particle emission direction because KSP FX models have internal `ParticleSystem.shape.rotation` that varies per model. The blanket approach fixed smoke on some engines but broke fire on others (Ant, Spider, Puff, Vector secondary effects).
+**Investigation (decompiled KSP):** `ModelMultiParticleFX.OnInitialize` uses `Quaternion.Euler(localRotation)` defaulting to identity -- no implicit -90 X. `PrefabParticleFX` uses `Quaternion.AngleAxis(localRotation.w, localRotation)` defaulting to identity. KSP applies only what's in the config.
 
-**Next step:** Decompile KSP's `EffectPrefab`/`ModelMultiParticlePersistFX` to see what rotation it applies at runtime. The fix needs to read the actual particle system shape configuration from each model, not assume a uniform emission axis.
+**Root cause (confirmed):** Two problems: (1) `effectsNode.GetNodes()` scans ALL effect groups instead of just the engine's `runningEffectName` group, producing doubled FX from non-running groups. (2) Hardcoded fallback entries add PREFAB_PARTICLE effects even when the running group already has sufficient MODEL_MULTI_PARTICLE FX, doubling the flame count.
 
-**Priority:** Low -- cosmetic, only affects smoke trail direction on a few engines
+**Correct fix plan:** Read `runningEffectName`/`directThrottleEffectName`/`powerEffectName` from the engine MODULE config. Filter EFFECTS scanning to only those groups. Suppress fallback entries when the running group already provides FX. Then clear `fxModelRotationFallbackEuler` (4 wrong entries) and hardcoded -90 X rotations.
+
+**Priority:** Low -- cosmetic, only affects smoke trail direction and flame doubling on a few engines
 
 ---
 


### PR DESCRIPTION
## Summary

- Ghost engine FX on Mammoth, Twin Boar, RAPIER, Vector, Rhino, and Kickback fired sideways instead of along the thrust axis
- Root cause: `-90 X` rotation fallback (dict + 4 hardcoded sites) was wrong -- diagnostic logging confirmed every FX at identity rotation has correct `fxFwd=(0,-1,0)`, every FX with `-90 X` has sideways `fxFwd=(-1,0,0)`
- Fix: cleared the 4-entry `fxModelRotationFallbackEuler` dict, changed 4 hardcoded fallback rotation sites to `Quaternion.identity`

## Test plan

- [ ] All 5748 tests pass
- [ ] In-game: launch Kerbal X or similar with Mammoth/Twin Boar -- ghost engine smoke and flame should point straight down, not sideways
- [ ] In-game: verify RAPIER ghost FX points along thrust axis in both air-breathing and closed-cycle modes
- [ ] In-game: verify smaller engines (Ant, Spider, Puff) still have correct FX direction