### PR TITLE
Bold kerbal names in Mission Outcomes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ All notable changes to Parsek are documented here.
 - Consolidated scattered tunables into a single `Source/Parsek/ParsekConfig.cs`. `DistanceThresholds` moved from its standalone file into the same config file; new top-level static classes `GhostPlayback` (concurrency caps, per-frame throttles, prewarm/hold buffers), `LoopTiming` (loop/cycle periods, boundary epsilon), `WarpThresholds` (FX-suppress / ghost-hide warp levels), and `WatchMode` (grace windows, camera entry defaults, pending-bridge frame budget) own the numbers that used to live inside `GhostPlaybackEngine`, `GhostPlaybackLogic`, `ParsekKSC`, and `WatchModeController` (including the duplicated KSC copy of the concurrent-ghost cap). Behaviour-neutral refactor - every constant keeps its value.
 - `#473` The `Gloops - Ghosts Only` group is now treated as a permanent root group in the Recordings window: no disband `X`, stale parent assignments self-heal back to root, and the group stays pinned above every other root item whenever it has recordings.
 - `#450 B2` Timeline ghost snapshot construction now advances in staged chunks across multiple playback frames instead of instantiating the entire snapshot in one `UpdatePlayback` tick, eliminating the remaining bimodal single-spawn hitch after the B3 lazy-reentry follow-up.
+- Kerbals window Mission Outcomes fold headers now bold only the main kerbal name next to the fold arrow, leaving the arrow and folded mission summary in normal weight.
 
 ### Bug Fixes
 

--- a/Source/Parsek.Tests/KerbalsWindowUITests.cs
+++ b/Source/Parsek.Tests/KerbalsWindowUITests.cs
@@ -817,6 +817,39 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void FormatMissionOutcomeHeaderText_Unfolded_BoldsOnlyKerbalName()
+        {
+            var entries = new List<KerbalsWindowUI.CrewEndStateEntry>
+            {
+                EndStateEntry("Bill Kerman", KerbalEndState.Recovered)
+            };
+
+            string result = KerbalsWindowUI.FormatMissionOutcomeHeaderText(
+                "Bill Kerman", entries, 0, entries.Count, folded: false);
+
+            Assert.Equal("<b>Bill Kerman</b>", result);
+        }
+
+        [Fact]
+        public void FormatMissionOutcomeHeaderText_Folded_BoldsOnlyKerbalName()
+        {
+            var entries = new List<KerbalsWindowUI.CrewEndStateEntry>
+            {
+                EndStateEntry("Jebediah Kerman", KerbalEndState.Recovered),
+                EndStateEntry("Jebediah Kerman", KerbalEndState.Aboard),
+                EndStateEntry("Jebediah Kerman", KerbalEndState.Dead)
+            };
+
+            string result = KerbalsWindowUI.FormatMissionOutcomeHeaderText(
+                "Jebediah Kerman", entries, 0, entries.Count, folded: true);
+
+            Assert.Equal(
+                "<b>Jebediah Kerman</b> (3 missions - 1 Dead, 1 Recovered, 1 Aboard)",
+                result);
+            Assert.DoesNotContain("<b> (3 missions", result);
+        }
+
+        [Fact]
         public void ToggleFold_WhenNotFolded_AddsToSetAndLogsFolded()
         {
             var folded = new HashSet<string>(StringComparer.Ordinal);

--- a/Source/Parsek.Tests/KerbalsWindowUITests.cs
+++ b/Source/Parsek.Tests/KerbalsWindowUITests.cs
@@ -850,6 +850,24 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void FormatMissionOutcomeHeaderText_EscapesKerbalNameRichTextTags()
+        {
+            const string name = "Bill </b><color=red>Kerman";
+            var entries = new List<KerbalsWindowUI.CrewEndStateEntry>
+            {
+                EndStateEntry(name, KerbalEndState.Recovered)
+            };
+
+            string result = KerbalsWindowUI.FormatMissionOutcomeHeaderText(
+                name, entries, 0, entries.Count, folded: true);
+
+            Assert.Equal(
+                "<b>Bill <\u200B/b><\u200Bcolor=red>Kerman</b> (1 mission - 1 Recovered)",
+                result);
+            Assert.DoesNotContain("</b><color=red>", result);
+        }
+
+        [Fact]
         public void ToggleFold_WhenNotFolded_AddsToSetAndLogsFolded()
         {
             var folded = new HashSet<string>(StringComparer.Ordinal);

--- a/Source/Parsek/UI/KerbalsWindowUI.cs
+++ b/Source/Parsek/UI/KerbalsWindowUI.cs
@@ -503,7 +503,7 @@ namespace Parsek
             int end,
             bool folded)
         {
-            string boldName = $"<b>{kerbalName}</b>";
+            string boldName = $"<b>{EscapeRichText(kerbalName)}</b>";
             if (!folded) return boldName;
 
             string summary = FormatKerbalSummary(kerbalName, entries, start, end);
@@ -512,6 +512,12 @@ namespace Parsek
                 return boldName + summary.Substring(kerbalName.Length);
             }
             return boldName + " " + summary;
+        }
+
+        private static string EscapeRichText(string text)
+        {
+            if (string.IsNullOrEmpty(text)) return text ?? "";
+            return text.Replace("<", "<\u200B");
         }
 
         /// <summary>

--- a/Source/Parsek/UI/KerbalsWindowUI.cs
+++ b/Source/Parsek/UI/KerbalsWindowUI.cs
@@ -56,6 +56,7 @@ namespace Parsek
         private GUIStyle aboardStyle;
         private GUIStyle activeChainStyle;
         private GUIStyle displacedStyle;
+        private GUIStyle missionOutcomeHeaderStyle;
         // Toggle button style for tab bar — mirrors CareerStateWindowUI / TimelineWindowUI:
         // the "on" background is copied from GUI.skin.button.active so the selected tab
         // looks visibly pushed in.
@@ -229,6 +230,10 @@ namespace Parsek
             displacedStyle = new GUIStyle(GUI.skin.label)
             {
                 normal = { textColor = new Color(0.5f, 0.5f, 0.5f) }
+            };
+            missionOutcomeHeaderStyle = new GUIStyle(GUI.skin.label)
+            {
+                richText = true
             };
             // Tab bar button: selected tab looks pressed via onNormal.background copied
             // from GUI.skin.button.active.background (matches CareerStateWindowUI and
@@ -487,6 +492,29 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Renders the per-kerbal Mission Outcomes fold header with rich text so only
+        /// the main kerbal name is bold; arrow glyphs and folded summary details stay
+        /// in the normal label weight.
+        /// </summary>
+        internal static string FormatMissionOutcomeHeaderText(
+            string kerbalName,
+            IReadOnlyList<CrewEndStateEntry> entries,
+            int start,
+            int end,
+            bool folded)
+        {
+            string boldName = $"<b>{kerbalName}</b>";
+            if (!folded) return boldName;
+
+            string summary = FormatKerbalSummary(kerbalName, entries, start, end);
+            if (summary.StartsWith(kerbalName, StringComparison.Ordinal))
+            {
+                return boldName + summary.Substring(kerbalName.Length);
+            }
+            return boldName + " " + summary;
+        }
+
+        /// <summary>
         /// Renders a Roster State chain-member subitem row as a single pre-indented
         /// string with a tree-branch glyph. <paramref name="isLast"/> picks between
         /// the "mid" (├─) and "last" (└─) tree characters.
@@ -515,14 +543,17 @@ namespace Parsek
 
                 bool folded = foldedKerbals.Contains(name);
                 string arrow = folded ? FoldedArrow : UnfoldedArrow;
-                string headerText = folded
-                    ? FormatKerbalSummary(name, endStates, i, j)
-                    : name;
+                string headerText = FormatMissionOutcomeHeaderText(
+                    name,
+                    endStates,
+                    i,
+                    j,
+                    folded);
 
-                // Per-kerbal fold row: non-bold label-styled button so the dropdown header
-                // sits visually as a row rather than a sub-heading (RecordingsTableUI uses
-                // the same pattern for its chain blocks).
-                if (GUILayout.Button($"{arrow} {headerText}", GUI.skin.label, GUILayout.ExpandWidth(true)))
+                // Per-kerbal fold row: label-styled button so the dropdown header
+                // sits visually as a row rather than a sub-heading. Rich text is
+                // limited to the main kerbal-name substring.
+                if (GUILayout.Button($"{arrow} {headerText}", missionOutcomeHeaderStyle, GUILayout.ExpandWidth(true)))
                 {
                     ToggleFold(foldedKerbals, name, j - i);
                 }


### PR DESCRIPTION
## Summary
- Bold only the main kerbal name in Kerbals > Mission Outcomes fold headers.
- Keep the fold arrow and folded mission summary at normal label weight.
- Escape kerbal names before inserting them into the rich-text header so tag-like names render literally instead of being parsed as markup.
- Add focused formatter tests and update the 0.8.3 changelog entry.

## Validation
- dotnet test Source\\Parsek.Tests\\Parsek.Tests.csproj --filter FullyQualifiedName~KerbalsWindowUITests (passed: 41/41)
- dotnet test Source\\Parsek.Tests\\Parsek.Tests.csproj --filter FullyQualifiedName!~InjectAllRecordings (passed before follow-up escape fix: 7957/7957)
- dotnet test Source\\Parsek.Tests\\Parsek.Tests.csproj hit environment blocker: InjectAllRecordings refused to purge recordings because KSP.log is locked by another process.
- gpt-5.4 xhigh review found rich-text escaping gap; fixed in 911753b0.
- gpt-5.4 xhigh re-review of only the escaping fix: no findings.

Note: build/test emitted the existing post-build copy warning because the deployed KSP GameData Parsek.dll is locked by the running KSP process, but compilation and the passing test runs completed.