### PR TITLE
Add Gloops Flight Recorder window

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -104,6 +104,7 @@ Key source files and what they do - read the relevant one before modifying:
 - `UI/TestRunnerUI.cs` - in-game test runner window
 - `UI/GroupPickerUI.cs` - group picker popup (recording/chain group assignment)
 - `UI/SpawnControlUI.cs` - Real Spawn Control window (nearby vessel proximity spawning)
+- `UI/GloopsRecorderUI.cs` - Gloops Flight Recorder window (manual ghost-only recording controls)
 - `UI/ActionsWindowUI.cs` - Game Actions window (ledger display, budget, retired kerbals)
 - `InGameTests/` - runtime test framework: `InGameTestAttribute` (discovery), `InGameAssert` (assertions), `InGameTestRunner` (execution + results export), `TestRunnerShortcut` (global Ctrl+Shift+T addon), `RuntimeTests` (74 tests across 21 categories), `LogContractTests` (log format/level/resource validation migrated from post-hoc KSP.log checker)
 - `SelectiveSpawnUI.cs` - pure static methods for Real Spawn Control (proximity candidates, countdown formatting)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Parsek are documented here.
 
 ---
 
+## 0.8.3
+
+### Features
+
+- Add Gloops Flight Recorder window for manual ghost-only recordings. Manual recording controls (Start/Stop, Preview, Discard) moved from the main Parsek UI to a dedicated "Gloops Flight Recorder" window opened via a button in the main UI. Recordings are marked `IsGhostOnly` and never spawn a real vessel at playback end. They auto-commit on stop with looping enabled by default and are placed in the "Gloops Flight Recordings - Ghosts Only" group. Ghost-only recordings can run in parallel with the auto-recording system. An X (delete) button is added to the recordings table for ghost-only recordings.
+
+---
+
 ## 0.8.2
 
 ### Tests

--- a/Source/Parsek.Tests/GhostOnlyRecordingTests.cs
+++ b/Source/Parsek.Tests/GhostOnlyRecordingTests.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Tests for the IsGhostOnly field: serialization round-trip, spawn suppression,
+    /// persistence artifact copying, and Gloops group assignment.
+    /// </summary>
+    [Collection("Sequential")]
+    public class GhostOnlyRecordingTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public GhostOnlyRecordingTests()
+        {
+            RecordingStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+            MilestoneStore.ResetForTesting();
+            GameStateStore.SuppressLogging = true;
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+            RecordingStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+            MilestoneStore.ResetForTesting();
+        }
+
+        // --- Serialization round-trip ---
+
+        [Fact]
+        public void IsGhostOnly_True_RoundTripViaSaveLoad()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "ghost_rt_1",
+                IsGhostOnly = true
+            };
+
+            var node = new ConfigNode("RECORDING");
+            RecordingTree.SaveRecordingInto(node, rec);
+
+            var restored = new Recording();
+            RecordingTree.LoadRecordingFrom(node, restored);
+
+            Assert.True(restored.IsGhostOnly);
+        }
+
+        [Fact]
+        public void IsGhostOnly_False_NotSerializedByDefault()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "ghost_rt_2",
+                IsGhostOnly = false
+            };
+
+            var node = new ConfigNode("RECORDING");
+            RecordingTree.SaveRecordingInto(node, rec);
+
+            // IsGhostOnly=false should not produce a node value (same pattern as IsDebris)
+            Assert.Null(node.GetValue("isGhostOnly"));
+
+            var restored = new Recording();
+            RecordingTree.LoadRecordingFrom(node, restored);
+
+            Assert.False(restored.IsGhostOnly);
+        }
+
+        // --- Spawn suppression ---
+
+        [Fact]
+        public void ShouldSpawnAtRecordingEnd_GhostOnly_ReturnsFalse()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "ghost_spawn_1",
+                IsGhostOnly = true,
+                VesselSnapshot = new ConfigNode("VESSEL"),
+                TerminalStateValue = TerminalState.Landed
+            };
+
+            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtRecordingEnd(
+                rec,
+                isActiveChainMember: false,
+                isChainLoopingOrDisabled: false,
+                treeContext: null);
+
+            Assert.False(needsSpawn);
+            Assert.Contains("ghost-only", reason);
+        }
+
+        [Fact]
+        public void ShouldSpawnAtRecordingEnd_NotGhostOnly_CanSpawn()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "ghost_spawn_2",
+                IsGhostOnly = false,
+                VesselSnapshot = new ConfigNode("VESSEL"),
+                TerminalStateValue = TerminalState.Landed
+            };
+
+            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtRecordingEnd(
+                rec,
+                isActiveChainMember: false,
+                isChainLoopingOrDisabled: false,
+                treeContext: null);
+
+            Assert.True(needsSpawn);
+        }
+
+        // --- ApplyPersistenceArtifactsFrom ---
+
+        [Fact]
+        public void ApplyPersistenceArtifactsFrom_CopiesIsGhostOnly()
+        {
+            var source = new Recording
+            {
+                RecordingId = "ghost_copy_src",
+                IsGhostOnly = true
+            };
+
+            var target = new Recording();
+            target.ApplyPersistenceArtifactsFrom(source);
+
+            Assert.True(target.IsGhostOnly);
+        }
+
+        // --- Gloops group assignment ---
+
+        [Fact]
+        public void CommitGloopsRecording_AssignsGloopsGroup()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "ghost_group_1",
+                VesselName = "Test Vessel"
+            };
+            rec.Points.Add(new TrajectoryPoint { ut = 100.0 });
+            rec.Points.Add(new TrajectoryPoint { ut = 110.0 });
+
+            RecordingStore.CommitGloopsRecording(rec);
+
+            Assert.True(rec.IsGhostOnly);
+            Assert.NotNull(rec.RecordingGroups);
+            Assert.Contains(RecordingStore.GloopsGroupName, rec.RecordingGroups);
+            Assert.Contains(rec, RecordingStore.CommittedRecordings);
+        }
+
+        [Fact]
+        public void CommitGloopsRecording_SetsLoopPlaybackIfPreset()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "ghost_loop_1",
+                VesselName = "Loopy Ghost",
+                LoopPlayback = true
+            };
+            rec.Points.Add(new TrajectoryPoint { ut = 200.0 });
+            rec.Points.Add(new TrajectoryPoint { ut = 220.0 });
+
+            RecordingStore.CommitGloopsRecording(rec);
+
+            Assert.True(rec.LoopPlayback);
+            Assert.True(rec.IsGhostOnly);
+        }
+    }
+}

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -111,6 +111,20 @@ namespace Parsek
         private HashSet<uint> loggedFairingReadFailures = new HashSet<uint>();
         internal bool partEventsSubscribed;
         public bool IsRecording { get; internal set; }
+
+        /// <summary>
+        /// When true, this recorder operates in Gloops ghost-only mode:
+        /// registers with GloopsRecorderInstance instead of ActiveRecorder,
+        /// skips rewind save/pre-launch resources, auto-stops on vessel switch.
+        /// </summary>
+        internal bool IsGloopsMode { get; set; }
+
+        /// <summary>
+        /// Stash for the ghost visual snapshot captured at Gloops recording start.
+        /// Applied to the committed Recording by ParsekFlight.StopGloopsRecording().
+        /// </summary>
+        internal ConfigNode GloopsGhostVisualSnapshot { get; set; }
+
         public uint RecordingVesselId { get; private set; }
         public bool RecordingStartedAsEva { get; private set; }
         public bool VesselDestroyedDuringRecording { get; set; }
@@ -4184,11 +4198,13 @@ namespace Parsek
 
             LogVisualRecordingCoverage(v);
 
-            if (!isPromotion)
+            if (!isPromotion && !IsGloopsMode)
                 CapturePreLaunchResources();
 
             // Capture rewind save (quicksave stored in Parsek/Saves/)
-            CaptureRewindSave(v, isPromotion);
+            // Gloops mode skips rewind saves — ghost-only recordings have no revert target
+            if (!IsGloopsMode)
+                CaptureRewindSave(v, isPromotion);
 
             InitializeRecordingFlags(v);
             CaptureStartLocation(v, isPromotion);
@@ -4215,7 +4231,10 @@ namespace Parsek
             }
 
             // Register the Harmony patch to call us each physics frame
-            Patches.PhysicsFramePatch.ActiveRecorder = this;
+            if (IsGloopsMode)
+                Patches.PhysicsFramePatch.GloopsRecorderInstance = this;
+            else
+                Patches.PhysicsFramePatch.ActiveRecorder = this;
 
             SubscribePartEvents();
 
@@ -4689,7 +4708,10 @@ namespace Parsek
             }
 
             // Disconnect from Harmony patch
-            Patches.PhysicsFramePatch.ActiveRecorder = null;
+            if (IsGloopsMode)
+                Patches.PhysicsFramePatch.GloopsRecorderInstance = null;
+            else
+                Patches.PhysicsFramePatch.ActiveRecorder = null;
             UnsubscribePartEvents();
             IsRecording = false;
 
@@ -5109,6 +5131,18 @@ namespace Parsek
         /// </summary>
         private bool HandleVesselSwitchDuringRecording(Vessel v)
         {
+            // Gloops mode: auto-stop on vessel switch (no tree/chain logic)
+            if (IsGloopsMode)
+            {
+                ParsekLog.Info("Recorder",
+                    $"Gloops recorder auto-stopping on vessel switch " +
+                    $"(was pid={RecordingVesselId}, now pid={v.persistentId})");
+                FinalizeRecordingState(emitTerminalEvents: true,
+                    clearRelativeMode: true, sampleBoundaryOnRails: false,
+                    logTag: "GloopsVesselSwitch");
+                return true;
+            }
+
             // 1. Dock merge guard — must be first. DockMergePending was set by
             //    OnPartCouple; let the existing capture+stop flow handle it below.
             //    Do NOT enter tree decision logic for dock PID changes.

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -125,6 +125,12 @@ namespace Parsek
         /// </summary>
         internal ConfigNode GloopsGhostVisualSnapshot { get; set; }
 
+        /// <summary>
+        /// Set true when the Gloops recorder is auto-stopped by a vessel switch.
+        /// ParsekFlight checks this flag to auto-commit the orphaned recording.
+        /// </summary>
+        internal bool GloopsAutoStoppedByVesselSwitch { get; set; }
+
         public uint RecordingVesselId { get; private set; }
         public bool RecordingStartedAsEva { get; private set; }
         public bool VesselDestroyedDuringRecording { get; set; }
@@ -5131,15 +5137,16 @@ namespace Parsek
         /// </summary>
         private bool HandleVesselSwitchDuringRecording(Vessel v)
         {
-            // Gloops mode: auto-stop on vessel switch (no tree/chain logic)
+            // Gloops mode: auto-stop on vessel switch (no tree/chain logic).
+            // Call StopRecording (not bare FinalizeRecordingState) so CaptureAtStop
+            // is built — ParsekFlight detects the auto-stopped state and commits.
             if (IsGloopsMode)
             {
                 ParsekLog.Info("Recorder",
                     $"Gloops recorder auto-stopping on vessel switch " +
                     $"(was pid={RecordingVesselId}, now pid={v.persistentId})");
-                FinalizeRecordingState(emitTerminalEvents: true,
-                    clearRelativeMode: true, sampleBoundaryOnRails: false,
-                    logTag: "GloopsVesselSwitch");
+                StopRecording();
+                GloopsAutoStoppedByVesselSwitch = true;
                 return true;
             }
 

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -2944,6 +2944,12 @@ namespace Parsek
                 return (false, "vessel destroyed");
             }
 
+            // Gloops Flight Recorder recordings are ghost-only — never spawn a real vessel
+            if (rec.IsGhostOnly)
+            {
+                return (false, "ghost-only recording (Gloops)");
+            }
+
             // Branch > 0 recordings are ghost-only (undock continuations) — never spawn
             if (rec.ChainBranch > 0)
             {

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -832,6 +832,7 @@ namespace Parsek
                 ui.DrawTimelineWindowIfOpen(windowRect);
                 ui.DrawSettingsWindowIfOpen(windowRect);
                 ui.DrawSpawnControlWindowIfOpen(windowRect);
+                ui.DrawGloopsRecorderWindowIfOpen(windowRect);
                 ui.DrawTestRunnerWindowIfOpen(windowRect, this);
             }
         }
@@ -873,6 +874,9 @@ namespace Parsek
                 Patches.PhysicsFramePatch.BackgroundRecorderInstance = null;
                 backgroundRecorder = null;
             }
+
+            // Clean up Gloops recorder if active
+            CleanupGloopsRecorder();
 
             // Clear tree destruction dialog guard
             treeDestructionDialogPending = false;
@@ -976,6 +980,9 @@ namespace Parsek
 
             // Finalize continuation sampling before anything else
             chainManager.StopAllContinuations("scene change");
+
+            // Clean up Gloops recorder on scene change (discard in-progress)
+            CleanupGloopsRecorder();
 
             ClearSceneChangeTransientState();
 
@@ -7381,6 +7388,273 @@ namespace Parsek
 
         #endregion
 
+        #region Gloops Flight Recorder (parallel ghost-only recording)
+
+        private FlightRecorder gloopsRecorder;
+        private Recording lastGloopsRecording;
+
+        /// <summary>True when the Gloops ghost-only recorder is actively sampling.</summary>
+        internal bool IsGloopsRecording => gloopsRecorder?.IsRecording ?? false;
+
+        /// <summary>
+        /// The most recent Gloops recording (committed or in-progress).
+        /// Used by GloopsRecorderUI for preview and discard.
+        /// </summary>
+        internal Recording LastGloopsRecording => lastGloopsRecording;
+
+        /// <summary>Access to in-progress Gloops recorder for point count display.</summary>
+        internal FlightRecorder GloopsRecorderForUI => gloopsRecorder;
+
+        /// <summary>
+        /// Starts a parallel Gloops ghost-only recording on the active vessel.
+        /// Can run alongside the main auto-recording.
+        /// </summary>
+        internal void StartGloopsRecording()
+        {
+            if (IsGloopsRecording)
+            {
+                ParsekLog.Warn("Flight", "StartGloopsRecording called while already recording");
+                return;
+            }
+
+            Vessel v = FlightGlobals.ActiveVessel;
+            if (v == null)
+            {
+                ParsekLog.Warn("Flight", "StartGloopsRecording: no active vessel");
+                return;
+            }
+
+            gloopsRecorder = new FlightRecorder { IsGloopsMode = true };
+            gloopsRecorder.StartRecording(isPromotion: false);
+
+            if (!gloopsRecorder.IsRecording)
+            {
+                ParsekLog.Warn("Flight", "StartGloopsRecording blocked (paused or no vessel)");
+                gloopsRecorder = null;
+                return;
+            }
+
+            // Capture ghost visual snapshot at recording start (full vessel before staging)
+            ConfigNode ghostSnap = VesselSpawner.TryBackupSnapshot(v);
+
+            // Stash it for later use when building the recording
+            gloopsRecorder.GloopsGhostVisualSnapshot = ghostSnap;
+
+            lastGloopsRecording = null;
+
+            ParsekLog.Info("Flight",
+                $"Gloops recording started: vessel={v.vesselName}, pid={v.persistentId}, " +
+                $"ghostSnap={ghostSnap != null}");
+            ParsekLog.ScreenMessage("Gloops Recording STARTED", 2f);
+        }
+
+        /// <summary>
+        /// Stops the Gloops recorder, builds a Recording, and commits it as ghost-only
+        /// with looping enabled by default.
+        /// </summary>
+        internal void StopGloopsRecording()
+        {
+            if (gloopsRecorder == null || !gloopsRecorder.IsRecording)
+            {
+                ParsekLog.Warn("Flight", "StopGloopsRecording: no active Gloops recorder");
+                return;
+            }
+
+            gloopsRecorder.StopRecording();
+
+            Recording rec = RecordingStore.CreateRecordingFromFlightData(
+                gloopsRecorder.Recording,
+                FlightGlobals.ActiveVessel?.vesselName ?? "Gloops Recording",
+                gloopsRecorder.OrbitSegments,
+                partEvents: gloopsRecorder.PartEvents,
+                flagEvents: gloopsRecorder.FlagEvents,
+                segmentEvents: gloopsRecorder.SegmentEvents,
+                trackSections: gloopsRecorder.TrackSections);
+
+            if (rec == null)
+            {
+                ParsekLog.Warn("Flight", "StopGloopsRecording: not enough points (< 2)");
+                gloopsRecorder = null;
+                ParsekLog.ScreenMessage("Gloops recording too short — discarded", 2f);
+                return;
+            }
+
+            rec.IsGhostOnly = true;
+            rec.LoopPlayback = true;
+
+            // Apply snapshots
+            rec.GhostVisualSnapshot = gloopsRecorder.GloopsGhostVisualSnapshot;
+            var captureAtStop = gloopsRecorder.CaptureAtStop;
+            if (captureAtStop != null)
+            {
+                rec.VesselSnapshot = captureAtStop.VesselSnapshot;
+                rec.TerminalStateValue = captureAtStop.TerminalStateValue;
+                rec.TerminalPosition = captureAtStop.TerminalPosition;
+            }
+
+            RecordingStore.CommitGloopsRecording(rec);
+            lastGloopsRecording = rec;
+            gloopsRecorder = null;
+
+            ParsekLog.Info("Flight",
+                $"Gloops recording committed: \"{rec.VesselName}\" " +
+                $"({rec.Points.Count} points, id={rec.RecordingId})");
+            ParsekLog.ScreenMessage("Gloops Recording SAVED", 2f);
+        }
+
+        /// <summary>
+        /// Discards the in-progress Gloops recording without committing.
+        /// </summary>
+        internal void DiscardGloopsInProgress()
+        {
+            if (gloopsRecorder == null)
+            {
+                ParsekLog.Warn("Flight", "DiscardGloopsInProgress: no Gloops recorder");
+                return;
+            }
+
+            if (gloopsRecorder.IsRecording)
+                gloopsRecorder.ForceStop();
+            gloopsRecorder = null;
+
+            ParsekLog.Info("Flight", "Gloops in-progress recording discarded");
+            ParsekLog.ScreenMessage("Gloops recording discarded", 2f);
+        }
+
+        /// <summary>
+        /// Deletes the most recently committed Gloops recording.
+        /// </summary>
+        internal void DiscardLastGloopsRecording()
+        {
+            if (lastGloopsRecording == null)
+            {
+                ParsekLog.Warn("Flight", "DiscardLastGloopsRecording: nothing to discard");
+                return;
+            }
+
+            int idx = RecordingStore.CommittedRecordings.IndexOf(lastGloopsRecording);
+            if (idx >= 0)
+            {
+                // Destroy ghost if active
+                if (engine.ghostStates.ContainsKey(idx))
+                    engine.DestroyGhost(idx);
+
+                RecordingStore.RemoveRecordingAt(idx);
+                ParsekLog.Info("Flight",
+                    $"Deleted Gloops recording \"{lastGloopsRecording.VesselName}\" " +
+                    $"(id={lastGloopsRecording.RecordingId})");
+            }
+            else
+            {
+                ParsekLog.Warn("Flight",
+                    $"DiscardLastGloopsRecording: recording not found in committed list " +
+                    $"(id={lastGloopsRecording.RecordingId})");
+            }
+
+            lastGloopsRecording = null;
+            ParsekLog.ScreenMessage("Gloops recording deleted", 2f);
+        }
+
+        /// <summary>
+        /// Starts preview playback of the last Gloops recording and enters watch mode.
+        /// Reuses the existing manual playback system.
+        /// </summary>
+        internal void PreviewGloopsRecording()
+        {
+            if (lastGloopsRecording == null || lastGloopsRecording.Points.Count < 2)
+            {
+                ParsekLog.Warn("Flight", "PreviewGloopsRecording: no recording to preview");
+                return;
+            }
+
+            // Stop any existing preview
+            if (isPlaying)
+                StopPlayback();
+
+            // Use the committed Gloops recording for preview
+            // Set up the preview using the recording's snapshot
+            previewRecording = lastGloopsRecording;
+            previewGhostState = null;
+            GameObject ghost = null;
+            bool builtFromSnapshot = false;
+
+            var buildResult = GhostVisualBuilder.BuildTimelineGhostFromSnapshot(
+                previewRecording, "Parsek_Ghost_GloopsPreview");
+            if (buildResult != null)
+                ghost = buildResult.root;
+            builtFromSnapshot = ghost != null;
+
+            if (builtFromSnapshot)
+            {
+                previewGhostState = new GhostPlaybackState
+                {
+                    ghost = ghost,
+                    playbackIndex = 0,
+                    partEventIndex = 0,
+                    partTree = GhostVisualBuilder.BuildPartSubtreeMap(
+                        GhostVisualBuilder.GetGhostSnapshot(previewRecording)),
+                    logicalPartIds = GhostVisualBuilder.BuildSnapshotPartIdSet(
+                        GhostVisualBuilder.GetGhostSnapshot(previewRecording))
+                };
+                previewGhostState.materials = new List<Material>();
+
+                GhostPlaybackLogic.PopulateGhostInfoDictionaries(previewGhostState, buildResult);
+                GhostPlaybackLogic.InitializeInventoryPlacementVisibility(previewRecording, previewGhostState);
+                GhostPlaybackLogic.RefreshCompoundPartVisibility(previewGhostState);
+
+                if (TrajectoryMath.HasReentryPotential(previewRecording))
+                {
+                    previewGhostState.reentryFxInfo = GhostVisualBuilder.TryBuildReentryFx(
+                        ghost, previewGhostState.heatInfos, -1, previewRecording.VesselName);
+                }
+                else
+                {
+                    previewGhostState.reentryFxInfo = null;
+                }
+
+                GhostPlaybackLogic.InitializeFlagVisibility(previewRecording, previewGhostState);
+                previewGhostMaterials = previewGhostState.materials;
+            }
+            else
+            {
+                Color previewColor = Color.green;
+                ghost = GhostVisualBuilder.CreateGhostSphere("Parsek_Ghost_GloopsPreview", previewColor);
+                var m = ghost.GetComponent<Renderer>()?.material;
+                previewGhostMaterials = m != null ? new List<Material> { m } : new List<Material>();
+                previewGhostState = null;
+            }
+
+            ghostObject = ghost;
+            playbackStartUT = Planetarium.GetUniversalTime();
+            recordingStartUT = previewRecording.Points[0].ut;
+            lastPlaybackIndex = 0;
+            isPlaying = true;
+
+            ParsekLog.Info("Flight",
+                $"Gloops preview started: \"{previewRecording.VesselName}\" " +
+                $"({previewRecording.Points.Count} points)");
+            ParsekLog.ScreenMessage("Gloops Preview STARTED", 2f);
+        }
+
+        /// <summary>
+        /// Cleans up the Gloops recorder on scene change or destroy.
+        /// </summary>
+        private void CleanupGloopsRecorder()
+        {
+            if (gloopsRecorder != null)
+            {
+                if (gloopsRecorder.IsRecording)
+                {
+                    gloopsRecorder.ForceStop();
+                    ParsekLog.Info("Flight", "Gloops recorder force-stopped on cleanup");
+                }
+                Patches.PhysicsFramePatch.GloopsRecorderInstance = null;
+                gloopsRecorder = null;
+            }
+        }
+
+        #endregion
+
         #region Manual Playback (preview)
 
         public void StartPlayback()
@@ -8858,6 +9132,46 @@ namespace Parsek
             policy.RemovePendingSpawn(rec.RecordingId);
 
             ParsekLog.ScreenMessage($"Recording '{rec.VesselName}' deleted", 2f);
+        }
+
+        /// <summary>
+        /// Deletes a ghost-only recording without the CanDeleteRecording guard.
+        /// Ghost-only recordings are independent of the auto-recording system,
+        /// so they can safely be deleted even while auto-recording is active.
+        /// </summary>
+        internal void DeleteGhostOnlyRecording(int index)
+        {
+            var committed = RecordingStore.CommittedRecordings;
+            if (index < 0 || index >= committed.Count)
+            {
+                ParsekLog.Warn("Flight", $"DeleteGhostOnlyRecording: index={index} out of range");
+                return;
+            }
+
+            var rec = committed[index];
+            if (!rec.IsGhostOnly)
+            {
+                ParsekLog.Warn("Flight", $"DeleteGhostOnlyRecording: recording at index {index} is not ghost-only");
+                return;
+            }
+
+            ParsekLog.Info("Flight", $"Deleting ghost-only recording '{rec.VesselName}' at index {index}");
+
+            // Destroy ghost if active (primary + overlap)
+            DestroyAllOverlapGhosts(index);
+            engine.DestroyGhost(index);
+
+            RecordingStore.RemoveRecordingAt(index);
+
+            watchMode.OnRecordingDeleted(index);
+            engine.ReindexAfterDelete(index);
+            orbitCache.Clear();
+            ui?.ClearMapMarkerCache();
+            loggedOrbitSegments.Clear();
+            loggedOrbitRotationSegments.Clear();
+            policy.RemovePendingSpawn(rec.RecordingId);
+
+            ParsekLog.ScreenMessage($"Ghost recording '{rec.VesselName}' deleted", 2f);
         }
 
         private const double PadFailureDurationThresholdSeconds = 10.0;

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -542,6 +542,9 @@ namespace Parsek
             ClearStaleConfirmations();
             HandleMissedVesselSwitchRecovery();
 
+            // Gloops: auto-commit if vessel switch auto-stopped the recorder
+            CheckGloopsAutoStoppedByVesselSwitch();
+
             HandleTreeDockMerge();
             HandleDockUndockCommitRestart();
 
@@ -7454,14 +7457,41 @@ namespace Parsek
         /// </summary>
         internal void StopGloopsRecording()
         {
-            if (gloopsRecorder == null || !gloopsRecorder.IsRecording)
+            if (gloopsRecorder == null)
             {
-                ParsekLog.Warn("Flight", "StopGloopsRecording: no active Gloops recorder");
+                ParsekLog.Warn("Flight", "StopGloopsRecording: no Gloops recorder");
                 return;
             }
 
-            gloopsRecorder.StopRecording();
+            // Normal stop: recorder still running
+            if (gloopsRecorder.IsRecording)
+                gloopsRecorder.StopRecording();
 
+            CommitGloopsRecorderData("StopGloopsRecording");
+        }
+
+        /// <summary>
+        /// Called each frame to detect Gloops recordings auto-stopped by vessel switch
+        /// and commit them automatically so recording data is not lost.
+        /// </summary>
+        private void CheckGloopsAutoStoppedByVesselSwitch()
+        {
+            if (gloopsRecorder == null) return;
+            if (!gloopsRecorder.GloopsAutoStoppedByVesselSwitch) return;
+
+            gloopsRecorder.GloopsAutoStoppedByVesselSwitch = false;
+            ParsekLog.Info("Flight", "Gloops recorder was auto-stopped by vessel switch — committing");
+            CommitGloopsRecorderData("GloopsAutoCommit");
+            ParsekLog.ScreenMessage("Gloops recording auto-saved (vessel switched)", 3f);
+        }
+
+        /// <summary>
+        /// Shared commit path for Gloops recordings: builds a Recording from the
+        /// FlightRecorder's buffers, sets ghost-only + looping, and commits.
+        /// Used by both manual StopGloopsRecording and vessel-switch auto-commit.
+        /// </summary>
+        private void CommitGloopsRecorderData(string logTag)
+        {
             Recording rec = RecordingStore.CreateRecordingFromFlightData(
                 gloopsRecorder.Recording,
                 FlightGlobals.ActiveVessel?.vesselName ?? "Gloops Recording",
@@ -7473,7 +7503,7 @@ namespace Parsek
 
             if (rec == null)
             {
-                ParsekLog.Warn("Flight", "StopGloopsRecording: not enough points (< 2)");
+                ParsekLog.Warn("Flight", $"{logTag}: not enough points (< 2)");
                 gloopsRecorder = null;
                 ParsekLog.ScreenMessage("Gloops recording too short — discarded", 2f);
                 return;
@@ -7497,9 +7527,8 @@ namespace Parsek
             gloopsRecorder = null;
 
             ParsekLog.Info("Flight",
-                $"Gloops recording committed: \"{rec.VesselName}\" " +
+                $"{logTag}: Gloops recording committed \"{rec.VesselName}\" " +
                 $"({rec.Points.Count} points, id={rec.RecordingId})");
-            ParsekLog.ScreenMessage("Gloops Recording SAVED", 2f);
         }
 
         /// <summary>
@@ -7523,6 +7552,8 @@ namespace Parsek
 
         /// <summary>
         /// Deletes the most recently committed Gloops recording.
+        /// Delegates to DeleteGhostOnlyRecording for full cleanup (ghost destroy,
+        /// engine reindex, orbit cache clear, etc.).
         /// </summary>
         internal void DiscardLastGloopsRecording()
         {
@@ -7535,14 +7566,7 @@ namespace Parsek
             int idx = RecordingStore.CommittedRecordings.IndexOf(lastGloopsRecording);
             if (idx >= 0)
             {
-                // Destroy ghost if active
-                if (engine.ghostStates.ContainsKey(idx))
-                    engine.DestroyGhost(idx);
-
-                RecordingStore.RemoveRecordingAt(idx);
-                ParsekLog.Info("Flight",
-                    $"Deleted Gloops recording \"{lastGloopsRecording.VesselName}\" " +
-                    $"(id={lastGloopsRecording.RecordingId})");
+                DeleteGhostOnlyRecording(idx);
             }
             else
             {
@@ -7552,7 +7576,6 @@ namespace Parsek
             }
 
             lastGloopsRecording = null;
-            ParsekLog.ScreenMessage("Gloops recording deleted", 2f);
         }
 
         /// <summary>

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -56,6 +56,9 @@ namespace Parsek
         // Spawn Control window (extracted to SpawnControlUI)
         private SpawnControlUI spawnControlUI;
 
+        // Gloops Flight Recorder window (extracted to GloopsRecorderUI)
+        private GloopsRecorderUI gloopsUI;
+
         private static readonly string VersionLabel = "v" +
             System.Reflection.Assembly.GetExecutingAssembly().GetName().Version.ToString(3);
 
@@ -82,6 +85,7 @@ namespace Parsek
             this.mode = UIMode.Flight;
             this.recordingsTableUI = new RecordingsTableUI(this);
             this.spawnControlUI = new SpawnControlUI(this);
+            this.gloopsUI = new GloopsRecorderUI(this);
             this.timelineUI = new TimelineWindowUI(this);
             this.testRunnerUI = new TestRunnerUI(this);
             this.settingsUI = new SettingsWindowUI(this);
@@ -94,6 +98,7 @@ namespace Parsek
             this.mode = mode;
             this.recordingsTableUI = new RecordingsTableUI(this);
             this.spawnControlUI = new SpawnControlUI(this);
+            this.gloopsUI = new GloopsRecorderUI(this);
             this.timelineUI = new TimelineWindowUI(this);
             this.testRunnerUI = new TestRunnerUI(this);
             this.settingsUI = new SettingsWindowUI(this);
@@ -160,7 +165,15 @@ namespace Parsek
             }
 
             if (InFlight)
-                DrawFlightRecordingControls();
+            {
+                GUILayout.Space(SpacingLarge);
+                if (GUILayout.Button("Gloops Flight Recorder"))
+                {
+                    gloopsUI.IsOpen = !gloopsUI.IsOpen;
+                    ParsekLog.Verbose("UI",
+                        $"Gloops Flight Recorder window toggled: {(gloopsUI.IsOpen ? "open" : "closed")}");
+                }
+            }
 
             // --- Settings button ---
             GUILayout.Space(SpacingLarge);
@@ -202,66 +215,7 @@ namespace Parsek
             GUILayout.Label($"Active Ghosts: {flight.TimelineGhostCount}");
         }
 
-        private void DrawFlightRecordingControls()
-        {
-            GUILayout.Space(SpacingLarge);
-
-            if (!flight.IsRecording)
-            {
-                if (GUILayout.Button("Start Recording"))
-                {
-                    ParsekLog.Verbose("UI", "Start Recording button clicked");
-                    flight.StartRecording();
-                }
-            }
-            else
-            {
-                if (GUILayout.Button("Stop Recording"))
-                {
-                    ParsekLog.Verbose("UI", "Stop Recording button clicked");
-                    flight.StopRecording();
-                }
-            }
-
-            if (!flight.IsPlaying)
-            {
-                GUI.enabled = !flight.IsRecording && flight.recording.Count > 0;
-                if (GUILayout.Button("Preview Playback"))
-                {
-                    ParsekLog.Verbose("UI", "Preview Playback button clicked");
-                    flight.StartPlayback();
-                }
-                GUI.enabled = true;
-            }
-            else
-            {
-                if (GUILayout.Button("Stop Preview"))
-                {
-                    ParsekLog.Verbose("UI", "Stop Preview button clicked");
-                    flight.StopPlayback();
-                }
-            }
-
-            GUI.enabled = !flight.IsRecording && !flight.IsPlaying && flight.recording.Count > 0;
-            if (GUILayout.Button("Clear Current Recording"))
-            {
-                ParsekLog.Verbose("UI", "Clear Current Recording button clicked");
-                recordingsTableUI.ShowClearRecordingConfirmation();
-            }
-
-            bool canCommitTree = flight.HasActiveTree;
-            bool stableSituation = FlightGlobals.ActiveVessel != null
-                && RecordingStore.IsStableState((int)FlightGlobals.ActiveVessel.situation);
-            GUI.enabled = canCommitTree && stableSituation;
-            if (GUILayout.Button(stableSituation
-                ? new GUIContent("Commit Recording to Timeline")
-                : new GUIContent("Commit Recording to Timeline", "Land or stop before committing.")))
-            {
-                ParsekLog.Verbose("UI", "Commit Flight button clicked");
-                flight.CommitTreeFlight();
-            }
-            GUI.enabled = true;
-        }
+        // Recording controls moved to GloopsRecorderUI (Gloops Flight Recorder window)
 
         /// <summary>
         /// Call after each window's GUILayoutWindow to log position/size changes (rate-limited).
@@ -606,6 +560,12 @@ namespace Parsek
         public void DrawSpawnControlWindowIfOpen(Rect mainWindowRect)
         {
             spawnControlUI.DrawIfOpen(mainWindowRect, flight, InFlight);
+        }
+
+        public void DrawGloopsRecorderWindowIfOpen(Rect mainWindowRect)
+        {
+            if (InFlight && flight != null)
+                gloopsUI.DrawIfOpen(mainWindowRect, flight);
         }
 
         public void DrawTestRunnerWindowIfOpen(Rect mainWindowRect, MonoBehaviour host)

--- a/Source/Parsek/Patches/PhysicsFramePatch.cs
+++ b/Source/Parsek/Patches/PhysicsFramePatch.cs
@@ -47,9 +47,6 @@ namespace Parsek.Patches
                 lastObservedRecorder = ActiveRecorder;
             }
 
-            if (ActiveRecorder == null && GloopsRecorderInstance == null && BackgroundRecorderInstance == null)
-                return;
-
             if (GloopsRecorderInstance != lastObservedGloopsRecorder)
             {
                 if (GloopsRecorderInstance == null)
@@ -58,6 +55,9 @@ namespace Parsek.Patches
                     ParsekLog.Info("PhysicsPatch", "Gloops recorder attached");
                 lastObservedGloopsRecorder = GloopsRecorderInstance;
             }
+
+            if (ActiveRecorder == null && GloopsRecorderInstance == null && BackgroundRecorderInstance == null)
+                return;
 
             // VesselPrecalculate.vessel is protected; resolve the vessel
             // via the GameObject instead.

--- a/Source/Parsek/Patches/PhysicsFramePatch.cs
+++ b/Source/Parsek/Patches/PhysicsFramePatch.cs
@@ -21,6 +21,13 @@ namespace Parsek.Patches
         private static FlightRecorder lastObservedRecorder;
 
         /// <summary>
+        /// Set by ParsekFlight.StartGloopsRecording(), cleared on stop.
+        /// Null when not Gloops-recording. Runs in parallel with ActiveRecorder.
+        /// </summary>
+        internal static FlightRecorder GloopsRecorderInstance;
+        private static FlightRecorder lastObservedGloopsRecorder;
+
+        /// <summary>
         /// Set by ParsekFlight when a recording tree is active.
         /// Null when no tree is active. Enables background physics recording
         /// for non-active vessels in the tree.
@@ -40,8 +47,17 @@ namespace Parsek.Patches
                 lastObservedRecorder = ActiveRecorder;
             }
 
-            if (ActiveRecorder == null && BackgroundRecorderInstance == null)
+            if (ActiveRecorder == null && GloopsRecorderInstance == null && BackgroundRecorderInstance == null)
                 return;
+
+            if (GloopsRecorderInstance != lastObservedGloopsRecorder)
+            {
+                if (GloopsRecorderInstance == null)
+                    ParsekLog.Info("PhysicsPatch", "Gloops recorder cleared");
+                else
+                    ParsekLog.Info("PhysicsPatch", "Gloops recorder attached");
+                lastObservedGloopsRecorder = GloopsRecorderInstance;
+            }
 
             // VesselPrecalculate.vessel is protected; resolve the vessel
             // via the GameObject instead.
@@ -65,6 +81,15 @@ namespace Parsek.Patches
                     DiagnosticsState.recordingBudget.totalMicroseconds = elapsedUs;
 
                     DiagnosticsComputation.CheckRecordingBudgetThreshold(elapsedUs, v.vesselName);
+                }
+            }
+
+            // Gloops recorder runs in parallel with the active recorder on the same vessel
+            if (GloopsRecorderInstance != null)
+            {
+                if (v != null && __instance.gameObject == v.gameObject)
+                {
+                    GloopsRecorderInstance.OnPhysicsFrame(v);
                 }
             }
 

--- a/Source/Parsek/Recording.cs
+++ b/Source/Parsek/Recording.cs
@@ -24,6 +24,10 @@ namespace Parsek
         // True if vessel has no controller parts (debris). Minimal recording only.
         public bool IsDebris;
 
+        // True if this recording was created via the Gloops Flight Recorder (manual ghost-only).
+        // Ghost-only recordings never spawn a real vessel at playback end.
+        public bool IsGhostOnly;
+
         // Cascade depth from primary recording. 0 = primary recording (active vessel),
         // 1 = primary debris (boosters/fairings decoupled by gen-0 vessel). Background
         // splits whose parent is at Generation >= MaxRecordingGeneration are skipped
@@ -571,6 +575,7 @@ namespace Parsek
             if (source.Controllers != null)
                 Controllers = new List<ControllerInfo>(source.Controllers);
             IsDebris = source.IsDebris;
+            IsGhostOnly = source.IsGhostOnly;
             // Generation is transient, but copied so the cascade-depth state is
             // preserved across recording creation/commit boundaries within a tree session.
             // Loaded recordings reset to 0 since the field is [NonSerialized].

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -55,6 +55,11 @@ namespace Parsek
     {
         public const int LaunchToLaunchLoopIntervalFormatVersion = 4;
         public const int CurrentRecordingFormatVersion = LaunchToLaunchLoopIntervalFormatVersion;
+
+        /// <summary>
+        /// Top-level group name for ghost-only recordings created via the Gloops Flight Recorder.
+        /// </summary>
+        internal const string GloopsGroupName = "Gloops Flight Recordings - Ghosts Only";
         // v0: initial release format
         // v1: track sections become authoritative on disk when present; flat lists rebuild on load
         // v2: binary .prec sidecars with header dispatch, exact scalar storage, and file-level string tables
@@ -359,6 +364,37 @@ namespace Parsek
 
             // Create a milestone bundling game state events since the previous milestone
             MilestoneStore.CreateMilestone(rec.RecordingId, rec.EndUT);
+        }
+
+        /// <summary>
+        /// Commits a ghost-only Gloops recording: adds to committed list, flushes to disk,
+        /// but skips game-state side effects (science subjects, milestones, baselines) since
+        /// ghost-only recordings do not affect game state.
+        /// </summary>
+        internal static void CommitGloopsRecording(Recording rec)
+        {
+            if (rec == null)
+            {
+                ParsekLog.Warn("RecordingStore", "CommitGloopsRecording called with null recording");
+                return;
+            }
+
+            rec.IsGhostOnly = true;
+            rec.FilesDirty = true;
+
+            // Assign to Gloops group
+            if (rec.RecordingGroups == null)
+                rec.RecordingGroups = new List<string>();
+            if (!rec.RecordingGroups.Contains(GloopsGroupName))
+                rec.RecordingGroups.Add(GloopsGroupName);
+
+            committedRecordings.Add(rec);
+            FlushDirtyFiles(committedRecordings);
+
+            ParsekLog.Info("RecordingStore",
+                $"Committed Gloops ghost-only recording \"{rec.VesselName}\" " +
+                $"({rec.Points.Count} points, id={rec.RecordingId}). " +
+                $"Total committed: {committedRecordings.Count}");
         }
 
         /// <summary>

--- a/Source/Parsek/RecordingTree.cs
+++ b/Source/Parsek/RecordingTree.cs
@@ -523,6 +523,8 @@ namespace Parsek
             }
             if (rec.IsDebris)
                 recNode.AddValue("isDebris", rec.IsDebris.ToString());
+            if (rec.IsGhostOnly)
+                recNode.AddValue("isGhostOnly", rec.IsGhostOnly.ToString());
 
             // Max distance from launch (#302): needed for idle-on-pad auto-discard
             // after scene reload (without this, deserialized recordings default to 0.0
@@ -928,6 +930,14 @@ namespace Parsek
                 bool isDebris;
                 if (bool.TryParse(isDebrisStr, out isDebris))
                     rec.IsDebris = isDebris;
+            }
+
+            string isGhostOnlyStr = recNode.GetValue("isGhostOnly");
+            if (isGhostOnlyStr != null)
+            {
+                bool isGhostOnly;
+                if (bool.TryParse(isGhostOnlyStr, out isGhostOnly))
+                    rec.IsGhostOnly = isGhostOnly;
             }
 
             // Max distance from launch (#302)

--- a/Source/Parsek/UI/GloopsRecorderUI.cs
+++ b/Source/Parsek/UI/GloopsRecorderUI.cs
@@ -1,0 +1,211 @@
+using ClickThroughFix;
+using UnityEngine;
+
+namespace Parsek
+{
+    /// <summary>
+    /// Gloops Flight Recorder window — manual ghost-only recording controls.
+    /// Runs a parallel FlightRecorder that produces IsGhostOnly recordings
+    /// auto-committed to the Gloops group with looping enabled by default.
+    /// </summary>
+    internal class GloopsRecorderUI
+    {
+        private readonly ParsekUI parentUI;
+
+        private bool showWindow;
+        private Rect windowRect;
+        private bool hasInputLock;
+        private const string InputLockId = "Parsek_GloopsRecorderWindow";
+
+        private Rect lastWindowRect;
+
+        public bool IsOpen
+        {
+            get { return showWindow; }
+            set { showWindow = value; }
+        }
+
+        internal GloopsRecorderUI(ParsekUI parentUI)
+        {
+            this.parentUI = parentUI;
+        }
+
+        public void DrawIfOpen(Rect mainWindowRect, ParsekFlight flight)
+        {
+            if (!showWindow)
+            {
+                ReleaseInputLock();
+                return;
+            }
+
+            if (flight == null)
+            {
+                showWindow = false;
+                ReleaseInputLock();
+                return;
+            }
+
+            if (windowRect.width < 1f)
+            {
+                float x = mainWindowRect.x + mainWindowRect.width + 10;
+                windowRect = new Rect(x, mainWindowRect.y, 280, 180);
+                var ic = System.Globalization.CultureInfo.InvariantCulture;
+                ParsekLog.Verbose("UI",
+                    $"Gloops Recorder window initial position: " +
+                    $"x={windowRect.x.ToString("F0", ic)} y={windowRect.y.ToString("F0", ic)}");
+            }
+
+            var opaqueWindowStyle = parentUI.GetOpaqueWindowStyle();
+            windowRect = ClickThruBlocker.GUILayoutWindow(
+                "ParsekGloopsRecorder".GetHashCode(),
+                windowRect,
+                (id) => DrawWindow(id, flight),
+                "Gloops Flight Recorder",
+                opaqueWindowStyle,
+                GUILayout.Width(windowRect.width),
+                GUILayout.Height(windowRect.height)
+            );
+            parentUI.LogWindowPosition("GloopsRecorder", ref lastWindowRect, windowRect);
+
+            if (windowRect.Contains(Event.current.mousePosition))
+            {
+                if (!hasInputLock)
+                {
+                    InputLockManager.SetControlLock(ControlTypes.CAMERACONTROLS, InputLockId);
+                    hasInputLock = true;
+                }
+            }
+            else
+            {
+                ReleaseInputLock();
+            }
+        }
+
+        public void ReleaseInputLock()
+        {
+            if (!hasInputLock) return;
+            InputLockManager.RemoveControlLock(InputLockId);
+            hasInputLock = false;
+        }
+
+        private void DrawWindow(int windowID, ParsekFlight flight)
+        {
+            GUILayout.BeginVertical();
+
+            bool isRecording = flight.IsGloopsRecording;
+            bool hasLastRecording = flight.LastGloopsRecording != null;
+            bool isPreviewing = flight.IsPlaying;
+
+            if (isRecording)
+            {
+                // --- State B: Recording in progress ---
+                DrawRecordingStatus(flight);
+
+                GUILayout.Space(6f);
+
+                if (GUILayout.Button("Stop Recording"))
+                {
+                    ParsekLog.Verbose("UI", "Gloops Stop Recording clicked");
+                    flight.StopGloopsRecording();
+                }
+
+                if (GUILayout.Button("Discard"))
+                {
+                    ParsekLog.Verbose("UI", "Gloops Discard (in-progress) clicked");
+                    flight.DiscardGloopsInProgress();
+                }
+            }
+            else if (hasLastRecording)
+            {
+                // --- State C: Recording just saved ---
+                var rec = flight.LastGloopsRecording;
+                GUILayout.Label($"Saved: \"{rec.VesselName}\"");
+                GUILayout.Label($"Points: {rec.Points.Count}");
+                double duration = rec.Points.Count > 1
+                    ? rec.Points[rec.Points.Count - 1].ut - rec.Points[0].ut
+                    : 0;
+                GUILayout.Label(string.Format(
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    "Duration: {0:F1}s", duration));
+
+                GUILayout.Space(6f);
+
+                if (!isPreviewing)
+                {
+                    if (GUILayout.Button("Preview"))
+                    {
+                        ParsekLog.Verbose("UI", "Gloops Preview clicked");
+                        flight.PreviewGloopsRecording();
+                    }
+                }
+                else
+                {
+                    if (GUILayout.Button("Stop Preview"))
+                    {
+                        ParsekLog.Verbose("UI", "Gloops Stop Preview clicked");
+                        flight.StopPlayback();
+                    }
+                }
+
+                if (GUILayout.Button("Discard Recording"))
+                {
+                    ParsekLog.Verbose("UI", "Gloops Discard (saved) clicked");
+                    if (isPreviewing)
+                        flight.StopPlayback();
+                    flight.DiscardLastGloopsRecording();
+                }
+
+                GUILayout.Space(6f);
+
+                if (GUILayout.Button("Start New Recording"))
+                {
+                    ParsekLog.Verbose("UI", "Gloops Start New Recording clicked");
+                    if (isPreviewing)
+                        flight.StopPlayback();
+                    flight.StartGloopsRecording();
+                }
+            }
+            else
+            {
+                // --- State A: Idle ---
+                string vesselName = FlightGlobals.ActiveVessel != null
+                    ? FlightGlobals.ActiveVessel.vesselName
+                    : "No vessel";
+                GUILayout.Label($"Vessel: {vesselName}");
+                GUILayout.Label("Ghost-only \u2014 loops by default");
+
+                GUILayout.Space(6f);
+
+                if (GUILayout.Button("Start Recording"))
+                {
+                    ParsekLog.Verbose("UI", "Gloops Start Recording clicked");
+                    flight.StartGloopsRecording();
+                }
+            }
+
+            GUILayout.EndVertical();
+            GUI.DragWindow();
+        }
+
+        private void DrawRecordingStatus(ParsekFlight flight)
+        {
+            GUILayout.Label("Recording...", GUI.skin.box);
+
+            var gloopsRecorder = flight.GloopsRecorderForUI;
+            if (gloopsRecorder != null)
+            {
+                int pointCount = gloopsRecorder.Recording.Count;
+                GUILayout.Label($"Points: {pointCount}");
+
+                if (pointCount > 1)
+                {
+                    double duration = gloopsRecorder.Recording[pointCount - 1].ut
+                        - gloopsRecorder.Recording[0].ut;
+                    GUILayout.Label(string.Format(
+                        System.Globalization.CultureInfo.InvariantCulture,
+                        "Duration: {0:F1}s", duration));
+                }
+            }
+        }
+    }
+}

--- a/Source/Parsek/UI/RecordingsTableUI.cs
+++ b/Source/Parsek/UI/RecordingsTableUI.cs
@@ -154,6 +154,9 @@ namespace Parsek
         private GUIStyle statusStyleActive;
         private GUIStyle statusStylePast;
 
+        // Deferred ghost-only recording deletion (avoids mid-layout list mutation)
+        private int pendingDeleteGhostOnlyIndex = -1;
+
         // Window drag tracking for position logging
         private Rect lastRecordingsWindowRect;
 
@@ -699,6 +702,14 @@ namespace Parsek
 
         private void DrawRecordingsWindow(int windowID)
         {
+            // Process deferred ghost-only recording deletion (avoids mid-layout list mutation)
+            if (pendingDeleteGhostOnlyIndex >= 0)
+            {
+                int delIdx = pendingDeleteGhostOnlyIndex;
+                pendingDeleteGhostOnlyIndex = -1;
+                DeleteGhostOnlyRecording(delIdx);
+            }
+
             var committed = RecordingStore.CommittedRecordings;
             double now = Planetarium.GetUniversalTime();
 
@@ -977,12 +988,30 @@ namespace Parsek
             var statusContent = new GUIContent(statusText, chainStatusTooltip);
             GUILayout.Label(statusContent, statusStyle, GUILayout.Width(ColW_Status));
 
-            // Group assignment button
-            if (GUILayout.Button("G", GUILayout.Width(ColW_Group)))
+            // Group assignment button (split with X delete for ghost-only recordings)
+            if (rec.IsGhostOnly)
             {
-                var mousePos = GUIUtility.GUIToScreenPoint(Event.current.mousePosition);
-                groupPicker.OpenForRecording(ri, mousePos);
-                ParsekLog.Verbose("UI", $"Group popup opened for recording index={ri} name='{rec.VesselName}'");
+                float halfGroup = (ColW_Group - 4f) * 0.5f;
+                if (GUILayout.Button("G", GUILayout.Width(halfGroup)))
+                {
+                    var mousePos = GUIUtility.GUIToScreenPoint(Event.current.mousePosition);
+                    groupPicker.OpenForRecording(ri, mousePos);
+                    ParsekLog.Verbose("UI", $"Group popup opened for recording index={ri} name='{rec.VesselName}'");
+                }
+                if (GUILayout.Button("X", GUILayout.Width(halfGroup)))
+                {
+                    pendingDeleteGhostOnlyIndex = ri;
+                    ParsekLog.Verbose("UI", $"Delete ghost-only recording clicked: index={ri} name='{rec.VesselName}'");
+                }
+            }
+            else
+            {
+                if (GUILayout.Button("G", GUILayout.Width(ColW_Group)))
+                {
+                    var mousePos = GUIUtility.GUIToScreenPoint(Event.current.mousePosition);
+                    groupPicker.OpenForRecording(ri, mousePos);
+                    ParsekLog.Verbose("UI", $"Group popup opened for recording index={ri} name='{rec.VesselName}'");
+                }
             }
 
             // Loop checkbox
@@ -2032,6 +2061,43 @@ namespace Parsek
                     })
                 ),
                 false, HighLogic.UISkin);
+        }
+
+        /// <summary>
+        /// Deletes a ghost-only recording by index. No confirmation dialog — ghost-only
+        /// recordings are low-commitment.
+        /// </summary>
+        private void DeleteGhostOnlyRecording(int index)
+        {
+            var committed = RecordingStore.CommittedRecordings;
+            if (index < 0 || index >= committed.Count)
+            {
+                ParsekLog.Warn("UI", $"DeleteGhostOnlyRecording: index {index} out of range");
+                return;
+            }
+
+            var rec = committed[index];
+            if (!rec.IsGhostOnly)
+            {
+                ParsekLog.Warn("UI", $"DeleteGhostOnlyRecording: recording at index {index} is not ghost-only");
+                return;
+            }
+
+            var flight = parentUI.Flight;
+            if (flight != null && parentUI.InFlightMode)
+            {
+                // Flight scene: use ParsekFlight.DeleteRecording for ghost cleanup
+                flight.DeleteGhostOnlyRecording(index);
+            }
+            else
+            {
+                // KSC scene: direct store deletion
+                RecordingStore.DeleteRecordingFull(index);
+            }
+
+            InvalidateSort();
+            ParsekLog.Info("UI",
+                $"Deleted ghost-only recording \"{rec.VesselName}\" (id={rec.RecordingId})");
         }
 
         private void DrawSortableHeader(string label, SortColumn col, float width, bool expand = false)

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -37,6 +37,12 @@ are fixed in the same PR branch with additional commits:
 
 ---
 
+## Gloops Flight Recorder
+
+- **Gloops Flight Recorder window** — manual ghost-only recording controls moved from main UI to a dedicated window. Recordings marked `IsGhostOnly`, auto-commit on stop, loop by default, grouped under "Gloops Flight Recordings - Ghosts Only". Parallel FlightRecorder instance with `IsGloopsMode` flag for separate Harmony patch routing, skipped rewind saves, and auto-stop on vessel switch. X delete button in recordings table for ghost-only recordings (no confirmation). Needs in-game verification when KSP is available.
+
+---
+
 # Known Bugs
 
 ## ~~411. Playback engine and KSC dispatcher still compute loop duration from raw/hybrid ranges instead of the effective loop range~~


### PR DESCRIPTION
## Summary

- Move manual recording controls (Start/Stop, Preview, Discard) from the main Parsek UI to a dedicated "Gloops Flight Recorder" window, opened via a button in the main UI
- Recordings created through this window are marked `IsGhostOnly` and never spawn a real vessel — they auto-commit on stop with looping enabled by default
- Ghost-only recordings are placed in the "Gloops Flight Recordings - Ghosts Only" top-level group
- Parallel FlightRecorder instance (`IsGloopsMode`) can run alongside the auto-recording system
- X delete button added to recordings table for ghost-only recordings (no confirmation dialog)

### Key files
- `Recording.cs` — `IsGhostOnly` field + serialization + `ApplyPersistenceArtifactsFrom`
- `GhostPlaybackLogic.cs` — spawn suppression for ghost-only recordings
- `FlightRecorder.cs` — `IsGloopsMode` flag: separate Harmony registration, skip rewind save/resources, auto-stop on vessel switch
- `PhysicsFramePatch.cs` — `GloopsRecorderInstance` for dual-recorder support
- `ParsekFlight.cs` — Gloops recorder lifecycle (start/stop/discard/preview/cleanup)
- `UI/GloopsRecorderUI.cs` — new window with 3 states (idle/recording/saved)
- `RecordingStore.cs` — `CommitGloopsRecording` bypasses game-state side effects (science, milestones, baselines)
- `RecordingsTableUI.cs` — X delete button for ghost-only recordings, deferred deletion
- `ParsekUI.cs` — replaced `DrawFlightRecordingControls` with Gloops button

## Test plan
- [ ] Verify `IsGhostOnly` serialization round-trip (unit test)
- [ ] Verify `ShouldSpawnAtRecordingEnd` returns false for ghost-only (unit test)
- [ ] Verify Gloops group assignment on commit (unit test)
- [ ] In-game: open Gloops window, start recording, fly, stop — recording appears in Gloops group
- [ ] In-game: verify ghost-only recording loops and does NOT spawn a real vessel
- [ ] In-game: preview button shows ghost and enters watch mode
- [ ] In-game: discard button removes the recording
- [ ] In-game: X button in recordings table deletes ghost-only recordings
- [ ] In-game: Gloops recording runs in parallel with auto-recording
- [ ] In-game: scene change while Gloops recording in progress — no crash/leak
- [ ] In-game: vessel switch while Gloops recording — auto-stops cleanly

https://claude.ai/code/session_01D8ZyMPxTFhVC9y2DPB52zx