### PR TITLE
Refine spawn audit follow-up seams and coverage

### DIFF
--- a/Source/Parsek.Tests/EndOfRecordingWalkbackTests.cs
+++ b/Source/Parsek.Tests/EndOfRecordingWalkbackTests.cs
@@ -469,6 +469,52 @@ namespace Parsek.Tests
             Assert.True(Quaternion.Angle(Quaternion.Euler(0f, 90f, 0f), result.point.rotation) > 0.1f);
         }
 
+        [Fact]
+        public void WalkbackSubdividedDetailed_BodyTransition_LogsTieBreakChoice()
+        {
+            double latDelta = MetersToLatDegrees(6.0, KerbinRadius);
+            var points = new List<TrajectoryPoint>
+            {
+                new TrajectoryPoint
+                {
+                    ut = 100.0,
+                    latitude = 0.0,
+                    longitude = 0.0,
+                    altitude = 70.0,
+                    bodyName = "Mun",
+                    rotation = Quaternion.identity,
+                    velocity = Vector3.zero,
+                },
+                new TrajectoryPoint
+                {
+                    ut = 104.0,
+                    latitude = latDelta,
+                    longitude = 0.0,
+                    altitude = 80.0,
+                    bodyName = "Kerbin",
+                    rotation = Quaternion.identity,
+                    velocity = Vector3.zero,
+                },
+            };
+
+            int call = 0;
+            var result = SpawnCollisionDetector.WalkbackAlongTrajectorySubdividedDetailed(
+                points,
+                KerbinRadius,
+                1.5f,
+                PosClosure,
+                _ => { call++; return call <= 1; });
+
+            Assert.True(result.found);
+            Assert.Equal("Kerbin", result.point.bodyName);
+            Assert.Contains(logLines, l =>
+                l.Contains("[SpawnCollision]") &&
+                l.Contains("body transition") &&
+                l.Contains("later='Kerbin'") &&
+                l.Contains("earlier='Mun'") &&
+                l.Contains("using 'Kerbin'"));
+        }
+
         // ─────────────────────────────────────────────────────────────
         //  Degenerate inputs
         // ─────────────────────────────────────────────────────────────

--- a/Source/Parsek.Tests/SpawnAuditFollowupTests.cs
+++ b/Source/Parsek.Tests/SpawnAuditFollowupTests.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using UnityEngine;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    [Collection("Sequential")]
+    public class SpawnAuditFollowupTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+        private readonly Func<int, string> originalBodyNameResolver;
+        private readonly Func<string, CelestialBody> originalBodyResolver;
+        private readonly Func<CelestialBody, int> originalBodyIndexResolver;
+
+        public SpawnAuditFollowupTests()
+        {
+            originalBodyNameResolver = VesselSpawner.BodyNameResolverForTesting;
+            originalBodyResolver = VesselSpawner.BodyResolverForTesting;
+            originalBodyIndexResolver = VesselSpawner.BodyIndexResolverForTesting;
+
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.VerboseOverrideForTesting = true;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+        }
+
+        public void Dispose()
+        {
+            VesselSpawner.BodyNameResolverForTesting = originalBodyNameResolver;
+            VesselSpawner.BodyResolverForTesting = originalBodyResolver;
+            VesselSpawner.BodyIndexResolverForTesting = originalBodyIndexResolver;
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+        }
+
+        [Fact]
+        public void CleanupFailedSpawnedProtoVessel_DestroyFailureStillRemovesAndLogsWarning()
+        {
+            var pv = (ProtoVessel)FormatterServices.GetUninitializedObject(typeof(ProtoVessel));
+            var protoVessels = new List<ProtoVessel> { pv };
+
+            VesselSpawner.CleanupFailedSpawnedProtoVessel(
+                pv,
+                "Spawner",
+                "unit-test cleanup",
+                protoVessels,
+                _ => throw new InvalidOperationException("boom"));
+
+            Assert.Empty(protoVessels);
+            Assert.Contains(logLines, l =>
+                l.Contains("[Spawner]") &&
+                l.Contains("unit-test cleanup") &&
+                l.Contains("failed to destroy partially spawned vessel") &&
+                l.Contains("boom"));
+        }
+
+        [Fact]
+        public void BuildValidatedRespawnSnapshot_PreparedSnapshotHappyPath_RepairsCopyOnly()
+        {
+            TestBodyRegistry.Install(("Kerbin", 600000.0, 3.5316e12), ("Mun", 200000.0, 6.5138398e10));
+            VesselSpawner.BodyNameResolverForTesting = TestBodyRegistry.ResolveBodyNameByIndex;
+            VesselSpawner.BodyResolverForTesting = TestBodyRegistry.ResolveBodyByName;
+            VesselSpawner.BodyIndexResolverForTesting = TestBodyRegistry.ResolveBodyIndex;
+
+            var preparedSnapshot = new ConfigNode("VESSEL");
+            preparedSnapshot.AddValue("sit", "LANDED");
+            preparedSnapshot.AddValue("lat", "1.0");
+            preparedSnapshot.AddValue("lon", "2.0");
+            preparedSnapshot.AddValue("alt", "3.0");
+            var orbitNode = new ConfigNode("ORBIT");
+            orbitNode.AddValue("SMA", "700000");
+            orbitNode.AddValue("ECC", "0.01");
+            orbitNode.AddValue("INC", "0.0");
+            orbitNode.AddValue("LPE", "0.0");
+            orbitNode.AddValue("LAN", "0.0");
+            orbitNode.AddValue("MNA", "0.0");
+            orbitNode.AddValue("EPH", "100.0");
+            orbitNode.AddValue("REF", "0");
+            preparedSnapshot.AddNode(orbitNode);
+
+            var rec = new Recording
+            {
+                VesselName = "Prepared Surface Repair",
+                VesselSnapshot = new ConfigNode("VESSEL"),
+                TerminalStateValue = TerminalState.Landed,
+                EndpointPhase = RecordingEndpointPhase.TerminalPosition,
+                EndpointBodyName = "Mun",
+                TerminalPosition = new SurfacePosition
+                {
+                    body = "Mun",
+                    latitude = 4.0,
+                    longitude = 5.0,
+                    altitude = 6.0
+                }
+            };
+
+            ConfigNode validated = VesselSpawner.BuildValidatedRespawnSnapshot(
+                preparedSnapshot,
+                rec,
+                currentUT: 123.0,
+                logContext: "prepared-snapshot");
+
+            Assert.NotNull(validated);
+            Assert.NotSame(preparedSnapshot, validated);
+            Assert.Equal("1.0", preparedSnapshot.GetValue("lat"));
+            Assert.Equal("2.0", preparedSnapshot.GetValue("lon"));
+            Assert.Equal("3.0", preparedSnapshot.GetValue("alt"));
+            Assert.Equal("0", preparedSnapshot.GetNode("ORBIT").GetValue("REF"));
+            Assert.Equal("4", validated.GetValue("lat"));
+            Assert.Equal("5", validated.GetValue("lon"));
+            Assert.Equal("6", validated.GetValue("alt"));
+            Assert.Equal("1", validated.GetNode("ORBIT").GetValue("REF"));
+            Assert.Contains(logLines, l =>
+                l.Contains("[Spawner]") &&
+                l.Contains("using endpoint surface coordinates") &&
+                l.Contains("prepared-snapshot"));
+        }
+
+        [Fact]
+        public void ApplyResolvedSpawnStateToSnapshot_EvaRecording_OverridesCoordsRotationAndStripsLadder()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            snapshot.AddValue("lat", "0");
+            snapshot.AddValue("lon", "0");
+            snapshot.AddValue("alt", "0");
+            snapshot.AddValue("rot", "0,0,0,1");
+            var part = snapshot.AddNode("PART");
+            var module = part.AddNode("MODULE");
+            module.AddValue("name", "KerbalEVA");
+            module.AddValue("state", "Ladder (Acquire)");
+            module.AddValue("OnALadder", "True");
+
+            var rec = new Recording
+            {
+                VesselName = "Val",
+                EvaCrewName = "Val",
+                TerminalStateValue = TerminalState.Landed
+            };
+            var rotationPoint = new TrajectoryPoint
+            {
+                bodyName = "Kerbin",
+                rotation = new Quaternion(0.1f, 0.2f, 0.3f, 0.9f)
+            };
+
+            VesselSpawner.ApplyResolvedSpawnStateToSnapshot(
+                snapshot,
+                rec,
+                rotationPoint,
+                10.5,
+                20.5,
+                30.5,
+                7,
+                "unit-test resolved snapshot");
+
+            Assert.Equal("10.5", snapshot.GetValue("lat"));
+            Assert.Equal("20.5", snapshot.GetValue("lon"));
+            Assert.Equal("30.5", snapshot.GetValue("alt"));
+            Assert.False(module.HasValue("state"));
+            Assert.Equal("False", module.GetValue("OnALadder"));
+            Assert.Contains(logLines, l =>
+                l.Contains("[Spawner]") &&
+                l.Contains("rot updated from surface-relative frame") &&
+                l.Contains("unit-test resolved snapshot"));
+            Assert.Contains(logLines, l =>
+                l.Contains("[Spawner]") &&
+                l.Contains("ladder state stripped") &&
+                l.Contains("Val"));
+        }
+
+        [Fact]
+        public void ApplyResolvedSpawnStateToSnapshot_StripEvaDisabled_LeavesLadderState()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            var part = snapshot.AddNode("PART");
+            var module = part.AddNode("MODULE");
+            module.AddValue("name", "KerbalEVA");
+            module.AddValue("state", "Ladder (Acquire)");
+            module.AddValue("OnALadder", "True");
+
+            var rec = new Recording
+            {
+                VesselName = "Val",
+                EvaCrewName = "Val",
+                TerminalStateValue = TerminalState.Landed
+            };
+
+            VesselSpawner.ApplyResolvedSpawnStateToSnapshot(
+                snapshot,
+                rec,
+                rotationPoint: null,
+                spawnLat: 1.0,
+                spawnLon: 2.0,
+                spawnAlt: 3.0,
+                index: 8,
+                logContext: "unit-test no-strip",
+                allowPreferredRotation: false,
+                stripEvaLadder: false);
+
+            Assert.Equal("Ladder (Acquire)", module.GetValue("state"));
+            Assert.Equal("True", module.GetValue("OnALadder"));
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("[Spawner]") &&
+                l.Contains("ladder state stripped") &&
+                l.Contains("Val"));
+        }
+    }
+}

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -9345,6 +9345,13 @@ namespace Parsek
                     // Route scene-load leaf spawns through the shared end-of-recording helper
                     // so EVA/orbital paths rebuild endpoint-aligned ORBIT data the same way
                     // the in-flight spawn path does.
+                    if (leaf.SpawnAttempts > 0)
+                    {
+                        ParsekLog.Verbose("Flight",
+                            $"SpawnTreeLeaves: leaf '{leaf.VesselName}' entering shared spawn path " +
+                            $"with prior attempts={leaf.SpawnAttempts} (shared helper caps retries at 3)");
+                    }
+
                     VesselSpawner.SpawnOrRecoverIfTooClose(leaf, -1);
                     if (leaf.SpawnedVesselPersistentId != 0)
                     {

--- a/Source/Parsek/ParsekKSC.cs
+++ b/Source/Parsek/ParsekKSC.cs
@@ -1234,8 +1234,8 @@ namespace Parsek
                 ParsekLog.Info("KSCSpawn",
                     $"Attempting spawn for #{recIdx} \"{rec.VesselName}\" (id={rec.RecordingId})");
 
-                // KSC spawn works from a private snapshot copy so the recording's stored
-                // snapshot stays untouched if the materialization falls back or aborts.
+                // Keep a private working snapshot for the entire KSC spawn flow so route
+                // selection, fallback repairs, and aborts never mutate the stored recording.
                 ConfigNode spawnSnapshot = rec.VesselSnapshot.CreateCopy();
 
                 // Bug #167: apply crew swap directly on the KSC spawn snapshot because
@@ -1314,106 +1314,42 @@ namespace Parsek
 
                     if (isEva)
                     {
-                        if (VesselSpawner.TryResolvePreferredSpawnRotation(
+                        VesselSpawner.ApplyResolvedSpawnStateToSnapshot(
+                            spawnSnapshot,
                             rec,
                             lastPt,
-                            out string evaRotationBodyName,
-                            out Quaternion? evaBodyRotation,
-                            out Quaternion evaSurfaceRelativeRotation,
-                            out string evaRotationSource))
-                        {
-                            VesselSpawner.OverrideSnapshotPosition(
-                                spawnSnapshot,
-                                spawnLat,
-                                spawnLon,
-                                spawnAlt,
-                                recIdx,
-                                rec.VesselName,
-                                evaRotationBodyName,
-                                evaBodyRotation,
-                                evaSurfaceRelativeRotation,
-                                evaRotationSource);
-                        }
-                        else
-                        {
-                            VesselSpawner.OverrideSnapshotPosition(
-                                spawnSnapshot,
-                                spawnLat,
-                                spawnLon,
-                                spawnAlt,
-                                recIdx,
-                                rec.VesselName);
-                        }
-
-                        VesselSpawner.StripEvaLadderState(spawnSnapshot, recIdx, rec.VesselName);
+                            spawnLat,
+                            spawnLon,
+                            spawnAlt,
+                            recIdx,
+                            rec.VesselName);
                     }
                     else if (isBreakupContinuous)
                     {
-                        if (!useRecordedTerminalOrbit
-                            && VesselSpawner.TryResolvePreferredSpawnRotation(
-                                rec,
-                                lastPt,
-                                out string breakupRotationBodyName,
-                                out Quaternion? breakupBodyRotation,
-                                out Quaternion breakupSurfaceRelativeRotation,
-                                out string breakupRotationSource))
-                        {
-                            VesselSpawner.OverrideSnapshotPosition(
-                                spawnSnapshot,
-                                spawnLat,
-                                spawnLon,
-                                spawnAlt,
-                                recIdx,
-                                rec.VesselName,
-                                breakupRotationBodyName,
-                                breakupBodyRotation,
-                                breakupSurfaceRelativeRotation,
-                                breakupRotationSource);
-                        }
-                        else
-                        {
-                            VesselSpawner.OverrideSnapshotPosition(
-                                spawnSnapshot,
-                                spawnLat,
-                                spawnLon,
-                                spawnAlt,
-                                recIdx,
-                                rec.VesselName);
-                        }
-                    }
-                    else if (rec.TerminalStateValue == TerminalState.Landed
-                        || rec.TerminalStateValue == TerminalState.Splashed)
-                    {
-                        if (VesselSpawner.TryResolvePreferredSpawnRotation(
+                        VesselSpawner.ApplyResolvedSpawnStateToSnapshot(
+                            spawnSnapshot,
                             rec,
                             lastPt,
-                            out string surfaceRotationBodyName,
-                            out Quaternion? surfaceBodyRotation,
-                            out Quaternion surfaceRelativeRotation,
-                            out string surfaceRotationSource))
-                        {
-                            VesselSpawner.OverrideSnapshotPosition(
-                                spawnSnapshot,
-                                spawnLat,
-                                spawnLon,
-                                spawnAlt,
-                                recIdx,
-                                rec.VesselName,
-                                surfaceRotationBodyName,
-                                surfaceBodyRotation,
-                                surfaceRelativeRotation,
-                                surfaceRotationSource);
-                        }
-                        else
-                        {
-                            VesselSpawner.OverrideSnapshotPosition(
-                                spawnSnapshot,
-                                spawnLat,
-                                spawnLon,
-                                spawnAlt,
-                                recIdx,
-                                rec.VesselName);
-                        }
+                            spawnLat,
+                            spawnLon,
+                            spawnAlt,
+                            recIdx,
+                            rec.VesselName,
+                            allowPreferredRotation: !useRecordedTerminalOrbit,
+                            stripEvaLadder: false);
+                    }
+                    else if (VesselSpawner.IsSurfaceTerminal(rec.TerminalStateValue))
+                    {
+                        VesselSpawner.ApplyResolvedSpawnStateToSnapshot(
+                            spawnSnapshot,
+                            rec,
+                            lastPt,
+                            spawnLat,
+                            spawnLon,
+                            spawnAlt,
+                            recIdx,
+                            rec.VesselName,
+                            stripEvaLadder: false);
                     }
                 }
 

--- a/Source/Parsek/SpawnCollisionDetector.cs
+++ b/Source/Parsek/SpawnCollisionDetector.cs
@@ -533,6 +533,17 @@ namespace Parsek
                 bodyName = string.IsNullOrEmpty(earlier.bodyName) ? later.bodyName : earlier.bodyName;
             }
 
+            if (!string.Equals(later.bodyName, earlier.bodyName, StringComparison.Ordinal))
+            {
+                ParsekLog.Verbose(Tag,
+                    string.Format(IC,
+                        "WalkbackSubdivided: body transition later='{0}' earlier='{1}' t={2:F2} -> using '{3}'",
+                        string.IsNullOrEmpty(later.bodyName) ? "(none)" : later.bodyName,
+                        string.IsNullOrEmpty(earlier.bodyName) ? "(none)" : earlier.bodyName,
+                        t,
+                        string.IsNullOrEmpty(bodyName) ? "(none)" : bodyName));
+            }
+
             return new TrajectoryPoint
             {
                 ut = later.ut + (earlier.ut - later.ut) * t,

--- a/Source/Parsek/VesselGhoster.cs
+++ b/Source/Parsek/VesselGhoster.cs
@@ -622,13 +622,14 @@ namespace Parsek
                 return 0;
 
             ConfigNode spawnSnapshot = vesselSnapshot.CreateCopy();
-            ApplyResolvedSpawnStateToSnapshot(
+            VesselSpawner.ApplyResolvedSpawnStateToSnapshot(
                 spawnSnapshot,
                 tipRecording,
                 rotationPoint,
                 spawnLat,
                 spawnLon,
                 spawnAlt,
+                -1,
                 logContext);
 
             if (TerrainCorrector.ShouldCorrectTerrain(
@@ -688,55 +689,9 @@ namespace Parsek
             if (validatedSpawnSnapshot == null)
                 return 0;
 
+            // The snapshot has already been route-specifically overridden and validated above,
+            // so the fallback only needs raw materialization here rather than another wrapper.
             return VesselSpawner.RespawnVessel(validatedSpawnSnapshot, preserveIdentity: true);
-        }
-
-        private static void ApplyResolvedSpawnStateToSnapshot(
-            ConfigNode spawnSnapshot,
-            Recording tipRecording,
-            TrajectoryPoint? rotationPoint,
-            double spawnLat,
-            double spawnLon,
-            double spawnAlt,
-            string logContext)
-        {
-            if (spawnSnapshot == null)
-                return;
-
-            if (rotationPoint.HasValue
-                && VesselSpawner.TryResolvePreferredSpawnRotation(
-                    tipRecording,
-                    rotationPoint,
-                    out string rotationBodyName,
-                    out Quaternion? rotationBodyRotation,
-                    out Quaternion surfaceRelativeRotation,
-                    out string rotationSource))
-            {
-                VesselSpawner.OverrideSnapshotPosition(
-                    spawnSnapshot,
-                    spawnLat,
-                    spawnLon,
-                    spawnAlt,
-                    -1,
-                    logContext ?? tipRecording?.VesselName,
-                    rotationBodyName,
-                    rotationBodyRotation,
-                    surfaceRelativeRotation,
-                    rotationSource);
-            }
-            else
-            {
-                VesselSpawner.OverrideSnapshotPosition(
-                    spawnSnapshot,
-                    spawnLat,
-                    spawnLon,
-                    spawnAlt,
-                    -1,
-                    logContext ?? tipRecording?.VesselName);
-            }
-
-            if (!string.IsNullOrEmpty(tipRecording?.EvaCrewName))
-                VesselSpawner.StripEvaLadderState(spawnSnapshot, -1, tipRecording.VesselName);
         }
 
         /// <summary>
@@ -824,6 +779,7 @@ namespace Parsek
                 ? (TrajectoryPoint?)tipRecording.Points[tipRecording.Points.Count - 1]
                 : null;
             CelestialBody walkbackBody = VesselSpawner.ResolveSpawnRotationBody(tipRecording, lastPoint);
+            CelestialBody walkbackSpawnBody = walkbackBody;
             TrajectoryPoint walkPt;
 
             if (walkbackBody != null)
@@ -906,6 +862,8 @@ namespace Parsek
                 walkPt.velocity.x,
                 walkPt.velocity.y,
                 walkPt.velocity.z);
+            if (walkbackSpawnBody == null)
+                walkbackSpawnBody = VesselSpawner.ResolveSpawnRotationBody(tipRecording, walkPt);
             uint walkbackPid = SpawnChainTipWithResolvedState(
                 tipRecording,
                 vesselSnapshot,
@@ -916,7 +874,7 @@ namespace Parsek
                 walkPt.altitude,
                 spawnVelocity,
                 walkPt,
-                VesselSpawner.ResolveSpawnRotationBody(tipRecording, walkPt));
+                walkbackSpawnBody);
             if (walkbackPid != 0)
             {
                 MarkChainTipRecordingSpawned(

--- a/Source/Parsek/VesselSpawner.cs
+++ b/Source/Parsek/VesselSpawner.cs
@@ -496,13 +496,31 @@ namespace Parsek
             string logTag,
             string logContext)
         {
+            CleanupFailedSpawnedProtoVessel(
+                pv,
+                logTag,
+                logContext,
+                HighLogic.CurrentGame?.flightState?.protoVessels,
+                proto =>
+                {
+                    if (proto?.vesselRef != null)
+                        proto.vesselRef.Die();
+                });
+        }
+
+        internal static void CleanupFailedSpawnedProtoVessel(
+            ProtoVessel pv,
+            string logTag,
+            string logContext,
+            IList<ProtoVessel> protoVessels,
+            Action<ProtoVessel> destroyPartialVessel)
+        {
             if (pv == null)
                 return;
 
             try
             {
-                if (pv.vesselRef != null)
-                    pv.vesselRef.Die();
+                destroyPartialVessel?.Invoke(pv);
             }
             catch (Exception ex)
             {
@@ -513,7 +531,7 @@ namespace Parsek
 
             try
             {
-                HighLogic.CurrentGame?.flightState?.protoVessels?.Remove(pv);
+                protoVessels?.Remove(pv);
             }
             catch (Exception ex)
             {
@@ -767,6 +785,61 @@ namespace Parsek
                 bodyRotation,
                 surfaceRelativeRotation,
                 $"{context}, source={source}");
+        }
+
+        internal static void ApplyResolvedSpawnStateToSnapshot(
+            ConfigNode spawnSnapshot,
+            Recording rec,
+            TrajectoryPoint? rotationPoint,
+            double spawnLat,
+            double spawnLon,
+            double spawnAlt,
+            int index,
+            string logContext,
+            bool allowPreferredRotation = true,
+            bool stripEvaLadder = true)
+        {
+            if (spawnSnapshot == null)
+                return;
+
+            string snapshotLabel = !string.IsNullOrEmpty(logContext)
+                ? logContext
+                : rec?.VesselName ?? "(unknown)";
+            string vesselName = rec?.VesselName ?? snapshotLabel;
+            if (allowPreferredRotation
+                && TryResolvePreferredSpawnRotation(
+                    rec,
+                    rotationPoint,
+                    out string rotationBodyName,
+                    out Quaternion? rotationBodyRotation,
+                    out Quaternion surfaceRelativeRotation,
+                    out string rotationSource))
+            {
+                OverrideSnapshotPosition(
+                    spawnSnapshot,
+                    spawnLat,
+                    spawnLon,
+                    spawnAlt,
+                    index,
+                    snapshotLabel,
+                    rotationBodyName,
+                    rotationBodyRotation,
+                    surfaceRelativeRotation,
+                    rotationSource);
+            }
+            else
+            {
+                OverrideSnapshotPosition(
+                    spawnSnapshot,
+                    spawnLat,
+                    spawnLon,
+                    spawnAlt,
+                    index,
+                    snapshotLabel);
+            }
+
+            if (stripEvaLadder && !string.IsNullOrEmpty(rec?.EvaCrewName))
+                StripEvaLadderState(spawnSnapshot, index, vesselName);
         }
 
         internal static CelestialBody ResolveSpawnRotationBody(
@@ -1125,26 +1198,15 @@ namespace Parsek
             // ladder, triggering KSP's "Kerbals on a ladder — cannot save" error.
             if (isEva && rec.VesselSnapshot != null)
             {
-                if (TryResolvePreferredSpawnRotation(
-                    rec, lastPt,
-                    out string evaRotationBodyName,
-                    out Quaternion? evaBodyRotation,
-                    out Quaternion evaSurfaceRelativeRotation,
-                    out string evaRotationSource))
-                {
-                    OverrideSnapshotPosition(rec.VesselSnapshot, spawnLat, spawnLon, spawnAlt,
-                        index, rec.VesselName,
-                        evaRotationBodyName,
-                        evaBodyRotation,
-                        evaSurfaceRelativeRotation,
-                        evaRotationSource);
-                }
-                else
-                {
-                    OverrideSnapshotPosition(rec.VesselSnapshot, spawnLat, spawnLon, spawnAlt,
-                        index, rec.VesselName);
-                }
-                StripEvaLadderState(rec.VesselSnapshot, index, rec.VesselName);
+                ApplyResolvedSpawnStateToSnapshot(
+                    rec.VesselSnapshot,
+                    rec,
+                    lastPt,
+                    spawnLat,
+                    spawnLon,
+                    spawnAlt,
+                    index,
+                    rec.VesselName);
             }
 
             // Breakup-continuous recordings: snapshot position is from breakup time (mid-air).
@@ -1152,26 +1214,17 @@ namespace Parsek
             // endpoint. Same pattern as EVA fix above. (#224)
             if (!isEva && isBreakupContinuous && rec.VesselSnapshot != null)
             {
-                if (!useRecordedTerminalOrbit
-                    && TryResolvePreferredSpawnRotation(
-                        rec, lastPt,
-                        out string breakupRotationBodyName,
-                        out Quaternion? breakupBodyRotation,
-                        out Quaternion breakupSurfaceRelativeRotation,
-                        out string breakupRotationSource))
-                {
-                    OverrideSnapshotPosition(rec.VesselSnapshot, spawnLat, spawnLon, spawnAlt,
-                        index, rec.VesselName,
-                        breakupRotationBodyName,
-                        breakupBodyRotation,
-                        breakupSurfaceRelativeRotation,
-                        breakupRotationSource);
-                }
-                else
-                {
-                    OverrideSnapshotPosition(rec.VesselSnapshot, spawnLat, spawnLon, spawnAlt,
-                        index, rec.VesselName);
-                }
+                ApplyResolvedSpawnStateToSnapshot(
+                    rec.VesselSnapshot,
+                    rec,
+                    lastPt,
+                    spawnLat,
+                    spawnLon,
+                    spawnAlt,
+                    index,
+                    rec.VesselName,
+                    allowPreferredRotation: !useRecordedTerminalOrbit,
+                    stripEvaLadder: false);
             }
 
             // Surface terminal override: for any LANDED/SPLASHED recording, the snapshot
@@ -1180,27 +1233,18 @@ namespace Parsek
             // uses the raw snapshot. Override position and rotation so the vessel spawns
             // in its near-landing orientation, not the mid-flight descent pose. (#231)
             if (!isEva && !isBreakupContinuous && rec.VesselSnapshot != null
-                && (rec.TerminalStateValue == TerminalState.Landed || rec.TerminalStateValue == TerminalState.Splashed))
+                && IsSurfaceTerminal(rec.TerminalStateValue))
             {
-                if (TryResolvePreferredSpawnRotation(
-                    rec, lastPt,
-                    out string surfaceRotationBodyName,
-                    out Quaternion? surfaceBodyRotation,
-                    out Quaternion surfaceRelativeRotation,
-                    out string surfaceRotationSource))
-                {
-                    OverrideSnapshotPosition(rec.VesselSnapshot, spawnLat, spawnLon, spawnAlt,
-                        index, rec.VesselName,
-                        surfaceRotationBodyName,
-                        surfaceBodyRotation,
-                        surfaceRelativeRotation,
-                        surfaceRotationSource);
-                }
-                else
-                {
-                    OverrideSnapshotPosition(rec.VesselSnapshot, spawnLat, spawnLon, spawnAlt,
-                        index, rec.VesselName);
-                }
+                ApplyResolvedSpawnStateToSnapshot(
+                    rec.VesselSnapshot,
+                    rec,
+                    lastPt,
+                    spawnLat,
+                    spawnLon,
+                    spawnAlt,
+                    index,
+                    rec.VesselName,
+                    stripEvaLadder: false);
             }
 
             // Dead crew guard: if ALL crew in the snapshot are dead, abandon spawn.


### PR DESCRIPTION
## Summary
- extract the repeated resolved-snapshot override path into one shared helper used by flight, KSC, and chain-tip spawns
- add follow-up diagnostics for tree-leaf retry carryover, walkback body-name tie-breaks, and the validated chain-tip respawn fallback
- add headless coverage for the prepared-snapshot validation overload, injected ProtoVessel cleanup, shared resolved-snapshot helper, and the walkback body-transition log path

## Verification
- git diff --cached --check
- dotnet build Source/Parsek.Tests/Parsek.Tests.csproj --no-restore *(fails locally: missing .NET Framework 4.7.2 targeting pack on this machine)*