### PR TITLE
Fix ResolveLoopInterval clamp-warning log storm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ All notable changes to Parsek are documented here.
 - `#409` Fixed a watch-mode overlap-vs-single dispatch mismatch for recordings with a loop subrange: `ResolveWatchPlaybackUT` and `TryStartWatchSession` now read the same `EffectiveLoopDuration` and cycle-start reference, so the two sites can no longer disagree on which playback path to take.
 - `#410` Fixed a one-frame `playing → paused → playing` flicker at exact loop-cycle boundaries — `ComputeLoopPhaseFromUT`, `TryComputeLoopPlaybackUT`, and the live flight/KSC loop schedulers now share a `BoundaryEpsilon` tolerance so they agree on the `isInPause` flag at `phase == duration`.
 - `#411` Loop playback now uses the effective loop subrange consistently in flight and KSC: the overlap-vs-single dispatch, overlap active-cycle bounds, overlap phase anchoring, and loop-end teardown/pause holds now read `EffectiveLoopDuration` / `EffectiveLoopStartUT` / `EffectiveLoopEndUT` instead of raw or hybrid recording ranges.
+- Fixed a per-frame `ResolveLoopInterval` clamp-warning log storm (over 1 million entries in a 6-minute session on saves with legacy loop data) — each affected recording now warns at most once per session while the defensive 1s clamp is unchanged.
 
 ### Maintenance
 

--- a/Source/Parsek.Tests/AutoLoopTests.cs
+++ b/Source/Parsek.Tests/AutoLoopTests.cs
@@ -11,12 +11,16 @@ namespace Parsek.Tests
         {
             ParsekLog.SuppressLogging = false;
             RecordingStore.SuppressLogging = true;
+            // Per-recording clamp-warning dedupe set is static — flush between tests so
+            // clamp assertions don't get swallowed by a prior test's warning on "TestVessel".
+            GhostPlaybackLogic.ResetForTesting();
         }
 
         public void Dispose()
         {
             ParsekLog.ResetTestOverrides();
             RecordingStore.ResetForTesting();
+            GhostPlaybackLogic.ResetForTesting();
         }
 
         static Recording MakeRec(

--- a/Source/Parsek.Tests/MockTrajectory.cs
+++ b/Source/Parsek.Tests/MockTrajectory.cs
@@ -21,6 +21,7 @@ namespace Parsek.Tests
         public ConfigNode GhostVisualSnapshot { get; set; }
         public ConfigNode VesselSnapshot { get; set; }
         public string VesselName { get; set; } = "MockVessel";
+        public string RecordingId { get; set; }
         public bool LoopPlayback { get; set; }
         public double LoopIntervalSeconds { get; set; } = 10;
         public LoopTimeUnit LoopTimeUnit { get; set; }

--- a/Source/Parsek.Tests/ResolveLoopIntervalWarnDedupeTests.cs
+++ b/Source/Parsek.Tests/ResolveLoopIntervalWarnDedupeTests.cs
@@ -1,0 +1,196 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Regression tests for the per-frame log-spam bug in
+    /// GhostPlaybackLogic.ResolveLoopInterval. Before the dedupe fix, degenerate
+    /// loop periods (period &lt; MinCycleDuration) emitted an unrate-limited
+    /// ParsekLog.Warn per frame per recording, producing ~1.3M lines in a
+    /// 6-minute session with ~20 offending recordings. Each offender must warn
+    /// at most once per session.
+    /// </summary>
+    [Collection("Sequential")]
+    public class ResolveLoopIntervalWarnDedupeTests : IDisposable
+    {
+        private const double DefaultInterval = 10.0;
+        private const double MinCycleDuration = GhostPlaybackLogic.MinCycleDuration;
+
+        private readonly List<string> logLines = new List<string>();
+
+        public ResolveLoopIntervalWarnDedupeTests()
+        {
+            GhostPlaybackLogic.ResetForTesting();
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+            GhostPlaybackLogic.ResetForTesting();
+        }
+
+        private static int CountClampWarnings(List<string> lines, string vesselName)
+        {
+            return lines.Count(l =>
+                l.Contains("[WARN]") &&
+                l.Contains("[Loop]") &&
+                l.Contains("ResolveLoopInterval:") &&
+                l.Contains($"'{vesselName}'"));
+        }
+
+        [Fact]
+        public void DegenerateInterval_HundredCalls_SameRecording_EmitsExactlyOneWarning()
+        {
+            var rec = new MockTrajectory
+            {
+                RecordingId = "rec-legacy-zero",
+                VesselName = "LegacyZero",
+                LoopTimeUnit = LoopTimeUnit.Sec,
+                LoopIntervalSeconds = 0.0,
+            };
+
+            for (int i = 0; i < 100; i++)
+            {
+                double result = GhostPlaybackLogic.ResolveLoopInterval(
+                    rec, globalAutoInterval: DefaultInterval,
+                    defaultInterval: DefaultInterval, minCycleDuration: MinCycleDuration);
+
+                // Defensive clamp behavior is unchanged: every call still returns the floor.
+                Assert.Equal(MinCycleDuration, result);
+            }
+
+            Assert.Equal(1, CountClampWarnings(logLines, "LegacyZero"));
+        }
+
+        [Fact]
+        public void DegenerateInterval_HundredCallsEach_TwoRecordings_EmitsExactlyTwoWarnings()
+        {
+            var recA = new MockTrajectory
+            {
+                RecordingId = "rec-alpha",
+                VesselName = "Alpha",
+                LoopTimeUnit = LoopTimeUnit.Sec,
+                LoopIntervalSeconds = 0.0,
+            };
+            var recB = new MockTrajectory
+            {
+                RecordingId = "rec-beta",
+                VesselName = "Beta",
+                LoopTimeUnit = LoopTimeUnit.Sec,
+                LoopIntervalSeconds = 0.0,
+            };
+
+            for (int i = 0; i < 100; i++)
+            {
+                double a = GhostPlaybackLogic.ResolveLoopInterval(
+                    recA, DefaultInterval, DefaultInterval, MinCycleDuration);
+                double b = GhostPlaybackLogic.ResolveLoopInterval(
+                    recB, DefaultInterval, DefaultInterval, MinCycleDuration);
+                Assert.Equal(MinCycleDuration, a);
+                Assert.Equal(MinCycleDuration, b);
+            }
+
+            // Each recording logs its clamp exactly once — 200 calls produce 2 lines.
+            Assert.Equal(1, CountClampWarnings(logLines, "Alpha"));
+            Assert.Equal(1, CountClampWarnings(logLines, "Beta"));
+        }
+
+        [Fact]
+        public void DegenerateInterval_DedupesOnRecordingId_EvenWhenVesselNamesCollide()
+        {
+            // Two recordings of the same vessel (e.g. two reverts of "Pad Walk") must each
+            // get their own warning: the stable key is RecordingId, not VesselName.
+            var recA = new MockTrajectory
+            {
+                RecordingId = "rec-a",
+                VesselName = "PadWalk",
+                LoopTimeUnit = LoopTimeUnit.Sec,
+                LoopIntervalSeconds = 0.0,
+            };
+            var recB = new MockTrajectory
+            {
+                RecordingId = "rec-b",
+                VesselName = "PadWalk",
+                LoopTimeUnit = LoopTimeUnit.Sec,
+                LoopIntervalSeconds = 0.0,
+            };
+
+            GhostPlaybackLogic.ResolveLoopInterval(recA, DefaultInterval, DefaultInterval, MinCycleDuration);
+            GhostPlaybackLogic.ResolveLoopInterval(recA, DefaultInterval, DefaultInterval, MinCycleDuration);
+            GhostPlaybackLogic.ResolveLoopInterval(recB, DefaultInterval, DefaultInterval, MinCycleDuration);
+            GhostPlaybackLogic.ResolveLoopInterval(recB, DefaultInterval, DefaultInterval, MinCycleDuration);
+
+            // Two distinct RecordingIds → two warnings, both tagged with the shared VesselName.
+            Assert.Equal(2, CountClampWarnings(logLines, "PadWalk"));
+        }
+
+        [Fact]
+        public void DegenerateInterval_FallsBackToVesselName_WhenRecordingIdMissing()
+        {
+            // Fixtures without an id (e.g. transient non-Recording fixtures) must still dedupe.
+            var rec = new MockTrajectory
+            {
+                RecordingId = null,
+                VesselName = "Nameless",
+                LoopTimeUnit = LoopTimeUnit.Sec,
+                LoopIntervalSeconds = 0.0,
+            };
+
+            for (int i = 0; i < 50; i++)
+            {
+                GhostPlaybackLogic.ResolveLoopInterval(
+                    rec, DefaultInterval, DefaultInterval, MinCycleDuration);
+            }
+
+            Assert.Equal(1, CountClampWarnings(logLines, "Nameless"));
+        }
+
+        [Fact]
+        public void HealthyInterval_DoesNotWarn_AndDoesNotConsumeDedupeSlot()
+        {
+            var rec = new MockTrajectory
+            {
+                VesselName = "Healthy",
+                LoopTimeUnit = LoopTimeUnit.Sec,
+                LoopIntervalSeconds = 30.0,
+            };
+
+            double resolved = GhostPlaybackLogic.ResolveLoopInterval(
+                rec, DefaultInterval, DefaultInterval, MinCycleDuration);
+
+            Assert.Equal(30.0, resolved);
+            Assert.Equal(0, CountClampWarnings(logLines, "Healthy"));
+        }
+
+        [Fact]
+        public void ResetForTesting_AllowsWarningToFireAgain()
+        {
+            var rec = new MockTrajectory
+            {
+                RecordingId = "rec-legacy-zero",
+                VesselName = "LegacyZero",
+                LoopTimeUnit = LoopTimeUnit.Sec,
+                LoopIntervalSeconds = 0.0,
+            };
+
+            GhostPlaybackLogic.ResolveLoopInterval(
+                rec, DefaultInterval, DefaultInterval, MinCycleDuration);
+            Assert.Equal(1, CountClampWarnings(logLines, "LegacyZero"));
+
+            // Simulating a new session — reset flushes the dedupe set.
+            GhostPlaybackLogic.ResetForTesting();
+            GhostPlaybackLogic.ResolveLoopInterval(
+                rec, DefaultInterval, DefaultInterval, MinCycleDuration);
+
+            // Now two warnings total — one from before reset, one after.
+            Assert.Equal(2, CountClampWarnings(logLines, "LegacyZero"));
+        }
+    }
+}

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -29,6 +29,14 @@ namespace Parsek
         // Prevents immediate exit when a ghost briefly crosses a zone boundary at watch-mode start.
         internal const float WatchModeZoneGraceSeconds = 2.0f;
 
+        // Dedupe set for ResolveLoopInterval clamp warnings. Without this, a recording whose
+        // LoopIntervalSeconds is below MinCycleDuration produces a log line every frame from
+        // GhostPlaybackEngine + ParsekKSC (~3,600 lines/sec with ~20 offending recordings —
+        // ~1.3M entries in a 6-minute session). Keyed on RecordingId (stable across loads)
+        // with fallback to VesselName for transient fixtures lacking an id. Reset between
+        // tests via ResetForTesting.
+        private static readonly HashSet<string> loopIntervalClampWarned = new HashSet<string>(StringComparer.Ordinal);
+
         #region Warp / Loop Policy
 
         internal static bool ShouldSuppressVisualFx(float currentWarpRate)
@@ -286,12 +294,27 @@ namespace Parsek
 
             if (interval < minCycleDuration)
             {
-                ParsekLog.Warn("Loop",
-                    $"ResolveLoopInterval: period {interval.ToString("R", CultureInfo.InvariantCulture)}s below MinCycleDuration " +
-                    $"{minCycleDuration.ToString("R", CultureInfo.InvariantCulture)}s for '{rec.VesselName}' — clamping defensively (#381)");
+                string key = !string.IsNullOrEmpty(rec.RecordingId)
+                    ? rec.RecordingId
+                    : (rec.VesselName ?? string.Empty);
+                if (loopIntervalClampWarned.Add(key))
+                {
+                    ParsekLog.Warn("Loop",
+                        $"ResolveLoopInterval: period {interval.ToString("R", CultureInfo.InvariantCulture)}s below MinCycleDuration " +
+                        $"{minCycleDuration.ToString("R", CultureInfo.InvariantCulture)}s for '{rec.VesselName}' — clamping defensively (#381)");
+                }
                 return minCycleDuration;
             }
             return interval;
+        }
+
+        /// <summary>
+        /// Reset the per-recording clamp-warning dedupe set. Test-only — call from Dispose
+        /// of any test touching ResolveLoopInterval so state doesn't leak across tests.
+        /// </summary>
+        internal static void ResetForTesting()
+        {
+            loopIntervalClampWarned.Clear();
         }
 
         /// <summary>

--- a/Source/Parsek/IPlaybackTrajectory.cs
+++ b/Source/Parsek/IPlaybackTrajectory.cs
@@ -30,6 +30,12 @@ namespace Parsek
         ConfigNode VesselSnapshot { get; }
         string VesselName { get; }
 
+        // === Identity ===
+        // Stable GUID-style id for dedupe of per-recording diagnostics (e.g. the clamp
+        // warning in GhostPlaybackLogic.ResolveLoopInterval). May be null/empty on
+        // transient or test fixtures; consumers must fall back to VesselName.
+        string RecordingId { get; }
+
         // === Loop configuration ===
         bool LoopPlayback { get; }
         double LoopIntervalSeconds { get; }

--- a/Source/Parsek/Recording.cs
+++ b/Source/Parsek/Recording.cs
@@ -764,6 +764,7 @@ namespace Parsek
         ConfigNode IPlaybackTrajectory.GhostVisualSnapshot => GhostVisualSnapshot;
         ConfigNode IPlaybackTrajectory.VesselSnapshot => VesselSnapshot;
         string IPlaybackTrajectory.VesselName => VesselName;
+        string IPlaybackTrajectory.RecordingId => RecordingId;
         bool IPlaybackTrajectory.LoopPlayback => LoopPlayback;
         double IPlaybackTrajectory.LoopIntervalSeconds => LoopIntervalSeconds;
         LoopTimeUnit IPlaybackTrajectory.LoopTimeUnit => LoopTimeUnit;

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -45,6 +45,80 @@ are fixed in the same PR branch with additional commits:
 
 # Known Bugs
 
+## 412. Legacy pre-v4 recordings can reach ghost playback with `LoopIntervalSeconds=0`, firing the `ResolveLoopInterval` clamp warning forever
+
+Two-part bug introduced by `#381` (commit `5fedff32`, "Loop every = launch-to-launch
+period semantics").
+
+- **Symptom (fixed in the current PR):** `GhostPlaybackLogic.ResolveLoopInterval`
+  (`Source/Parsek/GhostPlaybackLogic.cs:269`) emitted an unrate-limited
+  `ParsekLog.Warn` on every degenerate call. Called per-frame per-recording from
+  `GhostPlaybackEngine.cs:1314` and `ParsekKSC.cs:750`, a 6-minute session with
+  roughly 20 affected recordings produced 1,298,168 lines of
+  `[Parsek][WARN][Loop] ResolveLoopInterval: period 0s below MinCycleDuration 1s for '<name>' — clamping defensively (#381)`
+  (~3,600/sec, with a full string format + log-writer flush per line). The spam
+  itself is now fixed: a per-`RecordingId` `HashSet` inside `GhostPlaybackLogic`
+  ensures each offending recording warns at most once per session; the defensive
+  clamp to `MinCycleDuration` is unchanged.
+- **Root cause still open:** those recordings should never reach the resolver
+  with period `0`. The load pipeline has a two-phase migration:
+  `RecordingTree.LoadLoopFields` / `ParsekScenario.LoadLoopFields` call
+  `GhostPlaybackEngine.TryConvertLegacyGapToLoopPeriodSeconds` at
+  `.sfs` load time, which returns `false` when the trajectory bounds are not
+  hydrated yet (the `EffectiveLoopDuration <= 0` guard in
+  `GhostPlaybackEngine.cs:1276`) and logs `deferred migration because loop bounds
+  are not hydrated yet`; the legacy gap value is stored as-is. The deferred step
+  is supposed to run from `RecordingStore.MigrateLegacyLoopIntervalAfterHydration`
+  (`Source/Parsek/RecordingStore.cs:5385`), invoked as the last line of
+  `LoadRecordingFilesFromPathsInternal` (line 5381). That call is only reached
+  when *every* sidecar gate passes — trajectory exists, probe valid, format
+  supported, RecordingId matches, sidecar epoch fresh, snapshot sidecar load
+  succeeds. Any early return at lines 5311 / 5319 / 5329 / 5338 / 5344 / 5370
+  skips the migration, leaving `rec.LoopIntervalSeconds` at its legacy `.sfs`
+  value (often `0`, the pre-#381 default for non-looping recordings) and
+  `rec.RecordingFormatVersion` at `3`.
+- **Evidence from user save:** sibling recordings in the same tree successfully
+  migrate to 68–70 s (logs show `RecordingStore: migrated recording 'X' from
+  legacy gap loopIntervalSeconds=10 to launch-to-launch period=68s`), while ~20
+  recordings — mixed kerbal / chain / flight: "Pad Walk", "Reentry South", "Flea
+  Chain", "KSC Hopper", "Jebediah Kerman", "Bill Kerman", etc. — never emit a
+  migration line and keep hitting the clamp. The common factor is therefore not
+  the recording class but rather which sidecar gate failed at load; the logs to
+  check are `LoadRecordingFiles: invalid …`, `Trajectory file missing for …`,
+  `LoadRecordingFiles: id=… unsupported trajectory sidecar`, and
+  `ShouldSkipStaleSidecar`. Hydration-salvage (`#T61`) may also be relevant — if
+  a recording is restored from the pending tree after a stale-sidecar failure,
+  the migration pass needs to run on the salvaged copy too.
+- **Hypothesis:** at least two distinct paths leave a v3 recording persistently
+  un-migrated: (a) the sidecar-gate early returns above (migration never runs),
+  and (b) a recording that genuinely has `Points.Count < 2` (e.g. a recording
+  that was committed before enough frames were sampled) where
+  `EffectiveLoopDuration` legitimately is `0` and `TryConvert` returns `false`
+  even after hydration. Neither path resets the legacy gap to a safe period, so
+  `LoopIntervalSeconds` stays at whatever the `.sfs` held.
+- **Fix proposal (not yet implemented):** when migration cannot produce a real
+  period, still normalize `rec.LoopIntervalSeconds` and `RecordingFormatVersion`
+  so the resolver never sees a legacy-encoded 0. Either (a) run
+  `MigrateLegacyLoopIntervalAfterHydration` unconditionally for every recording
+  returned to the committed set — including sidecar-failed ones — and, when
+  `TryConvert` still fails, set the recording to `LoopPlayback = false` +
+  `LoopIntervalSeconds = DefaultLoopIntervalSeconds` (so ghost playback is
+  skipped entirely for the broken recording instead of relying on the resolver's
+  1 s clamp), or (b) make the resolver detect v3 recordings and promote the
+  legacy gap to `duration + gap` on the fly, mirroring what the migration would
+  have done. Option (a) is cleaner because it keeps the clamp-warning a pure
+  sanity net. A regression test should load a tree containing a v3 recording
+  with 0 trajectory points (or a missing `.prec`) and assert that after the
+  normal load path completes, the recording is no longer producing degenerate
+  loop periods at the resolver.
+- **Scope note:** out of scope for the spam fix PR — the spam fix is independent
+  and lands on its own. The correctness fix is large enough that it needs its
+  own design discussion before coding (needs a repro save, a decision on whether
+  to silently drop playback vs. auto-repair, and an upgrade to the post-hydration
+  pass).
+
+---
+
 ## ~~411. Playback engine and KSC dispatcher still compute loop duration from raw/hybrid ranges instead of the effective loop range~~
 
 **Source:** `#409` fix pass `2026-04-15`. Surfaced while fixing the `WatchModeController` duration mismatch: three sibling sites in the playback engine and the KSC dispatcher also compute "loop duration" in ways that diverge from the new shared `GhostPlaybackEngine.EffectiveLoopDuration` helper. The `#409` fix was scoped to the watch-mode path and intentionally left these untouched because they predate `#381` and need in-game validation on a save with a real loop subrange before changing.


### PR DESCRIPTION
## Summary

- `GhostPlaybackLogic.ResolveLoopInterval` (`Source/Parsek/GhostPlaybackLogic.cs:269`) emitted an unrate-limited `ParsekLog.Warn` whenever `interval < minCycleDuration`. It's called per-frame per-recording from `GhostPlaybackEngine.cs:1314` and `ParsekKSC.cs:750`, so a save with ~20 legacy recordings whose migration silently failed produced 1,298,168 `[Parsek][WARN][Loop] ResolveLoopInterval: period 0s ...` lines (~3,600/sec) in a 6-minute session. Each line formatted a string and flushed the log writer — the full perf cliff.
- Dedupe: a static `HashSet<string>` inside `GhostPlaybackLogic` keyed on `rec.RecordingId` (fallback to `VesselName` for fixtures lacking an id). Each offending recording warns at most once per session. Defensive clamp to `MinCycleDuration` unchanged.
- `IPlaybackTrajectory` gains a `RecordingId` getter (forwarded from `Recording`, set on `MockTrajectory`).

## Why one commit

Spam fix is independent of the underlying migration hole. The root cause — some pre-v4 recordings never get their deferred `MigrateLegacyLoopIntervalAfterHydration` pass (skipped by sidecar-gate early returns or legitimately `TryConvertLegacyGapToLoopPeriodSeconds`-false) — is documented in `docs/dev/todo-and-known-bugs.md` as bug #412 with repro notes, evidence from the user save, and a proposed fix path. That correctness work is out of scope here.

## Test plan

- [x] `cd Source/Parsek && dotnet build` — clean.
- [x] `cd Source/Parsek.Tests && dotnet test` — 6,466 passing, 0 failing, 1 pre-existing skip.
- [x] New `ResolveLoopIntervalWarnDedupeTests` (4 tests) proves:
  - 100 calls on one degenerate recording emit exactly 1 warning.
  - 100 calls each on two degenerate recordings emit exactly 2 warnings.
  - Two recordings with the same `VesselName` but distinct `RecordingId` each get their own warning.
  - A fixture with no `RecordingId` falls back to `VesselName` and still dedupes.
  - Every call still returns `MinCycleDuration` (defensive clamp unchanged).
- [x] `AutoLoopTests` setup/teardown now resets the dedupe set so its clamp assertions do not get swallowed by cross-test state.

## Impact

In a comparable 6-minute session with ~20 offending recordings, this reduces the clamp-warning volume from 1,298,168 to 20 — one per recording instead of one per call. The degenerate recordings themselves still need bug #412 to be fully repaired.