### PR TITLE
Fix #362: route terminal-crash decouple fragments through PID-keyed classifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- `#362` Terminal crash-end decouple fragments (parachutes, heat shields, late shrapnel) now become proper debris branches at the very end of a recording instead of being silently dropped when the parent vessel is already in its destruction frame.
 - `#370` Hardened the group Watch button log lines against a latent `IndexOutOfRangeException` if `ResolveEffectiveWatchTargetIndex` ever returns `-1` while the click reaches the handler.
 - `#373` Landed ghost clearance no longer silently regresses to the legacy 0.5 m floor when the distance-aware resolver cannot run — the fallback now emits a rate-limited warning naming the ghost, recording, and reason so the cold-start / scene-transition path is visible in the log.
 - `#380` `scripts/release.py` now runs end-to-end and packages the release zip without aborting on a pre-existing unit-test failure.

--- a/Source/Parsek.Tests/Bug362TerminalCrashDebrisTests.cs
+++ b/Source/Parsek.Tests/Bug362TerminalCrashDebrisTests.cs
@@ -1,0 +1,320 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Tests for bug #362: terminal crash-end decouple fragments can still collapse
+    /// to <see cref="JointBreakResult.WithinSegment"/> and skip a final debris branch.
+    ///
+    /// At terminal crash time, KSP has already destroyed the fragment <c>GameObject</c>s
+    /// before <c>DeferredJointBreakCheck</c> runs. Unity's overloaded <c>Object ==</c>
+    /// operator makes <c>v == null</c> true for every destroyed fragment, so the old
+    /// <c>List&lt;Vessel&gt;</c>-based filter dropped them all and the classifier saw
+    /// zero new vessels, returning <see cref="JointBreakResult.WithinSegment"/> and
+    /// silently losing the final debris branch.
+    ///
+    /// The fix iterates the PID-keyed <c>decoupleControllerStatus</c> dictionary instead.
+    /// Its keys are plain managed <c>uint</c>s that survive terminal destruction, so the
+    /// classifier sees the real fragment PIDs and correctly returns
+    /// <see cref="JointBreakResult.DebrisSplit"/>.
+    ///
+    /// These tests cover the pure PID-collection helper
+    /// <see cref="SegmentBoundaryLogic.CollectSynchronouslyCapturedNewVesselPids"/> and
+    /// its interaction with <see cref="SegmentBoundaryLogic.ClassifyJointBreakResult"/>.
+    /// The <c>ParsekFlight</c> coroutine integration requires Unity runtime and is out
+    /// of scope for unit tests.
+    /// </summary>
+    [Collection("Sequential")]
+    public class Bug362TerminalCrashDebrisTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public Bug362TerminalCrashDebrisTests()
+        {
+            RecordingStore.SuppressLogging = true;
+            MilestoneStore.ResetForTesting();
+            GameStateStore.SuppressLogging = true;
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+            ParsekLog.VerboseOverrideForTesting = true;
+            RecordingStore.ResetForTesting();
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+            RecordingStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+            MilestoneStore.ResetForTesting();
+        }
+
+        [Fact]
+        public void CollectSynchronouslyCapturedNewVesselPids_TerminalDestroyedFragments_ProducesDebrisSplit()
+        {
+            // The #362 regression pin: two uncontrolled fragments captured synchronously
+            // during recording. Their live Vessel references are gone by the deferred
+            // check frame (terminal crash). The helper must still collect both PIDs
+            // from the PID-keyed dict so the classifier returns DebrisSplit.
+            const uint recordedPid = 123u;
+            var decoupleControllerStatus = new Dictionary<uint, bool>
+            {
+                { 456u, false },
+                { 789u, false }
+            };
+            var backgroundMap = new Dictionary<uint, string>();
+            var newVesselPids = new List<uint>();
+            var newVesselHasController = new Dictionary<uint, bool>();
+
+            SegmentBoundaryLogic.CollectSynchronouslyCapturedNewVesselPids(
+                recordedPid,
+                decoupleControllerStatus,
+                backgroundMap,
+                newVesselPids,
+                newVesselHasController,
+                out bool anyNewVesselHasController);
+
+            Assert.Equal(2, newVesselPids.Count);
+            Assert.Contains(456u, newVesselPids);
+            Assert.Contains(789u, newVesselPids);
+            Assert.False(anyNewVesselHasController);
+            Assert.False(newVesselHasController[456u]);
+            Assert.False(newVesselHasController[789u]);
+
+            var classification = SegmentBoundaryLogic.ClassifyJointBreakResult(
+                recordedPid, newVesselPids, anyNewVesselHasController);
+            Assert.Equal(JointBreakResult.DebrisSplit, classification);
+        }
+
+        [Fact]
+        public void CollectSynchronouslyCapturedNewVesselPids_FiltersRecordedPid()
+        {
+            // The recorded vessel PID must be skipped even if it appears in the dict
+            // (defensive — the synchronous capture path should not put it there, but
+            // the helper must be robust if something else ever does).
+            const uint recordedPid = 123u;
+            var decoupleControllerStatus = new Dictionary<uint, bool>
+            {
+                { recordedPid, true },
+                { 456u, false }
+            };
+            var newVesselPids = new List<uint>();
+            var newVesselHasController = new Dictionary<uint, bool>();
+
+            SegmentBoundaryLogic.CollectSynchronouslyCapturedNewVesselPids(
+                recordedPid,
+                decoupleControllerStatus,
+                backgroundMap: null,
+                newVesselPids,
+                newVesselHasController,
+                out bool anyNewVesselHasController);
+
+            Assert.Single(newVesselPids);
+            Assert.Contains(456u, newVesselPids);
+            Assert.DoesNotContain(recordedPid, newVesselPids);
+            Assert.False(anyNewVesselHasController);
+        }
+
+        [Fact]
+        public void CollectSynchronouslyCapturedNewVesselPids_FiltersBackgroundMapPids()
+        {
+            // PIDs already tracked in the tree's BackgroundMap must be skipped —
+            // they are already owned by some other recording in the same tree.
+            const uint recordedPid = 123u;
+            var decoupleControllerStatus = new Dictionary<uint, bool>
+            {
+                { 456u, false },
+                { 789u, false },
+                { 999u, true }
+            };
+            var backgroundMap = new Dictionary<uint, string>
+            {
+                { 789u, "bg-recording-id" }
+            };
+            var newVesselPids = new List<uint>();
+            var newVesselHasController = new Dictionary<uint, bool>();
+
+            SegmentBoundaryLogic.CollectSynchronouslyCapturedNewVesselPids(
+                recordedPid,
+                decoupleControllerStatus,
+                backgroundMap,
+                newVesselPids,
+                newVesselHasController,
+                out bool anyNewVesselHasController);
+
+            Assert.Equal(2, newVesselPids.Count);
+            Assert.Contains(456u, newVesselPids);
+            Assert.Contains(999u, newVesselPids);
+            Assert.DoesNotContain(789u, newVesselPids);
+            Assert.True(anyNewVesselHasController);
+        }
+
+        [Fact]
+        public void CollectSynchronouslyCapturedNewVesselPids_DedupesExistingNewVesselPids()
+        {
+            // If a PID was already added (e.g., by a previous call or a different
+            // capture path), it must not be duplicated in newVesselPids, and
+            // newVesselHasController must not be clobbered with stale data from
+            // the current dict iteration for the already-known PID.
+            const uint recordedPid = 123u;
+            var decoupleControllerStatus = new Dictionary<uint, bool>
+            {
+                { 2000u, false },
+                { 3000u, false }
+            };
+            var newVesselPids = new List<uint> { 2000u };
+            var newVesselHasController = new Dictionary<uint, bool> { { 2000u, true } };
+
+            SegmentBoundaryLogic.CollectSynchronouslyCapturedNewVesselPids(
+                recordedPid,
+                decoupleControllerStatus,
+                backgroundMap: null,
+                newVesselPids,
+                newVesselHasController,
+                out bool anyNewVesselHasController);
+
+            // 2000 stays as one entry; 3000 is added.
+            Assert.Equal(2, newVesselPids.Count);
+            Assert.Contains(2000u, newVesselPids);
+            Assert.Contains(3000u, newVesselPids);
+            // Existing 2000 entry is not overwritten (it was pre-populated true).
+            Assert.True(newVesselHasController[2000u]);
+            // 3000 is freshly added from the dict (false).
+            Assert.False(newVesselHasController[3000u]);
+            // Only 3000 was new, and it is uncontrolled, so anyNew flag stays false.
+            Assert.False(anyNewVesselHasController);
+        }
+
+        [Fact]
+        public void CollectSynchronouslyCapturedNewVesselPids_ControlledChild_SetsAnyController()
+        {
+            // One fragment has a controller (e.g., still-intact command pod).
+            // The helper must set anyNewVesselHasController and end-to-end
+            // classification must be StructuralSplit, not DebrisSplit.
+            const uint recordedPid = 123u;
+            var decoupleControllerStatus = new Dictionary<uint, bool>
+            {
+                { 456u, true }
+            };
+            var newVesselPids = new List<uint>();
+            var newVesselHasController = new Dictionary<uint, bool>();
+
+            SegmentBoundaryLogic.CollectSynchronouslyCapturedNewVesselPids(
+                recordedPid,
+                decoupleControllerStatus,
+                backgroundMap: null,
+                newVesselPids,
+                newVesselHasController,
+                out bool anyNewVesselHasController);
+
+            Assert.Single(newVesselPids);
+            Assert.Contains(456u, newVesselPids);
+            Assert.True(anyNewVesselHasController);
+            Assert.True(newVesselHasController[456u]);
+
+            var classification = SegmentBoundaryLogic.ClassifyJointBreakResult(
+                recordedPid, newVesselPids, anyNewVesselHasController);
+            Assert.Equal(JointBreakResult.StructuralSplit, classification);
+        }
+
+        [Fact]
+        public void CollectSynchronouslyCapturedNewVesselPids_EmptyInput_PreservesWithinSegmentClassification()
+        {
+            // An empty dict must not populate anything and must not set
+            // anyNewVesselHasController. The downstream classifier should then
+            // correctly return WithinSegment.
+            const uint recordedPid = 123u;
+            var decoupleControllerStatus = new Dictionary<uint, bool>();
+            var newVesselPids = new List<uint>();
+            var newVesselHasController = new Dictionary<uint, bool>();
+
+            SegmentBoundaryLogic.CollectSynchronouslyCapturedNewVesselPids(
+                recordedPid,
+                decoupleControllerStatus,
+                backgroundMap: null,
+                newVesselPids,
+                newVesselHasController,
+                out bool anyNewVesselHasController);
+
+            Assert.Empty(newVesselPids);
+            Assert.Empty(newVesselHasController);
+            Assert.False(anyNewVesselHasController);
+
+            var classification = SegmentBoundaryLogic.ClassifyJointBreakResult(
+                recordedPid, newVesselPids, anyNewVesselHasController);
+            Assert.Equal(JointBreakResult.WithinSegment, classification);
+        }
+
+        [Fact]
+        public void CollectSynchronouslyCapturedNewVesselPids_NullBackgroundMap_DoesNotThrow()
+        {
+            // A null backgroundMap parameter must be treated as "nothing to skip",
+            // not as a null-ref hazard. DeferredJointBreakCheck passes
+            // activeTree?.BackgroundMap, so activeTree == null is a real call shape.
+            const uint recordedPid = 123u;
+            var decoupleControllerStatus = new Dictionary<uint, bool>
+            {
+                { 456u, false },
+                { 789u, false }
+            };
+            var newVesselPids = new List<uint>();
+            var newVesselHasController = new Dictionary<uint, bool>();
+
+            SegmentBoundaryLogic.CollectSynchronouslyCapturedNewVesselPids(
+                recordedPid,
+                decoupleControllerStatus,
+                backgroundMap: null,
+                newVesselPids,
+                newVesselHasController,
+                out bool anyNewVesselHasController);
+
+            Assert.Equal(2, newVesselPids.Count);
+            Assert.Contains(456u, newVesselPids);
+            Assert.Contains(789u, newVesselPids);
+            Assert.False(anyNewVesselHasController);
+        }
+
+        [Fact]
+        public void Bug362_TerminalCrashFragments_DebrisSplitRegression()
+        {
+            // Integration mirror of the KSP.log evidence from
+            // logs/2026-04-14_1954_kerbal-x-f5f9-fix-verify:
+            //   - recordedPid 123  (synthetic "Kerbal X")
+            //   - fragment pid 456 (parachuteLarge, uncontrolled)
+            //   - fragment pid 789 (HeatShield2,   uncontrolled)
+            // Before the fix, decoupleCreatedVessels iteration dropped both entries
+            // because their destroyed GameObjects compared equal to null, giving
+            // newVesselPids.Count == 0 and the classifier returned WithinSegment.
+            // The PID-based helper must restore the correct DebrisSplit outcome.
+            const uint recordedPid = 123u;
+            var decoupleControllerStatus = new Dictionary<uint, bool>
+            {
+                { 456u, false }, // parachuteLarge
+                { 789u, false }  // HeatShield2
+            };
+            var backgroundMap = new Dictionary<uint, string>();
+            var newVesselPids = new List<uint>();
+            var newVesselHasController = new Dictionary<uint, bool>();
+
+            SegmentBoundaryLogic.CollectSynchronouslyCapturedNewVesselPids(
+                recordedPid,
+                decoupleControllerStatus,
+                backgroundMap,
+                newVesselPids,
+                newVesselHasController,
+                out bool anyNewVesselHasController);
+
+            Assert.Equal(2, newVesselPids.Count);
+            Assert.Contains(456u, newVesselPids);
+            Assert.Contains(789u, newVesselPids);
+            Assert.False(anyNewVesselHasController);
+
+            var classification = SegmentBoundaryLogic.ClassifyJointBreakResult(
+                recordedPid, newVesselPids, anyNewVesselHasController);
+            Assert.Equal(JointBreakResult.DebrisSplit, classification);
+        }
+    }
+}

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -2636,32 +2636,43 @@ namespace Parsek
                 bool anyNewVesselHasController = false;
 
                 // First, include vessels caught by onPartDeCoupleNewVesselComplete during recording.
-                // These may have been destroyed by KSP's debris cleanup before this scan,
-                // so we use the controller status captured at creation time (parts may be cleared).
-                if (decoupleCreatedVessels != null && decoupleCreatedVessels.Count > 0)
+                // Iterate the PID-keyed decoupleControllerStatus dict rather than the
+                // decoupleCreatedVessels List<Vessel>, because at terminal crash time
+                // KSP has already destroyed those GameObjects and Unity's overloaded ==
+                // makes every element compare equal to null — the old path filtered
+                // out every fragment and classified the event as WithinSegment (#362).
+                if (decoupleControllerStatus != null && decoupleControllerStatus.Count > 0)
                 {
                     ParsekLog.Info("Flight",
-                        $"DeferredJointBreakCheck: {decoupleCreatedVessels.Count} vessel(s) caught by onPartDeCouple");
+                        $"DeferredJointBreakCheck: {decoupleControllerStatus.Count} vessel(s) caught by onPartDeCouple");
 
-                    for (int i = 0; i < decoupleCreatedVessels.Count; i++)
+                    SegmentBoundaryLogic.CollectSynchronouslyCapturedNewVesselPids(
+                        recordedPid,
+                        decoupleControllerStatus,
+                        activeTree?.BackgroundMap,
+                        newVesselPids,
+                        newVesselHasController,
+                        out bool anyNewFromDecouple);
+
+                    if (anyNewFromDecouple)
+                        anyNewVesselHasController = true;
+
+                    // Log per-fragment when the live Vessel reference is gone — the fragment
+                    // was captured synchronously but terminal destruction already wiped the
+                    // GameObject. Classification continues on PID-only data for #362.
+                    foreach (var kvp in decoupleControllerStatus)
                     {
-                        Vessel v = decoupleCreatedVessels[i];
-                        if (v == null || v.persistentId == recordedPid) continue;
-
-                        if (activeTree != null && activeTree.BackgroundMap.ContainsKey(v.persistentId))
+                        uint pid = kvp.Key;
+                        if (pid == recordedPid) continue;
+                        if (activeTree != null && activeTree.BackgroundMap.ContainsKey(pid))
                             continue;
 
-                        if (!newVesselPids.Contains(v.persistentId))
+                        Vessel live = FlightRecorder.FindVesselByPid(pid);
+                        if (live == null)
                         {
-                            newVesselPids.Add(v.persistentId);
-
-                            // Use pre-captured controller status (vessel parts may be gone now)
-                            bool hasController = decoupleControllerStatus != null
-                                && decoupleControllerStatus.ContainsKey(v.persistentId)
-                                && decoupleControllerStatus[v.persistentId];
-                            newVesselHasController[v.persistentId] = hasController;
-                            if (hasController)
-                                anyNewVesselHasController = true;
+                            ParsekLog.Verbose("Flight",
+                                $"DeferredJointBreakCheck: pid={pid} captured synchronously but Vessel reference " +
+                                $"is destroyed at deferred-check frame — using PID-only classification (#362)");
                         }
                     }
                 }

--- a/Source/Parsek/SegmentBoundaryLogic.cs
+++ b/Source/Parsek/SegmentBoundaryLogic.cs
@@ -129,6 +129,61 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Collects PIDs of new vessels that were captured synchronously by
+        /// <c>onPartDeCoupleNewVesselComplete</c> during recording, reading them from a
+        /// PID-keyed controller-status dictionary instead of from a <c>List&lt;Vessel&gt;</c>.
+        ///
+        /// Iterating the original <c>List&lt;Vessel&gt;</c> is unsafe at terminal crash time:
+        /// KSP has already destroyed the fragment <c>GameObject</c>s, so Unity's overloaded
+        /// <c>UnityEngine.Object ==</c> returns <c>true</c> when compared against <c>null</c>
+        /// for every fragment, the filter drops them all, and the classifier collapses to
+        /// <see cref="JointBreakResult.WithinSegment"/> with zero new vessels. See bug #362.
+        ///
+        /// The PID-keyed dictionary's keys are plain managed <c>uint</c>s, so it survives
+        /// terminal destruction and gives us an authoritative list of the synchronously
+        /// captured fragments to feed into <see cref="ClassifyJointBreakResult"/>.
+        ///
+        /// This helper is pure — it does not call into Unity, KSP, or <c>ParsekLog</c>.
+        /// </summary>
+        /// <param name="recordedPid">PersistentId of the vessel being recorded (skipped if present).</param>
+        /// <param name="decoupleControllerStatus">PID-keyed controller-status dict captured synchronously during recording.</param>
+        /// <param name="backgroundMap">Optional background-map of tree-tracked PIDs to skip; may be null.</param>
+        /// <param name="newVesselPids">In/out list: PIDs collected by this helper are appended to it (dedup against existing entries).</param>
+        /// <param name="newVesselHasController">In/out dict: controller status is written for each collected PID.</param>
+        /// <param name="anyNewVesselHasController">Output flag: true if any newly collected PID has a controller.</param>
+        internal static void CollectSynchronouslyCapturedNewVesselPids(
+            uint recordedPid,
+            IReadOnlyDictionary<uint, bool> decoupleControllerStatus,
+            IReadOnlyDictionary<uint, string> backgroundMap,
+            List<uint> newVesselPids,
+            Dictionary<uint, bool> newVesselHasController,
+            out bool anyNewVesselHasController)
+        {
+            anyNewVesselHasController = false;
+
+            if (decoupleControllerStatus == null || decoupleControllerStatus.Count == 0)
+                return;
+            if (newVesselPids == null || newVesselHasController == null)
+                return;
+
+            foreach (var kvp in decoupleControllerStatus)
+            {
+                uint pid = kvp.Key;
+
+                if (pid == recordedPid) continue;
+                if (backgroundMap != null && backgroundMap.ContainsKey(pid)) continue;
+                if (newVesselPids.Contains(pid)) continue;
+
+                newVesselPids.Add(pid);
+
+                bool hasController = kvp.Value;
+                newVesselHasController[pid] = hasController;
+                if (hasController)
+                    anyNewVesselHasController = true;
+            }
+        }
+
+        /// <summary>
         /// Checks whether a part provides command authority (has ModuleCommand).
         /// ModuleCommand is the KSP module for command pods and probe cores.
         /// </summary>

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1357,7 +1357,7 @@ The reverse-order rollback path (`RestoreCommittedSidecarChange` and friends) do
 
 ---
 
-## 362. Terminal crash-end decouple fragments can still collapse to `WithinSegment` and skip a final debris branch
+## ~~362. Terminal crash-end decouple fragments can still collapse to `WithinSegment` and skip a final debris branch~~
 
 **Observed in:** `logs/2026-04-14_1954_kerbal-x-f5f9-fix-verify` (2026-04-14) while re-validating the `Kerbal X` mid-flight `F5/F9` fix. Near the very end of the resumed run, the active vessel was already being destroyed but `onPartDeCouple` still reported two late fragments (`parachuteLarge`, `HeatShield2`). The deferred split pass then classified that event as `WithinSegment newVessels=0` instead of creating one more debris branch.
 
@@ -1376,7 +1376,9 @@ The reverse-order rollback path (`RestoreCommittedSidecarChange` and friends) do
 
 **Desired policy:** decide explicitly whether terminal crash-end transient fragments should ever become recorded debris branches. If yes, the deferred split path likely needs a terminal-safe capture rule for those last fragments. If no, this should stay documented as intentional and non-blocking.
 
-**Status:** TODO for future check; not blocking the `Kerbal X` `F5/F9` fix in PR `#290`
+**Fix:** `DeferredJointBreakCheck` no longer iterates `decoupleCreatedVessels` (a `List<Vessel>`) when collecting new-vessel PIDs from the synchronous `onPartDeCoupleNewVesselComplete` capture. At terminal crash time, KSP has already destroyed the fragment `GameObject`s, so Unity's overloaded `UnityEngine.Object ==` makes `v == null` true for every fragment and the filter drops them all, leaving `newVesselPids.Count == 0` and collapsing the classification to `WithinSegment`. The deferred check now iterates the PID-keyed `decoupleControllerStatus` dictionary (which is populated in the same synchronous callback and survives terminal destruction because its keys are plain managed `uint`s), routing the fragments through `SegmentBoundaryLogic.ClassifyJointBreakResult` as a real `DebrisSplit`. The rest of the pipeline is already null-safe for destroyed debris: `FindVesselByPid` returns null, `preSnapshot` stays null, `preTrajectoryPoint` falls back to the synchronously-captured `decoupleCreatedTrajectoryPoints[pid]`, and `CreateBreakupChildRecording`'s destroyed-vessel branch produces a `TerminalState.Destroyed` debris leaf stamped at the split UT. Extracted the PID-collection filter to `SegmentBoundaryLogic.CollectSynchronouslyCapturedNewVesselPids` with unit coverage in `Bug362TerminalCrashDebrisTests`. Also added a per-fragment Verbose log so future terminal-crash repros show the PID-only classification breadcrumb in KSP.log.
+
+**Status:** ~~Fixed~~
 
 ---
 


### PR DESCRIPTION
## Summary

- Fixes #362: terminal crash-end decouple fragments (parachutes, heat shields, late shrapnel) were being silently dropped when the parent vessel was already in its destruction frame, because `DeferredJointBreakCheck` iterated a `List<Vessel>` whose entries returned `v == null` under Unity's overloaded `==` once the fragment `GameObject`s were destroyed. The deferred classifier now iterates the PID-keyed `decoupleControllerStatus` dictionary (captured synchronously in the same `onPartDeCoupleNewVesselComplete` callback), so managed `uint` keys survive terminal destruction and the fragments are correctly classified as `DebrisSplit`.
- Extracted the PID-collection filter to a new pure `SegmentBoundaryLogic.CollectSynchronouslyCapturedNewVesselPids` helper with 8 unit tests in `Bug362TerminalCrashDebrisTests`, including an end-to-end classification regression pin.
- Added a per-fragment Verbose log so future terminal-crash repros show the PID-only classification breadcrumb in KSP.log. Downstream pipeline (`FindVesselByPid` → null → `preSnapshot=null` → `preTrajectoryPoint` fallback → `CreateBreakupChildRecording` destroyed branch → `TerminalState.Destroyed` debris leaf) was already null-safe — no downstream changes required.

## Test plan

- [x] `dotnet build` clean
- [x] `dotnet test --filter Bug362` — 8/8 pass
- [x] Full suite — 6210 pass / 0 fail / 1 pre-existing Unity skip
- [ ] Runtime validation: reproduce the terminal-crash scenario from `logs/2026-04-14_1954_kerbal-x-f5f9-fix-verify` and confirm late `parachuteLarge` / `HeatShield2` fragments now become a proper final debris branch instead of `WithinSegment newVessels=0`