### PR TITLE
Fix #242: ghost engine PREFAB_PARTICLE FX orientation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to Parsek are documented here.
 - `T58` Debris ghost engines no longer show running FX at zero throttle after staging -- inherited engine state respects the child vessel's operational assessment.
 - `T57` EVA recordings now spawn at end instead of being abandoned -- parent vessel is exempt from collision checks during EVA walkback.
 - `#290` Debris and EVA branch recordings in the active tree no longer lose trajectory data after two cold starts (quit KSP mid-flight, relaunch, quit again).
+- `#242` Ghost PREFAB_PARTICLE FX (smoke, small engine flames) no longer fires sideways -- auto-detects parent transform orientation and applies -90 X correction when needed.
 
 ### New Features
 

--- a/Source/Parsek/EngineFxBuilder.cs
+++ b/Source/Parsek/EngineFxBuilder.cs
@@ -151,6 +151,13 @@ namespace Parsek
                     Quaternion localRot = Quaternion.identity;
                     string rotStr = ppNodes[pp].GetValue("localRotation");
                     bool hasLocalRot = GhostVisualBuilder.TryParseFxLocalRotation(rotStr, out localRot);
+                    if (!hasLocalRot)
+                    {
+                        // #242: ghost model transforms have +Y sideways, not along thrust axis.
+                        // Default -90 X aligns PREFAB_PARTICLE emission (+Y) with thrust direction.
+                        localRot = Quaternion.Euler(-90f, 0f, 0f);
+                        hasLocalRot = true;
+                    }
 
                     prefabFxEntries.Add((prefabName, transformName, localOffset, localRot, hasLocalRot, groupName));
                 }

--- a/Source/Parsek/EngineFxBuilder.cs
+++ b/Source/Parsek/EngineFxBuilder.cs
@@ -151,13 +151,6 @@ namespace Parsek
                     Quaternion localRot = Quaternion.identity;
                     string rotStr = ppNodes[pp].GetValue("localRotation");
                     bool hasLocalRot = GhostVisualBuilder.TryParseFxLocalRotation(rotStr, out localRot);
-                    if (!hasLocalRot)
-                    {
-                        // #242: ghost model transforms have +Y sideways, not along thrust axis.
-                        // Default -90 X aligns PREFAB_PARTICLE emission (+Y) with thrust direction.
-                        localRot = Quaternion.Euler(-90f, 0f, 0f);
-                        hasLocalRot = true;
-                    }
 
                     prefabFxEntries.Add((prefabName, transformName, localOffset, localRot, hasLocalRot, groupName));
                 }
@@ -409,7 +402,21 @@ namespace Parsek
                     fxInstance.transform.SetParent(ghostFxParent, false);
                     fxInstance.transform.localPosition = localOffset;
                     if (hasLocalRot)
+                    {
                         fxInstance.transform.localRotation = localRot;
+                    }
+                    else
+                    {
+                        // #242: PREFAB_PARTICLE emits along local +Y. If the parent transform's
+                        // +Y is already close to the thrust axis (world up at build time), identity
+                        // is correct (e.g. SSME's thrustTransformYup). Otherwise apply -90 X to
+                        // rotate emission from sideways +Y onto the thrust axis.
+                        float yComponent = Mathf.Abs(ghostFxParent.up.y);
+                        if (yComponent > 0.5f)
+                            fxInstance.transform.localRotation = Quaternion.identity;
+                        else
+                            fxInstance.transform.localRotation = Quaternion.Euler(-90f, 0f, 0f);
+                    }
 
                     if (isRapierWhiteFlame)
                     {

--- a/Source/Parsek/EngineFxBuilder.cs
+++ b/Source/Parsek/EngineFxBuilder.cs
@@ -47,10 +47,10 @@ namespace Parsek
             string transformName, string fxName, Transform fxTransform)
         {
             Vector3 emitWorld = fxTransform.up; // local +Y in world space
-            Vector3 down = Vector3.down;        // (0,-1,0)
-            float angle = Vector3.Angle(emitWorld, down);
+            float angle = Vector3.Angle(emitWorld, Vector3.down);
             Quaternion localRot = fxTransform.localRotation;
-            ParsekLog.Verbose("EngineFx", $"#242 dir: '{partName}' midx={moduleIndex} " +
+            ParsekLog.VerboseRateLimited("EngineFx", $"fxdir-{partName}-{moduleIndex}-{fxType}-{transformName}",
+                $"#242 dir: '{partName}' midx={moduleIndex} " +
                 $"type={fxType} transform='{transformName}' fx='{fxName}' " +
                 $"emitWorld={emitWorld} angleFromDown={angle:F1} localRot={localRot.eulerAngles}");
         }

--- a/Source/Parsek/EngineFxBuilder.cs
+++ b/Source/Parsek/EngineFxBuilder.cs
@@ -39,6 +39,23 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Logs the FX emission direction relative to ground for a placed FX instance.
+        /// ParticleSystems emit along local +Y by default; reports that axis in world space
+        /// plus the angle from straight down (0 = correct for downward engine on pad).
+        /// </summary>
+        private static void LogFxDirection(string partName, int moduleIndex, string fxType,
+            string transformName, string fxName, Transform fxTransform)
+        {
+            Vector3 emitWorld = fxTransform.up; // local +Y in world space
+            Vector3 down = Vector3.down;        // (0,-1,0)
+            float angle = Vector3.Angle(emitWorld, down);
+            Quaternion localRot = fxTransform.localRotation;
+            ParsekLog.Verbose("EngineFx", $"#242 dir: '{partName}' midx={moduleIndex} " +
+                $"type={fxType} transform='{transformName}' fx='{fxName}' " +
+                $"emitWorld={emitWorld} angleFromDown={angle:F1} localRot={localRot.eulerAngles}");
+        }
+
+        /// <summary>
         /// Scans EFFECTS config groups for MODEL_MULTI_PARTICLE/MODEL_PARTICLE entries.
         /// Populates modelFxEntries with transform/model/offset/rotation tuples and extracts
         /// the first emission and speed curves found.
@@ -218,6 +235,7 @@ namespace Parsek
                                 legacyFxOffset, legacyLocalRot, true);
                             ParsekLog.VerboseRateLimited("EngineFx", $"legacy-{partName}-{moduleIndex}",
                                 $"Engine FX (legacy): '{partName}' midx={moduleIndex} fx='{child.name}' systems={addedSystems}");
+                            LogFxDirection(partName, moduleIndex, "LEGACY", srcLegacyAnchor.name, child.name, fxClone.transform);
                         }
                         else
                         {
@@ -245,6 +263,7 @@ namespace Parsek
                             child.name, child.name, prefab.transform, ghostModelNode,
                             child, fallbackParent, fxClone.transform,
                             child.localPosition, child.localRotation, true);
+                        LogFxDirection(partName, moduleIndex, "LEGACY_FALLBACK", child.name, child.name, fxClone.transform);
                         ParsekLog.VerboseRateLimited("EngineFx", $"legacy-{partName}-{moduleIndex}",
                             $"Engine FX (legacy): '{partName}' midx={moduleIndex} fx='{child.name}' systems={addedSystems}");
                     }
@@ -308,18 +327,10 @@ namespace Parsek
                                 GhostVisualBuilder.LogFxInstancePlacementDiagnostic(partName, moduleIndex, nodeType, transformName,
                                     modelName, prefab.transform, ghostModelNode, srcFxTransform, ghostFxParent,
                                     fxInstance.transform, mmpLocalPos, mmpLocalRot, true);
-                                Vector3 srcFwd = srcFxTransform.forward;
-                                Vector3 srcUp = srcFxTransform.up;
-                                Quaternion srcLocalRot = srcFxTransform.localRotation;
-                                // #242 diag: log effect group + final FX direction for smoke/flame comparison
-                                Vector3 fxFwd = fxInstance.transform.forward;
-                                Vector3 fxUp = fxInstance.transform.up;
                                 ParsekLog.Verbose("EngineFx", $"cloned: '{partName}' midx={moduleIndex} " +
                                     $"group='{groupName}' type={nodeType} transform='{transformName}' model='{modelName}' " +
-                                    $"systems={addedSystems} " +
-                                    $"cfgRot={mmpLocalRot.eulerAngles} " +
-                                    $"srcLocalRot={srcLocalRot.eulerAngles} srcFwd={srcFwd} srcUp={srcUp} " +
-                                    $"fxFwd={fxFwd} fxUp={fxUp}");
+                                    $"systems={addedSystems} cfgRot={mmpLocalRot.eulerAngles}");
+                                LogFxDirection(partName, moduleIndex, nodeType, transformName, modelName, fxInstance.transform);
                             }
                             else
                             {
@@ -413,14 +424,10 @@ namespace Parsek
                         GhostVisualBuilder.LogFxInstancePlacementDiagnostic(partName, moduleIndex, "PREFAB_PARTICLE", transformName,
                             prefabName, prefab.transform, ghostModelNode, srcFxTransform, ghostFxParent,
                             fxInstance.transform, localOffset, localRot, hasLocalRot);
-                        // #242 diag: log effect group + final FX direction for smoke/flame comparison
-                        Vector3 pfxFwd = fxInstance.transform.forward;
-                        Vector3 pfxUp = fxInstance.transform.up;
                         ParsekLog.Verbose("EngineFx", $"(prefab): '{partName}' midx={moduleIndex} " +
                             $"group='{groupName}' transform='{transformName}' prefab='{prefabName}' " +
-                            $"systems={addedSystems} " +
-                            $"cfgRot={localRot.eulerAngles} hasCfgRot={hasLocalRot} " +
-                            $"fxFwd={pfxFwd} fxUp={pfxUp}");
+                            $"systems={addedSystems} cfgRot={localRot.eulerAngles} hasCfgRot={hasLocalRot}");
+                        LogFxDirection(partName, moduleIndex, "PREFAB_PARTICLE", transformName, prefabName, fxInstance.transform);
                     }
                     else
                     {

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -149,11 +149,25 @@ Parts whose base/default variant is implicit (not a VARIANT node) showed the wro
 
 ---
 
-## 242. Ghost engine smoke emits perpendicular to flame direction
+## ~~242. Ghost engine PREFAB_PARTICLE FX fires perpendicular to thrust axis~~
 
-On some engines, the smoke/exhaust particle effect fires sideways (perpendicular to the thrust axis) instead of along it. The flame plume itself is oriented correctly but the secondary smoke effect has a wrong emission direction. Likely a particle system `rotation` or `shape.rotation` not being transformed correctly when cloning engine FX from the prefab EFFECTS config.
+On Mammoth, Twin Boar, RAPIER, Twitch, Ant, Spider, Puff, and other engines, ghost PREFAB_PARTICLE FX (smoke trails, small engine flames) fired sideways instead of along the thrust axis.
 
-**Priority:** Low — cosmetic, only noticeable on certain engine models
+**Root cause:** Ghost model parent transforms (thrustTransform, smokePoint, FXTransform) have their local +Y axis pointing sideways, not along the thrust axis. PREFAB_PARTICLE FX emits along local +Y (Unity ParticleSystem default cone axis). Without rotation correction, particles fire perpendicular to the nozzle.
+
+In KSP's live game, the part model hierarchy is oriented within the vessel so that transforms end up with +Y along thrust. In our ghost, the cloned prefab model keeps the raw model-space orientation where +Y is typically sideways.
+
+**Investigation:** Decompiled `PrefabParticleFX.OnInitialize` — uses `NestToParent` (resets localRotation to identity) then sets `Quaternion.AngleAxis(localRotation.w, localRotation)` from config. Decompiled `ModelMultiParticleFX.OnInitialize` — same pattern with `Quaternion.Euler(localRotation)`. Decompiled `NestToParent` — calls `SetParent(parent)` with worldPositionStays=true, then explicitly resets localPosition=zero and localRotation=identity.
+
+Added `LogFxDirection` diagnostic that logs `emitWorld` (local +Y in world space) and `angleFromDown` for every FX instance. This revealed the pattern: entries with explicit -90 X rotation (from config or fallback) had correct angleFromDown=180, while entries with identity had wrong angleFromDown=90.
+
+Exception: SSME (Vector) has `thrustTransformYup` where +Y already points along thrust — applying -90 X there breaks it.
+
+**Fix:** In `ProcessEnginePrefabFxEntries`, when config has no `localRotation`, check `ghostFxParent.up.y` at process time. If abs(y) > 0.5, the parent +Y already aligns with the thrust axis — use identity. Otherwise apply `Quaternion.Euler(-90, 0, 0)` to rotate emission onto the thrust axis. Existing entries with explicit config `localRotation` (jets with `1,0,0,-90`) are unaffected.
+
+**Remaining:** MODEL_MULTI_PARTICLE entries without config localRotation (Mammoth `ks25_Exhaust`, Twin Boar `ks1_Exhaust`, SSME `hydroLOXFlame`, ion engine `IonPlume`) still show angleFromDown=90 in the diagnostic log. These use `KSPParticleEmitter` (legacy particle system) rather than Unity `ParticleSystem`, so their emission axis may differ from +Y — visually they appear correct despite the diagnostic reading. May need separate investigation if visual issues are reported.
+
+**Status:** ~~Fixed~~ (PREFAB_PARTICLE path)
 
 ---
 


### PR DESCRIPTION
## Summary

- Ghost PREFAB_PARTICLE FX (smoke trails, small engine flames) fired sideways because parent transforms on the ghost model have +Y axis perpendicular to the thrust axis
- Auto-detects correct rotation at process time: checks `ghostFxParent.up.y` to decide between identity (transform already aligned, e.g. SSME's `thrustTransformYup`) and -90 X (most engines)
- Adds `LogFxDirection` diagnostic logging for all FX paths (emitWorld direction + angleFromDown)

## Test plan

- [x] In-game: Mammoth, Twin Boar, RAPIER black smoke now points along thrust axis
- [x] In-game: Twitch, Ant, Spider, Puff flames now align with nozzle
- [x] In-game: SSME (Vector) smoke and blue flame not regressed
- [x] In-game: verify jets (Wheesley, Panther, Goliath) smoke unchanged
- [x] `dotnet test` passes

Generated with [Claude Code](https://claude.com/claude-code)