### PR TITLE
Fix #439 Phase A: strategy lifecycle capture for v0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- Fix #439: capture strategy activate/deactivate lifecycle so StrategiesModule sees input on strategy-using careers; eliminates the spurious PatchFunds suspicious-drawdown warning on revert/rewind after a strategy activates. Known limitation: strategies with Science or Reputation setup cost still emit a reconciliation warning on those resource legs (follow-up).
 - `#448` KSC reconciliation no longer false-positive WARNs on every R&D part purchase under the stock-default `BypassEntryPurchaseAfterResearch=true` difficulty; the harder no-bypass difficulty still WARNs on genuine debit mismatches.
 - `#452` Cancelled-rollout build costs now render with a "(cancelled rollout)" suffix in the Actions and Timeline views so they're distinguishable from adopted, recording-tagged build costs.
 - `#451` R&D part-purchase ledger now records the actual stock debit in `cost=` (`0` under bypass=on, `entryCost` under bypass=off). Load heals the immediately previous bad save shape so stock-default free auto-unlocks no longer reload as paid purchases or reserved funds.
@@ -110,7 +111,7 @@ All notable changes to Parsek are documented here.
 
 ### Known Limitations
 
-- KSP career strategies (Leadership Initiative, Open-Source Tech Program, etc.) are not yet captured by the ledger. Activating a strategy that diverts or grants resources can produce `PatchFunds: suspicious drawdown` WARN lines in `KSP.log` and small balance corrections after scene transitions until strategy lifecycle capture lands (tracked as `#439`). Fresh careers that do not activate strategies are unaffected.
+- KSP career strategies with non-zero Science or Reputation setup costs still produce a single KSC reconciliation WARN line per activation on the Science or Reputation leg. Stock Admin-tier-1 strategies are funds-only and unaffected; the follow-up is tracked as `#439B` (multi-resource `KscActionExpectation`).
 
 ### Maintenance
 

--- a/Source/Parsek.Tests/CrossTierIntegrationTests.cs
+++ b/Source/Parsek.Tests/CrossTierIntegrationTests.cs
@@ -137,14 +137,18 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void ContractComplete_WithStrategyDiversion_FundsReducedScienceFieldTransformed()
+        public void ContractComplete_WithStrategyActive_TransformsAreIdentityAfterPhaseE1_5()
         {
-            // Scenario: contract completion with an active strategy diverts funds to science.
-            // FundsModule (second tier) sees the reduced TransformedFundsReward.
-            // ScienceModule (first tier) runs BEFORE the strategy transform, so it sees the
-            // original ScienceReward=0 — the diverted science is written to TransformedScienceReward
-            // but not credited to the science balance. This is a known limitation of the current
-            // tier ordering (ScienceModule is first tier, strategy is between tiers).
+            // #439 Phase A (Option B): StrategiesModule.TransformContractReward is now
+            // an identity no-op because KSP's CurrencyModifierQuery already transformed
+            // the reward before the FundsChanged event fired (which is what the
+            // recorder reads via contract.FundsCompletion). Applying Commitment a
+            // second time would double-divert. See
+            // docs/dev/plans/fix-439-strategy-lifecycle-capture.md section 3.5.
+            //
+            // This test pins the invariant at the cross-tier level: with an active
+            // strategy, TransformedFundsReward stays equal to FundsReward, and the
+            // downstream FundsModule credits the raw reward.
             var contracts = new ContractsModule();
             var strategies = new StrategiesModule();
             var science = new ScienceModule();
@@ -160,11 +164,9 @@ namespace Parsek.Tests
             var actions = new List<GameAction>
             {
                 new GameAction { UT = 0, Type = GameActionType.FundsInitial, InitialFunds = 50000 },
-                // Activate strategy: diverts 25% of funds reward to science
                 new GameAction { UT = 10, Type = GameActionType.StrategyActivate,
                     StrategyId = "UnpaidResearch", SourceResource = StrategyResource.Funds,
                     TargetResource = StrategyResource.Science, Commitment = 0.25f, SetupCost = 0 },
-                // Contract accepted (advance) then completed
                 new GameAction { UT = 50, Type = GameActionType.ContractAccept,
                     ContractId = "C1", AdvanceFunds = 0 },
                 new GameAction { UT = 100, Type = GameActionType.ContractComplete,
@@ -174,32 +176,28 @@ namespace Parsek.Tests
 
             RecalculationEngine.Recalculate(actions);
 
-            // Contract is effective (first completion)
             var complete = actions.Find(a => a.Type == GameActionType.ContractComplete);
             Assert.True(complete.Effective);
 
-            // Strategy diverts 25% of 10000 funds = 2500 to science on the action fields
-            Assert.Equal(7500f, complete.TransformedFundsReward, 1f);
-            Assert.Equal(2500f, complete.TransformedScienceReward, 1f);
+            // Identity: no diversion applied; transformed == raw.
+            Assert.Equal(10000f, complete.TransformedFundsReward, 1f);
+            Assert.Equal(0f, complete.TransformedScienceReward, 1f);
 
-            // Funds balance: 50000 (seed) + 7500 (transformed reward) = 57500
-            Assert.Equal(57500.0, funds.GetRunningBalance(), 1);
+            // Funds balance: 50000 (seed) + 10000 (raw/identity reward) = 60000.
+            Assert.Equal(60000.0, funds.GetRunningBalance(), 1);
 
-            // Science balance: ScienceModule (first tier) processed ContractComplete BEFORE
-            // the strategy transform ran, so it saw TransformedScienceReward=0 (the reset
-            // value from ScienceReward=0). The diverted 2500 is on the field but not credited.
-            // This documents the current behavior — strategy-diverted science is a known gap.
+            // Science unchanged — ScienceReward was 0.
             Assert.Equal(0.0, science.GetRunningScience(), 1);
+
+            // Strategy still registered for slot accounting and display.
+            Assert.True(strategies.IsStrategyActive("UnpaidResearch"));
         }
 
         [Fact]
-        public void ContractComplete_WithStrategyDiversion_ScienceToRep_FieldsTransformed()
+        public void ContractComplete_WithStrategyActive_ScienceReward_StillIdentity()
         {
-            // Scenario: strategy diverts science reward to reputation.
-            // Verify the derived fields on the action are correctly transformed,
-            // and that second-tier modules (Funds, Reputation) see the transformed values.
-            // ScienceModule is first tier so it sees the PRE-transform value (same limitation
-            // as ContractComplete_WithStrategyDiversion_FundsReducedScienceFieldTransformed).
+            // #439 Phase A follow-up: even a science-bearing reward stays identity
+            // under an active science-diverting strategy — double-transform averted.
             var contracts = new ContractsModule();
             var strategies = new StrategiesModule();
             var science = new ScienceModule();
@@ -215,11 +213,9 @@ namespace Parsek.Tests
             var actions = new List<GameAction>
             {
                 new GameAction { UT = 0, Type = GameActionType.FundsInitial, InitialFunds = 50000 },
-                // Strategy: diverts 10% of science reward to reputation
                 new GameAction { UT = 10, Type = GameActionType.StrategyActivate,
                     StrategyId = "ScienceForRep", SourceResource = StrategyResource.Science,
                     TargetResource = StrategyResource.Reputation, Commitment = 0.10f, SetupCost = 0 },
-                // Contract with science and rep rewards
                 new GameAction { UT = 100, Type = GameActionType.ContractComplete,
                     ContractId = "C1", RecordingId = "rec1",
                     FundsReward = 5000, ScienceReward = 100, RepReward = 10 }
@@ -230,24 +226,19 @@ namespace Parsek.Tests
             var complete = actions.Find(a => a.Type == GameActionType.ContractComplete);
             Assert.True(complete.Effective);
 
-            // Strategy transforms the action fields: 10% of 100 science = 10 diverted to rep
-            Assert.Equal(90f, complete.TransformedScienceReward, 1f);
-            Assert.Equal(20f, complete.TransformedRepReward, 1f); // 10 original + 10 diverted
-            Assert.Equal(5000f, complete.TransformedFundsReward, 1f); // unchanged
+            // Identity transform invariants.
+            Assert.Equal(100f, complete.TransformedScienceReward, 1f);
+            Assert.Equal(10f, complete.TransformedRepReward, 1f);
+            Assert.Equal(5000f, complete.TransformedFundsReward, 1f);
 
-            // ScienceModule (first tier) sees TransformedScienceReward BEFORE the strategy
-            // transform, so it credits the full 100 (reset value from ScienceReward=100).
             Assert.Equal(100.0, science.GetRunningScience(), 1);
-
-            // Funds: 50000 + 5000 = 55000 (unaffected by science strategy)
             Assert.Equal(55000.0, funds.GetRunningBalance(), 1);
 
-            // ReputationModule (second tier) sees TransformedRepReward=20 (10 original + 10 diverted)
-            // The reputation curve is applied, so the exact value depends on the curve at rep=0.
-            // At rep=0, gain curve multiplier is ~1.0, so effectiveRep ~ 20.
+            // ReputationModule applies its curve to the raw rep reward of 10. Around
+            // rep=0 the curve multiplier is ~1.0, so the final rep sits in [5, 15].
             float repAfterWalk = reputation.GetRunningRep();
-            Assert.True(repAfterWalk > 15f && repAfterWalk < 25f,
-                $"Expected rep ~20 (post-curve), actual={repAfterWalk}");
+            Assert.True(repAfterWalk > 5f && repAfterWalk < 15f,
+                $"Expected rep ~10 (post-curve, identity transform), actual={repAfterWalk}");
         }
     }
 }

--- a/Source/Parsek.Tests/EarningsReconciliationTests.cs
+++ b/Source/Parsek.Tests/EarningsReconciliationTests.cs
@@ -930,14 +930,51 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void ClassifyAction_StrategyActivate_TransformedNotUntransformed()
+        public void ClassifyAction_StrategyActivate_Untransformed_PairsWithStrategySetup()
         {
-            // StrategyActivate currently skips (Phase E1.5 lifecycle capture) — not
-            // untransformed yet, per plan.
-            var a = new GameAction { Type = GameActionType.StrategyActivate };
+            // #439 Phase A: StrategyActivate now pairs its SetupCost against the
+            // FundsChanged(StrategySetup) event KSP fires inside Strategy.Activate()
+            // when InitialCostFunds is non-zero.
+            var a = new GameAction
+            {
+                Type = GameActionType.StrategyActivate,
+                SetupCost = 100000f
+            };
             var exp = LedgerOrchestrator.ClassifyAction(a);
-            Assert.Equal(LedgerOrchestrator.KscReconcileClass.Transformed, exp.Class);
-            Assert.Contains("Phase E1.5", exp.SkipReason);
+            Assert.Equal(LedgerOrchestrator.KscReconcileClass.Untransformed, exp.Class);
+            Assert.Equal(GameStateEventType.FundsChanged, exp.EventType);
+            Assert.Equal("StrategySetup", exp.ExpectedReasonKey);
+            Assert.Equal(-100000.0, exp.ExpectedDelta);
+        }
+
+        [Fact]
+        public void ClassifyAction_StrategyActivate_ZeroSetupCost_ShortCircuits()
+        {
+            // Free-to-activate strategies (e.g. mod strategies with all InitialCost* = 0)
+            // stay on the Untransformed classification but hit the zero-expected-delta
+            // early return in ReconcileKscAction — no paired event needed.
+            var a = new GameAction
+            {
+                Type = GameActionType.StrategyActivate,
+                SetupCost = 0f
+            };
+            var exp = LedgerOrchestrator.ClassifyAction(a);
+            Assert.Equal(LedgerOrchestrator.KscReconcileClass.Untransformed, exp.Class);
+            Assert.Equal(0.0, exp.ExpectedDelta);
+
+            // Drive the reconcile path to confirm it stays silent on zero delta.
+            var events = new List<GameStateEvent>();
+            var ledger = new List<GameAction> { a };
+            ReconcileKsc(events, ledger, a, 500.0);
+            Assert.DoesNotContain(logLines, l => l.Contains("KSC reconciliation"));
+        }
+
+        [Fact]
+        public void ClassifyAction_StrategyDeactivate_NoResourceImpact()
+        {
+            var a = new GameAction { Type = GameActionType.StrategyDeactivate };
+            var exp = LedgerOrchestrator.ClassifyAction(a);
+            Assert.Equal(LedgerOrchestrator.KscReconcileClass.NoResourceImpact, exp.Class);
         }
 
         // ---------- #448 / #451: part-purchase zero-delta bypass path ----------

--- a/Source/Parsek.Tests/StrategiesModuleTests.cs
+++ b/Source/Parsek.Tests/StrategiesModuleTests.cs
@@ -95,42 +95,44 @@ namespace Parsek.Tests
         // ================================================================
 
         [Fact]
-        public void BasicTransform_WithinWindow()
+        public void BasicTransform_WithinWindow_IdentityAfterPhaseE1_5()
         {
-            // Strategy "Unpaid Research" activated at UT=300 (10% REP->SCIENCE, setup cost: -5 rep).
-            // UT=400: Contract reward +40k funds, +50 rep. -> transformed: +45 rep, +5 science.
-            // UT=600: Contract reward +30k funds, +30 rep. -> transformed: +27 rep, +3 science.
-            // UT=700: Strategy deactivated.
-            // UT=800: Contract reward +20k funds, +40 rep. (no transform - outside window)
-
+            // #439 Phase A (Option B): TransformContractReward is now an identity no-op
+            // because KSP's CurrencyModifierQuery already transformed the reward before
+            // the FundsChanged / ReputationChanged / ScienceChanged events fired, which
+            // is what feeds ContractComplete's reward fields. Applying Commitment a
+            // second time would double-divert. See plan section 3.5 for the full
+            // rationale. activeStrategies is still populated for slot-accounting and
+            // Actions window display.
             var activate = MakeActivate("UnpaidResearch", 300.0,
                 StrategyResource.Reputation, StrategyResource.Science,
                 commitment: 0.10f, setupCost: 5f);
             module.ProcessAction(activate);
+            Assert.True(module.IsStrategyActive("UnpaidResearch"));
 
-            // UT=400: inside window
+            // UT=400: inside window — identity, transformed fields equal raw rewards.
             var contract1 = MakeContractComplete("c1", 400.0,
                 fundsReward: 40000f, repReward: 50f, scienceReward: 0f);
             module.ProcessAction(contract1);
 
             Assert.Equal(40000f, contract1.TransformedFundsReward);
-            AssertFloatEqual(45f, contract1.TransformedRepReward);
-            AssertFloatEqual(5f, contract1.TransformedScienceReward);
+            Assert.Equal(50f, contract1.TransformedRepReward);
+            Assert.Equal(0f, contract1.TransformedScienceReward);
 
-            // UT=600: inside window
+            // UT=600: still identity.
             var contract2 = MakeContractComplete("c2", 600.0,
                 fundsReward: 30000f, repReward: 30f, scienceReward: 0f);
             module.ProcessAction(contract2);
 
             Assert.Equal(30000f, contract2.TransformedFundsReward);
-            AssertFloatEqual(27f, contract2.TransformedRepReward);
-            AssertFloatEqual(3f, contract2.TransformedScienceReward);
+            Assert.Equal(30f, contract2.TransformedRepReward);
+            Assert.Equal(0f, contract2.TransformedScienceReward);
 
-            // UT=700: deactivate
+            // UT=700: deactivate — slot frees, but contract rewards remain identity.
             var deactivate = MakeDeactivate("UnpaidResearch", 700.0);
             module.ProcessAction(deactivate);
+            Assert.False(module.IsStrategyActive("UnpaidResearch"));
 
-            // UT=800: outside window (strategy deactivated)
             var contract3 = MakeContractComplete("c3", 800.0,
                 fundsReward: 20000f, repReward: 40f, scienceReward: 0f);
             module.ProcessAction(contract3);
@@ -147,21 +149,17 @@ namespace Parsek.Tests
         [Fact]
         public void RetroactiveCommit_OutsideWindow()
         {
-            // Strategy active UT=200 to UT=600.
-            // Contract completed at UT=100 (BEFORE window). No transform.
-            // The contract's Effective flag was set by ContractsModule in first tier.
-
+            // #439 Phase A: identity no-op regardless of whether the contract falls
+            // inside or outside the strategy activation window.
             var activate = MakeActivate("UnpaidResearch", 200.0,
                 StrategyResource.Reputation, StrategyResource.Science,
                 commitment: 0.10f);
             module.ProcessAction(activate);
 
-            // UT=100: before activation window, effective=true
             var contract = MakeContractComplete("orbit-mun", 100.0,
                 fundsReward: 50000f, repReward: 50f, scienceReward: 0f);
             module.ProcessAction(contract);
 
-            // No transform — contract UT < strategy ActivateUT
             Assert.Equal(50000f, contract.TransformedFundsReward);
             Assert.Equal(50f, contract.TransformedRepReward);
             Assert.Equal(0f, contract.TransformedScienceReward);
@@ -308,10 +306,14 @@ namespace Parsek.Tests
         // Transform tests — source/target resource mapping
         // ================================================================
 
+        // #439 Phase A: TransformContractReward is an identity no-op — KSP's
+        // CurrencyModifierQuery already transformed the reward before our event-side
+        // capture saw it. The tests below pin the identity invariant for the three
+        // resource source axes and the min/max commitment values.
+
         [Fact]
-        public void Transform_FundsToReputation()
+        public void Transform_FundsSource_IsIdentityNoOp()
         {
-            // Strategy: 20% of Funds -> Reputation
             module.ProcessAction(MakeActivate("FundsToRep", 100.0,
                 StrategyResource.Funds, StrategyResource.Reputation,
                 commitment: 0.20f));
@@ -320,16 +322,14 @@ namespace Parsek.Tests
                 fundsReward: 10000f, repReward: 10f, scienceReward: 5f);
             module.ProcessAction(contract);
 
-            // 20% of 10000 funds diverted = 2000
-            AssertFloatEqual(8000f, contract.TransformedFundsReward);
-            AssertFloatEqual(2010f, contract.TransformedRepReward);  // 10 + 2000
-            AssertFloatEqual(5f, contract.TransformedScienceReward);  // unchanged
+            Assert.Equal(10000f, contract.TransformedFundsReward);
+            Assert.Equal(10f, contract.TransformedRepReward);
+            Assert.Equal(5f, contract.TransformedScienceReward);
         }
 
         [Fact]
-        public void Transform_ScienceToFunds()
+        public void Transform_ScienceSource_IsIdentityNoOp()
         {
-            // Strategy: 25% of Science -> Funds
             module.ProcessAction(MakeActivate("SciToFunds", 100.0,
                 StrategyResource.Science, StrategyResource.Funds,
                 commitment: 0.25f));
@@ -338,16 +338,14 @@ namespace Parsek.Tests
                 fundsReward: 1000f, repReward: 0f, scienceReward: 40f);
             module.ProcessAction(contract);
 
-            // 25% of 40 science diverted = 10
-            AssertFloatEqual(1010f, contract.TransformedFundsReward);   // 1000 + 10
-            AssertFloatEqual(0f, contract.TransformedRepReward);
-            AssertFloatEqual(30f, contract.TransformedScienceReward);   // 40 - 10
+            Assert.Equal(1000f, contract.TransformedFundsReward);
+            Assert.Equal(0f, contract.TransformedRepReward);
+            Assert.Equal(40f, contract.TransformedScienceReward);
         }
 
         [Fact]
-        public void Transform_ReputationToFunds()
+        public void Transform_ReputationSource_IsIdentityNoOp()
         {
-            // Strategy: 15% of Reputation -> Funds
             module.ProcessAction(MakeActivate("RepToFunds", 100.0,
                 StrategyResource.Reputation, StrategyResource.Funds,
                 commitment: 0.15f));
@@ -356,18 +354,17 @@ namespace Parsek.Tests
                 fundsReward: 5000f, repReward: 100f, scienceReward: 0f);
             module.ProcessAction(contract);
 
-            // 15% of 100 rep diverted = 15
-            AssertFloatEqual(5015f, contract.TransformedFundsReward);   // 5000 + 15
-            AssertFloatEqual(85f, contract.TransformedRepReward);        // 100 - 15
-            AssertFloatEqual(0f, contract.TransformedScienceReward);
+            Assert.Equal(5000f, contract.TransformedFundsReward);
+            Assert.Equal(100f, contract.TransformedRepReward);
+            Assert.Equal(0f, contract.TransformedScienceReward);
         }
 
         // ================================================================
-        // Transform tests — commitment percentage
+        // Transform tests — commitment percentage (identity invariant)
         // ================================================================
 
         [Fact]
-        public void Transform_MinCommitment_OnePercent()
+        public void Transform_MinCommitment_StillIdentity()
         {
             module.ProcessAction(MakeActivate("MinCommit", 100.0,
                 StrategyResource.Reputation, StrategyResource.Science,
@@ -377,12 +374,12 @@ namespace Parsek.Tests
                 repReward: 100f, scienceReward: 0f);
             module.ProcessAction(contract);
 
-            AssertFloatEqual(99f, contract.TransformedRepReward);
-            AssertFloatEqual(1f, contract.TransformedScienceReward);
+            Assert.Equal(100f, contract.TransformedRepReward);
+            Assert.Equal(0f, contract.TransformedScienceReward);
         }
 
         [Fact]
-        public void Transform_MaxCommitment_TwentyFivePercent()
+        public void Transform_MaxCommitment_StillIdentity()
         {
             module.ProcessAction(MakeActivate("MaxCommit", 100.0,
                 StrategyResource.Funds, StrategyResource.Science,
@@ -392,8 +389,33 @@ namespace Parsek.Tests
                 fundsReward: 40000f, scienceReward: 0f);
             module.ProcessAction(contract);
 
-            AssertFloatEqual(30000f, contract.TransformedFundsReward);
-            AssertFloatEqual(10000f, contract.TransformedScienceReward);
+            Assert.Equal(40000f, contract.TransformedFundsReward);
+            Assert.Equal(0f, contract.TransformedScienceReward);
+        }
+
+        [Fact]
+        public void TransformContractReward_IsIdentityNoOp_AfterPhaseE1_5()
+        {
+            // Pin the Phase A invariant: even with an active strategy whose source
+            // resource matches the reward field, TransformedFundsReward stays equal to
+            // FundsReward. Plan section 3.5 option B — KSP pre-transforms rewards
+            // through the modifier query before the FundsChanged event fires, so the
+            // raw-side double-transform this module used to do would double-divert.
+            module.ProcessAction(MakeActivate("UnpaidResearch", 100.0,
+                StrategyResource.Funds, StrategyResource.Science,
+                commitment: 0.25f));
+
+            var contract = MakeContractComplete("c1", 200.0,
+                fundsReward: 80000f, repReward: 10f, scienceReward: 0f);
+            module.ProcessAction(contract);
+
+            Assert.Equal(contract.FundsReward, contract.TransformedFundsReward);
+            Assert.Equal(contract.RepReward, contract.TransformedRepReward);
+            Assert.Equal(contract.ScienceReward, contract.TransformedScienceReward);
+            Assert.Contains(logLines, l =>
+                l.Contains("[Strategies]") &&
+                l.Contains("identity no-op") &&
+                l.Contains("CurrencyModifierQuery"));
         }
 
         // ================================================================
@@ -403,17 +425,18 @@ namespace Parsek.Tests
         [Fact]
         public void Transform_NonEffectiveContract_NotTransformed()
         {
+            // #439 Phase A: identity no-op applies to both effective and non-effective
+            // contracts; the module no longer short-circuits on Effective=false because
+            // there is nothing to short-circuit against.
             module.ProcessAction(MakeActivate("UnpaidResearch", 100.0,
                 StrategyResource.Reputation, StrategyResource.Science,
                 commitment: 0.10f));
 
-            // Non-effective (duplicate completion zeroed by ContractsModule)
             var contract = MakeContractComplete("c1", 200.0,
                 fundsReward: 10000f, repReward: 50f, scienceReward: 0f,
                 effective: false);
             module.ProcessAction(contract);
 
-            // No transform
             Assert.Equal(10000f, contract.TransformedFundsReward);
             Assert.Equal(50f, contract.TransformedRepReward);
             Assert.Equal(0f, contract.TransformedScienceReward);
@@ -442,12 +465,12 @@ namespace Parsek.Tests
         [Fact]
         public void Transform_ContractBeforeActivationUT_NotTransformed()
         {
-            // Strategy activates at UT=500
+            // #439 Phase A: identity no-op applies regardless of UT relationship
+            // between strategy and contract.
             module.ProcessAction(MakeActivate("LateStrat", 500.0,
                 StrategyResource.Reputation, StrategyResource.Science,
                 commitment: 0.10f));
 
-            // Contract at UT=300 (before activation)
             var contract = MakeContractComplete("c1", 300.0,
                 repReward: 100f, scienceReward: 0f);
             module.ProcessAction(contract);
@@ -489,16 +512,16 @@ namespace Parsek.Tests
         // ================================================================
 
         [Fact]
-        public void Transform_MultipleStrategies_BothApply()
+        public void Transform_MultipleStrategies_IdentityNoOp()
         {
+            // #439 Phase A: multiple active strategies still yield identity transformed
+            // fields. activeStrategies is populated for slot accounting, but the reward
+            // transform itself stays at zero applications.
             module.SetMaxSlots(3);
 
-            // Strategy 1: 10% Rep -> Science
             module.ProcessAction(MakeActivate("RepToSci", 100.0,
                 StrategyResource.Reputation, StrategyResource.Science,
                 commitment: 0.10f));
-
-            // Strategy 2: 20% Funds -> Reputation
             module.ProcessAction(MakeActivate("FundsToRep", 100.0,
                 StrategyResource.Funds, StrategyResource.Reputation,
                 commitment: 0.20f));
@@ -507,13 +530,10 @@ namespace Parsek.Tests
                 fundsReward: 10000f, repReward: 100f, scienceReward: 0f);
             module.ProcessAction(contract);
 
-            // Both strategies apply. Since they touch different source resources,
-            // order does not matter:
-            // Rep -> Sci: 10% of 100 = 10 diverted. Rep = 90, Sci = 10.
-            // Funds -> Rep: 20% of 10000 = 2000 diverted. Funds = 8000, Rep = 90 + 2000 = 2090.
-            AssertFloatEqual(8000f, contract.TransformedFundsReward);
-            AssertFloatEqual(2090f, contract.TransformedRepReward);
-            AssertFloatEqual(10f, contract.TransformedScienceReward);
+            Assert.Equal(10000f, contract.TransformedFundsReward);
+            Assert.Equal(100f, contract.TransformedRepReward);
+            Assert.Equal(0f, contract.TransformedScienceReward);
+            Assert.Equal(2, module.GetActiveStrategyCount());
         }
 
         // ================================================================
@@ -546,8 +566,11 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void Transform_LogsDiversionDetails()
+        public void Transform_LogsIdentityNoOp()
         {
+            // #439 Phase A: the diversion log was replaced by a single VERBOSE line
+            // per call announcing the identity no-op. Pin it here so future readers
+            // looking for the old diversion text in the log find the migration note.
             module.ProcessAction(MakeActivate("RepToSci", 100.0,
                 StrategyResource.Reputation, StrategyResource.Science,
                 commitment: 0.10f));
@@ -558,9 +581,8 @@ namespace Parsek.Tests
 
             Assert.Contains(logLines, l =>
                 l.Contains("[Strategies]") &&
-                l.Contains("Transform") &&
-                l.Contains("RepToSci") &&
-                l.Contains("diverted"));
+                l.Contains("identity no-op") &&
+                l.Contains("c1"));
         }
 
         [Fact]
@@ -583,8 +605,10 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void Transform_NonEffective_LogsSkip()
+        public void Transform_NonEffective_LogsIdentityNoOp()
         {
+            // #439 Phase A: the not-effective skip line was replaced with the single
+            // identity-no-op line. Transformed fields still match raw values.
             module.ProcessAction(MakeActivate("RepToSci", 100.0,
                 StrategyResource.Reputation, StrategyResource.Science,
                 commitment: 0.10f));
@@ -597,42 +621,24 @@ namespace Parsek.Tests
 
             Assert.Contains(logLines, l =>
                 l.Contains("[Strategies]") &&
-                l.Contains("skipped (not effective)") &&
+                l.Contains("identity no-op") &&
                 l.Contains("c1"));
         }
 
         [Fact]
-        public void Transform_BeforeActivationUT_LogsSkip()
+        public void Transform_NoActiveStrategies_LogsIdentityNoOp()
         {
-            module.ProcessAction(MakeActivate("LateStrat", 500.0,
-                StrategyResource.Reputation, StrategyResource.Science,
-                commitment: 0.10f));
-
-            logLines.Clear();
-
-            var contract = MakeContractComplete("c1", 300.0,
-                repReward: 100f, scienceReward: 0f);
-            module.ProcessAction(contract);
-
-            Assert.Contains(logLines, l =>
-                l.Contains("[Strategies]") &&
-                l.Contains("skipped for") &&
-                l.Contains("LateStrat") &&
-                l.Contains("c1"));
-        }
-
-        [Fact]
-        public void Transform_NoActiveStrategies_LogsSkip()
-        {
-            // No strategies activated — transform should log skip
+            // #439 Phase A: even without active strategies, the module logs the
+            // identity-no-op line so the call is observable.
             var contract = MakeContractComplete("c1", 200.0,
                 fundsReward: 10000f, repReward: 50f, scienceReward: 0f);
             module.ProcessAction(contract);
 
             Assert.Contains(logLines, l =>
                 l.Contains("[Strategies]") &&
-                l.Contains("skipped (no active strategies)") &&
-                l.Contains("c1"));
+                l.Contains("identity no-op") &&
+                l.Contains("c1") &&
+                l.Contains("activeStrategies=0"));
         }
 
         [Fact]
@@ -668,8 +674,12 @@ namespace Parsek.Tests
         // ================================================================
 
         [Fact]
-        public void Integration_EngineDispatchesStrategyActions()
+        public void Integration_EngineDispatchesStrategyActions_IdentityRewards()
         {
+            // #439 Phase A: activate/deactivate flow still dispatches through the engine,
+            // and the module still tracks active strategies for slot accounting. Rewards
+            // on ContractComplete stay identity in both windows because KSP pre-applies
+            // the transform through the modifier query.
             RecalculationEngine.RegisterModule(module, RecalculationEngine.ModuleTier.Strategy);
 
             var actions = new List<GameAction>
@@ -686,11 +696,8 @@ namespace Parsek.Tests
 
             RecalculationEngine.Recalculate(actions);
 
-            // c1 at UT=400 inside strategy window: rep 50->45, sci 0->5
-            AssertFloatEqual(45f, actions[1].TransformedRepReward);
-            AssertFloatEqual(5f, actions[1].TransformedScienceReward);
-
-            // c2 at UT=800 outside strategy window: no transform
+            Assert.Equal(50f, actions[1].TransformedRepReward);
+            Assert.Equal(0f, actions[1].TransformedScienceReward);
             Assert.Equal(40f, actions[3].TransformedRepReward);
             Assert.Equal(0f, actions[3].TransformedScienceReward);
         }
@@ -702,23 +709,26 @@ namespace Parsek.Tests
         [Fact]
         public void Activate_SameStrategyTwice_OverwritesPrevious()
         {
+            // #439 Phase A: overwriting semantics still hold for the activeStrategies
+            // dict (used for slot accounting and display). Transformed reward fields
+            // stay identity regardless of commitment.
             module.ProcessAction(MakeActivate("S1", 100.0,
                 StrategyResource.Reputation, StrategyResource.Science,
                 commitment: 0.10f));
 
-            // Activate again with different commitment — overwrites
             module.ProcessAction(MakeActivate("S1", 200.0,
                 StrategyResource.Reputation, StrategyResource.Science,
                 commitment: 0.20f));
 
             Assert.Equal(1, module.GetActiveStrategyCount());
+            Assert.Contains(logLines, l =>
+                l.Contains("[Strategies]") && l.Contains("already active") && l.Contains("S1"));
 
-            // Verify the new commitment applies
             var contract = MakeContractComplete("c1", 300.0, repReward: 100f, scienceReward: 0f);
             module.ProcessAction(contract);
 
-            AssertFloatEqual(80f, contract.TransformedRepReward);    // 20% diverted
-            AssertFloatEqual(20f, contract.TransformedScienceReward);
+            Assert.Equal(100f, contract.TransformedRepReward);
+            Assert.Equal(0f, contract.TransformedScienceReward);
         }
 
         [Fact]

--- a/Source/Parsek.Tests/StrategyCaptureTests.cs
+++ b/Source/Parsek.Tests/StrategyCaptureTests.cs
@@ -10,7 +10,7 @@ namespace Parsek.Tests
     /// #439 Phase A: strategy lifecycle capture coverage. These tests exercise the
     /// pure-static detail builders, the converter branches, the recorder emitters
     /// (exercised directly with a reflectively-constructed <c>Strategies.Strategy</c>
-    /// is not possible without a live KSP runtime — see the skipped test below), and
+    /// is not possible without a live KSP runtime -- see the skipped test below), and
     /// the classifier wiring. Harmony patch coverage itself is deferred to an in-game
     /// test: <c>Strategies.Strategy</c> requires a live <c>StrategyConfig</c> and
     /// PartLoader to construct, which xUnit cannot set up from scratch.
@@ -325,7 +325,7 @@ namespace Parsek.Tests
             Assert.Equal(LedgerOrchestrator.KscReconcileClass.Untransformed, exp.Class);
             Assert.Equal(0.0, exp.ExpectedDelta);
 
-            // Reconcile with an empty event stream — must stay silent.
+            // Reconcile with an empty event stream -- must stay silent.
             LedgerOrchestrator.ReconcileKscAction(
                 new List<GameStateEvent>(),
                 new List<GameAction> { a },

--- a/Source/Parsek.Tests/StrategyCaptureTests.cs
+++ b/Source/Parsek.Tests/StrategyCaptureTests.cs
@@ -1,0 +1,529 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// #439 Phase A: strategy lifecycle capture coverage. These tests exercise the
+    /// pure-static detail builders, the converter branches, the recorder emitters
+    /// (exercised directly with a reflectively-constructed <c>Strategies.Strategy</c>
+    /// is not possible without a live KSP runtime — see the skipped test below), and
+    /// the classifier wiring. Harmony patch coverage itself is deferred to an in-game
+    /// test: <c>Strategies.Strategy</c> requires a live <c>StrategyConfig</c> and
+    /// PartLoader to construct, which xUnit cannot set up from scratch.
+    ///
+    /// Pattern copied from <c>MilestoneRewardCaptureTests</c>: log capture, shared
+    /// static state resets in ctor/Dispose, <c>[Collection("Sequential")]</c>.
+    /// </summary>
+    [Collection("Sequential")]
+    public class StrategyCaptureTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+        private static readonly CultureInfo IC = CultureInfo.InvariantCulture;
+
+        public StrategyCaptureTests()
+        {
+            RecalculationEngine.ClearModules();
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+
+            GameStateStore.SuppressLogging = true;
+            GameStateStore.ResetForTesting();
+            LedgerOrchestrator.ResetForTesting();
+            KspStatePatcher.SuppressUnityCallsForTesting = true;
+            GameStateRecorder.ResetForTesting();
+        }
+
+        public void Dispose()
+        {
+            RecalculationEngine.ClearModules();
+            GameStateRecorder.ResetForTesting();
+            LedgerOrchestrator.ResetForTesting();
+            KspStatePatcher.ResetForTesting();
+            GameStateStore.ResetForTesting();
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+        }
+
+        // ================================================================
+        // Detail builders (pure static)
+        // ================================================================
+
+        [Fact]
+        public void BuildStrategyActivateDetail_FormatsAsExpected()
+        {
+            string s = GameStateRecorder.BuildStrategyActivateDetail(
+                title: "Unpaid Research Program",
+                dept: "Science",
+                factor: 0.25f,
+                setupFunds: 7500f,
+                setupSci: 0f,
+                setupRep: 0f);
+
+            Assert.Contains("title=Unpaid Research Program", s);
+            Assert.Contains("dept=Science", s);
+            Assert.Contains("factor=0.25", s);
+            Assert.Contains("setupFunds=7500", s);
+            Assert.Contains("setupSci=0", s);
+            Assert.Contains("setupRep=0", s);
+
+            // Six semicolon-separated fields, order-stable.
+            Assert.Equal(5, s.Split(';').Length - 1);
+        }
+
+        [Fact]
+        public void BuildStrategyActivateDetail_UsesInvariantCulture()
+        {
+            // 0.25 must stringify as "0.25", never "0,25" even on comma-locale hosts.
+            string s = GameStateRecorder.BuildStrategyActivateDetail(
+                title: "t", dept: "d",
+                factor: 0.25f, setupFunds: 1000.5f, setupSci: 0.5f, setupRep: -1.75f);
+
+            Assert.DoesNotContain(",", s);
+            Assert.Contains("factor=0.25", s);
+            Assert.Contains("setupFunds=1000.5", s);
+            Assert.Contains("setupSci=0.5", s);
+            Assert.Contains("setupRep=-1.75", s);
+        }
+
+        [Fact]
+        public void BuildStrategyDeactivateDetail_FormatsAsExpected()
+        {
+            string s = GameStateRecorder.BuildStrategyDeactivateDetail(
+                title: "Unpaid Research Program",
+                dept: "Science",
+                factor: 0.1f,
+                activeDurationSec: 12345.5);
+
+            Assert.Contains("title=Unpaid Research Program", s);
+            Assert.Contains("dept=Science", s);
+            Assert.Contains("factor=0.1", s);
+            Assert.Contains("activeDurationSec=12345.5", s);
+            Assert.DoesNotContain(",", s);
+        }
+
+        [Fact]
+        public void BuildStrategyActivateDetail_NullInputs_ProduceEmptyFields()
+        {
+            string s = GameStateRecorder.BuildStrategyActivateDetail(
+                title: null, dept: null,
+                factor: 0f, setupFunds: 0f, setupSci: 0f, setupRep: 0f);
+
+            // Null fields serialize as empty strings; the semicolon skeleton stays intact
+            // so the converter's ExtractDetail can still index by key name.
+            Assert.Contains("title=;", s);
+            Assert.Contains("dept=;", s);
+        }
+
+        // ================================================================
+        // Converter round-trip
+        // ================================================================
+
+        [Fact]
+        public void ConvertStrategyActivated_ReturnsStrategyActivateAction()
+        {
+            var evt = new GameStateEvent
+            {
+                ut = 1234.0,
+                eventType = GameStateEventType.StrategyActivated,
+                key = "UnpaidResearchProgram",
+                detail = GameStateRecorder.BuildStrategyActivateDetail(
+                    "Unpaid Research Program", "Science",
+                    factor: 0.25f, setupFunds: 7500f, setupSci: 0f, setupRep: 0f)
+            };
+
+            var action = GameStateEventConverter.ConvertStrategyActivated(evt, "rec-1");
+
+            Assert.Equal(GameActionType.StrategyActivate, action.Type);
+            Assert.Equal("UnpaidResearchProgram", action.StrategyId);
+            Assert.Equal(0.25f, action.Commitment);
+            Assert.Equal(7500f, action.SetupCost);
+            Assert.Equal(1234.0, action.UT);
+            Assert.Equal("rec-1", action.RecordingId);
+        }
+
+        [Fact]
+        public void ConvertStrategyDeactivated_ReturnsStrategyDeactivateAction()
+        {
+            var evt = new GameStateEvent
+            {
+                ut = 5000.0,
+                eventType = GameStateEventType.StrategyDeactivated,
+                key = "UnpaidResearchProgram",
+                detail = GameStateRecorder.BuildStrategyDeactivateDetail(
+                    "Unpaid Research Program", "Science",
+                    factor: 0.25f, activeDurationSec: 3766.0)
+            };
+
+            var action = GameStateEventConverter.ConvertStrategyDeactivated(evt, "rec-1");
+
+            Assert.Equal(GameActionType.StrategyDeactivate, action.Type);
+            Assert.Equal("UnpaidResearchProgram", action.StrategyId);
+            Assert.Equal(5000.0, action.UT);
+            Assert.Equal("rec-1", action.RecordingId);
+        }
+
+        [Fact]
+        public void ConvertStrategyActivated_MissingDetailFields_DefaultToZero()
+        {
+            // Resilience: a legacy or malformed StrategyActivated event whose detail
+            // lacks factor/setupFunds must not throw; missing numeric fields default
+            // to zero and the action still carries the strategy id.
+            var evt = new GameStateEvent
+            {
+                ut = 100.0,
+                eventType = GameStateEventType.StrategyActivated,
+                key = "BarebonesStrategy",
+                detail = "title=Barebones"
+            };
+
+            var action = GameStateEventConverter.ConvertStrategyActivated(evt, null);
+
+            Assert.Equal(GameActionType.StrategyActivate, action.Type);
+            Assert.Equal("BarebonesStrategy", action.StrategyId);
+            Assert.Equal(0f, action.Commitment);
+            Assert.Equal(0f, action.SetupCost);
+        }
+
+        [Fact]
+        public void ConvertEvents_RoutesStrategyEvents()
+        {
+            // End-to-end: ConvertEvents dispatches both event types through the right
+            // branches in ConvertEvent.
+            var events = new List<GameStateEvent>
+            {
+                new GameStateEvent
+                {
+                    ut = 100.0,
+                    eventType = GameStateEventType.StrategyActivated,
+                    key = "StratA",
+                    detail = GameStateRecorder.BuildStrategyActivateDetail(
+                        "A", "Science", 0.1f, 5000f, 0f, 0f)
+                },
+                new GameStateEvent
+                {
+                    ut = 200.0,
+                    eventType = GameStateEventType.StrategyDeactivated,
+                    key = "StratA",
+                    detail = GameStateRecorder.BuildStrategyDeactivateDetail(
+                        "A", "Science", 0.1f, 100.0)
+                }
+            };
+
+            var actions = GameStateEventConverter.ConvertEvents(events, "rec-e2e", 0, 1000);
+
+            Assert.Equal(2, actions.Count);
+            Assert.Equal(GameActionType.StrategyActivate, actions[0].Type);
+            Assert.Equal(GameActionType.StrategyDeactivate, actions[1].Type);
+            Assert.Equal(5000f, actions[0].SetupCost);
+        }
+
+        // ================================================================
+        // Save/load round-trip via GameStateEvent (SerializeInto / DeserializeFrom)
+        // ================================================================
+
+        [Fact]
+        public void SerializeDeserialize_StrategyActivated_RoundTripsByteExact()
+        {
+            var original = new GameStateEvent
+            {
+                ut = 4242.25,
+                eventType = GameStateEventType.StrategyActivated,
+                key = "UnpaidResearchProgram",
+                detail = GameStateRecorder.BuildStrategyActivateDetail(
+                    "Unpaid Research Program", "Science",
+                    factor: 0.25f, setupFunds: 7500f, setupSci: 0f, setupRep: 0f),
+                epoch = 3,
+                recordingId = "rec-round-trip"
+            };
+
+            var node = new ConfigNode("EVENT");
+            original.SerializeInto(node);
+            var reloaded = GameStateEvent.DeserializeFrom(node);
+
+            Assert.Equal(original.eventType, reloaded.eventType);
+            Assert.Equal(original.ut, reloaded.ut);
+            Assert.Equal(original.key, reloaded.key);
+            Assert.Equal(original.detail, reloaded.detail);
+            Assert.Equal(original.epoch, reloaded.epoch);
+            Assert.Equal(original.recordingId, reloaded.recordingId);
+        }
+
+        [Fact]
+        public void SerializeDeserialize_StrategyDeactivated_RoundTripsByteExact()
+        {
+            var original = new GameStateEvent
+            {
+                ut = 9999.0,
+                eventType = GameStateEventType.StrategyDeactivated,
+                key = "UnpaidResearchProgram",
+                detail = GameStateRecorder.BuildStrategyDeactivateDetail(
+                    "Unpaid Research Program", "Science",
+                    factor: 0.25f, activeDurationSec: 5757.0)
+            };
+
+            var node = new ConfigNode("EVENT");
+            original.SerializeInto(node);
+            var reloaded = GameStateEvent.DeserializeFrom(node);
+
+            Assert.Equal(original.eventType, reloaded.eventType);
+            Assert.Equal(original.ut, reloaded.ut);
+            Assert.Equal(original.key, reloaded.key);
+            Assert.Equal(original.detail, reloaded.detail);
+        }
+
+        [Fact]
+        public void EnumValues_StrategyActivatedAndDeactivated_AppendedAt20And21()
+        {
+            // Append-only enum contract: existing saves with event ids 0-19 continue
+            // to load, and any future additions must keep these two IDs fixed.
+            Assert.Equal(20, (int)GameStateEventType.StrategyActivated);
+            Assert.Equal(21, (int)GameStateEventType.StrategyDeactivated);
+        }
+
+        // ================================================================
+        // Classifier (ClassifyAction) and reconciliation behavior
+        // ================================================================
+
+        [Fact]
+        public void ClassifyAction_StrategyActivate_Untransformed_PairsWithStrategySetup()
+        {
+            var a = new GameAction
+            {
+                Type = GameActionType.StrategyActivate,
+                StrategyId = "S1",
+                SetupCost = 7500f,
+                UT = 100.0
+            };
+
+            var exp = LedgerOrchestrator.ClassifyAction(a);
+
+            Assert.Equal(LedgerOrchestrator.KscReconcileClass.Untransformed, exp.Class);
+            Assert.Equal(GameStateEventType.FundsChanged, exp.EventType);
+            Assert.Equal("StrategySetup", exp.ExpectedReasonKey);
+            Assert.Equal(-7500.0, exp.ExpectedDelta);
+        }
+
+        [Fact]
+        public void ClassifyAction_StrategyActivate_ZeroSetupCost_ShortCircuits()
+        {
+            // Free-to-activate strategy: classifier says Untransformed, but the zero
+            // ExpectedDelta triggers the early return in ReconcileKscAction. Drive both
+            // the classifier and the reconciler to pin the behavior.
+            var a = new GameAction
+            {
+                Type = GameActionType.StrategyActivate,
+                StrategyId = "FreeStrat",
+                SetupCost = 0f,
+                UT = 100.0
+            };
+            var exp = LedgerOrchestrator.ClassifyAction(a);
+            Assert.Equal(LedgerOrchestrator.KscReconcileClass.Untransformed, exp.Class);
+            Assert.Equal(0.0, exp.ExpectedDelta);
+
+            // Reconcile with an empty event stream — must stay silent.
+            LedgerOrchestrator.ReconcileKscAction(
+                new List<GameStateEvent>(),
+                new List<GameAction> { a },
+                a,
+                100.0);
+
+            Assert.DoesNotContain(logLines, l => l.Contains("KSC reconciliation"));
+        }
+
+        [Fact]
+        public void ClassifyAction_StrategyDeactivate_NoResourceImpact()
+        {
+            var a = new GameAction
+            {
+                Type = GameActionType.StrategyDeactivate,
+                StrategyId = "S1",
+                UT = 500.0
+            };
+            var exp = LedgerOrchestrator.ClassifyAction(a);
+            Assert.Equal(LedgerOrchestrator.KscReconcileClass.NoResourceImpact, exp.Class);
+        }
+
+        [Fact]
+        public void ReconcileKscAction_StrategyActivate_MatchingStrategySetupDebit_NoWarn()
+        {
+            // Happy path: the StrategyActivated patch fires after Strategy.Activate
+            // deducted InitialCostFunds, so the FundsChanged(StrategySetup) event is
+            // already in the store. Reconcile must match it cleanly.
+            var events = new List<GameStateEvent>
+            {
+                new GameStateEvent
+                {
+                    ut = 1000.0,
+                    eventType = GameStateEventType.FundsChanged,
+                    key = "StrategySetup",
+                    valueBefore = 50000.0,
+                    valueAfter = 42500.0  // -7500
+                }
+            };
+            var action = new GameAction
+            {
+                UT = 1000.0,
+                Type = GameActionType.StrategyActivate,
+                StrategyId = "UnpaidResearch",
+                SetupCost = 7500f
+            };
+            var ledger = new List<GameAction> { action };
+
+            LedgerOrchestrator.ReconcileKscAction(events, ledger, action, 1000.0);
+
+            Assert.DoesNotContain(logLines, l => l.Contains("KSC reconciliation"));
+        }
+
+        // ================================================================
+        // Emitter behavior (static helpers; Harmony patch tested in-game)
+        // ================================================================
+
+        [Fact]
+        public void BuildStrategyActivateDetail_ConverterRoundTrip_PreservesNumericFields()
+        {
+            // Belt-and-braces: go from builder -> event -> converter and assert the
+            // numeric fields survive the IC round-trip with full precision.
+            string detail = GameStateRecorder.BuildStrategyActivateDetail(
+                "T", "D", factor: 0.125f, setupFunds: 12345.5f,
+                setupSci: 0f, setupRep: 0f);
+            var evt = new GameStateEvent
+            {
+                ut = 1.0,
+                eventType = GameStateEventType.StrategyActivated,
+                key = "S",
+                detail = detail
+            };
+            var action = GameStateEventConverter.ConvertStrategyActivated(evt, null);
+
+            Assert.Equal(0.125f, action.Commitment);
+            Assert.Equal(12345.5f, action.SetupCost);
+        }
+
+        // ================================================================
+        // End-to-end: walk a StrategyActivate action through the ledger
+        // ================================================================
+
+        [Fact]
+        public void EndToEnd_ActivateDeactivateWalk_PopulatesActiveStrategies()
+        {
+            // Register Strategies at the module position the RecalculationEngine
+            // expects and walk an activate + deactivate pair. The module must see
+            // both actions and land in the expected activeStrategies state.
+            var strategies = new StrategiesModule();
+            RecalculationEngine.RegisterModule(
+                strategies, RecalculationEngine.ModuleTier.Strategy);
+
+            var activateEvt = new GameStateEvent
+            {
+                ut = 100.0,
+                eventType = GameStateEventType.StrategyActivated,
+                key = "UnpaidResearch",
+                detail = GameStateRecorder.BuildStrategyActivateDetail(
+                    "Unpaid Research Program", "Science",
+                    factor: 0.1f, setupFunds: 5000f, setupSci: 0f, setupRep: 0f)
+            };
+
+            var activateAction = GameStateEventConverter.ConvertStrategyActivated(
+                activateEvt, null);
+            var actions = new List<GameAction> { activateAction };
+
+            RecalculationEngine.Recalculate(actions);
+            Assert.True(strategies.IsStrategyActive("UnpaidResearch"));
+            Assert.Equal(1, strategies.GetActiveStrategyCount());
+
+            // Deactivate at UT=200.
+            var deactivateEvt = new GameStateEvent
+            {
+                ut = 200.0,
+                eventType = GameStateEventType.StrategyDeactivated,
+                key = "UnpaidResearch",
+                detail = GameStateRecorder.BuildStrategyDeactivateDetail(
+                    "Unpaid Research Program", "Science",
+                    factor: 0.1f, activeDurationSec: 100.0)
+            };
+            actions.Add(GameStateEventConverter.ConvertStrategyDeactivated(
+                deactivateEvt, null));
+
+            RecalculationEngine.Recalculate(actions);
+            Assert.False(strategies.IsStrategyActive("UnpaidResearch"));
+            Assert.Equal(0, strategies.GetActiveStrategyCount());
+        }
+
+        [Fact]
+        public void EndToEnd_OnKscSpending_StrategyActivated_WritesStrategyActivateAction()
+        {
+            // OnKscSpending routes the StrategyActivated event through ConvertEvent
+            // into the ledger, assigning a sequence number and running reconciliation.
+            LedgerOrchestrator.Initialize();
+
+            var evt = new GameStateEvent
+            {
+                ut = 1234.0,
+                eventType = GameStateEventType.StrategyActivated,
+                key = "UnpaidResearch",
+                detail = GameStateRecorder.BuildStrategyActivateDetail(
+                    "Unpaid Research Program", "Science",
+                    factor: 0.1f, setupFunds: 5000f, setupSci: 0f, setupRep: 0f)
+            };
+            GameStateStore.AddEvent(ref evt);
+
+            // Also seed the paired FundsChanged(StrategySetup) event that KSP emits
+            // from inside Strategy.Activate(). The reconciler must match it cleanly
+            // so no WARN fires.
+            var fundsEvt = new GameStateEvent
+            {
+                ut = 1234.0,
+                eventType = GameStateEventType.FundsChanged,
+                key = "StrategySetup",
+                valueBefore = 50000.0,
+                valueAfter = 45000.0
+            };
+            GameStateStore.AddEvent(ref fundsEvt);
+
+            LedgerOrchestrator.OnKscSpending(evt);
+
+            var written = Ledger.Actions.FirstOrDefault(a =>
+                a.Type == GameActionType.StrategyActivate &&
+                a.StrategyId == "UnpaidResearch");
+            Assert.NotNull(written);
+            Assert.Equal(5000f, written.SetupCost);
+            Assert.DoesNotContain(logLines, l => l.Contains("KSC reconciliation: Funds mismatch"));
+
+            // The INFO line from GameStateRecorder.OnContractCompleted's cousin is
+            // the KSC spending line; pin it so the log-assertion requirement is met.
+            Assert.Contains(logLines, l =>
+                l.Contains("[LedgerOrchestrator]") &&
+                l.Contains("KSC spending recorded") &&
+                l.Contains("StrategyActivate"));
+        }
+
+        [Fact]
+        public void EndToEnd_OnKscSpending_StrategyDeactivated_WritesNoResourceAction()
+        {
+            LedgerOrchestrator.Initialize();
+
+            var evt = new GameStateEvent
+            {
+                ut = 2000.0,
+                eventType = GameStateEventType.StrategyDeactivated,
+                key = "UnpaidResearch",
+                detail = GameStateRecorder.BuildStrategyDeactivateDetail(
+                    "Unpaid Research Program", "Science",
+                    factor: 0.1f, activeDurationSec: 1000.0)
+            };
+
+            LedgerOrchestrator.OnKscSpending(evt);
+
+            var written = Ledger.Actions.FirstOrDefault(a =>
+                a.Type == GameActionType.StrategyDeactivate &&
+                a.StrategyId == "UnpaidResearch");
+            Assert.NotNull(written);
+            Assert.DoesNotContain(logLines, l => l.Contains("KSC reconciliation: Funds mismatch"));
+        }
+    }
+}

--- a/Source/Parsek/GameActions/GameStateEventConverter.cs
+++ b/Source/Parsek/GameActions/GameStateEventConverter.cs
@@ -118,6 +118,12 @@ namespace Parsek
                 case GameStateEventType.KerbalRescued:
                     return ConvertKerbalRescued(evt, recordingId);
 
+                case GameStateEventType.StrategyActivated:
+                    return ConvertStrategyActivated(evt, recordingId);
+
+                case GameStateEventType.StrategyDeactivated:
+                    return ConvertStrategyDeactivated(evt, recordingId);
+
                 // Skipped event types — no GameAction equivalent.
                 //
                 // DO NOT try to "fix" this by re-emitting FundsChanged/ScienceChanged/
@@ -539,6 +545,58 @@ namespace Parsek
                 RecordingId = recordingId,
                 KerbalName = evt.key,
                 KerbalRole = trait
+            };
+        }
+
+        /// <summary>
+        /// StrategyActivated -> StrategyActivate (#439 Phase A). <c>StrategyId</c> comes
+        /// from <c>evt.key</c> (strategy config Name). <c>Commitment</c> parses the
+        /// <c>factor</c> detail field; <c>SetupCost</c> parses <c>setupFunds</c> — the
+        /// sci/rep setup costs (<c>setupSci</c>, <c>setupRep</c>) are deferred to Phase B
+        /// because <see cref="LedgerOrchestrator.KscActionExpectation"/> only carries a
+        /// single ExpectedDelta/EventType pair today. SourceResource / TargetResource
+        /// default to <see cref="StrategyResource.Funds"/>; stock strategies flow income
+        /// through <c>OnCurrencyModifierQuery</c> and our StrategiesModule transform is
+        /// now a no-op identity, so the source/target fields are unused by the walk.
+        /// Internal static for testability.
+        /// </summary>
+        internal static GameAction ConvertStrategyActivated(GameStateEvent evt, string recordingId)
+        {
+            float factor = 0f;
+            string factorStr = ExtractDetail(evt.detail, "factor");
+            if (factorStr != null)
+                float.TryParse(factorStr, NumberStyles.Float, IC, out factor);
+
+            float setupFunds = 0f;
+            string setupFundsStr = ExtractDetail(evt.detail, "setupFunds");
+            if (setupFundsStr != null)
+                float.TryParse(setupFundsStr, NumberStyles.Float, IC, out setupFunds);
+
+            return new GameAction
+            {
+                UT = evt.ut,
+                Type = GameActionType.StrategyActivate,
+                RecordingId = recordingId,
+                StrategyId = evt.key,
+                Commitment = factor,
+                SetupCost = setupFunds
+            };
+        }
+
+        /// <summary>
+        /// StrategyDeactivated -> StrategyDeactivate (#439 Phase A). Carries only the
+        /// StrategyId; the deactivate action has no resource flow and the classifier
+        /// maps it to <see cref="LedgerOrchestrator.KscReconcileClass.NoResourceImpact"/>.
+        /// Internal static for testability.
+        /// </summary>
+        internal static GameAction ConvertStrategyDeactivated(GameStateEvent evt, string recordingId)
+        {
+            return new GameAction
+            {
+                UT = evt.ut,
+                Type = GameActionType.StrategyDeactivate,
+                RecordingId = recordingId,
+                StrategyId = evt.key
             };
         }
 

--- a/Source/Parsek/GameActions/LedgerOrchestrator.cs
+++ b/Source/Parsek/GameActions/LedgerOrchestrator.cs
@@ -3194,12 +3194,26 @@ namespace Parsek
                     };
 
                 case GameActionType.StrategyActivate:
-                    // StrategyActivate has a SetupCost in the plan, but StrategyLifecyclePatch
-                    // is Phase E1.5 work — no capture yet. Skip for now.
+                    // #439 Phase A: StrategyLifecyclePatch now captures strategy activations
+                    // and the converter populates SetupCost from the StrategyActivated event's
+                    // setupFunds field. KSP's Strategy.Activate() calls Funding.Add(-InitialCostFunds,
+                    // TransactionReasons.StrategySetup) inside the method body, so by the time
+                    // our postfix runs GameStateStore already holds a FundsChanged(StrategySetup)
+                    // event with the matching negative delta. Zero-setup-cost strategies hit the
+                    // zero-expected-delta early return in ReconcileKscAction.
+                    //
+                    // Known Phase A limitation: only the Funds leg is reconciled here — a
+                    // strategy with non-zero InitialCostScience or InitialCostReputation will
+                    // still emit false-positive WARNs on those resource legs. Stock
+                    // Administration-tier-1 strategies are funds-only, so most new careers
+                    // never trip it. Multi-resource KscActionExpectation is deferred to
+                    // Phase B (see docs/dev/plans/fix-439-strategy-lifecycle-capture.md).
                     return new KscActionExpectation
                     {
-                        Class = KscReconcileClass.Transformed,
-                        SkipReason = "strategy activate setup cost not yet KSC-captured (Phase E1.5)"
+                        Class = KscReconcileClass.Untransformed,
+                        EventType = GameStateEventType.FundsChanged,
+                        ExpectedReasonKey = "StrategySetup",
+                        ExpectedDelta = -action.SetupCost
                     };
 
                 // ---- Transformed: raw fields do not equal post-walk contribution. ----

--- a/Source/Parsek/GameActions/StrategiesModule.cs
+++ b/Source/Parsek/GameActions/StrategiesModule.cs
@@ -146,113 +146,37 @@ namespace Parsek
         // ================================================================
 
         /// <summary>
-        /// Transforms contract reward fields on a ContractComplete action based on
-        /// active strategy commitments. Only transforms effective contract completions.
+        /// #439 Phase A: documented identity no-op.
         ///
-        /// For each active strategy whose source resource matches a reward field on
-        /// the contract, diverts commitment% of that reward into the target resource:
-        ///   diverted = rewardAmount * commitment
-        ///   sourceReward -= diverted
-        ///   targetReward += diverted
+        /// Stock KSP strategies (Strategies.Effects.CurrencyConverter /
+        /// CurrencyOperation) subscribe <c>GameEvents.Modifiers.OnCurrencyModifierQuery</c>
+        /// and mutate the pending currency query BEFORE KSP's Funding /
+        /// ReputationHandler / ResearchAndDevelopment code fires the final
+        /// <c>FundsChanged</c> / <c>ReputationChanged</c> / <c>ScienceChanged</c>
+        /// event. Our <see cref="GameStateRecorder.OnContractCompleted"/> captures
+        /// <c>contract.FundsCompletion</c> / <c>RepCompletion</c> / <c>ScienceCompletion</c>
+        /// which ARE the post-transform values — applying Commitment a second time here
+        /// would double-divert.
         ///
-        /// Uses the strategy's Commitment field (player's chosen commitment level,
-        /// 0.01 to 0.25) as the diversion fraction. Full per-strategy conversion
-        /// rates require KSP Strategy instances (deferred item D2).
-        /// Modifies the action in place (derived fields, not persisted).
+        /// The method is retained (not deleted) so the action walk still dispatches
+        /// ContractComplete through StrategiesModule for future extension (e.g. for
+        /// mod strategies that bypass the modifier-query path, or for a UI overlay that
+        /// needs to display "X% diverted" attribution). Phase A emits one VERBOSE line
+        /// per call so the no-op is observable in logs.
+        ///
+        /// See <c>docs/dev/plans/fix-439-strategy-lifecycle-capture.md</c> section 3.5
+        /// (option B) for the full rationale and option C deferral.
         /// </summary>
         internal void TransformContractReward(GameAction action)
         {
             if (action.Type != GameActionType.ContractComplete)
                 return;
 
-            if (!action.Effective)
-            {
-                ParsekLog.Verbose(Tag,
-                    $"TransformContractReward skipped (not effective): contractId='{action.ContractId ?? "(none)"}'");
-                return;
-            }
-
-            if (activeStrategies.Count == 0)
-            {
-                ParsekLog.Verbose(Tag,
-                    $"TransformContractReward skipped (no active strategies): contractId='{action.ContractId ?? "(none)"}'");
-                return;
-            }
-
-            foreach (var kvp in activeStrategies)
-            {
-                var strategy = kvp.Value;
-
-                // Only transform if the contract UT is within the strategy's active window.
-                // The strategy is active from ActivateUT onward (until a Deactivate removes it).
-                if (action.UT < strategy.ActivateUT)
-                {
-                    ParsekLog.Verbose(Tag,
-                        $"TransformContractReward: strategy='{strategy.StrategyId}' skipped for " +
-                        $"contractId='{action.ContractId ?? "(none)"}' (contract UT={action.UT.ToString("F1", IC)} " +
-                        $"< activateUT={strategy.ActivateUT.ToString("F1", IC)})");
-                    continue;
-                }
-
-                // Use the strategy's commitment level as the diversion fraction.
-                // Player-chosen commitment ranges from 0.01 to 0.25 (1% to 25%).
-                // Full per-strategy conversion rates require KSP Strategy instances
-                // which are unavailable during the pure recalculation walk (deferred D2).
-                float diversionFraction = strategy.Commitment;
-
-                float diverted;
-                switch (strategy.SourceResource)
-                {
-                    case StrategyResource.Funds:
-                        diverted = action.TransformedFundsReward * diversionFraction;
-                        action.TransformedFundsReward -= diverted;
-                        AddToTargetResource(action, strategy.TargetResource, diverted);
-                        LogTransform(strategy, action, "FundsReward", diverted, diversionFraction);
-                        break;
-
-                    case StrategyResource.Science:
-                        diverted = action.TransformedScienceReward * diversionFraction;
-                        action.TransformedScienceReward -= diverted;
-                        AddToTargetResource(action, strategy.TargetResource, diverted);
-                        LogTransform(strategy, action, "ScienceReward", diverted, diversionFraction);
-                        break;
-
-                    case StrategyResource.Reputation:
-                        diverted = action.TransformedRepReward * diversionFraction;
-                        action.TransformedRepReward -= diverted;
-                        AddToTargetResource(action, strategy.TargetResource, diverted);
-                        LogTransform(strategy, action, "RepReward", diverted, diversionFraction);
-                        break;
-                }
-            }
-        }
-
-        private static void AddToTargetResource(GameAction action, StrategyResource target, float amount)
-        {
-            switch (target)
-            {
-                case StrategyResource.Funds:
-                    action.TransformedFundsReward += amount;
-                    break;
-                case StrategyResource.Science:
-                    action.TransformedScienceReward += amount;
-                    break;
-                case StrategyResource.Reputation:
-                    action.TransformedRepReward += amount;
-                    break;
-            }
-        }
-
-        private static void LogTransform(
-            StrategyState strategy, GameAction action,
-            string sourceField, float diverted, float diversionFraction)
-        {
             ParsekLog.Verbose(Tag,
-                $"Transform: strategy='{strategy.StrategyId}' contractId='{action.ContractId}' " +
-                $"source={sourceField} diverted={diverted.ToString("F2", IC)} " +
-                $"diversionFraction={diversionFraction.ToString("F3", IC)} " +
-                $"target={strategy.TargetResource} added={diverted.ToString("F2", IC)} " +
-                $"ut={action.UT.ToString("F1", IC)}");
+                $"StrategiesModule.TransformContractReward: identity no-op (KSP " +
+                $"CurrencyModifierQuery already transformed contract reward pre-event) " +
+                $"contractId='{action.ContractId ?? "(none)"}' " +
+                $"activeStrategies={activeStrategies.Count}");
         }
 
         // ================================================================

--- a/Source/Parsek/GameStateEvent.cs
+++ b/Source/Parsek/GameStateEvent.cs
@@ -25,7 +25,9 @@ namespace Parsek
         ScienceChanged,      // 16
         ReputationChanged,   // 17
         MilestoneAchieved,   // 18
-        KerbalRescued        // 19
+        KerbalRescued,       // 19
+        StrategyActivated,   // 20
+        StrategyDeactivated  // 21
     }
 
     public struct GameStateEvent
@@ -315,6 +317,9 @@ namespace Parsek
                     return "Reputation";
                 case GameStateEventType.MilestoneAchieved:
                     return "Milestone";
+                case GameStateEventType.StrategyActivated:
+                case GameStateEventType.StrategyDeactivated:
+                    return "Strategy";
                 default:
                     return "Event";
             }
@@ -396,6 +401,16 @@ namespace Parsek
                 {
                     string trait = ExtractDetailField(detail, "trait");
                     return trait != null ? $"Rescued {key} ({trait})" : $"Rescued {key}";
+                }
+                case GameStateEventType.StrategyActivated:
+                {
+                    string title = ExtractDetailField(detail, "title");
+                    return title != null ? $"\"{title}\" activated" : $"\"{key}\" activated";
+                }
+                case GameStateEventType.StrategyDeactivated:
+                {
+                    string title = ExtractDetailField(detail, "title");
+                    return title != null ? $"\"{title}\" deactivated" : $"\"{key}\" deactivated";
                 }
                 default:
                     return key;

--- a/Source/Parsek/GameStateRecorder.cs
+++ b/Source/Parsek/GameStateRecorder.cs
@@ -1338,6 +1338,170 @@ namespace Parsek
 
         #endregion
 
+        #region Strategy Lifecycle (#439 Phase A)
+
+        /// <summary>
+        /// Called from the Harmony postfix on <c>Strategies.Strategy.Activate</c> when
+        /// <c>__result == true</c> (stock returns false on a CanBeActivated miss). Emits a
+        /// <see cref="GameStateEventType.StrategyActivated"/> event carrying the strategy's
+        /// configured setup costs; downstream <see cref="GameStateEventConverter"/> parses
+        /// the detail and the ledger's <see cref="LedgerOrchestrator.ClassifyAction"/>
+        /// reconciles the funds setup cost against the paired
+        /// <c>FundsChanged(StrategySetup)</c> event KSP fires inside <c>Activate()</c>.
+        ///
+        /// Respects <see cref="IsReplayingActions"/> so recalculation replays stay silent.
+        /// Internal static for testability — the Harmony postfix is the only production
+        /// call site.
+        /// </summary>
+        internal static void OnStrategyActivated(Strategies.Strategy strategy)
+        {
+            if (IsReplayingActions)
+            {
+                ParsekLog.Verbose("GameStateRecorder",
+                    "OnStrategyActivated: suppressed during action replay");
+                return;
+            }
+            if (strategy == null)
+            {
+                ParsekLog.Verbose("GameStateRecorder",
+                    "OnStrategyActivated: null strategy - skipped");
+                return;
+            }
+            if (strategy.Config == null)
+            {
+                ParsekLog.Warn("GameStateRecorder",
+                    "OnStrategyActivated: strategy.Config is null - skipped");
+                return;
+            }
+
+            string key = strategy.Config.Name ?? "";
+            string title = strategy.Title ?? "";
+            string dept = strategy.DepartmentName ?? "";
+            float factor = strategy.Factor;
+            float setupFunds = strategy.InitialCostFunds;
+            float setupSci = strategy.InitialCostScience;
+            float setupRep = strategy.InitialCostReputation;
+
+            var evt = new GameStateEvent
+            {
+                ut = Planetarium.GetUniversalTime(),
+                eventType = GameStateEventType.StrategyActivated,
+                key = key,
+                detail = BuildStrategyActivateDetail(title, dept, factor,
+                    setupFunds, setupSci, setupRep)
+            };
+            Emit(ref evt, "StrategyActivated");
+
+            ParsekLog.Info("GameStateRecorder",
+                $"Game state: StrategyActivated '{key}' title='{title}' dept='{dept}' " +
+                $"factor={factor.ToString("F2", System.Globalization.CultureInfo.InvariantCulture)} " +
+                $"setupFunds={setupFunds.ToString("F0", System.Globalization.CultureInfo.InvariantCulture)} " +
+                $"setupSci={setupSci.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)} " +
+                $"setupRep={setupRep.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)}");
+
+            // KSC-side forwarding mirror: StrategyActivate actions with a non-zero setup
+            // cost need to land on the ledger immediately when the player activates from
+            // the Administration building (i.e. outside flight). The commit-time
+            // ConvertEvents path will also pick up flight-scope strategies. The #431 gate
+            // skips the ledger write when the event was tagged during a teardown window.
+            if (!IsFlightScene() && string.IsNullOrEmpty(ResolveCurrentRecordingTag()))
+                LedgerOrchestrator.OnKscSpending(evt);
+        }
+
+        /// <summary>
+        /// Called from the Harmony postfix on <c>Strategies.Strategy.Deactivate</c> when
+        /// <c>__result == true</c>. Emits <see cref="GameStateEventType.StrategyDeactivated"/>.
+        /// Stock Deactivate has no resource cost, so the classifier maps this to
+        /// <see cref="LedgerOrchestrator.KscReconcileClass.NoResourceImpact"/>.
+        /// Internal static for testability.
+        /// </summary>
+        internal static void OnStrategyDeactivated(Strategies.Strategy strategy)
+        {
+            if (IsReplayingActions)
+            {
+                ParsekLog.Verbose("GameStateRecorder",
+                    "OnStrategyDeactivated: suppressed during action replay");
+                return;
+            }
+            if (strategy == null)
+            {
+                ParsekLog.Verbose("GameStateRecorder",
+                    "OnStrategyDeactivated: null strategy - skipped");
+                return;
+            }
+            if (strategy.Config == null)
+            {
+                ParsekLog.Warn("GameStateRecorder",
+                    "OnStrategyDeactivated: strategy.Config is null - skipped");
+                return;
+            }
+
+            string key = strategy.Config.Name ?? "";
+            string title = strategy.Title ?? "";
+            string dept = strategy.DepartmentName ?? "";
+            float factor = strategy.Factor;
+            double now = Planetarium.GetUniversalTime();
+            double activeDurationSec = now - strategy.DateActivated;
+            if (activeDurationSec < 0) activeDurationSec = 0;
+
+            var evt = new GameStateEvent
+            {
+                ut = now,
+                eventType = GameStateEventType.StrategyDeactivated,
+                key = key,
+                detail = BuildStrategyDeactivateDetail(title, dept, factor, activeDurationSec)
+            };
+            Emit(ref evt, "StrategyDeactivated");
+
+            ParsekLog.Info("GameStateRecorder",
+                $"Game state: StrategyDeactivated '{key}' title='{title}' dept='{dept}' " +
+                $"factor={factor.ToString("F2", System.Globalization.CultureInfo.InvariantCulture)} " +
+                $"activeDurationSec={activeDurationSec.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)}");
+
+            // Mirror the KSC-forwarding path even though StrategyDeactivate is a
+            // NoResourceImpact action — the ledger still needs the StrategyDeactivate row
+            // so StrategiesModule can pair activate/deactivate during the walk.
+            if (!IsFlightScene() && string.IsNullOrEmpty(ResolveCurrentRecordingTag()))
+                LedgerOrchestrator.OnKscSpending(evt);
+        }
+
+        /// <summary>
+        /// Pure: builds the semicolon-separated detail string for a StrategyActivated
+        /// event. Format: <c>title=&lt;t&gt;;dept=&lt;d&gt;;factor=&lt;f&gt;;setupFunds=&lt;sf&gt;;setupSci=&lt;ss&gt;;setupRep=&lt;sr&gt;</c>.
+        /// Numerics serialized with InvariantCulture "R" (round-trip) so comma-locale
+        /// hosts do not break the converter-side parse.
+        /// Internal static for direct unit testing without a KSP runtime.
+        /// </summary>
+        internal static string BuildStrategyActivateDetail(
+            string title, string dept, float factor,
+            float setupFunds, float setupSci, float setupRep)
+        {
+            var ic = System.Globalization.CultureInfo.InvariantCulture;
+            return $"title={title ?? ""};" +
+                   $"dept={dept ?? ""};" +
+                   $"factor={factor.ToString("R", ic)};" +
+                   $"setupFunds={setupFunds.ToString("R", ic)};" +
+                   $"setupSci={setupSci.ToString("R", ic)};" +
+                   $"setupRep={setupRep.ToString("R", ic)}";
+        }
+
+        /// <summary>
+        /// Pure: builds the semicolon-separated detail string for a StrategyDeactivated
+        /// event. Format: <c>title=&lt;t&gt;;dept=&lt;d&gt;;factor=&lt;f&gt;;activeDurationSec=&lt;d&gt;</c>.
+        /// Internal static for direct unit testing.
+        /// </summary>
+        internal static string BuildStrategyDeactivateDetail(
+            string title, string dept, float factor, double activeDurationSec)
+        {
+            var ic = System.Globalization.CultureInfo.InvariantCulture;
+            return $"title={title ?? ""};" +
+                   $"dept={dept ?? ""};" +
+                   $"factor={factor.ToString("R", ic)};" +
+                   $"activeDurationSec={activeDurationSec.ToString("R", ic)}";
+        }
+
+        #endregion
+
         #region Facility Polling
 
         /// <summary>

--- a/Source/Parsek/Patches/StrategyLifecyclePatch.cs
+++ b/Source/Parsek/Patches/StrategyLifecyclePatch.cs
@@ -1,0 +1,102 @@
+using System;
+using HarmonyLib;
+
+namespace Parsek.Patches
+{
+    /// <summary>
+    /// Harmony postfixes on <see cref="Strategies.Strategy.Activate"/> and
+    /// <see cref="Strategies.Strategy.Deactivate"/>. Both KSP methods return <c>true</c>
+    /// on success; we filter on <c>__result</c> to skip the false/CanBeActivated-failed
+    /// branch and only capture real lifecycle transitions.
+    ///
+    /// Fixes #439 Phase A: stock strategies flow through KSP's
+    /// <c>GameEvents.Modifiers.OnCurrencyModifierQuery</c> interception (contract rewards
+    /// are already transformed before <c>onContractCompleted</c> fires), so there is no
+    /// discrete payout API to patch. Capturing activate/deactivate is enough to feed
+    /// <see cref="StrategiesModule"/>'s slot-accounting and to reconcile the
+    /// <c>FundsChanged(StrategySetup)</c> debit KSP fires inside <c>Activate()</c> when
+    /// <c>InitialCostFunds</c> is non-zero. See
+    /// <c>docs/dev/plans/fix-439-strategy-lifecycle-capture.md</c> section 3 for the full
+    /// decompile trace.
+    ///
+    /// Both postfixes respect <see cref="GameStateRecorder.IsReplayingActions"/> so
+    /// <see cref="KspStatePatcher"/>-driven recalculation replays do not re-emit events.
+    /// Defensive try/catch mirrors <see cref="ProgressRewardPatch"/> — never rethrow into
+    /// KSP's strategy pipeline.
+    /// </summary>
+    [HarmonyPatch(typeof(Strategies.Strategy), nameof(Strategies.Strategy.Activate))]
+    internal static class StrategyActivatePatch
+    {
+        private const string Tag = "StrategyLifecyclePatch";
+
+        internal static void Postfix(Strategies.Strategy __instance, bool __result)
+        {
+            try
+            {
+                if (!__result)
+                {
+                    ParsekLog.Verbose(Tag,
+                        "Activate postfix: __result=false (CanBeActivated failed) - skipped");
+                    return;
+                }
+                if (GameStateRecorder.IsReplayingActions)
+                {
+                    ParsekLog.Verbose(Tag,
+                        "Activate postfix: suppressed during action replay");
+                    return;
+                }
+                if (__instance == null)
+                {
+                    ParsekLog.Verbose(Tag,
+                        "Activate postfix: __instance null - skipped");
+                    return;
+                }
+
+                GameStateRecorder.OnStrategyActivated(__instance);
+            }
+            catch (Exception ex)
+            {
+                ParsekLog.Warn(Tag,
+                    $"Activate postfix threw while capturing strategy lifecycle: {ex.Message}");
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(Strategies.Strategy), nameof(Strategies.Strategy.Deactivate))]
+    internal static class StrategyDeactivatePatch
+    {
+        private const string Tag = "StrategyLifecyclePatch";
+
+        internal static void Postfix(Strategies.Strategy __instance, bool __result)
+        {
+            try
+            {
+                if (!__result)
+                {
+                    ParsekLog.Verbose(Tag,
+                        "Deactivate postfix: __result=false - skipped");
+                    return;
+                }
+                if (GameStateRecorder.IsReplayingActions)
+                {
+                    ParsekLog.Verbose(Tag,
+                        "Deactivate postfix: suppressed during action replay");
+                    return;
+                }
+                if (__instance == null)
+                {
+                    ParsekLog.Verbose(Tag,
+                        "Deactivate postfix: __instance null - skipped");
+                    return;
+                }
+
+                GameStateRecorder.OnStrategyDeactivated(__instance);
+            }
+            catch (Exception ex)
+            {
+                ParsekLog.Warn(Tag,
+                    $"Deactivate postfix threw while capturing strategy lifecycle: {ex.Message}");
+            }
+        }
+    }
+}

--- a/Source/Parsek/Patches/StrategyLifecyclePatch.cs
+++ b/Source/Parsek/Patches/StrategyLifecyclePatch.cs
@@ -21,7 +21,7 @@ namespace Parsek.Patches
     ///
     /// Both postfixes respect <see cref="GameStateRecorder.IsReplayingActions"/> so
     /// <see cref="KspStatePatcher"/>-driven recalculation replays do not re-emit events.
-    /// Defensive try/catch mirrors <see cref="ProgressRewardPatch"/> — never rethrow into
+    /// Defensive try/catch mirrors <see cref="ProgressRewardPatch"/> -- never rethrow into
     /// KSP's strategy pipeline.
     /// </summary>
     [HarmonyPatch(typeof(Strategies.Strategy), nameof(Strategies.Strategy.Activate))]

--- a/docs/dev/plans/fix-439-strategy-lifecycle-capture.md
+++ b/docs/dev/plans/fix-439-strategy-lifecycle-capture.md
@@ -1,0 +1,436 @@
+# Fix #439: Strategy lifecycle capture (Phase E1.5 of ledger/lump-sum fix)
+
+Status: plan v2 (Phase A scope, user-confirmed 2026-04-18). Branch: feat/439-strategy-lifecycle-capture.
+Target: v0.8.2 release.
+Governs: Phase E1.5 of docs/dev/plans/fix-ledger-lump-sum-reconciliation.md.
+Depends on: #436 Phase A shipped, #437 Phase B shipped, Phase C, Phase D (#343) shipped, #441 shipped.
+
+## Phase A scope (supersedes detailed sections below where they conflict)
+
+Ship to v0.8.2:
+
+- New event types: `StrategyActivated`, `StrategyDeactivated`. **DROP** `StrategyPayout` entirely — no stock hook drives it. Enum is append-only; adding later is cost-free when a concrete need arises.
+- Harmony postfix on `Strategy.Activate` / `Deactivate` (filter on `__result==true`, try/catch, respect `IsReplayingActions`).
+- Recorder emitters + pure-static detail formatters.
+- Converter routes to existing `StrategyActivate` / `StrategyDeactivate` `GameAction`s.
+- `ClassifyAction`: `StrategyActivate` -> `Untransformed`, Funds-only `ExpectedDelta = -SetupCost` paired against `FundsChanged(StrategySetup)`. `StrategyDeactivate` stays `NoResourceImpact`.
+- `StrategiesModule.TransformContractReward` -> documented no-op + VERBOSE log (required — populating `activeStrategies` activates the dormant double-count).
+- `activeStrategies` populated (slot-accounting, reservation logic, Actions window display).
+- Flip the existing `ClassifyAction_StrategyActivate_TransformedNotUntransformed` test.
+- New `StrategyCaptureTests.cs`.
+- Audit `StrategiesModuleTests.cs` for any test asserting `TransformedFundsReward != FundsReward` under active strategy — update to the identity invariant.
+- CHANGELOG 1-liner; todo strike-through plus known-limitation note for Sci/Rep setup costs.
+
+**Known limitation shipped with Phase A**: strategies with non-zero `InitialCostScience` or `InitialCostReputation` will still emit a false-positive KSC-reconciliation WARN on those resource legs. Stock Admin-tier-1 strategies are funds-only, so most new careers never trip it. Follow-up entry filed for Phase B.
+
+**NOT in Phase A (deferred):**
+- Phase B: multi-resource `KscActionExpectation` + Sci/Rep setup cost reconciliation. ~200 lines, fast-follow candidate.
+- Phase C: `StrategyPayout` fallback emitter for mod-compat. Add when a specific mod demands it.
+- Phase D: raw pre-transform reward capture (Funding.AddFunds prefix). Only if a UI feature needs to display diversion.
+
+All sections below are the detailed engineering plan for Phase A. Sections that reference `StrategyPayout` are retained for context only; Phase A emits / converts / enum-adds nothing named `StrategyPayout`.
+
+## 1. Bug restatement
+
+Per docs/dev/todo-and-known-bugs.md entry #439:
+
+- GameStateEvent.cs has no strategy event types.
+- StrategiesModule (Source/Parsek/GameActions/StrategiesModule.cs) consumes StrategyActivate / StrategyDeactivate actions during the recalculation walk and reads action.StrategyId / SourceResource / TargetResource / Commitment / SetupCost.
+- Nothing in the mod captures strategy lifecycle from KSP and nothing converts strategy events into those actions, so StrategiesModule never sees input.
+- Any career that activates a stock strategy (Leadership Initiative, Unpaid Research Program, etc.) diverts contract rewards through a channel the ledger does not model; PatchFunds: suspicious drawdown WARN fires on every revert/rewind cycle for strategy-using careers (same shape as #436 but on new saves, where Phase A's legacy-migration safety net does not apply).
+
+## 2. Success criteria
+
+- On a strategy-using career, no PatchFunds: suspicious drawdown WARN during revert/rewind cycles solely attributable to strategy income or strategy setup cost.
+- StrategiesModule.activeStrategies contains the player's active strategies after a recalculation walk.
+- Contract rewards reconcile against actual KSP funds delta with strategies active (transformed rewards already match because KSP's modifier-query reduces them before the FundsChanged event fires; this plan documents that invariant rather than adding new transform code).
+- Strategy activate SetupCost passes KSC reconciliation (Untransformed class with paired FundsChanged(StrategySetup)).
+- Round-trip test through ParsekScenario save/load preserves the three new event types.
+
+## 3. KSP API research findings (CRITICAL -- reshapes the scope)
+
+Source: ilspycmd decompilation of Kerbal Space Program/KSP_x64_Data/Managed/Assembly-CSharp.dll. This section supersedes the original todo entry's "Strategies.Strategy.Activate / Deactivate and the payout callback" framing; there is NO payout callback.
+
+### 3.1 Patch targets
+
+Concrete, public, instance-method, non-abstract:
+
+- Strategies.Strategy.Activate() -- signature `public bool Activate()`, returns true on success, returns false if CanBeActivated fails. Sets isActive=true, calls Register() (which fires each effect's OnRegister()), sets dateActivated=Planetarium.fetch.time, then for non-zero InitialCostFunds / InitialCostReputation / InitialCostScience calls Funding/Reputation/ResearchAndDevelopment.Instance.Add*(-Mathf.Abs(...), TransactionReasons.StrategySetup). Harmony POSTFIX is correct: we only want to capture on success, and the cost deductions have already fired when the postfix runs, so the FundsChanged(StrategySetup) event has already landed in GameStateStore by the time we emit. Filter on the postfix result (`bool __result`) to skip the false/CanBeActivated-failed branch.
+- Strategies.Strategy.Deactivate() -- signature `public bool Deactivate()`, returns true on success. Sets isActive=false, calls Unregister(). No resource cost. Harmony POSTFIX, filter on __result.
+
+Both methods are concrete (not abstract / not virtual overrides that a subclass may elide), and both are reachable from StrategyListItem / ActiveStrategyListItem UI paths. The Harmony targets are stable.
+
+### 3.2 There is NO strategy-payout API call in stock KSP
+
+Stock strategies with ongoing effects work via CurrencyModifierQuery interception, not discrete payout calls. Evidence:
+
+- Strategies.StrategyEffect has virtual OnRegister / OnUnregister / OnUpdate. OnUpdate is called by Strategies.Strategy.Update() per tick but stock effects use it only for cache refresh, not payouts.
+- Strategies.Effects.CurrencyConverter.OnRegister subscribes GameEvents.Modifiers.OnCurrencyModifierQuery. Its handler reads `qry.GetInput(input)`, multiplies by share, calls `qry.AddDelta(input, -num)` and `qry.AddDelta(output, rate*num)`. The CurrencyModifierQuery is consulted by KSP's Funding/Reputation/RnD code BEFORE the final AddFunds / AddReputation / AddScience call -- so the diverted amount never enters the funds delta. The player never sees the "pre-transform" reward and neither does GameStateRecorder.OnFundsChanged -- by the time the FundsChanged event fires, the reward has already been reduced.
+- Strategies.Effects.CurrencyOperation follows the same OnCurrencyModifierQuery subscription pattern.
+- Strategies.Effects.ValueModifier modifies game values (e.g. kerbal training cost) via ad-hoc GameVariables hooks -- no currency flow at all.
+
+**Implication**: the "StrategyPayout" event originally planned as a captured-from-KSP event has no hook to capture. Strategy income on contract completion is ALREADY in the ContractComplete FundsReward value we read -- KSP has pre-transformed it through the modifier query before firing onContractCompleted. Our existing ContractComplete capture is therefore correct even with active strategies, contrary to the plan's premise. The StrategiesModule.TransformContractReward step that applies Commitment as a diversion fraction then DOUBLE-applies the transform. See section 3.5.
+
+### 3.3 There is NO `GameEvents.onStrategyToggled`
+
+`ilspycmd -t GameEvents` shows only strategy-UI-adjacent events (`onGUIAdministrationFacilitySpawn` / `Despawn`), no strategy state toggle. Harmony on Strategy.Activate / Deactivate is the only path.
+
+### 3.4 One-shot activation rewards (non-transform strategies)
+
+`Strategy.Activate()` pays setup cost only (InitialCostFunds / Science / Reputation, debits via TransactionReasons.StrategySetup). Stock does not grant one-shot funds/rep/science on activate; the initial-cost fields are always costs (Activate subtracts Mathf.Abs(cost)), never payouts. If a mod introduces a strategy that grants at activation, the generic FundsChanged(StrategySetup) / ScienceChanged / ReputationChanged stream with positive delta will capture it, and the StrategyActivated event's paired cost metrics let ClassifyAction do the reconciliation without a new "StrategyPayout" type.
+
+Leadership Initiative (cited in the todo entry as a one-shot payout milestone example) is actually stock-implemented as a CurrencyConverter -- it converts a fraction of incoming Reputation gains into Funds, not a milestone-style one-shot.
+
+### 3.5 Correctness review of StrategiesModule.TransformContractReward (existing code)
+
+StrategiesModule.cs:183-228 reads action.TransformedFundsReward, multiplies by Commitment, and re-credits the diverted amount to the target resource. BUT the ContractComplete action's FundsReward / RepReward / ScienceReward values that feed TransformedFundsReward / etc. are READ FROM the FundsChanged / ReputationChanged / ScienceChanged event deltas that KSP wrote AFTER the modifier-query already transformed them. Applying Commitment a second time over-diverts. This is a latent bug that only surfaces once #439 starts feeding StrategyActivate actions into the walk.
+
+**Resolution** (option B picked):
+
+- Option A: keep TransformContractReward, subtract a second diversion, and bank on ConvertContractCompleted reading pre-transform values from some KSP-side snapshot. No such snapshot exists -- onContractCompleted fires with `contract.FundsCompletion` which is the raw config value; the reward KSP actually pays (and we see via FundsChanged) is the transformed one. Mixed semantics, bug-prone.
+- Option B (picked): treat ConvertContractCompleted's FundsReward / RepReward / ScienceReward as the effective, already-transformed amount. Make StrategiesModule.TransformContractReward a no-op when the contract is post-activation (document the invariant). Keep the activeStrategies tracking for the reservation-slot accounting use case (GetActiveStrategyCount / GetAvailableSlots) and for detail rendering in the Actions window.
+- Option C: switch ConvertContractCompleted to read raw contract rewards (contract.FundsCompletion as it would pay without strategies), then let TransformContractReward re-apply diversion. Requires patching ConvertContractCompleted AND capturing raw pre-transform values at onContractCompleted time AND a separate reconciliation step for the difference. Large, out-of-scope for #439.
+
+Option B is the minimum viable change. Option C is deferred and tracked as a follow-up TODO (see section 12.2).
+
+## 4. Event-type design
+
+Match shape of existing events in `Source/Parsek/GameStateEvent.cs` (see ContractAccepted for the "semicolon-separated key=value detail" convention).
+
+### 4.1 StrategyActivated
+
+- key = strategy Config.Name (stable config identifier, not localized Title). Example: `"UnpaidResearchProgram"`.
+- detail format: `title=<Title>;dept=<DepartmentName>;factor=<Factor>;setupFunds=<InitialCostFunds>;setupSci=<InitialCostScience>;setupRep=<InitialCostReputation>`. All numerics with InvariantCulture "R" format.
+- valueBefore / valueAfter: unused, leave zero.
+- ut = Planetarium.GetUniversalTime() at the postfix.
+- epoch / recordingId: stamped by Emit via ref parameter per #454.
+
+### 4.2 StrategyDeactivated
+
+- key = Config.Name.
+- detail format: `title=<Title>;dept=<DepartmentName>;factor=<Factor>;activeDurationSec=<now-DateActivated>`.
+- valueBefore / valueAfter: unused.
+- ut = Planetarium.GetUniversalTime() at the postfix.
+
+### 4.3 StrategyPayout
+
+Retained in the enum but only emitted from a fallback path. Payload:
+
+- key = Config.Name.
+- detail format: `title=<Title>;fundsDelta=<f>;sciDelta=<s>;repDelta=<r>;reason=<TransactionReasons.ToString()>`.
+- valueBefore / valueAfter: running post-payout balance of the dominant non-zero currency.
+
+StrategyPayout exists as an enum value and a converter branch so a future mod-compat improvement (or a stock change) can populate it without schema migration.
+
+### 4.4 Enum ids
+
+Append to the enum (existing ids 0-19):
+
+```csharp
+public enum GameStateEventType
+{
+    // ... existing 0..19
+    StrategyActivated    = 20,
+    StrategyDeactivated  = 21,
+    StrategyPayout       = 22
+}
+```
+
+Append-only -- existing serialized saves continue to load.
+
+## 5. Harmony patch design
+
+### 5.1 StrategyLifecyclePatch.cs (new file)
+
+```
+Source/Parsek/Patches/StrategyLifecyclePatch.cs
+```
+
+Two Harmony postfixes, one per method. Both filter on `bool __result`.
+
+```csharp
+[HarmonyPatch(typeof(Strategies.Strategy), nameof(Strategies.Strategy.Activate))]
+internal static class StrategyActivatePatch
+{
+    internal static void Postfix(Strategies.Strategy __instance, bool __result) { ... }
+}
+
+[HarmonyPatch(typeof(Strategies.Strategy), nameof(Strategies.Strategy.Deactivate))]
+internal static class StrategyDeactivatePatch
+{
+    internal static void Postfix(Strategies.Strategy __instance, bool __result) { ... }
+}
+```
+
+**Replay guard**: mirror ProgressRewardPatch's `GameStateRecorder.IsReplayingActions` check so capture stays off during recalculation replay (prevents duplicate events during simulated walks).
+
+**Defensive wrapping**: try/catch around the whole postfix body, log WARN on exception, never rethrow into KSP's strategy pipeline.
+
+### 5.2 Fallback plan
+
+If `Strategies.Strategy.Activate` proves un-patchable in some KSP build variant (unlikely), fall back to Harmony on `Strategies.StrategySystem.OnSave` / `OnLoad` to diff the `strategies[i].IsActive` snapshot against the previous recorded snapshot. Coarse but self-healing. Not implemented unless primary target breaks.
+
+### 5.3 StrategyPayout emitter (fallback only)
+
+The recorder's existing `OnFundsChanged(double)` already fires `FundsChanged` events for every `TransactionReasons.StrategySetup` / any other strategy-attributed debit. The StrategyPayout event type is emitted ONLY when a future KSP update or mod introduces a non-query payout path whose reason enum lands outside `TransactionReasons.StrategySetup`. For v0.8.3 the code path is present but never reached on stock; covered by a unit test that pokes the helper directly.
+
+## 6. Recorder emission
+
+File: `Source/Parsek/GameStateRecorder.cs`.
+
+Add three methods plus two pure static helpers to keep logic testable without Harmony:
+
+- `internal void OnStrategyActivated(Strategies.Strategy strategy)` -- called from StrategyActivatePatch.
+- `internal void OnStrategyDeactivated(Strategies.Strategy strategy)` -- symmetric.
+- `internal void RecordStrategyPayout(string strategyConfigName, double fundsDelta, float sciDelta, float repDelta, string transactionReason)` -- fallback-only writer, unit-testable.
+- `internal static string BuildStrategyActivateDetail(string title, string dept, float factor, float setupFunds, float setupSci, float setupRep)` -- pure static, testable.
+- `internal static string BuildStrategyDeactivateDetail(string title, string dept, float factor, double activeDurationSec)` -- pure static, testable.
+
+Patterns copied from `OnContractAccepted` (for detail formatting via InvariantCulture "R") and `OnProgressComplete` / `EnrichPendingMilestoneRewards` (for the split-emit pattern).
+
+Subscribe site: the Harmony patches invoke the GameStateRecorder singleton directly. No GameEvents subscription to add / remove.
+
+**Flight vs KSC scope tagging**: ResolveCurrentRecordingTag already handles this.
+
+## 7. GameAction plumbing
+
+File: `Source/Parsek/GameActions/GameAction.cs`.
+
+### 7.1 Enum additions
+
+`FundsEarningSource` gets `Strategy = 6` appended (for strategy-derived funds gains -- fallback path).
+
+`ReputationSource` gets `Strategy = 3` appended.
+
+`ReputationPenaltySource` already has `Strategy = 3` (existing -- reuse).
+
+`FundsSpendingSource` already has `Strategy = 5` (existing -- consumed by classifier comment in LedgerOrchestrator.cs:3122).
+
+### 7.2 GameActionType
+
+Decision: DO NOT add `GameActionType.StrategyPayout`. Rationale:
+
+- Existing StrategyActivate / StrategyDeactivate carry all state we need.
+- A StrategyPayout event converts to an existing FundsEarning / ReputationEarning / ScienceEarning with the new Strategy source enum -- same plumbing as Milestone/Recovery.
+- Adding a distinct action type duplicates the entire serialize / deserialize ladder for zero schema value.
+
+This diverges from the original todo entry's Option 1 ("Add GameActionType.StrategyPayout") and matches Option 2 ("reuse existing earning types with a strategy source"). Flagged in Risks.
+
+### 7.3 No field changes to GameAction
+
+All existing strategy fields (StrategyId / SourceResource / TargetResource / Commitment / SetupCost) are already declared.
+
+## 8. Converter routing
+
+File: `Source/Parsek/GameActions/GameStateEventConverter.cs`.
+
+### 8.1 StrategyActivated -> GameAction
+
+Add a case branch in ConvertEvent:
+
+```csharp
+case GameStateEventType.StrategyActivated:
+    return ConvertStrategyActivated(evt, recordingId);
+```
+
+ConvertStrategyActivated:
+
+- Type = GameActionType.StrategyActivate.
+- StrategyId = evt.key.
+- SourceResource / TargetResource: default (StrategyResource.Funds). Acceptable gap: TransformContractReward is being made a no-op per section 3.5 -- SourceResource / TargetResource are consumed only for detail rendering.
+- Commitment = parse "factor" from detail.
+- SetupCost = parse "setupFunds" (converter side uses SetupCost for the funds leg; sci / rep setup costs are deferred -- section 12.2).
+
+### 8.2 StrategyDeactivated -> GameAction
+
+```csharp
+case GameStateEventType.StrategyDeactivated:
+    return ConvertStrategyDeactivated(evt, recordingId);
+```
+
+Trivially: Type = StrategyDeactivate, StrategyId = evt.key.
+
+### 8.3 StrategyPayout -> GameAction (fallback path)
+
+Prefer one StrategyPayout event per resource leg, so each converts to a single GameAction (FundsEarning + FundsSource=Strategy, or ReputationEarning + RepSource=Strategy, or ScienceEarning with SubjectId="Strategy:<name>"). Keeps the converter's single-return contract intact.
+
+## 9. LedgerOrchestrator wiring
+
+File: `Source/Parsek/GameActions/LedgerOrchestrator.cs`.
+
+### 9.1 ClassifyAction changes
+
+Flip StrategyActivate from its current Phase E1.5 skip stub to Untransformed:
+
+```csharp
+case GameActionType.StrategyActivate:
+    // Phase E1.5 delivered: StrategyActivate's SetupCost pairs with a
+    // FundsChanged(StrategySetup) event written by GameStateRecorder.OnFundsChanged.
+    return new KscActionExpectation
+    {
+        Class = KscReconcileClass.Untransformed,
+        EventType = GameStateEventType.FundsChanged,
+        ExpectedReasonKey = "StrategySetup",
+        ExpectedDelta = -action.SetupCost
+    };
+```
+
+Side-effects: ReconcileKsc will now WARN on strategies that activate with a non-zero InitialCostFunds but no paired FundsChanged(StrategySetup) event -- desired. The paired ScienceChanged(StrategySetup) / ReputationChanged(StrategySetup) pairings for InitialCostScience / InitialCostReputation are noted as gaps and deferred (section 12.2).
+
+StrategyDeactivate stays NoResourceImpact (no resource flow on deactivate in stock).
+
+### 9.2 Test flip
+
+`Source/Parsek.Tests/EarningsReconciliationTests.cs::ClassifyAction_StrategyActivate_TransformedNotUntransformed` (lines 932-941) becomes `ClassifyAction_StrategyActivate_Untransformed`:
+
+```csharp
+var a = new GameAction { Type = GameActionType.StrategyActivate, SetupCost = 100000f };
+var exp = LedgerOrchestrator.ClassifyAction(a);
+Assert.Equal(LedgerOrchestrator.KscReconcileClass.Untransformed, exp.Class);
+Assert.Equal(GameStateEventType.FundsChanged, exp.EventType);
+Assert.Equal("StrategySetup", exp.ExpectedReasonKey);
+Assert.Equal(-100000, exp.ExpectedDelta);
+```
+
+Plus a zero-cost case (free strategy) asserts the zero-delta early return.
+
+### 9.3 Post-walk hook
+
+Per #440's scope -- #440 owns the post-walk reconciliation. #439 does NOT change post-walk behavior.
+
+### 9.4 StrategiesModule behavioral change (from 3.5)
+
+File: `Source/Parsek/GameActions/StrategiesModule.cs`.
+
+TransformContractReward (lines 163-228) becomes a no-op documented as "KSP's CurrencyModifierQuery already transformed the reward pre-event; applying Commitment here would double-count". Keep the activeStrategies dict population (ProcessActivate / ProcessDeactivate) -- the dict is still used by GetActiveStrategyCount / GetAvailableSlots (reservation accounting) and by the Actions window for display.
+
+Prefer "documented identity function that logs VERBOSE on each call" over outright deletion -- clearer diff, easier to revert if KSP behavior changes.
+
+## 10. Save/load schema
+
+File: `Source/Parsek/ParsekScenario.cs` (no change required).
+
+File: `Source/Parsek/GameStateStore.cs` (no change required).
+
+Evidence: GameStateStore writes every event via a generic `e.SerializeInto(eventNode)`; reads via `GameStateEvent.DeserializeFrom(en)`. The serialize/deserialize pair in `GameStateEvent.cs` is generic over the enum value -- new ids round-trip automatically. Deserialize already logs WARN on unknown enum ids, so older builds loading new events degrade to a warning, not a crash.
+
+GameAction uses the same generic pattern -- any GameAction emitted by the converter round-trips.
+
+Round-trip test (section 11) explicitly covers save + reload + re-walk to verify these invariants.
+
+## 11. Test plan
+
+New file: `Source/Parsek.Tests/StrategyCaptureTests.cs`, pattern from `MilestoneRewardCaptureTests.cs`.
+
+Scaffolding (mirrors MilestoneRewardCaptureTests.ctor):
+
+- `[Collection("Sequential")]` -- touches GameStateStore / LedgerOrchestrator / ParsekLog static state.
+- Constructor clears RecalculationEngine modules, resets ParsekLog test sink, suppresses KspStatePatcher Unity calls, resets GameStateStore and LedgerOrchestrator.
+
+Test categories:
+
+### 11.1 Capture symmetry (recorder helpers, no Harmony)
+
+- `BuildStrategyActivateDetail_FormatsAsExpected` -- asserts semicolon-joined, InvariantCulture "R" formatting, all six fields present.
+- `BuildStrategyDeactivateDetail_FormatsAsExpected` -- symmetric.
+- `OnStrategyActivated_EmitsEventWithCorrectKeyAndDetail` -- calls recorder helper with a fake strategy mock, asserts GameStateStore.Events contains a StrategyActivated with the expected key / detail / ut / recordingId-empty (KSC scope).
+- `OnStrategyDeactivated_EmitsEvent` -- symmetric.
+- `OnStrategyActivated_DuringFlight_TagsRecordingId` -- TagResolverForTesting stubbed to return "rec-123", assert recordingId tag.
+- `OnStrategyActivated_DuringReplay_Suppresses` -- sets GameStateRecorder.IsReplayingActions = true, asserts no event added.
+
+### 11.2 Converter correctness
+
+- `ConvertStrategyActivated_ReturnsStrategyActivateAction` -- asserts Type, StrategyId, Commitment, SetupCost parsed from detail.
+- `ConvertStrategyActivated_MissingDetailField_DefaultsZero` -- resilience.
+- `ConvertStrategyDeactivated_ReturnsStrategyDeactivateAction` -- asserts Type, StrategyId.
+- `ConvertStrategyPayout_EmitsFundsEarningWithStrategySource` -- fallback path coverage.
+- `ConvertStrategyPayout_ZeroDelta_ReturnsNull` -- no-op shape.
+
+### 11.3 Round-trip
+
+- `RoundTrip_StrategyActivated_SurvivesSaveLoad` -- builds a minimal GameStateStore with one StrategyActivated event, calls GameStateStore.SaveToNode then LoadFromNode, asserts event survives byte-exact on key / detail / ut.
+- `RoundTrip_StrategyActivateAction_SurvivesGameActionSerialize` -- parallel for GameAction.
+- `EndToEnd_StrategyActivateConvertsReplaysPersists` -- emit event -> ConvertEvents -> register action in Ledger -> RecalculateAndPatch -> Save -> Load -> RecalculateAndPatch -> assert StrategiesModule.activeStrategies contains the strategy, assert running balance includes SetupCost deduction.
+
+### 11.4 Classifier
+
+- `ClassifyAction_StrategyActivate_Untransformed_PairsWithStrategySetup` -- replaces the existing "TransformedNotUntransformed" test.
+- `ClassifyAction_StrategyActivate_ZeroSetupCost_ShortCircuits` -- asserts Untransformed class but zero ExpectedDelta so ReconcileKscAction's early return kicks in.
+- `ClassifyAction_StrategyDeactivate_NoResourceImpact` (additive coverage).
+
+### 11.5 Log-capture
+
+Each test verifies logLines contains the expected `[Parsek][INFO][StrategyLifecyclePatch]` / `[Parsek][INFO][GameStateRecorder] Game state: StrategyActivated ...` line. Match the existing pattern from `RewindLoggingTests.cs`.
+
+### 11.6 StrategiesModule no-op transform test
+
+- `TransformContractReward_IsNoOp_AfterPhaseE1_5` -- activate a strategy, process a ContractComplete, assert TransformedFundsReward equals FundsReward (no diversion applied). Pins section 3.5 option B behavior.
+
+## 12. Documentation
+
+### 12.1 CHANGELOG.md
+
+Under the current version's "Fixed" section (ASCII only, 1-2 sentences):
+
+```
+- Fix #439: capture strategy activate / deactivate lifecycle so StrategiesModule sees input on strategy-using careers; removes the spurious PatchFunds suspicious-drawdown warning on revert / rewind cycles after a strategy is active.
+```
+
+### 12.2 docs/dev/todo-and-known-bugs.md
+
+- Strike through the #439 entry and append `Status: done in <branch / commit>`.
+- Update the "Fix:" bullets for #440 to note the StrategyPayout carve-out: stock strategies use CurrencyModifierQuery, so #440's post-walk reconciliation need not sum StrategyPayout deltas; it only needs to reconcile the ContractAccept advance / ContractFail penalty reconciliation paths that already exist in main, plus the strategy activate setup-cost sci/rep follow-ups.
+- Add a new follow-up entry: "Strategy contract-reward double-transform audit" -- if a future KSP update or mod begins emitting onContractCompleted with pre-transform values, StrategiesModule.TransformContractReward needs re-enabling. Low priority.
+- Add another follow-up: "Strategy setup cost for Science and Reputation" -- ClassifyAction currently returns a single ExpectedDelta / EventType; a multi-resource activate (InitialCostScience != 0 OR InitialCostReputation != 0) is unreconciled. Small follow-up once the classifier can return a tuple.
+
+## 13. Risks and open questions
+
+- **R1**: Harmony patch on Strategies.Strategy.Activate might collide with stock strategy mods (Strategia, Contract Configurator+Strategy). Mitigate by using postfix (additive, no prefix short-circuit) and filtering on __result=true. Document in mod-compatibility-notes.md.
+- **R2**: Decision to NOT add GameActionType.StrategyPayout diverges from the original todo text. If a future test or mod needs a distinct action type, adding it later is schema-compatible (append-only enum).
+- **R3**: Making TransformContractReward a no-op may regress a test that asserted diversion. Grep before commit: `Source/Parsek.Tests/StrategiesModuleTests.cs` -- audit for any test that expects TransformedFundsReward != FundsReward under an active strategy. Update those tests to match the new invariant (KSP pre-transforms -- our transform is an identity).
+- **R4**: ClassifyAction for StrategyActivate assumes setupCost = InitialCostFunds only. Strategies with non-zero InitialCostScience or InitialCostReputation will have unreconciled resource events. Follow-up filed in section 12.2. Not release-blocking because stock Administration-level-1-accessible strategies have funds-only or zero costs.
+- **R5**: Strategy.Activate() does not fire GameEvents for resource changes in a specific order; the FundsChanged(StrategySetup) may land on a different frame than the Strategy.Activate postfix runs. Test coverage section 11 pins the event order via GameStateStore.AddEvent call sequence in a unit test harness; real KSP frame ordering is covered by an InGameTests addition (deferred).
+
+## 14. Sequencing note
+
+### Conflict vectors with open PR #376 (#438 -- Phase E1 test coverage)
+
+PR #376 touches the following files that #439 also edits:
+
+- `Source/Parsek/GameActions/LedgerOrchestrator.cs` -- #376 adds switch cases in `ReconcileEarningsWindow`; #439 edits ClassifyAction's StrategyActivate branch. Likely textual conflict around different methods but the same file; `git rebase` should handle it cleanly.
+- `Source/Parsek.Tests/EarningsReconciliationTests.cs` -- #376 adds new cases; #439 flips the `ClassifyAction_StrategyActivate_TransformedNotUntransformed` test.
+- `docs/dev/todo-and-known-bugs.md` -- both edit status.
+- `CHANGELOG.md` -- both append.
+
+**Sequencing**: land #376 first, then rebase #439 onto `origin/main`. All four conflicts are mechanical.
+
+### Downstream dependent
+
+#440 (post-walk reconciliation) depends on #439 and must rebase after #439 merges. #440's scope shrinks substantially given the section 3.5 finding that strategy income is pre-transformed -- #440 now primarily covers the ContractComplete / Fail / Cancel / MilestoneAchievement / ReputationEarning / direct-KSC FundsEarning / ScienceEarning post-walk path.
+
+## 15. Files touched
+
+- `Source/Parsek/GameStateEvent.cs` -- enum values 20/21/22.
+- `Source/Parsek/Patches/StrategyLifecyclePatch.cs` -- new file.
+- `Source/Parsek/GameStateRecorder.cs` -- helpers + emitters.
+- `Source/Parsek/GameActions/GameAction.cs` -- FundsEarningSource.Strategy, ReputationSource.Strategy.
+- `Source/Parsek/GameActions/GameStateEventConverter.cs` -- three case branches + helpers.
+- `Source/Parsek/GameActions/StrategiesModule.cs` -- make TransformContractReward a documented no-op.
+- `Source/Parsek/GameActions/LedgerOrchestrator.cs` -- ClassifyAction branch flip.
+- `Source/Parsek.Tests/StrategyCaptureTests.cs` -- new file.
+- `Source/Parsek.Tests/EarningsReconciliationTests.cs` -- flip one test, add classifier coverage.
+- `Source/Parsek.Tests/StrategiesModuleTests.cs` -- audit and update any tests that asserted active-strategy contract-reward diversion.
+- `CHANGELOG.md`, `docs/dev/todo-and-known-bugs.md`, `docs/dev/plans/fix-ledger-lump-sum-reconciliation.md` (mark Phase E1.5 delivered).
+
+## 16. Out of scope
+
+- Full pre-transform capture path (Option C in section 3.5).
+- Science / Reputation legs of strategy setup cost reconciliation -- deferred follow-up in section 12.2.
+- Modded strategy interactions (Strategia etc.) -- covered only insofar as Harmony postfix on Strategy.Activate is additive.
+- KSP version drift -- ilspycmd verified against the 1.12.x Assembly-CSharp.dll in this repo's KSP install.
+
+## 17. Acknowledgements (from research)
+
+- Plan v1 (this doc) supersedes the original todo entry's "Harmony patch on Strategies.Strategy.Activate / Deactivate and the payout callback" -- there is no payout callback in stock KSP; strategies use OnCurrencyModifierQuery interception.
+- The "StrategyPayout event type is redundant with TransformedFundsReward on ContractComplete" hypothesis from the user prompt is confirmed by decompile. The plan retains the enum value for mod-compat and degrades emission to a fallback-only path.
+- StrategiesModule.TransformContractReward is a pre-existing over-application bug (double-transform) that only surfaces once strategy capture starts; #439 neutralizes it as a corollary, not a separate bug.

--- a/docs/dev/plans/fix-439-strategy-lifecycle-capture.md
+++ b/docs/dev/plans/fix-439-strategy-lifecycle-capture.md
@@ -9,16 +9,16 @@ Depends on: #436 Phase A shipped, #437 Phase B shipped, Phase C, Phase D (#343) 
 
 Ship to v0.8.2:
 
-- New event types: `StrategyActivated`, `StrategyDeactivated`. **DROP** `StrategyPayout` entirely — no stock hook drives it. Enum is append-only; adding later is cost-free when a concrete need arises.
+- New event types: `StrategyActivated`, `StrategyDeactivated`. **DROP** `StrategyPayout` entirely -- no stock hook drives it. Enum is append-only; adding later is cost-free when a concrete need arises.
 - Harmony postfix on `Strategy.Activate` / `Deactivate` (filter on `__result==true`, try/catch, respect `IsReplayingActions`).
 - Recorder emitters + pure-static detail formatters.
 - Converter routes to existing `StrategyActivate` / `StrategyDeactivate` `GameAction`s.
 - `ClassifyAction`: `StrategyActivate` -> `Untransformed`, Funds-only `ExpectedDelta = -SetupCost` paired against `FundsChanged(StrategySetup)`. `StrategyDeactivate` stays `NoResourceImpact`.
-- `StrategiesModule.TransformContractReward` -> documented no-op + VERBOSE log (required — populating `activeStrategies` activates the dormant double-count).
+- `StrategiesModule.TransformContractReward` -> documented no-op + VERBOSE log (required -- populating `activeStrategies` activates the dormant double-count).
 - `activeStrategies` populated (slot-accounting, reservation logic, Actions window display).
 - Flip the existing `ClassifyAction_StrategyActivate_TransformedNotUntransformed` test.
 - New `StrategyCaptureTests.cs`.
-- Audit `StrategiesModuleTests.cs` for any test asserting `TransformedFundsReward != FundsReward` under active strategy — update to the identity invariant.
+- Audit `StrategiesModuleTests.cs` for any test asserting `TransformedFundsReward != FundsReward` under active strategy -- update to the identity invariant.
 - CHANGELOG 1-liner; todo strike-through plus known-limitation note for Sci/Rep setup costs.
 
 **Known limitation shipped with Phase A**: strategies with non-zero `InitialCostScience` or `InitialCostReputation` will still emit a false-positive KSC-reconciliation WARN on those resource legs. Stock Admin-tier-1 strategies are funds-only, so most new careers never trip it. Follow-up entry filed for Phase B.

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -351,26 +351,35 @@ Design constraints pulled from Phase D's (#343) plumbing:
 
 ---
 
-## 439. Strategy lifecycle capture (Phase E1.5 of ledger/lump-sum fix)
+## ~~439.~~ Strategy lifecycle capture (Phase E1.5 of ledger/lump-sum fix)
 
-**Source:** `docs/dev/plans/fix-ledger-lump-sum-reconciliation.md` Phase E1.5, flagged during plan review and re-flagged by Phase B's audit of `GameStateEvent.cs:6-27` — no strategy event types exist. `LedgerOrchestrator.StrategiesModule` consumes `StrategyActivate` / `StrategyDeactivate` actions during the walk (and `StrategiesModule.cs:207-208,235` mutates `TransformedFundsReward` on contract-complete actions), but nothing in the mod captures strategy lifecycle from KSP and nothing emits those action types.
+**Status:** Phase A (v0.8.2) fixed in `feat/439-strategy-lifecycle-capture`. Phase B (multi-resource reconciliation for Science and Reputation setup costs) deferred as a follow-up, see #439B below.
 
-**Why it matters:** any career that activates a KSP strategy (Leadership Initiative, Open-Source Tech Program, etc.) has funds/rep/science flowing through channels the ledger doesn't model. `StrategiesModule` runs but has no input. Strategy payouts become phantom income that `tree.DeltaFunds` captures but the ledger walk doesn't — the exact repro shape of #436 for strategy-active careers. Phase A's legacy migration catches it as an "unknown channel residual" and injects a `LegacyMigration` synthetic on load; going forward, we want the events captured correctly instead of papered over.
+**Summary of Phase A fix:** added `GameStateEventType.StrategyActivated` / `StrategyDeactivated` (enum ids 20/21, append-only). New `Source/Parsek/Patches/StrategyLifecyclePatch.cs` installs Harmony postfixes on `Strategies.Strategy.Activate` / `Deactivate`, filtering on `__result == true` and honoring `GameStateRecorder.IsReplayingActions`. Recorder emits new events with pure-static detail builders (`BuildStrategyActivateDetail` / `BuildStrategyDeactivateDetail`) formatted with InvariantCulture "R". `GameStateEventConverter` routes the new events to the existing `StrategyActivate` / `StrategyDeactivate` `GameAction`s. `LedgerOrchestrator.ClassifyAction` now returns `Untransformed` with `ExpectedReasonKey="StrategySetup"` / `ExpectedDelta=-SetupCost` so the funds setup cost reconciles against the `FundsChanged(StrategySetup)` event KSP fires inside `Strategy.Activate()`. `StrategiesModule.TransformContractReward` was made a documented identity no-op: KSP's `CurrencyModifierQuery` already transformed contract rewards before `onContractCompleted` fires (see decompile trace in `docs/dev/plans/fix-439-strategy-lifecycle-capture.md` section 3.5), so applying Commitment a second time would double-divert. `activeStrategies` is still populated for slot accounting and Actions-window display.
 
-**Fix:**
-- Add `GameStateEventType.StrategyActivated` / `StrategyDeactivated` / `StrategyPayout` in `Source/Parsek/GameStateEvent.cs`.
-- New Harmony patch `Source/Parsek/Patches/StrategyLifecyclePatch.cs` on `Strategies.Strategy.Activate` / `Deactivate` and whichever callback KSP uses for strategy payouts. Find exact symbols via `ilspycmd` per `.claude/CLAUDE.md`'s decompilation workflow.
-- Extend `Source/Parsek/GameStateRecorder.cs` to emit the new event types, tagging with the current recording id when in flight (KSC-scope otherwise).
-- Add `FundsEarningSource.Strategy` (and a `ReputationSource.Strategy` if KSP strategies grant rep, which they do for some — verify).
-- `Source/Parsek/GameActions/GameStateEventConverter.cs`: convert the new events into the existing `StrategyActivate` / `StrategyDeactivate` action types, and into a new `StrategyPayout` `FundsEarning`/`ReputationEarning` with source = `Strategy`. `GameActionType` may need a new value for payout if reusing existing earning types is awkward.
-- Wire `ReconcileKscAction.ClassifyAction` to route the new action types correctly (strategy payouts are transformed-type candidates → post-walk reconciliation per #440).
-- New file `Source/Parsek.Tests/StrategyCaptureTests.cs` — capture/replay symmetry for all three events, conversion correctness, end-to-end round-trip through `ParsekScenario` save/load.
+**NOT included in Phase A (deferred to Phase B, filed below):** multi-resource `KscActionExpectation` + Sci/Rep setup cost reconciliation. Strategies with non-zero `InitialCostScience` or `InitialCostReputation` still emit false-positive KSC-reconciliation WARNs on those resource legs. Stock Admin-tier-1 strategies are funds-only, so most new careers never trip it.
 
-**Scope:** medium-large. New Harmony patches + new event types + new enum values + converter + module plumbing + test file. Estimate 2-3 days of focused work.
+**NOT included (deferred further):** a `StrategyPayout` fallback emitter for mod-compat strategies that bypass the `OnCurrencyModifierQuery` path. No current stock or major mod needs it; add when a concrete requirement arises.
 
-**Dependencies:** #436 (Phase A), Phase B (#437), Phase C, Phase D (#343), Phase F, #441 all shipped. Strategy income on new saves is currently uncredited in the ledger walk — Phase A's legacy-migration path does NOT fire for new-save trees because they don't have persisted `tree.DeltaFunds` to migrate. A KSC-active strategy on a brand-new career will produce a `PatchFunds: suspicious drawdown` WARN until #439 lands. Recommended ordering: #439 → #440.
+---
 
-**Status:** TODO. Priority: medium. Release-blocking for strategy-using careers in v0.8.3; v0.8.2 ships with strategies unsupported (user-visible effect: `PatchFunds: suspicious drawdown` WARN when a strategy diverts reward). Documented as a known limitation in CHANGELOG for v0.8.2.
+## 439B. Strategy setup cost reconciliation for Science and Reputation legs (#439 follow-up)
+
+**Source:** #439 Phase A shipped a single-resource `KscActionExpectation` (Funds leg only). Strategies with non-zero `InitialCostScience` or `InitialCostReputation` still emit false-positive KSC-reconciliation WARNs on the Science/Rep legs because `ClassifyAction` only returns one (`EventType`, `ExpectedReasonKey`, `ExpectedDelta`) tuple.
+
+**Why it matters:** stock Administration-building tier-1 strategies are funds-only, so most new careers never trip it. Admin-tier-2 and some modded strategies (Strategia, Contract Configurator + Strategy) charge Science or Reputation on activation and will produce one WARN per resource leg per activation. Log noise, not a correctness bug.
+
+**Fix (rough):**
+- Extend `LedgerOrchestrator.KscActionExpectation` from a single tuple to a list of expectation tuples (or a small struct-of-arrays).
+- `ReconcileKscAction` iterates over each expectation and key-matches in turn.
+- `ClassifyAction` for `StrategyActivate` returns expectations for the Funds / Science / Reputation setup costs that are non-zero.
+- Add test coverage to `StrategyCaptureTests` for a Science-setup-cost strategy and a Rep-setup-cost strategy.
+
+**Scope:** small, ~200 lines including tests. Fast-follow candidate.
+
+**Dependencies:** #439 Phase A (shipped).
+
+**Status:** TODO. Priority: low. Not release-blocking.
 
 ---
 


### PR DESCRIPTION
## Summary

Capture stock KSP strategy activate/deactivate lifecycle so `StrategiesModule.activeStrategies` gets populated. Removes the spurious `PatchFunds: suspicious drawdown` WARN on revert/rewind for strategy-using careers.

**Key finding from KSP decompilation that reshaped the scope:** stock strategies have NO discrete payout API. All income flows through `GameEvents.Modifiers.OnCurrencyModifierQuery` interception BEFORE KSP emits `FundsChanged`. The existing `ContractComplete` capture already sees post-transform values. So Phase A only needs to capture lifecycle; no `StrategyPayout` event/action/source enum is added.

**Corollary fix:** `StrategiesModule.TransformContractReward` is a latent double-count bug (KSP pre-transforms, then our code would transform again). It's been dormant only because no `StrategyActivate` actions ever reached the walk. Populating `activeStrategies` activates it, so this PR neutralizes `TransformContractReward` to an identity no-op with a VERBOSE log.

## Scope (Phase A of #439)

- New `GameStateEventType.StrategyActivated` / `StrategyDeactivated`.
- New `Source/Parsek/Patches/StrategyLifecyclePatch.cs` — Harmony postfix on `Strategies.Strategy.Activate` / `Deactivate`, `__result==true` filter, replay-guarded, try/catch.
- `GameStateRecorder` emitters + pure-static detail builders.
- `GameStateEventConverter` converts events to existing `StrategyActivate` / `StrategyDeactivate` `GameAction`s.
- `LedgerOrchestrator.ClassifyAction`: `StrategyActivate` -> `Untransformed` with `FundsChanged(StrategySetup)` + `ExpectedDelta=-SetupCost`. `StrategyDeactivate` -> `NoResourceImpact`.
- `StrategiesModule.TransformContractReward` -> documented identity no-op.
- Test flips in `EarningsReconciliationTests.cs`, `StrategiesModuleTests.cs`, `CrossTierIntegrationTests.cs` to the identity invariant.
- New `StrategyCaptureTests.cs` (19 tests).

## Known limitation shipped with Phase A

Strategies with non-zero `InitialCostScience` or `InitialCostReputation` will still emit a false-positive KSC-reconciliation WARN on those resource legs. Stock Admin-tier-1 strategies are funds-only, so most new careers never trip it. Follow-up entry `#439B` filed for Phase B (multi-resource `KscActionExpectation`).

## Explicitly NOT in this PR (deferred)

- `StrategyPayout` event type / action type / source enum. No stock hook drives it; add when a concrete mod demands it.
- Multi-resource Sci/Rep setup-cost reconciliation (Phase B).
- Raw pre-transform reward capture (Phase D).
- Mod compat (Strategia, Contract Configurator+Strategy).

## Test plan

- [x] `dotnet test --filter "FullyQualifiedName~StrategyCapture"` — 19/19 pass.
- [x] `dotnet test --filter "FullyQualifiedName~StrategiesModule"` — 45/45 pass.
- [x] `dotnet test --filter "FullyQualifiedName~EarningsReconciliation"` — 41/41 pass.
- [x] `dotnet test --filter "FullyQualifiedName~CrossTierIntegration"` — 6/6 pass.
- [x] Full suite — 7162 passed, 1 skipped (pre-existing), 0 failed.
- [ ] In-game Harmony-patch coverage via an `[InGameTest]` is a follow-up (xUnit cannot instantiate `Strategies.Strategy`).

## Notes for reviewer

- Plan doc: `docs/dev/plans/fix-439-strategy-lifecycle-capture.md` (read the "Phase A scope" section at the top).
- Depends on #376 (#438 Phase E1) landing first — both touch `LedgerOrchestrator.ClassifyAction` + `EarningsReconciliationTests.cs`. Rebase if #376 merges first.