### PR TITLE
Fix watch handoff gaps after branched quickloads

### DIFF
--- a/Source/Parsek.Tests/BugFixTests.cs
+++ b/Source/Parsek.Tests/BugFixTests.cs
@@ -1447,6 +1447,43 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void TreeBranch_DifferentPidFallbackNoGhost_PendingActivationReturnedOnUndock()
+        {
+            var bp = new BranchPoint
+            {
+                Id = "bp1",
+                Type = BranchPointType.Undock,
+                ChildRecordingIds = new List<string> { "child-debris", "child-main" }
+            };
+            var tree = new RecordingTree
+            {
+                Id = "t1",
+                TreeName = "Test",
+                BranchPoints = new List<BranchPoint> { bp }
+            };
+
+            var recs = new List<Recording>
+            {
+                MakeRec("root", vesselPid: 100, treeId: "t1", childBpId: "bp1"),
+                MakeRec("child-debris", vesselPid: 200, treeId: "t1"),
+                MakeRec("child-main", vesselPid: 300, treeId: "t1"),
+            };
+            recs[1].IsDebris = true;
+            recs[2].ExplicitStartUT = 115.0;
+            recs[2].Points = new List<TrajectoryPoint>
+            {
+                new TrajectoryPoint { ut = 132.0 },
+                new TrajectoryPoint { ut = 140.0 }
+            };
+
+            bool found = GhostPlaybackLogic.TryGetPendingWatchActivationUT(
+                recs[0], recs, new List<RecordingTree> { tree }, idx => false, out double activationUT);
+
+            Assert.True(found);
+            Assert.Equal(132.0, activationUT);
+        }
+
+        [Fact]
         public void TreeBranch_PidMatchWithGhost_StillPreferred()
         {
             // Both continuation and debris have ghosts — PID match wins as before.

--- a/Source/Parsek.Tests/BugFixTests.cs
+++ b/Source/Parsek.Tests/BugFixTests.cs
@@ -1384,6 +1384,69 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void TreeBranch_PidMatchNoGhost_PendingActivationUsesActualPayloadStartUT()
+        {
+            var bp = new BranchPoint
+            {
+                Id = "bp1",
+                ChildRecordingIds = new List<string> { "child-main", "child-debris" }
+            };
+            var tree = new RecordingTree
+            {
+                Id = "t1",
+                TreeName = "Test",
+                BranchPoints = new List<BranchPoint> { bp }
+            };
+
+            var recs = new List<Recording>
+            {
+                MakeRec("root", vesselPid: 100, treeId: "t1", childBpId: "bp1"),
+                MakeRec("child-main", vesselPid: 100, treeId: "t1"),
+                MakeRec("child-debris", vesselPid: 200, treeId: "t1"),
+            };
+
+            recs[1].ExplicitStartUT = 110.0;
+            recs[1].Points = new List<TrajectoryPoint>
+            {
+                new TrajectoryPoint { ut = 130.0 },
+                new TrajectoryPoint { ut = 140.0 }
+            };
+
+            bool found = GhostPlaybackLogic.TryGetPendingWatchActivationUT(
+                recs[0], recs, new List<RecordingTree> { tree }, idx => false, out double activationUT);
+
+            Assert.True(found);
+            Assert.Equal(130.0, activationUT);
+        }
+
+        [Fact]
+        public void TreeBranch_PidMatchGhostAlreadyActive_NoPendingActivationReturned()
+        {
+            var bp = new BranchPoint
+            {
+                Id = "bp1",
+                ChildRecordingIds = new List<string> { "child-main" }
+            };
+            var tree = new RecordingTree
+            {
+                Id = "t1",
+                TreeName = "Test",
+                BranchPoints = new List<BranchPoint> { bp }
+            };
+
+            var recs = new List<Recording>
+            {
+                MakeRec("root", vesselPid: 100, treeId: "t1", childBpId: "bp1"),
+                MakeRec("child-main", vesselPid: 100, treeId: "t1"),
+            };
+
+            bool found = GhostPlaybackLogic.TryGetPendingWatchActivationUT(
+                recs[0], recs, new List<RecordingTree> { tree }, idx => idx == 1, out _);
+
+            Assert.False(found);
+        }
+
+        [Fact]
         public void TreeBranch_PidMatchWithGhost_StillPreferred()
         {
             // Both continuation and debris have ghosts — PID match wins as before.

--- a/Source/Parsek.Tests/RuntimePolicyTests.cs
+++ b/Source/Parsek.Tests/RuntimePolicyTests.cs
@@ -210,6 +210,33 @@ namespace Parsek.Tests
         #endregion
 
         [Fact]
+        public void ComputePendingWatchHoldSeconds_ExtendsHoldForFutureContinuationAt1x()
+        {
+            float holdSeconds = GhostPlaybackLogic.ComputePendingWatchHoldSeconds(
+                3f, currentUT: 53.68, continuationActivationUT: 83.04, warpRate: 1f);
+
+            Assert.InRange(holdSeconds, 31f, 33f);
+        }
+
+        [Fact]
+        public void ComputePendingWatchHoldSeconds_UsesWarpRateForEstimatedRealTime()
+        {
+            float holdSeconds = GhostPlaybackLogic.ComputePendingWatchHoldSeconds(
+                3f, currentUT: 53.68, continuationActivationUT: 83.04, warpRate: 5f);
+
+            Assert.InRange(holdSeconds, 8f, 9f);
+        }
+
+        [Fact]
+        public void ComputePendingWatchHoldSeconds_NoFutureGap_LeavesBaseHold()
+        {
+            float holdSeconds = GhostPlaybackLogic.ComputePendingWatchHoldSeconds(
+                3f, currentUT: 83.04, continuationActivationUT: 83.04, warpRate: 1f);
+
+            Assert.Equal(3f, holdSeconds);
+        }
+
+        [Fact]
         public void ComputeScaledRcsEmissionRate_ShowcaseEnforcesVisibilityFloor()
         {
             float rate = GhostPlaybackLogic.ComputeScaledRcsEmissionRate(

--- a/Source/Parsek.Tests/RuntimePolicyTests.cs
+++ b/Source/Parsek.Tests/RuntimePolicyTests.cs
@@ -237,6 +237,38 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void ComputePendingWatchHoldWindow_PendingContinuationUsesSharedRealtimeBase()
+        {
+            GhostPlaybackLogic.ComputePendingWatchHoldWindow(
+                3f,
+                currentRealtime: 10f,
+                currentUT: 53.68,
+                continuationActivationUT: 83.04,
+                warpRate: 5f,
+                out float holdUntilRealTime,
+                out float holdMaxRealTime);
+
+            Assert.Equal(18f, holdUntilRealTime);
+            Assert.Equal(55f, holdMaxRealTime);
+        }
+
+        [Fact]
+        public void ComputePendingWatchHoldWindow_PendingContinuationCapsInitialDeadlineAtMax()
+        {
+            GhostPlaybackLogic.ComputePendingWatchHoldWindow(
+                3f,
+                currentRealtime: 10f,
+                currentUT: 53.68,
+                continuationActivationUT: 200.0,
+                warpRate: 0.1f,
+                out float holdUntilRealTime,
+                out float holdMaxRealTime);
+
+            Assert.Equal(55f, holdUntilRealTime);
+            Assert.Equal(55f, holdMaxRealTime);
+        }
+
+        [Fact]
         public void ComputeScaledRcsEmissionRate_ShowcaseEnforcesVisibilityFloor()
         {
             float rate = GhostPlaybackLogic.ComputeScaledRcsEmissionRate(

--- a/Source/Parsek.Tests/WatchModeControllerTests.cs
+++ b/Source/Parsek.Tests/WatchModeControllerTests.cs
@@ -59,7 +59,9 @@ namespace Parsek.Tests
             RecordingStore.ResetForTesting();
             ParsekLog.SuppressLogging = true;
             var previousRealtimeNow = WatchModeController.RealtimeNow;
+            var previousCurrentUTNow = WatchModeController.CurrentUTNow;
             WatchModeController.RealtimeNow = () => 0f;
+            WatchModeController.CurrentUTNow = () => 0.0;
 
             try
             {
@@ -121,6 +123,127 @@ namespace Parsek.Tests
             finally
             {
                 WatchModeController.RealtimeNow = previousRealtimeNow;
+                WatchModeController.CurrentUTNow = previousCurrentUTNow;
+                RecordingStore.ResetForTesting();
+                ParsekLog.SuppressLogging = false;
+            }
+        }
+
+        [Fact]
+        public void ProcessWatchEndHoldTimer_PendingActivationUT_BlocksExpiryUntilCurrentUTCatchesUp()
+        {
+            RecordingStore.ResetForTesting();
+            ParsekLog.SuppressLogging = true;
+            var previousRealtimeNow = WatchModeController.RealtimeNow;
+            var previousCurrentUTNow = WatchModeController.CurrentUTNow;
+            WatchModeController.RealtimeNow = () => 5f;
+            WatchModeController.CurrentUTNow = () => 120.0;
+
+            try
+            {
+                var root = MakeRecording("root", 100);
+                RecordingStore.AddCommittedInternal(root);
+
+                var host = (ParsekFlight)FormatterServices.GetUninitializedObject(typeof(ParsekFlight));
+                var engine = new GhostPlaybackEngine(null);
+                engine.ghostStates[0] = new GhostPlaybackState();
+
+                var engineField = typeof(ParsekFlight).GetField("engine",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+                engineField.SetValue(host, engine);
+
+                var controller = new WatchModeController(host);
+
+                var watchedRecordingIndexField = typeof(WatchModeController).GetField("watchedRecordingIndex",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+                watchedRecordingIndexField.SetValue(controller, 0);
+
+                var watchedRecordingIdField = typeof(WatchModeController).GetField("watchedRecordingId",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+                watchedRecordingIdField.SetValue(controller, root.RecordingId);
+
+                var holdUntilField = typeof(WatchModeController).GetField("watchEndHoldUntilRealTime",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+                holdUntilField.SetValue(controller, 1f);
+
+                var pendingActivationField = typeof(WatchModeController).GetField("watchEndHoldPendingActivationUT",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+                pendingActivationField.SetValue(controller, 150.0);
+
+                var processMethod = typeof(WatchModeController).GetMethod("ProcessWatchEndHoldTimer",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+                bool handled = (bool)processMethod.Invoke(controller, null);
+
+                Assert.True(handled);
+                Assert.Equal(0, watchedRecordingIndexField.GetValue(controller));
+                Assert.Equal(1f, (float)holdUntilField.GetValue(controller));
+                Assert.Equal(150.0, (double)pendingActivationField.GetValue(controller));
+                Assert.True(engine.ghostStates.ContainsKey(0));
+            }
+            finally
+            {
+                WatchModeController.RealtimeNow = previousRealtimeNow;
+                WatchModeController.CurrentUTNow = previousCurrentUTNow;
+                RecordingStore.ResetForTesting();
+                ParsekLog.SuppressLogging = false;
+            }
+        }
+
+        [Fact]
+        public void ProcessWatchEndHoldTimer_PendingActivationUTReached_AddsPostActivationGrace()
+        {
+            RecordingStore.ResetForTesting();
+            ParsekLog.SuppressLogging = true;
+            var previousRealtimeNow = WatchModeController.RealtimeNow;
+            var previousCurrentUTNow = WatchModeController.CurrentUTNow;
+            WatchModeController.RealtimeNow = () => 5f;
+            WatchModeController.CurrentUTNow = () => 150.0;
+
+            try
+            {
+                var root = MakeRecording("root", 100);
+                RecordingStore.AddCommittedInternal(root);
+
+                var host = (ParsekFlight)FormatterServices.GetUninitializedObject(typeof(ParsekFlight));
+                var engine = new GhostPlaybackEngine(null);
+                engine.ghostStates[0] = new GhostPlaybackState();
+
+                var engineField = typeof(ParsekFlight).GetField("engine",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+                engineField.SetValue(host, engine);
+
+                var controller = new WatchModeController(host);
+
+                var watchedRecordingIndexField = typeof(WatchModeController).GetField("watchedRecordingIndex",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+                watchedRecordingIndexField.SetValue(controller, 0);
+
+                var watchedRecordingIdField = typeof(WatchModeController).GetField("watchedRecordingId",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+                watchedRecordingIdField.SetValue(controller, root.RecordingId);
+
+                var holdUntilField = typeof(WatchModeController).GetField("watchEndHoldUntilRealTime",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+                holdUntilField.SetValue(controller, 1f);
+
+                var pendingActivationField = typeof(WatchModeController).GetField("watchEndHoldPendingActivationUT",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+                pendingActivationField.SetValue(controller, 150.0);
+
+                var processMethod = typeof(WatchModeController).GetMethod("ProcessWatchEndHoldTimer",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+                bool handled = (bool)processMethod.Invoke(controller, null);
+
+                Assert.True(handled);
+                Assert.Equal(7f, (float)holdUntilField.GetValue(controller));
+                Assert.True(double.IsNaN((double)pendingActivationField.GetValue(controller)));
+                Assert.Equal(0, watchedRecordingIndexField.GetValue(controller));
+                Assert.True(engine.ghostStates.ContainsKey(0));
+            }
+            finally
+            {
+                WatchModeController.RealtimeNow = previousRealtimeNow;
+                WatchModeController.CurrentUTNow = previousCurrentUTNow;
                 RecordingStore.ResetForTesting();
                 ParsekLog.SuppressLogging = false;
             }

--- a/Source/Parsek.Tests/WatchModeControllerTests.cs
+++ b/Source/Parsek.Tests/WatchModeControllerTests.cs
@@ -333,35 +333,5 @@ namespace Parsek.Tests
             }
         }
 
-        [Fact]
-        public void StartWatchHold_PendingActivation_ClampsInitialDeadlineToMaxCap()
-        {
-            ParsekLog.SuppressLogging = true;
-            var previousRealtimeNow = WatchModeController.RealtimeNow;
-            WatchModeController.RealtimeNow = () => 10f;
-
-            try
-            {
-                var host = (ParsekFlight)FormatterServices.GetUninitializedObject(typeof(ParsekFlight));
-                var controller = new WatchModeController(host);
-
-                var startHoldMethod = typeof(WatchModeController).GetMethod("StartWatchHold",
-                    BindingFlags.Instance | BindingFlags.NonPublic);
-                startHoldMethod.Invoke(controller, new object[] { 100f, 150.0 });
-
-                var holdUntilField = typeof(WatchModeController).GetField("watchEndHoldUntilRealTime",
-                    BindingFlags.Instance | BindingFlags.NonPublic);
-                var holdMaxField = typeof(WatchModeController).GetField("watchEndHoldMaxRealTime",
-                    BindingFlags.Instance | BindingFlags.NonPublic);
-
-                Assert.Equal(55f, (float)holdUntilField.GetValue(controller));
-                Assert.Equal(55f, (float)holdMaxField.GetValue(controller));
-            }
-            finally
-            {
-                WatchModeController.RealtimeNow = previousRealtimeNow;
-                ParsekLog.SuppressLogging = false;
-            }
-        }
     }
 }

--- a/Source/Parsek.Tests/WatchModeControllerTests.cs
+++ b/Source/Parsek.Tests/WatchModeControllerTests.cs
@@ -332,5 +332,36 @@ namespace Parsek.Tests
                 ParsekLog.SuppressLogging = false;
             }
         }
+
+        [Fact]
+        public void StartWatchHold_PendingActivation_ClampsInitialDeadlineToMaxCap()
+        {
+            ParsekLog.SuppressLogging = true;
+            var previousRealtimeNow = WatchModeController.RealtimeNow;
+            WatchModeController.RealtimeNow = () => 10f;
+
+            try
+            {
+                var host = (ParsekFlight)FormatterServices.GetUninitializedObject(typeof(ParsekFlight));
+                var controller = new WatchModeController(host);
+
+                var startHoldMethod = typeof(WatchModeController).GetMethod("StartWatchHold",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+                startHoldMethod.Invoke(controller, new object[] { 100f, 150.0 });
+
+                var holdUntilField = typeof(WatchModeController).GetField("watchEndHoldUntilRealTime",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+                var holdMaxField = typeof(WatchModeController).GetField("watchEndHoldMaxRealTime",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+
+                Assert.Equal(55f, (float)holdUntilField.GetValue(controller));
+                Assert.Equal(55f, (float)holdMaxField.GetValue(controller));
+            }
+            finally
+            {
+                WatchModeController.RealtimeNow = previousRealtimeNow;
+                ParsekLog.SuppressLogging = false;
+            }
+        }
     }
 }

--- a/Source/Parsek.Tests/WatchModeControllerTests.cs
+++ b/Source/Parsek.Tests/WatchModeControllerTests.cs
@@ -60,8 +60,10 @@ namespace Parsek.Tests
             ParsekLog.SuppressLogging = true;
             var previousRealtimeNow = WatchModeController.RealtimeNow;
             var previousCurrentUTNow = WatchModeController.CurrentUTNow;
+            var previousCurrentWarpRateNow = WatchModeController.CurrentWarpRateNow;
             WatchModeController.RealtimeNow = () => 0f;
             WatchModeController.CurrentUTNow = () => 0.0;
+            WatchModeController.CurrentWarpRateNow = () => 1f;
 
             try
             {
@@ -124,20 +126,23 @@ namespace Parsek.Tests
             {
                 WatchModeController.RealtimeNow = previousRealtimeNow;
                 WatchModeController.CurrentUTNow = previousCurrentUTNow;
+                WatchModeController.CurrentWarpRateNow = previousCurrentWarpRateNow;
                 RecordingStore.ResetForTesting();
                 ParsekLog.SuppressLogging = false;
             }
         }
 
         [Fact]
-        public void ProcessWatchEndHoldTimer_PendingActivationUT_BlocksExpiryUntilCurrentUTCatchesUp()
+        public void ProcessWatchEndHoldTimer_PendingActivationUT_RecomputesDeadlineBeforeExpiry()
         {
             RecordingStore.ResetForTesting();
             ParsekLog.SuppressLogging = true;
             var previousRealtimeNow = WatchModeController.RealtimeNow;
             var previousCurrentUTNow = WatchModeController.CurrentUTNow;
+            var previousCurrentWarpRateNow = WatchModeController.CurrentWarpRateNow;
             WatchModeController.RealtimeNow = () => 5f;
             WatchModeController.CurrentUTNow = () => 120.0;
+            WatchModeController.CurrentWarpRateNow = () => 1f;
 
             try
             {
@@ -166,6 +171,10 @@ namespace Parsek.Tests
                     BindingFlags.Instance | BindingFlags.NonPublic);
                 holdUntilField.SetValue(controller, 1f);
 
+                var holdMaxField = typeof(WatchModeController).GetField("watchEndHoldMaxRealTime",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+                holdMaxField.SetValue(controller, 45f);
+
                 var pendingActivationField = typeof(WatchModeController).GetField("watchEndHoldPendingActivationUT",
                     BindingFlags.Instance | BindingFlags.NonPublic);
                 pendingActivationField.SetValue(controller, 150.0);
@@ -176,7 +185,7 @@ namespace Parsek.Tests
 
                 Assert.True(handled);
                 Assert.Equal(0, watchedRecordingIndexField.GetValue(controller));
-                Assert.Equal(1f, (float)holdUntilField.GetValue(controller));
+                Assert.Equal(37f, (float)holdUntilField.GetValue(controller));
                 Assert.Equal(150.0, (double)pendingActivationField.GetValue(controller));
                 Assert.True(engine.ghostStates.ContainsKey(0));
             }
@@ -184,6 +193,7 @@ namespace Parsek.Tests
             {
                 WatchModeController.RealtimeNow = previousRealtimeNow;
                 WatchModeController.CurrentUTNow = previousCurrentUTNow;
+                WatchModeController.CurrentWarpRateNow = previousCurrentWarpRateNow;
                 RecordingStore.ResetForTesting();
                 ParsekLog.SuppressLogging = false;
             }
@@ -196,8 +206,10 @@ namespace Parsek.Tests
             ParsekLog.SuppressLogging = true;
             var previousRealtimeNow = WatchModeController.RealtimeNow;
             var previousCurrentUTNow = WatchModeController.CurrentUTNow;
+            var previousCurrentWarpRateNow = WatchModeController.CurrentWarpRateNow;
             WatchModeController.RealtimeNow = () => 5f;
             WatchModeController.CurrentUTNow = () => 150.0;
+            WatchModeController.CurrentWarpRateNow = () => 1f;
 
             try
             {
@@ -225,6 +237,10 @@ namespace Parsek.Tests
                 var holdUntilField = typeof(WatchModeController).GetField("watchEndHoldUntilRealTime",
                     BindingFlags.Instance | BindingFlags.NonPublic);
                 holdUntilField.SetValue(controller, 1f);
+
+                var holdMaxField = typeof(WatchModeController).GetField("watchEndHoldMaxRealTime",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+                holdMaxField.SetValue(controller, 10f);
 
                 var pendingActivationField = typeof(WatchModeController).GetField("watchEndHoldPendingActivationUT",
                     BindingFlags.Instance | BindingFlags.NonPublic);
@@ -244,6 +260,74 @@ namespace Parsek.Tests
             {
                 WatchModeController.RealtimeNow = previousRealtimeNow;
                 WatchModeController.CurrentUTNow = previousCurrentUTNow;
+                WatchModeController.CurrentWarpRateNow = previousCurrentWarpRateNow;
+                RecordingStore.ResetForTesting();
+                ParsekLog.SuppressLogging = false;
+            }
+        }
+
+        [Fact]
+        public void ProcessWatchEndHoldTimer_PendingActivationUT_RecomputedDeadlineRespectsMaxCap()
+        {
+            RecordingStore.ResetForTesting();
+            ParsekLog.SuppressLogging = true;
+            var previousRealtimeNow = WatchModeController.RealtimeNow;
+            var previousCurrentUTNow = WatchModeController.CurrentUTNow;
+            var previousCurrentWarpRateNow = WatchModeController.CurrentWarpRateNow;
+            WatchModeController.RealtimeNow = () => 44f;
+            WatchModeController.CurrentUTNow = () => 120.0;
+            WatchModeController.CurrentWarpRateNow = () => 0.1f;
+
+            try
+            {
+                var root = MakeRecording("root", 100);
+                RecordingStore.AddCommittedInternal(root);
+
+                var host = (ParsekFlight)FormatterServices.GetUninitializedObject(typeof(ParsekFlight));
+                var engine = new GhostPlaybackEngine(null);
+                engine.ghostStates[0] = new GhostPlaybackState();
+
+                var engineField = typeof(ParsekFlight).GetField("engine",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+                engineField.SetValue(host, engine);
+
+                var controller = new WatchModeController(host);
+
+                var watchedRecordingIndexField = typeof(WatchModeController).GetField("watchedRecordingIndex",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+                watchedRecordingIndexField.SetValue(controller, 0);
+
+                var watchedRecordingIdField = typeof(WatchModeController).GetField("watchedRecordingId",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+                watchedRecordingIdField.SetValue(controller, root.RecordingId);
+
+                var holdUntilField = typeof(WatchModeController).GetField("watchEndHoldUntilRealTime",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+                holdUntilField.SetValue(controller, 1f);
+
+                var holdMaxField = typeof(WatchModeController).GetField("watchEndHoldMaxRealTime",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+                holdMaxField.SetValue(controller, 45f);
+
+                var pendingActivationField = typeof(WatchModeController).GetField("watchEndHoldPendingActivationUT",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+                pendingActivationField.SetValue(controller, 150.0);
+
+                var processMethod = typeof(WatchModeController).GetMethod("ProcessWatchEndHoldTimer",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+                bool handled = (bool)processMethod.Invoke(controller, null);
+
+                Assert.True(handled);
+                Assert.Equal(45f, (float)holdUntilField.GetValue(controller));
+                Assert.Equal(150.0, (double)pendingActivationField.GetValue(controller));
+                Assert.Equal(0, watchedRecordingIndexField.GetValue(controller));
+                Assert.True(engine.ghostStates.ContainsKey(0));
+            }
+            finally
+            {
+                WatchModeController.RealtimeNow = previousRealtimeNow;
+                WatchModeController.CurrentUTNow = previousCurrentUTNow;
+                WatchModeController.CurrentWarpRateNow = previousCurrentWarpRateNow;
                 RecordingStore.ResetForTesting();
                 ParsekLog.SuppressLogging = false;
             }

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -3417,6 +3417,9 @@ namespace Parsek
             return false;
         }
 
+        internal const float PendingWatchPostActivationGraceSeconds = 2f;
+        internal const float MaxPendingWatchHoldSeconds = 45f;
+
         internal static float ComputePendingWatchHoldSeconds(
             float baseHoldSeconds,
             double currentUT,
@@ -3430,8 +3433,9 @@ namespace Parsek
                 return baseHoldSeconds;
 
             float effectiveWarpRate = warpRate > 0.01f ? warpRate : 1f;
-            float requiredSeconds = Mathf.Ceil((float)((continuationActivationUT - currentUT) / effectiveWarpRate) + 2f);
-            return Mathf.Clamp(Mathf.Max(baseHoldSeconds, requiredSeconds), baseHoldSeconds, 45f);
+            float requiredSeconds = Mathf.Ceil((float)((continuationActivationUT - currentUT) / effectiveWarpRate)
+                + PendingWatchPostActivationGraceSeconds);
+            return Mathf.Clamp(Mathf.Max(baseHoldSeconds, requiredSeconds), baseHoldSeconds, MaxPendingWatchHoldSeconds);
         }
 
         private static double MinPendingActivationUT(double currentBest, double candidate)

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -3278,6 +3278,140 @@ namespace Parsek
             return -1;
         }
 
+        /// <summary>
+        /// Returns the earliest UT at which a preferred watch continuation could become
+        /// ghost-active, even if it is not active yet. This is used to extend the
+        /// watch-end hold timer for quickload-resumed branches whose continuation data
+        /// starts later than the parent branch boundary.
+        /// </summary>
+        internal static bool TryGetPendingWatchActivationUT(
+            Recording currentRec,
+            IReadOnlyList<Recording> committed,
+            IReadOnlyList<RecordingTree> trees,
+            Func<int, bool> isGhostActive,
+            out double activationUT,
+            int depth = 0)
+        {
+            activationUT = double.NaN;
+            const int MaxRecursionDepth = 10;
+            if (currentRec == null || committed == null || depth > MaxRecursionDepth)
+                return false;
+
+            // Case 1: Chain continuation.
+            if (!string.IsNullOrEmpty(currentRec.ChainId)
+                && currentRec.ChainIndex >= 0
+                && currentRec.ChainBranch == 0)
+            {
+                int nextChainIndex = currentRec.ChainIndex + 1;
+                for (int j = 0; j < committed.Count; j++)
+                {
+                    var candidate = committed[j];
+                    if (candidate.ChainId != currentRec.ChainId
+                        || candidate.ChainBranch != 0
+                        || candidate.ChainIndex != nextChainIndex)
+                    {
+                        continue;
+                    }
+
+                    if (isGhostActive != null && isGhostActive(j))
+                        return false;
+
+                    return candidate.TryGetGhostActivationStartUT(out activationUT);
+                }
+            }
+
+            // Case 2: Tree branching via ChildBranchPointId, same-PID continuation only.
+            if (!string.IsNullOrEmpty(currentRec.ChildBranchPointId)
+                && currentRec.IsTreeRecording
+                && trees != null)
+            {
+                BranchPoint bp = null;
+                for (int t = 0; t < trees.Count; t++)
+                {
+                    var tree = trees[t];
+                    if (tree.Id != currentRec.TreeId)
+                        continue;
+
+                    for (int b = 0; b < tree.BranchPoints.Count; b++)
+                    {
+                        if (tree.BranchPoints[b].Id == currentRec.ChildBranchPointId)
+                        {
+                            bp = tree.BranchPoints[b];
+                            break;
+                        }
+                    }
+                    break;
+                }
+
+                if (bp != null)
+                {
+                    double bestActivationUT = double.NaN;
+                    bool sawSamePidContinuation = false;
+                    for (int c = 0; c < bp.ChildRecordingIds.Count; c++)
+                    {
+                        string childId = bp.ChildRecordingIds[c];
+                        for (int j = 0; j < committed.Count; j++)
+                        {
+                            var candidate = committed[j];
+                            if (candidate.RecordingId != childId
+                                || candidate.VesselPersistentId != currentRec.VesselPersistentId)
+                            {
+                                continue;
+                            }
+
+                            sawSamePidContinuation = true;
+
+                            if (isGhostActive != null && isGhostActive(j))
+                                return false;
+
+                            if (candidate.TryGetGhostActivationStartUT(out double candidateActivationUT))
+                                bestActivationUT = MinPendingActivationUT(bestActivationUT, candidateActivationUT);
+
+                            if (TryGetPendingWatchActivationUT(
+                                    candidate, committed, trees, isGhostActive, out double deeperActivationUT, depth + 1))
+                            {
+                                bestActivationUT = MinPendingActivationUT(bestActivationUT, deeperActivationUT);
+                            }
+                        }
+                    }
+
+                    if (sawSamePidContinuation && !double.IsNaN(bestActivationUT))
+                    {
+                        activationUT = bestActivationUT;
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        internal static float ComputePendingWatchHoldSeconds(
+            float baseHoldSeconds,
+            double currentUT,
+            double continuationActivationUT,
+            float warpRate)
+        {
+            if (baseHoldSeconds < 0f)
+                baseHoldSeconds = 0f;
+
+            if (double.IsNaN(continuationActivationUT) || continuationActivationUT <= currentUT)
+                return baseHoldSeconds;
+
+            float effectiveWarpRate = warpRate > 0.01f ? warpRate : 1f;
+            float requiredSeconds = Mathf.Ceil((float)((continuationActivationUT - currentUT) / effectiveWarpRate) + 2f);
+            return Mathf.Clamp(Mathf.Max(baseHoldSeconds, requiredSeconds), baseHoldSeconds, 45f);
+        }
+
+        private static double MinPendingActivationUT(double currentBest, double candidate)
+        {
+            if (double.IsNaN(candidate))
+                return currentBest;
+            if (double.IsNaN(currentBest))
+                return candidate;
+            return Math.Min(currentBest, candidate);
+        }
+
         #endregion
 
         #region Auto Loop Range

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -3320,7 +3320,9 @@ namespace Parsek
                 }
             }
 
-            // Case 2: Tree branching via ChildBranchPointId, same-PID continuation only.
+            // Case 2: Tree branching via ChildBranchPointId. Mirror FindNextWatchTarget:
+            // prefer same-PID continuation, otherwise allow non-debris fallback on
+            // non-breakup branches.
             if (!string.IsNullOrEmpty(currentRec.ChildBranchPointId)
                 && currentRec.IsTreeRecording
                 && trees != null)
@@ -3345,39 +3347,68 @@ namespace Parsek
 
                 if (bp != null)
                 {
-                    double bestActivationUT = double.NaN;
+                    double samePidActivationUT = double.NaN;
+                    double fallbackActivationUT = double.NaN;
                     bool sawSamePidContinuation = false;
+                    bool sawActiveFallback = false;
+                    bool allowDifferentPidFallback = bp.Type != BranchPointType.Breakup;
                     for (int c = 0; c < bp.ChildRecordingIds.Count; c++)
                     {
                         string childId = bp.ChildRecordingIds[c];
                         for (int j = 0; j < committed.Count; j++)
                         {
                             var candidate = committed[j];
-                            if (candidate.RecordingId != childId
-                                || candidate.VesselPersistentId != currentRec.VesselPersistentId)
+                            if (candidate.RecordingId != childId)
                             {
                                 continue;
                             }
 
-                            sawSamePidContinuation = true;
+                            bool isPidMatch = candidate.VesselPersistentId == currentRec.VesselPersistentId;
+                            bool isAllowedFallback = allowDifferentPidFallback && !candidate.IsDebris;
+                            if (!isPidMatch && !isAllowedFallback)
+                                continue;
+
+                            if (isPidMatch)
+                            {
+                                sawSamePidContinuation = true;
+
+                                if (isGhostActive != null && isGhostActive(j))
+                                    return false;
+
+                                if (candidate.TryGetGhostActivationStartUT(out double candidateActivationUT))
+                                    samePidActivationUT = MinPendingActivationUT(samePidActivationUT, candidateActivationUT);
+
+                                if (TryGetPendingWatchActivationUT(
+                                        candidate, committed, trees, isGhostActive, out double deeperActivationUT, depth + 1))
+                                {
+                                    samePidActivationUT = MinPendingActivationUT(samePidActivationUT, deeperActivationUT);
+                                }
+                                continue;
+                            }
 
                             if (isGhostActive != null && isGhostActive(j))
-                                return false;
-
-                            if (candidate.TryGetGhostActivationStartUT(out double candidateActivationUT))
-                                bestActivationUT = MinPendingActivationUT(bestActivationUT, candidateActivationUT);
-
-                            if (TryGetPendingWatchActivationUT(
-                                    candidate, committed, trees, isGhostActive, out double deeperActivationUT, depth + 1))
                             {
-                                bestActivationUT = MinPendingActivationUT(bestActivationUT, deeperActivationUT);
+                                sawActiveFallback = true;
+                                continue;
                             }
+
+                            if (candidate.TryGetGhostActivationStartUT(out double candidateActivationFallbackUT))
+                                fallbackActivationUT = MinPendingActivationUT(fallbackActivationUT, candidateActivationFallbackUT);
                         }
                     }
 
-                    if (sawSamePidContinuation && !double.IsNaN(bestActivationUT))
+                    if (sawSamePidContinuation && !double.IsNaN(samePidActivationUT))
                     {
-                        activationUT = bestActivationUT;
+                        activationUT = samePidActivationUT;
+                        return true;
+                    }
+                    if (sawSamePidContinuation)
+                        return false;
+                    if (sawActiveFallback)
+                        return false;
+                    if (!double.IsNaN(fallbackActivationUT))
+                    {
+                        activationUT = fallbackActivationUT;
                         return true;
                     }
                 }

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -3438,6 +3438,33 @@ namespace Parsek
             return Mathf.Clamp(Mathf.Max(baseHoldSeconds, requiredSeconds), baseHoldSeconds, MaxPendingWatchHoldSeconds);
         }
 
+        internal static void ComputePendingWatchHoldWindow(
+            float baseHoldSeconds,
+            float currentRealtime,
+            double currentUT,
+            double continuationActivationUT,
+            float warpRate,
+            out float holdUntilRealTime,
+            out float holdMaxRealTime)
+        {
+            float holdSeconds = ComputePendingWatchHoldSeconds(
+                baseHoldSeconds,
+                currentUT,
+                continuationActivationUT,
+                warpRate);
+
+            holdUntilRealTime = currentRealtime + holdSeconds;
+            if (!double.IsNaN(continuationActivationUT) && continuationActivationUT > currentUT)
+            {
+                holdMaxRealTime = currentRealtime + MaxPendingWatchHoldSeconds;
+                holdUntilRealTime = Mathf.Min(holdUntilRealTime, holdMaxRealTime);
+            }
+            else
+            {
+                holdMaxRealTime = holdUntilRealTime;
+            }
+        }
+
         private static double MinPendingActivationUT(double currentBest, double candidate)
         {
             if (double.IsNaN(candidate))

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -7550,8 +7550,8 @@ namespace Parsek
             StartCoroutine(DeferredActivateVessel(vesselPid));
 
         /// <summary>Called by policy to start the watch-mode hold timer at recording end.</summary>
-        internal void StartWatchHoldFromPolicy(float holdUntilRealTime) =>
-            watchMode.StartWatchHold(holdUntilRealTime);
+        internal void StartWatchHoldFromPolicy(float holdUntilRealTime, double pendingActivationUT = double.NaN) =>
+            watchMode.StartWatchHold(holdUntilRealTime, pendingActivationUT);
 
         private static float GetCurrentWarpRateSafe()
         {

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -7550,8 +7550,11 @@ namespace Parsek
             StartCoroutine(DeferredActivateVessel(vesselPid));
 
         /// <summary>Called by policy to start the watch-mode hold timer at recording end.</summary>
-        internal void StartWatchHoldFromPolicy(float holdUntilRealTime, double pendingActivationUT = double.NaN) =>
-            watchMode.StartWatchHold(holdUntilRealTime, pendingActivationUT);
+        internal void StartWatchHoldFromPolicy(
+            float holdUntilRealTime,
+            double pendingActivationUT = double.NaN,
+            float holdMaxRealTime = -1f) =>
+            watchMode.StartWatchHold(holdUntilRealTime, pendingActivationUT, holdMaxRealTime);
 
         private static float GetCurrentWarpRateSafe()
         {

--- a/Source/Parsek/ParsekPlaybackPolicy.cs
+++ b/Source/Parsek/ParsekPlaybackPolicy.cs
@@ -339,31 +339,33 @@ namespace Parsek
                     }
 
                     // No continuation found — hold ghost for camera (3-5 real seconds).
-                    // Uses real time (Time.time), not UT, so the hold duration is warp-independent.
+                    // Pending-activation holds also gate expiry on game UT inside WatchModeController
+                    // so warp-rate changes do not expire the hold before the continuation can spawn.
                     float holdSeconds = evt.Trajectory?.TerminalStateValue == TerminalState.Destroyed
                         ? 5f : 3f;
                     string holdDetail = null;
+                    double pendingContinuationUT = double.NaN;
                     if (evt.Index >= 0 && evt.Index < committed.Count
                         && GhostPlaybackLogic.TryGetPendingWatchActivationUT(
                             committed[evt.Index],
                             committed,
                             RecordingStore.CommittedTrees,
                             engine.HasActiveGhost,
-                            out double continuationActivationUT))
+                            out pendingContinuationUT))
                     {
                         float extendedHold = GhostPlaybackLogic.ComputePendingWatchHoldSeconds(
-                            holdSeconds, evt.CurrentUT, continuationActivationUT, TimeWarp.CurrentRate);
+                            holdSeconds, evt.CurrentUT, pendingContinuationUT, TimeWarp.CurrentRate);
                         if (extendedHold > holdSeconds)
                         {
                             holdSeconds = extendedHold;
                             holdDetail = string.Format(
                                 CultureInfo.InvariantCulture,
                                 " pendingContinuationUT={0:F1} currentUT={1:F1}",
-                                continuationActivationUT,
+                                pendingContinuationUT,
                                 evt.CurrentUT);
                         }
                     }
-                    host.StartWatchHoldFromPolicy(Time.time + holdSeconds);
+                    host.StartWatchHoldFromPolicy(Time.time + holdSeconds, pendingContinuationUT);
 
                     // Trigger explosion if terminal was Destroyed
                     engine.TriggerExplosionIfDestroyed(evt.State, evt.Trajectory, evt.Index,

--- a/Source/Parsek/ParsekPlaybackPolicy.cs
+++ b/Source/Parsek/ParsekPlaybackPolicy.cs
@@ -343,6 +343,9 @@ namespace Parsek
                     // so warp-rate changes do not expire the hold before the continuation can spawn.
                     float holdSeconds = evt.Trajectory?.TerminalStateValue == TerminalState.Destroyed
                         ? 5f : 3f;
+                    float holdStartedRealTime = Time.time;
+                    float holdUntilRealTime = holdStartedRealTime + holdSeconds;
+                    float holdMaxRealTime = holdUntilRealTime;
                     string holdDetail = null;
                     double pendingContinuationUT = double.NaN;
                     if (evt.Index >= 0 && evt.Index < committed.Count
@@ -353,8 +356,15 @@ namespace Parsek
                             engine.HasActiveGhost,
                             out pendingContinuationUT))
                     {
-                        float extendedHold = GhostPlaybackLogic.ComputePendingWatchHoldSeconds(
-                            holdSeconds, evt.CurrentUT, pendingContinuationUT, TimeWarp.CurrentRate);
+                        GhostPlaybackLogic.ComputePendingWatchHoldWindow(
+                            holdSeconds,
+                            holdStartedRealTime,
+                            evt.CurrentUT,
+                            pendingContinuationUT,
+                            TimeWarp.CurrentRate,
+                            out holdUntilRealTime,
+                            out holdMaxRealTime);
+                        float extendedHold = holdUntilRealTime - holdStartedRealTime;
                         if (extendedHold > holdSeconds)
                         {
                             holdSeconds = extendedHold;
@@ -365,7 +375,7 @@ namespace Parsek
                                 evt.CurrentUT);
                         }
                     }
-                    host.StartWatchHoldFromPolicy(Time.time + holdSeconds, pendingContinuationUT);
+                    host.StartWatchHoldFromPolicy(holdUntilRealTime, pendingContinuationUT, holdMaxRealTime);
 
                     // Trigger explosion if terminal was Destroyed
                     engine.TriggerExplosionIfDestroyed(evt.State, evt.Trajectory, evt.Index,

--- a/Source/Parsek/ParsekPlaybackPolicy.cs
+++ b/Source/Parsek/ParsekPlaybackPolicy.cs
@@ -342,6 +342,27 @@ namespace Parsek
                     // Uses real time (Time.time), not UT, so the hold duration is warp-independent.
                     float holdSeconds = evt.Trajectory?.TerminalStateValue == TerminalState.Destroyed
                         ? 5f : 3f;
+                    string holdDetail = null;
+                    if (evt.Index >= 0 && evt.Index < committed.Count
+                        && GhostPlaybackLogic.TryGetPendingWatchActivationUT(
+                            committed[evt.Index],
+                            committed,
+                            RecordingStore.CommittedTrees,
+                            engine.HasActiveGhost,
+                            out double continuationActivationUT))
+                    {
+                        float extendedHold = GhostPlaybackLogic.ComputePendingWatchHoldSeconds(
+                            holdSeconds, evt.CurrentUT, continuationActivationUT, TimeWarp.CurrentRate);
+                        if (extendedHold > holdSeconds)
+                        {
+                            holdSeconds = extendedHold;
+                            holdDetail = string.Format(
+                                CultureInfo.InvariantCulture,
+                                " pendingContinuationUT={0:F1} currentUT={1:F1}",
+                                continuationActivationUT,
+                                evt.CurrentUT);
+                        }
+                    }
                     host.StartWatchHoldFromPolicy(Time.time + holdSeconds);
 
                     // Trigger explosion if terminal was Destroyed
@@ -350,7 +371,8 @@ namespace Parsek
 
                     ParsekLog.Info("Policy",
                         $"Watch hold started for #{evt.Index}: {holdSeconds:F0}s " +
-                        $"terminal={evt.Trajectory?.TerminalStateValue}");
+                        $"terminal={evt.Trajectory?.TerminalStateValue}" +
+                        (holdDetail ?? string.Empty));
                     // Ghost stays alive — ParsekFlight's watch hold timer will destroy it
                     return;
                 }

--- a/Source/Parsek/Recording.cs
+++ b/Source/Parsek/Recording.cs
@@ -255,6 +255,21 @@ namespace Parsek
             }
         }
 
+        internal bool TryGetGhostActivationStartUT(out double startUT)
+        {
+            if (TryGetActualTrajectoryBounds(out startUT, out _))
+                return true;
+
+            if (!double.IsNaN(ExplicitStartUT))
+            {
+                startUT = ExplicitStartUT;
+                return true;
+            }
+
+            startUT = 0.0;
+            return false;
+        }
+
         private bool TryGetActualTrajectoryBounds(out double startUT, out double endUT)
         {
             startUT = 0.0;

--- a/Source/Parsek/WatchModeController.cs
+++ b/Source/Parsek/WatchModeController.cs
@@ -25,6 +25,7 @@ namespace Parsek
             ControlTypes.CAMERAMODES;
         internal static Func<float> RealtimeNow = GetRealtimeSafe;
         internal static Func<double> CurrentUTNow = GetCurrentUTSafe;
+        internal static Func<float> CurrentWarpRateNow = GetCurrentWarpRateSafe;
 
         // Camera follow state — transient, never serialized
         private int watchedRecordingIndex = -1;       // -1 = not watching
@@ -38,6 +39,7 @@ namespace Parsek
         private float savedCameraPitch;
         private float savedCameraHeading;
         private float watchEndHoldUntilRealTime = -1;  // non-looped end hold timer
+        private float watchEndHoldMaxRealTime = -1;
         private double watchEndHoldPendingActivationUT = double.NaN;
         private int lineageProtectionRecordingIndex = -1; // post-watch debris visibility root
         private string lineageProtectionRecordingId;
@@ -196,6 +198,22 @@ namespace Parsek
             catch (MethodAccessException)
             {
                 return double.NaN;
+            }
+        }
+
+        private static float GetCurrentWarpRateSafe()
+        {
+            try
+            {
+                return TimeWarp.CurrentRate;
+            }
+            catch (System.Security.SecurityException)
+            {
+                return 1f;
+            }
+            catch (MethodAccessException)
+            {
+                return 1f;
             }
         }
 
@@ -634,6 +652,7 @@ namespace Parsek
 
             // Clear hold timer and safety counter
             watchEndHoldUntilRealTime = -1;
+            watchEndHoldMaxRealTime = -1;
             watchEndHoldPendingActivationUT = double.NaN;
             watchNoTargetFrames = 0;
             lastLoggedWatchTargetMismatch = null;
@@ -726,6 +745,7 @@ namespace Parsek
             savedCameraPitch = 0f;
             savedCameraHeading = 0f;
             watchEndHoldUntilRealTime = -1;
+            watchEndHoldMaxRealTime = -1;
             watchEndHoldPendingActivationUT = double.NaN;
             watchNoTargetFrames = 0;
             currentCameraMode = WatchCameraMode.Free;
@@ -1195,6 +1215,7 @@ namespace Parsek
                 $"InputLockManager control lock \"{WatchModeLockId}\" re-set after transfer");
 
             watchEndHoldUntilRealTime = -1;
+            watchEndHoldMaxRealTime = -1;
             watchEndHoldPendingActivationUT = double.NaN;
 
             // Reset watch start time so the zone-exemption logging starts fresh
@@ -1349,10 +1370,24 @@ namespace Parsek
             {
                 double currentUT = CurrentUTNow();
                 if (!double.IsNaN(currentUT) && currentUT + 0.001 < watchEndHoldPendingActivationUT)
+                {
+                    float recomputedHoldSeconds = GhostPlaybackLogic.ComputePendingWatchHoldSeconds(
+                        0f,
+                        currentUT,
+                        watchEndHoldPendingActivationUT,
+                        CurrentWarpRateNow());
+                    float recomputedHoldUntil = RealtimeNow() + recomputedHoldSeconds;
+                    if (watchEndHoldMaxRealTime > 0f)
+                        recomputedHoldUntil = Mathf.Min(recomputedHoldUntil, watchEndHoldMaxRealTime);
+                    if (watchEndHoldUntilRealTime < recomputedHoldUntil)
+                        watchEndHoldUntilRealTime = recomputedHoldUntil;
                     return true;
+                }
 
                 watchEndHoldPendingActivationUT = double.NaN;
-                float postActivationGraceUntil = RealtimeNow() + 2f;
+                float postActivationGraceUntil = RealtimeNow() + GhostPlaybackLogic.PendingWatchPostActivationGraceSeconds;
+                if (watchEndHoldMaxRealTime > 0f)
+                    postActivationGraceUntil = Mathf.Min(postActivationGraceUntil, watchEndHoldMaxRealTime);
                 if (watchEndHoldUntilRealTime < postActivationGraceUntil)
                     watchEndHoldUntilRealTime = postActivationGraceUntil;
             }
@@ -1718,6 +1753,9 @@ namespace Parsek
         internal void StartWatchHold(float holdUntilRealTime, double pendingActivationUT = double.NaN)
         {
             watchEndHoldUntilRealTime = holdUntilRealTime;
+            watchEndHoldMaxRealTime = double.IsNaN(pendingActivationUT)
+                ? holdUntilRealTime
+                : RealtimeNow() + GhostPlaybackLogic.MaxPendingWatchHoldSeconds;
             watchEndHoldPendingActivationUT = pendingActivationUT;
             ParsekLog.Info("CameraFollow",
                 $"Watch hold timer set: holdUntilRealTime={holdUntilRealTime:F1}" +

--- a/Source/Parsek/WatchModeController.cs
+++ b/Source/Parsek/WatchModeController.cs
@@ -1750,14 +1750,13 @@ namespace Parsek
         /// <summary>
         /// Sets the watch hold timer. Called by policy when playback ends for a watched recording.
         /// </summary>
-        internal void StartWatchHold(float holdUntilRealTime, double pendingActivationUT = double.NaN)
+        internal void StartWatchHold(
+            float holdUntilRealTime,
+            double pendingActivationUT = double.NaN,
+            float holdMaxRealTime = -1f)
         {
             watchEndHoldUntilRealTime = holdUntilRealTime;
-            watchEndHoldMaxRealTime = double.IsNaN(pendingActivationUT)
-                ? holdUntilRealTime
-                : RealtimeNow() + GhostPlaybackLogic.MaxPendingWatchHoldSeconds;
-            if (watchEndHoldMaxRealTime > 0f && watchEndHoldUntilRealTime > watchEndHoldMaxRealTime)
-                watchEndHoldUntilRealTime = watchEndHoldMaxRealTime;
+            watchEndHoldMaxRealTime = holdMaxRealTime > 0f ? holdMaxRealTime : holdUntilRealTime;
             watchEndHoldPendingActivationUT = pendingActivationUT;
             ParsekLog.Info("CameraFollow",
                 $"Watch hold timer set: holdUntilRealTime={holdUntilRealTime:F1}" +

--- a/Source/Parsek/WatchModeController.cs
+++ b/Source/Parsek/WatchModeController.cs
@@ -1756,6 +1756,8 @@ namespace Parsek
             watchEndHoldMaxRealTime = double.IsNaN(pendingActivationUT)
                 ? holdUntilRealTime
                 : RealtimeNow() + GhostPlaybackLogic.MaxPendingWatchHoldSeconds;
+            if (watchEndHoldMaxRealTime > 0f && watchEndHoldUntilRealTime > watchEndHoldMaxRealTime)
+                watchEndHoldUntilRealTime = watchEndHoldMaxRealTime;
             watchEndHoldPendingActivationUT = pendingActivationUT;
             ParsekLog.Info("CameraFollow",
                 $"Watch hold timer set: holdUntilRealTime={holdUntilRealTime:F1}" +

--- a/Source/Parsek/WatchModeController.cs
+++ b/Source/Parsek/WatchModeController.cs
@@ -24,6 +24,7 @@ namespace Parsek
             ControlTypes.VESSEL_SWITCHING | ControlTypes.EVA_INPUT |
             ControlTypes.CAMERAMODES;
         internal static Func<float> RealtimeNow = GetRealtimeSafe;
+        internal static Func<double> CurrentUTNow = GetCurrentUTSafe;
 
         // Camera follow state — transient, never serialized
         private int watchedRecordingIndex = -1;       // -1 = not watching
@@ -36,7 +37,8 @@ namespace Parsek
         private float savedCameraDistance;
         private float savedCameraPitch;
         private float savedCameraHeading;
-        private float watchEndHoldUntilRealTime = -1;  // non-looped end hold timer (real time, warp-independent)
+        private float watchEndHoldUntilRealTime = -1;  // non-looped end hold timer
+        private double watchEndHoldPendingActivationUT = double.NaN;
         private int lineageProtectionRecordingIndex = -1; // post-watch debris visibility root
         private string lineageProtectionRecordingId;
         private double lineageProtectionUntilUT = double.NaN;
@@ -178,6 +180,22 @@ namespace Parsek
             catch (MethodAccessException)
             {
                 return 0f;
+            }
+        }
+
+        private static double GetCurrentUTSafe()
+        {
+            try
+            {
+                return Planetarium.GetUniversalTime();
+            }
+            catch (System.Security.SecurityException)
+            {
+                return double.NaN;
+            }
+            catch (MethodAccessException)
+            {
+                return double.NaN;
             }
         }
 
@@ -616,6 +634,7 @@ namespace Parsek
 
             // Clear hold timer and safety counter
             watchEndHoldUntilRealTime = -1;
+            watchEndHoldPendingActivationUT = double.NaN;
             watchNoTargetFrames = 0;
             lastLoggedWatchTargetMismatch = null;
             lastLoggedWatchFocusKey = null;
@@ -707,6 +726,7 @@ namespace Parsek
             savedCameraPitch = 0f;
             savedCameraHeading = 0f;
             watchEndHoldUntilRealTime = -1;
+            watchEndHoldPendingActivationUT = double.NaN;
             watchNoTargetFrames = 0;
             currentCameraMode = WatchCameraMode.Free;
             userModeOverride = false;
@@ -1175,6 +1195,7 @@ namespace Parsek
                 $"InputLockManager control lock \"{WatchModeLockId}\" re-set after transfer");
 
             watchEndHoldUntilRealTime = -1;
+            watchEndHoldPendingActivationUT = double.NaN;
 
             // Reset watch start time so the zone-exemption logging starts fresh
             // for the new segment (no stale elapsed time from the previous segment)
@@ -1295,7 +1316,7 @@ namespace Parsek
         /// </summary>
         private bool ProcessWatchEndHoldTimer()
         {
-            if (watchEndHoldUntilRealTime <= 0)
+            if (watchEndHoldUntilRealTime <= 0 && double.IsNaN(watchEndHoldPendingActivationUT))
                 return false;
 
             int idx = watchedRecordingIndex;
@@ -1322,6 +1343,18 @@ namespace Parsek
                     TransferWatchToNextSegment(nextTarget);
                     return true;
                 }
+            }
+
+            if (!double.IsNaN(watchEndHoldPendingActivationUT))
+            {
+                double currentUT = CurrentUTNow();
+                if (!double.IsNaN(currentUT) && currentUT + 0.001 < watchEndHoldPendingActivationUT)
+                    return true;
+
+                watchEndHoldPendingActivationUT = double.NaN;
+                float postActivationGraceUntil = RealtimeNow() + 2f;
+                if (watchEndHoldUntilRealTime < postActivationGraceUntil)
+                    watchEndHoldUntilRealTime = postActivationGraceUntil;
             }
 
             // Hold expired -- no continuation found, destroy and exit
@@ -1682,11 +1715,16 @@ namespace Parsek
         /// <summary>
         /// Sets the watch hold timer. Called by policy when playback ends for a watched recording.
         /// </summary>
-        internal void StartWatchHold(float holdUntilRealTime)
+        internal void StartWatchHold(float holdUntilRealTime, double pendingActivationUT = double.NaN)
         {
             watchEndHoldUntilRealTime = holdUntilRealTime;
+            watchEndHoldPendingActivationUT = pendingActivationUT;
             ParsekLog.Info("CameraFollow",
-                $"Watch hold timer set: holdUntilRealTime={holdUntilRealTime:F1} (watched #{watchedRecordingIndex})");
+                $"Watch hold timer set: holdUntilRealTime={holdUntilRealTime:F1}" +
+                (double.IsNaN(pendingActivationUT)
+                    ? string.Empty
+                    : $" pendingActivationUT={pendingActivationUT:F1}") +
+                $" (watched #{watchedRecordingIndex})");
         }
     }
 }


### PR DESCRIPTION
Problem: repeated F5/F9 in a branched recording can leave child sidecars starting later than the branch boundary, so watch hold expires before the continuation ghost spawns. Fix: derive pending continuation activation from actual sidecar payload bounds and extend the watch hold when a same-PID continuation exists but is not active yet. Tests: dotnet test Source\\Parsek.Tests\\Parsek.Tests.csproj.