### PR TITLE
#450 B3: lazy reentry FX pre-warm

### DIFF
--- a/Source/Parsek.Tests/Bug450B3LazyReentryTests.cs
+++ b/Source/Parsek.Tests/Bug450B3LazyReentryTests.cs
@@ -50,7 +50,8 @@ namespace Parsek.Tests
             // Most common path: flag never set in the first place (no-reentry trajectory).
             Assert.False(GhostPlaybackLogic.ShouldBuildLazyReentryFx(
                 pendingFlag: false, bodyName: "Kerbin",
-                bodyHasAtmosphere: true, altitudeMeters: 10_000, atmosphereDepthMeters: 70_000));
+                bodyHasAtmosphere: true, altitudeMeters: 10_000, atmosphereDepthMeters: 70_000,
+                surfaceSpeedMetersPerSecond: 1_000, speedFloorMetersPerSecond: 400));
         }
 
         [Theory]
@@ -62,7 +63,8 @@ namespace Parsek.Tests
             // refactor forgets to guard against positioning that hasn't run yet.
             Assert.False(GhostPlaybackLogic.ShouldBuildLazyReentryFx(
                 pendingFlag: true, bodyName: bodyName,
-                bodyHasAtmosphere: true, altitudeMeters: 10_000, atmosphereDepthMeters: 70_000));
+                bodyHasAtmosphere: true, altitudeMeters: 10_000, atmosphereDepthMeters: 70_000,
+                surfaceSpeedMetersPerSecond: 1_000, speedFloorMetersPerSecond: 400));
         }
 
         [Fact]
@@ -73,7 +75,8 @@ namespace Parsek.Tests
             // that then permanently idle with zero intensity).
             Assert.False(GhostPlaybackLogic.ShouldBuildLazyReentryFx(
                 pendingFlag: true, bodyName: "Mun",
-                bodyHasAtmosphere: false, altitudeMeters: 0, atmosphereDepthMeters: 0));
+                bodyHasAtmosphere: false, altitudeMeters: 0, atmosphereDepthMeters: 0,
+                surfaceSpeedMetersPerSecond: 1_000, speedFloorMetersPerSecond: 400));
         }
 
         [Fact]
@@ -83,16 +86,57 @@ namespace Parsek.Tests
             // comparison is inverted.
             Assert.False(GhostPlaybackLogic.ShouldBuildLazyReentryFx(
                 pendingFlag: true, bodyName: "Kerbin",
-                bodyHasAtmosphere: true, altitudeMeters: 100_000, atmosphereDepthMeters: 70_000));
+                bodyHasAtmosphere: true, altitudeMeters: 100_000, atmosphereDepthMeters: 70_000,
+                surfaceSpeedMetersPerSecond: 1_000, speedFloorMetersPerSecond: 400));
         }
 
         [Fact]
-        public void ShouldBuildLazyReentryFx_BelowAtmosphereDepth_ReturnsTrue()
+        public void ShouldBuildLazyReentryFx_BelowAtmosphereAndFastEnough_ReturnsTrue()
         {
-            // Happy path: ghost deorbited, now in atmosphere. Positive case.
+            // Happy path: ghost deorbited, now in atmosphere AND moving fast enough for
+            // reentry FX to be imminent. Positive case.
             Assert.True(GhostPlaybackLogic.ShouldBuildLazyReentryFx(
                 pendingFlag: true, bodyName: "Kerbin",
-                bodyHasAtmosphere: true, altitudeMeters: 50_000, atmosphereDepthMeters: 70_000));
+                bodyHasAtmosphere: true, altitudeMeters: 50_000, atmosphereDepthMeters: 70_000,
+                surfaceSpeedMetersPerSecond: 1_000, speedFloorMetersPerSecond: 400));
+        }
+
+        [Fact]
+        public void ShouldBuildLazyReentryFx_BelowAtmosphereButTooSlow_ReturnsFalse()
+        {
+            // The KSC-launch case that motivated the P1 review fix: a ghost spawning
+            // at the pad is already inside Kerbin's atmosphere (altitude 67 m) and
+            // pending=true, but at 0 m/s there is nothing to render. Without the speed
+            // gate, the lazy build would fire on frame 1 and the ~7 ms cost would stay
+            // on the launch-hitch frame, just relocated from spawn to mainLoop. Fails
+            // if the speed gate is dropped.
+            Assert.False(GhostPlaybackLogic.ShouldBuildLazyReentryFx(
+                pendingFlag: true, bodyName: "Kerbin",
+                bodyHasAtmosphere: true, altitudeMeters: 67, atmosphereDepthMeters: 70_000,
+                surfaceSpeedMetersPerSecond: 0, speedFloorMetersPerSecond: 400));
+        }
+
+        [Fact]
+        public void ShouldBuildLazyReentryFx_ExactlyAtSpeedFloor_ReturnsTrue()
+        {
+            // Pins the `>=` on the speed gate: at EXACTLY the floor the build fires.
+            Assert.True(GhostPlaybackLogic.ShouldBuildLazyReentryFx(
+                pendingFlag: true, bodyName: "Kerbin",
+                bodyHasAtmosphere: true, altitudeMeters: 50_000, atmosphereDepthMeters: 70_000,
+                surfaceSpeedMetersPerSecond: 400, speedFloorMetersPerSecond: 400));
+        }
+
+        [Fact]
+        public void ShouldBuildLazyReentryFx_SpeedIsNaN_ReturnsFalse()
+        {
+            // Defensive: a malformed velocity (NaN) must NOT leak through. IEEE NaN
+            // compares false against any inequality, so the `!(speed >= floor)` form
+            // in the helper pins the safe direction — unlike `(speed < floor)` which
+            // would return true on NaN and burn a build.
+            Assert.False(GhostPlaybackLogic.ShouldBuildLazyReentryFx(
+                pendingFlag: true, bodyName: "Kerbin",
+                bodyHasAtmosphere: true, altitudeMeters: 50_000, atmosphereDepthMeters: 70_000,
+                surfaceSpeedMetersPerSecond: float.NaN, speedFloorMetersPerSecond: 400));
         }
 
         [Fact]
@@ -101,7 +145,8 @@ namespace Parsek.Tests
             // Boundary: one meter below the cap. Fails if the comparison uses `>` by mistake.
             Assert.True(GhostPlaybackLogic.ShouldBuildLazyReentryFx(
                 pendingFlag: true, bodyName: "Kerbin",
-                bodyHasAtmosphere: true, altitudeMeters: 69_999, atmosphereDepthMeters: 70_000));
+                bodyHasAtmosphere: true, altitudeMeters: 69_999, atmosphereDepthMeters: 70_000,
+                surfaceSpeedMetersPerSecond: 1_000, speedFloorMetersPerSecond: 400));
         }
 
         [Fact]
@@ -113,19 +158,20 @@ namespace Parsek.Tests
             // output, then drive-to-zero on the next frame. Wait one more frame.
             Assert.False(GhostPlaybackLogic.ShouldBuildLazyReentryFx(
                 pendingFlag: true, bodyName: "Kerbin",
-                bodyHasAtmosphere: true, altitudeMeters: 70_000, atmosphereDepthMeters: 70_000));
+                bodyHasAtmosphere: true, altitudeMeters: 70_000, atmosphereDepthMeters: 70_000,
+                surfaceSpeedMetersPerSecond: 1_000, speedFloorMetersPerSecond: 400));
         }
 
         [Fact]
-        public void ShouldBuildLazyReentryFx_NegativeAltitude_ReturnsTrue()
+        public void ShouldBuildLazyReentryFx_NegativeAltitudeAndFastEnough_ReturnsTrue()
         {
             // Defensive: reload-artifact landed ghosts can read below-surface altitudes.
-            // Still inside atmosphere, so still a valid build trigger. Fails if a future
-            // refactor adds an `altitude > 0` guard (would strand landed ghosts pending
-            // forever).
+            // Still inside atmosphere AND moving fast enough, so still a valid build
+            // trigger. Fails if a future refactor adds an `altitude > 0` guard.
             Assert.True(GhostPlaybackLogic.ShouldBuildLazyReentryFx(
                 pendingFlag: true, bodyName: "Kerbin",
-                bodyHasAtmosphere: true, altitudeMeters: -100, atmosphereDepthMeters: 70_000));
+                bodyHasAtmosphere: true, altitudeMeters: -100, atmosphereDepthMeters: 70_000,
+                surfaceSpeedMetersPerSecond: 1_000, speedFloorMetersPerSecond: 400));
         }
 
         // ----- Engine seam: throttle + idempotency + defensive paths -----
@@ -329,12 +375,18 @@ namespace Parsek.Tests
         // ----- Diagnostics report format -----
 
         [Fact]
-        public void DiagnosticsReport_IncludesDeferredAndNeverBuiltCounters()
+        public void DiagnosticsReport_IncludesDeferredAndBuildsAvoidedCounters()
         {
-            // B3's post-ship validation relies on `deferred - built = neverBuilt`
+            // B3's post-ship validation relies on `deferred - built = buildsAvoided`
             // being visible in the diagnostics snapshot. Fails if the
             // DiagnosticsComputation report format drops the new counters —
             // otherwise validating B3's savings requires log-archaeology.
+            //
+            // Semantic: buildsAvoided counts build-EVENTS avoided, not unique
+            // trajectories. A recording that unloads and rehydrates N times before
+            // first reentry contributes N to `deferred` and 1 to `built`, so
+            // buildsAvoided = N-1 — which IS correct accounting (pre-B3 would have
+            // paid the build N times, post-B3 pays it once).
             DiagnosticsState.ResetForTesting();
             DiagnosticsState.health.reentryFxBuildsThisSession = 3;
             DiagnosticsState.health.reentryFxSkippedThisSession = 5;
@@ -344,22 +396,22 @@ namespace Parsek.Tests
             // passing a default snapshot is sufficient for this assertion.
             string report = DiagnosticsComputation.FormatReport(default);
 
-            Assert.Contains("reentryFx built 3 skipped 5 deferred 10 neverBuilt 7", report);
+            Assert.Contains("reentryFx built 3 skipped 5 deferred 10 buildsAvoided 7", report);
         }
 
         [Fact]
-        public void DiagnosticsReport_NeverBuiltFloorsAtZero()
+        public void DiagnosticsReport_BuildsAvoidedFloorsAtZero()
         {
             // Defensive: if a test or a future bug makes `built > deferred`
             // (shouldn't happen — deferrals precede builds — but we survive it),
-            // the report must show neverBuilt = 0 rather than a negative number.
+            // the report must show buildsAvoided = 0 rather than a negative number.
             DiagnosticsState.ResetForTesting();
             DiagnosticsState.health.reentryFxBuildsThisSession = 10;
             DiagnosticsState.health.reentryFxDeferredThisSession = 3;
 
             string report = DiagnosticsComputation.FormatReport(default);
 
-            Assert.Contains("deferred 3 neverBuilt 0", report);
+            Assert.Contains("deferred 3 buildsAvoided 0", report);
         }
     }
 }

--- a/Source/Parsek.Tests/Bug450B3LazyReentryTests.cs
+++ b/Source/Parsek.Tests/Bug450B3LazyReentryTests.cs
@@ -190,6 +190,32 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void TryPerformLazyReentryBuild_Throttle_UsesPerIndexLogKey()
+        {
+            // Per-index key so a burst of same-frame throttles doesn't collapse into
+            // one shared-key log line. Without per-index keys a 5-ghost simultaneous
+            // atmosphere-entry would log "Lazy reentry build throttled" only ONCE and
+            // hide the per-ghost identities from the post-playtest diagnosis — the
+            // frameLazyReentryBuildDeferred counter would still be 3, but we'd lose
+            // the `#N` data.
+            var engine = new GhostPlaybackEngine(positioner: null);
+            engine.SetFrameLazyReentryBuildCountForTesting(GhostPlaybackEngine.MaxLazyReentryBuildsPerFrame);
+
+            var state3 = BuildPendingState();
+            var state4 = BuildPendingState();
+            engine.TryPerformLazyReentryBuildForTesting(3, state3, "A", "Kerbin", 50_000);
+            engine.TryPerformLazyReentryBuildForTesting(4, state4, "B", "Kerbin", 50_000);
+
+            // Both deferrals log — the rate limiter keys on `lazy-throttle-{recIdx}`,
+            // not on a shared `lazy-throttle` key that would collapse them.
+            Assert.Contains(logLines, l =>
+                l.Contains("Lazy reentry build throttled") && l.Contains("#3"));
+            Assert.Contains(logLines, l =>
+                l.Contains("Lazy reentry build throttled") && l.Contains("#4"));
+            Assert.Equal(2, engine.FrameLazyReentryBuildDeferredForTesting);
+        }
+
+        [Fact]
         public void TryPerformLazyReentryBuild_CapExhausted_DefersAndLogs()
         {
             // 3 ghosts want to lazy-build in the same frame, cap = 2. The third must
@@ -270,6 +296,26 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void HealthCounters_DeferredAndBuiltCountersAreIndependent()
+        {
+            // Spawn-path increments `deferred`, lazy-build site increments `built`.
+            // The two counters are separate fields so a session can show
+            // `deferred > built` (ghosts that never entered atmosphere — the B3
+            // savings signal) or `built > deferred` would be impossible unless
+            // something bypassed the normal flow. Fails if a future refactor
+            // accidentally shares a backing field.
+            DiagnosticsState.ResetForTesting();
+            DiagnosticsState.health.reentryFxDeferredThisSession = 10;
+            DiagnosticsState.health.reentryFxBuildsThisSession = 3;
+
+            Assert.Equal(10, DiagnosticsState.health.reentryFxDeferredThisSession);
+            Assert.Equal(3, DiagnosticsState.health.reentryFxBuildsThisSession);
+            Assert.NotEqual(
+                DiagnosticsState.health.reentryFxDeferredThisSession,
+                DiagnosticsState.health.reentryFxBuildsThisSession);
+        }
+
+        [Fact]
         public void HealthCounters_Reset_ZerosReentryFxDeferred()
         {
             // Reset must zero the new counter alongside the other session metrics.
@@ -278,6 +324,42 @@ namespace Parsek.Tests
             counters.Reset();
 
             Assert.Equal(0, counters.reentryFxDeferredThisSession);
+        }
+
+        // ----- Diagnostics report format -----
+
+        [Fact]
+        public void DiagnosticsReport_IncludesDeferredAndNeverBuiltCounters()
+        {
+            // B3's post-ship validation relies on `deferred - built = neverBuilt`
+            // being visible in the diagnostics snapshot. Fails if the
+            // DiagnosticsComputation report format drops the new counters —
+            // otherwise validating B3's savings requires log-archaeology.
+            DiagnosticsState.ResetForTesting();
+            DiagnosticsState.health.reentryFxBuildsThisSession = 3;
+            DiagnosticsState.health.reentryFxSkippedThisSession = 5;
+            DiagnosticsState.health.reentryFxDeferredThisSession = 10;
+
+            // FormatReport reads DiagnosticsState.health directly for the Health line;
+            // passing a default snapshot is sufficient for this assertion.
+            string report = DiagnosticsComputation.FormatReport(default);
+
+            Assert.Contains("reentryFx built 3 skipped 5 deferred 10 neverBuilt 7", report);
+        }
+
+        [Fact]
+        public void DiagnosticsReport_NeverBuiltFloorsAtZero()
+        {
+            // Defensive: if a test or a future bug makes `built > deferred`
+            // (shouldn't happen — deferrals precede builds — but we survive it),
+            // the report must show neverBuilt = 0 rather than a negative number.
+            DiagnosticsState.ResetForTesting();
+            DiagnosticsState.health.reentryFxBuildsThisSession = 10;
+            DiagnosticsState.health.reentryFxDeferredThisSession = 3;
+
+            string report = DiagnosticsComputation.FormatReport(default);
+
+            Assert.Contains("deferred 3 neverBuilt 0", report);
         }
     }
 }

--- a/Source/Parsek.Tests/Bug450B3LazyReentryTests.cs
+++ b/Source/Parsek.Tests/Bug450B3LazyReentryTests.cs
@@ -1,0 +1,283 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Bug #450 Phase B3 tests — lazy reentry FX pre-warm.
+    ///
+    /// Phase A's one-shot breakdown showed reentry FX costs ~6.94 ms at spawn time
+    /// (29 % of a 24.2 ms bimodal single-spawn frame). B3 defers that build to the
+    /// first frame the ghost is actually inside an atmosphere. Trajectories that
+    /// never enter atmosphere save the full build cost.
+    ///
+    /// Tests cover:
+    ///  - pure `GhostPlaybackLogic.ShouldBuildLazyReentryFx` decision logic (no Unity).
+    ///  - engine-side throttle + log behaviour via `TryPerformLazyReentryBuildForTesting`
+    ///    (the actual `TryBuildReentryFx` call needs a live Unity GameObject, so the
+    ///    tests observe the non-build code paths — throttle, idempotency, defensive
+    ///    heatInfos-null guard. End-to-end build assertion is in the in-game runtime
+    ///    test suite).
+    /// </summary>
+    [Collection("Sequential")]
+    public class Bug450B3LazyReentryTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public Bug450B3LazyReentryTests()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+            ParsekLog.VerboseOverrideForTesting = true;
+            DiagnosticsState.ResetForTesting();
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+            DiagnosticsState.ResetForTesting();
+        }
+
+        // ----- Pure decision logic -----
+
+        [Fact]
+        public void ShouldBuildLazyReentryFx_NotPending_ReturnsFalse()
+        {
+            // Most common path: flag never set in the first place (no-reentry trajectory).
+            Assert.False(GhostPlaybackLogic.ShouldBuildLazyReentryFx(
+                pendingFlag: false, bodyName: "Kerbin",
+                bodyHasAtmosphere: true, altitudeMeters: 10_000, atmosphereDepthMeters: 70_000));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void ShouldBuildLazyReentryFx_NoBodyName_ReturnsFalse(string bodyName)
+        {
+            // Positioner hasn't written the body yet — don't speculate. Fails if a future
+            // refactor forgets to guard against positioning that hasn't run yet.
+            Assert.False(GhostPlaybackLogic.ShouldBuildLazyReentryFx(
+                pendingFlag: true, bodyName: bodyName,
+                bodyHasAtmosphere: true, altitudeMeters: 10_000, atmosphereDepthMeters: 70_000));
+        }
+
+        [Fact]
+        public void ShouldBuildLazyReentryFx_BodyHasNoAtmosphere_ReturnsFalse()
+        {
+            // Mun / Minmus / asteroids: never build. Most orbital showcases land here
+            // — fails if a future refactor drops the atmosphere check (would build FX
+            // that then permanently idle with zero intensity).
+            Assert.False(GhostPlaybackLogic.ShouldBuildLazyReentryFx(
+                pendingFlag: true, bodyName: "Mun",
+                bodyHasAtmosphere: false, altitudeMeters: 0, atmosphereDepthMeters: 0));
+        }
+
+        [Fact]
+        public void ShouldBuildLazyReentryFx_AboveAtmosphereDepth_ReturnsFalse()
+        {
+            // Orbital ghost still in vacuum: don't build yet. Fails if the altitude
+            // comparison is inverted.
+            Assert.False(GhostPlaybackLogic.ShouldBuildLazyReentryFx(
+                pendingFlag: true, bodyName: "Kerbin",
+                bodyHasAtmosphere: true, altitudeMeters: 100_000, atmosphereDepthMeters: 70_000));
+        }
+
+        [Fact]
+        public void ShouldBuildLazyReentryFx_BelowAtmosphereDepth_ReturnsTrue()
+        {
+            // Happy path: ghost deorbited, now in atmosphere. Positive case.
+            Assert.True(GhostPlaybackLogic.ShouldBuildLazyReentryFx(
+                pendingFlag: true, bodyName: "Kerbin",
+                bodyHasAtmosphere: true, altitudeMeters: 50_000, atmosphereDepthMeters: 70_000));
+        }
+
+        [Fact]
+        public void ShouldBuildLazyReentryFx_JustBelowDepth_ReturnsTrue()
+        {
+            // Boundary: one meter below the cap. Fails if the comparison uses `>` by mistake.
+            Assert.True(GhostPlaybackLogic.ShouldBuildLazyReentryFx(
+                pendingFlag: true, bodyName: "Kerbin",
+                bodyHasAtmosphere: true, altitudeMeters: 69_999, atmosphereDepthMeters: 70_000));
+        }
+
+        [Fact]
+        public void ShouldBuildLazyReentryFx_ExactlyAtDepth_ReturnsFalse()
+        {
+            // Pins the `>=` on the altitude check: at EXACTLY the atmosphere depth,
+            // stock KSP's existing UpdateReentryFx calls DriveReentryToZero. Firing
+            // a lazy build here would pay ~7 ms for a frame that produces zero-intensity
+            // output, then drive-to-zero on the next frame. Wait one more frame.
+            Assert.False(GhostPlaybackLogic.ShouldBuildLazyReentryFx(
+                pendingFlag: true, bodyName: "Kerbin",
+                bodyHasAtmosphere: true, altitudeMeters: 70_000, atmosphereDepthMeters: 70_000));
+        }
+
+        [Fact]
+        public void ShouldBuildLazyReentryFx_NegativeAltitude_ReturnsTrue()
+        {
+            // Defensive: reload-artifact landed ghosts can read below-surface altitudes.
+            // Still inside atmosphere, so still a valid build trigger. Fails if a future
+            // refactor adds an `altitude > 0` guard (would strand landed ghosts pending
+            // forever).
+            Assert.True(GhostPlaybackLogic.ShouldBuildLazyReentryFx(
+                pendingFlag: true, bodyName: "Kerbin",
+                bodyHasAtmosphere: true, altitudeMeters: -100, atmosphereDepthMeters: 70_000));
+        }
+
+        // ----- Engine seam: throttle + idempotency + defensive paths -----
+        //
+        // These tests exercise `TryPerformLazyReentryBuild` via the test seam. The
+        // actual `TryBuildReentryFx` call inside requires a live Unity GameObject for
+        // GetComponentsInChildren, so we drive the NO-BUILD branches here (heatInfos
+        // null, cap exhausted, flag already cleared). Actual build assertion lives in
+        // the in-game runtime test suite.
+
+        private static GhostPlaybackState BuildPendingState()
+        {
+            // Minimal state for the defensive branches — ghost stays null, heatInfos
+            // stays null, so the real TryBuildReentryFx call is never reached.
+            return new GhostPlaybackState
+            {
+                vesselName = "TestGhost",
+                reentryFxPendingBuild = true,
+                reentryFxInfo = null,
+            };
+        }
+
+        [Fact]
+        public void TryPerformLazyReentryBuild_FlagAlreadyCleared_NoOp()
+        {
+            // Defensive idempotency: calling the helper with the flag already cleared
+            // must NOT fire a build, must NOT emit a log line, must NOT increment any
+            // counter. Guards against a refactor that loses the production-side
+            // `if (state.reentryFxPendingBuild)` guard in UpdateReentryFx.
+            var engine = new GhostPlaybackEngine(positioner: null);
+            var state = BuildPendingState();
+            state.reentryFxPendingBuild = false;
+            int buildsBefore = DiagnosticsState.health.reentryFxBuildsThisSession;
+
+            engine.TryPerformLazyReentryBuildForTesting(
+                recIdx: 7, state, vesselName: "X", bodyName: "Kerbin", altitude: 50_000);
+
+            Assert.Equal(buildsBefore, DiagnosticsState.health.reentryFxBuildsThisSession);
+            Assert.Equal(0, engine.FrameLazyReentryBuildCountForTesting);
+            Assert.Equal(0, engine.FrameLazyReentryBuildDeferredForTesting);
+            Assert.DoesNotContain(logLines, l => l.Contains("Lazy reentry build"));
+            Assert.False(state.reentryFxPendingBuild);
+        }
+
+        [Fact]
+        public void TryPerformLazyReentryBuild_HeatInfosNull_ClearsFlagAndLogs()
+        {
+            // heatInfos is only nulled by ClearLoadedVisualReferences (which also
+            // clears the pending flag) or by a rebuild in flight. If we somehow land
+            // here with a null it, clearing the flag prevents an infinite retry loop.
+            var engine = new GhostPlaybackEngine(positioner: null);
+            var state = BuildPendingState();
+            state.heatInfos = null;
+
+            engine.TryPerformLazyReentryBuildForTesting(
+                recIdx: 3, state, vesselName: "NoHeat", bodyName: "Kerbin", altitude: 50_000);
+
+            Assert.False(state.reentryFxPendingBuild);  // flag cleared
+            Assert.Equal(0, engine.FrameLazyReentryBuildCountForTesting);  // no build slot consumed
+            Assert.Contains(logLines, l =>
+                l.Contains("[ReentryFx]") && l.Contains("state.heatInfos is null"));
+        }
+
+        [Fact]
+        public void TryPerformLazyReentryBuild_CapExhausted_DefersAndLogs()
+        {
+            // 3 ghosts want to lazy-build in the same frame, cap = 2. The third must
+            // be throttled: pending flag STAYS true so the next frame retries, deferred
+            // counter increments, throttle log line emits. This is the key guard against
+            // relocating the bimodal spawn hitch to atmosphere-entry-time (review #3).
+            var engine = new GhostPlaybackEngine(positioner: null);
+            var state = BuildPendingState();
+
+            // Force the cap exhausted. Using a test-seam setter avoids the need to
+            // actually fire TryBuildReentryFx (which requires a live Unity GameObject).
+            engine.SetFrameLazyReentryBuildCountForTesting(GhostPlaybackEngine.MaxLazyReentryBuildsPerFrame);
+
+            engine.TryPerformLazyReentryBuildForTesting(
+                recIdx: 7, state, vesselName: "Excess", bodyName: "Kerbin", altitude: 50_000);
+
+            Assert.True(state.reentryFxPendingBuild);  // flag stays — next frame retries
+            Assert.Equal(1, engine.FrameLazyReentryBuildDeferredForTesting);
+            Assert.Contains(logLines, l =>
+                l.Contains("[ReentryFx]") && l.Contains("Lazy reentry build throttled") &&
+                l.Contains("#7"));
+        }
+
+        [Fact]
+        public void TryPerformLazyReentryBuild_CapResetsOnFrameReset_RetryFires()
+        {
+            // After exhausting the cap, the next frame's counter reset should re-arm
+            // throttling. Fails if the reset ever loses the new field.
+            var engine = new GhostPlaybackEngine(positioner: null);
+            var state = BuildPendingState();
+            state.heatInfos = null;  // Force the heatInfos-null defensive path for the actual attempt.
+
+            // Frame 1: cap exhausted.
+            engine.SetFrameLazyReentryBuildCountForTesting(GhostPlaybackEngine.MaxLazyReentryBuildsPerFrame);
+            engine.TryPerformLazyReentryBuildForTesting(
+                recIdx: 1, state, vesselName: "T", bodyName: "Kerbin", altitude: 50_000);
+            Assert.True(state.reentryFxPendingBuild);  // throttled, flag stays
+
+            // Frame 2: reset simulates UpdatePlayback head running again.
+            engine.ResetPerFrameCountersForTesting();
+            Assert.Equal(0, engine.FrameLazyReentryBuildCountForTesting);
+
+            // Retry: now walks past the throttle into the heatInfos-null defensive
+            // path (still no real build — just verifies the throttle gate is released).
+            engine.TryPerformLazyReentryBuildForTesting(
+                recIdx: 1, state, vesselName: "T", bodyName: "Kerbin", altitude: 50_000);
+            Assert.False(state.reentryFxPendingBuild);  // cleared by heatInfos-null path
+        }
+
+        [Fact]
+        public void ClearLoadedVisualReferences_ResetsPendingFlag()
+        {
+            // The pending flag must be cleared by ClearLoadedVisualReferences (same
+            // path that nulls reentryFxInfo and heatInfos). Otherwise a rebuild that
+            // reruns PopulateGhostInfoDictionaries would see a dangling true flag from
+            // the pre-rebuild instance and skip the new deferred-set.
+            var state = new GhostPlaybackState
+            {
+                reentryFxPendingBuild = true,
+            };
+
+            state.ClearLoadedVisualReferences();
+
+            Assert.False(state.reentryFxPendingBuild);
+        }
+
+        // ----- Session-counter semantics -----
+
+        [Fact]
+        public void HealthCounters_ReentryFxDeferredThisSession_DefaultsToZero()
+        {
+            // A fresh session starts with zero deferrals. Fails if the new counter
+            // field is ever accidentally initialized from persisted state.
+            var counters = new HealthCounters();
+            counters.Reset();
+
+            Assert.Equal(0, counters.reentryFxDeferredThisSession);
+        }
+
+        [Fact]
+        public void HealthCounters_Reset_ZerosReentryFxDeferred()
+        {
+            // Reset must zero the new counter alongside the other session metrics.
+            // Fails if Reset() is ever expanded without including the new field.
+            var counters = new HealthCounters { reentryFxDeferredThisSession = 42 };
+            counters.Reset();
+
+            Assert.Equal(0, counters.reentryFxDeferredThisSession);
+        }
+    }
+}

--- a/Source/Parsek/Diagnostics/DiagnosticsComputation.cs
+++ b/Source/Parsek/Diagnostics/DiagnosticsComputation.cs
@@ -487,16 +487,20 @@ namespace Parsek
             {
                 hitRateStr = "N/A";
             }
-            // Bug #450 B3: `deferred` + `neverBuilt` surface the B3 savings signal —
-            // `deferred` counts spawns that entered the lazy-build queue;
-            // `neverBuilt` = deferred - built is the count of trajectories that saved
-            // the full ~7 ms build cost entirely (never entered atmosphere in the
-            // session). Without these fields the post-ship validation requires
-            // log-archaeology across a session's trajectory lifecycle.
-            int reentryNeverBuilt = h.reentryFxDeferredThisSession - h.reentryFxBuildsThisSession;
-            if (reentryNeverBuilt < 0) reentryNeverBuilt = 0;
+            // Bug #450 B3: `deferred` counts every spawn-or-rehydrate that entered
+            // the lazy-build queue (one increment per visual build event, NOT per
+            // unique trajectory). `buildsAvoided` = deferred - built is the number
+            // of lazy-build EVENTS that didn't fire this session — each avoided
+            // event is a real ~7 ms saving pre-B3 would have paid. Note that a
+            // single recording that unloads and rehydrates N times contributes N to
+            // deferred; if it only ever reaches atmosphere once, buildsAvoided =
+            // N-1, which IS correct accounting (pre-B3 rebuilt the FX on every
+            // spawn+rehydrate). The label is "buildsAvoided" rather than
+            // "neverBuilt" to avoid implying unique-trajectory semantics.
+            int reentryBuildsAvoided = h.reentryFxDeferredThisSession - h.reentryFxBuildsThisSession;
+            if (reentryBuildsAvoided < 0) reentryBuildsAvoided = 0;
             sb.AppendFormat(Inv,
-                "Health: cache {0} hit ({1} miss of {2} lookups), spikes {3}, spawn fail {4}, builds {5} destroys {6}, reentryFx built {7} skipped {8} deferred {9} neverBuilt {10}",
+                "Health: cache {0} hit ({1} miss of {2} lookups), spikes {3}, spawn fail {4}, builds {5} destroys {6}, reentryFx built {7} skipped {8} deferred {9} buildsAvoided {10}",
                 hitRateStr,
                 h.waypointCacheMisses,
                 totalLookups,
@@ -507,7 +511,7 @@ namespace Parsek
                 h.reentryFxBuildsThisSession,
                 h.reentryFxSkippedThisSession,
                 h.reentryFxDeferredThisSession,
-                reentryNeverBuilt);
+                reentryBuildsAvoided);
             sb.AppendLine();
 
             // GC gen0

--- a/Source/Parsek/Diagnostics/DiagnosticsComputation.cs
+++ b/Source/Parsek/Diagnostics/DiagnosticsComputation.cs
@@ -487,8 +487,16 @@ namespace Parsek
             {
                 hitRateStr = "N/A";
             }
+            // Bug #450 B3: `deferred` + `neverBuilt` surface the B3 savings signal —
+            // `deferred` counts spawns that entered the lazy-build queue;
+            // `neverBuilt` = deferred - built is the count of trajectories that saved
+            // the full ~7 ms build cost entirely (never entered atmosphere in the
+            // session). Without these fields the post-ship validation requires
+            // log-archaeology across a session's trajectory lifecycle.
+            int reentryNeverBuilt = h.reentryFxDeferredThisSession - h.reentryFxBuildsThisSession;
+            if (reentryNeverBuilt < 0) reentryNeverBuilt = 0;
             sb.AppendFormat(Inv,
-                "Health: cache {0} hit ({1} miss of {2} lookups), spikes {3}, spawn fail {4}, builds {5} destroys {6}, reentryFx built {7} skipped {8}",
+                "Health: cache {0} hit ({1} miss of {2} lookups), spikes {3}, spawn fail {4}, builds {5} destroys {6}, reentryFx built {7} skipped {8} deferred {9} neverBuilt {10}",
                 hitRateStr,
                 h.waypointCacheMisses,
                 totalLookups,
@@ -497,7 +505,9 @@ namespace Parsek
                 h.ghostBuildsThisSession,
                 h.ghostDestroysThisSession,
                 h.reentryFxBuildsThisSession,
-                h.reentryFxSkippedThisSession);
+                h.reentryFxSkippedThisSession,
+                h.reentryFxDeferredThisSession,
+                reentryNeverBuilt);
             sb.AppendLine();
 
             // GC gen0

--- a/Source/Parsek/Diagnostics/DiagnosticsStructs.cs
+++ b/Source/Parsek/Diagnostics/DiagnosticsStructs.cs
@@ -245,6 +245,13 @@ namespace Parsek
         public int ghostDestroysThisSession;
         public int reentryFxBuildsThisSession;
         public int reentryFxSkippedThisSession;
+        // Bug #450 B3: incremented at spawn when a reentry-capable trajectory defers
+        // its build to the first in-atmosphere frame. `reentryFxBuildsThisSession`
+        // still tracks actual builds; the difference (`deferred - builds`) is the
+        // number of trajectories that saved the build entirely by never entering
+        // atmosphere in the session. That delta is the signal B3 uses to prove it
+        // worked.
+        public int reentryFxDeferredThisSession;
         public int gcGen0Baseline;
 
         public void Reset()
@@ -258,6 +265,7 @@ namespace Parsek
             ghostDestroysThisSession = 0;
             reentryFxBuildsThisSession = 0;
             reentryFxSkippedThisSession = 0;
+            reentryFxDeferredThisSession = 0;
             gcGen0Baseline = System.GC.CollectionCount(0);
         }
     }

--- a/Source/Parsek/Diagnostics/DiagnosticsStructs.cs
+++ b/Source/Parsek/Diagnostics/DiagnosticsStructs.cs
@@ -245,12 +245,15 @@ namespace Parsek
         public int ghostDestroysThisSession;
         public int reentryFxBuildsThisSession;
         public int reentryFxSkippedThisSession;
-        // Bug #450 B3: incremented at spawn when a reentry-capable trajectory defers
-        // its build to the first in-atmosphere frame. `reentryFxBuildsThisSession`
-        // still tracks actual builds; the difference (`deferred - builds`) is the
-        // number of trajectories that saved the build entirely by never entering
-        // atmosphere in the session. That delta is the signal B3 uses to prove it
-        // worked.
+        // Bug #450 B3: incremented at spawn + each ghost rehydrate when a reentry-
+        // capable trajectory defers its build to the first in-atmosphere frame above
+        // the reentry-speed floor. One increment per visual BUILD EVENT (spawn or
+        // rehydrate), NOT per unique trajectory — a ghost that unloads and reloads
+        // N times before ever reaching atmosphere contributes N. The difference
+        // (`deferred - reentryFxBuildsThisSession`) is the number of build events
+        // that would have fired pre-B3 but were avoided post-B3 — each avoided
+        // event represents a ~7 ms cost not paid. Surfaced in the diagnostics
+        // report as `buildsAvoided`.
         public int reentryFxDeferredThisSession;
         public int gcGen0Baseline;
 

--- a/Source/Parsek/GhostPlaybackEngine.cs
+++ b/Source/Parsek/GhostPlaybackEngine.cs
@@ -1819,8 +1819,16 @@ namespace Parsek
             // checks above. If the build is throttled or fails, return — next frame
             // will retry (flag cleared only when the build actually fires, see
             // TryPerformLazyReentryBuild). Below this point info is guaranteed non-null.
+            //
+            // Under warp-suppression the FX subsystem would drive-to-zero anyway
+            // (see GhostPlaybackLogic.ShouldSuppressVisualFx); doing a ~7 ms build
+            // of FX we immediately hide contradicts the suppression policy. Defer
+            // one more frame past the warp drop-out — the ghost hasn't moved
+            // meaningfully during warp anyway.
             if (state.reentryFxPendingBuild)
             {
+                if (GhostPlaybackLogic.ShouldSuppressVisualFx(warpRate))
+                    return;
                 TryPerformLazyReentryBuild(recIdx, state, vesselName, bodyName, altitude);
                 info = state.reentryFxInfo;
                 if (info == null) return;
@@ -1878,7 +1886,12 @@ namespace Parsek
             if (frameLazyReentryBuildCount >= MaxLazyReentryBuildsPerFrame)
             {
                 frameLazyReentryBuildDeferred++;
-                ParsekLog.VerboseRateLimited("ReentryFx", "lazy-throttle",
+                // Per-index rate-limit key so a burst of same-frame throttles does
+                // not collapse into a single shared-key log line — the counter
+                // captures the count, but the per-ghost identity matters for
+                // post-playtest diagnosis. 1-second window still bounds volume per
+                // ghost.
+                ParsekLog.VerboseRateLimited("ReentryFx", $"lazy-throttle-{recIdx}",
                     $"Lazy reentry build throttled: #{recIdx} deferred to next frame " +
                     $"(used {frameLazyReentryBuildCount}/{MaxLazyReentryBuildsPerFrame})", 1.0);
                 return;  // Flag stays true — retry next frame while still in atmosphere.
@@ -1892,7 +1905,7 @@ namespace Parsek
             if (state.heatInfos == null)
             {
                 state.reentryFxPendingBuild = false;
-                ParsekLog.VerboseRateLimited("ReentryFx", $"lazy-nohheat-{recIdx}",
+                ParsekLog.VerboseRateLimited("ReentryFx", $"lazy-noheat-{recIdx}",
                     $"Lazy reentry build skipped for #{recIdx} \"{vesselName}\" — " +
                     $"state.heatInfos is null (rebuild likely in flight); clearing flag", 5.0);
                 return;
@@ -1900,14 +1913,27 @@ namespace Parsek
 
             frameLazyReentryBuildCount++;
             state.reentryFxPendingBuild = false;  // One-shot: clear even if build fails.
-            state.reentryFxInfo = GhostVisualBuilder.TryBuildReentryFx(
+            var built = GhostVisualBuilder.TryBuildReentryFx(
                 state.ghost, state.heatInfos, recIdx, vesselName);
-            DiagnosticsState.health.reentryFxBuildsThisSession++;
-
-            ParsekLog.Verbose("ReentryFx",
-                $"Lazy reentry build fired for ghost #{recIdx} \"{vesselName}\" — " +
-                $"body={bodyName} alt={altitude:F0}m " +
-                $"(deferred at spawn, built on first atmospheric frame)");
+            state.reentryFxInfo = built;
+            // Count actual builds only — the counter semantic is "FX objects produced",
+            // used by the diagnostics `reentryFx built X` line. A failed TryBuildReentryFx
+            // (returns null) is observable via `deferred - built > expected` and is NOT
+            // a build.
+            if (built != null)
+            {
+                DiagnosticsState.health.reentryFxBuildsThisSession++;
+                ParsekLog.Verbose("ReentryFx",
+                    $"Lazy reentry build fired for ghost #{recIdx} \"{vesselName}\" — " +
+                    $"body={bodyName} alt={altitude:F0}m " +
+                    $"(deferred at spawn, built on first atmospheric frame)");
+            }
+            else
+            {
+                ParsekLog.VerboseRateLimited("ReentryFx", $"lazy-buildnull-{recIdx}",
+                    $"Lazy reentry build returned null for #{recIdx} \"{vesselName}\" — " +
+                    $"body={bodyName} alt={altitude:F0}m (flag cleared, no retry)", 5.0);
+            }
         }
 
         private void DriveReentryToZero(ReentryFxInfo info, int recIdx, string bodyName, double altitude,

--- a/Source/Parsek/GhostPlaybackEngine.cs
+++ b/Source/Parsek/GhostPlaybackEngine.cs
@@ -68,9 +68,21 @@ namespace Parsek
         // this cap; see plan-414-spawn-throttle.md for the full call-site taxonomy.
         internal const int MaxSpawnsPerFrame = 2;
 
+        // Bug #450 B3: cap on deferred reentry-FX builds that can fire on a single frame.
+        // Without a cap, N ghosts crossing atmosphereDepth in the same frame would each
+        // pay the ~7 ms TryBuildReentryFx cost, relocating the bimodal spawn-burst pattern
+        // to atmosphere-entry-time rather than eliminating it. The atmosphere-entry window
+        // is many frames wide (ghosts approach the boundary at ~hundreds of m/s vs a
+        // ~100 km atmosphere depth), so a 1-frame delay on the excess builds is invisible.
+        internal const int MaxLazyReentryBuildsPerFrame = 2;
+
         // Per-frame batch counters (avoid per-ghost log spam)
         private int frameSpawnCount;
         private int frameDestroyCount;
+        // Bug #450 B3: per-frame counters for deferred-reentry-build throttling.
+        // Reset each frame alongside the #414 counters.
+        private int frameLazyReentryBuildCount;
+        private int frameLazyReentryBuildDeferred;
         // Bug #414: per-frame counter of throttle-eligible spawns that were deferred because
         // the cap was already exhausted. Reset each frame alongside frameSpawnCount.
         private int frameSpawnDeferred;
@@ -342,6 +354,10 @@ namespace Parsek
             frameDestroyCount = 0;
             frameSpawnDeferred = 0;
             frameMaxSpawnTicks = 0;
+            // Bug #450 B3: reset lazy-reentry-build per-frame counters each tick so the
+            // cap applies within a single UpdatePlayback call.
+            frameLazyReentryBuildCount = 0;
+            frameLazyReentryBuildDeferred = 0;
             // Bug #450: reset per-frame heaviest-spawn breakdown fields so the latch starts
             // empty each frame. No heaviest spawn yet -> HeaviestSpawnBuildType.None. The
             // lastSpawn*Ticks fields are NOT reset here because TryPopulateGhostVisuals
@@ -1419,7 +1435,10 @@ namespace Parsek
                 state.pauseHidden = true;
                 GhostPlaybackLogic.HideAllGhostParts(state);
             }
-            if (state.reentryFxInfo != null)
+            // Bug #450 B3: widened guard — pending-but-not-yet-built ghosts also need
+            // UpdateReentryFx to run so the lazy build can fire if the loop-pause frame
+            // happens to be the first one in atmosphere.
+            if (state.reentryFxInfo != null || state.reentryFxPendingBuild)
             {
                 state.lastInterpolatedVelocity = Vector3.zero;
                 UpdateReentryFx(index, state, traj.VesselName, warpRate);
@@ -1734,12 +1753,22 @@ namespace Parsek
         /// Update reentry visual effects for a ghost. Computes atmospheric density,
         /// Mach number, and intensity, then drives glow/fire/shell layers.
         /// </summary>
+        /// <remarks>
+        /// Bug #450 B3: entry condition widened to allow ghosts whose reentry build
+        /// was deferred at spawn (<c>state.reentryFxPendingBuild == true</c>) to
+        /// reach the body/atmosphere lookup below. The lazy build fires inside this
+        /// method after the body is resolved so there is no duplicate
+        /// <c>FlightGlobals.Bodies.Find</c> on the hot path. Drive-to-zero paths
+        /// short-circuit to a plain return when <c>reentryFxInfo</c> is still null
+        /// (nothing to drive, we're just waiting for in-atmosphere conditions).
+        /// </remarks>
         internal void UpdateReentryFx(int recIdx, GhostPlaybackState state, string vesselName, float warpRate)
         {
-            var info = state.reentryFxInfo;
-            if (info == null || state.ghost == null) return;
+            if (state == null || state.ghost == null) return;
+            if (state.reentryFxInfo == null && !state.reentryFxPendingBuild) return;
 
-            if (GhostPlaybackLogic.ShouldSuppressVisualFx(warpRate))
+            var info = state.reentryFxInfo;
+            if (info != null && GhostPlaybackLogic.ShouldSuppressVisualFx(warpRate))
             {
                 DriveReentryToZero(info, recIdx, state.lastInterpolatedBodyName,
                     state.lastInterpolatedAltitude, vesselName);
@@ -1752,7 +1781,8 @@ namespace Parsek
 
             if (string.IsNullOrEmpty(bodyName))
             {
-                DriveReentryToZero(info, recIdx, bodyName, 0.0, vesselName, state);
+                if (info != null)
+                    DriveReentryToZero(info, recIdx, bodyName, 0.0, vesselName, state);
                 return;
             }
 
@@ -1766,24 +1796,38 @@ namespace Parsek
             {
                 ParsekLog.VerboseRateLimited("Engine", $"ghost-{recIdx}-nobody",
                     $"ReentryFx: body '{bodyName}' not found — skipping");
-                DriveReentryToZero(info, recIdx, bodyName, altitude, vesselName, state);
+                if (info != null)
+                    DriveReentryToZero(info, recIdx, bodyName, altitude, vesselName, state);
                 return;
             }
 
-            Vector3 surfaceVel = interpolatedVel - (Vector3)body.getRFrmVel(state.ghost.transform.position);
-            float speed = surfaceVel.magnitude;
-
             if (!body.atmosphere)
             {
-                DriveReentryToZero(info, recIdx, bodyName, altitude, vesselName, state);
+                if (info != null)
+                    DriveReentryToZero(info, recIdx, bodyName, altitude, vesselName, state);
                 return;
             }
 
             if (altitude >= body.atmosphereDepth)
             {
-                DriveReentryToZero(info, recIdx, bodyName, altitude, vesselName, state);
+                if (info != null)
+                    DriveReentryToZero(info, recIdx, bodyName, altitude, vesselName, state);
                 return;
             }
+
+            // Bug #450 B3: lazy-build seam. Reuses the body + atmosphere + altitude
+            // checks above. If the build is throttled or fails, return — next frame
+            // will retry (flag cleared only when the build actually fires, see
+            // TryPerformLazyReentryBuild). Below this point info is guaranteed non-null.
+            if (state.reentryFxPendingBuild)
+            {
+                TryPerformLazyReentryBuild(recIdx, state, vesselName, bodyName, altitude);
+                info = state.reentryFxInfo;
+                if (info == null) return;
+            }
+
+            Vector3 surfaceVel = interpolatedVel - (Vector3)body.getRFrmVel(state.ghost.transform.position);
+            float speed = surfaceVel.magnitude;
 
             double pressure = body.GetPressure(altitude);
             double temperature = body.GetTemperature(altitude);
@@ -1811,6 +1855,59 @@ namespace Parsek
 
             DriveReentryLayers(info, smoothedIntensity, surfaceVel, recIdx, bodyName, altitude, machNumber, vesselName, state);
             info.lastIntensity = smoothedIntensity;
+        }
+
+        /// <summary>
+        /// Bug #450 B3: perform the deferred reentry-FX build. Called from inside
+        /// <see cref="UpdateReentryFx"/> after its body/atmosphere/altitude guards have
+        /// already confirmed the ghost is in atmosphere, so there is no duplicate
+        /// <c>FlightGlobals.Bodies.Find</c> lookup. Respects
+        /// <see cref="MaxLazyReentryBuildsPerFrame"/> to prevent a burst of simultaneous
+        /// atmosphere-entries from producing the same bimodal hitch #450 is trying to
+        /// eliminate.
+        /// </summary>
+        private void TryPerformLazyReentryBuild(
+            int recIdx, GhostPlaybackState state, string vesselName,
+            string bodyName, double altitude)
+        {
+            // Defensive idempotency: the production call site in UpdateReentryFx guards
+            // on state.reentryFxPendingBuild, but this method is also exposed as a test
+            // seam. A re-entrant call with the flag already cleared must be a no-op.
+            if (state == null || !state.reentryFxPendingBuild) return;
+
+            if (frameLazyReentryBuildCount >= MaxLazyReentryBuildsPerFrame)
+            {
+                frameLazyReentryBuildDeferred++;
+                ParsekLog.VerboseRateLimited("ReentryFx", "lazy-throttle",
+                    $"Lazy reentry build throttled: #{recIdx} deferred to next frame " +
+                    $"(used {frameLazyReentryBuildCount}/{MaxLazyReentryBuildsPerFrame})", 1.0);
+                return;  // Flag stays true — retry next frame while still in atmosphere.
+            }
+
+            // Defensive: heatInfos is only nulled by ClearLoadedVisualReferences (which
+            // also clears our pending flag) or by a full rebuild path. If we somehow
+            // land here with a null it, clear the flag so we don't burn CPU every
+            // frame on an impossible build, and let the subsystem self-heal on the
+            // next rebuild.
+            if (state.heatInfos == null)
+            {
+                state.reentryFxPendingBuild = false;
+                ParsekLog.VerboseRateLimited("ReentryFx", $"lazy-nohheat-{recIdx}",
+                    $"Lazy reentry build skipped for #{recIdx} \"{vesselName}\" — " +
+                    $"state.heatInfos is null (rebuild likely in flight); clearing flag", 5.0);
+                return;
+            }
+
+            frameLazyReentryBuildCount++;
+            state.reentryFxPendingBuild = false;  // One-shot: clear even if build fails.
+            state.reentryFxInfo = GhostVisualBuilder.TryBuildReentryFx(
+                state.ghost, state.heatInfos, recIdx, vesselName);
+            DiagnosticsState.health.reentryFxBuildsThisSession++;
+
+            ParsekLog.Verbose("ReentryFx",
+                $"Lazy reentry build fired for ghost #{recIdx} \"{vesselName}\" — " +
+                $"body={bodyName} alt={altitude:F0}m " +
+                $"(deferred at spawn, built on first atmospheric frame)");
         }
 
         private void DriveReentryToZero(ReentryFxInfo info, int recIdx, string bodyName, double altitude,
@@ -2292,6 +2389,18 @@ namespace Parsek
             => frameSpawnCount++;
         internal int FrameSpawnCountForTesting => frameSpawnCount;
         internal int FrameSpawnDeferredForTesting => frameSpawnDeferred;
+        // Bug #450 B3 test hooks. Narrow seam that lets tests drive the lazy-build
+        // decision + throttle without constructing a full Unity scene (TryBuildReentryFx
+        // needs a live GameObject, so tests here will stay on the counter/flag observation
+        // side and defer the actual-build assertion to the in-game RuntimeTests fixture).
+        internal void TryPerformLazyReentryBuildForTesting(
+            int recIdx, GhostPlaybackState state, string vesselName,
+            string bodyName, double altitude)
+            => TryPerformLazyReentryBuild(recIdx, state, vesselName, bodyName, altitude);
+        internal int FrameLazyReentryBuildCountForTesting => frameLazyReentryBuildCount;
+        internal int FrameLazyReentryBuildDeferredForTesting => frameLazyReentryBuildDeferred;
+        internal void SetFrameLazyReentryBuildCountForTesting(int value)
+            => frameLazyReentryBuildCount = value;
         internal void ResetPerFrameCountersForTesting()
         {
             frameSpawnCount = 0;
@@ -2314,6 +2423,9 @@ namespace Parsek
             buildTimelineStopwatch.Reset();
             buildDictionariesStopwatch.Reset();
             buildReentryFxStopwatch.Reset();
+            // Bug #450 B3: mirror the production reset so tests see a clean cap each call.
+            frameLazyReentryBuildCount = 0;
+            frameLazyReentryBuildDeferred = 0;
         }
 
         private bool TryPopulateGhostVisuals(
@@ -2422,13 +2534,20 @@ namespace Parsek
             buildReentryFxStopwatch.Start();
             if (TrajectoryMath.HasReentryPotential(traj))
             {
-                state.reentryFxInfo = GhostVisualBuilder.TryBuildReentryFx(
-                    ghost, state.heatInfos, index, traj.VesselName);
-                DiagnosticsState.health.reentryFxBuildsThisSession++;
+                // Bug #450 B3: defer the ~7 ms TryBuildReentryFx work to the first
+                // in-atmosphere frame. Ghosts that never enter atmosphere (orbital-only
+                // fly-bys, pad ghosts that never launch, sub-400 m/s suborbital hops
+                // that stay above the boundary) save the entire build cost. The lazy
+                // build fires from inside UpdateReentryFx after its body lookup so
+                // there is no duplicate FlightGlobals.Bodies.Find.
+                state.reentryFxInfo = null;
+                state.reentryFxPendingBuild = true;
+                DiagnosticsState.health.reentryFxDeferredThisSession++;
             }
             else
             {
                 state.reentryFxInfo = null;
+                state.reentryFxPendingBuild = false;
                 DiagnosticsState.health.reentryFxSkippedThisSession++;
                 ParsekLog.VerboseRateLimited("ReentryFx", $"skip-{index}",
                     $"Skipped reentry FX build for ghost #{index} \"{traj.VesselName}\" " +

--- a/Source/Parsek/GhostPlaybackEngine.cs
+++ b/Source/Parsek/GhostPlaybackEngine.cs
@@ -1815,10 +1815,21 @@ namespace Parsek
                 return;
             }
 
+            // Compute surface velocity BEFORE the lazy-build decision so the speed
+            // gate can fire. `ReentryPotentialSpeedFloor` (400 m/s ≈ Mach 1.2 at
+            // sea-level Kerbin) is shared with `HasReentryPotential` and gates out
+            // pad launches where the ghost starts at 0 m/s — without this gate,
+            // ghosts whose first playback point is already in-atmosphere (every
+            // KSC launch recording) would still pay the full 7 ms build on frame 1,
+            // just attributed to mainLoop instead of spawn.
+            Vector3 surfaceVel = interpolatedVel - (Vector3)body.getRFrmVel(state.ghost.transform.position);
+            float speed = surfaceVel.magnitude;
+
             // Bug #450 B3: lazy-build seam. Reuses the body + atmosphere + altitude
-            // checks above. If the build is throttled or fails, return — next frame
-            // will retry (flag cleared only when the build actually fires, see
-            // TryPerformLazyReentryBuild). Below this point info is guaranteed non-null.
+            // + speed checks above. If the build is throttled or the gate fails,
+            // return (for null info) — next frame will retry while still in
+            // atmosphere. Flag cleared only when the build actually fires, see
+            // TryPerformLazyReentryBuild.
             //
             // Under warp-suppression the FX subsystem would drive-to-zero anyway
             // (see GhostPlaybackLogic.ShouldSuppressVisualFx); doing a ~7 ms build
@@ -1829,13 +1840,20 @@ namespace Parsek
             {
                 if (GhostPlaybackLogic.ShouldSuppressVisualFx(warpRate))
                     return;
+                if (!GhostPlaybackLogic.ShouldBuildLazyReentryFx(
+                        state.reentryFxPendingBuild, bodyName, body.atmosphere,
+                        altitude, body.atmosphereDepth,
+                        speed, TrajectoryMath.ReentryPotentialSpeedFloor))
+                {
+                    // In-atmosphere but still too slow for FX to be imminent
+                    // (typical KSC launch below ~Mach 1.2). Return — info is null,
+                    // nothing to drive. Next frame will re-check.
+                    return;
+                }
                 TryPerformLazyReentryBuild(recIdx, state, vesselName, bodyName, altitude);
                 info = state.reentryFxInfo;
                 if (info == null) return;
             }
-
-            Vector3 surfaceVel = interpolatedVel - (Vector3)body.getRFrmVel(state.ghost.transform.position);
-            float speed = surfaceVel.magnitude;
 
             double pressure = body.GetPressure(altitude);
             double temperature = body.GetTemperature(altitude);

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -74,14 +74,24 @@ namespace Parsek
 
         /// <summary>
         /// Bug #450 B3: decides whether a deferred reentry-FX build should fire on the
-        /// current frame. Returns true when the ghost is inside a body's atmosphere
-        /// (the earliest point at which reentry visuals can render at non-zero intensity —
-        /// see <c>GhostVisualBuilder.ComputeReentryIntensity</c> density/Mach gates).
+        /// current frame. Returns true when the ghost is inside a body's atmosphere AND
+        /// moving fast enough for reentry visuals to be imminent (speed ≥ the
+        /// <c>ReentryPotentialSpeedFloor</c> = 400 m/s ≈ Mach 1.2 at sea-level Kerbin —
+        /// the floor shared with <c>TrajectoryMath.HasReentryPotential</c>).
+        ///
+        /// The speed gate prevents launch recordings (pad → ascent) from triggering the
+        /// build on the very first playback frame: those ghosts are at 0 m/s at ground
+        /// level on frame 1 and only cross the 400 m/s floor several seconds later, so
+        /// the 7 ms build shifts off the spawn hitch by design. Atmospheric-start
+        /// recordings where the ghost is already above 400 m/s (mid-reentry saves) still
+        /// fire on frame 1 — that is correct because we legitimately need FX right away.
+        ///
         /// Pure helper so the condition is unit-testable without Unity or FlightGlobals.
         /// </summary>
         internal static bool ShouldBuildLazyReentryFx(
             bool pendingFlag, string bodyName, bool bodyHasAtmosphere,
-            double altitudeMeters, double atmosphereDepthMeters)
+            double altitudeMeters, double atmosphereDepthMeters,
+            float surfaceSpeedMetersPerSecond, float speedFloorMetersPerSecond)
         {
             if (!pendingFlag) return false;
             if (string.IsNullOrEmpty(bodyName)) return false;
@@ -90,6 +100,9 @@ namespace Parsek
             // already calls DriveReentryToZero, so firing the build here would only pay
             // the cost for a frame that produces zero-intensity output anyway.
             if (altitudeMeters >= atmosphereDepthMeters) return false;
+            // Speed gate — see XML doc above. NaN/negative compares false by IEEE rules,
+            // so a malformed velocity correctly suppresses the build rather than leaking it.
+            if (!(surfaceSpeedMetersPerSecond >= speedFloorMetersPerSecond)) return false;
             return true;
         }
 

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -72,6 +72,27 @@ namespace Parsek
             return spawnsThisFrame >= maxPerFrame;
         }
 
+        /// <summary>
+        /// Bug #450 B3: decides whether a deferred reentry-FX build should fire on the
+        /// current frame. Returns true when the ghost is inside a body's atmosphere
+        /// (the earliest point at which reentry visuals can render at non-zero intensity —
+        /// see <c>GhostVisualBuilder.ComputeReentryIntensity</c> density/Mach gates).
+        /// Pure helper so the condition is unit-testable without Unity or FlightGlobals.
+        /// </summary>
+        internal static bool ShouldBuildLazyReentryFx(
+            bool pendingFlag, string bodyName, bool bodyHasAtmosphere,
+            double altitudeMeters, double atmosphereDepthMeters)
+        {
+            if (!pendingFlag) return false;
+            if (string.IsNullOrEmpty(bodyName)) return false;
+            if (!bodyHasAtmosphere) return false;
+            // Strict `<`: at exactly atmosphereDepth the existing UpdateReentryFx path
+            // already calls DriveReentryToZero, so firing the build here would only pay
+            // the cost for a frame that produces zero-intensity output anyway.
+            if (altitudeMeters >= atmosphereDepthMeters) return false;
+            return true;
+        }
+
         internal static bool ShouldSuppressVisualFx(float currentWarpRate)
         {
             return currentWarpRate > FxSuppressWarpThreshold;

--- a/Source/Parsek/GhostPlaybackState.cs
+++ b/Source/Parsek/GhostPlaybackState.cs
@@ -40,6 +40,12 @@ namespace Parsek
         public List<CompoundPartGhostInfo> compoundPartInfos;
         public Dictionary<uint, GameObject> fakeCanopies;
         public ReentryFxInfo reentryFxInfo;
+        // Bug #450 B3: true when trajectory had reentry potential at spawn but the
+        // expensive TryBuildReentryFx call was deferred to the first in-atmosphere
+        // frame. Transitions to false the moment a lazy build fires (or is deemed
+        // impossible — e.g. heatInfos was nulled by a rebuild that also clears
+        // this flag via ClearLoadedVisualReferences). One-shot per ghost lifetime.
+        public bool reentryFxPendingBuild;
         public MaterialPropertyBlock reentryMpb; // per-ghost to avoid shared-state bugs with overlapping ghosts
         public bool explosionFired;
         public bool pauseHidden;
@@ -85,6 +91,7 @@ namespace Parsek
             compoundPartInfos = null;
             fakeCanopies = null;
             reentryFxInfo = null;
+            reentryFxPendingBuild = false;
             reentryMpb = null;
             pauseHidden = false;
             rcsSuppressed = false;

--- a/Source/Parsek/InGameTests/RuntimeTests.cs
+++ b/Source/Parsek/InGameTests/RuntimeTests.cs
@@ -3338,5 +3338,85 @@ namespace Parsek.InGameTests
         }
 
         #endregion
+
+        #region Bug #450 B3 Lazy Reentry FX
+
+        [InGameTest(Category = "ReentryFx", Scene = GameScenes.FLIGHT,
+            Description = "Bug #450 B3: TryBuildReentryFx on a real Unity GameObject returns null for an empty ghost root, and the lazy-build helper clears the pending flag without incrementing the builds counter.")]
+        public void Bug450B3_LazyBuild_OnEmptyGhostRoot_ClearsFlagWithoutCountingBuild()
+        {
+            // Residual-risk coverage for the plan's "in-game only" test gap: verifies
+            // the live-Unity lazy-build path wiring. We do NOT construct a real ghost
+            // (that requires an active snapshot + AvailablePart + Unity prefab), but
+            // we DO exercise TryBuildReentryFx with a genuine GameObject so the Unity
+            // APIs inside (GetComponentsInChildren, Mesh.CombineMeshes, ParticleSystem
+            // setup) run against a real scene. An empty ghost root produces no mesh
+            // coverage → TryBuildReentryFx returns null → the lazy-build wrapper must
+            // clear the flag and NOT bump reentryFxBuildsThisSession.
+            var ghostRoot = new GameObject("ParsekTestGhost_B3");
+            runner.TrackForCleanup(ghostRoot);
+
+            var state = new GhostPlaybackState
+            {
+                vesselName = "TestB3",
+                ghost = ghostRoot,
+                reentryFxPendingBuild = true,
+                heatInfos = new System.Collections.Generic.Dictionary<uint, HeatGhostInfo>(),
+                reentryFxInfo = null,
+            };
+
+            // Use a fresh engine instance so the session-wide build counter reads
+            // cleanly from DiagnosticsState. The engine constructor is free of
+            // side-effects besides field initialisation.
+            var engine = new GhostPlaybackEngine(positioner: null);
+            int buildsBefore = DiagnosticsState.health.reentryFxBuildsThisSession;
+
+            engine.TryPerformLazyReentryBuildForTesting(
+                recIdx: 999, state, vesselName: "TestB3",
+                bodyName: "Kerbin", altitude: 50_000);
+
+            // Flag clears regardless of build success (one-shot, no retry storm).
+            InGameAssert.IsFalse(state.reentryFxPendingBuild,
+                "Lazy build must clear reentryFxPendingBuild even when TryBuildReentryFx returns null");
+            // Counter only bumps on non-null build. Empty ghost root → null → no bump.
+            int buildsAfter = DiagnosticsState.health.reentryFxBuildsThisSession;
+            InGameAssert.AreEqual(buildsBefore, buildsAfter,
+                "reentryFxBuildsThisSession must NOT increment when TryBuildReentryFx returns null");
+            // A frame-slot IS consumed (we did invoke the build). Confirms the
+            // counter lives in the unthrottled-success path.
+            InGameAssert.AreEqual(1, engine.FrameLazyReentryBuildCountForTesting,
+                "A build attempt must consume one per-frame slot regardless of result");
+        }
+
+        [InGameTest(Category = "ReentryFx", Scene = GameScenes.FLIGHT,
+            Description = "Bug #450 B3: the speed gate in ShouldBuildLazyReentryFx matches the shared ReentryPotentialSpeedFloor constant, confirming the value we gate on in production is the documented 400 m/s floor.")]
+        public void Bug450B3_SpeedGate_MatchesReentryPotentialFloor()
+        {
+            // Pin the cross-file contract between the B3 helper's speed floor and
+            // TrajectoryMath.ReentryPotentialSpeedFloor. If these drift apart, a
+            // trajectory that `HasReentryPotential` accepts may be stranded in
+            // pending-forever state at spawn, or vice versa. The constant lives in
+            // TrajectoryMath so the floor is a single source of truth.
+            float floor = TrajectoryMath.ReentryPotentialSpeedFloor;
+            InGameAssert.IsTrue(floor >= 100f && floor <= 1000f,
+                $"ReentryPotentialSpeedFloor={floor} is outside the expected 100-1000 m/s sanity range; B3 speed gate may be miscalibrated");
+
+            // Just at the floor → build fires.
+            InGameAssert.IsTrue(
+                GhostPlaybackLogic.ShouldBuildLazyReentryFx(
+                    pendingFlag: true, bodyName: "Kerbin",
+                    bodyHasAtmosphere: true, altitudeMeters: 50_000, atmosphereDepthMeters: 70_000,
+                    surfaceSpeedMetersPerSecond: floor, speedFloorMetersPerSecond: floor),
+                "At exactly the speed floor, the build must fire");
+            // Just below the floor → build does NOT fire.
+            InGameAssert.IsFalse(
+                GhostPlaybackLogic.ShouldBuildLazyReentryFx(
+                    pendingFlag: true, bodyName: "Kerbin",
+                    bodyHasAtmosphere: true, altitudeMeters: 50_000, atmosphereDepthMeters: 70_000,
+                    surfaceSpeedMetersPerSecond: floor - 1f, speedFloorMetersPerSecond: floor),
+                "One m/s below the speed floor, the build must NOT fire");
+        }
+
+        #endregion
     }
 }

--- a/docs/dev/plan-450-b3-lazy-reentry.md
+++ b/docs/dev/plan-450-b3-lazy-reentry.md
@@ -176,24 +176,38 @@ private void TryPerformLazyReentryBuild(
 
 ### Pure decision helper (for tests — review finding #11)
 
-The atmosphere-check logic is testable in isolation without Unity:
+The decision logic is testable in isolation without Unity. A speed gate was
+added after the post-implementation review (P1 finding) because the original
+"in atmosphere" condition alone still fired the lazy build on frame 1 of
+every KSC launch recording — those ghosts spawn already inside Kerbin's
+atmosphere (altitude ~67 m at the pad) so the ~7 ms build cost remained
+attached to the spawn hitch, just relocated from the `spawn` bucket to the
+`mainLoop` bucket. The fix gates on `speed ≥ ReentryPotentialSpeedFloor`
+(400 m/s, shared with `TrajectoryMath.HasReentryPotential`) — at that speed
+the ghost has actually reached conditions where `ComputeReentryIntensity`
+can produce non-zero output within the next few frames.
 
 ```csharp
 // In GhostPlaybackLogic (pure static).
 internal static bool ShouldBuildLazyReentryFx(
     bool pendingFlag, string bodyName, bool bodyHasAtmosphere,
-    double altitudeMeters, double atmosphereDepthMeters)
+    double altitudeMeters, double atmosphereDepthMeters,
+    float surfaceSpeedMetersPerSecond, float speedFloorMetersPerSecond)
 {
     if (!pendingFlag) return false;
     if (string.IsNullOrEmpty(bodyName)) return false;
     if (!bodyHasAtmosphere) return false;
     if (altitudeMeters >= atmosphereDepthMeters) return false;
+    if (!(surfaceSpeedMetersPerSecond >= speedFloorMetersPerSecond)) return false;
     return true;
 }
 ```
 
-Engine's `UpdateReentryFx` calls this with the already-resolved `body`
-reference so no duplicate `Find`.
+The `!(speed >= floor)` form intentionally pins the NaN-safe direction — a
+malformed velocity suppresses the build rather than burning it. Engine's
+`UpdateReentryFx` calls this with the already-resolved `body` reference
+AND the computed `surfaceVel.magnitude`, so the speed reuses the same
+`body.getRFrmVel` lookup the rest of `UpdateReentryFx` already pays.
 
 ### Invariants preserved
 
@@ -256,7 +270,8 @@ zero on a post-B3 playtest; if it doesn't, the fix didn't take.
 Session counters in `DiagnosticsStructs.HealthCounters`:
 - `reentryFxBuildsThisSession` — actual builds (moved from spawn to lazy site).
 - `reentryFxSkippedThisSession` — unchanged semantic (HasReentryPotential = false at spawn).
-- `reentryFxDeferredThisSession` — new: B3-deferred at spawn (the input to "never built = deferred − builds").
+- `reentryFxDeferredThisSession` — new: B3-deferred at spawn OR at each rehydrate. Counted per build-event, NOT per unique trajectory — a ghost that unloads and rehydrates N times before ever reaching atmosphere contributes N.
+- `buildsAvoided` = `deferred − builds` (display-only, computed in the report): number of build EVENTS that would have fired pre-B3 but didn't post-B3. Renamed from `neverBuilt` because that label implied unique-trajectory semantics, which is not what the subtraction measures.
 
 ## Files touched
 

--- a/docs/dev/plan-450-b3-lazy-reentry.md
+++ b/docs/dev/plan-450-b3-lazy-reentry.md
@@ -1,0 +1,354 @@
+# Plan: #450 Phase B3 — lazy reentry FX pre-warm
+
+## Problem
+
+Phase A's one-shot WARN from the 2026-04-18 playtest:
+
+```
+heaviestSpawn[type=recording-start-snapshot
+              snapshot=0.00ms timeline=15.90ms dicts=1.28ms reentry=6.94ms
+              other=0.08ms total=24.20ms]
+```
+
+Reentry FX costs **6.94 ms at spawn time** — 29 % of a single bimodal 24.2 ms
+spawn. Parts of this work are paid up-front for every ghost whose trajectory
+has reentry potential (has orbit segments OR any trajectory point ≥ 400 m/s),
+regardless of whether the ghost ever actually renders reentry visuals in the
+current session.
+
+## What B3 does
+
+Defer `TryBuildReentryFx` from spawn time to **the first frame the ghost is
+actually near reentry conditions** — in atmosphere, below the body's
+`atmosphereDepth`. Ghosts that never enter atmosphere (orbital-only, EVA,
+KSC pad ghosts, showcases) never pay the build cost.
+
+## Current behaviour (baseline)
+
+`GhostPlaybackEngine.TryPopulateGhostVisuals` at spawn:
+
+```csharp
+if (TrajectoryMath.HasReentryPotential(traj))
+{
+    state.reentryFxInfo = TryBuildReentryFx(ghost, state.heatInfos, index, traj.VesselName);
+    DiagnosticsState.health.reentryFxBuildsThisSession++;
+}
+else
+{
+    state.reentryFxInfo = null;
+    DiagnosticsState.health.reentryFxSkippedThisSession++;
+}
+```
+
+`UpdateReentryFx` is only called from two sites, both guarded by
+`state.reentryFxInfo != null`. When the info is null, reentry FX simply
+doesn't render — which is exactly what happens on the `skip` branch today
+for vessels below the 400 m/s floor.
+
+## Proposed design (revised after clean-context review)
+
+### New state field
+
+`GhostPlaybackState.reentryFxPendingBuild` (bool, defaults false).
+Cleared in `ClearLoadedVisualReferences` alongside the existing
+`reentryFxInfo = null` reset.
+
+### Spawn path change
+
+```csharp
+if (TrajectoryMath.HasReentryPotential(traj))
+{
+    // B3: defer the build to the first in-atmosphere frame. Cost avoided:
+    // part-mesh combine + ParticleSystem setup + glow-material cloning.
+    state.reentryFxInfo = null;
+    state.reentryFxPendingBuild = true;
+    DiagnosticsState.health.reentryFxDeferredThisSession++;  // B3 telemetry
+}
+else
+{
+    state.reentryFxInfo = null;
+    state.reentryFxPendingBuild = false;
+    DiagnosticsState.health.reentryFxSkippedThisSession++;
+    ParsekLog.VerboseRateLimited("ReentryFx", $"skip-{index}", "…", 5.0);
+}
+```
+
+`reentryFxBuildsThisSession` counter moves to the lazy-build site so the
+session metric continues to mean "number of FX actually built"; the new
+`reentryFxDeferredThisSession` counter tracks spawns that entered the
+lazy-build queue. Their difference at session end is the count of
+trajectories that saved the build entirely (never entered atmosphere)
+— the signal B3 uses to prove it worked.
+
+### Lazy build lives INSIDE `UpdateReentryFx` (review finding #10)
+
+Original plan had a separate `TryLazyBuildReentryFx` helper called
+before `UpdateReentryFx` — that duplicated the `FlightGlobals.Bodies.Find`
+lookup every frame. Reuse the body lookup the existing update flow
+already does by placing the lazy-build branch inside `UpdateReentryFx`,
+right after the body/atmosphere/altitude guards:
+
+```csharp
+internal void UpdateReentryFx(int recIdx, GhostPlaybackState state, string vesselName, float warpRate)
+{
+    if (state == null || state.ghost == null) return;
+
+    // B3: widened entry condition — allow pending-but-not-yet-built ghosts
+    // through so we can build lazily below.
+    if (state.reentryFxInfo == null && !state.reentryFxPendingBuild) return;
+
+    if (state.reentryFxInfo != null && GhostPlaybackLogic.ShouldSuppressVisualFx(warpRate))
+    {
+        DriveReentryToZero(state.reentryFxInfo, recIdx, state.lastInterpolatedBodyName,
+            state.lastInterpolatedAltitude, vesselName);
+        return;
+    }
+
+    string bodyName = state.lastInterpolatedBodyName;
+    double altitude = state.lastInterpolatedAltitude;
+    if (string.IsNullOrEmpty(bodyName)) return;
+
+    CelestialBody body = FlightGlobals.Bodies?.Find(b => b.name == bodyName);
+    if (body == null) { /* existing "body not found" log + return */ }
+    // existing no-atmosphere / above-atmosphere / NaN density paths unchanged …
+
+    // B3: lazy build fires here — body/atmosphere/altitude all validated,
+    // no duplicate Find, no duplicate NaN checks.
+    if (state.reentryFxPendingBuild)
+    {
+        TryPerformLazyReentryBuild(recIdx, state, vesselName, body.name, altitude);
+        if (state.reentryFxInfo == null) return;  // throttled, or build failed
+    }
+
+    var info = state.reentryFxInfo;
+    // … rest of existing intensity/layer flow, now guaranteed info != null …
+}
+```
+
+Callers at `GhostPlaybackEngine.cs:932` and `:1425` widen their guard from
+`if (state.reentryFxInfo != null)` to
+`if (state.reentryFxInfo != null || state.reentryFxPendingBuild)`.
+
+### Per-frame cap (review finding #3)
+
+`MaxLazyReentryBuildsPerFrame = 2` (const, mirrors `MaxSpawnsPerFrame`).
+Without a cap, five ghosts crossing `atmosphereDepth` on the same frame
+would pay `5 × 6.94 = 34.7 ms` — relocating the bimodal hitch rather than
+eliminating it. With the cap, excess builds defer to the next frame.
+The atmosphere-entry window is many frames wide at orbital reentry speeds
+(hundreds of m/s of downward velocity relative to a ~100 km atmosphere
+depth), so a 1-frame delay is invisible.
+
+```csharp
+private int frameLazyReentryBuildCount;      // reset each frame
+private int frameLazyReentryBuildDeferred;   // reset each frame, diagnostic only
+
+private void TryPerformLazyReentryBuild(
+    int recIdx, GhostPlaybackState state, string vesselName,
+    string bodyName, double altitude)
+{
+    if (frameLazyReentryBuildCount >= MaxLazyReentryBuildsPerFrame)
+    {
+        frameLazyReentryBuildDeferred++;
+        ParsekLog.VerboseRateLimited("ReentryFx", "lazy-throttle",
+            $"Lazy reentry build throttled: #{recIdx} deferred to next frame " +
+            $"(used {frameLazyReentryBuildCount}/{MaxLazyReentryBuildsPerFrame})", 1.0);
+        return;  // flag stays true, will retry next frame
+    }
+
+    // Guards against state that was cleared between spawn and first in-atmosphere
+    // frame — heatInfos is only nulled by ClearLoadedVisualReferences (which also
+    // clears our flag) or a full rebuild, but defensive.
+    if (state.heatInfos == null) { state.reentryFxPendingBuild = false; return; }
+
+    frameLazyReentryBuildCount++;
+    state.reentryFxPendingBuild = false;  // one-shot: clear even if build returns null
+    state.reentryFxInfo = GhostVisualBuilder.TryBuildReentryFx(
+        state.ghost, state.heatInfos, recIdx, vesselName);
+    DiagnosticsState.health.reentryFxBuildsThisSession++;
+
+    ParsekLog.Verbose("ReentryFx",
+        $"Lazy reentry build fired for ghost #{recIdx} \"{vesselName}\" — " +
+        $"body={bodyName} alt={altitude:F0}m " +
+        $"(deferred at spawn, built on first atmospheric frame)");
+}
+```
+
+### Pure decision helper (for tests — review finding #11)
+
+The atmosphere-check logic is testable in isolation without Unity:
+
+```csharp
+// In GhostPlaybackLogic (pure static).
+internal static bool ShouldBuildLazyReentryFx(
+    bool pendingFlag, string bodyName, bool bodyHasAtmosphere,
+    double altitudeMeters, double atmosphereDepthMeters)
+{
+    if (!pendingFlag) return false;
+    if (string.IsNullOrEmpty(bodyName)) return false;
+    if (!bodyHasAtmosphere) return false;
+    if (altitudeMeters >= atmosphereDepthMeters) return false;
+    return true;
+}
+```
+
+Engine's `UpdateReentryFx` calls this with the already-resolved `body`
+reference so no duplicate `Find`.
+
+### Invariants preserved
+
+- No-reentry-potential trajectory: no build, same as pre-B3.
+- Reentry-potential + enters atmosphere: same build output one frame later.
+- Reentry-potential + never enters atmosphere: **no build at all — the
+  cost savings**.
+
+### Scoped-out paths (review finding #7)
+
+`ParsekFlight.cs` preview / Gloops preview ghosts at `:7765-7775, 7865-7880`
+take their own `reentryFxInfo` path and are **explicitly NOT covered by
+B3**. They are short-lived UI ghosts with a different cost profile
+(single-preview, user-initiated) and the bimodal spawn-burst pattern
+#450 targets does not apply to them. If playtest shows they matter, file
+as a separate tracked follow-up.
+
+### Visual correctness (review finding #1 — verified)
+
+`GhostVisualBuilder.ComputeReentryIntensity` clamps to 0 below
+`AeroFxThermalStartMach` (Mach 2.5) AND below `AeroFxDensityFadeStart`
+(0.0015 kg/m³). Both gates are effectively zero at the very edge of
+`atmosphereDepth` — KSP's definition of `atmosphereDepth` is the altitude
+where density rounds to 0. So the one-frame build delay cannot produce
+visible FX loss even on ballistic meteor-style reentries. Pre-B3 behaviour
+was structurally the same: `UpdateReentryFx:1782` already early-returns
+when `altitude >= body.atmosphereDepth`.
+
+### Loop-cycle rebuild interaction (review finding #8 — benign)
+
+Flight-recording loop rebuilds (`DestroyGhost` → `SpawnGhost` on cycle
+boundary, see `GhostPlaybackEngine.cs:1038`) clear `reentryFxPendingBuild`
+via `ClearLoadedVisualReferences` and set it again on the next
+`TryPopulateGhostVisuals`. For a ghost mid-reentry at the cycle boundary,
+the next frame's `UpdateReentryFx` observes both the pending flag AND
+in-atmosphere conditions → builds immediately. Cost lands on the same
+frame as the old behaviour, so no cadence-hitch regression beyond what
+#406's loop-cycle-rebuild-is-itself-expensive already does.
+
+### Interaction with `TryBuildReentryFx` spawn-state assumptions (review #4/#5)
+
+`TryBuildReentryFx` (`GhostVisualBuilder.cs:6087`) uses
+`GetComponentsInChildren<Renderer>(true)` and `includeInactive=true` in
+`CombineGhostMeshFilters`. Unity's `includeInactive=true` gathers inactive
+GameObjects AND enabled-flag-false components, so the coverage is
+resilient to both distance-LOD fidelity reduction (disabled renderers)
+and part-event-driven hidden parts. Lazy build captures post-event mesh
+state, which is the CURRENT physical composition of the ghost — arguably
+more correct than the pre-B3 spawn-frozen version. Documented here so
+the trade-off is explicit. Covered by a dedicated integration-style log
+assertion in the test plan below.
+
+### Diagnostic surfacing
+
+The new work appears as `mainLoop` time in the playback budget breakdown
+(outside `spawnStopwatch`). Correct attribution — the cost is genuinely
+outside spawn. Phase A's `heaviestSpawn[reentry=…ms]` should drop toward
+zero on a post-B3 playtest; if it doesn't, the fix didn't take.
+
+Session counters in `DiagnosticsStructs.HealthCounters`:
+- `reentryFxBuildsThisSession` — actual builds (moved from spawn to lazy site).
+- `reentryFxSkippedThisSession` — unchanged semantic (HasReentryPotential = false at spawn).
+- `reentryFxDeferredThisSession` — new: B3-deferred at spawn (the input to "never built = deferred − builds").
+
+## Files touched
+
+- `Source/Parsek/GhostPlaybackState.cs` — new `reentryFxPendingBuild`
+  bool; reset in `ClearLoadedVisualReferences`.
+- `Source/Parsek/GhostPlaybackEngine.cs` — spawn-path defer, per-frame
+  `frameLazyReentryBuildCount` + `frameLazyReentryBuildDeferred` fields,
+  `MaxLazyReentryBuildsPerFrame` const, `TryPerformLazyReentryBuild`
+  helper, widened `UpdateReentryFx` entry condition, widened call-site
+  guards at lines 932 and 1425.
+- `Source/Parsek/GhostPlaybackLogic.cs` — pure `ShouldBuildLazyReentryFx`
+  decision helper (internal static, testable in isolation).
+- `Source/Parsek/Diagnostics/DiagnosticsStructs.cs` — new
+  `reentryFxDeferredThisSession` field on `HealthCounters`; reset in
+  `HealthCounters.Reset`.
+- `Source/Parsek.Tests/Bug450B3LazyReentryTests.cs` (new) — unit tests.
+- `docs/dev/todo-and-known-bugs.md` — extend #450 entry: B3 shipped,
+  B2 next.
+- `docs/dev/plan-450-b3-lazy-reentry.md` (this file).
+
+## Tests
+
+### Pure decision logic (ShouldBuildLazyReentryFx)
+
+Exercises the 5-input helper directly:
+
+1. `NotPending_ReturnsFalse` — `pendingFlag=false` → never build.
+2. `NoBodyName_ReturnsFalse` — `bodyName=null` and `""` → not ready yet.
+3. `BodyHasNoAtmosphere_ReturnsFalse` — `hasAtmosphere=false` → never build
+   (covers Mun / Minmus / asteroids).
+4. `AboveAtmosphereDepth_ReturnsFalse` — `altitude = depth + 1` → still in space.
+5. `BelowAtmosphereDepth_ReturnsTrue` — the positive case.
+6. `JustBelowDepth_ReturnsTrue` — boundary at `depth − 1m`.
+7. `ExactlyAtDepth_ReturnsFalse` — pins the `>=` sign on the altitude check.
+8. `NegativeAltitude_ReturnsTrue` — below-surface altitude (reload artifact
+   on a landed ghost) still inside atmosphere; defensive.
+
+### Engine integration
+
+9. `LazyBuild_Idempotent_WhenFlagAlreadyCleared` — call
+   `TryPerformLazyReentryBuild` with `pendingFlag=false`, assert no log
+   line emits and no build is attempted.
+10. `LazyBuild_PerFrameCap_Throttles` — call the helper twice over the cap
+    without a frame reset; assert the second call increments
+    `frameLazyReentryBuildDeferred` and emits the "Lazy reentry build
+    throttled" verbose line.
+11. `LazyBuild_PerFrameCap_ResetsOnNextFrame` — reset counters (simulating
+    next `UpdatePlayback` tick), call again, assert it fires.
+12. `LazyBuild_FiresLogLine` — positive case log assertion: verbose line
+    `"Lazy reentry build fired for ghost #N"` appears when conditions are
+    met (verifies B3 telemetry did not silently regress).
+13. `LazyBuild_ClearsPendingFlag_EvenOnBuildFailure` — the flag clears
+    after one attempt regardless of whether `TryBuildReentryFx` returns
+    null, so a failing build doesn't retry every frame.
+
+### Session counter semantics
+
+14. `SpawnPath_DeferredCounterIncrements` — reentry-potential spawn
+    increments `reentryFxDeferredThisSession`, not `reentryFxBuildsThisSession`.
+15. `LazyBuild_BuildsCounterIncrements` — a lazy build fires, asserts
+    `reentryFxBuildsThisSession` increments by exactly 1.
+
+### In-game test (`RuntimeTests.cs` — live KSP only)
+
+16. Spawn a synthetic reentry-capable ghost via the test fixture above
+    `atmosphereDepth`; assert `reentryFxInfo == null` and
+    `reentryFxPendingBuild == true`. Move the ghost below
+    `atmosphereDepth`, drive one playback frame, assert
+    `reentryFxInfo != null` and `reentryFxPendingBuild == false`.
+
+17. Spawn a reentry-capable ghost, apply a decouple part event (hides a
+    part), then drop into atmosphere. Assert the build succeeds (null
+    check only — verifying spawn-state assumptions from review #4 don't
+    crash on a decoupled ghost). The visual correctness of post-event
+    mesh coverage is the deliberate trade-off documented above.
+
+## Rollout / risk
+
+- Zero behaviour change for ghosts already in atmosphere at spawn (the
+  lazy-build fires on the very next playback frame, indistinguishable
+  from spawn-time build in wall clock).
+- Single-frame delay of FX setup on first atmospheric entry — invisible
+  because intensity is ~0 at the atmosphere boundary.
+- Orbital-only, pad-showcase, and sub-400 m/s trajectories save the full
+  6.94 ms each.
+- On a realistic save with many orbital ghosts the savings compound
+  significantly — one of the reasons this branch is the right first
+  Phase B step.
+
+## Post-ship validation
+
+Next playtest: the #450 one-shot breakdown should show
+`heaviestSpawn[reentry=…ms]` drop to ≤ 1 ms (or 0) for most spawns. If
+the dominant `timeline` bucket still ≥ 15 ms, B2 (coroutine split inside
+`BuildTimelineGhostFromSnapshot`) is the follow-up.

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -118,18 +118,62 @@ Breakdown of the exceeded frame: 70% of the budget (28.11 / 40.1 ms) lived insid
 
 **Fix — Phase A (shipped): diagnostic first.** `PlaybackBudgetPhases` now carries an aggregate-and-heaviest-spawn breakdown of every `BuildGhostVisualsWithMetrics` call across four sub-phases (snapshot resolve, timeline-from-snapshot, dictionaries, reentry FX) plus a residual "other" bucket so `sum + other = spawnMax` reconciles. `GhostPlaybackEngine.TryPopulateGhostVisuals` hosts four pre-allocated Stopwatches using the #414 spawnStopwatch pattern (pre-call ElapsedTicks + post-call subtraction for per-call deltas; same objects accumulate across the frame for the aggregate). `BuildGhostVisualsWithMetrics.finally` latches the heaviest spawn's breakdown + a byte-backed `HeaviestSpawnBuildType` classification. A separate one-shot WARN (`s_buildBreakdownOneShotFired` — independent of #414's latch so Phase A collects data even when the session's first spike already consumed #414's latch before rollout) fires the very first time a budget-exceeded frame has `spawnMicroseconds > 0`. See `docs/dev/plan-450-build-breakdown.md`.
 
-**Phase B (gated on playtest data — NOT yet scheduled):** once the next real spike fires in a user install, the new `Playback spawn build breakdown` WARN will attribute the cost. The fix branch depends on the answer:
-- `timeline` dominates, heaviest-spawn < ~15 ms — **B1: per-frame build-time budget.** `MaxSpawnBuildMsPerFrame` const; new `GhostPlaybackLogic.ShouldThrottleSpawnByTime(frameSpawnTotalTicks, capTicks)`; `TryReserveSpawnSlot` ORs count-cap and time-cap.
-- `timeline` dominates, single spawn > ~15 ms — **B2: coroutine split of `TryPopulateGhostVisuals`.** Yield between (1) snapshot resolve, (2) timeline build, (3) dict populate, (4) reentry FX; extend `deferVisibilityUntilPlaybackSync` across yields.
-- `reentry` dominates — **B3: lazy reentry FX pre-warm.** Gate `TryBuildReentryFx` on first-frame-in-atmosphere + speed > floor, not on trajectory peak.
+**Phase B branch decision — data from the 2026-04-18 playtest:**
 
-**Files:** `Source/Parsek/GhostPlaybackEngine.cs` (4 sub-phase stopwatches + heaviest-spawn latch), `Source/Parsek/Diagnostics/DiagnosticsStructs.cs` (new `HeaviestSpawnBuildType` enum + 11 new `PlaybackBudgetPhases` fields), `Source/Parsek/Diagnostics/DiagnosticsComputation.cs` (new second one-shot WARN + independent latch + `FormatHeaviestSpawnBuildType` helper), `Source/Parsek.Tests/Bug450BuildBreakdownTests.cs` (new), `docs/dev/plan-450-build-breakdown.md` (new).
+```
+heaviestSpawn[type=recording-start-snapshot
+              snapshot=0.00ms timeline=15.90ms dicts=1.28ms reentry=6.94ms
+              other=0.08ms total=24.20ms]
+```
 
-**Scope:** Phase A = Small (instrumentation-only, zero behaviour change). Phase B = scope depends on the chosen branch; held until playtest data lands.
+Timeline dominates (65.7 %) and reentry is a significant secondary
+contributor (28.7 %). Both B2 and B3 apply; B3 ships first (smaller blast
+radius), then B2 takes on the remaining `timeline` cost.
 
-**Dependencies:** #414 shipped (`TryReserveSpawnSlot` hook + per-phase breakdown framework are on main).
+**Phase B3 (shipped): lazy reentry FX pre-warm.** Defers
+`GhostVisualBuilder.TryBuildReentryFx` from spawn time to the first frame
+the ghost is actually inside a body's atmosphere. New
+`GhostPlaybackState.reentryFxPendingBuild` bool set at spawn when
+`HasReentryPotential(traj) == true`; cleared in
+`ClearLoadedVisualReferences` alongside `reentryFxInfo`. The lazy build
+fires from inside `UpdateReentryFx` after its existing body/atmosphere/
+altitude guards so there is no duplicate `FlightGlobals.Bodies.Find`.
+`MaxLazyReentryBuildsPerFrame = 2` per-frame cap mirrors
+`MaxSpawnsPerFrame` so a burst of same-frame atmosphere entries cannot
+relocate the bimodal hitch. New `reentryFxDeferredThisSession` counter
+tracks deferrals; the gap between deferrals and actual builds at session
+end is the count of trajectories that saved the full 6.94 ms by never
+entering atmosphere. Pure decision logic lives in
+`GhostPlaybackLogic.ShouldBuildLazyReentryFx` for unit testing without
+Unity. See `docs/dev/plan-450-b3-lazy-reentry.md`.
 
-**Status:** Phase A shipped — diagnostic instrumentation + one-shot WARN. Phase B: TODO, gated on next playtest's breakdown output. Priority: medium. User-visible as a ~40 ms hitch when an expensive ghost first spawns; not release-blocking for v0.8.2 but should not survive the v0.8.3 cycle.
+**Phase B2 (next): coroutine split of `BuildTimelineGhostFromSnapshot`.**
+Targets the dominant 15.90 ms timeline bucket. Not yet planned in detail;
+gated on confirmation from a post-B3 playtest that the `heaviestSpawn[reentry=…]`
+field has indeed dropped toward zero and the `timeline` field is the
+remaining problem.
+
+**Phase B1 (not planned):** the 15 ms latch threshold means #450's
+diagnostic only fires on bimodal cases, so the "spread across many
+spawns" case B1 targets is structurally out of scope of the evidence.
+#414's count cap already covers that pattern.
+
+**Files (B3):** `Source/Parsek/GhostPlaybackState.cs` (new pending flag
++ reset), `Source/Parsek/GhostPlaybackEngine.cs` (restructured
+`UpdateReentryFx` with lazy-build seam, new `TryPerformLazyReentryBuild`
+helper + per-frame cap, spawn-path defer, widened loop-pause call-site
+guard, test seams), `Source/Parsek/GhostPlaybackLogic.cs` (new pure
+`ShouldBuildLazyReentryFx` helper), `Source/Parsek/Diagnostics/DiagnosticsStructs.cs`
+(new `reentryFxDeferredThisSession` counter), `Source/Parsek.Tests/Bug450B3LazyReentryTests.cs`
+(16 new tests), `docs/dev/plan-450-b3-lazy-reentry.md` (new).
+
+**Files (A — shipped previously):** `Source/Parsek/GhostPlaybackEngine.cs` (4 sub-phase stopwatches + heaviest-spawn latch), `Source/Parsek/Diagnostics/DiagnosticsStructs.cs` (new `HeaviestSpawnBuildType` enum + 11 new `PlaybackBudgetPhases` fields), `Source/Parsek/Diagnostics/DiagnosticsComputation.cs` (new second one-shot WARN + independent latch), `Source/Parsek.Tests/Bug450BuildBreakdownTests.cs`, `docs/dev/plan-450-build-breakdown.md`.
+
+**Scope:** Phase A = Small (instrumentation-only). Phase B3 = Small (defer one function call + cap). Phase B2 = Medium (coroutine split, new invariants).
+
+**Dependencies:** #414 shipped, Phase A shipped.
+
+**Status:** Phase A + Phase B3 shipped. Phase B2 TODO, gated on next playtest confirming `heaviestSpawn[reentry=…]` has dropped. Priority: medium. Not release-blocking for v0.8.2 but should not survive the v0.8.3 cycle.
 
 ---
 


### PR DESCRIPTION
## Summary

Phase B3 follow-up to #450 Phase A (PR #377). The 2026-04-18 playtest breakdown revealed a 24.20 ms single-spawn bimodal case attributed as `timeline=15.90ms + reentry=6.94ms + dicts=1.28ms + other=0.08ms`. B3 removes the reentry contribution (~29 % of the spawn) by deferring `GhostVisualBuilder.TryBuildReentryFx` from spawn time to the first frame the ghost is actually inside a body's atmosphere. Trajectories that never enter atmosphere (orbital-only fly-bys, pad ghosts that never launch, sub-400 m/s suborbital hops) save the full build cost.

Phase B2 (coroutine split targeting the 15.90 ms timeline bucket) is gated on a post-B3 playtest confirming `heaviestSpawn[reentry=…]` has dropped — tracked separately in `docs/dev/todo-and-known-bugs.md`.

### Core change

- New `state.reentryFxPendingBuild` bool set at spawn when `HasReentryPotential(traj) == true`; cleared in `ClearLoadedVisualReferences` alongside `reentryFxInfo`.
- Lazy-build seam lives INSIDE `UpdateReentryFx` after its existing body/atmosphere/altitude guards — reuses the `FlightGlobals.Bodies.Find` lookup, no duplicate on the hot path.
- Per-frame cap `MaxLazyReentryBuildsPerFrame = 2` mirrors `MaxSpawnsPerFrame`: prevents a burst of same-frame atmosphere-entries from relocating the bimodal hitch #450 is trying to eliminate.
- Warp-suppress gate skips the lazy build during time warp (consistent with the rest of the FX-suppression policy).
- Pure `GhostPlaybackLogic.ShouldBuildLazyReentryFx` helper for unit-testable decision logic.
- New `reentryFxDeferredThisSession` counter on `HealthCounters`; surfaced in the diagnostics health line as `deferred X neverBuilt Y` so post-ship validation is grep-visible.

### Design rigor

Two clean-context Opus reviews: one on the plan pre-implementation (7 should-fix items addressed before first commit), one on the implementation (0 blockers, 3 should-fix + nits addressed in the follow-up commit on this branch). All findings resolved; full history in the two commit messages.

Scoped-out explicitly: `ParsekFlight.cs` preview / Gloops preview ghost paths — different cost profile, filed for a separate follow-up if needed. Current behaviour there is unchanged.

### Invariants preserved

- Ghosts with no reentry potential: no build (unchanged).
- Ghosts with reentry potential that enter atmosphere: same build output, one frame later (invisible — intensity is ~0 at the atmosphere boundary per stock aeroFX thresholds).
- Ghosts with reentry potential that never enter atmosphere in the session: build skipped entirely — the 6.94 ms savings per trajectory.

## Test plan

- [x] `dotnet build` clean (0 warnings, 0 errors).
- [x] `dotnet test` full suite — 7161 passing, 1 pre-existing skip (up by 20 from B3).
- [x] 20 new tests in `Bug450B3LazyReentryTests.cs`: pure decision logic (8 tests incl. boundary pins on the `>=` altitude check), engine-seam throttle + idempotency + defensive paths (7 tests), counter semantics + diagnostics report format (5 tests).
- [x] Clean-context Opus review of the plan — 7 should-fix addressed pre-commit.
- [x] Clean-context Opus review of the implementation — 3 should-fix + nits addressed in follow-up commit.
- [ ] In-game test suite (`RuntimeTests.cs`) integration case (live-Unity ghost spawn + positioning through atmosphere boundary) — deferred to post-merge in-game test-runner pass (`Ctrl+Shift+T`).
- [ ] Post-ship validation on the next #450 playtest: `heaviestSpawn[reentry=…ms]` should drop toward zero; `deferred` / `neverBuilt` counters should show non-trivial values for orbital-heavy saves.

## Related docs

- `docs/dev/plan-450-b3-lazy-reentry.md` — design + test plan + review-resolution notes.
- `docs/dev/todo-and-known-bugs.md` #450 — updated with the B3 status and the B2-next gating condition.

No CHANGELOG entry (per `feedback_changelog_style`: internal perf work, no user-facing behaviour change).