### PR TITLE
Fix #527 preserve rewind cutoff through scene-load recalc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,7 +121,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
-- `#527` Rewind follow-up scene-load recalculations now rebuild career state at the current loaded UT instead of walking the full ledger. The later FLIGHT `OnLoad` pass no longer restores future funds/contracts immediately after rewind; those actions stay filtered until replay reaches their UT again.
+- `#527` Rewind follow-up post-rewind FLIGHT-load recalculations now rebuild career state at the current loaded UT instead of walking the full ledger. The later FLIGHT `OnLoad` pass no longer restores future funds/contracts immediately after rewind; those actions stay filtered until replay reaches their UT again. The cutoff-dispatch log now includes every decision input, the other deferred `ParsekScenario` recalcs were audited as intentional full-ledger non-rewind paths, and a manual-only live rewind canary now exercises the real load flow.
 - Ballistic orbital-frame storage now normalizes as well as canonicalizes the saved quaternions, so SOI handoffs keep the same represented world attitude instead of drifting when a frozen playback rotation started as a scaled quaternion.
 - Hyperbolic predicted segments now reconstruct true anomaly with a quadrant-safe formula, so parent-body SOI handoffs keep the same boundary state and frozen playback attitude instead of folding the new segment onto the wrong outbound branch.
 - Hyperbolic predicted segments now keep periapsis orientation even when the parent escape orbit is equatorial, so SOI handoffs no longer serialize the parent segment with `argumentOfPeriapsis = 0` and then reconstruct the wrong start state and frozen attitude.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- `#527` Rewind follow-up scene-load recalculations now rebuild career state at the current loaded UT instead of walking the full ledger. The later FLIGHT `OnLoad` pass no longer restores future funds/contracts immediately after rewind; those actions stay filtered until replay reaches their UT again.
 - Ballistic orbital-frame storage now normalizes as well as canonicalizes the saved quaternions, so SOI handoffs keep the same represented world attitude instead of drifting when a frozen playback rotation started as a scaled quaternion.
 - Hyperbolic predicted segments now reconstruct true anomaly with a quadrant-safe formula, so parent-body SOI handoffs keep the same boundary state and frozen playback attitude instead of folding the new segment onto the wrong outbound branch.
 - Hyperbolic predicted segments now keep periapsis orientation even when the parent escape orbit is equatorial, so SOI handoffs no longer serialize the parent segment with `argumentOfPeriapsis = 0` and then reconstruct the wrong start state and frozen attitude.

--- a/Source/Parsek.Tests/LedgerOrchestratorTests.cs
+++ b/Source/Parsek.Tests/LedgerOrchestratorTests.cs
@@ -312,6 +312,28 @@ namespace Parsek.Tests
                 l.Contains("[KspStatePatcher]") && l.Contains("PatchAll complete"));
         }
 
+        [Fact]
+        public void RecalculateAndPatchForSceneLoad_WithPendingTree_StillDefersKspStatePatch()
+        {
+            LedgerOrchestrator.Initialize();
+            RecordingStore.StashPendingTree(new RecordingTree
+            {
+                Id = "tree-scene-load",
+                TreeName = "SceneLoadTree",
+                RootRecordingId = "rec-scene-load",
+                ActiveRecordingId = "rec-scene-load"
+            });
+
+            LedgerOrchestrator.RecalculateAndPatchForSceneLoad(100.0);
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[LedgerOrchestrator]")
+                && l.Contains("deferred KSP state patch")
+                && l.Contains("SceneLoadTree"));
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("[KspStatePatcher]") && l.Contains("PatchAll complete"));
+        }
+
         // ================================================================
         // Multiple recalculations (idempotency)
         // ================================================================

--- a/Source/Parsek.Tests/LedgerOrchestratorTests.cs
+++ b/Source/Parsek.Tests/LedgerOrchestratorTests.cs
@@ -313,7 +313,7 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void RecalculateAndPatchForSceneLoad_WithPendingTree_StillDefersKspStatePatch()
+        public void RecalculateAndPatchForPostRewindFlightLoad_WithPendingTree_StillDefersKspStatePatch()
         {
             LedgerOrchestrator.Initialize();
             RecordingStore.StashPendingTree(new RecordingTree
@@ -324,7 +324,7 @@ namespace Parsek.Tests
                 ActiveRecordingId = "rec-scene-load"
             });
 
-            LedgerOrchestrator.RecalculateAndPatchForSceneLoad(100.0);
+            LedgerOrchestrator.RecalculateAndPatchForPostRewindFlightLoad(100.0);
 
             Assert.Contains(logLines, l =>
                 l.Contains("[LedgerOrchestrator]")
@@ -332,6 +332,44 @@ namespace Parsek.Tests
                 && l.Contains("SceneLoadTree"));
             Assert.DoesNotContain(logLines, l =>
                 l.Contains("[KspStatePatcher]") && l.Contains("PatchAll complete"));
+        }
+
+        [Fact]
+        public void HasActionsAfterUT_WhenLaterActionExists_ReturnsTrue()
+        {
+            Ledger.AddAction(new GameAction
+            {
+                UT = 100.0,
+                Type = GameActionType.FundsInitial,
+                InitialFunds = 1000f
+            });
+            Ledger.AddAction(new GameAction
+            {
+                UT = 250.0,
+                Type = GameActionType.FundsEarning,
+                FundsAwarded = 100f
+            });
+
+            Assert.True(LedgerOrchestrator.HasActionsAfterUT(200.0));
+        }
+
+        [Fact]
+        public void HasActionsAfterUT_WhenAllActionsAreAtOrBeforeThreshold_ReturnsFalse()
+        {
+            Ledger.AddAction(new GameAction
+            {
+                UT = 100.0,
+                Type = GameActionType.FundsInitial,
+                InitialFunds = 1000f
+            });
+            Ledger.AddAction(new GameAction
+            {
+                UT = 200.0,
+                Type = GameActionType.FundsEarning,
+                FundsAwarded = 100f
+            });
+
+            Assert.False(LedgerOrchestrator.HasActionsAfterUT(200.0));
         }
 
         // ================================================================

--- a/Source/Parsek.Tests/RewindUtCutoffTests.cs
+++ b/Source/Parsek.Tests/RewindUtCutoffTests.cs
@@ -673,6 +673,87 @@ namespace Parsek.Tests
             Assert.Equal(5000.0, second, 1);
         }
 
+        [Fact]
+        public void SceneLoadFollowup_AfterRewind_UsesCurrentUtCutoff()
+        {
+            AddAll(
+                FundsSeed(10000f),
+                ContractAccept(500.0, "future-contract", 400f),
+                Milestone(500.0, "future-funds", 1000f));
+
+            RewindContext.BeginRewind(500.0, default(BudgetSummary), 0, 0, 0);
+            RewindContext.SetAdjustedUT(200.0);
+
+            LedgerOrchestrator.RecalculateAndPatch(RewindContext.RewindAdjustedUT);
+            double firstBalance = LedgerOrchestrator.Funds.GetRunningBalance();
+            int firstActiveContracts = LedgerOrchestrator.Contracts.GetActiveContractCount();
+
+            RewindContext.EndRewind();
+            logLines.Clear();
+
+            ParsekScenario.RecalculateAndPatchForSceneLoad(200.0);
+
+            AssertLogHasCutoffSummary(logLines, 3, 1, "200");
+            Assert.Equal(firstBalance, LedgerOrchestrator.Funds.GetRunningBalance(), 5);
+            Assert.Equal(10000.0, LedgerOrchestrator.Funds.GetRunningBalance(), 1);
+            Assert.Equal(firstActiveContracts, LedgerOrchestrator.Contracts.GetActiveContractCount());
+            Assert.Equal(0, LedgerOrchestrator.Contracts.GetActiveContractCount());
+        }
+
+        [Fact]
+        public void SceneLoadCurrentUtCutoffDecision_RequiresSpecificPostRewindShape()
+        {
+            Assert.False(ParsekScenario.ShouldUseCurrentUtCutoffForSceneLoad(
+                isRevert: false,
+                loadedSceneIsFlight: true,
+                planetariumReady: false,
+                hasPendingTree: false,
+                restoreMode: ParsekScenario.ActiveTreeRestoreMode.None,
+                hasLiveRecorder: false,
+                hasActiveUncommittedTree: false,
+                hasFutureLedgerActions: true));
+
+            Assert.False(ParsekScenario.ShouldUseCurrentUtCutoffForSceneLoad(
+                isRevert: false,
+                loadedSceneIsFlight: true,
+                planetariumReady: true,
+                hasPendingTree: true,
+                restoreMode: ParsekScenario.ActiveTreeRestoreMode.None,
+                hasLiveRecorder: false,
+                hasActiveUncommittedTree: false,
+                hasFutureLedgerActions: true));
+
+            Assert.False(ParsekScenario.ShouldUseCurrentUtCutoffForSceneLoad(
+                isRevert: false,
+                loadedSceneIsFlight: true,
+                planetariumReady: true,
+                hasPendingTree: false,
+                restoreMode: ParsekScenario.ActiveTreeRestoreMode.Quickload,
+                hasLiveRecorder: false,
+                hasActiveUncommittedTree: false,
+                hasFutureLedgerActions: true));
+
+            Assert.False(ParsekScenario.ShouldUseCurrentUtCutoffForSceneLoad(
+                isRevert: false,
+                loadedSceneIsFlight: false,
+                planetariumReady: true,
+                hasPendingTree: false,
+                restoreMode: ParsekScenario.ActiveTreeRestoreMode.None,
+                hasLiveRecorder: false,
+                hasActiveUncommittedTree: false,
+                hasFutureLedgerActions: true));
+
+            Assert.True(ParsekScenario.ShouldUseCurrentUtCutoffForSceneLoad(
+                isRevert: false,
+                loadedSceneIsFlight: true,
+                planetariumReady: true,
+                hasPendingTree: false,
+                restoreMode: ParsekScenario.ActiveTreeRestoreMode.None,
+                hasLiveRecorder: false,
+                hasActiveUncommittedTree: false,
+                hasFutureLedgerActions: true));
+        }
+
         // ================================================================
         // Mixed-type filter test
         // ================================================================

--- a/Source/Parsek.Tests/RewindUtCutoffTests.cs
+++ b/Source/Parsek.Tests/RewindUtCutoffTests.cs
@@ -272,6 +272,27 @@ namespace Parsek.Tests
                 Ledger.AddAction(actions[i]);
         }
 
+        private static bool ShouldUseCurrentUtCutoffForPostRewindFlightLoad(
+            bool isRevert = false,
+            bool loadedSceneIsFlight = true,
+            bool planetariumReady = true,
+            bool hasPendingTree = false,
+            ParsekScenario.ActiveTreeRestoreMode restoreMode = ParsekScenario.ActiveTreeRestoreMode.None,
+            bool hasLiveRecorder = false,
+            bool hasActiveUncommittedTree = false,
+            bool hasFutureLedgerActions = true)
+        {
+            return ParsekScenario.ShouldUseCurrentUtCutoffForPostRewindFlightLoad(
+                isRevert,
+                loadedSceneIsFlight,
+                planetariumReady,
+                hasPendingTree,
+                restoreMode,
+                hasLiveRecorder,
+                hasActiveUncommittedTree,
+                hasFutureLedgerActions);
+        }
+
         private static void AssertLogHasCutoffSummary(List<string> lines, int actionsTotal,
             int actionsAfterCutoff, string cutoffLabel)
         {
@@ -674,7 +695,7 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void SceneLoadFollowup_AfterRewind_UsesCurrentUtCutoff()
+        public void PostRewindFlightLoadFollowup_AfterRewind_UsesCurrentUtCutoff()
         {
             AddAll(
                 FundsSeed(10000f),
@@ -691,7 +712,7 @@ namespace Parsek.Tests
             RewindContext.EndRewind();
             logLines.Clear();
 
-            ParsekScenario.RecalculateAndPatchForSceneLoad(200.0);
+            ParsekScenario.RecalculateAndPatchForPostRewindFlightLoad(200.0);
 
             AssertLogHasCutoffSummary(logLines, 3, 1, "200");
             Assert.Equal(firstBalance, LedgerOrchestrator.Funds.GetRunningBalance(), 5);
@@ -701,57 +722,67 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void SceneLoadCurrentUtCutoffDecision_RequiresSpecificPostRewindShape()
+        public void PostRewindFlightLoadCurrentUtCutoffDecision_HappyPath_ReturnsTrue()
         {
-            Assert.False(ParsekScenario.ShouldUseCurrentUtCutoffForSceneLoad(
-                isRevert: false,
-                loadedSceneIsFlight: true,
-                planetariumReady: false,
-                hasPendingTree: false,
-                restoreMode: ParsekScenario.ActiveTreeRestoreMode.None,
-                hasLiveRecorder: false,
-                hasActiveUncommittedTree: false,
-                hasFutureLedgerActions: true));
+            Assert.True(ShouldUseCurrentUtCutoffForPostRewindFlightLoad());
+        }
 
-            Assert.False(ParsekScenario.ShouldUseCurrentUtCutoffForSceneLoad(
-                isRevert: false,
-                loadedSceneIsFlight: true,
-                planetariumReady: true,
-                hasPendingTree: true,
-                restoreMode: ParsekScenario.ActiveTreeRestoreMode.None,
-                hasLiveRecorder: false,
-                hasActiveUncommittedTree: false,
-                hasFutureLedgerActions: true));
+        [Fact]
+        public void PostRewindFlightLoadCurrentUtCutoffDecision_RejectsRevert()
+        {
+            Assert.False(ShouldUseCurrentUtCutoffForPostRewindFlightLoad(isRevert: true));
+        }
 
-            Assert.False(ParsekScenario.ShouldUseCurrentUtCutoffForSceneLoad(
-                isRevert: false,
-                loadedSceneIsFlight: true,
-                planetariumReady: true,
-                hasPendingTree: false,
-                restoreMode: ParsekScenario.ActiveTreeRestoreMode.Quickload,
-                hasLiveRecorder: false,
-                hasActiveUncommittedTree: false,
-                hasFutureLedgerActions: true));
+        [Fact]
+        public void PostRewindFlightLoadCurrentUtCutoffDecision_RejectsNonFlightScene()
+        {
+            Assert.False(ShouldUseCurrentUtCutoffForPostRewindFlightLoad(loadedSceneIsFlight: false));
+        }
 
-            Assert.False(ParsekScenario.ShouldUseCurrentUtCutoffForSceneLoad(
-                isRevert: false,
-                loadedSceneIsFlight: false,
-                planetariumReady: true,
-                hasPendingTree: false,
-                restoreMode: ParsekScenario.ActiveTreeRestoreMode.None,
-                hasLiveRecorder: false,
-                hasActiveUncommittedTree: false,
-                hasFutureLedgerActions: true));
+        [Fact]
+        public void PostRewindFlightLoadCurrentUtCutoffDecision_RejectsPlanetariumNotReady()
+        {
+            Assert.False(ShouldUseCurrentUtCutoffForPostRewindFlightLoad(planetariumReady: false));
+        }
 
-            Assert.True(ParsekScenario.ShouldUseCurrentUtCutoffForSceneLoad(
-                isRevert: false,
-                loadedSceneIsFlight: true,
-                planetariumReady: true,
-                hasPendingTree: false,
-                restoreMode: ParsekScenario.ActiveTreeRestoreMode.None,
-                hasLiveRecorder: false,
-                hasActiveUncommittedTree: false,
-                hasFutureLedgerActions: true));
+        [Fact]
+        public void PostRewindFlightLoadCurrentUtCutoffDecision_RejectsPendingTree()
+        {
+            Assert.False(ShouldUseCurrentUtCutoffForPostRewindFlightLoad(hasPendingTree: true));
+        }
+
+        [Fact]
+        public void PostRewindFlightLoadCurrentUtCutoffDecision_RejectsQuickloadRestore()
+        {
+            Assert.False(ShouldUseCurrentUtCutoffForPostRewindFlightLoad(
+                restoreMode: ParsekScenario.ActiveTreeRestoreMode.Quickload));
+        }
+
+        [Fact]
+        public void PostRewindFlightLoadCurrentUtCutoffDecision_RejectsVesselSwitchRestore()
+        {
+            Assert.False(ShouldUseCurrentUtCutoffForPostRewindFlightLoad(
+                restoreMode: ParsekScenario.ActiveTreeRestoreMode.VesselSwitch));
+        }
+
+        [Fact]
+        public void PostRewindFlightLoadCurrentUtCutoffDecision_RejectsLiveRecorder()
+        {
+            Assert.False(ShouldUseCurrentUtCutoffForPostRewindFlightLoad(hasLiveRecorder: true));
+        }
+
+        [Fact]
+        public void PostRewindFlightLoadCurrentUtCutoffDecision_RejectsActiveUncommittedTree()
+        {
+            Assert.False(ShouldUseCurrentUtCutoffForPostRewindFlightLoad(
+                hasActiveUncommittedTree: true));
+        }
+
+        [Fact]
+        public void PostRewindFlightLoadCurrentUtCutoffDecision_RejectsMissingFutureLedgerActions()
+        {
+            Assert.False(ShouldUseCurrentUtCutoffForPostRewindFlightLoad(
+                hasFutureLedgerActions: false));
         }
 
         // ================================================================

--- a/Source/Parsek/GameActions/LedgerOrchestrator.cs
+++ b/Source/Parsek/GameActions/LedgerOrchestrator.cs
@@ -1146,6 +1146,31 @@ namespace Parsek
         /// </param>
         internal static void RecalculateAndPatch(double? utCutoff = null)
         {
+            RecalculateAndPatchCore(
+                utCutoff,
+                bypassPatchDeferral: utCutoff.HasValue,
+                authoritativeRepeatableRecordState: utCutoff.HasValue);
+        }
+
+        /// <summary>
+        /// Scene-load follow-up recalculation that filters the walk to the currently
+        /// loaded UT without opting into rewind-only patch side effects. Unlike the
+        /// normal explicit-cutoff path, this preserves pending/live-tree patch
+        /// deferral and same-branch repeatable-record preservation.
+        /// </summary>
+        internal static void RecalculateAndPatchForSceneLoad(double utCutoff)
+        {
+            RecalculateAndPatchCore(
+                utCutoff,
+                bypassPatchDeferral: false,
+                authoritativeRepeatableRecordState: false);
+        }
+
+        private static void RecalculateAndPatchCore(
+            double? utCutoff,
+            bool bypassPatchDeferral,
+            bool authoritativeRepeatableRecordState)
+        {
             Initialize();
 
             // Seed initial balances for career mode (per-resource, idempotent).
@@ -1231,7 +1256,9 @@ namespace Parsek
             // uncommitted in-flight effects that the committed-only ledger cannot see yet.
             // Walking the committed ledger is still useful, but writing that partial state
             // back into KSP is destructive. Rewind-style cutoff walks remain authoritative.
-            string patchDeferralReason = GetKspPatchDeferralReason(utCutoff);
+            string patchDeferralReason = bypassPatchDeferral
+                ? null
+                : GetKspPatchDeferralReason();
             if (!string.IsNullOrEmpty(patchDeferralReason))
             {
                 ParsekLog.Verbose(Tag,
@@ -1247,7 +1274,7 @@ namespace Parsek
                 kerbalsModule.ApplyToRoster(HighLogic.CurrentGame?.CrewRoster);
                 KspStatePatcher.PatchAll(scienceModule, fundsModule, reputationModule,
                     milestonesModule, facilitiesModule, contractsModule,
-                    authoritativeRepeatableRecordState: utCutoff.HasValue);
+                    authoritativeRepeatableRecordState: authoritativeRepeatableRecordState);
             }
 
             // #391: rebuild committedScienceSubjects from the walk's authoritative
@@ -1263,11 +1290,20 @@ namespace Parsek
             OnTimelineDataChanged?.Invoke();
         }
 
-        private static string GetKspPatchDeferralReason(double? utCutoff)
+        internal static bool HasActionsAfterUT(double ut)
         {
-            if (utCutoff.HasValue)
-                return null;
+            for (int i = 0; i < Ledger.Actions.Count; i++)
+            {
+                var action = Ledger.Actions[i];
+                if (action != null && action.UT > ut)
+                    return true;
+            }
 
+            return false;
+        }
+
+        private static string GetKspPatchDeferralReason()
+        {
             bool hasActiveUncommittedTree = GameStateRecorder.HasActiveUncommittedTree();
             bool hasLiveRecorder = GameStateRecorder.HasLiveRecorder();
             bool hasPendingTree = RecordingStore.HasPendingTree;

--- a/Source/Parsek/GameActions/LedgerOrchestrator.cs
+++ b/Source/Parsek/GameActions/LedgerOrchestrator.cs
@@ -1153,12 +1153,13 @@ namespace Parsek
         }
 
         /// <summary>
-        /// Scene-load follow-up recalculation that filters the walk to the currently
-        /// loaded UT without opting into rewind-only patch side effects. Unlike the
-        /// normal explicit-cutoff path, this preserves pending/live-tree patch
-        /// deferral and same-branch repeatable-record preservation.
+        /// Post-rewind FLIGHT-load follow-up recalculation that filters the walk to
+        /// the currently loaded UT without opting into rewind-only patch side
+        /// effects. Unlike the normal explicit-cutoff path, this preserves
+        /// pending/live-tree patch deferral and same-branch repeatable-record
+        /// preservation.
         /// </summary>
-        internal static void RecalculateAndPatchForSceneLoad(double utCutoff)
+        internal static void RecalculateAndPatchForPostRewindFlightLoad(double utCutoff)
         {
             RecalculateAndPatchCore(
                 utCutoff,
@@ -1249,7 +1250,8 @@ namespace Parsek
             // #440 Phase E2: post-walk reconciliation for strategy-transformed
             // and curve-applied reward types. Runs once per walk, log-only,
             // after derived fields (Transformed*Reward/EffectiveRep/
-            // EffectiveScience) are populated and before KSP state is patched.
+            // EffectiveScience) are populated and before the later KSP patch/defer
+            // branch decides whether this walk mutates live game state.
             ReconcilePostWalk(GameStateStore.Events, actions, utCutoff);
 
             // #466: a live or pending tree means KSP's mutable state may already include

--- a/Source/Parsek/InGameTests/RuntimeTests.cs
+++ b/Source/Parsek/InGameTests/RuntimeTests.cs
@@ -4569,6 +4569,46 @@ namespace Parsek.InGameTests
                 $"situation={timedOutVessel?.situation.ToString() ?? "null"})");
         }
 
+        private static IEnumerator WaitForCommittedRecording(
+            string recordingId, int committedBefore, float timeoutSeconds)
+        {
+            float deadline = Time.time + timeoutSeconds;
+            while (Time.time < deadline)
+            {
+                bool committed = RecordingStore.CommittedRecordings.Any(
+                    r => r != null && r.RecordingId == recordingId);
+                bool countIncreased = RecordingStore.CommittedRecordings.Count > committedBefore;
+                bool stillRecording = ParsekFlight.Instance != null && ParsekFlight.Instance.IsRecording;
+                if (committed && countIncreased && !stillRecording)
+                    yield break;
+
+                yield return null;
+            }
+
+            InGameAssert.Fail(
+                $"WaitForCommittedRecording timed out after {timeoutSeconds:F0}s " +
+                $"(recordingId={recordingId ?? "null"}, committedBefore={committedBefore}, " +
+                $"committedNow={RecordingStore.CommittedRecordings.Count}, " +
+                $"isRecording={ParsekFlight.Instance?.IsRecording == true})");
+        }
+
+        private static IEnumerator WaitForCapturedLogLine(
+            List<string> captured, string containsText, float timeoutSeconds)
+        {
+            float deadline = Time.time + timeoutSeconds;
+            while (Time.time < deadline)
+            {
+                if (captured.Any(line => line.Contains(containsText)))
+                    yield break;
+
+                yield return null;
+            }
+
+            InGameAssert.Fail(
+                $"WaitForCapturedLogLine timed out after {timeoutSeconds:F0}s " +
+                $"(text='{containsText}', captured={captured?.Count ?? 0})");
+        }
+
         private static IEnumerator AssertNoPopupDialog(string dialogName, float durationSeconds)
         {
             float deadline = Time.time + durationSeconds;
@@ -6124,6 +6164,195 @@ namespace Parsek.InGameTests
             {
                 FlightInputHandler.state.mainThrottle = originalThrottle;
                 ParsekLog.TestObserverForTesting = priorObserver;
+                if (ParsekFlight.Instance != null && ParsekFlight.Instance.IsRecording)
+                    ParsekFlight.Instance.StopRecording();
+            }
+        }
+
+        /// <summary>
+        /// Live rewind canary for #527. Commits a real launch recording to get a real
+        /// rewind save, injects future ledger actions, then drives the actual rewind
+        /// load path and asserts the post-rewind FLIGHT follow-up keeps those future
+        /// funds/contracts filtered.
+        /// </summary>
+        [InGameTest(Category = "RewindFlow", Scene = GameScenes.FLIGHT, RunLast = true,
+            AllowBatchExecution = false,
+            RestoreBatchFlightBaselineAfterExecution = true,
+            BatchSkipReason = "Isolated-run only — excluded from ordinary Run All / Run category because this test commits a real launch recording, injects future ledger actions, and drives a live rewind in the current FLIGHT session. Use Run All + Isolated or the row play button in a disposable Career-mode FLIGHT session.",
+            Description = "Live rewind keeps future funds/contracts filtered during the post-rewind FLIGHT load follow-up")]
+        public IEnumerator RewindToLaunch_PostRewindFlightLoad_KeepsFutureFundsAndContractsFiltered()
+        {
+            var flight = ParsekFlight.Instance;
+            InGameAssert.IsNotNull(flight, "ParsekFlight.Instance required");
+            if (HighLogic.CurrentGame == null || HighLogic.CurrentGame.Mode != Game.Modes.CAREER)
+            {
+                InGameAssert.Skip("requires a Career-mode FLIGHT save");
+                yield break;
+            }
+
+            var vessel = FlightGlobals.ActiveVessel;
+            if (vessel == null)
+            {
+                InGameAssert.Skip("no active vessel");
+                yield break;
+            }
+            if (vessel.isEVA || vessel.vesselType == VesselType.EVA)
+            {
+                InGameAssert.Skip("requires a non-EVA active vessel");
+                yield break;
+            }
+            if (vessel.situation != Vessel.Situations.PRELAUNCH)
+            {
+                InGameAssert.Skip(
+                    $"requires a PRELAUNCH vessel on the pad so the test can launch, commit, and rewind, got {vessel.situation}");
+                yield break;
+            }
+            if (flight.IsRecording)
+            {
+                InGameAssert.Skip("requires an idle prelaunch vessel (recording already active)");
+                yield break;
+            }
+            if (FlightInputHandler.state == null)
+            {
+                InGameAssert.Skip("FlightInputHandler.state is null");
+                yield break;
+            }
+            if (Funding.Instance == null)
+            {
+                InGameAssert.Skip("Funding.Instance is null — this live rewind cutoff canary needs career funds");
+                yield break;
+            }
+
+            int committedBefore = RecordingStore.CommittedRecordings.Count;
+            float originalThrottle = FlightInputHandler.state.mainThrottle;
+            var captured = new List<string>();
+            var priorObserver = ParsekLog.TestObserverForTesting;
+            string syntheticLedgerTag = null;
+
+            try
+            {
+                ParsekLog.TestObserverForTesting = line => { captured.Add(line); priorObserver?.Invoke(line); };
+
+                flight.StartRecording();
+                InGameAssert.IsTrue(flight.IsRecording,
+                    "ParsekFlight.StartRecording should start a live recording before the rewind canary");
+
+                string activeRecId = flight.ActiveTreeForSerialization?.ActiveRecordingId;
+                InGameAssert.IsNotNull(activeRecId,
+                    "ActiveRecordingId should be set before staging the live rewind canary");
+
+                yield return new WaitForSeconds(0.5f);
+
+                FlightInputHandler.state.mainThrottle = 1f;
+                KSP.UI.Screens.StageManager.ActivateNextStage();
+
+                yield return WaitForRecordingToLeavePrelaunch(activeRecId, 10f);
+                yield return RuntimeTests.WaitForActiveRecordingPoint(flight, 5f);
+                yield return new WaitForSeconds(0.5f);
+
+                FlightInputHandler.state.mainThrottle = 0f;
+                flight.StopRecording();
+                yield return WaitForCommittedRecording(activeRecId, committedBefore, 10f);
+
+                Recording committedRecording = RecordingStore.CommittedRecordings.FirstOrDefault(
+                    r => r != null && r.RecordingId == activeRecId);
+                InGameAssert.IsNotNull(committedRecording,
+                    "Stopping the live rewind canary recording should commit it into the timeline");
+                InGameAssert.IsTrue(!string.IsNullOrEmpty(committedRecording.RewindSaveFileName),
+                    "Committed rewind canary recording must have a rewind save file");
+
+                double fundsBeforeFutureActions = Funding.Instance.Funds;
+                int activeContractsBeforeFutureActions = LedgerOrchestrator.Contracts.GetActiveContractCount();
+
+                syntheticLedgerTag = "ingame-rewind-cutoff-" + System.Guid.NewGuid().ToString("N");
+                string futureContractId = syntheticLedgerTag + "-contract";
+                double futureUT = Planetarium.GetUniversalTime() + 120.0;
+
+                Ledger.AddAction(new GameAction
+                {
+                    UT = futureUT,
+                    Type = GameActionType.ContractAccept,
+                    RecordingId = syntheticLedgerTag,
+                    ContractId = futureContractId,
+                    ContractType = "ParsekRewindCutoffCanary",
+                    ContractTitle = "Parsek Rewind Cutoff Canary",
+                    AdvanceFunds = 321f,
+                    DeadlineUT = (float)(futureUT + 3600.0)
+                });
+                Ledger.AddAction(new GameAction
+                {
+                    UT = futureUT + 1.0,
+                    Type = GameActionType.MilestoneAchievement,
+                    RecordingId = syntheticLedgerTag,
+                    MilestoneId = syntheticLedgerTag + "-milestone",
+                    MilestoneFundsAwarded = 654f
+                });
+
+                InGameAssert.IsTrue(
+                    LedgerOrchestrator.HasActionsAfterUT(Planetarium.GetUniversalTime()),
+                    "Injected future ledger actions should sit after the current UT before rewind");
+
+                int previousFlightInstanceId = flight.GetInstanceID();
+                RecordingStore.InitiateRewind(committedRecording);
+
+                yield return Helpers.QuickloadResumeHelpers.WaitForFlightReady(previousFlightInstanceId, 20f);
+                yield return WaitForCapturedLogLine(
+                    captured,
+                    "post-rewind FLIGHT recalc using current-UT cutoff",
+                    10f);
+                yield return new WaitForSeconds(0.5f);
+
+                InGameAssert.IsNotNull(Funding.Instance,
+                    "Funding.Instance must exist after the live rewind cutoff canary reloads");
+
+                double postFunds = Funding.Instance.Funds;
+                int postActiveContracts = LedgerOrchestrator.Contracts.GetActiveContractCount();
+                bool sawDecisionInputs = captured.Any(
+                    line => line.Contains("post-rewind FLIGHT cutoff decision")
+                        && line.Contains("useCurrentUtCutoff=True")
+                        && line.Contains("hasFutureLedgerActions=True"));
+
+                InGameAssert.IsTrue(
+                    sawDecisionInputs,
+                    "Expected OnLoad to log the post-rewind FLIGHT cutoff decision inputs");
+                InGameAssert.IsTrue(
+                    System.Math.Abs(postFunds - fundsBeforeFutureActions) < 1.0,
+                    $"Post-rewind funds should stay at the pre-future baseline until replay catches up " +
+                    $"(before={fundsBeforeFutureActions:F1}, after={postFunds:F1})");
+                InGameAssert.AreEqual(
+                    activeContractsBeforeFutureActions,
+                    postActiveContracts,
+                    "Post-rewind active-contract count should stay at the pre-future baseline");
+                InGameAssert.IsFalse(
+                    LedgerOrchestrator.Contracts.GetActiveContractIds().Contains(futureContractId),
+                    "Future contract should stay filtered until replay catches up");
+
+                ParsekLog.Info("TestRunner",
+                    $"Rewind cutoff runtime: rec='{activeRecId}' fundsBefore={fundsBeforeFutureActions.ToString("F1", CultureInfo.InvariantCulture)} " +
+                    $"fundsAfter={postFunds.ToString("F1", CultureInfo.InvariantCulture)} " +
+                    $"activeContractsBefore={activeContractsBeforeFutureActions} activeContractsAfter={postActiveContracts}");
+            }
+            finally
+            {
+                if (FlightInputHandler.state != null)
+                    FlightInputHandler.state.mainThrottle = originalThrottle;
+                ParsekLog.TestObserverForTesting = priorObserver;
+
+                if (!string.IsNullOrEmpty(syntheticLedgerTag))
+                {
+                    try
+                    {
+                        Ledger.RemoveActionsForRecording(syntheticLedgerTag);
+                        if (HighLogic.CurrentGame != null)
+                            LedgerOrchestrator.RecalculateAndPatch();
+                    }
+                    catch (System.Exception ex)
+                    {
+                        ParsekLog.Warn("TestRunner",
+                            $"Rewind cutoff runtime cleanup failed for synthetic ledger tag '{syntheticLedgerTag}': {ex.Message}");
+                    }
+                }
+
                 if (ParsekFlight.Instance != null && ParsekFlight.Instance.IsRecording)
                     ParsekFlight.Instance.StopRecording();
             }

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -167,7 +167,7 @@ namespace Parsek
             LedgerOrchestrator.RecalculateAndPatch();
         }
 
-        internal static bool ShouldUseCurrentUtCutoffForSceneLoad(
+        internal static bool ShouldUseCurrentUtCutoffForPostRewindFlightLoad(
             bool isRevert,
             bool loadedSceneIsFlight,
             bool planetariumReady,
@@ -193,9 +193,9 @@ namespace Parsek
         /// Filters the walk to the already-captured loaded UT while preserving the
         /// normal patch-deferral and same-branch repeatable-record behavior.
         /// </summary>
-        internal static void RecalculateAndPatchForSceneLoad(double loadedUT)
+        internal static void RecalculateAndPatchForPostRewindFlightLoad(double loadedUT)
         {
-            LedgerOrchestrator.RecalculateAndPatchForSceneLoad(loadedUT);
+            LedgerOrchestrator.RecalculateAndPatchForPostRewindFlightLoad(loadedUT);
         }
 
         /// <summary>
@@ -1288,22 +1288,36 @@ namespace Parsek
                         }
                     }
 
-                    bool useCurrentUtCutoffForSceneLoad =
-                        ShouldUseCurrentUtCutoffForSceneLoad(
+                    bool loadedSceneIsFlight = HighLogic.LoadedScene == GameScenes.FLIGHT;
+                    bool hasPendingTree = RecordingStore.HasPendingTree;
+                    ActiveTreeRestoreMode restoreMode = ScheduleActiveTreeRestoreOnFlightReady;
+                    bool hasLiveRecorder = GameStateRecorder.HasLiveRecorder();
+                    bool hasActiveUncommittedTree = GameStateRecorder.HasActiveUncommittedTree();
+                    bool hasFutureLedgerActions = LedgerOrchestrator.HasActionsAfterUT(loadedUT);
+                    bool useCurrentUtCutoffForPostRewindFlightLoad =
+                        ShouldUseCurrentUtCutoffForPostRewindFlightLoad(
                             isRevert,
-                            HighLogic.LoadedScene == GameScenes.FLIGHT,
+                            loadedSceneIsFlight,
                             planetariumReady,
-                            RecordingStore.HasPendingTree,
-                            ScheduleActiveTreeRestoreOnFlightReady,
-                            GameStateRecorder.HasLiveRecorder(),
-                            GameStateRecorder.HasActiveUncommittedTree(),
-                            LedgerOrchestrator.HasActionsAfterUT(loadedUT));
-                    if (useCurrentUtCutoffForSceneLoad)
+                            hasPendingTree,
+                            restoreMode,
+                            hasLiveRecorder,
+                            hasActiveUncommittedTree,
+                            hasFutureLedgerActions);
+                    ParsekLog.Info("Scenario",
+                        $"OnLoad: post-rewind FLIGHT cutoff decision useCurrentUtCutoff={useCurrentUtCutoffForPostRewindFlightLoad} " +
+                        $"loadedUT={loadedUT.ToString("R", CultureInfo.InvariantCulture)} " +
+                        $"isRevert={isRevert} loadedSceneIsFlight={loadedSceneIsFlight} " +
+                        $"planetariumReady={planetariumReady} hasPendingTree={hasPendingTree} " +
+                        $"restoreMode={restoreMode} hasLiveRecorder={hasLiveRecorder} " +
+                        $"hasActiveUncommittedTree={hasActiveUncommittedTree} " +
+                        $"hasFutureLedgerActions={hasFutureLedgerActions}");
+                    if (useCurrentUtCutoffForPostRewindFlightLoad)
                     {
                         ParsekLog.Info("Scenario",
-                            $"OnLoad: scene-load recalc using current-UT cutoff {loadedUT.ToString("R", CultureInfo.InvariantCulture)} " +
+                            $"OnLoad: post-rewind FLIGHT recalc using current-UT cutoff {loadedUT.ToString("R", CultureInfo.InvariantCulture)} " +
                             "to keep future funds/contracts filtered until replay catches up");
-                        RecalculateAndPatchForSceneLoad(loadedUT);
+                        RecalculateAndPatchForPostRewindFlightLoad(loadedUT);
                     }
                     else
                     {
@@ -2952,6 +2966,8 @@ namespace Parsek
                 $"Science={(ResearchAndDevelopment.Instance != null ? ResearchAndDevelopment.Instance.Science.ToString("F0", ic) : "null")}, " +
                 $"Rep={(Reputation.Instance != null ? Reputation.Instance.reputation.ToString("F1", ic) : "null")}");
 
+            // Audited for #527: this initial-load-only reseed runs before any rewind
+            // context exists, so it intentionally stays full-ledger.
             LedgerOrchestrator.RecalculateAndPatch();
         }
 
@@ -2988,6 +3004,9 @@ namespace Parsek
             }
             budgetDeductionEpoch = MilestoneStore.CurrentEpoch;
 
+            // Audited for #527: this coroutine only runs on true revert follow-up
+            // budget restoration. The rewind path pre-sets budgetDeductionEpoch and
+            // uses ApplyRewindResourceAdjustment(adjustedUT) instead.
             LedgerOrchestrator.RecalculateAndPatch();
 
         }

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -167,6 +167,37 @@ namespace Parsek
             LedgerOrchestrator.RecalculateAndPatch();
         }
 
+        internal static bool ShouldUseCurrentUtCutoffForSceneLoad(
+            bool isRevert,
+            bool loadedSceneIsFlight,
+            bool planetariumReady,
+            bool hasPendingTree,
+            ActiveTreeRestoreMode restoreMode,
+            bool hasLiveRecorder,
+            bool hasActiveUncommittedTree,
+            bool hasFutureLedgerActions)
+        {
+            return !isRevert
+                && loadedSceneIsFlight
+                && planetariumReady
+                && !hasPendingTree
+                && restoreMode == ActiveTreeRestoreMode.None
+                && !hasLiveRecorder
+                && !hasActiveUncommittedTree
+                && hasFutureLedgerActions;
+        }
+
+        /// <summary>
+        /// Scene-load follow-up recalculation for the specific post-rewind FLIGHT
+        /// case where the loaded UT is still behind future committed actions.
+        /// Filters the walk to the already-captured loaded UT while preserving the
+        /// normal patch-deferral and same-branch repeatable-record behavior.
+        /// </summary>
+        internal static void RecalculateAndPatchForSceneLoad(double loadedUT)
+        {
+            LedgerOrchestrator.RecalculateAndPatchForSceneLoad(loadedUT);
+        }
+
         /// <summary>
         /// #434 follow-up: dispatch-level guard that decides whether the OnLoad
         /// quickload-discard branch should fire. Pure function of the three
@@ -1257,7 +1288,27 @@ namespace Parsek
                         }
                     }
 
-                    LedgerOrchestrator.RecalculateAndPatch();
+                    bool useCurrentUtCutoffForSceneLoad =
+                        ShouldUseCurrentUtCutoffForSceneLoad(
+                            isRevert,
+                            HighLogic.LoadedScene == GameScenes.FLIGHT,
+                            planetariumReady,
+                            RecordingStore.HasPendingTree,
+                            ScheduleActiveTreeRestoreOnFlightReady,
+                            GameStateRecorder.HasLiveRecorder(),
+                            GameStateRecorder.HasActiveUncommittedTree(),
+                            LedgerOrchestrator.HasActionsAfterUT(loadedUT));
+                    if (useCurrentUtCutoffForSceneLoad)
+                    {
+                        ParsekLog.Info("Scenario",
+                            $"OnLoad: scene-load recalc using current-UT cutoff {loadedUT.ToString("R", CultureInfo.InvariantCulture)} " +
+                            "to keep future funds/contracts filtered until replay catches up");
+                        RecalculateAndPatchForSceneLoad(loadedUT);
+                    }
+                    else
+                    {
+                        LedgerOrchestrator.RecalculateAndPatch();
+                    }
                     if (KerbalLoadRepairDiagnostics.IsActive)
                         KerbalLoadRepairDiagnostics.EmitAndReset();
                     ParsekLog.Info("Scenario", $"{(isRevert ? "Revert" : "Scene change")} — preserving {recordings.Count} session recordings");

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -288,15 +288,17 @@ The four top-of-queue correctness fixes (#431, #432, #433, #434) shipped in the 
 
 ---
 
-## 527. Rewind's deferred recalc can drop `utCutoff` and restore future funds/contracts before replay catches up
+## ~~527. Rewind's deferred recalc can drop `utCutoff` and restore future funds/contracts before replay catches up~~
 
 **Source:** `logs/2026-04-21_2335_live-collect-script/KSP.log` around 23:30:25-23:30:28. The rewind path first does the expected cutoff walk (`cutoffUT=19.159999999999467`), dropping funds from `53861.7` to `21495.0` and removing two active contracts. About five seconds later, a deferred FLIGHT recalc runs with `cutoffUT=null` and restores the end-of-timeline funds/contracts before any replay has advanced.
 
 **Concern:** one rewind caller is re-entering `RecalculateAndPatch()` without forwarding the rewind cutoff. That makes career state snap back toward the future timeline immediately after rewind, explains the new `PatchFunds: suspicious drawdown` warning in the same package, and breaks the expected "rewind means pre-cutoff state until replay progresses" model.
 
-**Files:** `Source/Parsek/ParsekScenario.cs`, `Source/Parsek/GameActions/LedgerOrchestrator.cs`, `Source/Parsek/GameActions/KspStatePatcher.cs`, `Source/Parsek.Tests/RewindUtCutoffTests.cs`.
+**Files:** `Source/Parsek/ParsekScenario.cs`, `Source/Parsek/GameActions/LedgerOrchestrator.cs`, `Source/Parsek.Tests/RewindUtCutoffTests.cs`.
 
-**Status:** OPEN. Repro captured in-package.
+**Fix:** the generic scene-load follow-up path now applies the current-UT cutoff only in the specific post-rewind FLIGHT case with no pending/live restore state, via `ParsekScenario.ShouldUseCurrentUtCutoffForSceneLoad(...)` and `LedgerOrchestrator.RecalculateAndPatchForSceneLoad(loadedUT)`. That keeps the later FLIGHT `OnLoad` pass aligned with the rewound clock without bypassing normal pending-tree patch deferral or same-branch repeatable-record preservation.
+
+**Status:** CLOSED 2026-04-22. Fixed for v0.8.3.
 
 ---
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -296,9 +296,9 @@ The four top-of-queue correctness fixes (#431, #432, #433, #434) shipped in the 
 
 **Files:** `Source/Parsek/ParsekScenario.cs`, `Source/Parsek/GameActions/LedgerOrchestrator.cs`, `Source/Parsek.Tests/RewindUtCutoffTests.cs`.
 
-**Fix:** the generic scene-load follow-up path now applies the current-UT cutoff only in the specific post-rewind FLIGHT case with no pending/live restore state, via `ParsekScenario.ShouldUseCurrentUtCutoffForSceneLoad(...)` and `LedgerOrchestrator.RecalculateAndPatchForSceneLoad(loadedUT)`. That keeps the later FLIGHT `OnLoad` pass aligned with the rewound clock without bypassing normal pending-tree patch deferral or same-branch repeatable-record preservation.
+**Fix:** the generic scene-load follow-up path now applies the current-UT cutoff only in the specific post-rewind FLIGHT case with no pending/live restore state, via `ParsekScenario.ShouldUseCurrentUtCutoffForPostRewindFlightLoad(...)` and `LedgerOrchestrator.RecalculateAndPatchForPostRewindFlightLoad(loadedUT)`. That keeps the later FLIGHT `OnLoad` pass aligned with the rewound clock without bypassing normal pending-tree patch deferral or same-branch repeatable-record preservation. The dispatch `Info` log now records every decision input, the other deferred `ParsekScenario.RecalculateAndPatch()` sites were audited as true revert / initial-load full-ledger paths, and `Source/Parsek/InGameTests/RuntimeTests.cs` now contains a manual-only live rewind canary for this exact regression.
 
-**Status:** CLOSED 2026-04-22. Fixed for v0.8.3.
+**Status:** CLOSED 2026-04-23. Fixed for v0.9.0.
 
 ---
 


### PR DESCRIPTION
## Summary
- add a scene-load-specific current-UT recalc path for the post-rewind FLIGHT follow-up load
- preserve existing pending-tree deferral and same-branch repeatable-state behavior instead of routing all scene loads through the rewind-authoritative cutoff path
- close the changelog/todo entry under 0.9.0

## Validation
- dotnet build Source/Parsek/Parsek.csproj
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter RewindUtCutoffTests
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter LedgerOrchestratorTests
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter MilestonePatchingTests

## Notes
- validated headlessly; I did not rerun a live KSP rewind canary in this branch.