### PR TITLE
Fix #468 widen science transmission reconcile window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to Parsek are documented here.
 - `#475` Mun-end ghost spawns now use endpoint-aligned body/orbit data after rewind, and load heals stale cached terminal orbit bodies from older saves.
 - `#476` Post-walk and commit-time earnings reconciliation now skip sandbox / tracker-unavailable resource legs instead of comparing against zeroed stock stores. When funds, science, and reputation tracking are all unavailable, Parsek emits a one-shot VERBOSE skip line instead of flooding `KSP.log` with false `store delta=0.0` and `no matching event` WARNs.
 - `#477` Post-walk milestone reconciliation now compares coalesced `Progression` bursts once per window instead of attributing the summed funds/rep delta to each individual `MilestoneAchievement`. Same-UT milestone bursts now log grouped ids/counts, eliminating the misleading 2× / 3× `expected=` warnings while preserving correct aggregate matching.
+- `#468` Post-walk science reconciliation now matches `ScienceTransmission` across the owning recording span for end-anchored committed `ScienceEarning` rows.
 - `#479` Stable-terminal finalize re-snapshots now normalize unsafe cached `sit` values on the fresh `BackupVessel()` snapshot before persisting it, so one-frame situation lag no longer leaves `FLYING` / `SUB_ORBITAL` in landed, splashed, or orbiting sidecars.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Parsek are documented here.
 
 ---
 
+## 0.8.3
+
+### Bug Fixes
+
+- `#468` Post-walk science reconciliation now matches `ScienceTransmission` deltas across the owning recording window when a committed `ScienceEarning` is still end-anchored to commit/recovery UT, eliminating the false WARN spam from flights that transmit science before recovery.
+
 ## 0.8.2
 
 ### Features

--- a/Source/Parsek.Tests/EarningsReconciliationTests.cs
+++ b/Source/Parsek.Tests/EarningsReconciliationTests.cs
@@ -2071,6 +2071,171 @@ namespace Parsek.Tests
             Assert.DoesNotContain(logLines, l => l.Contains("Earnings reconciliation (post-walk, sci)"));
         }
 
+        [Fact]
+        public void PostWalk_ScienceEarning_EndAnchoredCommit_MatchesEarlierTransmissionWindow_NoWarn()
+        {
+            // #468: the committed ScienceEarning stays anchored at recording end/recovery
+            // UT, but the paired ScienceTransmission events were emitted earlier in flight.
+            var events = new List<GameStateEvent>
+            {
+                MakeKeyedScienceChanged(39.8, 0.0, 5.5, "ScienceTransmission", recordingId: "rec_sci_window"),
+                MakeKeyedScienceChanged(66.3, 5.5, 11.0, "ScienceTransmission", recordingId: "rec_sci_window")
+            };
+            var action = new GameAction
+            {
+                UT = 204.4,
+                Type = GameActionType.ScienceEarning,
+                RecordingId = "rec_sci_window",
+                SubjectId = "mysteryGoo@KerbinSrfLandedLaunchPad",
+                Effective = true,
+                ScienceAwarded = 11.0f,
+                EffectiveScience = 11.0f,
+                StartUT = 10.0f,
+                EndUT = 204.4f
+            };
+            var actions = new List<GameAction> { action };
+
+            LedgerOrchestrator.ReconcilePostWalk(events, actions, utCutoff: null);
+
+            Assert.DoesNotContain(logLines, l => l.Contains("Earnings reconciliation (post-walk, sci)"));
+        }
+
+        [Fact]
+        public void PostWalk_ScienceEarning_EndAnchoredCommit_LargeUtFloatSpanStillMatchesEarlierTransmissionWindow_NoWarn()
+        {
+            // Reviewer follow-up: ScienceEarning spans round-trip through float fields.
+            // At large UTs, the stored EndUT drifts from the double-backed action.UT by
+            // more than 0.1s, so both the end-anchor gate and the widened window
+            // boundaries must allow float quantization loss.
+            const double actionUt = 10000000.4;
+
+            var events = new List<GameStateEvent>
+            {
+                MakeKeyedScienceChanged(9999950.0, 0.0, 5.5, "ScienceTransmission", recordingId: "rec_sci_window_large_ut"),
+                MakeKeyedScienceChanged(10000000.35, 5.5, 11.0, "ScienceTransmission", recordingId: "rec_sci_window_large_ut")
+            };
+            var action = new GameAction
+            {
+                UT = actionUt,
+                Type = GameActionType.ScienceEarning,
+                RecordingId = "rec_sci_window_large_ut",
+                SubjectId = "mysteryGoo@KerbinSrfLandedLaunchPad",
+                Effective = true,
+                ScienceAwarded = 11.0f,
+                EffectiveScience = 11.0f,
+                StartUT = 9999900.0f,
+                EndUT = (float)actionUt
+            };
+            Assert.NotEqual(actionUt, (double)action.EndUT);
+
+            LedgerOrchestrator.ReconcilePostWalk(events, new List<GameAction> { action }, utCutoff: null);
+
+            Assert.DoesNotContain(logLines, l => l.Contains("Earnings reconciliation (post-walk, sci)"));
+        }
+
+        [Fact]
+        public void PostWalk_ScienceEarning_AndMilestoneAchievement_SameUtNeighborhood_DoNotCrossCoalesce()
+        {
+            var events = new List<GameStateEvent>
+            {
+                MakeKeyedScienceChanged(39.8, 0.0, 5.5, "ScienceTransmission", recordingId: "rec_mix"),
+                MakeKeyedScienceChanged(66.3, 5.5, 11.0, "ScienceTransmission", recordingId: "rec_mix"),
+                MakeKeyedScienceChanged(204.45, 11.0, 14.0, "Progression", recordingId: "rec_mix")
+            };
+            var actions = new List<GameAction>
+            {
+                new GameAction
+                {
+                    UT = 204.4,
+                    Type = GameActionType.ScienceEarning,
+                    RecordingId = "rec_mix",
+                    SubjectId = "mysteryGoo@KerbinSrfLandedLaunchPad",
+                    Effective = true,
+                    ScienceAwarded = 11.0f,
+                    EffectiveScience = 11.0f,
+                    StartUT = 10.0f,
+                    EndUT = 204.4f
+                },
+                new GameAction
+                {
+                    UT = 204.45,
+                    Type = GameActionType.MilestoneAchievement,
+                    RecordingId = "rec_mix",
+                    MilestoneId = "Kerbin/Escape",
+                    Effective = true,
+                    MilestoneScienceAwarded = 3.0f
+                }
+            };
+
+            LedgerOrchestrator.ReconcilePostWalk(events, actions, utCutoff: null);
+
+            Assert.DoesNotContain(logLines, l => l.Contains("Earnings reconciliation (post-walk, sci)"));
+
+            var scienceMatches = logLines.FindAll(l =>
+                l.Contains("Post-walk match: ScienceEarning sci"));
+            var milestoneMatches = logLines.FindAll(l =>
+                l.Contains("Post-walk match: MilestoneAchievement sci"));
+
+            Assert.Single(scienceMatches);
+            Assert.Single(milestoneMatches);
+            Assert.Contains("within recording window [10.0,204.4]", scienceMatches[0]);
+            Assert.Contains("id=mysteryGoo@KerbinSrfLandedLaunchPad", scienceMatches[0]);
+            Assert.Contains("within 0.1s of ut=204.4", milestoneMatches[0]);
+            Assert.Contains("id=Kerbin/Escape", milestoneMatches[0]);
+        }
+
+        [Fact]
+        public void PostWalk_ScienceEarning_EndAnchoredCommit_MultiSubjectRecording_CoalescesOnce()
+        {
+            var events = new List<GameStateEvent>
+            {
+                MakeKeyedScienceChanged(39.8, 0.0, 5.5, "ScienceTransmission", recordingId: "rec_multi_subject"),
+                MakeKeyedScienceChanged(66.3, 5.5, 11.0, "ScienceTransmission", recordingId: "rec_multi_subject"),
+                MakeKeyedScienceChanged(80.0, 11.0, 15.0, "ScienceTransmission", recordingId: "rec_multi_subject")
+            };
+            var actions = new List<GameAction>
+            {
+                new GameAction
+                {
+                    UT = 204.4,
+                    Type = GameActionType.ScienceEarning,
+                    RecordingId = "rec_multi_subject",
+                    SubjectId = "mysteryGoo@KerbinSrfLandedLaunchPad",
+                    Effective = true,
+                    ScienceAwarded = 11.0f,
+                    EffectiveScience = 11.0f,
+                    StartUT = 10.0f,
+                    EndUT = 204.4f
+                },
+                new GameAction
+                {
+                    UT = 204.4,
+                    Type = GameActionType.ScienceEarning,
+                    RecordingId = "rec_multi_subject",
+                    SubjectId = "crewReport@KerbinSrfLandedLaunchPad",
+                    Effective = true,
+                    ScienceAwarded = 4.0f,
+                    EffectiveScience = 4.0f,
+                    StartUT = 10.0f,
+                    EndUT = 204.4f
+                }
+            };
+
+            LedgerOrchestrator.ReconcilePostWalk(events, actions, utCutoff: null);
+
+            Assert.DoesNotContain(logLines, l => l.Contains("Earnings reconciliation (post-walk, sci)"));
+
+            var scienceMatches = logLines.FindAll(l =>
+                l.Contains("Post-walk match: ScienceEarning sci"));
+
+            Assert.Single(scienceMatches);
+            Assert.Contains(
+                "ids=[mysteryGoo@KerbinSrfLandedLaunchPad, crewReport@KerbinSrfLandedLaunchPad] across 2 action(s)",
+                scienceMatches[0]);
+            Assert.Contains("expected=15.0, observed=15.0", scienceMatches[0]);
+            Assert.Contains("within recording window [10.0,204.4]", scienceMatches[0]);
+        }
+
         // ---------- utCutoff ----------
 
         [Fact]

--- a/Source/Parsek.Tests/EarningsReconciliationTests.cs
+++ b/Source/Parsek.Tests/EarningsReconciliationTests.cs
@@ -1808,6 +1808,68 @@ namespace Parsek.Tests
             Assert.DoesNotContain(logLines, l => l.Contains("Earnings reconciliation (post-walk, sci)"));
         }
 
+        [Fact]
+        public void PostWalk_ScienceEarning_EndAnchoredCommit_MatchesEarlierTransmissionWindow_NoWarn()
+        {
+            // #468: the committed ScienceEarning stays anchored at recording end/recovery
+            // UT, but the paired ScienceTransmission events were emitted earlier in flight.
+            var events = new List<GameStateEvent>
+            {
+                MakeKeyedScienceChanged(39.8, 0.0, 5.5, "ScienceTransmission"),
+                MakeKeyedScienceChanged(66.3, 5.5, 11.0, "ScienceTransmission")
+            };
+            var action = new GameAction
+            {
+                UT = 204.4,
+                Type = GameActionType.ScienceEarning,
+                RecordingId = "rec_sci_window",
+                SubjectId = "mysteryGoo@KerbinSrfLandedLaunchPad",
+                Effective = true,
+                ScienceAwarded = 11.0f,
+                EffectiveScience = 11.0f,
+                StartUT = 10.0f,
+                EndUT = 204.4f
+            };
+            var actions = new List<GameAction> { action };
+
+            LedgerOrchestrator.ReconcilePostWalk(events, actions, utCutoff: null);
+
+            Assert.DoesNotContain(logLines, l => l.Contains("Earnings reconciliation (post-walk, sci)"));
+        }
+
+        [Fact]
+        public void PostWalk_ScienceEarning_EndAnchoredCommit_LargeUtFloatSpanStillMatchesEarlierTransmissionWindow_NoWarn()
+        {
+            // Reviewer follow-up: ScienceEarning spans round-trip through float fields.
+            // At large UTs, the stored EndUT drifts from the double-backed action.UT by
+            // more than 0.1s, so both the end-anchor gate and the widened window
+            // boundaries must allow float quantization loss.
+            const double actionUt = 10000000.4;
+
+            var events = new List<GameStateEvent>
+            {
+                MakeKeyedScienceChanged(9999950.0, 0.0, 5.5, "ScienceTransmission"),
+                MakeKeyedScienceChanged(10000000.35, 5.5, 11.0, "ScienceTransmission")
+            };
+            var action = new GameAction
+            {
+                UT = actionUt,
+                Type = GameActionType.ScienceEarning,
+                RecordingId = "rec_sci_window_large_ut",
+                SubjectId = "mysteryGoo@KerbinSrfLandedLaunchPad",
+                Effective = true,
+                ScienceAwarded = 11.0f,
+                EffectiveScience = 11.0f,
+                StartUT = 9999900.0f,
+                EndUT = (float)actionUt
+            };
+            Assert.NotEqual(actionUt, (double)action.EndUT);
+
+            LedgerOrchestrator.ReconcilePostWalk(events, new List<GameAction> { action }, utCutoff: null);
+
+            Assert.DoesNotContain(logLines, l => l.Contains("Earnings reconciliation (post-walk, sci)"));
+        }
+
         // ---------- utCutoff ----------
 
         [Fact]

--- a/Source/Parsek.Tests/GameActionSerializationTests.cs
+++ b/Source/Parsek.Tests/GameActionSerializationTests.cs
@@ -61,7 +61,9 @@ namespace Parsek.Tests
                 ScienceAwarded = 2.4f,
                 Method = ScienceMethod.Transmitted,
                 TransmitScalar = 0.3f,
-                SubjectMaxValue = 8.0f
+                SubjectMaxValue = 8.0f,
+                StartUT = 17500.0f,
+                EndUT = 18000.0f
             };
 
             var result = RoundTrip(original);
@@ -69,6 +71,8 @@ namespace Parsek.Tests
             Assert.Equal(ScienceMethod.Transmitted, result.Method);
             Assert.Equal(0.3f, result.TransmitScalar);
             Assert.Equal(2.4f, result.ScienceAwarded);
+            Assert.Equal(17500.0f, result.StartUT);
+            Assert.Equal(18000.0f, result.EndUT);
         }
 
         [Fact]

--- a/Source/Parsek.Tests/GameStateEventConverterTests.cs
+++ b/Source/Parsek.Tests/GameStateEventConverterTests.cs
@@ -419,7 +419,7 @@ namespace Parsek.Tests
                 new PendingScienceSubject { subjectId = "evaReport@MunSrfLandedMidlands", science = 8.0f },
             };
 
-            var actions = GameStateEventConverter.ConvertScienceSubjects(subjects, "rec", 1000.0);
+            var actions = GameStateEventConverter.ConvertScienceSubjects(subjects, "rec", 900.0, 1000.0);
 
             Assert.Equal(2, actions.Count);
             Assert.Equal(GameActionType.ScienceEarning, actions[0].Type);
@@ -427,6 +427,8 @@ namespace Parsek.Tests
             Assert.Equal(5.0f, actions[0].ScienceAwarded);
             Assert.Equal(1000.0, actions[0].UT);
             Assert.Equal("rec", actions[0].RecordingId);
+            Assert.Equal(900.0f, actions[0].StartUT);
+            Assert.Equal(1000.0f, actions[0].EndUT);
         }
 
         [Fact]
@@ -438,7 +440,7 @@ namespace Parsek.Tests
                 new PendingScienceSubject { subjectId = "valid@subject", science = 3.0f },
             };
 
-            var actions = GameStateEventConverter.ConvertScienceSubjects(subjects, "rec", 100.0);
+            var actions = GameStateEventConverter.ConvertScienceSubjects(subjects, "rec", 50.0, 100.0);
 
             Assert.Single(actions);
             Assert.Equal("valid@subject", actions[0].SubjectId);
@@ -453,7 +455,7 @@ namespace Parsek.Tests
                 new PendingScienceSubject { subjectId = "negative@subject", science = -1.0f },
             };
 
-            var actions = GameStateEventConverter.ConvertScienceSubjects(subjects, "rec", 100.0);
+            var actions = GameStateEventConverter.ConvertScienceSubjects(subjects, "rec", 50.0, 100.0);
 
             Assert.Empty(actions);
         }
@@ -461,7 +463,7 @@ namespace Parsek.Tests
         [Fact]
         public void ConvertScienceSubjects_NullList_ReturnsEmpty()
         {
-            var actions = GameStateEventConverter.ConvertScienceSubjects(null, "rec", 100.0);
+            var actions = GameStateEventConverter.ConvertScienceSubjects(null, "rec", 50.0, 100.0);
             Assert.Empty(actions);
         }
 
@@ -546,7 +548,7 @@ namespace Parsek.Tests
                 new PendingScienceSubject { subjectId = "temperatureScan@KerbinFlyingLow", science = 3.0f },
             };
 
-            var actions = GameStateEventConverter.ConvertScienceSubjects(subjects, "rec", 1000.0);
+            var actions = GameStateEventConverter.ConvertScienceSubjects(subjects, "rec", 900.0, 1000.0);
 
             Assert.Equal(3, actions.Count);
             Assert.Equal(1, actions[0].Sequence);
@@ -565,7 +567,7 @@ namespace Parsek.Tests
                 new PendingScienceSubject { subjectId = "valid2@subject", science = 8.0f },
             };
 
-            var actions = GameStateEventConverter.ConvertScienceSubjects(subjects, "rec", 1000.0);
+            var actions = GameStateEventConverter.ConvertScienceSubjects(subjects, "rec", 900.0, 1000.0);
 
             Assert.Equal(2, actions.Count);
             Assert.Equal(1, actions[0].Sequence);
@@ -581,7 +583,7 @@ namespace Parsek.Tests
                 new PendingScienceSubject { subjectId = "evaReport@MunSrfLanded", science = 8.0f, subjectMaxValue = 24.0f },
             };
 
-            var actions = GameStateEventConverter.ConvertScienceSubjects(subjects, "rec", 1000.0);
+            var actions = GameStateEventConverter.ConvertScienceSubjects(subjects, "rec", 900.0, 1000.0);
 
             Assert.Equal(2, actions.Count);
             Assert.Equal(10.0f, actions[0].SubjectMaxValue);

--- a/Source/Parsek.Tests/GameStateEventConverterTests.cs
+++ b/Source/Parsek.Tests/GameStateEventConverterTests.cs
@@ -385,7 +385,7 @@ namespace Parsek.Tests
                 new PendingScienceSubject { subjectId = "evaReport@MunSrfLandedMidlands", science = 8.0f },
             };
 
-            var actions = GameStateEventConverter.ConvertScienceSubjects(subjects, "rec", 1000.0);
+            var actions = GameStateEventConverter.ConvertScienceSubjects(subjects, "rec", 900.0, 1000.0);
 
             Assert.Equal(2, actions.Count);
             Assert.Equal(GameActionType.ScienceEarning, actions[0].Type);
@@ -393,6 +393,8 @@ namespace Parsek.Tests
             Assert.Equal(5.0f, actions[0].ScienceAwarded);
             Assert.Equal(1000.0, actions[0].UT);
             Assert.Equal("rec", actions[0].RecordingId);
+            Assert.Equal(900.0f, actions[0].StartUT);
+            Assert.Equal(1000.0f, actions[0].EndUT);
         }
 
         [Fact]
@@ -404,7 +406,7 @@ namespace Parsek.Tests
                 new PendingScienceSubject { subjectId = "valid@subject", science = 3.0f },
             };
 
-            var actions = GameStateEventConverter.ConvertScienceSubjects(subjects, "rec", 100.0);
+            var actions = GameStateEventConverter.ConvertScienceSubjects(subjects, "rec", 50.0, 100.0);
 
             Assert.Single(actions);
             Assert.Equal("valid@subject", actions[0].SubjectId);
@@ -419,7 +421,7 @@ namespace Parsek.Tests
                 new PendingScienceSubject { subjectId = "negative@subject", science = -1.0f },
             };
 
-            var actions = GameStateEventConverter.ConvertScienceSubjects(subjects, "rec", 100.0);
+            var actions = GameStateEventConverter.ConvertScienceSubjects(subjects, "rec", 50.0, 100.0);
 
             Assert.Empty(actions);
         }
@@ -427,7 +429,7 @@ namespace Parsek.Tests
         [Fact]
         public void ConvertScienceSubjects_NullList_ReturnsEmpty()
         {
-            var actions = GameStateEventConverter.ConvertScienceSubjects(null, "rec", 100.0);
+            var actions = GameStateEventConverter.ConvertScienceSubjects(null, "rec", 50.0, 100.0);
             Assert.Empty(actions);
         }
 
@@ -512,7 +514,7 @@ namespace Parsek.Tests
                 new PendingScienceSubject { subjectId = "temperatureScan@KerbinFlyingLow", science = 3.0f },
             };
 
-            var actions = GameStateEventConverter.ConvertScienceSubjects(subjects, "rec", 1000.0);
+            var actions = GameStateEventConverter.ConvertScienceSubjects(subjects, "rec", 900.0, 1000.0);
 
             Assert.Equal(3, actions.Count);
             Assert.Equal(1, actions[0].Sequence);
@@ -531,7 +533,7 @@ namespace Parsek.Tests
                 new PendingScienceSubject { subjectId = "valid2@subject", science = 8.0f },
             };
 
-            var actions = GameStateEventConverter.ConvertScienceSubjects(subjects, "rec", 1000.0);
+            var actions = GameStateEventConverter.ConvertScienceSubjects(subjects, "rec", 900.0, 1000.0);
 
             Assert.Equal(2, actions.Count);
             Assert.Equal(1, actions[0].Sequence);
@@ -547,7 +549,7 @@ namespace Parsek.Tests
                 new PendingScienceSubject { subjectId = "evaReport@MunSrfLanded", science = 8.0f, subjectMaxValue = 24.0f },
             };
 
-            var actions = GameStateEventConverter.ConvertScienceSubjects(subjects, "rec", 1000.0);
+            var actions = GameStateEventConverter.ConvertScienceSubjects(subjects, "rec", 900.0, 1000.0);
 
             Assert.Equal(2, actions.Count);
             Assert.Equal(10.0f, actions[0].SubjectMaxValue);

--- a/Source/Parsek/GameActions/GameAction.cs
+++ b/Source/Parsek/GameActions/GameAction.cs
@@ -579,6 +579,11 @@ namespace Parsek
             n.AddValue("method", ((int)Method).ToString(IC));
             n.AddValue("transmitScalar", TransmitScalar.ToString("R", IC));
             n.AddValue("subjectMaxValue", SubjectMaxValue.ToString("R", IC));
+            if (!float.IsNaN(EndUT))
+            {
+                n.AddValue("startUT", StartUT.ToString("R", IC));
+                n.AddValue("endUT", EndUT.ToString("R", IC));
+            }
         }
 
         private static void DeserializeScienceEarning(ConfigNode n, GameAction a)
@@ -592,6 +597,9 @@ namespace Parsek
             TryParseEnum(n, "method", out a.Method);
             TryParseFloat(n, "transmitScalar", out a.TransmitScalar);
             TryParseFloat(n, "subjectMaxValue", out a.SubjectMaxValue);
+            TryParseFloat(n, "startUT", out a.StartUT);
+            if (!TryParseFloat(n, "endUT", out a.EndUT))
+                a.EndUT = float.NaN;
         }
 
         private void SerializeScienceSpending(ConfigNode n)

--- a/Source/Parsek/GameActions/GameStateEventConverter.cs
+++ b/Source/Parsek/GameActions/GameStateEventConverter.cs
@@ -178,13 +178,18 @@ namespace Parsek
 
         /// <summary>
         /// Converts a list of PendingScienceSubjects into ScienceEarning GameActions.
-        /// Each subject becomes a ScienceEarning action with subjectId, scienceAwarded, and subjectMaxValue.
+        /// Each subject becomes a ScienceEarning action anchored at commit/end UT while
+        /// also carrying the owning recording span for post-walk reconciliation.
         /// </summary>
         /// <param name="subjects">Science subjects to convert.</param>
         /// <param name="recordingId">Recording that produced these subjects.</param>
-        /// <param name="ut">Universal time to assign to all generated actions.</param>
+        /// <param name="startUT">Owning recording start UT.</param>
+        /// <param name="endUT">Owning recording end/commit UT.</param>
         internal static List<GameAction> ConvertScienceSubjects(
-            IReadOnlyList<PendingScienceSubject> subjects, string recordingId, double ut)
+            IReadOnlyList<PendingScienceSubject> subjects,
+            string recordingId,
+            double startUT,
+            double endUT)
         {
             var result = new List<GameAction>();
 
@@ -218,12 +223,14 @@ namespace Parsek
 
                 result.Add(new GameAction
                 {
-                    UT = ut,
+                    UT = endUT,
                     Type = GameActionType.ScienceEarning,
                     RecordingId = recordingId,
                     SubjectId = subj.subjectId,
                     ScienceAwarded = subj.science,
                     SubjectMaxValue = subj.subjectMaxValue,
+                    StartUT = (float)startUT,
+                    EndUT = (float)endUT,
                     Sequence = sequence++
                 });
             }

--- a/Source/Parsek/GameActions/GameStateEventConverter.cs
+++ b/Source/Parsek/GameActions/GameStateEventConverter.cs
@@ -160,13 +160,18 @@ namespace Parsek
 
         /// <summary>
         /// Converts a list of PendingScienceSubjects into ScienceEarning GameActions.
-        /// Each subject becomes a ScienceEarning action with subjectId, scienceAwarded, and subjectMaxValue.
+        /// Each subject becomes a ScienceEarning action anchored at commit/end UT while
+        /// also carrying the owning recording span for post-walk reconciliation.
         /// </summary>
         /// <param name="subjects">Science subjects to convert.</param>
         /// <param name="recordingId">Recording that produced these subjects.</param>
-        /// <param name="ut">Universal time to assign to all generated actions.</param>
+        /// <param name="startUT">Owning recording start UT.</param>
+        /// <param name="endUT">Owning recording end/commit UT.</param>
         internal static List<GameAction> ConvertScienceSubjects(
-            IReadOnlyList<PendingScienceSubject> subjects, string recordingId, double ut)
+            IReadOnlyList<PendingScienceSubject> subjects,
+            string recordingId,
+            double startUT,
+            double endUT)
         {
             var result = new List<GameAction>();
 
@@ -200,12 +205,14 @@ namespace Parsek
 
                 result.Add(new GameAction
                 {
-                    UT = ut,
+                    UT = endUT,
                     Type = GameActionType.ScienceEarning,
                     RecordingId = recordingId,
                     SubjectId = subj.subjectId,
                     ScienceAwarded = subj.science,
                     SubjectMaxValue = subj.subjectMaxValue,
+                    StartUT = (float)startUT,
+                    EndUT = (float)endUT,
                     Sequence = sequence++
                 });
             }

--- a/Source/Parsek/GameActions/LedgerOrchestrator.cs
+++ b/Source/Parsek/GameActions/LedgerOrchestrator.cs
@@ -220,7 +220,7 @@ namespace Parsek
             IReadOnlyList<PendingScienceSubject> pendingSource =
                 pendingScienceOverride ?? GameStateRecorder.PendingScienceSubjects;
             var scienceActions = GameStateEventConverter.ConvertScienceSubjects(
-                pendingSource, recordingId, endUT);
+                pendingSource, recordingId, startUT, endUT);
             actions.AddRange(scienceActions);
 
             // 3. Inject vessel build cost and recovery funds from recording data
@@ -4155,8 +4155,10 @@ namespace Parsek
         /// order; for each Transformed-bucket action whose UT survives the
         /// cutoff, compares the post-walk derived delta against the live KSP
         /// delta (<c>valueAfter - valueBefore</c>) summed across matching
-        /// <see cref="GameStateStore"/> events within
-        /// <see cref="PostWalkReconcileEpsilonSeconds"/> of <c>action.UT</c>.
+        /// <see cref="GameStateStore"/> events inside the observed-side match window:
+        /// normally <see cref="PostWalkReconcileEpsilonSeconds"/> around <c>action.UT</c>,
+        /// but for end-anchored <see cref="GameActionType.ScienceEarning"/> actions the
+        /// owning recording span is used so earlier in-flight science transmissions still pair.
         /// WARN on divergence per leg; VERBOSE rate-limited on match. Emits a
         /// single INFO summary after the iteration. Log-only.
         /// <para>
@@ -4257,6 +4259,12 @@ namespace Parsek
             double summedExpected = SumExpectedPostWalkWindow(
                 action, leg, tolerance, actions, utCutoff);
 
+            GetPostWalkObservedWindow(
+                action, leg,
+                out double observedWindowStartUt,
+                out double observedWindowEndUt,
+                out string observedWindowLabel);
+
             double observed = 0.0;
             int observedCount = 0;
             if (events != null)
@@ -4265,7 +4273,7 @@ namespace Parsek
                 {
                     var e = events[i];
                     if (e.eventType != leg.EventType) continue;
-                    if (Math.Abs(e.ut - action.UT) > PostWalkReconcileEpsilonSeconds) continue;
+                    if (e.ut < observedWindowStartUt || e.ut > observedWindowEndUt) continue;
                     string eventKey = e.key ?? "";
                     if (!string.Equals(eventKey, leg.ReasonKey, StringComparison.Ordinal))
                         continue;
@@ -4287,8 +4295,7 @@ namespace Parsek
                 ParsekLog.Warn(Tag,
                     $"Earnings reconciliation (post-walk, {legTag}): {action.Type} " +
                     $"id={id} expected={summedExpected:F1} but no matching {leg.EventType} event " +
-                    $"keyed '{leg.ReasonKey}' within {PostWalkReconcileEpsilonSeconds:F1}s of " +
-                    $"ut={action.UT:F1} -- missing earning channel or stale event?");
+                    $"keyed '{leg.ReasonKey}' {observedWindowLabel} -- missing earning channel or stale event?");
                 return false;
             }
 
@@ -4297,7 +4304,7 @@ namespace Parsek
                 ParsekLog.Warn(Tag,
                     $"Earnings reconciliation (post-walk, {legTag}): {action.Type} " +
                     $"id={id} expected={summedExpected:F1}, observed={observed:F1} across " +
-                    $"{observedCount} event(s) keyed '{leg.ReasonKey}' at ut={action.UT:F1} " +
+                    $"{observedCount} event(s) keyed '{leg.ReasonKey}' {observedWindowLabel} " +
                     $"-- post-walk delta mismatch");
                 return false;
             }
@@ -4305,8 +4312,104 @@ namespace Parsek
             ParsekLog.VerboseRateLimited(Tag,
                 $"post-walk-match:{action.Type}:{legTag}",
                 $"Post-walk match: {action.Type} {legTag} id={id} " +
-                $"expected={summedExpected:F1}, observed={observed:F1}, ut={action.UT:F1}");
+                $"expected={summedExpected:F1}, observed={observed:F1}, {observedWindowLabel}");
             return true;
+        }
+
+        private static void GetPostWalkObservedWindow(
+            GameAction action,
+            PostWalkLeg leg,
+            out double startUt,
+            out double endUt,
+            out string label)
+        {
+            double epsilon = PostWalkReconcileEpsilonSeconds;
+            if (action == null)
+            {
+                startUt = double.NegativeInfinity;
+                endUt = double.PositiveInfinity;
+                label = $"within {epsilon:F1}s of ut=(null)";
+                return;
+            }
+
+            startUt = action.UT - epsilon;
+            endUt = action.UT + epsilon;
+            label = $"within {epsilon:F1}s of ut={action.UT:F1}";
+
+            if (action.Type != GameActionType.ScienceEarning ||
+                leg.EventType != GameStateEventType.ScienceChanged ||
+                !string.Equals(leg.ReasonKey, "ScienceTransmission", StringComparison.Ordinal) ||
+                string.IsNullOrEmpty(action.SubjectId) ||
+                action.SubjectId.StartsWith("LegacyMigration:", StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            if (!TryGetScienceTransmissionReconcileWindow(action, out double recordingStartUt, out double recordingEndUt))
+                return;
+
+            double startPad = GetScienceTransmissionBoundaryPadding(recordingStartUt);
+            double endPad = GetScienceTransmissionBoundaryPadding(recordingEndUt);
+            startUt = recordingStartUt - epsilon - startPad;
+            endUt = recordingEndUt + epsilon + endPad;
+            label = $"within recording window [{recordingStartUt:F1},{recordingEndUt:F1}] for action ut={action.UT:F1}";
+        }
+
+        private static bool TryGetScienceTransmissionReconcileWindow(
+            GameAction action,
+            out double startUt,
+            out double endUt)
+        {
+            startUt = 0.0;
+            endUt = 0.0;
+
+            if (action == null)
+                return false;
+
+            if (!float.IsNaN(action.EndUT) && action.EndUT > action.StartUT)
+            {
+                startUt = action.StartUT;
+                endUt = action.EndUT;
+            }
+            else
+            {
+                var rec = FindRecordingById(action.RecordingId);
+                if (rec == null)
+                    return false;
+
+                startUt = rec.StartUT;
+                endUt = rec.EndUT;
+                if (endUt <= startUt)
+                    return false;
+            }
+
+            // Only widen the observed-side window for the current end-anchored shape.
+            // ScienceEarning spans are persisted through float fields, so at large UTs
+            // the stored EndUT may drift from the double-backed action.UT by more than
+            // the nominal 0.1 s epsilon. Allow the float quantization loss here while
+            // still keeping the gate tight enough to reject truly non-end-anchored rows.
+            return Math.Abs(action.UT - endUt) <= GetScienceTransmissionAnchorTolerance(action.UT);
+        }
+
+        private static double GetScienceTransmissionAnchorTolerance(double actionUt)
+        {
+            double floatRoundTripLoss = Math.Abs((double)(float)actionUt - actionUt);
+            return PostWalkReconcileEpsilonSeconds + floatRoundTripLoss;
+        }
+
+        private static double GetScienceTransmissionBoundaryPadding(double value)
+        {
+            if (double.IsNaN(value) || double.IsInfinity(value))
+                return 0.0;
+
+            float single = (float)value;
+            int bits = BitConverter.ToInt32(BitConverter.GetBytes(single), 0);
+            float nextUp = BitConverter.ToSingle(BitConverter.GetBytes(bits + 1), 0);
+            if (float.IsNaN(nextUp) || float.IsInfinity(nextUp))
+                return 0.0;
+
+            // One full ULP safely covers any double->float rounding loss at this magnitude.
+            return Math.Abs((double)nextUp - single);
         }
 
         /// <summary>

--- a/Source/Parsek/GameActions/LedgerOrchestrator.cs
+++ b/Source/Parsek/GameActions/LedgerOrchestrator.cs
@@ -244,7 +244,7 @@ namespace Parsek
             IReadOnlyList<PendingScienceSubject> pendingSource =
                 pendingScienceOverride ?? GameStateRecorder.PendingScienceSubjects;
             var scienceActions = GameStateEventConverter.ConvertScienceSubjects(
-                pendingSource, recordingId, endUT);
+                pendingSource, recordingId, startUT, endUT);
             actions.AddRange(scienceActions);
 
             // 3. Inject vessel build cost and recovery funds from recording data
@@ -4211,8 +4211,10 @@ namespace Parsek
         /// order; for each Transformed-bucket action whose UT survives the
         /// cutoff, compares the post-walk derived delta against the live KSP
         /// delta (<c>valueAfter - valueBefore</c>) summed across matching
-        /// <see cref="GameStateStore"/> events within
-        /// <see cref="PostWalkReconcileEpsilonSeconds"/> of <c>action.UT</c>.
+        /// <see cref="GameStateStore"/> events inside the observed-side match window:
+        /// normally <see cref="PostWalkReconcileEpsilonSeconds"/> around <c>action.UT</c>,
+        /// but for end-anchored <see cref="GameActionType.ScienceEarning"/> actions the
+        /// owning recording span is used so earlier in-flight science transmissions still pair.
         /// WARN on divergence per leg; VERBOSE rate-limited on match. Emits a
         /// single INFO summary after the iteration. Log-only.
         /// <para>
@@ -4367,6 +4369,12 @@ namespace Parsek
             if (!aggregate.IsPrimary)
                 return PostWalkCompareResult.Skipped;
 
+            GetPostWalkObservedWindow(
+                action, leg,
+                out double observedWindowStartUt,
+                out double observedWindowEndUt,
+                out string observedWindowLabel);
+
             double observed = 0.0;
             int observedCount = 0;
             if (events != null)
@@ -4375,7 +4383,7 @@ namespace Parsek
                 {
                     var e = events[i];
                     if (e.eventType != leg.EventType) continue;
-                    if (Math.Abs(e.ut - action.UT) > PostWalkReconcileEpsilonSeconds) continue;
+                    if (e.ut < observedWindowStartUt || e.ut > observedWindowEndUt) continue;
                     if (!PostWalkEventMatchesAction(e, action)) continue;
                     string eventKey = e.key ?? "";
                     if (!string.Equals(eventKey, leg.ReasonKey, StringComparison.Ordinal))
@@ -4396,8 +4404,7 @@ namespace Parsek
                 ParsekLog.Warn(Tag,
                     $"Earnings reconciliation (post-walk, {legTag}): {action.Type} " +
                     $"{aggregate.ContributorLabel} expected={aggregate.Expected:F1} but no matching {leg.EventType} event " +
-                    $"keyed '{leg.ReasonKey}' within {PostWalkReconcileEpsilonSeconds:F1}s of " +
-                    $"ut={action.UT:F1} -- missing earning channel or stale event?");
+                    $"keyed '{leg.ReasonKey}' {observedWindowLabel} -- missing earning channel or stale event?");
                 return PostWalkCompareResult.Mismatch;
             }
 
@@ -4406,7 +4413,7 @@ namespace Parsek
                 ParsekLog.Warn(Tag,
                     $"Earnings reconciliation (post-walk, {legTag}): {action.Type} " +
                     $"{aggregate.ContributorLabel} expected={aggregate.Expected:F1}, observed={observed:F1} across " +
-                    $"{observedCount} event(s) keyed '{leg.ReasonKey}' at ut={action.UT:F1} " +
+                    $"{observedCount} event(s) keyed '{leg.ReasonKey}' {observedWindowLabel} " +
                     $"-- post-walk delta mismatch");
                 return PostWalkCompareResult.Mismatch;
             }
@@ -4414,8 +4421,102 @@ namespace Parsek
             ParsekLog.VerboseRateLimited(Tag,
                 $"post-walk-match:{action.Type}:{legTag}:{action.UT.ToString("R", CultureInfo.InvariantCulture)}",
                 $"Post-walk match: {action.Type} {legTag} {aggregate.ContributorLabel} " +
-                $"expected={aggregate.Expected:F1}, observed={observed:F1}, ut={action.UT:F1}");
+                $"expected={aggregate.Expected:F1}, observed={observed:F1}, {observedWindowLabel}");
             return PostWalkCompareResult.Match;
+        }
+
+        private static void GetPostWalkObservedWindow(
+            GameAction action,
+            PostWalkLeg leg,
+            out double startUt,
+            out double endUt,
+            out string label)
+        {
+            double epsilon = PostWalkReconcileEpsilonSeconds;
+            startUt = action.UT - epsilon;
+            endUt = action.UT + epsilon;
+            label = $"within {epsilon:F1}s of ut={action.UT:F1}";
+
+            if (action.Type != GameActionType.ScienceEarning ||
+                leg.EventType != GameStateEventType.ScienceChanged ||
+                !string.Equals(leg.ReasonKey, "ScienceTransmission", StringComparison.Ordinal) ||
+                string.IsNullOrEmpty(action.SubjectId) ||
+                action.SubjectId.StartsWith("LegacyMigration:", StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            if (!TryGetScienceTransmissionReconcileWindow(action, out double recordingStartUt, out double recordingEndUt))
+                return;
+
+            double startPad = GetScienceTransmissionBoundaryPadding(recordingStartUt);
+            double endPad = GetScienceTransmissionBoundaryPadding(recordingEndUt);
+            startUt = recordingStartUt - epsilon - startPad;
+            endUt = recordingEndUt + epsilon + endPad;
+            label = $"within recording window [{recordingStartUt:F1},{recordingEndUt:F1}] for action ut={action.UT:F1}";
+        }
+
+        private static bool TryGetScienceTransmissionReconcileWindow(
+            GameAction action,
+            out double startUt,
+            out double endUt)
+        {
+            startUt = 0.0;
+            endUt = 0.0;
+
+            if (action == null)
+                return false;
+
+            if (!float.IsNaN(action.EndUT) && action.EndUT > action.StartUT)
+            {
+                startUt = action.StartUT;
+                endUt = action.EndUT;
+            }
+            else
+            {
+                var rec = FindRecordingById(action.RecordingId);
+                if (rec == null)
+                    return false;
+
+                startUt = rec.StartUT;
+                endUt = rec.EndUT;
+                if (endUt <= startUt)
+                    return false;
+
+                ParsekLog.VerboseRateLimited(Tag,
+                    $"post-walk-science-window-fallback:{action.RecordingId}:{ActionIdForPostWalk(action)}",
+                    $"Post-walk science window: {ActionIdForPostWalk(action)} missing persisted span; " +
+                    $"falling back to recording {action.RecordingId ?? "(null)"} " +
+                    $"[{startUt:F1},{endUt:F1}]");
+            }
+
+            // Only widen the observed-side window for the current end-anchored shape.
+            // ScienceEarning spans are persisted through float fields, so at large UTs
+            // the stored EndUT may drift from the double-backed action.UT by more than
+            // the nominal 0.1 s epsilon. Allow the float quantization loss here while
+            // still keeping the gate tight enough to reject truly non-end-anchored rows.
+            return Math.Abs(action.UT - endUt) <= GetScienceTransmissionAnchorTolerance(action.UT);
+        }
+
+        private static double GetScienceTransmissionAnchorTolerance(double actionUt)
+        {
+            double floatRoundTripLoss = Math.Abs((double)(float)actionUt - actionUt);
+            return PostWalkReconcileEpsilonSeconds + floatRoundTripLoss;
+        }
+
+        private static double GetScienceTransmissionBoundaryPadding(double value)
+        {
+            if (double.IsNaN(value) || double.IsInfinity(value))
+                return 0.0;
+
+            float single = (float)value;
+            int bits = BitConverter.ToInt32(BitConverter.GetBytes(single), 0);
+            float nextUp = BitConverter.ToSingle(BitConverter.GetBytes(bits + 1), 0);
+            if (float.IsNaN(nextUp) || float.IsInfinity(nextUp))
+                return 0.0;
+
+            // One full ULP safely covers any double->float rounding loss at this magnitude.
+            return Math.Abs((double)nextUp - single);
         }
 
         /// <summary>

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -339,7 +339,7 @@ Once root cause is known, fix is local to `CompareLeg` or its call site. Test: x
 
 ---
 
-## 468. `ScienceEarning` reconcile anchor UT is vessel-recovery-time, but `ScienceChanged 'ScienceTransmission'` events are emitted at transmission-time earlier in the flight — the 0.1s window can never match
+## ~~468. `ScienceEarning` reconcile anchor UT is vessel-recovery-time, but `ScienceChanged 'ScienceTransmission'` events are emitted at transmission-time earlier in the flight — the 0.1s window can never match~~
 
 **Source:** `logs/2026-04-19_0049_career-ledger/KSP.log:10410-10415`.
 
@@ -372,7 +372,7 @@ Option 1 is cleaner but touches the emit path; option 2 is localised to `Compare
 
 **Dependencies:** surface with #469 during the same investigation — root-cause signal will tell which option is right.
 
-**Status:** TODO. Priority: medium. Currently produces 126+ WARNs per launch session.
+**Status:** DONE/CLOSED (2026-04-19). `CompareLeg` now widens the observed-side `ScienceTransmission` match window to the owning recording span only for end-anchored `ScienceEarning` actions, and new science actions persist `StartUT`/`EndUT` so reloads keep the same reconcile context. `#469` remains separate: it is the same-UT false-negative path, not this earlier-transmission window mismatch.
 
 ---
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -384,7 +384,7 @@ Once root cause is known, fix is local to `CompareLeg` or its call site. Test: x
 
 ---
 
-## 468. `ScienceEarning` reconcile anchor UT is vessel-recovery-time, but `ScienceChanged 'ScienceTransmission'` events are emitted at transmission-time earlier in the flight — the 0.1s window can never match
+## ~~468. `ScienceEarning` reconcile anchor UT is vessel-recovery-time, but `ScienceChanged 'ScienceTransmission'` events are emitted at transmission-time earlier in the flight — the 0.1s window can never match~~
 
 **Source:** `logs/2026-04-19_0049_career-ledger/KSP.log:10410-10415`.
 
@@ -417,7 +417,7 @@ Option 1 is cleaner but touches the emit path; option 2 is localised to `Compare
 
 **Dependencies:** surface with #469 during the same investigation — root-cause signal will tell which option is right.
 
-**Status:** TODO. Priority: medium. Currently produces 126+ WARNs per launch session.
+**Status:** DONE/CLOSED (2026-04-19). `CompareLeg` now widens the observed-side `ScienceTransmission` match window to the owning recording span only for end-anchored `ScienceEarning` actions, and new science actions persist `StartUT`/`EndUT` so reloads keep the same reconcile context. `#469` remains separate: it is the same-UT false-negative path, not this earlier-transmission window mismatch.
 
 ---
 


### PR DESCRIPTION
## Summary
- Widens the `ScienceEarning` reconcile window so `ScienceChanged 'ScienceTransmission'` events emitted at transmission-time (earlier in the flight) are matched against the vessel-recovery-time anchor, instead of falling outside the previous 0.1s window.

Closes #468 (internal; see `docs/dev/todo-and-known-bugs.md`).

## Test plan
- [ ] Unit coverage for widened reconcile window against transmission-time emission.
- [ ] In-KSP transmit-then-recover confirms no spurious "no matching event" WARN.