### PR TITLE
Fix #531 diagnose destroyed recordings correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- `#531` Destroyed recordings without a preserved vessel snapshot now diagnose as `vessel destroyed` instead of the misleading `no vessel snapshot`, so playback/rewind/KSC spawn suppression logs report the real terminal state.
 - Ballistic orbital-frame storage now normalizes as well as canonicalizes the saved quaternions, so SOI handoffs keep the same represented world attitude instead of drifting when a frozen playback rotation started as a scaled quaternion.
 - Hyperbolic predicted segments now reconstruct true anomaly with a quadrant-safe formula, so parent-body SOI handoffs keep the same boundary state and frozen playback attitude instead of folding the new segment onto the wrong outbound branch.
 - Hyperbolic predicted segments now keep periapsis orientation even when the parent escape orbit is equatorial, so SOI handoffs no longer serialize the parent segment with `argumentOfPeriapsis = 0` and then reconstruct the wrong start state and frozen attitude.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- `#531` Destroyed recordings without a preserved vessel snapshot now diagnose as `vessel destroyed` instead of the misleading `no vessel snapshot`, so playback/rewind/KSC spawn suppression logs report the real terminal state.
 - `#545` Timeline milestone rows now squash same-moment duplicate entries for the same milestone into one richer entry, including near-UT copies inside the same 0.1s window and same-timestamp rows separated by another entry. The surviving row unions missing funds/rep/science reward legs while leaving genuinely conflicting reward values split instead of inventing a combined total. Timeline milestone labels now also show science rewards, reducing the remaining “looks double-counted” milestone presentation path from `#522`.
 - `#546` Idle vessel switches now arm auto-record and start on the first meaningful physical modification.
 
@@ -121,7 +122,6 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
-- `#531` Destroyed recordings without a preserved vessel snapshot now diagnose as `vessel destroyed` instead of the misleading `no vessel snapshot`, so playback/rewind/KSC spawn suppression logs report the real terminal state.
 - Ballistic orbital-frame storage now normalizes as well as canonicalizes the saved quaternions, so SOI handoffs keep the same represented world attitude instead of drifting when a frozen playback rotation started as a scaled quaternion.
 - Hyperbolic predicted segments now reconstruct true anomaly with a quadrant-safe formula, so parent-body SOI handoffs keep the same boundary state and frozen playback attitude instead of folding the new segment onto the wrong outbound branch.
 - Hyperbolic predicted segments now keep periapsis orientation even when the parent escape orbit is equatorial, so SOI handoffs no longer serialize the parent segment with `argumentOfPeriapsis = 0` and then reconstruct the wrong start state and frozen attitude.

--- a/Source/Parsek.Tests/KscSpawnTests.cs
+++ b/Source/Parsek.Tests/KscSpawnTests.cs
@@ -134,6 +134,19 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void ShouldSpawnAtKscEnd_DestroyedWithoutSnapshot_ReturnsDestroyedReason()
+        {
+            var rec = MakeEligibleRecording();
+            rec.VesselDestroyed = true;
+            rec.VesselSnapshot = null;
+
+            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtKscEnd(rec, rec.EndUT + 1);
+
+            Assert.False(needsSpawn);
+            Assert.Equal("vessel destroyed", reason);
+        }
+
+        [Fact]
         public void ShouldSpawnAtKscEnd_BranchGtZero_ReturnsFalse()
         {
             var rec = MakeEligibleRecording();

--- a/Source/Parsek.Tests/RewindTimelineTests.cs
+++ b/Source/Parsek.Tests/RewindTimelineTests.cs
@@ -97,6 +97,23 @@ namespace Parsek.Tests
             Assert.Contains("vessel destroyed", reason);
         }
 
+        [Fact]
+        public void ShouldSpawn_DestroyedWithoutSnapshot_ReturnsDestroyedReason()
+        {
+            var rec = new Recording
+            {
+                VesselSnapshot = null,
+                VesselSpawned = false,
+                VesselDestroyed = true
+            };
+
+            var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtRecordingEnd(
+                rec, isActiveChainMember: false, isChainLooping: false);
+
+            Assert.False(needsSpawn);
+            Assert.Equal("vessel destroyed", reason);
+        }
+
         #endregion
 
         #region ShouldSpawnAtRecordingEnd — Branch Suppression

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -3911,11 +3911,8 @@ namespace Parsek
             bool isChainLooping,
             RecordingTree treeContext)
         {
-            // Base condition: must have a snapshot, not already spawned, not destroyed
-            if (rec.VesselSnapshot == null)
-            {
-                return (false, "no vessel snapshot");
-            }
+            // Preserve the existing "already spawned" precedence, but make destroyed
+            // recordings win over the generic missing-snapshot diagnostic.
             if (rec.VesselSpawned)
             {
                 return (false, "already spawned (VesselSpawned=true)");
@@ -3923,6 +3920,11 @@ namespace Parsek
             if (rec.VesselDestroyed)
             {
                 return (false, "vessel destroyed");
+            }
+            // Base condition: must have a snapshot
+            if (rec.VesselSnapshot == null)
+            {
+                return (false, "no vessel snapshot");
             }
 
             // Gloops Flight Recorder recordings are ghost-only — never spawn a real vessel

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -346,7 +346,7 @@ The four top-of-queue correctness fixes (#431, #432, #433, #434) shipped in the 
 
 **Files:** `Source/Parsek/GhostPlaybackLogic.cs`, `Source/Parsek.Tests/RewindTimelineTests.cs`, `Source/Parsek.Tests/KscSpawnTests.cs`.
 
-**Status:** CLOSED 2026-04-22. Fixed for v0.8.3.
+**Status:** CLOSED 2026-04-22. Fixed for v0.9.0.
 
 ---
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -336,15 +336,17 @@ The four top-of-queue correctness fixes (#431, #432, #433, #434) shipped in the 
 
 ---
 
-## 531. Destroyed recordings are still being diagnosed as `no vessel snapshot` instead of `vessel destroyed`
+## ~~531. Destroyed recordings are still being diagnosed as `no vessel snapshot` instead of `vessel destroyed`~~
 
 **Source:** the package's playback loop repeatedly logs `Spawn suppressed ... no vessel snapshot` for both committed recordings, even though the same session reports the timeline contains only destroyed recordings. The behavior is stable across many suppression cycles.
 
 **Concern:** `GhostPlaybackLogic.ShouldSpawnAtRecordingEnd(...)` currently checks `rec.VesselSnapshot == null` before `rec.VesselDestroyed`, so destroyed recordings get the wrong suppression reason. This does not change the spawn outcome, but it hides the real state during FF/watch investigations and adds misleading playback noise.
 
-**Files:** `Source/Parsek/GhostPlaybackLogic.cs`, `Source/Parsek/ParsekFlight.cs`, `Source/Parsek.Tests/RewindTimelineTests.cs`, `Source/Parsek.Tests/SpawnSafetyNetTests.cs`.
+**Fix:** `ShouldSpawnAtRecordingEnd(...)` now checks `rec.VesselDestroyed` before the missing-snapshot guard, so destroyed recordings without a preserved snapshot still report `vessel destroyed`. Focused regressions pin both the direct playback/rewind helper and the KSC wrapper with the exact `VesselDestroyed=true` + `VesselSnapshot=null` shape.
 
-**Status:** OPEN. Low-severity diagnostic correctness issue.
+**Files:** `Source/Parsek/GhostPlaybackLogic.cs`, `Source/Parsek.Tests/RewindTimelineTests.cs`, `Source/Parsek.Tests/KscSpawnTests.cs`.
+
+**Status:** CLOSED 2026-04-22. Fixed for v0.8.3.
 
 ---
 


### PR DESCRIPTION
## Summary
- check VesselDestroyed before the missing-snapshot guard in end-of-recording spawn diagnostics
- cover both the core helper and the KSC spawn wrapper for destroyed recordings without preserved snapshots
- move the changelog note to the 0.9.0 section

## Testing
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter FullyQualifiedName~Parsek.Tests.RewindTimelineTests|FullyQualifiedName~Parsek.Tests.KscSpawnTests