### PR TITLE
Fix long-range landed ghost terrain clearance

### DIFF
--- a/Source/Parsek.Tests/TerrainCorrectorTests.cs
+++ b/Source/Parsek.Tests/TerrainCorrectorTests.cs
@@ -164,6 +164,32 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void ResolveNaNFallbackLandedGhostClearance_BelowLegacyFloor_UsesLegacyMinimum()
+        {
+            double clearance = ParsekFlight.ResolveNaNFallbackLandedGhostClearanceMeters(2.42);
+            Assert.Equal(VesselSpawner.LandedGhostClearanceMeters, clearance, 3);
+        }
+
+        [Fact]
+        public void ResolveNaNFallbackLandedGhostClearance_AboveLegacyFloor_UsesDistanceAwareFloor()
+        {
+            double clearance = ParsekFlight.ResolveNaNFallbackLandedGhostClearanceMeters(5.0);
+            Assert.Equal(5.0, clearance, 3);
+        }
+
+        [Fact]
+        public void ShouldApplyImmediateSurfacePositionClearance_NaNTerrain_False()
+        {
+            Assert.False(ParsekFlight.ShouldApplyImmediateSurfacePositionClearance(double.NaN));
+        }
+
+        [Fact]
+        public void ShouldApplyImmediateSurfacePositionClearance_CapturedTerrain_True()
+        {
+            Assert.True(ParsekFlight.ShouldApplyImmediateSurfacePositionClearance(283.1));
+        }
+
+        [Fact]
         public void ClampAltitude_JustAboveClearance_NoChange()
         {
             // Ghost at 70.6m, terrain at 70m, clearance 0.5m — just above threshold

--- a/Source/Parsek.Tests/TerrainCorrectorTests.cs
+++ b/Source/Parsek.Tests/TerrainCorrectorTests.cs
@@ -151,6 +151,19 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void ClampAltitude_LongRangeWatchRepro_UsesDistanceAwareClearance()
+        {
+            // Repro from logs/2026-04-13_2136: watched landed ghost #19 was in
+            // Visual zone at 18.621 km with alt=283.8 and PQS terrain=283.1.
+            // The distance-based clearance at that range is ~2.42 m, so the
+            // visual floor should be ~285.52 m instead of the old 283.6 m
+            // (terrain + 0.5 m) last-frame floor.
+            double clearance = ParsekFlight.ComputeTerrainClearance(18621.0);
+            double result = TerrainCorrector.ClampAltitude(283.8, 283.1, clearance);
+            Assert.Equal(283.1 + clearance, result, 3);
+        }
+
+        [Fact]
         public void ClampAltitude_JustAboveClearance_NoChange()
         {
             // Ghost at 70.6m, terrain at 70m, clearance 0.5m — just above threshold

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -8826,19 +8826,10 @@ namespace Parsek
                 var term = traj.TerminalStateValue;
                 if (term == TerminalState.Landed || term == TerminalState.Splashed)
                 {
-                    double minClearanceMeters = 0.5;
-                    CelestialBody clearanceBody = FlightGlobals.Bodies?.Find(b => b.name == point.bodyName);
-                    if (clearanceBody != null && FlightGlobals.ActiveVessel != null)
-                    {
-                        Vector3d pointWorld = clearanceBody.GetWorldSurfacePosition(
-                            point.latitude, point.longitude, point.altitude);
-                        double distToVessel = Vector3d.Distance(
-                            pointWorld, FlightGlobals.ActiveVessel.GetWorldPos3D());
-                        minClearanceMeters = ComputeTerrainClearance(distToVessel);
-                    }
-
                     positioned = ApplyLandedGhostClearance(
-                        point, index, traj.VesselName, traj.TerrainHeightAtEnd, minClearanceMeters);
+                        point, index, traj.VesselName, traj.TerrainHeightAtEnd,
+                        ResolveImmediateLandedGhostClearanceMeters(
+                            point.bodyName, point.latitude, point.longitude, point.altitude));
                 }
             }
 
@@ -8849,6 +8840,18 @@ namespace Parsek
             // for its "ghost at alt N m on Kerbin" line — if we don't update it,
             // the log reports the buried raw altitude even after the visual is fixed.
             state.lastInterpolatedAltitude = positioned.altitude;
+        }
+
+        private static double ResolveImmediateLandedGhostClearanceMeters(
+            string bodyName, double latitude, double longitude, double altitude)
+        {
+            CelestialBody body = FlightGlobals.Bodies?.Find(b => b.name == bodyName);
+            if (body == null || FlightGlobals.ActiveVessel == null)
+                return 0.5;
+
+            Vector3d pointWorld = body.GetWorldSurfacePosition(latitude, longitude, altitude);
+            double distToVessel = Vector3d.Distance(pointWorld, FlightGlobals.ActiveVessel.GetWorldPos3D());
+            return ComputeTerrainClearance(distToVessel);
         }
 
         /// <summary>
@@ -8933,7 +8936,25 @@ namespace Parsek
             GhostPlaybackState state)
         {
             if (state?.ghost == null || traj?.SurfacePos == null) return;
-            PositionGhostAtSurface(state.ghost, traj.SurfacePos.Value, ShouldAutoActivateGhost(state));
+
+            SurfacePosition positioned = traj.SurfacePos.Value;
+            var syntheticPoint = new TrajectoryPoint
+            {
+                latitude = positioned.latitude,
+                longitude = positioned.longitude,
+                altitude = positioned.altitude,
+                rotation = positioned.rotation,
+                bodyName = positioned.body,
+            };
+            syntheticPoint = ApplyLandedGhostClearance(
+                syntheticPoint, index, traj.VesselName, traj.TerrainHeightAtEnd,
+                ResolveImmediateLandedGhostClearanceMeters(
+                    positioned.body, positioned.latitude, positioned.longitude, positioned.altitude));
+            positioned.altitude = syntheticPoint.altitude;
+
+            PositionGhostAtSurface(state.ghost, positioned, ShouldAutoActivateGhost(state));
+            state.lastInterpolatedBodyName = positioned.body;
+            state.lastInterpolatedAltitude = positioned.altitude;
         }
 
         void IGhostPositioner.PositionFromOrbit(int index, IPlaybackTrajectory traj,

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -8854,6 +8854,18 @@ namespace Parsek
             return ComputeTerrainClearance(distToVessel);
         }
 
+        internal static double ResolveNaNFallbackLandedGhostClearanceMeters(double minClearanceMeters)
+        {
+            return System.Math.Max(
+                VesselSpawner.LandedGhostClearanceMeters,
+                System.Math.Max(0.5, minClearanceMeters));
+        }
+
+        internal static bool ShouldApplyImmediateSurfacePositionClearance(double recordedTerrainHeight)
+        {
+            return !double.IsNaN(recordedTerrainHeight);
+        }
+
         /// <summary>
         /// Position a Landed/Splashed ghost. The recorded altitude is the TRUTH —
         /// the vessel was literally at that world-space position when the terminal
@@ -8869,8 +8881,9 @@ namespace Parsek
         /// below the current PQS terrain floor. The caller supplies the minimum
         /// clearance to use for the current playback context; long-range watched
         /// ghosts use the same distance-aware floor as <c>ClampGhostsToTerrain</c>.
-        /// For NaN-recorded-terrain legacy recordings we fall back to a fixed
-        /// clearance above PQS.</para>
+        /// For NaN-recorded-terrain legacy recordings we keep the historical 4 m
+        /// minimum clearance above PQS, but allow callers to request a larger
+        /// distance-aware floor at extreme watch ranges.</para>
         ///
         /// <para>Ghosts are kinematic — no physics damage concern — so the safety
         /// floor defaults to 0.5 m when the caller has no better context.
@@ -8896,11 +8909,15 @@ namespace Parsek
             var ic = System.Globalization.CultureInfo.InvariantCulture;
             double pqsTerrain = body.TerrainAltitude(p.latitude, p.longitude, true);
 
-            // Legacy (NaN) path: no recorded surface height — use fixed clearance
-            // above PQS terrain as before.
+            double floorClearance = System.Math.Max(0.5, minClearanceMeters);
+
+            // Legacy (NaN) path: no recorded surface height — keep the historical
+            // 4 m fallback floor, but honor a larger caller-requested clearance so
+            // long-range watched ghosts do not clip near the edge of visual range.
             if (double.IsNaN(recordedTerrainHeight))
             {
-                double legacyTarget = pqsTerrain + VesselSpawner.LandedGhostClearanceMeters;
+                double legacyClearance = ResolveNaNFallbackLandedGhostClearanceMeters(minClearanceMeters);
+                double legacyTarget = pqsTerrain + legacyClearance;
                 if (p.altitude >= legacyTarget)
                     return p;
                 // delta is always > 0 here because we already verified p.altitude < legacyTarget.
@@ -8909,7 +8926,7 @@ namespace Parsek
                     $"Landed ghost clamp #{index} (\"{vesselName}\"): " +
                     $"alt={p.altitude.ToString("F1", ic)} pqsTerrain={pqsTerrain.ToString("F1", ic)} " +
                     $"-> {legacyTarget.ToString("F1", ic)} (delta=+{delta.ToString("F2", ic)}m, " +
-                    $"body={body.name}, NaN fallback)");
+                    $"body={body.name}, NaN fallback, clearance={legacyClearance.ToString("F1", ic)}m)");
                 p.altitude = legacyTarget;
                 return p;
             }
@@ -8917,7 +8934,7 @@ namespace Parsek
             // Primary path: trust the recorded altitude. Only push up if the
             // recorded altitude is below the current PQS terrain floor — which
             // only happens when PQS terrain has shifted UP since recording.
-            double safetyFloor = pqsTerrain + System.Math.Max(0.5, minClearanceMeters);
+            double safetyFloor = pqsTerrain + floorClearance;
             if (p.altitude >= safetyFloor)
                 return p;
 
@@ -8926,7 +8943,7 @@ namespace Parsek
                 $"Landed ghost clamp #{index} (\"{vesselName}\"): " +
                 $"alt={p.altitude.ToString("F1", ic)} pqsTerrain={pqsTerrain.ToString("F1", ic)} " +
                 $"-> {safetyFloor.ToString("F1", ic)} (delta=+{upDelta.ToString("F2", ic)}m, " +
-                $"body={body.name}, below-pqs-floor, clearance={System.Math.Max(0.5, minClearanceMeters).ToString("F1", ic)}m, " +
+                $"body={body.name}, below-pqs-floor, clearance={floorClearance.ToString("F1", ic)}m, " +
                 $"recSurface={recordedTerrainHeight.ToString("F1", ic)})");
             p.altitude = safetyFloor;
             return p;
@@ -8938,19 +8955,22 @@ namespace Parsek
             if (state?.ghost == null || traj?.SurfacePos == null) return;
 
             SurfacePosition positioned = traj.SurfacePos.Value;
-            var syntheticPoint = new TrajectoryPoint
+            if (ShouldApplyImmediateSurfacePositionClearance(traj.TerrainHeightAtEnd))
             {
-                latitude = positioned.latitude,
-                longitude = positioned.longitude,
-                altitude = positioned.altitude,
-                rotation = positioned.rotation,
-                bodyName = positioned.body,
-            };
-            syntheticPoint = ApplyLandedGhostClearance(
-                syntheticPoint, index, traj.VesselName, traj.TerrainHeightAtEnd,
-                ResolveImmediateLandedGhostClearanceMeters(
-                    positioned.body, positioned.latitude, positioned.longitude, positioned.altitude));
-            positioned.altitude = syntheticPoint.altitude;
+                var syntheticPoint = new TrajectoryPoint
+                {
+                    latitude = positioned.latitude,
+                    longitude = positioned.longitude,
+                    altitude = positioned.altitude,
+                    rotation = positioned.rotation,
+                    bodyName = positioned.body,
+                };
+                syntheticPoint = ApplyLandedGhostClearance(
+                    syntheticPoint, index, traj.VesselName, traj.TerrainHeightAtEnd,
+                    ResolveImmediateLandedGhostClearanceMeters(
+                        positioned.body, positioned.latitude, positioned.longitude, positioned.altitude));
+                positioned.altitude = syntheticPoint.altitude;
+            }
 
             PositionGhostAtSurface(state.ghost, positioned, ShouldAutoActivateGhost(state));
             state.lastInterpolatedBodyName = positioned.body;

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -8816,16 +8816,30 @@ namespace Parsek
             // under ~2 m buries the pod. Applies only to the PositionAtPoint
             // call sites (past-end hold, loop cycle boundary, loop pause hold,
             // overlap expired): these are the "stuck at final point" paths.
-            // Normal in-flight playback goes through InterpolateAndPosition and
-            // still relies on the existing ClampGhostsToTerrain LateUpdate pass
-            // with its 0.5 m floor — mid-playback clamp is a follow-up tracked
-            // in the #282 todo-and-known-bugs entry.
+            // Normal in-flight playback already gets the distance-aware terrain
+            // floor from ClampGhostsToTerrain in LateUpdate; mirror that same
+            // minimum here so long-range watched landed ghosts do not sink below
+            // the visual terrain right as playback reaches its final point.
             TrajectoryPoint positioned = point;
             if (traj != null)
             {
                 var term = traj.TerminalStateValue;
                 if (term == TerminalState.Landed || term == TerminalState.Splashed)
-                    positioned = ApplyLandedGhostClearance(point, index, traj.VesselName, traj.TerrainHeightAtEnd);
+                {
+                    double minClearanceMeters = 0.5;
+                    CelestialBody clearanceBody = FlightGlobals.Bodies?.Find(b => b.name == point.bodyName);
+                    if (clearanceBody != null && FlightGlobals.ActiveVessel != null)
+                    {
+                        Vector3d pointWorld = clearanceBody.GetWorldSurfacePosition(
+                            point.latitude, point.longitude, point.altitude);
+                        double distToVessel = Vector3d.Distance(
+                            pointWorld, FlightGlobals.ActiveVessel.GetWorldPos3D());
+                        minClearanceMeters = ComputeTerrainClearance(distToVessel);
+                    }
+
+                    positioned = ApplyLandedGhostClearance(
+                        point, index, traj.VesselName, traj.TerrainHeightAtEnd, minClearanceMeters);
+                }
             }
 
             PositionGhostAt(state.ghost, positioned);
@@ -8849,16 +8863,20 @@ namespace Parsek
         ///
         /// <para>New behavior: preserve the recorded altitude. The only correction
         /// is an underground safety floor — push up if the recorded altitude is
-        /// below (current PQS terrain + 0.5 m), which only fires when PQS terrain
-        /// has shifted UP since recording. For NaN-recorded-terrain legacy
-        /// recordings we fall back to a fixed clearance above PQS.</para>
+        /// below the current PQS terrain floor. The caller supplies the minimum
+        /// clearance to use for the current playback context; long-range watched
+        /// ghosts use the same distance-aware floor as <c>ClampGhostsToTerrain</c>.
+        /// For NaN-recorded-terrain legacy recordings we fall back to a fixed
+        /// clearance above PQS.</para>
         ///
         /// <para>Ghosts are kinematic — no physics damage concern — so the safety
-        /// floor is small (0.5 m). <c>internal static</c> so in-game tests can
-        /// exercise it without needing a full <c>IGhostPositioner</c> chain.</para>
+        /// floor defaults to 0.5 m when the caller has no better context.
+        /// <c>internal static</c> so in-game tests can exercise it without
+        /// needing a full <c>IGhostPositioner</c> chain.</para>
         /// </summary>
         internal static TrajectoryPoint ApplyLandedGhostClearance(
-            TrajectoryPoint p, int index, string vesselName, double recordedTerrainHeight)
+            TrajectoryPoint p, int index, string vesselName, double recordedTerrainHeight,
+            double minClearanceMeters = 0.5)
         {
             CelestialBody body = FlightGlobals.Bodies?.Find(b => b.name == p.bodyName);
             if (body == null)
@@ -8896,7 +8914,7 @@ namespace Parsek
             // Primary path: trust the recorded altitude. Only push up if the
             // recorded altitude is below the current PQS terrain floor — which
             // only happens when PQS terrain has shifted UP since recording.
-            double safetyFloor = pqsTerrain + 0.5;
+            double safetyFloor = pqsTerrain + System.Math.Max(0.5, minClearanceMeters);
             if (p.altitude >= safetyFloor)
                 return p;
 
@@ -8905,7 +8923,7 @@ namespace Parsek
                 $"Landed ghost clamp #{index} (\"{vesselName}\"): " +
                 $"alt={p.altitude.ToString("F1", ic)} pqsTerrain={pqsTerrain.ToString("F1", ic)} " +
                 $"-> {safetyFloor.ToString("F1", ic)} (delta=+{upDelta.ToString("F2", ic)}m, " +
-                $"body={body.name}, below-pqs-floor, " +
+                $"body={body.name}, below-pqs-floor, clearance={System.Math.Max(0.5, minClearanceMeters).ToString("F1", ic)}m, " +
                 $"recSurface={recordedTerrainHeight.ToString("F1", ic)})");
             p.altitude = safetyFloor;
             return p;


### PR DESCRIPTION
## Summary
- use distance-aware terrain clearance when landed ghosts snap to their final watched point
- apply the same immediate clearance to surface-hold ghosts instead of relying on a later update tick
- add a regression test covering the long-range landed ghost repro from the 2026-04-13 log package

## Testing
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj -c Release --filter ''TerrainCorrectorTests|CameraFollowTests|WatchModeControllerTests|SpawnSafetyNetTests|Bug156Tests''