### PR TITLE
Add timeline L (loop toggle) button for loopable recordings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Parsek are documented here.
 
 ## 0.8.2
 
+### Features
+
+- Added an **L** (loop toggle) button to the timeline for recordings that are logically loopable — launches, atmospheric descents, surface departures, and docking segments. The button sits after the R (rewind) button and uses the recording's existing saved loop interval. Active loops show green text for quick scanning.
+
 ### Tests
 
 - `#371` Added a `MergeInto` continuous-EVA boundary merge round-trip test covering v3 binary sidecar save/load/optimize/resave/reload, plus a companion assertion that the optimizer rejects orbital-phase pairs.

--- a/Source/Parsek.Tests/IsLoopableRecordingTests.cs
+++ b/Source/Parsek.Tests/IsLoopableRecordingTests.cs
@@ -60,9 +60,20 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void TerminalStateDocked_ReturnsTrue()
+        public void DockedTerminalState_WithoutDockTarget_ReturnsFalse()
         {
             var rec = new Recording { TerminalStateValue = TerminalState.Docked };
+            Assert.False(Recording.IsLoopableRecording(rec));
+        }
+
+        [Fact]
+        public void DockedTerminalState_WithDockTarget_ReturnsTrue()
+        {
+            var rec = new Recording
+            {
+                DockTargetVesselPid = 12345,
+                TerminalStateValue = TerminalState.Docked
+            };
             Assert.True(Recording.IsLoopableRecording(rec));
         }
 
@@ -83,7 +94,12 @@ namespace Parsek.Tests
         [Fact]
         public void Debris_ExcludedEvenWithDocking()
         {
-            var rec = new Recording { TerminalStateValue = TerminalState.Docked, IsDebris = true };
+            var rec = new Recording
+            {
+                DockTargetVesselPid = 12345,
+                TerminalStateValue = TerminalState.Docked,
+                IsDebris = true
+            };
             Assert.False(Recording.IsLoopableRecording(rec));
         }
 
@@ -122,7 +138,7 @@ namespace Parsek.Tests
             {
                 LaunchSiteName = "Runway",
                 SegmentPhase = "atmo",
-                TerminalStateValue = TerminalState.Docked
+                DockTargetVesselPid = 12345
             };
             Assert.True(Recording.IsLoopableRecording(rec));
         }

--- a/Source/Parsek.Tests/IsLoopableRecordingTests.cs
+++ b/Source/Parsek.Tests/IsLoopableRecordingTests.cs
@@ -1,0 +1,130 @@
+using Xunit;
+
+namespace Parsek.Tests
+{
+    public class IsLoopableRecordingTests
+    {
+        [Fact]
+        public void Null_ReturnsFalse()
+        {
+            Assert.False(Recording.IsLoopableRecording(null));
+        }
+
+        [Fact]
+        public void PlainRecording_ReturnsFalse()
+        {
+            var rec = new Recording();
+            Assert.False(Recording.IsLoopableRecording(rec));
+        }
+
+        [Fact]
+        public void LaunchSite_ReturnsTrue()
+        {
+            var rec = new Recording { LaunchSiteName = "LaunchPad" };
+            Assert.True(Recording.IsLoopableRecording(rec));
+        }
+
+        [Fact]
+        public void PrelaunchSituation_ReturnsTrue()
+        {
+            var rec = new Recording { StartSituation = "Prelaunch" };
+            Assert.True(Recording.IsLoopableRecording(rec));
+        }
+
+        [Fact]
+        public void AtmoPhase_ReturnsTrue()
+        {
+            var rec = new Recording { SegmentPhase = "atmo" };
+            Assert.True(Recording.IsLoopableRecording(rec));
+        }
+
+        [Fact]
+        public void ApproachPhase_ReturnsTrue()
+        {
+            var rec = new Recording { SegmentPhase = "approach" };
+            Assert.True(Recording.IsLoopableRecording(rec));
+        }
+
+        [Fact]
+        public void SurfacePhase_ReturnsTrue()
+        {
+            var rec = new Recording { SegmentPhase = "surface" };
+            Assert.True(Recording.IsLoopableRecording(rec));
+        }
+
+        [Fact]
+        public void DockTargetPid_ReturnsTrue()
+        {
+            var rec = new Recording { DockTargetVesselPid = 12345 };
+            Assert.True(Recording.IsLoopableRecording(rec));
+        }
+
+        [Fact]
+        public void TerminalStateDocked_ReturnsTrue()
+        {
+            var rec = new Recording { TerminalStateValue = TerminalState.Docked };
+            Assert.True(Recording.IsLoopableRecording(rec));
+        }
+
+        [Fact]
+        public void ExoPhase_NoOtherCriteria_ReturnsFalse()
+        {
+            var rec = new Recording { SegmentPhase = "exo" };
+            Assert.False(Recording.IsLoopableRecording(rec));
+        }
+
+        [Fact]
+        public void Debris_ExcludedEvenWithLaunchSite()
+        {
+            var rec = new Recording { LaunchSiteName = "LaunchPad", IsDebris = true };
+            Assert.False(Recording.IsLoopableRecording(rec));
+        }
+
+        [Fact]
+        public void Debris_ExcludedEvenWithDocking()
+        {
+            var rec = new Recording { TerminalStateValue = TerminalState.Docked, IsDebris = true };
+            Assert.False(Recording.IsLoopableRecording(rec));
+        }
+
+        [Fact]
+        public void OrbitalTerminalState_ReturnsFalse()
+        {
+            var rec = new Recording { TerminalStateValue = TerminalState.Orbiting };
+            Assert.False(Recording.IsLoopableRecording(rec));
+        }
+
+        [Fact]
+        public void BoardedTerminalState_ReturnsFalse()
+        {
+            var rec = new Recording { TerminalStateValue = TerminalState.Boarded };
+            Assert.False(Recording.IsLoopableRecording(rec));
+        }
+
+        [Fact]
+        public void DestroyedTerminalState_ReturnsFalse()
+        {
+            var rec = new Recording { TerminalStateValue = TerminalState.Destroyed };
+            Assert.False(Recording.IsLoopableRecording(rec));
+        }
+
+        [Fact]
+        public void FlyingSituation_NoOtherCriteria_ReturnsFalse()
+        {
+            var rec = new Recording { StartSituation = "Flying" };
+            Assert.False(Recording.IsLoopableRecording(rec));
+        }
+
+        [Fact]
+        public void MultipleLoopableCriteria_ReturnsTrue()
+        {
+            var rec = new Recording
+            {
+                LaunchSiteName = "Runway",
+                SegmentPhase = "atmo",
+                TerminalStateValue = TerminalState.Docked
+            };
+            Assert.True(Recording.IsLoopableRecording(rec));
+        }
+    }
+}

--- a/Source/Parsek.Tests/TimelineWindowUITests.cs
+++ b/Source/Parsek.Tests/TimelineWindowUITests.cs
@@ -1,0 +1,39 @@
+using Xunit;
+
+namespace Parsek.Tests
+{
+    public class TimelineWindowUITests
+    {
+        [Fact]
+        public void ShouldShowLoopToggle_FutureRecording_ReturnsFalse()
+        {
+            var rec = new Recording { LaunchSiteName = "LaunchPad" };
+
+            Assert.False(TimelineWindowUI.ShouldShowLoopToggle(rec, isFuture: true));
+        }
+
+        [Fact]
+        public void ShouldShowLoopToggle_PastLoopableRecording_ReturnsTrue()
+        {
+            var rec = new Recording { SegmentPhase = "atmo" };
+
+            Assert.True(TimelineWindowUI.ShouldShowLoopToggle(rec, isFuture: false));
+        }
+
+        [Fact]
+        public void ShouldShowLoopToggle_PastActiveLoopOutsideHeuristic_ReturnsTrue()
+        {
+            var rec = new Recording { LoopPlayback = true };
+
+            Assert.True(TimelineWindowUI.ShouldShowLoopToggle(rec, isFuture: false));
+        }
+
+        [Fact]
+        public void ShouldShowLoopToggle_PastNonLoopableInactiveRecording_ReturnsFalse()
+        {
+            var rec = new Recording();
+
+            Assert.False(TimelineWindowUI.ShouldShowLoopToggle(rec, isFuture: false));
+        }
+    }
+}

--- a/Source/Parsek/Recording.cs
+++ b/Source/Parsek/Recording.cs
@@ -712,10 +712,10 @@ namespace Parsek
             if (rec.SegmentPhase == "atmo" || rec.SegmentPhase == "approach" || rec.SegmentPhase == "surface")
                 return true;
 
-            // Docking segment (either started from dock or ended with dock)
+            // Actual docking segments record the other vessel's PID at the boundary.
+            // A plain Docked terminal state is too broad: some recordings simply stay
+            // docked in orbit and should not get the timeline loop toggle.
             if (rec.DockTargetVesselPid != 0)
-                return true;
-            if (rec.TerminalStateValue == TerminalState.Docked)
                 return true;
 
             return false;

--- a/Source/Parsek/Recording.cs
+++ b/Source/Parsek/Recording.cs
@@ -691,6 +691,37 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Returns true if this recording is "logically loopable" — a launch, atmospheric
+        /// descent, surface departure, or docking segment whose loop replay has visual value.
+        /// Used by the timeline L button to decide which entries get a loop toggle.
+        /// </summary>
+        internal static bool IsLoopableRecording(Recording rec)
+        {
+            if (rec == null || rec.IsDebris)
+                return false;
+
+            // Launch from pad/runway
+            if (!string.IsNullOrEmpty(rec.LaunchSiteName))
+                return true;
+
+            // Prelaunch start (e.g. pad without a named site)
+            if (rec.StartSituation == "Prelaunch")
+                return true;
+
+            // Atmospheric entry/exit or high-altitude approach
+            if (rec.SegmentPhase == "atmo" || rec.SegmentPhase == "approach" || rec.SegmentPhase == "surface")
+                return true;
+
+            // Docking segment (either started from dock or ended with dock)
+            if (rec.DockTargetVesselPid != 0)
+                return true;
+            if (rec.TerminalStateValue == TerminalState.Docked)
+                return true;
+
+            return false;
+        }
+
+        /// <summary>
         /// Resolves KSP localization keys (e.g., "#autoLOC_501220") to human-readable text
         /// via KSP.Localization.Localizer. Returns the input unchanged if it is not a
         /// localization key or if the Localizer is unavailable (e.g., unit tests).

--- a/Source/Parsek/UI/RecordingsTableUI.cs
+++ b/Source/Parsek/UI/RecordingsTableUI.cs
@@ -3026,6 +3026,15 @@ namespace Parsek
             }
         }
 
+        /// <summary>
+        /// Clears any active loop-period text-edit focus. Called by TimelineWindowUI
+        /// when the L button toggles loop off, so a stale edit field doesn't linger.
+        /// </summary>
+        internal void ClearLoopPeriodFocus()
+        {
+            loopPeriodFocusedRi = -1;
+        }
+
         // --- Loop period cell ---
 
         private void DrawLoopPeriodCell(Recording rec, int ri, double dur)

--- a/Source/Parsek/UI/TimelineWindowUI.cs
+++ b/Source/Parsek/UI/TimelineWindowUI.cs
@@ -495,8 +495,9 @@ namespace Parsek
                         GUI.enabled = true;
                     }
 
-                    // L (loop toggle) — only for past/active loopable recordings
-                    if (!isFuture && Recording.IsLoopableRecording(rec))
+                    // L (loop toggle) — show for past/active recordings that are loopable,
+                    // or any recording already looping so the timeline can still disable it.
+                    if (ShouldShowLoopToggle(rec, isFuture))
                     {
                         GUIStyle lStyle = rec.LoopPlayback ? loopActiveButtonStyle : GUI.skin.button;
                         string lTooltip = rec.LoopPlayback ? "Disable looping" : "Enable looping (uses saved interval)";
@@ -524,6 +525,13 @@ namespace Parsek
             }
 
             GUILayout.EndHorizontal();
+        }
+
+        internal static bool ShouldShowLoopToggle(Recording rec, bool isFuture)
+        {
+            return !isFuture
+                && rec != null
+                && (rec.LoopPlayback || Recording.IsLoopableRecording(rec));
         }
 
         private GUIStyle GetStyleForColor(Color color)

--- a/Source/Parsek/UI/TimelineWindowUI.cs
+++ b/Source/Parsek/UI/TimelineWindowUI.cs
@@ -51,6 +51,7 @@ namespace Parsek
         private GUIStyle timelineStrikethroughStyle;
         private GUIStyle timelineBlueStyle;
         private GUIStyle toggleButtonStyle;
+        private GUIStyle loopActiveButtonStyle;
 
         private int lastRetiredKerbalCount = -1;
 
@@ -188,6 +189,11 @@ namespace Parsek
             toggleButtonStyle.onHover.background = GUI.skin.button.active.background;
             toggleButtonStyle.onNormal.textColor = Color.white;
             toggleButtonStyle.onHover.textColor = Color.white;
+
+            // Loop active button: green-tinted text so active loops stand out in the timeline
+            loopActiveButtonStyle = new GUIStyle(GUI.skin.button);
+            loopActiveButtonStyle.normal.textColor = new Color(0.5f, 1f, 0.5f);
+            loopActiveButtonStyle.hover.textColor = new Color(0.5f, 1f, 0.5f);
         }
 
         private void DrawTimelineWindow(int windowID)
@@ -487,6 +493,20 @@ namespace Parsek
                             tableUI.ShowRewindConfirmation(rec);
                         }
                         GUI.enabled = true;
+                    }
+
+                    // L (loop toggle) — only for past/active loopable recordings
+                    if (!isFuture && Recording.IsLoopableRecording(rec))
+                    {
+                        GUIStyle lStyle = rec.LoopPlayback ? loopActiveButtonStyle : GUI.skin.button;
+                        string lTooltip = rec.LoopPlayback ? "Disable looping" : "Enable looping (uses saved interval)";
+                        if (GUILayout.Button(new GUIContent("L", lTooltip), lStyle, GUILayout.Width(25)))
+                        {
+                            rec.LoopPlayback = !rec.LoopPlayback;
+                            RecordingsTableUI.ApplyAutoLoopRange(rec, rec.LoopPlayback);
+                            ParsekLog.Info("Timeline",
+                                $"Loop toggled {(rec.LoopPlayback ? "ON" : "OFF")} for \"{rec.VesselName}\" id={rec.RecordingId}");
+                        }
                     }
 
                     // GoTo button — always last, right-aligned

--- a/Source/Parsek/UI/TimelineWindowUI.cs
+++ b/Source/Parsek/UI/TimelineWindowUI.cs
@@ -504,8 +504,10 @@ namespace Parsek
                         {
                             rec.LoopPlayback = !rec.LoopPlayback;
                             RecordingsTableUI.ApplyAutoLoopRange(rec, rec.LoopPlayback);
-                            ParsekLog.Info("Timeline",
-                                $"Loop toggled {(rec.LoopPlayback ? "ON" : "OFF")} for \"{rec.VesselName}\" id={rec.RecordingId}");
+                            if (!rec.LoopPlayback)
+                                tableUI?.ClearLoopPeriodFocus();
+                            ParsekLog.Info("UI",
+                                $"Timeline loop toggled {(rec.LoopPlayback ? "ON" : "OFF")} for \"{rec.VesselName}\" id={rec.RecordingId}");
                         }
                     }
 


### PR DESCRIPTION
## Summary

- Adds a small **L** button to the timeline (after R, before GoTo) that toggles loop playback for recordings that are logically loopable — launches, atmospheric descents, surface departures, and docking segments.
- New `Recording.IsLoopableRecording()` classifies recordings by: launch site, prelaunch situation, atmo/approach/surface segment phase, or docking state. Debris is always excluded.
- Active loops render with green text for quick visual scanning. Uses existing saved loop interval and auto-configures loop range via `ApplyAutoLoopRange`.

## Test plan

- [x] 15 unit tests in `IsLoopableRecordingTests.cs` cover all criteria, debris exclusion, and edge cases
- [x] `dotnet test` passes
- [ ] In-game: verify L button appears on launch recordings but not orbital/debris segments
- [ ] In-game: verify toggling L on/off matches the recordings table loop checkbox state
- [ ] In-game: verify green text on active loop buttons

https://claude.ai/code/session_01SrJ41WXMxWMth8tZBfJgBv