### PR TITLE
fix: polish spawned chain-tip restore follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,13 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- `#534` Returning to a spawned chain-tip vessel after a FLIGHT->FLIGHT switch now restores the existing mission tree instead of stranding the continuation in a fresh tree.
 - `#545` Timeline milestone rows now squash same-moment duplicate entries for the same milestone into one richer entry, including near-UT copies inside the same 0.1s window and same-timestamp rows separated by another entry. The surviving row unions missing funds/rep/science reward legs while leaving genuinely conflicting reward values split instead of inventing a combined total. Timeline milestone labels now also show science rewards, reducing the remaining “looks double-counted” milestone presentation path from `#522`.
 - `#546` Idle vessel switches now arm auto-record and start on the first meaningful physical modification.
 
 ### Tests
 
+- `#534` Added spawned chain-tip restore regressions covering committed-tree ownership, restorable-leaf filtering, multi-tree selection, and the throttled Update-time retry guard.
 - Added manual-only in-game coverage for the deferred FLIGHT `Merge to Timeline` commit path, a synthetic `Keep Vessel` playback-control canary that fast-forwards into playback and asserts the end-of-recording vessel spawn happens exactly once, a stock `Revert to Launch` canary that asserts the shipped soft-unstash / no-merge revert semantics, and two real `Space Center` exit canaries that drive the deferred merge-dialog `Merge to Timeline` and `Discard` branches end-to-end.
 - `#491` Archived live runtime evidence now covers both `SceneExitMerge` canaries: the stock `Space Center` exit discard branch clears the pending tree without a commit, and the merge branch commits the pending tree into `CommittedTrees` / `CommittedRecordings`.
 - Added deterministic in-game `PartEventTiming` canaries that assert light-toggle and deployable-transform ghost playback flips exactly at their authored UT boundaries, and retained live bundles under `C:\Users\vlad3\Documents\Code\Parsek\logs\2026-04-21_2008_finish-line-validation\` and `C:\Users\vlad3\Documents\Code\Parsek\logs\2026-04-21_2042_live-collect-script\` now show both exported `FlightIntegrationTests.PartEventTiming_*` rows passing in `FLIGHT`.
@@ -111,8 +113,6 @@ All notable changes to Parsek are documented here.
 - `#469` Added post-walk reconciliation regressions for pruned milestone history, stale pre-live-event history after an epoch bump, invariant-culture WARN formatting, and the still-live missing-event warning path.
 - `#467` Added `GameStateRecorder` regression coverage for near-threshold `ReputationChanged` deltas, including the stock-rounded `+/-0.9999995` shape and a control case that still ignores clearly sub-threshold reputation noise.
 - Added focused scene-exit finalization regressions for rejected hook outputs, decline diagnostics, ghost-only surface metadata preservation, and preservation of hook-authored terminal-orbit metadata.
-- `#534` Added committed-tree vessel-switch restore regressions for spawned chain-tip returns, including the detach-and-recommit ownership seam.
-
 ### Documentation
 
 - Added `docs/dev/test-coverage-matrix.md`, a current-tree subsystem matrix that maps major Parsek areas to their headless xUnit, in-game runtime, `KSP.log` validation, and manual coverage surfaces.
@@ -122,7 +122,6 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
-- `#534` Returning to a spawned chain-tip vessel after a FLIGHT->FLIGHT switch now restores the existing mission tree instead of stranding the continuation in a fresh tree.
 - Ballistic orbital-frame storage now normalizes as well as canonicalizes the saved quaternions, so SOI handoffs keep the same represented world attitude instead of drifting when a frozen playback rotation started as a scaled quaternion.
 - Hyperbolic predicted segments now reconstruct true anomaly with a quadrant-safe formula, so parent-body SOI handoffs keep the same boundary state and frozen playback attitude instead of folding the new segment onto the wrong outbound branch.
 - Hyperbolic predicted segments now keep periapsis orientation even when the parent escape orbit is equatorial, so SOI handoffs no longer serialize the parent segment with `argumentOfPeriapsis = 0` and then reconstruct the wrong start state and frozen attitude.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,7 +111,7 @@ All notable changes to Parsek are documented here.
 - `#469` Added post-walk reconciliation regressions for pruned milestone history, stale pre-live-event history after an epoch bump, invariant-culture WARN formatting, and the still-live missing-event warning path.
 - `#467` Added `GameStateRecorder` regression coverage for near-threshold `ReputationChanged` deltas, including the stock-rounded `+/-0.9999995` shape and a control case that still ignores clearly sub-threshold reputation noise.
 - Added focused scene-exit finalization regressions for rejected hook outputs, decline diagnostics, ghost-only surface metadata preservation, and preservation of hook-authored terminal-orbit metadata.
-- `#534` Added committed-tree vessel-switch restore regressions so returns to spawned mission-tree vessels now pin both restore shapes and the ownership seam: pre-transitioning the former active recording back into `BackgroundMap`, clearing stale recorded-PID background entries for the returned spawned leaf, detaching the matched tree from committed storage before it becomes live again, and preserving a normal later recommit.
+- `#534` Added committed-tree vessel-switch restore regressions for spawned chain-tip returns, including the detach-and-recommit ownership seam.
 
 ### Documentation
 
@@ -122,7 +122,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
-- `#534` Returning to a spawned chain-tip vessel after a FLIGHT->FLIGHT switch/scene reload now rehydrates the matching committed mission tree from the active vessel's spawned PID, preserves the previously-active recording in `BackgroundMap`, clears stale recorded-PID background entries for the returned spawned leaf, detaches the tree from committed storage before making it live again, and then promotes or resumes that vessel immediately instead of stranding the next continuation in a fresh single-node tree.
+- `#534` Returning to a spawned chain-tip vessel after a FLIGHT->FLIGHT switch now restores the existing mission tree instead of stranding the continuation in a fresh tree.
 - Ballistic orbital-frame storage now normalizes as well as canonicalizes the saved quaternions, so SOI handoffs keep the same represented world attitude instead of drifting when a frozen playback rotation started as a scaled quaternion.
 - Hyperbolic predicted segments now reconstruct true anomaly with a quadrant-safe formula, so parent-body SOI handoffs keep the same boundary state and frozen playback attitude instead of folding the new segment onto the wrong outbound branch.
 - Hyperbolic predicted segments now keep periapsis orientation even when the parent escape orbit is equatorial, so SOI handoffs no longer serialize the parent segment with `argumentOfPeriapsis = 0` and then reconstruct the wrong start state and frozen attitude.

--- a/Source/Parsek.Tests/MissedVesselSwitchRecoveryTests.cs
+++ b/Source/Parsek.Tests/MissedVesselSwitchRecoveryTests.cs
@@ -188,6 +188,61 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void ShouldAttemptCommittedSpawnedRestoreInUpdate_WhenStableAndDue_ReturnsTrue()
+        {
+            bool shouldAttempt = ParsekFlight.ShouldAttemptCommittedSpawnedRestoreInUpdate(
+                hasActiveTree: false,
+                hasRecorder: false,
+                isRestoringActiveTree: false,
+                hasPendingTree: false,
+                restoreMode: ParsekScenario.ActiveTreeRestoreMode.None,
+                currentUnscaledTime: 10f,
+                nextRetryAt: 9f);
+
+            Assert.True(shouldAttempt);
+        }
+
+        [Fact]
+        public void ShouldAttemptCommittedSpawnedRestoreInUpdate_WhenBlockedOrThrottled_ReturnsFalse()
+        {
+            Assert.False(ParsekFlight.ShouldAttemptCommittedSpawnedRestoreInUpdate(
+                hasActiveTree: true,
+                hasRecorder: false,
+                isRestoringActiveTree: false,
+                hasPendingTree: false,
+                restoreMode: ParsekScenario.ActiveTreeRestoreMode.None,
+                currentUnscaledTime: 10f,
+                nextRetryAt: 0f));
+
+            Assert.False(ParsekFlight.ShouldAttemptCommittedSpawnedRestoreInUpdate(
+                hasActiveTree: false,
+                hasRecorder: false,
+                isRestoringActiveTree: false,
+                hasPendingTree: true,
+                restoreMode: ParsekScenario.ActiveTreeRestoreMode.None,
+                currentUnscaledTime: 10f,
+                nextRetryAt: 0f));
+
+            Assert.False(ParsekFlight.ShouldAttemptCommittedSpawnedRestoreInUpdate(
+                hasActiveTree: false,
+                hasRecorder: false,
+                isRestoringActiveTree: false,
+                hasPendingTree: false,
+                restoreMode: ParsekScenario.ActiveTreeRestoreMode.VesselSwitch,
+                currentUnscaledTime: 10f,
+                nextRetryAt: 0f));
+
+            Assert.False(ParsekFlight.ShouldAttemptCommittedSpawnedRestoreInUpdate(
+                hasActiveTree: false,
+                hasRecorder: false,
+                isRestoringActiveTree: false,
+                hasPendingTree: false,
+                restoreMode: ParsekScenario.ActiveTreeRestoreMode.None,
+                currentUnscaledTime: 10f,
+                nextRetryAt: 11f));
+        }
+
+        [Fact]
         public void Update_CallsMissedVesselSwitchRecoveryBeforeTreeHandlers()
         {
             string parsekFlightPath = LocateParsekFlightSource();

--- a/Source/Parsek.Tests/VesselSwitchTreeTests.cs
+++ b/Source/Parsek.Tests/VesselSwitchTreeTests.cs
@@ -292,6 +292,48 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void TryFindCommittedTreeForSpawnedVessel_PrefersNewestCommittedTreeAcrossList()
+        {
+            var olderTree = MakeTree("old_active");
+            olderTree.Id = "tree_old";
+            olderTree.Recordings["old_tip"] = new Recording
+            {
+                RecordingId = "old_tip",
+                VesselName = "Older Tip",
+                VesselPersistentId = 10,
+                VesselSpawned = true,
+                SpawnedVesselPersistentId = 200,
+                ExplicitStartUT = 100.0,
+                ExplicitEndUT = 150.0,
+                TreeOrder = 0
+            };
+
+            var newerTree = MakeTree("new_active");
+            newerTree.Id = "tree_new";
+            newerTree.Recordings["new_tip"] = new Recording
+            {
+                RecordingId = "new_tip",
+                VesselName = "Newer Tip",
+                VesselPersistentId = 20,
+                VesselSpawned = true,
+                SpawnedVesselPersistentId = 200,
+                ExplicitStartUT = 151.0,
+                ExplicitEndUT = 200.0,
+                TreeOrder = 0
+            };
+
+            bool found = ParsekFlight.TryFindCommittedTreeForSpawnedVessel(
+                new List<RecordingTree> { olderTree, newerTree },
+                activeVesselPid: 200,
+                out RecordingTree matchedTree,
+                out string matchedRecordingId);
+
+            Assert.True(found);
+            Assert.Same(newerTree, matchedTree);
+            Assert.Equal("new_tip", matchedRecordingId);
+        }
+
+        [Fact]
         public void PrepareCommittedTreeRestoreForSpawnedVessel_BackgroundTarget_UsesSpawnedPidAndClearsStaleBackgroundEntry()
         {
             var tree = MakeTree("rec_active", (20, "rec_tip"));
@@ -379,6 +421,65 @@ namespace Parsek.Tests
             Assert.Single(RecordingStore.CommittedTrees);
             Assert.Equal(tree.Id, RecordingStore.CommittedTrees[0].Id);
             Assert.Equal(liveTree.Recordings.Count, RecordingStore.CommittedRecordings.Count);
+        }
+
+        [Fact]
+        public void IsCommittedSpawnedRecordingRestorable_RejectsTerminalStates()
+        {
+            TerminalState[] blockedStates =
+            {
+                TerminalState.Destroyed,
+                TerminalState.Recovered,
+                TerminalState.Docked,
+                TerminalState.Boarded
+            };
+
+            for (int i = 0; i < blockedStates.Length; i++)
+            {
+                var tree = MakeTree("rec_other");
+                var rec = new Recording
+                {
+                    RecordingId = "rec_tip",
+                    VesselPersistentId = 20,
+                    VesselSpawned = true,
+                    SpawnedVesselPersistentId = 200,
+                    TerminalStateValue = blockedStates[i]
+                };
+
+                tree.Recordings["rec_tip"] = rec;
+                Assert.False(ParsekFlight.IsCommittedSpawnedRecordingRestorable(tree, rec));
+            }
+        }
+
+        [Fact]
+        public void IsCommittedSpawnedRecordingRestorable_RejectsMidChainSegment()
+        {
+            var tree = MakeTree("rec_other");
+            var rec = new Recording
+            {
+                RecordingId = "rec_mid",
+                VesselPersistentId = 20,
+                VesselSpawned = true,
+                SpawnedVesselPersistentId = 200,
+                ChainId = "chain",
+                ChainIndex = 0,
+                ChainBranch = 0
+            };
+            var next = new Recording
+            {
+                RecordingId = "rec_tip",
+                VesselPersistentId = 21,
+                VesselSpawned = true,
+                SpawnedVesselPersistentId = 201,
+                ChainId = "chain",
+                ChainIndex = 1,
+                ChainBranch = 0
+            };
+
+            tree.Recordings[rec.RecordingId] = rec;
+            tree.Recordings[next.RecordingId] = next;
+
+            Assert.False(ParsekFlight.IsCommittedSpawnedRecordingRestorable(tree, rec));
         }
 
         #endregion

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -182,10 +182,12 @@ namespace Parsek
         private const double PostSwitchResourceDeltaEpsilon = 0.01;
         private const double PostSwitchManifestEvaluationIntervalSeconds = 0.25;
         private const double PostSwitchManifestEvaluateNextFrameUt = 0.0;
+        private const float CommittedSpawnedRestoreRetryIntervalSeconds = 1.0f;
 
         // Set true in OnSceneChangeRequested — suppresses Update() to prevent
         // ghost spawns and other processing into the dying scene.
         private bool sceneChangeInProgress;
+        private float nextCommittedSpawnedRestoreRetryAt;
 
         // Deferred watch target after fast-forward — the ghost needs one frame
         // to be positioned after the time jump before we can enter watch mode.
@@ -2071,7 +2073,9 @@ namespace Parsek
 
             ParsekLog.RecState("PromoteFromBackground:entry", CaptureRecorderState());
 
-            // Remove from BackgroundMap
+            // Callers pass the target recording id explicitly; BackgroundMap membership is
+            // not a hard precondition here. The committed-tree restore path may already have
+            // removed stale entries for this recording before the live promotion runs.
             activeTree.BackgroundMap.Remove(newVessel.persistentId);
 
             // Set as the active recording
@@ -6003,8 +6007,33 @@ namespace Parsek
         /// </summary>
         private void HandleMissedVesselSwitchRecovery()
         {
-            if (TryRestoreCommittedTreeForSpawnedActiveVessel())
-                return;
+            if (ShouldAttemptCommittedSpawnedRestoreInUpdate(
+                    activeTree != null,
+                    recorder != null,
+                    restoringActiveTree,
+                    RecordingStore.HasPendingTree,
+                    ParsekScenario.ScheduleActiveTreeRestoreOnFlightReady,
+                    Time.unscaledTime,
+                    nextCommittedSpawnedRestoreRetryAt))
+            {
+                nextCommittedSpawnedRestoreRetryAt =
+                    Time.unscaledTime + CommittedSpawnedRestoreRetryIntervalSeconds;
+                if (TryRestoreCommittedTreeForSpawnedActiveVessel())
+                {
+                    nextCommittedSpawnedRestoreRetryAt = 0f;
+                    return;
+                }
+
+                // A matched committed-tree restore may already have installed the tree,
+                // detached it from committed storage, and put the returned vessel back in
+                // BackgroundMap before the recorder attach failed. Falling through here is
+                // intentional: the existing missed-switch recovery path can retry the final
+                // promotion/resume from that live tree shape without rolling the tree back.
+            }
+            else if (activeTree != null || recorder != null)
+            {
+                nextCommittedSpawnedRestoreRetryAt = 0f;
+            }
 
             Vessel activeVessel = FlightGlobals.ActiveVessel;
             uint activeVesselPid = activeVessel != null ? activeVessel.persistentId : 0;
@@ -7630,6 +7659,22 @@ namespace Parsek
 
             return activeVesselTrackedInBackground
                 && !activeVesselAlreadyArmedForPostSwitchAutoRecord;
+        }
+
+        internal static bool ShouldAttemptCommittedSpawnedRestoreInUpdate(
+            bool hasActiveTree,
+            bool hasRecorder,
+            bool isRestoringActiveTree,
+            bool hasPendingTree,
+            ParsekScenario.ActiveTreeRestoreMode restoreMode,
+            float currentUnscaledTime,
+            float nextRetryAt)
+        {
+            if (hasActiveTree || hasRecorder) return false;
+            if (isRestoringActiveTree) return false;
+            if (hasPendingTree) return false;
+            if (restoreMode != ParsekScenario.ActiveTreeRestoreMode.None) return false;
+            return currentUnscaledTime >= nextRetryAt;
         }
 
         internal static bool TryFindCommittedTreeForSpawnedVessel(

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -6032,6 +6032,9 @@ namespace Parsek
             }
             else if (activeTree != null || recorder != null)
             {
+                // Only reset once a live tree/recorder takes over ownership. The other
+                // transient blockers (restore coroutine, pending tree, restore mode) are
+                // allowed to age out naturally against the 1s retry window.
                 nextCommittedSpawnedRestoreRetryAt = 0f;
             }
 

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -2071,9 +2071,14 @@ namespace Parsek
                 // though the save file has the T2 active version), remove the committed
                 // copy so the active version is the single source of truth. Otherwise
                 // the next OnSave would write the tree twice with the same id.
-                RecordingStore.RemoveCommittedTreeById(
-                    tree.Id,
-                    logContext: "TryRestoreActiveTreeNode");
+                if (!RecordingStore.RemoveCommittedTreeById(
+                        tree.Id,
+                        logContext: "TryRestoreActiveTreeNode"))
+                {
+                    ParsekLog.Verbose("Scenario",
+                        $"TryRestoreActiveTreeNode: no committed copy of tree '{tree.TreeName}' " +
+                        $"(id={tree.Id}) needed detaching");
+                }
 
                 // Bug #290d: if the pending tree is already Finalized (set by
                 // CommitTreeSceneExit during the same scene transition), it has


### PR DESCRIPTION
## Summary
- add small follow-ups after the merged #534 restore change: throttle the Update-time committed-tree scan, clarify the safe late-recovery shape, and log the no-op committed-tree detach path during active-tree restore
- extend spawned chain-tip restore coverage with multi-tree ordering and restorable-rejection cases, plus targeted guard coverage for the new Update-time retry throttle
- compress the #534 changelog wording to match the changelog style guidance

## Testing
- dotnet build Source/Parsek/Parsek.csproj
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter "VesselSwitchTreeTests|MissedVesselSwitchRecoveryTests"
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj