### PR TITLE
fix: harden group Watch button log lines against latent IOOBE (#370)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to Parsek are documented here.
 
 _Unreleased._
 
+### Bug Fixes
+
+- `#370` Hardened the group Watch button log lines against a latent `IndexOutOfRangeException` if `ResolveEffectiveWatchTargetIndex` ever returns `-1` while the click reaches the handler.
+
 ---
 
 ## 0.8.1

--- a/Source/Parsek/UI/RecordingsTableUI.cs
+++ b/Source/Parsek/UI/RecordingsTableUI.cs
@@ -1390,7 +1390,7 @@ namespace Parsek
                             string reason = GetWatchButtonReason(canWatch, hasGhost, sameBody, inRange, isDebris: false);
                             ParsekLog.Info("UI",
                                 $"Group Watch button '{groupName}' source=#{mainIdx} \"{committed[mainIdx].VesselName}\" " +
-                                $"resolved={(resolvedWatchIdx >= 0 ? "#" + resolvedWatchIdx + " \"" + committed[resolvedWatchIdx].VesselName + "\"" : "<none>")} {reason} " +
+                                $"resolved={(resolvedWatchIdx >= 0 && resolvedWatchIdx < committed.Count ? "#" + resolvedWatchIdx + " \"" + committed[resolvedWatchIdx].VesselName + "\"" : "<none>")} {reason} " +
                                 $"(hasGhost={hasGhost} sameBody={sameBody} inRange={inRange}) " +
                                 $"{BuildWatchObservabilitySuffix(flight, mainIdx, resolvedWatchIdx)}");
                         }
@@ -1409,7 +1409,7 @@ namespace Parsek
                             flight.EnterWatchMode(resolvedWatchIdx);
                         ParsekLog.Info("UI",
                             $"Group '{groupName}' W button: {(isWatching ? "exit" : "enter")} watch on source #{mainIdx} " +
-                            $"resolved #{resolvedWatchIdx} \"{committed[resolvedWatchIdx].VesselName}\" " +
+                            $"resolved {(resolvedWatchIdx >= 0 && resolvedWatchIdx < committed.Count ? "#" + resolvedWatchIdx + " \"" + committed[resolvedWatchIdx].VesselName + "\"" : "<none>")} " +
                             $"before={beforeEligibility} beforeFocus={beforeFocus} afterFocus={flight.DescribeWatchFocusForLogs()}");
                     }
                     GUI.enabled = true;

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -178,7 +178,7 @@ The merge logic looks correct in isolation, but it runs over the same `TrackSect
 
 ---
 
-## 370. PR #246 follow-up: latent NRE in group watch button log line
+## ~~370. PR #246 follow-up: latent NRE in group watch button log line~~
 
 **Source:** light review of PRs `#246`-`#255` after `v0.8.0` ship.
 
@@ -188,7 +188,9 @@ The merge logic looks correct in isolation, but it runs over the same `TrackSect
 
 **What to do (later):** defensive `resolvedWatchIdx >= 0 ? committed[resolvedWatchIdx].VesselName : "<none>"` in the log line. Trivial.
 
-**Status:** TODO. Cosmetic/defensive cleanup.
+**Fix:** Both group-W log sites in `Source/Parsek/UI/RecordingsTableUI.cs` (the enable/disable transition log at ~line 1393 and the click-time log at ~line 1412) now guard `committed[resolvedWatchIdx].VesselName` with `resolvedWatchIdx >= 0 && resolvedWatchIdx < committed.Count ? ... : "<none>"`, matching the pre-existing pattern at the `resolvedTargetId` computation one scope above. `GUI.enabled = canWatch` still blocks the click path in practice; this hardens the log lines so a future refactor of the `canWatch`/`resolvedWatchIdx` ordering can't turn either into an `IndexOutOfRangeException`.
+
+**Status:** ~~Fixed~~.
 
 ---
 


### PR DESCRIPTION
## Summary

- Fixes bug `#370` — PR `#246` added `ResolveEffectiveWatchTargetIndex` so group "W" buttons follow auto-follow handoffs, but the click-time and transition log lines in `RecordingsTableUI.cs` dereference `committed[resolvedWatchIdx].VesselName` without bounds-checking the resolved index.
- The helper can legitimately return `-1` (see the existing `BugFixTests` cases `ResolveEffectiveWatchTargetIndex_NonBreakupInactiveFallbackChild_...` and `..._BreakupDifferentPid_...`). Today `GUI.enabled = canWatch` blocks the click path, but any future refactor that reorders `canWatch` / `resolvedWatchIdx` would turn the log lines into an `IndexOutOfRangeException`.
- Both sites now match the pre-existing `resolvedTargetId` guard one scope above: `resolvedWatchIdx >= 0 && resolvedWatchIdx < committed.Count ? "#" + resolvedWatchIdx + " \"" + committed[resolvedWatchIdx].VesselName + "\"" : "<none>"`. `CHANGELOG.md` and `docs/dev/todo-and-known-bugs.md` entry `#370` updated in the same commit.

## Test plan

- [x] `dotnet build` green with explicit `KSPDir` (worktree lives one level deeper than the 5-level probe walk).
- [x] `dotnet test` — 6195 passed, 1 pre-existing unrelated Unity-GameObject test failure (`GhostPlaybackEngineTests.SpawnGhost_PrimesFreshGhostToCurrentPlaybackUT`, `SecurityException: ECall methods must be packaged into a system module`), already being addressed on `fix/release-py-test-skip`.
- [ ] Smoke-test in KSP: open a recording group with a chain continuation, rewind/truncate the main recording, observe the group row "W" button transition log line emits `<none>` instead of crashing when the resolver returns `-1`.
- No new unit test added: the defensive change is a one-liner inside a Unity GUI handler; the `-1` return path of the helper is already covered by existing unit tests.