### PR TITLE
docs: list KSP Community Fixes in Supported Mods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ All notable changes to Parsek are documented here.
 
 - `#473` The `Gloops - Ghosts Only` group is now treated as a permanent root group in the Recordings window: no disband `X`, stale parent assignments self-heal back to root, and the group stays pinned above every other root item whenever it has recordings.
 
+### Documentation
+
+- README now lists KSP Community Fixes in the Supported Mods table. KCF is fully compatible with Parsek; it replaces the body of `VesselPrecalculate.CalculatePhysicsStats` for performance, and Parsek's recording postfix on the same method composes cleanly.
+
 ### Bug Fixes
 
 - `#470` Funds recalculation no longer logs `FundsSpending: -0, source=Other` for zero-cost replay entries during module walks. The no-op action still participates in affordability/balance tracking; only the useless VERBOSE line is suppressed.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The Parsek window is available from the toolbar button in Flight and Map view.
 | Mod | Integration |
 |-----|-------------|
 | [PersistentRotation](https://github.com/MarkusA380/PersistentRotation) | When detected, Parsek records vessel angular velocity at time warp boundaries. Ghost vessels spin during orbital playback, matching what the player saw with PersistentRotation active. Without it, ghosts hold their SAS-locked attitude (the correct behavior for stock KSP, which freezes rotation on rails). |
+| [KSP Community Fixes](https://github.com/KSPModdingLibs/KSPCommunityFixes) | Fully compatible. KCF's `FlightIntegratorPerf` patch replaces the body of `VesselPrecalculate.CalculatePhysicsStats` for performance; Parsek's recording postfix on the same method composes cleanly on top, so recordings still capture every physics frame. Players running long missions with high part counts benefit from KCF's perf gains and its stock-bug fixes (packed-parts rotation, time-warp orbit drift, memory-leak cleanup). |
 
 ## Installation
 


### PR DESCRIPTION
## Summary

- Adds **KSP Community Fixes** to the `Supported Mods` table in README.md (previously only listed PersistentRotation).
- Adds a matching `### Documentation` entry under 0.8.3 in CHANGELOG.md.

## Why

KCF is widely used and I investigated whether it's safe to run alongside Parsek:

- KCF patches ~180 stock KSP methods (BugFixes / Performance / QoL / Modding).
- Parsek has 20 Harmony patch targets. KCF touches **exactly one** of them: `VesselPrecalculate.CalculatePhysicsStats`.
- KCF uses `PatchType.Override` (transpiler body replacement for perf) on that method; Parsek uses a `Postfix`. Postfixes run after the (now KCF-optimized) body executes, so the per-physics-frame recording hook still fires. No functional conflict.
- The other 19 Parsek targets (`Vessel.GoOffRails/CheckKill`, `CommNetVessel.OnStart`, R&D/tech/facility/strategy/science hooks, all `SpaceTracking.*`, `FlightGlobals.SetActiveVessel`, `Sun.LateUpdate`, etc.) are untouched by KCF.

Players running long recorded missions with high part counts get KCF's perf gains and its stock-bug fixes (packed-parts rotation, time-warp orbit drift, memory-leak cleanup on `OnDestroy`) for free.

## Test plan

- [x] Verify README renders correctly on GitHub (table row formatting)
- [x] `dotnet build` passes (no code changes, should be unaffected)
- [x] With KCF installed, start and commit a recording; verify ghost playback works normally
- [x] Check `KSP.log` for any Harmony conflict warnings when both mods load