### PR TITLE
docs: mark #433 closed in priority-queue header

### DIFF
--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -11,10 +11,10 @@ These four TODOs are the top of the work queue. They're load-bearing correctness
 
 1. ~~**#431** — Events captured during a recording share the recording's commit/discard fate (purge on discard, not epoch-filter).~~
 2. ~~**#432** — Gloops ghost-only recordings must not capture or apply any game events.~~
-3. **#433** — `PlaybackEnabled` toggle should be visual-only (stop gating vessel spawn and crew reservations).
+3. ~~**#433** — `PlaybackEnabled` toggle should be visual-only (stop gating vessel spawn and crew reservations).~~
 4. ~~**#434** — Revert to Launch should auto-discard, not open the merge dialog.~~
 
-Only #433 remains open. Once it ships, the `MilestoneStore.CurrentEpoch` filter can be retired as legacy work-around (see #431's notes).
+All four have shipped. The `MilestoneStore.CurrentEpoch` filter can now be retired as the legacy work-around (see #431's notes).
 
 ---
 


### PR DESCRIPTION
## Summary
- All four priority-queue items (#431/#432/#433/#434) have shipped, but the trailing sentence still read "Only #433 remains open". Updated the #433 bullet to strikethrough and replaced the stale sentence with the post-ship status.

## Test plan
- [x] Skim the updated section in `docs/dev/todo-and-known-bugs.md` renders cleanly on GitHub.