### PR TITLE
fix: #487 harden test runner opaque window rebuild

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,8 @@ Prefer running these commands from the repo/worktree root so they behave the sam
 
 `dotnet test` only covers the headless xUnit suite. Runtime / in-game tests live under `Source/Parsek/InGameTests/` and must be run inside KSP via `Ctrl+Shift+T`; results export to `parsek-test-results.txt` in the KSP root.
 
+Tests marked `AllowBatchExecution = false` are single-run only. They do not execute under `Run All` / batch category runs and will show up as `(never run)` in `parsek-test-results.txt` until you launch them individually from the in-game test runner.
+
 If a machine-specific environment issue blocks `dotnet test` or `dotnet restore` (for example testhost socket startup or NuGet initialization), treat that as an environment blocker, not a repo failure. In that case, use:
 
 ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to Parsek are documented here.
 
 ### Tests
 
+- `#487` Added an in-game `TestRunner` regression that drives the scene-reset + missing-skin path, clears any preexisting cache before the initial build, and asserts lagging hover/focus/active states fall back to the ready normal window background instead of caching a transparent frame.
 - `#461` Added in-game loop-cycle reuse visibility regressions that drive the full `UpdatePlayback -> UpdateLoopingPlayback` boundary path, pinning both the same-frame visible reactivation case and the hidden-by-zone deferred/inactive case.
 - `#478` `RuntimeTests.MapMarkerIconsMatchStockAtlas` now skips outside `FLIGHT` and `TRACKSTATION` instead of failing in `EDITOR`, `MAINMENU`, and `SPACECENTER`, so the runtime test only asserts `MapView.fetch` where that API actually exists.
 - `#480` Strategy lifecycle in-game regressions now wait for stock strategy hydration to stabilize before probing activation, so the SPACECENTER career tests fail with targeted readiness diagnostics instead of early `NullReferenceException`s.
@@ -35,6 +36,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- `#487` The Ctrl+Shift+T test runner window now defers opaque-style rebuilds until the destination scene's IMGUI skin exposes a real normal window background, and any lagging hover/focus/active variants fall back to that ready background instead of being cached as transparent states. Scene-reset cleanup also destroys the copied opaque textures before rebuilding to avoid leaking them across repeated transitions.
 - `#463` Deferred warp-end spawns now replay already-due `FlagEvents` for the spawned recording, so flags planted mid-recording still materialise even if you time-warp past that recording while watching something else.
 - `#466` `RecalculateAndPatch` now defers KSP state patching while a live, active, or pending flight tree is still uncommitted, so mid-flight/load-time recalculations no longer snap funds back down to the committed-ledger target. Discard paths now explicitly recalculate once the pending tree is gone.
 - `#470` Funds recalculation no longer logs `FundsSpending: -0, source=Other` for zero-cost replay entries during module walks. The no-op action still participates in affordability/balance tracking; only the useless VERBOSE line is suppressed.

--- a/Source/Parsek/InGameTests/RuntimeTests.cs
+++ b/Source/Parsek/InGameTests/RuntimeTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using UnityEngine;
 
 namespace Parsek.InGameTests
@@ -3459,6 +3460,91 @@ namespace Parsek.InGameTests
                 "TestRunnerShortcut.Instance must be non-null after quickload (DontDestroyOnLoad)");
             InGameAssert.AreEqual(preInstance.GetInstanceID(), postInstance.GetInstanceID(),
                 "TestRunnerShortcut instance must be the SAME object after quickload");
+        }
+
+        /// <summary>
+        /// #487 regression: scene reset must not cache a transparent opaque window
+        /// style while the destination scene skin is still bootstrapping.
+        /// </summary>
+        [InGameTest(Category = "TestRunner",
+            Description = "Scene reset defers opaque window rebuild until a skin background exists")]
+        public void SceneReset_DefersOpaqueStyleUntilSkinReady()
+        {
+            var shortcut = TestRunnerShortcut.Instance;
+            InGameAssert.IsNotNull(shortcut, "TestRunnerShortcut.Instance must exist");
+
+            MethodInfo onSceneChange = typeof(TestRunnerShortcut).GetMethod(
+                "OnSceneChangeRequested",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            InGameAssert.IsNotNull(onSceneChange,
+                "Failed to reflect TestRunnerShortcut.OnSceneChangeRequested");
+
+            var readySkin = ScriptableObject.CreateInstance<GUISkin>();
+            var missingBackgroundSkin = ScriptableObject.CreateInstance<GUISkin>();
+            var sourceBackground = new Texture2D(2, 2, TextureFormat.ARGB32, false);
+
+            try
+            {
+                sourceBackground.SetPixels(new[]
+                {
+                    new Color(0.18f, 0.24f, 0.31f, 0.35f),
+                    new Color(0.20f, 0.27f, 0.34f, 0.40f),
+                    new Color(0.22f, 0.29f, 0.36f, 0.45f),
+                    new Color(0.24f, 0.31f, 0.38f, 0.50f),
+                });
+                sourceBackground.Apply();
+
+                onSceneChange.Invoke(shortcut, new object[] { HighLogic.LoadedScene });
+                InGameAssert.IsFalse(shortcut.HasOpaqueStyleForTesting,
+                    "Test must start from a cleared opaque-style cache");
+
+                readySkin.window = new GUIStyle();
+                readySkin.window.normal.background = sourceBackground;
+
+                missingBackgroundSkin.window = new GUIStyle();
+
+                bool builtBeforeReset = shortcut.TryEnsureOpaqueStyleForTesting(readySkin);
+                InGameAssert.IsTrue(builtBeforeReset,
+                    "Opaque style should build when a window background exists");
+                InGameAssert.IsTrue(shortcut.HasOpaqueStyleForTesting,
+                    "Opaque style must be cached before the scene reset");
+                InGameAssert.IsNotNull(shortcut.OpaqueWindowBackgroundForTesting,
+                    "Opaque style cache must keep a non-null window background before reset");
+                InGameAssert.IsTrue(shortcut.HasAllOpaqueStateBackgroundsForTesting,
+                    "Lagging hover/focus/active states must fall back to the ready normal background");
+                InGameAssert.AreNotEqual(sourceBackground.GetInstanceID(),
+                    shortcut.OpaqueWindowBackgroundForTesting.GetInstanceID(),
+                    "Opaque style must keep a copied background texture instead of the live skin texture");
+
+                onSceneChange.Invoke(shortcut, new object[] { HighLogic.LoadedScene });
+                InGameAssert.IsFalse(shortcut.HasOpaqueStyleForTesting,
+                    "Scene reset should clear the cached opaque style before the next rebuild");
+
+                bool builtWithMissingBackground = shortcut.TryEnsureOpaqueStyleForTesting(missingBackgroundSkin);
+                InGameAssert.IsFalse(builtWithMissingBackground,
+                    "Opaque style rebuild must defer when the destination scene skin has no window background yet");
+                InGameAssert.IsFalse(shortcut.HasOpaqueStyleForTesting,
+                    "Deferred rebuild must not cache an opaque style with null backgrounds");
+                InGameAssert.IsNull(shortcut.OpaqueWindowBackgroundForTesting,
+                    "Deferred rebuild must leave the cached opaque background unset");
+
+                bool builtAfterSkinReady = shortcut.TryEnsureOpaqueStyleForTesting(readySkin);
+                InGameAssert.IsTrue(builtAfterSkinReady,
+                    "Opaque style rebuild should succeed once the scene skin is ready");
+                InGameAssert.IsTrue(shortcut.HasOpaqueStyleForTesting,
+                    "Ready-skin rebuild must repopulate the cached opaque style");
+                InGameAssert.IsNotNull(shortcut.OpaqueWindowBackgroundForTesting,
+                    "Ready-skin rebuild must cache a non-null opaque background");
+                InGameAssert.IsTrue(shortcut.HasAllOpaqueStateBackgroundsForTesting,
+                    "Ready-skin rebuild must populate every window state background");
+            }
+            finally
+            {
+                onSceneChange.Invoke(shortcut, new object[] { HighLogic.LoadedScene });
+                Object.Destroy(readySkin);
+                Object.Destroy(missingBackgroundSkin);
+                Object.Destroy(sourceBackground);
+            }
         }
 
         /// <summary>

--- a/Source/Parsek/InGameTests/TestRunnerShortcut.cs
+++ b/Source/Parsek/InGameTests/TestRunnerShortcut.cs
@@ -42,6 +42,9 @@ namespace Parsek.InGameTests
         /// instance alive. Used by in-game tests to verify bridge survival (#269).
         /// </summary>
         internal static TestRunnerShortcut Instance => instance;
+        internal bool HasOpaqueStyleForTesting => opaqueStyle != null;
+        internal bool HasAllOpaqueStateBackgroundsForTesting => AreAllOpaqueStyleBackgroundsPresent(opaqueStyle);
+        internal Texture2D OpaqueWindowBackgroundForTesting => opaqueStyle?.normal.background;
 
         void Awake()
         {
@@ -105,19 +108,8 @@ namespace Parsek.InGameTests
             if (windowRect.width < 1f)
                 windowRect = new Rect(20, 60, DefaultWindowWidth, DefaultWindowHeight);
 
-            if (opaqueStyle == null)
-            {
-                // Match ParsekUI's opaque window style: copy KSP skin, force alpha to 1
-                opaqueStyle = new GUIStyle(GUI.skin.window);
-                opaqueStyle.normal.background = MakeOpaqueCopy(opaqueStyle.normal.background);
-                opaqueStyle.onNormal.background = MakeOpaqueCopy(opaqueStyle.onNormal.background);
-                opaqueStyle.focused.background = MakeOpaqueCopy(opaqueStyle.focused.background);
-                opaqueStyle.onFocused.background = MakeOpaqueCopy(opaqueStyle.onFocused.background);
-                opaqueStyle.active.background = MakeOpaqueCopy(opaqueStyle.active.background);
-                opaqueStyle.onActive.background = MakeOpaqueCopy(opaqueStyle.onActive.background);
-                opaqueStyle.hover.background = MakeOpaqueCopy(opaqueStyle.hover.background);
-                opaqueStyle.onHover.background = MakeOpaqueCopy(opaqueStyle.onHover.background);
-            }
+            if (!EnsureOpaqueStyle(GUI.skin))
+                return;
 
             windowRect = GUILayout.Window(
                 "ParsekTestRunnerGlobal".GetHashCode(),
@@ -154,6 +146,7 @@ namespace Parsek.InGameTests
                 instance = null;
                 GameEvents.onGameSceneLoadRequested.Remove(OnSceneChangeRequested);
             }
+            ClearOpaqueStyle();
             if (windowHasInputLock)
                 InputLockManager.RemoveControlLock(InputLockId);
         }
@@ -161,15 +154,107 @@ namespace Parsek.InGameTests
         /// <summary>
         /// #269: Reset scene-scoped state on scene transition.
         /// InputLockManager locks are cleared by KSP, so our tracking flag must match.
-        /// opaqueStyle references GUI.skin textures that may not survive scene changes.
+        /// Opaque window textures are copied into owned Texture2D instances, so drop
+        /// and destroy them explicitly before the next scene rebuild.
         /// </summary>
         private void OnSceneChangeRequested(GameScenes scene)
         {
             windowHasInputLock = false;
-            opaqueStyle = null;
+            ClearOpaqueStyle();
             zeroHeightLabelStyle = null;
             wrappedErrorLabelStyle = null;
             wrappedTooltipStyle = null;
+        }
+
+        internal bool TryEnsureOpaqueStyleForTesting(GUISkin skin)
+        {
+            return EnsureOpaqueStyle(skin);
+        }
+
+        private bool EnsureOpaqueStyle(GUISkin skin)
+        {
+            if (opaqueStyle != null)
+                return true;
+
+            if (!IsOpaqueStyleSkinReady(skin))
+            {
+                ParsekLog.VerboseRateLimited(Tag, "opaque-style-skin-not-ready",
+                    "Test runner: skin not ready, deferring opaque style rebuild", 1f);
+                return false;
+            }
+
+            opaqueStyle = BuildOpaqueStyle(skin.window);
+            return true;
+        }
+
+        private void ClearOpaqueStyle()
+        {
+            if (opaqueStyle == null)
+                return;
+
+            var destroyedBackgrounds = new HashSet<int>();
+            DestroyOpaqueBackground(opaqueStyle.normal.background, destroyedBackgrounds);
+            DestroyOpaqueBackground(opaqueStyle.onNormal.background, destroyedBackgrounds);
+            DestroyOpaqueBackground(opaqueStyle.focused.background, destroyedBackgrounds);
+            DestroyOpaqueBackground(opaqueStyle.onFocused.background, destroyedBackgrounds);
+            DestroyOpaqueBackground(opaqueStyle.active.background, destroyedBackgrounds);
+            DestroyOpaqueBackground(opaqueStyle.onActive.background, destroyedBackgrounds);
+            DestroyOpaqueBackground(opaqueStyle.hover.background, destroyedBackgrounds);
+            DestroyOpaqueBackground(opaqueStyle.onHover.background, destroyedBackgrounds);
+            opaqueStyle = null;
+        }
+
+        private static bool IsOpaqueStyleSkinReady(GUISkin skin)
+        {
+            return skin != null
+                && skin.window != null
+                && skin.window.normal.background != null;
+        }
+
+        private static GUIStyle BuildOpaqueStyle(GUIStyle sourceStyle)
+        {
+            // Match ParsekUI's opaque window style: copy KSP skin, force alpha to 1.
+            // KSP can hydrate the normal window background a frame before the other
+            // state variants, so fall back to the ready normal texture for any state
+            // that is still null on this frame.
+            Texture2D normalSource = sourceStyle.normal.background;
+            var style = new GUIStyle(sourceStyle);
+            style.normal.background = MakeOpaqueCopy(normalSource);
+            style.onNormal.background = MakeOpaqueCopy(sourceStyle.onNormal.background ?? normalSource);
+            style.focused.background = MakeOpaqueCopy(sourceStyle.focused.background ?? normalSource);
+            style.onFocused.background = MakeOpaqueCopy(sourceStyle.onFocused.background ?? normalSource);
+            style.active.background = MakeOpaqueCopy(sourceStyle.active.background ?? normalSource);
+            style.onActive.background = MakeOpaqueCopy(sourceStyle.onActive.background ?? normalSource);
+            style.hover.background = MakeOpaqueCopy(sourceStyle.hover.background ?? normalSource);
+            style.onHover.background = MakeOpaqueCopy(sourceStyle.onHover.background ?? normalSource);
+            return style;
+        }
+
+        private static bool AreAllOpaqueStyleBackgroundsPresent(GUIStyle style)
+        {
+            return style != null
+                && style.normal.background != null
+                && style.onNormal.background != null
+                && style.focused.background != null
+                && style.onFocused.background != null
+                && style.active.background != null
+                && style.onActive.background != null
+                && style.hover.background != null
+                && style.onHover.background != null;
+        }
+
+        private static void DestroyOpaqueBackground(
+            Texture2D background,
+            HashSet<int> destroyedBackgrounds)
+        {
+            if (background == null)
+                return;
+
+            int id = background.GetInstanceID();
+            if (!destroyedBackgrounds.Add(id))
+                return;
+
+            Object.Destroy(background);
         }
 
         private void DrawWindow(int windowID)

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -18,6 +18,26 @@ The four top-of-queue correctness fixes (#431, #432, #433, #434) shipped in the 
 
 # Known Bugs
 
+## ~~487. Test runner window (Ctrl+Shift+T) goes fully transparent after staying open across a scene transition~~
+
+**Source:** `logs/2026-04-19_2228/KSP.log:9075` plus local repro notes (`Flight pad -> Space Center -> Flight pad` with the runner left open the whole time).
+
+**Concern:** the runner's opaque window style is reset on `GameEvents.onGameSceneLoadRequested`, which fires before the destination scene's IMGUI skin is ready. The next `OnGUI` during the transition sees `opaqueStyle == null`, clones `GUI.skin.window` while `GUI.skin.window.normal.background` is still null/stale, and caches a non-null `GUIStyle` whose backgrounds are all null. From that point the frame renders fully transparent until another scene transition happens to rebuild it at a safer moment.
+
+**Fix:** keep the current scene-reset flow, but gate opaque-style rebuild on `GUI.skin.window.normal.background != null`; if the destination skin is not ready yet, `OnGUI` now returns early and retries on a later frame instead of caching a transparent style. When the normal background is ready but hover/focus/active variants are still null, the builder now falls those states back to the ready normal texture so the cache never freezes in a partially transparent state. Scene-reset cleanup explicitly destroys the copied opaque textures before dropping the cached style, and the new in-game `TestRunner` regression clears any preexisting cache, invokes the private scene-change handler directly, exercises both the missing-background and lagging-state paths, and asserts the cache stays empty until a ready skin is supplied.
+
+**Files:** `Source/Parsek/InGameTests/TestRunnerShortcut.cs`, `Source/Parsek/InGameTests/RuntimeTests.cs`.
+
+**Scope:** Small. No scene-hook swap required; the fix is a guarded rebuild plus cache cleanup and regression coverage.
+
+**Dependencies:** none.
+
+**Resolution:** fixed on 2026-04-19 in `bug/487-test-runner-transparent`. The runner now logs a rate-limited `Test runner: skin not ready, deferring opaque style rebuild` message on the deferred path, so future log captures will show the race if it ever reappears.
+
+**Status:** CLOSED 2026-04-19. Fixed for v0.8.3.
+
+---
+
 ## 486. Quicksave/quickload while recording on the runway produces a spurious-looking tree with a ~7s surface segment glued to a post-takeoff atmo segment — user-visible as "two recordings (landed + in air)" that both describe the same takeoff
 
 **Source:** `logs/2026-04-19_2126/KSP.log` + `saves/c2/persistent.sfs`. User reported: "There was a problem with the runway R0 recording — I did a save/load while on the runway and it caused problems — created two recordings (one landed, one in air) which looked weird."


### PR DESCRIPTION
## Summary
- Defer the Ctrl+Shift+T test runner's opaque window-style rebuild until the destination scene's IMGUI skin exposes a real `window.normal.background`; if not ready, `OnGUI` skips the frame instead of caching a transparent style.
- Fall back to the ready normal texture for any hover/focus/active state the skin hasn't hydrated yet, and destroy the owned opaque textures on scene reset so repeated transitions can't leak them.
- Add an in-game `TestRunner` regression (`SceneReset_DefersOpaqueStyleUntilSkinReady`) that clears the cache, invokes the private scene-change handler, and asserts both the missing-background and lagging-state paths.

## Test plan
- [ ] In-game: Ctrl+Shift+T, then `Flight pad -> Space Center -> Flight pad` with runner open; confirm window stays opaque across both transitions and no transparent frame appears.
- [ ] In-game: run the `TestRunner` category and confirm `SceneReset_DefersOpaqueStyleUntilSkinReady` passes (plus the pre-existing `TestRunnerShortcut` tests).
- [ ] Grep `KSP.log` after the repro for `Test runner: skin not ready, deferring opaque style rebuild` to confirm the deferred path logs when the race triggers.

Closes #487.