### PR TITLE
docs: update shortcut and recording control docs

### DIFF
--- a/Source/README.md
+++ b/Source/README.md
@@ -145,14 +145,17 @@ The script exits non-zero if required log contracts fail.
 2. Open the Parsek window from the toolbar button
 
 **Controls:**
-- **F9** - Start/Stop recording
-- **F10** - Preview playback (plays current recording from now)
-- **F11** - Stop preview
 - **Toolbar button** - Show/hide the Parsek window
+- **Parsek window buttons** - Start/Stop recording and Preview Playback
+- **Ctrl+Shift+T** - Toggle the diagnostics / in-game test runner
+- **[** or **]** - Exit watch mode
+- **V** - Toggle watch camera mode while watching a ghost
+
+Parsek does not bind `F5` or `F9`. Those remain stock KSP quicksave/quickload keys only.
 
 ### Timeline Test (core flow)
 
-1. Press F9, fly for 30-60s, press F9 to stop
+1. Start recording from the Parsek window (or let auto-record start on liftoff), fly for 30-60s, then stop recording from the Parsek window
 2. Revert to Launch (Esc > Revert to Launch)
 3. Context-aware merge dialog appears with recommended action
 4. Wait on the pad - when UT reaches the original timestamps, an opaque ghost vessel replays the flight
@@ -161,7 +164,7 @@ The script exits non-zero if required log contracts fail.
 ### Vessel Persistence Tests
 
 **Persist in orbit:**
-1. Launch to orbit, F9 record, revert to launch
+1. Launch to orbit, stop the recording from the Parsek window, revert to launch
 2. Dialog defaults to "Merge to Timeline" - click it
 3. Go to Tracking Station - vessel should appear in orbit
 

--- a/docs/dev/manual-testing/test-auto-record.md
+++ b/docs/dev/manual-testing/test-auto-record.md
@@ -5,7 +5,7 @@
 2. Stage / throttle up so the vessel lifts off
 3. Verify: screen message "Recording STARTED (auto)" appears
 4. Verify: Parsek UI (toolbar window) shows "RECORDING" status
-5. Fly for 30+ seconds, press F9 to stop, revert, merge as usual
+5. Fly for 30+ seconds, stop the recording from the Parsek window, revert, merge as usual
 
 ## 2. Auto-start on runway
 1. Launch a plane from the runway
@@ -17,18 +17,18 @@
 2. EVA a kerbal (right-click crew hatch → EVA)
 3. Verify: recording auto-starts on the EVA kerbal
 4. Verify: screen message "Recording STARTED (auto - EVA from pad)"
-5. Walk around, F9 to stop, revert, check merge dialog works
+5. Walk around, stop the recording from the Parsek window, revert, check merge dialog works
 
 ## 4. EVA from orbit (negative test)
 1. Launch to orbit normally (auto-record triggers on launch - that's fine)
-2. F9 to stop recording
+2. Stop the current recording from the Parsek window
 3. EVA a kerbal in orbit
 4. Verify: recording does NOT auto-start (vessel was not PRELAUNCH)
 
-## 5. Manual F9 still works
+## 5. Manual recording via UI still works
 1. Sit on the pad (don't launch)
-2. Press F9 manually - recording should start
-3. Press F9 again - recording should stop
+2. Click `Start Recording` in the Parsek window - recording should start
+3. Click `Stop Recording` in the Parsek window - recording should stop
 4. Verify no double-start when you then launch (already recording, guard should prevent it)
 
 ## 6. No double-trigger
@@ -37,7 +37,7 @@
 3. Check KSP.log: should see exactly one "Auto-record started" entry per launch
 
 ## 7. Full revert cycle with auto-record
-1. Launch (auto-records) → fly 30-60s → F9 stop → Revert to Launch
+1. Launch (auto-records) → fly 30-60s → stop the recording from the Parsek window → Revert to Launch
 2. Merge dialog should appear as normal
 3. Ghost should play back correctly
 4. No regressions in crew replacement, vessel spawning, etc.
@@ -45,7 +45,7 @@
 ## 8. Auto-record disabled via Settings
 1. Open Parsek UI → Settings → uncheck "Auto-record on launch"
 2. Launch from pad - verify recording does NOT auto-start
-3. Press F9 manually - verify manual recording still works
+3. Click `Start Recording` in the Parsek window - verify manual recording still works
 4. Re-enable "Auto-record on launch" → launch again → verify auto-record works
 
 ## 9. Auto-EVA-record disabled via Settings

--- a/docs/dev/manual-testing/test-general.md
+++ b/docs/dev/manual-testing/test-general.md
@@ -7,9 +7,9 @@ Use career mode for all tests (resource tracking requires it).
 ## Recording + Timeline (core flow)
 
 1. Launch any vessel from the pad
-2. Recording auto-starts on liftoff (or press F9 manually)
+2. Recording auto-starts on liftoff if enabled, or click `Start Recording` in the Parsek window
 3. Fly around for 30-60 seconds
-4. Press F9 to stop recording
+4. Click `Stop Recording` in the Parsek window
 5. Revert to Launch (Esc → Revert to Launch)
 6. Merge dialog appears - pick any option
 7. Wait on the pad until UT reaches the recording's timestamps
@@ -24,7 +24,7 @@ Use career mode for all tests (resource tracking requires it).
 3. Pick "Merge to Timeline" - ghost plays back, no vessel spawns
 
 ### Vessel intact
-1. Launch to orbit, F9 stop, revert
+1. Launch to orbit, stop the recording from the Parsek window, revert
 2. Verify: dialog shows "Merge to Timeline" and "Discard" buttons
 3. Pick "Merge to Timeline" - vessel appears in Tracking Station after ghost finishes
 
@@ -41,7 +41,7 @@ Use career mode for all tests (resource tracking requires it).
 
 ### Basic swap (regression test for crew-not-swapped bug)
 1. Launch a vessel with Jeb as pilot
-2. F9 start recording, fly around briefly, F9 stop
+2. Start recording from the Parsek window, fly around briefly, then stop recording from the Parsek window
 3. Revert to Launch
 4. Merge dialog appears - pick "Merge to Timeline"
 5. **Verify on the pad:** the vessel's crew portrait should show a REPLACEMENT kerbal, NOT Jeb
@@ -77,16 +77,16 @@ Use career mode for all tests (resource tracking requires it).
 
 ## Manual Preview
 
-1. Record a flight, press F9 to stop (do NOT revert)
-2. Press F10 - ghost replays your flight in real time
-3. Press F11 to stop the preview
+1. Record a flight, then stop the recording from the Parsek window (do NOT revert)
+2. Click `Preview Playback` - ghost replays your flight in real time
+3. Click `Stop Preview`
 4. Verify: ghost disappears cleanly
 
 ## Recording Safeguards
 
 ### Paused game
 1. Pause the game (Esc)
-2. Press F9 - should show "Cannot record while paused"
+2. Click `Start Recording` in the Parsek window - should show "Cannot record while paused"
 
 ### Vessel change stops recording
 1. Start recording on one vessel


### PR DESCRIPTION
## Summary
- remove stale references to F9/F10/F11 as Parsek controls
- document the current controls: toolbar/UI actions, Ctrl+Shift+T, watch-mode [/] and V
- update manual testing docs to use the Parsek window for recording and preview actions

## Testing
- not run (documentation-only changes)