### PR TITLE
Fix #533 preserve contract type on contract accepts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- `#533` `ContractAccepted -> ContractAccept` conversion now preserves `contractType` on both the immediate KSC ledger path and the later commit-time conversion path. New captures write `type=` into the accepted-contract event detail, and conversion backfills older events from the stored contract snapshot when that detail field is absent.
 - `#545` Timeline milestone rows now squash same-moment duplicate entries for the same milestone into one richer entry, including near-UT copies inside the same 0.1s window and same-timestamp rows separated by another entry. The surviving row unions missing funds/rep/science reward legs while leaving genuinely conflicting reward values split instead of inventing a combined total. Timeline milestone labels now also show science rewards, reducing the remaining “looks double-counted” milestone presentation path from `#522`.
 - `#546` Idle vessel switches now arm auto-record and start on the first meaningful physical modification.
 
@@ -56,7 +57,6 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
-- `#533` `ContractAccepted -> ContractAccept` conversion now preserves `contractType` on both the immediate KSC ledger path and the later commit-time conversion path. New captures write `type=` into the accepted-contract event detail, and conversion backfills older events from the stored contract snapshot when that detail field is absent.
 
 ### Tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ All notable changes to Parsek are documented here.
 - `#473` The `Gloops - Ghosts Only` group is now treated as a permanent root group in the Recordings window: no disband `X`, stale parent assignments self-heal back to root, and the group stays pinned above every other root item whenever it has recordings.
 - `#450 B2` Timeline ghost snapshot construction now advances in staged chunks across multiple playback frames instead of instantiating the entire snapshot in one `UpdatePlayback` tick, eliminating the remaining bimodal single-spawn hitch after the B3 lazy-reentry follow-up.
 
+### Bug Fixes
+
+- `#533` `ContractAccepted -> ContractAccept` conversion now preserves `contractType` on both the immediate KSC ledger path and the later commit-time conversion path. New captures write `type=` into the accepted-contract event detail, and conversion backfills older events from the stored contract snapshot when that detail field is absent.
+
 ### Tests
 
 - `Bug278FinalizeLimboTests` now pins the orbit-only terminal-body heal path: a leaf with a stale `TerminalOrbitBody` but only orbit-segment evidence heals to the segment body and emits the `PopulateTerminalOrbitFromLastSegment: healed stale cached terminal orbit` log line.

--- a/Source/Parsek.Tests/GameStateEventConverterTests.cs
+++ b/Source/Parsek.Tests/GameStateEventConverterTests.cs
@@ -15,10 +15,14 @@ namespace Parsek.Tests
             ParsekLog.SuppressLogging = false;
             ParsekLog.VerboseOverrideForTesting = true;
             ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+            GameStateStore.SuppressLogging = true;
+            GameStateStore.ResetForTesting();
         }
 
         public void Dispose()
         {
+            GameStateStore.ResetForTesting();
+            GameStateStore.SuppressLogging = false;
             ParsekLog.ResetTestOverrides();
             ParsekLog.SuppressLogging = true;
         }
@@ -654,13 +658,14 @@ namespace Parsek.Tests
         {
             var evt = MakeEvent(GameStateEventType.ContractAccepted, 8000.0,
                 key: "guid-1234",
-                detail: "title=Orbit the Mun;deadline=50000;failFunds=12000;failRep=5");
+                detail: "title=Orbit the Mun;deadline=50000;type=ExploreBody;failFunds=12000;failRep=5");
             var action = GameStateEventConverter.ConvertEvent(evt, "rec9");
 
             Assert.NotNull(action);
             Assert.Equal(GameActionType.ContractAccept, action.Type);
             Assert.Equal("guid-1234", action.ContractId);
             Assert.Equal("Orbit the Mun", action.ContractTitle);
+            Assert.Equal("ExploreBody", action.ContractType);
             Assert.Equal(50000f, action.DeadlineUT);
             Assert.Equal(12000f, action.FundsPenalty);
             Assert.Equal(5f, action.RepPenalty);
@@ -703,13 +708,15 @@ namespace Parsek.Tests
         {
             var evt = MakeEvent(GameStateEventType.ContractAccepted, 8000.0,
                 key: "guid-1234",
-                detail: "title=Test;deadline=50000;failFunds=1000;failRep=2");
+                detail: "title=Test;deadline=50000;type=PartTest;failFunds=1000;failRep=2");
             GameStateEventConverter.ConvertEvent(evt, "rec");
 
             Assert.Contains(logLines, l =>
                 l.Contains("[GameStateEventConverter]") &&
                 l.Contains("structured format") &&
-                l.Contains("guid-1234"));
+                l.Contains("guid-1234") &&
+                l.Contains("type='PartTest'") &&
+                l.Contains("typeSource=detail"));
         }
 
         [Fact]
@@ -772,6 +779,27 @@ namespace Parsek.Tests
 
             Assert.NotNull(action);
             Assert.Equal(0f, action.AdvanceFunds);
+        }
+
+        [Fact]
+        public void ConvertContractAccepted_WhenDetailOmitsType_BackfillsFromSnapshot()
+        {
+            var snapshot = new ConfigNode("CONTRACT");
+            snapshot.AddValue("type", "PartTest");
+            GameStateStore.AddContractSnapshot("guid-snap", snapshot);
+
+            var evt = MakeEvent(GameStateEventType.ContractAccepted, 8000.0,
+                key: "guid-snap",
+                detail: "title=Test Part;deadline=NaN;funds=0;failFunds=3000;failRep=1");
+            var action = GameStateEventConverter.ConvertEvent(evt, "rec-snap");
+
+            Assert.NotNull(action);
+            Assert.Equal("Test Part", action.ContractTitle);
+            Assert.Equal("PartTest", action.ContractType);
+            Assert.Contains(logLines, l =>
+                l.Contains("[GameStateEventConverter]") &&
+                l.Contains("guid-snap") &&
+                l.Contains("typeSource=snapshot"));
         }
 
         // ================================================================

--- a/Source/Parsek.Tests/GameStateRecorderLedgerTests.cs
+++ b/Source/Parsek.Tests/GameStateRecorderLedgerTests.cs
@@ -63,13 +63,15 @@ namespace Parsek.Tests
                 ut = 100.0,
                 eventType = GameStateEventType.ContractAccepted,
                 key = "contract-guid-1",
-                detail = "title=Explore Mun;deadline=NaN;failFunds=5000;failRep=10"
+                detail = "title=Explore Mun;deadline=NaN;type=PartTest;failFunds=5000;failRep=10"
             };
 
             LedgerOrchestrator.OnKscSpending(evt);
 
-            Assert.Contains(Ledger.Actions, a =>
+            var match = Ledger.Actions.FirstOrDefault(a =>
                 a.Type == GameActionType.ContractAccept && a.ContractId == "contract-guid-1");
+            Assert.NotNull(match);
+            Assert.Equal("PartTest", match.ContractType);
             Assert.Contains(logLines, l =>
                 l.Contains("[LedgerOrchestrator]") && l.Contains("KSC spending recorded") && l.Contains("ContractAccept"));
         }

--- a/Source/Parsek/GameActions/GameStateEventConverter.cs
+++ b/Source/Parsek/GameActions/GameStateEventConverter.cs
@@ -10,8 +10,8 @@ namespace Parsek
     /// events that are purely informational (resource deltas, status changes) are skipped.
     ///
     /// Also converts <see cref="PendingScienceSubject"/> entries into ScienceEarning actions.
-    ///
-    /// Pure static — no KSP state access.
+    /// ContractAccepted backfill may consult the stored contract snapshot when older event
+    /// detail rows predate newer fields.
     /// </summary>
     internal static class GameStateEventConverter
     {
@@ -405,24 +405,31 @@ namespace Parsek
         }
 
         /// <summary>
-        /// ContractAccepted -> ContractAccept (contractId=key, title/deadline/advance/penalties from detail).
-        /// New format (v3): "title=...;deadline=...;funds=...;failFunds=...;failRep=..."
+        /// ContractAccepted -> ContractAccept (contractId=key, title/type/deadline/advance/penalties from detail).
+        /// New format (v4): "title=...;deadline=...;type=...;funds=...;failFunds=...;failRep=..."
+        /// v3 (no type= key): backward compatible via snapshot fallback.
         /// v2 (no funds= key): backward compatible, advance defaults to 0.
         /// Legacy (v1): plain title string (no semicolons). Backward compatible.
         /// </summary>
         private static GameAction ConvertContractAccepted(GameStateEvent evt, string recordingId)
         {
             string title;
+            string contractType = null;
             float deadlineUT = float.NaN;
             float advanceFunds = 0f;
             float fundsPenalty = 0f;
             float repPenalty = 0f;
+            bool structured = evt.detail != null && evt.detail.Contains(";");
+            string typeSource = "missing";
 
             // Detect structured vs legacy format by checking for semicolons
-            if (evt.detail != null && evt.detail.Contains(";"))
+            if (structured)
             {
                 // Structured format: extract fields
                 title = ExtractDetail(evt.detail, "title") ?? "";
+                contractType = ExtractDetail(evt.detail, "type");
+                if (!string.IsNullOrEmpty(contractType))
+                    typeSource = "detail";
 
                 string deadlineStr = ExtractDetail(evt.detail, "deadline");
                 if (deadlineStr != null && deadlineStr != "NaN")
@@ -441,20 +448,29 @@ namespace Parsek
                 string failRepStr = ExtractDetail(evt.detail, "failRep");
                 if (failRepStr != null)
                     float.TryParse(failRepStr, NumberStyles.Float, IC, out repPenalty);
-
-                ParsekLog.Verbose(Tag,
-                    $"ConvertContractAccepted: structured format contractId='{evt.key}' " +
-                    $"title='{title}' deadline={deadlineUT} advance={advanceFunds} " +
-                    $"failFunds={fundsPenalty} failRep={repPenalty}");
             }
             else
             {
                 // Legacy format: entire detail is the title
                 title = evt.detail ?? "";
-
-                ParsekLog.Verbose(Tag,
-                    $"ConvertContractAccepted: legacy format contractId='{evt.key}' title='{title}'");
             }
+
+            if (string.IsNullOrEmpty(contractType))
+            {
+                ConfigNode snapshot = GameStateStore.GetContractSnapshot(evt.key);
+                if (snapshot != null)
+                {
+                    contractType = snapshot.GetValue("type");
+                    if (!string.IsNullOrEmpty(contractType))
+                        typeSource = "snapshot";
+                }
+            }
+
+            ParsekLog.Verbose(Tag,
+                $"ConvertContractAccepted: {(structured ? "structured" : "legacy")} format " +
+                $"contractId='{evt.key}' title='{title}' type='{contractType ?? ""}' " +
+                $"typeSource={typeSource} deadline={deadlineUT} advance={advanceFunds} " +
+                $"failFunds={fundsPenalty} failRep={repPenalty}");
 
             return new GameAction
             {
@@ -463,6 +479,7 @@ namespace Parsek
                 RecordingId = recordingId,
                 ContractId = evt.key,
                 ContractTitle = title,
+                ContractType = contractType,
                 DeadlineUT = deadlineUT,
                 AdvanceFunds = advanceFunds,
                 FundsPenalty = fundsPenalty,

--- a/Source/Parsek/GameStateRecorder.cs
+++ b/Source/Parsek/GameStateRecorder.cs
@@ -373,17 +373,37 @@ namespace Parsek
             float advanceFunds = (float)contract.FundsAdvance;
             float failFunds = (float)contract.FundsFailure;
             float failRep = (float)contract.ReputationFailure;
+            string contractType = contract.GetType().Name ?? "";
+            ConfigNode contractNode = null;
+            Exception snapshotFailure = null;
 
-            // Structured detail: title + deadline + advance + failure penalties.
+            try
+            {
+                contractNode = new ConfigNode("CONTRACT");
+                contract.Save(contractNode);
+                string savedContractType = contractNode.GetValue("type");
+                if (!string.IsNullOrEmpty(savedContractType))
+                    contractType = savedContractType;
+            }
+            catch (Exception ex)
+            {
+                snapshotFailure = ex;
+                contractNode = null;
+            }
+
+            // Structured detail: title + deadline + type + advance + failure penalties.
             // advance must be captured at accept time — KSP applies it immediately via
             // FundsChanged(ContractAdvance), which the converter intentionally drops.
             // Without funds= here, AdvanceFunds stayed 0 and FundsModule never credited
-            // the advance (codex review [P1] on PR #307).
+            // the advance (codex review [P1] on PR #307). type= must also be captured
+            // here because ContractAccept ledger actions are consumed by UI/policy paths
+            // that do not re-open the stored snapshot.
             // deadline=0 means no deadline (KSP convention) — store as NaN.
             string deadlineStr = deadline > 0
                 ? deadline.ToString("R", System.Globalization.CultureInfo.InvariantCulture)
                 : "NaN";
             var detail = $"title={title};deadline={deadlineStr}" +
+                (string.IsNullOrEmpty(contractType) ? "" : $";type={contractType}") +
                 $";funds={advanceFunds.ToString("R", System.Globalization.CultureInfo.InvariantCulture)}" +
                 $";failFunds={failFunds.ToString("R", System.Globalization.CultureInfo.InvariantCulture)}" +
                 $";failRep={failRep.ToString("R", System.Globalization.CultureInfo.InvariantCulture)}";
@@ -398,19 +418,18 @@ namespace Parsek
             Emit(ref evt, "ContractAccepted");
 
             // Store full contract snapshot for reversal
-            try
+            if (contractNode != null)
             {
-                var contractNode = new ConfigNode("CONTRACT");
-                contract.Save(contractNode);
                 GameStateStore.AddContractSnapshot(guid, contractNode);
                 ParsekLog.Info("GameStateRecorder",
-                    $"Game state: ContractAccepted '{title}' deadline={deadlineStr} " +
+                    $"Game state: ContractAccepted '{title}' type='{contractType}' deadline={deadlineStr} " +
                     $"advance={advanceFunds} failFunds={failFunds} failRep={failRep} (snapshot saved)");
             }
-            catch (Exception ex)
+            else
             {
                 ParsekLog.Warn("GameStateRecorder",
-                    $"Game state: ContractAccepted '{title}' (snapshot FAILED: {ex.Message})");
+                    $"Game state: ContractAccepted '{title}' type='{contractType}' " +
+                    $"(snapshot FAILED: {(snapshotFailure != null ? snapshotFailure.Message : "unknown error")})");
             }
 
             // Write directly to ledger when at KSC (not during a flight recording).

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -370,7 +370,7 @@ The four top-of-queue correctness fixes (#431, #432, #433, #434) shipped in the 
 
 **Fix:** `GameStateRecorder.OnContractAccepted()` now writes the accepted contract's `type=` into the structured event detail using the same value saved in the contract snapshot, and `GameStateEventConverter.ConvertContractAccepted()` now populates `GameAction.ContractType`, falling back to `GameStateStore.GetContractSnapshot(contractId)` for pre-fix events that still lack the new detail token. Regression coverage pins both the direct-detail path and the snapshot-backfill path.
 
-**Status:** ~~OPEN. Data-loss bug in the ledger conversion path.~~ Closed 2026-04-22.
+**Status:** ~~OPEN. Data-loss bug in the ledger conversion path.~~ Closed 2026-04-22. Fixed for v0.9.0.
 
 ---
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -360,7 +360,7 @@ The four top-of-queue correctness fixes (#431, #432, #433, #434) shipped in the 
 
 ---
 
-## 533. `ContractAccepted -> ContractAccept` conversion drops `contractType` on the ledger path
+## ~~533. `ContractAccepted -> ContractAccept` conversion drops `contractType` on the ledger path~~ CLOSED 2026-04-22
 
 **Source:** replay in `logs/2026-04-21_2335_live-collect-script/KSP.log` logs both accepted launch-site test contracts as `type=''`, and the committed `ledger.pgld` actions contain title/deadline/advance/penalties but no `contractType`. The raw stored contract snapshots still carry `type = PartTest`, so the type exists at capture time and is being lost during conversion.
 
@@ -368,7 +368,9 @@ The four top-of-queue correctness fixes (#431, #432, #433, #434) shipped in the 
 
 **Files:** `Source/Parsek/GameStateRecorder.cs`, `Source/Parsek/GameActions/GameStateEventConverter.cs`, `Source/Parsek/GameActions/ContractsModule.cs`, `Source/Parsek/GameActions/GameActionDisplay.cs`.
 
-**Status:** OPEN. Data-loss bug in the ledger conversion path.
+**Fix:** `GameStateRecorder.OnContractAccepted()` now writes the accepted contract's `type=` into the structured event detail using the same value saved in the contract snapshot, and `GameStateEventConverter.ConvertContractAccepted()` now populates `GameAction.ContractType`, falling back to `GameStateStore.GetContractSnapshot(contractId)` for pre-fix events that still lack the new detail token. Regression coverage pins both the direct-detail path and the snapshot-backfill path.
+
+**Status:** ~~OPEN. Data-loss bug in the ledger conversion path.~~ Closed 2026-04-22.
 
 ---
 


### PR DESCRIPTION
## Summary
- record contract type in ContractAccepted event detail on the immediate KSC ledger path
- backfill ContractAccept conversion from the stored contract snapshot when older events do not carry a type field
- move the changelog note to the 0.9.0 section

## Testing
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter FullyQualifiedName~GameStateEventConverterTests|FullyQualifiedName~GameStateRecorderLedgerTests
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj