### PR TITLE
Fix breakup ghost snapshot anchoring

### DIFF
--- a/Source/Parsek.Tests/GhostVisualFrameTests.cs
+++ b/Source/Parsek.Tests/GhostVisualFrameTests.cs
@@ -8,14 +8,14 @@ namespace Parsek.Tests
     public class GhostVisualFrameTests
     {
         [Fact]
-        public void ComputeSnapshotVisualRootLocalOffset_DebrisUsesNegativeSnapshotCom()
+        public void ComputeSnapshotVisualRootLocalOffset_DebrisLeavesVisualsUnshifted()
         {
             var snapshot = BuildSnapshot("1.25,-2.5,3.75");
             var traj = new MockTrajectory { IsDebris = true };
 
             Vector3 offset = GhostVisualBuilder.ComputeSnapshotVisualRootLocalOffset(traj, snapshot);
 
-            AssertVector3Close(new Vector3(-1.25f, 2.5f, -3.75f), offset);
+            AssertVector3Close(Vector3.zero, offset);
         }
 
         [Fact]

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -491,14 +491,10 @@ namespace Parsek
         internal static Vector3 ComputeSnapshotVisualRootLocalOffset(
             IPlaybackTrajectory rec, ConfigNode snapshotNode)
         {
-            if (rec == null || !rec.IsDebris)
-                return Vector3.zero;
-
-            Vector3 snapshotCoM;
-            if (!TryGetSnapshotCenterOfMass(snapshotNode, out snapshotCoM))
-                return Vector3.zero;
-
-            return -snapshotCoM;
+            // The playback root already uses the vessel/root transform reference from
+            // the recorded trajectory point. Debris-only CoM shifting moves split
+            // stages and boosters forward from their actual separation position.
+            return Vector3.zero;
         }
 
         internal static bool TryGetSnapshotCenterOfMass(ConfigNode snapshotNode, out Vector3 centerOfMass)

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -3024,9 +3024,10 @@ namespace Parsek
                 {
                     uint pid = controlledChildren[i];
                     Vessel childVessel = FlightRecorder.FindVesselByPid(pid);
-                    ConfigNode ctrlSnap = childVessel == null
-                        ? crashCoalescer.GetPreCapturedSnapshot(pid)
-                        : null;
+                    // Keep the split-time ghost snapshot even when the child vessel is
+                    // still alive 0.5s later; otherwise the ghost builds from a later
+                    // post-split snapshot and can appear spatially ahead on frame 1.
+                    ConfigNode ctrlSnap = crashCoalescer.GetPreCapturedSnapshot(pid);
                     TrajectoryPoint? breakupChildPoint = crashCoalescer.GetPreCapturedTrajectoryPoint(pid);
                     var childRec = CreateBreakupChildRecording(activeTree, breakupBp, pid, childVessel, false, "Unknown",
                         ctrlSnap, breakupChildPoint, parentGeneration: activeRec.Generation);
@@ -3072,9 +3073,10 @@ namespace Parsek
                         continue;
                     }
 
-                    ConfigNode preSnap = debrisVessel == null
-                        ? crashCoalescer.GetPreCapturedSnapshot(pid)
-                        : null;
+                    // Use the coalescer's split-time snapshot for ghost visuals even when
+                    // the debris vessel survives the coalescing window; VesselSnapshot still
+                    // comes from the later live state for spawning.
+                    ConfigNode preSnap = crashCoalescer.GetPreCapturedSnapshot(pid);
                     TrajectoryPoint? breakupChildPoint = crashCoalescer.GetPreCapturedTrajectoryPoint(pid);
                     var childRec = CreateBreakupChildRecording(activeTree, breakupBp, pid, debrisVessel, true, "Debris",
                         preSnap, breakupChildPoint, parentGeneration: activeRec.Generation);

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -630,7 +630,9 @@ That confirms PR `#258` removed the original "ghost is visible before its first 
 
 **Implemented fix:** Seed breakup/background child recordings with split-time trajectory data only when that pose is actually captured at the split moment, and otherwise fall back to the first honest post-split sample instead of backdating a later pose to the earlier branch UT. Packed/on-rails background starts still persist that seed immediately into the recording, and loaded starts still use it as the recorder's first-sample baseline.
 
-**Status:** Fix implemented in PR `#264`; `gpt-5.4` `xhigh` review found no remaining substantive issues. Runtime validation is still pending from a fresh replay/save bundle.
+**Fresh validation:** `logs/2026-04-14_0000_main-stage-forward-bias` confirmed the split-time snapshot/seed fix is working: breakup children now build with `snapshotSource=pre-captured-ghost + live-vessel`, and the old slide-into-place behavior is gone. The remaining residual was a smaller but still visible debris-only root-frame bias: ghost playback was still applying a blanket `visualRootLocal = -snapshotCoM` shift to breakup debris, which moved both radial boosters and the stack-separated main stage forward from the recorded split point by roughly the magnitude of their saved `CoM`.
+
+**Status:** Follow-up root-frame fix implemented locally after the fresh bundle: debris ghosts no longer apply the snapshot-`CoM` visual-root shift. Runtime revalidation is still pending from the next replay/save bundle.
 
 ---
 


### PR DESCRIPTION
Summary:
- use the pre-captured split-time ghost snapshot for breakup child visuals while keeping live vessel snapshots for spawn state
- stop applying the blanket debris snapshot CoM visual shift that moved split stages and boosters forward
- update the regression test and todo note for the validated follow-up

Testing:
- focused ghost/background regression tests passed