### PR TITLE
Filter timeline resource seeds by game mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,7 @@ All notable changes to Parsek are documented here.
 - `#556` Tracking Station `buildVesselsList` finalizer now suppresses only the known ghost ProtoVessel missing-orbit-renderer NRE shape, using the first failing missing-renderer vessel plus the stock IL offset when available; unrelated or ambiguous stock exceptions are warned with vessel-context counts and left visible.
 - `#562` Tracking Station ghost-selection clearing now also zeroes the previously selected vessel's `orbitRenderer.isFocused`/`drawIcons` and detaches its patched-conics solver before nulling the private `selectedVessel` field, so focusing a Parsek ghost no longer leaves the earlier real-vessel orbit focus and patched-conics state latched without re-entering stock `SpaceTracking.SetVessel`.
 - `#564` Tracking Station ghost selections now open a Parsek-owned ghost action panel with safe Focus, Target, Recording details, and a selected-recording-only Materialize action keyed by stable recording ID; the panel refreshes action eligibility every GUI frame, and when that ghost resolves, Target and map Focus now hand off to the materialized real vessel, while stock Fly/Delete/Recover remain explicitly blocked and the private KSP selected-vessel field is still cleared on every ghost block.
+- Timeline initial-resource rows now respect the save mode: Sandbox hides resource seed rows entirely, and Science mode shows only the science baseline instead of zero funds/reputation noise.
 
 ### Tests
 

--- a/Source/Parsek.Tests/TimelineBuilderTests.cs
+++ b/Source/Parsek.Tests/TimelineBuilderTests.cs
@@ -226,6 +226,99 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void SandboxMode_HidesInitialResourceSeedRows()
+        {
+            var actions = new List<GameAction>
+            {
+                new GameAction { UT = 0, Type = GameActionType.FundsInitial, InitialFunds = 0f, Effective = true },
+                new GameAction { UT = 0, Type = GameActionType.ScienceInitial, InitialScience = 0f, Effective = true },
+                new GameAction { UT = 0, Type = GameActionType.ReputationInitial, InitialReputation = 0f, Effective = true }
+            };
+
+            var result = TimelineBuilder.Build(
+                new List<Recording>(),
+                actions,
+                new List<Milestone>(),
+                _ => true,
+                Game.Modes.SANDBOX);
+
+            Assert.Empty(result);
+            Assert.Contains(logLines, l =>
+                l.Contains("[Timeline]") && l.Contains("Filtered 3 mode-inapplicable initial resource"));
+        }
+
+        [Fact]
+        public void ScienceSandboxMode_ShowsOnlyScienceInitialSeedRow()
+        {
+            var actions = new List<GameAction>
+            {
+                new GameAction { UT = 0, Type = GameActionType.FundsInitial, InitialFunds = 25000f, Effective = true },
+                new GameAction { UT = 0, Type = GameActionType.ScienceInitial, InitialScience = 12.5f, Effective = true },
+                new GameAction { UT = 0, Type = GameActionType.ReputationInitial, InitialReputation = 0f, Effective = true }
+            };
+
+            var result = TimelineBuilder.Build(
+                new List<Recording>(),
+                actions,
+                new List<Milestone>(),
+                _ => true,
+                Game.Modes.SCIENCE_SANDBOX);
+
+            var entry = Assert.Single(result);
+            Assert.Equal(TimelineEntryType.ScienceInitial, entry.Type);
+            Assert.Equal("Starting science: 12.5", entry.DisplayText);
+            Assert.Contains(logLines, l =>
+                l.Contains("[Timeline]") && l.Contains("Filtered 2 mode-inapplicable initial resource"));
+        }
+
+        [Fact]
+        public void CareerMode_ShowsAllInitialResourceSeedRows()
+        {
+            var actions = new List<GameAction>
+            {
+                new GameAction { UT = 0, Type = GameActionType.FundsInitial, InitialFunds = 25000f, Effective = true },
+                new GameAction { UT = 0, Type = GameActionType.ScienceInitial, InitialScience = 12.5f, Effective = true },
+                new GameAction { UT = 0, Type = GameActionType.ReputationInitial, InitialReputation = 25f, Effective = true }
+            };
+
+            var result = TimelineBuilder.Build(
+                new List<Recording>(),
+                actions,
+                new List<Milestone>(),
+                _ => true,
+                Game.Modes.CAREER);
+
+            Assert.Equal(3, result.Count);
+            Assert.Contains(result, e => e.Type == TimelineEntryType.FundsInitial);
+            Assert.Contains(result, e => e.Type == TimelineEntryType.ScienceInitial);
+            Assert.Contains(result, e => e.Type == TimelineEntryType.ReputationInitial);
+        }
+
+        [Fact]
+        public void NullMode_LeavesInitialResourceSeedRowsVisible()
+        {
+            var actions = new List<GameAction>
+            {
+                new GameAction { UT = 0, Type = GameActionType.FundsInitial, InitialFunds = 25000f, Effective = true },
+                new GameAction { UT = 0, Type = GameActionType.ScienceInitial, InitialScience = 12.5f, Effective = true },
+                new GameAction { UT = 0, Type = GameActionType.ReputationInitial, InitialReputation = 25f, Effective = true }
+            };
+            Game.Modes? nullMode = null;
+
+            var result = TimelineBuilder.Build(
+                new List<Recording>(),
+                actions,
+                new List<Milestone>(),
+                _ => true,
+                nullMode);
+
+            Assert.Equal(3, result.Count);
+            Assert.Contains(result, e => e.Type == TimelineEntryType.FundsInitial);
+            Assert.Contains(result, e => e.Type == TimelineEntryType.ScienceInitial);
+            Assert.Contains(result, e => e.Type == TimelineEntryType.ReputationInitial);
+        }
+
+        [Fact]
         public void MilestoneText_IncludesAllRewardLegs()
         {
             string text = TimelineEntryDisplay.GetGameActionText(

--- a/Source/Parsek/Timeline/TimelineBuilder.cs
+++ b/Source/Parsek/Timeline/TimelineBuilder.cs
@@ -26,7 +26,8 @@ namespace Parsek
             IReadOnlyList<Recording> committedRecordings,
             IReadOnlyList<GameAction> ledgerActions,
             IReadOnlyList<Milestone> milestones,
-            Func<GameStateEvent, bool> isLegacyEventVisible)
+            Func<GameStateEvent, bool> isLegacyEventVisible,
+            Game.Modes? currentMode = null)
         {
             // Build recording-id to vessel-name lookup once, shared by both collectors
             var vesselNameById = new Dictionary<string, string>();
@@ -45,7 +46,7 @@ namespace Parsek
             var entries = new List<TimelineEntry>();
 
             int recordingCount = CollectRecordingEntries(committedRecordings, vesselNameById, entries);
-            int actionCount = CollectGameActionEntries(ledgerActions, vesselNameById, evaBranchKeys, entries);
+            int actionCount = CollectGameActionEntries(ledgerActions, vesselNameById, evaBranchKeys, currentMode, entries);
             int legacyCount = CollectLegacyEntries(
                 milestones,
                 isLegacyEventVisible ?? (_ => true),
@@ -442,13 +443,22 @@ namespace Parsek
             IReadOnlyList<GameAction> ledgerActions,
             Dictionary<string, string> vesselNameById,
             HashSet<string> evaBranchKeys,
+            Game.Modes? currentMode,
             List<TimelineEntry> entries)
         {
             int count = 0;
             int evaReassignSkipped = 0;
+            int modeSeedSkipped = 0;
             for (int i = 0; i < ledgerActions.Count; i++)
             {
                 var action = ledgerActions[i];
+
+                if (!IsInitialResourceSeedVisibleInMode(action.Type, currentMode))
+                {
+                    modeSeedSkipped++;
+                    continue;
+                }
+
                 var entryType = TimelineEntryDisplay.MapGameActionType(action.Type);
                 var tier = TimelineEntryDisplay.GetTier(entryType);
 
@@ -502,7 +512,40 @@ namespace Parsek
                 ParsekLog.Verbose("Timeline",
                     $"Filtered {evaReassignSkipped} KerbalAssignment action(s) at EVA branch time(s)");
 
+            if (modeSeedSkipped > 0)
+                ParsekLog.Verbose("Timeline",
+                    $"Filtered {modeSeedSkipped} mode-inapplicable initial resource action(s)");
+
             return count;
+        }
+
+        internal static bool IsInitialResourceSeedVisibleInMode(GameActionType type, Game.Modes? currentMode)
+        {
+            if (!IsInitialResourceSeed(type))
+                return true;
+            if (!currentMode.HasValue)
+                return true;
+
+            switch (currentMode.Value)
+            {
+                case Game.Modes.SCIENCE_SANDBOX:
+                    return type == GameActionType.ScienceInitial;
+
+                case Game.Modes.SANDBOX:
+                case Game.Modes.MISSION_BUILDER:
+                case Game.Modes.MISSION:
+                    return false;
+
+                default:
+                    return true;
+            }
+        }
+
+        private static bool IsInitialResourceSeed(GameActionType type)
+        {
+            return type == GameActionType.FundsInitial
+                || type == GameActionType.ScienceInitial
+                || type == GameActionType.ReputationInitial;
         }
 
         private static bool CanCompactMilestoneEntry(TimelineEntry entry)

--- a/Source/Parsek/UI/TimelineWindowUI.cs
+++ b/Source/Parsek/UI/TimelineWindowUI.cs
@@ -324,7 +324,8 @@ namespace Parsek
                     EffectiveState.ComputeERS(),
                     EffectiveState.ComputeELS(),
                     MilestoneStore.Milestones,
-                    GameStateStore.IsEventVisibleToCurrentTimeline);
+                    GameStateStore.IsEventVisibleToCurrentTimeline,
+                    GetCurrentGameMode());
                 timelineDirty = false;
                 filterDirty = true;
 
@@ -395,6 +396,19 @@ namespace Parsek
                 "Timeline window");
 
             GUI.DragWindow();
+        }
+
+        private static Game.Modes? GetCurrentGameMode()
+        {
+            try
+            {
+                var currentGame = HighLogic.CurrentGame;
+                if (currentGame != null)
+                    return currentGame.Mode;
+            }
+            catch (NullReferenceException) { }
+
+            return null;
         }
 
         private void DrawFilterBar()
@@ -1094,13 +1108,9 @@ namespace Parsek
 
         private void DrawResourceBudget()
         {
-            // Hide budget entirely in sandbox mode
-            try
-            {
-                if (HighLogic.CurrentGame?.Mode == Game.Modes.SANDBOX)
-                    return;
-            }
-            catch { }
+            Game.Modes? currentMode = GetCurrentGameMode();
+            if (currentMode == Game.Modes.SANDBOX)
+                return;
 
             var budget = parentUI.GetCachedBudget();
 
@@ -1112,9 +1122,7 @@ namespace Parsek
             GUILayout.Label("Resources", parentUI.GetSectionHeaderStyle());
 
             bool anyOverCommitted = false;
-            bool isScienceMode = false;
-            try { isScienceMode = HighLogic.CurrentGame?.Mode == Game.Modes.SCIENCE_SANDBOX; }
-            catch { }
+            bool isScienceMode = currentMode == Game.Modes.SCIENCE_SANDBOX;
 
             if (!isScienceMode && budget.reservedFunds > 0)
             {


### PR DESCRIPTION
## Summary
- Pass the current KSP game mode into the timeline builder.
- Hide initial resource seed rows that do not apply to Sandbox or Science saves.
- Add timeline regressions for Sandbox, Science, Career, and null-mode compatibility.

## Tests
- dotnet test Source\Parsek.Tests\Parsek.Tests.csproj --filter TimelineBuilderTests
- dotnet test Source\Parsek.Tests\Parsek.Tests.csproj