### PR TITLE
claude.md: elevate worktree rule to HARD RULE

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -125,13 +125,23 @@ Key source files and what they do - read the relevant one before modifying:
 
 ## Worktree Workflow
 
+**HARD RULE — never edit or commit inside an existing worktree without explicit per-session approval.** "Existing worktree" = anything `git worktree list` already shows: the main repo at `Parsek/`, and every `Parsek-<branch>/` sibling. This applies to every change that will produce a commit — code, tests, CHANGELOG trims, todo edits, doc tweaks, anything. "It's just a one-line fix" is not an exception.
+
 For manual worktrees (when not using `isolation=worktree`), create as sibling folders:
 ```bash
 cd Parsek
-git worktree add ../Parsek-<branch-name> -b <branch-name> HEAD
+git worktree add ../Parsek-<branch-name> -b <branch-name> <target>
 ```
 
-`Parsek.csproj` probes up to 5 parent levels for `Kerbal Space Program/`, so builds work from worktrees at this location. Merge: `cd Parsek && git merge <branch-name>`
+Pick `<target>` carefully:
+- Branching from `main` → use `origin/main` (local main may be ahead of remote from in-progress work).
+- Branching from a feature branch that's about to be merged → compare `git log --oneline <local>..origin/<branch>` first. Use the local ref if it's ahead; use `origin/<branch>` if it's behind or matches.
+
+Every change-producing task ends in: commit on the fix/chore branch → in the target worktree, `git merge --no-ff <branch>` it back → leave the branch around unless the user asks to prune.
+
+**If I slip and edit directly in an existing worktree**: stop before pushing. Recovery: stash any unrelated WIP in the dirty worktree, `git worktree add` a new worktree at the tip containing the direct-edit commit (picks up my work on a clean branch), `git reset --hard` the dirty worktree back to the pre-direct-edit tip, `git merge --no-ff` the rescue branch back in, `git stash pop`. Never leave a direct-edit commit standing on a shared branch.
+
+`Parsek.csproj` probes up to 5 parent levels for `Kerbal Space Program/`, so builds work from worktrees at this location.
 
 ## In-Game Controls
 


### PR DESCRIPTION
## Summary

Strengthens the Worktree Workflow section in `.claude/CLAUDE.md`:

- Leads with a **HARD RULE**: never edit or commit inside an existing worktree (main OR any `Parsek-<branch>/` sibling) without explicit per-session approval — every change that produces a commit gets its own new worktree + branch, no matter how small.
- Adds target-branch selection guidance: `origin/main` vs local main when branching from main; `git log <local>..origin/<branch>` check before branching from a feature branch that might be ahead / behind origin.
- Documents the recovery procedure for slipping (stash WIP, add rescue worktree at the direct-edit commit, reset --hard the dirty worktree, merge --no-ff the rescue branch back, stash pop).

Driven by a 2026-04-17 incident: doc-only CHANGELOG/todo edits were committed directly inside `Parsek-416-career-window/` rather than via a new worktree. Old phrasing was permissive enough that "just a one-line doc fix" slipped through. New wording leaves no room for that interpretation.

## Test plan

- [x] `.claude/CLAUDE.md` change reviewed in the diff.
- [ ] No functional impact — documentation only.