### PR TITLE
chore(settings): default auto-loop interval is now 30 s (was 10 s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- Default "Auto-launch every" setting is now 30 s (was 10 s). Existing saves keep the value the user had; only fresh installs and the Settings reset path pick up the new default.
 - `#441` Legacy flights whose net science or reputation was negative now reconcile cleanly on load instead of being skipped — the load-time migration injects a spending-side synthetic and the ledger purges it with the tree on discard. Long missions that overlap unrelated KSC activity (contract accept, part purchase) no longer silently drop their persisted residuals, and optimizer merges that absorb a tree's root recording retag any ledger synthetics to the new root so they survive subsequent reconcile passes.
 - Every non-revert tree-commit path (post-revert merge dialog, scene-exit auto-merge, Esc > Abort Mission auto-commit, and the OnSave safety-net auto-commit) now disarms the legacy lump-sum replay path on the just-committed tree, matching the in-flight Commit Flight behavior so the next FLIGHT scene cannot re-credit those resources on top of the ledger.
 - Pre-existing committed flights now reconcile their funds/science/reputation against the ledger on load, so saves that persisted a tree's lump-sum delta no longer cause a silent drawdown after revert/rewind cycles.

--- a/Source/Parsek.Tests/KscGhostPlaybackTests.cs
+++ b/Source/Parsek.Tests/KscGhostPlaybackTests.cs
@@ -413,7 +413,7 @@ namespace Parsek.Tests
         [Fact]
         public void GetLoopIntervalSeconds_NullRecording_ReturnsDefault()
         {
-            Assert.Equal(10.0, ParsekKSC.GetLoopIntervalSeconds(null));
+            Assert.Equal(GhostPlaybackLogic.DefaultLoopIntervalSeconds, ParsekKSC.GetLoopIntervalSeconds(null));
         }
 
         [Fact]
@@ -421,7 +421,7 @@ namespace Parsek.Tests
         {
             var rec = MakeKerbinRecording();
             rec.LoopIntervalSeconds = double.NaN;
-            Assert.Equal(10.0, ParsekKSC.GetLoopIntervalSeconds(rec));
+            Assert.Equal(GhostPlaybackLogic.DefaultLoopIntervalSeconds, ParsekKSC.GetLoopIntervalSeconds(rec));
         }
 
         [Fact]
@@ -429,7 +429,7 @@ namespace Parsek.Tests
         {
             var rec = MakeKerbinRecording();
             rec.LoopIntervalSeconds = double.PositiveInfinity;
-            Assert.Equal(10.0, ParsekKSC.GetLoopIntervalSeconds(rec));
+            Assert.Equal(GhostPlaybackLogic.DefaultLoopIntervalSeconds, ParsekKSC.GetLoopIntervalSeconds(rec));
         }
 
         [Fact]

--- a/Source/Parsek.Tests/LegacyTreeMigrationTests.cs
+++ b/Source/Parsek.Tests/LegacyTreeMigrationTests.cs
@@ -533,7 +533,7 @@ namespace Parsek.Tests
                 LoopPlayback = false,
                 PlaybackEnabled = true,
                 Hidden = false,
-                LoopIntervalSeconds = 10.0
+                LoopIntervalSeconds = GhostPlaybackLogic.DefaultLoopIntervalSeconds
             };
             target.Points.Add(new TrajectoryPoint { ut = 100.0, altitude = 50000 });
             target.Points.Add(new TrajectoryPoint { ut = 150.0, altitude = 50000 });
@@ -551,7 +551,7 @@ namespace Parsek.Tests
                 LoopPlayback = false,
                 PlaybackEnabled = true,
                 Hidden = false,
-                LoopIntervalSeconds = 10.0
+                LoopIntervalSeconds = GhostPlaybackLogic.DefaultLoopIntervalSeconds
             };
             absorbed.Points.Add(new TrajectoryPoint { ut = 150.0, altitude = 50000 });
             absorbed.Points.Add(new TrajectoryPoint { ut = 200.0, altitude = 50000 });

--- a/Source/Parsek.Tests/LegacyTreeMigrationTests.cs
+++ b/Source/Parsek.Tests/LegacyTreeMigrationTests.cs
@@ -533,7 +533,7 @@ namespace Parsek.Tests
                 LoopPlayback = false,
                 PlaybackEnabled = true,
                 Hidden = false,
-                LoopIntervalSeconds = GhostPlaybackLogic.DefaultLoopIntervalSeconds
+                LoopIntervalSeconds = GhostPlaybackLogic.UntouchedLoopIntervalSentinel
             };
             target.Points.Add(new TrajectoryPoint { ut = 100.0, altitude = 50000 });
             target.Points.Add(new TrajectoryPoint { ut = 150.0, altitude = 50000 });
@@ -551,7 +551,7 @@ namespace Parsek.Tests
                 LoopPlayback = false,
                 PlaybackEnabled = true,
                 Hidden = false,
-                LoopIntervalSeconds = GhostPlaybackLogic.DefaultLoopIntervalSeconds
+                LoopIntervalSeconds = GhostPlaybackLogic.UntouchedLoopIntervalSentinel
             };
             absorbed.Points.Add(new TrajectoryPoint { ut = 150.0, altitude = 50000 });
             absorbed.Points.Add(new TrajectoryPoint { ut = 200.0, altitude = 50000 });

--- a/Source/Parsek.Tests/RecordingBuilderLoopIntervalTests.cs
+++ b/Source/Parsek.Tests/RecordingBuilderLoopIntervalTests.cs
@@ -59,7 +59,7 @@ namespace Parsek.Tests
             var b = new RecordingBuilder("Empty")
                 .WithLoopPlayback(loop: true, intervalSeconds: 0.0);
 
-            // No points → builder can't derive duration → DefaultLoopIntervalSeconds (10 s).
+            // No points → builder can't derive duration → DefaultLoopIntervalSeconds (30 s).
             Assert.Equal(GhostPlaybackLogic.DefaultLoopIntervalSeconds, b.GetLoopIntervalSeconds());
             Assert.Equal(GhostPlaybackLogic.DefaultLoopIntervalSeconds, ParseInterval(b.Build()));
         }

--- a/Source/Parsek.Tests/RecordingOptimizerTests.cs
+++ b/Source/Parsek.Tests/RecordingOptimizerTests.cs
@@ -33,7 +33,7 @@ namespace Parsek.Tests
                 LoopPlayback = false,
                 PlaybackEnabled = true,
                 Hidden = false,
-                LoopIntervalSeconds = GhostPlaybackLogic.DefaultLoopIntervalSeconds,
+                LoopIntervalSeconds = GhostPlaybackLogic.UntouchedLoopIntervalSentinel,
                 LoopAnchorVesselId = 0,
             };
             rec.Points.Add(new TrajectoryPoint { ut = startUT, altitude = 50000 });
@@ -210,8 +210,33 @@ namespace Parsek.Tests
         {
             var a = MakeChainSegment("chain1", 0);
             var b = MakeChainSegment("chain1", 1);
-            b.LoopIntervalSeconds = GhostPlaybackLogic.DefaultLoopIntervalSeconds + 15.0;
+            b.LoopIntervalSeconds = GhostPlaybackLogic.UntouchedLoopIntervalSentinel + 15.0;
             Assert.False(RecordingOptimizer.CanAutoMerge(a, b));
+        }
+
+        [Fact]
+        public void CanAutoMerge_UntouchedRecordingFieldInit_StaysInLockstepWithSentinel()
+        {
+            // Regression guard for a prior bug: DefaultLoopIntervalSeconds was bumped
+            // 10 -> 30 and RecordingOptimizer.CanAutoMerge used it as the "untouched"
+            // sentinel, but Recording.LoopIntervalSeconds field init stayed at 10. Fresh
+            // captures and legacy saves then failed the guard (10 != 30) and stopped
+            // auto-merging. This test pins the invariant: the field init and the sentinel
+            // MUST be equal.
+            var fresh = new Recording();
+            Assert.Equal(GhostPlaybackLogic.UntouchedLoopIntervalSentinel, fresh.LoopIntervalSeconds);
+        }
+
+        [Fact]
+        public void CanAutoMerge_TwoUntouchedRecordings_ReturnsTrue()
+        {
+            // Same regression: two recordings at the untouched sentinel must be mergeable
+            // regardless of the user-facing DefaultLoopIntervalSeconds value.
+            var a = MakeChainSegment("chain1", 0);
+            var b = MakeChainSegment("chain1", 1);
+            Assert.Equal(GhostPlaybackLogic.UntouchedLoopIntervalSentinel, a.LoopIntervalSeconds);
+            Assert.Equal(GhostPlaybackLogic.UntouchedLoopIntervalSentinel, b.LoopIntervalSeconds);
+            Assert.True(RecordingOptimizer.CanAutoMerge(a, b));
         }
 
         [Fact]

--- a/Source/Parsek.Tests/RecordingOptimizerTests.cs
+++ b/Source/Parsek.Tests/RecordingOptimizerTests.cs
@@ -33,7 +33,7 @@ namespace Parsek.Tests
                 LoopPlayback = false,
                 PlaybackEnabled = true,
                 Hidden = false,
-                LoopIntervalSeconds = 10.0,
+                LoopIntervalSeconds = GhostPlaybackLogic.DefaultLoopIntervalSeconds,
                 LoopAnchorVesselId = 0,
             };
             rec.Points.Add(new TrajectoryPoint { ut = startUT, altitude = 50000 });
@@ -210,7 +210,7 @@ namespace Parsek.Tests
         {
             var a = MakeChainSegment("chain1", 0);
             var b = MakeChainSegment("chain1", 1);
-            b.LoopIntervalSeconds = 30.0;
+            b.LoopIntervalSeconds = GhostPlaybackLogic.DefaultLoopIntervalSeconds + 15.0;
             Assert.False(RecordingOptimizer.CanAutoMerge(a, b));
         }
 

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -16,7 +16,7 @@ namespace Parsek
         // Ghost threshold: 50x is the last level where ghost meshes update often enough to be useful.
         internal const float FxSuppressWarpThreshold = 10f;
         internal const float GhostHideWarpThreshold = 50f;
-        internal const double DefaultLoopIntervalSeconds = 10.0;
+        internal const double DefaultLoopIntervalSeconds = 30.0;
         internal const double MinLoopDurationSeconds = 1.0;
         internal const double MinCycleDuration = 1.0;
         // #410: shared boundary tolerance for loop-phase comparisons. Used by

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -16,7 +16,21 @@ namespace Parsek
         // Ghost threshold: 50x is the last level where ghost meshes update often enough to be useful.
         internal const float FxSuppressWarpThreshold = 10f;
         internal const float GhostHideWarpThreshold = 50f;
+        // User-facing default for fresh ParsekSettings.autoLoopIntervalSeconds and the
+        // Settings "reset" path. Also used as an engine fallback when a trajectory's loop
+        // interval is NaN/infinite/unset. NOT an "untouched" sentinel for the optimizer.
         internal const double DefaultLoopIntervalSeconds = 30.0;
+
+        // Sentinel value used by RecordingOptimizer.CanAutoMerge to detect an
+        // "uncustomized" loop interval on a Recording, and by Recording.LoopIntervalSeconds
+        // as its field initializer. The two MUST stay equal — a fresh Recording whose loop
+        // settings the user never touched must compare equal to this constant, otherwise
+        // the optimizer treats it as user-customized and refuses to auto-merge. This
+        // value is deliberately decoupled from DefaultLoopIntervalSeconds so changing the
+        // user-facing default doesn't silently break auto-merge for legacy saves or fresh
+        // untouched captures.
+        internal const double UntouchedLoopIntervalSentinel = 10.0;
+
         internal const double MinLoopDurationSeconds = 1.0;
         internal const double MinCycleDuration = 1.0;
         // #410: shared boundary tolerance for loop-phase comparisons. Used by

--- a/Source/Parsek/ParsekSettings.cs
+++ b/Source/Parsek/ParsekSettings.cs
@@ -133,7 +133,7 @@ namespace Parsek
         /// LoopTimeUnit.Auto. Must be &gt;= GhostPlaybackLogic.MinCycleDuration. Overlap
         /// emerges when the period is shorter than the recording's duration.
         /// </summary>
-        public float autoLoopIntervalSeconds = 10.0f;
+        public float autoLoopIntervalSeconds = (float)GhostPlaybackLogic.DefaultLoopIntervalSeconds;
         public int autoLoopTimeUnit = 0; // 0=Sec, 1=Min, 2=Hour
 
         [GameParameters.CustomFloatParameterUI("Ghost audio volume", minValue = 0f, maxValue = 1f,

--- a/Source/Parsek/Recording.cs
+++ b/Source/Parsek/Recording.cs
@@ -50,7 +50,7 @@ namespace Parsek
         /// When less than the recording duration, successive launches overlap (multi-ghost
         /// overlap path). When greater, there is a pause window between cycles.
         /// </summary>
-        public double LoopIntervalSeconds = 10.0;
+        public double LoopIntervalSeconds = GhostPlaybackLogic.UntouchedLoopIntervalSentinel;
         public LoopTimeUnit LoopTimeUnit = LoopTimeUnit.Sec;
         public double LoopStartUT = double.NaN;  // NaN = use StartUT (loop entire recording)
         public double LoopEndUT = double.NaN;    // NaN = use EndUT (loop entire recording)

--- a/Source/Parsek/RecordingOptimizer.cs
+++ b/Source/Parsek/RecordingOptimizer.cs
@@ -54,8 +54,12 @@ namespace Parsek
             if (!double.IsNaN(b.LoopStartUT) || !double.IsNaN(b.LoopEndUT)) return false;
             if (!a.PlaybackEnabled || !b.PlaybackEnabled) return false;
             if (a.Hidden || b.Hidden) return false;
-            if (a.LoopIntervalSeconds != GhostPlaybackLogic.DefaultLoopIntervalSeconds
-                || b.LoopIntervalSeconds != GhostPlaybackLogic.DefaultLoopIntervalSeconds) return false;
+            // Sentinel == Recording.LoopIntervalSeconds field initializer. Any value
+            // other than the sentinel signals the user explicitly configured this recording's
+            // loop interval — in that case auto-merge is blocked. Deliberately NOT comparing
+            // against DefaultLoopIntervalSeconds, which is the UI default and may differ.
+            if (a.LoopIntervalSeconds != GhostPlaybackLogic.UntouchedLoopIntervalSentinel
+                || b.LoopIntervalSeconds != GhostPlaybackLogic.UntouchedLoopIntervalSentinel) return false;
             if (a.LoopAnchorVesselId != 0 || b.LoopAnchorVesselId != 0) return false;
 
             // Different recording groups = user organized them differently

--- a/Source/Parsek/UI/RecordingsTableUI.cs
+++ b/Source/Parsek/UI/RecordingsTableUI.cs
@@ -3486,7 +3486,8 @@ namespace Parsek
                 {
                     var settings = ParsekSettings.Current;
                     double gv = settings != null
-                        ? ParsekUI.ConvertFromSeconds(settings.autoLoopIntervalSeconds, settings.AutoLoopDisplayUnit) : 10;
+                        ? ParsekUI.ConvertFromSeconds(settings.autoLoopIntervalSeconds, settings.AutoLoopDisplayUnit)
+                        : GhostPlaybackLogic.DefaultLoopIntervalSeconds;
                     var gu = settings != null ? settings.AutoLoopDisplayUnit : LoopTimeUnit.Sec;
                     disabledText = ParsekUI.FormatLoopValue(gv, gu) + UnitSuffix(gu);
                 }
@@ -3507,7 +3508,7 @@ namespace Parsek
                 var settings = ParsekSettings.Current;
                 double globalVal = settings != null
                     ? ParsekUI.ConvertFromSeconds(settings.autoLoopIntervalSeconds, settings.AutoLoopDisplayUnit)
-                    : 10;
+                    : GhostPlaybackLogic.DefaultLoopIntervalSeconds;
                 GUI.enabled = false;
                 var globalDisplayUnit = settings != null ? settings.AutoLoopDisplayUnit : LoopTimeUnit.Sec;
                 GUILayout.TextField(ParsekUI.FormatLoopValue(globalVal, globalDisplayUnit) + UnitSuffix(globalDisplayUnit), bodyCellTextFieldFlush, GUILayout.Width(valueBtnW));

--- a/Source/Parsek/UI/SettingsWindowUI.cs
+++ b/Source/Parsek/UI/SettingsWindowUI.cs
@@ -197,7 +197,7 @@ namespace Parsek
                 s.verboseLogging = true;
                 s.writeReadableSidecarMirrors = true;
                 s.SamplingDensityLevel = SamplingDensity.Medium;
-                s.autoLoopIntervalSeconds = 10.0f;
+                s.autoLoopIntervalSeconds = (float)GhostPlaybackLogic.DefaultLoopIntervalSeconds;
                 s.autoLoopTimeUnit = 0;
                 s.ghostCameraCutoffKm = DistanceThresholds.GhostFlight.DefaultWatchCameraCutoffKm;
                 s.showGhostsInTrackingStation = true;


### PR DESCRIPTION
## Summary
- Bump `GhostPlaybackLogic.DefaultLoopIntervalSeconds` 10.0 -> 30.0. Every other default/fallback site now sources this constant (was a mix of literals at 10 / 30 scattered through `ParsekSettings`, `SettingsWindowUI` reset, and two `RecordingsTableUI` null-settings fallbacks).
- Five test files updated to stop pinning the literal 10.0 and pull from the shared constant instead (or to pick a different 'custom, not-default' sentinel where the previous one was 30.0).

## Test plan
- [x] Full xUnit suite: 6944 passed / 0 failed / 1 skipped
- [x] Deployed DLL verified
- [ ] In-game: Settings "Reset to defaults" picks 30 s; fresh save defaults to 30 s; existing saves keep user-configured value

## User-visible change
CHANGELOG entry under 0.8.2 Bug Fixes: "Default 'Auto-launch every' setting is now 30 s (was 10 s). Existing saves keep the value the user had; only fresh installs and the Settings reset path pick up the new default."