### PR TITLE
Per-module EFFECTS group filtering for RAPIER/Panther multi-mode engines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ All notable changes to Parsek are documented here.
 - `T57` EVA recordings now spawn at end instead of being abandoned -- parent vessel is exempt from collision checks during EVA walkback.
 - `#290` Debris and EVA branch recordings in the active tree no longer lose trajectory data after two cold starts (quit KSP mid-flight, relaunch, quit again).
 - `#242` Ghost PREFAB_PARTICLE FX (smoke, small engine flames) no longer fires sideways -- auto-detects parent transform orientation and applies -90 X correction when needed.
-- `#242` RAPIER and Panther ghost FX now shows only the active engine mode (jet or rocket) instead of both simultaneously -- per-module EFFECTS group filtering with automatic mode switching via existing engine events.
+- `#242` RAPIER and Panther ghost FX now shows only the active engine mode (jet or rocket) instead of both simultaneously.
 
 ### New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to Parsek are documented here.
 - `T57` EVA recordings now spawn at end instead of being abandoned -- parent vessel is exempt from collision checks during EVA walkback.
 - `#290` Debris and EVA branch recordings in the active tree no longer lose trajectory data after two cold starts (quit KSP mid-flight, relaunch, quit again).
 - `#242` Ghost PREFAB_PARTICLE FX (smoke, small engine flames) no longer fires sideways -- auto-detects parent transform orientation and applies -90 X correction when needed.
+- `#242` RAPIER and Panther ghost FX now shows only the active engine mode (jet or rocket) instead of both simultaneously -- per-module EFFECTS group filtering with automatic mode switching via existing engine events.
 
 ### New Features
 

--- a/Source/Parsek.Tests/SyntheticRecordingTests.cs
+++ b/Source/Parsek.Tests/SyntheticRecordingTests.cs
@@ -1475,6 +1475,48 @@ namespace Parsek.Tests
             return b;
         }
 
+        /// <summary>
+        /// RAPIER mode-switch showcase: jet mode (midx=0) then rocket mode (midx=1).
+        /// Demonstrates per-module FX switching via EngineIgnited/EngineShutdown events.
+        /// </summary>
+        private static RecordingBuilder BuildRapierModeSwitchShowcase(
+            double baseUT, int rowIndex, uint pidBase)
+        {
+            double t = baseUT + 30;
+            ShowcasePosition(rowIndex, ShowcaseDistanceFromPadMeters, out double lat, out double lon, out double alt);
+            alt += ShowcaseAltitudeOffset("RAPIER");
+
+            var b = new RecordingBuilder("Part Showcase - RAPIER")
+                .WithDefaultRotation(KscRotX, KscRotY, KscRotZ, KscRotW)
+                .WithLoopPlayback(loop: true, intervalSeconds: 0.0)
+                .WithRecordingGroup("Part Showcases");
+
+            for (int i = 0; i <= 8; i++)
+                b.AddPoint(t + (i * 3), lat, lon, alt);
+
+            // Jet mode (AirBreathing = midx 0): red exhaust
+            b.AddPartEvent(t + 0,    SinglePartPid, (int)PartEventType.EngineIgnited,  "RAPIER", value: 0.5f, moduleIndex: 0);
+            b.AddPartEvent(t + 3,    SinglePartPid, (int)PartEventType.EngineThrottle, "RAPIER", value: 1.0f, moduleIndex: 0);
+            b.AddPartEvent(t + 6,    SinglePartPid, (int)PartEventType.EngineShutdown, "RAPIER", moduleIndex: 0);
+            // Switch to rocket mode (ClosedCycle = midx 1): blue exhaust
+            b.AddPartEvent(t + 6.1,  SinglePartPid, (int)PartEventType.EngineIgnited,  "RAPIER", value: 0.8f, moduleIndex: 1);
+            b.AddPartEvent(t + 9,    SinglePartPid, (int)PartEventType.EngineThrottle, "RAPIER", value: 1.0f, moduleIndex: 1);
+            b.AddPartEvent(t + 15,   SinglePartPid, (int)PartEventType.EngineShutdown, "RAPIER", moduleIndex: 1);
+            // Back to jet mode
+            b.AddPartEvent(t + 15.1, SinglePartPid, (int)PartEventType.EngineIgnited,  "RAPIER", value: 1.0f, moduleIndex: 0);
+            b.AddPartEvent(t + 21,   SinglePartPid, (int)PartEventType.EngineShutdown, "RAPIER", moduleIndex: 0);
+
+            var snap = new VesselSnapshotBuilder()
+                .WithName("Part Showcase - RAPIER")
+                .WithPersistentId((uint)(pidBase + rowIndex))
+                .AddPart("RAPIER", rotation: "0,-0.7071068,0,0.7071068")
+                .AsLanded(lat, lon, alt)
+                .Build();
+
+            b.WithGhostVisualSnapshot(snap);
+            return b;
+        }
+
         internal static RecordingBuilder[] LightShowcaseRecordings(double baseUT = 0)
         {
             return new[]
@@ -1640,7 +1682,7 @@ namespace Parsek.Tests
                 BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Twin-Boar", "Size2LFB.v2", 220, pidBase),
                 BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Mammoth", "Size3EngineCluster", 221, pidBase),
                 BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Pug", "LiquidEngineRV-1", 222, pidBase),
-                BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - RAPIER", "RAPIER", 223, pidBase),
+                BuildRapierModeSwitchShowcase(baseUT, 223, pidBase),
 
                 // ── SRBs flame only (rows 224-229) ──
                 BuildCombinedEngineShowcaseRecording(baseUT, "Part Showcase - Thumper", "solidBooster1-1", 224, pidBase, isSrb: true),
@@ -3238,6 +3280,11 @@ namespace Parsek.Tests
                     continue;
                 }
 
+                // RAPIER mode-switch showcase has a custom event profile (3 ignite/3 shutdown).
+                string vesselName = built.GetValue("vesselName");
+                if (string.Equals(vesselName, "Part Showcase - RAPIER", System.StringComparison.Ordinal))
+                    continue;
+
                 int shroudCount = 0;
                 int igniteCount = 0;
                 int throttleCount = 0;
@@ -4287,10 +4334,16 @@ namespace Parsek.Tests
             foreach (var rb in recordings)
             {
                 var rec = rb.Build();
+                string vesselName = rec.GetValue("vesselName");
                 var events = rec.GetNodes("PART_EVENT");
+
+                // RAPIER mode-switch showcase has a custom multi-midx event profile.
+                if (string.Equals(vesselName, "Part Showcase - RAPIER", System.StringComparison.Ordinal))
+                    continue;
+
                 Assert.True(
                     events.Length == 2 || events.Length == 3 || events.Length == 8,
-                    $"Unexpected event count {events.Length} for {rec.GetValue("vesselName")}");
+                    $"Unexpected event count {events.Length} for {vesselName}");
 
                 var primaryPart = rec.GetNode("GHOST_VISUAL_SNAPSHOT").GetNodes("PART")[0];
 

--- a/Source/Parsek.Tests/SyntheticRecordingTests.cs
+++ b/Source/Parsek.Tests/SyntheticRecordingTests.cs
@@ -3361,6 +3361,65 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void EngineShowcaseRecordings_RapierModeSwitchHasCorrectEventProfile()
+        {
+            var recordings = EngineShowcaseRecordings(baseUT: 17000);
+            ConfigNode rapier = null;
+            for (int i = 0; i < recordings.Length; i++)
+            {
+                ConfigNode built = recordings[i].Build();
+                if (built.GetValue("vesselName") == "Part Showcase - RAPIER")
+                {
+                    rapier = built;
+                    break;
+                }
+            }
+            Assert.NotNull(rapier);
+
+            var events = rapier.GetNodes("PART_EVENT");
+            Assert.Equal(8, events.Length);
+
+            // Verify all events target the primary part
+            var primaryPart = rapier.GetNode("GHOST_VISUAL_SNAPSHOT").GetNodes("PART")[0];
+            string expectedPid = primaryPart.GetValue("persistentId");
+            for (int i = 0; i < events.Length; i++)
+                Assert.Equal(expectedPid, events[i].GetValue("pid"));
+
+            // Verify UTs are monotonically increasing
+            double previousUt = double.MinValue;
+            for (int i = 0; i < events.Length; i++)
+            {
+                double ut = double.Parse(events[i].GetValue("ut"), CultureInfo.InvariantCulture);
+                Assert.True(ut > previousUt, $"Non-monotonic UT at event {i}");
+                previousUt = ut;
+            }
+
+            // Verify event type/moduleIndex sequence:
+            // jet ignite(0), jet throttle(0), jet shutdown(0),
+            // rocket ignite(1), rocket throttle(1), rocket shutdown(1),
+            // jet ignite(0), jet shutdown(0)
+            var expectedTypes = new[]
+            {
+                PartEventType.EngineIgnited,  PartEventType.EngineThrottle, PartEventType.EngineShutdown,
+                PartEventType.EngineIgnited,  PartEventType.EngineThrottle, PartEventType.EngineShutdown,
+                PartEventType.EngineIgnited,  PartEventType.EngineShutdown
+            };
+            var expectedMidx = new[] { 0, 0, 0, 1, 1, 1, 0, 0 };
+            for (int i = 0; i < events.Length; i++)
+            {
+                Assert.Equal(((int)expectedTypes[i]).ToString(CultureInfo.InvariantCulture),
+                    events[i].GetValue("type"));
+                Assert.Equal(expectedMidx[i].ToString(CultureInfo.InvariantCulture),
+                    events[i].GetValue("midx"));
+            }
+
+            // Verify throttle values on ignite events
+            Assert.Equal("0.5", events[0].GetValue("value"));  // jet ignite at 50%
+            Assert.Equal("0.8", events[3].GetValue("value"));  // rocket ignite at 80%
+            Assert.Equal("1", events[6].GetValue("value"));    // jet re-ignite at 100%
+        }
+
+        [Fact]
         public void RcsShowcaseRecordings_BuildExpectedShape()
         {
             var recordings = RcsShowcaseRecordings(baseUT: 17000);

--- a/Source/Parsek/EngineFxBuilder.cs
+++ b/Source/Parsek/EngineFxBuilder.cs
@@ -39,6 +39,25 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Reads effect group names referenced by a single engine module.
+        /// Returns the set of EFFECTS group names this module uses (for per-module filtering).
+        /// Empty set means no filtering (base ModuleEngines without named effects).
+        /// </summary>
+        internal static HashSet<string> GetModuleEffectGroupNames(ModuleEngines engine)
+        {
+            var result = new HashSet<string>(System.StringComparer.OrdinalIgnoreCase);
+            var engineFX = engine as ModuleEnginesFX;
+            if (engineFX == null)
+                return result;
+
+            if (!string.IsNullOrEmpty(engineFX.runningEffectName)) result.Add(engineFX.runningEffectName);
+            if (!string.IsNullOrEmpty(engineFX.powerEffectName)) result.Add(engineFX.powerEffectName);
+            if (!string.IsNullOrEmpty(engineFX.spoolEffectName)) result.Add(engineFX.spoolEffectName);
+            if (!string.IsNullOrEmpty(engineFX.directThrottleEffectName)) result.Add(engineFX.directThrottleEffectName);
+            return result;
+        }
+
+        /// <summary>
         /// Logs the FX emission direction relative to ground for a placed FX instance.
         /// ParticleSystems emit along local +Y by default; reports that axis in world space
         /// plus the angle from straight down (0 = correct for downward engine on pad).
@@ -494,13 +513,6 @@ namespace Parsek
 
                 bool isRapierPart =
                     string.Equals(partName, "RAPIER", System.StringComparison.OrdinalIgnoreCase);
-                if (isRapierPart && moduleIndex > 0)
-                {
-                    // RAPIER has multi-mode engine modules sharing nozzle transforms; recording events
-                    // target midx=0, so skip duplicate module FX to avoid doubled plumes.
-                    ParsekLog.Verbose("EngineFx", $"'{partName}' midx={moduleIndex}: skipped duplicate multi-mode FX module");
-                    continue;
-                }
 
                 // Try to read EFFECTS config from the part config
                 ConfigNode partConfig = prefab.partInfo?.partConfig;
@@ -526,12 +538,41 @@ namespace Parsek
 
                 if (effectsNode != null)
                 {
-                    ConfigNode[] effectGroups = effectsNode.GetNodes();
-                    // #242 diag: extract group names so we can log which EFFECTS group
-                    // each FX entry came from (running, power_open, engage, etc.)
-                    string[] effectGroupNames = new string[effectGroups.Length];
-                    for (int eg = 0; eg < effectGroups.Length; eg++)
-                        effectGroupNames[eg] = effectGroups[eg].name ?? "?";
+                    ConfigNode[] allGroups = effectsNode.GetNodes();
+                    string[] allGroupNames = new string[allGroups.Length];
+                    for (int eg = 0; eg < allGroups.Length; eg++)
+                        allGroupNames[eg] = allGroups[eg].name ?? "?";
+
+                    // Per-module EFFECTS group filtering: only scan groups referenced by
+                    // this engine module's effect name fields (multi-mode support).
+                    HashSet<string> moduleGroups = GetModuleEffectGroupNames(engine);
+                    ConfigNode[] effectGroups;
+                    string[] effectGroupNames;
+
+                    if (moduleGroups.Count > 0)
+                    {
+                        var filtered = new List<ConfigNode>();
+                        var filteredNames = new List<string>();
+                        for (int eg = 0; eg < allGroups.Length; eg++)
+                        {
+                            if (moduleGroups.Contains(allGroupNames[eg]))
+                            {
+                                filtered.Add(allGroups[eg]);
+                                filteredNames.Add(allGroupNames[eg]);
+                            }
+                        }
+                        effectGroups = filtered.Count > 0 ? filtered.ToArray() : allGroups;
+                        effectGroupNames = filtered.Count > 0 ? filteredNames.ToArray() : allGroupNames;
+                        ParsekLog.Verbose("EngineFx", $"'{partName}' midx={moduleIndex}: " +
+                            $"filtered {allGroups.Length} EFFECTS groups to {effectGroups.Length} " +
+                            $"by module effects=[{string.Join(",", moduleGroups)}]");
+                    }
+                    else
+                    {
+                        effectGroups = allGroups;
+                        effectGroupNames = allGroupNames;
+                    }
+
                     ScanEffectsModelFxEntries(effectGroups, effectGroupNames, modelFxEntries, ref emissionCurve, ref speedCurve);
                     ScanEffectsPrefabParticleEntries(effectGroups, effectGroupNames, prefabFxEntries);
                 }
@@ -962,9 +1003,10 @@ namespace Parsek
                         }
                     }
 
-                    if (!hasWhiteFlame)
+                    if (!hasWhiteFlame && modelFxEntries.Count == 0)
                     {
-                        // Keep it compact: anchor the added white core to the same smokePoint frame.
+                        // Only add white flame core when no MODEL_MULTI_PARTICLE FX exists.
+                        // With per-module filtering, each mode already has its own model exhaust.
                         string flameTransform = rapierSmokeTransform;
                         Vector3 flameOffset = Vector3.zero;
                         if (!HasNamedTransform(flameTransform))

--- a/Source/Parsek/EngineFxBuilder.cs
+++ b/Source/Parsek/EngineFxBuilder.cs
@@ -14,12 +14,12 @@ namespace Parsek
         private static readonly Dictionary<string, Vector3> fxModelRotationFallbackEuler =
             new Dictionary<string, Vector3>(System.StringComparer.OrdinalIgnoreCase)
             {
-                // These stock model FX are authored with implicit -90deg X orientation in KSP's
-                // runtime FX pipeline when localRotation is omitted in EFFECTS config.
+                // #242: MODEL_MULTI_PARTICLE models using KSPParticleEmitter emit along their
+                // internal axis — identity rotation is correct. shockExhaust entries removed
+                // (were causing perpendicular RAPIER flames). Monoprop entries kept for Ant/Spider
+                // where the model FX is visually overshadowed by the corrected PREFAB_PARTICLE.
                 { "Squad/FX/Monoprop_small", new Vector3(-90f, 0f, 0f) },
-                { "Squad/FX/Monoprop_medium", new Vector3(-90f, 0f, 0f) },
-                { "Squad/FX/shockExhaust_blue_small", new Vector3(-90f, 0f, 0f) },
-                { "Squad/FX/shockExhaust_red_small", new Vector3(-90f, 0f, 0f) }
+                { "Squad/FX/Monoprop_medium", new Vector3(-90f, 0f, 0f) }
             };
         private static readonly string[] EngineModelNodeTypes =
             { "MODEL_MULTI_PARTICLE_PERSIST", "MODEL_MULTI_PARTICLE", "MODEL_PARTICLE" };

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -181,6 +181,16 @@ RAPIER and Panther (and any other `ModuleEnginesFX` multi-mode engines) rendered
 
 ---
 
+## 242c. Ghost variant geometry not toggled -- extra FX on multi-variant parts
+
+Parts with `ModulePartVariants` that toggle geometry via GAMEOBJECTS (e.g. Poodle DoubleBell/SingleBell) show all variant geometry on the ghost, including inactive variants. The Poodle ghost has 3 thrustTransforms (2 from DoubleBell + 1 from SingleBell) instead of 2, producing 3 flames instead of 2.
+
+**Root cause:** Ghost model is cloned from the raw prefab which contains ALL variant GameObjects. The variant system's `GAMEOBJECTS` visibility (e.g. `EngineFixed = true/false`) is not applied during ghost build. Variant texture support (#241) was implemented but geometry toggling was not.
+
+**Priority:** Low -- cosmetic, only affects parts with geometry-switching variants (Poodle, possibly others)
+
+---
+
 ## ~~270. Sidecar file (.prec) version staleness across save points~~
 
 Latent pre-existing architectural limitation of the v3 external sidecar format: sidecar files (`saves/<save>/Parsek/Recordings/*.prec`) are shared across ALL save points for a given save slot. If the player quicksaves in flight at T2, exits to TS at T3 (which rewrites the sidecars with T3 data), then quickloads the T2 save, the .sfs loads the T2 active tree metadata but `LoadRecordingFiles` hydrates from T3 sidecars on disk — a mismatch.

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -169,6 +169,16 @@ Exception: SSME (Vector) has `thrustTransformYup` where +Y already points along 
 
 **Status:** ~~Fixed~~ (PREFAB_PARTICLE path)
 
+### 242b. Multi-mode engine ghosts show both modes simultaneously
+
+RAPIER and Panther (and any other `ModuleEnginesFX` multi-mode engines) rendered FX for all engine modes at once instead of only the active mode. Ghost would show jet exhaust and rocket exhaust simultaneously.
+
+**Root cause:** `TryBuildEngineFX` scanned ALL EFFECTS groups for every engine module on a part. Multi-mode engines like RAPIER have separate EFFECTS groups per mode (e.g. `running_closed` for rocket, `running_open` for jet). Without filtering, each `EngineGhostInfo` contained particles from all modes.
+
+**Fix:** Added `GetModuleEffectGroupNames(ModuleEngines)` which downcasts to `ModuleEnginesFX` and reads `runningEffectName`, `powerEffectName`, `spoolEffectName`, `directThrottleEffectName`. These names are used to filter EFFECTS groups so each engine module only scans its own referenced groups. Base `ModuleEngines` (not FX) returns empty set and falls through to scanning all groups (backward compat). Removed the old RAPIER `midx>0` skip that suppressed the second engine module entirely. RAPIER white flame fallback guarded by `modelFxEntries.Count == 0` to avoid doubling with per-module model exhaust. Added RAPIER mode-switch showcase recording with per-moduleIndex events demonstrating jet-to-rocket-to-jet switching.
+
+**Status:** ~~Fixed~~ (PR #220)
+
 ---
 
 ## ~~270. Sidecar file (.prec) version staleness across save points~~


### PR DESCRIPTION
## Summary

- RAPIER and Panther ghost FX previously showed both engine modes simultaneously because all EFFECTS groups were scanned into a single EngineGhostInfo for midx=0
- Added `GetModuleEffectGroupNames` to read effect name fields from `ModuleEnginesFX` and filter EFFECTS groups per module
- Removed RAPIER midx>0 skip -- both modules now build separate FX
- RAPIER showcase recording demonstrates jet->rocket->jet mode switching
- Audio mode switching confirmed working in-game

## Known issues (follow-up)

- RAPIER visual FX mode switch needs further investigation (KSPParticleEmitter toggling for MODEL_MULTI_PARTICLE models)
- RAPIER fallback dark smoke (`fx_smokeTrail_large`) may need removal -- stock RAPIER doesn't show it

## Test plan

- [x] 5733 unit tests pass
- [x] In-game: audio switches between jet and rocket mode correctly
- [x] In-game: verify Panther (turboJet) dual-mode FX
- [x] In-game: verify single-mode engines unchanged (Mainsail, Thumper, etc.)

Generated with [Claude Code](https://claude.com/claude-code)