### PR TITLE
Fix #327 save-time track section checkpointing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ All notable changes to Parsek are documented here.
 - The old warp-only orbital exemption no longer punches through the new `50-120 km` hidden-mesh tier. Orbital ghosts still get the legacy exemption only in the true `Beyond` zone.
 - Entering watch mode now uses the tracked playback distance first, avoiding false "in range" decisions from a hidden ghost's stale transform.
 - `#326` EVA branch recordings no longer seed bogus atmospheric start fragments when a landed or splashed kerbal is backgrounded before KSP finishes the vessel switch. The branch path now carries a one-shot surface override through delayed child initialization, and atmospheric-body EVA classification now keeps ground-adjacent or sea-level bobbing kerbals in surface segments instead of producing stray `atmo` optimizer splits.
+- Mid-flight active-tree saves now checkpoint the recorder's currently-open `TrackSection` before serializing and immediately reopen a continuation section afterward, so quickload no longer drops the live sparse trajectory chunk and post-separation main-stage playback does not freeze or drift across the missing save/load interval (`#327`).
 - The in-game test runner window now uses a more compact layout without the visible blank rows between tests, and disruptive quickload-resume tests run last in batch execution so they do not interfere with later scenarios.
 
 ### Developer Tools
@@ -55,6 +56,7 @@ All notable changes to Parsek are documented here.
 - Added archived-topology regression coverage for issue `#316`, including missing loop-sync parents after chain splitting, retained watched-lineage protection through late debris end times, and the current non-retarget-to-debris watch-target rule.
 - Added regression coverage for zero-throttle engine seeding vs. orphan-engine auto-start, so staged-off debris boosters are pinned against replaying as visually full-throttle.
 - Added regression coverage for EVA branch surface seeding and atmospheric/splashed EVA environment classification, covering the queued background override path and the near-ground / sea-level EVA surface heuristics behind `#326`.
+- Added regression coverage for save-time `TrackSection` checkpointing across active, relative, and orbital-checkpoint sections, and saved a reusable `tools/inspect-recording-sidecar.ps1` inspector for decoding `.prec` sparse trajectory payloads while debugging storage/playback issues like `#327`.
 - Diagnostics now report live engine/RCS FX counts plus last-frame ghost spawn/destroy timings, giving a measurement-first view of FX cost without changing FX behavior.
 - `scripts/inject-recordings.ps1 --run-diagnostics-tests` now runs the focused diagnostics/observability slice before showcase injection, including observability logging and in-game test runner ordering coverage.
 

--- a/Source/Parsek.Tests/SerializationTrackSectionCheckpointTests.cs
+++ b/Source/Parsek.Tests/SerializationTrackSectionCheckpointTests.cs
@@ -1,0 +1,100 @@
+using System.Reflection;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    [Collection("Sequential")]
+    public class SerializationTrackSectionCheckpointTests : System.IDisposable
+    {
+        public SerializationTrackSectionCheckpointTests()
+        {
+            RecordingStore.SuppressLogging = true;
+            MilestoneStore.ResetForTesting();
+            GameStateStore.SuppressLogging = true;
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+            RecordingStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+            MilestoneStore.ResetForTesting();
+        }
+
+        [Fact]
+        public void CheckpointOpenTrackSectionForSerialization_ClosesOpenSectionAndStartsContinuation()
+        {
+            var recorder = new FlightRecorder();
+
+            recorder.StartNewTrackSection(SegmentEnvironment.Atmospheric, ReferenceFrame.Absolute, 100.0);
+            recorder.CheckpointOpenTrackSectionForSerialization(120.0);
+            recorder.CloseCurrentTrackSection(140.0);
+
+            Assert.Equal(2, recorder.TrackSections.Count);
+            Assert.Equal(100.0, recorder.TrackSections[0].startUT);
+            Assert.Equal(120.0, recorder.TrackSections[0].endUT);
+            Assert.Equal(120.0, recorder.TrackSections[1].startUT);
+            Assert.Equal(140.0, recorder.TrackSections[1].endUT);
+            Assert.Equal(recorder.TrackSections[0].endUT, recorder.TrackSections[1].startUT);
+            Assert.Equal(SegmentEnvironment.Atmospheric, recorder.TrackSections[1].environment);
+            Assert.Equal(ReferenceFrame.Absolute, recorder.TrackSections[1].referenceFrame);
+            Assert.Equal(TrackSectionSource.Active, recorder.TrackSections[1].source);
+        }
+
+        [Fact]
+        public void CheckpointOpenTrackSectionForSerialization_PreservesRelativeAnchor()
+        {
+            var recorder = new FlightRecorder();
+
+            recorder.StartNewTrackSection(SegmentEnvironment.Atmospheric, ReferenceFrame.Relative, 200.0);
+            SetCurrentTrackSectionAnchor(recorder, 123456789u);
+
+            recorder.CheckpointOpenTrackSectionForSerialization(220.0);
+            recorder.CloseCurrentTrackSection(240.0);
+
+            Assert.Equal(2, recorder.TrackSections.Count);
+            Assert.Equal(ReferenceFrame.Relative, recorder.TrackSections[0].referenceFrame);
+            Assert.Equal(ReferenceFrame.Relative, recorder.TrackSections[1].referenceFrame);
+            Assert.Equal(123456789u, recorder.TrackSections[0].anchorVesselId);
+            Assert.Equal(123456789u, recorder.TrackSections[1].anchorVesselId);
+        }
+
+        [Fact]
+        public void CheckpointOpenTrackSectionForSerialization_PreservesCheckpointSourceWithoutSeedingFrames()
+        {
+            var recorder = new FlightRecorder();
+
+            recorder.StartNewTrackSection(
+                SegmentEnvironment.ExoBallistic,
+                ReferenceFrame.OrbitalCheckpoint,
+                300.0,
+                TrackSectionSource.Checkpoint);
+
+            recorder.CheckpointOpenTrackSectionForSerialization(330.0);
+            recorder.CloseCurrentTrackSection(360.0);
+
+            Assert.Equal(2, recorder.TrackSections.Count);
+            Assert.Equal(TrackSectionSource.Checkpoint, recorder.TrackSections[0].source);
+            Assert.Equal(TrackSectionSource.Checkpoint, recorder.TrackSections[1].source);
+            Assert.Equal(ReferenceFrame.OrbitalCheckpoint, recorder.TrackSections[1].referenceFrame);
+            Assert.Empty(recorder.TrackSections[1].frames);
+        }
+
+        private static void SetCurrentTrackSectionAnchor(FlightRecorder recorder, uint anchorPid)
+        {
+            var field = typeof(FlightRecorder).GetField(
+                "currentTrackSection",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+
+            Assert.NotNull(field);
+
+            var section = (TrackSection)field.GetValue(recorder);
+            section.anchorVesselId = anchorPid;
+            field.SetValue(recorder, section);
+        }
+    }
+}

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -3946,6 +3946,37 @@ namespace Parsek
                 $"UT={segment.startUT.ToString("F2", CultureInfo.InvariantCulture)}-{segment.endUT.ToString("F2", CultureInfo.InvariantCulture)}");
         }
 
+        /// <summary>
+        /// Closes the recorder's current open TrackSection at the given UT and immediately
+        /// opens a continuation section with the same environment/reference metadata.
+        /// Used by OnSave serialization flushes so the active tree persists the live
+        /// trajectory section that is still in progress, without stopping the recorder.
+        /// </summary>
+        internal void CheckpointOpenTrackSectionForSerialization(double ut)
+        {
+            if (!trackSectionActive) return;
+
+            var currentEnv = currentTrackSection.environment;
+            var currentRef = currentTrackSection.referenceFrame;
+            var currentSource = currentTrackSection.source;
+            uint currentAnchor = currentTrackSection.anchorVesselId;
+            TrajectoryPoint? boundaryPoint = GetLastTrackSectionFrame();
+
+            CloseCurrentTrackSection(ut);
+            StartNewTrackSection(currentEnv, currentRef, ut, currentSource);
+
+            if (currentRef == ReferenceFrame.Relative)
+                currentTrackSection.anchorVesselId = currentAnchor;
+
+            // Only absolute/relative sections carry sparse frame payloads.
+            if (currentRef != ReferenceFrame.OrbitalCheckpoint)
+                SeedBoundaryPoint(boundaryPoint);
+
+            ParsekLog.Verbose("Recorder",
+                $"Serialization checkpoint: env={currentEnv} ref={currentRef} " +
+                $"source={currentSource} at UT={ut.ToString("F2", CultureInfo.InvariantCulture)}");
+        }
+
         #endregion
 
         #region Anchor detection helpers (Phase 3a)

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -214,6 +214,12 @@ namespace Parsek
                 return;
             }
 
+            // Persist the currently-open TrackSection as a closed segment before we append
+            // recorder.TrackSections into the tree. Without this, mid-flight saves drop the
+            // active sparse trajectory chunk, and quickload playback can freeze or drift
+            // across the missing interval (#327).
+            recorder.CheckpointOpenTrackSectionForSerialization(Planetarium.GetUniversalTime());
+
             int prevPointCount = treeRec.Points.Count;
             int prevEventCount = treeRec.PartEvents.Count;
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -269,18 +269,16 @@ Add unit/in-game coverage around `F5/F9` during a branch, final save/load, and w
   - `Auto-follow on completion: #10 -> #13 (vessel=Kerbal X)`
   - the corresponding watch-focus lines show descending altitude (`278 m` then `65 m`), not a frozen parent trajectory
 - The older `s6` breakup bundle (`logs/2026-04-12_2055_main-stage-freeze-after-separation/`) did show a different watch bug where focus transferred to debris (`#0 -> #6 "GDLV3 Debris"`), but that was the now-fixed `#321` issue and is not proof of a current regression.
+- The same `s13` bundle **does** show a save/load storage gap in the main-stage `.prec` payload. At `03:03:26`, `FlushRecorderIntoActiveTreeForSerialization` logged `103` live points for root recording `034b687...`, but the sidecar written immediately afterward still contained only `trackSections=1 / sparsePoints=35`; the next quickload rebuilt only that single section. The `a936e14...` and `8109e9e...` same-PID continuations showed the same pattern at later save boundaries.
+- A saved local inspector script, `tools/inspect-recording-sidecar.ps1`, confirmed the persisted `Kerbal X` chain had large gaps between section-authoritative sparse segments even though live recording had advanced further in memory before save.
 
 **Impact:** If this is real on current head, the parent/main-stage recording can become visually unreliable after separation even while child debris recordings continue correctly. That would be a more serious playback-integrity bug than simple camera recovery or grouping.
 
-**Root cause / hypothesis:** Not isolated yet. Candidate areas are:
+**Root cause / hypothesis:** Root cause isolated on the `fix/327-main-stage-freeze-after-separation` branch. `ParsekFlight.FlushRecorderIntoActiveTreeForSerialization()` appended only already-closed `recorder.TrackSections` into the active-tree recording and then cleared them, but it did **not** checkpoint the recorder's currently-open `TrackSection` first. Mid-flight saves could therefore write a section-authoritative `.prec` sidecar that was missing the live in-progress sparse trajectory chunk, and quickload playback could freeze or drift across that gap while debris/child recordings continued normally.
 
-- same-PID continuation selection around breakup/save/load
-- parent trajectory hydration after save/load when child branches already exist
-- ghost/watch lifecycle around breakup-continuous effective-leaf parents versus debris children
+**Fix direction:** The branch now checkpoints the open active `TrackSection` during save-time serialization, immediately reopens a continuation section with the same environment/reference metadata, and adds regression coverage for absolute, relative, and orbital-checkpoint cases. This still needs an in-game save/load breakup repro on current head to confirm the visible frozen/off-trajectory symptom is gone.
 
-**Fix direction:** Capture a focused reproduction bundle where the frozen main stage is visible on current head, preferably with watch active and a save/load in the middle. Compare the parent `.prec` bounds, branchpoint ordering, watch transitions, and parent/child recording metadata before and after load. Add a regression only after the failure is reproduced concretely.
-
-**Status:** Open (needs focused repro)
+**Status:** Open (fix implemented on branch; needs in-game verification)
 
 ---
 

--- a/tools/inspect-recording-sidecar.ps1
+++ b/tools/inspect-recording-sidecar.ps1
@@ -1,0 +1,53 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$RecordingsDir,
+    [string[]]$RecordingIds,
+    [string]$ParsekDll,
+    [string]$ManagedDir
+)
+$ErrorActionPreference = 'Stop'
+if (-not $ParsekDll) {
+    $ParsekDll = Join-Path $PSScriptRoot '..\Source\Parsek\bin\Debug\Parsek.dll'
+}
+if (-not $ManagedDir) {
+    $ManagedDir = Join-Path $PSScriptRoot '..\..\Kerbal Space Program\KSP_x64_Data\Managed'
+}
+[Reflection.Assembly]::LoadFrom((Join-Path $ManagedDir 'UnityEngine.dll')) | Out-Null
+[Reflection.Assembly]::LoadFrom((Join-Path $ManagedDir 'UnityEngine.CoreModule.dll')) | Out-Null
+[Reflection.Assembly]::LoadFrom((Join-Path $ManagedDir 'Assembly-CSharp.dll')) | Out-Null
+ $asm = [Reflection.Assembly]::LoadFrom($ParsekDll)
+$probeType = $asm.GetType('Parsek.TrajectorySidecarProbe', $true)
+$recordingType = $asm.GetType('Parsek.Recording', $true)
+$binaryType = $asm.GetType('Parsek.TrajectorySidecarBinary', $true)
+$flags = [Reflection.BindingFlags]'Static, NonPublic, Public'
+$tryProbe = $binaryType.GetMethod('TryProbe', $flags)
+$read = $binaryType.GetMethod('Read', $flags)
+if (-not $RecordingIds -or $RecordingIds.Count -eq 0) {
+    $RecordingIds = Get-ChildItem $RecordingsDir -Filter '*.prec' | ForEach-Object BaseName
+}
+foreach ($id in $RecordingIds) {
+    $path = Join-Path $RecordingsDir ($id + '.prec')
+    if (-not (Test-Path $path)) { Write-Output "MISSING $id $path"; continue }
+    $probe = [Activator]::CreateInstance($probeType)
+    $invokeArgs = [object[]]@([string]$path, $probe)
+    if (-not $tryProbe.Invoke($null, $invokeArgs)) { Write-Output "PROBE_FAIL $id"; continue }
+    $probe = $invokeArgs[1]
+    $rec = [Activator]::CreateInstance($recordingType)
+    $recordingType.GetField('RecordingId').SetValue($rec, $id)
+    $read.Invoke($null, [object[]]@([string]$path, $rec, $probe)) | Out-Null
+    $points = $recordingType.GetField('Points').GetValue($rec)
+    $sections = $recordingType.GetField('TrackSections').GetValue($rec)
+    Write-Output "=== $id ==="
+    Write-Output (("points={0} sections={1}") -f $points.Count, $sections.Count)
+    if ($points.Count -gt 0) {
+        $first = $points[0]
+        $last = $points[$points.Count - 1]
+        Write-Output (("firstUT={0} lastUT={1} firstAlt={2} lastAlt={3} body={4}") -f $first.ut, $last.ut, $first.altitude, $last.altitude, $first.bodyName)
+    }
+    for ($i = 0; $i -lt $sections.Count; $i++) {
+        $s = $sections[$i]
+        $frames = if ($null -ne $s.frames) { $s.frames.Count } else { -1 }
+        $checkpoints = if ($null -ne $s.checkpoints) { $s.checkpoints.Count } else { -1 }
+        Write-Output (("sec[{0}] ut=[{1},{2}] env={3} ref={4} src={5} anchor={6} frames={7} checkpoints={8}") -f $i, $s.startUT, $s.endUT, $s.environment, $s.referenceFrame, $s.source, $s.anchorVesselId, $frames, $checkpoints)
+    }
+}


### PR DESCRIPTION
## Summary

- checkpoint the recorder's currently-open TrackSection during active-tree save serialization before appending buffered data into the tree
- immediately reopen a continuation section with the same environment/reference metadata so live recording continues without dropping sparse trajectory coverage
- add regression tests for active, relative, and orbital-checkpoint save-time checkpointing
- save a reusable `tools/inspect-recording-sidecar.ps1` helper and update the changelog/todo docs for #327

## Evidence

- in the 2026-04-13 s13 bundle, root recording `034b687...` logged `103` live points during save, but the sidecar written immediately afterward still contained only `trackSections=1 / sparsePoints=35`, and the next quickload rebuilt only that single section
- the same log bundle kept same-vessel watch handoff on the main-stage continuation (`#0 -> #10 -> #13`), which points to save/load trajectory persistence rather than the earlier debris-handoff bug fixed by #321

## Testing

- `dotnet test Source\Parsek.Tests\Parsek.Tests.csproj --filter "EnvironmentTrackingIntegrationTests|ReferenceFrameTrackingTests|SerializationTrackSectionCheckpointTests"`

## Follow-up

- still needs an in-game breakup save/load repro on current head to confirm the visible frozen/off-trajectory symptom is gone
