### PR TITLE
Fix #440 Phase E2: post-walk reconciliation for transformed reward types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- Fix #440: post-walk reconciliation now covers strategy-transformed and curve-applied reward types (contract complete/fail/cancel, milestone, reputation earning/penalty, KSC-path funds/science earning), emitting a warning when post-walk derived values diverge from observed KSP deltas. Does not close #439B.
 - Fix #439: capture strategy activate/deactivate lifecycle so StrategiesModule sees input on strategy-using careers; eliminates the spurious PatchFunds suspicious-drawdown warning on revert/rewind after a strategy activates. Known limitation: strategies with Science or Reputation setup cost still emit a reconciliation warning on those resource legs (follow-up).
 - `#448` KSC reconciliation no longer false-positive WARNs on every R&D part purchase under the stock-default `BypassEntryPurchaseAfterResearch=true` difficulty; the harder no-bypass difficulty still WARNs on genuine debit mismatches.
 - `#452` Cancelled-rollout build costs now render with a "(cancelled rollout)" suffix in the Actions and Timeline views so they're distinguishable from adopted, recording-tagged build costs.

--- a/Source/Parsek.Tests/EarningsReconciliationTests.cs
+++ b/Source/Parsek.Tests/EarningsReconciliationTests.cs
@@ -1107,6 +1107,507 @@ namespace Parsek.Tests
             }
         }
 
+        #region #440 post-walk tests
+
+        // ================================================================
+        // #440 Phase E2 — post-walk reconciliation for strategy-transformed
+        // and curve-applied reward types. The new LedgerOrchestrator.
+        // ReconcilePostWalk pairs the derived Transformed*/EffectiveRep/
+        // EffectiveScience values (set by RecalculationEngine.Recalculate)
+        // against live KSP deltas captured in GameStateStore.Events.
+        //
+        // Gate zero: `PostWalk_ReputationCurveMatchesKsp` must pass before
+        // any rep-leg test is trustworthy — it pins our curve output
+        // against the Spike A decompile of KSP's addReputation_granular.
+        // ================================================================
+
+        // Pre-captured reference values from the Spike A KSP decompile of
+        // addReputation_granular + the reputationAddition / reputationSubtraction
+        // AnimationCurve keyframes (see docs/dev/done/game-actions/
+        // game-actions-spike-findings.md). If these change, the curve has drifted.
+        //
+        // Values computed offline against the exact keyframes and algorithm in
+        // ReputationModule.cs.
+        private const float KspRefDelta_Nominal25_Rep0   = 24.980690f;
+        private const float KspRefDelta_Nominal10_Rep200 =  9.471328f;
+        private const float KspRefDelta_NegNom5_Rep150   = -5.737427f;
+        private const float KspRefDelta_Nominal50_Rep500 = 23.845410f;
+
+        [Fact]
+        public void PostWalk_ReputationCurveMatchesKsp()
+        {
+            // Gate zero: feed known (nominal rep, runningRep) tuples into the curve
+            // and assert output matches the KSP-decompile reference within 0.1.
+            // If this fails, the curve has drifted and #440 rep-leg reconciliation
+            // would false-WARN on every contract completion.
+
+            var r1 = ReputationModule.ApplyReputationCurve(25f, 0f);
+            var r2 = ReputationModule.ApplyReputationCurve(10f, 200f);
+            var r3 = ReputationModule.ApplyReputationCurve(-5f, 150f);
+            var r4 = ReputationModule.ApplyReputationCurve(50f, 500f);
+
+            const float tol = 0.1f;
+            Assert.InRange(r1.actualDelta, KspRefDelta_Nominal25_Rep0   - tol, KspRefDelta_Nominal25_Rep0   + tol);
+            Assert.InRange(r2.actualDelta, KspRefDelta_Nominal10_Rep200 - tol, KspRefDelta_Nominal10_Rep200 + tol);
+            Assert.InRange(r3.actualDelta, KspRefDelta_NegNom5_Rep150   - tol, KspRefDelta_NegNom5_Rep150   + tol);
+            Assert.InRange(r4.actualDelta, KspRefDelta_Nominal50_Rep500 - tol, KspRefDelta_Nominal50_Rep500 + tol);
+
+            // Log-capture assertion: invoke ProcessRepEarning so the module logs a
+            // VERBOSE line, and assert the log shape carries the curve output. This
+            // ties the curve-fidelity assertion to an observable log line consumed
+            // by the reconcile hook's diagnostic path.
+            var action = new GameAction
+            {
+                UT = 100,
+                Type = GameActionType.ReputationEarning,
+                NominalRep = 25f,
+                RepSource = ReputationSource.Other
+            };
+            var module = new ReputationModule();
+            module.ProcessAction(action);
+
+            Assert.InRange(action.EffectiveRep,
+                KspRefDelta_Nominal25_Rep0 - tol,
+                KspRefDelta_Nominal25_Rep0 + tol);
+            Assert.Contains(logLines, l =>
+                l.Contains("[Reputation]") && l.Contains("RepEarning") && l.Contains("effective="));
+        }
+
+        // ---------- MakeKeyedRepChanged helper ----------
+
+        private static GameStateEvent MakeKeyedRepChanged(double ut, double before, double after, string reason)
+        {
+            return new GameStateEvent
+            {
+                ut = ut,
+                eventType = GameStateEventType.ReputationChanged,
+                key = reason,
+                valueBefore = before,
+                valueAfter = after
+            };
+        }
+
+        // ---------- ContractComplete: all three legs match -> no WARN ----------
+
+        [Fact]
+        public void PostWalk_ContractComplete_AllLegsMatch_NoWarn()
+        {
+            var events = new List<GameStateEvent>
+            {
+                MakeKeyedFundsChanged(500, 20000, 24700, "ContractReward"),   // +4700
+                MakeKeyedRepChanged(500, 0, 7, "ContractReward"),             // +7
+                MakeKeyedScienceChanged(500, 0, 3, "ContractReward")          // +3
+            };
+            var action = new GameAction
+            {
+                UT = 500,
+                Type = GameActionType.ContractComplete,
+                ContractId = "c1",
+                Effective = true,
+                TransformedFundsReward = 4700f,
+                EffectiveRep = 7f,
+                TransformedScienceReward = 3f
+            };
+            var actions = new List<GameAction> { action };
+
+            LedgerOrchestrator.ReconcilePostWalk(events, actions, utCutoff: null);
+
+            Assert.DoesNotContain(logLines, l => l.Contains("Earnings reconciliation (post-walk,"));
+        }
+
+        [Fact]
+        public void PostWalk_ContractComplete_FundsMismatch_OnlyFundsWarn()
+        {
+            // Funds leg diverges by 500; rep and sci match. Only the funds WARN fires.
+            var events = new List<GameStateEvent>
+            {
+                MakeKeyedFundsChanged(500, 20000, 24700, "ContractReward"),   // observed +4700
+                MakeKeyedRepChanged(500, 0, 7, "ContractReward"),
+                MakeKeyedScienceChanged(500, 0, 3, "ContractReward")
+            };
+            var action = new GameAction
+            {
+                UT = 500,
+                Type = GameActionType.ContractComplete,
+                ContractId = "c1",
+                Effective = true,
+                TransformedFundsReward = 5200f,   // diverges by +500
+                EffectiveRep = 7f,
+                TransformedScienceReward = 3f
+            };
+            var actions = new List<GameAction> { action };
+
+            LedgerOrchestrator.ReconcilePostWalk(events, actions, utCutoff: null);
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[LedgerOrchestrator]") &&
+                l.Contains("Earnings reconciliation (post-walk, funds)") &&
+                l.Contains("ContractComplete"));
+            Assert.DoesNotContain(logLines, l => l.Contains("Earnings reconciliation (post-walk, rep)"));
+            Assert.DoesNotContain(logLines, l => l.Contains("Earnings reconciliation (post-walk, sci)"));
+        }
+
+        [Fact]
+        public void PostWalk_ContractComplete_RepMismatch_OnlyRepWarn()
+        {
+            var events = new List<GameStateEvent>
+            {
+                MakeKeyedFundsChanged(500, 20000, 24700, "ContractReward"),
+                MakeKeyedRepChanged(500, 0, 12, "ContractReward"),            // observed +12
+                MakeKeyedScienceChanged(500, 0, 3, "ContractReward")
+            };
+            var action = new GameAction
+            {
+                UT = 500,
+                Type = GameActionType.ContractComplete,
+                ContractId = "c1",
+                Effective = true,
+                TransformedFundsReward = 4700f,
+                EffectiveRep = 7f,               // diverges from +12
+                TransformedScienceReward = 3f
+            };
+            var actions = new List<GameAction> { action };
+
+            LedgerOrchestrator.ReconcilePostWalk(events, actions, utCutoff: null);
+
+            Assert.Contains(logLines, l =>
+                l.Contains("Earnings reconciliation (post-walk, rep)") &&
+                l.Contains("ContractComplete"));
+            Assert.DoesNotContain(logLines, l => l.Contains("Earnings reconciliation (post-walk, funds)"));
+            Assert.DoesNotContain(logLines, l => l.Contains("Earnings reconciliation (post-walk, sci)"));
+        }
+
+        [Fact]
+        public void PostWalk_ContractComplete_SciMismatch_OnlySciWarn()
+        {
+            var events = new List<GameStateEvent>
+            {
+                MakeKeyedFundsChanged(500, 20000, 24700, "ContractReward"),
+                MakeKeyedRepChanged(500, 0, 7, "ContractReward"),
+                MakeKeyedScienceChanged(500, 0, 8.5, "ContractReward")       // observed +8.5
+            };
+            var action = new GameAction
+            {
+                UT = 500,
+                Type = GameActionType.ContractComplete,
+                ContractId = "c1",
+                Effective = true,
+                TransformedFundsReward = 4700f,
+                EffectiveRep = 7f,
+                TransformedScienceReward = 3f    // diverges from +8.5
+            };
+            var actions = new List<GameAction> { action };
+
+            LedgerOrchestrator.ReconcilePostWalk(events, actions, utCutoff: null);
+
+            Assert.Contains(logLines, l =>
+                l.Contains("Earnings reconciliation (post-walk, sci)") &&
+                l.Contains("ContractComplete"));
+            Assert.DoesNotContain(logLines, l => l.Contains("Earnings reconciliation (post-walk, funds)"));
+            Assert.DoesNotContain(logLines, l => l.Contains("Earnings reconciliation (post-walk, rep)"));
+        }
+
+        // ---------- ContractFail / ContractCancel (ContractPenalty key) ----------
+
+        [Fact]
+        public void PostWalk_ContractFail_RepCurve_NoWarn()
+        {
+            var events = new List<GameStateEvent>
+            {
+                MakeKeyedFundsChanged(800, 20000, 19000, "ContractPenalty"),  // -1000
+                MakeKeyedRepChanged(800, 10, 7, "ContractPenalty")            // -3 (curve-compressed)
+            };
+            var action = new GameAction
+            {
+                UT = 800,
+                Type = GameActionType.ContractFail,
+                ContractId = "c2",
+                FundsPenalty = 1000f,
+                RepPenalty = 5f,          // raw nominal
+                EffectiveRep = -3f        // curve output
+            };
+            var actions = new List<GameAction> { action };
+
+            LedgerOrchestrator.ReconcilePostWalk(events, actions, utCutoff: null);
+
+            Assert.DoesNotContain(logLines, l => l.Contains("Earnings reconciliation (post-walk,"));
+        }
+
+        [Fact]
+        public void PostWalk_ContractCancel_FundsAndRep_Match_NoWarn()
+        {
+            var events = new List<GameStateEvent>
+            {
+                MakeKeyedFundsChanged(900, 20000, 19500, "ContractPenalty"),  // -500
+                MakeKeyedRepChanged(900, 10, 8, "ContractPenalty")            // -2
+            };
+            var action = new GameAction
+            {
+                UT = 900,
+                Type = GameActionType.ContractCancel,
+                ContractId = "c3",
+                FundsPenalty = 500f,
+                RepPenalty = 3f,
+                EffectiveRep = -2f
+            };
+            var actions = new List<GameAction> { action };
+
+            LedgerOrchestrator.ReconcilePostWalk(events, actions, utCutoff: null);
+
+            Assert.DoesNotContain(logLines, l => l.Contains("Earnings reconciliation (post-walk,"));
+        }
+
+        // ---------- MilestoneAchievement (Progression key, Effective gate) ----------
+
+        [Fact]
+        public void PostWalk_MilestoneAchievement_EffectiveTrue_AllLegsMatch_NoWarn()
+        {
+            var events = new List<GameStateEvent>
+            {
+                MakeKeyedFundsChanged(600, 20000, 22000, "Progression"),     // +2000
+                MakeKeyedRepChanged(600, 0, 4, "Progression"),               // +4
+                MakeKeyedScienceChanged(600, 0, 6, "Progression")            // +6
+            };
+            var action = new GameAction
+            {
+                UT = 600,
+                Type = GameActionType.MilestoneAchievement,
+                MilestoneId = "FirstLaunch",
+                Effective = true,
+                MilestoneFundsAwarded = 2000f,
+                MilestoneRepAwarded = 5f,     // nominal
+                EffectiveRep = 4f,            // curve output
+                MilestoneScienceAwarded = 6f
+            };
+            var actions = new List<GameAction> { action };
+
+            LedgerOrchestrator.ReconcilePostWalk(events, actions, utCutoff: null);
+
+            Assert.DoesNotContain(logLines, l => l.Contains("Earnings reconciliation (post-walk,"));
+        }
+
+        [Fact]
+        public void PostWalk_MilestoneAchievement_EffectiveFalseDuplicate_Skipped_NoWarn()
+        {
+            // Two milestone actions with the same id. The second is Effective=false
+            // (duplicate; MilestonesModule already credited the first). The live
+            // FundsChanged(Progression) event reflects only the first credit.
+            // Post-walk must NOT reconcile the second -> no WARN.
+            var events = new List<GameStateEvent>
+            {
+                MakeKeyedFundsChanged(600, 20000, 22000, "Progression")      // +2000 from first
+            };
+            var firstMilestone = new GameAction
+            {
+                UT = 600,
+                Type = GameActionType.MilestoneAchievement,
+                MilestoneId = "FirstLaunch",
+                Effective = true,
+                MilestoneFundsAwarded = 2000f
+            };
+            var dupMilestone = new GameAction
+            {
+                UT = 700,   // different UT, no matching event in window
+                Type = GameActionType.MilestoneAchievement,
+                MilestoneId = "FirstLaunch",
+                Effective = false,           // duplicate
+                MilestoneFundsAwarded = 2000f
+            };
+            var actions = new List<GameAction> { firstMilestone, dupMilestone };
+
+            LedgerOrchestrator.ReconcilePostWalk(events, actions, utCutoff: null);
+
+            Assert.DoesNotContain(logLines, l => l.Contains("Earnings reconciliation (post-walk,"));
+        }
+
+        // ---------- ReputationEarning / ReputationPenalty ----------
+
+        [Fact]
+        public void PostWalk_ReputationEarning_CurveMatch_NoWarn()
+        {
+            // RepSource.Other has no paired event source -> ClassifyPostWalk returns
+            // Reconcile=false, so post-walk skips entirely. Use a mapped source.
+            var events = new List<GameStateEvent>
+            {
+                MakeKeyedRepChanged(700, 10, 17, "VesselRecovery")           // +7
+            };
+            var action = new GameAction
+            {
+                UT = 700,
+                Type = GameActionType.ReputationEarning,
+                NominalRep = 10f,
+                RepSource = (ReputationSource)99,   // sentinel; overridden below
+                EffectiveRep = 7f
+            };
+            // Note: ReputationSource enum today only has ContractComplete/Milestone/Other;
+            // the production classifier treats Other as synthetic (skip). We deliberately
+            // choose ContractComplete as the mapped source so the test exercises the
+            // ContractReward key path.
+            action.RepSource = ReputationSource.ContractComplete;
+            // Re-emit the event under the right key:
+            events.Clear();
+            events.Add(MakeKeyedRepChanged(700, 10, 17, "ContractReward"));  // +7
+
+            var actions = new List<GameAction> { action };
+
+            LedgerOrchestrator.ReconcilePostWalk(events, actions, utCutoff: null);
+
+            Assert.DoesNotContain(logLines, l => l.Contains("Earnings reconciliation (post-walk, rep)"));
+        }
+
+        [Fact]
+        public void PostWalk_ReputationEarning_CurveDiverges_Warn()
+        {
+            var events = new List<GameStateEvent>
+            {
+                // Observed +12 from KSP, but walk's curve output was +7 -> 5 rep mismatch
+                MakeKeyedRepChanged(700, 10, 22, "ContractReward")           // +12
+            };
+            var action = new GameAction
+            {
+                UT = 700,
+                Type = GameActionType.ReputationEarning,
+                NominalRep = 10f,
+                RepSource = ReputationSource.ContractComplete,
+                EffectiveRep = 7f     // diverges from observed +12
+            };
+            var actions = new List<GameAction> { action };
+
+            LedgerOrchestrator.ReconcilePostWalk(events, actions, utCutoff: null);
+
+            Assert.Contains(logLines, l =>
+                l.Contains("Earnings reconciliation (post-walk, rep)") &&
+                l.Contains("ReputationEarning"));
+        }
+
+        [Fact]
+        public void PostWalk_ReputationPenalty_CurveMatch_NoWarn()
+        {
+            var events = new List<GameStateEvent>
+            {
+                MakeKeyedRepChanged(900, 20, 17, "ContractPenalty")          // -3
+            };
+            var action = new GameAction
+            {
+                UT = 900,
+                Type = GameActionType.ReputationPenalty,
+                NominalPenalty = 5f,
+                RepPenaltySource = ReputationPenaltySource.ContractFail,
+                EffectiveRep = -3f
+            };
+            var actions = new List<GameAction> { action };
+
+            LedgerOrchestrator.ReconcilePostWalk(events, actions, utCutoff: null);
+
+            Assert.DoesNotContain(logLines, l => l.Contains("Earnings reconciliation (post-walk,"));
+        }
+
+        // ---------- KSC-path FundsEarning / ScienceEarning ----------
+
+        [Fact]
+        public void PostWalk_FundsEarning_KscPath_Match_NoWarn()
+        {
+            var events = new List<GameStateEvent>
+            {
+                // Keyed "Other" to represent a generic KSC-path funds earning whose
+                // emitter did not attach a strategy/recovery/contract reason.
+                MakeKeyedFundsChanged(1100, 20000, 21000, "Other")
+            };
+            var action = new GameAction
+            {
+                UT = 1100,
+                Type = GameActionType.FundsEarning,
+                FundsSource = FundsEarningSource.Other,
+                Effective = true,
+                FundsAwarded = 1000f
+            };
+            var actions = new List<GameAction> { action };
+
+            LedgerOrchestrator.ReconcilePostWalk(events, actions, utCutoff: null);
+
+            Assert.DoesNotContain(logLines, l => l.Contains("Earnings reconciliation (post-walk, funds)"));
+        }
+
+        [Fact]
+        public void PostWalk_ScienceEarning_SubjectCapApplied_Match_NoWarn()
+        {
+            // ScienceEarning with EffectiveScience already post-cap. Observed matches.
+            var events = new List<GameStateEvent>
+            {
+                MakeKeyedScienceChanged(1200, 0, 8.5, "ScienceTransmission")
+            };
+            var action = new GameAction
+            {
+                UT = 1200,
+                Type = GameActionType.ScienceEarning,
+                SubjectId = "crewReport@KerbinSrfLanded",
+                Effective = true,
+                ScienceAwarded = 10f,            // raw pre-cap
+                EffectiveScience = 8.5f          // post-cap
+            };
+            var actions = new List<GameAction> { action };
+
+            LedgerOrchestrator.ReconcilePostWalk(events, actions, utCutoff: null);
+
+            Assert.DoesNotContain(logLines, l => l.Contains("Earnings reconciliation (post-walk, sci)"));
+        }
+
+        // ---------- utCutoff ----------
+
+        [Fact]
+        public void PostWalk_UtCutoff_FiltersFutureActions_NoWarn()
+        {
+            // A ContractComplete at UT=500 with a funds-leg divergence. With utCutoff=200,
+            // the action is filtered out and NO WARN fires (matches walk behavior).
+            var events = new List<GameStateEvent>
+            {
+                MakeKeyedFundsChanged(500, 20000, 24700, "ContractReward")
+            };
+            var action = new GameAction
+            {
+                UT = 500,
+                Type = GameActionType.ContractComplete,
+                ContractId = "c_future",
+                Effective = true,
+                TransformedFundsReward = 9999f,   // gross divergence that WOULD warn
+                EffectiveRep = 0f,
+                TransformedScienceReward = 0f
+            };
+            var actions = new List<GameAction> { action };
+
+            LedgerOrchestrator.ReconcilePostWalk(events, actions, utCutoff: 200.0);
+
+            Assert.DoesNotContain(logLines, l => l.Contains("Earnings reconciliation (post-walk,"));
+        }
+
+        // ---------- No matching event ----------
+
+        [Fact]
+        public void PostWalk_NoMatchingEvent_WarnsMissingChannel()
+        {
+            var events = new List<GameStateEvent>();  // no events at all
+            var action = new GameAction
+            {
+                UT = 500,
+                Type = GameActionType.ContractComplete,
+                ContractId = "c_orphan",
+                Effective = true,
+                TransformedFundsReward = 4700f,
+                EffectiveRep = 0f,
+                TransformedScienceReward = 0f
+            };
+            var actions = new List<GameAction> { action };
+
+            LedgerOrchestrator.ReconcilePostWalk(events, actions, utCutoff: null);
+
+            Assert.Contains(logLines, l =>
+                l.Contains("Earnings reconciliation (post-walk, funds)") &&
+                l.Contains("ContractComplete") &&
+                (l.Contains("no matching") || l.Contains("missing earning channel")));
+        }
+
+        #endregion
+
         [Fact]
         public void ReconcileKsc_PartPurchase_BypassOff_LegacyCostMismatch_WarnsDelta()
         {

--- a/Source/Parsek.Tests/EarningsReconciliationTests.cs
+++ b/Source/Parsek.Tests/EarningsReconciliationTests.cs
@@ -1110,14 +1110,14 @@ namespace Parsek.Tests
         #region #440 post-walk tests
 
         // ================================================================
-        // #440 Phase E2 — post-walk reconciliation for strategy-transformed
+        // #440 Phase E2 -- post-walk reconciliation for strategy-transformed
         // and curve-applied reward types. The new LedgerOrchestrator.
         // ReconcilePostWalk pairs the derived Transformed*/EffectiveRep/
         // EffectiveScience values (set by RecalculationEngine.Recalculate)
         // against live KSP deltas captured in GameStateStore.Events.
         //
         // Gate zero: `PostWalk_ReputationCurveMatchesKsp` must pass before
-        // any rep-leg test is trustworthy — it pins our curve output
+        // any rep-leg test is trustworthy -- it pins our curve output
         // against the Spike A decompile of KSP's addReputation_granular.
         // ================================================================
 
@@ -1425,29 +1425,21 @@ namespace Parsek.Tests
         [Fact]
         public void PostWalk_ReputationEarning_CurveMatch_NoWarn()
         {
-            // RepSource.Other has no paired event source -> ClassifyPostWalk returns
-            // Reconcile=false, so post-walk skips entirely. Use a mapped source.
+            // ReputationSource enum today has ContractComplete / Milestone / Other.
+            // RepSource.Other is synthetic -> ClassifyPostWalk returns Reconcile=false.
+            // Use ContractComplete so the test exercises the ContractReward key path.
             var events = new List<GameStateEvent>
             {
-                MakeKeyedRepChanged(700, 10, 17, "VesselRecovery")           // +7
+                MakeKeyedRepChanged(700, 10, 17, "ContractReward")           // +7
             };
             var action = new GameAction
             {
                 UT = 700,
                 Type = GameActionType.ReputationEarning,
                 NominalRep = 10f,
-                RepSource = (ReputationSource)99,   // sentinel; overridden below
+                RepSource = ReputationSource.ContractComplete,
                 EffectiveRep = 7f
             };
-            // Note: ReputationSource enum today only has ContractComplete/Milestone/Other;
-            // the production classifier treats Other as synthetic (skip). We deliberately
-            // choose ContractComplete as the mapped source so the test exercises the
-            // ContractReward key path.
-            action.RepSource = ReputationSource.ContractComplete;
-            // Re-emit the event under the right key:
-            events.Clear();
-            events.Add(MakeKeyedRepChanged(700, 10, 17, "ContractReward"));  // +7
-
             var actions = new List<GameAction> { action };
 
             LedgerOrchestrator.ReconcilePostWalk(events, actions, utCutoff: null);
@@ -1604,6 +1596,57 @@ namespace Parsek.Tests
                 l.Contains("Earnings reconciliation (post-walk, funds)") &&
                 l.Contains("ContractComplete") &&
                 (l.Contains("no matching") || l.Contains("missing earning channel")));
+        }
+
+        [Fact]
+        public void PostWalk_DoubleWarnGuard_TransformedActionOnlyFiresOnce()
+        {
+            // Regression guard for plan invariant I2 and success-criterion #6:
+            // the existing per-action ReconcileKscAction path must NOT emit a
+            // WARN for an action classified as Transformed, even when the
+            // action genuinely diverges from the paired event. The post-walk
+            // hook is the sole emitter of "Earnings reconciliation (post-walk,"
+            // WARNs for the eight Transformed action types. If a future refactor
+            // accidentally re-enables per-action WARN for a Transformed type,
+            // this test catches the double-WARN regression.
+            var events = new List<GameStateEvent>
+            {
+                MakeKeyedFundsChanged(500, 100000, 102000, "ContractReward"),
+                MakeKeyedRepChanged(500, 10, 10, "ContractReward"),
+                MakeKeyedScienceChanged(500, 0, 0, "ContractReward"),
+            };
+            var action = new GameAction
+            {
+                UT = 500,
+                Type = GameActionType.ContractComplete,
+                ContractId = "c_dbl",
+                Effective = true,
+                // Force a divergence: expected funds=+5000 but store saw +2000.
+                TransformedFundsReward = 5000f,
+                EffectiveRep = 0f,
+                TransformedScienceReward = 0f,
+            };
+            var actions = new List<GameAction> { action };
+
+            // Per-action KSC path (must stay silent on Transformed).
+            Ledger.ResetForTesting();
+            Ledger.AddAction(action);
+            ReconcileKsc(events, new List<GameAction> { action }, action, action.UT);
+
+            // Post-walk path (the only site allowed to WARN here).
+            LedgerOrchestrator.ReconcilePostWalk(events, actions, utCutoff: null);
+
+            // Post-walk must have emitted the mismatch WARN.
+            Assert.Contains(logLines, l =>
+                l.Contains("Earnings reconciliation (post-walk, funds)") &&
+                l.Contains("ContractComplete"));
+
+            // The KSC-path ReconcileKscAction must NOT have emitted a non-post-walk
+            // funds WARN for the same action (it VERBOSE-skips Transformed types).
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("Earnings reconciliation") &&
+                l.Contains("(funds)") &&
+                !l.Contains("(post-walk"));
         }
 
         #endregion

--- a/Source/Parsek.Tests/PostWalkReconciliationIntegrationTests.cs
+++ b/Source/Parsek.Tests/PostWalkReconciliationIntegrationTests.cs
@@ -1,0 +1,216 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// #440 Phase E2 -- integration tests that drive
+    /// <see cref="LedgerOrchestrator.RecalculateAndPatch"/> end-to-end and assert
+    /// the post-walk reconciliation hook fires (or does not fire) correctly.
+    ///
+    /// Each test seeds the Ledger + GameStateStore with an action/event pair
+    /// that exercises one code path through <c>ReconcilePostWalk</c>:
+    /// * commit-path baseline (no WARN when walk output matches observed KSP delta)
+    /// * controlled-divergence (exactly one funds-leg WARN when Transformed*Reward
+    ///   diverges from the store delta)
+    /// * utCutoff filter (future actions past the cutoff do not reconcile)
+    ///
+    /// Shares the [Collection("Sequential")] scope with the other reconciliation
+    /// test fixtures because <c>LedgerOrchestrator</c>, <c>Ledger</c>, and
+    /// <c>GameStateStore</c> all hold static state.
+    /// </summary>
+    [Collection("Sequential")]
+    public class PostWalkReconciliationIntegrationTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public PostWalkReconciliationIntegrationTests()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+
+            RecordingStore.SuppressLogging = true;
+            KspStatePatcher.SuppressUnityCallsForTesting = true;
+            GameStateStore.SuppressLogging = true;
+            GameStateStore.ResetForTesting();
+            LedgerOrchestrator.ResetForTesting();
+        }
+
+        public void Dispose()
+        {
+            LedgerOrchestrator.ResetForTesting();
+            KspStatePatcher.ResetForTesting();
+            RecordingStore.SuppressLogging = false;
+            GameStateStore.ResetForTesting();
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+        }
+
+        private static void AddKeyedEvent(
+            double ut, GameStateEventType type, string key, double before, double after)
+        {
+            var e = new GameStateEvent
+            {
+                ut = ut,
+                eventType = type,
+                key = key,
+                valueBefore = before,
+                valueAfter = after
+            };
+            GameStateStore.AddEvent(ref e);
+        }
+
+        [Fact]
+        public void Integration_StrategyActive_ContractComplete_NoPostWalkWarn()
+        {
+            // Commit-path baseline. Seed initial funds, a StrategyActivate, and a
+            // ContractComplete whose raw rewards match the observed KSP deltas.
+            // After Recalculate populates Transformed*Reward + EffectiveRep, the
+            // post-walk hook finds a clean match on all three legs -> no WARN.
+            LedgerOrchestrator.Initialize();
+
+            Ledger.AddAction(new GameAction
+            {
+                UT = 0.0,
+                Type = GameActionType.FundsInitial,
+                InitialFunds = 25000f
+            });
+            Ledger.AddAction(new GameAction
+            {
+                UT = 0.0,
+                Type = GameActionType.ReputationInitial,
+                InitialReputation = 0f
+            });
+            Ledger.AddAction(new GameAction
+            {
+                UT = 100.0,
+                Type = GameActionType.StrategyActivate,
+                StrategyId = "UnpaidResearch",
+                SetupCost = 0f
+            });
+            Ledger.AddAction(new GameAction
+            {
+                UT = 500.0,
+                Type = GameActionType.ContractComplete,
+                RecordingId = "rec-contract",
+                ContractId = "c-strat-1",
+                FundsReward = 4700f,
+                RepReward = 7f,
+                ScienceReward = 3f
+            });
+
+            // KSP-side store events observed at the same UT (paired with the
+            // ContractComplete by key "ContractReward").
+            AddKeyedEvent(500.0, GameStateEventType.FundsChanged,      "ContractReward", 25000, 29700);
+            AddKeyedEvent(500.0, GameStateEventType.ReputationChanged, "ContractReward",     0,     7);
+            AddKeyedEvent(500.0, GameStateEventType.ScienceChanged,    "ContractReward",     0,     3);
+
+            LedgerOrchestrator.RecalculateAndPatch(utCutoff: null);
+
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("[LedgerOrchestrator]") &&
+                l.Contains("Earnings reconciliation (post-walk,"));
+
+            // Positive assertion: the post-walk summary ran (proves the hook was wired).
+            Assert.Contains(logLines, l =>
+                l.Contains("[LedgerOrchestrator]") &&
+                l.Contains("Post-walk reconcile: actions="));
+        }
+
+        [Fact]
+        public void Integration_StrategyActive_ContractComplete_TransformDiverges_Warn()
+        {
+            // Controlled divergence: the raw FundsReward is 4700, which the walk will
+            // copy to TransformedFundsReward (identity transform today). But we seed
+            // the FundsChanged event with a LARGER observed delta (+9200) so the
+            // funds leg diverges -> exactly one post-walk funds WARN fires. Rep + sci
+            // match -> no WARN on those legs.
+            LedgerOrchestrator.Initialize();
+
+            Ledger.AddAction(new GameAction
+            {
+                UT = 0.0,
+                Type = GameActionType.FundsInitial,
+                InitialFunds = 25000f
+            });
+            Ledger.AddAction(new GameAction
+            {
+                UT = 0.0,
+                Type = GameActionType.ReputationInitial,
+                InitialReputation = 0f
+            });
+            Ledger.AddAction(new GameAction
+            {
+                UT = 500.0,
+                Type = GameActionType.ContractComplete,
+                RecordingId = "rec-contract",
+                ContractId = "c-diverge-1",
+                FundsReward = 4700f,
+                RepReward = 7f,
+                ScienceReward = 3f
+            });
+
+            // Store observed +9200 funds, +7 rep, +3 sci -> funds diverges by 4500.
+            AddKeyedEvent(500.0, GameStateEventType.FundsChanged,      "ContractReward", 25000, 34200);
+            AddKeyedEvent(500.0, GameStateEventType.ReputationChanged, "ContractReward",     0,     7);
+            AddKeyedEvent(500.0, GameStateEventType.ScienceChanged,    "ContractReward",     0,     3);
+
+            LedgerOrchestrator.RecalculateAndPatch(utCutoff: null);
+
+            int fundsWarns = 0;
+            foreach (var l in logLines)
+            {
+                if (l.Contains("Earnings reconciliation (post-walk, funds)") &&
+                    l.Contains("ContractComplete"))
+                    fundsWarns++;
+            }
+            Assert.Equal(1, fundsWarns);
+
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("Earnings reconciliation (post-walk, rep)"));
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("Earnings reconciliation (post-walk, sci)"));
+        }
+
+        [Fact]
+        public void Integration_RewindCutoffsFiltersPostWalk()
+        {
+            // A ContractComplete at UT=500 with a gross funds divergence that WOULD
+            // warn. With utCutoff=200, the walk filters the action out and the
+            // post-walk hook mirrors that filter -> no WARN.
+            LedgerOrchestrator.Initialize();
+
+            Ledger.AddAction(new GameAction
+            {
+                UT = 0.0,
+                Type = GameActionType.FundsInitial,
+                InitialFunds = 25000f
+            });
+            Ledger.AddAction(new GameAction
+            {
+                UT = 0.0,
+                Type = GameActionType.ReputationInitial,
+                InitialReputation = 0f
+            });
+            Ledger.AddAction(new GameAction
+            {
+                UT = 500.0,
+                Type = GameActionType.ContractComplete,
+                RecordingId = "rec-future",
+                ContractId = "c-past-cutoff",
+                FundsReward = 99999f,
+                RepReward = 7f,
+                ScienceReward = 3f
+            });
+
+            AddKeyedEvent(500.0, GameStateEventType.FundsChanged, "ContractReward", 25000, 29700);
+
+            LedgerOrchestrator.RecalculateAndPatch(utCutoff: 200.0);
+
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("Earnings reconciliation (post-walk,"));
+        }
+    }
+}

--- a/Source/Parsek/GameActions/LedgerOrchestrator.cs
+++ b/Source/Parsek/GameActions/LedgerOrchestrator.cs
@@ -3487,7 +3487,7 @@ namespace Parsek
         internal const double KscReconcileEpsilonSeconds = 0.1;
 
         // ================================================================
-        // #440 Phase E2 — Post-walk reconciliation (transformed reward types)
+        // #440 Phase E2 -- Post-walk reconciliation (transformed reward types)
         //
         // After RecalculationEngine.Recalculate populates TransformedFundsReward,
         // TransformedScienceReward, EffectiveRep, and EffectiveScience on each

--- a/Source/Parsek/GameActions/LedgerOrchestrator.cs
+++ b/Source/Parsek/GameActions/LedgerOrchestrator.cs
@@ -902,6 +902,12 @@ namespace Parsek
 
             RecalculationEngine.Recalculate(actions, utCutoff);
 
+            // #440 Phase E2: post-walk reconciliation for strategy-transformed
+            // and curve-applied reward types. Runs once per walk, log-only,
+            // after derived fields (Transformed*Reward/EffectiveRep/
+            // EffectiveScience) are populated and before KSP state is patched.
+            ReconcilePostWalk(GameStateStore.Events, actions, utCutoff);
+
             // KSP state mutations (PostWalk already called by engine). Repeatable
             // Records* nodes only rebuild strictly from ledger-backed thresholds on
             // rewind-style cutoff walks; normal same-branch recalculations preserve the
@@ -3221,33 +3227,32 @@ namespace Parsek
                 case GameActionType.ContractComplete:
                     // FundsReward/RepReward/ScienceReward subject to StrategiesModule's
                     // TransformedFundsReward/Rep/Science during the walk; RepReward also
-                    // passes through ApplyReputationCurve. Post-walk reconciliation hook
-                    // will live in Phase D's RecalculationEngine changes.
+                    // passes through ApplyReputationCurve. Per-action KSC path stays
+                    // silent; post-walk hook reconciles (#440).
                     return new KscActionExpectation
                     {
                         Class = KscReconcileClass.Transformed,
-                        SkipReason = "contract rewards transformed by strategy + rep curve"
+                        SkipReason = "contract rewards -- post-walk hook reconciles (#440)"
                     };
 
                 case GameActionType.ContractFail:
                 case GameActionType.ContractCancel:
                     // FundsPenalty is raw, but RepPenalty passes through the reputation
-                    // curve. Partial coverage would be awkward; skip until the walk-aware
-                    // hook exists.
+                    // curve. Post-walk hook reconciles both legs (#440).
                     return new KscActionExpectation
                     {
                         Class = KscReconcileClass.Transformed,
-                        SkipReason = "contract penalty rep curve not yet post-walk-aware"
+                        SkipReason = "contract penalty -- post-walk hook reconciles (#440)"
                     };
 
                 case GameActionType.MilestoneAchievement:
-                    // Current modules do not strategy-transform milestone rewards, but
-                    // some stock/stock-alike mods divert. Skip for safety until the
-                    // post-walk hook lands.
+                    // Rep leg goes through the curve; funds/sci are identity today but
+                    // post-walk hook reconciles all three legs (#440) for regression
+                    // safety if a mod introduces a transform.
                     return new KscActionExpectation
                     {
                         Class = KscReconcileClass.Transformed,
-                        SkipReason = "milestone rewards may be mod-transformed"
+                        SkipReason = "milestone rewards -- post-walk hook reconciles (#440)"
                     };
 
                 case GameActionType.ReputationEarning:
@@ -3255,19 +3260,19 @@ namespace Parsek
                     return new KscActionExpectation
                     {
                         Class = KscReconcileClass.Transformed,
-                        SkipReason = "reputation curve not yet post-walk-aware"
+                        SkipReason = "reputation curve -- post-walk hook reconciles (#440)"
                     };
 
                 case GameActionType.FundsEarning:
                 case GameActionType.ScienceEarning:
                     // Earning actions on the KSC path would be direct deposits (not seen
-                    // today — recovery/contract/milestone flow through their own action
-                    // types). Skip to be safe; strategy payout income will land here once
-                    // Phase E1.5 captures it.
+                    // today -- recovery/contract/milestone flow through their own action
+                    // types). Post-walk hook reconciles the safety path (#440); strategy
+                    // payout income will land here once #439 Phase C captures it.
                     return new KscActionExpectation
                     {
                         Class = KscReconcileClass.Transformed,
-                        SkipReason = "direct earning may be strategy-transformed"
+                        SkipReason = "direct earning -- post-walk hook reconciles (#440)"
                     };
 
                 // ---- No resource impact: short-circuit silently. ----
@@ -3480,6 +3485,430 @@ namespace Parsek
         /// </para>
         /// </summary>
         internal const double KscReconcileEpsilonSeconds = 0.1;
+
+        // ================================================================
+        // #440 Phase E2 — Post-walk reconciliation (transformed reward types)
+        //
+        // After RecalculationEngine.Recalculate populates TransformedFundsReward,
+        // TransformedScienceReward, EffectiveRep, and EffectiveScience on each
+        // action, ReconcilePostWalk iterates the same (cutoff-filtered) action
+        // list and compares those derived values against live KSP deltas in
+        // GameStateStore. WARN on divergence, VERBOSE on match. Log-only: does
+        // not mutate the ledger, the KSP state, or any module.
+        //
+        // Scope: the eight action types ClassifyAction routes to the Transformed
+        // bucket (ContractComplete, ContractFail, ContractCancel,
+        // MilestoneAchievement, ReputationEarning, ReputationPenalty, KSC-path
+        // FundsEarning and ScienceEarning). Other action types are reconciled
+        // per-action by ReconcileKscAction and return Reconcile=false here.
+        //
+        // See docs/dev/plans/fix-440-post-walk-reconciliation.md.
+        // ================================================================
+
+        /// <summary>
+        /// UT window (seconds) used by <see cref="ReconcilePostWalk"/> to pair a
+        /// transformed-type action with its resource-changed event. Matches the
+        /// <see cref="KscReconcileEpsilonSeconds"/> rationale: same coalesce
+        /// invariant, kept independent so a future tune cannot inadvertently
+        /// couple the two paths.
+        /// </summary>
+        internal const double PostWalkReconcileEpsilonSeconds = 0.1;
+
+        /// <summary>
+        /// One resource leg of a <see cref="PostWalkExpectation"/>. Populated
+        /// only when the leg applies for the action type; otherwise the leg is
+        /// default-zeroed (Applies=false).
+        /// </summary>
+        internal struct PostWalkLeg
+        {
+            public bool Applies;
+            public double Expected;
+            public string ReasonKey;
+            public GameStateEventType EventType;
+        }
+
+        /// <summary>
+        /// Classification output for one action in the post-walk reconcile pass.
+        /// Up to three legs (funds/rep/sci) may apply independently. Returns
+        /// Reconcile=false for action types outside #440 scope.
+        /// </summary>
+        internal struct PostWalkExpectation
+        {
+            public bool Reconcile;
+            public PostWalkLeg Funds;
+            public PostWalkLeg Rep;
+            public PostWalkLeg Sci;
+        }
+
+        /// <summary>
+        /// Pure classifier: maps a Transformed-bucket <see cref="GameAction"/>
+        /// to its post-walk expected delta(s) and the TransactionReasons key
+        /// the emitter stamps on the paired GameStateEvent. Action types
+        /// outside #440 scope (everything ClassifyAction returns as
+        /// Untransformed or NoResourceImpact) return Reconcile=false.
+        /// <para>
+        /// Reviewer-corrected event keys (see plan sections 3.1-3.6):
+        /// <list type="bullet">
+        /// <item><c>ContractComplete</c> -> <c>ContractReward</c> (all three legs)</item>
+        /// <item><c>ContractFail</c> / <c>ContractCancel</c> -> <c>ContractPenalty</c></item>
+        /// <item><c>MilestoneAchievement</c> -> <c>Progression</c> (all three legs, via
+        /// the generic resource-event path; <c>MilestoneAchieved.detail</c> is NOT parsed)</item>
+        /// <item><c>ReputationEarning</c> maps by <see cref="ReputationSource"/>;
+        /// <c>Other</c> returns Reconcile=false (synthetic, no paired event).</item>
+        /// <item><c>ReputationPenalty</c> maps by <see cref="ReputationPenaltySource"/>;
+        /// <c>Other</c> returns Reconcile=false.</item>
+        /// </list>
+        /// </para>
+        /// </summary>
+        internal static PostWalkExpectation ClassifyPostWalk(GameAction action)
+        {
+            var exp = new PostWalkExpectation();
+            if (action == null) return exp;
+
+            switch (action.Type)
+            {
+                case GameActionType.ContractComplete:
+                    // All three legs when Effective; duplicate completions (Effective=false)
+                    // are filtered by MilestonesModule/ContractsModule and the modules
+                    // skip crediting, so the observed delta is 0 for those. Post-walk
+                    // mirrors the module gate by skipping entirely.
+                    if (!action.Effective) return exp;
+                    exp.Reconcile = true;
+                    exp.Funds = new PostWalkLeg
+                    {
+                        Applies = true,
+                        Expected = action.TransformedFundsReward,
+                        ReasonKey = "ContractReward",
+                        EventType = GameStateEventType.FundsChanged
+                    };
+                    exp.Rep = new PostWalkLeg
+                    {
+                        Applies = true,
+                        Expected = action.EffectiveRep,
+                        ReasonKey = "ContractReward",
+                        EventType = GameStateEventType.ReputationChanged
+                    };
+                    exp.Sci = new PostWalkLeg
+                    {
+                        Applies = true,
+                        Expected = action.TransformedScienceReward,
+                        ReasonKey = "ContractReward",
+                        EventType = GameStateEventType.ScienceChanged
+                    };
+                    return exp;
+
+                case GameActionType.ContractFail:
+                case GameActionType.ContractCancel:
+                    // Penalties fire unconditionally (no Effective gate in the modules).
+                    // Funds leg: FundsModule deducts FundsPenalty directly (no transform
+                    // today). Rep leg: EffectiveRep from the curve (negative).
+                    exp.Reconcile = true;
+                    exp.Funds = new PostWalkLeg
+                    {
+                        Applies = true,
+                        Expected = -(double)action.FundsPenalty,
+                        ReasonKey = "ContractPenalty",
+                        EventType = GameStateEventType.FundsChanged
+                    };
+                    exp.Rep = new PostWalkLeg
+                    {
+                        Applies = true,
+                        Expected = action.EffectiveRep,
+                        ReasonKey = "ContractPenalty",
+                        EventType = GameStateEventType.ReputationChanged
+                    };
+                    return exp;
+
+                case GameActionType.MilestoneAchievement:
+                    // All three legs gated on Effective (duplicates skip).
+                    if (!action.Effective) return exp;
+                    exp.Reconcile = true;
+                    exp.Funds = new PostWalkLeg
+                    {
+                        Applies = true,
+                        Expected = action.MilestoneFundsAwarded,
+                        ReasonKey = "Progression",
+                        EventType = GameStateEventType.FundsChanged
+                    };
+                    exp.Rep = new PostWalkLeg
+                    {
+                        Applies = true,
+                        Expected = action.EffectiveRep,
+                        ReasonKey = "Progression",
+                        EventType = GameStateEventType.ReputationChanged
+                    };
+                    exp.Sci = new PostWalkLeg
+                    {
+                        Applies = true,
+                        Expected = action.MilestoneScienceAwarded,
+                        ReasonKey = "Progression",
+                        EventType = GameStateEventType.ScienceChanged
+                    };
+                    return exp;
+
+                case GameActionType.ReputationEarning:
+                {
+                    // Map source -> key. Synthetic sources (Other, and LegacyMigration if
+                    // re-introduced on the rep enum later) return Reconcile=false.
+                    string key;
+                    switch (action.RepSource)
+                    {
+                        case ReputationSource.ContractComplete:
+                            key = "ContractReward"; break;
+                        case ReputationSource.Milestone:
+                            key = "Progression"; break;
+                        case ReputationSource.Other:
+                        default:
+                            return exp; // synthetic, no paired event
+                    }
+                    exp.Reconcile = true;
+                    exp.Rep = new PostWalkLeg
+                    {
+                        Applies = true,
+                        Expected = action.EffectiveRep,
+                        ReasonKey = key,
+                        EventType = GameStateEventType.ReputationChanged
+                    };
+                    return exp;
+                }
+
+                case GameActionType.ReputationPenalty:
+                {
+                    string key;
+                    switch (action.RepPenaltySource)
+                    {
+                        case ReputationPenaltySource.ContractFail:
+                            key = "ContractPenalty"; break;
+                        case ReputationPenaltySource.ContractDecline:
+                            key = "ContractDecline"; break;
+                        case ReputationPenaltySource.KerbalDeath:
+                            key = "CrewKilled"; break;
+                        case ReputationPenaltySource.Strategy:
+                        case ReputationPenaltySource.Other:
+                        default:
+                            return exp; // synthetic / no stock emitter today
+                    }
+                    exp.Reconcile = true;
+                    exp.Rep = new PostWalkLeg
+                    {
+                        Applies = true,
+                        Expected = action.EffectiveRep,
+                        ReasonKey = key,
+                        EventType = GameStateEventType.ReputationChanged
+                    };
+                    return exp;
+                }
+
+                case GameActionType.FundsEarning:
+                {
+                    // KSC-path direct earnings (source != Recovery / ContractComplete /
+                    // Milestone). Recovery/ContractComplete/Milestone arrive as their own
+                    // action types and are handled above. This branch is a safety net
+                    // for direct "Other"-source KSC payouts (today: none from stock; mod
+                    // strategy payouts could land here once #439 Phase C captures them).
+                    if (!action.Effective) return exp;
+                    if (action.FundsSource == FundsEarningSource.LegacyMigration) return exp;
+                    if (action.FundsSource == FundsEarningSource.Recovery) return exp;
+                    if (action.FundsSource == FundsEarningSource.ContractComplete) return exp;
+                    if (action.FundsSource == FundsEarningSource.ContractAdvance) return exp;
+                    if (action.FundsSource == FundsEarningSource.Milestone) return exp;
+                    exp.Reconcile = true;
+                    exp.Funds = new PostWalkLeg
+                    {
+                        Applies = true,
+                        Expected = action.FundsAwarded,
+                        ReasonKey = "Other",
+                        EventType = GameStateEventType.FundsChanged
+                    };
+                    return exp;
+                }
+
+                case GameActionType.ScienceEarning:
+                {
+                    // Post-cap EffectiveScience (ScienceModule sets this on walk).
+                    if (!action.Effective) return exp;
+                    exp.Reconcile = true;
+                    exp.Sci = new PostWalkLeg
+                    {
+                        Applies = true,
+                        Expected = action.EffectiveScience,
+                        ReasonKey = "ScienceTransmission",
+                        EventType = GameStateEventType.ScienceChanged
+                    };
+                    return exp;
+                }
+
+                default:
+                    return exp; // Reconcile stays false
+            }
+        }
+
+        /// <summary>
+        /// Post-walk reconciliation. Runs once per <see cref="RecalculateAndPatch"/>
+        /// after <see cref="RecalculationEngine.Recalculate"/> returns and before
+        /// <see cref="KspStatePatcher.PatchAll"/>. Iterates actions in stored
+        /// order; for each Transformed-bucket action whose UT survives the
+        /// cutoff, compares the post-walk derived delta against the live KSP
+        /// delta (<c>valueAfter - valueBefore</c>) summed across matching
+        /// <see cref="GameStateStore"/> events within
+        /// <see cref="PostWalkReconcileEpsilonSeconds"/> of <c>action.UT</c>.
+        /// WARN on divergence per leg; VERBOSE rate-limited on match. Emits a
+        /// single INFO summary after the iteration. Log-only.
+        /// <para>
+        /// Parameterized for testability — production calls pass
+        /// <see cref="GameStateStore.Events"/> and <see cref="Ledger.Actions"/>.
+        /// </para>
+        /// </summary>
+        internal static void ReconcilePostWalk(
+            IReadOnlyList<GameStateEvent> events,
+            IReadOnlyList<GameAction> actions,
+            double? utCutoff)
+        {
+            if (actions == null || actions.Count == 0) return;
+
+            const double fundsTol = 1.0;
+            const double repTol = 0.1;
+            const double sciTol = 0.1;
+
+            int walked = 0;
+            int matched = 0;
+            int mismatchFunds = 0;
+            int mismatchRep = 0;
+            int mismatchSci = 0;
+
+            for (int i = 0; i < actions.Count; i++)
+            {
+                var action = actions[i];
+                if (action == null) continue;
+
+                // Respect the same filter as RecalculationEngine.Recalculate: seed
+                // types always pass; non-seed actions pass when UT <= cutoff.
+                if (utCutoff.HasValue &&
+                    !RecalculationEngine.IsSeedType(action.Type) &&
+                    action.UT > utCutoff.Value)
+                {
+                    continue;
+                }
+
+                var exp = ClassifyPostWalk(action);
+                if (!exp.Reconcile) continue;
+                walked++;
+
+                bool anyMismatch = false;
+                if (exp.Funds.Applies)
+                {
+                    if (!CompareLeg(action, "funds", exp.Funds, fundsTol, events))
+                    {
+                        mismatchFunds++;
+                        anyMismatch = true;
+                    }
+                }
+                if (exp.Rep.Applies)
+                {
+                    if (!CompareLeg(action, "rep", exp.Rep, repTol, events))
+                    {
+                        mismatchRep++;
+                        anyMismatch = true;
+                    }
+                }
+                if (exp.Sci.Applies)
+                {
+                    if (!CompareLeg(action, "sci", exp.Sci, sciTol, events))
+                    {
+                        mismatchSci++;
+                        anyMismatch = true;
+                    }
+                }
+
+                if (!anyMismatch) matched++;
+            }
+
+            string cutoffLabel = utCutoff.HasValue
+                ? utCutoff.Value.ToString("R", CultureInfo.InvariantCulture)
+                : "null";
+            ParsekLog.Info(Tag,
+                $"Post-walk reconcile: actions={walked}, matches={matched}, " +
+                $"mismatches(funds/rep/sci)={mismatchFunds}/{mismatchRep}/{mismatchSci}, " +
+                $"cutoffUT={cutoffLabel}");
+        }
+
+        /// <summary>
+        /// Compares one resource leg for a transformed action. Returns true on
+        /// match (WARN suppressed, VERBOSE rate-limited), false on mismatch or
+        /// missing event (WARN fired). Observed delta =
+        /// <c>sum(valueAfter - valueBefore)</c> across events with matching
+        /// type + key within <see cref="PostWalkReconcileEpsilonSeconds"/> of
+        /// <c>action.UT</c>.
+        /// </summary>
+        private static bool CompareLeg(
+            GameAction action,
+            string legTag,
+            PostWalkLeg leg,
+            double tolerance,
+            IReadOnlyList<GameStateEvent> events)
+        {
+            double observed = 0.0;
+            int observedCount = 0;
+            if (events != null)
+            {
+                for (int i = 0; i < events.Count; i++)
+                {
+                    var e = events[i];
+                    if (e.eventType != leg.EventType) continue;
+                    if (Math.Abs(e.ut - action.UT) > PostWalkReconcileEpsilonSeconds) continue;
+                    string eventKey = e.key ?? "";
+                    if (!string.Equals(eventKey, leg.ReasonKey, StringComparison.Ordinal))
+                        continue;
+                    observed += (e.valueAfter - e.valueBefore);
+                    observedCount++;
+                }
+            }
+
+            // Zero-expected + zero-observed is silent match (no event fired, none
+            // expected). Zero-expected + non-zero observed is a mismatch: the walk
+            // produced nothing but KSP credited a delta.
+            if (Math.Abs(leg.Expected) <= tolerance && observedCount == 0)
+                return true;
+
+            string id = ActionIdForPostWalk(action);
+
+            if (observedCount == 0)
+            {
+                ParsekLog.Warn(Tag,
+                    $"Earnings reconciliation (post-walk, {legTag}): {action.Type} " +
+                    $"id={id} expected={leg.Expected:F1} but no matching {leg.EventType} event " +
+                    $"keyed '{leg.ReasonKey}' within {PostWalkReconcileEpsilonSeconds:F1}s of " +
+                    $"ut={action.UT:F1} -- missing earning channel or stale event?");
+                return false;
+            }
+
+            if (Math.Abs(leg.Expected - observed) > tolerance)
+            {
+                ParsekLog.Warn(Tag,
+                    $"Earnings reconciliation (post-walk, {legTag}): {action.Type} " +
+                    $"id={id} expected={leg.Expected:F1}, observed={observed:F1} across " +
+                    $"{observedCount} event(s) keyed '{leg.ReasonKey}' at ut={action.UT:F1} " +
+                    $"-- post-walk delta mismatch");
+                return false;
+            }
+
+            ParsekLog.VerboseRateLimited(Tag,
+                $"post-walk-match:{action.Type}:{legTag}",
+                $"Post-walk match: {action.Type} {legTag} id={id} " +
+                $"expected={leg.Expected:F1}, observed={observed:F1}, ut={action.UT:F1}");
+            return true;
+        }
+
+        /// <summary>Pure: best-effort identifier for post-walk log lines.</summary>
+        private static string ActionIdForPostWalk(GameAction action)
+        {
+            if (action == null) return "null";
+            if (!string.IsNullOrEmpty(action.ContractId)) return action.ContractId;
+            if (!string.IsNullOrEmpty(action.MilestoneId)) return action.MilestoneId;
+            if (!string.IsNullOrEmpty(action.SubjectId)) return action.SubjectId;
+            if (!string.IsNullOrEmpty(action.RecordingId)) return action.RecordingId;
+            return "(none)";
+        }
 
         /// <summary>
         /// Test-only seam for the "now UT" used by <see cref="CanAffordScienceSpending"/>

--- a/docs/dev/plans/fix-440-post-walk-reconciliation.md
+++ b/docs/dev/plans/fix-440-post-walk-reconciliation.md
@@ -1,0 +1,418 @@
+# Fix #440: Post-walk reconciliation for strategy-transformed and curve-applied reward types
+
+Status: plan v1 (Phase E2 of ledger/lump-sum fix). Branch: feat/440-post-walk-reconciliation.
+Target: v0.8.2 release (sits on top of #439; rebase onto origin/main when #439 merges).
+Governs: Phase E2 of docs/dev/plans/fix-ledger-lump-sum-reconciliation.md.
+Depends on: #436 Phase A shipped, #437 Phase B shipped, #343 Phase D shipped, #439 Phase A shipped.
+Scope note: "do it all" per user direction. Full action-type coverage across funds, science, reputation.
+
+## 1. Bug restatement and success criteria
+
+Per docs/dev/todo-and-known-bugs.md entry #440 and the governing plan Phase E2:
+
+LedgerOrchestrator.ReconcileKscAction.ClassifyAction routes eight action types into the "Transformed" bucket and VERBOSE-skips them:
+
+- ContractComplete (funds/rep/sci, all strategy-transformable; rep via ApplyReputationCurve)
+- ContractFail (funds/rep; rep via curve)
+- ContractCancel (funds/rep; rep via curve)
+- MilestoneAchievement (funds/rep/sci; rep via curve; gated on Effective)
+- ReputationEarning (rep via curve)
+- ReputationPenalty (rep via curve)
+- FundsEarning on KSC path (safety route; no transform today)
+- ScienceEarning on KSC path (safety route; no transform today)
+
+Comparing their raw fields (FundsReward, NominalRep, MilestoneRepAwarded, etc.) against live KSP deltas would false-positive on every legitimate contract completion once strategies are active and on every rep change that crosses the curve. So today these channels pass through silently.
+
+After #439, strategy-transformed rewards are first-class and the VERBOSE skip is no longer defensible. Phase D already threads utCutoff through RecalculateAndPatch, and after the walk the derived fields TransformedFundsReward, TransformedScienceReward, TransformedRepReward, EffectiveRep, and Effective are populated on each action.
+
+Success criteria (all measurable):
+
+- On a stock career after revert/rewind with active strategies, no post-walk reconciliation WARN is produced solely by ContractComplete, ContractFail, ContractCancel, MilestoneAchievement, ReputationEarning, ReputationPenalty, KSC-path FundsEarning/ScienceEarning income when ReputationCurve matches KSP.
+- Controlled-divergence unit tests: seed a ContractComplete whose post-walk TransformedFundsReward does not match the store delta -> exactly one "Earnings reconciliation (post-walk, funds)" WARN fires.
+- Controlled-divergence rep curve test: seed a ReputationEarning where the walk's curve output diverges from a pre-captured store delta -> WARN fires on the rep leg.
+- Milestone duplicate test: two MilestoneAchievement actions with the same key, first Effective=true, second Effective=false -> only the first reconciles. No WARN for the duplicate.
+- utCutoff test: a ContractComplete past the cutoff is not reconciled (rewind does not produce false WARNs for filtered actions).
+- Double-WARN regression: the existing ReconcileKscAction pass must not also fire for the same action (these action types stay routed to the Transformed bucket with a SkipReason; the new post-walk hook is the only site that fires a post-walk WARN).
+
+## 2. Invariants (authoritative list, enforced by tests)
+
+I1. ClassifyAction stays authoritative for the per-action ReconcileKscAction split. "Untransformed" and "NoResourceImpact" buckets do not change.
+I2. The new post-walk reconciliation is a separate iteration at the top of RecalculateAndPatch after RecalculationEngine.Recalculate returns. It does NOT interleave with ReconcileKscAction. "Transformed" class still skips with VERBOSE in ReconcileKscAction (per-action path); the post-walk hook picks them up at the end of the walk exactly once.
+I3. utCutoff applies identically to the post-walk hook as to the walk. Actions with a.UT > utCutoff (and not seeds) are filtered out, never reconciled.
+I4. Non-effective MilestoneAchievement duplicates skip reconciliation. EffectiveRep is set to 0f by ReputationModule and funds/science are skipped in their modules when Effective=false (see FundsModule:314, ScienceModule:332), so the post-walk hook must gate on action.Effective for MilestoneAchievement. Applies to ContractComplete identically.
+I5. Multi-leg actions emit at most one WARN per resource leg per action. A ContractComplete may emit funds+rep+sci warns independently if all three diverge; a ContractFail may emit funds+rep independently.
+I6. Per-walk, the post-walk hook runs ONCE, not per-action. Same call pattern as ReconcileEarningsWindow (pure reconciliation, log-only).
+I7. Tolerances: funds=1.0, rep=0.1, sci=0.1 (match the existing LegacyMigrationFundsTolerance family and ReconcileKscAction's fundsTol/repTol/sciTol constants).
+
+## 3. Audit findings per action type
+
+For each type: raw field(s), post-walk derived field(s), store event(s) and TransactionReasons key, and whether a transform applies today.
+
+### 3.1 ContractComplete
+
+- Raw fields: action.FundsReward, action.RepReward, action.ScienceReward.
+- Post-walk fields:
+  - Funds: action.TransformedFundsReward (FundsModule reads this into runningBalance when Effective). Per #439 section 3.5, TransformContractReward is an identity no-op today, so TransformedFundsReward == FundsReward. Kept under the post-walk path for regression safety if a future mod re-enables a legitimate transform.
+  - Reputation: action.EffectiveRep (set by ReputationModule.ProcessContractCompleteRep, applies ApplyReputationCurve to TransformedRepReward when Effective).
+  - Science: action.TransformedScienceReward (ScienceModule reads this when Effective). Same identity invariant as funds today.
+- Store events (tag GameStateStore.Events):
+  - FundsChanged key=ContractReward (TransactionReasons.ContractReward). Recorder writes it via OnFundsChanged. Confirmed by existing test `ReconcileKsc_ContractComplete_SkipsWithVerbose` and `GameStateEventTests.cs`.
+  - ReputationChanged key=ContractReward.
+  - ScienceChanged key=ContractReward.
+- Transform applies today? Rep does (curve). Funds/Sci are identity post-#439 Phase A; include them so the structural match protects against regressions.
+- Effective gate: yes. Duplicates flagged by ContractsModule skip.
+
+### 3.2 ContractFail
+
+- Raw fields: action.FundsPenalty (positive magnitude; applied as -penalty by FundsModule), action.RepPenalty (positive magnitude).
+- Post-walk fields:
+  - Funds: no TransformedFundsPenalty field; FundsModule deducts FundsPenalty directly. Post-walk compare uses -FundsPenalty as the "expected delta" (structural no-op today; future parity).
+  - Reputation: action.EffectiveRep (negative). Computed by ReputationModule.ProcessContractPenaltyRep with nominal = -RepPenalty through the curve. NOT gated on Effective (penalties always apply).
+- Store events:
+  - FundsChanged key=ContractPenalty (TransactionReasons.ContractPenalty).
+  - ReputationChanged key=ContractPenalty.
+- Transform applies today? Rep does (curve). Funds is identity.
+- Effective gate: no.
+
+### 3.3 ContractCancel
+
+Same as ContractFail (shares ProcessContractPenalty and ProcessContractPenaltyRep).
+
+- Store event key: TransactionReasons.ContractPenalty. Both Contract.Fail and Contract.Cancel emit via ContractPenalty (confirmed by existing test `ReconcileKsc_ContractCancel_SkipsWithVerbose`). `TransactionReasons.ContractDecline` is a separate reason fired by `onDeclined` on offered-but-not-accepted contracts, not Cancel.
+
+### 3.4 MilestoneAchievement
+
+- Raw fields: action.MilestoneFundsAwarded, action.MilestoneRepAwarded, action.MilestoneScienceAwarded. All gated on action.Effective.
+- Post-walk fields:
+  - Funds: no Transformed* variant. FundsModule.ProcessMilestoneEarning credits MilestoneFundsAwarded when Effective.
+  - Rep: action.EffectiveRep (ReputationModule.ProcessMilestoneRep curve-transforms MilestoneRepAwarded when Effective).
+  - Sci: no Transformed* variant. ScienceModule credits MilestoneScienceAwarded when Effective.
+- Store events (confirmed via existing test `ReconcileKsc_MilestoneAchievement_SkipsWithVerbose`):
+  - FundsChanged key=Progression (TransactionReasons.Progression).
+  - ReputationChanged key=Progression.
+  - ScienceChanged key=Progression.
+  - Note: KSP's `ProgressNode.AwardProgress` calls `Funding.Add`/`ResearchAndDevelopment.Add`/`Reputation.AddReputation` which emit the three standard resource events with reason `Progression`. The MilestoneAchieved event itself carries the reward values in its detail string for display / ledger reconciliation via `ReconcileEarningsWindow`, but post-walk hook pairs against the generic resource events — the MilestoneAchieved event has no `valueBefore`/`valueAfter` to reconcile against.
+- Transform applies today? Rep does (curve). Funds/Sci are identity.
+- Effective gate: yes. Per invariant I4, non-effective duplicates skip.
+
+### 3.5 ReputationEarning
+
+- Raw field: action.NominalRep.
+- Post-walk field: action.EffectiveRep (via ApplyReputationCurve with runningRep-at-walk-time; NOT gated on Effective).
+- Store event: ReputationChanged, keyed by the emitter's `TransactionReasons`. The source taxonomy is dictated by the action's `RepSource` field:
+  - `RepSource.VesselRecovery` -> key=`VesselRecovery`.
+  - `RepSource.ContractReward` -> key=`ContractReward` (but these should arrive as ContractComplete actions, not ReputationEarning; audit at implementation time).
+  - `RepSource.Progression` -> key=`Progression` (audit — may come in as MilestoneAchievement).
+  - `RepSource.Other` / `RepSource.LegacyMigration` (#436 legacy path) -> untagged synthetics with no paired event; skip post-walk for those (ClassifyPostWalk returns Reconcile=false when RepSource is Other/LegacyMigration).
+- Transform applies today? Yes (curve) for captured sources; not for synthetics.
+- Effective gate: no (ReputationEarning is always effective).
+
+### 3.6 ReputationPenalty
+
+- Raw field: action.NominalPenalty (positive magnitude).
+- Post-walk field: action.EffectiveRep (negative; curve applied).
+- Store event: ReputationChanged. Source taxonomy by `RepPenaltySource`:
+  - `RepPenaltySource.ContractPenalty` -> key=`ContractPenalty` (typically arrives as ContractFail/ContractCancel; audit).
+  - `RepPenaltySource.Strategy` -> strategy-driven penalties (none emitted today from stock).
+  - `RepPenaltySource.Other` / `LegacyMigration` -> skip.
+- Transform applies today? Yes (curve) for captured sources.
+- Effective gate: no.
+
+### 3.7 FundsEarning (KSC path, source != Recovery/ContractReward/Milestone)
+
+- Raw field: action.FundsAwarded. Gated on action.Effective.
+- Post-walk field: none (no transform today; use FundsAwarded directly if Effective else 0.0).
+- Store event: FundsChanged with a source-specific key.
+- Transform applies today? No. This is the "safety" route: include it so that a future strategy payout or mod introduces a transform that gets caught immediately. For v0.8.2 this is structural.
+- Effective gate: yes.
+
+### 3.8 ScienceEarning (KSC path, SubjectId-driven)
+
+- Raw field: action.ScienceAwarded. Post-walk field: action.EffectiveScience (after subject-cap headroom). This IS a transform (subject cap), not strategy-driven but still a walk-level transformation.
+- Store event: ScienceChanged. Key depends on emitter.
+- Transform applies today? Yes (subject cap).
+- Effective gate: yes.
+
+### 3.9 Not in scope -- FundsSpending(source=Strategy)
+
+After #439, StrategyActivate is Untransformed and its SetupCost pairs with FundsChanged(StrategySetup) via ReconcileKscAction. Post-walk does NOT re-reconcile StrategyActivate. FundsSpending with source=Strategy is today flagged as Transformed in ClassifyAction (SkipReason "strategy spending not yet KSC-captured"). No strategy-driven FundsSpending action is emitted today from the KSC path (#439 captures activate/deactivate only; no ongoing-payout channel exists in stock), so this route stays dormant. If a future mod introduces a strategy FundsSpending, the post-walk hook will inherit it via the "Transformed" classification without further work. Flag in section 13 as carve-out for #439B follow-up.
+
+## 4. Post-walk hook design
+
+### 4.1 Placement
+
+Inside LedgerOrchestrator.RecalculateAndPatch after RecalculationEngine.Recalculate returns and BEFORE KspStatePatcher.PatchAll. Rationale: the walk has populated all derived fields and the reconciliation is log-only (does not affect patching). Runs once per RecalculateAndPatch.
+
+### 4.2 Method signature
+
+```csharp
+internal static void ReconcilePostWalk(
+    IReadOnlyList<GameStateEvent> events,
+    IReadOnlyList<GameAction> actions,
+    double? utCutoff)
+```
+
+- events = GameStateStore.Events (parameterized for testability).
+- actions = the walk copy of Ledger.Actions.
+- utCutoff = same cutoff the walk used; null means no cutoff.
+- Internal static, no KSP singleton access. Tests call it directly.
+
+### 4.3 Iteration order
+
+Single pass over `actions` in stored order. For each action:
+
+1. Filter by utCutoff per RecalculationEngine.IsSeedType rule.
+2. Gate by action type via a new classifier helper (see 4.4).
+3. For each applicable resource leg (funds, rep, sci), compute:
+   - expected = post-walk derived value.
+   - observed = sum of store events with matching type + matching TransactionReasons key within PostWalkReconcileEpsilonSeconds of action.UT.
+4. If |expected - observed| > tolerance, emit ONE WARN per (action, leg) with tag "Earnings reconciliation (post-walk, {leg})".
+5. Otherwise emit VERBOSE.
+
+### 4.4 New classifier helper
+
+`internal static PostWalkExpectation ClassifyPostWalk(GameAction action)` returning a small struct with up to three legs populated:
+
+```csharp
+internal struct PostWalkExpectation
+{
+    public bool Reconcile;
+    public PostWalkLeg Funds;
+    public PostWalkLeg Rep;
+    public PostWalkLeg Sci;
+}
+
+internal struct PostWalkLeg
+{
+    public bool Applies;
+    public double Expected;
+    public string ReasonKey;
+}
+```
+
+Maps each action type per 3.1-3.8 above. Non-transformed / out-of-scope types return Reconcile=false.
+
+Rationale for a separate classifier: keeps ClassifyAction (and its KscReconcileClass enum) untouched per invariant I1.
+
+### 4.5 Per-leg comparison
+
+Shared helper:
+
+```csharp
+private static void CompareLeg(
+    GameAction action,
+    string legTag,
+    GameStateEventType evtType,
+    string reasonKey,
+    double expected,
+    double tolerance,
+    IReadOnlyList<GameStateEvent> events)
+```
+
+- Walks events with e.eventType == evtType and e.key == reasonKey within PostWalkReconcileEpsilonSeconds of action.UT. Sums valueAfter-valueBefore.
+- If |expected - observed| > tolerance: WARN.
+- Else: VERBOSE (rate-limited per (Type, legTag) pair).
+
+Window and matching logic reuse the same pattern as ReconcileKscAction so the two functions share a predictable contract.
+
+### 4.6 Summary log
+
+After the iteration, emit one INFO summary with counts:
+
+```
+Post-walk reconcile: actions=X, matches=Y, mismatches(funds/rep/sci)=A/B/C, cutoffUT=Z
+```
+
+### 4.7 WARN format
+
+Match existing "Earnings reconciliation" tagging so log readers already filtering for that substring catch new lines:
+
+```
+Earnings reconciliation (post-walk, funds): {Type} id={id} expected={expected:F1},
+observed={observed:F1} across {n} event(s) keyed '{reasonKey}' at ut={ut:F1}
+- post-walk delta mismatch
+```
+
+Where `id` is ContractId / MilestoneId / SubjectId depending on type.
+
+## 5. Module surface audit
+
+Current exposure on GameAction: Effective (bool), EffectiveRep (float), EffectiveScience (float), TransformedFundsReward (float), TransformedRepReward (float), TransformedScienceReward (float). All public fields. No module-level access required.
+
+Gap: no "EffectiveFunds" per-action field. But none of the eight action types has a funds-specific transform separate from TransformedFundsReward (which is today identity). So funds needs NO new field.
+
+Decision: NO production module surface changes required for #440 scope.
+
+## 6. Windowing and event matching
+
+Reuse ReconcileKscAction's UT-window + key-matching pattern. Edge cases:
+
+- Event outside window: observedCount=0 -> WARN "no matching event within {epsilon}s of ut={ut} - missing earning channel or stale event?"
+- Duplicate / coalesced events: summing valueAfter-valueBefore across the window handles coalescing by construction (ResourceCoalesceEpsilon).
+- MilestoneAchievement duplicate (Effective=false second occurrence): skip in the iteration (I4).
+
+Window constant: introduce PostWalkReconcileEpsilonSeconds = 0.1, same rationale as KscReconcileEpsilonSeconds. Keep independent so a future tune does not inadvertently couple them.
+
+## 7. Tolerance
+
+Per invariant I7, match the existing family:
+
+- funds: 1.0
+- rep: 0.1
+- sci: 0.1
+
+Promote to three `private const double` fields on LedgerOrchestrator alongside the existing KSC constants (or reuse the KSC trio; a single shared set is cleanest).
+
+## 8. Logging and observability
+
+- WARN tag: "Earnings reconciliation (post-walk, {leg})". Leg in {"funds","rep","sci"}. Prefix kept identical to ReconcileEarningsWindow so existing log scanners catch it.
+- VERBOSE per-match (rate-limited) via ParsekLog.VerboseRateLimited with key "post-walk-match:{Type}:{leg}".
+- INFO summary per walk: always emitted.
+- SkipReason updates in ClassifyAction: each Transformed-class branch gets its SkipReason tweaked to reference "post-walk hook reconciles (#440)" instead of "not yet post-walk-aware". Cosmetic.
+
+## 9. Tests
+
+New tests in Source/Parsek.Tests/EarningsReconciliationTests.cs (shared test class, existing [Collection("Sequential")] and Dispose teardown cover the same static state).
+
+### 9.1 Unit tests (pure post-walk comparison)
+
+Approximately 14 cases:
+
+- PostWalk_ContractComplete_AllLegsMatch_NoWarn
+- PostWalk_ContractComplete_FundsMismatch_OnlyFundsWarn
+- PostWalk_ContractComplete_RepMismatch_OnlyRepWarn
+- PostWalk_ContractComplete_SciMismatch_OnlySciWarn
+- PostWalk_ContractFail_RepCurve_NoWarn
+- PostWalk_ContractCancel_FundsAndRep_Match_NoWarn
+- PostWalk_MilestoneAchievement_EffectiveTrue_AllLegsMatch_NoWarn
+- PostWalk_MilestoneAchievement_EffectiveFalseDuplicate_Skipped_NoWarn
+- PostWalk_ReputationEarning_CurveMatch_NoWarn
+- PostWalk_ReputationEarning_CurveDiverges_Warn
+- PostWalk_ReputationPenalty_CurveMatch_NoWarn
+- PostWalk_FundsEarning_KscPath_Match_NoWarn
+- PostWalk_ScienceEarning_SubjectCapApplied_Match_NoWarn
+- PostWalk_UtCutoff_FiltersFutureActions_NoWarn
+- PostWalk_NoMatchingEvent_WarnsMissingChannel
+
+### 9.2 Integration tests
+
+New file Source/Parsek.Tests/PostWalkReconciliationIntegrationTests.cs:
+
+- Integration_StrategyActive_ContractComplete_NoPostWalkWarn (commit path — drives OnRecordingCommitted end-to-end with seeded events; baseline ship criterion for v0.8.2)
+- Integration_StrategyActive_ContractComplete_TransformDiverges_Warn (rewind path)
+- Integration_RewindCutoffsFiltersPostWalk
+
+### 9.3 ClassifyAction SkipReason updates
+
+Update any test that asserts the current SkipReason string to match the new language. Grep targets include ReconcileKsc_ContractComplete_SkipsWithVerbose etc.
+
+### 9.4 Regression tests
+
+- PostWalk_DoubleWarnGuard_TransformedActionOnlyFiresOnce
+- PostWalk_ReputationCurveMatchesKsp (guards against curve drift)
+
+## 10. ClassifyAction changes
+
+Leave ClassifyAction alone (user gut-read confirmed). Add a separate iteration at the top of RecalculateAndPatch.
+
+- ClassifyAction continues to return KscReconcileClass.Transformed for the eight types. No new enum value.
+- ReconcileKscAction continues to VERBOSE-skip "Transformed" per-action on the KSC path.
+- The post-walk hook is an independent iteration at the top of RecalculateAndPatch. Consults the new ClassifyPostWalk helper, not ClassifyAction.
+
+Only cosmetic change to ClassifyAction: update SkipReason strings to "post-walk hook reconciles (#440)" for the eight Transformed branches.
+
+## 11. Interaction with #438, #439, and #439B
+
+### 11.1 #438 follow-ups
+
+#438 added ReconcileEarningsWindow switch cases for ContractAccept, FacilityUpgrade, FacilityRepair (funds-only, identity). Those are Untransformed-class and are reconciled per-action by ReconcileKscAction. Post-walk does NOT cover them (ClassifyPostWalk returns Reconcile=false).
+
+Latent double-WARN risk (flagged, not blocking): `ReconcileEarningsWindow` (commit path) sums raw `FundsReward`/`RepReward`/`ScienceReward` into `emittedFundsDelta`/etc., not `Transformed*Reward`. Today (identity transforms) this is equivalent. If a future non-identity transform lands (e.g. mod-provided strategy effect), both `ReconcileEarningsWindow` on commit AND `ReconcilePostWalk` will WARN for the same action with different signs. Follow-up: switch `ReconcileEarningsWindow` switch cases to `Transformed*Reward` after #440 ships. Document as a post-#440 follow-up in todo-and-known-bugs.md.
+
+### 11.2 #439 interaction
+
+#439 Phase A flipped StrategyActivate to Untransformed with ExpectedReasonKey="StrategySetup". The post-walk hook MUST NOT re-reconcile StrategyActivate. Per invariant I1, ClassifyAction handles it.
+
+Known invariant from #439 section 3.5: StrategiesModule.TransformContractReward is an identity no-op. So today TransformedFundsReward == FundsReward for every ContractComplete. The post-walk hook's funds-leg comparison is a structural no-op.
+
+### 11.3 #439B follow-up
+
+#439B defers multi-resource KscActionExpectation for Sci/Rep StrategyActivate setup costs. #440 does NOT cover #439B.
+
+## 12. Conflict vectors with open PRs
+
+- PR #376 (#438): adds switch cases in ReconcileEarningsWindow and test cases in EarningsReconciliationTests.cs. #440 also edits the same test file (adds approximately 15 new post-walk tests) and touches LedgerOrchestrator.cs. Likely textual conflict; git rebase handles mechanically.
+- PR #378 (#439): this branch sits on top of #378. Will rebase onto origin/main after #378 merges. Possible follow-up rebase if #376 merges first.
+- CHANGELOG.md, docs/dev/todo-and-known-bugs.md: mechanical conflicts expected.
+
+Sequencing: #440 rebases onto origin/main after #439 (and #438) merge. When that happens, ClassifyAction StrategyActivate is already flipped.
+
+## 13. File-touch list
+
+Production:
+
+- Source/Parsek/GameActions/LedgerOrchestrator.cs
+  - Add ReconcilePostWalk method and ClassifyPostWalk / PostWalkExpectation / PostWalkLeg types.
+  - Add PostWalkReconcileEpsilonSeconds constant.
+  - Call site in RecalculateAndPatch after RecalculationEngine.Recalculate.
+  - Update Transformed SkipReason strings (cosmetic).
+  - Estimate: approximately 180-220 lines added.
+
+No other production files.
+
+Tests:
+
+- Source/Parsek.Tests/EarningsReconciliationTests.cs
+  - Approximately 14 new Fact methods per 9.1/9.3/9.4.
+  - Update existing ReconcileKsc_*_SkipsWithVerbose cases to match new SkipReason strings.
+- Source/Parsek.Tests/PostWalkReconciliationIntegrationTests.cs (new)
+  - 3 integration tests per 9.2.
+
+Docs:
+
+- docs/dev/todo-and-known-bugs.md: strike through entry #440.
+- CHANGELOG.md: under v0.8.2 "Fixed". Plain ASCII, 1-2 sentences.
+- docs/dev/plans/fix-ledger-lump-sum-reconciliation.md: mark Phase E2 delivered.
+
+## 14. Risks and open questions
+
+R1. Does ReputationModule.ApplyReputationCurve exactly match KSP's addReputation_granular? If not, every ContractComplete rep leg would false-warn. **Mitigation: `PostWalk_ReputationCurveMatchesKsp` regression test is gate zero — write it FIRST, run it before any other implementation work. If it fails, #440 stops until the curve fidelity is fixed (separate bug, blocks this one).** Verify during implementation with a one-off ilspycmd extract of KSP's RepPenalty/RepGain paths alongside the curves stored in ReputationModule.cs.
+
+R2. MilestoneAchievement.Effective=false means duplicates re-emitted but not credited. The live event only reflects the first credit. Post-walk hook gates on action.Effective for MilestoneAchievement and ContractComplete. Duplicate-skip tested in 9.1.
+
+R3. Transformed fields reset between walks? YES. RecalculationEngine.Recalculate has a reset loop that zeroes EffectiveScience / EffectiveRep / Affordable and seeds TransformedFundsReward/ScienceReward/RepReward from the immutable raw fields. Each walk produces deterministic derived values.
+
+R4. Double-WARN risk: Existing ReconcileKscAction VERBOSE-skips Transformed action types, so it does not emit WARN. The new post-walk hook is the only site. Regression tested in 9.4.
+
+R5. [RESOLVED] MilestoneAchievement store-event source: KSP fires separate FundsChanged/ReputationChanged/ScienceChanged events with reason `Progression`. Confirmed by existing test fixture. Use generic key-matching path.
+
+R6. Multi-leg coalescing: a ContractComplete fires FundsChanged + ReputationChanged + ScienceChanged in sequence within ResourceCoalesceEpsilon (0.1s). GameStateStore coalesces same-eventType/same-key within the window, but the three legs are different eventTypes, so they land in separate slots.
+
+R7. KSC-path FundsEarning has no transform today; post-walk is a structural no-op. Safety net; keep included.
+
+R8. FundsSpending(source=Strategy) scope carve-out: not emitted today. Low risk.
+
+## 15. Acceptance checklist (v0.8.2 ship)
+
+- [ ] **Gate zero**: `PostWalk_ReputationCurveMatchesKsp` written FIRST and passing — proves our ApplyReputationCurve output matches a KSP-captured before/after rep delta. If this fails, stop the PR and file a rep-curve fidelity bug.
+- [ ] LedgerOrchestrator.ReconcilePostWalk + ClassifyPostWalk implemented.
+- [ ] PostWalkReconcileEpsilonSeconds constant added.
+- [ ] Call site in RecalculateAndPatch added after Recalculate returns.
+- [ ] Cosmetic SkipReason updates in ClassifyAction branches.
+- [ ] EarningsReconciliationTests.cs: approximately 14 new tests pass.
+- [ ] PostWalkReconciliationIntegrationTests.cs: 3 integration tests pass.
+- [ ] Existing ReconcileKsc_*_SkipsWithVerbose tests updated for new SkipReason strings, still pass.
+- [ ] dotnet test green in Source/Parsek.Tests.
+- [ ] docs/dev/todo-and-known-bugs.md entry #440 struck through.
+- [ ] CHANGELOG.md v0.8.2 Fixed entry added.
+- [ ] docs/dev/plans/fix-ledger-lump-sum-reconciliation.md Phase E2 marked delivered.
+- [ ] Rebased onto origin/main after #439 (and #376 if earlier) merge.
+- [ ] Manual in-game check (v0.8.2 user-visible ship criterion): stock career, activate one Admin-tier-1 strategy, complete one contract, save, reload. Grep KSP.log for `Earnings reconciliation (post-walk,` -> zero matches. Revert to launch, reload -> still zero matches.
+
+## 16. Out of scope
+
+- Multi-resource KscActionExpectation for StrategyActivate (tracked as #439B).
+- A StrategyPayout capture path (#439 Phase C).
+- Pre-transform raw ContractComplete reward capture (#439 Option C).
+- Enriching MilestoneAchieved events with Source / TransactionReasons keys if R5 resolution requires detail parsing.
+- Per-leg EffectiveFunds field on GameAction.

--- a/docs/dev/plans/fix-ledger-lump-sum-reconciliation.md
+++ b/docs/dev/plans/fix-ledger-lump-sum-reconciliation.md
@@ -174,6 +174,8 @@ This phase blocks Phase E2 for strategy. Without it, strategy income permanently
 
 ### Phase E2 — Plug remaining channels
 
+**Status:** Delivered in v0.8.2 via #440 (`feat/440-post-walk-reconciliation`); see `docs/dev/plans/fix-440-post-walk-reconciliation.md` for the per-action-type audit and the reviewer-corrected event keys. Remaining reconciliation follow-ups (non-blocking) tracked as #440B (switch `ReconcileEarningsWindow` to Transformed* fields) and #439B (multi-resource `KscActionExpectation` for strategy setup costs).
+
 **Branch family:** `fix/ledger-channel-<channel>`
 
 Per E1 audit. World firsts (if not covered by `ProgressRewardPatch`), any other green-field channel surfaced by the reproducer test. One commit per channel.

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -330,24 +330,23 @@ Prefer the full re-evaluation — it also defends against the same stale-local p
 
 ---
 
-## 440. Post-walk reconciliation for strategy-transformed and curve-applied reward types
+## ~~440.~~ Post-walk reconciliation for strategy-transformed and curve-applied reward types
 
-**Source:** Phase B (#437, PR #340) explicitly excluded these from KSC-side reconciliation. `LedgerOrchestrator.ReconcileKscAction.ClassifyAction` routes `ContractComplete` / `ContractFail` / `ContractCancel` / `MilestoneAchievement` / `ReputationEarning` / `ReputationPenalty` / direct KSC-path `FundsEarning` / `ScienceEarning` into the "transformed — skip with VERBOSE" bucket because their raw action fields (e.g. `FundsReward`, `NominalRep`) diverge from the live KSP balance delta by the time the walk runs: `StrategiesModule` mutates `TransformedFundsReward` during the walk, and `ReputationModule.ApplyReputationCurve` transforms rep earnings/penalties non-linearly. Comparing raw fields to observed deltas would produce false-positive WARNs on every legitimate contract completion once strategies are active.
+**Status:** Fixed (Phase E2, v0.8.2) in feat/440-post-walk-reconciliation.
 
-**Why it matters:** today strategy diversion, the reputation curve, and milestone rewards all pass through silently unless something external catches a mismatch (Phase A's legacy migration, or a `PatchFunds: suspicious drawdown` WARN from `KspStatePatcher`). Once #439 (strategy lifecycle capture) lands, strategy-transformed rewards become a first-class concern and the VERBOSE-skip is no longer defensible.
+**Fix summary:** `LedgerOrchestrator.RecalculateAndPatch` now calls a new `ReconcilePostWalk` helper after `RecalculationEngine.Recalculate` populates the derived `Transformed*Reward`, `EffectiveRep`, and `EffectiveScience` fields. The hook iterates actions in ledger order, respects `utCutoff` (mirrors the walk's filter; seed types always pass), and for each of the eight Transformed-bucket action types (ContractComplete, ContractFail, ContractCancel, MilestoneAchievement, ReputationEarning, ReputationPenalty, KSC-path FundsEarning, ScienceEarning) compares the post-walk derived value against the sum of matching `GameStateStore` events within 0.1 s of the action's UT. WARN per leg on divergence (tolerances: funds 1.0, rep 0.1, sci 0.1); rate-limited VERBOSE on match; single INFO summary per walk. Reviewer-corrected event keys: `ContractComplete` uses `ContractReward` (not `Contracts`), `ContractFail`/`ContractCancel` use `ContractPenalty` (not `ContractDecline`), `MilestoneAchievement` uses `Progression` via the generic resource-event path (the MilestoneAchieved event's detail is NOT parsed). Reputation earning/penalty actions map by their source enum; synthetic sources (`Other`, `LegacyMigration`) return `Reconcile=false`. Tests: 14 unit tests in `EarningsReconciliationTests.cs` including a gate-zero `PostWalk_ReputationCurveMatchesKsp` regression that pins `ApplyReputationCurve` against Spike A's KSP decompile within 0.1 tolerance, plus 3 integration tests in `PostWalkReconciliationIntegrationTests.cs`.
 
-**Fix:** Add a **post-walk reconciliation hook** that runs inside `LedgerOrchestrator.RecalculateAndPatch` after `RecalculationEngine.Recalculate` has populated `TransformedFundsReward` / `TransformedScienceReward` / `TransformedRepReward` and `ReputationModule.EffectiveRep`. The hook iterates actions of the transformed types and compares the POST-walk field to the live observed delta in `GameStateStore` within the same UT window / `TransactionReasons` key used by `ReconcileKscAction`. WARN on mismatch; VERBOSE on match.
+---
 
-Design constraints pulled from Phase D's (#343) plumbing:
-- The post-walk hook must respect `utCutoff` the same way the walk does — if a transformed-type action is past the cutoff it gets filtered out of reconciliation too (otherwise rewind would produce false WARNs for rewards that the walk skipped).
-- Keep the action-type classifier (`ReconcileKscAction.ClassifyAction`) as the authoritative split; "transformed" types get routed to the post-walk path instead of being VERBOSE-skipped. The "untransformed" and "no-op" buckets don't change.
-- Milestone rewards need special care: `MilestoneAchievement.Effective` is set by `MilestonesModule` at walk time; duplicates get `Effective=false` and should NOT reconcile (the live delta reflects the first credit only).
+## 440B. Switch `ReconcileEarningsWindow` from raw to Transformed* rewards (follow-up after #440)
 
-**Scope:** new helper in `LedgerOrchestrator.cs` (~80-120 lines), new tests in `EarningsReconciliationTests.cs` (~10 cases for: contract complete pre-strategy vs post-strategy, rep earning through the curve, milestone + effective duplicate, strategy-diverted reward, cutoff filter). Medium.
+**Source:** #440 (v0.8.2) review flagged a latent double-WARN risk. `LedgerOrchestrator.ReconcileEarningsWindow` (commit path) currently sums raw `FundsReward`/`RepReward`/`ScienceReward` into `emittedFundsDelta`/etc., not `Transformed*Reward`. Today this is equivalent because `StrategiesModule.TransformContractReward` is an identity no-op (see #439 Phase A). If a future mod introduces a non-identity transform (e.g. a strategy effect that diverts rewards), both `ReconcileEarningsWindow` on commit AND `ReconcilePostWalk` will WARN for the same action with different signs.
 
-**Dependencies:** #439 (strategy capture) should land first so the strategy-diversion cases can be tested end-to-end; otherwise a significant cohort of "transformed" WARNs won't have a test to pin them. Phase D (#343) shipped — `utCutoff` is already threaded through `RecalculateAndPatch`. Order: #439 → #440.
+**Fix:** switch the relevant switch cases in `ReconcileEarningsWindow` to `TransformedFundsReward` / `TransformedRepReward` / `TransformedScienceReward`. Small, purely additive. Add a unit test that pins the double-WARN scenario.
 
-**Status:** TODO. Priority: medium. Diagnostic-only (like the rest of reconciliation). Not release-blocking.
+**Status:** TODO. Priority: low. Does not bite today.
+
+---
 
 ---
 


### PR DESCRIPTION
## Summary

Close the VERBOSE-skip gap for the eight "Transformed" action types that `ReconcileKscAction.ClassifyAction` currently short-circuits (ContractComplete/Fail/Cancel, MilestoneAchievement, ReputationEarning/Penalty, KSC-path FundsEarning/ScienceEarning). A new `ReconcilePostWalk` hook runs once per `RecalculateAndPatch` after `RecalculationEngine.Recalculate` populates the transformed fields, and emits per-leg WARNs when post-walk derived values diverge from observed KSP deltas.

**Depends on:** #378 (#439 Phase A) — this branch is currently stacked on top. Will rebase onto `origin/main` when #378 merges.

## Scope

- `LedgerOrchestrator.cs`: new `ReconcilePostWalk` + `ClassifyPostWalk` + `PostWalkExpectation` / `PostWalkLeg` types + per-leg `CompareLeg` helper. Call site in `RecalculateAndPatch` between `RecalculationEngine.Recalculate` and `KspStatePatcher.PatchAll`.
- Cosmetic `ClassifyAction` `SkipReason` updates in the eight Transformed branches to reference `#440`.
- `EarningsReconciliationTests.cs`: 16 new unit tests (14 coverage + gate-zero `PostWalk_ReputationCurveMatchesKsp` + double-WARN regression guard + missing-channel WARN).
- `PostWalkReconciliationIntegrationTests.cs` (NEW): 3 end-to-end tests driving `RecalculateAndPatch`.
- CHANGELOG 1-liner, `todo-and-known-bugs.md` struck-through with `#440B` follow-up filed.
- Plan doc: `docs/dev/plans/fix-440-post-walk-reconciliation.md`.

## Key reviewer-driven corrections embedded

- `ContractComplete` uses `TransactionReasons.ContractReward` (not `Contracts`).
- `ContractFail`/`ContractCancel` both use `ContractPenalty` (not `ContractDecline`).
- `MilestoneAchievement` uses the generic FundsChanged/RepChanged/SciChanged path with key `Progression`.
- Source-enum mapping for `ReputationSource` / `ReputationPenaltySource` respects the real enum values (synthetics skip reconciliation).

## Reputation curve fidelity

Gate-zero test `PostWalk_ReputationCurveMatchesKsp` pins four pre-captured reference tuples against `ReputationModule.ApplyReputationCurve`. The curve keyframes in `ReputationModule.cs` are the Spike A port of KSP's decompiled `reputationAddition`/`reputationSubtraction` AnimationCurves.

## Test plan

- [x] `dotnet test --filter "FullyQualifiedName~PostWalk"` -- 20/20 pass (incl. new double-WARN regression guard).
- [x] `dotnet test --filter "FullyQualifiedName~EarningsReconciliation"` -- all pass.
- [x] `dotnet test --filter "FullyQualifiedName~PostWalkReconciliationIntegration"` -- 3/3 pass.
- [x] Full suite -- 7182 passed, 1 skipped (pre-existing), 0 failed.
- [ ] Manual in-game (v0.8.2 ship criterion): stock career, activate Admin-tier-1 strategy, complete one contract, save/reload, revert/reload. Grep KSP.log for `Earnings reconciliation (post-walk,` -- expect zero matches.

## Explicitly NOT in this PR (follow-ups filed)

- `#439B`: multi-resource `KscActionExpectation` for Science/Reputation StrategyActivate setup costs.
- `#440B`: switch `ReconcileEarningsWindow` from raw `FundsReward`/etc. to `Transformed*Reward` -- guards against double-WARN if a future non-identity transform lands.