### PR TITLE
Fix strategy lifecycle in-game test readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Parsek are documented here.
 
 ---
 
+## 0.8.3
+
+### Tests
+
+- `#480` Strategy lifecycle in-game regressions no longer throw an early `NullReferenceException` on some SPACECENTER career saves. The tests now wait for stock strategy hydration to stabilize, reject nameless configs, and fail with targeted readiness/activation diagnostics instead of silently downgrading the regression to a skip.
+
+### Bug Fixes
+
+- `#480` Hardened the SPACECENTER stock-strategy lifecycle regression tests against transient stock strategy-system hydration on early scene frames, while keeping persistent readiness or `Activate()` failures visible as real test failures.
+
 ## 0.8.2
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,7 @@ All notable changes to Parsek are documented here.
 
 ### Tests
 
-- `#480` Strategy lifecycle in-game regressions no longer throw an early `NullReferenceException` on some SPACECENTER career saves. The tests now wait for stock strategy hydration to stabilize, reject nameless configs, and fail with targeted readiness/activation diagnostics instead of silently downgrading the regression to a skip.
-
-### Bug Fixes
-
-- `#480` Hardened the SPACECENTER stock-strategy lifecycle regression tests against transient stock strategy-system hydration on early scene frames, while keeping persistent readiness or `Activate()` failures visible as real test failures.
+- `#480` Strategy lifecycle in-game regressions now wait for stock strategy hydration to stabilize before probing activation, so the SPACECENTER career tests fail with targeted readiness diagnostics instead of early `NullReferenceException`s.
 
 ## 0.8.2
 

--- a/Source/Parsek/InGameTests/RuntimeTests.cs
+++ b/Source/Parsek/InGameTests/RuntimeTests.cs
@@ -3902,6 +3902,14 @@ namespace Parsek.InGameTests
             public bool HadProbeException;
         }
 
+        private sealed class StrategySelectionResult
+        {
+            public Strategies.Strategy Strategy;
+            public string ConfigName;
+            public string Diagnostic;
+            public bool SawProbeException;
+        }
+
         private static StrategyProbeResult ProbeActivatableStockStrategy()
         {
             var result = new StrategyProbeResult
@@ -4003,6 +4011,56 @@ namespace Parsek.InGameTests
             return result;
         }
 
+        private static IEnumerator WaitForStableActivatableStockStrategy(StrategySelectionResult result)
+        {
+            if (result == null)
+                throw new System.ArgumentNullException(nameof(result));
+
+            result.Strategy = null;
+            result.ConfigName = null;
+            result.Diagnostic = "no activatable stock strategy available";
+            result.SawProbeException = false;
+
+            for (int i = 0; i < StrategyLifecycleProbeWarmupFrames; i++)
+                yield return null;
+
+            string stableConfigName = null;
+            int stableFrames = 0;
+            for (int attempt = 0; attempt < StrategyLifecycleProbeRetryFrames; attempt++)
+            {
+                var probe = ProbeActivatableStockStrategy();
+                result.Diagnostic = probe.Diagnostic;
+                result.SawProbeException |= probe.HadProbeException;
+                if (probe.Strategy != null)
+                {
+                    if (probe.ConfigName == stableConfigName)
+                        stableFrames++;
+                    else
+                    {
+                        stableConfigName = probe.ConfigName;
+                        stableFrames = 1;
+                    }
+
+                    result.Strategy = probe.Strategy;
+                    result.ConfigName = probe.ConfigName;
+                    if (stableFrames >= StrategyLifecycleProbeStableFrames)
+                        yield break;
+
+                    yield return null;
+                    continue;
+                }
+
+                result.Strategy = null;
+                result.ConfigName = null;
+                stableConfigName = null;
+                stableFrames = 0;
+                if (!probe.ShouldRetry)
+                    yield break;
+
+                yield return null;
+            }
+        }
+
         [InGameTest(Category = "StrategyLifecycle", Scene = GameScenes.SPACECENTER,
             Description = "#439 Phase A: StrategyLifecyclePatch postfixes emit StrategyActivated/StrategyDeactivated events into GameStateStore for a real Strategies.Strategy instance.")]
         public IEnumerator ActivateAndDeactivate_StockStrategy_EmitsLifecycleEvents()
@@ -4019,62 +4077,22 @@ namespace Parsek.InGameTests
                 yield break;
             }
 
-            // Give StrategySystem a few frames to finish hydrating its stock entries.
-            // On some career-save SPACECENTER loads, probing immediately can hit a
-            // transient stock-strategy NullReferenceException inside CanBeActivated().
-            for (int i = 0; i < StrategyLifecycleProbeWarmupFrames; i++)
-                yield return null;
-
             // Gate 2/3: wait briefly for StrategySystem hydration to stabilize, but
             // DO NOT silently convert persistent probe exceptions into a skip. If
             // readiness never settles after the retry window, fail with diagnostics.
-            Strategies.Strategy strategy = null;
-            string configName = null;
-            string strategyDiagnostic = null;
-            bool sawProbeException = false;
-            string stableConfigName = null;
-            int stableFrames = 0;
-            for (int attempt = 0; attempt < StrategyLifecycleProbeRetryFrames; attempt++)
-            {
-                var probe = ProbeActivatableStockStrategy();
-                strategyDiagnostic = probe.Diagnostic;
-                sawProbeException |= probe.HadProbeException;
-                if (probe.Strategy != null)
-                {
-                    if (probe.ConfigName == stableConfigName)
-                        stableFrames++;
-                    else
-                    {
-                        stableConfigName = probe.ConfigName;
-                        stableFrames = 1;
-                    }
-
-                    strategy = probe.Strategy;
-                    configName = probe.ConfigName;
-                    if (stableFrames >= StrategyLifecycleProbeStableFrames)
-                        break;
-
-                    yield return null;
-                    continue;
-                }
-
-                strategy = null;
-                configName = null;
-                stableConfigName = null;
-                stableFrames = 0;
-                if (!probe.ShouldRetry)
-                    break;
-                yield return null;
-            }
+            var selection = new StrategySelectionResult();
+            yield return WaitForStableActivatableStockStrategy(selection);
+            var strategy = selection.Strategy;
+            var configName = selection.ConfigName;
 
             if (strategy == null || string.IsNullOrEmpty(configName))
             {
-                if (sawProbeException)
+                if (selection.SawProbeException)
                 {
-                    InGameAssert.Fail($"StrategyLifecycle readiness never stabilized: {strategyDiagnostic}");
+                    InGameAssert.Fail($"StrategyLifecycle readiness never stabilized: {selection.Diagnostic}");
                     yield break;
                 }
-                InGameAssert.Skip(strategyDiagnostic);
+                InGameAssert.Skip(selection.Diagnostic);
                 yield break;
             }
 
@@ -4284,56 +4302,19 @@ namespace Parsek.InGameTests
                 yield break;
             }
 
-            for (int i = 0; i < StrategyLifecycleProbeWarmupFrames; i++)
-                yield return null;
-
-            Strategies.Strategy strategy = null;
-            string configName = null;
-            string strategyDiagnostic = null;
-            bool sawProbeException = false;
-            string stableConfigName = null;
-            int stableFrames = 0;
-            for (int attempt = 0; attempt < StrategyLifecycleProbeRetryFrames; attempt++)
-            {
-                var probe = ProbeActivatableStockStrategy();
-                strategyDiagnostic = probe.Diagnostic;
-                sawProbeException |= probe.HadProbeException;
-                if (probe.Strategy != null)
-                {
-                    if (probe.ConfigName == stableConfigName)
-                        stableFrames++;
-                    else
-                    {
-                        stableConfigName = probe.ConfigName;
-                        stableFrames = 1;
-                    }
-
-                    strategy = probe.Strategy;
-                    configName = probe.ConfigName;
-                    if (stableFrames >= StrategyLifecycleProbeStableFrames)
-                        break;
-
-                    yield return null;
-                    continue;
-                }
-
-                strategy = null;
-                configName = null;
-                stableConfigName = null;
-                stableFrames = 0;
-                if (!probe.ShouldRetry)
-                    break;
-                yield return null;
-            }
+            var selection = new StrategySelectionResult();
+            yield return WaitForStableActivatableStockStrategy(selection);
+            var strategy = selection.Strategy;
+            var configName = selection.ConfigName;
 
             if (strategy == null || string.IsNullOrEmpty(configName))
             {
-                if (sawProbeException)
+                if (selection.SawProbeException)
                 {
-                    InGameAssert.Fail($"StrategyLifecycle readiness never stabilized: {strategyDiagnostic}");
+                    InGameAssert.Fail($"StrategyLifecycle readiness never stabilized: {selection.Diagnostic}");
                     yield break;
                 }
-                InGameAssert.Skip(strategyDiagnostic);
+                InGameAssert.Skip(selection.Diagnostic);
                 yield break;
             }
 

--- a/Source/Parsek/InGameTests/RuntimeTests.cs
+++ b/Source/Parsek/InGameTests/RuntimeTests.cs
@@ -3888,23 +3888,119 @@ namespace Parsek.InGameTests
             }
         }
 
-        private static Strategies.Strategy FindActivatableStockStrategy()
+        private const int StrategyLifecycleProbeWarmupFrames = 3;
+        private const int StrategyLifecycleProbeRetryFrames = 30;
+        private const int StrategyLifecycleProbeStableFrames = 2;
+        private const int StrategyLifecycleActivateSettleFrames = 2;
+
+        private struct StrategyProbeResult
         {
+            public Strategies.Strategy Strategy;
+            public string ConfigName;
+            public string Diagnostic;
+            public bool ShouldRetry;
+            public bool HadProbeException;
+        }
+
+        private static StrategyProbeResult ProbeActivatableStockStrategy()
+        {
+            var result = new StrategyProbeResult
+            {
+                Diagnostic = "no activatable stock strategy available",
+                ShouldRetry = false,
+                HadProbeException = false
+            };
+
             var system = Strategies.StrategySystem.Instance;
-            if (system == null) return null;
+            if (system == null)
+            {
+                result.Diagnostic = "StrategySystem.Instance is null";
+                result.ShouldRetry = true;
+                return result;
+            }
             var list = system.Strategies;
-            if (list == null) return null;
+            if (list == null)
+            {
+                result.Diagnostic = "StrategySystem.Strategies is null";
+                result.ShouldRetry = true;
+                return result;
+            }
+
+            int nullEntries = 0;
+            int activeEntries = 0;
+            int configlessEntries = 0;
+            int namelessEntries = 0;
+            int blockedEntries = 0;
+            int probeThrows = 0;
+            string lastProbeFailure = null;
             for (int i = 0; i < list.Count; i++)
             {
                 var s = list[i];
-                if (s == null) continue;
-                if (s.IsActive) continue;
-                if (s.Config == null) continue;
-                string reason;
-                if (!s.CanBeActivated(out reason)) continue;
-                return s;
+                if (s == null)
+                {
+                    nullEntries++;
+                    continue;
+                }
+
+                try
+                {
+                    if (s.IsActive)
+                    {
+                        activeEntries++;
+                        continue;
+                    }
+
+                    var config = s.Config;
+                    if (config == null)
+                    {
+                        configlessEntries++;
+                        continue;
+                    }
+
+                    string configName = config.Name;
+                    if (string.IsNullOrEmpty(configName))
+                    {
+                        namelessEntries++;
+                        continue;
+                    }
+
+                    string reason;
+                    if (!s.CanBeActivated(out reason))
+                    {
+                        blockedEntries++;
+                        continue;
+                    }
+
+                    result.Strategy = s;
+                    result.ConfigName = configName;
+                    result.Diagnostic = $"selected activatable strategy '{configName}'";
+                    return result;
+                }
+                catch (System.Exception ex)
+                {
+                    probeThrows++;
+                    result.HadProbeException = true;
+                    lastProbeFailure = $"{ex.GetType().Name}: {ex.Message}";
+                    ParsekLog.Warn("TestRunner",
+                        $"StrategyLifecycle probe skipped strategy index {i} because readiness access threw: {lastProbeFailure}");
+                }
             }
-            return null;
+
+            result.Diagnostic =
+                $"no CanBeActivated-true stock strategy available (count={list.Count}, null={nullEntries}, " +
+                $"active={activeEntries}, configless={configlessEntries}, nameless={namelessEntries}, " +
+                $"blocked={blockedEntries}, " +
+                $"probeThrows={probeThrows}" +
+                (string.IsNullOrEmpty(lastProbeFailure)
+                    ? ")"
+                    : $", lastProbe='{lastProbeFailure}')");
+            result.ShouldRetry =
+                system == null
+                || list == null
+                || configlessEntries > 0
+                || namelessEntries > 0
+                || probeThrows > 0;
+            return result;
         }
 
         [InGameTest(Category = "StrategyLifecycle", Scene = GameScenes.SPACECENTER,
@@ -3923,24 +4019,69 @@ namespace Parsek.InGameTests
                 yield break;
             }
 
-            // Gate 2: StrategySystem singleton available.
-            var system = Strategies.StrategySystem.Instance;
-            if (system == null)
+            // Give StrategySystem a few frames to finish hydrating its stock entries.
+            // On some career-save SPACECENTER loads, probing immediately can hit a
+            // transient stock-strategy NullReferenceException inside CanBeActivated().
+            for (int i = 0; i < StrategyLifecycleProbeWarmupFrames; i++)
+                yield return null;
+
+            // Gate 2/3: wait briefly for StrategySystem hydration to stabilize, but
+            // DO NOT silently convert persistent probe exceptions into a skip. If
+            // readiness never settles after the retry window, fail with diagnostics.
+            Strategies.Strategy strategy = null;
+            string configName = null;
+            string strategyDiagnostic = null;
+            bool sawProbeException = false;
+            string stableConfigName = null;
+            int stableFrames = 0;
+            for (int attempt = 0; attempt < StrategyLifecycleProbeRetryFrames; attempt++)
             {
-                InGameAssert.Skip("StrategySystem.Instance is null — Admin facility may be missing or scene not ready");
+                var probe = ProbeActivatableStockStrategy();
+                strategyDiagnostic = probe.Diagnostic;
+                sawProbeException |= probe.HadProbeException;
+                if (probe.Strategy != null)
+                {
+                    if (probe.ConfigName == stableConfigName)
+                        stableFrames++;
+                    else
+                    {
+                        stableConfigName = probe.ConfigName;
+                        stableFrames = 1;
+                    }
+
+                    strategy = probe.Strategy;
+                    configName = probe.ConfigName;
+                    if (stableFrames >= StrategyLifecycleProbeStableFrames)
+                        break;
+
+                    yield return null;
+                    continue;
+                }
+
+                strategy = null;
+                configName = null;
+                stableConfigName = null;
+                stableFrames = 0;
+                if (!probe.ShouldRetry)
+                    break;
+                yield return null;
+            }
+
+            if (strategy == null || string.IsNullOrEmpty(configName))
+            {
+                if (sawProbeException)
+                {
+                    InGameAssert.Fail($"StrategyLifecycle readiness never stabilized: {strategyDiagnostic}");
+                    yield break;
+                }
+                InGameAssert.Skip(strategyDiagnostic);
                 yield break;
             }
 
-            // Gate 3: at least one activatable strategy. No cost gate — teardown
-            // restores Funds/Science/Reputation via snapshot-diff.
-            var strategy = FindActivatableStockStrategy();
-            if (strategy == null)
-            {
-                InGameAssert.Skip("no CanBeActivated-true stock strategy available for testing");
-                yield break;
-            }
-
-            string configName = strategy.Config.Name ?? "";
+            var strategyConfig = strategy.Config;
+            InGameAssert.IsNotNull(strategyConfig, "Selected strategy lost Config after probe");
+            InGameAssert.IsFalse(string.IsNullOrEmpty(strategyConfig.Name),
+                "Selected strategy must have a non-empty Config.Name");
             ParsekLog.Info("TestRunner",
                 $"StrategyLifecycle test target: configName={configName} title={strategy.Title} " +
                 $"setupF={strategy.InitialCostFunds.ToString("R", CultureInfo.InvariantCulture)} " +
@@ -3972,7 +4113,20 @@ namespace Parsek.InGameTests
             // starts a recalculation walk mid-test, this assumption breaks and the
             // test's event-find step will fail with a clear message.
 
-            bool activateOk = strategy.Activate();
+            for (int i = 0; i < StrategyLifecycleActivateSettleFrames; i++)
+                yield return null;
+
+            bool activateOk;
+            try
+            {
+                activateOk = strategy.Activate();
+            }
+            catch (System.Exception ex)
+            {
+                InGameAssert.Fail(
+                    $"Strategy.Activate threw {ex.GetType().Name} for key='{configName}' after readiness stabilized: {ex.Message}");
+                yield break;
+            }
             yield return null;
 
             // deactSnapshot is set inside the first try and read in the second;
@@ -4117,34 +4271,76 @@ namespace Parsek.InGameTests
 
         [InGameTest(Category = "StrategyLifecycle", Scene = GameScenes.SPACECENTER,
             Description = "#439 Phase A: Activate()=false path (already-active) does NOT emit StrategyActivated (pins the __result==true filter in StrategyLifecyclePatch).")]
-        public void FailedActivation_DoesNotEmitEvent()
+        public IEnumerator FailedActivation_DoesNotEmitEvent()
         {
             if (HighLogic.CurrentGame == null)
             {
                 InGameAssert.Skip("HighLogic.CurrentGame is null");
-                return;
+                yield break;
             }
             if (HighLogic.CurrentGame.Mode != Game.Modes.CAREER)
             {
                 InGameAssert.Skip($"StrategySystem is career-only (mode={HighLogic.CurrentGame.Mode})");
-                return;
+                yield break;
             }
 
-            var system = Strategies.StrategySystem.Instance;
-            if (system == null)
+            for (int i = 0; i < StrategyLifecycleProbeWarmupFrames; i++)
+                yield return null;
+
+            Strategies.Strategy strategy = null;
+            string configName = null;
+            string strategyDiagnostic = null;
+            bool sawProbeException = false;
+            string stableConfigName = null;
+            int stableFrames = 0;
+            for (int attempt = 0; attempt < StrategyLifecycleProbeRetryFrames; attempt++)
             {
-                InGameAssert.Skip("StrategySystem.Instance is null");
-                return;
+                var probe = ProbeActivatableStockStrategy();
+                strategyDiagnostic = probe.Diagnostic;
+                sawProbeException |= probe.HadProbeException;
+                if (probe.Strategy != null)
+                {
+                    if (probe.ConfigName == stableConfigName)
+                        stableFrames++;
+                    else
+                    {
+                        stableConfigName = probe.ConfigName;
+                        stableFrames = 1;
+                    }
+
+                    strategy = probe.Strategy;
+                    configName = probe.ConfigName;
+                    if (stableFrames >= StrategyLifecycleProbeStableFrames)
+                        break;
+
+                    yield return null;
+                    continue;
+                }
+
+                strategy = null;
+                configName = null;
+                stableConfigName = null;
+                stableFrames = 0;
+                if (!probe.ShouldRetry)
+                    break;
+                yield return null;
             }
 
-            var strategy = FindActivatableStockStrategy();
-            if (strategy == null)
+            if (strategy == null || string.IsNullOrEmpty(configName))
             {
-                InGameAssert.Skip("no CanBeActivated-true stock strategy available for testing");
-                return;
+                if (sawProbeException)
+                {
+                    InGameAssert.Fail($"StrategyLifecycle readiness never stabilized: {strategyDiagnostic}");
+                    yield break;
+                }
+                InGameAssert.Skip(strategyDiagnostic);
+                yield break;
             }
 
-            string configName = strategy.Config.Name ?? "";
+            var strategyConfig = strategy.Config;
+            InGameAssert.IsNotNull(strategyConfig, "Selected strategy lost Config after probe");
+            InGameAssert.IsFalse(string.IsNullOrEmpty(strategyConfig.Name),
+                "Selected strategy must have a non-empty Config.Name");
 
             // Snapshot financials — the first (successful) Activate below will
             // spend setup costs that we must restore in teardown.
@@ -4161,18 +4357,41 @@ namespace Parsek.InGameTests
             {
                 // Activate the strategy FIRST so the second Activate hits the
                 // already-active short-circuit and returns false.
-                bool firstActivate = strategy.Activate();
+                for (int i = 0; i < StrategyLifecycleActivateSettleFrames; i++)
+                    yield return null;
+
+                bool firstActivate;
+                try
+                {
+                    firstActivate = strategy.Activate();
+                }
+                catch (System.Exception ex)
+                {
+                    InGameAssert.Fail(
+                        $"Initial Strategy.Activate threw {ex.GetType().Name} for key='{configName}' after readiness stabilized: {ex.Message}");
+                    yield break;
+                }
                 if (!firstActivate)
                 {
                     InGameAssert.Skip("initial Activate returned false — cannot test failed-path filter");
-                    return;
+                    yield break;
                 }
 
                 int eventCountBefore = GameStateStore.EventCount;
 
                 // Second Activate — KSP short-circuits when IsActive is true and
                 // returns false. The postfix should detect __result=false and skip.
-                bool ok = strategy.Activate();
+                bool ok;
+                try
+                {
+                    ok = strategy.Activate();
+                }
+                catch (System.Exception ex)
+                {
+                    InGameAssert.Fail(
+                        $"Second Strategy.Activate threw {ex.GetType().Name} for already-active key='{configName}': {ex.Message}");
+                    yield break;
+                }
                 InGameAssert.IsFalse(ok,
                     "Strategy.Activate should return false when already active");
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -18,7 +18,7 @@ The four top-of-queue correctness fixes (#431, #432, #433, #434) shipped in the 
 
 # Known Bugs
 
-## 480. `FlightIntegrationTests.ActivateAndDeactivate_StockStrategy_EmitsLifecycleEvents` / `FailedActivation_DoesNotEmitEvent` NRE ~2ms into SPACECENTER run on a career save with an activatable stock strategy
+## ~~480. `FlightIntegrationTests.ActivateAndDeactivate_StockStrategy_EmitsLifecycleEvents` / `FailedActivation_DoesNotEmitEvent` NRE ~2ms into SPACECENTER run on a career save with an activatable stock strategy~~
 
 **Source:** `logs/2026-04-19_0123_test-report/parsek-test-results.txt` + `KSP.log:9471-9474`.
 
@@ -47,7 +47,9 @@ Separately: the same save-state shape may make #439 Phase A behaviour unreliable
 
 **Dependencies:** none (the other StrategyLifecycle work is on main already).
 
-**Status:** TODO. Priority: medium — test regression on main, user-visible if the underlying NRE also fires during normal career play.
+**Resolution:** fixed in PR #409 (`issue-480-stock-strategy-lifecycle`). Root cause landed in the test harness: probing stock strategies on the first SPACECENTER frames could catch the strategy system mid-hydration, and the tests also lacked targeted diagnostics around stock `Activate()` itself. The fix adds a bounded readiness/stability probe, rejects nameless configs, and fails loudly if readiness never settles or activation still throws after stabilization.
+
+**Status:** CLOSED. Fixed for v0.8.3.
 
 ---
 


### PR DESCRIPTION
## Summary
- replace the broad catch-and-skip strategy probe with a bounded readiness/stability loop that fails if stock strategy hydration never settles
- add explicit activation diagnostics for both strategy lifecycle in-game tests and reject nameless strategy configs before event/log assertions
- keep the two SPACECENTER strategy lifecycle tests aligned on warmup, probe, and cleanup behavior

## Testing
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter "StrategyCaptureTests|EarningsReconciliationTests"

Closes #480.