### PR TITLE
fix(merger): #449 classify boundary discontinuities (diagnostic-only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to Parsek are documented here.
 - Replaced the four sampling sliders with a single **Recorder Sample Density** setting (Low / Medium / High). Legacy slider-based saves migrate to the nearest preset on load.
 - `#375` Demoted chatty per-appearance `GhostAppearance` logs from Info to Verbose.
 - `#378` Added a rate-limited warn when on-save monotonicity rebuild exceeds 5 ms on a single recording, so save-time stutter is visible in `KSP.log`.
+- `#449` Merger boundary-discontinuity warnings now include the inter-section time gap, the velocity-implied expected gap, and a `cause=` tag (`unrecorded-gap` / `sample-skip` / `frame-mismatch`) so quickload-resume gaps are immediately distinguishable from real recorder bugs in `KSP.log`.
 - `#376` Documented the dual-storage invariant for auto-assigned standalone group names.
 - Gloops Flight Recorder window now has a Close button at the bottom, matching other Parsek windows.
 - Recordings window opens wider by default (1280 px) so more columns fit without a horizontal scroll; the Info-expanded width scales up to match.

--- a/Source/Parsek.Tests/SessionMergerTests.cs
+++ b/Source/Parsek.Tests/SessionMergerTests.cs
@@ -1034,31 +1034,88 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void MergeTree_DiscontinuityWarning_IncludesClassification()
+        public void ClassifyBoundaryDiscontinuity_NaNVelocity_DefaultsToSampleSkip()
         {
-            // Two adjacent Active sections with a velocity-explained gap — the WARN
-            // should now carry dt=, expectedFromVel=, and cause= fields so future
-            // occurrences are immediately classifiable from the log alone.
-            var prev = MakeSectionWithFrame(0, 0, 0, 70000, new Vector3(100, 0, 0));
-            var next = MakeSectionWithFrame(1.0, 0, 0, 70110, Vector3.zero,
-                source: TrackSectionSource.Active);
-            // Force them not to overlap so ResolveOverlaps doesn't merge/trim them.
-            // MakeSectionWithFrame leaves startUT==endUT; widen the second so it
-            // is sorted strictly after the first.
-            var prevTail = prev; prevTail.endUT = 0.5;
-            var nextHead = next; nextHead.startUT = 1.0; nextHead.endUT = 2.0;
+            // NaN-component velocity: vMag becomes NaN, so expectedMeters is NaN and
+            // tolerance is NaN. Both branch comparisons against NaN are false, so the
+            // classifier falls through to "sample-skip". This pins the silent-default
+            // so a future "fix" that drops NaN-velocity boundaries can't slip past
+            // review without updating this test.
+            var prev = MakeSectionWithFrame(100, 0, 0, 70000,
+                new Vector3(float.NaN, 0, 0));
+            var next = MakeSectionWithFrame(101, 0, 0, 70050, Vector3.zero);
+            SessionMerger.ClassifyBoundaryDiscontinuity(
+                prev, next, hasPrev: true, discMeters: 50f,
+                out double dt, out double expected, out string cause);
+            Assert.InRange(dt, 0.99, 1.01);
+            Assert.True(double.IsNaN(expected),
+                $"Expected NaN expectedMeters with NaN velocity, got {expected}");
+            Assert.Equal("sample-skip", cause);
+        }
+
+        [Fact]
+        public void ClassifyBoundaryDiscontinuity_InfinityVelocity_DefaultsToSampleSkip()
+        {
+            // Infinity-component velocity: same NaN-comparison pattern as the NaN
+            // case above. expectedMeters is Infinity, tolerance is Infinity, the
+            // discMeters <= Infinity branch is true → unrecorded-gap. Pin this so a
+            // future infinity-guard refactor doesn't silently flip the bucket.
+            var prev = MakeSectionWithFrame(100, 0, 0, 70000,
+                new Vector3(float.PositiveInfinity, 0, 0));
+            var next = MakeSectionWithFrame(101, 0, 0, 70050, Vector3.zero);
+            SessionMerger.ClassifyBoundaryDiscontinuity(
+                prev, next, hasPrev: true, discMeters: 50f,
+                out double dt, out double expected, out string cause);
+            Assert.InRange(dt, 0.99, 1.01);
+            Assert.True(double.IsPositiveInfinity(expected),
+                $"Expected +Infinity expectedMeters with +Infinity velocity, got {expected}");
+            Assert.Equal("unrecorded-gap", cause);
+        }
+
+        // Parameterised so a regression that hard-codes a single cause (e.g. always
+        // emits "cause=no-prev") fails for the other rows instead of slipping past
+        // a substring-only assertion.
+        [Theory]
+        [InlineData("unrecorded-gap", 100f, 1.0, 110f)]
+        [InlineData("sample-skip",     10f, 0.5, 500f)]
+        [InlineData("frame-mismatch", 130f, 0.0,  50f)]
+        public void MergeTree_DiscontinuityWarning_IncludesClassification(
+            string expectedCause, float prevVelX, double dtSeconds, float altGapMeters)
+        {
+            // Two adjacent Active sections — the WARN should carry dt=,
+            // expectedFromVel=, and the exact cause= value matching the scenario.
+            // Boundary UT is where prev ends and next starts; prev's last frame is
+            // at boundaryUT, next's first frame is at boundaryUT + dtSeconds, so the
+            // computed dt between frames equals dtSeconds.
+            const double boundaryUT = 1.0;
+            var prev = MakeSectionWithFrame(boundaryUT, 0, 0, 70000,
+                new Vector3(prevVelX, 0, 0));
+            var next = MakeSectionWithFrame(boundaryUT + dtSeconds, 0, 0,
+                70000 + altGapMeters, Vector3.zero, source: TrackSectionSource.Active);
+            // MakeSectionWithFrame leaves startUT==endUT (zero duration). Widen each
+            // so ResolveOverlaps doesn't drop them as zero-duration sections. The
+            // sections must be non-overlapping and ordered (prev before next).
+            var prevTail = prev;
+            prevTail.startUT = 0.0;
+            prevTail.endUT = boundaryUT;
+            var nextHead = next;
+            nextHead.startUT = boundaryUT + dtSeconds;
+            nextHead.endUT = boundaryUT + dtSeconds + 1.0;
+            // For dt=0 the two sections share the same boundary UT (prev.endUT ==
+            // next.startUT == boundaryUT) — adjacent, not overlapping.
             var rec = MakeRecording("rec-449", "Diag Vessel",
                 new List<TrackSection> { prevTail, nextHead });
             var tree = MakeTree("449 Test", rec);
 
             SessionMerger.MergeTree(tree);
 
+            // Strict: substring match for the exact cause= value (not just "cause=").
             Assert.Contains(logLines, l =>
                 l.Contains("[WARN]") && l.Contains("[Merger]") &&
                 l.Contains("boundary discontinuity=") &&
                 l.Contains("dt=") &&
                 l.Contains("expectedFromVel=") &&
-                l.Contains("cause="));
+                l.Contains("cause=" + expectedCause));
         }
 
         #endregion

--- a/Source/Parsek.Tests/SessionMergerTests.cs
+++ b/Source/Parsek.Tests/SessionMergerTests.cs
@@ -924,6 +924,145 @@ namespace Parsek.Tests
 
         #endregion
 
+        #region #449 — boundary discontinuity classification
+
+        /// <summary>
+        /// Builds a TrackSection with a single in-section frame at <paramref name="ut"/>
+        /// carrying a velocity. Used by the #449 classifier tests so we can drive
+        /// dt and expectedFromVel deterministically.
+        /// </summary>
+        private static TrackSection MakeSectionWithFrame(
+            double ut, double lat, double lon, double alt, Vector3 velocity,
+            string bodyName = "Kerbin",
+            ReferenceFrame referenceFrame = ReferenceFrame.Absolute,
+            TrackSectionSource source = TrackSectionSource.Active)
+        {
+            var frames = new List<TrajectoryPoint>
+            {
+                new TrajectoryPoint
+                {
+                    ut = ut,
+                    latitude = lat, longitude = lon, altitude = alt,
+                    bodyName = bodyName,
+                    rotation = Quaternion.identity,
+                    velocity = velocity
+                }
+            };
+            return new TrackSection
+            {
+                environment = SegmentEnvironment.Atmospheric,
+                referenceFrame = referenceFrame,
+                startUT = ut,
+                endUT = ut,
+                source = source,
+                sampleRateHz = 10f,
+                frames = frames,
+                checkpoints = new List<OrbitSegment>(),
+                boundaryDiscontinuityMeters = 0f
+            };
+        }
+
+        [Fact]
+        public void ClassifyBoundaryDiscontinuity_NoPrev_TaggedNoPrev()
+        {
+            var next = MakeSectionWithFrame(100, 0, 0, 70000, Vector3.zero);
+            SessionMerger.ClassifyBoundaryDiscontinuity(
+                default(TrackSection), next, hasPrev: false, discMeters: 50f,
+                out double dt, out double expected, out string cause);
+            Assert.Equal(0.0, dt);
+            Assert.Equal(0.0, expected);
+            Assert.Equal("no-prev", cause);
+        }
+
+        [Fact]
+        public void ClassifyBoundaryDiscontinuity_ZeroDt_TaggedFrameMismatch()
+        {
+            // Same UT on both sides — interpolation/source-frame bug, not motion.
+            var prev = MakeSectionWithFrame(100, 0, 0, 70000, new Vector3(130, 0, 0));
+            var next = MakeSectionWithFrame(100, 0, 0, 70050, new Vector3(130, 0, 0));
+            SessionMerger.ClassifyBoundaryDiscontinuity(
+                prev, next, hasPrev: true, discMeters: 50f,
+                out double dt, out double expected, out string cause);
+            Assert.Equal(0.0, dt);
+            Assert.Equal("frame-mismatch", cause);
+        }
+
+        [Fact]
+        public void ClassifyBoundaryDiscontinuity_GapMatchesVelocity_TaggedUnrecordedGap()
+        {
+            // #449 reproducer: ~1s of unrecorded vessel motion at ~130 m/s after a
+            // quickload-resume produces a ~130 m boundary gap. Should be classified
+            // as unrecorded-gap, not as a sample-skip bug.
+            var prev = MakeSectionWithFrame(4003.9, 0, 0, 70000, new Vector3(130, 0, 0));
+            var next = MakeSectionWithFrame(4004.92, 0, 0.001183, 70000, Vector3.zero);
+            SessionMerger.ClassifyBoundaryDiscontinuity(
+                prev, next, hasPrev: true, discMeters: 132.82f,
+                out double dt, out double expected, out string cause);
+            Assert.InRange(dt, 1.01, 1.03);
+            Assert.InRange(expected, 130.0, 135.0);
+            Assert.Equal("unrecorded-gap", cause);
+        }
+
+        [Fact]
+        public void ClassifyBoundaryDiscontinuity_SmallGapLargeJump_TaggedSampleSkip()
+        {
+            // Tight time gap, but the position jumps far beyond what velocity could
+            // explain — points at a dropped-sample / drift bug or src-tag mismatch.
+            var prev = MakeSectionWithFrame(100, 0, 0, 70000, new Vector3(10, 0, 0));
+            var next = MakeSectionWithFrame(100.5, 0, 0, 70000, Vector3.zero);
+            SessionMerger.ClassifyBoundaryDiscontinuity(
+                prev, next, hasPrev: true, discMeters: 500f,
+                out double dt, out double expected, out string cause);
+            Assert.InRange(dt, 0.4, 0.6);
+            Assert.InRange(expected, 4.0, 6.0);
+            Assert.Equal("sample-skip", cause);
+        }
+
+        [Fact]
+        public void ClassifyBoundaryDiscontinuity_StationaryWithFloor_TaggedUnrecordedGap()
+        {
+            // Stationary vessel (vMag=0) with a small jump under the 5m floor:
+            // the floor swallows pure quantization noise so this stays tagged
+            // as unrecorded-gap instead of false-positive sample-skip.
+            var prev = MakeSectionWithFrame(100, 0, 0, 70000, Vector3.zero);
+            var next = MakeSectionWithFrame(101, 0, 0, 70003, Vector3.zero);
+            SessionMerger.ClassifyBoundaryDiscontinuity(
+                prev, next, hasPrev: true, discMeters: 3f,
+                out double dt, out double expected, out string cause);
+            Assert.Equal(0.0, expected);
+            Assert.Equal("unrecorded-gap", cause);
+        }
+
+        [Fact]
+        public void MergeTree_DiscontinuityWarning_IncludesClassification()
+        {
+            // Two adjacent Active sections with a velocity-explained gap — the WARN
+            // should now carry dt=, expectedFromVel=, and cause= fields so future
+            // occurrences are immediately classifiable from the log alone.
+            var prev = MakeSectionWithFrame(0, 0, 0, 70000, new Vector3(100, 0, 0));
+            var next = MakeSectionWithFrame(1.0, 0, 0, 70110, Vector3.zero,
+                source: TrackSectionSource.Active);
+            // Force them not to overlap so ResolveOverlaps doesn't merge/trim them.
+            // MakeSectionWithFrame leaves startUT==endUT; widen the second so it
+            // is sorted strictly after the first.
+            var prevTail = prev; prevTail.endUT = 0.5;
+            var nextHead = next; nextHead.startUT = 1.0; nextHead.endUT = 2.0;
+            var rec = MakeRecording("rec-449", "Diag Vessel",
+                new List<TrackSection> { prevTail, nextHead });
+            var tree = MakeTree("449 Test", rec);
+
+            SessionMerger.MergeTree(tree);
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[WARN]") && l.Contains("[Merger]") &&
+                l.Contains("boundary discontinuity=") &&
+                l.Contains("dt=") &&
+                l.Contains("expectedFromVel=") &&
+                l.Contains("cause="));
+        }
+
+        #endregion
+
         #region ResolveOverlaps — frame trimming
 
         [Fact]

--- a/Source/Parsek/SessionMerger.cs
+++ b/Source/Parsek/SessionMerger.cs
@@ -207,7 +207,8 @@ namespace Parsek
                 $"overlapsResolved={overlapCount} " +
                 $"active={activeCount} background={bgCount} checkpoint={cpCount}");
 
-            // Log discontinuity warnings
+            // Log discontinuity warnings (#449: include time-gap classification so the
+            // root cause is visible at-a-glance instead of needing log-archaeology).
             for (int i = 0; i < mergedSections.Count; i++)
             {
                 float disc = mergedSections[i].boundaryDiscontinuityMeters;
@@ -215,14 +216,86 @@ namespace Parsek
                 {
                     string prevRef = i > 0 ? mergedSections[i - 1].referenceFrame.ToString() : "?";
                     string prevSrc = i > 0 ? mergedSections[i - 1].source.ToString() : "?";
+                    ClassifyBoundaryDiscontinuity(
+                        i > 0 ? mergedSections[i - 1] : default(TrackSection),
+                        mergedSections[i],
+                        i > 0,
+                        disc,
+                        out double dt, out double expectedM, out string cause);
                     ParsekLog.Warn(Tag,
                         $"MergeTree: boundary discontinuity={disc.ToString("F2", ic)}m " +
                         $"at section[{i}] ut={mergedSections[i].startUT.ToString("F2", ic)} " +
                         $"vessel='{vesselName}' " +
                         $"prevRef={prevRef} nextRef={mergedSections[i].referenceFrame} " +
-                        $"prevSrc={prevSrc} nextSrc={mergedSections[i].source}");
+                        $"prevSrc={prevSrc} nextSrc={mergedSections[i].source} " +
+                        $"dt={dt.ToString("F2", ic)}s " +
+                        $"expectedFromVel={expectedM.ToString("F2", ic)}m " +
+                        $"cause={cause}");
                 }
             }
+        }
+
+        /// <summary>
+        /// Classifies a boundary discontinuity using the time gap and the previous section's
+        /// last-frame velocity (#449). Output buckets:
+        /// <list type="bullet">
+        ///   <item><c>frame-mismatch</c> — gap is effectively zero (&lt;0.05s) but the
+        ///   position jumps; points at an interpolation/source-frame bug.</item>
+        ///   <item><c>unrecorded-gap</c> — discontinuity is consistent with
+        ///   <c>|prev.velocity| × dt</c> (with a tolerance margin); points at a legitimate
+        ///   pause-and-resume span (quickload-resume, scene-reload, frame-budget spike) that
+        ///   the recorder couldn't sample through.</item>
+        ///   <item><c>sample-skip</c> — discontinuity exceeds the velocity-implied gap;
+        ///   points at a dropped-sample / drift bug or a source-tag mismatch.</item>
+        /// </list>
+        /// Pure helper so unit tests can verify the classification independently of logging.
+        /// </summary>
+        internal static void ClassifyBoundaryDiscontinuity(
+            TrackSection prev, TrackSection next, bool hasPrev, float discMeters,
+            out double dtSeconds, out double expectedMeters, out string cause)
+        {
+            dtSeconds = 0.0;
+            expectedMeters = 0.0;
+            cause = "no-prev";
+
+            if (!hasPrev) return;
+            if (prev.frames == null || prev.frames.Count == 0)
+            {
+                cause = "prev-no-frames";
+                return;
+            }
+            if (next.frames == null || next.frames.Count == 0)
+            {
+                cause = "next-no-frames";
+                return;
+            }
+
+            TrajectoryPoint lastPrev = prev.frames[prev.frames.Count - 1];
+            TrajectoryPoint firstNext = next.frames[0];
+
+            dtSeconds = firstNext.ut - lastPrev.ut;
+            // Magnitude of the recorded velocity at the prior section's tail. The
+            // velocity field stores playback velocity captured from KSP — surface or
+            // orbital depending on situation, but its magnitude is a reasonable
+            // upper-bound on how far the vessel could have moved during dt.
+            double vMag = Math.Sqrt(
+                (double)lastPrev.velocity.x * lastPrev.velocity.x +
+                (double)lastPrev.velocity.y * lastPrev.velocity.y +
+                (double)lastPrev.velocity.z * lastPrev.velocity.z);
+            double dtAbs = dtSeconds < 0 ? -dtSeconds : dtSeconds;
+            expectedMeters = vMag * dtAbs;
+
+            // 5m floor + 2x margin: the velocity sample is one tick stale, the next
+            // section's first sample is one tick ahead, and KSP physics can change
+            // velocity between them. The floor swallows pure quantization noise.
+            double tolerance = expectedMeters * 2.0 + 5.0;
+
+            if (dtAbs < 0.05)
+                cause = "frame-mismatch";
+            else if ((double)discMeters <= tolerance)
+                cause = "unrecorded-gap";
+            else
+                cause = "sample-skip";
         }
 
         /// <summary>

--- a/Source/Parsek/SessionMerger.cs
+++ b/Source/Parsek/SessionMerger.cs
@@ -282,7 +282,7 @@ namespace Parsek
                 (double)lastPrev.velocity.x * lastPrev.velocity.x +
                 (double)lastPrev.velocity.y * lastPrev.velocity.y +
                 (double)lastPrev.velocity.z * lastPrev.velocity.z);
-            double dtAbs = dtSeconds < 0 ? -dtSeconds : dtSeconds;
+            double dtAbs = Math.Abs(dtSeconds);
             expectedMeters = vMag * dtAbs;
 
             // 5m floor + 2x margin: the velocity sample is one tick stale, the next

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -97,7 +97,9 @@ Once the dominant sub-phase is identified, the fix is one of:
 
 ---
 
-## 449. Merger boundary discontinuity 132.82 m within a single-source tree
+## ~~449. Merger boundary discontinuity 132.82 m within a single-source tree~~
+
+**Status:** ~~Fixed~~ — diagnostic-only improvement (root cause is benign, no behavioral change needed).
 
 **Source:** smoke-test bundle `logs/2026-04-18_0221_v0.8.2-smoke/KSP.log:17917`. Single WARN per session:
 
@@ -106,26 +108,21 @@ Once the dominant sub-phase is identified, the fix is one of:
 ut=4004.92 vessel='r0' prevRef=Absolute nextRef=Absolute prevSrc=Active nextSrc=Active
 ```
 
-**Concern:** the two adjacent track sections at the boundary are **both** `prevSrc=Active nextSrc=Active` with `prevRef=Absolute nextRef=Absolute` — i.e., both halves come from the active flight recorder (not a background-recorder split, not a revert merge), same reference frame, and still a 132.82 m position jump. The merger's boundary-continuity invariant is that an all-Active / same-reference pair should stitch within a sampling tolerance (usually sub-meter after interpolation). A 132.82 m gap inside a single-source tree points at one of:
+**Investigation finding:** this is **case (2) from the original analysis** — a quickload-resume scene reload stitched at the same-source boundary. Trace:
+1. OnSave at UT 4004.7 closes section 0 (last sample at UT 4003.9) and writes the sidecar with one section.
+2. Live recorder samples for ~48 s (section A, UT 4004.7 → 4052.9) until `OnSceneChangeRequested` fires (FLIGHT→FLIGHT vessel switch that wasn't pre-transitionable, so it fell into `StashActiveTreeAsPendingLimbo`).
+3. After the scene reload, `RestoreActiveTreeFromPending` reinstalls the on-disk tree (which only has section 0 — section A was never persisted) and `recorder.StartRecording(isPromotion: true)` resumes at UT ~4004.92.
+4. New section 1's first sample lands at UT 4004.92, ~1 s after section 0's tail at UT 4003.9. At the recorded surface velocity (~130 m/s) the unsampled vessel motion across that 1 s fully accounts for the 132.82 m gap.
 
-1. **Dropped sample window around a physics step large enough to miss the boundary UT** — the recorder's `Update`/`FixedUpdate` sampling may have skipped the frame at ut ≈ 4004.92 (e.g., the 40 ms frame-budget spike at `KSP.log:11489` / see #450, or a Krakensbane float-origin shift at ut=4004.92 that the recorder didn't re-sample through).
-2. **Boundary stitched across a scene-level discontinuity** the merger doesn't tag as a source change — e.g., vessel switch with the recorder keeping the same `Active` source label, or a time-warp rate change that dilated the sample interval.
-3. **Interpolation bug at `Merger.MergeTree` section[1]** — the specific code path that computes the continuity check may be comparing positions in mismatched frames despite both sides claiming `Absolute`.
+Both halves are correctly tagged `Active` because they came from the same source semantically — there is no scene-source distinction to add. The user-visible "teleport" is real but unavoidable: the resume point cannot retroactively interpolate motion that wasn't recorded.
 
-The smoke-test session recorded two recordings — recording 2 starts at ut ≈ 3988.6 and the WARN lands at ut=4004.92, ~16 s into recording 2. Recording 1 ended at ut ≈ 177, so this is not a cross-recording merge boundary; it is a within-recording section boundary. The `[1]` index suggests section[1] is the second section of recording 2 — consistent with a single section split at ut=4004.92 within recording 2.
+**Fix shipped:** `SessionMerger.LogMergeDiagnostics` now classifies each discontinuity using the inter-section time gap and the previous section's last-frame velocity. The WARN line carries `dt=`, `expectedFromVel=`, and `cause=` (`unrecorded-gap` / `sample-skip` / `frame-mismatch`) so future occurrences are immediately classifiable from `KSP.log` alone, without log-archaeology around the boundary UT.
 
-**Investigation steps:**
-1. Correlate ut=4004.92 with adjacent KSP.log lines — look for vessel-switch events, Krakensbane shifts, time-warp rate changes, or frame-budget spikes in a ±1 s window. Starting point: `KSP.log:17900-17940`.
-2. Dump the two trajectory points bracketing section[1]'s boundary: their `ut`, `position`, `velocity`, `refFrame`, and sample-interval-to-neighbor. If the gap is >1 physics step's worth of the previous-point velocity, the sample was dropped. If the gap equals `prev_velocity × dt` for the expected `dt`, the recorder sampled correctly but the merger is misinterpreting the positions.
-3. Check `FlightRecorder.HandleVesselSwitchDuringRecording` and `BackgroundRecorder` split paths for any condition that would insert a section boundary without flipping `Src` to `Background` or `Paused`.
+- `unrecorded-gap` — discontinuity is consistent with `|prev.velocity| × dt` (with a 5 m floor + 2× margin); benign quickload-resume / scene-reload / frame-budget spike.
+- `sample-skip` — discontinuity exceeds the velocity-implied gap; points at a real dropped-sample / drift / src-tag bug.
+- `frame-mismatch` — `dt < 0.05 s` but a position jump; points at an interpolation/source-frame bug at the same boundary UT.
 
-**Fix:** depends on the root cause from the investigation. If (1), the recorder needs to clamp-sample at boundary UT or the merger's continuity tolerance needs to widen for known-skipped-frame cases (with a DEBUG trail). If (2), the `Src` label needs extending to distinguish "Active before vessel-switch" from "Active after vessel-switch". If (3), pure bug in `Merger.MergeTree` section-boundary math.
-
-**Files:** `Source/Parsek/Merger.cs` (boundary-continuity check + section assembly), `Source/Parsek/FlightRecorder.cs` / `Source/Parsek/BackgroundRecorder.cs` (sample-dropped or src-relabel paths), `Source/Parsek.Tests/MergerTests.cs` (new case: same-src/same-ref 132 m gap should either stitch with a clamp-sample or WARN with a specific root-cause tag).
-
-**Scope:** Small once the investigation identifies the path; unknown until then.
-
-**Status:** TODO. Priority: low. Single occurrence in a smoke test, recoverable (playback continues through the gap, vessel visibly "teleports" 132 m), not a crash. Worth a diagnostic investigation in the next cycle to prevent it compounding if the underlying cause is systemic (e.g., tied to #450's frame-budget spikes).
+**Files:** `Source/Parsek/SessionMerger.cs` (classifier + WARN format), `Source/Parsek.Tests/SessionMergerTests.cs` (5 classifier unit tests + WARN format assertion).
 
 ---
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -122,7 +122,7 @@ Both halves are correctly tagged `Active` because they came from the same source
 - `sample-skip` — discontinuity exceeds the velocity-implied gap; points at a real dropped-sample / drift / src-tag bug.
 - `frame-mismatch` — `dt < 0.05 s` but a position jump; points at an interpolation/source-frame bug at the same boundary UT.
 
-**Files:** `Source/Parsek/SessionMerger.cs` (classifier + WARN format), `Source/Parsek.Tests/SessionMergerTests.cs` (5 classifier unit tests + WARN format assertion).
+**Files:** `Source/Parsek/SessionMerger.cs` (classifier + WARN format), `Source/Parsek.Tests/SessionMergerTests.cs` (7 classifier unit tests covering no-prev / zero-dt / velocity-matched / sample-skip / floor / NaN / Infinity, plus a parameterised WARN-format assertion that checks the exact `cause=` value across all three buckets).
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #449. Diagnostic-only follow-up to the merger boundary-discontinuity WARN — no behavioral change to recording, merge selection, or playback.

The WARN at `ut=4004.92, disc=132.82m, prevSrc=Active nextSrc=Active, prevRef=Absolute nextRef=Absolute` (smoke-test bundle `2026-04-18_0221_v0.8.2-smoke`) was a benign quickload-resume gap, not a recorder bug. Trace in `docs/dev/todo-and-known-bugs.md` (#449 entry, now marked done): OnSave closes section 0 → ~48 s of unrecorded live samples → scene reload re-installs the on-disk tree without that tail → resume at UT 4004.92 leaves a 1 s `prev.velocity × dt` gap that fully accounts for the 132 m jump.

To make future WARNs immediately classifiable from `KSP.log` alone (without log-archaeology around the boundary UT), `SessionMerger.LogMergeDiagnostics` now classifies each discontinuity using the inter-section time gap and the previous section's last-frame velocity, and the WARN line carries `dt=`, `expectedFromVel=`, and a `cause=` tag:

- `unrecorded-gap` — discontinuity is consistent with `|prev.velocity| × dt` (5 m floor + 2× margin); benign quickload-resume / scene-reload / frame-budget spike.
- `sample-skip` — discontinuity exceeds the velocity-implied gap; points at a real dropped-sample / drift / src-tag bug.
- `frame-mismatch` — `dt < 0.05 s` with a position jump; points at an interpolation/source-frame bug at the same boundary UT.

Unit tests cover all three buckets plus the corner cases (no-prev, zero-dt with non-zero jump, stationary-with-floor, NaN velocity, +Infinity velocity), and the WARN-format assertion is parameterised so a regression that hard-codes a single cause string fails for the other rows.

## Test plan

- [x] `dotnet build` clean from `Source/Parsek/`
- [x] `dotnet test` from `Source/Parsek.Tests/` — 6953 pass, 1 skip (pre-existing), 1 fail on the `InjectAllRecordings` env test that already fails on `origin/main` (sidecar directory locking, unrelated to this change)
- [x] SessionMergerTests: 50 → 54 (+4 from this PR's classifier coverage)
- [x] Deployed `GameData/Parsek/Plugins/Parsek.dll` MD5 matches `bin/Debug/Parsek.dll` and contains `unrecorded-gap`, `sample-skip`, `frame-mismatch`, `no-prev`, `expectedFromVel` UTF-16 strings
- [ ] In-game smoke: trigger another quickload-resume on a high-velocity Active recording and confirm the next WARN reports `cause=unrecorded-gap` with sensible `dt=` / `expectedFromVel=` values