### PR TITLE
Fix pending-tree merge dialog persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- `#354` Active breakup-continuous tree recordings that end in a stable spawned state now get a fresh terminal snapshot during tree finalization, so effective-leaf orbital end-of-playback spawns no longer reuse the old post-breakup `_vessel.craft` node after the orbit itself has already been corrected.
 - `#353` High-warp orbital end-of-playback spawns now trim stable orbital boring tails against real activity instead of stale zero-throttle engine seed artifacts, then propagate stored terminal orbits to the current spawn UT and scrub stale packed-vessel/part atmospheric metadata before `ProtoVessel.Load()`, so stable-orbit recordings resolve around the normal 10-second boring-state buffer and deferred orbital spawns no longer mix an old endpoint state with a later planet rotation on the way into KSP's on-rails `SUB_ORBITAL`/`101.3 kPa` pressure kill path.
 - `#352` Pending-tree merge dialogs now evaluate active non-leaf vessels against the current tree structure instead of only committed trees, so breakup-continuous landings and splashdowns default to persist exactly when runtime playback would spawn them.
 - `#350` Boarded-EVA playback now preserves post-board flat trajectory tails when merged `TrackSections` are only a stale prefix, and single-point boarded leaf recordings now count as renderable playback/spawn data, so the last kerbal can finish the visible re-entry path and the final capsule with the re-boarded kerbal now spawns at recording end.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- `#352` Pending-tree merge dialogs now evaluate active non-leaf vessels against the current tree structure instead of only committed trees, so breakup-continuous landings and splashdowns default to persist exactly when runtime playback would spawn them.
 - `#349` Kerbal retirement tracking now preserves raw snapshot crew names alongside the repaired logical owner names, so historical stand-ins still retire/delete correctly after `KerbalAssignment` repair rewrites their ledger rows back to the slot owner.
 - `#348` The displaced-stand-in roster fix now preserves retired stand-ins as a special case, so missing retired roster entries are still recreated while truly unused displaced stand-ins stay deleted.
 - `#347` Historical stand-in repair now falls back to persisted `KERBAL_SLOTS` as well as the live `CREW_REPLACEMENTS` bridge, so old ledgers with stale stand-in names still heal after the current replacement map has already been cleared.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- `#353` High-warp orbital end-of-playback spawns now trim stable orbital boring tails against real activity instead of stale zero-throttle engine seed artifacts, then propagate stored terminal orbits to the current spawn UT and scrub stale packed-vessel/part atmospheric metadata before `ProtoVessel.Load()`, so stable-orbit recordings resolve around the normal 10-second boring-state buffer and deferred orbital spawns no longer mix an old endpoint state with a later planet rotation on the way into KSP's on-rails `SUB_ORBITAL`/`101.3 kPa` pressure kill path.
 - `#352` Pending-tree merge dialogs now evaluate active non-leaf vessels against the current tree structure instead of only committed trees, so breakup-continuous landings and splashdowns default to persist exactly when runtime playback would spawn them.
 - `#350` Boarded-EVA playback now preserves post-board flat trajectory tails when merged `TrackSections` are only a stale prefix, and single-point boarded leaf recordings now count as renderable playback/spawn data, so the last kerbal can finish the visible re-entry path and the final capsule with the re-boarded kerbal now spawns at recording end.
 - `#349` Kerbal retirement tracking now preserves raw snapshot crew names alongside the repaired logical owner names, so historical stand-ins still retire/delete correctly after `KerbalAssignment` repair rewrites their ledger rows back to the slot owner.
@@ -85,6 +86,7 @@ All notable changes to Parsek are documented here.
 
 ### Developer Tools
 
+- Added regression coverage for high-warp orbital spawn hardening and stable-orbit tail trimming: terminal-orbit spawn-state selection, top-level and per-part orbital metadata normalization, and zero-throttle engine-seed filtering in boring-tail trim so stable orbital coasts resolve on the normal 10-second buffer instead of replaying their full tail (`#353`).
 - Added regression coverage for boarded-EVA re-entry playback: board-merge stale-section tail preservation, single-point ghost renderability/state seeding, and direct stale-track fallback serialization for `#350`.
 - Documented the next kerbals hardening follow-ups in `todo-and-known-bugs.md`: a true cold-start slot-migration integration test, end-to-end `ApplyToRoster()` coverage for repaired historical stand-ins, and concise load-time diagnostics when kerbal reservation data is auto-repaired.
 - Added regression coverage for R/FF enablement reasons, including future/past timing, tree-branch rewind save resolution, and a UI guard that pins rewind/fast-forward independence from watch-distance state (`T60`).

--- a/Source/Parsek.Tests/Bug278FinalizeLimboTests.cs
+++ b/Source/Parsek.Tests/Bug278FinalizeLimboTests.cs
@@ -212,6 +212,73 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void ShouldRefreshActiveEffectiveLeafSnapshot_StableTerminalBreakupContinuous_ReturnsTrue()
+        {
+            var tree = new RecordingTree { TreeName = "Test", Id = "tree-1" };
+            var active = new Recording
+            {
+                RecordingId = "active-effective-leaf",
+                TreeId = tree.Id,
+                VesselPersistentId = 42,
+                ChildBranchPointId = "bp-1",
+                TerminalStateValue = TerminalState.Orbiting,
+            };
+            var debris = new Recording
+            {
+                RecordingId = "debris-child",
+                TreeId = tree.Id,
+                VesselPersistentId = 99,
+                ParentBranchPointId = "bp-1",
+                IsDebris = true,
+            };
+
+            tree.Recordings[active.RecordingId] = active;
+            tree.Recordings[debris.RecordingId] = debris;
+            tree.ActiveRecordingId = active.RecordingId;
+            tree.BranchPoints.Add(new BranchPoint
+            {
+                Id = "bp-1",
+                ParentRecordingIds = new List<string> { active.RecordingId },
+                ChildRecordingIds = new List<string> { debris.RecordingId }
+            });
+
+            Assert.True(ParsekFlight.ShouldRefreshActiveEffectiveLeafSnapshot(tree, active));
+        }
+
+        [Fact]
+        public void ShouldRefreshActiveEffectiveLeafSnapshot_SamePidContinuation_ReturnsFalse()
+        {
+            var tree = new RecordingTree { TreeName = "Test", Id = "tree-1" };
+            var active = new Recording
+            {
+                RecordingId = "active-nonleaf",
+                TreeId = tree.Id,
+                VesselPersistentId = 42,
+                ChildBranchPointId = "bp-1",
+                TerminalStateValue = TerminalState.Orbiting,
+            };
+            var continuation = new Recording
+            {
+                RecordingId = "same-pid-child",
+                TreeId = tree.Id,
+                VesselPersistentId = 42,
+                ParentBranchPointId = "bp-1",
+            };
+
+            tree.Recordings[active.RecordingId] = active;
+            tree.Recordings[continuation.RecordingId] = continuation;
+            tree.ActiveRecordingId = active.RecordingId;
+            tree.BranchPoints.Add(new BranchPoint
+            {
+                Id = "bp-1",
+                ParentRecordingIds = new List<string> { active.RecordingId },
+                ChildRecordingIds = new List<string> { continuation.RecordingId }
+            });
+
+            Assert.False(ParsekFlight.ShouldRefreshActiveEffectiveLeafSnapshot(tree, active));
+        }
+
+        [Fact]
         public void PruneZeroPointLeaves_RemovesEmptyDestroyedLeaves()
         {
             // The limbo finalize now also runs PruneZeroPointLeaves, so any

--- a/Source/Parsek.Tests/MergeDialogVesselTests.cs
+++ b/Source/Parsek.Tests/MergeDialogVesselTests.cs
@@ -159,6 +159,101 @@ namespace Parsek.Tests
             Assert.False(MergeDialog.CanPersistVessel(rec));
         }
 
+        [Fact]
+        public void CanPersistVessel_ActiveNonLeafEffectiveLeafInPendingTree_ReturnsTrue()
+        {
+            var tree = new RecordingTree
+            {
+                Id = "tree-1",
+                TreeName = "Kerbal X",
+                RootRecordingId = "active",
+                ActiveRecordingId = "active"
+            };
+
+            var active = new Recording
+            {
+                RecordingId = "active",
+                TreeId = "tree-1",
+                VesselName = "Kerbal X",
+                VesselPersistentId = 100,
+                ChildBranchPointId = "bp-1",
+                TerminalStateValue = TerminalState.Landed,
+                VesselSnapshot = new ConfigNode("VESSEL")
+            };
+            var debris = new Recording
+            {
+                RecordingId = "debris",
+                TreeId = "tree-1",
+                VesselName = "Kerbal X Debris",
+                VesselPersistentId = 200,
+                ParentBranchPointId = "bp-1",
+                TerminalStateValue = TerminalState.Destroyed,
+                VesselSnapshot = new ConfigNode("VESSEL"),
+                IsDebris = true
+            };
+            var bp = new BranchPoint
+            {
+                Id = "bp-1",
+                Type = BranchPointType.Breakup,
+                UT = 10.0
+            };
+            bp.ParentRecordingIds.Add("active");
+            bp.ChildRecordingIds.Add("debris");
+
+            tree.Recordings["active"] = active;
+            tree.Recordings["debris"] = debris;
+            tree.BranchPoints.Add(bp);
+
+            Assert.True(MergeDialog.CanPersistVessel(active, tree));
+        }
+
+        [Fact]
+        public void CanPersistVessel_ActiveNonLeafWithSamePidContinuationInPendingTree_ReturnsFalse()
+        {
+            var tree = new RecordingTree
+            {
+                Id = "tree-1",
+                TreeName = "Kerbal X",
+                RootRecordingId = "active",
+                ActiveRecordingId = "active"
+            };
+
+            var active = new Recording
+            {
+                RecordingId = "active",
+                TreeId = "tree-1",
+                VesselName = "Kerbal X",
+                VesselPersistentId = 100,
+                ChildBranchPointId = "bp-1",
+                TerminalStateValue = TerminalState.Landed,
+                VesselSnapshot = new ConfigNode("VESSEL")
+            };
+            var continuation = new Recording
+            {
+                RecordingId = "continuation",
+                TreeId = "tree-1",
+                VesselName = "Kerbal X",
+                VesselPersistentId = 100,
+                ParentBranchPointId = "bp-1",
+                TerminalStateValue = TerminalState.Landed,
+                VesselSnapshot = new ConfigNode("VESSEL")
+            };
+            var bp = new BranchPoint
+            {
+                Id = "bp-1",
+                Type = BranchPointType.JointBreak,
+                UT = 10.0
+            };
+            bp.ParentRecordingIds.Add("active");
+            bp.ChildRecordingIds.Add("continuation");
+
+            tree.Recordings["active"] = active;
+            tree.Recordings["continuation"] = continuation;
+            tree.BranchPoints.Add(bp);
+
+            Assert.False(MergeDialog.CanPersistVessel(active, tree));
+        }
+
         // ============================================================
         // BuildDefaultVesselDecisions
         // ============================================================
@@ -296,6 +391,61 @@ namespace Parsek.Tests
             Assert.Single(decisions);
             Assert.True(decisions.ContainsKey("leaf"));
             Assert.False(decisions.ContainsKey("root"));
+        }
+
+        [Fact]
+        public void BuildDefaultVesselDecisions_ActiveNonLeafEffectiveLeaf_DefaultsToPersist()
+        {
+            var tree = new RecordingTree
+            {
+                Id = "tree-1",
+                TreeName = "Kerbal X",
+                RootRecordingId = "active",
+                ActiveRecordingId = "active"
+            };
+
+            var active = new Recording
+            {
+                RecordingId = "active",
+                TreeId = "tree-1",
+                VesselName = "Kerbal X",
+                VesselPersistentId = 100,
+                ChildBranchPointId = "bp-1",
+                TerminalStateValue = TerminalState.Landed,
+                VesselSnapshot = new ConfigNode("VESSEL")
+            };
+            var debris = new Recording
+            {
+                RecordingId = "debris",
+                TreeId = "tree-1",
+                VesselName = "Kerbal X Debris",
+                VesselPersistentId = 200,
+                ParentBranchPointId = "bp-1",
+                TerminalStateValue = TerminalState.Destroyed,
+                VesselSnapshot = new ConfigNode("VESSEL"),
+                IsDebris = true
+            };
+            var bp = new BranchPoint
+            {
+                Id = "bp-1",
+                Type = BranchPointType.Breakup,
+                UT = 10.0
+            };
+            bp.ParentRecordingIds.Add("active");
+            bp.ChildRecordingIds.Add("debris");
+
+            tree.Recordings["active"] = active;
+            tree.Recordings["debris"] = debris;
+            tree.BranchPoints.Add(bp);
+
+            var decisions = MergeDialog.BuildDefaultVesselDecisions(tree);
+
+            Assert.Equal(2, decisions.Count);
+            Assert.True(decisions["active"]);
+            Assert.False(decisions["debris"]);
+            Assert.Contains(logLines, l =>
+                l.Contains("active-nonleaf='active'") &&
+                l.Contains("canPersist=True"));
         }
 
         // MarkForceSpawnOnTreeRecordings tests removed — spawn dedup bypass is now

--- a/Source/Parsek.Tests/RecordingOptimizerTests.cs
+++ b/Source/Parsek.Tests/RecordingOptimizerTests.cs
@@ -2069,6 +2069,27 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void FindLastInterestingUT_ZeroThrottleEngineSeedInBoringTail_Ignored()
+        {
+            var rec = new Recording();
+            rec.TrackSections.Add(new TrackSection
+                { environment = SegmentEnvironment.Atmospheric, startUT = 100, endUT = 200 });
+            rec.TrackSections.Add(new TrackSection
+                { environment = SegmentEnvironment.ExoBallistic, startUT = 200, endUT = 800 });
+            rec.PartEvents.Add(new PartEvent
+            {
+                ut = 790,
+                eventType = PartEventType.EngineIgnited,
+                value = 0f,
+                partPersistentId = 2485666303,
+                partName = "liquidEngineMainsail.v2",
+                moduleIndex = 0
+            });
+
+            Assert.Equal(200, RecordingOptimizer.FindLastInterestingUT(rec));
+        }
+
+        [Fact]
         public void FindLastInterestingUT_SegmentEventTakesMaximum()
         {
             var rec = new Recording();
@@ -2583,6 +2604,49 @@ namespace Parsek.Tests
             // Should trim based on event at 17200, not section end at 17050
             Assert.True(rec.EndUT >= 17200);
             Assert.True(rec.EndUT <= 17210 + 1);
+        }
+
+        [Fact]
+        public void TrimBoringTail_StableOrbitLateZeroThrottleEngineSeed_StillTrims()
+        {
+            var rec = MakeRecordingWithBoringTail(2000, 2042.84, 5000,
+                SegmentEnvironment.Atmospheric, SegmentEnvironment.ExoBallistic,
+                activePointCount: 6, boringPointCount: 40);
+            rec.PartEvents.Add(new PartEvent
+            {
+                ut = 2042.84,
+                eventType = PartEventType.EngineThrottle,
+                value = 0f,
+                partPersistentId = 2485666303,
+                partName = "liquidEngineMainsail.v2",
+                moduleIndex = 0
+            });
+            rec.PartEvents.Add(new PartEvent
+            {
+                ut = 2042.84,
+                eventType = PartEventType.EngineShutdown,
+                value = 0f,
+                partPersistentId = 2485666303,
+                partName = "unknown",
+                moduleIndex = 0
+            });
+            rec.PartEvents.Add(new PartEvent
+            {
+                ut = 4995,
+                eventType = PartEventType.EngineIgnited,
+                value = 0f,
+                partPersistentId = 2485666303,
+                partName = "liquidEngineMainsail.v2",
+                moduleIndex = 0
+            });
+            var recordings = new List<Recording> { rec };
+
+            Assert.True(RecordingOptimizer.TrimBoringTail(rec, recordings));
+            Assert.True(rec.EndUT >= 2042.84);
+            Assert.True(rec.EndUT <= 2042.84 + RecordingOptimizer.DefaultTailBufferSeconds + 1,
+                $"Expected stable orbit to trim near entry, got EndUT={rec.EndUT}");
+            Assert.DoesNotContain(rec.PartEvents,
+                e => e.eventType == PartEventType.EngineIgnited && e.value <= 0f && e.ut > rec.EndUT);
         }
 
         /// <summary>

--- a/Source/Parsek.Tests/RewindTimelineTests.cs
+++ b/Source/Parsek.Tests/RewindTimelineTests.cs
@@ -654,6 +654,49 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void ShouldSpawn_NonLeafWithSamePidChildInPendingTreeContext_ReturnsFalse()
+        {
+            var tree = new RecordingTree
+            {
+                Id = "tree-1",
+                TreeName = "TestTree",
+                RootRecordingId = "parent-rec"
+            };
+            var parentRec = new Recording
+            {
+                RecordingId = "parent-rec",
+                TreeId = "tree-1",
+                VesselPersistentId = 100,
+                VesselSnapshot = new ConfigNode("VESSEL"),
+                ChildBranchPointId = "bp-decouple"
+            };
+            var continuationRec = new Recording
+            {
+                RecordingId = "continuation-rec",
+                TreeId = "tree-1",
+                VesselPersistentId = 100,
+                ParentBranchPointId = "bp-decouple"
+            };
+            var bp = new BranchPoint
+            {
+                Id = "bp-decouple",
+                Type = BranchPointType.JointBreak,
+                UT = 50.0
+            };
+            bp.ParentRecordingIds.Add("parent-rec");
+            bp.ChildRecordingIds.Add("continuation-rec");
+            tree.Recordings["parent-rec"] = parentRec;
+            tree.Recordings["continuation-rec"] = continuationRec;
+            tree.BranchPoints.Add(bp);
+
+            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtRecordingEnd(
+                parentRec, isActiveChainMember: false, isChainLoopingOrDisabled: false, tree);
+
+            Assert.False(needsSpawn);
+            Assert.Contains("non-leaf tree recording", reason);
+        }
+
+        [Fact]
         public void ShouldSpawn_EffectiveLeaf_BreakupDebrisOnly_ReturnsTrue()
         {
             // Breakup-continuous: ChildBranchPointId set but no same-PID child.
@@ -696,6 +739,50 @@ namespace Parsek.Tests
 
             var (needsSpawn, _) = GhostPlaybackLogic.ShouldSpawnAtRecordingEnd(
                 parentRec, isActiveChainMember: false, isChainLoopingOrDisabled: false);
+
+            Assert.True(needsSpawn);
+        }
+
+        [Fact]
+        public void ShouldSpawn_EffectiveLeaf_BreakupDebrisOnlyInPendingTreeContext_ReturnsTrue()
+        {
+            var tree = new RecordingTree
+            {
+                Id = "tree-1",
+                TreeName = "TestTree",
+                RootRecordingId = "parent-rec"
+            };
+            var parentRec = new Recording
+            {
+                RecordingId = "parent-rec",
+                TreeId = "tree-1",
+                VesselPersistentId = 100,
+                VesselSnapshot = new ConfigNode("VESSEL"),
+                ChildBranchPointId = "bp-crash",
+                TerminalStateValue = TerminalState.Splashed
+            };
+            var debrisRec = new Recording
+            {
+                RecordingId = "debris-rec",
+                TreeId = "tree-1",
+                VesselPersistentId = 999,
+                ParentBranchPointId = "bp-crash",
+                IsDebris = true
+            };
+            var bp = new BranchPoint
+            {
+                Id = "bp-crash",
+                Type = BranchPointType.Breakup,
+                UT = 102.8
+            };
+            bp.ParentRecordingIds.Add("parent-rec");
+            bp.ChildRecordingIds.Add("debris-rec");
+            tree.Recordings["parent-rec"] = parentRec;
+            tree.Recordings["debris-rec"] = debrisRec;
+            tree.BranchPoints.Add(bp);
+
+            var (needsSpawn, _) = GhostPlaybackLogic.ShouldSpawnAtRecordingEnd(
+                parentRec, isActiveChainMember: false, isChainLoopingOrDisabled: false, tree);
 
             Assert.True(needsSpawn);
         }

--- a/Source/Parsek.Tests/SpawnSafetyNetTests.cs
+++ b/Source/Parsek.Tests/SpawnSafetyNetTests.cs
@@ -865,6 +865,106 @@ namespace Parsek.Tests
             Assert.False(VesselSpawner.ShouldUseRecordedTerminalOrbitSpawnState(rec, isEva: false));
         }
 
+        [Fact]
+        public void ComputeRecordedTerminalOrbitMeanAnomalyAtUT_ShiftsToSpawnUT()
+        {
+            var rec = new Recording
+            {
+                TerminalOrbitMeanAnomalyAtEpoch = 0.25,
+                TerminalOrbitEpoch = 2000.0,
+                TerminalOrbitSemiMajorAxis = 1535076.0272732542
+            };
+
+            double actual = VesselSpawner.ComputeRecordedTerminalOrbitMeanAnomalyAtUT(
+                rec, 3.5316e12, 2053.8556687927244);
+            double expected = TimeJumpManager.ComputeEpochShiftedMeanAnomaly(
+                rec.TerminalOrbitMeanAnomalyAtEpoch,
+                rec.TerminalOrbitEpoch,
+                rec.TerminalOrbitSemiMajorAxis,
+                3.5316e12,
+                2053.8556687927244);
+
+            Assert.Equal(expected, actual, 10);
+        }
+
+        [Fact]
+        public void ComputeRecordedTerminalOrbitMeanAnomalyAtUT_InvalidInputs_UsesRecordedValue()
+        {
+            var rec = new Recording
+            {
+                TerminalOrbitMeanAnomalyAtEpoch = 1.75,
+                TerminalOrbitEpoch = 2000.0,
+                TerminalOrbitSemiMajorAxis = 0.0
+            };
+
+            Assert.Equal(1.75,
+                VesselSpawner.ComputeRecordedTerminalOrbitMeanAnomalyAtUT(rec, 3.5316e12, 2100.0), 10);
+            Assert.Equal(1.75,
+                VesselSpawner.ComputeRecordedTerminalOrbitMeanAnomalyAtUT(rec, 0.0, 2100.0), 10);
+        }
+
+        [Fact]
+        public void TryGetPreferredRecordedOrbitSeedForSpawn_PrefersLastOrbitSegment()
+        {
+            var rec = new Recording
+            {
+                TerminalOrbitBody = "Kerbin",
+                TerminalOrbitInclination = 3.1941697709596331,
+                TerminalOrbitEccentricity = 0.13020261702803454,
+                TerminalOrbitSemiMajorAxis = 1535076.0272732542,
+                TerminalOrbitLAN = 3.6481022360695761,
+                TerminalOrbitArgumentOfPeriapsis = 45.008215755350477,
+                TerminalOrbitMeanAnomalyAtEpoch = 2.1799662805681828,
+                TerminalOrbitEpoch = 2042.84218735994
+            };
+            rec.OrbitSegments.Add(new OrbitSegment
+            {
+                startUT = 1843.4542587652486,
+                endUT = 2028.0,
+                inclination = 0.61893643894622086,
+                eccentricity = 0.45999751866457206,
+                semiMajorAxis = 1140570.053246473,
+                longitudeOfAscendingNode = 187.83370664986606,
+                argumentOfPeriapsis = 178.86920484839638,
+                meanAnomalyAtEpoch = 2.7470939631732678,
+                epoch = 1843.4542587652486,
+                bodyName = "Kerbin"
+            });
+            rec.OrbitSegments.Add(new OrbitSegment
+            {
+                startUT = 2042.84218735994,
+                endUT = 2052.84218735994,
+                inclination = 3.1941697709596331,
+                eccentricity = 0.13020261702803454,
+                semiMajorAxis = 1535076.0272732542,
+                longitudeOfAscendingNode = 3.6481022360695761,
+                argumentOfPeriapsis = 45.008215755350477,
+                meanAnomalyAtEpoch = 2.1799662805681828,
+                epoch = 2042.84218735994,
+                bodyName = "Kerbin"
+            });
+
+            Assert.True(VesselSpawner.TryGetPreferredRecordedOrbitSeedForSpawn(
+                rec,
+                out double inclination,
+                out double eccentricity,
+                out double semiMajorAxis,
+                out double lan,
+                out double argumentOfPeriapsis,
+                out double meanAnomalyAtEpoch,
+                out double epoch,
+                out string bodyName));
+
+            Assert.Equal(3.1941697709596331, inclination, 10);
+            Assert.Equal(0.13020261702803454, eccentricity, 10);
+            Assert.Equal(1535076.0272732542, semiMajorAxis, 10);
+            Assert.Equal(3.6481022360695761, lan, 10);
+            Assert.Equal(45.008215755350477, argumentOfPeriapsis, 10);
+            Assert.Equal(2.1799662805681828, meanAnomalyAtEpoch, 10);
+            Assert.Equal(2042.84218735994, epoch, 10);
+            Assert.Equal("Kerbin", bodyName);
+        }
+
         #endregion
 
         #region NormalizeOrbitalSpawnMetadata (#353)

--- a/Source/Parsek.Tests/SpawnSafetyNetTests.cs
+++ b/Source/Parsek.Tests/SpawnSafetyNetTests.cs
@@ -834,6 +834,108 @@ namespace Parsek.Tests
 
         #endregion
 
+        #region Recorded terminal orbit spawn state (#353)
+
+        [Fact]
+        public void ShouldUseRecordedTerminalOrbitSpawnState_OrbitingRecording_ReturnsTrue()
+        {
+            var rec = new Recording
+            {
+                TerminalStateValue = TerminalState.Orbiting,
+                TerminalOrbitBody = "Kerbin",
+                TerminalOrbitSemiMajorAxis = 700000.0
+            };
+
+            Assert.True(VesselSpawner.ShouldUseRecordedTerminalOrbitSpawnState(rec, isEva: false));
+        }
+
+        [Fact]
+        public void ShouldUseRecordedTerminalOrbitSpawnState_EvaOrMissingOrbitData_ReturnsFalse()
+        {
+            var rec = new Recording
+            {
+                TerminalStateValue = TerminalState.Orbiting,
+                TerminalOrbitBody = "Kerbin",
+                TerminalOrbitSemiMajorAxis = 700000.0
+            };
+
+            Assert.False(VesselSpawner.ShouldUseRecordedTerminalOrbitSpawnState(rec, isEva: true));
+
+            rec.TerminalOrbitSemiMajorAxis = 0.0;
+            Assert.False(VesselSpawner.ShouldUseRecordedTerminalOrbitSpawnState(rec, isEva: false));
+        }
+
+        #endregion
+
+        #region NormalizeOrbitalSpawnMetadata (#353)
+
+        [Fact]
+        public void NormalizeOrbitalSpawnMetadata_RewritesPackedAscentFields()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            snapshot.AddValue("hgt", "12521.6553");
+            snapshot.AddValue("distanceTraveled", "8210.7499948265686");
+            snapshot.AddValue("PQSMin", "2");
+            snapshot.AddValue("PQSMax", "10");
+            snapshot.AddValue("altDispState", "ASL");
+            snapshot.AddValue("skipGroundPositioning", "True");
+            snapshot.AddValue("skipGroundPositioningForDroppedPart", "True");
+            snapshot.AddValue("vesselSpawning", "True");
+            snapshot.AddValue("lastUT", "74.220361328121982");
+
+            VesselSpawner.NormalizeOrbitalSpawnMetadata(snapshot, 1323814.6578770601);
+
+            Assert.Equal("-1", snapshot.GetValue("hgt"));
+            Assert.Equal("0", snapshot.GetValue("distanceTraveled"));
+            Assert.Equal("0", snapshot.GetValue("PQSMin"));
+            Assert.Equal("0", snapshot.GetValue("PQSMax"));
+            Assert.Equal("DEFAULT", snapshot.GetValue("altDispState"));
+            Assert.Equal("False", snapshot.GetValue("skipGroundPositioning"));
+            Assert.Equal("False", snapshot.GetValue("skipGroundPositioningForDroppedPart"));
+            Assert.Equal("False", snapshot.GetValue("vesselSpawning"));
+            Assert.Equal("1323814.6578770601", snapshot.GetValue("lastUT"));
+        }
+
+        [Fact]
+        public void NormalizeOrbitalSpawnMetadata_RewritesPartAtmosphereFields()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            var part = snapshot.AddNode("PART");
+            part.AddValue("tempExt", "353.89914853869396");
+            part.AddValue("tempExtUnexp", "4");
+            part.AddValue("staticPressureAtm", "0.10801468253165093");
+
+            VesselSpawner.NormalizeOrbitalSpawnMetadata(snapshot, 200.0);
+
+            Assert.Equal("0", part.GetValue("tempExt"));
+            Assert.Equal("0", part.GetValue("tempExtUnexp"));
+            Assert.Equal("0", part.GetValue("staticPressureAtm"));
+        }
+
+        [Fact]
+        public void NormalizeOrbitalSpawnMetadata_CreatesMissingFields()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            var part = snapshot.AddNode("PART");
+
+            VesselSpawner.NormalizeOrbitalSpawnMetadata(snapshot, 123.5);
+
+            Assert.Equal("-1", snapshot.GetValue("hgt"));
+            Assert.Equal("0", snapshot.GetValue("distanceTraveled"));
+            Assert.Equal("0", snapshot.GetValue("PQSMin"));
+            Assert.Equal("0", snapshot.GetValue("PQSMax"));
+            Assert.Equal("DEFAULT", snapshot.GetValue("altDispState"));
+            Assert.Equal("False", snapshot.GetValue("skipGroundPositioning"));
+            Assert.Equal("False", snapshot.GetValue("skipGroundPositioningForDroppedPart"));
+            Assert.Equal("False", snapshot.GetValue("vesselSpawning"));
+            Assert.Equal("123.5", snapshot.GetValue("lastUT"));
+            Assert.Equal("0", part.GetValue("tempExt"));
+            Assert.Equal("0", part.GetValue("tempExtUnexp"));
+            Assert.Equal("0", part.GetValue("staticPressureAtm"));
+        }
+
+        #endregion
+
         #region OverrideSnapshotPosition (EVA spawn fix)
 
         [Fact]

--- a/Source/Parsek.Tests/SpawnSafetyNetTests.cs
+++ b/Source/Parsek.Tests/SpawnSafetyNetTests.cs
@@ -85,7 +85,7 @@ namespace Parsek.Tests
             Assert.True(result);
             Assert.Contains(logLines, l =>
                 l.Contains("[Spawner]") &&
-                l.Contains("IsNonLeafInCommittedTree") &&
+                l.Contains("IsNonLeafInTree") &&
                 l.Contains("root-rec") &&
                 l.Contains("safety net triggered"));
         }
@@ -418,7 +418,7 @@ namespace Parsek.Tests
                 rootRec, isActiveChainMember: false, isChainLoopingOrDisabled: false);
 
             Assert.False(needsSpawn);
-            Assert.Contains("non-leaf in committed tree", reason);
+            Assert.Contains("non-leaf in tree", reason);
         }
 
         [Fact]
@@ -459,7 +459,46 @@ namespace Parsek.Tests
                 rootRec, isActiveChainMember: false, isChainLoopingOrDisabled: false);
 
             Assert.False(needsSpawn);
-            Assert.Contains("non-leaf in committed tree", reason);
+            Assert.Contains("non-leaf in tree", reason);
+        }
+
+        [Fact]
+        public void ShouldSpawn_NonLeafInPendingTreeContext_NullChildBranchPointId_ReturnsFalse()
+        {
+            var tree = new RecordingTree
+            {
+                Id = "tree-pending",
+                TreeName = "PendingTree",
+                RootRecordingId = "root-rec"
+            };
+
+            var rootRec = new Recording
+            {
+                RecordingId = "root-rec",
+                TreeId = "tree-pending",
+                VesselPersistentId = 100,
+                VesselSnapshot = new ConfigNode("VESSEL"),
+                ChildBranchPointId = null,
+                TerminalStateValue = TerminalState.Splashed
+            };
+
+            var bp = new BranchPoint
+            {
+                Id = "bp-pending",
+                Type = BranchPointType.Breakup,
+                UT = 78.0
+            };
+            bp.ParentRecordingIds.Add("root-rec");
+            bp.ChildRecordingIds.Add("child-rec");
+
+            tree.Recordings["root-rec"] = rootRec;
+            tree.BranchPoints.Add(bp);
+
+            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtRecordingEnd(
+                rootRec, isActiveChainMember: false, isChainLoopingOrDisabled: false, tree);
+
+            Assert.False(needsSpawn);
+            Assert.Contains("non-leaf in tree", reason);
         }
 
         #endregion

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -2680,6 +2680,19 @@ namespace Parsek
             bool isActiveChainMember,
             bool isChainLoopingOrDisabled)
         {
+            return ShouldSpawnAtRecordingEnd(
+                rec,
+                isActiveChainMember,
+                isChainLoopingOrDisabled,
+                treeContext: null);
+        }
+
+        internal static (bool needsSpawn, string reason) ShouldSpawnAtRecordingEnd(
+            Recording rec,
+            bool isActiveChainMember,
+            bool isChainLoopingOrDisabled,
+            RecordingTree treeContext)
+        {
             // Base condition: must have a snapshot, not already spawned, not destroyed
             if (rec.VesselSnapshot == null)
             {
@@ -2729,7 +2742,7 @@ namespace Parsek
             bool effectiveLeaf = rec.ChildBranchPointId != null
                 && !rec.IsDebris
                 && hasSpawnableTerminal
-                && IsEffectiveLeafForVessel(rec);
+                && IsEffectiveLeafForVessel(rec, treeContext);
 
             // Non-leaf tree recordings should never spawn — they branched into a
             // same-vessel continuation that carries the correct snapshot.
@@ -2738,14 +2751,14 @@ namespace Parsek
                 return (false, "non-leaf tree recording");
             }
 
-            // Safety net: even if ChildBranchPointId is null, check committed trees
+            // Safety net: even if ChildBranchPointId is null, check the resolved tree
             // for recordings that are parents of a branch point. Covers edge cases where
             // ChildBranchPointId was not set (e.g., serialization gaps). (#114)
             // Skip for effective-leaf recordings — the branch point exists but the recording
             // is still the leaf for its vessel.
-            if (!effectiveLeaf && IsNonLeafInCommittedTree(rec))
+            if (!effectiveLeaf && IsNonLeafInTree(rec, treeContext))
             {
-                return (false, "non-leaf in committed tree (safety net)");
+                return (false, "non-leaf in tree (safety net)");
             }
 
             // Debris recordings are visual-only (short TTL, no meaningful vessel to persist)
@@ -2847,31 +2860,30 @@ namespace Parsek
         /// </summary>
         internal static bool IsNonLeafInCommittedTree(Recording rec)
         {
-            if (!rec.IsTreeRecording || string.IsNullOrEmpty(rec.RecordingId))
+            return IsNonLeafInTree(rec, treeContext: null);
+        }
+
+        internal static bool IsNonLeafInTree(Recording rec, RecordingTree treeContext)
+        {
+            RecordingTree tree;
+            if (!TryResolveTreeContext(rec, treeContext, out tree))
                 return false;
 
-            var trees = RecordingStore.CommittedTrees;
-            for (int t = 0; t < trees.Count; t++)
+            // Check if any branch point lists this recording as a parent.
+            for (int b = 0; b < tree.BranchPoints.Count; b++)
             {
-                var tree = trees[t];
-                if (tree.Id != rec.TreeId) continue;
-
-                // Check if any branch point lists this recording as a parent
-                for (int b = 0; b < tree.BranchPoints.Count; b++)
+                var bp = tree.BranchPoints[b];
+                if (bp.ParentRecordingIds != null && bp.ParentRecordingIds.Contains(rec.RecordingId))
                 {
-                    var bp = tree.BranchPoints[b];
-                    if (bp.ParentRecordingIds != null && bp.ParentRecordingIds.Contains(rec.RecordingId))
-                    {
-                        ParsekLog.VerboseRateLimited("Spawner",
-                            $"safety-net-{rec.RecordingId}",
-                            string.Format(CultureInfo.InvariantCulture,
-                                "IsNonLeafInCommittedTree: recording {0} is parent of branch point {1} " +
-                                "in tree {2} (ChildBranchPointId was null — safety net triggered)",
-                                rec.RecordingId, bp.Id, tree.Id), 30.0);
-                        return true;
-                    }
+                    string treeLabel = !string.IsNullOrEmpty(tree.Id) ? tree.Id : (tree.TreeName ?? "(pending)");
+                    ParsekLog.VerboseRateLimited("Spawner",
+                        $"safety-net-{rec.RecordingId}",
+                        string.Format(CultureInfo.InvariantCulture,
+                            "IsNonLeafInTree: recording {0} is parent of branch point {1} " +
+                            "in tree {2} (ChildBranchPointId was null — safety net triggered)",
+                            rec.RecordingId, bp.Id, treeLabel), 30.0);
+                    return true;
                 }
-                break; // Found the tree, no need to check others
             }
             return false;
         }
@@ -2885,43 +2897,78 @@ namespace Parsek
         /// </summary>
         internal static bool IsEffectiveLeafForVessel(Recording rec)
         {
-            if (string.IsNullOrEmpty(rec.ChildBranchPointId) || !rec.IsTreeRecording)
+            return IsEffectiveLeafForVessel(rec, treeContext: null);
+        }
+
+        internal static bool IsEffectiveLeafForVessel(Recording rec, RecordingTree treeContext)
+        {
+            if (string.IsNullOrEmpty(rec.ChildBranchPointId))
                 return false;
+
+            RecordingTree tree;
+            if (!TryResolveTreeContext(rec, treeContext, out tree))
+                return false;
+
+            // Find the branch point
+            for (int b = 0; b < tree.BranchPoints.Count; b++)
+            {
+                var bp = tree.BranchPoints[b];
+                if (bp.Id != rec.ChildBranchPointId) continue;
+
+                // Check if any child recording shares the same vessel PID
+                for (int c = 0; c < bp.ChildRecordingIds.Count; c++)
+                {
+                    Recording childRec;
+                    if (tree.Recordings.TryGetValue(bp.ChildRecordingIds[c], out childRec))
+                    {
+                        if (childRec.VesselPersistentId == rec.VesselPersistentId)
+                            return false; // Same-PID continuation exists — NOT effective leaf
+                    }
+                }
+
+                // No child shares this vessel PID — recording IS the effective leaf
+                ParsekLog.VerboseRateLimited("Spawner",
+                    rec.RecordingId,
+                    string.Format(CultureInfo.InvariantCulture,
+                        "IsEffectiveLeafForVessel: recording {0} vessel={1} is effective leaf " +
+                        "(breakup-continuous, no same-PID continuation child)",
+                        rec.RecordingId, rec.VesselPersistentId));
+                return true;
+            }
+            return false;
+        }
+
+        private static bool TryResolveTreeContext(
+            Recording rec,
+            RecordingTree treeContext,
+            out RecordingTree tree)
+        {
+            tree = null;
+            if (rec == null || string.IsNullOrEmpty(rec.RecordingId) || !rec.IsTreeRecording)
+                return false;
+
+            if (treeContext != null)
+            {
+                bool sameTreeId = !string.IsNullOrEmpty(treeContext.Id) && treeContext.Id == rec.TreeId;
+                bool containsRecording = treeContext.Recordings != null
+                    && treeContext.Recordings.ContainsKey(rec.RecordingId);
+                if (sameTreeId || containsRecording)
+                {
+                    tree = treeContext;
+                    return true;
+                }
+            }
 
             var trees = RecordingStore.CommittedTrees;
             for (int t = 0; t < trees.Count; t++)
             {
-                var tree = trees[t];
-                if (tree.Id != rec.TreeId) continue;
-
-                // Find the branch point
-                for (int b = 0; b < tree.BranchPoints.Count; b++)
+                if (trees[t].Id == rec.TreeId)
                 {
-                    var bp = tree.BranchPoints[b];
-                    if (bp.Id != rec.ChildBranchPointId) continue;
-
-                    // Check if any child recording shares the same vessel PID
-                    for (int c = 0; c < bp.ChildRecordingIds.Count; c++)
-                    {
-                        Recording childRec;
-                        if (tree.Recordings.TryGetValue(bp.ChildRecordingIds[c], out childRec))
-                        {
-                            if (childRec.VesselPersistentId == rec.VesselPersistentId)
-                                return false; // Same-PID continuation exists — NOT effective leaf
-                        }
-                    }
-
-                    // No child shares this vessel PID — recording IS the effective leaf
-                    ParsekLog.VerboseRateLimited("Spawner",
-                        rec.RecordingId,
-                        string.Format(CultureInfo.InvariantCulture,
-                            "IsEffectiveLeafForVessel: recording {0} vessel={1} is effective leaf " +
-                            "(breakup-continuous, no same-PID continuation child)",
-                            rec.RecordingId, rec.VesselPersistentId));
+                    tree = trees[t];
                     return true;
                 }
-                break;
             }
+
             return false;
         }
 

--- a/Source/Parsek/MergeDialog.cs
+++ b/Source/Parsek/MergeDialog.cs
@@ -178,7 +178,7 @@ namespace Parsek
         /// This reuses the same intrinsic spawn policy as timeline playback so the dialog's
         /// default "spawnable" count stays aligned with runtime behavior.
         /// </summary>
-        internal static bool CanPersistVessel(Recording rec)
+        internal static bool CanPersistVessel(Recording rec, RecordingTree treeContext = null)
         {
             if (rec == null)
                 return false;
@@ -186,7 +186,8 @@ namespace Parsek
             var (needsSpawn, _) = GhostPlaybackLogic.ShouldSpawnAtRecordingEnd(
                 rec,
                 isActiveChainMember: false,
-                isChainLoopingOrDisabled: false);
+                isChainLoopingOrDisabled: false,
+                treeContext: treeContext);
             return needsSpawn;
         }
 
@@ -205,7 +206,7 @@ namespace Parsek
             for (int i = 0; i < leaves.Count; i++)
             {
                 var leaf = leaves[i];
-                bool canPersist = CanPersistVessel(leaf);
+                bool canPersist = CanPersistVessel(leaf, tree);
                 decisions[leaf.RecordingId] = canPersist;
                 ParsekLog.Verbose("MergeDialog",
                     $"BuildDefaultVesselDecisions: leaf='{leaf.RecordingId}' vessel='{leaf.VesselName}' " +
@@ -223,7 +224,7 @@ namespace Parsek
                 Recording activeRec;
                 if (tree.Recordings.TryGetValue(tree.ActiveRecordingId, out activeRec))
                 {
-                    bool canPersist = CanPersistVessel(activeRec);
+                    bool canPersist = CanPersistVessel(activeRec, tree);
                     decisions[activeRec.RecordingId] = canPersist;
                     ParsekLog.Verbose("MergeDialog",
                         $"BuildDefaultVesselDecisions: active-nonleaf='{activeRec.RecordingId}' " +

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -6152,6 +6152,7 @@ namespace Parsek
             // so FinalizeIndividualRecording skips its terminalState. The optimizer
             // will propagate this to the chain tip via SplitAtSection.
             EnsureActiveRecordingTerminalState(tree);
+            RefreshActiveEffectiveLeafSnapshot(tree, isSceneExit);
 
             // 4. Prune zero-point debris leaves (#173) — removes recordings with no
             // trajectory data that were created from same-frame destruction debris.
@@ -6202,6 +6203,54 @@ namespace Parsek
                     $"{activeRec.TerminalStateValue} on active recording " +
                     $"'{activeRec.RecordingId}' (non-leaf, vessel situation={v.situation})");
             }
+        }
+
+        internal static bool ShouldRefreshActiveEffectiveLeafSnapshot(
+            RecordingTree tree,
+            Recording activeRec)
+        {
+            if (tree == null || activeRec == null)
+                return false;
+            if (string.IsNullOrEmpty(tree.ActiveRecordingId)
+                || tree.ActiveRecordingId != activeRec.RecordingId)
+                return false;
+            if (string.IsNullOrEmpty(activeRec.ChildBranchPointId))
+                return false;
+            if (!activeRec.TerminalStateValue.HasValue
+                || !IsStableSpawnTerminal(activeRec.TerminalStateValue.Value))
+                return false;
+
+            return GhostPlaybackLogic.IsEffectiveLeafForVessel(activeRec, tree);
+        }
+
+        internal static void RefreshActiveEffectiveLeafSnapshot(RecordingTree tree, bool isSceneExit)
+        {
+            if (tree == null || string.IsNullOrEmpty(tree.ActiveRecordingId))
+                return;
+            if (!tree.Recordings.TryGetValue(tree.ActiveRecordingId, out var activeRec))
+                return;
+            if (!ShouldRefreshActiveEffectiveLeafSnapshot(tree, activeRec))
+                return;
+
+            Vessel activeVessel = activeRec.VesselPersistentId != 0
+                ? FlightRecorder.FindVesselByPid(activeRec.VesselPersistentId)
+                : null;
+            if (activeVessel == null)
+            {
+                ParsekLog.Verbose("Flight",
+                    $"FinalizeTreeRecordings: active effective leaf '{activeRec.RecordingId}' " +
+                    $"stable terminal={activeRec.TerminalStateValue} but vessel not found " +
+                    $"(isSceneExit={isSceneExit}) — keeping existing snapshot");
+                return;
+            }
+
+            CaptureTerminalOrbit(activeRec, activeVessel);
+            CaptureTerminalPosition(activeRec, activeVessel);
+            TryRefreshStableTerminalSnapshot(
+                activeRec,
+                activeVessel,
+                isSceneExit,
+                "FinalizeTreeRecordings: re-snapshotted active effective leaf");
         }
 
         internal static void FinalizeIndividualRecording(Recording rec, double commitUT, bool isSceneExit)
@@ -6328,30 +6377,8 @@ namespace Parsek
             if (isLeaf && rec.TerminalStateValue.HasValue && finalizeVessel != null)
             {
                 var ts = rec.TerminalStateValue.Value;
-                bool stableTerminal = ts == TerminalState.Landed
-                    || ts == TerminalState.Splashed
-                    || ts == TerminalState.Orbiting;
-                if (stableTerminal)
-                {
-                    ConfigNode freshSnapshot = VesselSpawner.TryBackupSnapshot(finalizeVessel);
-                    if (freshSnapshot != null)
-                    {
-                        rec.VesselSnapshot = freshSnapshot;
-                        if (rec.GhostVisualSnapshot == null)
-                            rec.GhostVisualSnapshot = freshSnapshot.CreateCopy();
-                        rec.MarkFilesDirty();  // Critical: ensures next SaveRecordingFiles writes the fresh snapshot to disk
-                        ParsekLog.Info("Flight",
-                            $"FinalizeIndividualRecording: re-snapshotted '{rec.RecordingId}' " +
-                            $"with stable terminal state {ts} " +
-                            $"(vessel.situation={finalizeVessel.situation}, isSceneExit={isSceneExit}) [#289]");
-                    }
-                    else
-                    {
-                        ParsekLog.Verbose("Flight",
-                            $"FinalizeIndividualRecording: re-snapshot returned null for " +
-                            $"'{rec.RecordingId}' (terminal={ts}, isSceneExit={isSceneExit}) — keeping stale snapshot");
-                    }
-                }
+                if (IsStableSpawnTerminal(ts))
+                    TryRefreshStableTerminalSnapshot(rec, finalizeVessel, isSceneExit, "FinalizeIndividualRecording");
             }
 
             // Backfill terminal orbit for recordings that had TerminalStateValue set early
@@ -6485,6 +6512,42 @@ namespace Parsek
 
             // Default: vessel was in flight (atmospheric descent, suborbital, etc.)
             return TerminalState.SubOrbital;
+        }
+
+        private static bool IsStableSpawnTerminal(TerminalState state)
+        {
+            return state == TerminalState.Landed
+                || state == TerminalState.Splashed
+                || state == TerminalState.Orbiting;
+        }
+
+        private static bool TryRefreshStableTerminalSnapshot(
+            Recording rec,
+            Vessel vessel,
+            bool isSceneExit,
+            string logPrefix)
+        {
+            if (rec == null || vessel == null || !rec.TerminalStateValue.HasValue)
+                return false;
+
+            var ts = rec.TerminalStateValue.Value;
+            ConfigNode freshSnapshot = VesselSpawner.TryBackupSnapshot(vessel);
+            if (freshSnapshot == null)
+            {
+                ParsekLog.Verbose("Flight",
+                    $"{logPrefix}: re-snapshot returned null for '{rec.RecordingId}' " +
+                    $"(terminal={ts}, isSceneExit={isSceneExit}) — keeping stale snapshot");
+                return false;
+            }
+
+            rec.VesselSnapshot = freshSnapshot;
+            if (rec.GhostVisualSnapshot == null)
+                rec.GhostVisualSnapshot = freshSnapshot.CreateCopy();
+            rec.MarkFilesDirty();
+            ParsekLog.Info("Flight",
+                $"{logPrefix} '{rec.RecordingId}' with stable terminal state {ts} " +
+                $"(vessel.situation={vessel.situation}, isSceneExit={isSceneExit}) [#289/#354]");
+            return true;
         }
 
         /// <summary>

--- a/Source/Parsek/RecordingOptimizer.cs
+++ b/Source/Parsek/RecordingOptimizer.cs
@@ -1034,9 +1034,29 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Returns true when a PartEvent is a zero-effect control-state seed that should
+        /// not keep a long boring tail alive. Real positive-throttle / positive-power
+        /// transitions still count as interesting activity.
+        /// </summary>
+        internal static bool IsInertPartEventForTailTrim(PartEvent evt)
+        {
+            switch (evt.eventType)
+            {
+                case PartEventType.EngineIgnited:
+                case PartEventType.EngineThrottle:
+                case PartEventType.RCSActivated:
+                case PartEventType.RCSThrottle:
+                    return evt.value <= 0f;
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
         /// Finds the UT of the last interesting activity in a recording.
-        /// Interesting = last non-boring TrackSection end, last PartEvent, last SegmentEvent,
-        /// or last FlagEvent — whichever is latest. Returns NaN if nothing interesting found.
+        /// Interesting = last non-boring TrackSection end, last non-inert PartEvent,
+        /// last SegmentEvent, or last FlagEvent — whichever is latest. Returns NaN if
+        /// nothing interesting found.
         /// </summary>
         internal static double FindLastInterestingUT(Recording rec)
         {
@@ -1058,8 +1078,15 @@ namespace Parsek
             // Last PartEvent
             if (rec.PartEvents != null && rec.PartEvents.Count > 0)
             {
-                double evtUT = rec.PartEvents[rec.PartEvents.Count - 1].ut;
-                if (double.IsNaN(lastUT) || evtUT > lastUT) lastUT = evtUT;
+                for (int i = rec.PartEvents.Count - 1; i >= 0; i--)
+                {
+                    if (IsInertPartEventForTailTrim(rec.PartEvents[i]))
+                        continue;
+
+                    double evtUT = rec.PartEvents[i].ut;
+                    if (double.IsNaN(lastUT) || evtUT > lastUT) lastUT = evtUT;
+                    break;
+                }
             }
 
             // Last SegmentEvent

--- a/Source/Parsek/VesselSpawner.cs
+++ b/Source/Parsek/VesselSpawner.cs
@@ -303,7 +303,8 @@ namespace Parsek
             Vector3d velocity, double ut,
             HashSet<string> excludeCrew = null, bool preserveIdentity = false,
             TerminalState? terminalState = null,
-            Quaternion? rotation = null)
+            Quaternion? rotation = null,
+            Orbit orbitOverride = null)
         {
             try
             {
@@ -349,9 +350,13 @@ namespace Parsek
                 }
 
                 // Rebuild ORBIT subnode from position + velocity
-                var orbit = new Orbit();
-                Vector3d worldPos = body.GetWorldSurfacePosition(lat, lon, alt);
-                orbit.UpdateFromStateVectors(worldPos, velocity, body, ut);
+                Orbit orbit = orbitOverride;
+                if (orbit == null)
+                {
+                    orbit = new Orbit();
+                    Vector3d worldPos = body.GetWorldSurfacePosition(lat, lon, alt);
+                    orbit.UpdateFromStateVectors(worldPos, velocity, body, ut);
+                }
                 spawnNode.RemoveNode("ORBIT");
                 ConfigNode orbitNode = new ConfigNode("ORBIT");
                 SaveOrbitToNode(orbit, orbitNode, body);
@@ -509,11 +514,12 @@ namespace Parsek
 
             double spawnUT = Planetarium.GetUniversalTime();
             Vector3d orbitalSpawnVelocity = Vector3d.zero;
+            Orbit orbitalSpawnOrbit = null;
             if (useRecordedTerminalOrbit)
             {
                 if (TryResolveRecordedTerminalOrbitSpawnState(
                     rec, body, spawnUT, out double orbitLat, out double orbitLon,
-                    out double orbitAlt, out orbitalSpawnVelocity))
+                    out double orbitAlt, out orbitalSpawnVelocity, out orbitalSpawnOrbit))
                 {
                     spawnLat = orbitLat;
                     spawnLon = orbitLon;
@@ -649,7 +655,8 @@ namespace Parsek
                 rec.SpawnedVesselPersistentId = SpawnAtPosition(
                     rec.VesselSnapshot, body, spawnLat, spawnLon, spawnAlt, velocity, spawnUT, excludeCrew,
                     terminalState: rec.TerminalStateValue,
-                    rotation: rotArg);
+                    rotation: rotArg,
+                    orbitOverride: orbitalSpawnOrbit);
                 rec.VesselSpawned = rec.SpawnedVesselPersistentId != 0;
                 if (rec.VesselSpawned)
                 {
@@ -2398,6 +2405,86 @@ namespace Parsek
                 && rec.TerminalOrbitSemiMajorAxis > 0.0;
         }
 
+        internal static double ComputeRecordedTerminalOrbitMeanAnomalyAtUT(
+            Recording rec, double bodyGravParam, double ut)
+        {
+            if (rec == null
+                || rec.TerminalOrbitSemiMajorAxis <= 0.0
+                || bodyGravParam <= 0.0
+                || double.IsNaN(ut)
+                || double.IsInfinity(ut))
+            {
+                return rec != null ? rec.TerminalOrbitMeanAnomalyAtEpoch : 0.0;
+            }
+
+            if (Math.Abs(ut - rec.TerminalOrbitEpoch) < 1e-9)
+                return rec.TerminalOrbitMeanAnomalyAtEpoch;
+
+            return TimeJumpManager.ComputeEpochShiftedMeanAnomaly(
+                rec.TerminalOrbitMeanAnomalyAtEpoch,
+                rec.TerminalOrbitEpoch,
+                rec.TerminalOrbitSemiMajorAxis,
+                bodyGravParam,
+                ut);
+        }
+
+        internal static bool TryGetPreferredRecordedOrbitSeedForSpawn(
+            Recording rec,
+            out double inclination,
+            out double eccentricity,
+            out double semiMajorAxis,
+            out double lan,
+            out double argumentOfPeriapsis,
+            out double meanAnomalyAtEpoch,
+            out double epoch,
+            out string bodyName)
+        {
+            inclination = 0.0;
+            eccentricity = 0.0;
+            semiMajorAxis = 0.0;
+            lan = 0.0;
+            argumentOfPeriapsis = 0.0;
+            meanAnomalyAtEpoch = 0.0;
+            epoch = 0.0;
+            bodyName = null;
+
+            if (rec == null)
+                return false;
+
+            if (rec.OrbitSegments != null)
+            {
+                for (int i = rec.OrbitSegments.Count - 1; i >= 0; i--)
+                {
+                    OrbitSegment seg = rec.OrbitSegments[i];
+                    if (string.IsNullOrEmpty(seg.bodyName) || seg.semiMajorAxis <= 0.0)
+                        continue;
+
+                    inclination = seg.inclination;
+                    eccentricity = seg.eccentricity;
+                    semiMajorAxis = seg.semiMajorAxis;
+                    lan = seg.longitudeOfAscendingNode;
+                    argumentOfPeriapsis = seg.argumentOfPeriapsis;
+                    meanAnomalyAtEpoch = seg.meanAnomalyAtEpoch;
+                    epoch = seg.epoch;
+                    bodyName = seg.bodyName;
+                    return true;
+                }
+            }
+
+            if (!HasRecordedTerminalOrbit(rec))
+                return false;
+
+            inclination = rec.TerminalOrbitInclination;
+            eccentricity = rec.TerminalOrbitEccentricity;
+            semiMajorAxis = rec.TerminalOrbitSemiMajorAxis;
+            lan = rec.TerminalOrbitLAN;
+            argumentOfPeriapsis = rec.TerminalOrbitArgumentOfPeriapsis;
+            meanAnomalyAtEpoch = rec.TerminalOrbitMeanAnomalyAtEpoch;
+            epoch = rec.TerminalOrbitEpoch;
+            bodyName = rec.TerminalOrbitBody;
+            return true;
+        }
+
         internal static bool ShouldUseRecordedTerminalOrbitSpawnState(Recording rec, bool isEva)
         {
             return !isEva
@@ -2406,38 +2493,91 @@ namespace Parsek
                 && HasRecordedTerminalOrbit(rec);
         }
 
-        internal static bool TryResolveRecordedTerminalOrbitSpawnState(
-            Recording rec, CelestialBody body, double ut,
-            out double lat, out double lon, out double alt, out Vector3d velocity)
+        internal static bool TryBuildRecordedTerminalOrbitForSpawn(
+            Recording rec, CelestialBody body, double ut, out Orbit orbit)
         {
-            lat = 0.0;
-            lon = 0.0;
-            alt = 0.0;
-            velocity = Vector3d.zero;
+            orbit = null;
 
-            if (!HasRecordedTerminalOrbit(rec) || body == null)
+            if (body == null)
                 return false;
 
-            if (!string.Equals(body.name, rec.TerminalOrbitBody, StringComparison.Ordinal))
+            if (!TryGetPreferredRecordedOrbitSeedForSpawn(
+                rec,
+                out double inclination,
+                out double eccentricity,
+                out double semiMajorAxis,
+                out double lan,
+                out double argumentOfPeriapsis,
+                out double meanAnomalyAtEpoch,
+                out double epoch,
+                out string orbitBodyName))
+            {
+                return false;
+            }
+
+            if (!string.Equals(body.name, orbitBodyName, StringComparison.Ordinal))
             {
                 ParsekLog.Warn("Spawner",
-                    $"TryResolveRecordedTerminalOrbitSpawnState: body mismatch " +
-                    $"(body={body.name}, terminalBody={rec.TerminalOrbitBody})");
+                    $"TryBuildRecordedTerminalOrbitForSpawn: body mismatch " +
+                    $"(body={body.name}, terminalBody={orbitBodyName})");
                 return false;
             }
 
             try
             {
-                var orbit = new Orbit(
-                    rec.TerminalOrbitInclination,
-                    rec.TerminalOrbitEccentricity,
-                    rec.TerminalOrbitSemiMajorAxis,
-                    rec.TerminalOrbitLAN,
-                    rec.TerminalOrbitArgumentOfPeriapsis,
-                    rec.TerminalOrbitMeanAnomalyAtEpoch,
-                    rec.TerminalOrbitEpoch,
-                    body);
+                double meanAnomalyAtSpawnUT;
+                if (semiMajorAxis <= 0.0
+                    || body.gravParameter <= 0.0
+                    || double.IsNaN(ut)
+                    || double.IsInfinity(ut)
+                    || Math.Abs(ut - epoch) < 1e-9)
+                {
+                    meanAnomalyAtSpawnUT = meanAnomalyAtEpoch;
+                }
+                else
+                {
+                    meanAnomalyAtSpawnUT = TimeJumpManager.ComputeEpochShiftedMeanAnomaly(
+                        meanAnomalyAtEpoch,
+                        epoch,
+                        semiMajorAxis,
+                        body.gravParameter,
+                        ut);
+                }
 
+                orbit = new Orbit(
+                    inclination,
+                    eccentricity,
+                    semiMajorAxis,
+                    lan,
+                    argumentOfPeriapsis,
+                    meanAnomalyAtSpawnUT,
+                    ut,
+                    body);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                ParsekLog.Warn("Spawner",
+                    $"TryBuildRecordedTerminalOrbitForSpawn failed: {ex.Message}");
+                return false;
+            }
+        }
+
+        internal static bool TryResolveRecordedTerminalOrbitSpawnState(
+            Recording rec, CelestialBody body, double ut,
+            out double lat, out double lon, out double alt, out Vector3d velocity, out Orbit orbit)
+        {
+            lat = 0.0;
+            lon = 0.0;
+            alt = 0.0;
+            velocity = Vector3d.zero;
+            orbit = null;
+
+            if (!TryBuildRecordedTerminalOrbitForSpawn(rec, body, ut, out orbit))
+                return false;
+
+            try
+            {
                 Vector3d worldPos = orbit.getPositionAtUT(ut);
                 velocity = orbit.getOrbitalVelocityAtUT(ut);
                 if (!IsFinite(worldPos) || !IsFinite(velocity))

--- a/Source/Parsek/VesselSpawner.cs
+++ b/Source/Parsek/VesselSpawner.cs
@@ -356,6 +356,8 @@ namespace Parsek
                 ConfigNode orbitNode = new ConfigNode("ORBIT");
                 SaveOrbitToNode(orbit, orbitNode, body);
                 spawnNode.AddNode(orbitNode);
+                if (sit == "ORBITING")
+                    NormalizeOrbitalSpawnMetadata(spawnNode, ut);
 
                 // Crew handling
                 RemoveDeadCrewFromSnapshot(spawnNode);
@@ -480,12 +482,18 @@ namespace Parsek
                 return;
             }
 
-            // Resolve spawn position from snapshot or trajectory endpoint
+            bool isEva = !string.IsNullOrEmpty(rec.EvaCrewName);
+            bool isBreakupContinuous = rec.ChildBranchPointId != null && rec.TerminalStateValue.HasValue;
+            bool useRecordedTerminalOrbit = ShouldUseRecordedTerminalOrbitSpawnState(rec, isEva);
+
+            // Resolve spawn position from snapshot or trajectory endpoint.
             var lastPt = rec.Points[rec.Points.Count - 1];
             double spawnLat, spawnLon, spawnAlt;
             ResolveSpawnPosition(rec, index, lastPt, out spawnLat, out spawnLon, out spawnAlt);
 
-            string spawnBodyName = RecordingEndpointResolver.GetPreferredEndpointBodyName(rec);
+            string spawnBodyName = useRecordedTerminalOrbit
+                ? rec.TerminalOrbitBody
+                : RecordingEndpointResolver.GetPreferredEndpointBodyName(rec);
             CelestialBody body = FlightGlobals.Bodies?.Find(b => b.name == spawnBodyName);
             if (body == null)
             {
@@ -499,9 +507,32 @@ namespace Parsek
                 return;
             }
 
+            double spawnUT = Planetarium.GetUniversalTime();
+            Vector3d orbitalSpawnVelocity = Vector3d.zero;
+            if (useRecordedTerminalOrbit)
+            {
+                if (TryResolveRecordedTerminalOrbitSpawnState(
+                    rec, body, spawnUT, out double orbitLat, out double orbitLon,
+                    out double orbitAlt, out orbitalSpawnVelocity))
+                {
+                    spawnLat = orbitLat;
+                    spawnLon = orbitLon;
+                    spawnAlt = orbitAlt;
+
+                    ParsekLog.Verbose("Spawner", string.Format(CultureInfo.InvariantCulture,
+                        "Spawn #{0} ({1}): using recorded terminal orbit propagated to current UT " +
+                        "(ut={2:F2}, body={3}, lat={4:F4}, lon={5:F4}, alt={6:F1}, speed={7:F1})",
+                        index, rec.VesselName, spawnUT, body.name, spawnLat, spawnLon,
+                        spawnAlt, orbitalSpawnVelocity.magnitude));
+                }
+                else
+                {
+                    useRecordedTerminalOrbit = false;
+                }
+            }
+
             Vector3d spawnPos = body.GetWorldSurfacePosition(spawnLat, spawnLon, spawnAlt);
 
-            bool isEva = !string.IsNullOrEmpty(rec.EvaCrewName);
             // T57: resolve parent vessel PID for EVA collision exemption.
             // EVA trajectories overlap the parent vessel for their entire length;
             // without exemption, walkback exhausts all points and abandons the spawn.
@@ -530,7 +561,6 @@ namespace Parsek
             // Breakup-continuous recordings: snapshot position is from breakup time (mid-air).
             // RespawnVessel uses raw snapshot position, so override it with the trajectory
             // endpoint. Same pattern as EVA fix above. (#224)
-            bool isBreakupContinuous = rec.ChildBranchPointId != null && rec.TerminalStateValue.HasValue;
             if (!isEva && isBreakupContinuous && rec.VesselSnapshot != null)
             {
                 OverrideSnapshotPosition(rec.VesselSnapshot, spawnLat, spawnLon, spawnAlt,
@@ -573,13 +603,16 @@ namespace Parsek
 
             LogSpawnContext(rec, closestDist);
 
-            // SpawnAtPosition dispatch: orbital, EVA, and breakup-continuous all need the
-            // ORBIT subnode rebuilt from the endpoint's lat/lon/alt + velocity.
+            // SpawnAtPosition dispatch: EVA and breakup-continuous paths rebuild the ORBIT
+            // subnode from the resolved spawn position + velocity. Orbiting paths now prefer
+            // the recording's stored terminal orbit propagated to the current spawn UT, so
+            // deferred high-warp spawns do not mix an old endpoint state vector with a later
+            // planet rotation.
             //
             // - Orbital/Docked (#171): raw snapshot orbit was captured during ascent
             //   (suborbital), KSP's on-rails pressure check would destroy the vessel at
-            //   periapsis. SpawnAtPosition constructs a new orbit + correct sit from
-            //   altitude+speed.
+            //   periapsis. SpawnAtPosition constructs a new orbit + correct sit from a
+            //   current-UT propagated orbital state when terminal orbit data is available.
             // - EVA (#264): the snapshot's stale ORBIT subnode (captured when the kerbal
             //   was on the parent ladder) causes OrbitDriver.updateFromParameters to
             //   overwrite the corrected transform with the parent position on the first
@@ -600,12 +633,16 @@ namespace Parsek
                 || isBreakupContinuous;
             if (routeThroughSpawnAtPosition)
             {
-                Vector3d velocity = new Vector3d(lastPt.velocity.x, lastPt.velocity.y, lastPt.velocity.z);
-                double spawnUT = Planetarium.GetUniversalTime();
-                Quaternion? rotArg = isBreakupContinuous ? (Quaternion?)lastPt.rotation : null;
+                Vector3d velocity = useRecordedTerminalOrbit
+                    ? orbitalSpawnVelocity
+                    : new Vector3d(lastPt.velocity.x, lastPt.velocity.y, lastPt.velocity.z);
+                Quaternion? rotArg = isBreakupContinuous && !useRecordedTerminalOrbit
+                    ? (Quaternion?)lastPt.rotation
+                    : null;
 
                 string pathLabel;
-                if (isEva) pathLabel = "EVA";
+                if (useRecordedTerminalOrbit) pathLabel = "Orbital";
+                else if (isEva) pathLabel = "EVA";
                 else if (isBreakupContinuous) pathLabel = "Breakup";
                 else pathLabel = "Orbital";
 
@@ -2298,6 +2335,143 @@ namespace Parsek
 
             if (fixCount > 0)
                 ParsekLog.Info("Spawner", $"Spawn prep: added {fixCount} missing node(s) to snapshot");
+        }
+
+        /// <summary>
+        /// Orbital spawns can stay on rails for a while during high warp. Normalize both the
+        /// top-level packed vessel flags and the per-part atmospheric fields to stock orbital
+        /// ProtoVessel conventions before Load(), so deferred spawns do not inherit ascent-era
+        /// packed metadata. (#353)
+        /// </summary>
+        internal static void NormalizeOrbitalSpawnMetadata(ConfigNode spawnNode, double ut)
+        {
+            if (spawnNode == null)
+                return;
+
+            var ic = CultureInfo.InvariantCulture;
+            int topLevelFixCount = 0;
+            int partFixCount = 0;
+
+            void SetNodeValue(ConfigNode node, string key, string value, ref int fixCount)
+            {
+                if (node == null)
+                    return;
+
+                string current = node.GetValue(key);
+                if (current == value)
+                    return;
+
+                node.SetValue(key, value, true);
+                fixCount++;
+            }
+
+            SetNodeValue(spawnNode, "hgt", "-1", ref topLevelFixCount);
+            SetNodeValue(spawnNode, "distanceTraveled", "0", ref topLevelFixCount);
+            SetNodeValue(spawnNode, "PQSMin", "0", ref topLevelFixCount);
+            SetNodeValue(spawnNode, "PQSMax", "0", ref topLevelFixCount);
+            SetNodeValue(spawnNode, "altDispState", "DEFAULT", ref topLevelFixCount);
+            SetNodeValue(spawnNode, "skipGroundPositioning", "False", ref topLevelFixCount);
+            SetNodeValue(spawnNode, "skipGroundPositioningForDroppedPart", "False", ref topLevelFixCount);
+            SetNodeValue(spawnNode, "vesselSpawning", "False", ref topLevelFixCount);
+            SetNodeValue(spawnNode, "lastUT", ut.ToString("R", ic), ref topLevelFixCount);
+
+            ConfigNode[] partNodes = spawnNode.GetNodes("PART");
+            for (int i = 0; i < partNodes.Length; i++)
+            {
+                SetNodeValue(partNodes[i], "tempExt", "0", ref partFixCount);
+                SetNodeValue(partNodes[i], "tempExtUnexp", "0", ref partFixCount);
+                SetNodeValue(partNodes[i], "staticPressureAtm", "0", ref partFixCount);
+            }
+
+            if (topLevelFixCount > 0 || partFixCount > 0)
+            {
+                ParsekLog.Verbose("Spawner",
+                    $"NormalizeOrbitalSpawnMetadata: rewrote {topLevelFixCount} top-level field(s) " +
+                    $"and {partFixCount} part field(s) for orbital on-rails spawn");
+            }
+        }
+
+        internal static bool HasRecordedTerminalOrbit(Recording rec)
+        {
+            return rec != null
+                && !string.IsNullOrEmpty(rec.TerminalOrbitBody)
+                && rec.TerminalOrbitSemiMajorAxis > 0.0;
+        }
+
+        internal static bool ShouldUseRecordedTerminalOrbitSpawnState(Recording rec, bool isEva)
+        {
+            return !isEva
+                && rec != null
+                && rec.TerminalStateValue == TerminalState.Orbiting
+                && HasRecordedTerminalOrbit(rec);
+        }
+
+        internal static bool TryResolveRecordedTerminalOrbitSpawnState(
+            Recording rec, CelestialBody body, double ut,
+            out double lat, out double lon, out double alt, out Vector3d velocity)
+        {
+            lat = 0.0;
+            lon = 0.0;
+            alt = 0.0;
+            velocity = Vector3d.zero;
+
+            if (!HasRecordedTerminalOrbit(rec) || body == null)
+                return false;
+
+            if (!string.Equals(body.name, rec.TerminalOrbitBody, StringComparison.Ordinal))
+            {
+                ParsekLog.Warn("Spawner",
+                    $"TryResolveRecordedTerminalOrbitSpawnState: body mismatch " +
+                    $"(body={body.name}, terminalBody={rec.TerminalOrbitBody})");
+                return false;
+            }
+
+            try
+            {
+                var orbit = new Orbit(
+                    rec.TerminalOrbitInclination,
+                    rec.TerminalOrbitEccentricity,
+                    rec.TerminalOrbitSemiMajorAxis,
+                    rec.TerminalOrbitLAN,
+                    rec.TerminalOrbitArgumentOfPeriapsis,
+                    rec.TerminalOrbitMeanAnomalyAtEpoch,
+                    rec.TerminalOrbitEpoch,
+                    body);
+
+                Vector3d worldPos = orbit.getPositionAtUT(ut);
+                velocity = orbit.getOrbitalVelocityAtUT(ut);
+                if (!IsFinite(worldPos) || !IsFinite(velocity))
+                {
+                    ParsekLog.Warn("Spawner",
+                        "TryResolveRecordedTerminalOrbitSpawnState: propagated orbital state was non-finite");
+                    return false;
+                }
+
+                lat = body.GetLatitude(worldPos);
+                lon = body.GetLongitude(worldPos);
+                alt = body.GetAltitude(worldPos);
+                if (double.IsNaN(lat) || double.IsNaN(lon) || double.IsNaN(alt)
+                    || double.IsInfinity(lat) || double.IsInfinity(lon) || double.IsInfinity(alt))
+                {
+                    ParsekLog.Warn("Spawner",
+                        "TryResolveRecordedTerminalOrbitSpawnState: propagated orbital position was non-finite");
+                    return false;
+                }
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                ParsekLog.Warn("Spawner",
+                    $"TryResolveRecordedTerminalOrbitSpawnState failed: {ex.Message}");
+                return false;
+            }
+        }
+
+        private static bool IsFinite(Vector3d value)
+        {
+            return !(double.IsNaN(value.x) || double.IsNaN(value.y) || double.IsNaN(value.z)
+                || double.IsInfinity(value.x) || double.IsInfinity(value.y) || double.IsInfinity(value.z));
         }
 
         internal static double SelectRelocatedAltitude(

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -7,13 +7,15 @@ Entries 272–303 (78 bugs, 6 TODOs — mostly resolved) archived in `done/todo-
 
 # Known Bugs
 
-## 354. Orbital end-of-playback spawns can use the wrong vessel snapshot even when the orbit is correct
+## ~~354. Orbital end-of-playback spawns can use the wrong vessel snapshot even when the orbit is correct~~
 
-**Observed in:** `logs/2026-04-14_0419_high-warp-orbit-wrong-real-orbit` (2026-04-14). After the `#353` orbit-source fixes, the real vessel for `Kerbal X` spawned onto the expected last stable Kerbin orbit instead of dying or inheriting a nonsense orbit, but the spawned vessel state still did not match the expected final recorded vessel snapshot.
+**Observed in:** `logs/2026-04-14_0419_high-warp-orbit-wrong-real-orbit` and `logs/2026-04-14_0434_orbital-spawn-wrong-snapshot-followup` (2026-04-14). After the `#353` orbit-source fixes, the real vessel for `Kerbal X` spawned onto the expected last stable Kerbin orbit instead of dying or inheriting a nonsense orbit, but the spawned vessel state still matched an older breakup-time snapshot instead of the final stable-recording state.
 
-**Current understanding:** the orbital spawn path now appears to be sourcing the correct last stable orbit seed, but it still reuses a vessel snapshot whose part/module state does not line up with the final stable-recording state that the user expects to materialize at end of playback. The exact stale fields and whether the bad source is the saved vessel snapshot, snapshot repair, or spawn-time mutation are still unknown.
+**Root cause:** the bad snapshot was already persisted before spawn. In the breakup-continuous tree design, the active recording keeps its earlier `ChildBranchPointId`, so `FinalizeIndividualRecording()` treated it as a non-leaf and skipped the stable-terminal re-snapshot path that normal landed/splashed/orbiting leaves use. `EnsureActiveRecordingTerminalState()` only set `TerminalStateValue`; it did not refresh `VesselSnapshot`, so the tree kept the old post-breakup `_vessel.craft` sidecar even though the terminal orbit had been updated correctly.
 
-**Next investigation:** compare the final trimmed recording state against the spawned vessel snapshot node after `SpawnAtPosition()` / `ProtoVessel.Load()`, then identify which vessel-level or part/module fields need to be refreshed from the final stable recording state instead of the earlier snapshot.
+**Fix:** tree finalization now detects when the active recording is the effective leaf for its vessel and ends in a stable spawnable terminal state (`Landed`, `Splashed`, `Orbiting`). For that case it captures terminal orbit/position from the live vessel and rewrites the terminal snapshot before the tree is persisted, using the same stable-terminal snapshot refresh path as ordinary leaf recordings. Added regression coverage for the effective-leaf versus same-PID-continuation gating helper.
+
+**Status:** ~~Fixed~~
 
 ---
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -7,6 +7,18 @@ Entries 272–303 (78 bugs, 6 TODOs — mostly resolved) archived in `done/todo-
 
 # Known Bugs
 
+## ~~352. Pending-tree merge dialogs can ghost-only the active vessel even when playback would spawn it~~
+
+**Observed in:** `wt-fix-mun-landing-persist` follow-up (2026-04-14). In the merge dialog for a pending tree, an active non-leaf vessel from a breakup-continuous Mun landing or splashdown could default to ghost-only even though the same recording would be spawnable once committed and played back.
+
+**Root cause:** `MergeDialog.CanPersistVessel()` reuses `GhostPlaybackLogic.ShouldSpawnAtRecordingEnd()`, but that policy originally resolved effective-leaf and non-leaf safety-net checks only through `RecordingStore.CommittedTrees`. During the merge dialog the tree is still pending, so active non-leaf recordings had no resolvable tree context and lost the breakup/effective-leaf distinction.
+
+**Fix:** `ShouldSpawnAtRecordingEnd()` now accepts an optional `RecordingTree` context and resolves effective-leaf / non-leaf safety-net checks against either the pending tree or the committed tree. `MergeDialog.BuildDefaultVesselDecisions()` passes the pending tree through for both normal leaves and the active non-leaf fallback, and regression coverage now pins pending-tree effective-leaf, same-PID continuation, and null-`ChildBranchPointId` safety-net behavior.
+
+**Status:** ~~Fixed~~
+
+---
+
 ## ~~351. Long-range landed ghosts can clip into terrain on held final-pose paths~~
 
 **Observed in:** `logs/2026-04-13_2136` ghost-underground follow-up (2026-04-13). A landed watched ghost in the visual tier could still end a playback step with its mesh partially sunk into terrain even though the normal in-flight clamp path kept earlier frames above ground.

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -7,6 +7,18 @@ Entries 272–303 (78 bugs, 6 TODOs — mostly resolved) archived in `done/todo-
 
 # Known Bugs
 
+## ~~353. High-warp orbital end-of-playback spawns can immediately die to on-rails pressure despite a valid rebuilt orbit~~
+
+**Observed in:** `logs/2026-04-14_0301_high-warp-orbit-spawn-missing` and `logs/2026-04-14_0359_high-warp-orbit-stable-orbit-trim` (2026-04-14). During deferred high-time-warp orbital playback for `Kerbal X`, Parsek reported a successful real-vessel spawn but nothing materialized in orbit. The newer bundle also showed the ghost replaying a long stable orbital coast all the way to the original recording end instead of trimming to the normal boring-state buffer after orbit insertion.
+
+**Root cause:** two faults were compounding on the same path. First, `RecordingOptimizer.FindLastInterestingUT()` treated a late zero-throttle `EngineIgnited` seed artifact as real activity, so stable `ExoBallistic` tails were not trimmed to `last real activity + 10s`; playback stayed alive until the raw recording end instead of resolving shortly after the vessel entered its final stable orbit. Second, when the deferred orbital spawn finally ran, the spawn path was mixing time domains: it rebuilt the real vessel at the current `spawnUT`, but it fed `SpawnAtPosition()` a lat/lon/alt + velocity sample captured at the recording endpoint UT. During high warp, that let `GetWorldSurfacePosition()` use a later body rotation while the velocity still belonged to the old inertial state, so the reconstructed orbit could collapse into a suborbital trajectory even though the recording's stored terminal orbit was valid. The reused ascent snapshot also still carried stale packed-vessel and per-part atmospheric fields (`hgt`, PQS bounds, `altDispState`, `tempExt`, `tempExtUnexp`, `staticPressureAtm`), which made the packed vessel look even less like a stock orbital save-state.
+
+**Fix:** stable-orbit boring tails now ignore inert zero-throttle engine/RCS control-state seed artifacts when computing `lastInterestingUT`, so they trim to the normal `~10s` boring-state buffer after the last real activity instead of replaying a full orbital coast. Orbiting end-of-playback spawns also now prefer the recording's stored terminal orbit: `SpawnOrRecoverIfTooClose()` propagates that orbit to the current spawn UT, derives a current lat/lon/alt + orbital velocity from it, and only then calls `SpawnAtPosition()`. `NormalizeOrbitalSpawnMetadata()` also now scrubs both top-level packed fields and per-part atmospheric state back to stock orbital defaults before `ProtoVessel.Load()`. Added regression coverage for the terminal-orbit spawn-state selection, orbital metadata normalization, and zero-throttle engine-seed filtering in boring-tail trim.
+
+**Status:** ~~Fixed~~
+
+---
+
 ## ~~352. Pending-tree merge dialogs can ghost-only the active vessel even when playback would spawn it~~
 
 **Observed in:** `wt-fix-mun-landing-persist` follow-up (2026-04-14). In the merge dialog for a pending tree, an active non-leaf vessel from a breakup-continuous Mun landing or splashdown could default to ghost-only even though the same recording would be spawnable once committed and played back.

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -7,6 +7,16 @@ Entries 272–303 (78 bugs, 6 TODOs — mostly resolved) archived in `done/todo-
 
 # Known Bugs
 
+## 354. Orbital end-of-playback spawns can use the wrong vessel snapshot even when the orbit is correct
+
+**Observed in:** `logs/2026-04-14_0419_high-warp-orbit-wrong-real-orbit` (2026-04-14). After the `#353` orbit-source fixes, the real vessel for `Kerbal X` spawned onto the expected last stable Kerbin orbit instead of dying or inheriting a nonsense orbit, but the spawned vessel state still did not match the expected final recorded vessel snapshot.
+
+**Current understanding:** the orbital spawn path now appears to be sourcing the correct last stable orbit seed, but it still reuses a vessel snapshot whose part/module state does not line up with the final stable-recording state that the user expects to materialize at end of playback. The exact stale fields and whether the bad source is the saved vessel snapshot, snapshot repair, or spawn-time mutation are still unknown.
+
+**Next investigation:** compare the final trimmed recording state against the spawned vessel snapshot node after `SpawnAtPosition()` / `ProtoVessel.Load()`, then identify which vessel-level or part/module fields need to be refreshed from the final stable recording state instead of the earlier snapshot.
+
+---
+
 ## ~~353. High-warp orbital end-of-playback spawns can immediately die to on-rails pressure despite a valid rebuilt orbit~~
 
 **Observed in:** `logs/2026-04-14_0301_high-warp-orbit-spawn-missing` and `logs/2026-04-14_0359_high-warp-orbit-stable-orbit-trim` (2026-04-14). During deferred high-time-warp orbital playback for `Kerbal X`, Parsek reported a successful real-vessel spawn but nothing materialized in orbit. The newer bundle also showed the ghost replaying a long stable orbital coast all the way to the original recording end instead of trimming to the normal boring-state buffer after orbit insertion.


### PR DESCRIPTION
## Summary
- pass the pending tree into merge-dialog persist decisions
- reuse tree-aware effective-leaf and non-leaf safety-net logic before commit
- add regression coverage for pending-tree spawn-policy paths

## Testing
- dotnet test --filter "MergeDialogVesselTests|SpawnSafetyNetTests|RewindTimelineTests"
- dotnet test (1 unrelated pre-existing failure: GhostPlaybackEngineTests.SpawnGhost_PrimesFreshGhostToCurrentPlaybackUT -> System.Security.SecurityException)