### PR TITLE
Fix #466 defer ledger patch until flight tree committed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Parsek are documented here.
 
 ---
 
+## 0.8.3
+
+### Bug Fixes
+
+- `#466` `RecalculateAndPatch` now defers KSP state patching while a live or pending flight tree is still uncommitted, so mid-flight/load-time recalculations no longer snap funds back down to the committed-ledger target and discard paths now explicitly recalculate once the pending tree is gone.
+
+---
+
 ## 0.8.2
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- `#466` `RecalculateAndPatch` now defers KSP state patching while a live, active, or pending flight tree is still uncommitted, so mid-flight/load-time recalculations no longer snap funds back down to the committed-ledger target. Discard paths now explicitly recalculate once the pending tree is gone.
 - `#470` Funds recalculation no longer logs `FundsSpending: -0, source=Other` for zero-cost replay entries during module walks. The no-op action still participates in affordability/balance tracking; only the useless VERBOSE line is suppressed.
 - `#471` Gloops recordings now commit with looping off by default, so fresh ghost-only captures stay idle until you turn looping on and then follow the normal auto loop timing.
 - `#472` Watch-mode camera retargets now preserve the current pitch/heading when follow rebinds to a replacement ghost, eliminating the visible camera jerk on loop/overlap handoffs, quiet-expiry primary rebinds, and stock vessel-switch re-targets.

--- a/Source/Parsek.Tests/LedgerOrchestratorTests.cs
+++ b/Source/Parsek.Tests/LedgerOrchestratorTests.cs
@@ -20,6 +20,8 @@ namespace Parsek.Tests
             KspStatePatcher.SuppressUnityCallsForTesting = true;
             GameStateStore.SuppressLogging = true;
             GameStateStore.ResetForTesting();
+            GameStateRecorder.ResetForTesting();
+            RecordingStore.ResetForTesting();
             LedgerOrchestrator.ResetForTesting();
         }
 
@@ -28,6 +30,8 @@ namespace Parsek.Tests
             LedgerOrchestrator.ResetForTesting();
             KspStatePatcher.ResetForTesting();
             RecordingStore.SuppressLogging = false;
+            RecordingStore.ResetForTesting();
+            GameStateRecorder.ResetForTesting();
             GameStateStore.ResetForTesting();
             ParsekLog.ResetTestOverrides();
             ParsekLog.SuppressLogging = true;
@@ -209,6 +213,103 @@ namespace Parsek.Tests
             Assert.True(LedgerOrchestrator.IsInitialized);
             Assert.Contains(logLines, l =>
                 l.Contains("[LedgerOrchestrator]") && l.Contains("8 modules registered"));
+        }
+
+        [Fact]
+        public void RecalculateAndPatch_WithoutUncommittedTree_DoesNotDeferPatch()
+        {
+            LedgerOrchestrator.Initialize();
+
+            LedgerOrchestrator.RecalculateAndPatch();
+
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("[LedgerOrchestrator]") && l.Contains("deferred KSP state patch"));
+            Assert.Contains(logLines, l =>
+                l.Contains("[KspStatePatcher]") && l.Contains("PatchAll complete"));
+        }
+
+        [Fact]
+        public void RecalculateAndPatch_WithPendingTree_DefersKspStatePatch()
+        {
+            LedgerOrchestrator.Initialize();
+            Ledger.AddAction(new GameAction
+            {
+                UT = 0.0,
+                Type = GameActionType.FundsInitial,
+                InitialFunds = 25000f
+            });
+
+            RecordingStore.StashPendingTree(new RecordingTree
+            {
+                Id = "tree-pending",
+                TreeName = "PendingTree",
+                RootRecordingId = "rec-pending",
+                ActiveRecordingId = "rec-pending"
+            });
+
+            LedgerOrchestrator.RecalculateAndPatch();
+
+            Assert.Equal(25000.0, LedgerOrchestrator.Funds.GetAvailableFunds(), 1);
+            Assert.Contains(logLines, l =>
+                l.Contains("[LedgerOrchestrator]")
+                && l.Contains("deferred KSP state patch")
+                && l.Contains("PendingTree"));
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("[KspStatePatcher]") && l.Contains("PatchAll complete"));
+        }
+
+        [Fact]
+        public void RecalculateAndPatch_WithLiveRecorder_DefersKspStatePatch()
+        {
+            GameStateRecorder.HasLiveRecorderProviderForTesting = () => true;
+            GameStateRecorder.HasActiveUncommittedTreeProviderForTesting = () => true;
+            LedgerOrchestrator.Initialize();
+
+            LedgerOrchestrator.RecalculateAndPatch();
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[LedgerOrchestrator]")
+                && l.Contains("deferred KSP state patch")
+                && l.Contains("live recorder active"));
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("[KspStatePatcher]") && l.Contains("PatchAll complete"));
+        }
+
+        [Fact]
+        public void RecalculateAndPatch_WithActiveOutsiderTree_DefersKspStatePatch()
+        {
+            GameStateRecorder.HasActiveUncommittedTreeProviderForTesting = () => true;
+            GameStateRecorder.HasLiveRecorderProviderForTesting = () => false;
+            LedgerOrchestrator.Initialize();
+
+            LedgerOrchestrator.RecalculateAndPatch();
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[LedgerOrchestrator]")
+                && l.Contains("deferred KSP state patch")
+                && l.Contains("active uncommitted flight tree"));
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("[KspStatePatcher]") && l.Contains("PatchAll complete"));
+        }
+
+        [Fact]
+        public void RecalculateAndPatch_WithUtCutoff_DoesNotDeferPatchForPendingTree()
+        {
+            LedgerOrchestrator.Initialize();
+            RecordingStore.StashPendingTree(new RecordingTree
+            {
+                Id = "tree-cutoff",
+                TreeName = "CutoffTree",
+                RootRecordingId = "rec-cutoff",
+                ActiveRecordingId = "rec-cutoff"
+            });
+
+            LedgerOrchestrator.RecalculateAndPatch(100.0);
+
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("[LedgerOrchestrator]") && l.Contains("deferred KSP state patch"));
+            Assert.Contains(logLines, l =>
+                l.Contains("[KspStatePatcher]") && l.Contains("PatchAll complete"));
         }
 
         // ================================================================

--- a/Source/Parsek.Tests/MergeDialogResourcesAppliedTests.cs
+++ b/Source/Parsek.Tests/MergeDialogResourcesAppliedTests.cs
@@ -261,6 +261,29 @@ namespace Parsek.Tests
             Assert.DoesNotContain(RecordingStore.CommittedTrees, t => t.Id == "tree-discard");
         }
 
+        [Fact]
+        public void MergeDiscard_RecalculatesAfterPendingTreeRemoval()
+        {
+            LedgerOrchestrator.Initialize();
+            Ledger.AddAction(new GameAction
+            {
+                UT = 0.0,
+                Type = GameActionType.FundsInitial,
+                InitialFunds = 25000f
+            });
+
+            var rec = MakeRecording("rec-discard-recalc", "tree-discard-recalc", 100.0, 200.0);
+            var tree = MakeTree("tree-discard-recalc", "rec-discard-recalc", rec);
+            RecordingStore.StashPendingTree(tree);
+
+            MergeDialog.MergeDiscard(tree);
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[KspStatePatcher]") && l.Contains("PatchAll complete"));
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("[LedgerOrchestrator]") && l.Contains("deferred KSP state patch"));
+        }
+
         // ================================================================
         // 5. MergeCommit logs the user-choice INFO line (regression: lambda
         //    extraction must preserve the diagnostic the in-game log relies on)

--- a/Source/Parsek.Tests/ScenarioAutoCommitResourcesAppliedTests.cs
+++ b/Source/Parsek.Tests/ScenarioAutoCommitResourcesAppliedTests.cs
@@ -298,6 +298,17 @@ namespace Parsek.Tests
                 l.Contains("[LedgerOrchestrator]") && l.Contains("deferred KSP state patch"));
         }
 
+        [Fact]
+        public void DiscardPendingTreeAndRecalculate_WithoutPendingTree_IsSilentNoOp()
+        {
+            ParsekScenario.DiscardPendingTreeAndRecalculate("test helper no-op");
+
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("[Scenario]") && l.Contains("DiscardPendingTree recalc path"));
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("[KspStatePatcher]") && l.Contains("PatchAll complete"));
+        }
+
         // ================================================================
         // 5. Determination documented: no post-revert caller should land here
         //    (pinning test — asserts only one production call pattern exists)

--- a/Source/Parsek.Tests/ScenarioAutoCommitResourcesAppliedTests.cs
+++ b/Source/Parsek.Tests/ScenarioAutoCommitResourcesAppliedTests.cs
@@ -46,6 +46,7 @@ namespace Parsek.Tests
 
             RecordingStore.SuppressLogging = true;
             GameStateStore.SuppressLogging = true;
+            KspStatePatcher.SuppressUnityCallsForTesting = true;
             GameStateStore.ResetForTesting();
             MilestoneStore.ResetForTesting();
             RecordingStore.ResetForTesting();
@@ -55,6 +56,7 @@ namespace Parsek.Tests
         public void Dispose()
         {
             LedgerOrchestrator.ResetForTesting();
+            KspStatePatcher.ResetForTesting();
             RecordingStore.ResetForTesting();
             MilestoneStore.ResetForTesting();
             GameStateStore.ResetForTesting();
@@ -270,6 +272,30 @@ namespace Parsek.Tests
             Assert.Equal(2, rec.LastAppliedResourceIndex);
             // But CommitPendingTree was a no-op so committed storage stays empty.
             Assert.DoesNotContain(RecordingStore.CommittedTrees, t => t.Id == "tree-nopending");
+        }
+
+        [Fact]
+        public void DiscardPendingTreeAndRecalculate_RemovesPendingTreeAndRunsPatch()
+        {
+            LedgerOrchestrator.Initialize();
+            Ledger.AddAction(new GameAction
+            {
+                UT = 0.0,
+                Type = GameActionType.FundsInitial,
+                InitialFunds = 25000f
+            });
+
+            var rec = MakeRecording("rec-discard-helper", "tree-discard-helper", 100.0, 200.0);
+            var tree = MakeTree("tree-discard-helper", "rec-discard-helper", rec);
+            RecordingStore.StashPendingTree(tree);
+
+            ParsekScenario.DiscardPendingTreeAndRecalculate("test helper");
+
+            Assert.False(RecordingStore.HasPendingTree);
+            Assert.Contains(logLines, l =>
+                l.Contains("[KspStatePatcher]") && l.Contains("PatchAll complete"));
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("[LedgerOrchestrator]") && l.Contains("deferred KSP state patch"));
         }
 
         // ================================================================

--- a/Source/Parsek/GameActions/LedgerOrchestrator.cs
+++ b/Source/Parsek/GameActions/LedgerOrchestrator.cs
@@ -995,15 +995,28 @@ namespace Parsek
             // EffectiveScience) are populated and before KSP state is patched.
             ReconcilePostWalk(GameStateStore.Events, actions, utCutoff);
 
-            // KSP state mutations (PostWalk already called by engine). Repeatable
-            // Records* nodes only rebuild strictly from ledger-backed thresholds on
-            // rewind-style cutoff walks; normal same-branch recalculations preserve the
-            // live in-tier best value because that finer-grained partial progress is not
-            // persisted in the ledger.
-            kerbalsModule.ApplyToRoster(HighLogic.CurrentGame?.CrewRoster);
-            KspStatePatcher.PatchAll(scienceModule, fundsModule, reputationModule,
-                milestonesModule, facilitiesModule, contractsModule,
-                authoritativeRepeatableRecordState: utCutoff.HasValue);
+            // #466: a live or pending tree means KSP's mutable state may already include
+            // uncommitted in-flight effects that the committed-only ledger cannot see yet.
+            // Walking the committed ledger is still useful, but writing that partial state
+            // back into KSP is destructive. Rewind-style cutoff walks remain authoritative.
+            string patchDeferralReason = GetKspPatchDeferralReason(utCutoff);
+            if (!string.IsNullOrEmpty(patchDeferralReason))
+            {
+                ParsekLog.Verbose(Tag,
+                    $"RecalculateAndPatch: deferred KSP state patch ({patchDeferralReason})");
+            }
+            else
+            {
+                // KSP state mutations (PostWalk already called by engine). Repeatable
+                // Records* nodes only rebuild strictly from ledger-backed thresholds on
+                // rewind-style cutoff walks; normal same-branch recalculations preserve the
+                // live in-tier best value because that finer-grained partial progress is not
+                // persisted in the ledger.
+                kerbalsModule.ApplyToRoster(HighLogic.CurrentGame?.CrewRoster);
+                KspStatePatcher.PatchAll(scienceModule, fundsModule, reputationModule,
+                    milestonesModule, facilitiesModule, contractsModule,
+                    authoritativeRepeatableRecordState: utCutoff.HasValue);
+            }
 
             // #391: rebuild committedScienceSubjects from the walk's authoritative
             // per-subject credits. This prunes stale entries left behind when a
@@ -1016,6 +1029,37 @@ namespace Parsek
                 $"RecalculateAndPatch complete: {actions.Count} actions walked");
 
             OnTimelineDataChanged?.Invoke();
+        }
+
+        private static string GetKspPatchDeferralReason(double? utCutoff)
+        {
+            if (utCutoff.HasValue)
+                return null;
+
+            bool hasActiveUncommittedTree = GameStateRecorder.HasActiveUncommittedTree();
+            bool hasLiveRecorder = GameStateRecorder.HasLiveRecorder();
+            bool hasPendingTree = RecordingStore.HasPendingTree;
+            if (!hasActiveUncommittedTree && !hasPendingTree)
+                return null;
+
+            string reason = null;
+            if (hasLiveRecorder)
+                reason = "live recorder active";
+            else if (hasActiveUncommittedTree)
+                reason = "active uncommitted flight tree";
+
+            if (hasPendingTree)
+            {
+                string treeName = RecordingStore.PendingTree?.TreeName;
+                string pendingReason = string.IsNullOrEmpty(treeName)
+                    ? $"pending tree state={RecordingStore.PendingTreeStateValue}"
+                    : $"pending tree '{treeName}' state={RecordingStore.PendingTreeStateValue}";
+                reason = string.IsNullOrEmpty(reason)
+                    ? pendingReason
+                    : reason + "; " + pendingReason;
+            }
+
+            return reason;
         }
 
         /// <summary>

--- a/Source/Parsek/GameActions/LedgerOrchestrator.cs
+++ b/Source/Parsek/GameActions/LedgerOrchestrator.cs
@@ -1030,15 +1030,28 @@ namespace Parsek
             // EffectiveScience) are populated and before KSP state is patched.
             ReconcilePostWalk(GameStateStore.Events, actions, utCutoff);
 
-            // KSP state mutations (PostWalk already called by engine). Repeatable
-            // Records* nodes only rebuild strictly from ledger-backed thresholds on
-            // rewind-style cutoff walks; normal same-branch recalculations preserve the
-            // live in-tier best value because that finer-grained partial progress is not
-            // persisted in the ledger.
-            kerbalsModule.ApplyToRoster(HighLogic.CurrentGame?.CrewRoster);
-            KspStatePatcher.PatchAll(scienceModule, fundsModule, reputationModule,
-                milestonesModule, facilitiesModule, contractsModule,
-                authoritativeRepeatableRecordState: utCutoff.HasValue);
+            // #466: a live or pending tree means KSP's mutable state may already include
+            // uncommitted in-flight effects that the committed-only ledger cannot see yet.
+            // Walking the committed ledger is still useful, but writing that partial state
+            // back into KSP is destructive. Rewind-style cutoff walks remain authoritative.
+            string patchDeferralReason = GetKspPatchDeferralReason(utCutoff);
+            if (!string.IsNullOrEmpty(patchDeferralReason))
+            {
+                ParsekLog.Verbose(Tag,
+                    $"RecalculateAndPatch: deferred KSP state patch ({patchDeferralReason})");
+            }
+            else
+            {
+                // KSP state mutations (PostWalk already called by engine). Repeatable
+                // Records* nodes only rebuild strictly from ledger-backed thresholds on
+                // rewind-style cutoff walks; normal same-branch recalculations preserve the
+                // live in-tier best value because that finer-grained partial progress is not
+                // persisted in the ledger.
+                kerbalsModule.ApplyToRoster(HighLogic.CurrentGame?.CrewRoster);
+                KspStatePatcher.PatchAll(scienceModule, fundsModule, reputationModule,
+                    milestonesModule, facilitiesModule, contractsModule,
+                    authoritativeRepeatableRecordState: utCutoff.HasValue);
+            }
 
             // #391: rebuild committedScienceSubjects from the walk's authoritative
             // per-subject credits. This prunes stale entries left behind when a
@@ -1051,6 +1064,37 @@ namespace Parsek
                 $"RecalculateAndPatch complete: {actions.Count} actions walked");
 
             OnTimelineDataChanged?.Invoke();
+        }
+
+        private static string GetKspPatchDeferralReason(double? utCutoff)
+        {
+            if (utCutoff.HasValue)
+                return null;
+
+            bool hasActiveUncommittedTree = GameStateRecorder.HasActiveUncommittedTree();
+            bool hasLiveRecorder = GameStateRecorder.HasLiveRecorder();
+            bool hasPendingTree = RecordingStore.HasPendingTree;
+            if (!hasActiveUncommittedTree && !hasPendingTree)
+                return null;
+
+            string reason = null;
+            if (hasLiveRecorder)
+                reason = "live recorder active";
+            else if (hasActiveUncommittedTree)
+                reason = "active uncommitted flight tree";
+
+            if (hasPendingTree)
+            {
+                string treeName = RecordingStore.PendingTree?.TreeName;
+                string pendingReason = string.IsNullOrEmpty(treeName)
+                    ? $"pending tree state={RecordingStore.PendingTreeStateValue}"
+                    : $"pending tree '{treeName}' state={RecordingStore.PendingTreeStateValue}";
+                reason = string.IsNullOrEmpty(reason)
+                    ? pendingReason
+                    : reason + "; " + pendingReason;
+            }
+
+            return reason;
         }
 
         /// <summary>

--- a/Source/Parsek/GameStateRecorder.cs
+++ b/Source/Parsek/GameStateRecorder.cs
@@ -47,6 +47,8 @@ namespace Parsek
         /// Production code never touches it.
         /// </summary>
         internal static System.Func<string> TagResolverForTesting;
+        internal static System.Func<bool> HasLiveRecorderProviderForTesting;
+        internal static System.Func<bool> HasActiveUncommittedTreeProviderForTesting;
 
         /// <summary>
         /// #431: central funnel for every <see cref="GameStateEvent"/> the recorder produces.
@@ -114,11 +116,29 @@ namespace Parsek
         /// #431: true when a flight recorder is currently live on the active tree. Used by
         /// <see cref="Emit"/>'s drift-warn branch to flag "in-flight, should have a tag, doesn't."
         /// </summary>
-        internal static bool HasLiveRecorder() => ParsekFlight.HasLiveRecorderForTagging();
+        internal static bool HasLiveRecorder()
+        {
+            var provider = HasLiveRecorderProviderForTesting;
+            if (provider != null)
+                return provider();
+
+            return ParsekFlight.HasLiveRecorderForTagging();
+        }
+
+        internal static bool HasActiveUncommittedTree()
+        {
+            var provider = HasActiveUncommittedTreeProviderForTesting;
+            if (provider != null)
+                return provider();
+
+            return ParsekFlight.HasUncommittedTreeForKspPatchDeferral();
+        }
 
         internal static void ResetForTesting()
         {
             TagResolverForTesting = null;
+            HasLiveRecorderProviderForTesting = null;
+            HasActiveUncommittedTreeProviderForTesting = null;
             ClearPendingMilestoneEvents("ResetForTesting");
             PendingScienceSubjects.Clear();
             SuppressCrewEvents = false;

--- a/Source/Parsek/MergeDialog.cs
+++ b/Source/Parsek/MergeDialog.cs
@@ -177,7 +177,10 @@ namespace Parsek
                 if (rec.VesselSnapshot != null)
                     CrewReservationManager.UnreserveCrewInSnapshot(rec.VesselSnapshot);
             }
-            RecordingStore.DiscardPendingTree();
+            // #466: while the merge/discard choice is pending, mid-flight effects stay live
+            // in KSP and patching is deferred. Discard must now rebuild from the committed
+            // ledger immediately after the pending tree is removed.
+            ParsekScenario.DiscardPendingTreeAndRecalculate("merge dialog discard");
             ClearPendingFlag();
             ParsekLog.ScreenMessage("Recording discarded", 2f);
             ParsekLog.Info("MergeDialog",

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -1556,27 +1556,16 @@ namespace Parsek
             ParsekLog.Info("Flight",
                 $"ShowPostDestructionTreeMergeDialog: stashed pending tree '{activeTree.TreeName}'");
 
+            string autoDiscardReason = null;
             // Auto-discard pad failures: if every recording in the tree is a pad failure
             // (< 10s duration AND < 30m from launch), discard the whole tree.
             // Also discard if every recording is idle-on-pad (< 30m, any duration).
             if (IsTreePadFailure(activeTree) || IsTreeIdleOnPad(activeTree))
             {
-                string reason = IsTreePadFailure(activeTree) ? "pad failure" : "idle on pad";
+                autoDiscardReason = IsTreePadFailure(activeTree) ? "pad failure" : "idle on pad";
                 ParsekLog.Info("Flight",
-                    $"ShowPostDestructionTreeMergeDialog: tree {reason} — auto-discarding");
-                ScreenMessage($"Recording discarded - {reason}", 3f);
-                RecordingStore.DiscardPendingTree();
-                // Clean up flight state
-                recorder = null;
-                if (backgroundRecorder != null)
-                {
-                    backgroundRecorder.Shutdown();
-                    Patches.PhysicsFramePatch.BackgroundRecorderInstance = null;
-                    backgroundRecorder = null;
-                }
-                activeTree = null;
-                treeDestructionDialogPending = false;
-                yield break;
+                    $"ShowPostDestructionTreeMergeDialog: tree {autoDiscardReason} — auto-discarding");
+                ScreenMessage($"Recording discarded - {autoDiscardReason}", 3f);
             }
 
             // Clean up flight state
@@ -1589,6 +1578,13 @@ namespace Parsek
             }
             activeTree = null;
             treeDestructionDialogPending = false;
+
+            if (!string.IsNullOrEmpty(autoDiscardReason))
+            {
+                ParsekScenario.DiscardPendingTreeAndRecalculate(
+                    $"post-destruction {autoDiscardReason} auto-discard");
+                yield break;
+            }
 
             // #434: do NOT show the in-flight merge dialog or commit via auto-merge here.
             // The tree is stashed; the stock KSP crash report shows first (with Revert /

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -43,6 +43,16 @@ namespace Parsek
         internal static bool HasLiveRecorderForTagging()
             => Instance != null && Instance.activeTree != null && Instance.recorder != null && Instance.recorder.IsRecording;
 
+        /// <summary>
+        /// #466: returns true whenever the flight scene is carrying an uncommitted tree,
+        /// including outsider-state restores where <see cref="recorder"/> is intentionally
+        /// null until the player returns to a tracked vessel.
+        /// </summary>
+        internal static bool HasUncommittedTreeForKspPatchDeferral()
+            => Instance != null
+                && Instance.activeTree != null
+                && !RecordingStore.CommittedTrees.Contains(Instance.activeTree);
+
         internal const string MODID = "Parsek_NS";
         internal const string MODNAME = "Parsek";
 

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -153,6 +153,20 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Discards a pending tree after its live effects have already been allowed to stay
+        /// in KSP (for example while waiting on a merge/discard decision), then immediately
+        /// rebuilds state from the committed ledger.
+        /// </summary>
+        internal static void DiscardPendingTreeAndRecalculate(string reason)
+        {
+            bool hadPendingTree = RecordingStore.HasPendingTree;
+            ParsekLog.Verbose("Scenario", $"DiscardPendingTree recalc path: {reason}");
+            RecordingStore.DiscardPendingTree();
+            if (hadPendingTree)
+                LedgerOrchestrator.RecalculateAndPatch();
+        }
+
+        /// <summary>
         /// #434 follow-up: dispatch-level guard that decides whether the OnLoad
         /// quickload-discard branch should fire. Pure function of the three
         /// classification bits so it can be unit-tested in isolation — the
@@ -1366,7 +1380,8 @@ namespace Parsek
                     if (ParsekFlight.IsTreeIdleOnPad(RecordingStore.PendingTree))
                     {
                         ScenarioLog("[Parsek Scenario] Idle on pad — auto-discarding pending tree");
-                        RecordingStore.DiscardPendingTree();
+                        DiscardPendingTreeAndRecalculate(
+                            "outside-flight idle-on-pad auto-discard");
                     }
 
                     if (IsAutoMerge || HighLogic.LoadedScene == GameScenes.MAINMENU)
@@ -2396,7 +2411,8 @@ namespace Parsek
             if (ParsekFlight.IsTreeIdleOnPad(RecordingStore.PendingTree))
             {
                 ParsekLog.Info("Scenario", "Idle on pad detected — auto-discarding tree recording");
-                RecordingStore.DiscardPendingTree();
+                DiscardPendingTreeAndRecalculate(
+                    "deferred merge dialog idle-on-pad auto-discard");
                 ScreenMessages.PostScreenMessage("Recording discarded - vessel idle on pad", 4f);
                 mergeDialogPending = false;
                 yield break;

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -159,11 +159,12 @@ namespace Parsek
         /// </summary>
         internal static void DiscardPendingTreeAndRecalculate(string reason)
         {
-            bool hadPendingTree = RecordingStore.HasPendingTree;
+            if (!RecordingStore.HasPendingTree)
+                return;
+
             ParsekLog.Verbose("Scenario", $"DiscardPendingTree recalc path: {reason}");
             RecordingStore.DiscardPendingTree();
-            if (hadPendingTree)
-                LedgerOrchestrator.RecalculateAndPatch();
+            LedgerOrchestrator.RecalculateAndPatch();
         }
 
         /// <summary>
@@ -1210,7 +1211,8 @@ namespace Parsek
                             if (RecordingStore.HasPendingTree && ParsekFlight.IsTreeIdleOnPad(RecordingStore.PendingTree))
                             {
                                 ParsekLog.Info("Scenario", "Idle on pad at scene exit — auto-discarding tree");
-                                RecordingStore.DiscardPendingTree();
+                                DiscardPendingTreeAndRecalculate(
+                                    "scene-exit idle-on-pad auto-discard");
                             }
 
                             bool anythingLeft = RecordingStore.HasPendingTree;

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -453,7 +453,7 @@ Similar care needed for `FundsThreshold = 100.0` and `ScienceThreshold = 1.0` �
 
 ---
 
-## 466. `RecalculateAndPatch` runs mid-flight with an incomplete ledger, patches funds DOWN to the pre-milestone target and destroys in-progress earnings
+## ~~466. `RecalculateAndPatch` runs mid-flight with an incomplete ledger, patches funds DOWN to the pre-milestone target and destroys in-progress earnings~~
 
 **Source:** `logs/2026-04-19_0049_career-ledger/KSP.log:9993`.
 
@@ -470,12 +470,7 @@ A subsequent recalc at `:10134` with `actionsTotal=12` (post-commit) computes th
 
 **User-visible:** player earns milestones in flight (visible in game UI), then on scene transition / quickload the funds snap back to a lower value. This is the "ledger/resource recalculation did not really work correctly" the reporter is describing.
 
-**Fix:** two layered fixes, both probably needed:
-
-1. **Gate `RecalculateAndPatch` on "no mid-flight uncommitted tree"**. If a tree is actively accumulating but not yet committed, defer `PatchFunds` / `PatchScience` / `PatchReputation` until commit. Policy: recalc still walks the known-committed ledger (updates in-memory balances), but the KSP patch step is skipped with a VERBOSE log `Deferred patch: uncommitted tree active`. Alternative: include provisional/pending-tree actions in the walk so the target reflects the in-flight work.
-2. **Harden `IsSuspiciousDrawdown` into an abort, not just a log**. When the drawdown exceeds the threshold AND the ledger has a known uncommitted tree (or provisional FundsChanged events within the last recalc window), refuse to patch — no `AddFunds(-36800)` call, just a WARN. This keeps the design flexibility of patching down for legitimate revert/rewind paths (where a stale ledger is *supposed* to reset), but blocks the destructive case.
-
-Fix 1 is preferred — prevention over detection. Fix 2 is a safety net for paths that can't be gated cleanly (OnLoad from save, cross-session resume).
+**Fix:** shipped. `LedgerOrchestrator.RecalculateAndPatch` now still walks the committed ledger but defers the KSP write-back step whenever there is a live recorder or pending tree and the walk is a normal non-cutoff pass. That keeps in-flight / pending-tree earnings live in KSP until the tree is either committed or discarded, while rewind-style cutoff walks remain authoritative. `MergeDialog.MergeDiscard` and the deferred merge-dialog idle-on-pad auto-discard path now trigger an immediate recalculation after the pending tree is removed so a discard still cleanly tears those live effects back out.
 
 Add a cross-reference: `#439`, `#440`, `#448` and the already-archived post-#307 reconciliation work all touched adjacent logic. Re-read `done/todo-and-known-bugs-v3.md` entries for those before writing the fix — the reason several drawdown WARNs were *kept* log-only was a prior bug where aborting the patch masked a different class of problem. Don't regress that.
 
@@ -485,7 +480,7 @@ Add a cross-reference: `#439`, `#440`, `#448` and the already-archived post-#307
 
 **Dependencies:** read the #307/#439/#440 history first. Fix should land before / alongside #469 since the reconcile warnings mostly disappear once the patch gate prevents the stale-target state from ever being written.
 
-**Status:** TODO. Priority: **critical** — silently destroys earned player funds. Reproducible in ~3 minutes in career mode with any launch that completes milestones, as the collected log shows three occurrences in one 10-minute session.
+**Status:** Fixed in `0.8.3`. Priority was **critical** — now closed. The suspicious-drawdown WARN stays log-only for genuine rewind/reset paths, but the destructive "uncommitted tree patched back to committed-ledger funds" case is blocked at the orchestrator layer before `PatchFunds` runs.
 
 ---
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -408,7 +408,7 @@ Similar care needed for `FundsThreshold = 100.0` and `ScienceThreshold = 1.0` �
 
 ---
 
-## 466. `RecalculateAndPatch` runs mid-flight with an incomplete ledger, patches funds DOWN to the pre-milestone target and destroys in-progress earnings
+## ~~466. `RecalculateAndPatch` runs mid-flight with an incomplete ledger, patches funds DOWN to the pre-milestone target and destroys in-progress earnings~~
 
 **Source:** `logs/2026-04-19_0049_career-ledger/KSP.log:9993`.
 
@@ -425,12 +425,7 @@ A subsequent recalc at `:10134` with `actionsTotal=12` (post-commit) computes th
 
 **User-visible:** player earns milestones in flight (visible in game UI), then on scene transition / quickload the funds snap back to a lower value. This is the "ledger/resource recalculation did not really work correctly" the reporter is describing.
 
-**Fix:** two layered fixes, both probably needed:
-
-1. **Gate `RecalculateAndPatch` on "no mid-flight uncommitted tree"**. If a tree is actively accumulating but not yet committed, defer `PatchFunds` / `PatchScience` / `PatchReputation` until commit. Policy: recalc still walks the known-committed ledger (updates in-memory balances), but the KSP patch step is skipped with a VERBOSE log `Deferred patch: uncommitted tree active`. Alternative: include provisional/pending-tree actions in the walk so the target reflects the in-flight work.
-2. **Harden `IsSuspiciousDrawdown` into an abort, not just a log**. When the drawdown exceeds the threshold AND the ledger has a known uncommitted tree (or provisional FundsChanged events within the last recalc window), refuse to patch — no `AddFunds(-36800)` call, just a WARN. This keeps the design flexibility of patching down for legitimate revert/rewind paths (where a stale ledger is *supposed* to reset), but blocks the destructive case.
-
-Fix 1 is preferred — prevention over detection. Fix 2 is a safety net for paths that can't be gated cleanly (OnLoad from save, cross-session resume).
+**Fix:** shipped. `LedgerOrchestrator.RecalculateAndPatch` now still walks the committed ledger but defers the KSP write-back step whenever there is a live recorder or pending tree and the walk is a normal non-cutoff pass. That keeps in-flight / pending-tree earnings live in KSP until the tree is either committed or discarded, while rewind-style cutoff walks remain authoritative. `MergeDialog.MergeDiscard` and the deferred merge-dialog idle-on-pad auto-discard path now trigger an immediate recalculation after the pending tree is removed so a discard still cleanly tears those live effects back out.
 
 Add a cross-reference: `#439`, `#440`, `#448` and the already-archived post-#307 reconciliation work all touched adjacent logic. Re-read `done/todo-and-known-bugs-v3.md` entries for those before writing the fix — the reason several drawdown WARNs were *kept* log-only was a prior bug where aborting the patch masked a different class of problem. Don't regress that.
 
@@ -440,7 +435,7 @@ Add a cross-reference: `#439`, `#440`, `#448` and the already-archived post-#307
 
 **Dependencies:** read the #307/#439/#440 history first. Fix should land before / alongside #469 since the reconcile warnings mostly disappear once the patch gate prevents the stale-target state from ever being written.
 
-**Status:** TODO. Priority: **critical** — silently destroys earned player funds. Reproducible in ~3 minutes in career mode with any launch that completes milestones, as the collected log shows three occurrences in one 10-minute session.
+**Status:** Fixed in `0.8.3`. Priority was **critical** — now closed. The suspicious-drawdown WARN stays log-only for genuine rewind/reset paths, but the destructive "uncommitted tree patched back to committed-ledger funds" case is blocked at the orchestrator layer before `PatchFunds` runs.
 
 ---
 


### PR DESCRIPTION
## Summary
- Defers `RecalculateAndPatch` so it no longer runs mid-flight against an incomplete ledger; patches now wait until the flight tree is committed, preventing funds from being patched DOWN to a pre-milestone target and destroying in-progress earnings.

Closes #466 (internal; see `docs/dev/todo-and-known-bugs.md`).

## Test plan
- [ ] Unit coverage for deferred patch timing.
- [ ] In-KSP career playtest confirms mid-flight milestones no longer lose in-progress funds.