### PR TITLE
Drive ghost throttle heat visuals from engine playback

### DIFF
--- a/Source/Parsek.Tests/FxDiagnosticsTests.cs
+++ b/Source/Parsek.Tests/FxDiagnosticsTests.cs
@@ -78,5 +78,26 @@ namespace Parsek.Tests
             Assert.Contains("speed=12.00", line);
             Assert.Contains("playing=True", line);
         }
+
+        [Fact]
+        public void ComputeThrottleDrivenHeatLevel_ZeroPower_ReturnsCold()
+        {
+            Assert.Equal(HeatLevel.Cold, GhostPlaybackLogic.ComputeThrottleDrivenHeatLevel(0f));
+            Assert.Equal(HeatLevel.Cold, GhostPlaybackLogic.ComputeThrottleDrivenHeatLevel(-0.1f));
+        }
+
+        [Fact]
+        public void ComputeThrottleDrivenHeatLevel_PartialPower_ReturnsMedium()
+        {
+            Assert.Equal(HeatLevel.Medium, GhostPlaybackLogic.ComputeThrottleDrivenHeatLevel(0.01f));
+            Assert.Equal(HeatLevel.Medium, GhostPlaybackLogic.ComputeThrottleDrivenHeatLevel(0.5f));
+        }
+
+        [Fact]
+        public void ComputeThrottleDrivenHeatLevel_HighPower_ReturnsHot()
+        {
+            Assert.Equal(HeatLevel.Hot, GhostPlaybackLogic.ComputeThrottleDrivenHeatLevel(0.8f));
+            Assert.Equal(HeatLevel.Hot, GhostPlaybackLogic.ComputeThrottleDrivenHeatLevel(1f));
+        }
     }
 }

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -1174,16 +1174,20 @@ namespace Parsek
                         // the recording-side fix. The 0.01 floor ensures plume visibility
                         // for backward compatibility. New recordings skip zero-throttle
                         // engine seeds entirely (PartStateSeeder.EmitEngineSeedEvents).
-                        SetEngineEmission(state, evt, System.Math.Max(evt.value, 0.01f));
-                        SetEngineAudio(state, evt, System.Math.Max(evt.value, 0.01f));
+                        float ignitionPower = System.Math.Max(evt.value, 0.01f);
+                        SetEngineEmission(state, evt, ignitionPower);
+                        SetEngineAudio(state, evt, ignitionPower);
+                        ApplyThrottleDrivenEngineHeat(state, evt, ignitionPower);
                         break;
                     case PartEventType.EngineShutdown:
                         SetEngineEmission(state, evt, 0f);
                         SetEngineAudio(state, evt, 0f);
+                        ApplyThrottleDrivenEngineHeat(state, evt, 0f);
                         break;
                     case PartEventType.EngineThrottle:
                         SetEngineEmission(state, evt, evt.value);
                         SetEngineAudio(state, evt, evt.value);
+                        ApplyThrottleDrivenEngineHeat(state, evt, evt.value);
                         break;
                     case PartEventType.DeployableExtended:
                         ApplyDeployableState(state, evt, deployed: true);
@@ -1627,6 +1631,33 @@ namespace Parsek
                 }
 
             }
+        }
+
+        // FXModuleAnimateThrottle visuals are sampled into HeatGhostInfo at build time,
+        // but recordings only guarantee engine state events. Drive those sampled
+        // nozzle/emissive states directly from engine playback so active engines do
+        // not stay visually cold in close views.
+        internal static void ApplyThrottleDrivenEngineHeat(
+            GhostPlaybackState state, PartEvent evt, float power)
+        {
+            if (state?.heatInfos == null)
+                return;
+            if (!state.heatInfos.TryGetValue(evt.partPersistentId, out HeatGhostInfo info) || info == null)
+                return;
+            if (info.driverKind != HeatVisualDriverKind.EngineThrottle)
+                return;
+
+            ApplyHeatState(state, evt, ComputeThrottleDrivenHeatLevel(power));
+        }
+
+        internal static HeatLevel ComputeThrottleDrivenHeatLevel(float power)
+        {
+            if (power <= 0f)
+                return HeatLevel.Cold;
+
+            return power >= FlightRecorder.AnimateHeatHotThreshold
+                ? HeatLevel.Hot
+                : HeatLevel.Medium;
         }
 
         /// <summary>

--- a/Source/Parsek/GhostTypes.cs
+++ b/Source/Parsek/GhostTypes.cs
@@ -77,9 +77,17 @@ namespace Parsek
         public Color hotEmission;
     }
 
+    internal enum HeatVisualDriverKind
+    {
+        ModuleAnimateHeat,
+        EngineThrottle,
+        RcsThrottle
+    }
+
     internal class HeatGhostInfo
     {
         public uint partPersistentId;
+        public HeatVisualDriverKind driverKind;
         public List<HeatTransformState> transforms;
         public List<HeatMaterialState> materialStates;
     }

--- a/Source/Parsek/GhostVisualBuilder.cs
+++ b/Source/Parsek/GhostVisualBuilder.cs
@@ -4466,7 +4466,7 @@ namespace Parsek
         /// Returns null if no heat transforms or materials were resolved.
         /// </summary>
         private static HeatGhostInfo TryBuildHeatInfo(
-            Part prefab, string heatAnimName, string heatSource,
+            Part prefab, string heatAnimName, string heatSource, HeatVisualDriverKind driverKind,
             Transform modelNodeTransform, string partName, uint persistentId)
         {
             List<HeatTransformState> resolvedHeatTransforms = null;
@@ -4514,6 +4514,7 @@ namespace Parsek
                 var heatInfo = new HeatGhostInfo
                 {
                     partPersistentId = persistentId,
+                    driverKind = driverKind,
                     transforms = resolvedHeatTransforms,
                     materialStates = heatMaterialStates
                 };
@@ -5709,7 +5710,12 @@ namespace Parsek
                 string heatSource = hasAnimateHeat ? "ModuleAnimateHeat"
                     : hasAnimateThrottle ? "FXModuleAnimateThrottle"
                     : "FXModuleAnimateRCS";
-                heatInfo = TryBuildHeatInfo(prefab, heatAnimName, heatSource,
+                HeatVisualDriverKind driverKind = hasAnimateHeat
+                    ? HeatVisualDriverKind.ModuleAnimateHeat
+                    : hasAnimateThrottle
+                        ? HeatVisualDriverKind.EngineThrottle
+                        : HeatVisualDriverKind.RcsThrottle;
+                heatInfo = TryBuildHeatInfo(prefab, heatAnimName, heatSource, driverKind,
                     modelNode.transform, partName, persistentId);
             }
 


### PR DESCRIPTION
## Summary
- tag ghost heat visuals by driver type so playback can distinguish FXModuleAnimateThrottle from generic heat sources
- drive throttle-based engine heat/emissive visuals from engine ignite/throttle/shutdown events during ghost playback
- add focused regression coverage for the throttle-to-heat mapping used by close flight-camera ghost views

## Testing
- dotnet test Source\\Parsek.Tests\\Parsek.Tests.csproj --filter FxDiagnosticsTests -v minimal