### PR TITLE
Preserve watched ghost focus when entering map view

### DIFF
--- a/Source/Parsek.Tests/WatchModeControllerTests.cs
+++ b/Source/Parsek.Tests/WatchModeControllerTests.cs
@@ -372,5 +372,55 @@ namespace Parsek.Tests
             Assert.Equal(WatchCameraMode.Free, result);
         }
 
+        [Fact]
+        public void InitializeMapFocusRestoreState_MapAlreadyOpen_PrimesOneShotRestore()
+        {
+            var (lastMapViewEnabled, pendingMapFocusRestore) =
+                WatchModeController.InitializeMapFocusRestoreState(mapViewEnabled: true);
+
+            Assert.True(lastMapViewEnabled);
+            Assert.True(pendingMapFocusRestore);
+        }
+
+        [Fact]
+        public void AdvanceMapFocusRestoreState_ReopeningMap_RearmsRestoreAttempt()
+        {
+            var (lastMapViewEnabled, pendingMapFocusRestore, shouldAttemptRestore) =
+                WatchModeController.AdvanceMapFocusRestoreState(
+                    lastMapViewEnabled: false,
+                    pendingMapFocusRestore: false,
+                    mapViewEnabled: true);
+
+            Assert.True(lastMapViewEnabled);
+            Assert.True(pendingMapFocusRestore);
+            Assert.True(shouldAttemptRestore);
+        }
+
+        [Fact]
+        public void AdvanceMapFocusRestoreState_MapStillOpenWithoutPendingRestore_DoesNotRefocusAgain()
+        {
+            var (lastMapViewEnabled, pendingMapFocusRestore, shouldAttemptRestore) =
+                WatchModeController.AdvanceMapFocusRestoreState(
+                    lastMapViewEnabled: true,
+                    pendingMapFocusRestore: false,
+                    mapViewEnabled: true);
+
+            Assert.True(lastMapViewEnabled);
+            Assert.False(pendingMapFocusRestore);
+            Assert.False(shouldAttemptRestore);
+        }
+
+        [Fact]
+        public void CanRestoreMapFocus_MissingMapObject_StaysDeferred()
+        {
+            bool canRestore = WatchModeController.CanRestoreMapFocus(
+                ghostPid: 123u,
+                hasGhostVessel: true,
+                hasMapObject: false,
+                hasPlanetariumCamera: true);
+
+            Assert.False(canRestore);
+        }
+
     }
 }

--- a/Source/Parsek/WatchModeController.cs
+++ b/Source/Parsek/WatchModeController.cs
@@ -875,8 +875,8 @@ namespace Parsek
             userModeOverride = false;
             currentCameraMode = WatchCameraMode.Free; // auto-detect will set this on first frame
             lastLoggedHorizonVectorKey = null;
-            lastMapViewEnabled = MapView.MapIsEnabled;
-            pendingMapFocusRestore = lastMapViewEnabled;
+            (lastMapViewEnabled, pendingMapFocusRestore) =
+                InitializeMapFocusRestoreState(MapView.MapIsEnabled);
             return true;
         }
 
@@ -1636,20 +1636,9 @@ namespace Parsek
 
         private void UpdateMapFocusRestore()
         {
-            bool mapViewEnabled = MapView.MapIsEnabled;
-            if (!mapViewEnabled)
-            {
-                lastMapViewEnabled = false;
-                pendingMapFocusRestore = false;
-                return;
-            }
-
-            if (!lastMapViewEnabled)
-                pendingMapFocusRestore = true;
-
-            lastMapViewEnabled = true;
-
-            if (!pendingMapFocusRestore)
+            (lastMapViewEnabled, pendingMapFocusRestore, bool shouldAttemptRestore) =
+                AdvanceMapFocusRestoreState(lastMapViewEnabled, pendingMapFocusRestore, MapView.MapIsEnabled);
+            if (!shouldAttemptRestore)
                 return;
 
             uint ghostPid = GhostMapPresence.GetGhostVesselPidForRecording(watchedRecordingIndex);
@@ -1666,13 +1655,50 @@ namespace Parsek
                 GhostMapPresence.EnsureGhostOrbitRenderers();
             }
 
-            if (PlanetariumCamera.fetch == null || ghostVessel.mapObject == null)
+            if (!CanRestoreMapFocus(
+                    ghostPid,
+                    ghostVessel != null,
+                    ghostVessel.mapObject != null,
+                    PlanetariumCamera.fetch != null))
                 return;
 
             PlanetariumCamera.fetch.SetTarget(ghostVessel.mapObject);
             pendingMapFocusRestore = false;
             ParsekLog.Info("GhostMap",
                 $"Restored map focus to watched ghost '{ghostVessel.vesselName}' (recIndex={watchedRecordingIndex})");
+        }
+
+        internal static (bool lastMapViewEnabled, bool pendingMapFocusRestore)
+            InitializeMapFocusRestoreState(bool mapViewEnabled)
+        {
+            return (mapViewEnabled, mapViewEnabled);
+        }
+
+        internal static (bool lastMapViewEnabled, bool pendingMapFocusRestore, bool shouldAttemptRestore)
+            AdvanceMapFocusRestoreState(
+                bool lastMapViewEnabled,
+                bool pendingMapFocusRestore,
+                bool mapViewEnabled)
+        {
+            if (!mapViewEnabled)
+                return (false, false, false);
+
+            if (!lastMapViewEnabled)
+                pendingMapFocusRestore = true;
+
+            return (true, pendingMapFocusRestore, pendingMapFocusRestore);
+        }
+
+        internal static bool CanRestoreMapFocus(
+            uint ghostPid,
+            bool hasGhostVessel,
+            bool hasMapObject,
+            bool hasPlanetariumCamera)
+        {
+            return ghostPid != 0
+                && hasGhostVessel
+                && hasMapObject
+                && hasPlanetariumCamera;
         }
 
         /// <summary>

--- a/Source/Parsek/WatchModeController.cs
+++ b/Source/Parsek/WatchModeController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using KSP.UI.Screens.Mapview;
 using UnityEngine;
 
 namespace Parsek
@@ -74,6 +75,8 @@ namespace Parsek
         private string lastLoggedWatchTargetMismatch;
         private string lastLoggedWatchFocusKey;
         private string lastLoggedHorizonVectorKey;
+        private bool lastMapViewEnabled;
+        private bool pendingMapFocusRestore;
 
         internal WatchModeController(ParsekFlight host)
         {
@@ -872,6 +875,8 @@ namespace Parsek
             userModeOverride = false;
             currentCameraMode = WatchCameraMode.Free; // auto-detect will set this on first frame
             lastLoggedHorizonVectorKey = null;
+            lastMapViewEnabled = MapView.MapIsEnabled;
+            pendingMapFocusRestore = lastMapViewEnabled;
             return true;
         }
 
@@ -908,6 +913,8 @@ namespace Parsek
             lastLoggedWatchTargetMismatch = null;
             lastLoggedWatchFocusKey = null;
             lastLoggedHorizonVectorKey = null;
+            lastMapViewEnabled = false;
+            pendingMapFocusRestore = false;
         }
 
         private void RestoreCameraAfterWatchExit(bool skipCameraRestore)
@@ -1043,6 +1050,8 @@ namespace Parsek
             savedCameraDistance = 0f;
             savedCameraPitch = 0f;
             savedCameraHeading = 0f;
+            lastMapViewEnabled = false;
+            pendingMapFocusRestore = false;
 
             if (overlapCameraAnchor == null)
                 return;
@@ -1566,6 +1575,8 @@ namespace Parsek
         {
             if (watchedRecordingIndex < 0) return;
 
+            UpdateMapFocusRestore();
+
             // Watch-end hold timer: after non-looped playback completes, the ghost
             // is held visible for a few seconds so the user sees the terminal state.
             // During the hold, try to auto-follow to a continuation ghost each frame
@@ -1621,6 +1632,47 @@ namespace Parsek
             UpdateHorizonProxy(state);
             LogWatchTargetMismatch(state);
             LogWatchFocusStateChanged(state);
+        }
+
+        private void UpdateMapFocusRestore()
+        {
+            bool mapViewEnabled = MapView.MapIsEnabled;
+            if (!mapViewEnabled)
+            {
+                lastMapViewEnabled = false;
+                pendingMapFocusRestore = false;
+                return;
+            }
+
+            if (!lastMapViewEnabled)
+                pendingMapFocusRestore = true;
+
+            lastMapViewEnabled = true;
+
+            if (!pendingMapFocusRestore)
+                return;
+
+            uint ghostPid = GhostMapPresence.GetGhostVesselPidForRecording(watchedRecordingIndex);
+            if (ghostPid == 0)
+                return;
+
+            Vessel ghostVessel = FlightRecorder.FindVesselByPid(ghostPid);
+            if (ghostVessel == null)
+                return;
+
+            if ((ghostVessel.mapObject == null || ghostVessel.orbitRenderer == null)
+                && MapView.fetch != null)
+            {
+                GhostMapPresence.EnsureGhostOrbitRenderers();
+            }
+
+            if (PlanetariumCamera.fetch == null || ghostVessel.mapObject == null)
+                return;
+
+            PlanetariumCamera.fetch.SetTarget(ghostVessel.mapObject);
+            pendingMapFocusRestore = false;
+            ParsekLog.Info("GhostMap",
+                $"Restored map focus to watched ghost '{ghostVessel.vesselName}' (recIndex={watchedRecordingIndex})");
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- restore map focus to the watched ghost when map view opens during watch mode
- wait until the watched ghost map vessel has a map object/orbit renderer before restoring focus
- keep the restore one-shot so manual map refocus still works after entry

## Testing
- dotnet build Source/Parsek/Parsek.csproj -c Debug
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj -c Debug --no-restore (6080 passed, 1 existing SecurityException failure in GhostPlaybackEngineTests.SpawnGhost_PrimesFreshGhostToCurrentPlaybackUT)