### PR TITLE
Keep ghost map orbit lines through same-SOI gaps

### DIFF
--- a/Source/Parsek.Tests/GhostMapPresenceTests.cs
+++ b/Source/Parsek.Tests/GhostMapPresenceTests.cs
@@ -1113,7 +1113,7 @@ namespace Parsek.Tests
                 OrbitSegments = new List<OrbitSegment>
                 {
                     new OrbitSegment { startUT = 100, endUT = 200, bodyName = "Kerbin", semiMajorAxis = 700000 },
-                    new OrbitSegment { startUT = 240, endUT = 500, bodyName = "Kerbin", semiMajorAxis = 710000 }
+                    new OrbitSegment { startUT = 240, endUT = 500, bodyName = "Kerbin", semiMajorAxis = 700000, meanAnomalyAtEpoch = 2.5, epoch = 240 }
                 }
             };
 
@@ -1121,6 +1121,28 @@ namespace Parsek.Tests
 
             Assert.True(should);
             Assert.Null(reason);
+        }
+
+        /// <summary>
+        /// Same-body gap with a real orbit change should not be carried across.
+        /// </summary>
+        [Fact]
+        public void ShouldCreate_NullTerminal_WithSameBodyOrbitChangeGap_Skipped()
+        {
+            var rec = new Recording
+            {
+                TerminalStateValue = null,
+                OrbitSegments = new List<OrbitSegment>
+                {
+                    new OrbitSegment { startUT = 100, endUT = 200, bodyName = "Kerbin", semiMajorAxis = 700000 },
+                    new OrbitSegment { startUT = 240, endUT = 500, bodyName = "Kerbin", semiMajorAxis = 710000 }
+                }
+            };
+
+            var (should, reason) = GhostMapPresence.ShouldCreateTrackingStationGhost(rec, false, 220);
+
+            Assert.False(should);
+            Assert.Equal("no-current-segment", reason);
         }
 
         /// <summary>

--- a/Source/Parsek.Tests/GhostMapPresenceTests.cs
+++ b/Source/Parsek.Tests/GhostMapPresenceTests.cs
@@ -1102,6 +1102,28 @@ namespace Parsek.Tests
         }
 
         /// <summary>
+        /// Null terminal state with same-body segment gap: keep showing the orbit ghost.
+        /// </summary>
+        [Fact]
+        public void ShouldCreate_NullTerminal_WithSameBodyGap_Created()
+        {
+            var rec = new Recording
+            {
+                TerminalStateValue = null,
+                OrbitSegments = new List<OrbitSegment>
+                {
+                    new OrbitSegment { startUT = 100, endUT = 200, bodyName = "Kerbin", semiMajorAxis = 700000 },
+                    new OrbitSegment { startUT = 240, endUT = 500, bodyName = "Kerbin", semiMajorAxis = 710000 }
+                }
+            };
+
+            var (should, reason) = GhostMapPresence.ShouldCreateTrackingStationGhost(rec, false, 220);
+
+            Assert.True(should);
+            Assert.Null(reason);
+        }
+
+        /// <summary>
         /// Null terminal state with orbit segments: skip when UT past all segments.
         /// </summary>
         [Fact]

--- a/Source/Parsek.Tests/OrbitSegmentTests.cs
+++ b/Source/Parsek.Tests/OrbitSegmentTests.cs
@@ -172,7 +172,19 @@ namespace Parsek.Tests
             var segments = new List<OrbitSegment>
             {
                 MakeSegment(100, 200, "Kerbin"),
-                MakeSegment(240, 400, "Kerbin")
+                new OrbitSegment
+                {
+                    startUT = 240,
+                    endUT = 400,
+                    inclination = 28.5,
+                    eccentricity = 0.001,
+                    semiMajorAxis = 700000,
+                    longitudeOfAscendingNode = 90,
+                    argumentOfPeriapsis = 45,
+                    meanAnomalyAtEpoch = 2.5,
+                    epoch = 240,
+                    bodyName = "Kerbin"
+                }
             };
 
             var result = TrajectoryMath.FindOrbitSegmentForMapDisplay(segments, 220);
@@ -189,7 +201,19 @@ namespace Parsek.Tests
             var segments = new List<OrbitSegment>
             {
                 MakeSegment(100, 200, "Kerbin"),
-                MakeSegment(240, 400, "Kerbin")
+                new OrbitSegment
+                {
+                    startUT = 240,
+                    endUT = 400,
+                    inclination = 28.5,
+                    eccentricity = 0.001,
+                    semiMajorAxis = 700000,
+                    longitudeOfAscendingNode = 90,
+                    argumentOfPeriapsis = 45,
+                    meanAnomalyAtEpoch = 2.5,
+                    epoch = 240,
+                    bodyName = "Kerbin"
+                }
             };
 
             bool found = TrajectoryMath.TryGetOrbitSegmentForMapDisplay(
@@ -199,6 +223,53 @@ namespace Parsek.Tests
             Assert.Equal(100, segment.startUT);
             Assert.Equal(100, visibleStartUT);
             Assert.Equal(240, visibleEndUT);
+        }
+
+        [Fact]
+        public void FindOrbitSegmentForMapDisplay_UTInSameBodyDifferentOrbitGap_ReturnsNull()
+        {
+            var segments = new List<OrbitSegment>
+            {
+                MakeSegment(100, 200, "Kerbin"),
+                new OrbitSegment
+                {
+                    startUT = 240,
+                    endUT = 400,
+                    inclination = 28.5,
+                    eccentricity = 0.001,
+                    semiMajorAxis = 710000,
+                    longitudeOfAscendingNode = 90,
+                    argumentOfPeriapsis = 45,
+                    meanAnomalyAtEpoch = 2.5,
+                    epoch = 240,
+                    bodyName = "Kerbin"
+                }
+            };
+
+            var result = TrajectoryMath.FindOrbitSegmentForMapDisplay(segments, 220);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void AreOrbitSegmentsEquivalentForMapDisplay_IgnoresEpochAndMeanAnomaly()
+        {
+            var a = MakeSegment(100, 200, "Kerbin");
+            var b = MakeSegment(240, 400, "Kerbin");
+            b.meanAnomalyAtEpoch = 2.5;
+            b.epoch = 240;
+
+            Assert.True(TrajectoryMath.AreOrbitSegmentsEquivalentForMapDisplay(a, b));
+        }
+
+        [Fact]
+        public void AreOrbitSegmentsEquivalentForMapDisplay_RejectsSameBodyOrbitChange()
+        {
+            var a = MakeSegment(100, 200, "Kerbin");
+            var b = MakeSegment(240, 400, "Kerbin");
+            b.semiMajorAxis = 710000;
+
+            Assert.False(TrajectoryMath.AreOrbitSegmentsEquivalentForMapDisplay(a, b));
         }
 
         [Fact]

--- a/Source/Parsek.Tests/OrbitSegmentTests.cs
+++ b/Source/Parsek.Tests/OrbitSegmentTests.cs
@@ -184,6 +184,24 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void TryGetOrbitSegmentForMapDisplay_UTInSameBodyGap_ExtendsVisibleWindowToNextStart()
+        {
+            var segments = new List<OrbitSegment>
+            {
+                MakeSegment(100, 200, "Kerbin"),
+                MakeSegment(240, 400, "Kerbin")
+            };
+
+            bool found = TrajectoryMath.TryGetOrbitSegmentForMapDisplay(
+                segments, 220, out OrbitSegment segment, out double visibleStartUT, out double visibleEndUT);
+
+            Assert.True(found);
+            Assert.Equal(100, segment.startUT);
+            Assert.Equal(100, visibleStartUT);
+            Assert.Equal(240, visibleEndUT);
+        }
+
+        [Fact]
         public void FindOrbitSegmentForMapDisplay_UTInDifferentBodyGap_ReturnsNull()
         {
             var segments = new List<OrbitSegment>
@@ -195,6 +213,24 @@ namespace Parsek.Tests
             var result = TrajectoryMath.FindOrbitSegmentForMapDisplay(segments, 220);
 
             Assert.Null(result);
+        }
+
+        [Fact]
+        public void TryGetOrbitSegmentForMapDisplay_UTInDifferentBodyGap_ReturnsFalse()
+        {
+            var segments = new List<OrbitSegment>
+            {
+                MakeSegment(100, 200, "Kerbin"),
+                MakeSegment(240, 400, "Mun")
+            };
+
+            bool found = TrajectoryMath.TryGetOrbitSegmentForMapDisplay(
+                segments, 220, out OrbitSegment segment, out double visibleStartUT, out double visibleEndUT);
+
+            Assert.False(found);
+            Assert.Equal(default(OrbitSegment), segment);
+            Assert.Equal(0, visibleStartUT);
+            Assert.Equal(0, visibleEndUT);
         }
 
         [Fact]

--- a/Source/Parsek.Tests/OrbitSegmentTests.cs
+++ b/Source/Parsek.Tests/OrbitSegmentTests.cs
@@ -166,6 +166,51 @@ namespace Parsek.Tests
             Assert.Null(result);
         }
 
+        [Fact]
+        public void FindOrbitSegmentForMapDisplay_UTInSameBodyGap_CarriesPreviousSegment()
+        {
+            var segments = new List<OrbitSegment>
+            {
+                MakeSegment(100, 200, "Kerbin"),
+                MakeSegment(240, 400, "Kerbin")
+            };
+
+            var result = TrajectoryMath.FindOrbitSegmentForMapDisplay(segments, 220);
+
+            Assert.NotNull(result);
+            Assert.Equal(100, result.Value.startUT);
+            Assert.Equal(200, result.Value.endUT);
+            Assert.Equal("Kerbin", result.Value.bodyName);
+        }
+
+        [Fact]
+        public void FindOrbitSegmentForMapDisplay_UTInDifferentBodyGap_ReturnsNull()
+        {
+            var segments = new List<OrbitSegment>
+            {
+                MakeSegment(100, 200, "Kerbin"),
+                MakeSegment(240, 400, "Mun")
+            };
+
+            var result = TrajectoryMath.FindOrbitSegmentForMapDisplay(segments, 220);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void FindOrbitSegmentForMapDisplay_UTPastLastSegment_ReturnsNull()
+        {
+            var segments = new List<OrbitSegment>
+            {
+                MakeSegment(100, 200, "Kerbin"),
+                MakeSegment(240, 400, "Kerbin")
+            };
+
+            var result = TrajectoryMath.FindOrbitSegmentForMapDisplay(segments, 450);
+
+            Assert.Null(result);
+        }
+
         #endregion
 
         #region OrbitSegment Serialization

--- a/Source/Parsek.Tests/OrbitSegmentTests.cs
+++ b/Source/Parsek.Tests/OrbitSegmentTests.cs
@@ -196,7 +196,7 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void TryGetOrbitSegmentForMapDisplay_UTInSameBodyGap_ExtendsVisibleWindowToNextStart()
+        public void TryGetOrbitSegmentForMapDisplay_UTInSameBodyGap_MergesEquivalentWindowAcrossGap()
         {
             var segments = new List<OrbitSegment>
             {
@@ -213,6 +213,19 @@ namespace Parsek.Tests
                     meanAnomalyAtEpoch = 2.5,
                     epoch = 240,
                     bodyName = "Kerbin"
+                },
+                new OrbitSegment
+                {
+                    startUT = 430,
+                    endUT = 600,
+                    inclination = 28.5,
+                    eccentricity = 0.001,
+                    semiMajorAxis = 700000,
+                    longitudeOfAscendingNode = 90,
+                    argumentOfPeriapsis = 45,
+                    meanAnomalyAtEpoch = 3.1,
+                    epoch = 430,
+                    bodyName = "Kerbin"
                 }
             };
 
@@ -222,7 +235,93 @@ namespace Parsek.Tests
             Assert.True(found);
             Assert.Equal(100, segment.startUT);
             Assert.Equal(100, visibleStartUT);
-            Assert.Equal(240, visibleEndUT);
+            Assert.Equal(600, visibleEndUT);
+        }
+
+        [Fact]
+        public void TryGetOrbitSegmentForMapDisplay_UTInsideEquivalentSegmentChain_MergesPastAndFutureSegments()
+        {
+            var segments = new List<OrbitSegment>
+            {
+                MakeSegment(100, 200, "Kerbin"),
+                new OrbitSegment
+                {
+                    startUT = 240,
+                    endUT = 400,
+                    inclination = 28.5,
+                    eccentricity = 0.001,
+                    semiMajorAxis = 700000,
+                    longitudeOfAscendingNode = 90,
+                    argumentOfPeriapsis = 45,
+                    meanAnomalyAtEpoch = 2.5,
+                    epoch = 240,
+                    bodyName = "Kerbin"
+                },
+                new OrbitSegment
+                {
+                    startUT = 430,
+                    endUT = 600,
+                    inclination = 28.5,
+                    eccentricity = 0.001,
+                    semiMajorAxis = 700000,
+                    longitudeOfAscendingNode = 90,
+                    argumentOfPeriapsis = 45,
+                    meanAnomalyAtEpoch = 3.1,
+                    epoch = 430,
+                    bodyName = "Kerbin"
+                }
+            };
+
+            bool found = TrajectoryMath.TryGetOrbitSegmentForMapDisplay(
+                segments, 300, out OrbitSegment segment, out double visibleStartUT, out double visibleEndUT);
+
+            Assert.True(found);
+            Assert.Equal(240, segment.startUT);
+            Assert.Equal(100, visibleStartUT);
+            Assert.Equal(600, visibleEndUT);
+        }
+
+        [Fact]
+        public void TryGetOrbitSegmentForMapDisplay_UTInsideEquivalentRun_StopsAtOrbitChangeBoundary()
+        {
+            var segments = new List<OrbitSegment>
+            {
+                MakeSegment(100, 200, "Kerbin"),
+                new OrbitSegment
+                {
+                    startUT = 240,
+                    endUT = 400,
+                    inclination = 28.5,
+                    eccentricity = 0.001,
+                    semiMajorAxis = 700000,
+                    longitudeOfAscendingNode = 90,
+                    argumentOfPeriapsis = 45,
+                    meanAnomalyAtEpoch = 2.5,
+                    epoch = 240,
+                    bodyName = "Kerbin"
+                },
+                new OrbitSegment
+                {
+                    startUT = 430,
+                    endUT = 600,
+                    inclination = 28.5,
+                    eccentricity = 0.001,
+                    semiMajorAxis = 710000,
+                    longitudeOfAscendingNode = 90,
+                    argumentOfPeriapsis = 45,
+                    meanAnomalyAtEpoch = 3.1,
+                    epoch = 430,
+                    bodyName = "Kerbin"
+                }
+            };
+
+            bool found = TrajectoryMath.TryGetOrbitSegmentForMapDisplay(
+                segments, 300, out OrbitSegment segment, out double visibleStartUT, out double visibleEndUT);
+
+            Assert.True(found);
+            Assert.Equal(240, segment.startUT);
+            Assert.Equal(100, visibleStartUT);
+            Assert.Equal(400, visibleEndUT);
         }
 
         [Fact]

--- a/Source/Parsek/GhostMapPresence.cs
+++ b/Source/Parsek/GhostMapPresence.cs
@@ -1016,15 +1016,66 @@ namespace Parsek
                 && committed != null
                 && recordingIndex < committed.Count
                 && committed[recordingIndex].HasOrbitSegments
-                && TrajectoryMath.TryGetOrbitSegmentForMapDisplay(
+                && TrajectoryMath.TryGetOrbitWindowForMapDisplay(
                     committed[recordingIndex].OrbitSegments, currentUT,
-                    out _, out startUT, out endUT))
+                    out OrbitSegment segment,
+                    out startUT,
+                    out endUT,
+                    out int firstVisibleIndex,
+                    out int lastVisibleIndex,
+                    out bool carriedAcrossGap))
+            {
+                ParsekLog.VerboseRateLimited(Tag,
+                    string.Format(ic,
+                        "visible-window-{0}-{1:F3}-{2:F3}-{3:F3}-{4:F3}-{5}",
+                        vesselPid,
+                        segment.startUT,
+                        segment.endUT,
+                        startUT,
+                        endUT,
+                        carriedAcrossGap ? "gap" : "segment"),
+                    string.Format(ic,
+                        "Map-visible orbit window pid={0} recIndex={1} ut={2:F2} body={3} " +
+                        "segmentUT={4:F2}-{5:F2} windowUT={6:F2}-{7:F2} windowIndices={8}-{9} gapCarry={10}",
+                        vesselPid,
+                        recordingIndex,
+                        currentUT,
+                        segment.bodyName,
+                        segment.startUT,
+                        segment.endUT,
+                        startUT,
+                        endUT,
+                        firstVisibleIndex,
+                        lastVisibleIndex,
+                        carriedAcrossGap),
+                    1.0);
                 return true;
+            }
+
+            if (recordingIndex >= 0
+                && committed != null
+                && recordingIndex < committed.Count
+                && committed[recordingIndex].HasOrbitSegments)
+            {
+                ParsekLog.VerboseRateLimited(Tag,
+                    "visible-window-none-" + vesselPid,
+                    string.Format(ic,
+                        "Map-visible orbit window unavailable pid={0} recIndex={1} ut={2:F2} — " +
+                        "no active or equivalent same-orbit segment chain",
+                        vesselPid, recordingIndex, currentUT),
+                    1.0);
+            }
 
             if (ghostOrbitBounds.TryGetValue(vesselPid, out var bounds))
             {
                 startUT = bounds.startUT;
                 endUT = bounds.endUT;
+                ParsekLog.VerboseRateLimited(Tag,
+                    string.Format(ic, "visible-window-fallback-{0}-{1:F3}-{2:F3}", vesselPid, startUT, endUT),
+                    string.Format(ic,
+                        "Map-visible orbit window pid={0} source=stored-bounds ut={1:F2} windowUT={2:F2}-{3:F2}",
+                        vesselPid, currentUT, startUT, endUT),
+                    1.0);
                 return true;
             }
 

--- a/Source/Parsek/GhostMapPresence.cs
+++ b/Source/Parsek/GhostMapPresence.cs
@@ -460,7 +460,7 @@ namespace Parsek
         {
             double currentUT = Planetarium.GetUniversalTime();
             var committed = RecordingStore.CommittedRecordings;
-            if (committed == null || committed.Count == 0) return;
+            bool hasCommittedRecordings = committed != null && committed.Count > 0;
 
             // --- Phase 1: refresh existing segment-based ghosts or remove exhausted ones ---
             if (vesselsByRecordingIndex.Count > 0)
@@ -469,6 +469,13 @@ namespace Parsek
                 foreach (var kvp in vesselsByRecordingIndex)
                 {
                     int idx = kvp.Key;
+                    if (!hasCommittedRecordings)
+                    {
+                        if (toRemove == null) toRemove = new List<int>();
+                        toRemove.Add(idx);
+                        continue;
+                    }
+
                     uint pid = kvp.Value.persistentId;
                     if (!ghostOrbitBounds.TryGetValue(pid, out var bounds)) continue;
 
@@ -504,6 +511,12 @@ namespace Parsek
                                 idx, currentUT));
                     }
                 }
+            }
+
+            if (!hasCommittedRecordings)
+            {
+                CachedSupersededIds = new HashSet<string>();
+                return;
             }
 
             // --- Phase 2: create ghosts for recordings that just entered visible orbit range ---

--- a/Source/Parsek/GhostMapPresence.cs
+++ b/Source/Parsek/GhostMapPresence.cs
@@ -449,8 +449,9 @@ namespace Parsek
 
         /// <summary>
         /// Per-frame lifecycle for tracking station ghost ProtoVessels.
-        /// Creates ghosts when UT enters an orbit segment range (handles time warp),
-        /// and removes them when UT passes the segment endUT.
+        /// Creates ghosts when UT enters a map-visible orbit range (handles time warp),
+        /// carries them across brief same-body gaps, and removes them when the visible
+        /// orbit range is truly exhausted.
         /// Called periodically from ParsekTrackingStation.Update.
         /// In the flight scene, this lifecycle is handled by ParsekPlaybackPolicy.CheckPendingMapVessels;
         /// in the tracking station, this method provides the equivalent.
@@ -458,21 +459,37 @@ namespace Parsek
         internal static void UpdateTrackingStationGhostLifecycle()
         {
             double currentUT = Planetarium.GetUniversalTime();
+            var committed = RecordingStore.CommittedRecordings;
+            if (committed == null || committed.Count == 0) return;
 
-            // --- Phase 1: remove expired ghosts ---
+            // --- Phase 1: refresh existing segment-based ghosts or remove exhausted ones ---
             if (vesselsByRecordingIndex.Count > 0)
             {
                 List<int> toRemove = null;
                 foreach (var kvp in vesselsByRecordingIndex)
                 {
+                    int idx = kvp.Key;
                     uint pid = kvp.Value.persistentId;
                     if (!ghostOrbitBounds.TryGetValue(pid, out var bounds)) continue;
 
-                    if (currentUT > bounds.endUT)
+                    if (idx < 0 || idx >= committed.Count)
                     {
                         if (toRemove == null) toRemove = new List<int>();
-                        toRemove.Add(kvp.Key);
+                        toRemove.Add(idx);
+                        continue;
                     }
+
+                    var rec = committed[idx];
+                    OrbitSegment? seg = TrajectoryMath.FindOrbitSegmentForMapDisplay(rec.OrbitSegments, currentUT);
+                    if (!seg.HasValue)
+                    {
+                        if (toRemove == null) toRemove = new List<int>();
+                        toRemove.Add(idx);
+                        continue;
+                    }
+
+                    if (bounds.startUT != seg.Value.startUT || bounds.endUT != seg.Value.endUT)
+                        UpdateGhostOrbitForRecording(idx, seg.Value);
                 }
 
                 if (toRemove != null)
@@ -483,16 +500,13 @@ namespace Parsek
                         RemoveGhostVesselForRecording(idx, "tracking-station-expired");
                         ParsekLog.Info(Tag,
                             string.Format(ic,
-                                "Removed expired ghost #{0} — UT {1:F1} past segment endUT",
+                                "Removed expired ghost #{0} — UT {1:F1} past visible orbit range",
                                 idx, currentUT));
                     }
                 }
             }
 
-            // --- Phase 2: create ghosts for recordings that just entered orbit segment range ---
-            var committed = RecordingStore.CommittedRecordings;
-            if (committed == null || committed.Count == 0) return;
-
+            // --- Phase 2: create ghosts for recordings that just entered visible orbit range ---
             // Compute once per tick — also used by ParsekTrackingStation.OnGUI via CachedSupersededIds
             var superseded = FindSupersededRecordingIds(committed);
             CachedSupersededIds = superseded;
@@ -514,7 +528,7 @@ namespace Parsek
                 }
                 else if (rec.HasOrbitSegments)
                 {
-                    OrbitSegment? seg = TrajectoryMath.FindOrbitSegment(rec.OrbitSegments, currentUT);
+                    OrbitSegment? seg = TrajectoryMath.FindOrbitSegmentForMapDisplay(rec.OrbitSegments, currentUT);
                     if (seg.HasValue)
                         v = CreateGhostVesselFromSegment(i, rec, seg.Value);
                 }
@@ -525,7 +539,7 @@ namespace Parsek
                     EnsureGhostOrbitRenderers();
                     ParsekLog.Info(Tag,
                         string.Format(ic,
-                            "Deferred ghost creation for #{0} \"{1}\" — UT {2:F1} entered orbit segment",
+                            "Deferred ghost creation for #{0} \"{1}\" — UT {2:F1} entered visible orbit range",
                             i, rec.VesselName ?? "(null)", currentUT));
                 }
             }
@@ -791,7 +805,7 @@ namespace Parsek
             // Orbit segments: find the one matching currentUT
             if (rec.HasOrbitSegments)
             {
-                OrbitSegment? seg = TrajectoryMath.FindOrbitSegment(rec.OrbitSegments, currentUT);
+                OrbitSegment? seg = TrajectoryMath.FindOrbitSegmentForMapDisplay(rec.OrbitSegments, currentUT);
                 if (seg.HasValue)
                     return (true, null);
                 return (false, "no-current-segment");
@@ -841,7 +855,7 @@ namespace Parsek
                 }
                 else if (rec.HasOrbitSegments)
                 {
-                    OrbitSegment? seg = TrajectoryMath.FindOrbitSegment(rec.OrbitSegments, currentUT);
+                    OrbitSegment? seg = TrajectoryMath.FindOrbitSegmentForMapDisplay(rec.OrbitSegments, currentUT);
                     if (seg.HasValue)
                         v = CreateGhostVesselFromSegment(i, rec, seg.Value);
                 }

--- a/Source/Parsek/GhostMapPresence.cs
+++ b/Source/Parsek/GhostMapPresence.cs
@@ -987,6 +987,38 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Resolve the visible orbit time window for a ghost vessel at the current UT.
+        /// Recording-index ghosts use dynamic same-body gap carry; other segment-based
+        /// ghosts fall back to their stored bounds.
+        /// </summary>
+        internal static bool TryGetVisibleOrbitBoundsForGhostVessel(
+            uint vesselPid, double currentUT, out double startUT, out double endUT)
+        {
+            startUT = 0;
+            endUT = 0;
+
+            int recordingIndex = FindRecordingIndexByVesselPid(vesselPid);
+            var committed = RecordingStore.CommittedRecordings;
+            if (recordingIndex >= 0
+                && committed != null
+                && recordingIndex < committed.Count
+                && committed[recordingIndex].HasOrbitSegments
+                && TrajectoryMath.TryGetOrbitSegmentForMapDisplay(
+                    committed[recordingIndex].OrbitSegments, currentUT,
+                    out _, out startUT, out endUT))
+                return true;
+
+            if (ghostOrbitBounds.TryGetValue(vesselPid, out var bounds))
+            {
+                startUT = bounds.startUT;
+                endUT = bounds.endUT;
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Reset all state for testing (avoids Debug.Log crash outside Unity).
         /// </summary>
         internal static void ResetForTesting()

--- a/Source/Parsek/ParsekPlaybackPolicy.cs
+++ b/Source/Parsek/ParsekPlaybackPolicy.cs
@@ -721,7 +721,7 @@ namespace Parsek
                     IPlaybackTrajectory traj = kvp.Value;
 
                     // Path A: orbit-segment-based (existing)
-                    OrbitSegment? seg = TrajectoryMath.FindOrbitSegment(traj.OrbitSegments, currentUT);
+                    OrbitSegment? seg = TrajectoryMath.FindOrbitSegmentForMapDisplay(traj.OrbitSegments, currentUT);
                     if (seg.HasValue)
                     {
                         if (toCreateFromSegment == null)
@@ -821,10 +821,10 @@ namespace Parsek
                 var rec = committed[idx];
                 if (!rec.HasOrbitSegments) continue;
 
-                OrbitSegment? seg = TrajectoryMath.FindOrbitSegment(rec.OrbitSegments, currentUT);
+                OrbitSegment? seg = TrajectoryMath.FindOrbitSegmentForMapDisplay(rec.OrbitSegments, currentUT);
 
-                // No orbit segment at current UT — either in a gap between segments or
-                // truly past all segments. Check if future segments exist.
+                // No map-visible orbit at current UT — either we've truly left orbital
+                // playback, or the next segment is in a different SOI/body.
                 if (!seg.HasValue)
                 {
                     bool hasFutureSegment = false;

--- a/Source/Parsek/Patches/GhostOrbitLinePatch.cs
+++ b/Source/Parsek/Patches/GhostOrbitLinePatch.cs
@@ -47,36 +47,37 @@ namespace Parsek.Patches
 
             uint pid = __instance.vessel.persistentId;
             if (!GhostMapPresence.IsGhostMapVessel(pid)) return;
-            if (!GhostMapPresence.ghostOrbitBounds.TryGetValue(pid, out var bounds)) return;
+            double currentUT = Planetarium.GetUniversalTime();
+            if (!GhostMapPresence.TryGetVisibleOrbitBoundsForGhostVessel(
+                pid, currentUT, out double startUT, out double endUT))
+                return;
 
             Orbit orbit = __instance.orbit;
             if (orbit == null || orbit.eccentricity >= 1.0 || orbit.period <= 0) return;
 
-            double currentUT = Planetarium.GetUniversalTime();
-
             // Past recording bounds → clamp to endUT so icon sits at last recorded position
-            if (currentUT > bounds.endUT)
+            if (currentUT > endUT)
             {
-                orbit.UpdateFromUT(bounds.endUT);
+                orbit.UpdateFromUT(endUT);
                 GhostMapPresence.ghostsWithSuppressedIcon.Add(pid);
                 return;
             }
-            if (currentUT < bounds.startUT)
+            if (currentUT < startUT)
             {
-                orbit.UpdateFromUT(bounds.startUT);
+                orbit.UpdateFromUT(startUT);
                 GhostMapPresence.ghostsWithSuppressedIcon.Add(pid);
                 return;
             }
 
             // Within bounds — check if on the visible arc
-            bool onArc = GhostOrbitArcCheck.IsOnOrbitalArc(orbit, bounds.startUT, bounds.endUT, currentUT);
+            bool onArc = GhostOrbitArcCheck.IsOnOrbitalArc(orbit, startUT, endUT, currentUT);
             if (!onArc)
             {
                 // Off the visible arc (underground) — clamp to the nearest arc endpoint
                 double period = orbit.period;
                 double obtNow = ((orbit.getObtAtUT(currentUT) % period) + period) % period;
-                double obtStart = ((orbit.getObtAtUT(bounds.startUT) % period) + period) % period;
-                double obtEnd = ((orbit.getObtAtUT(bounds.endUT) % period) + period) % period;
+                double obtStart = ((orbit.getObtAtUT(startUT) % period) + period) % period;
+                double obtEnd = ((orbit.getObtAtUT(endUT) % period) + period) % period;
 
                 // Pick the closer endpoint in orbital-time space
                 double distToStart, distToEnd;
@@ -93,14 +94,14 @@ namespace Parsek.Patches
                     distToEnd = (obtNow >= obtEnd) ? (obtNow - obtEnd) : (obtNow + period - obtEnd);
                 }
 
-                double clampUT = (distToEnd <= distToStart) ? bounds.endUT : bounds.startUT;
+                double clampUT = (distToEnd <= distToStart) ? endUT : startUT;
                 orbit.UpdateFromUT(clampUT);
                 GhostMapPresence.ghostsWithSuppressedIcon.Add(pid);
 
                 ParsekLog.VerboseRateLimited("GhostOrbitIcon", "clamp-" + pid,
                     string.Format(System.Globalization.CultureInfo.InvariantCulture,
                         "Icon clamped pid={0} UT={1:F1} clampUT={2:F1} bounds=[{3:F1},{4:F1}]",
-                        pid, currentUT, clampUT, bounds.startUT, bounds.endUT));
+                        pid, currentUT, clampUT, startUT, endUT));
                 return;
             }
 
@@ -144,10 +145,11 @@ namespace Parsek.Patches
 
             // Segment-based ghosts: the orbit line is clipped by GhostOrbitArcPatch.
             // When UT is past the recording bounds, hide the line entirely.
-            if (GhostMapPresence.ghostOrbitBounds.TryGetValue(pid, out var timeBounds))
+            double currentUT = Planetarium.GetUniversalTime();
+            if (GhostMapPresence.TryGetVisibleOrbitBoundsForGhostVessel(
+                pid, currentUT, out double startUT, out double endUT))
             {
-                double currentUT = Planetarium.GetUniversalTime();
-                if (currentUT > timeBounds.endUT || currentUT < timeBounds.startUT || belowAtmosphere)
+                if (currentUT > endUT || currentUT < startUT || belowAtmosphere)
                 {
                     line.active = false;
                     __instance.drawIcons = OrbitRendererBase.DrawIcons.NONE;
@@ -229,7 +231,9 @@ namespace Parsek.Patches
             if (__instance.vessel == null) return true;
             uint pid = __instance.vessel.persistentId;
             if (!GhostMapPresence.IsGhostMapVessel(pid)) return true;
-            if (!GhostMapPresence.ghostOrbitBounds.TryGetValue(pid, out var bounds))
+            double currentUT = Planetarium.GetUniversalTime();
+            if (!GhostMapPresence.TryGetVisibleOrbitBoundsForGhostVessel(
+                pid, currentUT, out double startUT, out double endUT))
             {
                 ParsekLog.VerboseRateLimited(Tag, "nobounds-" + pid,
                     string.Format(System.Globalization.CultureInfo.InvariantCulture,
@@ -243,11 +247,11 @@ namespace Parsek.Patches
             if (orbit.eccentricity >= 1.0) return true; // let stock handle hyperbolic
 
             // Full orbit or more — let stock draw the complete ellipse
-            if (bounds.endUT - bounds.startUT >= orbit.period) return true;
+            if (endUT - startUT >= orbit.period) return true;
 
             // Convert UT bounds to eccentric anomaly (same as PatchRendering/Trajectory)
-            double fromE = orbit.EccentricAnomalyAtUT(bounds.startUT);
-            double toE = orbit.EccentricAnomalyAtUT(bounds.endUT);
+            double fromE = orbit.EccentricAnomalyAtUT(startUT);
+            double toE = orbit.EccentricAnomalyAtUT(endUT);
 
             // NaN guard — degenerate orbits or UT outside validity
             if (double.IsNaN(fromE) || double.IsNaN(toE)) return true;

--- a/Source/Parsek/TrajectoryMath.cs
+++ b/Source/Parsek/TrajectoryMath.cs
@@ -130,6 +130,58 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Map-view policy helper: return the active orbit segment for the given UT plus
+        /// the visible time bounds to use for map-line/icon continuity. During a same-body
+        /// gap, the previous segment remains the active orbit and visibility extends until
+        /// the next segment starts so the ghost ProtoVessel does not disappear mid-SOI.
+        /// </summary>
+        internal static bool TryGetOrbitSegmentForMapDisplay(
+            List<OrbitSegment> segments, double ut,
+            out OrbitSegment segment, out double visibleStartUT, out double visibleEndUT)
+        {
+            segment = default(OrbitSegment);
+            visibleStartUT = 0;
+            visibleEndUT = 0;
+
+            OrbitSegment? current = FindOrbitSegment(segments, ut);
+            if (current.HasValue)
+            {
+                segment = current.Value;
+                visibleStartUT = current.Value.startUT;
+                visibleEndUT = current.Value.endUT;
+                return true;
+            }
+
+            if (segments == null || segments.Count < 2)
+                return false;
+
+            OrbitSegment? previous = null;
+            for (int i = 0; i < segments.Count; i++)
+            {
+                OrbitSegment candidate = segments[i];
+                if (candidate.endUT <= ut)
+                {
+                    previous = candidate;
+                    continue;
+                }
+
+                if (!previous.HasValue || candidate.startUT <= ut)
+                    return false;
+
+                if (string.IsNullOrEmpty(previous.Value.bodyName)
+                    || !string.Equals(previous.Value.bodyName, candidate.bodyName, System.StringComparison.Ordinal))
+                    return false;
+
+                segment = previous.Value;
+                visibleStartUT = previous.Value.startUT;
+                visibleEndUT = candidate.startUT;
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Map-view policy helper: return the active orbit segment for the given UT, or
         /// carry the immediately preceding segment across a gap when the next segment stays
         /// in the same SOI/body. This avoids fragmenting ghost orbit lines across brief
@@ -137,31 +189,10 @@ namespace Parsek
         /// </summary>
         internal static OrbitSegment? FindOrbitSegmentForMapDisplay(List<OrbitSegment> segments, double ut)
         {
-            OrbitSegment? current = FindOrbitSegment(segments, ut);
-            if (current.HasValue || segments == null || segments.Count < 2)
-                return current;
-
-            OrbitSegment? previous = null;
-            for (int i = 0; i < segments.Count; i++)
-            {
-                OrbitSegment segment = segments[i];
-                if (segment.endUT <= ut)
-                {
-                    previous = segment;
-                    continue;
-                }
-
-                if (!previous.HasValue || segment.startUT <= ut)
-                    return null;
-
-                return string.IsNullOrEmpty(previous.Value.bodyName)
-                    ? (OrbitSegment?)null
-                    : (string.Equals(previous.Value.bodyName, segment.bodyName, System.StringComparison.Ordinal)
-                        ? previous
-                        : (OrbitSegment?)null);
-            }
-
-            return null;
+            return TryGetOrbitSegmentForMapDisplay(segments, ut,
+                out OrbitSegment segment, out _, out _)
+                ? (OrbitSegment?)segment
+                : null;
         }
 
         /// <summary>

--- a/Source/Parsek/TrajectoryMath.cs
+++ b/Source/Parsek/TrajectoryMath.cs
@@ -157,55 +157,121 @@ namespace Parsek
             return delta > 180.0 ? 360.0 - delta : delta;
         }
 
+        private static void ExpandEquivalentOrbitWindow(
+            List<OrbitSegment> segments,
+            int seedFirstIndex,
+            int seedLastIndex,
+            out double visibleStartUT,
+            out double visibleEndUT,
+            out int firstVisibleIndex,
+            out int lastVisibleIndex)
+        {
+            firstVisibleIndex = seedFirstIndex;
+            while (firstVisibleIndex > 0
+                && AreOrbitSegmentsEquivalentForMapDisplay(
+                    segments[firstVisibleIndex - 1], segments[firstVisibleIndex]))
+            {
+                firstVisibleIndex--;
+            }
+
+            lastVisibleIndex = seedLastIndex;
+            while (lastVisibleIndex < segments.Count - 1
+                && AreOrbitSegmentsEquivalentForMapDisplay(
+                    segments[lastVisibleIndex], segments[lastVisibleIndex + 1]))
+            {
+                lastVisibleIndex++;
+            }
+
+            visibleStartUT = segments[firstVisibleIndex].startUT;
+            visibleEndUT = segments[lastVisibleIndex].endUT;
+        }
+
         /// <summary>
         /// Map-view policy helper: return the active orbit segment for the given UT plus
-        /// the visible time bounds to use for map-line/icon continuity. During a same-body
-        /// gap, the previous segment remains the active orbit and visibility extends until
-        /// the next segment starts so the ghost ProtoVessel does not disappear mid-SOI.
+        /// the merged visible time bounds to use for map-line/icon continuity.
+        /// Equivalent same-body segments are expanded into one continuous visible window,
+        /// including brief gaps between them, so prerecorded same-SOI journeys render as
+        /// one uninterrupted map line.
         /// </summary>
-        internal static bool TryGetOrbitSegmentForMapDisplay(
-            List<OrbitSegment> segments, double ut,
-            out OrbitSegment segment, out double visibleStartUT, out double visibleEndUT)
+        internal static bool TryGetOrbitWindowForMapDisplay(
+            List<OrbitSegment> segments,
+            double ut,
+            out OrbitSegment segment,
+            out double visibleStartUT,
+            out double visibleEndUT,
+            out int firstVisibleIndex,
+            out int lastVisibleIndex,
+            out bool carriedAcrossGap)
         {
             segment = default(OrbitSegment);
             visibleStartUT = 0;
             visibleEndUT = 0;
+            firstVisibleIndex = -1;
+            lastVisibleIndex = -1;
+            carriedAcrossGap = false;
 
-            OrbitSegment? current = FindOrbitSegment(segments, ut);
-            if (current.HasValue)
+            if (segments == null || segments.Count == 0)
+                return false;
+
+            for (int i = 0; i < segments.Count; i++)
             {
-                segment = current.Value;
-                visibleStartUT = current.Value.startUT;
-                visibleEndUT = current.Value.endUT;
+                bool inRange = (i == segments.Count - 1)
+                    ? (ut >= segments[i].startUT && ut <= segments[i].endUT)
+                    : (ut >= segments[i].startUT && ut < segments[i].endUT);
+                if (!inRange)
+                    continue;
+
+                segment = segments[i];
+                ExpandEquivalentOrbitWindow(
+                    segments, i, i,
+                    out visibleStartUT, out visibleEndUT,
+                    out firstVisibleIndex, out lastVisibleIndex);
                 return true;
             }
 
-            if (segments == null || segments.Count < 2)
+            if (segments.Count < 2)
                 return false;
 
-            OrbitSegment? previous = null;
+            int previousIndex = -1;
             for (int i = 0; i < segments.Count; i++)
             {
                 OrbitSegment candidate = segments[i];
                 if (candidate.endUT <= ut)
                 {
-                    previous = candidate;
+                    previousIndex = i;
                     continue;
                 }
 
-                if (!previous.HasValue || candidate.startUT <= ut)
+                if (previousIndex < 0 || candidate.startUT <= ut)
                     return false;
 
-                if (!AreOrbitSegmentsEquivalentForMapDisplay(previous.Value, candidate))
+                if (!AreOrbitSegmentsEquivalentForMapDisplay(segments[previousIndex], candidate))
                     return false;
 
-                segment = previous.Value;
-                visibleStartUT = previous.Value.startUT;
-                visibleEndUT = candidate.startUT;
+                segment = segments[previousIndex];
+                carriedAcrossGap = true;
+                ExpandEquivalentOrbitWindow(
+                    segments, previousIndex, i,
+                    out visibleStartUT, out visibleEndUT,
+                    out firstVisibleIndex, out lastVisibleIndex);
                 return true;
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Map-view policy helper: return the active orbit segment for the given UT plus
+        /// the visible time bounds to use for map-line/icon continuity.
+        /// </summary>
+        internal static bool TryGetOrbitSegmentForMapDisplay(
+            List<OrbitSegment> segments, double ut,
+            out OrbitSegment segment, out double visibleStartUT, out double visibleEndUT)
+        {
+            return TryGetOrbitWindowForMapDisplay(
+                segments, ut,
+                out segment, out visibleStartUT, out visibleEndUT,
+                out _, out _, out _);
         }
 
         /// <summary>

--- a/Source/Parsek/TrajectoryMath.cs
+++ b/Source/Parsek/TrajectoryMath.cs
@@ -130,6 +130,34 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Pure: returns true when two orbit segments represent the same underlying orbit
+        /// for map-display continuity purposes. Epoch and mean anomaly are intentionally
+        /// ignored because the same orbit can be serialized at different times.
+        /// </summary>
+        internal static bool AreOrbitSegmentsEquivalentForMapDisplay(OrbitSegment a, OrbitSegment b)
+        {
+            if (string.IsNullOrEmpty(a.bodyName)
+                || !string.Equals(a.bodyName, b.bodyName, System.StringComparison.Ordinal))
+                return false;
+
+            double smaTolerance = System.Math.Max(10.0, System.Math.Abs(a.semiMajorAxis) * 1e-6);
+            const double EccTolerance = 1e-5;
+            const double AngleToleranceDeg = 0.01;
+
+            return System.Math.Abs(a.semiMajorAxis - b.semiMajorAxis) <= smaTolerance
+                && System.Math.Abs(a.eccentricity - b.eccentricity) <= EccTolerance
+                && AngularDeltaDegrees(a.inclination, b.inclination) <= AngleToleranceDeg
+                && AngularDeltaDegrees(a.longitudeOfAscendingNode, b.longitudeOfAscendingNode) <= AngleToleranceDeg
+                && AngularDeltaDegrees(a.argumentOfPeriapsis, b.argumentOfPeriapsis) <= AngleToleranceDeg;
+        }
+
+        private static double AngularDeltaDegrees(double a, double b)
+        {
+            double delta = System.Math.Abs(a - b) % 360.0;
+            return delta > 180.0 ? 360.0 - delta : delta;
+        }
+
+        /// <summary>
         /// Map-view policy helper: return the active orbit segment for the given UT plus
         /// the visible time bounds to use for map-line/icon continuity. During a same-body
         /// gap, the previous segment remains the active orbit and visibility extends until
@@ -168,8 +196,7 @@ namespace Parsek
                 if (!previous.HasValue || candidate.startUT <= ut)
                     return false;
 
-                if (string.IsNullOrEmpty(previous.Value.bodyName)
-                    || !string.Equals(previous.Value.bodyName, candidate.bodyName, System.StringComparison.Ordinal))
+                if (!AreOrbitSegmentsEquivalentForMapDisplay(previous.Value, candidate))
                     return false;
 
                 segment = previous.Value;

--- a/Source/Parsek/TrajectoryMath.cs
+++ b/Source/Parsek/TrajectoryMath.cs
@@ -130,6 +130,41 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Map-view policy helper: return the active orbit segment for the given UT, or
+        /// carry the immediately preceding segment across a gap when the next segment stays
+        /// in the same SOI/body. This avoids fragmenting ghost orbit lines across brief
+        /// off-rails sections during a continuous same-body journey.
+        /// </summary>
+        internal static OrbitSegment? FindOrbitSegmentForMapDisplay(List<OrbitSegment> segments, double ut)
+        {
+            OrbitSegment? current = FindOrbitSegment(segments, ut);
+            if (current.HasValue || segments == null || segments.Count < 2)
+                return current;
+
+            OrbitSegment? previous = null;
+            for (int i = 0; i < segments.Count; i++)
+            {
+                OrbitSegment segment = segments[i];
+                if (segment.endUT <= ut)
+                {
+                    previous = segment;
+                    continue;
+                }
+
+                if (!previous.HasValue || segment.startUT <= ut)
+                    return null;
+
+                return string.IsNullOrEmpty(previous.Value.bodyName)
+                    ? (OrbitSegment?)null
+                    : (string.Equals(previous.Value.bodyName, segment.bodyName, System.StringComparison.Ordinal)
+                        ? previous
+                        : (OrbitSegment?)null);
+            }
+
+            return null;
+        }
+
+        /// <summary>
         /// Find the waypoint index for interpolation using cached lookup.
         /// Parameterized to work with any point list + cached index.
         /// </summary>


### PR DESCRIPTION
## Summary
- keep ghost map ProtoVessels alive across short gaps between orbit segments when the next segment stays in the same SOI/body
- use the same map-visible segment selection in both flight playback and tracking station ghost lifecycle
- add regression coverage for same-body gap carry behavior and cross-body gap rejection

## Verification
- focused tests passed: OrbitSegmentTests
- focused tests passed: GhostMapPresenceTests