### PR TITLE
docs: announce Rewind to Staging (targeting v0.9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Time travel paradoxes are avoided by enforcing causality: events are always proc
 - **Part events** - staging, decoupling, parachutes, engines, solar panels, antennas, lights, landing gear, cargo bays, fairings, RCS, and inventory deployables replay on the ghost; docking / undocking are recorded as chain boundaries
 - **Resource tracking** - game actions related to funds, science, and reputation deltas are recorded and applied at the correct time
 - **Rewind** - go back to any earlier point in your timeline; resources reset to baseline, ghost playback re-applies everything at the correct time
+- **Rewind to staging** - go back to any past staging, undock, or EVA event and fly the sibling vessel you did not originally fly - take a spent booster back down for a self-landing recovery, fly the other half of an undock, or return an abandoned EVA kerbal; the previously-committed flight plays as a ghost while the new attempt commits additively alongside it
 - **Multi-vessel recording** - undocking, EVA, and docking are tracked automatically; all vessels in a mission record as a single tree
 - **Career mode integration** - milestones track tech research, part purchases, facility upgrades, and contracts; resource budgeting prevents paradoxes when rewinding
 - **Recordings manager** - browse, sort, loop, and delete individual recordings
@@ -68,12 +69,6 @@ dotnet build
 ```
 
 Requires .NET SDK and KSP assemblies in `Kerbal Space Program/KSP_x64_Data/Managed/`.
-
-## In Design
-
-Active design work beyond the current shipped feature set:
-
-- **Rewind to Staging** - go back to a past staging, undock, or EVA event and fly the other half of the mission. Launch an AB stack, stage, take B to orbit and commit it - then rewind to the separation moment and fly A back down as a self-landing booster. Previously-merged siblings play as ghosts of their original flights; the new attempt commits additively without touching the original timeline. Works for any split that produces two or more controllable vessels (stage decouple, undock, EVA). Design doc: [`docs/parsek-rewind-staging-design.md`](docs/parsek-rewind-staging-design.md).
 
 ## Beyond Recording
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ dotnet build
 
 Requires .NET SDK and KSP assemblies in `Kerbal Space Program/KSP_x64_Data/Managed/`.
 
+## In Design
+
+Active design work beyond the current shipped feature set:
+
+- **Rewind to Staging** - go back to a past staging, undock, or EVA event and fly the other half of the mission. Launch an AB stack, stage, take B to orbit and commit it - then rewind to the separation moment and fly A back down as a self-landing booster. Previously-merged siblings play as ghosts of their original flights; the new attempt commits additively without touching the original timeline. Works for any split that produces two or more controllable vessels (stage decouple, undock, EVA). Design doc: [`docs/parsek-rewind-staging-design.md`](docs/parsek-rewind-staging-design.md).
+
 ## Beyond Recording
 
 Parsek's infrastructure - looped playback, vessel snapshots, game state tracking, resource budgeting - forms a natural foundation to build on. These are not planned features, just ideas that the architecture makes possible:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -249,7 +249,7 @@ follow-up is validation/tuning work against larger corpora rather than another p
 
 ---
 
-## Rewind to Staging (in design, post-v0.8.2)
+## Rewind to Staging (v0.9, in design)
 
 Go back to a past multi-controllable split event and fly the sibling vessel you did not originally fly. The motivating case is booster recovery: launch an AB stack, stage, take B to orbit and commit - then rewind to the separation moment and fly A back down as a self-landing booster. The same mechanism covers any split that produces two or more controllable entities: stage decouples, undocks, and EVA.
 
@@ -369,7 +369,7 @@ Phase 11.5: Recording Optimization & Observability (v0.8.x)
     │  Observability + ghost LOD + trajectory/snapshot shrink shipped;
     │  remaining follow-up is synthetic stress benchmarking/tuning
     │
-    ├──▶ Rewind to Staging (in design, post-v0.8.2)
+    ├──▶ Rewind to Staging (v0.9, in design)
     │      Rewind Points at multi-controllable splits, Unfinished Flights
     │      group, append-only supersede, narrow v1 scope. Independent of
     │      Phase 12 — both consume Phase 11 resource/inventory/crew manifests.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -249,7 +249,7 @@ follow-up is validation/tuning work against larger corpora rather than another p
 
 ---
 
-## Rewind to Staging (v0.9, in design)
+## Phase 12: Rewind to Staging (v0.9, in design)
 
 Go back to a past multi-controllable split event and fly the sibling vessel you did not originally fly. The motivating case is booster recovery: launch an AB stack, stage, take B to orbit and commit - then rewind to the separation moment and fly A back down as a self-landing booster. The same mechanism covers any split that produces two or more controllable entities: stage decouples, undocks, and EVA.
 
@@ -263,11 +263,11 @@ Go back to a past multi-controllable split event and fly the sibling vessel you 
 - **Effective-state model** - a single `Effective Recording Set` plus `Effective Ledger Set` abstraction gives every subsystem one rule for "what counts right now." A narrow session-suppressed subtree carve-out applies during an active re-fly only to physical-visibility subsystems (ghost walker, claim tracker, map/tracking-station/CommNet). Career state keeps reading through directly.
 - **Journaled staged merge** - irreversible file operations (deleting reap-eligible Rewind Point quicksaves) happen only after a durable save, so crashes mid-merge are recoverable on the next load.
 
-This slots between the shipped v0.8.x work and Phase 12. Phase 12 (logistics routes) does not depend on it, and it does not depend on Phase 12 - both use the resource/inventory/crew manifests shipped in Phase 11.
+This slots between the shipped v0.8.x work and Phase 13. Phase 13 (logistics routes) does not depend on it, and it does not depend on Phase 13 - both use the resource/inventory/crew manifests shipped in Phase 11.
 
 ---
 
-## Phase 12: Looped Transport Logistics
+## Phase 13: Looped Transport Logistics
 
 Automated supply routes realized through Parsek's existing loop mechanic. Fly a cargo run once, loop the recording, each iteration is a supply delivery.
 
@@ -282,15 +282,15 @@ Every supply ship is a replay of a real mission the player flew — more immersi
 
 ---
 
-## Phase 13: Cooperative Async Multiplayer
+## Phase 14: Cooperative Async Multiplayer
 
 Multiple players contribute recordings to a shared timeline. The Kerbal system feels populated with vessels flying and bases being built. All players share one game actions timeline — science, funds, reputation, contracts, and kerbals are pooled.
 
-### Gloops Extraction (Phase 13 Prerequisite)
+### Gloops Extraction (Phase 14 Prerequisite)
 
 Extract the ghost playback engine into a separate assembly (`Gloops.dll`) within the same repository. This provides build-time boundary enforcement and defines the `.gloop` file format needed for recording export/import. See `docs/dev/gloops-recorder-design.md` for the full design.
 
-**Extraction timing rationale:** The engine boundary already exists (IPlaybackTrajectory, IGhostPositioner, GhostPlaybackEngine with zero Recording references). Extracting earlier than Phase 13 adds overhead without user benefit — new features through Phase 12 still touch engine code, and doing that across assemblies adds friction. Phase 13 is the natural trigger because recording export/import requires a standalone file format (`.gloop`), which is exactly what the extraction produces.
+**Extraction timing rationale:** The engine boundary already exists (IPlaybackTrajectory, IGhostPositioner, GhostPlaybackEngine with zero Recording references). Extracting earlier than Phase 14 adds overhead without user benefit — new features through Phase 13 still touch engine code, and doing that across assemblies adds friction. Phase 14 is the natural trigger because recording export/import requires a standalone file format (`.gloop`), which is exactly what the extraction produces.
 
 **Extraction scope:**
 - Separate .csproj in the same repo (not a submodule yet)
@@ -298,7 +298,7 @@ Extract the ghost playback engine into a separate assembly (`Gloops.dll`) within
 - Pre-extraction refactors: split `GhostPlaybackLogic.cs` (engine vs. policy), extract recorder from `FlightRecorder.cs`, `ParsekLog` abstraction
 - Parsek becomes a consumer of the Gloops API
 
-**Standalone Gloops mod (post Phase 13, if demand exists):**
+**Standalone Gloops mod (post Phase 14, if demand exists):**
 - Split into separate repository / submodule
 - Content pack system for ambient world activity (KSC traffic, scenery)
 - Standalone UI (loop manager, pack toggles, settings)
@@ -320,7 +320,7 @@ Players never need to be online simultaneously. Fly missions, export recordings.
 
 ---
 
-## Phase 14: Competitive Play & Space Race
+## Phase 15: Competitive Play & Space Race
 
 Player boundaries that enable competitive multiplayer. Each player has their own game actions timeline (separate science, funds, reputation, contracts, kerbals). Only things with visible effect on the common game world are shared — vessel recordings play as ghosts in everyone's game, but each player's economy is independent.
 
@@ -369,28 +369,29 @@ Phase 11.5: Recording Optimization & Observability (v0.8.x)
     │  Observability + ghost LOD + trajectory/snapshot shrink shipped;
     │  remaining follow-up is synthetic stress benchmarking/tuning
     │
-    ├──▶ Rewind to Staging (v0.9, in design)
-    │      Rewind Points at multi-controllable splits, Unfinished Flights
-    │      group, append-only supersede, narrow v1 scope. Independent of
-    │      Phase 12 — both consume Phase 11 resource/inventory/crew manifests.
+    ▼
+Phase 12: Rewind to Staging (v0.9, in design)
+    │  Rewind Points at multi-controllable splits, Unfinished Flights
+    │  group, append-only supersede, narrow v1 scope. Independent of
+    │  Phase 13 — both consume Phase 11 resource/inventory/crew manifests.
     │
     ▼
-Phase 12: Looped Transport Logistics
+Phase 13: Looped Transport Logistics
     │  Routes = looped recordings with resource delivery
     │
     ▼
 Gloops Extraction ─── Extract ghost engine to separate assembly,
     │                   define .gloop file format
     ▼
-Phase 13: Cooperative Async Multiplayer
+Phase 14: Cooperative Async Multiplayer
     │  .gloop export/import, shared folder, player identity
     │
     ▼
-Phase 14: Competitive Play + Space Race
+Phase 15: Competitive Play + Space Race
     │  Per-player game actions, milestone racing, opponent packs
     │
     ▼
-Phase 15: Mod Compatibility
+Phase 16: Mod Compatibility
     │  Kerbal Konstructs, KSC Switcher, Extraplanetary Launchpads,
     │  off-world construction, modded launch sites via reflection
     │
@@ -401,7 +402,7 @@ Standalone Gloops Mod (if demand exists)
 
 ---
 
-## Phase 15: Mod Compatibility
+## Phase 16: Mod Compatibility
 
 All prior phases target stock KSP (including Making History DLC). This phase adds support for popular mods via reflection-based detection and API integration. Only attempted after the stock experience is stable and fun.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -249,6 +249,24 @@ follow-up is validation/tuning work against larger corpora rather than another p
 
 ---
 
+## Rewind to Staging (in design, post-v0.8.2)
+
+Go back to a past multi-controllable split event and fly the sibling vessel you did not originally fly. The motivating case is booster recovery: launch an AB stack, stage, take B to orbit and commit - then rewind to the separation moment and fly A back down as a self-landing booster. The same mechanism covers any split that produces two or more controllable entities: stage decouples, undocks, and EVA.
+
+**Design doc:** [`docs/parsek-rewind-staging-design.md`](parsek-rewind-staging-design.md).
+
+- **Rewind Points at split time** - every multi-controllable split writes a KSP quicksave into `saves/<save>/Parsek/RewindPoints/` plus a persistent-id-to-slot map captured at save time, so the post-load strip can reliably identify which vessels to replace with ghosts.
+- **Unfinished Flights group** - a virtual, computed group in the Recordings Manager lists every committed BG-crash sibling whose parent split has a Rewind Point. Membership updates automatically as flights are flown and merged.
+- **Append-only supersede** - invoking a Rewind Point and merging a new attempt adds a `RecordingSupersede(old, new)` relation record. The original recording is never mutated or deleted; ghost/claim subsystems filter via the relation list. Preserves the flight-recorder's monotonic additive tree invariant.
+- **Narrow v1 supersede scope** - the only ledger retirement on supersede is `KerbalDeath` (and reputation penalties bundled with it); kerbals return to active via the normal reservation walk. Contract completions, milestones, facility upgrades, strategies, tech, science, and other rep/funds deltas from the original attempt stay in career totals (these are KSP-sticky and can't be safely re-emitted).
+- **Crashed re-fly stays rewindable** - merging a crashed attempt commits it as `CommittedProvisional Crashed`; the supersede chain extends and the slot remains an Unfinished Flight the player can try again. Merging a stable outcome (Landed, Orbited, Recovered) seals the slot.
+- **Effective-state model** - a single `Effective Recording Set` plus `Effective Ledger Set` abstraction gives every subsystem one rule for "what counts right now." A narrow session-suppressed subtree carve-out applies during an active re-fly only to physical-visibility subsystems (ghost walker, claim tracker, map/tracking-station/CommNet). Career state keeps reading through directly.
+- **Journaled staged merge** - irreversible file operations (deleting reap-eligible Rewind Point quicksaves) happen only after a durable save, so crashes mid-merge are recoverable on the next load.
+
+This slots between the shipped v0.8.x work and Phase 12. Phase 12 (logistics routes) does not depend on it, and it does not depend on Phase 12 - both use the resource/inventory/crew manifests shipped in Phase 11.
+
+---
+
 ## Phase 12: Looped Transport Logistics
 
 Automated supply routes realized through Parsek's existing loop mechanic. Fly a cargo run once, loop the recording, each iteration is a supply delivery.
@@ -351,6 +369,11 @@ Phase 11.5: Recording Optimization & Observability (v0.8.x)
     │  Observability + ghost LOD + trajectory/snapshot shrink shipped;
     │  remaining follow-up is synthetic stress benchmarking/tuning
     │
+    ├──▶ Rewind to Staging (in design, post-v0.8.2)
+    │      Rewind Points at multi-controllable splits, Unfinished Flights
+    │      group, append-only supersede, narrow v1 scope. Independent of
+    │      Phase 12 — both consume Phase 11 resource/inventory/crew manifests.
+    │
     ▼
 Phase 12: Looped Transport Logistics
     │  Routes = looped recordings with resource delivery
@@ -418,5 +441,5 @@ Ghost escape orbits clip at finite distance (~12,000 km). Active vessels show fu
 - **Racing modes or lap timing**
 - **AI playback or autopilot**
 - **Real-time multiplayer synchronization** — Parsek's multiplayer model is async (Phases 13–14). No shared physics simulation, no lockstep networking.
-- **Taking control of recorded vessels** — jumping into a ghost mid-playback creates unresolvable paradoxes (recording future events, reserved crew, applied resource deltas). The complexity is not worth the payoff.
+- **Taking control of recorded vessels mid-playback** — jumping into a live ghost while it is playing out creates unresolvable paradoxes (recording future events, reserved crew, applied resource deltas). The complexity is not worth the payoff. **Note:** the narrower "Rewind to Staging" feature (see above) does allow re-flying a sibling vessel from a past split event — that works because it rewinds UT to the split moment and replaces the sibling's BG-crash via append-only supersede, rather than hijacking an in-flight ghost.
 - **Timeline branching or alternate histories**


### PR DESCRIPTION
## Summary

- Adds an **In Design** section to the README highlighting the Rewind to Staging / Unfinished Flights feature with a link to the in-progress design doc on `design/rewind-staging`.
- Adds a new **Rewind to Staging (v0.9, in design)** section to the roadmap between the v0.8.x optimization work and Phase 12, with seven bullets covering the key design pieces (Rewind Points at split time, Unfinished Flights group, append-only supersede, narrow v1 scope, crashed-re-fly still rewindable, effective-state model, journaled merge).
- Updates the dependency-chain diagram to show the new feature branching off v0.8.x, independent of Phase 12.
- Refines the **Out of Scope** entry for "Taking control of recorded vessels": the general case (hijacking an in-flight ghost) stays out of scope; the narrow rewind-to-split-point case is now planned, with a note on why it avoids the paradoxes.

## What this is / isn't

- **Is:** announcement-only docs change. Merges to `main` immediately; no code impact.
- **Isn't:** the design doc itself or any implementation. The full design doc lives on the `design/rewind-staging` branch (currently at v0.5 after four rounds of clean-context review) and will come to `main` along with implementation in its own PR(s) when feature work begins.

## Target release

Parsek **v0.9** (the next minor after the v0.8.x line). Does not block or require any in-flight 0.8.x work; independent of Phase 12.

## Test plan

- [x] Render README.md and roadmap.md in a markdown viewer; confirm formatting.
- [x] Verify the link `docs/parsek-rewind-staging-design.md` will resolve once the design branch merges; dead link until then is expected for a "look ahead" doc.
- [x] `git diff origin/main...HEAD` shows only README.md and docs/roadmap.md changes.