### PR TITLE
Fix #563 tracking station control surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ All notable changes to Parsek are documented here.
 
 ### Features
 
+- `#563` Tracking Station now has a Parsek toolbar button and compact in-scene control surface. The panel exposes the Tracking Station ghost-visibility toggle, shared Recordings and Settings windows, and a small status readout for committed recordings, map ghosts, suppressed entries, and materialized vessels.
 - Timeline window now has a `Rewind/FF` filter button that shows only recordings you can currently rewind to or fast-forward to.
 - Timeline recording rows now expose the same `W` / `W*` watch control as the Recordings Manager, including disabled states when a ghost is unavailable and a clickable `W*` to stop watching.
 
@@ -139,6 +140,7 @@ All notable changes to Parsek are documented here.
 - `#560` The default solution build now compiles the deployable `Parsek` plugin project only, avoiding SDK 6.0's parallel solution-build false exit `1`; full test validation remains `dotnet test Source\Parsek.Tests\Parsek.Tests.csproj`.
 - `#556` Added headless coverage for known ghost NRE suppression plus earlier/later non-ghost missing-renderer mixes, different-stock-offset, unrelated-exception, and prior-stock-null `buildVesselsList` exception handling.
 - `#562` Added a headless regression that pins `GhostTrackingStationSelection.TryClearSelectedVessel` to the deselection-only orbit-renderer/patched-conics path and asserts it does not invoke stock `SetVessel` on the cleared selection.
+- `#563` Added headless Tracking Station control-surface UI coverage for status counts, compact labels, ghost-visibility setting application, and reuse of the shared Recordings/Settings window wiring.
 - `Bug278FinalizeLimboTests` now pins the orbit-only terminal-body heal path: a leaf with a stale `TerminalOrbitBody` but only orbit-segment evidence heals to the segment body and emits the `PopulateTerminalOrbitFromLastSegment: healed stale cached terminal orbit` log line.
 - The last xUnit smoke/assertion follow-ups now catch headless `ParsekUI.Cleanup()` teardown in the KSC wiring smoke test and anchor the Bug219 negative log checks to the full production log prefix instead of the overlapping `ShouldPopulate...` diagnostic.
 - Headless landed snapshot-repair coverage now survives Unity pseudo-null `CelestialBody` fixtures all the way through the real `REF` rewrite path instead of bailing out before the repaired surface orbit node is written.

--- a/Source/Parsek.Tests/TrackingStationControlSurfaceUITests.cs
+++ b/Source/Parsek.Tests/TrackingStationControlSurfaceUITests.cs
@@ -1,0 +1,169 @@
+using System.Collections.Generic;
+using System.Security;
+using UnityEngine;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    [Collection("Sequential")]
+    public class TrackingStationControlSurfaceUITests
+    {
+        [Fact]
+        public void BuildControlSurfaceState_CountsRecordingsAndMaterializedVessels()
+        {
+            var committed = new List<Recording>
+            {
+                new Recording(),
+                new Recording { VesselSpawned = true },
+                new Recording { SpawnedVesselPersistentId = 42 },
+                null
+            };
+
+            ParsekTrackingStation.TrackingStationControlSurfaceState state =
+                ParsekTrackingStation.BuildControlSurfaceState(
+                    committed,
+                    visibleGhostVessels: 3,
+                    suppressedRecordings: 2,
+                    showGhosts: true);
+
+            Assert.Equal(4, state.CommittedRecordings);
+            Assert.Equal(3, state.VisibleGhostVessels);
+            Assert.Equal(2, state.SuppressedRecordings);
+            Assert.Equal(2, state.MaterializedRecordings);
+            Assert.True(state.ShowGhosts);
+        }
+
+        [Fact]
+        public void BuildControlSurfaceState_ClampsNegativeExternalCounts()
+        {
+            ParsekTrackingStation.TrackingStationControlSurfaceState state =
+                ParsekTrackingStation.BuildControlSurfaceState(
+                    committed: null,
+                    visibleGhostVessels: -4,
+                    suppressedRecordings: -2,
+                    showGhosts: false);
+
+            Assert.Equal(0, state.CommittedRecordings);
+            Assert.Equal(0, state.VisibleGhostVessels);
+            Assert.Equal(0, state.SuppressedRecordings);
+            Assert.Equal(0, state.MaterializedRecordings);
+            Assert.False(state.ShowGhosts);
+        }
+
+        [Fact]
+        public void FormatControlSurfaceLines_UsesCompactStableLabels()
+        {
+            var state = new ParsekTrackingStation.TrackingStationControlSurfaceState
+            {
+                CommittedRecordings = 7,
+                VisibleGhostVessels = 3,
+                SuppressedRecordings = 2,
+                MaterializedRecordings = 1,
+                ShowGhosts = true
+            };
+
+            Assert.Equal(
+                "Recordings: 7 | Map ghosts: 3",
+                ParsekTrackingStation.FormatControlSurfaceCountsLine(state));
+            Assert.Equal(
+                "Suppressed: 2 | Materialized: 1",
+                ParsekTrackingStation.FormatControlSurfaceLifecycleLine(state));
+        }
+
+        [Fact]
+        public void TryApplyGhostVisibilitySetting_UpdatesLiveSettingsWhenPresent()
+        {
+            var settings = new ParsekSettings { showGhostsInTrackingStation = true };
+
+            bool applied = ParsekTrackingStation.TryApplyGhostVisibilitySetting(
+                settings,
+                showGhosts: false);
+
+            Assert.True(applied);
+            Assert.False(settings.showGhostsInTrackingStation);
+        }
+
+        [Fact]
+        public void TryApplyGhostVisibilitySetting_NullSettings_ReturnsFalse()
+        {
+            bool applied = ParsekTrackingStation.TryApplyGhostVisibilitySetting(
+                null,
+                showGhosts: false);
+
+            Assert.False(applied);
+        }
+
+        [Theory]
+        [InlineData(EventType.Repaint, false, true)]
+        [InlineData(EventType.MouseDown, false, true)]
+        [InlineData(EventType.MouseUp, false, true)]
+        [InlineData(EventType.MouseDown, true, false)]
+        [InlineData(EventType.MouseUp, true, false)]
+        [InlineData(EventType.Layout, false, false)]
+        public void ShouldProcessAtmosphericMarkerEvent_OnlyPassesAllowedCases(
+            EventType eventType,
+            bool pointerOverParsekWindow,
+            bool expected)
+        {
+            Assert.Equal(
+                expected,
+                ParsekTrackingStation.ShouldProcessAtmosphericMarkerEvent(
+                    eventType,
+                    pointerOverParsekWindow));
+        }
+
+        [Fact]
+        public void IsPointerOverOpenWindow_RequiresOpenSizedRectContainingMouse()
+        {
+            Rect rect = new Rect(20f, 40f, 120f, 80f);
+            Vector2 inside = new Vector2(60f, 70f);
+            Vector2 outside = new Vector2(200f, 70f);
+
+            Assert.True(ParsekUI.IsPointerOverOpenWindow(true, rect, inside));
+            Assert.False(ParsekUI.IsPointerOverOpenWindow(false, rect, inside));
+            Assert.False(ParsekUI.IsPointerOverOpenWindow(true, default, inside));
+            Assert.False(ParsekUI.IsPointerOverOpenWindow(true, rect, outside));
+        }
+
+        [Theory]
+        [InlineData(UIMode.Flight, true)]
+        [InlineData(UIMode.KSC, true)]
+        [InlineData(UIMode.TrackingStation, false)]
+        public void CanOfferGhostOnlyDelete_MatchesSceneCompatibility(UIMode mode, bool expected)
+        {
+            Assert.Equal(expected, RecordingsTableUI.CanOfferGhostOnlyDelete(mode));
+        }
+
+        [Fact]
+        public void ParsekUI_TrackingStationCtor_ExposesReusableRecordingsAndSettingsWindows()
+        {
+            var ui = new ParsekUI(UIMode.TrackingStation);
+            try
+            {
+                Assert.NotNull(ui.GetRecordingsTableUI());
+                Assert.NotNull(ui.GetSettingsWindowUI());
+
+                Assert.False(ui.GetRecordingsTableUI().IsOpen);
+                Assert.False(ui.GetSettingsWindowUI().IsOpen);
+
+                ui.ToggleRecordingsWindow();
+                ui.ToggleSettingsWindow();
+
+                Assert.True(ui.GetRecordingsTableUI().IsOpen);
+                Assert.True(ui.GetSettingsWindowUI().IsOpen);
+            }
+            finally
+            {
+                try
+                {
+                    ui.Cleanup();
+                }
+                catch (SecurityException)
+                {
+                    // Headless xUnit can still lack Unity GUI teardown; this test only
+                    // cares about Tracking Station window wiring.
+                }
+            }
+        }
+    }
+}

--- a/Source/Parsek/ParsekTrackingStation.cs
+++ b/Source/Parsek/ParsekTrackingStation.cs
@@ -1,4 +1,8 @@
 using System.Collections.Generic;
+using System.Globalization;
+using ClickThroughFix;
+using KSP.UI.Screens;
+using ToolbarControl_NS;
 using UnityEngine;
 
 namespace Parsek
@@ -24,6 +28,10 @@ namespace Parsek
         private const string Tag = "TrackingStation";
         private const float LifecycleCheckIntervalSec = 2.0f;
         private float nextLifecycleCheckTime;
+        private ToolbarControl toolbarControl;
+        private ParsekUI ui;
+        private bool showUI;
+        private Rect windowRect = new Rect(20, 100, 250, 10);
 
         /// <summary>Cached interpolation indices for atmospheric ghost icon rendering (per recording index).</summary>
         private readonly Dictionary<int, int> atmosCachedIndices = new Dictionary<int, int>();
@@ -38,8 +46,20 @@ namespace Parsek
         /// </summary>
         private bool lastKnownShowGhosts = true;
 
+        internal struct TrackingStationControlSurfaceState
+        {
+            internal int CommittedRecordings;
+            internal int VisibleGhostVessels;
+            internal int SuppressedRecordings;
+            internal int MaterializedRecordings;
+            internal bool ShowGhosts;
+        }
+
         void Start()
         {
+            ui = new ParsekUI(UIMode.TrackingStation);
+            InstallToolbar();
+
             // Read through the persistence store so the startup tick uses the
             // recorded user preference even when ParsekSettings.Current isn't
             // resolved yet (early-scene-load case, see ParsekScenario.cs:546).
@@ -61,6 +81,26 @@ namespace Parsek
                 $"showGhostsInTrackingStation={lastKnownShowGhosts}, " +
                 $"trackingStationSuppressed={suppressedForGhosts}, " +
                 "orbitSourceDiagnostics=aggregated");
+        }
+
+        private void InstallToolbar()
+        {
+            toolbarControl = gameObject.AddComponent<ToolbarControl>();
+            toolbarControl.AddToAllToolbars(
+                () => { showUI = true; ParsekLog.Verbose(Tag, "Toolbar button ON"); },
+                () => { showUI = false; ParsekLog.Verbose(Tag, "Toolbar button OFF"); },
+                ApplicationLauncher.AppScenes.TRACKSTATION,
+                ParsekFlight.MODID, "parsekTrackingStationButton",
+                "Parsek/Textures/parsek_64",
+                "Parsek/Textures/parsek_32",
+                ParsekFlight.MODNAME
+            );
+
+            ui.CloseMainWindow = () =>
+            {
+                showUI = false;
+                if (toolbarControl != null) toolbarControl.SetFalse();
+            };
         }
 
         void Update()
@@ -106,6 +146,12 @@ namespace Parsek
 
         void OnGUI()
         {
+            DrawAtmosphericMarkers();
+            DrawControlSurface();
+        }
+
+        private void DrawAtmosphericMarkers()
+        {
             // Draw icons for recordings in atmospheric phases (no ProtoVessel).
             // Position comes directly from trajectory point interpolation —
             // same approach as ParsekUI.DrawMapMarkers in the flight scene.
@@ -113,10 +159,12 @@ namespace Parsek
             // sticky-label handling in MapMarkerRenderer (#386) can consume
             // clicks. Previously this gate short-circuited on anything but
             // Repaint, which made the click-to-pin interaction dead in TS.
-            var etype = Event.current.type;
-            if (etype != EventType.Repaint
-                && etype != EventType.MouseDown
-                && etype != EventType.MouseUp) return;
+            Event currentEvent = Event.current;
+            EventType etype = currentEvent.type;
+            if (!ShouldProcessAtmosphericMarkerEvent(
+                    etype,
+                    IsPointerOverParsekWindow(currentEvent.mousePosition)))
+                return;
             if (PlanetariumCamera.Camera == null) return;
 
             // #388: skip the whole atmospheric-marker pass when the user has
@@ -160,6 +208,191 @@ namespace Parsek
                     $"terminal={rec.TerminalStateValue?.ToString() ?? "null"} " +
                     $"lat={pt.Value.latitude:F2} lon={pt.Value.longitude:F2} alt={pt.Value.altitude:F0}");
             }
+        }
+
+        internal bool IsPointerOverParsekWindow(Vector2 mousePosition)
+        {
+            return ParsekUI.IsPointerOverOpenWindow(showUI, windowRect, mousePosition)
+                || (ui != null && ui.IsMouseOverOpenAuxiliaryWindows(mousePosition));
+        }
+
+        internal static bool ShouldProcessAtmosphericMarkerEvent(
+            EventType eventType,
+            bool pointerOverParsekWindow)
+        {
+            if (eventType != EventType.Repaint
+                && eventType != EventType.MouseDown
+                && eventType != EventType.MouseUp)
+                return false;
+
+            if (pointerOverParsekWindow
+                && (eventType == EventType.MouseDown || eventType == EventType.MouseUp))
+                return false;
+
+            return true;
+        }
+
+        private void DrawControlSurface()
+        {
+            if (!showUI || ui == null) return;
+
+            windowRect.height = 0f;
+            var opaqueWindowStyle = ui.GetOpaqueWindowStyle();
+            if (opaqueWindowStyle == null)
+                return;
+
+            ParsekUI.ResetWindowGuiColors(
+                out Color prevColor,
+                out Color prevBackgroundColor,
+                out Color prevContentColor);
+            try
+            {
+                windowRect = ClickThruBlocker.GUILayoutWindow(
+                    GetInstanceID(),
+                    windowRect,
+                    DrawControlSurfaceWindow,
+                    "Parsek",
+                    opaqueWindowStyle,
+                    GUILayout.Width(250));
+            }
+            finally
+            {
+                ParsekUI.RestoreWindowGuiColors(prevColor, prevBackgroundColor, prevContentColor);
+            }
+
+            ui.LogMainWindowPosition(windowRect);
+            ui.DrawRecordingsWindowIfOpen(windowRect);
+            ui.DrawSettingsWindowIfOpen(windowRect);
+            ui.DrawTestRunnerWindowIfOpen(windowRect, this);
+        }
+
+        private void DrawControlSurfaceWindow(int windowID)
+        {
+            TrackingStationControlSurfaceState state = BuildControlSurfaceState(
+                RecordingStore.CommittedRecordings,
+                GhostMapPresence.ghostMapVesselPids.Count,
+                GhostMapPresence.CachedTrackingStationSuppressedIds?.Count ?? 0,
+                ParsekSettingsPersistence.EffectiveShowGhostsInTrackingStation());
+
+            GUILayout.BeginVertical();
+
+            GUILayout.Label("Tracking Station", GUI.skin.box);
+            GUILayout.Label(state.ShowGhosts ? "Ghosts: visible" : "Ghosts: hidden");
+            GUILayout.Label(FormatControlSurfaceCountsLine(state));
+            GUILayout.Label(FormatControlSurfaceLifecycleLine(state));
+
+            GUILayout.Space(10f);
+
+            bool showGhosts = GUILayout.Toggle(
+                state.ShowGhosts,
+                new GUIContent(
+                    " Show ghosts in Tracking Station",
+                    "Show or hide Parsek ghost vessels and markers in the Tracking Station"));
+            if (showGhosts != state.ShowGhosts)
+                SetShowGhostsFromControlSurface(showGhosts);
+
+            GUILayout.Space(10f);
+
+            if (GUILayout.Button(string.Format(
+                    CultureInfo.InvariantCulture,
+                    "Recordings ({0})",
+                    state.CommittedRecordings)))
+            {
+                ui.ToggleRecordingsWindow();
+            }
+
+            if (GUILayout.Button("Settings"))
+                ui.ToggleSettingsWindow();
+
+            GUILayout.Space(10f);
+            if (GUILayout.Button("Close"))
+            {
+                showUI = false;
+                if (toolbarControl != null) toolbarControl.SetFalse();
+                ParsekLog.Verbose(Tag, "Control surface closed via button");
+            }
+
+            GUILayout.EndVertical();
+            GUI.DragWindow();
+        }
+
+        private void SetShowGhostsFromControlSurface(bool showGhosts)
+        {
+            bool liveSettingsUpdated = TryApplyGhostVisibilitySetting(
+                ParsekSettings.Current,
+                showGhosts);
+            ParsekSettingsPersistence.RecordShowGhostsInTrackingStation(showGhosts);
+            lastKnownShowGhosts = showGhosts;
+
+            if (!showGhosts)
+                GhostMapPresence.RemoveAllGhostVessels("tracking-station-ui-toggle");
+
+            nextLifecycleCheckTime = 0f;
+            ParsekLog.Info(Tag,
+                $"Control surface set showGhostsInTrackingStation={showGhosts} " +
+                $"liveSettingsUpdated={liveSettingsUpdated}");
+        }
+
+        internal static bool TryApplyGhostVisibilitySetting(ParsekSettings settings, bool showGhosts)
+        {
+            if (settings == null)
+                return false;
+
+            settings.showGhostsInTrackingStation = showGhosts;
+            return true;
+        }
+
+        internal static TrackingStationControlSurfaceState BuildControlSurfaceState(
+            IReadOnlyList<Recording> committed,
+            int visibleGhostVessels,
+            int suppressedRecordings,
+            bool showGhosts)
+        {
+            int committedCount = committed?.Count ?? 0;
+            int materialized = 0;
+            if (committed != null)
+            {
+                for (int i = 0; i < committed.Count; i++)
+                {
+                    Recording rec = committed[i];
+                    if (rec != null && (rec.VesselSpawned || rec.SpawnedVesselPersistentId != 0))
+                        materialized++;
+                }
+            }
+
+            return new TrackingStationControlSurfaceState
+            {
+                CommittedRecordings = ClampNonNegative(committedCount),
+                VisibleGhostVessels = ClampNonNegative(visibleGhostVessels),
+                SuppressedRecordings = ClampNonNegative(suppressedRecordings),
+                MaterializedRecordings = ClampNonNegative(materialized),
+                ShowGhosts = showGhosts
+            };
+        }
+
+        internal static string FormatControlSurfaceCountsLine(
+            TrackingStationControlSurfaceState state)
+        {
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                "Recordings: {0} | Map ghosts: {1}",
+                state.CommittedRecordings,
+                state.VisibleGhostVessels);
+        }
+
+        internal static string FormatControlSurfaceLifecycleLine(
+            TrackingStationControlSurfaceState state)
+        {
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                "Suppressed: {0} | Materialized: {1}",
+                state.SuppressedRecordings,
+                state.MaterializedRecordings);
+        }
+
+        private static int ClampNonNegative(int value)
+        {
+            return value < 0 ? 0 : value;
         }
 
         /// <summary>
@@ -225,6 +458,14 @@ namespace Parsek
             // Flight scene's own OnSceneChangeRequested hook runs too, but this
             // addon is the only always-present TS listener — keep it defensive.
             MapMarkerRenderer.ResetForSceneChange();
+            ui?.Cleanup();
+            ui = null;
+            if (toolbarControl != null)
+            {
+                toolbarControl.OnDestroy();
+                Destroy(toolbarControl);
+                toolbarControl = null;
+            }
             ParsekLog.Info(Tag, "ParsekTrackingStation destroyed");
         }
     }

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 namespace Parsek
 {
-    public enum UIMode { Flight, KSC }
+    public enum UIMode { Flight, KSC, TrackingStation }
 
     /// <summary>
     /// UI rendering for the Parsek window and map view markers.
@@ -78,8 +78,10 @@ namespace Parsek
         internal readonly TimeRangeFilterState TimeRangeFilter = new TimeRangeFilterState();
 
         internal ParsekFlight Flight => flight;
+        internal UIMode Mode => mode;
         internal bool InFlightMode => InFlight;
         internal RecordingsTableUI GetRecordingsTableUI() => recordingsTableUI;
+        internal SettingsWindowUI GetSettingsWindowUI() => settingsUI;
         internal TimelineWindowUI GetTimelineUI() => timelineUI;
         internal CareerStateWindowUI GetCareerStateUI() { return careerStateUI; }
 
@@ -198,10 +200,7 @@ namespace Parsek
             // session-suppressed).
             int committedCount = EffectiveState.ComputeERS().Count;
             if (GUILayout.Button($"Recordings ({committedCount})"))
-            {
-                recordingsTableUI.IsOpen = !recordingsTableUI.IsOpen;
-                ParsekLog.Verbose("UI", $"Recordings window toggled: {(recordingsTableUI.IsOpen ? "open" : "closed")}");
-            }
+                ToggleRecordingsWindow();
 
             GUILayout.Space(SpacingLarge);
 
@@ -233,10 +232,7 @@ namespace Parsek
 
             // --- Settings ---
             if (GUILayout.Button("Settings"))
-            {
-                settingsUI.IsOpen = !settingsUI.IsOpen;
-                ParsekLog.Verbose("UI", $"Settings window toggled: {(settingsUI.IsOpen ? "open" : "closed")}");
-            }
+                ToggleSettingsWindow();
 
             // --- Version footer (version on the left, Close button fills the rest) ---
             GUILayout.Space(SpacingLarge);
@@ -348,6 +344,18 @@ namespace Parsek
         public void DrawRecordingsWindowIfOpen(Rect mainWindowRect)
         {
             recordingsTableUI.DrawIfOpen(mainWindowRect);
+        }
+
+        internal void ToggleRecordingsWindow()
+        {
+            recordingsTableUI.IsOpen = !recordingsTableUI.IsOpen;
+            ParsekLog.Verbose("UI", $"Recordings window toggled: {(recordingsTableUI.IsOpen ? "open" : "closed")}");
+        }
+
+        internal void ToggleSettingsWindow()
+        {
+            settingsUI.IsOpen = !settingsUI.IsOpen;
+            ParsekLog.Verbose("UI", $"Settings window toggled: {(settingsUI.IsOpen ? "open" : "closed")}");
         }
 
         // ════════════════════════════════════════════════════════════════
@@ -943,6 +951,21 @@ namespace Parsek
         public void DrawTestRunnerWindowIfOpen(Rect mainWindowRect, MonoBehaviour host)
         {
             testRunnerUI.DrawIfOpen(mainWindowRect, host);
+        }
+
+        internal bool IsMouseOverOpenAuxiliaryWindows(Vector2 mousePosition)
+        {
+            return recordingsTableUI.IsMouseOverOpenWindow(mousePosition)
+                || settingsUI.IsMouseOverOpenWindow(mousePosition)
+                || testRunnerUI.IsMouseOverOpenWindow(mousePosition);
+        }
+
+        internal static bool IsPointerOverOpenWindow(bool isOpen, Rect windowRect, Vector2 mousePosition)
+        {
+            return isOpen
+                && windowRect.width > 0f
+                && windowRect.height > 0f
+                && windowRect.Contains(mousePosition);
         }
 
         internal void ToggleTestRunner()

--- a/Source/Parsek/UI/RecordingsTableUI.cs
+++ b/Source/Parsek/UI/RecordingsTableUI.cs
@@ -247,6 +247,14 @@ namespace Parsek
             this.groupPicker = new GroupPickerUI(parentUI);
         }
 
+        internal bool IsMouseOverOpenWindow(Vector2 mousePosition)
+        {
+            return ParsekUI.IsPointerOverOpenWindow(
+                showRecordingsWindow,
+                recordingsWindowRect,
+                mousePosition);
+        }
+
         /// <summary>
         /// Called by the Timeline GoTo button. Ensures the target recording is visible
         /// (unhides if hidden, disables hide filter if needed, expands parent groups),
@@ -1396,7 +1404,7 @@ namespace Parsek
             if (captureThisRow) AlignDebugLogLastRect(alignmentDebugRowLog, "rowStatus");
 
             // Group assignment button (split with X delete for ghost-only recordings)
-            if (rec.IsGhostOnly)
+            if (rec.IsGhostOnly && CanOfferGhostOnlyDelete(parentUI.Mode))
             {
                 bool ghostGClicked, ghostXClicked;
                 DrawBodyCenteredTwoButtons("G", "X", ColW_Group, out ghostGClicked, out ghostXClicked);
@@ -3058,6 +3066,12 @@ namespace Parsek
         {
             // [ERS-exempt] reason: delete operates by index into the raw
             // committed list. See TODO(phase 6+) on DrawRecordingsWindow.
+            if (!CanOfferGhostOnlyDelete(parentUI.Mode))
+            {
+                ParsekLog.Warn("UI",
+                    $"DeleteGhostOnlyRecording ignored in {parentUI.Mode} mode: index={index}");
+                return;
+            }
             var committed = RecordingStore.CommittedRecordings;
             if (index < 0 || index >= committed.Count)
             {
@@ -3087,6 +3101,11 @@ namespace Parsek
             InvalidateSort();
             ParsekLog.Info("UI",
                 $"Deleted ghost-only recording \"{rec.VesselName}\" (id={rec.RecordingId})");
+        }
+
+        internal static bool CanOfferGhostOnlyDelete(UIMode mode)
+        {
+            return mode != UIMode.TrackingStation;
         }
 
         private void DrawSortableHeader(string label, SortColumn col, float width, bool expand = false)

--- a/Source/Parsek/UI/SettingsWindowUI.cs
+++ b/Source/Parsek/UI/SettingsWindowUI.cs
@@ -102,6 +102,14 @@ namespace Parsek
             settingsWindowHasInputLock = false;
         }
 
+        internal bool IsMouseOverOpenWindow(Vector2 mousePosition)
+        {
+            return ParsekUI.IsPointerOverOpenWindow(
+                showSettingsWindow,
+                settingsWindowRect,
+                mousePosition);
+        }
+
         private void CommitAutoLoopEdit(ParsekSettings s)
         {
             var ic = System.Globalization.CultureInfo.InvariantCulture;

--- a/Source/Parsek/UI/TestRunnerUI.cs
+++ b/Source/Parsek/UI/TestRunnerUI.cs
@@ -111,6 +111,14 @@ namespace Parsek
             testRunnerWindowHasInputLock = false;
         }
 
+        internal bool IsMouseOverOpenWindow(Vector2 mousePosition)
+        {
+            return ParsekUI.IsPointerOverOpenWindow(
+                showTestRunnerWindow,
+                testRunnerWindowRect,
+                mousePosition);
+        }
+
         private void RebuildTestGroupCache()
         {
             var groups = new Dictionary<string, List<InGameTestInfo>>();

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -732,6 +732,20 @@ Both cases are valid data, but they clutter the UI and read like broken/empty gh
 
 ---
 
+## ~~563. Tracking Station needs an in-scene Parsek control surface comparable to Map View~~
+
+**Source:** Tracking Station / Map Mode UI audit from the `#561` investigation.
+
+**Concern:** Map View and Flight/KSC scenes expose the Parsek button/window surface, while Tracking Station mostly exposes only stock map objects plus defensive ghost blocking. A player can inspect ghosts there but cannot conveniently toggle Parsek ghost visibility, open Recordings/Settings, see Parsek status, or understand why a TS object is ghost-only, materialized, suppressed, or blocked.
+
+**Fix:** Tracking Station now installs a Parsek toolbar button and draws a compact IMGUI control surface using the same opaque window styling as the existing scene UI. The panel exposes the sticky `Show ghosts in Tracking Station` toggle, shared Recordings and Settings windows, and status rows for committed recordings, current map ghosts, suppressed entries, and materialized vessels. The ghost toggle updates live settings when available, persists through `ParsekSettingsPersistence`, removes ghost ProtoVessels immediately when disabled, and forces the next lifecycle tick when changed.
+
+**Files:** `Source/Parsek/ParsekTrackingStation.cs`, `Source/Parsek/ParsekUI.cs`, `Source/Parsek/UI/RecordingsTableUI.cs`, `Source/Parsek/UI/SettingsWindowUI.cs`, `Source/Parsek/UI/TestRunnerUI.cs`, `Source/Parsek.Tests/TrackingStationControlSurfaceUITests.cs`.
+
+**Status:** CLOSED 2026-04-23. Fixed for v0.8.3 by `#563`. Runtime collection of Tracking Station scene smoke evidence remains tracked separately by `#554`.
+
+---
+
 ## ~~553. Untagged pre-recording FLIGHT contract events can miss the ledger because the direct path was KSC-only~~
 
 **Source:** latest collected package `logs/2026-04-23_1829_logs-package/`. The launch-site contract path emitted untagged `ContractAccepted` / `ContractCompleted` events with `tag=''` and no recording owner, while the ledger needed the accepted contract to preserve the active contract and advance.


### PR DESCRIPTION
Add the Tracking Station Parsek control surface and its UI tests. This branch/worktree started as #552, but the changelog and todo docs were renumbered to #563 on current main because #552 is already taken by the recovery-funds fix. Validation: dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter FullyQualifiedName~TrackingStationControlSurfaceUITests|FullyQualifiedName~RecordingsTableUITests; dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter FullyQualifiedName!=Parsek.Tests.SyntheticRecordingTests.InjectAllRecordings (the excluded test is blocked by the shared KSP install lock).