### PR TITLE
Fix splashed spawn floor and clarify R/FF guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- Splashed terminal spawns now floor any slightly negative endpoint altitude back to sea level before spawn, so EVA and breakup-continuous splashdowns no longer materialize a few centimeters underwater (`#313`).
 - Watched ghosts now use exact watched-state identity (`recording + overlap cycle`) for full-fidelity protection. Overlap copies of the same looping recording no longer inherit watched-only exemptions or diagnostics counts.
 - Watch cutoff / zone state for hidden looped ghosts now follows their logical playback position instead of a stale hidden transform, so watch eligibility and auto-exit stay correct while a loop is off-screen.
 - The old warp-only orbital exemption no longer punches through the new `50-120 km` hidden-mesh tier. Orbital ghosts still get the legacy exemption only in the true `Beyond` zone.
@@ -20,6 +21,7 @@ All notable changes to Parsek are documented here.
 
 ### Developer Tools
 
+- Added regression coverage for R/FF enablement reasons, including future/past timing, tree-branch rewind save resolution, and a UI guard that pins rewind/fast-forward independence from watch-distance state (`T60`).
 - Added regression coverage for exact watched-cycle protection, hidden-tier warp exemption, watched-override diagnostics counting, and the new frame-context watch-cycle field.
 
 ---

--- a/Source/Parsek.Tests/FastForwardTests.cs
+++ b/Source/Parsek.Tests/FastForwardTests.cs
@@ -84,6 +84,42 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void CanFastForwardAtUT_CurrentRecording_ReturnsFalse()
+        {
+            var rec = new Recording { VesselName = "Current" };
+            rec.Points.Add(new TrajectoryPoint { ut = 100.0 });
+            rec.Points.Add(new TrajectoryPoint { ut = 150.0 });
+
+            string reason;
+            Assert.False(RecordingStore.CanFastForwardAtUT(rec, 100.0, out reason, isRecording: false));
+            Assert.Equal("Recording is not in the future", reason);
+        }
+
+        [Fact]
+        public void CanFastForwardAtUT_PastRecording_ReturnsFalse()
+        {
+            var rec = new Recording { VesselName = "Past" };
+            rec.Points.Add(new TrajectoryPoint { ut = 100.0 });
+            rec.Points.Add(new TrajectoryPoint { ut = 150.0 });
+
+            string reason;
+            Assert.False(RecordingStore.CanFastForwardAtUT(rec, 500.0, out reason, isRecording: false));
+            Assert.Equal("Recording is not in the future", reason);
+        }
+
+        [Fact]
+        public void CanFastForwardAtUT_FutureRecording_ReturnsTrue()
+        {
+            var rec = new Recording { VesselName = "Future" };
+            rec.Points.Add(new TrajectoryPoint { ut = 100.0 });
+            rec.Points.Add(new TrajectoryPoint { ut = 150.0 });
+
+            string reason;
+            Assert.True(RecordingStore.CanFastForwardAtUT(rec, 50.0, out reason, isRecording: false));
+            Assert.Equal(string.Empty, reason);
+        }
+
+        [Fact]
         public void CanFastForward_IsRecording_ReturnsFalse()
         {
             var rec = MakeFutureRecording();

--- a/Source/Parsek.Tests/RecordingsTableUITests.cs
+++ b/Source/Parsek.Tests/RecordingsTableUITests.cs
@@ -196,6 +196,42 @@ namespace Parsek.Tests
             Assert.DoesNotContain("groupName + \"/\" + (mainRecId ?? \"\")", uiSrc);
         }
 
+        [Fact]
+        public void TemporalButtons_RemainIndependentFromWatchState_PinnedBySourceInspection()
+        {
+            // T60: the watch button uses ghost presence/body/range, but R/FF must stay
+            // coupled only to recording timing/save/runtime state. Pin that separation
+            // in both row and group call sites so a future refactor can't silently wire
+            // watch-distance variables into the temporal controls.
+            string srcRoot = System.IO.Path.GetFullPath(
+                System.IO.Path.Combine(System.AppDomain.CurrentDomain.BaseDirectory,
+                    "..", "..", "..", "..", "Parsek"));
+            string uiSrc = System.IO.File.ReadAllText(
+                System.IO.Path.Combine(srcRoot, "UI", "RecordingsTableUI.cs"));
+
+            int rowStart = uiSrc.IndexOf("// Rewind / Fast-forward button", StringComparison.Ordinal);
+            int rowEnd = uiSrc.IndexOf("// Hide checkbox", rowStart, StringComparison.Ordinal);
+            string rowBlock = uiSrc.Substring(rowStart, rowEnd - rowStart);
+
+            Assert.Contains("RecordingStore.CanFastForward(rec, out ffReason, isRecording: isRecording)", rowBlock);
+            Assert.Contains("RecordingStore.CanRewind(rec, out rewindReason, isRecording: isRecording)", rowBlock);
+            Assert.DoesNotContain("canWatch", rowBlock);
+            Assert.DoesNotContain("hasGhost", rowBlock);
+            Assert.DoesNotContain("sameBody", rowBlock);
+            Assert.DoesNotContain("inRange", rowBlock);
+
+            int groupStart = uiSrc.IndexOf("// Rewind / Fast-forward button — targets main recording", StringComparison.Ordinal);
+            int groupEnd = uiSrc.IndexOf("// Hide group checkbox", groupStart, StringComparison.Ordinal);
+            string groupBlock = uiSrc.Substring(groupStart, groupEnd - groupStart);
+
+            Assert.Contains("RecordingStore.CanFastForward(mainRec, out ffReason, isRecording: isRecording)", groupBlock);
+            Assert.Contains("RecordingStore.CanRewind(mainRec, out rewindReason, isRecording: isRecording)", groupBlock);
+            Assert.DoesNotContain("canWatch", groupBlock);
+            Assert.DoesNotContain("hasGhost", groupBlock);
+            Assert.DoesNotContain("sameBody", groupBlock);
+            Assert.DoesNotContain("inRange", groupBlock);
+        }
+
         // ── GetRecordingSortKey ──
 
         [Fact]

--- a/Source/Parsek.Tests/RewindTreeLookupTests.cs
+++ b/Source/Parsek.Tests/RewindTreeLookupTests.cs
@@ -243,6 +243,42 @@ namespace Parsek.Tests
             Assert.Equal("No rewind save available", reason);
         }
 
+        [Fact]
+        public void CanRewind_TreeBranchRootHasNoSave_ReturnsNoSaveAvailable()
+        {
+            var tree = BuildTree("tree6", "root6", null,
+                ("branch6", "EVAKerbal"));
+            RecordingStore.AddCommittedTreeForTesting(tree);
+
+            var branch = tree.Recordings["branch6"];
+            string resolvedSave = RecordingStore.GetRewindSaveFileName(branch);
+
+            string reason;
+            bool result = RecordingStore.CanRewindWithResolvedSaveState(
+                resolvedSave, saveExists: false, out reason, isRecording: false);
+
+            Assert.False(result);
+            Assert.Equal("No rewind save available", reason);
+        }
+
+        [Fact]
+        public void CanRewind_TreeBranchSaveFileMissing_ReturnsSaveMissing()
+        {
+            var tree = BuildTree("tree7", "root7", "parsek_rw_r7",
+                ("branch7", "EVAKerbal"));
+            RecordingStore.AddCommittedTreeForTesting(tree);
+
+            var branch = tree.Recordings["branch7"];
+            string resolvedSave = RecordingStore.GetRewindSaveFileName(branch);
+
+            string reason;
+            bool result = RecordingStore.CanRewindWithResolvedSaveState(
+                resolvedSave, saveExists: false, out reason, isRecording: false);
+
+            Assert.False(result);
+            Assert.Equal("Rewind save file missing", reason);
+        }
+
         #endregion
 
         #region Logging

--- a/Source/Parsek.Tests/SpawnSafetyNetTests.cs
+++ b/Source/Parsek.Tests/SpawnSafetyNetTests.cs
@@ -912,9 +912,11 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void ResolveSpawnPosition_BreakupContinuousSplashed_NegativeAlt_NoClamp()
+        public void ResolveSpawnPosition_BreakupContinuousSplashed_NegativeAlt_FloorsToZero()
         {
-            // Already at or below sea level — no clamping needed
+            // Bug #313 follow-up: breakup-continuous splashed endpoints use the same
+            // sea-surface floor as EVA/non-breakup spawns. Slightly negative altitudes
+            // are numerical noise and must be corrected back to 0 before spawn.
             var rec = new Recording
             {
                 VesselSnapshot = new ConfigNode("VESSEL"),
@@ -926,7 +928,8 @@ namespace Parsek.Tests
             var lastPt = new TrajectoryPoint { latitude = -0.12, longitude = -73.72, altitude = -1.5 };
             VesselSpawner.ResolveSpawnPosition(rec, 13, lastPt, out double lat, out double lon, out double alt);
 
-            Assert.Equal(-1.5, alt);
+            Assert.Equal(0.0, alt);
+            Assert.Contains(logLines, l => l.Contains("Clamped altitude") && l.Contains("SPLASHED"));
         }
 
         [Fact]
@@ -974,6 +977,38 @@ namespace Parsek.Tests
             Assert.Equal(10.0, lon);
             Assert.Equal(0.0, alt);
             Assert.Contains(logLines, l => l.Contains("Clamped altitude") && l.Contains("SPLASHED"));
+        }
+
+        [Fact]
+        public void ResolveSpawnPosition_EvaSplashed_NegativeEndpointAltitude_FloorsToSeaLevel()
+        {
+            // Bug #313: splashed EVA endpoints can land slightly below sea level due to
+            // the recorded final trajectory sample. The spawn safety net must floor those
+            // negative values back to the water surface before snapshot override/spawn.
+            var rec = new Recording
+            {
+                VesselSnapshot = new ConfigNode("VESSEL"),
+                EvaCrewName = "Raydred Kerman",
+                TerminalStateValue = TerminalState.Splashed,
+                VesselName = "Raydred Kerman"
+            };
+
+            var lastPt = new TrajectoryPoint
+            {
+                latitude = 1.25,
+                longitude = -74.5,
+                altitude = -0.213434,
+                bodyName = "Kerbin"
+            };
+
+            VesselSpawner.ResolveSpawnPosition(rec, 25, lastPt, out double lat, out double lon, out double alt);
+
+            Assert.Equal(1.25, lat);
+            Assert.Equal(-74.5, lon);
+            Assert.Equal(0.0, alt);
+            Assert.Contains(logLines, l =>
+                l.Contains("Clamped altitude for SPLASHED spawn #25")
+                && l.Contains("Raydred Kerman"));
         }
 
         // ── ClampAltitudeForLanded (pure, testable without CelestialBody) ──

--- a/Source/Parsek.Tests/SpawnSafetyNetTests.cs
+++ b/Source/Parsek.Tests/SpawnSafetyNetTests.cs
@@ -959,6 +959,36 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void ResolveSpawnPosition_NonBreakupSplashed_NegativeSnapshotAltitude_FloorsToSeaLevel()
+        {
+            // The splashed safety net must also floor slightly negative snapshot altitudes,
+            // not just positive ones, for non-breakup snapshot-based spawns.
+            var snapshot = new ConfigNode("VESSEL");
+            snapshot.AddValue("lat", "-0.12");
+            snapshot.AddValue("lon", "-73.72");
+            snapshot.AddValue("alt", "-0.25");
+
+            var rec = new Recording
+            {
+                VesselSnapshot = snapshot,
+                EvaCrewName = null,
+                ChildBranchPointId = null,
+                TerminalStateValue = TerminalState.Splashed,
+                VesselName = "Snapshot Floater"
+            };
+
+            var lastPt = new TrajectoryPoint { latitude = 0, longitude = 0, altitude = 0 };
+            VesselSpawner.ResolveSpawnPosition(rec, 6, lastPt, out double lat, out double lon, out double alt);
+
+            Assert.Equal(-0.12, lat);
+            Assert.Equal(-73.72, lon);
+            Assert.Equal(0.0, alt);
+            Assert.Contains(logLines, l =>
+                l.Contains("Clamped altitude for SPLASHED spawn #6")
+                && l.Contains("Snapshot Floater"));
+        }
+
+        [Fact]
         public void ResolveSpawnPosition_EvaLanded_FallsThroughToSplashedClamp()
         {
             // EVA recordings previously returned early, bypassing altitude clamping.

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -2130,14 +2130,12 @@ namespace Parsek
         internal static bool CanRewind(Recording rec, out string reason, bool isRecording)
         {
             string resolvedSave = GetRewindSaveFileName(rec);
-            bool saveExists = false;
-            if (!string.IsNullOrEmpty(resolvedSave))
-            {
-                string savePath = RecordingPaths.ResolveSaveScopedPath(
-                    RecordingPaths.BuildRewindSaveRelativePath(resolvedSave));
-                saveExists = !string.IsNullOrEmpty(savePath) && File.Exists(savePath);
-            }
+            if (!CanRewindPreFileCheck(resolvedSave, out reason, isRecording))
+                return false;
 
+            string savePath = RecordingPaths.ResolveSaveScopedPath(
+                RecordingPaths.BuildRewindSaveRelativePath(resolvedSave));
+            bool saveExists = !string.IsNullOrEmpty(savePath) && File.Exists(savePath);
             return CanRewindWithResolvedSaveState(resolvedSave, saveExists, out reason, isRecording);
         }
 
@@ -2147,6 +2145,23 @@ namespace Parsek
         /// </summary>
         internal static bool CanRewindWithResolvedSaveState(
             string resolvedSave, bool saveExists, out string reason, bool isRecording)
+        {
+            if (!CanRewindPreFileCheck(resolvedSave, out reason, isRecording))
+                return false;
+
+            if (!saveExists)
+            {
+                reason = "Rewind save file missing";
+                // Per-frame logging removed (was 3.7% of all log output); reason returned to caller
+                return false;
+            }
+
+            reason = "";
+            // Per-frame logging removed; reason returned to caller
+            return true;
+        }
+
+        private static bool CanRewindPreFileCheck(string resolvedSave, out string reason, bool isRecording)
         {
             if (IsRewinding)
             {
@@ -2172,13 +2187,6 @@ namespace Parsek
             if (HasPendingTree)
             {
                 reason = "Merge or discard pending tree first";
-                // Per-frame logging removed (was 3.7% of all log output); reason returned to caller
-                return false;
-            }
-
-            if (!saveExists)
-            {
-                reason = "Rewind save file missing";
                 // Per-frame logging removed (was 3.7% of all log output); reason returned to caller
                 return false;
             }

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -2129,6 +2129,25 @@ namespace Parsek
         /// </summary>
         internal static bool CanRewind(Recording rec, out string reason, bool isRecording)
         {
+            string resolvedSave = GetRewindSaveFileName(rec);
+            bool saveExists = false;
+            if (!string.IsNullOrEmpty(resolvedSave))
+            {
+                string savePath = RecordingPaths.ResolveSaveScopedPath(
+                    RecordingPaths.BuildRewindSaveRelativePath(resolvedSave));
+                saveExists = !string.IsNullOrEmpty(savePath) && File.Exists(savePath);
+            }
+
+            return CanRewindWithResolvedSaveState(resolvedSave, saveExists, out reason, isRecording);
+        }
+
+        /// <summary>
+        /// Testable core of <see cref="CanRewind"/> once tree-root save resolution and file
+        /// existence have already been computed by the caller.
+        /// </summary>
+        internal static bool CanRewindWithResolvedSaveState(
+            string resolvedSave, bool saveExists, out string reason, bool isRecording)
+        {
             if (IsRewinding)
             {
                 reason = "Rewind already in progress";
@@ -2136,8 +2155,6 @@ namespace Parsek
                 return false;
             }
 
-            // Resolve rewind save through tree root if needed
-            string resolvedSave = GetRewindSaveFileName(rec);
             if (string.IsNullOrEmpty(resolvedSave))
             {
                 reason = "No rewind save available";
@@ -2159,10 +2176,7 @@ namespace Parsek
                 return false;
             }
 
-            // Verify the save file exists
-            string savePath = RecordingPaths.ResolveSaveScopedPath(
-                RecordingPaths.BuildRewindSaveRelativePath(resolvedSave));
-            if (string.IsNullOrEmpty(savePath) || !File.Exists(savePath))
+            if (!saveExists)
             {
                 reason = "Rewind save file missing";
                 // Per-frame logging removed (was 3.7% of all log output); reason returned to caller
@@ -2179,6 +2193,34 @@ namespace Parsek
         /// Subset of CanRewind — no save file required (FF advances UT, doesn't load a save).
         /// </summary>
         internal static bool CanFastForward(Recording rec, out string reason, bool isRecording)
+        {
+            if (!CanFastForwardPreRuntime(rec, out reason, isRecording))
+                return false;
+
+            return CanFastForwardAtUT(rec, Planetarium.GetUniversalTime(), out reason, isRecording);
+        }
+
+        /// <summary>
+        /// Testable core of <see cref="CanFastForward"/> with the current UT supplied by the caller.
+        /// </summary>
+        internal static bool CanFastForwardAtUT(Recording rec, double now, out string reason, bool isRecording)
+        {
+            if (!CanFastForwardPreRuntime(rec, out reason, isRecording))
+                return false;
+
+            if (now >= rec.StartUT)
+            {
+                reason = "Recording is not in the future";
+                // Per-frame logging removed (was 20% of all log output); reason returned to caller
+                return false;
+            }
+
+            reason = "";
+            // Per-frame logging removed; reason returned to caller
+            return true;
+        }
+
+        private static bool CanFastForwardPreRuntime(Recording rec, out string reason, bool isRecording)
         {
             if (IsRewinding)
             {
@@ -2204,15 +2246,6 @@ namespace Parsek
             if (HasPendingTree)
             {
                 reason = "Merge or discard pending tree first";
-                // Per-frame logging removed (was 20% of all log output); reason returned to caller
-                return false;
-            }
-
-            // Timing check last — requires KSP runtime (Planetarium)
-            double now = Planetarium.GetUniversalTime();
-            if (now >= rec.StartUT)
-            {
-                reason = "Recording is not in the future";
                 // Per-frame logging removed (was 20% of all log output); reason returned to caller
                 return false;
             }

--- a/Source/Parsek/VesselSpawner.cs
+++ b/Source/Parsek/VesselSpawner.cs
@@ -1006,7 +1006,7 @@ namespace Parsek
             // colliders (including buildings), handling any residual clipping properly.
             if (rec.TerminalStateValue == TerminalState.Splashed)
             {
-                if (alt > 0)
+                if (alt != 0.0)
                 {
                     ParsekLog.Verbose("Spawner",
                         $"Clamped altitude for SPLASHED spawn #{index} ({rec.VesselName}): {alt:F1} -> 0");

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -7,7 +7,7 @@ Entries 272–303 (78 bugs, 6 TODOs — mostly resolved) archived in `done/todo-
 
 # Known Bugs
 
-## 313. Splashed EVA spawn-at-end can place the kerbal slightly underwater
+## ~~313. Splashed EVA spawn-at-end can place the kerbal slightly underwater~~
 
 **Observed in:** 0.8.0 (2026-04-12). In the Phase 11.5 playtest bundle, the parent splashed vessel (`#24 "Kerbal X"`) was clamped and spawned at sea level, but the EVA child (`#25 "Raydred Kerman"`) spawned at `alt=-0.2` with `terminal=Splashed`. Log sequence:
 
@@ -24,9 +24,9 @@ Entries 272–303 (78 bugs, 6 TODOs — mostly resolved) archived in `done/todo-
 
 **Test gap:** `SpawnSafetyNetTests.ResolveSpawnPosition_EvaLanded_FallsThroughToSplashedClamp` only covers `alt > 0 -> 0`. There is no regression test for a splashed EVA endpoint with `alt < 0`.
 
-**Follow-up:** Add a sea-surface floor invariant for splashed terminal spawns on the EVA path as well, and add a regression test that a negative splashed EVA endpoint is floored to `0.0` before spawn.
+**Fix:** `VesselSpawner.ResolveSpawnPosition` now floors every non-zero `TerminalState.Splashed` altitude to sea level (`0.0`), not just the `alt > 0` case. That applies uniformly to EVA, breakup-continuous, and snapshot-based splashed spawns before `OverrideSnapshotPosition` / `SpawnAtPosition` runs. Added `ResolveSpawnPosition_EvaSplashed_NegativeEndpointAltitude_FloorsToSeaLevel` and updated breakup-continuous coverage so slightly negative terminal samples cannot place a spawned vessel underwater.
 
-**Status:** Open
+**Status:** ~~Fixed~~
 
 ---
 
@@ -471,7 +471,7 @@ Test game actions system with popular mods: CustomBarnKit (non-standard facility
 
 ## TODO — Recording Data Integrity
 
-### T60. Add regression coverage and diagnostics for R/FF enablement reasons
+### ~~T60. Add regression coverage and diagnostics for R/FF enablement reasons~~
 
 **Evidence bundle:** `.tmp/logs/2026-04-12_163227_phase-11-5-branch-validation/`
 
@@ -485,15 +485,20 @@ The current Phase 11.5 playtest log shows R/FF row enablement is driven by recor
 
 The governing code is `RecordingsTableUI` + `RecordingStore.CanRewind/CanFastForward`. Distance/watch state is only used for the `W` button path and should never affect R/FF availability.
 
-Add focused coverage for:
+**Conclusion:** No real R/FF distance bug found. The runtime behavior was already correct: row/group R/FF enablement comes from recording timing/save/runtime state, while watch distance only gates `W`.
+
+**Fix:** Added focused coverage for:
 
 - `CanFastForward`: 0-point recordings return `Recording not available`
 - `CanFastForward`: current/past recordings return `Recording is not in the future`
 - `CanRewind`: tree branches with no root rewind save return `No rewind save available` / `Rewind save file missing`
 - transient blocks: `isRecording`, `IsRewinding`, and `HasPendingTree`
 - UI-level guard that distance/watch state never changes R/FF enablement
+- testable core helpers: `CanFastForwardAtUT` and `CanRewindWithResolvedSaveState` preserve the runtime guard order while making the missing reason cases unit-testable
 
 **Priority:** Medium — current runtime logic is mostly correct, but the failure modes are easy to misread in playtests unless we lock them down with tests and explicit reasoning
+
+**Status:** ~~Fixed~~
 
 ---
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -477,15 +477,22 @@ Test game actions system with popular mods: CustomBarnKit (non-standard facility
 
 **Primary log:** `.tmp/logs/2026-04-12_163227_phase-11-5-branch-validation/KSP.log`
 
-The current Phase 11.5 playtest log shows R/FF row enablement is driven by recording state, not ghost distance. Examples:
+Available local playtest logs show R/FF row enablement is driven by recording/runtime state, not ghost distance. Examples:
 
-- `R #0 "Kerbal X": disabled — Stop recording before rewinding`
-- `FF #24 "Kerbal X": disabled — Stop recording before fast-forwarding`
-- later in the same session, the same rows become enabled again once recording stops
+- `logs/2026-04-10_engine-fx-regression/KSP.log:15443` — `FF #13 "Kerbal X": disabled — Stop recording before fast-forwarding`
+- `logs/2026-04-12_0348_bugfixes-2-walkback/KSP.log:23067` — `R #4 "Crater Crawler": disabled — Stop recording before rewinding`
+- `logs/2026-04-12_0213_bugfixes-2/KSP.log:12946-12961` — `BeginRewind` is immediately followed by `R #0 "Crater Crawler": disabled — Rewind already in progress`
+
+The local `s3` / LOD archive (`logs/2026-04-11_2339_290-rover-underground/KSP.log`) predates those explicit UI-reason lines, but it does show two long active tree-recording windows:
+
+- `StartRecording succeeded` at `9137`, then the tree is finalized/committed at `11702-12030`
+- `StartRecording succeeded` at `12502`, then the tree is finalized/committed at `14659-15003`
+
+That means the long disabled interval reported for the `s3` save lines up with an active recording window; distance is not involved, and the most likely reason in that bundle is the normal `Stop recording before rewinding/fast-forwarding` guard.
 
 The governing code is `RecordingsTableUI` + `RecordingStore.CanRewind/CanFastForward`. Distance/watch state is only used for the `W` button path and should never affect R/FF availability.
 
-**Conclusion:** No real R/FF distance bug found. The runtime behavior was already correct: row/group R/FF enablement comes from recording timing/save/runtime state, while watch distance only gates `W`.
+**Conclusion:** No real R/FF distance bug found. The runtime behavior was already correct: row/group R/FF enablement comes from recording timing/save/runtime state, while watch distance only gates `W`. In the archived `s3` / LOD save, the long disabled interval tracks active recording; in later reason-logged bundles, the same buttons also legitimately disable during an active rewind.
 
 **Fix:** Added focused coverage for:
 


### PR DESCRIPTION
Summary: floor splashed spawn altitudes to sea level for slightly negative EVA and snapshot endpoints; add focused regression coverage for splashed spawn safety and R/FF guard reasons; clarify T60 diagnostics and the s3/LOD disabled interval evidence. Testing: focused tests passed; full test suite passed; build passed.