### PR TITLE
fix: trim quickload runway resume seams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- `#486` Quickload-resume on runway takeoffs now trims stale payload across the restored tree before sampling restarts, prunes future-only branch state and rebuilds `BackgroundMap` after that rewind, treats the first post-load environment transition back to the post-trim tail phase as restored state even when EVA parent-fallback rewrites the resumed recording id, and tags overlap-derived save/load seams in `MergeTree` as `cause=save-load-teleport` instead of `sample-skip`.
 - `#463` Deferred warp-end spawns now replay already-due `FlagEvents` for the spawned recording, so flags planted mid-recording still materialise even if you time-warp past that recording while watching something else.
 - `#466` `RecalculateAndPatch` now defers KSP state patching while a live, active, or pending flight tree is still uncommitted, so mid-flight/load-time recalculations no longer snap funds back down to the committed-ledger target. Discard paths now explicitly recalculate once the pending tree is gone.
 - `#470` Funds recalculation no longer logs `FundsSpending: -0, source=Other` for zero-cost replay entries during module walks. The no-op action still participates in affordability/balance tracking; only the useless VERBOSE line is suppressed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
-- `#486` Quickload-resume on runway takeoffs now trims stale payload across the restored tree before sampling restarts, prunes future-only branch state and rebuilds `BackgroundMap` after that rewind, treats the first post-load environment transition back to the post-trim tail phase as restored state even when EVA parent-fallback rewrites the resumed recording id, and tags overlap-derived save/load seams in `MergeTree` as `cause=save-load-teleport` instead of `sample-skip`.
+- `#486` Quickload after a runway takeoff no longer leaves stale future samples or fake save/load discontinuity warnings in the merged recording tree.
 - `#463` Deferred warp-end spawns now replay already-due `FlagEvents` for the spawned recording, so flags planted mid-recording still materialise even if you time-warp past that recording while watching something else.
 - `#466` `RecalculateAndPatch` now defers KSP state patching while a live, active, or pending flight tree is still uncommitted, so mid-flight/load-time recalculations no longer snap funds back down to the committed-ledger target. Discard paths now explicitly recalculate once the pending tree is gone.
 - `#470` Funds recalculation no longer logs `FundsSpending: -0, source=Other` for zero-cost replay entries during module walks. The no-op action still participates in affordability/balance tracking; only the useless VERBOSE line is suppressed.

--- a/Source/Parsek.Tests/EnvironmentTrackingIntegrationTests.cs
+++ b/Source/Parsek.Tests/EnvironmentTrackingIntegrationTests.cs
@@ -367,6 +367,53 @@ namespace Parsek.Tests
             Assert.Equal(resumedSegment.semiMajorAxis, currentOrbitSegment.semiMajorAxis);
         }
 
+        [Fact]
+        public void TryApplyRestoreEnvironmentResync_MatchingTailEnvironmentRelabelsOpenSection()
+        {
+            recorder.StartNewTrackSection(SegmentEnvironment.SurfaceStationary, ReferenceFrame.Absolute, 100.0);
+            recorder.ArmRestoreEnvironmentResync(
+                SegmentEnvironment.Atmospheric,
+                "test matching tail environment");
+
+            bool applied = recorder.TryApplyRestoreEnvironmentResync(
+                SegmentEnvironment.Atmospheric,
+                106.0);
+            recorder.CloseCurrentTrackSection(110.0);
+
+            Assert.True(applied);
+            Assert.Single(recorder.TrackSections);
+            Assert.Equal(
+                SegmentEnvironment.Atmospheric,
+                recorder.TrackSections[0].environment);
+            Assert.Contains(logLines, l =>
+                l.Contains("Restore environment resync") &&
+                l.Contains("treated as restored state"));
+        }
+
+        [Fact]
+        public void TryApplyRestoreEnvironmentResync_NonMatchingTransitionDisarmsWithoutRelabel()
+        {
+            recorder.StartNewTrackSection(SegmentEnvironment.Atmospheric, ReferenceFrame.Absolute, 200.0);
+            recorder.ArmRestoreEnvironmentResync(
+                SegmentEnvironment.SurfaceStationary,
+                "test non-matching transition");
+
+            bool firstAttempt = recorder.TryApplyRestoreEnvironmentResync(
+                SegmentEnvironment.ExoBallistic,
+                205.0);
+            bool secondAttempt = recorder.TryApplyRestoreEnvironmentResync(
+                SegmentEnvironment.SurfaceStationary,
+                206.0);
+            recorder.CloseCurrentTrackSection(210.0);
+
+            Assert.False(firstAttempt);
+            Assert.False(secondAttempt);
+            Assert.Single(recorder.TrackSections);
+            Assert.Equal(
+                SegmentEnvironment.Atmospheric,
+                recorder.TrackSections[0].environment);
+        }
+
         private static void SetCurrentTrackSectionAnchor(FlightRecorder recorder, uint anchorPid)
         {
             var field = typeof(FlightRecorder).GetField(

--- a/Source/Parsek.Tests/QuickloadResumeTests.cs
+++ b/Source/Parsek.Tests/QuickloadResumeTests.cs
@@ -429,6 +429,298 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void ConfigurePendingQuickloadResumeContext_MatchesActiveTreeEvenIfResumedRecordingChanges()
+        {
+            var tree = MakeTree("resume_tree", "Resume", 1);
+            var other = MakeTree("other_tree", "Other", 1);
+
+            ParsekScenario.ConfigurePendingQuickloadResumeContext(tree);
+
+            Assert.True(ParsekScenario.MatchesPendingQuickloadResumeContext(tree.Id));
+
+            tree.ActiveRecordingId = "parent_after_boarding";
+            Assert.True(ParsekScenario.MatchesPendingQuickloadResumeContext(tree.Id));
+            Assert.False(ParsekScenario.MatchesPendingQuickloadResumeContext(other.Id));
+
+            ParsekScenario.ClearPendingQuickloadResumeContext();
+            Assert.False(ParsekScenario.MatchesPendingQuickloadResumeContext(tree.Id));
+        }
+
+        [Fact]
+        public void TrimRecordingPastUT_RemovesFuturePayloadAcrossBuffers()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "trim_buffers",
+                VesselName = "Buffer Trim",
+                ExplicitStartUT = 100.0,
+                ExplicitEndUT = 180.0,
+            };
+            rec.Points.Add(new TrajectoryPoint { ut = 100.0 });
+            rec.Points.Add(new TrajectoryPoint { ut = 120.0 });
+            rec.Points.Add(new TrajectoryPoint { ut = 160.0 });
+            rec.OrbitSegments.Add(new OrbitSegment { startUT = 110.0, endUT = 170.0 });
+            rec.PartEvents.Add(new PartEvent { ut = 115.0 });
+            rec.PartEvents.Add(new PartEvent { ut = 165.0 });
+            rec.FlagEvents.Add(new FlagEvent { ut = 118.0 });
+            rec.FlagEvents.Add(new FlagEvent { ut = 168.0 });
+            rec.SegmentEvents.Add(new SegmentEvent { ut = 125.0, type = SegmentEventType.TimeJump });
+            rec.SegmentEvents.Add(new SegmentEvent { ut = 175.0, type = SegmentEventType.TimeJump });
+            rec.TrackSections.Add(new TrackSection
+            {
+                environment = SegmentEnvironment.Atmospheric,
+                referenceFrame = ReferenceFrame.Absolute,
+                startUT = 100.0,
+                endUT = 170.0,
+                frames = new List<TrajectoryPoint>
+                {
+                    new TrajectoryPoint { ut = 100.0, altitude = 10.0 },
+                    new TrajectoryPoint { ut = 120.0, altitude = 20.0 },
+                    new TrajectoryPoint { ut = 160.0, altitude = 30.0 },
+                },
+                checkpoints = new List<OrbitSegment>(),
+            });
+
+            bool trimmed = ParsekScenario.TrimRecordingPastUT(rec, 130.0);
+
+            Assert.True(trimmed);
+            Assert.True(rec.FilesDirty);
+            Assert.Equal(2, rec.Points.Count);
+            Assert.Equal(100.0, rec.Points[0].ut);
+            Assert.Equal(120.0, rec.Points[1].ut);
+            Assert.Single(rec.OrbitSegments);
+            Assert.Equal(130.0, rec.OrbitSegments[0].endUT);
+            Assert.Single(rec.PartEvents);
+            Assert.Equal(115.0, rec.PartEvents[0].ut);
+            Assert.Single(rec.FlagEvents);
+            Assert.Equal(118.0, rec.FlagEvents[0].ut);
+            Assert.Single(rec.SegmentEvents);
+            Assert.Equal(125.0, rec.SegmentEvents[0].ut);
+            Assert.Single(rec.TrackSections);
+            Assert.Equal(130.0, rec.TrackSections[0].endUT);
+            Assert.Equal(2, rec.TrackSections[0].frames.Count);
+            Assert.Equal(130.0, rec.ExplicitEndUT);
+        }
+
+        [Fact]
+        public void TrimRecordingPastUT_CutoffBeforeFirstSample_RemovesFutureOnlyRecording()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "trim_future_only",
+                VesselName = "Future Only",
+                ExplicitStartUT = 324.92,
+                ExplicitEndUT = 333.40,
+            };
+            rec.Points.Add(new TrajectoryPoint { ut = 324.92 });
+            rec.Points.Add(new TrajectoryPoint { ut = 333.40 });
+            rec.PartEvents.Add(new PartEvent { ut = 329.70 });
+            rec.TrackSections.Add(new TrackSection
+            {
+                environment = SegmentEnvironment.Atmospheric,
+                referenceFrame = ReferenceFrame.Absolute,
+                startUT = 324.92,
+                endUT = 333.40,
+                frames = new List<TrajectoryPoint>
+                {
+                    new TrajectoryPoint { ut = 324.92, altitude = 71.0 },
+                    new TrajectoryPoint { ut = 333.40, altitude = 94.0 },
+                },
+                checkpoints = new List<OrbitSegment>(),
+            });
+
+            bool trimmed = ParsekScenario.TrimRecordingPastUT(rec, 323.08);
+
+            Assert.True(trimmed);
+            Assert.True(rec.FilesDirty);
+            Assert.Empty(rec.Points);
+            Assert.Empty(rec.PartEvents);
+            Assert.Empty(rec.TrackSections);
+            Assert.Equal(323.08, rec.ExplicitStartUT);
+            Assert.Equal(323.08, rec.ExplicitEndUT);
+        }
+
+        [Fact]
+        public void TrimRecordingPastUT_TailEnvironmentAfterTrimUsesRemainingSection()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "trim_tail_env",
+                VesselName = "Tail Env",
+                ExplicitStartUT = 100.0,
+                ExplicitEndUT = 170.0,
+            };
+            rec.TrackSections.Add(new TrackSection
+            {
+                environment = SegmentEnvironment.SurfaceStationary,
+                referenceFrame = ReferenceFrame.Absolute,
+                startUT = 100.0,
+                endUT = 130.0,
+                frames = new List<TrajectoryPoint>
+                {
+                    new TrajectoryPoint { ut = 100.0, altitude = 0.0 },
+                    new TrajectoryPoint { ut = 120.0, altitude = 0.0 },
+                },
+                checkpoints = new List<OrbitSegment>(),
+            });
+            rec.TrackSections.Add(new TrackSection
+            {
+                environment = SegmentEnvironment.Atmospheric,
+                referenceFrame = ReferenceFrame.Absolute,
+                startUT = 130.0,
+                endUT = 170.0,
+                frames = new List<TrajectoryPoint>
+                {
+                    new TrajectoryPoint { ut = 140.0, altitude = 10.0 },
+                    new TrajectoryPoint { ut = 160.0, altitude = 30.0 },
+                },
+                checkpoints = new List<OrbitSegment>(),
+            });
+
+            bool trimmed = ParsekScenario.TrimRecordingPastUT(rec, 125.0);
+            bool hasTailEnv = FlightRecorder.TryGetTailTrackSectionEnvironment(rec, out SegmentEnvironment tailEnv);
+
+            Assert.True(trimmed);
+            Assert.True(hasTailEnv);
+            Assert.Equal(SegmentEnvironment.SurfaceStationary, tailEnv);
+        }
+
+        [Fact]
+        public void TrimRecordingTreePastUT_TrimsSiblingRecordingsAcrossTree()
+        {
+            var tree = MakeTree("trim_tree", "Trim Tree", 2);
+            var activeRec = tree.Recordings[tree.ActiveRecordingId];
+            activeRec.Points.Clear();
+            activeRec.TrackSections.Clear();
+            activeRec.ExplicitStartUT = 100.0;
+            activeRec.ExplicitEndUT = 160.0;
+            activeRec.Points.Add(new TrajectoryPoint { ut = 100.0 });
+            activeRec.Points.Add(new TrajectoryPoint { ut = 160.0 });
+            activeRec.TrackSections.Add(new TrackSection
+            {
+                environment = SegmentEnvironment.SurfaceStationary,
+                referenceFrame = ReferenceFrame.Absolute,
+                startUT = 100.0,
+                endUT = 160.0,
+                frames = new List<TrajectoryPoint>
+                {
+                    new TrajectoryPoint { ut = 100.0, altitude = 0.0 },
+                    new TrajectoryPoint { ut = 160.0, altitude = 5.0 },
+                },
+                checkpoints = new List<OrbitSegment>(),
+            });
+
+            var siblingRec = tree.Recordings["child_trim_tree_1"];
+            siblingRec.Points.Clear();
+            siblingRec.PartEvents.Clear();
+            siblingRec.TrackSections.Clear();
+            siblingRec.ExplicitStartUT = 120.0;
+            siblingRec.ExplicitEndUT = 180.0;
+            siblingRec.Points.Add(new TrajectoryPoint { ut = 120.0 });
+            siblingRec.Points.Add(new TrajectoryPoint { ut = 175.0 });
+            siblingRec.PartEvents.Add(new PartEvent { ut = 176.0 });
+            siblingRec.TrackSections.Add(new TrackSection
+            {
+                environment = SegmentEnvironment.Atmospheric,
+                referenceFrame = ReferenceFrame.Absolute,
+                startUT = 120.0,
+                endUT = 180.0,
+                frames = new List<TrajectoryPoint>
+                {
+                    new TrajectoryPoint { ut = 120.0, altitude = 10.0 },
+                    new TrajectoryPoint { ut = 175.0, altitude = 30.0 },
+                },
+                checkpoints = new List<OrbitSegment>(),
+            });
+
+            bool trimmed = ParsekScenario.TrimRecordingTreePastUT(tree, 150.0);
+
+            Assert.True(trimmed);
+            Assert.Equal(150.0, activeRec.ExplicitEndUT);
+            Assert.Single(activeRec.Points);
+            Assert.Equal(150.0, siblingRec.ExplicitEndUT);
+            Assert.Single(siblingRec.Points);
+            Assert.Empty(siblingRec.PartEvents);
+            Assert.Single(siblingRec.TrackSections);
+            Assert.Equal(150.0, siblingRec.TrackSections[0].endUT);
+        }
+
+        [Fact]
+        public void TrimRecordingTreePastUT_PrunesFutureOnlyBranchStateAndRebuildsBackgroundMap()
+        {
+            var tree = MakeTree("future_branch_tree", "Future Branch Tree", 2);
+            var rootRec = tree.Recordings[tree.RootRecordingId];
+            rootRec.VesselPersistentId = 111;
+
+            var futureRec = tree.Recordings["child_future_branch_tree_1"];
+            futureRec.Points.Clear();
+            futureRec.TrackSections.Clear();
+            futureRec.ExplicitStartUT = 170.0;
+            futureRec.ExplicitEndUT = 180.0;
+            futureRec.VesselPersistentId = 222;
+            futureRec.ParentBranchPointId = "bp_future";
+            futureRec.Points.Add(new TrajectoryPoint { ut = 170.0 });
+            futureRec.Points.Add(new TrajectoryPoint { ut = 180.0 });
+
+            rootRec.ChildBranchPointId = "bp_future";
+            tree.BranchPoints.Add(new BranchPoint
+            {
+                Id = "bp_future",
+                UT = 140.0,
+                Type = BranchPointType.EVA,
+                ParentRecordingIds = new List<string> { rootRec.RecordingId },
+                ChildRecordingIds = new List<string> { futureRec.RecordingId }
+            });
+            tree.BackgroundMap[futureRec.VesselPersistentId] = futureRec.RecordingId;
+
+            bool trimmed = ParsekScenario.TrimRecordingTreePastUT(tree, 150.0);
+
+            Assert.True(trimmed);
+            Assert.False(tree.Recordings.ContainsKey(futureRec.RecordingId));
+            Assert.Empty(tree.BranchPoints);
+            Assert.Null(rootRec.ChildBranchPointId);
+            Assert.Empty(tree.BackgroundMap);
+        }
+
+        [Fact]
+        public void TrimRecordingTreePastUT_PrunesFutureOnlyBranchEvenWhenPayloadAlreadyCollapsedAtCutoff()
+        {
+            var tree = MakeTree("future_empty_tree", "Future Empty Tree", 2);
+            var rootRec = tree.Recordings[tree.RootRecordingId];
+            rootRec.VesselPersistentId = 111;
+
+            var futureRec = tree.Recordings["child_future_empty_tree_1"];
+            futureRec.Points.Clear();
+            futureRec.TrackSections.Clear();
+            futureRec.PartEvents.Clear();
+            futureRec.FlagEvents.Clear();
+            futureRec.SegmentEvents.Clear();
+            futureRec.ExplicitStartUT = 150.0;
+            futureRec.ExplicitEndUT = 150.0;
+            futureRec.VesselPersistentId = 222;
+            futureRec.ParentBranchPointId = "bp_future_empty";
+
+            rootRec.ChildBranchPointId = "bp_future_empty";
+            tree.BranchPoints.Add(new BranchPoint
+            {
+                Id = "bp_future_empty",
+                UT = 150.0,
+                Type = BranchPointType.EVA,
+                ParentRecordingIds = new List<string> { rootRec.RecordingId },
+                ChildRecordingIds = new List<string> { futureRec.RecordingId }
+            });
+            tree.BackgroundMap[futureRec.VesselPersistentId] = futureRec.RecordingId;
+
+            bool trimmed = ParsekScenario.TrimRecordingTreePastUT(tree, 150.0);
+
+            Assert.True(trimmed);
+            Assert.False(tree.Recordings.ContainsKey(futureRec.RecordingId));
+            Assert.Empty(tree.BranchPoints);
+            Assert.Null(rootRec.ChildBranchPointId);
+            Assert.Empty(tree.BackgroundMap);
+        }
+
+        [Fact]
         public void SaveActiveTreeIfAny_CopiesRecorderRewindSaveToSerializedRoot()
         {
             string srcRoot = System.IO.Path.GetFullPath(

--- a/Source/Parsek.Tests/QuickloadResumeTests.cs
+++ b/Source/Parsek.Tests/QuickloadResumeTests.cs
@@ -50,6 +50,9 @@ namespace Parsek.Tests
             GroupHierarchyStore.ResetGroupsForTesting();
             CrewReservationManager.ResetReplacementsForTesting();
             RewindContext.ResetForTesting();
+            ParsekScenario.ClearPendingQuickloadResumeContext();
+            ParsekScenario.pendingActiveTreeResumeRewindSave = null;
+            FlightRecorder.QuickloadResumeUTProviderForTesting = null;
             ParsekLog.ResetTestOverrides();
             ParsekLog.SuppressLogging = true;
             RecordingStore.SuppressLogging = true;
@@ -447,6 +450,52 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void PrepareQuickloadResumeStateIfNeeded_LogsResumePrepSummary()
+        {
+            var tree = MakeTree("resume_prep_tree", "Resume Prep Tree", 2);
+            var activeRec = tree.Recordings[tree.ActiveRecordingId];
+            activeRec.Points.Clear();
+            activeRec.TrackSections.Clear();
+            activeRec.ExplicitStartUT = 100.0;
+            activeRec.ExplicitEndUT = 180.0;
+            activeRec.Points.Add(new TrajectoryPoint { ut = 100.0 });
+            activeRec.Points.Add(new TrajectoryPoint { ut = 180.0 });
+            activeRec.TrackSections.Add(new TrackSection
+            {
+                environment = SegmentEnvironment.Atmospheric,
+                referenceFrame = ReferenceFrame.Absolute,
+                startUT = 100.0,
+                endUT = 180.0,
+                frames = new List<TrajectoryPoint>
+                {
+                    new TrajectoryPoint { ut = 100.0, altitude = 0.0 },
+                    new TrajectoryPoint { ut = 180.0, altitude = 10.0 },
+                },
+                checkpoints = new List<OrbitSegment>(),
+            });
+
+            var recorder = new FlightRecorder
+            {
+                ActiveTree = tree,
+            };
+            FlightRecorder.QuickloadResumeUTProviderForTesting = () => 150.0;
+            ParsekScenario.ConfigurePendingQuickloadResumeContext(tree);
+
+            logLines.Clear();
+            InvokePrepareQuickloadResumeStateIfNeeded(recorder);
+
+            Assert.Equal(150.0, activeRec.ExplicitEndUT);
+            Assert.False(ParsekScenario.MatchesPendingQuickloadResumeContext(tree.Id));
+            Assert.Contains(logLines, l =>
+                l.Contains("Quickload resume prep:") &&
+                l.Contains($"activeRec='{activeRec.RecordingId}'") &&
+                l.Contains("cutoffUT=150.00") &&
+                l.Contains("preTrimEndUT=180.00") &&
+                l.Contains("treeTrimmed=True") &&
+                l.Contains("envResyncTarget=Atmospheric"));
+        }
+
+        [Fact]
         public void TrimRecordingPastUT_RemovesFuturePayloadAcrossBuffers()
         {
             var rec = new Recording
@@ -633,6 +682,7 @@ namespace Parsek.Tests
                 checkpoints = new List<OrbitSegment>(),
             });
 
+            logLines.Clear();
             bool trimmed = ParsekScenario.TrimRecordingTreePastUT(tree, 150.0);
 
             Assert.True(trimmed);
@@ -643,6 +693,13 @@ namespace Parsek.Tests
             Assert.Empty(siblingRec.PartEvents);
             Assert.Single(siblingRec.TrackSections);
             Assert.Equal(150.0, siblingRec.TrackSections[0].endUT);
+            Assert.Contains(logLines, l =>
+                l.Contains("Quickload tree trim:") &&
+                l.Contains("tree='Trim Tree'") &&
+                l.Contains("cutoffUT=150.00") &&
+                l.Contains("trimmedRecordings=2/2") &&
+                l.Contains("prunedFutureRecordings=0") &&
+                l.Contains("backgroundEntries=0"));
         }
 
         [Fact]
@@ -673,6 +730,7 @@ namespace Parsek.Tests
             });
             tree.BackgroundMap[futureRec.VesselPersistentId] = futureRec.RecordingId;
 
+            logLines.Clear();
             bool trimmed = ParsekScenario.TrimRecordingTreePastUT(tree, 150.0);
 
             Assert.True(trimmed);
@@ -680,6 +738,12 @@ namespace Parsek.Tests
             Assert.Empty(tree.BranchPoints);
             Assert.Null(rootRec.ChildBranchPointId);
             Assert.Empty(tree.BackgroundMap);
+            Assert.Contains(logLines, l =>
+                l.Contains("Quickload tree trim:") &&
+                l.Contains("tree='Future Branch Tree'") &&
+                l.Contains("prunedFutureRecordings=1") &&
+                l.Contains("prunedBranchPoints=1") &&
+                l.Contains("backgroundEntries=0"));
         }
 
         [Fact]
@@ -711,6 +775,7 @@ namespace Parsek.Tests
             });
             tree.BackgroundMap[futureRec.VesselPersistentId] = futureRec.RecordingId;
 
+            logLines.Clear();
             bool trimmed = ParsekScenario.TrimRecordingTreePastUT(tree, 150.0);
 
             Assert.True(trimmed);
@@ -718,6 +783,12 @@ namespace Parsek.Tests
             Assert.Empty(tree.BranchPoints);
             Assert.Null(rootRec.ChildBranchPointId);
             Assert.Empty(tree.BackgroundMap);
+            Assert.Contains(logLines, l =>
+                l.Contains("Quickload tree trim:") &&
+                l.Contains("tree='Future Empty Tree'") &&
+                l.Contains("prunedFutureRecordings=1") &&
+                l.Contains("prunedBranchPoints=1") &&
+                l.Contains("backgroundEntries=0"));
         }
 
         [Fact]
@@ -1724,6 +1795,16 @@ namespace Parsek.Tests
             {
                 initialLoadDoneField.SetValue(null, previousInitialLoadDone);
             }
+        }
+
+        private static void InvokePrepareQuickloadResumeStateIfNeeded(FlightRecorder recorder)
+        {
+            MethodInfo method = typeof(FlightRecorder).GetMethod(
+                "PrepareQuickloadResumeStateIfNeeded",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+
+            Assert.NotNull(method);
+            method.Invoke(recorder, null);
         }
     }
 }

--- a/Source/Parsek.Tests/SessionMergerTests.cs
+++ b/Source/Parsek.Tests/SessionMergerTests.cs
@@ -1019,6 +1019,128 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void LooksLikeSaveLoadTeleportBoundary_OverlappingActiveSections_ReturnsTrue()
+        {
+            var trimmedFutureTail = MakeSection(
+                100.0, 110.0, TrackSectionSource.Active,
+                alt: 70000.0, endAlt: 70000.0);
+            var resumedOverlap = new TrackSection
+            {
+                environment = SegmentEnvironment.Atmospheric,
+                referenceFrame = ReferenceFrame.Absolute,
+                startUT = 105.0,
+                endUT = 120.0,
+                source = TrackSectionSource.Active,
+                sampleRateHz = 10f,
+                frames = new List<TrajectoryPoint>
+                {
+                    new TrajectoryPoint
+                    {
+                        ut = 105.0,
+                        altitude = 70005.0,
+                        bodyName = "Kerbin",
+                        rotation = Quaternion.identity,
+                        velocity = Vector3.zero
+                    },
+                    new TrajectoryPoint
+                    {
+                        ut = 110.5,
+                        altitude = 70500.0,
+                        bodyName = "Kerbin",
+                        rotation = Quaternion.identity,
+                        velocity = Vector3.zero
+                    },
+                    new TrajectoryPoint
+                    {
+                        ut = 120.0,
+                        altitude = 70510.0,
+                        bodyName = "Kerbin",
+                        rotation = Quaternion.identity,
+                        velocity = Vector3.zero
+                    }
+                },
+                checkpoints = new List<OrbitSegment>()
+            };
+            var mergedHead = MakeSection(
+                110.0, 120.0, TrackSectionSource.Active,
+                alt: 70500.0, endAlt: 70510.0);
+
+            Assert.True(SessionMerger.LooksLikeSaveLoadTeleportBoundary(
+                new List<TrackSection> { trimmedFutureTail, resumedOverlap },
+                trimmedFutureTail,
+                mergedHead));
+        }
+
+        [Fact]
+        public void MergeTree_DiscontinuityWarning_OverlapSeam_TaggedSaveLoadTeleport()
+        {
+            var futureTail = MakeSection(
+                100.0, 110.0, TrackSectionSource.Active,
+                alt: 70000.0, endAlt: 70000.0);
+            futureTail.frames[futureTail.frames.Count - 1] = new TrajectoryPoint
+            {
+                ut = 110.0,
+                altitude = 70000.0,
+                bodyName = "Kerbin",
+                rotation = Quaternion.identity,
+                velocity = new Vector3(10f, 0f, 0f)
+            };
+
+            var resumed = new TrackSection
+            {
+                environment = SegmentEnvironment.Atmospheric,
+                referenceFrame = ReferenceFrame.Absolute,
+                startUT = 105.0,
+                endUT = 120.0,
+                source = TrackSectionSource.Active,
+                sampleRateHz = 10f,
+                frames = new List<TrajectoryPoint>
+                {
+                    new TrajectoryPoint
+                    {
+                        ut = 105.0,
+                        altitude = 70005.0,
+                        bodyName = "Kerbin",
+                        rotation = Quaternion.identity,
+                        velocity = Vector3.zero
+                    },
+                    new TrajectoryPoint
+                    {
+                        ut = 110.5,
+                        altitude = 70500.0,
+                        bodyName = "Kerbin",
+                        rotation = Quaternion.identity,
+                        velocity = Vector3.zero
+                    },
+                    new TrajectoryPoint
+                    {
+                        ut = 120.0,
+                        altitude = 70510.0,
+                        bodyName = "Kerbin",
+                        rotation = Quaternion.identity,
+                        velocity = Vector3.zero
+                    }
+                },
+                checkpoints = new List<OrbitSegment>(),
+                boundaryDiscontinuityMeters = 0f
+            };
+
+            var rec = MakeRecording(
+                "rec-486-teleport",
+                "Teleport Vessel",
+                new List<TrackSection> { futureTail, resumed });
+            var tree = MakeTree("486 Teleport", rec);
+
+            SessionMerger.MergeTree(tree);
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[WARN]") &&
+                l.Contains("[Merger]") &&
+                l.Contains("boundary discontinuity=") &&
+                l.Contains("cause=save-load-teleport"));
+        }
+
+        [Fact]
         public void ClassifyBoundaryDiscontinuity_StationaryWithFloor_TaggedUnrecordedGap()
         {
             // Stationary vessel (vMag=0) with a small jump under the 5m floor:

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -14,6 +14,8 @@ namespace Parsek
     /// </summary>
     public class FlightRecorder
     {
+        internal static Func<double> QuickloadResumeUTProviderForTesting;
+
         internal enum VesselSwitchDecision
         {
             None,
@@ -283,7 +285,7 @@ namespace Parsek
                 return;
             }
 
-            double resumeUT = Planetarium.GetUniversalTime();
+            double resumeUT = GetQuickloadResumeUT();
             double preTrimEndUT = activeRec.EndUT;
             bool treeTrimmed = ParsekScenario.TrimRecordingTreePastUT(ActiveTree, resumeUT);
             bool hasTailEnv = TryGetTailTrackSectionEnvironment(activeRec, out SegmentEnvironment tailEnv);
@@ -297,6 +299,14 @@ namespace Parsek
                 $"preTrimEndUT={preTrimEndUT.ToString("F2", CultureInfo.InvariantCulture)} " +
                 $"treeTrimmed={treeTrimmed}" +
                 (hasTailEnv ? $" envResyncTarget={tailEnv}" : ""));
+        }
+
+        private static double GetQuickloadResumeUT()
+        {
+            if (QuickloadResumeUTProviderForTesting != null)
+                return QuickloadResumeUTProviderForTesting();
+
+            return Planetarium.GetUniversalTime();
         }
 
         internal static bool TryGetTailTrackSectionEnvironment(Recording rec, out SegmentEnvironment env)

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -37,6 +37,8 @@ namespace Parsek
         private EnvironmentHysteresis environmentHysteresis;
         private TrackSection currentTrackSection;
         private bool trackSectionActive;
+        private bool pendingRestoreEnvironmentResync;
+        private SegmentEnvironment restoreEnvironmentResyncTarget;
 
         // Anchor detection for RELATIVE frame (Phase 3a)
         private bool isRelativeMode;
@@ -228,6 +230,94 @@ namespace Parsek
             ParsekLog.Verbose("Recorder",
                 $"Start location restored: body={bodyName ?? "(null)"}, biome={biome ?? "(null)"}, " +
                 $"situation={situation ?? "(null)"}, launchSite={launchSite ?? "(null)"}");
+        }
+
+        internal void ArmRestoreEnvironmentResync(SegmentEnvironment target, string reason)
+        {
+            pendingRestoreEnvironmentResync = true;
+            restoreEnvironmentResyncTarget = target;
+            ParsekLog.Verbose("Recorder",
+                $"Restore environment resync armed: target={target} ({reason})");
+        }
+
+        internal bool TryApplyRestoreEnvironmentResync(SegmentEnvironment transitionedEnv, double ut)
+        {
+            if (!pendingRestoreEnvironmentResync)
+                return false;
+
+            pendingRestoreEnvironmentResync = false;
+            if (transitionedEnv != restoreEnvironmentResyncTarget || !trackSectionActive)
+            {
+                ParsekLog.Verbose("Recorder",
+                    $"Restore environment resync disarmed: transition={transitionedEnv} " +
+                    $"target={restoreEnvironmentResyncTarget} trackSectionActive={trackSectionActive}");
+                return false;
+            }
+
+            SegmentEnvironment previousEnv = currentTrackSection.environment;
+            currentTrackSection.environment = transitionedEnv;
+            ParsekLog.Info("Recorder",
+                $"Restore environment resync: {previousEnv} -> {transitionedEnv} " +
+                $"at UT={ut.ToString("F2", CultureInfo.InvariantCulture)} treated as restored state");
+            return true;
+        }
+
+        private void PrepareQuickloadResumeStateIfNeeded()
+        {
+            pendingRestoreEnvironmentResync = false;
+
+            if (ActiveTree == null || string.IsNullOrEmpty(ActiveTree.Id))
+                return;
+
+            string activeRecId = ActiveTree.ActiveRecordingId;
+            if (string.IsNullOrEmpty(activeRecId)
+                || !ParsekScenario.MatchesPendingQuickloadResumeContext(ActiveTree.Id))
+                return;
+
+            if (!ActiveTree.Recordings.TryGetValue(activeRecId, out Recording activeRec) || activeRec == null)
+            {
+                ParsekLog.Warn("Recorder",
+                    $"Quickload resume prep skipped: active tree '{ActiveTree.TreeName}' " +
+                    $"missing activeRecId={activeRecId}");
+                ParsekScenario.ClearPendingQuickloadResumeContext();
+                return;
+            }
+
+            double resumeUT = Planetarium.GetUniversalTime();
+            double preTrimEndUT = activeRec.EndUT;
+            bool treeTrimmed = ParsekScenario.TrimRecordingTreePastUT(ActiveTree, resumeUT);
+            bool hasTailEnv = TryGetTailTrackSectionEnvironment(activeRec, out SegmentEnvironment tailEnv);
+            if (hasTailEnv)
+                ArmRestoreEnvironmentResync(tailEnv, "quickload-resume tail environment");
+
+            ParsekScenario.ClearPendingQuickloadResumeContext();
+            ParsekLog.Info("Recorder",
+                $"Quickload resume prep: activeRec='{activeRec.RecordingId}' " +
+                $"cutoffUT={resumeUT.ToString("F2", CultureInfo.InvariantCulture)} " +
+                $"preTrimEndUT={preTrimEndUT.ToString("F2", CultureInfo.InvariantCulture)} " +
+                $"treeTrimmed={treeTrimmed}" +
+                (hasTailEnv ? $" envResyncTarget={tailEnv}" : ""));
+        }
+
+        internal static bool TryGetTailTrackSectionEnvironment(Recording rec, out SegmentEnvironment env)
+        {
+            if (rec != null && rec.TrackSections != null)
+            {
+                for (int i = rec.TrackSections.Count - 1; i >= 0; i--)
+                {
+                    TrackSection section = rec.TrackSections[i];
+                    bool hasFrames = section.frames != null && section.frames.Count > 0;
+                    bool hasCheckpoints = section.checkpoints != null && section.checkpoints.Count > 0;
+                    if (hasFrames || hasCheckpoints || section.endUT > section.startUT)
+                    {
+                        env = section.environment;
+                        return true;
+                    }
+                }
+            }
+
+            env = default(SegmentEnvironment);
+            return false;
         }
 
         public double RewindReservedFunds { get; private set; }
@@ -4201,6 +4291,7 @@ namespace Parsek
             FlagEvents.Clear();
             SegmentEvents.Clear();
             ResetPartEventTrackingState(v, emitSeedEvents: !isPromotion);
+            PrepareQuickloadResumeStateIfNeeded();
 
             LogVisualRecordingCoverage(v);
 
@@ -5311,8 +5402,12 @@ namespace Parsek
             if (environmentHysteresis != null)
             {
                 var rawEnv = ClassifyCurrentEnvironment(v);
-                if (environmentHysteresis.Update(rawEnv, Planetarium.GetUniversalTime()))
+                double currentUT = Planetarium.GetUniversalTime();
+                if (environmentHysteresis.Update(rawEnv, currentUT))
                 {
+                    if (TryApplyRestoreEnvironmentResync(environmentHysteresis.CurrentEnvironment, currentUT))
+                        return;
+
                     // Environment changed — close current section, start new one.
                     // Preserve current reference frame (RELATIVE stays RELATIVE).
                     // Sample boundary point BEFORE closing — adaptive sampler may have
@@ -5324,9 +5419,9 @@ namespace Parsek
                     TrajectoryPoint? boundaryPoint = GetLastTrackSectionFrame();
 
                     var currentRef = isRelativeMode ? ReferenceFrame.Relative : ReferenceFrame.Absolute;
-                    CloseCurrentTrackSection(Planetarium.GetUniversalTime());
+                    CloseCurrentTrackSection(currentUT);
                     StartNewTrackSection(environmentHysteresis.CurrentEnvironment, currentRef,
-                        Planetarium.GetUniversalTime());
+                        currentUT);
                     if (isRelativeMode)
                         currentTrackSection.anchorVesselId = currentAnchorPid;
 

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -1136,6 +1136,7 @@ namespace Parsek
                     // StashActiveTreeForVesselSwitch (LimboVesselSwitch — bug #266).
                     // #434: on revert the block above already discarded the pending tree, so
                     // HasPendingTree will be false here and the dispatch is skipped entirely.
+                    ClearPendingQuickloadResumeContext();
                     if (RecordingStore.HasPendingTree
                         && (RecordingStore.PendingTreeStateValue == PendingTreeState.Limbo
                             || RecordingStore.PendingTreeStateValue == PendingTreeState.LimboVesselSwitch))
@@ -1148,6 +1149,7 @@ namespace Parsek
                             // to OnFlightReady for the vessel-switch restore coroutine, which
                             // reinstalls the tree and (optionally) promotes the new active
                             // vessel from BackgroundMap.
+                            ClearPendingQuickloadResumeContext();
                             ScheduleActiveTreeRestoreOnFlightReady = ActiveTreeRestoreMode.VesselSwitch;
                             ParsekLog.Info("Scenario",
                                 $"OnLoad: pending-LimboVesselSwitch tree '{RecordingStore.PendingTree?.TreeName}' " +
@@ -1167,6 +1169,7 @@ namespace Parsek
                             // exact case where vessels ARE still loaded in FlightGlobals
                             // (it's a vessel switch, not a quickload — no scene reset).
                             FinalizePendingLimboTreeForRevert();
+                            ClearPendingQuickloadResumeContext();
                             ParsekLog.Info("Scenario",
                                 "OnLoad: Limbo tree finalized on vessel switch (safety-net path; " +
                                 "stash didn't pre-transition — usually means a guard at stash " +
@@ -1177,6 +1180,7 @@ namespace Parsek
                             // Quickload or cold-start resume: defer restore to OnFlightReady.
                             // ParsekFlight.RestoreActiveTreeFromPending picks up the
                             // pending-Limbo tree and wires a fresh recorder to it.
+                            ConfigurePendingQuickloadResumeContext(RecordingStore.PendingTree);
                             ScheduleActiveTreeRestoreOnFlightReady = ActiveTreeRestoreMode.Quickload;
                             ParsekLog.Info("Scenario",
                                 $"OnLoad: pending-Limbo tree '{RecordingStore.PendingTree?.TreeName}' " +
@@ -1280,6 +1284,7 @@ namespace Parsek
                 // quickload. Without this, cold-start resume silently drops the active
                 // tree and the player's in-progress mission fragments just like the
                 // original Bug C scenario.
+                ClearPendingQuickloadResumeContext();
                 if (TryRestoreActiveTreeNode(node))
                 {
                     // Flag the coroutine to run on OnFlightReady so the active vessel is
@@ -1295,6 +1300,10 @@ namespace Parsek
                         RecordingStore.PendingTreeStateValue == PendingTreeState.LimboVesselSwitch
                             ? ActiveTreeRestoreMode.VesselSwitch
                             : ActiveTreeRestoreMode.Quickload;
+                    if (ScheduleActiveTreeRestoreOnFlightReady == ActiveTreeRestoreMode.Quickload)
+                        ConfigurePendingQuickloadResumeContext(RecordingStore.PendingTree);
+                    else
+                        ClearPendingQuickloadResumeContext();
                     ParsekLog.Info("Scenario",
                         $"OnLoad: cold-start active tree detected (state={RecordingStore.PendingTreeStateValue}) — " +
                         $"deferred to OnFlightReady as {ScheduleActiveTreeRestoreOnFlightReady}");
@@ -2081,6 +2090,349 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Truncates a live active-tree recording to the current quickload-resume UT so
+        /// post-load recording can continue from the restored timeline without appending
+        /// stale samples/events from the pre-load future. Returns true when any payload was
+        /// removed or clipped.
+        /// </summary>
+        internal static bool TrimRecordingPastUT(Recording rec, double cutoffUT)
+        {
+            if (rec == null || double.IsNaN(cutoffUT) || double.IsInfinity(cutoffUT))
+                return false;
+
+            bool mutated = false;
+
+            mutated |= RemoveItemsPastUT(rec.Points, cutoffUT, p => p.ut);
+            mutated |= TrimOrbitSegmentsPastUT(rec.OrbitSegments, cutoffUT);
+            mutated |= RemoveItemsPastUT(rec.PartEvents, cutoffUT, e => e.ut);
+            mutated |= RemoveItemsPastUT(rec.FlagEvents, cutoffUT, e => e.ut);
+            mutated |= RemoveItemsPastUT(rec.SegmentEvents, cutoffUT, e => e.ut);
+            mutated |= TrimTrackSectionsPastUT(rec.TrackSections, cutoffUT);
+
+            if (!double.IsNaN(rec.ExplicitStartUT) && rec.ExplicitStartUT > cutoffUT)
+            {
+                rec.ExplicitStartUT = cutoffUT;
+                mutated = true;
+            }
+
+            if (double.IsNaN(rec.ExplicitEndUT) || rec.ExplicitEndUT > cutoffUT)
+            {
+                rec.ExplicitEndUT = cutoffUT;
+                mutated = true;
+            }
+
+            if (mutated)
+                rec.MarkFilesDirty();
+
+            return mutated;
+        }
+
+        internal static bool TrimRecordingTreePastUT(RecordingTree tree, double cutoffUT)
+        {
+            if (tree == null || tree.Recordings == null || tree.Recordings.Count == 0
+                || double.IsNaN(cutoffUT) || double.IsInfinity(cutoffUT))
+            {
+                return false;
+            }
+
+            bool mutated = false;
+            int trimmedCount = 0;
+            HashSet<string> futureOnlyIds = CollectFutureOnlyRecordingIds(tree, cutoffUT);
+            int recordingCountBeforeTrim = tree.Recordings.Count;
+            foreach (Recording rec in tree.Recordings.Values)
+            {
+                if (TrimRecordingPastUT(rec, cutoffUT))
+                {
+                    mutated = true;
+                    trimmedCount++;
+                }
+            }
+
+            if (mutated || (futureOnlyIds != null && futureOnlyIds.Count > 0))
+            {
+                int prunedRecordings = PruneFutureOnlyRecordings(tree, futureOnlyIds);
+                int prunedBranchPoints = RemoveEmptyBranchPoints(tree);
+                if (prunedRecordings > 0 || prunedBranchPoints > 0)
+                    mutated = true;
+
+                tree.RebuildBackgroundMap();
+                ParsekLog.Info("Scenario",
+                    $"Quickload tree trim: tree='{tree.TreeName}' cutoffUT={cutoffUT.ToString("F2", CultureInfo.InvariantCulture)} " +
+                    $"trimmedRecordings={trimmedCount}/{recordingCountBeforeTrim} " +
+                    $"prunedFutureRecordings={prunedRecordings} prunedBranchPoints={prunedBranchPoints} " +
+                    $"backgroundEntries={tree.BackgroundMap.Count}");
+            }
+
+            return mutated;
+        }
+
+        private static HashSet<string> CollectFutureOnlyRecordingIds(RecordingTree tree, double cutoffUT)
+        {
+            HashSet<string> futureOnlyIds = null;
+            foreach (KeyValuePair<string, Recording> kvp in tree.Recordings)
+            {
+                string recordingId = kvp.Key;
+                Recording rec = kvp.Value;
+                if (rec == null
+                    || rec.SidecarLoadFailed
+                    || string.Equals(recordingId, tree.ActiveRecordingId, StringComparison.Ordinal)
+                    || string.Equals(recordingId, tree.RootRecordingId, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (rec.StartUT >= cutoffUT)
+                {
+                    if (futureOnlyIds == null)
+                        futureOnlyIds = new HashSet<string>(StringComparer.Ordinal);
+                    futureOnlyIds.Add(recordingId);
+                }
+            }
+
+            return futureOnlyIds;
+        }
+
+        private static int PruneFutureOnlyRecordings(RecordingTree tree, HashSet<string> futureOnlyIds)
+        {
+            if (tree == null || futureOnlyIds == null || futureOnlyIds.Count == 0)
+                return 0;
+
+            int removed = 0;
+            foreach (string recordingId in futureOnlyIds)
+            {
+                if (tree.Recordings.Remove(recordingId))
+                    removed++;
+            }
+
+            if (removed == 0)
+                return 0;
+
+            if (tree.BranchPoints != null)
+            {
+                for (int i = 0; i < tree.BranchPoints.Count; i++)
+                {
+                    BranchPoint bp = tree.BranchPoints[i];
+                    bp.ParentRecordingIds?.RemoveAll(id => futureOnlyIds.Contains(id));
+                    bp.ChildRecordingIds?.RemoveAll(id => futureOnlyIds.Contains(id));
+                }
+            }
+
+            foreach (Recording rec in tree.Recordings.Values)
+            {
+                if (rec != null && futureOnlyIds.Contains(rec.ParentRecordingId))
+                    rec.ParentRecordingId = null;
+            }
+
+            return removed;
+        }
+
+        private static int RemoveEmptyBranchPoints(RecordingTree tree)
+        {
+            if (tree == null || tree.BranchPoints == null || tree.BranchPoints.Count == 0)
+                return 0;
+
+            HashSet<string> removedBranchPointIds = null;
+            int removed = 0;
+            for (int i = tree.BranchPoints.Count - 1; i >= 0; i--)
+            {
+                BranchPoint bp = tree.BranchPoints[i];
+                int parentCount = bp.ParentRecordingIds != null ? bp.ParentRecordingIds.Count : 0;
+                int childCount = bp.ChildRecordingIds != null ? bp.ChildRecordingIds.Count : 0;
+                if (parentCount > 0 && childCount > 0)
+                    continue;
+
+                if (removedBranchPointIds == null)
+                    removedBranchPointIds = new HashSet<string>(StringComparer.Ordinal);
+                removedBranchPointIds.Add(bp.Id);
+                tree.BranchPoints.RemoveAt(i);
+                removed++;
+            }
+
+            if (removedBranchPointIds == null || removedBranchPointIds.Count == 0)
+                return 0;
+
+            foreach (Recording rec in tree.Recordings.Values)
+            {
+                if (rec == null)
+                    continue;
+
+                if (!string.IsNullOrEmpty(rec.ParentBranchPointId)
+                    && removedBranchPointIds.Contains(rec.ParentBranchPointId))
+                {
+                    rec.ParentBranchPointId = null;
+                }
+
+                if (!string.IsNullOrEmpty(rec.ChildBranchPointId)
+                    && removedBranchPointIds.Contains(rec.ChildBranchPointId))
+                {
+                    rec.ChildBranchPointId = null;
+                }
+            }
+
+            return removed;
+        }
+
+        private static bool TrimOrbitSegmentsPastUT(List<OrbitSegment> segments, double cutoffUT)
+        {
+            if (segments == null || segments.Count == 0)
+                return false;
+
+            bool mutated = false;
+            for (int i = segments.Count - 1; i >= 0; i--)
+            {
+                OrbitSegment seg = segments[i];
+                if (seg.startUT >= cutoffUT)
+                {
+                    segments.RemoveAt(i);
+                    mutated = true;
+                    continue;
+                }
+
+                if (seg.endUT > cutoffUT)
+                {
+                    seg.endUT = cutoffUT;
+                    segments[i] = seg;
+                    mutated = true;
+                }
+            }
+
+            return mutated;
+        }
+
+        private static bool TrimTrackSectionsPastUT(List<TrackSection> sections, double cutoffUT)
+        {
+            if (sections == null || sections.Count == 0)
+                return false;
+
+            bool mutated = false;
+            for (int i = sections.Count - 1; i >= 0; i--)
+            {
+                TrackSection section = sections[i];
+                if (section.startUT >= cutoffUT)
+                {
+                    sections.RemoveAt(i);
+                    mutated = true;
+                    continue;
+                }
+
+                bool sectionMutated = false;
+                if (section.endUT > cutoffUT)
+                {
+                    section.endUT = cutoffUT;
+                    sectionMutated = true;
+                }
+
+                sectionMutated |= TrimTrackSectionFramesPastUT(ref section, cutoffUT);
+                sectionMutated |= TrimTrackSectionCheckpointsPastUT(ref section, cutoffUT);
+
+                bool hasFrames = section.frames != null && section.frames.Count > 0;
+                bool hasCheckpoints = section.checkpoints != null && section.checkpoints.Count > 0;
+                if (!hasFrames && !hasCheckpoints)
+                {
+                    sections.RemoveAt(i);
+                    mutated = true;
+                    continue;
+                }
+
+                if (sectionMutated)
+                {
+                    RecomputeTrimmedTrackSectionMetadata(ref section);
+                    sections[i] = section;
+                    mutated = true;
+                }
+            }
+
+            return mutated;
+        }
+
+        private static bool TrimTrackSectionFramesPastUT(ref TrackSection section, double cutoffUT)
+        {
+            if (section.frames == null || section.frames.Count == 0)
+                return false;
+
+            int originalCount = section.frames.Count;
+            for (int i = section.frames.Count - 1; i >= 0; i--)
+            {
+                if (section.frames[i].ut > cutoffUT)
+                    section.frames.RemoveAt(i);
+            }
+
+            if (section.frames.Count == 0)
+                section.frames = null;
+
+            int remainingCount = section.frames != null ? section.frames.Count : 0;
+            return remainingCount != originalCount;
+        }
+
+        private static bool TrimTrackSectionCheckpointsPastUT(ref TrackSection section, double cutoffUT)
+        {
+            if (section.checkpoints == null || section.checkpoints.Count == 0)
+                return false;
+
+            bool mutated = false;
+            for (int i = section.checkpoints.Count - 1; i >= 0; i--)
+            {
+                OrbitSegment checkpoint = section.checkpoints[i];
+                if (checkpoint.startUT >= cutoffUT)
+                {
+                    section.checkpoints.RemoveAt(i);
+                    mutated = true;
+                    continue;
+                }
+
+                if (checkpoint.endUT > cutoffUT)
+                {
+                    checkpoint.endUT = cutoffUT;
+                    section.checkpoints[i] = checkpoint;
+                    mutated = true;
+                }
+            }
+
+            if (section.checkpoints.Count == 0)
+                section.checkpoints = null;
+
+            return mutated;
+        }
+
+        private static void RecomputeTrimmedTrackSectionMetadata(ref TrackSection section)
+        {
+            section.sampleRateHz = 0f;
+            section.minAltitude = float.NaN;
+            section.maxAltitude = float.NaN;
+
+            if (section.frames == null || section.frames.Count == 0)
+                return;
+
+            for (int i = 0; i < section.frames.Count; i++)
+            {
+                float alt = (float)section.frames[i].altitude;
+                if (float.IsNaN(section.minAltitude) || alt < section.minAltitude)
+                    section.minAltitude = alt;
+                if (float.IsNaN(section.maxAltitude) || alt > section.maxAltitude)
+                    section.maxAltitude = alt;
+            }
+
+            double duration = section.endUT - section.startUT;
+            if (duration > 0.0 && section.frames.Count > 1)
+                section.sampleRateHz = (float)(section.frames.Count / duration);
+        }
+
+        private static bool RemoveItemsPastUT<T>(List<T> items, double cutoffUT, Func<T, double> getUT)
+        {
+            if (items == null || items.Count == 0)
+                return false;
+
+            int originalCount = items.Count;
+            for (int i = items.Count - 1; i >= 0; i--)
+            {
+                if (getUT(items[i]) > cutoffUT)
+                    items.RemoveAt(i);
+            }
+
+            return items.Count != originalCount;
+        }
+
+        /// <summary>
         /// Removes a committed tree from <see cref="RecordingStore.CommittedTrees"/>
         /// (and its recordings from the flat committed list) if a tree with the given id
         /// exists. Used by the active-tree restore path to prevent duplicate-id collisions
@@ -2276,9 +2628,45 @@ namespace Parsek
             return rec.VesselSnapshot != null || rec.GhostVisualSnapshot != null;
         }
 
-        // Resume hints parsed from PARSEK_ACTIVE_TREE node, consumed by ParsekFlight
-        // when it constructs the new recorder during the restore coroutine.
+        private sealed class QuickloadResumeContext
+        {
+            internal string TreeId;
+            internal string OriginalActiveRecordingId;
+        }
+
+        // Resume hints parsed from PARSEK_ACTIVE_TREE, consumed by the quickload-resume
+        // path when FlightRecorder.StartRecording reopens the restored active tree.
         internal static string pendingActiveTreeResumeRewindSave;
+        private static QuickloadResumeContext pendingQuickloadResumeContext;
+
+        internal static void ConfigurePendingQuickloadResumeContext(RecordingTree tree)
+        {
+            if (tree == null || string.IsNullOrEmpty(tree.Id) || string.IsNullOrEmpty(tree.ActiveRecordingId))
+            {
+                ClearPendingQuickloadResumeContext();
+                return;
+            }
+
+            pendingQuickloadResumeContext = new QuickloadResumeContext
+            {
+                TreeId = tree.Id,
+                OriginalActiveRecordingId = tree.ActiveRecordingId
+            };
+
+            ParsekLog.Verbose("Scenario",
+                $"Quickload-resume context armed: treeId={tree.Id} activeRecId={tree.ActiveRecordingId}");
+        }
+
+        internal static bool MatchesPendingQuickloadResumeContext(string treeId)
+        {
+            return pendingQuickloadResumeContext != null
+                && string.Equals(pendingQuickloadResumeContext.TreeId, treeId, StringComparison.Ordinal);
+        }
+
+        internal static void ClearPendingQuickloadResumeContext()
+        {
+            pendingQuickloadResumeContext = null;
+        }
 
         /// <summary>
         /// Restore path that <see cref="ParsekFlight.OnFlightReady"/> should run on

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -2631,7 +2631,6 @@ namespace Parsek
         private sealed class QuickloadResumeContext
         {
             internal string TreeId;
-            internal string OriginalActiveRecordingId;
         }
 
         // Resume hints parsed from PARSEK_ACTIVE_TREE, consumed by the quickload-resume
@@ -2649,8 +2648,7 @@ namespace Parsek
 
             pendingQuickloadResumeContext = new QuickloadResumeContext
             {
-                TreeId = tree.Id,
-                OriginalActiveRecordingId = tree.ActiveRecordingId
+                TreeId = tree.Id
             };
 
             ParsekLog.Verbose("Scenario",

--- a/Source/Parsek/SessionMerger.cs
+++ b/Source/Parsek/SessionMerger.cs
@@ -216,11 +216,17 @@ namespace Parsek
                 {
                     string prevRef = i > 0 ? mergedSections[i - 1].referenceFrame.ToString() : "?";
                     string prevSrc = i > 0 ? mergedSections[i - 1].source.ToString() : "?";
+                    bool saveLoadTeleport = i > 0
+                        && LooksLikeSaveLoadTeleportBoundary(
+                            inputSections,
+                            mergedSections[i - 1],
+                            mergedSections[i]);
                     ClassifyBoundaryDiscontinuity(
                         i > 0 ? mergedSections[i - 1] : default(TrackSection),
                         mergedSections[i],
                         i > 0,
                         disc,
+                        saveLoadTeleport,
                         out double dt, out double expectedM, out string cause);
                     ParsekLog.Warn(Tag,
                         $"MergeTree: boundary discontinuity={disc.ToString("F2", ic)}m " +
@@ -245,6 +251,8 @@ namespace Parsek
         ///   <c>|prev.velocity| × dt</c> (with a tolerance margin); points at a legitimate
         ///   pause-and-resume span (quickload-resume, scene-reload, frame-budget spike) that
         ///   the recorder couldn't sample through.</item>
+        ///   <item><c>save-load-teleport</c> — overlap resolution exposed a boundary where
+        ///   active data from the pre-load future was glued to resumed post-load data.</item>
         ///   <item><c>sample-skip</c> — discontinuity exceeds the velocity-implied gap;
         ///   points at a dropped-sample / drift bug or a source-tag mismatch.</item>
         ///   <item><c>invalid-data</c> — boundary UTs or the previous tail velocity are
@@ -254,6 +262,17 @@ namespace Parsek
         /// </summary>
         internal static void ClassifyBoundaryDiscontinuity(
             TrackSection prev, TrackSection next, bool hasPrev, float discMeters,
+            out double dtSeconds, out double expectedMeters, out string cause)
+        {
+            ClassifyBoundaryDiscontinuity(
+                prev, next, hasPrev, discMeters,
+                looksLikeSaveLoadTeleport: false,
+                out dtSeconds, out expectedMeters, out cause);
+        }
+
+        internal static void ClassifyBoundaryDiscontinuity(
+            TrackSection prev, TrackSection next, bool hasPrev, float discMeters,
+            bool looksLikeSaveLoadTeleport,
             out double dtSeconds, out double expectedMeters, out string cause)
         {
             dtSeconds = 0.0;
@@ -303,8 +322,49 @@ namespace Parsek
                 cause = "frame-mismatch";
             else if ((double)discMeters <= tolerance)
                 cause = "unrecorded-gap";
+            else if (looksLikeSaveLoadTeleport)
+                cause = "save-load-teleport";
             else
                 cause = "sample-skip";
+        }
+
+        internal static bool LooksLikeSaveLoadTeleportBoundary(
+            List<TrackSection> inputSections, TrackSection prev, TrackSection next)
+        {
+            if (inputSections == null || inputSections.Count < 2)
+                return false;
+            if (prev.source != TrackSectionSource.Active || next.source != TrackSectionSource.Active)
+                return false;
+            if (prev.referenceFrame != next.referenceFrame)
+                return false;
+
+            const double boundaryTolerance = 0.05;
+            const double overlapEpsilon = 1e-3;
+            double boundaryUT = next.startUT;
+            bool foundTrimmedFutureTail = false;
+            bool foundResumedOverlap = false;
+
+            for (int i = 0; i < inputSections.Count; i++)
+            {
+                TrackSection section = inputSections[i];
+                if (section.source != TrackSectionSource.Active
+                    || section.referenceFrame != prev.referenceFrame)
+                    continue;
+
+                if (section.startUT < boundaryUT - overlapEpsilon
+                    && Math.Abs(section.endUT - boundaryUT) <= boundaryTolerance)
+                {
+                    foundTrimmedFutureTail = true;
+                }
+
+                if (section.startUT < boundaryUT - overlapEpsilon
+                    && section.endUT > boundaryUT + overlapEpsilon)
+                {
+                    foundResumedOverlap = true;
+                }
+            }
+
+            return foundTrimmedFutureTail && foundResumedOverlap;
         }
 
         /// <summary>

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -59,6 +59,15 @@ Separately, the `MergeTree` "sample-skip" cause label is wrong for the observed 
 
 **Dependencies:** none. The `QuickloadResume` in-game test category (currently partially populated — several `(never run)` entries in the test report) is the right home for new regression coverage.
 
+**Update (2026-04-19):** Implementation landed on branch `bug/486-quicksave-runway-restore`.
+
+- The quickload-resume path now arms a restore-specific tree context, truncates every restored tree recording back to the current UT before sampling restarts, prunes future-only branch recordings / empty branch points left behind by that rewind, rebuilds `BackgroundMap`, and marks touched recordings dirty so stale future points / events / sections cannot survive into the resumed merge.
+- `FlightRecorder` now derives the restore-environment resync target from the post-trim tail of the recording that actually resumes, so the one-shot relabel still applies when EVA parent-fallback rewrites `ActiveRecordingId` between F5 and F9.
+- `SessionMerger` now labels overlap-derived active save/load seams as `cause=save-load-teleport` instead of falling through to the generic `sample-skip` bucket.
+- Added headless regression coverage for tree-wide trim, post-trim tail-environment selection, restore-environment resync, and the merger label heuristic.
+
+**Status:** Implementation complete for `0.8.3`, but leave this item open until the original runway F5/F9 repro is rerun in KSP on a machine that can build/run the `net472` test project. Local verification on this workstation is blocked by a missing `.NET Framework 4.7.2` targeting pack, so the code path was reviewed and covered in xUnit only.
+
 ---
 
 ## 485. `StrategyLifecycle` readiness probe throws `NullReferenceException` for every stock strategy on every poll — ~1980 `[Parsek][WARN][TestRunner]` lines in a single session


### PR DESCRIPTION
## Summary
- Quickload-resume now trims stale payload across the restored recording tree, prunes future-only branch state, rebuilds `BackgroundMap`, and labels overlap-derived seams as `save-load-teleport` instead of generic `sample-skip`.
- Resync target is now derived from the post-trim tail of the recording that actually resumes, so the subsequent merge no longer references a section that no longer exists.
- Removed dead `OriginalActiveRecordingId` state from `QuickloadResumeContext` (only `TreeId` is consulted by `MatchesPendingQuickloadResumeContext`).
- New xUnit log-assertion coverage for both `Quickload tree trim:` and `Quickload resume prep:` summary lines, plus a narrow `internal` test seam (`QuickloadResumeUTProviderForTesting`) so the private resume-prep path can be exercised directly.

## Test plan
- [x] `dotnet test Source/Parsek.Tests/Parsek.Tests.csproj` (only pre-existing `Integration_FundsTrackerUnavailable_PostWalkStillReconcilesTrackedLegs` remains; not introduced by this PR).
- [x] xUnit `QuickloadResumeTests`, `SessionMergerTests`, `EnvironmentTrackingIntegrationTests` cover trim, prune, rebuild, resync-target, and seam labeling.
- [ ] **In-game F5/F9 verification on the original runway-takeoff repro is still pending — todo entry intentionally remains OPEN.**