### PR TITLE
#540 Clean up remaining xUnit style warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ All notable changes to Parsek are documented here.
 
 ### Tests
 
+- `#540` `Parsek.Tests` now builds cleanly without the remaining xUnit style warnings: `FormatCoroutineState_ReportsActiveAndIdleSlots` is a real `[Fact]`, and the Kerbals subitem-indent regressions now use `Assert.StartsWith(...)` instead of `Assert.True(text.StartsWith(...))`.
 - `Bug278FinalizeLimboTests` now pins the orbit-only terminal-body heal path: a leaf with a stale `TerminalOrbitBody` but only orbit-segment evidence heals to the segment body and emits the `PopulateTerminalOrbitFromLastSegment: healed stale cached terminal orbit` log line.
 - The last xUnit smoke/assertion follow-ups now catch headless `ParsekUI.Cleanup()` teardown in the KSC wiring smoke test and anchor the Bug219 negative log checks to the full production log prefix instead of the overlapping `ShouldPopulate...` diagnostic.
 - Headless landed snapshot-repair coverage now survives Unity pseudo-null `CelestialBody` fixtures all the way through the real `REF` rewrite path instead of bailing out before the repaired surface orbit node is written.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to Parsek are documented here.
 ### Tests
 
 - `#534` Added spawned chain-tip restore regressions covering committed-tree ownership, restorable-leaf filtering, multi-tree selection, and the throttled Update-time retry guard.
+- `#540` `Parsek.Tests` now builds cleanly without the remaining xUnit style warnings: `FormatCoroutineState_ReportsActiveAndIdleSlots` is a real `[Fact]`, and the Kerbals subitem-indent regressions now use xUnit `Assert.StartsWith(...)` while preserving the original `StringComparison.Ordinal` semantics instead of the old `Assert.True(text.StartsWith(..., StringComparison.Ordinal))` form.
 - Added manual-only in-game coverage for the deferred FLIGHT `Merge to Timeline` commit path, a synthetic `Keep Vessel` playback-control canary that fast-forwards into playback and asserts the end-of-recording vessel spawn happens exactly once, a stock `Revert to Launch` canary that asserts the shipped soft-unstash / no-merge revert semantics, and two real `Space Center` exit canaries that drive the deferred merge-dialog `Merge to Timeline` and `Discard` branches end-to-end.
 - `#491` Archived live runtime evidence now covers both `SceneExitMerge` canaries: the stock `Space Center` exit discard branch clears the pending tree without a commit, and the merge branch commits the pending tree into `CommittedTrees` / `CommittedRecordings`.
 - Added deterministic in-game `PartEventTiming` canaries that assert light-toggle and deployable-transform ghost playback flips exactly at their authored UT boundaries, and retained live bundles under `C:\Users\vlad3\Documents\Code\Parsek\logs\2026-04-21_2008_finish-line-validation\` and `C:\Users\vlad3\Documents\Code\Parsek\logs\2026-04-21_2042_live-collect-script\` now show both exported `FlightIntegrationTests.PartEventTiming_*` rows passing in `FLIGHT`.
@@ -58,7 +59,6 @@ All notable changes to Parsek are documented here.
 
 ### Tests
 
-- `#540` `Parsek.Tests` now builds cleanly without the remaining xUnit style warnings: `FormatCoroutineState_ReportsActiveAndIdleSlots` is a real `[Fact]`, and the Kerbals subitem-indent regressions now use xUnit `Assert.StartsWith(...)` while preserving the original `StringComparison.Ordinal` semantics instead of the old `Assert.True(text.StartsWith(..., StringComparison.Ordinal))` form.
 - `Bug278FinalizeLimboTests` now pins the orbit-only terminal-body heal path: a leaf with a stale `TerminalOrbitBody` but only orbit-segment evidence heals to the segment body and emits the `PopulateTerminalOrbitFromLastSegment: healed stale cached terminal orbit` log line.
 - The last xUnit smoke/assertion follow-ups now catch headless `ParsekUI.Cleanup()` teardown in the KSC wiring smoke test and anchor the Bug219 negative log checks to the full production log prefix instead of the overlapping `ShouldPopulate...` diagnostic.
 - Headless landed snapshot-repair coverage now survives Unity pseudo-null `CelestialBody` fixtures all the way through the real `REF` rewrite path instead of bailing out before the repaired surface orbit node is written.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ All notable changes to Parsek are documented here.
 
 ### Tests
 
-- `#540` `Parsek.Tests` now builds cleanly without the remaining xUnit style warnings: `FormatCoroutineState_ReportsActiveAndIdleSlots` is a real `[Fact]`, and the Kerbals subitem-indent regressions now use `Assert.StartsWith(...)` instead of `Assert.True(text.StartsWith(...))`.
+- `#540` `Parsek.Tests` now builds cleanly without the remaining xUnit style warnings: `FormatCoroutineState_ReportsActiveAndIdleSlots` is a real `[Fact]`, and the Kerbals subitem-indent regressions now use xUnit `Assert.StartsWith(...)` while preserving the original `StringComparison.Ordinal` semantics instead of the old `Assert.True(text.StartsWith(..., StringComparison.Ordinal))` form.
 - `Bug278FinalizeLimboTests` now pins the orbit-only terminal-body heal path: a leaf with a stale `TerminalOrbitBody` but only orbit-segment evidence heals to the segment body and emits the `PopulateTerminalOrbitFromLastSegment: healed stale cached terminal orbit` log line.
 - The last xUnit smoke/assertion follow-ups now catch headless `ParsekUI.Cleanup()` teardown in the KSC wiring smoke test and anchor the Bug219 negative log checks to the full production log prefix instead of the overlapping `ShouldPopulate...` diagnostic.
 - Headless landed snapshot-repair coverage now survives Unity pseudo-null `CelestialBody` fixtures all the way through the real `REF` rewrite path instead of bailing out before the repaired surface orbit node is written.

--- a/Source/Parsek.Tests/InGameTestRunnerTests.cs
+++ b/Source/Parsek.Tests/InGameTestRunnerTests.cs
@@ -256,6 +256,7 @@ namespace Parsek.Tests
             Assert.False(prepared);
         }
 
+        [Fact]
         public void FormatCoroutineState_ReportsActiveAndIdleSlots()
         {
             string state = InGameTestRunner.FormatCoroutineState(

--- a/Source/Parsek.Tests/KerbalsWindowUITests.cs
+++ b/Source/Parsek.Tests/KerbalsWindowUITests.cs
@@ -697,8 +697,8 @@ namespace Parsek.Tests
             string rosterText = KerbalsWindowUI.FormatRosterChainMemberText(member, isLast: true);
 
             // Both texts must begin with the same leading run of spaces.
-            Assert.StartsWith(KerbalsWindowUI.SubitemIndent, outcomeText);
-            Assert.StartsWith(KerbalsWindowUI.SubitemIndent, rosterText);
+            Assert.StartsWith(KerbalsWindowUI.SubitemIndent, outcomeText, StringComparison.Ordinal);
+            Assert.StartsWith(KerbalsWindowUI.SubitemIndent, rosterText, StringComparison.Ordinal);
             // The indent length must be identical (defensive check in case a future
             // SubitemIndent becomes non-space; then startswith + equal-length still
             // holds but the content must match exactly).

--- a/Source/Parsek.Tests/KerbalsWindowUITests.cs
+++ b/Source/Parsek.Tests/KerbalsWindowUITests.cs
@@ -642,7 +642,7 @@ namespace Parsek.Tests
                 EndState = KerbalEndState.Recovered
             };
             string text = KerbalsWindowUI.FormatMissionOutcomeSubitemText(entry);
-            Assert.StartsWith(KerbalsWindowUI.SubitemIndent, text);
+            Assert.StartsWith(KerbalsWindowUI.SubitemIndent, text, StringComparison.Ordinal);
             // And the body itself (after the indent) is the unchanged FormatEndStateRow output.
             Assert.Equal(
                 KerbalsWindowUI.SubitemIndent + KerbalsWindowUI.FormatEndStateRow(entry),
@@ -665,8 +665,8 @@ namespace Parsek.Tests
             string mid = KerbalsWindowUI.FormatRosterChainMemberText(member, isLast: false);
             string last = KerbalsWindowUI.FormatRosterChainMemberText(member, isLast: true);
 
-            Assert.StartsWith(KerbalsWindowUI.SubitemIndent, mid);
-            Assert.StartsWith(KerbalsWindowUI.SubitemIndent, last);
+            Assert.StartsWith(KerbalsWindowUI.SubitemIndent, mid, StringComparison.Ordinal);
+            Assert.StartsWith(KerbalsWindowUI.SubitemIndent, last, StringComparison.Ordinal);
             Assert.Contains("\u251c\u2500", mid);   // mid-child branch char (├─)
             Assert.Contains("\u2514\u2500", last);  // last-child branch char (└─)
             Assert.Contains(KerbalsWindowUI.FormatChainMember(member), mid);

--- a/Source/Parsek.Tests/KerbalsWindowUITests.cs
+++ b/Source/Parsek.Tests/KerbalsWindowUITests.cs
@@ -697,8 +697,8 @@ namespace Parsek.Tests
             string rosterText = KerbalsWindowUI.FormatRosterChainMemberText(member, isLast: true);
 
             // Both texts must begin with the same leading run of spaces.
-            Assert.True(outcomeText.StartsWith(KerbalsWindowUI.SubitemIndent, StringComparison.Ordinal));
-            Assert.True(rosterText.StartsWith(KerbalsWindowUI.SubitemIndent, StringComparison.Ordinal));
+            Assert.StartsWith(KerbalsWindowUI.SubitemIndent, outcomeText);
+            Assert.StartsWith(KerbalsWindowUI.SubitemIndent, rosterText);
             // The indent length must be identical (defensive check in case a future
             // SubitemIndent becomes non-space; then startswith + equal-length still
             // holds but the content must match exactly).

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -454,9 +454,9 @@ The four top-of-queue correctness fixes (#431, #432, #433, #434) shipped in the 
 
 **Files:** `Source/Parsek.Tests/InGameTestRunnerTests.cs` (add `[Fact]` to `FormatCoroutineState_ReportsActiveAndIdleSlots` or reduce visibility), `Source/Parsek.Tests/KerbalsWindowUITests.cs` (swap both `Assert.True(x.StartsWith(...))` for `Assert.StartsWith(...)`).
 
-**Fix / Resolution (2026-04-22):** CLOSED for v0.8.3. `InGameTestRunnerTests.FormatCoroutineState_ReportsActiveAndIdleSlots` is now explicitly marked `[Fact]`, so the assertion runs instead of sitting as public test-shaped dead code, and the Kerbals subitem-indent regressions now use xUnit `Assert.StartsWith(...)` with the original `StringComparison.Ordinal` semantics preserved across the touched prefix checks instead of the old `Assert.True(text.StartsWith(..., StringComparison.Ordinal))` form. A forced `dotnet build Source/Parsek.Tests/Parsek.Tests.csproj -t:Rebuild --no-restore` rerun now reports `0 Warning(s)`.
+**Fix / Resolution (2026-04-22):** CLOSED for v0.9.0. `InGameTestRunnerTests.FormatCoroutineState_ReportsActiveAndIdleSlots` is now explicitly marked `[Fact]`, so the assertion runs instead of sitting as public test-shaped dead code, and the Kerbals subitem-indent regressions now use xUnit `Assert.StartsWith(...)` with the original `StringComparison.Ordinal` semantics preserved across the touched prefix checks instead of the old `Assert.True(text.StartsWith(..., StringComparison.Ordinal))` form. A forced `dotnet build Source/Parsek.Tests/Parsek.Tests.csproj -t:Rebuild --no-restore` rerun now reports `0 Warning(s)`.
 
-**Status:** CLOSED 2026-04-22. Cheap cleanup completed; the test project no longer carries these baseline analyzer warnings.
+**Status:** CLOSED 2026-04-22. Cheap cleanup completed for v0.9.0; the test project no longer carries these baseline analyzer warnings.
 
 ---
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -446,7 +446,7 @@ The four top-of-queue correctness fixes (#431, #432, #433, #434) shipped in the 
 
 ---
 
-## 540. Three xUnit style warnings on `dotnet test` should be cleaned up
+## ~~540. Three xUnit style warnings on `dotnet test` should be cleaned up~~
 
 **Source:** `dotnet test` on current `main` emits three xUnit analyzer warnings: `InGameTestRunnerTests.cs:259` (`xUnit1013` — `FormatCoroutineState_ReportsActiveAndIdleSlots` is public but missing `[Fact]`, so it silently does not run) and `KerbalsWindowUITests.cs:700-701` (two `xUnit2009` — `Assert.True(text.StartsWith(prefix, StringComparison.Ordinal))` should be `Assert.StartsWith(prefix, text, StringComparison.Ordinal)` for better failure messages).
 
@@ -454,7 +454,9 @@ The four top-of-queue correctness fixes (#431, #432, #433, #434) shipped in the 
 
 **Files:** `Source/Parsek.Tests/InGameTestRunnerTests.cs` (add `[Fact]` to `FormatCoroutineState_ReportsActiveAndIdleSlots` or reduce visibility), `Source/Parsek.Tests/KerbalsWindowUITests.cs` (swap both `Assert.True(x.StartsWith(...))` for `Assert.StartsWith(...)`).
 
-**Status:** OPEN. Cheap cleanup; unblocks any later `TreatWarningsAsErrors` for the test project.
+**Fix / Resolution (2026-04-22):** CLOSED for v0.8.3. `InGameTestRunnerTests.FormatCoroutineState_ReportsActiveAndIdleSlots` is now explicitly marked `[Fact]`, so the assertion runs instead of sitting as public test-shaped dead code, and `KerbalsWindowUITests.MissionOutcomesAndRosterUseSameSubitemIndent` now uses `Assert.StartsWith(...)` for both indent-prefix checks instead of `Assert.True(text.StartsWith(...))`. A forced `dotnet build Source/Parsek.Tests/Parsek.Tests.csproj -t:Rebuild --no-restore` rerun now reports `0 Warning(s)`.
+
+**Status:** CLOSED 2026-04-22. Cheap cleanup completed; the test project no longer carries these baseline analyzer warnings.
 
 ---
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -454,7 +454,7 @@ The four top-of-queue correctness fixes (#431, #432, #433, #434) shipped in the 
 
 **Files:** `Source/Parsek.Tests/InGameTestRunnerTests.cs` (add `[Fact]` to `FormatCoroutineState_ReportsActiveAndIdleSlots` or reduce visibility), `Source/Parsek.Tests/KerbalsWindowUITests.cs` (swap both `Assert.True(x.StartsWith(...))` for `Assert.StartsWith(...)`).
 
-**Fix / Resolution (2026-04-22):** CLOSED for v0.8.3. `InGameTestRunnerTests.FormatCoroutineState_ReportsActiveAndIdleSlots` is now explicitly marked `[Fact]`, so the assertion runs instead of sitting as public test-shaped dead code, and `KerbalsWindowUITests.MissionOutcomesAndRosterUseSameSubitemIndent` now uses `Assert.StartsWith(...)` for both indent-prefix checks instead of `Assert.True(text.StartsWith(...))`. A forced `dotnet build Source/Parsek.Tests/Parsek.Tests.csproj -t:Rebuild --no-restore` rerun now reports `0 Warning(s)`.
+**Fix / Resolution (2026-04-22):** CLOSED for v0.8.3. `InGameTestRunnerTests.FormatCoroutineState_ReportsActiveAndIdleSlots` is now explicitly marked `[Fact]`, so the assertion runs instead of sitting as public test-shaped dead code, and the Kerbals subitem-indent regressions now use xUnit `Assert.StartsWith(...)` with the original `StringComparison.Ordinal` semantics preserved across the touched prefix checks instead of the old `Assert.True(text.StartsWith(..., StringComparison.Ordinal))` form. A forced `dotnet build Source/Parsek.Tests/Parsek.Tests.csproj -t:Rebuild --no-restore` rerun now reports `0 Warning(s)`.
 
 **Status:** CLOSED 2026-04-22. Cheap cleanup completed; the test project no longer carries these baseline analyzer warnings.
 


### PR DESCRIPTION
Closes #540

## Summary
- add the missing [Fact] to the orphaned test-shaped method in InGameTestRunnerTests
- replace the remaining StartsWith Assert.True calls with xUnit Assert.StartsWith while preserving ordinal semantics
- move the release note to 0.9.0 and mark the todo item closed/struck through

## Validation
- dotnet build Source/Parsek.Tests/Parsek.Tests.csproj -t:Rebuild --no-restore
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --no-build