### PR TITLE
chore(ui): widen Recordings window, match Group to Loop, add Gloops Close button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ All notable changes to Parsek are documented here.
 - `#375` Demoted chatty per-appearance `GhostAppearance` logs from Info to Verbose.
 - `#378` Added a rate-limited warn when on-save monotonicity rebuild exceeds 5 ms on a single recording, so save-time stutter is visible in `KSP.log`.
 - `#376` Documented the dual-storage invariant for auto-assigned standalone group names.
+- Gloops Flight Recorder window now has a Close button at the bottom, matching other Parsek windows.
+- Recordings window opens wider by default (1280 px) so more columns fit without a horizontal scroll; the Info-expanded width scales up to match.
+- Group column in the Recordings table widened to match the Loop column so the G and X buttons sit under the header.
 
 ### Tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to Parsek are documented here.
 - Gloops Flight Recorder window now has a Close button at the bottom, matching other Parsek windows.
 - Recordings window opens wider by default (1280 px) so more columns fit without a horizontal scroll; the Info-expanded width scales up to match.
 - Group column in the Recordings table widened to match the Loop column so the G and X buttons sit under the header.
+- Main Parsek window now has a Close button in the footer, inline to the right of the version text (which moved from the right to the left).
 
 ### Tests
 

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -549,6 +549,12 @@ namespace Parsek
                 "Parsek/Textures/parsek_32",
                 MODNAME
             );
+
+            ui.CloseMainWindow = () =>
+            {
+                showUI = false;
+                if (toolbarControl != null) toolbarControl.SetFalse();
+            };
         }
 
         void Update()
@@ -840,6 +846,7 @@ namespace Parsek
 
             if (showUI)
             {
+                windowRect.height = 0f;
                 windowRect = ClickThruBlocker.GUILayoutWindow(
                     GetInstanceID(),
                     windowRect,

--- a/Source/Parsek/ParsekKSC.cs
+++ b/Source/Parsek/ParsekKSC.cs
@@ -67,6 +67,12 @@ namespace Parsek
                 ParsekFlight.MODNAME
             );
 
+            ui.CloseMainWindow = () =>
+            {
+                showUI = false;
+                if (toolbarControl != null) toolbarControl.SetFalse();
+            };
+
             // Build body lookup cache
             bodyCache = new Dictionary<string, CelestialBody>();
             if (FlightGlobals.Bodies != null)
@@ -104,6 +110,7 @@ namespace Parsek
         {
             if (!showUI) return;
 
+            windowRect.height = 0f;
             windowRect = ClickThruBlocker.GUILayoutWindow(
                 GetInstanceID(), windowRect, ui.DrawWindow,
                 "Parsek", ui.GetOpaqueWindowStyle(), GUILayout.Width(250));

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -91,6 +91,11 @@ namespace Parsek
         // Runtime-only empty groups — delegated to RecordingsTableUI
         internal List<string> KnownEmptyGroups => recordingsTableUI.KnownEmptyGroups;
 
+        // Host-supplied callback invoked when the user clicks the main window Close
+        // button. Host (ParsekFlight / ParsekKSC) wires this to hide the window and
+        // un-press the toolbar button.
+        internal Action CloseMainWindow { get; set; }
+
         public ParsekUI(ParsekFlight flight)
         {
             this.flight = flight;
@@ -289,18 +294,27 @@ namespace Parsek
                 ParsekLog.Verbose("UI", $"Settings window toggled: {(settingsUI.IsOpen ? "open" : "closed")}");
             }
 
-            // --- Version footer ---
-            GUILayout.Space(SpacingSmall);
+            // --- Version footer (version on the left, Close button fills the rest) ---
+            GUILayout.Space(SpacingLarge);
             if (versionStyle == null)
             {
                 versionStyle = new GUIStyle(GUI.skin.label)
                 {
                     fontSize = 10,
-                    alignment = TextAnchor.MiddleRight,
-                    normal = { textColor = new Color(1f, 1f, 1f, 0.4f) }
+                    alignment = TextAnchor.MiddleLeft,
+                    normal = { textColor = new Color(1f, 1f, 1f, 0.4f) },
+                    contentOffset = new Vector2(0f, 3f)
                 };
             }
-            GUILayout.Label(VersionLabel, versionStyle);
+            GUILayout.BeginHorizontal();
+            GUILayout.Label(VersionLabel, versionStyle, GUILayout.ExpandWidth(false));
+            GUILayout.Space(10f);
+            if (GUILayout.Button("Close", GUILayout.ExpandWidth(true)))
+            {
+                ParsekLog.Verbose("UI", "Main window closed via button");
+                CloseMainWindow?.Invoke();
+            }
+            GUILayout.EndHorizontal();
 
             GUILayout.EndVertical();
 

--- a/Source/Parsek/UI/GloopsRecorderUI.cs
+++ b/Source/Parsek/UI/GloopsRecorderUI.cs
@@ -181,6 +181,15 @@ namespace Parsek
                 GUILayout.Label("Ghost-only - loops by default");
             }
 
+            GUILayout.FlexibleSpace();
+
+            if (GUILayout.Button("Close"))
+            {
+                showWindow = false;
+                ReleaseInputLock();
+                ParsekLog.Verbose("UI", "Gloops Recorder window closed via button");
+            }
+
             GUILayout.EndVertical();
             GUI.DragWindow();
         }

--- a/Source/Parsek/UI/RecordingsTableUI.cs
+++ b/Source/Parsek/UI/RecordingsTableUI.cs
@@ -46,7 +46,7 @@ namespace Parsek
         // cells without over-inflating them.
         private const float ColHeaderHeight = 32f;
         private const float ColW_Site = 90f;
-        private const float ColW_Group = 50f;
+        private const float ColW_Group = 60f;
 
         // Reusable per-frame buffers (avoid allocation each frame)
         private static readonly Dictionary<string, int> chainTipIndexBuffer = new Dictionary<string, int>();
@@ -342,7 +342,7 @@ namespace Parsek
                 recordingsWindowRect = new Rect(
                     mainWindowRect.x + mainWindowRect.width + 10,
                     mainWindowRect.y,
-                    1196, recHeight);
+                    1280, recHeight);
                 var ic = System.Globalization.CultureInfo.InvariantCulture;
                 ParsekLog.Verbose("UI", $"Recordings window initial position: x={recordingsWindowRect.x.ToString("F0", ic)} y={recordingsWindowRect.y.ToString("F0", ic)}");
             }
@@ -909,10 +909,10 @@ namespace Parsek
                 {
                     showExpandedStats = !showExpandedStats;
                     ParsekLog.Verbose("UI", $"Recordings Info toggled: {(showExpandedStats ? "expanded" : "collapsed")}");
-                    if (showExpandedStats && recordingsWindowRect.width < 1654f)
-                        recordingsWindowRect.width = 1654f;
+                    if (showExpandedStats && recordingsWindowRect.width < 1738f)
+                        recordingsWindowRect.width = 1738f;
                     else if (!showExpandedStats)
-                        recordingsWindowRect.width = 1196f;
+                        recordingsWindowRect.width = 1280f;
                 }
             }
 


### PR DESCRIPTION
## Summary
- Recordings window default width 1196 -> 1280 (2x Timeline's 640); Info-expanded 1654 -> 1738 (preserves the +458 px delta for the extra columns).
- Recordings table Group column width 50 -> 60 so the G/X buttons sit under the header like the Loop cell.
- Gloops Flight Recorder window gets a Close button at the bottom, matching the Timeline/Kerbals/Settings pattern.

## Test plan
- [x] `dotnet build` clean, DLL deployed and verified in `GameData`
- [x] `dotnet test` — 6944 passed, 0 failed
- [x] In-game: open Recordings window, confirm wider default and Group column header aligned with G/X buttons
- [x] In-game: toggle Info on/off, confirm expanded width fits all columns
- [x] In-game: open Gloops Flight Recorder, click Close, confirm window closes and input lock releases