### PR TITLE
fix: trigger debris explosion FX at first destroy event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable changes to Parsek are documented here.
 - Zero-throttle breakup debris now emits `EngineShutdown` sentinels instead of looking like a zero-event orphan-engine recording, so replay no longer auto-starts max-throttle booster FX/audio for staged-off debris.
 - The old warp-only orbital exemption no longer punches through the new `50-120 km` hidden-mesh tier. Orbital ghosts still get the legacy exemption only in the true `Beyond` zone.
 - Entering watch mode now uses the tracked playback distance first, avoiding false "in range" decisions from a hidden ghost's stale transform.
+- Destroyed debris playback now triggers whole-vessel explosion FX from the earliest eligible recorded destroy event instead of waiting for `EndUT`, so debris that visibly hits the ground no longer hangs before the final blast in either Flight or KSC playback (`#329`).
 - `#326` EVA branch recordings no longer seed bogus atmospheric start fragments when a landed or splashed kerbal is backgrounded before KSP finishes the vessel switch. The branch path now carries a one-shot surface override through delayed child initialization, and atmospheric-body EVA classification now keeps ground-adjacent or sea-level bobbing kerbals in surface segments instead of producing stray `atmo` optimizer splits.
 - The in-game test runner window now uses a more compact layout without the visible blank rows between tests, and disruptive quickload-resume tests run last in batch execution so they do not interfere with later scenarios.
 

--- a/Source/Parsek.Tests/ExplosionFxTests.cs
+++ b/Source/Parsek.Tests/ExplosionFxTests.cs
@@ -115,6 +115,87 @@ namespace Parsek.Tests
             Assert.False(result);
         }
 
+        [Fact]
+        public void TryGetEarlyDestroyedDebrisExplosionUT_DestroyedDebris_ReturnsFirstDestroyedEvent()
+        {
+            var rec = new Recording
+            {
+                IsDebris = true,
+                TerminalStateValue = TerminalState.Destroyed,
+                ExplicitStartUT = 10.0,
+                ExplicitEndUT = 20.0
+            };
+            rec.PartEvents.Add(new PartEvent
+            {
+                ut = 11.5,
+                eventType = PartEventType.EngineIgnited,
+                partName = "engine"
+            });
+            rec.PartEvents.Add(new PartEvent
+            {
+                ut = 12.5,
+                eventType = PartEventType.Destroyed,
+                partName = "tank"
+            });
+            rec.PartEvents.Add(new PartEvent
+            {
+                ut = 14.0,
+                eventType = PartEventType.Destroyed,
+                partName = "noseCone"
+            });
+
+            bool result = GhostPlaybackLogic.TryGetEarlyDestroyedDebrisExplosionUT(rec, out double explosionUT);
+
+            Assert.True(result);
+            Assert.Equal(12.5, explosionUT, 3);
+        }
+
+        [Fact]
+        public void TryGetEarlyDestroyedDebrisExplosionUT_OnlyEndDestroyedEvent_ReturnsFalse()
+        {
+            var rec = new Recording
+            {
+                IsDebris = true,
+                TerminalStateValue = TerminalState.Destroyed,
+                ExplicitStartUT = 10.0,
+                ExplicitEndUT = 20.0
+            };
+            rec.PartEvents.Add(new PartEvent
+            {
+                ut = 20.0,
+                eventType = PartEventType.Destroyed,
+                partName = "tank"
+            });
+
+            bool result = GhostPlaybackLogic.TryGetEarlyDestroyedDebrisExplosionUT(rec, out double explosionUT);
+
+            Assert.False(result);
+            Assert.True(double.IsNaN(explosionUT));
+        }
+
+        [Fact]
+        public void TryGetEarlyDestroyedDebrisExplosionUT_NonDebris_ReturnsFalse()
+        {
+            var rec = new Recording
+            {
+                IsDebris = false,
+                TerminalStateValue = TerminalState.Destroyed,
+                ExplicitStartUT = 10.0,
+                ExplicitEndUT = 20.0
+            };
+            rec.PartEvents.Add(new PartEvent
+            {
+                ut = 12.5,
+                eventType = PartEventType.Destroyed,
+                partName = "tank"
+            });
+
+            bool result = GhostPlaybackLogic.TryGetEarlyDestroyedDebrisExplosionUT(rec, out double explosionUT);
+
+            Assert.False(result);
+            Assert.True(double.IsNaN(explosionUT));
+        }
+
         // --- Guard evaluation order: already-fired checked before terminal state ---
 
         [Fact]

--- a/Source/Parsek.Tests/ExplosionFxTests.cs
+++ b/Source/Parsek.Tests/ExplosionFxTests.cs
@@ -196,6 +196,41 @@ namespace Parsek.Tests
             Assert.True(double.IsNaN(explosionUT));
         }
 
+        [Fact]
+        public void TryGetEarlyDestroyedDebrisExplosionUT_UnsortedEvents_ReturnsEarliestEligibleDestroyedEvent()
+        {
+            var rec = new Recording
+            {
+                IsDebris = true,
+                TerminalStateValue = TerminalState.Destroyed,
+                ExplicitStartUT = 10.0,
+                ExplicitEndUT = 20.0
+            };
+            rec.PartEvents.Add(new PartEvent
+            {
+                ut = 19.9,
+                eventType = PartEventType.Destroyed,
+                partName = "late"
+            });
+            rec.PartEvents.Add(new PartEvent
+            {
+                ut = 13.0,
+                eventType = PartEventType.Destroyed,
+                partName = "mid"
+            });
+            rec.PartEvents.Add(new PartEvent
+            {
+                ut = 12.0,
+                eventType = PartEventType.Destroyed,
+                partName = "early"
+            });
+
+            bool result = GhostPlaybackLogic.TryGetEarlyDestroyedDebrisExplosionUT(rec, out double explosionUT);
+
+            Assert.True(result);
+            Assert.Equal(12.0, explosionUT, 3);
+        }
+
         // --- Guard evaluation order: already-fired checked before terminal state ---
 
         [Fact]

--- a/Source/Parsek/GhostPlaybackEngine.cs
+++ b/Source/Parsek/GhostPlaybackEngine.cs
@@ -67,6 +67,10 @@ namespace Parsek
         // DestroyAllGhosts (via ParsekFlight cleanup path), so completedEventFired
         // is guaranteed to be empty when playback restarts after a rewind.
         private readonly HashSet<int> completedEventFired = new HashSet<int>();
+        // Destroyed debris can complete before EndUT when the recording captured a clear
+        // destructive part event. Keep those indices suppressed until a rewind/reset so
+        // they do not respawn while the original recording window is still in range.
+        private readonly HashSet<int> earlyDestroyedDebrisCompleted = new HashSet<int>();
 
         #endregion
 
@@ -253,6 +257,12 @@ namespace Parsek
                 bool hasSurfaceData = traj.SurfacePos.HasValue;
                 if (!hasPoints && !hasOrbitData && !hasSurfaceData) continue;
 
+                if (ctx.currentUT < traj.StartUT)
+                {
+                    completedEventFired.Remove(i);
+                    earlyDestroyedDebrisCompleted.Remove(i);
+                }
+
                 bool inRange = ctx.currentUT >= traj.StartUT && ctx.currentUT <= traj.EndUT;
                 bool pastEnd = ctx.currentUT > traj.EndUT;
                 bool pastEffectiveEnd = ctx.currentUT > f.chainEndUT;
@@ -336,7 +346,9 @@ namespace Parsek
                             var syncCtx = ctx;
                             syncCtx.currentUT = parentLoopUT;
                             if (RenderInRangeGhost(i, traj, f, syncCtx, suppressVisualFx,
-                                    hasPoints, hasSurfaceData, hasOrbitData, ref state, ref ghostActive))
+                                    hasPoints, hasSurfaceData, hasOrbitData,
+                                    allowEarlyDestroyedDebrisCompletion: false,
+                                    ref state, ref ghostActive))
                             {
                                 if (state != null)
                                     state.loopCycleIndex = parentCycle;
@@ -363,12 +375,16 @@ namespace Parsek
                 if (inRange)
                 {
                     if (RenderInRangeGhost(i, traj, f, ctx, suppressVisualFx,
-                            hasPoints, hasSurfaceData, hasOrbitData, ref state, ref ghostActive))
+                            hasPoints, hasSurfaceData, hasOrbitData,
+                            allowEarlyDestroyedDebrisCompletion: true,
+                            ref state, ref ghostActive))
                         continue;
                 }
 
                 // === Past end: fire completed event, optionally destroy ===
-                if ((pastEnd || pastEffectiveEnd) && !completedEventFired.Contains(i))
+                if ((pastEnd || pastEffectiveEnd)
+                    && !completedEventFired.Contains(i)
+                    && !earlyDestroyedDebrisCompleted.Contains(i))
                     HandlePastEndGhost(i, traj, f, ctx, state, ghostActive, hasPoints);
 
                 // === Stale past-end ghost cleanup ===
@@ -429,8 +445,12 @@ namespace Parsek
         private bool RenderInRangeGhost(int i, IPlaybackTrajectory traj, TrajectoryPlaybackFlags f,
             FrameContext ctx, bool suppressVisualFx,
             bool hasPoints, bool hasSurfaceData, bool hasOrbitData,
+            bool allowEarlyDestroyedDebrisCompletion,
             ref GhostPlaybackState state, ref bool ghostActive)
         {
+            if (allowEarlyDestroyedDebrisCompletion && earlyDestroyedDebrisCompleted.Contains(i))
+                return true;
+
             if (state == null)
             {
                 SpawnGhost(i, traj);
@@ -515,6 +535,50 @@ namespace Parsek
             ApplyFrameVisuals(i, traj, state, ctx.currentUT, ctx.warpRate,
                 zoneResult.skipPartEvents, suppressVisualFx || zoneResult.suppressVisualFx);
 
+            if (allowEarlyDestroyedDebrisCompletion
+                && TryHandleEarlyDestroyedDebrisCompletion(
+                    i, traj, f, ctx, state, ghostActive, hasPoints))
+            {
+                return true;
+            }
+
+            return true;
+        }
+
+        private bool TryHandleEarlyDestroyedDebrisCompletion(
+            int index, IPlaybackTrajectory traj, TrajectoryPlaybackFlags flags,
+            FrameContext ctx, GhostPlaybackState state, bool ghostActive, bool hasPoints)
+        {
+            if (completedEventFired.Contains(index))
+                return true;
+
+            if (!GhostPlaybackLogic.TryGetEarlyDestroyedDebrisExplosionUT(traj, out double explosionUT))
+                return false;
+
+            if (ctx.currentUT + 1e-6 < explosionUT)
+                return false;
+
+            completedEventFired.Add(index);
+            earlyDestroyedDebrisCompleted.Add(index);
+
+            if (ghostActive)
+                TriggerExplosionIfDestroyed(state, traj, index, ctx.warpRate);
+
+            deferredCompletedEvents.Add(new PlaybackCompletedEvent
+            {
+                Index = index,
+                Trajectory = traj,
+                State = state,
+                Flags = flags,
+                GhostWasActive = ghostActive,
+                PastEffectiveEnd = ctx.currentUT > flags.chainEndUT,
+                LastPoint = hasPoints ? traj.Points[traj.Points.Count - 1] : default,
+                CurrentUT = ctx.currentUT
+            });
+
+            ParsekLog.Info("Engine",
+                $"Early debris completion: ghost #{index} \"{traj.VesselName}\" " +
+                $"explosionUT={explosionUT:F2} currentUT={ctx.currentUT:F2} endUT={traj.EndUT:F2}");
             return true;
         }
 
@@ -2244,6 +2308,7 @@ namespace Parsek
             loggedGhostEnter.Clear();
             loggedReshow.Clear();
             completedEventFired.Clear();
+            earlyDestroyedDebrisCompleted.Clear();
 
             CleanupActiveExplosions();
         }
@@ -2260,6 +2325,7 @@ namespace Parsek
             ReindexSet(loggedGhostEnter, removedIndex);
             ReindexSet(loggedReshow, removedIndex);
             ReindexSet(completedEventFired, removedIndex);
+            ReindexSet(earlyDestroyedDebrisCompleted, removedIndex);
         }
 
         private static void ReindexDict<T>(Dictionary<int, T> dict, int removedIndex)

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -19,6 +19,7 @@ namespace Parsek
         internal const double DefaultLoopIntervalSeconds = 10.0;
         internal const double MinLoopDurationSeconds = 1.0;
         internal const double MinCycleDuration = 1.0;
+        internal const double MinEarlyDebrisExplosionLeadSeconds = 0.25;
         // Grace period before zone-based watch mode exit (wall-clock seconds).
         // Prevents immediate exit when a ghost briefly crosses a zone boundary at watch-mode start.
         internal const float WatchModeZoneGraceSeconds = 2.0f;
@@ -849,6 +850,38 @@ namespace Parsek
                 return false;
             }
             return true;
+        }
+
+        internal static bool TryGetEarlyDestroyedDebrisExplosionUT(
+            IPlaybackTrajectory traj, out double explosionUT)
+        {
+            explosionUT = double.NaN;
+
+            if (traj == null || !traj.IsDebris || traj.TerminalStateValue != TerminalState.Destroyed)
+                return false;
+
+            if (traj.PartEvents == null || traj.PartEvents.Count == 0)
+                return false;
+
+            double latestEligibleUT = traj.EndUT - MinEarlyDebrisExplosionLeadSeconds;
+            if (latestEligibleUT <= traj.StartUT)
+                return false;
+
+            for (int i = 0; i < traj.PartEvents.Count; i++)
+            {
+                var evt = traj.PartEvents[i];
+                if (evt.eventType != PartEventType.Destroyed)
+                    continue;
+                if (evt.ut < traj.StartUT)
+                    continue;
+                if (evt.ut > latestEligibleUT)
+                    break;
+
+                explosionUT = evt.ut;
+                return true;
+            }
+
+            return false;
         }
 
         internal static void HideAllGhostParts(GhostPlaybackState state)

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -867,6 +867,7 @@ namespace Parsek
             if (latestEligibleUT <= traj.StartUT)
                 return false;
 
+            double earliestEligibleUT = double.NaN;
             for (int i = 0; i < traj.PartEvents.Count; i++)
             {
                 var evt = traj.PartEvents[i];
@@ -875,13 +876,17 @@ namespace Parsek
                 if (evt.ut < traj.StartUT)
                     continue;
                 if (evt.ut > latestEligibleUT)
-                    break;
+                    continue;
 
-                explosionUT = evt.ut;
-                return true;
+                if (double.IsNaN(earliestEligibleUT) || evt.ut < earliestEligibleUT)
+                    earliestEligibleUT = evt.ut;
             }
 
-            return false;
+            if (double.IsNaN(earliestEligibleUT))
+                return false;
+
+            explosionUT = earliestEligibleUT;
+            return true;
         }
 
         internal static void HideAllGhostParts(GhostPlaybackState state)

--- a/Source/Parsek/ParsekKSC.cs
+++ b/Source/Parsek/ParsekKSC.cs
@@ -267,7 +267,14 @@ namespace Parsek
                 else
                     GhostPlaybackLogic.RestoreAllRcsEmissions(state);
 
-                if (!state.explosionFired && targetUT >= rec.EndUT)
+                bool shouldTriggerExplosion = targetUT >= rec.EndUT;
+                if (!shouldTriggerExplosion
+                    && GhostPlaybackLogic.TryGetEarlyDestroyedDebrisExplosionUT(rec, out double earlyExplosionUT))
+                {
+                    shouldTriggerExplosion = targetUT >= earlyExplosionUT;
+                }
+
+                if (!state.explosionFired && shouldTriggerExplosion)
                     TriggerExplosionIfDestroyed(state, rec, recIdx);
             }
             else if (ghostActive)
@@ -385,7 +392,14 @@ namespace Parsek
                 else
                     GhostPlaybackLogic.RestoreAllRcsEmissions(primaryState);
 
-                if (!primaryState.explosionFired && phase >= duration)
+                bool shouldTriggerExplosion = phase >= duration;
+                if (!shouldTriggerExplosion
+                    && GhostPlaybackLogic.TryGetEarlyDestroyedDebrisExplosionUT(rec, out double earlyExplosionUT))
+                {
+                    shouldTriggerExplosion = loopUT >= earlyExplosionUT;
+                }
+
+                if (!primaryState.explosionFired && shouldTriggerExplosion)
                     TriggerExplosionIfDestroyed(primaryState, rec, recIdx);
             }
 
@@ -432,6 +446,13 @@ namespace Parsek
                     GhostPlaybackLogic.StopAllRcsEmissions(ovState);
                 else
                     GhostPlaybackLogic.RestoreAllRcsEmissions(ovState);
+
+                if (!ovState.explosionFired
+                    && GhostPlaybackLogic.TryGetEarlyDestroyedDebrisExplosionUT(rec, out double earlyExplosionUT)
+                    && loopUT >= earlyExplosionUT)
+                {
+                    TriggerExplosionIfDestroyed(ovState, rec, recIdx);
+                }
             }
         }
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -316,7 +316,7 @@ If the answer is yes, add focused regression coverage for a real continuous EVA 
 
 ---
 
-## 329. Debris explosion FX can fire noticeably after visible ground contact
+## ~~329. Debris explosion FX can fire noticeably after visible ground contact~~
 
 **Observed in:** 2026-04-13 local smoke after the snapshot-storage PR. User report: there was a visible delay between debris hitting the ground and the explosion effect.
 
@@ -334,9 +334,9 @@ If the answer is yes, add focused regression coverage for a real continuous EVA 
 - the deliberate `0.5 s` crash-coalescing window before the breakup branchpoint exists
 - explosion FX being tied to ghost terminal/past-end destruction timing instead of the earliest impact-aligned sample
 
-**Fix direction:** Capture a focused debris-impact bundle and compare three times for the same fragment: trajectory impact/contact, breakup branchpoint UT, and `Triggering explosion for ghost ...` log time. If the delay is confirmed, consider keeping the coalescer for branch classification while moving the FX timing closer to the first impact-aligned sample, or reducing/special-casing the coalescing window for simple crash playback.
+**Fix implemented:** Destroyed debris playback now resolves an earlier explosion UT from the earliest eligible recorded `PartEventType.Destroyed` and completes the debris ghost there instead of waiting for `EndUT`. Flight and KSC playback both use the same helper, while breakup coalescing/classification timing remains unchanged.
 
-**Status:** Open
+**Status:** Fixed in PR `#241`
 
 ---
 


### PR DESCRIPTION
## Summary
- trigger destroyed debris explosion FX from the first recorded destroy event instead of waiting for recording end
- apply the same earlier trigger in flight and KSC playback paths
- add unit coverage for early debris explosion timing

## Testing
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj