### PR TITLE
Fix Timeline kerbal hire rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- Timeline kerbal-hire rows now live in the Details tier instead of the Overview tier. Sandbox, Mission, and Science saves render hire rows as `Hire: <kerbal>` without a funds suffix because those modes have no funds ledger.
+
 - Nearby-vessel switches now treat deliberate attitude-only alignment as a meaningful post-switch change, so docking-port alignment done with SAS, reaction wheels, or light RCS is no longer lost just because translation/orbit barely moved. New relative-frame recordings now store true anchor-local docking geometry, while older recordings keep replaying through the legacy path for compatibility.
 
 - Contextual auto-record starts now show one notification: pad/runway launches, post-switch first-modification starts, and EVA-from-pad starts suppress the generic `Recording STARTED` toast when they post their own `(auto)` message.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
-- Timeline kerbal-hire rows now live in the Details tier instead of the Overview tier. Sandbox, Mission, and Science saves render hire rows as `Hire: <kerbal>` without a funds suffix because those modes have no funds ledger.
+- `#533` Timeline kerbal-hire rows now live in the Details tier instead of the Overview tier. Sandbox, Mission, and Science saves render hire rows as `Hire: <kerbal>` without a funds suffix because those modes have no funds ledger.
 
 - Nearby-vessel switches now treat deliberate attitude-only alignment as a meaningful post-switch change, so docking-port alignment done with SAS, reaction wheels, or light RCS is no longer lost just because translation/orbit barely moved. New relative-frame recordings now store true anchor-local docking geometry, while older recordings keep replaying through the legacy path for compatibility.
 

--- a/Source/Parsek.Tests/Bug452RolloutLabelTests.cs
+++ b/Source/Parsek.Tests/Bug452RolloutLabelTests.cs
@@ -151,7 +151,7 @@ namespace Parsek.Tests
             Assert.True(GameActionDisplay.IsUnclaimedRolloutAction(longKey));
             Assert.Equal(
                 "Vessel build -5000" + GameActionDisplay.CancelledRolloutSuffix,
-                GameActionDisplay.GetDescription(longKey));
+                GameActionDisplay.GetDescription(longKey, Game.Modes.CAREER));
         }
 
         [Fact]
@@ -237,7 +237,7 @@ namespace Parsek.Tests
         {
             // The user-visible #452 fix: the cancelled-rollout entry now carries a
             // suffix that distinguishes it from an adopted build cost.
-            string desc = GameActionDisplay.GetDescription(MakeUnclaimedRollout(cost: 5000f));
+            string desc = GameActionDisplay.GetDescription(MakeUnclaimedRollout(cost: 5000f), Game.Modes.CAREER);
             Assert.Equal("Vessel build -5000" + GameActionDisplay.CancelledRolloutSuffix, desc);
         }
 
@@ -245,7 +245,7 @@ namespace Parsek.Tests
         public void GetDescription_AdoptedRollout_NoSuffix()
         {
             // Adopted by a recording — render as the existing plain label, no suffix.
-            string desc = GameActionDisplay.GetDescription(MakeAdoptedRollout(cost: 5000f));
+            string desc = GameActionDisplay.GetDescription(MakeAdoptedRollout(cost: 5000f), Game.Modes.CAREER);
             Assert.Equal("Vessel build -5000", desc);
         }
 
@@ -254,7 +254,7 @@ namespace Parsek.Tests
         {
             // Regression guard: a normal recording-side build action without any
             // rollout: dedup tag must continue to render unchanged.
-            string desc = GameActionDisplay.GetDescription(MakeOrdinaryBuildAction(cost: 5000f));
+            string desc = GameActionDisplay.GetDescription(MakeOrdinaryBuildAction(cost: 5000f), Game.Modes.CAREER);
             Assert.Equal("Vessel build -5000", desc);
         }
 
@@ -268,7 +268,7 @@ namespace Parsek.Tests
             // Both renderers (Actions and Timeline) must agree, so the suffix is
             // also present in the per-frame Timeline view.
             string text = TimelineEntryDisplay.GetGameActionText(
-                MakeUnclaimedRollout(cost: 5000f), vesselName: null);
+                MakeUnclaimedRollout(cost: 5000f), vesselName: null, currentMode: Game.Modes.CAREER);
             Assert.Equal("Build -5000" + GameActionDisplay.CancelledRolloutSuffix, text);
         }
 
@@ -276,7 +276,7 @@ namespace Parsek.Tests
         public void TimelineGetGameActionText_AdoptedRollout_NoSuffix()
         {
             string text = TimelineEntryDisplay.GetGameActionText(
-                MakeAdoptedRollout(cost: 5000f), vesselName: null);
+                MakeAdoptedRollout(cost: 5000f), vesselName: null, currentMode: Game.Modes.CAREER);
             Assert.Equal("Build -5000", text);
         }
 
@@ -284,7 +284,7 @@ namespace Parsek.Tests
         public void TimelineGetGameActionText_OrdinaryRecordingBuildCost_NoSuffix()
         {
             string text = TimelineEntryDisplay.GetGameActionText(
-                MakeOrdinaryBuildAction(cost: 5000f), vesselName: null);
+                MakeOrdinaryBuildAction(cost: 5000f), vesselName: null, currentMode: Game.Modes.CAREER);
             Assert.Equal("Build -5000", text);
         }
     }

--- a/Source/Parsek.Tests/TimelineBuilderTests.cs
+++ b/Source/Parsek.Tests/TimelineBuilderTests.cs
@@ -347,7 +347,8 @@ namespace Parsek.Tests
                     MilestoneRepAwarded = 2f,
                     MilestoneScienceAwarded = 1.5f
                 },
-                vesselName: null);
+                vesselName: null,
+                currentMode: Game.Modes.CAREER);
 
             Assert.Equal("Milestone: Kerbin - Records Distance +4800 funds +2 rep +1.5 sci", text);
         }
@@ -690,6 +691,38 @@ namespace Parsek.Tests
             Assert.Equal(TimelineEntryType.KerbalHire, hire.Type);
             Assert.Equal(SignificanceTier.T2, hire.Tier);
             Assert.Equal("Hire: Valentina Kerman -62113 funds", hire.DisplayText);
+            Assert.Equal("Hire: Valentina Kerman -62113 funds",
+                GameActionDisplay.GetDescription(actions[0], Game.Modes.CAREER));
+        }
+
+        [Fact]
+        public void KerbalHire_CareerModeWithZeroCost_HidesFunds()
+        {
+            var actions = new List<GameAction>
+            {
+                new GameAction
+                {
+                    UT = 100,
+                    Type = GameActionType.KerbalHire,
+                    KerbalName = "Valentina Kerman",
+                    HireCost = 0f,
+                    Effective = true
+                }
+            };
+
+            var result = TimelineBuilder.Build(
+                new List<Recording>(),
+                actions,
+                new List<Milestone>(),
+                _ => true,
+                Game.Modes.CAREER);
+
+            var hire = Assert.Single(result);
+            Assert.Equal(TimelineEntryType.KerbalHire, hire.Type);
+            Assert.Equal(SignificanceTier.T2, hire.Tier);
+            Assert.Equal("Hire: Valentina Kerman", hire.DisplayText);
+            Assert.Equal("Hire: Valentina Kerman",
+                GameActionDisplay.GetDescription(actions[0], Game.Modes.CAREER));
         }
 
         [Theory]
@@ -722,6 +755,12 @@ namespace Parsek.Tests
             Assert.Equal(TimelineEntryType.KerbalHire, hire.Type);
             Assert.Equal(SignificanceTier.T2, hire.Tier);
             Assert.Equal("Hire: Valentina Kerman", hire.DisplayText);
+            Assert.Equal("Hire: Valentina Kerman",
+                GameActionDisplay.GetDescription(actions[0], mode));
+            Assert.Contains(logLines, l =>
+                l.Contains("[Timeline]") &&
+                l.Contains("Filtered 1 kerbal-hire funds suffix") &&
+                l.Contains(mode.ToString()));
         }
 
         // ================================================================

--- a/Source/Parsek.Tests/TimelineBuilderTests.cs
+++ b/Source/Parsek.Tests/TimelineBuilderTests.cs
@@ -612,7 +612,6 @@ namespace Parsek.Tests
                 TimelineEntryType.ContractFail,
                 TimelineEntryType.FacilityUpgrade,
                 TimelineEntryType.FacilityDestruction,
-                TimelineEntryType.KerbalHire,
                 TimelineEntryType.FundsInitial,
                 TimelineEntryType.ScienceInitial,
                 TimelineEntryType.ReputationInitial
@@ -625,7 +624,7 @@ namespace Parsek.Tests
                     $"Expected T1 for {type} but got {tier}");
             }
 
-            Assert.Equal(12, t1Types.Length);
+            Assert.Equal(11, t1Types.Length);
         }
 
         // ================================================================
@@ -646,6 +645,7 @@ namespace Parsek.Tests
                 TimelineEntryType.ContractAccept,
                 TimelineEntryType.ContractCancel,
                 TimelineEntryType.KerbalAssignment,
+                TimelineEntryType.KerbalHire,
                 TimelineEntryType.KerbalRescue,
                 TimelineEntryType.KerbalStandIn,
                 TimelineEntryType.FacilityRepair,
@@ -661,7 +661,67 @@ namespace Parsek.Tests
                     $"Expected T2 for {type} but got {tier}");
             }
 
-            Assert.Equal(15, t2Types.Length);
+            Assert.Equal(16, t2Types.Length);
+        }
+
+        [Fact]
+        public void KerbalHire_CareerMode_IsDetailsOnlyAndShowsFunds()
+        {
+            var actions = new List<GameAction>
+            {
+                new GameAction
+                {
+                    UT = 100,
+                    Type = GameActionType.KerbalHire,
+                    KerbalName = "Valentina Kerman",
+                    HireCost = 62113f,
+                    Effective = true
+                }
+            };
+
+            var result = TimelineBuilder.Build(
+                new List<Recording>(),
+                actions,
+                new List<Milestone>(),
+                _ => true,
+                Game.Modes.CAREER);
+
+            var hire = Assert.Single(result);
+            Assert.Equal(TimelineEntryType.KerbalHire, hire.Type);
+            Assert.Equal(SignificanceTier.T2, hire.Tier);
+            Assert.Equal("Hire: Valentina Kerman -62113 funds", hire.DisplayText);
+        }
+
+        [Theory]
+        [InlineData(Game.Modes.SANDBOX)]
+        [InlineData(Game.Modes.SCIENCE_SANDBOX)]
+        [InlineData(Game.Modes.MISSION_BUILDER)]
+        [InlineData(Game.Modes.MISSION)]
+        public void KerbalHire_NoFundsModes_HidesFunds(Game.Modes mode)
+        {
+            var actions = new List<GameAction>
+            {
+                new GameAction
+                {
+                    UT = 100,
+                    Type = GameActionType.KerbalHire,
+                    KerbalName = "Valentina Kerman",
+                    HireCost = 62113f,
+                    Effective = true
+                }
+            };
+
+            var result = TimelineBuilder.Build(
+                new List<Recording>(),
+                actions,
+                new List<Milestone>(),
+                _ => true,
+                mode);
+
+            var hire = Assert.Single(result);
+            Assert.Equal(TimelineEntryType.KerbalHire, hire.Type);
+            Assert.Equal(SignificanceTier.T2, hire.Tier);
+            Assert.Equal("Hire: Valentina Kerman", hire.DisplayText);
         }
 
         // ================================================================

--- a/Source/Parsek/GameActions/GameActionDisplay.cs
+++ b/Source/Parsek/GameActions/GameActionDisplay.cs
@@ -61,7 +61,7 @@ namespace Parsek
         }
 
         /// <summary>Human-readable description of the action.</summary>
-        internal static string GetDescription(GameAction action)
+        internal static string GetDescription(GameAction action, Game.Modes? currentMode)
         {
             if (action == null)
                 return "";
@@ -135,8 +135,7 @@ namespace Parsek
                         action.KerbalName ?? "unknown", action.KerbalRole ?? "unknown");
 
                 case GameActionType.KerbalHire:
-                    return string.Format(IC, "Hire: {0} -{1:0} funds",
-                        action.KerbalName ?? "unknown", action.HireCost);
+                    return GetKerbalHireDescription(action, currentMode);
 
                 case GameActionType.KerbalRescue:
                     return "Rescue: " + (action.KerbalName ?? "unknown");
@@ -166,6 +165,36 @@ namespace Parsek
 
                 default:
                     return action.Type.ToString();
+            }
+        }
+
+        internal static string GetKerbalHireDescription(GameAction action, Game.Modes? currentMode)
+        {
+            string kerbalName = action?.KerbalName ?? "unknown";
+            if (!ShouldShowFundsForKerbalHire(action, currentMode))
+                return "Hire: " + kerbalName;
+
+            return string.Format(IC, "Hire: {0} -{1:0} funds", kerbalName, action.HireCost);
+        }
+
+        internal static bool ShouldShowFundsForKerbalHire(GameAction action, Game.Modes? currentMode)
+        {
+            if (action == null || action.HireCost <= 0f)
+                return false;
+
+            if (!currentMode.HasValue)
+                return true;
+
+            switch (currentMode.Value)
+            {
+                case Game.Modes.SANDBOX:
+                case Game.Modes.SCIENCE_SANDBOX:
+                case Game.Modes.MISSION_BUILDER:
+                case Game.Modes.MISSION:
+                    return false;
+
+                default:
+                    return true;
             }
         }
 

--- a/Source/Parsek/Timeline/TimelineBuilder.cs
+++ b/Source/Parsek/Timeline/TimelineBuilder.cs
@@ -494,7 +494,7 @@ namespace Parsek
                 {
                     UT = action.UT,
                     Type = entryType,
-                    DisplayText = TimelineEntryDisplay.GetGameActionText(action, vesselName),
+                    DisplayText = TimelineEntryDisplay.GetGameActionText(action, vesselName, currentMode),
                     Source = TimelineSource.GameAction,
                     Tier = tier,
                     DisplayColor = GameActionDisplay.GetColor(action.Type),

--- a/Source/Parsek/Timeline/TimelineBuilder.cs
+++ b/Source/Parsek/Timeline/TimelineBuilder.cs
@@ -451,6 +451,7 @@ namespace Parsek
             int count = 0;
             int evaReassignSkipped = 0;
             int modeSeedSkipped = 0;
+            int hireCostSuffixSuppressed = 0;
             for (int i = 0; i < ledgerActions.Count; i++)
             {
                 var action = ledgerActions[i];
@@ -490,11 +491,19 @@ namespace Parsek
                     continue;
                 }
 
+                string displayText = TimelineEntryDisplay.GetGameActionText(action, vesselName, currentMode);
+                if (action.Type == GameActionType.KerbalHire &&
+                    action.HireCost > 0f &&
+                    !GameActionDisplay.ShouldShowFundsForKerbalHire(action, currentMode))
+                {
+                    hireCostSuffixSuppressed++;
+                }
+
                 entries.Add(new TimelineEntry
                 {
                     UT = action.UT,
                     Type = entryType,
-                    DisplayText = TimelineEntryDisplay.GetGameActionText(action, vesselName, currentMode),
+                    DisplayText = displayText,
                     Source = TimelineSource.GameAction,
                     Tier = tier,
                     DisplayColor = GameActionDisplay.GetColor(action.Type),
@@ -518,7 +527,16 @@ namespace Parsek
                 ParsekLog.Verbose("Timeline",
                     $"Filtered {modeSeedSkipped} mode-inapplicable initial resource action(s)");
 
+            if (hireCostSuffixSuppressed > 0)
+                ParsekLog.Verbose("Timeline",
+                    $"Filtered {hireCostSuffixSuppressed} kerbal-hire funds suffix(es) in mode {FormatModeForLog(currentMode)}");
+
             return count;
+        }
+
+        private static string FormatModeForLog(Game.Modes? currentMode)
+        {
+            return currentMode.HasValue ? currentMode.Value.ToString() : "(unknown)";
         }
 
         internal static bool IsInitialResourceSeedVisibleInMode(GameActionType type, Game.Modes? currentMode)

--- a/Source/Parsek/Timeline/TimelineEntryDisplay.cs
+++ b/Source/Parsek/Timeline/TimelineEntryDisplay.cs
@@ -279,7 +279,7 @@ namespace Parsek
         /// Custom handling for science subjects (humanized), kerbal assignments (with vessel),
         /// ScienceInitial, and ReputationInitial. All others delegate to GameActionDisplay.
         /// </summary>
-        internal static string GetGameActionText(GameAction action, string vesselName, Game.Modes? currentMode = null)
+        internal static string GetGameActionText(GameAction action, string vesselName, Game.Modes? currentMode)
         {
             if (action == null)
                 return "";
@@ -351,40 +351,10 @@ namespace Parsek
                 }
 
                 case GameActionType.KerbalHire:
-                    return GetKerbalHireText(action, currentMode);
+                    return GameActionDisplay.GetKerbalHireDescription(action, currentMode);
 
                 default:
-                    return GameActionDisplay.GetDescription(action);
-            }
-        }
-
-        private static string GetKerbalHireText(GameAction action, Game.Modes? currentMode)
-        {
-            string kerbalName = action.KerbalName ?? "unknown";
-            if (!ShouldShowFundsForHire(action, currentMode))
-                return "Hire: " + kerbalName;
-
-            return string.Format(IC, "Hire: {0} -{1:0} funds", kerbalName, action.HireCost);
-        }
-
-        private static bool ShouldShowFundsForHire(GameAction action, Game.Modes? currentMode)
-        {
-            if (action.HireCost <= 0f)
-                return false;
-
-            if (!currentMode.HasValue)
-                return true;
-
-            switch (currentMode.Value)
-            {
-                case Game.Modes.SANDBOX:
-                case Game.Modes.SCIENCE_SANDBOX:
-                case Game.Modes.MISSION_BUILDER:
-                case Game.Modes.MISSION:
-                    return false;
-
-                default:
-                    return true;
+                    return GameActionDisplay.GetDescription(action, currentMode);
             }
         }
 

--- a/Source/Parsek/Timeline/TimelineEntryDisplay.cs
+++ b/Source/Parsek/Timeline/TimelineEntryDisplay.cs
@@ -39,7 +39,6 @@ namespace Parsek
                 case TimelineEntryType.ContractFail:
                 case TimelineEntryType.FacilityUpgrade:
                 case TimelineEntryType.FacilityDestruction:
-                case TimelineEntryType.KerbalHire:
                 case TimelineEntryType.FundsInitial:
                 case TimelineEntryType.ScienceInitial:
                 case TimelineEntryType.ReputationInitial:
@@ -280,7 +279,7 @@ namespace Parsek
         /// Custom handling for science subjects (humanized), kerbal assignments (with vessel),
         /// ScienceInitial, and ReputationInitial. All others delegate to GameActionDisplay.
         /// </summary>
-        internal static string GetGameActionText(GameAction action, string vesselName)
+        internal static string GetGameActionText(GameAction action, string vesselName, Game.Modes? currentMode = null)
         {
             if (action == null)
                 return "";
@@ -351,8 +350,41 @@ namespace Parsek
                     return crew;
                 }
 
+                case GameActionType.KerbalHire:
+                    return GetKerbalHireText(action, currentMode);
+
                 default:
                     return GameActionDisplay.GetDescription(action);
+            }
+        }
+
+        private static string GetKerbalHireText(GameAction action, Game.Modes? currentMode)
+        {
+            string kerbalName = action.KerbalName ?? "unknown";
+            if (!ShouldShowFundsForHire(action, currentMode))
+                return "Hire: " + kerbalName;
+
+            return string.Format(IC, "Hire: {0} -{1:0} funds", kerbalName, action.HireCost);
+        }
+
+        private static bool ShouldShowFundsForHire(GameAction action, Game.Modes? currentMode)
+        {
+            if (action.HireCost <= 0f)
+                return false;
+
+            if (!currentMode.HasValue)
+                return true;
+
+            switch (currentMode.Value)
+            {
+                case Game.Modes.SANDBOX:
+                case Game.Modes.SCIENCE_SANDBOX:
+                case Game.Modes.MISSION_BUILDER:
+                case Game.Modes.MISSION:
+                    return false;
+
+                default:
+                    return true;
             }
         }
 


### PR DESCRIPTION
## Summary
- move Timeline kerbal-hire rows to the Details tier so they no longer appear in Overview
- pass the current game mode into Timeline action formatting
- render hire rows without funds text in sandbox, science, and mission modes

## Tests
- dotnet test Source\\Parsek.Tests\\Parsek.Tests.csproj --filter TimelineBuilderTests
- dotnet test Source\\Parsek.Tests\\Parsek.Tests.csproj --filter FullyQualifiedName!~InjectAllRecordings

Note: full unfiltered test run reached the test runner but InjectAllRecordings failed because the local KSP install had KSP.log / Parsek.dll locked by another process.