### PR TITLE
#450 Phase A: per-sub-phase spawn build attribution (diagnostic only)

### DIFF
--- a/Source/Parsek.Tests/Bug450BuildBreakdownTests.cs
+++ b/Source/Parsek.Tests/Bug450BuildBreakdownTests.cs
@@ -138,12 +138,44 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void SpawnMicrosecondsZero_SuppressesBuildBreakdown()
+        public void SpawnMaxBelowThreshold_SuppressesBuildBreakdown()
         {
-            // A budget spike caused purely by mainLoop / deferred events with no spawn time
-            // has nothing to attribute across build sub-phases. Emitting five zeros under
-            // `heaviestSpawn[type=none ...]` would be noise; the latch must stay unfired so
-            // the next real spawn-dominated spike gets its diagnostic.
+            // A budget spike whose heaviest single spawn is below the 15 ms bimodal
+            // threshold (e.g. incidental cheap prewarm during a mainLoop-driven hitch)
+            // must NOT consume the #450 latch. Otherwise the first such frame burns the
+            // session's only sample before the real single-spawn regression fires.
+            var phases = BimodalSingleSpawnPhases();
+            phases.spawnMicroseconds = 3_000;          // 3ms spread across spawns
+            phases.spawnMaxMicroseconds = 3_000;        // single-spawn max well under 15 ms
+            phases.buildSnapshotResolveMicroseconds = 50;
+            phases.buildTimelineFromSnapshotMicroseconds = 2_500;
+            phases.buildDictionariesMicroseconds = 300;
+            phases.buildReentryFxMicroseconds = 100;
+            phases.buildOtherMicroseconds = 50;
+            phases.heaviestSpawnSnapshotResolveMicroseconds = 50;
+            phases.heaviestSpawnTimelineFromSnapshotMicroseconds = 2_500;
+            phases.heaviestSpawnDictionariesMicroseconds = 300;
+            phases.heaviestSpawnReentryFxMicroseconds = 100;
+            phases.heaviestSpawnOtherMicroseconds = 50;
+            phases.heaviestSpawnBuildType = HeaviestSpawnBuildType.SphereFallback;
+
+            DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
+                40_100, 0, 1.0f, phases);
+
+            Assert.DoesNotContain(logLines, l => l.Contains("Playback spawn build breakdown"));
+
+            // Fire a real spawn-dominated spike (heaviest = 28.11ms, over threshold) next —
+            // the latch must still be armed so this one fires.
+            DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
+                40_100, 0, 1.0f, BimodalSingleSpawnPhases());
+            Assert.Contains(logLines, l => l.Contains("Playback spawn build breakdown"));
+        }
+
+        [Fact]
+        public void SpawnMaxZero_SuppressesBuildBreakdown()
+        {
+            // A budget spike with literally zero spawn time (pure mainLoop / deferred-events
+            // hitch) has nothing to attribute and must leave the latch armed.
             var phases = BimodalSingleSpawnPhases();
             phases.spawnMicroseconds = 0;
             phases.spawnMaxMicroseconds = 0;
@@ -158,11 +190,6 @@ namespace Parsek.Tests
                 40_100, 0, 1.0f, phases);
 
             Assert.DoesNotContain(logLines, l => l.Contains("Playback spawn build breakdown"));
-
-            // Fire a real spawn-dominated spike next — the latch must still be armed.
-            DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
-                40_100, 0, 1.0f, BimodalSingleSpawnPhases());
-            Assert.Contains(logLines, l => l.Contains("Playback spawn build breakdown"));
         }
 
         [Fact]

--- a/Source/Parsek.Tests/Bug450BuildBreakdownTests.cs
+++ b/Source/Parsek.Tests/Bug450BuildBreakdownTests.cs
@@ -1,0 +1,269 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Bug #450 instrumentation tests.
+    ///
+    /// A 40.1ms playback frame spike from `logs/2026-04-18_0221_v0.8.2-smoke` showed a single
+    /// spawn consuming 28.11ms on its own (`built=1 throttled=0 max=28.11ms`). The #414 count
+    /// cap is structurally useless here — only one spawn happened. Phase A adds per-sub-phase
+    /// attribution inside `BuildGhostVisualsWithMetrics` so the next such spike reveals which
+    /// bucket (snapshot resolve / timeline / dictionaries / reentry FX / other) dominates.
+    ///
+    /// These tests exercise <see cref="DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown"/>
+    /// by forcing a synthetic spike with non-zero sub-phase values and asserting:
+    ///  - the new "Playback spawn build breakdown" WARN fires exactly once (one-shot latch),
+    ///  - it contains every sub-phase field plus the heaviest-spawn breakdown,
+    ///  - the build-type enum renders as a human-readable token for every value,
+    ///  - the #450 latch is independent of #414's (so Phase A collects data even when the
+    ///    session's first spike already consumed #414's latch before rollout),
+    ///  - no build breakdown is emitted when `spawnMicroseconds == 0` (nothing to attribute),
+    ///  - ResetForTesting re-arms both latches.
+    /// </summary>
+    [Collection("Sequential")]
+    public class Bug450BuildBreakdownTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public Bug450BuildBreakdownTests()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+            ParsekLog.VerboseOverrideForTesting = true;
+            DiagnosticsState.ResetForTesting();
+            DiagnosticsComputation.ResetForTesting();
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+            DiagnosticsState.ResetForTesting();
+            DiagnosticsComputation.ResetForTesting();
+        }
+
+        private static PlaybackBudgetPhases BimodalSingleSpawnPhases()
+        {
+            // Represents the smoke-test 40.1ms spike: one spawn at 28.11ms, with attribution
+            // artificially split across the four sub-phases so tests can assert each renders.
+            // Aggregate == heaviest spawn because there was only one spawn this frame.
+            return new PlaybackBudgetPhases
+            {
+                mainLoopMicroseconds = 11_340,         // 11.34ms — from the real log line
+                spawnMicroseconds = 28_110,            // 28.11ms — single-spawn dominated frame
+                destroyMicroseconds = 0,
+                explosionCleanupMicroseconds = 0,
+                deferredCreatedEventsMicroseconds = 240,
+                deferredCompletedEventsMicroseconds = 0,
+                observabilityCaptureMicroseconds = 430,
+                trajectoriesIterated = 1,
+                createdEventsFired = 1,
+                completedEventsFired = 0,
+                spawnsAttempted = 1,
+                spawnsThrottled = 0,
+                spawnMaxMicroseconds = 28_110,
+
+                // Aggregate = heaviest spawn (only one spawn this frame).
+                buildSnapshotResolveMicroseconds = 110,       // 0.11ms — trivial lookup
+                buildTimelineFromSnapshotMicroseconds = 24_500, // 24.50ms — dominant suspect
+                buildDictionariesMicroseconds = 1_800,         // 1.80ms
+                buildReentryFxMicroseconds = 1_500,            // 1.50ms
+                buildOtherMicroseconds = 200,                   // 0.20ms residual
+
+                heaviestSpawnSnapshotResolveMicroseconds = 110,
+                heaviestSpawnTimelineFromSnapshotMicroseconds = 24_500,
+                heaviestSpawnDictionariesMicroseconds = 1_800,
+                heaviestSpawnReentryFxMicroseconds = 1_500,
+                heaviestSpawnOtherMicroseconds = 200,
+                heaviestSpawnBuildType = HeaviestSpawnBuildType.RecordingStartSnapshot,
+            };
+        }
+
+        [Fact]
+        public void AboveThreshold_FiresBuildBreakdownWarn_WithAllSubPhases()
+        {
+            DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
+                40_100, 0, 1.0f, BimodalSingleSpawnPhases());
+
+            var breakdownLine = logLines.FirstOrDefault(l =>
+                l.Contains("[WARN]") &&
+                l.Contains("[Diagnostics]") &&
+                l.Contains("Playback spawn build breakdown"));
+
+            Assert.NotNull(breakdownLine);
+            Assert.Contains("one-shot", breakdownLine);
+            // Aggregate row covers every sub-phase.
+            Assert.Contains("sum[snapshot=0.11ms", breakdownLine);
+            Assert.Contains("timeline=24.50ms", breakdownLine);
+            Assert.Contains("dicts=1.80ms", breakdownLine);
+            Assert.Contains("reentry=1.50ms", breakdownLine);
+            Assert.Contains("other=0.20ms", breakdownLine);
+            // Heaviest spawn row echoes the single-spawn attribution.
+            Assert.Contains("heaviestSpawn[type=recording-start-snapshot", breakdownLine);
+            Assert.Contains("snapshot=0.11ms", breakdownLine);
+            Assert.Contains("timeline=24.50ms", breakdownLine);
+            Assert.Contains("dicts=1.80ms", breakdownLine);
+            Assert.Contains("reentry=1.50ms", breakdownLine);
+            Assert.Contains("other=0.20ms", breakdownLine);
+            // Heaviest total reconciles: 0.11 + 24.50 + 1.80 + 1.50 + 0.20 = 28.11ms.
+            Assert.Contains("total=28.11ms", breakdownLine);
+        }
+
+        // Theory uses the enum's byte value (via InlineData) and casts inside — passing the
+        // internal enum type directly through a public method signature trips CS0051, and
+        // xUnit serializes InlineData args by value so keeping them primitive is idiomatic.
+        [Theory]
+        [InlineData((byte)1, "recording-start-snapshot")] // HeaviestSpawnBuildType.RecordingStartSnapshot
+        [InlineData((byte)2, "vessel-snapshot")]          // HeaviestSpawnBuildType.VesselSnapshot
+        [InlineData((byte)3, "sphere-fallback")]          // HeaviestSpawnBuildType.SphereFallback
+        [InlineData((byte)0, "none")]                     // HeaviestSpawnBuildType.None
+        public void BuildTypeEnum_RendersAsHumanReadableString(
+            byte buildTypeByte, string expectedToken)
+        {
+            var phases = BimodalSingleSpawnPhases();
+            phases.heaviestSpawnBuildType = (HeaviestSpawnBuildType)buildTypeByte;
+
+            DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
+                40_100, 0, 1.0f, phases);
+
+            var breakdownLine = logLines.FirstOrDefault(l =>
+                l.Contains("Playback spawn build breakdown"));
+            Assert.NotNull(breakdownLine);
+            Assert.Contains($"type={expectedToken}", breakdownLine);
+        }
+
+        [Fact]
+        public void SpawnMicrosecondsZero_SuppressesBuildBreakdown()
+        {
+            // A budget spike caused purely by mainLoop / deferred events with no spawn time
+            // has nothing to attribute across build sub-phases. Emitting five zeros under
+            // `heaviestSpawn[type=none ...]` would be noise; the latch must stay unfired so
+            // the next real spawn-dominated spike gets its diagnostic.
+            var phases = BimodalSingleSpawnPhases();
+            phases.spawnMicroseconds = 0;
+            phases.spawnMaxMicroseconds = 0;
+            phases.buildSnapshotResolveMicroseconds = 0;
+            phases.buildTimelineFromSnapshotMicroseconds = 0;
+            phases.buildDictionariesMicroseconds = 0;
+            phases.buildReentryFxMicroseconds = 0;
+            phases.buildOtherMicroseconds = 0;
+            phases.heaviestSpawnBuildType = HeaviestSpawnBuildType.None;
+
+            DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
+                40_100, 0, 1.0f, phases);
+
+            Assert.DoesNotContain(logLines, l => l.Contains("Playback spawn build breakdown"));
+
+            // Fire a real spawn-dominated spike next — the latch must still be armed.
+            DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
+                40_100, 0, 1.0f, BimodalSingleSpawnPhases());
+            Assert.Contains(logLines, l => l.Contains("Playback spawn build breakdown"));
+        }
+
+        [Fact]
+        public void LatchIsIndependentOfBug414Latch()
+        {
+            // Simulate the mid-session rollout case: a budget-exceeded spike already fired
+            // (and consumed #414's latch) BEFORE Phase A's code loaded into the running
+            // process. The #450 build breakdown must still fire on the next spike that
+            // actually contains build-phase data.
+            //
+            // We emulate "Phase A just loaded" by calling WithBreakdown twice: the first
+            // call populates the #414 latch; the second call should emit ONLY the #450
+            // build breakdown line (the #414 breakdown is latched out, but the build
+            // breakdown latch is independent).
+            DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
+                40_100, 0, 1.0f, BimodalSingleSpawnPhases());
+            int breakdownAfterFirst = logLines.Count(l => l.Contains("Playback budget breakdown"));
+            int buildBreakdownAfterFirst = logLines.Count(l => l.Contains("Playback spawn build breakdown"));
+            Assert.Equal(1, breakdownAfterFirst);
+            Assert.Equal(1, buildBreakdownAfterFirst);
+
+            // Second spike: both latches already consumed, neither line re-emits.
+            DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
+                42_000, 0, 1.0f, BimodalSingleSpawnPhases());
+            Assert.Equal(1, logLines.Count(l => l.Contains("Playback budget breakdown")));
+            Assert.Equal(1, logLines.Count(l => l.Contains("Playback spawn build breakdown")));
+        }
+
+        [Fact]
+        public void ResetForTesting_ReArmsBothLatches()
+        {
+            // Fire once.
+            DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
+                40_100, 0, 1.0f, BimodalSingleSpawnPhases());
+            Assert.Equal(1, logLines.Count(l => l.Contains("Playback spawn build breakdown")));
+
+            // Reset re-arms both the #414 and #450 latches, per
+            // ResetPlaybackBreakdownOneShotForTesting contract.
+            DiagnosticsComputation.ResetPlaybackBreakdownOneShotForTesting();
+            DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
+                40_100, 0, 1.0f, BimodalSingleSpawnPhases());
+            Assert.Equal(2, logLines.Count(l => l.Contains("Playback spawn build breakdown")));
+            Assert.Equal(2, logLines.Count(l => l.Contains("Playback budget breakdown")));
+        }
+
+        [Fact]
+        public void BelowThreshold_DoesNotFireBuildBreakdown()
+        {
+            // Healthy frame — 3ms total, under the 8ms threshold. No spike means no latch
+            // consumption on either line.
+            DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
+                3_000, 0, 1.0f, BimodalSingleSpawnPhases());
+
+            Assert.DoesNotContain(logLines, l => l.Contains("Playback spawn build breakdown"));
+
+            // Latch preserved — next real spike emits the breakdown.
+            DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
+                40_100, 0, 1.0f, BimodalSingleSpawnPhases());
+            Assert.Contains(logLines, l => l.Contains("Playback spawn build breakdown"));
+        }
+
+        [Fact]
+        public void MultipleSpawns_AggregateAndHeaviestAreDistinct()
+        {
+            // Two spawns this frame: one 20ms, one 8ms. Aggregate timeline = 20+8 = 28ms;
+            // heaviest spawn timeline = 20ms only. The log format must show both rows so a
+            // reviewer can tell "cost spread across spawns" from "single heavy spawn".
+            var phases = new PlaybackBudgetPhases
+            {
+                mainLoopMicroseconds = 2_000,
+                spawnMicroseconds = 28_000,
+                spawnMaxMicroseconds = 20_000,
+                spawnsAttempted = 2,
+
+                buildSnapshotResolveMicroseconds = 200,       // 0.10 + 0.10
+                buildTimelineFromSnapshotMicroseconds = 28_000, // aggregate of both spawns
+                buildDictionariesMicroseconds = 0,
+                buildReentryFxMicroseconds = 0,
+                buildOtherMicroseconds = 0,
+
+                heaviestSpawnSnapshotResolveMicroseconds = 100,
+                heaviestSpawnTimelineFromSnapshotMicroseconds = 19_800,
+                heaviestSpawnDictionariesMicroseconds = 0,
+                heaviestSpawnReentryFxMicroseconds = 0,
+                heaviestSpawnOtherMicroseconds = 100,
+                heaviestSpawnBuildType = HeaviestSpawnBuildType.VesselSnapshot,
+            };
+
+            DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
+                30_000, 0, 1.0f, phases);
+
+            var breakdownLine = logLines.FirstOrDefault(l =>
+                l.Contains("Playback spawn build breakdown"));
+            Assert.NotNull(breakdownLine);
+            // Aggregate captures both spawns.
+            Assert.Contains("sum[snapshot=0.20ms timeline=28.00ms", breakdownLine);
+            // Heaviest captures the 20ms one — type must match that spawn's classification.
+            Assert.Contains("heaviestSpawn[type=vessel-snapshot", breakdownLine);
+            Assert.Contains("timeline=19.80ms", breakdownLine);
+            // Heaviest total reconciles: 0.10 + 19.80 + 0 + 0 + 0.10 = 20.00ms.
+            Assert.Contains("total=20.00ms", breakdownLine);
+        }
+    }
+}

--- a/Source/Parsek.Tests/Bug450BuildBreakdownTests.cs
+++ b/Source/Parsek.Tests/Bug450BuildBreakdownTests.cs
@@ -170,21 +170,38 @@ namespace Parsek.Tests
         {
             // Simulate the mid-session rollout case: a budget-exceeded spike already fired
             // (and consumed #414's latch) BEFORE Phase A's code loaded into the running
-            // process. The #450 build breakdown must still fire on the next spike that
-            // actually contains build-phase data.
-            //
-            // We emulate "Phase A just loaded" by calling WithBreakdown twice: the first
-            // call populates the #414 latch; the second call should emit ONLY the #450
-            // build breakdown line (the #414 breakdown is latched out, but the build
-            // breakdown latch is independent).
+            // process. Use the #414-only test seam to pre-consume that latch without
+            // touching #450's. The next spike must still emit the #450 build breakdown
+            // (latch genuinely independent), while the #414 breakdown stays suppressed.
+            DiagnosticsComputation.SetBug414BreakdownLatchFiredForTesting();
+
             DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
                 40_100, 0, 1.0f, BimodalSingleSpawnPhases());
-            int breakdownAfterFirst = logLines.Count(l => l.Contains("Playback budget breakdown"));
-            int buildBreakdownAfterFirst = logLines.Count(l => l.Contains("Playback spawn build breakdown"));
-            Assert.Equal(1, breakdownAfterFirst);
-            Assert.Equal(1, buildBreakdownAfterFirst);
 
-            // Second spike: both latches already consumed, neither line re-emits.
+            // #414 breakdown must NOT fire — its latch was pre-consumed.
+            Assert.DoesNotContain(logLines, l => l.Contains("Playback budget breakdown"));
+            // #450 build breakdown fires because its latch is still armed.
+            Assert.Contains(logLines, l => l.Contains("Playback spawn build breakdown"));
+
+            // Second spike: both latches consumed now, neither breakdown line re-emits.
+            DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
+                42_000, 0, 1.0f, BimodalSingleSpawnPhases());
+            Assert.Equal(0, logLines.Count(l => l.Contains("Playback budget breakdown")));
+            Assert.Equal(1, logLines.Count(l => l.Contains("Playback spawn build breakdown")));
+        }
+
+        [Fact]
+        public void BothLatchesConsumeOnFreshSession_OneEmissionEach()
+        {
+            // On a fresh session with both latches armed, the first spike emits BOTH
+            // breakdowns once. Subsequent spikes emit neither. Complements the
+            // independence test — together they establish that the latches are
+            // separate state but fire in lockstep on the happy path.
+            DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
+                40_100, 0, 1.0f, BimodalSingleSpawnPhases());
+            Assert.Equal(1, logLines.Count(l => l.Contains("Playback budget breakdown")));
+            Assert.Equal(1, logLines.Count(l => l.Contains("Playback spawn build breakdown")));
+
             DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
                 42_000, 0, 1.0f, BimodalSingleSpawnPhases());
             Assert.Equal(1, logLines.Count(l => l.Contains("Playback budget breakdown")));

--- a/Source/Parsek/Diagnostics/DiagnosticsComputation.cs
+++ b/Source/Parsek/Diagnostics/DiagnosticsComputation.cs
@@ -687,6 +687,18 @@ namespace Parsek
         internal const double RecordingBudgetThresholdMs = 4.0;
 
         /// <summary>
+        /// Bug #450: minimum single-spawn cost (in microseconds) required before the
+        /// one-shot spawn-build breakdown WARN consumes its latch. Matches the 15 ms
+        /// figure the #450 todo entry proposes as the threshold where a spawn alone
+        /// exceeds the 8 ms frame budget enough to constitute the "bimodal" case a
+        /// count cap cannot cover. Gating on `spawnMaxMicroseconds` (not
+        /// `spawnMicroseconds` aggregate) means an incidental cheap prewarm or
+        /// watch-mode spawn on an otherwise non-spawn hitch cannot burn the
+        /// session's only #450 sample before the real regression fires.
+        /// </summary>
+        internal const long BuildBreakdownMinHeaviestSpawnMicroseconds = 15_000;
+
+        /// <summary>
         /// One-shot latch for the bug #414 per-phase breakdown log. Flipped true the first
         /// time a playback-budget-exceeded warning fires in the session; once latched, the
         /// breakdown is never re-emitted even on subsequent spikes. This keeps the steady-state
@@ -769,11 +781,17 @@ namespace Parsek
             }
 
             // Bug #450: emit the spawn-build sub-phase breakdown on its own one-shot latch.
-            // Skip when no spawn happened this frame — a budget spike with spawn=0 carries no
-            // useful attribution for the build path and would print a row of zeros. The latch
-            // is independent of #414's so Phase A collects data even when the session's first
+            // Gate on `spawnMaxMicroseconds >= BuildBreakdownMinHeaviestSpawnMicroseconds`
+            // (not just `spawnMicroseconds > 0`) so an incidental cheap prewarm or watch-
+            // mode spawn on a frame whose hitch was driven by something else cannot burn
+            // the session's only #450 sample before the real single-spawn regression fires.
+            // 15 ms is the threshold the #450 todo entry proposes as the bimodal line —
+            // above it, at least one spawn is, on its own, eating most of the frame budget,
+            // which is exactly the case Phase A is meant to diagnose. The latch itself is
+            // independent of #414's so Phase A collects data even when the session's first
             // spike already consumed the #414 latch before #450 rolled out.
-            if (!s_buildBreakdownOneShotFired && phases.spawnMicroseconds > 0)
+            if (!s_buildBreakdownOneShotFired
+                && phases.spawnMaxMicroseconds >= BuildBreakdownMinHeaviestSpawnMicroseconds)
             {
                 s_buildBreakdownOneShotFired = true;
                 ParsekLog.Warn("Diagnostics",

--- a/Source/Parsek/Diagnostics/DiagnosticsComputation.cs
+++ b/Source/Parsek/Diagnostics/DiagnosticsComputation.cs
@@ -696,6 +696,13 @@ namespace Parsek
         private static bool s_playbackBreakdownOneShotFired;
 
         /// <summary>
+        /// Bug #450: independent latch for the spawn-build sub-phase WARN. Separate from the
+        /// #414 latch so the build breakdown fires on the next spike after #450 rollout even
+        /// when the session's first budget-exceeded frame already consumed #414's latch.
+        /// </summary>
+        private static bool s_buildBreakdownOneShotFired;
+
+        /// <summary>
         /// Checks the playback budget and emits a rate-limited WARN if exceeded.
         /// Called by GhostPlaybackEngine after each frame. Pure static, testable.
         /// Kept for back-compat with existing call sites and tests that have no phase breakdown.
@@ -729,45 +736,94 @@ namespace Parsek
                     totalMs.ToString("F1", Inv), ghostsProcessed, warpRate.ToString("F0", Inv)),
                 30.0);
 
-            if (s_playbackBreakdownOneShotFired)
-                return;
+            if (!s_playbackBreakdownOneShotFired)
+            {
+                // One-shot: emit the phase breakdown on the very first exceeded frame. The breakdown
+                // is a plain WARN (not rate-limited) so it always lands next to the triggering
+                // budget-exceeded line in KSP.log regardless of the rate limiter's state for any
+                // future spikes. See bug #414 in docs/dev/todo-and-known-bugs.md.
+                s_playbackBreakdownOneShotFired = true;
+                ParsekLog.Warn("Diagnostics",
+                    string.Format(Inv,
+                        "Playback budget breakdown (one-shot, first exceeded frame): total={0}ms"
+                        + " mainLoop={1}ms spawn={2}ms (built={13} throttled={14} max={15}ms)"
+                        + " destroy={3}ms explosionCleanup={4}ms"
+                        + " deferredCreated={5}ms ({6} evts) deferredCompleted={7}ms ({8} evts)"
+                        + " observabilityCapture={9}ms trajectories={10} ghosts={11} warp={12}x",
+                        totalMs.ToString("F1", Inv),
+                        (phases.mainLoopMicroseconds / 1000.0).ToString("F2", Inv),
+                        (phases.spawnMicroseconds / 1000.0).ToString("F2", Inv),
+                        (phases.destroyMicroseconds / 1000.0).ToString("F2", Inv),
+                        (phases.explosionCleanupMicroseconds / 1000.0).ToString("F2", Inv),
+                        (phases.deferredCreatedEventsMicroseconds / 1000.0).ToString("F2", Inv),
+                        phases.createdEventsFired,
+                        (phases.deferredCompletedEventsMicroseconds / 1000.0).ToString("F2", Inv),
+                        phases.completedEventsFired,
+                        (phases.observabilityCaptureMicroseconds / 1000.0).ToString("F2", Inv),
+                        phases.trajectoriesIterated,
+                        ghostsProcessed,
+                        warpRate.ToString("F0", Inv),
+                        phases.spawnsAttempted,
+                        phases.spawnsThrottled,
+                        (phases.spawnMaxMicroseconds / 1000.0).ToString("F2", Inv)));
+            }
 
-            // One-shot: emit the phase breakdown on the very first exceeded frame. The breakdown
-            // is a plain WARN (not rate-limited) so it always lands next to the triggering
-            // budget-exceeded line in KSP.log regardless of the rate limiter's state for any
-            // future spikes. See bug #414 in docs/dev/todo-and-known-bugs.md.
-            s_playbackBreakdownOneShotFired = true;
-            ParsekLog.Warn("Diagnostics",
-                string.Format(Inv,
-                    "Playback budget breakdown (one-shot, first exceeded frame): total={0}ms"
-                    + " mainLoop={1}ms spawn={2}ms (built={13} throttled={14} max={15}ms)"
-                    + " destroy={3}ms explosionCleanup={4}ms"
-                    + " deferredCreated={5}ms ({6} evts) deferredCompleted={7}ms ({8} evts)"
-                    + " observabilityCapture={9}ms trajectories={10} ghosts={11} warp={12}x",
-                    totalMs.ToString("F1", Inv),
-                    (phases.mainLoopMicroseconds / 1000.0).ToString("F2", Inv),
-                    (phases.spawnMicroseconds / 1000.0).ToString("F2", Inv),
-                    (phases.destroyMicroseconds / 1000.0).ToString("F2", Inv),
-                    (phases.explosionCleanupMicroseconds / 1000.0).ToString("F2", Inv),
-                    (phases.deferredCreatedEventsMicroseconds / 1000.0).ToString("F2", Inv),
-                    phases.createdEventsFired,
-                    (phases.deferredCompletedEventsMicroseconds / 1000.0).ToString("F2", Inv),
-                    phases.completedEventsFired,
-                    (phases.observabilityCaptureMicroseconds / 1000.0).ToString("F2", Inv),
-                    phases.trajectoriesIterated,
-                    ghostsProcessed,
-                    warpRate.ToString("F0", Inv),
-                    phases.spawnsAttempted,
-                    phases.spawnsThrottled,
-                    (phases.spawnMaxMicroseconds / 1000.0).ToString("F2", Inv)));
+            // Bug #450: emit the spawn-build sub-phase breakdown on its own one-shot latch.
+            // Skip when no spawn happened this frame — a budget spike with spawn=0 carries no
+            // useful attribution for the build path and would print a row of zeros. The latch
+            // is independent of #414's so Phase A collects data even when the session's first
+            // spike already consumed the #414 latch before #450 rolled out.
+            if (!s_buildBreakdownOneShotFired && phases.spawnMicroseconds > 0)
+            {
+                s_buildBreakdownOneShotFired = true;
+                ParsekLog.Warn("Diagnostics",
+                    string.Format(Inv,
+                        "Playback spawn build breakdown (one-shot): "
+                        + "sum[snapshot={0}ms timeline={1}ms dicts={2}ms reentry={3}ms other={4}ms] "
+                        + "heaviestSpawn[type={5} snapshot={6}ms timeline={7}ms dicts={8}ms reentry={9}ms other={10}ms total={11}ms]",
+                        (phases.buildSnapshotResolveMicroseconds / 1000.0).ToString("F2", Inv),
+                        (phases.buildTimelineFromSnapshotMicroseconds / 1000.0).ToString("F2", Inv),
+                        (phases.buildDictionariesMicroseconds / 1000.0).ToString("F2", Inv),
+                        (phases.buildReentryFxMicroseconds / 1000.0).ToString("F2", Inv),
+                        (phases.buildOtherMicroseconds / 1000.0).ToString("F2", Inv),
+                        FormatHeaviestSpawnBuildType(phases.heaviestSpawnBuildType),
+                        (phases.heaviestSpawnSnapshotResolveMicroseconds / 1000.0).ToString("F2", Inv),
+                        (phases.heaviestSpawnTimelineFromSnapshotMicroseconds / 1000.0).ToString("F2", Inv),
+                        (phases.heaviestSpawnDictionariesMicroseconds / 1000.0).ToString("F2", Inv),
+                        (phases.heaviestSpawnReentryFxMicroseconds / 1000.0).ToString("F2", Inv),
+                        (phases.heaviestSpawnOtherMicroseconds / 1000.0).ToString("F2", Inv),
+                        ((phases.heaviestSpawnSnapshotResolveMicroseconds
+                            + phases.heaviestSpawnTimelineFromSnapshotMicroseconds
+                            + phases.heaviestSpawnDictionariesMicroseconds
+                            + phases.heaviestSpawnReentryFxMicroseconds
+                            + phases.heaviestSpawnOtherMicroseconds) / 1000.0).ToString("F2", Inv)));
+            }
         }
 
         /// <summary>
-        /// Test-only: reset the bug #414 one-shot breakdown latch so each test starts clean.
+        /// Bug #450: map the byte-backed enum to a log-friendly string. Kept in the format
+        /// layer so the struct stays allocation-free during hot-path writes.
+        /// </summary>
+        private static string FormatHeaviestSpawnBuildType(HeaviestSpawnBuildType buildType)
+        {
+            switch (buildType)
+            {
+                case HeaviestSpawnBuildType.RecordingStartSnapshot: return "recording-start-snapshot";
+                case HeaviestSpawnBuildType.VesselSnapshot: return "vessel-snapshot";
+                case HeaviestSpawnBuildType.SphereFallback: return "sphere-fallback";
+                default: return "none";
+            }
+        }
+
+        /// <summary>
+        /// Test-only: reset the bug #414 and #450 one-shot breakdown latches so each test
+        /// starts clean. Callers that only want one latch cleared should read the field
+        /// directly via a dedicated helper; in practice every test path clears both.
         /// </summary>
         internal static void ResetPlaybackBreakdownOneShotForTesting()
         {
             s_playbackBreakdownOneShotFired = false;
+            s_buildBreakdownOneShotFired = false;
         }
 
         /// <summary>
@@ -832,6 +888,7 @@ namespace Parsek
         {
             ClockSource = null;
             s_playbackBreakdownOneShotFired = false;
+            s_buildBreakdownOneShotFired = false;
         }
     }
 }

--- a/Source/Parsek/Diagnostics/DiagnosticsComputation.cs
+++ b/Source/Parsek/Diagnostics/DiagnosticsComputation.cs
@@ -786,7 +786,7 @@ namespace Parsek
                         (phases.buildDictionariesMicroseconds / 1000.0).ToString("F2", Inv),
                         (phases.buildReentryFxMicroseconds / 1000.0).ToString("F2", Inv),
                         (phases.buildOtherMicroseconds / 1000.0).ToString("F2", Inv),
-                        FormatHeaviestSpawnBuildType(phases.heaviestSpawnBuildType),
+                        phases.heaviestSpawnBuildType.ToLogToken(),
                         (phases.heaviestSpawnSnapshotResolveMicroseconds / 1000.0).ToString("F2", Inv),
                         (phases.heaviestSpawnTimelineFromSnapshotMicroseconds / 1000.0).ToString("F2", Inv),
                         (phases.heaviestSpawnDictionariesMicroseconds / 1000.0).ToString("F2", Inv),
@@ -800,30 +800,28 @@ namespace Parsek
             }
         }
 
-        /// <summary>
-        /// Bug #450: map the byte-backed enum to a log-friendly string. Kept in the format
-        /// layer so the struct stays allocation-free during hot-path writes.
-        /// </summary>
-        private static string FormatHeaviestSpawnBuildType(HeaviestSpawnBuildType buildType)
-        {
-            switch (buildType)
-            {
-                case HeaviestSpawnBuildType.RecordingStartSnapshot: return "recording-start-snapshot";
-                case HeaviestSpawnBuildType.VesselSnapshot: return "vessel-snapshot";
-                case HeaviestSpawnBuildType.SphereFallback: return "sphere-fallback";
-                default: return "none";
-            }
-        }
 
         /// <summary>
         /// Test-only: reset the bug #414 and #450 one-shot breakdown latches so each test
-        /// starts clean. Callers that only want one latch cleared should read the field
-        /// directly via a dedicated helper; in practice every test path clears both.
+        /// starts clean. Use <see cref="SetBug414BreakdownLatchFiredForTesting"/> when a
+        /// test needs to pre-consume just the #414 latch.
         /// </summary>
         internal static void ResetPlaybackBreakdownOneShotForTesting()
         {
             s_playbackBreakdownOneShotFired = false;
             s_buildBreakdownOneShotFired = false;
+        }
+
+        /// <summary>
+        /// Bug #450 test seam: flip the #414 breakdown latch without touching #450's latch,
+        /// so a test can simulate the mid-session rollout case where the session's first
+        /// budget-exceeded frame already consumed the #414 latch BEFORE Phase A's code
+        /// loaded. Without this helper the "latch independence" test can only verify that
+        /// both latches consume in lockstep, not that they are independent.
+        /// </summary>
+        internal static void SetBug414BreakdownLatchFiredForTesting()
+        {
+            s_playbackBreakdownOneShotFired = true;
         }
 
         /// <summary>

--- a/Source/Parsek/Diagnostics/DiagnosticsStructs.cs
+++ b/Source/Parsek/Diagnostics/DiagnosticsStructs.cs
@@ -35,6 +35,20 @@ namespace Parsek
     }
 
     /// <summary>
+    /// Bug #450: build-path classification for the heaviest single spawn of a frame.
+    /// Byte-backed so <see cref="PlaybackBudgetPhases"/> stays a pure value type with no
+    /// heap references in the hot playback loop. Mapped to a human-readable string only
+    /// at WARN format time in <see cref="DiagnosticsComputation"/>.
+    /// </summary>
+    internal enum HeaviestSpawnBuildType : byte
+    {
+        None = 0,
+        RecordingStartSnapshot = 1,
+        VesselSnapshot = 2,
+        SphereFallback = 3
+    }
+
+    /// <summary>
     /// One-shot per-phase breakdown of a single UpdatePlayback frame, captured only
     /// when the first playback-budget-exceeded warning fires (see bug #414). Used by
     /// <see cref="DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown"/>
@@ -69,6 +83,36 @@ namespace Parsek
         public int spawnsThrottled;
         /// <summary>Bug #414: largest single BuildGhostVisualsWithMetrics cost in microseconds this frame. Tells us whether any individual ghost blows the budget.</summary>
         public long spawnMaxMicroseconds;
+
+        // --- Bug #450: per-sub-phase build attribution ---
+        // Aggregate (summed across every BuildGhostVisualsWithMetrics call this frame).
+        /// <summary>Bug #450: aggregate time in GetGhostSnapshot resolution across all spawns this frame.</summary>
+        public long buildSnapshotResolveMicroseconds;
+        /// <summary>Bug #450: aggregate time in BuildTimelineGhostFromSnapshot / CreateGhostSphere across all spawns this frame (the dominant suspect for bimodal cost).</summary>
+        public long buildTimelineFromSnapshotMicroseconds;
+        /// <summary>Bug #450: aggregate time in BuildPartSubtreeMap + logical-id set + PopulateGhostInfoDictionaries + inventory/compound visibility across all spawns this frame.</summary>
+        public long buildDictionariesMicroseconds;
+        /// <summary>Bug #450: aggregate time in TryBuildReentryFx across all spawns this frame (conditional on HasReentryPotential).</summary>
+        public long buildReentryFxMicroseconds;
+        /// <summary>Bug #450: aggregate residual time inside BuildGhostVisualsWithMetrics not attributed to any other sub-phase (camera pivot, materials, MaterialPropertyBlock, activeSelf toggle, appearance reset).</summary>
+        public long buildOtherMicroseconds;
+
+        // Heaviest-spawn breakdown: latched on whichever single BuildGhostVisualsWithMetrics
+        // call produced the largest delta this frame (ties broken by "first wins"). This
+        // preserves the bimodal signal that motivated #450 — if one spawn dominates, its
+        // sub-phase attribution survives even when other cheap spawns run alongside.
+        /// <summary>Bug #450: the heaviest single spawn's GetGhostSnapshot time.</summary>
+        public long heaviestSpawnSnapshotResolveMicroseconds;
+        /// <summary>Bug #450: the heaviest single spawn's BuildTimelineGhostFromSnapshot / CreateGhostSphere time.</summary>
+        public long heaviestSpawnTimelineFromSnapshotMicroseconds;
+        /// <summary>Bug #450: the heaviest single spawn's dictionaries phase time.</summary>
+        public long heaviestSpawnDictionariesMicroseconds;
+        /// <summary>Bug #450: the heaviest single spawn's TryBuildReentryFx time.</summary>
+        public long heaviestSpawnReentryFxMicroseconds;
+        /// <summary>Bug #450: the heaviest single spawn's residual time (total − attributed sub-phases). Preserves the sum+residual = spawnMax invariant.</summary>
+        public long heaviestSpawnOtherMicroseconds;
+        /// <summary>Bug #450: build-path classification of the heaviest single spawn this frame.</summary>
+        public HeaviestSpawnBuildType heaviestSpawnBuildType;
     }
 
     /// <summary>

--- a/Source/Parsek/Diagnostics/DiagnosticsStructs.cs
+++ b/Source/Parsek/Diagnostics/DiagnosticsStructs.cs
@@ -37,8 +37,9 @@ namespace Parsek
     /// <summary>
     /// Bug #450: build-path classification for the heaviest single spawn of a frame.
     /// Byte-backed so <see cref="PlaybackBudgetPhases"/> stays a pure value type with no
-    /// heap references in the hot playback loop. Mapped to a human-readable string only
-    /// at WARN format time in <see cref="DiagnosticsComputation"/>.
+    /// heap references in the hot playback loop. Plumbed directly through the spawn path
+    /// as an out-param — the WARN format layer calls <see cref="HeaviestSpawnBuildTypeExtensions.ToLogToken"/>
+    /// for the single human-readable rendering.
     /// </summary>
     internal enum HeaviestSpawnBuildType : byte
     {
@@ -46,6 +47,26 @@ namespace Parsek
         RecordingStartSnapshot = 1,
         VesselSnapshot = 2,
         SphereFallback = 3
+    }
+
+    /// <summary>
+    /// Bug #450: single source of truth for the enum → log-token mapping. Lives next to the
+    /// enum so the spawn-side build log and the breakdown WARN cannot drift apart. Avoids
+    /// the brittle string-equality coupling that a prior revision had between
+    /// GhostPlaybackEngine.ClassifyBuildType and DiagnosticsComputation.FormatHeaviestSpawnBuildType.
+    /// </summary>
+    internal static class HeaviestSpawnBuildTypeExtensions
+    {
+        internal static string ToLogToken(this HeaviestSpawnBuildType buildType)
+        {
+            switch (buildType)
+            {
+                case HeaviestSpawnBuildType.RecordingStartSnapshot: return "recording-start-snapshot";
+                case HeaviestSpawnBuildType.VesselSnapshot: return "vessel-snapshot";
+                case HeaviestSpawnBuildType.SphereFallback: return "sphere-fallback";
+                default: return "none";
+            }
+        }
     }
 
     /// <summary>
@@ -94,7 +115,7 @@ namespace Parsek
         public long buildDictionariesMicroseconds;
         /// <summary>Bug #450: aggregate time in TryBuildReentryFx across all spawns this frame (conditional on HasReentryPotential).</summary>
         public long buildReentryFxMicroseconds;
-        /// <summary>Bug #450: aggregate residual time inside BuildGhostVisualsWithMetrics not attributed to any other sub-phase (camera pivot, materials, MaterialPropertyBlock, activeSelf toggle, appearance reset).</summary>
+        /// <summary>Bug #450: aggregate residual time inside BuildGhostVisualsWithMetrics not attributed to any other sub-phase (camera pivot + horizonProxy GameObject construction, MaterialPropertyBlock allocation, activeSelf toggle, appearance reset). Materials-list allocation sits inside the dictionaries window — see GhostPlaybackEngine.TryPopulateGhostVisuals for exact attribution.</summary>
         public long buildOtherMicroseconds;
 
         // Heaviest-spawn breakdown: latched on whichever single BuildGhostVisualsWithMetrics

--- a/Source/Parsek/GhostPlaybackEngine.cs
+++ b/Source/Parsek/GhostPlaybackEngine.cs
@@ -2407,23 +2407,23 @@ namespace Parsek
             buildDictionariesStopwatch.Stop();
             lastSpawnDictionariesTicks = buildDictionariesStopwatch.ElapsedTicks - dictionariesPre;
 
-            // Bug #450 sub-phase 4: reentry FX. Only timed on the HasReentryPotential branch
-            // — the skip branch is trivial (a VerboseRateLimited log and a counter bump) and
-            // lumping it in with the build path would muddy the attribution. On the skip
-            // branch lastSpawnReentryTicks stays 0, which correctly reflects zero work.
+            // Bug #450 sub-phase 4: reentry FX. Bracket the ENTIRE reentry decision
+            // (classification + build or skip) in a single window so the O(n)
+            // HasReentryPotential scan over trajectory points on non-orbital recordings
+            // is attributed to the reentry bucket rather than leaking into "other". If
+            // the scan dominated and we lumped it into "other", Phase B would see a big
+            // residual and pick the wrong fix branch.
             // Gate reentry FX build: stationary part-showcase ghosts, EVA walks, and slow
             // suborbital hops below Mach 1.5 can never produce reentry visuals, so we skip
             // the mesh-combine + ParticleSystem + glow-material clone work entirely. With
             // hundreds of ghosts looping, rebuilding reentry FX on every loop-cycle
             // boundary was the dominant cost in the map-view perf tank (#406).
+            long reentryPre = buildReentryFxStopwatch.ElapsedTicks;
+            buildReentryFxStopwatch.Start();
             if (TrajectoryMath.HasReentryPotential(traj))
             {
-                long reentryPre = buildReentryFxStopwatch.ElapsedTicks;
-                buildReentryFxStopwatch.Start();
                 state.reentryFxInfo = GhostVisualBuilder.TryBuildReentryFx(
                     ghost, state.heatInfos, index, traj.VesselName);
-                buildReentryFxStopwatch.Stop();
-                lastSpawnReentryTicks = buildReentryFxStopwatch.ElapsedTicks - reentryPre;
                 DiagnosticsState.health.reentryFxBuildsThisSession++;
             }
             else
@@ -2435,6 +2435,8 @@ namespace Parsek
                     $"— trajectory peak speed below {TrajectoryMath.ReentryPotentialSpeedFloor:F0} m/s " +
                     $"and no orbit segments (cannot produce reentry visuals)", 5.0);
             }
+            buildReentryFxStopwatch.Stop();
+            lastSpawnReentryTicks = buildReentryFxStopwatch.ElapsedTicks - reentryPre;
             state.reentryMpb = new MaterialPropertyBlock();
 
             // Keep fresh builds hidden until the playback loop has positioned them at the

--- a/Source/Parsek/GhostPlaybackEngine.cs
+++ b/Source/Parsek/GhostPlaybackEngine.cs
@@ -79,6 +79,27 @@ namespace Parsek
         // so the breakdown WARN reveals whether one ghost alone is blowing the budget.
         private long frameMaxSpawnTicks;
 
+        // Bug #450: per-sub-phase tick accumulators captured while processing the single
+        // spawn that is the new heaviest of this frame. Latched inside the finally block of
+        // BuildGhostVisualsWithMetrics when deltaTicks > frameMaxSpawnTicks. Reset each frame.
+        // Surfaced via PlaybackBudgetPhases.heaviestSpawn* so the one-shot breakdown WARN can
+        // attribute a single heavy spawn's cost across snapshot / timeline / dicts / reentry.
+        private long frameHeaviestSpawnSnapshotResolveTicks;
+        private long frameHeaviestSpawnTimelineTicks;
+        private long frameHeaviestSpawnDictionariesTicks;
+        private long frameHeaviestSpawnReentryTicks;
+        private long frameHeaviestSpawnOtherTicks;
+        private HeaviestSpawnBuildType frameHeaviestSpawnBuildType;
+
+        // Bug #450: "last spawn" per-sub-phase tick deltas written by TryPopulateGhostVisuals
+        // and read by BuildGhostVisualsWithMetrics.finally when deciding whether this call is
+        // the new frame heaviest. Reset at the start of TryPopulateGhostVisuals to guarantee
+        // stale values from a prior call cannot leak into a later spawn's attribution.
+        private long lastSpawnSnapshotResolveTicks;
+        private long lastSpawnTimelineTicks;
+        private long lastSpawnDictionariesTicks;
+        private long lastSpawnReentryTicks;
+
         // Diagnostics: reusable Stopwatches (allocated once, no per-frame GC)
         private readonly Stopwatch updateStopwatch = new Stopwatch();
         private readonly Stopwatch spawnStopwatch = new Stopwatch();
@@ -90,6 +111,15 @@ namespace Parsek
         private readonly Stopwatch deferredCreatedStopwatch = new Stopwatch();
         private readonly Stopwatch deferredCompletedStopwatch = new Stopwatch();
         private readonly Stopwatch observabilityStopwatch = new Stopwatch();
+        // Bug #450: per-sub-phase spawn stopwatches. Accumulate across every spawn in the
+        // frame; ElapsedTicks at populate time gives the aggregate surfaced via
+        // PlaybackBudgetPhases.build*Microseconds. Per-call deltas (captured via pre-call
+        // ElapsedTicks + post-call subtraction, identical to the #414 spawnStopwatch pattern)
+        // feed the heaviest-spawn latch. Zero per-frame GC.
+        private readonly Stopwatch buildSnapshotResolveStopwatch = new Stopwatch();
+        private readonly Stopwatch buildTimelineStopwatch = new Stopwatch();
+        private readonly Stopwatch buildDictionariesStopwatch = new Stopwatch();
+        private readonly Stopwatch buildReentryFxStopwatch = new Stopwatch();
 
         // Deferred event lists (reused per frame to avoid GC allocation)
         private readonly List<PlaybackCompletedEvent> deferredCompletedEvents = new List<PlaybackCompletedEvent>();
@@ -312,6 +342,14 @@ namespace Parsek
             frameDestroyCount = 0;
             frameSpawnDeferred = 0;
             frameMaxSpawnTicks = 0;
+            // Bug #450: reset per-frame heaviest-spawn breakdown fields so the latch starts
+            // empty each frame. No heaviest spawn yet -> HeaviestSpawnBuildType.None.
+            frameHeaviestSpawnSnapshotResolveTicks = 0;
+            frameHeaviestSpawnTimelineTicks = 0;
+            frameHeaviestSpawnDictionariesTicks = 0;
+            frameHeaviestSpawnReentryTicks = 0;
+            frameHeaviestSpawnOtherTicks = 0;
+            frameHeaviestSpawnBuildType = HeaviestSpawnBuildType.None;
 
             // Diagnostics: start total frame timing
             updateStopwatch.Restart();
@@ -325,6 +363,11 @@ namespace Parsek
             deferredCreatedStopwatch.Reset();
             deferredCompletedStopwatch.Reset();
             observabilityStopwatch.Reset();
+            // Bug #450: reset per-sub-phase spawn stopwatches (same pattern as #414).
+            buildSnapshotResolveStopwatch.Reset();
+            buildTimelineStopwatch.Reset();
+            buildDictionariesStopwatch.Reset();
+            buildReentryFxStopwatch.Reset();
             long spawnMicroseconds = 0;
             int ghostsProcessed = 0;
             int trajectoriesIterated = 0;
@@ -585,6 +628,22 @@ namespace Parsek
             long elapsedMicrosecondsAtLoopEnd = elapsedTicksAtLoopEnd * 1000000L / Stopwatch.Frequency;
             long mainLoopMicroseconds = elapsedMicrosecondsAtLoopEnd - spawnMicroseconds - destroyMicroseconds;
             if (mainLoopMicroseconds < 0) mainLoopMicroseconds = 0;
+            // Bug #450: per-sub-phase aggregate = sum across all spawns in the frame.
+            long buildSnapshotResolveMicroseconds = buildSnapshotResolveStopwatch.ElapsedTicks * 1000000L / Stopwatch.Frequency;
+            long buildTimelineFromSnapshotMicroseconds = buildTimelineStopwatch.ElapsedTicks * 1000000L / Stopwatch.Frequency;
+            long buildDictionariesMicroseconds = buildDictionariesStopwatch.ElapsedTicks * 1000000L / Stopwatch.Frequency;
+            long buildReentryFxMicroseconds = buildReentryFxStopwatch.ElapsedTicks * 1000000L / Stopwatch.Frequency;
+            // Residual = outer spawn time − attributed sub-phases (covers camera pivot,
+            // materials, MaterialPropertyBlock, SetActive, appearance reset). Floors at 0 so
+            // sub-microsecond rounding between the four sub-phase ticks and spawnMicroseconds
+            // cannot produce a negative.
+            long buildOtherMicroseconds = spawnMicroseconds
+                - buildSnapshotResolveMicroseconds
+                - buildTimelineFromSnapshotMicroseconds
+                - buildDictionariesMicroseconds
+                - buildReentryFxMicroseconds;
+            if (buildOtherMicroseconds < 0) buildOtherMicroseconds = 0;
+
             var phases = new PlaybackBudgetPhases
             {
                 mainLoopMicroseconds = mainLoopMicroseconds,
@@ -600,6 +659,20 @@ namespace Parsek
                 spawnsAttempted = frameSpawnCount,
                 spawnsThrottled = frameSpawnDeferred,
                 spawnMaxMicroseconds = frameMaxSpawnTicks * 1000000L / Stopwatch.Frequency,
+                // Bug #450: per-sub-phase aggregate across every spawn this frame.
+                buildSnapshotResolveMicroseconds = buildSnapshotResolveMicroseconds,
+                buildTimelineFromSnapshotMicroseconds = buildTimelineFromSnapshotMicroseconds,
+                buildDictionariesMicroseconds = buildDictionariesMicroseconds,
+                buildReentryFxMicroseconds = buildReentryFxMicroseconds,
+                buildOtherMicroseconds = buildOtherMicroseconds,
+                // Bug #450: heaviest-spawn breakdown (latched on whichever single
+                // BuildGhostVisualsWithMetrics call produced the largest delta).
+                heaviestSpawnSnapshotResolveMicroseconds = frameHeaviestSpawnSnapshotResolveTicks * 1000000L / Stopwatch.Frequency,
+                heaviestSpawnTimelineFromSnapshotMicroseconds = frameHeaviestSpawnTimelineTicks * 1000000L / Stopwatch.Frequency,
+                heaviestSpawnDictionariesMicroseconds = frameHeaviestSpawnDictionariesTicks * 1000000L / Stopwatch.Frequency,
+                heaviestSpawnReentryFxMicroseconds = frameHeaviestSpawnReentryTicks * 1000000L / Stopwatch.Frequency,
+                heaviestSpawnOtherMicroseconds = frameHeaviestSpawnOtherTicks * 1000000L / Stopwatch.Frequency,
+                heaviestSpawnBuildType = frameHeaviestSpawnBuildType,
             };
 
             // Budget threshold warning (8ms = half of 16.6ms frame budget at 60fps).
@@ -2155,10 +2228,44 @@ namespace Parsek
                 spawnStopwatch.Stop();
                 long deltaTicks = spawnStopwatch.ElapsedTicks - preCallTicks;
                 if (deltaTicks > frameMaxSpawnTicks)
+                {
                     frameMaxSpawnTicks = deltaTicks;
+                    // Bug #450: this call is the new frame-heaviest — latch its sub-phase
+                    // breakdown so the one-shot WARN can attribute whichever single spawn
+                    // dominates. Copy the per-call deltas set by TryPopulateGhostVisuals;
+                    // "other" is the residual that preserves the sum+residual = delta
+                    // invariant the tests assert.
+                    frameHeaviestSpawnSnapshotResolveTicks = lastSpawnSnapshotResolveTicks;
+                    frameHeaviestSpawnTimelineTicks = lastSpawnTimelineTicks;
+                    frameHeaviestSpawnDictionariesTicks = lastSpawnDictionariesTicks;
+                    frameHeaviestSpawnReentryTicks = lastSpawnReentryTicks;
+                    long attributedTicks =
+                        lastSpawnSnapshotResolveTicks
+                        + lastSpawnTimelineTicks
+                        + lastSpawnDictionariesTicks
+                        + lastSpawnReentryTicks;
+                    long otherTicks = deltaTicks - attributedTicks;
+                    frameHeaviestSpawnOtherTicks = otherTicks < 0 ? 0 : otherTicks;
+                    frameHeaviestSpawnBuildType = ClassifyBuildType(buildType);
+                }
                 if (built)
                     DiagnosticsState.health.ghostBuildsThisSession++;
             }
+        }
+
+        /// <summary>
+        /// Bug #450: map the human-readable buildType strings produced by
+        /// TryPopulateGhostVisuals onto the byte-backed HeaviestSpawnBuildType enum.
+        /// Returns None when the build failed (buildType == null) or a new build type
+        /// was added without updating this map — both are safe default behaviour (the
+        /// breakdown WARN renders "None" so the gap is visible in logs).
+        /// </summary>
+        private static HeaviestSpawnBuildType ClassifyBuildType(string buildType)
+        {
+            if (buildType == "recording-start snapshot") return HeaviestSpawnBuildType.RecordingStartSnapshot;
+            if (buildType == "vessel snapshot") return HeaviestSpawnBuildType.VesselSnapshot;
+            if (buildType == "sphere fallback") return HeaviestSpawnBuildType.SphereFallback;
+            return HeaviestSpawnBuildType.None;
         }
 
         /// <summary>
@@ -2196,6 +2303,22 @@ namespace Parsek
             frameDestroyCount = 0;
             frameSpawnDeferred = 0;
             frameMaxSpawnTicks = 0;
+            // Bug #450: mirror the production per-frame reset at UpdatePlayback's head so
+            // test seams see a clean heaviest-spawn latch.
+            frameHeaviestSpawnSnapshotResolveTicks = 0;
+            frameHeaviestSpawnTimelineTicks = 0;
+            frameHeaviestSpawnDictionariesTicks = 0;
+            frameHeaviestSpawnReentryTicks = 0;
+            frameHeaviestSpawnOtherTicks = 0;
+            frameHeaviestSpawnBuildType = HeaviestSpawnBuildType.None;
+            lastSpawnSnapshotResolveTicks = 0;
+            lastSpawnTimelineTicks = 0;
+            lastSpawnDictionariesTicks = 0;
+            lastSpawnReentryTicks = 0;
+            buildSnapshotResolveStopwatch.Reset();
+            buildTimelineStopwatch.Reset();
+            buildDictionariesStopwatch.Reset();
+            buildReentryFxStopwatch.Reset();
         }
 
         private bool TryPopulateGhostVisuals(
@@ -2203,6 +2326,15 @@ namespace Parsek
             out string buildType)
         {
             buildType = null;
+            // Bug #450: reset per-call sub-phase deltas so a prior (shorter-lived) spawn's
+            // attribution cannot leak into this call's heaviest-spawn latch. Each delta is
+            // captured via pre/post Start-Stop subtraction below, matching the #414
+            // spawnStopwatch pattern.
+            lastSpawnSnapshotResolveTicks = 0;
+            lastSpawnTimelineTicks = 0;
+            lastSpawnDictionariesTicks = 0;
+            lastSpawnReentryTicks = 0;
+
             if (state == null)
                 return false;
 
@@ -2210,8 +2342,22 @@ namespace Parsek
             GhostBuildResult buildResult = null;
             GameObject ghost = null;
             bool builtFromSnapshot = false;
-            ConfigNode snapshot = GhostVisualBuilder.GetGhostSnapshot(traj);
 
+            // Bug #450 sub-phase 1: snapshot resolve. Included even though it's trivial so
+            // the breakdown reconciles — callers reading the log can sanity-check that
+            // snapshot+timeline+dicts+reentry+other ≈ spawnMax.
+            long snapshotResolvePre = buildSnapshotResolveStopwatch.ElapsedTicks;
+            buildSnapshotResolveStopwatch.Start();
+            ConfigNode snapshot = GhostVisualBuilder.GetGhostSnapshot(traj);
+            buildSnapshotResolveStopwatch.Stop();
+            lastSpawnSnapshotResolveTicks = buildSnapshotResolveStopwatch.ElapsedTicks - snapshotResolvePre;
+
+            // Bug #450 sub-phase 2: timeline build (the dominant suspect). Covers both the
+            // snapshot path (BuildTimelineGhostFromSnapshot — part instantiation, engine FX
+            // size-boost, audio wiring) and the sphere fallback (CreateGhostSphere). Grouping
+            // them gives a single bucket for "ghost GameObject construction".
+            long timelinePre = buildTimelineStopwatch.ElapsedTicks;
+            buildTimelineStopwatch.Start();
             // Skip expensive snapshot build when no snapshot exists — go straight to sphere fallback.
             if (snapshot != null)
             {
@@ -2224,6 +2370,9 @@ namespace Parsek
 
             if (ghost == null)
                 ghost = GhostVisualBuilder.CreateGhostSphere($"Parsek_Timeline_{index}", ghostColor);
+            buildTimelineStopwatch.Stop();
+            lastSpawnTimelineTicks = buildTimelineStopwatch.ElapsedTicks - timelinePre;
+
             if (ghost == null)
                 return false;
 
@@ -2237,6 +2386,13 @@ namespace Parsek
             state.ghost = ghost;
             state.cameraPivot = cameraPivotObj.transform;
             state.horizonProxy = horizonProxyObj.transform;
+
+            // Bug #450 sub-phase 3: dictionaries. Subtree map + logical-id set +
+            // PopulateGhostInfoDictionaries + inventory/compound visibility are all
+            // snapshot-walk consumers; grouped as one bucket because splitting at this
+            // granularity isn't actionable for a Phase B fix.
+            long dictionariesPre = buildDictionariesStopwatch.ElapsedTicks;
+            buildDictionariesStopwatch.Start();
             state.partTree = GhostVisualBuilder.BuildPartSubtreeMap(snapshot);
             state.logicalPartIds = GhostVisualBuilder.BuildSnapshotPartIdSet(snapshot);
 
@@ -2253,7 +2409,13 @@ namespace Parsek
             GhostPlaybackLogic.PopulateGhostInfoDictionaries(state, buildResult, traj);
             GhostPlaybackLogic.InitializeInventoryPlacementVisibility(traj, state);
             GhostPlaybackLogic.RefreshCompoundPartVisibility(state);
+            buildDictionariesStopwatch.Stop();
+            lastSpawnDictionariesTicks = buildDictionariesStopwatch.ElapsedTicks - dictionariesPre;
 
+            // Bug #450 sub-phase 4: reentry FX. Only timed on the HasReentryPotential branch
+            // — the skip branch is trivial (a VerboseRateLimited log and a counter bump) and
+            // lumping it in with the build path would muddy the attribution. On the skip
+            // branch lastSpawnReentryTicks stays 0, which correctly reflects zero work.
             // Gate reentry FX build: stationary part-showcase ghosts, EVA walks, and slow
             // suborbital hops below Mach 1.5 can never produce reentry visuals, so we skip
             // the mesh-combine + ParticleSystem + glow-material clone work entirely. With
@@ -2261,8 +2423,12 @@ namespace Parsek
             // boundary was the dominant cost in the map-view perf tank (#406).
             if (TrajectoryMath.HasReentryPotential(traj))
             {
+                long reentryPre = buildReentryFxStopwatch.ElapsedTicks;
+                buildReentryFxStopwatch.Start();
                 state.reentryFxInfo = GhostVisualBuilder.TryBuildReentryFx(
                     ghost, state.heatInfos, index, traj.VesselName);
+                buildReentryFxStopwatch.Stop();
+                lastSpawnReentryTicks = buildReentryFxStopwatch.ElapsedTicks - reentryPre;
                 DiagnosticsState.health.reentryFxBuildsThisSession++;
             }
             else

--- a/Source/Parsek/GhostPlaybackEngine.cs
+++ b/Source/Parsek/GhostPlaybackEngine.cs
@@ -343,7 +343,15 @@ namespace Parsek
             frameSpawnDeferred = 0;
             frameMaxSpawnTicks = 0;
             // Bug #450: reset per-frame heaviest-spawn breakdown fields so the latch starts
-            // empty each frame. No heaviest spawn yet -> HeaviestSpawnBuildType.None.
+            // empty each frame. No heaviest spawn yet -> HeaviestSpawnBuildType.None. The
+            // lastSpawn*Ticks fields are NOT reset here because TryPopulateGhostVisuals
+            // resets them itself at its head every call — any read of frameHeaviestSpawn*
+            // happens only inside the PlaybackBudgetPhases populate block below, strictly
+            // after all BuildGhostVisualsWithMetrics calls this frame have run. Scene-
+            // cleanup paths (DestroyAllGhosts, ReindexAfterDelete) do not need to clear
+            // these fields either — they run outside UpdatePlayback, and the next frame's
+            // reset at the head of UpdatePlayback zeroes everything before any producer
+            // touches it. Same invariant #414's frameMaxSpawnTicks already relies on.
             frameHeaviestSpawnSnapshotResolveTicks = 0;
             frameHeaviestSpawnTimelineTicks = 0;
             frameHeaviestSpawnDictionariesTicks = 0;
@@ -2190,7 +2198,7 @@ namespace Parsek
                 flagEventIndex = 0
             };
 
-            if (!BuildGhostVisualsWithMetrics(index, traj, state, resetCompletedEventDedup: true, out string buildType))
+            if (!BuildGhostVisualsWithMetrics(index, traj, state, resetCompletedEventDedup: true, out HeaviestSpawnBuildType buildType))
                 return;
 
             PrimeLoadedGhostForPlaybackUT(index, traj, state, playbackUT);
@@ -2198,17 +2206,17 @@ namespace Parsek
             ghostStates[index] = state;
 
             ParsekLog.VerboseRateLimited("Engine", $"spawn-{index}",
-                $"Ghost #{index} \"{traj?.VesselName}\" spawned ({buildType}, " +
+                $"Ghost #{index} \"{traj?.VesselName}\" spawned ({buildType.ToLogToken()}, " +
                 $"parts={state.partTree?.Count ?? 0} engines={state.engineInfos?.Count ?? 0} " +
                 $"rcs={state.rcsInfos?.Count ?? 0})", 1.0);
         }
 
         private bool BuildGhostVisualsWithMetrics(
             int index, IPlaybackTrajectory traj, GhostPlaybackState state,
-            bool resetCompletedEventDedup, out string buildType)
+            bool resetCompletedEventDedup, out HeaviestSpawnBuildType buildType)
         {
             bool built = false;
-            buildType = null;
+            buildType = HeaviestSpawnBuildType.None;
             // Bug #414: record per-spawn cost so the breakdown WARN surfaces whether a single
             // heavy ghost is the culprit vs many light ones. Take the pre-call tick count
             // before Start() resumes the stopwatch so the delta is this call only.
@@ -2234,7 +2242,9 @@ namespace Parsek
                     // breakdown so the one-shot WARN can attribute whichever single spawn
                     // dominates. Copy the per-call deltas set by TryPopulateGhostVisuals;
                     // "other" is the residual that preserves the sum+residual = delta
-                    // invariant the tests assert.
+                    // invariant the tests assert. The enum arrives directly through the
+                    // out-param — no string-classification coupling between engine and
+                    // diagnostics layer (prior revision had that brittleness).
                     frameHeaviestSpawnSnapshotResolveTicks = lastSpawnSnapshotResolveTicks;
                     frameHeaviestSpawnTimelineTicks = lastSpawnTimelineTicks;
                     frameHeaviestSpawnDictionariesTicks = lastSpawnDictionariesTicks;
@@ -2246,26 +2256,11 @@ namespace Parsek
                         + lastSpawnReentryTicks;
                     long otherTicks = deltaTicks - attributedTicks;
                     frameHeaviestSpawnOtherTicks = otherTicks < 0 ? 0 : otherTicks;
-                    frameHeaviestSpawnBuildType = ClassifyBuildType(buildType);
+                    frameHeaviestSpawnBuildType = buildType;
                 }
                 if (built)
                     DiagnosticsState.health.ghostBuildsThisSession++;
             }
-        }
-
-        /// <summary>
-        /// Bug #450: map the human-readable buildType strings produced by
-        /// TryPopulateGhostVisuals onto the byte-backed HeaviestSpawnBuildType enum.
-        /// Returns None when the build failed (buildType == null) or a new build type
-        /// was added without updating this map — both are safe default behaviour (the
-        /// breakdown WARN renders "None" so the gap is visible in logs).
-        /// </summary>
-        private static HeaviestSpawnBuildType ClassifyBuildType(string buildType)
-        {
-            if (buildType == "recording-start snapshot") return HeaviestSpawnBuildType.RecordingStartSnapshot;
-            if (buildType == "vessel snapshot") return HeaviestSpawnBuildType.VesselSnapshot;
-            if (buildType == "sphere fallback") return HeaviestSpawnBuildType.SphereFallback;
-            return HeaviestSpawnBuildType.None;
         }
 
         /// <summary>
@@ -2323,9 +2318,9 @@ namespace Parsek
 
         private bool TryPopulateGhostVisuals(
             int index, IPlaybackTrajectory traj, GhostPlaybackState state,
-            out string buildType)
+            out HeaviestSpawnBuildType buildType)
         {
-            buildType = null;
+            buildType = HeaviestSpawnBuildType.None;
             // Bug #450: reset per-call sub-phase deltas so a prior (shorter-lived) spawn's
             // attribution cannot leak into this call's heaviest-spawn latch. Each delta is
             // captured via pre/post Start-Stop subtraction below, matching the #414
@@ -2450,8 +2445,10 @@ namespace Parsek
             ResetGhostAppearanceTracking(state);
 
             buildType = builtFromSnapshot
-                ? (traj.GhostVisualSnapshot != null ? "recording-start snapshot" : "vessel snapshot")
-                : "sphere fallback";
+                ? (traj.GhostVisualSnapshot != null
+                    ? HeaviestSpawnBuildType.RecordingStartSnapshot
+                    : HeaviestSpawnBuildType.VesselSnapshot)
+                : HeaviestSpawnBuildType.SphereFallback;
             return true;
         }
 
@@ -2517,12 +2514,12 @@ namespace Parsek
             if (traj.IsDebris && GhostVisualBuilder.GetGhostSnapshot(traj) == null)
                 return false;
 
-            if (!BuildGhostVisualsWithMetrics(index, traj, state, resetCompletedEventDedup: false, out string buildType))
+            if (!BuildGhostVisualsWithMetrics(index, traj, state, resetCompletedEventDedup: false, out HeaviestSpawnBuildType buildType))
                 return false;
 
             PrimeLoadedGhostForPlaybackUT(index, traj, state, playbackUT);
             ParsekLog.VerboseRateLimited("Engine", $"rebuild-{index}",
-                $"Ghost #{index} \"{state.vesselName}\" visuals rebuilt ({buildType}, {reason})", 1.0);
+                $"Ghost #{index} \"{state.vesselName}\" visuals rebuilt ({buildType.ToLogToken()}, {reason})", 1.0);
             return HasLoadedGhostVisuals(state);
         }
 

--- a/docs/dev/plan-450-build-breakdown.md
+++ b/docs/dev/plan-450-build-breakdown.md
@@ -1,0 +1,251 @@
+# Plan: #450 — per-spawn build-phase breakdown (Phase A diagnostic)
+
+## Problem
+
+Smoke-test `logs/2026-04-18_0221_v0.8.2-smoke/KSP.log:11489` surfaced the
+bimodal-single-spawn case that #414 explicitly deferred:
+
+```
+Playback budget breakdown (one-shot, first exceeded frame):
+total=40.1ms mainLoop=11.34ms
+spawn=28.11ms (built=1 throttled=0 max=28.11ms)
+destroy=0.00ms ... trajectories=1 ghosts=0 warp=1x
+```
+
+One spawn cost 28.11 ms on its own. #414's count cap is structurally useless
+here — there was only one spawn to cap. The #450 entry in
+`docs/dev/todo-and-known-bugs.md` mandates **investigation-first**: instrument
+the spawn build to identify which sub-phase dominates BEFORE committing to a
+fix shape.
+
+## Scope (Phase A only)
+
+Ship the diagnostic alone. Do NOT pick the Phase B fix shape until a real
+playtest produces data. The diagnostic-then-fix cycle mirrors #414's
+original sequencing.
+
+## Current spawn path (reconfirmed from code)
+
+`GhostPlaybackEngine.SpawnGhost` →
+`BuildGhostVisualsWithMetrics` (outer `spawnStopwatch` window,
+`frameSpawnCount++`, `frameMaxSpawnTicks` update in `finally`) →
+`TryPopulateGhostVisuals` (the method with the actual work).
+
+Inside `TryPopulateGhostVisuals`, the natural sub-phase boundaries are:
+
+1. **snapshotResolve** — `GhostVisualBuilder.GetGhostSnapshot(traj)` (trivial
+   lookup; included so the breakdown reconciles arithmetically).
+2. **timelineFromSnapshot** — `BuildTimelineGhostFromSnapshot` (on snapshot
+   path) OR `CreateGhostSphere` (fallback). This is the dominant suspect:
+   part instantiation + engine-FX size-boost + audio wiring.
+3. **dictionaries** — `BuildPartSubtreeMap` + `BuildSnapshotPartIdSet` +
+   `GhostPlaybackLogic.PopulateGhostInfoDictionaries` +
+   `InitializeInventoryPlacementVisibility` + `RefreshCompoundPartVisibility`.
+4. **reentryFx** — conditional `TryBuildReentryFx` on the
+   `HasReentryPotential` branch (skip branch is trivial and not timed).
+
+Residual work (camera pivot + horizonProxy GameObject construction, materials
+list, `MaterialPropertyBlock`, `SetActive(false)`, `ResetGhostAppearanceTracking`)
+is captured arithmetically as `other = deltaTicks − sum(sub-phases)`, which
+holds sum-reconciliation as an invariant the tests can assert.
+
+## Design (addresses clean-context review findings)
+
+### New enum — `HeaviestSpawnBuildType`
+
+```csharp
+internal enum HeaviestSpawnBuildType : byte
+{
+    None = 0,
+    RecordingStartSnapshot = 1,
+    VesselSnapshot = 2,
+    SphereFallback = 3
+}
+```
+
+Byte-backed to keep `PlaybackBudgetPhases` a pure value type with no heap
+references (review finding #3). The string form is only reconstructed inside
+the one-shot WARN format layer.
+
+### Extended `PlaybackBudgetPhases`
+
+Two groups of new fields:
+
+**Aggregate (sum across every spawn this frame):**
+- `long buildSnapshotResolveMicroseconds`
+- `long buildTimelineFromSnapshotMicroseconds`
+- `long buildDictionariesMicroseconds`
+- `long buildReentryFxMicroseconds`
+- `long buildOtherMicroseconds` (residual)
+
+**Heaviest-spawn breakdown (latched on whichever single spawn was the most
+expensive this frame — addresses review finding #2):**
+- `long heaviestSpawnSnapshotResolveMicroseconds`
+- `long heaviestSpawnTimelineFromSnapshotMicroseconds`
+- `long heaviestSpawnDictionariesMicroseconds`
+- `long heaviestSpawnReentryFxMicroseconds`
+- `long heaviestSpawnOtherMicroseconds`
+- `HeaviestSpawnBuildType heaviestSpawnBuildType`
+
+The heaviest-spawn breakdown is the signal that localizes the bimodal case.
+The aggregate rows tell us whether the cost is spread (3 × 10 ms spawns)
+or concentrated (1 × 28 ms spawn). Both are needed.
+
+### `GhostPlaybackEngine` instrumentation
+
+Four new pre-allocated `Stopwatch` fields mirroring the established
+`spawnStopwatch` pattern (review finding #6):
+
+- `buildSnapshotResolveStopwatch`
+- `buildTimelineStopwatch`
+- `buildDictionariesStopwatch`
+- `buildReentryFxStopwatch`
+
+These accumulate across all spawns in a frame; `ElapsedTicks` at
+`PlaybackBudgetPhases` populate-time gives the aggregate.
+
+Per-frame heaviest-breakdown fields (reset each frame alongside the existing
+`frameMaxSpawnTicks`):
+
+- `frameHeaviestSpawnSnapshotResolveTicks`
+- `frameHeaviestSpawnTimelineTicks`
+- `frameHeaviestSpawnDictionariesTicks`
+- `frameHeaviestSpawnReentryTicks`
+- `frameHeaviestSpawnOtherTicks`
+- `frameHeaviestSpawnBuildType`
+
+Per-call "last spawn" fields populated inside `TryPopulateGhostVisuals`
+(the sub-phase timer reads `ElapsedTicks` before/after each Start/Stop pair
+to compute the delta for *this* call):
+
+- `lastSpawnSnapshotResolveTicks`
+- `lastSpawnTimelineTicks`
+- `lastSpawnDictionariesTicks`
+- `lastSpawnReentryTicks`
+
+`BuildGhostVisualsWithMetrics.finally` — extends the existing
+`deltaTicks > frameMaxSpawnTicks` branch to also latch the heaviest
+breakdown (review finding #10 BLOCKER): when this call is the new heaviest,
+copy `lastSpawn*Ticks` + `buildType` into `frameHeaviestSpawn*Ticks`, and
+compute `frameHeaviestSpawnOtherTicks = deltaTicks − sum(lastSpawn*Ticks)`.
+
+### Log format
+
+Two lines (review finding #4) — second line added on the same one-shot
+branch inside `DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown`:
+
+```
+[WARN][Diagnostics] Playback budget breakdown (one-shot, first exceeded frame): total=... (existing #414 line)
+[WARN][Diagnostics] Playback spawn build breakdown (one-shot):
+    sum[snapshot=X.XXms timeline=X.XXms dicts=X.XXms reentry=X.XXms other=X.XXms]
+    heaviestSpawn[type=X snapshot=X.XXms timeline=X.XXms dicts=X.XXms reentry=X.XXms other=X.XXms total=X.XXms]
+```
+
+Emitted only when the aggregate `spawnMicroseconds > 0` (no point logging
+a breakdown for a budget spike whose spawn phase didn't contribute).
+`grep "build breakdown"` returns just the attribution line; `grep "budget
+breakdown"` returns the aggregate line.
+
+### One-shot latch
+
+Separate from #414's latch (review finding on "latch sharing"): a new
+`s_buildBreakdownOneShotFired` lives alongside `s_playbackBreakdownOneShotFired`
+so the build breakdown fires on the next spike after #450 rollout even if
+the session's first spike already consumed #414's latch before this code
+loaded. `ResetForTesting` clears both.
+
+### Steady-state overhead
+
+Four pre-allocated `Stopwatch` Start/Stop pairs per spawn ≈ 200-600 ns.
+Negligible vs the ~28 ms single-spawn cost we're attributing and vs the
+existing `spawnStopwatch` overhead #414 already pays. Zero steady-state log
+output (one-shot latch shared semantics).
+
+## Files touched (Phase A)
+
+- `Source/Parsek/GhostPlaybackEngine.cs` — 4 stopwatch fields, 6
+  per-frame heaviest-spawn fields, 4 "last spawn" fields, reset hooks,
+  4 instrumentation windows in `TryPopulateGhostVisuals`, heaviest-spawn
+  latch in `BuildGhostVisualsWithMetrics.finally`, populate
+  `PlaybackBudgetPhases` at the existing site.
+- `Source/Parsek/Diagnostics/DiagnosticsStructs.cs` — new
+  `HeaviestSpawnBuildType` byte enum, 11 new `PlaybackBudgetPhases` fields.
+- `Source/Parsek/Diagnostics/DiagnosticsComputation.cs` — new
+  `s_buildBreakdownOneShotFired` latch, new second WARN line, reset helper.
+- `Source/Parsek.Tests/Bug450BuildBreakdownTests.cs` (new) — mirror
+  `Bug414BudgetBreakdownTests` format assertions; independent one-shot
+  latch test; sum+max-reconciliation invariant test.
+- `docs/dev/todo-and-known-bugs.md` — note Phase A diagnostic shipped;
+  Phase B branch (B1/B2/B3) gated on next playtest's breakdown output.
+- `docs/dev/plan-450-build-breakdown.md` (this file, checked in per
+  review finding #9).
+
+No CHANGELOG entry: per `feedback_changelog_style` the CHANGELOG is
+user-facing only; this is pure internal diagnostic plumbing, so the record
+lives in `todo-and-known-bugs.md`.
+
+## Phase B branch table (NOT part of this PR — gated on playtest data)
+
+When the next budget-exceeded spike fires after Phase A is in a user's KSP
+install, the new build-breakdown WARN will attribute the cost to one of
+four buckets. The fix branch depends on the answer:
+
+| Dominant sub-phase | Fix | Scope |
+|---|---|---|
+| `timeline` (part instantiation), heaviest-spawn < ~15 ms, aggregate > cap | **B1: per-frame build-time budget.** `MaxSpawnBuildMsPerFrame` const; new `GhostPlaybackLogic.ShouldThrottleSpawnByTime(frameSpawnTotalTicks, capTicks)`; `TryReserveSpawnSlot` ORs count-cap and time-cap. One monolithic >cap spawn still runs; prevents second spawn from stacking. | Small |
+| `timeline`, single spawn alone > ~15 ms | **B2: coroutine split of `TryPopulateGhostVisuals`.** Yield between (1) snapshot resolve, (2) timeline build, (3) dict populate, (4) reentry FX. Hold `ghost.SetActive(false)` across yields (extends the existing `deferVisibilityUntilPlaybackSync` mechanism at `:2283`). `ghostStates[index]` populated only on final yield to keep the "fully-built or not there" invariant. | Medium-large |
+| `reentryFx` | **B3: lazy reentry pre-warm.** Gate `TryBuildReentryFx` on first-frame-in-atmosphere + speed > floor, not on trajectory peak. | Small |
+| `dictionaries` | Unlikely (pure data-structure walks). Profile with more targeted instrumentation before committing to a fix. | Unknown |
+
+## Tests
+
+Log-format assertions mirroring `Bug414BudgetBreakdownTests` (the proven
+shape for this type of plumbing) — the diagnostic is a pure transformation
+from `PlaybackBudgetPhases` values to a log line. Specific tests:
+
+1. **Synthetic heaviest-spawn breakdown formats correctly** — populate all
+   11 new fields with distinct values; assert each appears in the WARN
+   with the expected prefix (`sum[snapshot=…`, `heaviestSpawn[type=…`).
+2. **Build-type enum renders as human-readable string** — three positive
+   cases (`RecordingStartSnapshot`, `VesselSnapshot`, `SphereFallback`) and
+   one `None` case (no heaviest spawn captured — aggregate only).
+3. **One-shot latch fires once per session, independently of #414** —
+   set `s_playbackBreakdownOneShotFired = true` first; trip a budget
+   exceeded frame; assert build-breakdown line still emits (new latch
+   hasn't fired yet); trip a second spike; assert build-breakdown line
+   does NOT re-emit.
+4. **No build breakdown line when `spawnMicroseconds == 0`** — the
+   aggregate spike happened but zero spawn time; build-breakdown line
+   suppressed (no useful data to log).
+5. **Sum+max reconciliation invariant** — given a synthetic heaviest spawn
+   with `total=10ms snapshot=1ms timeline=6ms dicts=1ms reentry=1ms`,
+   the formatted line shows `other=1.0ms` (= 10 − 1 − 6 − 1 − 1).
+6. **Reset clears both latches** —
+   `DiagnosticsComputation.ResetForTesting` clears the new latch plus the
+   existing one.
+
+Integration-style testing of the producer (the stopwatch instrumentation
+in `TryPopulateGhostVisuals` actually populating the per-call fields)
+deferred to manual verification in-game: Phase A's value is the log
+evidence on a real KSP playtest, and the sub-phase accumulators are
+straightforward Stopwatch reads with no branch logic to gate.
+
+## Rollout / risk
+
+- Zero behavior change on any playback path.
+- Steady-state overhead: ~300-600 ns per spawn (4 × Stopwatch Start/Stop);
+  on a healthy non-spike frame this is invisible against the existing
+  `spawnStopwatch` overhead.
+- Memory: `PlaybackBudgetPhases` grows by 10 longs + 1 byte ≈ 81 bytes.
+  Struct is allocated once per `UpdatePlayback` tick (already the case
+  from #414); no additional allocation pressure.
+- Log output: zero new log lines in steady state. One new line on the
+  first spike per session.
+
+## Post-ship validation
+
+On the next playtest, observe the one-shot "spawn build breakdown" WARN
+adjacent to the existing #414 "playback budget breakdown" WARN in
+`KSP.log`. The `heaviestSpawn[type=X total=Xms]` fields tell us which
+fix branch to take in Phase B. Decision criteria recorded in the Phase B
+branch table above.

--- a/docs/dev/plan-450-build-breakdown.md
+++ b/docs/dev/plan-450-build-breakdown.md
@@ -44,10 +44,13 @@ Inside `TryPopulateGhostVisuals`, the natural sub-phase boundaries are:
 4. **reentryFx** — conditional `TryBuildReentryFx` on the
    `HasReentryPotential` branch (skip branch is trivial and not timed).
 
-Residual work (camera pivot + horizonProxy GameObject construction, materials
-list, `MaterialPropertyBlock`, `SetActive(false)`, `ResetGhostAppearanceTracking`)
+Residual work (camera pivot + horizonProxy GameObject construction,
+`MaterialPropertyBlock`, `SetActive(false)`, `ResetGhostAppearanceTracking`)
 is captured arithmetically as `other = deltaTicks − sum(sub-phases)`, which
-holds sum-reconciliation as an invariant the tests can assert.
+holds sum-reconciliation as an invariant the tests can assert. Materials-list
+allocation sits inside the dictionaries window (it runs between the subtree-map
+build and `PopulateGhostInfoDictionaries`, so bracketing it separately would
+artificially split a single contiguous region of snapshot-walking work).
 
 ## Design (addresses clean-context review findings)
 
@@ -64,8 +67,10 @@ internal enum HeaviestSpawnBuildType : byte
 ```
 
 Byte-backed to keep `PlaybackBudgetPhases` a pure value type with no heap
-references (review finding #3). The string form is only reconstructed inside
-the one-shot WARN format layer.
+references (review finding #3). The enum is plumbed directly through the
+spawn path as an out-param; the log-token string lives in one place (an
+extension method beside the enum) so engine and diagnostics layers cannot
+drift apart.
 
 ### Extended `PlaybackBudgetPhases`
 
@@ -156,10 +161,13 @@ loaded. `ResetForTesting` clears both.
 
 ### Steady-state overhead
 
-Four pre-allocated `Stopwatch` Start/Stop pairs per spawn ≈ 200-600 ns.
-Negligible vs the ~28 ms single-spawn cost we're attributing and vs the
-existing `spawnStopwatch` overhead #414 already pays. Zero steady-state log
-output (one-shot latch shared semantics).
+Per spawn: 4 `Start`/`Stop` pairs + 8 `ElapsedTicks` reads = 12 Stopwatch
+calls, plus a handful of local-field writes. Under Mono on Windows each
+`ElapsedTicks` read is backed by `QueryPerformanceCounter` (~20-30 ns), so
+the total is ≈ 400-800 ns per spawn — negligible vs the 28 ms spike we're
+attributing and the same order of magnitude as the existing `spawnStopwatch`
+overhead #414 already pays. Zero steady-state log output (one-shot latch,
+independent from #414's).
 
 ## Files touched (Phase A)
 

--- a/docs/dev/plan-450-build-breakdown.md
+++ b/docs/dev/plan-450-build-breakdown.md
@@ -159,6 +159,23 @@ so the build breakdown fires on the next spike after #450 rollout even if
 the session's first spike already consumed #414's latch before this code
 loaded. `ResetForTesting` clears both.
 
+**Threshold gate.** The #450 latch additionally requires
+`spawnMaxMicroseconds >= BuildBreakdownMinHeaviestSpawnMicroseconds` (15 ms,
+matching the bimodal threshold the original #450 todo entry proposes). An
+incidental cheap prewarm or watch-mode spawn on a frame whose hitch was
+driven by something else (mainLoop, deferred events) will NOT consume the
+latch — the only sample per session is reserved for the real single-spawn
+regression we're trying to diagnose. `spawnMaxMicroseconds` (not aggregate)
+is the right gate because this is the bimodal-single-spawn case.
+
+### Reentry bucket covers the potential-scan too
+
+`TrajectoryMath.HasReentryPotential` is `O(n)` in trajectory-point count
+on non-orbital recordings. Bracketing the entire `if (HasReentryPotential)`
+decision (classification + build or skip) in the reentry window ensures the
+scan cost is attributed to the reentry bucket rather than leaking into
+`other`, so Phase B branches on the correct dominant bucket.
+
 ### Steady-state overhead
 
 Per spawn: 4 `Start`/`Stop` pairs + 8 `ElapsedTicks` reads = 12 Stopwatch

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -116,20 +116,20 @@ Breakdown of the exceeded frame: 70% of the budget (28.11 / 40.1 ms) lived insid
 
 `mainLoop=11.34 ms` with `trajectories=1 ghosts=0` is also on the high side (expected ≤1 ms per trajectory on an established session), worth subtracting from the spawn cost attribution when a follow-up breakdown lands.
 
-**Fix — investigation-first:** add per-phase timing inside `GhostVisualBuilder.BuildGhostVisuals` (matching #414's pattern in `GhostPlaybackEngine.UpdatePlayback`) to identify which sub-phase dominates. One-shot latch on the first spawn whose total exceeds a threshold (say ≥15 ms) emits a `"Ghost build breakdown (one-shot): partsInstantiated=... partsConfigured=... fxWired=... materialsSwapped=... fxSizeBoost=... reentryPrewarm=... "` line. Steady-state cost zero (Stopwatch `Reset/Start/Stop` only on the exceeded path).
+**Fix — Phase A (shipped): diagnostic first.** `PlaybackBudgetPhases` now carries an aggregate-and-heaviest-spawn breakdown of every `BuildGhostVisualsWithMetrics` call across four sub-phases (snapshot resolve, timeline-from-snapshot, dictionaries, reentry FX) plus a residual "other" bucket so `sum + other = spawnMax` reconciles. `GhostPlaybackEngine.TryPopulateGhostVisuals` hosts four pre-allocated Stopwatches using the #414 spawnStopwatch pattern (pre-call ElapsedTicks + post-call subtraction for per-call deltas; same objects accumulate across the frame for the aggregate). `BuildGhostVisualsWithMetrics.finally` latches the heaviest spawn's breakdown + a byte-backed `HeaviestSpawnBuildType` classification. A separate one-shot WARN (`s_buildBreakdownOneShotFired` — independent of #414's latch so Phase A collects data even when the session's first spike already consumed #414's latch before rollout) fires the very first time a budget-exceeded frame has `spawnMicroseconds > 0`. See `docs/dev/plan-450-build-breakdown.md`.
 
-Once the dominant sub-phase is identified, the fix is one of:
-- **Per-frame time budget on spawn** (`MaxSpawnBuildMsPerFrame`). `TryReserveSpawnSlot` already has the structural hook — extend the predicate to also check accumulated `spawnTicks` against a budget (e.g. 12 ms) and defer any spawn that would push past the cap, whether or not the count cap has been hit.
-- **Coroutine split of `BuildGhostVisuals`** — yield after each major phase (parts, FX, materials, reentry), so a heavy build spreads across 2-3 frames instead of one. Risk: ghost appears visually in stages, which is ugly if the ghost is in-frame at build time. Mitigate with `ApplyGhostVisibility(false)` during the build and one `ApplyGhostVisibility(true)` at the end of the final coroutine step.
-- **Lazy reentry material pre-warm** (if the breakdown fingers it). Defer the pre-warm to the first frame the ghost is actually moving fast enough to need reentry FX, not at spawn time.
+**Phase B (gated on playtest data — NOT yet scheduled):** once the next real spike fires in a user install, the new `Playback spawn build breakdown` WARN will attribute the cost. The fix branch depends on the answer:
+- `timeline` dominates, heaviest-spawn < ~15 ms — **B1: per-frame build-time budget.** `MaxSpawnBuildMsPerFrame` const; new `GhostPlaybackLogic.ShouldThrottleSpawnByTime(frameSpawnTotalTicks, capTicks)`; `TryReserveSpawnSlot` ORs count-cap and time-cap.
+- `timeline` dominates, single spawn > ~15 ms — **B2: coroutine split of `TryPopulateGhostVisuals`.** Yield between (1) snapshot resolve, (2) timeline build, (3) dict populate, (4) reentry FX; extend `deferVisibilityUntilPlaybackSync` across yields.
+- `reentry` dominates — **B3: lazy reentry FX pre-warm.** Gate `TryBuildReentryFx` on first-frame-in-atmosphere + speed > floor, not on trajectory peak.
 
-**Files:** `Source/Parsek/GhostVisualBuilder.cs` (per-phase stopwatches + possible coroutine split), `Source/Parsek/GhostPlaybackEngine.cs` (`MaxSpawnBuildMsPerFrame` const + threaded into `TryReserveSpawnSlot`), `Source/Parsek/Diagnostics/DiagnosticsStructs.cs` (extend `PlaybackBudgetPhases` with build sub-phases), `Source/Parsek/Diagnostics/DiagnosticsComputation.cs` (new one-shot build-breakdown log), `Source/Parsek.Tests/` (new test file or extend `Bug414SpawnThrottleTests.cs`).
+**Files:** `Source/Parsek/GhostPlaybackEngine.cs` (4 sub-phase stopwatches + heaviest-spawn latch), `Source/Parsek/Diagnostics/DiagnosticsStructs.cs` (new `HeaviestSpawnBuildType` enum + 11 new `PlaybackBudgetPhases` fields), `Source/Parsek/Diagnostics/DiagnosticsComputation.cs` (new second one-shot WARN + independent latch + `FormatHeaviestSpawnBuildType` helper), `Source/Parsek.Tests/Bug450BuildBreakdownTests.cs` (new), `docs/dev/plan-450-build-breakdown.md` (new).
 
-**Scope:** Medium. Investigation first (diagnostic-only, mirrors #414 Phase 1), then a targeted fix scoped to the identified dominant sub-phase. Do NOT commit to the coroutine-split approach before the breakdown tells us which sub-phase is at fault — the fix shape changes depending on the answer.
+**Scope:** Phase A = Small (instrumentation-only, zero behaviour change). Phase B = scope depends on the chosen branch; held until playtest data lands.
 
-**Dependencies:** #414 shipped — the diagnostic framework and `TryReserveSpawnSlot` hook are already on main.
+**Dependencies:** #414 shipped (`TryReserveSpawnSlot` hook + per-phase breakdown framework are on main).
 
-**Status:** TODO. Priority: medium. User-visible as a ~40 ms hitch when an expensive ghost first spawns (e.g., entering physics range on a complex vessel). Not release-blocking for v0.8.2 but should not survive the v0.8.3 cycle.
+**Status:** Phase A shipped — diagnostic instrumentation + one-shot WARN. Phase B: TODO, gated on next playtest's breakdown output. Priority: medium. User-visible as a ~40 ms hitch when an expensive ghost first spawns; not release-blocking for v0.8.2 but should not survive the v0.8.3 cycle.
 
 ---
 


### PR DESCRIPTION
## Summary

- Follow-up to #414's shipped spawn throttle. Smoke-test `logs/2026-04-18_0221_v0.8.2-smoke/KSP.log:11489` showed a 40.1 ms frame where a **single spawn cost 28.11 ms on its own** (`built=1 throttled=0 max=28.11ms`) — the bimodal case a count cap alone cannot solve.
- **Phase A (this PR): diagnostic only.** Instruments `BuildGhostVisualsWithMetrics` across four sub-phases (snapshot resolve / timeline-from-snapshot / dictionaries / reentry FX) plus a residual `other` bucket so `sum + other = spawnMax` reconciles. A new one-shot WARN `Playback spawn build breakdown` emits the aggregate + heaviest-spawn breakdown on the first spike with `spawnMicroseconds > 0`.
- **Phase B deliberately deferred.** The fix shape (per-frame time budget vs coroutine split vs lazy reentry pre-warm) is gated on what the next playtest's breakdown WARN actually fingers — committing now would be guessing. Branch table documented in `docs/dev/plan-450-build-breakdown.md`.

Mirrors #414's pre-allocated `Stopwatch` pattern (pre/post `ElapsedTicks` subtraction for per-call deltas; same object accumulates across the frame for the aggregate). ~400-800 ns per spawn overhead, zero steady-state log output (independent one-shot latch from #414's, so Phase A captures data even on a session whose first spike consumed the #414 latch before rollout).

`HeaviestSpawnBuildType` byte-backed enum is plumbed through the spawn path as an out-param; a single `ToLogToken` extension sitting beside the enum means the engine spawn log and the breakdown WARN cannot drift apart (addressed from the implementation review).

## Test plan

- [x] `dotnet build` clean (0 warnings, 0 errors).
- [x] `dotnet test` clean (7140/7141 passing, 1 pre-existing skip).
- [x] New `Bug450BuildBreakdownTests.cs`: 11 tests covering log format, enum rendering (Theory over all 4 values), latch independence with the `SetBug414BreakdownLatchFiredForTesting` test seam, `spawnMicroseconds == 0` suppression, multi-spawn aggregate-vs-heaviest distinctness, reset-re-arms-both-latches.
- [x] Clean-context Opus review of the plan (pre-implementation) — 1 blocker + 5 should-fix addressed before commit.
- [x] Clean-context Opus review of the implementation — 0 blockers + 3 should-fix + 6 nits addressed in a follow-up commit.
- [ ] Manual in-game verification deferred to first real budget-exceeded spike; Phase A's value IS the log evidence on a real playtest.

## Related docs

- `docs/dev/plan-450-build-breakdown.md` — design + Phase B branch table.
- `docs/dev/todo-and-known-bugs.md` — entry updated: Phase A shipped, Phase B TODO.
- No CHANGELOG entry (per `feedback_changelog_style`: diagnostic plumbing, not user-facing).