### PR TITLE
#432: Gloops ghost-only recordings no longer leak into the career ledger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ All notable changes to Parsek are documented here.
 - `#434` KSP's stock crash/mission report (with its Revert buttons) now shows first on vessel destruction; Parsek's merge dialog no longer pre-empts it. Revert to Launch and Revert to VAB/SPH soft-clear the pending recording — sidecar files and captured events stay on disk so a flight quicksave can still be F9'd back into, while the bumped milestone epoch keeps reverted events out of the current ledger.
 - `#434` Fixed a NullReferenceException in `RevertDetector.Subscribe` that aborted `ParsekScenario.OnLoad` before the merge-dialog dispatch path could run, so going back to Space Center after a flight silently auto-committed the pending tree instead of showing the merge/discard dialog.
 - `#434` Revert to Launch no longer accidentally deletes the in-flight recording's files, so a flight F5 quicksave can still be F9'd back in after reverting. Stale science captured between the launch quicksave and the revert is also now cleared even when no recording was yet stashed.
+- `#432` Gloops (ghost-only) recordings no longer leak kerbal assignments or vessel costs into the career ledger — they are purely visual.
 - `#431` Discarding a recording now reverses every career effect it captured — contracts, tech, crew changes, milestones, and resource deltas are all purged, including events the flush-on-save path had already bundled into a milestone.
 - `#416` New career no longer starts with zero funds.
 - `#416` Crashed-vessel recordings now keep their R (rewind) button.

--- a/Source/Parsek.Tests/GloopsEventSuppressionTests.cs
+++ b/Source/Parsek.Tests/GloopsEventSuppressionTests.cs
@@ -171,6 +171,34 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void FilterOutGhostOnlyActions_PreservesMigratedOldSaveActionsWithEmptyTag()
+        {
+            // MigrateOldSaveEvents (LedgerOrchestrator.cs:803) converts pre-ledger
+            // save events into GameActions with null/empty RecordingId — documented
+            // intentional tradeoff: we can't reliably map them to specific recordings.
+            // The filter must keep these alongside the legitimate seed-action empty tags.
+            var ghostOnly = new Recording { RecordingId = "gloops-old", IsGhostOnly = true };
+            RecordingStore.AddRecordingWithTreeForTesting(ghostOnly);
+
+            var actions = new List<GameAction>
+            {
+                // Simulated MigrateOldSaveEvents output: a FundsSpending with null tag.
+                new GameAction { RecordingId = null, Type = GameActionType.FundsSpending, FundsSpent = 1000f },
+                // Simulated InitialFunds seed.
+                new GameAction { RecordingId = "", Type = GameActionType.FundsInitial },
+                // The actually-ghost-only-tagged row that must be dropped.
+                new GameAction { RecordingId = "gloops-old", Type = GameActionType.KerbalAssignment },
+            };
+
+            var filtered = LedgerOrchestrator.FilterOutGhostOnlyActions(actions);
+
+            Assert.Equal(2, filtered.Count);
+            Assert.Contains(filtered, a => a.Type == GameActionType.FundsSpending && a.RecordingId == null);
+            Assert.Contains(filtered, a => a.Type == GameActionType.FundsInitial);
+            Assert.DoesNotContain(filtered, a => a.RecordingId == "gloops-old");
+        }
+
+        [Fact]
         public void FilterOutGhostOnlyActions_NoGhostOnlyRecordings_ReturnsInputUnchanged()
         {
             var normal = new Recording { RecordingId = "normal-only", IsGhostOnly = false };
@@ -194,9 +222,13 @@ namespace Parsek.Tests
         // ================================================================
 
         [Fact]
-        public void GetActiveRecordingIdForTagging_WithGloopsCommittedInStore_ReturnsEmpty()
+        public void GetActiveRecordingIdForTagging_WithGloopsAndNormalCommitted_NeverReturnsGloopsId()
         {
-            // Simulate a committed Gloops recording in the store.
+            // Seed BOTH a committed Gloops recording and a committed normal recording.
+            // The resolver must never return the Gloops id — proving that empty return
+            // is due to the resolver honoring the active tree (empty in tests, no
+            // ParsekFlight.Instance), not due to "the Gloops recording happened to be
+            // skipped because no recording was committed at all."
             var gloops = new Recording
             {
                 RecordingId = "gloops-B",
@@ -207,22 +239,28 @@ namespace Parsek.Tests
             gloops.Points.Add(new TrajectoryPoint { ut = 20.0 });
             RecordingStore.CommitGloopsRecording(gloops);
 
-            // No ParsekFlight.Instance in tests -> active tree is absent.
-            // Resolver must return "" (empty), never the Gloops id.
-            string tag = ParsekFlight.GetActiveRecordingIdForTagging();
+            var normal = new Recording { RecordingId = "normal-A", IsGhostOnly = false };
+            RecordingStore.AddRecordingWithTreeForTesting(normal);
 
-            Assert.NotEqual("gloops-B", tag);
-            Assert.True(string.IsNullOrEmpty(tag));
+            // Call the resolver many times to rule out any nondeterministic path.
+            for (int i = 0; i < 10; i++)
+            {
+                string tag = ParsekFlight.GetActiveRecordingIdForTagging();
+                Assert.NotEqual("gloops-B", tag);
+                // May return "" or "normal-A" depending on activeTree wiring; never the Gloops id.
+                Assert.True(tag == "" || tag == "normal-A",
+                    $"Unexpected tag '{tag}' — resolver must return the active tree's id or empty");
+            }
         }
 
         [Fact]
-        public void PurgeEventsForRecordings_RemovesForcedGloopsTaggedEvent()
+        public void PurgeEventsForRecordings_RemovesForcedGloopsTaggedEvent_LiveAndSnapshot()
         {
-            // This test pins the purge *mechanism* — forcing a Gloops-tagged event
-            // into the store via the test hook and asserting it can be purged.
-            // The default resolver never produces such events (previous test).
+            // This test pins the purge *mechanism* across all three stores touched by
+            // PurgeEventsForRecordings: live events, contract snapshots, and milestones.
             GameStateRecorder.TagResolverForTesting = () => "gloops-forced";
 
+            // Branch 1: live events list.
             var evt = new GameStateEvent
             {
                 ut = 100.0,
@@ -232,14 +270,25 @@ namespace Parsek.Tests
             };
             GameStateRecorder.Emit(evt, "test");
 
-            int beforeCount = GameStateStore.EventCount;
-            Assert.True(beforeCount >= 1);
+            // Branch 2: orphan contract snapshots (must be removed when the matching
+            // ContractAccepted event is purged — PurgeOrphanedContractSnapshots).
+            var contractNode = new ConfigNode("CONTRACT");
+            contractNode.AddValue("guid", "contract-1");
+            GameStateStore.AddContractSnapshot("contract-1", contractNode);
+
+            int eventCountBefore = GameStateStore.EventCount;
+            int snapshotCountBefore = GameStateStore.ContractSnapshots.Count;
+            Assert.True(eventCountBefore >= 1);
+            Assert.True(snapshotCountBefore >= 1);
 
             int removed = GameStateStore.PurgeEventsForRecordings(
                 new[] { "gloops-forced" }, "test");
 
             Assert.Equal(1, removed);
-            Assert.Equal(beforeCount - 1, GameStateStore.EventCount);
+            Assert.Equal(eventCountBefore - 1, GameStateStore.EventCount);
+            // Snapshot's matching ContractAccepted event was purged, so the orphan
+            // cleanup should have removed the snapshot too.
+            Assert.Equal(snapshotCountBefore - 1, GameStateStore.ContractSnapshots.Count);
         }
 
         // ================================================================
@@ -268,6 +317,17 @@ namespace Parsek.Tests
 
             LedgerOrchestrator.RecalculateAndPatch();
 
+            Assert.Contains(logLines, l =>
+                l.Contains("[LedgerOrchestrator]")
+                && l.Contains("filtered 1 action(s) tagged with ghost-only recordings"));
+
+            // Filter fires on every RecalculateAndPatch as long as the stale row sits in
+            // Ledger.Actions. The self-heal path (via MigrateKerbalAssignments in
+            // OnKspLoad) is what actually rewrites the stale row — the walk filter itself
+            // does not mutate Ledger.Actions. Verify this: a second call produces another
+            // filter line with the same count.
+            logLines.Clear();
+            LedgerOrchestrator.RecalculateAndPatch();
             Assert.Contains(logLines, l =>
                 l.Contains("[LedgerOrchestrator]")
                 && l.Contains("filtered 1 action(s) tagged with ghost-only recordings"));

--- a/Source/Parsek.Tests/GloopsEventSuppressionTests.cs
+++ b/Source/Parsek.Tests/GloopsEventSuppressionTests.cs
@@ -1,0 +1,345 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// #432 — Gloops ghost-only recordings must contribute zero actions to the ledger.
+    /// Covers the two action-creation guards in <see cref="LedgerOrchestrator"/>
+    /// (<c>CreateKerbalAssignmentActions</c>, <c>CreateVesselCostActions</c>), the
+    /// belt-and-braces <c>FilterOutGhostOnlyActions</c> pre-pass, the walk-integration
+    /// log signal from <c>RecalculateAndPatch</c>, the self-heal path through
+    /// <c>MigrateKerbalAssignments</c> → <c>OnKspLoad</c>, and the invariant that
+    /// events never get tagged with a Gloops recording's id in the first place.
+    /// </summary>
+    [Collection("Sequential")]
+    public class GloopsEventSuppressionTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public GloopsEventSuppressionTests()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+
+            RecordingStore.SuppressLogging = true;
+            KspStatePatcher.SuppressUnityCallsForTesting = true;
+            GameStateStore.SuppressLogging = true;
+
+            RecordingStore.ResetForTesting();
+            GameStateStore.ResetForTesting();
+            MilestoneStore.ResetForTesting();
+            LedgerOrchestrator.ResetForTesting();
+        }
+
+        public void Dispose()
+        {
+            LedgerOrchestrator.ResetForTesting();
+            KspStatePatcher.ResetForTesting();
+            MilestoneStore.ResetForTesting();
+            GameStateStore.ResetForTesting();
+            RecordingStore.ResetForTesting();
+            RecordingStore.SuppressLogging = false;
+            GameStateRecorder.TagResolverForTesting = null;
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+        }
+
+        private static Recording MakeCrewedRecording(string id, bool ghostOnly)
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            var part = new ConfigNode("PART");
+            part.AddValue("crew", "Jeb Kerman");
+            snapshot.AddNode(part);
+
+            var rec = new Recording
+            {
+                RecordingId = id,
+                VesselName = "Test Ship",
+                GhostVisualSnapshot = snapshot,
+                IsGhostOnly = ghostOnly,
+            };
+            rec.CrewEndStates = new Dictionary<string, KerbalEndState>
+            {
+                { "Jeb Kerman", KerbalEndState.Aboard }
+            };
+            return rec;
+        }
+
+        // ================================================================
+        // 1. CreateKerbalAssignmentActions — ghost-only returns empty
+        // ================================================================
+
+        [Fact]
+        public void CreateKerbalAssignmentActions_GhostOnlyRecording_ReturnsEmpty()
+        {
+            var rec = MakeCrewedRecording("gloops-kerbal-empty", ghostOnly: true);
+            RecordingStore.AddRecordingWithTreeForTesting(rec);
+
+            var actions = LedgerOrchestrator.CreateKerbalAssignmentActions(
+                "gloops-kerbal-empty", 100.0, 200.0);
+
+            Assert.Empty(actions);
+            Assert.Contains(logLines, l =>
+                l.Contains("[LedgerOrchestrator]")
+                && l.Contains("CreateKerbalAssignmentActions")
+                && l.Contains("gloops-kerbal-empty")
+                && l.Contains("ghost-only"));
+        }
+
+        // ================================================================
+        // 2. CreateKerbalAssignmentActions — normal recording still produces rows
+        // ================================================================
+
+        [Fact]
+        public void CreateKerbalAssignmentActions_NormalRecording_ProducesRow()
+        {
+            var rec = MakeCrewedRecording("normal-kerbal-row", ghostOnly: false);
+            RecordingStore.AddRecordingWithTreeForTesting(rec);
+
+            var actions = LedgerOrchestrator.CreateKerbalAssignmentActions(
+                "normal-kerbal-row", 100.0, 200.0);
+
+            Assert.Single(actions);
+            Assert.Equal(GameActionType.KerbalAssignment, actions[0].Type);
+            Assert.Equal("Jeb Kerman", actions[0].KerbalName);
+            Assert.Equal("normal-kerbal-row", actions[0].RecordingId);
+        }
+
+        // ================================================================
+        // 3. CreateVesselCostActions — ghost-only returns empty
+        // ================================================================
+
+        [Fact]
+        public void CreateVesselCostActions_GhostOnlyRecording_ReturnsEmpty()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "gloops-cost-empty",
+                IsGhostOnly = true,
+                // Values that would normally produce both build cost and recovery.
+                PreLaunchFunds = 50000.0,
+                TerminalStateValue = TerminalState.Recovered
+            };
+            rec.Points.Add(new TrajectoryPoint { ut = 100.0, funds = 40000.0 });
+            rec.Points.Add(new TrajectoryPoint { ut = 200.0, funds = 40000.0 });
+            rec.Points.Add(new TrajectoryPoint { ut = 300.0, funds = 47000.0 });
+            RecordingStore.AddRecordingWithTreeForTesting(rec);
+
+            var actions = LedgerOrchestrator.CreateVesselCostActions(
+                "gloops-cost-empty", 100.0, 300.0);
+
+            Assert.Empty(actions);
+            Assert.Contains(logLines, l =>
+                l.Contains("[LedgerOrchestrator]")
+                && l.Contains("CreateVesselCostActions")
+                && l.Contains("gloops-cost-empty")
+                && l.Contains("ghost-only"));
+        }
+
+        // ================================================================
+        // 4. FilterOutGhostOnlyActions — drops ghost-only, keeps normal + empty-tag
+        // ================================================================
+
+        [Fact]
+        public void FilterOutGhostOnlyActions_DropsGhostOnlyAndKeepsOthers()
+        {
+            // Seed two recordings: one ghost-only, one normal.
+            var ghostOnly = new Recording { RecordingId = "gloops-A", IsGhostOnly = true };
+            var normal = new Recording { RecordingId = "normal-B", IsGhostOnly = false };
+            RecordingStore.AddRecordingWithTreeForTesting(ghostOnly);
+            RecordingStore.AddRecordingWithTreeForTesting(normal);
+
+            // Three actions: one ghost-only-tagged, one normal-tagged, one empty-tagged
+            // (legitimate empty-RecordingId cases include InitialFunds/Science/Reputation
+            //  seed actions and KSC-spending-forwarded rows — those must survive the filter).
+            var actions = new List<GameAction>
+            {
+                new GameAction { RecordingId = "gloops-A", Type = GameActionType.KerbalAssignment },
+                new GameAction { RecordingId = "normal-B", Type = GameActionType.KerbalAssignment },
+                new GameAction { RecordingId = "", Type = GameActionType.FundsInitial },
+            };
+
+            var filtered = LedgerOrchestrator.FilterOutGhostOnlyActions(actions);
+
+            Assert.Equal(2, filtered.Count);
+            Assert.DoesNotContain(filtered, a => a.RecordingId == "gloops-A");
+            Assert.Contains(filtered, a => a.RecordingId == "normal-B");
+            Assert.Contains(filtered, a => string.IsNullOrEmpty(a.RecordingId));
+        }
+
+        [Fact]
+        public void FilterOutGhostOnlyActions_NoGhostOnlyRecordings_ReturnsInputUnchanged()
+        {
+            var normal = new Recording { RecordingId = "normal-only", IsGhostOnly = false };
+            RecordingStore.AddRecordingWithTreeForTesting(normal);
+
+            var actions = new List<GameAction>
+            {
+                new GameAction { RecordingId = "normal-only", Type = GameActionType.KerbalAssignment },
+                new GameAction { RecordingId = "", Type = GameActionType.FundsInitial },
+            };
+
+            var filtered = LedgerOrchestrator.FilterOutGhostOnlyActions(actions);
+
+            // When no ghost-only recordings exist, the filter short-circuits to the input.
+            Assert.Equal(2, filtered.Count);
+        }
+
+        // ================================================================
+        // 5. Active-recording tag never returns a Gloops id (invariant guard)
+        //    + forced Gloops-tagged event can be purged (mechanism check)
+        // ================================================================
+
+        [Fact]
+        public void GetActiveRecordingIdForTagging_WithGloopsCommittedInStore_ReturnsEmpty()
+        {
+            // Simulate a committed Gloops recording in the store.
+            var gloops = new Recording
+            {
+                RecordingId = "gloops-B",
+                VesselName = "Air Show",
+                IsGhostOnly = true,
+            };
+            gloops.Points.Add(new TrajectoryPoint { ut = 10.0 });
+            gloops.Points.Add(new TrajectoryPoint { ut = 20.0 });
+            RecordingStore.CommitGloopsRecording(gloops);
+
+            // No ParsekFlight.Instance in tests -> active tree is absent.
+            // Resolver must return "" (empty), never the Gloops id.
+            string tag = ParsekFlight.GetActiveRecordingIdForTagging();
+
+            Assert.NotEqual("gloops-B", tag);
+            Assert.True(string.IsNullOrEmpty(tag));
+        }
+
+        [Fact]
+        public void PurgeEventsForRecordings_RemovesForcedGloopsTaggedEvent()
+        {
+            // This test pins the purge *mechanism* — forcing a Gloops-tagged event
+            // into the store via the test hook and asserting it can be purged.
+            // The default resolver never produces such events (previous test).
+            GameStateRecorder.TagResolverForTesting = () => "gloops-forced";
+
+            var evt = new GameStateEvent
+            {
+                ut = 100.0,
+                eventType = GameStateEventType.ContractAccepted,
+                key = "contract-1",
+                detail = ""
+            };
+            GameStateRecorder.Emit(evt, "test");
+
+            int beforeCount = GameStateStore.EventCount;
+            Assert.True(beforeCount >= 1);
+
+            int removed = GameStateStore.PurgeEventsForRecordings(
+                new[] { "gloops-forced" }, "test");
+
+            Assert.Equal(1, removed);
+            Assert.Equal(beforeCount - 1, GameStateStore.EventCount);
+        }
+
+        // ================================================================
+        // 6-7. RecalculateAndPatch integration — log fires when filtering happens
+        // ================================================================
+
+        [Fact]
+        public void RecalculateAndPatch_FilterLogFires_WhenGhostOnlyActionPresent()
+        {
+            // Seed a ghost-only recording and a stale ledger row tagged with its id
+            // (simulating a pre-fix save that leaked into Ledger.Actions).
+            var ghostOnly = new Recording { RecordingId = "gloops-stale", IsGhostOnly = true };
+            RecordingStore.AddRecordingWithTreeForTesting(ghostOnly);
+
+            Ledger.AddAction(new GameAction
+            {
+                UT = 100.0,
+                Type = GameActionType.KerbalAssignment,
+                RecordingId = "gloops-stale",
+                KerbalName = "Jeb Kerman",
+                KerbalRole = "Pilot",
+                StartUT = 100f,
+                EndUT = 200f,
+                KerbalEndStateField = KerbalEndState.Aboard,
+            });
+
+            LedgerOrchestrator.RecalculateAndPatch();
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[LedgerOrchestrator]")
+                && l.Contains("filtered 1 action(s) tagged with ghost-only recordings"));
+        }
+
+        [Fact]
+        public void RecalculateAndPatch_NoFilterLog_WhenNoGhostOnlyRecordings()
+        {
+            var normal = new Recording { RecordingId = "normal-only", IsGhostOnly = false };
+            RecordingStore.AddRecordingWithTreeForTesting(normal);
+
+            Ledger.AddAction(new GameAction
+            {
+                UT = 100.0,
+                Type = GameActionType.KerbalAssignment,
+                RecordingId = "normal-only",
+                KerbalName = "Jeb Kerman",
+                KerbalRole = "Pilot",
+                StartUT = 100f,
+                EndUT = 200f,
+                KerbalEndStateField = KerbalEndState.Aboard,
+            });
+
+            LedgerOrchestrator.RecalculateAndPatch();
+
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("[LedgerOrchestrator]")
+                && l.Contains("filtered") && l.Contains("ghost-only"));
+        }
+
+        // ================================================================
+        // 8. MigrateKerbalAssignments self-heal: stale pre-fix rows get replaced
+        //    with the (now empty) guarded output of CreateKerbalAssignmentActions.
+        // ================================================================
+
+        [Fact]
+        public void OnKspLoad_RewritesStaleGhostOnlyKerbalRowsToEmpty()
+        {
+            // Pre-fix scenario: a Gloops recording committed on an older build already
+            // has a KerbalAssignment row in Ledger.Actions tagged with its id.
+            var gloopsWithCrew = MakeCrewedRecording("gloops-stale-crew", ghostOnly: true);
+            RecordingStore.AddRecordingWithTreeForTesting(gloopsWithCrew);
+
+            Ledger.AddAction(new GameAction
+            {
+                UT = 100.0,
+                Type = GameActionType.KerbalAssignment,
+                RecordingId = "gloops-stale-crew",
+                KerbalName = "Jeb Kerman",
+                KerbalRole = "Pilot",
+                StartUT = 100f,
+                EndUT = 200f,
+                KerbalEndStateField = KerbalEndState.Aboard,
+            });
+
+            int before = Ledger.Actions.Count;
+            Assert.Equal(1, before);
+
+            var validIds = new HashSet<string> { "gloops-stale-crew" };
+            LedgerOrchestrator.OnKspLoad(validIds, maxUT: 1000.0);
+
+            // MigrateKerbalAssignments should have replaced the stale row with an empty
+            // desired list (CreateKerbalAssignmentActions returns empty for ghost-only).
+            int afterGhost = 0;
+            for (int i = 0; i < Ledger.Actions.Count; i++)
+            {
+                var a = Ledger.Actions[i];
+                if (a.Type == GameActionType.KerbalAssignment
+                    && a.RecordingId == "gloops-stale-crew")
+                    afterGhost++;
+            }
+            Assert.Equal(0, afterGhost);
+        }
+    }
+}

--- a/Source/Parsek.Tests/GloopsEventSuppressionTests.cs
+++ b/Source/Parsek.Tests/GloopsEventSuppressionTests.cs
@@ -8,7 +8,7 @@ namespace Parsek.Tests
     /// #432 — Gloops ghost-only recordings must contribute zero actions to the ledger.
     /// Covers the two action-creation guards in <see cref="LedgerOrchestrator"/>
     /// (<c>CreateKerbalAssignmentActions</c>, <c>CreateVesselCostActions</c>), the
-    /// belt-and-braces <c>FilterOutGhostOnlyActions</c> pre-pass, the walk-integration
+    /// belt-and-braces <c>PurgeGhostOnlyActionsFromLedger</c> pre-pass, the walk-integration
     /// log signal from <c>RecalculateAndPatch</c>, the self-heal path through
     /// <c>MigrateKerbalAssignments</c> → <c>OnKspLoad</c>, and the invariant that
     /// events never get tagged with a Gloops recording's id in the first place.
@@ -140,117 +140,95 @@ namespace Parsek.Tests
         }
 
         // ================================================================
-        // 4. FilterOutGhostOnlyActions — drops ghost-only, keeps normal + empty-tag
+        // 4. PurgeGhostOnlyActionsFromLedger — mutates Ledger.Actions in place
         // ================================================================
 
         [Fact]
-        public void FilterOutGhostOnlyActions_DropsGhostOnlyAndKeepsOthers()
+        public void PurgeGhostOnlyActionsFromLedger_DropsGhostOnlyRowsAndMutatesLedger()
         {
-            // Seed two recordings: one ghost-only, one normal.
+            // Seed two committed recordings: one ghost-only, one normal.
             var ghostOnly = new Recording { RecordingId = "gloops-A", IsGhostOnly = true };
             var normal = new Recording { RecordingId = "normal-B", IsGhostOnly = false };
             RecordingStore.AddRecordingWithTreeForTesting(ghostOnly);
             RecordingStore.AddRecordingWithTreeForTesting(normal);
 
-            // Three actions: one ghost-only-tagged, one normal-tagged, one empty-tagged
-            // (legitimate empty-RecordingId cases include InitialFunds/Science/Reputation
-            //  seed actions and KSC-spending-forwarded rows — those must survive the filter).
-            var actions = new List<GameAction>
-            {
-                new GameAction { RecordingId = "gloops-A", Type = GameActionType.KerbalAssignment },
-                new GameAction { RecordingId = "normal-B", Type = GameActionType.KerbalAssignment },
-                new GameAction { RecordingId = "", Type = GameActionType.FundsInitial },
-            };
+            // Pre-fix / regression scenario: three stale actions in Ledger.Actions —
+            // one tagged to the ghost-only recording, one to the normal one, and a
+            // legitimate empty-tag seed row (which must survive — empty-RecordingId
+            // actions cover InitialFunds/Science/Reputation seeds, KSC-spending-
+            // forwarded rows, and MigrateOldSaveEvents output).
+            Ledger.AddAction(new GameAction { RecordingId = "gloops-A", Type = GameActionType.KerbalAssignment });
+            Ledger.AddAction(new GameAction { RecordingId = "normal-B", Type = GameActionType.KerbalAssignment });
+            Ledger.AddAction(new GameAction { RecordingId = "", Type = GameActionType.FundsInitial });
 
-            var filtered = LedgerOrchestrator.FilterOutGhostOnlyActions(actions);
+            Assert.Equal(3, Ledger.Actions.Count);
 
-            Assert.Equal(2, filtered.Count);
-            Assert.DoesNotContain(filtered, a => a.RecordingId == "gloops-A");
-            Assert.Contains(filtered, a => a.RecordingId == "normal-B");
-            Assert.Contains(filtered, a => string.IsNullOrEmpty(a.RecordingId));
+            int removed = LedgerOrchestrator.PurgeGhostOnlyActionsFromLedger();
+
+            Assert.Equal(1, removed);
+            Assert.Equal(2, Ledger.Actions.Count);
+            // Timeline / career-state views read Ledger.Actions directly, so mutate
+            // in place — not just filter a walk-time copy.
+            Assert.DoesNotContain(Ledger.Actions, a => a.RecordingId == "gloops-A");
+            Assert.Contains(Ledger.Actions, a => a.RecordingId == "normal-B");
+            Assert.Contains(Ledger.Actions, a => string.IsNullOrEmpty(a.RecordingId));
         }
 
         [Fact]
-        public void FilterOutGhostOnlyActions_PreservesMigratedOldSaveActionsWithEmptyTag()
+        public void PurgeGhostOnlyActionsFromLedger_PreservesMigratedOldSaveActionsWithNullTag()
         {
             // MigrateOldSaveEvents (LedgerOrchestrator.cs:803) converts pre-ledger
             // save events into GameActions with null/empty RecordingId — documented
-            // intentional tradeoff: we can't reliably map them to specific recordings.
-            // The filter must keep these alongside the legitimate seed-action empty tags.
+            // intentional tradeoff: we cannot reliably map them to specific recordings.
+            // The purge must keep these alongside the legitimate seed-action empty tags.
             var ghostOnly = new Recording { RecordingId = "gloops-old", IsGhostOnly = true };
             RecordingStore.AddRecordingWithTreeForTesting(ghostOnly);
 
-            var actions = new List<GameAction>
-            {
-                // Simulated MigrateOldSaveEvents output: a FundsSpending with null tag.
-                new GameAction { RecordingId = null, Type = GameActionType.FundsSpending, FundsSpent = 1000f },
-                // Simulated InitialFunds seed.
-                new GameAction { RecordingId = "", Type = GameActionType.FundsInitial },
-                // The actually-ghost-only-tagged row that must be dropped.
-                new GameAction { RecordingId = "gloops-old", Type = GameActionType.KerbalAssignment },
-            };
+            Ledger.AddAction(new GameAction { RecordingId = null, Type = GameActionType.FundsSpending, FundsSpent = 1000f });
+            Ledger.AddAction(new GameAction { RecordingId = "", Type = GameActionType.FundsInitial });
+            Ledger.AddAction(new GameAction { RecordingId = "gloops-old", Type = GameActionType.KerbalAssignment });
 
-            var filtered = LedgerOrchestrator.FilterOutGhostOnlyActions(actions);
+            int removed = LedgerOrchestrator.PurgeGhostOnlyActionsFromLedger();
 
-            Assert.Equal(2, filtered.Count);
-            Assert.Contains(filtered, a => a.Type == GameActionType.FundsSpending && a.RecordingId == null);
-            Assert.Contains(filtered, a => a.Type == GameActionType.FundsInitial);
-            Assert.DoesNotContain(filtered, a => a.RecordingId == "gloops-old");
+            Assert.Equal(1, removed);
+            Assert.Equal(2, Ledger.Actions.Count);
+            Assert.Contains(Ledger.Actions, a => a.Type == GameActionType.FundsSpending && a.RecordingId == null);
+            Assert.Contains(Ledger.Actions, a => a.Type == GameActionType.FundsInitial);
+            Assert.DoesNotContain(Ledger.Actions, a => a.RecordingId == "gloops-old");
         }
 
         [Fact]
-        public void FilterOutGhostOnlyActions_NoGhostOnlyRecordings_ReturnsInputUnchanged()
+        public void PurgeGhostOnlyActionsFromLedger_NoGhostOnlyRecordings_Noop()
         {
             var normal = new Recording { RecordingId = "normal-only", IsGhostOnly = false };
             RecordingStore.AddRecordingWithTreeForTesting(normal);
 
-            var actions = new List<GameAction>
-            {
-                new GameAction { RecordingId = "normal-only", Type = GameActionType.KerbalAssignment },
-                new GameAction { RecordingId = "", Type = GameActionType.FundsInitial },
-            };
+            Ledger.AddAction(new GameAction { RecordingId = "normal-only", Type = GameActionType.KerbalAssignment });
+            Ledger.AddAction(new GameAction { RecordingId = "", Type = GameActionType.FundsInitial });
 
-            var filtered = LedgerOrchestrator.FilterOutGhostOnlyActions(actions);
+            int removed = LedgerOrchestrator.PurgeGhostOnlyActionsFromLedger();
 
-            // When no ghost-only recordings exist, the filter short-circuits to the input.
-            Assert.Equal(2, filtered.Count);
+            Assert.Equal(0, removed);
+            Assert.Equal(2, Ledger.Actions.Count);
         }
 
-        // ================================================================
-        // 5. Active-recording tag never returns a Gloops id (invariant guard)
-        //    + forced Gloops-tagged event can be purged (mechanism check)
-        // ================================================================
-
         [Fact]
-        public void GetActiveRecordingIdForTagging_WithGloopsAndNormalCommitted_NeverReturnsGloopsId()
+        public void PurgeGhostOnlyActionsFromLedger_RemovesAllTypesForGhostOnlyRecording()
         {
-            // Seed BOTH a committed Gloops recording and a committed normal recording.
-            // The resolver must never return the Gloops id — proving that empty return
-            // is due to the resolver honoring the active tree (empty in tests, no
-            // ParsekFlight.Instance), not due to "the Gloops recording happened to be
-            // skipped because no recording was committed at all."
-            var gloops = new Recording
-            {
-                RecordingId = "gloops-B",
-                VesselName = "Air Show",
-                IsGhostOnly = true,
-            };
-            gloops.Points.Add(new TrajectoryPoint { ut = 10.0 });
-            gloops.Points.Add(new TrajectoryPoint { ut = 20.0 });
-            RecordingStore.CommitGloopsRecording(gloops);
+            // A ghost-only recording may have multiple action types leaked in from
+            // different migration / past-code paths — the purge must remove them all,
+            // not just one type (as ReplaceActionsForRecording would for KerbalAssignment).
+            var ghostOnly = new Recording { RecordingId = "gloops-multi", IsGhostOnly = true };
+            RecordingStore.AddRecordingWithTreeForTesting(ghostOnly);
 
-            var normal = new Recording { RecordingId = "normal-A", IsGhostOnly = false };
-            RecordingStore.AddRecordingWithTreeForTesting(normal);
+            Ledger.AddAction(new GameAction { RecordingId = "gloops-multi", Type = GameActionType.KerbalAssignment });
+            Ledger.AddAction(new GameAction { RecordingId = "gloops-multi", Type = GameActionType.FundsSpending, FundsSpent = 5000f });
+            Ledger.AddAction(new GameAction { RecordingId = "gloops-multi", Type = GameActionType.FundsEarning, FundsAwarded = 3000f });
 
-            // Call the resolver many times to rule out any nondeterministic path.
-            for (int i = 0; i < 10; i++)
-            {
-                string tag = ParsekFlight.GetActiveRecordingIdForTagging();
-                Assert.NotEqual("gloops-B", tag);
-                // May return "" or "normal-A" depending on activeTree wiring; never the Gloops id.
-                Assert.True(tag == "" || tag == "normal-A",
-                    $"Unexpected tag '{tag}' — resolver must return the active tree's id or empty");
-            }
+            int removed = LedgerOrchestrator.PurgeGhostOnlyActionsFromLedger();
+
+            Assert.Equal(3, removed);
+            Assert.Empty(Ledger.Actions);
         }
 
         [Fact]
@@ -292,14 +270,13 @@ namespace Parsek.Tests
         }
 
         // ================================================================
-        // 6-7. RecalculateAndPatch integration — log fires when filtering happens
+        // RecalculateAndPatch integration — purge happens in-place, log fires once,
+        // subsequent calls are no-ops because the ledger is already clean.
         // ================================================================
 
         [Fact]
-        public void RecalculateAndPatch_FilterLogFires_WhenGhostOnlyActionPresent()
+        public void RecalculateAndPatch_PurgesGhostOnlyActions_AndSecondCallIsNoop()
         {
-            // Seed a ghost-only recording and a stale ledger row tagged with its id
-            // (simulating a pre-fix save that leaked into Ledger.Actions).
             var ghostOnly = new Recording { RecordingId = "gloops-stale", IsGhostOnly = true };
             RecordingStore.AddRecordingWithTreeForTesting(ghostOnly);
 
@@ -317,24 +294,24 @@ namespace Parsek.Tests
 
             LedgerOrchestrator.RecalculateAndPatch();
 
+            // Purge log fired and the stale row is gone from Ledger.Actions itself.
             Assert.Contains(logLines, l =>
                 l.Contains("[LedgerOrchestrator]")
-                && l.Contains("filtered 1 action(s) tagged with ghost-only recordings"));
+                && l.Contains("PurgeGhostOnlyActionsFromLedger")
+                && l.Contains("removed 1 action(s)"));
+            Assert.DoesNotContain(Ledger.Actions, a => a.RecordingId == "gloops-stale");
 
-            // Filter fires on every RecalculateAndPatch as long as the stale row sits in
-            // Ledger.Actions. The self-heal path (via MigrateKerbalAssignments in
-            // OnKspLoad) is what actually rewrites the stale row — the walk filter itself
-            // does not mutate Ledger.Actions. Verify this: a second call produces another
-            // filter line with the same count.
+            // Second call is a no-op: nothing left to purge, so no purge log line fires.
             logLines.Clear();
             LedgerOrchestrator.RecalculateAndPatch();
-            Assert.Contains(logLines, l =>
+            Assert.DoesNotContain(logLines, l =>
                 l.Contains("[LedgerOrchestrator]")
-                && l.Contains("filtered 1 action(s) tagged with ghost-only recordings"));
+                && l.Contains("PurgeGhostOnlyActionsFromLedger")
+                && l.Contains("removed"));
         }
 
         [Fact]
-        public void RecalculateAndPatch_NoFilterLog_WhenNoGhostOnlyRecordings()
+        public void RecalculateAndPatch_NoPurgeLog_WhenNoGhostOnlyRecordings()
         {
             var normal = new Recording { RecordingId = "normal-only", IsGhostOnly = false };
             RecordingStore.AddRecordingWithTreeForTesting(normal);
@@ -355,7 +332,10 @@ namespace Parsek.Tests
 
             Assert.DoesNotContain(logLines, l =>
                 l.Contains("[LedgerOrchestrator]")
-                && l.Contains("filtered") && l.Contains("ghost-only"));
+                && l.Contains("PurgeGhostOnlyActionsFromLedger")
+                && l.Contains("removed"));
+            // Normal action survives.
+            Assert.Contains(Ledger.Actions, a => a.RecordingId == "normal-only");
         }
 
         // ================================================================

--- a/Source/Parsek/GameActions/Ledger.cs
+++ b/Source/Parsek/GameActions/Ledger.cs
@@ -105,6 +105,32 @@ namespace Parsek
                 $"removed={removed}, inserted={replacements.Count}, total={actions.Count}");
         }
 
+        /// <summary>
+        /// Removes every action tagged with the given recording id (regardless of type).
+        /// Returns the number of actions removed. Null/empty recordingId is a no-op.
+        /// </summary>
+        internal static int RemoveActionsForRecording(string recordingId)
+        {
+            if (string.IsNullOrEmpty(recordingId))
+                return 0;
+
+            int removed = 0;
+            for (int i = actions.Count - 1; i >= 0; i--)
+            {
+                if (string.Equals(actions[i].RecordingId, recordingId, StringComparison.Ordinal))
+                {
+                    actions.RemoveAt(i);
+                    removed++;
+                }
+            }
+
+            if (removed > 0)
+                ParsekLog.Verbose("Ledger",
+                    $"RemoveActionsForRecording: recordingId='{recordingId}', removed={removed}, total={actions.Count}");
+
+            return removed;
+        }
+
         /// <summary>Clears all actions from the in-memory ledger.</summary>
         internal static void Clear()
         {

--- a/Source/Parsek/GameActions/LedgerOrchestrator.cs
+++ b/Source/Parsek/GameActions/LedgerOrchestrator.cs
@@ -609,40 +609,42 @@ namespace Parsek
         }
 
         /// <summary>
-        /// #432: filters out any action whose <see cref="GameAction.RecordingId"/> belongs to a
-        /// ghost-only (Gloops) recording. Pure belt-and-braces defense — today's action-creation
-        /// paths already skip ghost-only recordings, but this catches future regressions and any
-        /// stale ledger rows left by pre-fix builds. Empty-RecordingId actions (InitialFunds /
-        /// InitialScience / InitialReputation seeds at <c>:625,631,637</c>, KSC-forwarded rows at
-        /// <c>:1350</c>) are preserved.
+        /// #432: removes every action in <see cref="Ledger.Actions"/> whose <c>RecordingId</c>
+        /// belongs to a ghost-only (Gloops) recording. Mutates the ledger in place so raw-ledger
+        /// consumers (Timeline, career-state views) see a clean list — filtering only the walk
+        /// copy would leave stale rows visible elsewhere. Action-creation guards
+        /// (<see cref="CreateKerbalAssignmentActions"/>, <see cref="CreateVesselCostActions"/>)
+        /// already prevent new ghost-only rows from being produced; this catches pre-fix saves
+        /// and any future regression that deposits a ghost-only-tagged action via some other
+        /// path. Empty-<c>RecordingId</c> actions (InitialFunds / InitialScience / InitialReputation
+        /// seeds, KSC-spending-forwarded rows, and <see cref="MigrateOldSaveEvents"/> output) are
+        /// preserved — <see cref="Ledger.RemoveActionsForRecording"/> keys strictly on non-empty ids.
+        /// Returns the number of actions removed.
         /// </summary>
-        internal static List<GameAction> FilterOutGhostOnlyActions(List<GameAction> actions)
+        internal static int PurgeGhostOnlyActionsFromLedger()
         {
-            if (actions == null || actions.Count == 0)
-                return actions ?? new List<GameAction>();
+            var recs = RecordingStore.CommittedRecordings;
+            if (recs == null || recs.Count == 0) return 0;
 
             var ghostOnlyIds = new HashSet<string>(StringComparer.Ordinal);
-            var recs = RecordingStore.CommittedRecordings;
-            if (recs != null)
+            for (int i = 0; i < recs.Count; i++)
             {
-                for (int i = 0; i < recs.Count; i++)
-                {
-                    var r = recs[i];
-                    if (r != null && r.IsGhostOnly && !string.IsNullOrEmpty(r.RecordingId))
-                        ghostOnlyIds.Add(r.RecordingId);
-                }
+                var r = recs[i];
+                if (r != null && r.IsGhostOnly && !string.IsNullOrEmpty(r.RecordingId))
+                    ghostOnlyIds.Add(r.RecordingId);
             }
 
-            if (ghostOnlyIds.Count == 0) return actions;
+            if (ghostOnlyIds.Count == 0) return 0;
 
-            var kept = new List<GameAction>(actions.Count);
-            for (int i = 0; i < actions.Count; i++)
-            {
-                var a = actions[i];
-                if (string.IsNullOrEmpty(a.RecordingId) || !ghostOnlyIds.Contains(a.RecordingId))
-                    kept.Add(a);
-            }
-            return kept;
+            int removedTotal = 0;
+            foreach (var id in ghostOnlyIds)
+                removedTotal += Ledger.RemoveActionsForRecording(id);
+
+            if (removedTotal > 0)
+                ParsekLog.Info(Tag,
+                    $"PurgeGhostOnlyActionsFromLedger: removed {removedTotal} action(s) tagged with ghost-only recordings");
+
+            return removedTotal;
         }
 
         /// <summary>
@@ -709,20 +711,17 @@ namespace Parsek
             // End-state population safety net: catch recordings with unpopulated end states
             PopulateUnpopulatedCrewEndStates();
 
+            // #432: purge any ghost-only-tagged actions from the ledger before the walk.
+            // Mutates Ledger.Actions directly so raw-ledger consumers (Timeline window,
+            // career-state views) never see stale rows — filtering the walk copy alone
+            // would leave Ledger.Actions dirty. Idempotent — no-op when no ghost-only
+            // recordings exist or no actions are tagged with them. CreateKerbalAssignment-
+            // Actions / CreateVesselCostActions already skip ghost-only recordings; this
+            // catches pre-fix saves and any future regression that deposits a ghost-only-
+            // tagged action via some other path.
+            PurgeGhostOnlyActionsFromLedger();
+
             var actions = new List<GameAction>(Ledger.Actions);
-
-            // #432: belt-and-braces filter — no action tagged with a ghost-only recording
-            // reaches the walk. CreateKerbalAssignmentActions and CreateVesselCostActions
-            // already skip ghost-only recordings; this catches future regressions and
-            // pre-fix saves where a stale action might still sit in Ledger.Actions
-            // (self-heals on next MigrateKerbalAssignments pass).
-            int beforeFilter = actions.Count;
-            actions = FilterOutGhostOnlyActions(actions);
-            int filtered = beforeFilter - actions.Count;
-            if (filtered > 0)
-                ParsekLog.Info(Tag,
-                    $"RecalculateAndPatch: filtered {filtered} action(s) tagged with ghost-only recordings");
-
             RecalculationEngine.Recalculate(actions);
 
             // KSP state mutations (PostWalk already called by engine)

--- a/Source/Parsek/GameActions/LedgerOrchestrator.cs
+++ b/Source/Parsek/GameActions/LedgerOrchestrator.cs
@@ -406,6 +406,14 @@ namespace Parsek
                 return result;
             }
 
+            // #432: ghost-only recordings (Gloops) have zero career footprint on the ledger.
+            if (rec.IsGhostOnly)
+            {
+                ParsekLog.Verbose(Tag,
+                    $"CreateVesselCostActions: recording '{recordingId}' is ghost-only — skipping");
+                return result;
+            }
+
             if (rec.Points.Count == 0)
             {
                 ParsekLog.Verbose(Tag,
@@ -475,6 +483,16 @@ namespace Parsek
 
             var rec = FindRecordingById(recordingId);
             if (rec == null) return result;
+
+            // #432: ghost-only recordings (Gloops) have zero career footprint on the ledger.
+            // Closes the MigrateKerbalAssignments leak where a crewed Gloops recording would
+            // reserve its kerbals for the loop duration.
+            if (rec.IsGhostOnly)
+            {
+                ParsekLog.Verbose(Tag,
+                    $"CreateKerbalAssignmentActions: recording '{recordingId}' is ghost-only — skipping");
+                return result;
+            }
 
             if (NeedsCrewEndStatePopulation(rec))
                 KerbalsModule.PopulateCrewEndStates(rec);
@@ -587,6 +605,43 @@ namespace Parsek
         }
 
         /// <summary>
+        /// #432: filters out any action whose <see cref="GameAction.RecordingId"/> belongs to a
+        /// ghost-only (Gloops) recording. Pure belt-and-braces defense — today's action-creation
+        /// paths already skip ghost-only recordings, but this catches future regressions and any
+        /// stale ledger rows left by pre-fix builds. Empty-RecordingId actions (InitialFunds /
+        /// InitialScience / InitialReputation seeds at <c>:625,631,637</c>, KSC-forwarded rows at
+        /// <c>:1350</c>) are preserved.
+        /// </summary>
+        internal static List<GameAction> FilterOutGhostOnlyActions(List<GameAction> actions)
+        {
+            if (actions == null || actions.Count == 0)
+                return actions ?? new List<GameAction>();
+
+            var ghostOnlyIds = new HashSet<string>(StringComparer.Ordinal);
+            var recs = RecordingStore.CommittedRecordings;
+            if (recs != null)
+            {
+                for (int i = 0; i < recs.Count; i++)
+                {
+                    var r = recs[i];
+                    if (r != null && r.IsGhostOnly && !string.IsNullOrEmpty(r.RecordingId))
+                        ghostOnlyIds.Add(r.RecordingId);
+                }
+            }
+
+            if (ghostOnlyIds.Count == 0) return actions;
+
+            var kept = new List<GameAction>(actions.Count);
+            for (int i = 0; i < actions.Count; i++)
+            {
+                var a = actions[i];
+                if (string.IsNullOrEmpty(a.RecordingId) || !ghostOnlyIds.Contains(a.RecordingId))
+                    kept.Add(a);
+            }
+            return kept;
+        }
+
+        /// <summary>
         /// Finds a committed recording by its ID. Returns null if not found.
         /// </summary>
         internal static Recording FindRecordingById(string recordingId)
@@ -651,6 +706,19 @@ namespace Parsek
             PopulateUnpopulatedCrewEndStates();
 
             var actions = new List<GameAction>(Ledger.Actions);
+
+            // #432: belt-and-braces filter — no action tagged with a ghost-only recording
+            // reaches the walk. CreateKerbalAssignmentActions and CreateVesselCostActions
+            // already skip ghost-only recordings; this catches future regressions and
+            // pre-fix saves where a stale action might still sit in Ledger.Actions
+            // (self-heals on next MigrateKerbalAssignments pass).
+            int beforeFilter = actions.Count;
+            actions = FilterOutGhostOnlyActions(actions);
+            int filtered = beforeFilter - actions.Count;
+            if (filtered > 0)
+                ParsekLog.Info(Tag,
+                    $"RecalculateAndPatch: filtered {filtered} action(s) tagged with ghost-only recordings");
+
             RecalculationEngine.Recalculate(actions);
 
             // KSP state mutations (PostWalk already called by engine)

--- a/Source/Parsek/GameActions/LedgerOrchestrator.cs
+++ b/Source/Parsek/GameActions/LedgerOrchestrator.cs
@@ -486,7 +486,11 @@ namespace Parsek
 
             // #432: ghost-only recordings (Gloops) have zero career footprint on the ledger.
             // Closes the MigrateKerbalAssignments leak where a crewed Gloops recording would
-            // reserve its kerbals for the loop duration.
+            // reserve its kerbals for the loop duration. Note that end-state population still
+            // occurs via PopulateUnpopulatedCrewEndStates (the safety-net pass inside
+            // RecalculateAndPatch at :1108) for Gloops recordings that need CrewEndStates for
+            // the Kerbals-window per-recording-fates view; only the ledger-action emission is
+            // suppressed here.
             if (rec.IsGhostOnly)
             {
                 ParsekLog.Verbose(Tag,

--- a/docs/dev/plans/fix-432-gloops-no-events.md
+++ b/docs/dev/plans/fix-432-gloops-no-events.md
@@ -1,0 +1,359 @@
+# Fix #432 — Gloops ghost-only recordings must not capture or apply any game events
+
+**Branch:** `fix/432-gloops-no-events` (off `origin/main`)
+**Worktree:** `C:/Users/vlad3/Documents/Code/Parsek/Parsek-432-gloops-no-events`
+**Depends on:** #431 (PR #332, merged) — the `GameStateRecorder.Emit` funnel.
+**Unrelated to:** #434 (PR #333, open) — same naming convention, independent scope.
+
+## Invariant to enforce
+
+> A Gloops ghost-only recording has zero career-state footprint. No `GameStateEvent` is captured while the Gloops recorder is live, and no ledger action is produced from a committed `IsGhostOnly` recording.
+
+## Why the naive "check active recording's IsGhostOnly" accessor does not work
+
+The bug entry and the user's task brief both propose an accessor like `ParsekFlight.GetActiveRecordingGhostOnlyFlag()` that probes the active recording's `IsGhostOnly` flag. That probe returns the wrong answer for the live-capture window because of how Gloops is wired:
+
+- `ParsekFlight.gloopsRecorder` (`ParsekFlight.cs:7426`) is a **parallel** `FlightRecorder` instance with `IsGloopsMode = true`. It runs **alongside** the normal `recorder` (`ParsekFlight.cs:55`); neither suppresses the other. `StartGloopsRecording` (`ParsekFlight.cs:7445`) has no gate against an already-running normal auto-record and vice versa.
+- A Gloops `Recording` object does not exist until commit. `CommitGloopsRecorderData` (`ParsekFlight.cs:7523-7562`) builds the `Recording`, sets `rec.IsGhostOnly = true` at `ParsekFlight.cs:7542`, and pushes it straight into `committedRecordings` via `RecordingStore.CommitGloopsRecording` (`RecordingStore.cs:394`). It never enters `pendingTree` and never becomes `activeTree.ActiveRecordingId`.
+- `ParsekFlight.GetActiveRecordingIdForTagging()` (`ParsekFlight.cs:35-36`) returns `Instance?.activeTree?.ActiveRecordingId ?? ""` — the **normal** active recording's id, or `""`. It cannot point at a Gloops recording during the live window.
+
+So the live-capture gate has to be "is a Gloops recorder currently sampling?" — which is already exposed as `ParsekFlight.IsGloopsRecording` (`ParsekFlight.cs:7430`, `gloopsRecorder?.IsRecording ?? false`). That is the accessor the Emit guard reads.
+
+The apply-side gate is a different question: committed Gloops recordings live in `RecordingStore.CommittedRecordings` with `rec.IsGhostOnly == true`, and the ledger's action-generation paths walk that list. On the apply side we do check `rec.IsGhostOnly`.
+
+## Current-state map (as of 2026-04-17 on `fix/432-gloops-no-events`, post-#431)
+
+### `IsGhostOnly` declaration and lifecycle
+
+- `Source/Parsek/Recording.cs:29` — `public bool IsGhostOnly;` on the `Recording` object. Serialized at `RecordingTree.cs:526-527` (only written when true), deserialized at `RecordingTree.cs:953`.
+- `Source/Parsek/ParsekFlight.cs:7542` — `rec.IsGhostOnly = true;` set at commit time inside `CommitGloopsRecorderData`.
+- `Source/Parsek/RecordingStore.cs:402` — belt-and-braces: `CommitGloopsRecording` re-asserts `rec.IsGhostOnly = true;` before adding to `committedRecordings`.
+- `Source/Parsek/FlightRecorder.cs:120` — `internal bool IsGloopsMode { get; set; }`, set once at `ParsekFlight.cs:7460` (`new FlightRecorder { IsGloopsMode = true }`). Read at `FlightRecorder.cs:4207, 4212, 4240, 4717, 5143` to skip resource baselines / rewind save / tree logic / auto-stop on vessel switch.
+
+### Gloops lifecycle — start, stop, auto-commit, discard
+
+- Start: `ParsekFlight.StartGloopsRecording` (`ParsekFlight.cs:7445-7482`) allocates `gloopsRecorder`, calls `gloopsRecorder.StartRecording(isPromotion: false)`, stashes a ghost-visual snapshot. Does **not** stop or block the normal auto-recorder.
+- Stop (manual): `ParsekFlight.StopGloopsRecording` (`ParsekFlight.cs:7488-7501`) → `CommitGloopsRecorderData` (`ParsekFlight.cs:7523`) → `RecordingStore.CommitGloopsRecording` (`RecordingStore.cs:394`).
+- Stop (auto, on vessel switch): `FlightRecorder.HandleVesselSwitchDuringRecording` (`FlightRecorder.cs:5140-5151`) calls `StopRecording()` then sets `GloopsAutoStoppedByVesselSwitch = true`. `ParsekFlight.CheckGloopsAutoStoppedByVesselSwitch` (`ParsekFlight.cs:7507-7516`) fires on the next frame and commits. **Gloops does NOT stash into `LimboVesselSwitch`** — that state is only ever set by the normal-recording tree path.
+- Discard: `ParsekFlight.DiscardGloopsInProgress` (`ParsekFlight.cs:7567`) and `DiscardLastGloopsRecording` (referenced at `GloopsRecorderUI.cs:152`).
+- UI entry point: `Source/Parsek/UI/GloopsRecorderUI.cs` — only the "Start Recording" button at `:109`, reached via `flight.StartGloopsRecording()` at `:120`. There is no `switch-to-Gloops mid-flight` affordance.
+
+### Capture-side event paths (the sites the guard must cover)
+
+The #431 funnel is `GameStateRecorder.Emit(GameStateEvent evt, string source)` at `GameStateRecorder.cs:58-83`. Every `GameStateEvent` creation in that file routes through it — 17 sites, verified by `grep "Emit(" Source/Parsek/GameStateRecorder.cs`: lines 285, 341, 369, 395, 409, 459, 491, 542, 574, 665, 681, 726, 757, 788, 884, 1136, 1172.
+
+Two capture pipelines live **outside** the `Emit` funnel:
+
+- `GameStateRecorder.cs:832` — `PendingScienceSubjects.Add(new PendingScienceSubject { ... })` inside `OnScienceReceived`. This is the only `PendingScienceSubjects.Add` call site (`grep PendingScienceSubjects.Add Source/Parsek`). The subject is later committed into the ledger by `GameStateEventConverter.ConvertScienceSubjects` via `LedgerOrchestrator.OnRecordingCommitted` — Gloops recordings never call that path (see below), but a subject sitting in the pending list bleeds into **the next normal recording's** commit via `LedgerOrchestrator.NotifyLedgerTreeCommitted` (`LedgerOrchestrator.cs:1519-1560`). That is the real leak on the capture side.
+- `GameStateRecorder.cs:292` — `GameStateStore.AddContractSnapshot(guid, contractNode)` inside `OnContractAccepted`, fired immediately after the `ContractAccepted` `Emit` at `:285`. If the `Emit` is suppressed the snapshot should be too, otherwise a contract-revert snapshot lingers for a contract that was never recorded as accepted. `AddContractSnapshot` is defined at `GameStateStore.cs:120`; this is the only production caller.
+
+### Apply-side event paths (recording → ledger)
+
+The ledger is written at action-creation time, not at walk time. Paths that translate recordings into `GameAction`s:
+
+- `LedgerOrchestrator.OnRecordingCommitted` (`LedgerOrchestrator.cs:130-194`). Called only from `NotifyLedgerTreeCommitted` (`LedgerOrchestrator.cs:1546`), `ChainSegmentManager.CommitSegmentCore`, and `ParsekFlight.FallbackCommitSplitRecorder` — **none of which run for Gloops.** `CommitGloopsRecording` (`RecordingStore.cs:394-418`) does NOT call `NotifyLedgerTreeCommitted`. So the event-to-action convert at line `:141` and the science-to-action convert at line `:151` never touch Gloops recordings today.
+- `LedgerOrchestrator.CreateVesselCostActions` (`LedgerOrchestrator.cs:397-463`). Called from `OnRecordingCommitted` line `:156`. Not reached for Gloops (no commit path), but the routine blindly reads `rec.PreLaunchFunds - firstFunds` — because `FlightRecorder.cs:4207-4208` skips `CapturePreLaunchResources` in Gloops mode, `rec.PreLaunchFunds` is `0` and the resulting `buildCost` is strongly negative, so the `> 0` gate at `:421` means no action would be emitted even if the path were reached. The recovery-funds branch at `:439` gates on `TerminalStateValue == Recovered`, which a manual Gloops stop does not set.
+- `LedgerOrchestrator.CreateKerbalAssignmentActions` (`LedgerOrchestrator.cs:471-510`). Called from two sites:
+  - `:165` inside `OnRecordingCommitted` — not reached for Gloops (above).
+  - `:800` inside `MigrateKerbalAssignments` (`LedgerOrchestrator.cs:769-840`), which walks **every** recording in `RecordingStore.CommittedRecordings` at `:771-796` and calls `CreateKerbalAssignmentActions(rec.RecordingId, rec.StartUT, rec.EndUT)` unconditionally. The function extracts crew from `rec.VesselSnapshot` via `ExtractCrewFromRecording` (LedgerOrchestrator.cs, same file). **A Gloops recording of a crewed vessel does have a `VesselSnapshot`** — set by `CommitGloopsRecorderData` at `ParsekFlight.cs:7550`. So today `MigrateKerbalAssignments` can generate `KerbalAssignment` actions for a Gloops recording, causing those kerbals to be reserved by `KerbalsModule.ProcessAction` for the Gloops loop duration. This is a real leak.
+- `LedgerOrchestrator.RecalculateAndPatch` (`LedgerOrchestrator.cs:612-672`). Builds `actions` from `Ledger.Actions` at `:653`, sorts, walks. The walk is action-driven, not recording-driven, so it does not need to re-probe `IsGhostOnly` — but as a belt-and-braces guard (which is what the bug asks for under "Apply-side defense in depth") a filter at `:653` that drops actions whose `RecordingId` belongs to a ghost-only recording closes the "future regression routes events through a Gloops recording" hole.
+- `RecalculationEngine.Recalculate` (`RecalculationEngine.cs:136-226`). Pure: takes a `List<GameAction>`, sorts, dispatches. No direct `Recording` access; needs no change.
+
+### Interaction with #431's tagging
+
+- `GameStateRecorder.Emit` (`GameStateRecorder.cs:58-83`) reads the tag from `ResolveCurrentRecordingTag()` at `:60`, which in turn reads `ParsekFlight.GetActiveRecordingIdForTagging()` — the **normal** active recording id.
+- During a Gloops capture window where the normal auto-recorder is also running, events would be tagged with the **normal** recording's id (not a Gloops id). Without #432, those events ride with the normal recording's fate: they'd be purged on normal-recording discard, preserved on normal-recording commit — exactly the opposite of what the Gloops invariant demands.
+- With #432's capture-side guard in place, the event never reaches `Emit`, so no tag is stamped at all. A Gloops recording never has an id that owns events in `GameStateStore.Events` or in any `Milestone.Events` list. Therefore:
+  > `PurgeEventsForRecordings(idsToPurge)` (`GameStateStore.cs:261`) called with a Gloops id in the set is a no-op by construction — the HashSet lookup at `GameStateStore.cs:282` (the `set.Contains(events[i].recordingId)` filter) never matches.
+- That invariant is a useful regression check for the test matrix (step 7 below).
+
+## Plan
+
+### Step 1 — Capture-side guard: central Emit prologue + two out-of-funnel sites
+
+**Decision: central guard at `Emit` + explicit guard at each of the two out-of-funnel sites (science subjects, contract snapshots).** Rationale:
+
+- 17 `Emit` call sites in `GameStateRecorder.cs` all funnel through line `:82`. One guard at the top of `Emit` covers all 17 with a single code path, matching the #431 architecture.
+- `PendingScienceSubjects.Add` (`:832`) and `AddContractSnapshot` (`GameStateRecorder.cs:292`) do not go through `Emit`. Two extra early-returns.
+- Per-site guards at the 17 `Emit` call sites would multiply boilerplate and spread the invariant across the file, contradicting #431's "one funnel" design.
+
+Concrete change in `GameStateRecorder.cs`, after the existing tag-resolve block:
+
+```csharp
+// GameStateRecorder.cs — inside Emit, before the existing AddEvent call.
+internal static void Emit(GameStateEvent evt, string source)
+{
+    // #432: Gloops (ghost-only) recordings must have zero career footprint.
+    // When the Gloops recorder is live, suppress event capture entirely.
+    if (ParsekFlight.IsGloopsCaptureActive())
+    {
+        ParsekLog.Verbose("GameStateRecorder",
+            $"Gloops capture active — suppressed {evt.eventType} event (key='{evt.key}', source='{source ?? ""}')");
+        return;
+    }
+
+    string tag = ResolveCurrentRecordingTag();
+    ... // existing body unchanged
+}
+```
+
+And at the two out-of-funnel sites:
+
+```csharp
+// GameStateRecorder.cs:285-292 — OnContractAccepted. Guard wraps BOTH the Emit
+// and the contract-snapshot write. A snapshot without its accept event would
+// leak into a later contract-revert path. Gate before Emit so the log line order
+// reads as "snapshot suppressed because Gloops active".
+if (ParsekFlight.IsGloopsCaptureActive())
+{
+    ParsekLog.Verbose("GameStateRecorder",
+        $"Gloops capture active — suppressed ContractAccepted (guid={guid})");
+    return;
+}
+Emit(evt, "ContractAccepted");
+try { GameStateStore.AddContractSnapshot(guid, contractNode); ... }
+```
+
+```csharp
+// GameStateRecorder.cs:826-840 — OnScienceReceived. PendingScienceSubjects.Add
+// is its own pipeline; guard it independently. The list is consumed on the NEXT
+// normal-recording commit (LedgerOrchestrator.NotifyLedgerTreeCommitted:1519),
+// so a leaked subject would credit science to an unrelated career mission.
+if (ParsekFlight.IsGloopsCaptureActive())
+{
+    ParsekLog.Verbose("GameStateRecorder",
+        $"Gloops capture active — suppressed PendingScienceSubjects.Add (subject={subject.id})");
+    return;
+}
+PendingScienceSubjects.Add(new PendingScienceSubject { ... });
+```
+
+The two explicit guards are small enough that they don't warrant factoring into a helper. They also document the two non-Emit capture pipelines for the next person reading the file.
+
+Note that the duplicate Emit-guard inside `Emit` itself still fires for the `ContractAccepted` path the second time (we early-return before it) — so in practice `Emit` only sees the guard on the 15 sites that aren't contract-accepted / science-received. This is fine: the guard is idempotent and its Verbose log stays a useful signal for the "some handler slipped through" case.
+
+### Step 2 — Add the `ParsekFlight.IsGloopsCaptureActive()` accessor
+
+The task brief proposes `GetActiveRecordingGhostOnlyFlag()`. That name suggests a probe of the active recording's flag, which we established above does not work for the live-capture window — it would return `false` every time because the Gloops `Recording` does not exist in the tree yet.
+
+The right name is one that describes the live state the guard actually checks. Use `IsGloopsCaptureActive` — parallels `IsGloopsRecording` (the existing instance property at `ParsekFlight.cs:7430`) but is static and null-safe, like `GetActiveRecordingIdForTagging` and `HasLiveRecorderForTagging` (`ParsekFlight.cs:35, 43`):
+
+```csharp
+// ParsekFlight.cs — near the existing tagging accessors at :35.
+/// <summary>
+/// #432: true when a Gloops ghost-only recorder is currently sampling. The
+/// GameStateRecorder.Emit prologue and the two out-of-funnel capture sites
+/// (PendingScienceSubjects.Add, AddContractSnapshot) consult this to suppress
+/// career-state capture during Gloops flights.
+///
+/// Unlike GetActiveRecordingIdForTagging, this does not probe the active tree —
+/// a Gloops Recording does not exist in the tree until CommitGloopsRecording
+/// runs, so the live-window gate must read the recorder state directly.
+/// </summary>
+internal static bool IsGloopsCaptureActive()
+{
+    if (GloopsCaptureActiveForTesting != null)
+        return GloopsCaptureActiveForTesting();
+    return Instance != null && Instance.IsGloopsRecording;
+}
+
+/// <summary>
+/// #432: test hook for IsGloopsCaptureActive, mirrors #431's TagResolverForTesting
+/// pattern in GameStateRecorder. Tests set this to a fixed bool supplier so they
+/// don't have to spin up the ParsekFlight MonoBehaviour.
+/// </summary>
+internal static System.Func<bool> GloopsCaptureActiveForTesting;
+```
+
+A corresponding `ParsekFlight.ResetTestOverrides()` clears `GloopsCaptureActiveForTesting = null` alongside any future test hooks on this class. (No such reset exists on `ParsekFlight` today; add it. `GameStateRecorder.ResetForTesting` at `GameStateRecorder.cs:115` is a clear model.)
+
+**LimboVesselSwitch fallback — NOT needed.** The #431 `ResolveCurrentRecordingTag` fallback (`GameStateRecorder.cs:100-104`) exists because a normal recording stashes its pending tree into `LimboVesselSwitch` during a vessel switch and events captured in that window still belong to the outgoing recording. **Gloops has no such stash.** `FlightRecorder.HandleVesselSwitchDuringRecording` (`FlightRecorder.cs:5143-5151`) auto-stops the Gloops recorder immediately on vessel-switch detection, and `CheckGloopsAutoStoppedByVesselSwitch` commits it on the next frame. By the time any ambiguity window opens, `gloopsRecorder.IsRecording` is already `false`, so `IsGloopsCaptureActive()` returns `false`. Events fired during the switch belong to the incoming vessel's normal recording (or no recording), which is the correct place for them.
+
+### Step 3 — Apply-side: action-creation guards + belt-and-braces walk filter
+
+**At action-creation.** `CreateKerbalAssignmentActions` (`LedgerOrchestrator.cs:471`) and `CreateVesselCostActions` (`LedgerOrchestrator.cs:397`) both already call `FindRecordingById` (`LedgerOrchestrator.cs:592`) to resolve the `Recording`. Add an early-return:
+
+```csharp
+// LedgerOrchestrator.cs:471 — CreateKerbalAssignmentActions, after FindRecordingById.
+if (rec == null) return result;
+if (rec.IsGhostOnly)
+{
+    ParsekLog.Verbose(Tag,
+        $"CreateKerbalAssignmentActions: recording '{recordingId}' is ghost-only — skipping");
+    return result;
+}
+```
+
+```csharp
+// LedgerOrchestrator.cs:401 — CreateVesselCostActions, after FindRecordingById.
+if (rec == null) { ... return result; }
+if (rec.IsGhostOnly)
+{
+    ParsekLog.Verbose(Tag,
+        $"CreateVesselCostActions: recording '{recordingId}' is ghost-only — skipping");
+    return result;
+}
+```
+
+This closes the real leak at `LedgerOrchestrator.cs:800` where `MigrateKerbalAssignments` walks every `CommittedRecordings` entry and would synthesize `KerbalAssignment` actions for a crewed Gloops recording.
+
+**Belt-and-braces walk filter.** Add a pre-pass filter inside `LedgerOrchestrator.RecalculateAndPatch` (`LedgerOrchestrator.cs:612`) that drops actions whose `RecordingId` maps to an `IsGhostOnly` recording. This catches:
+
+- Stale actions from a pre-#432 save where `MigrateKerbalAssignments` already ran on a Gloops recording and deposited `KerbalAssignment` rows into the ledger file on disk.
+- Future regressions where some new code path produces a `GameAction` with a Gloops `RecordingId`.
+
+```csharp
+// LedgerOrchestrator.cs:653 — inside RecalculateAndPatch, before Recalculate.
+var actions = new List<GameAction>(Ledger.Actions);
+
+// #432: filter out any actions tagged with a ghost-only recording's id.
+// Pure defense-in-depth: action-creation should already skip these, but a
+// save from before the action-creation guards landed could hold stale rows.
+int beforeFilter = actions.Count;
+actions = FilterOutGhostOnlyActions(actions);
+int filtered = beforeFilter - actions.Count;
+if (filtered > 0)
+    ParsekLog.Info(Tag,
+        $"RecalculateAndPatch: filtered {filtered} action(s) tagged with ghost-only recordings");
+
+RecalculationEngine.Recalculate(actions);
+```
+
+```csharp
+// LedgerOrchestrator.cs — new internal static helper.
+internal static List<GameAction> FilterOutGhostOnlyActions(List<GameAction> actions)
+{
+    if (actions == null || actions.Count == 0) return actions ?? new List<GameAction>();
+
+    // Build ghost-only id set once per call. Cheap: CommittedRecordings is usually <100.
+    var ghostOnlyIds = new HashSet<string>(StringComparer.Ordinal);
+    var recs = RecordingStore.CommittedRecordings;
+    for (int i = 0; i < recs.Count; i++)
+        if (recs[i].IsGhostOnly && !string.IsNullOrEmpty(recs[i].RecordingId))
+            ghostOnlyIds.Add(recs[i].RecordingId);
+
+    if (ghostOnlyIds.Count == 0) return actions;
+
+    var kept = new List<GameAction>(actions.Count);
+    for (int i = 0; i < actions.Count; i++)
+        if (string.IsNullOrEmpty(actions[i].RecordingId) || !ghostOnlyIds.Contains(actions[i].RecordingId))
+            kept.Add(actions[i]);
+    return kept;
+}
+```
+
+**`MigrateKerbalAssignments` — no extra change needed.** Once `CreateKerbalAssignmentActions` early-returns for ghost-only, `KerbalAssignmentActionsMatch(existing, kerbalActions)` at `LedgerOrchestrator.cs:804` trivially matches an empty desired list against any empty existing list → `continue;`, and for a Gloops recording that had stale rows from a pre-fix save, `Ledger.ReplaceActionsForRecording(KerbalAssignment, rec.RecordingId, empty)` cleans them up on next load. That is the one-shot self-heal we want.
+
+### Step 4 — One-time self-heal for pre-fix saves that already leaked Gloops actions
+
+The walk filter in step 3 keeps Gloops actions out of the recalculation, but leaves them sitting in `Ledger.Actions` forever (written back to disk on `OnSave`). That bloats the file and keeps the log line "filtered N actions" firing on every load.
+
+**Decision: clean the ledger on load, not every call.** Add a one-shot pass in `LedgerOrchestrator.OnLoad` (`LedgerOrchestrator.cs:1080`) that calls `FilterOutGhostOnlyActions` once, compares counts, and if anything was removed, calls `Ledger.RemoveActionsForRecording` for each ghost-only id. Logs at Info. This runs after `Ledger.LoadFromFile(path)` at `:1094`.
+
+```csharp
+// LedgerOrchestrator.cs — inside OnLoad, after Ledger.LoadFromFile.
+int removed = PurgeGhostOnlyActionsFromLedger();
+if (removed > 0)
+    ParsekLog.Info(Tag,
+        $"OnLoad: removed {removed} stale action(s) tagged with ghost-only recordings (pre-#432 save)");
+```
+
+The helper walks `Ledger.Actions`, collects ghost-only-tagged entries, and removes them via whatever public API `Ledger` already exposes (`Ledger.RemoveActionsForRecording` or direct list mutation — pick whichever exists; `MigrateKerbalAssignments` uses `Ledger.ReplaceActionsForRecording` at `:809` as precedent). A cheap, idempotent cleanup.
+
+### Step 5 — Interaction with #431's purge, formally
+
+Once steps 1–3 are in place, the Gloops-capture flow is:
+
+1. Player opens Gloops UI, clicks Start.
+2. `gloopsRecorder.IsRecording` flips to `true`. The normal auto-recorder may also be running; `activeTree.ActiveRecordingId` holds the normal recording's id (or `""`).
+3. A career event fires (e.g. `ContractAccepted`).
+4. `GameStateRecorder.OnContractAccepted` sees `ParsekFlight.IsGloopsCaptureActive() == true`, early-returns **before** the `Emit` and **before** the `AddContractSnapshot`. No `GameStateEvent` reaches `GameStateStore.Events`, no snapshot reaches `contractSnapshots`.
+5. Player stops Gloops. `CommitGloopsRecording` mints a recording id, flips `IsGhostOnly = true`, adds to `committedRecordings`.
+
+At no point is a `GameStateEvent` tagged with the Gloops recording id. Therefore `GameStateStore.PurgeEventsForRecordings([gloopsId], reason)` (`GameStateStore.cs:261`) finds zero matches: the `events[i].recordingId == gloopsId` check at `:282` never fires. The purge path is a no-op for Gloops ids **by construction of the capture guard**, not by any extra check in `PurgeEventsForRecordings`. This matches the explicit prediction in the bug entry (`todo-and-known-bugs.md:222`: "Gloops ghost-only recordings are covered by #432: they never capture events, so #431's purge logic is a no-op for them").
+
+Codify this as a test case (step 7, test `purge_for_gloops_id_is_noop`), not as runtime code. No runtime change needed in `PurgeEventsForRecordings`.
+
+### Step 6 — Edge cases, worked through
+
+1. **Normal recording + Gloops concurrently.** Allowed by the current UI (no gate in `GloopsRecorderUI.cs` or `StartGloopsRecording`). With the step-1 guard, while Gloops is live every career event is suppressed — including events the normal recording should rightfully have captured. **This is a real UX gotcha.** Two ways to resolve:
+   - **(a) Accept as user error**, document in the user-guide note at step 9. "Don't run career missions while a Gloops recording is active." Pragmatic: Gloops is decorative and intended for plane flies / airshows, not career missions.
+   - **(b) Add a UI gate** in `GloopsRecorderUI.DrawWindow` and `StartGloopsRecording` that blocks Start while `IsRecording == true` (normal recorder running), plus a symmetric check in the normal-recording start paths.
+   I recommend **(a)** for this PR — the smaller change and the existing parallel-recorder design is explicit in the bug's framing. (b) is a cleaner UX but widens the scope into UI work that the bug entry does not mention. **Open question for the user** (see final section).
+2. **Player switches to a Gloops recording mid-flight.** The UI has no such affordance. `GloopsRecorderUI.DrawWindow` (`UI/GloopsRecorderUI.cs:91-186`) only offers Start / Stop / Preview / Discard for the Gloops recorder itself — there is no switch-recording-type control. On vessel switch, `FlightRecorder.HandleVesselSwitchDuringRecording` (`FlightRecorder.cs:5143-5151`) auto-stops Gloops. Answer: **not possible with the current UI flow** — no code change needed to handle it.
+3. **Quicksave during a Gloops flight + F9.** `GameStateStore.Events` serializes to disk on save (via `ParsekScenario.OnSave` → `GameStateStore.SaveEventFile`). Events captured BEFORE the #432 guard landed (i.e., from a save created on a pre-fix build) are already in the save file. F9ing that quicksave loads them back. **Retroactive cleanup is out of scope** — documented in step 10. Step 4's one-time ledger-side self-heal handles the related leak in `Ledger.Actions`, but the `GameStateStore.Events` / `MilestoneStore` side would need a full migration pass that this PR does not ship. A player running a pre-#432 save through a post-#432 build still sees the stale event rows until they manually discard the old Gloops recording; step 11 covers it in the risks section.
+4. **Gloops + LimboVesselSwitch fallback.** Covered above in step 2 ("LimboVesselSwitch fallback — NOT needed"). Gloops auto-stops on vessel switch; there is no limbo window for it.
+5. **Science subjects pipeline.** Addressed in step 1 with the explicit `OnScienceReceived` guard. `PendingScienceSubjects` is the only science capture target; `GameStateEventConverter.ConvertScienceSubjects` is consumer-side and only fires from the normal `OnRecordingCommitted` path, never from Gloops commit.
+6. **Resource events (FundsChanged, ScienceChanged, ReputationChanged).** The `Emit` guard suppresses them identically to other event types. The invariant says Gloops has zero career footprint, and resource events that the game fires during a Gloops flight (e.g. recovery funds credited because the player happened to recover a different vessel while Gloops is running) would today flow into `GameStateStore.Events`. Under #432 they are suppressed. **This is the intended behavior** — Gloops windows explicitly contract to not capture career state. The corollary: real career effects that happen to fire during a Gloops window do not get ledger-replayed later. Documented in step 9's user-guide note. No extra guard; the `Emit` gate covers it.
+7. **Auto-commit after vessel-switch auto-stop.** Between `gloopsRecorder.StopRecording()` (`FlightRecorder.cs:5148`) and `CommitGloopsRecorderData` on the next frame (`ParsekFlight.cs:7514`), `gloopsRecorder.IsRecording == false` → `IsGloopsCaptureActive()` returns `false`. Events that fire in that narrow window (e.g. science rewards credited after the vessel switch completes) are captured normally and tagged with whatever recording is newly active. This is correct: by the time the gate has lowered, the Gloops window has closed and those events belong to the next mission's fate.
+
+### Step 7 — Tests
+
+New `Source/Parsek.Tests/GloopsEventSuppressionTests.cs`. `[Collection("Sequential")]` — touches `GameStateRecorder` / `GameStateStore` / `Ledger` / `RecordingStore` static state. All tests swap the Gloops-capture hook via `ParsekFlight.GloopsCaptureActiveForTesting = () => true` (or `false`) so they don't need the MonoBehaviour alive. `ParsekLog.TestSinkForTesting` captures the Verbose suppression log lines for assertions.
+
+1. **`contract_accept_during_gloops_is_suppressed`** — `GloopsCaptureActiveForTesting = () => true`, fire a synthetic `ContractAccepted` through the handler. Assert `GameStateStore.Events` count unchanged, `contractSnapshots` unchanged, and a `"Gloops capture active — suppressed ContractAccepted"` Verbose line was logged.
+2. **`normal_contract_accept_still_captured`** — `GloopsCaptureActiveForTesting = () => false` (or null), fire a `ContractAccepted`. Assert event was added to the store (and to `contractSnapshots` where appropriate).
+3. **`science_subject_during_gloops_is_suppressed`** — `GloopsCaptureActiveForTesting = () => true`, call `OnScienceReceived` directly with a synthetic subject. Assert `PendingScienceSubjects.Count == 0` and the suppress-log line for `OnScienceReceived` fired.
+4. **`normal_science_subject_still_captured`** — gate off, same call. Assert `PendingScienceSubjects.Count == 1`.
+5. **`resource_event_during_gloops_is_suppressed`** — gate on, fire a `FundsChanged` event. Assert no event in the store, suppress log fired.
+6. **`ledger_walk_skips_ghost_only_recording`** — seed `Ledger.Actions` with two `KerbalAssignment` actions, one tagged with a `RecordingId` whose `IsGhostOnly = true` (injected via a test `Recording` added to `RecordingStore`), one tagged with a normal recording id. Call `LedgerOrchestrator.FilterOutGhostOnlyActions` directly. Assert the ghost-only action is filtered, the normal one is kept, and the "filtered N" Info log fires when called from `RecalculateAndPatch`.
+7. **`create_kerbal_assignment_actions_returns_empty_for_ghost_only`** — construct a test `Recording` with `IsGhostOnly = true` and a synthetic `VesselSnapshot` containing one crew. Add it to `committedRecordings`. Call `LedgerOrchestrator.CreateKerbalAssignmentActions(recId, startUT, endUT)`. Assert the result is empty and the Verbose "ghost-only — skipping" line fired.
+8. **`purge_for_gloops_id_is_noop`** — set `GloopsCaptureActiveForTesting = () => true`, run 5 distinct `Emit` attempts. Then set the gate off, add a normal event tagged with a different id. Call `GameStateStore.PurgeEventsForRecordings` with a fake "gloops-id" (which was never used as a tag because the gate suppressed all 5). Assert `removed == 0` and the live store still contains the one normal event.
+9. **`limbo_vessel_switch_does_not_affect_gloops_guard`** — set `RecordingStore.pendingTreeState = LimboVesselSwitch`, gate on. Fire an `Emit`. Assert suppressed regardless of the limbo state. Codifies that the Gloops guard runs before the tag resolver's LimboVesselSwitch fallback.
+10. **`on_load_purge_removes_stale_ghost_only_actions`** — seed `Ledger.Actions` with two actions tagged with a ghost-only id, call `LedgerOrchestrator.PurgeGhostOnlyActionsFromLedger()` (the helper from step 4). Assert both actions removed and the "removed N stale action(s)" Info log fires. Complement: same setup but ids are all non-ghost-only → assert nothing removed, no log.
+11. **`reset_test_overrides_clears_hook`** — set `GloopsCaptureActiveForTesting = () => true`, call `ParsekFlight.ResetTestOverrides()`. Assert `IsGloopsCaptureActive()` now returns `false` (no Instance in tests, Instance == null ⇒ false).
+
+**Test hook summary:** add `ParsekFlight.GloopsCaptureActiveForTesting` (`Func<bool>`) and `ParsekFlight.ResetTestOverrides()`. Same pattern as `GameStateRecorder.TagResolverForTesting` / `ResetForTesting` (`GameStateRecorder.cs:49, 115`). Yes, the test hook is needed — production tests can't easily instantiate `ParsekFlight` (it's a `MonoBehaviour` with heavy state).
+
+### Step 8 — Post-build verification
+
+`dotnet build` + `dotnet test` from the worktree. After deploy, grep the deployed DLL for a distinctive UTF-16 string introduced by this change (`IsGloopsCaptureActive` or `"Gloops capture active — suppressed"`). Manual playtest recipe:
+
+1. Start a career game, launch a plane.
+2. Open Gloops window, click Start Recording.
+3. In flight, take an EVA science sample or accept a contract via KAC. (If that isn't reachable mid-Gloops-flight, use a stock save-file edit to force a `FundsChanged` event mid-flight — e.g. `MODIFY_FUNDS`.)
+4. Stop Gloops.
+5. Check `KSP.log` for `"Gloops capture active — suppressed"` lines.
+6. Open Parsek Career State window — confirm the contract / science / funds from step 3 did not appear in the ledger.
+7. Delete the Gloops recording. Confirm the career state window still shows no Gloops-derived entries (and no log lines about purged Gloops events — because there were none to purge).
+
+### Step 9 — Docs updates (staged in the implementation commit per CLAUDE.md)
+
+- **`CHANGELOG.md`** — one user-facing line under `## 0.8.2` (or the next active heading). Suggested wording: `Gloops (ghost-only) recordings no longer leak contracts, science, funds, reputation, crew assignments, or milestones into the career ledger — they are purely visual.` Fits the repo's 1-line hard-rule CHANGELOG style.
+- **`docs/dev/todo-and-known-bugs.md`** — strike the `## 432.` header and body at `:159-192`, replace the `**Status:** TODO.` line with a status note along the lines of what `#431` got at `:240` (pattern: `**Status:** ~~DONE~~. <one-paragraph summary of approach and file map>`). Keep the "Related edge cases" section intact for reference.
+- **`docs/user-guide.md`** — append to the Gloops Flight Recorder section at `:36-46`. Suggested line: `Gloops recordings have no effect on your career — contracts accepted, science collected, funds spent, milestones achieved, and kerbals aboard during a Gloops flight are all ignored by the Parsek ledger. Use normal recordings for missions you want to count.`
+- **`.claude/CLAUDE.md`** — no change. The file layout and patterns are unchanged.
+
+### Step 10 — Scope
+
+**In scope for this PR:**
+- `GameStateRecorder.Emit` capture-side gate.
+- Explicit gates at `OnContractAccepted` (before Emit + snapshot) and `OnScienceReceived` (before `PendingScienceSubjects.Add`).
+- `ParsekFlight.IsGloopsCaptureActive()` + `GloopsCaptureActiveForTesting` test hook + `ResetTestOverrides`.
+- `CreateKerbalAssignmentActions` and `CreateVesselCostActions` action-creation early-returns on `rec.IsGhostOnly`.
+- `LedgerOrchestrator.FilterOutGhostOnlyActions` + `RecalculateAndPatch` pre-pass filter.
+- One-time self-heal `PurgeGhostOnlyActionsFromLedger` called from `LedgerOrchestrator.OnLoad`.
+- New `Source/Parsek.Tests/GloopsEventSuppressionTests.cs` per step 7.
+- Doc updates per step 9.
+
+**Out of scope:**
+- **Retroactive cleanup of leaked events in pre-#432 saves.** Events already in `GameStateStore.Events` / `Milestone.Events` / contract snapshots from a pre-fix Gloops flight are not purged by this PR. The ledger-side self-heal (step 4) handles `Ledger.Actions`; the event-store side would need a migration pass that walks every saved event, looks up its tag against currently-committed ghost-only recordings, and removes matches. That migration is cheap but scope-creeps into schema-migration territory; document as a known limitation in the CHANGELOG.
+- **UI gate against concurrent normal + Gloops recording.** Documented in step 6 case 1 and the Open Questions section. Would add UI work not scoped to this bug.
+- **Allowing Gloops recordings to opt into career capture.** Contradicts the decorative-only design intent (bug entry, `todo-and-known-bugs.md:186-187`). If a player wants career effects, they use a normal recording.
+- **Removing `MilestoneStore.CurrentEpoch` filter.** Separate cleanup per the #431 retirement-follow-up TODO at `todo-and-known-bugs.md:216`.
+
+## Risks
+
+- **The `IsGloopsCaptureActive` guard suppresses events that happen during a Gloops window even if the player also has a normal career mission recording concurrently.** See step 6 case 1. Mitigated by the user-guide note in step 9 and flagged as an open question for the implementer.
+- **Pre-#432 saves carry stale leaked data.** Step 4 heals `Ledger.Actions`; events in `GameStateStore.Events` and `Milestone.Events` stay behind. A subsequent migration pass could clean them, but it is out of scope here. Players unaffected in practice unless they happened to have a heavy Gloops + career session on an older build.
+- **Performance.** `FilterOutGhostOnlyActions` runs on every `RecalculateAndPatch` call — builds a HashSet of ghost-only ids from `CommittedRecordings` (typically <100 entries) and walks `actions` once. O(recordings + actions). Negligible next to the existing sort + walk in `RecalculationEngine.Recalculate`. No index needed.
+
+## Sequencing
+
+Independent of #434. Can ship alongside or after #434 in any order; they touch disjoint code paths (#434 is the revert-auto-discard rebase on top of #431's `DiscardPendingTree`, #432 is about capture gating + ledger filter).
+
+## Open questions for the user before implementation
+
+1. **Concurrent Gloops + normal recording — suppress all, or gate the UI?** (Step 6 case 1 / Risks section.) My default is to suppress all events during the Gloops window and document in the user-guide. Alternative: add a UI gate that blocks Start Gloops while the normal recorder is active, and vice versa. The latter is a behavior change this PR could sneak in, but also widens scope.
+2. **Retroactive save-side cleanup — ship a migration, or leave as documented limitation?** Step 10 goes with "documented limitation". A migration would walk `GameStateStore.Events` + every `Milestone.Events` list on load and purge entries whose `recordingId` maps to a ghost-only recording. One-shot pass, idempotent, mirrors step 4's ledger-side heal. Implementer can add it if desired; I scoped it out to keep the PR focused.
+3. **Accessor name — `IsGloopsCaptureActive` vs. `GetActiveRecordingGhostOnlyFlag` (task brief wording) vs. something else?** My case for renaming is in the Step 2 body. If the reviewer prefers the brief's original name I'll rename — but the rename-only change doesn't affect correctness.

--- a/docs/dev/plans/fix-432-gloops-no-events.md
+++ b/docs/dev/plans/fix-432-gloops-no-events.md
@@ -2,213 +2,134 @@
 
 **Branch:** `fix/432-gloops-no-events` (off `origin/main`)
 **Worktree:** `C:/Users/vlad3/Documents/Code/Parsek/Parsek-432-gloops-no-events`
-**Depends on:** #431 (PR #332, merged) — the `GameStateRecorder.Emit` funnel.
-**Unrelated to:** #434 (PR #333, open) — same naming convention, independent scope.
+**Depends on:** #431 (PR #332, merged) — `GameStateRecorder.Emit` tagging funnel establishes ownership of events.
+**Related:** #435 (new, aspirational) — multi-recording Gloops trees; #432's per-recording filter makes the tree case a no-op when #435 lands.
+**Unrelated to:** #434 (PR #333, open) — shares naming convention only.
 
 ## Invariant to enforce
 
-> A Gloops ghost-only recording has zero career-state footprint. No `GameStateEvent` is captured while the Gloops recorder is live, and no ledger action is produced from a committed `IsGhostOnly` recording.
+> A Gloops ghost-only recording has zero career-state footprint on the ledger. No ledger action is produced from any recording flagged `IsGhostOnly`. Events captured during a Gloops window flow through their existing #431 pipeline unchanged — tagged with the parallel normal recording's id (if any), otherwise empty-tagged as between-mission state. Gloops never owns events.
 
-## Why the naive "check active recording's IsGhostOnly" accessor does not work
+## Architectural context
 
-The bug entry and the user's task brief both propose an accessor like `ParsekFlight.GetActiveRecordingGhostOnlyFlag()` that probes the active recording's `IsGhostOnly` flag. That probe returns the wrong answer for the live-capture window because of how Gloops is wired:
+Gloops is on track to be extracted as a standalone mod (see `docs/dev/gloops-recorder-design.md`). The extraction boundary keeps the trajectory recorder, ghost playback engine, and visual mesh builder in Gloops; Parsek (the consumer) keeps the tree/DAG structure, career state, resource ledger, crew reservation, and world presence (CommNet, tracking station). The recorder is **shared** — a single recording pipeline that both Gloops and Parsek feed from; Parsek then layers career state on top of the trajectory data via its metadata envelope around the Gloops `IPlaybackTrajectory` interface.
 
-- `ParsekFlight.gloopsRecorder` (`ParsekFlight.cs:7426`) is a **parallel** `FlightRecorder` instance with `IsGloopsMode = true`. It runs **alongside** the normal `recorder` (`ParsekFlight.cs:55`); neither suppresses the other. `StartGloopsRecording` (`ParsekFlight.cs:7445`) has no gate against an already-running normal auto-record and vice versa.
-- A Gloops `Recording` object does not exist until commit. `CommitGloopsRecorderData` (`ParsekFlight.cs:7523-7562`) builds the `Recording`, sets `rec.IsGhostOnly = true` at `ParsekFlight.cs:7542`, and pushes it straight into `committedRecordings` via `RecordingStore.CommitGloopsRecording` (`RecordingStore.cs:394`). It never enters `pendingTree` and never becomes `activeTree.ActiveRecordingId`.
-- `ParsekFlight.GetActiveRecordingIdForTagging()` (`ParsekFlight.cs:35-36`) returns `Instance?.activeTree?.ActiveRecordingId ?? ""` — the **normal** active recording's id, or `""`. It cannot point at a Gloops recording during the live window.
+That extraction direction further justifies the apply-side-only design for #432:
 
-So the live-capture gate has to be "is a Gloops recorder currently sampling?" — which is already exposed as `ParsekFlight.IsGloopsRecording` (`ParsekFlight.cs:7430`, `gloopsRecorder?.IsRecording ?? false`). That is the accessor the Emit guard reads.
+- The recorder is Gloops's concern; career events are Parsek's concern. Guarding at the recorder level (a capture-side `Emit` suppression) would push a Parsek-only concept (the ledger) into the code that becomes Gloops, pulling the extraction boundary out of shape.
+- The apply-side filter lives where the career ledger lives — entirely on the Parsek side of the future extraction. After extraction, Gloops has no notion of `IsGhostOnly` as a career-state suppressor; it just sees trajectories, some of which the consumer flagged for non-career rendering. Parsek on its side of the boundary filters out ghost-only recordings before generating ledger actions. No code needs to move across the boundary to preserve #432's behavior.
 
-The apply-side gate is a different question: committed Gloops recordings live in `RecordingStore.CommittedRecordings` with `rec.IsGhostOnly == true`, and the ledger's action-generation paths walk that list. On the apply side we do check `rec.IsGhostOnly`.
+In short: capture-side guards would be anti-architecture. Apply-side guards match the extraction direction.
+
+## Scope decision — apply-side only
+
+The task brief and the original bug entry sketched both capture-side suppression (guard `GameStateRecorder.Emit`, short-circuit the science-subject and contract-snapshot pipelines) and apply-side codification (skip ghost-only recordings when producing ledger actions). After a world-model clarification from the user on 2026-04-17, the design is **purely apply-side**.
+
+Rationale:
+
+- A Gloops recording is the **visual ghost slice** of whatever is happening — a parallel ghost from point A at T0 to point B at T1, optimizer-post-processed, nothing more. It is not a flight, not a mission, not an owner of career events.
+- When the player runs a Gloops recording in parallel with a normal Parsek mission recording (which is possible today — neither blocks the other), events that fire during that window belong to the **normal** recording and should share its commit/discard fate per #431. Suppressing them at Emit would wrongly drop career events from the normal recording too.
+- When the player runs Gloops with no normal recording active (auto-record off, or a vessel not eligible for auto-record), events land in `GameStateStore.Events` with an empty tag — exactly the "between-mission career state" path #431 already models. On save, `MilestoneStore.FlushPendingEvents` bundles them into a Committed milestone, crediting the career as if Gloops weren't running. This is the intended and pre-existing behavior; #432 touches none of it.
+- Gloops recordings commit via `RecordingStore.CommitGloopsRecording` (`RecordingStore.cs:394-418`), which never calls `LedgerOrchestrator.NotifyLedgerTreeCommitted`. So the `OnRecordingCommitted` event-to-action conversion path is not reached for Gloops today. The only leaks into the ledger are the **recording-walking migration paths** that don't check `IsGhostOnly`. That's the specific hole to close.
 
 ## Current-state map (as of 2026-04-17 on `fix/432-gloops-no-events`, post-#431)
 
-### `IsGhostOnly` declaration and lifecycle
+### `IsGhostOnly` flag lifecycle
 
-- `Source/Parsek/Recording.cs:29` — `public bool IsGhostOnly;` on the `Recording` object. Serialized at `RecordingTree.cs:526-527` (only written when true), deserialized at `RecordingTree.cs:953`.
-- `Source/Parsek/ParsekFlight.cs:7542` — `rec.IsGhostOnly = true;` set at commit time inside `CommitGloopsRecorderData`.
-- `Source/Parsek/RecordingStore.cs:402` — belt-and-braces: `CommitGloopsRecording` re-asserts `rec.IsGhostOnly = true;` before adding to `committedRecordings`.
-- `Source/Parsek/FlightRecorder.cs:120` — `internal bool IsGloopsMode { get; set; }`, set once at `ParsekFlight.cs:7460` (`new FlightRecorder { IsGloopsMode = true }`). Read at `FlightRecorder.cs:4207, 4212, 4240, 4717, 5143` to skip resource baselines / rewind save / tree logic / auto-stop on vessel switch.
+- `Source/Parsek/Recording.cs:29` — `public bool IsGhostOnly;` on `Recording`. Serialized only when true at `RecordingTree.cs:526-527`, deserialized at `RecordingTree.cs:953`.
+- `Source/Parsek/FlightRecorder.cs:120` — `IsGloopsMode` flag on the recorder. Set once at `ParsekFlight.cs:7460` (`new FlightRecorder { IsGloopsMode = true }`). Read at `FlightRecorder.cs:4207, 4212, 4240, 4717, 5143` to skip resource baselines / rewind save / tree logic / auto-stop on vessel switch.
+- `Source/Parsek/ParsekFlight.cs:7542` — `rec.IsGhostOnly = true` set at commit time inside `CommitGloopsRecorderData`. `RecordingStore.cs:402` re-asserts it.
+- Read sites: `GhostPlaybackLogic.cs:3001` (loop-from-end semantics), `ParsekFlight.cs:9221` (`if (!rec.IsGhostOnly)` — gates vessel spawn at ghost-end, already correct), `RecordingTree.cs:526, 953` (serialize/deserialize), `RecordingsTableUI.cs:1313, 2445` (X delete button + group display), `KerbalsModule.cs` (ghost-only chain handoff end-state fallback).
 
-### Gloops lifecycle — start, stop, auto-commit, discard
+### Gloops is strictly single-recording today
 
-- Start: `ParsekFlight.StartGloopsRecording` (`ParsekFlight.cs:7445-7482`) allocates `gloopsRecorder`, calls `gloopsRecorder.StartRecording(isPromotion: false)`, stashes a ghost-visual snapshot. Does **not** stop or block the normal auto-recorder.
-- Stop (manual): `ParsekFlight.StopGloopsRecording` (`ParsekFlight.cs:7488-7501`) → `CommitGloopsRecorderData` (`ParsekFlight.cs:7523`) → `RecordingStore.CommitGloopsRecording` (`RecordingStore.cs:394`).
-- Stop (auto, on vessel switch): `FlightRecorder.HandleVesselSwitchDuringRecording` (`FlightRecorder.cs:5140-5151`) calls `StopRecording()` then sets `GloopsAutoStoppedByVesselSwitch = true`. `ParsekFlight.CheckGloopsAutoStoppedByVesselSwitch` (`ParsekFlight.cs:7507-7516`) fires on the next frame and commits. **Gloops does NOT stash into `LimboVesselSwitch`** — that state is only ever set by the normal-recording tree path.
-- Discard: `ParsekFlight.DiscardGloopsInProgress` (`ParsekFlight.cs:7567`) and `DiscardLastGloopsRecording` (referenced at `GloopsRecorderUI.cs:152`).
-- UI entry point: `Source/Parsek/UI/GloopsRecorderUI.cs` — only the "Start Recording" button at `:109`, reached via `flight.StartGloopsRecording()` at `:120`. There is no `switch-to-Gloops mid-flight` affordance.
+Verified by audit 2026-04-17 (documented in the new `#435` TODO entry):
 
-### Capture-side event paths (the sites the guard must cover)
+- `gloopsRecorder` is a single `FlightRecorder` instance with no `ActiveTree` (`ParsekFlight.cs:7460`).
+- No `BackgroundRecorder` subscription for Gloops; staging produces no debris child.
+- `FlightRecorder.HandleVesselSwitchDuringRecording` auto-stops Gloops on any vessel switch (`FlightRecorder.cs:5143-5151`); EVA produces no linked crew child.
+- `RecordingStore.CommitGloopsRecording` accepts a single `Recording`, flat-groups it under `"Gloops - Ghosts Only"` (`RecordingStore.cs:394-418`).
 
-The #431 funnel is `GameStateRecorder.Emit(GameStateEvent evt, string source)` at `GameStateRecorder.cs:58-83`. Every `GameStateEvent` creation in that file routes through it — 17 sites, verified by `grep "Emit(" Source/Parsek/GameStateRecorder.cs`: lines 285, 341, 369, 395, 409, 459, 491, 542, 574, 665, 681, 726, 757, 788, 884, 1136, 1172.
+So `#432`'s target surface is the single-recording case. The apply-side filter uses `rec.IsGhostOnly` per-recording, so when #435 (multi-recording Gloops trees) lands later, the filter handles trees automatically without re-touching #432.
 
-Two capture pipelines live **outside** the `Emit` funnel:
+### Apply-side action-creation paths
 
-- `GameStateRecorder.cs:832` — `PendingScienceSubjects.Add(new PendingScienceSubject { ... })` inside `OnScienceReceived`. This is the only `PendingScienceSubjects.Add` call site (`grep PendingScienceSubjects.Add Source/Parsek`). The subject is later committed into the ledger by `GameStateEventConverter.ConvertScienceSubjects` via `LedgerOrchestrator.OnRecordingCommitted` — Gloops recordings never call that path (see below), but a subject sitting in the pending list bleeds into **the next normal recording's** commit via `LedgerOrchestrator.NotifyLedgerTreeCommitted` (`LedgerOrchestrator.cs:1519-1560`). That is the real leak on the capture side.
-- `GameStateRecorder.cs:292` — `GameStateStore.AddContractSnapshot(guid, contractNode)` inside `OnContractAccepted`, fired immediately after the `ContractAccepted` `Emit` at `:285`. If the `Emit` is suppressed the snapshot should be too, otherwise a contract-revert snapshot lingers for a contract that was never recorded as accepted. `AddContractSnapshot` is defined at `GameStateStore.cs:120`; this is the only production caller.
-
-### Apply-side event paths (recording → ledger)
-
-The ledger is written at action-creation time, not at walk time. Paths that translate recordings into `GameAction`s:
-
-- `LedgerOrchestrator.OnRecordingCommitted` (`LedgerOrchestrator.cs:130-194`). Called only from `NotifyLedgerTreeCommitted` (`LedgerOrchestrator.cs:1546`), `ChainSegmentManager.CommitSegmentCore`, and `ParsekFlight.FallbackCommitSplitRecorder` — **none of which run for Gloops.** `CommitGloopsRecording` (`RecordingStore.cs:394-418`) does NOT call `NotifyLedgerTreeCommitted`. So the event-to-action convert at line `:141` and the science-to-action convert at line `:151` never touch Gloops recordings today.
-- `LedgerOrchestrator.CreateVesselCostActions` (`LedgerOrchestrator.cs:397-463`). Called from `OnRecordingCommitted` line `:156`. Not reached for Gloops (no commit path), but the routine blindly reads `rec.PreLaunchFunds - firstFunds` — because `FlightRecorder.cs:4207-4208` skips `CapturePreLaunchResources` in Gloops mode, `rec.PreLaunchFunds` is `0` and the resulting `buildCost` is strongly negative, so the `> 0` gate at `:421` means no action would be emitted even if the path were reached. The recovery-funds branch at `:439` gates on `TerminalStateValue == Recovered`, which a manual Gloops stop does not set.
+- `LedgerOrchestrator.OnRecordingCommitted` (`LedgerOrchestrator.cs:130-194`). Called **only** from `NotifyLedgerTreeCommitted` (`:1546`), `ChainSegmentManager.CommitSegmentCore`, and `ParsekFlight.FallbackCommitSplitRecorder`. **Never fires for Gloops** — `CommitGloopsRecording` does not go through `NotifyLedgerTreeCommitted`. The event-to-action convert at `:141` and science-to-action convert at `:151` therefore don't touch Gloops recordings today.
+- `LedgerOrchestrator.CreateVesselCostActions` (`LedgerOrchestrator.cs:397-463`). Called from `OnRecordingCommitted` `:156`. Not reached for Gloops (above). Guard here is defense-in-depth: if a future code path routes a Gloops recording through `OnRecordingCommitted`, the guard keeps the ledger clean. `rec.PreLaunchFunds` is 0 for Gloops (Gloops skips `CapturePreLaunchResources` at `FlightRecorder.cs:4207-4208`), so the `buildCost > 0` gate at `:421` already wouldn't fire even without a guard; the `rec.TerminalStateValue == Recovered` recovery branch at `:439` is the live risk for a cleanly-landed Gloops ship.
 - `LedgerOrchestrator.CreateKerbalAssignmentActions` (`LedgerOrchestrator.cs:471-510`). Called from two sites:
-  - `:165` inside `OnRecordingCommitted` — not reached for Gloops (above).
-  - `:800` inside `MigrateKerbalAssignments` (`LedgerOrchestrator.cs:769-840`), which walks **every** recording in `RecordingStore.CommittedRecordings` at `:771-796` and calls `CreateKerbalAssignmentActions(rec.RecordingId, rec.StartUT, rec.EndUT)` unconditionally. The function extracts crew from `rec.VesselSnapshot` via `ExtractCrewFromRecording` (LedgerOrchestrator.cs, same file). **A Gloops recording of a crewed vessel does have a `VesselSnapshot`** — set by `CommitGloopsRecorderData` at `ParsekFlight.cs:7550`. So today `MigrateKerbalAssignments` can generate `KerbalAssignment` actions for a Gloops recording, causing those kerbals to be reserved by `KerbalsModule.ProcessAction` for the Gloops loop duration. This is a real leak.
-- `LedgerOrchestrator.RecalculateAndPatch` (`LedgerOrchestrator.cs:612-672`). Builds `actions` from `Ledger.Actions` at `:653`, sorts, walks. The walk is action-driven, not recording-driven, so it does not need to re-probe `IsGhostOnly` — but as a belt-and-braces guard (which is what the bug asks for under "Apply-side defense in depth") a filter at `:653` that drops actions whose `RecordingId` belongs to a ghost-only recording closes the "future regression routes events through a Gloops recording" hole.
-- `RecalculationEngine.Recalculate` (`RecalculationEngine.cs:136-226`). Pure: takes a `List<GameAction>`, sorts, dispatches. No direct `Recording` access; needs no change.
+  - `:165` inside `OnRecordingCommitted` — not reached for Gloops.
+  - `:800` inside `MigrateKerbalAssignments` (`LedgerOrchestrator.cs:769-840`), which walks **every** recording in `RecordingStore.CommittedRecordings` unconditionally. The function extracts crew from `rec.VesselSnapshot` via `ExtractCrewFromRecording`, and Gloops recordings **do** have a `VesselSnapshot` (`ParsekFlight.cs:7550`). **This is the real leak**: a Gloops recording of a crewed vessel today produces `KerbalAssignment` rows on every ledger load, reserving those kerbals for the Gloops loop duration. The user's earlier bug-entry phrasing "leaks into the ledger" is this specific path.
+- `LedgerOrchestrator.RecalculateAndPatch` (`LedgerOrchestrator.cs:612-672`). Builds `actions` from `Ledger.Actions` at `:653`, sorts, walks. Action-driven — doesn't re-probe `IsGhostOnly`. Suitable place for the belt-and-braces filter.
+- `RecalculationEngine.Recalculate` (`RecalculationEngine.cs:136-226`). Pure over a `List<GameAction>` — no change needed.
 
-### Interaction with #431's tagging
+### Capture-side paths — unchanged
 
-- `GameStateRecorder.Emit` (`GameStateRecorder.cs:58-83`) reads the tag from `ResolveCurrentRecordingTag()` at `:60`, which in turn reads `ParsekFlight.GetActiveRecordingIdForTagging()` — the **normal** active recording id.
-- During a Gloops capture window where the normal auto-recorder is also running, events would be tagged with the **normal** recording's id (not a Gloops id). Without #432, those events ride with the normal recording's fate: they'd be purged on normal-recording discard, preserved on normal-recording commit — exactly the opposite of what the Gloops invariant demands.
-- With #432's capture-side guard in place, the event never reaches `Emit`, so no tag is stamped at all. A Gloops recording never has an id that owns events in `GameStateStore.Events` or in any `Milestone.Events` list. Therefore:
-  > `PurgeEventsForRecordings(idsToPurge)` (`GameStateStore.cs:261`) called with a Gloops id in the set is a no-op by construction — the HashSet lookup at `GameStateStore.cs:282` (the `set.Contains(events[i].recordingId)` filter) never matches.
-- That invariant is a useful regression check for the test matrix (step 7 below).
+- `GameStateRecorder.Emit` (`GameStateRecorder.cs:58-83`) — no guard added. Events during a Gloops window are tagged via `ResolveCurrentRecordingTag()` with whatever the normal recorder's state says, exactly as they are today under #431.
+- `OnContractAccepted` snapshot (`GameStateRecorder.cs:292`) — unchanged.
+- `OnScienceReceived` / `PendingScienceSubjects.Add` (`GameStateRecorder.cs:832`) — unchanged.
+
+### Interaction with #431's tagging — no change needed
+
+- Events fired during a Gloops window with an active normal recorder get tagged with the normal recording's id. They share the normal recording's commit/discard fate. Discarding the normal recording purges them; committing it keeps them.
+- Events fired during a Gloops window with no active normal recorder get empty tags. They flow into the between-mission career state via the save-time `FlushPendingEvents` path.
+- **No event ever receives a Gloops recording's id as a tag** (a Gloops recording's id doesn't exist until commit, and `GetActiveRecordingIdForTagging` resolves to the normal recorder's active tree, never to the Gloops recorder). Therefore:
+  > `GameStateStore.PurgeEventsForRecordings(idsToPurge)` called with a Gloops id in the set is a no-op by construction — the HashSet lookup at `GameStateStore.cs:282` never matches.
+
+Codified as a test case (test 5 below), not as runtime code.
 
 ## Plan
 
-### Step 1 — Capture-side guard: central Emit prologue + two out-of-funnel sites
+### Step 1 — Action-creation early-return on `rec.IsGhostOnly`
 
-**Decision: central guard at `Emit` + explicit guard at each of the two out-of-funnel sites (science subjects, contract snapshots).** Rationale:
-
-- 17 `Emit` call sites in `GameStateRecorder.cs` all funnel through line `:82`. One guard at the top of `Emit` covers all 17 with a single code path, matching the #431 architecture.
-- `PendingScienceSubjects.Add` (`:832`) and `AddContractSnapshot` (`GameStateRecorder.cs:292`) do not go through `Emit`. Two extra early-returns.
-- Per-site guards at the 17 `Emit` call sites would multiply boilerplate and spread the invariant across the file, contradicting #431's "one funnel" design.
-
-Concrete change in `GameStateRecorder.cs`, after the existing tag-resolve block:
+Both functions already call `FindRecordingById` (`LedgerOrchestrator.cs:592`) to resolve the `Recording` object and then read fields off it. Add an early-return right after the null check.
 
 ```csharp
-// GameStateRecorder.cs — inside Emit, before the existing AddEvent call.
-internal static void Emit(GameStateEvent evt, string source)
-{
-    // #432: Gloops (ghost-only) recordings must have zero career footprint.
-    // When the Gloops recorder is live, suppress event capture entirely.
-    if (ParsekFlight.IsGloopsCaptureActive())
-    {
-        ParsekLog.Verbose("GameStateRecorder",
-            $"Gloops capture active — suppressed {evt.eventType} event (key='{evt.key}', source='{source ?? ""}')");
-        return;
-    }
-
-    string tag = ResolveCurrentRecordingTag();
-    ... // existing body unchanged
-}
-```
-
-And at the two out-of-funnel sites:
-
-```csharp
-// GameStateRecorder.cs:285-292 — OnContractAccepted. Guard wraps BOTH the Emit
-// and the contract-snapshot write. A snapshot without its accept event would
-// leak into a later contract-revert path. Gate before Emit so the log line order
-// reads as "snapshot suppressed because Gloops active".
-if (ParsekFlight.IsGloopsCaptureActive())
-{
-    ParsekLog.Verbose("GameStateRecorder",
-        $"Gloops capture active — suppressed ContractAccepted (guid={guid})");
-    return;
-}
-Emit(evt, "ContractAccepted");
-try { GameStateStore.AddContractSnapshot(guid, contractNode); ... }
-```
-
-```csharp
-// GameStateRecorder.cs:826-840 — OnScienceReceived. PendingScienceSubjects.Add
-// is its own pipeline; guard it independently. The list is consumed on the NEXT
-// normal-recording commit (LedgerOrchestrator.NotifyLedgerTreeCommitted:1519),
-// so a leaked subject would credit science to an unrelated career mission.
-if (ParsekFlight.IsGloopsCaptureActive())
-{
-    ParsekLog.Verbose("GameStateRecorder",
-        $"Gloops capture active — suppressed PendingScienceSubjects.Add (subject={subject.id})");
-    return;
-}
-PendingScienceSubjects.Add(new PendingScienceSubject { ... });
-```
-
-The two explicit guards are small enough that they don't warrant factoring into a helper. They also document the two non-Emit capture pipelines for the next person reading the file.
-
-Note that the duplicate Emit-guard inside `Emit` itself still fires for the `ContractAccepted` path the second time (we early-return before it) — so in practice `Emit` only sees the guard on the 15 sites that aren't contract-accepted / science-received. This is fine: the guard is idempotent and its Verbose log stays a useful signal for the "some handler slipped through" case.
-
-### Step 2 — Add the `ParsekFlight.IsGloopsCaptureActive()` accessor
-
-The task brief proposes `GetActiveRecordingGhostOnlyFlag()`. That name suggests a probe of the active recording's flag, which we established above does not work for the live-capture window — it would return `false` every time because the Gloops `Recording` does not exist in the tree yet.
-
-The right name is one that describes the live state the guard actually checks. Use `IsGloopsCaptureActive` — parallels `IsGloopsRecording` (the existing instance property at `ParsekFlight.cs:7430`) but is static and null-safe, like `GetActiveRecordingIdForTagging` and `HasLiveRecorderForTagging` (`ParsekFlight.cs:35, 43`):
-
-```csharp
-// ParsekFlight.cs — near the existing tagging accessors at :35.
-/// <summary>
-/// #432: true when a Gloops ghost-only recorder is currently sampling. The
-/// GameStateRecorder.Emit prologue and the two out-of-funnel capture sites
-/// (PendingScienceSubjects.Add, AddContractSnapshot) consult this to suppress
-/// career-state capture during Gloops flights.
-///
-/// Unlike GetActiveRecordingIdForTagging, this does not probe the active tree —
-/// a Gloops Recording does not exist in the tree until CommitGloopsRecording
-/// runs, so the live-window gate must read the recorder state directly.
-/// </summary>
-internal static bool IsGloopsCaptureActive()
-{
-    if (GloopsCaptureActiveForTesting != null)
-        return GloopsCaptureActiveForTesting();
-    return Instance != null && Instance.IsGloopsRecording;
-}
-
-/// <summary>
-/// #432: test hook for IsGloopsCaptureActive, mirrors #431's TagResolverForTesting
-/// pattern in GameStateRecorder. Tests set this to a fixed bool supplier so they
-/// don't have to spin up the ParsekFlight MonoBehaviour.
-/// </summary>
-internal static System.Func<bool> GloopsCaptureActiveForTesting;
-```
-
-A corresponding `ParsekFlight.ResetTestOverrides()` clears `GloopsCaptureActiveForTesting = null` alongside any future test hooks on this class. (No such reset exists on `ParsekFlight` today; add it. `GameStateRecorder.ResetForTesting` at `GameStateRecorder.cs:115` is a clear model.)
-
-**LimboVesselSwitch fallback — NOT needed.** The #431 `ResolveCurrentRecordingTag` fallback (`GameStateRecorder.cs:100-104`) exists because a normal recording stashes its pending tree into `LimboVesselSwitch` during a vessel switch and events captured in that window still belong to the outgoing recording. **Gloops has no such stash.** `FlightRecorder.HandleVesselSwitchDuringRecording` (`FlightRecorder.cs:5143-5151`) auto-stops the Gloops recorder immediately on vessel-switch detection, and `CheckGloopsAutoStoppedByVesselSwitch` commits it on the next frame. By the time any ambiguity window opens, `gloopsRecorder.IsRecording` is already `false`, so `IsGloopsCaptureActive()` returns `false`. Events fired during the switch belong to the incoming vessel's normal recording (or no recording), which is the correct place for them.
-
-### Step 3 — Apply-side: action-creation guards + belt-and-braces walk filter
-
-**At action-creation.** `CreateKerbalAssignmentActions` (`LedgerOrchestrator.cs:471`) and `CreateVesselCostActions` (`LedgerOrchestrator.cs:397`) both already call `FindRecordingById` (`LedgerOrchestrator.cs:592`) to resolve the `Recording`. Add an early-return:
-
-```csharp
-// LedgerOrchestrator.cs:471 — CreateKerbalAssignmentActions, after FindRecordingById.
+// LedgerOrchestrator.cs:471 — CreateKerbalAssignmentActions.
+var rec = FindRecordingById(recordingId);
 if (rec == null) return result;
+
 if (rec.IsGhostOnly)
 {
     ParsekLog.Verbose(Tag,
         $"CreateKerbalAssignmentActions: recording '{recordingId}' is ghost-only — skipping");
     return result;
 }
+
+if (NeedsCrewEndStatePopulation(rec)) ...
 ```
 
 ```csharp
-// LedgerOrchestrator.cs:401 — CreateVesselCostActions, after FindRecordingById.
-if (rec == null) { ... return result; }
+// LedgerOrchestrator.cs:397 — CreateVesselCostActions.
+var rec = FindRecordingById(recordingId);
+if (rec == null)
+{
+    ParsekLog.Verbose(Tag,
+        $"CreateVesselCostActions: recording '{recordingId}' not found in CommittedRecordings — skipping");
+    return result;
+}
 if (rec.IsGhostOnly)
 {
     ParsekLog.Verbose(Tag,
         $"CreateVesselCostActions: recording '{recordingId}' is ghost-only — skipping");
     return result;
 }
+
+if (rec.Points.Count == 0) ...
 ```
 
-This closes the real leak at `LedgerOrchestrator.cs:800` where `MigrateKerbalAssignments` walks every `CommittedRecordings` entry and would synthesize `KerbalAssignment` actions for a crewed Gloops recording.
+These two early-returns close the real leak at `MigrateKerbalAssignments:800`. A Gloops-crewed recording on next ledger load returns an empty `desired` from `CreateKerbalAssignmentActions`; `KerbalAssignmentActionsMatch(existing, empty)` returns false when there are stale rows (from pre-fix builds); `Ledger.ReplaceActionsForRecording(KerbalAssignment, rec.RecordingId, empty)` cleans them out. One-shot self-heal with no extra code.
 
-**Belt-and-braces walk filter.** Add a pre-pass filter inside `LedgerOrchestrator.RecalculateAndPatch` (`LedgerOrchestrator.cs:612`) that drops actions whose `RecordingId` maps to an `IsGhostOnly` recording. This catches:
+### Step 2 — Belt-and-braces walk filter in `RecalculateAndPatch`
 
-- Stale actions from a pre-#432 save where `MigrateKerbalAssignments` already ran on a Gloops recording and deposited `KerbalAssignment` rows into the ledger file on disk.
-- Future regressions where some new code path produces a `GameAction` with a Gloops `RecordingId`.
+Drop any action whose `RecordingId` maps to an `IsGhostOnly` recording before handing the list to `RecalculationEngine.Recalculate`. This catches future regressions where some new path deposits a Gloops-tagged action into the ledger, and makes the invariant "no Gloops action reaches the walk" explicit instead of implied.
 
 ```csharp
 // LedgerOrchestrator.cs:653 — inside RecalculateAndPatch, before Recalculate.
 var actions = new List<GameAction>(Ledger.Actions);
 
-// #432: filter out any actions tagged with a ghost-only recording's id.
-// Pure defense-in-depth: action-creation should already skip these, but a
-// save from before the action-creation guards landed could hold stale rows.
+// #432: belt-and-braces filter — no action tagged with a ghost-only recording
+// reaches the walk. Step 1's action-creation guards should prevent any such
+// action from being produced today; this catches future regressions.
 int beforeFilter = actions.Count;
 actions = FilterOutGhostOnlyActions(actions);
 int filtered = beforeFilter - actions.Count;
@@ -220,12 +141,11 @@ RecalculationEngine.Recalculate(actions);
 ```
 
 ```csharp
-// LedgerOrchestrator.cs — new internal static helper.
+// LedgerOrchestrator.cs — new internal static helper, unit-testable.
 internal static List<GameAction> FilterOutGhostOnlyActions(List<GameAction> actions)
 {
     if (actions == null || actions.Count == 0) return actions ?? new List<GameAction>();
 
-    // Build ghost-only id set once per call. Cheap: CommittedRecordings is usually <100.
     var ghostOnlyIds = new HashSet<string>(StringComparer.Ordinal);
     var recs = RecordingStore.CommittedRecordings;
     for (int i = 0; i < recs.Count; i++)
@@ -242,118 +162,86 @@ internal static List<GameAction> FilterOutGhostOnlyActions(List<GameAction> acti
 }
 ```
 
-**`MigrateKerbalAssignments` — no extra change needed.** Once `CreateKerbalAssignmentActions` early-returns for ghost-only, `KerbalAssignmentActionsMatch(existing, kerbalActions)` at `LedgerOrchestrator.cs:804` trivially matches an empty desired list against any empty existing list → `continue;`, and for a Gloops recording that had stale rows from a pre-fix save, `Ledger.ReplaceActionsForRecording(KerbalAssignment, rec.RecordingId, empty)` cleans them up on next load. That is the one-shot self-heal we want.
+Performance: O(recordings + actions). `CommittedRecordings` is typically under 100 entries, `Ledger.Actions` under a few thousand. Negligible versus the existing sort + walk in `RecalculationEngine.Recalculate`.
 
-### Step 4 — One-time self-heal for pre-fix saves that already leaked Gloops actions
+### Step 3 — No capture-side changes
 
-The walk filter in step 3 keeps Gloops actions out of the recalculation, but leaves them sitting in `Ledger.Actions` forever (written back to disk on `OnSave`). That bloats the file and keeps the log line "filtered N actions" firing on every load.
+Confirmed by the 2026-04-17 clarification. `GameStateRecorder.Emit`, the `OnContractAccepted` snapshot call, and the `OnScienceReceived` `PendingScienceSubjects.Add` are untouched. Events flow through the #431 pipeline exactly as they do today.
 
-**Decision: clean the ledger on load, not every call.** Add a one-shot pass in `LedgerOrchestrator.OnLoad` (`LedgerOrchestrator.cs:1080`) that calls `FilterOutGhostOnlyActions` once, compares counts, and if anything was removed, calls `Ledger.RemoveActionsForRecording` for each ghost-only id. Logs at Info. This runs after `Ledger.LoadFromFile(path)` at `:1094`.
+### Step 4 — No accessor on `ParsekFlight`
 
-```csharp
-// LedgerOrchestrator.cs — inside OnLoad, after Ledger.LoadFromFile.
-int removed = PurgeGhostOnlyActionsFromLedger();
-if (removed > 0)
-    ParsekLog.Info(Tag,
-        $"OnLoad: removed {removed} stale action(s) tagged with ghost-only recordings (pre-#432 save)");
-```
+Originally proposed `GetActiveRecordingGhostOnlyFlag()` / `IsGloopsCaptureActive()`. With the capture-side dropped, the accessor has no caller — the apply-side code already has the `Recording` object in hand and reads `rec.IsGhostOnly` directly. Dropped as dead code.
 
-The helper walks `Ledger.Actions`, collects ghost-only-tagged entries, and removes them via whatever public API `Ledger` already exposes (`Ledger.RemoveActionsForRecording` or direct list mutation — pick whichever exists; `MigrateKerbalAssignments` uses `Ledger.ReplaceActionsForRecording` at `:809` as precedent). A cheap, idempotent cleanup.
+### Step 5 — No retroactive save cleanup
 
-### Step 5 — Interaction with #431's purge, formally
+Parsek is in beta. Pre-fix saves with stale `KerbalAssignment` rows tagged with a ghost-only recording id are self-healed on next load via step 1 (`CreateKerbalAssignmentActions` returns empty, `MigrateKerbalAssignments` calls `Ledger.ReplaceActionsForRecording` with the empty list). No separate migration pass needed.
 
-Once steps 1–3 are in place, the Gloops-capture flow is:
+Event-store side: events captured during pre-fix Gloops windows were already tagged correctly per #431 (with the normal recording's id, or empty for Gloops-solo) — Gloops never owned them in the first place. No cleanup needed.
 
-1. Player opens Gloops UI, clicks Start.
-2. `gloopsRecorder.IsRecording` flips to `true`. The normal auto-recorder may also be running; `activeTree.ActiveRecordingId` holds the normal recording's id (or `""`).
-3. A career event fires (e.g. `ContractAccepted`).
-4. `GameStateRecorder.OnContractAccepted` sees `ParsekFlight.IsGloopsCaptureActive() == true`, early-returns **before** the `Emit` and **before** the `AddContractSnapshot`. No `GameStateEvent` reaches `GameStateStore.Events`, no snapshot reaches `contractSnapshots`.
-5. Player stops Gloops. `CommitGloopsRecording` mints a recording id, flips `IsGhostOnly = true`, adds to `committedRecordings`.
+### Step 6 — Tests
 
-At no point is a `GameStateEvent` tagged with the Gloops recording id. Therefore `GameStateStore.PurgeEventsForRecordings([gloopsId], reason)` (`GameStateStore.cs:261`) finds zero matches: the `events[i].recordingId == gloopsId` check at `:282` never fires. The purge path is a no-op for Gloops ids **by construction of the capture guard**, not by any extra check in `PurgeEventsForRecordings`. This matches the explicit prediction in the bug entry (`todo-and-known-bugs.md:222`: "Gloops ghost-only recordings are covered by #432: they never capture events, so #431's purge logic is a no-op for them").
+New `Source/Parsek.Tests/GloopsEventSuppressionTests.cs`. `[Collection("Sequential")]` — touches `RecordingStore`, `Ledger`, `LedgerOrchestrator` static state. `ParsekLog.TestSinkForTesting` captures log lines for assertions. File name kept despite the design flip so the test discovery tooling doesn't break; tests describe what the filter does.
 
-Codify this as a test case (step 7, test `purge_for_gloops_id_is_noop`), not as runtime code. No runtime change needed in `PurgeEventsForRecordings`.
+1. **`create_kerbal_assignment_actions_returns_empty_for_ghost_only`** — build a synthetic `Recording` with `IsGhostOnly = true` and a `VesselSnapshot` containing one crew entry. Add to `committedRecordings`. Call `LedgerOrchestrator.CreateKerbalAssignmentActions(recId, startUT, endUT)`. Assert the result is empty and the Verbose `"is ghost-only — skipping"` line fired.
+2. **`create_kerbal_assignment_actions_returns_rows_for_normal`** — same setup but `IsGhostOnly = false`. Assert the result contains one `KerbalAssignment` action.
+3. **`create_vessel_cost_actions_returns_empty_for_ghost_only`** — synthetic `Recording` with `IsGhostOnly = true`, `PreLaunchFunds = 5000`, first-point funds 4000, `TerminalStateValue = Recovered`, last-point funds 9000, penultimate-point funds 5000. Call `CreateVesselCostActions`. Without the guard the result would hold a `FundsSpending` (cost=1000) + `FundsEarning` (recovery=4000); with the guard, asserts empty and the Verbose `"is ghost-only — skipping"` line fired.
+4. **`filter_out_ghost_only_actions_drops_ghost_only_and_keeps_others`** — seed `committedRecordings` with two test recordings, one `IsGhostOnly = true` (id `"gloops-A"`), one `IsGhostOnly = false` (id `"normal-B"`). Build a `List<GameAction>` with three entries: one tagged `"gloops-A"`, one tagged `"normal-B"`, one with empty `RecordingId`. Call `FilterOutGhostOnlyActions`. Assert the returned list contains exactly the `"normal-B"` and the empty-tagged actions.
+5. **`purge_for_gloops_id_is_noop`** — regression guard that events never receive a Gloops recording id as a tag. Seed `GameStateStore.Events` with a tagged normal-recording event and an untagged event. Call `GameStateStore.PurgeEventsForRecordings(new[] { "never-existed-gloops-id" }, "test")`. Assert zero events removed.
+6. **`recalculate_and_patch_filter_log_line_fires_when_ghost_only_action_present`** — seed one ghost-only recording in `committedRecordings`, seed `Ledger.Actions` with one action tagged with that id. Trigger `RecalculateAndPatch`. Assert the `"filtered 1 action(s)"` Info log line fired.
+7. **`recalculate_and_patch_no_filter_log_when_no_ghost_only_recordings`** — same but no ghost-only recording in `committedRecordings`. Assert the filter log line did NOT fire (nothing filtered).
+8. **`migrate_kerbal_assignments_replaces_stale_ghost_only_rows_with_empty`** — simulate a pre-fix save state by seeding `Ledger.Actions` with a `KerbalAssignment` row tagged with a ghost-only recording's id. Add that ghost-only recording to `committedRecordings`. Call `MigrateKerbalAssignments`. Assert the stale row was removed via `Ledger.ReplaceActionsForRecording`-style replacement, and the "repaired N recording(s)" info log fired.
 
-### Step 6 — Edge cases, worked through
+All tests use `ParsekLog.ResetTestOverrides()` + any necessary `LedgerOrchestrator.ResetForTesting` hooks in Dispose. Neither `GameStateRecorder.TagResolverForTesting` nor a new Gloops-side test hook is needed — no capture-side changes, no new accessor.
 
-1. **Normal recording + Gloops concurrently.** Allowed by the current UI (no gate in `GloopsRecorderUI.cs` or `StartGloopsRecording`). With the step-1 guard, while Gloops is live every career event is suppressed — including events the normal recording should rightfully have captured. **This is a real UX gotcha.** Two ways to resolve:
-   - **(a) Accept as user error**, document in the user-guide note at step 9. "Don't run career missions while a Gloops recording is active." Pragmatic: Gloops is decorative and intended for plane flies / airshows, not career missions.
-   - **(b) Add a UI gate** in `GloopsRecorderUI.DrawWindow` and `StartGloopsRecording` that blocks Start while `IsRecording == true` (normal recorder running), plus a symmetric check in the normal-recording start paths.
-   I recommend **(a)** for this PR — the smaller change and the existing parallel-recorder design is explicit in the bug's framing. (b) is a cleaner UX but widens the scope into UI work that the bug entry does not mention. **Open question for the user** (see final section).
-2. **Player switches to a Gloops recording mid-flight.** The UI has no such affordance. `GloopsRecorderUI.DrawWindow` (`UI/GloopsRecorderUI.cs:91-186`) only offers Start / Stop / Preview / Discard for the Gloops recorder itself — there is no switch-recording-type control. On vessel switch, `FlightRecorder.HandleVesselSwitchDuringRecording` (`FlightRecorder.cs:5143-5151`) auto-stops Gloops. Answer: **not possible with the current UI flow** — no code change needed to handle it.
-3. **Quicksave during a Gloops flight + F9.** `GameStateStore.Events` serializes to disk on save (via `ParsekScenario.OnSave` → `GameStateStore.SaveEventFile`). Events captured BEFORE the #432 guard landed (i.e., from a save created on a pre-fix build) are already in the save file. F9ing that quicksave loads them back. **Retroactive cleanup is out of scope** — documented in step 10. Step 4's one-time ledger-side self-heal handles the related leak in `Ledger.Actions`, but the `GameStateStore.Events` / `MilestoneStore` side would need a full migration pass that this PR does not ship. A player running a pre-#432 save through a post-#432 build still sees the stale event rows until they manually discard the old Gloops recording; step 11 covers it in the risks section.
-4. **Gloops + LimboVesselSwitch fallback.** Covered above in step 2 ("LimboVesselSwitch fallback — NOT needed"). Gloops auto-stops on vessel switch; there is no limbo window for it.
-5. **Science subjects pipeline.** Addressed in step 1 with the explicit `OnScienceReceived` guard. `PendingScienceSubjects` is the only science capture target; `GameStateEventConverter.ConvertScienceSubjects` is consumer-side and only fires from the normal `OnRecordingCommitted` path, never from Gloops commit.
-6. **Resource events (FundsChanged, ScienceChanged, ReputationChanged).** The `Emit` guard suppresses them identically to other event types. The invariant says Gloops has zero career footprint, and resource events that the game fires during a Gloops flight (e.g. recovery funds credited because the player happened to recover a different vessel while Gloops is running) would today flow into `GameStateStore.Events`. Under #432 they are suppressed. **This is the intended behavior** — Gloops windows explicitly contract to not capture career state. The corollary: real career effects that happen to fire during a Gloops window do not get ledger-replayed later. Documented in step 9's user-guide note. No extra guard; the `Emit` gate covers it.
-7. **Auto-commit after vessel-switch auto-stop.** Between `gloopsRecorder.StopRecording()` (`FlightRecorder.cs:5148`) and `CommitGloopsRecorderData` on the next frame (`ParsekFlight.cs:7514`), `gloopsRecorder.IsRecording == false` → `IsGloopsCaptureActive()` returns `false`. Events that fire in that narrow window (e.g. science rewards credited after the vessel switch completes) are captured normally and tagged with whatever recording is newly active. This is correct: by the time the gate has lowered, the Gloops window has closed and those events belong to the next mission's fate.
+### Step 7 — Post-build verification
 
-### Step 7 — Tests
+`dotnet build` + `dotnet test` from the worktree. Deploy and grep the deployed DLL for the new `"FilterOutGhostOnlyActions"` or `"is ghost-only — skipping"` UTF-16 string to confirm the correct build is live. Manual playtest recipe:
 
-New `Source/Parsek.Tests/GloopsEventSuppressionTests.cs`. `[Collection("Sequential")]` — touches `GameStateRecorder` / `GameStateStore` / `Ledger` / `RecordingStore` static state. All tests swap the Gloops-capture hook via `ParsekFlight.GloopsCaptureActiveForTesting = () => true` (or `false`) so they don't need the MonoBehaviour alive. `ParsekLog.TestSinkForTesting` captures the Verbose suppression log lines for assertions.
+1. Start a career save, launch a crewed plane.
+2. Open Gloops window, Start Recording.
+3. Fly the plane around for ~30 seconds, then Stop. Confirm the Gloops recording appears in the recordings table under `"Gloops - Ghosts Only"`.
+4. Open the Career State / Kerbals windows. Confirm the plane's kerbal is **not** listed as reserved for the Gloops recording's duration.
+5. Check `KSP.log` for `"CreateKerbalAssignmentActions: recording '<id>' is ghost-only — skipping"` (the Gloops recording's id) alongside the normal migration output.
+6. Quickload an older save created on a pre-#432 build where a Gloops recording already has stale KerbalAssignment rows. Confirm the one-shot self-heal fires (`MigrateKerbalAssignments` repairs it).
 
-1. **`contract_accept_during_gloops_is_suppressed`** — `GloopsCaptureActiveForTesting = () => true`, fire a synthetic `ContractAccepted` through the handler. Assert `GameStateStore.Events` count unchanged, `contractSnapshots` unchanged, and a `"Gloops capture active — suppressed ContractAccepted"` Verbose line was logged.
-2. **`normal_contract_accept_still_captured`** — `GloopsCaptureActiveForTesting = () => false` (or null), fire a `ContractAccepted`. Assert event was added to the store (and to `contractSnapshots` where appropriate).
-3. **`science_subject_during_gloops_is_suppressed`** — `GloopsCaptureActiveForTesting = () => true`, call `OnScienceReceived` directly with a synthetic subject. Assert `PendingScienceSubjects.Count == 0` and the suppress-log line for `OnScienceReceived` fired.
-4. **`normal_science_subject_still_captured`** — gate off, same call. Assert `PendingScienceSubjects.Count == 1`.
-5. **`resource_event_during_gloops_is_suppressed`** — gate on, fire a `FundsChanged` event. Assert no event in the store, suppress log fired.
-6. **`ledger_walk_skips_ghost_only_recording`** — seed `Ledger.Actions` with two `KerbalAssignment` actions, one tagged with a `RecordingId` whose `IsGhostOnly = true` (injected via a test `Recording` added to `RecordingStore`), one tagged with a normal recording id. Call `LedgerOrchestrator.FilterOutGhostOnlyActions` directly. Assert the ghost-only action is filtered, the normal one is kept, and the "filtered N" Info log fires when called from `RecalculateAndPatch`.
-7. **`create_kerbal_assignment_actions_returns_empty_for_ghost_only`** — construct a test `Recording` with `IsGhostOnly = true` and a synthetic `VesselSnapshot` containing one crew. Add it to `committedRecordings`. Call `LedgerOrchestrator.CreateKerbalAssignmentActions(recId, startUT, endUT)`. Assert the result is empty and the Verbose "ghost-only — skipping" line fired.
-8. **`purge_for_gloops_id_is_noop`** — set `GloopsCaptureActiveForTesting = () => true`, run 5 distinct `Emit` attempts. Then set the gate off, add a normal event tagged with a different id. Call `GameStateStore.PurgeEventsForRecordings` with a fake "gloops-id" (which was never used as a tag because the gate suppressed all 5). Assert `removed == 0` and the live store still contains the one normal event.
-9. **`limbo_vessel_switch_does_not_affect_gloops_guard`** — set `RecordingStore.pendingTreeState = LimboVesselSwitch`, gate on. Fire an `Emit`. Assert suppressed regardless of the limbo state. Codifies that the Gloops guard runs before the tag resolver's LimboVesselSwitch fallback.
-10. **`on_load_purge_removes_stale_ghost_only_actions`** — seed `Ledger.Actions` with two actions tagged with a ghost-only id, call `LedgerOrchestrator.PurgeGhostOnlyActionsFromLedger()` (the helper from step 4). Assert both actions removed and the "removed N stale action(s)" Info log fires. Complement: same setup but ids are all non-ghost-only → assert nothing removed, no log.
-11. **`reset_test_overrides_clears_hook`** — set `GloopsCaptureActiveForTesting = () => true`, call `ParsekFlight.ResetTestOverrides()`. Assert `IsGloopsCaptureActive()` now returns `false` (no Instance in tests, Instance == null ⇒ false).
+### Step 8 — Docs updates (staged in the implementation commit per CLAUDE.md)
 
-**Test hook summary:** add `ParsekFlight.GloopsCaptureActiveForTesting` (`Func<bool>`) and `ParsekFlight.ResetTestOverrides()`. Same pattern as `GameStateRecorder.TagResolverForTesting` / `ResetForTesting` (`GameStateRecorder.cs:49, 115`). Yes, the test hook is needed — production tests can't easily instantiate `ParsekFlight` (it's a `MonoBehaviour` with heavy state).
+- **`CHANGELOG.md`** — one user-facing line under `## 0.8.2`. Suggested wording: `Gloops (ghost-only) recordings no longer leak kerbal assignments or vessel costs into the career ledger — they are purely visual.` Fits the repo's 1-line CHANGELOG style.
+- **`docs/dev/todo-and-known-bugs.md`** — strike the `## 432.` header and rewrite the body as a ~~DONE~~ status note describing the apply-side-only design, per CLAUDE.md's "doc updates per commit, not per PR" rule. (Already updated on this branch to reflect the refined scope; the implementation commit flips it to ~~done~~.)
+- **`docs/user-guide.md`** — append to the Gloops Flight Recorder section. Suggested line: `Gloops recordings are purely visual. They never charge funds for the vessel you captured, never reserve the kerbals aboard for the loop duration, never complete contracts, and never credit science or milestones — those stay with your normal mission recording (if any) or your between-mission career state.`
+- **`.claude/CLAUDE.md`** — no change.
 
-### Step 8 — Post-build verification
+### Step 9 — Scope
 
-`dotnet build` + `dotnet test` from the worktree. After deploy, grep the deployed DLL for a distinctive UTF-16 string introduced by this change (`IsGloopsCaptureActive` or `"Gloops capture active — suppressed"`). Manual playtest recipe:
-
-1. Start a career game, launch a plane.
-2. Open Gloops window, click Start Recording.
-3. In flight, take an EVA science sample or accept a contract via KAC. (If that isn't reachable mid-Gloops-flight, use a stock save-file edit to force a `FundsChanged` event mid-flight — e.g. `MODIFY_FUNDS`.)
-4. Stop Gloops.
-5. Check `KSP.log` for `"Gloops capture active — suppressed"` lines.
-6. Open Parsek Career State window — confirm the contract / science / funds from step 3 did not appear in the ledger.
-7. Delete the Gloops recording. Confirm the career state window still shows no Gloops-derived entries (and no log lines about purged Gloops events — because there were none to purge).
-
-### Step 9 — Docs updates (staged in the implementation commit per CLAUDE.md)
-
-- **`CHANGELOG.md`** — one user-facing line under `## 0.8.2` (or the next active heading). Suggested wording: `Gloops (ghost-only) recordings no longer leak contracts, science, funds, reputation, crew assignments, or milestones into the career ledger — they are purely visual.` Fits the repo's 1-line hard-rule CHANGELOG style.
-- **`docs/dev/todo-and-known-bugs.md`** — strike the `## 432.` header and body at `:159-192`, replace the `**Status:** TODO.` line with a status note along the lines of what `#431` got at `:240` (pattern: `**Status:** ~~DONE~~. <one-paragraph summary of approach and file map>`). Keep the "Related edge cases" section intact for reference.
-- **`docs/user-guide.md`** — append to the Gloops Flight Recorder section at `:36-46`. Suggested line: `Gloops recordings have no effect on your career — contracts accepted, science collected, funds spent, milestones achieved, and kerbals aboard during a Gloops flight are all ignored by the Parsek ledger. Use normal recordings for missions you want to count.`
-- **`.claude/CLAUDE.md`** — no change. The file layout and patterns are unchanged.
-
-### Step 10 — Scope
-
-**In scope for this PR:**
-- `GameStateRecorder.Emit` capture-side gate.
-- Explicit gates at `OnContractAccepted` (before Emit + snapshot) and `OnScienceReceived` (before `PendingScienceSubjects.Add`).
-- `ParsekFlight.IsGloopsCaptureActive()` + `GloopsCaptureActiveForTesting` test hook + `ResetTestOverrides`.
-- `CreateKerbalAssignmentActions` and `CreateVesselCostActions` action-creation early-returns on `rec.IsGhostOnly`.
+**In scope:**
+- `CreateKerbalAssignmentActions` and `CreateVesselCostActions` early-return on `rec.IsGhostOnly`.
 - `LedgerOrchestrator.FilterOutGhostOnlyActions` + `RecalculateAndPatch` pre-pass filter.
-- One-time self-heal `PurgeGhostOnlyActionsFromLedger` called from `LedgerOrchestrator.OnLoad`.
-- New `Source/Parsek.Tests/GloopsEventSuppressionTests.cs` per step 7.
-- Doc updates per step 9.
+- New `Source/Parsek.Tests/GloopsEventSuppressionTests.cs`.
+- Doc updates per step 8.
 
 **Out of scope:**
-- **Retroactive cleanup of leaked events in pre-#432 saves.** Events already in `GameStateStore.Events` / `Milestone.Events` / contract snapshots from a pre-fix Gloops flight are not purged by this PR. The ledger-side self-heal (step 4) handles `Ledger.Actions`; the event-store side would need a migration pass that walks every saved event, looks up its tag against currently-committed ghost-only recordings, and removes matches. That migration is cheap but scope-creeps into schema-migration territory; document as a known limitation in the CHANGELOG.
-- **UI gate against concurrent normal + Gloops recording.** Documented in step 6 case 1 and the Open Questions section. Would add UI work not scoped to this bug.
-- **Allowing Gloops recordings to opt into career capture.** Contradicts the decorative-only design intent (bug entry, `todo-and-known-bugs.md:186-187`). If a player wants career effects, they use a normal recording.
-- **Removing `MilestoneStore.CurrentEpoch` filter.** Separate cleanup per the #431 retirement-follow-up TODO at `todo-and-known-bugs.md:216`.
+- Capture-side event suppression — events during a Gloops window belong to the parallel normal recording or between-mission state under #431; no Gloops involvement.
+- Retroactive save cleanup (beta; pre-fix saves self-heal on next load via step 1's one-shot migration rewrite).
+- `ParsekFlight` accessor (dead code — no caller).
+- Multi-recording Gloops trees (new feature in `#435`; #432's per-recording filter handles them automatically when they land).
+- Removing `MilestoneStore.CurrentEpoch` — separate cleanup per #431's retirement-follow-up TODO.
 
 ## Risks
 
-- **The `IsGloopsCaptureActive` guard suppresses events that happen during a Gloops window even if the player also has a normal career mission recording concurrently.** See step 6 case 1. Mitigated by the user-guide note in step 9 and flagged as an open question for the implementer.
-- **Pre-#432 saves carry stale leaked data.** Step 4 heals `Ledger.Actions`; events in `GameStateStore.Events` and `Milestone.Events` stay behind. A subsequent migration pass could clean them, but it is out of scope here. Players unaffected in practice unless they happened to have a heavy Gloops + career session on an older build.
-- **Performance.** `FilterOutGhostOnlyActions` runs on every `RecalculateAndPatch` call — builds a HashSet of ghost-only ids from `CommittedRecordings` (typically <100 entries) and walks `actions` once. O(recordings + actions). Negligible next to the existing sort + walk in `RecalculationEngine.Recalculate`. No index needed.
+- **`FilterOutGhostOnlyActions` overhead on every `RecalculateAndPatch`.** O(recordings + actions). Negligible next to the existing sort + walk. No index needed.
+- **A future code path accidentally generating a Gloops-tagged action.** Caught by the walk filter (step 2) with an Info log identifying the count. Any non-zero count in a live save is a signal to find and fix the new path. The log line fires on every such call, so if it becomes noise, it indicates a real leak worth tracing.
+- **Multi-recording Gloops (#435) future interaction.** When #435 lands, every leaf in a Gloops tree will have `IsGhostOnly = true`. The existing per-recording `FindRecordingById(...).IsGhostOnly` and `FilterOutGhostOnlyActions` logic both read per-recording flags, so the tree case works automatically. No #432 re-work needed.
 
 ## Sequencing
 
-Independent of #434. Can ship alongside or after #434 in any order; they touch disjoint code paths (#434 is the revert-auto-discard rebase on top of #431's `DiscardPendingTree`, #432 is about capture gating + ledger filter).
+Independent of #434. Can ship in any order relative to it. No hard dependency on further work.
 
-## Open questions for the user before implementation
+## Open questions
 
-1. **Concurrent Gloops + normal recording — suppress all, or gate the UI?** (Step 6 case 1 / Risks section.) My default is to suppress all events during the Gloops window and document in the user-guide. Alternative: add a UI gate that blocks Start Gloops while the normal recorder is active, and vice versa. The latter is a behavior change this PR could sneak in, but also widens scope.
-2. **Retroactive save-side cleanup — ship a migration, or leave as documented limitation?** Step 10 goes with "documented limitation". A migration would walk `GameStateStore.Events` + every `Milestone.Events` list on load and purge entries whose `recordingId` maps to a ghost-only recording. One-shot pass, idempotent, mirrors step 4's ledger-side heal. Implementer can add it if desired; I scoped it out to keep the PR focused.
-3. **Accessor name — `IsGloopsCaptureActive` vs. `GetActiveRecordingGhostOnlyFlag` (task brief wording) vs. something else?** My case for renaming is in the Step 2 body. If the reviewer prefers the brief's original name I'll rename — but the rename-only change doesn't affect correctness.
+None outstanding after the 2026-04-17 clarification:
+
+- Concurrent Gloops + normal recording: events go to the normal recording. Confirmed — the apply-side-only design preserves this automatically.
+- Gloops-solo + event: empty-tag between-mission state per #431 existing behavior. Confirmed — no change.
+- Accessor name / existence: dropped as dead code.
+- Retroactive save cleanup: beta, not needed.
+- Multi-recording Gloops: aspirational, tracked in `#435`; #432's per-recording filter future-proofs the ledger-side.

--- a/docs/dev/plans/fix-432-gloops-no-events.md
+++ b/docs/dev/plans/fix-432-gloops-no-events.md
@@ -39,7 +39,7 @@ Rationale:
 - `Source/Parsek/Recording.cs:29` — `public bool IsGhostOnly;` on `Recording`. Serialized only when true at `RecordingTree.cs:526-527`, deserialized at `RecordingTree.cs:953`.
 - `Source/Parsek/FlightRecorder.cs:120` — `IsGloopsMode` flag on the recorder. Set once at `ParsekFlight.cs:7460` (`new FlightRecorder { IsGloopsMode = true }`). Read at `FlightRecorder.cs:4207, 4212, 4240, 4717, 5143` to skip resource baselines / rewind save / tree logic / auto-stop on vessel switch.
 - `Source/Parsek/ParsekFlight.cs:7542` — `rec.IsGhostOnly = true` set at commit time inside `CommitGloopsRecorderData`. `RecordingStore.cs:402` re-asserts it.
-- Read sites: `GhostPlaybackLogic.cs:3001` (loop-from-end semantics), `ParsekFlight.cs:9221` (`if (!rec.IsGhostOnly)` — gates vessel spawn at ghost-end, already correct), `RecordingTree.cs:526, 953` (serialize/deserialize), `RecordingsTableUI.cs:1313, 2445` (X delete button + group display), `KerbalsModule.cs` (ghost-only chain handoff end-state fallback).
+- Read sites: `GhostPlaybackLogic.cs:3001` (loop-from-end semantics), `ParsekFlight.cs:9221` (`if (!rec.IsGhostOnly) warn + return` — delete-button guard inside `DeleteGhostOnlyRecording`, unrelated to spawn), `RecordingTree.cs:526, 953` (serialize/deserialize), `RecordingsTableUI.cs:1313, 2445` (X delete button + group display), `KerbalsModule.cs` (ghost-only chain handoff end-state fallback). **Note: there is no explicit `IsGhostOnly` gate on vessel-spawn-at-ghost-end anywhere in the code.** Gloops recordings don't spawn a real vessel at ghost-end because their commit path (`CommitGloopsRecording`) bypasses `NotifyLedgerTreeCommitted` entirely — so no `VesselSpawn` action is ever produced for a Gloops recording. This is an implicit consequence of the commit-path split, not an explicit per-spawn filter.
 
 ### Gloops is strictly single-recording today
 
@@ -58,7 +58,8 @@ So `#432`'s target surface is the single-recording case. The apply-side filter u
 - `LedgerOrchestrator.CreateVesselCostActions` (`LedgerOrchestrator.cs:397-463`). Called from `OnRecordingCommitted` `:156`. Not reached for Gloops (above). Guard here is defense-in-depth: if a future code path routes a Gloops recording through `OnRecordingCommitted`, the guard keeps the ledger clean. `rec.PreLaunchFunds` is 0 for Gloops (Gloops skips `CapturePreLaunchResources` at `FlightRecorder.cs:4207-4208`), so the `buildCost > 0` gate at `:421` already wouldn't fire even without a guard; the `rec.TerminalStateValue == Recovered` recovery branch at `:439` is the live risk for a cleanly-landed Gloops ship.
 - `LedgerOrchestrator.CreateKerbalAssignmentActions` (`LedgerOrchestrator.cs:471-510`). Called from two sites:
   - `:165` inside `OnRecordingCommitted` — not reached for Gloops.
-  - `:800` inside `MigrateKerbalAssignments` (`LedgerOrchestrator.cs:769-840`), which walks **every** recording in `RecordingStore.CommittedRecordings` unconditionally. The function extracts crew from `rec.VesselSnapshot` via `ExtractCrewFromRecording`, and Gloops recordings **do** have a `VesselSnapshot` (`ParsekFlight.cs:7550`). **This is the real leak**: a Gloops recording of a crewed vessel today produces `KerbalAssignment` rows on every ledger load, reserving those kerbals for the Gloops loop duration. The user's earlier bug-entry phrasing "leaks into the ledger" is this specific path.
+  - `:800` inside `MigrateKerbalAssignments` (`LedgerOrchestrator.cs:769-840`), which walks **every** recording in `RecordingStore.CommittedRecordings` unconditionally. The function extracts crew via `ExtractCrewFromRecording` (`LedgerOrchestrator.cs:537-583`), which reads `rec.GhostVisualSnapshot ?? rec.VesselSnapshot` (`:543`) — not just `VesselSnapshot`. Gloops recordings populate **both** (`ParsekFlight.cs:7546` sets `GhostVisualSnapshot`, `:7550` sets `VesselSnapshot`), so the crew extraction hits the `GhostVisualSnapshot` branch first. **This is the real leak**: a Gloops recording of a crewed vessel today produces `KerbalAssignment` rows on every ledger load, reserving those kerbals for the Gloops loop duration. The user's earlier bug-entry phrasing "leaks into the ledger" is this specific path.
+- `LedgerOrchestrator.PopulateUnpopulatedCrewEndStates` (`LedgerOrchestrator.cs:1040-1058`). Safety-net pass called from `RecalculateAndPatch` (`:651`) that walks every committed recording and mutates `rec.CrewEndStates` via `KerbalsModule.PopulateCrewEndStates(rec)` when needed. For a Gloops recording this does an in-memory mutation that serves no purpose (the CrewEndStates are never read for a recording that produces no actions), but it is **not** a ledger leak — no ledger row is produced. Intentionally **not guarded** by this PR: the mutation is harmless, the cost is trivial, and adding the guard would mean touching a third function that doesn't write to the ledger. Documented here so the next reader doesn't wonder why.
 - `LedgerOrchestrator.RecalculateAndPatch` (`LedgerOrchestrator.cs:612-672`). Builds `actions` from `Ledger.Actions` at `:653`, sorts, walks. Action-driven — doesn't re-probe `IsGhostOnly`. Suitable place for the belt-and-braces filter.
 - `RecalculationEngine.Recalculate` (`RecalculationEngine.cs:136-226`). Pure over a `List<GameAction>` — no change needed.
 
@@ -73,7 +74,7 @@ So `#432`'s target surface is the single-recording case. The apply-side filter u
 - Events fired during a Gloops window with an active normal recorder get tagged with the normal recording's id. They share the normal recording's commit/discard fate. Discarding the normal recording purges them; committing it keeps them.
 - Events fired during a Gloops window with no active normal recorder get empty tags. They flow into the between-mission career state via the save-time `FlushPendingEvents` path.
 - **No event ever receives a Gloops recording's id as a tag** (a Gloops recording's id doesn't exist until commit, and `GetActiveRecordingIdForTagging` resolves to the normal recorder's active tree, never to the Gloops recorder). Therefore:
-  > `GameStateStore.PurgeEventsForRecordings(idsToPurge)` called with a Gloops id in the set is a no-op by construction — the HashSet lookup at `GameStateStore.cs:282` never matches.
+  > `GameStateStore.PurgeEventsForRecordings(idsToPurge)` called with a Gloops id in the set is a no-op by construction — the HashSet lookup at `GameStateStore.cs:277` (`set.Contains(e.recordingId)`) never matches.
 
 Codified as a test case (test 5 below), not as runtime code.
 
@@ -85,6 +86,7 @@ Both functions already call `FindRecordingById` (`LedgerOrchestrator.cs:592`) to
 
 ```csharp
 // LedgerOrchestrator.cs:471 — CreateKerbalAssignmentActions.
+// Insert the ghost-only guard after the existing "if (rec == null) return result;" at :477.
 var rec = FindRecordingById(recordingId);
 if (rec == null) return result;
 
@@ -97,6 +99,8 @@ if (rec.IsGhostOnly)
 
 if (NeedsCrewEndStatePopulation(rec)) ...
 ```
+
+The guard sits above the existing `NeedsCrewEndStatePopulation` / `KerbalsModule.PopulateCrewEndStates` call on `:479-480`, which is a deliberate side-effect: a Gloops recording no longer triggers KSP roster lookups via that path. (The separate `PopulateUnpopulatedCrewEndStates` safety net at `:1040-1058` still hits it once per recalculation; see the current-state map above for why that's OK.)
 
 ```csharp
 // LedgerOrchestrator.cs:397 — CreateVesselCostActions.
@@ -185,13 +189,13 @@ New `Source/Parsek.Tests/GloopsEventSuppressionTests.cs`. `[Collection("Sequenti
 1. **`create_kerbal_assignment_actions_returns_empty_for_ghost_only`** — build a synthetic `Recording` with `IsGhostOnly = true` and a `VesselSnapshot` containing one crew entry. Add to `committedRecordings`. Call `LedgerOrchestrator.CreateKerbalAssignmentActions(recId, startUT, endUT)`. Assert the result is empty and the Verbose `"is ghost-only — skipping"` line fired.
 2. **`create_kerbal_assignment_actions_returns_rows_for_normal`** — same setup but `IsGhostOnly = false`. Assert the result contains one `KerbalAssignment` action.
 3. **`create_vessel_cost_actions_returns_empty_for_ghost_only`** — synthetic `Recording` with `IsGhostOnly = true`, `PreLaunchFunds = 5000`, first-point funds 4000, `TerminalStateValue = Recovered`, last-point funds 9000, penultimate-point funds 5000. Call `CreateVesselCostActions`. Without the guard the result would hold a `FundsSpending` (cost=1000) + `FundsEarning` (recovery=4000); with the guard, asserts empty and the Verbose `"is ghost-only — skipping"` line fired.
-4. **`filter_out_ghost_only_actions_drops_ghost_only_and_keeps_others`** — seed `committedRecordings` with two test recordings, one `IsGhostOnly = true` (id `"gloops-A"`), one `IsGhostOnly = false` (id `"normal-B"`). Build a `List<GameAction>` with three entries: one tagged `"gloops-A"`, one tagged `"normal-B"`, one with empty `RecordingId`. Call `FilterOutGhostOnlyActions`. Assert the returned list contains exactly the `"normal-B"` and the empty-tagged actions.
-5. **`purge_for_gloops_id_is_noop`** — regression guard that events never receive a Gloops recording id as a tag. Seed `GameStateStore.Events` with a tagged normal-recording event and an untagged event. Call `GameStateStore.PurgeEventsForRecordings(new[] { "never-existed-gloops-id" }, "test")`. Assert zero events removed.
+4. **`filter_out_ghost_only_actions_drops_ghost_only_and_keeps_others`** — seed `committedRecordings` with two test recordings, one `IsGhostOnly = true` (id `"gloops-A"`), one `IsGhostOnly = false` (id `"normal-B"`). Build a `List<GameAction>` with three entries: one tagged `"gloops-A"`, one tagged `"normal-B"`, one with empty `RecordingId`. Call `FilterOutGhostOnlyActions`. Assert the returned list contains exactly the `"normal-B"` and the empty-tagged actions. Empty-tag preservation is deliberate — audited against `InitialFunds` / `InitialScience` / `InitialReputation` seed actions and KSC-spending-forwarded actions at `LedgerOrchestrator.cs:625, 631, 637, 1350`, all of which legitimately use empty `RecordingId` and must survive the filter.
+5. **`active_recording_tag_never_returns_gloops_id`** — regression guard that locks the "Gloops never owns events" invariant in place. Configure a test scenario where a normal `activeTree` holds id `"normal-A"` and a Gloops recording has already been committed with id `"gloops-B"`. Assert `ParsekFlight.GetActiveRecordingIdForTagging()` returns `"normal-A"` or empty, never `"gloops-B"`. Pair with a second test that uses `GameStateRecorder.TagResolverForTesting` to force-resolve a Gloops-tagged event into the store (bypassing the live resolver), then assert `PurgeEventsForRecordings(new[] { "gloops-B" })` removes that forced event — verifying the purge mechanism works, while the default resolver never produces such events in the first place. The trivial "zero-events-removed" assertion is too weak; these two tests together pin down both halves of the invariant.
 6. **`recalculate_and_patch_filter_log_line_fires_when_ghost_only_action_present`** — seed one ghost-only recording in `committedRecordings`, seed `Ledger.Actions` with one action tagged with that id. Trigger `RecalculateAndPatch`. Assert the `"filtered 1 action(s)"` Info log line fired.
 7. **`recalculate_and_patch_no_filter_log_when_no_ghost_only_recordings`** — same but no ghost-only recording in `committedRecordings`. Assert the filter log line did NOT fire (nothing filtered).
 8. **`migrate_kerbal_assignments_replaces_stale_ghost_only_rows_with_empty`** — simulate a pre-fix save state by seeding `Ledger.Actions` with a `KerbalAssignment` row tagged with a ghost-only recording's id. Add that ghost-only recording to `committedRecordings`. Call `MigrateKerbalAssignments`. Assert the stale row was removed via `Ledger.ReplaceActionsForRecording`-style replacement, and the "repaired N recording(s)" info log fired.
 
-All tests use `ParsekLog.ResetTestOverrides()` + any necessary `LedgerOrchestrator.ResetForTesting` hooks in Dispose. Neither `GameStateRecorder.TagResolverForTesting` nor a new Gloops-side test hook is needed — no capture-side changes, no new accessor.
+All tests use `ParsekLog.ResetTestOverrides()` + any necessary `LedgerOrchestrator.ResetForTesting` hooks in Dispose. Test setup adds synthetic recordings via `RecordingStore.AddCommittedInternal` (`:425`) — the private `committedRecordings` list is not accessible directly. No new Gloops-side test hook is needed — no capture-side changes, no new accessor. `GameStateRecorder.TagResolverForTesting` is used only for the second half of test 5 to force-resolve a Gloops-tagged event.
 
 ### Step 7 — Post-build verification
 
@@ -228,7 +232,7 @@ All tests use `ParsekLog.ResetTestOverrides()` + any necessary `LedgerOrchestrat
 
 ## Risks
 
-- **`FilterOutGhostOnlyActions` overhead on every `RecalculateAndPatch`.** O(recordings + actions). Negligible next to the existing sort + walk. No index needed.
+- **`FilterOutGhostOnlyActions` overhead on every `RecalculateAndPatch`.** O(recordings + actions). Negligible next to the existing sort + walk. No index needed. The helper allocates a `HashSet<string>` every call even on loads with zero ghost-only recordings (early-return happens after the HashSet walk). If that allocation shows up in a future profile, cache the ghost-only id set on `RecordingStore.Committed` changes; for now, keep it simple.
 - **A future code path accidentally generating a Gloops-tagged action.** Caught by the walk filter (step 2) with an Info log identifying the count. Any non-zero count in a live save is a signal to find and fix the new path. The log line fires on every such call, so if it becomes noise, it indicates a real leak worth tracing.
 - **Multi-recording Gloops (#435) future interaction.** When #435 lands, every leaf in a Gloops tree will have `IsGhostOnly = true`. The existing per-recording `FindRecordingById(...).IsGhostOnly` and `FilterOutGhostOnlyActions` logic both read per-recording flags, so the tree case works automatically. No #432 re-work needed.
 

--- a/docs/dev/plans/fix-432-gloops-no-events.md
+++ b/docs/dev/plans/fix-432-gloops-no-events.md
@@ -60,7 +60,7 @@ So `#432`'s target surface is the single-recording case. The apply-side filter u
   - `:165` inside `OnRecordingCommitted` — not reached for Gloops.
   - `:800` inside `MigrateKerbalAssignments` (`LedgerOrchestrator.cs:769-840`), which walks **every** recording in `RecordingStore.CommittedRecordings` unconditionally. The function extracts crew via `ExtractCrewFromRecording` (`LedgerOrchestrator.cs:537-583`), which reads `rec.GhostVisualSnapshot ?? rec.VesselSnapshot` (`:543`) — not just `VesselSnapshot`. Gloops recordings populate **both** (`ParsekFlight.cs:7546` sets `GhostVisualSnapshot`, `:7550` sets `VesselSnapshot`), so the crew extraction hits the `GhostVisualSnapshot` branch first. **This is the real leak**: a Gloops recording of a crewed vessel today produces `KerbalAssignment` rows on every ledger load, reserving those kerbals for the Gloops loop duration. The user's earlier bug-entry phrasing "leaks into the ledger" is this specific path.
 - `LedgerOrchestrator.PopulateUnpopulatedCrewEndStates` (`LedgerOrchestrator.cs:1040-1058`). Safety-net pass called from `RecalculateAndPatch` (`:651`) that walks every committed recording and mutates `rec.CrewEndStates` via `KerbalsModule.PopulateCrewEndStates(rec)` when needed. For a Gloops recording this does an in-memory mutation that serves no purpose (the CrewEndStates are never read for a recording that produces no actions), but it is **not** a ledger leak — no ledger row is produced. Intentionally **not guarded** by this PR: the mutation is harmless, the cost is trivial, and adding the guard would mean touching a third function that doesn't write to the ledger. Documented here so the next reader doesn't wonder why.
-- `LedgerOrchestrator.RecalculateAndPatch` (`LedgerOrchestrator.cs:612-672`). Builds `actions` from `Ledger.Actions` at `:653`, sorts, walks. Action-driven — doesn't re-probe `IsGhostOnly`. Suitable place for the belt-and-braces filter.
+- `LedgerOrchestrator.RecalculateAndPatch` (`LedgerOrchestrator.cs:612-672`). Builds `actions` from `Ledger.Actions` at `:653`, sorts, walks. Action-driven — doesn't re-probe `IsGhostOnly`. Suitable place for the belt-and-braces ledger purge (mutates `Ledger.Actions`, so raw-ledger consumers see a clean list too).
 - `RecalculationEngine.Recalculate` (`RecalculationEngine.cs:136-226`). Pure over a `List<GameAction>` — no change needed.
 
 ### Capture-side paths — unchanged
@@ -123,50 +123,78 @@ if (rec.Points.Count == 0) ...
 
 These two early-returns close the real leak at `MigrateKerbalAssignments:800`. A Gloops-crewed recording on next ledger load returns an empty `desired` from `CreateKerbalAssignmentActions`; `KerbalAssignmentActionsMatch(existing, empty)` returns false when there are stale rows (from pre-fix builds); `Ledger.ReplaceActionsForRecording(KerbalAssignment, rec.RecordingId, empty)` cleans them out. One-shot self-heal with no extra code.
 
-### Step 2 — Belt-and-braces walk filter in `RecalculateAndPatch`
+### Step 2 — Belt-and-braces purge in `RecalculateAndPatch` (mutates `Ledger.Actions`)
 
-Drop any action whose `RecordingId` maps to an `IsGhostOnly` recording before handing the list to `RecalculationEngine.Recalculate`. This catches future regressions where some new path deposits a Gloops-tagged action into the ledger, and makes the invariant "no Gloops action reaches the walk" explicit instead of implied.
+Remove any action whose `RecordingId` maps to an `IsGhostOnly` recording **from `Ledger.Actions` itself**, not just from a walk-time copy. Raw-ledger consumers — the Timeline window (`TimelineBuilder.cs:21` reads `ledgerActions`), the career-state windows, ledger serialization — all read `Ledger.Actions` directly. Filtering only the walk copy would leave those consumers with a dirty view. The purge runs at the top of `RecalculateAndPatch` (called on commit, rewind, warp exit, load), so the ledger stays clean across every normal lifecycle event.
 
 ```csharp
-// LedgerOrchestrator.cs:653 — inside RecalculateAndPatch, before Recalculate.
+// LedgerOrchestrator.cs — inside RecalculateAndPatch, before the actions copy.
+// #432: purge any ghost-only-tagged actions from the ledger before the walk.
+// Mutates Ledger.Actions directly so raw-ledger consumers never see stale rows.
+// Idempotent — no-op when no ghost-only recordings exist or no actions are
+// tagged with them.
+PurgeGhostOnlyActionsFromLedger();
+
 var actions = new List<GameAction>(Ledger.Actions);
-
-// #432: belt-and-braces filter — no action tagged with a ghost-only recording
-// reaches the walk. Step 1's action-creation guards should prevent any such
-// action from being produced today; this catches future regressions.
-int beforeFilter = actions.Count;
-actions = FilterOutGhostOnlyActions(actions);
-int filtered = beforeFilter - actions.Count;
-if (filtered > 0)
-    ParsekLog.Info(Tag,
-        $"RecalculateAndPatch: filtered {filtered} action(s) tagged with ghost-only recordings");
-
 RecalculationEngine.Recalculate(actions);
 ```
 
 ```csharp
-// LedgerOrchestrator.cs — new internal static helper, unit-testable.
-internal static List<GameAction> FilterOutGhostOnlyActions(List<GameAction> actions)
+// LedgerOrchestrator.cs — new internal static helper.
+internal static int PurgeGhostOnlyActionsFromLedger()
 {
-    if (actions == null || actions.Count == 0) return actions ?? new List<GameAction>();
+    var recs = RecordingStore.CommittedRecordings;
+    if (recs == null || recs.Count == 0) return 0;
 
     var ghostOnlyIds = new HashSet<string>(StringComparer.Ordinal);
-    var recs = RecordingStore.CommittedRecordings;
     for (int i = 0; i < recs.Count; i++)
-        if (recs[i].IsGhostOnly && !string.IsNullOrEmpty(recs[i].RecordingId))
-            ghostOnlyIds.Add(recs[i].RecordingId);
+    {
+        var r = recs[i];
+        if (r != null && r.IsGhostOnly && !string.IsNullOrEmpty(r.RecordingId))
+            ghostOnlyIds.Add(r.RecordingId);
+    }
 
-    if (ghostOnlyIds.Count == 0) return actions;
+    if (ghostOnlyIds.Count == 0) return 0;
 
-    var kept = new List<GameAction>(actions.Count);
-    for (int i = 0; i < actions.Count; i++)
-        if (string.IsNullOrEmpty(actions[i].RecordingId) || !ghostOnlyIds.Contains(actions[i].RecordingId))
-            kept.Add(actions[i]);
-    return kept;
+    int removedTotal = 0;
+    foreach (var id in ghostOnlyIds)
+        removedTotal += Ledger.RemoveActionsForRecording(id);
+
+    if (removedTotal > 0)
+        ParsekLog.Info(Tag,
+            $"PurgeGhostOnlyActionsFromLedger: removed {removedTotal} action(s) tagged with ghost-only recordings");
+
+    return removedTotal;
 }
 ```
 
-Performance: O(recordings + actions). `CommittedRecordings` is typically under 100 entries, `Ledger.Actions` under a few thousand. Negligible versus the existing sort + walk in `RecalculationEngine.Recalculate`.
+```csharp
+// Ledger.cs — new helper. Removes every action with the given RecordingId
+// regardless of Type. Null/empty recordingId is a no-op. Used by the
+// #432 purge + any future code that needs cross-type ledger cleanup.
+internal static int RemoveActionsForRecording(string recordingId)
+{
+    if (string.IsNullOrEmpty(recordingId)) return 0;
+
+    int removed = 0;
+    for (int i = actions.Count - 1; i >= 0; i--)
+    {
+        if (string.Equals(actions[i].RecordingId, recordingId, StringComparison.Ordinal))
+        {
+            actions.RemoveAt(i);
+            removed++;
+        }
+    }
+    if (removed > 0)
+        ParsekLog.Verbose("Ledger",
+            $"RemoveActionsForRecording: recordingId='{recordingId}', removed={removed}, total={actions.Count}");
+    return removed;
+}
+```
+
+`Ledger.ReplaceActionsForRecording(type, id, new)` already exists but keys on (type, id) — useful for `MigrateKerbalAssignments` which owns only `KerbalAssignment`. For the ghost-only purge we need cross-type removal, hence the new helper.
+
+Performance: O(recordings + actions) per call. `CommittedRecordings` is typically under 100 entries, `Ledger.Actions` under a few thousand. Reverse walk on `Ledger.Actions` makes each remove O(1). Negligible versus the existing sort + walk in `RecalculationEngine.Recalculate`.
 
 ### Step 3 — No capture-side changes
 
@@ -176,9 +204,9 @@ Confirmed by the 2026-04-17 clarification. `GameStateRecorder.Emit`, the `OnCont
 
 Originally proposed `GetActiveRecordingGhostOnlyFlag()` / `IsGloopsCaptureActive()`. With the capture-side dropped, the accessor has no caller — the apply-side code already has the `Recording` object in hand and reads `rec.IsGhostOnly` directly. Dropped as dead code.
 
-### Step 5 — No retroactive save cleanup
+### Step 5 — Retroactive save cleanup covered by the purge
 
-Parsek is in beta. Pre-fix saves with stale `KerbalAssignment` rows tagged with a ghost-only recording id are self-healed on next load via step 1 (`CreateKerbalAssignmentActions` returns empty, `MigrateKerbalAssignments` calls `Ledger.ReplaceActionsForRecording` with the empty list). No separate migration pass needed.
+Pre-fix saves with stale ledger rows tagged with a ghost-only recording id (any action type — `KerbalAssignment`, `FundsSpending`, `FundsEarning`, etc.) are cleaned by the step-2 purge on the first `RecalculateAndPatch` after load. `OnKspLoad` calls `RecalculateAndPatch` after running `MigrateKerbalAssignments`, so the sequence on load is: reconcile → migrate-kerbal-assignments (type-specific rewrite for `KerbalAssignment`) → recalculate (cross-type ghost-only purge, then walk). The purge is a superset of the migration's ghost-only handling; the migration still does its own work for non-ghost-only recordings where it matters most.
 
 Event-store side: events captured during pre-fix Gloops windows were already tagged correctly per #431 (with the normal recording's id, or empty for Gloops-solo) — Gloops never owned them in the first place. No cleanup needed.
 
@@ -189,17 +217,22 @@ New `Source/Parsek.Tests/GloopsEventSuppressionTests.cs`. `[Collection("Sequenti
 1. **`create_kerbal_assignment_actions_returns_empty_for_ghost_only`** — build a synthetic `Recording` with `IsGhostOnly = true` and a `VesselSnapshot` containing one crew entry. Add to `committedRecordings`. Call `LedgerOrchestrator.CreateKerbalAssignmentActions(recId, startUT, endUT)`. Assert the result is empty and the Verbose `"is ghost-only — skipping"` line fired.
 2. **`create_kerbal_assignment_actions_returns_rows_for_normal`** — same setup but `IsGhostOnly = false`. Assert the result contains one `KerbalAssignment` action.
 3. **`create_vessel_cost_actions_returns_empty_for_ghost_only`** — synthetic `Recording` with `IsGhostOnly = true`, `PreLaunchFunds = 5000`, first-point funds 4000, `TerminalStateValue = Recovered`, last-point funds 9000, penultimate-point funds 5000. Call `CreateVesselCostActions`. Without the guard the result would hold a `FundsSpending` (cost=1000) + `FundsEarning` (recovery=4000); with the guard, asserts empty and the Verbose `"is ghost-only — skipping"` line fired.
-4. **`filter_out_ghost_only_actions_drops_ghost_only_and_keeps_others`** — seed `committedRecordings` with two test recordings, one `IsGhostOnly = true` (id `"gloops-A"`), one `IsGhostOnly = false` (id `"normal-B"`). Build a `List<GameAction>` with three entries: one tagged `"gloops-A"`, one tagged `"normal-B"`, one with empty `RecordingId`. Call `FilterOutGhostOnlyActions`. Assert the returned list contains exactly the `"normal-B"` and the empty-tagged actions. Empty-tag preservation is deliberate — audited against `InitialFunds` / `InitialScience` / `InitialReputation` seed actions and KSC-spending-forwarded actions at `LedgerOrchestrator.cs:625, 631, 637, 1350`, all of which legitimately use empty `RecordingId` and must survive the filter.
-5. **`active_recording_tag_never_returns_gloops_id`** — regression guard that locks the "Gloops never owns events" invariant in place. Configure a test scenario where a normal `activeTree` holds id `"normal-A"` and a Gloops recording has already been committed with id `"gloops-B"`. Assert `ParsekFlight.GetActiveRecordingIdForTagging()` returns `"normal-A"` or empty, never `"gloops-B"`. Pair with a second test that uses `GameStateRecorder.TagResolverForTesting` to force-resolve a Gloops-tagged event into the store (bypassing the live resolver), then assert `PurgeEventsForRecordings(new[] { "gloops-B" })` removes that forced event — verifying the purge mechanism works, while the default resolver never produces such events in the first place. The trivial "zero-events-removed" assertion is too weak; these two tests together pin down both halves of the invariant.
-6. **`recalculate_and_patch_filter_log_line_fires_when_ghost_only_action_present`** — seed one ghost-only recording in `committedRecordings`, seed `Ledger.Actions` with one action tagged with that id. Trigger `RecalculateAndPatch`. Assert the `"filtered 1 action(s)"` Info log line fired.
-7. **`recalculate_and_patch_no_filter_log_when_no_ghost_only_recordings`** — same but no ghost-only recording in `committedRecordings`. Assert the filter log line did NOT fire (nothing filtered).
-8. **`migrate_kerbal_assignments_replaces_stale_ghost_only_rows_with_empty`** — simulate a pre-fix save state by seeding `Ledger.Actions` with a `KerbalAssignment` row tagged with a ghost-only recording's id. Add that ghost-only recording to `committedRecordings`. Call `MigrateKerbalAssignments`. Assert the stale row was removed via `Ledger.ReplaceActionsForRecording`-style replacement, and the "repaired N recording(s)" info log fired.
+4. **`PurgeGhostOnlyActionsFromLedger_DropsGhostOnlyRowsAndMutatesLedger`** — seed `committedRecordings` with one `IsGhostOnly = true` (id `"gloops-A"`) and one normal recording (id `"normal-B"`). Seed `Ledger.Actions` with three entries: one tagged `"gloops-A"`, one tagged `"normal-B"`, one with empty `RecordingId`. Call the helper directly. Assert `Ledger.Actions.Count == 2`, ghost-only row gone from `Ledger.Actions` itself (not just filtered out of a copy), normal and empty-tag rows retained. Empty-tag preservation is deliberate — audited against `InitialFunds` / `InitialScience` / `InitialReputation` seed actions and KSC-spending-forwarded actions at `LedgerOrchestrator.cs:625, 631, 637, 1350`, all of which legitimately use empty `RecordingId`.
+5. **`PurgeGhostOnlyActionsFromLedger_PreservesMigratedOldSaveActionsWithNullTag`** — covers `MigrateOldSaveEvents` output (null `RecordingId`). Asserts null-tag `FundsSpending` survives alongside empty-tag seeds; ghost-only row is removed. Documents the intentional tradeoff that old-save migrated rows can't be mapped back to a recording and must be preserved.
+6. **`PurgeGhostOnlyActionsFromLedger_NoGhostOnlyRecordings_Noop`** — ensures the helper is a clean no-op when no ghost-only recordings exist. `Ledger.Actions` unchanged, `removed == 0`.
+7. **`PurgeGhostOnlyActionsFromLedger_RemovesAllTypesForGhostOnlyRecording`** — seeds three actions of different types (`KerbalAssignment` + `FundsSpending` + `FundsEarning`) all tagged to a ghost-only recording. Asserts all three removed. Differentiates from `ReplaceActionsForRecording`'s per-type semantics — the purge is cross-type.
+8. **`RecalculateAndPatch_PurgesGhostOnlyActions_AndSecondCallIsNoop`** — seeds one ghost-only recording and one stale action tagged with its id. Triggers `RecalculateAndPatch`. Asserts the `"PurgeGhostOnlyActionsFromLedger: removed 1 action(s)"` Info log fired and the row is gone from `Ledger.Actions`. A second `RecalculateAndPatch` call does NOT fire the purge log — the ledger is already clean (contrast with the old walk-filter design where the log would fire every recalc).
+9. **`RecalculateAndPatch_NoPurgeLog_WhenNoGhostOnlyRecordings`** — same but no ghost-only recording. Asserts the purge log did NOT fire, normal action survives.
+10. **`PurgeEventsForRecordings_RemovesForcedGloopsTaggedEvent_LiveAndSnapshot`** — pins the `GameStateStore.PurgeEventsForRecordings` mechanism across live events + orphan contract snapshots. Forces a Gloops-tagged `ContractAccepted` via `GameStateRecorder.TagResolverForTesting`, adds a matching `ContractSnapshot`, asserts both are removed by the purge. The test exercises the purge path for a safety story — the default resolver never produces Gloops-tagged events in the first place (invariant held by architecture: `GetActiveRecordingIdForTagging` reads `activeTree.ActiveRecordingId`, which `CommitGloopsRecording` does not touch).
+11. **`OnKspLoad_RewritesStaleGhostOnlyKerbalRowsToEmpty`** — simulates a pre-fix save with a stale `KerbalAssignment` row on a Gloops recording. Calls `OnKspLoad`. Asserts the row is gone (either via `MigrateKerbalAssignments` → `ReplaceActionsForRecording` OR via the subsequent `RecalculateAndPatch` → `PurgeGhostOnlyActionsFromLedger`; both run in sequence, test only pins the final state).
 
-All tests use `ParsekLog.ResetTestOverrides()` + any necessary `LedgerOrchestrator.ResetForTesting` hooks in Dispose. Test setup adds synthetic recordings via `RecordingStore.AddCommittedInternal` (`:425`) — the private `committedRecordings` list is not accessible directly. No new Gloops-side test hook is needed — no capture-side changes, no new accessor. `GameStateRecorder.TagResolverForTesting` is used only for the second half of test 5 to force-resolve a Gloops-tagged event.
+Tautological resolver test dropped — `ParsekFlight.GetActiveRecordingIdForTagging` reads `Instance?.activeTree?.ActiveRecordingId` and `Instance` is null in xUnit (no MonoBehaviour setup), so any assertion on its return value is trivially satisfied. The "Gloops never owns events" invariant is architectural (no code path assigns a Gloops id to `activeTree.ActiveRecordingId`, verified by code audit, documented in plan) rather than unit-testable without a full ParsekFlight/activeTree harness.
+
+All tests use `ParsekLog.ResetTestOverrides()` + `LedgerOrchestrator.ResetForTesting` hooks in Dispose. Test setup adds synthetic recordings via `RecordingStore.AddRecordingWithTreeForTesting` (`:2170`). No new Gloops-side test hook is needed. `GameStateRecorder.TagResolverForTesting` is used only in test 10 to force-resolve a Gloops-tagged event into the store.
 
 ### Step 7 — Post-build verification
 
-`dotnet build` + `dotnet test` from the worktree. Deploy and grep the deployed DLL for the new `"FilterOutGhostOnlyActions"` or `"is ghost-only — skipping"` UTF-16 string to confirm the correct build is live. Manual playtest recipe:
+`dotnet build` + `dotnet test` from the worktree. Deploy and grep the deployed DLL for the new `"PurgeGhostOnlyActionsFromLedger"` or `"is ghost-only — skipping"` UTF-16 string to confirm the correct build is live. Manual playtest recipe:
 
 1. Start a career save, launch a crewed plane.
 2. Open Gloops window, Start Recording.
@@ -219,7 +252,7 @@ All tests use `ParsekLog.ResetTestOverrides()` + any necessary `LedgerOrchestrat
 
 **In scope:**
 - `CreateKerbalAssignmentActions` and `CreateVesselCostActions` early-return on `rec.IsGhostOnly`.
-- `LedgerOrchestrator.FilterOutGhostOnlyActions` + `RecalculateAndPatch` pre-pass filter.
+- `LedgerOrchestrator.PurgeGhostOnlyActionsFromLedger` + `Ledger.RemoveActionsForRecording` helper, called from `RecalculateAndPatch` to mutate `Ledger.Actions` in place.
 - New `Source/Parsek.Tests/GloopsEventSuppressionTests.cs`.
 - Doc updates per step 8.
 
@@ -232,9 +265,9 @@ All tests use `ParsekLog.ResetTestOverrides()` + any necessary `LedgerOrchestrat
 
 ## Risks
 
-- **`FilterOutGhostOnlyActions` overhead on every `RecalculateAndPatch`.** O(recordings + actions). Negligible next to the existing sort + walk. No index needed. The helper allocates a `HashSet<string>` every call even on loads with zero ghost-only recordings (early-return happens after the HashSet walk). If that allocation shows up in a future profile, cache the ghost-only id set on `RecordingStore.Committed` changes; for now, keep it simple.
-- **A future code path accidentally generating a Gloops-tagged action.** Caught by the walk filter (step 2) with an Info log identifying the count. Any non-zero count in a live save is a signal to find and fix the new path. The log line fires on every such call, so if it becomes noise, it indicates a real leak worth tracing.
-- **Multi-recording Gloops (#435) future interaction.** When #435 lands, every leaf in a Gloops tree will have `IsGhostOnly = true`. The existing per-recording `FindRecordingById(...).IsGhostOnly` and `FilterOutGhostOnlyActions` logic both read per-recording flags, so the tree case works automatically. No #432 re-work needed.
+- **`PurgeGhostOnlyActionsFromLedger` overhead on every `RecalculateAndPatch`.** O(recordings + actions). Negligible next to the existing sort + walk. Reverse walk on `Ledger.Actions` makes each remove O(1). The helper allocates a `HashSet<string>` every call, but early-returns before touching `Ledger.Actions` if the set is empty — so steady-state saves with no ghost-only recordings pay only the HashSet allocation (skip the mutation walk entirely). If the HashSet allocation ever shows up in a profile, cache the ghost-only id set on `RecordingStore.Committed` changes; for now, keep it simple.
+- **A future code path accidentally generating a Gloops-tagged action.** Caught by the purge (step 2) with an Info log identifying the count. Fires once per `RecalculateAndPatch` that finds any ghost-only rows to remove — so steady-state post-purge it's silent. A fresh non-zero count after a commit/rewind is a signal to find and fix the new path.
+- **Multi-recording Gloops (#435) future interaction.** When #435 lands, every leaf in a Gloops tree will have `IsGhostOnly = true`. The existing per-recording `FindRecordingById(...).IsGhostOnly` and `PurgeGhostOnlyActionsFromLedger` logic both read per-recording flags, so the tree case works automatically. No #432 re-work needed.
 
 ## Sequencing
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -9,12 +9,12 @@ Entries 272–303 (78 bugs, 6 TODOs — mostly resolved) archived in `done/todo-
 
 These four TODOs are the top of the work queue. They're load-bearing correctness fixes that enforce the "every career effect flows from the committed ledger, nothing survives the recording it was born in" invariant. Ship in this order; #431 should land first since #433 / #434 depend on its purge semantics.
 
-1. **#431** — Events captured during a recording share the recording's commit/discard fate (purge on discard, not epoch-filter).
-2. **#432** — Gloops ghost-only recordings must not capture or apply any game events.
+1. ~~**#431** — Events captured during a recording share the recording's commit/discard fate (purge on discard, not epoch-filter).~~
+2. ~~**#432** — Gloops ghost-only recordings must not capture or apply any game events.~~
 3. **#433** — `PlaybackEnabled` toggle should be visual-only (stop gating vessel spawn and crew reservations).
-4. **#434** — Revert to Launch should auto-discard, not open the merge dialog.
+4. ~~**#434** — Revert to Launch should auto-discard, not open the merge dialog.~~
 
-Once this cluster lands, the `MilestoneStore.CurrentEpoch` filter can be retired as legacy work-around (see #431's notes).
+Only #433 remains open. Once it ships, the `MilestoneStore.CurrentEpoch` filter can be retired as legacy work-around (see #431's notes).
 
 ---
 
@@ -216,7 +216,7 @@ This TODO's correctness depends on #431 (event-purge-on-discard) landing first (
 
 ---
 
-## 432. Gloops ghost-only recordings must not capture or apply any game events
+## ~~432. Gloops ghost-only recordings must not capture or apply any game events~~
 
 **Source:** world-model conversation follow-up to #431, refined 2026-04-17. Gloops recordings (the "Gloops - Ghosts Only" group) are manual captures made for pure visual / airshow replays — they're flagged `IsGhostOnly`, auto-loop by default, and never spawn a real vessel at ghost-end. Their intent is **visual-only**: a Gloops recording is the ghost-visual slice from T0 to T1, a decorative parallel ghost that has nothing to do with career events. Events that fire during a Gloops window belong to the parallel normal recording (if any) or to between-mission career state (if none) — they don't belong to Gloops at all.
 
@@ -249,7 +249,7 @@ Concretely: today `CommitGloopsRecording` (`RecordingStore.cs:394`) bypasses `No
 
 **Priority:** **HIGHEST** (part of the deterministic-timeline correctness cluster).
 
-**Status:** TODO. Size: S. Purely apply-side now; no capture-side guards. Independent of #434 (they share a naming convention only). Pairs loosely with #431 on the "events share intent" theme.
+**Status:** ~~DONE~~. Purely apply-side fix: `CreateKerbalAssignmentActions` and `CreateVesselCostActions` in `LedgerOrchestrator` early-return on `rec.IsGhostOnly` with a Verbose log; `LedgerOrchestrator.FilterOutGhostOnlyActions` runs as a pre-pass in `RecalculateAndPatch` (`LedgerOrchestrator.cs:666-676`) as belt-and-braces against stale ledger rows. Self-heal: pre-fix saves with `KerbalAssignment` rows tagged to a Gloops recording get rewritten to an empty set on next `OnKspLoad` → `MigrateKerbalAssignments` pass. No capture-side guards — Gloops never owns events per #431's tagging; events during a Gloops window flow to the parallel normal recording (if any) or to between-mission career state (if none). Tests in `Source/Parsek.Tests/GloopsEventSuppressionTests.cs` cover both action-creation paths, the filter helper, the resolver invariant, the purge mechanism with a forced Gloops-tagged event, the `RecalculateAndPatch` log signal, and the `OnKspLoad` self-heal.
 
 ---
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -81,7 +81,7 @@ are fixed in the same PR branch with additional commits:
 - Staging during a Gloops flight → debris gets its own ghost-only recording via the normal `BackgroundRecorder` split path, with `IsGhostOnly = true` inherited from the tree.
 - EVA during a Gloops flight → linked child ghost-only recording via the normal EVA split path.
 - Commit: the whole Gloops tree flushes as a nested group under `"Gloops - Ghosts Only"` — e.g. `"Gloops - Ghosts Only / Mk3 Airshow Flight"` with child debris / crew recordings under it. Every leaf is `IsGhostOnly`.
-- No vessel-spawn-at-end for any recording in a Gloops tree. `ParsekFlight`'s spawn decision already gates on `!rec.IsGhostOnly` (see `ParsekFlight.cs:9221`); the tree case reuses this.
+- No vessel-spawn-at-end for any recording in a Gloops tree. `GhostPlaybackLogic.ShouldSpawnAtRecordingEnd` already gates on `!rec.IsGhostOnly` (see `GhostPlaybackLogic.cs:3001`); the tree case reuses this.
 - Per-recording delete / regroup / rename in the Recordings Manager works the same as normal trees.
 - Apply-side: `#432`'s filter reads `rec.IsGhostOnly` per-recording, so every leaf in a Gloops tree is already excluded from the ledger with no extra work.
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -58,6 +58,60 @@ are fixed in the same PR branch with additional commits:
 
 # Known Bugs
 
+## 435. Multi-recording Gloops trees (main + debris + crew children, no vessel spawn)
+
+**Source:** world-model conversation on #432 (2026-04-17). The aspirational design for Gloops: when the player records a Gloops flight that stages or EVAs, the capture produces a **tree of ghost-only recordings** — main + debris children + crew children — all flagged `IsGhostOnly`, all grouped under a per-flight Gloops parent in the Recordings Manager, and none of them spawning a real vessel at ghost-end. Structurally the same as the normal Parsek recording tree (decouple → debris background recording, EVA → linked crew child), with the ghost-only flag applied uniformly and the vessel-spawn-at-end path skipped.
+
+**Guiding architectural principle:** per `docs/dev/gloops-recorder-design.md`, Gloops is on track to be extracted as a standalone mod on which Parsek will depend. Parsek's recorder and tree infrastructure will become the base that both Gloops and Parsek share — Gloops exposes the trajectory recorder + playback engine, Parsek layers the career-state / tree / DAG / world-presence envelope on top via the `IPlaybackTrajectory` boundary. Multi-recording Gloops must therefore **reuse Parsek's existing recorder, tree, and BackgroundRecorder infrastructure** rather than growing a parallel Gloops-flavored implementation. The ghost-only distinction is a per-recording flag on top of shared machinery, not a separate code path.
+
+**Current state (audited 2026-04-17):**
+
+- `gloopsRecorder` is a **parallel** `FlightRecorder` instance with no `ActiveTree` (`ParsekFlight.cs:7460`) — a temporary workaround that the extraction direction wants to retire.
+- `BackgroundRecorder` is never initialized in the Gloops path — only alongside `activeTree` for normal recordings. Staging during a Gloops flight does not produce a debris child.
+- `FlightRecorder.HandleVesselSwitchDuringRecording` auto-stops Gloops on any vessel switch (`FlightRecorder.cs:5143-5151`), so EVA does not produce a linked crew child either.
+- `RecordingStore.CommitGloopsRecording` accepts a single `Recording`, adds it to the flat `"Gloops - Ghosts Only"` group (`RecordingStore.cs:394-418`). No `CommitGloopsTree`, no nested group structure.
+- No conditional `IsGloopsMode` branch inside `RecordingTree`, no half-finished Gloops tree scaffolding.
+
+**Net: Gloops is strictly single-recording by design today**, implemented as a parallel workaround. Multi-recording Gloops is a separate, sizable feature that should also consolidate Gloops onto the shared Parsek recorder (retire the parallel `gloopsRecorder` path).
+
+**Desired behavior:**
+
+- Gloops uses Parsek's main `FlightRecorder` + `RecordingTree` + `BackgroundRecorder` path, with a tree-level `IsGhostOnly` flag propagated to every leaf at commit. No parallel `gloopsRecorder`.
+- Starting a Gloops recording creates a `RecordingTree` with the ghost-only flag; normal recording continues alongside on the same machinery if already active, or the tree operates solo if not. How the two modes interleave in the UI (explicit toggle, implicit based on UI state, etc.) is for the implementing PR to decide — possibly in coordination with a UI gate preventing concurrent career + Gloops capture.
+- Staging during a Gloops flight → debris gets its own ghost-only recording via the normal `BackgroundRecorder` split path, with `IsGhostOnly = true` inherited from the tree.
+- EVA during a Gloops flight → linked child ghost-only recording via the normal EVA split path.
+- Commit: the whole Gloops tree flushes as a nested group under `"Gloops - Ghosts Only"` — e.g. `"Gloops - Ghosts Only / Mk3 Airshow Flight"` with child debris / crew recordings under it. Every leaf is `IsGhostOnly`.
+- No vessel-spawn-at-end for any recording in a Gloops tree. `ParsekFlight`'s spawn decision already gates on `!rec.IsGhostOnly` (see `ParsekFlight.cs:9221`); the tree case reuses this.
+- Per-recording delete / regroup / rename in the Recordings Manager works the same as normal trees.
+- Apply-side: `#432`'s filter reads `rec.IsGhostOnly` per-recording, so every leaf in a Gloops tree is already excluded from the ledger with no extra work.
+
+**Files likely to touch (sketch, not exhaustive):**
+
+- `Source/Parsek/ParsekFlight.cs` — retire `gloopsRecorder` in favor of the main `recorder`/`activeTree` path; the "Start Gloops" action creates a tree flagged ghost-only. `CheckGloopsAutoStoppedByVesselSwitch` goes away or is folded into normal tree commit.
+- `Source/Parsek/FlightRecorder.cs` — remove `IsGloopsMode` branches once the parallel recorder is retired; the recorder becomes agnostic to career semantics (aligning with the extraction boundary in `gloops-recorder-design.md`).
+- `Source/Parsek/BackgroundRecorder.cs` — carry a tree-level ghost-only flag so debris children inherit it.
+- `Source/Parsek/RecordingStore.cs` — collapse `CommitGloopsRecording` into the normal tree commit path; the ghost-only distinction is per-tree (or per-leaf, if partial-Gloops trees ever become a thing, which they shouldn't).
+- `Source/Parsek/UI/GloopsRecorderUI.cs` — controls now drive the main recorder with a ghost-only flag rather than spinning up a parallel instance.
+- `Source/Parsek.Tests/` — tree-structural tests for multi-recording Gloops capture and commit.
+
+**Dependencies / sequencing:**
+
+- Ships after #432 (which closes the existing single-recording leak and establishes the per-recording `IsGhostOnly` apply-side filter that multi-recording Gloops will rely on).
+- Coordinates loosely with the Gloops extraction work (`docs/dev/gloops-recorder-design.md` Section 11 — the extraction sequence); ideally this consolidation happens before extraction so the extraction moves a single unified recorder, not two.
+- Not tied to the deterministic-timeline correctness cluster — this is a feature extension, not a correctness bug.
+
+**Out of scope:**
+
+- Making Gloops spawn real vessels at ghost-end (explicitly not wanted — Gloops is visual-only).
+- Turning the existing single-recording Gloops path into a tree retroactively for existing saves (beta, restart the save if you want the new behavior).
+- Actually extracting Gloops into its own mod. That's covered by `docs/dev/gloops-recorder-design.md`'s extraction plan. #435 is a preparatory consolidation step on the Parsek side.
+
+**Priority:** Medium. Feature extension + architectural cleanup. Worth scoping after #432 lands.
+
+**Status:** TODO. Size: L. New feature — not a follow-up to anything shipped today.
+
+---
+
 ## ~~434. Revert to Launch should auto-discard, not open the merge dialog~~
 
 **Source:** follow-up on #431 and the deterministic-timeline conversation. Today when the player hits KSP's "Revert to Launch", Parsek shows the merge/discard dialog same as a normal end-of-flight. This was kept deliberately as testing / debugging scaffolding — it's useful during development to be able to inspect a reverted recording before deciding — but it's wrong for ship: Revert is the player's explicit signal that "this mission never happened", and offering a "Merge to Timeline" button at that moment invites a footgun where a misclick or a "but I want the science" impulse commits a recording the player conceptually un-did. The committed recording then survives as a ghost and eventually spawns its vessel at ghost-end, producing exactly the paradox (reverted mission whose vessel materializes anyway) that the deterministic principle rules out.
@@ -72,7 +126,7 @@ are fixed in the same PR branch with additional commits:
 - The discard must purge events stamped with the reverted recording's id (see #431). If #431 hasn't shipped yet, the epoch-increment fallback at `ParsekScenario.cs:970` stays — but the long-term correct path is purge-on-discard, not filter-by-epoch.
 - A brief screen message confirms the outcome — e.g. `"Recording discarded (revert)"` — so the player isn't surprised that no dialog appeared.
 - Flight-scene revert: the in-progress recording is discarded even if it wasn't yet stashed as pending. The recorder flushes whatever it had, then routes through the same discard path.
-- Gloops recordings under revert: already auto-committed when stopped, but on revert they're treated like any other recording — discarded (and under #432 they have no events to purge anyway).
+- Gloops recordings under revert: already auto-committed when stopped, but on revert they're treated like any other recording — discarded. Events captured during the Gloops window were never tagged with a Gloops id (Gloops doesn't own events — see #432), so `PurgeEventsForRecordings` with a Gloops id is a no-op by construction.
 
 **Files likely to touch:**
 
@@ -164,36 +218,38 @@ This TODO's correctness depends on #431 (event-purge-on-discard) landing first (
 
 ## 432. Gloops ghost-only recordings must not capture or apply any game events
 
-**Source:** world-model conversation follow-up to #431. Gloops recordings (the "Gloops - Ghosts Only" group) are manual captures made for pure visual / airshow replays — they're flagged `IsGhostOnly`, auto-loop by default, and never spawn a real vessel at ghost-end. Their intent is decorative: the player records a cinematic flight and wants to see it loop in the background forever. They should have zero career-state footprint: no contracts, no science, no funds deltas, no milestones, no reputation, no tech research, no part purchases — nothing that a Gloops recording does in-flight should leak into the committed career ledger.
+**Source:** world-model conversation follow-up to #431, refined 2026-04-17. Gloops recordings (the "Gloops - Ghosts Only" group) are manual captures made for pure visual / airshow replays — they're flagged `IsGhostOnly`, auto-loop by default, and never spawn a real vessel at ghost-end. Their intent is **visual-only**: a Gloops recording is the ghost-visual slice from T0 to T1, a decorative parallel ghost that has nothing to do with career events. Events that fire during a Gloops window belong to the parallel normal recording (if any) or to between-mission career state (if none) — they don't belong to Gloops at all.
 
-Currently `GameStateRecorder` runs regardless of recording type, so events captured during a Gloops flight window end up in `GameStateStore.Events` exactly like they would during a normal recording. Their eventual fate depends on whatever downstream plumbing happens; even if the Gloops recording itself produces zero actions, the raw events still get bundled into milestones and applied to the career ledger. That's wrong by design — a Gloops recording should be invisible to the career.
+Concretely: today `CommitGloopsRecording` (`RecordingStore.cs:394`) bypasses `NotifyLedgerTreeCommitted`, so a Gloops recording already contributes zero event-derived actions to the ledger. But two ledger-action sources that walk `RecordingStore.CommittedRecordings` unconditionally **do** fire for Gloops recordings — `CreateKerbalAssignmentActions` (via `MigrateKerbalAssignments` at `LedgerOrchestrator.cs:800`, reserving kerbals from the Gloops vessel snapshot for the loop duration) and `CreateVesselCostActions` at recording commit. This leak is what #432 closes.
 
 **The invariant that should hold:**
 
-> While a recording is active AND flagged `IsGhostOnly`, `GameStateRecorder` must not capture any new `GameStateEvent`s into `GameStateStore.Events`. On the apply side (ledger walk, `KspStatePatcher`, etc.), any recording flagged `IsGhostOnly` must contribute zero actions to the ledger regardless of what got captured.
+> A Gloops ghost-only recording has zero career-state footprint. No ledger action is produced from a committed `IsGhostOnly` recording. Events captured during a Gloops window flow through their existing #431 pipeline unchanged — tagged with the parallel normal recording's id (if any), otherwise empty-tagged as between-mission state. Gloops never owns events.
+
+**Design decision (from the 2026-04-17 refinement):** the fix is **purely apply-side**, not capture-side. No `GameStateRecorder.Emit` guard, no science-subject guard, no contract-snapshot guard. #431's tagging already routes events to the correct owner; Gloops simply isn't one.
 
 **Desired behavior:**
 
-- `GameStateRecorder` consults the active recording's `IsGhostOnly` flag at event-capture time. When true, the `AddEvent` / `OnContract*` / `OnTechResearched` / `OnPartPurchased` / etc. handlers short-circuit with a Verbose log (`"Gloops recording active — event X suppressed"`) and do not push to the store.
-- Defense-in-depth on the apply side: any `GameAction` tagged with a `RecordingId` belonging to an `IsGhostOnly` recording is skipped by the ledger walk (`Effective = false` with reason `GhostOnly`, or filtered at recording-iterate time).
-- Verify the science pipeline specifically: `GameStateRecorder.PendingScienceSubjects` should not accept subjects captured during a Gloops recording. Stop at the entry gate, same as other events.
-- The flight itself still records trajectory + part events (engine fire, decouples, parachutes, etc.) — Gloops's whole point is the visual replay. Only the career-event side is suppressed.
+- Apply-side: `CreateKerbalAssignmentActions` and `CreateVesselCostActions` in `LedgerOrchestrator` early-return when `rec.IsGhostOnly == true`, with a Verbose log. Closes the real `MigrateKerbalAssignments` leak.
+- Belt-and-braces: `LedgerOrchestrator.RecalculateAndPatch` pre-pass filter drops any `GameAction` whose `RecordingId` maps to an `IsGhostOnly` recording, so a future code path that emits a Gloops-tagged action still cannot reach the ledger walk.
+- The flight itself still records trajectory + part events — Gloops's whole point is the visual replay.
+- No accessor on `ParsekFlight` needed. Apply-side code has the `Recording` object in hand and reads `rec.IsGhostOnly` directly.
 
 **Files likely to touch:**
 
-- `Source/Parsek/GameStateRecorder.cs` — every `GameEvents.*` handler that currently writes to `GameStateStore` / `PendingScienceSubjects` gains an early-return guard: `if (ParsekFlight.Instance?.ActiveRecording?.IsGhostOnly == true) { log + return; }`. Pick a helper method or a property accessor to avoid duplicating the guard 20 times.
-- `Source/Parsek/GameActions/LedgerOrchestrator.cs` or `RecalculationEngine` — skip recordings with `IsGhostOnly = true` during the walk. Probably already happens implicitly (they have zero actions today), but codify it explicitly so #431's event-tagging work doesn't accidentally route events through a Gloops recording.
-- `Source/Parsek.Tests/GloopsEventSuppressionTests.cs` (new) — record a synthetic Gloops recording that fires a contract-accept event mid-flight; assert the event never reaches `GameStateStore.Events` and the ledger walk produces no corresponding action.
+- `Source/Parsek/GameActions/LedgerOrchestrator.cs` — `CreateKerbalAssignmentActions` (`:471`) and `CreateVesselCostActions` (`:397`) early-return on `rec.IsGhostOnly`; add `FilterOutGhostOnlyActions` helper and call from `RecalculateAndPatch` (`:653`).
+- `Source/Parsek.Tests/GloopsEventSuppressionTests.cs` (new) — assert ghost-only recordings produce zero actions from both creation paths, walk filter drops any stale ghost-only-tagged actions.
 - `docs/user-guide.md` Gloops section — add a one-line note: "Gloops recordings have no effect on your career's contracts, science, funds, or milestones — they're purely visual."
 
 **Out of scope for v1 of this fix:**
 
-- Retroactive cleanup of existing saves that have leaked events from past Gloops recordings. Document the limitation; ship a forward-fix.
-- Allowing the player to opt into career capture for a Gloops recording. That would contradict the "decorative-only" design intent; if someone wants career effects they should use a normal recording.
+- Retroactive save-side cleanup — Parsek is in beta; pre-fix saves can be restarted if affected.
+- Allowing the player to opt into career capture for a Gloops recording. That would contradict the "visual-only" design intent; if someone wants career effects they should use a normal recording.
+- Multi-recording Gloops trees (main + debris + crew children in a nested Gloops group, matching normal Parsek's tree shape). **Today Gloops is strictly single-recording** (audited 2026-04-17: `gloopsRecorder` is one `FlightRecorder` with no `ActiveTree`, auto-stops on vessel switch, no `BackgroundRecorder` subscription, no debris fork, no EVA split). The apply-side filter reads `rec.IsGhostOnly` per-recording so when multi-recording Gloops lands (see #435) the filter handles trees automatically without re-touching #432.
 
 **Priority:** **HIGHEST** (part of the deterministic-timeline correctness cluster).
 
-**Status:** TODO. Size: S-M. Pairs naturally with #431 (both enforce "events must share the recording's intent"); ship together or back-to-back.
+**Status:** TODO. Size: S. Purely apply-side now; no capture-side guards. Independent of #434 (they share a naming convention only). Pairs loosely with #431 on the "events share intent" theme.
 
 ---
 
@@ -225,7 +281,7 @@ The symmetric-case is fine: Revert already advances the epoch, so those events g
 
 - Deletion of an **already-committed** recording from the Recordings Manager: events from it have already been bundled into milestones and applied to the ledger. The commit was the decision point; deletion is metadata cleanup, not time travel. Leave those events alone.
 - EVA-split chains: if the parent recording commits but a child recording is discarded (or vice versa), only the discarded one's events are purged. Tagging per-recording (not per-tree) resolves this — verify against the tree-merge path in the plan.
-- Gloops ghost-only recordings (`Gloops - Ghosts Only` group) are covered by #432: they never capture events, so #431's purge logic is a no-op for them.
+- Gloops ghost-only recordings (`Gloops - Ghosts Only` group) are covered by #432: they never own events (events during a Gloops window belong to the parallel normal recording or to between-mission state), so #431's purge logic called with a Gloops id is a no-op by construction.
 
 **Files likely to touch:**
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -237,8 +237,9 @@ Concretely: today `CommitGloopsRecording` (`RecordingStore.cs:394`) bypasses `No
 
 **Files likely to touch:**
 
-- `Source/Parsek/GameActions/LedgerOrchestrator.cs` — `CreateKerbalAssignmentActions` (`:471`) and `CreateVesselCostActions` (`:397`) early-return on `rec.IsGhostOnly`; add `FilterOutGhostOnlyActions` helper and call from `RecalculateAndPatch` (`:653`).
-- `Source/Parsek.Tests/GloopsEventSuppressionTests.cs` (new) — assert ghost-only recordings produce zero actions from both creation paths, walk filter drops any stale ghost-only-tagged actions.
+- `Source/Parsek/GameActions/LedgerOrchestrator.cs` — `CreateKerbalAssignmentActions` (`:471`) and `CreateVesselCostActions` (`:397`) early-return on `rec.IsGhostOnly`; add `PurgeGhostOnlyActionsFromLedger` helper (mutates `Ledger.Actions` in place — filtering only the walk copy would leave Timeline and other raw-ledger consumers dirty) and call from `RecalculateAndPatch` (`:653`).
+- `Source/Parsek/GameActions/Ledger.cs` — add `RemoveActionsForRecording(string)` removing every action tagged with the given recording id regardless of type.
+- `Source/Parsek.Tests/GloopsEventSuppressionTests.cs` (new) — assert ghost-only recordings produce zero actions from both creation paths, purge mutates `Ledger.Actions` and removes every type (not just `KerbalAssignment`).
 - `docs/user-guide.md` Gloops section — add a one-line note: "Gloops recordings have no effect on your career's contracts, science, funds, or milestones — they're purely visual."
 
 **Out of scope for v1 of this fix:**
@@ -249,7 +250,7 @@ Concretely: today `CommitGloopsRecording` (`RecordingStore.cs:394`) bypasses `No
 
 **Priority:** **HIGHEST** (part of the deterministic-timeline correctness cluster).
 
-**Status:** ~~DONE~~. Purely apply-side fix: `CreateKerbalAssignmentActions` and `CreateVesselCostActions` in `LedgerOrchestrator` early-return on `rec.IsGhostOnly` with a Verbose log; `LedgerOrchestrator.FilterOutGhostOnlyActions` runs as a pre-pass in `RecalculateAndPatch` (`LedgerOrchestrator.cs:666-676`) as belt-and-braces against stale ledger rows. Self-heal: pre-fix saves with `KerbalAssignment` rows tagged to a Gloops recording get rewritten to an empty set on next `OnKspLoad` → `MigrateKerbalAssignments` pass. No capture-side guards — Gloops never owns events per #431's tagging; events during a Gloops window flow to the parallel normal recording (if any) or to between-mission career state (if none). Tests in `Source/Parsek.Tests/GloopsEventSuppressionTests.cs` cover both action-creation paths, the filter helper, the resolver invariant, the purge mechanism with a forced Gloops-tagged event, the `RecalculateAndPatch` log signal, and the `OnKspLoad` self-heal.
+**Status:** ~~DONE~~. Purely apply-side fix: `CreateKerbalAssignmentActions` and `CreateVesselCostActions` in `LedgerOrchestrator` early-return on `rec.IsGhostOnly` with a Verbose log. `LedgerOrchestrator.PurgeGhostOnlyActionsFromLedger` runs at the top of `RecalculateAndPatch` and **mutates `Ledger.Actions` in place** — so raw-ledger consumers (Timeline window, career-state views) see a clean list too, not just the walk. Built on a new `Ledger.RemoveActionsForRecording(string)` that removes every action for a given recording id regardless of type — covers `FundsSpending` / `FundsEarning` / `KerbalAssignment` etc. Pre-fix saves self-heal on the first `RecalculateAndPatch` after load (called from `OnKspLoad`). No capture-side guards — Gloops never owns events per #431's tagging; events during a Gloops window flow to the parallel normal recording (if any) or to between-mission career state (if none). Tests in `Source/Parsek.Tests/GloopsEventSuppressionTests.cs` cover both action-creation guards, the purge mechanism across all types, empty-tag preservation (`InitialFunds` seeds and `MigrateOldSaveEvents` output), the purge-log idempotency (fires once, then ledger is clean and the second call is a no-op), the `PurgeEventsForRecordings` orphan-contract-snapshot path, and the `OnKspLoad` → `MigrateKerbalAssignments` self-heal.
 
 ---
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -45,6 +45,8 @@ The Gloops window (opened from the "Gloops Flight Recorder" button in the main P
 
 Gloops recording auto-stops if the active vessel changes. Ghost-only recordings get an **X** button in the Recordings Manager's Group column for quick deletion.
 
+Gloops recordings are purely visual. They never charge funds for the vessel you captured, never reserve the kerbals aboard for the loop duration, never complete contracts, and never credit science or milestones — those stay with your normal mission recording (if any) or your between-mission career state.
+
 ### Merge Dialog
 
 After reverting (or aborting a mission to the Space Center with a recording pending), a dialog appears with context-aware options:


### PR DESCRIPTION
## Summary

- Apply-side fix: `CreateKerbalAssignmentActions` and `CreateVesselCostActions` in `LedgerOrchestrator` early-return on `rec.IsGhostOnly`, closing the `MigrateKerbalAssignments` leak that reserved a crewed Gloops recording's kerbals for the loop duration.
- Belt-and-braces `FilterOutGhostOnlyActions` pre-pass in `RecalculateAndPatch` drops any action tagged to a ghost-only recording, with an Info log that fires only when something was actually filtered. Empty-RecordingId seed / KSC-forwarded actions are preserved.
- Self-heal: pre-fix saves with stale `KerbalAssignment` rows on a Gloops recording get rewritten to an empty set on next `OnKspLoad` via the existing `MigrateKerbalAssignments` → `ReplaceActionsForRecording` flow.

## Design decisions

No capture-side guards. Per #431's tagging, events during a Gloops window belong to the parallel normal recording (via `GetActiveRecordingIdForTagging`) or to between-mission career state (empty tag). Gloops never owns events. This is also consistent with the planned extraction of Gloops as a standalone mod (see `docs/dev/gloops-recorder-design.md`) — career-ledger concerns stay on the Parsek side of the future boundary.

Plan doc: `docs/dev/plans/fix-432-gloops-no-events.md`. Went through a clean-Opus plan review; P1 fixes applied before implementation (stale `:9221` citation removed, `ExtractCrewFromRecording` source clarified to `GhostVisualSnapshot ?? VesselSnapshot`, `PopulateUnpopulatedCrewEndStates` intentional-no-guard documented, `PurgeEventsForRecordings` line number corrected, test 5 strengthened, empty-tag preservation audit added).

## Test plan

- [x] `dotnet build` — clean (0 warnings, 0 errors).
- [x] `dotnet test` — full suite: 6767 passed, 0 failed, 1 skipped (pre-existing skip).
- [x] New `Source/Parsek.Tests/GloopsEventSuppressionTests.cs` — 10 tests covering both action-creation guards, filter helper (drops + preserves), resolver invariant (`GetActiveRecordingIdForTagging` never returns a Gloops id), purge mechanism (forced Gloops-tagged event), `RecalculateAndPatch` filter-log signal (fires / doesn't), `OnKspLoad` self-heal for stale rows.
- [ ] Playtest recipe: launch a crewed plane on a career save, Start Gloops, fly ~30s, Stop. Open Career State / Kerbals — the plane's kerbals are not listed as reserved for the Gloops recording's duration. `KSP.log` contains `"CreateKerbalAssignmentActions: recording '<id>' is ghost-only — skipping"`.
- [ ] Self-heal recipe: quickload an older save where a Gloops recording already has stale `KerbalAssignment` rows, confirm `MigrateKerbalAssignments` rewrites them on first load.

## Follow-ups

- #435 (new, aspirational) — multi-recording Gloops trees (main + debris + crew children, all `IsGhostOnly`, no vessel spawn). The per-recording `rec.IsGhostOnly` filter this PR adds handles the tree case automatically when #435 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)