### PR TITLE
Heal MergeTree unrecorded-gap at Background-to-Active handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- MergeTree now heals velocity-consistent Background-to-Active handoff gaps by inserting a shared boundary point, preventing Kerbal X-style ghost trajectory pops from section-authoritative merged recordings.
+
 - Re-fly merge now supersedes every chain segment of an env-split crashed recording. Previously the closure walker followed `ChildBranchPointId` only, so an exo HEAD + in-atmo TIP chain produced by `RecordingOptimizer.SplitAtSection` left the TIP behind as an orphan "kerbal destroyed in atmo" row alongside the new "kerbal lived" provisional. Saves committed before this fix that already completed a chain-crossing crashed re-fly merge are not retroactively healed; affected players can `Discard` the orphan via the table.
 
 - EVA splits now author a Rewind Point, so a destroyed EVA kerbal becomes an Unfinished Flight with a Re-Fly button. Previously `IsTrackableVessel` only recognised parts with `ModuleCommand`, so the kerbal didn't count as a controllable output, the split classified as single-controllable, and no RP was authored.
@@ -185,6 +187,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- MergeTree now heals velocity-consistent Background-to-Active handoff gaps by inserting a shared boundary point, preventing Kerbal X-style ghost trajectory pops from section-authoritative merged recordings.
 - Follow-up cleanup to `#431/#432`: retired `MilestoneStore.CurrentEpoch` from production branch filtering. Timeline rows, milestone bundling, reward enrichment, revert bookkeeping, and load-time ledger recovery now exclude abandoned branches through recording-tag visibility plus deterministic discard/unstash behavior instead of epoch stamping/filtering.
 - `#552` Vessel recovery funds now tolerate stock firing `onVesselRecovered` before the paired `FundsChanged(VesselRecovery)` event. Parsek defers the recovery request and pairs it when the funds event arrives, preferring vessel-name matches over nearest-UT, warning on ambiguous ties, and evicting unclaimed requests on scene switches, rewind boundaries, and save loads.
 - `#553` Untagged lifecycle events (contract accept/complete/fail/cancel, tech, part purchase, crew hire, milestone, strategy activate/deactivate, facility upgrade) now forward directly to the ledger even in FLIGHT, so launch-site events that occur before any Parsek recording owner exists do not get stranded only in `GameStateStore`. Tagged FLIGHT teardown events remain protected by the non-empty recording tag gate.

--- a/Source/Parsek.Tests/SessionMergerTests.cs
+++ b/Source/Parsek.Tests/SessionMergerTests.cs
@@ -1299,6 +1299,128 @@ namespace Parsek.Tests
 
         #endregion
 
+        #region #580 — Background to Active unrecorded-gap healing
+
+        [Fact]
+        public void MergeTree_BackgroundToActiveUnrecordedGap_InsertsSharedBoundaryPoint()
+        {
+            // Regresses the largest 2026-04-25 Kerbal X handoff citation:
+            // section[1] ut=193985.09, dt=3.36s, discontinuity=4029.13m,
+            // expectedFromVel=4128.99m, prevSrc=Background, nextSrc=Active.
+            const double boundaryUT = 193985.090668523;
+            const double bgTailUT = 193981.75066852474;
+            const double activeHeadUT = 193985.11066852298;
+            const double bgAlt = 26477.944626131211;
+            const double activeAlt = bgAlt - 4029.13013;
+
+            var background = MakeSectionWithFrame(
+                bgTailUT, lat: 0, lon: 0, alt: bgAlt,
+                velocity: new Vector3(1228.866f, 0f, 0f),
+                source: TrackSectionSource.Background);
+            background.startUT = 193981.73066852475;
+            background.endUT = boundaryUT;
+
+            var active = MakeSectionWithFrame(
+                activeHeadUT, lat: 0, lon: 0, alt: activeAlt,
+                velocity: Vector3.zero,
+                source: TrackSectionSource.Active);
+            active.startUT = boundaryUT;
+            active.endUT = boundaryUT + 120.0;
+
+            var rec = MakeRecording("rec-580", "Kerbal X",
+                new List<TrackSection> { background, active });
+            var tree = MakeTree("580 Handoff", rec);
+
+            var mergedById = SessionMerger.MergeTree(tree);
+
+            var merged = mergedById["rec-580"];
+            Assert.Equal(2, merged.TrackSections.Count);
+            Assert.True(merged.TrackSections[0].frames.Count >= 2);
+            Assert.Equal(boundaryUT, merged.TrackSections[0].frames.Last().ut, 6);
+            Assert.Equal(boundaryUT, merged.TrackSections[1].frames[0].ut, 6);
+            Assert.InRange(merged.TrackSections[1].boundaryDiscontinuityMeters, 0f, 0.01f);
+            Assert.Equal(3, merged.Points.Count);
+            Assert.Contains(merged.Points, p => Math.Abs(p.ut - boundaryUT) <= 1e-6);
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[INFO]") &&
+                l.Contains("[Merger]") &&
+                l.Contains("healed unrecorded-gap") &&
+                l.Contains("section[1]") &&
+                l.Contains("prevSrc=Background") &&
+                l.Contains("nextSrc=Active") &&
+                l.Contains("cause=unrecorded-gap #580"));
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("[WARN]") &&
+                l.Contains("[Merger]") &&
+                l.Contains("boundary discontinuity=") &&
+                l.Contains("vessel='Kerbal X'") &&
+                l.Contains("cause=unrecorded-gap"));
+        }
+
+        [Fact]
+        public void MergeTree_BackgroundToActiveUnrecordedGap_PreservesValidatedFlatTail()
+        {
+            const double boundaryUT = 2.0;
+
+            var background = MakeSectionWithFrame(
+                0.0, lat: 0, lon: 0, alt: 100.0,
+                velocity: new Vector3(50f, 0f, 0f),
+                source: TrackSectionSource.Background);
+            background.startUT = 0.0;
+            background.endUT = boundaryUT;
+
+            var active = MakeSectionWithFrame(
+                3.0, lat: 0, lon: 0, alt: 250.0,
+                velocity: Vector3.zero,
+                source: TrackSectionSource.Active);
+            active.startUT = boundaryUT;
+            active.endUT = 4.0;
+
+            var tailPoint = new TrajectoryPoint
+            {
+                ut = 5.0,
+                latitude = 0,
+                longitude = 0,
+                altitude = 280.0,
+                bodyName = "Kerbin",
+                rotation = Quaternion.identity,
+                velocity = Vector3.zero
+            };
+
+            var rec = MakeRecording("rec-580-tail", "Kerbal X",
+                new List<TrackSection> { background, active });
+            rec.Points = new List<TrajectoryPoint>
+            {
+                background.frames[0],
+                active.frames[0],
+                tailPoint
+            };
+            var tree = MakeTree("580 Handoff Tail", rec);
+
+            var mergedById = SessionMerger.MergeTree(tree);
+
+            var merged = mergedById["rec-580-tail"];
+            Assert.Equal(new[] { 0.0, boundaryUT, 3.0, 5.0 },
+                merged.Points.Select(p => p.ut).ToArray());
+            Assert.Equal(2, merged.TrackSections[0].frames.Count);
+            Assert.Equal(2, merged.TrackSections[1].frames.Count);
+            Assert.Single(rec.TrackSections[0].frames);
+            Assert.Single(rec.TrackSections[1].frames);
+            Assert.Contains(logLines, l =>
+                l.Contains("[INFO]") &&
+                l.Contains("[Merger]") &&
+                l.Contains("healed unrecorded-gap") &&
+                l.Contains("section[1]") &&
+                l.Contains("cause=unrecorded-gap #580"));
+            Assert.Contains(logLines, l =>
+                l.Contains("[Merger]") &&
+                l.Contains("recording='rec-580-tail'") &&
+                l.Contains("flatSync=healed-track-sections-preserved-flat-tail"));
+        }
+
+        #endregion
+
         #region ResolveOverlaps — frame trimming
 
         [Fact]

--- a/Source/Parsek.Tests/SessionMergerTests.cs
+++ b/Source/Parsek.Tests/SessionMergerTests.cs
@@ -1419,6 +1419,192 @@ namespace Parsek.Tests
                 l.Contains("flatSync=healed-track-sections-preserved-flat-tail"));
         }
 
+        [Fact]
+        public void MergeTree_BackgroundToActiveSampleSkip_LeavesBoundaryWarningUnhealed()
+        {
+            const double boundaryUT = 1.0;
+            var background = MakeSectionWithFrame(
+                boundaryUT, lat: 0, lon: 0, alt: 100.0,
+                velocity: new Vector3(1f, 0f, 0f),
+                source: TrackSectionSource.Background);
+            background.startUT = 0.0;
+            background.endUT = boundaryUT;
+
+            var active = MakeSectionWithFrame(
+                2.0, lat: 0, lon: 0, alt: 1000.0,
+                velocity: Vector3.zero,
+                source: TrackSectionSource.Active);
+            active.startUT = boundaryUT;
+            active.endUT = 3.0;
+
+            var rec = MakeRecording("rec-580-sample-skip", "Kerbal X",
+                new List<TrackSection> { background, active });
+            var tree = MakeTree("580 Sample Skip", rec);
+
+            var merged = SessionMerger.MergeTree(tree)["rec-580-sample-skip"];
+
+            Assert.Single(merged.TrackSections[0].frames);
+            Assert.Single(merged.TrackSections[1].frames);
+            Assert.Equal(2.0, merged.TrackSections[1].frames[0].ut);
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("[Merger]") &&
+                l.Contains("healed unrecorded-gap") &&
+                l.Contains("rec-580-sample-skip"));
+            Assert.Contains(logLines, l =>
+                l.Contains("[WARN]") &&
+                l.Contains("[Merger]") &&
+                l.Contains("boundary discontinuity=") &&
+                l.Contains("vessel='Kerbal X'") &&
+                l.Contains("prevSrc=Background") &&
+                l.Contains("nextSrc=Active") &&
+                l.Contains("cause=sample-skip"));
+        }
+
+        [Fact]
+        public void MergeTree_BackgroundToActiveRelativeAnchorMismatch_SkipsHeal()
+        {
+            const double boundaryUT = 1.0;
+            var background = MakeSectionWithFrame(
+                boundaryUT, lat: 0, lon: 0, alt: 0.0,
+                velocity: new Vector3(100f, 0f, 0f),
+                referenceFrame: ReferenceFrame.Relative,
+                source: TrackSectionSource.Background);
+            background.startUT = 0.0;
+            background.endUT = boundaryUT;
+            background.anchorVesselId = 101;
+
+            var active = MakeSectionWithFrame(
+                2.0, lat: 0, lon: 0, alt: 50.0,
+                velocity: Vector3.zero,
+                referenceFrame: ReferenceFrame.Relative,
+                source: TrackSectionSource.Active);
+            active.startUT = boundaryUT;
+            active.endUT = 3.0;
+            active.anchorVesselId = 202;
+
+            var rec = MakeRecording("rec-580-anchor", "Anchor Vessel",
+                new List<TrackSection> { background, active });
+            var tree = MakeTree("580 Anchor Mismatch", rec);
+
+            var merged = SessionMerger.MergeTree(tree)["rec-580-anchor"];
+
+            Assert.Single(merged.TrackSections[0].frames);
+            Assert.Single(merged.TrackSections[1].frames);
+            Assert.Equal(2.0, merged.TrackSections[1].frames[0].ut);
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("[Merger]") &&
+                l.Contains("healed unrecorded-gap") &&
+                l.Contains("rec-580-anchor"));
+            Assert.Contains(logLines, l =>
+                l.Contains("[WARN]") &&
+                l.Contains("[Merger]") &&
+                l.Contains("vessel='Anchor Vessel'") &&
+                l.Contains("prevRef=Relative") &&
+                l.Contains("nextRef=Relative") &&
+                l.Contains("cause=unrecorded-gap"));
+        }
+
+        [Fact]
+        public void MergeTree_BackgroundToActiveUnrecordedGap_HealsMultipleBoundaries()
+        {
+            var background1 = MakeSectionWithFrame(
+                0.0, lat: 0, lon: 0, alt: 100.0,
+                velocity: new Vector3(100f, 0f, 0f),
+                source: TrackSectionSource.Background);
+            background1.startUT = 0.0;
+            background1.endUT = 1.0;
+
+            var active1 = MakeSectionWithFrame(
+                2.0, lat: 0, lon: 0, alt: 200.0,
+                velocity: Vector3.zero,
+                source: TrackSectionSource.Active);
+            active1.startUT = 1.0;
+            active1.endUT = 3.0;
+
+            var background2 = MakeSectionWithFrame(
+                3.0, lat: 0, lon: 0, alt: 200.0,
+                velocity: new Vector3(100f, 0f, 0f),
+                source: TrackSectionSource.Background);
+            background2.startUT = 3.0;
+            background2.endUT = 4.0;
+
+            var active2 = MakeSectionWithFrame(
+                5.0, lat: 0, lon: 0, alt: 350.0,
+                velocity: Vector3.zero,
+                source: TrackSectionSource.Active);
+            active2.startUT = 4.0;
+            active2.endUT = 6.0;
+
+            var rec = MakeRecording("rec-580-multi", "Multi Vessel",
+                new List<TrackSection> { background1, active1, background2, active2 });
+            var tree = MakeTree("580 Multiple Handoffs", rec);
+
+            var merged = SessionMerger.MergeTree(tree)["rec-580-multi"];
+
+            Assert.Equal(4, merged.TrackSections.Count);
+            Assert.Equal(1.0, merged.TrackSections[0].frames.Last().ut);
+            Assert.Equal(1.0, merged.TrackSections[1].frames[0].ut);
+            Assert.Equal(4.0, merged.TrackSections[2].frames.Last().ut);
+            Assert.Equal(4.0, merged.TrackSections[3].frames[0].ut);
+            Assert.InRange(merged.TrackSections[1].boundaryDiscontinuityMeters, 0f, 0.01f);
+            Assert.InRange(merged.TrackSections[3].boundaryDiscontinuityMeters, 0f, 0.01f);
+            Assert.Contains(merged.Points, p => Math.Abs(p.ut - 1.0) <= 1e-6);
+            Assert.Contains(merged.Points, p => Math.Abs(p.ut - 4.0) <= 1e-6);
+            Assert.Equal(2, logLines.Count(l =>
+                l.Contains("[INFO]") &&
+                l.Contains("[Merger]") &&
+                l.Contains("recId=rec-580-multi") &&
+                l.Contains("healed unrecorded-gap") &&
+                l.Contains("cause=unrecorded-gap #580")));
+        }
+
+        [Fact]
+        public void MergeTree_BackgroundToActiveUnrecordedGap_LogsUnhealableSeam()
+        {
+            const double boundaryUT = 1.0;
+            var background = MakeSectionWithFrame(
+                boundaryUT, lat: 0, lon: 0, alt: 100.0,
+                velocity: new Vector3(100f, 0f, 0f),
+                bodyName: "Kerbin",
+                source: TrackSectionSource.Background);
+            background.startUT = 0.0;
+            background.endUT = boundaryUT;
+
+            var active = MakeSectionWithFrame(
+                2.0, lat: 0, lon: 0, alt: 150.0,
+                velocity: Vector3.zero,
+                bodyName: "Mun",
+                source: TrackSectionSource.Active);
+            active.startUT = boundaryUT;
+            active.endUT = 3.0;
+
+            var rec = MakeRecording("rec-580-body-mismatch", "Body Mismatch",
+                new List<TrackSection> { background, active });
+            var tree = MakeTree("580 Body Mismatch", rec);
+
+            var merged = SessionMerger.MergeTree(tree)["rec-580-body-mismatch"];
+
+            Assert.Single(merged.TrackSections[0].frames);
+            Assert.Single(merged.TrackSections[1].frames);
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("[INFO]") &&
+                l.Contains("[Merger]") &&
+                l.Contains("rec-580-body-mismatch") &&
+                l.Contains("healed unrecorded-gap"));
+            Assert.Contains(logLines, l =>
+                l.Contains("[WARN]") &&
+                l.Contains("[Merger]") &&
+                l.Contains("unable to heal unrecorded-gap") &&
+                l.Contains("recId=rec-580-body-mismatch") &&
+                l.Contains("reason=body-mismatch"));
+            Assert.Contains(logLines, l =>
+                l.Contains("[WARN]") &&
+                l.Contains("[Merger]") &&
+                l.Contains("vessel='Body Mismatch'") &&
+                l.Contains("boundary discontinuity=") &&
+                l.Contains("cause=unrecorded-gap"));
+        }
+
         #endregion
 
         #region ResolveOverlaps — frame trimming

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -3989,6 +3989,88 @@ namespace Parsek
             return pointsExtend || orbitSegmentsExtend;
         }
 
+        internal static bool TrySyncFlatTrajectoryFromTrackSectionsPreservingFlatTail(
+            Recording target,
+            Recording source,
+            List<TrackSection> tailReferenceTracks,
+            bool allowRelativeSections = false)
+        {
+            if (target == null
+                || source == null
+                || tailReferenceTracks == null
+                || !HasCompleteTrackSectionPayloadForFlatSync(target.TrackSections, allowRelativeSections)
+                || !HasCompleteTrackSectionPayloadForFlatSync(tailReferenceTracks, allowRelativeSections))
+            {
+                return false;
+            }
+
+            var referencePoints = new List<TrajectoryPoint>();
+            RebuildPointsFromTrackSections(tailReferenceTracks, referencePoints);
+            var sourcePoints = source.Points ?? new List<TrajectoryPoint>();
+            if (sourcePoints.Count < referencePoints.Count)
+                return false;
+            for (int i = 0; i < referencePoints.Count; i++)
+            {
+                if (!TrajectoryPointEquals(referencePoints[i], sourcePoints[i]))
+                    return false;
+            }
+
+            int pointSuffixStart = -1;
+            if (sourcePoints.Count > referencePoints.Count)
+            {
+                pointSuffixStart = FindSafeTrajectoryPointSuffixStart(sourcePoints, referencePoints);
+                if (pointSuffixStart < 0)
+                    return false;
+            }
+
+            var referenceOrbitSegments = new List<OrbitSegment>();
+            RebuildOrbitSegmentsFromTrackSections(tailReferenceTracks, referenceOrbitSegments);
+            var sourceOrbitSegments = source.OrbitSegments ?? new List<OrbitSegment>();
+            if (sourceOrbitSegments.Count < referenceOrbitSegments.Count)
+                return false;
+            for (int i = 0; i < referenceOrbitSegments.Count; i++)
+            {
+                if (!OrbitSegmentEquals(referenceOrbitSegments[i], sourceOrbitSegments[i]))
+                    return false;
+            }
+
+            int orbitSuffixStart = -1;
+            if (sourceOrbitSegments.Count > referenceOrbitSegments.Count)
+            {
+                orbitSuffixStart = FindSafeOrbitSegmentSuffixStart(
+                    sourceOrbitSegments, referenceOrbitSegments);
+                if (orbitSuffixStart < 0)
+                    return false;
+            }
+
+            if (pointSuffixStart < 0 && orbitSuffixStart < 0)
+                return false;
+
+            var healedPoints = new List<TrajectoryPoint>();
+            RebuildPointsFromTrackSections(target.TrackSections, healedPoints);
+            if (pointSuffixStart >= 0)
+            {
+                AppendTrajectoryPointSuffix(healedPoints, sourcePoints, pointSuffixStart);
+                if (!TrajectoryPointListIsMonotonicNonDecreasing(healedPoints))
+                    return false;
+            }
+
+            var healedOrbitSegments = new List<OrbitSegment>();
+            RebuildOrbitSegmentsFromTrackSections(target.TrackSections, healedOrbitSegments);
+            if (orbitSuffixStart >= 0)
+            {
+                AppendOrbitSegmentSuffix(healedOrbitSegments, sourceOrbitSegments, orbitSuffixStart);
+                if (!OrbitSegmentListIsMonotonicNonDecreasing(healedOrbitSegments))
+                    return false;
+            }
+
+            target.Points = healedPoints;
+            target.OrbitSegments = healedOrbitSegments;
+            target.CachedStats = null;
+            target.CachedStatsPointCount = 0;
+            return true;
+        }
+
         internal static bool ShouldWriteSectionAuthoritativeTrajectory(Recording rec)
         {
             return rec != null

--- a/Source/Parsek/SessionMerger.cs
+++ b/Source/Parsek/SessionMerger.cs
@@ -89,9 +89,8 @@ namespace Parsek
                 // Resolve overlapping TrackSections
                 List<TrackSection> mergedSections = ResolveOverlaps(
                     srcRec.TrackSections ?? new List<TrackSection>());
-                List<TrackSection> preHealMergedSections = CloneTrackSections(mergedSections);
                 int healedUnrecordedGaps = HealBackgroundActiveUnrecordedGapBoundaries(
-                    recId, srcRec.VesselName, mergedSections);
+                    recId, srcRec.VesselName, mergedSections, out List<TrackSection> preHealMergedSections);
                 if (healedUnrecordedGaps > 0)
                     RecomputeBoundaryDiscontinuities(mergedSections);
 
@@ -110,54 +109,12 @@ namespace Parsek
                 merged.TrackSections = mergedSections;
                 merged.PartEvents = mergedEvents;
 
-                // Preserve newer flat tail data when the resolved TrackSections are only a
-                // prefix of the source flat trajectory (e.g. board/merge appended points after
-                // the last flushed sparse section). Otherwise prefer the resolved sections and
-                // rebuild the flat lists from them.
-                bool flatTailExtendsResolvedSections =
-                    RecordingStore.FlatTrajectoryExtendsTrackSectionPayload(
-                        srcRec, mergedSections, allowRelativeSections: true);
-                bool rebuiltFlatTrajectory = false;
-                string flatSyncMode = null;
-                if (!flatTailExtendsResolvedSections
-                    && healedUnrecordedGaps > 0
-                    && RecordingStore.TrySyncFlatTrajectoryFromTrackSectionsPreservingFlatTail(
-                        merged, srcRec, preHealMergedSections, allowRelativeSections: true))
-                {
-                    rebuiltFlatTrajectory = true;
-                    flatSyncMode = "healed-track-sections-preserved-flat-tail";
-                }
-                if (!rebuiltFlatTrajectory && !flatTailExtendsResolvedSections)
-                {
-                    rebuiltFlatTrajectory = RecordingStore.TrySyncFlatTrajectoryFromTrackSections(
-                        merged, allowRelativeSections: true);
-                    if (rebuiltFlatTrajectory && flatSyncMode == null)
-                        flatSyncMode = "track-sections";
-                }
-
-                if (!rebuiltFlatTrajectory)
-                {
-                    bool copiedFlatTrajectory = false;
-                    if (srcRec.Points != null && srcRec.Points.Count > 0)
-                    {
-                        merged.Points = new List<TrajectoryPoint>(srcRec.Points);
-                        copiedFlatTrajectory = true;
-                    }
-
-                    if (srcRec.OrbitSegments != null && srcRec.OrbitSegments.Count > 0)
-                    {
-                        merged.OrbitSegments = new List<OrbitSegment>(srcRec.OrbitSegments);
-                        copiedFlatTrajectory = true;
-                    }
-
-                    if (!copiedFlatTrajectory)
-                    {
-                        rebuiltFlatTrajectory = RecordingStore.TrySyncFlatTrajectoryFromTrackSections(
-                            merged, allowRelativeSections: true);
-                        if (rebuiltFlatTrajectory)
-                            flatSyncMode = "track-sections-fallback";
-                    }
-                }
+                SyncMergedFlatTrajectory(
+                    srcRec,
+                    merged,
+                    preHealMergedSections,
+                    healedUnrecordedGaps,
+                    out string flatSyncMode);
 
                 // Copy SegmentEvents
                 if (srcRec.SegmentEvents != null)
@@ -184,10 +141,6 @@ namespace Parsek
 
                 LogMergeDiagnostics(recId, srcRec.VesselName, inputSectionCount,
                     srcRec.TrackSections ?? new List<TrackSection>(), mergedSections);
-                if (flatSyncMode == null)
-                    flatSyncMode = rebuiltFlatTrajectory
-                        ? "track-sections"
-                        : (flatTailExtendsResolvedSections ? "preserved-flat-copy" : "track-sections-fallback");
                 ParsekLog.Verbose(Tag,
                     $"MergeTree: recording='{recId}' flatSync={flatSyncMode}");
             }
@@ -196,6 +149,73 @@ namespace Parsek
                 $"MergeTree: completed merge for tree='{tree.TreeName}' merged={result.Count} recordings");
 
             return result;
+        }
+
+        private static bool SyncMergedFlatTrajectory(
+            Recording source,
+            Recording target,
+            List<TrackSection> preHealMergedSections,
+            int healedUnrecordedGaps,
+            out string flatSyncMode)
+        {
+            const bool allowRelativeSections = true;
+            flatSyncMode = "track-sections-fallback";
+
+            // Preserve newer flat tail data when the resolved TrackSections are only a
+            // prefix of the source flat trajectory (e.g. board/merge appended points after
+            // the last flushed sparse section). Otherwise prefer the resolved sections and
+            // rebuild the flat lists from them.
+            bool flatTailExtendsResolvedSections =
+                RecordingStore.FlatTrajectoryExtendsTrackSectionPayload(
+                    source, target.TrackSections, allowRelativeSections);
+
+            if (!flatTailExtendsResolvedSections)
+            {
+                if (healedUnrecordedGaps > 0
+                    && preHealMergedSections != null
+                    && RecordingStore.TrySyncFlatTrajectoryFromTrackSectionsPreservingFlatTail(
+                        target, source, preHealMergedSections, allowRelativeSections))
+                {
+                    flatSyncMode = "healed-track-sections-preserved-flat-tail";
+                    return true;
+                }
+
+                if (RecordingStore.TrySyncFlatTrajectoryFromTrackSections(
+                        target, allowRelativeSections))
+                {
+                    flatSyncMode = "track-sections";
+                    return true;
+                }
+            }
+
+            bool copiedFlatTrajectory = false;
+            if (source.Points != null && source.Points.Count > 0)
+            {
+                target.Points = new List<TrajectoryPoint>(source.Points);
+                copiedFlatTrajectory = true;
+            }
+
+            if (source.OrbitSegments != null && source.OrbitSegments.Count > 0)
+            {
+                target.OrbitSegments = new List<OrbitSegment>(source.OrbitSegments);
+                copiedFlatTrajectory = true;
+            }
+
+            if (copiedFlatTrajectory)
+            {
+                flatSyncMode = flatTailExtendsResolvedSections
+                    ? "preserved-flat-copy"
+                    : "track-sections-fallback";
+                return false;
+            }
+
+            bool rebuiltFlatTrajectory =
+                RecordingStore.TrySyncFlatTrajectoryFromTrackSections(
+                    target, allowRelativeSections);
+            flatSyncMode = rebuiltFlatTrajectory
+                ? "track-sections"
+                : "track-sections-fallback";
+            return rebuiltFlatTrajectory;
         }
 
         /// <summary>
@@ -600,8 +620,10 @@ namespace Parsek
         }
 
         private static int HealBackgroundActiveUnrecordedGapBoundaries(
-            string recId, string vesselName, List<TrackSection> sections)
+            string recId, string vesselName, List<TrackSection> sections,
+            out List<TrackSection> preHealSections)
         {
+            preHealSections = null;
             if (sections == null || sections.Count < 2)
                 return 0;
 
@@ -612,6 +634,10 @@ namespace Parsek
             {
                 TrackSection prev = sections[i - 1];
                 TrackSection next = sections[i];
+                // #580 is specifically a resume-into-active seam: Background holds
+                // the tail and Active owns the next authoritative head. Leave the
+                // reverse direction diagnostic-only until its sampling semantics are
+                // proven equivalent.
                 if (prev.source != TrackSectionSource.Background
                     || next.source != TrackSectionSource.Active
                     || prev.referenceFrame != next.referenceFrame
@@ -664,6 +690,8 @@ namespace Parsek
                     continue;
                 }
 
+                if (preHealSections == null)
+                    preHealSections = CloneTrackSections(sections);
                 sections[i - 1] = prev;
                 sections[i] = next;
                 healed++;
@@ -860,6 +888,9 @@ namespace Parsek
 
         private static void ExpandAltitudeRange(ref TrackSection section, double altitude)
         {
+            // The healer only inserts after TryBuildBoundarySeamPoint has verified
+            // non-empty frame lists; NaN guards keep synthetic tests and legacy
+            // sections from narrowing an uninitialized range.
             float value = (float)altitude;
             if (float.IsNaN(section.minAltitude) || value < section.minAltitude)
                 section.minAltitude = value;
@@ -884,6 +915,9 @@ namespace Parsek
 
         private static Quaternion LerpRotation(Quaternion a, Quaternion b, float t)
         {
+            // UnityEngine.Quaternion.Slerp is an engine internal call and throws under
+            // the net472 headless test runner, so use hemisphere-corrected NLERP for
+            // this visual seam glue instead.
             float dot = a.x * b.x + a.y * b.y + a.z * b.z + a.w * b.w;
             if (dot < 0f)
                 b = new Quaternion(-b.x, -b.y, -b.z, -b.w);

--- a/Source/Parsek/SessionMerger.cs
+++ b/Source/Parsek/SessionMerger.cs
@@ -89,6 +89,11 @@ namespace Parsek
                 // Resolve overlapping TrackSections
                 List<TrackSection> mergedSections = ResolveOverlaps(
                     srcRec.TrackSections ?? new List<TrackSection>());
+                List<TrackSection> preHealMergedSections = CloneTrackSections(mergedSections);
+                int healedUnrecordedGaps = HealBackgroundActiveUnrecordedGapBoundaries(
+                    recId, srcRec.VesselName, mergedSections);
+                if (healedUnrecordedGaps > 0)
+                    RecomputeBoundaryDiscontinuities(mergedSections);
 
                 // Merge PartEvents (source recording may only have one list, just deduplicate+sort)
                 List<PartEvent> mergedEvents = MergePartEvents(
@@ -113,9 +118,22 @@ namespace Parsek
                     RecordingStore.FlatTrajectoryExtendsTrackSectionPayload(
                         srcRec, mergedSections, allowRelativeSections: true);
                 bool rebuiltFlatTrajectory = false;
-                if (!flatTailExtendsResolvedSections)
+                string flatSyncMode = null;
+                if (!flatTailExtendsResolvedSections
+                    && healedUnrecordedGaps > 0
+                    && RecordingStore.TrySyncFlatTrajectoryFromTrackSectionsPreservingFlatTail(
+                        merged, srcRec, preHealMergedSections, allowRelativeSections: true))
+                {
+                    rebuiltFlatTrajectory = true;
+                    flatSyncMode = "healed-track-sections-preserved-flat-tail";
+                }
+                if (!rebuiltFlatTrajectory && !flatTailExtendsResolvedSections)
+                {
                     rebuiltFlatTrajectory = RecordingStore.TrySyncFlatTrajectoryFromTrackSections(
                         merged, allowRelativeSections: true);
+                    if (rebuiltFlatTrajectory && flatSyncMode == null)
+                        flatSyncMode = "track-sections";
+                }
 
                 if (!rebuiltFlatTrajectory)
                 {
@@ -133,8 +151,12 @@ namespace Parsek
                     }
 
                     if (!copiedFlatTrajectory)
+                    {
                         rebuiltFlatTrajectory = RecordingStore.TrySyncFlatTrajectoryFromTrackSections(
                             merged, allowRelativeSections: true);
+                        if (rebuiltFlatTrajectory)
+                            flatSyncMode = "track-sections-fallback";
+                    }
                 }
 
                 // Copy SegmentEvents
@@ -162,11 +184,12 @@ namespace Parsek
 
                 LogMergeDiagnostics(recId, srcRec.VesselName, inputSectionCount,
                     srcRec.TrackSections ?? new List<TrackSection>(), mergedSections);
-                ParsekLog.Verbose(Tag,
-                    $"MergeTree: recording='{recId}' flatSync=" +
-                    (rebuiltFlatTrajectory
+                if (flatSyncMode == null)
+                    flatSyncMode = rebuiltFlatTrajectory
                         ? "track-sections"
-                        : (flatTailExtendsResolvedSections ? "preserved-flat-copy" : "track-sections-fallback")));
+                        : (flatTailExtendsResolvedSections ? "preserved-flat-copy" : "track-sections-fallback");
+                ParsekLog.Verbose(Tag,
+                    $"MergeTree: recording='{recId}' flatSync={flatSyncMode}");
             }
 
             ParsekLog.Info(Tag,
@@ -525,22 +548,7 @@ namespace Parsek
             // Sort final output by startUT
             output.Sort((a, b) => a.startUT.CompareTo(b.startUT));
 
-            // Compute boundary discontinuities at each junction
-            for (int i = 1; i < output.Count; i++)
-            {
-                float disc = ComputeBoundaryDiscontinuity(output[i - 1], output[i]);
-                TrackSection s = output[i];
-                s.boundaryDiscontinuityMeters = disc;
-                output[i] = s;
-            }
-
-            // Clear discontinuity on first section
-            if (output.Count > 0)
-            {
-                TrackSection first = output[0];
-                first.boundaryDiscontinuityMeters = 0f;
-                output[0] = first;
-            }
+            RecomputeBoundaryDiscontinuities(output);
 
             ParsekLog.Verbose(Tag,
                 $"ResolveOverlaps: input={sections.Count} output={output.Count}");
@@ -591,6 +599,316 @@ namespace Parsek
             return (float)dist;
         }
 
+        private static int HealBackgroundActiveUnrecordedGapBoundaries(
+            string recId, string vesselName, List<TrackSection> sections)
+        {
+            if (sections == null || sections.Count < 2)
+                return 0;
+
+            var ic = CultureInfo.InvariantCulture;
+            int healed = 0;
+
+            for (int i = 1; i < sections.Count; i++)
+            {
+                TrackSection prev = sections[i - 1];
+                TrackSection next = sections[i];
+                if (prev.source != TrackSectionSource.Background
+                    || next.source != TrackSectionSource.Active
+                    || prev.referenceFrame != next.referenceFrame
+                    || prev.referenceFrame == ReferenceFrame.OrbitalCheckpoint
+                    || (prev.referenceFrame == ReferenceFrame.Relative
+                        && prev.anchorVesselId != next.anchorVesselId))
+                {
+                    continue;
+                }
+
+                float disc = next.boundaryDiscontinuityMeters > 0f
+                    ? next.boundaryDiscontinuityMeters
+                    : ComputeBoundaryDiscontinuity(prev, next);
+                if (disc <= 1.0f)
+                    continue;
+
+                ClassifyBoundaryDiscontinuity(
+                    prev,
+                    next,
+                    hasPrev: true,
+                    discMeters: disc,
+                    out double dt,
+                    out double expectedM,
+                    out string cause);
+                if (cause != "unrecorded-gap")
+                    continue;
+
+                if (!TryBuildBoundarySeamPoint(
+                        prev, next, next.startUT, out TrajectoryPoint seamPoint, out string reason))
+                {
+                    ParsekLog.Warn(Tag,
+                        $"MergeTree: unable to heal unrecorded-gap at section[{i}] " +
+                        $"ut={next.startUT.ToString("F2", ic)} vessel='{vesselName}' " +
+                        $"recId={recId} prevSrc={prev.source} nextSrc={next.source} " +
+                        $"dt={dt.ToString("F2", ic)}s expectedFromVel={expectedM.ToString("F2", ic)}m " +
+                        $"reason={reason}");
+                    continue;
+                }
+
+                bool appended = TryAppendSeamPoint(ref prev, seamPoint);
+                bool prepended = TryPrependSeamPoint(ref next, seamPoint);
+                if (!appended || !prepended)
+                {
+                    ParsekLog.Warn(Tag,
+                        $"MergeTree: unable to heal unrecorded-gap at section[{i}] " +
+                        $"ut={next.startUT.ToString("F2", ic)} vessel='{vesselName}' " +
+                        $"recId={recId} prevSrc={prev.source} nextSrc={next.source} " +
+                        $"dt={dt.ToString("F2", ic)}s expectedFromVel={expectedM.ToString("F2", ic)}m " +
+                        $"reason=seam-insert-failed");
+                    continue;
+                }
+
+                sections[i - 1] = prev;
+                sections[i] = next;
+                healed++;
+
+                float residual = ComputeBoundaryDiscontinuity(prev, next);
+                ParsekLog.Info(Tag,
+                    $"MergeTree: healed unrecorded-gap at section[{i}] " +
+                    $"ut={next.startUT.ToString("F2", ic)} vessel='{vesselName}' " +
+                    $"recId={recId} prevRef={prev.referenceFrame} nextRef={next.referenceFrame} " +
+                    $"prevSrc={prev.source} nextSrc={next.source} " +
+                    $"dt={dt.ToString("F2", ic)}s expectedFromVel={expectedM.ToString("F2", ic)}m " +
+                    $"insertedBoundaryPointUT={seamPoint.ut.ToString("F2", ic)} " +
+                    $"residual={residual.ToString("F2", ic)}m cause=unrecorded-gap #580");
+            }
+
+            return healed;
+        }
+
+        private static void RecomputeBoundaryDiscontinuities(List<TrackSection> sections)
+        {
+            if (sections == null || sections.Count == 0)
+                return;
+
+            TrackSection first = sections[0];
+            first.boundaryDiscontinuityMeters = 0f;
+            sections[0] = first;
+
+            for (int i = 1; i < sections.Count; i++)
+            {
+                TrackSection section = sections[i];
+                section.boundaryDiscontinuityMeters =
+                    ComputeBoundaryDiscontinuity(sections[i - 1], section);
+                sections[i] = section;
+            }
+        }
+
+        private static List<TrackSection> CloneTrackSections(List<TrackSection> sections)
+        {
+            var clones = new List<TrackSection>();
+            if (sections == null)
+                return clones;
+
+            for (int i = 0; i < sections.Count; i++)
+            {
+                TrackSection clone = sections[i];
+                if (clone.frames != null)
+                    clone.frames = new List<TrajectoryPoint>(clone.frames);
+                if (clone.checkpoints != null)
+                    clone.checkpoints = new List<OrbitSegment>(clone.checkpoints);
+                clones.Add(clone);
+            }
+
+            return clones;
+        }
+
+        private static bool TryBuildBoundarySeamPoint(
+            TrackSection prev, TrackSection next, double boundaryUT,
+            out TrajectoryPoint seamPoint, out string reason)
+        {
+            seamPoint = default(TrajectoryPoint);
+            reason = null;
+
+            if (prev.frames == null || prev.frames.Count == 0)
+            {
+                reason = "prev-no-frames";
+                return false;
+            }
+            if (next.frames == null || next.frames.Count == 0)
+            {
+                reason = "next-no-frames";
+                return false;
+            }
+            if (!IsFinite(boundaryUT))
+            {
+                reason = "boundary-ut-nonfinite";
+                return false;
+            }
+
+            TrajectoryPoint prevPoint = prev.frames[prev.frames.Count - 1];
+            TrajectoryPoint nextPoint = next.frames[0];
+            if (!IsFinite(prevPoint.ut) || !IsFinite(nextPoint.ut))
+            {
+                reason = "point-ut-nonfinite";
+                return false;
+            }
+            if (!string.Equals(prevPoint.bodyName, nextPoint.bodyName, StringComparison.Ordinal))
+            {
+                reason = "body-mismatch";
+                return false;
+            }
+            if (!IsFinite(prevPoint.latitude) || !IsFinite(prevPoint.longitude)
+                || !IsFinite(prevPoint.altitude) || !IsFinite(nextPoint.latitude)
+                || !IsFinite(nextPoint.longitude) || !IsFinite(nextPoint.altitude)
+                || !IsFiniteVector3(prevPoint.velocity) || !IsFiniteVector3(nextPoint.velocity)
+                || !IsFiniteQuaternion(prevPoint.rotation) || !IsFiniteQuaternion(nextPoint.rotation))
+            {
+                reason = "point-data-nonfinite";
+                return false;
+            }
+
+            const double epsilon = 1e-6;
+            double span = nextPoint.ut - prevPoint.ut;
+            if (Math.Abs(boundaryUT - prevPoint.ut) <= epsilon)
+            {
+                seamPoint = prevPoint;
+                seamPoint.ut = boundaryUT;
+                return true;
+            }
+            if (Math.Abs(boundaryUT - nextPoint.ut) <= epsilon)
+            {
+                seamPoint = nextPoint;
+                seamPoint.ut = boundaryUT;
+                return true;
+            }
+            if (span <= epsilon)
+            {
+                reason = "non-positive-span";
+                return false;
+            }
+
+            double t = (boundaryUT - prevPoint.ut) / span;
+            if (t < -epsilon || t > 1.0 + epsilon)
+            {
+                reason = "boundary-outside-point-span";
+                return false;
+            }
+
+            float tf = Mathf.Clamp01((float)t);
+            seamPoint = new TrajectoryPoint
+            {
+                ut = boundaryUT,
+                latitude = Lerp(prevPoint.latitude, nextPoint.latitude, t),
+                longitude = Lerp(prevPoint.longitude, nextPoint.longitude, t),
+                altitude = Lerp(prevPoint.altitude, nextPoint.altitude, t),
+                rotation = LerpRotation(prevPoint.rotation, nextPoint.rotation, tf),
+                velocity = Vector3.Lerp(prevPoint.velocity, nextPoint.velocity, tf),
+                bodyName = prevPoint.bodyName,
+                funds = prevPoint.funds,
+                science = prevPoint.science,
+                reputation = prevPoint.reputation
+            };
+            return true;
+        }
+
+        private static bool TryAppendSeamPoint(ref TrackSection section, TrajectoryPoint seamPoint)
+        {
+            if (section.frames == null)
+            {
+                section.frames = new List<TrajectoryPoint>();
+            }
+            else
+            {
+                if (section.frames.Count > 0)
+                {
+                    TrajectoryPoint last = section.frames[section.frames.Count - 1];
+                    if (SameBoundaryPoint(last, seamPoint))
+                        return true;
+                    if (last.ut > seamPoint.ut)
+                        return false;
+                }
+
+                section.frames = new List<TrajectoryPoint>(section.frames);
+            }
+
+            section.frames.Add(seamPoint);
+            ExpandAltitudeRange(ref section, seamPoint.altitude);
+            return true;
+        }
+
+        private static bool TryPrependSeamPoint(ref TrackSection section, TrajectoryPoint seamPoint)
+        {
+            if (section.frames == null)
+            {
+                section.frames = new List<TrajectoryPoint>();
+            }
+            else
+            {
+                if (section.frames.Count > 0)
+                {
+                    TrajectoryPoint first = section.frames[0];
+                    if (SameBoundaryPoint(first, seamPoint))
+                        return true;
+                    if (first.ut < seamPoint.ut)
+                        return false;
+                }
+
+                section.frames = new List<TrajectoryPoint>(section.frames);
+            }
+
+            section.frames.Insert(0, seamPoint);
+            ExpandAltitudeRange(ref section, seamPoint.altitude);
+            return true;
+        }
+
+        private static void ExpandAltitudeRange(ref TrackSection section, double altitude)
+        {
+            float value = (float)altitude;
+            if (float.IsNaN(section.minAltitude) || value < section.minAltitude)
+                section.minAltitude = value;
+            if (float.IsNaN(section.maxAltitude) || value > section.maxAltitude)
+                section.maxAltitude = value;
+        }
+
+        private static bool SameBoundaryPoint(TrajectoryPoint a, TrajectoryPoint b)
+        {
+            const double epsilon = 1e-6;
+            return Math.Abs(a.ut - b.ut) <= epsilon
+                && Math.Abs(a.latitude - b.latitude) <= epsilon
+                && Math.Abs(a.longitude - b.longitude) <= epsilon
+                && Math.Abs(a.altitude - b.altitude) <= epsilon
+                && string.Equals(a.bodyName, b.bodyName, StringComparison.Ordinal);
+        }
+
+        private static double Lerp(double a, double b, double t)
+        {
+            return a + (b - a) * t;
+        }
+
+        private static Quaternion LerpRotation(Quaternion a, Quaternion b, float t)
+        {
+            float dot = a.x * b.x + a.y * b.y + a.z * b.z + a.w * b.w;
+            if (dot < 0f)
+                b = new Quaternion(-b.x, -b.y, -b.z, -b.w);
+
+            return NormalizeQuaternion(new Quaternion(
+                a.x + (b.x - a.x) * t,
+                a.y + (b.y - a.y) * t,
+                a.z + (b.z - a.z) * t,
+                a.w + (b.w - a.w) * t));
+        }
+
+        private static Quaternion NormalizeQuaternion(Quaternion q)
+        {
+            double magnitude = Math.Sqrt(
+                (double)q.x * q.x
+                + (double)q.y * q.y
+                + (double)q.z * q.z
+                + (double)q.w * q.w);
+            if (!IsFinite(magnitude) || magnitude < 0.001)
+                return new Quaternion(0f, 0f, 0f, 1f);
+
+            float inv = (float)(1.0 / magnitude);
+            return new Quaternion(q.x * inv, q.y * inv, q.z * inv, q.w * inv);
+        }
+
         /// <summary>
         /// Merges two PartEvent lists, deduplicating by (ut, partPersistentId, eventType)
         /// and sorting by UT with stable semantics so same-UT events keep their insertion
@@ -626,6 +944,14 @@ namespace Parsek
             return !float.IsNaN(value.x) && !float.IsInfinity(value.x)
                 && !float.IsNaN(value.y) && !float.IsInfinity(value.y)
                 && !float.IsNaN(value.z) && !float.IsInfinity(value.z);
+        }
+
+        private static bool IsFiniteQuaternion(Quaternion value)
+        {
+            return !float.IsNaN(value.x) && !float.IsInfinity(value.x)
+                && !float.IsNaN(value.y) && !float.IsInfinity(value.y)
+                && !float.IsNaN(value.z) && !float.IsInfinity(value.z)
+                && !float.IsNaN(value.w) && !float.IsInfinity(value.w);
         }
 
         private static void AddEventsWithDedup(

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -336,7 +336,7 @@ filter.
 
 ---
 
-## 580. MergeTree: 3 boundary discontinuity warnings (`unrecorded-gap`) between Background and Active sources
+## ~~580. MergeTree: 3 boundary discontinuity warnings (`unrecorded-gap`) between Background and Active sources~~
 
 **Source:** `logs/2026-04-25_1314_marker-validator-fix/KSP.log.cleaned` —
 3 occurrences of:
@@ -357,7 +357,9 @@ correction at handoff is missing a term.
 - Whether `unrecorded-gap` should heal the boundary by interpolating or just
   surface as a WARN.
 
-**Status:** Open.
+**Status:** ~~Open~~ Fixed.
+
+**Fix:** `SessionMerger.MergeTree` now heals same-reference-frame Background→Active `unrecorded-gap` seams before rebuilding the merged flat trajectory from section-authoritative payload. The merger inserts one interpolated boundary point shared by the Background tail and Active head, preserves validated flat tail data, recomputes `boundaryDiscontinuityMeters`, and logs `MergeTree: healed unrecorded-gap ... #580` instead of leaving the old WARN shape for the three cited Kerbal X boundaries: section[2] UT 193973.61, section[4] UT 193977.99, and section[1] UT 193985.09.
 
 ---
 


### PR DESCRIPTION
Summary:
- Heal velocity-consistent Background-to-Active MergeTree handoff gaps by inserting a shared boundary point and recomputing section discontinuities.
- Preserve validated flat tail data when healing changes the section-authoritative payload.
- Mark bug #580 fixed in docs and add release notes under v0.9.0 and v0.8.3 bug fixes.

Validation:
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter FullyQualifiedName~SessionMergerTests (61/61)
- cd Source/Parsek && dotnet build (0 warnings, 0 errors)
- cd Source/Parsek.Tests && dotnet test (8631/8631)
- Deployed GameData Parsek.dll hash, size, and UTC mtime match Source/Parsek/bin/Debug/Parsek.dll; UTF-16 strings verified.