### PR TITLE
Polish Timeline row widths and capture bug findings #521-#538

### DIFF
--- a/Source/Parsek.Tests/MapMarkerRendererTests.cs
+++ b/Source/Parsek.Tests/MapMarkerRendererTests.cs
@@ -128,6 +128,22 @@ namespace Parsek.Tests
             Assert.Equal(expected, MapMarkerRenderer.ShouldDrawLabel(sticky));
         }
 
+        [Fact]
+        public void GetLabelColor_ReturnsSharedYellowInsteadOfPerTypePalette()
+        {
+            Color labelColor = MapMarkerRenderer.GetLabelColor();
+            Color shipColor = MapMarkerRenderer.GetColorForType(VesselType.Ship);
+            Color stationColor = MapMarkerRenderer.GetColorForType(VesselType.Station);
+
+            Assert.Equal(shipColor.r, labelColor.r);
+            Assert.Equal(shipColor.g, labelColor.g);
+            Assert.Equal(shipColor.b, labelColor.b);
+            Assert.Equal(shipColor.a, labelColor.a);
+
+            Assert.NotEqual(stationColor.r, labelColor.r);
+            Assert.NotEqual(stationColor.g, labelColor.g);
+        }
+
         // IsToggleClick — only left-button MouseDown toggles sticky state.
         // Non-left clicks must pass through so stock map/tracking handlers can
         // still react normally. The production click handler gates on this

--- a/Source/Parsek/MapMarkerRenderer.cs
+++ b/Source/Parsek/MapMarkerRenderer.cs
@@ -101,9 +101,9 @@ namespace Parsek
         }
 
         /// <summary>
-        /// Returns the orbit color for a ghost marker by vessel type.
-        /// Matches KSP's own orbit color scheme — single source of truth used
-        /// by both ParsekUI (flight) and ParsekTrackingStation (TS).
+        /// Returns the per-vessel-type accent color for a ghost marker.
+        /// Stock atlas icons ignore this tint, but the fallback diamond still
+        /// uses it and flight/TS callers keep one shared vessel-type palette.
         /// </summary>
         internal static Color GetColorForType(VesselType vtype)
         {
@@ -121,6 +121,15 @@ namespace Parsek
                 default:                 return new Color(0.63f, 0.63f, 0.63f); // grey
             }
         }
+
+        /// <summary>
+        /// Returns the shared ghost label color used in map view. Labels stay
+        /// yellow for every vessel type; the icon itself already carries the
+        /// vehicle distinction, so per-type label tints add noise without
+        /// improving scanability.
+        /// </summary>
+        internal static Color GetLabelColor()
+            => GetColorForType(VesselType.Ship);
 
         /// <summary>
         /// Draw a marker for a world-space position (tracking station path).
@@ -201,7 +210,7 @@ namespace Parsek
 
             if (ShouldDrawLabel(sticky))
             {
-                labelStyle.normal.textColor = color;
+                labelStyle.normal.textColor = GetLabelColor();
                 GUI.Label(
                     new Rect(x - 75, y + IconSize / 2 + 2, 150, 20),
                     "Ghost: " + (label ?? "(unknown)"),

--- a/Source/Parsek/UI/CareerStateWindowUI.cs
+++ b/Source/Parsek/UI/CareerStateWindowUI.cs
@@ -47,9 +47,9 @@ namespace Parsek
         private GUIStyle grayStyle;
         private GUIStyle bannerStyle;
 
-        private const float DefaultWindowWidth = 820f;
+        internal const float DefaultWindowWidth = 820f;
         private const float DefaultWindowHeight = 400f;
-        private const float MinWindowWidth = 520f;
+        internal const float MinWindowWidth = 520f;
         private const float MinWindowHeight = 200f;
         private const string CareerStateInputLockId = "Parsek_CareerStateWindow";
 

--- a/Source/Parsek/UI/TimelineWindowUI.cs
+++ b/Source/Parsek/UI/TimelineWindowUI.cs
@@ -36,9 +36,11 @@ namespace Parsek
         private bool timelineWindowHasInputLock;
         private const string TimelineInputLockId = "Parsek_TimelineWindow";
         private Rect lastTimelineWindowRect;
-        private const float MinWindowWidth = 350f;
+        private const float DefaultWindowWidth = CareerStateWindowUI.DefaultWindowWidth;
+        private const float MinWindowWidth = CareerStateWindowUI.MinWindowWidth;
         private const float MinWindowHeight = 150f;
         private const float ApproxRowHeight = 20f;
+        private const float RowActionButtonWidth = 35f;
 
         // Shared width for all top filter/preset buttons (Overview, Details, Rewind/FF,
         // Recordings, Actions, Events + Last Day / Last 7d / Last 30d / This Year / All / Custom).
@@ -129,15 +131,15 @@ namespace Parsek
                 return;
             }
 
-            // Position to the left of main window on first open. Default width must
-            // accommodate 6 minimum-width buttons + inter-button margin budget
-            // (6*93 + 28 + chrome ≈ 608), with some breathing room.
+            // Position to the left of main window on first open. Keep Timeline's
+            // default width aligned with Career State so both wide data windows
+            // have the same footprint once the row action buttons share one width.
             if (timelineWindowRect.width < 1f)
             {
-                float x = mainWindowRect.x - 650;
+                float x = mainWindowRect.x - (DefaultWindowWidth + 10f);
                 if (x < 0) x = mainWindowRect.x + mainWindowRect.width + 10;
                 float height = Math.Max(600f, mainWindowRect.height);
-                timelineWindowRect = new Rect(x, mainWindowRect.y, 640, height);
+                timelineWindowRect = new Rect(x, mainWindowRect.y, DefaultWindowWidth, height);
                 var ic = System.Globalization.CultureInfo.InvariantCulture;
                 ParsekLog.Verbose("UI",
                     $"Timeline window initial position: x={x.ToString("F0", ic)} y={mainWindowRect.y.ToString("F0", ic)} (mainWindow.x={mainWindowRect.x.ToString("F0", ic)})");
@@ -808,7 +810,7 @@ namespace Parsek
                         GUI.enabled = watchButton.Enabled;
                         if (GUILayout.Button(
                             new GUIContent(watchButton.Label, watchButton.Tooltip),
-                            GUILayout.Width(30)))
+                            GUILayout.Width(RowActionButtonWidth)))
                         {
                             string beforeFocus = flight.DescribeWatchFocusForLogs();
                             string beforeEligibility = flight.DescribeWatchEligibilityForLogs(recIndex);
@@ -835,7 +837,7 @@ namespace Parsek
                         bool canFF = CanFastForwardNow(rec, out ffReason);
                         GUI.enabled = canFF;
                         if (GUILayout.Button(new GUIContent("FF", canFF ? "Fast-forward to this launch" : ffReason),
-                            GUILayout.Width(35)))
+                            GUILayout.Width(RowActionButtonWidth)))
                         {
                             ParsekLog.Info("UI",
                                 $"Timeline FF button clicked: \"{rec.VesselName}\" id={rec.RecordingId}");
@@ -850,7 +852,7 @@ namespace Parsek
                         bool canRewind = CanRewindWithResolvedSaveState(rec, out rewindReason);
                         GUI.enabled = canRewind;
                         if (GUILayout.Button(new GUIContent("R", canRewind ? "Rewind to this launch" : rewindReason),
-                            GUILayout.Width(25)))
+                            GUILayout.Width(RowActionButtonWidth)))
                         {
                             ParsekLog.Info("UI",
                                 $"Timeline rewind button clicked: \"{rec.VesselName}\" id={rec.RecordingId}");
@@ -867,7 +869,7 @@ namespace Parsek
                     {
                         string lTooltip = rec.LoopPlayback ? "Disable looping" : "Enable looping (uses saved interval)";
                         bool newLoop = GUILayout.Toggle(rec.LoopPlayback, new GUIContent("L", lTooltip),
-                            toggleButtonStyle, GUILayout.Width(25));
+                            toggleButtonStyle, GUILayout.Width(RowActionButtonWidth));
                         if (newLoop != rec.LoopPlayback)
                         {
                             rec.LoopPlayback = newLoop;

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -212,6 +212,222 @@ The four top-of-queue correctness fixes (#431, #432, #433, #434) shipped in the 
 
 ---
 
+## 521. Main Parsek page can visibly flicker while clicking around the Parsek windows
+
+**Source:** user observation from `logs/2026-04-21_2335_live-collect-script`. The package does not contain a screenshot/video, but `KSP.log` shows `CareerStateWindow: rebuilt VM ...` being emitted every ~16-25 ms for long stretches even when the data is stable (for example around 23:29:45-23:29:57 with `contracts=2/2`, `strategies=0/0`, `facilities=9`, `milestones=4/4` unchanged). The same session also keeps logging `Main window position: x=20 y=100 w=250 h=0`.
+
+**Concern:** this does not look like the old transparent-window path from closed `#487`; it looks like the Career State VM and/or the shared main window layout is rebuilding at draw cadence instead of only on cache invalidation. That would explain why the main Parsek page flickers when the user clicks controls in Parsek-owned windows even though the underlying data is not changing.
+
+**Files:** `Source/Parsek/UI/CareerStateWindowUI.cs`, `Source/Parsek/ParsekUI.cs`, `Source/Parsek.Tests/CareerStateWindowUITests.cs`.
+
+**Status:** OPEN. User-observed; current package provides redraw/rebuild breadcrumbs but not a visual capture.
+
+---
+
+## 522. Timeline milestone rewards can still look double-counted even when the ledger itself does not warn
+
+**Source:** user observation from the same `2026-04-21_2335_live-collect-script` package. When the Timeline opened at 23:30:36, `KSP.log` reported `Build complete: 35 entries (2 recording, 33 action, 0 legacy)`, and the package does not contain milestone-funds reconciliation WARNs of the kind that motivated closed `#477`. The session does, however, contain dense milestone activity (`FirstLaunch`, `RecordsSpeed`, `RecordsAltitude`, `RecordsDistance`, plus later repeatable `stays effective` rows), so it is a good repro corpus for "this looks duplicated in the Timeline".
+
+**Concern:** this currently looks more like a presentation regression than a real funds over-credit. Closed `#464` fixed the old gray `GameStateEvent` shadow rows in Timeline Details, and closed `#477` fixed the false-positive milestone over-attribution. This package does not show either exact old signal. If the Timeline still looks double-counted, suspect duplicate/ambiguous milestone action rows or text formatting in the Timeline render path before touching the ledger math again.
+
+**Files:** `Source/Parsek/Timeline/TimelineBuilder.cs`, `Source/Parsek/Timeline/TimelineEntryDisplay.cs`, `Source/Parsek/UI/TimelineWindowUI.cs`.
+
+**Status:** OPEN. Investigate against this exact `c3` package before revisiting milestone accounting.
+
+---
+
+## 523. Two SPACECENTER strategy canaries fail because strategy readiness never hydrates
+
+**Source:** `logs/2026-04-21_2335_live-collect-script/parsek-test-results.txt` records two SPACECENTER failures: `FlightIntegrationTests.ActivateAndDeactivate_StockStrategy_EmitsLifecycleEvents` and `FlightIntegrationTests.FailedActivation_DoesNotEmitEvent`, both with `StrategyLifecycle readiness never stabilized: Administration.Instance is null (stock Strategy.CanBeActivated dereferences it before Administration finishes hydrating)`. The same package's `KSP.log` also shows an early `[StrategySystem]: Found 0 strategy types` during KSC setup.
+
+**Concern:** the package later replays a strategy activate/deactivate pair from the ledger (`researchIPsellout` at UT=72.2), so this looks like a live KSC/test-harness readiness race, not a broad failure of `StrategiesModule` or event conversion. The current readiness gate is likely probing too early or waiting on the wrong hydration condition.
+
+**Files:** `Source/Parsek/InGameTests/StrategyLifecycleProbeSupport.cs`, `Source/Parsek/InGameTests/RuntimeTests.cs`, and possibly `Source/Parsek/ParsekKSC.cs` if the KSC/test startup ordering needs an explicit hook.
+
+**Status:** OPEN. Repro captured in-package.
+
+---
+
+## 524. Timeline row action buttons use inconsistent widths (`W=30`, `FF=35`, `R=25`, `L=25`)
+
+**Source:** user observation plus code read in `Source/Parsek/UI/TimelineWindowUI.cs`.
+
+**Concern:** the row-action column visibly jitters because the watch, fast-forward, rewind, and loop buttons all use different hard-coded widths. The mismatch is cosmetic, but it makes dense Timeline rows harder to scan and undermines the otherwise deliberate table alignment.
+
+**Files:** `Source/Parsek/UI/TimelineWindowUI.cs` (make the row-action buttons share a single width constant, likely matching `FF`).
+
+**Status:** TODO / UI polish. Cheap fix, low risk.
+
+---
+
+## 525. Watch-mode ghost explosions can still end up visually buried if FX anchors to the raw ghost root instead of a clearance-checked position
+
+**Source:** user observed multiple "explosion happened underground" cases in watch mode. The current `2026-04-21_2335_live-collect-script` package did not capture the underground variant directly, but it did capture a watched destroyed ghost (`"x"`) exploding at 23:32:42 immediately after a terrain-correction log (`Ghost terrain clamp: alt=65.3 terrain=64.8 -> 66.8 (clearance=2.0m)`).
+
+**Concern:** `GhostPlaybackEngine.TriggerExplosionIfDestroyed()` currently anchors the FX at `state.ghost.transform.position`. If watch mode or a late playback frame ever leaves the ghost root below terrain for even one frame, the stock/custom explosion FX and the watch hold will both anchor underground. This package narrows the bug even though it does not show the bad frame itself: explosion placement still trusts the raw ghost root instead of re-validating clearance at fire time.
+
+**Files:** `Source/Parsek/GhostPlaybackEngine.cs`, `Source/Parsek/TerrainCorrector.cs`, `Source/Parsek/ParsekFlight.cs`, plus a new in-game regression in the terrain/watch test coverage.
+
+**Status:** OPEN. User-observed; current package provides a nearby watch-destruction repro and code-path confirmation.
+
+---
+
+## 526. Timeline FF can falsely auto-start a new recording on the real pad vessel after the time jump
+
+**Source:** `logs/2026-04-21_2335_live-collect-script/KSP.log` around 23:32:24-23:32:25. After `Timeline FF button clicked: "x"` and `FastForwardToRecording: jumping to UT=102.9`, the real vessel `r0` is put on rails/unrails for the forward jump. Immediately after, Parsek starts a fresh tree recording on `r0`: `Recording started: vessel="r0"` plus `Auto-record started (PRELAUNCH -> FLYING)`. The new recording seeds `Start location captured: body=Kerbin, biome=Shores, situation=Flying, launchSite=Launch Pad`, then 0.5s later the recorder corrects back to `SurfaceStationary`.
+
+**Concern:** the FF/time-jump path transiently makes the real launchpad vessel look like a `PRELAUNCH -> FLYING` launch transition, so the normal auto-record logic creates a bogus recording even though the vessel is just sitting on the pad. This is a direct regression with a tight repro sequence in the collected package.
+
+**Files:** `Source/Parsek/ParsekFlight.cs` (`OnVesselSituationChange` / `EvaluateAutoRecordLaunchDecision`), `Source/Parsek/TimeJumpManager.cs` (forward-jump rails/unrails path), `Source/Parsek/InGameTests/RuntimeTests.cs`, `docs/dev/manual-testing/test-auto-record.md`.
+
+**Status:** OPEN. Repro captured in-package.
+
+---
+
+## 527. Rewind's deferred recalc can drop `utCutoff` and restore future funds/contracts before replay catches up
+
+**Source:** `logs/2026-04-21_2335_live-collect-script/KSP.log` around 23:30:25-23:30:28. The rewind path first does the expected cutoff walk (`cutoffUT=19.159999999999467`), dropping funds from `53861.7` to `21495.0` and removing two active contracts. About five seconds later, a deferred FLIGHT recalc runs with `cutoffUT=null` and restores the end-of-timeline funds/contracts before any replay has advanced.
+
+**Concern:** one rewind caller is re-entering `RecalculateAndPatch()` without forwarding the rewind cutoff. That makes career state snap back toward the future timeline immediately after rewind, explains the new `PatchFunds: suspicious drawdown` warning in the same package, and breaks the expected "rewind means pre-cutoff state until replay progresses" model.
+
+**Files:** `Source/Parsek/ParsekScenario.cs`, `Source/Parsek/GameActions/LedgerOrchestrator.cs`, `Source/Parsek/GameActions/KspStatePatcher.cs`, `Source/Parsek.Tests/RewindUtCutoffTests.cs`.
+
+**Status:** OPEN. Repro captured in-package.
+
+---
+
+## 528. Launchpad science gathered before recording start is still being committed onto the later flight recording
+
+**Source:** the same package records launchpad science subjects before `r0` starts, then later commits those `KerbinSrfLandedLaunchPad` subjects under recording id `3c32a9406c044f3daf00c79d0852dbf3` / `startUT=29.16`. The resulting run also emits the familiar science-mismatch warnings: `Earnings reconciliation (sci): store delta=7.7 vs ledger emitted delta=11.0`, plus post-walk misses for `ScienceTransmission` / `VesselRecovery`.
+
+**Concern:** this reopens the closed `#483` family in a narrower but still real shape: pre-recording launchpad science is getting swept into the later flight recording, so commit-time and post-walk science reconciliation no longer operate on a clean same-scope event set. The package shows both ends of the problem on current `main`: the early subject capture and the later mismatch.
+
+**Files:** `Source/Parsek/GameStateRecorder.cs`, `Source/Parsek/GameActions/GameStateEventConverter.cs`, `Source/Parsek/GameActions/LedgerOrchestrator.cs`, `Source/Parsek.Tests/PostWalkReconciliationIntegrationTests.cs`.
+
+**Status:** OPEN. Strong regression/new-shape signal from the package.
+
+---
+
+## 529. Stable-terminal landed re-snapshots can still persist a stale orbital `ORBIT` block
+
+**Source:** the finalized sidecar `parsek/Recordings/a31472b008f042848e868bf1759e1259_vessel.craft.txt` from `logs/2026-04-21_2335_live-collect-script` has `sit = LANDED` and `skipGroundPositioning = True`, but its `ORBIT` block still contains a stale orbital tuple (`SMA = 300816.6`, `ECC = 0.9948`, `REF = 1`). `KSP.log` shows the recording being finalized via the stable-terminal re-snapshot path immediately beforehand.
+
+**Concern:** closed `#479` normalized unsafe `sit` values during stable-terminal persistence, but the current persistence path only rewrites situation metadata. The surface-orbit repair logic still lives only in spawn-time healing, so landed/splashed stable-terminal sidecars can remain internally contradictory until a later repair path touches them.
+
+**Files:** `Source/Parsek/ParsekFlight.cs`, `Source/Parsek/VesselSpawner.cs`, `Source/Parsek.Tests/Bug278FinalizeLimboTests.cs`.
+
+**Status:** OPEN. Data-integrity bug captured in-package.
+
+---
+
+## 530. Timeline `W` can open in a false disabled state until the lazy ghost build finishes
+
+**Source:** when Timeline opens in `logs/2026-04-21_2335_live-collect-script`, `KSP.log` records `Timeline watch button "r0" ... disabled (no ghost)` for the same recording that becomes watchable less than a second later once the ghost finishes building/spawning. No user context changed; the row just self-corrected when the ghost materialized.
+
+**Concern:** initial watchability is being computed from transient `HasActiveGhost` / same-body / range state before the lazy ghost build completes, so the Timeline row can briefly advertise a false "not watchable" state on first open. This is small, but it makes watch mode feel flaky and is distinct from the older watch-transfer bugs.
+
+**Files:** `Source/Parsek/UI/TimelineWindowUI.cs`, `Source/Parsek/UI/RecordingsTableUI.cs`, `Source/Parsek/WatchModeController.cs`, `Source/Parsek.Tests/TimelineWindowUITests.cs`.
+
+**Status:** OPEN. Minor UI-state bug captured in-package.
+
+---
+
+## 531. Destroyed recordings are still being diagnosed as `no vessel snapshot` instead of `vessel destroyed`
+
+**Source:** the package's playback loop repeatedly logs `Spawn suppressed ... no vessel snapshot` for both committed recordings, even though the same session reports the timeline contains only destroyed recordings. The behavior is stable across many suppression cycles.
+
+**Concern:** `GhostPlaybackLogic.ShouldSpawnAtRecordingEnd(...)` currently checks `rec.VesselSnapshot == null` before `rec.VesselDestroyed`, so destroyed recordings get the wrong suppression reason. This does not change the spawn outcome, but it hides the real state during FF/watch investigations and adds misleading playback noise.
+
+**Files:** `Source/Parsek/GhostPlaybackLogic.cs`, `Source/Parsek/ParsekFlight.cs`, `Source/Parsek.Tests/RewindTimelineTests.cs`, `Source/Parsek.Tests/SpawnSafetyNetTests.cs`.
+
+**Status:** OPEN. Low-severity diagnostic correctness issue.
+
+---
+
+## 532. Same-UT tech unlock bursts can temporarily refund science until the `TechResearched` action lands
+
+**Source:** `logs/2026-04-21_2335_live-collect-script/KSP.log` shows `basicRocketry` being allowed, then `PatchScience: 17.1 -> 22.1`, and only later the matching `TechResearched` ledger event. The same pattern repeats for `engineering101`: allow tech, patch science back up, then record the action later.
+
+**Concern:** during bursty R&D activity, KSP's science pool is being patched upward in the gap between stock unlock and the recorder/ledger catching up. That means the player can briefly see refunded science or even try to re-spend it while the action stream is still converging.
+
+**Files:** `Source/Parsek/Patches/TechResearchPatch.cs`, `Source/Parsek/GameStateRecorder.cs`, `Source/Parsek/GameActions/KspStatePatcher.cs`, `Source/Parsek/GameActions/LedgerOrchestrator.cs`.
+
+**Status:** OPEN. Visible resource-state bug captured in-package.
+
+---
+
+## 533. `ContractAccepted -> ContractAccept` conversion drops `contractType` on the ledger path
+
+**Source:** replay in `logs/2026-04-21_2335_live-collect-script/KSP.log` logs both accepted launch-site test contracts as `type=''`, and the committed `ledger.pgld` actions contain title/deadline/advance/penalties but no `contractType`. The raw stored contract snapshots still carry `type = PartTest`, so the type exists at capture time and is being lost during conversion.
+
+**Concern:** `GameStateRecorder.OnContractAccepted()` preserves the full contract snapshot, but `GameStateEventConverter.ConvertContractAccepted()` only reads title/deadline/funds/penalties and never populates `GameAction.ContractType`. `PatchContracts` currently survives because it re-reads the snapshot, but any UI/rule/path that relies on `GameAction.ContractType` already sees empty data.
+
+**Files:** `Source/Parsek/GameStateRecorder.cs`, `Source/Parsek/GameActions/GameStateEventConverter.cs`, `Source/Parsek/GameActions/ContractsModule.cs`, `Source/Parsek/GameActions/GameActionDisplay.cs`.
+
+**Status:** OPEN. Data-loss bug in the ledger conversion path.
+
+---
+
+## 534. Returning to a spawned chain-tip vessel can miss the vessel-switch restore and strand the next continuation outside the existing mission tree
+
+**Source:** `logs/2026-04-22_0012_followup-log-sweep/KSP.log` around 23:56:39-00:00:38. When switching back to the spawned Mun-orbit `Kerbal X`, `ParsekScenario` logs `vesselSwitchPending flag stale ... treating FLIGHT→FLIGHT as quickload, not vessel switch`. The follow-up `OnFlightReady` state is still `mode=none tree=-`, even though scene entry active vessel pid `2641112149` is the already-spawned chain tip. The later Mun landing logs `OnVesselSituationChange: not a launch transition (SUB_ORBITAL -> LANDED)`, and the only new recording that starts afterward is a fresh single-node EVA tree for Bob Kerman.
+
+**Concern:** the FLIGHT→FLIGHT return-to-vessel path can lose the pending tree restore/promotion for a spawned chain tip, so the later continuation never rejoins the existing `Kerbal X` mission tree/group. Once that tree context is lost, landing or engine-burn follow-up on the returned vessel no longer auto-starts a chained continuation; only the separate EVA auto-record path re-arms.
+
+**Files:** `Source/Parsek/ParsekScenario.cs`, `Source/Parsek/ParsekFlight.cs`, `Source/Parsek.Tests/VesselSwitchTreeTests.cs`, `Source/Parsek/InGameTests/ExtendedRuntimeTests.cs`.
+
+**Status:** OPEN. Strong repro captured in-package.
+
+---
+
+## 535. Tracking Station can show a future Mun-orbit chain tip before the current ghost has actually reached the Mun
+
+**Source:** `logs/2026-04-22_0012_followup-log-sweep/KSP.log` around 00:01:42-00:02:07. Tracking Station startup immediately creates recording `#3` as a ghost vessel on `body=Mun` from terminal orbit data, then still draws atmospheric markers `#0` and `#1` over Kerbin, and later creates recording `#1` as a Kerbin ghost-map vessel from the current segment.
+
+**Concern:** Tracking Station is mixing the future chain tip's terminal orbit with the earlier active leg, so the vessel list can advertise a second `Kerbal X` as already "in Mun orbit" before the current ghost has actually reached the Mun. `CreateGhostVesselsFromCommittedRecordings()` currently instantiates tip recordings with `HasOrbitData(rec)` even when current UT is still on an earlier chain segment.
+
+**Files:** `Source/Parsek/GhostMapPresence.cs`, `Source/Parsek/ParsekTrackingStation.cs`, `Source/Parsek/InGameTests/RuntimeTests.cs`, `Source/Parsek/InGameTests/ExtendedRuntimeTests.cs`.
+
+**Status:** OPEN. Repro captured in-package.
+
+---
+
+## 536. Tracking Station can drop the current atmospheric continuation at the Kerbin-exit handoff
+
+**Source:** the same package logs `Drawing atmospheric marker #2 "Kerbal X" ... alt=69999` at 00:03:47, then immediately removes recording `#1` with `Removed ghost map vessel for recording #1 ... reason=tracking-station-expired` at 00:03:49. No same-moment replacement current-phase marker/orbit handoff is logged for the in-progress continuation before the much later Mun-leg visibility resumes.
+
+**Concern:** the Kerbin-exit handoff in Tracking Station can drop the current ghost entirely at the boundary between atmospheric-marker playback and orbit-map lifecycle. The package shows the removal, but not a synchronized successor for the current continuation, matching the user report that the icon vanished even though the craft was still on its way back out of atmosphere toward Mun transfer.
+
+**Files:** `Source/Parsek/GhostMapPresence.cs`, `Source/Parsek/ParsekTrackingStation.cs`, `Source/Parsek/TrajectoryMath.cs`.
+
+**Status:** OPEN. Strong lifecycle gap signal in-package.
+
+---
+
+## 537. Tracking Station never runs the real-vessel spawn handoff that flight/map playback does
+
+**Source:** user observed the missing Mun-orbit materialization in Tracking Station; the same package shows the contrast directly. In TRACKSTATION, the host only initializes and updates ghost ProtoVessels (`ParsekTrackingStation initialized`, atmospheric markers, ghost create/remove). Later in FLIGHT/map playback, the same recording `#3` does execute the normal handoff: `Spawn #3 (Kerbal X) ... body=Mun` followed by `SpawnAtPosition: vessel spawned (sit=ORBITING, pid=3724180956, body=Mun, alt=63723m)`.
+
+**Concern:** Tracking Station currently has ghost list/map presence, but not the matching chain-tip real-vessel spawn path that flight playback runs. That makes Tracking Station playback/list state diverge from map view exactly at the moment the ghost should materialize into the real vessel.
+
+**Files:** `Source/Parsek/ParsekTrackingStation.cs`, `Source/Parsek/GhostMapPresence.cs`, `Source/Parsek/ParsekPlaybackPolicy.cs`, `Source/Parsek/VesselSpawner.cs`.
+
+**Status:** OPEN. Cross-scene behavior gap confirmed by the package.
+
+---
+
+## 538. Atmospheric reentry fire still looks too sparse; tuning target is roughly 2x the current particle density
+
+**Source:** user observed that the atmospheric drag/heating fire is too thin and should emit about twice as many particles. Current code still hardcodes a single fire-particle layer at `ReentryFireEmissionMin=300`, `ReentryFireEmissionMax=2000`, and `ReentryFireMaxParticles=1500`. The package's reentry run confirms the path is active (`Lazy reentry build fired`, later `rebuilt emission mesh ... and 105 fire shell meshes after decouple`), but does not measure visual density.
+
+**Concern:** reentry fire density is still tuned too low for the intended look. If the target is roughly "2x the current fire particles", the adjustment points live in `DriveReentryLayers()` emission-rate scaling plus the build-time reentry particle limits. This is a visual-tuning issue rather than a package-proven correctness regression, but it should be tracked explicitly as an atmospheric-FX follow-up.
+
+**Files:** `Source/Parsek/GhostVisualBuilder.cs`, `Source/Parsek/GhostPlaybackEngine.cs`, `Source/Parsek/InGameTests/RuntimeTests.cs`.
+
+**Status:** OPEN. User-observed tuning bug; package confirms the path, not the exact multiplier.
+
+---
+
 ## ~~487. Test Runner transparent background on scene change / Settings-hosted reopen path~~
 
 **Source:** follow-up on the transparent `TestRunner` window after scene transitions. The original fix hardened the global Ctrl+Shift+T shortcut path, but the shared `ParsekUI` cache used by the Settings-hosted Test Runner and other Parsek windows could still cache a transparent or unreadable window style after scene changes / skin-lag frames.

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -428,15 +428,15 @@ The four top-of-queue correctness fixes (#431, #432, #433, #434) shipped in the 
 
 ---
 
-## 539. Two `GhostPlaybackEngineTests` cases stay permanently `[Fact(Skip = ...)]` because xUnit has no Unity runtime harness
+## 539. Two `GhostPlaybackEngineTests` cases are `[Fact(Skip = ...)]` stubs that xUnit should not keep shipping
 
-**Source:** `Source/Parsek.Tests/GhostPlaybackEngineTests.cs` has two permanently-skipped cases: `UpdateLoopingPlayback_PendingCycleBoundary_DoesNotEmitRestartEvents` (line 1153, Skip: `UpdateLoopingPlayback` body references `GameObject.activeSelf / SetActive`, which trip .NET 4.7.2 JIT verification) and `SpawnGhost_PrimesFreshGhostToCurrentPlaybackUT` (line 1509, Skip: Unity `GameObject` instantiation requires runtime). Today's `dotnet test` confirms them still skipped (7729 passed / 2 skipped).
+**Source:** `Source/Parsek.Tests/GhostPlaybackEngineTests.cs` has two permanently-skipped cases. `SpawnGhost_PrimesFreshGhostToCurrentPlaybackUT` (line 1509) is already covered by a dedicated in-game replacement — `InGameTests/RuntimeTests.cs:1860` is literally labelled "in-game replacement for xUnit SpawnGhost_PrimesFreshGhostToCurrentPlaybackUT". `UpdateLoopingPlayback_PendingCycleBoundary_DoesNotEmitRestartEvents` (line 1153) has no dedicated in-game counterpart; its skip message leans on the pure-logic xUnit sibling `ReusePrimaryGhostAcrossCycle_NullGhost_AdvancesCycleWithoutEvents` (line 1206) plus "the in-game flow". Today's `dotnet test` confirms both still skipped (7729 passed / 2 skipped).
 
-**Concern:** both behaviors are currently only covered by neighboring pure-logic siblings and in-game tests (`ReusePrimaryGhostAcrossCycle_NullGhost_AdvancesCycleWithoutEvents`, `GhostPlayback.SpawnGhost_PrimesFreshGhostToCurrentPlaybackUT_InGame` in `InGameTests/RuntimeTests.cs`). Skip messages explicitly say "do not re-enable without a Unity runtime harness". A standing xUnit Unity shim (or isolating the non-Unity portions so these scenarios can be unit-tested directly) would remove the coverage gap without requiring Ctrl+Shift+T.
+**Concern:** by project convention (`.claude/CLAUDE.md` — in-game tests are the tool for anything requiring live KSP), the `SpawnGhost` xUnit stub is pure dead weight and should be deleted. The `UpdateLoopingPlayback_PendingCycleBoundary` stub is the only signal that the pending-build cycle-advance edge case is not yet a dedicated in-game regression — either add one under `GhostPlayback` in `RuntimeTests.cs` (parallel to the `SpawnGhost` replacement) and delete the xUnit stub, or confirm the sibling pure-logic test plus existing in-game flow is sufficient and delete the stub with a note.
 
-**Files:** `Source/Parsek.Tests/GhostPlaybackEngineTests.cs`, `Source/Parsek/GhostPlaybackEngine.cs`, `Source/Parsek/InGameTests/RuntimeTests.cs`, `Source/Parsek.Tests/Parsek.Tests.csproj`.
+**Files:** `Source/Parsek.Tests/GhostPlaybackEngineTests.cs` (delete both `[Fact(Skip = ...)]` stubs), `Source/Parsek/InGameTests/RuntimeTests.cs` (add a dedicated `PendingCycleBoundary` in-game regression if coverage is judged insufficient).
 
-**Status:** OPEN. Long-standing skip — revisit only with a Unity runtime harness or a refactor that isolates the non-Unity paths.
+**Status:** OPEN. Cleanup — delete `SpawnGhost` stub outright; add an in-game counterpart for `PendingCycleBoundary` before deleting its stub.
 
 ---
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -428,6 +428,30 @@ The four top-of-queue correctness fixes (#431, #432, #433, #434) shipped in the 
 
 ---
 
+## 539. Two `GhostPlaybackEngineTests` cases stay permanently `[Fact(Skip = ...)]` because xUnit has no Unity runtime harness
+
+**Source:** `Source/Parsek.Tests/GhostPlaybackEngineTests.cs` has two permanently-skipped cases: `UpdateLoopingPlayback_PendingCycleBoundary_DoesNotEmitRestartEvents` (line 1153, Skip: `UpdateLoopingPlayback` body references `GameObject.activeSelf / SetActive`, which trip .NET 4.7.2 JIT verification) and `SpawnGhost_PrimesFreshGhostToCurrentPlaybackUT` (line 1509, Skip: Unity `GameObject` instantiation requires runtime). Today's `dotnet test` confirms them still skipped (7729 passed / 2 skipped).
+
+**Concern:** both behaviors are currently only covered by neighboring pure-logic siblings and in-game tests (`ReusePrimaryGhostAcrossCycle_NullGhost_AdvancesCycleWithoutEvents`, `GhostPlayback.SpawnGhost_PrimesFreshGhostToCurrentPlaybackUT_InGame` in `InGameTests/RuntimeTests.cs`). Skip messages explicitly say "do not re-enable without a Unity runtime harness". A standing xUnit Unity shim (or isolating the non-Unity portions so these scenarios can be unit-tested directly) would remove the coverage gap without requiring Ctrl+Shift+T.
+
+**Files:** `Source/Parsek.Tests/GhostPlaybackEngineTests.cs`, `Source/Parsek/GhostPlaybackEngine.cs`, `Source/Parsek/InGameTests/RuntimeTests.cs`, `Source/Parsek.Tests/Parsek.Tests.csproj`.
+
+**Status:** OPEN. Long-standing skip — revisit only with a Unity runtime harness or a refactor that isolates the non-Unity paths.
+
+---
+
+## 540. Three xUnit style warnings on `dotnet test` should be cleaned up
+
+**Source:** `dotnet test` on current `main` emits three xUnit analyzer warnings: `InGameTestRunnerTests.cs:259` (`xUnit1013` — `FormatCoroutineState_ReportsActiveAndIdleSlots` is public but missing `[Fact]`, so it silently does not run) and `KerbalsWindowUITests.cs:700-701` (two `xUnit2009` — `Assert.True(text.StartsWith(prefix, StringComparison.Ordinal))` should be `Assert.StartsWith(prefix, text, StringComparison.Ordinal)` for better failure messages).
+
+**Concern:** the `xUnit1013` case is a real correctness gap — the orphaned method sits between two `[Fact]`-attributed siblings and looks like a test that lost its attribute during an edit, so a code path currently believed to be tested is not. The two `xUnit2009` cases are presentation-only, but leaving analyzer warnings in the baseline trains reviewers to ignore real signals.
+
+**Files:** `Source/Parsek.Tests/InGameTestRunnerTests.cs` (add `[Fact]` to `FormatCoroutineState_ReportsActiveAndIdleSlots` or reduce visibility), `Source/Parsek.Tests/KerbalsWindowUITests.cs` (swap both `Assert.True(x.StartsWith(...))` for `Assert.StartsWith(...)`).
+
+**Status:** OPEN. Cheap cleanup; unblocks any later `TreatWarningsAsErrors` for the test project.
+
+---
+
 ## ~~487. Test Runner transparent background on scene change / Settings-hosted reopen path~~
 
 **Source:** follow-up on the transparent `TestRunner` window after scene transitions. The original fix hardened the global Ctrl+Shift+T shortcut path, but the shared `ParsekUI` cache used by the Settings-hosted Test Runner and other Parsek windows could still cache a transparent or unreadable window style after scene changes / skin-lag frames.


### PR DESCRIPTION
## Summary
- Add 18 new bug findings (#521-#538) to `docs/dev/todo-and-known-bugs.md`, sourced from the `2026-04-21_2335_live-collect-script` and `2026-04-22_0012_followup-log-sweep` log packages.
- Unify Timeline row action buttons (`W`, `FF`, `R`, `L`) to one shared 35f width constant and align Timeline's default/min window width with Career State so the two wide data windows share one footprint.
- Split ghost map label color from the per-vessel-type icon palette: labels stay yellow (shared `GetLabelColor()`) while icon tinting keeps the per-type palette; covered by a new `MapMarkerRendererTests` assertion.

## Test plan
- [x] `dotnet test Source/Parsek.Tests/Parsek.Tests.csproj` — confirm new `GetLabelColor_ReturnsSharedYellowInsteadOfPerTypePalette` passes.
- [ ] Open Timeline in-game and verify `W`/`FF`/`R`/`L` column no longer jitters between rows.
- [ ] Open Timeline alongside Career State and verify both windows share the same default width.
- [ ] Scan ghost markers in map view and confirm labels read yellow regardless of vessel type while icons keep their per-type color.