### PR TITLE
fix #449 follow-up: harden invalid boundary data classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ All notable changes to Parsek are documented here.
 - Replaced the four sampling sliders with a single **Recorder Sample Density** setting (Low / Medium / High). Legacy slider-based saves migrate to the nearest preset on load.
 - `#375` Demoted chatty per-appearance `GhostAppearance` logs from Info to Verbose.
 - `#378` Added a rate-limited warn when on-save monotonicity rebuild exceeds 5 ms on a single recording, so save-time stutter is visible in `KSP.log`.
-- `#449` Merger boundary-discontinuity warnings now include the inter-section time gap, the velocity-implied expected gap, and a `cause=` tag (`unrecorded-gap` / `sample-skip` / `frame-mismatch`) so quickload-resume gaps are immediately distinguishable from real recorder bugs in `KSP.log`.
+- `#449` Merger boundary-discontinuity warnings now include the inter-section time gap, the velocity-implied expected gap, and a `cause=` tag (`unrecorded-gap` / `sample-skip` / `frame-mismatch`, plus `invalid-data` when boundary timing/velocity samples are non-finite) so quickload-resume gaps are immediately distinguishable from real recorder bugs in `KSP.log`.
 - `#376` Documented the dual-storage invariant for auto-assigned standalone group names.
 - Gloops Flight Recorder window now has a Close button at the bottom, matching other Parsek windows.
 - Recordings window opens wider by default (1280 px) so more columns fit without a horizontal scroll; the Info-expanded width scales up to match.

--- a/Source/Parsek.Tests/SessionMergerTests.cs
+++ b/Source/Parsek.Tests/SessionMergerTests.cs
@@ -1034,13 +1034,11 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void ClassifyBoundaryDiscontinuity_NaNVelocity_DefaultsToSampleSkip()
+        public void ClassifyBoundaryDiscontinuity_NaNVelocity_TaggedInvalidData()
         {
-            // NaN-component velocity: vMag becomes NaN, so expectedMeters is NaN and
-            // tolerance is NaN. Both branch comparisons against NaN are false, so the
-            // classifier falls through to "sample-skip". This pins the silent-default
-            // so a future "fix" that drops NaN-velocity boundaries can't slip past
-            // review without updating this test.
+            // NaN-component velocity means the boundary data itself is broken. Do not
+            // fall through to a normal bucket — emit invalid-data so the WARN stays
+            // clearly suspicious instead of looking like a recorder gap.
             var prev = MakeSectionWithFrame(100, 0, 0, 70000,
                 new Vector3(float.NaN, 0, 0));
             var next = MakeSectionWithFrame(101, 0, 0, 70050, Vector3.zero);
@@ -1050,16 +1048,15 @@ namespace Parsek.Tests
             Assert.InRange(dt, 0.99, 1.01);
             Assert.True(double.IsNaN(expected),
                 $"Expected NaN expectedMeters with NaN velocity, got {expected}");
-            Assert.Equal("sample-skip", cause);
+            Assert.Equal("invalid-data", cause);
         }
 
         [Fact]
-        public void ClassifyBoundaryDiscontinuity_InfinityVelocity_DefaultsToSampleSkip()
+        public void ClassifyBoundaryDiscontinuity_InfinityVelocity_TaggedInvalidData()
         {
-            // Infinity-component velocity: same NaN-comparison pattern as the NaN
-            // case above. expectedMeters is Infinity, tolerance is Infinity, the
-            // discMeters <= Infinity branch is true → unrecorded-gap. Pin this so a
-            // future infinity-guard refactor doesn't silently flip the bucket.
+            // Infinity-component velocity previously forced any discontinuity into the
+            // benign unrecorded-gap bucket because the inferred tolerance became
+            // Infinity. That hides corrupted boundary data as "expected motion".
             var prev = MakeSectionWithFrame(100, 0, 0, 70000,
                 new Vector3(float.PositiveInfinity, 0, 0));
             var next = MakeSectionWithFrame(101, 0, 0, 70050, Vector3.zero);
@@ -1067,9 +1064,24 @@ namespace Parsek.Tests
                 prev, next, hasPrev: true, discMeters: 50f,
                 out double dt, out double expected, out string cause);
             Assert.InRange(dt, 0.99, 1.01);
-            Assert.True(double.IsPositiveInfinity(expected),
-                $"Expected +Infinity expectedMeters with +Infinity velocity, got {expected}");
-            Assert.Equal("unrecorded-gap", cause);
+            Assert.True(double.IsNaN(expected),
+                $"Expected NaN expectedMeters with +Infinity velocity, got {expected}");
+            Assert.Equal("invalid-data", cause);
+        }
+
+        [Fact]
+        public void ClassifyBoundaryDiscontinuity_NonFiniteUT_TaggedInvalidData()
+        {
+            var prev = MakeSectionWithFrame(100, 0, 0, 70000, new Vector3(130, 0, 0));
+            var next = MakeSectionWithFrame(double.NaN, 0, 0, 70050, Vector3.zero);
+            SessionMerger.ClassifyBoundaryDiscontinuity(
+                prev, next, hasPrev: true, discMeters: 50f,
+                out double dt, out double expected, out string cause);
+            Assert.True(double.IsNaN(dt),
+                $"Expected NaN dt with non-finite next.ut, got {dt}");
+            Assert.True(double.IsNaN(expected),
+                $"Expected NaN expectedMeters with non-finite UT, got {expected}");
+            Assert.Equal("invalid-data", cause);
         }
 
         // Parameterised so a regression that hard-codes a single cause (e.g. always
@@ -1116,6 +1128,32 @@ namespace Parsek.Tests
                 l.Contains("dt=") &&
                 l.Contains("expectedFromVel=") &&
                 l.Contains("cause=" + expectedCause));
+        }
+
+        [Fact]
+        public void MergeTree_DiscontinuityWarning_InvalidData_UsesExactCause()
+        {
+            const double boundaryUT = 1.0;
+            var prev = MakeSectionWithFrame(boundaryUT, 0, 0, 70000,
+                new Vector3(float.PositiveInfinity, 0, 0));
+            var next = MakeSectionWithFrame(boundaryUT + 1.0, 0, 0, 70050, Vector3.zero);
+            var prevTail = prev;
+            prevTail.startUT = 0.0;
+            prevTail.endUT = boundaryUT;
+            var nextHead = next;
+            nextHead.startUT = boundaryUT + 1.0;
+            nextHead.endUT = boundaryUT + 2.0;
+            var rec = MakeRecording("rec-449-invalid", "Diag Vessel",
+                new List<TrackSection> { prevTail, nextHead });
+            var tree = MakeTree("449 Invalid Data Test", rec);
+
+            SessionMerger.MergeTree(tree);
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[WARN]") && l.Contains("[Merger]") &&
+                l.Contains("boundary discontinuity=") &&
+                l.Contains("expectedFromVel=NaN") &&
+                l.Contains("cause=invalid-data"));
         }
 
         #endregion

--- a/Source/Parsek/SessionMerger.cs
+++ b/Source/Parsek/SessionMerger.cs
@@ -247,6 +247,8 @@ namespace Parsek
         ///   the recorder couldn't sample through.</item>
         ///   <item><c>sample-skip</c> — discontinuity exceeds the velocity-implied gap;
         ///   points at a dropped-sample / drift bug or a source-tag mismatch.</item>
+        ///   <item><c>invalid-data</c> — boundary UTs or the previous tail velocity are
+        ///   non-finite, so the classifier refuses to downgrade the warning to a benign gap.</item>
         /// </list>
         /// Pure helper so unit tests can verify the classification independently of logging.
         /// </summary>
@@ -274,6 +276,13 @@ namespace Parsek
             TrajectoryPoint firstNext = next.frames[0];
 
             dtSeconds = firstNext.ut - lastPrev.ut;
+            if (!IsFinite(dtSeconds) || !IsFiniteVector3(lastPrev.velocity))
+            {
+                expectedMeters = double.NaN;
+                cause = "invalid-data";
+                return;
+            }
+
             // Magnitude of the recorded velocity at the prior section's tail. The
             // velocity field stores playback velocity captured from KSP — surface or
             // orbital depending on situation, but its magnitude is a reasonable
@@ -546,6 +555,18 @@ namespace Parsek
         }
 
         // --- Private helpers ---
+
+        private static bool IsFinite(double value)
+        {
+            return !double.IsNaN(value) && !double.IsInfinity(value);
+        }
+
+        private static bool IsFiniteVector3(Vector3 value)
+        {
+            return !float.IsNaN(value.x) && !float.IsInfinity(value.x)
+                && !float.IsNaN(value.y) && !float.IsInfinity(value.y)
+                && !float.IsNaN(value.z) && !float.IsInfinity(value.z);
+        }
 
         private static void AddEventsWithDedup(
             List<PartEvent> merged, HashSet<string> seen, List<PartEvent> events)

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -116,13 +116,14 @@ ut=4004.92 vessel='r0' prevRef=Absolute nextRef=Absolute prevSrc=Active nextSrc=
 
 Both halves are correctly tagged `Active` because they came from the same source semantically — there is no scene-source distinction to add. The user-visible "teleport" is real but unavoidable: the resume point cannot retroactively interpolate motion that wasn't recorded.
 
-**Fix shipped:** `SessionMerger.LogMergeDiagnostics` now classifies each discontinuity using the inter-section time gap and the previous section's last-frame velocity. The WARN line carries `dt=`, `expectedFromVel=`, and `cause=` (`unrecorded-gap` / `sample-skip` / `frame-mismatch`) so future occurrences are immediately classifiable from `KSP.log` alone, without log-archaeology around the boundary UT.
+**Fix shipped:** `SessionMerger.LogMergeDiagnostics` now classifies each discontinuity using the inter-section time gap and the previous section's last-frame velocity. The WARN line carries `dt=`, `expectedFromVel=`, and `cause=` (`unrecorded-gap` / `sample-skip` / `frame-mismatch`, plus `invalid-data` when the boundary UT or prior tail velocity is non-finite) so future occurrences are immediately classifiable from `KSP.log` alone, without log-archaeology around the boundary UT.
 
 - `unrecorded-gap` — discontinuity is consistent with `|prev.velocity| × dt` (with a 5 m floor + 2× margin); benign quickload-resume / scene-reload / frame-budget spike.
 - `sample-skip` — discontinuity exceeds the velocity-implied gap; points at a real dropped-sample / drift / src-tag bug.
 - `frame-mismatch` — `dt < 0.05 s` but a position jump; points at an interpolation/source-frame bug at the same boundary UT.
+- `invalid-data` — boundary timing or prior tail velocity is non-finite; do not treat the warning as a benign motion gap.
 
-**Files:** `Source/Parsek/SessionMerger.cs` (classifier + WARN format), `Source/Parsek.Tests/SessionMergerTests.cs` (7 classifier unit tests covering no-prev / zero-dt / velocity-matched / sample-skip / floor / NaN / Infinity, plus a parameterised WARN-format assertion that checks the exact `cause=` value across all three buckets).
+**Files:** `Source/Parsek/SessionMerger.cs` (classifier + WARN format), `Source/Parsek.Tests/SessionMergerTests.cs` (8 classifier unit tests covering no-prev / zero-dt / velocity-matched / sample-skip / floor / NaN / Infinity / non-finite UT, plus WARN-format assertions that check the exact `cause=` value across the normal buckets and the `invalid-data` guard).
 
 ---
 


### PR DESCRIPTION
Follow-up to PR #355 — the hardening commit (79474e29) was added locally after the original PR was opened but before its merge, so it missed the original cut. This PR brings it into main on top of the merged base.

Single commit. Same scope as #355: defensive classification for invalid boundary data in SessionMerger.