### PR TITLE
docs: #453 document the zero playbackVel / rawAlignment=fallback diagnostic artifact

### DIFF
--- a/docs/dev/plan-fix-zero-playback-velocity.md
+++ b/docs/dev/plan-fix-zero-playback-velocity.md
@@ -1,0 +1,229 @@
+# Plan: Address one-frame zero `playbackVel` / `rawAlignment=fallback` log events
+
+Branch: `fix/zero-playback-velocity-fallback`
+Worktree: `Parsek-fix-zero-playback-velocity`
+Date: 2026-04-18
+
+## Problem
+
+The watch-camera horizon log occasionally emits one-frame events where
+`playbackVel=(0.0,0.0,0.0)` and `rawAlignment=fallback`, even though the
+ghost is clearly flying at that instant (e.g. `alt=1467m`, valid `bodyVel`).
+The neighboring frames report non-zero velocity. Observed in
+`logs/2026-04-18_1106_ghosts-stuck-at-pad/KSP.log` at lines 15020, 16853,
+17507, 18080. Flagged as a possible secondary bug during the post-#361
+log investigation; not tracked in `docs/dev/todo-and-known-bugs.md` and
+no open PR addresses it (checked 2026-04-18).
+
+Example log line:
+
+```
+[Parsek][INFO][CameraFollow] Watch horizon basis: ... alt=1467m
+velocityFrame=surfaceRelative source=ProjectedVelocity rawAlignment=fallback
+playbackVel=(0.0,0.0,0.0) bodyVel=(-99.6,0.0,-144.3) ...
+```
+
+## Root cause (identified)
+
+Sampled playback velocity is computed by linear interpolation of the two
+bracketing trajectory points' stored velocities:
+
+- `ParsekFlight.cs:9967-9970` (point interpolation path)
+- `ParsekFlight.cs:10706-10708` (relative-frame interpolation path)
+
+Both read `Vector3.Lerp(before.velocity, after.velocity, t)`. When the two
+bracketing points have near-opposite velocities (e.g. a decoupler event
+recorded ~0.1 s apart flips the vessel's rigidbody velocity, or a landing
+that bounces, or any sub-second direction reversal), the linear
+interpolation at `t ≈ 0.5` collapses to approximately zero magnitude.
+
+`WatchModeController.DescribeHorizonAlignment` then labels the result
+`fallback`:
+
+```csharp
+if (velocity.sqrMagnitude < 0.01f) return "fallback";
+```
+
+and the horizon-basis computation falls through to the
+`HorizonForwardSource.LastForwardFallback` /
+`ArbitraryPerpendicularFallback` branch for that single frame.
+
+## Severity assessment — LOW
+
+This matters less than it looks:
+
+1. **Ghost positioning is unaffected.** The ghost's mesh position is
+   driven by the stored `position` field of bracketing points, not the
+   interpolated velocity. Visually the ghost moves continuously through
+   the glitched frame.
+2. **Camera fallback is smooth.** `LastForwardFallback` uses the
+   previous frame's forward vector, which is still a good approximation
+   of prograde across a one-frame transient. The camera does NOT snap.
+3. **The "glitch" is essentially log noise.** Users aren't reporting
+   visible issues; the fallback events were detected by grepping INFO
+   lines.
+4. **One-frame transient** — blink-and-miss even if visible.
+
+Consider this a diagnostic-cleanup task, not a user-facing bug fix. It
+was promoted to the todo list only because my original log investigation
+called it out as an "unknown" that could mask a deeper bug. After the
+root cause analysis here, the mechanism is fully explained and benign.
+
+## Options
+
+### Option A — Accept as diagnostic noise (recommended default)
+
+- **Code change:** none.
+- **Doc change:** add a todo entry documenting the mechanism so the next
+  log-audit doesn't re-investigate this.
+- **Rationale:** severity is cosmetic; fixing it introduces a
+  correctness/complexity tradeoff for zero perceptible benefit. Track it
+  as a known diagnostic artifact.
+
+### Option B — Snap to bracket-point velocity on detected reversal
+
+- **Code change:** in the two interpolation sites in `ParsekFlight.cs`,
+  detect `Vector3.Dot(before.velocity, after.velocity) < 0` and use the
+  nearer bracket's velocity instead of the Lerp:
+  ```csharp
+  Vector3 velocity;
+  if (Vector3.Dot(before.velocity, after.velocity) < 0f)
+      velocity = (t < 0.5f) ? before.velocity : after.velocity;
+  else
+      velocity = Vector3.Lerp(before.velocity, after.velocity, t);
+  ```
+- **Pros:** pure-static and unit-testable, eliminates the zero-crossing,
+  camera horizon stays on a meaningful direction across a reversal.
+- **Cons:** introduces a discontinuity in the logged velocity at `t = 0.5`
+  (jumps from `before.velocity` to `after.velocity`), which is arguably
+  less physically accurate than the linear interpolation. Also affects
+  both the point-interpolation and relative-frame-interpolation paths —
+  two call sites to keep in sync.
+- **Recording impact:** none. Stored trajectory data unchanged.
+
+### Option C — Use velocity history (EMA) for the horizon log, not the instant sample
+
+- **Code change:** in `WatchModeController.UpdateHorizonProxy`, maintain
+  a per-session exponentially-weighted moving average of the watched
+  ghost's `lastInterpolatedVelocity`, and log THAT value as `playbackVel`.
+  The ghost's actual motion and camera targeting stay on the instant
+  sample; only the DIAGNOSTIC log uses the smoothed value.
+- **Pros:** zero impact on engine behaviour; log becomes noise-free;
+  intuitive physical meaning (the horizon camera cares about sustained
+  direction, not instantaneous derivatives).
+- **Cons:** hides real sub-second velocity transients from the log if we
+  later need to diagnose one. Needs a time constant tuning (e.g.
+  half-life of 0.5 s would dampen the one-frame zero to ~50% magnitude
+  drop on the affected frame, still above the 0.01 threshold). Adds
+  per-frame state to `WatchModeController`.
+- **Recording impact:** none.
+
+### Option D — Fall back to numerical differentiation when interpolated velocity is near zero
+
+- **Code change:** in the interpolator, if `Vector3.Lerp(...)` returns
+  `sqrMagnitude < 0.01`, recompute velocity from `(after.position -
+  before.position) / (after.ut - before.ut)`. Position-based velocity
+  can't collapse unless the two points are literally at the same
+  position.
+- **Pros:** physically meaningful; uses data that's always available.
+- **Cons:** returns the AVERAGE velocity over the whole bracket interval
+  (same value for `t=0.1` and `t=0.9`), which is a different semantic
+  from the Lerp'd value elsewhere in the sample. Callers of the
+  interpolator that use velocity for anything physical (not just the
+  camera log) would see this semantic shift.
+
+## Recommendation
+
+**Ship Option A.** Add a one-line todo entry documenting the root cause
+and the reason we chose not to fix it. The severity does not justify
+code churn.
+
+If the user would rather "not see the log line", Option C (EMA for log
+only) is the minimal-risk code change. Do NOT touch the interpolation
+math (Options B, D) — interpolated velocity is consumed by paths beyond
+just the camera log (e.g. the horizon-proxy orientation, horizon
+alignment source, possibly others), and changing the semantics to
+preserve magnitude under reversal would subtly alter playback math
+everywhere.
+
+## If Option A is adopted, the doc entry looks like
+
+```markdown
+## 453. Watch camera horizon log occasionally shows `playbackVel=(0,0,0) rawAlignment=fallback` for one frame
+
+**Source:** post-v0.8.0 log investigation `2026-04-18`
+(`logs/2026-04-18_1106_ghosts-stuck-at-pad/KSP.log` lines 15020,
+16853, 17507, 18080).
+
+**Symptom:** one-frame events in the "Watch horizon basis" log where
+`playbackVel=(0.0,0.0,0.0)` and `rawAlignment=fallback`, even though
+the ghost is clearly flying (non-zero `alt`, non-zero `bodyVel`).
+Frames before and after show non-zero playback velocity.
+
+**Cause:** `ParsekFlight.cs:9967-9970` and `:10706-10708` compute
+`velocity = Vector3.Lerp(before.velocity, after.velocity, t)` over the
+two bracketing trajectory points. When the stored velocities of the
+bracket happen to be near-opposite (sub-second direction reversal from
+a decoupler fire, a bounce landing, an rb_velocity flip during an
+atmospheric transition), linear interpolation near `t=0.5` collapses
+the magnitude to below the 0.01 fallback threshold used by
+`WatchModeController.DescribeHorizonAlignment` at line ~2800, and the
+horizon basis briefly falls to `LastForwardFallback` /
+`ArbitraryPerpendicularFallback`.
+
+**Impact:** cosmetic only. Ghost positioning uses the stored
+`position` field, not the interpolated velocity, so the ghost's
+motion is unaffected. `LastForwardFallback` reuses the previous
+frame's forward vector, so the camera does NOT snap visibly. The
+effect is one frame of "fallback" in the log; no user-reported visual
+glitch.
+
+**Decision:** leave as-is. Options to snap-to-bracket-velocity on
+reversal (risks semantic shift in interpolation used elsewhere) or
+log-only EMA smoothing (hides real transients) are documented in
+`docs/dev/plan-fix-zero-playback-velocity.md`. Severity does not
+justify the code churn or the tradeoff.
+
+**Status:** Known, not fixed (diagnostic artifact).
+```
+
+## If Option C is later adopted
+
+Minimal change, two commits:
+
+1. Add `Vector3 smoothedPlaybackVelocity` field to `WatchModeController`,
+   update each frame with an EMA:
+   `smoothed = Lerp(smoothed, state.lastInterpolatedVelocity, alpha)`
+   where `alpha = 1 - exp(-dt / halfLife)` and `halfLife = 0.5f`.
+2. In `UpdateHorizonProxy` / the log emission, substitute `smoothed`
+   for `state.lastInterpolatedVelocity` ONLY in the log line and in the
+   `sqrMagnitude < 0.01` fallback check. Keep the actual
+   horizon-forward computation on the instant sample.
+3. Add a unit test: construct a sequence of `lastInterpolatedVelocity`
+   values including one zero-transient, run the EMA, assert the
+   smoothed value never drops below 0.1 magnitude.
+4. Reset `smoothedPlaybackVelocity` in `ResetWatchState` so it doesn't
+   leak across watch sessions.
+
+## Implementation checklist (only if Option B/C/D chosen)
+
+- [ ] Pick an option (A / B / C / D).
+- [ ] If A: add the todo entry and commit. No code change.
+- [ ] If B: update both interpolator sites in `ParsekFlight.cs`, add
+      unit test for the reversal case, verify no other caller of the
+      interpolator breaks.
+- [ ] If C: add EMA field + reset site, one unit test, update log
+      format if needed. Document the semantic change in the log line.
+- [ ] If D: update interpolator, document the semantic shift in XML
+      doc, audit all callers, update tests that pin specific
+      interpolated velocity values.
+- [ ] CHANGELOG / todo updates.
+- [ ] Build, deploy, full test suite.
+- [ ] Commit, push, PR.
+
+## Out of scope
+
+- Any change to trajectory recording format or sampling cadence.
+- Any change to the bracketing logic in `TrajectoryMath.InterpolatePoints`.
+- Any change to non-camera consumers of `state.lastInterpolatedVelocity`
+  (e.g. sound pitch, engine FX modulation).

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -58,6 +58,32 @@ are fixed in the same PR branch with additional commits:
 
 # Known Bugs
 
+## ~~453. Watch camera horizon log occasionally shows `playbackVel=(0,0,0) rawAlignment=fallback` for one frame~~
+
+**Source:** post-#361 log audit `2026-04-18` (`logs/2026-04-18_1106_ghosts-stuck-at-pad/KSP.log` lines 15020, 16853, 17507, 18080). Flagged as "possibly other bugs" during investigation of the stuck-at-pad report; root cause traced here after #361 shipped.
+
+**Symptom:** one-frame events in the "Watch horizon basis" INFO log where `playbackVel=(0.0,0.0,0.0)` and `rawAlignment=fallback`, while the ghost is clearly flying (non-zero `alt`, non-zero `bodyVel`). The frame immediately before and after shows non-zero playback velocity.
+
+**Cause:** the two sampled trajectory bracket points sometimes have near-opposite stored velocities (a sub-second direction reversal — decoupler fire, bounce landing, `rb_velocity` flip at an atmosphere boundary). Linear interpolation at `ParsekFlight.cs:9967-9970` (point path) and `:10706-10708` (relative-frame path) computes `Vector3.Lerp(before.velocity, after.velocity, t)`; near `t = 0.5` the magnitude collapses below the 0.01 fallback threshold used by `WatchModeController.DescribeHorizonAlignment` (line ~2800), so the log line tags the alignment "fallback" and the horizon basis briefly falls through to `HorizonForwardSource.LastForwardFallback`.
+
+**Impact — cosmetic only:**
+
+- Ghost positioning uses the stored `position` field, not the interpolated velocity, so the ghost's motion is continuous through the affected frame.
+- `LastForwardFallback` reuses the previous frame's forward vector, so the CAMERA does not snap visibly — the direction smoothly carries across the one-frame transient.
+- Net effect: one line of "fallback" in the log that looks like a bug during a KSP.log audit but isn't. Diagnostic noise, not a gameplay defect.
+
+**Decision — leave as-is.** Candidate code fixes (documented in `docs/dev/plan-fix-zero-playback-velocity.md` on branch `fix/zero-playback-velocity-fallback`) all carry tradeoffs that outweigh the benefit:
+
+- Snap to the nearer bracket's velocity on reversal detection: changes the semantics of interpolated velocity for every consumer, not just the camera log.
+- EMA smoothing for the log line only: hides real sub-second transients from future audits.
+- Numerical-differentiation fallback: changes the meaning of "velocity at time t" away from the Lerp'd value every other caller assumes.
+
+The severity does not justify the code churn or the regression risk. This entry exists so the next log auditor recognises the line on sight and moves on.
+
+**Status:** ~~Known, not fixed~~ (diagnostic artifact, accepted).
+
+---
+
 ## 450. Per-spawn time budgeting / coroutine split — #414 follow-up for bimodal single-spawn cost
 
 **Source:** smoke-test bundle `logs/2026-04-18_0221_v0.8.2-smoke/KSP.log:11489`. One-shot #414 breakdown line (first exceeded frame in the session):


### PR DESCRIPTION
## Summary

One-frame events in the "Watch horizon basis" INFO log where `playbackVel=(0,0,0)` and `rawAlignment=fallback` are a benign artifact of linear-interpolating trajectory velocities across sub-second direction reversals. Adding a todo entry (#453) so future KSP.log audits recognise the line on sight and don't reinvestigate.

## Rationale

Root cause traced to `ParsekFlight.cs:9967-9970` and `:10706-10708`: `Vector3.Lerp(before.velocity, after.velocity, t)` collapses near `t=0.5` when the bracket velocities are near-opposite (decoupler fires, bounce landings, `rb_velocity` flips). Ghost positioning uses stored `position` (not interpolated velocity) so the ghost moves continuously, and `LastForwardFallback` reuses the previous frame's forward so the camera does not snap. Net effect: one log line that looks suspicious during an audit but isn't.

All candidate code fixes (snap-to-bracket on reversal, EMA smoothing, numerical-differentiation fallback) change semantics for callers beyond the camera log. Severity does not justify the regression risk. Logging is already well-rate-limited (INFO only on state-key change, VERBOSE at 1/10s per cycle) so it's not spammy.

## Changes

- `docs/dev/todo-and-known-bugs.md`: new #453 entry marked `~~Known, not fixed~~ (diagnostic artifact, accepted)`.
- `docs/dev/plan-fix-zero-playback-velocity.md`: full options analysis preserved on this branch for anyone who wants to reopen the decision.

## Test plan

- [x] Doc-only change; no code paths altered.
- [x] Verified existing logging in `WatchModeController.LogHorizonForwardState` (line 2786-2839) is state-key-gated for INFO and 10 s rate-limited for VERBOSE — confirms the artifact won't spam.