### PR TITLE
#382 Group W button cycles through watchable vessels on each press

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to Parsek are documented here.
 - `#370` Hardened the group Watch button log lines against a latent `IndexOutOfRangeException` if `ResolveEffectiveWatchTargetIndex` ever returns `-1` while the click reaches the handler.
 - `#373` Landed ghost clearance no longer silently regresses to the legacy 0.5 m floor when the distance-aware resolver cannot run — the fallback now emits a rate-limited warning naming the ghost, recording, and reason so the cold-start / scene-transition path is visible in the log.
 - `#380` `scripts/release.py` now runs end-to-end and packages the release zip without aborting on a pre-existing unit-test failure.
+- `#382` Group `W` button now cycles to the next watchable vessel in the group on each press instead of always toggling the same target.
 
 ### Maintenance
 

--- a/Source/Parsek.Tests/GroupWatchCursorTests.cs
+++ b/Source/Parsek.Tests/GroupWatchCursorTests.cs
@@ -1,0 +1,310 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Bug #382: tests for <see cref="GhostPlaybackLogic.AdvanceGroupWatchCursor"/>.
+    /// The helper is a pure-static rotation advancer, so every test exercises it
+    /// directly without any Unity / ParsekUI scaffolding.
+    /// </summary>
+    [Collection("Sequential")]
+    public class GroupWatchCursorTests : IDisposable
+    {
+        public GroupWatchCursorTests()
+        {
+            RecordingStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+        }
+
+        private static Recording MakeRec(double startUT, string recordingId, string vesselName = "test", bool debris = false)
+        {
+            var r = new Recording { VesselName = vesselName, RecordingId = recordingId };
+            r.Points.Add(new TrajectoryPoint { ut = startUT });
+            r.IsDebris = debris;
+            return r;
+        }
+
+        private static Func<int, bool> AllEligible => _ => true;
+
+        // ── Empty / guard cases ──
+
+        [Fact]
+        public void NullDescendants_ReturnsEmpty()
+        {
+            var result = GhostPlaybackLogic.AdvanceGroupWatchCursor(
+                null, new List<Recording>(), AllEligible, null, null);
+            Assert.Null(result.NextRecordingId);
+            Assert.Equal(0, result.TotalEligible);
+            Assert.False(result.IsToggleOff);
+        }
+
+        [Fact]
+        public void EmptyDescendants_ReturnsEmpty()
+        {
+            var result = GhostPlaybackLogic.AdvanceGroupWatchCursor(
+                new HashSet<int>(), new List<Recording>(), AllEligible, null, null);
+            Assert.Null(result.NextRecordingId);
+            Assert.Equal(0, result.TotalEligible);
+        }
+
+        [Fact]
+        public void AllIneligible_ReturnsEmpty()
+        {
+            var committed = new List<Recording>
+            {
+                MakeRec(100, "a"),
+                MakeRec(200, "b"),
+            };
+            var descendants = new HashSet<int> { 0, 1 };
+            var result = GhostPlaybackLogic.AdvanceGroupWatchCursor(
+                descendants, committed, _ => false, null, null);
+            Assert.Null(result.NextRecordingId);
+            Assert.Equal(0, result.TotalEligible);
+        }
+
+        [Fact]
+        public void NullRecordingId_Skipped()
+        {
+            var committed = new List<Recording>
+            {
+                MakeRec(100, null),         // filtered: null RecordingId
+                MakeRec(200, "b"),
+            };
+            var descendants = new HashSet<int> { 0, 1 };
+            var result = GhostPlaybackLogic.AdvanceGroupWatchCursor(
+                descendants, committed, AllEligible, null, null);
+            Assert.Equal("b", result.NextRecordingId);
+            Assert.Equal(1, result.TotalEligible);
+        }
+
+        // ── Single-entry rotations ──
+
+        [Fact]
+        public void SingleEligibleNotWatched_ReturnsIt()
+        {
+            var committed = new List<Recording> { MakeRec(100, "only") };
+            var descendants = new HashSet<int> { 0 };
+            var result = GhostPlaybackLogic.AdvanceGroupWatchCursor(
+                descendants, committed, AllEligible, null, null);
+            Assert.Equal("only", result.NextRecordingId);
+            Assert.Equal(1, result.Position);
+            Assert.Equal(1, result.TotalEligible);
+            Assert.False(result.IsToggleOff);
+            Assert.False(result.IsWrap);
+        }
+
+        [Fact]
+        public void SingleEligibleIsWatched_ReturnsToggleOff()
+        {
+            var committed = new List<Recording> { MakeRec(100, "only") };
+            var descendants = new HashSet<int> { 0 };
+            var result = GhostPlaybackLogic.AdvanceGroupWatchCursor(
+                descendants, committed, AllEligible, cursorRecordingId: "only", currentlyWatchedRecId: "only");
+            Assert.True(result.IsToggleOff);
+            Assert.Equal("only", result.NextRecordingId);
+            Assert.Equal(1, result.TotalEligible);
+        }
+
+        // ── Two-entry rotations ──
+
+        [Fact]
+        public void TwoEligibleCursorNull_ReturnsFirstByStartUT()
+        {
+            var committed = new List<Recording>
+            {
+                MakeRec(200, "late"),
+                MakeRec(100, "early"),
+            };
+            var descendants = new HashSet<int> { 0, 1 };
+            var result = GhostPlaybackLogic.AdvanceGroupWatchCursor(
+                descendants, committed, AllEligible, null, null);
+            Assert.Equal("early", result.NextRecordingId);
+            Assert.Equal(1, result.Position);
+            Assert.Equal(2, result.TotalEligible);
+            Assert.False(result.IsWrap);
+        }
+
+        [Fact]
+        public void CursorOnFirst_ReturnsSecond()
+        {
+            var committed = new List<Recording>
+            {
+                MakeRec(100, "early"),
+                MakeRec(200, "late"),
+            };
+            var descendants = new HashSet<int> { 0, 1 };
+            var result = GhostPlaybackLogic.AdvanceGroupWatchCursor(
+                descendants, committed, AllEligible, cursorRecordingId: "early", currentlyWatchedRecId: "early");
+            Assert.Equal("late", result.NextRecordingId);
+            Assert.Equal(2, result.Position);
+            Assert.False(result.IsWrap);
+            Assert.False(result.IsToggleOff);
+        }
+
+        [Fact]
+        public void CursorOnSecond_WrapsToFirst()
+        {
+            var committed = new List<Recording>
+            {
+                MakeRec(100, "early"),
+                MakeRec(200, "late"),
+            };
+            var descendants = new HashSet<int> { 0, 1 };
+            var result = GhostPlaybackLogic.AdvanceGroupWatchCursor(
+                descendants, committed, AllEligible, cursorRecordingId: "late", currentlyWatchedRecId: "late");
+            Assert.Equal("early", result.NextRecordingId);
+            Assert.Equal(1, result.Position);
+            Assert.True(result.IsWrap);
+        }
+
+        [Fact]
+        public void StaleCursor_ReturnsFirstEligible()
+        {
+            // Cursor id not in eligible list → behaves like cursor=null.
+            var committed = new List<Recording>
+            {
+                MakeRec(100, "a"),
+                MakeRec(200, "b"),
+            };
+            var descendants = new HashSet<int> { 0, 1 };
+            var result = GhostPlaybackLogic.AdvanceGroupWatchCursor(
+                descendants, committed, AllEligible, cursorRecordingId: "ghost", currentlyWatchedRecId: null);
+            Assert.Equal("a", result.NextRecordingId);
+            Assert.Equal(1, result.Position);
+            Assert.False(result.IsWrap);
+        }
+
+        [Fact]
+        public void CursorMatchesWatched_AdvancePastWatched()
+        {
+            // Cursor on "a", watched is "b": the rotation should skip "b" and
+            // wrap back to "a" (which is not watched). Also covers the
+            // companion case cursor=a, watched=a → advance to b.
+            var committed = new List<Recording>
+            {
+                MakeRec(100, "a"),
+                MakeRec(200, "b"),
+            };
+            var descendants = new HashSet<int> { 0, 1 };
+
+            // cursor=a, watched=b → next non-watched is "a" (wrap).
+            var r1 = GhostPlaybackLogic.AdvanceGroupWatchCursor(
+                descendants, committed, AllEligible, cursorRecordingId: "a", currentlyWatchedRecId: "b");
+            Assert.Equal("a", r1.NextRecordingId);
+
+            // cursor=a, watched=a → next non-watched is "b".
+            var r2 = GhostPlaybackLogic.AdvanceGroupWatchCursor(
+                descendants, committed, AllEligible, cursorRecordingId: "a", currentlyWatchedRecId: "a");
+            Assert.Equal("b", r2.NextRecordingId);
+            Assert.False(r2.IsToggleOff);
+        }
+
+        [Fact]
+        public void StartUtTieBrokenByRecordingIdOrdinal()
+        {
+            var committed = new List<Recording>
+            {
+                MakeRec(100, "zulu"),
+                MakeRec(100, "alpha"),
+            };
+            var descendants = new HashSet<int> { 0, 1 };
+            var result = GhostPlaybackLogic.AdvanceGroupWatchCursor(
+                descendants, committed, AllEligible, null, null);
+            // Ordinal ascending: "alpha" < "zulu".
+            Assert.Equal("alpha", result.NextRecordingId);
+        }
+
+        [Fact]
+        public void OutOfRangeDescendantSkipped()
+        {
+            var committed = new List<Recording>
+            {
+                MakeRec(100, "a"),
+                MakeRec(200, "b"),
+            };
+            var descendants = new HashSet<int> { 0, 1, 99 };  // 99 is out of range
+            var result = GhostPlaybackLogic.AdvanceGroupWatchCursor(
+                descendants, committed, AllEligible, null, null);
+            Assert.Equal("a", result.NextRecordingId);
+            Assert.Equal(2, result.TotalEligible);
+        }
+
+        [Fact]
+        public void StaleDescendant_NoCrash()
+        {
+            var committed = new List<Recording>
+            {
+                null,                  // stale: committed[0] is null
+                MakeRec(200, "b"),
+            };
+            var descendants = new HashSet<int> { 0, 1 };
+            var result = GhostPlaybackLogic.AdvanceGroupWatchCursor(
+                descendants, committed, AllEligible, null, null);
+            Assert.Equal("b", result.NextRecordingId);
+            Assert.Equal(1, result.TotalEligible);
+        }
+
+        [Fact]
+        public void ThreeEntryFullCycle()
+        {
+            var committed = new List<Recording>
+            {
+                MakeRec(100, "A"),
+                MakeRec(200, "B"),
+                MakeRec(300, "C"),
+            };
+            var descendants = new HashSet<int> { 0, 1, 2 };
+
+            // cursor null → first by StartUT = A.
+            var r1 = GhostPlaybackLogic.AdvanceGroupWatchCursor(
+                descendants, committed, AllEligible, null, null);
+            Assert.Equal("A", r1.NextRecordingId);
+            Assert.False(r1.IsWrap);
+
+            // cursor A → B (advance, no wrap).
+            var r2 = GhostPlaybackLogic.AdvanceGroupWatchCursor(
+                descendants, committed, AllEligible, cursorRecordingId: "A", currentlyWatchedRecId: "A");
+            Assert.Equal("B", r2.NextRecordingId);
+            Assert.False(r2.IsWrap);
+
+            // cursor B → C (advance, no wrap).
+            var r3 = GhostPlaybackLogic.AdvanceGroupWatchCursor(
+                descendants, committed, AllEligible, cursorRecordingId: "B", currentlyWatchedRecId: "B");
+            Assert.Equal("C", r3.NextRecordingId);
+            Assert.False(r3.IsWrap);
+
+            // cursor C → A (wrap).
+            var r4 = GhostPlaybackLogic.AdvanceGroupWatchCursor(
+                descendants, committed, AllEligible, cursorRecordingId: "C", currentlyWatchedRecId: "C");
+            Assert.Equal("A", r4.NextRecordingId);
+            Assert.True(r4.IsWrap);
+        }
+
+        [Fact]
+        public void NullCurrentlyWatched_FirstPress_ReturnsFirst()
+        {
+            var committed = new List<Recording>
+            {
+                MakeRec(100, "a"),
+                MakeRec(200, "b"),
+            };
+            var descendants = new HashSet<int> { 0, 1 };
+            var result = GhostPlaybackLogic.AdvanceGroupWatchCursor(
+                descendants, committed, AllEligible, cursorRecordingId: null, currentlyWatchedRecId: null);
+            Assert.Equal("a", result.NextRecordingId);
+            Assert.False(result.IsToggleOff);
+            Assert.Equal(1, result.Position);
+        }
+    }
+}

--- a/Source/Parsek.Tests/RecordingsTableUITests.cs
+++ b/Source/Parsek.Tests/RecordingsTableUITests.cs
@@ -172,6 +172,46 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void PruneStaleWatchEntries_StaleGroupCursorEntries_Removed()
+        {
+            // Bug #382: the per-group rotation cursor dict (keyed by group
+            // name, valued by last-entered RecordingId) must drop entries
+            // whose stored RecordingId is no longer live. Without this, a
+            // group whose previously-watched vessel is rewound away would
+            // keep probing a dead id and fall back to first-eligible on
+            // every draw, breaking the advance semantics.
+            var cursor = new Dictionary<string, string>
+            {
+                ["Alpha"] = "live-id",
+                ["Beta"] = "dead-id"
+            };
+            var committed = new List<Recording> { MakeRecWithId("live-id", "A") };
+            RecordingsTableUI.PruneStaleWatchEntries(
+                new Dictionary<string, bool>(),
+                new Dictionary<string, bool>(),
+                new Dictionary<string, string>(),
+                cursor,
+                committed);
+            Assert.Single(cursor);
+            Assert.Equal("live-id", cursor["Alpha"]);
+            Assert.False(cursor.ContainsKey("Beta"));
+        }
+
+        [Fact]
+        public void PruneStaleWatchEntries_EmptyCommitted_ClearsGroupCursor()
+        {
+            // Edge: empty committed list also clears the rotation cursor dict.
+            var cursor = new Dictionary<string, string> { ["Alpha"] = "x" };
+            RecordingsTableUI.PruneStaleWatchEntries(
+                new Dictionary<string, bool>(),
+                new Dictionary<string, bool>(),
+                new Dictionary<string, string>(),
+                cursor,
+                new List<Recording>());
+            Assert.Empty(cursor);
+        }
+
+        [Fact]
         public void WatchTransitionLogging_BothCallSitesGuardNullRecordingId_PinnedBySourceInspection()
         {
             // Bug #279 follow-up review: the per-row site already guards
@@ -273,14 +313,27 @@ namespace Parsek.Tests
             string uiSrc = System.IO.File.ReadAllText(
                 System.IO.Path.Combine(srcRoot, "UI", "RecordingsTableUI.cs"));
 
+            // Per-row site still uses (flight, ri).
             Assert.Contains("BuildWatchObservabilitySuffix(flight, ri)", uiSrc);
-            Assert.Contains("BuildWatchObservabilitySuffix(flight, mainIdx, resolvedWatchIdx)", uiSrc);
+            // Bug #382: group site now passes nextTargetIdx (the cycle's next
+            // vessel) instead of resolvedWatchIdx, but the 3-arg observability
+            // helper signature (flight, sourceIndex, resolvedOrNextIndex) is
+            // unchanged so the log still names the watched/source/next pair.
+            Assert.Contains("BuildWatchObservabilitySuffix(flight, mainIdx, nextTargetIdx)", uiSrc);
             Assert.Contains("beforeFocus={beforeFocus} afterFocus={flight.DescribeWatchFocusForLogs()}", uiSrc);
         }
 
         [Fact]
-        public void GroupWatchUsesResolvedTargetWhileRowsStayExact_PinnedBySourceInspection()
+        public void GroupWatchUsesRotationCursor_PinnedBySourceInspection()
         {
+            // Bug #382: group W button no longer routes through a single
+            // ResolveEffectiveWatchTargetIndex call — it builds a per-press
+            // rotation via GhostPlaybackLogic.AdvanceGroupWatchCursor and
+            // stores the cursor in groupWatchCursorByGroupName. Pin that
+            // contract so a future refactor can't silently fall back to the
+            // old "always resolve the main index" behavior. The per-row W
+            // button continues to use the exact row index (no resolve) and
+            // that invariant is pinned below.
             string srcRoot = System.IO.Path.GetFullPath(
                 System.IO.Path.Combine(System.AppDomain.CurrentDomain.BaseDirectory,
                     "..", "..", "..", "..", "Parsek"));
@@ -294,13 +347,14 @@ namespace Parsek.Tests
             Assert.DoesNotContain("ResolveEffectiveWatchTargetIndex", rowWatchBlock);
             Assert.Contains("flight.WatchedRecordingIndex == ri", rowWatchBlock);
 
-            int groupWatchStart = uiSrc.IndexOf("// Watch button (flight only) — follows the group's current live continuation", StringComparison.Ordinal);
+            int groupWatchStart = uiSrc.IndexOf("// Watch button (flight only) — Bug #382", StringComparison.Ordinal);
             int groupWatchEnd = uiSrc.IndexOf("// Rewind / Fast-forward button — targets main recording", groupWatchStart, StringComparison.Ordinal);
             string groupWatchBlock = uiSrc.Substring(groupWatchStart, groupWatchEnd - groupWatchStart);
 
-            Assert.Contains("ResolveEffectiveWatchTargetIndex", groupWatchBlock);
-            Assert.Contains("flight.WatchedRecordingIndex == resolvedWatchIdx", groupWatchBlock);
-            Assert.Contains("resolvedWatchIdx", groupWatchBlock);
+            Assert.Contains("GhostPlaybackLogic.AdvanceGroupWatchCursor", groupWatchBlock);
+            Assert.Contains("groupWatchCursorByGroupName", groupWatchBlock);
+            Assert.Contains("rotation.NextRecordingId", groupWatchBlock);
+            Assert.DoesNotContain("ResolveEffectiveWatchTargetIndex", groupWatchBlock);
         }
 
         // ── GetRecordingSortKey ──

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -3747,7 +3747,134 @@ namespace Parsek
             return -1;
         }
 
-        private static int FindRecordingIndexById(
+        /// <summary>
+        /// Bug #382: result of advancing a group's watch-rotation cursor. Returned by
+        /// <see cref="AdvanceGroupWatchCursor"/>. When <see cref="NextRecordingId"/> is
+        /// null there are no eligible descendants in the group (button should be
+        /// disabled). When <see cref="IsToggleOff"/> is true the only eligible
+        /// descendant is the one currently being watched, and the caller should call
+        /// ExitWatchMode rather than re-enter the same target.
+        /// </summary>
+        internal readonly struct GroupWatchAdvanceResult
+        {
+            public readonly string NextRecordingId;   // null == empty eligible set
+            public readonly int Position;             // 1-based index in eligible list (0 when NextRecordingId is null)
+            public readonly int TotalEligible;        // count of eligible descendants
+            public readonly bool IsToggleOff;         // single-entry rotation where that entry IS currently watched
+            public readonly bool IsWrap;              // advance wrapped past the end of the eligible list
+
+            public GroupWatchAdvanceResult(string nextId, int pos, int total, bool toggleOff, bool wrap)
+            {
+                NextRecordingId = nextId;
+                Position = pos;
+                TotalEligible = total;
+                IsToggleOff = toggleOff;
+                IsWrap = wrap;
+            }
+
+            public static GroupWatchAdvanceResult Empty => new GroupWatchAdvanceResult(null, 0, 0, false, false);
+        }
+
+        /// <summary>
+        /// Bug #382: advances the rotation cursor for a group's W button. Builds a
+        /// stable eligible list from <paramref name="descendants"/> (sorted by
+        /// <c>StartUT</c> ascending, with <c>RecordingId</c> ordinal ascending as
+        /// a deterministic tiebreaker), locates <paramref name="cursorRecordingId"/>
+        /// in that list, and advances one step forward (wrapping) to the first entry
+        /// whose <c>RecordingId</c> differs from <paramref name="currentlyWatchedRecId"/>.
+        ///
+        /// The <paramref name="isEligible"/> predicate is the single source of truth
+        /// for "watchable" — callers are expected to fold
+        /// <c>hasGhost &amp;&amp; sameBody &amp;&amp; inRange &amp;&amp; !IsDebris</c>
+        /// (plus any non-null RecordingId filter they need) into it.
+        ///
+        /// If every eligible entry equals <paramref name="currentlyWatchedRecId"/>
+        /// (only possible when the rotation reduces to a single entry and that entry
+        /// is already the watched one), the result has
+        /// <see cref="GroupWatchAdvanceResult.IsToggleOff"/> = true and
+        /// <see cref="GroupWatchAdvanceResult.NextRecordingId"/> set to the watched
+        /// id, so the caller can detect the identity and invoke ExitWatchMode.
+        /// </summary>
+        internal static GroupWatchAdvanceResult AdvanceGroupWatchCursor(
+            HashSet<int> descendants,
+            IReadOnlyList<Recording> committed,
+            Func<int, bool> isEligible,
+            string cursorRecordingId,
+            string currentlyWatchedRecId)
+        {
+            if (descendants == null || committed == null || isEligible == null || descendants.Count == 0)
+                return GroupWatchAdvanceResult.Empty;
+
+            // 1. Build eligible list.
+            var eligibleIdx = new List<int>(descendants.Count);
+            var eligibleRec = new List<Recording>(descendants.Count);
+            foreach (int idx in descendants)
+            {
+                if (idx < 0 || idx >= committed.Count) continue;
+                var rec = committed[idx];
+                if (rec == null) continue;
+                if (string.IsNullOrEmpty(rec.RecordingId)) continue;
+                if (!isEligible(idx)) continue;
+                eligibleIdx.Add(idx);
+                eligibleRec.Add(rec);
+            }
+
+            if (eligibleRec.Count == 0)
+                return GroupWatchAdvanceResult.Empty;
+
+            // 2. Stable sort: StartUT asc, then RecordingId ordinal asc.
+            // Sort paired lists by building an index permutation.
+            int count = eligibleRec.Count;
+            var order = new int[count];
+            for (int i = 0; i < count; i++) order[i] = i;
+            Array.Sort(order, (a, b) =>
+            {
+                int c = eligibleRec[a].StartUT.CompareTo(eligibleRec[b].StartUT);
+                return c != 0 ? c : string.CompareOrdinal(eligibleRec[a].RecordingId, eligibleRec[b].RecordingId);
+            });
+            var sortedRec = new Recording[count];
+            for (int i = 0; i < count; i++)
+                sortedRec[i] = eligibleRec[order[i]];
+
+            // 3. Locate cursor by RecordingId. -1 means "before-first".
+            int cursorPos = -1;
+            if (!string.IsNullOrEmpty(cursorRecordingId))
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    if (sortedRec[i].RecordingId == cursorRecordingId)
+                    {
+                        cursorPos = i;
+                        break;
+                    }
+                }
+            }
+
+            // 4. Walk forward, wrapping, skipping the currently-watched id.
+            for (int step = 1; step <= count; step++)
+            {
+                int probe = ((cursorPos + step) % count + count) % count;
+                var candidate = sortedRec[probe];
+                if (candidate.RecordingId != currentlyWatchedRecId)
+                {
+                    // stepping wrapped past end: probe index is at or before cursorPos.
+                    bool wrap = cursorPos >= 0 && probe <= cursorPos;
+                    return new GroupWatchAdvanceResult(candidate.RecordingId, probe + 1, count, toggleOff: false, wrap: wrap);
+                }
+            }
+
+            // 5. All eligible entries equal currentlyWatchedRecId → single-entry rotation
+            //    that IS watched. Return the watched id with IsToggleOff = true.
+            //    Because step 1's filter rejects rows with null/empty RecordingId, every
+            //    candidate.RecordingId in the loop is a non-null string. If
+            //    currentlyWatchedRecId is null, every iteration's inequality check is true
+            //    and the loop returns on the first probe. So this trailing return only
+            //    fires when currentlyWatchedRecId is a non-null string equal to every
+            //    eligible entry — guaranteed-safe toggle-off.
+            return new GroupWatchAdvanceResult(currentlyWatchedRecId, 1, count, toggleOff: true, wrap: false);
+        }
+
+        internal static int FindRecordingIndexById(
             IReadOnlyList<Recording> committed,
             string recordingId)
         {

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -3805,9 +3805,9 @@ namespace Parsek
             if (descendants == null || committed == null || isEligible == null || descendants.Count == 0)
                 return GroupWatchAdvanceResult.Empty;
 
-            // 1. Build eligible list.
-            var eligibleIdx = new List<int>(descendants.Count);
-            var eligibleRec = new List<Recording>(descendants.Count);
+            // 1. Build eligible list. Only Recording refs are needed from here on;
+            // the UI re-resolves index by RecordingId after the call.
+            var eligible = new List<Recording>(descendants.Count);
             foreach (int idx in descendants)
             {
                 if (idx < 0 || idx >= committed.Count) continue;
@@ -3815,26 +3815,19 @@ namespace Parsek
                 if (rec == null) continue;
                 if (string.IsNullOrEmpty(rec.RecordingId)) continue;
                 if (!isEligible(idx)) continue;
-                eligibleIdx.Add(idx);
-                eligibleRec.Add(rec);
+                eligible.Add(rec);
             }
 
-            if (eligibleRec.Count == 0)
+            if (eligible.Count == 0)
                 return GroupWatchAdvanceResult.Empty;
 
             // 2. Stable sort: StartUT asc, then RecordingId ordinal asc.
-            // Sort paired lists by building an index permutation.
-            int count = eligibleRec.Count;
-            var order = new int[count];
-            for (int i = 0; i < count; i++) order[i] = i;
-            Array.Sort(order, (a, b) =>
+            eligible.Sort((a, b) =>
             {
-                int c = eligibleRec[a].StartUT.CompareTo(eligibleRec[b].StartUT);
-                return c != 0 ? c : string.CompareOrdinal(eligibleRec[a].RecordingId, eligibleRec[b].RecordingId);
+                int c = a.StartUT.CompareTo(b.StartUT);
+                return c != 0 ? c : string.CompareOrdinal(a.RecordingId, b.RecordingId);
             });
-            var sortedRec = new Recording[count];
-            for (int i = 0; i < count; i++)
-                sortedRec[i] = eligibleRec[order[i]];
+            int count = eligible.Count;
 
             // 3. Locate cursor by RecordingId. -1 means "before-first".
             int cursorPos = -1;
@@ -3842,7 +3835,7 @@ namespace Parsek
             {
                 for (int i = 0; i < count; i++)
                 {
-                    if (sortedRec[i].RecordingId == cursorRecordingId)
+                    if (eligible[i].RecordingId == cursorRecordingId)
                     {
                         cursorPos = i;
                         break;
@@ -3853,8 +3846,12 @@ namespace Parsek
             // 4. Walk forward, wrapping, skipping the currently-watched id.
             for (int step = 1; step <= count; step++)
             {
+                // (((cursorPos + step) % count) + count) % count handles the
+                // cursorPos=-1 "before-first" sentinel: with step=1 the first
+                // probe is 0 (first eligible entry). The double-mod is
+                // defensive against any future negative inputs.
                 int probe = ((cursorPos + step) % count + count) % count;
-                var candidate = sortedRec[probe];
+                var candidate = eligible[probe];
                 if (candidate.RecordingId != currentlyWatchedRecId)
                 {
                     // stepping wrapped past end: probe index is at or before cursorPos.

--- a/Source/Parsek/UI/RecordingsTableUI.cs
+++ b/Source/Parsek/UI/RecordingsTableUI.cs
@@ -143,6 +143,12 @@ namespace Parsek
         private Dictionary<string, bool> lastCanWatchByGroup = new Dictionary<string, bool>();
         private Dictionary<string, string> lastResolvedWatchTargetByGroup = new Dictionary<string, string>();
 
+        // Bug #382: transient per-group rotation cursor. Group name → RecordingId most
+        // recently entered via the group W button. Cleared when the stored RecordingId
+        // no longer exists in committed (via PruneStaleWatchEntries). Not serialized;
+        // resets naturally when the player opens a different save.
+        private Dictionary<string, string> groupWatchCursorByGroupName = new Dictionary<string, string>();
+
         // Cached styles for status labels
         private GUIStyle statusStyleFuture;
         private GUIStyle statusStyleActive;
@@ -366,6 +372,7 @@ namespace Parsek
                 lastCanWatchByRecId,
                 lastCanWatchByGroup,
                 lastResolvedWatchTargetByGroup,
+                groupWatchCursorByGroupName,
                 committed);
         }
 
@@ -387,6 +394,7 @@ namespace Parsek
                 lastCanWatchByRecId,
                 lastCanWatchByGroup,
                 null,
+                null,
                 committed);
         }
 
@@ -396,11 +404,27 @@ namespace Parsek
             Dictionary<string, string> lastResolvedWatchTargetByGroup,
             IReadOnlyList<Recording> committed)
         {
+            PruneStaleWatchEntries(
+                lastCanWatchByRecId,
+                lastCanWatchByGroup,
+                lastResolvedWatchTargetByGroup,
+                null,
+                committed);
+        }
+
+        internal static void PruneStaleWatchEntries(
+            Dictionary<string, bool> lastCanWatchByRecId,
+            Dictionary<string, bool> lastCanWatchByGroup,
+            Dictionary<string, string> lastResolvedWatchTargetByGroup,
+            Dictionary<string, string> groupWatchCursorByGroupName,
+            IReadOnlyList<Recording> committed)
+        {
             if (committed == null || committed.Count == 0)
             {
                 lastCanWatchByRecId?.Clear();
                 lastCanWatchByGroup?.Clear();
                 lastResolvedWatchTargetByGroup?.Clear();
+                groupWatchCursorByGroupName?.Clear();
                 return;
             }
 
@@ -452,6 +476,26 @@ namespace Parsek
                         lastCanWatchByGroup.Remove(stale[i]);
                         lastResolvedWatchTargetByGroup?.Remove(stale[i]);
                     }
+            }
+
+            // Bug #382: per-group rotation cursor. Keys are group names,
+            // values are RecordingIds. Drop entries whose RecordingId is
+            // no longer live — the rotation naturally falls back to the
+            // first eligible entry on the next press.
+            if (groupWatchCursorByGroupName != null && groupWatchCursorByGroupName.Count > 0)
+            {
+                List<string> stale = null;
+                foreach (var kv in groupWatchCursorByGroupName)
+                {
+                    if (string.IsNullOrEmpty(kv.Value) || !liveIds.Contains(kv.Value))
+                    {
+                        if (stale == null) stale = new List<string>();
+                        stale.Add(kv.Key);
+                    }
+                }
+                if (stale != null)
+                    for (int i = 0; i < stale.Count; i++)
+                        groupWatchCursorByGroupName.Remove(stale[i]);
             }
         }
 
@@ -1335,49 +1379,66 @@ namespace Parsek
             // Find the "main" (earliest non-debris) recording for group-level W and R/FF buttons
             int mainIdx = FindGroupMainRecordingIndex(descendants, committed);
 
-            // Watch button (flight only) — follows the group's current live continuation
+            // Watch button (flight only) — Bug #382: cycles through eligible
+            // descendants on repeated presses instead of toggling a single main.
             if (parentUI.InFlightMode)
             {
+                // Bug #382: build the rotation and let the W button cycle through
+                // eligible descendants. The helper is pure — we pass a closure
+                // capturing the live eligibility probes; cursorRecId comes from
+                // groupWatchCursorByGroupName (null on the first press or after prune).
+                Func<int, bool> isEligibleForWatch = idx =>
+                {
+                    if (idx < 0 || idx >= committed.Count) return false;
+                    var r = committed[idx];
+                    if (r == null || r.IsDebris) return false;
+                    if (!flight.HasActiveGhost(idx)) return false;
+                    if (!flight.IsGhostOnSameBody(idx)) return false;
+                    if (!flight.IsGhostWithinVisualRange(idx)) return false;
+                    return true;
+                };
+
+                // W* indicator: any descendant currently under watch → W*.
+                int watchedIdx = flight.WatchedRecordingIndex;
+                bool anyDescendantWatched =
+                    watchedIdx >= 0
+                    && descendants.Contains(watchedIdx)
+                    && watchedIdx < committed.Count
+                    && committed[watchedIdx] != null;
+                string watchedDescendantRecId = anyDescendantWatched ? committed[watchedIdx].RecordingId : null;
+
+                string cursorRecId;
+                groupWatchCursorByGroupName.TryGetValue(groupName, out cursorRecId);
+                GhostPlaybackLogic.GroupWatchAdvanceResult rotation = GhostPlaybackLogic.AdvanceGroupWatchCursor(
+                    descendants, committed, isEligibleForWatch, cursorRecId, watchedDescendantRecId);
+
+                int nextTargetIdx = rotation.NextRecordingId != null
+                    ? GhostPlaybackLogic.FindRecordingIndexById(committed, rotation.NextRecordingId)
+                    : -1;
+
+                // nextTargetIdx can legitimately be -1 even if rotation.NextRecordingId != null
+                // when the recording has been removed between draws — treat as empty rotation.
+                if (nextTargetIdx < 0)
+                    rotation = GhostPlaybackLogic.GroupWatchAdvanceResult.Empty;
+
+                bool canWatch = rotation.NextRecordingId != null && nextTargetIdx >= 0 && !rotation.IsToggleOff;
+                bool isToggleOffPress = rotation.IsToggleOff && anyDescendantWatched;
+                bool isWatching = anyDescendantWatched;
+
+                // Bug #279 transition logging. Key by groupName + mainRecId (unchanged).
+                // To keep this log silent on cursor rotations (would otherwise spam
+                // once per press), log the eligibility-set fingerprint as
+                // resolvedTargetId instead of an individual target id — the set only
+                // changes when a vessel enters/leaves eligibility, not on cursor
+                // advance. Fingerprint is the sorted, comma-joined RecordingIds.
                 if (mainIdx >= 0)
                 {
-                    int resolvedWatchIdx = GhostPlaybackLogic.ResolveEffectiveWatchTargetIndex(
-                        mainIdx,
-                        committed,
-                        RecordingStore.CommittedTrees,
-                        flight.HasActiveGhost);
-                    bool hasGhost = resolvedWatchIdx >= 0 && flight.HasActiveGhost(resolvedWatchIdx);
-                    bool sameBody = hasGhost && flight.IsGhostOnSameBody(resolvedWatchIdx);
-                    bool inRange = hasGhost && flight.IsGhostWithinVisualRange(resolvedWatchIdx);
-                    bool isWatching = resolvedWatchIdx >= 0 && flight.WatchedRecordingIndex == resolvedWatchIdx;
-                    // No IsDebris check needed: FindGroupMainRecordingIndex
-                    // (RecordingsTableUI.cs:~2021) already excludes debris from
-                    // the candidate set, so mainIdx is never a debris row.
-                    bool canWatch = hasGhost && sameBody && inRange;
-
-                    // Bug #279: log enabled/disabled transitions for the group W
-                    // button at INFO level. Group key combines group name + the
-                    // RecordingId of the current main recording. RecordingId is
-                    // stable across rewind/truncate index reuse, so a group whose
-                    // main recording is replaced (e.g., truncate followed by a
-                    // new launch) doesn't carry over the previous main's cached
-                    // canWatch and emit a spurious transition.
-                    //
-                    // Skip the cache+log entirely if the main recording has a
-                    // null/empty RecordingId. Mirrors the per-row guard above.
-                    // Without this, the group dict would cache "{groupName}/",
-                    // log once, get pruned by PruneStaleWatchEntries on the
-                    // next draw (empty trailing recId → stale), and re-add on
-                    // the draw after that — a spam loop. RecordingId being
-                    // null/empty shouldn't happen in practice (all recordings
-                    // get a GUID at construction), but the defensive guard is
-                    // free and matches the per-row site for consistency.
                     string mainRecId = committed[mainIdx].RecordingId;
                     if (!string.IsNullOrEmpty(mainRecId))
                     {
                         string groupWatchKey = groupName + "/" + mainRecId;
-                        string resolvedTargetId = resolvedWatchIdx >= 0 && resolvedWatchIdx < committed.Count
-                            ? committed[resolvedWatchIdx].RecordingId
-                            : null;
+                        string resolvedTargetId = BuildEligibleSetFingerprint(
+                            descendants, committed, isEligibleForWatch);
                         bool prevGroupCanWatch;
                         string prevResolvedTargetId;
                         if (!lastCanWatchByGroup.TryGetValue(groupWatchKey, out prevGroupCanWatch)
@@ -1387,37 +1448,66 @@ namespace Parsek
                         {
                             lastCanWatchByGroup[groupWatchKey] = canWatch;
                             lastResolvedWatchTargetByGroup[groupWatchKey] = resolvedTargetId;
-                            string reason = GetWatchButtonReason(canWatch, hasGhost, sameBody, inRange, isDebris: false);
+                            string reason = GetWatchButtonReason(canWatch,
+                                hasGhost: nextTargetIdx >= 0,
+                                sameBody: nextTargetIdx >= 0,
+                                inRange: nextTargetIdx >= 0,
+                                isDebris: false);
                             ParsekLog.Info("UI",
                                 $"Group Watch button '{groupName}' source=#{mainIdx} \"{committed[mainIdx].VesselName}\" " +
-                                $"resolved={(resolvedWatchIdx >= 0 && resolvedWatchIdx < committed.Count ? "#" + resolvedWatchIdx + " \"" + committed[resolvedWatchIdx].VesselName + "\"" : "<none>")} {reason} " +
-                                $"(hasGhost={hasGhost} sameBody={sameBody} inRange={inRange}) " +
-                                $"{BuildWatchObservabilitySuffix(flight, mainIdx, resolvedWatchIdx)}");
+                                $"next={(nextTargetIdx >= 0 ? "#" + nextTargetIdx + " \"" + committed[nextTargetIdx].VesselName + "\"" : "<none>")} " +
+                                $"pos={rotation.Position}/{rotation.TotalEligible} eligibleSet=[{resolvedTargetId}] {reason} " +
+                                $"{BuildWatchObservabilitySuffix(flight, mainIdx, nextTargetIdx)}");
                         }
                     }
+                }
 
-                    GUI.enabled = canWatch;
-                    string watchLabel = isWatching ? "W*" : "W";
-                    string watchTooltip = GetWatchButtonTooltip(isWatching, hasGhost, sameBody, inRange, isDebris: false);
-                    if (GUILayout.Button(new GUIContent(watchLabel, watchTooltip), GUILayout.Width(ColW_Watch)))
-                    {
-                        string beforeFocus = flight.DescribeWatchFocusForLogs();
-                        string beforeEligibility = BuildWatchObservabilitySuffix(flight, mainIdx, resolvedWatchIdx);
-                        if (isWatching)
-                            flight.ExitWatchMode();
-                        else
-                            flight.EnterWatchMode(resolvedWatchIdx);
-                        ParsekLog.Info("UI",
-                            $"Group '{groupName}' W button: {(isWatching ? "exit" : "enter")} watch on source #{mainIdx} " +
-                            $"resolved {(resolvedWatchIdx >= 0 && resolvedWatchIdx < committed.Count ? "#" + resolvedWatchIdx + " \"" + committed[resolvedWatchIdx].VesselName + "\"" : "<none>")} " +
-                            $"before={beforeEligibility} beforeFocus={beforeFocus} afterFocus={flight.DescribeWatchFocusForLogs()}");
-                    }
-                    GUI.enabled = true;
-                }
+                GUI.enabled = canWatch || isToggleOffPress;
+                string watchLabel = isWatching ? "W*" : "W";
+                string watchTooltip;
+                if (rotation.TotalEligible == 0)
+                    watchTooltip = "no watchable vessels in this group";
+                else if (isWatching && nextTargetIdx >= 0 && rotation.NextRecordingId != watchedDescendantRecId)
+                    watchTooltip = $"switch to {committed[nextTargetIdx].VesselName}";
+                else if (isWatching && rotation.IsToggleOff)
+                    watchTooltip = "exit watch (no other watchable vessels)";
+                else if (nextTargetIdx >= 0)
+                    watchTooltip = $"enter watch on {committed[nextTargetIdx].VesselName}";
                 else
+                    watchTooltip = GetWatchButtonTooltip(isWatching, false, false, false, false);
+
+                if (GUILayout.Button(new GUIContent(watchLabel, watchTooltip), GUILayout.Width(ColW_Watch)))
                 {
-                    GUILayout.Label("", GUILayout.Width(ColW_Watch));
+                    string beforeFocus = flight.DescribeWatchFocusForLogs();
+                    string beforeEligibility = BuildWatchObservabilitySuffix(flight, mainIdx, nextTargetIdx);
+                    string pressKind;
+                    if (isToggleOffPress)
+                    {
+                        flight.ExitWatchMode();
+                        groupWatchCursorByGroupName.Remove(groupName);
+                        pressKind = "toggle-off";
+                    }
+                    else if (nextTargetIdx >= 0)
+                    {
+                        flight.EnterWatchMode(nextTargetIdx);
+                        groupWatchCursorByGroupName[groupName] = rotation.NextRecordingId;
+                        pressKind = string.IsNullOrEmpty(cursorRecId)
+                            ? "enter"
+                            : (rotation.IsWrap ? "wrap" : "advance");
+                    }
+                    else
+                    {
+                        // Button is disabled when nextTargetIdx<0 and !isToggleOffPress, so this branch is unreachable.
+                        pressKind = "no-op";
+                    }
+                    ParsekLog.Info("UI",
+                        $"Group '{groupName}' W button: {pressKind} " +
+                        $"next={(nextTargetIdx >= 0 ? "#" + nextTargetIdx + " \"" + committed[nextTargetIdx].VesselName + "\"" : "<none>")} " +
+                        $"pos={rotation.Position}/{rotation.TotalEligible} " +
+                        $"cursorBefore={cursorRecId ?? "<null>"} " +
+                        $"before={beforeEligibility} beforeFocus={beforeFocus} afterFocus={flight.DescribeWatchFocusForLogs()}");
                 }
+                GUI.enabled = true;
             }
 
             // Rewind / Fast-forward button — targets main recording
@@ -2493,6 +2583,31 @@ namespace Parsek
                 if (dur > 0) total += dur;
             }
             return total;
+        }
+
+        /// <summary>
+        /// Bug #382: builds a stable fingerprint of the eligible descendant set
+        /// for the group W button transition log. The fingerprint is the sorted,
+        /// comma-joined RecordingIds of eligible descendants, so the bug #279
+        /// transition log only fires when the eligibility set itself changes
+        /// (vessel comes into range, goes out of range, etc.) — cursor advances
+        /// within a steady set do not retrigger the log.
+        /// </summary>
+        private static string BuildEligibleSetFingerprint(
+            HashSet<int> descendants, IReadOnlyList<Recording> committed, Func<int, bool> isEligible)
+        {
+            if (descendants == null || committed == null || isEligible == null) return string.Empty;
+            var ids = new List<string>(descendants.Count);
+            foreach (int idx in descendants)
+            {
+                if (idx < 0 || idx >= committed.Count) continue;
+                var r = committed[idx];
+                if (r == null || string.IsNullOrEmpty(r.RecordingId)) continue;
+                if (!isEligible(idx)) continue;
+                ids.Add(r.RecordingId);
+            }
+            ids.Sort(StringComparer.Ordinal);
+            return string.Join(",", ids);
         }
 
         /// <summary>

--- a/Source/Parsek/UI/RecordingsTableUI.cs
+++ b/Source/Parsek/UI/RecordingsTableUI.cs
@@ -1497,7 +1497,14 @@ namespace Parsek
                     }
                     else
                     {
-                        // Button is disabled when nextTargetIdx<0 and !isToggleOffPress, so this branch is unreachable.
+                        // Unreachable: GUI.enabled is canWatch || isToggleOffPress,
+                        // and canWatch==true implies nextTargetIdx>=0. If this branch
+                        // ever fires, the enable-gate has drifted — log a warning so
+                        // the regression surfaces instead of silently no-opping.
+                        ParsekLog.Warn("UI",
+                            $"Group '{groupName}' W button press reached unreachable branch " +
+                            $"(canWatch={canWatch} isToggleOffPress={isToggleOffPress} nextTargetIdx={nextTargetIdx}) — " +
+                            "enable-gate and press-dispatch are out of sync");
                         pressKind = "no-op";
                     }
                     ParsekLog.Info("UI",

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -936,7 +936,7 @@ Start with option 1. Add the field to the engine FX info payload (`GhostTypes.cs
 
 ---
 
-## 382. Group "W" button should cycle to the next watchable vessel on each press
+## ~~382. Group "W" button should cycle to the next watchable vessel on each press~~
 
 **Source:** maintenance request `2026-04-14`. Today the group `W` button only ever resolves to one target (the group's "main" recording), so repeated presses toggle watch on/off for that single vessel. The user wants a **watch-next** semantics instead.
 
@@ -979,7 +979,9 @@ Start with option 1. Dictionary keyed by group name → last-entered `RecordingI
 - Tests covering the new cursor advancement logic (empty eligible set, single-entry rotation, wrap, cursor-stale-recovery).
 - `CHANGELOG.md` under Unreleased: "Group `W` button now cycles to the next watchable vessel in the group on each press instead of always toggling the same target."
 
-**Status:** TODO. Size: S-M. No immediate blocker, but a high-visibility UX improvement for groups with multiple simultaneous ghosts.
+**Status:** ~~Fixed~~. High-visibility UX improvement for groups with multiple simultaneous ghosts.
+
+**Fix:** Added `GhostPlaybackLogic.AdvanceGroupWatchCursor` (new pure-static helper + `GroupWatchAdvanceResult` struct) that returns the next watchable descendant in stable `(StartUT, RecordingId)` order, skipping the currently-watched target so repeat presses advance the rotation. `UI/RecordingsTableUI.cs` group W button now stores a transient per-group cursor (`groupWatchCursorByGroupName`, keyed by group name, valued by the last-entered RecordingId) and wires it to the helper. Single-eligible-and-watched groups toggle off cleanly; stale cursors fall back to the first eligible entry; an eligibility-set fingerprint replaces the per-target value in the bug `#279` transition log so cursor advances no longer spam the log. `PruneStaleWatchEntries` gained a fifth `groupWatchCursorByGroupName` overload and now drops cursor entries whose stored RecordingId has left the committed list (or clears the whole dict when the committed list is empty). Covered by new `GroupWatchCursorTests` (16 cases) and an extended `PruneStaleWatchEntries_StaleGroupCursorEntries_Removed` test.
 
 ---
 


### PR DESCRIPTION
## Summary

- Pressing `W` on a group now cycles to the next watchable descendant on each press instead of always toggling the same "main" target. Wraps at the end; single-eligible-and-watched groups still toggle off cleanly.
- New pure-static `GhostPlaybackLogic.AdvanceGroupWatchCursor` helper + `GroupWatchAdvanceResult` struct. Filters via caller predicate, skips the currently watched id so repeat presses advance, reports wrap and toggle-off state. Stable order: `(StartUT asc, RecordingId ordinal asc)`.
- Transient per-group cursor stored in `RecordingsTableUI.groupWatchCursorByGroupName` keyed by group name, valued by last-entered `RecordingId` (stable across rewind/truncate index reuse). Pruned by `PruneStaleWatchEntries` when the stored id leaves `committed`.
- Rewritten group W button block: `W*` lights whenever any descendant is watched; tooltip reflects the next action (`next target`, `switch to`, `exit watch`, `no watchable vessels in this group`); press handler logs `pressKind` with `pos=N/M` for observability.
- Bug #279 transition log now fingerprints the sorted eligible set instead of a single resolved target id, so cursor advances no longer spam it.
- `FindRecordingIndexById` promoted `private` to `internal` for UI reuse.

## Test plan

- [x] New `GroupWatchCursorTests` (16 cases): null/empty guards, null-RecordingId skip, single-eligible not-watched / is-watched (toggle-off), two-entry cursor null / advance / wrap, stale cursor, cursor-matches-watched skip, StartUT tie-break by ordinal RecordingId, out-of-range descendant skipped, stale (null) descendant no crash, three-entry full A->B->C->A cycle, null-currently-watched first press.
- [x] `RecordingsTableUITests.PruneStaleWatchEntries_StaleGroupCursorEntries_Removed` + `_EmptyCommitted_ClearsGroupCursor`.
- [x] Existing source-inspection tests updated to pin the new contract (`AdvanceGroupWatchCursor`, `groupWatchCursorByGroupName`, `BuildWatchObservabilitySuffix(flight, mainIdx, nextTargetIdx)`).
- [x] Full suite: 6220 pass, 0 fail, 1 pre-existing skip (`SpawnGhost_PrimesFreshGhostToCurrentPlaybackUT`, unrelated).
- [ ] In-game smoke test with a group of 3 synthetic ghosts (pad walker + hopper + flea): press W repeatedly, confirm cycles through all three and wraps, confirm tooltip updates, confirm `W*` stays lit.
- [ ] In-game: toggle-off test — group with a single watchable ghost, press W, confirm camera follows; press W again, confirm clean exit; press W a third time, confirm re-entry.

Closes #382.