### PR TITLE
Fix ghost thermal visuals: clear emissive, decouple from throttle, merge variant fix (#306, #242c)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to Parsek are documented here.
 - `#297` Vessel destruction during tree recording no longer orphans continuation data as a standalone recording.
 - `#304` Stock vessel recordings now show resolved names instead of raw `#autoLOC` keys in the UI, timeline, and logs.
 - `#305` Standalone recordings (rovers, planes) now survive revert-to-launch and show the merge dialog instead of being silently discarded.
-- `#306` Ghost engine nozzles no longer glow red permanently -- inherited prefab emissive values are cleared to black at build time.
+- `#306` Ghost engine nozzles no longer glow red permanently -- inherited prefab emissive values are cleared to black at build time. Thermal glow now driven purely by temperature thresholds (cool <40%, warm 40-80%, hot >80%), decoupled from engine/RCS throttle.
 - Landed ghost terrain correction now clamps downward when terrain height decreased since recording (was only clamping upward, leaving ghosts floating above ground).
 - Test runner window no longer spams IMGUI layout exceptions when opened during flight.
 - `T55` FlagEvents and SegmentEvents are now preserved across tree recording splits and flushes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,8 @@ All notable changes to Parsek are documented here.
 - `#241` Ghost parts with the base/default color variant (e.g., BlackAndWhite fuel tanks) no longer show the wrong variant texture (was Orange).
 - `#297` Vessel destruction during tree recording no longer orphans continuation data as a standalone recording.
 - `#304` Stock vessel recordings now show resolved names instead of raw `#autoLOC` keys in the UI, timeline, and logs.
-- `#306` Ghost engine nozzles no longer glow red permanently -- inherited prefab emissive values are cleared to black at build time.
 - `#305` Standalone recordings (rovers, planes) now survive revert-to-launch and show the merge dialog instead of being silently discarded.
+- `#306` Ghost engine nozzles no longer glow red permanently -- inherited prefab emissive values are cleared to black at build time.
 - Landed ghost terrain correction now clamps downward when terrain height decreased since recording (was only clamping upward, leaving ghosts floating above ground).
 - Test runner window no longer spams IMGUI layout exceptions when opened during flight.
 - `T55` FlagEvents and SegmentEvents are now preserved across tree recording splits and flushes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to Parsek are documented here.
 - `#241` Ghost parts with the base/default color variant (e.g., BlackAndWhite fuel tanks) no longer show the wrong variant texture (was Orange).
 - `#297` Vessel destruction during tree recording no longer orphans continuation data as a standalone recording.
 - `#304` Stock vessel recordings now show resolved names instead of raw `#autoLOC` keys in the UI, timeline, and logs.
+- `#306` Ghost engine nozzles no longer glow red permanently -- inherited prefab emissive values are cleared to black at build time.
 - `#305` Standalone recordings (rovers, planes) now survive revert-to-launch and show the merge dialog instead of being silently discarded.
 - Landed ghost terrain correction now clamps downward when terrain height decreased since recording (was only clamping upward, leaving ghosts floating above ground).
 - Test runner window no longer spams IMGUI layout exceptions when opened during flight.

--- a/Source/Parsek.Tests/PartEventTests.cs
+++ b/Source/Parsek.Tests/PartEventTests.cs
@@ -2056,7 +2056,7 @@ namespace Parsek.Tests
 
             var evt = FlightRecorder.CheckAnimateHeatTransition(
                 key, 450, "shockConeIntake",
-                normalizedHeat: 0.70f,
+                normalizedHeat: 0.85f,
                 levelMap, ut: 100.0, moduleIndex: 0);
 
             Assert.True(evt.HasValue);
@@ -2134,9 +2134,10 @@ namespace Parsek.Tests
             ulong key = FlightRecorder.EncodeEngineKey(450, 0);
             var levelMap = new Dictionary<ulong, HeatLevel>();
 
+            // 0.37 is in the [0.35, 0.40) Cold-Medium hysteresis gap — Cold stays Cold
             var evt = FlightRecorder.CheckAnimateHeatTransition(
                 key, 450, "shockConeIntake",
-                normalizedHeat: 0.20f,
+                normalizedHeat: 0.37f,
                 levelMap, ut: 100.0, moduleIndex: 0);
 
             Assert.Null(evt);
@@ -2162,9 +2163,10 @@ namespace Parsek.Tests
             ulong key = FlightRecorder.EncodeEngineKey(450, 0);
             var levelMap = new Dictionary<ulong, HeatLevel> { { key, HeatLevel.Medium } };
 
+            // 0.37 is in the [0.35, 0.40) hysteresis gap — Medium stays Medium
             var evt = FlightRecorder.CheckAnimateHeatTransition(
                 key, 450, "shockConeIntake",
-                normalizedHeat: 0.20f,
+                normalizedHeat: 0.37f,
                 levelMap, ut: 100.0, moduleIndex: 0);
 
             Assert.Null(evt);
@@ -2177,9 +2179,10 @@ namespace Parsek.Tests
             ulong key = FlightRecorder.EncodeEngineKey(450, 0);
             var levelMap = new Dictionary<ulong, HeatLevel> { { key, HeatLevel.Hot } };
 
+            // 0.77 is in the [0.75, 0.80) hysteresis gap — Hot stays Hot
             var evt = FlightRecorder.CheckAnimateHeatTransition(
                 key, 450, "shockConeIntake",
-                normalizedHeat: 0.63f,
+                normalizedHeat: 0.77f,
                 levelMap, ut: 100.0, moduleIndex: 0);
 
             Assert.Null(evt);

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -233,10 +233,10 @@ namespace Parsek
         private const double roboticSampleIntervalSeconds = 0.25; // 4 Hz
         private const float roboticAngularDeadbandDegrees = 0.5f;
         private const float roboticLinearDeadbandMeters = 0.01f;
-        internal const float AnimateHeatHotThreshold = 0.66f;
-        internal const float AnimateHeatHotFallbackThreshold = 0.60f; // hysteresis: fall from Hot at 0.60, rise at 0.66
-        internal const float AnimateHeatMediumThreshold = 0.33f;
-        internal const float AnimateHeatColdThreshold = 0.10f;
+        internal const float AnimateHeatHotThreshold = 0.80f;
+        internal const float AnimateHeatHotFallbackThreshold = 0.75f; // hysteresis: fall from Hot at 0.75, rise at 0.80
+        internal const float AnimateHeatMediumThreshold = 0.40f;
+        internal const float AnimateHeatMediumFallbackThreshold = 0.35f; // hysteresis: fall from Medium at 0.35, rise at 0.40
         private double lastRecordedUT = -1;
         private Vector3 lastRecordedVelocity;
 
@@ -917,8 +917,8 @@ namespace Parsek
                 current = HeatLevel.Cold;
 
             // Determine target level with hysteresis gaps:
-            // Cold-Medium: rise at 0.33, fall at 0.10 (gap [0.10, 0.33) preserves current)
-            // Medium-Hot:  rise at 0.66, fall at 0.60 (gap [0.60, 0.66) preserves current)
+            // Cold-Medium: rise at 0.40, fall at 0.35 (gap [0.35, 0.40) preserves current)
+            // Medium-Hot:  rise at 0.80, fall at 0.75 (gap [0.75, 0.80) preserves current)
             HeatLevel target;
             if (normalizedHeat >= AnimateHeatHotThreshold)
                 target = HeatLevel.Hot;
@@ -926,14 +926,17 @@ namespace Parsek
             {
                 // In the Medium zone — but check if falling from Hot with hysteresis
                 if (current == HeatLevel.Hot && normalizedHeat >= AnimateHeatHotFallbackThreshold)
-                    target = HeatLevel.Hot; // stay Hot in [0.60, 0.66) gap
+                    target = HeatLevel.Hot; // stay Hot in [0.75, 0.80) gap
                 else
                     target = HeatLevel.Medium;
             }
-            else if (normalizedHeat < AnimateHeatColdThreshold)
-                target = HeatLevel.Cold;
+            else if (normalizedHeat >= AnimateHeatMediumFallbackThreshold)
+            {
+                // In the hysteresis gap [0.35, 0.40) — keep current level
+                target = current;
+            }
             else
-                target = current; // hysteresis gap [0.10, 0.33) — keep current level
+                target = HeatLevel.Cold;
 
             if (target == current)
                 return null;

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -966,19 +966,14 @@ namespace Parsek
                         // engine seeds entirely (PartStateSeeder.EmitEngineSeedEvents).
                         SetEngineEmission(state, evt, System.Math.Max(evt.value, 0.01f));
                         SetEngineAudio(state, evt, System.Math.Max(evt.value, 0.01f));
-                        ApplyHeatState(state, evt, HeatLevel.Hot);
                         break;
                     case PartEventType.EngineShutdown:
                         SetEngineEmission(state, evt, 0f);
                         SetEngineAudio(state, evt, 0f);
-                        // Also reset heat animation glow — engine nozzles stay emissive
-                        // after shutdown if ThermalAnimationCold hasn't fired yet.
-                        ApplyHeatState(state, evt, HeatLevel.Cold);
                         break;
                     case PartEventType.EngineThrottle:
                         SetEngineEmission(state, evt, evt.value);
                         SetEngineAudio(state, evt, evt.value);
-                        ApplyHeatState(state, evt, HeatLevel.Hot);
                         break;
                     case PartEventType.DeployableExtended:
                         ApplyDeployableState(state, evt, deployed: true);
@@ -1037,11 +1032,9 @@ namespace Parsek
                         break;
                     case PartEventType.RCSActivated:
                         SetRcsEmission(state, evt, evt.value);
-                        ApplyHeatState(state, evt, HeatLevel.Hot);
                         break;
                     case PartEventType.RCSStopped:
                         SetRcsEmission(state, evt, 0f);
-                        ApplyHeatState(state, evt, HeatLevel.Cold);
                         break;
                     case PartEventType.RCSThrottle:
                         SetRcsEmission(state, evt, evt.value);

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -779,10 +779,9 @@ namespace Parsek
                     {
                         uint pid; int midx;
                         FlightRecorder.DecodeEngineKey(kvp.Key, out pid, out midx);
-                        // eventType unused by SetEngineEmission/ApplyHeatState — only pid+midx matter
+                        // eventType unused by SetEngineEmission — only pid+midx matter
                         var syntheticEvt = new PartEvent { partPersistentId = pid, moduleIndex = midx };
                         SetEngineEmission(state, syntheticEvt, 1f);
-                        ApplyHeatState(state, syntheticEvt, HeatLevel.Hot);
                         ParsekLog.Verbose("GhostFx",
                             $"Auto-started engine FX for orphan engine key={kvp.Key} pid={pid} midx={midx} " +
                             $"(no engine events in recording — likely debris booster)");
@@ -1038,7 +1037,6 @@ namespace Parsek
                         break;
                     case PartEventType.RCSThrottle:
                         SetRcsEmission(state, evt, evt.value);
-                        ApplyHeatState(state, evt, HeatLevel.Hot);
                         break;
                     case PartEventType.RoboticMotionStarted:
                     case PartEventType.RoboticPositionSample:

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -4028,6 +4028,7 @@ namespace Parsek
             int clonedMaterials = 0;
             int trackedMaterials = 0;
             int skippedRenderers = 0;
+            int clearedEmissives = 0;
 
             for (int i = 0; i < renderers.Length; i++)
             {
@@ -4083,6 +4084,16 @@ namespace Parsek
                     clonedMaterials++;
                     hasTrackedMaterial = true;
 
+                    // Clear inherited emissive immediately — prefab materials may have
+                    // non-zero _EmissiveColor baked in, but KSP's stock thermal system
+                    // drives that property at runtime from part.temperature. Ghost parts
+                    // have no temperature simulation, so cold state = no emissive glow.
+                    if (emissiveProperty != null)
+                    {
+                        materialClone.SetColor(emissiveProperty, Color.black);
+                        clearedEmissives++;
+                    }
+
                     Color coldColor = colorProperty != null
                         ? materialClone.GetColor(colorProperty)
                         : Color.white;
@@ -4090,11 +4101,9 @@ namespace Parsek
                         ? Color.Lerp(coldColor, HeatTintColor, 0.45f)
                         : coldColor;
 
-                    Color coldEmission = emissiveProperty != null
-                        ? materialClone.GetColor(emissiveProperty)
-                        : Color.black;
+                    Color coldEmission = Color.black;
                     Color hotEmission = emissiveProperty != null
-                        ? coldEmission + HeatEmissionColor
+                        ? HeatEmissionColor
                         : coldEmission;
 
                     Color mediumColor = Color.Lerp(coldColor, hotColor, 0.5f);
@@ -4122,6 +4131,9 @@ namespace Parsek
 
             if (trackedMaterials > 0)
             {
+                if (clearedEmissives > 0)
+                    ParsekLog.Verbose("GhostVisual",
+                        $"Part '{partName}' pid={persistentId}: cleared {clearedEmissives} inherited emissive(s) to black");
                 return materialStates;
             }
 
@@ -6027,6 +6039,10 @@ namespace Parsek
                         : null;
                     string emissiveProperty = TryGetHeatEmissiveProperty(materialClone);
 
+                    // Clear inherited emissive — see BuildHeatMaterialStates comment
+                    if (emissiveProperty != null)
+                        materialClone.SetColor(emissiveProperty, Color.black);
+
                     if (colorProperty == null && emissiveProperty == null)
                         continue;
 
@@ -6037,11 +6053,9 @@ namespace Parsek
                         ? Color.Lerp(coldColor, HeatTintColor, 0.45f)
                         : coldColor;
 
-                    Color coldEmission = emissiveProperty != null
-                        ? materialClone.GetColor(emissiveProperty)
-                        : Color.black;
+                    Color coldEmission = Color.black;
                     Color hotEmission = emissiveProperty != null
-                        ? coldEmission + ReentryHotEmissionLow
+                        ? ReentryHotEmissionLow
                         : coldEmission;
 
                     // Medium fields populated for struct consistency but unused by reentry FX,

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -7,6 +7,18 @@ Entries 272–303 (78 bugs, 6 TODOs — mostly resolved) archived in `done/todo-
 
 # Known Bugs
 
+## ~~306. Ghost engine nozzles always glow red~~
+
+**Observed in:** 0.8.0 (2026-04-12). Engine nozzle parts on ghost vessels permanently displayed a red/orange emissive glow, as if overheating. Stock KSP engines do not glow during normal operation -- the emissive channel is driven at runtime by the thermal system (`part.temperature / part.maxTemperature`).
+
+**Root cause:** `BuildHeatMaterialStates` and `CollectReentryGlowMaterials` in `GhostVisualBuilder.cs` read `coldEmission` from the cloned prefab material via `materialClone.GetColor(emissiveProperty)`. Engine nozzle prefab materials have non-zero `_EmissiveColor` values baked in. Since ghost parts have no temperature simulation, this inherited emissive became the permanent baseline -- the nozzle always glowed at the prefab's emissive level.
+
+**Fix:** Force `coldEmission = Color.black` and clear the emissive property on cloned materials immediately after cloning, in both `BuildHeatMaterialStates` (per-part heat) and `CollectReentryGlowMaterials` (whole-ghost reentry glow). Ghost cold state now has zero emissive; heat/reentry systems still animate emissive from black to hot colors when appropriate.
+
+**Status:** Fixed
+
+---
+
 ## ~~304. Raw #autoLOC keys in standalone recording vessel names~~
 
 **Observed in:** Sandbox (2026-04-10). Rovers and stock vessels launched from runway/island airfield showed `#autoLOC_501182` instead of "Crater Crawler" in the Recordings Manager, timeline entries, and log messages.

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -13,7 +13,7 @@ Entries 272–303 (78 bugs, 6 TODOs — mostly resolved) archived in `done/todo-
 
 **Root cause:** `BuildHeatMaterialStates` and `CollectReentryGlowMaterials` in `GhostVisualBuilder.cs` read `coldEmission` from the cloned prefab material via `materialClone.GetColor(emissiveProperty)`. Engine nozzle prefab materials have non-zero `_EmissiveColor` values baked in. Since ghost parts have no temperature simulation, this inherited emissive became the permanent baseline -- the nozzle always glowed at the prefab's emissive level.
 
-**Fix:** Force `coldEmission = Color.black` and clear the emissive property on cloned materials immediately after cloning, in both `BuildHeatMaterialStates` (per-part heat) and `CollectReentryGlowMaterials` (whole-ghost reentry glow). Ghost cold state now has zero emissive; heat/reentry systems still animate emissive from black to hot colors when appropriate.
+**Fix:** Two changes: (1) Force `coldEmission = Color.black` and clear the emissive property on cloned materials immediately after cloning, in both `BuildHeatMaterialStates` (per-part heat) and `CollectReentryGlowMaterials` (whole-ghost reentry glow). (2) Decouple thermal animation from engine/RCS throttle -- removed `ApplyHeatState` calls from `EngineIgnited/Shutdown/Throttle` and `RCSActivated/Stopped` handlers in `GhostPlaybackLogic`. Thermal glow now driven purely by `ThermalAnimationCold/Medium/Hot` events from `ModuleAnimateHeat` polling. Thresholds adjusted: cool <40%, warm 40-80%, hot >80% (was <10%, 33%+, 66%+). Hysteresis gaps [0.35, 0.40) and [0.75, 0.80).
 
 **Status:** Fixed
 


### PR DESCRIPTION
## Summary

- **#306 emissive fix**: Ghost engine nozzles permanently glowed red because cloned materials inherited non-zero `_EmissiveColor` from prefabs. Force `coldEmission = Color.black` and clear emissive on clone in both `BuildHeatMaterialStates` and `CollectReentryGlowMaterials`.
- **#306 thermal decoupling**: Removed `ApplyHeatState` calls from `EngineIgnited/Shutdown/Throttle` and `RCSActivated/Stopped` handlers. Ghost thermal glow is now driven purely by `ModuleAnimateHeat` temperature threshold events.
- **#306 threshold adjustment**: Changed heat thresholds to cool <40%, warm 40-80%, hot >80% (was <10%, 33%+, 66%+). Hysteresis gaps at [0.35, 0.40) and [0.75, 0.80).
- **#242c merge**: Variant geometry filtering for engine/RCS FX (fixes Poodle 3-flame regression).

## Test plan

- [x] 5753 unit tests pass
- [x] No log spam from new emissive clear logging
- [x] Ghost engine nozzles do not glow red at rest
- [x] Reentry glow still activates during high-speed atmospheric flight
- [x] Poodle ghost shows 2 flames, not 3
- [ ] RAPIER mode-switch FX still correct