### PR TITLE
fix(#458): heal malformed binary flat-fallback trajectory loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to Parsek are documented here.
 
 ### Tests
 
+- `#458` Added a binary sidecar regression test for duplicated flat-prefix loads and expanded the in-game committed-recording monotonicity failure to report track-section prefix/source diagnostics.
 - `#371` Added a `MergeInto` continuous-EVA boundary merge round-trip test plus an assertion that the optimizer rejects orbital-phase pairs.
 - `#384` Added the Learstar A1 S16 mission to the `DefaultCareer` fixture so `InjectAllRecordings` covers a far-away / map-view recording.
 - `#399` Regression tests for `ScienceModule.ComputeTotalSpendings` at duplicate UTs.
@@ -54,6 +55,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- `#458` Binary `.prec` flat-fallback loads now run the malformed-prefix healer against track-section data, logging `healed=true/false` with pre/post counts and marking healed recordings dirty so the corrected sidecar flushes back out on the next save.
 - `#456` Reserved crew are now placed in the tightest-fit same-name part when the snapshot's part pid can't be matched (e.g. after launching a new vessel that reuses a showcase ghost's part), preferring a 1-seat cockpit over a larger cabin.
 - `#455` `PatchMilestones` no longer spams thousands of `repeatable node '<Body>/<Name>' is missing stock record fields` WARNs on every recalculation; one-shot per-body progress nodes (`Bop/Orbit`, `Dres/Flight`, …) now correctly fall through to the one-shot patch path instead of being short-circuited by the repeatable-record branch.
 - `#387` Ghost map icons for `DeployedScienceController` and `DeployedGroundPart` now render the stock icon instead of the generic diamond fallback; their sprites live on separate atlas textures that the single-atlas init path used to silently reject.

--- a/Source/Parsek.Tests/Bug458BinaryFlatFallbackHealTests.cs
+++ b/Source/Parsek.Tests/Bug458BinaryFlatFallbackHealTests.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    [Collection("Sequential")]
+    public class Bug458BinaryFlatFallbackHealTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+        private readonly string tempDir;
+
+        public Bug458BinaryFlatFallbackHealTests()
+        {
+            RecordingStore.SuppressLogging = false;
+            RecordingStore.ResetForTesting();
+            RecordingStore.WriteReadableSidecarMirrorsOverrideForTesting = false;
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.VerboseOverrideForTesting = true;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+
+            tempDir = Path.Combine(Path.GetTempPath(), "parsek-bug458-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+            RecordingStore.SuppressLogging = true;
+            RecordingStore.WriteReadableSidecarMirrorsOverrideForTesting = null;
+            RecordingStore.ResetForTesting();
+
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); }
+                catch { }
+            }
+        }
+
+        [Fact]
+        public void BinaryFlatFallbackWithDuplicatedTrackSectionPrefix_HealsOnLoadAndMarksFilesDirty()
+        {
+            var written = BuildMalformedBinaryFlatFallbackRecording();
+            string precPath = Path.Combine(tempDir, written.RecordingId + ".prec");
+            string vesselPath = Path.Combine(tempDir, written.RecordingId + "_vessel.craft");
+            string ghostPath = Path.Combine(tempDir, written.RecordingId + "_ghost.craft");
+
+            Assert.True(RecordingStore.SaveRecordingFilesToPathsForTesting(
+                written, precPath, vesselPath, ghostPath, incrementEpoch: true));
+
+            var restored = new Recording { RecordingId = written.RecordingId };
+            logLines.Clear();
+
+            Assert.True(RecordingStore.LoadTrajectorySidecarForTesting(precPath, restored));
+
+            Assert.Equal(14, restored.Points.Count);
+            Assert.Single(restored.TrackSections);
+            Assert.True(restored.FilesDirty);
+            Assert.Equal(215.84, restored.Points[restored.Points.Count - 1].ut, 6);
+            for (int i = 1; i < restored.Points.Count; i++)
+            {
+                Assert.True(restored.Points[i].ut >= restored.Points[i - 1].ut,
+                    $"Non-monotonic point at {i}: {restored.Points[i].ut} < {restored.Points[i - 1].ut}");
+            }
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[RecordingStore]") &&
+                l.Contains("ReadBinaryTrajectoryFile") &&
+                l.Contains("used flat fallback path") &&
+                l.Contains("healed=true") &&
+                l.Contains("prePoints=27") &&
+                l.Contains("postPoints=14"));
+        }
+
+        private static Recording BuildMalformedBinaryFlatFallbackRecording()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "bug458-malformed-binary-flat-fallback",
+                RecordingFormatVersion = 3
+            };
+
+            var frames = new List<TrajectoryPoint>();
+            double[] uts =
+            {
+                155.84, 156.86, 157.52, 158.24, 159.12, 160.10, 161.20,
+                162.38, 163.62, 164.92, 166.92, 168.92, 170.92
+            };
+            for (int i = 0; i < uts.Length; i++)
+                frames.Add(MakePoint(uts[i], i));
+
+            rec.TrackSections.Add(new TrackSection
+            {
+                environment = SegmentEnvironment.ExoBallistic,
+                referenceFrame = ReferenceFrame.Absolute,
+                startUT = frames[0].ut,
+                endUT = frames[frames.Count - 1].ut,
+                source = TrackSectionSource.Background,
+                frames = new List<TrajectoryPoint>(frames),
+                checkpoints = new List<OrbitSegment>()
+            });
+
+            rec.Points.AddRange(frames);
+            rec.Points.AddRange(frames);
+            rec.Points.Add(MakePoint(215.84, uts.Length));
+            return rec;
+        }
+
+        private static TrajectoryPoint MakePoint(double ut, int index)
+        {
+            return new TrajectoryPoint
+            {
+                ut = ut,
+                latitude = 0.1 + (index * 0.01),
+                longitude = -74.0 + (index * 0.02),
+                altitude = 1000.0 + (index * 25.0),
+                rotation = new Quaternion(0f, 0f, 0f, 1f),
+                velocity = new Vector3(1f + index, 2f + index, 3f + index),
+                bodyName = "Kerbin",
+                funds = 0.0,
+                science = 0.0f,
+                reputation = 0.0f
+            };
+        }
+    }
+}

--- a/Source/Parsek/InGameTests/RuntimeTests.cs
+++ b/Source/Parsek/InGameTests/RuntimeTests.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using UnityEngine;
@@ -41,6 +42,7 @@ namespace Parsek.InGameTests
             }
 
             int valid = 0, skippedRoots = 0;
+            var monotonicFailures = new List<string>();
             foreach (var rec in recordings)
             {
                 InGameAssert.IsNotNull(rec.RecordingId, $"Recording has null ID");
@@ -55,15 +57,89 @@ namespace Parsek.InGameTests
                 }
 
                 // Time should be monotonically non-decreasing
+                bool monotonic = true;
                 for (int i = 1; i < rec.Points.Count; i++)
                 {
-                    InGameAssert.IsTrue(rec.Points[i].ut >= rec.Points[i - 1].ut,
-                        $"Recording {rec.RecordingId}: point {i} UT {rec.Points[i].ut} < previous {rec.Points[i - 1].ut}");
+                    if (rec.Points[i].ut < rec.Points[i - 1].ut)
+                    {
+                        int prefixMatchCount = CountTrackSectionPrefixMatches(rec);
+                        string firstPostPrefixSource = DescribeFirstPostPrefixPointSource(rec, prefixMatchCount);
+                        monotonicFailures.Add(
+                            $"Recording {rec.RecordingId}: point {i} UT {rec.Points[i].ut.ToString("R", CultureInfo.InvariantCulture)} " +
+                            $"< previous {rec.Points[i - 1].ut.ToString("R", CultureInfo.InvariantCulture)}; " +
+                            $"trackSections={rec.TrackSections?.Count ?? 0} prefixMatchCount={prefixMatchCount} " +
+                            $"firstPostPrefixSource={firstPostPrefixSource}");
+                        monotonic = false;
+                        break;
+                    }
                 }
-                valid++;
+
+                if (monotonic)
+                    valid++;
             }
+
+            InGameAssert.IsTrue(monotonicFailures.Count == 0, string.Join(System.Environment.NewLine, monotonicFailures.ToArray()));
             ParsekLog.Verbose("TestRunner",
                 $"Validated {valid} committed recordings, {skippedRoots} tree root(s) skipped");
+
+            int CountTrackSectionPrefixMatches(Recording rec)
+            {
+                if (rec.TrackSections == null || rec.TrackSections.Count == 0)
+                    return 0;
+
+                var rebuiltPoints = new List<TrajectoryPoint>();
+                RecordingStore.RebuildPointsFromTrackSections(rec.TrackSections, rebuiltPoints);
+                int max = System.Math.Min(rebuiltPoints.Count, rec.Points.Count);
+                int prefixMatchCount = 0;
+                while (prefixMatchCount < max &&
+                    TrajectoryPointsEqual(rebuiltPoints[prefixMatchCount], rec.Points[prefixMatchCount]))
+                {
+                    prefixMatchCount++;
+                }
+
+                return prefixMatchCount;
+            }
+
+            string DescribeFirstPostPrefixPointSource(Recording rec, int prefixMatchCount)
+            {
+                if (rec.Points == null || prefixMatchCount < 0 || prefixMatchCount >= rec.Points.Count)
+                    return "none";
+
+                TrajectoryPoint target = rec.Points[prefixMatchCount];
+                for (int sectionIndex = 0; sectionIndex < rec.TrackSections.Count; sectionIndex++)
+                {
+                    List<TrajectoryPoint> frames = rec.TrackSections[sectionIndex].frames;
+                    if (frames == null)
+                        continue;
+
+                    for (int frameIndex = 0; frameIndex < frames.Count; frameIndex++)
+                    {
+                        if (TrajectoryPointsEqual(frames[frameIndex], target))
+                            return $"section[{sectionIndex}] source={rec.TrackSections[sectionIndex].source} frame[{frameIndex}]";
+                    }
+                }
+
+                return "flat-only";
+            }
+
+            bool TrajectoryPointsEqual(TrajectoryPoint a, TrajectoryPoint b)
+            {
+                return a.ut == b.ut
+                    && a.latitude == b.latitude
+                    && a.longitude == b.longitude
+                    && a.altitude == b.altitude
+                    && a.rotation.x == b.rotation.x
+                    && a.rotation.y == b.rotation.y
+                    && a.rotation.z == b.rotation.z
+                    && a.rotation.w == b.rotation.w
+                    && a.velocity.x == b.velocity.x
+                    && a.velocity.y == b.velocity.y
+                    && a.velocity.z == b.velocity.z
+                    && a.bodyName == b.bodyName
+                    && a.funds == b.funds
+                    && a.science == b.science
+                    && a.reputation == b.reputation;
+            }
         }
 
         #endregion

--- a/Source/Parsek/TrajectorySidecarBinary.cs
+++ b/Source/Parsek/TrajectorySidecarBinary.cs
@@ -199,6 +199,16 @@ namespace Parsek
                 ReadFlagEventList(reader, rec.FlagEvents, stringTable);
                 ReadSegmentEventList(reader, rec.SegmentEvents, stringTable);
                 ReadTrackSections(reader, rec.TrackSections, stringTable, probe.FormatVersion, ref stats);
+                int preHealPointCount = rec.Points.Count;
+                int preHealOrbitSegmentCount = rec.OrbitSegments.Count;
+                bool healedMalformedFlatFallback = false;
+                if (!sectionAuthoritative &&
+                    probe.FormatVersion >= 1 &&
+                    rec.TrackSections.Count > 0)
+                {
+                    healedMalformedFlatFallback = RecordingStore.TryHealMalformedFlatFallbackTrajectoryFromTrackSections(
+                        rec, allowRelativeSections: true);
+                }
 
                 // #411 follow-up: promote-only. Never demote rec.RecordingFormatVersion from a
                 // higher in-memory value (e.g. a v4 stamp set by the tree/scenario legacy loop
@@ -230,7 +240,9 @@ namespace Parsek
                 {
                     ParsekLog.Verbose("RecordingStore",
                         $"ReadBinaryTrajectoryFile: recording={rec.RecordingId} version={probe.FormatVersion} " +
-                        $"used flat fallback path points={rec.Points.Count} orbitSegments={rec.OrbitSegments.Count} " +
+                        $"used flat fallback path healed={(healedMalformedFlatFallback ? "true" : "false")} " +
+                        $"prePoints={preHealPointCount} postPoints={rec.Points.Count} " +
+                        $"preOrbitSegments={preHealOrbitSegmentCount} postOrbitSegments={rec.OrbitSegments.Count} " +
                         $"trackSections={rec.TrackSections.Count} sparsePointLists={stats.SparsePointLists} " +
                         $"defaultedBody={stats.DefaultedBody} defaultedFunds={stats.DefaultedFunds} " +
                         $"defaultedScience={stats.DefaultedScience} defaultedRep={stats.DefaultedReputation}");

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -58,6 +58,18 @@ are fixed in the same PR branch with additional commits:
 
 # Known Bugs
 
+## ~~458.~~ Binary `.prec` flat-fallback loads skip the malformed-prefix healer
+
+**Source:** playtest `2026-04-18 1947`. `RuntimeTests.CommittedRecordingsHaveValidData` failed on recording `393b82ccb697492bb7b35c6c621f9d07` (`Learstar A1 Debris`) with `point 13 UT 155.840000000006 < previous 170.920000000014`. Hex-decoding the `.prec` confirmed the top-level flat point list duplicated the authoritative 13-frame prefix and then appended a terminal endpoint, while `TrackSection[0]` itself held the correct monotonically increasing frames. Root cause: commit `4474ba97` added `TryHealMalformedFlatFallbackTrajectoryFromTrackSections`, but only the text `ConfigNode` load path (`DeserializeTrajectoryFrom`) called it. Real committed recordings hydrate through `TrajectorySidecarBinary.Read`, so the bad binary shape bypassed the healer entirely.
+
+**Fix:** `TrajectorySidecarBinary.Read` now runs the same healer in the non-section-authoritative branch after `ReadTrackSections`, with `allowRelativeSections: true` to match the text load path. The existing `ReadBinaryTrajectoryFile ... used flat fallback path` VERBOSE line now includes `healed=true/false` plus `prePoints/postPoints` and `preOrbitSegments/postOrbitSegments`, making it obvious in `KSP.log` whether a malformed flat fallback was rewritten on read. The healer already calls `rec.MarkFilesDirty()`, so a healed sidecar now flushes back out automatically on the next save. `RuntimeTests.CommittedRecordingsHaveValidData` also reports `trackSections=`, `prefixMatchCount=`, and `firstPostPrefixSource=` for any future monotonicity failure so the next playtest points directly at duplicated track-section payload vs flat-only tail data.
+
+**Files:** `Source/Parsek/TrajectorySidecarBinary.cs`, `Source/Parsek/InGameTests/RuntimeTests.cs`, `Source/Parsek.Tests/Bug458BinaryFlatFallbackHealTests.cs`.
+
+**Status:** ~~Fixed~~. Targeted unit verification passes via `dotnet test --filter Bug458BinaryFlatFallbackHealTests` (1/1). In-game verification is pending the next playtest bundle.
+
+---
+
 ## ~~457.~~ Ghost icon right-click opens Parsek menu instead of pinning the label
 
 **Source:** maintenance request `2026-04-18`. `GhostIconClickPatch.Prefix` (`Source/Parsek/Patches/GhostVesselLoadPatch.cs`) returned `false` for every click on a ghost ProtoVessel icon in map view, suppressing KSP's own `objectNode_OnClick`. That also ate the stock right-click "pin the label" behavior, so ghosts were the only icons whose labels could not be pinned with the same gesture as real vessels.


### PR DESCRIPTION
## Summary
- In-game test `CommittedRecordingsHaveValidData` failed on the 2026-04-18 1947 playtest: recording `393b82ccb697492bb7b35c6c621f9d07` had non-monotonic UT (point 13 UT=155.840 came after point 12 UT=170.920) — a trajectory data-integrity violation.
- Root cause: the healer `RecordingStore.TryHealMalformedFlatFallbackTrajectoryFromTrackSections` (added in `4474ba97` to rebuild `rec.Points` from the authoritative `TrackSection` when the flat fallback list is malformed) is only wired into the ConfigNode text load path at `DeserializeTrajectoryFrom` — it was never called from the binary sidecar path (`TrajectorySidecarBinary.Read`). Every real recording loads via binary, so the heal never ran.
- Fix: invoke the heal from the non-section-authoritative branch of `TrajectorySidecarBinary.Read`. Healed-on-read state flushes back to disk on next save via `MarkFilesDirty`.
- Diagnostic follow-up in `RuntimeTests.CommittedRecordingsHaveValidData` failure messages: now includes `TrackSections.Count`, prefix-match count vs `rec.Points`, and the source of the first post-prefix point so future regressions self-diagnose.

## Test plan
- [x] New `Bug458BinaryFlatFallbackHealTests.cs` (xUnit): generator writes a Recording with `TrackSection[0] = N frames` + bad `Points = [frames]×2 + terminal`, saves via binary sidecar, loads back, asserts `rec.Points.Count == N+1` and monotonic UT; log-assertion confirms `healed=true` token.
- [x] `TrajectorySidecarBinary` verbose log extended with `healed=true/false` + pre/post point counts.
- [ ] In-game rerun of `CommittedRecordingsHaveValidData` against the existing save — `.prec` on disk should round-trip smaller (14 points) after one save cycle and the test passes.