### PR TITLE
Pin orbit-only terminal-body heal path + open follow-up for Points-anchor case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to Parsek are documented here.
 
 ### Tests
 
+- `Bug278FinalizeLimboTests` now pins the orbit-only terminal-body heal path: a leaf with a stale `TerminalOrbitBody` but only orbit-segment evidence heals to the segment body and emits the `PopulateTerminalOrbitFromLastSegment: healed stale cached terminal orbit` log line.
 - The last xUnit smoke/assertion follow-ups now catch headless `ParsekUI.Cleanup()` teardown in the KSC wiring smoke test and anchor the Bug219 negative log checks to the full production log prefix instead of the overlapping `ShouldPopulate...` diagnostic.
 - Headless landed snapshot-repair coverage now survives Unity pseudo-null `CelestialBody` fixtures all the way through the real `REF` rewrite path instead of bailing out before the repaired surface orbit node is written.
 - The last SOI attitude xUnit follow-up now compares normalized quaternion rotation equivalence by absolute dot product, so exact `q` / `-q` handoff matches no longer fail just because the same world rotation chose the opposite sign.

--- a/Source/Parsek.Tests/Bug278FinalizeLimboTests.cs
+++ b/Source/Parsek.Tests/Bug278FinalizeLimboTests.cs
@@ -111,6 +111,35 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void FinalizeIndividualRecording_LeafWithOrbitOnlyEndpoint_HealsStaleTerminalOrbitBody()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "leaf-orbit-only-terminal-orbit",
+                VesselPersistentId = 0,
+                ChildBranchPointId = null,
+                TerminalStateValue = TerminalState.Orbiting,
+                TerminalOrbitBody = "Kerbin",
+                TerminalOrbitSemiMajorAxis = 700000.0,
+            };
+            rec.OrbitSegments.Add(new OrbitSegment
+            {
+                startUT = 1000.0,
+                endUT = 2000.0,
+                bodyName = "Mun",
+                semiMajorAxis = 250000.0,
+            });
+
+            ParsekFlight.FinalizeIndividualRecording(rec, commitUT: 2000.0, isSceneExit: false);
+
+            Assert.Equal("Mun", rec.TerminalOrbitBody);
+            Assert.Equal(250000.0, rec.TerminalOrbitSemiMajorAxis);
+            Assert.Contains(logLines, l =>
+                l.Contains("PopulateTerminalOrbitFromLastSegment: healed stale cached terminal orbit") &&
+                l.Contains("leaf-orbit-only-terminal-orbit"));
+        }
+
+        [Fact]
         public void FinalizeIndividualRecording_NonLeaf_SkipsTerminalStateAssignment()
         {
             // Non-leaf recordings (those with a ChildBranchPointId — interior nodes

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -198,6 +198,20 @@ The four top-of-queue correctness fixes (#431, #432, #433, #434) shipped in the 
 
 ---
 
+## 520. `FinalizeIndividualRecording` overwrites a correctly-set terminal orbit body when a same-UT orbit segment reports a different body, even if `Points` anchor the original body
+
+**Source:** port attempt from the superseded `Parsek-fix-batch-terminalorbit` on 2026-04-21. When its `FinalizeIndividualRecording_LeafWithExistingTerminalOrbit_DoesNotOverwriteFromLaterOrbitEndpoint` test was run against current `main`, the assertion `Assert.Equal("Mun", rec.TerminalOrbitBody)` failed with an actual value of `"Kerbin"`.
+
+**Concern:** with a leaf recording where `TerminalOrbitBody = "Mun"`, one `Points` entry at `ut=1000, bodyName="Mun"`, and one `OrbitSegment` on `"Kerbin"` spanning `startUT=1000, endUT=2000`, `FinalizeIndividualRecording` overwrites the cached terminal orbit from Mun to Kerbin. `RecordingEndpointResolver.TryGetExplicitEndpointBodyName` already returns `"Mun"` for this recording (the Points anchor wins over the segment body), but the finalize flow does not gate the overwrite on that anchor. Main's heal path is otherwise correct for the "orbit-only stale body" case (covered by the ported `LeafWithOrbitOnlyEndpoint_HealsStaleTerminalOrbitBody` test), so the gap is specific to "Points anchor one body, segment claims another at the same UT".
+
+**Next step:** decide whether Kerbin-wins-over-Mun is the intended behavior here or a bug. If the intent matches `#484` ("keep an already-correct cached orbit"), the overwrite should be gated on `TryGetExplicitEndpointBodyName` agreement with the new segment body, and a regression test can be added in that shape. If Kerbin-wins is the intended design (later authoritative artifact), add the opposite regression documenting that rule and revisit `#484`'s wording. Either outcome should land together with an explicit test, not just a prod change.
+
+**Files:** `Source/Parsek/ParsekFlight.cs` (around `FinalizeIndividualRecording` / `PopulateTerminalOrbitFromLastSegment`), `Source/Parsek/RecordingEndpointResolver.cs` (the existing `TryGetExplicitEndpointBodyName`), `Source/Parsek.Tests/Bug278FinalizeLimboTests.cs`.
+
+**Status:** OPEN. Discovered 2026-04-21.
+
+---
+
 ## ~~487. Test Runner transparent background on scene change / Settings-hosted reopen path~~
 
 **Source:** follow-up on the transparent `TestRunner` window after scene transitions. The original fix hardened the global Ctrl+Shift+T shortcut path, but the shared `ParsekUI` cache used by the Settings-hosted Test Runner and other Parsek windows could still cache a transparent or unreadable window style after scene changes / skin-lag frames.


### PR DESCRIPTION
## Summary

Ports one of the two unique `Bug278FinalizeLimboTests` regressions from the now-closed `Parsek-fix-batch-terminalorbit` branch and documents the other as open item #520 for a separate design call.

**Ported and passing on main:**
- `FinalizeIndividualRecording_LeafWithOrbitOnlyEndpoint_HealsStaleTerminalOrbitBody` — locks the heal path: a leaf with `TerminalOrbitBody="Kerbin"` but only an `OrbitSegment` on `Mun` correctly heals to `Mun` and logs `PopulateTerminalOrbitFromLastSegment: healed stale cached terminal orbit`. Log assertion adjusted to main's current phrasing (the superseded branch's assertion used an older `"overwrote mismatched body"` log line that no longer exists).

**Deferred to #520:**
- The superseded branch's second test (`LeafWithExistingTerminalOrbit_DoesNotOverwriteFromLaterOrbitEndpoint`) encoded an expected-behavior change that isn't on main: when `Points` anchor a body (e.g. Mun) and a same-UT `OrbitSegment` claims another (Kerbin), main overwrites the cached terminal body to Kerbin. Whether that's correct or a regression needs a design decision. Landing a test in either direction without that call would pin the wrong answer, so the todo captures the scenario, the evidence, and the two plausible resolutions.

## Test plan

- [x] `cd Source/Parsek.Tests && dotnet test --no-build --filter FinalizeIndividualRecording_LeafWithOrbitOnlyEndpoint` — 1 passed
- [x] `cd Source/Parsek.Tests && dotnet test --no-build` — 7723 passed, 0 failed, 2 pre-existing skipped
- [x] `cd Source/Parsek && dotnet build` — clean, no new warnings