### PR TITLE
Fix #242c: ghost variant FX fires from inactive variant geometry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ All notable changes to Parsek are documented here.
 - `#290` Debris and EVA branch recordings in the active tree no longer lose trajectory data after two cold starts (quit KSP mid-flight, relaunch, quit again).
 - `#242` Ghost PREFAB_PARTICLE FX (smoke, small engine flames) no longer fires sideways -- auto-detects parent transform orientation and applies -90 X correction when needed.
 - `#242` RAPIER and Panther ghost FX now shows only the active engine mode (jet or rocket) instead of both simultaneously.
+- `#242c` Ghost engine and RCS FX on multi-variant parts (Poodle, Terrier, RV-105, etc.) now only fires from the selected variant's nozzles instead of all variants simultaneously.
 
 ### New Features
 

--- a/Source/Parsek.Tests/VariantFxFilterTests.cs
+++ b/Source/Parsek.Tests/VariantFxFilterTests.cs
@@ -1,0 +1,237 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Tests for bug #242c: ghost variant geometry not toggled for FX transforms.
+    ///
+    /// Parts with ModulePartVariants that toggle geometry via GAMEOBJECTS (e.g.,
+    /// Poodle DoubleBell/SingleBell) showed FX from all variant geometries on
+    /// the ghost. The fix filters FX transforms against the selected variant's
+    /// GAMEOBJECTS rules using IsAncestorChainEnabledByVariantRule.
+    ///
+    /// These tests cover the pure ancestor-matching logic extracted from
+    /// IsRendererEnabledByVariantRule — no Unity dependency.
+    /// </summary>
+    public class VariantFxFilterTests
+    {
+        [Fact]
+        public void AncestorUnderEnabledVariant_ReturnsTrue()
+        {
+            // thrustTransform is under EngineFixed, which is enabled
+            var ancestors = new List<string> { "thrustTransform", "EngineFixed" };
+            var rules = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "EngineFixed", true }
+            };
+
+            bool result = GhostVisualBuilder.IsAncestorChainEnabledByVariantRule(
+                ancestors, rules, out string matched, out bool enabled);
+
+            Assert.True(result);
+            Assert.Equal("EngineFixed", matched);
+            Assert.True(enabled);
+        }
+
+        [Fact]
+        public void AncestorUnderDisabledVariant_ReturnsFalse()
+        {
+            // thrustTransform is under EngineFixed, which is disabled (SingleBell variant)
+            var ancestors = new List<string> { "thrustTransform", "EngineFixed" };
+            var rules = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "EngineFixed", false }
+            };
+
+            bool result = GhostVisualBuilder.IsAncestorChainEnabledByVariantRule(
+                ancestors, rules, out string matched, out bool enabled);
+
+            Assert.False(result);
+            Assert.Equal("EngineFixed", matched);
+            Assert.False(enabled);
+        }
+
+        [Fact]
+        public void NoMatchingRule_ReturnsTrue()
+        {
+            // thrustTransform is under UnrelatedParent — no rule matches
+            var ancestors = new List<string> { "thrustTransform", "UnrelatedParent" };
+            var rules = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "EngineFixed", true }
+            };
+
+            bool result = GhostVisualBuilder.IsAncestorChainEnabledByVariantRule(
+                ancestors, rules, out string matched, out bool enabled);
+
+            Assert.True(result);
+            Assert.Null(matched);
+            Assert.True(enabled);
+        }
+
+        [Fact]
+        public void NullGameObjectStates_ReturnsTrue()
+        {
+            var ancestors = new List<string> { "thrustTransform", "EngineFixed" };
+
+            bool result = GhostVisualBuilder.IsAncestorChainEnabledByVariantRule(
+                ancestors, null, out string matched, out bool enabled);
+
+            Assert.True(result);
+            Assert.Null(matched);
+            Assert.True(enabled);
+        }
+
+        [Fact]
+        public void EmptyGameObjectStates_ReturnsTrue()
+        {
+            var ancestors = new List<string> { "thrustTransform", "EngineFixed" };
+            var rules = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+
+            bool result = GhostVisualBuilder.IsAncestorChainEnabledByVariantRule(
+                ancestors, rules, out string matched, out bool enabled);
+
+            Assert.True(result);
+            Assert.Null(matched);
+            Assert.True(enabled);
+        }
+
+        [Fact]
+        public void FirstDeepestMatchWins_DisabledChildUnderEnabledParent()
+        {
+            // Walk is bottom-up: DisabledChild is checked before EnabledParent
+            var ancestors = new List<string> { "thrustTransform", "DisabledChild", "EnabledParent" };
+            var rules = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "EnabledParent", true },
+                { "DisabledChild", false }
+            };
+
+            bool result = GhostVisualBuilder.IsAncestorChainEnabledByVariantRule(
+                ancestors, rules, out string matched, out bool enabled);
+
+            Assert.False(result);
+            Assert.Equal("DisabledChild", matched);
+            Assert.False(enabled);
+        }
+
+        [Fact]
+        public void CaseInsensitiveMatching()
+        {
+            // Rule uses "EngineFixed", ancestor has "engineFixed" (different case)
+            // matchedRuleName returns the ancestor name as-found, not the dictionary key
+            var ancestors = new List<string> { "thrustTransform", "engineFixed" };
+            var rules = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "EngineFixed", true }
+            };
+
+            bool result = GhostVisualBuilder.IsAncestorChainEnabledByVariantRule(
+                ancestors, rules, out string matched, out bool enabled);
+
+            Assert.True(result);
+            Assert.Equal("engineFixed", matched);
+            Assert.True(enabled);
+        }
+
+        [Fact]
+        public void ExtractShortTransformName_MatchesCloneSuffix()
+        {
+            // Multi-MODEL parts: KSP names with full path + (Clone)
+            var ancestors = new List<string>
+            {
+                "thrustTransform",
+                "Squad/Parts/Engine/Shroud3x0(Clone)"
+            };
+            var rules = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "Shroud3x0", false }
+            };
+
+            bool result = GhostVisualBuilder.IsAncestorChainEnabledByVariantRule(
+                ancestors, rules, out string matched, out bool enabled);
+
+            Assert.False(result);
+            Assert.Equal("Shroud3x0", matched);
+            Assert.False(enabled);
+        }
+
+        [Fact]
+        public void PoodleDoubleBell_EnabledTransformsPass()
+        {
+            // Poodle DoubleBell variant: EngineFixed=true, Shroud=false
+            // thrustTransform under EngineFixed should pass
+            var ancestors = new List<string> { "thrustTransform", "EngineFixed", "model" };
+            var rules = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "EngineFixed", true },
+                { "Shroud", false },
+                { "Shroud1", true },
+                { "Shroud2", false }
+            };
+
+            bool result = GhostVisualBuilder.IsAncestorChainEnabledByVariantRule(
+                ancestors, rules, out string matched, out bool enabled);
+
+            Assert.True(result);
+            Assert.Equal("EngineFixed", matched);
+            Assert.True(enabled);
+        }
+
+        [Fact]
+        public void PoodleSingleBell_DisabledEngineFixedBlocked()
+        {
+            // Poodle SingleBell variant: EngineFixed=false
+            // thrustTransform under EngineFixed should be blocked
+            var ancestors = new List<string> { "thrustTransform", "EngineFixed", "model" };
+            var rules = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "EngineFixed", false },
+                { "Shroud", true },
+                { "Shroud1", false },
+                { "Shroud2", true }
+            };
+
+            bool result = GhostVisualBuilder.IsAncestorChainEnabledByVariantRule(
+                ancestors, rules, out string matched, out bool enabled);
+
+            Assert.False(result);
+            Assert.Equal("EngineFixed", matched);
+            Assert.False(enabled);
+        }
+
+        [Fact]
+        public void NullAncestorList_ReturnsTrue()
+        {
+            var rules = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "EngineFixed", false }
+            };
+
+            bool result = GhostVisualBuilder.IsAncestorChainEnabledByVariantRule(
+                null, rules, out string matched, out bool enabled);
+
+            Assert.True(result);
+            Assert.Null(matched);
+            Assert.True(enabled);
+        }
+
+        [Fact]
+        public void EmptyAncestorList_ReturnsTrue()
+        {
+            var rules = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "EngineFixed", false }
+            };
+
+            bool result = GhostVisualBuilder.IsAncestorChainEnabledByVariantRule(
+                new List<string>(), rules, out string matched, out bool enabled);
+
+            Assert.True(result);
+            Assert.Null(matched);
+            Assert.True(enabled);
+        }
+    }
+}

--- a/Source/Parsek.Tests/VariantFxFilterTests.cs
+++ b/Source/Parsek.Tests/VariantFxFilterTests.cs
@@ -118,6 +118,43 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void FirstDeepestMatchWins_EnabledChildUnderDisabledParent()
+        {
+            // Inverse of above: EnabledChild is closer (checked first), should win
+            var ancestors = new List<string> { "thrustTransform", "EnabledChild", "DisabledParent" };
+            var rules = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "EnabledChild", true },
+                { "DisabledParent", false }
+            };
+
+            bool result = GhostVisualBuilder.IsAncestorChainEnabledByVariantRule(
+                ancestors, rules, out string matched, out bool enabled);
+
+            Assert.True(result);
+            Assert.Equal("EnabledChild", matched);
+            Assert.True(enabled);
+        }
+
+        [Fact]
+        public void TransformItselfMatchesRule()
+        {
+            // The transform name itself (index 0) matches a variant rule
+            var ancestors = new List<string> { "EngineFixed", "model" };
+            var rules = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "EngineFixed", false }
+            };
+
+            bool result = GhostVisualBuilder.IsAncestorChainEnabledByVariantRule(
+                ancestors, rules, out string matched, out bool enabled);
+
+            Assert.False(result);
+            Assert.Equal("EngineFixed", matched);
+            Assert.False(enabled);
+        }
+
+        [Fact]
         public void CaseInsensitiveMatching()
         {
             // Rule uses "EngineFixed", ancestor has "engineFixed" (different case)

--- a/Source/Parsek/EngineFxBuilder.cs
+++ b/Source/Parsek/EngineFxBuilder.cs
@@ -185,7 +185,8 @@ namespace Parsek
             Part prefab, ModuleEngines engine, EngineGhostInfo info,
             string partName, int moduleIndex,
             Transform modelRoot, Transform ghostModelNode,
-            Dictionary<Transform, Transform> cloneMap)
+            Dictionary<Transform, Transform> cloneMap,
+            Dictionary<string, bool> selectedVariantGameObjects)
         {
             var legacyAnchors = new List<Transform>();
             if (engine != null && engine.thrustTransforms != null)
@@ -208,6 +209,22 @@ namespace Parsek
                         legacyAnchors.Add(anchor);
                 }
             }
+
+            // #242c: filter out thrustTransforms under disabled variant GameObjects.
+            // engine.thrustTransforms is populated by KSP from ALL matching transforms
+            // in the prefab, regardless of which variant is active.
+            if (selectedVariantGameObjects != null && selectedVariantGameObjects.Count > 0)
+            {
+                int preFilter = legacyAnchors.Count;
+                legacyAnchors.RemoveAll(t =>
+                    !GhostVisualBuilder.IsRendererEnabledByVariantRule(
+                        t, modelRoot, selectedVariantGameObjects, out _, out _));
+                if (legacyAnchors.Count < preFilter)
+                    ParsekLog.Verbose("EngineFx", $"'{partName}' midx={moduleIndex}: " +
+                        $"variant filter removed {preFilter - legacyAnchors.Count} of {preFilter} " +
+                        $"legacy thrust anchors");
+            }
+
             Vector3 legacyFxOffset = engine != null ? engine.fxOffset : Vector3.zero;
 
             for (int c = 0; c < prefab.transform.childCount; c++)
@@ -305,13 +322,26 @@ namespace Parsek
             Part prefab, EngineGhostInfo info,
             string partName, int moduleIndex,
             Transform modelRoot, Transform ghostModelNode,
-            Dictionary<Transform, Transform> cloneMap)
+            Dictionary<Transform, Transform> cloneMap,
+            Dictionary<string, bool> selectedVariantGameObjects)
         {
             for (int f = 0; f < modelFxEntries.Count; f++)
             {
                 var (nodeType, transformName, modelName, mmpLocalPos, mmpLocalRot, groupName) = modelFxEntries[f];
 
                 var fxTransforms = GhostVisualBuilder.FindTransformsRecursive(prefab.transform, transformName);
+                // #242c: exclude transforms under disabled variant GameObjects
+                if (selectedVariantGameObjects != null && selectedVariantGameObjects.Count > 0)
+                {
+                    int preFilter = fxTransforms.Count;
+                    fxTransforms.RemoveAll(t =>
+                        !GhostVisualBuilder.IsRendererEnabledByVariantRule(
+                            t, modelRoot, selectedVariantGameObjects, out _, out _));
+                    if (fxTransforms.Count < preFilter)
+                        ParsekLog.Verbose("EngineFx", $"'{partName}' midx={moduleIndex}: " +
+                            $"variant filter removed {preFilter - fxTransforms.Count} of {preFilter} " +
+                            $"'{transformName}' model FX transforms");
+                }
                 for (int t = 0; t < fxTransforms.Count; t++)
                 {
                     Transform srcFxTransform = fxTransforms[t];
@@ -375,7 +405,8 @@ namespace Parsek
             Part prefab, EngineGhostInfo info,
             string partName, int moduleIndex,
             Transform modelRoot, Transform ghostModelNode,
-            Dictionary<Transform, Transform> cloneMap)
+            Dictionary<Transform, Transform> cloneMap,
+            Dictionary<string, bool> selectedVariantGameObjects)
         {
             for (int f = 0; f < prefabFxEntries.Count; f++)
             {
@@ -393,6 +424,18 @@ namespace Parsek
                 }
 
                 var fxTransforms = GhostVisualBuilder.FindTransformsRecursive(prefab.transform, transformName);
+                // #242c: exclude transforms under disabled variant GameObjects
+                if (selectedVariantGameObjects != null && selectedVariantGameObjects.Count > 0)
+                {
+                    int preFilter = fxTransforms.Count;
+                    fxTransforms.RemoveAll(t =>
+                        !GhostVisualBuilder.IsRendererEnabledByVariantRule(
+                            t, modelRoot, selectedVariantGameObjects, out _, out _));
+                    if (fxTransforms.Count < preFilter)
+                        ParsekLog.Verbose("EngineFx", $"'{partName}' midx={moduleIndex}: " +
+                            $"variant filter removed {preFilter - fxTransforms.Count} of {preFilter} " +
+                            $"'{transformName}' prefab FX transforms");
+                }
                 if (fxTransforms.Count == 0)
                 {
                     ParsekLog.Verbose("EngineFx", $"'{partName}' midx={moduleIndex} " +
@@ -475,7 +518,8 @@ namespace Parsek
         internal static List<EngineGhostInfo> TryBuildEngineFX(
             Part prefab, uint persistentId, string partName,
             Transform modelRoot, Transform ghostModelNode,
-            Dictionary<Transform, Transform> cloneMap)
+            Dictionary<Transform, Transform> cloneMap,
+            Dictionary<string, bool> selectedVariantGameObjects)
         {
             // Find all ModuleEngines on the part
             int midx = 0;
@@ -579,6 +623,15 @@ namespace Parsek
 
                 var namedTransformCache = new Dictionary<string, List<Transform>>(System.StringComparer.OrdinalIgnoreCase);
 
+                // #242c: Filter out transforms under disabled variant GameObjects.
+                bool IsTransformEnabledByVariant(Transform t)
+                {
+                    if (selectedVariantGameObjects == null || selectedVariantGameObjects.Count == 0)
+                        return true;
+                    return GhostVisualBuilder.IsRendererEnabledByVariantRule(
+                        t, modelRoot, selectedVariantGameObjects, out _, out _);
+                }
+
                 List<Transform> FindNamedTransformsCached(string transformName)
                 {
                     if (string.IsNullOrEmpty(transformName))
@@ -588,6 +641,16 @@ namespace Parsek
                         return cached;
 
                     List<Transform> found = GhostVisualBuilder.FindTransformsRecursive(prefab.transform, transformName);
+                    // #242c: exclude transforms under disabled variant GameObjects
+                    if (selectedVariantGameObjects != null && selectedVariantGameObjects.Count > 0)
+                    {
+                        int preFilter = found.Count;
+                        found.RemoveAll(t => !IsTransformEnabledByVariant(t));
+                        if (found.Count < preFilter)
+                            ParsekLog.Verbose("EngineFx", $"'{partName}' midx={moduleIndex}: " +
+                                $"variant filter removed {preFilter - found.Count} of {preFilter} " +
+                                $"'{transformName}' transforms in FindNamedTransformsCached");
+                    }
                     namedTransformCache[transformName] = found;
                     return found;
                 }
@@ -1041,7 +1104,7 @@ namespace Parsek
 
                     bool legacyAdded = ProcessEngineLegacyFx(
                         prefab, engine, info, partName, moduleIndex,
-                        modelRoot, ghostModelNode, cloneMap);
+                        modelRoot, ghostModelNode, cloneMap, selectedVariantGameObjects);
                     if (legacyAdded)
                         result.Add(info);
                     else
@@ -1054,11 +1117,11 @@ namespace Parsek
 
                 // Process model FX entries (MODEL_MULTI_PARTICLE/MODEL_PARTICLE variants).
                 ProcessEngineModelFxEntries(modelFxEntries, prefab, info, partName, moduleIndex,
-                    modelRoot, ghostModelNode, cloneMap);
+                    modelRoot, ghostModelNode, cloneMap, selectedVariantGameObjects);
 
                 // Process PREFAB_PARTICLE entries (Spark, Twitch, Pug, Juno, Wheesley, Goliath)
                 ProcessEnginePrefabFxEntries(prefabFxEntries, prefab, info, partName, moduleIndex,
-                    modelRoot, ghostModelNode, cloneMap);
+                    modelRoot, ghostModelNode, cloneMap, selectedVariantGameObjects);
 
                 if (info.particleSystems.Count > 0)
                     result.Add(info);

--- a/Source/Parsek/EngineFxBuilder.cs
+++ b/Source/Parsek/EngineFxBuilder.cs
@@ -213,6 +213,7 @@ namespace Parsek
             // #242c: filter out thrustTransforms under disabled variant GameObjects.
             // engine.thrustTransforms is populated by KSP from ALL matching transforms
             // in the prefab, regardless of which variant is active.
+            bool variantFilteredAllAnchors = false;
             if (selectedVariantGameObjects != null && selectedVariantGameObjects.Count > 0)
             {
                 int preFilter = legacyAnchors.Count;
@@ -220,9 +221,13 @@ namespace Parsek
                     !GhostVisualBuilder.IsRendererEnabledByVariantRule(
                         t, modelRoot, selectedVariantGameObjects, out _, out _));
                 if (legacyAnchors.Count < preFilter)
+                {
                     ParsekLog.Verbose("EngineFx", $"'{partName}' midx={moduleIndex}: " +
                         $"variant filter removed {preFilter - legacyAnchors.Count} of {preFilter} " +
                         $"legacy thrust anchors");
+                    if (legacyAnchors.Count == 0)
+                        variantFilteredAllAnchors = true;
+                }
             }
 
             Vector3 legacyFxOffset = engine != null ? engine.fxOffset : Vector3.zero;
@@ -280,7 +285,10 @@ namespace Parsek
                     }
                 }
 
-                if (clonesAdded == 0)
+                // #242c: skip fallback placement when variant filtering intentionally
+                // emptied the anchor list — the active variant has no thrust transforms
+                // for this engine, so placing FX at the model root would be incorrect.
+                if (clonesAdded == 0 && !variantFilteredAllAnchors)
                 {
                     GameObject fxClone = Object.Instantiate(child.gameObject);
                     fxClone.transform.SetParent(ghostModelNode.parent, false);
@@ -623,7 +631,7 @@ namespace Parsek
 
                 var namedTransformCache = new Dictionary<string, List<Transform>>(System.StringComparer.OrdinalIgnoreCase);
 
-                // #242c: Filter out transforms under disabled variant GameObjects.
+                // #242c: filter out transforms under disabled variant GameObjects.
                 bool IsTransformEnabledByVariant(Transform t)
                 {
                     if (selectedVariantGameObjects == null || selectedVariantGameObjects.Count == 0)
@@ -641,16 +649,14 @@ namespace Parsek
                         return cached;
 
                     List<Transform> found = GhostVisualBuilder.FindTransformsRecursive(prefab.transform, transformName);
-                    // #242c: exclude transforms under disabled variant GameObjects
-                    if (selectedVariantGameObjects != null && selectedVariantGameObjects.Count > 0)
-                    {
-                        int preFilter = found.Count;
-                        found.RemoveAll(t => !IsTransformEnabledByVariant(t));
-                        if (found.Count < preFilter)
-                            ParsekLog.Verbose("EngineFx", $"'{partName}' midx={moduleIndex}: " +
-                                $"variant filter removed {preFilter - found.Count} of {preFilter} " +
-                                $"'{transformName}' transforms in FindNamedTransformsCached");
-                    }
+                    // #242c: exclude transforms under disabled variant GameObjects.
+                    // IsTransformEnabledByVariant handles the null/empty guard internally.
+                    int preFilter = found.Count;
+                    found.RemoveAll(t => !IsTransformEnabledByVariant(t));
+                    if (found.Count < preFilter)
+                        ParsekLog.Verbose("EngineFx", $"'{partName}' midx={moduleIndex}: " +
+                            $"variant filter removed {preFilter - found.Count} of {preFilter} " +
+                            $"'{transformName}' transforms in FindNamedTransformsCached");
                     namedTransformCache[transformName] = found;
                     return found;
                 }

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -2252,7 +2252,8 @@ namespace Parsek
             Part prefab, uint persistentId, string partName,
             Transform modelRoot, Transform ghostModelNode,
             Dictionary<Transform, Transform> cloneMap,
-            bool raiseRcsVisualOnly)
+            bool raiseRcsVisualOnly,
+            Dictionary<string, bool> selectedVariantGameObjects)
         {
             // Find all ModuleRCS on the part (catches both ModuleRCS and ModuleRCSFX)
             int midx = 0;
@@ -2372,7 +2373,22 @@ namespace Parsek
                     string transformName = fxDefinitions[f].transformName;
                     string modelName = fxDefinitions[f].modelName;
 
+                    // Note: RCS discovery uses FindTransformsRecursive (not rcs.thrusterTransforms
+                    // directly). If a thrusterTransforms-based path is added in the future,
+                    // it would also need variant filtering here.
                     var fxTransforms = FindTransformsRecursive(prefab.transform, transformName);
+                    // #242c: exclude transforms under disabled variant GameObjects
+                    if (selectedVariantGameObjects != null && selectedVariantGameObjects.Count > 0)
+                    {
+                        int preFilter = fxTransforms.Count;
+                        fxTransforms.RemoveAll(t =>
+                            !IsRendererEnabledByVariantRule(
+                                t, modelRoot, selectedVariantGameObjects, out _, out _));
+                        if (fxTransforms.Count < preFilter)
+                            ParsekLog.Verbose("GhostVisual", $"RCS '{partName}' midx={moduleIndex}: " +
+                                $"variant filter removed {preFilter - fxTransforms.Count} of {preFilter} " +
+                                $"'{transformName}' RCS FX transforms");
+                    }
                     if (fxTransforms.Count == 0)
                     {
                         continue;
@@ -3292,7 +3308,13 @@ namespace Parsek
             return true;
         }
 
-        private static bool IsRendererEnabledByVariantRule(
+        /// <summary>
+        /// Checks whether a transform is enabled by the selected variant's GAMEOBJECTS rules.
+        /// Walks up from the transform to modelRoot, checking each ancestor against the rules.
+        /// Returns true if no rule matches (default include). Used by mesh renderer filtering
+        /// and FX transform filtering (#242c).
+        /// </summary>
+        internal static bool IsRendererEnabledByVariantRule(
             Transform rendererTransform,
             Transform modelRoot,
             Dictionary<string, bool> gameObjectStates,
@@ -3305,12 +3327,48 @@ namespace Parsek
             if (rendererTransform == null || gameObjectStates == null || gameObjectStates.Count == 0)
                 return true;
 
+            // Build ancestor name list from transform up to modelRoot
+            var ancestorNames = new List<string>();
             Transform current = rendererTransform;
             while (current != null)
             {
-                if (gameObjectStates.TryGetValue(current.name, out bool enabled))
+                ancestorNames.Add(current.name);
+                if (current == modelRoot)
+                    break;
+                current = current.parent;
+            }
+
+            return IsAncestorChainEnabledByVariantRule(
+                ancestorNames, gameObjectStates,
+                out matchedRuleName, out matchedRuleEnabled);
+        }
+
+        /// <summary>
+        /// Pure matching logic: given a list of ancestor names (bottom-up, from transform
+        /// to modelRoot) and GAMEOBJECTS rules, returns whether the transform is enabled.
+        /// First matching ancestor wins. Returns true if no rule matches (default include).
+        /// Extracted for unit testability without Unity (#242c).
+        /// </summary>
+        internal static bool IsAncestorChainEnabledByVariantRule(
+            List<string> ancestorNamesBottomUp,
+            Dictionary<string, bool> gameObjectStates,
+            out string matchedRuleName,
+            out bool matchedRuleEnabled)
+        {
+            matchedRuleName = null;
+            matchedRuleEnabled = true;
+
+            if (ancestorNamesBottomUp == null || ancestorNamesBottomUp.Count == 0 ||
+                gameObjectStates == null || gameObjectStates.Count == 0)
+                return true;
+
+            for (int i = 0; i < ancestorNamesBottomUp.Count; i++)
+            {
+                string name = ancestorNamesBottomUp[i];
+
+                if (gameObjectStates.TryGetValue(name, out bool enabled))
                 {
-                    matchedRuleName = current.name;
+                    matchedRuleName = name;
                     matchedRuleEnabled = enabled;
                     return enabled;
                 }
@@ -3319,18 +3377,13 @@ namespace Parsek
                 // plus "(Clone)" suffix (e.g. "SquadExpansion/.../Shroud3x0(Clone)").
                 // Variant GAMEOBJECTS rules use short names (e.g. "Shroud3x0").
                 // Try matching the last path segment after stripping "(Clone)".
-                string shortName = ExtractShortTransformName(current.name);
+                string shortName = ExtractShortTransformName(name);
                 if (shortName != null && gameObjectStates.TryGetValue(shortName, out bool shortEnabled))
                 {
                     matchedRuleName = shortName;
                     matchedRuleEnabled = shortEnabled;
                     return shortEnabled;
                 }
-
-                if (current == modelRoot)
-                    break;
-
-                current = current.parent;
             }
 
             return true;
@@ -5403,12 +5456,14 @@ namespace Parsek
             }
 
             // Detect engine parts and clone FX particle systems
+            // selectedVariantGameObjects is null when no variant rules exist or when
+            // the base-implicit variant is selected (prefab defaults, no geometry toggling).
             engineInfos = EngineFxBuilder.TryBuildEngineFX(prefab, persistentId, partName, modelRoot,
-                modelNode.transform, cloneMap);
+                modelNode.transform, cloneMap, selectedVariantGameObjects);
 
             // Detect RCS parts and clone FX particle systems
             rcsInfos = TryBuildRcsFX(prefab, persistentId, partName, modelRoot,
-                modelNode.transform, cloneMap, raiseRcsVisualOnly);
+                modelNode.transform, cloneMap, raiseRcsVisualOnly, selectedVariantGameObjects);
 
             string ladderAnimName;
             string ladderAnimRootName;

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -3315,7 +3315,7 @@ namespace Parsek
         /// and FX transform filtering (#242c).
         /// </summary>
         internal static bool IsRendererEnabledByVariantRule(
-            Transform rendererTransform,
+            Transform targetTransform,
             Transform modelRoot,
             Dictionary<string, bool> gameObjectStates,
             out string matchedRuleName,
@@ -3324,12 +3324,12 @@ namespace Parsek
             matchedRuleName = null;
             matchedRuleEnabled = true;
 
-            if (rendererTransform == null || gameObjectStates == null || gameObjectStates.Count == 0)
+            if (targetTransform == null || gameObjectStates == null || gameObjectStates.Count == 0)
                 return true;
 
             // Build ancestor name list from transform up to modelRoot
             var ancestorNames = new List<string>();
-            Transform current = rendererTransform;
+            Transform current = targetTransform;
             while (current != null)
             {
                 ancestorNames.Add(current.name);

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -181,13 +181,15 @@ RAPIER and Panther (and any other `ModuleEnginesFX` multi-mode engines) rendered
 
 ---
 
-## 242c. Ghost variant geometry not toggled -- extra FX on multi-variant parts
+## ~~242c. Ghost variant geometry not toggled -- extra FX on multi-variant parts~~
 
 Parts with `ModulePartVariants` that toggle geometry via GAMEOBJECTS (e.g. Poodle DoubleBell/SingleBell) show all variant geometry on the ghost, including inactive variants. The Poodle ghost has 3 thrustTransforms (2 from DoubleBell + 1 from SingleBell) instead of 2, producing 3 flames instead of 2.
 
-**Root cause:** Ghost model is cloned from the raw prefab which contains ALL variant GameObjects. The variant system's `GAMEOBJECTS` visibility (e.g. `EngineFixed = true/false`) is not applied during ghost build. Variant texture support (#241) was implemented but geometry toggling was not.
+**Root cause:** Ghost model mesh filtering already excluded inactive variant renderers (#241), but the engine FX builder (`EngineFxBuilder`) and RCS FX builder (`TryBuildRcsFX`) discovered transforms from the raw prefab without variant awareness. `engine.thrustTransforms` (populated by KSP from ALL matching transforms regardless of variant state) was the primary source for the Poodle bug. `FindTransformsRecursive` calls in model/prefab FX methods were secondary sources. `MirrorTransformChain` then created ghost transforms for inactive-variant objects.
 
-**Priority:** Low -- cosmetic, only affects parts with geometry-switching variants (Poodle, possibly others)
+**Fix:** Threaded `selectedVariantGameObjects` into `TryBuildEngineFX` and `TryBuildRcsFX`. Extracted `IsAncestorChainEnabledByVariantRule` (pure, testable) from `IsRendererEnabledByVariantRule`. Filter applied at 5 points: `FindNamedTransformsCached`, `ProcessEngineLegacyFx` (engine.thrustTransforms), `ProcessEngineModelFxEntries`, `ProcessEnginePrefabFxEntries`, and `TryBuildRcsFX` (FindTransformsRecursive). Affects 9 engine parts and 3 RCS parts with GAMEOBJECTS variant rules.
+
+**Status:** ~~Fixed~~
 
 ---
 


### PR DESCRIPTION
## Summary

- Ghost engine and RCS FX on multi-variant parts (Poodle, Terrier, RV-105, etc.) now only fires from the selected variant's nozzles instead of all variants simultaneously
- Poodle DoubleBell ghost had 3 flames instead of 2 because `engine.thrustTransforms` and `FindTransformsRecursive` discovered transforms from inactive variant GameObjects
- Threads `selectedVariantGameObjects` into `TryBuildEngineFX` and `TryBuildRcsFX`, filtering at 5 transform discovery points

## Changes

- Extract `IsAncestorChainEnabledByVariantRule` (pure, testable) from `IsRendererEnabledByVariantRule`
- Make `IsRendererEnabledByVariantRule` `internal static` for cross-file access
- Filter in `FindNamedTransformsCached`, `ProcessEngineLegacyFx`, `ProcessEngineModelFxEntries`, `ProcessEnginePrefabFxEntries`, `TryBuildRcsFX`
- 12 new tests in `VariantFxFilterTests.cs` (5751 total pass)

## Test plan

- [x] Build succeeds, all 5751 tests pass
- [x] In-game: Poodle DoubleBell ghost shows 2 flames, not 3
- [x] In-game: Poodle SingleBell ghost shows 1 flame
- [x] In-game: Terrier/Mainsail/Skipper with non-default shroud variants -- no extra FX
- [ ] In-game: RV-105 RCS Orthogonal variant -- correct thruster count
- [x] KSP.log shows variant filter log lines on affected parts