### PR TITLE
Preserve partial patched-conic chain on transient null-body patch (#575)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ All notable changes to Parsek are documented here.
 
 - Strip-killing the upper stage during re-fly no longer trips spawn-death respawn, so a duplicate upper-stage vessel doesn't materialise next to the booster.
 
+- Patched-conic snapshots now keep the valid prefix of a chain when KSP's stock solver leaves a later patch with a null reference body, instead of discarding everything. Recordings now retain their predicted-tail orbit data through transient ascent solver hiccups, and the previous WARN tier downgrades to a single VERBOSE truncation note.
+
 - Merging an in-place re-fly now reaps the Rewind Point and seals the recording as Immutable, so it's promoted out of Unfinished Flights even if the re-flight crashed.
 
 - Unfinished Flights rows now show a `Re-Fly` button (the action loads a staging Rewind Point — different from the legacy `R` / `FF` time-rewind on every other row).

--- a/Source/Parsek.Tests/PatchedConicSnapshotTests.cs
+++ b/Source/Parsek.Tests/PatchedConicSnapshotTests.cs
@@ -182,7 +182,53 @@ namespace Parsek.Tests
             Assert.Null(result.LastCapturedBodyName);
             Assert.Contains(logLines, line =>
                 line.Contains("[PatchedSnapshot]") &&
-                line.Contains("missing-reference-body"));
+                line.Contains("missing-reference-body") &&
+                line.Contains("aborting predicted snapshot capture"));
+        }
+
+        /// <summary>
+        /// Regression for #575: when patch 0 is valid but a later patch has a
+        /// null body, the captured prefix must be preserved instead of the
+        /// whole result being reset. The 2026-04-25_1314 marker-validator-fix
+        /// playtest emitted this pattern 153× — every entry had
+        /// <c>patchIndex=1</c>, never 0 — so the previous discard-everything
+        /// policy threw away every valid first patch and starved the
+        /// recording's predicted tail. With partial preservation the
+        /// downstream <see cref="IncompleteBallisticSceneExitFinalizer"/>
+        /// applies the captured segment via its existing
+        /// <c>snapshot.Segments.Count &gt; 0</c> branch and skips the
+        /// transient-ascent bail-out (which gates on
+        /// <c>appendedSegments.Count == 0</c>).
+        /// </summary>
+        [Fact]
+        public void Snapshot_MissingPatchBodyAfterValidPrefix_KeepsPartialResult()
+        {
+            var nullBodyPatch = MakePatch(200, 320, body: null,
+                transition: PatchedConicTransitionType.Encounter);
+            var firstPatch = MakePatch(100, 200, body: "Kerbin",
+                transition: PatchedConicTransitionType.Encounter);
+            firstPatch.NextPatch = nullBodyPatch;
+
+            var source = new FakePatchedConicSnapshotSource(4)
+            {
+                RootPatch = firstPatch
+            };
+
+            PatchedConicSnapshotResult result = PatchedConicSnapshot.SnapshotPatchedConicChain(
+                source, 120, 8, "Truncated Ascent Vessel");
+
+            Assert.Equal(PatchedConicSnapshotFailureReason.MissingPatchBody, result.FailureReason);
+            Assert.Single(result.Segments);
+            Assert.Equal("Kerbin", result.Segments[0].bodyName);
+            Assert.Equal(1, result.CapturedPatchCount);
+            Assert.True(result.HasTruncatedTail);
+            Assert.Equal("Kerbin", result.LastCapturedBodyName);
+            Assert.Equal(4, source.PatchLimit);
+            Assert.Contains(logLines, line =>
+                line.Contains("[Parsek][VERBOSE][PatchedSnapshot]") &&
+                line.Contains("truncated chain after 1 valid patch(es), keeping partial result"));
+            Assert.DoesNotContain(logLines, line =>
+                line.Contains("aborting predicted snapshot capture"));
         }
 
         [Fact]

--- a/Source/Parsek/PatchedConicSnapshot.cs
+++ b/Source/Parsek/PatchedConicSnapshot.cs
@@ -154,6 +154,29 @@ namespace Parsek
                     if (string.IsNullOrEmpty(bodyName))
                     {
                         int failedPatchIndex = result.CapturedPatchCount;
+                        // Preserve the partial chain captured before the first
+                        // null-body patch (#575). KSP's stock solver routinely
+                        // has a transient `nextPatch.referenceBody == null`
+                        // during ascent, but earlier patches in the chain are
+                        // valid orbits we want to record. Discarding everything
+                        // when patch[N>0] is null was costing the recording its
+                        // entire predicted tail and feeding the
+                        // `IncompleteBallisticSceneExitFinalizer` "transient
+                        // early-ascent state" skip path on every refresh, so
+                        // the recording effectively had no patched-conic
+                        // augmentation. Only reset when patch 0 is null —
+                        // that's the genuine "no usable data" case the WARN
+                        // tier was designed for.
+                        if (failedPatchIndex > 0)
+                        {
+                            result.FailureReason = PatchedConicSnapshotFailureReason.MissingPatchBody;
+                            result.HasTruncatedTail = true;
+                            ParsekLog.Verbose("PatchedSnapshot",
+                                $"SnapshotPatchedConicChain: vessel={safeVesselName} patchIndex={failedPatchIndex} " +
+                                $"body={MissingPatchBodySentinel}; truncated chain after {failedPatchIndex} valid patch(es), " +
+                                "keeping partial result");
+                            break;
+                        }
                         ResetFailedResult(ref result, PatchedConicSnapshotFailureReason.MissingPatchBody);
                         ParsekLog.Warn("PatchedSnapshot",
                             $"SnapshotPatchedConicChain: vessel={safeVesselName} patchIndex={failedPatchIndex} " +

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -188,7 +188,7 @@ captures the symptom for cross-reference.
 
 ---
 
-## 575. PatchedSnapshot: MissingPatchBody warning floor of 153/session for the same recordings
+## ~~575. PatchedSnapshot: MissingPatchBody warning floor of 153/session for the same recordings~~
 
 **Source:** `logs/2026-04-25_1314_marker-validator-fix/KSP.log.cleaned` —
 153 occurrences each of:
@@ -206,15 +206,42 @@ per recording over a single session. Either:
 - The "transient" classifier is firing for non-transient cases too;
 - WARN is the wrong level for an expected condition that fires by design.
 
-**Files to investigate:**
+**Diagnosis (2026-04-25):** `PatchedConicSnapshot.SnapshotPatchedConicChain`
+(`Source/Parsek/PatchedConicSnapshot.cs:151-162`) walked the stock patched-conic
+chain and called `ResetFailedResult` the moment any patch returned an empty
+`BodyName`, throwing away every previously-captured patch in the same chain.
+In the captured log every entry was `patchIndex=1`, never `patchIndex=0` —
+patch 0 was always valid, only the *next* patch occasionally had a transient
+`referenceBody == null` that KSP's stock solver fixes a few frames later.
+With the discard-everything policy the recording therefore had no
+patched-conic augmentation, and the downstream
+`IncompleteBallisticSceneExitFinalizer` (`Source/Parsek/IncompleteBallisticSceneExitFinalizer.cs:287-296`)
+took the "transient early-ascent state, not a destroyed vessel" skip path on
+every refresh because `appendedSegments.Count == 0`.
 
-- `Source/Parsek/PatchedConicSnapshot.cs` — `SnapshotPatchedConicChain`,
-  `missing-reference-body` branch.
-- `Source/Parsek/IncompleteBallisticSceneExitFinalizer.cs` — `TryFinalizeRecording`,
-  the `MissingPatchBody` failure-mode-to-fallback dispatch and the "transient
-  early-ascent" classifier.
+**Fix:** preserve the partial chain captured before the first null-body patch
+when `failedPatchIndex > 0` — set `FailureReason = MissingPatchBody`,
+`HasTruncatedTail = true`, log a single rate-of-context VERBOSE truncation
+note ("truncated chain after N valid patch(es), keeping partial result"), and
+break out of the loop with the captured segments intact. The genuine
+"patch 0 has null body" case (`failedPatchIndex == 0`) keeps the original
+ResetFailedResult + WARN behaviour. The downstream finalizer's existing
+`snapshot.Segments.Count > 0` branch (line 250-258) appends the partial chain
+naturally; the transient-ascent skip at line 287-296 only fires when no
+patches at all could be captured, which is the correct intent.
 
-**Status:** Open. Cross-reference with #571 and #574.
+This also closes part B of #571 — the user-visible "weird trajectory"
+symptom that included a starved predicted tail. Recordings now retain their
+predicted-tail orbit data through ascent solver hiccups instead of falling
+back to a single Keplerian arc covering the entire warp window.
+
+Regression
+`PatchedConicSnapshotTests.Snapshot_MissingPatchBodyAfterValidPrefix_KeepsPartialResult`
+pins the new partial-preservation behaviour;
+`Snapshot_MissingPatchBody_FailsWithoutKerbinFallback` still pins the original
+patch-0-null discard-and-warn case.
+
+**Status:** CLOSED 2026-04-25. Fixed for v0.9.0.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes [#575](https://github.com/vl3c/Parsek/issues/575) and addresses Part B of [#571](https://github.com/vl3c/Parsek/issues/571).

### Root cause

[`PatchedConicSnapshot.SnapshotPatchedConicChain`](Source/Parsek/PatchedConicSnapshot.cs) previously called `ResetFailedResult` the moment any patch returned an empty `BodyName`, discarding every previously-captured patch in the same chain. The 2026-04-25_1314_marker-validator-fix playtest emitted this WARN 153 times — and **every entry was `patchIndex=1`, never `patchIndex=0`**. Patch 0 was always valid; only the next patch occasionally had a transient `referenceBody == null` that KSP's stock solver fixes a few frames later.

With the discard-everything policy the recording therefore had no patched-conic augmentation, and the downstream [`IncompleteBallisticSceneExitFinalizer`](Source/Parsek/IncompleteBallisticSceneExitFinalizer.cs:287-296) took the *"transient early-ascent state, not a destroyed vessel"* skip path on every refresh because `appendedSegments.Count == 0`.

### Fix

Preserve the partial chain captured before the first null-body patch when `failedPatchIndex > 0` — set `FailureReason = MissingPatchBody`, `HasTruncatedTail = true`, log a single VERBOSE truncation note (`"truncated chain after N valid patch(es), keeping partial result"`), and break out of the loop with the captured segments intact. The genuine "patch 0 has null body" case (`failedPatchIndex == 0`) keeps the original `ResetFailedResult` + WARN behaviour.

The downstream finalizer's existing `snapshot.Segments.Count > 0` branch ([IncompleteBallisticSceneExitFinalizer.cs:250-258](Source/Parsek/IncompleteBallisticSceneExitFinalizer.cs)) appends the partial chain naturally; the transient-ascent skip at line 287-296 only fires when no patches at all could be captured, which is the correct intent.

### Cross-reference with #571

This also closes Part B of [#571](https://github.com/vl3c/Parsek/issues/571). The user-visible "weird trajectory" symptom had two contributing causes; this PR addresses the predicted-tail starvation half. Recordings now retain their predicted-tail orbit data through transient ascent solver hiccups instead of falling back to a single Keplerian arc covering the entire warp window. **Part A (long-warp `OrbitalCheckpoint` section densification) remains a separate recorder-side change** tracked in #571.

## Test plan

- [x] `dotnet test` — 8630 / 8630 passing.
- [x] New regression `PatchedConicSnapshotTests.Snapshot_MissingPatchBodyAfterValidPrefix_KeepsPartialResult` proves a chain with a valid prefix and a null-body successor preserves the captured segment, sets `HasTruncatedTail=true`, and downgrades the log line from WARN to VERBOSE.
- [x] Existing `Snapshot_MissingPatchBody_FailsWithoutKerbinFallback` still passes (patch-0-null genuine-failure case unchanged).
- [x] Build deploys to `Kerbal Space Program/GameData/Parsek/Plugins/Parsek.dll`; UTF-16 grep confirms `truncated chain after` and `keeping partial result` strings are present.
- [ ] In-game smoke test: launch a vessel, observe KSP.log no longer contains the 153×/session `aborting predicted snapshot capture` storm during ascent.