### PR TITLE
Close T61: salvage regression tests + post-compression storage rebaseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,11 @@ All notable changes to Parsek are documented here.
 
 ---
 
-## 0.8.3
-
-### Features
-
-- Add Gloops Flight Recorder window for manual ghost-only recordings. Manual recording controls (Start/Stop, Preview, Discard) moved from the main Parsek UI to a dedicated "Gloops Flight Recorder" window opened via a button in the main UI. Recordings are marked `IsGhostOnly` and never spawn a real vessel at playback end. They auto-commit on stop with looping enabled by default and are placed in the "Gloops Flight Recordings - Ghosts Only" group. Ghost-only recordings can run in parallel with the auto-recording system. An X (delete) button is added to the recordings table for ghost-only recordings.
-
----
-
 ## 0.8.2
 
 ### Features
 
+- Add Gloops Flight Recorder window for manual ghost-only recordings. Manual recording controls (Start/Stop, Preview, Discard) moved from the main Parsek UI to a dedicated "Gloops Flight Recorder" window opened via a button in the main UI. Recordings are marked `IsGhostOnly` and never spawn a real vessel at playback end. They auto-commit on stop with looping enabled by default and are placed in the "Gloops Flight Recordings - Ghosts Only" group. Ghost-only recordings can run in parallel with the auto-recording system. An X (delete) button is added to the recordings table for ghost-only recordings.
 - `#389` Timeline and Recordings windows now support a shared time-range filter. Quick presets (Last Day, Last 7d, Last 30d, This Year, All) and a collapsible custom-range dual-slider let you narrow both windows to a specific time slice — useful for navigating long careers with many missions. Recordings table shows a compact filter indicator with a Clear button so the active filter is visible even when the Timeline is closed.
 - Added an **L** (loop toggle) button to the timeline for recordings that are logically loopable — launches, atmospheric descents, surface departures, and docking segments. The button sits after the R (rewind) button and uses the recording's existing saved loop interval. Active loops show green text for quick scanning.
 
@@ -33,6 +26,11 @@ All notable changes to Parsek are documented here.
 - `T67` Replaced the skipped Unity-GameObject xUnit priming test with an in-game runtime test (`GhostPlayback.SpawnGhost_PrimesFreshGhostToCurrentPlaybackUT_InGame`) so `dotnet test` runs clean without losing `GhostPlaybackEngine.SpawnGhost` priming coverage.
 - `T63` Pinned `KerbalsModule.ApplyToRoster` real-roster `Remove` path against a reflected `KerbalRoster` instance in `KerbalLoadDiagnosticsTests`, confirming unused displaced stand-in deletion works end-to-end through the real adapter.
 - `T66` Added in-game runtime regression for PR #288 fresh watch-entry camera orientation -- pins canonical pitch/heading and guards against the 180-degree flip.
+- `T61` Added two hydration-salvage regression tests: one drives a save after `RestoreHydrationFailedRecordingsFromPendingTree` and pins that the `.prec` sidecar is rewritten, the epoch advances, and `FilesDirty` clears; the other covers a mixed-case tree with three failed recordings where only a subset is restorable from the pending tree and asserts the restore count plus the snapshot-only/full accounting in the summary log.
+
+### Documentation
+
+- `T61` Refreshed the live storage rebaseline in `docs/dev/research/phase-11-5-recording-storage-baseline.md` against the April 14-16 playtest bundles; post-compression `.prec` and `_ghost.craft` are now roughly equal buckets at around 46% each of the authoritative payload, so further snapshot-side shrink work is measurement-gated rather than pre-committed.
 
 ### Bug Fixes
 

--- a/Source/Parsek.Tests/QuickloadResumeTests.cs
+++ b/Source/Parsek.Tests/QuickloadResumeTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
 using Xunit;
 
@@ -778,6 +779,146 @@ namespace Parsek.Tests
             Assert.True(loadedRec.SidecarLoadFailed);
             Assert.Equal("snapshot-ghost-invalid", loadedRec.SidecarLoadFailureReason);
             Assert.False(loadedRec.FilesDirty);
+        }
+
+        [Fact]
+        public void RestoreHydrationFailedRecordingsFromPendingTree_ThenSaveRecordingFiles_HealsSidecarsAndClearsFilesDirty()
+        {
+            // T61 end-to-end slice: prove a later save after salvage actually rewrites
+            // the .prec sidecar to disk and clears FilesDirty. The other salvage tests
+            // stop at "FilesDirty = true" after restore; this one drives the subsequent
+            // SaveRecordingFilesToPathsForTesting call and asserts the resulting bytes.
+            var pendingTree = MakeTree("tree_t61_heal", "Pending", 2);
+            var pendingChild = pendingTree.Recordings["child_tree_t61_heal_1"];
+            pendingChild.VesselName = "Pending Child";
+            // The v3 binary writer requires bodyName to be non-null on every point.
+            // MakeTree leaves it unset; set it explicitly on the points that will be
+            // DeepCloned into the disk tree so the post-salvage save path succeeds.
+            for (int i = 0; i < pendingChild.Points.Count; i++)
+            {
+                var p = pendingChild.Points[i];
+                p.bodyName = "Kerbin";
+                pendingChild.Points[i] = p;
+            }
+            pendingChild.Points.Add(new TrajectoryPoint { ut = 999, bodyName = "Kerbin" });
+            RecordingStore.StashPendingTree(pendingTree, PendingTreeState.Limbo);
+
+            var loadedTree = MakeTree("tree_t61_heal", "Disk", 2);
+            loadedTree.Recordings["child_tree_t61_heal_1"].SidecarLoadFailed = true;
+            loadedTree.Recordings["child_tree_t61_heal_1"].SidecarLoadFailureReason = "trajectory-missing";
+            int preSaveEpoch = loadedTree.Recordings["child_tree_t61_heal_1"].SidecarEpoch;
+
+            int restored = ParsekScenario.RestoreHydrationFailedRecordingsFromPendingTree(loadedTree);
+            Assert.Equal(1, restored);
+
+            Recording restoredRec = loadedTree.Recordings["child_tree_t61_heal_1"];
+            Assert.True(restoredRec.FilesDirty);
+            Assert.False(restoredRec.SidecarLoadFailed);
+            Assert.Equal("Pending Child", restoredRec.VesselName);
+            Assert.Equal(3, restoredRec.Points.Count);
+
+            string dir = Path.Combine(Path.GetTempPath(),
+                "parsek-t61-salvage-save-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            bool? previousMirrorOverride = RecordingStore.WriteReadableSidecarMirrorsOverrideForTesting;
+            RecordingStore.WriteReadableSidecarMirrorsOverrideForTesting = false;
+            try
+            {
+                string precPath = Path.Combine(dir, restoredRec.RecordingId + ".prec");
+                string vesselPath = Path.Combine(dir, restoredRec.RecordingId + "_vessel.craft");
+                string ghostPath = Path.Combine(dir, restoredRec.RecordingId + "_ghost.craft");
+
+                Assert.True(RecordingStore.SaveRecordingFilesToPathsForTesting(
+                    restoredRec, precPath, vesselPath, ghostPath, incrementEpoch: true));
+
+                Assert.False(restoredRec.FilesDirty);
+                Assert.Equal(preSaveEpoch + 1, restoredRec.SidecarEpoch);
+                Assert.True(File.Exists(precPath));
+                Assert.False(File.Exists(vesselPath));
+                Assert.False(File.Exists(ghostPath));
+
+                TrajectorySidecarProbe probe;
+                Assert.True(RecordingStore.TryProbeTrajectorySidecar(precPath, out probe));
+                Assert.Equal(restoredRec.SidecarEpoch, probe.SidecarEpoch);
+            }
+            finally
+            {
+                RecordingStore.WriteReadableSidecarMirrorsOverrideForTesting = previousMirrorOverride;
+                try { Directory.Delete(dir, true); }
+                catch { /* best-effort cleanup; test has already asserted */ }
+            }
+        }
+
+        [Fact]
+        public void RestoreHydrationFailedRecordingsFromPendingTree_MixedRestorabilitySubset_RestoresOnlyTheRecoverableRecordings()
+        {
+            // T61 mixed-case: one tree with three SidecarLoadFailed recordings; one full
+            // restore, one snapshot-only restore, one unrecoverable because the pending
+            // tree no longer has a matching id. Confirms the salvage loop counts exactly
+            // the restorable subset and leaves unrecoverable entries in their disk state.
+            var pendingTree = MakeTree("tree_t61_mixed", "Pending", 4);
+
+            var pendingFull = pendingTree.Recordings["child_tree_t61_mixed_1"];
+            pendingFull.VesselName = "Pending Full";
+            pendingFull.Points.Add(new TrajectoryPoint { ut = 999 });
+
+            var pendingSnapshot = pendingTree.Recordings["child_tree_t61_mixed_2"];
+            pendingSnapshot.VesselSnapshot = BuildSnapshot("Pending Snapshot Vessel", 7601);
+            pendingSnapshot.GhostVisualSnapshot = BuildSnapshot("Pending Snapshot Ghost", 7602);
+            pendingSnapshot.GhostSnapshotMode = GhostSnapshotMode.Separate;
+
+            pendingTree.Recordings.Remove("child_tree_t61_mixed_3");
+
+            RecordingStore.StashPendingTree(pendingTree, PendingTreeState.Limbo);
+
+            var loadedTree = MakeTree("tree_t61_mixed", "Disk", 4);
+
+            var loadedFull = loadedTree.Recordings["child_tree_t61_mixed_1"];
+            loadedFull.SidecarLoadFailed = true;
+            loadedFull.SidecarLoadFailureReason = "trajectory-missing";
+
+            var loadedSnapshot = loadedTree.Recordings["child_tree_t61_mixed_2"];
+            loadedSnapshot.VesselSnapshot = BuildSnapshot("Disk Snapshot Vessel", 7701);
+            loadedSnapshot.GhostSnapshotMode = GhostSnapshotMode.Separate;
+            loadedSnapshot.SidecarLoadFailed = true;
+            loadedSnapshot.SidecarLoadFailureReason = "snapshot-ghost-invalid";
+
+            var loadedMissing = loadedTree.Recordings["child_tree_t61_mixed_3"];
+            loadedMissing.SidecarLoadFailed = true;
+            loadedMissing.SidecarLoadFailureReason = "snapshot-ghost-invalid";
+            int missingPointCountBefore = loadedMissing.Points.Count;
+
+            logLines.Clear();
+            int restored = ParsekScenario.RestoreHydrationFailedRecordingsFromPendingTree(loadedTree);
+
+            Assert.Equal(2, restored);
+
+            Assert.Equal("Pending Full", loadedTree.Recordings["child_tree_t61_mixed_1"].VesselName);
+            Assert.Equal(3, loadedTree.Recordings["child_tree_t61_mixed_1"].Points.Count);
+            Assert.True(loadedTree.Recordings["child_tree_t61_mixed_1"].FilesDirty);
+            Assert.False(loadedTree.Recordings["child_tree_t61_mixed_1"].SidecarLoadFailed);
+
+            var restoredSnapshot = loadedTree.Recordings["child_tree_t61_mixed_2"];
+            Assert.Equal(2, restoredSnapshot.Points.Count);
+            Assert.Equal(120, restoredSnapshot.Points[0].ut);
+            Assert.Equal(130, restoredSnapshot.Points[1].ut);
+            Assert.Equal("Disk Snapshot Vessel", restoredSnapshot.VesselSnapshot.GetValue("name"));
+            Assert.Equal("Pending Snapshot Ghost", restoredSnapshot.GhostVisualSnapshot.GetValue("name"));
+            Assert.True(restoredSnapshot.FilesDirty);
+            Assert.False(restoredSnapshot.SidecarLoadFailed);
+
+            Assert.True(loadedMissing.SidecarLoadFailed);
+            Assert.Equal("snapshot-ghost-invalid", loadedMissing.SidecarLoadFailureReason);
+            Assert.False(loadedMissing.FilesDirty);
+            Assert.Equal(missingPointCountBefore, loadedMissing.Points.Count);
+
+            Assert.Equal("Disk #0", loadedTree.Recordings["root_tree_t61_mixed"].VesselName);
+            Assert.False(loadedTree.Recordings["root_tree_t61_mixed"].FilesDirty);
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[Scenario]")
+                && l.Contains("restored 2 hydration-failed recording")
+                && l.Contains("(1 snapshot-only, 1 full)"));
         }
 
         // ============================================================

--- a/docs/dev/research/phase-11-5-recording-storage-baseline.md
+++ b/docs/dev/research/phase-11-5-recording-storage-baseline.md
@@ -62,9 +62,10 @@ The regression corpus now proves two size relations:
 1. binary `v2` is smaller than equivalent text `v1`
 2. sparse binary `v3` is smaller than equivalent legacy binary `v2` when those fields are stable
 
-## Live `v3` Rebaseline
+## Live `v3` Rebaseline (pre-compression)
 
-Measured from the live `v3` playtest bundles:
+Measured from the live `v3` playtest bundles written before the April 13 snapshot
+compression slice landed:
 
 - `logs/2026-04-12_1857_phase-11-5-storage-followup-test-career/`
 - `logs/2026-04-12_1857_phase-11-5-storage-followup-s4/`
@@ -86,12 +87,43 @@ Combined:
 - `_vessel.craft` snapshots: `370,479` bytes (`20.5%`)
 - `_ghost.craft` snapshots: `1,155,027` bytes (`63.9%`)
 
-This is the key Phase 11.5 storage outcome:
+That snapshot of the pre-compression world identified `_ghost.craft` as the next clear
+optimization target.
 
-1. trajectory sidecars stopped being the dominant storage bucket
-2. snapshot-side payload is now the next clear optimization target
-3. the next PR should focus on `_ghost.craft` / `_vessel.craft` size rather than more speculative
-   `.prec` work
+## Post-Compression `v3` Rebaseline
+
+The April 13 snapshot compression slice (Deflate-compressed `_vessel.craft` / `_ghost.craft`
+via `SnapshotSidecarCodec`) changes the picture. Measured across the five most recent playtest
+bundles that include a `parsek/Recordings/` payload, all post-compression:
+
+| bundle | `.prec` | `_vessel.craft` | `_ghost.craft` | AUTH total | readable-mirror total |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `logs/2026-04-16_0100_383-flame-test/` | `321,885` B (`53.1%`) | `45,360` B (`7.5%`) | `239,030` B (`39.4%`) | `606,275` B | `1,227,458` B |
+| `logs/2026-04-15_2034_showcase-loop-perf/` | `639,778` B (`46.2%`) | `18,491` B (`1.3%`) | `726,752` B (`52.5%`) | `1,385,021` B | `1,227,458` B |
+| `logs/2026-04-15_0005_c1-career-bugs/` | `23,894` B (`57.9%`) | `4,105` B (`9.9%`) | `13,267` B (`32.1%`) | `41,266` B | `264,865` B |
+| `logs/2026-04-14_2108_watch-camera-final/` | `137,311` B (`37.4%`) | `105,253` B (`28.7%`) | `124,413` B (`33.9%`) | `366,977` B | `3,039,478` B |
+| `logs/2026-04-14_1459_ghost-engine-fix-smoke/` | `146,107` B (`42.7%`) | `47,275` B (`13.8%`) | `149,136` B (`43.5%`) | `342,518` B | `2,127,314` B |
+
+Combined across all five bundles:
+
+- total authoritative sidecar payload: `2,742,057` bytes (`2.62 MiB`)
+- `.prec` trajectory sidecars: `1,268,975` bytes (`46.3%`) across `585` distinct recording ids
+- `_vessel.craft` snapshots: `220,484` bytes (`8.0%`)
+- `_ghost.craft` snapshots: `1,252,598` bytes (`45.7%`)
+- readable-mirror total: `7,886,573` bytes (`7.52 MiB`)
+- authoritative payload is `34.8%` of the readable mirror size (`65.2%` saved)
+- recordings with both snapshots: `40`; vessel-only (alias or missing ghost): `10`; ghost-only:
+  `533` (most recordings in these bundles are showcase / gloops-style that never had a live
+  vessel counterpart, which is why `_vessel.craft` is so small)
+
+This is the current Phase 11.5 storage outcome after the compression + readable-mirror slices:
+
+1. `.prec` (`46.3%`) and `_ghost.craft` (`45.7%`) are now roughly equal buckets; neither
+   dominates
+2. `_vessel.craft` is small and mostly swallowed by alias mode or by the ghost-only recording
+   mix in recent bundles
+3. further snapshot-side or trajectory-side shrink work only makes sense if a future corpus
+   shows one of those buckets growing disproportionately against this baseline
 
 ## Current Format Pressure Points
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -2964,10 +2964,10 @@ without unpacking the authoritative files first.
 Remaining high-value work should stay measurement-gated and follow
 `docs/dev/done/plans/phase-11-5-recording-storage-optimization.md`:
 
-- fresh live-corpus rebaseline against current `v3` sidecars
-- snapshot-side work should keep focusing on `_ghost.craft` / `_vessel.craft` bytes, where the remaining storage bulk still lives after the first lossless compression slice
+- ~~fresh live-corpus rebaseline against current `v3` sidecars~~ — done; the current post-compression split (`.prec` `46.3%`, `_vessel.craft` `8.0%`, `_ghost.craft` `45.7%` across five April-14-to-16 bundles) is captured in the `Post-Compression v3 Rebaseline` section of `docs/dev/research/phase-11-5-recording-storage-baseline.md`
+- any further snapshot-side work now has to clear a higher bar: `.prec` and `_ghost.craft` are already roughly equal buckets after compression, and `_vessel.craft` is small, so "focus on snapshots next" only applies if a future corpus shifts the split back toward snapshots
 - keep the readable mirror path strictly diagnostic: authoritative load/save stays on `.prec` / `.craft`, mirror failures stay non-fatal, and stale mirrors should continue to reconcile cleanly on flag changes
-- only pursue intra-save snapshot dedupe or any custom binary snapshot schema if the post-compression rebaseline still shows a meaningful measured win
+- only pursue intra-save snapshot dedupe or any custom binary snapshot schema if a future rebaseline against a larger / more vessel-heavy corpus shows a meaningful measured win
 - additional sparse payload work only where exact reconstruction and real byte wins are proven
 - post-commit, error-bounded trajectory thinning only after the format wins are re-measured
 - snapshot-only hydration salvage must keep the loaded disk trajectory authoritative; if pending-tree data is used to heal bad snapshot sidecars, it should restore only snapshot state, not overwrite trajectory/timing with future in-memory data
@@ -2975,12 +2975,12 @@ Remaining high-value work should stay measurement-gated and follow
 - any further snapshot-side work should preserve current alias semantics, keep the
   missing-only ghost fallback contract, keep partial-write rollback safety intact, and stay
   covered by sidecar/load diagnostics
-- add an end-to-end active-tree salvage test that proves a later `OnSave` rewrites healed sidecars
-  and clears `FilesDirty`
-- add a mixed-case salvage test where several recordings fail hydration but only a subset can be
-  restored from the matching pending tree
+- ~~add an end-to-end active-tree salvage test that proves a later `OnSave` rewrites healed sidecars
+  and clears `FilesDirty`~~ — done via `QuickloadResumeTests.RestoreHydrationFailedRecordingsFromPendingTree_ThenSaveRecordingFiles_HealsSidecarsAndClearsFilesDirty`
+- ~~add a mixed-case salvage test where several recordings fail hydration but only a subset can be
+  restored from the matching pending tree~~ — done via `QuickloadResumeTests.RestoreHydrationFailedRecordingsFromPendingTree_MixedRestorabilitySubset_RestoresOnlyTheRecoverableRecordings`
 
-**Priority:** Current Phase 11.5 follow-on work
+**Priority:** Current Phase 11.5 follow-on work — the concrete shipped/rebaseline items above are closed; remaining bullets are measurement-gated guidance for future shrink work rather than active tasks
 
 ---
 


### PR DESCRIPTION
## Summary

Closes out the three concrete items remaining in `T61. Continue Phase 11.5 recording storage shrink work`.

### Tests

Two new unit tests in `Source/Parsek.Tests/QuickloadResumeTests.cs`:

- `RestoreHydrationFailedRecordingsFromPendingTree_ThenSaveRecordingFiles_HealsSidecarsAndClearsFilesDirty` — the existing salvage tests stop at `FilesDirty=true`; this one drives `SaveRecordingFilesToPathsForTesting` afterward and pins that the `.prec` sidecar is rewritten on disk, `SidecarEpoch` advances, `FilesDirty` clears, and `TryProbeTrajectorySidecar` round-trips the new epoch.
- `RestoreHydrationFailedRecordingsFromPendingTree_MixedRestorabilitySubset_RestoresOnlyTheRecoverableRecordings` — a 4-recording tree with three `SidecarLoadFailed=true` children in three distinct configurations (trajectory full restore, snapshot-only restore, snapshot failure but id missing from pending tree). Asserts `restored == 2`, per-recording outcomes, and the `(1 snapshot-only, 1 full)` summary log.

### Storage rebaseline

Rewrites the `Live v3 Rebaseline` section of `docs/dev/research/phase-11-5-recording-storage-baseline.md` against five post-compression playtest bundles from April 14-16, 2026:

| bucket | bytes | % of AUTH |
| --- | ---: | ---: |
| `.prec` | `1,268,975` | `46.3%` |
| `_vessel.craft` | `220,484` | `8.0%` |
| `_ghost.craft` | `1,252,598` | `45.7%` |
| **AUTH total** | **`2,742,057`** (`2.62 MiB`) | |
| readable-mirror total | `7,886,573` (`7.52 MiB`) | |

Authoritative is `34.8%` of the readable mirror size (`65.2%` saved). `.prec` and `_ghost.craft` are now roughly equal buckets, so further snapshot-side shrink work is measurement-gated rather than pre-committed as the next target.

### TODO / CHANGELOG cleanup

- `docs/dev/todo-and-known-bugs.md` T61 entry — the three closed bullets are struck through; the remaining bullets are reworded as measurement-gated guidance rather than active tasks.
- `CHANGELOG.md` — the preceding Gloops Flight Recorder entry was landed under a stale `## 0.8.3` draft header, but `Parsek.version` and `AssemblyInfo.cs` are `0.8.2`. That entry is moved into `0.8.2 Features` alongside the new `T61` Tests and Documentation bullets.

## Test plan

- [x] `dotnet test` — 6460 passed, 1 skipped, 0 failed on the new branch
- [x] `dotnet test --filter "FullyQualifiedName~QuickloadResumeTests"` — 69 passed
- [ ] No in-game verification required; all changes are either pure unit tests or doc.