### PR TITLE
Refactor-4 pass 2 SidecarFileCommitBatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to Parsek are documented here.
 - Phase 12 — Revert-during-re-fly dialog (Retry from Rewind Point / Discard Re-fly / Continue Flying) intercepts both `FlightDriver.RevertToLaunch` and `FlightDriver.RevertToPrelaunch` while a session is active. Discard Re-fly is session-scoped: it removes only the current attempt's provisional recording, promotes the origin RP to persistent, reloads the RP quicksave, and transitions to the Space Center (Launch) or VAB/SPH (Prelaunch) — other RPs, supersede relations, and tombstones in the tree are preserved.
 - Phase 13 — load-time sweep (`LoadTimeSweep.Run`): validates marker's six durable fields, discards zombie NotCommitted provisionals + session-provisional RPs, warns on orphan supersede/tombstone rows.
 - Phase 14 — polish + pre-release prep: disk-usage diagnostics line in Settings; rename persists + hide warns on Unfinished Flight rows; dialog copy polish (Merge + ReFlyRevert).
+- Continued refactor-4 (Pass 2) with a behavior-neutral `SidecarFileCommitBatch` extraction: staged sidecar write/delete commit, rollback, and artifact cleanup now live in a focused helper while preserving the `[RecordingStore]` log tag, per-step rollback semantics from `#366`, sidecar epoch ordering, and `FilesDirty` mutation order.
 
 ### Enhancements
 

--- a/Source/Parsek.Tests/RecordingStorageRoundTripTests.cs
+++ b/Source/Parsek.Tests/RecordingStorageRoundTripTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
-using System.Reflection;
 using Parsek.Tests.Generators;
 using UnityEngine;
 using Xunit;
@@ -1304,12 +1303,15 @@ namespace Parsek.Tests
             File.WriteAllText(stagedBlockedPath, "staged trajectory");
             Directory.CreateDirectory(blockedPath);
 
-            TargetInvocationException ex = Assert.Throws<TargetInvocationException>(
-                () => InvokeApplyStagedSidecarChangesForTesting(
-                    CreateStagedDeleteChangeForTesting(ghostPath),
-                    CreateStagedWriteChangeForTesting(blockedPath, stagedBlockedPath)));
+            Assert.ThrowsAny<Exception>(
+                () => SidecarFileCommitBatch.Apply(
+                    new List<SidecarFileCommitBatch.StagedChange>
+                    {
+                        CreateStagedDeleteChangeForTesting(ghostPath),
+                        CreateStagedWriteChangeForTesting(blockedPath, stagedBlockedPath)
+                    },
+                    () => RecordingStore.SuppressLogging));
 
-            Assert.NotNull(ex.InnerException);
             Assert.True(File.Exists(ghostPath));
             Assert.Equal("original ghost snapshot", File.ReadAllText(ghostPath));
             Assert.True(Directory.Exists(blockedPath));
@@ -1790,45 +1792,23 @@ namespace Parsek.Tests
             Assert.DoesNotContain(files, f => RecordingStore.IsTransientSidecarArtifactFile(Path.GetFileName(f)));
         }
 
-        private static object CreateStagedDeleteChangeForTesting(string finalPath)
+        private static SidecarFileCommitBatch.StagedChange CreateStagedDeleteChangeForTesting(string finalPath)
         {
-            Type stagedType = GetStagedSidecarChangeType();
-            object change = Activator.CreateInstance(stagedType, nonPublic: true);
-            stagedType.GetField("FinalPath").SetValue(change, finalPath);
-            stagedType.GetField("DeleteExisting").SetValue(change, true);
-            return change;
+            return new SidecarFileCommitBatch.StagedChange
+            {
+                FinalPath = finalPath,
+                DeleteExisting = true
+            };
         }
 
-        private static object CreateStagedWriteChangeForTesting(string finalPath, string stagedPath)
+        private static SidecarFileCommitBatch.StagedChange CreateStagedWriteChangeForTesting(string finalPath, string stagedPath)
         {
-            Type stagedType = GetStagedSidecarChangeType();
-            object change = Activator.CreateInstance(stagedType, nonPublic: true);
-            stagedType.GetField("FinalPath").SetValue(change, finalPath);
-            stagedType.GetField("StagedPath").SetValue(change, stagedPath);
-            stagedType.GetField("DeleteExisting").SetValue(change, false);
-            return change;
-        }
-
-        private static void InvokeApplyStagedSidecarChangesForTesting(params object[] changes)
-        {
-            Type stagedType = GetStagedSidecarChangeType();
-            Type listType = typeof(List<>).MakeGenericType(stagedType);
-            object list = Activator.CreateInstance(listType);
-            MethodInfo addMethod = listType.GetMethod("Add");
-            for (int i = 0; i < changes.Length; i++)
-                addMethod.Invoke(list, new[] { changes[i] });
-
-            MethodInfo applyMethod = typeof(RecordingStore).GetMethod(
-                "ApplyStagedSidecarChanges",
-                BindingFlags.Static | BindingFlags.NonPublic);
-            applyMethod.Invoke(null, new[] { list });
-        }
-
-        private static Type GetStagedSidecarChangeType()
-        {
-            return typeof(RecordingStore).GetNestedType(
-                "StagedSidecarChange",
-                BindingFlags.NonPublic);
+            return new SidecarFileCommitBatch.StagedChange
+            {
+                FinalPath = finalPath,
+                StagedPath = stagedPath,
+                DeleteExisting = false
+            };
         }
 
         // -----------------------------------------------------------------------

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -6154,21 +6154,6 @@ namespace Parsek
             public string FailureReason;
         }
 
-        private sealed class StagedSidecarChange
-        {
-            public string FinalPath;
-            public string StagedPath;
-            public bool DeleteExisting;
-        }
-
-        private sealed class CommittedSidecarChange
-        {
-            public StagedSidecarChange Change;
-            public bool HadOriginalFile;
-            public bool Committed;
-            public string BackupPath;
-        }
-
         internal static bool TryProbeSnapshotSidecar(string path, out SnapshotSidecarProbe probe)
         {
             probe = default(SnapshotSidecarProbe);
@@ -6443,7 +6428,7 @@ namespace Parsek
             bool wroteVesselSnapshot = false;
             bool wroteGhostSnapshot = false;
             bool deletedStaleGhostSnapshot = false;
-            var changes = new List<StagedSidecarChange>();
+            var changes = new List<SidecarFileCommitBatch.StagedChange>();
 
             try
             {
@@ -6457,11 +6442,11 @@ namespace Parsek
                 if (incrementEpoch)
                     rec.SidecarEpoch++;
 
-                changes.Add(StageSidecarWrite(path => WriteTrajectorySidecar(path, rec, rec.SidecarEpoch), precPath));
+                changes.Add(SidecarFileCommitBatch.StageWrite(path => WriteTrajectorySidecar(path, rec, rec.SidecarEpoch), precPath));
 
                 if (rec.VesselSnapshot != null)
                 {
-                    changes.Add(StageSidecarWrite(path => WriteSnapshotSidecar(path, rec.VesselSnapshot), vesselPath));
+                    changes.Add(SidecarFileCommitBatch.StageWrite(path => WriteSnapshotSidecar(path, rec.VesselSnapshot), vesselPath));
                     wroteVesselSnapshot = true;
                 }
 
@@ -6473,7 +6458,7 @@ namespace Parsek
                     }
                     else
                     {
-                        changes.Add(StageSidecarWrite(path => WriteSnapshotSidecar(path, rec.GhostVisualSnapshot), ghostPath));
+                        changes.Add(SidecarFileCommitBatch.StageWrite(path => WriteSnapshotSidecar(path, rec.GhostVisualSnapshot), ghostPath));
                         wroteGhostSnapshot = true;
                     }
                 }
@@ -6481,7 +6466,7 @@ namespace Parsek
                     !string.IsNullOrEmpty(ghostPath) &&
                     File.Exists(ghostPath))
                 {
-                    changes.Add(new StagedSidecarChange
+                    changes.Add(new SidecarFileCommitBatch.StagedChange
                     {
                         FinalPath = ghostPath,
                         DeleteExisting = true
@@ -6489,7 +6474,7 @@ namespace Parsek
                     deletedStaleGhostSnapshot = true;
                 }
 
-                ApplyStagedSidecarChanges(changes);
+                SidecarFileCommitBatch.Apply(changes, () => SuppressLogging);
 
                 ReadableMirrorReconcileSummary mirrorSummary =
                     ReconcileReadableSidecarMirrors(rec, precPath, vesselPath, ghostPath, ghostSnapshotMode);
@@ -6525,7 +6510,7 @@ namespace Parsek
             }
             catch (Exception ex)
             {
-                CleanupStagedSidecarArtifacts(changes, committed: null);
+                SidecarFileCommitBatch.CleanupStagedArtifacts(changes);
                 // Keep .sfs metadata authoritative if the sidecar write set did not
                 // complete after an OnSave-triggered epoch bump.
                 rec.SidecarEpoch = originalSidecarEpoch;
@@ -6542,7 +6527,7 @@ namespace Parsek
             {
                 Enabled = ShouldWriteReadableSidecarMirrors()
             };
-            var changes = new List<StagedSidecarChange>();
+            var changes = new List<SidecarFileCommitBatch.StagedChange>();
             bool wroteTrajectory = false;
             bool wroteVessel = false;
             bool wroteGhost = false;
@@ -6558,14 +6543,14 @@ namespace Parsek
             {
                 if (summary.Enabled)
                 {
-                    changes.Add(StageSidecarWrite(
+                    changes.Add(SidecarFileCommitBatch.StageWrite(
                         path => WriteReadableTrajectoryMirror(path, rec, rec.SidecarEpoch),
                         readablePrecPath));
                     wroteTrajectory = true;
 
                     if (rec.VesselSnapshot != null)
                     {
-                        changes.Add(StageSidecarWrite(
+                        changes.Add(SidecarFileCommitBatch.StageWrite(
                             path => WriteReadableSnapshotMirror(path, rec.VesselSnapshot),
                             readableVesselPath));
                         wroteVessel = true;
@@ -6576,7 +6561,7 @@ namespace Parsek
                         ConfigNode preservedVesselSnapshot = LoadSnapshotSidecarForReadableMirror(vesselPath);
                         if (preservedVesselSnapshot != null)
                         {
-                            changes.Add(StageSidecarWrite(
+                            changes.Add(SidecarFileCommitBatch.StageWrite(
                                 path => WriteReadableSnapshotMirror(path, preservedVesselSnapshot),
                                 readableVesselPath));
                             wroteVessel = true;
@@ -6586,7 +6571,7 @@ namespace Parsek
 
                     if (ghostSnapshotMode == GhostSnapshotMode.Separate && rec.GhostVisualSnapshot != null)
                     {
-                        changes.Add(StageSidecarWrite(
+                        changes.Add(SidecarFileCommitBatch.StageWrite(
                             path => WriteReadableSnapshotMirror(path, rec.GhostVisualSnapshot),
                             readableGhostPath));
                         wroteGhost = true;
@@ -6596,7 +6581,7 @@ namespace Parsek
                              !string.IsNullOrEmpty(readableGhostPath) &&
                              File.Exists(readableGhostPath))
                     {
-                        changes.Add(new StagedSidecarChange
+                        changes.Add(new SidecarFileCommitBatch.StagedChange
                         {
                             FinalPath = readableGhostPath,
                             DeleteExisting = true
@@ -6608,7 +6593,7 @@ namespace Parsek
                 {
                     if (!string.IsNullOrEmpty(readablePrecPath) && File.Exists(readablePrecPath))
                     {
-                        changes.Add(new StagedSidecarChange
+                        changes.Add(new SidecarFileCommitBatch.StagedChange
                         {
                             FinalPath = readablePrecPath,
                             DeleteExisting = true
@@ -6618,7 +6603,7 @@ namespace Parsek
 
                     if (!string.IsNullOrEmpty(readableVesselPath) && File.Exists(readableVesselPath))
                     {
-                        changes.Add(new StagedSidecarChange
+                        changes.Add(new SidecarFileCommitBatch.StagedChange
                         {
                             FinalPath = readableVesselPath,
                             DeleteExisting = true
@@ -6628,7 +6613,7 @@ namespace Parsek
 
                     if (!string.IsNullOrEmpty(readableGhostPath) && File.Exists(readableGhostPath))
                     {
-                        changes.Add(new StagedSidecarChange
+                        changes.Add(new SidecarFileCommitBatch.StagedChange
                         {
                             FinalPath = readableGhostPath,
                             DeleteExisting = true
@@ -6637,7 +6622,7 @@ namespace Parsek
                     }
                 }
 
-                ApplyStagedSidecarChanges(changes);
+                SidecarFileCommitBatch.Apply(changes, () => SuppressLogging);
                 summary.WroteTrajectory = wroteTrajectory;
                 summary.WroteVessel = wroteVessel;
                 summary.WroteGhost = wroteGhost;
@@ -6647,7 +6632,7 @@ namespace Parsek
             }
             catch (Exception ex)
             {
-                CleanupStagedSidecarArtifacts(changes, committed: null);
+                SidecarFileCommitBatch.CleanupStagedArtifacts(changes);
                 InvalidateReadableMirrorFinalFiles(changes);
                 summary.Failed = true;
                 summary.FailureReason = ex.Message;
@@ -6664,7 +6649,7 @@ namespace Parsek
             return summary;
         }
 
-        private static void InvalidateReadableMirrorFinalFiles(IEnumerable<StagedSidecarChange> changes)
+        private static void InvalidateReadableMirrorFinalFiles(IEnumerable<SidecarFileCommitBatch.StagedChange> changes)
         {
             if (changes == null)
                 return;
@@ -6842,184 +6827,6 @@ namespace Parsek
             }
 
             return null;
-        }
-
-        private static StagedSidecarChange StageSidecarWrite(Action<string> writer, string finalPath)
-        {
-            if (writer == null)
-                throw new ArgumentNullException(nameof(writer));
-            if (string.IsNullOrEmpty(finalPath))
-                throw new ArgumentException("Final path is required.", nameof(finalPath));
-
-            string dir = Path.GetDirectoryName(finalPath);
-            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
-                Directory.CreateDirectory(dir);
-
-            string stagedPath = finalPath + ".stage." + Guid.NewGuid().ToString("N");
-            try
-            {
-                writer(stagedPath);
-            }
-            catch
-            {
-                DeleteTransientSidecarArtifact(stagedPath);
-                DeleteTransientSidecarArtifact(stagedPath + ".tmp");
-                throw;
-            }
-
-            return new StagedSidecarChange
-            {
-                FinalPath = finalPath,
-                StagedPath = stagedPath,
-                DeleteExisting = false
-            };
-        }
-
-        private static void ApplyStagedSidecarChanges(List<StagedSidecarChange> changes)
-        {
-            if (changes == null || changes.Count == 0)
-                return;
-
-            var committed = new List<CommittedSidecarChange>(changes.Count);
-            try
-            {
-                for (int i = 0; i < changes.Count; i++)
-                {
-                    StagedSidecarChange change = changes[i];
-                    var state = new CommittedSidecarChange
-                    {
-                        Change = change,
-                        HadOriginalFile = !string.IsNullOrEmpty(change.FinalPath) && File.Exists(change.FinalPath),
-                        BackupPath = string.IsNullOrEmpty(change.FinalPath)
-                            ? null
-                            : change.FinalPath + ".bak." + Guid.NewGuid().ToString("N")
-                    };
-
-                    if (change.DeleteExisting)
-                    {
-                        if (state.HadOriginalFile)
-                        {
-                            File.Move(change.FinalPath, state.BackupPath);
-                            state.Committed = true;
-                        }
-                    }
-                    else if (!string.IsNullOrEmpty(change.StagedPath))
-                    {
-                        if (state.HadOriginalFile)
-                            File.Replace(change.StagedPath, change.FinalPath, state.BackupPath, true);
-                        else
-                            File.Move(change.StagedPath, change.FinalPath);
-
-                        state.Committed = true;
-                    }
-
-                    committed.Add(state);
-                }
-            }
-            catch
-            {
-                // #366: per-step try/catch so a rollback failure on one file
-                // (e.g. backup deleted by external process or disk full mid-restore)
-                // doesn't abort the remaining rollback. Atomicity is best-effort
-                // across multiple files; the goal is to minimize remaining
-                // inconsistency rather than achieve perfect rollback.
-                for (int i = committed.Count - 1; i >= 0; i--)
-                {
-                    try
-                    {
-                        RestoreCommittedSidecarChange(committed[i]);
-                    }
-                    catch (Exception rollbackEx)
-                    {
-                        if (!SuppressLogging)
-                        {
-                            string finalPath = committed[i]?.Change?.FinalPath ?? "?";
-                            ParsekLog.Warn("RecordingStore",
-                                $"ApplyStagedSidecarChanges: rollback step failed " +
-                                $"path={finalPath} " +
-                                $"ex={rollbackEx.GetType().Name}:{rollbackEx.Message}");
-                        }
-                    }
-                }
-                throw;
-            }
-            finally
-            {
-                CleanupStagedSidecarArtifacts(changes, committed: null);
-            }
-
-            CleanupCommittedSidecarBackups(committed);
-        }
-
-        private static void RestoreCommittedSidecarChange(CommittedSidecarChange state)
-        {
-            if (state == null || !state.Committed || state.Change == null || string.IsNullOrEmpty(state.Change.FinalPath))
-                return;
-
-            if (state.Change.DeleteExisting)
-            {
-                if (!state.HadOriginalFile || string.IsNullOrEmpty(state.BackupPath) || !File.Exists(state.BackupPath))
-                    return;
-
-                if (File.Exists(state.Change.FinalPath))
-                    File.Delete(state.Change.FinalPath);
-
-                File.Move(state.BackupPath, state.Change.FinalPath);
-                return;
-            }
-
-            if (state.HadOriginalFile)
-            {
-                if (string.IsNullOrEmpty(state.BackupPath) || !File.Exists(state.BackupPath))
-                    return;
-
-                if (File.Exists(state.Change.FinalPath))
-                    File.Replace(state.BackupPath, state.Change.FinalPath, null, true);
-                else
-                    File.Move(state.BackupPath, state.Change.FinalPath);
-                return;
-            }
-
-            if (File.Exists(state.Change.FinalPath))
-                File.Delete(state.Change.FinalPath);
-        }
-
-        private static void CleanupStagedSidecarArtifacts(
-            List<StagedSidecarChange> changes, List<CommittedSidecarChange> committed)
-        {
-            if (changes != null)
-            {
-                for (int i = 0; i < changes.Count; i++)
-                {
-                    string stagedPath = changes[i]?.StagedPath;
-                    DeleteTransientSidecarArtifact(stagedPath);
-                    DeleteTransientSidecarArtifact(
-                        string.IsNullOrEmpty(stagedPath) ? null : stagedPath + ".tmp");
-                }
-            }
-
-            if (committed != null)
-            {
-                for (int i = 0; i < committed.Count; i++)
-                {
-                    string backupPath = committed[i]?.BackupPath;
-                    DeleteTransientSidecarArtifact(backupPath);
-                }
-            }
-        }
-
-        private static void CleanupCommittedSidecarBackups(List<CommittedSidecarChange> committed)
-        {
-            CleanupStagedSidecarArtifacts(changes: null, committed: committed);
-        }
-
-        private static void DeleteTransientSidecarArtifact(string path)
-        {
-            if (string.IsNullOrEmpty(path) || !File.Exists(path))
-                return;
-
-            try { File.Delete(path); }
-            catch { }
         }
 
         #endregion

--- a/Source/Parsek/SidecarFileCommitBatch.cs
+++ b/Source/Parsek/SidecarFileCommitBatch.cs
@@ -1,0 +1,206 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Parsek
+{
+    internal static class SidecarFileCommitBatch
+    {
+        internal sealed class StagedChange
+        {
+            public string FinalPath;
+            public string StagedPath;
+            public bool DeleteExisting;
+        }
+
+        private sealed class CommittedChange
+        {
+            public StagedChange Change;
+            public bool HadOriginalFile;
+            public bool Committed;
+            public string BackupPath;
+        }
+
+        internal static StagedChange StageWrite(Action<string> writer, string finalPath)
+        {
+            if (writer == null)
+                throw new ArgumentNullException(nameof(writer));
+            if (string.IsNullOrEmpty(finalPath))
+                throw new ArgumentException("Final path is required.", nameof(finalPath));
+
+            string dir = Path.GetDirectoryName(finalPath);
+            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+                Directory.CreateDirectory(dir);
+
+            string stagedPath = finalPath + ".stage." + Guid.NewGuid().ToString("N");
+            try
+            {
+                writer(stagedPath);
+            }
+            catch
+            {
+                DeleteTransientArtifact(stagedPath);
+                DeleteTransientArtifact(stagedPath + ".tmp");
+                throw;
+            }
+
+            return new StagedChange
+            {
+                FinalPath = finalPath,
+                StagedPath = stagedPath,
+                DeleteExisting = false
+            };
+        }
+
+        internal static void Apply(List<StagedChange> changes, Func<bool> suppressLogging)
+        {
+            if (changes == null || changes.Count == 0)
+                return;
+
+            var committed = new List<CommittedChange>(changes.Count);
+            try
+            {
+                for (int i = 0; i < changes.Count; i++)
+                {
+                    StagedChange change = changes[i];
+                    var state = new CommittedChange
+                    {
+                        Change = change,
+                        HadOriginalFile = !string.IsNullOrEmpty(change.FinalPath) && File.Exists(change.FinalPath),
+                        BackupPath = string.IsNullOrEmpty(change.FinalPath)
+                            ? null
+                            : change.FinalPath + ".bak." + Guid.NewGuid().ToString("N")
+                    };
+
+                    if (change.DeleteExisting)
+                    {
+                        if (state.HadOriginalFile)
+                        {
+                            File.Move(change.FinalPath, state.BackupPath);
+                            state.Committed = true;
+                        }
+                    }
+                    else if (!string.IsNullOrEmpty(change.StagedPath))
+                    {
+                        if (state.HadOriginalFile)
+                            File.Replace(change.StagedPath, change.FinalPath, state.BackupPath, true);
+                        else
+                            File.Move(change.StagedPath, change.FinalPath);
+
+                        state.Committed = true;
+                    }
+
+                    committed.Add(state);
+                }
+            }
+            catch
+            {
+                // #366: per-step try/catch so a rollback failure on one file
+                // (e.g. backup deleted by external process or disk full mid-restore)
+                // doesn't abort the remaining rollback. Atomicity is best-effort
+                // across multiple files; the goal is to minimize remaining
+                // inconsistency rather than achieve perfect rollback.
+                for (int i = committed.Count - 1; i >= 0; i--)
+                {
+                    try
+                    {
+                        RestoreCommittedChange(committed[i]);
+                    }
+                    catch (Exception rollbackEx)
+                    {
+                        if (suppressLogging == null || !suppressLogging())
+                        {
+                            string finalPath = committed[i]?.Change?.FinalPath ?? "?";
+                            ParsekLog.Warn("RecordingStore",
+                                $"ApplyStagedSidecarChanges: rollback step failed " +
+                                $"path={finalPath} " +
+                                $"ex={rollbackEx.GetType().Name}:{rollbackEx.Message}");
+                        }
+                    }
+                }
+                throw;
+            }
+            finally
+            {
+                CleanupArtifacts(changes, committed: null);
+            }
+
+            CleanupCommittedBackups(committed);
+        }
+
+        internal static void CleanupStagedArtifacts(List<StagedChange> changes)
+        {
+            CleanupArtifacts(changes, committed: null);
+        }
+
+        private static void RestoreCommittedChange(CommittedChange state)
+        {
+            if (state == null || !state.Committed || state.Change == null || string.IsNullOrEmpty(state.Change.FinalPath))
+                return;
+
+            if (state.Change.DeleteExisting)
+            {
+                if (!state.HadOriginalFile || string.IsNullOrEmpty(state.BackupPath) || !File.Exists(state.BackupPath))
+                    return;
+
+                if (File.Exists(state.Change.FinalPath))
+                    File.Delete(state.Change.FinalPath);
+
+                File.Move(state.BackupPath, state.Change.FinalPath);
+                return;
+            }
+
+            if (state.HadOriginalFile)
+            {
+                if (string.IsNullOrEmpty(state.BackupPath) || !File.Exists(state.BackupPath))
+                    return;
+
+                if (File.Exists(state.Change.FinalPath))
+                    File.Replace(state.BackupPath, state.Change.FinalPath, null, true);
+                else
+                    File.Move(state.BackupPath, state.Change.FinalPath);
+                return;
+            }
+
+            if (File.Exists(state.Change.FinalPath))
+                File.Delete(state.Change.FinalPath);
+        }
+
+        private static void CleanupArtifacts(List<StagedChange> changes, List<CommittedChange> committed)
+        {
+            if (changes != null)
+            {
+                for (int i = 0; i < changes.Count; i++)
+                {
+                    string stagedPath = changes[i]?.StagedPath;
+                    DeleteTransientArtifact(stagedPath);
+                    DeleteTransientArtifact(
+                        string.IsNullOrEmpty(stagedPath) ? null : stagedPath + ".tmp");
+                }
+            }
+
+            if (committed != null)
+            {
+                for (int i = 0; i < committed.Count; i++)
+                {
+                    string backupPath = committed[i]?.BackupPath;
+                    DeleteTransientArtifact(backupPath);
+                }
+            }
+        }
+
+        private static void CleanupCommittedBackups(List<CommittedChange> committed)
+        {
+            CleanupArtifacts(changes: null, committed: committed);
+        }
+
+        private static void DeleteTransientArtifact(string path)
+        {
+            if (string.IsNullOrEmpty(path) || !File.Exists(path))
+                return;
+
+            try { File.Delete(path); }
+            catch { }
+        }
+    }
+}

--- a/docs/dev/plans/refactor-4-inventory.md
+++ b/docs/dev/plans/refactor-4-inventory.md
@@ -44,7 +44,7 @@ locked KSP process/log condition above; the build itself succeeds.
 | `Source/Parsek/ParsekFlight.cs` | 14,503 | Pass1-Done; post-switch auto-record trigger helpers extracted, finalization deferred |
 | `Source/Parsek/GhostVisualBuilder.cs` | 7,193 | Pass1-Deferred; visual-builder split needs owner plan and runtime validation |
 | `Source/Parsek/GameActions/LedgerOrchestrator.cs` | 6,976 | Pass1-Done; earnings-window, vessel-cost, and recalculation helpers extracted |
-| `Source/Parsek/RecordingStore.cs` | 6,902 | Pass1-Done; optimization and rewind helpers extracted |
+| `Source/Parsek/RecordingStore.cs` | 6,834 | Pass2-Done for `SidecarFileCommitBatch`; Pass1-Done for optimization and rewind helpers; remaining sidecar orchestration deferred |
 | `Source/Parsek/FlightRecorder.cs` | 6,689 | Pass1-Done; visual coverage logging helpers extracted |
 | `Source/Parsek/GhostPlaybackLogic.cs` | 5,343 | Pass1-Done; ghost info population and part-event helpers extracted |
 | `Source/Parsek/UI/RecordingsTableUI.cs` | 4,868 | Pass1-Deferred; high-coupling IMGUI row/tree split deferred |
@@ -71,7 +71,7 @@ These deltas compare files that also existed in
 |------|------------------|---------------|-------|
 | `LedgerOrchestrator.cs` | 900 | 6,976 | +6,076 |
 | `ParsekFlight.cs` | 8,765 | 14,503 | +5,738 |
-| `RecordingStore.cs` | 2,958 | 6,902 | +3,944 |
+| `RecordingStore.cs` | 2,958 | 6,834 | +3,876 |
 | `GhostPlaybackLogic.cs` | 2,589 | 5,343 | +2,754 |
 | `VesselSpawner.cs` | 1,473 | 4,166 | +2,693 |
 | `GhostPlaybackEngine.cs` | 1,770 | 4,312 | +2,542 |
@@ -141,7 +141,7 @@ central enough that parallel edits would make review and rollback worse.
 |------|--------|
 | `ParsekFlight.cs` | 14.5k-line scene controller, +5.7k since refactor-3 |
 | `LedgerOrchestrator.cs` | 7.0k-line GameActions hub, +6.1k since refactor-3 |
-| `RecordingStore.cs` | 6.9k-line storage surface, +3.9k since refactor-3 |
+| `RecordingStore.cs` | 6.8k-line storage surface, +3.9k since refactor-3; Pass 2 sidecar commit batch extracted |
 | `FlightRecorder.cs` | 6.7k-line sampling/event surface |
 | `GhostPlaybackLogic.cs` | 5.3k-line playback/visual logic helper |
 | `UI/RecordingsTableUI.cs` | 4.9k-line extracted UI surface with prior coupling risk |
@@ -451,19 +451,27 @@ Pass 1 completed:
   temp save copy/preprocess, load-game invocation, adjusted-UT capture, scene
   load, and failure cleanup behavior remain unchanged.
 
+Pass 2 first slice completed:
+
+- Extracted `SidecarFileCommitBatch` into `Source/Parsek/SidecarFileCommitBatch.cs`
+  for staged sidecar write/delete commits, rollback, and artifact cleanup.
+  `RecordingStore` still owns save/load orchestration, sidecar epoch ownership
+  and mutation order, `FilesDirty`, readable mirrors, snapshot policy, and codec
+  dispatch.
+
 Validation:
 
 - `dotnet build Source/Parsek/Parsek.csproj`
 - `dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter "FullyQualifiedName~RecordingOptimizerTests|FullyQualifiedName~RecordingStoreTests|FullyQualifiedName~LegacyTreeMigrationTests|FullyQualifiedName~RewindLoggingTests"`
 - `dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter FullyQualifiedName!~InjectAllRecordings`
 
-Remaining sidecar mirror reconciliation work is deferred unless a later read
-finds a contiguous extraction that preserves file ordering and exception
-handling exactly.
+Remaining sidecar orchestration and codec work follows the Pass 2 owner plan
+and remains gated on preserving file ordering, exception handling, sidecar epoch
+ordering, and `FilesDirty` mutation order exactly.
 
-Pass 2 discussion only: storage codec/sidecar deduplication, recording tree
-I/O ownership, and rewind service ownership. Initial storage/sidecar owner
-proposal: `docs/dev/plans/refactor-4-pass2-storage-sidecars.md`.
+Pass 2 storage/sidecar owner proposal:
+`docs/dev/plans/refactor-4-pass2-storage-sidecars.md`. Rewind service
+ownership remains discussion-only.
 
 ### `Source/Parsek/FlightRecorder.cs`
 
@@ -902,6 +910,7 @@ semantic, architectural, runtime-visual, math-sensitive, or UI-order-sensitive.
 | `ParsekFlight.cs` | Done for post-switch auto-record; finalization split deferred to Pass 2. |
 | `FlightRecorder.cs` | Done for visual coverage logging; remaining part-event poller work deferred. |
 | `GhostPlaybackLogic.cs` | Done for dictionary population and part events; remaining spawn policy cleanup deferred. |
+| `RecordingStore.cs` | Pass 2 first slice done for `SidecarFileCommitBatch`; save/load orchestration, codecs, grouping, optimization, deletion, and rewind wrappers remain with `RecordingStore` until separately approved. |
 | `GameStateRecorder.cs` | Deferred; resource/milestone/facility handler families need owner map. |
 | `GameActions/KspStatePatcher.cs` | Deferred; patch-order/reflection/UI mutation paths need state-family patcher proposal. |
 | `BallisticExtrapolator.cs` | Deferred; math and iteration-order sensitive. |
@@ -946,8 +955,10 @@ raw scan with a manual map for the high-risk owners:
    sidecar helpers for repeated binary/text serialization patterns before any
    deduplication. Initial result: `refactor-4-pass2-storage-sidecars.md`
    recommends separate sidecar commit, sidecar orchestration, trajectory text
-   codec, manifest codec, and tree-record codec owners; it rejects schema or
-   binary/text format redesign for this refactor pass.
+   codec, manifest codec, and tree-record codec owners. The sidecar commit
+   batch slice is complete; schema redesign remains out of scope, and binary/text
+   format unification is deferred until the orchestration and manifest codec
+   owners land.
 3. Build a static mutable state map for `GameStateRecorder`,
    `LedgerOrchestrator`, `RecordingStore`, `ParsekScenario`,
    `WatchModeController`, and `GhostPlaybackEngine`.

--- a/docs/dev/plans/refactor-4-inventory.md
+++ b/docs/dev/plans/refactor-4-inventory.md
@@ -462,7 +462,8 @@ finds a contiguous extraction that preserves file ordering and exception
 handling exactly.
 
 Pass 2 discussion only: storage codec/sidecar deduplication, recording tree
-I/O ownership, and rewind service ownership.
+I/O ownership, and rewind service ownership. Initial storage/sidecar owner
+proposal: `docs/dev/plans/refactor-4-pass2-storage-sidecars.md`.
 
 ### `Source/Parsek/FlightRecorder.cs`
 
@@ -943,7 +944,10 @@ raw scan with a manual map for the high-risk owners:
    serialization codecs, and rewind invocation.
 2. Compare `RecordingStore.cs`, `TrajectorySidecarBinary.cs`, and snapshot
    sidecar helpers for repeated binary/text serialization patterns before any
-   deduplication.
+   deduplication. Initial result: `refactor-4-pass2-storage-sidecars.md`
+   recommends separate sidecar commit, sidecar orchestration, trajectory text
+   codec, manifest codec, and tree-record codec owners; it rejects schema or
+   binary/text format redesign for this refactor pass.
 3. Build a static mutable state map for `GameStateRecorder`,
    `LedgerOrchestrator`, `RecordingStore`, `ParsekScenario`,
    `WatchModeController`, and `GhostPlaybackEngine`.

--- a/docs/dev/plans/refactor-4-pass2-storage-sidecars.md
+++ b/docs/dev/plans/refactor-4-pass2-storage-sidecars.md
@@ -111,6 +111,14 @@ load sequence:
 7. load snapshot sidecars
 8. report failure without losing hydrated trajectory state
 
+Implementation should split this owner into at least two commits: save-path
+orchestration first, then load-path orchestration. Do not start this step until
+the save/load split has been reviewed again. Sidecar epoch mutation and
+`FilesDirty` assignment remain owned by the sidecar orchestration layer, not by
+the low-level codecs. During the wrapper phase, existing `RecordingStore`
+methods still expose these calls, but the mutation order must stay exactly
+where the save/load sequence currently performs it.
+
 ### 3. `TrajectoryTextSidecarCodec`
 
 Third owner. It would move text ConfigNode trajectory serialization out of
@@ -132,6 +140,10 @@ batch because many tests and generators call the current wrappers.
 Rejected for this pass: merging text and binary trajectory codecs into one new
 abstraction. The existing binary owner is cohesive; forcing a shared interface
 now would add design risk without reducing behavior risk.
+
+Revisit after `RecordingSidecarStore` and `RecordingManifestCodec` land. At
+that point a narrow `ITrajectorySidecarFormat` dispatcher may be cheaper because
+sidecar orchestration will be the only trajectory sidecar caller.
 
 ### 4. `RecordingManifestCodec`
 
@@ -163,6 +175,15 @@ This is useful, but it should wait until manifest ownership is settled because
 bridge tree metadata, manifest codecs, rewind metadata, UI grouping tags, and
 legacy merge-state migration.
 
+## RecordingStore Target State
+
+After the proposed owners land, `RecordingStore` should still own recording
+store state and store-level operations: committed and pending recordings/trees,
+grouping, tree commit/adoption, optimization, deletion/orphan cleanup, rewind
+entry points, and compatibility wrappers for older call sites. It should not own
+low-level sidecar transactions, trajectory text serialization, snapshot codec
+details, or manifest field serialization.
+
 ## Rejected In This Pass
 
 - No binary `.prec` format redesign.
@@ -180,17 +201,29 @@ legacy merge-state migration.
 1. Extract `SidecarFileCommitBatch`. This is the narrowest cross-file move and
    gives the save path a named transaction owner without changing storage
    policy.
-2. Extract `RecordingSidecarStore` behind `RecordingStore` wrappers. Keep
-   public/internal wrapper signatures stable and preserve `RecordingStore` log
-   tags unless explicitly approved otherwise.
-3. Extract `TrajectoryTextSidecarCodec`, again behind wrappers. Do not merge it
+2. Extract the save-path half of `RecordingSidecarStore` behind
+   `RecordingStore` wrappers. Keep public/internal wrapper signatures stable and
+   preserve `RecordingStore` log tags unless explicitly approved otherwise.
+3. Extract the load-path half of `RecordingSidecarStore` behind wrappers only
+   after separately reviewing sidecar epoch validation, failure flagging,
+   hydrated trajectory preservation, and snapshot fallback order.
+4. Extract `TrajectoryTextSidecarCodec`, again behind wrappers. Before this
+   step, grep `Source/Parsek.Tests/Generators/` for direct `RecordingStore`
+   codec calls so the wrapper surface is known up front. Do not merge it
    with `TrajectorySidecarBinary`.
-4. Extract `RecordingManifestCodec` behind wrappers.
-5. Re-evaluate `RecordingTreeRecordCodec` after the first four steps. Do not
+5. Extract `RecordingManifestCodec` behind wrappers.
+6. Re-evaluate `RecordingTreeRecordCodec` after the first five steps. Do not
    start it in the same PR as sidecar orchestration.
 
-Each item should be its own commit at minimum. If review risk is high, split
-items 2-5 into separate PRs.
+PR granularity:
+
+- PR 1: `SidecarFileCommitBatch` only.
+- PR 2: `RecordingSidecarStore` only, preferably save and load as separate
+  commits after an explicit pre-review of the split.
+- PR 3: `TrajectoryTextSidecarCodec` and `RecordingManifestCodec` may share a
+  PR only if manifest movement is small and wrappers keep the call surface
+  stable.
+- PR 4: `RecordingTreeRecordCodec` only.
 
 ## Validation Scope
 
@@ -242,3 +275,23 @@ Recommended next implementation, if approved: extract only
 `SidecarFileCommitBatch` first. It is the smallest architectural move with a
 clear owner boundary and the least chance of hidden save/load logic drift.
 
+## Implementation Checkpoint - SidecarFileCommitBatch
+
+Approved first slice completed in this branch:
+
+- Added `Source/Parsek/SidecarFileCommitBatch.cs`.
+- Moved only staged sidecar write/delete commit helpers out of
+  `RecordingStore`.
+- Left save/load orchestration, sidecar epoch mutation, `FilesDirty`,
+  readable mirror policy, snapshot fallback, and codec dispatch in
+  `RecordingStore`.
+- Updated the rollback test to cover `SidecarFileCommitBatch` directly instead
+  of reflecting into old private `RecordingStore` helpers.
+
+Validation:
+
+```powershell
+dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter "FullyQualifiedName~RecordingStorageRoundTripTests|FullyQualifiedName~SnapshotSidecarCodecTests|FullyQualifiedName~TrajectorySidecarBinaryTests|FullyQualifiedName~Bug270SidecarEpochTests|FullyQualifiedName~FormatVersionTests|FullyQualifiedName~TrackSectionSerializationTests|FullyQualifiedName~LoopIntervalLoadNormalizationTests|FullyQualifiedName~QuickloadResumeTests"
+dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter FullyQualifiedName!~InjectAllRecordings
+dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter FullyQualifiedName~InjectAllRecordings
+```

--- a/docs/dev/plans/refactor-4-pass2-storage-sidecars.md
+++ b/docs/dev/plans/refactor-4-pass2-storage-sidecars.md
@@ -1,0 +1,244 @@
+# Refactor-4 Pass 2 - Storage and Sidecar Owner Proposal
+
+**Date:** 2026-04-25.
+**Worktree:** `Parsek-refactor-4-pass2`, branch `refactor-4-pass2`.
+**Base:** `18574260` (`main`, after PR #545 merge).
+**Status:** Proposal only. No production code changes are approved by this
+document.
+
+## Guardrails
+
+- Zero logic changes still applies. This proposal is not approval to move code.
+- Any Pass 3 implementation must be discussed before it starts.
+- Keep on-disk schemas, binary layouts, text key names, fallback policy,
+  logging text, exception behavior, and test-facing wrappers stable unless a
+  later explicit design says otherwise.
+- `RecordingStore` should remain the compatibility facade during the first
+  implementation slice. Existing production and test call sites should not be
+  forced to move while ownership is being carved out.
+
+## Current Ownership Map
+
+| Area | Current owner | Notes |
+| --- | --- | --- |
+| Recording/tree store state | `RecordingStore` | Static committed/pending state, grouping, optimization, rewind, deletion, cleanup, and sidecar I/O live together. This is why direct cross-file movement is risky. |
+| Save/load sidecar orchestration | `RecordingStore` | `SaveRecordingFiles`, `LoadRecordingFiles`, path resolution, sidecar epoch bump/validation, readable mirror reconciliation, snapshot fallback, and staged multi-file commits are in one region. |
+| Trajectory text codec | `RecordingStore` | `SerializeTrajectoryInto`, `DeserializeTrajectoryFrom`, point/orbit/part/flag/segment/track-section text serialization, format-version gates, and flat/section fallback repair all live here. |
+| Trajectory binary codec | `TrajectorySidecarBinary` | Already a focused binary codec for `.prec` v2-v6 bytes, string tables, sparse point lists, and section payloads. It still calls back to `RecordingStore` for policy helpers and version constants. |
+| Snapshot binary/text codec | `SnapshotSidecarCodec` | Already a focused snapshot codec: binary magic/header, Deflate payload, CRC, legacy text fallback, and payload limits. `RecordingStore` wraps it for logging and snapshot-mode policy. |
+| `.sfs` recording metadata | `RecordingTree` | `SaveRecordingInto`/`LoadRecordingFrom` own recording metadata, linkage, loop settings, mutable playback state, manifests, and legacy defaulting. They call `RecordingStore` for manifest codecs and ghost snapshot mode. |
+| Paths and atomic primitive writes | `RecordingPaths`, `FileIOUtils` | These are already separate. `RecordingStore` still owns multi-file transaction staging and rollback. |
+
+## Dependency Map
+
+```text
+RecordingTree
+  -> RecordingStore.GetExpectedGhostSnapshotMode
+  -> RecordingStore.ParseGhostSnapshotMode
+  -> RecordingStore.Serialize/Deserialize*Manifest
+  -> RecordingStore.BumpLegacyMergeStateMigrationCounterForTesting
+
+RecordingStore sidecar region
+  -> RecordingPaths
+  -> FileIOUtils
+  -> TrajectorySidecarBinary
+  -> SnapshotSidecarCodec
+  -> ParsekFlight terminal-orbit helpers
+  -> RecordingEndpointResolver
+  -> GhostPlaybackEngine loop migration helpers
+  -> ParsekSettings writeReadableSidecarMirrors
+
+TrajectorySidecarBinary
+  -> RecordingStore version constants and section-authoritative policy
+  -> FileIOUtils.SafeWriteBytes
+
+SnapshotSidecarCodec
+  -> FileIOUtils.SafeWriteBytes
+```
+
+The important constraint is that sidecar hydration is not a pure codec call.
+It also runs loop migration, degenerate loop repair, terminal-orbit backfill,
+endpoint backfill, snapshot policy, and failure flagging. Those policy steps
+must either stay in `RecordingStore` or move as one visible orchestration owner;
+they should not be hidden inside low-level codec classes.
+
+## Proposed Owners
+
+### 1. `SidecarFileCommitBatch`
+
+Smallest safe first owner. It would take the staged multi-file write/delete
+helpers out of `RecordingStore`:
+
+- `StagedSidecarChange`
+- `CommittedSidecarChange`
+- `StageSidecarWrite`
+- `ApplyStagedSidecarChanges`
+- `RestoreCommittedSidecarChange`
+- `CleanupStagedSidecarArtifacts`
+- `CleanupCommittedSidecarBackups`
+- `DeleteTransientSidecarArtifact`
+
+Recommended shape: an internal helper in a new file with a narrow API for
+staging writes and deletes, applying them, and cleaning artifacts. Keep the log
+tag and exception behavior identical. This owner is mechanical and does not
+alter schema, save/load policy, epoch rules, or recording state.
+
+### 2. `RecordingSidecarStore`
+
+Second owner, after the commit batch has landed. It would own the sidecar
+orchestration facade behind existing `RecordingStore` wrappers:
+
+- `SaveRecordingFiles` and `SaveRecordingFilesToPathsInternal`
+- `LoadRecordingFiles` and `LoadRecordingFilesFromPathsInternal`
+- sidecar load failure marking/clearing
+- sidecar epoch validation and bump placement
+- readable mirror reconciliation
+- snapshot sidecar load summary/fallback policy
+- trajectory sidecar dispatch wrappers
+
+`RecordingStore` should keep delegating methods with the current names during
+the first split. That avoids broad test churn and keeps blame readable.
+
+Risk: this owner touches policy, not just file I/O. It must preserve the exact
+load sequence:
+
+1. probe trajectory sidecar
+2. reject unsupported/id-mismatched/stale trajectory files
+3. deserialize trajectory
+4. run loop migration and degenerate loop normalization
+5. populate terminal orbit if needed
+6. backfill endpoint decision
+7. load snapshot sidecars
+8. report failure without losing hydrated trajectory state
+
+### 3. `TrajectoryTextSidecarCodec`
+
+Third owner. It would move text ConfigNode trajectory serialization out of
+`RecordingStore` while leaving `TrajectorySidecarBinary` focused on binary
+bytes:
+
+- `SerializeTrajectoryInto`
+- `DeserializeTrajectoryFrom`
+- point/orbit/part/flag/segment-event serializers
+- track-section text serialization
+- flat trajectory vs section-authoritative sync/fallback helpers
+- text format version probing
+
+Keep `RecordingStore.SerializeTrajectoryInto` and
+`RecordingStore.DeserializeTrajectoryFrom` as wrappers until all callers are
+intentionally migrated. This split is valuable, but broader than the commit
+batch because many tests and generators call the current wrappers.
+
+Rejected for this pass: merging text and binary trajectory codecs into one new
+abstraction. The existing binary owner is cohesive; forcing a shared interface
+now would add design risk without reducing behavior risk.
+
+### 4. `RecordingManifestCodec`
+
+Fourth owner. It would move the manifest-like ConfigNode codecs currently
+stored in `RecordingStore`:
+
+- crew end states
+- resource manifest
+- inventory manifest
+- crew manifest
+
+These codecs are used by both `RecordingTree` and `ParsekScenario` standalone
+metadata paths. Keep wrappers on `RecordingStore` first, then migrate call sites
+only after tests confirm identical nodes and log output.
+
+### 5. `RecordingTreeRecordCodec`
+
+Later owner, not first. It would move record-level `.sfs` metadata serialization
+out of `RecordingTree`:
+
+- `SaveRecordingInto`
+- `LoadRecordingFrom`
+- playback/linkage save/load helpers
+- resource/state save/load helpers
+- branch point serialization only if a second, separate pass says so
+
+This is useful, but it should wait until manifest ownership is settled because
+`SaveRecordingResourceAndState` and `LoadRecordingResourceAndState` currently
+bridge tree metadata, manifest codecs, rewind metadata, UI grouping tags, and
+legacy merge-state migration.
+
+## Rejected In This Pass
+
+- No binary `.prec` format redesign.
+- No snapshot sidecar wrapper/header redesign.
+- No ConfigNode key renames or field reordering for `.sfs`, `.prec.txt`, or
+  snapshot readable mirrors.
+- No deduplication that changes exception timing, logging text, fallback order,
+  or `FilesDirty` / `SidecarEpoch` mutation order.
+- No replacement of `RecordingStore` static state with injected services.
+- No migration of KSP path resolution out of `RecordingPaths`.
+- No test rewrites just to chase new owner names while wrappers still exist.
+
+## Recommended Pass 3 Order
+
+1. Extract `SidecarFileCommitBatch`. This is the narrowest cross-file move and
+   gives the save path a named transaction owner without changing storage
+   policy.
+2. Extract `RecordingSidecarStore` behind `RecordingStore` wrappers. Keep
+   public/internal wrapper signatures stable and preserve `RecordingStore` log
+   tags unless explicitly approved otherwise.
+3. Extract `TrajectoryTextSidecarCodec`, again behind wrappers. Do not merge it
+   with `TrajectorySidecarBinary`.
+4. Extract `RecordingManifestCodec` behind wrappers.
+5. Re-evaluate `RecordingTreeRecordCodec` after the first four steps. Do not
+   start it in the same PR as sidecar orchestration.
+
+Each item should be its own commit at minimum. If review risk is high, split
+items 2-5 into separate PRs.
+
+## Validation Scope
+
+Focused unit slices for any sidecar/codec movement:
+
+```powershell
+dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter "FullyQualifiedName~RecordingStorageRoundTripTests|FullyQualifiedName~SnapshotSidecarCodecTests|FullyQualifiedName~TrajectorySidecarBinaryTests|FullyQualifiedName~Bug270SidecarEpochTests|FullyQualifiedName~FormatVersionTests|FullyQualifiedName~TrackSectionSerializationTests|FullyQualifiedName~LoopIntervalLoadNormalizationTests|FullyQualifiedName~QuickloadResumeTests"
+```
+
+Focused unit slices for manifest/tree metadata movement:
+
+```powershell
+dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter "FullyQualifiedName~ResourceManifestSerializationTests|FullyQualifiedName~InventoryManifestSerializationTests|FullyQualifiedName~CrewManifestSerializationTests|FullyQualifiedName~RewindLoggingTests|FullyQualifiedName~TreeCommitTests|FullyQualifiedName~BackwardCompatTests"
+```
+
+Before a PR:
+
+```powershell
+dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter FullyQualifiedName!~InjectAllRecordings
+```
+
+When KSP/log locks are clear, also run:
+
+```powershell
+dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter FullyQualifiedName~InjectAllRecordings
+```
+
+Runtime canary after sidecar orchestration or codec movement:
+
+- `CurrentFormatTrajectorySidecarsProbeAsBinary` in the in-game test runner.
+- A manual save/load or quickload scenario if the implementation moves
+  `LoadRecordingFilesFromPathsInternal`, readable mirror reconciliation, or
+  snapshot fallback policy.
+
+## Rollback Plan
+
+- Keep `RecordingStore` wrappers until all moved owners are settled. This makes
+  each split revertible without changing callers.
+- Commit the commit-batch extraction separately from the sidecar orchestration
+  extraction.
+- Avoid schema changes so rollback is source-only; no save migration or cleanup
+  is needed.
+- If validation finds a behavior drift, revert the most recent owner split
+  rather than patching over it inside the same PR.
+
+## Open Approval Question
+
+Recommended next implementation, if approved: extract only
+`SidecarFileCommitBatch` first. It is the smallest architectural move with a
+clear owner boundary and the least chance of hidden save/load logic drift.
+


### PR DESCRIPTION
## Summary
- Document the refactor-4 Pass 2 storage/sidecar split plan.
- Extract `SidecarFileCommitBatch` from `RecordingStore` for staged sidecar write/delete commit, rollback, and staged artifact cleanup.
- Add the Pass 2 changelog line and refresh the RecordingStore inventory status/line counts.

## Scope and guardrails
- Behavior-neutral extraction only.
- No save/load orchestration was moved yet.
- `RecordingStore` remains the wrapper facade and still owns `SidecarEpoch`, `FilesDirty`, save/load orchestration, readable mirrors, snapshot policy, and codec dispatch.
- The next `RecordingSidecarStore` save-path split is intentionally not part of this PR.

## Validation
- `dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter "FullyQualifiedName~RecordingStorageRoundTripTests|FullyQualifiedName~SnapshotSidecarCodecTests|FullyQualifiedName~TrajectorySidecarBinaryTests|FullyQualifiedName~Bug270SidecarEpochTests|FullyQualifiedName~FormatVersionTests|FullyQualifiedName~TrackSectionSerializationTests|FullyQualifiedName~LoopIntervalLoadNormalizationTests|FullyQualifiedName~QuickloadResumeTests"` — 234/234 passed.
- `dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter FullyQualifiedName!~InjectAllRecordings` — 8646/8646 passed.
- `dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter FullyQualifiedName~InjectAllRecordings` — 3/3 passed.