### PR TITLE
Fix #307 #308 #309 #310 #311: rewind save loss, crew dialog auto-assign, mesh-object positioning overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to Parsek are documented here.
 ### Bug Fixes
 
 - `#307` Rewind (R button) now works for recordings committed after an in-flight vessel switch -- the rewind save is now copied to the tree root in both vessel-switch flush paths.
+- `#308` Reserved kerbals no longer appear auto-assigned in the VAB/SPH crew dialog -- new Harmony patch replaces reserved crew with their stand-ins before the dialog builds.
 - `#241` Ghost parts with the base/default color variant (e.g., BlackAndWhite fuel tanks) no longer show the wrong variant texture (was Orange).
 - `#297` Vessel destruction during tree recording no longer orphans continuation data as a standalone recording.
 - `#304` Stock vessel recordings now show resolved names instead of raw `#autoLOC` keys in the UI, timeline, and logs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ All notable changes to Parsek are documented here.
 
 - `#307` Rewind (R button) now works for recordings committed after an in-flight vessel switch -- the rewind save is now copied to the tree root in both vessel-switch flush paths.
 - `#308` Reserved kerbals no longer appear auto-assigned in the VAB/SPH crew dialog -- new Harmony patch replaces reserved crew with their stand-ins before the dialog builds.
+- `#309` Rovers and ghosts recorded on the Island Airfield (or launchpad/KSC buildings) no longer spawn 19 m underground -- recording now captures the true surface height from KSP's raycast-derived `vessel.terrainAltitude` instead of PQS-only terrain, and spawn/ghost altitudes trust the recorded value with only an underground safety floor against PQS.
+- `#310` Spawn collision detection now uses `Physics.OverlapBox` against real part colliders instead of a 2 m-cube blocker approximation, so large vessels (stations, planes, carriers) block spawns correctly.
+- `#311` Walkback spawns on diagonally-descending trajectories are now snapped to the true surface via top-down `Physics.Raycast`, preventing mid-air spawns that fall.
 - `#241` Ghost parts with the base/default color variant (e.g., BlackAndWhite fuel tanks) no longer show the wrong variant texture (was Orange).
 - `#297` Vessel destruction during tree recording no longer orphans continuation data as a standalone recording.
 - `#304` Stock vessel recordings now show resolved names instead of raw `#autoLOC` keys in the UI, timeline, and logs.
@@ -62,7 +65,7 @@ Dev notes: technical narratives for the fixes below live in `docs/dev/todo-and-k
 ### Bug Fixes — Name resolution & ghost positioning
 
 - Vessel names in split/EVA/background recordings now resolve KSP localization tags (e.g., `#autoLOC_501232` → "Kerbal X") instead of displaying raw tags.
-- `#282` Landed ghosts now sit at their natural recorded height above terrain instead of floating 4m up; uses `TerrainCorrector.ComputeCorrectedAltitude` with `Recording.TerrainHeightAtEnd` when available (NaN fallback preserves old behavior for legacy recordings).
+- `#282` Landed ghosts now sit at their natural recorded height above terrain instead of floating 4m up, using `Recording.TerrainHeightAtEnd` when available (NaN fallback preserves old behavior for legacy recordings).
 - `#BugC` Switching to a spawned vessel no longer fills empty seats with extra kerbals — crew swap skips Parsek-spawned vessels entirely.
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- `#307` Rewind (R button) now works for recordings committed after an in-flight vessel switch -- the rewind save is now copied to the tree root in both vessel-switch flush paths.
 - `#241` Ghost parts with the base/default color variant (e.g., BlackAndWhite fuel tanks) no longer show the wrong variant texture (was Orange).
 - `#297` Vessel destruction during tree recording no longer orphans continuation data as a standalone recording.
 - `#304` Stock vessel recordings now show resolved names instead of raw `#autoLOC` keys in the UI, timeline, and logs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to Parsek are documented here.
 - `#309` Rovers and ghosts recorded on the Island Airfield (or launchpad/KSC buildings) no longer spawn 19 m underground -- recording now captures the true surface height from KSP's raycast-derived `vessel.terrainAltitude` instead of PQS-only terrain, and spawn/ghost altitudes trust the recorded value with only an underground safety floor against PQS.
 - `#310` Spawn collision detection now uses `Physics.OverlapBox` against real part colliders instead of a 2 m-cube blocker approximation, so large vessels (stations, planes, carriers) block spawns correctly.
 - `#311` Walkback spawns on diagonally-descending trajectories are now snapped to the true surface via top-down `Physics.Raycast`, preventing mid-air spawns that fall.
+- `#312` Placing multiple showcase ghosts of the same vessel type near each other no longer causes each new spawn to destroy the previous one -- the duplicate-blocker recovery now requires a PID match against the recording's own previous spawn, so siblings correctly fall through to walkback.
 - `#241` Ghost parts with the base/default color variant (e.g., BlackAndWhite fuel tanks) no longer show the wrong variant texture (was Orange).
 - `#297` Vessel destruction during tree recording no longer orphans continuation data as a standalone recording.
 - `#304` Stock vessel recordings now show resolved names instead of raw `#autoLOC` keys in the UI, timeline, and logs.

--- a/Source/Parsek.Tests/CrewAutoAssignPatchTests.cs
+++ b/Source/Parsek.Tests/CrewAutoAssignPatchTests.cs
@@ -1,0 +1,203 @@
+using System.Collections.Generic;
+using System.Linq;
+using Parsek.Patches;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Tests for CrewAutoAssignPatch.DecideSlotAction — the pure decision method
+    /// that determines whether a crew slot should be kept, swapped with a stand-in,
+    /// or cleared when the crew assignment dialog is refreshed.
+    /// </summary>
+    [Collection("Sequential")]
+    public class CrewAutoAssignPatchTests : System.IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public CrewAutoAssignPatchTests()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+            RecordingStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+            RecordingStore.SuppressLogging = false;
+            RecordingStore.ResetForTesting();
+        }
+
+        private Recording MakeRecording(string vesselName, string[] crew,
+            TerminalState terminal, double endUT)
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            var part = snapshot.AddNode("PART");
+            foreach (var c in crew)
+                part.AddValue("crew", c);
+
+            var rec = new Recording
+            {
+                VesselName = vesselName,
+                VesselSnapshot = snapshot,
+                TerminalStateValue = terminal,
+                ExplicitStartUT = 0,
+                ExplicitEndUT = endUT,
+            };
+
+            rec.CrewEndStates = new Dictionary<string, KerbalEndState>();
+            var endCrewSet = new HashSet<string>(crew);
+            for (int i = 0; i < crew.Length; i++)
+            {
+                rec.CrewEndStates[crew[i]] = KerbalsModule.InferCrewEndState(
+                    crew[i], terminal, endCrewSet);
+            }
+
+            return rec;
+        }
+
+        [Fact]
+        public void DecideSlotAction_NullOrEmptyName_ReturnsKeep()
+        {
+            var kerbals = new KerbalsModule();
+            var replacements = new Dictionary<string, string>();
+
+            var action1 = CrewAutoAssignPatch.DecideSlotAction(
+                null, kerbals, replacements, out _);
+            var action2 = CrewAutoAssignPatch.DecideSlotAction(
+                "", kerbals, replacements, out _);
+
+            Assert.Equal(CrewAutoAssignPatch.SlotAction.Keep, action1);
+            Assert.Equal(CrewAutoAssignPatch.SlotAction.Keep, action2);
+        }
+
+        [Fact]
+        public void DecideSlotAction_NullKerbalsModule_ReturnsKeep()
+        {
+            var replacements = new Dictionary<string, string>();
+
+            var action = CrewAutoAssignPatch.DecideSlotAction(
+                "Jeb", null, replacements, out _);
+
+            Assert.Equal(CrewAutoAssignPatch.SlotAction.Keep, action);
+        }
+
+        [Fact]
+        public void DecideSlotAction_UnreservedKerbal_ReturnsKeep()
+        {
+            var rec = MakeRecording("Ship", new[] { "Jeb" },
+                TerminalState.Recovered, 2000);
+            RecordingStore.AddRecordingWithTreeForTesting(rec);
+
+            var kerbals = KerbalsTestHelper.RecalculateFromStore();
+            var replacements = new Dictionary<string, string> { { "Jeb", "StandIn1" } };
+
+            // Val is not reserved
+            var action = CrewAutoAssignPatch.DecideSlotAction(
+                "Val", kerbals, replacements, out string standIn);
+
+            Assert.Equal(CrewAutoAssignPatch.SlotAction.Keep, action);
+            Assert.Null(standIn);
+        }
+
+        [Fact]
+        public void DecideSlotAction_ReservedWithStandIn_ReturnsSwap()
+        {
+            var rec = MakeRecording("Ship", new[] { "Jeb" },
+                TerminalState.Recovered, 2000);
+            RecordingStore.AddRecordingWithTreeForTesting(rec);
+
+            var kerbals = KerbalsTestHelper.RecalculateFromStore();
+            var replacements = new Dictionary<string, string> { { "Jeb", "StandIn1" } };
+
+            var action = CrewAutoAssignPatch.DecideSlotAction(
+                "Jeb", kerbals, replacements, out string standIn);
+
+            Assert.Equal(CrewAutoAssignPatch.SlotAction.Swap, action);
+            Assert.Equal("StandIn1", standIn);
+        }
+
+        [Fact]
+        public void DecideSlotAction_ReservedNoStandIn_ReturnsClear()
+        {
+            var rec = MakeRecording("Ship", new[] { "Jeb" },
+                TerminalState.Recovered, 2000);
+            RecordingStore.AddRecordingWithTreeForTesting(rec);
+
+            var kerbals = KerbalsTestHelper.RecalculateFromStore();
+            var replacements = new Dictionary<string, string>(); // no stand-in
+
+            var action = CrewAutoAssignPatch.DecideSlotAction(
+                "Jeb", kerbals, replacements, out string standIn);
+
+            Assert.Equal(CrewAutoAssignPatch.SlotAction.Clear, action);
+            Assert.Null(standIn);
+        }
+
+        [Fact]
+        public void DecideSlotAction_ReservedNullReplacements_ReturnsClear()
+        {
+            var rec = MakeRecording("Ship", new[] { "Jeb" },
+                TerminalState.Recovered, 2000);
+            RecordingStore.AddRecordingWithTreeForTesting(rec);
+
+            var kerbals = KerbalsTestHelper.RecalculateFromStore();
+
+            var action = CrewAutoAssignPatch.DecideSlotAction(
+                "Jeb", kerbals, null, out string standIn);
+
+            Assert.Equal(CrewAutoAssignPatch.SlotAction.Clear, action);
+            Assert.Null(standIn);
+        }
+
+        [Fact]
+        public void DecideSlotAction_MultipleCrew_CorrectlyClassifiesEach()
+        {
+            var rec = MakeRecording("Ship", new[] { "Jeb", "Bill" },
+                TerminalState.Recovered, 2000);
+            RecordingStore.AddRecordingWithTreeForTesting(rec);
+
+            var kerbals = KerbalsTestHelper.RecalculateFromStore();
+            // Only Jeb has a stand-in; Bill does not
+            var replacements = new Dictionary<string, string> { { "Jeb", "StandIn1" } };
+
+            var jebAction = CrewAutoAssignPatch.DecideSlotAction(
+                "Jeb", kerbals, replacements, out string jebStandIn);
+            var billAction = CrewAutoAssignPatch.DecideSlotAction(
+                "Bill", kerbals, replacements, out string billStandIn);
+            var valAction = CrewAutoAssignPatch.DecideSlotAction(
+                "Val", kerbals, replacements, out string valStandIn);
+
+            Assert.Equal(CrewAutoAssignPatch.SlotAction.Swap, jebAction);
+            Assert.Equal("StandIn1", jebStandIn);
+
+            Assert.Equal(CrewAutoAssignPatch.SlotAction.Clear, billAction);
+            Assert.Null(billStandIn);
+
+            Assert.Equal(CrewAutoAssignPatch.SlotAction.Keep, valAction);
+            Assert.Null(valStandIn);
+        }
+
+        [Fact]
+        public void DecideSlotAction_ReservedWithEmptyStandInName_ReturnsClear()
+        {
+            var rec = MakeRecording("Ship", new[] { "Jeb" },
+                TerminalState.Recovered, 2000);
+            RecordingStore.AddRecordingWithTreeForTesting(rec);
+
+            var kerbals = KerbalsTestHelper.RecalculateFromStore();
+            // Stand-in name is empty string — treat as no stand-in
+            var replacements = new Dictionary<string, string> { { "Jeb", "" } };
+
+            var action = CrewAutoAssignPatch.DecideSlotAction(
+                "Jeb", kerbals, replacements, out string standIn);
+
+            Assert.Equal(CrewAutoAssignPatch.SlotAction.Clear, action);
+            Assert.Null(standIn);
+        }
+    }
+}

--- a/Source/Parsek.Tests/DuplicateBlockerRecoveryTests.cs
+++ b/Source/Parsek.Tests/DuplicateBlockerRecoveryTests.cs
@@ -34,56 +34,112 @@ namespace Parsek.Tests
 
         // ────────────────────────────────────────────────────────────
         //  ShouldRecoverBlockerVessel — pure decision method
+        //
+        //  #112 original scenario: a Parsek-spawned vessel is restored from a
+        //  quicksave and collides with the fresh spawn. Recovery is the right move.
+        //
+        //  #312 regression: the original version matched by NAME only, so four
+        //  "Crater Crawler" showcase recordings on the runway cannibalized each
+        //  other -- each new spawn found the previous as a "duplicate" and
+        //  destroyed it. New rule: blocker PID must match this recording's OWN
+        //  SpawnedVesselPersistentId. Siblings fall through to walkback.
         // ────────────────────────────────────────────────────────────
 
-        [Fact]
-        public void ShouldRecoverBlockerVessel_SameName_ReturnsTrue()
+        private static Recording MakeRecordedSpawn(string name, uint spawnedPid)
         {
-            Assert.True(VesselSpawner.ShouldRecoverBlockerVessel("Aeris 4A", "Aeris 4A"));
+            return new Recording
+            {
+                VesselName = name,
+                VesselSpawned = true,
+                SpawnedVesselPersistentId = spawnedPid,
+            };
+        }
+
+        [Fact]
+        public void ShouldRecoverBlockerVessel_SelfPidMatch_ReturnsTrue()
+        {
+            // #112 quicksave-duplicate: KSP restored our own spawn with the same PID.
+            var rec = MakeRecordedSpawn("Aeris 4A", spawnedPid: 12345);
+            Assert.True(VesselSpawner.ShouldRecoverBlockerVessel(rec, "Aeris 4A", "Aeris 4A", blockerPid: 12345));
+        }
+
+        [Fact]
+        public void ShouldRecoverBlockerVessel_SiblingRecordingPid_ReturnsFalse_Bug312()
+        {
+            // #312: two recordings of the same vessel type on the runway. The blocker's
+            // PID belongs to a DIFFERENT recording, so recovery would destroy sibling
+            // work. Must return false so the caller falls through to walkback.
+            var rec = MakeRecordedSpawn("Crater Crawler", spawnedPid: 11111);
+            Assert.False(VesselSpawner.ShouldRecoverBlockerVessel(rec, "Crater Crawler", "Crater Crawler", blockerPid: 22222));
         }
 
         [Fact]
         public void ShouldRecoverBlockerVessel_DifferentName_ReturnsFalse()
         {
-            Assert.False(VesselSpawner.ShouldRecoverBlockerVessel("Kerbal X", "Aeris 4A"));
+            var rec = MakeRecordedSpawn("Aeris 4A", spawnedPid: 12345);
+            Assert.False(VesselSpawner.ShouldRecoverBlockerVessel(rec, "Kerbal X", "Aeris 4A", blockerPid: 12345));
+        }
+
+        [Fact]
+        public void ShouldRecoverBlockerVessel_NotYetSpawned_ReturnsFalse()
+        {
+            // First-spawn case: recording has never spawned before (VesselSpawned=false).
+            // There is no "previous spawn" to recover, so the blocker cannot be a #112 duplicate.
+            var rec = new Recording { VesselName = "Aeris 4A" }; // VesselSpawned=false, SpawnedVesselPersistentId=0
+            Assert.False(VesselSpawner.ShouldRecoverBlockerVessel(rec, "Aeris 4A", "Aeris 4A", blockerPid: 99999));
+        }
+
+        [Fact]
+        public void ShouldRecoverBlockerVessel_ZeroSpawnedPid_ReturnsFalse()
+        {
+            // Defensive: VesselSpawned=true but SpawnedVesselPersistentId=0 should never
+            // match any real blocker PID.
+            var rec = new Recording { VesselName = "Aeris 4A", VesselSpawned = true };
+            Assert.False(VesselSpawner.ShouldRecoverBlockerVessel(rec, "Aeris 4A", "Aeris 4A", blockerPid: 0));
+        }
+
+        [Fact]
+        public void ShouldRecoverBlockerVessel_NullRecording_ReturnsFalse()
+        {
+            Assert.False(VesselSpawner.ShouldRecoverBlockerVessel(null, "Aeris 4A", "Aeris 4A", blockerPid: 12345));
         }
 
         [Fact]
         public void ShouldRecoverBlockerVessel_NullBlockerName_ReturnsFalse()
         {
-            Assert.False(VesselSpawner.ShouldRecoverBlockerVessel(null, "Aeris 4A"));
+            var rec = MakeRecordedSpawn("Aeris 4A", spawnedPid: 12345);
+            Assert.False(VesselSpawner.ShouldRecoverBlockerVessel(rec, null, "Aeris 4A", blockerPid: 12345));
         }
 
         [Fact]
         public void ShouldRecoverBlockerVessel_NullRecordingName_ReturnsFalse()
         {
-            Assert.False(VesselSpawner.ShouldRecoverBlockerVessel("Aeris 4A", null));
+            var rec = MakeRecordedSpawn("Aeris 4A", spawnedPid: 12345);
+            Assert.False(VesselSpawner.ShouldRecoverBlockerVessel(rec, "Aeris 4A", null, blockerPid: 12345));
         }
 
         [Fact]
         public void ShouldRecoverBlockerVessel_EmptyBlockerName_ReturnsFalse()
         {
-            Assert.False(VesselSpawner.ShouldRecoverBlockerVessel("", "Aeris 4A"));
+            var rec = MakeRecordedSpawn("Aeris 4A", spawnedPid: 12345);
+            Assert.False(VesselSpawner.ShouldRecoverBlockerVessel(rec, "", "Aeris 4A", blockerPid: 12345));
         }
 
         [Fact]
         public void ShouldRecoverBlockerVessel_EmptyRecordingName_ReturnsFalse()
         {
-            Assert.False(VesselSpawner.ShouldRecoverBlockerVessel("Aeris 4A", ""));
-        }
-
-        [Fact]
-        public void ShouldRecoverBlockerVessel_BothEmpty_ReturnsFalse()
-        {
-            Assert.False(VesselSpawner.ShouldRecoverBlockerVessel("", ""));
+            var rec = MakeRecordedSpawn("Aeris 4A", spawnedPid: 12345);
+            Assert.False(VesselSpawner.ShouldRecoverBlockerVessel(rec, "Aeris 4A", "", blockerPid: 12345));
         }
 
         [Fact]
         public void ShouldRecoverBlockerVessel_CaseSensitive_ReturnsFalse()
         {
-            // Ordinal comparison — both names should already be resolved via
-            // ResolveLocalizedName, so case differences indicate different vessels
-            Assert.False(VesselSpawner.ShouldRecoverBlockerVessel("aeris 4a", "Aeris 4A"));
+            // Ordinal comparison -- both names are already resolved via
+            // ResolveLocalizedName at the call site, so case differences signal
+            // different vessels.
+            var rec = MakeRecordedSpawn("Aeris 4A", spawnedPid: 12345);
+            Assert.False(VesselSpawner.ShouldRecoverBlockerVessel(rec, "aeris 4a", "Aeris 4A", blockerPid: 12345));
         }
 
         // ────────────────────────────────────────────────────────────
@@ -101,12 +157,18 @@ namespace Parsek.Tests
         public void DuplicateBlockerRecovered_PreventsSecondRecoveryCheck()
         {
             // Simulates the guard in CheckSpawnCollisions: once DuplicateBlockerRecovered
-            // is set, the name-match check is not entered regardless of match
-            var rec = new Recording { DuplicateBlockerRecovered = true };
+            // is set, the recovery check is not entered regardless of match.
+            var rec = new Recording
+            {
+                DuplicateBlockerRecovered = true,
+                VesselSpawned = true,
+                SpawnedVesselPersistentId = 12345,
+                VesselName = "Aeris 4A",
+            };
 
-            // Even with a matching name, the guard prevents entry
+            // Even with a matching PID + name, the guard prevents entry
             bool wouldRecover = !rec.DuplicateBlockerRecovered
-                && VesselSpawner.ShouldRecoverBlockerVessel("Aeris 4A", "Aeris 4A");
+                && VesselSpawner.ShouldRecoverBlockerVessel(rec, "Aeris 4A", "Aeris 4A", blockerPid: 12345);
             Assert.False(wouldRecover);
         }
 

--- a/Source/Parsek.Tests/SpawnCollisionWiringTests.cs
+++ b/Source/Parsek.Tests/SpawnCollisionWiringTests.cs
@@ -261,22 +261,16 @@ namespace Parsek.Tests
         #region TerrainCorrector integration
 
         [Fact]
-        public void TerrainCorrection_AppliedForSurfaceSpawn()
+        public void TerrainCorrection_ShouldCorrectForSurfaceSpawn()
         {
             // ShouldCorrectTerrain returns true for Landed + valid terrain height.
-            // ComputeCorrectedAltitude preserves clearance above terrain.
+            // (ComputeCorrectedAltitude was removed in #309 — terrain-relative
+            // correction broke mesh-object positioning. See
+            // ClampAltitudeForLanded for the new preserve-recorded-altitude behavior.)
             bool shouldCorrect = TerrainCorrector.ShouldCorrectTerrain(
                 TerminalState.Landed, 65.0);
 
             Assert.True(shouldCorrect);
-
-            // Recorded: altitude=66, terrainHeight=65 -> clearance=1m
-            // Current terrain=70 -> corrected altitude=71m
-            double corrected = TerrainCorrector.ComputeCorrectedAltitude(70.0, 66.0, 65.0);
-
-            Assert.Equal(71.0, corrected);
-            Assert.Contains(logLines, l =>
-                l.Contains("[TerrainCorrect]") && l.Contains("corrected=71"));
         }
 
         [Fact]

--- a/Source/Parsek.Tests/SpawnSafetyNetTests.cs
+++ b/Source/Parsek.Tests/SpawnSafetyNetTests.cs
@@ -977,90 +977,84 @@ namespace Parsek.Tests
         }
 
         // ── ClampAltitudeForLanded (pure, testable without CelestialBody) ──
+        //
+        // NEW SEMANTICS (#309 mesh-object positioning fix):
+        //   The recorded altitude is trusted — it's where the vessel came to rest
+        //   per the LANDED terminal state. We no longer down-clamp to PQS terrain,
+        //   because body.TerrainAltitude() is blind to mesh objects (Island
+        //   Airfield, launchpad, KSC buildings) and the old clamp buried any
+        //   vessel recorded on a raised surface 19m below the runway. The only
+        //   case where the clamp fires is when the recorded altitude is below
+        //   (PQS terrain + UndergroundSafetyFloorMeters), meaning PQS terrain
+        //   has shifted UP since recording (rare: KSP update / terrain mod).
 
         [Fact]
-        public void ClampAltitudeForLanded_HighAboveTerrain_ClampsDown()
+        public void ClampAltitudeForLanded_HighAboveTerrain_Preserved_Airfield()
         {
-            // Vessel at 500m, terrain at 67m → clamp down to 67 + LandedClearanceMeters.
-            // #231 regression guard (original down-clamp behavior preserved).
-            double target = 67.0 + VesselSpawner.LandedClearanceMeters;
-            double result = VesselSpawner.ClampAltitudeForLanded(500.0, 67.0, 3, "Kerbal X");
-            Assert.Equal(target, result);
-            Assert.Contains(logLines, l =>
-                l.Contains("Clamped altitude") && l.Contains("LANDED")
-                && l.Contains("down-clamp"));
+            // Butterfly Rover on the Island Airfield: recorded alt=133.9m, PQS
+            // terrain beneath the airfield mesh=114.9m, mesh offset ~19m. The
+            // old down-clamp buried the rover 17m underground. New behavior:
+            // preserve the recorded altitude; KSP CheckGroundCollision will
+            // settle against real colliders (airfield runway) after spawn.
+            double result = VesselSpawner.ClampAltitudeForLanded(133.9, 114.9, 2, "Butterfly Rover");
+            Assert.Equal(133.9, result);
+            Assert.DoesNotContain(logLines, l => l.Contains("below-pqs-floor"));
         }
 
         [Fact]
-        public void ClampAltitudeForLanded_BelowTerrain_ClampsUpWithUndergroundReason()
+        public void ClampAltitudeForLanded_BelowTerrain_PushedUp()
         {
-            // Vessel at -5m, terrain at 67m → clamp up, reason "underground".
-            double target = 67.0 + VesselSpawner.LandedClearanceMeters;
+            // Vessel at -5m, PQS terrain at 67m → below safety floor, push up.
+            // This is the only case where we clamp now.
+            double expected = 67.0 + VesselSpawner.UndergroundSafetyFloorMeters;
             double result = VesselSpawner.ClampAltitudeForLanded(-5.0, 67.0, 3, "Kerbal X");
-            Assert.Equal(target, result);
+            Assert.Equal(expected, result);
             Assert.Contains(logLines, l =>
-                l.Contains("Clamped altitude") && l.Contains("underground"));
+                l.Contains("Clamped altitude") && l.Contains("below-pqs-floor"));
         }
 
         [Fact]
-        public void ClampAltitudeForLanded_LowClearanceGap_ClampsUp_Bug282()
+        public void ClampAltitudeForLanded_LowClearanceAboveTerrain_PushedToSafetyFloor_Bug282()
         {
-            // Bug #282 regression guard — the exact 2026-04-09 s33 playtest numbers.
-            // KSP.log:13768: vessel alt=176.5m, terrain=175.6m, clearance=0.9m.
-            // The original implementation left alt ∈ [terrainAlt, target) unchanged
-            // on the assumption that "alt ≥ terrain ⇒ not underground". That's
-            // wrong for any vessel with the command pod on top — the Mk1-3's
-            // lowest mesh vertex is ~1.77 m below the root origin, so a 0.9 m
-            // clearance buries the pod by ~0.87 m. The gap is now closed: any
-            // alt < target is clamped up, with reason "low-clearance" if alt is
-            // above terrain (as in the playtest) or "underground" if below.
-            double target = 175.6 + VesselSpawner.LandedClearanceMeters;
+            // #282 scenario: vessel recorded 0.9m above PQS terrain (Mk1-3 pod root
+            // with wheels/legs extending below). This is below the 2m underground
+            // safety floor, so we push up to terrain+2m. The safety floor handles
+            // the "bury the pod" case without the old aggressive blanket down-clamp
+            // that was breaking mesh-object positioning (Island Airfield, launchpad).
+            double expected = 175.6 + VesselSpawner.UndergroundSafetyFloorMeters;
             double result = VesselSpawner.ClampAltitudeForLanded(176.5, 175.6, 41, "Kerbal X");
-            Assert.Equal(target, result);
+            Assert.Equal(expected, result);
             Assert.Contains(logLines, l =>
-                l.Contains("Clamped altitude") && l.Contains("low-clearance"));
-            // Must NOT use the "underground" reason — alt is above terrain, just low.
-            Assert.DoesNotContain(logLines, l =>
-                l.Contains("Clamped altitude") && l.Contains("underground"));
+                l.Contains("Clamped altitude") && l.Contains("below-pqs-floor"));
         }
 
         [Fact]
-        public void ClampAltitudeForLanded_AtTarget_Unchanged()
+        public void ClampAltitudeForLanded_AtSafetyFloor_Preserved()
         {
-            double target = 67.0 + VesselSpawner.LandedClearanceMeters;
-            double result = VesselSpawner.ClampAltitudeForLanded(target, 67.0, 3, "Kerbal X");
-            Assert.Equal(target, result);
-            // Boundary: alt == target, no log line (no clamping happened).
+            // alt == safetyFloor exactly — treat as preserved (boundary).
+            double safetyFloor = 67.0 + VesselSpawner.UndergroundSafetyFloorMeters;
+            double result = VesselSpawner.ClampAltitudeForLanded(safetyFloor, 67.0, 3, "Kerbal X");
+            Assert.Equal(safetyFloor, result);
             Assert.DoesNotContain(logLines, l =>
-                l.Contains("Clamped altitude for LANDED spawn #3"));
+                l.Contains("below-pqs-floor"));
         }
 
         [Fact]
-        public void ClampAltitudeForLanded_JustAboveTerrainAtOneCm_ClampsUp()
+        public void ClampAltitudeForLanded_JustBelowSafetyFloor_PushedUp()
         {
-            // Boundary between "underground" and "low-clearance": 1 cm above terrain
-            // is still firmly in the gap, so reason should be "low-clearance".
-            double target = 67.0 + VesselSpawner.LandedClearanceMeters;
-            double result = VesselSpawner.ClampAltitudeForLanded(67.01, 67.0, 3, "Kerbal X");
-            Assert.Equal(target, result);
+            // 1 cm below the safety floor → push up by 1 cm to the floor.
+            double safetyFloor = 67.0 + VesselSpawner.UndergroundSafetyFloorMeters;
+            double result = VesselSpawner.ClampAltitudeForLanded(safetyFloor - 0.01, 67.0, 3, "Kerbal X");
+            Assert.Equal(safetyFloor, result);
             Assert.Contains(logLines, l =>
-                l.Contains("Clamped altitude") && l.Contains("low-clearance"));
+                l.Contains("Clamped altitude") && l.Contains("below-pqs-floor"));
         }
 
         [Fact]
-        public void LandedGhostClearanceMeters_IsLargerThanSpawnClearance_Bug282()
+        public void UndergroundSafetyFloorMeters_IsPinned()
         {
-            // Bug #282: ghost playback uses a larger clearance than spawn because
-            // ghosts are kinematic (no physics drop damage). The split-constant
-            // justification from the plan review — if this assertion flips,
-            // either someone unified the constants (should trip the review)
-            // or the physics drop concern from #231 was revisited.
-            Assert.True(VesselSpawner.LandedGhostClearanceMeters
-                > VesselSpawner.LandedClearanceMeters,
-                "Ghost clearance must exceed spawn clearance — see #282 revised plan " +
-                "and #231 physics-damage constraint.");
-            // Pin values so unintended drift is caught.
-            Assert.Equal(2.0, VesselSpawner.LandedClearanceMeters);
+            // Pin the constant so unintended drift is caught in review.
+            Assert.Equal(2.0, VesselSpawner.UndergroundSafetyFloorMeters);
             Assert.Equal(4.0, VesselSpawner.LandedGhostClearanceMeters);
         }
 

--- a/Source/Parsek.Tests/TerrainCorrectorTests.cs
+++ b/Source/Parsek.Tests/TerrainCorrectorTests.cs
@@ -27,48 +27,11 @@ namespace Parsek.Tests
             RecordingStore.SuppressLogging = false;
         }
 
-        #region ComputeCorrectedAltitude
-
-        [Fact]
-        public void ComputeCorrectedAltitude_TerrainHigher_AltitudeIncreases()
-        {
-            // recordedAlt=100, recordedTerrain=90, currentTerrain=100
-            // Expected: 100 + (100-90) = 110
-            // Guards: vessel clips into ground when terrain rises
-            double result = TerrainCorrector.ComputeCorrectedAltitude(100.0, 100.0, 90.0);
-            Assert.Equal(110.0, result);
-
-            Assert.Contains(logLines, l =>
-                l.Contains("[TerrainCorrect]") && l.Contains("corrected=110"));
-        }
-
-        [Fact]
-        public void ComputeCorrectedAltitude_TerrainLower_AltitudeDecreases()
-        {
-            // recordedAlt=100, recordedTerrain=90, currentTerrain=80
-            // Expected: 80 + (100-90) = 90
-            // Guards: vessel floats when terrain drops
-            double result = TerrainCorrector.ComputeCorrectedAltitude(80.0, 100.0, 90.0);
-            Assert.Equal(90.0, result);
-
-            Assert.Contains(logLines, l =>
-                l.Contains("[TerrainCorrect]") && l.Contains("corrected=90"));
-        }
-
-        [Fact]
-        public void ComputeCorrectedAltitude_TerrainUnchanged_AltitudeSame()
-        {
-            // recordedAlt=100, recordedTerrain=90, currentTerrain=90
-            // Expected: 90 + (100-90) = 100
-            // Guards: unnecessary correction
-            double result = TerrainCorrector.ComputeCorrectedAltitude(90.0, 100.0, 90.0);
-            Assert.Equal(100.0, result);
-
-            Assert.Contains(logLines, l =>
-                l.Contains("[TerrainCorrect]") && l.Contains("corrected=100"));
-        }
-
-        #endregion
+        // ComputeCorrectedAltitude removed (#309): terrain-relative correction buried
+        // vessels recorded on mesh objects (Island Airfield, launchpad, KSC buildings)
+        // because body.TerrainAltitude() is PQS-only and blind to placed colliders.
+        // Replaced by "trust recorded altitude + underground safety floor" semantics
+        // in VesselSpawner.ClampAltitudeForLanded and ParsekFlight.ApplyLandedGhostClearance.
 
         #region ShouldCorrectTerrain
 

--- a/Source/Parsek/InGameTests/RuntimeTests.cs
+++ b/Source/Parsek/InGameTests/RuntimeTests.cs
@@ -1434,6 +1434,86 @@ namespace Parsek.InGameTests
                     $"(expected={savedReplacements.Count}, actual={CrewReservationManager.CrewReplacements.Count})");
             }
         }
+
+        [InGameTest(Category = "CrewReservation", Scene = GameScenes.SPACECENTER,
+            Description = "#308 CrewAutoAssignPatch.ApplyCrewAssignmentSwaps replaces reserved crew with stand-ins in a VesselCrewManifest")]
+        public void CrewAutoAssignPatch_SwapsReservedCrew()
+        {
+            // Construct a synthetic VesselCrewManifest with one command pod and
+            // a reserved kerbal pre-assigned (simulating KSP's DefaultCrewForVessel
+            // auto-assign). Then call the extracted ApplyCrewAssignmentSwaps logic
+            // and verify the reserved name was replaced with the registered stand-in.
+
+            var replacements = CrewReservationManager.CrewReplacements;
+            if (replacements.Count == 0)
+            {
+                InGameAssert.Skip("needs at least one active crew reservation to exercise the swap path");
+                return;
+            }
+
+            // Pick a reservation whose stand-in is Available (so the patch can place it).
+            var roster = HighLogic.CurrentGame?.CrewRoster;
+            if (roster == null)
+            {
+                InGameAssert.Skip("No crew roster");
+                return;
+            }
+            string reservedName = null;
+            string standInName = null;
+            foreach (var kvp in replacements)
+            {
+                var pcmStandIn = roster[kvp.Value];
+                if (pcmStandIn != null && pcmStandIn.rosterStatus == ProtoCrewMember.RosterStatus.Available)
+                {
+                    reservedName = kvp.Key;
+                    standInName = kvp.Value;
+                    break;
+                }
+            }
+            if (reservedName == null)
+            {
+                InGameAssert.Skip("no active reservation with an Available stand-in in the roster");
+                return;
+            }
+
+            // Resolve a stock command pod with at least one crew seat. Try v2 first,
+            // then fall back to the original Mk1.
+            AvailablePart pod = PartLoader.getPartInfoByName("mk1pod.v2")
+                ?? PartLoader.getPartInfoByName("mk1pod")
+                ?? PartLoader.getPartInfoByName("Mark1Cockpit");
+            if (pod == null || pod.partPrefab == null || pod.partPrefab.CrewCapacity == 0)
+            {
+                InGameAssert.Skip("no stock crew-capable pod found in PartLoader");
+                return;
+            }
+
+            // Build a minimal SHIP ConfigNode and let VesselCrewManifest.FromConfigNode
+            // construct the manifest. "part" value is "name_id".
+            var shipNode = new ConfigNode("SHIP");
+            var partNode = shipNode.AddNode("PART");
+            partNode.AddValue("part", pod.name + "_12345");
+
+            VesselCrewManifest vcm = VesselCrewManifest.FromConfigNode(shipNode);
+            InGameAssert.IsNotNull(vcm, "FromConfigNode should return a manifest");
+            InGameAssert.AreEqual(1, vcm.PartManifests.Count, "manifest should have exactly one part");
+
+            var pcm = vcm.PartManifests[0];
+            InGameAssert.IsTrue(pcm.partCrew.Length >= 1,
+                $"test pod must have at least one seat (got {pcm.partCrew.Length})");
+
+            // Pre-assign the reserved kerbal into seat 0 (simulating auto-assign).
+            pcm.partCrew[0] = reservedName;
+
+            // Fire the patch logic.
+            Parsek.Patches.CrewAutoAssignPatch.ApplyCrewAssignmentSwaps(vcm);
+
+            // Verify the reserved kerbal is no longer in the seat.
+            InGameAssert.AreNotEqual(reservedName, pcm.partCrew[0],
+                $"Reserved '{reservedName}' should have been removed from seat 0");
+            // Stand-in should have been placed (Available + not already in manifest).
+            InGameAssert.AreEqual(standInName, pcm.partCrew[0],
+                $"Stand-in '{standInName}' should have been placed in seat 0 (got '{pcm.partCrew[0]}')");
+        }
     }
 
     /// <summary>

--- a/Source/Parsek/InGameTests/RuntimeTests.cs
+++ b/Source/Parsek/InGameTests/RuntimeTests.cs
@@ -1661,7 +1661,7 @@ namespace Parsek.InGameTests
         }
 
         [InGameTest(Category = "TerrainClearance", Scene = GameScenes.FLIGHT,
-            Description = "Recorded terrain: ghost sits at natural clearance above current terrain (#282)")]
+            Description = "Recorded surface: ghost altitude is preserved when above the PQS safety floor (#309)")]
         public void LandedGhostClearance_RecordedTerrain_PreservesClearance()
         {
             var activeVessel = FlightGlobals.ActiveVessel;
@@ -1676,11 +1676,12 @@ namespace Parsek.InGameTests
             double lon = activeVessel.longitude;
             double currentTerrain = body.TerrainAltitude(lat, lon, true);
 
-            // Simulate: at recording time, terrain was 100m, vessel at 100.8m (0.8m clearance).
-            // Current terrain may differ — clearance should be preserved.
-            double recordedTerrain = 100.0;
-            double recordedAlt = 100.8;
-            double expectedClearance = recordedAlt - recordedTerrain; // 0.8m
+            // #309 new semantics: the recorded altitude is the truth. Position the
+            // recorded altitude well above the current PQS safety floor so it's
+            // preserved exactly. Simulates a vessel recorded on a mesh object
+            // (Island Airfield) where alt is far above the raw PQS surface.
+            double recordedTerrain = currentTerrain + 19.0; // mesh-object offset like the airfield
+            double recordedAlt = recordedTerrain + 1.0;     // 1m clearance above the mesh
 
             var point = new Parsek.TrajectoryPoint
             {
@@ -1694,20 +1695,12 @@ namespace Parsek.InGameTests
             };
 
             var clamped = ParsekFlight.ApplyLandedGhostClearance(
-                point, index: 282, vesselName: "Bug282Terrain", recordedTerrainHeight: recordedTerrain);
+                point, index: 309, vesselName: "Bug309MeshObject", recordedTerrainHeight: recordedTerrain);
 
-            double expectedAlt = currentTerrain + expectedClearance;
-            // Safety floor: at least terrain + 0.5m
-            if (expectedAlt < currentTerrain + 0.5)
-                expectedAlt = currentTerrain + 0.5;
-
-            InGameAssert.IsGreaterThan(clamped.altitude, expectedAlt - 0.01,
-                $"With recorded terrain, ghost should be at ~{expectedAlt:F2} " +
-                $"(currentTerrain={currentTerrain:F2} + clearance={expectedClearance:F1}) " +
-                $"(got {clamped.altitude:F2})");
-            InGameAssert.IsLessThan(clamped.altitude, expectedAlt + 0.01,
-                $"Ghost should not be significantly above expected alt {expectedAlt:F2} " +
-                $"(got {clamped.altitude:F2})");
+            // Recorded alt is well above (currentTerrain + 0.5m floor) → preserved exactly.
+            InGameAssert.AreEqual(recordedAlt, clamped.altitude,
+                $"Recorded altitude ({recordedAlt:F2}) above PQS safety floor " +
+                $"({currentTerrain + 0.5:F2}) must be preserved exactly (got {clamped.altitude:F2})");
         }
 
         [InGameTest(Category = "TerrainClearance", Scene = GameScenes.FLIGHT,
@@ -1746,7 +1739,7 @@ namespace Parsek.InGameTests
         }
 
         [InGameTest(Category = "TerrainClearance", Scene = GameScenes.FLIGHT,
-            Description = "Recorded-terrain no-op: point already above corrected altitude is unchanged (#282)")]
+            Description = "Recorded-surface no-op: high altitude (e.g. mid-orbit reentry sample) is unchanged (#309)")]
         public void LandedGhostClearance_RecordedTerrain_AlreadyClear_Unchanged()
         {
             var activeVessel = FlightGlobals.ActiveVessel;
@@ -1761,15 +1754,11 @@ namespace Parsek.InGameTests
             double lon = activeVessel.longitude;
             double currentTerrain = body.TerrainAltitude(lat, lon, true);
 
-            // Simulate: at recording time terrain was HIGHER than current (e.g., terrain
-            // erosion between sessions). Vessel had 5m clearance above recorded terrain.
-            // ComputeCorrectedAltitude formula: corrected = currentTerrain + (alt - recTerrain).
-            // No-op path requires recTerrain >= currentTerrain so corrected <= alt.
+            // #309 new semantics: as long as the recorded altitude is above the
+            // current PQS terrain + 0.5m safety floor, it is preserved unchanged.
+            // The old terrain-relative correction formula has been removed.
             double recordedTerrain = currentTerrain + 200.0;
-            double clearance = 5.0;
-            double recordedAlt = recordedTerrain + clearance;
-            double correctedTarget = currentTerrain + clearance;
-            // recordedAlt > correctedTarget because recordedTerrain > currentTerrain
+            double recordedAlt = recordedTerrain + 5.0;
 
             var point = new Parsek.TrajectoryPoint
             {
@@ -1783,15 +1772,15 @@ namespace Parsek.InGameTests
             };
 
             var clamped = ParsekFlight.ApplyLandedGhostClearance(
-                point, index: 282, vesselName: "Bug282RecNoOp", recordedTerrainHeight: recordedTerrain);
+                point, index: 309, vesselName: "Bug309AboveFloor", recordedTerrainHeight: recordedTerrain);
 
             InGameAssert.AreEqual(recordedAlt, clamped.altitude,
-                $"Point already above corrected target ({correctedTarget:F2}) must not be modified " +
-                $"(got {clamped.altitude:F2})");
+                $"Recorded altitude above PQS safety floor must be preserved exactly " +
+                $"(got {clamped.altitude:F2}, expected {recordedAlt:F2})");
         }
 
         [InGameTest(Category = "TerrainClearance", Scene = GameScenes.FLIGHT,
-            Description = "Negative recorded clearance (physics glitch) is clamped to 0.5m floor (#282)")]
+            Description = "Recorded altitude below current PQS terrain is pushed up to safety floor (#309)")]
         public void LandedGhostClearance_NegativeClearance_ClampsToFloor()
         {
             var activeVessel = FlightGlobals.ActiveVessel;
@@ -1806,10 +1795,11 @@ namespace Parsek.InGameTests
             double lon = activeVessel.longitude;
             double currentTerrain = body.TerrainAltitude(lat, lon, true);
 
-            // Simulate physics glitch: vessel was below terrain at recording time
-            // (recordedAlt < recordedTerrain → negative clearance)
-            double recordedTerrain = 100.0;
-            double recordedAlt = 99.0; // 1m below terrain
+            // #309 new semantics: the safety floor is against CURRENT PQS terrain
+            // (not recorded terrain). Place the recorded altitude clearly below
+            // the current floor so the clamp fires.
+            double recordedTerrain = currentTerrain - 5.0; // arbitrary "recorded surface"
+            double recordedAlt = currentTerrain - 5.0;     // 5m below current floor
 
             var point = new Parsek.TrajectoryPoint
             {
@@ -1823,11 +1813,11 @@ namespace Parsek.InGameTests
             };
 
             var clamped = ParsekFlight.ApplyLandedGhostClearance(
-                point, index: 282, vesselName: "Bug282NegClearance", recordedTerrainHeight: recordedTerrain);
+                point, index: 309, vesselName: "Bug309BelowFloor", recordedTerrainHeight: recordedTerrain);
 
             double floor = currentTerrain + 0.5;
             InGameAssert.IsGreaterThan(clamped.altitude, floor - 0.001,
-                $"Negative clearance must be caught by 0.5m safety floor: " +
+                $"Recorded altitude below PQS floor must be pushed up to floor: " +
                 $"expected >= {floor:F2} (got {clamped.altitude:F2})");
         }
 

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -1334,6 +1334,9 @@ namespace Parsek
             {
                 recorder.TransitionToBackground();
                 FlushRecorderToTreeRecording(recorder, activeTree);
+                CopyRewindSaveToRoot(activeTree, recorder.CaptureAtStop,
+                    recorderFallbackSave: recorder.RewindSaveFileName,
+                    logTag: "OnVesselSwitch(active)");
 
                 // Add old vessel to BackgroundMap
                 string oldRecId = activeTree.ActiveRecordingId;
@@ -1356,6 +1359,9 @@ namespace Parsek
             else if (recorder != null && recorder.IsBackgrounded && recorder.TransitionToBackgroundPending)
             {
                 FlushRecorderToTreeRecording(recorder, activeTree);
+                CopyRewindSaveToRoot(activeTree, recorder.CaptureAtStop,
+                    recorderFallbackSave: recorder.RewindSaveFileName,
+                    logTag: "OnVesselSwitch(bg)");
 
                 string oldRecId = activeTree.ActiveRecordingId;
                 Recording oldRec;

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -6467,13 +6467,21 @@ namespace Parsek
                         : SurfaceSituation.Landed
                 };
 
-                // Capture terrain height for terrain correction on spawn
+                // Capture TRUE surface height (including buildings/mesh objects like
+                // the Island Airfield, launchpad, KSC facilities). vessel.terrainAltitude
+                // is computed by KSP from Physics.Raycast in CheckGroundCollision, so it
+                // accounts for placed colliders — unlike body.TerrainAltitude() which is
+                // PQS-only and returns the raw planetary surface UNDER any mesh object.
+                // Without this, a rover on the Island Airfield records its surface as the
+                // terrain far below the runway, and the ghost/spawn ends up underground.
                 if (vessel.mainBody != null)
                 {
-                    rec.TerrainHeightAtEnd = vessel.mainBody.TerrainAltitude(vessel.latitude, vessel.longitude);
+                    rec.TerrainHeightAtEnd = vessel.terrainAltitude;
+                    double pqs = vessel.mainBody.TerrainAltitude(vessel.latitude, vessel.longitude);
                     ParsekLog.Verbose("TerrainCorrect",
-                        $"Captured terrain height at recording end: {rec.TerrainHeightAtEnd:F1}m " +
-                        $"(vessel alt={vessel.altitude:F1}m, clearance={vessel.altitude - rec.TerrainHeightAtEnd:F1}m)");
+                        $"Captured surface height at recording end: {rec.TerrainHeightAtEnd:F1}m " +
+                        $"(vessel alt={vessel.altitude:F1}m, clearance={vessel.altitude - rec.TerrainHeightAtEnd:F1}m, " +
+                        $"pqsTerrain={pqs:F1}m, meshOffset={rec.TerrainHeightAtEnd - pqs:F1}m)");
                 }
             }
         }
@@ -7883,14 +7891,24 @@ namespace Parsek
         }
 
         /// <summary>
-        /// Bug #282: position a Landed/Splashed ghost at its natural clearance
-        /// above terrain. When <paramref name="recordedTerrainHeight"/> is valid
-        /// (not NaN), preserves the original clearance from recording time via
-        /// <see cref="TerrainCorrector.ComputeCorrectedAltitude"/>, with a 0.5 m
-        /// safety floor. When NaN (legacy recordings without terrain data), falls
-        /// back to a fixed <see cref="VesselSpawner.LandedGhostClearanceMeters"/>
-        /// offset. <c>internal static</c> so in-game tests can exercise it
-        /// without needing a full <c>IGhostPositioner</c> chain.
+        /// Position a Landed/Splashed ghost. The recorded altitude is the TRUTH —
+        /// the vessel was literally at that world-space position when the terminal
+        /// state was determined. For vessels recorded on mesh objects (Island
+        /// Airfield, launchpad, KSC buildings), the altitude encodes the airfield
+        /// surface height, which <c>body.TerrainAltitude()</c> cannot see (PQS-only).
+        /// The old code applied terrain-relative correction via
+        /// <c>ComputeCorrectedAltitude</c> which pulled mesh-object ghosts down to
+        /// raw PQS terrain, burying them under the runway.
+        ///
+        /// <para>New behavior: preserve the recorded altitude. The only correction
+        /// is an underground safety floor — push up if the recorded altitude is
+        /// below (current PQS terrain + 0.5 m), which only fires when PQS terrain
+        /// has shifted UP since recording. For NaN-recorded-terrain legacy
+        /// recordings we fall back to a fixed clearance above PQS.</para>
+        ///
+        /// <para>Ghosts are kinematic — no physics damage concern — so the safety
+        /// floor is small (0.5 m). <c>internal static</c> so in-game tests can
+        /// exercise it without needing a full <c>IGhostPositioner</c> chain.</para>
         /// </summary>
         internal static TrajectoryPoint ApplyLandedGhostClearance(
             TrajectoryPoint p, int index, string vesselName, double recordedTerrainHeight)
@@ -7908,42 +7926,42 @@ namespace Parsek
             }
 
             var ic = System.Globalization.CultureInfo.InvariantCulture;
-            double terrainAlt = body.TerrainAltitude(p.latitude, p.longitude, true);
+            double pqsTerrain = body.TerrainAltitude(p.latitude, p.longitude, true);
 
-            double targetAlt;
-            if (!double.IsNaN(recordedTerrainHeight))
+            // Legacy (NaN) path: no recorded surface height — use fixed clearance
+            // above PQS terrain as before.
+            if (double.IsNaN(recordedTerrainHeight))
             {
-                // Preserve the vessel's original clearance above terrain.
-                // Ghosts are purely visual — no physics damage concern.
-                // ComputeCorrectedAltitude already enforces a terrain+0.5m floor.
-                targetAlt = TerrainCorrector.ComputeCorrectedAltitude(
-                    terrainAlt, p.altitude, recordedTerrainHeight);
-            }
-            else
-            {
-                // Legacy fallback: no recorded terrain data — use fixed clearance
-                targetAlt = terrainAlt + VesselSpawner.LandedGhostClearanceMeters;
+                double legacyTarget = pqsTerrain + VesselSpawner.LandedGhostClearanceMeters;
+                if (p.altitude >= legacyTarget)
+                    return p;
+                double delta = legacyTarget - p.altitude;
+                if (System.Math.Abs(delta) < 0.01)
+                    return p;
+                ParsekLog.VerboseRateLimited("TerrainCorrect", $"landed-ghost-{index}",
+                    $"Landed ghost clamp #{index} (\"{vesselName}\"): " +
+                    $"alt={p.altitude.ToString("F1", ic)} pqsTerrain={pqsTerrain.ToString("F1", ic)} " +
+                    $"-> {legacyTarget.ToString("F1", ic)} (delta=+{delta.ToString("F2", ic)}m, " +
+                    $"body={body.name}, NaN fallback)");
+                p.altitude = legacyTarget;
+                return p;
             }
 
-            // When we have recorded terrain data, always correct to preserve the original
-            // clearance — terrain may be higher OR lower now than at recording time.
-            // Without recorded terrain (NaN fallback), only push up to minimum clearance.
-            if (double.IsNaN(recordedTerrainHeight) && p.altitude >= targetAlt)
+            // Primary path: trust the recorded altitude. Only push up if the
+            // recorded altitude is below the current PQS terrain floor — which
+            // only happens when PQS terrain has shifted UP since recording.
+            double safetyFloor = pqsTerrain + 0.5;
+            if (p.altitude >= safetyFloor)
                 return p;
 
-            double delta = targetAlt - p.altitude;
-            if (System.Math.Abs(delta) < 0.01)
-                return p; // already at target (within tolerance)
-
+            double upDelta = safetyFloor - p.altitude;
             ParsekLog.VerboseRateLimited("TerrainCorrect", $"landed-ghost-{index}",
                 $"Landed ghost clamp #{index} (\"{vesselName}\"): " +
-                $"alt={p.altitude.ToString("F1", ic)} terrain={terrainAlt.ToString("F1", ic)} " +
-                $"-> {targetAlt.ToString("F1", ic)} (delta={delta.ToString("F2", ic)}m, body={body.name}" +
-                (!double.IsNaN(recordedTerrainHeight)
-                    ? $", recTerrain={recordedTerrainHeight.ToString("F1", ic)})"
-                    : ", NaN fallback)"));
-
-            p.altitude = targetAlt;
+                $"alt={p.altitude.ToString("F1", ic)} pqsTerrain={pqsTerrain.ToString("F1", ic)} " +
+                $"-> {safetyFloor.ToString("F1", ic)} (delta=+{upDelta.ToString("F2", ic)}m, " +
+                $"body={body.name}, below-pqs-floor, " +
+                $"recSurface={recordedTerrainHeight.ToString("F1", ic)})");
+            p.altitude = safetyFloor;
             return p;
         }
 

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -6472,15 +6472,53 @@ namespace Parsek
                 // is computed by KSP from Physics.Raycast in CheckGroundCollision, so it
                 // accounts for placed colliders — unlike body.TerrainAltitude() which is
                 // PQS-only and returns the raw planetary surface UNDER any mesh object.
-                // Without this, a rover on the Island Airfield records its surface as the
-                // terrain far below the runway, and the ghost/spawn ends up underground.
+                //
+                // CAVEAT (review finding): KSP's Vessel.UpdatePosVel sets
+                //   terrainAltitude = altitude - heightFromTerrain   // raycast path, includes buildings
+                // only when vessel.heightFromTerrain != -1f, which requires the vessel to
+                // be loaded AND unpacked. For a packed vessel it falls through to
+                //   terrainAltitude = pqsAltitude                     // PQS-only path
+                // which is exactly the value we're trying to escape. So if the vessel is
+                // packed at capture time (commit-tree-later flow with a backgrounded
+                // airfield vessel), fall back to firing our own raycast against the same
+                // layer mask KSP uses in GetHeightFromSurface. Covers the mesh-object
+                // case without requiring the vessel to be active.
                 if (vessel.mainBody != null)
                 {
-                    rec.TerrainHeightAtEnd = vessel.terrainAltitude;
+                    double captured;
+                    string source;
+                    if (!vessel.packed)
+                    {
+                        captured = vessel.terrainAltitude;
+                        source = "vessel.terrainAltitude";
+                    }
+                    else
+                    {
+                        double raycastSurface = VesselSpawner.TryFindSurfaceAltitudeViaRaycast(
+                            vessel.mainBody, vessel.latitude, vessel.longitude, vessel.altitude);
+                        if (!double.IsNaN(raycastSurface))
+                        {
+                            captured = raycastSurface;
+                            source = "packed-vessel raycast";
+                        }
+                        else
+                        {
+                            // Last-resort fallback: PQS terrain. Logs a warning so it's visible
+                            // if the mesh-object fix silently degrades on a future recording.
+                            captured = vessel.mainBody.TerrainAltitude(vessel.latitude, vessel.longitude);
+                            source = "PQS fallback";
+                            ParsekLog.Warn("TerrainCorrect",
+                                $"CaptureTerminalPosition: vessel '{vessel.vesselName}' is packed and " +
+                                $"raycast missed — falling back to PQS terrain (may bury mesh-object spawns)");
+                        }
+                    }
+
+                    rec.TerrainHeightAtEnd = captured;
                     double pqs = vessel.mainBody.TerrainAltitude(vessel.latitude, vessel.longitude);
                     ParsekLog.Verbose("TerrainCorrect",
                         $"Captured surface height at recording end: {rec.TerrainHeightAtEnd:F1}m " +
-                        $"(vessel alt={vessel.altitude:F1}m, clearance={vessel.altitude - rec.TerrainHeightAtEnd:F1}m, " +
+                        $"(source={source}, vessel alt={vessel.altitude:F1}m, " +
+                        $"clearance={vessel.altitude - rec.TerrainHeightAtEnd:F1}m, " +
                         $"pqsTerrain={pqs:F1}m, meshOffset={rec.TerrainHeightAtEnd - pqs:F1}m)");
                 }
             }
@@ -7935,9 +7973,8 @@ namespace Parsek
                 double legacyTarget = pqsTerrain + VesselSpawner.LandedGhostClearanceMeters;
                 if (p.altitude >= legacyTarget)
                     return p;
+                // delta is always > 0 here because we already verified p.altitude < legacyTarget.
                 double delta = legacyTarget - p.altitude;
-                if (System.Math.Abs(delta) < 0.01)
-                    return p;
                 ParsekLog.VerboseRateLimited("TerrainCorrect", $"landed-ghost-{index}",
                     $"Landed ghost clamp #{index} (\"{vesselName}\"): " +
                     $"alt={p.altitude.ToString("F1", ic)} pqsTerrain={pqsTerrain.ToString("F1", ic)} " +

--- a/Source/Parsek/Patches/CrewAutoAssignPatch.cs
+++ b/Source/Parsek/Patches/CrewAutoAssignPatch.cs
@@ -104,8 +104,23 @@ namespace Parsek.Patches
         /// <summary>
         /// Prefix that walks the incoming VesselCrewManifest and replaces any
         /// reserved kerbals with their stand-ins before the UI lists are built.
+        /// Thin wrapper around <see cref="ApplyCrewAssignmentSwaps"/> so the
+        /// body is exercisable from in-game tests without Harmony.
         /// </summary>
         static void Prefix(VesselCrewManifest crewManifest)
+        {
+            ApplyCrewAssignmentSwaps(crewManifest);
+        }
+
+        /// <summary>
+        /// Core swap logic extracted from <c>Prefix</c>. Walks each part manifest
+        /// in <paramref name="crewManifest"/>, and for every occupied seat holding
+        /// a reserved kerbal, swaps the seat for the registered stand-in (or
+        /// clears it if no stand-in is available / already seated elsewhere).
+        /// Pulls its own state (kerbals module, replacements, roster) so callers
+        /// don't have to thread four arguments through the Harmony prefix.
+        /// </summary>
+        internal static void ApplyCrewAssignmentSwaps(VesselCrewManifest crewManifest)
         {
             if (crewManifest == null) return;
 
@@ -123,6 +138,12 @@ namespace Parsek.Patches
 
             foreach (PartCrewManifest pcm in crewManifest.PartManifests)
             {
+                // Defensive null guard (review finding): KSP initializes partCrew
+                // for every part that can host crew, but a custom part with zero
+                // crew capacity or a malformed manifest could theoretically leave
+                // it null. Skip rather than NRE.
+                if (pcm == null || pcm.partCrew == null) continue;
+
                 for (int i = 0; i < pcm.partCrew.Length; i++)
                 {
                     string crewName = pcm.partCrew[i];

--- a/Source/Parsek/Patches/CrewAutoAssignPatch.cs
+++ b/Source/Parsek/Patches/CrewAutoAssignPatch.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using HarmonyLib;
+using KSP.UI;
+
+namespace Parsek.Patches
+{
+    /// <summary>
+    /// Removes reserved kerbals from auto-assigned crew slots in the VAB/SPH
+    /// crew assignment dialog, replacing them with their stand-ins.
+    ///
+    /// KSP's KerbalRoster.DefaultCrewForVessel auto-assigns Available kerbals
+    /// into command pod seats BEFORE the crew dialog is displayed. Reserved
+    /// kerbals remain at Available status (by design — changing rosterStatus
+    /// caused tug-of-war bugs), so they get auto-assigned into the manifest.
+    ///
+    /// The existing CrewDialogFilterPatch removes reserved kerbals from the
+    /// "available crew" list, but by that point they're already assigned to
+    /// seats and appear in the vessel crew panel.
+    ///
+    /// This patch intercepts RefreshCrewLists (called before UI list creation)
+    /// and walks the VesselCrewManifest to replace any reserved crew with their
+    /// stand-ins. If no stand-in exists for a reserved kerbal, the seat is left
+    /// empty.
+    /// </summary>
+    [HarmonyPatch]
+    internal static class CrewAutoAssignPatch
+    {
+        private const string Tag = "CrewAutoAssign";
+
+        /// <summary>
+        /// Result of evaluating a single crew slot for auto-assign filtering.
+        /// </summary>
+        internal enum SlotAction
+        {
+            /// <summary>Crew member is not reserved — leave in seat.</summary>
+            Keep,
+            /// <summary>Crew member is reserved and has a stand-in — swap.</summary>
+            Swap,
+            /// <summary>Crew member is reserved but no stand-in available — clear seat.</summary>
+            Clear
+        }
+
+        /// <summary>
+        /// Pure decision method: given a crew name, determines what action the
+        /// auto-assign patch should take. Testable without Unity or KSP UI types.
+        /// </summary>
+        /// <param name="crewName">Name of the crew member in the seat.</param>
+        /// <param name="kerbals">KerbalsModule for reservation checks.</param>
+        /// <param name="replacements">Reserved-name to stand-in-name mapping.</param>
+        /// <param name="standInName">Output: stand-in name if action is Swap, null otherwise.</param>
+        /// <returns>The action to take for this crew slot.</returns>
+        internal static SlotAction DecideSlotAction(
+            string crewName,
+            KerbalsModule kerbals,
+            IReadOnlyDictionary<string, string> replacements,
+            out string standInName)
+        {
+            standInName = null;
+
+            if (string.IsNullOrEmpty(crewName))
+                return SlotAction.Keep;
+
+            if (kerbals == null)
+                return SlotAction.Keep;
+
+            if (!kerbals.ShouldFilterFromCrewDialog(crewName))
+                return SlotAction.Keep;
+
+            // Crew is reserved — check for stand-in
+            if (replacements != null && replacements.TryGetValue(crewName, out standInName)
+                && !string.IsNullOrEmpty(standInName))
+            {
+                return SlotAction.Swap;
+            }
+
+            standInName = null;
+            return SlotAction.Clear;
+        }
+
+        static MethodBase TargetMethod()
+        {
+            var method = AccessTools.Method(
+                typeof(BaseCrewAssignmentDialog),
+                nameof(BaseCrewAssignmentDialog.RefreshCrewLists),
+                new[]
+                {
+                    typeof(VesselCrewManifest),
+                    typeof(bool),
+                    typeof(bool),
+                    typeof(Func<PartCrewManifest, bool>)
+                });
+
+            if (method == null)
+                ParsekLog.Warn(Tag,
+                    "BaseCrewAssignmentDialog.RefreshCrewLists not found " +
+                    "— crew auto-assign filtering will not apply. " +
+                    "Harmony will skip this patch (caught by ParsekHarmony try/catch).");
+
+            return method;
+        }
+
+        /// <summary>
+        /// Prefix that walks the incoming VesselCrewManifest and replaces any
+        /// reserved kerbals with their stand-ins before the UI lists are built.
+        /// </summary>
+        static void Prefix(VesselCrewManifest crewManifest)
+        {
+            if (crewManifest == null) return;
+
+            var kerbals = LedgerOrchestrator.Kerbals;
+            if (kerbals == null) return;
+
+            var replacements = CrewReservationManager.CrewReplacements;
+            if (replacements.Count == 0) return;
+
+            var roster = HighLogic.CurrentGame?.CrewRoster;
+            if (roster == null) return;
+
+            int swapCount = 0;
+            int clearCount = 0;
+
+            foreach (PartCrewManifest pcm in crewManifest.PartManifests)
+            {
+                for (int i = 0; i < pcm.partCrew.Length; i++)
+                {
+                    string crewName = pcm.partCrew[i];
+                    var action = DecideSlotAction(crewName, kerbals, replacements,
+                        out string standInName);
+
+                    switch (action)
+                    {
+                        case SlotAction.Swap:
+                        {
+                            ProtoCrewMember standIn = roster[standInName];
+                            if (standIn != null && !crewManifest.Contains(standIn))
+                            {
+                                pcm.RemoveCrewFromSeat(i);
+                                pcm.AddCrewToSeat(standIn, i);
+                                swapCount++;
+
+                                ParsekLog.Verbose(Tag,
+                                    $"Swapped reserved '{crewName}' -> stand-in '{standInName}' " +
+                                    $"in part '{pcm.PartInfo?.title ?? "unknown"}' seat {i}");
+                            }
+                            else
+                            {
+                                // Stand-in already assigned elsewhere or not in roster
+                                pcm.RemoveCrewFromSeat(i);
+                                clearCount++;
+
+                                ParsekLog.Verbose(Tag,
+                                    $"Cleared reserved '{crewName}' from part " +
+                                    $"'{pcm.PartInfo?.title ?? "unknown"}' seat {i} " +
+                                    $"(stand-in '{standInName}' unavailable)");
+                            }
+                            break;
+                        }
+                        case SlotAction.Clear:
+                        {
+                            pcm.RemoveCrewFromSeat(i);
+                            clearCount++;
+
+                            ParsekLog.Verbose(Tag,
+                                $"Cleared reserved '{crewName}' from part " +
+                                $"'{pcm.PartInfo?.title ?? "unknown"}' seat {i} " +
+                                "(no stand-in registered)");
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if (swapCount > 0 || clearCount > 0)
+            {
+                ParsekLog.Info(Tag,
+                    $"Crew manifest adjusted: {swapCount} reserved crew replaced with stand-ins, " +
+                    $"{clearCount} seats cleared");
+            }
+        }
+    }
+}

--- a/Source/Parsek/SpawnCollisionDetector.cs
+++ b/Source/Parsek/SpawnCollisionDetector.cs
@@ -513,14 +513,23 @@ namespace Parsek
         // ────────────────────────────────────────────────────────────
 
         /// <summary>
-        /// Layer mask for part-collider overlap checks. Matches the default layers
-        /// KSP parts live on (layer 0 = Default, layer 19 = PartTriggers per
-        /// LayerUtil). We deliberately exclude terrain (15) and local scenery (23)
-        /// since building/runway colliders are not blockers — only other vessels
-        /// are. Hit filtering by Part-in-parent-chain is the actual source of
-        /// truth; this mask is a broad first-pass.
+        /// Layer mask for part-collider overlap checks. Matches KSP's own
+        /// <c>LayerUtil.DefaultEquivalent = 0x820001</c> (bits 0, 17, 23) — the
+        /// authoritative "part-bearing layers" mask used inside
+        /// <c>Vessel.CheckGroundCollision</c>, verified against the decompiled
+        /// KSP source. Using KSP's own constant guarantees we'll see every layer
+        /// the game considers a part-ownable surface.
+        ///
+        /// <para>We do NOT widen to include terrain (layer 15) or building
+        /// layers — they aren't part-ownable, and the downstream
+        /// <see cref="FlightGlobals.GetPartUpwardsCached"/> filter would strip
+        /// them anyway. But narrowing the mask keeps the overlap query cheaper
+        /// when spawning near cluttered KSC scenery.</para>
         /// </summary>
-        private const int PartOverlapLayerMask = (1 << 0) | (1 << 17) | (1 << 19);
+        private static int PartOverlapLayerMask
+        {
+            get { return LayerUtil.DefaultEquivalent; }
+        }
 
         /// <summary>
         /// Checks whether a vessel spawned at <paramref name="spawnWorldPos"/> with
@@ -540,7 +549,33 @@ namespace Parsek
             Vector3d spawnWorldPos, Bounds spawnBounds, float padding, bool skipActiveVessel = true,
             uint exemptVesselPid = 0)
         {
-            Vector3 worldCenter = (Vector3)spawnWorldPos + spawnBounds.center;
+            // Compute the surface-aligned rotation for the spawn box. spawnBounds is in
+            // vessel-local space, where the vessel's local Y axis points along the surface
+            // normal (a landed vessel sits "up" from the body). On a curved body that Y
+            // axis is tilted relative to world-Y. FromToRotation maps Vector3.up to the
+            // actual local up at the spawn position, so the OverlapBox's extents are
+            // oriented correctly. For the previous Quaternion.identity the error was small
+            // for vessels near KSC (world-Y is nearly parallel to Kerbin-up there), but
+            // grew for spawns on the far side of a body. Review finding from PR #225.
+            Vector3 upAxis = Vector3.up;
+            for (int bi = 0; FlightGlobals.Bodies != null && bi < FlightGlobals.Bodies.Count; bi++)
+            {
+                CelestialBody b = FlightGlobals.Bodies[bi];
+                if (b == null) continue;
+                double distSq = (spawnWorldPos - b.position).sqrMagnitude;
+                double r = b.Radius;
+                // The closest body whose center-to-spawn distance is within its
+                // sphere of influence radius is "the body we're spawning near".
+                // For our use case — landed/splashed spawns near the surface —
+                // testing against 1.5x body radius is enough to pick the correct one.
+                if (distSq < (r * 1.5) * (r * 1.5))
+                {
+                    upAxis = (Vector3)FlightGlobals.getUpAxis(b, (Vector3d)spawnWorldPos);
+                    break;
+                }
+            }
+            Quaternion surfaceRot = Quaternion.FromToRotation(Vector3.up, upAxis);
+            Vector3 worldCenter = (Vector3)spawnWorldPos + surfaceRot * spawnBounds.center;
             Vector3 halfExtents = spawnBounds.extents + Vector3.one * padding;
 
             // Rate-limited: walkback calls this once per sub-step (potentially hundreds of
@@ -553,7 +588,7 @@ namespace Parsek
                 $"padding={padding.ToString("F1", IC)}m, skipActiveVessel={skipActiveVessel}" +
                 (exemptVesselPid != 0 ? $", exemptPid={exemptVesselPid} (T57)" : ""));
 
-            Collider[] hits = Physics.OverlapBox(worldCenter, halfExtents, Quaternion.identity,
+            Collider[] hits = Physics.OverlapBox(worldCenter, halfExtents, surfaceRot,
                 PartOverlapLayerMask, QueryTriggerInteraction.Ignore);
 
             if (hits == null || hits.Length == 0)

--- a/Source/Parsek/SpawnCollisionDetector.cs
+++ b/Source/Parsek/SpawnCollisionDetector.cs
@@ -513,87 +513,131 @@ namespace Parsek
         // ────────────────────────────────────────────────────────────
 
         /// <summary>
-        /// Checks whether the spawn bounding box (at spawnWorldPos) overlaps with
-        /// any loaded vessel's approximate bounding box. Returns the closest
-        /// overlapping vessel's info, or overlap=false if no overlap found.
+        /// Layer mask for part-collider overlap checks. Matches the default layers
+        /// KSP parts live on (layer 0 = Default, layer 19 = PartTriggers per
+        /// LayerUtil). We deliberately exclude terrain (15) and local scenery (23)
+        /// since building/runway colliders are not blockers — only other vessels
+        /// are. Hit filtering by Part-in-parent-chain is the actual source of
+        /// truth; this mask is a broad first-pass.
+        /// </summary>
+        private const int PartOverlapLayerMask = (1 << 0) | (1 << 17) | (1 << 19);
+
+        /// <summary>
+        /// Checks whether a vessel spawned at <paramref name="spawnWorldPos"/> with
+        /// the given local <paramref name="spawnBounds"/> would overlap any real
+        /// part collider of a loaded vessel. Uses <see cref="Physics.OverlapBox"/>
+        /// so the other vessel's actual part geometry is considered — no more
+        /// 2 m-cube approximation.
+        ///
+        /// <para>Hit filtering: each overlapping collider is resolved to its owning
+        /// <see cref="Part"/> via <see cref="FlightGlobals.GetPartUpwardsCached"/>
+        /// (same helper KSP uses in <c>Vessel.CheckGroundCollision</c>). Hits
+        /// without a Part owner (terrain, buildings, runway mesh colliders) are
+        /// ignored. Hits on the active vessel / exempt vessel / skipped vessel
+        /// types are filtered per the existing semantics.</para>
         /// </summary>
         internal static (bool overlap, float closestDistance, string blockerName, Vessel blockerVessel) CheckOverlapAgainstLoadedVessels(
             Vector3d spawnWorldPos, Bounds spawnBounds, float padding, bool skipActiveVessel = true,
             uint exemptVesselPid = 0)
         {
-            ParsekLog.Verbose(Tag,
-                $"CheckOverlapAgainstLoadedVessels: checking spawn at ({spawnWorldPos.x.ToString("F0", IC)},{spawnWorldPos.y.ToString("F0", IC)},{spawnWorldPos.z.ToString("F0", IC)}) " +
-                $"padding={padding.ToString("F1", IC)}m against {FlightGlobals.Vessels.Count} vessels, skipActiveVessel={skipActiveVessel}" +
+            Vector3 worldCenter = (Vector3)spawnWorldPos + spawnBounds.center;
+            Vector3 halfExtents = spawnBounds.extents + Vector3.one * padding;
+
+            // Rate-limited: walkback calls this once per sub-step (potentially hundreds of
+            // calls per spawn attempt). A single diagnostic line per second is enough to
+            // confirm the method is being called and see the latest parameters.
+            ParsekLog.VerboseRateLimited(Tag, "overlap-check-entry",
+                $"CheckOverlapAgainstLoadedVessels: Physics.OverlapBox at " +
+                $"({worldCenter.x.ToString("F0", IC)},{worldCenter.y.ToString("F0", IC)},{worldCenter.z.ToString("F0", IC)}) " +
+                $"halfExtents=({halfExtents.x.ToString("F1", IC)},{halfExtents.y.ToString("F1", IC)},{halfExtents.z.ToString("F1", IC)}) " +
+                $"padding={padding.ToString("F1", IC)}m, skipActiveVessel={skipActiveVessel}" +
                 (exemptVesselPid != 0 ? $", exemptPid={exemptVesselPid} (T57)" : ""));
+
+            Collider[] hits = Physics.OverlapBox(worldCenter, halfExtents, Quaternion.identity,
+                PartOverlapLayerMask, QueryTriggerInteraction.Ignore);
+
+            if (hits == null || hits.Length == 0)
+            {
+                // Happy path, no log -- walkback's per-substep summary is enough.
+                return (false, float.MaxValue, null, null);
+            }
 
             bool anyOverlap = false;
             float closestDist = float.MaxValue;
             string blockerName = null;
             Vessel blockerVessel = null;
+            int totalHits = hits.Length;
+            int nonPartHits = 0;
+            int filteredHits = 0;
+            var reportedPids = new HashSet<uint>();
 
-            for (int i = 0; i < FlightGlobals.Vessels.Count; i++)
+            for (int i = 0; i < hits.Length; i++)
             {
-                Vessel other = FlightGlobals.Vessels[i];
-                if (!other.loaded) continue;
-                if (GhostMapPresence.IsGhostMapVessel(other.persistentId)) continue;
+                Collider hit = hits[i];
+                if (hit == null) continue;
 
-                // Skip player's own vessel — shouldn't block non-EVA spawns.
-                // EVA spawns need to detect the active vessel (parent rocket) as a
-                // blocker so the walkback can find a clear position (#291), UNLESS
-                // it's the EVA's parent vessel (#T57).
-                if (skipActiveVessel && other == FlightGlobals.ActiveVessel) continue;
+                Part part = FlightGlobals.GetPartUpwardsCached(hit.gameObject);
+                if (part == null)
+                {
+                    nonPartHits++;
+                    continue;
+                }
 
-                // T57: skip the EVA's parent vessel — the EVA trajectory is always
-                // adjacent to the parent, so without exemption the entire walkback
-                // is exhausted and the spawn is abandoned.
+                Vessel other = part.vessel;
+                if (other == null)
+                {
+                    nonPartHits++;
+                    continue;
+                }
+
+                if (!other.loaded) { filteredHits++; continue; }
+                if (GhostMapPresence.IsGhostMapVessel(other.persistentId)) { filteredHits++; continue; }
+                if (skipActiveVessel && other == FlightGlobals.ActiveVessel) { filteredHits++; continue; }
                 if (exemptVesselPid != 0 && other.persistentId == exemptVesselPid)
                 {
-                    ParsekLog.Verbose(Tag,
-                        $"Skipping exempt parent vessel '{Recording.ResolveLocalizedName(other.vesselName)}' " +
-                        $"(pid={other.persistentId}) for EVA collision check (T57)");
+                    // Rate-limited per-vessel: walkback substeps hitting the same exempt
+                    // parent vessel would otherwise log once per substep.
+                    if (reportedPids.Add(other.persistentId))
+                        ParsekLog.VerboseRateLimited(Tag, "overlap-exempt-" + other.persistentId,
+                            $"Skipping exempt parent vessel '{Recording.ResolveLocalizedName(other.vesselName)}' " +
+                            $"(pid={other.persistentId}) for EVA collision check (T57)");
+                    filteredHits++;
                     continue;
                 }
-
-                // Skip non-significant vessel types that shouldn't block spawns
                 if (ShouldSkipVesselType(other.vesselType))
                 {
-                    ParsekLog.Verbose(Tag,
-                        string.Format(IC, "Skipping {0} vessel {1} in overlap check",
-                            other.vesselType, Recording.ResolveLocalizedName(other.vesselName)));
+                    if (reportedPids.Add(other.persistentId))
+                        ParsekLog.VerboseRateLimited(Tag, "overlap-skiptype-" + other.persistentId,
+                            string.Format(IC, "Skipping {0} vessel '{1}' in overlap check",
+                                other.vesselType, Recording.ResolveLocalizedName(other.vesselName)));
+                    filteredHits++;
                     continue;
                 }
 
+                anyOverlap = true;
                 Vector3d otherPos = other.GetWorldPos3D();
                 float dist = (float)Vector3d.Distance(spawnWorldPos, otherPos);
-
-                // Approximate other vessel bounds as a default-sized cube
-                Bounds otherBounds = new Bounds(Vector3.zero, Vector3.one * FallbackBoundsSize);
-
-                if (BoundsOverlap(spawnBounds, spawnWorldPos, otherBounds, otherPos, padding))
+                if (dist < closestDist)
                 {
-                    anyOverlap = true;
-                    if (dist < closestDist)
-                    {
-                        closestDist = dist;
-                        blockerName = Recording.ResolveLocalizedName(other.vesselName);
-                        blockerVessel = other;
-                    }
+                    closestDist = dist;
+                    blockerName = Recording.ResolveLocalizedName(other.vesselName);
+                    blockerVessel = other;
+                }
 
+                if (reportedPids.Add(other.persistentId))
+                {
                     ParsekLog.VerboseRateLimited(Tag,
                         "overlap-" + other.persistentId,
-                        $"Spawn overlaps with {Recording.ResolveLocalizedName(other.vesselName)} (pid={other.persistentId}) at {dist.ToString("F1", IC)}m");
-                }
-                else
-                {
-                    ParsekLog.Verbose(Tag,
-                        $"No overlap with {Recording.ResolveLocalizedName(other.vesselName)} at {dist.ToString("F1", IC)}m");
+                        $"Spawn overlaps with {Recording.ResolveLocalizedName(other.vesselName)} " +
+                        $"(pid={other.persistentId}) via part '{part.partInfo?.name ?? "?"}' at {dist.ToString("F1", IC)}m");
                 }
             }
 
-            if (!anyOverlap)
-            {
-                ParsekLog.Verbose(Tag, "No spawn overlap detected against loaded vessels");
-            }
+            // Rate-limited summary: same key spans all walkback substeps so we get at most
+            // one summary per second even when walkback is hammering this call.
+            ParsekLog.VerboseRateLimited(Tag, "overlap-check-summary",
+                $"OverlapBox summary: {totalHits} total hits, {nonPartHits} non-part (terrain/building), " +
+                $"{filteredHits} filtered vessels, {(anyOverlap ? "BLOCKED by " + blockerName : "CLEAR")}");
 
             return (anyOverlap, closestDist, blockerName, blockerVessel);
         }

--- a/Source/Parsek/TerrainCorrector.cs
+++ b/Source/Parsek/TerrainCorrector.cs
@@ -13,41 +13,15 @@ namespace Parsek
         private const string Tag = "TerrainCorrect";
         private static readonly CultureInfo IC = CultureInfo.InvariantCulture;
 
-        /// <summary>
-        /// Computes the corrected altitude that preserves the vessel's clearance
-        /// above terrain, even when terrain height has changed since recording.
-        ///
-        /// correctedAlt = currentTerrainHeight + (recordedAltitude - recordedTerrainHeight)
-        ///
-        /// The difference (recordedAltitude - recordedTerrainHeight) is the recorded
-        /// clearance — how far above terrain the vessel was when recording ended.
-        /// Adding that clearance to the current terrain height gives the correct
-        /// altitude for spawning.
-        /// </summary>
-        internal static double ComputeCorrectedAltitude(
-            double currentTerrainHeight,
-            double recordedAltitude,
-            double recordedTerrainHeight)
-        {
-            double clearance = recordedAltitude - recordedTerrainHeight;
-            double corrected = currentTerrainHeight + clearance;
-
-            // Never spawn below terrain + 0.5m safety margin
-            double minAlt = currentTerrainHeight + 0.5;
-            if (corrected < minAlt)
-            {
-                ParsekLog.Verbose(Tag,
-                    $"ComputeCorrectedAltitude: clamped from {corrected.ToString("F1", IC)} to {minAlt.ToString("F1", IC)} (terrain+0.5m floor)");
-                corrected = minAlt;
-            }
-
-            ParsekLog.Verbose(Tag,
-                $"ComputeCorrectedAltitude: currentTerrain={currentTerrainHeight.ToString("F1", IC)} " +
-                $"recordedAlt={recordedAltitude.ToString("F1", IC)} recordedTerrain={recordedTerrainHeight.ToString("F1", IC)} " +
-                $"clearance={clearance.ToString("F1", IC)} corrected={corrected.ToString("F1", IC)}");
-
-            return corrected;
-        }
+        // ComputeCorrectedAltitude removed (#309): the terrain-relative clearance
+        // model ("currentTerrain + (recordedAlt - recordedTerrain)") buries any
+        // vessel recorded on a mesh object (Island Airfield runway, launchpad,
+        // KSC buildings) because body.TerrainAltitude() is PQS-only and returns
+        // the raw planetary surface UNDER placed colliders. Replaced by
+        // "trust the recorded altitude + underground safety floor" semantics in
+        // VesselSpawner.ClampAltitudeForLanded and ParsekFlight.ApplyLandedGhostClearance.
+        // The recorded altitude is the authoritative surface position — KSP's own
+        // CheckGroundCollision will settle against real colliders on load.
 
         /// <summary>
         /// Clamps a ghost altitude so it stays above terrain surface.

--- a/Source/Parsek/UI/RecordingsTableUI.cs
+++ b/Source/Parsek/UI/RecordingsTableUI.cs
@@ -1578,15 +1578,16 @@ namespace Parsek
                 : statusStylePast;
             GUILayout.Label(chainStatusText, chainStatusStyle, GUILayout.Width(ColW_Status));
 
-            // Chain G button (share ColW_Group width with X placeholder)
-            float halfGroup = (ColW_Group - 4f) * 0.5f;
-            if (GUILayout.Button("G", GUILayout.Width(halfGroup)))
+            // Chain G button takes the full ColW_Group width since chain blocks have
+            // no X (disband) button — chain segments must stay grouped to preserve
+            // tree lineage and rewind anchors. Matches the per-recording row layout
+            // where G also fills ColW_Group.
+            if (GUILayout.Button("G", GUILayout.Width(ColW_Group)))
             {
                 var mousePos = GUIUtility.GUIToScreenPoint(Event.current.mousePosition);
                 groupPicker.OpenForChain(chainId, mousePos);
                 ParsekLog.Verbose("UI", $"Group popup opened for chain '{chainName}'");
             }
-            GUILayout.Space(halfGroup + 4f);
 
             // Loop checkbox (aggregate over chain members)
             int chainLoopCount = 0;

--- a/Source/Parsek/VesselGhoster.cs
+++ b/Source/Parsek/VesselGhoster.cs
@@ -586,9 +586,12 @@ namespace Parsek
         }
 
         /// <summary>
-        /// Apply terrain correction to a vessel snapshot's altitude.
-        /// Queries current terrain height at the recording's terminal position
-        /// and adjusts the snapshot altitude to preserve clearance.
+        /// Applies underground safety floor against current PQS terrain at the
+        /// recording's terminal position. Only clamps UP — if the recorded
+        /// altitude is below (current PQS terrain + 0.5 m), push up to the floor.
+        /// Never down-clamps — the recorded altitude is the truth, including
+        /// mesh-object offsets (Island Airfield, launchpad, KSC buildings) that
+        /// PQS terrain alone cannot represent.
         /// </summary>
         private static void ApplyTerrainCorrection(Recording rec, ConfigNode vesselSnapshot)
         {
@@ -603,21 +606,23 @@ namespace Parsek
                 return;
             }
 
-            double currentTerrainHeight = body.TerrainAltitude(tp.latitude, tp.longitude);
-            double correctedAlt = TerrainCorrector.ComputeCorrectedAltitude(
-                currentTerrainHeight, tp.altitude, rec.TerrainHeightAtEnd);
+            double pqsTerrain = body.TerrainAltitude(tp.latitude, tp.longitude);
+            double safetyFloor = pqsTerrain + 0.5;
 
-            // Update the snapshot's altitude value if present
+            if (tp.altitude >= safetyFloor)
+                return; // trust recorded altitude
+
             string altStr = vesselSnapshot.GetValue("alt");
             if (!string.IsNullOrEmpty(altStr))
             {
-                vesselSnapshot.SetValue("alt", correctedAlt.ToString("R", ic));
+                vesselSnapshot.SetValue("alt", safetyFloor.ToString("R", ic));
                 ParsekLog.Info("TerrainCorrect",
                     string.Format(ic,
-                        "Applied terrain correction: recorded={0} current={1} corrected={2}",
+                        "Applied underground safety floor: recorded={0} pqsTerrain={1} -> {2} (delta=+{3})",
                         tp.altitude.ToString("F1", ic),
-                        currentTerrainHeight.ToString("F1", ic),
-                        correctedAlt.ToString("F1", ic)));
+                        pqsTerrain.ToString("F1", ic),
+                        safetyFloor.ToString("F1", ic),
+                        (safetyFloor - tp.altitude).ToString("F1", ic)));
             }
         }
 

--- a/Source/Parsek/VesselGhoster.cs
+++ b/Source/Parsek/VesselGhoster.cs
@@ -607,7 +607,12 @@ namespace Parsek
             }
 
             double pqsTerrain = body.TerrainAltitude(tp.latitude, tp.longitude);
-            double safetyFloor = pqsTerrain + 0.5;
+            // Use the shared underground safety floor (2 m) so the snapshot-alt
+            // path matches what ClampAltitudeForLanded would apply downstream.
+            // Review finding: the previous hard-coded 0.5 m value was consistent
+            // only with ApplyLandedGhostClearance (for kinematic ghosts), not
+            // with the spawn path this code serves.
+            double safetyFloor = pqsTerrain + VesselSpawner.UndergroundSafetyFloorMeters;
 
             if (tp.altitude >= safetyFloor)
                 return; // trust recorded altitude

--- a/Source/Parsek/VesselSpawner.cs
+++ b/Source/Parsek/VesselSpawner.cs
@@ -756,7 +756,7 @@ namespace Parsek
                 if (!rec.DuplicateBlockerRecovered
                     && blockerVessel != null
                     && blockerVessel.loaded
-                    && ShouldRecoverBlockerVessel(blockerName, resolvedRecName))
+                    && ShouldRecoverBlockerVessel(rec, blockerName, resolvedRecName, blockerVessel.persistentId))
                 {
                     ParsekLog.Warn("Spawner",
                         $"Duplicate blocker detected for #{index} ({rec.VesselName}): " +
@@ -1232,15 +1232,41 @@ namespace Parsek
 
         /// <summary>
         /// Pure decision: should the blocking vessel be recovered as a likely duplicate?
-        /// Returns true when the blocker's resolved name matches the recording's vessel name,
-        /// indicating a leftover from a previous spawn (e.g., quicksave-loaded duplicate after rewind).
-        /// Both names must already be resolved via ResolveLocalizedName. (#112)
+        ///
+        /// <para>#112 original scenario: the player quicksaves a Parsek-spawned vessel and
+        /// then loads. KSP restores the vessel from the quicksave with its original PID,
+        /// and Parsek tries to spawn the same recording again. We end up with two copies
+        /// of the same recording's vessel overlapping. The correct response is to destroy
+        /// the quicksave-restored copy (same PID as before) and keep the fresh spawn.</para>
+        ///
+        /// <para>#312 regression: the original check matched by NAME only. When multiple
+        /// recordings of the same vessel (e.g. four "Crater Crawler" showcases on the
+        /// runway) spawn near each other, each new spawn's overlap-check found the
+        /// PREVIOUS recording's vessel -- same name -- and destroyed it. Only 2 of 4
+        /// recordings survived in a playtest because each new spawn killed the last.
+        /// Siblings should walkback, not recover.</para>
+        ///
+        /// <para>Fix: the blocker must match this recording's OWN <see cref="Recording.SpawnedVesselPersistentId"/>
+        /// -- the PID we recorded the last time WE spawned. That's the only way to be
+        /// certain the blocker is a duplicate of ourselves (the #112 scenario). If the
+        /// blocker belongs to a sibling recording or to a non-Parsek vessel, PIDs
+        /// differ and we fall through to walkback.</para>
         /// </summary>
-        internal static bool ShouldRecoverBlockerVessel(string blockerName, string recordingVesselName)
+        internal static bool ShouldRecoverBlockerVessel(
+            Recording rec, string blockerName, string recordingVesselName, uint blockerPid)
         {
+            if (rec == null || blockerPid == 0) return false;
             if (string.IsNullOrEmpty(blockerName) || string.IsNullOrEmpty(recordingVesselName))
                 return false;
-            return string.Equals(blockerName, recordingVesselName, StringComparison.Ordinal);
+            if (!string.Equals(blockerName, recordingVesselName, StringComparison.Ordinal))
+                return false;
+
+            // Primary discriminator: the blocker must be the SAME vessel we spawned
+            // previously for THIS recording. #112 applies only when KSP's quicksave
+            // restored our own spawn with the same PID.
+            return rec.VesselSpawned
+                && rec.SpawnedVesselPersistentId != 0
+                && rec.SpawnedVesselPersistentId == blockerPid;
         }
 
         /// <summary>

--- a/Source/Parsek/VesselSpawner.cs
+++ b/Source/Parsek/VesselSpawner.cs
@@ -879,12 +879,46 @@ namespace Parsek
                 walkLon = walkResult.lon;
                 walkAlt = walkResult.alt;
 
-                // Clamp altitude for surface terminals (#231) — the walkback candidate may be
-                // mid-flight altitude; ClampAltitudeForLanded puts the root part above terrain.
+                // For LANDED terminals: the walkback may return a mid-descent trajectory
+                // point where the vessel was 10-50m in the air (approaching the landing
+                // spot from a diagonal). Trusting that altitude would spawn the vessel in
+                // mid-air and let it fall. Fix: top-down Physics.Raycast at the walkback
+                // (lat, lon) to find the true surface (including mesh objects like the
+                // Island Airfield runway), and clamp the candidate altitude to
+                // surface + small clearance when it's notably higher.
+                //
+                // The raycast uses the same layer mask as KSP's Vessel.GetHeightFromSurface
+                // (default + terrain + buildings), so it hits both PQS terrain AND placed
+                // colliders correctly. Falls back to the PQS safety floor if the raycast
+                // misses (e.g., target area not loaded).
                 if (rec.TerminalStateValue == TerminalState.Landed)
                 {
-                    double terrainAlt = body.TerrainAltitude(walkLat, walkLon);
-                    walkAlt = ClampAltitudeForLanded(walkAlt, terrainAlt, index, rec.VesselName);
+                    double raycastSurface = TryFindSurfaceAltitudeViaRaycast(body, walkLat, walkLon, walkAlt);
+                    if (!double.IsNaN(raycastSurface))
+                    {
+                        double above = walkAlt - raycastSurface;
+                        if (above > WalkbackSurfaceSnapThresholdMeters)
+                        {
+                            double snapped = raycastSurface + WalkbackSurfaceClearanceMeters;
+                            ParsekLog.Info("Spawner",
+                                $"Walkback altitude too high above surface for #{index} ({rec.VesselName}): " +
+                                $"walkAlt={walkAlt.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)} " +
+                                $"raycastSurface={raycastSurface.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)} " +
+                                $"above={above.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)}m " +
+                                $"-> snapping to {snapped.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)} " +
+                                $"(raycast=surface + {WalkbackSurfaceClearanceMeters}m)");
+                            walkAlt = snapped;
+                        }
+                        // else: trusted — happy path, no log. Walkback substep spam.
+                    }
+                    else
+                    {
+                        double pqsTerrain = body.TerrainAltitude(walkLat, walkLon);
+                        ParsekLog.VerboseRateLimited("Spawner", $"walkback-pqs-fallback-{index}",
+                            $"Walkback raycast missed for #{index} ({rec.VesselName}) — " +
+                            $"falling back to PQS safety floor (pqsTerrain={pqsTerrain.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)})");
+                        walkAlt = ClampAltitudeForLanded(walkAlt, pqsTerrain, index, rec.VesselName);
+                    }
                 }
                 else if (rec.TerminalStateValue == TerminalState.Splashed && walkAlt > 0)
                 {
@@ -956,10 +990,16 @@ namespace Parsek
             }
 
             // Safety net: clamp altitude for surface terminal states.
-            // The last trajectory point or snapshot may be from while still descending —
-            // altitude is above the actual rest position. Without clamping, KSP spawns
-            // a LANDED vessel in mid-air, reclassifies to FLYING, and it falls and crashes.
-            // SPLASHED: clamp to sea level. LANDED: clamp to terrain height. (#224, #231)
+            // SPLASHED: clamp to sea level.
+            // LANDED: trust the recorded altitude (it's where the vessel came to rest — the
+            // terminal state proves it had settled). Only push UP if the recorded altitude is
+            // below the current PQS terrain (indicates the surface has shifted UP since
+            // recording — rare, e.g. KSP version change or terrain-mod changes). Do NOT
+            // clamp DOWN to PQS terrain — that would bury vessels recorded on mesh objects
+            // (Island Airfield, launchpad, KSC buildings) since body.TerrainAltitude() is
+            // PQS-only and ignores placed colliders. KSP's Vessel.CheckGroundCollision will
+            // fire once the vessel loads and adjust using getLowestPoint() against real
+            // colliders (including buildings), handling any residual clipping properly.
             if (rec.TerminalStateValue == TerminalState.Splashed)
             {
                 if (alt > 0)
@@ -975,67 +1015,158 @@ namespace Parsek
                 CelestialBody body = FlightGlobals.Bodies?.Find(b => b.name == bodyName);
                 if (body != null)
                 {
-                    double terrainAlt = body.TerrainAltitude(lat, lon);
-                    alt = ClampAltitudeForLanded(alt, terrainAlt, index, rec.VesselName);
+                    double pqsTerrain = body.TerrainAltitude(lat, lon);
+                    alt = ClampAltitudeForLanded(alt, pqsTerrain, index, rec.VesselName);
                 }
             }
         }
 
         /// <summary>
-        /// Pure: clamp altitude to terrain height + clearance for LANDED spawns.
-        /// KSP's alt field positions the vessel's root part (typically the command pod at the top).
-        /// Setting alt = terrainAlt puts the root part at ground level, burying lower parts
-        /// (heat shields, engines, landing legs) underground. The clearance offset ensures the
-        /// entire vessel is above the surface so KSP's physics can settle it naturally. (#231)
-        ///
-        /// <para>Bug #282: the original implementation left <c>alt ∈ [terrainAlt, target)</c>
-        /// unchanged on the assumption that "alt ≥ terrain ⇒ not underground". That only
-        /// holds if the root part origin is the lowest point of the vessel, which is
-        /// false for any vessel with the command pod on top (Mk1-3: ~1.77 m below root).
-        /// The 2026-04-09 s33 playtest had three landed leaves with clearances 0.8/0.9/1.3 m,
-        /// all in the no-op range, all spawned clipped into terrain. The gap is now closed:
-        /// any alt below target is clamped up regardless of whether it's below terrain.</para>
+        /// Safety floor above PQS terrain. Only used when the recorded altitude is below
+        /// current PQS terrain (terrain shift since recording) — we push up by this much
+        /// above raw terrain to avoid an underground spawn. Not a clearance target.
         /// </summary>
-        internal const double LandedClearanceMeters = 2.0;
+        internal const double UndergroundSafetyFloorMeters = 2.0;
 
         /// <summary>
-        /// NaN-fallback clearance for ghost playback of Landed/Splashed recordings (#282).
+        /// Trigger threshold for walkback-to-surface snapping. If a walkback trajectory
+        /// candidate is more than this many metres above the raycast-detected surface at
+        /// its (lat, lon), we snap it down to surface + clearance — otherwise trust the
+        /// recorded altitude. Guards against spawning a diagonally-descending vessel in
+        /// mid-air.
+        /// </summary>
+        internal const double WalkbackSurfaceSnapThresholdMeters = 5.0;
+
+        /// <summary>
+        /// Clearance above the raycast-detected surface when snapping a walkback candidate
+        /// down to the ground. KSP's Vessel.CheckGroundCollision will fire on load and
+        /// further adjust via getLowestPoint(), so we only need a small breathing-room.
+        /// </summary>
+        internal const double WalkbackSurfaceClearanceMeters = 1.0;
+
+        /// <summary>
+        /// Part-collider layer mask used by the walkback raycast. Matches KSP's
+        /// Vessel.GetHeightFromSurface: <c>LayerUtil.DefaultEquivalent | 0x8000 | 0x80000</c>
+        /// — default layers + terrain (layer 15) + buildings (layer 19). Hits BOTH raw PQS
+        /// terrain AND placed mesh objects (Island Airfield, launchpad, KSC facilities),
+        /// unlike body.TerrainAltitude() which is PQS-only.
+        /// </summary>
+        private static int WalkbackSurfaceLayerMask
+        {
+            get { return LayerUtil.DefaultEquivalent | 0x8000 | 0x80000; }
+        }
+
+        /// <summary>
+        /// Starting height above expected surface for the walkback raycast origin. We
+        /// cast downward from (startAltAboveSurface + this) to ensure the ray origin is
+        /// above any collider at the query point.
+        /// </summary>
+        private const double WalkbackRaycastOriginOffsetMeters = 1000.0;
+
+        /// <summary>
+        /// Maximum raycast distance. Covers the offset + a margin for deep valleys.
+        /// </summary>
+        private const float WalkbackRaycastMaxDistanceMeters = 2500f;
+
+        /// <summary>
+        /// Fires a top-down <see cref="Physics.Raycast"/> at <paramref name="lat"/>/<paramref name="lon"/>
+        /// to find the true surface altitude — including mesh objects the PQS terrain
+        /// query cannot see. Returns <see cref="double.NaN"/> if no collider is hit
+        /// (target area not loaded, space, etc.). Used by the walkback clamp path to
+        /// snap mid-air trajectory candidates to the ground without losing mesh-object
+        /// offsets.
+        /// </summary>
+        internal static double TryFindSurfaceAltitudeViaRaycast(
+            CelestialBody body, double lat, double lon, double startAltAboveSurface)
+        {
+            if (body == null)
+            {
+                ParsekLog.Verbose("Spawner",
+                    "TryFindSurfaceAltitudeViaRaycast: null body — returning NaN");
+                return double.NaN;
+            }
+
+            double originAlt = startAltAboveSurface + WalkbackRaycastOriginOffsetMeters;
+            Vector3d originWorld = body.GetWorldSurfacePosition(lat, lon, originAlt);
+            Vector3d upAxis = body.GetSurfaceNVector(lat, lon);
+
+            RaycastHit hit;
+            bool didHit = Physics.Raycast(
+                (Vector3)originWorld,
+                -(Vector3)upAxis,
+                out hit,
+                WalkbackRaycastMaxDistanceMeters,
+                WalkbackSurfaceLayerMask,
+                QueryTriggerInteraction.Ignore);
+
+            if (!didHit)
+            {
+                // Rate-limited: walkback may call this once per sub-step on trajectories
+                // where the area is not loaded (distant spawn from tracking station).
+                ParsekLog.VerboseRateLimited("Spawner", "walkback-raycast-miss",
+                    $"TryFindSurfaceAltitudeViaRaycast: no hit at " +
+                    $"lat={lat.ToString("F6", System.Globalization.CultureInfo.InvariantCulture)} " +
+                    $"lon={lon.ToString("F6", System.Globalization.CultureInfo.InvariantCulture)} " +
+                    $"(origin alt={originAlt.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)}) — returning NaN");
+                return double.NaN;
+            }
+
+            double hitAlt = FlightGlobals.getAltitudeAtPos((Vector3d)hit.point, body);
+            ParsekLog.VerboseRateLimited("Spawner", "walkback-raycast-hit",
+                $"TryFindSurfaceAltitudeViaRaycast: hit at alt={hitAlt.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)} " +
+                $"(distance={hit.distance.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)}m, " +
+                $"collider={(hit.collider != null ? hit.collider.name : "<null>")})");
+            return hitAlt;
+        }
+
+        /// <summary>
+        /// NaN-fallback clearance for ghost playback of Landed/Splashed recordings.
         /// Only used when <c>Recording.TerrainHeightAtEnd</c> is NaN (legacy recordings
-        /// without terrain data). When terrain data is available,
-        /// <c>ApplyLandedGhostClearance</c> uses <c>TerrainCorrector.ComputeCorrectedAltitude</c>
-        /// to preserve the vessel's original recorded clearance above terrain instead.
+        /// without surface data). When surface data is available,
+        /// <c>ApplyLandedGhostClearance</c> trusts the recorded altitude directly and
+        /// only pushes up when it falls below the current PQS underground safety floor.
         /// </summary>
         internal const double LandedGhostClearanceMeters = 4.0;
 
-        internal static double ClampAltitudeForLanded(double alt, double terrainAlt,
+        /// <summary>
+        /// Pure: sanity check landed spawn altitude against PQS terrain.
+        ///
+        /// <para>Philosophy: the recorded altitude is the TRUTH — the vessel was literally
+        /// at that altitude when the recording terminal state was determined to be LANDED.
+        /// For vessels on terrain, the recorded clearance above PQS is small (1-5m). For
+        /// vessels on mesh objects (Island Airfield, launchpad, KSC buildings), the recorded
+        /// clearance above PQS can be 10-30m because <c>body.TerrainAltitude()</c> only
+        /// returns the raw planetary surface UNDER the mesh object. We must preserve both.</para>
+        ///
+        /// <para>The only case where clamping is needed: the PQS terrain has shifted UP
+        /// since recording (KSP update, terrain mod change). Then the recorded altitude may
+        /// be below the current terrain, and we push up by <see cref="UndergroundSafetyFloorMeters"/>.
+        /// Otherwise we return the recorded altitude unchanged and let KSP's
+        /// <c>Vessel.CheckGroundCollision</c> handle any remaining part-geometry clipping
+        /// via <c>getLowestPoint()</c> against real colliders (including buildings).</para>
+        /// </summary>
+        internal static double ClampAltitudeForLanded(double alt, double pqsTerrainAlt,
             int index, string vesselName)
         {
             var ic = CultureInfo.InvariantCulture;
-            double target = terrainAlt + LandedClearanceMeters;
+            double safetyFloor = pqsTerrainAlt + UndergroundSafetyFloorMeters;
 
-            if (alt > target)
+            if (alt < safetyFloor)
             {
-                // Above target: clamp down (vessel was still descending when recorded)
-                double delta = alt - target;
-                ParsekLog.Verbose("Spawner",
+                // Rate-limited by spawn index so each spawn logs once, but repeated
+                // walkback substeps for the same spawn are deduped.
+                double delta = safetyFloor - alt;
+                ParsekLog.VerboseRateLimited("Spawner", $"clamp-pqs-floor-{index}",
                     $"Clamped altitude for LANDED spawn #{index} ({vesselName}): " +
-                    $"{alt.ToString("F1", ic)} -> {target.ToString("F1", ic)} " +
-                    $"(down-clamp, delta={delta.ToString("F1", ic)})");
-                return target;
+                    $"{alt.ToString("F1", ic)} -> {safetyFloor.ToString("F1", ic)} " +
+                    $"(below-pqs-floor, delta=+{delta.ToString("F1", ic)}m, pqsTerrain={pqsTerrainAlt.ToString("F1", ic)})");
+                return safetyFloor;
             }
-            if (alt < target)
-            {
-                // Below target: clamp up. Reason depends on whether alt is also below terrain
-                // (truly underground) or just in the low-clearance gap above terrain.
-                double delta = target - alt;
-                string reason = alt < terrainAlt ? "underground" : "low-clearance";
-                ParsekLog.Verbose("Spawner",
-                    $"Clamped altitude for LANDED spawn #{index} ({vesselName}): " +
-                    $"{alt.ToString("F1", ic)} -> {target.ToString("F1", ic)} " +
-                    $"({reason}, delta={delta.ToString("F1", ic)})");
-                return target;
-            }
-            // alt == target exactly — no-op (rare, but possible after a prior clamp)
+
+            // Happy path (recorded altitude preserved) — no log. Walkback calls this
+            // once per substep, so logging the no-op case would spam hundreds of lines
+            // per spawn attempt. The diagnostic value is low; callers already log when
+            // they actually resolve the final spawn position.
             return alt;
         }
 

--- a/Source/Parsek/VesselSpawner.cs
+++ b/Source/Parsek/VesselSpawner.cs
@@ -897,11 +897,15 @@ namespace Parsek
                     if (!double.IsNaN(raycastSurface))
                     {
                         double above = walkAlt - raycastSurface;
-                        if (above > WalkbackSurfaceSnapThresholdMeters)
+                        // Snap when the candidate is well above the surface (mid-descent
+                        // trajectory point) OR below the surface (physics glitch / recorded
+                        // alt ended up under the real mesh). Review finding: the original
+                        // `above > threshold` check silently passed negative values through.
+                        if (above > WalkbackSurfaceSnapThresholdMeters || above < 0)
                         {
                             double snapped = raycastSurface + WalkbackSurfaceClearanceMeters;
                             ParsekLog.Info("Spawner",
-                                $"Walkback altitude too high above surface for #{index} ({rec.VesselName}): " +
+                                $"Walkback altitude snapping to surface for #{index} ({rec.VesselName}): " +
                                 $"walkAlt={walkAlt.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)} " +
                                 $"raycastSurface={raycastSurface.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)} " +
                                 $"above={above.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)}m " +
@@ -1065,6 +1069,14 @@ namespace Parsek
 
         /// <summary>
         /// Maximum raycast distance. Covers the offset + a margin for deep valleys.
+        /// Combined with <see cref="WalkbackRaycastOriginOffsetMeters"/> this gives a
+        /// practical altitude ceiling of ~1500 m above surface for walkback candidates
+        /// (above that, the ray won't reach the surface and <see cref="TryFindSurfaceAltitudeViaRaycast"/>
+        /// returns NaN, falling back to the PQS safety floor via
+        /// <see cref="ClampAltitudeForLanded"/>). This is fine for the walkback's target
+        /// use case — LANDED terminal trajectories where the final descent happens in
+        /// the last few hundred meters. Higher-altitude sub-orbital walkback candidates
+        /// degrade gracefully to PQS-based clamping.
         /// </summary>
         private const float WalkbackRaycastMaxDistanceMeters = 2500f;
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -7,6 +7,18 @@ Entries 272–303 (78 bugs, 6 TODOs — mostly resolved) archived in `done/todo-
 
 # Known Bugs
 
+## ~~308. Reserved kerbals appear assignable in VAB/SPH crew dialog~~
+
+**Observed in:** 0.8.0 (2026-04-12). Reserved kerbals (those whose recordings are playing back as ghosts) appear auto-assigned to vessel seats in the VAB/SPH crew dialog. The player sees them in the crew panel and thinks the reservation system failed.
+
+**Root cause:** KSP's `KerbalRoster.DefaultCrewForVessel` auto-assigns all Available kerbals into command pod seats. Reserved kerbals stay at Available status by design (changing rosterStatus caused tug-of-war bugs with `ValidateAssignments` -- see `CrewDialogFilterPatch` history). The existing `CrewDialogFilterPatch` (prefix on `BaseCrewAssignmentDialog.AddAvailItem`) correctly filters reserved kerbals from the Available crew list, but `DefaultCrewForVessel` runs before that filter, so reserved kerbals are already seated in the manifest. The flight-ready swap (`SwapReservedCrewInFlight` in `CrewReservationManager.cs`) catches this at launch time, but the user sees the wrong crew in the editor.
+
+**Fix:** Added `CrewAutoAssignPatch` (Harmony prefix on `BaseCrewAssignmentDialog.RefreshCrewLists`). Walks the `VesselCrewManifest` before UI list creation and replaces any reserved crew with their stand-ins from `CrewReservationManager.CrewReplacements`. If no stand-in is available, the seat is cleared. Pure decision logic extracted into `DecideSlotAction` (internal static) for testability. 8 unit tests in `CrewAutoAssignPatchTests.cs`. Files: `Patches/CrewAutoAssignPatch.cs`.
+
+**Status:** Fixed
+
+---
+
 ## ~~307. Rewind save lost on vessel switch during recording~~
 
 **Observed in:** 0.8.0 (2026-04-12). When the player switches vessels during an active recording session (e.g. switching from a booster to a payload, or clicking a different vessel in the tracking station), the R (rewind) button never appears on recordings committed after the switch.

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -7,6 +7,20 @@ Entries 272–303 (78 bugs, 6 TODOs — mostly resolved) archived in `done/todo-
 
 # Known Bugs
 
+## ~~312. Duplicate-blocker recovery destroys sibling recordings~~
+
+**Observed in:** 0.8.0 (2026-04-12). Playtest placed 4 "Crater Crawler" ghosts on the runway within ~10 m of each other. Only 2 of 4 spawned -- each new spawn destroyed the previous one. Log sequence showed `Duplicate blocker detected for #6: recovering pid=... at 8m -- likely quicksave-loaded duplicate (#112)` firing for every pair.
+
+**Root cause:** `VesselSpawner.ShouldRecoverBlockerVessel` matched by NAME only. The #112 fix was written for a specific scenario -- KSP's quicksave restores a Parsek-spawned vessel with the same PID while Parsek is also trying to spawn the same recording, creating two copies owned by the same recording. The correct response in that case is to destroy the restored duplicate. But a name-only check cannot distinguish that scenario from "four sibling recordings of the same vessel type landed near each other" -- in the latter, each new spawn found a sibling with the same vesselName and destroyed it, cascading across all four showcases.
+
+**Fix:** `ShouldRecoverBlockerVessel` now also requires the blocker's PID to match THIS recording's own `Recording.SpawnedVesselPersistentId`. That's the only way to be certain the blocker is a duplicate of OURSELVES (the #112 scenario). If the blocker belongs to a sibling recording (different `SpawnedVesselPersistentId`), the check returns false and `CheckSpawnCollisions` falls through to walkback, which finds a clear sub-step along the trajectory and spawns in the correct place.
+
+Signature change: `ShouldRecoverBlockerVessel(Recording rec, string blockerName, string recordingVesselName, uint blockerPid)`. The single call site in `CheckSpawnCollisions` now passes the recording and `blockerVessel.persistentId`. Unit tests in `DuplicateBlockerRecoveryTests` rewritten to cover the new PID-match logic: the #112 self-PID case (recover), the #312 sibling case (walkback), the first-spawn / `SpawnedVesselPersistentId == 0` case (walkback), and preserved null/empty/case-sensitive behavior from the original.
+
+**Status:** Fixed
+
+---
+
 ## ~~311. Walkback spawns mid-air on diagonally-descending trajectories~~
 
 **Observed in:** 0.8.0 (2026-04-12). When `TryWalkbackForEndOfRecordingSpawn` steps backward through a trajectory to find a non-overlapping candidate, it historically used the raw trajectory altitude for the clear position. For a vessel diagonally descending onto a landing site, the earlier trajectory points were 10-30 m in the air — walking back found a lateral-clear spot but placed the vessel mid-air, and it fell. Related to #309 (old `ClampAltitudeForLanded` would down-clamp the walkback result aggressively, which *accidentally* masked this, but broke mesh-object positioning).

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -39,7 +39,13 @@ Signature change: `ShouldRecoverBlockerVessel(Recording rec, string blockerName,
 
 **Root cause:** The original implementation (#127 or earlier) used `FallbackBoundsSize = 2f` as a conservative placeholder for the blocker vessel's bounds because there was no easy way to get the real bounds from a loaded `Vessel` object. The spawn side had access to the snapshot-computed AABB, but the blocker side used the 2 m cube. This was accurate enough for most rocket-to-rocket cases but broke down for large blockers and for mesh-object-adjacent spawns.
 
-**Fix:** Rewrote `CheckOverlapAgainstLoadedVessels` to use `Physics.OverlapBox` against real part colliders. Each hit is resolved to its owning `Part` via `FlightGlobals.GetPartUpwardsCached` (the same helper KSP uses in `Vessel.CheckGroundCollision`). Non-part hits (terrain, building, runway mesh colliders) are skipped via the null-Part filter — the airfield runway never blocks a spawn, but real vessel parts do. Layer mask: `(1<<0) | (1<<17) | (1<<19)` — default + EVA + PartTriggers, deliberately excluding terrain (15) and local scenery (23) since those are filtered at the Part-lookup stage anyway. Legacy filters (skip debris/EVA/flag, exempt parent vessel PID, skip active vessel) retained. The `BoundsOverlap` pure helper is kept for unit tests using injected predicates.
+**Fix:** Rewrote `CheckOverlapAgainstLoadedVessels` to use `Physics.OverlapBox` against real part colliders. Each hit is resolved to its owning `Part` via `FlightGlobals.GetPartUpwardsCached` (the same helper KSP uses in `Vessel.CheckGroundCollision`). Non-part hits (terrain, building, runway mesh colliders) are skipped via the null-Part filter — the airfield runway never blocks a spawn, but real vessel parts do.
+
+Layer mask: `LayerUtil.DefaultEquivalent` (0x820001 = bits 0, 17, 23) — the same mask KSP itself uses inside `Vessel.CheckGroundCollision` as the "part-bearing layers" identifier. An earlier revision of this fix used `(1<<0)|(1<<17)|(1<<19)` based on a misreading of Unity's layer map (assumed layer 19 was "PartTriggers"; per Principia's verified layer enum layer 19 is PhysicalObjects and PartTriggers is actually layer 21). Using KSP's own constant directly is both correct and future-proof against layer renumbering.
+
+OverlapBox rotation: `Quaternion.FromToRotation(Vector3.up, upAxis)` where `upAxis` is the surface normal at the spawn position (derived from the enclosing celestial body). Aligns the local-space AABB with the body's local up direction so spawns on the far side of a curved body use a correctly-oriented query box.
+
+Legacy filters (skip debris/EVA/flag, exempt parent vessel PID, skip active vessel) retained. The `BoundsOverlap` pure helper is kept for unit tests using injected predicates.
 
 **Status:** Fixed
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -7,13 +7,51 @@ Entries 272–303 (78 bugs, 6 TODOs — mostly resolved) archived in `done/todo-
 
 # Known Bugs
 
-## ~~308. Reserved kerbals appear assignable in VAB/SPH crew dialog~~
+## ~~311. Walkback spawns mid-air on diagonally-descending trajectories~~
 
-**Observed in:** 0.8.0 (2026-04-12). Reserved kerbals (those whose recordings are playing back as ghosts) appear auto-assigned to vessel seats in the VAB/SPH crew dialog. The player sees them in the crew panel and thinks the reservation system failed.
+**Observed in:** 0.8.0 (2026-04-12). When `TryWalkbackForEndOfRecordingSpawn` steps backward through a trajectory to find a non-overlapping candidate, it historically used the raw trajectory altitude for the clear position. For a vessel diagonally descending onto a landing site, the earlier trajectory points were 10-30 m in the air — walking back found a lateral-clear spot but placed the vessel mid-air, and it fell. Related to #309 (old `ClampAltitudeForLanded` would down-clamp the walkback result aggressively, which *accidentally* masked this, but broke mesh-object positioning).
 
-**Root cause:** KSP's `KerbalRoster.DefaultCrewForVessel` auto-assigns all Available kerbals into command pod seats. Reserved kerbals stay at Available status by design (changing rosterStatus caused tug-of-war bugs with `ValidateAssignments` -- see `CrewDialogFilterPatch` history). The existing `CrewDialogFilterPatch` (prefix on `BaseCrewAssignmentDialog.AddAvailItem`) correctly filters reserved kerbals from the Available crew list, but `DefaultCrewForVessel` runs before that filter, so reserved kerbals are already seated in the manifest. The flight-ready swap (`SwapReservedCrewInFlight` in `CrewReservationManager.cs`) catches this at launch time, but the user sees the wrong crew in the editor.
+**Root cause:** The walkback callback used `body.TerrainAltitude(lat, lon)` as the surface reference, which is PQS-only and cannot see the real surface when it includes mesh objects (Island Airfield runway, launchpad, KSC buildings). Either the vessel was spawned underground (mesh-object case) or left mid-air (regular terrain with sparse PQS fallback).
 
-**Fix:** Added `CrewAutoAssignPatch` (Harmony prefix on `BaseCrewAssignmentDialog.RefreshCrewLists`). Walks the `VesselCrewManifest` before UI list creation and replaces any reserved crew with their stand-ins from `CrewReservationManager.CrewReplacements`. If no stand-in is available, the seat is cleared. Pure decision logic extracted into `DecideSlotAction` (internal static) for testability. 8 unit tests in `CrewAutoAssignPatchTests.cs`. Files: `Patches/CrewAutoAssignPatch.cs`.
+**Fix:** After walkback returns a clear candidate, fire a top-down `Physics.Raycast` at the candidate `(lat, lon)` using the same layer mask as `Vessel.GetHeightFromSurface` (`LayerUtil.DefaultEquivalent | 0x8000 | 0x80000` — default + terrain + buildings). If the raycast hits AND the candidate altitude is more than `WalkbackSurfaceSnapThresholdMeters` (5 m) above the hit, snap the altitude down to `surface + WalkbackSurfaceClearanceMeters` (1 m). If the raycast misses (target area unloaded), fall back to the PQS safety floor via `ClampAltitudeForLanded`. The raycast catches real mesh-object surfaces that PQS terrain alone cannot represent. New helper: `VesselSpawner.TryFindSurfaceAltitudeViaRaycast(body, lat, lon, startAltAboveSurface)`. Uses `FlightGlobals.getAltitudeAtPos` to convert the hit point to ASL altitude.
+
+**Status:** Fixed
+
+---
+
+## ~~310. Spawn collision detection used 2 m-cube blocker approximation~~
+
+**Observed in:** 0.8.0 (2026-04-12). `SpawnCollisionDetector.CheckOverlapAgainstLoadedVessels` approximated every loaded vessel as a 2 m-cube at its `GetWorldPos3D()` position and did an AABB overlap check against the spawn bounds. Large vessels (stations, planes, carriers) were under-represented, letting walkback candidates pass inside their real geometry. Small rovers spawned near a docked station would be flagged as clear despite being inside the station's wings. Conversely, AABB false-positives were possible for sparse vessels with wide bounds.
+
+**Root cause:** The original implementation (#127 or earlier) used `FallbackBoundsSize = 2f` as a conservative placeholder for the blocker vessel's bounds because there was no easy way to get the real bounds from a loaded `Vessel` object. The spawn side had access to the snapshot-computed AABB, but the blocker side used the 2 m cube. This was accurate enough for most rocket-to-rocket cases but broke down for large blockers and for mesh-object-adjacent spawns.
+
+**Fix:** Rewrote `CheckOverlapAgainstLoadedVessels` to use `Physics.OverlapBox` against real part colliders. Each hit is resolved to its owning `Part` via `FlightGlobals.GetPartUpwardsCached` (the same helper KSP uses in `Vessel.CheckGroundCollision`). Non-part hits (terrain, building, runway mesh colliders) are skipped via the null-Part filter — the airfield runway never blocks a spawn, but real vessel parts do. Layer mask: `(1<<0) | (1<<17) | (1<<19)` — default + EVA + PartTriggers, deliberately excluding terrain (15) and local scenery (23) since those are filtered at the Part-lookup stage anyway. Legacy filters (skip debris/EVA/flag, exempt parent vessel PID, skip active vessel) retained. The `BoundsOverlap` pure helper is kept for unit tests using injected predicates.
+
+**Status:** Fixed
+
+---
+
+## ~~309. Rovers on Island Airfield spawn 19 m underground~~
+
+**Observed in:** 0.8.0 (2026-04-12). Rover recordings captured at the Island Airfield runway spawned 19 m below the runway surface, inside the raw PQS terrain. Ghost playback of the same recordings also rendered below the runway. Both spawn and ghost placement were treating the airfield as if it didn't exist.
+
+**Root cause:** Three call sites used `body.TerrainAltitude(lat, lon)` which is PQS-only — it queries `pqsController.GetSurfaceHeight()` and returns the raw planetary surface UNDER any placed mesh object (Island Airfield, launchpad, KSC facilities). For a vessel recorded ON the airfield at alt=133.9 m, `body.TerrainAltitude()` returned ~114.9 m (raw terrain under the runway). The three sites and their bugs:
+
+1. **`ParsekFlight.CaptureTerminalPosition`** stored `rec.TerrainHeightAtEnd = body.TerrainAltitude(...)` — losing the 19 m airfield offset. Downstream consumers computed `recordedClearance = alt - TerrainHeightAtEnd` and got ~19 m, which was meaningless to them.
+2. **`VesselSpawner.ClampAltitudeForLanded`** computed `target = terrainAlt + LandedClearanceMeters` and aggressively down-clamped any altitude above the target — specifically to fix #282 (Mk1-3 pod low-clearance clipping). For airfield rovers, this buried them 17 m below the runway.
+3. **`VesselGhoster.ApplyTerrainCorrection`** called `TerrainCorrector.ComputeCorrectedAltitude(currentTerrain, recordedAlt, recordedTerrain)` which computed `corrected = currentTerrain + (recordedAlt - recordedTerrain)` — mathematically correct for terrain-relative correction, but `currentTerrain` was PQS-only, so the "corrected" altitude was placed relative to PQS, burying ghosts under the runway.
+
+Decompiling `Vessel.CheckGroundCollision` and `Vessel.GetHeightFromSurface` confirmed the right API: KSP uses `Physics.Raycast` with layer mask `LayerUtil.DefaultEquivalent | 0x8000 | 0x80000` to find the true surface including building colliders. The `Vessel.terrainAltitude` property (documented as "height in meters of the nearest terrain **including buildings**") is reverse-computed from that raycast — available on loaded vessels.
+
+**Fix:** Replaced PQS-only terrain queries with the correct surface-aware sources and changed the clamping philosophy from "force to terrain+2 m" to "trust the recorded altitude, only push up if below PQS safety floor":
+
+1. **`ParsekFlight.CaptureTerminalPosition`** — captures `vessel.terrainAltitude` (raycast-derived, includes buildings) instead of `body.TerrainAltitude()`. Also logs the PQS vs. mesh offset for diagnostics.
+2. **`VesselSpawner.ClampAltitudeForLanded`** — rewritten. No more down-clamp. Only clamps UP when `alt < (pqsTerrain + UndergroundSafetyFloorMeters)` (2 m), which only fires when PQS terrain has shifted up since recording (rare: KSP update / terrain mod). The #282 low-clearance case is still caught by this floor. KSP's own `Vessel.CheckGroundCollision` handles part-geometry clipping via `getLowestPoint()` on vessel load, so we don't need to front-run it. Renamed `LandedClearanceMeters` → `UndergroundSafetyFloorMeters` (semantic shift — it's a floor, not a target).
+3. **`ParsekFlight.ApplyLandedGhostClearance`** — same philosophy. Trusts the recorded altitude; only pushes up if below `pqsTerrain + 0.5 m`. NaN-fallback legacy path unchanged.
+4. **`VesselGhoster.ApplyTerrainCorrection`** — rewritten to apply the underground safety floor (0.5 m above PQS) instead of terrain-relative correction.
+5. **Removed `TerrainCorrector.ComputeCorrectedAltitude`** — the terrain-relative correction formula was the core of the bug. Tests that encoded it also removed.
+
+**Test rewrite:** `SpawnSafetyNetTests.ClampAltitudeForLanded_*` updated to match the new semantics. The #282 low-clearance case (176.5 m recorded, 175.6 m PQS terrain, 0.9 m clearance) is preserved as a regression guard — it now triggers the 2 m safety floor and pushes up to 177.6 m. Airfield case (133.9 m recorded, 114.9 m PQS terrain, 19 m mesh offset) passes through unchanged.
 
 **Status:** Fixed
 
@@ -461,6 +499,18 @@ The R button never appears in the recordings table because `RewindSaveFileName` 
 **Fix:** Extracted `CopyRewindSaveToRoot` (ParsekFlight, internal static) that copies `RewindSaveFileName`, reserved budget (funds/science/rep), and pre-launch budget from a `CaptureAtStop` to the tree's root recording. Called from four sites: `CreateSplitBranch` (the primary T59 fix -- copies at branch time before the EVA recorder takes over), `FinalizeTreeRecordings`, `StashActiveTreeAsPendingLimbo`, and `MergeCommitFlush`. First-wins semantics: root fields are only set if currently empty.
 
 **Status:** ~~Fixed~~
+
+---
+
+## 308. Reserved kerbals appear assignable in VAB/SPH crew dialog
+
+**Observed in:** 0.8.0 (2026-04-12). Reserved kerbals (those whose recordings are playing back as ghosts) appear auto-assigned to vessel seats in the VAB/SPH crew dialog. The player sees them in the crew panel and thinks the reservation system failed.
+
+**Root cause:** KSP's `KerbalRoster.DefaultCrewForVessel` auto-assigns all Available kerbals into command pod seats. Reserved kerbals stay at Available status by design (changing rosterStatus caused tug-of-war bugs with `ValidateAssignments` -- see `CrewDialogFilterPatch` history). The existing `CrewDialogFilterPatch` (prefix on `BaseCrewAssignmentDialog.AddAvailItem`) correctly filters reserved kerbals from the Available crew list, but `DefaultCrewForVessel` runs before that filter, so reserved kerbals are already seated in the manifest. The flight-ready swap (`SwapReservedCrewInFlight` in `CrewReservationManager.cs`) catches this at launch time, but the user sees the wrong crew in the editor.
+
+**Fix:** Added `CrewAutoAssignPatch` (Harmony prefix on `BaseCrewAssignmentDialog.RefreshCrewLists`). Walks the `VesselCrewManifest` before UI list creation and replaces any reserved crew with their stand-ins from `CrewReservationManager.CrewReplacements`. If no stand-in is available, the seat is cleared. Pure decision logic extracted into `DecideSlotAction` (internal static) for testability. 8 unit tests in `CrewAutoAssignPatchTests.cs`. Files: `Patches/CrewAutoAssignPatch.cs`.
+
+**Status:** Fixed
 
 ---
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -7,6 +7,20 @@ Entries 272–303 (78 bugs, 6 TODOs — mostly resolved) archived in `done/todo-
 
 # Known Bugs
 
+## ~~307. Rewind save lost on vessel switch during recording~~
+
+**Observed in:** 0.8.0 (2026-04-12). When the player switches vessels during an active recording session (e.g. switching from a booster to a payload, or clicking a different vessel in the tracking station), the R (rewind) button never appears on recordings committed after the switch.
+
+**Root cause:** `OnVesselSwitchComplete` has two flush paths for the outgoing recorder: (1) still-active recorder transitioned to background (line 1335), and (2) already-backgrounded recorder with pending flush (line 1361). Both paths called `FlushRecorderToTreeRecording` but did not call `CopyRewindSaveToRoot`. The rewind save filename from the outgoing recorder's `CaptureAtStop` was never propagated to the tree root recording. After the switch, `recorder` is set to null, and when the tree is eventually committed, `GetRewindRecording` resolves through the root -- which has a null `RewindSaveFileName`.
+
+Related to T59 (EVA branch case), which fixed the same underlying problem in `CreateSplitBranch`. The vessel-switch paths were missed.
+
+**Fix:** Added `CopyRewindSaveToRoot` calls in both vessel-switch flush paths in `OnVesselSwitchComplete` (lines 1337 and 1362), right after `FlushRecorderToTreeRecording` and before `recorder = null`. Uses `recorder.CaptureAtStop` as primary source with `recorder.RewindSaveFileName` as fallback, consistent with all other flush sites.
+
+**Status:** Fixed
+
+---
+
 ## ~~306. Ghost engine nozzles always glow red~~
 
 **Observed in:** 0.8.0 (2026-04-12). Engine nozzle parts on ghost vessels permanently displayed a red/orange emissive glow, as if overheating. Stock KSP engines do not glow during normal operation -- the emissive channel is driven at runtime by the thermal system (`part.temperature / part.maxTemperature`).


### PR DESCRIPTION
## Summary

Five bugs from the bugfixes-2 playtest. Three commits + a UI polish + an in-game test refresh.

- **#307** Rewind (R button) lost on vessel-switch during recording -- `CopyRewindSaveToRoot` not called in `OnVesselSwitchComplete`'s two flush paths.
- **#308** Reserved kerbals auto-assigned in VAB/SPH crew dialog -- KSP's `KerbalRoster.DefaultCrewForVessel` runs before `CrewDialogFilterPatch`, leaving reserved crew seated in the manifest. New `CrewAutoAssignPatch` swaps them for stand-ins.
- **#309 / #310 / #311** Spawn positioning overhaul. `body.TerrainAltitude()` is PQS-only and is blind to placed mesh objects (Island Airfield runway, launchpad, KSC buildings) -- the old code used it everywhere and buried any vessel recorded on a raised mesh surface 19 m below the runway. The collision-avoidance walkback also approximated blocker vessels as 2 m cubes, missing real geometry.
  - **#309** Recording captures `vessel.terrainAltitude` (KSP's raycast-derived true surface). Spawn / ghost / VesselGhoster all trust the recorded altitude and only apply an underground safety floor against PQS. Removed `TerrainCorrector.ComputeCorrectedAltitude`.
  - **#310** `SpawnCollisionDetector.CheckOverlapAgainstLoadedVessels` uses `Physics.OverlapBox` + `FlightGlobals.GetPartUpwardsCached` (the same helper KSP's `Vessel.CheckGroundCollision` uses) to test against real part colliders. Non-part hits (terrain, building, runway mesh) are filtered.
  - **#311** Walkback now fires a top-down `Physics.Raycast` at the cleared candidate position. If the candidate altitude is more than 5 m above the hit, snap down to surface + 1 m. Prevents diagonally-descending trajectories from spawning a vessel mid-air.

All per-substep diagnostic logs are `VerboseRateLimited` to avoid spam.

## Test plan

- [x] `dotnet build` clean (0 warnings, 0 errors)
- [x] `dotnet test` -- 5758 / 5758 pass
- [ ] Playtest: record a rover on the Island Airfield, exit to KSC, verify the spawned rover sits on the runway (not below it)
- [ ] Playtest: record on a tree with an in-flight vessel switch, verify the R (rewind) button appears on the recording row in the manager
- [ ] Playtest: launch a new vessel from the VAB while a recording is active and a kerbal is reserved -- verify the reserved kerbal is replaced by a stand-in in the crew dialog before launch
- [ ] Playtest: spawn an EVA next to its parent vessel, verify walkback finds a clear position on the ground (not in mid-air)
- [ ] Playtest: spawn a small vessel near a docked station, verify the station's actual hull blocks the spawn (not just the 2 m cube around its center)