### PR TITLE
docs: document canonical test commands for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,12 +4,24 @@
 ## Build & Test
 
 ```bash
-cd Source/Parsek && dotnet build          # builds + auto-copies to KSP GameData
-cd Source/Parsek.Tests && dotnet test     # all unit tests
-dotnet test --filter InjectAllRecordings  # inject 8 synthetic recordings into test save
+dotnet build Source/Parsek/Parsek.csproj                         # builds + auto-copies to KSP GameData
+dotnet test Source/Parsek.Tests/Parsek.Tests.csproj             # full xUnit suite
+dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter InjectAllRecordings
+pwsh -File scripts/test-coverage.ps1                            # local xUnit coverage report
 ```
 
 Post-build copy uses `ContinueOnError="true"` - builds succeed when KSP has DLL locked.
+Prefer running these commands from the repo/worktree root so they behave the same in sibling worktrees.
+
+`dotnet test` only covers the headless xUnit suite. Runtime / in-game tests live under `Source/Parsek/InGameTests/` and must be run inside KSP via `Ctrl+Shift+T`; results export to `parsek-test-results.txt` in the KSP root.
+
+If a machine-specific environment issue blocks `dotnet test` or `dotnet restore` (for example testhost socket startup or NuGet initialization), treat that as an environment blocker, not a repo failure. In that case, use:
+
+```bash
+dotnet build Source/Parsek.Tests/Parsek.Tests.csproj --no-restore
+```
+
+and record clearly that full xUnit execution was blocked by the local environment.
 
 ## Release
 
@@ -160,7 +172,8 @@ After any change to enums, event types, serialized fields, or schema:
 1. Verify `ParsekScenario.cs` OnSave/OnLoad handles the new data
 2. Verify test generators in `Tests/Generators/` can produce test data for the new feature
 3. Consider adding a synthetic recording for end-to-end testing
-4. Run `dotnet test` - all tests must pass
+4. Run `dotnet test Source/Parsek.Tests/Parsek.Tests.csproj` - all headless tests must pass
+5. If the change affects runtime-only behavior, run the relevant in-game tests via `Ctrl+Shift+T` and keep `parsek-test-results.txt` / `KSP.log` evidence
 
 ## Documentation Updates — Per Commit, Not Per PR
 


### PR DESCRIPTION
## Summary
- Ships the direct-to-main commit 84ba5e19 as a proper PR so main goes back to matching origin/main once merged.
- AGENTS.md update documents the canonical `dotnet test` commands for agents to use.

## Test plan
- [x] No code change; docs-only diff
- [x] Merge and confirm local main fast-forwards cleanly to origin/main