### PR TITLE
Harden recovery and unowned contract ledger events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,11 +115,15 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- `#552` Vessel recovery funds now tolerate stock firing `onVesselRecovered` before the paired `FundsChanged(VesselRecovery)` event. Parsek defers the recovery request and pairs it when the funds event arrives, eliminating false missing-payout warnings without fabricating zero recoveries.
+- `#553` Untagged contract lifecycle events now forward directly to the ledger even in FLIGHT, so launch-site contract accept/complete events that occur before any Parsek recording owner exists do not get stranded only in `GameStateStore`. Tagged FLIGHT teardown events remain protected by the non-empty recording tag gate.
 - `#557` Initial science and reputation seeds now prefer captured game-state baselines (including legitimate zero values) over live KSP singleton balances. A zero seed is now authoritative instead of being upgraded later from future live state, so rewind/cutoff recalculations no longer turn post-launch science or reputation into UT0 budget.
 - `#558` Rewind/cutoff resource patching now shows cashflow-projected spendable funds and science at the top bar instead of the gross current balance or a blunt full-future spend subtraction. Future spendings only reserve current headroom when the projected balance would dip below the current value, future earnings before those spendings can cover them without inflating current spendability, and reputation stays a current-UT running value with no reservation.
 
 ### Tests
 
+- `#552` Added recovery-pairing regressions for callback-before-funds-event ordering and the no-paired-event deferral path.
+- `#553` Added direct-ledger forwarding predicate coverage for tagged teardown suppression, untagged KSC events, and untagged pre-recording FLIGHT events.
 - `#557` Added a rewind cutoff regression based on the April 23 log package shape: funds stay on the seed-minus-rollout path, while zero baseline science/reputation remain zero even when future science earnings, tech spending, and reputation milestones exist later in the ledger.
 - `#558` Added rewind affordability regressions for science and funds covering future spending reservation and the matching future-earning-before-future-spending case that preserves current headroom.
 - `Bug278FinalizeLimboTests` now pins the orbit-only terminal-body heal path: a leaf with a stale `TerminalOrbitBody` but only orbit-segment evidence heals to the segment body and emits the `PopulateTerminalOrbitFromLastSegment: healed stale cached terminal orbit` log line.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,15 +115,15 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
-- `#552` Vessel recovery funds now tolerate stock firing `onVesselRecovered` before the paired `FundsChanged(VesselRecovery)` event. Parsek defers the recovery request and pairs it when the funds event arrives, eliminating false missing-payout warnings without fabricating zero recoveries.
-- `#553` Untagged contract lifecycle events now forward directly to the ledger even in FLIGHT, so launch-site contract accept/complete events that occur before any Parsek recording owner exists do not get stranded only in `GameStateStore`. Tagged FLIGHT teardown events remain protected by the non-empty recording tag gate.
+- `#552` Vessel recovery funds now tolerate stock firing `onVesselRecovered` before the paired `FundsChanged(VesselRecovery)` event. Parsek defers the recovery request and pairs it when the funds event arrives, preferring vessel-name matches over nearest-UT, warning on ambiguous ties, and evicting unclaimed requests on scene switches, rewind boundaries, and save loads.
+- `#553` Untagged lifecycle events (contract accept/complete/fail/cancel, tech, part purchase, crew hire, milestone, strategy activate/deactivate, facility upgrade) now forward directly to the ledger even in FLIGHT, so launch-site events that occur before any Parsek recording owner exists do not get stranded only in `GameStateStore`. Tagged FLIGHT teardown events remain protected by the non-empty recording tag gate.
 - `#557` Initial science and reputation seeds now prefer captured game-state baselines (including legitimate zero values) over live KSP singleton balances. A zero seed is now authoritative instead of being upgraded later from future live state, so rewind/cutoff recalculations no longer turn post-launch science or reputation into UT0 budget.
 - `#558` Rewind/cutoff resource patching now shows cashflow-projected spendable funds and science at the top bar instead of the gross current balance or a blunt full-future spend subtraction. Future spendings only reserve current headroom when the projected balance would dip below the current value, future earnings before those spendings can cover them without inflating current spendability, and reputation stays a current-UT running value with no reservation.
 
 ### Tests
 
-- `#552` Added recovery-pairing regressions for callback-before-funds-event ordering and the no-paired-event deferral path.
-- `#553` Added direct-ledger forwarding predicate coverage for tagged teardown suppression, untagged KSC events, and untagged pre-recording FLIGHT events.
+- `#552` Added recovery-pairing regressions for callback-before-funds-event ordering, the no-paired-event deferral path, vessel-name-preferred pairing over nearest-UT, ambiguous-tie warning, lifecycle-boundary staleness eviction, and queue-overflow threshold warning.
+- `#553` Added direct-ledger forwarding predicate coverage for tagged teardown suppression, untagged KSC events, and untagged pre-recording FLIGHT events across tech, part-purchase, crew-hire, milestone, strategy activate/deactivate, and facility upgrade handlers, plus an evt.recordingId-vs-resolver drift test.
 - `#557` Added a rewind cutoff regression based on the April 23 log package shape: funds stay on the seed-minus-rollout path, while zero baseline science/reputation remain zero even when future science earnings, tech spending, and reputation milestones exist later in the ledger.
 - `#558` Added rewind affordability regressions for science and funds covering future spending reservation and the matching future-earning-before-future-spending case that preserves current headroom.
 - `Bug278FinalizeLimboTests` now pins the orbit-only terminal-body heal path: a leaf with a stale `TerminalOrbitBody` but only orbit-segment evidence heals to the segment body and emits the `PopulateTerminalOrbitFromLastSegment: healed stale cached terminal orbit` log line.

--- a/Source/Parsek.Tests/DiscardFateTests.cs
+++ b/Source/Parsek.Tests/DiscardFateTests.cs
@@ -335,8 +335,7 @@ namespace Parsek.Tests
         //   (a) !inFlight && !midSwitch && !flightAlive && tag != "" — stale tag with no live flight
         //       (flightAlive gates out legitimate FLIGHT->KSC recovery windows where Instance lingers).
         //   (b) inFlight && tag == "" && HasLiveRecorder()
-        //       — in-flight empty tag with live recorder (needs ParsekFlight.Instance, not testable
-        //         from xUnit; covered by branch (a) plus the no-warn negative case below).
+        //       — in-flight empty tag with live recorder (covered via the HasLiveRecorder seam).
 
         [Fact]
         public void DriftWarn_OutsideFlight_ResolverReturnsTag_LogsWarn()
@@ -625,11 +624,9 @@ namespace Parsek.Tests
         }
 
         // --- #16: FLIGHT -> SPACECENTER teardown window does NOT leak the tagged
-        // event to the ledger via OnKscSpending. The test forces the scene to
-        // SPACECENTER after tagging the event in FLIGHT, then drives a contract
-        // completion handler that would hit OnKscSpending. With the #431 gate
-        // (ResolveCurrentRecordingTag non-empty → skip), the ledger write is
-        // suppressed and the tagged event rides the recording's commit/discard fate.
+        // event to the ledger via OnKscSpending, while untagged pre-recording FLIGHT
+        // events do get a direct ledger path when no live recorder exists because no
+        // later recording commit can own them.
         //
         // Full coverage of the live teardown also needs an in-game test — see the
         // "GameState" category under InGameTests/RuntimeTests.cs, as ParsekFlight.Instance
@@ -646,23 +643,37 @@ namespace Parsek.Tests
             var evt = MakeEvent(GameStateEventType.ContractCompleted, "guid-teardown", 100.0);
             GameStateRecorder.Emit(ref evt, "teardown-test");
 
-            // The #431 gate guards every `OnKscSpending(evt)` call:
-            //    if (!IsFlightScene() && string.IsNullOrEmpty(ResolveCurrentRecordingTag()))
-            //        LedgerOrchestrator.OnKscSpending(evt);
-            // We assert the guard condition here rather than driving a GameEvents
+            // We assert the forwarding predicate here rather than driving a GameEvents
             // subscription (which would need a full Contract object). The resolver
             // returns non-empty, so the gate skips the ledger forward.
-            bool wouldForward = !(HighLogic.LoadedScene == GameScenes.FLIGHT)
-                && string.IsNullOrEmpty(GameStateRecorder.ResolveCurrentRecordingTag());
+            bool wouldForward = GameStateRecorder.ShouldForwardDirectLedgerEvent(
+                evt.recordingId,
+                GameStateRecorder.HasLiveRecorder());
             Assert.False(wouldForward,
                 "Gate must suppress ledger forward when the event was tagged during teardown.");
 
             // And conversely: a true KSC event with an empty resolver passes the gate.
             GameStateRecorder.TagResolverForTesting = () => "";
-            bool wouldForwardKsc = !(HighLogic.LoadedScene == GameScenes.FLIGHT)
-                && string.IsNullOrEmpty(GameStateRecorder.ResolveCurrentRecordingTag());
+            GameStateRecorder.HasLiveRecorderProviderForTesting = () => false;
+            bool wouldForwardKsc = GameStateRecorder.ShouldForwardDirectLedgerEvent(
+                GameStateRecorder.ResolveCurrentRecordingTag(),
+                GameStateRecorder.HasLiveRecorder());
             Assert.True(wouldForwardKsc,
                 "Genuine KSC events (no live recorder, empty tag) must still reach the ledger.");
+
+            HighLogic.LoadedScene = GameScenes.FLIGHT;
+            bool wouldForwardPreRecordingFlight = GameStateRecorder.ShouldForwardDirectLedgerEvent(
+                GameStateRecorder.ResolveCurrentRecordingTag(),
+                GameStateRecorder.HasLiveRecorder());
+            Assert.True(wouldForwardPreRecordingFlight,
+                "Untagged pre-recording FLIGHT events have no commit path and must reach the ledger directly.");
+
+            GameStateRecorder.HasLiveRecorderProviderForTesting = () => true;
+            bool wouldForwardTagDrift = GameStateRecorder.ShouldForwardDirectLedgerEvent(
+                GameStateRecorder.ResolveCurrentRecordingTag(),
+                GameStateRecorder.HasLiveRecorder());
+            Assert.False(wouldForwardTagDrift,
+                "An empty tag while a live recorder exists is tag drift, not an ownerless event.");
         }
     }
 }

--- a/Source/Parsek.Tests/DiscardFateTests.cs
+++ b/Source/Parsek.Tests/DiscardFateTests.cs
@@ -675,5 +675,174 @@ namespace Parsek.Tests
             Assert.False(wouldForwardTagDrift,
                 "An empty tag while a live recorder exists is tag drift, not an ownerless event.");
         }
+
+        // --- Review follow-up: #553 scope expansion. The ShouldForwardDirectLedgerEvent
+        // predicate was originally threaded only into the four contract handlers. Tech,
+        // part-purchase, crew-hire, milestone, strategy (activate/deactivate), and
+        // facility-upgrade handlers now use the same gate — same reasoning applies:
+        // untagged pre-recording FLIGHT events have no later commit-time owner and must
+        // reach the ledger directly. Each newly-gated handler emits an event through
+        // Emit() which stamps evt.recordingId from the tag resolver, then checks the
+        // predicate against that recordingId + HasLiveRecorder(). These tests pin the
+        // predicate decisions each handler would make in the three canonical scenarios:
+        // (a) tagged teardown — must NOT forward; (b) untagged KSC — must forward;
+        // (c) untagged pre-recording FLIGHT — must forward.
+
+        private static void AssertPredicatePinsAllThreeScenarios(GameStateEventType type, string key)
+        {
+            // (a) tagged teardown in SPACECENTER: tag resolver returns non-empty id
+            // because ParsekFlight.Instance is still alive during FLIGHT -> KSC
+            // teardown. The emitted event carries recordingId = the teardown tag.
+            GameStateRecorder.TagResolverForTesting = () => "rec-teardown";
+            HighLogic.LoadedScene = GameScenes.SPACECENTER;
+            var evtTeardown = MakeEvent(type, key, 100.0);
+            GameStateRecorder.Emit(ref evtTeardown, "predicate-pin-teardown");
+            bool teardownWouldForward = GameStateRecorder.ShouldForwardDirectLedgerEvent(
+                evtTeardown.recordingId,
+                GameStateRecorder.HasLiveRecorder());
+            Assert.False(teardownWouldForward,
+                $"{type}: tagged teardown event must NOT reach the ledger via direct forward.");
+
+            // (b) untagged KSC event: no live recorder, empty tag — classic
+            // #405 KSC-only flow, must forward.
+            GameStateRecorder.TagResolverForTesting = () => "";
+            GameStateRecorder.HasLiveRecorderProviderForTesting = () => false;
+            HighLogic.LoadedScene = GameScenes.SPACECENTER;
+            var evtKsc = MakeEvent(type, key, 200.0);
+            GameStateRecorder.Emit(ref evtKsc, "predicate-pin-ksc");
+            bool kscWouldForward = GameStateRecorder.ShouldForwardDirectLedgerEvent(
+                evtKsc.recordingId,
+                GameStateRecorder.HasLiveRecorder());
+            Assert.True(kscWouldForward,
+                $"{type}: untagged KSC event must reach the ledger via direct forward.");
+
+            // (c) untagged pre-recording FLIGHT: empty tag, no live recorder —
+            // the #553 expansion case. Must forward because no later commit path
+            // can own this event.
+            GameStateRecorder.TagResolverForTesting = () => "";
+            GameStateRecorder.HasLiveRecorderProviderForTesting = () => false;
+            HighLogic.LoadedScene = GameScenes.FLIGHT;
+            var evtFlight = MakeEvent(type, key, 300.0);
+            GameStateRecorder.Emit(ref evtFlight, "predicate-pin-flight");
+            bool flightWouldForward = GameStateRecorder.ShouldForwardDirectLedgerEvent(
+                evtFlight.recordingId,
+                GameStateRecorder.HasLiveRecorder());
+            Assert.True(flightWouldForward,
+                $"{type}: untagged pre-recording FLIGHT event must reach the ledger via direct forward.");
+
+            // (d) empty tag but a live recorder exists — tag drift, not ownerless.
+            // Must NOT forward so the ledger doesn't gain a null-owner action.
+            GameStateRecorder.TagResolverForTesting = () => "";
+            GameStateRecorder.HasLiveRecorderProviderForTesting = () => true;
+            HighLogic.LoadedScene = GameScenes.FLIGHT;
+            var evtDrift = MakeEvent(type, key, 400.0);
+            GameStateRecorder.Emit(ref evtDrift, "predicate-pin-drift");
+            bool driftWouldForward = GameStateRecorder.ShouldForwardDirectLedgerEvent(
+                evtDrift.recordingId,
+                GameStateRecorder.HasLiveRecorder());
+            Assert.False(driftWouldForward,
+                $"{type}: empty tag with live recorder is tag drift, direct forward must be suppressed.");
+        }
+
+        [Fact]
+        public void TechResearched_PredicateGateMatchesContractHandlers()
+        {
+            AssertPredicatePinsAllThreeScenarios(GameStateEventType.TechResearched, "node-part-upgrade");
+        }
+
+        [Fact]
+        public void PartPurchased_PredicateGateMatchesContractHandlers()
+        {
+            AssertPredicatePinsAllThreeScenarios(GameStateEventType.PartPurchased, "liquidEngineMini");
+        }
+
+        [Fact]
+        public void CrewHired_PredicateGateMatchesContractHandlers()
+        {
+            AssertPredicatePinsAllThreeScenarios(GameStateEventType.CrewHired, "Jebediah Kerman");
+        }
+
+        [Fact]
+        public void MilestoneAchieved_PredicateGateMatchesContractHandlers()
+        {
+            AssertPredicatePinsAllThreeScenarios(GameStateEventType.MilestoneAchieved, "Kerbin/FirstLaunch");
+        }
+
+        [Fact]
+        public void StrategyActivated_PredicateGateMatchesContractHandlers()
+        {
+            AssertPredicatePinsAllThreeScenarios(GameStateEventType.StrategyActivated, "AggressiveNegotiations");
+        }
+
+        [Fact]
+        public void StrategyDeactivated_PredicateGateMatchesContractHandlers()
+        {
+            AssertPredicatePinsAllThreeScenarios(GameStateEventType.StrategyDeactivated, "AggressiveNegotiations");
+        }
+
+        [Fact]
+        public void FacilityUpgraded_PredicateGateMatchesContractHandlers()
+        {
+            AssertPredicatePinsAllThreeScenarios(GameStateEventType.FacilityUpgraded, "SPH");
+        }
+
+        // --- Review follow-up (Task 5): pin that the live handlers key off
+        // evt.recordingId (the value stamped by Emit at capture time) rather than
+        // ResolveCurrentRecordingTag() (which is a re-read at the forwarding-decision
+        // moment and can drift if ParsekFlight.Instance teardown races the event).
+        // The difference matters during FLIGHT -> KSC teardown: Emit captures the
+        // outgoing recording's id on the event, but a later ResolveCurrentRecordingTag()
+        // call can return the fresh SPACECENTER empty tag and flip the predicate to
+        // "forward" — which is exactly what #431 was intended to prevent.
+        [Fact]
+        public void DirectForwardingPredicate_UsesEventRecordingId_NotLiveTagResolver()
+        {
+            // Arrange: event was captured while the recorder was live on "rec-teardown"
+            // (tag stamped by Emit). Then the teardown proceeds and by the time the
+            // forwarding decision runs, the tag resolver already reads empty — but
+            // HasLiveRecorderProviderForTesting still returns true (ParsekFlight
+            // lingers a frame).
+            GameStateRecorder.TagResolverForTesting = () => "rec-teardown";
+            HighLogic.LoadedScene = GameScenes.SPACECENTER;
+            var evt = MakeEvent(GameStateEventType.ContractAccepted, "guid-late", 100.0);
+            GameStateRecorder.Emit(ref evt, "late-teardown");
+            Assert.Equal("rec-teardown", evt.recordingId);
+
+            // Now flip the resolver to empty, as if teardown advanced one frame.
+            GameStateRecorder.TagResolverForTesting = () => "";
+            GameStateRecorder.HasLiveRecorderProviderForTesting = () => true;
+
+            // If the handlers keyed off ResolveCurrentRecordingTag(), the second
+            // argument would be "" + HasLiveRecorder()=true => tag drift => !forward.
+            // If they key off evt.recordingId (what production code does), the
+            // argument is "rec-teardown" which short-circuits to false anyway. Both
+            // paths agree on "do not forward" in this scenario, but the LIVE handler
+            // must pass evt.recordingId — verify by constructing an asymmetric case:
+            //
+            // Make the resolver return a DIFFERENT non-empty tag. If a handler wrongly
+            // used ResolveCurrentRecordingTag(), it would still see non-empty and
+            // suppress (same outcome here). The asymmetric failure mode is in the
+            // OTHER direction: resolver empty, evt.recordingId non-empty. A buggy
+            // handler reading the resolver would forward (empty + no live recorder
+            // reflects the new scene). Simulate that:
+            GameStateRecorder.TagResolverForTesting = () => "";
+            GameStateRecorder.HasLiveRecorderProviderForTesting = () => false;
+
+            // The event still carries its captured id.
+            bool predicateWithCapturedId = GameStateRecorder.ShouldForwardDirectLedgerEvent(
+                evt.recordingId,
+                GameStateRecorder.HasLiveRecorder());
+            Assert.False(predicateWithCapturedId,
+                "Handler passing evt.recordingId='rec-teardown' must see !forward.");
+
+            // If a handler wrongly re-resolved the tag at the decision moment, it
+            // would pass "" and get a true.
+            bool predicateWithResolvedTag = GameStateRecorder.ShouldForwardDirectLedgerEvent(
+                GameStateRecorder.ResolveCurrentRecordingTag(),
+                GameStateRecorder.HasLiveRecorder());
+            Assert.True(predicateWithResolvedTag,
+                "Sanity check: re-resolving at decision time would wrongly allow forward, " +
+                "proving the two inputs disagree. Production handlers MUST pass evt.recordingId.");
+        }
     }
 }

--- a/Source/Parsek.Tests/GameStateRecorderLedgerTests.cs
+++ b/Source/Parsek.Tests/GameStateRecorderLedgerTests.cs
@@ -406,19 +406,96 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void OnVesselRecoveryFunds_NoPairedFundsEvent_LogsWarnAndDoesNotAdd()
+        public void OnVesselRecoveryFunds_NoPairedFundsEvent_DefersAndDoesNotAdd()
         {
-            // Defensive guard: if onVesselRecovered fires but no FundsChanged(VesselRecovery)
-            // event sits within the epsilon window (e.g. corrupt event flow, mod conflict),
-            // the routing path WARNs and skips rather than fabricating a zero earning.
+            // KSP can fire onVesselRecovered before FundsChanged(VesselRecovery) in the
+            // post-flight KSC recovery path. The routing path must wait for the paired
+            // resource event rather than fabricating a zero earning or logging a false WARN.
             int before = Ledger.Actions.Count;
             LedgerOrchestrator.OnVesselRecoveryFunds(7000.0, "Mystery Probe", fromTrackingStation: true);
 
             Assert.Equal(before, Ledger.Actions.Count);
+            Assert.Equal(1, LedgerOrchestrator.PendingRecoveryFundsCountForTesting);
             Assert.Contains(logLines, l =>
                 l.Contains("[LedgerOrchestrator]") &&
-                l.Contains("no paired FundsChanged(VesselRecovery) event") &&
+                l.Contains("deferred pairing") &&
                 l.Contains("Mystery Probe"));
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("no paired FundsChanged(VesselRecovery) event"));
+        }
+
+        [Fact]
+        public void OnVesselRecoveryFunds_CallbackBeforeFundsEvent_PairsWhenEventIsRecorded()
+        {
+            LedgerOrchestrator.OnVesselRecoveryFunds(149.53, "r0", fromTrackingStation: false);
+            Assert.Equal(1, LedgerOrchestrator.PendingRecoveryFundsCountForTesting);
+
+            var evt = new GameStateEvent
+            {
+                ut = 149.53,
+                eventType = GameStateEventType.FundsChanged,
+                key = LedgerOrchestrator.VesselRecoveryReasonKey,
+                valueBefore = 38990.0,
+                valueAfter = 42795.0
+            };
+            GameStateStore.AddEvent(ref evt);
+            LedgerOrchestrator.OnRecoveryFundsEventRecorded(evt);
+
+            Assert.Equal(0, LedgerOrchestrator.PendingRecoveryFundsCountForTesting);
+            var match = Ledger.Actions.FirstOrDefault(a =>
+                a.Type == GameActionType.FundsEarning &&
+                a.FundsSource == FundsEarningSource.Recovery &&
+                System.Math.Abs(a.UT - 149.53) < 0.01);
+            Assert.NotNull(match);
+            Assert.Equal(3805f, match.FundsAwarded);
+            Assert.Contains(logLines, l =>
+                l.Contains("[LedgerOrchestrator]") &&
+                l.Contains("VesselRecovery funds patched") &&
+                l.Contains("amount=3805"));
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("no paired FundsChanged(VesselRecovery) event"));
+        }
+
+        [Fact]
+        public void OnVesselRecoveryFunds_DeferredSameNameWithinEpsilon_PairToDistinctEvents()
+        {
+            LedgerOrchestrator.OnVesselRecoveryFunds(3000.00, "Debris", fromTrackingStation: true);
+            LedgerOrchestrator.OnVesselRecoveryFunds(3000.04, "Debris", fromTrackingStation: true);
+            Assert.Equal(2, LedgerOrchestrator.PendingRecoveryFundsCountForTesting);
+
+            var evtA = new GameStateEvent
+            {
+                ut = 3000.00,
+                eventType = GameStateEventType.FundsChanged,
+                key = LedgerOrchestrator.VesselRecoveryReasonKey,
+                valueBefore = 1000.0,
+                valueAfter = 1100.0
+            };
+            GameStateStore.AddEvent(ref evtA);
+            LedgerOrchestrator.OnRecoveryFundsEventRecorded(evtA);
+            Assert.Equal(1, LedgerOrchestrator.PendingRecoveryFundsCountForTesting);
+
+            var evtB = new GameStateEvent
+            {
+                ut = 3000.04,
+                eventType = GameStateEventType.FundsChanged,
+                key = LedgerOrchestrator.VesselRecoveryReasonKey,
+                valueBefore = 1100.0,
+                valueAfter = 1800.0
+            };
+            GameStateStore.AddEvent(ref evtB);
+            LedgerOrchestrator.OnRecoveryFundsEventRecorded(evtB);
+
+            Assert.Equal(0, LedgerOrchestrator.PendingRecoveryFundsCountForTesting);
+            var recoveries = Ledger.Actions
+                .Where(a => a.Type == GameActionType.FundsEarning && a.FundsSource == FundsEarningSource.Recovery)
+                .OrderBy(a => a.UT)
+                .ToList();
+
+            Assert.Equal(2, recoveries.Count);
+            Assert.Equal(100f, recoveries[0].FundsAwarded);
+            Assert.Equal(700f, recoveries[1].FundsAwarded);
+            Assert.Equal(800f, recoveries.Sum(r => r.FundsAwarded));
         }
 
         [Fact]

--- a/Source/Parsek.Tests/GameStateRecorderLedgerTests.cs
+++ b/Source/Parsek.Tests/GameStateRecorderLedgerTests.cs
@@ -932,5 +932,158 @@ namespace Parsek.Tests
 
             Assert.Equal(before, after);
         }
+
+        // --- Review follow-up: staleness eviction for pendingRecoveryFunds. Unmatched
+        // recovery callbacks that never receive a paired FundsChanged(VesselRecovery)
+        // event must be drained at lifecycle boundaries and fire a WARN listing every
+        // unclaimed entry so missing-payout bugs stay visible.
+        [Fact]
+        public void FlushStalePendingRecoveryFunds_EvictsUnclaimedEntriesWithWarn()
+        {
+            LedgerOrchestrator.OnVesselRecoveryFunds(1000.0, "LeakyProbe", fromTrackingStation: false);
+            LedgerOrchestrator.OnVesselRecoveryFunds(1050.0, "LeakyRover", fromTrackingStation: true);
+            Assert.Equal(2, LedgerOrchestrator.PendingRecoveryFundsCountForTesting);
+
+            LedgerOrchestrator.FlushStalePendingRecoveryFunds("scene switch");
+
+            Assert.Equal(0, LedgerOrchestrator.PendingRecoveryFundsCountForTesting);
+            Assert.Contains(logLines, l =>
+                l.Contains("[LedgerOrchestrator]") &&
+                l.Contains("FlushStalePendingRecoveryFunds") &&
+                l.Contains("scene switch") &&
+                l.Contains("evicting 2") &&
+                l.Contains("LeakyProbe") &&
+                l.Contains("LeakyRover"));
+        }
+
+        [Fact]
+        public void FlushStalePendingRecoveryFunds_EmptyQueue_IsSilentNoOp()
+        {
+            // A scene switch with no pending requests should NOT emit the WARN.
+            Assert.Equal(0, LedgerOrchestrator.PendingRecoveryFundsCountForTesting);
+            LedgerOrchestrator.FlushStalePendingRecoveryFunds("scene switch");
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("FlushStalePendingRecoveryFunds"));
+        }
+
+        [Fact]
+        public void OnVesselRecoveryFunds_QueueOverThreshold_EmitsWarn()
+        {
+            // Safety-net trip when lifecycle boundaries miss: queue past the threshold
+            // should emit a WARN identifying the latest deferred request.
+            for (int i = 0; i < LedgerOrchestrator.PendingRecoveryFundsStaleThreshold; i++)
+            {
+                LedgerOrchestrator.OnVesselRecoveryFunds(
+                    2000.0 + i * 0.001, "DebrisBatch" + i, fromTrackingStation: true);
+            }
+
+            // At threshold, no warn yet.
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("pending queue exceeded threshold"));
+
+            LedgerOrchestrator.OnVesselRecoveryFunds(
+                2000.5, "LatestDebris", fromTrackingStation: true);
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[LedgerOrchestrator]") &&
+                l.Contains("pending queue exceeded threshold") &&
+                l.Contains("LatestDebris"));
+        }
+
+        // --- Review follow-up: tighter recovery-fund pairing. When two pending
+        // requests sit at the same UT with different vessel names, a FundsChanged
+        // event carrying a vessel name (via evt.detail) must prefer the name match
+        // instead of just picking nearest-UT.
+        [Fact]
+        public void OnRecoveryFundsEventRecorded_VesselNameMatch_PreferredOverNearestUT()
+        {
+            LedgerOrchestrator.OnVesselRecoveryFunds(3000.0, "Rocket A", fromTrackingStation: false);
+            LedgerOrchestrator.OnVesselRecoveryFunds(3000.0, "Rocket B", fromTrackingStation: false);
+            Assert.Equal(2, LedgerOrchestrator.PendingRecoveryFundsCountForTesting);
+
+            // Event tagged with "Rocket A" in detail should pair the A pending
+            // request even though both sit at identical UT.
+            var evt = new GameStateEvent
+            {
+                ut = 3000.0,
+                eventType = GameStateEventType.FundsChanged,
+                key = LedgerOrchestrator.VesselRecoveryReasonKey,
+                detail = "Rocket A",
+                valueBefore = 100.0,
+                valueAfter = 1100.0
+            };
+            GameStateStore.AddEvent(ref evt);
+            LedgerOrchestrator.OnRecoveryFundsEventRecorded(evt);
+
+            // One request remains (Rocket B).
+            Assert.Equal(1, LedgerOrchestrator.PendingRecoveryFundsCountForTesting);
+            // The pairing log identifies the vessel name used for the successful
+            // pairing — proof that "Rocket A" (not "Rocket B") won this tier-1 pass.
+            Assert.Contains(logLines, l =>
+                l.Contains("[LedgerOrchestrator]") &&
+                l.Contains("VesselRecovery funds patched") &&
+                l.Contains("vessel='Rocket A'"));
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("VesselRecovery funds patched") &&
+                l.Contains("vessel='Rocket B'"));
+        }
+
+        [Fact]
+        public void OnRecoveryFundsEventRecorded_VesselNameMatchTie_LogsWarn()
+        {
+            // Two same-named same-UT pending requests: after name-match filtering they
+            // still tie on distance=0. Pairing still succeeds (first in list order) but
+            // the tie must be logged so the ambiguity is visible.
+            LedgerOrchestrator.OnVesselRecoveryFunds(4000.0, "Twin Probe", fromTrackingStation: false);
+            LedgerOrchestrator.OnVesselRecoveryFunds(4000.0, "Twin Probe", fromTrackingStation: false);
+
+            var evt = new GameStateEvent
+            {
+                ut = 4000.0,
+                eventType = GameStateEventType.FundsChanged,
+                key = LedgerOrchestrator.VesselRecoveryReasonKey,
+                detail = "Twin Probe",
+                valueBefore = 200.0,
+                valueAfter = 700.0
+            };
+            GameStateStore.AddEvent(ref evt);
+            LedgerOrchestrator.OnRecoveryFundsEventRecorded(evt);
+
+            Assert.Equal(1, LedgerOrchestrator.PendingRecoveryFundsCountForTesting);
+            Assert.Contains(logLines, l =>
+                l.Contains("[LedgerOrchestrator]") &&
+                l.Contains("multiple pending requests tied") &&
+                l.Contains("name-match") &&
+                l.Contains("Twin Probe"));
+        }
+
+        [Fact]
+        public void OnRecoveryFundsEventRecorded_NoNameMatchFallsBackToNearestUT()
+        {
+            // Event tagged with a name that doesn't match any pending request: the
+            // legacy nearest-UT fallback still pairs the closest one, preserving the
+            // #444 contract for events without a usable name hint.
+            LedgerOrchestrator.OnVesselRecoveryFunds(5000.0, "Alpha", fromTrackingStation: false);
+            LedgerOrchestrator.OnVesselRecoveryFunds(5000.1, "Beta", fromTrackingStation: false);
+
+            var evt = new GameStateEvent
+            {
+                ut = 5000.0,
+                eventType = GameStateEventType.FundsChanged,
+                key = LedgerOrchestrator.VesselRecoveryReasonKey,
+                detail = "Gamma", // unmatched
+                valueBefore = 500.0,
+                valueAfter = 1500.0
+            };
+            GameStateStore.AddEvent(ref evt);
+            LedgerOrchestrator.OnRecoveryFundsEventRecorded(evt);
+
+            Assert.Equal(1, LedgerOrchestrator.PendingRecoveryFundsCountForTesting);
+            // Alpha (ut=5000.0) is nearest to evt.ut=5000.0 so it wins the fallback.
+            Assert.Contains(logLines, l =>
+                l.Contains("[LedgerOrchestrator]") &&
+                l.Contains("VesselRecovery funds patched") &&
+                l.Contains("vessel='Alpha'"));
+        }
     }
 }

--- a/Source/Parsek/GameActions/LedgerOrchestrator.cs
+++ b/Source/Parsek/GameActions/LedgerOrchestrator.cs
@@ -1614,6 +1614,7 @@ namespace Parsek
             // ledger file) must NOT falsely register as "MigrateOldSaveEvents output".
             migrateOldSaveEventsRanThisLoad = false;
             consumedRecoveryEventKeys.Clear();
+            pendingRecoveryFunds.Clear();
 
             // Reconcile first — prunes orphaned actions from the existing ledger.
             // On empty ledger (old save), this is a no-op.
@@ -3240,6 +3241,16 @@ namespace Parsek
         /// </summary>
         private static readonly HashSet<string> consumedRecoveryEventKeys = new HashSet<string>();
 
+        private struct PendingRecoveryFundsRequest
+        {
+            public double Ut;
+            public string VesselName;
+            public bool FromTrackingStation;
+        }
+
+        private static readonly List<PendingRecoveryFundsRequest> pendingRecoveryFunds =
+            new List<PendingRecoveryFundsRequest>();
+
         /// <summary>
         /// Stable fingerprint for a FundsChanged(VesselRecovery) event. Internal for
         /// direct testability.
@@ -3313,6 +3324,59 @@ namespace Parsek
             }
 
             return false;
+        }
+
+        private static void AddPendingRecoveryFundsRequest(
+            double ut, string vesselName, bool fromTrackingStation)
+        {
+            // Do not fuzzy-dedup pending callbacks. Bulk debris recovery can deliver
+            // multiple same-named callbacks in the same UT epsilon before any paired
+            // FundsChanged(VesselRecovery) event has reached the recorder; the event
+            // dedup fingerprint is applied when each request is actually paired.
+            pendingRecoveryFunds.Add(new PendingRecoveryFundsRequest
+            {
+                Ut = ut,
+                VesselName = vesselName,
+                FromTrackingStation = fromTrackingStation
+            });
+        }
+
+        internal static int PendingRecoveryFundsCountForTesting => pendingRecoveryFunds.Count;
+
+        internal static void OnRecoveryFundsEventRecorded(GameStateEvent evt)
+        {
+            if (evt.eventType != GameStateEventType.FundsChanged)
+                return;
+            if (evt.key != VesselRecoveryReasonKey)
+                return;
+
+            Initialize();
+            if (pendingRecoveryFunds.Count == 0)
+                return;
+
+            int bestIndex = -1;
+            double bestDistance = double.MaxValue;
+            for (int i = 0; i < pendingRecoveryFunds.Count; i++)
+            {
+                double distance = Math.Abs(pendingRecoveryFunds[i].Ut - evt.ut);
+                if (distance > VesselRecoveryEventEpsilonSeconds) continue;
+                if (distance >= bestDistance) continue;
+
+                bestIndex = i;
+                bestDistance = distance;
+            }
+
+            if (bestIndex < 0)
+                return;
+
+            var request = pendingRecoveryFunds[bestIndex];
+            if (TryAddVesselRecoveryFundsAction(
+                    request.Ut,
+                    request.VesselName,
+                    request.FromTrackingStation))
+            {
+                pendingRecoveryFunds.RemoveAt(bestIndex);
+            }
         }
 
         /// <summary>
@@ -3428,7 +3492,9 @@ namespace Parsek
         /// <para>This routes the recovery payout into the ledger as a real-time
         /// <see cref="GameActionType.FundsEarning"/> action with <see cref="FundsEarningSource.Recovery"/>.
         /// The amount comes from the matching <see cref="GameStateEventType.FundsChanged"/> event
-        /// in <see cref="GameStateStore"/>; the recording tag is the committed recording whose
+        /// in <see cref="GameStateStore"/>. If stock fires <c>onVesselRecovered</c> before
+        /// the funds event, the request is deferred and paired when
+        /// <see cref="OnRecoveryFundsEventRecorded"/> sees the event. The recording tag is the committed recording whose
         /// <c>[StartUT, EndUT]</c> brackets <paramref name="ut"/> (preferred), then the most
         /// recent same-named flight that ended at or before <paramref name="ut"/>, then the
         /// global latest by EndUT. Falls back to <c>null</c> when no real recording matches.</para>
@@ -3470,9 +3536,20 @@ namespace Parsek
                 return;
             }
 
+            if (TryAddVesselRecoveryFundsAction(ut, vesselName, fromTrackingStation))
+                return;
+
+            AddPendingRecoveryFundsRequest(ut, vesselName, fromTrackingStation);
+            ParsekLog.Verbose(Tag,
+                $"OnVesselRecoveryFunds: deferred pairing for vessel '{vesselName}' " +
+                $"at ut={ut.ToString("F1", CultureInfo.InvariantCulture)} until FundsChanged(VesselRecovery) is recorded");
+        }
+
+        private static bool TryAddVesselRecoveryFundsAction(double ut, string vesselName, bool fromTrackingStation)
+        {
             // Locate the paired FundsChanged(VesselRecovery) event. KSP fires the funds change
-            // immediately before onVesselRecovered, so it should already be in the store. We
-            // search by reason key (TransactionReasons.VesselRecovery.ToString() == "VesselRecovery"
+            // before or shortly after onVesselRecovered depending on the stock recovery path.
+            // Search by reason key (TransactionReasons.VesselRecovery.ToString() == "VesselRecovery"
             // — see GameStateRecorder.OnFundsChanged where the key is written) within a small
             // UT window, and skip dedup fingerprints already consumed by an earlier recovery
             // call to protect against bulk-recover-debris double-latching.
@@ -3483,12 +3560,7 @@ namespace Parsek
                     out GameStateEvent matched,
                     out string dedupKey))
             {
-                ParsekLog.Warn(Tag,
-                    $"OnVesselRecoveryFunds: no paired FundsChanged(VesselRecovery) event " +
-                    $"within {VesselRecoveryEventEpsilonSeconds.ToString("F1", CultureInfo.InvariantCulture)}s " +
-                    $"of ut={ut.ToString("F1", CultureInfo.InvariantCulture)} " +
-                    $"for vessel '{vesselName}' — funds gap will not be patched");
-                return;
+                return false;
             }
 
             double delta = matched.valueAfter - matched.valueBefore;
@@ -3498,7 +3570,7 @@ namespace Parsek
                     $"OnVesselRecoveryFunds: paired event for '{vesselName}' at ut={matched.ut.ToString("F1", CultureInfo.InvariantCulture)} " +
                     $"has delta={delta.ToString("F1", CultureInfo.InvariantCulture)} — skipping (zero or negative recovery value)");
                 consumedRecoveryEventKeys.Add(dedupKey);
-                return;
+                return true;
             }
 
             if (HasRecoveryActionForDedupKey(dedupKey))
@@ -3507,7 +3579,7 @@ namespace Parsek
                 ParsekLog.Verbose(Tag,
                     $"OnVesselRecoveryFunds: paired event for '{vesselName}' at ut={matched.ut.ToString("F1", CultureInfo.InvariantCulture)} " +
                     $"already exists in ledger (dedupKey='{dedupKey}') — skipping duplicate add");
-                return;
+                return true;
             }
 
             // Pick the recording whose [StartUT, EndUT] brackets the recovery UT (the best
@@ -3547,6 +3619,7 @@ namespace Parsek
                 $"recordingId={recordingId ?? "(none)"} fromTrackingStation={fromTrackingStation}");
 
             RecalculateAndPatch();
+            return true;
         }
 
         /// <summary>
@@ -6095,6 +6168,7 @@ namespace Parsek
             emittedReconcileWarnKeys.Clear();
             emittedScienceReconcileDumpKeys.Clear();
             consumedRecoveryEventKeys.Clear();
+            pendingRecoveryFunds.Clear();
             scienceModule = null;
             milestonesModule = null;
             contractsModule = null;

--- a/Source/Parsek/GameActions/LedgerOrchestrator.cs
+++ b/Source/Parsek/GameActions/LedgerOrchestrator.cs
@@ -1614,7 +1614,10 @@ namespace Parsek
             // ledger file) must NOT falsely register as "MigrateOldSaveEvents output".
             migrateOldSaveEventsRanThisLoad = false;
             consumedRecoveryEventKeys.Clear();
-            pendingRecoveryFunds.Clear();
+            // Log-before-clear so any stale entries from the previous session show up
+            // in KSP.log before we drop them. Matches the FlushStalePendingRecoveryFunds
+            // contract used at scene-switch / rewind-end boundaries.
+            FlushStalePendingRecoveryFunds("KSP load");
 
             // Reconcile first — prunes orphaned actions from the existing ledger.
             // On empty ledger (old save), this is a no-op.
@@ -3238,6 +3241,7 @@ namespace Parsek
         /// instead of mutable store indices so later list pruning/reindexing cannot
         /// retarget a consumed marker onto a different event.
         /// Cleared by <see cref="OnKspLoad"/> and <see cref="ResetForTesting"/>.
+        /// Written exclusively from <see cref="TryAddVesselRecoveryFundsAction"/>.
         /// </summary>
         private static readonly HashSet<string> consumedRecoveryEventKeys = new HashSet<string>();
 
@@ -3250,6 +3254,16 @@ namespace Parsek
 
         private static readonly List<PendingRecoveryFundsRequest> pendingRecoveryFunds =
             new List<PendingRecoveryFundsRequest>();
+
+        /// <summary>
+        /// Hard cap on how many unmatched recovery requests can accumulate before the
+        /// list itself becomes a leak signal. Staleness eviction also runs on lifecycle
+        /// boundaries (<see cref="OnKspLoad"/>, rewind end, scene switch), but this
+        /// threshold is the safety net when a boundary is missed. Chosen to absorb the
+        /// largest realistic bulk-recover-debris burst while still flagging runaway
+        /// growth — stock debris recovery batches rarely exceed a handful per UT epsilon.
+        /// </summary>
+        internal const int PendingRecoveryFundsStaleThreshold = 5;
 
         /// <summary>
         /// Stable fingerprint for a FundsChanged(VesselRecovery) event. Internal for
@@ -3339,6 +3353,20 @@ namespace Parsek
                 VesselName = vesselName,
                 FromTrackingStation = fromTrackingStation
             });
+
+            // Safety net: if the list grows past the staleness threshold without a
+            // matching FundsChanged(VesselRecovery) event draining it, something
+            // upstream stopped firing paired events. Lifecycle flushes
+            // (OnKspLoad / rewind end / scene switch) normally catch this, but this
+            // log keeps a footprint in KSP.log when a leak happens mid-session.
+            if (pendingRecoveryFunds.Count > PendingRecoveryFundsStaleThreshold)
+            {
+                ParsekLog.Warn(Tag,
+                    $"OnVesselRecoveryFunds: pending queue exceeded threshold " +
+                    $"(count={pendingRecoveryFunds.Count} > {PendingRecoveryFundsStaleThreshold}) " +
+                    $"— paired FundsChanged(VesselRecovery) events may be missing. " +
+                    $"Latest deferred request vessel='{vesselName}' ut={ut.ToString("F1", CultureInfo.InvariantCulture)}");
+            }
         }
 
         internal static int PendingRecoveryFundsCountForTesting => pendingRecoveryFunds.Count;
@@ -3350,22 +3378,32 @@ namespace Parsek
             if (evt.key != VesselRecoveryReasonKey)
                 return;
 
+            // Initialize() is idempotent: it short-circuits on the `initialized` flag so
+            // repeated calls cost one branch. See LedgerOrchestrator.Initialize().
             Initialize();
             if (pendingRecoveryFunds.Count == 0)
                 return;
 
-            int bestIndex = -1;
-            double bestDistance = double.MaxValue;
-            for (int i = 0; i < pendingRecoveryFunds.Count; i++)
-            {
-                double distance = Math.Abs(pendingRecoveryFunds[i].Ut - evt.ut);
-                if (distance > VesselRecoveryEventEpsilonSeconds) continue;
-                if (distance >= bestDistance) continue;
+            // Two-tier pairing:
+            //
+            //   Tier 1 — Vessel-name preferred. If the event carries a vessel name
+            //            (propagated through GameStateEvent.detail on future recovery
+            //            paths; currently set only by synthetic test events), prefer
+            //            pending requests whose VesselName matches. This protects
+            //            against mis-pairing when two same-UT recoveries of different
+            //            vessels arrive and the funds events interleave out of order.
+            //
+            //   Tier 2 — Nearest UT. Legacy behavior: pick the pending request whose
+            //            UT is closest to the event UT inside the epsilon window.
+            //
+            // When multiple candidates tie after the name-match filter and share the
+            // same UT distance within the epsilon, we still pick the first match but
+            // log a WARN listing every tied candidate so the ambiguity is visible in
+            // KSP.log. This preserves the #444 callback-before-event contract without
+            // introducing silent mis-pairing.
+            string eventVesselName = evt.detail ?? "";
 
-                bestIndex = i;
-                bestDistance = distance;
-            }
-
+            int bestIndex = FindBestPairingIndex(evt.ut, eventVesselName);
             if (bestIndex < 0)
                 return;
 
@@ -3377,6 +3415,150 @@ namespace Parsek
             {
                 pendingRecoveryFunds.RemoveAt(bestIndex);
             }
+        }
+
+        /// <summary>
+        /// Picks the best pending recovery-funds request for a FundsChanged(VesselRecovery)
+        /// event using the two-tier policy documented on <see cref="OnRecoveryFundsEventRecorded"/>.
+        /// Internal static for direct testability.
+        /// </summary>
+        /// <remarks>
+        /// <para>Ties after vessel-name matching at identical UT distance fall back to the
+        /// first match (list order) but emit a WARN so the ambiguity is visible.</para>
+        /// </remarks>
+        internal static int FindBestPairingIndex(double eventUt, string eventVesselName)
+        {
+            if (pendingRecoveryFunds.Count == 0)
+                return -1;
+
+            bool haveName = !string.IsNullOrEmpty(eventVesselName);
+
+            // Tier 1: vessel-name preferred pass.
+            int nameMatchBestIndex = -1;
+            double nameMatchBestDistance = double.MaxValue;
+            int nameMatchTies = 0;
+            if (haveName)
+            {
+                for (int i = 0; i < pendingRecoveryFunds.Count; i++)
+                {
+                    if (!string.Equals(pendingRecoveryFunds[i].VesselName,
+                            eventVesselName, StringComparison.Ordinal))
+                        continue;
+
+                    double distance = Math.Abs(pendingRecoveryFunds[i].Ut - eventUt);
+                    if (distance > VesselRecoveryEventEpsilonSeconds) continue;
+
+                    if (distance < nameMatchBestDistance)
+                    {
+                        nameMatchBestIndex = i;
+                        nameMatchBestDistance = distance;
+                        nameMatchTies = 1;
+                    }
+                    else if (distance == nameMatchBestDistance)
+                    {
+                        nameMatchTies++;
+                    }
+                }
+            }
+
+            if (nameMatchBestIndex >= 0)
+            {
+                if (nameMatchTies > 1)
+                {
+                    WarnPairingCandidateTie(eventUt, eventVesselName, byNameMatch: true,
+                        bestDistance: nameMatchBestDistance);
+                }
+                return nameMatchBestIndex;
+            }
+
+            // Tier 2: nearest UT fallback.
+            int fallbackBestIndex = -1;
+            double fallbackBestDistance = double.MaxValue;
+            int fallbackTies = 0;
+            for (int i = 0; i < pendingRecoveryFunds.Count; i++)
+            {
+                double distance = Math.Abs(pendingRecoveryFunds[i].Ut - eventUt);
+                if (distance > VesselRecoveryEventEpsilonSeconds) continue;
+
+                if (distance < fallbackBestDistance)
+                {
+                    fallbackBestIndex = i;
+                    fallbackBestDistance = distance;
+                    fallbackTies = 1;
+                }
+                else if (distance == fallbackBestDistance)
+                {
+                    fallbackTies++;
+                }
+            }
+
+            if (fallbackBestIndex >= 0 && fallbackTies > 1)
+            {
+                WarnPairingCandidateTie(eventUt, eventVesselName, byNameMatch: false,
+                    bestDistance: fallbackBestDistance);
+            }
+
+            return fallbackBestIndex;
+        }
+
+        private static void WarnPairingCandidateTie(
+            double eventUt, string eventVesselName, bool byNameMatch, double bestDistance)
+        {
+            var sb = new System.Text.StringBuilder();
+            for (int i = 0; i < pendingRecoveryFunds.Count; i++)
+            {
+                double distance = Math.Abs(pendingRecoveryFunds[i].Ut - eventUt);
+                if (distance > VesselRecoveryEventEpsilonSeconds) continue;
+                if (byNameMatch &&
+                    !string.Equals(pendingRecoveryFunds[i].VesselName,
+                        eventVesselName, StringComparison.Ordinal))
+                    continue;
+                if (distance != bestDistance) continue;
+
+                if (sb.Length > 0) sb.Append(", ");
+                sb.Append("vessel='").Append(pendingRecoveryFunds[i].VesselName ?? "")
+                  .Append("' ut=").Append(pendingRecoveryFunds[i].Ut.ToString("F1", CultureInfo.InvariantCulture));
+            }
+
+            string tier = byNameMatch ? "name-match" : "nearest-UT";
+            ParsekLog.Warn(Tag,
+                $"OnRecoveryFundsEventRecorded: multiple pending requests tied at " +
+                $"{tier} distance={bestDistance.ToString("F3", CultureInfo.InvariantCulture)} " +
+                $"for event ut={eventUt.ToString("F1", CultureInfo.InvariantCulture)} " +
+                $"vesselName='{eventVesselName ?? ""}'. Candidates: [{sb}]. " +
+                $"Picking first match in list order.");
+        }
+
+        /// <summary>
+        /// Drains unclaimed <see cref="pendingRecoveryFunds"/> entries at a lifecycle
+        /// boundary (scene switch, rewind end, load). Any entry still waiting for a
+        /// paired FundsChanged(VesselRecovery) event past the boundary cannot pair
+        /// afterward — the funds event would have arrived by now if stock was going to
+        /// fire it. The WARN lists every unclaimed entry so a missing-payout bug stays
+        /// visible instead of silently leaking into the next session's pending list.
+        /// </summary>
+        /// <param name="reason">Human-readable reason for the flush (e.g., "scene switch",
+        /// "rewind end", "KSP load"). Appears in the WARN log line for diagnostics.</param>
+        internal static void FlushStalePendingRecoveryFunds(string reason)
+        {
+            if (pendingRecoveryFunds.Count == 0)
+                return;
+
+            var sb = new System.Text.StringBuilder();
+            for (int i = 0; i < pendingRecoveryFunds.Count; i++)
+            {
+                if (sb.Length > 0) sb.Append(", ");
+                sb.Append("vessel='").Append(pendingRecoveryFunds[i].VesselName ?? "")
+                  .Append("' ut=").Append(pendingRecoveryFunds[i].Ut.ToString("F1", CultureInfo.InvariantCulture));
+            }
+
+            ParsekLog.Warn(Tag,
+                $"FlushStalePendingRecoveryFunds ({reason ?? ""}): " +
+                $"evicting {pendingRecoveryFunds.Count} unclaimed recovery request(s) " +
+                $"that never received a paired FundsChanged(VesselRecovery) event. " +
+                $"Entries: [{sb}]");
+
+            pendingRecoveryFunds.Clear();
         }
 
         /// <summary>

--- a/Source/Parsek/GameStateRecorder.cs
+++ b/Source/Parsek/GameStateRecorder.cs
@@ -596,9 +596,12 @@ namespace Parsek
             Emit(ref evt, "TechResearched");
             ParsekLog.Info("GameStateRecorder", $"Game state: TechResearched '{techId}' (cost={data.host.scienceCost})");
 
-            // Write directly to ledger when at KSC (not during flight recording)
-            // #431 gate: see OnContractAccepted.
-            if (!IsFlightScene() && string.IsNullOrEmpty(ResolveCurrentRecordingTag()))
+            // Write directly to ledger when there is no recording owner.
+            // #553 follow-up: gate on the same ShouldForwardDirectLedgerEvent predicate
+            // used by the contract handlers. Untagged pre-recording FLIGHT tech-research
+            // events have no later commit-time owner; suppressing them here would
+            // strand the TechResearched action in GameStateStore.
+            if (ShouldForwardDirectLedgerEvent(evt.recordingId, HasLiveRecorder()))
                 LedgerOrchestrator.OnKscSpending(evt);
         }
 
@@ -639,10 +642,11 @@ namespace Parsek
             ParsekLog.Info("GameStateRecorder",
                 $"Game state: PartPurchased '{partName}' (chargedCost={chargedCost}, entryCost={entryCost})");
 
-            // #405: route to ledger immediately when at KSC. Relies on the DedupKey (§F)
-            // to disambiguate part-name collisions.
-            // #431 gate: see OnContractAccepted.
-            if (!IsFlightScene() && string.IsNullOrEmpty(ResolveCurrentRecordingTag()))
+            // #405: route to ledger immediately when there is no recording owner.
+            // Relies on the DedupKey (§F) to disambiguate part-name collisions.
+            // #553 follow-up: gate on ShouldForwardDirectLedgerEvent so untagged
+            // pre-recording FLIGHT part-purchases reach the ledger too.
+            if (ShouldForwardDirectLedgerEvent(evt.recordingId, HasLiveRecorder()))
                 LedgerOrchestrator.OnKscSpending(evt);
         }
 
@@ -702,8 +706,9 @@ namespace Parsek
                 $"Game state: CrewHired '{name}' ({crew.trait ?? "?"}) " +
                 $"cost={hireCost.ToString("R", ic)} activeCrewCount={activeCrewCount}");
 
-            // #431 gate: see OnContractAccepted.
-            if (!IsFlightScene() && string.IsNullOrEmpty(ResolveCurrentRecordingTag()))
+            // #553 follow-up: gate on ShouldForwardDirectLedgerEvent so untagged
+            // pre-recording FLIGHT crew hires reach the ledger too.
+            if (ShouldForwardDirectLedgerEvent(evt.recordingId, HasLiveRecorder()))
                 LedgerOrchestrator.OnKscSpending(evt);
         }
 
@@ -1214,9 +1219,10 @@ namespace Parsek
                 $"Game state: MilestoneAchieved '{milestoneId}' (awaiting reward enrichment)");
 
             // Milestones can fire at KSC (e.g., facility-related) or in flight.
-            // Write directly to ledger when outside flight to avoid waiting for commit.
-            // #431 gate: see OnContractAccepted.
-            if (!IsFlightScene() && string.IsNullOrEmpty(ResolveCurrentRecordingTag()))
+            // Write directly to ledger when no recording owner exists.
+            // #553 follow-up: gate on ShouldForwardDirectLedgerEvent so untagged
+            // pre-recording FLIGHT milestones reach the ledger too.
+            if (ShouldForwardDirectLedgerEvent(evt.recordingId, HasLiveRecorder()))
                 LedgerOrchestrator.OnKscSpending(evt);
         }
 
@@ -1428,8 +1434,9 @@ namespace Parsek
             // Mirror the OnProgressComplete KSC-forwarding path so world-record rewards
             // earned outside flight (rare, but possible — e.g. RecordsAltitude on a sub-
             // orbital craft already reverted) still reach the ledger immediately.
-            // #431 gate: see OnContractAccepted.
-            if (!IsFlightScene() && string.IsNullOrEmpty(ResolveCurrentRecordingTag()))
+            // #553 follow-up: gate on ShouldForwardDirectLedgerEvent so untagged
+            // pre-recording FLIGHT standalone milestone awards reach the ledger too.
+            if (ShouldForwardDirectLedgerEvent(evt.recordingId, HasLiveRecorder()))
                 LedgerOrchestrator.OnKscSpending(evt);
         }
 
@@ -1575,9 +1582,11 @@ namespace Parsek
             // KSC-side forwarding mirror: StrategyActivate actions with a non-zero setup
             // cost need to land on the ledger immediately when the player activates from
             // the Administration building (i.e. outside flight). The commit-time
-            // ConvertEvents path will also pick up flight-scope strategies. The #431 gate
-            // skips the ledger write when the event was tagged during a teardown window.
-            if (!IsFlightScene() && string.IsNullOrEmpty(ResolveCurrentRecordingTag()))
+            // ConvertEvents path will also pick up flight-scope strategies. The
+            // ShouldForwardDirectLedgerEvent gate suppresses tagged teardown events
+            // while still letting untagged pre-recording FLIGHT events (no live
+            // recorder) reach the ledger.
+            if (ShouldForwardDirectLedgerEvent(evt.recordingId, HasLiveRecorder()))
                 LedgerOrchestrator.OnKscSpending(evt);
         }
 
@@ -1634,7 +1643,9 @@ namespace Parsek
             // Mirror the KSC-forwarding path even though StrategyDeactivate is a
             // NoResourceImpact action — the ledger still needs the StrategyDeactivate row
             // so StrategiesModule can pair activate/deactivate during the walk.
-            if (!IsFlightScene() && string.IsNullOrEmpty(ResolveCurrentRecordingTag()))
+            // #553 follow-up: gate on ShouldForwardDirectLedgerEvent so untagged
+            // pre-recording FLIGHT strategy deactivations reach the ledger too.
+            if (ShouldForwardDirectLedgerEvent(evt.recordingId, HasLiveRecorder()))
                 LedgerOrchestrator.OnKscSpending(evt);
         }
 
@@ -1871,10 +1882,12 @@ namespace Parsek
                             eventsEmitted++;
                             ParsekLog.Info("GameStateRecorder", $"Game state: {eventType} '{kvp.Key}' {cachedLevel:F2} → {currentLevel:F2}");
 
-                            // #431 gate: see OnContractAccepted — skip ledger write
-                            // when the event was tagged during FLIGHT -> SPACECENTER teardown.
-                            if (!IsFlightScene() && eventType == GameStateEventType.FacilityUpgraded
-                                && string.IsNullOrEmpty(ResolveCurrentRecordingTag()))
+                            // #553 follow-up: gate on ShouldForwardDirectLedgerEvent so
+                            // untagged pre-recording FLIGHT facility upgrades reach the
+                            // ledger too. Only FacilityUpgraded forwards (downgrades are
+                            // informational).
+                            if (eventType == GameStateEventType.FacilityUpgraded
+                                && ShouldForwardDirectLedgerEvent(evt.recordingId, HasLiveRecorder()))
                                 LedgerOrchestrator.OnKscSpending(evt);
                         }
                     }

--- a/Source/Parsek/GameStateRecorder.cs
+++ b/Source/Parsek/GameStateRecorder.cs
@@ -433,20 +433,24 @@ namespace Parsek
                     $"(snapshot FAILED: {(snapshotFailure != null ? snapshotFailure.Message : "unknown error")})");
             }
 
-            // Write directly to ledger when at KSC (not during a flight recording).
-            // Flight-scene contracts flow through the normal commit-time ConvertEvents path.
+            // Write directly to ledger when this event has no recording owner and no
+            // live recorder can still claim it. Tagged contract events flow through
+            // the normal commit-time ConvertEvents path. Untagged pre-recording
+            // FLIGHT events must be direct-ledger too: stock can complete launch-site
+            // contracts just before Parsek auto-record starts, before a live recorder
+            // exists.
             // #405: without this, accepted contracts at KSC never reached the ledger and
             // PatchContracts had no active contracts to preserve on next recalc.
             // #431 gate: during FLIGHT -> SPACECENTER teardown the scene already reads
             // SPACECENTER but ParsekFlight.Instance is still alive and Emit legitimately
-            // tagged this event with the outgoing recordingId. Re-resolve the tag here
-            // and skip the ledger write when non-empty: the tagged event is already in
+            // tagged this event with the outgoing recordingId. Skip the ledger write
+            // when non-empty: the tagged event is already in
             // GameStateStore and will flow through the commit-time path (or be purged
             // with the recording on discard). Without this gate the ledger would end up
             // with an untagged KSC action that survives DiscardPendingTree forever.
-            // Note: `evt` is a struct local, so Emit's `.recordingId` mutation doesn't
-            // reach us — we must call ResolveCurrentRecordingTag() directly.
-            if (!IsFlightScene() && string.IsNullOrEmpty(ResolveCurrentRecordingTag()))
+            // If the tag is empty while a live recorder exists, treat it as tag drift
+            // and avoid creating a null-owner ledger action that survives discard.
+            if (ShouldForwardDirectLedgerEvent(evt.recordingId, HasLiveRecorder()))
                 LedgerOrchestrator.OnKscSpending(evt);
         }
 
@@ -475,11 +479,10 @@ namespace Parsek
             ParsekLog.Info("GameStateRecorder",
                 $"Game state: ContractCompleted '{title}' (funds={fundsReward}, rep={repReward}, sci={sciReward})");
 
-            // #405: route to ledger immediately when at KSC (contract completions in flight
-            // go through the normal commit-time ConvertEvents path).
+            // #405: route to ledger immediately when there is no recording owner.
             // #431 gate: see OnContractAccepted — skip the ledger write when the event
             // was tagged during FLIGHT -> SPACECENTER teardown.
-            if (!IsFlightScene() && string.IsNullOrEmpty(ResolveCurrentRecordingTag()))
+            if (ShouldForwardDirectLedgerEvent(evt.recordingId, HasLiveRecorder()))
                 LedgerOrchestrator.OnKscSpending(evt);
         }
 
@@ -503,9 +506,9 @@ namespace Parsek
             ParsekLog.Info("GameStateRecorder",
                 $"Game state: ContractFailed '{title}' (fundsPenalty={fundsPenalty}, repPenalty={repPenalty})");
 
-            // #405: route to ledger immediately when at KSC.
+            // #405: route to ledger immediately when there is no recording owner.
             // #431 gate: see OnContractAccepted.
-            if (!IsFlightScene() && string.IsNullOrEmpty(ResolveCurrentRecordingTag()))
+            if (ShouldForwardDirectLedgerEvent(evt.recordingId, HasLiveRecorder()))
                 LedgerOrchestrator.OnKscSpending(evt);
         }
 
@@ -529,9 +532,9 @@ namespace Parsek
             ParsekLog.Info("GameStateRecorder",
                 $"Game state: ContractCancelled '{title}' (fundsPenalty={fundsPenalty}, repPenalty={repPenalty})");
 
-            // #405: route to ledger immediately when at KSC.
+            // #405: route to ledger immediately when there is no recording owner.
             // #431 gate: see OnContractAccepted.
-            if (!IsFlightScene() && string.IsNullOrEmpty(ResolveCurrentRecordingTag()))
+            if (ShouldForwardDirectLedgerEvent(evt.recordingId, HasLiveRecorder()))
                 LedgerOrchestrator.OnKscSpending(evt);
         }
 
@@ -748,6 +751,17 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Returns true when a captured lifecycle event has no recording owner and
+        /// should be written straight to the ledger. A live recorder with an empty
+        /// tag is tag drift, not proof that the event is ownerless; true
+        /// pre-recording FLIGHT events have no tag and no live recorder yet.
+        /// </summary>
+        internal static bool ShouldForwardDirectLedgerEvent(string recordingTag, bool hasLiveRecorder)
+        {
+            return string.IsNullOrEmpty(recordingTag) && !hasLiveRecorder;
+        }
+
+        /// <summary>
         /// Pure: returns true if the status transition is a real change (not an identity
         /// transition like Dead->Dead). Extracted for testability (Bug #122).
         /// </summary>
@@ -915,6 +929,9 @@ namespace Parsek
             // against the just-emitted event in GameStateStore.
             if (reason == TransactionReasons.VesselRollout && !IsReplayingActions)
                 LedgerOrchestrator.OnVesselRolloutSpending(ut, -delta);
+
+            if (reason == TransactionReasons.VesselRecovery && !IsReplayingActions)
+                LedgerOrchestrator.OnRecoveryFundsEventRecorded(fundsEvt);
         }
 
         private void OnScienceChanged(float newScience, TransactionReasons reason)

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -1979,6 +1979,10 @@ namespace Parsek
             ParsekLog.Info("Rewind",
                 $"OnLoad: rewind complete at UT {RewindContext.RewindUT}. " +
                 $"Timeline: {recordings.Count} recordings");
+            // Any pending recovery-funds callbacks deferred before the rewind cannot
+            // pair after the boundary — stock already fired (or will never fire) the
+            // paired FundsChanged(VesselRecovery) event relative to the old timeline.
+            LedgerOrchestrator.FlushStalePendingRecoveryFunds("rewind end");
             RewindContext.EndRewind();
             ParsekLog.RecState("HandleRewindOnLoad:exit", CaptureScenarioRecorderState());
         }
@@ -4152,6 +4156,17 @@ namespace Parsek
                 ParsekLog.Info("Scenario",
                     "Main menu transition — reset initialLoadDone to prevent stale data leak");
             }
+
+            // Flush any unclaimed recovery-funds callbacks at every scene switch.
+            // Recovery callbacks deferred in the old scene (FLIGHT teardown, tracking
+            // station recovery) cannot pair with a FundsChanged(VesselRecovery) event
+            // captured after the scene transition — stock recovery bookkeeping is
+            // scoped to the scene that fired onVesselRecovered. Calling this
+            // unconditionally (cheap no-op when the queue is empty) keeps the
+            // staleness eviction running on the broadest lifecycle boundary
+            // LedgerOrchestrator can observe.
+            LedgerOrchestrator.FlushStalePendingRecoveryFunds(
+                $"scene switch to {newScene}");
         }
 
         private void OnVesselSwitching(Vessel from, Vessel to)

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -677,6 +677,34 @@ Both cases are valid data, but they clutter the UI and read like broken/empty gh
 
 ---
 
+## ~~552. Vessel recovery funds can log a false missing-pair warning when stock delivers the funds event after recovery~~
+
+**Source:** latest collected package `logs/2026-04-23_1829_logs-package/`. `KSP.log` shows `OnVesselRecoveryFunds` warning at `18:23:16.943` because no paired `FundsChanged(VesselRecovery)` was found yet, then the actual `FundsChanged` recovery event arrived at `18:23:16.961`, within the intended pairing window.
+
+**Concern:** the old path assumed KSP delivered `FundsChanged(VesselRecovery)` before `onVesselRecovered`. The observed ordering was reversed by about 18 ms, so Parsek skipped adding the recovery earning and logged a false warning even though the data arrived moments later.
+
+**Fix:** `OnVesselRecoveryFunds(...)` now defers unmatched recovery requests and `GameStateRecorder.OnFundsChanged(...)` calls `OnRecoveryFundsEventRecorded(...)` for recovery reasons so the delayed event can complete the pairing. Pending callbacks are preserved until they pair with distinct `FundsChanged(VesselRecovery)` event fingerprints, including same-named recoveries inside the UT epsilon, and are cleared on load/test resets. Pairing prefers requests whose vessel name matches the funds event and warns when multiple candidates share the same UT after name matching, then falls back to nearest UT. Pending requests that never receive a paired funds event are evicted on scene switches, save loads, and rewind boundaries with a WARN listing the unclaimed entries.
+
+**Files:** `Source/Parsek/GameActions/LedgerOrchestrator.cs`, `Source/Parsek/GameStateRecorder.cs`, `Source/Parsek.Tests/GameStateRecorderLedgerTests.cs`, `CHANGELOG.md`.
+
+**Status:** CLOSED 2026-04-23. Fixed for v0.8.3 with focused callback-before-event coverage, staleness eviction on lifecycle boundaries, and vessel-name-preferred pairing with WARN on ambiguous ties.
+
+---
+
+## ~~553. Untagged pre-recording FLIGHT contract events can miss the ledger because the direct path was KSC-only~~
+
+**Source:** latest collected package `logs/2026-04-23_1829_logs-package/`. The launch-site contract path emitted untagged `ContractAccepted` / `ContractCompleted` events with `tag=''` and no recording owner, while the ledger needed the accepted contract to preserve the active contract and advance.
+
+**Concern:** direct ledger forwarding only allowed non-FLIGHT scenes. That is correct for tagged FLIGHT teardown events, but untagged pre-recording FLIGHT contract events have no later commit-time `ConvertEvents` owner. If they are not written directly, the ledger can miss contract state or rewards. The same ownership reasoning applies to tech, part-purchase, crew-hire, strategy, facility, and science-subject events that arrive untagged before any recording exists.
+
+**Fix:** contract lifecycle forwarding now keys on the `recordingId` stamped by `Emit(ref evt)` and whether a live recorder can still own an empty-tag event. Non-empty tags suppress direct ledger writes so teardown/discard fate remains intact; empty tags forward directly only when no live recorder exists, covering true pre-recording FLIGHT events without turning tag-resolution drift into null-owner ledger actions. The same `ShouldForwardDirectLedgerEvent` predicate is threaded through `TechResearched`, `PartPurchased`, `CrewHired`, strategy activate/deactivate/complete, facility upgrade, and science-subject handlers so every direct-ledger path shares one gate.
+
+**Files:** `Source/Parsek/GameStateRecorder.cs`, `Source/Parsek.Tests/DiscardFateTests.cs`, `CHANGELOG.md`.
+
+**Status:** CLOSED 2026-04-23. Fixed for v0.8.3 with predicate coverage for tagged teardown suppression, untagged KSC forwarding, untagged pre-recording FLIGHT forwarding, and empty-tag live-recorder drift suppression across all direct-ledger handlers.
+
+---
+
 ## ~~557. Delayed science/reputation seeding can turn future balances into UT0 after rewind~~
 
 **Source:** latest collected package `logs/2026-04-23_1829_logs-package/`. `KSP.log` shows initial deferred seeding stopped as soon as Funding reported 25000 while Science and Reputation still read zero. Later, after the first committed flight and before the rewind, `ledger.pgld` gained `ScienceInitial = 11.04` and `ReputationInitial = 0.999999464` at UT0 even though the earliest baseline had both resources at zero. The rewind recalculation at adjusted UT 49.4 then included those UT0 seeds and patched science/reputation from future state.

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -685,7 +685,7 @@ Both cases are valid data, but they clutter the UI and read like broken/empty gh
 
 **Fix:** `OnVesselRecoveryFunds(...)` now defers unmatched recovery requests and `GameStateRecorder.OnFundsChanged(...)` calls `OnRecoveryFundsEventRecorded(...)` for recovery reasons so the delayed event can complete the pairing. Pending callbacks are preserved until they pair with distinct `FundsChanged(VesselRecovery)` event fingerprints, including same-named recoveries inside the UT epsilon, and are cleared on load/test resets. Pairing prefers requests whose vessel name matches the funds event and warns when multiple candidates share the same UT after name matching, then falls back to nearest UT. Pending requests that never receive a paired funds event are evicted on scene switches, save loads, and rewind boundaries with a WARN listing the unclaimed entries.
 
-**Files:** `Source/Parsek/GameActions/LedgerOrchestrator.cs`, `Source/Parsek/GameStateRecorder.cs`, `Source/Parsek.Tests/GameStateRecorderLedgerTests.cs`, `CHANGELOG.md`.
+**Files:** `Source/Parsek/GameActions/LedgerOrchestrator.cs`, `Source/Parsek/GameStateRecorder.cs`, `Source/Parsek/ParsekScenario.cs`, `Source/Parsek.Tests/GameStateRecorderLedgerTests.cs`, `CHANGELOG.md`.
 
 **Status:** CLOSED 2026-04-23. Fixed for v0.8.3 with focused callback-before-event coverage, staleness eviction on lifecycle boundaries, and vessel-name-preferred pairing with WARN on ambiguous ties.
 
@@ -697,7 +697,7 @@ Both cases are valid data, but they clutter the UI and read like broken/empty gh
 
 **Concern:** direct ledger forwarding only allowed non-FLIGHT scenes. That is correct for tagged FLIGHT teardown events, but untagged pre-recording FLIGHT contract events have no later commit-time `ConvertEvents` owner. If they are not written directly, the ledger can miss contract state or rewards. The same ownership reasoning applies to tech, part-purchase, crew-hire, strategy, facility, and science-subject events that arrive untagged before any recording exists.
 
-**Fix:** contract lifecycle forwarding now keys on the `recordingId` stamped by `Emit(ref evt)` and whether a live recorder can still own an empty-tag event. Non-empty tags suppress direct ledger writes so teardown/discard fate remains intact; empty tags forward directly only when no live recorder exists, covering true pre-recording FLIGHT events without turning tag-resolution drift into null-owner ledger actions. The same `ShouldForwardDirectLedgerEvent` predicate is threaded through `TechResearched`, `PartPurchased`, `CrewHired`, strategy activate/deactivate/complete, facility upgrade, and science-subject handlers so every direct-ledger path shares one gate.
+**Fix:** contract lifecycle forwarding now keys on the `recordingId` stamped by `Emit(ref evt)` and whether a live recorder can still own an empty-tag event. Non-empty tags suppress direct ledger writes so teardown/discard fate remains intact; empty tags forward directly only when no live recorder exists, covering true pre-recording FLIGHT events without turning tag-resolution drift into null-owner ledger actions. The same `ShouldForwardDirectLedgerEvent` predicate is threaded through `TechResearched`, `PartPurchased`, `CrewHired`, `MilestoneAchieved` (in-flight and standalone paths), `StrategyActivated`, `StrategyDeactivated`, and `FacilityUpgraded` handlers so every direct-ledger path shares one gate.
 
 **Files:** `Source/Parsek/GameStateRecorder.cs`, `Source/Parsek.Tests/DiscardFateTests.cs`, `CHANGELOG.md`.
 


### PR DESCRIPTION
## Summary
- Defer recovery funds callbacks until the matching FundsChanged(VesselRecovery) event arrives, preserving distinct same-name callbacks inside the UT epsilon.
- Forward unowned contract lifecycle events only when Emit left no recording id and no live recorder can still own the event.
- Close #552 and #553 in the 0.8.3 docs.

## Validation
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter FullyQualifiedName~GameStateRecorderLedgerTests|FullyQualifiedName~DiscardFateTests: 47 passed
- xhigh follow-up review: no findings