### PR TITLE
Restore hover labels for simple ghost markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- Simple ghost map/tracking-station marker labels now appear on icon hover again, while left-click still pins or unpins the label and non-left clicks continue to pass through to stock handlers.
 - Ballistic orbital-frame storage now normalizes as well as canonicalizes the saved quaternions, so SOI handoffs keep the same represented world attitude instead of drifting when a frozen playback rotation started as a scaled quaternion.
 - Hyperbolic predicted segments now reconstruct true anomaly with a quadrant-safe formula, so parent-body SOI handoffs keep the same boundary state and frozen playback attitude instead of folding the new segment onto the wrong outbound branch.
 - Hyperbolic predicted segments now keep periapsis orientation even when the parent escape orbit is equatorial, so SOI handoffs no longer serialize the parent segment with `argumentOfPeriapsis = 0` and then reconstruct the wrong start state and frozen attitude.

--- a/Source/Parsek.Tests/MapMarkerRendererTests.cs
+++ b/Source/Parsek.Tests/MapMarkerRendererTests.cs
@@ -116,16 +116,17 @@ namespace Parsek.Tests
             Assert.False(MapMarkerRenderer.ToggleSticky("x", null));
         }
 
-        // ghost-label-click-toggle follow-up: visibility is driven exclusively by
-        // sticky. Hover MUST NOT reveal the label — that behavior from the
-        // original #386 ship was explicitly removed. These cases pin the new
-        // contract: the decision table is just `sticky`.
+        // Simple ghost marker labels are transient on hover and persistent when
+        // pinned by click. These cases pin the full decision table.
         [Theory]
-        [InlineData(false, false)]
-        [InlineData(true,  true)]
-        public void ShouldDrawLabel_ReturnsStickyOnly(bool sticky, bool expected)
+        [InlineData(false, false, false)]
+        [InlineData(false, true,  true)]
+        [InlineData(true,  false, true)]
+        [InlineData(true,  true,  true)]
+        public void ShouldDrawLabel_ReturnsHoverOrSticky(
+            bool sticky, bool hover, bool expected)
         {
-            Assert.Equal(expected, MapMarkerRenderer.ShouldDrawLabel(sticky));
+            Assert.Equal(expected, MapMarkerRenderer.ShouldDrawLabel(sticky, hover));
         }
 
         [Fact]

--- a/Source/Parsek/MapMarkerRenderer.cs
+++ b/Source/Parsek/MapMarkerRenderer.cs
@@ -17,10 +17,9 @@ namespace Parsek
     /// taken from the decompiled stock KSP.UI.Screens.Mapview.MapNode logic,
     /// so ghost icons match stock ProtoVessel icons for every VesselType (#387).
     ///
-    /// Label is hidden by default and toggled sticky by left-clicking the
-    /// icon. Hover does not affect visibility (changed from the original #386
-    /// hover-reveal behavior). Non-left clicks pass through so KSP's stock
-    /// map/tracking handlers still see them. The sticky set is keyed by
+    /// Label is hidden by default, revealed while hovering the icon, and
+    /// toggled sticky by left-clicking the icon. Non-left clicks pass through
+    /// so KSP's stock map/tracking handlers still see them. The sticky set is keyed by
     /// recording ID and cleared on scene change. The custom marker is only
     /// drawn when the stock MapNode for the same recording is absent or
     /// suppressed, so there is no double-labeling when a ghost ProtoVessel
@@ -184,17 +183,17 @@ namespace Parsek
             }
             GUI.color = prevColor;
 
-            // Label sticky + click toggle (#386; hover reveal removed per
-            // ghost-label-click-toggle follow-up — left click only so non-left
-            // clicks still reach KSP's stock handlers).
+            // Label hover + sticky click toggle. Left click only so non-left
+            // clicks still reach KSP's stock handlers.
             bool sticky = !string.IsNullOrEmpty(markerKey) && stickyMarkers.Contains(markerKey);
+            bool mouseOver = false;
 
             if (Event.current != null && AllowClickInteraction())
             {
                 Rect hitRect = new Rect(
                     iconRect.x - ClickPadding, iconRect.y - ClickPadding,
                     iconRect.width + ClickPadding * 2, iconRect.height + ClickPadding * 2);
-                bool mouseOver = hitRect.Contains(Event.current.mousePosition);
+                mouseOver = hitRect.Contains(Event.current.mousePosition);
 
                 if (mouseOver
                     && !string.IsNullOrEmpty(markerKey)
@@ -208,7 +207,7 @@ namespace Parsek
                 }
             }
 
-            if (ShouldDrawLabel(sticky))
+            if (ShouldDrawLabel(sticky, mouseOver))
             {
                 labelStyle.normal.textColor = GetLabelColor();
                 GUI.Label(
@@ -219,14 +218,12 @@ namespace Parsek
         }
 
         /// <summary>
-        /// Pure: should the label be drawn given <paramref name="sticky"/>?
-        /// Visibility is driven exclusively by sticky state — hover does NOT
-        /// reveal the label (per ghost-label-click-toggle follow-up). Kept as
+        /// Pure: should the label be drawn given sticky and hover state?
+        /// Sticky pins the label, while hover reveals it transiently. Kept as
         /// an internal helper so the decision table is readable at call sites
-        /// even though its body is trivial, and so the tests can pin the
-        /// "hover is irrelevant" contract.
+        /// and so tests can pin the hover/pin contract.
         /// </summary>
-        internal static bool ShouldDrawLabel(bool sticky) => sticky;
+        internal static bool ShouldDrawLabel(bool sticky, bool hover) => sticky || hover;
 
         /// <summary>
         /// Pure: is this event a label-toggle click (MouseDown + left button)?


### PR DESCRIPTION
Summary:
- Show simple ghost marker labels on hover while preserving click-to-pin behavior.
- Keep non-left click pass-through and update the decision-table unit coverage.
- Add changelog note under 0.8.3.

Validation:
- dotnet test Source\Parsek.Tests\Parsek.Tests.csproj --filter FullyQualifiedName~MapMarkerRendererTests