### PR TITLE
Fix #530 stabilize lazy Timeline watch eligibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- `#530` Pending timeline ghost shells now seed their playback body metadata before a split lazy build finishes, so Timeline and Recordings `W` buttons no longer open in a false disabled state just because the snapshot build is still advancing across frames.
 - Ballistic orbital-frame storage now normalizes as well as canonicalizes the saved quaternions, so SOI handoffs keep the same represented world attitude instead of drifting when a frozen playback rotation started as a scaled quaternion.
 - Hyperbolic predicted segments now reconstruct true anomaly with a quadrant-safe formula, so parent-body SOI handoffs keep the same boundary state and frozen playback attitude instead of folding the new segment onto the wrong outbound branch.
 - Hyperbolic predicted segments now keep periapsis orientation even when the parent escape orbit is equatorial, so SOI handoffs no longer serialize the parent segment with `argumentOfPeriapsis = 0` and then reconstruct the wrong start state and frozen attitude.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- `#530` Pending timeline ghost shells now seed their playback body metadata before a split lazy build finishes, so Timeline and Recordings `W` buttons no longer open in a false disabled state just because the snapshot build is still advancing across frames.
 - `#545` Timeline milestone rows now squash same-moment duplicate entries for the same milestone into one richer entry, including near-UT copies inside the same 0.1s window and same-timestamp rows separated by another entry. The surviving row unions missing funds/rep/science reward legs while leaving genuinely conflicting reward values split instead of inventing a combined total. Timeline milestone labels now also show science rewards, reducing the remaining “looks double-counted” milestone presentation path from `#522`.
 - `#546` Idle vessel switches now arm auto-record and start on the first meaningful physical modification.
 
@@ -121,7 +122,6 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
-- `#530` Pending timeline ghost shells now seed their playback body metadata before a split lazy build finishes, so Timeline and Recordings `W` buttons no longer open in a false disabled state just because the snapshot build is still advancing across frames.
 - Ballistic orbital-frame storage now normalizes as well as canonicalizes the saved quaternions, so SOI handoffs keep the same represented world attitude instead of drifting when a frozen playback rotation started as a scaled quaternion.
 - Hyperbolic predicted segments now reconstruct true anomaly with a quadrant-safe formula, so parent-body SOI handoffs keep the same boundary state and frozen playback attitude instead of folding the new segment onto the wrong outbound branch.
 - Hyperbolic predicted segments now keep periapsis orientation even when the parent escape orbit is equatorial, so SOI handoffs no longer serialize the parent segment with `argumentOfPeriapsis = 0` and then reconstruct the wrong start state and frozen attitude.

--- a/Source/Parsek.Tests/GhostPlaybackEngineTests.cs
+++ b/Source/Parsek.Tests/GhostPlaybackEngineTests.cs
@@ -26,6 +26,7 @@ namespace Parsek.Tests
             ParsekLog.ResetTestOverrides();
             ParsekLog.SuppressLogging = true;
             RecordingStore.ResetForTesting();
+            GhostPlaybackEngine.PendingOrbitBodyRadiusResolverForTesting = null;
         }
 
         private static EngineGhostInfo BuildEngineGhostInfo(int particleSystemCount)
@@ -1412,6 +1413,279 @@ namespace Parsek.Tests
         // ===================================================================
         // Query API — HasGhost, HasActiveGhost, IsGhostOnBody, etc.
         // ===================================================================
+
+        #region PendingPlaybackMetadata
+
+        [Fact]
+        public void TryResolvePendingPlaybackInterpolation_PointInterpolation_UsesInterpolatedState()
+        {
+            var traj = new MockTrajectory
+            {
+                Points = new List<TrajectoryPoint>
+                {
+                    new TrajectoryPoint
+                    {
+                        ut = 100,
+                        bodyName = "Kerbin",
+                        altitude = 1000,
+                        velocity = new Vector3(10f, 0f, 0f),
+                        rotation = Quaternion.identity
+                    },
+                    new TrajectoryPoint
+                    {
+                        ut = 110,
+                        bodyName = "Mun",
+                        altitude = 3000,
+                        velocity = new Vector3(30f, 0f, 0f),
+                        rotation = Quaternion.identity
+                    }
+                }
+            };
+
+            bool resolved = GhostPlaybackEngine.TryResolvePendingPlaybackInterpolation(
+                traj, playbackUT: 105.0, out InterpolationResult result);
+
+            Assert.True(resolved);
+            Assert.Equal("Mun", result.bodyName);
+            Assert.Equal(2000.0, result.altitude);
+            Assert.Equal(new Vector3(20f, 0f, 0f), result.velocity);
+        }
+
+        [Fact]
+        public void TryResolvePendingPlaybackInterpolation_BeforeStart_UsesFirstPointState()
+        {
+            var traj = new MockTrajectory
+            {
+                Points = new List<TrajectoryPoint>
+                {
+                    new TrajectoryPoint
+                    {
+                        ut = 100,
+                        bodyName = "Kerbin",
+                        altitude = 1500,
+                        velocity = new Vector3(7f, 0f, 0f),
+                        rotation = Quaternion.identity
+                    },
+                    new TrajectoryPoint
+                    {
+                        ut = 110,
+                        bodyName = "Kerbin",
+                        altitude = 1700,
+                        velocity = new Vector3(9f, 0f, 0f),
+                        rotation = Quaternion.identity
+                    }
+                }
+            };
+
+            bool resolved = GhostPlaybackEngine.TryResolvePendingPlaybackInterpolation(
+                traj, playbackUT: 90.0, out InterpolationResult result);
+
+            Assert.True(resolved);
+            Assert.Equal("Kerbin", result.bodyName);
+            Assert.Equal(1500.0, result.altitude);
+            Assert.Equal(new Vector3(7f, 0f, 0f), result.velocity);
+        }
+
+        [Fact]
+        public void TryResolvePendingPlaybackInterpolation_OrbitOnlyTrajectory_UsesSegmentBody()
+        {
+            var traj = new MockTrajectory
+            {
+                OrbitSegments = new List<OrbitSegment>
+                {
+                    new OrbitSegment
+                    {
+                        bodyName = "Minmus",
+                        semiMajorAxis = 800000,
+                        startUT = 100,
+                        endUT = 200
+                    }
+                },
+                EndUTOverride = 200
+            };
+
+            bool resolved = GhostPlaybackEngine.TryResolvePendingPlaybackInterpolation(
+                traj, playbackUT: 150.0, out InterpolationResult result);
+
+            Assert.True(resolved);
+            Assert.Equal("Minmus", result.bodyName);
+            Assert.Equal(0.0, result.altitude);
+            Assert.Equal(Vector3.zero, result.velocity);
+        }
+
+        [Fact]
+        public void TryResolvePendingPlaybackInterpolation_MixedPointAndOrbitData_PrefersActiveOrbitSegment()
+        {
+            GhostPlaybackEngine.PendingOrbitBodyRadiusResolverForTesting = _ => 600000;
+
+            var traj = new MockTrajectory
+            {
+                Points = new List<TrajectoryPoint>
+                {
+                    new TrajectoryPoint
+                    {
+                        ut = 100,
+                        bodyName = "Kerbin",
+                        altitude = 1000,
+                        velocity = new Vector3(5f, 0f, 0f),
+                        rotation = Quaternion.identity
+                    },
+                    new TrajectoryPoint
+                    {
+                        ut = 110,
+                        bodyName = "Kerbin",
+                        altitude = 2000,
+                        velocity = new Vector3(15f, 0f, 0f),
+                        rotation = Quaternion.identity
+                    }
+                },
+                OrbitSegments = new List<OrbitSegment>
+                {
+                    new OrbitSegment
+                    {
+                        bodyName = "Mun",
+                        semiMajorAxis = 800000,
+                        startUT = 100,
+                        endUT = 200
+                    }
+                }
+            };
+
+            bool resolved = GhostPlaybackEngine.TryResolvePendingPlaybackInterpolation(
+                traj, playbackUT: 105.0, out InterpolationResult result);
+
+            Assert.True(resolved);
+            Assert.Equal("Mun", result.bodyName);
+            Assert.Equal(0.0, result.altitude);
+            Assert.Equal(Vector3.zero, result.velocity);
+        }
+
+        [Fact]
+        public void TryResolvePendingPlaybackInterpolation_SubSurfaceMixedOrbitSegment_FallsBackToPoints()
+        {
+            GhostPlaybackEngine.PendingOrbitBodyRadiusResolverForTesting = _ => 600000;
+
+            var traj = new MockTrajectory
+            {
+                Points = new List<TrajectoryPoint>
+                {
+                    new TrajectoryPoint
+                    {
+                        ut = 100,
+                        bodyName = "Kerbin",
+                        altitude = 1000,
+                        velocity = new Vector3(5f, 0f, 0f),
+                        rotation = Quaternion.identity
+                    },
+                    new TrajectoryPoint
+                    {
+                        ut = 110,
+                        bodyName = "Kerbin",
+                        altitude = 2000,
+                        velocity = new Vector3(15f, 0f, 0f),
+                        rotation = Quaternion.identity
+                    }
+                },
+                OrbitSegments = new List<OrbitSegment>
+                {
+                    new OrbitSegment
+                    {
+                        bodyName = "Mun",
+                        semiMajorAxis = 100000,
+                        startUT = 100,
+                        endUT = 200
+                    }
+                }
+            };
+
+            bool resolved = GhostPlaybackEngine.TryResolvePendingPlaybackInterpolation(
+                traj, playbackUT: 105.0, out InterpolationResult result);
+
+            Assert.True(resolved);
+            Assert.Equal("Kerbin", result.bodyName);
+            Assert.Equal(1500.0, result.altitude);
+            Assert.Equal(new Vector3(10f, 0f, 0f), result.velocity);
+        }
+
+        [Fact]
+        public void TryResolvePendingPlaybackInterpolation_SurfaceTrackSection_SkipsOrbitSegmentPrecedence()
+        {
+            GhostPlaybackEngine.PendingOrbitBodyRadiusResolverForTesting = _ => 600000;
+
+            var traj = new MockTrajectory
+            {
+                Points = new List<TrajectoryPoint>
+                {
+                    new TrajectoryPoint
+                    {
+                        ut = 100,
+                        bodyName = "Kerbin",
+                        altitude = 1000,
+                        velocity = new Vector3(5f, 0f, 0f),
+                        rotation = Quaternion.identity
+                    },
+                    new TrajectoryPoint
+                    {
+                        ut = 110,
+                        bodyName = "Kerbin",
+                        altitude = 2000,
+                        velocity = new Vector3(15f, 0f, 0f),
+                        rotation = Quaternion.identity
+                    }
+                },
+                OrbitSegments = new List<OrbitSegment>
+                {
+                    new OrbitSegment
+                    {
+                        bodyName = "Mun",
+                        semiMajorAxis = 800000,
+                        startUT = 100,
+                        endUT = 200
+                    }
+                },
+                TrackSections = new List<TrackSection>
+                {
+                    new TrackSection
+                    {
+                        environment = SegmentEnvironment.SurfaceMobile,
+                        startUT = 100,
+                        endUT = 110
+                    }
+                }
+            };
+
+            bool resolved = GhostPlaybackEngine.TryResolvePendingPlaybackInterpolation(
+                traj, playbackUT: 105.0, out InterpolationResult result);
+
+            Assert.True(resolved);
+            Assert.Equal("Kerbin", result.bodyName);
+            Assert.Equal(1500.0, result.altitude);
+            Assert.Equal(new Vector3(10f, 0f, 0f), result.velocity);
+        }
+
+        [Fact]
+        public void TryResolvePendingPlaybackInterpolation_SurfaceOnlyTrajectory_UsesSurfaceBody()
+        {
+            var traj = new MockTrajectory
+            {
+                SurfacePos = new SurfacePosition
+                {
+                    body = "Duna",
+                    altitude = 42
+                },
+                EndUTOverride = 100
+            };
+
+            bool resolved = GhostPlaybackEngine.TryResolvePendingPlaybackInterpolation(
+                traj, playbackUT: 100.0, out InterpolationResult result);
+
+            Assert.True(resolved);
+            Assert.Equal("Duna", result.bodyName);
+            Assert.Equal(42.0, result.altitude);
+            Assert.Equal(Vector3.zero, result.velocity);
+        }
+
+        #endregion
 
         #region QueryAPI
 

--- a/Source/Parsek.Tests/GhostPlaybackEngineTests.cs
+++ b/Source/Parsek.Tests/GhostPlaybackEngineTests.cs
@@ -1794,6 +1794,65 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void TryResolvePendingPlaybackInterpolation_SurfaceTrackSection_SubSurfaceOrbitSegment_DoesNotLogSkippedOrbitPrecedence()
+        {
+            logLines.Clear();
+            GhostPlaybackEngine.PendingOrbitBodyRadiusResolverForTesting = _ => 600000;
+
+            var traj = new MockTrajectory
+            {
+                VesselName = "SubSurfaceSurfaceGhost",
+                Points = new List<TrajectoryPoint>
+                {
+                    new TrajectoryPoint
+                    {
+                        ut = 100,
+                        bodyName = "Kerbin",
+                        altitude = 1000,
+                        velocity = new Vector3(5f, 0f, 0f),
+                        rotation = Quaternion.identity
+                    },
+                    new TrajectoryPoint
+                    {
+                        ut = 110,
+                        bodyName = "Kerbin",
+                        altitude = 2000,
+                        velocity = new Vector3(15f, 0f, 0f),
+                        rotation = Quaternion.identity
+                    }
+                },
+                OrbitSegments = new List<OrbitSegment>
+                {
+                    new OrbitSegment
+                    {
+                        bodyName = "Mun",
+                        semiMajorAxis = 100000,
+                        startUT = 100,
+                        endUT = 200
+                    }
+                },
+                TrackSections = new List<TrackSection>
+                {
+                    new TrackSection
+                    {
+                        environment = SegmentEnvironment.SurfaceMobile,
+                        startUT = 100,
+                        endUT = 110
+                    }
+                }
+            };
+
+            bool resolved = GhostPlaybackEngine.TryResolvePendingPlaybackInterpolation(
+                traj, playbackUT: 105.0, out InterpolationResult result);
+
+            Assert.True(resolved);
+            Assert.Equal("Kerbin", result.bodyName);
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("SubSurfaceSurfaceGhost")
+                && l.Contains("surface track section active, skipping orbit precedence"));
+        }
+
+        [Fact]
         public void TryResolvePendingPlaybackInterpolation_SurfaceOnlyTrajectory_UsesSurfaceBody()
         {
             var traj = new MockTrajectory

--- a/Source/Parsek.Tests/GhostPlaybackEngineTests.cs
+++ b/Source/Parsek.Tests/GhostPlaybackEngineTests.cs
@@ -1436,8 +1436,11 @@ namespace Parsek.Tests
         [Fact]
         public void TryResolvePendingPlaybackInterpolation_PointInterpolation_UsesInterpolatedState()
         {
+            logLines.Clear();
+
             var traj = new MockTrajectory
             {
+                VesselName = "CrossBodyGhost",
                 Points = new List<TrajectoryPoint>
                 {
                     new TrajectoryPoint
@@ -1466,6 +1469,11 @@ namespace Parsek.Tests
             Assert.Equal("Mun", result.bodyName);
             Assert.Equal(2000.0, result.altitude);
             Assert.Equal(new Vector3(20f, 0f, 0f), result.velocity);
+            Assert.Contains(logLines, l =>
+                l.Contains("[Engine]")
+                && l.Contains("CrossBodyGhost")
+                && l.Contains("cross-body point transition Kerbin->Mun")
+                && l.Contains("body='Mun'"));
         }
 
         [Fact]
@@ -1670,6 +1678,7 @@ namespace Parsek.Tests
         [Fact]
         public void TryResolvePendingPlaybackInterpolation_SurfaceTrackSection_SkipsOrbitSegmentPrecedence()
         {
+            logLines.Clear();
             GhostPlaybackEngine.PendingOrbitBodyRadiusResolverForTesting = _ => 600000;
 
             var traj = new MockTrajectory
@@ -1721,6 +1730,67 @@ namespace Parsek.Tests
             Assert.Equal("Kerbin", result.bodyName);
             Assert.Equal(1500.0, result.altitude);
             Assert.Equal(new Vector3(10f, 0f, 0f), result.velocity);
+            Assert.Contains(logLines, l =>
+                l.Contains("[Engine]")
+                && l.Contains("surface track section active, skipping orbit precedence"));
+        }
+
+        [Fact]
+        public void TryResolvePendingPlaybackInterpolation_SurfaceTrackSection_OffUtOrbitSegment_DoesNotLogSkippedOrbitPrecedence()
+        {
+            logLines.Clear();
+
+            var traj = new MockTrajectory
+            {
+                VesselName = "SurfaceOnlyGhost",
+                Points = new List<TrajectoryPoint>
+                {
+                    new TrajectoryPoint
+                    {
+                        ut = 100,
+                        bodyName = "Kerbin",
+                        altitude = 1000,
+                        velocity = new Vector3(5f, 0f, 0f),
+                        rotation = Quaternion.identity
+                    },
+                    new TrajectoryPoint
+                    {
+                        ut = 110,
+                        bodyName = "Kerbin",
+                        altitude = 2000,
+                        velocity = new Vector3(15f, 0f, 0f),
+                        rotation = Quaternion.identity
+                    }
+                },
+                OrbitSegments = new List<OrbitSegment>
+                {
+                    new OrbitSegment
+                    {
+                        bodyName = "Mun",
+                        semiMajorAxis = 800000,
+                        startUT = 200,
+                        endUT = 300
+                    }
+                },
+                TrackSections = new List<TrackSection>
+                {
+                    new TrackSection
+                    {
+                        environment = SegmentEnvironment.SurfaceMobile,
+                        startUT = 100,
+                        endUT = 110
+                    }
+                }
+            };
+
+            bool resolved = GhostPlaybackEngine.TryResolvePendingPlaybackInterpolation(
+                traj, playbackUT: 105.0, out InterpolationResult result);
+
+            Assert.True(resolved);
+            Assert.Equal("Kerbin", result.bodyName);
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("SurfaceOnlyGhost")
+                && l.Contains("surface track section active, skipping orbit precedence"));
         }
 
         [Fact]

--- a/Source/Parsek.Tests/GhostPlaybackEngineTests.cs
+++ b/Source/Parsek.Tests/GhostPlaybackEngineTests.cs
@@ -1767,7 +1767,7 @@ namespace Parsek.Tests
                     new TrajectoryPoint
                     {
                         ut = 110,
-                        bodyName = "Mun",
+                        bodyName = "Kerbin",
                         altitude = 2000,
                         velocity = new Vector3(15f, 0f, 0f),
                         rotation = Quaternion.identity
@@ -1782,20 +1782,20 @@ namespace Parsek.Tests
                 PendingSpawnLifecycle.StandardEnter,
                 default(TrajectoryPlaybackFlags));
 
-            Assert.Equal("Mun", state.lastInterpolatedBodyName);
+            Assert.Equal("Kerbin", state.lastInterpolatedBodyName);
             Assert.Equal(1500.0, state.lastInterpolatedAltitude);
             Assert.Equal(new Vector3(10f, 0f, 0f), state.lastInterpolatedVelocity);
             Assert.Contains(logLines, l =>
                 l.Contains("[Engine]")
                 && l.Contains("SeededGhost")
                 && l.Contains("resolved from point interpolation")
-                && l.Contains("body='Mun'"));
+                && l.Contains("body='Kerbin'"));
             Assert.Contains(logLines, l =>
                 l.Contains("[Engine]")
                 && l.Contains("Pending spawn interpolation seed")
                 && l.Contains("SeededGhost")
                 && l.Contains("lifecycle=StandardEnter")
-                && l.Contains("body='Mun'"));
+                && l.Contains("body='Kerbin'"));
         }
 
         #endregion

--- a/Source/Parsek.Tests/GhostPlaybackEngineTests.cs
+++ b/Source/Parsek.Tests/GhostPlaybackEngineTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using UnityEngine;
 using Xunit;
 
@@ -66,6 +67,22 @@ namespace Parsek.Tests
                 VesselName = recordingId,
                 PlaybackEnabled = true,
             }.WithTimeRange(startUT, endUT).WithLoop(999.0, LoopTimeUnit.Auto);
+        }
+
+        private static GhostPlaybackState InvokeCreatePendingSpawnState(
+            GhostPlaybackEngine engine,
+            IPlaybackTrajectory traj,
+            double playbackUT,
+            PendingSpawnLifecycle lifecycle,
+            TrajectoryPlaybackFlags flags)
+        {
+            MethodInfo method = typeof(GhostPlaybackEngine).GetMethod(
+                "CreatePendingSpawnState",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(method);
+
+            object state = method.Invoke(engine, new object[] { traj, playbackUT, lifecycle, flags });
+            return Assert.IsType<GhostPlaybackState>(state);
         }
 
         private sealed class SpawnPrimingPositioner : IGhostPositioner
@@ -1487,6 +1504,49 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void TryResolvePendingPlaybackInterpolation_AfterEnd_UsesLastPointStateAndLogsClamp()
+        {
+            logLines.Clear();
+
+            var traj = new MockTrajectory
+            {
+                VesselName = "AfterEndGhost",
+                Points = new List<TrajectoryPoint>
+                {
+                    new TrajectoryPoint
+                    {
+                        ut = 100,
+                        bodyName = "Kerbin",
+                        altitude = 1500,
+                        velocity = new Vector3(7f, 0f, 0f),
+                        rotation = Quaternion.identity
+                    },
+                    new TrajectoryPoint
+                    {
+                        ut = 110,
+                        bodyName = "Mun",
+                        altitude = 1700,
+                        velocity = new Vector3(9f, 0f, 0f),
+                        rotation = Quaternion.identity
+                    }
+                }
+            };
+
+            bool resolved = GhostPlaybackEngine.TryResolvePendingPlaybackInterpolation(
+                traj, playbackUT: 120.0, out InterpolationResult result);
+
+            Assert.True(resolved);
+            Assert.Equal("Mun", result.bodyName);
+            Assert.Equal(1700.0, result.altitude);
+            Assert.Equal(new Vector3(9f, 0f, 0f), result.velocity);
+            Assert.Contains(logLines, l =>
+                l.Contains("[Engine]")
+                && l.Contains("AfterEndGhost")
+                && l.Contains("resolved from point after-end clamp")
+                && l.Contains("body='Mun'"));
+        }
+
+        [Fact]
         public void TryResolvePendingPlaybackInterpolation_OrbitOnlyTrajectory_UsesSegmentBody()
         {
             var traj = new MockTrajectory
@@ -1683,6 +1743,59 @@ namespace Parsek.Tests
             Assert.Equal("Duna", result.bodyName);
             Assert.Equal(42.0, result.altitude);
             Assert.Equal(Vector3.zero, result.velocity);
+        }
+
+        [Fact]
+        public void CreatePendingSpawnState_ResolvedInterpolation_SeedsStateAndLogs()
+        {
+            logLines.Clear();
+
+            var engine = new GhostPlaybackEngine(null);
+            var traj = new MockTrajectory
+            {
+                VesselName = "SeededGhost",
+                Points = new List<TrajectoryPoint>
+                {
+                    new TrajectoryPoint
+                    {
+                        ut = 100,
+                        bodyName = "Kerbin",
+                        altitude = 1000,
+                        velocity = new Vector3(5f, 0f, 0f),
+                        rotation = Quaternion.identity
+                    },
+                    new TrajectoryPoint
+                    {
+                        ut = 110,
+                        bodyName = "Mun",
+                        altitude = 2000,
+                        velocity = new Vector3(15f, 0f, 0f),
+                        rotation = Quaternion.identity
+                    }
+                }
+            };
+
+            GhostPlaybackState state = InvokeCreatePendingSpawnState(
+                engine,
+                traj,
+                playbackUT: 105.0,
+                PendingSpawnLifecycle.StandardEnter,
+                default(TrajectoryPlaybackFlags));
+
+            Assert.Equal("Mun", state.lastInterpolatedBodyName);
+            Assert.Equal(1500.0, state.lastInterpolatedAltitude);
+            Assert.Equal(new Vector3(10f, 0f, 0f), state.lastInterpolatedVelocity);
+            Assert.Contains(logLines, l =>
+                l.Contains("[Engine]")
+                && l.Contains("SeededGhost")
+                && l.Contains("resolved from point interpolation")
+                && l.Contains("body='Mun'"));
+            Assert.Contains(logLines, l =>
+                l.Contains("[Engine]")
+                && l.Contains("Pending spawn interpolation seed")
+                && l.Contains("SeededGhost")
+                && l.Contains("lifecycle=StandardEnter")
+                && l.Contains("body='Mun'"));
         }
 
         #endregion

--- a/Source/Parsek/GhostPlaybackEngine.cs
+++ b/Source/Parsek/GhostPlaybackEngine.cs
@@ -3426,20 +3426,18 @@ namespace Parsek
             if (traj.Points != null && traj.Points.Count >= 2)
             {
                 bool surfaceSkip = TrajectoryMath.IsSurfaceAtUT(traj.TrackSections, playbackUT);
-                bool hasActiveOrbitSegment =
-                    traj.OrbitSegments != null
-                    && traj.OrbitSegments.Count > 0
-                    && TrajectoryMath.FindOrbitSegment(traj.OrbitSegments, playbackUT).HasValue;
-                if (surfaceSkip && hasActiveOrbitSegment)
+                bool canUseOrbitPrecedence = TryResolvePendingOrbitSegmentInterpolation(
+                    traj, playbackUT, applySubSurfaceGuard: true, out InterpolationResult orbitSegmentResult);
+                if (surfaceSkip && canUseOrbitPrecedence)
                 {
                     string vesselName = traj.VesselName ?? "Unknown";
                     ParsekLog.Verbose("Engine", FormattableString.Invariant(
                         $"Pending playback interpolation: vessel='{vesselName}' UT={playbackUT:F1} surface track section active, skipping orbit precedence"));
                 }
 
-                if (!surfaceSkip && TryResolvePendingOrbitSegmentInterpolation(
-                    traj, playbackUT, applySubSurfaceGuard: true, out result))
+                if (!surfaceSkip && canUseOrbitPrecedence)
                 {
+                    result = orbitSegmentResult;
                     return LogPendingPlaybackInterpolationResolved(
                         traj, playbackUT, result, "active orbit segment");
                 }

--- a/Source/Parsek/GhostPlaybackEngine.cs
+++ b/Source/Parsek/GhostPlaybackEngine.cs
@@ -3426,7 +3426,7 @@ namespace Parsek
             if (traj.Points != null && traj.Points.Count >= 2)
             {
                 bool surfaceSkip = TrajectoryMath.IsSurfaceAtUT(traj.TrackSections, playbackUT);
-                if (surfaceSkip)
+                if (surfaceSkip && traj.OrbitSegments != null && traj.OrbitSegments.Count > 0)
                 {
                     string vesselName = traj.VesselName ?? "Unknown";
                     ParsekLog.Verbose("Engine", FormattableString.Invariant(

--- a/Source/Parsek/GhostPlaybackEngine.cs
+++ b/Source/Parsek/GhostPlaybackEngine.cs
@@ -3426,7 +3426,11 @@ namespace Parsek
             if (traj.Points != null && traj.Points.Count >= 2)
             {
                 bool surfaceSkip = TrajectoryMath.IsSurfaceAtUT(traj.TrackSections, playbackUT);
-                if (surfaceSkip && traj.OrbitSegments != null && traj.OrbitSegments.Count > 0)
+                bool hasActiveOrbitSegment =
+                    traj.OrbitSegments != null
+                    && traj.OrbitSegments.Count > 0
+                    && TrajectoryMath.FindOrbitSegment(traj.OrbitSegments, playbackUT).HasValue;
+                if (surfaceSkip && hasActiveOrbitSegment)
                 {
                     string vesselName = traj.VesselName ?? "Unknown";
                     ParsekLog.Verbose("Engine", FormattableString.Invariant(
@@ -3465,10 +3469,16 @@ namespace Parsek
                             useBeforePoint
                                 ? before.altitude
                                 : TrajectoryMath.InterpolateAltitude(before.altitude, after.altitude, t));
+                        bool crossBodyTransition =
+                            !useBeforePoint
+                            && !string.Equals(before.bodyName, after.bodyName, StringComparison.Ordinal);
                         string pointSource = useBeforePoint
                             ? "same-UT point segment"
                             : afterEndClamp
                                 ? "point after-end clamp"
+                                : crossBodyTransition
+                                    ? FormattableString.Invariant(
+                                        $"cross-body point transition {before.bodyName ?? "(null)"}->{after.bodyName ?? "(null)"} (using upper-point body)")
                                 : "point interpolation";
                         return LogPendingPlaybackInterpolationResolved(
                             traj, playbackUT, result, pointSource);

--- a/Source/Parsek/GhostPlaybackEngine.cs
+++ b/Source/Parsek/GhostPlaybackEngine.cs
@@ -53,6 +53,7 @@ namespace Parsek
         // buffers used below.
         private static readonly long MaxSpawnTimelineBuildTicksPerAdvance =
             (long)(Stopwatch.Frequency * (GhostPlayback.MaxSpawnBuildMillisecondsPerAdvance / 1000.0));
+        private const double DefaultPendingOrbitBodyRadiusMeters = 600000.0;
 
         // Per-frame batch counters (avoid per-ghost log spam)
         private int frameSpawnCount;
@@ -2721,7 +2722,17 @@ namespace Parsek
             };
 
             if (TryResolvePendingPlaybackInterpolation(traj, playbackUT, out InterpolationResult initialPlayback))
+            {
                 state.SetInterpolated(initialPlayback);
+                string seededBodyName = initialPlayback.bodyName ?? "(null)";
+                ParsekLog.Verbose("Engine", FormattableString.Invariant(
+                    $"Pending spawn interpolation seed: vessel='{state.vesselName}' lifecycle={lifecycle} UT={playbackUT:F1} body='{seededBodyName}' altitude={initialPlayback.altitude:F1}"));
+            }
+            else
+            {
+                ParsekLog.Verbose("Engine", FormattableString.Invariant(
+                    $"Pending spawn interpolation seed unavailable: vessel='{state.vesselName}' lifecycle={lifecycle} UT={playbackUT:F1}"));
+            }
 
             return state;
         }
@@ -3409,14 +3420,25 @@ namespace Parsek
         {
             result = InterpolationResult.Zero;
             if (traj == null)
-                return false;
+                return LogPendingPlaybackInterpolationUnresolved(
+                    null, playbackUT, "null trajectory");
 
             if (traj.Points != null && traj.Points.Count >= 2)
             {
                 bool surfaceSkip = TrajectoryMath.IsSurfaceAtUT(traj.TrackSections, playbackUT);
+                if (surfaceSkip)
+                {
+                    string vesselName = traj.VesselName ?? "Unknown";
+                    ParsekLog.Verbose("Engine", FormattableString.Invariant(
+                        $"Pending playback interpolation: vessel='{vesselName}' UT={playbackUT:F1} surface track section active, skipping orbit precedence"));
+                }
+
                 if (!surfaceSkip && TryResolvePendingOrbitSegmentInterpolation(
                     traj, playbackUT, applySubSurfaceGuard: true, out result))
-                    return true;
+                {
+                    return LogPendingPlaybackInterpolationResolved(
+                        traj, playbackUT, result, "active orbit segment");
+                }
 
                 int cachedIndex = 0;
                 if (!TrajectoryMath.InterpolatePoints(
@@ -3426,12 +3448,14 @@ namespace Parsek
                     if (!string.IsNullOrEmpty(before.bodyName))
                     {
                         result = new InterpolationResult(before.velocity, before.bodyName, before.altitude);
-                        return true;
+                        return LogPendingPlaybackInterpolationResolved(
+                            traj, playbackUT, result, "before-start point fallback");
                     }
                 }
                 else
                 {
                     bool useBeforePoint = t == 0f && before.ut == after.ut;
+                    bool afterEndClamp = playbackUT > after.ut;
                     string bodyName = useBeforePoint ? before.bodyName : after.bodyName;
                     if (!string.IsNullOrEmpty(bodyName))
                     {
@@ -3441,7 +3465,13 @@ namespace Parsek
                             useBeforePoint
                                 ? before.altitude
                                 : TrajectoryMath.InterpolateAltitude(before.altitude, after.altitude, t));
-                        return true;
+                        string pointSource = useBeforePoint
+                            ? "same-UT point segment"
+                            : afterEndClamp
+                                ? "point after-end clamp"
+                                : "point interpolation";
+                        return LogPendingPlaybackInterpolationResolved(
+                            traj, playbackUT, result, pointSource);
                     }
                 }
             }
@@ -3450,7 +3480,8 @@ namespace Parsek
             {
                 SurfacePosition surface = traj.SurfacePos.Value;
                 result = new InterpolationResult(Vector3.zero, surface.body, surface.altitude);
-                return true;
+                return LogPendingPlaybackInterpolationResolved(
+                    traj, playbackUT, result, "surface metadata");
             }
 
             if (traj.Points != null && traj.Points.Count == 1)
@@ -3458,26 +3489,54 @@ namespace Parsek
                 if (ShouldPrimeSinglePointGhostFromOrbit(traj, playbackUT)
                     && TryResolvePendingOrbitSegmentInterpolation(
                         traj, playbackUT, applySubSurfaceGuard: false, out result))
-                    return true;
+                {
+                    return LogPendingPlaybackInterpolationResolved(
+                        traj, playbackUT, result, "single-point orbit segment");
+                }
 
                 TrajectoryPoint point = traj.Points[0];
                 if (!string.IsNullOrEmpty(point.bodyName))
                 {
                     result = new InterpolationResult(point.velocity, point.bodyName, point.altitude);
-                    return true;
+                    return LogPendingPlaybackInterpolationResolved(
+                        traj, playbackUT, result, "single-point fallback");
                 }
             }
 
             if (TryResolvePendingOrbitSegmentInterpolation(
                 traj, playbackUT, applySubSurfaceGuard: false, out result))
-                return true;
+            {
+                return LogPendingPlaybackInterpolationResolved(
+                    traj, playbackUT, result, "fallback orbit segment");
+            }
 
             if (!string.IsNullOrEmpty(traj.EndpointBodyName))
             {
                 result = new InterpolationResult(Vector3.zero, traj.EndpointBodyName, 0.0);
-                return true;
+                return LogPendingPlaybackInterpolationResolved(
+                    traj, playbackUT, result, "endpoint body fallback");
             }
 
+            return LogPendingPlaybackInterpolationUnresolved(
+                traj, playbackUT, "no points, surface metadata, orbit segment, or endpoint body");
+        }
+
+        private static bool LogPendingPlaybackInterpolationResolved(
+            IPlaybackTrajectory traj, double playbackUT, InterpolationResult result, string source)
+        {
+            string vesselName = traj?.VesselName ?? "Unknown";
+            string bodyName = result.bodyName ?? "(null)";
+            ParsekLog.Verbose("Engine", FormattableString.Invariant(
+                $"Pending playback interpolation: vessel='{vesselName}' UT={playbackUT:F1} resolved from {source} body='{bodyName}' altitude={result.altitude:F1}"));
+            return true;
+        }
+
+        private static bool LogPendingPlaybackInterpolationUnresolved(
+            IPlaybackTrajectory traj, double playbackUT, string reason)
+        {
+            string vesselName = traj?.VesselName ?? "Unknown";
+            ParsekLog.Verbose("Engine", FormattableString.Invariant(
+                $"Pending playback interpolation: vessel='{vesselName}' UT={playbackUT:F1} unresolved ({reason})"));
             return false;
         }
 
@@ -3528,7 +3587,7 @@ namespace Parsek
             {
             }
 
-            return 600000;
+            return DefaultPendingOrbitBodyRadiusMeters;
         }
 
         private void TrackGhostAppearance(

--- a/Source/Parsek/GhostPlaybackEngine.cs
+++ b/Source/Parsek/GhostPlaybackEngine.cs
@@ -184,6 +184,8 @@ namespace Parsek
 
         #endregion
 
+        internal static Func<string, double?> PendingOrbitBodyRadiusResolverForTesting;
+
         internal static bool HasRenderableGhostData(IPlaybackTrajectory traj)
         {
             return traj != null
@@ -745,7 +747,8 @@ namespace Parsek
                 if (!TryReserveSpawnSlot(i, "first-spawn"))
                     return false;
 
-                state = CreatePendingSpawnState(traj, PendingSpawnLifecycle.StandardEnter, f);
+                state = CreatePendingSpawnState(
+                    traj, ctx.currentUT, PendingSpawnLifecycle.StandardEnter, f);
                 ghostStates[i] = state;
                 GhostVisualLoadStatus firstSpawnStatus = EnsureGhostVisualsLoaded(
                     i, traj, state, ctx.currentUT, "first spawn",
@@ -1131,7 +1134,8 @@ namespace Parsek
                 // safe on this line.
                 if (!TryReserveSpawnSlot(index, "loop-first-spawn"))
                     return;
-                state = CreatePendingSpawnState(traj, PendingSpawnLifecycle.LoopEnter, flags);
+                state = CreatePendingSpawnState(
+                    traj, loopUT, PendingSpawnLifecycle.LoopEnter, flags);
                 state.loopCycleIndex = cycleIndex;
                 ghostStates[index] = state;
                 GhostVisualLoadStatus loopSpawnStatus = EnsureGhostVisualsLoaded(
@@ -1292,7 +1296,8 @@ namespace Parsek
                 }
 
                 // Spawn new primary for lastCycle
-                primaryState = CreatePendingSpawnState(traj, PendingSpawnLifecycle.OverlapPrimaryEnter, flags);
+                primaryState = CreatePendingSpawnState(
+                    traj, primaryLoopUT, PendingSpawnLifecycle.OverlapPrimaryEnter, flags);
                 primaryState.loopCycleIndex = lastCycle;
                 ghostStates[index] = primaryState;
                 GhostVisualLoadStatus overlapPrimarySpawnStatus = EnsureGhostVisualsLoaded(
@@ -2691,7 +2696,7 @@ namespace Parsek
             }
 
             var state = CreatePendingSpawnState(
-                traj, PendingSpawnLifecycle.StandardEnter, default(TrajectoryPlaybackFlags));
+                traj, playbackUT, PendingSpawnLifecycle.StandardEnter, default(TrajectoryPlaybackFlags));
             ghostStates[index] = state;
 
             GhostVisualLoadStatus status = EnsureGhostVisualsLoaded(
@@ -2702,9 +2707,10 @@ namespace Parsek
         }
 
         private GhostPlaybackState CreatePendingSpawnState(
-            IPlaybackTrajectory traj, PendingSpawnLifecycle lifecycle, TrajectoryPlaybackFlags flags)
+            IPlaybackTrajectory traj, double playbackUT,
+            PendingSpawnLifecycle lifecycle, TrajectoryPlaybackFlags flags)
         {
-            return new GhostPlaybackState
+            var state = new GhostPlaybackState
             {
                 vesselName = traj?.VesselName ?? "Unknown",
                 playbackIndex = 0,
@@ -2713,6 +2719,11 @@ namespace Parsek
                 pendingSpawnLifecycle = lifecycle,
                 pendingSpawnFlags = flags
             };
+
+            if (TryResolvePendingPlaybackInterpolation(traj, playbackUT, out InterpolationResult initialPlayback))
+                state.SetInterpolated(initialPlayback);
+
+            return state;
         }
 
         private void QueueOrEmitGhostCreated(
@@ -3391,6 +3402,133 @@ namespace Parsek
                 return playbackUT;
 
             return activationStartUT;
+        }
+
+        internal static bool TryResolvePendingPlaybackInterpolation(
+            IPlaybackTrajectory traj, double playbackUT, out InterpolationResult result)
+        {
+            result = InterpolationResult.Zero;
+            if (traj == null)
+                return false;
+
+            if (traj.Points != null && traj.Points.Count >= 2)
+            {
+                bool surfaceSkip = TrajectoryMath.IsSurfaceAtUT(traj.TrackSections, playbackUT);
+                if (!surfaceSkip && TryResolvePendingOrbitSegmentInterpolation(
+                    traj, playbackUT, applySubSurfaceGuard: true, out result))
+                    return true;
+
+                int cachedIndex = 0;
+                if (!TrajectoryMath.InterpolatePoints(
+                    traj.Points, ref cachedIndex, playbackUT,
+                    out TrajectoryPoint before, out TrajectoryPoint after, out float t))
+                {
+                    if (!string.IsNullOrEmpty(before.bodyName))
+                    {
+                        result = new InterpolationResult(before.velocity, before.bodyName, before.altitude);
+                        return true;
+                    }
+                }
+                else
+                {
+                    bool useBeforePoint = t == 0f && before.ut == after.ut;
+                    string bodyName = useBeforePoint ? before.bodyName : after.bodyName;
+                    if (!string.IsNullOrEmpty(bodyName))
+                    {
+                        result = new InterpolationResult(
+                            useBeforePoint ? before.velocity : Vector3.Lerp(before.velocity, after.velocity, t),
+                            bodyName,
+                            useBeforePoint
+                                ? before.altitude
+                                : TrajectoryMath.InterpolateAltitude(before.altitude, after.altitude, t));
+                        return true;
+                    }
+                }
+            }
+
+            if (traj.SurfacePos.HasValue && !string.IsNullOrEmpty(traj.SurfacePos.Value.body))
+            {
+                SurfacePosition surface = traj.SurfacePos.Value;
+                result = new InterpolationResult(Vector3.zero, surface.body, surface.altitude);
+                return true;
+            }
+
+            if (traj.Points != null && traj.Points.Count == 1)
+            {
+                if (ShouldPrimeSinglePointGhostFromOrbit(traj, playbackUT)
+                    && TryResolvePendingOrbitSegmentInterpolation(
+                        traj, playbackUT, applySubSurfaceGuard: false, out result))
+                    return true;
+
+                TrajectoryPoint point = traj.Points[0];
+                if (!string.IsNullOrEmpty(point.bodyName))
+                {
+                    result = new InterpolationResult(point.velocity, point.bodyName, point.altitude);
+                    return true;
+                }
+            }
+
+            if (TryResolvePendingOrbitSegmentInterpolation(
+                traj, playbackUT, applySubSurfaceGuard: false, out result))
+                return true;
+
+            if (!string.IsNullOrEmpty(traj.EndpointBodyName))
+            {
+                result = new InterpolationResult(Vector3.zero, traj.EndpointBodyName, 0.0);
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool TryResolvePendingOrbitSegmentInterpolation(
+            IPlaybackTrajectory traj, double playbackUT, bool applySubSurfaceGuard,
+            out InterpolationResult result)
+        {
+            result = InterpolationResult.Zero;
+            if (traj?.OrbitSegments == null || traj.OrbitSegments.Count == 0)
+                return false;
+
+            OrbitSegment? seg = TrajectoryMath.FindOrbitSegment(traj.OrbitSegments, playbackUT);
+            if (!seg.HasValue || string.IsNullOrEmpty(seg.Value.bodyName))
+                return false;
+
+            if (applySubSurfaceGuard)
+            {
+                double bodyRadius = ResolvePendingOrbitBodyRadius(seg.Value.bodyName);
+                double absSma = System.Math.Abs(seg.Value.semiMajorAxis);
+                if (absSma < bodyRadius * 0.9)
+                    return false;
+            }
+
+            result = new InterpolationResult(Vector3.zero, seg.Value.bodyName, 0.0);
+            return true;
+        }
+
+        private static double ResolvePendingOrbitBodyRadius(string bodyName)
+        {
+            Func<string, double?> resolver = PendingOrbitBodyRadiusResolverForTesting;
+            if (resolver != null)
+            {
+                double? resolved = resolver(bodyName);
+                if (resolved.HasValue && !double.IsNaN(resolved.Value) && !double.IsInfinity(resolved.Value) && resolved.Value > 0)
+                    return resolved.Value;
+            }
+
+            try
+            {
+                CelestialBody segBody = FlightGlobals.Bodies?.Find(b => b.name == bodyName);
+                if (segBody != null)
+                    return segBody.Radius;
+            }
+            catch (TypeInitializationException)
+            {
+            }
+            catch (System.Security.SecurityException)
+            {
+            }
+
+            return 600000;
         }
 
         private void TrackGhostAppearance(

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -334,7 +334,7 @@ The four top-of-queue correctness fixes (#431, #432, #433, #434) shipped in the 
 
 **Files:** `Source/Parsek/GhostPlaybackEngine.cs`, `Source/Parsek.Tests/GhostPlaybackEngineTests.cs`.
 
-**Status:** CLOSED 2026-04-22. Fixed for v0.8.3.
+**Status:** CLOSED 2026-04-22. Fixed for v0.9.0.
 
 ---
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -324,15 +324,17 @@ The four top-of-queue correctness fixes (#431, #432, #433, #434) shipped in the 
 
 ---
 
-## 530. Timeline `W` can open in a false disabled state until the lazy ghost build finishes
+## ~~530. Timeline `W` can open in a false disabled state until the lazy ghost build finishes~~
 
 **Source:** when Timeline opens in `logs/2026-04-21_2335_live-collect-script`, `KSP.log` records `Timeline watch button "r0" ... disabled (no ghost)` for the same recording that becomes watchable less than a second later once the ghost finishes building/spawning. No user context changed; the row just self-corrected when the ghost materialized.
 
-**Concern:** initial watchability is being computed from transient `HasActiveGhost` / same-body / range state before the lazy ghost build completes, so the Timeline row can briefly advertise a false "not watchable" state on first open. This is small, but it makes watch mode feel flaky and is distinct from the older watch-transfer bugs.
+**Concern:** initial watchability was being computed from a pending ghost shell that existed before the lazy snapshot build finished, but that shell had no seeded playback body metadata yet. The Timeline row could therefore briefly advertise a false "not watchable" state on first open even though the recording became watchable as soon as the build completed.
 
-**Files:** `Source/Parsek/UI/TimelineWindowUI.cs`, `Source/Parsek/UI/RecordingsTableUI.cs`, `Source/Parsek/WatchModeController.cs`, `Source/Parsek.Tests/TimelineWindowUITests.cs`.
+**Fix:** pending ghost shells now resolve and store playback interpolation metadata from the trajectory at spawn time, so same-body watch eligibility is stable before the split build completes.
 
-**Status:** OPEN. Minor UI-state bug captured in-package.
+**Files:** `Source/Parsek/GhostPlaybackEngine.cs`, `Source/Parsek.Tests/GhostPlaybackEngineTests.cs`.
+
+**Status:** CLOSED 2026-04-22. Fixed for v0.8.3.
 
 ---
 


### PR DESCRIPTION
## Summary
- seed pending playback metadata for lazy ghost shells before the split build finishes
- mirror runtime orbit and surface precedence in the pending resolver so Timeline and Recordings watchability stays stable
- move the changelog note to the 0.9.0 section

## Testing
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter GhostPlaybackEngineTests|WatchModeControllerTests|TimelineWindowUITests|RecordingsTableUITests|BugFixTests
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter FullyQualifiedName!=Parsek.Tests.SyntheticRecordingTests.InjectAllRecordings