### PR TITLE
Fix bug 326 EVA branch surface classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to Parsek are documented here.
 - Zero-throttle breakup debris now emits `EngineShutdown` sentinels instead of looking like a zero-event orphan-engine recording, so replay no longer auto-starts max-throttle booster FX/audio for staged-off debris.
 - The old warp-only orbital exemption no longer punches through the new `50-120 km` hidden-mesh tier. Orbital ghosts still get the legacy exemption only in the true `Beyond` zone.
 - Entering watch mode now uses the tracked playback distance first, avoiding false "in range" decisions from a hidden ghost's stale transform.
+- `#326` EVA branch recordings no longer seed bogus atmospheric start fragments when a landed or splashed kerbal is backgrounded before KSP finishes the vessel switch. The branch path now carries a one-shot surface override through delayed child initialization, and atmospheric-body EVA classification now keeps ground-adjacent or sea-level bobbing kerbals in surface segments instead of producing stray `atmo` optimizer splits.
 - The in-game test runner window now uses a more compact layout without the visible blank rows between tests, and disruptive quickload-resume tests run last in batch execution so they do not interfere with later scenarios.
 
 ### Developer Tools
@@ -42,6 +43,7 @@ All notable changes to Parsek are documented here.
 - Added regression coverage for hidden-tier shell-state handling so unloaded ghosts keep their logical loop identity and rebuild paths preserve playback bookkeeping.
 - Added regression coverage for watched-lineage debris visibility, so watch-mode protection now stays pinned to the intended same-tree same-vessel debris path instead of only the exact watched recording row.
 - Added regression coverage for zero-throttle engine seeding vs. orphan-engine auto-start, so staged-off debris boosters are pinned against replaying as visually full-throttle.
+- Added regression coverage for EVA branch surface seeding and atmospheric/splashed EVA environment classification, covering the queued background override path and the near-ground / sea-level EVA surface heuristics behind `#326`.
 - Diagnostics now report live engine/RCS FX counts plus last-frame ghost spawn/destroy timings, giving a measurement-first view of FX cost without changing FX behavior.
 - `scripts/inject-recordings.ps1 --run-diagnostics-tests` now runs the focused diagnostics/observability slice before showcase injection, including observability logging and in-game test runner ordering coverage.
 

--- a/Source/Parsek.Tests/BackgroundRecorderTests.cs
+++ b/Source/Parsek.Tests/BackgroundRecorderTests.cs
@@ -436,6 +436,48 @@ namespace Parsek.Tests
             Assert.False(bgRecorder.HasOnRailsState(999));
         }
 
+        [Fact]
+        public void OnVesselBackgrounded_WithInitialEnvironmentOverride_QueuesPendingOverride()
+        {
+            var tree = MakeTree((100, "rec_bg1"));
+            var bgRecorder = new BackgroundRecorder(tree);
+
+            bgRecorder.OnVesselBackgrounded(100,
+                initialEnvironmentOverride: SegmentEnvironment.SurfaceStationary);
+
+            Assert.Equal(1, bgRecorder.PendingInitialEnvironmentOverrideCount);
+            Assert.Equal(SegmentEnvironment.SurfaceStationary,
+                bgRecorder.PeekPendingInitialEnvironmentOverrideForTesting(100));
+        }
+
+        [Fact]
+        public void ConsumePendingInitialEnvironmentOverrideForTesting_RemovesQueuedOverride()
+        {
+            var tree = MakeTree((100, "rec_bg1"));
+            var bgRecorder = new BackgroundRecorder(tree);
+
+            bgRecorder.OnVesselBackgrounded(100,
+                initialEnvironmentOverride: SegmentEnvironment.SurfaceStationary);
+
+            Assert.Equal(SegmentEnvironment.SurfaceStationary,
+                bgRecorder.ConsumePendingInitialEnvironmentOverrideForTesting(100));
+            Assert.Equal(0, bgRecorder.PendingInitialEnvironmentOverrideCount);
+        }
+
+        [Fact]
+        public void OnVesselRemovedFromBackground_ClearsPendingInitialEnvironmentOverride()
+        {
+            var tree = MakeTree((100, "rec_bg1"));
+            var bgRecorder = new BackgroundRecorder(tree);
+
+            bgRecorder.OnVesselBackgrounded(100,
+                initialEnvironmentOverride: SegmentEnvironment.SurfaceStationary);
+            bgRecorder.OnVesselRemovedFromBackground(100);
+
+            Assert.Equal(0, bgRecorder.PendingInitialEnvironmentOverrideCount);
+            Assert.Null(bgRecorder.PeekPendingInitialEnvironmentOverrideForTesting(100));
+        }
+
         #endregion
 
         #region EncodeEngineKey consistency

--- a/Source/Parsek.Tests/BackgroundTrackSectionTests.cs
+++ b/Source/Parsek.Tests/BackgroundTrackSectionTests.cs
@@ -247,6 +247,18 @@ namespace Parsek.Tests
             Assert.Equal(SegmentEnvironment.SurfaceMobile, result);
         }
 
+        [Fact]
+        public void ClassifyBackgroundEnvironment_AtmosphericEvaAtSeaLevelWithOcean_ReturnsSurfaceMobile()
+        {
+            var result = BackgroundRecorder.ClassifyBackgroundEnvironment(
+                hasAtmosphere: true, altitude: 0.2, atmosphereDepth: 70000,
+                situation: 8, srfSpeed: 1.5, cachedEngines: null,
+                isEva: true, heightFromTerrain: 600.0, heightFromTerrainValid: true,
+                hasOcean: true);
+
+            Assert.Equal(SegmentEnvironment.SurfaceMobile, result);
+        }
+
         #endregion
 
         #region Environment transition creates new section

--- a/Source/Parsek.Tests/BackgroundTrackSectionTests.cs
+++ b/Source/Parsek.Tests/BackgroundTrackSectionTests.cs
@@ -236,6 +236,17 @@ namespace Parsek.Tests
             Assert.Equal(SegmentEnvironment.ExoBallistic, result);
         }
 
+        [Fact]
+        public void ClassifyBackgroundEnvironment_AtmosphericEvaNearGround_ReturnsSurfaceMobile()
+        {
+            var result = BackgroundRecorder.ClassifyBackgroundEnvironment(
+                hasAtmosphere: true, altitude: 75, atmosphereDepth: 70000,
+                situation: 8, srfSpeed: 1.5, cachedEngines: null,
+                isEva: true, heightFromTerrain: 1.0, heightFromTerrainValid: true);
+
+            Assert.Equal(SegmentEnvironment.SurfaceMobile, result);
+        }
+
         #endregion
 
         #region Environment transition creates new section

--- a/Source/Parsek.Tests/EnvironmentDetectorTests.cs
+++ b/Source/Parsek.Tests/EnvironmentDetectorTests.cs
@@ -531,6 +531,40 @@ namespace Parsek.Tests
             Assert.Equal(SegmentEnvironment.Approach, result);
         }
 
+        [Fact]
+        public void Classify_AtmosphericEvaNearGroundFlying_ReturnsSurface()
+        {
+            var result = EnvironmentDetector.Classify(
+                hasAtmosphere: true,
+                altitude: 75,
+                atmosphereDepth: 70000,
+                situation: 8, // FLYING
+                srfSpeed: 1.5,
+                hasActiveThrust: false,
+                isEva: true,
+                heightFromTerrain: 1.0,
+                heightFromTerrainValid: true);
+
+            Assert.Equal(SegmentEnvironment.SurfaceMobile, result);
+        }
+
+        [Fact]
+        public void Classify_AtmosphericEvaWithoutValidTerrainHeight_RemainsAtmospheric()
+        {
+            var result = EnvironmentDetector.Classify(
+                hasAtmosphere: true,
+                altitude: 75,
+                atmosphereDepth: 70000,
+                situation: 8, // FLYING
+                srfSpeed: 1.5,
+                hasActiveThrust: false,
+                isEva: true,
+                heightFromTerrain: -1.0,
+                heightFromTerrainValid: false);
+
+            Assert.Equal(SegmentEnvironment.Atmospheric, result);
+        }
+
         #endregion
 
         #region Classify — Surface takes priority over atmosphere

--- a/Source/Parsek.Tests/EnvironmentDetectorTests.cs
+++ b/Source/Parsek.Tests/EnvironmentDetectorTests.cs
@@ -565,6 +565,42 @@ namespace Parsek.Tests
             Assert.Equal(SegmentEnvironment.Atmospheric, result);
         }
 
+        [Fact]
+        public void Classify_AtmosphericEvaAtSeaLevelWithOcean_ReturnsSurface()
+        {
+            var result = EnvironmentDetector.Classify(
+                hasAtmosphere: true,
+                altitude: 0.2,
+                atmosphereDepth: 70000,
+                situation: 8, // FLYING
+                srfSpeed: 0.5,
+                hasActiveThrust: false,
+                isEva: true,
+                heightFromTerrain: 600.0,
+                heightFromTerrainValid: true,
+                hasOcean: true);
+
+            Assert.Equal(SegmentEnvironment.SurfaceMobile, result);
+        }
+
+        [Fact]
+        public void Classify_AtmosphericEvaAboveSeaLevelThreshold_RemainsAtmospheric()
+        {
+            var result = EnvironmentDetector.Classify(
+                hasAtmosphere: true,
+                altitude: 3.0,
+                atmosphereDepth: 70000,
+                situation: 8, // FLYING
+                srfSpeed: 0.5,
+                hasActiveThrust: false,
+                isEva: true,
+                heightFromTerrain: 600.0,
+                heightFromTerrainValid: true,
+                hasOcean: true);
+
+            Assert.Equal(SegmentEnvironment.Atmospheric, result);
+        }
+
         #endregion
 
         #region Classify — Surface takes priority over atmosphere

--- a/Source/Parsek.Tests/SplitEventDetectionTests.cs
+++ b/Source/Parsek.Tests/SplitEventDetectionTests.cs
@@ -70,7 +70,7 @@ namespace Parsek.Tests
                 BranchPointType.EVA,
                 backgroundChildIsEva: true,
                 activeSituation: (int)Vessel.Situations.LANDED,
-                activeSrfSpeed: 0.0);
+                backgroundSrfSpeed: 0.0);
 
             Assert.Equal(SegmentEnvironment.SurfaceStationary, result);
         }
@@ -82,9 +82,21 @@ namespace Parsek.Tests
                 BranchPointType.EVA,
                 backgroundChildIsEva: true,
                 activeSituation: (int)Vessel.Situations.LANDED,
-                activeSrfSpeed: 2.0);
+                backgroundSrfSpeed: 2.0);
 
             Assert.Equal(SegmentEnvironment.SurfaceMobile, result);
+        }
+
+        [Fact]
+        public void GetEvaBackgroundInitialEnvironmentOverride_UsesBackgroundEvaSpeed()
+        {
+            var result = ParsekFlight.GetEvaBackgroundInitialEnvironmentOverride(
+                BranchPointType.EVA,
+                backgroundChildIsEva: true,
+                activeSituation: (int)Vessel.Situations.LANDED,
+                backgroundSrfSpeed: 0.0);
+
+            Assert.Equal(SegmentEnvironment.SurfaceStationary, result);
         }
 
         [Fact]
@@ -94,7 +106,7 @@ namespace Parsek.Tests
                 BranchPointType.EVA,
                 backgroundChildIsEva: true,
                 activeSituation: (int)Vessel.Situations.FLYING,
-                activeSrfSpeed: 50.0);
+                backgroundSrfSpeed: 50.0);
 
             Assert.Null(result);
         }
@@ -106,7 +118,7 @@ namespace Parsek.Tests
                 BranchPointType.EVA,
                 backgroundChildIsEva: false,
                 activeSituation: (int)Vessel.Situations.LANDED,
-                activeSrfSpeed: 0.0);
+                backgroundSrfSpeed: 0.0);
 
             Assert.Null(result);
         }

--- a/Source/Parsek.Tests/SplitEventDetectionTests.cs
+++ b/Source/Parsek.Tests/SplitEventDetectionTests.cs
@@ -61,6 +61,58 @@ namespace Parsek.Tests
 
         #endregion
 
+        #region GetEvaBackgroundInitialEnvironmentOverride
+
+        [Fact]
+        public void GetEvaBackgroundInitialEnvironmentOverride_LandedStationaryShip_ReturnsSurfaceStationary()
+        {
+            var result = ParsekFlight.GetEvaBackgroundInitialEnvironmentOverride(
+                BranchPointType.EVA,
+                backgroundChildIsEva: true,
+                activeSituation: (int)Vessel.Situations.LANDED,
+                activeSrfSpeed: 0.0);
+
+            Assert.Equal(SegmentEnvironment.SurfaceStationary, result);
+        }
+
+        [Fact]
+        public void GetEvaBackgroundInitialEnvironmentOverride_LandedMovingShip_ReturnsSurfaceMobile()
+        {
+            var result = ParsekFlight.GetEvaBackgroundInitialEnvironmentOverride(
+                BranchPointType.EVA,
+                backgroundChildIsEva: true,
+                activeSituation: (int)Vessel.Situations.LANDED,
+                activeSrfSpeed: 2.0);
+
+            Assert.Equal(SegmentEnvironment.SurfaceMobile, result);
+        }
+
+        [Fact]
+        public void GetEvaBackgroundInitialEnvironmentOverride_NonSurfaceShip_ReturnsNull()
+        {
+            var result = ParsekFlight.GetEvaBackgroundInitialEnvironmentOverride(
+                BranchPointType.EVA,
+                backgroundChildIsEva: true,
+                activeSituation: (int)Vessel.Situations.FLYING,
+                activeSrfSpeed: 50.0);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetEvaBackgroundInitialEnvironmentOverride_NonEvaBackgroundChild_ReturnsNull()
+        {
+            var result = ParsekFlight.GetEvaBackgroundInitialEnvironmentOverride(
+                BranchPointType.EVA,
+                backgroundChildIsEva: false,
+                activeSituation: (int)Vessel.Situations.LANDED,
+                activeSrfSpeed: 0.0);
+
+            Assert.Null(result);
+        }
+
+        #endregion
+
         #region BuildSplitBranchData — Undock
 
         [Fact]

--- a/Source/Parsek/BackgroundRecorder.cs
+++ b/Source/Parsek/BackgroundRecorder.cs
@@ -977,7 +977,8 @@ namespace Parsek
                     hasAtmo, bgVessel.altitude, atmoDepth,
                     (int)bgVessel.situation, bgVessel.srfSpeed, state.cachedEngines, approachAlt,
                     bgVessel.isEVA, bgVessel.heightFromTerrain,
-                    EnvironmentDetector.IsHeightFromTerrainValid(bgVessel.heightFromTerrain));
+                    EnvironmentDetector.IsHeightFromTerrainValid(bgVessel.heightFromTerrain),
+                    bgVessel.mainBody != null && bgVessel.mainBody.ocean);
                 if (state.environmentHysteresis.Update(rawEnv, ut))
                 {
                     var newEnv = state.environmentHysteresis.CurrentEnvironment;
@@ -1767,7 +1768,8 @@ namespace Parsek
                     hasAtmo, v.altitude, atmoDepth,
                     (int)v.situation, v.srfSpeed, state.cachedEngines, approachAlt,
                     v.isEVA, v.heightFromTerrain,
-                    EnvironmentDetector.IsHeightFromTerrainValid(v.heightFromTerrain));
+                    EnvironmentDetector.IsHeightFromTerrainValid(v.heightFromTerrain),
+                    v.mainBody != null && v.mainBody.ocean);
             }
             state.environmentHysteresis = new EnvironmentHysteresis(initialEnv);
             StartBackgroundTrackSection(state, initialEnv, ReferenceFrame.Absolute, ut);
@@ -2083,7 +2085,8 @@ namespace Parsek
             double approachAltitude = 0,
             bool isEva = false,
             double heightFromTerrain = -1,
-            bool heightFromTerrainValid = false)
+            bool heightFromTerrainValid = false,
+            bool hasOcean = false)
         {
             bool hasActiveThrust = false;
             if (cachedEngines != null)
@@ -2103,7 +2106,7 @@ namespace Parsek
             return EnvironmentDetector.Classify(
                 hasAtmosphere, altitude, atmosphereDepth,
                 situation, srfSpeed, hasActiveThrust, approachAltitude,
-                isEva, heightFromTerrain, heightFromTerrainValid);
+                isEva, heightFromTerrain, heightFromTerrainValid, hasOcean);
         }
 
         private bool TryConsumePendingInitialEnvironmentOverride(uint vesselPid, out SegmentEnvironment environment)

--- a/Source/Parsek/BackgroundRecorder.cs
+++ b/Source/Parsek/BackgroundRecorder.cs
@@ -95,6 +95,11 @@ namespace Parsek
         private Dictionary<uint, HashSet<uint>> preBreakVesselPidSnapshots
             = new Dictionary<uint, HashSet<uint>>();
 
+        // Consumed on the first loaded-state init after a branch backgrounds a vessel.
+        // This survives the "backgrounded while not yet loaded" path used by EVA splits.
+        private Dictionary<uint, SegmentEnvironment> pendingInitialEnvironmentOverrides
+            = new Dictionary<uint, SegmentEnvironment>();
+
         // Reusable buffer for transition-check methods (avoids per-frame List<PartEvent> allocations)
         private readonly List<PartEvent> reusableEventBuffer = new List<PartEvent>();
 
@@ -970,7 +975,9 @@ namespace Parsek
                     ? FlightRecorder.ComputeApproachAltitude(bgVessel.mainBody) : 0;
                 var rawEnv = ClassifyBackgroundEnvironment(
                     hasAtmo, bgVessel.altitude, atmoDepth,
-                    (int)bgVessel.situation, bgVessel.srfSpeed, state.cachedEngines, approachAlt);
+                    (int)bgVessel.situation, bgVessel.srfSpeed, state.cachedEngines, approachAlt,
+                    bgVessel.isEVA, bgVessel.heightFromTerrain,
+                    EnvironmentDetector.IsHeightFromTerrainValid(bgVessel.heightFromTerrain));
                 if (state.environmentHysteresis.Update(rawEnv, ut))
                 {
                     var newEnv = state.environmentHysteresis.CurrentEnvironment;
@@ -1063,20 +1070,28 @@ namespace Parsek
         /// <summary>
         /// Called when a vessel is added to the background map (transition or branch creation).
         /// </summary>
-        public void OnVesselBackgrounded(uint vesselPid, InheritedEngineState? inherited = null)
+        public void OnVesselBackgrounded(uint vesselPid, InheritedEngineState? inherited = null,
+            SegmentEnvironment? initialEnvironmentOverride = null)
         {
             if (tree == null) return;
 
             string recordingId;
             if (!tree.BackgroundMap.TryGetValue(vesselPid, out recordingId)) return;
 
+            if (initialEnvironmentOverride.HasValue)
+            {
+                pendingInitialEnvironmentOverrides[vesselPid] = initialEnvironmentOverride.Value;
+                ParsekLog.Verbose("BgRecorder",
+                    $"Queued initial environment override for pid={vesselPid}: {initialEnvironmentOverride.Value}");
+            }
+
             // Remove any stale state from a prior initialization (e.g. constructor
             // created on-rails state before this method is called for the same vessel).
             // Close any open orbit segment first so data is not lost.
-            double ut = Planetarium.GetUniversalTime();
             BackgroundOnRailsState staleRails;
             if (onRailsStates.TryGetValue(vesselPid, out staleRails) && staleRails.hasOpenOrbitSegment)
             {
+                double ut = Planetarium.GetUniversalTime();
                 CloseOrbitSegment(staleRails, ut);
             }
             onRailsStates.Remove(vesselPid);
@@ -1118,7 +1133,7 @@ namespace Parsek
         /// </summary>
         public void OnVesselRemovedFromBackground(uint vesselPid)
         {
-            double ut = Planetarium.GetUniversalTime();
+            double? ut = null;
 
             // Close any open orbit segment
             BackgroundOnRailsState railsState;
@@ -1126,7 +1141,8 @@ namespace Parsek
             {
                 if (railsState.hasOpenOrbitSegment)
                 {
-                    CloseOrbitSegment(railsState, ut);
+                    if (!ut.HasValue) ut = Planetarium.GetUniversalTime();
+                    CloseOrbitSegment(railsState, ut.Value);
                 }
                 onRailsStates.Remove(vesselPid);
             }
@@ -1135,7 +1151,8 @@ namespace Parsek
             BackgroundVesselState loadedState;
             if (loadedStates.TryGetValue(vesselPid, out loadedState))
             {
-                CloseBackgroundTrackSection(loadedState, ut);
+                if (!ut.HasValue) ut = Planetarium.GetUniversalTime();
+                CloseBackgroundTrackSection(loadedState, ut.Value);
 
                 Recording flushRec;
                 if (tree.Recordings.TryGetValue(loadedState.recordingId, out flushRec))
@@ -1146,12 +1163,13 @@ namespace Parsek
                     Vessel v = FlightRecorder.FindVesselByPid(vesselPid);
                     if (v != null)
                     {
-                        SampleBoundaryPoint(v, flushRec, ut);
+                        SampleBoundaryPoint(v, flushRec, ut.Value);
                     }
                 }
                 loadedStates.Remove(vesselPid);
             }
 
+            pendingInitialEnvironmentOverrides.Remove(vesselPid);
             ParsekLog.Info("BgRecorder", $"Vessel removed from background: pid={vesselPid}");
         }
 
@@ -1320,6 +1338,8 @@ namespace Parsek
                 ParsekLog.Info("BgRecorder", $"Background EVA vessel ended: pid={pid}");
             else
                 ParsekLog.Warn("BgRecorder", $"Background vessel destroyed: pid={pid}");
+
+            pendingInitialEnvironmentOverrides.Remove(pid);
         }
 
         /// <summary>
@@ -1391,6 +1411,7 @@ namespace Parsek
 
             onRailsStates.Clear();
             loadedStates.Clear();
+            pendingInitialEnvironmentOverrides.Clear();
 
             ParsekLog.Info("BgRecorder", "Shutdown complete — all background states cleared");
         }
@@ -1728,13 +1749,26 @@ namespace Parsek
 
             // Initialize environment tracking and open first TrackSection
             double ut = Planetarium.GetUniversalTime();
-            bool hasAtmo = v.mainBody != null && v.mainBody.atmosphere;
-            double atmoDepth = hasAtmo ? v.mainBody.atmosphereDepth : 0;
-            double approachAlt = (!hasAtmo && v.mainBody != null)
-                ? FlightRecorder.ComputeApproachAltitude(v.mainBody) : 0;
-            var initialEnv = ClassifyBackgroundEnvironment(
-                hasAtmo, v.altitude, atmoDepth,
-                (int)v.situation, v.srfSpeed, state.cachedEngines, approachAlt);
+            SegmentEnvironment overrideEnv;
+            SegmentEnvironment initialEnv;
+            if (TryConsumePendingInitialEnvironmentOverride(vesselPid, out overrideEnv))
+            {
+                initialEnv = overrideEnv;
+                ParsekLog.Verbose("BgRecorder",
+                    $"InitializeLoadedState: consumed initial environment override for pid={vesselPid}: {initialEnv}");
+            }
+            else
+            {
+                bool hasAtmo = v.mainBody != null && v.mainBody.atmosphere;
+                double atmoDepth = hasAtmo ? v.mainBody.atmosphereDepth : 0;
+                double approachAlt = (!hasAtmo && v.mainBody != null)
+                    ? FlightRecorder.ComputeApproachAltitude(v.mainBody) : 0;
+                initialEnv = ClassifyBackgroundEnvironment(
+                    hasAtmo, v.altitude, atmoDepth,
+                    (int)v.situation, v.srfSpeed, state.cachedEngines, approachAlt,
+                    v.isEVA, v.heightFromTerrain,
+                    EnvironmentDetector.IsHeightFromTerrainValid(v.heightFromTerrain));
+            }
             state.environmentHysteresis = new EnvironmentHysteresis(initialEnv);
             StartBackgroundTrackSection(state, initialEnv, ReferenceFrame.Absolute, ut);
 
@@ -2046,7 +2080,10 @@ namespace Parsek
             bool hasAtmosphere, double altitude, double atmosphereDepth,
             int situation, double srfSpeed,
             List<(Part part, ModuleEngines engine, int moduleIndex)> cachedEngines,
-            double approachAltitude = 0)
+            double approachAltitude = 0,
+            bool isEva = false,
+            double heightFromTerrain = -1,
+            bool heightFromTerrainValid = false)
         {
             bool hasActiveThrust = false;
             if (cachedEngines != null)
@@ -2065,7 +2102,20 @@ namespace Parsek
 
             return EnvironmentDetector.Classify(
                 hasAtmosphere, altitude, atmosphereDepth,
-                situation, srfSpeed, hasActiveThrust, approachAltitude);
+                situation, srfSpeed, hasActiveThrust, approachAltitude,
+                isEva, heightFromTerrain, heightFromTerrainValid);
+        }
+
+        private bool TryConsumePendingInitialEnvironmentOverride(uint vesselPid, out SegmentEnvironment environment)
+        {
+            if (pendingInitialEnvironmentOverrides.TryGetValue(vesselPid, out environment))
+            {
+                pendingInitialEnvironmentOverrides.Remove(vesselPid);
+                return true;
+            }
+
+            environment = SegmentEnvironment.Atmospheric;
+            return false;
         }
 
         /// <summary>
@@ -3174,6 +3224,24 @@ namespace Parsek
         /// For testing: gets the count of debris TTL entries.
         /// </summary>
         internal int DebrisTTLCount => debrisTTLExpiry.Count;
+
+        internal int PendingInitialEnvironmentOverrideCount => pendingInitialEnvironmentOverrides.Count;
+
+        internal SegmentEnvironment? PeekPendingInitialEnvironmentOverrideForTesting(uint vesselPid)
+        {
+            SegmentEnvironment env;
+            if (pendingInitialEnvironmentOverrides.TryGetValue(vesselPid, out env))
+                return env;
+            return null;
+        }
+
+        internal SegmentEnvironment? ConsumePendingInitialEnvironmentOverrideForTesting(uint vesselPid)
+        {
+            SegmentEnvironment env;
+            if (TryConsumePendingInitialEnvironmentOverride(vesselPid, out env))
+                return env;
+            return null;
+        }
 
         /// <summary>
         /// For testing: gets the accumulated TrackSections for a loaded vessel.

--- a/Source/Parsek/EnvironmentDetector.cs
+++ b/Source/Parsek/EnvironmentDetector.cs
@@ -8,6 +8,8 @@ namespace Parsek
     /// </summary>
     internal static class EnvironmentDetector
     {
+        internal const double AtmosphericEvaNearSurfaceMeters = 5.0;
+
         /// <summary>
         /// Pure classification — no hysteresis, no debounce.
         /// Parameters extracted from Vessel for testability (no Vessel dependency).
@@ -19,6 +21,9 @@ namespace Parsek
         /// <param name="srfSpeed">vessel.srfSpeed</param>
         /// <param name="hasActiveThrust">any engine with currentThrust > 0</param>
         /// <param name="approachAltitude">approach altitude threshold for airless bodies (0 = not applicable)</param>
+        /// <param name="isEva">true for Kerbal EVA vessels only</param>
+        /// <param name="heightFromTerrain">vessel.heightFromTerrain when available</param>
+        /// <param name="heightFromTerrainValid">true when heightFromTerrain comes from a valid ground query</param>
         internal static SegmentEnvironment Classify(
             bool hasAtmosphere,
             double altitude,
@@ -26,11 +31,25 @@ namespace Parsek
             int situation,
             double srfSpeed,
             bool hasActiveThrust,
-            double approachAltitude = 0)
+            double approachAltitude = 0,
+            bool isEva = false,
+            double heightFromTerrain = -1,
+            bool heightFromTerrainValid = false)
         {
             // Landed/Splashed/Prelaunch -> surface states
             // situation == 1 (LANDED) or situation == 2 (SPLASHED) or situation == 4 (PRELAUNCH)
             if (situation == 1 || situation == 2 || situation == 4)
+            {
+                return srfSpeed > 0.1
+                    ? SegmentEnvironment.SurfaceMobile
+                    : SegmentEnvironment.SurfaceStationary;
+            }
+
+            // Kerbin/Laythe EVA vessels can briefly report FLYING/SUB_ORBITAL while the
+            // kerbal is still effectively on the ground. Keep this narrow to avoid
+            // turning actual jetpack flight into a surface segment.
+            if (isEva && hasAtmosphere && heightFromTerrainValid &&
+                heightFromTerrain <= AtmosphericEvaNearSurfaceMeters)
             {
                 return srfSpeed > 0.1
                     ? SegmentEnvironment.SurfaceMobile
@@ -92,6 +111,9 @@ namespace Parsek
                 return IsSurfaceEnvironment(envHint.Value);
             return situation == 1 || situation == 2 || situation == 4;
         }
+
+        internal static bool IsHeightFromTerrainValid(double heightFromTerrain)
+            => !double.IsNaN(heightFromTerrain) && heightFromTerrain >= 0.0;
     }
 
     /// <summary>

--- a/Source/Parsek/EnvironmentDetector.cs
+++ b/Source/Parsek/EnvironmentDetector.cs
@@ -9,6 +9,7 @@ namespace Parsek
     internal static class EnvironmentDetector
     {
         internal const double AtmosphericEvaNearSurfaceMeters = 5.0;
+        internal const double AtmosphericEvaNearSeaLevelMeters = 1.0;
 
         /// <summary>
         /// Pure classification — no hysteresis, no debounce.
@@ -24,6 +25,7 @@ namespace Parsek
         /// <param name="isEva">true for Kerbal EVA vessels only</param>
         /// <param name="heightFromTerrain">vessel.heightFromTerrain when available</param>
         /// <param name="heightFromTerrainValid">true when heightFromTerrain comes from a valid ground query</param>
+        /// <param name="hasOcean">body.ocean</param>
         internal static SegmentEnvironment Classify(
             bool hasAtmosphere,
             double altitude,
@@ -34,7 +36,8 @@ namespace Parsek
             double approachAltitude = 0,
             bool isEva = false,
             double heightFromTerrain = -1,
-            bool heightFromTerrainValid = false)
+            bool heightFromTerrainValid = false,
+            bool hasOcean = false)
         {
             // Landed/Splashed/Prelaunch -> surface states
             // situation == 1 (LANDED) or situation == 2 (SPLASHED) or situation == 4 (PRELAUNCH)
@@ -50,6 +53,17 @@ namespace Parsek
             // turning actual jetpack flight into a surface segment.
             if (isEva && hasAtmosphere && heightFromTerrainValid &&
                 heightFromTerrain <= AtmosphericEvaNearSurfaceMeters)
+            {
+                return srfSpeed > 0.1
+                    ? SegmentEnvironment.SurfaceMobile
+                    : SegmentEnvironment.SurfaceStationary;
+            }
+
+            // Swimming / bobbing EVA kerbals on atmospheric ocean worlds can jitter out of
+            // SPLASHED while heightFromTerrain still measures the seafloor, not the water
+            // surface. Treat sea-level-adjacent EVA as surface as well.
+            if (isEva && hasAtmosphere && hasOcean &&
+                altitude <= AtmosphericEvaNearSeaLevelMeters)
             {
                 return srfSpeed > 0.1
                     ? SegmentEnvironment.SurfaceMobile

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -3849,7 +3849,9 @@ namespace Parsek
 
             return EnvironmentDetector.Classify(
                 hasAtmosphere, v.altitude, atmosphereDepth,
-                (int)v.situation, v.srfSpeed, hasActiveThrust, approachAlt);
+                (int)v.situation, v.srfSpeed, hasActiveThrust, approachAlt,
+                v.isEVA, v.heightFromTerrain,
+                EnvironmentDetector.IsHeightFromTerrainValid(v.heightFromTerrain));
         }
 
         /// <summary>

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -3851,7 +3851,8 @@ namespace Parsek
                 hasAtmosphere, v.altitude, atmosphereDepth,
                 (int)v.situation, v.srfSpeed, hasActiveThrust, approachAlt,
                 v.isEVA, v.heightFromTerrain,
-                EnvironmentDetector.IsHeightFromTerrainValid(v.heightFromTerrain));
+                EnvironmentDetector.IsHeightFromTerrainValid(v.heightFromTerrain),
+                v.mainBody != null && v.mainBody.ocean);
         }
 
         /// <summary>

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -1818,6 +1818,27 @@ namespace Parsek
             return (bp, activeChild, backgroundChild);
         }
 
+        internal static SegmentEnvironment? GetEvaBackgroundInitialEnvironmentOverride(
+            BranchPointType branchType,
+            bool backgroundChildIsEva,
+            int activeSituation,
+            double activeSrfSpeed)
+        {
+            if (branchType != BranchPointType.EVA || !backgroundChildIsEva)
+                return null;
+
+            if (activeSituation == (int)Vessel.Situations.LANDED ||
+                activeSituation == (int)Vessel.Situations.SPLASHED ||
+                activeSituation == (int)Vessel.Situations.PRELAUNCH)
+            {
+                return activeSrfSpeed > 0.1
+                    ? SegmentEnvironment.SurfaceMobile
+                    : SegmentEnvironment.SurfaceStationary;
+            }
+
+            return null;
+        }
+
         /// <summary>
         /// Pure data-model method: creates the BranchPoint and one child Recording object
         /// for a vessel merge (dock or board). Testable without Unity.
@@ -1956,8 +1977,23 @@ namespace Parsek
             // Add background child to BackgroundMap FIRST, then notify BackgroundRecorder
             if (backgroundVessel != null && backgroundVessel.persistentId != 0)
             {
+                var initialBackgroundEnvOverride = GetEvaBackgroundInitialEnvironmentOverride(
+                    branchType,
+                    backgroundVessel.isEVA,
+                    activeVessel != null ? (int)activeVessel.situation : 0,
+                    activeVessel != null ? activeVessel.srfSpeed : 0.0);
+
+                if (initialBackgroundEnvOverride.HasValue)
+                {
+                    ParsekLog.Verbose("Flight",
+                        $"CreateSplitBranch: forcing initial background env {initialBackgroundEnvOverride.Value} " +
+                        $"for pid={backgroundVessel.persistentId}");
+                }
+
                 activeTree.BackgroundMap[backgroundVessel.persistentId] = bgChild.RecordingId;
-                backgroundRecorder?.OnVesselBackgrounded(backgroundVessel.persistentId);
+                backgroundRecorder?.OnVesselBackgrounded(
+                    backgroundVessel.persistentId,
+                    initialEnvironmentOverride: initialBackgroundEnvOverride);
             }
 
             // Stop any existing undock continuation and vessel continuation (tree handles them)

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -1822,7 +1822,7 @@ namespace Parsek
             BranchPointType branchType,
             bool backgroundChildIsEva,
             int activeSituation,
-            double activeSrfSpeed)
+            double backgroundSrfSpeed)
         {
             if (branchType != BranchPointType.EVA || !backgroundChildIsEva)
                 return null;
@@ -1831,7 +1831,7 @@ namespace Parsek
                 activeSituation == (int)Vessel.Situations.SPLASHED ||
                 activeSituation == (int)Vessel.Situations.PRELAUNCH)
             {
-                return activeSrfSpeed > 0.1
+                return backgroundSrfSpeed > 0.1
                     ? SegmentEnvironment.SurfaceMobile
                     : SegmentEnvironment.SurfaceStationary;
             }
@@ -1981,7 +1981,7 @@ namespace Parsek
                     branchType,
                     backgroundVessel.isEVA,
                     activeVessel != null ? (int)activeVessel.situation : 0,
-                    activeVessel != null ? activeVessel.srfSpeed : 0.0);
+                    backgroundVessel.srfSpeed);
 
                 if (initialBackgroundEnvOverride.HasValue)
                 {

--- a/docs/dev/plans/fix-326-landed-eva-atmo-stub.md
+++ b/docs/dev/plans/fix-326-landed-eva-atmo-stub.md
@@ -1,0 +1,342 @@
+# Fix Plan: Bug #326 — Landed EVA branch seeded as Atmospheric
+
+**Bug:** #326  
+**Branch:** `fix/phase-11-5-bug-investigation`  
+**Status:** Investigation complete, implementation not started
+
+## Problem
+
+When a player EVAs from a landed vessel, KSP can spend one frame with the ship still
+as `FlightGlobals.ActiveVessel` before switching focus to the kerbal. In that window,
+Parsek creates the EVA branch with:
+
+- the ship as the active child recording
+- the new EVA kerbal as the background child recording
+
+That background EVA child is initialized from a transient pre-switch state. On
+atmospheric bodies, the raw classifier sees `situation != LANDED` and
+`altitude < atmosphereDepth`, so the first background `TrackSection` becomes
+`Atmospheric` even though the kerbal is effectively on the ground.
+
+This workflow currently exposes two related defects:
+
+1. the branch keeps a bogus 1-point non-leaf EVA stub
+2. later near-ground EVA motion on Kerbin can still be misclassified as `Atmospheric`,
+   which creates a real optimizer split candidate
+
+## Investigation Findings
+
+### Repro sequence from `logs/2026-04-12_2242_quickload-branch-gaps-s10/KSP.log`
+
+First EVA branch:
+
+- `13085`: `DeferredEvaBranch: ship still active (KSP hasn't switched)`
+- `13094`: `BgRecorder TrackSection started: env=Atmospheric ... pid=1614280122 at UT=70.24`
+- `13213`: one background point sampled for that EVA child before the switch
+- `13257`: the atmospheric background section closes with `frames=1`
+- `13260`: the EVA child is removed from background and promoted
+- `13289`: the promoted active EVA recorder starts correctly as `SurfaceStationary`
+
+Second EVA branch repeats the same pattern:
+
+- `15552`: `DeferredEvaBranch: ship still active`
+- `15559`: background EVA child starts as `Atmospheric`
+
+Saved/runtime outcome later in the same log:
+
+- `19010`: `Recording #2: "Jebediah Kerman" UT 70-79, 1 pts, vessel`
+- `19013-19014`: second EVA branch becomes two chain entries:
+  - `#5 ... UT 92-99, 13 pts, ghost, chain idx=0`
+  - `#6 ... UT 99-127, 44 pts, vessel, chain idx=1`
+
+Later in the second EVA branch, there is also a separate background-classification flip:
+
+- `15918-15921`: `SurfaceMobile -> Atmospheric` at `UT=98.68`, then a new atmospheric
+  background section starts for the EVA child
+- `17537-17540`: the optimizer later splits at exactly that `UT=98.68` boundary
+
+### Runtime path for the first symptom (the 1-point stub)
+
+1. `ParsekFlight.OnCrewOnEva` stops the active recorder and defers branch creation.
+2. `ParsekFlight.DeferredEvaBranch` can still observe the ship as active one frame later.
+3. `ParsekFlight.CreateSplitBranch` immediately adds the EVA child to `BackgroundMap`
+   and calls `backgroundRecorder.OnVesselBackgrounded(...)`.
+4. `BackgroundRecorder.InitializeLoadedState` opens the first `TrackSection` using
+   `ClassifyBackgroundEnvironment(...)`, which currently trusts the raw loaded-vessel
+   situation/altitude at that instant.
+5. `OnVesselSwitchComplete` promotes the EVA child moments later, but by then the bad
+   background section has already been flushed into the recording.
+
+### Runtime path for the later split
+
+After the second EVA branch is promoted correctly, the EVA child becomes backgrounded
+again when the player switches back to the rover. At that point:
+
+1. the background EVA child starts correctly as `SurfaceMobile`
+2. `BackgroundRecorder.OnBackgroundPhysicsFrame` later re-classifies it as
+   `Atmospheric` at `UT=98.68`
+3. that atmospheric section lasts long enough to survive into the saved recording
+4. the optimizer legitimately splits on that later section boundary
+
+## Root Cause
+
+This is not a single isolated defect.
+
+Bug `326` is really two related defects:
+
+1. **Initial branch handoff defect:** the EVA child is sometimes background-initialized
+   before its surface state stabilizes, so the first section is seeded from a transient
+   pre-switch state.
+2. **Ongoing atmospheric-body EVA classification defect:** once the EVA is backgrounded
+   later, near-ground movement on an atmospheric body can still flip to
+   `Atmospheric` because the current near-surface override only exists for airless
+   bodies.
+
+The fix plan should address both. Fixing only the first symptom would remove the
+1-point stub, but would not remove the later `UT=98.68` split boundary seen in the log.
+
+## Fix Goal
+
+For landed/splashed EVA workflows on atmospheric bodies:
+
+- prevent the initial background EVA child from seeding as `Atmospheric` during the
+  pre-switch race window
+- keep near-ground EVA motion in `SurfaceStationary` / `SurfaceMobile` while it remains
+  ground-adjacent in background recording
+- leave genuine in-flight EVA behavior unchanged
+- avoid any optimizer-side cleanup heuristic unless the root fix proves insufficient
+
+## Preferred Fix
+
+### 1. Add a narrow branch-time override for the first loaded init
+
+Add a small scalar-only helper in `ParsekFlight` that decides whether the background
+child of an EVA branch should receive a forced initial surface environment.
+
+Suggested shape:
+
+```csharp
+internal static SegmentEnvironment? ResolveEvaBackgroundInitialEnvironmentOverride(
+    BranchPointType branchType,
+    bool activeChildIsEva,
+    int activeChildSituation,
+    bool backgroundChildIsEva,
+    uint backgroundChildPid,
+    uint evaVesselPid,
+    double backgroundChildSurfaceSpeed)
+```
+
+Return a surface override only when all of these are true:
+
+- `branchType == BranchPointType.EVA`
+- `backgroundChildPid == evaVesselPid`
+- `backgroundChildIsEva`
+- `!activeChildIsEva`
+- `activeChildSituation` is `LANDED`, `SPLASHED`, or `PRELAUNCH`
+
+Choose the specific surface state from the EVA vessel's own speed:
+
+- `backgroundChildSurfaceSpeed > 0.1` -> `SurfaceMobile`
+- otherwise -> `SurfaceStationary`
+
+If any guard fails, return `null`.
+
+Why this scope is right:
+
+- it only affects the exact race window proven by the log
+- it does not touch true in-flight EVA from flying vessels
+- it does not change the classifier used by normal active recording or non-EVA backgrounding
+
+### 2. Persist that override until the first loaded initialization consumes it
+
+Do not rely on `CreateSplitBranch -> OnVesselBackgrounded -> InitializeLoadedState`
+being a single uninterrupted path. `OnVesselBackgrounded` can fall back to minimal
+state if the vessel is not found yet, and the first real loaded init can happen later
+via `OnBackgroundVesselGoOffRails`.
+
+Instead, add a PID-keyed pending override in `BackgroundRecorder`:
+
+- `SetPendingInitialEnvironmentOverride(uint pid, SegmentEnvironment env)`
+- consume-and-clear on the first loaded-state initialization for that PID
+
+Suggested plumbing:
+
+- `ParsekFlight.CreateSplitBranch` decides whether the EVA child needs the override
+- if yes, it registers the override with `BackgroundRecorder` before/alongside
+  backgrounding the child
+- both `OnVesselBackgrounded(...loaded...)` and `OnBackgroundVesselGoOffRails(...)`
+  consult the same pending override store when they reach `InitializeLoadedState`
+
+Suggested API shape:
+
+```csharp
+internal void SetPendingInitialEnvironmentOverride(
+    uint vesselPid,
+    SegmentEnvironment env)
+```
+
+Inside `InitializeLoadedState`, use the override only for the first section:
+
+- if `initialEnvOverride.HasValue`, initialize `EnvironmentHysteresis` and the first
+  `TrackSection` from that override
+- otherwise keep the current `ClassifyBackgroundEnvironment(...)` path
+
+Add an explicit log so future playtests can confirm the override fired:
+
+```csharp
+Loaded state initialized: pid=... initialEnv=SurfaceStationary source=eva-surface-override
+```
+
+### 3. Extend EVA near-ground classification on atmospheric bodies
+
+The later `UT=98.68` split proves there is still a second defect after promotion:
+background EVA movement near the ground on Kerbin can flip from `SurfaceMobile` to
+`Atmospheric`.
+
+The current near-surface override in `EnvironmentDetector.Classify(...)` only applies
+to airless bodies. Add an EVA-specific near-ground override that works on atmospheric
+bodies too, but only when the vessel is ground-adjacent.
+
+Preferred shape:
+
+- extend the pure classifier inputs so callers can supply:
+  - `isEva`
+  - `heightFromTerrain`
+  - `heightFromTerrainValid`
+- keep the override narrow:
+  - only for EVA
+  - only when `heightFromTerrain` is valid
+  - only below a small threshold such as `NearGroundEvaMeters`
+  - still return `SurfaceMobile` vs `SurfaceStationary` from `srfSpeed`
+
+This should be implemented in the pure classifier layer, not as a special case buried
+inside background recorder update logic, so active and background EVA recording stay
+consistent.
+
+### 4. Leave promotion and optimizer logic unchanged initially
+
+Do not add an optimizer-side band-aid in the first fix.
+
+If both creation-time defects are fixed, then:
+
+- the 1-point atmospheric EVA stub is never produced
+- the saved child recording no longer picks up the later fake atmospheric section
+- the optimizer no longer sees a false split boundary for the landed EVA chain
+
+This keeps the fix at the point where the bad data is created, not where it is later
+consumed.
+
+## Explicit Non-Goals
+
+### Do not broaden `EnvironmentDetector.Classify` for non-EVA vessels
+
+Avoid adding a general atmospheric-body "near ground means surface" override for all
+vessel types.
+
+Why not:
+
+- it would affect rockets, planes, and other non-EVA cases
+- it risks misclassifying genuine low-altitude flight / descent / jetpack movement
+- the evidence points to EVA-specific ground-adjacent behavior, not a generic
+  atmospheric-body issue
+
+### Do not add optimizer special-casing first
+
+Avoid logic like "ignore a 1-point atmospheric section before a surface EVA segment" as
+the primary fix.
+
+Why not:
+
+- it hides bad data after the fact
+- it leaves the recording itself polluted
+- it would not help any other consumer of `TrackSections`
+
+## Target Files
+
+- `Source/Parsek/ParsekFlight.cs`
+- `Source/Parsek/BackgroundRecorder.cs`
+- `Source/Parsek/EnvironmentDetector.cs`
+- `Source/Parsek.Tests/SplitEventDetectionTests.cs`
+- `Source/Parsek.Tests/BackgroundTrackSectionTests.cs`
+- `Source/Parsek.Tests/EnvironmentDetectorTests.cs`
+
+Potentially:
+
+- `Source/Parsek.Tests/RecordingOptimizerTests.cs` for one downstream regression built
+  from the exact log shape
+
+## Test Plan
+
+### 1. Pure helper tests for the branch-time override decision
+
+Add tests in `SplitEventDetectionTests.cs` for the new scalar-only
+`ResolveEvaBackgroundInitialEnvironmentOverride(...)` helper:
+
+- landed ship + background EVA + low speed -> `SurfaceStationary`
+- landed ship + background EVA + moving EVA -> `SurfaceMobile`
+- flying ship + background EVA -> `null`
+- EVA already active (ship is background) -> `null`
+- non-EVA branch type -> `null`
+
+These tests lock down the intended scope so the override cannot silently expand later.
+
+### 2. Background override persistence / consumption tests
+
+Add tests in `BackgroundTrackSectionTests.cs` for the pending override store:
+
+- registering an override for a PID causes the first loaded init to use that env
+- the override is consumed exactly once
+- missing overrides preserve the current classification path unchanged
+- delayed loaded init paths still see the override
+
+This addresses the timing hole where `OnVesselBackgrounded` may not be the hook that
+first sees the loaded vessel.
+
+### 3. Atmospheric-body EVA near-ground classification tests
+
+Add tests in `EnvironmentDetectorTests.cs` for the second defect:
+
+- atmospheric-body EVA, `FLYING`, near ground -> `SurfaceStationary`
+- atmospheric-body EVA, `FLYING`, near ground and moving -> `SurfaceMobile`
+- atmospheric-body non-EVA, same inputs -> still `Atmospheric`
+- EVA above the near-ground threshold -> `Atmospheric`
+
+These tests keep the override narrow and prove we are not broadening normal
+atmospheric classification.
+
+### 4. Regression test for the exact log shape
+
+Add one focused downstream regression that models the saved section sequence from the
+evidence log:
+
+- initial short atmospheric stub
+- later surface -> atmospheric -> surface flip around `UT=98.68`
+- optimizer split candidate produced from that shape
+
+After the fix, that log-shaped sequence should no longer be constructible from the
+intended landed-EVA classification path.
+
+This can live in `RecordingOptimizerTests.cs` if the fixture is easiest there.
+
+## Manual Verification
+
+After implementation, replay the `s10` scenario or an equivalent landed-EVA test and
+confirm:
+
+- `DeferredEvaBranch: ship still active` can still occur without harm
+- the background EVA child initializes as `SurfaceStationary` / `SurfaceMobile`
+- no `TrackSection started: env=Atmospheric` appears for the landed EVA child
+- the first EVA branch no longer saves as a 1-point non-leaf atmospheric stub
+- later near-ground background EVA motion no longer flips to `Atmospheric`
+- the second EVA branch no longer produces the false optimizer split at `UT=98.68`
+
+## Rollout Notes
+
+This should be a small, local fix. The safest order is:
+
+1. add the pure branch-decision helper and its tests
+2. add the pending PID override store and its tests
+3. extend EVA near-ground classification for atmospheric bodies
+4. add the downstream regression test for the log shape
+5. run the relevant test subset
+6. only then update `docs/dev/todo-and-known-bugs.md`

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -592,7 +592,7 @@ After removing ResourceBudget.ComputeTotal logging (52% of output), remaining sp
 
 ---
 
-## 189b. Ghost escape orbit line stops short of Kerbin SOI edge
+## ~~189b. Ghost escape orbit line stops short of Kerbin SOI edge~~
 
 For hyperbolic escape orbits, KSP's `OrbitRendererBase.UpdateSpline` draws the geometric hyperbola from `-acos(-1/e)` to `+acos(-1/e)` using circular trig (cos/sin), which clips at a finite distance (~12,000 km for e=1.342). The active vessel shows the full escape trajectory to the SOI boundary because it uses `PatchedConicSolver` + `PatchRendering`. Ghost ProtoVessels don't get a `PatchedConicSolver`.
 
@@ -602,6 +602,8 @@ For hyperbolic escape orbits, KSP's `OrbitRendererBase.UpdateSpline` draws the g
 3. Give the ghost a `PatchedConicSolver` (complex, may conflict with KSP internals)
 
 **Priority:** Deferred to Phase 11.5 (Recording Optimization & Observability) — cosmetic, same tier as T25 fairing truss
+
+**Status:** ~~Closed as expected behavior.~~
 
 ---
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -250,7 +250,7 @@ Add unit/in-game coverage around `F5/F9` during a branch, final save/load, and w
 
 ---
 
-## 326. Landed EVA branch can be seeded as Atmospheric, leaving a bogus 1-point EVA fragment and bad optimizer splits
+## ~~326. Landed EVA branch can be seeded as Atmospheric, leaving a bogus 1-point EVA fragment and bad optimizer splits~~
 
 **Observed in:** `logs/2026-04-12_2242_quickload-branch-gaps-s10/` (`s10`). The latest retry did **not** reproduce the exact `s9` watch-handoff failure; main-vessel watch transfer worked on current head. But the run exposed a different regression in the EVA branch path.
 
@@ -272,16 +272,14 @@ Add unit/in-game coverage around `F5/F9` during a branch, final save/load, and w
 
 **Impact:** A surface EVA can be recorded as if it briefly started in atmosphere, which pollutes the final tree with a tiny non-leaf stub and causes later optimizer output to classify EVA chain segments as `atmo`. That matches the user-visible symptom of "gaps" / badly stitched EVA recordings even though watch transfer on the main vessel path works.
 
-**Root cause / hypothesis:** During EVA split creation, the child kerbal is first background-initialized from a transient pre-stable loaded state. The environment classifier appears to trust `inAtmo/altitude` too early, before landed/grounded state is stable, so it seeds `Atmospheric` for a loaded surface EVA. Once the switch completes, the active recorder correctly sees `SurfaceStationary`, but the one-frame atmospheric background section has already been persisted into the recording.
+**Root cause:** This turned out to be two related defects:
 
-**Fix direction:** In the EVA branch path, either:
+- when KSP left the source vessel active for one more frame, `CreateSplitBranch -> OnVesselBackgrounded -> InitializeLoadedState` could background-seed the new EVA child from a transient pre-stable loaded state, producing the 1-point `Atmospheric` stub
+- later, atmospheric-body EVA classification still trusted transient `FLYING` / `SUB_ORBITAL` state too much for ground-adjacent and splashed kerbals, so near-surface or sea-level bobbing EVAs could still flip into `Atmospheric` and create bogus optimizer splits
 
-- seed surface EVAs conservatively as `SurfaceStationary` / `SurfaceMobile` when the source situation is landed/splashed or the EVA is known to be ground-adjacent, or
-- delay background loaded-state initialization for the new EVA vessel until its landed/ground-contact state stabilizes
+**Fix:** EVA branch creation now queues a PID-keyed one-shot initial environment override when the background child is an EVA spawned from a landed / splashed / prelaunch source, and `BackgroundRecorder.InitializeLoadedState` consumes that override on the first real loaded init, including delayed go-off-rails initialization. `EnvironmentDetector`, `FlightRecorder`, and `BackgroundRecorder` now also keep atmospheric-body EVAs in surface segments when they are validly near terrain or bobbing at sea level on an ocean world. Added regression coverage for the branch override helper, pending override bookkeeping, and landed/splashed atmospheric-body EVA classification.
 
-Then add coverage that a landed EVA split does not create a 1-point atmospheric stub and that optimizer output for the resulting EVA chain is surface-classified unless the kerbal actually goes airborne.
-
-**Status:** Open
+**Status:** ~~Fixed~~
 
 ---
 


### PR DESCRIPTION
## Summary
- seed background EVA branches with a surface environment override when KSP leaves the parent vessel active during EVA handoff
- classify atmospheric-body EVAs near terrain or sea level as surface in both active and background recorders, including splashed/swimming cases
- add regression coverage for the branch override path and bug 326 surface classification cases, and keep the reviewed fix plan plus 189b todo status update in the branch

## Testing
- `dotnet test Source/Parsek.Tests/Parsek.Tests.csproj`
- `dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter "FullyQualifiedName~SplitEventDetectionTests|FullyQualifiedName~BackgroundRecorderTests|FullyQualifiedName~BackgroundTrackSectionTests|FullyQualifiedName~EnvironmentDetectorTests"`
