### PR TITLE
Rate-limit IsUnfinishedFlight + missed-vessel-switch log spam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@ All notable changes to Parsek are documented here.
 
 - Deferred spawn queue waits outside the physics bubble now log a rate-limited queue summary instead of repeating the same kept/warp-ended pair every frame while the spawn remains queued.
 
+- Unfinished-flight predicate and missed-vessel-switch fallback now rate-limit their per-frame diagnostic lines, so KSP.log is no longer dominated by hundreds of thousands of identical `[UnfinishedFlights]` decisions or repeated `recovering missed vessel switch` warnings during a normal session.
+
 - Boring-end trim now clamps the displayed and playable end time to the trimmed trajectory instead of keeping the scene-exit time. Trim diagnostics also report `trimUT` and `lastInterestingUT`.
 - Boring-end trim now tolerates normal landed physics jitter in idle tails while still rejecting meaningful movement. Skipped trims log the first divergent field to make future tolerance problems easier to diagnose.
 - Resume-on-scene-enter screen toast (`Recording STARTED (resume)`) now appears after the flight UI is ready instead of being swallowed during scene load.

--- a/Source/Parsek.Tests/EffectiveStateTests.cs
+++ b/Source/Parsek.Tests/EffectiveStateTests.cs
@@ -391,6 +391,31 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void IsUnfinishedFlight_RepeatedCallsSameRec_RateLimitedToOneLine()
+        {
+            // Regression: IsUnfinishedFlight is invoked from per-frame UI hot
+            // paths (RecordingsTableUI rows, UnfinishedFlightsGroup membership,
+            // TimelineBuilder) once per recording per frame. Before the fix it
+            // emitted plain Verbose lines on every return path, producing
+            // hundreds of thousands of identical lines per session — captured
+            // KSP.log dated 2026-04-25 had ~511k UnfinishedFlights lines, ~94%
+            // of total file. The branches now route through VerboseRateLimited
+            // keyed by reason+recId so each (rec, reason) pair logs at most
+            // once per rate-limit window.
+            var rec = Rec("rec_spam", MergeState.Immutable, TerminalState.Orbiting,
+                parentBranchPointId: "bp_1");
+            var rp = new RewindPoint { RewindPointId = "rp_1", BranchPointId = "bp_1" };
+            MakeScenario(rps: new List<RewindPoint> { rp });
+
+            for (int i = 0; i < 100; i++)
+                Assert.False(EffectiveState.IsUnfinishedFlight(rec));
+
+            int notCrashedLines = logLines.Count(l =>
+                l.Contains("[UnfinishedFlights]") && l.Contains("rec_spam") && l.Contains("notCrashed"));
+            Assert.Equal(1, notCrashedLines);
+        }
+
+        [Fact]
         public void ResolveChainTerminalRecording_NoChain_ReturnsSelf()
         {
             var rec = new Recording

--- a/Source/Parsek/EffectiveState.cs
+++ b/Source/Parsek/EffectiveState.cs
@@ -156,7 +156,8 @@ namespace Parsek
             if (rec.MergeState != MergeState.Immutable
                 && rec.MergeState != MergeState.CommittedProvisional)
             {
-                ParsekLog.Verbose("UnfinishedFlights",
+                ParsekLog.VerboseRateLimited("UnfinishedFlights",
+                    $"mergeState-{recId}",
                     $"IsUnfinishedFlight=false rec={recId} reason=mergeState:{rec.MergeState}");
                 return false;
             }
@@ -170,7 +171,8 @@ namespace Parsek
             Recording terminalRec = ResolveChainTerminalRecording(rec);
             if (!IsTerminalCrashed(terminalRec))
             {
-                ParsekLog.Verbose("UnfinishedFlights",
+                ParsekLog.VerboseRateLimited("UnfinishedFlights",
+                    $"notCrashed-{recId}",
                     $"IsUnfinishedFlight=false rec={recId} reason=notCrashed:{terminalRec.TerminalStateValue} " +
                     $"(tip={(ReferenceEquals(terminalRec, rec) ? "self" : terminalRec.RecordingId ?? "<no-id>")})");
                 return false;
@@ -185,7 +187,8 @@ namespace Parsek
             string childBpId = rec.ChildBranchPointId;
             if (string.IsNullOrEmpty(parentBpId) && string.IsNullOrEmpty(childBpId))
             {
-                ParsekLog.Verbose("UnfinishedFlights",
+                ParsekLog.VerboseRateLimited("UnfinishedFlights",
+                    $"noParentBp-{recId}",
                     $"IsUnfinishedFlight=false rec={recId} reason=noParentBp");
                 return false;
             }
@@ -197,7 +200,8 @@ namespace Parsek
             // a ParsekScenario without going through Unity's AddComponent).
             if (object.ReferenceEquals(null, scenario) || scenario.RewindPoints == null)
             {
-                ParsekLog.Verbose("UnfinishedFlights",
+                ParsekLog.VerboseRateLimited("UnfinishedFlights",
+                    $"noScenario-{recId}",
                     $"IsUnfinishedFlight=false rec={recId} reason=noScenario");
                 return false;
             }
@@ -218,13 +222,15 @@ namespace Parsek
                     // persisted RewindPoint list.
                     string matchedBp = matchesParent ? parentBpId : childBpId;
                     string side = matchesParent ? "parent" : "active-parent-child";
-                    ParsekLog.Verbose("UnfinishedFlights",
+                    ParsekLog.VerboseRateLimited("UnfinishedFlights",
+                        $"match-{recId}",
                         $"IsUnfinishedFlight=true rec={recId} bp={matchedBp} side={side} rp={rp.RewindPointId}");
                     return true;
                 }
             }
 
-            ParsekLog.Verbose("UnfinishedFlights",
+            ParsekLog.VerboseRateLimited("UnfinishedFlights",
+                $"noMatchingRP-{recId}",
                 $"IsUnfinishedFlight=false rec={recId} reason=noMatchingRP " +
                 $"parentBp={parentBpId ?? "<none>"} childBp={childBpId ?? "<none>"} " +
                 $"rpCount={scenario.RewindPoints.Count}");

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -6560,7 +6560,13 @@ namespace Parsek
             if (GhostMapPresence.IsGhostMapVessel(activeVesselPid)) return;
 
             uint recorderPid = recorder != null ? recorder.RecordingVesselId : 0;
-            ParsekLog.Warn("Flight",
+            // Update() runs every frame; if the recovery handler does not clear
+            // the predicate immediately (e.g. background recorder still pending),
+            // this branch fires repeatedly for the same vessel. Rate-limit by
+            // activePid so each vessel logs at most once per window — visibility
+            // is preserved (still a WARN), spam is bounded.
+            ParsekLog.WarnRateLimited("Flight",
+                $"missed-vessel-switch-{activeVesselPid}",
                 $"Update: recovering missed vessel switch for active vessel '{activeVessel.vesselName}' " +
                 $"(activePid={activeVesselPid}, recorderPid={recorderPid}, " +
                 $"trackedInBackground={activeVesselTrackedInBackground})");

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -328,6 +328,25 @@ After removing ResourceBudget.ComputeTotal logging (52% of output), remaining sp
 a spam source; the per-recording kept line and repeated warp-ended summary were
 replaced with a rate-limited queue wait summary.
 
+2026-04-25 update (UnfinishedFlights + missed-vessel-switch):
+`logs/2026-04-25_1314_marker-validator-fix/KSP.log` was 96 MB / 540k lines, of
+which ~511k (94%) were `[Parsek][VERBOSE][UnfinishedFlights]
+IsUnfinishedFlight=…` decisions and ~1k were `[Parsek][WARN][Flight] Update:
+recovering missed vessel switch` lines. Both fired from per-frame paths:
+`EffectiveState.IsUnfinishedFlight` is invoked once per recording per frame from
+`RecordingsTableUI` row drawing, `UnfinishedFlightsGroup` membership filtering,
+and `TimelineBuilder`; the missed-vessel-switch warn fires in `ParsekFlight`
+`Update()` until the recovery handler clears the predicate, which in this
+playtest took dozens to hundreds of frames per vessel. Each of the 7 return
+paths in `IsUnfinishedFlight` now uses `ParsekLog.VerboseRateLimited` keyed by
+`{reason}-{recordingId}` so each (recording, reason) pair logs once per
+rate-limit window. The missed-vessel-switch warn now uses
+`ParsekLog.WarnRateLimited` keyed by `missed-vessel-switch-{activeVesselPid}`
+so each vessel logs at most once per window. Regression
+`EffectiveStateTests.IsUnfinishedFlight_RepeatedCallsSameRec_RateLimitedToOneLine`
+calls the predicate 100x with the same recording and asserts a single emitted
+line.
+
 **Priority:** Deferred to Phase 11.5 (Recording Optimization & Observability)
 
 **Status:** Open


### PR DESCRIPTION
## Summary

The 2026-04-25 `marker-validator-fix` playtest captured a 96 MB / 540k-line `KSP.log` of which ~94% (511k lines) were per-frame `[Parsek][VERBOSE][UnfinishedFlights] IsUnfinishedFlight=…` decisions and ~1k lines were per-frame `[Parsek][WARN][Flight] Update: recovering missed vessel switch…` warnings. Both fired from per-frame paths and drowned out everything else, making the log unusable for investigation.

- `EffectiveState.IsUnfinishedFlight` now routes its seven return-path log lines through `ParsekLog.VerboseRateLimited`, keyed by `{reason}-{recordingId}` so each `(recording, reason)` pair logs at most once per rate-limit window. Hot callers: `RecordingsTableUI` row drawing, `UnfinishedFlightsGroup` membership, `TimelineBuilder`.
- `ParsekFlight.Update`'s missed-vessel-switch fallback now uses `ParsekLog.WarnRateLimited`, keyed by `activeVesselPid` so each vessel logs at most once per window while the recovery handler clears the predicate. The captured log had 688 / 324 repeats for two vessels.

The third spammer in the captured log — deferred-spawn `kept (outside bubble)` — is **already fixed on `main`** by [#534](https://github.com/vl3c/Parsek/pull/534); the captured commit `ef63407a` was on `bug/extrapolator-destroyed-on-subsurface` and predated the merge of #534 into that branch.

## Test plan

- [x] `dotnet test` — 8629 / 8629 passing.
- [x] New regression `EffectiveStateTests.IsUnfinishedFlight_RepeatedCallsSameRec_RateLimitedToOneLine` calls the predicate 100x with the same recording and asserts exactly one emitted line.
- [x] Build deploys to `Kerbal Space Program/GameData/Parsek/Plugins/Parsek.dll`; UTF-16 grep confirms the new keys (`mergeState-`, `noMatchingRP-`, `missed-vessel-switch-`) are present.
- [ ] In-game smoke playtest to confirm the next collected log is dominated by content other than these two patterns.