### PR TITLE
Rate-limit deferred spawn queue wait logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ All notable changes to Parsek are documented here.
 
 - Contextual auto-record starts now show one notification: pad/runway launches, post-switch first-modification starts, and EVA-from-pad starts suppress the generic `Recording STARTED` toast when they post their own `(auto)` message.
 
+- Deferred spawn queue waits outside the physics bubble now log a rate-limited queue summary instead of repeating the same kept/warp-ended pair every frame while the spawn remains queued.
+
 - Boring-end trim now clamps the displayed and playable end time to the trimmed trajectory instead of keeping the scene-exit time. Trim diagnostics also report `trimUT` and `lastInterestingUT`.
 - Boring-end trim now tolerates normal landed physics jitter in idle tails while still rejecting meaningful movement. Skipped trims log the first divergent field to make future tolerance problems easier to diagnose.
 - Resume-on-scene-enter screen toast (`Recording STARTED (resume)`) now appears after the flight UI is ready instead of being swallowed during scene load.

--- a/Source/Parsek.Tests/DeferredSpawnTests.cs
+++ b/Source/Parsek.Tests/DeferredSpawnTests.cs
@@ -206,6 +206,12 @@ namespace Parsek.Tests
                 line.Contains("Bob Kerman") &&
                 line.Contains("spawned 1/1 flag(s)") &&
                 line.Contains("failed=0"));
+            Assert.Contains(logLines, line =>
+                line.Contains("[Policy]") &&
+                line.Contains("Deferred spawn queue drained") &&
+                line.Contains("spawned 1 deferred spawn(s)") &&
+                line.Contains("cleared 1 spawn queue item(s)") &&
+                line.Contains("cleared 1 flag replay(s)"));
         }
 
         [Fact]
@@ -250,6 +256,12 @@ namespace Parsek.Tests
             Assert.Contains(rec.RecordingId, policy.pendingFlagReplayRecordingIds);
             Assert.DoesNotContain(rec.RecordingId, policy.pendingSpawnRecordingIds);
             Assert.DoesNotContain(logLines, line => line.Contains("Deferred flag replay still failing"));
+            Assert.Contains(logLines, line =>
+                line.Contains("[Policy]") &&
+                line.Contains("Deferred spawn queue waiting") &&
+                line.Contains("flushed 1 deferred spawn(s)") &&
+                line.Contains("1 flag replay(s) pending") &&
+                line.Contains("1 total pending"));
 
             policy.FlushDeferredSpawns();
             Assert.Contains(rec.RecordingId, policy.pendingFlagReplayRecordingIds);
@@ -301,13 +313,16 @@ namespace Parsek.Tests
             Assert.Contains(rec.RecordingId, policy.pendingSpawnRecordingIds);
             Assert.Single(logLines.FindAll(line =>
                 line.Contains("Deferred spawn queue waiting") &&
-                line.Contains("Distant Kerbal")));
+                line.Contains("Distant Kerbal") &&
+                line.Contains("sample=#0 \"Distant Kerbal\"")));
             Assert.DoesNotContain(logLines, line =>
                 line.Contains("Deferred spawn kept in queue (outside physics bubble)"));
             Assert.DoesNotContain(logLines, line =>
                 line.Contains("Warp ended") &&
                 line.Contains("kept") &&
                 line.Contains("outside"));
+            Assert.DoesNotContain(logLines, line =>
+                line.Contains("Deferred spawn queue drained"));
 
             clock += 6.0;
             policy.FlushDeferredSpawns();

--- a/Source/Parsek.Tests/DeferredSpawnTests.cs
+++ b/Source/Parsek.Tests/DeferredSpawnTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.Serialization;
+using UnityEngine;
 using Xunit;
 
 namespace Parsek.Tests
@@ -13,6 +14,8 @@ namespace Parsek.Tests
 
         public DeferredSpawnTests()
         {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
             RecordingStore.ResetForTesting();
             GhostPlaybackLogic.ResetForTesting();
             ParsekLog.VerboseOverrideForTesting = true;
@@ -21,8 +24,7 @@ namespace Parsek.Tests
 
         public void Dispose()
         {
-            ParsekLog.TestSinkForTesting = null;
-            ParsekLog.VerboseOverrideForTesting = false;
+            ParsekLog.ResetTestOverrides();
             RecordingStore.ResetForTesting();
             GhostPlaybackLogic.ResetForTesting();
         }
@@ -262,6 +264,60 @@ namespace Parsek.Tests
             policy.FlushDeferredSpawns();
             Assert.DoesNotContain(rec.RecordingId, policy.pendingFlagReplayRecordingIds);
             Assert.Equal(4, spawnAttempts);
+        }
+
+        [Fact]
+        public void FlushDeferredSpawns_OutOfBubbleWait_IsRateLimited()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "rec-outside-bubble",
+                VesselName = "Distant Kerbal",
+                VesselSnapshot = new ConfigNode("VESSEL")
+            };
+            RecordingStore.AddRecordingWithTreeForTesting(rec);
+
+            double clock = 100.0;
+            ParsekLog.ClockOverrideForTesting = () => clock;
+
+            var host = (ParsekFlight)FormatterServices.GetUninitializedObject(typeof(ParsekFlight));
+            var engine = new GhostPlaybackEngine(null);
+            var policy = new ParsekPlaybackPolicy(engine, host)
+            {
+                IsWarpActiveOverrideForTesting = () => false,
+                CurrentUTOverrideForTesting = () => 120.0,
+                HasActiveVesselOverrideForTesting = () => true,
+                ActiveVesselWorldPosOverrideForTesting = () => Vector3d.zero,
+                ShouldDeferSpawnOutsideBubbleOverrideForTesting = (recording, activePos) => true,
+                SpawnVesselOrChainTipOverrideForTesting = (recording, index) =>
+                    throw new InvalidOperationException("Out-of-bubble spawns must remain queued.")
+            };
+            policy.pendingSpawnRecordingIds.Add(rec.RecordingId);
+
+            policy.FlushDeferredSpawns();
+            policy.FlushDeferredSpawns();
+            policy.FlushDeferredSpawns();
+
+            Assert.Contains(rec.RecordingId, policy.pendingSpawnRecordingIds);
+            Assert.Single(logLines.FindAll(line =>
+                line.Contains("Deferred spawn queue waiting") &&
+                line.Contains("Distant Kerbal")));
+            Assert.DoesNotContain(logLines, line =>
+                line.Contains("Deferred spawn kept in queue (outside physics bubble)"));
+            Assert.DoesNotContain(logLines, line =>
+                line.Contains("Warp ended") &&
+                line.Contains("kept") &&
+                line.Contains("outside"));
+
+            clock += 6.0;
+            policy.FlushDeferredSpawns();
+
+            Assert.Equal(2, logLines.FindAll(line =>
+                line.Contains("Deferred spawn queue waiting") &&
+                line.Contains("Distant Kerbal")).Count);
+            Assert.Contains(logLines, line =>
+                line.Contains("Deferred spawn queue waiting") &&
+                line.Contains("suppressed=2"));
         }
 
         [Fact]

--- a/Source/Parsek/ParsekPlaybackPolicy.cs
+++ b/Source/Parsek/ParsekPlaybackPolicy.cs
@@ -31,6 +31,7 @@ namespace Parsek
         internal Func<double> CurrentUTOverrideForTesting;
         internal Func<bool> HasActiveVesselOverrideForTesting;
         internal Func<Vector3d> ActiveVesselWorldPosOverrideForTesting;
+        internal Func<Recording, Vector3d, bool> ShouldDeferSpawnOutsideBubbleOverrideForTesting;
         internal Action<Recording, int> SpawnVesselOrChainTipOverrideForTesting;
         internal Action<uint> DeferredActivateVesselOverrideForTesting;
         internal const int FlagReplayWarnRetryThreshold = 3;
@@ -165,6 +166,8 @@ namespace Parsek
                 : FlightGlobals.ActiveVessel != null;
             int spawnedCount = 0;
             int deferredOutOfBubble = 0;
+            int firstDeferredOutOfBubbleIndex = -1;
+            string firstDeferredOutOfBubbleName = null;
             var flushedSpawnIds = new List<string>();
             var clearedFlagReplayIds = new List<string>();
             Vector3d activeVesselPos = hasActiveVessel
@@ -194,11 +197,14 @@ namespace Parsek
                 {
                     // Physics-bubble scoping: skip out-of-bubble spawns (keep in queue)
                     if (hasActiveVessel &&
-                        ParsekFlight.ShouldDeferSpawnOutsideBubble(rec, activeVesselPos))
+                        ShouldDeferSpawnOutsideBubble(rec, activeVesselPos))
                     {
                         deferredOutOfBubble++;
-                        ParsekLog.Verbose("Policy",
-                            $"Deferred spawn kept in queue (outside physics bubble): #{i} \"{rec.VesselName}\"");
+                        if (firstDeferredOutOfBubbleIndex < 0)
+                        {
+                            firstDeferredOutOfBubbleIndex = i;
+                            firstDeferredOutOfBubbleName = rec.VesselName;
+                        }
                         continue;
                     }
 
@@ -273,12 +279,23 @@ namespace Parsek
                 pendingFlagReplayFailureCounts.Remove(clearedFlagReplayIds[j]);
             }
 
-            if (deferredOutOfBubble > 0)
+            int remainingCount = pendingSpawnRecordingIds.Count + pendingFlagReplayRecordingIds.Count;
+            bool madeProgress = spawnedCount > 0 || flushedSpawnIds.Count > 0 || clearedFlagReplayIds.Count > 0;
+            if (remainingCount > 0)
             {
-                ParsekLog.Info("Policy",
-                    $"Warp ended — flushed {spawnedCount} deferred spawn(s), " +
-                    $"{deferredOutOfBubble} kept (outside bubble), " +
-                    $"{pendingSpawnRecordingIds.Count + pendingFlagReplayRecordingIds.Count} remaining");
+                string outsideBubbleSample = firstDeferredOutOfBubbleIndex >= 0
+                    ? $" sample=#{firstDeferredOutOfBubbleIndex} \"{firstDeferredOutOfBubbleName}\""
+                    : string.Empty;
+                string message =
+                    $"Deferred spawn queue waiting — flushed {spawnedCount} deferred spawn(s), " +
+                    $"{deferredOutOfBubble} kept outside physics bubble, " +
+                    $"{pendingFlagReplayRecordingIds.Count} flag replay(s) pending, " +
+                    $"{remainingCount} total pending{outsideBubbleSample}";
+
+                if (madeProgress)
+                    ParsekLog.Info("Policy", message);
+                else
+                    ParsekLog.VerboseRateLimited("Policy", "deferred-spawn-queue-waiting", message);
             }
             else
             {
@@ -288,6 +305,14 @@ namespace Parsek
 
             if (pendingSpawnRecordingIds.Count == 0)
                 pendingWatchRecordingId = null;
+        }
+
+        private bool ShouldDeferSpawnOutsideBubble(Recording rec, Vector3d activeVesselPos)
+        {
+            if (ShouldDeferSpawnOutsideBubbleOverrideForTesting != null)
+                return ShouldDeferSpawnOutsideBubbleOverrideForTesting(rec, activeVesselPos);
+
+            return ParsekFlight.ShouldDeferSpawnOutsideBubble(rec, activeVesselPos);
         }
 
         private void HandlePlaybackCompleted(PlaybackCompletedEvent evt)

--- a/Source/Parsek/ParsekPlaybackPolicy.cs
+++ b/Source/Parsek/ParsekPlaybackPolicy.cs
@@ -300,7 +300,9 @@ namespace Parsek
             else
             {
                 ParsekLog.Info("Policy",
-                    $"Warp ended — flushed {spawnedCount}/{flushedSpawnIds.Count} deferred spawn(s)");
+                    $"Deferred spawn queue drained — spawned {spawnedCount} deferred spawn(s), " +
+                    $"cleared {flushedSpawnIds.Count} spawn queue item(s), " +
+                    $"cleared {clearedFlagReplayIds.Count} flag replay(s)");
             }
 
             if (pendingSpawnRecordingIds.Count == 0)

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -274,6 +274,10 @@ After removing ResourceBudget.ComputeTotal logging (52% of output), remaining sp
 - KSCSpawn "Spawn not needed" at INFO level (54 lines)
 - BgRecorder CheckpointAllVessels checkpointed=0 at INFO (15 lines)
 
+2026-04-25 update: deferred spawn queue outside-physics-bubble waits are no longer
+a spam source; the per-recording kept line and repeated warp-ended summary were
+replaced with a rate-limited queue wait summary.
+
 **Priority:** Deferred to Phase 11.5 (Recording Optimization & Observability)
 
 **Status:** Open


### PR DESCRIPTION
## Summary
- Replace repeated out-of-bubble deferred spawn logs with a rate-limited queue wait summary.
- Add regression coverage for repeated deferred spawn flush attempts.
- Document the log-spam source cleanup.

## Tests
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter FlushDeferredSpawns
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter DeferredSpawnTests
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter ParsekLogTests
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj