### PR TITLE
Replace sampling sliders with Recording Sampling Density preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to Parsek are documented here.
 
 ### Enhancements
 
-- Replaced the four individual sampling sliders (min/max interval, direction threshold, speed threshold) with a single **Recorder Sample Density** setting offering three presets: Low (fewer samples, smaller files), Medium (balanced, same as previous defaults), and High (dense sampling for cinematic recordings). The selected preset is shown with a summary of effective thresholds.
+- Replaced the four individual sampling sliders (min/max interval, direction threshold, speed threshold) with a single **Recorder Sample Density** setting offering three presets: Low (fewer samples, smaller files), Medium (balanced, same as previous defaults), and High (dense sampling for cinematic recordings). Existing slider-based saves now migrate their legacy thresholds to the nearest preset on load instead of silently defaulting to Medium, and the preset remains available from both the Parsek settings window and KSP's stock Game Parameters UI.
 
 ### Tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to Parsek are documented here.
 
 ### Enhancements
 
-- Replaced the four individual sampling sliders (min/max interval, direction threshold, speed threshold) with a single **Recording Sampling Density** setting offering three presets: Low (fewer samples, smaller files), Medium (balanced, same as previous defaults), and High (dense sampling for cinematic recordings). The selected preset is shown with a summary of effective thresholds.
+- Replaced the four individual sampling sliders (min/max interval, direction threshold, speed threshold) with a single **Recorder Sample Density** setting offering three presets: Low (fewer samples, smaller files), Medium (balanced, same as previous defaults), and High (dense sampling for cinematic recordings). The selected preset is shown with a summary of effective thresholds.
 
 ### Tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Parsek are documented here.
 
 ## 0.8.2
 
+### Enhancements
+
+- Replaced the four individual sampling sliders (min/max interval, direction threshold, speed threshold) with a single **Recording Sampling Density** setting offering three presets: Low (fewer samples, smaller files), Medium (balanced, same as previous defaults), and High (dense sampling for cinematic recordings). The selected preset is shown with a summary of effective thresholds.
+
 ### Tests
 
 - `#371` Added a `MergeInto` continuous-EVA boundary merge round-trip test covering v3 binary sidecar save/load/optimize/resave/reload, plus a companion assertion that the optimizer rejects orbital-phase pairs.

--- a/Source/Parsek.Tests/Fixtures/DefaultCareer/Parsek/Saves/parsek_rw_0a74d6.sfs
+++ b/Source/Parsek.Tests/Fixtures/DefaultCareer/Parsek/Saves/parsek_rw_0a74d6.sfs
@@ -123,10 +123,7 @@ GAME
 			autoMerge = False
 			verboseLogging = True
 			writeReadableSidecarMirrors = True
-			minSampleInterval = 0.2
-			maxSampleInterval = 3
-			velocityDirThreshold = 2
-			speedChangeThreshold = 5
+			samplingDensity = 1
 			autoLoopIntervalSeconds = 10
 			autoLoopTimeUnit = 0
 			ghostAudioVolume = 0.7

--- a/Source/Parsek.Tests/Fixtures/DefaultCareer/persistent.sfs
+++ b/Source/Parsek.Tests/Fixtures/DefaultCareer/persistent.sfs
@@ -124,9 +124,7 @@ GAME
 			autoSplitAtSoi = True
 			autoMerge = False
 			verboseLogging = True
-			maxSampleInterval = 3
-			velocityDirThreshold = 2
-			speedChangeThreshold = 5
+			samplingDensity = 1
 		}
 		HETTNCustomParams_Nodes
 		{

--- a/Source/Parsek.Tests/ParsekSettingsTests.cs
+++ b/Source/Parsek.Tests/ParsekSettingsTests.cs
@@ -1,0 +1,85 @@
+using System.Reflection;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    public class ParsekSettingsTests
+    {
+        [Fact]
+        public void SamplingDensityField_UsesCustomIntParameterUi()
+        {
+            FieldInfo field = typeof(ParsekSettings).GetField(nameof(ParsekSettings.samplingDensity));
+
+            Assert.NotNull(field);
+            Assert.NotNull(field.GetCustomAttribute<GameParameters.CustomIntParameterUI>());
+        }
+
+        [Fact]
+        public void ResolveSamplingDensityFromConfig_UsesStoredSamplingDensityWhenPresent()
+        {
+            var node = new ConfigNode("ParsekSettings");
+            node.AddValue("samplingDensity", "2");
+            node.AddValue("minSampleInterval", "0.5");
+            node.AddValue("maxSampleInterval", "8");
+            node.AddValue("velocityDirThreshold", "6");
+            node.AddValue("speedChangeThreshold", "12");
+
+            SamplingDensity level = ParsekSettings.ResolveSamplingDensityFromConfig(
+                node, out bool migratedFromLegacy, out string invalidSamplingDensityValue);
+
+            Assert.Equal(SamplingDensity.High, level);
+            Assert.False(migratedFromLegacy);
+            Assert.Null(invalidSamplingDensityValue);
+        }
+
+        [Fact]
+        public void ResolveSamplingDensityFromConfig_MigratesLegacyThresholdsToNearestPreset()
+        {
+            var node = new ConfigNode("ParsekSettings");
+            node.AddValue("minSampleInterval", "0.35");
+            node.AddValue("maxSampleInterval", "6.5");
+            node.AddValue("velocityDirThreshold", "4.5");
+            node.AddValue("speedChangeThreshold", "10");
+
+            SamplingDensity level = ParsekSettings.ResolveSamplingDensityFromConfig(
+                node, out bool migratedFromLegacy, out string invalidSamplingDensityValue);
+
+            Assert.Equal(SamplingDensity.Low, level);
+            Assert.True(migratedFromLegacy);
+            Assert.Null(invalidSamplingDensityValue);
+        }
+
+        [Fact]
+        public void ResolveSamplingDensityFromConfig_UsesLegacyDefaultsForMissingFields()
+        {
+            var node = new ConfigNode("ParsekSettings");
+            node.AddValue("maxSampleInterval", "3");
+            node.AddValue("speedChangeThreshold", "5");
+
+            SamplingDensity level = ParsekSettings.ResolveSamplingDensityFromConfig(
+                node, out bool migratedFromLegacy, out string invalidSamplingDensityValue);
+
+            Assert.Equal(SamplingDensity.Medium, level);
+            Assert.True(migratedFromLegacy);
+            Assert.Null(invalidSamplingDensityValue);
+        }
+
+        [Fact]
+        public void ResolveSamplingDensityFromConfig_InvalidStoredValueFallsBackToLegacyThresholds()
+        {
+            var node = new ConfigNode("ParsekSettings");
+            node.AddValue("samplingDensity", "99");
+            node.AddValue("minSampleInterval", "0.5");
+            node.AddValue("maxSampleInterval", "8");
+            node.AddValue("velocityDirThreshold", "6");
+            node.AddValue("speedChangeThreshold", "12");
+
+            SamplingDensity level = ParsekSettings.ResolveSamplingDensityFromConfig(
+                node, out bool migratedFromLegacy, out string invalidSamplingDensityValue);
+
+            Assert.Equal(SamplingDensity.Low, level);
+            Assert.True(migratedFromLegacy);
+            Assert.Equal("99", invalidSamplingDensityValue);
+        }
+    }
+}

--- a/Source/Parsek/BackgroundRecorder.cs
+++ b/Source/Parsek/BackgroundRecorder.cs
@@ -1067,9 +1067,9 @@ namespace Parsek
             // proximity tier from ProximityRateSelector), but the gating logic is unified.
             Vector3 currentVelocity = (Vector3)(bgVessel.rb_velocityD + Krakensbane.GetFrameVelocity());
 
-            float maxSampleInterval = ParsekSettings.Current?.maxSampleInterval ?? 3.0f;
-            float velocityDirThreshold = ParsekSettings.Current?.velocityDirThreshold ?? 2.0f;
-            float speedChangeThreshold = (ParsekSettings.Current?.speedChangeThreshold ?? 5.0f) / 100f;
+            float maxSampleInterval = ParsekSettings.Current?.maxSampleInterval ?? ParsekSettings.GetMaxSampleInterval(SamplingDensity.Medium);
+            float velocityDirThreshold = ParsekSettings.Current?.velocityDirThreshold ?? ParsekSettings.GetVelocityDirThreshold(SamplingDensity.Medium);
+            float speedChangeThreshold = (ParsekSettings.Current?.speedChangeThreshold ?? ParsekSettings.GetSpeedChangeThreshold(SamplingDensity.Medium)) / 100f;
 
             if (!TrajectoryMath.ShouldRecordPoint(currentVelocity, state.lastRecordedVelocity,
                 ut, state.lastRecordedUT,

--- a/Source/Parsek/ChainSegmentManager.cs
+++ b/Source/Parsek/ChainSegmentManager.cs
@@ -110,13 +110,13 @@ namespace Parsek
 
         // Continuation adaptive sampling thresholds (read from settings, same as FlightRecorder)
         private static float ContinuationMinInterval =>
-            ParsekSettings.Current?.minSampleInterval ?? 0.2f;
+            ParsekSettings.Current?.minSampleInterval ?? ParsekSettings.GetMinSampleInterval(SamplingDensity.Medium);
         private static float ContinuationMaxInterval =>
-            ParsekSettings.Current?.maxSampleInterval ?? 3.0f;
+            ParsekSettings.Current?.maxSampleInterval ?? ParsekSettings.GetMaxSampleInterval(SamplingDensity.Medium);
         private static float ContinuationVelDirThreshold =>
-            ParsekSettings.Current?.velocityDirThreshold ?? 2.0f;
+            ParsekSettings.Current?.velocityDirThreshold ?? ParsekSettings.GetVelocityDirThreshold(SamplingDensity.Medium);
         private static float ContinuationSpeedThreshold =>
-            (ParsekSettings.Current?.speedChangeThreshold ?? 5.0f) / 100f;
+            (ParsekSettings.Current?.speedChangeThreshold ?? ParsekSettings.GetSpeedChangeThreshold(SamplingDensity.Medium)) / 100f;
 
         internal ChainSegmentManager()
         {

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -222,15 +222,15 @@ namespace Parsek
         public ConfigNode LastGoodVesselSnapshot => lastGoodVesselSnapshot;
         public ConfigNode InitialGhostVisualSnapshot => initialGhostVisualSnapshot;
 
-        // Adaptive sampling thresholds (read from settings, fallback to defaults)
+        // Adaptive sampling thresholds (read from settings, fallback to Medium defaults)
         private static float minSampleInterval =>
-            ParsekSettings.Current?.minSampleInterval ?? 0.2f;
+            ParsekSettings.Current?.minSampleInterval ?? ParsekSettings.GetMinSampleInterval(SamplingDensity.Medium);
         private static float maxSampleInterval =>
-            ParsekSettings.Current?.maxSampleInterval ?? 3.0f;
+            ParsekSettings.Current?.maxSampleInterval ?? ParsekSettings.GetMaxSampleInterval(SamplingDensity.Medium);
         private static float velocityDirThreshold =>
-            ParsekSettings.Current?.velocityDirThreshold ?? 2.0f;
+            ParsekSettings.Current?.velocityDirThreshold ?? ParsekSettings.GetVelocityDirThreshold(SamplingDensity.Medium);
         private static float speedChangeThreshold =>
-            (ParsekSettings.Current?.speedChangeThreshold ?? 5.0f) / 100f;
+            (ParsekSettings.Current?.speedChangeThreshold ?? ParsekSettings.GetSpeedChangeThreshold(SamplingDensity.Medium)) / 100f;
         private const double snapshotRefreshIntervalUT = 10.0;
         private const float snapshotPerfLogThresholdMs = 25.0f;
         private const double roboticSampleIntervalSeconds = 0.25; // 4 Hz

--- a/Source/Parsek/InGameTests/RuntimeTests.cs
+++ b/Source/Parsek/InGameTests/RuntimeTests.cs
@@ -146,25 +146,29 @@ namespace Parsek.InGameTests
         }
 
         [InGameTest(Category = "TrajectoryMath",
-            Description = "Live ParsekSettings.minSampleInterval caps EVA-jitter sample rate (bug #256 regression guard)")]
+            Description = "Live sampling density preset caps EVA-jitter sample rate (bug #256 regression guard)")]
         public void MinSampleIntervalCapsEvaJitter()
         {
-            // Validates that the live game-loaded ParsekSettings.minSampleInterval is
-            // a sane non-zero value AND that ShouldRecordPoint with that value caps the
-            // simulated jitter pattern at the rate the floor allows. Regression guard
-            // for bug #256.
+            // Validates that the live game-loaded sampling density preset produces
+            // a sane non-zero minSampleInterval AND that ShouldRecordPoint with that
+            // value caps the simulated jitter pattern at the rate the floor allows.
+            // Regression guard for bug #256.
             //
             // Bounds are computed dynamically from the live minInterval so the test passes
-            // for any valid setting (0.05–1.0 s slider range), not just the default.
-            float minInterval = ParsekSettings.Current?.minSampleInterval ?? 0.2f;
+            // for any valid density level (Low/Medium/High), not just the default.
+            float minInterval = ParsekSettings.Current?.minSampleInterval
+                ?? ParsekSettings.GetMinSampleInterval(SamplingDensity.Medium);
             InGameAssert.IsGreaterThan(minInterval, 0.0f,
                 "minSampleInterval must be > 0 in the live game (bug #256 floor would be disabled)");
             InGameAssert.IsLessThan((double)minInterval, 1.01,
-                "minSampleInterval should be ≤ 1 second (anything larger conflicts with max-interval backstop)");
+                "minSampleInterval should be \u2264 1 second (anything larger conflicts with max-interval backstop)");
 
-            float maxInterval = ParsekSettings.Current?.maxSampleInterval ?? 3.0f;
-            float velDirThreshold = ParsekSettings.Current?.velocityDirThreshold ?? 2.0f;
-            float speedThreshold = (ParsekSettings.Current?.speedChangeThreshold ?? 5.0f) / 100f;
+            float maxInterval = ParsekSettings.Current?.maxSampleInterval
+                ?? ParsekSettings.GetMaxSampleInterval(SamplingDensity.Medium);
+            float velDirThreshold = ParsekSettings.Current?.velocityDirThreshold
+                ?? ParsekSettings.GetVelocityDirThreshold(SamplingDensity.Medium);
+            float speedThreshold = (ParsekSettings.Current?.speedChangeThreshold
+                ?? ParsekSettings.GetSpeedChangeThreshold(SamplingDensity.Medium)) / 100f;
 
             // Simulate 50 frames at 50 Hz physics (~1 s) with a velocity vector that
             // rotates 2.86°/frame around the up axis. That's parity-independent of

--- a/Source/Parsek/ParsekSettings.cs
+++ b/Source/Parsek/ParsekSettings.cs
@@ -1,7 +1,7 @@
 namespace Parsek
 {
     /// <summary>
-    /// Recording sampling density presets. Each level maps to a fixed set of
+    /// Recorder sample density presets. Each level maps to a fixed set of
     /// adaptive-sampling thresholds (min/max interval, direction, speed).
     /// </summary>
     public enum SamplingDensity
@@ -41,7 +41,7 @@ namespace Parsek
         public bool writeReadableSidecarMirrors = true;
 
         /// <summary>
-        /// Recording sampling density preset (0=Low, 1=Medium, 2=High).
+        /// Recorder sample density preset (0=Low, 1=Medium, 2=High).
         /// Replaces the four individual sampling sliders (minSampleInterval,
         /// maxSampleInterval, velocityDirThreshold, speedChangeThreshold).
         /// Serialized as int for ConfigNode round-trip.

--- a/Source/Parsek/ParsekSettings.cs
+++ b/Source/Parsek/ParsekSettings.cs
@@ -1,5 +1,16 @@
 namespace Parsek
 {
+    /// <summary>
+    /// Recording sampling density presets. Each level maps to a fixed set of
+    /// adaptive-sampling thresholds (min/max interval, direction, speed).
+    /// </summary>
+    public enum SamplingDensity
+    {
+        Low = 0,
+        Medium = 1,
+        High = 2,
+    }
+
     public class ParsekSettings : GameParameters.CustomParameterNode
     {
         public override string Title => "Parsek";
@@ -29,25 +40,69 @@ namespace Parsek
             toolTip = "When enabled, also write human-readable .txt mirrors of recording sidecars for debugging and binary/text comparison")]
         public bool writeReadableSidecarMirrors = true;
 
-        [GameParameters.CustomFloatParameterUI("Min sample interval (s)", minValue = 0.05f, maxValue = 1f,
-            stepCount = 20, displayFormat = "F2",
-            toolTip = "Minimum seconds between trajectory samples — caps sample rate during slow/jittery motion (e.g. EVA on surface)")]
-        public float minSampleInterval = 0.2f;
+        /// <summary>
+        /// Recording sampling density preset (0=Low, 1=Medium, 2=High).
+        /// Replaces the four individual sampling sliders (minSampleInterval,
+        /// maxSampleInterval, velocityDirThreshold, speedChangeThreshold).
+        /// Serialized as int for ConfigNode round-trip.
+        /// </summary>
+        public int samplingDensity = 1; // Medium
 
-        [GameParameters.CustomFloatParameterUI("Max sample interval (s)", minValue = 1f, maxValue = 10f,
-            stepCount = 19, displayFormat = "F1",
-            toolTip = "Maximum seconds between trajectory samples")]
-        public float maxSampleInterval = 3.0f;
+        public SamplingDensity SamplingDensityLevel
+        {
+            get => samplingDensity >= 0 && samplingDensity <= 2
+                ? (SamplingDensity)samplingDensity
+                : SamplingDensity.Medium;
+            set => samplingDensity = (int)value;
+        }
 
-        [GameParameters.CustomFloatParameterUI("Direction threshold (\u00b0)", minValue = 0.5f, maxValue = 10f,
-            stepCount = 20, displayFormat = "F1",
-            toolTip = "Velocity direction change (degrees) that triggers a new sample")]
-        public float velocityDirThreshold = 2.0f;
+        // --- Derived sampling thresholds from preset ---
 
-        [GameParameters.CustomFloatParameterUI("Speed threshold (%)", minValue = 1f, maxValue = 20f,
-            stepCount = 20, displayFormat = "F0",
-            toolTip = "Speed change (percent) that triggers a new sample")]
-        public float speedChangeThreshold = 5.0f;
+        public float minSampleInterval => GetMinSampleInterval(SamplingDensityLevel);
+        public float maxSampleInterval => GetMaxSampleInterval(SamplingDensityLevel);
+        public float velocityDirThreshold => GetVelocityDirThreshold(SamplingDensityLevel);
+        public float speedChangeThreshold => GetSpeedChangeThreshold(SamplingDensityLevel);
+
+        internal static float GetMinSampleInterval(SamplingDensity level) =>
+            level == SamplingDensity.Low ? 0.5f
+            : level == SamplingDensity.High ? 0.05f
+            : 0.2f;
+
+        internal static float GetMaxSampleInterval(SamplingDensity level) =>
+            level == SamplingDensity.Low ? 8.0f
+            : level == SamplingDensity.High ? 1.0f
+            : 3.0f;
+
+        internal static float GetVelocityDirThreshold(SamplingDensity level) =>
+            level == SamplingDensity.Low ? 6.0f
+            : level == SamplingDensity.High ? 0.5f
+            : 2.0f;
+
+        internal static float GetSpeedChangeThreshold(SamplingDensity level) =>
+            level == SamplingDensity.Low ? 12.0f
+            : level == SamplingDensity.High ? 1.0f
+            : 5.0f;
+
+        internal static string DensityLabel(SamplingDensity level) =>
+            level == SamplingDensity.Low ? "Low"
+            : level == SamplingDensity.High ? "High"
+            : "Medium";
+
+        internal static string DensityTooltip(SamplingDensity level) =>
+            level == SamplingDensity.Low
+                ? "Fewer samples \u2014 smaller files, less CPU. Trajectories may look angular during sharp maneuvers."
+            : level == SamplingDensity.High
+                ? "Dense sampling \u2014 smooth curves for cinematic recordings. Larger files."
+            : "Balanced sampling for most flights.";
+
+        internal static string DensitySummary(SamplingDensity level)
+        {
+            float min = GetMinSampleInterval(level);
+            float max = GetMaxSampleInterval(level);
+            float dir = GetVelocityDirThreshold(level);
+            float spd = GetSpeedChangeThreshold(level);
+            return $"Sampling: every {min:F2}\u2013{max:F1}s, {dir:F1}\u00b0 / {spd:F0}% thresholds";
+        }
 
         /// <summary>
         /// Default launch-to-launch period in seconds (#381) for recordings with

--- a/Source/Parsek/ParsekSettings.cs
+++ b/Source/Parsek/ParsekSettings.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace Parsek
 {
     /// <summary>
@@ -97,11 +99,13 @@ namespace Parsek
 
         internal static string DensitySummary(SamplingDensity level)
         {
+            var ic = CultureInfo.InvariantCulture;
             float min = GetMinSampleInterval(level);
             float max = GetMaxSampleInterval(level);
             float dir = GetVelocityDirThreshold(level);
             float spd = GetSpeedChangeThreshold(level);
-            return $"Sampling: every {min:F2}\u2013{max:F1}s, {dir:F1}\u00b0 / {spd:F0}% thresholds";
+            return $"Sampling: every {min.ToString("F2", ic)}\u2013{max.ToString("F1", ic)}s, " +
+                   $"{dir.ToString("F1", ic)}\u00b0 / {spd.ToString("F0", ic)}% thresholds";
         }
 
         /// <summary>

--- a/Source/Parsek/ParsekSettings.cs
+++ b/Source/Parsek/ParsekSettings.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Globalization;
 
 namespace Parsek
@@ -15,6 +16,12 @@ namespace Parsek
 
     public class ParsekSettings : GameParameters.CustomParameterNode
     {
+        private const string SamplingDensityKey = "samplingDensity";
+        private const string LegacyMinSampleIntervalKey = "minSampleInterval";
+        private const string LegacyMaxSampleIntervalKey = "maxSampleInterval";
+        private const string LegacyVelocityDirThresholdKey = "velocityDirThreshold";
+        private const string LegacySpeedChangeThresholdKey = "speedChangeThreshold";
+
         public override string Title => "Parsek";
         public override GameParameters.GameMode GameMode => GameParameters.GameMode.ANY;
         public override string Section => "Parsek";
@@ -48,6 +55,10 @@ namespace Parsek
         /// maxSampleInterval, velocityDirThreshold, speedChangeThreshold).
         /// Serialized as int for ConfigNode round-trip.
         /// </summary>
+        [GameParameters.CustomIntParameterUI("Recorder sample density", minValue = 0, maxValue = 2,
+            stepSize = 1, displayFormat = "N0",
+            toolTip = "Trajectory sampling preset. 0 = Low, 1 = Medium, 2 = High. " +
+                      "The Parsek settings window shows labeled buttons and an exact threshold summary.")]
         public int samplingDensity = 1; // Medium
 
         public SamplingDensity SamplingDensityLevel
@@ -135,5 +146,146 @@ namespace Parsek
 
         public static ParsekSettings Current =>
             HighLogic.CurrentGame?.Parameters?.CustomParams<ParsekSettings>();
+
+        public override void OnLoad(ConfigNode node)
+        {
+            base.OnLoad(node);
+
+            SamplingDensity level = ResolveSamplingDensityFromConfig(
+                node, out bool migratedFromLegacy, out string invalidSamplingDensityValue);
+            SamplingDensityLevel = level;
+
+            if (!string.IsNullOrEmpty(invalidSamplingDensityValue))
+            {
+                ParsekLog.Warn("Settings",
+                    $"Invalid samplingDensity='{invalidSamplingDensityValue}' in config; " +
+                    $"using {(migratedFromLegacy ? "legacy-derived" : "default")} " +
+                    $"{DensityLabel(level)} preset");
+            }
+
+            if (migratedFromLegacy &&
+                TryReadLegacySamplingThresholds(node,
+                    out float legacyMin, out float legacyMax, out float legacyDir, out float legacySpeed))
+            {
+                var ic = CultureInfo.InvariantCulture;
+                ParsekLog.Info("Settings",
+                    $"Migrated legacy sampling thresholds ({legacyMin.ToString("F2", ic)}s/" +
+                    $"{legacyMax.ToString("F1", ic)}s/{legacyDir.ToString("F1", ic)}\u00b0/" +
+                    $"{legacySpeed.ToString("F0", ic)}%) to samplingDensity={DensityLabel(level)}");
+            }
+        }
+
+        internal static SamplingDensity ResolveSamplingDensityFromConfig(
+            ConfigNode node, out bool migratedFromLegacy, out string invalidSamplingDensityValue)
+        {
+            migratedFromLegacy = false;
+            invalidSamplingDensityValue = null;
+
+            if (TryReadSamplingDensityFromConfig(node, out SamplingDensity storedLevel))
+                return storedLevel;
+
+            invalidSamplingDensityValue = GetConfigValueOrNull(node, SamplingDensityKey);
+
+            if (TryReadLegacySamplingThresholds(node,
+                out float legacyMin, out float legacyMax, out float legacyDir, out float legacySpeed))
+            {
+                migratedFromLegacy = true;
+                return DeriveSamplingDensityFromLegacyThresholds(
+                    legacyMin, legacyMax, legacyDir, legacySpeed);
+            }
+
+            return SamplingDensity.Medium;
+        }
+
+        internal static SamplingDensity DeriveSamplingDensityFromLegacyThresholds(
+            float minSampleInterval, float maxSampleInterval,
+            float velocityDirThreshold, float speedChangeThreshold)
+        {
+            SamplingDensity bestLevel = SamplingDensity.Medium;
+            double bestScore = double.MaxValue;
+
+            foreach (SamplingDensity level in new[]
+            {
+                SamplingDensity.Low,
+                SamplingDensity.Medium,
+                SamplingDensity.High
+            })
+            {
+                double score =
+                    Square(NormalizeLegacyDistance(minSampleInterval, GetMinSampleInterval(level), 0.95)) +
+                    Square(NormalizeLegacyDistance(maxSampleInterval, GetMaxSampleInterval(level), 9.0)) +
+                    Square(NormalizeLegacyDistance(velocityDirThreshold, GetVelocityDirThreshold(level), 9.5)) +
+                    Square(NormalizeLegacyDistance(speedChangeThreshold, GetSpeedChangeThreshold(level), 19.0));
+
+                if (score < bestScore)
+                {
+                    bestScore = score;
+                    bestLevel = level;
+                }
+            }
+
+            return bestLevel;
+        }
+
+        internal static bool TryReadLegacySamplingThresholds(
+            ConfigNode node,
+            out float minSampleInterval,
+            out float maxSampleInterval,
+            out float velocityDirThreshold,
+            out float speedChangeThreshold)
+        {
+            minSampleInterval = GetMinSampleInterval(SamplingDensity.Medium);
+            maxSampleInterval = GetMaxSampleInterval(SamplingDensity.Medium);
+            velocityDirThreshold = GetVelocityDirThreshold(SamplingDensity.Medium);
+            speedChangeThreshold = GetSpeedChangeThreshold(SamplingDensity.Medium);
+
+            if (node == null) return false;
+
+            bool sawLegacyField = false;
+            sawLegacyField |= TryReadFloat(node, LegacyMinSampleIntervalKey, ref minSampleInterval);
+            sawLegacyField |= TryReadFloat(node, LegacyMaxSampleIntervalKey, ref maxSampleInterval);
+            sawLegacyField |= TryReadFloat(node, LegacyVelocityDirThresholdKey, ref velocityDirThreshold);
+            sawLegacyField |= TryReadFloat(node, LegacySpeedChangeThresholdKey, ref speedChangeThreshold);
+            return sawLegacyField;
+        }
+
+        private static bool TryReadSamplingDensityFromConfig(ConfigNode node, out SamplingDensity level)
+        {
+            level = SamplingDensity.Medium;
+            string rawValue = GetConfigValueOrNull(node, SamplingDensityKey);
+            if (string.IsNullOrEmpty(rawValue))
+                return false;
+
+            if (!int.TryParse(rawValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out int parsed))
+                return false;
+            if (parsed < 0 || parsed > 2)
+                return false;
+
+            level = (SamplingDensity)parsed;
+            return true;
+        }
+
+        private static string GetConfigValueOrNull(ConfigNode node, string key)
+        {
+            if (node == null) return null;
+            string value = node.GetValue(key);
+            return string.IsNullOrEmpty(value) ? null : value;
+        }
+
+        private static bool TryReadFloat(ConfigNode node, string key, ref float value)
+        {
+            string rawValue = GetConfigValueOrNull(node, key);
+            if (rawValue == null)
+                return false;
+
+            if (float.TryParse(rawValue, NumberStyles.Float, CultureInfo.InvariantCulture, out float parsed))
+                value = parsed;
+            return true;
+        }
+
+        private static double NormalizeLegacyDistance(float actual, float preset, double range)
+            => (actual - preset) / range;
+
+        private static double Square(double value) => value * value;
     }
 }

--- a/Source/Parsek/UI/SettingsWindowUI.cs
+++ b/Source/Parsek/UI/SettingsWindowUI.cs
@@ -422,7 +422,7 @@ namespace Parsek
 
         private void DrawSamplingSettings(ParsekSettings s)
         {
-            GUILayout.Label("Recording Sampling Density", GUI.skin.box);
+            GUILayout.Label("Recorder Sample Density", GUI.skin.box);
 
             GUILayout.BeginHorizontal();
             foreach (SamplingDensity level in new[] { SamplingDensity.Low, SamplingDensity.Medium, SamplingDensity.High })

--- a/Source/Parsek/UI/SettingsWindowUI.cs
+++ b/Source/Parsek/UI/SettingsWindowUI.cs
@@ -5,7 +5,7 @@ namespace Parsek
 {
     /// <summary>
     /// Settings window extracted from ParsekUI.
-    /// Manages all Parsek settings: recording, looping, ghosts, diagnostics, sampling, data management.
+    /// Manages all Parsek settings: recording, looping, ghosts, diagnostics, sampling density, data management.
     /// </summary>
     internal class SettingsWindowUI
     {
@@ -192,10 +192,7 @@ namespace Parsek
                 s.autoMerge = false;
                 s.verboseLogging = true;
                 s.writeReadableSidecarMirrors = true;
-                s.minSampleInterval = 0.2f;
-                s.maxSampleInterval = 3.0f;
-                s.velocityDirThreshold = 2.0f;
-                s.speedChangeThreshold = 5.0f;
+                s.SamplingDensityLevel = SamplingDensity.Medium;
                 s.autoLoopIntervalSeconds = 10.0f;
                 s.autoLoopTimeUnit = 0;
                 s.ghostCameraCutoffKm = DistanceThresholds.GhostFlight.DefaultWatchCameraCutoffKm;
@@ -425,53 +422,27 @@ namespace Parsek
 
         private void DrawSamplingSettings(ParsekSettings s)
         {
-            GUILayout.Label("Sampling", GUI.skin.box);
+            GUILayout.Label("Recording Sampling Density", GUI.skin.box);
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label(new GUIContent($"Min interval: {s.minSampleInterval:F2}s",
-                "Minimum seconds between trajectory samples — caps sample rate during slow/jittery motion (e.g. EVA on surface)"),
-                GUILayout.Width(140));
-            float minSampleInterval = GUILayout.HorizontalSlider(s.minSampleInterval, 0.05f, 1f);
-            if (Mathf.Abs(minSampleInterval - s.minSampleInterval) > 0.0001f)
+            foreach (SamplingDensity level in new[] { SamplingDensity.Low, SamplingDensity.Medium, SamplingDensity.High })
             {
-                s.minSampleInterval = minSampleInterval;
-                ParsekLog.VerboseRateLimited("UI", "sampling.minSampleInterval",
-                    $"Setting changed: minSampleInterval={s.minSampleInterval:F2}s", 1.0);
+                bool isSelected = s.SamplingDensityLevel == level;
+                GUIStyle style = isSelected ? GUI.skin.box : GUI.skin.button;
+                if (GUILayout.Button(new GUIContent(ParsekSettings.DensityLabel(level),
+                    ParsekSettings.DensityTooltip(level)), style))
+                {
+                    if (!isSelected)
+                    {
+                        s.SamplingDensityLevel = level;
+                        ParsekLog.Info("UI", $"Setting changed: samplingDensity={level}");
+                    }
+                }
             }
             GUILayout.EndHorizontal();
 
-            GUILayout.BeginHorizontal();
-            GUILayout.Label($"Max interval: {s.maxSampleInterval:F1}s", GUILayout.Width(140));
-            float maxSampleInterval = GUILayout.HorizontalSlider(s.maxSampleInterval, 1f, 10f);
-            if (Mathf.Abs(maxSampleInterval - s.maxSampleInterval) > 0.0001f)
-            {
-                s.maxSampleInterval = maxSampleInterval;
-                ParsekLog.VerboseRateLimited("UI", "sampling.maxSampleInterval",
-                    $"Setting changed: maxSampleInterval={s.maxSampleInterval:F1}s", 1.0);
-            }
-            GUILayout.EndHorizontal();
-
-            GUILayout.BeginHorizontal();
-            GUILayout.Label($"Direction: {s.velocityDirThreshold:F1}\u00b0", GUILayout.Width(140));
-            float velocityDirThreshold = GUILayout.HorizontalSlider(s.velocityDirThreshold, 0.5f, 10f);
-            if (Mathf.Abs(velocityDirThreshold - s.velocityDirThreshold) > 0.0001f)
-            {
-                s.velocityDirThreshold = velocityDirThreshold;
-                ParsekLog.VerboseRateLimited("UI", "sampling.velocityDirThreshold",
-                    $"Setting changed: velocityDirThreshold={s.velocityDirThreshold:F1}", 1.0);
-            }
-            GUILayout.EndHorizontal();
-
-            GUILayout.BeginHorizontal();
-            GUILayout.Label($"Speed: {s.speedChangeThreshold:F0}%", GUILayout.Width(140));
-            float speedChangeThreshold = GUILayout.HorizontalSlider(s.speedChangeThreshold, 1f, 20f);
-            if (Mathf.Abs(speedChangeThreshold - s.speedChangeThreshold) > 0.0001f)
-            {
-                s.speedChangeThreshold = speedChangeThreshold;
-                ParsekLog.VerboseRateLimited("UI", "sampling.speedChangeThreshold",
-                    $"Setting changed: speedChangeThreshold={s.speedChangeThreshold:F0}%", 1.0);
-            }
-            GUILayout.EndHorizontal();
+            GUILayout.Label(ParsekSettings.DensitySummary(s.SamplingDensityLevel),
+                GUI.skin.label);
         }
 
         private void DrawDataManagementSettings(ParsekSettings s)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -118,9 +118,7 @@ Click the "Settings" button in the main Parsek window to open the Settings panel
 | Auto-record on launch | On | Start recording when a vessel leaves the pad/runway |
 | Auto-record on EVA | On | Start recording when a kerbal goes EVA from the pad |
 | Auto-stop time warp | On | Stop time warp when a ghost playback is about to begin |
-| Max sample interval | 3.0s | Maximum seconds between trajectory samples (1-10s) |
-| Direction threshold | 2.0° | Velocity direction change that triggers a new sample (0.5-10°) |
-| Speed threshold | 5% | Speed change that triggers a new sample (1-20%) |
+| Recording sampling density | Medium | Trajectory sampling precision: Low (smaller files), Medium (balanced), High (cinematic) |
 
 The "Defaults" button resets all settings to their original values.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -118,7 +118,7 @@ Click the "Settings" button in the main Parsek window to open the Settings panel
 | Auto-record on launch | On | Start recording when a vessel leaves the pad/runway |
 | Auto-record on EVA | On | Start recording when a kerbal goes EVA from the pad |
 | Auto-stop time warp | On | Stop time warp when a ghost playback is about to begin |
-| Recording sampling density | Medium | Trajectory sampling precision: Low (smaller files), Medium (balanced), High (cinematic) |
+| Recorder sample density | Medium | Trajectory sampling precision: Low (smaller files), Medium (balanced), High (cinematic) |
 
 The "Defaults" button resets all settings to their original values.
 


### PR DESCRIPTION
## Summary

- Replaced the four individual adaptive-sampling sliders (min/max interval, direction threshold, speed threshold) with a single **Recording Sampling Density** three-level preset: Low, Medium, High
- Medium matches previous defaults — no behavior change for existing users
- Low reduces sampling (~2.5x coarser) for performance-constrained systems; High increases density (~4x denser) for cinematic recordings
- UI shows three toggle buttons with tooltips and a summary line of effective thresholds
- Stored as a single `samplingDensity` int field; old per-field save data is silently ignored on load (defaults to Medium)

### Preset values

| Parameter | Low | Medium | High |
|---|---|---|---|
| Min interval | 0.5s | 0.2s | 0.05s |
| Max interval | 8.0s | 3.0s | 1.0s |
| Direction threshold | 6.0° | 2.0° | 0.5° |
| Speed threshold | 12% | 5% | 1% |

## Test plan

- [x] Build succeeds (`dotnet build`)
- [ ] `dotnet test` passes (fixture .sfs files updated)
- [ ] In-game: open Settings, verify "Recording Sampling Density" section shows Low/Medium/High buttons with Medium selected by default
- [ ] Click each button — summary line updates with correct thresholds
- [ ] Defaults button resets to Medium
- [ ] Tooltip appears on hover for each button
- [ ] Start a recording on each density level and verify ghost trajectory smoothness (Low = slightly angular on sharp turns, High = smooth)
- [ ] Save/load round-trip preserves the selected density level
- [ ] Old saves (with the four float fields) load without errors and default to Medium

https://claude.ai/code/session_01TtQxeBaYJGB1yhGxfUgeYq