### PR TITLE
Fix malformed flat fallback committed loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- `#360` Flat-fallback committed recording loads now heal malformed sidecars whose top-level point/orbit lists start by duplicating the exact `TrackSection` payload and only later resume with a valid tail, so old committed debris/background recordings no longer fail monotonicity validation just because the stale flat fallback survived on disk.
 - `#359` Background `TrackSection` flush/merge paths now dedupe real multi-point overlaps instead of only shaving a single boundary frame, and finalize/revert now prune one-point destroyed debris stubs before they can poison commit metrics, so merged recordings stay structurally monotonic and the related recording-integrity / stop-metrics failures are gone (`PR #285`).
 - `#358` Trees committed after an in-flight `F5`/`F9` quickload-resume now keep the root rewind save, reserved resource budget, and pre-launch baseline across quickload save, vessel-switch/background, split/promotion, and finalize paths, so destroyed-end merged recordings keep a working `Rewind` button instead of silently losing `R` (`PR #285`).
 - `#357` Deferred orbital end-of-playback spawns now recover missed active-vessel handoffs when KSP switches to the spawned vessel without Parsek seeing the normal vessel-switch path, so the live recorder/tree no longer stays attached to the previous vessel through the post-spawn frame sequence.
@@ -101,6 +102,7 @@ All notable changes to Parsek are documented here.
 
 ### Developer Tools
 
+- Added regression coverage for malformed flat-fallback committed sidecars whose duplicated `TrackSection` prefix leaves a later monotonic tail, so load-time healing now preserves the real suffix and rewrites the sidecar cleanly on the next save (`#360`).
 - Added regression coverage for quickload-resume rewind metadata propagation and background recording integrity, including root rewind-budget fallback, recorder-backed commit-path wiring, overlap-aware flat-tail preservation, destroyed-stub prune guards, and the refreshed in-game runtime log-contract assertion behind the `#358` / `#359` fallout.
 - Added regression coverage for missed vessel-switch recovery after deferred orbital spawns, including the pure guard cases and the `Update()` ordering requirement that recovery run before other tree transition handlers (`#357`).
 - Added regression coverage for terminal-state-aware boring-tail trim gating, including exact-match orbit/surface stability checks and the `SubOrbital` orbit-tail path so trims only happen once the spawn state has truly stopped changing (`#356`).

--- a/Source/Parsek.Tests/FormatVersionTests.cs
+++ b/Source/Parsek.Tests/FormatVersionTests.cs
@@ -462,6 +462,52 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void DeserializeTrajectoryFrom_V1WithMalformedDuplicatedFlatPrefixWithoutSafeTail_DoesNotRewrite()
+        {
+            var rec = BuildStaleTrackSectionTailRecording(formatVersion: 1);
+            rec.Points.Clear();
+            rec.Points.Add(MakePoint(100.0, 0.0, 0.0, 1000.0));
+            rec.Points.Add(MakePoint(110.0, 0.05, 0.02, 1200.0));
+            rec.Points.Add(MakePoint(100.0, 0.0, 0.0, 1000.0));
+            rec.Points.Add(MakePoint(110.0, 0.05, 0.02, 1200.0));
+            rec.Points.Add(MakePoint(90.0, -0.03, -0.02, 800.0));
+
+            var node = new ConfigNode("PARSEK_RECORDING");
+            RecordingStore.SerializeTrajectoryInto(node, rec);
+
+            logLines.Clear();
+            var restored = new Recording { RecordingId = rec.RecordingId };
+            RecordingStore.DeserializeTrajectoryFrom(node, restored);
+
+            Assert.Equal(new[] { 100.0, 110.0, 100.0, 110.0, 90.0 }, restored.Points.Select(p => p.ut).ToArray());
+            Assert.Single(restored.TrackSections);
+            Assert.False(restored.FilesDirty);
+            Assert.DoesNotContain(logLines, l => l.Contains("healed malformed flat fallback"));
+        }
+
+        [Fact]
+        public void DeserializeTrajectoryFrom_V1WithMalformedDuplicatedOrbitPrefix_HealsFromTrackSectionPrefixAndKeepsTail()
+        {
+            var rec = BuildStaleTrackSectionTailOrbitRecording(formatVersion: 1);
+            rec.OrbitSegments.Insert(1, MakeOrbitSegment(100.0, 150.0, 700000.0));
+
+            var node = new ConfigNode("PARSEK_RECORDING");
+            RecordingStore.SerializeTrajectoryInto(node, rec);
+
+            logLines.Clear();
+            var restored = new Recording { RecordingId = rec.RecordingId };
+            RecordingStore.DeserializeTrajectoryFrom(node, restored);
+
+            Assert.Equal(new[] { 100.0, 200.0 }, restored.OrbitSegments.Select(s => s.startUT).ToArray());
+            Assert.Single(restored.TrackSections);
+            Assert.True(restored.FilesDirty);
+            Assert.Contains(logLines, l =>
+                l.Contains("[RecordingStore]") &&
+                l.Contains("DeserializeTrajectoryFrom") &&
+                l.Contains("healed malformed flat fallback"));
+        }
+
+        [Fact]
         public void DeserializeTrajectoryFrom_InvalidVersion_LogsWarningAndTreatsAsV0()
         {
             var node = new ConfigNode("PARSEK_RECORDING");
@@ -602,6 +648,32 @@ namespace Parsek.Tests
             return rec;
         }
 
+        private static Recording BuildStaleTrackSectionTailOrbitRecording(int formatVersion)
+        {
+            var first = MakeOrbitSegment(100.0, 150.0, 700000.0);
+            var tail = MakeOrbitSegment(200.0, 260.0, 705000.0);
+
+            var rec = new Recording
+            {
+                RecordingId = "stale-track-orbit-tail",
+                RecordingFormatVersion = formatVersion,
+                VesselName = "Tail Vessel Orbit"
+            };
+            rec.OrbitSegments.Add(first);
+            rec.OrbitSegments.Add(tail);
+            rec.TrackSections.Add(new TrackSection
+            {
+                environment = SegmentEnvironment.ExoBallistic,
+                referenceFrame = ReferenceFrame.OrbitalCheckpoint,
+                source = TrackSectionSource.Background,
+                startUT = first.startUT,
+                endUT = first.endUT,
+                frames = new List<TrajectoryPoint>(),
+                checkpoints = new List<OrbitSegment> { first }
+            });
+            return rec;
+        }
+
         private static TrajectoryPoint MakePoint(
             double ut,
             double latitude,
@@ -617,6 +689,23 @@ namespace Parsek.Tests
                 rotation = new UnityEngine.Quaternion(0, 0, 0, 1),
                 bodyName = "Kerbin",
                 velocity = new UnityEngine.Vector3(0, 0, 0)
+            };
+        }
+
+        private static OrbitSegment MakeOrbitSegment(double startUT, double endUT, double semiMajorAxis)
+        {
+            return new OrbitSegment
+            {
+                startUT = startUT,
+                endUT = endUT,
+                semiMajorAxis = semiMajorAxis,
+                eccentricity = 0.01,
+                inclination = 28.5,
+                longitudeOfAscendingNode = 90.0,
+                argumentOfPeriapsis = 45.0,
+                meanAnomalyAtEpoch = 0.2,
+                epoch = startUT,
+                bodyName = "Kerbin"
             };
         }
 

--- a/Source/Parsek.Tests/FormatVersionTests.cs
+++ b/Source/Parsek.Tests/FormatVersionTests.cs
@@ -439,6 +439,29 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void DeserializeTrajectoryFrom_V1WithMalformedDuplicatedFlatPrefix_HealsFromTrackSectionPrefixAndKeepsTail()
+        {
+            var rec = BuildStaleTrackSectionTailRecording(formatVersion: 1);
+            rec.Points.Insert(2, MakePoint(100.0, 0.0, 0.0, 1000.0));
+            rec.Points.Insert(3, MakePoint(110.0, 0.05, 0.02, 1200.0));
+
+            var node = new ConfigNode("PARSEK_RECORDING");
+            RecordingStore.SerializeTrajectoryInto(node, rec);
+
+            logLines.Clear();
+            var restored = new Recording { RecordingId = rec.RecordingId };
+            RecordingStore.DeserializeTrajectoryFrom(node, restored);
+
+            Assert.Equal(new[] { 100.0, 110.0, 120.0 }, restored.Points.Select(p => p.ut).ToArray());
+            Assert.Single(restored.TrackSections);
+            Assert.True(restored.FilesDirty);
+            Assert.Contains(logLines, l =>
+                l.Contains("[RecordingStore]") &&
+                l.Contains("DeserializeTrajectoryFrom") &&
+                l.Contains("healed malformed flat fallback"));
+        }
+
+        [Fact]
         public void DeserializeTrajectoryFrom_InvalidVersion_LogsWarningAndTreatsAsV0()
         {
             var node = new ConfigNode("PARSEK_RECORDING");

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -3393,6 +3393,27 @@ namespace Parsek
             return true;
         }
 
+        internal static bool TryHealMalformedFlatFallbackTrajectoryFromTrackSections(
+            Recording rec,
+            bool allowRelativeSections = false)
+        {
+            if (rec == null
+                || !HasCompleteTrackSectionPayloadForFlatSync(rec.TrackSections, allowRelativeSections))
+            {
+                return false;
+            }
+
+            bool healedPoints = TryHealMalformedFlatFallbackPointsFromTrackSections(rec);
+            bool healedOrbitSegments = TryHealMalformedFlatFallbackOrbitSegmentsFromTrackSections(rec);
+            if (!healedPoints && !healedOrbitSegments)
+                return false;
+
+            rec.CachedStats = null;
+            rec.CachedStatsPointCount = 0;
+            rec.MarkFilesDirty();
+            return true;
+        }
+
         private static bool FlatTrajectoryExactlyMatchesTrackSectionPayload(Recording rec)
         {
             if (rec == null)
@@ -3406,6 +3427,70 @@ namespace Parsek
             var rebuiltOrbitSegments = new List<OrbitSegment>();
             RebuildOrbitSegmentsFromTrackSections(rec.TrackSections, rebuiltOrbitSegments);
             return OrbitSegmentListsEqual(rebuiltOrbitSegments, rec.OrbitSegments);
+        }
+
+        private static bool TryHealMalformedFlatFallbackPointsFromTrackSections(Recording rec)
+        {
+            if (rec.Points == null || rec.Points.Count == 0)
+                return false;
+
+            var rebuiltPoints = new List<TrajectoryPoint>();
+            RebuildPointsFromTrackSections(rec.TrackSections, rebuiltPoints);
+            if (rebuiltPoints.Count == 0 || rec.Points.Count < rebuiltPoints.Count)
+                return false;
+
+            for (int i = 0; i < rebuiltPoints.Count; i++)
+            {
+                if (!TrajectoryPointEquals(rebuiltPoints[i], rec.Points[i]))
+                    return false;
+            }
+
+            int suffixStart = FindSafeTrajectoryPointSuffixStart(rec.Points, rebuiltPoints);
+            if (suffixStart < 0)
+                return false;
+
+            var healedPoints = new List<TrajectoryPoint>(rebuiltPoints);
+            AppendTrajectoryPointSuffix(healedPoints, rec.Points, suffixStart);
+            if (!TrajectoryPointListIsMonotonicNonDecreasing(healedPoints)
+                || TrajectoryPointListsEqual(healedPoints, rec.Points))
+            {
+                return false;
+            }
+
+            rec.Points = healedPoints;
+            return true;
+        }
+
+        private static bool TryHealMalformedFlatFallbackOrbitSegmentsFromTrackSections(Recording rec)
+        {
+            if (rec.OrbitSegments == null || rec.OrbitSegments.Count == 0)
+                return false;
+
+            var rebuiltOrbitSegments = new List<OrbitSegment>();
+            RebuildOrbitSegmentsFromTrackSections(rec.TrackSections, rebuiltOrbitSegments);
+            if (rebuiltOrbitSegments.Count == 0 || rec.OrbitSegments.Count < rebuiltOrbitSegments.Count)
+                return false;
+
+            for (int i = 0; i < rebuiltOrbitSegments.Count; i++)
+            {
+                if (!OrbitSegmentEquals(rebuiltOrbitSegments[i], rec.OrbitSegments[i]))
+                    return false;
+            }
+
+            int suffixStart = FindSafeOrbitSegmentSuffixStart(rec.OrbitSegments, rebuiltOrbitSegments);
+            if (suffixStart < 0)
+                return false;
+
+            var healedOrbitSegments = new List<OrbitSegment>(rebuiltOrbitSegments);
+            AppendOrbitSegmentSuffix(healedOrbitSegments, rec.OrbitSegments, suffixStart);
+            if (!OrbitSegmentListIsMonotonicNonDecreasing(healedOrbitSegments)
+                || OrbitSegmentListsEqual(healedOrbitSegments, rec.OrbitSegments))
+            {
+                return false;
+            }
+
+            rec.OrbitSegments = healedOrbitSegments;
+            return true;
         }
 
         private static bool TrajectoryPointListsEqual(List<TrajectoryPoint> a, List<TrajectoryPoint> b)
@@ -3538,6 +3623,42 @@ namespace Parsek
             return 0;
         }
 
+        private static int FindSafeTrajectoryPointSuffixStart(
+            List<TrajectoryPoint> flatPoints,
+            List<TrajectoryPoint> rebuiltPoints)
+        {
+            if (flatPoints == null
+                || rebuiltPoints == null
+                || rebuiltPoints.Count == 0
+                || flatPoints.Count < rebuiltPoints.Count)
+            {
+                return -1;
+            }
+
+            double minUt = rebuiltPoints[rebuiltPoints.Count - 1].ut;
+            for (int start = Math.Max(rebuiltPoints.Count - 1, 0); start <= flatPoints.Count; start++)
+            {
+                if (start < flatPoints.Count)
+                {
+                    if (flatPoints[start].ut < minUt)
+                        continue;
+
+                    if (flatPoints[start].ut == minUt
+                        && !TrajectoryPointEquals(flatPoints[start], rebuiltPoints[rebuiltPoints.Count - 1]))
+                    {
+                        continue;
+                    }
+
+                    if (!TrajectoryPointSuffixIsMonotonicNonDecreasing(flatPoints, start))
+                        continue;
+                }
+
+                return start;
+            }
+
+            return -1;
+        }
+
         private static int FindOrbitSegmentSuffixPrefixOverlap(
             List<OrbitSegment> existing,
             List<OrbitSegment> incoming)
@@ -3564,6 +3685,104 @@ namespace Parsek
             }
 
             return 0;
+        }
+
+        private static int FindSafeOrbitSegmentSuffixStart(
+            List<OrbitSegment> flatOrbitSegments,
+            List<OrbitSegment> rebuiltOrbitSegments)
+        {
+            if (flatOrbitSegments == null
+                || rebuiltOrbitSegments == null
+                || rebuiltOrbitSegments.Count == 0
+                || flatOrbitSegments.Count < rebuiltOrbitSegments.Count)
+            {
+                return -1;
+            }
+
+            double minStartUT = rebuiltOrbitSegments[rebuiltOrbitSegments.Count - 1].startUT;
+            for (int start = Math.Max(rebuiltOrbitSegments.Count - 1, 0); start <= flatOrbitSegments.Count; start++)
+            {
+                if (start < flatOrbitSegments.Count)
+                {
+                    if (flatOrbitSegments[start].startUT < minStartUT)
+                        continue;
+
+                    if (flatOrbitSegments[start].startUT == minStartUT
+                        && !OrbitSegmentEquals(flatOrbitSegments[start], rebuiltOrbitSegments[rebuiltOrbitSegments.Count - 1]))
+                    {
+                        continue;
+                    }
+
+                    if (!OrbitSegmentSuffixIsMonotonicNonDecreasing(flatOrbitSegments, start))
+                        continue;
+                }
+
+                return start;
+            }
+
+            return -1;
+        }
+
+        private static bool TrajectoryPointSuffixIsMonotonicNonDecreasing(
+            List<TrajectoryPoint> points,
+            int startIndex)
+        {
+            if (points == null || startIndex >= points.Count)
+                return true;
+
+            double previousUt = points[startIndex].ut;
+            for (int i = startIndex + 1; i < points.Count; i++)
+            {
+                if (points[i].ut < previousUt)
+                    return false;
+                previousUt = points[i].ut;
+            }
+
+            return true;
+        }
+
+        private static bool OrbitSegmentSuffixIsMonotonicNonDecreasing(
+            List<OrbitSegment> orbitSegments,
+            int startIndex)
+        {
+            if (orbitSegments == null || startIndex >= orbitSegments.Count)
+                return true;
+
+            double previousStartUT = orbitSegments[startIndex].startUT;
+            for (int i = startIndex + 1; i < orbitSegments.Count; i++)
+            {
+                if (orbitSegments[i].startUT < previousStartUT)
+                    return false;
+                previousStartUT = orbitSegments[i].startUT;
+            }
+
+            return true;
+        }
+
+        private static void AppendTrajectoryPointSuffix(
+            List<TrajectoryPoint> target,
+            List<TrajectoryPoint> source,
+            int startIndex)
+        {
+            for (int i = startIndex; i < source.Count; i++)
+            {
+                if (target.Count > 0 && TrajectoryPointEquals(target[target.Count - 1], source[i]))
+                    continue;
+                target.Add(source[i]);
+            }
+        }
+
+        private static void AppendOrbitSegmentSuffix(
+            List<OrbitSegment> target,
+            List<OrbitSegment> source,
+            int startIndex)
+        {
+            for (int i = startIndex; i < source.Count; i++)
+            {
+                if (target.Count > 0 && OrbitSegmentEquals(target[target.Count - 1], source[i]))
+                    continue;
+                target.Add(source[i]);
+            }
         }
 
         private static bool TrajectoryPointEquals(TrajectoryPoint a, TrajectoryPoint b)
@@ -3709,6 +3928,21 @@ namespace Parsek
                 DeserializePoints(sourceNode, rec);
                 DeserializeOrbitSegments(sourceNode, rec);
                 DeserializeTrackSections(sourceNode, rec.TrackSections);
+
+                bool healedMalformedFlatFallback = false;
+                if (formatVersion >= 1 && rec.TrackSections.Count > 0)
+                {
+                    healedMalformedFlatFallback = TryHealMalformedFlatFallbackTrajectoryFromTrackSections(
+                        rec, allowRelativeSections: true);
+                    if (healedMalformedFlatFallback && !SuppressLogging)
+                    {
+                        ParsekLog.Verbose("RecordingStore",
+                            $"DeserializeTrajectoryFrom: recording={rec.RecordingId} version={formatVersion} " +
+                            $"healed malformed flat fallback using track-section prefix " +
+                            $"points={rec.Points.Count} orbitSegments={rec.OrbitSegments.Count} " +
+                            $"trackSections={rec.TrackSections.Count}");
+                    }
+                }
 
                 if (formatVersion >= 1)
                 {

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -3636,22 +3636,19 @@ namespace Parsek
             }
 
             double minUt = rebuiltPoints[rebuiltPoints.Count - 1].ut;
-            for (int start = Math.Max(rebuiltPoints.Count - 1, 0); start <= flatPoints.Count; start++)
+            for (int start = rebuiltPoints.Count; start < flatPoints.Count; start++)
             {
-                if (start < flatPoints.Count)
+                if (flatPoints[start].ut < minUt)
+                    continue;
+
+                if (flatPoints[start].ut == minUt
+                    && !TrajectoryPointEquals(flatPoints[start], rebuiltPoints[rebuiltPoints.Count - 1]))
                 {
-                    if (flatPoints[start].ut < minUt)
-                        continue;
-
-                    if (flatPoints[start].ut == minUt
-                        && !TrajectoryPointEquals(flatPoints[start], rebuiltPoints[rebuiltPoints.Count - 1]))
-                    {
-                        continue;
-                    }
-
-                    if (!TrajectoryPointSuffixIsMonotonicNonDecreasing(flatPoints, start))
-                        continue;
+                    continue;
                 }
+
+                if (!TrajectoryPointSuffixIsMonotonicNonDecreasing(flatPoints, start))
+                    continue;
 
                 return start;
             }
@@ -3700,22 +3697,19 @@ namespace Parsek
             }
 
             double minStartUT = rebuiltOrbitSegments[rebuiltOrbitSegments.Count - 1].startUT;
-            for (int start = Math.Max(rebuiltOrbitSegments.Count - 1, 0); start <= flatOrbitSegments.Count; start++)
+            for (int start = rebuiltOrbitSegments.Count; start < flatOrbitSegments.Count; start++)
             {
-                if (start < flatOrbitSegments.Count)
+                if (flatOrbitSegments[start].startUT < minStartUT)
+                    continue;
+
+                if (flatOrbitSegments[start].startUT == minStartUT
+                    && !OrbitSegmentEquals(flatOrbitSegments[start], rebuiltOrbitSegments[rebuiltOrbitSegments.Count - 1]))
                 {
-                    if (flatOrbitSegments[start].startUT < minStartUT)
-                        continue;
-
-                    if (flatOrbitSegments[start].startUT == minStartUT
-                        && !OrbitSegmentEquals(flatOrbitSegments[start], rebuiltOrbitSegments[rebuiltOrbitSegments.Count - 1]))
-                    {
-                        continue;
-                    }
-
-                    if (!OrbitSegmentSuffixIsMonotonicNonDecreasing(flatOrbitSegments, start))
-                        continue;
+                    continue;
                 }
+
+                if (!OrbitSegmentSuffixIsMonotonicNonDecreasing(flatOrbitSegments, start))
+                    continue;
 
                 return start;
             }

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -7,6 +7,18 @@ Entries 272–303 (78 bugs, 6 TODOs — mostly resolved) archived in `done/todo-
 
 # Known Bugs
 
+## ~~360. Loaded committed recordings can keep a duplicated flat-prefix tail and fail monotonicity checks~~
+
+**Observed in:** `logs/2026-04-14_1836_pr285-ingame-batches` (2026-04-14). Both the KSC-view and FLIGHT-mode in-game batches failed `RuntimeTests.CommittedRecordingsHaveValidData` on committed recording `393b82ccb697492bb7b35c6c621f9d07` (`Learstar A1 Debris`) because the loaded point list jumped backward from `170.92` to `155.84`.
+
+**Root cause:** the committed sidecar on disk was already malformed in a specific flat-fallback shape: top-level `Points` duplicated the exact trajectory payload already represented by nested `TrackSections`, then appended a later monotonic tail. `DeserializeTrajectoryFrom(...)` accepted that stale flat fallback as-is whenever section-authoritative rebuild was unavailable, so runtime validation could still see a non-monotonic committed recording even after the earlier overlap-aware merge fixes.
+
+**Fix:** flat-fallback load now detects the "duplicated track-section prefix plus later monotonic suffix" shape, rebuilds the authoritative prefix from `TrackSections`, appends only the safe monotonic suffix, and marks the recording dirty so the next save rewrites the sidecar cleanly. Added a regression test that serializes/deserializes that malformed v1 payload and pins the healed result.
+
+**Status:** ~~Fixed~~
+
+---
+
 ## ~~359. Background section flushes can duplicate flat tails and leave one-point destroyed debris stubs after merge~~
 
 **Observed in:** the same 2026-04-14 follow-up investigation that found the missing `Rewind` button. The runtime/in-game suite was failing `CommittedRecordingsHaveValidData` and `RecordingStopMetricsValid`, and merged quickload-resume trees could retain non-monotonic flat tails or single-point destroyed debris leaves that were never meant to survive commit.


### PR DESCRIPTION
## Summary
- heal malformed flat-fallback committed recordings whose top-level trajectory duplicates the same TrackSection prefix already stored in the sidecar
- preserve only the safe monotonic suffix and mark healed recordings dirty so the next save rewrites the sidecar cleanly
- add regression coverage plus changelog/todo entries for #360

## Testing
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter FullyQualifiedName~FormatVersionTests|FullyQualifiedName~SessionMergerTests
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter FullyQualifiedName~BackgroundTrackSectionTests|FullyQualifiedName~RecordingStorageRoundTripTests|FullyQualifiedName~RecordingStoreTests|FullyQualifiedName~FormatVersionTests|FullyQualifiedName~SessionMergerTests
- dotnet build Source/Parsek/Parsek.csproj -c Release -t:Rebuild