### PR TITLE
Fix rewind resume metadata and background recording cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- `#359` Background `TrackSection` flush/merge paths now dedupe real multi-point overlaps instead of only shaving a single boundary frame, and finalize/revert now prune one-point destroyed debris stubs before they can poison commit metrics, so merged recordings stay structurally monotonic and the related recording-integrity / stop-metrics failures are gone (`PR #285`).
+- `#358` Trees committed after an in-flight `F5`/`F9` quickload-resume now keep the root rewind save, reserved resource budget, and pre-launch baseline across quickload save, vessel-switch/background, split/promotion, and finalize paths, so destroyed-end merged recordings keep a working `Rewind` button instead of silently losing `R` (`PR #285`).
 - `#357` Deferred orbital end-of-playback spawns now recover missed active-vessel handoffs when KSP switches to the spawned vessel without Parsek seeing the normal vessel-switch path, so the live recorder/tree no longer stays attached to the previous vessel through the post-spawn frame sequence.
 - `#356` Optimizer boring-tail trims now require the tail after `lastInterestingUT + buffer` to already be the exact final spawn state, so orbiting/docked/suborbital and landed/splashed recordings are only shortened when nothing changes again before the real spawn.
 - `#355` Flight anchor-camera ghost playback now restores deferred engine/RCS runtime FX state on the first visible frame after deferred activation, so launch ghosts no longer appear to have their engines off until `Watch Ghost` or KSC playback reapplies the same runtime state (`PR #281`).
@@ -99,6 +101,7 @@ All notable changes to Parsek are documented here.
 
 ### Developer Tools
 
+- Added regression coverage for quickload-resume rewind metadata propagation and background recording integrity, including root rewind-budget fallback, recorder-backed commit-path wiring, overlap-aware flat-tail preservation, destroyed-stub prune guards, and the refreshed in-game runtime log-contract assertion behind the `#358` / `#359` fallout.
 - Added regression coverage for missed vessel-switch recovery after deferred orbital spawns, including the pure guard cases and the `Update()` ordering requirement that recovery run before other tree transition handlers (`#357`).
 - Added regression coverage for terminal-state-aware boring-tail trim gating, including exact-match orbit/surface stability checks and the `SubOrbital` orbit-tail path so trims only happen once the spawn state has truly stopped changing (`#356`).
 - Added regression coverage for deferred ghost runtime FX restore, including tracked current-power collection/clearing and first-activation restore gating so anchor-camera launch ghosts keep their engine plume/audio state on the first visible frame (`#355`).

--- a/Source/Parsek.Tests/BackgroundTrackSectionTests.cs
+++ b/Source/Parsek.Tests/BackgroundTrackSectionTests.cs
@@ -562,6 +562,63 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void FinalizeAllForCommit_DoesNotDuplicateTrackSectionPayloadAlreadyMirroredInFlatPoints()
+        {
+            uint pid = 70325;
+            string recId = "rec_flat_overlap";
+            var tree = MakeTree(pid, recId);
+            tree.Recordings[recId].Points.Add(new TrajectoryPoint
+            {
+                ut = 2000.0,
+                latitude = 1.0,
+                longitude = 2.0,
+                altitude = 100.0,
+                rotation = new UnityEngine.Quaternion(0, 0, 0, 1),
+                bodyName = "Kerbin",
+                velocity = new UnityEngine.Vector3(0, 10, 0)
+            });
+            tree.Recordings[recId].Points.Add(new TrajectoryPoint
+            {
+                ut = 2010.0,
+                latitude = 1.1,
+                longitude = 2.1,
+                altitude = 140.0,
+                rotation = new UnityEngine.Quaternion(0, 0.1f, 0, 0.99f),
+                bodyName = "Kerbin",
+                velocity = new UnityEngine.Vector3(0, 20, 0)
+            });
+            var bgRecorder = new BackgroundRecorder(tree);
+
+            bgRecorder.InjectLoadedStateWithEnvironmentForTesting(
+                pid, recId, SegmentEnvironment.Atmospheric, 2000.0);
+            bgRecorder.InjectCurrentTrackSectionFrameForTesting(pid, new TrajectoryPoint
+            {
+                ut = 2000.0,
+                latitude = 1.0,
+                longitude = 2.0,
+                altitude = 100.0,
+                rotation = new UnityEngine.Quaternion(0, 0, 0, 1),
+                bodyName = "Kerbin",
+                velocity = new UnityEngine.Vector3(0, 10, 0)
+            });
+            bgRecorder.InjectCurrentTrackSectionFrameForTesting(pid, new TrajectoryPoint
+            {
+                ut = 2010.0,
+                latitude = 1.1,
+                longitude = 2.1,
+                altitude = 140.0,
+                rotation = new UnityEngine.Quaternion(0, 0.1f, 0, 0.99f),
+                bodyName = "Kerbin",
+                velocity = new UnityEngine.Vector3(0, 20, 0)
+            });
+
+            bgRecorder.FinalizeAllForCommit(2010.0);
+
+            var rec = tree.Recordings[recId];
+            Assert.Equal(new[] { 2000.0, 2010.0 }, rec.Points.Select(p => p.ut).ToArray());
+        }
+
+        [Fact]
         public void FlushLoadedStateForOnRailsTransitionForTesting_NoPayloadEnvChange_PersistsBoundarySection()
         {
             uint pid = 7033;

--- a/Source/Parsek.Tests/Bug278FinalizeLimboTests.cs
+++ b/Source/Parsek.Tests/Bug278FinalizeLimboTests.cs
@@ -490,6 +490,46 @@ namespace Parsek.Tests
                 l.Contains("PruneSinglePointDestroyedDebrisLeaves: removed 1 single-point destroyed debris stub"));
         }
 
+        [Fact]
+        public void CollectSinglePointDestroyedDebrisLeafIds_SkipsRootAndActiveIds()
+        {
+            var tree = new RecordingTree
+            {
+                TreeName = "Test",
+                RootRecordingId = "root-stub",
+                ActiveRecordingId = "active-stub"
+            };
+
+            tree.Recordings["root-stub"] = new Recording
+            {
+                RecordingId = "root-stub",
+                IsDebris = true,
+                TerminalStateValue = TerminalState.Destroyed,
+                Points = new List<TrajectoryPoint> { new TrajectoryPoint { ut = 10.0 } }
+            };
+
+            tree.Recordings["active-stub"] = new Recording
+            {
+                RecordingId = "active-stub",
+                IsDebris = true,
+                TerminalStateValue = TerminalState.Destroyed,
+                Points = new List<TrajectoryPoint> { new TrajectoryPoint { ut = 20.0 } }
+            };
+
+            tree.Recordings["ordinary-stub"] = new Recording
+            {
+                RecordingId = "ordinary-stub",
+                IsDebris = true,
+                TerminalStateValue = TerminalState.Destroyed,
+                Points = new List<TrajectoryPoint> { new TrajectoryPoint { ut = 30.0 } }
+            };
+
+            var ids = ParsekFlight.CollectSinglePointDestroyedDebrisLeafIds(tree);
+
+            Assert.Single(ids);
+            Assert.Equal("ordinary-stub", ids[0]);
+        }
+
         #region InferTerminalStateFromTrajectory
 
         [Fact]

--- a/Source/Parsek.Tests/Bug278FinalizeLimboTests.cs
+++ b/Source/Parsek.Tests/Bug278FinalizeLimboTests.cs
@@ -451,6 +451,45 @@ namespace Parsek.Tests
                 l.Contains("PruneZeroPointLeaves: removed 1 zero-point"));
         }
 
+        [Fact]
+        public void PruneSinglePointDestroyedDebrisLeaves_RemovesDestroyedDebrisStub()
+        {
+            var tree = new RecordingTree { TreeName = "Test" };
+            var keep = new Recording
+            {
+                RecordingId = "keep",
+                VesselPersistentId = 0,
+                ChildBranchPointId = null,
+                ExplicitStartUT = 50.0,
+                ExplicitEndUT = 75.0,
+                IsDebris = true,
+                TerminalStateValue = TerminalState.Destroyed
+            };
+            keep.Points.Add(new TrajectoryPoint { ut = 50.0 });
+            keep.Points.Add(new TrajectoryPoint { ut = 75.0 });
+            tree.Recordings[keep.RecordingId] = keep;
+
+            var stub = new Recording
+            {
+                RecordingId = "destroyed-stub",
+                VesselPersistentId = 0,
+                ChildBranchPointId = null,
+                ExplicitStartUT = 50.0,
+                ExplicitEndUT = 50.0,
+                IsDebris = true,
+                TerminalStateValue = TerminalState.Destroyed
+            };
+            stub.Points.Add(new TrajectoryPoint { ut = 50.0 });
+            tree.Recordings[stub.RecordingId] = stub;
+
+            ParsekFlight.PruneSinglePointDestroyedDebrisLeaves(tree);
+
+            Assert.True(tree.Recordings.ContainsKey("keep"));
+            Assert.False(tree.Recordings.ContainsKey("destroyed-stub"));
+            Assert.Contains(logLines, l =>
+                l.Contains("PruneSinglePointDestroyedDebrisLeaves: removed 1 single-point destroyed debris stub"));
+        }
+
         #region InferTerminalStateFromTrajectory
 
         [Fact]

--- a/Source/Parsek.Tests/CopyRewindSaveToRootTests.cs
+++ b/Source/Parsek.Tests/CopyRewindSaveToRootTests.cs
@@ -150,6 +150,31 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void UsesRecorderFallbackBudget_WhenCaptureAtStopIsNull()
+        {
+            var tree = MakeTree();
+
+            ParsekFlight.CopyRewindSaveToRoot(
+                tree,
+                captureAtStop: null,
+                recorderFallbackSave: "parsek_rw_fallback",
+                recorderFallbackReservedFunds: 1200,
+                recorderFallbackReservedScience: 45,
+                recorderFallbackReservedRep: 7,
+                recorderFallbackPreLaunchFunds: 9000,
+                recorderFallbackPreLaunchScience: 123,
+                recorderFallbackPreLaunchRep: 55);
+
+            var root = tree.Recordings[tree.RootRecordingId];
+            Assert.Equal(1200, root.RewindReservedFunds);
+            Assert.Equal(45, root.RewindReservedScience);
+            Assert.Equal(7, root.RewindReservedRep);
+            Assert.Equal(9000, root.PreLaunchFunds);
+            Assert.Equal(123, root.PreLaunchScience);
+            Assert.Equal(55, root.PreLaunchReputation);
+        }
+
+        [Fact]
         public void UsesRecorderFallback_WhenCaptureHasNoSave()
         {
             var tree = MakeTree();

--- a/Source/Parsek.Tests/CopyRewindSaveToRootTests.cs
+++ b/Source/Parsek.Tests/CopyRewindSaveToRootTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using Xunit;
 
 namespace Parsek.Tests
@@ -67,6 +68,18 @@ namespace Parsek.Tests
                 PreLaunchScience = preSci,
                 PreLaunchReputation = preRep
             };
+        }
+
+        private static void SetRecorderProperty<T>(FlightRecorder recorder, string propertyName, T value)
+        {
+            var prop = typeof(FlightRecorder).GetProperty(
+                propertyName,
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(prop);
+
+            var setter = prop.GetSetMethod(nonPublic: true);
+            Assert.NotNull(setter);
+            setter.Invoke(recorder, new object[] { value });
         }
 
         [Fact]
@@ -166,6 +179,32 @@ namespace Parsek.Tests
                 recorderFallbackPreLaunchRep: 55);
 
             var root = tree.Recordings[tree.RootRecordingId];
+            Assert.Equal(1200, root.RewindReservedFunds);
+            Assert.Equal(45, root.RewindReservedScience);
+            Assert.Equal(7, root.RewindReservedRep);
+            Assert.Equal(9000, root.PreLaunchFunds);
+            Assert.Equal(123, root.PreLaunchScience);
+            Assert.Equal(55, root.PreLaunchReputation);
+        }
+
+        [Fact]
+        public void RecorderOverload_UsesFallbackBudget_WhenCaptureAtStopIsNull()
+        {
+            var tree = MakeTree();
+            var recorder = new FlightRecorder();
+
+            SetRecorderProperty(recorder, nameof(FlightRecorder.RewindSaveFileName), "parsek_rw_fallback");
+            SetRecorderProperty(recorder, nameof(FlightRecorder.RewindReservedFunds), 1200d);
+            SetRecorderProperty(recorder, nameof(FlightRecorder.RewindReservedScience), 45d);
+            SetRecorderProperty(recorder, nameof(FlightRecorder.RewindReservedRep), 7f);
+            SetRecorderProperty(recorder, nameof(FlightRecorder.PreLaunchFunds), 9000d);
+            SetRecorderProperty(recorder, nameof(FlightRecorder.PreLaunchScience), 123d);
+            SetRecorderProperty(recorder, nameof(FlightRecorder.PreLaunchReputation), 55f);
+
+            ParsekFlight.CopyRewindSaveToRoot(tree, recorder, logTag: "RecorderOverload");
+
+            var root = tree.Recordings[tree.RootRecordingId];
+            Assert.Equal("parsek_rw_fallback", root.RewindSaveFileName);
             Assert.Equal(1200, root.RewindReservedFunds);
             Assert.Equal(45, root.RewindReservedScience);
             Assert.Equal(7, root.RewindReservedRep);

--- a/Source/Parsek.Tests/QuickloadResumeTests.cs
+++ b/Source/Parsek.Tests/QuickloadResumeTests.cs
@@ -455,6 +455,8 @@ namespace Parsek.Tests
             Assert.True(copyIdx < saveIdx,
                 "SaveActiveTreeIfAny must copy rewind metadata before serializing the active tree");
             Assert.Contains("recorderFallbackSave: recorder?.RewindSaveFileName", scenarioSrc);
+            Assert.Contains("recorderFallbackReservedFunds: recorder?.RewindReservedFunds ?? 0", scenarioSrc);
+            Assert.Contains("recorderFallbackPreLaunchFunds: recorder?.PreLaunchFunds ?? 0", scenarioSrc);
         }
 
         [Fact]

--- a/Source/Parsek.Tests/QuickloadResumeTests.cs
+++ b/Source/Parsek.Tests/QuickloadResumeTests.cs
@@ -454,9 +454,24 @@ namespace Parsek.Tests
             Assert.True(saveIdx >= 0, "SaveActiveTreeIfAny serialization site not found");
             Assert.True(copyIdx < saveIdx,
                 "SaveActiveTreeIfAny must copy rewind metadata before serializing the active tree");
-            Assert.Contains("recorderFallbackSave: recorder?.RewindSaveFileName", scenarioSrc);
-            Assert.Contains("recorderFallbackReservedFunds: recorder?.RewindReservedFunds ?? 0", scenarioSrc);
-            Assert.Contains("recorderFallbackPreLaunchFunds: recorder?.PreLaunchFunds ?? 0", scenarioSrc);
+            string methodSrc = scenarioSrc.Substring(methodStart, saveIdx - methodStart);
+            Assert.Contains("ParsekFlight.CopyRewindSaveToRoot(", methodSrc);
+            Assert.Contains("activeTree,", methodSrc);
+            Assert.Contains("recorder,", methodSrc);
+        }
+
+        [Fact]
+        public void RecorderBackedCommitPaths_UseRecorderRootCopyOverload()
+        {
+            string srcRoot = System.IO.Path.GetFullPath(
+                System.IO.Path.Combine(System.AppDomain.CurrentDomain.BaseDirectory,
+                    "..", "..", "..", "..", "Parsek"));
+            string flightSrc = System.IO.File.ReadAllText(
+                System.IO.Path.Combine(srcRoot, "ParsekFlight.cs"));
+
+            Assert.Contains("CopyRewindSaveToRoot(activeTree, recorder,", flightSrc);
+            Assert.Contains("CopyRewindSaveToRoot(activeTree, splitRecorder);", flightSrc);
+            Assert.Contains("CopyRewindSaveToRoot(tree, recorder,", flightSrc);
         }
 
         [Fact]

--- a/Source/Parsek.Tests/QuickloadResumeTests.cs
+++ b/Source/Parsek.Tests/QuickloadResumeTests.cs
@@ -428,6 +428,36 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void SaveActiveTreeIfAny_CopiesRecorderRewindSaveToSerializedRoot()
+        {
+            string srcRoot = System.IO.Path.GetFullPath(
+                System.IO.Path.Combine(System.AppDomain.CurrentDomain.BaseDirectory,
+                    "..", "..", "..", "..", "Parsek"));
+            string scenarioSrc = System.IO.File.ReadAllText(
+                System.IO.Path.Combine(srcRoot, "ParsekScenario.cs"));
+
+            int methodStart = scenarioSrc.IndexOf(
+                "private static void SaveActiveTreeIfAny(ConfigNode node)",
+                StringComparison.Ordinal);
+            Assert.True(methodStart >= 0, "SaveActiveTreeIfAny method signature not found");
+
+            int copyIdx = scenarioSrc.IndexOf(
+                "ParsekFlight.CopyRewindSaveToRoot(",
+                methodStart,
+                StringComparison.Ordinal);
+            int saveIdx = scenarioSrc.IndexOf(
+                "activeTree.Save(treeNode);",
+                methodStart,
+                StringComparison.Ordinal);
+
+            Assert.True(copyIdx >= 0, "SaveActiveTreeIfAny no longer copies rewind metadata to the root");
+            Assert.True(saveIdx >= 0, "SaveActiveTreeIfAny serialization site not found");
+            Assert.True(copyIdx < saveIdx,
+                "SaveActiveTreeIfAny must copy rewind metadata before serializing the active tree");
+            Assert.Contains("recorderFallbackSave: recorder?.RewindSaveFileName", scenarioSrc);
+        }
+
+        [Fact]
         public void TryRestoreActiveTreeNode_DoesNotWriteDeadBoundaryAnchorUT()
         {
             // BoundaryAnchor can't round-trip (needs full TrajectoryPoint, not just UT),

--- a/Source/Parsek.Tests/SessionMergerTests.cs
+++ b/Source/Parsek.Tests/SessionMergerTests.cs
@@ -735,6 +735,70 @@ namespace Parsek.Tests
             Assert.Equal(2, merged.TrackSections.Count);
         }
 
+        [Fact]
+        public void MergeTree_NonMonotonicFlatTail_RebuildsFromTrackSectionsInsteadOfPreservingBadCopy()
+        {
+            var section = new TrackSection
+            {
+                environment = SegmentEnvironment.Atmospheric,
+                referenceFrame = ReferenceFrame.Absolute,
+                startUT = 0.0,
+                endUT = 20.0,
+                source = TrackSectionSource.Background,
+                sampleRateHz = 10f,
+                frames = new List<TrajectoryPoint>
+                {
+                    new TrajectoryPoint
+                    {
+                        ut = 0.0,
+                        latitude = 0.0,
+                        longitude = 0.0,
+                        altitude = 100.0,
+                        bodyName = "Kerbin",
+                        rotation = Quaternion.identity,
+                        velocity = Vector3.zero
+                    },
+                    new TrajectoryPoint
+                    {
+                        ut = 10.0,
+                        latitude = 0.1,
+                        longitude = 0.1,
+                        altitude = 110.0,
+                        bodyName = "Kerbin",
+                        rotation = Quaternion.identity,
+                        velocity = Vector3.zero
+                    },
+                    new TrajectoryPoint
+                    {
+                        ut = 20.0,
+                        latitude = 0.2,
+                        longitude = 0.2,
+                        altitude = 120.0,
+                        bodyName = "Kerbin",
+                        rotation = Quaternion.identity,
+                        velocity = Vector3.zero
+                    }
+                },
+                checkpoints = new List<OrbitSegment>(),
+                boundaryDiscontinuityMeters = 0f
+            };
+
+            var rec = MakeRecording("rec-bad-tail", "Bad Tail Vessel", new List<TrackSection> { section });
+            rec.Points = new List<TrajectoryPoint>(section.frames);
+            rec.Points.AddRange(section.frames);
+
+            var tree = MakeTree("Bad Tail", rec);
+
+            var result = SessionMerger.MergeTree(tree);
+            var merged = result["rec-bad-tail"];
+
+            Assert.Equal(new[] { 0.0, 10.0, 20.0 }, merged.Points.Select(p => p.ut).ToArray());
+            Assert.Contains(logLines, l =>
+                l.Contains("[Merger]") &&
+                l.Contains("recording='rec-bad-tail'") &&
+                l.Contains("flatSync=track-sections"));
+        }
+
         #endregion
 
         #region Log assertions — overlap count

--- a/Source/Parsek/InGameTests/RuntimeTests.cs
+++ b/Source/Parsek/InGameTests/RuntimeTests.cs
@@ -2452,14 +2452,17 @@ namespace Parsek.InGameTests
             bool found = false;
             foreach (var line in logLines)
             {
-                if (line.Contains("[Flight]") && line.Contains("re-snapshotted") && line.Contains("[#289]"))
+                if (line.Contains("[Flight]")
+                    && line.Contains("FinalizeIndividualRecording")
+                    && line.Contains("stable terminal state")
+                    && line.Contains("[#289"))
                 {
                     found = true;
                     break;
                 }
             }
             InGameAssert.IsTrue(found,
-                "Expected '[Flight] FinalizeIndividualRecording: re-snapshotted ... [#289]' log line during finalize");
+                "Expected FinalizeIndividualRecording stable-terminal re-snapshot log line during finalize");
         }
 
         [InGameTest(Category = "Bug289", Scene = GameScenes.FLIGHT,

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -1631,7 +1631,14 @@ namespace Parsek
         /// recorder never captures one — the parent's CaptureAtStop is the only source.
         /// </summary>
         internal static void CopyRewindSaveToRoot(RecordingTree tree, Recording captureAtStop,
-            string recorderFallbackSave = null, string logTag = null)
+            string recorderFallbackSave = null,
+            double recorderFallbackReservedFunds = 0,
+            double recorderFallbackReservedScience = 0,
+            float recorderFallbackReservedRep = 0,
+            double recorderFallbackPreLaunchFunds = 0,
+            double recorderFallbackPreLaunchScience = 0,
+            float recorderFallbackPreLaunchRep = 0,
+            string logTag = null)
         {
             if (tree == null || string.IsNullOrEmpty(tree.RootRecordingId)) return;
 
@@ -1652,21 +1659,21 @@ namespace Parsek
 
             // Copy reserved budget if not already set (same first-wins rule).
             // InitiateRewind reads these from the root recording via GetRewindRecording.
-            if (captureAtStop != null && rootRec.RewindReservedFunds == 0
+            if (rootRec.RewindReservedFunds == 0
                 && rootRec.RewindReservedScience == 0 && rootRec.RewindReservedRep == 0)
             {
-                rootRec.RewindReservedFunds = captureAtStop.RewindReservedFunds;
-                rootRec.RewindReservedScience = captureAtStop.RewindReservedScience;
-                rootRec.RewindReservedRep = captureAtStop.RewindReservedRep;
+                rootRec.RewindReservedFunds = captureAtStop?.RewindReservedFunds ?? recorderFallbackReservedFunds;
+                rootRec.RewindReservedScience = captureAtStop?.RewindReservedScience ?? recorderFallbackReservedScience;
+                rootRec.RewindReservedRep = captureAtStop?.RewindReservedRep ?? recorderFallbackReservedRep;
             }
 
             // Copy pre-launch budget if not already set.
-            if (captureAtStop != null && rootRec.PreLaunchFunds == 0
+            if (rootRec.PreLaunchFunds == 0
                 && rootRec.PreLaunchScience == 0 && rootRec.PreLaunchReputation == 0)
             {
-                rootRec.PreLaunchFunds = captureAtStop.PreLaunchFunds;
-                rootRec.PreLaunchScience = captureAtStop.PreLaunchScience;
-                rootRec.PreLaunchReputation = captureAtStop.PreLaunchReputation;
+                rootRec.PreLaunchFunds = captureAtStop?.PreLaunchFunds ?? recorderFallbackPreLaunchFunds;
+                rootRec.PreLaunchScience = captureAtStop?.PreLaunchScience ?? recorderFallbackPreLaunchScience;
+                rootRec.PreLaunchReputation = captureAtStop?.PreLaunchReputation ?? recorderFallbackPreLaunchRep;
             }
         }
 
@@ -6845,6 +6852,9 @@ namespace Parsek
             List<string> result = null;
             foreach (var kvp in tree.Recordings)
             {
+                if (kvp.Key == tree.RootRecordingId || kvp.Key == tree.ActiveRecordingId)
+                    continue;
+
                 var rec = kvp.Value;
                 if (IsSinglePointDestroyedDebrisLeaf(rec))
                 {

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -1490,8 +1490,7 @@ namespace Parsek
             {
                 recorder.TransitionToBackground();
                 FlushRecorderToTreeRecording(recorder, activeTree);
-                CopyRewindSaveToRoot(activeTree, recorder.CaptureAtStop,
-                    recorderFallbackSave: recorder.RewindSaveFileName,
+                CopyRewindSaveToRoot(activeTree, recorder,
                     logTag: "OnVesselSwitch(active)");
 
                 // Add old vessel to BackgroundMap
@@ -1515,8 +1514,7 @@ namespace Parsek
             else if (recorder != null && recorder.IsBackgrounded && recorder.TransitionToBackgroundPending)
             {
                 FlushRecorderToTreeRecording(recorder, activeTree);
-                CopyRewindSaveToRoot(activeTree, recorder.CaptureAtStop,
-                    recorderFallbackSave: recorder.RewindSaveFileName,
+                CopyRewindSaveToRoot(activeTree, recorder,
                     logTag: "OnVesselSwitch(bg)");
 
                 string oldRecId = activeTree.ActiveRecordingId;
@@ -1620,6 +1618,30 @@ namespace Parsek
             ParsekLog.Info("Flight", $"Flushed recorder to tree recording '{recId}': " +
                 $"{rec.Recording.Count} points, {rec.OrbitSegments.Count} orbit segments, " +
                 $"{rec.PartEvents.Count} part events");
+        }
+
+        /// <summary>
+        /// Copies rewind metadata from a live recorder onto the tree root using its
+        /// CaptureAtStop when present, otherwise the recorder's in-memory fallback fields.
+        /// Centralized so every recorder-backed commit path keeps the same rewind budget
+        /// and pre-launch baseline semantics.
+        /// </summary>
+        internal static void CopyRewindSaveToRoot(RecordingTree tree, FlightRecorder sourceRecorder,
+            string logTag = null)
+        {
+            if (sourceRecorder == null) return;
+
+            CopyRewindSaveToRoot(
+                tree,
+                sourceRecorder.CaptureAtStop,
+                recorderFallbackSave: sourceRecorder.RewindSaveFileName,
+                recorderFallbackReservedFunds: sourceRecorder.RewindReservedFunds,
+                recorderFallbackReservedScience: sourceRecorder.RewindReservedScience,
+                recorderFallbackReservedRep: sourceRecorder.RewindReservedRep,
+                recorderFallbackPreLaunchFunds: sourceRecorder.PreLaunchFunds,
+                recorderFallbackPreLaunchScience: sourceRecorder.PreLaunchScience,
+                recorderFallbackPreLaunchRep: sourceRecorder.PreLaunchReputation,
+                logTag: logTag);
         }
 
         /// <summary>
@@ -2067,7 +2089,7 @@ namespace Parsek
                 // After the split, the new child recorder never has the rewind save, so
                 // FinalizeTreeRecordings / StashActiveTreeAsPendingLimbo can't find it.
                 // Copying here preserves it for the R button and rewind budget.
-                CopyRewindSaveToRoot(activeTree, splitRecorder.CaptureAtStop);
+                CopyRewindSaveToRoot(activeTree, splitRecorder);
             }
 
             // Set ChildBranchPointId on parent
@@ -5978,8 +6000,7 @@ namespace Parsek
                 FlushRecorderToTreeRecording(recorder, activeTree);
 
                 // Copy rewind save to the root recording so the R button works after revert.
-                CopyRewindSaveToRoot(activeTree, recorder.CaptureAtStop,
-                    recorderFallbackSave: recorder.RewindSaveFileName,
+                CopyRewindSaveToRoot(activeTree, recorder,
                     logTag: "StashTreeLimbo");
             }
 
@@ -6166,8 +6187,7 @@ namespace Parsek
                 FlushRecorderToTreeRecording(recorder, activeTree);
 
                 // Copy rewind save + reserved budget to the root recording.
-                CopyRewindSaveToRoot(activeTree, recorder.CaptureAtStop,
-                    recorderFallbackSave: recorder.RewindSaveFileName,
+                CopyRewindSaveToRoot(activeTree, recorder,
                     logTag: "MergeCommitFlush");
 
                 oldVesselPid = recorder.RecordingVesselId;
@@ -6281,8 +6301,7 @@ namespace Parsek
                 FlushRecorderToTreeRecording(recorder, tree);
 
                 // Copy rewind save + reserved budget to the root recording.
-                CopyRewindSaveToRoot(tree, recorder.CaptureAtStop,
-                    recorderFallbackSave: recorder.RewindSaveFileName,
+                CopyRewindSaveToRoot(tree, recorder,
                     logTag: "FinalizeTreeRecordings");
             }
 

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -6297,6 +6297,7 @@ namespace Parsek
             // 4. Prune zero-point debris leaves (#173) — removes recordings with no
             // trajectory data that were created from same-frame destruction debris.
             PruneZeroPointLeaves(tree);
+            PruneSinglePointDestroyedDebrisLeaves(tree);
 
             // Compute tree-level resource delta
             tree.DeltaFunds = ComputeTreeDeltaFunds(tree);
@@ -6755,6 +6756,35 @@ namespace Parsek
             if (toPrune == null || toPrune.Count == 0)
                 return;
 
+            PruneLeafRecordings(
+                tree,
+                toPrune,
+                "PruneZeroPointLeaves",
+                "zero-point leaf recording(s)");
+        }
+
+        internal static void PruneSinglePointDestroyedDebrisLeaves(RecordingTree tree)
+        {
+            var toPrune = CollectSinglePointDestroyedDebrisLeafIds(tree);
+            if (toPrune == null || toPrune.Count == 0)
+                return;
+
+            // Same-frame breakup debris can die inside the coalescing window and only retain
+            // the split seed point. These stubs are non-playable, fail the data-health
+            // contract, and never contribute a meaningful ghost or spawn path.
+            PruneLeafRecordings(
+                tree,
+                toPrune,
+                "PruneSinglePointDestroyedDebrisLeaves",
+                "single-point destroyed debris stub(s)");
+        }
+
+        private static void PruneLeafRecordings(
+            RecordingTree tree,
+            List<string> toPrune,
+            string logTag,
+            string description)
+        {
             for (int i = 0; i < toPrune.Count; i++)
             {
                 string id = toPrune[i];
@@ -6786,7 +6816,7 @@ namespace Parsek
             }
 
             ParsekLog.Info("Flight",
-                $"PruneZeroPointLeaves: removed {toPrune.Count} zero-point leaf recording(s)" +
+                $"{logTag}: removed {toPrune.Count} {description}" +
                 (prunedBPs > 0 ? $" and {prunedBPs} empty branch point(s)" : "") +
                 $" from tree '{tree.TreeName}'");
         }
@@ -6810,6 +6840,21 @@ namespace Parsek
             return result;
         }
 
+        internal static List<string> CollectSinglePointDestroyedDebrisLeafIds(RecordingTree tree)
+        {
+            List<string> result = null;
+            foreach (var kvp in tree.Recordings)
+            {
+                var rec = kvp.Value;
+                if (IsSinglePointDestroyedDebrisLeaf(rec))
+                {
+                    if (result == null) result = new List<string>();
+                    result.Add(kvp.Key);
+                }
+            }
+            return result;
+        }
+
         /// <summary>
         /// Returns true if a recording is a leaf with no playback data (zero points,
         /// no orbit segments, no surface position).
@@ -6821,6 +6866,16 @@ namespace Parsek
             return rec.Points.Count == 0
                 && rec.OrbitSegments.Count == 0
                 && !rec.SurfacePos.HasValue;
+        }
+
+        internal static bool IsSinglePointDestroyedDebrisLeaf(Recording rec)
+        {
+            if (rec == null || rec.ChildBranchPointId != null) return false;
+            if (rec.SidecarLoadFailed) return false;
+            if (!rec.IsDebris || rec.TerminalStateValue != TerminalState.Destroyed) return false;
+            if (rec.Points.Count != 1) return false;
+            if (rec.OrbitSegments.Count > 0 || rec.SurfacePos.HasValue) return false;
+            return rec.TrackSections == null || rec.TrackSections.Count == 0;
         }
 
         internal static double ComputeTreeDeltaFunds(RecordingTree tree)

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -463,14 +463,7 @@ namespace Parsek
             // serializing so an F5/F9 tree keeps its rewind affordance after merge.
             ParsekFlight.CopyRewindSaveToRoot(
                 activeTree,
-                recorder?.CaptureAtStop,
-                recorderFallbackSave: recorder?.RewindSaveFileName,
-                recorderFallbackReservedFunds: recorder?.RewindReservedFunds ?? 0,
-                recorderFallbackReservedScience: recorder?.RewindReservedScience ?? 0,
-                recorderFallbackReservedRep: recorder?.RewindReservedRep ?? 0,
-                recorderFallbackPreLaunchFunds: recorder?.PreLaunchFunds ?? 0,
-                recorderFallbackPreLaunchScience: recorder?.PreLaunchScience ?? 0,
-                recorderFallbackPreLaunchRep: recorder?.PreLaunchReputation ?? 0,
+                recorder,
                 logTag: "SaveActiveTreeIfAny");
 
             ConfigNode treeNode = node.AddNode("RECORDING_TREE");

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -457,6 +457,16 @@ namespace Parsek
                 $"SaveActiveTreeIfAny: iterated {activeRecCount} recording(s), " +
                 $"{activeDirtyCount} dirty, {activeSavedCount} saved, {activeSaveFailedCount} failed");
 
+            // Quickload resume restores the recorder's rewind save hint from
+            // resumeRewindSave, but the committed tree's Rewind button resolves through the
+            // root recording. Mirror the live recorder rewind metadata onto the root before
+            // serializing so an F5/F9 tree keeps its rewind affordance after merge.
+            ParsekFlight.CopyRewindSaveToRoot(
+                activeTree,
+                recorder?.CaptureAtStop,
+                recorderFallbackSave: recorder?.RewindSaveFileName,
+                logTag: "SaveActiveTreeIfAny");
+
             ConfigNode treeNode = node.AddNode("RECORDING_TREE");
             activeTree.Save(treeNode);
             treeNode.AddValue("isActive", "True");
@@ -2148,6 +2158,7 @@ namespace Parsek
             }
             ParsekFlight.EnsureActiveRecordingTerminalState(tree, isSceneExit: true);
             ParsekFlight.PruneZeroPointLeaves(tree);
+            ParsekFlight.PruneSinglePointDestroyedDebrisLeaves(tree);
 
             RecordingStore.MarkPendingTreeFinalized();
             ParsekLog.Info("Scenario",

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -465,6 +465,12 @@ namespace Parsek
                 activeTree,
                 recorder?.CaptureAtStop,
                 recorderFallbackSave: recorder?.RewindSaveFileName,
+                recorderFallbackReservedFunds: recorder?.RewindReservedFunds ?? 0,
+                recorderFallbackReservedScience: recorder?.RewindReservedScience ?? 0,
+                recorderFallbackReservedRep: recorder?.RewindReservedRep ?? 0,
+                recorderFallbackPreLaunchFunds: recorder?.PreLaunchFunds ?? 0,
+                recorderFallbackPreLaunchScience: recorder?.PreLaunchScience ?? 0,
+                recorderFallbackPreLaunchRep: recorder?.PreLaunchReputation ?? 0,
                 logTag: "SaveActiveTreeIfAny");
 
             ConfigNode treeNode = node.AddNode("RECORDING_TREE");

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -3244,6 +3244,12 @@ namespace Parsek
                     return false;
             }
 
+            if (!TrajectoryPointListIsMonotonicNonDecreasing(flatPoints)
+                || !OrbitSegmentListIsMonotonicNonDecreasing(flatOrbitSegments))
+            {
+                return false;
+            }
+
             return flatPoints.Count > rebuiltPoints.Count
                 || flatOrbitSegments.Count > rebuiltOrbitSegments.Count;
         }
@@ -3309,26 +3315,13 @@ namespace Parsek
             if (tracks == null || tracks.Count == 0 || points == null)
                 return 0;
 
-            int dedupedBoundaryCopies = 0;
-            for (int t = 0; t < tracks.Count; t++)
-            {
-                if (tracks[t].referenceFrame == ReferenceFrame.OrbitalCheckpoint || tracks[t].frames == null)
-                    continue;
+            var rebuiltPoints = new List<TrajectoryPoint>();
+            int dedupedBoundaryCopies = RebuildPointsFromTrackSections(tracks, rebuiltPoints);
+            int overlapCopies = FindTrajectoryPointSuffixPrefixOverlap(points, rebuiltPoints);
+            for (int i = overlapCopies; i < rebuiltPoints.Count; i++)
+                points.Add(rebuiltPoints[i]);
 
-                for (int i = 0; i < tracks[t].frames.Count; i++)
-                {
-                    var pt = tracks[t].frames[i];
-                    if (points.Count > 0 && TrajectoryPointEquals(points[points.Count - 1], pt))
-                    {
-                        dedupedBoundaryCopies++;
-                        continue;
-                    }
-
-                    points.Add(pt);
-                }
-            }
-
-            return dedupedBoundaryCopies;
+            return dedupedBoundaryCopies + overlapCopies;
         }
 
         internal static bool ContainsRelativeTrackSections(List<TrackSection> tracks)
@@ -3431,6 +3424,20 @@ namespace Parsek
             return true;
         }
 
+        private static bool TrajectoryPointListIsMonotonicNonDecreasing(List<TrajectoryPoint> points)
+        {
+            if (points == null)
+                return true;
+
+            for (int i = 1; i < points.Count; i++)
+            {
+                if (points[i].ut < points[i - 1].ut)
+                    return false;
+            }
+
+            return true;
+        }
+
         private static bool OrbitSegmentListsEqual(List<OrbitSegment> a, List<OrbitSegment> b)
         {
             if (ReferenceEquals(a, b))
@@ -3441,6 +3448,20 @@ namespace Parsek
             for (int i = 0; i < a.Count; i++)
             {
                 if (!OrbitSegmentEquals(a[i], b[i]))
+                    return false;
+            }
+
+            return true;
+        }
+
+        private static bool OrbitSegmentListIsMonotonicNonDecreasing(List<OrbitSegment> orbitSegments)
+        {
+            if (orbitSegments == null)
+                return true;
+
+            for (int i = 1; i < orbitSegments.Count; i++)
+            {
+                if (orbitSegments[i].startUT < orbitSegments[i - 1].startUT)
                     return false;
             }
 
@@ -3480,26 +3501,69 @@ namespace Parsek
             if (tracks == null || tracks.Count == 0 || orbitSegments == null)
                 return 0;
 
-            int dedupedCopies = 0;
-            for (int t = 0; t < tracks.Count; t++)
+            var rebuiltOrbitSegments = new List<OrbitSegment>();
+            int dedupedCopies = RebuildOrbitSegmentsFromTrackSections(tracks, rebuiltOrbitSegments);
+            int overlapCopies = FindOrbitSegmentSuffixPrefixOverlap(orbitSegments, rebuiltOrbitSegments);
+            for (int i = overlapCopies; i < rebuiltOrbitSegments.Count; i++)
+                orbitSegments.Add(rebuiltOrbitSegments[i]);
+
+            return dedupedCopies + overlapCopies;
+        }
+
+        private static int FindTrajectoryPointSuffixPrefixOverlap(
+            List<TrajectoryPoint> existing,
+            List<TrajectoryPoint> incoming)
+        {
+            if (existing == null || incoming == null || existing.Count == 0 || incoming.Count == 0)
+                return 0;
+
+            int maxOverlap = Math.Min(existing.Count, incoming.Count);
+            for (int overlap = maxOverlap; overlap > 0; overlap--)
             {
-                if (tracks[t].referenceFrame != ReferenceFrame.OrbitalCheckpoint || tracks[t].checkpoints == null)
-                    continue;
-
-                for (int i = 0; i < tracks[t].checkpoints.Count; i++)
+                bool matches = true;
+                int existingStart = existing.Count - overlap;
+                for (int i = 0; i < overlap; i++)
                 {
-                    var seg = tracks[t].checkpoints[i];
-                    if (orbitSegments.Count > 0 && OrbitSegmentEquals(orbitSegments[orbitSegments.Count - 1], seg))
+                    if (!TrajectoryPointEquals(existing[existingStart + i], incoming[i]))
                     {
-                        dedupedCopies++;
-                        continue;
+                        matches = false;
+                        break;
                     }
-
-                    orbitSegments.Add(seg);
                 }
+
+                if (matches)
+                    return overlap;
             }
 
-            return dedupedCopies;
+            return 0;
+        }
+
+        private static int FindOrbitSegmentSuffixPrefixOverlap(
+            List<OrbitSegment> existing,
+            List<OrbitSegment> incoming)
+        {
+            if (existing == null || incoming == null || existing.Count == 0 || incoming.Count == 0)
+                return 0;
+
+            int maxOverlap = Math.Min(existing.Count, incoming.Count);
+            for (int overlap = maxOverlap; overlap > 0; overlap--)
+            {
+                bool matches = true;
+                int existingStart = existing.Count - overlap;
+                for (int i = 0; i < overlap; i++)
+                {
+                    if (!OrbitSegmentEquals(existing[existingStart + i], incoming[i]))
+                    {
+                        matches = false;
+                        break;
+                    }
+                }
+
+                if (matches)
+                    return overlap;
+            }
+
+            return 0;
         }
 
         private static bool TrajectoryPointEquals(TrajectoryPoint a, TrajectoryPoint b)

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -7,6 +7,30 @@ Entries 272–303 (78 bugs, 6 TODOs — mostly resolved) archived in `done/todo-
 
 # Known Bugs
 
+## ~~359. Background section flushes can duplicate flat tails and leave one-point destroyed debris stubs after merge~~
+
+**Observed in:** the same 2026-04-14 follow-up investigation that found the missing `Rewind` button. The runtime/in-game suite was failing `CommittedRecordingsHaveValidData` and `RecordingStopMetricsValid`, and merged quickload-resume trees could retain non-monotonic flat tails or single-point destroyed debris leaves that were never meant to survive commit.
+
+**Root cause:** loaded background recordings could already hold data in both top-level `Points`/`OrbitSegments` and nested `TrackSections`. Later flushes appended the same section payload again using only a single-boundary-element dedupe, so multi-point overlaps produced duplicated / non-monotonic flat tails that survived session merge. Separately, the crash/continuation coalescer could leave one-point destroyed debris leaf recordings in the tree, which then polluted stop-metric expectations unless pruned.
+
+**Fix:** background append/merge now performs suffix/prefix overlap matching and refuses to preserve flat extensions that are not monotonic past the authoritative section payload. Finalize/revert also prune single-point destroyed debris leaves while explicitly protecting the tree root and active recording IDs. The stale in-game runtime-log assertion was updated to the current logging contract.
+
+**Status:** ~~Fixed~~
+
+---
+
+## ~~358. Quickload-resumed destroyed-end merged recordings can lose the Rewind button and rewind baseline~~
+
+**Observed in:** local 2026-04-14 follow-up after the revert/finalize regression fix. A tree recording was quicksaved/quickloaded in flight, ended `Destroyed`, merged into the timeline, and the Recordings window showed no `R` button even though the mission should still rewind to the original launch save.
+
+**Root cause:** quickload resume preserved `resumeRewindSave` on the live recorder, but committed trees resolve rewind through the root recording. `SaveActiveTreeIfAny()` initially failed to mirror that metadata to the root, and several other recorder-backed commit paths (vessel-switch/background/finalize) still hand-wired only the save filename without the reserved-budget / pre-launch fallback fields. A resumed tree could therefore keep the save hint but lose the rewind baseline once the active recorder changed or the tree finalized.
+
+**Fix:** root rewind propagation is now centralized through `CopyRewindSaveToRoot(RecordingTree, FlightRecorder, ...)` and used by quickload save, split, vessel-switch/background, stash/finalize, and revert commit paths. The helper now copies the rewind save, reserved resource budget, and pre-launch baseline from `CaptureAtStop` when available or from the live recorder fallback fields otherwise. Added focused regression coverage for both the helper behavior and the critical call-site wiring.
+
+**Status:** ~~Fixed~~
+
+---
+
 ## ~~357. Deferred orbital spawn can switch the live active vessel without Parsek switching its recorder/tree~~
 
 **Observed in:** `logs/2026-04-14_1624_orbital-spawn-bug` (2026-04-14). During watched playback of `Goliath II HLV`, KSP handed control to the newly spawned real vessel, but Parsek still believed the active recorder/tree belonged to the pad-launched `Jumping Flea`. That left a short desync window immediately after spawn where subsequent logic was running against the wrong active vessel.


### PR DESCRIPTION
## Summary
- preserve active-tree rewind metadata on the root recording before quickload-resume serialization
- stop background track-section flushes from duplicating flat trajectory tails and rebuilding bad non-monotonic recordings
- prune single-point destroyed debris stubs and update the stale #289 in-game log assertion

## Testing
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter FullyQualifiedName~QuickloadResumeTests
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter FullyQualifiedName~BackgroundTrackSectionTests
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter FullyQualifiedName~SessionMergerTests
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter FullyQualifiedName~Bug278FinalizeLimboTests