### PR TITLE
Implement T7 hidden-tier ghost unload lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to Parsek are documented here.
 ### Improvements
 
 - Phase 11.5 ghost LOD is now live in Flight: shared distance thresholds, unwatched reduced tier at `2.3-50 km`, hidden-mesh tier at `50-120 km`, and live diagnostics counts for `full / reduced / hidden / watched override`.
-- Hidden-tier ghosts now unload built mesh/resources while keeping their logical playback shell alive, then rebuild from snapshot state without replaying transient puff/audio effects when they re-enter visible range.
+- Hidden-tier ghosts now unload built mesh/resources while keeping their logical playback shell alive, prewarm shortly before visible-tier re-entry or imminent structural part events, and rebuild from snapshot state without replaying transient puff/audio effects.
 - Ghost performance tuning is now backend-owned. The old ghost soft-cap settings and the soft-cap subsystem were removed instead of leaving user-facing knobs that conflicted with the new distance policy.
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to Parsek are documented here.
 ### Improvements
 
 - Phase 11.5 ghost LOD is now live in Flight: shared distance thresholds, unwatched reduced tier at `2.3-50 km`, hidden-mesh tier at `50-120 km`, and live diagnostics counts for `full / reduced / hidden / watched override`.
+- Hidden-tier ghosts now unload built mesh/resources while keeping their logical playback shell alive, then rebuild from snapshot state without replaying transient puff/audio effects when they re-enter visible range.
 - Ghost performance tuning is now backend-owned. The old ghost soft-cap settings and the soft-cap subsystem were removed instead of leaving user-facing knobs that conflicted with the new distance policy.
 
 ### Bug Fixes
@@ -24,6 +25,7 @@ All notable changes to Parsek are documented here.
 
 - Added regression coverage for R/FF enablement reasons, including future/past timing, tree-branch rewind save resolution, and a UI guard that pins rewind/fast-forward independence from watch-distance state (`T60`).
 - Added regression coverage for exact watched-cycle protection, hidden-tier warp exemption, watched-override diagnostics counting, and the new frame-context watch-cycle field.
+- Added regression coverage for hidden-tier shell-state handling so unloaded ghosts keep their logical loop identity and rebuild paths preserve playback bookkeeping.
 - Diagnostics now report live engine/RCS FX counts plus last-frame ghost spawn/destroy timings, giving a measurement-first view of FX cost without changing FX behavior.
 - `scripts/inject-recordings.ps1 --run-diagnostics-tests` now runs the focused diagnostics/observability slice before showcase injection, including observability logging and in-game test runner ordering coverage.
 

--- a/Source/Parsek.Tests/DiagnosticsStateTests.cs
+++ b/Source/Parsek.Tests/DiagnosticsStateTests.cs
@@ -838,8 +838,8 @@ namespace Parsek.Tests
                 watchedLoopCycleIndex: -1,
                 fallbackActiveGhostCount: 99);
 
-            Assert.Equal(5, snap.activeGhostCount);
-            Assert.Equal(1, snap.activeOverlapGhostCount);
+            Assert.Equal(0, snap.activeGhostCount);
+            Assert.Equal(0, snap.activeOverlapGhostCount);
             Assert.Equal(2, snap.fullGhostCount);
             Assert.Equal(2, snap.reducedGhostCount);
             Assert.Equal(1, snap.hiddenGhostCount);
@@ -883,8 +883,8 @@ namespace Parsek.Tests
                 watchedLoopCycleIndex: 7,
                 fallbackActiveGhostCount: 99);
 
-            Assert.Equal(2, snap.activeGhostCount);
-            Assert.Equal(1, snap.activeOverlapGhostCount);
+            Assert.Equal(0, snap.activeGhostCount);
+            Assert.Equal(0, snap.activeOverlapGhostCount);
             Assert.Equal(1, snap.fullGhostCount);
             Assert.Equal(1, snap.hiddenGhostCount);
             Assert.Equal(1, snap.watchedOverrideGhostCount);

--- a/Source/Parsek.Tests/GhostPlaybackEngineTests.cs
+++ b/Source/Parsek.Tests/GhostPlaybackEngineTests.cs
@@ -805,18 +805,18 @@ namespace Parsek.Tests
 
             GhostObservability result = engine.CaptureGhostObservability();
 
-            Assert.Equal(2, result.activePrimaryGhostCount);
-            Assert.Equal(1, result.activeOverlapGhostCount);
-            Assert.Equal(1, result.zone1GhostCount);
-            Assert.Equal(1, result.zone2GhostCount);
-            Assert.Equal(1, result.softCapReducedCount);
-            Assert.Equal(1, result.softCapSimplifiedCount);
-            Assert.Equal(2, result.ghostsWithEngineFx);
-            Assert.Equal(3, result.engineModuleCount);
-            Assert.Equal(7, result.engineParticleSystemCount);
-            Assert.Equal(2, result.ghostsWithRcsFx);
-            Assert.Equal(3, result.rcsModuleCount);
-            Assert.Equal(4, result.rcsParticleSystemCount);
+            Assert.Equal(0, result.activePrimaryGhostCount);
+            Assert.Equal(0, result.activeOverlapGhostCount);
+            Assert.Equal(0, result.zone1GhostCount);
+            Assert.Equal(0, result.zone2GhostCount);
+            Assert.Equal(0, result.softCapReducedCount);
+            Assert.Equal(0, result.softCapSimplifiedCount);
+            Assert.Equal(0, result.ghostsWithEngineFx);
+            Assert.Equal(0, result.engineModuleCount);
+            Assert.Equal(0, result.engineParticleSystemCount);
+            Assert.Equal(0, result.ghostsWithRcsFx);
+            Assert.Equal(0, result.rcsModuleCount);
+            Assert.Equal(0, result.rcsParticleSystemCount);
         }
 
         [Fact]
@@ -834,7 +834,7 @@ namespace Parsek.Tests
 
             GhostObservability result = engine.CaptureGhostObservability();
 
-            Assert.Equal(1, result.activePrimaryGhostCount);
+            Assert.Equal(0, result.activePrimaryGhostCount);
             Assert.Equal(0, result.activeOverlapGhostCount);
             Assert.Equal(0, result.zone1GhostCount);
             Assert.Equal(0, result.zone2GhostCount);
@@ -913,6 +913,58 @@ namespace Parsek.Tests
             Assert.False(state.fidelityReduced);
             Assert.False(state.distanceLodReduced);
             Assert.False(state.simplified);
+        }
+
+        [Fact]
+        public void ShouldPrewarmHiddenGhost_NearVisibleTierBoundary_ReturnsTrue()
+        {
+            var traj = new MockTrajectory().WithTimeRange(100, 200);
+            var state = new GhostPlaybackState { partEventIndex = 0 };
+
+            bool result = GhostPlaybackEngine.ShouldPrewarmHiddenGhost(
+                traj, state,
+                DistanceThresholds.GhostFlight.LoopSimplifiedMeters + 1000,
+                currentUT: 120);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void ShouldPrewarmHiddenGhost_UpcomingDecoupleEvent_ReturnsTrue()
+        {
+            var traj = new MockTrajectory().WithTimeRange(100, 200);
+            traj.PartEvents.Add(new PartEvent
+            {
+                ut = 121.5,
+                eventType = PartEventType.Decoupled
+            });
+            var state = new GhostPlaybackState { partEventIndex = 0 };
+
+            bool result = GhostPlaybackEngine.ShouldPrewarmHiddenGhost(
+                traj, state,
+                DistanceThresholds.GhostFlight.LoopSimplifiedMeters + 20000,
+                currentUT: 120);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void ShouldPrewarmHiddenGhost_UpcomingThrottleOnlyEvent_ReturnsFalse()
+        {
+            var traj = new MockTrajectory().WithTimeRange(100, 200);
+            traj.PartEvents.Add(new PartEvent
+            {
+                ut = 121.5,
+                eventType = PartEventType.EngineThrottle
+            });
+            var state = new GhostPlaybackState { partEventIndex = 0 };
+
+            bool result = GhostPlaybackEngine.ShouldPrewarmHiddenGhost(
+                traj, state,
+                DistanceThresholds.GhostFlight.LoopSimplifiedMeters + 20000,
+                currentUT: 120);
+
+            Assert.False(result);
         }
 
         #endregion
@@ -1062,13 +1114,13 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void GhostCount_ReflectsGhostStatesCount()
+        public void GhostCount_ReflectsLoadedGhostVisualCount()
         {
             var engine = new GhostPlaybackEngine(null);
             Assert.Equal(0, engine.GhostCount);
             engine.ghostStates[0] = new GhostPlaybackState();
             engine.ghostStates[3] = new GhostPlaybackState();
-            Assert.Equal(2, engine.GhostCount);
+            Assert.Equal(0, engine.GhostCount);
         }
 
         #endregion

--- a/Source/Parsek.Tests/GhostPlaybackEngineTests.cs
+++ b/Source/Parsek.Tests/GhostPlaybackEngineTests.cs
@@ -849,6 +849,75 @@ namespace Parsek.Tests
         #endregion
 
         // ===================================================================
+        // Ghost shell lifecycle helpers
+        // ===================================================================
+
+        #region GhostShellLifecycle
+
+        [Fact]
+        public void HasLoopCycleChanged_UnloadedShellSameCycle_ReturnsFalse()
+        {
+            var state = new GhostPlaybackState
+            {
+                loopCycleIndex = 12,
+                ghost = null
+            };
+
+            Assert.False(GhostPlaybackEngine.HasLoopCycleChanged(state, 12));
+        }
+
+        [Fact]
+        public void ClearLoadedVisualReferences_PreservesLogicalPlaybackState()
+        {
+            var state = new GhostPlaybackState
+            {
+                vesselName = "Test",
+                playbackIndex = 17,
+                partEventIndex = 9,
+                loopCycleIndex = 4,
+                flagEventIndex = 3,
+                currentZone = RenderingZone.Beyond,
+                lastDistance = 67890,
+                explosionFired = true,
+                pauseHidden = true,
+                fidelityReduced = true,
+                distanceLodReduced = true,
+                simplified = true,
+                materials = new List<Material>(),
+                partTree = new Dictionary<uint, List<uint>> { [1] = new List<uint> { 2, 3 } },
+                engineInfos = new Dictionary<ulong, EngineGhostInfo> { [1] = new EngineGhostInfo() },
+                rcsInfos = new Dictionary<ulong, RcsGhostInfo> { [2] = new RcsGhostInfo() },
+                audioInfos = new Dictionary<ulong, AudioGhostInfo> { [3] = new AudioGhostInfo() },
+                fakeCanopies = new Dictionary<uint, GameObject>(),
+                reentryFxInfo = new ReentryFxInfo()
+            };
+
+            state.ClearLoadedVisualReferences();
+
+            Assert.Equal("Test", state.vesselName);
+            Assert.Equal(17, state.playbackIndex);
+            Assert.Equal(9, state.partEventIndex);
+            Assert.Equal(4, state.loopCycleIndex);
+            Assert.Equal(3, state.flagEventIndex);
+            Assert.Equal(RenderingZone.Beyond, state.currentZone);
+            Assert.Equal(67890, state.lastDistance);
+            Assert.True(state.explosionFired);
+            Assert.NotNull(state.partTree);
+            Assert.Null(state.materials);
+            Assert.Null(state.engineInfos);
+            Assert.Null(state.rcsInfos);
+            Assert.Null(state.audioInfos);
+            Assert.Null(state.fakeCanopies);
+            Assert.Null(state.reentryFxInfo);
+            Assert.False(state.pauseHidden);
+            Assert.False(state.fidelityReduced);
+            Assert.False(state.distanceLodReduced);
+            Assert.False(state.simplified);
+        }
+
+        #endregion
+
+        // ===================================================================
         // Query API — HasGhost, HasActiveGhost, IsGhostOnBody, etc.
         // ===================================================================
 

--- a/Source/Parsek.Tests/WatchModeControllerTests.cs
+++ b/Source/Parsek.Tests/WatchModeControllerTests.cs
@@ -1,0 +1,30 @@
+using Xunit;
+
+namespace Parsek.Tests
+{
+    [Collection("Sequential")]
+    public class WatchModeControllerTests
+    {
+        [Fact]
+        public void PrimeLoopWatchResetState_NullGhost_DoesNotThrow_AndResetsState()
+        {
+            var state = new GhostPlaybackState
+            {
+                ghost = null,
+                currentZone = RenderingZone.Beyond,
+                playbackIndex = 42,
+                partEventIndex = 7,
+                pauseHidden = true,
+                explosionFired = true
+            };
+
+            WatchModeController.PrimeLoopWatchResetState(state);
+
+            Assert.Equal(RenderingZone.Physics, state.currentZone);
+            Assert.Equal(0, state.playbackIndex);
+            Assert.Equal(0, state.partEventIndex);
+            Assert.False(state.pauseHidden);
+            Assert.False(state.explosionFired);
+        }
+    }
+}

--- a/Source/Parsek/Diagnostics/DiagnosticsComputation.cs
+++ b/Source/Parsek/Diagnostics/DiagnosticsComputation.cs
@@ -557,7 +557,8 @@ namespace Parsek
                 foreach (var kvp in primaryStates)
                 {
                     if (kvp.Value == null) continue;
-                    snap.activeGhostCount++;
+                    if (GhostPlaybackEngine.HasLoadedGhostVisuals(kvp.Value))
+                        snap.activeGhostCount++;
                     AccumulateGhostTierCounts(
                         kvp.Key, kvp.Value, watchedIndex, watchedLoopCycleIndex,
                         ref snap.fullGhostCount,
@@ -579,8 +580,11 @@ namespace Parsek
                         var state = overlaps[i];
                         if (state == null) continue;
 
-                        snap.activeGhostCount++;
-                        snap.activeOverlapGhostCount++;
+                        if (GhostPlaybackEngine.HasLoadedGhostVisuals(state))
+                        {
+                            snap.activeGhostCount++;
+                            snap.activeOverlapGhostCount++;
+                        }
                         AccumulateGhostTierCounts(
                             kvp.Key, state, watchedIndex, watchedLoopCycleIndex,
                             ref snap.fullGhostCount,

--- a/Source/Parsek/GhostPlaybackEngine.cs
+++ b/Source/Parsek/GhostPlaybackEngine.cs
@@ -108,6 +108,16 @@ namespace Parsek
             ParsekLog.Info("Engine", "GhostPlaybackEngine created");
         }
 
+        private static bool HasLoadedGhostVisuals(GhostPlaybackState state)
+        {
+            return state != null && state.ghost != null;
+        }
+
+        internal static bool HasLoopCycleChanged(GhostPlaybackState state, long cycleIndex)
+        {
+            return state == null || state.loopCycleIndex != cycleIndex;
+        }
+
         #region Per-frame update
 
         /// <summary>
@@ -188,7 +198,7 @@ namespace Parsek
 
                 GhostPlaybackState state;
                 ghostStates.TryGetValue(i, out state);
-                bool ghostActive = state != null && state.ghost != null;
+                bool ghostActive = HasLoadedGhostVisuals(state);
                 if (ghostActive) ghostsProcessed++;
 
                 // === Loop dispatch (before main rendering) ===
@@ -243,13 +253,13 @@ namespace Parsek
 
                         if (parentPaused || suppressGhosts)
                         {
-                            if (ghostActive)
+                            if (state != null)
                                 DestroyGhost(i, traj, f, reason: "parent loop paused/warp");
                             continue;
                         }
 
                         // Cycle change: rebuild ghost for clean visual state
-                        if (ghostActive && state != null && state.loopCycleIndex != parentCycle)
+                        if (state != null && state.loopCycleIndex != parentCycle)
                         {
                             DestroyGhost(i, traj, f, reason: "parent loop cycle change");
                             ghostActive = false;
@@ -271,7 +281,7 @@ namespace Parsek
                                     state.loopCycleIndex = parentCycle;
                             }
                         }
-                        else if (ghostActive)
+                        else if (state != null)
                         {
                             DestroyGhost(i, traj, f, reason: "outside debris UT range in parent loop");
                         }
@@ -280,9 +290,9 @@ namespace Parsek
                 }
 
                 // === Warp suppression: hide ghost during high warp ===
-                if (suppressGhosts && ghostActive)
+                if (suppressGhosts && state != null)
                 {
-                    if (state.ghost.activeSelf)
+                    if (ghostActive && state.ghost.activeSelf)
                         state.ghost.SetActive(false);
                     DestroyAllOverlapGhosts(i);
                     continue;
@@ -304,7 +314,7 @@ namespace Parsek
                 // Ghost survived past-end (e.g. watch hold), completed event already fired,
                 // and not being held by the policy — destroy it. Prevents debris ghosts
                 // from freezing at their last trajectory point indefinitely.
-                if (ghostActive && completedEventFired.Contains(i)
+                if (state != null && completedEventFired.Contains(i)
                     && (IsGhostHeld == null || !IsGhostHeld(i)))
                 {
                     DestroyGhost(i, traj, f, reason: "stale past-end ghost (no longer held)");
@@ -360,11 +370,11 @@ namespace Parsek
             bool hasPoints, bool hasSurfaceData, bool hasOrbitData,
             ref GhostPlaybackState state, ref bool ghostActive)
         {
-            if (!ghostActive)
+            if (state == null)
             {
                 SpawnGhost(i, traj);
                 ghostStates.TryGetValue(i, out state);
-                ghostActive = state != null && state.ghost != null;
+                ghostActive = HasLoadedGhostVisuals(state);
                 if (ghostActive)
                 {
                     loggedGhostEnter.Add(i);
@@ -379,7 +389,7 @@ namespace Parsek
                 }
             }
 
-            if (!ghostActive) return false;
+            if (state == null) return false;
 
             // Zone-based rendering
             double ghostDist = ResolvePlaybackDistance(i, traj, state, ctx.currentUT, ctx.activeVesselPos);
@@ -390,7 +400,24 @@ namespace Parsek
             // exist whether or not the ghost is visible.
             GhostPlaybackLogic.ApplyFlagEvents(state, traj, ctx.currentUT);
 
-            if (zoneResult.hiddenByZone) return true;
+            if (zoneResult.hiddenByZone)
+            {
+                if (HasLoadedGhostVisuals(state))
+                    UnloadGhostVisuals(i, state, $"hidden by distance LOD at {ghostDist:F0}m");
+                ghostActive = false;
+                return true;
+            }
+
+            if (!HasLoadedGhostVisuals(state)
+                && !EnsureGhostVisualsLoaded(i, traj, state, ctx.currentUT, "entered visible distance tier"))
+            {
+                ghostActive = false;
+                return false;
+            }
+
+            ghostActive = HasLoadedGhostVisuals(state);
+            if (!ghostActive) return false;
+
             GhostPlaybackLogic.ApplyDistanceLodFidelity(state, zoneResult.reduceFidelity);
 
             // Position the ghost
@@ -515,7 +542,7 @@ namespace Parsek
         {
             GhostPlaybackState state;
             ghostStates.TryGetValue(index, out state);
-            bool ghostActive = state != null && state.ghost != null;
+            bool ghostActive = HasLoadedGhostVisuals(state);
 
             double intervalSeconds = GetLoopIntervalSeconds(traj, ctx.autoLoopIntervalSeconds);
             double duration = traj.EndUT - traj.StartUT;
@@ -542,7 +569,7 @@ namespace Parsek
             // For negative intervals: use multi-cycle overlap path
             if (intervalSeconds < 0)
             {
-                UpdateOverlapPlayback(index, traj, flags, ctx, state, ghostActive,
+                UpdateOverlapPlayback(index, traj, flags, ctx, state,
                     intervalSeconds, duration, suppressVisualFx);
                 return;
             }
@@ -561,8 +588,8 @@ namespace Parsek
             }
 
             // Rebuild once per loop cycle to guarantee clean visual state and event indices.
-            bool cycleChanged = !ghostActive || state == null || state.loopCycleIndex != cycleIndex;
-            if (cycleChanged && ghostActive)
+            bool cycleChanged = HasLoopCycleChanged(state, cycleIndex);
+            if (cycleChanged && state != null)
             {
                 // Position at final point so explosion appears at crash site
                 if (traj.Points.Count > 0 && state != null && state.ghost != null)
@@ -607,7 +634,7 @@ namespace Parsek
             var (_, loopSimplified) =
                 GhostPlaybackLogic.EvaluateLoopedGhostSpawn(loopGhostDistance);
 
-            if (!ghostActive)
+            if (state == null)
             {
                 SpawnGhost(index, traj);
                 if (!ghostStates.TryGetValue(index, out state) || state == null)
@@ -637,7 +664,7 @@ namespace Parsek
                 ghostActive = true;
             }
 
-            if (state == null || state.ghost == null)
+            if (state == null)
                 return;
 
             // Zone-based rendering
@@ -645,7 +672,17 @@ namespace Parsek
                 index, traj, state, loopUT, ctx.activeVesselPos);
             var zoneResult = positioner.ApplyZoneRendering(index, state, traj, loopZoneDistance, ctx.protectedIndex);
             if (zoneResult.hiddenByZone)
+            {
+                if (HasLoadedGhostVisuals(state))
+                    UnloadGhostVisuals(index, state, $"loop hidden by distance LOD at {loopZoneDistance:F0}m");
                 return;
+            }
+
+            if (!HasLoadedGhostVisuals(state)
+                && !EnsureGhostVisualsLoaded(index, traj, state, loopUT, "loop re-entered visible distance tier"))
+            {
+                return;
+            }
 
             GhostPlaybackLogic.ApplyDistanceLodFidelity(state, zoneResult.reduceFidelity);
             bool forceWatchedFullFidelity = IsWatchedGhostState(index, state, ctx);
@@ -673,12 +710,12 @@ namespace Parsek
         /// </summary>
         private void UpdateOverlapPlayback(int index, IPlaybackTrajectory traj,
             TrajectoryPlaybackFlags flags, FrameContext ctx,
-            GhostPlaybackState primaryState, bool primaryActive,
+            GhostPlaybackState primaryState,
             double intervalSeconds, double duration, bool suppressVisualFx)
         {
             if (ctx.currentUT < traj.StartUT)
             {
-                if (primaryActive) DestroyGhost(index, traj, flags, reason: "before start UT");
+                if (primaryState != null) DestroyGhost(index, traj, flags, reason: "before start UT");
                 DestroyAllOverlapGhosts(index);
                 return;
             }
@@ -699,23 +736,19 @@ namespace Parsek
             }
 
             // Primary ghost represents the newest (lastCycle)
-            bool primaryCycleChanged = !primaryActive || primaryState == null
-                || primaryState.loopCycleIndex != lastCycle;
+            bool primaryCycleChanged = HasLoopCycleChanged(primaryState, lastCycle);
 
             if (primaryCycleChanged)
             {
                 // Move old primary to overlap list if still alive
-                if (primaryActive && primaryState != null && primaryState.ghost != null)
+                if (primaryState != null)
                 {
                     ghostStates.Remove(index);
-                    GhostPlaybackLogic.MuteAllAudio(primaryState); // overlap ghosts get no audio
+                    if (primaryState.ghost != null)
+                        GhostPlaybackLogic.MuteAllAudio(primaryState); // overlap ghosts get no audio
                     overlaps.Add(primaryState);
                     ParsekLog.VerboseRateLimited("Engine", "overlap-move",
                         $"Ghost #{index} cycle={primaryState.loopCycleIndex} moved to overlap list (audio muted)");
-                }
-                else if (primaryActive)
-                {
-                    DestroyGhost(index, traj, flags, reason: "cycle transition");
                 }
 
                 // Spawn new primary for lastCycle
@@ -752,8 +785,9 @@ namespace Parsek
             // Position primary ghost
             // Note: anchor-relative positioning is handled internally by positioner.PositionLoop,
             // which calls ShouldUseLoopAnchor itself. No need to pre-compute here.
-            if (primaryState != null && primaryState.ghost != null)
+            if (primaryState != null)
             {
+                bool primaryReady = true;
                 double cycleStartUT = traj.StartUT + lastCycle * cycleDuration;
                 double phase = Math.Max(0, Math.Min(ctx.currentUT - cycleStartUT, duration));
                 double loopUT = traj.StartUT + phase;
@@ -761,13 +795,25 @@ namespace Parsek
                     index, traj, primaryState, loopUT, ctx.activeVesselPos);
                 var zoneResult = positioner.ApplyZoneRendering(
                     index, primaryState, traj, primaryDistance, ctx.protectedIndex);
-                if (!zoneResult.hiddenByZone)
+                if (zoneResult.hiddenByZone)
                 {
-                    GhostPlaybackLogic.ApplyDistanceLodFidelity(primaryState, zoneResult.reduceFidelity);
-                    bool effectiveSuppressVisualFx = suppressVisualFx || zoneResult.suppressVisualFx;
-                    positioner.PositionLoop(index, traj, primaryState, loopUT, effectiveSuppressVisualFx);
-                    ApplyFrameVisuals(index, traj, primaryState, loopUT, ctx.warpRate,
-                        zoneResult.skipPartEvents, effectiveSuppressVisualFx);
+                    if (HasLoadedGhostVisuals(primaryState))
+                        UnloadGhostVisuals(index, primaryState, $"overlap primary hidden by distance LOD at {primaryDistance:F0}m");
+                }
+                else
+                {
+                    if (!HasLoadedGhostVisuals(primaryState)
+                        && !EnsureGhostVisualsLoaded(index, traj, primaryState, loopUT, "overlap primary re-entered visible distance tier"))
+                        primaryReady = false;
+
+                    if (primaryReady)
+                    {
+                        GhostPlaybackLogic.ApplyDistanceLodFidelity(primaryState, zoneResult.reduceFidelity);
+                        bool effectiveSuppressVisualFx = suppressVisualFx || zoneResult.suppressVisualFx;
+                        positioner.PositionLoop(index, traj, primaryState, loopUT, effectiveSuppressVisualFx);
+                        ApplyFrameVisuals(index, traj, primaryState, loopUT, ctx.warpRate,
+                            zoneResult.skipPartEvents, effectiveSuppressVisualFx);
+                    }
                 }
             }
 
@@ -789,7 +835,7 @@ namespace Parsek
             for (int i = overlaps.Count - 1; i >= 0; i--)
             {
                 var ovState = overlaps[i];
-                if (ovState == null || ovState.ghost == null)
+                if (ovState == null)
                 {
                     overlaps.RemoveAt(i);
                     continue;
@@ -833,12 +879,6 @@ namespace Parsek
                     continue;
                 }
 
-                if (ovState.ghost == null)
-                {
-                    overlaps.RemoveAt(i);
-                    continue;
-                }
-
                 phase = Math.Max(0, Math.Min(phase, duration));
                 double loopUT = traj.StartUT + phase;
                 double overlapDistance = ResolvePlaybackDistance(
@@ -846,7 +886,17 @@ namespace Parsek
                 var zoneResult = positioner.ApplyZoneRendering(
                     index, ovState, traj, overlapDistance, ctx.protectedIndex);
                 if (zoneResult.hiddenByZone)
+                {
+                    if (HasLoadedGhostVisuals(ovState))
+                        UnloadOverlapGhostVisuals(index, ovState, $"overlap hidden by distance LOD at {overlapDistance:F0}m");
                     continue;
+                }
+
+                if (!HasLoadedGhostVisuals(ovState)
+                    && !EnsureGhostVisualsLoaded(index, traj, ovState, loopUT, "overlap re-entered visible distance tier"))
+                {
+                    continue;
+                }
 
                 GhostPlaybackLogic.ApplyDistanceLodFidelity(ovState, zoneResult.reduceFidelity);
                 bool effectiveSuppressVisualFx = suppressVisualFx || zoneResult.suppressVisualFx;
@@ -1382,7 +1432,7 @@ namespace Parsek
         /// <summary>Whether a ghost exists with a non-null GameObject.</summary>
         internal bool HasActiveGhost(int index)
         {
-            return ghostStates.TryGetValue(index, out var state) && state?.ghost != null;
+            return ghostStates.TryGetValue(index, out var state) && HasLoadedGhostVisuals(state);
         }
 
         /// <summary>Get the ghost state for a recording index.</summary>
@@ -1490,9 +1540,57 @@ namespace Parsek
                 return;
             }
 
+            var state = new GhostPlaybackState
+            {
+                vesselName = traj?.VesselName ?? "Unknown",
+                playbackIndex = 0,
+                partEventIndex = 0,
+                flagEventIndex = 0
+            };
+
+            if (!BuildGhostVisualsWithMetrics(index, traj, state, resetCompletedEventDedup: true, out string buildType))
+                return;
+
+            GhostPlaybackLogic.InitializeFlagVisibility(traj, state);
+            ghostStates[index] = state;
+
+            ParsekLog.VerboseRateLimited("Engine", $"spawn-{index}",
+                $"Ghost #{index} \"{traj?.VesselName}\" spawned ({buildType}, " +
+                $"parts={state.partTree?.Count ?? 0} engines={state.engineInfos?.Count ?? 0} " +
+                $"rcs={state.rcsInfos?.Count ?? 0})", 1.0);
+        }
+
+        private bool BuildGhostVisualsWithMetrics(
+            int index, IPlaybackTrajectory traj, GhostPlaybackState state,
+            bool resetCompletedEventDedup, out string buildType)
+        {
+            bool built = false;
+            buildType = null;
             spawnStopwatch.Start();
             frameSpawnCount++;
-            completedEventFired.Remove(index); // Reset dedup for time-jump backward
+            if (resetCompletedEventDedup)
+                completedEventFired.Remove(index);
+
+            try
+            {
+                built = TryPopulateGhostVisuals(index, traj, state, out buildType);
+                return built;
+            }
+            finally
+            {
+                spawnStopwatch.Stop();
+                if (built)
+                    DiagnosticsState.health.ghostBuildsThisSession++;
+            }
+        }
+
+        private bool TryPopulateGhostVisuals(
+            int index, IPlaybackTrajectory traj, GhostPlaybackState state,
+            out string buildType)
+        {
+            buildType = null;
+            if (state == null)
+                return false;
 
             Color ghostColor = new Color(0.2f, 1f, 0.4f, 0.8f); // bright green-cyan
             GhostBuildResult buildResult = null;
@@ -1510,9 +1608,9 @@ namespace Parsek
             }
 
             if (ghost == null)
-            {
                 ghost = GhostVisualBuilder.CreateGhostSphere($"Parsek_Timeline_{index}", ghostColor);
-            }
+            if (ghost == null)
+                return false;
 
             var cameraPivotObj = new GameObject("cameraPivot");
             cameraPivotObj.transform.SetParent(ghost.transform, false);
@@ -1520,16 +1618,11 @@ namespace Parsek
             var horizonProxyObj = new GameObject("horizonProxy");
             horizonProxyObj.transform.SetParent(cameraPivotObj.transform, false);
 
-            var state = new GhostPlaybackState
-            {
-                vesselName = traj?.VesselName ?? "Unknown",
-                ghost = ghost,
-                cameraPivot = cameraPivotObj.transform,
-                horizonProxy = horizonProxyObj.transform,
-                playbackIndex = 0,
-                partEventIndex = 0,
-                partTree = GhostVisualBuilder.BuildPartSubtreeMap(GhostVisualBuilder.GetGhostSnapshot(traj))
-            };
+            state.vesselName = traj?.VesselName ?? state.vesselName ?? "Unknown";
+            state.ghost = ghost;
+            state.cameraPivot = cameraPivotObj.transform;
+            state.horizonProxy = horizonProxyObj.transform;
+            state.partTree = GhostVisualBuilder.BuildPartSubtreeMap(GhostVisualBuilder.GetGhostSnapshot(traj));
 
             if (builtFromSnapshot)
             {
@@ -1548,20 +1641,63 @@ namespace Parsek
                 ghost, state.heatInfos, index, traj.VesselName);
             state.reentryMpb = new MaterialPropertyBlock();
 
-            GhostPlaybackLogic.InitializeFlagVisibility(traj, state);
-
-            ghostStates[index] = state;
-
-            string buildType = builtFromSnapshot
+            buildType = builtFromSnapshot
                 ? (traj.GhostVisualSnapshot != null ? "recording-start snapshot" : "vessel snapshot")
                 : "sphere fallback";
-            ParsekLog.VerboseRateLimited("Engine", $"spawn-{index}",
-                $"Ghost #{index} \"{traj?.VesselName}\" spawned ({buildType}, " +
-                $"parts={state.partTree?.Count ?? 0} engines={state.engineInfos?.Count ?? 0} " +
-                $"rcs={state.rcsInfos?.Count ?? 0})", 1.0);
+            return true;
+        }
 
-            spawnStopwatch.Stop();
-            DiagnosticsState.health.ghostBuildsThisSession++;
+        private bool EnsureGhostVisualsLoaded(
+            int index, IPlaybackTrajectory traj, GhostPlaybackState state,
+            double playbackUT, string reason)
+        {
+            if (state == null)
+                return false;
+            if (HasLoadedGhostVisuals(state))
+                return true;
+            if (traj.IsDebris && GhostVisualBuilder.GetGhostSnapshot(traj) == null)
+                return false;
+
+            if (!BuildGhostVisualsWithMetrics(index, traj, state, resetCompletedEventDedup: false, out string buildType))
+                return false;
+
+            RehydrateGhostVisualState(index, traj, state, playbackUT);
+            ParsekLog.VerboseRateLimited("Engine", $"rebuild-{index}",
+                $"Ghost #{index} \"{state.vesselName}\" visuals rebuilt ({buildType}, {reason})", 1.0);
+            return HasLoadedGhostVisuals(state);
+        }
+
+        private static void RehydrateGhostVisualState(
+            int index, IPlaybackTrajectory traj, GhostPlaybackState state, double playbackUT)
+        {
+            if (state?.ghost == null)
+                return;
+
+            state.playbackIndex = 0;
+            state.partEventIndex = 0;
+            GhostPlaybackLogic.ApplyPartEvents(index, traj, playbackUT, state, allowTransientEffects: false);
+        }
+
+        private void UnloadGhostVisuals(int index, GhostPlaybackState state, string reason)
+        {
+            if (!HasLoadedGhostVisuals(state))
+                return;
+
+            ParsekLog.VerboseRateLimited("Engine", $"unload-{index}",
+                $"Ghost #{index} \"{state.vesselName}\" visuals unloaded ({reason})", 1.0);
+            DestroyGhostResourcesWithMetrics(state);
+            state.ClearLoadedVisualReferences();
+        }
+
+        private void UnloadOverlapGhostVisuals(int index, GhostPlaybackState state, string reason)
+        {
+            if (!HasLoadedGhostVisuals(state))
+                return;
+
+            ParsekLog.VerboseRateLimited("Engine", $"overlap-unload-{index}-{state.loopCycleIndex}",
+                $"Ghost #{index} cycle={state.loopCycleIndex} visuals unloaded ({reason})", 1.0);
+            DestroyGhostResourcesWithMetrics(state);
+            state.ClearLoadedVisualReferences();
         }
 
         /// <summary>

--- a/Source/Parsek/GhostPlaybackEngine.cs
+++ b/Source/Parsek/GhostPlaybackEngine.cs
@@ -46,6 +46,8 @@ namespace Parsek
         internal const int MaxOverlapGhostsPerRecording = 5;
         internal const double OverlapExplosionHoldSeconds = 3.0;
         internal const int MaxActiveExplosions = 30;
+        internal const double HiddenGhostVisibleTierPrewarmBufferMeters = 5000.0;
+        internal const double HiddenGhostEventPrewarmLookaheadSeconds = 2.0;
 
         // Per-frame batch counters (avoid per-ghost log spam)
         private int frameSpawnCount;
@@ -108,7 +110,7 @@ namespace Parsek
             ParsekLog.Info("Engine", "GhostPlaybackEngine created");
         }
 
-        private static bool HasLoadedGhostVisuals(GhostPlaybackState state)
+        internal static bool HasLoadedGhostVisuals(GhostPlaybackState state)
         {
             return state != null && state.ghost != null;
         }
@@ -116,6 +118,65 @@ namespace Parsek
         internal static bool HasLoopCycleChanged(GhostPlaybackState state, long cycleIndex)
         {
             return state == null || state.loopCycleIndex != cycleIndex;
+        }
+
+        internal static bool ShouldPrewarmHiddenGhostForPartEvent(PartEventType type)
+        {
+            switch (type)
+            {
+                case PartEventType.Decoupled:
+                case PartEventType.Destroyed:
+                case PartEventType.ParachuteDeployed:
+                case PartEventType.ParachuteSemiDeployed:
+                case PartEventType.ParachuteCut:
+                case PartEventType.ParachuteDestroyed:
+                case PartEventType.ShroudJettisoned:
+                case PartEventType.DeployableExtended:
+                case PartEventType.DeployableRetracted:
+                case PartEventType.GearDeployed:
+                case PartEventType.GearRetracted:
+                case PartEventType.CargoBayOpened:
+                case PartEventType.CargoBayClosed:
+                case PartEventType.FairingJettisoned:
+                case PartEventType.Docked:
+                case PartEventType.Undocked:
+                case PartEventType.InventoryPartPlaced:
+                case PartEventType.InventoryPartRemoved:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        internal static bool ShouldPrewarmHiddenGhost(
+            IPlaybackTrajectory traj, GhostPlaybackState state, double ghostDistance, double currentUT)
+        {
+            if (traj == null || state == null)
+                return false;
+
+            if (ghostDistance <= DistanceThresholds.GhostFlight.LoopSimplifiedMeters
+                + HiddenGhostVisibleTierPrewarmBufferMeters)
+            {
+                return true;
+            }
+
+            if (traj.PartEvents == null || traj.PartEvents.Count == 0)
+                return false;
+
+            double lookaheadDeadline = currentUT + HiddenGhostEventPrewarmLookaheadSeconds;
+            int startIndex = Math.Max(0, state.partEventIndex);
+            for (int i = startIndex; i < traj.PartEvents.Count; i++)
+            {
+                var evt = traj.PartEvents[i];
+                if (evt.ut > lookaheadDeadline)
+                    break;
+                if (evt.ut < currentUT)
+                    continue;
+                if (ShouldPrewarmHiddenGhostForPartEvent(evt.eventType))
+                    return true;
+            }
+
+            return false;
         }
 
         #region Per-frame update
@@ -402,9 +463,9 @@ namespace Parsek
 
             if (zoneResult.hiddenByZone)
             {
-                if (HasLoadedGhostVisuals(state))
-                    UnloadGhostVisuals(i, state, $"hidden by distance LOD at {ghostDist:F0}m");
-                ghostActive = false;
+                ghostActive = HandleHiddenGhostVisualState(
+                    i, traj, state, ctx.currentUT, ctx.warpRate, ghostDist, overlapGhost: false,
+                    hiddenReason: $"hidden by distance LOD at {ghostDist:F0}m");
                 return true;
             }
 
@@ -502,11 +563,11 @@ namespace Parsek
         /// </summary>
         private void ApplyFrameVisuals(int index, IPlaybackTrajectory traj,
             GhostPlaybackState state, double ut, float warpRate,
-            bool skipPartEvents, bool suppressVisualFx)
+            bool skipPartEvents, bool suppressVisualFx, bool allowTransientEffects = true)
         {
             if (!skipPartEvents)
             {
-                GhostPlaybackLogic.ApplyPartEvents(index, traj, ut, state);
+                GhostPlaybackLogic.ApplyPartEvents(index, traj, ut, state, allowTransientEffects);
                 // Flag events are applied earlier in RenderInRangeGhost, before zone check (#249).
             }
 
@@ -673,8 +734,9 @@ namespace Parsek
             var zoneResult = positioner.ApplyZoneRendering(index, state, traj, loopZoneDistance, ctx.protectedIndex);
             if (zoneResult.hiddenByZone)
             {
-                if (HasLoadedGhostVisuals(state))
-                    UnloadGhostVisuals(index, state, $"loop hidden by distance LOD at {loopZoneDistance:F0}m");
+                ghostActive = HandleHiddenGhostVisualState(
+                    index, traj, state, loopUT, ctx.warpRate, loopZoneDistance, overlapGhost: false,
+                    hiddenReason: $"loop hidden by distance LOD at {loopZoneDistance:F0}m");
                 return;
             }
 
@@ -797,8 +859,9 @@ namespace Parsek
                     index, primaryState, traj, primaryDistance, ctx.protectedIndex);
                 if (zoneResult.hiddenByZone)
                 {
-                    if (HasLoadedGhostVisuals(primaryState))
-                        UnloadGhostVisuals(index, primaryState, $"overlap primary hidden by distance LOD at {primaryDistance:F0}m");
+                    HandleHiddenGhostVisualState(
+                        index, traj, primaryState, loopUT, ctx.warpRate, primaryDistance, overlapGhost: false,
+                        hiddenReason: $"overlap primary hidden by distance LOD at {primaryDistance:F0}m");
                 }
                 else
                 {
@@ -887,8 +950,9 @@ namespace Parsek
                     index, ovState, traj, overlapDistance, ctx.protectedIndex);
                 if (zoneResult.hiddenByZone)
                 {
-                    if (HasLoadedGhostVisuals(ovState))
-                        UnloadOverlapGhostVisuals(index, ovState, $"overlap hidden by distance LOD at {overlapDistance:F0}m");
+                    HandleHiddenGhostVisualState(
+                        index, traj, ovState, loopUT, ctx.warpRate, overlapDistance, overlapGhost: true,
+                        hiddenReason: $"overlap hidden by distance LOD at {overlapDistance:F0}m");
                     continue;
                 }
 
@@ -1348,7 +1412,7 @@ namespace Parsek
         private static void CountPrimaryGhostForObservability(
             GhostPlaybackState state, ref GhostObservability result)
         {
-            if (state == null) return;
+            if (!HasLoadedGhostVisuals(state)) return;
 
             result.activePrimaryGhostCount++;
 
@@ -1368,7 +1432,7 @@ namespace Parsek
         private static void CountOverlapGhostForObservability(
             GhostPlaybackState state, ref GhostObservability result)
         {
-            if (state == null) return;
+            if (!HasLoadedGhostVisuals(state)) return;
 
             result.activeOverlapGhostCount++;
             CountFxForObservability(state, ref result);
@@ -1423,8 +1487,20 @@ namespace Parsek
 
         #region Query API
 
-        /// <summary>Number of active primary timeline ghosts.</summary>
-        internal int GhostCount => ghostStates.Count;
+        /// <summary>Number of primary timeline ghosts with loaded visuals.</summary>
+        internal int GhostCount
+        {
+            get
+            {
+                int count = 0;
+                foreach (var state in ghostStates.Values)
+                {
+                    if (HasLoadedGhostVisuals(state))
+                        count++;
+                }
+                return count;
+            }
+        }
 
         /// <summary>Whether a ghost exists for the given recording index.</summary>
         internal bool HasGhost(int index) => ghostStates.ContainsKey(index);
@@ -1439,6 +1515,24 @@ namespace Parsek
         internal bool TryGetGhostState(int index, out GhostPlaybackState state)
         {
             return ghostStates.TryGetValue(index, out state);
+        }
+
+        internal bool EnsureGhostVisualsLoadedForWatch(
+            int index, IPlaybackTrajectory traj, double playbackUT,
+            bool forceRebuildLoadedVisuals = false)
+        {
+            if (!ghostStates.TryGetValue(index, out var state) || state == null)
+                return false;
+            if (forceRebuildLoadedVisuals && HasLoadedGhostVisuals(state))
+            {
+                DestroyGhostResourcesWithMetrics(state, lingerParticleSystems: false);
+                state.ClearLoadedVisualReferences();
+            }
+            if (!EnsureGhostVisualsLoaded(index, traj, state, playbackUT, "watch mode requested"))
+                return false;
+
+            SynchronizeLoadedGhostForWatch(index, traj, state, playbackUT);
+            return true;
         }
 
         /// <summary>Get the camera pivot transform for a ghost (for watch mode targeting).</summary>
@@ -1647,6 +1741,50 @@ namespace Parsek
             return true;
         }
 
+        private bool HandleHiddenGhostVisualState(
+            int index, IPlaybackTrajectory traj, GhostPlaybackState state,
+            double playbackUT, float warpRate, double ghostDistance,
+            bool overlapGhost, string hiddenReason)
+        {
+            if (state == null)
+                return false;
+
+            GhostPlaybackLogic.ApplyDistanceLodFidelity(state, shouldReduceFidelity: false);
+
+            if (ShouldPrewarmHiddenGhost(traj, state, ghostDistance, playbackUT))
+            {
+                if (!HasLoadedGhostVisuals(state)
+                    && !EnsureGhostVisualsLoaded(index, traj, state, playbackUT,
+                        $"hidden-tier prewarm ({hiddenReason})"))
+                {
+                    return false;
+                }
+
+                if (HasLoadedGhostVisuals(state))
+                {
+                    PositionLoadedGhostAtPlaybackUT(index, traj, state, playbackUT);
+                    if (state.ghost.activeSelf)
+                        state.ghost.SetActive(false);
+                    ApplyFrameVisuals(index, traj, state, playbackUT, warpRate,
+                        skipPartEvents: false, suppressVisualFx: true, allowTransientEffects: false);
+                    ParsekLog.VerboseRateLimited("Engine", $"prewarm-hidden-{index}",
+                        $"Ghost #{index} \"{state.vesselName}\" hidden-tier prewarm active " +
+                        $"({hiddenReason})", 1.0);
+                    return true;
+                }
+            }
+
+            if (HasLoadedGhostVisuals(state))
+            {
+                if (overlapGhost)
+                    UnloadOverlapGhostVisuals(index, state, hiddenReason);
+                else
+                    UnloadGhostVisuals(index, state, hiddenReason);
+            }
+
+            return false;
+        }
+
         private bool EnsureGhostVisualsLoaded(
             int index, IPlaybackTrajectory traj, GhostPlaybackState state,
             double playbackUT, string reason)
@@ -1678,6 +1816,67 @@ namespace Parsek
             GhostPlaybackLogic.ApplyPartEvents(index, traj, playbackUT, state, allowTransientEffects: false);
         }
 
+        private void SynchronizeLoadedGhostForWatch(
+            int index, IPlaybackTrajectory traj, GhostPlaybackState state, double playbackUT)
+        {
+            if (!HasLoadedGhostVisuals(state))
+                return;
+
+            state.playbackIndex = 0;
+            state.partEventIndex = 0;
+            PositionLoadedGhostAtPlaybackUT(index, traj, state, playbackUT);
+            ApplyFrameVisuals(index, traj, state, playbackUT, TimeWarp.CurrentRate,
+                skipPartEvents: false, suppressVisualFx: false, allowTransientEffects: false);
+
+            if (state.ghost != null && !state.ghost.activeSelf)
+                state.ghost.SetActive(true);
+        }
+
+        private void PositionLoadedGhostAtPlaybackUT(
+            int index, IPlaybackTrajectory traj, GhostPlaybackState state, double playbackUT)
+        {
+            if (!HasLoadedGhostVisuals(state) || traj == null || positioner == null)
+                return;
+
+            bool hasPoints = traj.Points != null && traj.Points.Count >= 2;
+            bool hasSurfaceData = traj.SurfacePos.HasValue;
+            bool hasOrbitData = traj.HasOrbitSegments;
+
+            if (hasPoints)
+            {
+                bool usedRelative = false;
+                if (traj.TrackSections != null && traj.TrackSections.Count > 0)
+                {
+                    int sectionIdx = TrajectoryMath.FindTrackSectionForUT(traj.TrackSections, playbackUT);
+                    if (sectionIdx >= 0 && traj.TrackSections[sectionIdx].referenceFrame == ReferenceFrame.Relative)
+                    {
+                        positioner.InterpolateAndPositionRelative(index, traj, state,
+                            playbackUT, suppressFx: true, traj.TrackSections[sectionIdx].anchorVesselId);
+                        usedRelative = true;
+                    }
+                }
+
+                if (!usedRelative)
+                    positioner.InterpolateAndPosition(index, traj, state, playbackUT, suppressFx: true);
+                return;
+            }
+
+            if (traj.Points != null && traj.Points.Count > 0)
+            {
+                positioner.PositionAtPoint(index, traj, state, traj.Points[0]);
+                return;
+            }
+
+            if (hasSurfaceData)
+            {
+                positioner.PositionAtSurface(index, traj, state);
+                return;
+            }
+
+            if (hasOrbitData)
+                positioner.PositionFromOrbit(index, traj, state, playbackUT);
+        }
+
         private void UnloadGhostVisuals(int index, GhostPlaybackState state, string reason)
         {
             if (!HasLoadedGhostVisuals(state))
@@ -1685,7 +1884,7 @@ namespace Parsek
 
             ParsekLog.VerboseRateLimited("Engine", $"unload-{index}",
                 $"Ghost #{index} \"{state.vesselName}\" visuals unloaded ({reason})", 1.0);
-            DestroyGhostResourcesWithMetrics(state);
+            DestroyGhostResourcesWithMetrics(state, lingerParticleSystems: false);
             state.ClearLoadedVisualReferences();
         }
 
@@ -1696,7 +1895,7 @@ namespace Parsek
 
             ParsekLog.VerboseRateLimited("Engine", $"overlap-unload-{index}-{state.loopCycleIndex}",
                 $"Ghost #{index} cycle={state.loopCycleIndex} visuals unloaded ({reason})", 1.0);
-            DestroyGhostResourcesWithMetrics(state);
+            DestroyGhostResourcesWithMetrics(state, lingerParticleSystems: false);
             state.ClearLoadedVisualReferences();
         }
 
@@ -1705,7 +1904,7 @@ namespace Parsek
         /// and fake canopies for a single ghost playback state.
         /// Does NOT remove from any dictionary — caller handles collection bookkeeping.
         /// </summary>
-        internal void DestroyGhostResources(GhostPlaybackState state)
+        internal void DestroyGhostResources(GhostPlaybackState state, bool lingerParticleSystems = true)
         {
             if (state.materials != null)
             {
@@ -1719,12 +1918,26 @@ namespace Parsek
             // Detach active engine/RCS particle systems so smoke trails linger (#107).
             // Stopped systems with no live particles are destroyed immediately.
             if (state.engineInfos != null)
+            {
                 foreach (var info in state.engineInfos.Values)
-                    GhostPlaybackLogic.DetachAndLingerParticleSystems(info.particleSystems, info.kspEmitters);
+                {
+                    if (lingerParticleSystems)
+                        GhostPlaybackLogic.DetachAndLingerParticleSystems(info.particleSystems, info.kspEmitters);
+                    else
+                        GhostPlaybackLogic.StopAndClearParticleSystems(info.particleSystems, info.kspEmitters);
+                }
+            }
 
             if (state.rcsInfos != null)
+            {
                 foreach (var info in state.rcsInfos.Values)
-                    GhostPlaybackLogic.DetachAndLingerParticleSystems(info.particleSystems, info.kspEmitters);
+                {
+                    if (lingerParticleSystems)
+                        GhostPlaybackLogic.DetachAndLingerParticleSystems(info.particleSystems, info.kspEmitters);
+                    else
+                        GhostPlaybackLogic.StopAndClearParticleSystems(info.particleSystems, info.kspEmitters);
+                }
+            }
 
             // Stop all ghost audio sources before destroying the GO hierarchy.
             int audioStopped = 0;
@@ -1755,21 +1968,21 @@ namespace Parsek
             GhostPlaybackLogic.DestroyAllFakeCanopies(state);
         }
 
-        private void DestroyGhostResourcesWithMetrics(GhostPlaybackState state)
+        private void DestroyGhostResourcesWithMetrics(GhostPlaybackState state, bool lingerParticleSystems = true)
         {
             if (state == null)
                 return;
 
             if (!updateStopwatch.IsRunning)
             {
-                DestroyGhostResources(state);
+                DestroyGhostResources(state, lingerParticleSystems);
                 return;
             }
 
             destroyStopwatch.Start();
             try
             {
-                DestroyGhostResources(state);
+                DestroyGhostResources(state, lingerParticleSystems);
             }
             finally
             {

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -875,7 +875,9 @@ namespace Parsek
 
         #region Part Events
 
-        internal static void ApplyPartEvents(int recIdx, IPlaybackTrajectory rec, double currentUT, GhostPlaybackState state)
+        internal static void ApplyPartEvents(
+            int recIdx, IPlaybackTrajectory rec, double currentUT, GhostPlaybackState state,
+            bool allowTransientEffects = true)
         {
             if (rec.PartEvents == null || rec.PartEvents.Count == 0) return;
             if (state.ghost == null)
@@ -900,7 +902,8 @@ namespace Parsek
                         StopRcsFxForPart(state, evt.partPersistentId);
                         StopAudioForPart(state, evt.partPersistentId);
                         ApplyHeatState(state, evt, HeatLevel.Cold);
-                        SpawnPartPuffAtPart(ghost, evt.partPersistentId);
+                        if (allowTransientEffects)
+                            SpawnPartPuffAtPart(ghost, evt.partPersistentId);
                         if (tree != null)
                             HidePartSubtree(ghost, evt.partPersistentId, tree);
                         else
@@ -912,9 +915,11 @@ namespace Parsek
                         StopEngineFxForPart(state, evt.partPersistentId);
                         StopRcsFxForPart(state, evt.partPersistentId);
                         StopAudioForPart(state, evt.partPersistentId);
-                        PlayOneShotAtGhost(state, evt.eventType);
+                        if (allowTransientEffects)
+                            PlayOneShotAtGhost(state, evt.eventType);
                         ApplyHeatState(state, evt, HeatLevel.Cold);
-                        SpawnPartPuffAtPart(ghost, evt.partPersistentId);
+                        if (allowTransientEffects)
+                            SpawnPartPuffAtPart(ghost, evt.partPersistentId);
                         HideGhostPart(ghost, evt.partPersistentId);
                         GhostVisualBuilder.RebuildReentryMeshes(ghost, state.reentryFxInfo);
                         visibilityChanged = true;

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -1789,6 +1789,24 @@ namespace Parsek
             particleSystems.Clear();
         }
 
+        internal static void StopAndClearParticleSystems(
+            List<ParticleSystem> particleSystems, List<KspEmitterRef> kspEmitters)
+        {
+            if (kspEmitters != null)
+                SetKspEmittersEnabled(kspEmitters, false);
+            if (particleSystems == null) return;
+
+            for (int i = 0; i < particleSystems.Count; i++)
+            {
+                var ps = particleSystems[i];
+                if (ps == null) continue;
+                ps.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
+                ps.Clear(true);
+                SetParticleRenderersEnabled(ps, false);
+            }
+            particleSystems.Clear();
+        }
+
         internal static void SetParticleRenderersEnabled(ParticleSystem ps, bool enabled)
         {
             if (ps == null)

--- a/Source/Parsek/GhostPlaybackState.cs
+++ b/Source/Parsek/GhostPlaybackState.cs
@@ -56,6 +56,39 @@ namespace Parsek
         public double lastDistance; // meters from active vessel, updated per frame in ApplyZonePolicy
         public int flagEventIndex;               // tracks which flags have been spawned
 
+        internal void ClearLoadedVisualReferences()
+        {
+            ghost = null;
+            materials = null;
+            parachuteInfos = null;
+            jettisonInfos = null;
+            engineInfos = null;
+            rcsInfos = null;
+            audioInfos = null;
+            oneShotAudio = null;
+            audioMuted = false;
+            cachedAudioBody = null;
+            cachedAudioBodyName = null;
+            roboticInfos = null;
+            deployableInfos = null;
+            heatInfos = null;
+            lightInfos = null;
+            lightPlaybackStates = null;
+            colorChangerInfos = null;
+            fairingInfos = null;
+            fakeCanopies = null;
+            reentryFxInfo = null;
+            reentryMpb = null;
+            pauseHidden = false;
+            rcsSuppressed = false;
+            fidelityReduced = false;
+            distanceLodReduced = false;
+            fidelityDisabledRenderers = null;
+            simplified = false;
+            cameraPivot = null;
+            horizonProxy = null;
+        }
+
         public void SetInterpolated(InterpolationResult r)
         {
             lastInterpolatedVelocity = r.velocity;

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -388,6 +388,14 @@ namespace Parsek
                                     ?? GhostPlaybackLogic.DefaultLoopIntervalSeconds;
             return engine.GetLoopIntervalSeconds(rec, globalInterval);
         }
+        internal bool TryComputeLoopPlaybackUTForWatch(
+            Recording rec, double currentUT,
+            out double loopUT, out long cycleIndex, out bool inPauseWindow,
+            int recIdx = -1)
+        {
+            return TryComputeLoopPlaybackUT(rec, currentUT,
+                out loopUT, out cycleIndex, out inPauseWindow, recIdx);
+        }
         internal void PositionGhostAtForWatch(GameObject ghost, TrajectoryPoint point) => PositionGhostAt(ghost, point);
 
         // Cached per-frame allocations for engine path (avoid GC pressure)
@@ -400,7 +408,7 @@ namespace Parsek
 
         public bool IsRecording => recorder?.IsRecording ?? false;
         public bool IsPlaying => isPlaying;
-        public int TimelineGhostCount => ghostStates.Count;
+        public int TimelineGhostCount => engine.GhostCount;
         public GameObject PreviewGhost => ghostObject;
         public Dictionary<int, GameObject> TimelineGhosts
         {

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -652,7 +652,7 @@ namespace Parsek
 
             // First pass: find the highest active index per chain
             chainTipIndexBuffer.Clear();
-            foreach (var kvp in flight.TimelineGhosts)
+            foreach (var kvp in flight.Engine.ghostStates)
             {
                 if (kvp.Value == null) continue;
                 if (kvp.Key >= committed.Count) continue;
@@ -671,10 +671,11 @@ namespace Parsek
             bool isMapView = MapView.MapIsEnabled;
             double currentUT = isMapView ? Planetarium.GetUniversalTime() : 0;
 
-            foreach (var kvp in flight.TimelineGhosts)
+            foreach (var kvp in flight.Engine.ghostStates)
             {
-                if (kvp.Value == null) continue;
-                bool meshActive = kvp.Value.activeSelf;
+                var state = kvp.Value;
+                if (state == null) continue;
+                bool meshActive = state.ghost != null && state.ghost.activeSelf;
 
                 // In flight view, skip hidden ghosts (stale positions cause wrong markers #245/#247)
                 if (!meshActive && !isMapView) continue;
@@ -703,7 +704,7 @@ namespace Parsek
                 Vector3 markerPos;
                 if (meshActive)
                 {
-                    markerPos = kvp.Value.transform.position;
+                    markerPos = state.ghost.transform.position;
                 }
                 else
                 {

--- a/Source/Parsek/WatchModeController.cs
+++ b/Source/Parsek/WatchModeController.cs
@@ -145,13 +145,14 @@ namespace Parsek
         }
 
         /// <summary>
-        /// Returns true if recording at index has an active ghost (exists and not null).
+        /// Returns true if recording at index has a live playback shell.
+        /// Hidden-tier ghosts may have unloaded visuals but are still watchable.
         /// </summary>
         internal bool HasActiveGhost(int index)
         {
             var ghostStates = host.Engine.ghostStates;
             GhostPlaybackState s;
-            return ghostStates.TryGetValue(index, out s) && s != null && s.ghost != null;
+            return ghostStates.TryGetValue(index, out s) && s != null;
         }
 
         /// <summary>
@@ -264,10 +265,11 @@ namespace Parsek
                 return;
             }
 
-            // Ghost must exist
+            // Ghost playback state must exist. Hidden-tier ghosts may not currently
+            // have a loaded mesh, but watch mode is allowed to force a rebuild.
             var ghostStates = host.Engine.ghostStates;
             GhostPlaybackState gs;
-            if (!ghostStates.TryGetValue(index, out gs) || gs == null || gs.ghost == null)
+            if (!ghostStates.TryGetValue(index, out gs) || gs == null)
                 return;
 
             // Ghost must be on the same body as the active vessel
@@ -333,8 +335,28 @@ namespace Parsek
             // If the ghost is currently beyond visual range and the recording loops,
             // reset the loop phase so the ghost starts from the beginning of the recording
             // (at the pad) instead of wherever it is mid-flight (e.g. near the Mun).
-            if (gs.currentZone == RenderingZone.Beyond && host.ShouldLoopPlaybackForWatch(rec))
+            double watchLoadUT = Planetarium.GetUniversalTime();
+            double loopIntervalSeconds = host.GetLoopIntervalSecondsForWatch(rec);
+            bool usesOverlapLooping = loopIntervalSeconds < 0;
+            bool resetLoopPhaseForWatch = gs.currentZone == RenderingZone.Beyond
+                && host.ShouldLoopPlaybackForWatch(rec)
+                && !usesOverlapLooping;
+            if (resetLoopPhaseForWatch)
+            {
                 ResetLoopPhaseForWatch(index, gs, rec);
+                watchLoadUT = GhostPlaybackEngine.EffectiveLoopStartUT(rec);
+            }
+            else
+            {
+                watchLoadUT = ResolveWatchPlaybackUT(rec, gs, watchLoadUT);
+            }
+
+            if (!host.Engine.EnsureGhostVisualsLoadedForWatch(index, rec, watchLoadUT,
+                forceRebuildLoadedVisuals: resetLoopPhaseForWatch))
+                return;
+            ghostStates.TryGetValue(index, out gs);
+            if (gs == null)
+                return;
 
             // Save camera state only when entering fresh (not switching between ghosts)
             if (!switching)
@@ -350,15 +372,24 @@ namespace Parsek
             FlightCamera.fetch.pivotTranslateSharpness = 0f;
 
             // Point camera at ghost (use cameraPivot or horizonProxy based on mode)
-            var watchTarget = GetWatchTarget(gs.cameraPivot) ?? gs.ghost.transform;
-            FlightCamera.fetch.SetTargetTransform(watchTarget);
+            var watchTarget = GetWatchTarget(gs.cameraPivot) ?? gs.ghost?.transform;
+            if (watchTarget != null)
+                FlightCamera.fetch.SetTargetTransform(watchTarget);
             FlightCamera.fetch.SetDistance(50f);  // override [75,400] entry clamp
             watchedOverlapCycleIndex = gs.loopCycleIndex; // track which cycle we're following
-            ParsekLog.Info("CameraFollow",
-                $"EnterWatchMode: ghost #{index} \"{committed[index].VesselName}\"" +
-                $" target='{watchTarget.name}' pivotLocal=({watchTarget.localPosition.x:F2},{watchTarget.localPosition.y:F2},{watchTarget.localPosition.z:F2})" +
-                $" ghostPos=({gs.ghost.transform.position.x:F1},{gs.ghost.transform.position.y:F1},{gs.ghost.transform.position.z:F1})" +
-                $" camDist={FlightCamera.fetch.Distance.ToString("F1", CultureInfo.InvariantCulture)}");
+            if (watchTarget != null && gs.ghost != null)
+            {
+                ParsekLog.Info("CameraFollow",
+                    $"EnterWatchMode: ghost #{index} \"{committed[index].VesselName}\"" +
+                    $" target='{watchTarget.name}' pivotLocal=({watchTarget.localPosition.x:F2},{watchTarget.localPosition.y:F2},{watchTarget.localPosition.z:F2})" +
+                    $" ghostPos=({gs.ghost.transform.position.x:F1},{gs.ghost.transform.position.y:F1},{gs.ghost.transform.position.z:F1})" +
+                    $" camDist={FlightCamera.fetch.Distance.ToString("F1", CultureInfo.InvariantCulture)}");
+            }
+            else
+            {
+                ParsekLog.Info("CameraFollow",
+                    $"EnterWatchMode: ghost #{index} \"{committed[index].VesselName}\" waiting for rebuilt camera target");
+            }
 
             // Block inputs that could affect the active vessel
             InputLockManager.SetControlLock(WatchModeLockMask, WatchModeLockId);
@@ -381,7 +412,9 @@ namespace Parsek
         private void ResetLoopPhaseForWatch(int index, GhostPlaybackState gs, Recording rec)
         {
             double currentUT = Planetarium.GetUniversalTime();
-            double duration = rec.EndUT - rec.StartUT;
+            double loopStartUT = GhostPlaybackEngine.EffectiveLoopStartUT(rec);
+            double loopEndUT = GhostPlaybackEngine.EffectiveLoopEndUT(rec);
+            double duration = loopEndUT - loopStartUT;
             double intervalSeconds = host.GetLoopIntervalSecondsForWatch(rec);
             double cycleDuration = duration + intervalSeconds;
             if (cycleDuration <= GhostPlaybackLogic.MinLoopDurationSeconds)
@@ -390,7 +423,7 @@ namespace Parsek
             var loopPhaseOffsets = host.Engine.loopPhaseOffsets;
 
             // Current elapsed time (with any existing offset)
-            double elapsed = currentUT - rec.StartUT;
+            double elapsed = currentUT - loopStartUT;
             double existingOffset;
             if (loopPhaseOffsets.TryGetValue(index, out existingOffset))
                 elapsed += existingOffset;
@@ -405,18 +438,24 @@ namespace Parsek
             loopPhaseOffsets[index] = newOffset;
 
             // Re-show the ghost so the camera has something to target
-            gs.ghost.SetActive(true);
-            gs.currentZone = RenderingZone.Physics;
-            gs.playbackIndex = 0;
-
-            // Position ghost at first trajectory point so camera targets the pad
-            if (rec.Points != null && rec.Points.Count > 0)
-                host.PositionGhostAtForWatch(gs.ghost, rec.Points[0]);
+            PrimeLoopWatchResetState(gs);
 
             ParsekLog.Info("CameraFollow",
                 string.Format(CultureInfo.InvariantCulture,
                     "Watch mode loop reset: ghost #{0} \"{1}\" cycleTime={2:F1}s -> offset={3:F1}s (ghost repositioned to recording start)",
                     index, rec.VesselName, cycleTime, newOffset));
+        }
+
+        internal static void PrimeLoopWatchResetState(GhostPlaybackState state)
+        {
+            if (state == null)
+                return;
+
+            state.currentZone = RenderingZone.Physics;
+            state.playbackIndex = 0;
+            state.partEventIndex = 0;
+            state.pauseHidden = false;
+            state.explosionFired = false;
         }
 
         /// <summary>
@@ -849,7 +888,7 @@ namespace Parsek
         internal void ValidateWatchedGhostStillActive()
         {
             if (watchedRecordingIndex < 0) return;
-            if (host.Engine.HasActiveGhost(watchedRecordingIndex)) return;
+            if (host.Engine.TryGetGhostState(watchedRecordingIndex, out var primary) && primary != null) return;
 
             // Check overlap ghosts
             bool hasOverlap = false;
@@ -1026,7 +1065,12 @@ namespace Parsek
                     GhostPlaybackState primary;
                     if (ghostStates.TryGetValue(watchedRecordingIndex, out primary)
                         && primary != null && primary.loopCycleIndex == watchedOverlapCycleIndex)
+                    {
+                        if ((primary.ghost == null || primary.cameraPivot == null)
+                            && !TryEnsurePrimaryWatchGhostLoaded(primary, out primary))
+                            primary = null;
                         state = primary;
+                    }
                 }
 
                 // Fallback: tracked cycle not found -- switch to primary if available
@@ -1034,8 +1078,13 @@ namespace Parsek
                 {
                     GhostPlaybackState primary;
                     if (ghostStates.TryGetValue(watchedRecordingIndex, out primary)
-                        && primary != null && primary.ghost != null
-                        && primary.cameraPivot != null)
+                        && primary != null)
+                    {
+                        if ((primary.ghost == null || primary.cameraPivot == null)
+                            && !TryEnsurePrimaryWatchGhostLoaded(primary, out primary))
+                            primary = null;
+                    }
+                    if (primary != null && primary.ghost != null && primary.cameraPivot != null)
                     {
                         state = primary;
                         watchedOverlapCycleIndex = primary.loopCycleIndex;
@@ -1049,6 +1098,8 @@ namespace Parsek
             else
             {
                 ghostStates.TryGetValue(watchedRecordingIndex, out state);
+                if (state != null && (state.ghost == null || state.cameraPivot == null))
+                    TryEnsurePrimaryWatchGhostLoaded(state, out state);
             }
             return state;
         }
@@ -1073,8 +1124,13 @@ namespace Parsek
                 // Immediately target the current primary ghost so FlightCamera
                 // doesn't reference the destroyed anchor
                 GhostPlaybackState primary;
+                bool primaryReady = ghostStates.TryGetValue(watchedRecordingIndex, out primary)
+                    && primary != null;
+                if (primaryReady && (primary.ghost == null || primary.cameraPivot == null))
+                    primaryReady = TryEnsurePrimaryWatchGhostLoaded(primary, out primary);
+
                 if (FlightCamera.fetch != null
-                    && ghostStates.TryGetValue(watchedRecordingIndex, out primary)
+                    && primaryReady
                     && primary != null && primary.ghost != null)
                 {
                     var target = GetWatchTarget(primary.cameraPivot) ?? primary.ghost.transform;
@@ -1102,6 +1158,68 @@ namespace Parsek
                 watchNoTargetFrames = 0;
                 return true;
             }
+        }
+
+        private double ResolveWatchPlaybackUT(
+            Recording rec, GhostPlaybackState currentState, double fallbackUT)
+        {
+            if (rec == null || !host.ShouldLoopPlaybackForWatch(rec))
+                return fallbackUT;
+
+            double intervalSeconds = host.GetLoopIntervalSecondsForWatch(rec);
+            if (intervalSeconds < 0)
+            {
+                if (currentState == null || currentState.loopCycleIndex < 0)
+                    return fallbackUT;
+
+                double duration = rec.EndUT - rec.StartUT;
+                if (duration <= GhostPlaybackLogic.MinCycleDuration)
+                    return fallbackUT;
+
+                double cycleDuration = duration + intervalSeconds;
+                if (cycleDuration < GhostPlaybackLogic.MinCycleDuration)
+                    cycleDuration = GhostPlaybackLogic.MinCycleDuration;
+
+                double cycleStartUT = rec.StartUT + currentState.loopCycleIndex * cycleDuration;
+                double phase = Math.Max(0, Math.Min(Planetarium.GetUniversalTime() - cycleStartUT, duration));
+                return rec.StartUT + phase;
+            }
+
+            if (host.TryComputeLoopPlaybackUTForWatch(rec, Planetarium.GetUniversalTime(),
+                out double loopUT, out _, out _, watchedRecordingIndex))
+            {
+                return loopUT;
+            }
+
+            return fallbackUT;
+        }
+
+        private bool TryEnsurePrimaryWatchGhostLoaded(
+            GhostPlaybackState currentState, out GhostPlaybackState state)
+        {
+            state = null;
+            int index = watchedRecordingIndex;
+            if (index < 0)
+                return false;
+
+            var committed = RecordingStore.CommittedRecordings;
+            if (index >= committed.Count)
+                return false;
+
+            var traj = committed[index] as IPlaybackTrajectory;
+            if (traj == null)
+                return false;
+
+            double playbackUT = ResolveWatchPlaybackUT(committed[index], currentState,
+                Planetarium.GetUniversalTime());
+
+            if (!host.Engine.EnsureGhostVisualsLoadedForWatch(index, traj, playbackUT))
+                return false;
+
+            return host.Engine.TryGetGhostState(index, out state)
+                && state != null
+                && state.ghost != null
+                && state.cameraPivot != null;
         }
 
         /// <summary>

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -433,11 +433,11 @@ Implemented in `0.8.1` as the shipped Flight ghost LOD policy:
 
 **Status:** Fixed in `0.8.1`
 
-### T7. Ghost mesh unloading outside active time range
+### ~~T7. Ghost mesh unloading outside active time range~~
 
-Ghost meshes built for recordings whose UT range is far from current playback time could be unloaded and rebuilt on demand.
+The Phase 11.5 LOD follow-up landed: ghosts that enter the hidden tier now unload built mesh/resources while keeping their logical playback shell alive, then rebuild on demand when they return to a visible tier.
 
-**Priority:** Deferred to Phase 11.5 (Recording Optimization & Observability)
+**Status:** Fixed in `0.8.1`
 
 ### ~~T8. Particle system pooling for engine/RCS FX~~
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -358,7 +358,7 @@ Commit crash window closed (sidecar files flushed immediately). Remaining gap: s
 Shorter key names, compact numeric encoding, optional compression, event name deduplication. Becomes important at scale (many recordings, long missions).
 
 ### Ghost LOD follow-up
-Distance-based ghost LOD shipped in `0.8.1`. Remaining follow-ups are ghost mesh unloading outside active time range, particle pooling for engine/RCS FX, and synthetic stress benchmarking/tuning.
+Distance-based ghost LOD shipped in `0.8.1`, including the hidden-tier ghost unload/rebuild follow-up. Particle pooling for engine/RCS FX is not scheduled; the Phase 11.5 outcome there was observability/measurement only. Remaining follow-up: synthetic stress benchmarking/tuning.
 
 ### Kerbal reservation refactor (T44)
 Replace `rosterStatus = Assigned` workaround with Parsek-internal state + Harmony crew dialog filtering. Would eliminate 2 workaround patches and ~27 KSP warnings per session. Low priority — current workaround is functional.


### PR DESCRIPTION
## Summary
- unload hidden-tier ghost visuals/resources while keeping logical playback shell state alive
- rebuild visuals on visible-tier re-entry without replaying transient puff/one-shot effects
- update T7/docs/changelog and add regression coverage for shell-state handling

## Testing
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj