### PR TITLE
Fix KSP.log spam: ReusePrimaryGhostAcrossCycle null-ghost + CameraFollow INFO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- Looping recordings whose ghost never built (missing vessel snapshot) no longer spam `ReusePrimaryGhostAcrossCycle ... null ghost` WARNs every frame in `KSP.log`; the skip branch now advances the cycle counter so the condition logs at most once per rate-limit window.
+- Demoted the chatty `CameraFollow Camera pivot recalculated` line from Info to VerboseRateLimited; it was firing thousands of times per session on any recording with part visibility changes.
 - Fix #439B: strategy activate setup cost reconciliation now covers Funds, Science, and Reputation legs, closing the known limitation that shipped with #439.
 - `#438` Commit-time earnings reconciliation now correctly accounts for contract advances and facility upgrade/repair deltas, eliminating spurious WARNs when those actions land inside a recording's commit window.
 - `#406 follow-up` Looping ghosts now reuse the same ghost GameObject across loop-cycle boundaries instead of destroying and rebuilding, eliminating the remaining ~21 ms per-cycle hitch on flight recordings with reentry FX. Per-cycle mutable state (engine throttle, RCS power, robotic servo, char intensity, reentry intensity) resets to the fresh-spawn baseline so the new cycle does not inherit stale readings.

--- a/Source/Parsek.Tests/Bug406GhostReuseLoopCycleTests.cs
+++ b/Source/Parsek.Tests/Bug406GhostReuseLoopCycleTests.cs
@@ -233,12 +233,18 @@ namespace Parsek.Tests
         // --- Engine-level reuse ---
 
         [Fact]
-        public void ReusePrimaryGhostAcrossCycle_NullGhost_WarnsAndSkips()
+        public void ReusePrimaryGhostAcrossCycle_NullGhost_AdvancesCycleAndLogsRateLimited()
         {
-            // Defensive guard: if the ghost GameObject was somehow destroyed
-            // between the caller's `state != null` check and this call, we
-            // must not NRE. Warn so the condition is visible in playtest
-            // logs and return without mutating state.
+            // Defensive guard: if the ghost GameObject was never built (no
+            // vessel snapshot) or was externally destroyed, this helper must
+            // not NRE and must not spam the log. The playtest-reproducer had
+            // a single stuck state fire this WARN ~85×/sec for >80s because
+            // the early-return did not advance loopCycleIndex, so every frame
+            // HasLoopCycleChanged returned true and re-entered this path.
+            // The fix advances loopCycleIndex even on the skip branch so the
+            // infinite re-entry loop breaks, and downgrades the log to
+            // VerboseRateLimited so a genuine regression still leaves a
+            // breadcrumb without 10k lines per session.
             var engine = new GhostPlaybackEngine(positioner: null);
             var state = new GhostPlaybackState
             {
@@ -253,12 +259,56 @@ namespace Parsek.Tests
 
             Assert.Equal(0, engine.FrameSpawnCountForTesting);
             Assert.Equal(0, engine.FrameLazyReentryBuildCountForTesting);
-            // State unchanged: the helper bailed before any reset.
+            // playbackIndex NOT reset — the helper bailed before ResetForLoopCycle.
             Assert.Equal(99, state.playbackIndex);
-            Assert.Equal(4L, state.loopCycleIndex);
+            // loopCycleIndex DOES advance so cycleChanged is false next frame.
+            // Without this, the caller at GhostPlaybackEngine.UpdateLoopingPlayback
+            // re-enters the cycle-boundary block every frame and spams the log.
+            Assert.Equal(5L, state.loopCycleIndex);
+            // Log fires at VERBOSE (rate-limited), not WARN.
             Assert.Contains(logLines, l =>
-                l.Contains("[Engine]") && l.Contains("ReusePrimaryGhostAcrossCycle")
-                && l.Contains("#7"));
+                l.Contains("[VERBOSE]") && l.Contains("[Engine]")
+                && l.Contains("ReusePrimaryGhostAcrossCycle") && l.Contains("#7")
+                && l.Contains("advanced cycle=5"));
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("[WARN]") && l.Contains("ReusePrimaryGhostAcrossCycle"));
+        }
+
+        [Fact]
+        public void ReusePrimaryGhostAcrossCycle_NullGhost_RapidRepeatEmitsAtMostOneLogLine()
+        {
+            // The whole point of the rate-limit downgrade is to prevent the
+            // playtest scenario where a single stuck state fires this log
+            // every frame. Freeze the clock and fire 500 rapid calls — all
+            // fall inside the same 1.0s rate-limit window so exactly ONE
+            // VERBOSE line must hit the sink. If a future refactor drops the
+            // rate-limit key or accidentally routes through `Verbose()` or
+            // `Warn()` directly, this test surfaces the regression.
+            ParsekLog.ClockOverrideForTesting = () => 1000.0;
+            ParsekLog.ResetRateLimitsForTesting();
+
+            var engine = new GhostPlaybackEngine(positioner: null);
+            var state = new GhostPlaybackState { ghost = null, loopCycleIndex = 0 };
+
+            for (int i = 0; i < 500; i++)
+            {
+                engine.ReusePrimaryGhostAcrossCycle(
+                    index: 255, traj: null, flags: default, state,
+                    playbackUT: 0, newCycleIndex: i + 1);
+            }
+
+            int emitted = 0;
+            foreach (var l in logLines)
+            {
+                if (l.Contains("[Engine]") && l.Contains("ReusePrimaryGhostAcrossCycle")
+                    && l.Contains("#255"))
+                    emitted++;
+            }
+            Assert.Equal(1, emitted);
+            // Final loopCycleIndex reflects the LAST call — confirms the
+            // advance-on-skip fix is active every iteration, not just the
+            // first (which is all the log would prove on its own).
+            Assert.Equal(500L, state.loopCycleIndex);
         }
 
         [Fact]

--- a/Source/Parsek/GhostPlaybackEngine.cs
+++ b/Source/Parsek/GhostPlaybackEngine.cs
@@ -2373,8 +2373,17 @@ namespace Parsek
         {
             if (state == null || state.ghost == null)
             {
-                ParsekLog.Warn("Engine",
-                    $"ReusePrimaryGhostAcrossCycle: #{index} called with null ghost — skipping");
+                // Advance loopCycleIndex so HasLoopCycleChanged returns false next
+                // frame — otherwise a state with a null/Unity-destroyed ghost
+                // re-enters this path every frame and spams the log. The ghost
+                // either never built (no snapshot) or was externally destroyed;
+                // the spawn path below is responsible for re-creating it if and
+                // when a snapshot becomes available. Rate-limited so a genuine
+                // regression still leaves a breadcrumb without 85/sec spam.
+                if (state != null)
+                    state.loopCycleIndex = newCycleIndex;
+                ParsekLog.VerboseRateLimited("Engine", $"reuse-skip-null-{index}",
+                    $"ReusePrimaryGhostAcrossCycle: #{index} skipped — state.ghost is null (advanced cycle={newCycleIndex})", 1.0);
                 return;
             }
 

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -2003,9 +2003,9 @@ namespace Parsek
                 count++;
             }
             state.cameraPivot.localPosition = count > 0 ? (min + max) * 0.5f : Vector3.zero;
-            ParsekLog.Info("CameraFollow",
+            ParsekLog.VerboseRateLimited("CameraFollow", $"pivot-{state.ghost.name}",
                 $"Camera pivot recalculated: localPos=({state.cameraPivot.localPosition.x:F2},{state.cameraPivot.localPosition.y:F2},{state.cameraPivot.localPosition.z:F2})" +
-                $" activeParts={count}");
+                $" activeParts={count}", 1.0);
         }
 
         #endregion

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -18,6 +18,29 @@ The four top-of-queue correctness fixes (#431, #432, #433, #434) shipped in the 
 
 # Known Bugs
 
+## 462. LedgerOrchestrator earnings reconciliation: MilestoneAchievement double-count vs FundsChanged
+
+**Source:** `logs/2026-04-19_0014_investigate/KSP.log` (48 WARN lines across one session). Representative pair:
+
+```
+[WARN][LedgerOrchestrator] Earnings reconciliation (post-walk, funds): MilestoneAchievement id=Kerbin/SurfaceEVA expected=960.0, observed=1440.0 across 2 event(s) keyed 'Progression' at ut=17110.6 -- post-walk delta mismatch
+[WARN][LedgerOrchestrator] Earnings reconciliation (funds): store delta=13920.0 vs ledger emitted delta=13440.0 — missing earning channel? window=[17076.5,17110.6]
+```
+
+**Concern:** post-walk funds reconciliation detects a systematic mismatch between the expected milestone award and the observed FundsChanged events for several stock milestones — `MilestoneAchievement id=` values hitting 1.5× the expected payout across 2 events (so every recalc is double-writing one of them), plus store-vs-ledger window mismatches where the full-window delta diverges by a stable offset. Seen for: `RecordsSpeed` (12×), `RecordsDistance` (12×), `Kerbin/SurfaceEVA` (6+3), `Kerbin/Landing` (6×), `Kerbin/FlagPlant` (6×), `FirstLaunch` (6×). All on the same test-career session at UT≈17110. Because the observed delta is higher than expected, funds accounting for these milestones is likely over-paying — the kind of bug that silently inflates funds over long play sessions and is very hard to spot without the reconciliation WARNs.
+
+**Fix:** investigate `LedgerOrchestrator.RecalculateAndPatch` + `GameActions/KerbalsModule`-style earnings paths for milestone events. Two plausible causes: (1) milestone event being emitted twice into the ledger (once from the live progress event, once during recalc replay); (2) `Progression` channel key matching two distinct events in the reconciliation window (ambient FundsChanged from another source collapsed in). Add a test generator that reproduces the double-count for `RecordsSpeed` in `Source/Parsek.Tests/` (the milestone most obviously reproducible — it fires on every takeoff/landing in the test save). Cross-reference with the existing PR #307 follow-ups in `done/todo-and-known-bugs-v3.md` — that bundle already touched the `Progression` dedup key.
+
+**Files:** likely `Source/Parsek/GameActions/LedgerOrchestrator.cs`, the earnings emit path for MilestoneAchievement, and whichever module owns MilestoneStore→FundsChanged conversion. Log snapshot saved under `logs/2026-04-19_0014_investigate/` for reproduction context.
+
+**Scope:** Medium. Funds reconciliation is safety-critical (double-counted earnings invalidate career economies), but the WARN mechanism is already catching it — so the fix is localised to one emit path, not a schema redesign.
+
+**Dependencies:** none.
+
+**Status:** TODO. Priority: medium-to-high — real data correctness bug with no user-facing symptom today except the WARNs, but compounds over long saves.
+
+---
+
 ## 461. Pin the #406 reuse post-frame visibility invariant with an in-game test
 
 **Source:** clean-context Opus review of PR #394 (#406 ghost GameObject reuse across loop-cycle boundaries), finding #4.


### PR DESCRIPTION
## Summary

- Fixes the runaway `ReusePrimaryGhostAcrossCycle: #X called with null ghost — skipping` WARN spam (10,215 lines in one reproducer session, 99%+ of all WARNs). The skip branch now advances `state.loopCycleIndex` so `HasLoopCycleChanged` returns false next frame, breaking the infinite re-entry loop; the log drops to `VerboseRateLimited` with a per-index key so a genuine regression still leaves a breadcrumb.
- Demotes `CameraFollow Camera pivot recalculated` from `Info` to `VerboseRateLimited` (per-ghost key). That line fired 4,107 times in the same session — per-visibility-change data belongs at `VerboseRateLimited` per `.claude/CLAUDE.md`'s logging convention.
- Files #462 in `docs/dev/todo-and-known-bugs.md` tracking the `LedgerOrchestrator` earnings-reconciliation WARNs spotted in the same log run (MilestoneAchievement double-count vs FundsChanged) — separate fix, logged for follow-up rather than bundled in this log-hygiene PR.

## Root cause (for #1)

`ReusePrimaryGhostAcrossCycle` early-returns on `state.ghost == null` without advancing `loopCycleIndex`. `UpdateLoopingPlayback`'s cycle-boundary block (`GhostPlaybackEngine.cs:1035`) re-enters every frame because `HasLoopCycleChanged(state, cycleIndex)` keeps returning true. Observed on recording #255 "Kerbin Ascent" which reported "no vessel snapshot" — state existed but the ghost GameObject was never built.

## Test plan

- [x] `dotnet test` — 7358/7358 pass (1 pre-existing skip).
- [x] `Bug406GhostReuseLoopCycleTests.ReusePrimaryGhostAcrossCycle_NullGhost_AdvancesCycleAndLogsRateLimited` — asserts `loopCycleIndex` advances, log is `[VERBOSE]` (not `[WARN]`), and mentions `advanced cycle=`.
- [x] New `..._RapidRepeatEmitsAtMostOneLogLine` — freezes the log clock, fires the helper 500× in a loop, asserts exactly one line hits the sink and every iteration advanced `loopCycleIndex`.
- [x] Deployed DLL verified to contain UTF-16 `advanced cycle=` / `reuse-skip-null-` strings; old `called with null ghost` string removed.
- [x] Playtest: load the reproducer save (`logs/2026-04-19_0014_investigate/saves/`) and confirm `grep -c "ReusePrimaryGhostAcrossCycle" KSP.log` drops from 10k+ to a handful.