### PR TITLE
Fix #406: skip reentry FX build for non-reentry trajectories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- `#406` Map-view framerate with many looping showcase ghosts no longer collapses — stationary and slow recordings skip the reentry FX build that was being thrown away and rebuilt on every loop-cycle boundary.
 - `#362` Terminal crash-end decouple fragments (parachutes, heat shields, late shrapnel) now become proper debris branches at the very end of a recording instead of being silently dropped when the parent vessel is already in its destruction frame.
 - `#370` Hardened the group Watch button log lines against a latent `IndexOutOfRangeException` if `ResolveEffectiveWatchTargetIndex` ever returns `-1` while the click reaches the handler.
 - `#373` Landed ghost clearance no longer silently regresses to the legacy 0.5 m floor when the distance-aware resolver cannot run — the fallback now emits a rate-limited warning naming the ghost, recording, and reason so the cold-start / scene-transition path is visible in the log.

--- a/Source/Parsek.Tests/ReentryPotentialTests.cs
+++ b/Source/Parsek.Tests/ReentryPotentialTests.cs
@@ -204,5 +204,52 @@ namespace Parsek.Tests
             // guaranteeing no false negatives on reentry heating.
             Assert.Equal(400f, TrajectoryMath.ReentryPotentialSpeedFloor);
         }
+
+        [Fact]
+        public void NanVelocityComponent_DoesNotThrow_ReturnsFalse()
+        {
+            // Malformed point with a NaN component — sqrMagnitude yields NaN and
+            // `NaN >= floorSq` is false, so the gate conservatively returns false
+            // without crashing. Protects against any upstream bug that leaks a
+            // degenerate velocity vector into the trajectory.
+            var traj = new MockTrajectory();
+            traj.Points.Add(new TrajectoryPoint
+            {
+                ut = 0, bodyName = "Kerbin",
+                velocity = new Vector3(float.NaN, 0f, 0f),
+                rotation = Quaternion.identity
+            });
+            bool result = false;
+            var ex = Record.Exception(() => result = TrajectoryMath.HasReentryPotential(traj));
+            Assert.Null(ex);
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void InfinityVelocityComponent_ReturnsTrue()
+        {
+            // Infinity passes the floor comparison (Infinity >= floorSq), so the gate
+            // plays it safe and builds reentry FX. Again, this is not expected in
+            // production — the test just locks in the behavior so a later refactor
+            // that adds input sanitization is a conscious choice, not an accident.
+            var traj = new MockTrajectory();
+            traj.Points.Add(new TrajectoryPoint
+            {
+                ut = 0, bodyName = "Kerbin",
+                velocity = new Vector3(float.PositiveInfinity, 0f, 0f),
+                rotation = Quaternion.identity
+            });
+            Assert.True(TrajectoryMath.HasReentryPotential(traj));
+        }
+
+        [Fact]
+        public void NullPointsList_ReturnsFalse()
+        {
+            // IPlaybackTrajectory.Points is not nominally null, but the helper
+            // defensively handles it (we have no ProtoVessel-sourced trajectories
+            // that might return null today, but the guard is cheap insurance).
+            var traj = new MockTrajectory { Points = null };
+            Assert.False(TrajectoryMath.HasReentryPotential(traj));
+        }
     }
 }

--- a/Source/Parsek.Tests/ReentryPotentialTests.cs
+++ b/Source/Parsek.Tests/ReentryPotentialTests.cs
@@ -1,0 +1,208 @@
+using System.Collections.Generic;
+using UnityEngine;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Tests for <see cref="TrajectoryMath.HasReentryPotential"/>. This gate skips the
+    /// expensive reentry FX build (mesh combine, ParticleSystem, glow material clones)
+    /// for trajectories that cannot possibly produce reentry visuals — the dominant
+    /// cost in the #406 showcase-loop map-view perf tank.
+    /// </summary>
+    [Collection("Sequential")]
+    public class ReentryPotentialTests
+    {
+        private static List<string> CaptureLog()
+        {
+            var lines = new List<string>();
+            ParsekLog.TestSinkForTesting = line => lines.Add(line);
+            return lines;
+        }
+
+        public ReentryPotentialTests() { CaptureLog(); }
+        // xunit will create a fresh instance per test; Sequential collection prevents
+        // ParsekLog static state from racing across tests.
+
+        [Fact]
+        public void NullTrajectory_ReturnsFalse()
+        {
+            Assert.False(TrajectoryMath.HasReentryPotential(null));
+        }
+
+        [Fact]
+        public void EmptyTrajectory_NoOrbitSegments_ReturnsFalse()
+        {
+            var traj = new MockTrajectory();
+            Assert.False(TrajectoryMath.HasReentryPotential(traj));
+        }
+
+        [Fact]
+        public void StationaryShowcase_AllZeroVelocity_ReturnsFalse()
+        {
+            // Stationary KSC-surface part showcase — the canonical case the fix targets.
+            // Peak velocity is literally zero.
+            var traj = new MockTrajectory().WithTimeRange(0, 30);
+            Assert.False(TrajectoryMath.HasReentryPotential(traj));
+        }
+
+        [Fact]
+        public void EvaWalk_SlowVelocity_ReturnsFalse()
+        {
+            var traj = new MockTrajectory();
+            traj.Points.Add(new TrajectoryPoint
+            {
+                ut = 0, bodyName = "Kerbin",
+                velocity = new Vector3(3f, 0f, 0f),
+                rotation = Quaternion.identity
+            });
+            traj.Points.Add(new TrajectoryPoint
+            {
+                ut = 10, bodyName = "Kerbin",
+                velocity = new Vector3(5f, 0f, 0f),
+                rotation = Quaternion.identity
+            });
+            Assert.False(TrajectoryMath.HasReentryPotential(traj));
+        }
+
+        [Fact]
+        public void SlowFleaHop_UnderFloor_ReturnsFalse()
+        {
+            // Flea-class solid booster hop: max velocity ~200 m/s, no orbit segments.
+            // Well below Mach 1 anywhere — cannot produce reentry FX.
+            var traj = new MockTrajectory();
+            traj.Points.Add(new TrajectoryPoint
+            {
+                ut = 0, bodyName = "Kerbin",
+                velocity = new Vector3(0f, 0f, 0f),
+                rotation = Quaternion.identity
+            });
+            traj.Points.Add(new TrajectoryPoint
+            {
+                ut = 15, bodyName = "Kerbin",
+                velocity = new Vector3(0f, 200f, 0f),
+                rotation = Quaternion.identity
+            });
+            traj.Points.Add(new TrajectoryPoint
+            {
+                ut = 30, bodyName = "Kerbin",
+                velocity = new Vector3(0f, 120f, 0f),
+                rotation = Quaternion.identity
+            });
+            Assert.False(TrajectoryMath.HasReentryPotential(traj));
+        }
+
+        [Fact]
+        public void JustBelowFloor_399MetersPerSecond_ReturnsFalse()
+        {
+            var traj = new MockTrajectory();
+            traj.Points.Add(new TrajectoryPoint
+            {
+                ut = 0, bodyName = "Kerbin",
+                velocity = new Vector3(399f, 0f, 0f),
+                rotation = Quaternion.identity
+            });
+            Assert.False(TrajectoryMath.HasReentryPotential(traj));
+        }
+
+        [Fact]
+        public void AtFloor_400MetersPerSecond_ReturnsTrue()
+        {
+            var traj = new MockTrajectory();
+            traj.Points.Add(new TrajectoryPoint
+            {
+                ut = 0, bodyName = "Kerbin",
+                velocity = new Vector3(TrajectoryMath.ReentryPotentialSpeedFloor, 0f, 0f),
+                rotation = Quaternion.identity
+            });
+            Assert.True(TrajectoryMath.HasReentryPotential(traj));
+        }
+
+        [Fact]
+        public void SuborbitalAscent_FastPoint_ReturnsTrue()
+        {
+            var traj = new MockTrajectory();
+            // Mostly slow points, one high-speed sample — should still flag the recording.
+            traj.Points.Add(new TrajectoryPoint
+            {
+                ut = 0, bodyName = "Kerbin",
+                velocity = Vector3.zero, rotation = Quaternion.identity
+            });
+            traj.Points.Add(new TrajectoryPoint
+            {
+                ut = 30, bodyName = "Kerbin",
+                velocity = new Vector3(0f, 800f, 0f),
+                rotation = Quaternion.identity
+            });
+            traj.Points.Add(new TrajectoryPoint
+            {
+                ut = 60, bodyName = "Kerbin",
+                velocity = new Vector3(0f, 50f, 0f),
+                rotation = Quaternion.identity
+            });
+            Assert.True(TrajectoryMath.HasReentryPotential(traj));
+        }
+
+        [Fact]
+        public void DiagonalVelocity_MagnitudeAboveFloor_ReturnsTrue()
+        {
+            // 300/300/300 has magnitude ~520 m/s — tests that we use magnitude,
+            // not any single axis component.
+            var traj = new MockTrajectory();
+            traj.Points.Add(new TrajectoryPoint
+            {
+                ut = 0, bodyName = "Kerbin",
+                velocity = new Vector3(300f, 300f, 300f),
+                rotation = Quaternion.identity
+            });
+            Assert.True(TrajectoryMath.HasReentryPotential(traj));
+        }
+
+        [Fact]
+        public void OrbitSegmentsPresent_AlwaysReturnsTrue()
+        {
+            // Orbital ghost with no high-speed point samples — e.g., a recording that
+            // only captured points during a slow rendezvous phase but has an orbit
+            // segment covering the faster parts. Must still build FX because de-orbit
+            // heat happens at orbital speed (~2300 m/s).
+            var traj = new MockTrajectory();
+            traj.OrbitSegments.Add(new OrbitSegment
+            {
+                bodyName = "Kerbin",
+                semiMajorAxis = 700000,
+                eccentricity = 0.01,
+                startUT = 0, endUT = 3000
+            });
+            traj.Points.Add(new TrajectoryPoint
+            {
+                ut = 0, bodyName = "Kerbin",
+                velocity = new Vector3(5f, 0f, 0f),
+                rotation = Quaternion.identity
+            });
+            Assert.True(TrajectoryMath.HasReentryPotential(traj));
+        }
+
+        [Fact]
+        public void OrbitSegmentOnly_NoPoints_ReturnsTrue()
+        {
+            var traj = new MockTrajectory();
+            traj.OrbitSegments.Add(new OrbitSegment
+            {
+                bodyName = "Kerbin",
+                semiMajorAxis = 700000,
+                eccentricity = 0.01,
+                startUT = 0, endUT = 3000
+            });
+            Assert.True(TrajectoryMath.HasReentryPotential(traj));
+        }
+
+        [Fact]
+        public void SpeedFloor_SaneDefault()
+        {
+            // Lock the constant so accidental drift is caught. 400 m/s chosen because
+            // it is well below Mach 1.5 on every stock body with an atmosphere,
+            // guaranteeing no false negatives on reentry heating.
+            Assert.Equal(400f, TrajectoryMath.ReentryPotentialSpeedFloor);
+        }
+    }
+}

--- a/Source/Parsek/Diagnostics/DiagnosticsComputation.cs
+++ b/Source/Parsek/Diagnostics/DiagnosticsComputation.cs
@@ -488,14 +488,16 @@ namespace Parsek
                 hitRateStr = "N/A";
             }
             sb.AppendFormat(Inv,
-                "Health: cache {0} hit ({1} miss of {2} lookups), spikes {3}, spawn fail {4}, builds {5} destroys {6}",
+                "Health: cache {0} hit ({1} miss of {2} lookups), spikes {3}, spawn fail {4}, builds {5} destroys {6}, reentryFx built {7} skipped {8}",
                 hitRateStr,
                 h.waypointCacheMisses,
                 totalLookups,
                 h.snapshotRefreshSpikes,
                 h.spawnFailures,
                 h.ghostBuildsThisSession,
-                h.ghostDestroysThisSession);
+                h.ghostDestroysThisSession,
+                h.reentryFxBuildsThisSession,
+                h.reentryFxSkippedThisSession);
             sb.AppendLine();
 
             // GC gen0

--- a/Source/Parsek/Diagnostics/DiagnosticsStructs.cs
+++ b/Source/Parsek/Diagnostics/DiagnosticsStructs.cs
@@ -141,6 +141,8 @@ namespace Parsek
         public int spawnRetries;
         public int ghostBuildsThisSession;
         public int ghostDestroysThisSession;
+        public int reentryFxBuildsThisSession;
+        public int reentryFxSkippedThisSession;
         public int gcGen0Baseline;
 
         public void Reset()
@@ -152,6 +154,8 @@ namespace Parsek
             spawnRetries = 0;
             ghostBuildsThisSession = 0;
             ghostDestroysThisSession = 0;
+            reentryFxBuildsThisSession = 0;
+            reentryFxSkippedThisSession = 0;
             gcGen0Baseline = System.GC.CollectionCount(0);
         }
     }

--- a/Source/Parsek/GhostPlaybackEngine.cs
+++ b/Source/Parsek/GhostPlaybackEngine.cs
@@ -1946,8 +1946,26 @@ namespace Parsek
             GhostPlaybackLogic.InitializeInventoryPlacementVisibility(traj, state);
             GhostPlaybackLogic.RefreshCompoundPartVisibility(state);
 
-            state.reentryFxInfo = GhostVisualBuilder.TryBuildReentryFx(
-                ghost, state.heatInfos, index, traj.VesselName);
+            // Gate reentry FX build: stationary part-showcase ghosts, EVA walks, and slow
+            // suborbital hops below Mach 1.5 can never produce reentry visuals, so we skip
+            // the mesh-combine + ParticleSystem + glow-material clone work entirely. With
+            // hundreds of ghosts looping, rebuilding reentry FX on every loop-cycle
+            // boundary was the dominant cost in the map-view perf tank (#406).
+            if (TrajectoryMath.HasReentryPotential(traj))
+            {
+                state.reentryFxInfo = GhostVisualBuilder.TryBuildReentryFx(
+                    ghost, state.heatInfos, index, traj.VesselName);
+                DiagnosticsState.health.reentryFxBuildsThisSession++;
+            }
+            else
+            {
+                state.reentryFxInfo = null;
+                DiagnosticsState.health.reentryFxSkippedThisSession++;
+                ParsekLog.VerboseRateLimited("ReentryFx", $"skip-{index}",
+                    $"Skipped reentry FX build for ghost #{index} \"{traj.VesselName}\" " +
+                    $"— trajectory peak speed below {TrajectoryMath.ReentryPotentialSpeedFloor:F0} m/s " +
+                    $"and no orbit segments (cannot produce reentry visuals)", 5.0);
+            }
             state.reentryMpb = new MaterialPropertyBlock();
 
             // Keep fresh builds hidden until the playback loop has positioned them at the

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -7415,8 +7415,21 @@ namespace Parsek
                     GhostPlaybackLogic.InitializeInventoryPlacementVisibility(previewRecording, previewGhostState);
                     GhostPlaybackLogic.RefreshCompoundPartVisibility(previewGhostState);
 
-                    previewGhostState.reentryFxInfo = GhostVisualBuilder.TryBuildReentryFx(
-                        ghost, previewGhostState.heatInfos, -1, previewRecording.VesselName);
+                    // Same reentry-potential gate as the timeline engine path (#406):
+                    // skip the mesh-combine / ParticleSystem build for trajectories that
+                    // cannot possibly produce reentry visuals.
+                    if (TrajectoryMath.HasReentryPotential(previewRecording))
+                    {
+                        previewGhostState.reentryFxInfo = GhostVisualBuilder.TryBuildReentryFx(
+                            ghost, previewGhostState.heatInfos, -1, previewRecording.VesselName);
+                    }
+                    else
+                    {
+                        previewGhostState.reentryFxInfo = null;
+                        ParsekLog.Verbose("ReentryFx",
+                            $"Skipped reentry FX build for preview ghost \"{previewRecording.VesselName}\" " +
+                            $"— trajectory peak speed below {TrajectoryMath.ReentryPotentialSpeedFloor:F0} m/s and no orbit segments");
+                    }
 
                     // Initialize flag event index for preview playback
                     GhostPlaybackLogic.InitializeFlagVisibility(previewRecording, previewGhostState);

--- a/Source/Parsek/TrajectoryMath.cs
+++ b/Source/Parsek/TrajectoryMath.cs
@@ -964,6 +964,14 @@ namespace Parsek
         ///   - any recorded trajectory point has velocity magnitude at or above
         ///     <see cref="ReentryPotentialSpeedFloor"/>.
         ///
+        /// <b>Velocity frame:</b> <see cref="TrajectoryPoint.velocity"/> is the
+        /// Krakensbane-corrected `rb_velocityD + Krakensbane.GetFrameVelocity()` captured
+        /// at sample time. In KSP's body-co-rotating world frame this is effectively the
+        /// vessel's inertial speed, so a landed/stationary vessel reads ≈0 and the 400 m/s
+        /// floor safely excludes showcases, walks, rovers, and low-speed suborbital hops
+        /// while preserving every supersonic / orbital trajectory. NaN components in a
+        /// point fail the ≥ comparison harmlessly and do not throw.
+        ///
         /// Pure function — no Unity dependencies, no side effects. O(n) in trajectory
         /// point count; called once per ghost build, not per frame.
         /// </summary>
@@ -980,6 +988,8 @@ namespace Parsek
             float floorSq = ReentryPotentialSpeedFloor * ReentryPotentialSpeedFloor;
             for (int i = 0; i < points.Count; i++)
             {
+                // sqrMagnitude with a NaN component yields NaN; `NaN >= floorSq` is false,
+                // so malformed points cannot produce a false positive.
                 if (points[i].velocity.sqrMagnitude >= floorSq)
                     return true;
             }

--- a/Source/Parsek/TrajectoryMath.cs
+++ b/Source/Parsek/TrajectoryMath.cs
@@ -940,5 +940,50 @@ namespace Parsek
             var env = sections[idx].environment;
             return env == SegmentEnvironment.SurfaceMobile || env == SegmentEnvironment.SurfaceStationary;
         }
+
+        /// <summary>
+        /// Speed floor for reentry FX build. A trajectory whose peak recorded velocity
+        /// magnitude is below this threshold and that has no orbit segments cannot ever
+        /// produce reentry visuals — Mach 2.5 thermal FX requires ~675 m/s even in thin
+        /// atmosphere on Kerbin, and real reentry on Laythe/Duna/Eve is higher still.
+        /// 400 m/s is well under Mach 1.5 anywhere, giving a safe cutoff for stationary
+        /// part showcases, EVA walks, slow rovers, and low-speed suborbital hops.
+        /// </summary>
+        internal const float ReentryPotentialSpeedFloor = 400f;
+
+        /// <summary>
+        /// Returns true if the trajectory could plausibly produce reentry visuals during
+        /// playback. Used to gate the expensive per-spawn reentry FX build
+        /// (<see cref="GhostVisualBuilder.TryBuildReentryFx"/>), which combines all ghost
+        /// meshes, allocates a ParticleSystem, and clones glow materials — costs that
+        /// multiply across every loop-cycle rebuild of every active ghost.
+        ///
+        /// Returns true if:
+        ///   - the trajectory has any orbit segments (orbital ghosts always de-orbit at
+        ///     high speed), OR
+        ///   - any recorded trajectory point has velocity magnitude at or above
+        ///     <see cref="ReentryPotentialSpeedFloor"/>.
+        ///
+        /// Pure function — no Unity dependencies, no side effects. O(n) in trajectory
+        /// point count; called once per ghost build, not per frame.
+        /// </summary>
+        internal static bool HasReentryPotential(IPlaybackTrajectory traj)
+        {
+            if (traj == null) return false;
+
+            // Orbital ghosts always re-enter at high speed on de-orbit.
+            if (traj.HasOrbitSegments) return true;
+
+            var points = traj.Points;
+            if (points == null) return false;
+
+            float floorSq = ReentryPotentialSpeedFloor * ReentryPotentialSpeedFloor;
+            for (int i = 0; i < points.Count; i++)
+            {
+                if (points[i].velocity.sqrMagnitude >= floorSq)
+                    return true;
+            }
+            return false;
+        }
     }
 }

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -20,13 +20,13 @@ Entries 272–303 (78 bugs, 6 TODOs — mostly resolved) archived in `done/todo-
 
 For stationary part showcases (lights, solar panels, antennae sitting on KSC ground), reentry is physically impossible — `ComputeReentryIntensity` requires Mach ≥ 2.5 and density ≥ 0.0015 kg/m³. The build work is pure waste, and it was being paid hundreds of times per second across the looping fleet.
 
-**Fix (PR #406):**
+**Fix (PR #309):**
 
 1. New pure static helper `TrajectoryMath.HasReentryPotential(IPlaybackTrajectory)` — returns `true` iff the trajectory has any orbit segments OR any recorded trajectory point has velocity magnitude at or above `TrajectoryMath.ReentryPotentialSpeedFloor` (`400 m/s`). 400 m/s is well under Mach 1.5 on every stock body, so the gate cannot hide any real reentry heating. Orbit segments are always considered high-speed because de-orbit happens at ~2300 m/s.
 2. `GhostPlaybackEngine.TryPopulateGhostVisuals` now gates the `TryBuildReentryFx` call behind `HasReentryPotential`. When skipped, `state.reentryFxInfo` stays `null`; all downstream paths already null-guard (`UpdateReentryFx` early-returns at `GhostPlaybackEngine.cs:1395`, `RebuildReentryMeshes` early-returns at `GhostVisualBuilder.cs:6311`, `DestroyReentryFxResources` early-returns at `GhostPlaybackEngine.cs:2577`, `ParsekKSC.cs:519` already documents this pattern).
 3. Matching gate in the `ParsekFlight` preview path (`ParsekFlight.cs:7407`) so manual preview playback gets the same savings.
 4. New session counters `DiagnosticsState.health.reentryFxBuildsThisSession` / `reentryFxSkippedThisSession` make the gate visible in the live diagnostics stream, and a rate-limited `ReentryFx` `Verbose` log line announces each skip with the ghost index, vessel name, and reason.
-5. Unit tests `ReentryPotentialTests` (12 cases) cover: null trajectory, empty, stationary showcase, EVA walk, 200 m/s Flea hop, just-below-floor, at-floor, fast suborbital point, diagonal magnitude, orbit-segment-only recordings, and the speed floor constant itself.
+5. Unit tests `ReentryPotentialTests` (15 cases) cover: null trajectory, empty, stationary showcase, EVA walk, 200 m/s Flea hop, just-below-floor, at-floor, fast suborbital point, diagonal magnitude, orbit-segment-only recordings, speed floor constant, and the NaN / +Infinity / null-`Points` input edges added in the Opus review follow-up.
 
 **Expected impact:** for the 259-ghost showcase scenario in the smoking-gun logs, ~250 of those ghosts are stationary KSC showcases whose `reentryFxInfo` now stays `null` permanently. The mesh-combine + ParticleSystem + cloned-material allocation is skipped on every loop-cycle rebuild, eliminating the dominant cost in `UpdatePlayback` and taking the playback frame cost back below the 8 ms budget threshold. Only genuine flight recordings (Suborbital Arc, Orbit-1, Kerbin Ascent, etc.) still pay the build cost, and they pay it correctly.
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -7,6 +7,33 @@ Entries 272–303 (78 bugs, 6 TODOs — mostly resolved) archived in `done/todo-
 
 # Known Bugs
 
+## 406. CRITICAL: map-view framerate collapses with many looping showcase ghosts because every loop-cycle rebuild runs the full reentry FX build pipeline even for stationary part showcases
+
+**Source:** `test career` playtest `2026-04-15` (logs `logs/2026-04-15_2034_showcase-loop-perf/`). Player opened flight map view with ~260 active showcase loops; FPS tanked. The `[Parsek][WARN][Diagnostics] Playback frame budget exceeded: 12.3ms (259 ghosts, warp: 1x) | suppressed=106` line proves the `GhostPlaybackEngine.UpdatePlayback` path alone was blowing the 8 ms budget on most frames, *before* any map OnGUI/icon render. 265 primary ghost audio sources paused on ESC (`PauseAllGhostAudio: paused 265 primary + 0 overlap`) confirms the active ghost count. `PauseAllGhostAudio`-scale log spam of `combined 7 meshes into emission shape (4346 verts) for ghost #N | suppressed=839` confirms the reentry FX mesh-combine was firing many hundreds of times per rate-limit window.
+
+**Root cause:** `GhostPlaybackEngine.TryPopulateGhostVisuals` (call site was `GhostPlaybackEngine.cs:1949`) called `GhostVisualBuilder.TryBuildReentryFx` unconditionally on every ghost build. Ghost builds happen on loop-cycle boundaries because the engine destroys + respawns the ghost (`DestroyGhost(reason: "loop cycle boundary")` followed by `SpawnGhost`, triggered by `HasLoopCycleChanged`). `TryBuildReentryFx` per call allocates:
+
+1. Combined emission `Mesh` (`CombineMeshes` on every MeshFilter in the ghost hierarchy),
+2. A `ParticleSystem` (`ReentryFire`) with runtime-generated soft-circle texture + additive material,
+3. Fire shell overlay `MaterialPropertyBlock` + material clone,
+4. Cloned glow materials for every renderer on the ghost via `CollectReentryGlowMaterials`.
+
+For stationary part showcases (lights, solar panels, antennae sitting on KSC ground), reentry is physically impossible — `ComputeReentryIntensity` requires Mach ≥ 2.5 and density ≥ 0.0015 kg/m³. The build work is pure waste, and it was being paid hundreds of times per second across the looping fleet.
+
+**Fix (PR #406):**
+
+1. New pure static helper `TrajectoryMath.HasReentryPotential(IPlaybackTrajectory)` — returns `true` iff the trajectory has any orbit segments OR any recorded trajectory point has velocity magnitude at or above `TrajectoryMath.ReentryPotentialSpeedFloor` (`400 m/s`). 400 m/s is well under Mach 1.5 on every stock body, so the gate cannot hide any real reentry heating. Orbit segments are always considered high-speed because de-orbit happens at ~2300 m/s.
+2. `GhostPlaybackEngine.TryPopulateGhostVisuals` now gates the `TryBuildReentryFx` call behind `HasReentryPotential`. When skipped, `state.reentryFxInfo` stays `null`; all downstream paths already null-guard (`UpdateReentryFx` early-returns at `GhostPlaybackEngine.cs:1395`, `RebuildReentryMeshes` early-returns at `GhostVisualBuilder.cs:6311`, `DestroyReentryFxResources` early-returns at `GhostPlaybackEngine.cs:2577`, `ParsekKSC.cs:519` already documents this pattern).
+3. Matching gate in the `ParsekFlight` preview path (`ParsekFlight.cs:7407`) so manual preview playback gets the same savings.
+4. New session counters `DiagnosticsState.health.reentryFxBuildsThisSession` / `reentryFxSkippedThisSession` make the gate visible in the live diagnostics stream, and a rate-limited `ReentryFx` `Verbose` log line announces each skip with the ghost index, vessel name, and reason.
+5. Unit tests `ReentryPotentialTests` (12 cases) cover: null trajectory, empty, stationary showcase, EVA walk, 200 m/s Flea hop, just-below-floor, at-floor, fast suborbital point, diagonal magnitude, orbit-segment-only recordings, and the speed floor constant itself.
+
+**Expected impact:** for the 259-ghost showcase scenario in the smoking-gun logs, ~250 of those ghosts are stationary KSC showcases whose `reentryFxInfo` now stays `null` permanently. The mesh-combine + ParticleSystem + cloned-material allocation is skipped on every loop-cycle rebuild, eliminating the dominant cost in `UpdatePlayback` and taking the playback frame cost back below the 8 ms budget threshold. Only genuine flight recordings (Suborbital Arc, Orbit-1, Kerbin Ascent, etc.) still pay the build cost, and they pay it correctly.
+
+**Status:** fix landed on branch `investigate-showcase-loop-perf`. Follow-up candidates (not in this PR): reuse ghost GameObject across loop cycles instead of destroy/rebuild (would eliminate the remaining per-cycle material/audio clone cost); gate hidden-tier prewarm by reentry potential too.
+
+---
+
 ## 405. CRITICAL: career-mode contract accept/complete/fail/cancel events and `PartPurchased` never reach the ledger — `PatchContracts` destroys active contracts on every recalc
 
 **Source:** c1 career-mode playtest `2026-04-15` (logs `logs/2026-04-15_0005_c1-career-bugs/`). Player accepted 2 contracts at UT ≈ 412.9 (`Test RT-5 "Flea"` and `Test LV-T45 "Swivel"` at launch site), both captured by `GameStateRecorder.OnContractAccepted` and written to `events.pgse`, both unconditionally destroyed by the next `PatchContracts` pass. Ledger at end of session has **zero** `ContractAccept`, `ContractComplete`, `ContractFail`, `ContractCancel`, or `FundsSpending (PartPurchased)` actions.


### PR DESCRIPTION
## Summary

- Map-view framerate in `test career` collapsed when ~260 showcase ghosts looped simultaneously. `GhostPlaybackEngine.UpdatePlayback` alone blew the 8 ms playback budget (logs: `Playback frame budget exceeded: 12.3ms (259 ghosts, warp: 1x) | suppressed=106`) *before* map OnGUI ran, and `PauseAllGhostAudio: paused 265 primary` confirmed the active fleet size.
- Root cause: `TryPopulateGhostVisuals` called `GhostVisualBuilder.TryBuildReentryFx` unconditionally on every ghost build, and loop cycle boundaries destroy-and-respawn ghosts (`DestroyGhost(reason: "loop cycle boundary")` → `SpawnGhost`). For stationary part showcases, the mesh-combine + `ParticleSystem` + glow material clones were pure waste — they can never produce reentry visuals because `ComputeReentryIntensity` gates on Mach ≥ 2.5 and density ≥ 0.0015 kg/m³.
- Fix: gate the build behind new `TrajectoryMath.HasReentryPotential(IPlaybackTrajectory)` — returns `true` iff the trajectory has any orbit segments or any point has velocity magnitude ≥ `ReentryPotentialSpeedFloor` (400 m/s, well under Mach 1.5 on any stock body). When skipped, `reentryFxInfo` stays `null`; all downstream paths already null-guard (same pattern `ParsekKSC.cs:519` uses for flag ghosts). Matching gate in the `ParsekFlight` preview path.

## Evidence

Logs `logs/2026-04-15_2034_showcase-loop-perf/`:

```
[LOG 20:30:53.058] [Parsek][WARN][Diagnostics] Playback frame budget exceeded: 12.3ms (259 ghosts, warp: 1x) | suppressed=106
[LOG 20:30:53.431] [Parsek][VERBOSE][ReentryFx] combined 7 meshes into emission shape (4346 verts) for ghost #1 | suppressed=839
[LOG 20:30:53.670] [Parsek][VERBOSE][GhostAudio] PauseAllGhostAudio: paused 265 primary + 0 overlap ghost(s)
```

The `suppressed=106` means 106 prior budget-exceedance warnings were rate-limited in a 30 s window — the budget was blown on most frames, not a one-off spike.

## Implementation notes

- `TrajectoryMath.HasReentryPotential` is pure static, takes `IPlaybackTrajectory`, O(n) in point count, called once per ghost build.
- Speed floor 400 m/s chosen because Mach 2.5 thermal FX requires ~675 m/s even in thin Kerbin air; 400 m/s is well under Mach 1.5 on every stock body, so the gate cannot hide any real reentry heating.
- Orbit segments always pass the gate — de-orbit happens at ~2300 m/s regardless of the point sampling density.
- New session counters `DiagnosticsState.health.reentryFxBuildsThisSession` / `reentryFxSkippedThisSession` make the gate visible in live diagnostics.
- Rate-limited `Verbose` log line on each skip identifies the ghost by index, vessel name, and reason.
- Follow-ups not in this PR: reusing ghost `GameObject` across loop cycles instead of destroy/rebuild (would eliminate the remaining per-cycle material/audio clone cost); gating hidden-tier prewarm by reentry potential too.

## Test plan

- [x] `dotnet test --filter "FullyQualifiedName~ReentryPotentialTests"` — 12 new unit tests pass (null / empty / stationary / EVA / 200 m/s Flea / just-below-floor / at-floor / fast suborbital point / diagonal magnitude / orbit-segment-only / speed floor constant).
- [x] `dotnet test` full suite — 6240 passed, 1 skipped (pre-existing).
- [x] `dotnet build` — deployed DLL verified to contain the `Skipped reentry FX build for ghost` UTF-16 string.
- [ ] Manual playtest: load `test career`, enter flight + map view on a vessel surrounded by the Part Showcase trees, confirm FPS no longer tanks and that `reentryFxSkippedThisSession` counter climbs while `reentryFxBuildsThisSession` stays low.
- [ ] Manual playtest: confirm a genuine suborbital or orbital ghost *still* shows reentry glow/fire during descent (e.g., Suborbital Arc, Orbit-1, Kerbin Ascent).