### PR TITLE
Track #583: Relative-frame state-vector ghost creation gap

### DIFF
--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -620,6 +620,77 @@ being addressed by the sibling
 
 ---
 
+## 583. Map-view state-vector ghost creation still skips when activation first lands inside a Relative-frame section
+
+**Source:** PR #547 review follow-up — out-of-scope note attached to the
+P1 fix that landed in commit `57aec636` on
+`fix/ghostmap-state-vector-relative-frame`. Distinct from PR #547's P1
+review item ("flight-scene update path thresholds dz as altitude") which
+covered the *"ghost already exists, then enters Relative section"* case.
+
+**Concern:** the create / pending-create resolver path still treats a
+Relative-frame current UT as "no map-visible source" and returns
+`TrackingStationGhostSource.None`. After the PR #547 P1 follow-up, an
+existing map ghost survives a Relative section and stays attached to its
+anchor through `UpdateGhostOrbitFromStateVectors`'s Relative branch. But
+the symmetric "no ghost exists yet, and the first map-visible source is
+inside a Relative section" case still produces missing map presence —
+the resolver never picks `StateVector` for a Relative-frame point, so
+`CreateGhostVesselFromStateVectors` (which already has a working
+Relative branch since PR #547) never gets called for that path.
+
+This is a missing-ghost defect, not a wrong-position one — the PR #547
+latent fix already prevents the icon-deep-inside-planet outcome for
+ghosts that get created. Likeliest player-visible scenario: a docking /
+rendezvous recording whose first map-visible UT is inside the
+docking-relative section never gets a map vessel until the trajectory
+crosses out of the Relative section (e.g., undock + re-enter Absolute or
+OrbitalCheckpoint frame).
+
+**Files to investigate:**
+
+- `Source/Parsek/GhostMapPresence.cs` — `ResolveMapPresenceGhostSource`
+  (line 1619). Specifically the `if (!traj.HasOrbitSegments)` branch
+  around line 1741 that gates state-vector resolution: a Relative-frame
+  current UT short-circuits there because the trajectory may have
+  OrbitalCheckpoint segments elsewhere. Decide whether to: (a) extend
+  the state-vector branch to fire when the current UT is in a Relative
+  section regardless of `HasOrbitSegments`, gated on anchor-resolvability;
+  or (b) introduce a new `TrackingStationGhostSource.Relative` source
+  kind that flows through to `CreateGhostVesselFromStateVectors`'s
+  existing Relative branch.
+- `Source/Parsek/ParsekPlaybackPolicy.cs:795-870` — `CheckPendingMapVessels`
+  pending-create flow. Whatever the resolver returns must dispatch
+  cleanly through `CreateGhostVesselFromSource`.
+- `Source/Parsek/GhostMapPresence.cs:2861` —
+  `CreateGhostVesselFromStateVectors`. Already dispatches on
+  `referenceFrame` (PR #547). Verify it handles the "anchor unresolvable
+  at create-time" case sensibly (defer? skip with VERBOSE? warn?).
+
+**Design questions to answer in the implementing PR:**
+
+- When the anchor vessel for a Relative-frame point is not resolvable
+  at create-time (e.g., anchor not yet in `FlightGlobals.Vessels`), what
+  should happen? Re-defer until the next tick? Skip silently? Skip with
+  WARN? Fall back to terminal-orbit if available?
+- If the recording is mid-section and the anchor disappears mid-flight
+  (vessel destroyed), should the existing ghost stay parked at last
+  known position, or be removed? Today
+  `UpdateGhostOrbitFromStateVectors`'s Relative branch presumably
+  already handles this — the create-side decision needs to match.
+
+**Coordination note:** ship after PR #547 merges. The CHANGELOG entry
+for #582 already says "ghost that traverses a Relative-frame
+docking/rendezvous segment stays attached to its anchor vessel" (an
+"existing-ghost" claim, not an "all map creation" claim), so it does
+not overclaim relative to the resolver gap left here.
+
+**Status:** Open. Not a regression of any shipped fix; a known remaining
+edge case that was deliberately left out of the PR #547 review-follow-up
+to keep that commit scoped.
+
+---
+
 ## ~~570. Warp-deferred survivor spawn stayed queued outside the active vessel's physics bubble~~
 
 **Source:** `logs/2026-04-25_1314_marker-validator-fix/KSP.log`. Recording #15


### PR DESCRIPTION
## Summary

Doc-only follow-up to PR #547. Adds entry **#583** to `docs/dev/todo-and-known-bugs.md` capturing the out-of-scope edge case left open by PR #547's reviewed P1 fix.

## Context

PR #547's P1 review fix (commit `57aec636`) closed the *"ghost already exists, then enters a Relative-frame section"* case — the flight-scene state-vector update path now bypasses the dz-as-altitude threshold for Relative frames so the ghost survives and stays attached to its anchor.

The symmetric *"no ghost exists yet, and the first map-visible source is inside a Relative section"* case is still open: `ResolveMapPresenceGhostSource` short-circuits to `None` for Relative-frame current UTs, so `CreateGhostVesselFromStateVectors`'s already-Relative-aware branch never fires for that path.

This is a **missing-map-presence** defect, not a wrong-position one — it does not regress any shipped fix.

## Test plan

- [x] `git diff` shows only `docs/dev/todo-and-known-bugs.md` changed.
- [x] Entry numbered `#583` with `Source / Concern / Files to investigate / Design questions / Coordination note / Status: Open`.
- [x] CHANGELOG #582 wording confirmed not overclaiming — uses *"ghost that traverses a Relative-frame docking/rendezvous segment stays attached"* (existing-ghost language), not *"all state-vector ghosts honour Relative frame"*.
- [ ] Reviewer: confirm the deferred-vs-skip-vs-WARN design question is captured fully.