### PR TITLE
Fix ghost watch entry camera side

### DIFF
--- a/Source/Parsek.Tests/WatchModeControllerTests.cs
+++ b/Source/Parsek.Tests/WatchModeControllerTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.Serialization;
+using UnityEngine;
 using Xunit;
 
 namespace Parsek.Tests
@@ -8,6 +9,16 @@ namespace Parsek.Tests
     [Collection("Sequential")]
     public class WatchModeControllerTests
     {
+        private static Vector3 OrbitDirectionFromAngles(float pitch, float heading)
+        {
+            float pitchRad = pitch * Mathf.Deg2Rad;
+            float headingRad = heading * Mathf.Deg2Rad;
+            return new Vector3(
+                Mathf.Sin(headingRad) * Mathf.Cos(pitchRad),
+                Mathf.Sin(pitchRad),
+                Mathf.Cos(headingRad) * Mathf.Cos(pitchRad));
+        }
+
         private static Recording MakeRecording(
             string id,
             uint vesselPid,
@@ -418,6 +429,35 @@ namespace Parsek.Tests
             Assert.Equal(WatchModeController.DefaultWatchEntryDistance, result.Distance);
             Assert.Equal(-5f, result.Pitch);
             Assert.Equal(170f, result.Heading);
+        }
+
+        [Fact]
+        public void CompensateTransferredWatchAngles_WorldOrbitDirection_PreservesDirection()
+        {
+            Vector3 worldOrbitDirection = new Vector3(0.31f, 0.22f, 0.92f).normalized;
+            var state = new WatchCameraTransitionState
+            {
+                Pitch = -11f,
+                Heading = 147f,
+                HasTargetRotation = true,
+                TargetRotation = new Quaternion(0f, 1f, 0f, 0f),
+                HasWorldOrbitDirection = true,
+                WorldOrbitDirection = worldOrbitDirection
+            };
+
+            Quaternion newTargetRotation = new Quaternion(0f, 0.7071068f, 0f, 0.7071068f);
+
+            var (newPitch, newHeading) = WatchModeController.CompensateTransferredWatchAngles(
+                state,
+                newTargetRotation);
+
+            Vector3 resolvedWorldDirection = WatchModeController.RotateVectorByQuaternion(
+                newTargetRotation,
+                OrbitDirectionFromAngles(newPitch, newHeading));
+
+            Assert.True(
+                Vector3.Dot(worldOrbitDirection, resolvedWorldDirection) > 0.999f,
+                $"Expected preserved orbit direction, got {resolvedWorldDirection} from ({newPitch}, {newHeading})");
         }
 
         [Fact]

--- a/Source/Parsek/WatchModeController.cs
+++ b/Source/Parsek/WatchModeController.cs
@@ -23,6 +23,8 @@ namespace Parsek
         public bool UserModeOverride;
         public bool HasTargetRotation;
         public Quaternion TargetRotation;
+        public bool HasWorldOrbitDirection;
+        public Vector3 WorldOrbitDirection;
     }
 
     /// <summary>
@@ -587,6 +589,52 @@ namespace Parsek
                 cameraState.HasTargetRotation = true;
                 cameraState.TargetRotation = flightCamera.Target.rotation;
             }
+            if (TryGetCurrentFlightCameraWorldOrbitDirection(
+                    flightCamera,
+                    out var worldOrbitDirection))
+            {
+                cameraState.HasWorldOrbitDirection = true;
+                cameraState.WorldOrbitDirection = worldOrbitDirection;
+            }
+            return true;
+        }
+
+        internal static bool TryGetCurrentFlightCameraWorldOrbitDirection(
+            FlightCamera flightCamera,
+            out Vector3 worldOrbitDirection)
+        {
+            worldOrbitDirection = Vector3.zero;
+            if (flightCamera?.transform == null)
+                return false;
+
+            Vector3 orbitCenter;
+            if (flightCamera.transform.parent != null)
+            {
+                orbitCenter = flightCamera.transform.parent.position;
+            }
+            else if (flightCamera.Target != null)
+            {
+                orbitCenter = flightCamera.Target.position;
+            }
+            else
+            {
+                return false;
+            }
+
+            Vector3 orbitVector = flightCamera.transform.position - orbitCenter;
+            float sqrMagnitude = orbitVector.sqrMagnitude;
+            if (sqrMagnitude <= 1e-6f
+                || float.IsNaN(orbitVector.x)
+                || float.IsNaN(orbitVector.y)
+                || float.IsNaN(orbitVector.z)
+                || float.IsInfinity(orbitVector.x)
+                || float.IsInfinity(orbitVector.y)
+                || float.IsInfinity(orbitVector.z))
+            {
+                return false;
+            }
+
+            worldOrbitDirection = orbitVector / Mathf.Sqrt(sqrMagnitude);
             return true;
         }
 
@@ -621,6 +669,11 @@ namespace Parsek
             WatchCameraTransitionState currentState,
             Quaternion newTargetRotation)
         {
+            if (currentState.HasWorldOrbitDirection)
+                return DecomposeOrbitDirectionInTargetFrame(
+                    currentState.WorldOrbitDirection,
+                    newTargetRotation);
+
             if (!currentState.HasTargetRotation)
                 return (currentState.Pitch, currentState.Heading);
 
@@ -1289,14 +1342,68 @@ namespace Parsek
                 Mathf.Cos(hdgRad) * Mathf.Cos(pitchRad));
 
             // Transform to world space via old target, then back to new target's local space
-            Vector3 worldDir = oldTargetRot * localDir;
-            Vector3 newLocalDir = Quaternion.Inverse(newTargetRot) * worldDir;
+            Vector3 worldDir = RotateVectorByQuaternion(oldTargetRot, localDir);
+            Vector3 newLocalDir = InverseRotateVectorByQuaternion(newTargetRot, worldDir);
 
             // Decompose back to pitch/hdg
             float newPitch = Mathf.Asin(Mathf.Clamp(newLocalDir.y, -1f, 1f)) * Mathf.Rad2Deg;
             float newHdg = Mathf.Atan2(newLocalDir.x, newLocalDir.z) * Mathf.Rad2Deg;
 
             return (newPitch, newHdg);
+        }
+
+        internal static (float pitch, float hdg) DecomposeOrbitDirectionInTargetFrame(
+            Vector3 worldOrbitDirection,
+            Quaternion targetRotation)
+        {
+            Vector3 normalizedDirection = worldOrbitDirection.normalized;
+            Vector3 localDir = InverseRotateVectorByQuaternion(targetRotation, normalizedDirection);
+            float pitch = Mathf.Asin(Mathf.Clamp(localDir.y, -1f, 1f)) * Mathf.Rad2Deg;
+            float hdg = Mathf.Atan2(localDir.x, localDir.z) * Mathf.Rad2Deg;
+            return (pitch, hdg);
+        }
+
+        internal static Vector3 RotateVectorByQuaternion(Quaternion rotation, Vector3 direction)
+        {
+            Quaternion normalized = NormalizeQuaternion(rotation);
+            Vector3 axis = new Vector3(normalized.x, normalized.y, normalized.z);
+            float scalar = normalized.w;
+            return 2f * Vector3.Dot(axis, direction) * axis
+                + (scalar * scalar - Vector3.Dot(axis, axis)) * direction
+                + 2f * scalar * Vector3.Cross(axis, direction);
+        }
+
+        internal static Vector3 InverseRotateVectorByQuaternion(Quaternion rotation, Vector3 direction)
+        {
+            Quaternion normalized = NormalizeQuaternion(rotation);
+            Quaternion inverse = new Quaternion(
+                -normalized.x,
+                -normalized.y,
+                -normalized.z,
+                normalized.w);
+            return RotateVectorByQuaternion(inverse, direction);
+        }
+
+        internal static Quaternion NormalizeQuaternion(Quaternion rotation)
+        {
+            float sqrMagnitude =
+                rotation.x * rotation.x
+                + rotation.y * rotation.y
+                + rotation.z * rotation.z
+                + rotation.w * rotation.w;
+            if (sqrMagnitude <= 1e-12f
+                || float.IsNaN(sqrMagnitude)
+                || float.IsInfinity(sqrMagnitude))
+            {
+                return new Quaternion(0f, 0f, 0f, 1f);
+            }
+
+            float inverseMagnitude = 1f / Mathf.Sqrt(sqrMagnitude);
+            return new Quaternion(
+                rotation.x * inverseMagnitude,
+                rotation.y * inverseMagnitude,
+                rotation.z * inverseMagnitude,
+                rotation.w * inverseMagnitude);
         }
 
         // === Horizon-locked camera mode — instance methods ===


### PR DESCRIPTION
## Summary
- preserve the actual live FlightCamera orbit vector when entering watch mode so fresh ghost watch entry keeps the same vessel side
- decompose that captured world orbit direction against the ghost watch target instead of relying only on target rotation transfer
- add watch controller regression coverage for world-orbit-direction transfer

## Testing
- dotnet test Source\\Parsek.Tests\\Parsek.Tests.csproj --filter WatchModeControllerTests
- dotnet test Source\\Parsek.Tests\\Parsek.Tests.csproj  # 1 unrelated existing failure: GhostPlaybackEngineTests.SpawnGhost_PrimesFreshGhostToCurrentPlaybackUT (Unity/net472 SecurityException)
