### PR TITLE
Fix orbital spawn replay state regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- `#357` Deferred orbital end-of-playback spawns now recover missed active-vessel handoffs when KSP switches to the spawned vessel without Parsek seeing the normal vessel-switch path, so the live recorder/tree no longer stays attached to the previous vessel through the post-spawn frame sequence.
+- `#356` Optimizer boring-tail trims now require the tail after `lastInterestingUT + buffer` to already match the recording's real terminal spawn state, so orbiting and landed/splashed recordings are only shortened when nothing meaningful changes again before the final spawn.
 - `#355` Flight anchor-camera ghost playback now restores deferred engine/RCS runtime FX state on the first visible frame after deferred activation, so launch ghosts no longer appear to have their engines off until `Watch Ghost` or KSC playback reapplies the same runtime state (`PR #281`).
 - Fresh first-appearance ghost engine audio now waits until the ghost hierarchy is actually active before calling Unity `AudioSource.Play()`, so the retained engine sources no longer emit `Can not play a disabled audio source` warnings on the same deferred first frame that `#355` restored runtime FX/audio state (`PR #282`).
 - `#354` Active breakup-continuous tree recordings that end in a stable spawned state now get a fresh terminal snapshot during tree finalization, so effective-leaf orbital end-of-playback spawns no longer reuse the old post-breakup `_vessel.craft` node after the orbit itself has already been corrected.
@@ -97,6 +99,8 @@ All notable changes to Parsek are documented here.
 
 ### Developer Tools
 
+- Added regression coverage for missed vessel-switch recovery after deferred orbital spawns, including the pure guard cases and the `Update()` ordering requirement that recovery run before other tree transition handlers (`#357`).
+- Added regression coverage for terminal-state-aware boring-tail trim gating, covering stable-vs-changing terminal orbit tails and stable-vs-changing landed surface tails so trims only happen once the spawn state has truly settled (`#356`).
 - Added regression coverage for deferred ghost runtime FX restore, including tracked current-power collection/clearing and first-activation restore gating so anchor-camera launch ghosts keep their engine plume/audio state on the first visible frame (`#355`).
 - Added regression coverage for high-warp orbital spawn hardening and stable-orbit tail trimming: terminal-orbit spawn-state selection, top-level and per-part orbital metadata normalization, and zero-throttle engine-seed filtering in boring-tail trim so stable orbital coasts resolve on the normal 10-second buffer instead of replaying their full tail (`#353`).
 - Expanded ghost-visual frame coverage so breakup child ghosts stay anchored to split-time snapshots without a duplicate debris center-of-mass offset (`PR #271`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to Parsek are documented here.
 ### Bug Fixes
 
 - `#357` Deferred orbital end-of-playback spawns now recover missed active-vessel handoffs when KSP switches to the spawned vessel without Parsek seeing the normal vessel-switch path, so the live recorder/tree no longer stays attached to the previous vessel through the post-spawn frame sequence.
-- `#356` Optimizer boring-tail trims now require the tail after `lastInterestingUT + buffer` to already match the recording's real terminal spawn state, so orbiting and landed/splashed recordings are only shortened when nothing meaningful changes again before the final spawn.
+- `#356` Optimizer boring-tail trims now require the tail after `lastInterestingUT + buffer` to already be the exact final spawn state, so orbiting/docked/suborbital and landed/splashed recordings are only shortened when nothing changes again before the real spawn.
 - `#355` Flight anchor-camera ghost playback now restores deferred engine/RCS runtime FX state on the first visible frame after deferred activation, so launch ghosts no longer appear to have their engines off until `Watch Ghost` or KSC playback reapplies the same runtime state (`PR #281`).
 - Fresh first-appearance ghost engine audio now waits until the ghost hierarchy is actually active before calling Unity `AudioSource.Play()`, so the retained engine sources no longer emit `Can not play a disabled audio source` warnings on the same deferred first frame that `#355` restored runtime FX/audio state (`PR #282`).
 - `#354` Active breakup-continuous tree recordings that end in a stable spawned state now get a fresh terminal snapshot during tree finalization, so effective-leaf orbital end-of-playback spawns no longer reuse the old post-breakup `_vessel.craft` node after the orbit itself has already been corrected.
@@ -100,7 +100,7 @@ All notable changes to Parsek are documented here.
 ### Developer Tools
 
 - Added regression coverage for missed vessel-switch recovery after deferred orbital spawns, including the pure guard cases and the `Update()` ordering requirement that recovery run before other tree transition handlers (`#357`).
-- Added regression coverage for terminal-state-aware boring-tail trim gating, covering stable-vs-changing terminal orbit tails and stable-vs-changing landed surface tails so trims only happen once the spawn state has truly settled (`#356`).
+- Added regression coverage for terminal-state-aware boring-tail trim gating, including exact-match orbit/surface stability checks and the `SubOrbital` orbit-tail path so trims only happen once the spawn state has truly stopped changing (`#356`).
 - Added regression coverage for deferred ghost runtime FX restore, including tracked current-power collection/clearing and first-activation restore gating so anchor-camera launch ghosts keep their engine plume/audio state on the first visible frame (`#355`).
 - Added regression coverage for high-warp orbital spawn hardening and stable-orbit tail trimming: terminal-orbit spawn-state selection, top-level and per-part orbital metadata normalization, and zero-throttle engine-seed filtering in boring-tail trim so stable orbital coasts resolve on the normal 10-second buffer instead of replaying their full tail (`#353`).
 - Expanded ghost-visual frame coverage so breakup child ghosts stay anchored to split-time snapshots without a duplicate debris center-of-mass offset (`PR #271`).

--- a/Source/Parsek.Tests/MissedVesselSwitchRecoveryTests.cs
+++ b/Source/Parsek.Tests/MissedVesselSwitchRecoveryTests.cs
@@ -1,0 +1,232 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    [Collection("Sequential")]
+    public class MissedVesselSwitchRecoveryTests
+    {
+        [Fact]
+        public void ShouldRecoverMissedVesselSwitch_RecorderPidMismatch_ReturnsTrue()
+        {
+            bool shouldRecover = ParsekFlight.ShouldRecoverMissedVesselSwitch(
+                isRestoringActiveTree: false,
+                hasActiveTree: true,
+                pendingTreeDockMerge: false,
+                hasPendingSplitRecorder: false,
+                pendingSplitInProgress: false,
+                hasRecorder: true,
+                recorderIsRecording: true,
+                recorderChainToVesselPending: false,
+                recorderVesselPid: 100,
+                activeVesselPid: 200,
+                activeVesselTrackedInBackground: false);
+
+            Assert.True(shouldRecover);
+        }
+
+        [Fact]
+        public void ShouldRecoverMissedVesselSwitch_OutsiderReturnToTrackedTreeVessel_ReturnsTrue()
+        {
+            bool shouldRecover = ParsekFlight.ShouldRecoverMissedVesselSwitch(
+                isRestoringActiveTree: false,
+                hasActiveTree: true,
+                pendingTreeDockMerge: false,
+                hasPendingSplitRecorder: false,
+                pendingSplitInProgress: false,
+                hasRecorder: false,
+                recorderIsRecording: false,
+                recorderChainToVesselPending: false,
+                recorderVesselPid: 0,
+                activeVesselPid: 200,
+                activeVesselTrackedInBackground: true);
+
+            Assert.True(shouldRecover);
+        }
+
+        [Fact]
+        public void ShouldRecoverMissedVesselSwitch_SamePid_ReturnsFalse()
+        {
+            bool shouldRecover = ParsekFlight.ShouldRecoverMissedVesselSwitch(
+                isRestoringActiveTree: false,
+                hasActiveTree: true,
+                pendingTreeDockMerge: false,
+                hasPendingSplitRecorder: false,
+                pendingSplitInProgress: false,
+                hasRecorder: true,
+                recorderIsRecording: true,
+                recorderChainToVesselPending: false,
+                recorderVesselPid: 100,
+                activeVesselPid: 100,
+                activeVesselTrackedInBackground: false);
+
+            Assert.False(shouldRecover);
+        }
+
+        [Fact]
+        public void ShouldRecoverMissedVesselSwitch_PendingTransientState_ReturnsFalse()
+        {
+            bool splitGuard = ParsekFlight.ShouldRecoverMissedVesselSwitch(
+                isRestoringActiveTree: false,
+                hasActiveTree: true,
+                pendingTreeDockMerge: false,
+                hasPendingSplitRecorder: true,
+                pendingSplitInProgress: false,
+                hasRecorder: true,
+                recorderIsRecording: true,
+                recorderChainToVesselPending: false,
+                recorderVesselPid: 100,
+                activeVesselPid: 200,
+                activeVesselTrackedInBackground: false);
+
+            bool dockGuard = ParsekFlight.ShouldRecoverMissedVesselSwitch(
+                isRestoringActiveTree: false,
+                hasActiveTree: true,
+                pendingTreeDockMerge: true,
+                hasPendingSplitRecorder: false,
+                pendingSplitInProgress: false,
+                hasRecorder: true,
+                recorderIsRecording: true,
+                recorderChainToVesselPending: false,
+                recorderVesselPid: 100,
+                activeVesselPid: 200,
+                activeVesselTrackedInBackground: false);
+
+            bool chainGuard = ParsekFlight.ShouldRecoverMissedVesselSwitch(
+                isRestoringActiveTree: false,
+                hasActiveTree: true,
+                pendingTreeDockMerge: false,
+                hasPendingSplitRecorder: false,
+                pendingSplitInProgress: false,
+                hasRecorder: true,
+                recorderIsRecording: true,
+                recorderChainToVesselPending: true,
+                recorderVesselPid: 100,
+                activeVesselPid: 200,
+                activeVesselTrackedInBackground: false);
+
+            Assert.False(splitGuard);
+            Assert.False(dockGuard);
+            Assert.False(chainGuard);
+        }
+
+        [Fact]
+        public void ShouldRecoverMissedVesselSwitch_RequiresStableActiveTreeContext()
+        {
+            bool noTree = ParsekFlight.ShouldRecoverMissedVesselSwitch(
+                isRestoringActiveTree: false,
+                hasActiveTree: false,
+                pendingTreeDockMerge: false,
+                hasPendingSplitRecorder: false,
+                pendingSplitInProgress: false,
+                hasRecorder: true,
+                recorderIsRecording: true,
+                recorderChainToVesselPending: false,
+                recorderVesselPid: 100,
+                activeVesselPid: 200,
+                activeVesselTrackedInBackground: false);
+
+            bool restoring = ParsekFlight.ShouldRecoverMissedVesselSwitch(
+                isRestoringActiveTree: true,
+                hasActiveTree: true,
+                pendingTreeDockMerge: false,
+                hasPendingSplitRecorder: false,
+                pendingSplitInProgress: false,
+                hasRecorder: true,
+                recorderIsRecording: true,
+                recorderChainToVesselPending: false,
+                recorderVesselPid: 100,
+                activeVesselPid: 200,
+                activeVesselTrackedInBackground: false);
+
+            bool zeroActivePid = ParsekFlight.ShouldRecoverMissedVesselSwitch(
+                isRestoringActiveTree: false,
+                hasActiveTree: true,
+                pendingTreeDockMerge: false,
+                hasPendingSplitRecorder: false,
+                pendingSplitInProgress: false,
+                hasRecorder: true,
+                recorderIsRecording: true,
+                recorderChainToVesselPending: false,
+                recorderVesselPid: 100,
+                activeVesselPid: 0,
+                activeVesselTrackedInBackground: false);
+
+            Assert.False(noTree);
+            Assert.False(restoring);
+            Assert.False(zeroActivePid);
+        }
+
+        [Fact]
+        public void Update_CallsMissedVesselSwitchRecoveryBeforeTreeHandlers()
+        {
+            string parsekFlightPath = LocateParsekFlightSource();
+            Assert.True(File.Exists(parsekFlightPath),
+                $"ParsekFlight.cs not found at {parsekFlightPath}");
+
+            string src = File.ReadAllText(parsekFlightPath);
+            string methodBody = ExtractMethodBody(src, "void Update()");
+
+            int clearIdx = methodBody.IndexOf("ClearStaleConfirmations();", StringComparison.Ordinal);
+            int recoverIdx = methodBody.IndexOf("HandleMissedVesselSwitchRecovery();", StringComparison.Ordinal);
+            int dockIdx = methodBody.IndexOf("HandleTreeDockMerge();", StringComparison.Ordinal);
+
+            Assert.True(clearIdx >= 0, "Update() no longer calls ClearStaleConfirmations().");
+            Assert.True(recoverIdx >= 0,
+                "Update() no longer calls HandleMissedVesselSwitchRecovery().");
+            Assert.True(dockIdx >= 0, "Update() no longer calls HandleTreeDockMerge().");
+            Assert.True(clearIdx < recoverIdx && recoverIdx < dockIdx,
+                "REGRESSION: missed vessel switch recovery must run immediately after " +
+                "ClearStaleConfirmations() and before tree transition handlers so a " +
+                "missed onVesselChange is reconciled before merge/background logic runs.");
+        }
+
+        private static string LocateParsekFlightSource()
+        {
+            string dir = AppDomain.CurrentDomain.BaseDirectory;
+            for (int i = 0; i < 10 && !string.IsNullOrEmpty(dir); i++)
+            {
+                string candidate = Path.Combine(dir, "Source", "Parsek", "ParsekFlight.cs");
+                if (File.Exists(candidate)) return candidate;
+                dir = Path.GetDirectoryName(dir);
+            }
+
+            return Path.GetFullPath(Path.Combine(
+                AppDomain.CurrentDomain.BaseDirectory,
+                "..", "..", "..", "..", "Parsek", "ParsekFlight.cs"));
+        }
+
+        private static string ExtractMethodBody(string src, string methodSignature)
+        {
+            int methodStart = src.IndexOf(methodSignature, StringComparison.Ordinal);
+            Assert.True(methodStart >= 0,
+                $"{methodSignature} not found in ParsekFlight.cs.");
+
+            int openBrace = src.IndexOf('{', methodStart);
+            Assert.True(openBrace >= 0,
+                $"{methodSignature} has no opening brace after its signature.");
+
+            int depth = 0;
+            int closeBrace = -1;
+            for (int i = openBrace; i < src.Length; i++)
+            {
+                char c = src[i];
+                if (c == '{') depth++;
+                else if (c == '}')
+                {
+                    depth--;
+                    if (depth == 0)
+                    {
+                        closeBrace = i;
+                        break;
+                    }
+                }
+            }
+
+            Assert.True(closeBrace >= 0,
+                $"{methodSignature} has unbalanced braces in ParsekFlight.cs.");
+            return src.Substring(methodStart, closeBrace - methodStart + 1);
+        }
+    }
+}

--- a/Source/Parsek.Tests/RecordingOptimizerTests.cs
+++ b/Source/Parsek.Tests/RecordingOptimizerTests.cs
@@ -2286,7 +2286,7 @@ namespace Parsek.Tests
             rec.Points.Add(new TrajectoryPoint { ut = 110, bodyName = "Kerbin", latitude = 0.3, longitude = 0.4, altitude = 60, rotation = Quaternion.identity });
             rec.Points.Add(new TrajectoryPoint { ut = 120, bodyName = "Kerbin", latitude = 1.0, longitude = 2.0, altitude = 3.0, rotation = Quaternion.identity });
             rec.Points.Add(new TrajectoryPoint { ut = 130, bodyName = "Kerbin", latitude = 1.0, longitude = 2.0, altitude = 3.0, rotation = Quaternion.identity });
-            rec.Points.Add(new TrajectoryPoint { ut = 140, bodyName = "Kerbin", latitude = 1.02, longitude = 2.0, altitude = 3.0, rotation = Quaternion.identity });
+            rec.Points.Add(new TrajectoryPoint { ut = 140, bodyName = "Kerbin", latitude = 1.00005, longitude = 2.0, altitude = 3.0, rotation = Quaternion.identity });
             rec.Points.Add(new TrajectoryPoint { ut = 150, bodyName = "Kerbin", latitude = 1.0, longitude = 2.0, altitude = 3.0, rotation = Quaternion.identity });
             rec.TrackSections.Add(new TrackSection
                 { environment = SegmentEnvironment.Atmospheric, startUT = 100, endUT = 120 });
@@ -2763,11 +2763,11 @@ namespace Parsek.Tests
                 startUT = 130,
                 endUT = 175,
                 bodyName = "Kerbin",
-                inclination = 1.25,
-                eccentricity = 0.01,
-                semiMajorAxis = 800000.0,
-                longitudeOfAscendingNode = 120.0,
-                argumentOfPeriapsis = 45.0
+                inclination = 3.5,
+                eccentricity = 0.2,
+                semiMajorAxis = 1200000.0,
+                longitudeOfAscendingNode = 200.0,
+                argumentOfPeriapsis = 75.0
             });
             rec.OrbitSegments.Add(new OrbitSegment
             {
@@ -2776,9 +2776,39 @@ namespace Parsek.Tests
                 bodyName = "Kerbin",
                 inclination = 3.5,
                 eccentricity = 0.2,
-                semiMajorAxis = 1200000.0,
+                semiMajorAxis = 1200000.5,
                 longitudeOfAscendingNode = 200.0,
                 argumentOfPeriapsis = 75.0
+            });
+            var recordings = new List<Recording> { rec };
+
+            Assert.False(RecordingOptimizer.TrimBoringTail(rec, recordings));
+            Assert.Equal(220, rec.EndUT);
+        }
+
+        [Fact]
+        public void TrimBoringTail_SubOrbitalTerminalUsesOrbitGuard()
+        {
+            var rec = MakeRecordingWithBoringTail(100, 130, 220,
+                SegmentEnvironment.Atmospheric, SegmentEnvironment.ExoBallistic,
+                activePointCount: 4, boringPointCount: 6);
+            rec.TerminalStateValue = TerminalState.SubOrbital;
+            rec.TerminalOrbitBody = "Kerbin";
+            rec.TerminalOrbitInclination = 1.25;
+            rec.TerminalOrbitEccentricity = 0.01;
+            rec.TerminalOrbitSemiMajorAxis = 800000.0;
+            rec.TerminalOrbitLAN = 120.0;
+            rec.TerminalOrbitArgumentOfPeriapsis = 45.0;
+            rec.OrbitSegments.Add(new OrbitSegment
+            {
+                startUT = 130,
+                endUT = 220,
+                bodyName = "Kerbin",
+                inclination = 1.25,
+                eccentricity = 0.01001,
+                semiMajorAxis = 800000.0,
+                longitudeOfAscendingNode = 120.0,
+                argumentOfPeriapsis = 45.0
             });
             var recordings = new List<Recording> { rec };
 

--- a/Source/Parsek.Tests/RecordingOptimizerTests.cs
+++ b/Source/Parsek.Tests/RecordingOptimizerTests.cs
@@ -2234,6 +2234,72 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void TrimBoringTail_LandedStableTerminalState_StillTrims()
+        {
+            var rec = new Recording
+            {
+                TerminalStateValue = TerminalState.Landed,
+                TerminalPosition = new SurfacePosition
+                {
+                    body = "Kerbin",
+                    latitude = 1.0,
+                    longitude = 2.0,
+                    altitude = 3.0,
+                    rotation = Quaternion.identity,
+                    situation = SurfaceSituation.Landed
+                }
+            };
+            rec.Points.Add(new TrajectoryPoint { ut = 100, bodyName = "Kerbin", latitude = 0.1, longitude = 0.2, altitude = 100, rotation = Quaternion.identity });
+            rec.Points.Add(new TrajectoryPoint { ut = 110, bodyName = "Kerbin", latitude = 0.3, longitude = 0.4, altitude = 60, rotation = Quaternion.identity });
+            rec.Points.Add(new TrajectoryPoint { ut = 120, bodyName = "Kerbin", latitude = 1.0, longitude = 2.0, altitude = 3.0, rotation = Quaternion.identity });
+            rec.Points.Add(new TrajectoryPoint { ut = 130, bodyName = "Kerbin", latitude = 1.0, longitude = 2.0, altitude = 3.0, rotation = Quaternion.identity });
+            rec.Points.Add(new TrajectoryPoint { ut = 140, bodyName = "Kerbin", latitude = 1.0, longitude = 2.0, altitude = 3.0, rotation = Quaternion.identity });
+            rec.Points.Add(new TrajectoryPoint { ut = 150, bodyName = "Kerbin", latitude = 1.0, longitude = 2.0, altitude = 3.0, rotation = Quaternion.identity });
+            rec.TrackSections.Add(new TrackSection
+                { environment = SegmentEnvironment.Atmospheric, startUT = 100, endUT = 120 });
+            rec.TrackSections.Add(new TrackSection
+                { environment = SegmentEnvironment.SurfaceStationary, startUT = 120, endUT = 150 });
+
+            var recordings = new List<Recording> { rec };
+
+            Assert.True(RecordingOptimizer.TrimBoringTail(rec, recordings));
+            Assert.Equal(130, rec.EndUT);
+        }
+
+        [Fact]
+        public void TrimBoringTail_LandedTerminalStateChangesLater_DoesNotTrim()
+        {
+            var rec = new Recording
+            {
+                TerminalStateValue = TerminalState.Landed,
+                TerminalPosition = new SurfacePosition
+                {
+                    body = "Kerbin",
+                    latitude = 1.0,
+                    longitude = 2.0,
+                    altitude = 3.0,
+                    rotation = Quaternion.identity,
+                    situation = SurfaceSituation.Landed
+                }
+            };
+            rec.Points.Add(new TrajectoryPoint { ut = 100, bodyName = "Kerbin", latitude = 0.1, longitude = 0.2, altitude = 100, rotation = Quaternion.identity });
+            rec.Points.Add(new TrajectoryPoint { ut = 110, bodyName = "Kerbin", latitude = 0.3, longitude = 0.4, altitude = 60, rotation = Quaternion.identity });
+            rec.Points.Add(new TrajectoryPoint { ut = 120, bodyName = "Kerbin", latitude = 1.0, longitude = 2.0, altitude = 3.0, rotation = Quaternion.identity });
+            rec.Points.Add(new TrajectoryPoint { ut = 130, bodyName = "Kerbin", latitude = 1.0, longitude = 2.0, altitude = 3.0, rotation = Quaternion.identity });
+            rec.Points.Add(new TrajectoryPoint { ut = 140, bodyName = "Kerbin", latitude = 1.02, longitude = 2.0, altitude = 3.0, rotation = Quaternion.identity });
+            rec.Points.Add(new TrajectoryPoint { ut = 150, bodyName = "Kerbin", latitude = 1.0, longitude = 2.0, altitude = 3.0, rotation = Quaternion.identity });
+            rec.TrackSections.Add(new TrackSection
+                { environment = SegmentEnvironment.Atmospheric, startUT = 100, endUT = 120 });
+            rec.TrackSections.Add(new TrackSection
+                { environment = SegmentEnvironment.SurfaceStationary, startUT = 120, endUT = 150 });
+
+            var recordings = new List<Recording> { rec };
+
+            Assert.False(RecordingOptimizer.TrimBoringTail(rec, recordings));
+            Assert.Equal(150, rec.EndUT);
+        }
+
+        [Fact]
         public void TrimBoringTail_TrimsExoBallisticTail()
         {
             var rec = MakeRecordingWithBoringTail(17000, 17060, 17660,
@@ -2647,6 +2713,77 @@ namespace Parsek.Tests
                 $"Expected stable orbit to trim near entry, got EndUT={rec.EndUT}");
             Assert.DoesNotContain(rec.PartEvents,
                 e => e.eventType == PartEventType.EngineIgnited && e.value <= 0f && e.ut > rec.EndUT);
+        }
+
+        [Fact]
+        public void TrimBoringTail_StableOrbitingTerminalShape_StillTrims()
+        {
+            var rec = MakeRecordingWithBoringTail(100, 130, 220,
+                SegmentEnvironment.Atmospheric, SegmentEnvironment.ExoBallistic,
+                activePointCount: 4, boringPointCount: 6);
+            rec.TerminalStateValue = TerminalState.Orbiting;
+            rec.TerminalOrbitBody = "Kerbin";
+            rec.TerminalOrbitInclination = 1.25;
+            rec.TerminalOrbitEccentricity = 0.01;
+            rec.TerminalOrbitSemiMajorAxis = 800000.0;
+            rec.TerminalOrbitLAN = 120.0;
+            rec.TerminalOrbitArgumentOfPeriapsis = 45.0;
+            rec.OrbitSegments.Add(new OrbitSegment
+            {
+                startUT = 130,
+                endUT = 220,
+                bodyName = "Kerbin",
+                inclination = 1.25,
+                eccentricity = 0.01,
+                semiMajorAxis = 800000.0,
+                longitudeOfAscendingNode = 120.0,
+                argumentOfPeriapsis = 45.0
+            });
+            var recordings = new List<Recording> { rec };
+
+            Assert.True(RecordingOptimizer.TrimBoringTail(rec, recordings));
+            Assert.True(rec.EndUT <= 140);
+        }
+
+        [Fact]
+        public void TrimBoringTail_OrbitChangesAfterTrimPoint_DoesNotTrim()
+        {
+            var rec = MakeRecordingWithBoringTail(100, 130, 220,
+                SegmentEnvironment.Atmospheric, SegmentEnvironment.ExoBallistic,
+                activePointCount: 4, boringPointCount: 6);
+            rec.TerminalStateValue = TerminalState.Orbiting;
+            rec.TerminalOrbitBody = "Kerbin";
+            rec.TerminalOrbitInclination = 3.5;
+            rec.TerminalOrbitEccentricity = 0.2;
+            rec.TerminalOrbitSemiMajorAxis = 1200000.0;
+            rec.TerminalOrbitLAN = 200.0;
+            rec.TerminalOrbitArgumentOfPeriapsis = 75.0;
+            rec.OrbitSegments.Add(new OrbitSegment
+            {
+                startUT = 130,
+                endUT = 175,
+                bodyName = "Kerbin",
+                inclination = 1.25,
+                eccentricity = 0.01,
+                semiMajorAxis = 800000.0,
+                longitudeOfAscendingNode = 120.0,
+                argumentOfPeriapsis = 45.0
+            });
+            rec.OrbitSegments.Add(new OrbitSegment
+            {
+                startUT = 175,
+                endUT = 220,
+                bodyName = "Kerbin",
+                inclination = 3.5,
+                eccentricity = 0.2,
+                semiMajorAxis = 1200000.0,
+                longitudeOfAscendingNode = 200.0,
+                argumentOfPeriapsis = 75.0
+            });
+            var recordings = new List<Recording> { rec };
+
+            Assert.False(RecordingOptimizer.TrimBoringTail(rec, recordings));
+            Assert.Equal(220, rec.EndUT);
         }
 
         /// <summary>

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -541,6 +541,7 @@ namespace Parsek
             if (sceneChangeInProgress) return;
 
             ClearStaleConfirmations();
+            HandleMissedVesselSwitchRecovery();
 
             HandleTreeDockMerge();
             HandleDockUndockCommitRestart();
@@ -4567,6 +4568,46 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Safety net for vessel switches that change <see cref="FlightGlobals.ActiveVessel"/>
+        /// without reaching either the physics-frame recorder path or onVesselChange.
+        /// Replays the normal <see cref="OnVesselSwitchComplete"/> transition once the
+        /// frame loop can prove Parsek's active recorder/tree state is out of sync.
+        /// </summary>
+        private void HandleMissedVesselSwitchRecovery()
+        {
+            Vessel activeVessel = FlightGlobals.ActiveVessel;
+            uint activeVesselPid = activeVessel != null ? activeVessel.persistentId : 0;
+            bool activeVesselTrackedInBackground = activeTree != null
+                && activeVesselPid != 0
+                && activeTree.BackgroundMap.ContainsKey(activeVesselPid);
+
+            if (!ShouldRecoverMissedVesselSwitch(
+                    restoringActiveTree,
+                    activeTree != null,
+                    pendingTreeDockMerge,
+                    pendingSplitRecorder != null,
+                    pendingSplitInProgress,
+                    recorder != null,
+                    recorder != null && recorder.IsRecording,
+                    recorder != null && recorder.ChainToVesselPending,
+                    recorder != null ? recorder.RecordingVesselId : 0,
+                    activeVesselPid,
+                    activeVesselTrackedInBackground))
+            {
+                return;
+            }
+
+            if (GhostMapPresence.IsGhostMapVessel(activeVesselPid)) return;
+
+            uint recorderPid = recorder != null ? recorder.RecordingVesselId : 0;
+            ParsekLog.Warn("Flight",
+                $"Update: recovering missed vessel switch for active vessel '{activeVessel.vesselName}' " +
+                $"(activePid={activeVesselPid}, recorderPid={recorderPid}, " +
+                $"trackedInBackground={activeVesselTrackedInBackground})");
+            OnVesselSwitchComplete(activeVessel);
+        }
+
+        /// <summary>
         /// Zeros all dock/undock pending-transition fields.
         /// Called from scene change, flight ready, and after dock/undock commit/restart.
         /// </summary>
@@ -6062,6 +6103,41 @@ namespace Parsek
             if (pendingSplitRecorder != null || pendingSplitInProgress) return false;
             if (recorder != null && recorder.ChainToVesselPending) return false;
             return true;
+        }
+
+        /// <summary>
+        /// Pure guard for the Update() safety net that replays missed vessel switches.
+        /// Runs only when tree state is active and stable enough that the normal
+        /// <see cref="OnVesselSwitchComplete"/> path is safe to reuse.
+        /// </summary>
+        internal static bool ShouldRecoverMissedVesselSwitch(
+            bool isRestoringActiveTree,
+            bool hasActiveTree,
+            bool pendingTreeDockMerge,
+            bool hasPendingSplitRecorder,
+            bool pendingSplitInProgress,
+            bool hasRecorder,
+            bool recorderIsRecording,
+            bool recorderChainToVesselPending,
+            uint recorderVesselPid,
+            uint activeVesselPid,
+            bool activeVesselTrackedInBackground)
+        {
+            if (isRestoringActiveTree) return false;
+            if (!hasActiveTree) return false;
+            if (pendingTreeDockMerge) return false;
+            if (hasPendingSplitRecorder || pendingSplitInProgress) return false;
+            if (activeVesselPid == 0) return false;
+
+            if (hasRecorder)
+            {
+                if (!recorderIsRecording) return false;
+                if (recorderChainToVesselPending) return false;
+                if (recorderVesselPid == 0) return false;
+                return recorderVesselPid != activeVesselPid;
+            }
+
+            return activeVesselTrackedInBackground;
         }
 
         /// <summary>

--- a/Source/Parsek/RecordingOptimizer.cs
+++ b/Source/Parsek/RecordingOptimizer.cs
@@ -1002,14 +1002,6 @@ namespace Parsek
         /// </summary>
         internal const double DefaultTailBufferSeconds = 10.0;
 
-        internal const double StableTailSurfaceLatitudeTolerance = 1e-4;
-        internal const double StableTailSurfaceLongitudeTolerance = 1e-4;
-        internal const double StableTailSurfaceAltitudeTolerance = 5.0;
-        internal const float StableTailSurfaceRotationToleranceDegrees = 1.0f;
-        internal const double StableTailOrbitSemiMajorAxisTolerance = 1000.0;
-        internal const double StableTailOrbitEccentricityTolerance = 1e-4;
-        internal const double StableTailOrbitAngleToleranceDegrees = 0.05;
-
         /// <summary>
         /// Minimum recording duration to be eligible for tail trimming.
         /// Recordings shorter than this are left untouched.
@@ -1124,6 +1116,7 @@ namespace Parsek
             switch (rec.TerminalStateValue.Value)
             {
                 case TerminalState.Orbiting:
+                case TerminalState.SubOrbital:
                 case TerminalState.Docked:
                     return TailMatchesTerminalOrbit(rec, trimUT);
 
@@ -1193,19 +1186,19 @@ namespace Parsek
             if (seg.bodyName != rec.TerminalOrbitBody)
                 return false;
 
-            if (Math.Abs(seg.semiMajorAxis - rec.TerminalOrbitSemiMajorAxis) > StableTailOrbitSemiMajorAxisTolerance)
+            if (seg.semiMajorAxis != rec.TerminalOrbitSemiMajorAxis)
                 return false;
 
-            if (Math.Abs(seg.eccentricity - rec.TerminalOrbitEccentricity) > StableTailOrbitEccentricityTolerance)
+            if (seg.eccentricity != rec.TerminalOrbitEccentricity)
                 return false;
 
-            if (AngleDeltaDegrees(seg.inclination, rec.TerminalOrbitInclination) > StableTailOrbitAngleToleranceDegrees)
+            if (seg.inclination != rec.TerminalOrbitInclination)
                 return false;
 
-            if (AngleDeltaDegrees(seg.longitudeOfAscendingNode, rec.TerminalOrbitLAN) > StableTailOrbitAngleToleranceDegrees)
+            if (seg.longitudeOfAscendingNode != rec.TerminalOrbitLAN)
                 return false;
 
-            if (AngleDeltaDegrees(seg.argumentOfPeriapsis, rec.TerminalOrbitArgumentOfPeriapsis) > StableTailOrbitAngleToleranceDegrees)
+            if (seg.argumentOfPeriapsis != rec.TerminalOrbitArgumentOfPeriapsis)
                 return false;
 
             return true;
@@ -1300,13 +1293,13 @@ namespace Parsek
                     return false;
             }
 
-            if (Math.Abs(pt.latitude - terminalLat) > StableTailSurfaceLatitudeTolerance)
+            if (pt.latitude != terminalLat)
                 return false;
 
-            if (Math.Abs(pt.longitude - terminalLon) > StableTailSurfaceLongitudeTolerance)
+            if (pt.longitude != terminalLon)
                 return false;
 
-            if (Math.Abs(pt.altitude - terminalAlt) > StableTailSurfaceAltitudeTolerance)
+            if (pt.altitude != terminalAlt)
                 return false;
 
             bool pointHasRotation = HasMeaningfulRotation(pt.rotation);
@@ -1315,8 +1308,13 @@ namespace Parsek
                 if (!(hasTerminalRotation && pointHasRotation))
                     return false;
 
-                if (Quaternion.Angle(pt.rotation, terminalRotation) > StableTailSurfaceRotationToleranceDegrees)
+                if (pt.rotation.x != terminalRotation.x
+                    || pt.rotation.y != terminalRotation.y
+                    || pt.rotation.z != terminalRotation.z
+                    || pt.rotation.w != terminalRotation.w)
+                {
                     return false;
+                }
             }
 
             return true;
@@ -1325,12 +1323,6 @@ namespace Parsek
         private static bool HasMeaningfulRotation(Quaternion rotation)
         {
             return rotation.x != 0f || rotation.y != 0f || rotation.z != 0f || rotation.w != 0f;
-        }
-
-        private static double AngleDeltaDegrees(double a, double b)
-        {
-            double delta = Math.Abs(a - b) % 360.0;
-            return delta > 180.0 ? 360.0 - delta : delta;
         }
 
         /// <summary>

--- a/Source/Parsek/RecordingOptimizer.cs
+++ b/Source/Parsek/RecordingOptimizer.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using UnityEngine;
 
 namespace Parsek
 {
@@ -1000,6 +1002,14 @@ namespace Parsek
         /// </summary>
         internal const double DefaultTailBufferSeconds = 10.0;
 
+        internal const double StableTailSurfaceLatitudeTolerance = 1e-4;
+        internal const double StableTailSurfaceLongitudeTolerance = 1e-4;
+        internal const double StableTailSurfaceAltitudeTolerance = 5.0;
+        internal const float StableTailSurfaceRotationToleranceDegrees = 1.0f;
+        internal const double StableTailOrbitSemiMajorAxisTolerance = 1000.0;
+        internal const double StableTailOrbitEccentricityTolerance = 1e-4;
+        internal const double StableTailOrbitAngleToleranceDegrees = 0.05;
+
         /// <summary>
         /// Minimum recording duration to be eligible for tail trimming.
         /// Recordings shorter than this are left untouched.
@@ -1106,6 +1116,223 @@ namespace Parsek
             return lastUT;
         }
 
+        internal static bool TailPreservesTerminalSpawnState(Recording rec, double trimUT)
+        {
+            if (rec == null || !rec.TerminalStateValue.HasValue)
+                return true;
+
+            switch (rec.TerminalStateValue.Value)
+            {
+                case TerminalState.Orbiting:
+                case TerminalState.Docked:
+                    return TailMatchesTerminalOrbit(rec, trimUT);
+
+                case TerminalState.Landed:
+                case TerminalState.Splashed:
+                    return TailMatchesTerminalSurfaceState(rec, trimUT);
+
+                default:
+                    return true;
+            }
+        }
+
+        private static bool TailMatchesTerminalOrbit(Recording rec, double trimUT)
+        {
+            if (rec == null
+                || string.IsNullOrEmpty(rec.TerminalOrbitBody)
+                || rec.TerminalOrbitSemiMajorAxis <= 0.0)
+            {
+                return false;
+            }
+
+            bool sawTailOrbit = false;
+
+            if (rec.OrbitSegments != null)
+            {
+                for (int i = 0; i < rec.OrbitSegments.Count; i++)
+                {
+                    OrbitSegment seg = rec.OrbitSegments[i];
+                    if (seg.endUT <= trimUT)
+                        continue;
+
+                    sawTailOrbit = true;
+                    if (!OrbitShapeMatchesTerminal(rec, seg))
+                        return false;
+                }
+            }
+
+            if (!sawTailOrbit && rec.TrackSections != null)
+            {
+                for (int i = 0; i < rec.TrackSections.Count; i++)
+                {
+                    TrackSection sec = rec.TrackSections[i];
+                    if (sec.checkpoints == null)
+                        continue;
+
+                    for (int j = 0; j < sec.checkpoints.Count; j++)
+                    {
+                        OrbitSegment checkpoint = sec.checkpoints[j];
+                        if (checkpoint.endUT <= trimUT)
+                            continue;
+
+                        sawTailOrbit = true;
+                        if (!OrbitShapeMatchesTerminal(rec, checkpoint))
+                            return false;
+                    }
+                }
+            }
+
+            return sawTailOrbit;
+        }
+
+        private static bool OrbitShapeMatchesTerminal(Recording rec, OrbitSegment seg)
+        {
+            if (string.IsNullOrEmpty(seg.bodyName) || seg.semiMajorAxis <= 0.0)
+                return false;
+
+            if (seg.bodyName != rec.TerminalOrbitBody)
+                return false;
+
+            if (Math.Abs(seg.semiMajorAxis - rec.TerminalOrbitSemiMajorAxis) > StableTailOrbitSemiMajorAxisTolerance)
+                return false;
+
+            if (Math.Abs(seg.eccentricity - rec.TerminalOrbitEccentricity) > StableTailOrbitEccentricityTolerance)
+                return false;
+
+            if (AngleDeltaDegrees(seg.inclination, rec.TerminalOrbitInclination) > StableTailOrbitAngleToleranceDegrees)
+                return false;
+
+            if (AngleDeltaDegrees(seg.longitudeOfAscendingNode, rec.TerminalOrbitLAN) > StableTailOrbitAngleToleranceDegrees)
+                return false;
+
+            if (AngleDeltaDegrees(seg.argumentOfPeriapsis, rec.TerminalOrbitArgumentOfPeriapsis) > StableTailOrbitAngleToleranceDegrees)
+                return false;
+
+            return true;
+        }
+
+        private static bool TailMatchesTerminalSurfaceState(Recording rec, double trimUT)
+        {
+            if (!TryGetTerminalSurfaceReference(rec, out string terminalBody,
+                out double terminalLat, out double terminalLon, out double terminalAlt,
+                out Quaternion terminalRotation, out bool hasTerminalRotation))
+            {
+                return false;
+            }
+
+            bool sawTailPoint = false;
+            for (int i = 0; i < rec.Points.Count; i++)
+            {
+                TrajectoryPoint pt = rec.Points[i];
+                if (pt.ut <= trimUT)
+                    continue;
+
+                sawTailPoint = true;
+                if (!SurfacePointMatchesTerminal(pt, terminalBody, terminalLat, terminalLon,
+                    terminalAlt, terminalRotation, hasTerminalRotation))
+                {
+                    return false;
+                }
+            }
+
+            return sawTailPoint;
+        }
+
+        private static bool TryGetTerminalSurfaceReference(Recording rec,
+            out string body, out double lat, out double lon, out double alt,
+            out Quaternion rotation, out bool hasRotation)
+        {
+            body = null;
+            lat = 0.0;
+            lon = 0.0;
+            alt = 0.0;
+            rotation = Quaternion.identity;
+            hasRotation = false;
+
+            if (rec == null)
+                return false;
+
+            if (rec.TerminalPosition.HasValue)
+            {
+                SurfacePosition pos = rec.TerminalPosition.Value;
+                body = pos.body;
+                lat = pos.latitude;
+                lon = pos.longitude;
+                alt = pos.altitude;
+                rotation = pos.rotation;
+                hasRotation = HasMeaningfulRotation(pos.rotation);
+                return true;
+            }
+
+            if (rec.SurfacePos.HasValue)
+            {
+                SurfacePosition pos = rec.SurfacePos.Value;
+                body = pos.body;
+                lat = pos.latitude;
+                lon = pos.longitude;
+                alt = pos.altitude;
+                rotation = pos.rotation;
+                hasRotation = HasMeaningfulRotation(pos.rotation);
+                return true;
+            }
+
+            if (rec.Points == null || rec.Points.Count == 0)
+                return false;
+
+            TrajectoryPoint lastPt = rec.Points[rec.Points.Count - 1];
+            body = lastPt.bodyName;
+            lat = lastPt.latitude;
+            lon = lastPt.longitude;
+            alt = lastPt.altitude;
+            rotation = lastPt.rotation;
+            hasRotation = HasMeaningfulRotation(lastPt.rotation);
+            return true;
+        }
+
+        private static bool SurfacePointMatchesTerminal(TrajectoryPoint pt,
+            string terminalBody, double terminalLat, double terminalLon, double terminalAlt,
+            Quaternion terminalRotation, bool hasTerminalRotation)
+        {
+            string pointBody = pt.bodyName;
+            if (!string.IsNullOrEmpty(terminalBody) || !string.IsNullOrEmpty(pointBody))
+            {
+                if ((terminalBody ?? string.Empty) != (pointBody ?? string.Empty))
+                    return false;
+            }
+
+            if (Math.Abs(pt.latitude - terminalLat) > StableTailSurfaceLatitudeTolerance)
+                return false;
+
+            if (Math.Abs(pt.longitude - terminalLon) > StableTailSurfaceLongitudeTolerance)
+                return false;
+
+            if (Math.Abs(pt.altitude - terminalAlt) > StableTailSurfaceAltitudeTolerance)
+                return false;
+
+            bool pointHasRotation = HasMeaningfulRotation(pt.rotation);
+            if (hasTerminalRotation || pointHasRotation)
+            {
+                if (!(hasTerminalRotation && pointHasRotation))
+                    return false;
+
+                if (Quaternion.Angle(pt.rotation, terminalRotation) > StableTailSurfaceRotationToleranceDegrees)
+                    return false;
+            }
+
+            return true;
+        }
+
+        private static bool HasMeaningfulRotation(Quaternion rotation)
+        {
+            return rotation.x != 0f || rotation.y != 0f || rotation.z != 0f || rotation.w != 0f;
+        }
+
+        private static double AngleDeltaDegrees(double a, double b)
+        {
+            double delta = Math.Abs(a - b) % 360.0;
+            return delta > 180.0 ? 360.0 - delta : delta;
+        }
+
         /// <summary>
         /// Trims the boring tail of a leaf recording. If the recording ends with a long
         /// idle period (ExoBallistic or SurfaceStationary), removes trailing points and
@@ -1146,6 +1373,15 @@ namespace Parsek
 
             double trimUT = lastInterestingUT + bufferSeconds;
             if (trimUT >= rec.EndUT) return false; // boring tail is shorter than buffer
+
+            if (!TailPreservesTerminalSpawnState(rec, trimUT))
+            {
+                ParsekLog.Verbose("Optimizer",
+                    $"TrimBoringTail: skipped '{rec.VesselName}' ({rec.RecordingId}) " +
+                    $"because tail still diverges from terminal state after trimUT={trimUT:F1} " +
+                    $"(terminal={rec.TerminalStateValue?.ToString() ?? "null"})");
+                return false;
+            }
 
             double originalEndUT = rec.EndUT;
             int originalPointCount = rec.Points.Count;

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -25,7 +25,7 @@ Entries 272–303 (78 bugs, 6 TODOs — mostly resolved) archived in `done/todo-
 
 **Root cause:** `RecordingOptimizer.TrimBoringTail()` only enforced `lastInterestingUT + bufferSeconds`; it never proved that the tail after that trim point already matched the true terminal spawn state. That made it legal to trim while the vessel was still coasting toward a different final orbit or still changing on the surface before its real terminal rest state.
 
-**Fix:** boring-tail trim now requires the post-trim tail to preserve the terminal spawn state. Orbiting/docked recordings only trim when every remaining orbit segment/checkpoint already matches the terminal orbit shape within tolerance, and landed/splashed recordings only trim when all remaining tail points already match the final terminal surface state. Added stable-vs-changing orbit and stable-vs-changing landed regressions.
+**Fix:** boring-tail trim now requires the post-trim tail to preserve the exact terminal spawn state. Orbiting/docked/suborbital recordings only trim when every remaining orbit segment/checkpoint is an exact match for the final terminal orbit shape, and landed/splashed recordings only trim when all remaining tail points exactly match the final terminal surface state. Added stable-vs-changing orbit, suborbital, and landed regressions.
 
 **Status:** ~~Fixed~~
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -7,6 +7,30 @@ Entries 272–303 (78 bugs, 6 TODOs — mostly resolved) archived in `done/todo-
 
 # Known Bugs
 
+## ~~357. Deferred orbital spawn can switch the live active vessel without Parsek switching its recorder/tree~~
+
+**Observed in:** `logs/2026-04-14_1624_orbital-spawn-bug` (2026-04-14). During watched playback of `Goliath II HLV`, KSP handed control to the newly spawned real vessel, but Parsek still believed the active recorder/tree belonged to the pad-launched `Jumping Flea`. That left a short desync window immediately after spawn where subsequent logic was running against the wrong active vessel.
+
+**Root cause:** the deferred orbital-spawn path could change `FlightGlobals.ActiveVessel` without Parsek seeing either of the normal reconciliation paths in time: the expected `onVesselChange` callback was missed, and the physics-frame recorder path never noticed the mismatch before later tree logic ran. Parsek therefore kept the stale recorder PID until some later transition happened to correct it.
+
+**Fix:** `ParsekFlight.Update()` now runs a narrow missed-switch recovery safety net before the other tree transition handlers. When tree state is stable and the active vessel PID provably diverges from Parsek's active recorder/tree state, it replays the normal `OnVesselSwitchComplete()` handoff. Added regression coverage for the pure guard and the required `Update()` ordering.
+
+**Status:** ~~Fixed~~
+
+---
+
+## ~~356. Boring-tail trim can cut a recording before the true final spawn state is reached~~
+
+**Observed in:** `logs/2026-04-14_1724_orbital-spawn-bug` (2026-04-14). After merging the `Goliath II HLV` recording, the optimizer shortened the committed exo leaf from `endUT=610217.8` down to `309083.3` even though the eventual spawned state later changed again before the real mission end. Playback therefore finished early and the later spawn no longer represented "the final-final state that never changes again until spawn."
+
+**Root cause:** `RecordingOptimizer.TrimBoringTail()` only enforced `lastInterestingUT + bufferSeconds`; it never proved that the tail after that trim point already matched the true terminal spawn state. That made it legal to trim while the vessel was still coasting toward a different final orbit or still changing on the surface before its real terminal rest state.
+
+**Fix:** boring-tail trim now requires the post-trim tail to preserve the terminal spawn state. Orbiting/docked recordings only trim when every remaining orbit segment/checkpoint already matches the terminal orbit shape within tolerance, and landed/splashed recordings only trim when all remaining tail points already match the final terminal surface state. Added stable-vs-changing orbit and stable-vs-changing landed regressions.
+
+**Status:** ~~Fixed~~
+
+---
+
 ## ~~355. Flight anchor-camera ghost can miss engine plumes until watch mode~~
 
 **Observed in:** `logs/2026-04-14_1354_flight-ghost-engine-off` (2026-04-14). In Flight, the primary `Kerbal X` ghost looked like its engines were off from the normal anchor / in-flight camera view at liftoff even though `Watch Ghost` immediately showed the same ghost with engine plumes, and KSC playback also showed the plumes correctly.


### PR DESCRIPTION
## Summary
- recover missed active-vessel handoffs after deferred orbital spawns when KSP changes the active vessel without Parsek seeing the normal switch path
- only trim boring tails once the tail already matches the true terminal spawn state for orbital and landed/splashed recordings
- document both follow-up fixes in the changelog and bug tracker

## Testing
- dotnet test Source\Parsek.Tests\Parsek.Tests.csproj --filter FullyQualifiedName~RecordingOptimizerTests|FullyQualifiedName~MissedVesselSwitchRecoveryTests