### PR TITLE
#386 #387 Map-marker renderer: stock icon mapping + hover/sticky label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,23 +4,17 @@ All notable changes to Parsek are documented here.
 
 ---
 
-## 0.8.3
-
-### Features
-
-- Add Gloops Flight Recorder window for manual ghost-only recordings. Manual recording controls (Start/Stop, Preview, Discard) moved from the main Parsek UI to a dedicated "Gloops Flight Recorder" window opened via a button in the main UI. Recordings are marked `IsGhostOnly` and never spawn a real vessel at playback end. They auto-commit on stop with looping enabled by default and are placed in the "Gloops Flight Recordings - Ghosts Only" group. Ghost-only recordings can run in parallel with the auto-recording system. An X (delete) button is added to the recordings table for ghost-only recordings.
-
----
-
 ## 0.8.2
 
 ### Features
 
+- Add Gloops Flight Recorder window for manual ghost-only recordings. Manual recording controls (Start/Stop, Preview, Discard) moved from the main Parsek UI to a dedicated "Gloops Flight Recorder" window opened via a button in the main UI. Recordings are marked `IsGhostOnly` and never spawn a real vessel at playback end. They auto-commit on stop with looping enabled by default and are placed in the "Gloops Flight Recordings - Ghosts Only" group. Ghost-only recordings can run in parallel with the auto-recording system. An X (delete) button is added to the recordings table for ghost-only recordings.
 - `#389` Timeline and Recordings windows now support a shared time-range filter. Quick presets (Last Day, Last 7d, Last 30d, This Year, All) and a collapsible custom-range dual-slider let you narrow both windows to a specific time slice — useful for navigating long careers with many missions. Recordings table shows a compact filter indicator with a Clear button so the active filter is visible even when the Timeline is closed.
 - Added an **L** (loop toggle) button to the timeline for recordings that are logically loopable — launches, atmospheric descents, surface departures, and docking segments. The button sits after the R (rewind) button and uses the recording's existing saved loop interval. Active loops show green text for quick scanning.
 
 ### Enhancements
 
+- `#386` Ghost map and tracking station icons now hide their label by default, show it on hover, and pin it on click — matching stock KSP vessel icons.
 - Replaced the four individual sampling sliders (min/max interval, direction threshold, speed threshold) with a single **Recorder Sample Density** setting offering three presets: Low (fewer samples, smaller files), Medium (balanced, same as previous defaults), and High (dense sampling for cinematic recordings). Existing slider-based saves now migrate their legacy thresholds to the nearest preset on load instead of silently defaulting to Medium, and the preset remains available from both the Parsek settings window and KSP's stock Game Parameters UI.
 
 ### Tests
@@ -50,6 +44,7 @@ All notable changes to Parsek are documented here.
 - `#409` Fixed a watch-mode overlap-vs-single dispatch mismatch for recordings with a loop subrange: `ResolveWatchPlaybackUT` and `TryStartWatchSession` now read the same `EffectiveLoopDuration` and cycle-start reference, so the two sites can no longer disagree on which playback path to take.
 - `#410` Fixed a one-frame `playing → paused → playing` flicker at exact loop-cycle boundaries — `ComputeLoopPhaseFromUT`, `TryComputeLoopPlaybackUT`, and the live flight/KSC loop schedulers now share a `BoundaryEpsilon` tolerance so they agree on the `isInPause` flag at `phase == duration`.
 - `#411` Loop playback now uses the effective loop subrange consistently in flight and KSC: the overlap-vs-single dispatch, overlap active-cycle bounds, overlap phase anchoring, and loop-end teardown/pause holds now read `EffectiveLoopDuration` / `EffectiveLoopStartUT` / `EffectiveLoopEndUT` instead of raw or hybrid recording ranges.
+- `#387` Ghost map icons now match stock ProtoVessel icons for each vessel type (Ship, Plane, Probe, Station, …).
 
 ### Maintenance
 

--- a/Source/Parsek.Tests/MapMarkerRendererTests.cs
+++ b/Source/Parsek.Tests/MapMarkerRendererTests.cs
@@ -1,0 +1,145 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Pure unit tests for <see cref="MapMarkerRenderer"/> — covers the decompiled
+    /// stock icon index table (#387), sticky-state toggle behavior (#386), and
+    /// the hover/sticky decision helper.
+    /// </summary>
+    [Collection("Sequential")]
+    public class MapMarkerRendererTests : System.IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public MapMarkerRendererTests()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+            MapMarkerRenderer.ResetForTesting();
+        }
+
+        public void Dispose()
+        {
+            MapMarkerRenderer.ResetForTesting();
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+        }
+
+        // #387 — the dict must match decompiled MapNode icon indices exactly.
+        // A regression here means ghosts will show a different vessel type's icon
+        // (the symptom users reported: ships appearing as stations, etc.).
+        [Fact]
+        public void StockIconIndexByVesselType_MatchesDecompiledMapNodeIndices()
+        {
+            var expected = new Dictionary<VesselType, int>
+            {
+                { VesselType.Station, 0 },
+                { VesselType.Base, 5 },
+                { VesselType.Debris, 7 },
+                { VesselType.Flag, 11 },
+                { VesselType.EVA, 13 },
+                { VesselType.Lander, 14 },
+                { VesselType.Probe, 18 },
+                { VesselType.Rover, 19 },
+                { VesselType.Ship, 20 },
+                { VesselType.SpaceObject, 21 },
+                { VesselType.Plane, 23 },
+                { VesselType.Relay, 24 },
+                { VesselType.DeployedScienceController, 28 },
+                { VesselType.DeployedGroundPart, 29 },
+            };
+
+            Assert.Equal(expected.Count, MapMarkerRenderer.StockIconIndexByVesselType.Count);
+            foreach (var kv in expected)
+            {
+                Assert.True(
+                    MapMarkerRenderer.StockIconIndexByVesselType.TryGetValue(kv.Key, out int actual),
+                    $"StockIconIndexByVesselType missing entry for {kv.Key}");
+                Assert.Equal(kv.Value, actual);
+            }
+        }
+
+        // #387 — the fix deliberately omits DeployedSciencePart (stock has no index
+        // for it; the renderer falls back to the diamond texture).
+        [Fact]
+        public void StockIconIndexByVesselType_OmitsDeployedSciencePart()
+        {
+            Assert.False(
+                MapMarkerRenderer.StockIconIndexByVesselType.ContainsKey(VesselType.DeployedSciencePart),
+                "DeployedSciencePart should fall back to the diamond, not an atlas index");
+        }
+
+        // #386 — toggling a fresh key adds it; toggling a present key removes it.
+        // Verified separately from DrawMarkerAtScreen because that path requires
+        // a live Unity GUI. Keeping the helper pure makes this directly testable.
+        [Fact]
+        public void ToggleSticky_AddsThenRemoves()
+        {
+            var set = new HashSet<string>();
+            Assert.True(MapMarkerRenderer.ToggleSticky("rec-1", set));
+            Assert.Contains("rec-1", set);
+            Assert.False(MapMarkerRenderer.ToggleSticky("rec-1", set));
+            Assert.DoesNotContain("rec-1", set);
+        }
+
+        [Fact]
+        public void ToggleSticky_IndependentKeys()
+        {
+            var set = new HashSet<string>();
+            MapMarkerRenderer.ToggleSticky("a", set);
+            MapMarkerRenderer.ToggleSticky("b", set);
+            Assert.Contains("a", set);
+            Assert.Contains("b", set);
+            MapMarkerRenderer.ToggleSticky("a", set);
+            Assert.DoesNotContain("a", set);
+            Assert.Contains("b", set);
+        }
+
+        [Fact]
+        public void ToggleSticky_RejectsNullOrEmptyKey()
+        {
+            var set = new HashSet<string>();
+            Assert.False(MapMarkerRenderer.ToggleSticky(null, set));
+            Assert.False(MapMarkerRenderer.ToggleSticky("", set));
+            Assert.Empty(set);
+        }
+
+        [Fact]
+        public void ToggleSticky_RejectsNullSet()
+        {
+            Assert.False(MapMarkerRenderer.ToggleSticky("x", null));
+        }
+
+        [Theory]
+        [InlineData(false, false, false)]
+        [InlineData(true,  false, true)]
+        [InlineData(false, true,  true)]
+        [InlineData(true,  true,  true)]
+        public void ShouldDrawLabel_ReturnsHoverOrSticky(bool hover, bool sticky, bool expected)
+        {
+            Assert.Equal(expected, MapMarkerRenderer.ShouldDrawLabel(hover, sticky));
+        }
+
+        // #386 — ResetForSceneChange clears sticky state (users expect stickies
+        // to survive toggle-on/off on the Tracking Station ghost filter #388 but
+        // to reset between scenes).
+        [Fact]
+        public void ResetForSceneChange_ClearsStickyAndLogsCount()
+        {
+            MapMarkerRenderer.ToggleSticky("rec-a", MapMarkerRenderer.StickyMarkersForTesting);
+            MapMarkerRenderer.ToggleSticky("rec-b", MapMarkerRenderer.StickyMarkersForTesting);
+            Assert.Equal(2, MapMarkerRenderer.StickyMarkersForTesting.Count);
+
+            MapMarkerRenderer.ResetForSceneChange();
+
+            Assert.Empty(MapMarkerRenderer.StickyMarkersForTesting);
+            Assert.Contains(logLines, l =>
+                l.Contains("[MapMarker]") &&
+                l.Contains("ResetForSceneChange") &&
+                l.Contains("2"));
+        }
+    }
+}

--- a/Source/Parsek/InGameTests/RuntimeTests.cs
+++ b/Source/Parsek/InGameTests/RuntimeTests.cs
@@ -348,6 +348,84 @@ namespace Parsek.InGameTests
         }
 
         #endregion
+
+        #region MapView icons (#387)
+
+        // Verify that MapMarkerRenderer's icon UVs match the live MapNode.iconSprites
+        // atlas for every vessel type in StockIconIndexByVesselType. Regressions here
+        // would mean ghost icons show a different vessel type's symbol (the symptom
+        // users reported before #387).
+        [InGameTest(Category = "MapView",
+            Description = "MapMarkerRenderer UVs match live MapNode.iconSprites for every stock vessel type (#387)")]
+        public void MapMarkerIconsMatchStockAtlas()
+        {
+            InGameAssert.IsNotNull(MapView.fetch,
+                "MapView.fetch should exist — test requires flight or tracking station scene");
+
+            // Force a fresh init against whatever atlas this scene resolves.
+            MapMarkerRenderer.ResetForSceneChange();
+
+            var prefab = MapView.UINodePrefab;
+            InGameAssert.IsNotNull(prefab, "MapView.UINodePrefab should not be null");
+
+            var fi = typeof(KSP.UI.Screens.Mapview.MapNode).GetField("iconSprites",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            InGameAssert.IsNotNull(fi, "MapNode.iconSprites field should be reflectable");
+
+            var sprites = fi.GetValue(prefab) as Sprite[];
+            InGameAssert.IsNotNull(sprites, "iconSprites should not be null");
+            InGameAssert.IsTrue(sprites.Length > 0, "iconSprites should not be empty");
+
+            // Run the atlas reflection/init without GUI context
+            // (InGameTestRunner coroutines don't always execute during OnGUI).
+            MapMarkerRenderer.ForceInitForTesting();
+
+            Texture2D atlas = MapMarkerRenderer.VesselIconAtlasForTesting;
+            InGameAssert.IsNotNull(atlas,
+                "MapMarkerRenderer atlas should be resolved after a draw call");
+
+            var uvs = MapMarkerRenderer.VesselIconUVsForTesting;
+            InGameAssert.IsNotNull(uvs, "MapMarkerRenderer UV dict should be built");
+
+            int verified = 0, missing = 0;
+            foreach (var kv in MapMarkerRenderer.StockIconIndexByVesselType)
+            {
+                int idx = kv.Value;
+                if (idx < 0 || idx >= sprites.Length || sprites[idx] == null
+                    || sprites[idx].texture != atlas)
+                {
+                    // Expected — renderer also skips these. Log and continue.
+                    missing++;
+                    ParsekLog.Verbose("TestRunner",
+                        $"MapView icon test: skipping {kv.Key} (idx={idx}, sprite/atlas mismatch)");
+                    continue;
+                }
+
+                Rect expectedRect = sprites[idx].textureRect;
+                Rect expectedUv = new Rect(
+                    expectedRect.x / atlas.width, expectedRect.y / atlas.height,
+                    expectedRect.width / atlas.width, expectedRect.height / atlas.height);
+
+                InGameAssert.IsTrue(uvs.TryGetValue(kv.Key, out Rect actualUv),
+                    $"UV dict missing entry for {kv.Key}");
+
+                InGameAssert.ApproxEqual(expectedUv.x, actualUv.x);
+                InGameAssert.ApproxEqual(expectedUv.y, actualUv.y);
+                InGameAssert.ApproxEqual(expectedUv.width, actualUv.width);
+                InGameAssert.ApproxEqual(expectedUv.height, actualUv.height);
+
+                verified++;
+                ParsekLog.Verbose("TestRunner",
+                    $"MapView icon {kv.Key} idx={idx} UV=({actualUv.x:F3},{actualUv.y:F3},{actualUv.width:F3},{actualUv.height:F3}) OK");
+            }
+
+            InGameAssert.IsTrue(verified > 0,
+                $"Expected at least one matching icon UV; verified={verified} missing={missing}");
+            ParsekLog.Info("TestRunner",
+                $"MapMarkerIconsMatchStockAtlas: verified={verified} missing={missing} total={MapMarkerRenderer.StockIconIndexByVesselType.Count}");
+        }
+
+        #endregion
     }
 
     /// <summary>

--- a/Source/Parsek/MapMarkerRenderer.cs
+++ b/Source/Parsek/MapMarkerRenderer.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
+using System.Globalization;
 using System.Reflection;
+using System.Text;
 using KSP.UI.Screens.Mapview;
 using UnityEngine;
 
@@ -7,24 +9,76 @@ namespace Parsek
 {
     /// <summary>
     /// Static helper for drawing ghost vessel map markers via OnGUI.
-    /// Extracts the rendering primitive from ParsekUI so it can be shared
-    /// between flight scene (ParsekUI.DrawMapMarkers) and tracking station
-    /// (ParsekTrackingStation.OnGUI). No dependency on ParsekFlight or
-    /// any scene-specific state.
+    /// Shared between flight-scene map view (ParsekUI.DrawMapMarkers via
+    /// <see cref="DrawMarkerAtScreen"/>) and the tracking station
+    /// (ParsekTrackingStation.OnGUI via <see cref="DrawMarker"/>).
     ///
-    /// Uses the same KSP atlas icons and projection math as ParsekUI:
-    /// worldPos → ScaledSpace → PlanetariumCamera → screen coordinates.
+    /// Icon lookup uses <see cref="StockIconIndexByVesselType"/> — indices
+    /// taken from the decompiled stock KSP.UI.Screens.Mapview.MapNode logic,
+    /// so ghost icons match stock ProtoVessel icons for every VesselType (#387).
+    ///
+    /// Label has stock-style hover/sticky behavior: hidden by default, shown on
+    /// hover, pinned by click (#386). Sticky set is keyed by recording ID and
+    /// cleared on scene change. The custom marker is only drawn when the stock
+    /// MapNode for the same recording is absent or suppressed, so there is no
+    /// double-labeling when a ghost ProtoVessel exists.
     /// </summary>
     internal static class MapMarkerRenderer
     {
+        private const string Tag = "MapMarker";
+        private const int IconSize = 20;
+        private const int ClickPadding = 6; // add to each side of the icon for easier hit-testing
+
+        // VesselType -> sprite index in MapNode.iconSprites, taken from the
+        // decompiled KSP.UI.Screens.Mapview.MapNode icon-index lookup.
+        // KSP-version dependent: if the atlas is reordered, these indices
+        // must be updated. Missing entries fall back to the diamond texture.
+        // Exposed as IReadOnlyDictionary so tests can iterate it without
+        // any caller being able to mutate the shared table.
+        internal static readonly IReadOnlyDictionary<VesselType, int> StockIconIndexByVesselType =
+            new Dictionary<VesselType, int>
+            {
+                { VesselType.Station, 0 },
+                { VesselType.Base, 5 },
+                { VesselType.Debris, 7 },
+                { VesselType.Flag, 11 },
+                { VesselType.EVA, 13 },
+                { VesselType.Lander, 14 },
+                { VesselType.Probe, 18 },
+                { VesselType.Rover, 19 },
+                { VesselType.Ship, 20 },
+                { VesselType.SpaceObject, 21 },
+                { VesselType.Plane, 23 },
+                { VesselType.Relay, 24 },
+                { VesselType.DeployedScienceController, 28 },
+                { VesselType.DeployedGroundPart, 29 },
+            };
+
         private static Texture2D vesselIconAtlas;
         private static Dictionary<VesselType, Rect> vesselIconUVs;
         private static Texture2D fallbackDiamond;
         private static GUIStyle labelStyle;
+        private static bool initAttempted;
+
+        /// <summary>
+        /// Recording IDs whose label is pinned open. Toggled by click-on-icon.
+        /// Keyed by rec.RecordingId (stable across index reuse, see bug #279).
+        /// </summary>
+        private static readonly HashSet<string> stickyMarkers = new HashSet<string>();
+
+        /// <summary>Test-only accessor for sticky state.</summary>
+        internal static HashSet<string> StickyMarkersForTesting => stickyMarkers;
+
+        /// <summary>Test-only accessor for the computed UV cache.</summary>
+        internal static IReadOnlyDictionary<VesselType, Rect> VesselIconUVsForTesting => vesselIconUVs;
+
+        /// <summary>Test-only accessor for the atlas texture resolved at init.</summary>
+        internal static Texture2D VesselIconAtlasForTesting => vesselIconAtlas;
 
         /// <summary>
         /// Returns the orbit color for a ghost marker by vessel type.
-        /// Matches KSP's own orbit color scheme — same table as ParsekUI.GetGhostMarkerColorForType.
+        /// Matches KSP's own orbit color scheme — single source of truth used
+        /// by both ParsekUI (flight) and ParsekTrackingStation (TS).
         /// </summary>
         internal static Color GetColorForType(VesselType vtype)
         {
@@ -43,41 +97,175 @@ namespace Parsek
             }
         }
 
-        internal static void DrawMarker(Vector3d worldPos, string label, Color color,
+        /// <summary>
+        /// Draw a marker for a world-space position (tracking station path).
+        /// Projects through <see cref="PlanetariumCamera"/> — map-only.
+        /// </summary>
+        internal static void DrawMarker(
+            Vector3d worldPos, string markerKey, string label, Color color,
+            VesselType vtype = VesselType.Ship)
+        {
+            if (PlanetariumCamera.Camera == null) return;
+
+            Vector3d scaledPos = ScaledSpace.LocalToScaledSpace(worldPos);
+            Vector3 screenPos = PlanetariumCamera.Camera.WorldToScreenPoint(scaledPos);
+            if (screenPos.z < 0) return; // behind camera
+
+            DrawMarkerAtScreen(new Vector2(screenPos.x, screenPos.y), markerKey, label, color, vtype);
+        }
+
+        /// <summary>
+        /// Draw a marker from an already-projected screen position (flight-scene path).
+        /// ParsekUI picks between FlightCamera and PlanetariumCamera itself, then
+        /// calls this overload so the camera branch isn't duplicated here.
+        /// </summary>
+        /// <param name="screenPos">Unity screen-space coordinates (origin bottom-left,
+        /// as returned by Camera.WorldToScreenPoint). Caller must have already handled
+        /// the z &lt; 0 behind-camera case.</param>
+        internal static void DrawMarkerAtScreen(
+            Vector2 screenPos, string markerKey, string label, Color color,
             VesselType vtype = VesselType.Ship)
         {
             EnsureResources();
 
-            Vector3d scaledPos = ScaledSpace.LocalToScaledSpace(worldPos);
-            Vector3 screenPos = PlanetariumCamera.Camera.WorldToScreenPoint(scaledPos);
-
-            if (screenPos.z < 0) return; // behind camera
-
             float x = screenPos.x;
             float y = Screen.height - screenPos.y; // GUI Y is inverted
 
+            Rect iconRect = new Rect(x - IconSize / 2f, y - IconSize / 2f, IconSize, IconSize);
+
+            // Draw the icon.
             Color prevColor = GUI.color;
-            int iconSize = 20;
             Rect uvRect;
             if (vesselIconAtlas != null && vesselIconUVs != null
                 && vesselIconUVs.TryGetValue(vtype, out uvRect))
             {
                 GUI.color = Color.white;
-                GUI.DrawTextureWithTexCoords(
-                    new Rect(x - iconSize / 2, y - iconSize / 2, iconSize, iconSize),
-                    vesselIconAtlas, uvRect);
+                GUI.DrawTextureWithTexCoords(iconRect, vesselIconAtlas, uvRect);
             }
             else if (fallbackDiamond != null)
             {
                 GUI.color = color;
-                GUI.DrawTexture(
-                    new Rect(x - iconSize / 2, y - iconSize / 2, iconSize, iconSize),
-                    fallbackDiamond);
+                GUI.DrawTexture(iconRect, fallbackDiamond);
             }
             GUI.color = prevColor;
 
-            labelStyle.normal.textColor = color;
-            GUI.Label(new Rect(x - 75, y + iconSize / 2 + 2, 150, 20), "Ghost: " + label, labelStyle);
+            // Label hover / sticky / click (#386).
+            bool sticky = !string.IsNullOrEmpty(markerKey) && stickyMarkers.Contains(markerKey);
+            bool hover = false;
+
+            if (Event.current != null && AllowClickInteraction())
+            {
+                Rect hitRect = new Rect(
+                    iconRect.x - ClickPadding, iconRect.y - ClickPadding,
+                    iconRect.width + ClickPadding * 2, iconRect.height + ClickPadding * 2);
+                hover = hitRect.Contains(Event.current.mousePosition);
+
+                if (hover
+                    && !string.IsNullOrEmpty(markerKey)
+                    && Event.current.type == EventType.MouseDown
+                    && Event.current.button == 0)
+                {
+                    bool nowSticky = ToggleSticky(markerKey, stickyMarkers);
+                    sticky = nowSticky;
+                    Event.current.Use();
+                    ParsekLog.Info(Tag,
+                        string.Format(CultureInfo.InvariantCulture,
+                            "Ghost icon '{0}' label sticky={1} key={2}",
+                            label ?? "(null)", nowSticky ? "on" : "off", markerKey));
+                }
+            }
+
+            if (ShouldDrawLabel(hover, sticky))
+            {
+                labelStyle.normal.textColor = color;
+                GUI.Label(
+                    new Rect(x - 75, y + IconSize / 2 + 2, 150, 20),
+                    "Ghost: " + (label ?? "(unknown)"),
+                    labelStyle);
+            }
+        }
+
+        /// <summary>
+        /// Pure: should the label be drawn given (hover, sticky)?
+        /// Kept as an internal helper so the decision table is readable
+        /// at call sites even though its body is trivial.
+        /// </summary>
+        internal static bool ShouldDrawLabel(bool hover, bool sticky) => hover || sticky;
+
+        /// <summary>
+        /// Pure: flip the sticky state for <paramref name="key"/> in <paramref name="set"/>.
+        /// Returns the new state (true = now sticky, false = now not sticky).
+        /// </summary>
+        internal static bool ToggleSticky(string key, HashSet<string> set)
+        {
+            if (set == null || string.IsNullOrEmpty(key)) return false;
+            if (set.Contains(key))
+            {
+                set.Remove(key);
+                return false;
+            }
+            set.Add(key);
+            return true;
+        }
+
+        /// <summary>
+        /// Reset sticky state and force icon re-init on the next draw.
+        /// Called from ParsekFlight.OnSceneChangeRequested and
+        /// ParsekTrackingStation.OnDestroy so each scene rebuilds its
+        /// icon atlas against the sprite atlas that scene actually uses.
+        /// Also destroys the generated fallback-diamond texture so the
+        /// re-created one on next scene doesn't leak its predecessor.
+        /// </summary>
+        internal static void ResetForSceneChange()
+        {
+            int stickyCount = stickyMarkers.Count;
+            stickyMarkers.Clear();
+            initAttempted = false;
+            vesselIconAtlas = null;
+            vesselIconUVs = null;
+            if (fallbackDiamond != null)
+            {
+                UnityEngine.Object.Destroy(fallbackDiamond);
+                fallbackDiamond = null;
+            }
+            ParsekLog.Info(Tag,
+                string.Format(CultureInfo.InvariantCulture,
+                    "ResetForSceneChange: cleared {0} sticky marker(s), forced icon re-init",
+                    stickyCount));
+        }
+
+        /// <summary>Pure test hook — reset everything including fallback resources.</summary>
+        internal static void ResetForTesting()
+        {
+            stickyMarkers.Clear();
+            initAttempted = false;
+            vesselIconAtlas = null;
+            vesselIconUVs = null;
+            fallbackDiamond = null;
+            labelStyle = null;
+        }
+
+        /// <summary>
+        /// Test-only: run the icon atlas reflection/init path without requiring
+        /// a GUI context. Used by the in-game MapView icon verification test
+        /// (InGameTestRunner coroutines don't always execute during OnGUI).
+        /// </summary>
+        internal static void ForceInitForTesting()
+        {
+            if (MapView.fetch != null)
+                InitVesselTypeIcons();
+        }
+
+        /// <summary>
+        /// Gate click / hover interaction to map-view-ish scenes.
+        /// Without this, a flight-scene main-window click that happens to overlap
+        /// a projected ghost marker position could double-fire (#386 edge case).
+        /// </summary>
+        private static bool AllowClickInteraction()
+        {
+            if (HighLogic.LoadedScene == GameScenes.TRACKSTATION) return true;
+            if (MapView.MapIsEnabled) return true;
+            return false;
         }
 
         private static void EnsureResources()
@@ -109,24 +297,15 @@ namespace Parsek
             }
         }
 
-        private static bool initAttempted;
-
         private static void InitVesselTypeIcons()
         {
-            if (initAttempted) return; // only try once per session
-
-            vesselIconAtlas = MapView.OrbitIconsMap;
-            if (vesselIconAtlas == null)
-            {
-                ParsekLog.Verbose("MapMarker", "InitVesselTypeIcons: OrbitIconsMap is null");
-                return;
-            }
+            if (initAttempted) return; // one attempt per scene; ResetForSceneChange clears this
+            initAttempted = true;
 
             var prefab = MapView.UINodePrefab;
             if (prefab == null)
             {
-                ParsekLog.Verbose("MapMarker", "InitVesselTypeIcons: UINodePrefab is null");
-                vesselIconAtlas = null;
+                ParsekLog.Verbose(Tag, "InitVesselTypeIcons: UINodePrefab is null");
                 return;
             }
 
@@ -134,34 +313,22 @@ namespace Parsek
                 BindingFlags.Instance | BindingFlags.NonPublic);
             if (fi == null)
             {
-                ParsekLog.Warn("MapMarker", "InitVesselTypeIcons: iconSprites field not found");
-                vesselIconAtlas = null;
-                initAttempted = true;
+                ParsekLog.Warn(Tag, "InitVesselTypeIcons: iconSprites field not found");
                 return;
             }
 
             var sprites = fi.GetValue(prefab) as Sprite[];
             if (sprites == null || sprites.Length == 0)
             {
-                ParsekLog.Warn("MapMarker",
-                    $"InitVesselTypeIcons: iconSprites is null or empty (sprites={sprites?.Length ?? 0})");
-                vesselIconAtlas = null;
-                initAttempted = true;
+                ParsekLog.Warn(Tag, string.Format(CultureInfo.InvariantCulture,
+                    "InitVesselTypeIcons: iconSprites is null or empty (sprites={0})",
+                    sprites == null ? 0 : sprites.Length));
                 return;
             }
 
-            vesselIconUVs = new Dictionary<VesselType, Rect>();
-            var vtypes = new[] {
-                VesselType.Ship, VesselType.Plane, VesselType.Probe,
-                VesselType.Relay, VesselType.Rover, VesselType.Lander,
-                VesselType.Station, VesselType.Base, VesselType.EVA,
-                VesselType.Flag, VesselType.Debris, VesselType.SpaceObject,
-                VesselType.DeployedScienceController, VesselType.DeployedSciencePart
-            };
-
-            // Use the sprite's own texture as atlas — in the tracking station,
-            // MapView.OrbitIconsMap may be a different Texture2D instance than
-            // the sprite atlas texture. The sprites from UINodePrefab are authoritative.
+            // Pick the first non-null sprite's texture as atlas. MapView.OrbitIconsMap
+            // may point at a different Texture2D instance than the sprite atlas in
+            // the tracking station, so the sprite is authoritative.
             Texture2D spriteAtlas = null;
             for (int i = 0; i < sprites.Length; i++)
             {
@@ -171,30 +338,61 @@ namespace Parsek
                     break;
                 }
             }
-
             if (spriteAtlas == null)
             {
-                ParsekLog.Warn("MapMarker", "InitVesselTypeIcons: no sprite has a texture");
-                vesselIconAtlas = null;
-                initAttempted = true;
+                ParsekLog.Warn(Tag, "InitVesselTypeIcons: no sprite has a texture");
                 return;
             }
 
             vesselIconAtlas = spriteAtlas;
+            vesselIconUVs = new Dictionary<VesselType, Rect>();
+            float atlasW = spriteAtlas.width;
+            float atlasH = spriteAtlas.height;
 
-            for (int i = 0; i < vtypes.Length && i < sprites.Length; i++)
+            int loaded = 0, outOfRange = 0, mismatchedAtlas = 0, missingSprite = 0;
+            var summary = new StringBuilder();
+
+            foreach (var kv in StockIconIndexByVesselType)
             {
-                Sprite s = sprites[i];
-                if (s == null) continue;
+                int idx = kv.Value;
+                if (idx < 0 || idx >= sprites.Length)
+                {
+                    outOfRange++;
+                    continue;
+                }
+                Sprite s = sprites[idx];
+                if (s == null)
+                {
+                    missingSprite++;
+                    continue;
+                }
+                if (s.texture != spriteAtlas)
+                {
+                    mismatchedAtlas++;
+                    ParsekLog.Warn(Tag, string.Format(CultureInfo.InvariantCulture,
+                        "InitVesselTypeIcons: {0} sprite at index {1} uses texture '{2}' " +
+                        "different from resolved atlas '{3}' — skipping",
+                        kv.Key, idx,
+                        s.texture != null ? s.texture.name : "(null)",
+                        spriteAtlas.name));
+                    continue;
+                }
+
                 Rect r = s.textureRect;
-                vesselIconUVs[vtypes[i]] = new Rect(
-                    r.x / spriteAtlas.width, r.y / spriteAtlas.height,
-                    r.width / spriteAtlas.width, r.height / spriteAtlas.height);
+                var uv = new Rect(r.x / atlasW, r.y / atlasH, r.width / atlasW, r.height / atlasH);
+                vesselIconUVs[kv.Key] = uv;
+                loaded++;
+                summary.AppendFormat(CultureInfo.InvariantCulture,
+                    " {0}=[{1}]({2:F3},{3:F3},{4:F3},{5:F3})",
+                    kv.Key, idx, uv.x, uv.y, uv.width, uv.height);
             }
 
-            initAttempted = true;
-            ParsekLog.Info("MapMarker",
-                $"InitVesselTypeIcons: loaded {vesselIconUVs.Count} vessel type icons from atlas ({sprites.Length} sprites)");
+            ParsekLog.Info(Tag, string.Format(CultureInfo.InvariantCulture,
+                "InitVesselTypeIcons: loaded={0} outOfRange={1} missingSprite={2} " +
+                "mismatchedAtlas={3} atlas={4}x{5} spriteCount={6}",
+                loaded, outOfRange, missingSprite, mismatchedAtlas,
+                atlasW, atlasH, sprites.Length));
+            ParsekLog.Verbose(Tag, "InitVesselTypeIcons UVs:" + summary);
         }
     }
 }

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -981,6 +981,12 @@ namespace Parsek
             watchMode.ExitWatchMode();
             InputLockManager.RemoveControlLock(WatchModeController.WatchModeLockId); // safety net
 
+            // Clear ghost-icon sticky state and force atlas re-init so the next
+            // scene loads its own sprite atlas (the tracking station and flight
+            // scenes may resolve different Texture2D instances for the same
+            // logical atlas). See MapMarkerRenderer.ResetForSceneChange.
+            MapMarkerRenderer.ResetForSceneChange();
+
             // Finalize continuation sampling before anything else
             chainManager.StopAllContinuations("scene change");
 

--- a/Source/Parsek/ParsekTrackingStation.cs
+++ b/Source/Parsek/ParsekTrackingStation.cs
@@ -67,7 +67,14 @@ namespace Parsek
             // Draw icons for recordings in atmospheric phases (no ProtoVessel).
             // Position comes directly from trajectory point interpolation —
             // same approach as ParsekUI.DrawMapMarkers in the flight scene.
-            if (Event.current.type != EventType.Repaint) return;
+            // NOTE: we must let MouseDown events through so the hover/click
+            // sticky-label handling in MapMarkerRenderer (#386) can consume
+            // clicks. Previously this gate short-circuited on anything but
+            // Repaint, which made the click-to-pin interaction dead in TS.
+            var etype = Event.current.type;
+            if (etype != EventType.Repaint
+                && etype != EventType.MouseDown
+                && etype != EventType.MouseUp) return;
             if (PlanetariumCamera.Camera == null) return;
 
             var committed = RecordingStore.CommittedRecordings;
@@ -99,7 +106,8 @@ namespace Parsek
 
                 VesselType vtype = ResolveVesselTypeWithFallback(committed, rec);
                 Color markerColor = MapMarkerRenderer.GetColorForType(vtype);
-                MapMarkerRenderer.DrawMarker(worldPos, rec.VesselName ?? "(unknown)", markerColor, vtype);
+                MapMarkerRenderer.DrawMarker(
+                    worldPos, rec.RecordingId, rec.VesselName ?? "(unknown)", markerColor, vtype);
 
                 ParsekLog.VerboseRateLimited(Tag, $"atmosMarker-{i}",
                     $"Drawing atmospheric marker #{i} \"{rec.VesselName}\" " +
@@ -166,6 +174,10 @@ namespace Parsek
         void OnDestroy()
         {
             GhostMapPresence.RemoveAllGhostVessels("tracking-station-cleanup");
+            // Clear ghost-icon sticky state and force atlas re-init when leaving TS.
+            // Flight scene's own OnSceneChangeRequested hook runs too, but this
+            // addon is the only always-present TS listener — keep it defensive.
+            MapMarkerRenderer.ResetForSceneChange();
             ParsekLog.Info(Tag, "ParsekTrackingStation destroyed");
         }
     }

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using ClickThroughFix;
-using KSP.UI.Screens.Mapview;
 using UnityEngine;
 
 namespace Parsek
@@ -24,11 +22,8 @@ namespace Parsek
         // Opaque window style (replaces KSP's semi-transparent default)
         private GUIStyle opaqueWindowStyle;
 
-        // Map view markers
-        private GUIStyle mapMarkerStyle;
-        private Texture2D mapMarkerDiamond; // fallback when atlas unavailable
-        private static Texture2D vesselIconAtlas;
-        private static Dictionary<VesselType, Rect> vesselIconUVs;
+        // Map view markers: icon atlas, fallback texture, label style, hover/sticky
+        // state all live in MapMarkerRenderer (shared with ParsekTrackingStation).
 
         // Recordings table window (extracted to RecordingsTableUI)
         private RecordingsTableUI recordingsTableUI;
@@ -598,12 +593,11 @@ namespace Parsek
                 if (FlightCamera.fetch == null || FlightCamera.fetch.mainCamera == null) return;
             }
 
-            EnsureMapMarkerResources();
-
-            // Manual preview ghost
+            // Manual preview ghost. Uses a fixed marker key so hover/sticky state is
+            // consistent across frames, and a "Preview" display label.
             if (flight.IsPlaying && flight.PreviewGhost != null)
             {
-                DrawMapMarkerAt(flight.PreviewGhost.transform.position, "Preview",
+                DrawMapMarkerAt(flight.PreviewGhost.transform.position, "preview", "Preview",
                     new Color(0.2f, 1f, 0.4f, 0.9f));
             }
 
@@ -676,11 +670,14 @@ namespace Parsek
                 }
 
                 string ghostName = kvp.Key < committed.Count ? committed[kvp.Key].VesselName : "Ghost";
+                // Use RecordingId as marker key so hover/sticky state follows the recording,
+                // not the array index (which may shuffle when recordings are added/removed).
+                string markerKey = kvp.Key < committed.Count ? committed[kvp.Key].RecordingId : null;
                 VesselType vtype = kvp.Key < committed.Count
                     ? GhostMapPresence.ResolveVesselType(committed[kvp.Key].VesselSnapshot)
                     : VesselType.Ship;
                 Color markerColor = GetGhostMarkerColorForType(vtype);
-                DrawMapMarkerAt(markerPos, ghostName, markerColor, vtype);
+                DrawMapMarkerAt(markerPos, markerKey, ghostName, markerColor, vtype);
             }
         }
 
@@ -761,8 +758,8 @@ namespace Parsek
             timelineUI.ReleaseInputLock();
             settingsUI.ReleaseInputLock();
             spawnControlUI.ReleaseInputLock();
-            if (mapMarkerDiamond != null)
-                UnityEngine.Object.Destroy(mapMarkerDiamond);
+            // Map marker resources (icon atlas, fallback diamond, label style) are
+            // owned by MapMarkerRenderer and reset per scene via ResetForSceneChange.
         }
 
         /// <summary>
@@ -775,142 +772,32 @@ namespace Parsek
             return MapMarkerRenderer.GetColorForType(vtype);
         }
 
-        private void DrawMapMarkerAt(Vector3 worldPos, string label, Color color,
+        /// <summary>
+        /// Flight-scene marker draw. Picks FlightCamera or PlanetariumCamera based on
+        /// current view, then delegates to <see cref="MapMarkerRenderer.DrawMarkerAtScreen"/>
+        /// so icon lookup, label hover/sticky, and click handling all stay in one place.
+        /// </summary>
+        private void DrawMapMarkerAt(Vector3 worldPos, string markerKey, string label, Color color,
             VesselType vtype = VesselType.Ship)
         {
             Vector3 screenPos;
             if (MapView.MapIsEnabled)
             {
                 Vector3d scaledPos = ScaledSpace.LocalToScaledSpace(worldPos);
+                if (PlanetariumCamera.Camera == null) return;
                 screenPos = PlanetariumCamera.Camera.WorldToScreenPoint(scaledPos);
             }
             else
             {
+                if (FlightCamera.fetch == null || FlightCamera.fetch.mainCamera == null) return;
                 screenPos = FlightCamera.fetch.mainCamera.WorldToScreenPoint(worldPos);
             }
 
             // Behind camera
             if (screenPos.z < 0) return;
 
-            // GUI coordinates (Y inverted)
-            float x = screenPos.x;
-            float y = Screen.height - screenPos.y;
-
-            // Draw vessel type icon from KSP atlas (untinted — original icon colors)
-            Color prevColor = GUI.color;
-            int iconSize = 20;
-            Rect uvRect;
-            if (vesselIconAtlas != null && vesselIconUVs != null
-                && vesselIconUVs.TryGetValue(vtype, out uvRect))
-            {
-                GUI.color = Color.white;
-                GUI.DrawTextureWithTexCoords(
-                    new Rect(x - iconSize / 2, y - iconSize / 2, iconSize, iconSize),
-                    vesselIconAtlas, uvRect);
-            }
-            else
-            {
-                GUI.color = color;
-                GUI.DrawTexture(
-                    new Rect(x - iconSize / 2, y - iconSize / 2, iconSize, iconSize),
-                    mapMarkerDiamond);
-            }
-            GUI.color = prevColor;
-
-            // Draw vessel name label
-            mapMarkerStyle.normal.textColor = color;
-            GUI.Label(new Rect(x - 75, y + iconSize / 2 + 2, 150, 20), "Ghost: " + label, mapMarkerStyle);
-        }
-
-        private void EnsureMapMarkerResources()
-        {
-            // Try to load KSP's stock vessel icon atlas from the MapView prefab
-            if (vesselIconAtlas == null && MapView.fetch != null)
-                InitVesselTypeIcons();
-
-            // Fallback diamond texture (used when atlas unavailable)
-            if (mapMarkerDiamond == null)
-            {
-                int size = 16;
-                mapMarkerDiamond = new Texture2D(size, size, TextureFormat.ARGB32, false);
-                float center = size / 2f;
-                float halfDiag = size / 2f - 1f;
-                for (int py = 0; py < size; py++)
-                {
-                    for (int px = 0; px < size; px++)
-                    {
-                        float manhattan = Mathf.Abs(px - center + 0.5f) + Mathf.Abs(py - center + 0.5f);
-                        mapMarkerDiamond.SetPixel(px, py, manhattan <= halfDiag ? Color.white : Color.clear);
-                    }
-                }
-                mapMarkerDiamond.Apply();
-            }
-
-            if (mapMarkerStyle == null)
-            {
-                mapMarkerStyle = new GUIStyle(GUI.skin.label);
-                mapMarkerStyle.fontSize = 11;
-                mapMarkerStyle.fontStyle = FontStyle.Bold;
-                mapMarkerStyle.alignment = TextAnchor.UpperCenter;
-            }
-        }
-
-        private static void InitVesselTypeIcons()
-        {
-            vesselIconAtlas = MapView.OrbitIconsMap;
-            if (vesselIconAtlas == null) return;
-
-            var prefab = MapView.UINodePrefab;
-            if (prefab == null) return;
-
-            var fi = typeof(MapNode).GetField("iconSprites",
-                BindingFlags.Instance | BindingFlags.NonPublic);
-            if (fi == null)
-            {
-                ParsekLog.Warn("UI", "InitVesselTypeIcons: iconSprites field not found on MapNode");
-                vesselIconAtlas = null;
-                return;
-            }
-
-            var sprites = fi.GetValue(prefab) as Sprite[];
-            if (sprites == null || sprites.Length == 0)
-            {
-                ParsekLog.Warn("UI", "InitVesselTypeIcons: iconSprites is null or empty");
-                vesselIconAtlas = null;
-                return;
-            }
-
-            // VesselType -> sprite index mapping from decompiled MapNode.GetIconIndex.
-            // KSP-version-dependent: indices may change if the atlas is reordered.
-            // Failure is graceful — falls back to diamond texture.
-            var mapping = new Dictionary<VesselType, int>
-            {
-                { VesselType.Ship,        20 }, { VesselType.Probe,    18 },
-                { VesselType.Rover,       19 }, { VesselType.Station,   0 },
-                { VesselType.Plane,       23 }, { VesselType.Lander,   14 },
-                { VesselType.Base,         5 }, { VesselType.EVA,      13 },
-                { VesselType.Relay,       24 }, { VesselType.Debris,    7 },
-                { VesselType.SpaceObject, 21 },
-            };
-
-            float atlasW = vesselIconAtlas.width;
-            float atlasH = vesselIconAtlas.height;
-            vesselIconUVs = new Dictionary<VesselType, Rect>();
-
-            foreach (var kvp in mapping)
-            {
-                if (kvp.Value < sprites.Length && sprites[kvp.Value] != null)
-                {
-                    Rect texRect = sprites[kvp.Value].textureRect;
-                    vesselIconUVs[kvp.Key] = new Rect(
-                        texRect.x / atlasW, texRect.y / atlasH,
-                        texRect.width / atlasW, texRect.height / atlasH);
-                }
-            }
-
-            ParsekLog.Info("UI",
-                $"InitVesselTypeIcons: loaded {vesselIconUVs.Count} vessel type icons from atlas " +
-                $"({atlasW}x{atlasH}, {sprites.Length} sprites)");
+            MapMarkerRenderer.DrawMarkerAtScreen(
+                new Vector2(screenPos.x, screenPos.y), markerKey, label, color, vtype);
         }
 
         /// <summary>

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -776,7 +776,9 @@ Start with **option 1** (SettingsWindowUI checkbox). It's enough for the feature
 
 ---
 
-## 387. Ghost map icons don't match stock ProtoVessel icons for the same VesselType
+## ~~387. Ghost map icons don't match stock ProtoVessel icons for the same VesselType~~ (DONE — 0.8.2)
+
+Fixed by replacing the sequential-index loop in `MapMarkerRenderer.InitVesselTypeIcons` with a `StockIconIndexByVesselType` dict taken from the decompiled `KSP.UI.Screens.Mapview.MapNode` icon lookup, and consolidating the duplicate flight-scene copy in `ParsekUI.cs` into the same renderer. In-game runtime test `MapMarkerIconsMatchStockAtlas` pins every vessel type's UV against the live `MapNode.iconSprites` array.
 
 **Source:** maintenance request `2026-04-14`. Users report that Parsek's custom ghost icon in map view / tracking station sometimes looks different from the stock icon for the same vessel type. Root cause confirmed by decompiling `KSP.UI.Screens.Mapview.MapNode` — Parsek's atlas-indexing logic is wrong.
 
@@ -887,7 +889,9 @@ A unit test is insufficient here — this needs the live `MapView` reflection ta
 
 ---
 
-## 386. Map view / tracking station ghost icon: hide label by default, show on hover, sticky-toggle on click
+## ~~386. Map view / tracking station ghost icon: hide label by default, show on hover, sticky-toggle on click~~ (DONE — 0.8.2)
+
+Fixed by adding a `stickyMarkers` set and `markerKey` parameter to `MapMarkerRenderer.DrawMarker`/`DrawMarkerAtScreen`, threading `rec.RecordingId` from both call sites (`ParsekUI.DrawMapMarkers`, `ParsekTrackingStation.OnGUI`), and resetting stickies on scene change from `ParsekFlight.OnSceneChangeRequested` + `ParsekTrackingStation.OnDestroy`. Click interaction is gated to `MapView.MapIsEnabled || TRACKSTATION` so flight main-window clicks don't double-fire.
 
 **Source:** maintenance request `2026-04-14`. Parsek's custom ghost map icon currently always draws a `"Ghost: <name>"` text label directly below it. Stock KSP vessel icons don't — they only show the name on hover (and clicking enters/pins the target). The ghost icon should match that behavior so the map view isn't cluttered with permanent text for every ghost.
 


### PR DESCRIPTION
## Summary

Two linked map-marker fixes that both ride on a consolidation of duplicate code between `MapMarkerRenderer` (tracking station) and `ParsekUI` (flight-scene map view).

- **#387 Ghost map icons now match stock ProtoVessel icons.** The old `MapMarkerRenderer.InitVesselTypeIcons` assumed `sprites[i]` matched `VesselType[i]` in an arbitrary-order array — so ghost Ships rendered as Stations, Planes as Probes, etc. Fixed with a `StockIconIndexByVesselType` dict taken from decompiled `KSP.UI.Screens.Mapview.MapNode` (Ship=20, Station=0, Debris=7, Flag=11, EVA=13, Lander=14, Probe=18, Rover=19, SpaceObject=21, Plane=23, Relay=24, Base=5, DeployedScienceController=28, DeployedGroundPart=29). `DeployedSciencePart` is deliberately omitted — stock has no index for it, so it falls back to the diamond texture, matching stock behavior.
- **#386 Ghost icon label now hidden by default, hover to show, click to pin.** Previously `"Ghost: <name>"` was drawn unconditionally under every marker, cluttering the map. Added `markerKey` parameter (threaded from `rec.RecordingId`), a sticky set, and hover/click handling inside `MapMarkerRenderer`. Click gating is restricted to `MapView.MapIsEnabled || TRACKSTATION` so flight main-window clicks that happen to overlap a projected marker can't double-fire.
- **Flight-scene and TS now share one renderer.** `ParsekUI` deleted its local `vesselIconAtlas` / `vesselIconUVs` / `mapMarkerDiamond` / `mapMarkerStyle` / `InitVesselTypeIcons` / `EnsureMapMarkerResources` and now calls `MapMarkerRenderer.DrawMarkerAtScreen` with an already-projected screen position (it still picks `FlightCamera` vs `PlanetariumCamera` locally). Previously both files had their own icon lookup; the flight-side copy was already correct but partial, and the TS-side copy was the broken one.
- **Scene-reset hooks wired.** `ParsekFlight.OnSceneChangeRequested` and `ParsekTrackingStation.OnDestroy` now call `MapMarkerRenderer.ResetForSceneChange`, which clears stickies, destroys the generated fallback-diamond texture, and nulls `initAttempted` so the icon atlas re-resolves against whatever sprite atlas the next scene loads. Without this reset the previous-scene atlas would leak across, which was the root cause of the cross-scene texture mismatch the old code papered over.
- **Tracking station `OnGUI` accepts mouse events.** Previously a `Repaint`-only early-return swallowed `MouseDown` entirely, so the click-to-pin path would never have fired in TS. Relaxed to let `MouseDown` / `MouseUp` through.

Tests:

- `Source/Parsek.Tests/MapMarkerRendererTests.cs` — 11 xUnit tests covering the exact stock icon indices, `DeployedSciencePart` omission, `ToggleSticky` add/remove/independence/null-safety, `ShouldDrawLabel` decision table, and `ResetForSceneChange` clearing + log emission.
- `Source/Parsek/InGameTests/RuntimeTests.cs` `MapMarkerIconsMatchStockAtlas` — reflects `MapNode.iconSprites` at runtime and asserts every `StockIconIndexByVesselType` entry's computed UV matches `sprites[idx].textureRect` normalized by the atlas texture dimensions. Catches KSP atlas reorders immediately.

## Test plan

- [x] `dotnet build` — 0 errors, 0 code warnings.
- [x] `dotnet test` — 6469 passed, 0 failed (was 6458 before; +11 new).
- [x] Deployed DLL verified: `StockIconIndexByVesselType`, `ResetForSceneChange`, `ToggleSticky`, `DrawMarkerAtScreen`, `"Ghost icon"`, `"sticky="` all present.
- [ ] In-game: open TS with ghost recordings, confirm every vessel-type ghost now shows the correct stock icon.
- [ ] In-game: hover a ghost icon, label appears; click, label pins; click again, label unpins.
- [ ] In-game: switch between Flight and TS, confirm no sticky label leak and no icon regression.
- [ ] In-game: run `MapMarkerIconsMatchStockAtlas` runtime test via Ctrl+Shift+T.