### PR TITLE
Delete orphaned synthetic-scenario test helpers (#372)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to Parsek are documented here.
 
 _Unreleased._
 
+### Maintenance
+
+- `#372` Removed orphaned synthetic-scenario test helpers left behind after the live FLIGHT save/load round-trip test infrastructure was reverted.
+
 ---
 
 ## 0.8.1

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -447,7 +447,6 @@ namespace Parsek
         }
         public bool HasActiveChain => chainManager?.HasActiveChain ?? false;
         public bool HasActiveTree => activeTree != null;
-        internal bool HasDeferredWatchAfterFastForward => !string.IsNullOrEmpty(pendingWatchAfterFFId);
 
         // Camera follow (watch mode) — forwarded from WatchModeController
         internal bool IsWatchingGhost => watchMode.IsWatchingGhost;
@@ -8732,25 +8731,10 @@ namespace Parsek
             engine.DestroyGhost(index);
         }
 
-        internal void NormalizeAfterSyntheticScenarioLoad(string reason)
-        {
-            string cleanupReason = string.IsNullOrEmpty(reason)
-                ? "synthetic scenario load"
-                : reason;
-            ParsekLog.Info("TestRunner",
-                $"Normalizing FLIGHT runtime after {cleanupReason}");
-
-            pendingWatchAfterFFId = null;
-            watchMode.ClearAfterSyntheticScenarioLoad();
-
-            StopPlayback();
-            DestroyAllTimelineGhosts("synthetic-scenario-load");
-        }
-
-        public void DestroyAllTimelineGhosts(string ghostMapReason = "rewind")
+        public void DestroyAllTimelineGhosts()
         {
             // Remove ghost map ProtoVessels before engine cleanup
-            GhostMapPresence.RemoveAllGhostVessels(ghostMapReason);
+            GhostMapPresence.RemoveAllGhostVessels("rewind");
 
             // Engine destroys all ghost GOs and clears engine-owned state.
             // Fires OnAllGhostsDestroying so policy clears its own state.

--- a/Source/Parsek/WatchModeController.cs
+++ b/Source/Parsek/WatchModeController.cs
@@ -1533,49 +1533,6 @@ namespace Parsek
             ResetWatchState(preserveLineageProtection, destroyOverlapAnchor: true);
         }
 
-        internal void ClearAfterSyntheticScenarioLoad()
-        {
-            if (watchedRecordingIndex >= 0)
-            {
-                ExitWatchMode(skipCameraRestore: false, preserveLineageProtection: false);
-                return;
-            }
-
-            RemoveWatchModeControlLockSafe();
-            ClearLineageProtection();
-            watchedOverlapCycleIndex = -1;
-            overlapRetargetAfterUT = -1;
-            watchEndHoldUntilRealTime = -1;
-            watchEndHoldMaxRealTime = -1;
-            watchEndHoldPendingActivationUT = double.NaN;
-            watchNoTargetFrames = 0;
-            currentCameraMode = WatchCameraMode.Free;
-            userModeOverride = false;
-            lastLoggedWatchTargetMismatch = null;
-            lastLoggedWatchFocusKey = null;
-            lastLoggedHorizonVectorKey = null;
-            savedCameraVessel = null;
-            savedCameraDistance = 0f;
-            savedCameraPitch = 0f;
-            savedCameraHeading = 0f;
-            lastMapViewEnabled = false;
-            pendingMapFocusRestore = false;
-
-            if (overlapCameraAnchor == null)
-                return;
-
-            FlightCamera flightCamera = GetFlightCameraSafe();
-            Vessel activeVessel = GetActiveVesselSafe();
-            bool targetingOverlapAnchor = flightCamera != null
-                && flightCamera.Target == overlapCameraAnchor.transform;
-
-            UnityEngine.Object.Destroy(overlapCameraAnchor);
-            overlapCameraAnchor = null;
-
-            if (targetingOverlapAnchor && flightCamera != null && activeVessel != null)
-                flightCamera.SetTargetVessel(activeVessel);
-        }
-
         /// <summary>
         /// Determines whether a vessel's flight situation is safe for unattended flight.
         /// Safe means the vessel will not crash or deorbit while the player watches a ghost.

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -7,7 +7,7 @@ Entries 272–303 (78 bugs, 6 TODOs — mostly resolved) archived in `done/todo-
 
 # Known Bugs
 
-## 372. PR #253 / #254 follow-up: dead helpers left behind after batch-skip pivot
+## ~~372. PR #253 / #254 follow-up: dead helpers left behind after batch-skip pivot~~
 
 **Source:** light review of PRs `#246`-`#255` after `v0.8.0` ship.
 
@@ -23,11 +23,16 @@ The very next PR `#254` ("Fix `#332` follow-up: keep destructive quickload tests
 
 **Why it didn't get caught:** the cleanup happened in the same day as the original add, and `#254` was framed as a test-runner change, not a production code revert.
 
-**What to do (later):** delete the orphaned helpers, or leave them with an explicit `// retained for future synthetic-scenario test infrastructure` comment if there is a known follow-up. `WatchModeController.ClearAfterSyntheticScenarioLoad` in particular duplicates ~15 fields from `ResetWatchState` and is a maintenance trap (any new field added to `ResetWatchState` won't be added here).
+**Status:** ~~Fixed~~. Cleanup pass, low priority.
 
-**Status:** TODO. Cleanup pass, low priority.
+**Fix:** deleted the four orphans after a grep-confirmed zero-caller check across `Source/`, `docs/`, and `scripts/`:
 
-**Verified current head (during #256-#265 review):** all four helpers are still present in `WatchModeController.cs` and `ParsekFlight.cs`. PR `#257` removed a different set of orphaned merge-flow helpers (`AwaitingSceneChangeMergeOwner`, `PendingTreeOwnsReplay`, `OnFlightReadyHasMergeOwnerAfterDispatch` from `FlightResultsPatch` / `ParsekScenario`), so a related cleanup pass already happened — the `#372` items appear to have just been missed by it.
+- `ParsekFlight.NormalizeAfterSyntheticScenarioLoad` removed outright.
+- `ParsekFlight.DestroyAllTimelineGhosts(string ghostMapReason = "rewind")` reverted to its pre-`#253` parameterless signature with a hard-coded `"rewind"` ghost-map removal reason; the two live call sites (`ParsekFlight.OnDestroy` scene teardown and `ParsekUI` "wipe all recordings") already called it without arguments.
+- `WatchModeController.ClearAfterSyntheticScenarioLoad` removed outright — this was the ~15-field duplicate of `ResetWatchState` flagged here as a maintenance trap.
+- `ParsekFlight.HasDeferredWatchAfterFastForward` property removed (`pendingWatchAfterFFId` itself stays, still live in the deferred-FF handoff path).
+
+Build: clean (0 warnings, 0 errors). Tests: 6195/6196 passing; the single failure is the pre-existing `SpawnGhost_PrimesFreshGhostToCurrentPlaybackUT` Unity-runtime `SecurityException` tracked as `#380`.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes bug `#372`. PR `#253` added production-side helpers to support live FLIGHT save/load round-trip tests under synthetic scenario loads. PR `#254` (next day) rediagnosed the root cause and deleted the live tests plus `SyntheticScenarioLoadHelpers.cs`, but left the production-side helpers in place with no live caller.

Removed the four orphans (zero-caller verified via grep over `Source/`, `docs/`, and `scripts/`):

- `ParsekFlight.NormalizeAfterSyntheticScenarioLoad` - deleted outright.
- `ParsekFlight.DestroyAllTimelineGhosts(string ghostMapReason = "rewind")` - reverted to its pre-`#253` parameterless signature with a hard-coded `"rewind"` ghost-map removal reason. Both live call sites (`ParsekFlight.OnDestroy` scene teardown and `ParsekUI` "wipe all recordings") already passed no argument, so this is the smallest diff that removes the unused string-parameter surface.
- `WatchModeController.ClearAfterSyntheticScenarioLoad` - deleted outright. This was the ~15-field `ResetWatchState` duplicate flagged in `#372` as a maintenance trap.
- `ParsekFlight.HasDeferredWatchAfterFastForward` property exposure - deleted. `pendingWatchAfterFFId` itself stays, still live in the deferred-FF handoff path.

Net diff: `+15 / -65` across four files (code plus `CHANGELOG.md` and `docs/dev/todo-and-known-bugs.md`).

## Test plan

- [x] `dotnet build` from `Source/Parsek/` - clean (0 warnings, 0 errors).
- [x] `dotnet test` from `Source/Parsek.Tests/` - `6195/6196` passing. The single failure is the pre-existing `SpawnGhost_PrimesFreshGhostToCurrentPlaybackUT` Unity-runtime `SecurityException` tracked as `#380`.
- [x] Grep confirmed zero remaining callers of the four symbols after deletion.