### PR TITLE
Fix #583: Relative-frame state-vector ghost creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ All notable changes to Parsek are documented here.
 
 - `#584` Flight-scene state-vector update path no longer thresholds a Relative-frame point's anchor-local dz as if it were geographic altitude, so a ghost in a docking/rendezvous Relative section is no longer wrongly removed and re-deferred (review follow-up). Source-resolve decision lines now carry the real recording index (`-1` sentinel when unknown) instead of misleadingly logging every entry as `idx=0`.
 
+- `#583` Map-view state-vector ghost creation now also fires when the first map-visible UT lands inside a Relative-frame docking/rendezvous section, so a recording that starts already-relative gets a map vessel attached to its anchor instead of staying invisible until the trajectory leaves the section.
+
 - `#578` Crew orphan-placement misses now distinguish a wrong active vessel from a full matching pod, so stand-ins stay available for a later correct-vessel retry without falling back to an unrelated seat.
 
 - Re-fly merge now supersedes every chain segment of an env-split crashed recording. Previously the closure walker followed `ChildBranchPointId` only, so an exo HEAD + in-atmo TIP chain produced by `RecordingOptimizer.SplitAtSection` left the TIP behind as an orphan "kerbal destroyed in atmo" row alongside the new "kerbal lived" provisional. Saves committed before this fix that already completed a chain-crossing crashed re-fly merge are not retroactively healed; affected players can `Discard` the orphan via the table.

--- a/Source/Parsek.Tests/GhostMapPresenceTests.cs
+++ b/Source/Parsek.Tests/GhostMapPresenceTests.cs
@@ -2177,6 +2177,248 @@ namespace Parsek.Tests
                     && l.Contains("reason=" + GhostMapPresence.TrackingStationGhostSkipRelativeFrame));
         }
 
+        // -----------------------------------------------------------------
+        // #583: When the first map-visible UT lands inside a Relative-frame
+        // section, the resolver used to short-circuit to None because
+        // TryResolveStateVectorMapPoint flatly rejected Relative-frame
+        // points and the outer gate was `!HasOrbitSegments` only. The fix
+        // widens the gate (Relative-frame currentUT is also considered for
+        // state-vector resolution) and allows StateVector creation when the
+        // section's anchor vessel is resolvable in the scene; otherwise it
+        // defers with a dedicated "relative-anchor-unresolved" skip reason
+        // so CheckPendingMapVessels retries on the next tick.
+        //
+        // CreateGhostVesselFromStateVectors already has a working Relative
+        // branch (PR #547) that resolves world position via the anchor
+        // pose, so flowing StateVector through gives the existing creator
+        // the right input shape — no new ghost-source kind needed.
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public void ResolveMapPresenceGhostSource_RelativeFrame_AnchorResolvable_ReturnsStateVector()
+        {
+            var rec = BuildRelativeFrameRecording(
+                anchorVesselId: 999u,
+                pointDz: 0.5,
+                pointSpeed: 0.2);
+
+            // Production path looks anchors up via FlightRecorder.FindVesselByPid.
+            // Override the test seam to simulate "anchor present in scene".
+            GhostMapPresence.AnchorResolvableForTesting = pid => pid == 999u;
+
+            int mapCached = -1;
+            var source = GhostMapPresence.ResolveMapPresenceGhostSource(
+                rec,
+                false,
+                false,
+                200,
+                false,
+                "test-rel-anchor-ok",
+                ref mapCached,
+                out _,
+                out TrajectoryPoint statePoint,
+                out string skipReason);
+
+            Assert.Equal(GhostMapPresence.TrackingStationGhostSource.StateVector, source);
+            Assert.Null(skipReason);
+            Assert.Equal("Mun", statePoint.bodyName);
+            Assert.Contains(logLines,
+                l => l.Contains("[GhostMap]")
+                    && l.Contains("test-rel-anchor-ok")
+                    && l.Contains("source=StateVector"));
+        }
+
+        [Fact]
+        public void ResolveMapPresenceGhostSource_RelativeFrame_AnchorUnresolvable_DefersWithRelativeAnchorUnresolved()
+        {
+            var rec = BuildRelativeFrameRecording(
+                anchorVesselId: 999u,
+                pointDz: 0.5,
+                pointSpeed: 0.2);
+
+            // Anchor PID is set but the scene lookup fails (anchor not yet
+            // loaded into FlightGlobals.Vessels).
+            GhostMapPresence.AnchorResolvableForTesting = pid => false;
+
+            int mapCached = -1;
+            var source = GhostMapPresence.ResolveMapPresenceGhostSource(
+                rec,
+                false,
+                false,
+                200,
+                false,
+                "test-rel-anchor-missing",
+                ref mapCached,
+                out _,
+                out _,
+                out string skipReason);
+
+            Assert.Equal(GhostMapPresence.TrackingStationGhostSource.None, source);
+            Assert.Equal(GhostMapPresence.TrackingStationGhostSkipRelativeAnchorUnresolved, skipReason);
+            Assert.Contains(logLines,
+                l => l.Contains("[GhostMap]")
+                    && l.Contains("test-rel-anchor-missing")
+                    && l.Contains("reason=" + GhostMapPresence.TrackingStationGhostSkipRelativeAnchorUnresolved));
+        }
+
+        [Fact]
+        public void ResolveMapPresenceGhostSource_RelativeFrame_NoAnchorId_StillSkipsWithRelativeFrame()
+        {
+            // Sections without an anchor id (legacy / synthetic) keep the
+            // pre-#583 skip-reason wording so the path is observably distinct
+            // from "anchor present but not yet resolvable".
+            var rec = BuildRelativeFrameRecording(
+                anchorVesselId: 0u,
+                pointDz: 0.5,
+                pointSpeed: 0.2);
+
+            GhostMapPresence.AnchorResolvableForTesting = pid => true;
+
+            int mapCached = -1;
+            var source = GhostMapPresence.ResolveMapPresenceGhostSource(
+                rec,
+                false,
+                false,
+                200,
+                false,
+                "test-rel-no-anchor",
+                ref mapCached,
+                out _,
+                out _,
+                out string skipReason);
+
+            Assert.Equal(GhostMapPresence.TrackingStationGhostSource.None, source);
+            Assert.Equal(GhostMapPresence.TrackingStationGhostSkipRelativeFrame, skipReason);
+        }
+
+        [Fact]
+        public void ResolveMapPresenceGhostSource_RelativeFrame_DzBelowAltitudeThreshold_StillReturnsStateVector()
+        {
+            // The whole point of the #583 fix: dz~0 (typical docking offset)
+            // must NOT trip the state-vector altitude threshold for
+            // Relative-frame points — the threshold is meaningful only for
+            // Absolute-frame points where altitude is geographic. Pin the
+            // joint behaviour: an Absolute-frame point with the same numeric
+            // altitude/speed would fail ShouldCreateStateVectorOrbit; the
+            // Relative-frame point must still produce StateVector because
+            // the threshold check is bypassed for that branch.
+            var rec = BuildRelativeFrameRecording(
+                anchorVesselId: 42u,
+                pointDz: 0.5,
+                pointSpeed: 0.2);
+
+            // Sanity: the same numbers as an Absolute-frame state-vector
+            // recording would fall under the airless-body create threshold
+            // (alt > 1500 && speed > 60).
+            Assert.False(GhostMapPresence.ShouldCreateStateVectorOrbit(0.5, 0.2, 0));
+
+            GhostMapPresence.AnchorResolvableForTesting = pid => pid == 42u;
+
+            int mapCached = -1;
+            var source = GhostMapPresence.ResolveMapPresenceGhostSource(
+                rec,
+                false,
+                false,
+                200,
+                false,
+                "test-rel-dz",
+                ref mapCached,
+                out _,
+                out _,
+                out string skipReason);
+
+            Assert.Equal(GhostMapPresence.TrackingStationGhostSource.StateVector, source);
+            Assert.Null(skipReason);
+        }
+
+        [Fact]
+        public void ResolveMapPresenceGhostSource_RelativeFrame_WithOrbitSegmentsElsewhere_StillReachesStateVectorBranch()
+        {
+            // Pre-#583: a recording with OrbitSegments anywhere short-circuited
+            // the state-vector branch (`if (!traj.HasOrbitSegments)`), so a
+            // currentUT inside a Relative section between segments produced
+            // None. The fix widens the gate to also consider state-vector
+            // resolution when IsInRelativeFrame(currentUT) is true.
+            var rec = BuildRelativeFrameRecording(
+                anchorVesselId: 7u,
+                pointDz: 0.5,
+                pointSpeed: 0.2);
+            // Add an unrelated orbit segment far before the Relative section
+            // so HasOrbitSegments=true but it doesn't cover currentUT.
+            rec.OrbitSegments = new List<OrbitSegment>
+            {
+                new OrbitSegment
+                {
+                    startUT = 0,
+                    endUT = 50,
+                    bodyName = "Kerbin",
+                    semiMajorAxis = 700000
+                }
+            };
+
+            GhostMapPresence.AnchorResolvableForTesting = pid => pid == 7u;
+
+            int mapCached = -1;
+            var source = GhostMapPresence.ResolveMapPresenceGhostSource(
+                rec,
+                false,
+                false,
+                200,
+                false,
+                "test-rel-with-segments",
+                ref mapCached,
+                out _,
+                out _,
+                out string skipReason);
+
+            Assert.Equal(GhostMapPresence.TrackingStationGhostSource.StateVector, source);
+            Assert.Null(skipReason);
+        }
+
+        private static Recording BuildRelativeFrameRecording(
+            uint anchorVesselId, double pointDz, double pointSpeed)
+        {
+            return new Recording
+            {
+                RecordingId = "state-vector-relative-anchor",
+                TerminalStateValue = TerminalState.SubOrbital,
+                Points = new List<TrajectoryPoint>
+                {
+                    new TrajectoryPoint
+                    {
+                        ut = 100,
+                        bodyName = "Mun",
+                        // In RELATIVE sections the lat/lon/altitude fields are
+                        // anchor-local x/y/z metres, not geographic — name them
+                        // accordingly so future readers don't get confused.
+                        latitude = 0.1,
+                        longitude = 0.2,
+                        altitude = pointDz,
+                        velocity = new UnityEngine.Vector3(0, (float)pointSpeed, 0)
+                    },
+                    new TrajectoryPoint
+                    {
+                        ut = 300,
+                        bodyName = "Mun",
+                        latitude = 0.3,
+                        longitude = 0.4,
+                        altitude = pointDz,
+                        velocity = new UnityEngine.Vector3(0, (float)pointSpeed, 0)
+                    }
+                },
+                TrackSections = new List<TrackSection>
+                {
+                    new TrackSection
+                    {
+                        startUT = 100,
+                        endUT = 300,
+                        referenceFrame = ReferenceFrame.Relative,
+                        anchorVesselId = anchorVesselId
+                    }
+                }
+            };
+        }
+
         [Fact]
         public void ResolveMapPresenceGhostSource_NoTerminalFallback_StateVectorFailure_NormalizesSkipReason()
         {

--- a/Source/Parsek.Tests/GhostMapPresenceTests.cs
+++ b/Source/Parsek.Tests/GhostMapPresenceTests.cs
@@ -1749,6 +1749,89 @@ namespace Parsek.Tests
             Assert.Equal("tracking-station-state-vector-expired", reasonPastEnd);
         }
 
+        // -----------------------------------------------------------------
+        // PR #556 follow-up — keep relative-frame state-vector ghosts alive
+        // through tracking-station refresh cycles. Mirrors the flight-scene
+        // guard tested in
+        // RuntimePolicyTests.RelativeFrameGuard_DzBelowAltitudeThreshold_WouldTripRemovalWithoutGate.
+        // The tracking-station refresh path used to remove any state-vector
+        // ghost whose currentUT was inside a Relative section; after #583
+        // the resolver creates these intentionally, so the refresh path
+        // would tear them down every cycle while the create path re-added
+        // them next tick. The fix gates the threshold check on
+        // !IsInRelativeFrame and the Relative branch flows straight into
+        // UpdateGhostOrbitFromStateVectors (which already dispatches on
+        // referenceFrame). The two-fact tripwire below pins the joint
+        // preconditions: in a Relative section, dz-as-altitude WOULD trip
+        // ShouldRemoveStateVectorOrbit if the gate weren't suppressing it.
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public void TrackingStationRefresh_RelativeFrameStateVector_WouldTripRemovalWithoutGate()
+        {
+            var rec = new Recording
+            {
+                RecordingId = "ts-relative-state-vector",
+                TrackSections = new List<TrackSection>
+                {
+                    new TrackSection
+                    {
+                        referenceFrame = ReferenceFrame.Relative,
+                        startUT = 1658.96,
+                        endUT = 1668.14,
+                        anchorVesselId = 12345u
+                    }
+                }
+            };
+            const double currentUT = 1662.0;
+            const double dzAsAltitude = -0.31; // anchor-local dz, not geographic alt
+            const double worldVelocityMag = 2920.0;
+            const double airlessAtmosphereDepth = 0;
+
+            Assert.True(
+                GhostMapPresence.IsInRelativeFrame(rec, currentUT),
+                "current UT lies inside the Relative-frame section");
+            Assert.True(
+                GhostMapPresence.ShouldRemoveStateVectorOrbit(
+                    dzAsAltitude, worldVelocityMag, airlessAtmosphereDepth),
+                "without the IsInRelativeFrame gate in RefreshTrackingStationGhosts, "
+                + "dz~0 would trip the altitude threshold and remove the ghost every "
+                + "refresh tick — the create path would re-add it next tick → flicker. "
+                + "The gate suppresses the threshold for Relative-frame points so "
+                + "UpdateGhostOrbitFromStateVectors stays in charge of the cycle.");
+        }
+
+        [Fact]
+        public void TrackingStationRefresh_AbsoluteFrameStateVector_StillEvaluatesThreshold()
+        {
+            // Discriminator: an Absolute-frame point with the same low
+            // altitude legitimately trips the threshold and removes the
+            // ghost. The gate must apply only to Relative frames.
+            var rec = new Recording
+            {
+                RecordingId = "ts-absolute-state-vector",
+                TrackSections = new List<TrackSection>
+                {
+                    new TrackSection
+                    {
+                        referenceFrame = ReferenceFrame.Absolute,
+                        startUT = 1658.96,
+                        endUT = 1668.14
+                    }
+                }
+            };
+            const double currentUT = 1662.0;
+
+            Assert.False(
+                GhostMapPresence.IsInRelativeFrame(rec, currentUT),
+                "Absolute section: gate must NOT bypass the threshold check");
+            Assert.True(
+                GhostMapPresence.ShouldRemoveStateVectorOrbit(
+                    altitude: -0.31, speed: 2920.0, atmosphereDepth: 0),
+                "Absolute frame: alt~0 below threshold legitimately removes "
+                + "the ghost (state-vector subsurface drift case).");
+        }
+
         /// <summary>
         /// Same-body gap with a real orbit change should not be carried across.
         /// </summary>

--- a/Source/Parsek/GhostMapPresence.cs
+++ b/Source/Parsek/GhostMapPresence.cs
@@ -301,6 +301,18 @@ namespace Parsek
         internal const string TrackingStationGhostSkipUnseedableTerminalOrbit = "terminal-orbit-unseedable";
         internal const string TrackingStationGhostSkipStateVectorThreshold = "state-vector-threshold";
         internal const string TrackingStationGhostSkipRelativeFrame = "relative-frame";
+        // #583: Relative-frame state-vector ghost CREATION reaches the resolver
+        // when the first map-visible UT lies inside a Relative section. We allow
+        // creation through the existing StateVector source kind iff the section's
+        // anchor vessel is resolvable in the scene (CreateGhostVesselFromStateVectors
+        // already dispatches on referenceFrame and resolves world position via the
+        // anchor in the Relative branch — PR #547). When the anchor is not yet
+        // resolvable, defer with this dedicated skip reason so the pending-create
+        // queue retries on the next tick. Distinct from `relative-frame` (the
+        // legacy "always defer" reason kept for sections without an anchor id —
+        // those have no resolvable anchor by construction and are unreachable
+        // from the new path).
+        internal const string TrackingStationGhostSkipRelativeAnchorUnresolved = "relative-anchor-unresolved";
         internal const string TrackingStationSpawnSkipRewindPending = "rewind-ut-adjustment-pending";
         internal const string TrackingStationSpawnSkipBeforeEnd = "before-recording-end";
         internal const string TrackingStationSpawnSkipIntermediateChainSegment = "intermediate-chain-segment";
@@ -312,6 +324,13 @@ namespace Parsek
         internal const double StateVectorRemoveSpeed = 30;        // m/s
         private const double LegacyPointCoverageMaxGapSeconds = 30.0;
         internal static Func<double> CurrentUTNow = GetCurrentUTSafe;
+
+        // #583 test seam: production looks the anchor up via
+        // FlightRecorder.FindVesselByPid (which short-circuits to null when
+        // FlightGlobals.Vessels is unavailable, e.g. xUnit). Tests that need
+        // to exercise the "anchor resolvable in scene" branch override this
+        // delegate; ResetForTesting clears it back to null.
+        internal static Func<uint, bool> AnchorResolvableForTesting = null;
 
         internal struct GhostProtoOrbitSeedDiagnostics
         {
@@ -1780,7 +1799,18 @@ namespace Parsek
             }
 
             string stateVectorSkipReason = null;
-            if (!traj.HasOrbitSegments)
+            // #583: try state-vector resolution when there are no orbit segments
+            // (the original physics-only-suborbital case) OR when the current UT
+            // sits inside a Relative-frame section. The latter widens the gate
+            // so a recording with OrbitalCheckpoint segments elsewhere can still
+            // get a map ghost while the playback head is in the docking /
+            // rendezvous section — CreateGhostVesselFromStateVectors's Relative
+            // branch (PR #547) handles the world-position resolution against
+            // the anchor vessel.
+            bool considerStateVector =
+                !traj.HasOrbitSegments
+                || IsInRelativeFrame(traj, currentUT);
+            if (considerStateVector)
             {
                 if (TryResolveStateVectorMapPoint(
                     traj,
@@ -1803,9 +1833,8 @@ namespace Parsek
 
             if (!allowTerminalOrbitFallback)
             {
-                skipReason = traj.HasOrbitSegments
-                    ? "no-current-segment"
-                    : NormalizeStateVectorSkipReasonForNoOrbit(stateVectorSkipReason);
+                skipReason = ResolveStateVectorOrSegmentSkipReason(
+                    traj, considerStateVector, stateVectorSkipReason);
                 return ReturnDecision(
                     TrackingStationGhostSource.None,
                     skipReason,
@@ -1814,9 +1843,8 @@ namespace Parsek
 
             if (!HasOrbitData(traj))
             {
-                skipReason = traj.HasOrbitSegments
-                    ? "no-current-segment"
-                    : NormalizeStateVectorSkipReasonForNoOrbit(stateVectorSkipReason);
+                skipReason = ResolveStateVectorOrSegmentSkipReason(
+                    traj, considerStateVector, stateVectorSkipReason);
                 return ReturnDecision(
                     TrackingStationGhostSource.None,
                     skipReason,
@@ -2230,10 +2258,77 @@ namespace Parsek
             return true;
         }
 
+        // #583: when state-vector resolution was attempted (either because
+        // there are no orbit segments OR because we're in a Relative section)
+        // and produced a meaningful skip reason — relative-frame /
+        // relative-anchor-unresolved / state-vector-threshold — surface that
+        // reason. Otherwise fall back to the legacy split between
+        // `no-current-segment` (orbit-bearing recording) and `no-orbit-data`
+        // (state-vector-only recording with no points). Preserves the prior
+        // log-shape contract for callers that don't reach the new Relative
+        // gate while making the new defer-and-retry skip reasons visible in
+        // the structured source-resolve line.
+        private static string ResolveStateVectorOrSegmentSkipReason(
+            IPlaybackTrajectory traj,
+            bool considerStateVector,
+            string stateVectorSkipReason)
+        {
+            if (considerStateVector
+                && !string.IsNullOrEmpty(stateVectorSkipReason)
+                && stateVectorSkipReason != "no-points"
+                && stateVectorSkipReason != "no-state-vector-point")
+            {
+                return stateVectorSkipReason;
+            }
+            return traj.HasOrbitSegments
+                ? "no-current-segment"
+                : NormalizeStateVectorSkipReasonForNoOrbit(stateVectorSkipReason);
+        }
+
         private static bool TryResolveStateVectorMapPoint(
             IPlaybackTrajectory traj,
             double currentUT,
             ref int cachedIndex,
+            out TrajectoryPoint point,
+            out string skipReason)
+        {
+            return TryResolveStateVectorMapPointPure(
+                traj,
+                currentUT,
+                ref cachedIndex,
+                ResolveAnchorInScene,
+                out point,
+                out skipReason);
+        }
+
+        // Production anchor-resolvability lookup. Honours the test seam so
+        // pure-xUnit cases can exercise the "anchor resolvable" Relative-frame
+        // branch without instantiating Unity's FlightGlobals.
+        private static bool ResolveAnchorInScene(uint anchorPid)
+        {
+            if (anchorPid == 0u) return false;
+            if (AnchorResolvableForTesting != null)
+                return AnchorResolvableForTesting(anchorPid);
+            return FlightRecorder.FindVesselByPid(anchorPid) != null;
+        }
+
+        /// <summary>
+        /// Resolve whether a state-vector trajectory point exists at the current
+        /// UT and is suitable for ghost map creation. #583: when the current UT
+        /// lies inside a Relative-frame section, the recorded
+        /// <c>point.altitude</c> is the anchor-local dz offset (metres), not
+        /// geographic altitude — the create/remove altitude thresholds are
+        /// meaningless and are skipped. Creation in that branch is gated on the
+        /// section's anchor being resolvable in the scene; otherwise we defer
+        /// to the next tick so <see cref="ParsekPlaybackPolicy.CheckPendingMapVessels"/>
+        /// can retry. Pure: the caller supplies the anchor-resolvability lookup
+        /// so xUnit tests can exercise both branches without FlightGlobals.
+        /// </summary>
+        internal static bool TryResolveStateVectorMapPointPure(
+            IPlaybackTrajectory traj,
+            double currentUT,
+            ref int cachedIndex,
+            Func<uint, bool> anchorResolvable,
             out TrajectoryPoint point,
             out string skipReason)
         {
@@ -2253,10 +2348,53 @@ namespace Parsek
                 return false;
             }
 
-            if (IsInRelativeFrame(traj, currentUT))
+            // Resolve the section covering currentUT once — the Relative branch
+            // needs the anchorVesselId, the Absolute branch needs nothing more.
+            TrackSection? currentSection = null;
+            if (traj.TrackSections != null && traj.TrackSections.Count > 0)
             {
-                skipReason = TrackingStationGhostSkipRelativeFrame;
-                return false;
+                int sectionIdx = TrajectoryMath.FindTrackSectionForUT(traj.TrackSections, currentUT);
+                if (sectionIdx >= 0 && sectionIdx < traj.TrackSections.Count)
+                    currentSection = traj.TrackSections[sectionIdx];
+            }
+
+            bool inRelative = currentSection.HasValue
+                && currentSection.Value.referenceFrame == ReferenceFrame.Relative;
+
+            if (inRelative)
+            {
+                uint anchorPid = currentSection.Value.anchorVesselId;
+                // Sections without an anchor id (legacy/synthetic) have no
+                // resolvable anchor pose by construction. Surface as the
+                // long-standing `relative-frame` reason to preserve pre-#583
+                // behaviour for that subset (no map presence inside the
+                // section, no log churn from a new reason kind).
+                if (anchorPid == 0u)
+                {
+                    skipReason = TrackingStationGhostSkipRelativeFrame;
+                    return false;
+                }
+                if (anchorResolvable == null || !anchorResolvable(anchorPid))
+                {
+                    skipReason = TrackingStationGhostSkipRelativeAnchorUnresolved;
+                    return false;
+                }
+
+                TrajectoryPoint? relPt = TrajectoryMath.BracketPointAtUT(traj.Points, currentUT, ref cachedIndex);
+                if (!relPt.HasValue)
+                {
+                    skipReason = "no-state-vector-point";
+                    return false;
+                }
+
+                // Threshold check is intentionally skipped: point.altitude is
+                // the anchor-local dz (metres along the anchor's local z), not
+                // geographic altitude. Symmetric to the PR #547 P1 update-path
+                // gate in ParsekPlaybackPolicy.CheckPendingMapVessels (lines
+                // 1042-1056) which skips ShouldRemoveStateVectorOrbit for the
+                // same reason.
+                point = relPt.Value;
+                return true;
             }
 
             TrajectoryPoint? pt = TrajectoryMath.BracketPointAtUT(traj.Points, currentUT, ref cachedIndex);
@@ -4095,6 +4233,7 @@ namespace Parsek
         internal static void ResetForTesting()
         {
             CurrentUTNow = GetCurrentUTSafe;
+            AnchorResolvableForTesting = null;
             ghostMapVesselPids.Clear();
             ghostsWithSuppressedIcon.Clear();
             ghostOrbitBounds.Clear();

--- a/Source/Parsek/GhostMapPresence.cs
+++ b/Source/Parsek/GhostMapPresence.cs
@@ -2680,22 +2680,41 @@ namespace Parsek
                         ref cachedStateVectorIndex);
                     trackingStationStateVectorCachedIndices[idx] = cachedStateVectorIndex;
 
-                    if (!pt.HasValue || IsInRelativeFrame(rec, currentUT))
+                    if (!pt.HasValue)
                     {
                         if (toRemove == null) toRemove = new List<(int, string)>();
                         toRemove.Add((idx, "tracking-station-state-vector-expired"));
                         continue;
                     }
 
-                    double atmosphereDepth = GetAtmosphereDepth(pt.Value.bodyName);
-                    if (ShouldRemoveStateVectorOrbit(
-                        pt.Value.altitude,
-                        pt.Value.velocity.magnitude,
-                        atmosphereDepth))
+                    // PR #556 follow-up: a Relative-frame state-vector ghost
+                    // must NOT be expired/removed just because the section is
+                    // Relative — pre-#583 the only way to get a Relative
+                    // currentUT here was a stale ghost the resolver would
+                    // never recreate, so killing it was safe. After #583 the
+                    // resolver creates these on purpose; the threshold check
+                    // is meaningless for Relative-frame points (point.altitude
+                    // is anchor-local dz, not geographic altitude) and would
+                    // tear the ghost down every cycle, then the create path
+                    // re-adds it next tick → flicker. Mirror the flight-scene
+                    // gate in ParsekPlaybackPolicy.CheckPendingMapVessels and
+                    // skip the threshold for Relative-frame points;
+                    // UpdateGhostOrbitFromStateVectors already dispatches on
+                    // referenceFrame and resolves world position via the
+                    // anchor for that branch.
+                    bool inRelativeFrame = IsInRelativeFrame(rec, currentUT);
+                    if (!inRelativeFrame)
                     {
-                        if (toRemove == null) toRemove = new List<(int, string)>();
-                        toRemove.Add((idx, "below-state-vector-threshold"));
-                        continue;
+                        double atmosphereDepth = GetAtmosphereDepth(pt.Value.bodyName);
+                        if (ShouldRemoveStateVectorOrbit(
+                            pt.Value.altitude,
+                            pt.Value.velocity.magnitude,
+                            atmosphereDepth))
+                        {
+                            if (toRemove == null) toRemove = new List<(int, string)>();
+                            toRemove.Add((idx, "below-state-vector-threshold"));
+                            continue;
+                        }
                     }
 
                     UpdateGhostOrbitFromStateVectors(idx, rec, pt.Value, currentUT);

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -794,6 +794,22 @@ tests (`ResolveMapPresenceGhostSource_RelativeFrame_AnchorResolvable_*`,
 `_AnchorUnresolvable_*`, `_NoAnchorId_*`, `_DzBelowAltitudeThreshold_*`,
 `_WithOrbitSegmentsElsewhere_*`) pin the new contract.
 
+PR #556 review follow-up (P2): `RefreshTrackingStationGhosts` used to
+expire any state-vector ghost whose currentUT was inside a Relative
+section (`if (!pt.HasValue || IsInRelativeFrame(rec, currentUT))` →
+`tracking-station-state-vector-expired`). After widening the resolver,
+that path tore the ghost down every refresh tick while the create path
+re-added it next tick — flicker. The refresh path now mirrors the
+flight-scene gate in `ParsekPlaybackPolicy.CheckPendingMapVessels`:
+remove on `!pt.HasValue` only, then skip the
+`ShouldRemoveStateVectorOrbit` threshold for Relative-frame points and
+hand off to `UpdateGhostOrbitFromStateVectors` (which already dispatches
+on `referenceFrame`). Two more tripwires
+(`TrackingStationRefresh_RelativeFrameStateVector_WouldTripRemovalWithoutGate`
+and `_AbsoluteFrameStateVector_StillEvaluatesThreshold`) document the
+joint precondition the gate suppresses, mirroring the existing
+flight-scene `RuntimePolicyTests.RelativeFrameGuard_*` pair.
+
 ---
 
 ## ~~584. State-vector ghost map paths fed RELATIVE-frame anchor offsets into `body.GetWorldSurfacePosition`~~

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -699,7 +699,7 @@ being addressed by the sibling
 
 ---
 
-## 583. Map-view state-vector ghost creation still skips when activation first lands inside a Relative-frame section
+## ~~583. Map-view state-vector ghost creation still skips when activation first lands inside a Relative-frame section~~
 
 **Source:** PR #547 review follow-up — out-of-scope note attached to the
 P1 fix that landed in commit `57aec636` on
@@ -770,9 +770,29 @@ overclaims relative to the resolver gap left here. When the
 implementing PR for #583 lands, add a sibling `#583` line under v0.9.0
 Bug Fixes naming the creation-side fix.
 
-**Status:** Open. Not a regression of any shipped fix; a known remaining
-edge case that was deliberately left out of PR #547's scope (PR #547
-merged 2026-04-25 as commit `8eaebfbb`).
+**Status:** ~~Open~~ Fixed.
+
+**Fix:** `GhostMapPresence.ResolveMapPresenceGhostSource` now considers
+state-vector resolution when the current UT lies inside a Relative-frame
+section even if the trajectory has `OrbitSegments` elsewhere (the gate
+widens from `!HasOrbitSegments` to `!HasOrbitSegments || IsInRelativeFrame`).
+`TryResolveStateVectorMapPoint` was rewritten as a pure helper
+(`TryResolveStateVectorMapPointPure`) that takes a `Func<uint,bool>`
+anchor-resolvability lookup, so xUnit can exercise both branches without
+KSP's `FlightGlobals`. In the Relative branch the helper bypasses the
+`ShouldCreateStateVectorOrbit` altitude/speed threshold (mirroring the
+PR #547 P1 update-path gate, since `point.altitude` is the anchor-local
+dz offset, not geographic altitude) and gates creation on
+`FlightRecorder.FindVesselByPid(anchorVesselId) != null`. When the
+anchor isn't yet loaded, the resolver returns `None` with a new
+dedicated skip reason `relative-anchor-unresolved`; the existing
+`pendingMapVessels` retry loop in `ParsekPlaybackPolicy.CheckPendingMapVessels`
+re-resolves on the next tick. Sections without an anchor id keep the
+legacy `relative-frame` skip wording so that subset is observably
+distinct from "anchor present but not yet resolvable". Five regression
+tests (`ResolveMapPresenceGhostSource_RelativeFrame_AnchorResolvable_*`,
+`_AnchorUnresolvable_*`, `_NoAnchorId_*`, `_DzBelowAltitudeThreshold_*`,
+`_WithOrbitSegmentsElsewhere_*`) pin the new contract.
 
 ---
 


### PR DESCRIPTION
## Summary

- Closes #583. Map-view state-vector ghost creation now also fires when the first map-visible UT lands inside a Relative-frame docking/rendezvous section, so a recording that starts already-relative gets a map vessel attached to its anchor instead of staying invisible until the trajectory leaves the section.
- The map-presence resolver gate widens from `!HasOrbitSegments` to `!HasOrbitSegments || IsInRelativeFrame(currentUT)`. `TryResolveStateVectorMapPoint` is rewritten as a pure helper (`TryResolveStateVectorMapPointPure`) taking an anchor-resolvability `Func<uint,bool>` so xUnit can drive both branches without `FlightGlobals`. In the Relative branch the helper bypasses the `ShouldCreateStateVectorOrbit` altitude/speed threshold (mirrors PR #547 P1 — `point.altitude` is anchor-local dz, not geographic altitude) and gates creation on `FlightRecorder.FindVesselByPid(anchorVesselId) != null`.
- When the anchor isn't yet loaded into the scene, the resolver returns `None` with a new dedicated skip reason `relative-anchor-unresolved`; the existing `pendingMapVessels` retry loop in `ParsekPlaybackPolicy.CheckPendingMapVessels` re-resolves on the next tick. Sections without an anchor id keep the legacy `relative-frame` skip wording, so the two cases stay observably distinct in `[GhostMap]` source-resolve lines.
- `CreateGhostVesselFromStateVectors`'s Relative branch (PR #547) handles the world-position resolution for the new path, so no new ghost-source kind was needed.

## Test plan

- [x] `dotnet test` — 8740 passed, 0 failed.
- [x] Five new regressions in `GhostMapPresenceTests`:
  - `ResolveMapPresenceGhostSource_RelativeFrame_AnchorResolvable_ReturnsStateVector` (happy path)
  - `ResolveMapPresenceGhostSource_RelativeFrame_AnchorUnresolvable_DefersWithRelativeAnchorUnresolved` (defer + new skip reason in structured line)
  - `ResolveMapPresenceGhostSource_RelativeFrame_NoAnchorId_StillSkipsWithRelativeFrame` (legacy subset tripwire)
  - `ResolveMapPresenceGhostSource_RelativeFrame_DzBelowAltitudeThreshold_StillReturnsStateVector` (joint-behaviour with `ShouldCreateStateVectorOrbit`)
  - `ResolveMapPresenceGhostSource_RelativeFrame_WithOrbitSegmentsElsewhere_StillReachesStateVectorBranch` (gate widening)
- [ ] In-game spot check: start a recording already inside a docking-relative section, switch to map view, confirm a ghost vessel appears attached to the anchor instead of waiting for the section to end.

## Notes

- CHANGELOG.md entry under v0.9.0 Bug Fixes ships the player-facing description as a sibling to the two `#584` PR #547 entries.
- `docs/dev/todo-and-known-bugs.md` item #583 closed with a Fix block.