### PR TITLE
Fix #373: log landed ghost clearance fallback instead of silent 0.5 m regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to Parsek are documented here.
 
 _Unreleased._
 
+### Bug Fixes
+
+- `#373` Landed ghost clearance no longer silently regresses to the legacy 0.5 m floor when the distance-aware resolver cannot run — the fallback now emits a rate-limited warning naming the ghost, recording, and reason so the cold-start / scene-transition path is visible in the log.
+
 ---
 
 ## 0.8.1

--- a/Source/Parsek.Tests/TerrainCorrectorTests.cs
+++ b/Source/Parsek.Tests/TerrainCorrectorTests.cs
@@ -178,6 +178,46 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void ResolveImmediateLandedGhostClearanceFallbackReason_AllLive_ReturnsNull()
+        {
+            string reason = ParsekFlight.ResolveImmediateLandedGhostClearanceFallbackReason(
+                hasBody: true, hasActiveVessel: true);
+            Assert.Null(reason);
+        }
+
+        [Fact]
+        public void ResolveImmediateLandedGhostClearanceFallbackReason_NoBody_ReturnsNoBody()
+        {
+            string reason = ParsekFlight.ResolveImmediateLandedGhostClearanceFallbackReason(
+                hasBody: false, hasActiveVessel: true);
+            Assert.Equal("no-body", reason);
+        }
+
+        [Fact]
+        public void ResolveImmediateLandedGhostClearanceFallbackReason_NoActiveVessel_ReturnsNoActiveVessel()
+        {
+            string reason = ParsekFlight.ResolveImmediateLandedGhostClearanceFallbackReason(
+                hasBody: true, hasActiveVessel: false);
+            Assert.Equal("no-active-vessel", reason);
+        }
+
+        [Fact]
+        public void ResolveImmediateLandedGhostClearanceFallbackReason_NeitherLive_ReturnsCombined()
+        {
+            string reason = ParsekFlight.ResolveImmediateLandedGhostClearanceFallbackReason(
+                hasBody: false, hasActiveVessel: false);
+            Assert.Equal("no-body-and-no-active-vessel", reason);
+        }
+
+        [Fact]
+        public void ImmediateLandedGhostClearanceFallbackMeters_MatchesLegacyFloor()
+        {
+            // #373: Pin the fallback floor at 0.5 m so a future refactor that
+            // silently changes this constant immediately breaks the test.
+            Assert.Equal(0.5, ParsekFlight.ImmediateLandedGhostClearanceFallbackMeters);
+        }
+
+        [Fact]
         public void ShouldApplyImmediateSurfacePositionClearance_NaNTerrain_False()
         {
             Assert.False(ParsekFlight.ShouldApplyImmediateSurfacePositionClearance(double.NaN));

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -9418,6 +9418,7 @@ namespace Parsek
                     positioned = ApplyLandedGhostClearance(
                         point, index, traj.VesselName, traj.TerrainHeightAtEnd,
                         ResolveImmediateLandedGhostClearanceMeters(
+                            index, traj.VesselName,
                             point.bodyName, point.latitude, point.longitude, point.altitude));
                 }
             }
@@ -9434,12 +9435,54 @@ namespace Parsek
                 positioned.altitude));
         }
 
+        // Literal floor returned by the immediate-clearance resolver when it
+        // cannot compute a distance-aware value. Matches the legacy pre-#262
+        // hardcoded floor — callers that hit this branch silently regress to
+        // the old behavior, so ResolveImmediateLandedGhostClearanceMeters
+        // emits a rate-limited warning naming the offending ghost (#373).
+        internal const double ImmediateLandedGhostClearanceFallbackMeters = 0.5;
+
+        /// <summary>
+        /// Pure decision helper: given whether a <see cref="CelestialBody"/>
+        /// resolved for the ghost's body name and whether an active vessel is
+        /// present, returns the reason the fallback fires (for logging), or
+        /// <c>null</c> when both inputs are live and the distance-aware path
+        /// can run. Extracted for unit testing without KSP singletons (#373).
+        /// </summary>
+        internal static string ResolveImmediateLandedGhostClearanceFallbackReason(
+            bool hasBody, bool hasActiveVessel)
+        {
+            if (!hasBody && !hasActiveVessel) return "no-body-and-no-active-vessel";
+            if (!hasBody) return "no-body";
+            if (!hasActiveVessel) return "no-active-vessel";
+            return null;
+        }
+
         private static double ResolveImmediateLandedGhostClearanceMeters(
+            int index, string vesselName,
             string bodyName, double latitude, double longitude, double altitude)
         {
             CelestialBody body = FlightGlobals.Bodies?.Find(b => b.name == bodyName);
-            if (body == null || FlightGlobals.ActiveVessel == null)
-                return 0.5;
+            bool hasBody = body != null;
+            bool hasActiveVessel = FlightGlobals.ActiveVessel != null;
+            string fallbackReason = ResolveImmediateLandedGhostClearanceFallbackReason(
+                hasBody, hasActiveVessel);
+            if (fallbackReason != null)
+            {
+                // #373: Silent regression to the legacy 0.5 m floor when the
+                // distance-aware resolver cannot run. Rate-limit per
+                // ghost+reason so scene-transition cold-start paths surface
+                // without spamming the log on every frame.
+                string safeVessel = string.IsNullOrEmpty(vesselName) ? "?" : vesselName;
+                string safeBody = string.IsNullOrEmpty(bodyName) ? "?" : bodyName;
+                ParsekLog.WarnRateLimited("TerrainCorrect",
+                    $"landed-ghost-clearance-fallback-{index}-{fallbackReason}",
+                    $"Landed ghost clearance fallback #{index} (\"{safeVessel}\") on body='{safeBody}': " +
+                    $"{fallbackReason} — using legacy floor " +
+                    $"{ImmediateLandedGhostClearanceFallbackMeters.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)}m " +
+                    "(distance-aware #262 path skipped)");
+                return ImmediateLandedGhostClearanceFallbackMeters;
+            }
 
             Vector3d pointWorld = body.GetWorldSurfacePosition(latitude, longitude, altitude);
             double distToVessel = Vector3d.Distance(pointWorld, FlightGlobals.ActiveVessel.GetWorldPos3D());
@@ -9560,6 +9603,7 @@ namespace Parsek
                 syntheticPoint = ApplyLandedGhostClearance(
                     syntheticPoint, index, traj.VesselName, traj.TerrainHeightAtEnd,
                     ResolveImmediateLandedGhostClearanceMeters(
+                        index, traj.VesselName,
                         positioned.body, positioned.latitude, positioned.longitude, positioned.altitude));
                 positioned.altitude = syntheticPoint.altitude;
             }

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -146,7 +146,7 @@ Two paths if it bites:
 
 ---
 
-## 373. PR #262 follow-up: `ResolveImmediateLandedGhostClearanceMeters` silently regresses to legacy floor when active vessel is null
+## ~~373. PR #262 follow-up: `ResolveImmediateLandedGhostClearanceMeters` silently regresses to legacy floor when active vessel is null~~
 
 **Source:** light review of PRs `#256`-`#265` after `v0.8.0` ship.
 
@@ -154,7 +154,9 @@ Two paths if it bites:
 
 Separately, `PositionAtSurface` updates `lastInterpolatedBodyName` / `lastInterpolatedAltitude` inside the new clearance branch but NOT in the non-clearance branch (where `TerrainHeightAtEnd` is `NaN`). Pre-fix code didn't set them at all, so this is a net improvement, but the asymmetry is a smell — the two branches should either both update the cache or both leave it untouched.
 
-**Status:** TODO. Both items are minor: log a warning when the fallback fires, and unify the cache-update behavior across branches.
+**Status:** ~~Fixed~~.
+
+**Fix:** (1) Replaced the silent `return 0.5;` fallback in `ResolveImmediateLandedGhostClearanceMeters` with an explicit `ParsekLog.WarnRateLimited("TerrainCorrect", ...)` naming the ghost index, vessel name, body, and the fallback reason (`no-body`, `no-active-vessel`, or `no-body-and-no-active-vessel`), rate-limited per ghost+reason so scene-transition / cold-start paths surface without spamming. The literal `0.5` is now pinned as `ImmediateLandedGhostClearanceFallbackMeters` and the `(hasBody, hasActiveVessel)` decision is extracted into `ResolveImmediateLandedGhostClearanceFallbackReason` (pure `internal static`) with unit tests in `TerrainCorrectorTests` covering all four input combinations. Call sites in `PositionAtPoint` and `PositionAtSurface` were updated to pass `index` / `traj.VesselName` through so the warning can name the offending ghost. (2) The second claim (`PositionAtSurface` cache asymmetry) was stale at review time: the follow-up commit `e54f9a8c` that added the `ShouldApplyImmediateSurfacePositionClearance` guard already placed the `state.lastInterpolatedBodyName` / `state.lastInterpolatedAltitude` updates OUTSIDE the `if` block, so both the clearance and non-clearance branches in current HEAD already update the cache unconditionally. Consumers (`WatchModeController` camera/atmo/reentry-FX, `DriveReentryToZero`, `GhostPlaybackEngine.UpdateReentryFx`) rely on that cache being fresh after every surface position, so the symmetric "both update" behavior is the correct one and no code change is needed for this sub-item. Documented the stale premise here to avoid re-opening the review comment.
 
 ---
 


### PR DESCRIPTION
## Summary

Bug `#373` part 1: `ResolveImmediateLandedGhostClearanceMeters` used to return a hardcoded `0.5` m whenever the distance-aware path could not run (no `CelestialBody`, no `FlightGlobals.ActiveVessel`, or both). That literal matched the legacy pre-`#262` floor, so scene-transition / cold-start paths silently regressed to the old buried-ghost behavior. Now the fallback emits a rate-limited warning naming the ghost index, vessel, body, and reason so the regression surfaces in `KSP.log`.

- New `internal const double ImmediateLandedGhostClearanceFallbackMeters = 0.5` pins the literal.
- New `internal static string ResolveImmediateLandedGhostClearanceFallbackReason(bool hasBody, bool hasActiveVessel)` pure helper classifies the fallback cause (`no-body`, `no-active-vessel`, `no-body-and-no-active-vessel`, or `null` when live).
- `ParsekLog.WarnRateLimited("TerrainCorrect", "landed-ghost-clearance-fallback-{index}-{reason}", ...)` rate-limits per ghost+reason combo.
- `ResolveImmediateLandedGhostClearanceMeters` now takes `int index, string vesselName` so the warning can name the offender; both call sites (`PositionAtPoint`, `PositionAtSurface`) updated.

Bug `#373` part 2 (`PositionAtSurface` cache asymmetry) was **stale at review time**. The follow-up commit `e54f9a8c` that added the `ShouldApplyImmediateSurfacePositionClearance` guard already placed the `state.lastInterpolatedBodyName` / `state.lastInterpolatedAltitude` writes OUTSIDE the `if` block, so both the clearance and non-clearance branches in current HEAD already update the cache unconditionally. Consumers (`WatchModeController` camera/atmo/reentry-FX, `DriveReentryToZero`, `GhostPlaybackEngine.UpdateReentryFx`) read the cache after every surface position, so the symmetric "both update" behavior is the correct one — no code change. The todo entry is annotated so the review comment does not get re-raised.

## Test plan

- [x] `dotnet build` from `Source/Parsek` — clean (0 warnings, 0 errors).
- [x] `dotnet test` from `Source/Parsek.Tests` — 6200 pass, only the known `SpawnGhost_PrimesFreshGhostToCurrentPlaybackUT` failure (bug `#380`).
- [x] 5 new unit tests in `TerrainCorrectorTests` cover all four `(hasBody, hasActiveVessel)` combinations of the extracted reason helper plus the pinned fallback constant.
- [ ] In-game smoke: watch a landed ghost across a scene transition and grep `KSP.log` for `landed-ghost-clearance-fallback` to confirm the fallback path is either never hit (normal) or visible when it is (no longer silent).

Touches bug `#373` in `docs/dev/todo-and-known-bugs.md`.