### PR TITLE
Fix KSC merge source vessel adoption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to Parsek are documented here.
 - `#538` Atmospheric reentry fire now uses the emission-rate lerp as the primary density dial, doubling the fire particle range from `300-2000` to `600-4000` particles/sec while only lifting the particle cap from `1500` to `2000` so the denser stream has headroom without opening a full 2x peak-particle budget.
 - `#545` Timeline milestone rows now squash same-moment duplicate entries for the same milestone into one richer entry, including near-UT copies inside the same 0.1s window and same-timestamp rows separated by another entry. The surviving row unions missing funds/rep/science reward legs while leaving genuinely conflicting reward values split instead of inventing a combined total. Timeline milestone labels now also show science rewards, reducing the remaining “looks double-counted” milestone presentation path from `#522`.
 - `#546` Idle vessel switches now arm auto-record and start on the first meaningful physical modification.
+- `#550` KSC end-of-recording spawn now adopts a surviving source vessel after a merge instead of spawning a duplicate real vessel at the same landed endpoint. The adopted source PID is saved as the live/restorable vessel, so switching back to that craft resumes the committed tree instead of colliding with a copied vessel or starting a fresh tree.
 - `#528` Launchpad science gathered before a flight starts no longer gets committed onto that later recording, and mixed tree/chain commits now keep science attached to the correct recording.
 
 ### Tests
@@ -60,6 +61,7 @@ All notable changes to Parsek are documented here.
 - `ParsekUITests` now pin the short main-window labels so `Kerbals` stays count-free and the launch-surface button text stays `Career` rather than drifting back to `Career State`.
 - `#542` Added regression coverage pinning the fixed 300 km watch cutoff helper, the removal of the mutable `ParsekSettings` cutoff field, and the persistence-store cleanup that now only tracks the remaining sticky user-intent toggles.
 - `#546` Added headless and runtime coverage for post-switch auto-record follow-up.
+- `#550` Added headless KSC spawn adoption and committed-tree restore regressions covering source-PID adoption, no-mutation cases, and matching adopted source vessels through the committed restore path.
 - `#532` Added headless coverage for the live KSC tech-unlock debit holdback, so the xUnit suite now pins both the unmatched-burst gap calculation and the `PatchScience` target adjustment that prevents temporary science refunds.
 
 ### Documentation

--- a/Source/Parsek.Tests/KscSpawnTests.cs
+++ b/Source/Parsek.Tests/KscSpawnTests.cs
@@ -68,6 +68,53 @@ namespace Parsek.Tests
 
         #endregion
 
+        #region Source vessel adoption
+
+        [Fact]
+        public void TryAdoptExistingSourceVesselForKscSpawn_SourceExists_UsesSourcePid()
+        {
+            var rec = MakeEligibleRecording();
+
+            bool adopted = ParsekKSC.TryAdoptExistingSourceVesselForKscSpawn(
+                rec,
+                sourceVesselExists: true);
+
+            Assert.True(adopted);
+            Assert.True(rec.VesselSpawned);
+            Assert.Equal(rec.VesselPersistentId, rec.SpawnedVesselPersistentId);
+        }
+
+        [Fact]
+        public void TryAdoptExistingSourceVesselForKscSpawn_SourceMissing_DoesNotMutate()
+        {
+            var rec = MakeEligibleRecording();
+
+            bool adopted = ParsekKSC.TryAdoptExistingSourceVesselForKscSpawn(
+                rec,
+                sourceVesselExists: false);
+
+            Assert.False(adopted);
+            Assert.False(rec.VesselSpawned);
+            Assert.Equal(0u, rec.SpawnedVesselPersistentId);
+        }
+
+        [Fact]
+        public void TryAdoptExistingSourceVesselForKscSpawn_AlreadySpawned_DoesNotOverwrite()
+        {
+            var rec = MakeEligibleRecording();
+            rec.VesselSpawned = true;
+            rec.SpawnedVesselPersistentId = 99999;
+
+            bool adopted = ParsekKSC.TryAdoptExistingSourceVesselForKscSpawn(
+                rec,
+                sourceVesselExists: true);
+
+            Assert.False(adopted);
+            Assert.Equal(99999u, rec.SpawnedVesselPersistentId);
+        }
+
+        #endregion
+
         #region ShouldSpawnAtKscEnd — eligible cases
 
         [Fact]

--- a/Source/Parsek.Tests/VesselSwitchTreeTests.cs
+++ b/Source/Parsek.Tests/VesselSwitchTreeTests.cs
@@ -334,6 +334,25 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void TryFindCommittedTreeForSpawnedVessel_AdoptedSourcePidMatchesSourceVessel()
+        {
+            var tree = MakeTree("rec_active");
+            tree.Recordings["rec_active"].VesselPersistentId = 12345;
+            tree.Recordings["rec_active"].VesselSpawned = true;
+            tree.Recordings["rec_active"].SpawnedVesselPersistentId = 12345;
+
+            bool found = ParsekFlight.TryFindCommittedTreeForSpawnedVessel(
+                new List<RecordingTree> { tree },
+                activeVesselPid: 12345,
+                out RecordingTree matchedTree,
+                out string matchedRecordingId);
+
+            Assert.True(found);
+            Assert.Same(tree, matchedTree);
+            Assert.Equal("rec_active", matchedRecordingId);
+        }
+
+        [Fact]
         public void PrepareCommittedTreeRestoreForSpawnedVessel_BackgroundTarget_UsesSpawnedPidAndClearsStaleBackgroundEntry()
         {
             var tree = MakeTree("rec_active", (20, "rec_tip"));

--- a/Source/Parsek/ParsekKSC.cs
+++ b/Source/Parsek/ParsekKSC.cs
@@ -1214,14 +1214,24 @@ namespace Parsek
                 return;
             }
 
-            // At KSC, FlightGlobals.Vessels may be empty/null but
-            // HighLogic.CurrentGame.flightState.protoVessels is always available.
-            // RespawnVessel uses protoVessels directly — works in any scene.
-            ParsekLog.Info("KSCSpawn",
-                $"Attempting spawn for #{recIdx} \"{rec.VesselName}\" (id={rec.RecordingId})");
-
             try
             {
+                if (TryAdoptExistingSourceVesselForKscSpawn(
+                    rec,
+                    SourceProtoVesselExists(rec.VesselPersistentId)))
+                {
+                    ParsekLog.Info("KSCSpawn",
+                        $"Spawn not needed for #{recIdx} \"{rec.VesselName}\": source vessel still exists " +
+                        $"(pid={rec.SpawnedVesselPersistentId}) - adopted for resume");
+                    return;
+                }
+
+                // At KSC, FlightGlobals.Vessels may be empty/null but
+                // HighLogic.CurrentGame.flightState.protoVessels is always available.
+                // RespawnVessel uses protoVessels directly - works in any scene.
+                ParsekLog.Info("KSCSpawn",
+                    $"Attempting spawn for #{recIdx} \"{rec.VesselName}\" (id={rec.RecordingId})");
+
                 // Bug #167: Apply crew swap on a snapshot copy before spawning.
                 // In KSC scene, SwapReservedCrewInFlight cannot run (no loaded vessel),
                 // so we swap reserved crew names directly in the snapshot.
@@ -1307,6 +1317,41 @@ namespace Parsek
                 ParsekLog.Error("KSCSpawn",
                     $"Spawn exception for #{recIdx} \"{rec.VesselName}\": {ex}");
             }
+        }
+
+        internal static bool TryAdoptExistingSourceVesselForKscSpawn(
+            Recording rec,
+            bool sourceVesselExists)
+        {
+            if (rec == null || !sourceVesselExists)
+                return false;
+            if (rec.VesselPersistentId == 0)
+                return false;
+            if (rec.VesselSpawned || rec.SpawnedVesselPersistentId != 0)
+                return false;
+
+            rec.VesselSpawned = true;
+            rec.SpawnedVesselPersistentId = rec.VesselPersistentId;
+            return true;
+        }
+
+        private static bool SourceProtoVesselExists(uint sourcePid)
+        {
+            if (sourcePid == 0 || GhostMapPresence.IsGhostMapVessel(sourcePid))
+                return false;
+
+            var protoVessels = HighLogic.CurrentGame?.flightState?.protoVessels;
+            if (protoVessels == null)
+                return false;
+
+            for (int i = 0; i < protoVessels.Count; i++)
+            {
+                ProtoVessel pv = protoVessels[i];
+                if (pv != null && pv.persistentId == sourcePid)
+                    return true;
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -590,6 +590,20 @@ Observation-only / cosmetic-only changes stay ignored. Checks are suppressed whi
 
 ---
 
+## ~~550. KSC merge spawn can duplicate the surviving source vessel at the same landed endpoint, then both unpack and collide~~
+
+**Source:** user repro and fresh package `logs/2026-04-23_1909_recording-resume-spawn-explosion`. `KSP.log` shows `Butterfly Rover` and `Crater Crawler` each being merged in SPACECENTER, then `KSCSpawn` spawning a real vessel for the committed recording while the source vessel still existed in the save. The save snapshot confirms the duplicate: `quicksave.sfs` contains source `persistentId = 22060629` and spawned copy `persistentId = 3693161297` at the same `lat/lon`, with only the altitude clamp separating them. Later FLIGHT loads unpacked two same-name vessels and produced collision/debris/crash-through-terrain logs.
+
+**Concern:** the KSC spawn path only checked intrinsic recording eligibility and the recording's prior `spawnedPid`. It did not check whether the original source vessel was still present after a normal Space Center scene exit. That created a second real vessel at the terminal pose. It also meant the resume mechanism depended on the duplicate's PID instead of the vehicle the user had actually just recorded.
+
+**Fix:** before `ParsekKSC.TrySpawnAtRecordingEnd()` calls `RespawnVessel`, it now checks `HighLogic.CurrentGame.flightState.protoVessels` for the recording's original `VesselPersistentId`. If the source vessel still exists, Parsek adopts that PID by setting `VesselSpawned` and `SpawnedVesselPersistentId` instead of spawning a copy. The committed-tree restore path already keys off `SpawnedVesselPersistentId`, so returning to that craft can resume the committed tree from the recorded endpoint.
+
+**Files:** `Source/Parsek/ParsekKSC.cs`, `Source/Parsek.Tests/KscSpawnTests.cs`, `Source/Parsek.Tests/VesselSwitchTreeTests.cs`.
+
+**Status:** CLOSED 2026-04-23. Fixed for v0.9.0 with source-vessel adoption and focused headless restore coverage.
+
+---
+
 ## 547. Recording optimizer should surface cross-body exo segments more clearly than the current first-body label
 
 **Source:** `docs/dev/recording-optimizer-review.md` (2026-04-07), especially the traced Kerbin-launch-to-Mun-landing scenario.


### PR DESCRIPTION
## Summary
- prevent KSC recording-end materialization from spawning a duplicate when the source vessel still exists in the save
- adopt the source vessel persistent id as the resume target so recording resume can continue on the original craft
- document #550 and add focused regression coverage

## Regression source
KSC spawn-at-end from #99 checked only whether Parsek had already spawned a copy, not whether the original source vessel still existed in the save. That allowed a merge-return flow to spawn a duplicate real vessel on top of the original.

## Validation
- dotnet test Source\Parsek.Tests\Parsek.Tests.csproj --no-restore --filter "FullyQualifiedName~KscSpawnTests|FullyQualifiedName~VesselSwitchTreeTests" --verbosity minimal