### PR TITLE
Fix #578 crew orphan placement no-match diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- `#578` Crew orphan-placement misses now distinguish a wrong active vessel from a full matching pod, so stand-ins stay available for a later correct-vessel retry without falling back to an unrelated seat.
+
 - Re-fly merge now supersedes every chain segment of an env-split crashed recording. Previously the closure walker followed `ChildBranchPointId` only, so an exo HEAD + in-atmo TIP chain produced by `RecordingOptimizer.SplitAtSection` left the TIP behind as an orphan "kerbal destroyed in atmo" row alongside the new "kerbal lived" provisional. Saves committed before this fix that already completed a chain-crossing crashed re-fly merge are not retroactively healed; affected players can `Discard` the orphan via the table.
 
 - EVA splits now author a Rewind Point, so a destroyed EVA kerbal becomes an Unfinished Flight with a Re-Fly button. Previously `IsTrackableVessel` only recognised parts with `ModuleCommand`, so the kerbal didn't count as a controllable output, the split classified as single-controllable, and no RP was authored.

--- a/Source/Parsek.Tests/CrewReservationNameHitFallbackTests.cs
+++ b/Source/Parsek.Tests/CrewReservationNameHitFallbackTests.cs
@@ -17,7 +17,7 @@ namespace Parsek.Tests
     ///   1. pid-hit beats name-hit when both are possible
     ///   2. name-hit with a unique match succeeds
     ///   3. name-hit with multiple matches picks the minimum-free-seats part
-    ///   4. no-match (pid and name both miss) returns -1 / None
+    ///   4. no-match (pid and name both miss) returns -1 / None with a reason
     ///   5. pid=100000 coincidence: a pid-hit still wins, no name-hit false positive
     ///   6. log-assertion: the summary line contains nameHitFallbacks=... counter
     ///
@@ -154,6 +154,51 @@ namespace Parsek.Tests
 
             Assert.Equal(-1, idx);
             Assert.Equal(CrewReservationManager.SeatMatchKind.None, kind);
+        }
+
+        [Fact]
+        public void TryResolveActiveVesselPartForSeat_Bug578_WrongActiveVessel_DiagnosesMissingSnapshotPart()
+        {
+            // Regression shape from #578: the snapshot resolves to a command pod
+            // seat, but the active vessel is a different craft with no matching
+            // part name. Even if an unrelated live part has a free crew seat, the
+            // removed tier-3 "any seat" fallback must stay rejected.
+            var snapshot = new ConfigNode("VESSEL");
+            var snapshotPart = snapshot.AddNode("PART");
+            snapshotPart.AddValue("name", "mk1-3pod");
+            snapshotPart.AddValue("persistentId", "10668187");
+            snapshotPart.AddValue("crew", "Magdo Kerman");
+            var seat = CrewReservationManager.ResolveOrphanSeatFromSnapshots(
+                "Magdo Kerman", new[] { snapshot }, null);
+
+            Assert.True(seat.Found);
+
+            var activeParts = new List<CrewReservationManager.ActivePartSeat>
+            {
+                Seat(pid: 95506284u, name: "probeCoreHex.v2", freeSeats: 0),
+                Seat(pid: 95506285u, name: "crewCabin", freeSeats: 2),
+            };
+
+            int idx = CrewReservationManager.TryResolveActiveVesselPartForSeat(
+                snapshotPartPid: seat.PartPid,
+                snapshotPartName: seat.PartName,
+                activeParts: activeParts,
+                out CrewReservationManager.SeatMatchKind kind,
+                out CrewReservationManager.SeatMatchMissDiagnostic diagnostic);
+
+            Assert.Equal(-1, idx);
+            Assert.Equal(CrewReservationManager.SeatMatchKind.None, kind);
+            Assert.Equal(
+                CrewReservationManager.SeatMatchMissReason.ActiveVesselMissingSnapshotPart,
+                diagnostic.Reason);
+            Assert.Equal(2, diagnostic.ActivePartCount);
+            Assert.Equal(1, diagnostic.FreeSeatPartCount);
+            Assert.Equal(0, diagnostic.PidMatchCount);
+            Assert.Equal(0, diagnostic.NameMatchCount);
+            string formatted = CrewReservationManager.FormatSeatMatchMissDiagnostic(diagnostic);
+            Assert.Contains("reason=active-vessel-missing-snapshot-part", formatted);
+            Assert.Contains("freeSeatParts=1", formatted);
+            Assert.Contains("nameMatches=0", formatted);
         }
 
         [Fact]
@@ -306,10 +351,16 @@ namespace Parsek.Tests
                 snapshotPartPid: 100000u,
                 snapshotPartName: "mk1pod.v2",
                 activeParts: parts,
-                out CrewReservationManager.SeatMatchKind kind);
+                out CrewReservationManager.SeatMatchKind kind,
+                out CrewReservationManager.SeatMatchMissDiagnostic diagnostic);
 
             Assert.Equal(-1, idx);
             Assert.Equal(CrewReservationManager.SeatMatchKind.None, kind);
+            Assert.Equal(
+                CrewReservationManager.SeatMatchMissReason.SnapshotPartSeatsFull,
+                diagnostic.Reason);
+            Assert.Equal(1, diagnostic.NameMatchCount);
+            Assert.Equal(0, diagnostic.NameFreeSeatCount);
         }
 
         // ────────────────────────────────────────────────────────

--- a/Source/Parsek.Tests/CrewReservationNameHitFallbackTests.cs
+++ b/Source/Parsek.Tests/CrewReservationNameHitFallbackTests.cs
@@ -20,6 +20,7 @@ namespace Parsek.Tests
     ///   4. no-match (pid and name both miss) returns -1 / None with a reason
     ///   5. pid=100000 coincidence: a pid-hit still wins, no name-hit false positive
     ///   6. log-assertion: the summary line contains nameHitFallbacks=... counter
+    ///   7. no-match WARN line includes the miss reason and retry semantics
     ///
     /// Live AddCrewmember placement is covered by the in-game test
     /// `Bug456_OrphanPlacement_NameHitFallback_PlacesStandin` in
@@ -62,6 +63,24 @@ namespace Parsek.Tests
                 PartName = name,
                 FreeSeats = freeSeats
             };
+        }
+
+        private static void AssertMissReason(
+            uint snapshotPartPid,
+            string snapshotPartName,
+            IList<CrewReservationManager.ActivePartSeat> parts,
+            CrewReservationManager.SeatMatchMissReason expected)
+        {
+            int idx = CrewReservationManager.TryResolveActiveVesselPartForSeat(
+                snapshotPartPid,
+                snapshotPartName,
+                parts,
+                out CrewReservationManager.SeatMatchKind kind,
+                out CrewReservationManager.SeatMatchMissDiagnostic diagnostic);
+
+            Assert.Equal(-1, idx);
+            Assert.Equal(CrewReservationManager.SeatMatchKind.None, kind);
+            Assert.Equal(expected, diagnostic.Reason);
         }
 
         // ────────────────────────────────────────────────────────
@@ -199,6 +218,127 @@ namespace Parsek.Tests
             Assert.Contains("reason=active-vessel-missing-snapshot-part", formatted);
             Assert.Contains("freeSeatParts=1", formatted);
             Assert.Contains("nameMatches=0", formatted);
+        }
+
+        [Fact]
+        public void TryResolveActiveVesselPartForSeat_MissReasons_CoverAllReachableBranches()
+        {
+            AssertMissReason(
+                10668187u,
+                "mk1-3pod",
+                null,
+                CrewReservationManager.SeatMatchMissReason.ActiveVesselHasNoParts);
+
+            AssertMissReason(
+                0u,
+                null,
+                new List<CrewReservationManager.ActivePartSeat>
+                {
+                    Seat(pid: 95506285u, name: "crewCabin", freeSeats: 2),
+                },
+                CrewReservationManager.SeatMatchMissReason.NoSnapshotLookupTier);
+
+            AssertMissReason(
+                10668187u,
+                "mk1-3pod",
+                new List<CrewReservationManager.ActivePartSeat>
+                {
+                    Seat(pid: 95506284u, name: "probeCoreHex.v2", freeSeats: 0),
+                    Seat(pid: 95506285u, name: "crewCabin", freeSeats: 2),
+                },
+                CrewReservationManager.SeatMatchMissReason.ActiveVesselMissingSnapshotPart);
+
+            AssertMissReason(
+                100000u,
+                "mk1pod.v2",
+                new List<CrewReservationManager.ActivePartSeat>
+                {
+                    Seat(pid: 18900260u, name: "mk1pod.v2", freeSeats: 0),
+                },
+                CrewReservationManager.SeatMatchMissReason.SnapshotPartSeatsFull);
+
+            AssertMissReason(
+                18900260u,
+                null,
+                new List<CrewReservationManager.ActivePartSeat>
+                {
+                    Seat(pid: 18900260u, name: "mk1pod.v2", freeSeats: 0),
+                    Seat(pid: 18900261u, name: "crewCabin", freeSeats: 2),
+                },
+                CrewReservationManager.SeatMatchMissReason.SnapshotPidPartSeatsFull);
+
+            AssertMissReason(
+                18900260u,
+                null,
+                new List<CrewReservationManager.ActivePartSeat>
+                {
+                    Seat(pid: 18900261u, name: "crewCabin", freeSeats: 2),
+                },
+                CrewReservationManager.SeatMatchMissReason.ActiveVesselMissingSnapshotPid);
+        }
+
+        [Fact]
+        public void TryResolveActiveVesselPartForSeat_PidCollisionWrongVessel_ReportsMissingSnapshotPart()
+        {
+            // If an active vessel happens to have the snapshot pid on an
+            // unrelated full part, the absent snapshot part name is the more
+            // actionable wrong-vessel signal.
+            var parts = new List<CrewReservationManager.ActivePartSeat>
+            {
+                Seat(pid: 10668187u, name: "probeCoreHex.v2", freeSeats: 0),
+                Seat(pid: 95506285u, name: "crewCabin", freeSeats: 2),
+            };
+
+            int idx = CrewReservationManager.TryResolveActiveVesselPartForSeat(
+                snapshotPartPid: 10668187u,
+                snapshotPartName: "mk1-3pod",
+                activeParts: parts,
+                out CrewReservationManager.SeatMatchKind kind,
+                out CrewReservationManager.SeatMatchMissDiagnostic diagnostic);
+
+            Assert.Equal(-1, idx);
+            Assert.Equal(CrewReservationManager.SeatMatchKind.None, kind);
+            Assert.Equal(
+                CrewReservationManager.SeatMatchMissReason.ActiveVesselMissingSnapshotPart,
+                diagnostic.Reason);
+            Assert.Equal(1, diagnostic.PidMatchCount);
+            Assert.Equal(0, diagnostic.PidFreeSeatCount);
+            Assert.Equal(0, diagnostic.NameMatchCount);
+        }
+
+        [Fact]
+        public void LogOrphanPlacementDeferred_EmitsReasonAndStandInRetrySemantics()
+        {
+            var diagnostic = new CrewReservationManager.SeatMatchMissDiagnostic
+            {
+                Reason = CrewReservationManager.SeatMatchMissReason.ActiveVesselMissingSnapshotPart,
+                ActivePartCount = 2,
+                FreeSeatPartCount = 1,
+                PidMatchCount = 0,
+                PidFreeSeatCount = 0,
+                NameMatchCount = 0,
+                NameFreeSeatCount = 0,
+            };
+
+            CrewReservationManager.LogOrphanPlacementDeferred(
+                "Magdo Kerman",
+                "Herfrid Kerman",
+                10668187u,
+                "mk1-3pod",
+                diagnostic,
+                pidHits: 0,
+                nameHitFallbacks: 0);
+
+            Assert.Contains(logLines, line =>
+                line.Contains("[WARN][CrewReservation] Orphan placement deferred:") &&
+                line.Contains("'Magdo Kerman' → 'Herfrid Kerman'") &&
+                line.Contains("(snapshot pid=10668187 name='mk1-3pod')") &&
+                line.Contains("stand-in kept in roster") &&
+                line.Contains("reason=active-vessel-missing-snapshot-part") &&
+                line.Contains("activeParts=2") &&
+                line.Contains("freeSeatParts=1") &&
+                line.Contains("attempted pidTier=yes nameTier=yes") &&
+                line.Contains("cumulative pidHits=0 nameHitFallbacks=0"));
         }
 
         [Fact]

--- a/Source/Parsek/CrewReservationManager.cs
+++ b/Source/Parsek/CrewReservationManager.cs
@@ -439,27 +439,14 @@ namespace Parsek
                 // to fix. The tightest-fit rule keeps that guarantee even when
                 // multiple parts share the snapshot part name (the cockpit typically
                 // has fewer seats than a passenger cabin).
-                string attemptDiagnostic = FormatSeatMatchAttemptDiagnostic(
-                    seat.PartPid, seat.PartName);
                 Part target = FindTargetPartForOrphan(
                     seat.PartPid, seat.PartName, out SeatMatchKind matchKind,
                     out SeatMatchMissDiagnostic missDiagnostic);
                 if (target == null)
                 {
-                    // Preserve the distinctive "snapshot pid=0" signal (bug #413):
-                    // a future regression where the capture site drops the real
-                    // persistentId will still show up here with pid=0 and a valid
-                    // part name, so it's callable out by log-grep.
-                    string pidDiagnostic = seat.PartPid == 0
-                        ? "pid=0 (suspicious: snapshot missing persistentId)"
-                        : $"pid={seat.PartPid}";
-                    ParsekLog.Warn("CrewReservation",
-                        $"Orphan placement deferred: no matching part with free seat in active vessel for " +
-                        $"'{originalName}' → '{replacementName}' " +
-                        $"(snapshot {pidDiagnostic} name='{seat.PartName}') — " +
-                        $"stand-in kept in roster; {FormatSeatMatchMissDiagnostic(missDiagnostic)} " +
-                        $"({attemptDiagnostic}; cumulative pidHits={pidHits} " +
-                        $"nameHitFallbacks={nameHitFallbacks})");
+                    LogOrphanPlacementDeferred(originalName, replacementName,
+                        seat.PartPid, seat.PartName, missDiagnostic,
+                        pidHits, nameHitFallbacks);
                     skippedNoMatchingPart++;
                     continue;
                 }
@@ -870,7 +857,6 @@ namespace Parsek
             SnapshotPartSeatsFull = 4,
             SnapshotPidPartSeatsFull = 5,
             ActiveVesselMissingSnapshotPid = 6,
-            NoMatchingFreeSeat = 7,
         }
 
         /// <summary>
@@ -936,11 +922,36 @@ namespace Parsek
                     return "snapshot-pid-part-seats-full";
                 case SeatMatchMissReason.ActiveVesselMissingSnapshotPid:
                     return "active-vessel-missing-snapshot-pid";
-                case SeatMatchMissReason.NoMatchingFreeSeat:
-                    return "no-matching-free-seat";
                 default:
                     return "none";
             }
+        }
+
+        internal static void LogOrphanPlacementDeferred(
+            string originalName,
+            string replacementName,
+            uint snapshotPartPid,
+            string snapshotPartName,
+            SeatMatchMissDiagnostic missDiagnostic,
+            int pidHits,
+            int nameHitFallbacks)
+        {
+            // Preserve the distinctive "snapshot pid=0" signal (bug #413):
+            // a future regression where the capture site drops the real
+            // persistentId will still show up here with pid=0 and a valid part
+            // name, so it's callable out by log-grep.
+            string pidDiagnostic = snapshotPartPid == 0
+                ? "pid=0 (suspicious: snapshot missing persistentId)"
+                : $"pid={snapshotPartPid}";
+            string attemptDiagnostic = FormatSeatMatchAttemptDiagnostic(
+                snapshotPartPid, snapshotPartName);
+            ParsekLog.Warn("CrewReservation",
+                $"Orphan placement deferred: no matching part with free seat in active vessel for " +
+                $"'{originalName}' → '{replacementName}' " +
+                $"(snapshot {pidDiagnostic} name='{snapshotPartName}') — " +
+                $"stand-in kept in roster; {FormatSeatMatchMissDiagnostic(missDiagnostic)} " +
+                $"({attemptDiagnostic}; cumulative pidHits={pidHits} " +
+                $"nameHitFallbacks={nameHitFallbacks})");
         }
 
         /// <summary>
@@ -996,32 +1007,20 @@ namespace Parsek
                 return -1;
             }
 
-            // Tier 1: pid-hit.
-            if (snapshotPartPid != 0)
+            for (int i = 0; i < activeParts.Count; i++)
             {
-                for (int i = 0; i < activeParts.Count; i++)
-                {
-                    var p = activeParts[i];
-                    if (p.FreeSeats > 0)
-                        missDiagnostic.FreeSeatPartCount++;
-                    if (p.PersistentId != snapshotPartPid)
-                        continue;
+                var p = activeParts[i];
+                if (p.FreeSeats > 0)
+                    missDiagnostic.FreeSeatPartCount++;
+                if (snapshotPartPid == 0 || p.PersistentId != snapshotPartPid)
+                    continue;
 
-                    missDiagnostic.PidMatchCount++;
-                    if (p.FreeSeats > 0)
-                    {
-                        missDiagnostic.PidFreeSeatCount++;
-                        matchKind = SeatMatchKind.PidHit;
-                        return i;
-                    }
-                }
-            }
-            else
-            {
-                for (int i = 0; i < activeParts.Count; i++)
+                missDiagnostic.PidMatchCount++;
+                if (p.FreeSeats > 0)
                 {
-                    if (activeParts[i].FreeSeats > 0)
-                        missDiagnostic.FreeSeatPartCount++;
+                    missDiagnostic.PidFreeSeatCount++;
+                    matchKind = SeatMatchKind.PidHit;
+                    return i;
                 }
             }
 
@@ -1069,6 +1068,12 @@ namespace Parsek
             if (!attemptedPid && !attemptedName)
                 return SeatMatchMissReason.NoSnapshotLookupTier;
 
+            if (attemptedName)
+            {
+                if (diagnostic.NameMatchCount == 0)
+                    return SeatMatchMissReason.ActiveVesselMissingSnapshotPart;
+            }
+
             if (attemptedPid &&
                 diagnostic.PidMatchCount > 0 &&
                 diagnostic.PidFreeSeatCount == 0)
@@ -1076,8 +1081,6 @@ namespace Parsek
 
             if (attemptedName)
             {
-                if (diagnostic.NameMatchCount == 0)
-                    return SeatMatchMissReason.ActiveVesselMissingSnapshotPart;
                 if (diagnostic.NameFreeSeatCount == 0)
                     return SeatMatchMissReason.SnapshotPartSeatsFull;
             }
@@ -1088,7 +1091,7 @@ namespace Parsek
                     return SeatMatchMissReason.ActiveVesselMissingSnapshotPid;
             }
 
-            return SeatMatchMissReason.NoMatchingFreeSeat;
+            return SeatMatchMissReason.None;
         }
 
         /// <summary>

--- a/Source/Parsek/CrewReservationManager.cs
+++ b/Source/Parsek/CrewReservationManager.cs
@@ -442,7 +442,8 @@ namespace Parsek
                 string attemptDiagnostic = FormatSeatMatchAttemptDiagnostic(
                     seat.PartPid, seat.PartName);
                 Part target = FindTargetPartForOrphan(
-                    seat.PartPid, seat.PartName, out SeatMatchKind matchKind);
+                    seat.PartPid, seat.PartName, out SeatMatchKind matchKind,
+                    out SeatMatchMissDiagnostic missDiagnostic);
                 if (target == null)
                 {
                     // Preserve the distinctive "snapshot pid=0" signal (bug #413):
@@ -453,9 +454,10 @@ namespace Parsek
                         ? "pid=0 (suspicious: snapshot missing persistentId)"
                         : $"pid={seat.PartPid}";
                     ParsekLog.Warn("CrewReservation",
-                        $"Orphan placement: no matching part with free seat in active vessel for " +
+                        $"Orphan placement deferred: no matching part with free seat in active vessel for " +
                         $"'{originalName}' → '{replacementName}' " +
-                        $"(snapshot {pidDiagnostic} name='{seat.PartName}') — stand-in left in roster " +
+                        $"(snapshot {pidDiagnostic} name='{seat.PartName}') — " +
+                        $"stand-in kept in roster; {FormatSeatMatchMissDiagnostic(missDiagnostic)} " +
                         $"({attemptDiagnostic}; cumulative pidHits={pidHits} " +
                         $"nameHitFallbacks={nameHitFallbacks})");
                     skippedNoMatchingPart++;
@@ -551,9 +553,13 @@ namespace Parsek
         /// Returns null if no matching part has a free seat.
         /// </summary>
         private static Part FindTargetPartForOrphan(
-            uint snapshotPartPid, string snapshotPartName, out SeatMatchKind matchKind)
+            uint snapshotPartPid,
+            string snapshotPartName,
+            out SeatMatchKind matchKind,
+            out SeatMatchMissDiagnostic missDiagnostic)
         {
             matchKind = SeatMatchKind.None;
+            missDiagnostic = default(SeatMatchMissDiagnostic);
             var av = FlightGlobals.ActiveVessel;
             if (av == null) return null;
 
@@ -574,7 +580,8 @@ namespace Parsek
             }
 
             int matchIdx = TryResolveActiveVesselPartForSeat(
-                snapshotPartPid, snapshotPartName, candidates, out matchKind);
+                snapshotPartPid, snapshotPartName, candidates, out matchKind,
+                out missDiagnostic);
             return matchIdx >= 0 ? av.parts[matchIdx] : null;
         }
 
@@ -854,6 +861,18 @@ namespace Parsek
             NameHit = 2,
         }
 
+        internal enum SeatMatchMissReason
+        {
+            None = 0,
+            ActiveVesselHasNoParts = 1,
+            NoSnapshotLookupTier = 2,
+            ActiveVesselMissingSnapshotPart = 3,
+            SnapshotPartSeatsFull = 4,
+            SnapshotPidPartSeatsFull = 5,
+            ActiveVesselMissingSnapshotPid = 6,
+            NoMatchingFreeSeat = 7,
+        }
+
         /// <summary>
         /// Bug #456 — lightweight view of a live vessel part used by the pure
         /// seat-matcher helper. Avoids taking a hard dependency on the KSP
@@ -867,6 +886,17 @@ namespace Parsek
             public int FreeSeats;
         }
 
+        internal struct SeatMatchMissDiagnostic
+        {
+            public SeatMatchMissReason Reason;
+            public int ActivePartCount;
+            public int FreeSeatPartCount;
+            public int PidMatchCount;
+            public int PidFreeSeatCount;
+            public int NameMatchCount;
+            public int NameFreeSeatCount;
+        }
+
         /// <summary>
         /// Formats truthful per-attempt tier telemetry for the no-match WARN.
         /// Distinct from the cumulative pidHits/nameHitFallbacks counters, which
@@ -877,6 +907,40 @@ namespace Parsek
         {
             return $"attempted pidTier={(snapshotPartPid != 0 ? "yes" : "no")} " +
                 $"nameTier={(!string.IsNullOrEmpty(snapshotPartName) ? "yes" : "no")}";
+        }
+
+        internal static string FormatSeatMatchMissDiagnostic(SeatMatchMissDiagnostic diagnostic)
+        {
+            return $"reason={FormatSeatMatchMissReason(diagnostic.Reason)} " +
+                $"activeParts={diagnostic.ActivePartCount} " +
+                $"freeSeatParts={diagnostic.FreeSeatPartCount} " +
+                $"pidMatches={diagnostic.PidMatchCount} " +
+                $"pidFreeSeats={diagnostic.PidFreeSeatCount} " +
+                $"nameMatches={diagnostic.NameMatchCount} " +
+                $"nameFreeSeats={diagnostic.NameFreeSeatCount}";
+        }
+
+        private static string FormatSeatMatchMissReason(SeatMatchMissReason reason)
+        {
+            switch (reason)
+            {
+                case SeatMatchMissReason.ActiveVesselHasNoParts:
+                    return "active-vessel-has-no-parts";
+                case SeatMatchMissReason.NoSnapshotLookupTier:
+                    return "no-snapshot-lookup-tier";
+                case SeatMatchMissReason.ActiveVesselMissingSnapshotPart:
+                    return "active-vessel-missing-snapshot-part";
+                case SeatMatchMissReason.SnapshotPartSeatsFull:
+                    return "snapshot-part-seats-full";
+                case SeatMatchMissReason.SnapshotPidPartSeatsFull:
+                    return "snapshot-pid-part-seats-full";
+                case SeatMatchMissReason.ActiveVesselMissingSnapshotPid:
+                    return "active-vessel-missing-snapshot-pid";
+                case SeatMatchMissReason.NoMatchingFreeSeat:
+                    return "no-matching-free-seat";
+                default:
+                    return "none";
+            }
         }
 
         /// <summary>
@@ -908,8 +972,29 @@ namespace Parsek
             IList<ActivePartSeat> activeParts,
             out SeatMatchKind matchKind)
         {
+            SeatMatchMissDiagnostic ignored;
+            return TryResolveActiveVesselPartForSeat(
+                snapshotPartPid, snapshotPartName, activeParts, out matchKind, out ignored);
+        }
+
+        internal static int TryResolveActiveVesselPartForSeat(
+            uint snapshotPartPid,
+            string snapshotPartName,
+            IList<ActivePartSeat> activeParts,
+            out SeatMatchKind matchKind,
+            out SeatMatchMissDiagnostic missDiagnostic)
+        {
             matchKind = SeatMatchKind.None;
-            if (activeParts == null || activeParts.Count == 0) return -1;
+            missDiagnostic = new SeatMatchMissDiagnostic
+            {
+                Reason = SeatMatchMissReason.None,
+                ActivePartCount = activeParts != null ? activeParts.Count : 0,
+            };
+            if (activeParts == null || activeParts.Count == 0)
+            {
+                missDiagnostic.Reason = SeatMatchMissReason.ActiveVesselHasNoParts;
+                return -1;
+            }
 
             // Tier 1: pid-hit.
             if (snapshotPartPid != 0)
@@ -917,11 +1002,26 @@ namespace Parsek
                 for (int i = 0; i < activeParts.Count; i++)
                 {
                     var p = activeParts[i];
-                    if (p.PersistentId == snapshotPartPid && p.FreeSeats > 0)
+                    if (p.FreeSeats > 0)
+                        missDiagnostic.FreeSeatPartCount++;
+                    if (p.PersistentId != snapshotPartPid)
+                        continue;
+
+                    missDiagnostic.PidMatchCount++;
+                    if (p.FreeSeats > 0)
                     {
+                        missDiagnostic.PidFreeSeatCount++;
                         matchKind = SeatMatchKind.PidHit;
                         return i;
                     }
+                }
+            }
+            else
+            {
+                for (int i = 0; i < activeParts.Count; i++)
+                {
+                    if (activeParts[i].FreeSeats > 0)
+                        missDiagnostic.FreeSeatPartCount++;
                 }
             }
 
@@ -935,7 +1035,9 @@ namespace Parsek
                     var p = activeParts[i];
                     if (string.IsNullOrEmpty(p.PartName)) continue;
                     if (p.PartName != snapshotPartName) continue;
+                    missDiagnostic.NameMatchCount++;
                     if (p.FreeSeats <= 0) continue;
+                    missDiagnostic.NameFreeSeatCount++;
                     if (p.FreeSeats < bestFreeSeats)
                     {
                         bestFreeSeats = p.FreeSeats;
@@ -949,7 +1051,44 @@ namespace Parsek
                 }
             }
 
+            missDiagnostic.Reason = ClassifySeatMatchMiss(
+                snapshotPartPid, snapshotPartName, missDiagnostic);
             return -1;
+        }
+
+        private static SeatMatchMissReason ClassifySeatMatchMiss(
+            uint snapshotPartPid,
+            string snapshotPartName,
+            SeatMatchMissDiagnostic diagnostic)
+        {
+            if (diagnostic.ActivePartCount <= 0)
+                return SeatMatchMissReason.ActiveVesselHasNoParts;
+
+            bool attemptedPid = snapshotPartPid != 0;
+            bool attemptedName = !string.IsNullOrEmpty(snapshotPartName);
+            if (!attemptedPid && !attemptedName)
+                return SeatMatchMissReason.NoSnapshotLookupTier;
+
+            if (attemptedPid &&
+                diagnostic.PidMatchCount > 0 &&
+                diagnostic.PidFreeSeatCount == 0)
+                return SeatMatchMissReason.SnapshotPidPartSeatsFull;
+
+            if (attemptedName)
+            {
+                if (diagnostic.NameMatchCount == 0)
+                    return SeatMatchMissReason.ActiveVesselMissingSnapshotPart;
+                if (diagnostic.NameFreeSeatCount == 0)
+                    return SeatMatchMissReason.SnapshotPartSeatsFull;
+            }
+
+            if (attemptedPid)
+            {
+                if (!attemptedName && diagnostic.PidMatchCount == 0)
+                    return SeatMatchMissReason.ActiveVesselMissingSnapshotPid;
+            }
+
+            return SeatMatchMissReason.NoMatchingFreeSeat;
         }
 
         /// <summary>

--- a/Source/Parsek/InGameTests/RuntimeTests.cs
+++ b/Source/Parsek/InGameTests/RuntimeTests.cs
@@ -5044,6 +5044,179 @@ namespace Parsek.InGameTests
             }
         }
 
+        [InGameTest(Category = "CrewReservation", Scene = GameScenes.FLIGHT,
+            Description = "Bug #578: PlaceOrphanedReplacements logs wrong-active-vessel no-match diagnostics without using an unrelated free seat")]
+        public void Bug578_OrphanPlacement_NoMatchingPart_LogsDeferredReason()
+        {
+            var av = FlightGlobals.ActiveVessel;
+            if (av == null)
+            {
+                InGameAssert.Skip("No active vessel");
+                return;
+            }
+
+            Part unrelatedFreeSeatPart = null;
+            for (int i = 0; i < av.parts.Count; i++)
+            {
+                var p = av.parts[i];
+                if (p != null && p.CrewCapacity > 0 && p.protoModuleCrew.Count < p.CrewCapacity
+                    && p.partInfo != null && !string.IsNullOrEmpty(p.partInfo.name))
+                {
+                    unrelatedFreeSeatPart = p;
+                    break;
+                }
+            }
+            if (unrelatedFreeSeatPart == null)
+            {
+                InGameAssert.Skip("Active vessel has no unrelated free crew seat to prove tier-3 fallback stays rejected");
+                return;
+            }
+
+            var roster = HighLogic.CurrentGame?.CrewRoster;
+            if (roster == null)
+            {
+                InGameAssert.Skip("No crew roster");
+                return;
+            }
+
+            var activeCrewNames = new HashSet<string>();
+            for (int p = 0; p < av.parts.Count; p++)
+            {
+                var crew = av.parts[p].protoModuleCrew;
+                for (int c = 0; c < crew.Count; c++)
+                {
+                    if (crew[c] != null && !string.IsNullOrEmpty(crew[c].name))
+                        activeCrewNames.Add(crew[c].name);
+                }
+            }
+
+            ProtoCrewMember standIn = null;
+            foreach (ProtoCrewMember pcm in roster.Crew)
+            {
+                if (pcm.rosterStatus == ProtoCrewMember.RosterStatus.Available
+                    && pcm.type == ProtoCrewMember.KerbalType.Crew
+                    && !activeCrewNames.Contains(pcm.name))
+                {
+                    standIn = pcm;
+                    break;
+                }
+            }
+            if (standIn == null)
+            {
+                InGameAssert.Skip("No Available crew kerbal in roster (not already on active vessel)");
+                return;
+            }
+
+            uint missingPid = 4000000000u;
+            bool pidCollision;
+            do
+            {
+                pidCollision = false;
+                for (int i = 0; i < av.parts.Count; i++)
+                {
+                    if (av.parts[i] != null && av.parts[i].persistentId == missingPid)
+                    {
+                        pidCollision = true;
+                        missingPid--;
+                        break;
+                    }
+                }
+            } while (pidCollision);
+
+            string missingPartName = "bug578_missing_part_" +
+                System.Guid.NewGuid().ToString("N").Substring(0, 8);
+            string fakeOriginal = "Bug578Test_" +
+                System.Guid.NewGuid().ToString("N").Substring(0, 8) + " Kerman";
+
+            var savedReplacements = new Dictionary<string, string>();
+            foreach (var kvp in CrewReservationManager.CrewReplacements)
+                savedReplacements[kvp.Key] = kvp.Value;
+            int savedCommittedCount = RecordingStore.CommittedRecordings.Count;
+            int beforeCrewCount = unrelatedFreeSeatPart.protoModuleCrew.Count;
+
+            Recording syntheticRecording = null;
+            bool addedToCommitted = false;
+            var logLines = new List<string>();
+            var priorObserver = ParsekLog.TestObserverForTesting;
+            ParsekLog.TestObserverForTesting = line => logLines.Add(line);
+            try
+            {
+                CrewReservationManager.ClearReplacementsInternal();
+
+                var snapshot = new ConfigNode("VESSEL");
+                var partNode = snapshot.AddNode("PART");
+                partNode.AddValue("name", missingPartName);
+                partNode.AddValue("persistentId", missingPid.ToString());
+                partNode.AddValue("crew", fakeOriginal);
+
+                syntheticRecording = new Recording
+                {
+                    RecordingId = "test-orphan-578-" +
+                        System.Guid.NewGuid().ToString("N").Substring(0, 8),
+                    VesselName = "Bug578WrongActiveVessel",
+                    GhostVisualSnapshot = snapshot
+                };
+
+                RecordingStore.AddCommittedInternal(syntheticRecording);
+                addedToCommitted = true;
+
+                CrewReservationManager.SetReplacement(fakeOriginal, standIn.name);
+
+                var swappedOriginals = new HashSet<string>();
+                int placed = CrewReservationManager.PlaceOrphanedReplacements(roster, swappedOriginals);
+
+                InGameAssert.AreEqual(0, placed,
+                    $"PlaceOrphanedReplacements should defer when pid and name both miss (placed={placed})");
+                InGameAssert.IsFalse(swappedOriginals.Contains(fakeOriginal),
+                    "Deferred orphan placement must not mark the original as swapped");
+                InGameAssert.IsFalse(unrelatedFreeSeatPart.protoModuleCrew.Contains(standIn),
+                    $"Stand-in '{standIn.name}' must not be placed into unrelated free part '{unrelatedFreeSeatPart.partInfo.title}'");
+                InGameAssert.AreEqual(beforeCrewCount, unrelatedFreeSeatPart.protoModuleCrew.Count,
+                    "Unrelated free-seat part crew count changed despite no pid/name match");
+
+                bool sawDeferredReason = false;
+                foreach (var line in logLines)
+                {
+                    if (line.Contains("[CrewReservation]")
+                        && line.Contains("Orphan placement deferred:")
+                        && line.Contains("stand-in kept in roster")
+                        && line.Contains("reason=active-vessel-missing-snapshot-part")
+                        && line.Contains("attempted pidTier=yes nameTier=yes"))
+                    {
+                        sawDeferredReason = true;
+                        break;
+                    }
+                }
+                InGameAssert.IsTrue(sawDeferredReason,
+                    "Expected deferred orphan-placement WARN with reason=active-vessel-missing-snapshot-part");
+
+                ParsekLog.Info("TestRunner",
+                    $"Bug578 end-to-end: orphan placement deferred '{fakeOriginal}' → '{standIn.name}' " +
+                    $"with missing snapshot part '{missingPartName}' despite unrelated free seat in '{unrelatedFreeSeatPart.partInfo.title}'");
+            }
+            finally
+            {
+                ParsekLog.TestObserverForTesting = priorObserver;
+
+                CrewReservationManager.ClearReplacementsInternal();
+                foreach (var kvp in savedReplacements)
+                    CrewReservationManager.SetReplacement(kvp.Key, kvp.Value);
+
+                if (addedToCommitted)
+                    RecordingStore.RemoveCommittedInternal(syntheticRecording);
+
+                InGameAssert.AreEqual(beforeCrewCount, unrelatedFreeSeatPart.protoModuleCrew.Count,
+                    $"Rollback failed: unrelated free-seat part crew count not restored " +
+                    $"(expected={beforeCrewCount}, actual={unrelatedFreeSeatPart.protoModuleCrew.Count})");
+                InGameAssert.AreEqual(savedCommittedCount, RecordingStore.CommittedRecordings.Count,
+                    $"Rollback failed: CommittedRecordings count not restored " +
+                    $"(expected={savedCommittedCount}, actual={RecordingStore.CommittedRecordings.Count})");
+                InGameAssert.AreEqual(savedReplacements.Count, CrewReservationManager.CrewReplacements.Count,
+                    $"Rollback failed: crewReplacements count not restored " +
+                    $"(expected={savedReplacements.Count}, actual={CrewReservationManager.CrewReplacements.Count})");
+            }
+        }
+
         [InGameTest(Category = "CrewReservation", Scene = GameScenes.SPACECENTER,
             Description = "#308 CrewAutoAssignPatch.ApplyCrewAssignmentSwaps replaces reserved crew with stand-ins in a VesselCrewManifest")]
         public void CrewAutoAssignPatch_SwapsReservedCrew()

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -283,30 +283,40 @@ session that authored the on-disk marker.
 
 ---
 
-## 578. CrewReservation: 3 orphan placements where pid AND name tiers both fail
+## 578. CrewReservation: 3 orphan placements where pid AND name tiers both fail ~~done~~
 
 **Source:** `logs/2026-04-25_1314_marker-validator-fix/KSP.log.cleaned` —
 3 occurrences of:
 
-- `[Parsek][WARN][CrewReservation] Orphan placement: no matching part with free seat in active vessel for 'Magdo Kerman' → 'Herfrid Kerman' (snapshot pid=<N> name='mk1-1pod') — stand-in left in roster (attempted pidTier=yes nameTier=yes; cumulative pidHits=<N> nameHitFallbacks=<N>)`
+- `[Parsek][WARN][CrewReservation] Orphan placement: no matching part with free seat in active vessel for 'Magdo Kerman' → 'Herfrid Kerman' (snapshot pid=<N> name='mk1-3pod') — stand-in left in roster (attempted pidTier=yes nameTier=yes; cumulative pidHits=<N> nameHitFallbacks=<N>)`
 - Same shape for `'Kathrick Kerman' → 'Lomy Kerman'`
 - Same shape for `'Ermore Kerman' → 'Shepry Kerman'`
 
 Both lookup tiers (`pidTier=yes` AND `nameTier=yes`) attempted and both
 failed → stand-in is left in the roster. Three different replacement pairs
-all pointing at the same `mk1-1pod` snapshot suggests the active vessel does
-not actually contain that part type, or all of its mk1-1pod seats are
+all pointing at the same `mk1-3pod` snapshot suggests the active vessel does
+not actually contain that part type, or all of its mk1-3pod seats are
 occupied at the time of placement.
 
 **Files to investigate:**
 
 - `Source/Parsek/CrewReservationManager.cs` — orphan-placement fallback path,
   the pid-tier and name-tier matchers, why neither resolved.
-- `Source/Parsek/GameActions/KerbalsModule.cs` — replacement dispatch.
+- `Source/Parsek/KerbalsModule.cs` — replacement dispatch.
 - This subsystem is flagged as elevated-risk in
   `memory/project_post_v0_8_0_risk_areas.md` after the 6-bug PR #263 mega-fix.
 
-**Status:** Open.
+**Fix:** Confirmed hypothesis (a) for the captured playtest: the orphan-placement
+pass ran while the active vessel lacked the snapshot command-pod part, so the
+old WARN collapsed a wrong-vessel target into a generic no-free-seat failure.
+`CrewReservationManager` now classifies no-match misses with active part,
+free-seat, pid-match, and name-match counters, logs the pass as deferred with
+`reason=active-vessel-missing-snapshot-part`, keeps the stand-in roster entry
+for a later retry, and still rejects the removed tier-3 "any free seat"
+fallback. Regression coverage:
+`CrewReservationNameHitFallbackTests.TryResolveActiveVesselPartForSeat_Bug578_WrongActiveVessel_DiagnosesMissingSnapshotPart`.
+
+**Status:** CLOSED 2026-04-25. Fixed for v0.9.0.
 
 ---
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -314,7 +314,9 @@ free-seat, pid-match, and name-match counters, logs the pass as deferred with
 `reason=active-vessel-missing-snapshot-part`, keeps the stand-in roster entry
 for a later retry, and still rejects the removed tier-3 "any free seat"
 fallback. Regression coverage:
-`CrewReservationNameHitFallbackTests.TryResolveActiveVesselPartForSeat_Bug578_WrongActiveVessel_DiagnosesMissingSnapshotPart`.
+`CrewReservationNameHitFallbackTests.TryResolveActiveVesselPartForSeat_Bug578_WrongActiveVessel_DiagnosesMissingSnapshotPart`,
+the miss-reason truth-table/log assertions in the same class, and the runtime
+`Bug578_OrphanPlacement_NoMatchingPart_LogsDeferredReason` in-game test.
 
 **Status:** CLOSED 2026-04-25. Fixed for v0.9.0.
 


### PR DESCRIPTION
## Summary
- classify crew orphan no-match misses so wrong-active-vessel cases log reason=active-vessel-missing-snapshot-part
- preserve pid/name seat matching behavior and keep unrelated free seats rejected
- remove the unreachable no-matching-free-seat reason, prefer missing snapshot part over coincidental full-pid collisions, and cover the miss-reason truth table
- add #578 headless matcher/log coverage, a runtime PlaceOrphanedReplacements no-match test, and update CHANGELOG/todo docs

## Testing
- dotnet test --filter CrewReservationNameHitFallbackTests (21/21)
- dotnet build (Source/Parsek)
- dotnet test (Source/Parsek.Tests: 8,633/8,633)
- deployed DLL SHA-256 matches build output; UTF-16 strings present in both: Orphan placement deferred, active-vessel-missing-snapshot-part, snapshot-pid-part-seats-full; no-matching-free-seat absent
- gpt-5.5 xhigh review: initial review no findings; follow-up review no findings

## Runtime coverage
- Added in-game test Bug578_OrphanPlacement_NoMatchingPart_LogsDeferredReason; not run in headless validation because it requires a live KSP FLIGHT scene.