### PR TITLE
Fix ghost map watch interactions

### DIFF
--- a/Source/Parsek.Tests/GhostMapWatchHelperTests.cs
+++ b/Source/Parsek.Tests/GhostMapWatchHelperTests.cs
@@ -1,0 +1,86 @@
+using Parsek.Patches;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    public class GhostMapWatchHelperTests
+    {
+        [Fact]
+        public void ResolveWatchAction_InvalidRecording_ReturnsUnavailable()
+        {
+            GhostMapWatchAction result = GhostMapWatchHelper.ResolveWatchAction(
+                recordingIndex: -1,
+                watchedRecordingIndex: -1,
+                hasActiveGhost: false,
+                sameBody: false,
+                toggleIfAlreadyWatching: true);
+
+            Assert.Equal(GhostMapWatchAction.Unavailable, result);
+        }
+
+        [Fact]
+        public void ResolveWatchAction_MenuClickOnWatchedGhost_ReturnsStop()
+        {
+            GhostMapWatchAction result = GhostMapWatchHelper.ResolveWatchAction(
+                recordingIndex: 4,
+                watchedRecordingIndex: 4,
+                hasActiveGhost: true,
+                sameBody: true,
+                toggleIfAlreadyWatching: true);
+
+            Assert.Equal(GhostMapWatchAction.Stop, result);
+        }
+
+        [Fact]
+        public void ResolveWatchAction_DoubleClickOnWatchedGhost_ReturnsRefresh()
+        {
+            GhostMapWatchAction result = GhostMapWatchHelper.ResolveWatchAction(
+                recordingIndex: 4,
+                watchedRecordingIndex: 4,
+                hasActiveGhost: true,
+                sameBody: true,
+                toggleIfAlreadyWatching: false);
+
+            Assert.Equal(GhostMapWatchAction.Refresh, result);
+        }
+
+        [Fact]
+        public void ResolveWatchAction_InactiveGhost_ReturnsNoActiveGhost()
+        {
+            GhostMapWatchAction result = GhostMapWatchHelper.ResolveWatchAction(
+                recordingIndex: 2,
+                watchedRecordingIndex: -1,
+                hasActiveGhost: false,
+                sameBody: true,
+                toggleIfAlreadyWatching: true);
+
+            Assert.Equal(GhostMapWatchAction.NoActiveGhost, result);
+        }
+
+        [Fact]
+        public void ResolveWatchAction_DifferentBody_ReturnsDifferentBody()
+        {
+            GhostMapWatchAction result = GhostMapWatchHelper.ResolveWatchAction(
+                recordingIndex: 2,
+                watchedRecordingIndex: -1,
+                hasActiveGhost: true,
+                sameBody: false,
+                toggleIfAlreadyWatching: true);
+
+            Assert.Equal(GhostMapWatchAction.DifferentBody, result);
+        }
+
+        [Fact]
+        public void ResolveWatchAction_ActiveGhostOnSameBody_ReturnsStart()
+        {
+            GhostMapWatchAction result = GhostMapWatchHelper.ResolveWatchAction(
+                recordingIndex: 2,
+                watchedRecordingIndex: 1,
+                hasActiveGhost: true,
+                sameBody: true,
+                toggleIfAlreadyWatching: true);
+
+            Assert.Equal(GhostMapWatchAction.Start, result);
+        }
+    }
+}

--- a/Source/Parsek.Tests/GhostMapWatchHelperTests.cs
+++ b/Source/Parsek.Tests/GhostMapWatchHelperTests.cs
@@ -13,6 +13,7 @@ namespace Parsek.Tests
                 watchedRecordingIndex: -1,
                 hasActiveGhost: false,
                 sameBody: false,
+                inRange: false,
                 toggleIfAlreadyWatching: true);
 
             Assert.Equal(GhostMapWatchAction.Unavailable, result);
@@ -26,6 +27,7 @@ namespace Parsek.Tests
                 watchedRecordingIndex: 4,
                 hasActiveGhost: true,
                 sameBody: true,
+                inRange: true,
                 toggleIfAlreadyWatching: true);
 
             Assert.Equal(GhostMapWatchAction.Stop, result);
@@ -39,6 +41,7 @@ namespace Parsek.Tests
                 watchedRecordingIndex: 4,
                 hasActiveGhost: true,
                 sameBody: true,
+                inRange: true,
                 toggleIfAlreadyWatching: false);
 
             Assert.Equal(GhostMapWatchAction.Refresh, result);
@@ -52,6 +55,7 @@ namespace Parsek.Tests
                 watchedRecordingIndex: -1,
                 hasActiveGhost: false,
                 sameBody: true,
+                inRange: true,
                 toggleIfAlreadyWatching: true);
 
             Assert.Equal(GhostMapWatchAction.NoActiveGhost, result);
@@ -65,22 +69,52 @@ namespace Parsek.Tests
                 watchedRecordingIndex: -1,
                 hasActiveGhost: true,
                 sameBody: false,
+                inRange: true,
                 toggleIfAlreadyWatching: true);
 
             Assert.Equal(GhostMapWatchAction.DifferentBody, result);
         }
 
         [Fact]
-        public void ResolveWatchAction_ActiveGhostOnSameBody_ReturnsStart()
+        public void ResolveWatchAction_OutOfRangeGhost_ReturnsOutOfRange()
+        {
+            GhostMapWatchAction result = GhostMapWatchHelper.ResolveWatchAction(
+                recordingIndex: 2,
+                watchedRecordingIndex: -1,
+                hasActiveGhost: true,
+                sameBody: true,
+                inRange: false,
+                toggleIfAlreadyWatching: true);
+
+            Assert.Equal(GhostMapWatchAction.OutOfRange, result);
+        }
+
+        [Fact]
+        public void ResolveWatchAction_ActiveGhostOnSameBodyInRange_ReturnsStart()
         {
             GhostMapWatchAction result = GhostMapWatchHelper.ResolveWatchAction(
                 recordingIndex: 2,
                 watchedRecordingIndex: 1,
                 hasActiveGhost: true,
                 sameBody: true,
+                inRange: true,
                 toggleIfAlreadyWatching: true);
 
             Assert.Equal(GhostMapWatchAction.Start, result);
+        }
+
+        [Fact]
+        public void IsWatchActionEnabled_OutOfRange_ReturnsFalse()
+        {
+            Assert.False(GhostMapWatchHelper.IsWatchActionEnabled(GhostMapWatchAction.OutOfRange));
+        }
+
+        [Fact]
+        public void IsWatchActionEnabled_StartAndStop_ReturnTrue()
+        {
+            Assert.True(GhostMapWatchHelper.IsWatchActionEnabled(GhostMapWatchAction.Start));
+            Assert.True(GhostMapWatchHelper.IsWatchActionEnabled(GhostMapWatchAction.Stop));
+            Assert.True(GhostMapWatchHelper.IsWatchActionEnabled(GhostMapWatchAction.Refresh));
         }
     }
 }

--- a/Source/Parsek/Patches/GhostVesselLoadPatch.cs
+++ b/Source/Parsek/Patches/GhostVesselLoadPatch.cs
@@ -12,6 +12,7 @@ namespace Parsek.Patches
         Unavailable,
         NoActiveGhost,
         DifferentBody,
+        OutOfRange,
         Start,
         Stop,
         Refresh,
@@ -24,6 +25,7 @@ namespace Parsek.Patches
             int watchedRecordingIndex,
             bool hasActiveGhost,
             bool sameBody,
+            bool inRange,
             bool toggleIfAlreadyWatching)
         {
             if (recordingIndex < 0)
@@ -36,7 +38,35 @@ namespace Parsek.Patches
                 return GhostMapWatchAction.NoActiveGhost;
             if (!sameBody)
                 return GhostMapWatchAction.DifferentBody;
+            if (!inRange)
+                return GhostMapWatchAction.OutOfRange;
             return GhostMapWatchAction.Start;
+        }
+
+        internal static string GetWatchButtonLabel(GhostMapWatchAction action)
+        {
+            switch (action)
+            {
+                case GhostMapWatchAction.Stop:
+                    return "Stop Watching";
+                case GhostMapWatchAction.Refresh:
+                    return "Refresh Watch";
+                case GhostMapWatchAction.OutOfRange:
+                    return "Watch (Too Far)";
+                case GhostMapWatchAction.NoActiveGhost:
+                    return "Watch (Inactive)";
+                case GhostMapWatchAction.DifferentBody:
+                    return "Watch (Other SOI)";
+                default:
+                    return "Watch";
+            }
+        }
+
+        internal static bool IsWatchActionEnabled(GhostMapWatchAction action)
+        {
+            return action == GhostMapWatchAction.Start
+                || action == GhostMapWatchAction.Stop
+                || action == GhostMapWatchAction.Refresh;
         }
 
         internal static bool TryFocusGhostInMapView(Vessel vessel, string source)
@@ -79,11 +109,13 @@ namespace Parsek.Patches
 
             bool hasActiveGhost = recIndex >= 0 && flight.HasActiveGhost(recIndex);
             bool sameBody = recIndex >= 0 && flight.IsGhostOnSameBody(recIndex);
+            bool inRange = recIndex >= 0 && flight.IsGhostWithinVisualRange(recIndex);
             GhostMapWatchAction action = ResolveWatchAction(
                 recIndex,
                 flight.WatchedRecordingIndex,
                 hasActiveGhost,
                 sameBody,
+                inRange,
                 toggleIfAlreadyWatching);
 
             switch (action)
@@ -110,6 +142,15 @@ namespace Parsek.Patches
                         5f, ScreenMessageStyle.UPPER_CENTER);
                     ParsekLog.Info("GhostMap",
                         $"Ghost '{vesselName}' watch refused via {source} — different SOI (recIndex={recIndex})");
+                    return;
+
+                case GhostMapWatchAction.OutOfRange:
+                    ScreenMessages.PostScreenMessage(
+                        $"<b>{vesselName}</b> — ghost is out of watch range.",
+                        5f, ScreenMessageStyle.UPPER_CENTER);
+                    ParsekLog.Info("GhostMap",
+                        $"Ghost '{vesselName}' watch refused via {source} — out of range " +
+                        $"(recIndex={recIndex}) {flight.DescribeWatchEligibilityForLogs(recIndex)}");
                     return;
 
                 case GhostMapWatchAction.Stop:
@@ -188,11 +229,20 @@ namespace Parsek.Patches
             Vessel v = __instance.vessel;
             int recIndex = GhostMapPresence.FindRecordingIndexByVesselPid(v.persistentId);
             string vesselName = v.vesselName ?? "Ghost";
-            var flight = ParsekFlight.Instance;
-            bool isWatchingThisGhost = flight != null
-                && recIndex >= 0
-                && flight.WatchedRecordingIndex == recIndex;
-            string watchButtonLabel = isWatchingThisGhost ? "Stop Watching" : "Watch";
+            System.Func<GhostMapWatchAction> resolveCurrentWatchAction = () =>
+            {
+                var currentFlight = ParsekFlight.Instance;
+                bool hasActiveGhost = currentFlight != null && recIndex >= 0 && currentFlight.HasActiveGhost(recIndex);
+                bool sameBody = currentFlight != null && recIndex >= 0 && currentFlight.IsGhostOnSameBody(recIndex);
+                bool inRange = currentFlight != null && recIndex >= 0 && currentFlight.IsGhostWithinVisualRange(recIndex);
+                return GhostMapWatchHelper.ResolveWatchAction(
+                    recIndex,
+                    currentFlight != null ? currentFlight.WatchedRecordingIndex : -1,
+                    hasActiveGhost,
+                    sameBody,
+                    inRange,
+                    toggleIfAlreadyWatching: true);
+            };
 
             // Dismiss any existing ghost menu before opening a new one
             DismissCurrentMenu();
@@ -221,7 +271,10 @@ namespace Parsek.Patches
                         ParsekLog.Info("GhostMap", $"Ghost '{vesselName}' set as target via icon click");
                     }
                 }, dismissOnSelect: true),
-                new DialogGUIButton(watchButtonLabel, () =>
+                new DialogGUIButton(() =>
+                {
+                    return GhostMapWatchHelper.GetWatchButtonLabel(resolveCurrentWatchAction());
+                }, () =>
                 {
                     currentGhostMenu = null;
                     GhostMapWatchHelper.HandleWatchRequest(
@@ -229,7 +282,8 @@ namespace Parsek.Patches
                         recIndex,
                         source: "icon menu",
                         toggleIfAlreadyWatching: true);
-                }, dismissOnSelect: true)
+                }, () => GhostMapWatchHelper.IsWatchActionEnabled(resolveCurrentWatchAction()),
+                160f, 30f, true, (DialogGUIBase[])null)
             };
 
             // Anchors at (0,0) — matches KSP's MapContextMenu pattern (#196).

--- a/Source/Parsek/Patches/GhostVesselLoadPatch.cs
+++ b/Source/Parsek/Patches/GhostVesselLoadPatch.cs
@@ -7,6 +7,143 @@ using UnityEngine.UI;
 
 namespace Parsek.Patches
 {
+    internal enum GhostMapWatchAction
+    {
+        Unavailable,
+        NoActiveGhost,
+        DifferentBody,
+        Start,
+        Stop,
+        Refresh,
+    }
+
+    internal static class GhostMapWatchHelper
+    {
+        internal static GhostMapWatchAction ResolveWatchAction(
+            int recordingIndex,
+            int watchedRecordingIndex,
+            bool hasActiveGhost,
+            bool sameBody,
+            bool toggleIfAlreadyWatching)
+        {
+            if (recordingIndex < 0)
+                return GhostMapWatchAction.Unavailable;
+            if (watchedRecordingIndex == recordingIndex)
+                return toggleIfAlreadyWatching
+                    ? GhostMapWatchAction.Stop
+                    : GhostMapWatchAction.Refresh;
+            if (!hasActiveGhost)
+                return GhostMapWatchAction.NoActiveGhost;
+            if (!sameBody)
+                return GhostMapWatchAction.DifferentBody;
+            return GhostMapWatchAction.Start;
+        }
+
+        internal static bool TryFocusGhostInMapView(Vessel vessel, string source)
+        {
+            if (vessel == null
+                || PlanetariumCamera.fetch == null
+                || !MapView.MapIsEnabled
+                || vessel.mapObject == null)
+            {
+                ParsekLog.Warn("GhostMap",
+                    $"Focus failed via {source}: vessel={vessel != null} " +
+                    $"camera={PlanetariumCamera.fetch != null} map={MapView.MapIsEnabled} " +
+                    $"mapObj={vessel?.mapObject != null}");
+                return false;
+            }
+
+            PlanetariumCamera.fetch.SetTarget(vessel.mapObject);
+            ParsekLog.Info("GhostMap",
+                $"Focused map camera on ghost '{vessel.vesselName}' via {source}");
+            return true;
+        }
+
+        internal static void HandleWatchRequest(
+            Vessel vessel,
+            int recIndex,
+            string source,
+            bool toggleIfAlreadyWatching)
+        {
+            string vesselName = vessel?.vesselName ?? "Ghost";
+            var flight = ParsekFlight.Instance;
+            if (flight == null)
+            {
+                ScreenMessages.PostScreenMessage(
+                    $"<b>{vesselName}</b> is a ghost — it will materialize when its timeline reaches the spawn point.",
+                    5f, ScreenMessageStyle.UPPER_CENTER);
+                ParsekLog.Info("GhostMap",
+                    $"Ghost '{vesselName}' watch unavailable via {source} (flight controller missing, recIndex={recIndex})");
+                return;
+            }
+
+            bool hasActiveGhost = recIndex >= 0 && flight.HasActiveGhost(recIndex);
+            bool sameBody = recIndex >= 0 && flight.IsGhostOnSameBody(recIndex);
+            GhostMapWatchAction action = ResolveWatchAction(
+                recIndex,
+                flight.WatchedRecordingIndex,
+                hasActiveGhost,
+                sameBody,
+                toggleIfAlreadyWatching);
+
+            switch (action)
+            {
+                case GhostMapWatchAction.Unavailable:
+                    ScreenMessages.PostScreenMessage(
+                        $"<b>{vesselName}</b> is a ghost — it will materialize when its timeline reaches the spawn point.",
+                        5f, ScreenMessageStyle.UPPER_CENTER);
+                    ParsekLog.Info("GhostMap",
+                        $"Ghost '{vesselName}' watch unavailable via {source} (recIndex={recIndex})");
+                    return;
+
+                case GhostMapWatchAction.NoActiveGhost:
+                    ScreenMessages.PostScreenMessage(
+                        $"<b>{vesselName}</b> — ghost not active yet (recording may be in the future).",
+                        5f, ScreenMessageStyle.UPPER_CENTER);
+                    ParsekLog.Info("GhostMap",
+                        $"Ghost '{vesselName}' watch refused via {source} — no active ghost (recIndex={recIndex})");
+                    return;
+
+                case GhostMapWatchAction.DifferentBody:
+                    ScreenMessages.PostScreenMessage(
+                        $"<b>{vesselName}</b> — ghost is in a different SOI.",
+                        5f, ScreenMessageStyle.UPPER_CENTER);
+                    ParsekLog.Info("GhostMap",
+                        $"Ghost '{vesselName}' watch refused via {source} — different SOI (recIndex={recIndex})");
+                    return;
+
+                case GhostMapWatchAction.Stop:
+                    flight.ExitWatchMode();
+                    ParsekLog.Info("GhostMap",
+                        $"Ghost '{vesselName}' watch stopped via {source} (recIndex={recIndex})");
+                    return;
+
+                case GhostMapWatchAction.Refresh:
+                    TryFocusGhostInMapView(vessel, source + " refresh");
+                    ParsekLog.Info("GhostMap",
+                        $"Ghost '{vesselName}' watch refreshed via {source} (recIndex={recIndex})");
+                    return;
+
+                case GhostMapWatchAction.Start:
+                    break;
+            }
+
+            string beforeFocus = flight.DescribeWatchFocusForLogs();
+            flight.EnterWatchMode(recIndex);
+            if (flight.WatchedRecordingIndex != recIndex)
+            {
+                ParsekLog.Warn("GhostMap",
+                    $"Ghost '{vesselName}' watch request via {source} did not enter watch mode " +
+                    $"(recIndex={recIndex}) beforeFocus={beforeFocus} afterFocus={flight.DescribeWatchFocusForLogs()}");
+                return;
+            }
+
+            TryFocusGhostInMapView(vessel, source + " watch");
+            ParsekLog.Info("GhostMap",
+                $"Ghost '{vesselName}' watch started via {source} (recIndex={recIndex})");
+        }
+    }
+
     /// <summary>
     /// Prevents ghost vessel orbit lines from being clickable in map view (#172).
     /// Ghost orbit lines are visual-only — clicking them should not open the target
@@ -51,6 +188,11 @@ namespace Parsek.Patches
             Vessel v = __instance.vessel;
             int recIndex = GhostMapPresence.FindRecordingIndexByVesselPid(v.persistentId);
             string vesselName = v.vesselName ?? "Ghost";
+            var flight = ParsekFlight.Instance;
+            bool isWatchingThisGhost = flight != null
+                && recIndex >= 0
+                && flight.WatchedRecordingIndex == recIndex;
+            string watchButtonLabel = isWatchingThisGhost ? "Stop Watching" : "Watch";
 
             // Dismiss any existing ghost menu before opening a new one
             DismissCurrentMenu();
@@ -79,36 +221,14 @@ namespace Parsek.Patches
                         ParsekLog.Info("GhostMap", $"Ghost '{vesselName}' set as target via icon click");
                     }
                 }, dismissOnSelect: true),
-                new DialogGUIButton("Watch", () =>
+                new DialogGUIButton(watchButtonLabel, () =>
                 {
                     currentGhostMenu = null;
-                    var flight = ParsekFlight.Instance;
-                    if (flight == null || recIndex < 0)
-                    {
-                        ScreenMessages.PostScreenMessage(
-                            $"<b>{vesselName}</b> is a ghost — it will materialize when its timeline reaches the spawn point.",
-                            5f, ScreenMessageStyle.UPPER_CENTER);
-                        ParsekLog.Info("GhostMap", $"Ghost '{vesselName}' watch unavailable (recIndex={recIndex})");
-                    }
-                    else if (!flight.HasActiveGhost(recIndex))
-                    {
-                        ScreenMessages.PostScreenMessage(
-                            $"<b>{vesselName}</b> — ghost not active yet (recording may be in the future).",
-                            5f, ScreenMessageStyle.UPPER_CENTER);
-                        ParsekLog.Info("GhostMap", $"Ghost '{vesselName}' watch refused — no active ghost (recIndex={recIndex})");
-                    }
-                    else if (!flight.IsGhostOnSameBody(recIndex))
-                    {
-                        ScreenMessages.PostScreenMessage(
-                            $"<b>{vesselName}</b> — ghost is in a different SOI.",
-                            5f, ScreenMessageStyle.UPPER_CENTER);
-                        ParsekLog.Info("GhostMap", $"Ghost '{vesselName}' watch refused — different SOI (recIndex={recIndex})");
-                    }
-                    else
-                    {
-                        flight.EnterWatchMode(recIndex);
-                        ParsekLog.Info("GhostMap", $"Ghost '{vesselName}' watch started via icon click (recIndex={recIndex})");
-                    }
+                    GhostMapWatchHelper.HandleWatchRequest(
+                        v,
+                        recIndex,
+                        source: "icon menu",
+                        toggleIfAlreadyWatching: true);
                 }, dismissOnSelect: true)
             };
 
@@ -281,18 +401,13 @@ namespace Parsek.Patches
             }
 
             var flight = ParsekFlight.Instance;
-            if (flight != null)
+            if (flight != null || recIndex >= 0)
             {
-                flight.EnterWatchMode(recIndex);
-                ParsekLog.Info("GhostMap",
-                    $"Redirected SetActiveVessel to watch mode for ghost '{v.vesselName}' recording #{recIndex}");
-            }
-
-            // Focus the map camera on the ghost vessel (#193)
-            if (PlanetariumCamera.fetch != null && MapView.MapIsEnabled && v.mapObject != null)
-            {
-                PlanetariumCamera.fetch.SetTarget(v.mapObject);
-                ParsekLog.Info("GhostMap", $"Focused map camera on ghost '{v.vesselName}'");
+                GhostMapWatchHelper.HandleWatchRequest(
+                    v,
+                    recIndex,
+                    source: "map double-click",
+                    toggleIfAlreadyWatching: false);
             }
 
             return false;


### PR DESCRIPTION
## Summary
- make ghost map watch actions explicit for menu and double-click flows
- avoid toggling off when double-clicking a ghost that is already being watched
- focus the map camera after successful watch entry and add watch-action tests

## Testing
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj (targeted watch and ghost-map tests)