### PR TITLE
Cleanup #576 PatchedSnapshot solver-unavailable + #581 frame-budget hybrid breakdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- `#576` PatchedConicSnapshot `solver unavailable` and the paired Extrapolator `patched-conic snapshot failed for ... with NullSolver; falling back to live orbit state` WARNs are now rate-limited per (vessel-name) and per (recording-id, failure-reason) respectively. The 2026-04-25 marker-validator-fix playtest emitted 146 of each — almost all from debris, EVA-kerbals, and probe-debris that have no patched-conic solver by design in stock KSP. Downstream NullSolver semantics (live-orbit fallback for the destroyed-vessel case) are unchanged; only the log-noise floor is trimmed.
+
+- `#581` New "Playback hybrid breakdown" one-shot diagnostic WARN closes the gap between the existing #450 (heaviest spawn ≥ 15 ms) and #460 (mainLoop ≥ 10 ms with spawn < 1 ms) sub-breakdown latches. The 2026-04-25 playtest's only budget-exceeded frame was a hybrid 11.6 ms spike (mainLoop 7.51 ms + spawn 3.44 ms) that fit neither prior latch and produced no Phase-B attribution; the new latch reports per-bucket itemisation plus mainLoop/spawn percent-of-frame fractions on the next such gap-shaped breach.
+
 - `#582` Format-v6 RELATIVE TrackSection position contract is now documented in `AGENTS.md` and `.claude/CLAUDE.md`, and pinned by regression tests so flat `Recording.Points` readers cannot silently misinterpret anchor-local metres as body-fixed lat/lon/alt.
 
 - MergeTree now heals velocity-consistent Background-to-Active handoff gaps by inserting a shared boundary point, preventing Kerbal X-style ghost trajectory pops from section-authoritative merged recordings.

--- a/Source/Parsek.Tests/Bug581HybridBreakdownTests.cs
+++ b/Source/Parsek.Tests/Bug581HybridBreakdownTests.cs
@@ -1,0 +1,258 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Bug #581 instrumentation tests.
+    ///
+    /// The 2026-04-25_1314 marker-validator-fix playtest emitted exactly one
+    /// <c>Playback frame budget exceeded: 11.6ms (0 ghosts, warp: 1x)</c> WARN
+    /// whose paired one-shot breakdown was
+    /// <c>total=11.6ms mainLoop=7.51ms spawn=3.44ms (built=1 throttled=0
+    /// max=3.44ms) destroy=0.00ms ...</c>. That spike falls in a gap between
+    /// the existing #450 (gate: <c>spawnMaxMicroseconds &gt;= 15ms</c>) and
+    /// #460 (gate: <c>mainLoop &gt;= 10ms</c> AND <c>spawn &lt; 1ms</c>)
+    /// sub-breakdown latches: heaviest spawn (3.44 ms) under #450's threshold
+    /// AND mainLoop (7.51 ms) under #460's floor, but their SUM was big enough
+    /// to push the frame past the 8 ms playback budget.
+    ///
+    /// Without this latch the session captures the generic #414 breakdown but
+    /// no Phase-B attribution that could decide whether the gap is dominated
+    /// by per-trajectory main-loop work, the single spawn, or both. These
+    /// tests exercise <see cref="DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown"/>
+    /// by replaying the captured shape and asserting the new hybrid-spike
+    /// breakdown WARN's gating, formatting, latch independence from #414 /
+    /// #450 / #460, and one-shot semantics.
+    /// </summary>
+    [Collection("Sequential")]
+    public class Bug581HybridBreakdownTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public Bug581HybridBreakdownTests()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+            ParsekLog.VerboseOverrideForTesting = true;
+            DiagnosticsState.ResetForTesting();
+            DiagnosticsComputation.ResetForTesting();
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+            DiagnosticsState.ResetForTesting();
+            DiagnosticsComputation.ResetForTesting();
+        }
+
+        /// <summary>
+        /// Mirrors the captured 2026-04-25 playtest spike: total=11.6 ms,
+        /// mainLoop=7.51 ms, spawn=3.44 ms (built=1 max=3.44 ms),
+        /// observabilityCapture=0.39 ms, deferredCreated=0.28 ms (1 evt),
+        /// trajectories=18, ghosts=0, warp=1x. Sub-#450 (heaviest spawn 3.44 ms
+        /// well under 15 ms) and sub-#460 (mainLoop 7.51 ms below 10 ms floor),
+        /// so this is the canonical hybrid-spike shape.
+        /// </summary>
+        private static PlaybackBudgetPhases HybridSpikePhases()
+        {
+            return new PlaybackBudgetPhases
+            {
+                mainLoopMicroseconds = 7_510,               // 7.51 ms — below #460's 10 ms floor
+                spawnMicroseconds = 3_440,                  // 3.44 ms aggregate
+                destroyMicroseconds = 0,
+                explosionCleanupMicroseconds = 0,
+                deferredCreatedEventsMicroseconds = 280,    // 0.28 ms
+                deferredCompletedEventsMicroseconds = 0,
+                observabilityCaptureMicroseconds = 390,     // 0.39 ms
+                trajectoriesIterated = 18,
+                overlapGhostIterationCount = 0,
+                createdEventsFired = 1,
+                completedEventsFired = 0,
+                spawnsAttempted = 1,
+                spawnsThrottled = 0,
+                spawnMaxMicroseconds = 3_440,               // below #450's 15 ms floor
+                buildSnapshotResolveMicroseconds = 0,
+                buildTimelineFromSnapshotMicroseconds = 0,
+                buildDictionariesMicroseconds = 0,
+                buildReentryFxMicroseconds = 0,
+                buildOtherMicroseconds = 0,
+                heaviestSpawnSnapshotResolveMicroseconds = 0,
+                heaviestSpawnTimelineFromSnapshotMicroseconds = 0,
+                heaviestSpawnDictionariesMicroseconds = 0,
+                heaviestSpawnReentryFxMicroseconds = 0,
+                heaviestSpawnOtherMicroseconds = 0,
+                heaviestSpawnBuildType = HeaviestSpawnBuildType.None,
+            };
+        }
+
+        [Fact]
+        public void HybridSpike_FiresBreakdown_WithCapturedLogShape()
+        {
+            DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
+                11_600, 0, 1.0f, HybridSpikePhases());
+
+            var hybridLine = logLines.FirstOrDefault(l =>
+                l.Contains("[Parsek][WARN][Diagnostics]") &&
+                l.Contains("Playback hybrid breakdown"));
+            Assert.NotNull(hybridLine);
+            Assert.Contains("one-shot", hybridLine);
+            Assert.Contains("hybrid spike", hybridLine);
+            // Pin the exact captured-log values so a future regression on the
+            // formatter (unit reshuffling, percent computation, missing field)
+            // surfaces immediately.
+            Assert.Contains("total=11.6ms", hybridLine);
+            Assert.Contains("mainLoop=7.51ms (65%)", hybridLine);
+            // spawn line carries (a) the percent-of-frame fraction, (b) the
+            // attempt count, (c) the heaviest single-spawn cost.
+            Assert.Contains("spawn=3.44ms (30% built=1 max=3.44ms)", hybridLine);
+            Assert.Contains("destroy=0.00ms", hybridLine);
+            Assert.Contains("explosionCleanup=0.00ms", hybridLine);
+            Assert.Contains("deferredCreated=0.28ms (1 evts)", hybridLine);
+            Assert.Contains("deferredCompleted=0.00ms (0 evts)", hybridLine);
+            Assert.Contains("observabilityCapture=0.39ms", hybridLine);
+            Assert.Contains("trajectories=18", hybridLine);
+            Assert.Contains("overlapIterations=0", hybridLine);
+            Assert.Contains("ghosts=0", hybridLine);
+            Assert.Contains("warp=1x", hybridLine);
+        }
+
+        [Fact]
+        public void HybridSpike_OneShotLatchHonored()
+        {
+            DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
+                11_600, 0, 1.0f, HybridSpikePhases());
+            int firstHitCount = logLines.Count(l => l.Contains("Playback hybrid breakdown"));
+            Assert.Equal(1, firstHitCount);
+
+            // Replay the same spike — the latch must absorb it.
+            DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
+                11_600, 0, 1.0f, HybridSpikePhases());
+            int secondHitCount = logLines.Count(l => l.Contains("Playback hybrid breakdown"));
+            Assert.Equal(1, secondHitCount);
+        }
+
+        [Fact]
+        public void HybridSpike_DoesNotFireWhenSpawnOverFiftyMsThreshold_BurnsHash450InsteadOfHybrid()
+        {
+            // Heaviest spawn at 18 ms (above the 15 ms #450 threshold) belongs
+            // to #450's bimodal-single-spawn territory, NOT #581. The hybrid
+            // latch must remain armed for the next genuine sub-#450 spike.
+            var phases = HybridSpikePhases();
+            phases.spawnMaxMicroseconds = 18_000;
+            phases.spawnMicroseconds = 18_000;
+
+            DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
+                25_000, 0, 1.0f, phases);
+
+            Assert.DoesNotContain(logLines, l => l.Contains("Playback hybrid breakdown"));
+            // #450 latch should have fired for this shape.
+            Assert.Contains(logLines, l => l.Contains("Playback spawn build breakdown"));
+
+            // Latch still armed — a real hybrid-shape spike next fires it.
+            DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
+                11_600, 0, 1.0f, HybridSpikePhases());
+            Assert.Contains(logLines, l => l.Contains("Playback hybrid breakdown"));
+        }
+
+        [Fact]
+        public void HybridSpike_DoesNotFireWhenMainLoopAboveTenMsFloor_BurnsHash460InsteadOfHybrid()
+        {
+            // mainLoop at 12 ms (above the 10 ms #460 floor) AND spawn under
+            // 1 ms qualifies as a #460 mainLoop-dominated spike, not a hybrid.
+            // The hybrid latch must remain armed for the next genuine
+            // sub-#460 spike.
+            var phases = HybridSpikePhases();
+            phases.mainLoopMicroseconds = 12_000;
+            phases.spawnMicroseconds = 0;
+            phases.spawnMaxMicroseconds = 0;
+            phases.spawnsAttempted = 0;
+
+            DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
+                15_000, 0, 1.0f, phases);
+
+            Assert.DoesNotContain(logLines, l => l.Contains("Playback hybrid breakdown"));
+            // #460 latch should have fired for this shape.
+            Assert.Contains(logLines, l => l.Contains("Playback mainLoop breakdown"));
+
+            // Latch still armed — a real hybrid-shape spike next fires it.
+            DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
+                11_600, 0, 1.0f, HybridSpikePhases());
+            Assert.Contains(logLines, l => l.Contains("Playback hybrid breakdown"));
+        }
+
+        [Fact]
+        public void HybridSpike_FiresEvenWhenHash450LatchAlreadyConsumed()
+        {
+            // Mid-session rollout case: the session's first spike was
+            // #450-shaped and consumed the spawn-build-breakdown latch before
+            // #581 was loaded. The hybrid latch must still fire on the next
+            // qualifying spike — that is the whole point of giving it an
+            // independent latch.
+            DiagnosticsComputation.SetBug450BreakdownLatchFiredForTesting();
+
+            DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
+                11_600, 0, 1.0f, HybridSpikePhases());
+
+            Assert.Contains(logLines, l => l.Contains("Playback hybrid breakdown"));
+            Assert.DoesNotContain(logLines, l => l.Contains("Playback spawn build breakdown"));
+        }
+
+        [Fact]
+        public void HybridSpike_FiresEvenWhenHash460LatchAlreadyConsumed()
+        {
+            // Mid-session rollout case: the session's first spike was
+            // #460-shaped and consumed the mainLoop-breakdown latch before
+            // #581 was loaded. The hybrid latch must still fire on the next
+            // qualifying spike. Mirrors how #460 was made independent of #414
+            // / #450.
+            DiagnosticsComputation.SetBug460BreakdownLatchFiredForTesting();
+
+            DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
+                11_600, 0, 1.0f, HybridSpikePhases());
+
+            Assert.Contains(logLines, l => l.Contains("Playback hybrid breakdown"));
+            Assert.DoesNotContain(logLines, l => l.Contains("Playback mainLoop breakdown"));
+        }
+
+        [Fact]
+        public void HybridSpike_TotalBelowBudget_DoesNotFireBreakdown()
+        {
+            // Defensive: if the budget short-circuit is ever removed from the
+            // method head, the hybrid latch must still respect the budget
+            // threshold so a healthy frame cannot burn the session's only
+            // sample.
+            DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
+                4_000, 0, 1.0f, HybridSpikePhases());
+
+            Assert.DoesNotContain(logLines, l => l.Contains("Playback hybrid breakdown"));
+
+            // Latch still armed — a real budget-exceeded hybrid spike next fires it.
+            DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
+                11_600, 0, 1.0f, HybridSpikePhases());
+            Assert.Contains(logLines, l => l.Contains("Playback hybrid breakdown"));
+        }
+
+        [Fact]
+        public void HybridSpike_ZeroTotalRendersFractionsAsNa()
+        {
+            // Degenerate: if a future caller ever drives the helper with
+            // total=0 (e.g. a stopwatch read that wrapped or returned 0 us)
+            // the percent renderer must not divide by zero.
+            var phases = HybridSpikePhases();
+
+            var ex = Record.Exception(() =>
+                DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
+                    0, 0, 1.0f, phases));
+            Assert.Null(ex);
+
+            // Below-budget short-circuit means no WARN at all — but the
+            // formatter must not throw if it ever IS reached with total=0.
+            // Verified by the absence of an exception above.
+        }
+    }
+}

--- a/Source/Parsek.Tests/Bug581HybridBreakdownTests.cs
+++ b/Source/Parsek.Tests/Bug581HybridBreakdownTests.cs
@@ -254,5 +254,178 @@ namespace Parsek.Tests
             // formatter must not throw if it ever IS reached with total=0.
             // Verified by the absence of an exception above.
         }
+
+        // ----------------------------------------------------------------
+        // PR #553 P2 review: positive-evidence gate. The original gate
+        // ("below #450 spawn threshold AND below #460 mainLoop threshold")
+        // matched every above-budget frame whose spike came from any other
+        // bucket, so the one-shot latch could be consumed before a genuine
+        // hybrid frame appeared. The tightened gate also requires:
+        //  - mainLoop ≥ 1 ms (rules out default / pre-init frames)
+        //  - spawn ≥ 1 ms (rules out non-spawn / observability-only frames)
+        //  - mainLoop+spawn > deferredEvents total (rules out deferred-
+        //    dominated spikes)
+        //  - mainLoop+spawn > observabilityCapture (rules out obs-dominated)
+        //  - mainLoop+spawn > explosionCleanup (rules out cleanup-dominated)
+        // The tests below pin each negative case AND assert the latch
+        // stays armed for the next real hybrid spike.
+        // ----------------------------------------------------------------
+
+        [Fact]
+        public void HybridSpike_DeferredEventDominatedSpike_DoesNotBurnLatch()
+        {
+            // 11 ms spike where deferredCreated dominates (8 ms) and
+            // mainLoop / spawn are below their #460/#450 thresholds — the
+            // pre-fix gate would have burned the hybrid latch on this
+            // deferred-dominated frame.
+            var phases = HybridSpikePhases();
+            phases.mainLoopMicroseconds = 1_500;          // ≥ 1 ms floor, < #460
+            phases.spawnMicroseconds = 1_200;             // ≥ 1 ms floor, < #450
+            phases.spawnMaxMicroseconds = 1_200;
+            phases.deferredCreatedEventsMicroseconds = 8_000; // 8 ms — dominates the pair (2.7 ms total)
+            phases.deferredCompletedEventsMicroseconds = 0;
+
+            DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
+                11_000, 0, 1.0f, phases);
+            Assert.DoesNotContain(logLines, l => l.Contains("Playback hybrid breakdown"));
+
+            // Latch still armed: the next genuine hybrid spike fires it.
+            DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
+                11_600, 0, 1.0f, HybridSpikePhases());
+            Assert.Contains(logLines, l => l.Contains("Playback hybrid breakdown"));
+        }
+
+        [Fact]
+        public void HybridSpike_ObservabilityCaptureDominatedSpike_DoesNotBurnLatch()
+        {
+            // observabilityCapture spike (e.g. PR #547's GhostMap structured-
+            // line widening) that pushes the frame over budget while mainLoop
+            // and spawn stay small. Pre-fix burned the latch.
+            var phases = HybridSpikePhases();
+            phases.mainLoopMicroseconds = 1_500;
+            phases.spawnMicroseconds = 1_500;
+            phases.spawnMaxMicroseconds = 1_500;
+            phases.observabilityCaptureMicroseconds = 7_500; // dominant bucket
+            phases.deferredCreatedEventsMicroseconds = 0;
+            phases.deferredCompletedEventsMicroseconds = 0;
+
+            DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
+                10_500, 0, 1.0f, phases);
+            Assert.DoesNotContain(logLines, l => l.Contains("Playback hybrid breakdown"));
+
+            DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
+                11_600, 0, 1.0f, HybridSpikePhases());
+            Assert.Contains(logLines, l => l.Contains("Playback hybrid breakdown"));
+        }
+
+        [Fact]
+        public void HybridSpike_ExplosionCleanupDominatedSpike_DoesNotBurnLatch()
+        {
+            var phases = HybridSpikePhases();
+            phases.mainLoopMicroseconds = 1_500;
+            phases.spawnMicroseconds = 1_500;
+            phases.spawnMaxMicroseconds = 1_500;
+            phases.explosionCleanupMicroseconds = 6_000; // dominant
+            phases.observabilityCaptureMicroseconds = 0;
+            phases.deferredCreatedEventsMicroseconds = 0;
+            phases.deferredCompletedEventsMicroseconds = 0;
+
+            DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
+                9_500, 0, 1.0f, phases);
+            Assert.DoesNotContain(logLines, l => l.Contains("Playback hybrid breakdown"));
+
+            DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
+                11_600, 0, 1.0f, HybridSpikePhases());
+            Assert.Contains(logLines, l => l.Contains("Playback hybrid breakdown"));
+        }
+
+        [Fact]
+        public void HybridSpike_ZeroSpawn_DoesNotBurnLatch()
+        {
+            // mainLoop fits in the #581 gap (8 ms < 10 ms #460 floor) but
+            // spawn=0 — this is a pure mainLoop spike that the gate must not
+            // misclassify as hybrid. Without the spawn ≥ 1 ms positive gate,
+            // the pre-fix latch would have fired.
+            var phases = HybridSpikePhases();
+            phases.mainLoopMicroseconds = 8_000;
+            phases.spawnMicroseconds = 0;
+            phases.spawnMaxMicroseconds = 0;
+            phases.deferredCreatedEventsMicroseconds = 0;
+            phases.deferredCompletedEventsMicroseconds = 0;
+
+            DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
+                8_500, 0, 1.0f, phases);
+            Assert.DoesNotContain(logLines, l => l.Contains("Playback hybrid breakdown"));
+
+            DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
+                11_600, 0, 1.0f, HybridSpikePhases());
+            Assert.Contains(logLines, l => l.Contains("Playback hybrid breakdown"));
+        }
+
+        [Fact]
+        public void HybridSpike_ZeroMainLoop_DoesNotBurnLatch()
+        {
+            // Symmetric to ZeroSpawn: an above-budget frame whose mainLoop
+            // is silent is not a hybrid. The mainLoop ≥ 1 ms positive gate
+            // protects the latch.
+            var phases = HybridSpikePhases();
+            phases.mainLoopMicroseconds = 0;
+            phases.spawnMicroseconds = 5_000;
+            phases.spawnMaxMicroseconds = 5_000;
+            phases.deferredCreatedEventsMicroseconds = 0;
+            phases.deferredCompletedEventsMicroseconds = 0;
+
+            DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
+                9_000, 0, 1.0f, phases);
+            Assert.DoesNotContain(logLines, l => l.Contains("Playback hybrid breakdown"));
+
+            DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
+                11_600, 0, 1.0f, HybridSpikePhases());
+            Assert.Contains(logLines, l => l.Contains("Playback hybrid breakdown"));
+        }
+
+        [Fact]
+        public void HybridSpike_SubMillisecondHybrid_DoesNotBurnLatch()
+        {
+            // mainLoop=0.5 ms + spawn=0.5 ms — neither phase clears the
+            // 1 ms hybrid floor, so this is below the noise threshold and
+            // not a meaningful hybrid spike. The frame goes over budget
+            // because of some other bucket; the latch must stay armed.
+            var phases = HybridSpikePhases();
+            phases.mainLoopMicroseconds = 500;
+            phases.spawnMicroseconds = 500;
+            phases.spawnMaxMicroseconds = 500;
+            phases.deferredCreatedEventsMicroseconds = 9_000; // pushes total over budget
+            phases.deferredCompletedEventsMicroseconds = 0;
+
+            DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
+                10_500, 0, 1.0f, phases);
+            Assert.DoesNotContain(logLines, l => l.Contains("Playback hybrid breakdown"));
+
+            DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
+                11_600, 0, 1.0f, HybridSpikePhases());
+            Assert.Contains(logLines, l => l.Contains("Playback hybrid breakdown"));
+        }
+
+        [Fact]
+        public void HybridSpike_DefaultPhasesFrame_DoesNotBurnLatch()
+        {
+            // A pre-init / placeholder frame with all phase counters at the
+            // struct default (zero). Even if the frame somehow goes
+            // over-budget, no phase contributed; the hybrid latch must not
+            // be consumed. (The CheckPlaybackBudgetThresholdWithBreakdown
+            // entry-guard at line 824 would normally short-circuit this on
+            // a healthy frame, but a fabricated over-budget total must not
+            // trip the latch either.)
+            var phases = default(PlaybackBudgetPhases);
+
+            DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
+                12_000, 0, 1.0f, phases);
+            Assert.DoesNotContain(logLines, l => l.Contains("Playback hybrid breakdown"));
+
+            DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(
+                11_600, 0, 1.0f, HybridSpikePhases());
+            Assert.Contains(logLines, l => l.Contains("Playback hybrid breakdown"));
+        }
     }
 }

--- a/Source/Parsek.Tests/PatchedConicSnapshotTests.cs
+++ b/Source/Parsek.Tests/PatchedConicSnapshotTests.cs
@@ -198,6 +198,63 @@ namespace Parsek.Tests
                 l.Contains("suppressed=9"));
         }
 
+        /// <summary>
+        /// Regression for PR #553 P2 review: the WarnRateLimited call must use the
+        /// documented 30-second window, not WarnRateLimited's 5-second default.
+        /// Walking the test clock forward 10 seconds (well past 5 s, well below
+        /// 30 s) and emitting a fresh hit must produce NO new WARN line — under
+        /// the 5-second default this would have re-emitted, so the assertion
+        /// catches a regression to the implicit interval.
+        /// </summary>
+        [Fact]
+        public void Snapshot_NullSolver_BetweenFiveAndThirtySeconds_RemainsSuppressed()
+        {
+            double clockSeconds = 0.0;
+            ParsekLog.ClockOverrideForTesting = () => clockSeconds;
+
+            // Seed: first hit always emits.
+            PatchedConicSnapshot.SnapshotPatchedConicChain(
+                source: null, snapshotUT: 100, captureLimit: 8, vesselName: "Kerbal X Debris");
+
+            int firstWarn = logLines.Count(l =>
+                l.Contains("[Parsek][WARN][PatchedSnapshot]") &&
+                l.Contains("vessel=Kerbal X Debris solver unavailable"));
+            Assert.Equal(1, firstWarn);
+
+            // Advance 10 seconds — past the 5 s default but well under the 30 s
+            // configured interval. A pre-fix build would have re-emitted here.
+            clockSeconds += 10.0;
+            PatchedConicSnapshot.SnapshotPatchedConicChain(
+                source: null, snapshotUT: 110, captureLimit: 8, vesselName: "Kerbal X Debris");
+
+            int afterTenSecondsWarn = logLines.Count(l =>
+                l.Contains("[Parsek][WARN][PatchedSnapshot]") &&
+                l.Contains("vessel=Kerbal X Debris solver unavailable"));
+            Assert.Equal(1, afterTenSecondsWarn);
+
+            // Advance to 25 seconds total — still inside the 30 s window. Same
+            // assertion: still exactly one WARN, the rate limiter must not have
+            // re-emitted.
+            clockSeconds += 15.0;
+            PatchedConicSnapshot.SnapshotPatchedConicChain(
+                source: null, snapshotUT: 125, captureLimit: 8, vesselName: "Kerbal X Debris");
+
+            int afterTwentyFiveSecondsWarn = logLines.Count(l =>
+                l.Contains("[Parsek][WARN][PatchedSnapshot]") &&
+                l.Contains("vessel=Kerbal X Debris solver unavailable"));
+            Assert.Equal(1, afterTwentyFiveSecondsWarn);
+
+            // Cross 30 s — re-emit with the suppressed=N suffix.
+            clockSeconds += 6.0; // total 31 s since seed
+            PatchedConicSnapshot.SnapshotPatchedConicChain(
+                source: null, snapshotUT: 200, captureLimit: 8, vesselName: "Kerbal X Debris");
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[Parsek][WARN][PatchedSnapshot]") &&
+                l.Contains("vessel=Kerbal X Debris solver unavailable") &&
+                l.Contains("suppressed=2"));
+        }
+
         [Fact]
         public void Snapshot_RestoresLimitOnUpdateException()
         {

--- a/Source/Parsek.Tests/PatchedConicSnapshotTests.cs
+++ b/Source/Parsek.Tests/PatchedConicSnapshotTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace Parsek.Tests
@@ -120,9 +121,81 @@ namespace Parsek.Tests
 
             Assert.Equal(PatchedConicSnapshotFailureReason.NullSolver, result.FailureReason);
             Assert.Empty(result.Segments);
+            // The first hit per (subsystem, vessel-name) key always emits at WARN
+            // level; rate-limiting only suppresses subsequent hits within the
+            // 30-second interval (covered by
+            // <see cref="Snapshot_NullSolver_RateLimitsRepeatsForSameVessel"/>).
             Assert.Contains(logLines, line =>
-                line.Contains("[PatchedSnapshot]") &&
+                line.Contains("[Parsek][WARN][PatchedSnapshot]") &&
                 line.Contains("solver unavailable"));
+        }
+
+        /// <summary>
+        /// Regression for #576: 146 `solver unavailable` WARNs were emitted in the
+        /// 2026-04-25 marker-validator-fix playtest, clustered as 77×Kerbal X
+        /// Debris + 45×Ermore Kerman + 12×Magdo Kerman + 11×Kerbal X Probe +
+        /// 1×Kerbal X. All but the lone "Kerbal X" hit were vessels whose
+        /// `patchedConicSolver` is null by design in stock KSP (debris,
+        /// EVA-kerbals, probe-debris that has lost active-vessel solver state).
+        /// Per-vessel rate-limiting collapses the floor to one WARN per vessel
+        /// per 30-second window with a `suppressed=N` suffix on the next
+        /// emission, while still surfacing the first occurrence of a NEW
+        /// vessel name immediately so a fresh regression on a piloted craft
+        /// mid-flight cannot be silently absorbed by an unrelated debris
+        /// floor.
+        /// </summary>
+        [Fact]
+        public void Snapshot_NullSolver_RateLimitsRepeatsForSameVessel()
+        {
+            double clockSeconds = 0.0;
+            ParsekLog.ClockOverrideForTesting = () => clockSeconds;
+
+            // Ten consecutive null-solver snapshots for the same vessel within a
+            // 1-second window must produce exactly ONE WARN line — not 10.
+            for (int i = 0; i < 10; i++)
+            {
+                clockSeconds += 0.1;
+                PatchedConicSnapshot.SnapshotPatchedConicChain(
+                    source: null,
+                    snapshotUT: 100 + i,
+                    captureLimit: 8,
+                    vesselName: "Kerbal X Debris");
+            }
+
+            int firstVesselWarnCount = logLines.Count(l =>
+                l.Contains("[Parsek][WARN][PatchedSnapshot]") &&
+                l.Contains("vessel=Kerbal X Debris solver unavailable"));
+            Assert.Equal(1, firstVesselWarnCount);
+
+            // A different vessel name has its own key — its first hit must
+            // emit immediately rather than being suppressed by the prior
+            // vessel's floor.
+            clockSeconds += 0.1;
+            PatchedConicSnapshot.SnapshotPatchedConicChain(
+                source: null,
+                snapshotUT: 200,
+                captureLimit: 8,
+                vesselName: "Ermore Kerman");
+
+            int secondVesselWarnCount = logLines.Count(l =>
+                l.Contains("[Parsek][WARN][PatchedSnapshot]") &&
+                l.Contains("vessel=Ermore Kerman solver unavailable"));
+            Assert.Equal(1, secondVesselWarnCount);
+
+            // After the 30-second rate-limit window expires, the same vessel
+            // emits its next WARN with a `suppressed=N` suffix attributing the
+            // intervening absorbed hits.
+            clockSeconds += 30.5;
+            PatchedConicSnapshot.SnapshotPatchedConicChain(
+                source: null,
+                snapshotUT: 300,
+                captureLimit: 8,
+                vesselName: "Kerbal X Debris");
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[Parsek][WARN][PatchedSnapshot]") &&
+                l.Contains("vessel=Kerbal X Debris solver unavailable") &&
+                l.Contains("suppressed=9"));
         }
 
         [Fact]

--- a/Source/Parsek.Tests/SceneExitFinalizationIntegrationTests.cs
+++ b/Source/Parsek.Tests/SceneExitFinalizationIntegrationTests.cs
@@ -1199,6 +1199,118 @@ namespace Parsek.Tests
             Assert.Equal(1, lifecycleInfoCount);
         }
 
+        /// <summary>
+        /// Regression for #576: 146 paired
+        /// `[Extrapolator] patched-conic snapshot failed for '<id>' with NullSolver`
+        /// WARNs were emitted in the 2026-04-25 marker-validator-fix playtest, one
+        /// per upstream `[PatchedSnapshot] solver unavailable` hit. The same root
+        /// cause (debris/EVA-kerbal/probe vessels with no patched-conic solver by
+        /// design) drives the floor on this paired warn. Per-(recordingId,
+        /// failureReason) rate-limiting collapses repeats within the 30-second
+        /// window into a single emission with `suppressed=N` suffix, while the
+        /// downstream NullSolver→live-orbit fallback continues to run because
+        /// only the LOG ROUTING changes.
+        /// </summary>
+        [Fact]
+        public void TryCompleteFinalizationFromPatchedSnapshot_NullSolver_WarnRateLimitedPerRecordingAndReason()
+        {
+            double clockSeconds = 0.0;
+            ParsekLog.ClockOverrideForTesting = () => clockSeconds;
+
+            var rec = new Recording
+            {
+                RecordingId = "scene-exit-rate-limit-floor",
+                ExplicitEndUT = 500.0
+            };
+            var snapshot = new PatchedConicSnapshotResult
+            {
+                FailureReason = PatchedConicSnapshotFailureReason.NullSolver,
+                Segments = new List<OrbitSegment>()
+            };
+            var bodies = new Dictionary<string, ExtrapolationBody>
+            {
+                ["Kerbin"] = new ExtrapolationBody
+                {
+                    Name = "Kerbin",
+                    GravitationalParameter = 3.5316e12,
+                    Radius = 600000.0,
+                    AtmosphereDepth = 70000.0
+                }
+            };
+
+            for (int i = 0; i < 5; i++)
+            {
+                clockSeconds += 0.1;
+                IncompleteBallisticSceneExitFinalizer.TryCompleteFinalizationFromPatchedSnapshotForTesting(
+                    rec,
+                    snapshot,
+                    bodies,
+                    delegate(out BallisticStateVector startState)
+                    {
+                        // Mirror the destroyed-vessel fingerprint position.
+                        startState = new BallisticStateVector
+                        {
+                            ut = 500.0,
+                            bodyName = "Kerbin",
+                            position = new Vector3d(5.0, 0.0, 0.0),
+                            velocity = new Vector3d(0.0, 0.0, 0.0),
+                            orbitalFrameRotation = Quaternion.identity
+                        };
+                        return true;
+                    },
+                    (startState, extrapolationBodies) =>
+                        BallisticExtrapolator.Extrapolate(
+                            startState,
+                            extrapolationBodies,
+                            warnOnSubSurfaceStart: false),
+                    out IncompleteBallisticFinalizationResult _);
+            }
+
+            int snapshotFailedWarnCount = CountLogLines(
+                "[Parsek][WARN][Extrapolator]",
+                "patched-conic snapshot failed for 'scene-exit-rate-limit-floor'",
+                "with NullSolver");
+            Assert.Equal(1, snapshotFailedWarnCount);
+
+            // A different recording-id has its own key — its first hit must
+            // emit immediately rather than being suppressed by the prior
+            // recording's floor.
+            var otherRec = new Recording
+            {
+                RecordingId = "scene-exit-rate-limit-other-recording",
+                ExplicitEndUT = 500.0
+            };
+            clockSeconds += 0.1;
+            IncompleteBallisticSceneExitFinalizer.TryCompleteFinalizationFromPatchedSnapshotForTesting(
+                otherRec,
+                snapshot,
+                bodies,
+                delegate(out BallisticStateVector startState)
+                {
+                    startState = new BallisticStateVector
+                    {
+                        ut = 500.0,
+                        bodyName = "Kerbin",
+                        position = new Vector3d(5.0, 0.0, 0.0),
+                        velocity = new Vector3d(0.0, 0.0, 0.0),
+                        orbitalFrameRotation = Quaternion.identity
+                    };
+                    return true;
+                },
+                (startState, extrapolationBodies) =>
+                    BallisticExtrapolator.Extrapolate(
+                        startState,
+                        extrapolationBodies,
+                        warnOnSubSurfaceStart: false),
+                out IncompleteBallisticFinalizationResult _);
+
+            int otherWarnCount = CountLogLines(
+                "[Parsek][WARN][Extrapolator]",
+                "patched-conic snapshot failed for 'scene-exit-rate-limit-other-recording'",
+                "with NullSolver");
+            Assert.Equal(1, otherWarnCount);
+        }
+
         [Fact]
         public void TryCompleteFinalizationFromPatchedSnapshot_ManeuverNode_DiscardTailAndUsesLiveState()
         {

--- a/Source/Parsek.Tests/SceneExitFinalizationIntegrationTests.cs
+++ b/Source/Parsek.Tests/SceneExitFinalizationIntegrationTests.cs
@@ -1311,6 +1311,113 @@ namespace Parsek.Tests
             Assert.Equal(1, otherWarnCount);
         }
 
+        /// <summary>
+        /// Regression for PR #553 P2 review: the paired Extrapolator
+        /// `WarnRateLimited` call must use the documented 30-second window, not
+        /// the 5-second `WarnRateLimited` default. Walking the test clock past
+        /// 5 s but before 30 s and emitting another hit must NOT re-emit; the
+        /// next emission only happens after the 30 s window closes.
+        /// </summary>
+        [Fact]
+        public void TryCompleteFinalizationFromPatchedSnapshot_NullSolver_BetweenFiveAndThirtySeconds_RemainsSuppressed()
+        {
+            double clockSeconds = 0.0;
+            ParsekLog.ClockOverrideForTesting = () => clockSeconds;
+
+            var rec = new Recording
+            {
+                RecordingId = "scene-exit-30s-window",
+                ExplicitEndUT = 500.0
+            };
+            var snapshot = new PatchedConicSnapshotResult
+            {
+                FailureReason = PatchedConicSnapshotFailureReason.NullSolver,
+                Segments = new List<OrbitSegment>()
+            };
+            var bodies = new Dictionary<string, ExtrapolationBody>
+            {
+                ["Kerbin"] = new ExtrapolationBody
+                {
+                    Name = "Kerbin",
+                    GravitationalParameter = 3.5316e12,
+                    Radius = 600000.0,
+                    AtmosphereDepth = 70000.0
+                }
+            };
+
+            // Seed: first hit always emits.
+            IncompleteBallisticSceneExitFinalizer.TryCompleteFinalizationFromPatchedSnapshotForTesting(
+                rec, snapshot, bodies,
+                delegate(out BallisticStateVector startState)
+                {
+                    startState = new BallisticStateVector
+                    {
+                        ut = 500.0,
+                        bodyName = "Kerbin",
+                        position = new Vector3d(5.0, 0.0, 0.0),
+                        velocity = new Vector3d(0.0, 0.0, 0.0),
+                        orbitalFrameRotation = Quaternion.identity
+                    };
+                    return true;
+                },
+                (startState, extrapolationBodies) =>
+                    BallisticExtrapolator.Extrapolate(
+                        startState, extrapolationBodies, warnOnSubSurfaceStart: false),
+                out IncompleteBallisticFinalizationResult _);
+            Assert.Equal(1, CountLogLines(
+                "[Parsek][WARN][Extrapolator]",
+                "patched-conic snapshot failed for 'scene-exit-30s-window'",
+                "with NullSolver"));
+
+            // Helper that fires another finalisation pass with the same
+            // synthetic state so each clock-tick can re-trigger the warn path.
+            Action fireAgain = () =>
+                IncompleteBallisticSceneExitFinalizer.TryCompleteFinalizationFromPatchedSnapshotForTesting(
+                    rec, snapshot, bodies,
+                    delegate(out BallisticStateVector startState)
+                    {
+                        startState = new BallisticStateVector
+                        {
+                            ut = 500.0,
+                            bodyName = "Kerbin",
+                            position = new Vector3d(5.0, 0.0, 0.0),
+                            velocity = new Vector3d(0.0, 0.0, 0.0),
+                            orbitalFrameRotation = Quaternion.identity
+                        };
+                        return true;
+                    },
+                    (startState, extrapolationBodies) =>
+                        BallisticExtrapolator.Extrapolate(
+                            startState, extrapolationBodies, warnOnSubSurfaceStart: false),
+                    out IncompleteBallisticFinalizationResult _);
+
+            // Advance 10 s — past 5 s default, well below 30 s. Pre-fix would
+            // have re-emitted; post-fix must remain suppressed.
+            clockSeconds += 10.0;
+            fireAgain();
+            Assert.Equal(1, CountLogLines(
+                "[Parsek][WARN][Extrapolator]",
+                "patched-conic snapshot failed for 'scene-exit-30s-window'",
+                "with NullSolver"));
+
+            // 25 s total — still inside the 30 s window.
+            clockSeconds += 15.0;
+            fireAgain();
+            Assert.Equal(1, CountLogLines(
+                "[Parsek][WARN][Extrapolator]",
+                "patched-conic snapshot failed for 'scene-exit-30s-window'",
+                "with NullSolver"));
+
+            // Cross 30 s — re-emit with `suppressed=2`.
+            clockSeconds += 6.0; // total 31 s since seed
+            fireAgain();
+            Assert.Contains(logLines, l =>
+                l.Contains("[Parsek][WARN][Extrapolator]")
+                && l.Contains("patched-conic snapshot failed for 'scene-exit-30s-window'")
+                && l.Contains("with NullSolver")
+                && l.Contains("suppressed=2"));
+        }
+
         [Fact]
         public void TryCompleteFinalizationFromPatchedSnapshot_ManeuverNode_DiscardTailAndUsesLiveState()
         {

--- a/Source/Parsek/Diagnostics/DiagnosticsComputation.cs
+++ b/Source/Parsek/Diagnostics/DiagnosticsComputation.cs
@@ -746,6 +746,21 @@ namespace Parsek
         internal const long MainLoopBreakdownMaxDestroyMicroseconds = 1_000;
 
         /// <summary>
+        /// Bug #581: minimum per-phase contribution required for the hybrid latch
+        /// to recognise a frame as a genuine mainLoop+spawn hybrid spike. Without
+        /// this floor, the gate (which is just "below #450 spawn threshold AND
+        /// below #460 mainLoop threshold") matches default-phase frames, deferred-
+        /// event-dominated spikes, and zero-spawn / zero-mainLoop spikes — any of
+        /// which would burn the one-shot latch on a non-hybrid frame and rob the
+        /// session of the diagnostic snapshot the latch is supposed to capture.
+        /// 1 ms (1 000 µs) is roughly an order of magnitude below either of the
+        /// individual thresholds, so it admits the captured 2026-04-25 spike
+        /// (mainLoop 7.51 ms + spawn 3.44 ms) and any plausible hybrid below the
+        /// #450/#460 lines, while rejecting per-frame measurement noise.
+        /// </summary>
+        internal const long HybridBreakdownMinPhaseMicroseconds = 1_000;
+
+        /// <summary>
         /// One-shot latch for the bug #414 per-phase breakdown log. Flipped true the first
         /// time a playback-budget-exceeded warning fires in the session; once latched, the
         /// breakdown is never re-emitted even on subsequent spikes. This keeps the steady-state
@@ -974,17 +989,33 @@ namespace Parsek
             // mainLoop >= 10ms AND spawn < 1ms): neither sub-bucket is large
             // enough to clear its own threshold, so without this latch the
             // session captures the generic #414 breakdown but no Phase-B
-            // attribution. Fires when the spike is in that gap — heaviest
-            // spawn under the #450 threshold AND mainLoop under the #460
-            // floor — and emits the full per-bucket itemisation plus the
-            // spawn ratio so a future playtest can decide whether the gap
-            // is dominated by per-trajectory main-loop work, the single
-            // spawn, or their combination. Independent of the prior three
-            // latches so a session that already burned them on bigger spikes
-            // can still capture the next hybrid breach.
+            // attribution. Fires when the spike is in that gap AND the
+            // mainLoop+spawn pair has positive evidence of genuine hybrid
+            // dominance — both phases must individually be ≥ 1 ms (rejecting
+            // default / pre-init frames, observability-only spikes, and
+            // zero-spawn or zero-mainLoop frames where one bucket is silent),
+            // and their sum must exceed every other non-spawn/destroy bucket
+            // (rejecting deferred-event, observability-capture, and explosion-
+            // cleanup-dominated spikes that happen to leave both mainLoop and
+            // spawn under threshold). Without these positive gates, the bare
+            // "<#450 AND <#460" floor matches every above-budget frame whose
+            // spike comes from any other bucket, and the one-shot latch can
+            // be consumed before a real hybrid frame appears (review note on
+            // PR #553). Independent of the prior three latches so a session
+            // that already burned them on bigger spikes can still capture the
+            // next hybrid breach.
+            long deferredEventsTotalMicrosecondsForHybrid =
+                phases.deferredCreatedEventsMicroseconds + phases.deferredCompletedEventsMicroseconds;
+            long hybridPairMicroseconds =
+                phases.mainLoopMicroseconds + phases.spawnMicroseconds;
             if (!s_hybridBreakdownOneShotFired
                 && phases.spawnMaxMicroseconds < BuildBreakdownMinHeaviestSpawnMicroseconds
-                && phases.mainLoopMicroseconds < MainLoopBreakdownMinMainLoopMicroseconds)
+                && phases.mainLoopMicroseconds < MainLoopBreakdownMinMainLoopMicroseconds
+                && phases.mainLoopMicroseconds >= HybridBreakdownMinPhaseMicroseconds
+                && phases.spawnMicroseconds >= HybridBreakdownMinPhaseMicroseconds
+                && hybridPairMicroseconds > deferredEventsTotalMicrosecondsForHybrid
+                && hybridPairMicroseconds > phases.observabilityCaptureMicroseconds
+                && hybridPairMicroseconds > phases.explosionCleanupMicroseconds)
             {
                 s_hybridBreakdownOneShotFired = true;
 

--- a/Source/Parsek/Diagnostics/DiagnosticsComputation.cs
+++ b/Source/Parsek/Diagnostics/DiagnosticsComputation.cs
@@ -776,6 +776,26 @@ namespace Parsek
         private static bool s_mainLoopBreakdownOneShotFired;
 
         /// <summary>
+        /// Bug #581: independent latch for the hybrid-spike breakdown WARN. The
+        /// 2026-04-25 marker-validator-fix playtest emitted a single
+        /// budget-exceeded frame at 11.6 ms whose phase shape was
+        /// <c>mainLoop=7.51ms spawn=3.44ms (built=1 max=3.44ms)</c> — partly
+        /// mainLoop work + partly a single non-trivial spawn, but neither
+        /// component large enough on its own to fit the existing #450 (gate:
+        /// <c>spawnMaxMicroseconds &gt;= 15 ms</c>) or #460 (gate:
+        /// <c>mainLoop &gt;= 10 ms</c> AND <c>spawn &lt; 1 ms</c>) sub-breakdowns.
+        /// The session therefore captured the generic #414 breakdown but no
+        /// sub-phase attribution that would let Phase B target a fix. This
+        /// latch fires on the next budget-exceeded frame that falls in the
+        /// gap between #450 and #460 — heaviest spawn under the 15 ms #450
+        /// threshold AND mainLoop under the 10 ms #460 floor — so the next
+        /// hybrid breach lands a sub-breakdown line that itemises the same
+        /// fields as #460's breakdown plus the spawn ratios. Independent of
+        /// the prior three latches so it can fire even after they are consumed.
+        /// </summary>
+        private static bool s_hybridBreakdownOneShotFired;
+
+        /// <summary>
         /// Checks the playback budget and emits a rate-limited WARN if exceeded.
         /// Called by GhostPlaybackEngine after each frame. Pure static, testable.
         /// Kept for back-compat with existing call sites and tests that have no phase breakdown.
@@ -946,13 +966,72 @@ namespace Parsek
                         ghostsProcessed,
                         warpRate.ToString("F0", Inv)));
             }
+
+            // Bug #581: hybrid-spike breakdown. The 2026-04-25 playtest's only
+            // budget-exceeded frame was total=11.6ms mainLoop=7.51ms
+            // spawn=3.44ms (built=1 max=3.44ms). That falls in a diagnostic
+            // gap between #450 (gate: spawnMax >= 15ms) and #460 (gate:
+            // mainLoop >= 10ms AND spawn < 1ms): neither sub-bucket is large
+            // enough to clear its own threshold, so without this latch the
+            // session captures the generic #414 breakdown but no Phase-B
+            // attribution. Fires when the spike is in that gap — heaviest
+            // spawn under the #450 threshold AND mainLoop under the #460
+            // floor — and emits the full per-bucket itemisation plus the
+            // spawn ratio so a future playtest can decide whether the gap
+            // is dominated by per-trajectory main-loop work, the single
+            // spawn, or their combination. Independent of the prior three
+            // latches so a session that already burned them on bigger spikes
+            // can still capture the next hybrid breach.
+            if (!s_hybridBreakdownOneShotFired
+                && phases.spawnMaxMicroseconds < BuildBreakdownMinHeaviestSpawnMicroseconds
+                && phases.mainLoopMicroseconds < MainLoopBreakdownMinMainLoopMicroseconds)
+            {
+                s_hybridBreakdownOneShotFired = true;
+
+                double mainLoopMs = phases.mainLoopMicroseconds / 1000.0;
+                double spawnMs = phases.spawnMicroseconds / 1000.0;
+                string mainLoopFractionStr = totalMs > 0
+                    ? (100.0 * mainLoopMs / totalMs).ToString("F0", Inv) + "%"
+                    : "n/a";
+                string spawnFractionStr = totalMs > 0
+                    ? (100.0 * spawnMs / totalMs).ToString("F0", Inv) + "%"
+                    : "n/a";
+
+                ParsekLog.Warn("Diagnostics",
+                    string.Format(Inv,
+                        "Playback hybrid breakdown (one-shot, first sub-#450/#460 hybrid spike):"
+                        + " total={0}ms mainLoop={1}ms ({2}) spawn={3}ms ({4} built={5} max={6}ms)"
+                        + " destroy={7}ms explosionCleanup={8}ms"
+                        + " deferredCreated={9}ms ({10} evts) deferredCompleted={11}ms ({12} evts)"
+                        + " observabilityCapture={13}ms trajectories={14} overlapIterations={15}"
+                        + " ghosts={16} warp={17}x",
+                        totalMs.ToString("F1", Inv),
+                        mainLoopMs.ToString("F2", Inv),
+                        mainLoopFractionStr,
+                        spawnMs.ToString("F2", Inv),
+                        spawnFractionStr,
+                        phases.spawnsAttempted,
+                        (phases.spawnMaxMicroseconds / 1000.0).ToString("F2", Inv),
+                        (phases.destroyMicroseconds / 1000.0).ToString("F2", Inv),
+                        (phases.explosionCleanupMicroseconds / 1000.0).ToString("F2", Inv),
+                        (phases.deferredCreatedEventsMicroseconds / 1000.0).ToString("F2", Inv),
+                        phases.createdEventsFired,
+                        (phases.deferredCompletedEventsMicroseconds / 1000.0).ToString("F2", Inv),
+                        phases.completedEventsFired,
+                        (phases.observabilityCaptureMicroseconds / 1000.0).ToString("F2", Inv),
+                        phases.trajectoriesIterated,
+                        phases.overlapGhostIterationCount,
+                        ghostsProcessed,
+                        warpRate.ToString("F0", Inv)));
+            }
         }
 
 
         /// <summary>
-        /// Test-only: reset the bug #414, #450, and #460 one-shot breakdown latches so each
+        /// Test-only: reset the bug #414, #450, #460, and #581 one-shot breakdown latches so each
         /// test starts clean. Use <see cref="SetBug414BreakdownLatchFiredForTesting"/> /
-        /// <see cref="SetBug450BreakdownLatchFiredForTesting"/> when a test needs to
+        /// <see cref="SetBug450BreakdownLatchFiredForTesting"/> /
+        /// <see cref="SetBug460BreakdownLatchFiredForTesting"/> when a test needs to
         /// pre-consume a specific prior latch without touching the others.
         /// </summary>
         internal static void ResetPlaybackBreakdownOneShotForTesting()
@@ -960,6 +1039,7 @@ namespace Parsek
             s_playbackBreakdownOneShotFired = false;
             s_buildBreakdownOneShotFired = false;
             s_mainLoopBreakdownOneShotFired = false;
+            s_hybridBreakdownOneShotFired = false;
         }
 
         /// <summary>
@@ -983,6 +1063,17 @@ namespace Parsek
         internal static void SetBug450BreakdownLatchFiredForTesting()
         {
             s_buildBreakdownOneShotFired = true;
+        }
+
+        /// <summary>
+        /// Added by #581: test seam that pre-fires the #460 mainLoop-dominated
+        /// breakdown latch without touching the #414, #450, or #581 latches, so the
+        /// hybrid-spike independence test can verify the #581 branch fires even when
+        /// #460 is already consumed. Companion to <see cref="SetBug450BreakdownLatchFiredForTesting"/>.
+        /// </summary>
+        internal static void SetBug460BreakdownLatchFiredForTesting()
+        {
+            s_mainLoopBreakdownOneShotFired = true;
         }
 
         /// <summary>
@@ -1049,6 +1140,7 @@ namespace Parsek
             s_playbackBreakdownOneShotFired = false;
             s_buildBreakdownOneShotFired = false;
             s_mainLoopBreakdownOneShotFired = false;
+            s_hybridBreakdownOneShotFired = false;
         }
     }
 }

--- a/Source/Parsek/IncompleteBallisticSceneExitFinalizer.cs
+++ b/Source/Parsek/IncompleteBallisticSceneExitFinalizer.cs
@@ -366,7 +366,8 @@ namespace Parsek
                 ParsekLog.WarnRateLimited("Extrapolator",
                     $"finalize-snapshot-failed-{recordingId}-{snapshot.FailureReason}",
                     $"TryFinalizeRecording: patched-conic snapshot failed for '{recordingId}' " +
-                    $"with {snapshot.FailureReason}; falling back to live orbit state");
+                    $"with {snapshot.FailureReason}; falling back to live orbit state",
+                    minIntervalSeconds: 30.0);
             }
 
             // Early ascent / transient patched-conic failures (`MissingPatchBody`,

--- a/Source/Parsek/IncompleteBallisticSceneExitFinalizer.cs
+++ b/Source/Parsek/IncompleteBallisticSceneExitFinalizer.cs
@@ -351,7 +351,20 @@ namespace Parsek
             }
             else if (snapshot.FailureReason != PatchedConicSnapshotFailureReason.None)
             {
-                ParsekLog.Warn("Extrapolator",
+                // #576: rate-limit per (recordingId, failureReason). The same
+                // 2026-04-25 playtest emitted 146 of these paired with the
+                // `[PatchedSnapshot] solver unavailable` floor — same root cause
+                // (debris/EVA-kerbal/probe vessels with no patched-conic solver
+                // by design). The downstream NullSolver branch at lines 287-289
+                // still runs unchanged: NullSolver remains the
+                // destroyed-vessel / no-solver-by-design fingerprint that drives
+                // the live-orbit fallback, only the log-noise floor changes.
+                // Keying on (recordingId, failureReason) lets a fresh regression
+                // on the SAME recording with a DIFFERENT failure mode surface
+                // immediately while the repeating same-cause floor is absorbed
+                // into a single line per 30 s with a `suppressed=N` suffix.
+                ParsekLog.WarnRateLimited("Extrapolator",
+                    $"finalize-snapshot-failed-{recordingId}-{snapshot.FailureReason}",
                     $"TryFinalizeRecording: patched-conic snapshot failed for '{recordingId}' " +
                     $"with {snapshot.FailureReason}; falling back to live orbit state");
             }

--- a/Source/Parsek/PatchedConicSnapshot.cs
+++ b/Source/Parsek/PatchedConicSnapshot.cs
@@ -113,7 +113,24 @@ namespace Parsek
             if (source == null || !source.IsAvailable)
             {
                 result.FailureReason = PatchedConicSnapshotFailureReason.NullSolver;
-                ParsekLog.Warn("PatchedSnapshot",
+                // #576: rate-limit per vessel name. The 2026-04-25 marker-validator
+                // playtest emitted 146 of these in an hour, clustered as
+                // 77×Kerbal X Debris + 45×Ermore Kerman + 12×Magdo Kerman +
+                // 11×Kerbal X Probe + 1×Kerbal X. The first four populations are
+                // by-design solver-less in stock KSP (debris has no command
+                // module; EVA kerbals run on the kerbal jetpack motion system;
+                // probe-debris loses solver state when the active vessel switches
+                // away). NullSolver is still emitted as the FailureReason and the
+                // downstream `IncompleteBallisticSceneExitFinalizer` continues to
+                // treat it as the destroyed-vessel / no-solver-by-design
+                // fingerprint that the live-orbit fallback was designed for; only
+                // the log-noise floor changes. Per-vessel keying preserves the
+                // first-of-its-kind hit per vessel so a fresh regression on a
+                // piloted craft mid-flight still surfaces immediately, while the
+                // repeating per-debris-vessel floor is absorbed into a single
+                // line per 30 s window with a `suppressed=N` suffix.
+                ParsekLog.WarnRateLimited("PatchedSnapshot",
+                    "solver-unavailable-" + safeVesselName,
                     $"SnapshotPatchedConicChain: vessel={safeVesselName} solver unavailable");
                 return result;
             }

--- a/Source/Parsek/PatchedConicSnapshot.cs
+++ b/Source/Parsek/PatchedConicSnapshot.cs
@@ -131,7 +131,8 @@ namespace Parsek
                 // line per 30 s window with a `suppressed=N` suffix.
                 ParsekLog.WarnRateLimited("PatchedSnapshot",
                     "solver-unavailable-" + safeVesselName,
-                    $"SnapshotPatchedConicChain: vessel={safeVesselName} solver unavailable");
+                    $"SnapshotPatchedConicChain: vessel={safeVesselName} solver unavailable",
+                    minIntervalSeconds: 30.0);
                 return result;
             }
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -321,7 +321,7 @@ patch-0-null discard-and-warn case.
 
 ---
 
-## 576. PatchedSnapshot: 146 "solver unavailable" warnings clustered on a few vessels
+## ~~576. PatchedSnapshot: 146 "solver unavailable" warnings clustered on a few vessels~~
 
 **Source:** `logs/2026-04-25_1314_marker-validator-fix/KSP.log.cleaned` —
 `[Parsek][WARN][PatchedSnapshot] SnapshotPatchedConicChain: vessel=<name> solver unavailable`:
@@ -340,15 +340,40 @@ This is the same WARN level as the MissingPatchBody case in #575 but with a
 different cause — the solver itself isn't reachable. Same concern: WARN floor
 for an expected-on-startup or transient-during-soi-transition condition.
 
-**Files to investigate:**
+**Diagnosis (2026-04-25):** `IPatchedConicSnapshotSource.IsAvailable` is
+`vessel != null && vessel.patchedConicSolver != null && vessel.orbit != null`
+(`Source/Parsek/PatchedConicSnapshot.cs:295-297`). In stock KSP,
+`Vessel.patchedConicSolver` is null **by design** for any vessel whose flight
+controller does not own a piloted/probe solver: `VesselType.Debris` (no command
+module — 77/77 of the `Kerbal X Debris` hits), EVA kerbals (jetpack motion
+system, no solver — 45+12 hits across `Ermore Kerman` / `Magdo Kerman`), and
+probe-debris that has lost its active-vessel solver state (11/11 of the
+`Kerbal X Probe` hits). Only the lone `Kerbal X` hit at 13:07:48 was the
+"genuine transient" case the original WARN tier was designed for. The downstream
+`IncompleteBallisticSceneExitFinalizer` (`...:280-286`) explicitly documents
+that NullSolver is the destroyed-vessel / no-solver-by-design fingerprint that
+drives the live-orbit fallback — the WARN tier was correct as a fallback
+signal but wrong for log noise of this shape.
 
-- `Source/Parsek/PatchedConicSnapshot.cs` — the `solver unavailable` branch
-  (this is the `__solver == null` / `solver.maneuverNodes == null` shape
-  check, distinct from #575's `MissingPatchBody`).
-- Whether the solver should be considered unavailable as a hard error (no
-  fallback) or as a soft transient (rate-limit / VERBOSE).
+**Fix:** swap both paired warns from `Warn` to `WarnRateLimited` with
+distinguishing keys — `solver-unavailable-{vesselName}` for the
+`PatchedConicSnapshot` site, and `finalize-snapshot-failed-{recordingId}-{failureReason}`
+for the paired `IncompleteBallisticSceneExitFinalizer` site. The `FailureReason
+= NullSolver` flow downstream is unchanged: only the level routing through the
+30-second-window rate limiter changes. The first hit per key still emits at
+WARN level so a fresh regression on a piloted craft mid-flight surfaces
+immediately; subsequent hits within 30 s on the same key are absorbed into a
+single line per window with a `suppressed=N` suffix.
 
-**Status:** Open.
+Regression `PatchedConicSnapshotTests.Snapshot_NullSolver_RateLimitsRepeatsForSameVessel`
+pins the per-vessel keying, the cross-vessel independence, and the
+30-second-window expiry suffix. Regression
+`SceneExitFinalizationIntegrationTests.TryCompleteFinalizationFromPatchedSnapshot_NullSolver_WarnRateLimitedPerRecordingAndReason`
+pins the paired Extrapolator rate-limit. The pre-existing
+`Snapshot_NullSolver_ReturnsEmptyList` test still pins the WARN level
+(`[Parsek][WARN][PatchedSnapshot]`) of the FIRST hit per key.
+
+**Status:** CLOSED 2026-04-25. Fixed for v0.9.0.
 
 ---
 
@@ -505,7 +530,7 @@ correction at handoff is missing a term.
 
 ---
 
-## 581. Diagnostics: 2 frame-budget breaches during normal flight playback
+## ~~581. Diagnostics: 2 frame-budget breaches during normal flight playback~~
 
 **Source:** `logs/2026-04-25_1314_marker-validator-fix/KSP.log.cleaned`:
 
@@ -518,15 +543,47 @@ first exceeded frame to capture per-bucket cost. Two breaches in an hour-long
 session is low frequency, but worth checking which bucket dominates the
 breakdown.
 
-**Files to investigate:**
+**Diagnosis (2026-04-25):** the captured log has exactly one breakdown line
+(`grep "budget breakdown" KSP.log.cleaned` → 1 hit, line 517040): `total=11.6ms
+mainLoop=7.51ms spawn=3.44ms (built=1 throttled=0 max=3.44ms) destroy=0.00ms
+explosionCleanup=0.00ms deferredCreated=0.28ms (1 evts) deferredCompleted=0.00ms
+(0 evts) observabilityCapture=0.39ms trajectories=18 ghosts=0 warp=1x`. This is
+a hybrid spike: partly mainLoop (7.51 ms / 65 % of frame) + partly a single
+non-trivial spawn (3.44 ms / 30 %). It falls in a diagnostic gap between the
+existing #450 (gate: `spawnMaxMicroseconds >= 15 ms`) and #460 (gate:
+`mainLoop >= 10 ms` AND `spawn < 1 ms`) sub-breakdown latches: heaviest spawn
+under #450's threshold AND mainLoop under #460's floor. `grep "mainLoop
+breakdown\|spawn build breakdown" KSP.log.cleaned` confirms 0 hits — the session
+captured the generic #414 breakdown but no Phase-B attribution.
 
-- `Source/Parsek/Diagnostics/FrameBudget.cs` (or wherever the budget check
-  lives) and the `Playback budget breakdown` emission point.
-- Cross-reference the breakdown's `spawn=`, `deferredCreated=`,
-  `observabilityCapture=` buckets against whichever was largest in the
-  one-shot line.
+The frequency itself (2 playback breaches in an hour-long session, plus 1
+recording breach) is well inside expected Unity-frame jitter and does not
+constitute a regression. The functional fix is therefore **none**: the budget
+itself stays at 8 ms, the existing latches are unchanged.
 
-**Status:** Open. Low priority unless reproducible at higher frequency.
+**Fix:** add a fourth one-shot latch — "Playback hybrid breakdown" — that
+fires when total > budget AND `spawnMaxMicroseconds <
+BuildBreakdownMinHeaviestSpawnMicroseconds` AND `mainLoopMicroseconds <
+MainLoopBreakdownMinMainLoopMicroseconds`. Reuses the existing
+`PlaybackBudgetPhases` field set; adds mainLoop / spawn percent-of-frame
+fractions so a future hybrid breach reports a Phase-B-actionable per-bucket
+itemisation rather than just the generic #414 breakdown that the gap-shaped
+spike in the captured log received.
+
+The new latch is independent of #414 / #450 / #460 (matches the precedent set
+by #460 itself): a session that already burned the prior three latches on
+bigger spikes can still capture the next gap-shaped breach. Test seam
+`SetBug460BreakdownLatchFiredForTesting` lets the independence pair-test
+between #460 and #581 land without reaching for `ResetForTesting`.
+
+Regression `Bug581HybridBreakdownTests` (8 cases: captured-log-shape format,
+one-shot latch, two negative-gate cases asserting the latch declines on
+#450-shape and #460-shape spikes, two latch-independence cases for #450 and
+#460, total-below-budget defensive case, zero-total degenerate-case
+non-throwing).
+
+**Status:** CLOSED 2026-04-25. Fixed for v0.9.0 — observability-only, no
+functional change to the budget itself.
 
 ---
 


### PR DESCRIPTION
## Summary

Two log-noise / observability cleanups that landed together because they're scope-adjacent and small.

### #576 — 146 PatchedSnapshot `solver unavailable` WARNs

**Cause** (parsed from `logs/2026-04-25_1314_marker-validator-fix/KSP.log`):

| vessel | hits | population |
|---|---|---|
| `Kerbal X Debris` | 77 | `VesselType.Debris` — no command module → no solver by design |
| `Ermore Kerman` | 45 | EVA kerbal — kerbal jetpack motion, no solver by design |
| `Magdo Kerman` | 12 | EVA kerbal — same |
| `Kerbal X Probe` | 11 | probe-debris that lost active-vessel solver state |
| `Kerbal X` | 1 | the lone genuine "transient" hit the WARN tier was designed for |

The downstream `IncompleteBallisticSceneExitFinalizer` (lines 280-286 in the file) explicitly documents that `NullSolver` is the destroyed-vessel / no-solver-by-design fingerprint that drives the live-orbit fallback — the WARN tier was correct as a fallback signal but wrong for log noise of this shape.

**Fix:** swap both paired warns from `Warn` to `WarnRateLimited`:
- `PatchedConicSnapshot.cs` — key `solver-unavailable-{vesselName}`
- `IncompleteBallisticSceneExitFinalizer.cs` — key `finalize-snapshot-failed-{recordingId}-{failureReason}`

`FailureReason = NullSolver` flow downstream is unchanged. First hit per key still WARNs immediately so a fresh regression on a piloted craft surfaces; subsequent hits within 30 s absorb with a `suppressed=N` suffix.

### #581 — diagnostic gap between #450 and #460 sub-breakdowns

**Cause:** the captured log's only budget-exceeded frame was `total=11.6ms mainLoop=7.51ms spawn=3.44ms (built=1 throttled=0 max=3.44ms)`. That's a hybrid spike (mainLoop 65 % + spawn 30 %) that fits *neither* existing sub-breakdown latch:

- **#450** gate: `spawnMaxMicroseconds >= 15 ms` — heaviest spawn was 3.44 ms.
- **#460** gate: `mainLoop >= 10 ms` AND `spawn < 1 ms` — mainLoop was 7.51 ms.

`grep "mainLoop breakdown\|spawn build breakdown" KSP.log` → 0 hits. The session captured the generic #414 breakdown but no Phase-B attribution.

**Fix:** add a fourth one-shot latch `s_hybridBreakdownOneShotFired` in `DiagnosticsComputation.cs`. Gates on the *gap* between #450 and #460 (heaviest spawn under #450's threshold AND mainLoop under #460's floor); emits the full per-bucket itemisation plus `mainLoop` / `spawn` percent-of-frame fractions. New `SetBug460BreakdownLatchFiredForTesting` seam matches the precedent set by #460.

**Frequency note:** 2 playback breaches in an hour-long session is well inside expected Unity-frame jitter. No functional change to the budget itself — observability only, so the next hybrid breach is actionable instead of falling into the gap.

## Test plan

- [x] `cd Source/Parsek.Tests && dotnet test` — 8719 passing (8701+ baseline + 10 new).
- [x] New `PatchedConicSnapshotTests.Snapshot_NullSolver_RateLimitsRepeatsForSameVessel` — 10 same-vessel hits in a 1 s window emit only 1 WARN; cross-vessel emits its own; 30 s window expiry suffix is `suppressed=9`.
- [x] New `SceneExitFinalizationIntegrationTests.TryCompleteFinalizationFromPatchedSnapshot_NullSolver_WarnRateLimitedPerRecordingAndReason` — 5 same-recording hits emit 1 WARN; different recording id emits its own.
- [x] New `Bug581HybridBreakdownTests` (8 cases): captured-log-shape format pin, one-shot latch, two negative-gate cases for #450-shape and #460-shape spikes, two latch-independence cases vs #450 / #460, total-below-budget defensive, zero-total non-throwing.
- [x] Pre-existing `Snapshot_NullSolver_ReturnsEmptyList` updated to assert the WARN level (`[Parsek][WARN][PatchedSnapshot]`) on the first hit per key — proves the rate limiter still emits at WARN for the first hit.
- [x] Pre-existing `Bug414BudgetBreakdownTests`, `Bug450BuildBreakdownTests`, `Bug460MainLoopBreakdownTests` all green — verified the new latch's gates do not collide with the existing latches' shapes.
- [x] Deployed DLL grepped for new UTF-16 strings: `solver-unavailable-`, `finalize-snapshot-failed-`, `Playback hybrid breakdown`, `first sub-#450/#460 hybrid spike` — all 1 hit each, build was deployed cleanly.

## Notes

- `CHANGELOG.md` updated under v0.9.0 Bug Fixes (one line per item).
- `docs/dev/todo-and-known-bugs.md` updated — both #576 and #581 marked CLOSED 2026-04-25.