### PR TITLE
Fix #290: F5/F9 recording data loss, spawn safety, UI fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,9 @@ All notable changes to Parsek are documented here.
 - `#270` Quickloading no longer loads stale sidecar trajectory data from a later save point.
 - `T58` Debris ghost engines no longer show running FX at zero throttle after staging -- inherited engine state respects the child vessel's operational assessment.
 - `T57` EVA recordings now spawn at end instead of being abandoned -- parent vessel is exempt from collision checks during EVA walkback.
-- `#290` Tree recordings now compute `MaxDistanceFromLaunch` at finalization, preventing false idle-on-pad discards that silently deleted entire flight trees on scene exit.
-- `#290` Quickload restore now matches the active vessel by persistentId (locale-proof) instead of vesselName, which failed when KSP hadn't resolved `#autoLOC` keys yet.
-- `#290` Sidecar files written by BackgroundRecorder or scene-exit force-writes no longer advance the epoch past the .sfs, preventing false-positive staleness rejection on F5/F9 quickload.
+- `#290` Five cascading bugs caused total recording loss on F5/F9 quickload: epoch drift, vessel name matching, idle-on-pad false positives, missing MaxDistanceFromLaunch, and Finalized tree overwrite by stale .sfs.
+- `#290` Spawn-at-end no longer places vessels below runway/launchpad structures when the vessel was unloaded at scene exit.
+- `#290` Phase column now correctly shows "surface" for landed/splashed vessels instead of "atmo"; LaunchSiteName now populates during OnSave for tree recordings.
 - `#290` Debris and EVA branch recordings in the active tree no longer lose trajectory data after two cold starts (quit KSP mid-flight, relaunch, quit again).
 - `#242` Ghost PREFAB_PARTICLE FX (smoke, small engine flames) no longer fires sideways -- auto-detects parent transform orientation and applies -90 X correction when needed.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ All notable changes to Parsek are documented here.
 - `#270` Quickloading no longer loads stale sidecar trajectory data from a later save point.
 - `T58` Debris ghost engines no longer show running FX at zero throttle after staging -- inherited engine state respects the child vessel's operational assessment.
 - `T57` EVA recordings now spawn at end instead of being abandoned -- parent vessel is exempt from collision checks during EVA walkback.
+- `#290` Tree recordings now compute `MaxDistanceFromLaunch` at finalization, preventing false idle-on-pad discards that silently deleted entire flight trees on scene exit.
+- `#290` Quickload restore now matches the active vessel by persistentId (locale-proof) instead of vesselName, which failed when KSP hadn't resolved `#autoLOC` keys yet.
+- `#290` Sidecar files written by BackgroundRecorder or scene-exit force-writes no longer advance the epoch past the .sfs, preventing false-positive staleness rejection on F5/F9 quickload.
 - `#290` Debris and EVA branch recordings in the active tree no longer lose trajectory data after two cold starts (quit KSP mid-flight, relaunch, quit again).
 - `#242` Ghost PREFAB_PARTICLE FX (smoke, small engine flames) no longer fires sideways -- auto-detects parent transform orientation and applies -90 X correction when needed.
 

--- a/Source/Parsek.Tests/Bug156Tests.cs
+++ b/Source/Parsek.Tests/Bug156Tests.cs
@@ -106,9 +106,26 @@ namespace Parsek.Tests
         public void IsTreeIdleOnPad_AllIdleRecordings_ReturnsTrue()
         {
             var tree = new RecordingTree { Recordings = new Dictionary<string, Recording>() };
-            tree.Recordings["a"] = new Recording { MaxDistanceFromLaunch = 5.0 };
-            tree.Recordings["b"] = new Recording { MaxDistanceFromLaunch = 10.0 };
+            var recA = new Recording { MaxDistanceFromLaunch = 5.0 };
+            recA.Points.Add(new TrajectoryPoint());
+            var recB = new Recording { MaxDistanceFromLaunch = 10.0 };
+            recB.Points.Add(new TrajectoryPoint());
+            tree.Recordings["a"] = recA;
+            tree.Recordings["b"] = recB;
             Assert.True(ParsekFlight.IsTreeIdleOnPad(tree));
+        }
+
+        [Fact]
+        public void IsTreeIdleOnPad_ZeroPointRecordings_ReturnsFalse()
+        {
+            // Bug #290d: recordings with 0 trajectory points (e.g., sidecar epoch mismatch)
+            // have MaxDistanceFromLaunch=0.0 which trivially passes the 30m threshold.
+            // Must not be classified as idle-on-pad — it's data loss, not a pad sit.
+            var tree = new RecordingTree { Recordings = new Dictionary<string, Recording>() };
+            tree.Recordings["a"] = new Recording { MaxDistanceFromLaunch = 0.0 };
+            tree.Recordings["b"] = new Recording { MaxDistanceFromLaunch = 0.0 };
+            // Points list is empty (default) — simulating epoch mismatch
+            Assert.False(ParsekFlight.IsTreeIdleOnPad(tree));
         }
 
         [Fact]

--- a/Source/Parsek.Tests/Bug156Tests.cs
+++ b/Source/Parsek.Tests/Bug156Tests.cs
@@ -116,6 +116,20 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void IsTreeIdleOnPad_MixedPointsAndZeroPoints_ReturnsTrue()
+        {
+            // A tree with one recording that has points (confirms idle) and one with
+            // zero points (data-loss). Since at least one recording has trajectory data
+            // confirming the vessel stayed near the pad, the tree IS idle.
+            var tree = new RecordingTree { Recordings = new Dictionary<string, Recording>() };
+            var recA = new Recording { MaxDistanceFromLaunch = 5.0 };
+            recA.Points.Add(new TrajectoryPoint());
+            tree.Recordings["a"] = recA;
+            tree.Recordings["b"] = new Recording { MaxDistanceFromLaunch = 0.0 };
+            Assert.True(ParsekFlight.IsTreeIdleOnPad(tree));
+        }
+
+        [Fact]
         public void IsTreeIdleOnPad_ZeroPointRecordings_ReturnsFalse()
         {
             // Bug #290d: recordings with 0 trajectory points (e.g., sidecar epoch mismatch)

--- a/Source/Parsek.Tests/Bug270SidecarEpochTests.cs
+++ b/Source/Parsek.Tests/Bug270SidecarEpochTests.cs
@@ -196,23 +196,36 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void MultipleOutOfBandWrites_DoNotDriftEpoch()
+        public void MultipleOnSaveIncrements_AllMatchAfterQuickload()
         {
+            // Simulate: two OnSave cycles (epoch 0->1->2), then quickload
+            // from the second save. .sfs and .prec both at epoch 2.
             var rec = new Recording
             {
-                RecordingId = "test-multi-oob",
+                RecordingId = "test-multi-save",
                 SidecarEpoch = 0
             };
 
-            // OnSave: epoch 0 -> 1
+            // First OnSave
             rec.SidecarEpoch++;
             Assert.Equal(1, rec.SidecarEpoch);
 
-            // Three out-of-band writes (incrementEpoch: false) — epoch must not change
-            // (In real code, SaveRecordingFiles skips the increment when incrementEpoch=false)
-            Assert.Equal(1, rec.SidecarEpoch);
-            Assert.Equal(1, rec.SidecarEpoch);
-            Assert.Equal(1, rec.SidecarEpoch);
+            // Second OnSave
+            rec.SidecarEpoch++;
+            Assert.Equal(2, rec.SidecarEpoch);
+
+            // Write to .sfs at epoch 2
+            var sfsNode = new ConfigNode("RECORDING");
+            RecordingTree.SaveRecordingInto(sfsNode, rec);
+
+            // Quickload: restore from .sfs
+            var loaded = new Recording();
+            RecordingTree.LoadRecordingFrom(sfsNode, loaded);
+            Assert.Equal(2, loaded.SidecarEpoch);
+
+            // Validate: .prec epoch 2 matches .sfs epoch 2
+            bool skipped = RecordingStore.ShouldSkipStaleSidecar(loaded, 2);
+            Assert.False(skipped);
         }
 
         [Fact]

--- a/Source/Parsek.Tests/Bug270SidecarEpochTests.cs
+++ b/Source/Parsek.Tests/Bug270SidecarEpochTests.cs
@@ -160,6 +160,94 @@ namespace Parsek.Tests
             Assert.False(skipped);
         }
 
+        // --- Bug #290: out-of-band writes must not drift epoch ---
+
+        [Fact]
+        public void OutOfBandWrite_PreservesEpoch_MatchesAfterQuickload()
+        {
+            // Simulate: OnSave (epoch 0->1), BgRecorder write (no increment),
+            // quickload validates .sfs epoch 1 vs .prec epoch 1 → match
+            var rec = new Recording
+            {
+                RecordingId = "test-oob",
+                SidecarEpoch = 0
+            };
+
+            // OnSave: increment epoch (simulates SaveRecordingFiles default)
+            rec.SidecarEpoch++;
+            int onSaveEpoch = rec.SidecarEpoch; // 1
+
+            // Write epoch to .sfs
+            var sfsNode = new ConfigNode("RECORDING");
+            RecordingTree.SaveRecordingInto(sfsNode, rec);
+
+            // BgRecorder out-of-band write: no increment (simulates incrementEpoch: false)
+            // epoch stays at 1
+            int precEpochAfterOob = rec.SidecarEpoch; // still 1
+
+            // Quickload: restore from .sfs
+            var loaded = new Recording();
+            RecordingTree.LoadRecordingFrom(sfsNode, loaded);
+            Assert.Equal(1, loaded.SidecarEpoch);
+
+            // Validate: .prec epoch matches .sfs epoch
+            bool skipped = RecordingStore.ShouldSkipStaleSidecar(loaded, precEpochAfterOob);
+            Assert.False(skipped);
+        }
+
+        [Fact]
+        public void MultipleOutOfBandWrites_DoNotDriftEpoch()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "test-multi-oob",
+                SidecarEpoch = 0
+            };
+
+            // OnSave: epoch 0 -> 1
+            rec.SidecarEpoch++;
+            Assert.Equal(1, rec.SidecarEpoch);
+
+            // Three out-of-band writes (incrementEpoch: false) — epoch must not change
+            // (In real code, SaveRecordingFiles skips the increment when incrementEpoch=false)
+            Assert.Equal(1, rec.SidecarEpoch);
+            Assert.Equal(1, rec.SidecarEpoch);
+            Assert.Equal(1, rec.SidecarEpoch);
+        }
+
+        [Fact]
+        public void SceneExitForceWrite_AfterOnSave_DoesNotCauseMismatch()
+        {
+            // Simulate the scene-exit sequence:
+            // 1. OnSave increments epoch (1), writes .sfs with epoch 1
+            // 2. FinalizeTreeRecordings marks dirty
+            // 3. Force-write with incrementEpoch:false writes .prec with epoch 1
+            // 4. OnLoad reads .sfs epoch 1, validates against .prec epoch 1
+            var rec = new Recording
+            {
+                RecordingId = "test-scene-exit",
+                SidecarEpoch = 0
+            };
+
+            // Step 1: OnSave
+            rec.SidecarEpoch++;
+            var sfsNode = new ConfigNode("RECORDING");
+            RecordingTree.SaveRecordingInto(sfsNode, rec);
+
+            // Steps 2-3: force-write without epoch increment
+            // epoch stays at 1, .prec written with epoch 1
+            int forceWriteEpoch = rec.SidecarEpoch; // 1
+
+            // Step 4: OnLoad in next scene
+            var loaded = new Recording();
+            RecordingTree.LoadRecordingFrom(sfsNode, loaded);
+
+            bool skipped = RecordingStore.ShouldSkipStaleSidecar(loaded, forceWriteEpoch);
+            Assert.False(skipped);
+        }
+
+        // --- Original #270 staleness detection (must still work) ---
+
         [Fact]
         public void SidecarEpoch_QuicksaveQuickload_DetectsStaleness()
         {

--- a/Source/Parsek/BackgroundRecorder.cs
+++ b/Source/Parsek/BackgroundRecorder.cs
@@ -1340,7 +1340,7 @@ namespace Parsek
         internal static void PersistFinalizedRecording(Recording rec, string context)
         {
             if (rec == null) return;
-            if (RecordingStore.SaveRecordingFiles(rec))
+            if (RecordingStore.SaveRecordingFiles(rec, incrementEpoch: false))
             {
                 ParsekLog.Verbose("BgRecorder",
                     $"PersistFinalizedRecording: wrote sidecar for " +

--- a/Source/Parsek/ChainSegmentManager.cs
+++ b/Source/Parsek/ChainSegmentManager.cs
@@ -726,7 +726,13 @@ namespace Parsek
                     if (recordedVessel != null && recordedVessel.mainBody != null)
                     {
                         pending.SegmentBodyName = recordedVessel.mainBody.name;
-                        if (recordedVessel.mainBody.atmosphere)
+                        if (recordedVessel.situation == Vessel.Situations.LANDED
+                            || recordedVessel.situation == Vessel.Situations.SPLASHED
+                            || recordedVessel.situation == Vessel.Situations.PRELAUNCH)
+                        {
+                            pending.SegmentPhase = "surface";
+                        }
+                        else if (recordedVessel.mainBody.atmosphere)
                             pending.SegmentPhase = recordedVessel.altitude < recordedVessel.mainBody.atmosphereDepth ? "atmo" : "exo";
                         else
                         {

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -1039,6 +1039,10 @@ namespace Parsek
                         $"after finalize so post-finalize state survives the next OnLoad [#289]");
                 }
 
+                // Default state = Finalized. TryRestoreActiveTreeNode relies on this to
+                // skip replacing the in-memory tree with the stale .sfs version (which was
+                // written before FinalizeTreeRecordings and lacks MaxDistanceFromLaunch,
+                // terminal states, and re-snapshotted vessels). See bug #290d.
                 RecordingStore.StashPendingTree(activeTree);
                 ParsekLog.Info("Flight",
                     $"CommitTreeSceneExit (autoMerge off): stashed tree '{activeTree.TreeName}' with snapshots preserved");

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -240,6 +240,18 @@ namespace Parsek
             if (treeRec.VesselPersistentId == 0 && recorder.RecordingVesselId != 0)
                 treeRec.VesselPersistentId = recorder.RecordingVesselId;
 
+            // Copy start location fields from recorder if not already set on the tree recording.
+            // FlushRecorderToTreeRecording (normal stop path) copies these from the captured
+            // recording, but this serialization flush runs during OnSave before BuildCaptureRecording.
+            if (string.IsNullOrEmpty(treeRec.StartBodyName))
+                treeRec.StartBodyName = recorder.StartBodyName;
+            if (string.IsNullOrEmpty(treeRec.StartBiome))
+                treeRec.StartBiome = recorder.StartBiome;
+            if (string.IsNullOrEmpty(treeRec.StartSituation))
+                treeRec.StartSituation = recorder.StartSituation;
+            if (string.IsNullOrEmpty(treeRec.LaunchSiteName))
+                treeRec.LaunchSiteName = recorder.LaunchSiteName;
+
             // Mark tree recording dirty so the sidecar file is rewritten
             treeRec.FilesDirty = true;
 
@@ -1016,7 +1028,7 @@ namespace Parsek
                 {
                     if (rec.FilesDirty)
                     {
-                        if (RecordingStore.SaveRecordingFiles(rec))
+                        if (RecordingStore.SaveRecordingFiles(rec, incrementEpoch: false))
                             forcedWrites++;
                     }
                 }
@@ -1685,7 +1697,13 @@ namespace Parsek
                 if (v != null && v.mainBody != null)
                 {
                     pending.SegmentBodyName = v.mainBody.name;
-                    if (v.mainBody.atmosphere)
+                    if (v.situation == Vessel.Situations.LANDED
+                        || v.situation == Vessel.Situations.SPLASHED
+                        || v.situation == Vessel.Situations.PRELAUNCH)
+                    {
+                        pending.SegmentPhase = "surface";
+                    }
+                    else if (v.mainBody.atmosphere)
                         pending.SegmentPhase = v.altitude < v.mainBody.atmosphereDepth ? "atmo" : "exo";
                     else
                     {
@@ -4931,7 +4949,13 @@ namespace Parsek
                 if (v != null && v.mainBody != null)
                 {
                     recorder.CaptureAtStop.SegmentBodyName = v.mainBody.name;
-                    if (v.mainBody.atmosphere)
+                    if (v.situation == Vessel.Situations.LANDED
+                        || v.situation == Vessel.Situations.SPLASHED
+                        || v.situation == Vessel.Situations.PRELAUNCH)
+                    {
+                        recorder.CaptureAtStop.SegmentPhase = "surface";
+                    }
+                    else if (v.mainBody.atmosphere)
                         recorder.CaptureAtStop.SegmentPhase = v.altitude < v.mainBody.atmosphereDepth ? "atmo" : "exo";
                     else
                     {
@@ -5132,13 +5156,16 @@ namespace Parsek
             }
 
             string targetName = activeRec.VesselName;
+            uint targetPid = activeRec.VesselPersistentId;
             ParsekLog.Info("Flight",
-                $"RestoreActiveTreeFromPending: waiting for vessel '{targetName}' to load " +
+                $"RestoreActiveTreeFromPending: waiting for vessel '{targetName}' (pid={targetPid}) to load " +
                 $"(activeRecId={activeRecId})");
 
-            // Wait up to 3 seconds for the current active vessel to match by name.
-            // Primary match = active recording's vessel name.
-            // Fallback (edge case 3): if the active recording was an EVA kerbal who got
+            // Wait up to 3 seconds for the current active vessel to match.
+            // Primary match = PID (locale-proof, available immediately even when
+            // vesselName is still a raw #autoLOC key). Bug #290b.
+            // Secondary match = vessel name (fallback for old recordings without PID).
+            // Tertiary (edge case 3): if the active recording was an EVA kerbal who got
             // boarded between quicksave and quickload, match against the parent recording's
             // vessel by walking ParentRecordingId up the EVA chain.
             Recording matchedRec = activeRec;
@@ -5150,26 +5177,38 @@ namespace Parsek
                 var v = FlightGlobals.ActiveVessel;
                 if (v != null)
                 {
-                    // Primary: active recording vessel name
+                    // Primary: PID match (locale-proof, available immediately)
+                    if (targetPid != 0 && v.persistentId == targetPid)
+                    {
+                        matched = v;
+                        ParsekLog.Verbose("Flight",
+                            $"RestoreActiveTreeFromPending: PID match pid={targetPid}");
+                        break;
+                    }
+                    // Secondary: name match (fallback for old recordings without PID)
                     if (v.vesselName == targetName)
                     {
                         matched = v;
+                        ParsekLog.Verbose("Flight",
+                            $"RestoreActiveTreeFromPending: name match '{targetName}'");
                         break;
                     }
-                    // Fallback: walk ParentRecordingId chain and try each parent's vessel name
+                    // Tertiary: walk ParentRecordingId chain and try each parent's PID/name
                     Recording probe = activeRec;
                     int walkDepth = 0;
                     while (walkDepth < 5 && !string.IsNullOrEmpty(probe?.ParentRecordingId))
                     {
                         if (!tree.Recordings.TryGetValue(probe.ParentRecordingId, out probe))
                             break;
-                        if (probe != null && v.vesselName == probe.VesselName)
+                        if (probe != null && (
+                            (probe.VesselPersistentId != 0 && v.persistentId == probe.VesselPersistentId) ||
+                            v.vesselName == probe.VesselName))
                         {
                             matched = v;
                             matchedRec = probe;
                             matchedRecId = probe.RecordingId;
                             ParsekLog.Info("Flight",
-                                $"RestoreActiveTreeFromPending: fallback match — active vessel '{v.vesselName}' " +
+                                $"RestoreActiveTreeFromPending: fallback match — active vessel pid={v.persistentId} " +
                                 $"matches parent recording '{matchedRecId}' (original active was '{targetName}', " +
                                 $"EVA kerbal likely boarded between F5 and F9)");
                             // Flip the tree's active-recording pointer to the parent
@@ -5874,6 +5913,33 @@ namespace Parsek
                         $"not found on scene exit for recording '{rec.RecordingId}' — " +
                         $"inferred {inferredState} from trajectory (vessel was alive when unloaded)");
                     PopulateTerminalOrbitFromLastSegment(rec);
+
+                    // Bug #290d: capture terrain height from last trajectory point for
+                    // landed/splashed recordings whose vessel was unloaded at scene exit.
+                    // Without this, TerrainHeightAtEnd stays NaN and the spawn safety net
+                    // uses PQS terrain height, which is below KSP static structures (runway,
+                    // launchpad), causing the spawned vessel to clip through and explode.
+                    if ((inferredState == TerminalState.Landed || inferredState == TerminalState.Splashed)
+                        && rec.Points.Count > 0)
+                    {
+                        var lastPt = rec.Points[rec.Points.Count - 1];
+                        try
+                        {
+                            CelestialBody body = FlightGlobals.GetBodyByName(lastPt.bodyName);
+                            if (body != null)
+                            {
+                                rec.TerrainHeightAtEnd = body.TerrainAltitude(lastPt.latitude, lastPt.longitude);
+                                ParsekLog.Verbose("TerrainCorrect",
+                                    $"Captured terrain height from trajectory for unloaded vessel: " +
+                                    $"{rec.TerrainHeightAtEnd:F1}m (lastPt alt={lastPt.altitude:F1}m, " +
+                                    $"rec={rec.RecordingId})");
+                            }
+                        }
+                        catch
+                        {
+                            // FlightGlobals not available (unit tests)
+                        }
+                    }
                 }
                 else
                 {
@@ -5982,6 +6048,15 @@ namespace Parsek
                 }
             }
 
+            // Bug #290d: backfill MaxDistanceFromLaunch if not yet computed.
+            // Tree recordings reach finalization via ForceStop which skips BuildCaptureRecording
+            // (where MaxDistanceFromLaunch is normally computed). Without this, all recordings
+            // have maxDist=0.0 and IsTreeIdleOnPad falsely discards the entire tree.
+            if (rec.MaxDistanceFromLaunch <= 0.0 && rec.Points.Count >= 2)
+            {
+                VesselSpawner.BackfillMaxDistance(rec);
+            }
+
             // Warn if leaf has no playback data
             if (isLeaf && rec.Points.Count == 0 && rec.OrbitSegments.Count == 0 && !rec.SurfacePos.HasValue)
                 ParsekLog.Warn("Flight", $"FinalizeTreeRecordings: leaf '{rec.RecordingId}' has no playback data");
@@ -5990,6 +6065,7 @@ namespace Parsek
                 $"FinalizeTreeRecordings: rec='{rec.RecordingId}' vessel='{rec.VesselName}' " +
                 $"points={rec.Points.Count} orbitSegs={rec.OrbitSegments.Count} " +
                 $"terminal={rec.TerminalStateValue?.ToString() ?? "none"} " +
+                $"maxDist={rec.MaxDistanceFromLaunch:F0}m " +
                 $"snapshot={rec.VesselSnapshot != null} leaf={isLeaf}");
         }
 
@@ -7512,8 +7588,11 @@ namespace Parsek
             if (tree == null || tree.Recordings == null || tree.Recordings.Count == 0)
                 return false;
 
+            bool anyHasPoints = false;
             foreach (var rec in tree.Recordings.Values)
             {
+                if (rec.Points != null && rec.Points.Count > 0)
+                    anyHasPoints = true;
                 if (!IsIdleOnPad(rec.MaxDistanceFromLaunch))
                 {
                     ParsekLog.Verbose("Flight",
@@ -7522,6 +7601,15 @@ namespace Parsek
                             rec.VesselName, rec.MaxDistanceFromLaunch));
                     return false;
                 }
+            }
+            // Bug #290d: a tree where no recording has trajectory points is data-loss
+            // (e.g., sidecar epoch mismatch), not idle-on-pad. Don't auto-discard.
+            if (!anyHasPoints)
+            {
+                ParsekLog.Verbose("Flight",
+                    $"IsTreeIdleOnPad: all {tree.Recordings.Count} recordings have 0 points — " +
+                    "cannot determine idle, returning false");
+                return false;
             }
             ParsekLog.Verbose("Flight",
                 $"IsTreeIdleOnPad: all {tree.Recordings.Count} recordings within 30m — idle on pad");

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -1723,6 +1723,21 @@ namespace Parsek
                 // the next OnSave would write the tree twice with the same id.
                 RemoveCommittedTreeById(tree.Id);
 
+                // Bug #290d: if the pending tree is already Finalized (set by
+                // CommitTreeSceneExit during the same scene transition), it has
+                // post-finalize data (MaxDistanceFromLaunch, terminal states, snapshots)
+                // that the .sfs version does NOT have (OnSave runs BEFORE finalization).
+                // Skip the replacement — the in-memory Finalized tree is authoritative.
+                if (RecordingStore.HasPendingTree
+                    && RecordingStore.PendingTreeStateValue == PendingTreeState.Finalized)
+                {
+                    ParsekLog.Info("Scenario",
+                        $"TryRestoreActiveTreeNode: keeping in-memory Finalized tree " +
+                        $"'{RecordingStore.PendingTree.TreeName}' — skipping .sfs replacement " +
+                        $"(OnSave ran before finalization, .sfs maxDist is stale)");
+                    return true;
+                }
+
                 // Pop any existing pending tree silently — StashActiveTreeAsPendingLimbo
                 // stashed the in-memory (future-timeline) version at OnSceneChangeRequested
                 // time; we want the freshly-loaded disk version (matches the quicksave UT

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -3467,7 +3467,7 @@ namespace Parsek
 
         #region Recording File I/O
 
-        internal static bool SaveRecordingFiles(Recording rec)
+        internal static bool SaveRecordingFiles(Recording rec, bool incrementEpoch = true)
         {
             if (rec == null)
             {
@@ -3502,13 +3502,15 @@ namespace Parsek
                     return false;
                 }
 
-                // Bug #270: increment sidecar epoch immediately before the .prec write
-                // (after all early-return guards) so the in-memory epoch only advances
-                // when the file actually hits disk. RecordingTree.SaveRecordingInto runs
-                // after this method and reads the same in-memory value, keeping .sfs and
-                // .prec in sync. On quickload, a stale .prec (from a later save) will
-                // have a higher epoch than the .sfs expects, and LoadRecordingFiles skips it.
-                rec.SidecarEpoch++;
+                // Bug #270 / #290: sidecar epoch synchronization.
+                // On OnSave (incrementEpoch=true): advance the epoch before writing so
+                // .prec and .sfs (written later by SaveRecordingInto) stay in sync.
+                // On out-of-band writes (incrementEpoch=false): preserve the current epoch
+                // so the .prec matches the last OnSave's .sfs. Without this, BgRecorder
+                // and scene-exit force-writes would advance the epoch independently,
+                // causing false-positive staleness on quickload (bug #290).
+                if (incrementEpoch)
+                    rec.SidecarEpoch++;
                 precNode.AddValue("sidecarEpoch", rec.SidecarEpoch.ToString(System.Globalization.CultureInfo.InvariantCulture));
                 SerializeTrajectoryInto(precNode, rec);
                 SafeWriteConfigNode(precNode, precPath);

--- a/Source/Parsek/UI/RecordingsTableUI.cs
+++ b/Source/Parsek/UI/RecordingsTableUI.cs
@@ -78,6 +78,7 @@ namespace Parsek
         private GUIStyle phaseStyleExo;
         private GUIStyle phaseStyleSpace;
         private GUIStyle phaseStyleApproach;
+        private GUIStyle phaseStyleSurface;
 
         // Sort state
         internal enum SortColumn { Index, Phase, Name, LaunchTime, Duration, Status, LaunchSite }
@@ -328,16 +329,19 @@ namespace Parsek
             if (phaseStyleAtmo != null) return;
 
             phaseStyleAtmo = new GUIStyle(GUI.skin.label);
-            phaseStyleAtmo.normal.textColor = new Color(1f, 0.6f, 0.2f); // orange
+            phaseStyleAtmo.normal.textColor = new Color(0.4f, 0.7f, 1f); // blue
 
             phaseStyleExo = new GUIStyle(GUI.skin.label);
-            phaseStyleExo.normal.textColor = new Color(0.3f, 0.8f, 1f); // cyan
+            phaseStyleExo.normal.textColor = new Color(0.75f, 0.55f, 1f); // light purple
 
             phaseStyleSpace = new GUIStyle(GUI.skin.label);
             phaseStyleSpace.normal.textColor = new Color(0.2f, 1f, 0.6f); // lime green
 
             phaseStyleApproach = new GUIStyle(GUI.skin.label);
-            phaseStyleApproach.normal.textColor = new Color(0.4f, 0.7f, 1f); // sky blue
+            phaseStyleApproach.normal.textColor = new Color(0.3f, 0.8f, 1f); // cyan
+
+            phaseStyleSurface = new GUIStyle(GUI.skin.label);
+            phaseStyleSurface.normal.textColor = new Color(1f, 0.6f, 0.2f); // orange
         }
 
         /// <summary>
@@ -779,6 +783,7 @@ namespace Parsek
             {
                 GUIStyle phaseStyle;
                 if (rec.SegmentPhase == "atmo") phaseStyle = phaseStyleAtmo;
+                else if (rec.SegmentPhase == "surface") phaseStyle = phaseStyleSurface;
                 else if (rec.SegmentPhase == "approach") phaseStyle = phaseStyleApproach;
                 else if (rec.SegmentPhase == "space") phaseStyle = phaseStyleSpace;
                 else phaseStyle = phaseStyleExo;

--- a/Source/Parsek/VesselSpawner.cs
+++ b/Source/Parsek/VesselSpawner.cs
@@ -1862,7 +1862,44 @@ namespace Parsek
         private static void ComputeMaxDistance(Recording pending, CelestialBody bodyFirst, TrajectoryPoint firstPoint)
         {
             if (bodyFirst == null) return;
+            ComputeMaxDistanceCore(pending, bodyFirst, firstPoint);
+        }
 
+        /// <summary>
+        /// Backfills <see cref="Recording.MaxDistanceFromLaunch"/> from trajectory points.
+        /// Called from <see cref="ParsekFlight.FinalizeIndividualRecording"/> for tree recordings
+        /// that reach finalization via ForceStop (which skips BuildCaptureRecording). Bug #290d.
+        /// Requires FlightGlobals.Bodies to be available (KSP runtime only).
+        /// </summary>
+        internal static void BackfillMaxDistance(Recording rec)
+        {
+            if (rec == null || rec.Points == null || rec.Points.Count < 2) return;
+
+            var firstPoint = rec.Points[0];
+            CelestialBody bodyFirst;
+            try
+            {
+                bodyFirst = FlightGlobals.Bodies?.Find(b => b.name == firstPoint.bodyName);
+            }
+            catch
+            {
+                // FlightGlobals not available (unit tests)
+                return;
+            }
+            if (bodyFirst == null)
+            {
+                ParsekLog.Warn("Spawner",
+                    $"BackfillMaxDistance: cannot resolve body '{firstPoint.bodyName}' for recording '{rec.RecordingId}'");
+                return;
+            }
+            ComputeMaxDistanceCore(rec, bodyFirst, firstPoint);
+            ParsekLog.Verbose("Spawner",
+                $"BackfillMaxDistance: rec={rec.RecordingId} maxDist={rec.MaxDistanceFromLaunch:F0}m " +
+                $"from {rec.Points.Count} points");
+        }
+
+        private static void ComputeMaxDistanceCore(Recording pending, CelestialBody bodyFirst, TrajectoryPoint firstPoint)
+        {
             Vector3d launchPos = bodyFirst.GetWorldSurfacePosition(
                 firstPoint.latitude, firstPoint.longitude, firstPoint.altitude);
             double maxDist = 0;

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -125,6 +125,42 @@ Broad investigation of F5/F9 + recording system interactions. Bug #292 (F9 after
 
 ---
 
+## ~~290e. TerrainHeightAtEnd not captured for unloaded vessels at scene exit~~
+
+**Observed in:** Sandbox (2026-04-11). Rover ghosts appeared under the runway surface and spawn-at-end placed the vessel below the runway, causing it to clip through and explode. The rover was a background vessel (player was controlling EVA kerbal) when the scene exited.
+
+**Root cause:** `CaptureTerminalPosition` (which captures `TerrainHeightAtEnd`) is only called when `finalizeVessel != null`. Unloaded background vessels are not findable at scene exit, so `TerrainHeightAtEnd` stays NaN. The spawn safety net falls back to PQS terrain height (~64.8m), which is below the runway structure surface (~70m).
+
+**Fix:** In the `isSceneExit` fallback path of `FinalizeIndividualRecording`, capture terrain height from the last trajectory point's lat/lon coordinates via `body.TerrainAltitude()` for Landed/Splashed recordings.
+
+**Status:** ~~Fixed~~
+
+---
+
+## ~~290f. SegmentPhase classified LANDED vessels as "atmo"~~
+
+**Observed in:** Sandbox (2026-04-11). Rover recordings on the runway showed "Kerbin atmo" instead of "Kerbin surface" in the Phase column.
+
+**Root cause:** Three code paths (`TagSegmentPhaseIfMissing`, `StopRecording`, `ChainSegmentManager`) classified SegmentPhase by altitude alone (`altitude < atmosphereDepth ? "atmo" : "exo"`), ignoring the vessel's situation. A landed rover on Kerbin is technically within the atmosphere by altitude, but its situation is LANDED.
+
+**Fix:** All three sites now check `Vessel.Situations.LANDED/SPLASHED/PRELAUNCH` first and assign "surface" phase. Also added `phaseStyleSurface` (orange) to the UI, changed atmo to blue, exo to light purple.
+
+**Status:** ~~Fixed~~
+
+---
+
+## ~~290g. LaunchSiteName missing from tree recordings~~
+
+**Observed in:** Sandbox (2026-04-11). Site column empty for most recordings in the Recordings window.
+
+**Root cause:** `FlushRecorderIntoActiveTreeForSerialization` (called during OnSave) did not copy `LaunchSiteName` or start location fields from the recorder to the tree recording. Only `FlushRecorderToTreeRecording` (normal stop path via `BuildCaptureRecording`) copied them.
+
+**Fix:** Added LaunchSiteName, StartBodyName, StartBiome, StartSituation copy to `FlushRecorderIntoActiveTreeForSerialization`.
+
+**Status:** ~~Fixed~~
+
+---
+
 ## ~~290c. F5/F9 epoch mismatch — BgRecorder and force-writes advance sidecar epoch past .sfs~~
 
 **Observed in:** Sandbox (2026-04-11). F5 quicksave, fly with staging (debris created), F9 quickload. All background recordings lost trajectory data (0 points). Same mismatch on scene exit: Bob Kerman EVA recording lost to epoch drift, then auto-discarded by idle-on-pad false positive.

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -98,6 +98,45 @@ Broad investigation of F5/F9 + recording system interactions. Bug #292 (F9 after
 
 ---
 
+## ~~290b. RestoreActiveTreeFromPending fails on #autoLOC vessel names~~
+
+**Observed in:** Sandbox (2026-04-11). After F9 quickload, the restore coroutine waited 3s for vessel "Kerbal X" to become active, but KSP's `vesselName` was still the raw `#autoLOC_501232` key (localization not yet resolved). The vessel WAS loaded (correct `persistentId` logged), but the name-only match failed. Tree stayed in Limbo, no recording started, and the orphaned tree eventually triggered a spurious merge dialog.
+
+**Root cause:** `RestoreActiveTreeFromPending` matched only by `vesselName`, which is unreliable immediately after quickload because KSP defers localization resolution.
+
+**Fix:** Added PID-based matching (`VesselPersistentId` vs `Vessel.persistentId`) as the primary check, with name match as secondary fallback. Same change applied to the EVA parent chain walk. PID is locale-proof and available immediately.
+
+**Status:** ~~Fixed~~
+
+---
+
+## ~~290d. MaxDistanceFromLaunch never computed for tree recordings~~
+
+**Observed in:** Sandbox (2026-04-11). All tree recordings had `MaxDistanceFromLaunch = 0.0` despite having real trajectory data (125+ points). `IsTreeIdleOnPad` returned true for all 7 recordings, discarding the entire flight on scene exit to Space Center.
+
+**Root cause:** `MaxDistanceFromLaunch` is computed in `VesselSpawner.ComputeMaxDistance`, which is called from `BuildCaptureRecording`. Tree recordings reach finalization via `ForceStop` (scene exit), which intentionally skips `BuildCaptureRecording` because vessel state may be unreliable during scene transitions. BgRecorder never computes it either. Result: every tree recording has the default `0.0`.
+
+**Fix (three parts):**
+1. `FinalizeIndividualRecording` now calls `VesselSpawner.BackfillMaxDistance(rec)` for recordings with `MaxDistanceFromLaunch <= 0.0` and `Points.Count >= 2`. Extracted `ComputeMaxDistanceCore` from the existing private `ComputeMaxDistance` method.
+2. `IsTreeIdleOnPad` now requires at least one recording with `Points.Count > 0` before classifying a tree as idle (guards against 0-point recordings from epoch mismatch).
+3. `TryRestoreActiveTreeNode` now skips .sfs replacement when the pending tree is already `Finalized` -- the in-memory tree has post-finalize data (MaxDistanceFromLaunch, terminal states) that the .sfs version lacks because KSP's OnSave runs BEFORE `FinalizeTreeOnSceneChange`.
+
+**Status:** ~~Fixed~~
+
+---
+
+## ~~290c. F5/F9 epoch mismatch — BgRecorder and force-writes advance sidecar epoch past .sfs~~
+
+**Observed in:** Sandbox (2026-04-11). F5 quicksave, fly with staging (debris created), F9 quickload. All background recordings lost trajectory data (0 points). Same mismatch on scene exit: Bob Kerman EVA recording lost to epoch drift, then auto-discarded by idle-on-pad false positive.
+
+**Root cause:** `BackgroundRecorder.PersistFinalizedRecording` and the scene-exit force-write loop both call `SaveRecordingFiles`, which unconditionally increments `SidecarEpoch`. Between an F5 (which writes .sfs with epoch N) and F9, BgRecorder can call `PersistFinalizedRecording` multiple times (once per `OnBackgroundVesselWillDestroy`, once per `EndDebrisRecording`), advancing the .prec epoch to N+2 or beyond. On quickload, .sfs expects epoch N but .prec has epoch N+2, triggering `ShouldSkipStaleSidecar` and silently dropping all trajectory data.
+
+**Fix:** Added `bool incrementEpoch = true` parameter to `SaveRecordingFiles`. Out-of-band callers (BgRecorder `PersistFinalizedRecording`, scene-exit force-write loop) pass `incrementEpoch: false` so the .prec keeps the epoch from the last OnSave. OnSave and commit paths use the default `true`, preserving original #270 cross-scene staleness detection.
+
+**Status:** ~~Fixed~~
+
+---
+
 ## ~~286. Full-tree crash leaves nothing to continue with — `CanPersistVessel` blocks all `Destroyed` leaves~~
 
 **Fix:** Option (c) implemented. When `spawnCount == 0 && decisions.Count > 0`, the merge dialog body shows: "No flight branches produced a vessel that can continue flying. The recordings will play back as ghosts, but no vessel will be placed." Screen message changed from generic "Merged to timeline!" to "Merged to timeline (no surviving vessels)". Wording is terminal-state-agnostic (covers Destroyed, Recovered, Docked, Boarded). The `CanPersistVessel` blocking logic is unchanged -- the player just needed to know why nothing spawned.


### PR DESCRIPTION
## Summary

- **Recording data loss on F5/F9**: Five cascading bugs (epoch drift, vessel name matching, idle-on-pad false positive, missing MaxDistanceFromLaunch, Finalized tree overwrite) caused total recording loss after quickload. All fixed.
- **Spawn underground**: Unloaded vessels at scene exit had no TerrainHeightAtEnd, causing spawn-at-end to place vessels below runway/launchpad structures. Fixed by capturing terrain from trajectory points.
- **Phase misclassification**: LANDED vessels on atmospheric bodies showed "atmo" instead of "surface". All 3 classification sites now check vessel situation first.
- **Missing LaunchSiteName**: Tree recordings never had LaunchSiteName populated during OnSave. Fixed by copying from recorder in FlushRecorderIntoActiveTreeForSerialization.
- **Phase colors**: atmo=blue, surface=orange, exo=light purple.

## Test plan

- [x] 5737 unit tests pass
- [x] In-game: launch rocket, F5, fly with staging, F9 -- recording resumes, all recordings survive to Space Center
- [x] In-game: rover on runway, exit to Space Center -- recordings not discarded, Phase shows "surface"
- [ ] Verify spawn-at-end on runway doesn't clip underground
- [x] Verify LaunchSiteName populates for all new recordings

🤖 Generated with [Claude Code](https://claude.com/claude-code)