### PR TITLE
Fix #270: sidecar epoch validation on quickload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to Parsek are documented here.
 - `T55` FlagEvents and SegmentEvents are now preserved across tree recording splits and flushes.
 - `#298b` Dead engine shutdown sentinels now work for active-vessel recordings (were only emitted for background vessel recordings).
 - `T59` Rewind (R button) now works after mid-recording EVA -- rewind save filename and budget are copied to the tree root at branch time.
+- `#270` Quickloading no longer loads stale sidecar trajectory data from a later save point.
 - `T58` Debris ghost engines no longer show running FX at zero throttle after staging -- inherited engine state respects the child vessel's operational assessment.
 - `T57` EVA recordings now spawn at end instead of being abandoned -- parent vessel is exempt from collision checks during EVA walkback.
 

--- a/Source/Parsek.Tests/Bug270SidecarEpochTests.cs
+++ b/Source/Parsek.Tests/Bug270SidecarEpochTests.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    [Collection("Sequential")]
+    public class Bug270SidecarEpochTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public Bug270SidecarEpochTests()
+        {
+            RecordingStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+            MilestoneStore.ResetForTesting();
+            GameStateStore.SuppressLogging = true;
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+            RecordingStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+            MilestoneStore.ResetForTesting();
+        }
+
+        // --- .sfs round-trip tests ---
+
+        [Fact]
+        public void SidecarEpoch_RoundTrips_ThroughSfsMetadata()
+        {
+            var rec = new Recording { SidecarEpoch = 3 };
+            var node = new ConfigNode("RECORDING");
+            RecordingTree.SaveRecordingInto(node, rec);
+
+            var restored = new Recording();
+            RecordingTree.LoadRecordingFrom(node, restored);
+
+            Assert.Equal(3, restored.SidecarEpoch);
+        }
+
+        [Fact]
+        public void SidecarEpoch_Zero_OmittedFromSfs()
+        {
+            var rec = new Recording { SidecarEpoch = 0 };
+            var node = new ConfigNode("RECORDING");
+            RecordingTree.SaveRecordingInto(node, rec);
+
+            Assert.Null(node.GetValue("sidecarEpoch"));
+        }
+
+        [Fact]
+        public void SidecarEpoch_MissingSfsField_DefaultsToZero()
+        {
+            var node = new ConfigNode("RECORDING");
+            node.AddValue("vesselName", "OldSave");
+
+            var rec = new Recording();
+            RecordingTree.LoadRecordingFrom(node, rec);
+
+            Assert.Equal(0, rec.SidecarEpoch);
+        }
+
+        // --- ShouldSkipStaleSidecar validation tests ---
+
+        [Fact]
+        public void ShouldSkipStaleSidecar_MatchingEpoch_ReturnsFalse()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "test-match",
+                SidecarEpoch = 2
+            };
+
+            bool skipped = RecordingStore.ShouldSkipStaleSidecar(rec, 2);
+
+            Assert.False(skipped);
+        }
+
+        [Fact]
+        public void ShouldSkipStaleSidecar_MismatchedEpoch_ReturnsTrue()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "test-stale",
+                SidecarEpoch = 1
+            };
+
+            bool skipped = RecordingStore.ShouldSkipStaleSidecar(rec, 3);
+
+            Assert.True(skipped);
+            Assert.Contains(logLines, l =>
+                l.Contains("Sidecar epoch mismatch") &&
+                l.Contains("test-stale") &&
+                l.Contains("expects epoch 1") &&
+                l.Contains("has epoch 3"));
+        }
+
+        [Fact]
+        public void ShouldSkipStaleSidecar_ZeroSfsEpoch_SkipsValidation()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "test-old-save",
+                SidecarEpoch = 0
+            };
+
+            bool skipped = RecordingStore.ShouldSkipStaleSidecar(rec, 5);
+
+            Assert.False(skipped);
+        }
+
+        [Fact]
+        public void ShouldSkipStaleSidecar_ZeroPrecEpoch_WithNonZeroSfsEpoch_DetectsMismatch()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "test-old-prec",
+                SidecarEpoch = 2
+            };
+
+            bool skipped = RecordingStore.ShouldSkipStaleSidecar(rec, 0);
+
+            Assert.True(skipped);
+        }
+
+        // --- Epoch increment in SaveRecordingFiles scenario ---
+
+        [Fact]
+        public void SidecarEpoch_IncrementedOnSave_MatchesSfsAfterSaveSequence()
+        {
+            // Simulate the save sequence: SaveRecordingFiles increments epoch,
+            // then SaveRecordingInto writes the same epoch to .sfs
+            var rec = new Recording
+            {
+                RecordingId = "test-sequence",
+                SidecarEpoch = 0
+            };
+
+            // Simulate SaveRecordingFiles incrementing the epoch
+            rec.SidecarEpoch++;
+            Assert.Equal(1, rec.SidecarEpoch);
+
+            // SaveRecordingInto would write this to .sfs
+            var sfsNode = new ConfigNode("RECORDING");
+            RecordingTree.SaveRecordingInto(sfsNode, rec);
+
+            // On load, .sfs epoch should match what was written to .prec
+            var restored = new Recording();
+            RecordingTree.LoadRecordingFrom(sfsNode, restored);
+            Assert.Equal(1, restored.SidecarEpoch);
+
+            // And the validation should pass
+            bool skipped = RecordingStore.ShouldSkipStaleSidecar(restored, 1);
+            Assert.False(skipped);
+        }
+
+        [Fact]
+        public void SidecarEpoch_QuicksaveQuickload_DetectsStaleness()
+        {
+            // Full scenario: quicksave at T2 (epoch=1), autosave at T3 (epoch=2),
+            // quickload T2 → .sfs has epoch=1, .prec has epoch=2
+            var rec = new Recording
+            {
+                RecordingId = "test-quickload",
+                SidecarEpoch = 0
+            };
+
+            // T2: quicksave → increment to 1
+            rec.SidecarEpoch++;
+            int t2Epoch = rec.SidecarEpoch;  // 1
+
+            var t2SfsNode = new ConfigNode("RECORDING");
+            RecordingTree.SaveRecordingInto(t2SfsNode, rec);
+
+            // T3: autosave → increment to 2
+            rec.SidecarEpoch++;
+            int t3Epoch = rec.SidecarEpoch;  // 2
+
+            // Quickload T2: load .sfs from T2 quicksave
+            var loaded = new Recording();
+            RecordingTree.LoadRecordingFrom(t2SfsNode, loaded);
+            Assert.Equal(1, loaded.SidecarEpoch);
+
+            // .prec on disk has T3 epoch
+            bool skipped = RecordingStore.ShouldSkipStaleSidecar(loaded, t3Epoch);
+            Assert.True(skipped);
+            Assert.Contains(logLines, l =>
+                l.Contains("Sidecar epoch mismatch") &&
+                l.Contains("sidecar is stale"));
+        }
+    }
+}

--- a/Source/Parsek.Tests/Bug270SidecarEpochTests.cs
+++ b/Source/Parsek.Tests/Bug270SidecarEpochTests.cs
@@ -192,7 +192,7 @@ namespace Parsek.Tests
             Assert.True(skipped);
             Assert.Contains(logLines, l =>
                 l.Contains("Sidecar epoch mismatch") &&
-                l.Contains("sidecar is stale"));
+                l.Contains("sidecar is stale (bug #270)"));
         }
     }
 }

--- a/Source/Parsek/Recording.cs
+++ b/Source/Parsek/Recording.cs
@@ -54,6 +54,12 @@ namespace Parsek
         // since last SaveRecordingFiles call. Checked in OnSave to skip unchanged recordings.
         [NonSerialized] public bool FilesDirty;
 
+        // Sidecar epoch: monotonically increasing counter stamped into both .sfs metadata
+        // and .prec sidecar file on each write. On load, if the .prec epoch doesn't match
+        // the .sfs epoch, the sidecar is stale (written by a different save point) and
+        // trajectory data is skipped. See bug #270.
+        internal int SidecarEpoch;
+
         /// <summary>
         /// Marks this recording as needing its <c>.prec</c> sidecar file rewritten
         /// on the next <c>OnSave</c>. MUST be called after any mutation to

--- a/Source/Parsek/Recording.cs
+++ b/Source/Parsek/Recording.cs
@@ -58,6 +58,8 @@ namespace Parsek
         // and .prec sidecar file on each write. On load, if the .prec epoch doesn't match
         // the .sfs epoch, the sidecar is stale (written by a different save point) and
         // trajectory data is skipped. See bug #270.
+        // Intentionally NOT [NonSerialized] — persists via ConfigNode in RecordingTree
+        // Save/LoadRecordingInto so the epoch survives scene reloads.
         internal int SidecarEpoch;
 
         /// <summary>

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -3454,16 +3454,9 @@ namespace Parsek
                 }
 
                 // Save .prec trajectory file
-                // Bug #270: increment sidecar epoch before writing so the .prec and .sfs
-                // (written immediately after by RecordingTree.SaveRecordingInto) share the
-                // same epoch. On quickload, a stale .prec (from a later save) will have a
-                // higher epoch than the .sfs expects, and LoadRecordingFiles will skip it.
-                rec.SidecarEpoch++;
                 var precNode = new ConfigNode("PARSEK_RECORDING");
                 precNode.AddValue("version", rec.RecordingFormatVersion);
                 precNode.AddValue("recordingId", rec.RecordingId);
-                precNode.AddValue("sidecarEpoch", rec.SidecarEpoch.ToString(System.Globalization.CultureInfo.InvariantCulture));
-                SerializeTrajectoryInto(precNode, rec);
 
                 string precPath = RecordingPaths.ResolveSaveScopedPath(
                     RecordingPaths.BuildTrajectoryRelativePath(rec.RecordingId));
@@ -3472,6 +3465,16 @@ namespace Parsek
                     Log($"[Parsek] WARNING: SaveRecordingFiles could not resolve trajectory path for {rec.RecordingId}");
                     return false;
                 }
+
+                // Bug #270: increment sidecar epoch immediately before the .prec write
+                // (after all early-return guards) so the in-memory epoch only advances
+                // when the file actually hits disk. RecordingTree.SaveRecordingInto runs
+                // after this method and reads the same in-memory value, keeping .sfs and
+                // .prec in sync. On quickload, a stale .prec (from a later save) will
+                // have a higher epoch than the .sfs expects, and LoadRecordingFiles skips it.
+                rec.SidecarEpoch++;
+                precNode.AddValue("sidecarEpoch", rec.SidecarEpoch.ToString(System.Globalization.CultureInfo.InvariantCulture));
+                SerializeTrajectoryInto(precNode, rec);
                 SafeWriteConfigNode(precNode, precPath);
 
                 // Save _vessel.craft (always rewrite — snapshot can be mutated by spawn offset)
@@ -3644,7 +3647,7 @@ namespace Parsek
             ParsekLog.Warn("RecordingStore",
                 $"Sidecar epoch mismatch for {rec.RecordingId}: " +
                 $".sfs expects epoch {rec.SidecarEpoch}, .prec has epoch {fileEpoch} — " +
-                $"sidecar is stale (bug #270), skipping trajectory load");
+                $"sidecar is stale (bug #270), skipping sidecar load (trajectory + snapshots)");
             return true;
         }
 

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -3454,9 +3454,15 @@ namespace Parsek
                 }
 
                 // Save .prec trajectory file
+                // Bug #270: increment sidecar epoch before writing so the .prec and .sfs
+                // (written immediately after by RecordingTree.SaveRecordingInto) share the
+                // same epoch. On quickload, a stale .prec (from a later save) will have a
+                // higher epoch than the .sfs expects, and LoadRecordingFiles will skip it.
+                rec.SidecarEpoch++;
                 var precNode = new ConfigNode("PARSEK_RECORDING");
                 precNode.AddValue("version", rec.RecordingFormatVersion);
                 precNode.AddValue("recordingId", rec.RecordingId);
+                precNode.AddValue("sidecarEpoch", rec.SidecarEpoch.ToString(System.Globalization.CultureInfo.InvariantCulture));
                 SerializeTrajectoryInto(precNode, rec);
 
                 string precPath = RecordingPaths.ResolveSaveScopedPath(
@@ -3559,6 +3565,16 @@ namespace Parsek
                     return false;
                 }
 
+                // Bug #270: validate sidecar epoch
+                string fileEpochStr = precNode.GetValue("sidecarEpoch");
+                int fileEpoch = 0;
+                if (fileEpochStr != null)
+                    int.TryParse(fileEpochStr, System.Globalization.NumberStyles.Integer,
+                        System.Globalization.CultureInfo.InvariantCulture, out fileEpoch);
+
+                if (ShouldSkipStaleSidecar(rec, fileEpoch))
+                    return false;
+
                 DeserializeTrajectoryFrom(precNode, rec);
 
                 // #288: eagerly populate TerminalOrbit cache from the last orbit segment if
@@ -3607,6 +3623,29 @@ namespace Parsek
                 Log($"[Parsek] Failed to load recording files for {rec.RecordingId}: {ex.Message}");
                 return false;
             }
+        }
+
+        /// <summary>
+        /// Bug #270: Returns true if the sidecar file's epoch doesn't match the
+        /// recording's expected epoch (loaded from .sfs). When true, the caller
+        /// should skip trajectory deserialization — the .prec is from a different
+        /// save point and its data would be inconsistent with the .sfs metadata.
+        /// Backward compat: if the .sfs epoch is 0 (old save without epoch),
+        /// validation is skipped and the sidecar is always accepted.
+        /// </summary>
+        internal static bool ShouldSkipStaleSidecar(Recording rec, int fileEpoch)
+        {
+            if (rec.SidecarEpoch <= 0)
+                return false;  // old save without epoch — skip validation
+
+            if (fileEpoch == rec.SidecarEpoch)
+                return false;  // epochs match — sidecar is valid
+
+            ParsekLog.Warn("RecordingStore",
+                $"Sidecar epoch mismatch for {rec.RecordingId}: " +
+                $".sfs expects epoch {rec.SidecarEpoch}, .prec has epoch {fileEpoch} — " +
+                $"sidecar is stale (bug #270), skipping trajectory load");
+            return true;
         }
 
         private static void SafeWriteConfigNode(ConfigNode node, string path)

--- a/Source/Parsek/RecordingTree.cs
+++ b/Source/Parsek/RecordingTree.cs
@@ -251,6 +251,10 @@ namespace Parsek
 
             // Existing recording metadata
             recNode.AddValue("recordingFormatVersion", rec.RecordingFormatVersion);
+
+            // Sidecar epoch (bug #270): stamped into .prec on write, validated on load
+            if (rec.SidecarEpoch > 0)
+                recNode.AddValue("sidecarEpoch", rec.SidecarEpoch.ToString(ic));
             recNode.AddValue("loopPlayback", rec.LoopPlayback);
             recNode.AddValue("loopIntervalSeconds", rec.LoopIntervalSeconds.ToString("R", ic));
             if (!double.IsNaN(rec.LoopStartUT))
@@ -492,6 +496,15 @@ namespace Parsek
                 int formatVersion;
                 if (int.TryParse(formatVersionStr, NumberStyles.Integer, ic, out formatVersion))
                     rec.RecordingFormatVersion = formatVersion;
+            }
+
+            // Sidecar epoch (bug #270)
+            string sidecarEpochStr = recNode.GetValue("sidecarEpoch");
+            if (sidecarEpochStr != null)
+            {
+                int sidecarEpoch;
+                if (int.TryParse(sidecarEpochStr, NumberStyles.Integer, ic, out sidecarEpoch))
+                    rec.SidecarEpoch = sidecarEpoch;
             }
 
             string loopPlaybackStr = recNode.GetValue("loopPlayback");

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -166,15 +166,15 @@ On some engines, the smoke/exhaust particle effect fires sideways (perpendicular
 
 ---
 
-## 270. Sidecar file (.prec) version staleness across save points
+## ~~270. Sidecar file (.prec) version staleness across save points~~
 
 Latent pre-existing architectural limitation of the v3 external sidecar format: sidecar files (`saves/<save>/Parsek/Recordings/*.prec`) are shared across ALL save points for a given save slot. If the player quicksaves in flight at T2, exits to TS at T3 (which rewrites the sidecars with T3 data), then quickloads the T2 save, the .sfs loads the T2 active tree metadata but `LoadRecordingFiles` hydrates from T3 sidecars on disk — a mismatch.
 
 Not introduced by PR #160, but PR #160's quickload-resume path makes it more reachable (previously, quickloading between scene changes always finalized the tree, so the tree was effectively "new" each time).
 
-**Fix plan (long-term):** version sidecar files per save point — stamp each `.prec` with the save epoch or a hash, refuse to load mismatched versions. Alternatively, never rewrite sidecars for committed trees; treat them as immutable.
+**Fix:** Added `SidecarEpoch` counter to Recording, incremented on every `SaveRecordingFiles` write. The epoch is stamped into both the .prec file and the .sfs metadata. On load, `LoadRecordingFiles` validates that the .prec epoch matches the .sfs epoch. On mismatch (stale sidecar from a later save), trajectory load is skipped and a warning is logged. Committed recordings are unaffected (FilesDirty stays false after first write, so .prec is never overwritten and epochs always match). Backward compatible: old saves without epoch (SidecarEpoch=0) skip validation entirely.
 
-**Priority:** Low — rare user workflow (quicksave in flight + exit to TS + quickload), and the worst case is playback inconsistency, not data loss. Flag again if it bites during playtest.
+**Status:** ~~Fixed~~
 
 ---
 


### PR DESCRIPTION
## Summary

- Add `SidecarEpoch` counter to `Recording`, incremented on every `.prec` sidecar write. Stamped into both `.prec` and `.sfs` metadata.
- On load, `LoadRecordingFiles` validates epochs match. Stale sidecar (from a later save point) is skipped with a warning log.
- Backward compatible: old saves without epoch (SidecarEpoch=0) skip validation entirely. Committed recordings are unaffected (FilesDirty stays false, .prec never overwritten).

## Test plan

- [x] 9 new unit tests in `Bug270SidecarEpochTests.cs` (round-trip, backward compat, mismatch detection, full quicksave/quickload scenario)
- [x] Full test suite passes (5724 tests)
- [ ] In-game: F5 during flight, continue flying, F9 -- verify no stale ghost trajectory
- [ ] In-game: verify old saves without epoch still load normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)