### PR TITLE
Fix repeated crew end-state population for no-crew recordings

### DIFF
--- a/Source/Parsek.Tests/KerbalEndStateTests.cs
+++ b/Source/Parsek.Tests/KerbalEndStateTests.cs
@@ -171,7 +171,7 @@ namespace Parsek.Tests
         /// Guards: crewless vessels (probes) don't get spurious end states.
         /// </summary>
         [Fact]
-        public void PopulateCrewEndStates_NoCrew_StaysNull()
+        public void PopulateCrewEndStates_NoCrew_LeavesNullButMarksResolved()
         {
             var rec = new Recording
             {
@@ -185,6 +185,7 @@ namespace Parsek.Tests
             KerbalsModule.PopulateCrewEndStates(rec);
 
             Assert.Null(rec.CrewEndStates);
+            Assert.True(rec.CrewEndStatesResolved);
             Assert.Contains(logLines, l => l.Contains("[KerbalsModule]") && l.Contains("has no crew"));
         }
 
@@ -302,6 +303,7 @@ namespace Parsek.Tests
             RecordingStore.DeserializeCrewEndStates(parentNode, rec);
 
             Assert.Null(rec.CrewEndStates);
+            Assert.False(rec.CrewEndStatesResolved);
         }
 
         /// <summary>
@@ -317,6 +319,26 @@ namespace Parsek.Tests
             RecordingStore.SerializeCrewEndStates(parentNode, rec);
 
             Assert.Null(parentNode.GetNode("CREW_END_STATES"));
+        }
+
+        [Fact]
+        public void RecordingTree_SaveLoad_PreservesResolvedNoCrewState()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "resolved-001",
+                VesselName = "Probe",
+                CrewEndStatesResolved = true
+            };
+
+            var node = new ConfigNode("RECORDING");
+            RecordingTree.SaveRecordingInto(node, rec);
+
+            var loaded = new Recording();
+            RecordingTree.LoadRecordingFrom(node, loaded);
+
+            Assert.True(loaded.CrewEndStatesResolved);
+            Assert.Null(loaded.CrewEndStates);
         }
 
         #endregion
@@ -541,6 +563,7 @@ namespace Parsek.Tests
             KerbalsModule.PopulateCrewEndStates(rec);
 
             Assert.Null(rec.CrewEndStates);
+            Assert.True(rec.CrewEndStatesResolved);
             Assert.Contains(logLines, l => l.Contains("no crew in ghost snapshot"));
         }
 

--- a/Source/Parsek.Tests/KerbalEndStateTests.cs
+++ b/Source/Parsek.Tests/KerbalEndStateTests.cs
@@ -189,6 +189,25 @@ namespace Parsek.Tests
             Assert.Contains(logLines, l => l.Contains("[KerbalsModule]") && l.Contains("has no crew"));
         }
 
+        [Fact]
+        public void PopulateCrewEndStates_MissingStartSnapshot_LeavesUnresolved()
+        {
+            var rec = new Recording
+            {
+                VesselName = "DamagedSnapshotShip",
+                RecordingId = "test-002b",
+                TerminalStateValue = TerminalState.Orbiting,
+                GhostVisualSnapshot = null,
+                VesselSnapshot = BuildSnapshotWithCrew("Jeb")
+            };
+
+            KerbalsModule.PopulateCrewEndStates(rec);
+
+            Assert.Null(rec.CrewEndStates);
+            Assert.False(rec.CrewEndStatesResolved);
+            Assert.Contains(logLines, l => l.Contains("[KerbalsModule]") && l.Contains("has no start crew source"));
+        }
+
         /// <summary>
         /// Null recording -> no crash, just logs and skips.
         /// Guards: defensive null handling.

--- a/Source/Parsek.Tests/KerbalsTestHelper.cs
+++ b/Source/Parsek.Tests/KerbalsTestHelper.cs
@@ -30,7 +30,7 @@ namespace Parsek.Tests
             for (int i = 0; i < recordings.Count; i++)
             {
                 var rec = recordings[i];
-                if (rec.CrewEndStates == null && rec.VesselSnapshot != null)
+                if (!rec.CrewEndStatesResolved && rec.CrewEndStates == null && rec.VesselSnapshot != null)
                     KerbalsModule.PopulateCrewEndStates(rec);
 
                 var snapshot = rec.GhostVisualSnapshot ?? rec.VesselSnapshot;

--- a/Source/Parsek/GameActions/LedgerOrchestrator.cs
+++ b/Source/Parsek/GameActions/LedgerOrchestrator.cs
@@ -113,7 +113,9 @@ namespace Parsek
 
             // 3b. Populate crew end states before action creation so KerbalEndStateField is correct
             var recForEndStates = FindRecordingById(recordingId);
-            if (recForEndStates != null && recForEndStates.CrewEndStates == null
+            if (recForEndStates != null
+                && !recForEndStates.CrewEndStatesResolved
+                && recForEndStates.CrewEndStates == null
                 && (recForEndStates.VesselSnapshot != null || !string.IsNullOrEmpty(recForEndStates.EvaCrewName)))
                 KerbalsModule.PopulateCrewEndStates(recForEndStates);
 
@@ -550,7 +552,7 @@ namespace Parsek
                 if (existingIds.Contains(rec.RecordingId)) continue;
 
                 // Populate end states first
-                if (rec.CrewEndStates == null && rec.VesselSnapshot != null)
+                if (!rec.CrewEndStatesResolved && rec.CrewEndStates == null && rec.VesselSnapshot != null)
                     KerbalsModule.PopulateCrewEndStates(rec);
 
                 var kerbalActions = CreateKerbalAssignmentActions(
@@ -581,7 +583,7 @@ namespace Parsek
             for (int i = 0; i < recordings.Count; i++)
             {
                 var rec = recordings[i];
-                if (rec.CrewEndStates == null && rec.VesselSnapshot != null)
+                if (!rec.CrewEndStatesResolved && rec.CrewEndStates == null && rec.VesselSnapshot != null)
                 {
                     KerbalsModule.PopulateCrewEndStates(rec);
                     if (rec.CrewEndStates != null) populated++;

--- a/Source/Parsek/KerbalsModule.cs
+++ b/Source/Parsek/KerbalsModule.cs
@@ -381,9 +381,10 @@ namespace Parsek
 
             if (startingCrew.Count == 0)
             {
+                rec.CrewEndStatesResolved = true;
                 ParsekLog.Verbose(Tag,
                     $"PopulateCrewEndStates: recording='{rec.VesselName}' (id={rec.RecordingId}) " +
-                    "has no crew in ghost snapshot -- skipping");
+                    "has no crew in ghost snapshot -- resolved");
                 return;
             }
 
@@ -421,6 +422,7 @@ namespace Parsek
                 $"PopulateCrewEndStates: recording='{rec.VesselName}' (id={rec.RecordingId}) " +
                 $"crew={startingCrew.Count} aboard={aboardCount} dead={deadCount} " +
                 $"recovered={recoveredCount} unknown={unknownCount}");
+            rec.CrewEndStatesResolved = true;
         }
 
         /// <summary>
@@ -441,7 +443,7 @@ namespace Parsek
             for (int i = 0; i < recordings.Count; i++)
             {
                 var rec = recordings[i];
-                if (rec.CrewEndStates != null)
+                if (rec.CrewEndStatesResolved || rec.CrewEndStates != null)
                 {
                     skipped++;
                     continue;

--- a/Source/Parsek/KerbalsModule.cs
+++ b/Source/Parsek/KerbalsModule.cs
@@ -370,6 +370,8 @@ namespace Parsek
                 return;
             }
 
+            bool hasStartCrewSource = rec.GhostVisualSnapshot != null || !string.IsNullOrEmpty(rec.EvaCrewName);
+
             // Extract starting crew from ghost visual snapshot (recording-start state)
             var startingCrew = CrewReservationManager.ExtractCrewFromSnapshot(rec.GhostVisualSnapshot);
 
@@ -381,6 +383,14 @@ namespace Parsek
 
             if (startingCrew.Count == 0)
             {
+                if (!hasStartCrewSource)
+                {
+                    ParsekLog.Verbose(Tag,
+                        $"PopulateCrewEndStates: recording='{rec.VesselName}' (id={rec.RecordingId}) " +
+                        "has no start crew source -- leaving unresolved");
+                    return;
+                }
+
                 rec.CrewEndStatesResolved = true;
                 ParsekLog.Verbose(Tag,
                     $"PopulateCrewEndStates: recording='{rec.VesselName}' (id={rec.RecordingId}) " +

--- a/Source/Parsek/Recording.cs
+++ b/Source/Parsek/Recording.cs
@@ -149,6 +149,10 @@ namespace Parsek
         // Per-crew end state (inferred at commit time from terminal state + snapshot)
         // null = not yet populated (legacy recording or pre-commit).
         public Dictionary<string, KerbalEndState> CrewEndStates;
+        // True once PopulateCrewEndStates has reached a final answer for this
+        // recording. This remains false for legacy/unprocessed recordings, and
+        // becomes true even when the recording is confirmed to have no crew.
+        public bool CrewEndStatesResolved;
 
         // Resource manifests (Phase 11) — per-resource amount/capacity at recording start and end
         // null = no data (legacy recording or not yet captured)
@@ -461,6 +465,7 @@ namespace Parsek
             StartCrew = source.StartCrew;
             EndCrew = source.EndCrew;
             DockTargetVesselPid = source.DockTargetVesselPid;
+            CrewEndStatesResolved = source.CrewEndStatesResolved;
 
             // Copy segment events and tracks if source has them
             if (source.SegmentEvents != null && source.SegmentEvents.Count > 0)
@@ -523,6 +528,7 @@ namespace Parsek
             clone.CrewEndStates = source.CrewEndStates != null
                 ? new Dictionary<string, KerbalEndState>(source.CrewEndStates)
                 : null;
+            clone.CrewEndStatesResolved = source.CrewEndStatesResolved;
             clone.StartResources = source.StartResources != null
                 ? new Dictionary<string, ResourceAmount>(source.StartResources)
                 : null;

--- a/Source/Parsek/RecordingTree.cs
+++ b/Source/Parsek/RecordingTree.cs
@@ -376,6 +376,8 @@ namespace Parsek
                 recNode.AddValue("generation", rec.Generation.ToString(ic));
 
             // Crew end states (kerbals module)
+            if (rec.CrewEndStatesResolved)
+                recNode.AddValue("crewEndStatesResolved", rec.CrewEndStatesResolved.ToString());
             RecordingStore.SerializeCrewEndStates(recNode, rec);
 
             // Resource manifests (Phase 11)
@@ -743,7 +745,16 @@ namespace Parsek
             }
 
             // Crew end states (kerbals module)
+            string crewEndStatesResolvedStr = recNode.GetValue("crewEndStatesResolved");
+            if (crewEndStatesResolvedStr != null)
+            {
+                bool crewEndStatesResolved;
+                if (bool.TryParse(crewEndStatesResolvedStr, out crewEndStatesResolved))
+                    rec.CrewEndStatesResolved = crewEndStatesResolved;
+            }
             RecordingStore.DeserializeCrewEndStates(recNode, rec);
+            if (rec.CrewEndStates != null)
+                rec.CrewEndStatesResolved = true;
 
             // Resource manifests (Phase 11)
             RecordingStore.DeserializeResourceManifest(recNode, rec);


### PR DESCRIPTION
## Summary
- add a resolved-state marker for crew end-state population so recordings proven to have no crew stop getting retried
- update KerbalsModule and ledger recalculation paths to skip resolved no-crew recordings while preserving legacy/populated behavior
- persist the resolved state in recording tree serialization and add regression coverage

## Evidence
- `logs/2026-04-13_0250_s12-snapshot-storage-stale-dll-check/KSP.log` contains 96 repeated `PopulateCrewEndStates` no-crew attempts
- four `Kerbal X Debris` recording IDs in that log each repeat 24 times

## Testing
- `dotnet test Source\\Parsek.Tests\\Parsek.Tests.csproj`