### PR TITLE
Fix FLIGHT save/load test cleanup and quickload canary guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ All notable changes to Parsek are documented here.
 - Destroyed debris playback now triggers whole-vessel explosion FX from the earliest eligible recorded destroy event instead of waiting for `EndUT`, so debris that visibly hits the ground no longer hangs before the final blast in either Flight or KSC playback (`#329`).
 - Mid-flight active-tree saves now checkpoint the recorder's currently-open `TrackSection` before serializing and immediately reopen a continuation section afterward, so quickload no longer drops the live sparse trajectory chunk and post-separation main-stage playback does not freeze or drift across the missing save/load interval (`#327`).
 - The in-game test runner window now uses a more compact layout without the visible blank rows between tests, and disruptive quickload-resume tests run last in batch execution so they do not interfere with later scenarios.
+- `#332` Running the in-game FLIGHT save/load round-trip tests no longer leaves the settings/diagnostics window transparent or watch/camera state pinned to stale ghost context: the settings window now keeps a stable tooltip layout every frame, and destructive synthetic `OnLoad` tests restore camera/playback/ghost state after they mutate the live session.
 
 ### Developer Tools
 
@@ -73,6 +74,7 @@ All notable changes to Parsek are documented here.
 - Added regression coverage for continuous EVA `atmo`/`surface` optimizer behavior, including split suppression for live same-body EVA sections, repair of already-split overlapping loaded pairs, and mixed-label UI formatting (`#328`).
 - Added regression coverage for resolved-no-crew end-state bookkeeping, including missing-start-snapshot behavior and save/load persistence of `crewEndStatesResolved` (`#220`).
 - Added regression coverage for save-time `TrackSection` checkpointing across active, relative, and orbital-checkpoint sections, and saved a reusable `tools/inspect-recording-sidecar.ps1` inspector for decoding `.prec` sparse trajectory payloads while debugging storage/playback issues like `#327`.
+- Live in-game `ParsekScenario.OnSave`/`OnLoad` round-trip tests now skip active-tree / pending-merge sessions, run last, clean up FLIGHT watch/ghost preview state after synthetic loads, and quickload wait helpers fail with explicit scene context instead of silently timing out (`#332`).
 - Diagnostics now report live engine/RCS FX counts plus last-frame ghost spawn/destroy timings, giving a measurement-first view of FX cost without changing FX behavior.
 - `scripts/inject-recordings.ps1 --run-diagnostics-tests` now runs the focused diagnostics/observability slice before showcase injection, including observability logging and in-game test runner ordering coverage.
 

--- a/Source/Parsek/InGameTests/ExtendedRuntimeTests.cs
+++ b/Source/Parsek/InGameTests/ExtendedRuntimeTests.cs
@@ -781,6 +781,19 @@ namespace Parsek.InGameTests
     /// </summary>
     public class SceneAndPatchTests
     {
+        private bool liveScenarioRoundTripMutatedSession;
+
+        [InGameTeardown]
+        private void CleanupLiveScenarioRoundTrip()
+        {
+            if (!liveScenarioRoundTripMutatedSession)
+                return;
+
+            Helpers.SyntheticScenarioLoadHelpers.CleanupFlightRuntime(
+                "SceneAndPatchTests live OnSave/OnLoad round-trip");
+            liveScenarioRoundTripMutatedSession = false;
+        }
+
         [InGameTest(Category = "SceneAndPatch", Scene = GameScenes.SPACECENTER,
             Description = "ParsekKSC MonoBehaviour exists in Space Center scene")]
         public void ParsekKscExistsInSpaceCenter()
@@ -853,10 +866,12 @@ namespace Parsek.InGameTests
                 $"ActiveRecorder={(Parsek.Patches.PhysicsFramePatch.ActiveRecorder != null ? "set" : "null")}");
         }
 
-        [InGameTest(Category = "SceneAndPatch",
+        [InGameTest(Category = "SceneAndPatch", RunLast = true,
             Description = "ParsekScenario survives OnSave+OnLoad round-trip for tree structure")]
         public void ScenarioRoundTripPreservesTreeStructure()
         {
+            Helpers.SyntheticScenarioLoadHelpers.EnsureRoundTripSafeToRun();
+
             // WARNING: This test calls OnSave+OnLoad on the live ParsekScenario.
             // OnLoad re-initializes RecordingStore from the serialized ConfigNode.
             // If the round-trip is imperfect, this could disrupt the session.
@@ -879,6 +894,7 @@ namespace Parsek.InGameTests
             // Round-trip
             var saveNode = new ConfigNode("SCENARIO");
             scenario.OnSave(saveNode);
+            liveScenarioRoundTripMutatedSession = true;
             scenario.OnLoad(saveNode);
 
             var treesAfter = RecordingStore.CommittedTrees;
@@ -899,10 +915,12 @@ namespace Parsek.InGameTests
                 $"Tree round-trip: {treesAfter.Count} trees, {afterBPTotal} branch points preserved");
         }
 
-        [InGameTest(Category = "SceneAndPatch",
+        [InGameTest(Category = "SceneAndPatch", RunLast = true,
             Description = "Crew replacement dict survives OnSave+OnLoad round-trip")]
         public void CrewReplacementsRoundTrip()
         {
+            Helpers.SyntheticScenarioLoadHelpers.EnsureRoundTripSafeToRun();
+
             // WARNING: Calls OnSave+OnLoad on live scenario — see comment on
             // ScenarioRoundTripPreservesTreeStructure for rationale.
             var scenario = Object.FindObjectOfType<ParsekScenario>();
@@ -912,6 +930,7 @@ namespace Parsek.InGameTests
 
             var saveNode = new ConfigNode("SCENARIO");
             scenario.OnSave(saveNode);
+            liveScenarioRoundTripMutatedSession = true;
             scenario.OnLoad(saveNode);
 
             var after = CrewReservationManager.CrewReplacements;

--- a/Source/Parsek/InGameTests/Helpers/QuickloadResumeHelpers.cs
+++ b/Source/Parsek/InGameTests/Helpers/QuickloadResumeHelpers.cs
@@ -16,9 +16,11 @@ namespace Parsek.InGameTests.Helpers
         internal static void TriggerQuicksave()
         {
             string saveName = HighLogic.SaveFolder;
-            GamePersistence.SaveGame("quicksave", saveName, SaveMode.OVERWRITE);
+            string result = GamePersistence.SaveGame("quicksave", saveName, SaveMode.OVERWRITE);
+            InGameAssert.IsTrue(!string.IsNullOrEmpty(result),
+                $"TriggerQuicksave failed for '{saveName}/quicksave'");
             ParsekLog.Info("TestHelper",
-                $"TriggerQuicksave: saved to '{saveName}/quicksave'");
+                $"TriggerQuicksave: saved to '{saveName}/quicksave' ({result})");
         }
 
         /// <summary>
@@ -31,12 +33,8 @@ namespace Parsek.InGameTests.Helpers
         {
             string saveName = HighLogic.SaveFolder;
             Game game = GamePersistence.LoadGame("quicksave", saveName, true, false);
-            if (game == null)
-            {
-                ParsekLog.Warn("TestHelper",
-                    $"TriggerQuickload: LoadGame returned null for '{saveName}/quicksave'");
-                return;
-            }
+            InGameAssert.IsNotNull(game,
+                $"TriggerQuickload failed: LoadGame returned null for '{saveName}/quicksave'");
 
             HighLogic.CurrentGame = game;
             HighLogic.LoadScene(GameScenes.FLIGHT);
@@ -48,21 +46,30 @@ namespace Parsek.InGameTests.Helpers
         /// Waits until FlightGlobals.ready is true and HighLogic.LoadedScene matches
         /// the target scene, or until timeout.
         /// </summary>
-        internal static IEnumerator WaitForFlightReady(float timeoutSeconds = 10f)
+        internal static IEnumerator WaitForFlightReady(int previousFlightInstanceId, float timeoutSeconds = 10f)
         {
             float deadline = Time.time + timeoutSeconds;
             while (Time.time < deadline)
             {
-                if (HighLogic.LoadedScene == GameScenes.FLIGHT && FlightGlobals.ready)
+                var flight = ParsekFlight.Instance;
+                bool replacedFlight = flight != null
+                    && (previousFlightInstanceId <= 0
+                        || flight.GetInstanceID() != previousFlightInstanceId);
+                if (HighLogic.LoadedScene == GameScenes.FLIGHT
+                    && FlightGlobals.ready
+                    && replacedFlight)
                     yield break;
                 yield return null;
             }
             string activeVesselName = FlightGlobals.ActiveVessel != null
                 ? FlightGlobals.ActiveVessel.vesselName
                 : "null";
+            var timedOutFlight = ParsekFlight.Instance;
             InGameAssert.IsTrue(false,
                 $"WaitForFlightReady timed out after {timeoutSeconds:F0}s " +
-                $"(scene={HighLogic.LoadedScene}, flightReady={FlightGlobals.ready}, activeVessel={activeVesselName})");
+                $"(scene={HighLogic.LoadedScene}, flightReady={FlightGlobals.ready}, activeVessel={activeVesselName}, " +
+                $"parsekFlight={(timedOutFlight != null ? timedOutFlight.GetInstanceID().ToString() : "null")}, " +
+                $"expectedDifferentFrom={previousFlightInstanceId})");
         }
 
         /// <summary>

--- a/Source/Parsek/InGameTests/Helpers/QuickloadResumeHelpers.cs
+++ b/Source/Parsek/InGameTests/Helpers/QuickloadResumeHelpers.cs
@@ -57,8 +57,12 @@ namespace Parsek.InGameTests.Helpers
                     yield break;
                 yield return null;
             }
-            ParsekLog.Warn("TestHelper",
-                $"WaitForFlightReady: timed out after {timeoutSeconds:F0}s");
+            string activeVesselName = FlightGlobals.ActiveVessel != null
+                ? FlightGlobals.ActiveVessel.vesselName
+                : "null";
+            InGameAssert.IsTrue(false,
+                $"WaitForFlightReady timed out after {timeoutSeconds:F0}s " +
+                $"(scene={HighLogic.LoadedScene}, flightReady={FlightGlobals.ready}, activeVessel={activeVesselName})");
         }
 
         /// <summary>
@@ -74,8 +78,13 @@ namespace Parsek.InGameTests.Helpers
                     yield break;
                 yield return null;
             }
-            ParsekLog.Warn("TestHelper",
-                $"WaitForActiveRecording: timed out after {timeoutSeconds:F0}s");
+            var flight = ParsekFlight.Instance;
+            string activeRecId = flight?.ActiveTreeForSerialization?.ActiveRecordingId ?? "null";
+            InGameAssert.IsTrue(false,
+                $"WaitForActiveRecording timed out after {timeoutSeconds:F0}s " +
+                $"(scene={HighLogic.LoadedScene}, flightReady={FlightGlobals.ready}, " +
+                $"parsekFlight={(flight != null)}, isRecording={flight?.IsRecording == true}, " +
+                $"hasActiveTree={flight?.HasActiveTree == true}, activeRecordingId={activeRecId})");
         }
     }
 }

--- a/Source/Parsek/InGameTests/Helpers/SyntheticScenarioLoadHelpers.cs
+++ b/Source/Parsek/InGameTests/Helpers/SyntheticScenarioLoadHelpers.cs
@@ -1,0 +1,37 @@
+namespace Parsek.InGameTests.Helpers
+{
+    /// <summary>
+    /// Guards and cleanup helpers for tests that call live ParsekScenario.OnSave/OnLoad
+    /// inside an already-running KSP scene.
+    /// </summary>
+    internal static class SyntheticScenarioLoadHelpers
+    {
+        internal static void EnsureRoundTripSafeToRun()
+        {
+            if (RecordingStore.HasPendingTree || ParsekScenario.MergeDialogPending)
+            {
+                InGameAssert.Skip(
+                    "Live session has pending merge state; OnSave/OnLoad round-trip would mutate it");
+            }
+
+            var flight = ParsekFlight.Instance;
+            if (flight != null && (flight.IsRecording || flight.HasActiveTree))
+            {
+                InGameAssert.Skip(
+                    "Live active tree/recording is in progress; OnSave/OnLoad round-trip would mutate it");
+            }
+        }
+
+        internal static void CleanupFlightRuntime(string reason)
+        {
+            if (HighLogic.LoadedScene != GameScenes.FLIGHT)
+                return;
+
+            var flight = ParsekFlight.Instance;
+            if (flight == null)
+                return;
+
+            flight.NormalizeAfterSyntheticScenarioLoad(reason);
+        }
+    }
+}

--- a/Source/Parsek/InGameTests/Helpers/SyntheticScenarioLoadHelpers.cs
+++ b/Source/Parsek/InGameTests/Helpers/SyntheticScenarioLoadHelpers.cs
@@ -15,10 +15,16 @@ namespace Parsek.InGameTests.Helpers
             }
 
             var flight = ParsekFlight.Instance;
-            if (flight != null && (flight.IsRecording || flight.HasActiveTree))
+            if (flight != null
+                && (flight.IsRecording
+                    || flight.HasActiveTree
+                    || flight.IsPlaying
+                    || flight.IsWatchingGhost
+                    || flight.TimelineGhostCount > 0
+                    || flight.HasDeferredWatchAfterFastForward))
             {
                 InGameAssert.Skip(
-                    "Live active tree/recording is in progress; OnSave/OnLoad round-trip would mutate it");
+                    "Live FLIGHT playback/watch state is active; OnSave/OnLoad round-trip would mutate it");
             }
         }
 

--- a/Source/Parsek/InGameTests/RuntimeTests.cs
+++ b/Source/Parsek/InGameTests/RuntimeTests.cs
@@ -2530,12 +2530,15 @@ namespace Parsek.InGameTests
             // Sentinel: use a static field on TestRunnerShortcut
             var preInstance = TestRunnerShortcut.Instance;
             InGameAssert.IsNotNull(preInstance, "TestRunnerShortcut.Instance must be non-null before quickload");
+            var preFlight = ParsekFlight.Instance;
+            InGameAssert.IsNotNull(preFlight, "ParsekFlight.Instance must be non-null before quickload");
 
             Helpers.QuickloadResumeHelpers.TriggerQuicksave();
             yield return new WaitForSeconds(0.5f);
 
             Helpers.QuickloadResumeHelpers.TriggerQuickload();
-            yield return Helpers.QuickloadResumeHelpers.WaitForFlightReady(15f);
+            yield return Helpers.QuickloadResumeHelpers.WaitForFlightReady(
+                preFlight.GetInstanceID(), 15f);
 
             // The same singleton must survive — DontDestroyOnLoad keeps it alive
             var postInstance = TestRunnerShortcut.Instance;
@@ -2564,6 +2567,7 @@ namespace Parsek.InGameTests
 
             string preRecId = flight.ActiveTreeForSerialization?.ActiveRecordingId;
             InGameAssert.IsNotNull(preRecId, "ActiveRecordingId must be set before F5");
+            int preFlightInstanceId = flight.GetInstanceID();
 
             // F5
             Helpers.QuickloadResumeHelpers.TriggerQuicksave();
@@ -2571,7 +2575,8 @@ namespace Parsek.InGameTests
 
             // F9
             Helpers.QuickloadResumeHelpers.TriggerQuickload();
-            yield return Helpers.QuickloadResumeHelpers.WaitForFlightReady(15f);
+            yield return Helpers.QuickloadResumeHelpers.WaitForFlightReady(
+                preFlightInstanceId, 15f);
             yield return Helpers.QuickloadResumeHelpers.WaitForActiveRecording(10f);
 
             // Re-query: old ParsekFlight instance is destroyed

--- a/Source/Parsek/InGameTests/RuntimeTests.cs
+++ b/Source/Parsek/InGameTests/RuntimeTests.cs
@@ -937,6 +937,19 @@ namespace Parsek.InGameTests
     /// </summary>
     public class SaveLoadTests
     {
+        private bool liveScenarioRoundTripMutatedSession;
+
+        [InGameTeardown]
+        private void CleanupLiveScenarioRoundTrip()
+        {
+            if (!liveScenarioRoundTripMutatedSession)
+                return;
+
+            Helpers.SyntheticScenarioLoadHelpers.CleanupFlightRuntime(
+                "SaveLoadTests live OnSave/OnLoad round-trip");
+            liveScenarioRoundTripMutatedSession = false;
+        }
+
         [InGameTest(Category = "SaveLoad",
             Description = "RecordingPaths.EnsureRecordingsDirectory creates/resolves the dir")]
         public void RecordingsDirectoryExists()
@@ -968,10 +981,12 @@ namespace Parsek.InGameTests
                 "ParsekScenario should be active (ScenarioModule loaded)");
         }
 
-        [InGameTest(Category = "SaveLoad",
+        [InGameTest(Category = "SaveLoad", RunLast = true,
             Description = "Recording count survives ConfigNode round-trip through ParsekScenario")]
         public void ScenarioRoundTripPreservesCount()
         {
+            Helpers.SyntheticScenarioLoadHelpers.EnsureRoundTripSafeToRun();
+
             var scenario = Object.FindObjectOfType<ParsekScenario>();
             if (scenario == null)
             {
@@ -986,6 +1001,7 @@ namespace Parsek.InGameTests
             scenario.OnSave(saveNode);
 
             // Deserialize back
+            liveScenarioRoundTripMutatedSession = true;
             scenario.OnLoad(saveNode);
             int afterCount = RecordingStore.CommittedRecordings.Count;
 

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -435,6 +435,7 @@ namespace Parsek
         }
         public bool HasActiveChain => chainManager?.HasActiveChain ?? false;
         public bool HasActiveTree => activeTree != null;
+        internal bool HasDeferredWatchAfterFastForward => !string.IsNullOrEmpty(pendingWatchAfterFFId);
 
         // Camera follow (watch mode) — forwarded from WatchModeController
         internal bool IsWatchingGhost => watchMode.IsWatchingGhost;
@@ -8067,11 +8068,7 @@ namespace Parsek
                 $"Normalizing FLIGHT runtime after {cleanupReason}");
 
             pendingWatchAfterFFId = null;
-
-            if (watchMode.IsWatchingGhost)
-                watchMode.ExitWatchMode();
-            else
-                InputLockManager.RemoveControlLock(WatchModeController.WatchModeLockId);
+            watchMode.ClearAfterSyntheticScenarioLoad();
 
             StopPlayback();
             DestroyAllTimelineGhosts("synthetic-scenario-load");

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -8058,10 +8058,29 @@ namespace Parsek
             engine.DestroyGhost(index);
         }
 
-        public void DestroyAllTimelineGhosts()
+        internal void NormalizeAfterSyntheticScenarioLoad(string reason)
+        {
+            string cleanupReason = string.IsNullOrEmpty(reason)
+                ? "synthetic scenario load"
+                : reason;
+            ParsekLog.Info("TestRunner",
+                $"Normalizing FLIGHT runtime after {cleanupReason}");
+
+            pendingWatchAfterFFId = null;
+
+            if (watchMode.IsWatchingGhost)
+                watchMode.ExitWatchMode();
+            else
+                InputLockManager.RemoveControlLock(WatchModeController.WatchModeLockId);
+
+            StopPlayback();
+            DestroyAllTimelineGhosts("synthetic-scenario-load");
+        }
+
+        public void DestroyAllTimelineGhosts(string ghostMapReason = "rewind")
         {
             // Remove ghost map ProtoVessels before engine cleanup
-            GhostMapPresence.RemoveAllGhostVessels("rewind");
+            GhostMapPresence.RemoveAllGhostVessels(ghostMapReason);
 
             // Engine destroys all ghost GOs and clears engine-owned state.
             // Fires OnAllGhostsDestroying so policy clears its own state.

--- a/Source/Parsek/UI/SettingsWindowUI.cs
+++ b/Source/Parsek/UI/SettingsWindowUI.cs
@@ -29,6 +29,8 @@ namespace Parsek
 
         private const float SpacingSmall = 3f;
         private const float SpacingLarge = 10f;
+        private GUIStyle zeroHeightLabelStyle;
+        private GUIStyle wrappedTooltipStyle;
 
         public bool IsOpen
         {
@@ -136,6 +138,7 @@ namespace Parsek
 
         private void DrawSettingsWindow(int windowID)
         {
+            EnsureLayoutStyles();
             var s = ParsekSettings.Current;
             if (s == null)
             {
@@ -201,17 +204,36 @@ namespace Parsek
             GUILayout.EndHorizontal();
 
             string tooltip = GUI.tooltip ?? "";
-            if (tooltip.Length > 0)
-            {
-                GUILayout.Space(SpacingSmall);
-                GUILayout.Label(tooltip, GUI.skin.box);
-            }
-            else
-            {
-                GUILayout.Label("", GUILayout.Height(0));
-            }
+            GUILayout.Space(tooltip.Length > 0 ? SpacingSmall : 0f);
+            GUILayout.Label(
+                tooltip.Length > 0 ? tooltip : string.Empty,
+                tooltip.Length > 0 ? wrappedTooltipStyle : zeroHeightLabelStyle,
+                tooltip.Length > 0 ? GUILayout.ExpandWidth(true) : GUILayout.Height(0f));
 
             GUI.DragWindow();
+        }
+
+        private void EnsureLayoutStyles()
+        {
+            if (zeroHeightLabelStyle == null)
+            {
+                zeroHeightLabelStyle = new GUIStyle(GUI.skin.label)
+                {
+                    fixedHeight = 0f,
+                    stretchHeight = false,
+                    wordWrap = false
+                };
+                zeroHeightLabelStyle.margin = new RectOffset(0, 0, 0, 0);
+                zeroHeightLabelStyle.padding = new RectOffset(0, 0, 0, 0);
+            }
+
+            if (wrappedTooltipStyle == null)
+            {
+                wrappedTooltipStyle = new GUIStyle(GUI.skin.box)
+                {
+                    wordWrap = true
+                };
+            }
         }
 
         private void DrawRecordingSettings(ParsekSettings s)

--- a/Source/Parsek/WatchModeController.cs
+++ b/Source/Parsek/WatchModeController.cs
@@ -877,6 +877,47 @@ namespace Parsek
             ResetWatchState(preserveLineageProtection, destroyOverlapAnchor: true);
         }
 
+        internal void ClearAfterSyntheticScenarioLoad()
+        {
+            if (watchedRecordingIndex >= 0)
+            {
+                ExitWatchMode(skipCameraRestore: false, preserveLineageProtection: false);
+                return;
+            }
+
+            RemoveWatchModeControlLockSafe();
+            ClearLineageProtection();
+            watchedOverlapCycleIndex = -1;
+            overlapRetargetAfterUT = -1;
+            watchEndHoldUntilRealTime = -1;
+            watchEndHoldMaxRealTime = -1;
+            watchEndHoldPendingActivationUT = double.NaN;
+            watchNoTargetFrames = 0;
+            currentCameraMode = WatchCameraMode.Free;
+            userModeOverride = false;
+            lastLoggedWatchTargetMismatch = null;
+            lastLoggedWatchFocusKey = null;
+            lastLoggedHorizonVectorKey = null;
+            savedCameraVessel = null;
+            savedCameraDistance = 0f;
+            savedCameraPitch = 0f;
+            savedCameraHeading = 0f;
+
+            if (overlapCameraAnchor == null)
+                return;
+
+            FlightCamera flightCamera = GetFlightCameraSafe();
+            Vessel activeVessel = GetActiveVesselSafe();
+            bool targetingOverlapAnchor = flightCamera != null
+                && flightCamera.Target == overlapCameraAnchor.transform;
+
+            UnityEngine.Object.Destroy(overlapCameraAnchor);
+            overlapCameraAnchor = null;
+
+            if (targetingOverlapAnchor && flightCamera != null && activeVessel != null)
+                flightCamera.SetTargetVessel(activeVessel);
+        }
+
         /// <summary>
         /// Determines whether a vessel's flight situation is safe for unattended flight.
         /// Safe means the vessel will not crash or deorbit while the player watches a ghost.

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -316,6 +316,29 @@ So the problem was not "bad auto-grouping on commit"; it was "stale hierarchy lo
 
 ---
 
+## ~~332. In-game FLIGHT save/load tests can leave the diagnostics window transparent and watch/camera state stale~~
+
+**Observed in:** 2026-04-13 local FLIGHT batch run after collecting `logs/2026-04-13_1635_332-flight-save-load-anchor-ui/`. User report: after the in-game save/load test, the diagnostics window became transparent and the camera/watch anchor no longer stayed on the expected anchor vehicle on the pad.
+
+**Collected evidence:**
+
+- `KSP.log` repeatedly threw `ArgumentException: Getting control ... position in a group with only ... controls when doing repaint` from `Parsek.SettingsWindowUI.DrawSettingsWindow`, which explains the transparent/corrupt diagnostics/settings window.
+- The failing code rendered the tooltip row conditionally: tooltip present emitted `GUILayout.Space(...)` + `GUILayout.Label(...)`, tooltip absent emitted a zero-height label only. That is the same IMGUI layout/repaint mismatch already avoided in `TestRunnerShortcut`.
+- The FLIGHT round-trip tests (`SaveLoadTests.ScenarioRoundTripPreservesCount`, `SceneAndPatchTests.ScenarioRoundTripPreservesTreeStructure`, `SceneAndPatchTests.CrewReplacementsRoundTrip`) call live `ParsekScenario.OnSave`/`OnLoad` mid-batch, which re-subscribes scenario/runtime state without a real scene transition.
+- `ParsekFlight` already had the right cleanup primitives (`ExitWatchMode`, `StopPlayback`, `DestroyAllTimelineGhosts`), but the destructive tests were not using them, so stale watch/ghost state could survive after the synthetic `OnLoad`.
+- The same bundle also showed the quickload canary path timing out after a broken restore while still reporting pass, because `QuickloadResumeHelpers.WaitForFlightReady` and `WaitForActiveRecording` only logged warnings instead of failing the test.
+
+**Root cause:** Two separate harness issues were compounding:
+
+- the settings/diagnostics window had a real IMGUI control-count bug in its tooltip row
+- the destructive live `OnSave`/`OnLoad` tests mutated the running FLIGHT session without being isolated or normalized afterward, while the quickload canary helper was too weak to expose broken restore paths honestly
+
+**Fix:** `SettingsWindowUI` now always renders a stable tooltip row using cached zero-height/wrapped styles. The live scenario round-trip tests now run last, skip active-tree / pending-merge sessions, and tear down FLIGHT runtime state after a synthetic load by restoring camera/watch state, stopping preview playback, clearing deferred watch retarget, and destroying timeline ghosts so playback caches rebuild cleanly. Quickload wait helpers now fail with explicit scene/readiness context instead of letting timed-out restores pass silently.
+
+**Status:** ~~Fixed~~
+
+---
+
 ## ~~329. Debris explosion FX can fire noticeably after visible ground contact~~
 
 **Observed in:** 2026-04-13 local smoke after the snapshot-storage PR. User report: there was a visible delay between debris hitting the ground and the explosion effect.


### PR DESCRIPTION
## Summary
- stabilize the settings/diagnostics tooltip row so IMGUI layout stays consistent instead of corrupting the window after FLIGHT test runs
- isolate live in-game ParsekScenario OnSave/OnLoad round-trip tests with run-last ordering, active-session guards, and FLIGHT runtime cleanup after synthetic loads
- harden quicksave/quickload test helpers so they assert save/load success and require a real ParsekFlight instance turnover before accepting FLIGHT as restored

## Testing
- dotnet build Source\\Parsek\\Parsek.csproj -v minimal (build succeeded; copy-to-KSP warnings because Kerbal Space Program\\GameData\\Parsek\\Plugins\\Parsek.dll was locked)
- dotnet test Source\\Parsek.Tests\\Parsek.Tests.csproj -v minimal