### PR TITLE
fix: build break — call IsBypassEntryPurchaseAfterResearch on GameStateRecorder

### DIFF
--- a/Source/Parsek/GameStateRecorder.cs
+++ b/Source/Parsek/GameStateRecorder.cs
@@ -590,7 +590,7 @@ namespace Parsek
         /// </summary>
         internal static float ComputePartPurchaseFundsSpent(float entryCost)
         {
-            return LedgerOrchestrator.IsBypassEntryPurchaseAfterResearch() ? 0f : entryCost;
+            return IsBypassEntryPurchaseAfterResearch() ? 0f : entryCost;
         }
 
         #endregion


### PR DESCRIPTION
Hotfix for the build break introduced by PR #362's merge.

The merge brought a stale call site that qualified the helper as `LedgerOrchestrator.IsBypassEntryPurchaseAfterResearch()`. The helper actually lives on `GameStateRecorder` (see GameStateRecorder.cs:163, defined by the user's iterations on PR #358). Drop the wrong qualifier.

Single-line fix. Build clean post-fix.