### PR TITLE
Accept prior-session InvokedUT in marker validator (#577)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,8 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- `#577` Re-Fly session markers loaded from an earlier game session now survive fresh-load scenes where KSP reports UT 0 during validation. The validator still rejects corrupt `InvokedUT` values and now logs current-UT/RP-UT comparisons for both accepts and rejects.
+
 - MergeTree now heals velocity-consistent Background-to-Active handoff gaps by inserting a shared boundary point, preventing Kerbal X-style ghost trajectory pops from section-authoritative merged recordings.
 - Follow-up cleanup to `#431/#432`: retired `MilestoneStore.CurrentEpoch` from production branch filtering. Timeline rows, milestone bundling, reward enrichment, revert bookkeeping, and load-time ledger recovery now exclude abandoned branches through recording-tag visibility plus deterministic discard/unstash behavior instead of epoch stamping/filtering.
 - `#579` Debris recoveries without an immediate funds event no longer enter the LedgerOrchestrator pending recovery-funds queue, preventing false overflow and rewind-flush warnings after debris-only recoveries.

--- a/Source/Parsek.Tests/LoadTimeSweepTests.cs
+++ b/Source/Parsek.Tests/LoadTimeSweepTests.cs
@@ -143,6 +143,28 @@ namespace Parsek.Tests
             };
         }
 
+        private static ParsekScenario InstallMarkerValidationFixture(
+            double invokedUt,
+            double currentUt,
+            double rewindPointUt = 577.5)
+        {
+            MarkerValidator.NowUtProvider = () => currentUt;
+            InstallTree("tree_1",
+                new List<Recording>
+                {
+                    Rec("rec_active", MergeState.NotCommitted),
+                    Rec("rec_origin", MergeState.CommittedProvisional),
+                },
+                new List<BranchPoint> { Bp("bp_1", "rp_1") });
+            var rp = Rp("rp_1", "bp_1", sessionProvisional: false);
+            rp.UT = rewindPointUt;
+            var marker = Marker("sess_1", "tree_1", "rec_active", "rec_origin", "rp_1",
+                invokedUt: invokedUt);
+            return InstallScenario(
+                rps: new List<RewindPoint> { rp },
+                marker: marker);
+        }
+
         private static void InstallTree(string treeId, List<Recording> recordings,
             List<BranchPoint> branchPoints)
         {
@@ -328,29 +350,85 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void MarkerInvalid_InvokedUtInFuture_Cleared()
+        public void MarkerValid_PriorSessionInvokedUtAfterFreshLoadUt_PreservedAndLogged()
         {
-            InstallTree("tree_1",
-                new List<Recording>
-                {
-                    Rec("rec_active", MergeState.NotCommitted),
-                    Rec("rec_origin", MergeState.CommittedProvisional),
-                },
-                new List<BranchPoint> { Bp("bp_1", "rp_1") });
-            var rp = Rp("rp_1", "bp_1", sessionProvisional: false);
-            // NowUtProvider returns 1_000_000 — set InvokedUT higher.
-            var marker = Marker("sess_1", "tree_1", "rec_active", "rec_origin", "rp_1",
-                invokedUt: 2_000_000.0);
-            var scenario = InstallScenario(
-                rps: new List<RewindPoint> { rp },
-                marker: marker);
+            // Regression #577: on a fresh SPACECENTER load the scenario load
+            // summary reported current UT 0 even though the durable marker
+            // had been authored in an earlier session at UT ~= the RP time.
+            // Current UT is therefore diagnostic-only; the persisted game UT
+            // remains sane and the marker must survive.
+            var scenario = InstallMarkerValidationFixture(
+                invokedUt: 578.13180328350882,
+                currentUt: 0.0,
+                rewindPointUt: 577.5);
+
+            LoadTimeSweep.Run();
+
+            Assert.NotNull(scenario.ActiveReFlySessionMarker);
+            Assert.Contains(logLines, l =>
+                l.Contains("[ReFlySession]") &&
+                l.Contains("Marker valid sess=sess_1") &&
+                l.Contains("invokedUT=578.13180328350882") &&
+                l.Contains("currentUT=0") &&
+                l.Contains("rpUT=577.5") &&
+                l.Contains("prePRWouldReject=InvokedUT>currentUT"));
+        }
+
+        [Fact]
+        public void MarkerInvalid_InvokedUtNaN_ClearedWithDiagnostic()
+        {
+            var scenario = InstallMarkerValidationFixture(
+                invokedUt: double.NaN,
+                currentUt: 0.0,
+                rewindPointUt: 577.5);
 
             LoadTimeSweep.Run();
 
             Assert.Null(scenario.ActiveReFlySessionMarker);
             Assert.Contains(logLines, l =>
                 l.Contains("[ReFlySession]") &&
-                l.Contains("Marker invalid field=InvokedUT"));
+                l.Contains("Marker invalid field=InvokedUT") &&
+                l.Contains("failure=not-finite") &&
+                l.Contains("currentUT=0") &&
+                l.Contains("rpUT=577.5"));
+        }
+
+        [Fact]
+        public void MarkerInvalid_InvokedUtNegative_ClearedWithDiagnostic()
+        {
+            var scenario = InstallMarkerValidationFixture(
+                invokedUt: -1.0,
+                currentUt: 0.0,
+                rewindPointUt: 577.5);
+
+            LoadTimeSweep.Run();
+
+            Assert.Null(scenario.ActiveReFlySessionMarker);
+            Assert.Contains(logLines, l =>
+                l.Contains("[ReFlySession]") &&
+                l.Contains("Marker invalid field=InvokedUT") &&
+                l.Contains("failure=negative") &&
+                l.Contains("invokedUT=-1") &&
+                l.Contains("rpUT=577.5"));
+        }
+
+        [Fact]
+        public void MarkerInvalid_InvokedUtExtremeFuture_ClearedWithDiagnostic()
+        {
+            var scenario = InstallMarkerValidationFixture(
+                invokedUt: 1.0e16,
+                currentUt: 22_116.0,
+                rewindPointUt: 577.5);
+
+            LoadTimeSweep.Run();
+
+            Assert.Null(scenario.ActiveReFlySessionMarker);
+            Assert.Contains(logLines, l =>
+                l.Contains("[ReFlySession]") &&
+                l.Contains("Marker invalid field=InvokedUT") &&
+                l.Contains("failure=exceeds-sanity-ceiling") &&
+                l.Contains("currentUT=22116") &&
+                l.Contains("maxReasonableInvokedUT=1E+15"));
         }
 
         [Fact]

--- a/Source/Parsek.Tests/LoadTimeSweepTests.cs
+++ b/Source/Parsek.Tests/LoadTimeSweepTests.cs
@@ -42,10 +42,9 @@ namespace Parsek.Tests
             MarkerValidator.ResetTestOverrides();
             RewindPointReaper.ResetTestOverrides();
 
-            // Keep the "current UT" finite so InvokedUT comparisons are
-            // deterministic (tests opt into a specific value via the
-            // NowUtProvider seam when they need to exercise the future-UT
-            // path).
+            // Keep the diagnostic "current UT" finite so marker-validation
+            // log assertions are deterministic. Individual tests override it
+            // when they need to exercise fresh-load clock behavior.
             MarkerValidator.NowUtProvider = () => 1_000_000.0;
         }
 
@@ -371,7 +370,7 @@ namespace Parsek.Tests
                 l.Contains("invokedUT=578.13180328350882") &&
                 l.Contains("currentUT=0") &&
                 l.Contains("rpUT=577.5") &&
-                l.Contains("prePRWouldReject=InvokedUT>currentUT"));
+                l.Contains("legacyFutureUtCheck=triggered"));
         }
 
         [Fact]

--- a/Source/Parsek/LoadTimeSweep.cs
+++ b/Source/Parsek/LoadTimeSweep.cs
@@ -72,17 +72,21 @@ namespace Parsek
             if (marker != null && !validation.Valid)
             {
                 clearedMarkerSessionId = marker.SessionId;
-                LogMarkerInvalid(marker, validation.Reason);
+                LogMarkerInvalid(marker, validation.Reason, validation.Details);
                 scenario.ActiveReFlySessionMarker = null;
             }
             else if (markerValid)
             {
+                var ic = CultureInfo.InvariantCulture;
                 ParsekLog.Info(SessionTag,
                     $"Marker valid sess={marker.SessionId ?? "<no-id>"} " +
                     $"tree={marker.TreeId ?? "<no-id>"} " +
                     $"active={marker.ActiveReFlyRecordingId ?? "<no-id>"} " +
                     $"origin={marker.OriginChildRecordingId ?? "<no-id>"} " +
-                    $"rp={marker.RewindPointId ?? "<no-id>"}");
+                    $"rp={marker.RewindPointId ?? "<no-id>"} " +
+                    $"invokedUT={marker.InvokedUT.ToString("R", ic)} " +
+                    $"invokedRealTime={marker.InvokedRealTime ?? "<none>"} " +
+                    $"details={validation.Details ?? "<none>"}");
             }
 
             // ----------------------------------------------------------------
@@ -534,7 +538,7 @@ namespace Parsek
             return false;
         }
 
-        private static void LogMarkerInvalid(ReFlySessionMarker marker, string reason)
+        private static void LogMarkerInvalid(ReFlySessionMarker marker, string reason, string details)
         {
             var ic = CultureInfo.InvariantCulture;
             ParsekLog.Warn(SessionTag,
@@ -545,7 +549,8 @@ namespace Parsek
                 $"origin={marker.OriginChildRecordingId ?? "<no-id>"} " +
                 $"rp={marker.RewindPointId ?? "<no-id>"} " +
                 $"invokedUT={marker.InvokedUT.ToString("R", ic)} " +
-                $"invokedRealTime={marker.InvokedRealTime ?? "<none>"}");
+                $"invokedRealTime={marker.InvokedRealTime ?? "<none>"} " +
+                $"details={details ?? "<none>"}");
         }
     }
 }

--- a/Source/Parsek/MarkerValidator.cs
+++ b/Source/Parsek/MarkerValidator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 
 namespace Parsek
 {
@@ -13,15 +14,16 @@ namespace Parsek
     {
         public bool Valid;
         public string Reason;  // populated on invalid
+        public string Details;
 
-        public static MarkerValidationResult Ok()
+        public static MarkerValidationResult Ok(string details = null)
         {
-            return new MarkerValidationResult { Valid = true, Reason = null };
+            return new MarkerValidationResult { Valid = true, Reason = null, Details = details };
         }
 
-        public static MarkerValidationResult Invalid(string reason)
+        public static MarkerValidationResult Invalid(string reason, string details = null)
         {
-            return new MarkerValidationResult { Valid = false, Reason = reason };
+            return new MarkerValidationResult { Valid = false, Reason = reason, Details = details };
         }
     }
 
@@ -47,9 +49,11 @@ namespace Parsek
     ///   resolves to a live entry in
     ///   <see cref="ParsekScenario.RewindPoints"/>.</description></item>
     ///   <item><description><see cref="ReFlySessionMarker.InvokedUT"/>
-    ///   not strictly greater than the current Planetarium UT (set via
-    ///   <see cref="NowUtProvider"/> in tests; <c>Planetarium.GetUniversalTime()</c>
-    ///   in production).</description></item>
+    ///   is a finite, non-negative game UT within Parsek's sanity ceiling.
+    ///   The current Planetarium UT (set via <see cref="NowUtProvider"/>
+    ///   in tests; <c>Planetarium.GetUniversalTime()</c> in production) is
+    ///   captured only for diagnostics because fresh scene loads can report
+    ///   UT 0 before the loaded save's clock is meaningful.</description></item>
     /// </list>
     /// </para>
     ///
@@ -61,13 +65,14 @@ namespace Parsek
     /// </summary>
     internal static class MarkerValidator
     {
+        internal const double MaxReasonableInvokedUT = 1.0e15;
+
         /// <summary>
-        /// Test seam: override the "current UT" used for the future-UT check.
+        /// Test seam: override the "current UT" captured for diagnostics.
         /// Production code leaves this null and the validator falls back to
         /// <c>Planetarium.GetUniversalTime()</c>, guarded so tests that do not
         /// have a Planetarium singleton still work (returns
-        /// <see cref="double.PositiveInfinity"/>, making any finite InvokedUT
-        /// pass the future check).
+        /// <see cref="double.PositiveInfinity"/>).
         /// </summary>
         internal static Func<double> NowUtProvider;
 
@@ -86,27 +91,42 @@ namespace Parsek
         public static MarkerValidationResult Validate(ReFlySessionMarker marker)
         {
             if (marker == null)
-                return MarkerValidationResult.Ok();
+                return MarkerValidationResult.Ok(
+                    "checked=marker-null; accepted because no active re-fly marker is a legitimate load state");
 
             if (string.IsNullOrEmpty(marker.SessionId))
-                return MarkerValidationResult.Invalid("SessionId");
+                return MarkerValidationResult.Invalid(
+                    "SessionId",
+                    "checked=SessionId.nonEmpty; rejected because SessionId is empty");
 
             if (string.IsNullOrEmpty(marker.TreeId))
-                return MarkerValidationResult.Invalid("TreeId");
+                return MarkerValidationResult.Invalid(
+                    "TreeId",
+                    "checked=TreeId.nonEmpty; rejected because TreeId is empty");
             if (!TreeExists(marker.TreeId))
-                return MarkerValidationResult.Invalid("TreeId");
+                return MarkerValidationResult.Invalid(
+                    "TreeId",
+                    "checked=TreeId.exists; rejected because TreeId was not found in RecordingStore.CommittedTrees");
 
             if (string.IsNullOrEmpty(marker.ActiveReFlyRecordingId))
-                return MarkerValidationResult.Invalid("ActiveReFlyRecordingId");
+                return MarkerValidationResult.Invalid(
+                    "ActiveReFlyRecordingId",
+                    "checked=ActiveReFlyRecordingId.nonEmpty; rejected because ActiveReFlyRecordingId is empty");
             var active = FindRecordingById(marker.ActiveReFlyRecordingId);
             if (active == null)
-                return MarkerValidationResult.Invalid("ActiveReFlyRecordingId");
+                return MarkerValidationResult.Invalid(
+                    "ActiveReFlyRecordingId",
+                    "checked=ActiveReFlyRecordingId.exists; rejected because active recording was not found in RecordingStore.CommittedRecordings");
 
             if (string.IsNullOrEmpty(marker.OriginChildRecordingId))
-                return MarkerValidationResult.Invalid("OriginChildRecordingId");
+                return MarkerValidationResult.Invalid(
+                    "OriginChildRecordingId",
+                    "checked=OriginChildRecordingId.nonEmpty; rejected because OriginChildRecordingId is empty");
             var origin = FindRecordingById(marker.OriginChildRecordingId);
             if (origin == null)
-                return MarkerValidationResult.Invalid("OriginChildRecordingId");
+                return MarkerValidationResult.Invalid(
+                    "OriginChildRecordingId",
+                    "checked=OriginChildRecordingId.exists; rejected because origin recording was not found in RecordingStore.CommittedRecordings");
 
             // MergeState gate. The placeholder pattern (origin != active)
             // creates a fresh `NotCommitted` recording at re-fly start, so
@@ -134,18 +154,46 @@ namespace Parsek
                     && (active.MergeState == MergeState.CommittedProvisional
                         || active.MergeState == MergeState.Immutable));
             if (!acceptableState)
-                return MarkerValidationResult.Invalid("ActiveReFlyRecordingId");
+            {
+                return MarkerValidationResult.Invalid(
+                    "ActiveReFlyRecordingId",
+                    "checked=ActiveReFlyRecordingId.mergeState " +
+                    $"state={active.MergeState} inPlace={inPlaceContinuation.ToString()} " +
+                    "expected=NotCommitted-or-inPlace-CommittedProvisional/Immutable; rejected because state/pattern is not valid for a live marker");
+            }
 
             if (string.IsNullOrEmpty(marker.RewindPointId))
-                return MarkerValidationResult.Invalid("RewindPointId");
-            if (!RewindPointExists(marker.RewindPointId))
-                return MarkerValidationResult.Invalid("RewindPointId");
+                return MarkerValidationResult.Invalid(
+                    "RewindPointId",
+                    "checked=RewindPointId.nonEmpty; rejected because RewindPointId is empty");
+            var rewindPoint = FindRewindPointById(marker.RewindPointId);
+            if (rewindPoint == null)
+                return MarkerValidationResult.Invalid(
+                    "RewindPointId",
+                    "checked=RewindPointId.exists; rejected because rewind point was not found in ParsekScenario.RewindPoints");
 
             double now = CurrentUt();
-            if (marker.InvokedUT > now)
-                return MarkerValidationResult.Invalid("InvokedUT");
+            if (!IsFinite(marker.InvokedUT))
+                return MarkerValidationResult.Invalid(
+                    "InvokedUT",
+                    BuildInvokedUtDetails(marker.InvokedUT, now, rewindPoint.UT,
+                        "not-finite",
+                        "rejected because InvokedUT is NaN or Infinity"));
+            if (marker.InvokedUT < 0.0)
+                return MarkerValidationResult.Invalid(
+                    "InvokedUT",
+                    BuildInvokedUtDetails(marker.InvokedUT, now, rewindPoint.UT,
+                        "negative",
+                        "rejected because InvokedUT is less than 0"));
+            if (marker.InvokedUT > MaxReasonableInvokedUT)
+                return MarkerValidationResult.Invalid(
+                    "InvokedUT",
+                    BuildInvokedUtDetails(marker.InvokedUT, now, rewindPoint.UT,
+                        "exceeds-sanity-ceiling",
+                        "rejected because InvokedUT exceeds the 1E+15 sanity ceiling"));
 
-            return MarkerValidationResult.Ok();
+            return MarkerValidationResult.Ok(
+                BuildAcceptedDetails(active, inPlaceContinuation, marker.InvokedUT, now, rewindPoint.UT));
         }
 
         private static bool TreeExists(string treeId)
@@ -179,20 +227,20 @@ namespace Parsek
             return null;
         }
 
-        private static bool RewindPointExists(string rewindPointId)
+        private static RewindPoint FindRewindPointById(string rewindPointId)
         {
             var scenario = ParsekScenario.Instance;
-            if (ReferenceEquals(null, scenario)) return false;
+            if (ReferenceEquals(null, scenario)) return null;
             var rps = scenario.RewindPoints;
-            if (rps == null) return false;
+            if (rps == null) return null;
             for (int i = 0; i < rps.Count; i++)
             {
                 var rp = rps[i];
                 if (rp == null) continue;
                 if (string.Equals(rp.RewindPointId, rewindPointId, StringComparison.Ordinal))
-                    return true;
+                    return rp;
             }
-            return false;
+            return null;
         }
 
         private static double CurrentUt()
@@ -206,11 +254,63 @@ namespace Parsek
             try { return Planetarium.GetUniversalTime(); }
             catch
             {
-                // No Planetarium singleton (unit tests without KSP). Treat
-                // "now" as +infinity so any finite InvokedUT passes — the
-                // future-UT check is only meaningful against a live clock.
+                // No Planetarium singleton (unit tests without KSP). Use
+                // +infinity so diagnostics clearly show the live clock was
+                // unavailable without turning that into a hard rejection.
                 return double.PositiveInfinity;
             }
+        }
+
+        private static string BuildAcceptedDetails(
+            Recording active,
+            bool inPlaceContinuation,
+            double invokedUt,
+            double currentUt,
+            double rewindPointUt)
+        {
+            bool wouldHaveRejectedPreFix = IsFinite(currentUt) && invokedUt > currentUt;
+            return "checked=SessionId.nonEmpty,TreeId.exists,ActiveReFlyRecordingId.exists+mergeState," +
+                "OriginChildRecordingId.exists,RewindPointId.exists,InvokedUT.finite>=0<=1E+15; " +
+                $"activeState={active.MergeState} inPlace={inPlaceContinuation.ToString()} " +
+                BuildInvokedUtComparison(invokedUt, currentUt, rewindPointUt) + " " +
+                $"prePRWouldReject={(wouldHaveRejectedPreFix ? "InvokedUT>currentUT" : "none")}";
+        }
+
+        private static string BuildInvokedUtDetails(
+            double invokedUt,
+            double currentUt,
+            double rewindPointUt,
+            string failure,
+            string explanation)
+        {
+            return "checked=InvokedUT.finite>=0<=1E+15; " +
+                BuildInvokedUtComparison(invokedUt, currentUt, rewindPointUt) + " " +
+                $"failure={failure}; {explanation}";
+        }
+
+        private static string BuildInvokedUtComparison(
+            double invokedUt,
+            double currentUt,
+            double rewindPointUt)
+        {
+            double deltaCurrent = invokedUt - currentUt;
+            double deltaRewindPoint = invokedUt - rewindPointUt;
+            return $"invokedUT={FormatDouble(invokedUt)} " +
+                $"currentUT={FormatDouble(currentUt)} " +
+                $"rpUT={FormatDouble(rewindPointUt)} " +
+                $"deltaCurrent={FormatDouble(deltaCurrent)} " +
+                $"deltaRp={FormatDouble(deltaRewindPoint)} " +
+                $"maxReasonableInvokedUT={FormatDouble(MaxReasonableInvokedUT)}";
+        }
+
+        private static bool IsFinite(double value)
+        {
+            return !double.IsNaN(value) && !double.IsInfinity(value);
+        }
+
+        private static string FormatDouble(double value)
+        {
+            return value.ToString("R", CultureInfo.InvariantCulture);
         }
     }
 }

--- a/Source/Parsek/MarkerValidator.cs
+++ b/Source/Parsek/MarkerValidator.cs
@@ -65,7 +65,15 @@ namespace Parsek
     /// </summary>
     internal static class MarkerValidator
     {
+        // 1e15 seconds is ~31.7 million years: far beyond any legitimate
+        // KSP campaign, while still catching overflow/garbage marker values.
         internal const double MaxReasonableInvokedUT = 1.0e15;
+
+        // Log-facing summary only. Keep in sync with the accept path below so
+        // "Marker valid" lines do not drift from the actual validator rules.
+        private const string AcceptedMarkerCheckPaths =
+            "SessionId.nonEmpty,TreeId.exists,ActiveReFlyRecordingId.exists+mergeState," +
+            "OriginChildRecordingId.exists,RewindPointId.exists,InvokedUT.finite>=0<=1E+15";
 
         /// <summary>
         /// Test seam: override the "current UT" captured for diagnostics.
@@ -91,8 +99,7 @@ namespace Parsek
         public static MarkerValidationResult Validate(ReFlySessionMarker marker)
         {
             if (marker == null)
-                return MarkerValidationResult.Ok(
-                    "checked=marker-null; accepted because no active re-fly marker is a legitimate load state");
+                return MarkerValidationResult.Ok();
 
             if (string.IsNullOrEmpty(marker.SessionId))
                 return MarkerValidationResult.Invalid(
@@ -158,7 +165,7 @@ namespace Parsek
                 return MarkerValidationResult.Invalid(
                     "ActiveReFlyRecordingId",
                     "checked=ActiveReFlyRecordingId.mergeState " +
-                    $"state={active.MergeState} inPlace={inPlaceContinuation.ToString()} " +
+                    $"state={active.MergeState} inPlace={inPlaceContinuation} " +
                     "expected=NotCommitted-or-inPlace-CommittedProvisional/Immutable; rejected because state/pattern is not valid for a live marker");
             }
 
@@ -268,12 +275,11 @@ namespace Parsek
             double currentUt,
             double rewindPointUt)
         {
-            bool wouldHaveRejectedPreFix = IsFinite(currentUt) && invokedUt > currentUt;
-            return "checked=SessionId.nonEmpty,TreeId.exists,ActiveReFlyRecordingId.exists+mergeState," +
-                "OriginChildRecordingId.exists,RewindPointId.exists,InvokedUT.finite>=0<=1E+15; " +
-                $"activeState={active.MergeState} inPlace={inPlaceContinuation.ToString()} " +
+            bool legacyFutureUtCheckTriggered = IsFinite(currentUt) && invokedUt > currentUt;
+            return $"checked={AcceptedMarkerCheckPaths}; " +
+                $"activeState={active.MergeState} inPlace={inPlaceContinuation} " +
                 BuildInvokedUtComparison(invokedUt, currentUt, rewindPointUt) + " " +
-                $"prePRWouldReject={(wouldHaveRejectedPreFix ? "InvokedUT>currentUT" : "none")}";
+                $"legacyFutureUtCheck={(legacyFutureUtCheckTriggered ? "triggered" : "none")}";
         }
 
         private static string BuildInvokedUtDetails(

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -336,7 +336,7 @@ for an expected-on-startup or transient-during-soi-transition condition.
 
 ---
 
-## 577. ReFlySession marker invalidated on the `InvokedUT` field on a fresh load
+## ~~577. ReFlySession marker invalidated on the `InvokedUT` field on a fresh load~~
 
 **Source:** `logs/2026-04-25_1314_marker-validator-fix/KSP.log.cleaned` line 8889:
 
@@ -365,8 +365,25 @@ fresh start. The cause may be a stale-marker survival problem, a too-strict
 - `Source/Parsek/ReFlySessionMarker.cs` — when `InvokedUT` is allowed to be
   null/zero and when it must be non-zero.
 
-**Status:** Open. Single occurrence in this log; reproducer needs the prior
-session that authored the on-disk marker.
+**Diagnosis (2026-04-25):** `InvokedUT` is Planetarium game UT; `InvokedRealTime`
+is the wall-clock UTC timestamp. The marker was rejected because the pre-fix
+validator compared `marker.InvokedUT > CurrentUt()`: the cited fresh
+SPACECENTER load reported current UT 0 in the scenario summary, so the valid
+prior-session `invokedUT=578.13180328350882` looked like a future value even
+though the referenced RP was from the same UT neighborhood.
+
+**Fix:** `InvokedUT` validation now rejects only corrupt values (NaN/Infinity,
+negative, or above the `1E+15` sanity ceiling); current UT is diagnostic-only
+and accept logs call out `prePRWouldReject=InvokedUT>currentUT` when the old rule
+would have wiped the marker. Load-time marker accept/reject logs include the
+six durable fields plus the specific validation details, including `currentUT`,
+`rpUT`, and deltas for `InvokedUT`. Regressions:
+`MarkerValid_PriorSessionInvokedUtAfterFreshLoadUt_PreservedAndLogged`,
+`MarkerInvalid_InvokedUtNaN_ClearedWithDiagnostic`,
+`MarkerInvalid_InvokedUtNegative_ClearedWithDiagnostic`, and
+`MarkerInvalid_InvokedUtExtremeFuture_ClearedWithDiagnostic`.
+
+**Status:** CLOSED 2026-04-25. Fixed for v0.8.3.
 
 ---
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -374,7 +374,7 @@ though the referenced RP was from the same UT neighborhood.
 
 **Fix:** `InvokedUT` validation now rejects only corrupt values (NaN/Infinity,
 negative, or above the `1E+15` sanity ceiling); current UT is diagnostic-only
-and accept logs call out `prePRWouldReject=InvokedUT>currentUT` when the old rule
+and accept logs call out `legacyFutureUtCheck=triggered` when the old rule
 would have wiped the marker. Load-time marker accept/reject logs include the
 six durable fields plus the specific validation details, including `currentUT`,
 `rpUT`, and deltas for `InvokedUT`. Regressions:


### PR DESCRIPTION
Summary: Treat current UT as diagnostic-only for InvokedUT validation because fresh loads can report UT 0; keep corrupt InvokedUT rejection for NaN/Infinity, negative, and >1E+15; add detailed marker accept/reject diagnostics; close #577 docs and add the 0.8.3 changelog entry. Tests: dotnet build Source\Parsek\Parsek.csproj; dotnet test Source\Parsek.Tests\Parsek.Tests.csproj (8652 passed). Deployed DLL hash matched build output: SHA256 34416A89B79F28BD5FE6DC5C193335FCC7F20053E0547FEFF3201C66D639531D.