### PR TITLE
docs: rename 'Rewind' to 'Rewind to launch' and tweak staging wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Time travel paradoxes are avoided by enforcing causality: events are always proc
 - **Orbital recording** - time warp segments use analytical Keplerian orbits with attitude preservation (SAS-locked orientations like retrograde, normal, radial hold correctly throughout the orbit)
 - **Part events** - staging, decoupling, parachutes, engines, solar panels, antennas, lights, landing gear, cargo bays, fairings, RCS, and inventory deployables replay on the ghost; docking / undocking are recorded as chain boundaries
 - **Resource tracking** - game actions related to funds, science, and reputation deltas are recorded and applied at the correct time
-- **Rewind** - go back to any earlier point in your timeline; resources reset to baseline, ghost playback re-applies everything at the correct time
-- **Rewind to staging** - go back to any past staging, undock, or EVA event and fly the sibling vessel you did not originally fly - take a spent booster back down for a self-landing recovery, fly the other half of an undock, or return an abandoned EVA kerbal; the previously-committed flight plays as a ghost while the new attempt commits additively alongside it
+- **Rewind to launch** - go back to any earlier point in your timeline; resources reset to baseline, ghost playback re-applies everything at the correct time
+- **Rewind to staging** - go back to any past staging, undock, or EVA event and fly the sibling vessel you did not originally fly - take a spent booster back down for a self-landing recovery, fly the other half of an undock, or save a poor EVA kerbal that had to jump out; the previously-committed flight plays as a ghost while the new attempt commits additively alongside it
 - **Multi-vessel recording** - undocking, EVA, and docking are tracked automatically; all vessels in a mission record as a single tree
 - **Career mode integration** - milestones track tech research, part purchases, facility upgrades, and contracts; resource budgeting prevents paradoxes when rewinding
 - **Recordings manager** - browse, sort, loop, and delete individual recordings


### PR DESCRIPTION
## Summary

Tiny README copy tweak that stacks on top of #341:

- Rename the **Rewind** feature bullet to **Rewind to launch** so it reads as an obvious parallel to **Rewind to staging** and makes the scope distinction clear at a glance.
- Soften the EVA example in the **Rewind to staging** bullet from "return an abandoned EVA kerbal" to "save a poor EVA kerbal that had to jump out" - reads more like an actual gameplay scenario.

## Stacking note

This PR is branched from \`docs/announce-rewind-staging\` (PR #341), so until #341 merges this PR's diff against \`main\` will show both sets of changes. The only commit that is uniquely this PR is \`ad295044\` - a 2-line README edit. Merge order:

1. Merge #341 first.
2. This PR's diff against \`main\` will then shrink to just the two lines; merge it second.

Or, squash-merge #341 and rebase this PR onto the new main - same effect.

## Test plan

- [x] The unique commit \`ad295044\` diff shows only two lines changed in README.md.
- [x] Render README.md in a markdown viewer; confirm the two rewind bullets read as a matched pair.