### PR TITLE
Tighten Real Spawn Control proximity gate (250 m, <=2 m/s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to Parsek are documented here.
 
 ### Enhancements
 
+- Real Spawn Control proximity gate tightened: candidate range cut from 500 m to 250 m and a new ≤2 m/s surface-frame relative-speed requirement, so fast-forward only offers ghosts you have actually rendezvoused with.
 - `#450 B3` Ghost spawn hitch reduced on reentry-capable recordings: the reentry-FX build is now deferred until the ghost actually enters atmosphere above Mach 1.2. Orbital-only and sub-Mach-1.2 trajectories skip the build entirely; a per-session `deferred / buildsAvoided` counter in the diagnostics health line shows how often the deferral saved real build work.
 - Map view ghost icon right-click now pins the label (stock behavior) instead of opening the Parsek menu. Left-click still opens the menu.
 - `#386` Ghost map and tracking station icons now hide their label by default and toggle it with a left click on the icon; hover no longer reveals the label, and non-left clicks pass through to stock handlers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to Parsek are documented here.
 
 ### Enhancements
 
-- Real Spawn Control proximity gate tightened: candidate range cut from 500 m to 250 m and a new ≤2 m/s surface-frame relative-speed requirement, so fast-forward only offers ghosts you have actually rendezvoused with.
+- Real Spawn Control proximity gate tightened: candidate range cut from 500 m to 250 m and a new <=2 m/s relative-speed requirement (derived frame-agnostically from the change in active-vessel/ghost separation between scans), so fast-forward only offers ghosts you have actually rendezvoused with.
 - `#450 B3` Ghost spawn hitch reduced on reentry-capable recordings: the reentry-FX build is now deferred until the ghost actually enters atmosphere above Mach 1.2. Orbital-only and sub-Mach-1.2 trajectories skip the build entirely; a per-session `deferred / buildsAvoided` counter in the diagnostics health line shows how often the deferral saved real build work.
 - Map view ghost icon right-click now pins the label (stock behavior) instead of opening the Parsek menu. Left-click still opens the menu.
 - `#386` Ghost map and tracking station icons now hide their label by default and toggle it with a left click on the icon; hover no longer reveals the label, and non-left clicks pass through to stock handlers.

--- a/Source/Parsek.Tests/SelectiveSpawnUITests.cs
+++ b/Source/Parsek.Tests/SelectiveSpawnUITests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using UnityEngine;
 using Xunit;
 
 namespace Parsek.Tests
@@ -123,6 +124,80 @@ namespace Parsek.Tests
                 needsSpawn: true, chainSuppressed: false,
                 distance: 200, proximityRadius: 250,
                 relativeSpeed: 0.0, maxRelativeSpeed: 2.0));
+        }
+
+        // ── ComputeRelativeSpeed ──
+
+        [Fact]
+        public void ComputeRelativeSpeed_StationKeeping_ReturnsZero()
+        {
+            // Same relative offset at both samples: ghost and active vessel moved together.
+            var prevActive = new Vector3d(1000, 0, 0);
+            var prevGhost = new Vector3d(1100, 0, 0);
+            var nowActive = new Vector3d(1500, 200, 0);  // both translated by (500, 200, 0)
+            var nowGhost = new Vector3d(1600, 200, 0);
+            double rel = SelectiveSpawnUI.ComputeRelativeSpeed(
+                nowActive, nowGhost, prevActive, prevGhost,
+                dt: 1.5f, minDt: 0.5f, maxDt: 5.0f);
+            Assert.Equal(0.0, rel, precision: 6);
+        }
+
+        [Fact]
+        public void ComputeRelativeSpeed_FrameShift_Cancels()
+        {
+            // Floating-origin shift: same uniform offset added to all four positions.
+            // Relative geometry preserved -> relative speed should still be zero.
+            var prevActive = new Vector3d(0, 0, 0);
+            var prevGhost = new Vector3d(50, 0, 0);
+            var shift = new Vector3d(1e6, -2e6, 5e5);
+            var nowActive = prevActive + shift;
+            var nowGhost = prevGhost + shift;
+            double rel = SelectiveSpawnUI.ComputeRelativeSpeed(
+                nowActive, nowGhost, prevActive, prevGhost,
+                dt: 1.5f, minDt: 0.5f, maxDt: 5.0f);
+            Assert.Equal(0.0, rel, precision: 6);
+        }
+
+        [Fact]
+        public void ComputeRelativeSpeed_ApproachingAt3MperS_Returns3()
+        {
+            // Active stationary; ghost moves 4.5 m closer along x over 1.5s -> 3 m/s.
+            var prevActive = new Vector3d(0, 0, 0);
+            var prevGhost = new Vector3d(100, 0, 0);
+            var nowActive = new Vector3d(0, 0, 0);
+            var nowGhost = new Vector3d(95.5, 0, 0);
+            double rel = SelectiveSpawnUI.ComputeRelativeSpeed(
+                nowActive, nowGhost, prevActive, prevGhost,
+                dt: 1.5f, minDt: 0.5f, maxDt: 5.0f);
+            Assert.Equal(3.0, rel, precision: 6);
+        }
+
+        [Fact]
+        public void ComputeRelativeSpeed_DtTooShort_ReturnsInfinity()
+        {
+            double rel = SelectiveSpawnUI.ComputeRelativeSpeed(
+                Vector3d.zero, Vector3d.zero, Vector3d.zero, Vector3d.zero,
+                dt: 0.1f, minDt: 0.5f, maxDt: 5.0f);
+            Assert.Equal(double.PositiveInfinity, rel);
+        }
+
+        [Fact]
+        public void ComputeRelativeSpeed_DtTooLong_ReturnsInfinity()
+        {
+            // Stale sample (e.g. after time warp / scene change) — must reject.
+            double rel = SelectiveSpawnUI.ComputeRelativeSpeed(
+                Vector3d.zero, Vector3d.zero, Vector3d.zero, Vector3d.zero,
+                dt: 10f, minDt: 0.5f, maxDt: 5.0f);
+            Assert.Equal(double.PositiveInfinity, rel);
+        }
+
+        [Fact]
+        public void ComputeRelativeSpeed_NegativeDt_ReturnsInfinity()
+        {
+            double rel = SelectiveSpawnUI.ComputeRelativeSpeed(
+                Vector3d.zero, Vector3d.zero, Vector3d.zero, Vector3d.zero,
+                dt: -1f, minDt: 0.5f, maxDt: 5.0f);
+            Assert.Equal(double.PositiveInfinity, rel);
         }
 
         // ── FindNextSpawnCandidate ──

--- a/Source/Parsek.Tests/SelectiveSpawnUITests.cs
+++ b/Source/Parsek.Tests/SelectiveSpawnUITests.cs
@@ -31,7 +31,8 @@ namespace Parsek.Tests
             Assert.True(SelectiveSpawnUI.IsSpawnCandidate(
                 endUT: 200, currentUT: 100,
                 needsSpawn: true, chainSuppressed: false,
-                distance: 300, proximityRadius: 500));
+                distance: 200, proximityRadius: 250,
+                relativeSpeed: 1.0, maxRelativeSpeed: 2.0));
         }
 
         [Fact]
@@ -40,7 +41,8 @@ namespace Parsek.Tests
             Assert.False(SelectiveSpawnUI.IsSpawnCandidate(
                 endUT: 50, currentUT: 100,
                 needsSpawn: true, chainSuppressed: false,
-                distance: 300, proximityRadius: 500));
+                distance: 200, proximityRadius: 250,
+                relativeSpeed: 1.0, maxRelativeSpeed: 2.0));
         }
 
         [Fact]
@@ -49,7 +51,8 @@ namespace Parsek.Tests
             Assert.False(SelectiveSpawnUI.IsSpawnCandidate(
                 endUT: 200, currentUT: 100,
                 needsSpawn: false, chainSuppressed: false,
-                distance: 300, proximityRadius: 500));
+                distance: 200, proximityRadius: 250,
+                relativeSpeed: 1.0, maxRelativeSpeed: 2.0));
         }
 
         [Fact]
@@ -58,7 +61,8 @@ namespace Parsek.Tests
             Assert.False(SelectiveSpawnUI.IsSpawnCandidate(
                 endUT: 200, currentUT: 100,
                 needsSpawn: true, chainSuppressed: true,
-                distance: 300, proximityRadius: 500));
+                distance: 200, proximityRadius: 250,
+                relativeSpeed: 1.0, maxRelativeSpeed: 2.0));
         }
 
         [Fact]
@@ -67,7 +71,8 @@ namespace Parsek.Tests
             Assert.False(SelectiveSpawnUI.IsSpawnCandidate(
                 endUT: 200, currentUT: 100,
                 needsSpawn: true, chainSuppressed: false,
-                distance: 600, proximityRadius: 500));
+                distance: 300, proximityRadius: 250,
+                relativeSpeed: 1.0, maxRelativeSpeed: 2.0));
         }
 
         [Fact]
@@ -76,7 +81,8 @@ namespace Parsek.Tests
             Assert.True(SelectiveSpawnUI.IsSpawnCandidate(
                 endUT: 200, currentUT: 100,
                 needsSpawn: true, chainSuppressed: false,
-                distance: 500, proximityRadius: 500));
+                distance: 250, proximityRadius: 250,
+                relativeSpeed: 1.0, maxRelativeSpeed: 2.0));
         }
 
         [Fact]
@@ -85,7 +91,38 @@ namespace Parsek.Tests
             Assert.False(SelectiveSpawnUI.IsSpawnCandidate(
                 endUT: 100, currentUT: 100,
                 needsSpawn: true, chainSuppressed: false,
-                distance: 300, proximityRadius: 500));
+                distance: 200, proximityRadius: 250,
+                relativeSpeed: 1.0, maxRelativeSpeed: 2.0));
+        }
+
+        [Fact]
+        public void IsSpawnCandidate_AboveMaxRelativeSpeed_False()
+        {
+            Assert.False(SelectiveSpawnUI.IsSpawnCandidate(
+                endUT: 200, currentUT: 100,
+                needsSpawn: true, chainSuppressed: false,
+                distance: 200, proximityRadius: 250,
+                relativeSpeed: 2.5, maxRelativeSpeed: 2.0));
+        }
+
+        [Fact]
+        public void IsSpawnCandidate_AtExactMaxRelativeSpeed_True()
+        {
+            Assert.True(SelectiveSpawnUI.IsSpawnCandidate(
+                endUT: 200, currentUT: 100,
+                needsSpawn: true, chainSuppressed: false,
+                distance: 200, proximityRadius: 250,
+                relativeSpeed: 2.0, maxRelativeSpeed: 2.0));
+        }
+
+        [Fact]
+        public void IsSpawnCandidate_ZeroRelativeSpeed_True()
+        {
+            Assert.True(SelectiveSpawnUI.IsSpawnCandidate(
+                endUT: 200, currentUT: 100,
+                needsSpawn: true, chainSuppressed: false,
+                distance: 200, proximityRadius: 250,
+                relativeSpeed: 0.0, maxRelativeSpeed: 2.0));
         }
 
         // ── FindNextSpawnCandidate ──

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -96,7 +96,12 @@ namespace Parsek
         private readonly List<NearbySpawnCandidate> nearbySpawnCandidates = new List<NearbySpawnCandidate>();
         private float nextProximityCheckTime;
         private const float ProximityCheckIntervalSec = 1.5f;
-        internal const double NearbySpawnRadius = 500.0;
+        internal const double NearbySpawnRadius = 250.0;
+        // Real Spawn Control: maximum surface-frame relative speed (m/s) between the
+        // active vessel and a ghost for the ghost to qualify as a spawn candidate.
+        // Tight enough to require a deliberate rendezvous (matched orbits, station-keeping)
+        // before fast-forward is offered.
+        internal const double MaxRelativeSpeed = 2.0;
         private readonly HashSet<string> notifiedSpawnRecordingIds = new HashSet<string>();
         private int proximityCheckGeneration;
         internal int ProximityCheckGeneration => proximityCheckGeneration;
@@ -11196,11 +11201,14 @@ namespace Parsek
 
             if (FlightGlobals.ActiveVessel == null) return;
 
-            Vector3d activePos = FlightGlobals.ActiveVessel.GetWorldPos3D();
+            var activeVessel = FlightGlobals.ActiveVessel;
+            Vector3d activePos = activeVessel.GetWorldPos3D();
+            Vector3d activeSrfVel = activeVessel.srf_velocity;
+            string activeBodyName = activeVessel.mainBody != null ? activeVessel.mainBody.name : null;
             double currentUT = Planetarium.GetUniversalTime();
             var committed = RecordingStore.CommittedRecordings;
 
-            CollectNearbySpawnCandidates(activePos, currentUT, committed);
+            CollectNearbySpawnCandidates(activePos, activeSrfVel, activeBodyName, currentUT, committed);
 
             // Sort by distance (closest first)
             nearbySpawnCandidates.Sort((a, b) => a.distance.CompareTo(b.distance));
@@ -11213,8 +11221,12 @@ namespace Parsek
         /// Scans active ghosts for spawn-eligible recordings within proximity range.
         /// Populates nearbySpawnCandidates with qualifying entries.
         /// </summary>
-        private void CollectNearbySpawnCandidates(Vector3d activePos, double currentUT, IReadOnlyList<Recording> committed)
+        private void CollectNearbySpawnCandidates(
+            Vector3d activePos, Vector3d activeSrfVel, string activeBodyName,
+            double currentUT, IReadOnlyList<Recording> committed)
         {
+            int skippedBody = 0;
+            int skippedSpeed = 0;
             foreach (var kvp in ghostStates)
             {
                 int i = kvp.Key;
@@ -11251,6 +11263,24 @@ namespace Parsek
                 if (dist > NearbySpawnRadius)
                     continue;
 
+                // Bodies must match — surface-frame velocities are body-relative, and a
+                // sub-250m proximity across two bodies is geometrically impossible anyway.
+                if (string.IsNullOrEmpty(activeBodyName) ||
+                    string.IsNullOrEmpty(state.lastInterpolatedBodyName) ||
+                    activeBodyName != state.lastInterpolatedBodyName)
+                {
+                    skippedBody++;
+                    continue;
+                }
+
+                // Both ghost and active vessel velocities are surface-frame (body-relative).
+                double relSpeed = (activeSrfVel - (Vector3d)state.lastInterpolatedVelocity).magnitude;
+                if (relSpeed > MaxRelativeSpeed)
+                {
+                    skippedSpeed++;
+                    continue;
+                }
+
                 var depInfo = SelectiveSpawnUI.ComputeDepartureInfo(rec, currentUT);
                 nearbySpawnCandidates.Add(new NearbySpawnCandidate
                 {
@@ -11264,6 +11294,12 @@ namespace Parsek
                     destination = depInfo.destination
                 });
             }
+
+            if ((skippedBody > 0 || skippedSpeed > 0) && ParsekLog.IsVerboseEnabled)
+                ParsekLog.Verbose("Flight",
+                    string.Format(CultureInfo.InvariantCulture,
+                        "Proximity check: skipped {0} (body mismatch) + {1} (rel-speed > {2:F1} m/s)",
+                        skippedBody, skippedSpeed, MaxRelativeSpeed));
         }
 
         /// <summary>
@@ -11302,8 +11338,8 @@ namespace Parsek
             if (ParsekLog.IsVerboseEnabled && nearbySpawnCandidates.Count > 0)
                 ParsekLog.Verbose("Flight",
                     string.Format(CultureInfo.InvariantCulture,
-                        "Proximity check: {0} candidate(s) within {1:F0}m",
-                        nearbySpawnCandidates.Count, NearbySpawnRadius));
+                        "Proximity check: {0} candidate(s) within {1:F0}m and rel-speed <= {2:F1} m/s",
+                        nearbySpawnCandidates.Count, NearbySpawnRadius, MaxRelativeSpeed));
         }
 
         /// <summary>

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -97,11 +97,33 @@ namespace Parsek
         private float nextProximityCheckTime;
         private const float ProximityCheckIntervalSec = 1.5f;
         internal const double NearbySpawnRadius = 250.0;
-        // Real Spawn Control: maximum surface-frame relative speed (m/s) between the
-        // active vessel and a ghost for the ghost to qualify as a spawn candidate.
-        // Tight enough to require a deliberate rendezvous (matched orbits, station-keeping)
-        // before fast-forward is offered.
+        // Real Spawn Control: maximum relative speed (m/s) between the active vessel and a
+        // ghost for the ghost to qualify as a spawn candidate. Tight enough to require a
+        // deliberate rendezvous (matched orbits, station-keeping) before fast-forward is offered.
+        // Computed frame-agnostically as d(active_pos - ghost_pos)/dt across consecutive
+        // proximity scans — see CollectNearbySpawnCandidates.
         internal const double MaxRelativeSpeed = 2.0;
+        // Per-recording position samples from the prior proximity scan, used to derive a
+        // frame-agnostic relative speed without depending on which frame
+        // GhostPlaybackState.lastInterpolatedVelocity happens to be in (it varies by
+        // playback path — orbit-only ghosts never seed it; trajectory-replay velocity is
+        // not guaranteed surface-relative).
+        private struct ProximityVelocitySample
+        {
+            public Vector3d activePos;
+            public Vector3d ghostPos;
+            public float time;
+        }
+        private readonly Dictionary<string, ProximityVelocitySample> proximityVelocitySamples =
+            new Dictionary<string, ProximityVelocitySample>();
+        // Sample is trustworthy when 0.5s <= dt <= 5s. Below: jitter dominates.
+        // Above: sample is stale (time warp, scene change, paused) — discard.
+        private const float ProximityVelocitySampleMinDt = 0.5f;
+        private const float ProximityVelocitySampleMaxDt = 5.0f;
+        // Tracks the active vessel pid the proximity samples were captured against; on
+        // vessel switch the cached activePos belongs to a different craft and must be
+        // discarded (otherwise the next scan would see a teleport-sized delta).
+        private uint lastProximityActiveVesselPid;
         private readonly HashSet<string> notifiedSpawnRecordingIds = new HashSet<string>();
         private int proximityCheckGeneration;
         internal int ProximityCheckGeneration => proximityCheckGeneration;
@@ -1067,6 +1089,7 @@ namespace Parsek
             loggedOrbitSegments.Clear();
             loggedOrbitRotationSegments.Clear();
             nearbySpawnCandidates.Clear();
+            proximityVelocitySamples.Clear();
             notifiedSpawnRecordingIds.Clear();
             loggedRelativeStart.Clear();
             loggedAnchorNotFound.Clear();
@@ -9164,6 +9187,7 @@ namespace Parsek
             loggedOrbitSegments.Clear();
             loggedOrbitRotationSegments.Clear();
             nearbySpawnCandidates.Clear();
+            proximityVelocitySamples.Clear();
             notifiedSpawnRecordingIds.Clear();
             loggedRelativeStart.Clear();
             loggedAnchorNotFound.Clear();
@@ -11201,14 +11225,22 @@ namespace Parsek
 
             if (FlightGlobals.ActiveVessel == null) return;
 
-            var activeVessel = FlightGlobals.ActiveVessel;
-            Vector3d activePos = activeVessel.GetWorldPos3D();
-            Vector3d activeSrfVel = activeVessel.srf_velocity;
-            string activeBodyName = activeVessel.mainBody != null ? activeVessel.mainBody.name : null;
+            Vector3d activePos = FlightGlobals.ActiveVessel.GetWorldPos3D();
+            uint activePid = FlightGlobals.ActiveVessel.persistentId;
+            if (activePid != lastProximityActiveVesselPid)
+            {
+                if (lastProximityActiveVesselPid != 0 && proximityVelocitySamples.Count > 0)
+                    ParsekLog.Verbose("Flight",
+                        string.Format(CultureInfo.InvariantCulture,
+                            "Proximity check: active vessel changed pid {0} -> {1}, dropped {2} velocity sample(s)",
+                            lastProximityActiveVesselPid, activePid, proximityVelocitySamples.Count));
+                proximityVelocitySamples.Clear();
+                lastProximityActiveVesselPid = activePid;
+            }
             double currentUT = Planetarium.GetUniversalTime();
             var committed = RecordingStore.CommittedRecordings;
 
-            CollectNearbySpawnCandidates(activePos, activeSrfVel, activeBodyName, currentUT, committed);
+            CollectNearbySpawnCandidates(activePos, currentUT, committed);
 
             // Sort by distance (closest first)
             nearbySpawnCandidates.Sort((a, b) => a.distance.CompareTo(b.distance));
@@ -11221,12 +11253,14 @@ namespace Parsek
         /// Scans active ghosts for spawn-eligible recordings within proximity range.
         /// Populates nearbySpawnCandidates with qualifying entries.
         /// </summary>
-        private void CollectNearbySpawnCandidates(
-            Vector3d activePos, Vector3d activeSrfVel, string activeBodyName,
-            double currentUT, IReadOnlyList<Recording> committed)
+        private void CollectNearbySpawnCandidates(Vector3d activePos, double currentUT, IReadOnlyList<Recording> committed)
         {
-            int skippedBody = 0;
             int skippedSpeed = 0;
+            int skippedSeeding = 0;
+            float now = Time.time;
+            // Track which recordings still have an active ghost so we can prune stale samples.
+            var seenRecordingIds = new HashSet<string>();
+
             foreach (var kvp in ghostStates)
             {
                 int i = kvp.Key;
@@ -11259,22 +11293,40 @@ namespace Parsek
                         continue;
                 }
 
-                double dist = Vector3d.Distance(activePos, state.ghost.transform.position);
+                Vector3d ghostPos = state.ghost.transform.position;
+                double dist = Vector3d.Distance(activePos, ghostPos);
                 if (dist > NearbySpawnRadius)
                     continue;
 
-                // Bodies must match — surface-frame velocities are body-relative, and a
-                // sub-250m proximity across two bodies is geometrically impossible anyway.
-                if (string.IsNullOrEmpty(activeBodyName) ||
-                    string.IsNullOrEmpty(state.lastInterpolatedBodyName) ||
-                    activeBodyName != state.lastInterpolatedBodyName)
+                // Frame-agnostic relative-speed gate. We compute d(active_pos - ghost_pos)/dt
+                // across consecutive proximity scans rather than subtracting velocity vectors
+                // from KSP and ghost playback (those are not in a guaranteed common frame —
+                // TrajectoryPoint.velocity is "not guaranteed surface-relative" and orbit-only
+                // ghosts never seed lastInterpolatedVelocity at all). Both samples are read
+                // from transform.position in the same Update tick, so floating-origin and
+                // krakensbane shifts cancel in the per-sample relative vector.
+                seenRecordingIds.Add(rec.RecordingId);
+                bool hasPrev = proximityVelocitySamples.TryGetValue(rec.RecordingId, out var prev);
+                // Always overwrite the sample so the next scan can compute against this one.
+                proximityVelocitySamples[rec.RecordingId] = new ProximityVelocitySample
                 {
-                    skippedBody++;
+                    activePos = activePos,
+                    ghostPos = ghostPos,
+                    time = now
+                };
+
+                if (!hasPrev)
+                {
+                    // First sighting in range — seed only, defer admission until we have
+                    // a second sample to derive a velocity from.
+                    skippedSeeding++;
                     continue;
                 }
 
-                // Both ghost and active vessel velocities are surface-frame (body-relative).
-                double relSpeed = (activeSrfVel - (Vector3d)state.lastInterpolatedVelocity).magnitude;
+                float dt = now - prev.time;
+                double relSpeed = SelectiveSpawnUI.ComputeRelativeSpeed(
+                    activePos, ghostPos, prev.activePos, prev.ghostPos, dt,
+                    ProximityVelocitySampleMinDt, ProximityVelocitySampleMaxDt);
                 if (relSpeed > MaxRelativeSpeed)
                 {
                     skippedSpeed++;
@@ -11295,11 +11347,22 @@ namespace Parsek
                 });
             }
 
-            if ((skippedBody > 0 || skippedSpeed > 0) && ParsekLog.IsVerboseEnabled)
+            // Drop samples for recordings that are no longer in-range / ghosted, so the cache
+            // doesn't grow unboundedly across a long session.
+            if (proximityVelocitySamples.Count > seenRecordingIds.Count)
+            {
+                var stale = new List<string>();
+                foreach (var key in proximityVelocitySamples.Keys)
+                    if (!seenRecordingIds.Contains(key)) stale.Add(key);
+                for (int s = 0; s < stale.Count; s++)
+                    proximityVelocitySamples.Remove(stale[s]);
+            }
+
+            if ((skippedSpeed > 0 || skippedSeeding > 0) && ParsekLog.IsVerboseEnabled)
                 ParsekLog.Verbose("Flight",
                     string.Format(CultureInfo.InvariantCulture,
-                        "Proximity check: skipped {0} (body mismatch) + {1} (rel-speed > {2:F1} m/s)",
-                        skippedBody, skippedSpeed, MaxRelativeSpeed));
+                        "Proximity check: skipped {0} (rel-speed > {1:F1} m/s) + {2} (seeding first sample)",
+                        skippedSpeed, MaxRelativeSpeed, skippedSeeding));
         }
 
         /// <summary>

--- a/Source/Parsek/SelectiveSpawnUI.cs
+++ b/Source/Parsek/SelectiveSpawnUI.cs
@@ -59,17 +59,20 @@ namespace Parsek
 
         /// <summary>
         /// Pure: determine whether a ghost qualifies as a spawn candidate.
-        /// True when endUT is in the future, spawn is needed, not suppressed, and within range.
+        /// True when endUT is in the future, spawn is needed, not suppressed,
+        /// within range, and the surface-frame relative speed is within tolerance.
         /// </summary>
         internal static bool IsSpawnCandidate(
             double endUT, double currentUT,
             bool needsSpawn, bool chainSuppressed,
-            double distance, double proximityRadius)
+            double distance, double proximityRadius,
+            double relativeSpeed, double maxRelativeSpeed)
         {
             return endUT > currentUT
                 && needsSpawn
                 && !chainSuppressed
-                && distance <= proximityRadius;
+                && distance <= proximityRadius
+                && relativeSpeed <= maxRelativeSpeed;
         }
 
         /// <summary>

--- a/Source/Parsek/SelectiveSpawnUI.cs
+++ b/Source/Parsek/SelectiveSpawnUI.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Globalization;
+using UnityEngine;
 
 namespace Parsek
 {
@@ -73,6 +74,25 @@ namespace Parsek
                 && !chainSuppressed
                 && distance <= proximityRadius
                 && relativeSpeed <= maxRelativeSpeed;
+        }
+
+        /// <summary>
+        /// Pure: derive the relative speed (m/s) between active vessel and ghost from two
+        /// position samples taken `dt` seconds apart. Frame-agnostic: any uniform shift
+        /// (floating-origin, krakensbane) cancels in the per-sample relative vector.
+        /// Returns +infinity when dt is outside [minDt, maxDt] — the sample is either
+        /// jitter-dominated (too short) or stale (time warp / scene change).
+        /// </summary>
+        internal static double ComputeRelativeSpeed(
+            Vector3d activePos, Vector3d ghostPos,
+            Vector3d prevActivePos, Vector3d prevGhostPos,
+            float dt, float minDt, float maxDt)
+        {
+            if (dt < minDt || dt > maxDt)
+                return double.PositiveInfinity;
+            Vector3d nowRel = activePos - ghostPos;
+            Vector3d prevRel = prevActivePos - prevGhostPos;
+            return (nowRel - prevRel).magnitude / dt;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

- `NearbySpawnRadius` lowered from 500 m to 250 m.
- New constraint: surface-frame relative speed between active vessel and ghost must be `<= 2 m/s` (`MaxRelativeSpeed`).
- Both gates require body match (different bodies skip with verbose log).
- `SelectiveSpawnUI.IsSpawnCandidate` signature extended with `relativeSpeed` / `maxRelativeSpeed`.

Together these make Real Spawn Control only offer fast-forward when the player has actually rendezvoused (close range AND station-keeping), not just flown past at orbital speed.

## Test plan

- [x] `dotnet build` clean (no warnings/errors)
- [x] `dotnet test` -- 7319 passed, 1 skipped, 0 failed
- [x] `SelectiveSpawnUITests`: 35 tests pass (7 updated for new signature/radius, 3 new for relative-speed gate: above-max false, at-exact-max true, zero-speed true)
- [ ] In-game: approach a ghost in matched orbit at <=2 m/s within 250 m -> Real Spawn Control window appears with FF-Spawn / FF-Depart enabled
- [ ] In-game: fly past a ghost at orbital speed within 250 m -> no notification, no FF buttons (verify `[Parsek][Verbose][Flight] Proximity check: skipped ... (rel-speed > 2.0 m/s)` in KSP.log)
- [ ] In-game: hover at 300 m matched orbit -> no notification (outside new 250 m radius)