### PR TITLE
Rate-limit checkpoint, milestone, and patcher log spam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,16 @@ All notable changes to Parsek are documented here.
 
 - Unfinished-flight predicate and missed-vessel-switch fallback now rate-limit their per-frame diagnostic lines, so KSP.log is no longer dominated by hundreds of thousands of identical `[UnfinishedFlights]` decisions or repeated `recovering missed vessel switch` warnings during a normal session.
 
+- `#592` Time-warp rate-change checkpoint logs now rate-limit per warp rate, so KSP's chatty `onTimeWarpRateChanged` GameEvent no longer re-emits ~3300 redundant `Time warp rate changed to 1.0x` / `CheckpointAllVessels` / `Active vessel orbit segments handled` lines during a single session of scene transitions and warp-to-here.
+
+- `#593` Repeatable record milestones (`RecordsSpeed`, `RecordsAltitude`, `RecordsDistance`) and their funds/rep modules now rate-limit the `Milestone funds`, `Repeatable record milestone stays effective`, and `Milestone rep at UT` lines per `(milestoneId, recordingId)` pair, so a steady recalc loop no longer re-emits the same milestone application hundreds of times.
+
+- `#594` `KspStatePatcher.PatchMilestones` bare-Id fallback diagnostic now rate-limits per `(nodeId, qualifiedId)` pair so an old-format recording with bare body-specific milestone IDs only logs once per pair per window instead of on every recalc walk.
+
+- `#595` `OrbitalCheckpoint point playback` and `Recorder Sample skipped` rate-limit windows widened from 1.0s and 2.0s to the default 5s, dropping per-section playback churn and stationary-recording skip lines from the hundreds per session into the tens.
+
+- `#596` `KspStatePatcher.PatchFacilities` no longer logs an INFO summary line when there is nothing to patch (`patched=0, skipped=0, notFound=0, total=0`); the no-op case is now a rate-limited Verbose line, and INFO is reserved for the case that actually mutated game state or hit a not-found diagnostic.
+
 - Boring-end trim now clamps the displayed and playable end time to the trimmed trajectory instead of keeping the scene-exit time. Trim diagnostics also report `trimUT` and `lastInterestingUT`.
 - Boring-end trim now tolerates normal landed physics jitter in idle tails while still rejecting meaningful movement. Skipped trims log the first divergent field to make future tolerance problems easier to diagnose.
 - Resume-on-scene-enter screen toast (`Recording STARTED (resume)`) now appears after the flight UI is ready instead of being swallowed during scene load.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,13 +110,13 @@ All notable changes to Parsek are documented here.
 
 - `#592` Time-warp rate-change checkpoint logs now rate-limit per warp rate, so KSP's chatty `onTimeWarpRateChanged` GameEvent no longer re-emits ~3300 redundant `Time warp rate changed to 1.0x` / `CheckpointAllVessels` / `Active vessel orbit segments handled` lines during a single session of scene transitions and warp-to-here.
 
-- `#593` Repeatable record milestones (`RecordsSpeed`, `RecordsAltitude`, `RecordsDistance`) and their funds/rep modules now rate-limit the `Milestone funds`, `Repeatable record milestone stays effective`, and `Milestone rep at UT` lines per `(milestoneId, recordingId)` pair, so a steady recalc loop no longer re-emits the same milestone application hundreds of times.
+- `#593` Repeatable record milestones (`RecordsSpeed`, `RecordsAltitude`, `RecordsDistance`) and their funds/rep modules now rate-limit the `Milestone funds`, `Repeatable record milestone stays effective`, and `Milestone rep at UT` lines per stable action identity, so a steady recalc loop walking the same committed grant collapses to one line while two distinct grants of the same milestone in the same recording at different UT or reward still each log on their first walk.
 
 - `#594` `KspStatePatcher.PatchMilestones` bare-Id fallback diagnostic now rate-limits per `(nodeId, qualifiedId)` pair so an old-format recording with bare body-specific milestone IDs only logs once per pair per window instead of on every recalc walk.
 
 - `#595` `OrbitalCheckpoint point playback` and `Recorder Sample skipped` rate-limit windows widened from 1.0s and 2.0s to the default 5s, dropping per-section playback churn and stationary-recording skip lines from the hundreds per session into the tens.
 
-- `#596` `KspStatePatcher.PatchFacilities` no longer logs an INFO summary line when there is nothing to patch (`patched=0, skipped=0, notFound=0, total=0`); the no-op case is now a rate-limited Verbose line, and INFO is reserved for the case that actually mutated game state or hit a not-found diagnostic.
+- `#596` `KspStatePatcher.PatchFacilities` now gates the INFO summary on real game-state work (`patched + notFound > 0`); skipped-only steady states and the all-zero empty case both route through rate-limited Verbose, so a non-empty `FacilitiesModule` whose facilities are already at their target levels no longer floods INFO every recalc.
 
 - Boring-end trim now clamps the displayed and playable end time to the trimmed trajectory instead of keeping the scene-exit time. Trim diagnostics also report `trimUT` and `lastInterestingUT`.
 - Boring-end trim now tolerates normal landed physics jitter in idle tails while still rejecting meaningful movement. Skipped trims log the first divergent field to make future tolerance problems easier to diagnose.

--- a/Source/Parsek.Tests/BackgroundRecorderTests.cs
+++ b/Source/Parsek.Tests/BackgroundRecorderTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using Xunit;
 
@@ -1331,6 +1332,51 @@ namespace Parsek.Tests
                     l.Contains("CheckpointAllVessels") &&
                     l.Contains("skippedNotOrbital=1") &&
                     l.Contains("skippedNoVessel=1"));
+            }
+            finally
+            {
+                ParsekLog.ResetTestOverrides();
+                ParsekLog.SuppressLogging = true;
+            }
+        }
+
+        [Fact]
+        public void CheckpointAllVessels_RepeatedCallsSameShape_RateLimitedToOneLine()
+        {
+            // Bug #592: KSP's onTimeWarpRateChanged GameEvent fires very
+            // chattily — a single 30-min playtest produced 1122 identical
+            // "CheckpointAllVessels at UT=N: checkpointed=0, ..." lines from
+            // ~1090 redundant 1.0x->1.0x event re-fires. The summary now
+            // routes through VerboseRateLimited keyed by the (checkpointed,
+            // skippedNotOrbital, skippedNoVessel) shape so a burst of
+            // identical no-op summaries collapses into one line per window
+            // while a real change in counts still surfaces immediately on the
+            // first call.
+            var logLines = new List<string>();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+
+            try
+            {
+                var tree = MakeTree((100, "rec_bg1"));
+                var bgRecorder = new BackgroundRecorder(tree);
+                bgRecorder.SetVesselFinderForTesting(pid => null);
+
+                // Call CheckpointAllVessels 50 times back-to-back with the
+                // same UT and the same recording-tree shape — every call
+                // produces the exact same (0, 1, 0) summary tuple.
+                for (int i = 0; i < 50; i++)
+                {
+                    bgRecorder.CheckpointAllVessels(100.0);
+                }
+
+                int summaryLines = logLines.Count(l =>
+                    l.Contains("[BgRecorder]") &&
+                    l.Contains("CheckpointAllVessels at UT=") &&
+                    l.Contains("checkpointed=0") &&
+                    l.Contains("skippedNotOrbital=1") &&
+                    l.Contains("skippedNoVessel=0"));
+                Assert.Equal(1, summaryLines);
             }
             finally
             {

--- a/Source/Parsek.Tests/FundsModuleTests.cs
+++ b/Source/Parsek.Tests/FundsModuleTests.cs
@@ -840,21 +840,24 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void MilestoneEarning_RepeatedSamePair_RateLimitedToOneLine()
+        public void MilestoneEarning_SameActionRecalculated_RateLimitedToOneLine()
         {
-            // Bug #593: ProcessMilestoneEarning is called once per
-            // (milestoneId, recordingId) pair on every recalc walk. In a single
-            // playtest the recalculation engine fired ~57 times, producing 170
-            // identical "Milestone funds: +N, milestoneId=RecordsSpeed, ..."
-            // lines per repeatable record-milestone (510 total across Speed/
-            // Altitude/Distance). The branch now routes through
-            // VerboseRateLimited keyed by (milestoneId, recordingId) so a
-            // steady recalc loop emits at most one line per pair per window.
+            // Bug #593 (P2 follow-up): the rate-limit key is the stable
+            // GameAction.ActionId, not (milestoneId, recordingId). The
+            // intended invariant is "recalculating the SAME action collapses
+            // its log line"; distinct actions with the same milestoneId/
+            // recordingId but different UT or reward must still log on their
+            // first walk because they are real, separate effective hits.
+            //
+            // This test pins the collapsing case: a single action object
+            // re-walked 100 times must emit at most one log line.
+            var action = MakeMilestone(
+                50.0, "RecordsSpeed", 5000f,
+                recordingId: "rec-pair-1", effective: true);
+
             for (int i = 0; i < 100; i++)
             {
-                module.ProcessAction(MakeMilestone(
-                    50 + i * 0.001, "RecordsSpeed", 5000f,
-                    recordingId: "rec-pair-1", effective: true));
+                module.ProcessAction(action);
             }
 
             int speedLines = logLines.Count(l =>
@@ -863,6 +866,66 @@ namespace Parsek.Tests
                 l.Contains("RecordsSpeed") &&
                 l.Contains("rec-pair-1"));
             Assert.Equal(1, speedLines);
+        }
+
+        [Fact]
+        public void MilestoneEarning_DistinctActionsSameMilestoneAndRecording_LogSeparately()
+        {
+            // Bug #593 (P2 follow-up): distinct actions sharing the same
+            // (milestoneId, recordingId) but with different UT or reward
+            // values MUST log separately on their first walk. Suppressing
+            // them would silently drop a real second resource application.
+            //
+            // Two distinct RecordsSpeed grants for rec-A at UT=50 and UT=80
+            // (different ActionId) plus a third grant at UT=80 with a
+            // different reward should produce three distinct log lines.
+            var grantA = MakeMilestone(50.0, "RecordsSpeed", 5000f,
+                recordingId: "rec-A", effective: true);
+            var grantB = MakeMilestone(80.0, "RecordsSpeed", 5000f,
+                recordingId: "rec-A", effective: true);
+            var grantC = MakeMilestone(80.0, "RecordsSpeed", 7500f,
+                recordingId: "rec-A", effective: true);
+
+            // Sanity: GameAction.ActionId auto-assigns to a new GUID for each
+            // construction, so the three actions are genuinely distinct
+            // identities even though milestoneId and recordingId match.
+            Assert.NotEqual(grantA.ActionId, grantB.ActionId);
+            Assert.NotEqual(grantB.ActionId, grantC.ActionId);
+            Assert.NotEqual(grantA.ActionId, grantC.ActionId);
+
+            module.ProcessAction(grantA);
+            module.ProcessAction(grantB);
+            module.ProcessAction(grantC);
+
+            int speedLines = logLines.Count(l =>
+                l.Contains("[Funds]") &&
+                l.Contains("Milestone funds:") &&
+                l.Contains("RecordsSpeed") &&
+                l.Contains("rec-A"));
+            Assert.Equal(3, speedLines);
+        }
+
+        [Fact]
+        public void MilestoneEarning_NullRecordingId_StillKeysOnActionId()
+        {
+            // Standalone/KSC-path milestones can have a null RecordingId.
+            // The earlier (milestoneId, recordingId) key collapsed two
+            // distinct null-recording grants into one log line; the
+            // ActionId-keyed gate must keep them separate.
+            var grant1 = MakeMilestone(50.0, "RecordsAltitude", 4800f,
+                recordingId: null, effective: true);
+            var grant2 = MakeMilestone(75.0, "RecordsAltitude", 5200f,
+                recordingId: null, effective: true);
+            Assert.NotEqual(grant1.ActionId, grant2.ActionId);
+
+            module.ProcessAction(grant1);
+            module.ProcessAction(grant2);
+
+            int lines = logLines.Count(l =>
+                l.Contains("[Funds]") &&
+                l.Contains("Milestone funds:") &&
+                l.Contains("RecordsAltitude"));
+            Assert.Equal(2, lines);
         }
 
         [Fact]

--- a/Source/Parsek.Tests/FundsModuleTests.cs
+++ b/Source/Parsek.Tests/FundsModuleTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace Parsek.Tests
@@ -836,6 +837,32 @@ namespace Parsek.Tests
 
             Assert.Contains(logLines, l =>
                 l.Contains("[Funds]") && l.Contains("Milestone") && l.Contains("FirstLaunch"));
+        }
+
+        [Fact]
+        public void MilestoneEarning_RepeatedSamePair_RateLimitedToOneLine()
+        {
+            // Bug #593: ProcessMilestoneEarning is called once per
+            // (milestoneId, recordingId) pair on every recalc walk. In a single
+            // playtest the recalculation engine fired ~57 times, producing 170
+            // identical "Milestone funds: +N, milestoneId=RecordsSpeed, ..."
+            // lines per repeatable record-milestone (510 total across Speed/
+            // Altitude/Distance). The branch now routes through
+            // VerboseRateLimited keyed by (milestoneId, recordingId) so a
+            // steady recalc loop emits at most one line per pair per window.
+            for (int i = 0; i < 100; i++)
+            {
+                module.ProcessAction(MakeMilestone(
+                    50 + i * 0.001, "RecordsSpeed", 5000f,
+                    recordingId: "rec-pair-1", effective: true));
+            }
+
+            int speedLines = logLines.Count(l =>
+                l.Contains("[Funds]") &&
+                l.Contains("Milestone funds:") &&
+                l.Contains("RecordsSpeed") &&
+                l.Contains("rec-pair-1"));
+            Assert.Equal(1, speedLines);
         }
 
         [Fact]

--- a/Source/Parsek.Tests/KspStatePatcherTests.cs
+++ b/Source/Parsek.Tests/KspStatePatcherTests.cs
@@ -541,6 +541,72 @@ namespace Parsek.Tests
         }
 
         // ================================================================
+        // Bug #596 (P2 follow-up) — INFO gate: only patched + notFound trigger INFO.
+        // skipped-only and empty-totals route through rate-limited Verbose so a
+        // steady-state non-empty FacilitiesModule does not flood INFO every recalc.
+        // ================================================================
+
+        [Fact]
+        public void PatchFacilities_NotFound_LogsInfoSummary()
+        {
+            // protoUpgradeables is empty in tests, so a tracked facility will
+            // hit the notFound branch. notFound > 0 must surface at INFO so
+            // missing-facility diagnostics stay visible.
+            var module = new FacilitiesModule();
+            module.ProcessAction(new GameAction
+            {
+                Type = GameActionType.FacilityUpgrade,
+                FacilityId = "SpaceCenter/LaunchPad",
+                ToLevel = 2
+            });
+
+            logLines.Clear();
+            KspStatePatcher.PatchFacilities(module);
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[INFO]") &&
+                l.Contains("[KspStatePatcher]") &&
+                l.Contains("PatchFacilities: levels patched=") &&
+                l.Contains("notFound=1"));
+        }
+
+        [Fact]
+        public void PatchFacilities_Empty_DoesNotLogInfo_UsesRateLimitedVerbose()
+        {
+            // No tracked facilities -> patched=0, skipped=0, notFound=0.
+            // Must NOT log at INFO; must hit the rate-limited Verbose
+            // "nothing to patch" path.
+            var module = new FacilitiesModule();
+
+            logLines.Clear();
+            for (int i = 0; i < 50; i++)
+                KspStatePatcher.PatchFacilities(module);
+
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("[INFO]") &&
+                l.Contains("[KspStatePatcher]") &&
+                l.Contains("PatchFacilities: levels patched"));
+            Assert.Contains(logLines, l =>
+                l.Contains("[KspStatePatcher]") &&
+                l.Contains("PatchFacilities: nothing to patch"));
+            int emptyLines = logLines.FindAll(l =>
+                l.Contains("[KspStatePatcher]") &&
+                l.Contains("PatchFacilities: nothing to patch")).Count;
+            // Rate-limited to one line per 5s window; 50 immediate calls
+            // collapse to one.
+            Assert.Equal(1, emptyLines);
+        }
+
+        // Note: the skipped-only branch (patchedCount==0 && notFoundCount==0
+        // && skippedCount>0) requires real KSP UpgradeableFacility refs in
+        // ScenarioUpgradeableFacilities.protoUpgradeables, which are not
+        // wireable in the headless xUnit environment. That path is exercised
+        // in-game by a steady-state non-empty FacilitiesModule recalc loop
+        // — bug #596's playtest log captured the original symptom and the
+        // post-fix verification (no INFO summary) belongs in the next
+        // playtest validation rather than an xUnit canary.
+
+        // ================================================================
         // PatchAll — suppression flags
         // ================================================================
 

--- a/Source/Parsek.Tests/MilestonesModuleTests.cs
+++ b/Source/Parsek.Tests/MilestonesModuleTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace Parsek.Tests
@@ -210,6 +211,42 @@ namespace Parsek.Tests
             Assert.True(module.IsMilestoneCredited("RecordsDistance"));
             Assert.Equal(1, module.GetCreditedCount());
             Assert.Equal(2, module.GetEffectiveMilestoneCount("RecordsDistance"));
+        }
+
+        [Fact]
+        public void RepeatableRecordMilestone_RepeatedSamePair_RateLimitedToOneLine()
+        {
+            // Bug #593: ProcessMilestoneAchievement runs through the
+            // "Repeatable record milestone stays effective" branch on every
+            // recalc walk for every committed RecordsSpeed/Altitude/Distance
+            // grant. A single 30-min playtest produced 510 identical "stays
+            // effective" lines (170 per record-milestone) because the credit
+            // is established on the first hit and every subsequent walk just
+            // re-emits the same line. The branch now routes through
+            // VerboseRateLimited keyed by (milestoneId, recordingId) so a
+            // steady recalc loop emits at most one line per pair per window.
+
+            // Seed credit for RecordsDistance with a separate recording so
+            // subsequent same-recording hits go through the repeatable branch
+            // (which only triggers after the milestone is already credited).
+            module.ProcessAction(MakeMilestone("RecordsDistance", 0,
+                recordingId: "rec-seed", fundsAwarded: 100f));
+            logLines.Clear();
+
+            for (int i = 0; i < 100; i++)
+            {
+                var action = MakeMilestone("RecordsDistance", 100 + i * 0.001,
+                    recordingId: "rec-spam", fundsAwarded: 100f);
+                module.ProcessAction(action);
+                Assert.True(action.Effective);
+            }
+
+            int staysEffectiveLines = logLines.Count(l =>
+                l.Contains("[Milestones]") &&
+                l.Contains("Repeatable record milestone") &&
+                l.Contains("RecordsDistance") &&
+                l.Contains("rec-spam"));
+            Assert.Equal(1, staysEffectiveLines);
         }
 
         // ================================================================

--- a/Source/Parsek.Tests/MilestonesModuleTests.cs
+++ b/Source/Parsek.Tests/MilestonesModuleTests.cs
@@ -214,17 +214,14 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void RepeatableRecordMilestone_RepeatedSamePair_RateLimitedToOneLine()
+        public void RepeatableRecordMilestone_SameActionRecalculated_RateLimitedToOneLine()
         {
-            // Bug #593: ProcessMilestoneAchievement runs through the
-            // "Repeatable record milestone stays effective" branch on every
-            // recalc walk for every committed RecordsSpeed/Altitude/Distance
-            // grant. A single 30-min playtest produced 510 identical "stays
-            // effective" lines (170 per record-milestone) because the credit
-            // is established on the first hit and every subsequent walk just
-            // re-emits the same line. The branch now routes through
-            // VerboseRateLimited keyed by (milestoneId, recordingId) so a
-            // steady recalc loop emits at most one line per pair per window.
+            // Bug #593 (P2 follow-up): the rate-limit key is the stable
+            // GameAction.ActionId, not (milestoneId, recordingId). The
+            // intended invariant is "recalculating the SAME action collapses
+            // its log line"; distinct grants with the same milestoneId/
+            // recordingId but different UT/reward must still log on first
+            // walk because they are real, separate effective hits.
 
             // Seed credit for RecordsDistance with a separate recording so
             // subsequent same-recording hits go through the repeatable branch
@@ -233,10 +230,13 @@ namespace Parsek.Tests
                 recordingId: "rec-seed", fundsAwarded: 100f));
             logLines.Clear();
 
+            // Build ONE action and re-walk it 100 times. This is the case
+            // the rate-limit must collapse — a steady recalc loop replaying
+            // the same committed grant.
+            var action = MakeMilestone("RecordsDistance", 100.0,
+                recordingId: "rec-spam", fundsAwarded: 100f);
             for (int i = 0; i < 100; i++)
             {
-                var action = MakeMilestone("RecordsDistance", 100 + i * 0.001,
-                    recordingId: "rec-spam", fundsAwarded: 100f);
                 module.ProcessAction(action);
                 Assert.True(action.Effective);
             }
@@ -247,6 +247,66 @@ namespace Parsek.Tests
                 l.Contains("RecordsDistance") &&
                 l.Contains("rec-spam"));
             Assert.Equal(1, staysEffectiveLines);
+        }
+
+        [Fact]
+        public void RepeatableRecordMilestone_DistinctActionsSamePair_LogSeparately()
+        {
+            // Bug #593 (P2 follow-up): two distinct repeatable record-
+            // milestone grants for the same (milestoneId, recordingId) but
+            // different UT/reward represent real separate effective hits.
+            // The earlier (milestoneId, recordingId)-keyed gate collapsed
+            // them into one line, silently hiding a second application.
+            // The ActionId-keyed gate must let both grants log on their
+            // first walk.
+
+            // Seed credit so the next two hits take the repeatable branch.
+            module.ProcessAction(MakeMilestone("RecordsDistance", 0,
+                recordingId: "rec-seed", fundsAwarded: 100f));
+            logLines.Clear();
+
+            var grantA = MakeMilestone("RecordsDistance", 100.0,
+                recordingId: "rec-X", fundsAwarded: 100f);
+            var grantB = MakeMilestone("RecordsDistance", 200.0,
+                recordingId: "rec-X", fundsAwarded: 150f);
+            Assert.NotEqual(grantA.ActionId, grantB.ActionId);
+
+            module.ProcessAction(grantA);
+            module.ProcessAction(grantB);
+
+            int staysEffectiveLines = logLines.Count(l =>
+                l.Contains("[Milestones]") &&
+                l.Contains("Repeatable record milestone") &&
+                l.Contains("RecordsDistance") &&
+                l.Contains("rec-X"));
+            Assert.Equal(2, staysEffectiveLines);
+        }
+
+        [Fact]
+        public void RepeatableRecordMilestone_NullRecordingId_StillKeysOnActionId()
+        {
+            // Standalone/KSC-path repeatable record milestones can have a
+            // null RecordingId. The earlier key collapsed two distinct
+            // null-recording grants into one line; the ActionId-keyed gate
+            // must keep them separate.
+            module.ProcessAction(MakeMilestone("RecordsSpeed", 0,
+                recordingId: "rec-seed", fundsAwarded: 100f));
+            logLines.Clear();
+
+            var grant1 = MakeMilestone("RecordsSpeed", 100.0,
+                recordingId: null, fundsAwarded: 100f);
+            var grant2 = MakeMilestone("RecordsSpeed", 200.0,
+                recordingId: null, fundsAwarded: 150f);
+            Assert.NotEqual(grant1.ActionId, grant2.ActionId);
+
+            module.ProcessAction(grant1);
+            module.ProcessAction(grant2);
+
+            int lines = logLines.Count(l =>
+                l.Contains("[Milestones]") &&
+                l.Contains("Repeatable record milestone") &&
+                l.Contains("RecordsSpeed"));
+            Assert.Equal(2, lines);
         }
 
         // ================================================================

--- a/Source/Parsek.Tests/ReputationModuleTests.cs
+++ b/Source/Parsek.Tests/ReputationModuleTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace Parsek.Tests
@@ -741,6 +742,83 @@ namespace Parsek.Tests
                 RepSource = ReputationSource.Other
             });
             Assert.False(module.HasSeed);
+        }
+
+        // ================================================================
+        // Bug #593 (P2 follow-up) — milestone-rep rate limiting
+        // ================================================================
+
+        [Fact]
+        public void MilestoneRep_SameActionRecalculated_RateLimitedToOneLine()
+        {
+            // Bug #593 (P2 follow-up): the rate-limit key for the
+            // "Milestone rep" line is the stable GameAction.ActionId so a
+            // recalc loop walking the SAME action collapses to one line per
+            // window.
+            var action = MakeMilestone("RecordsSpeed", 50.0, "rec-A",
+                repAwarded: 5f);
+            for (int i = 0; i < 100; i++)
+            {
+                module.ProcessAction(action);
+            }
+
+            int lines = logLines.Count(l =>
+                l.Contains("[Reputation]") &&
+                l.Contains("Milestone rep at UT=") &&
+                l.Contains("RecordsSpeed") &&
+                l.Contains("rec-A"));
+            Assert.Equal(1, lines);
+        }
+
+        [Fact]
+        public void MilestoneRep_DistinctActionsSamePair_LogSeparately()
+        {
+            // Bug #593 (P2 follow-up): distinct grants sharing
+            // (milestoneId, recordingId) but with different UT or reward
+            // are separate effective hits and must each log on first walk.
+            var grantA = MakeMilestone("RecordsSpeed", 50.0, "rec-A",
+                repAwarded: 5f);
+            var grantB = MakeMilestone("RecordsSpeed", 80.0, "rec-A",
+                repAwarded: 5f);
+            var grantC = MakeMilestone("RecordsSpeed", 80.0, "rec-A",
+                repAwarded: 8f);
+            Assert.NotEqual(grantA.ActionId, grantB.ActionId);
+            Assert.NotEqual(grantB.ActionId, grantC.ActionId);
+            Assert.NotEqual(grantA.ActionId, grantC.ActionId);
+
+            module.ProcessAction(grantA);
+            module.ProcessAction(grantB);
+            module.ProcessAction(grantC);
+
+            int lines = logLines.Count(l =>
+                l.Contains("[Reputation]") &&
+                l.Contains("Milestone rep at UT=") &&
+                l.Contains("RecordsSpeed") &&
+                l.Contains("rec-A"));
+            Assert.Equal(3, lines);
+        }
+
+        [Fact]
+        public void MilestoneRep_NullRecordingId_StillKeysOnActionId()
+        {
+            // Standalone/KSC-path repeatable record milestones can have a
+            // null RecordingId. The earlier (milestoneId, recordingId)-keyed
+            // gate would collapse two distinct null-recording grants into
+            // one line; the ActionId-keyed gate must keep them separate.
+            var grant1 = MakeMilestone("RecordsAltitude", 50.0, null,
+                repAwarded: 4f);
+            var grant2 = MakeMilestone("RecordsAltitude", 75.0, null,
+                repAwarded: 6f);
+            Assert.NotEqual(grant1.ActionId, grant2.ActionId);
+
+            module.ProcessAction(grant1);
+            module.ProcessAction(grant2);
+
+            int lines = logLines.Count(l =>
+                l.Contains("[Reputation]") &&
+                l.Contains("Milestone rep at UT=") &&
+                l.Contains("RecordsAltitude"));
+            Assert.Equal(2, lines);
         }
     }
 }

--- a/Source/Parsek/BackgroundRecorder.cs
+++ b/Source/Parsek/BackgroundRecorder.cs
@@ -2081,7 +2081,16 @@ namespace Parsek
                 checkpointed++;
             }
 
-            ParsekLog.Verbose("BgRecorder",
+            // Bug #592: this summary fires once per onTimeWarpRateChanged, which KSP
+            // can re-emit hundreds of times at the same rate during a single session.
+            // Rate-limit per "shape" of the result so changes in checkpoint counts still
+            // surface (we want to see the moment behavior changes), but identical
+            // no-op summaries during a quiet warp burst collapse into one line.
+            string key = string.Format(
+                System.Globalization.CultureInfo.InvariantCulture,
+                "checkpoint-all-{0}-{1}-{2}",
+                checkpointed, skippedNotOrbital, skippedNoVessel);
+            ParsekLog.VerboseRateLimited("BgRecorder", key,
                 $"CheckpointAllVessels at UT={ut:F2}: checkpointed={checkpointed}, " +
                 $"skippedNotOrbital={skippedNotOrbital}, skippedNoVessel={skippedNoVessel}");
         }

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -5455,9 +5455,13 @@ namespace Parsek
 
             if (!motionTriggered && !attitudeTriggered)
             {
+                // Bug #595: the previous 2.0s rate-limit window still produced
+                // ~200 lines per 30-min session during stationary intervals.
+                // Use the default 5s window — the line conveys "stationary,
+                // waiting" which is a steady state, so per-window granularity
+                // is plenty.
                 ParsekLog.VerboseRateLimited("Recorder", "sample-skipped",
-                    $"Sample skipped at ut={currentUT:F2}; waiting for motion/attitude trigger",
-                    2.0);
+                    $"Sample skipped at ut={currentUT:F2}; waiting for motion/attitude trigger");
                 return;
             }
 

--- a/Source/Parsek/GameActions/FundsModule.cs
+++ b/Source/Parsek/GameActions/FundsModule.cs
@@ -345,18 +345,28 @@ namespace Parsek
 
             // Bug #593: this fires every recalc walk for every effective
             // record-milestone (RecordsSpeed/Altitude/Distance), producing 170+
-            // identical lines per session. The state being logged is steady — the
-            // amount, milestoneId, and recordingId don't change between walks — so
-            // rate-limit per (milestoneId, recordingId) pair to keep one line per
-            // distinct application per window.
-            string key = string.Format(IC,
-                "milestone-funds-{0}-{1}",
-                action.MilestoneId ?? "(none)",
-                action.RecordingId ?? "(none)");
+            // identical lines per session. The state being logged is steady
+            // across recalculations of the SAME action — the amount,
+            // milestoneId, recordingId, and UT are all immutable — so
+            // rate-limit per stable GameAction.ActionId. Two distinct
+            // record-milestone hits with the same milestoneId+recordingId but
+            // different UT/reward have different ActionIds and still log
+            // separately on their first walk; only repeated recalculations
+            // of the SAME action collapse.
+            string actionIdKey = !string.IsNullOrEmpty(action.ActionId)
+                ? action.ActionId
+                : string.Format(IC, "{0}|{1}|{2}|{3}",
+                    action.MilestoneId ?? "(none)",
+                    action.RecordingId ?? "(none)",
+                    action.UT.ToString("R", IC),
+                    amount.ToString("R", IC));
+            string key = "milestone-funds-action-" + actionIdKey;
             ParsekLog.VerboseRateLimited(Tag, key,
                 $"Milestone funds: +{amount.ToString("R", IC)}, " +
+                $"actionId={action.ActionId ?? "(none)"}, " +
                 $"milestoneId={action.MilestoneId ?? "(none)"}, " +
                 $"recordingId={action.RecordingId ?? "(none)"}, " +
+                $"ut={action.UT.ToString("R", IC)}, " +
                 $"runningBalance={runningBalance.ToString("R", IC)}, " +
                 $"totalEarnings={totalEarnings.ToString("R", IC)}");
         }

--- a/Source/Parsek/GameActions/FundsModule.cs
+++ b/Source/Parsek/GameActions/FundsModule.cs
@@ -343,9 +343,20 @@ namespace Parsek
             runningBalance += amount;
             totalEarnings += amount;
 
-            ParsekLog.Verbose(Tag,
+            // Bug #593: this fires every recalc walk for every effective
+            // record-milestone (RecordsSpeed/Altitude/Distance), producing 170+
+            // identical lines per session. The state being logged is steady — the
+            // amount, milestoneId, and recordingId don't change between walks — so
+            // rate-limit per (milestoneId, recordingId) pair to keep one line per
+            // distinct application per window.
+            string key = string.Format(IC,
+                "milestone-funds-{0}-{1}",
+                action.MilestoneId ?? "(none)",
+                action.RecordingId ?? "(none)");
+            ParsekLog.VerboseRateLimited(Tag, key,
                 $"Milestone funds: +{amount.ToString("R", IC)}, " +
                 $"milestoneId={action.MilestoneId ?? "(none)"}, " +
+                $"recordingId={action.RecordingId ?? "(none)"}, " +
                 $"runningBalance={runningBalance.ToString("R", IC)}, " +
                 $"totalEarnings={totalEarnings.ToString("R", IC)}");
         }

--- a/Source/Parsek/GameActions/KspStatePatcher.cs
+++ b/Source/Parsek/GameActions/KspStatePatcher.cs
@@ -688,26 +688,37 @@ namespace Parsek
                     $"{targetLevel.ToString(IC)} (destroyed={state.Destroyed.ToString(IC)})");
             }
 
-            // Bug #596: this summary previously fired at INFO on every recalc
-            // even when there was nothing to do, producing dozens of identical
-            // "patched=0, skipped=0, notFound=0, total=0" lines per session.
-            // Promote the no-work case to a rate-limited Verbose line (so the
-            // diagnostic is still available when somebody is investigating an
-            // empty facilities module) and keep INFO for the case that
-            // actually changed game state or hit a notFound diagnostic.
-            int totalWork = patchedCount + skippedCount + notFoundCount;
-            if (totalWork == 0)
-            {
-                ParsekLog.VerboseRateLimited(Tag, "patch-facilities-empty",
-                    $"PatchFacilities: nothing to patch (total={allFacilities.Count})");
-            }
-            else
+            // Bug #596: gate INFO on changed-state-or-not-found-diagnostic only.
+            // skippedCount increments when a facility is already at its target
+            // level (no-op pass), so a steady-state non-empty facility list
+            // would still emit the INFO summary on every recalc if `skipped`
+            // counted toward the gate. Use `patched + notFound > 0` so INFO
+            // fires only when real game state changed (`patched`) or when a
+            // facility lookup miss is worth surfacing (`notFound`). Skipped-
+            // only summaries (steady state, nothing to do) and the all-zero
+            // empty-totals case both route through `VerboseRateLimited` so the
+            // diagnostic stays available when investigating without flooding
+            // INFO.
+            int materialWork = patchedCount + notFoundCount;
+            if (materialWork > 0)
             {
                 ParsekLog.Info(Tag,
                     $"PatchFacilities: levels patched={patchedCount.ToString(IC)}, " +
                     $"skipped={skippedCount.ToString(IC)}, " +
                     $"notFound={notFoundCount.ToString(IC)}, " +
                     $"total={allFacilities.Count}");
+            }
+            else if (skippedCount > 0)
+            {
+                ParsekLog.VerboseRateLimited(Tag, "patch-facilities-skipped-only",
+                    $"PatchFacilities: skipped-only steady state " +
+                    $"(patched=0, skipped={skippedCount.ToString(IC)}, " +
+                    $"notFound=0, total={allFacilities.Count})");
+            }
+            else
+            {
+                ParsekLog.VerboseRateLimited(Tag, "patch-facilities-empty",
+                    $"PatchFacilities: nothing to patch (total={allFacilities.Count})");
             }
 
             // Patch destruction state via DestructibleBuilding components.

--- a/Source/Parsek/GameActions/KspStatePatcher.cs
+++ b/Source/Parsek/GameActions/KspStatePatcher.cs
@@ -688,11 +688,27 @@ namespace Parsek
                     $"{targetLevel.ToString(IC)} (destroyed={state.Destroyed.ToString(IC)})");
             }
 
-            ParsekLog.Info(Tag,
-                $"PatchFacilities: levels patched={patchedCount.ToString(IC)}, " +
-                $"skipped={skippedCount.ToString(IC)}, " +
-                $"notFound={notFoundCount.ToString(IC)}, " +
-                $"total={allFacilities.Count}");
+            // Bug #596: this summary previously fired at INFO on every recalc
+            // even when there was nothing to do, producing dozens of identical
+            // "patched=0, skipped=0, notFound=0, total=0" lines per session.
+            // Promote the no-work case to a rate-limited Verbose line (so the
+            // diagnostic is still available when somebody is investigating an
+            // empty facilities module) and keep INFO for the case that
+            // actually changed game state or hit a notFound diagnostic.
+            int totalWork = patchedCount + skippedCount + notFoundCount;
+            if (totalWork == 0)
+            {
+                ParsekLog.VerboseRateLimited(Tag, "patch-facilities-empty",
+                    $"PatchFacilities: nothing to patch (total={allFacilities.Count})");
+            }
+            else
+            {
+                ParsekLog.Info(Tag,
+                    $"PatchFacilities: levels patched={patchedCount.ToString(IC)}, " +
+                    $"skipped={skippedCount.ToString(IC)}, " +
+                    $"notFound={notFoundCount.ToString(IC)}, " +
+                    $"total={allFacilities.Count}");
+            }
 
             // Patch destruction state via DestructibleBuilding components.
             // Collect all destructibles once (expensive FindObjectsOfType call),
@@ -985,7 +1001,16 @@ namespace Parsek
                         if (milestones.IsMilestoneCredited(nodeId))
                         {
                             shouldBeAchieved = true;
-                            ParsekLog.Verbose(Tag,
+                            // Bug #594: this diagnostic fires every recalc walk for the
+                            // same (nodeId, qualifiedId) pair — once a fallback match
+                            // exists for an old recording, every walk re-emits the
+                            // same line. Rate-limit per pair so the diagnostic still
+                            // surfaces when a new fallback path appears, without
+                            // flooding the log on steady-state walks.
+                            string fallbackKey = string.Format(IC,
+                                "patch-milestones-fallback-{0}-{1}",
+                                nodeId, qualifiedId);
+                            ParsekLog.VerboseRateLimited(Tag, fallbackKey,
                                 $"PatchMilestones: bare-Id fallback match for '{nodeId}' " +
                                 $"(qualified='{qualifiedId}' not found — old recording?)");
                         }

--- a/Source/Parsek/GameActions/MilestonesModule.cs
+++ b/Source/Parsek/GameActions/MilestonesModule.cs
@@ -83,16 +83,24 @@ namespace Parsek
                 // Bug #593: repeatable record milestones (RecordsSpeed/Altitude/
                 // Distance) hit this branch on every recalc walk for every
                 // committed record-grant action, producing 170+ identical
-                // "stays effective" lines per session. Rate-limit per
-                // (milestoneId, recordingId) so each distinct repeated grant
-                // logs at most once per window.
-                string key = string.Format(IC,
-                    "milestone-stays-effective-{0}-{1}",
-                    milestoneId,
-                    action.RecordingId ?? "(none)");
+                // "stays effective" lines per session. Rate-limit per stable
+                // GameAction.ActionId so a recalc loop walking the SAME
+                // action collapses, while two distinct grants of the same
+                // milestoneId in the same recording but at different UT (or
+                // with different reward shapes) still log on their first
+                // walk because they have different ActionIds.
+                string actionIdKey = !string.IsNullOrEmpty(action.ActionId)
+                    ? action.ActionId
+                    : string.Format(IC, "{0}|{1}|{2}|{3}",
+                        milestoneId,
+                        action.RecordingId ?? "(none)",
+                        action.UT.ToString("R", IC),
+                        action.MilestoneFundsAwarded.ToString("R", IC));
+                string key = "milestone-stays-effective-action-" + actionIdKey;
                 ParsekLog.VerboseRateLimited("Milestones", key,
                     $"Repeatable record milestone '{milestoneId}' stays effective at UT={action.UT.ToString("F1", IC)}" +
-                    $" (recording={action.RecordingId ?? "null"}," +
+                    $" (actionId={action.ActionId ?? "(none)"}," +
+                    $" recording={action.RecordingId ?? "null"}," +
                     $" funds={action.MilestoneFundsAwarded.ToString("F0", IC)}," +
                     $" rep={action.MilestoneRepAwarded.ToString("F0", IC)}," +
                     $" sci={action.MilestoneScienceAwarded.ToString("F1", IC)})," +

--- a/Source/Parsek/GameActions/MilestonesModule.cs
+++ b/Source/Parsek/GameActions/MilestonesModule.cs
@@ -80,7 +80,17 @@ namespace Parsek
                     effectiveMilestoneCounts[milestoneId] = currentCount + 1;
                 else
                     effectiveMilestoneCounts[milestoneId] = 1;
-                ParsekLog.Verbose("Milestones",
+                // Bug #593: repeatable record milestones (RecordsSpeed/Altitude/
+                // Distance) hit this branch on every recalc walk for every
+                // committed record-grant action, producing 170+ identical
+                // "stays effective" lines per session. Rate-limit per
+                // (milestoneId, recordingId) so each distinct repeated grant
+                // logs at most once per window.
+                string key = string.Format(IC,
+                    "milestone-stays-effective-{0}-{1}",
+                    milestoneId,
+                    action.RecordingId ?? "(none)");
+                ParsekLog.VerboseRateLimited("Milestones", key,
                     $"Repeatable record milestone '{milestoneId}' stays effective at UT={action.UT.ToString("F1", IC)}" +
                     $" (recording={action.RecordingId ?? "null"}," +
                     $" funds={action.MilestoneFundsAwarded.ToString("F0", IC)}," +

--- a/Source/Parsek/GameActions/ReputationModule.cs
+++ b/Source/Parsek/GameActions/ReputationModule.cs
@@ -147,8 +147,16 @@ namespace Parsek
             action.EffectiveRep = result.actualDelta;
             runningRep = result.newRep;
 
-            ParsekLog.Verbose(Tag,
+            // Bug #593: every effective milestone re-emits this line on every
+            // recalc walk, even though milestoneId/recordingId/nominal don't
+            // change between walks. Rate-limit per (milestoneId, recordingId).
+            string key = string.Format(IC,
+                "milestone-rep-{0}-{1}",
+                action.MilestoneId ?? "null",
+                action.RecordingId ?? "(none)");
+            ParsekLog.VerboseRateLimited(Tag, key,
                 $"Milestone rep at UT={action.UT.ToString("F1", IC)}: milestoneId={action.MilestoneId ?? "null"}, " +
+                $"recordingId={action.RecordingId ?? "(none)"}, " +
                 $"nominal={nominal.ToString("F2", IC)}, effective={result.actualDelta.ToString("F2", IC)}, " +
                 $"runningRep={runningRep.ToString("F2", IC)}");
         }

--- a/Source/Parsek/GameActions/ReputationModule.cs
+++ b/Source/Parsek/GameActions/ReputationModule.cs
@@ -148,14 +148,23 @@ namespace Parsek
             runningRep = result.newRep;
 
             // Bug #593: every effective milestone re-emits this line on every
-            // recalc walk, even though milestoneId/recordingId/nominal don't
-            // change between walks. Rate-limit per (milestoneId, recordingId).
-            string key = string.Format(IC,
-                "milestone-rep-{0}-{1}",
-                action.MilestoneId ?? "null",
-                action.RecordingId ?? "(none)");
+            // recalc walk, even though milestoneId/recordingId/nominal/UT
+            // don't change between walks for the SAME action. Rate-limit per
+            // stable GameAction.ActionId so distinct grants (same
+            // milestoneId+recordingId but different UT or reward) still each
+            // log once on their first walk.
+            string actionIdKey = !string.IsNullOrEmpty(action.ActionId)
+                ? action.ActionId
+                : string.Format(IC, "{0}|{1}|{2}|{3}",
+                    action.MilestoneId ?? "null",
+                    action.RecordingId ?? "(none)",
+                    action.UT.ToString("R", IC),
+                    nominal.ToString("R", IC));
+            string key = "milestone-rep-action-" + actionIdKey;
             ParsekLog.VerboseRateLimited(Tag, key,
-                $"Milestone rep at UT={action.UT.ToString("F1", IC)}: milestoneId={action.MilestoneId ?? "null"}, " +
+                $"Milestone rep at UT={action.UT.ToString("F1", IC)}: " +
+                $"actionId={action.ActionId ?? "(none)"}, " +
+                $"milestoneId={action.MilestoneId ?? "null"}, " +
                 $"recordingId={action.RecordingId ?? "(none)"}, " +
                 $"nominal={nominal.ToString("F2", IC)}, effective={result.actualDelta.ToString("F2", IC)}, " +
                 $"runningRep={runningRep.ToString("F2", IC)}");

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -5886,8 +5886,17 @@ namespace Parsek
             double ut = Planetarium.GetUniversalTime();
             float warpRate = TimeWarp.CurrentRate;
 
-            ParsekLog.Verbose("Checkpoint",
-                $"Time warp rate changed to {warpRate.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)}x " +
+            // Bug #592: KSP fires onTimeWarpRateChanged very chattily — a single
+            // playtest produced ~1090 events at 1.0x without any actual rate change
+            // (scene transitions, warp-to-here, etc. retrigger the GameEvent).
+            // Rate-limit by warpRate so transitions between distinct rates still log
+            // immediately, but a burst of redundant 1x->1x fires collapses into one
+            // line per window.
+            string warpRateKey = warpRate.ToString("F1",
+                System.Globalization.CultureInfo.InvariantCulture);
+            ParsekLog.VerboseRateLimited("Checkpoint",
+                $"warp-rate-changed-{warpRateKey}",
+                $"Time warp rate changed to {warpRateKey}x " +
                 $"at UT={ut:F2} — checkpointing all background vessels");
 
             // Checkpoint background vessels first (before any state changes)
@@ -5896,7 +5905,8 @@ namespace Parsek
             // The active vessel's orbit segments are already handled by
             // onVesselGoOnRails/onVesselGoOffRails events which fire when
             // time warp transitions between physics and rails modes.
-            ParsekLog.Verbose("Checkpoint",
+            ParsekLog.VerboseRateLimited("Checkpoint",
+                $"warp-rate-changed-on-rails-{warpRateKey}",
                 "Active vessel orbit segments handled by on-rails events");
         }
 
@@ -13867,6 +13877,13 @@ namespace Parsek
                     point.Value.velocity.magnitude)
                 : "pointUT=(none) body=(none) alt=0 speed=0";
 
+            // Bug #595: the previous 1.0s rate-limit window was tight enough that
+            // a long-playing OrbitalCheckpoint section still emitted ~14
+            // lines/min per (rec, section) pair (413 lines in a single 30-min
+            // session). Use the default 5s window to keep one line per section
+            // per (typical) rate-limit window without losing the section-change
+            // signal — the key is per-(recId, sectionIdx) so a new section
+            // still logs immediately on first frame.
             ParsekLog.VerboseRateLimited(
                 "Playback",
                 string.Format(
@@ -13884,8 +13901,7 @@ namespace Parsek
                     section.endUT,
                     pointDetail,
                     FormatVector3d(worldPos),
-                    section.frames?.Count ?? 0),
-                1.0);
+                    section.frames?.Count ?? 0));
         }
 
         bool TryResolvePlaybackWorldPosition(

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1363,14 +1363,22 @@ record-milestones, that produces ~170 lines per branch.
 **Fix:** `MilestonesModule.ProcessMilestoneAchievement` (the repeatable
 "stays effective" branch), `FundsModule.ProcessMilestoneEarning`, and
 `ReputationModule.ProcessMilestoneRep` now all route through
-`ParsekLog.VerboseRateLimited` with the key
-`(milestoneId, recordingId)` so each unique pair logs at most once
-per rate-limit window. Regressions
-`FundsModuleTests.MilestoneEarning_RepeatedSamePair_RateLimitedToOneLine`
-and
-`MilestonesModuleTests.RepeatableRecordMilestone_RepeatedSamePair_RateLimitedToOneLine`
-call 100x with the same `(milestoneId, recordingId)` pair and assert a
-single emitted line.
+`ParsekLog.VerboseRateLimited` keyed by the stable
+`GameAction.ActionId` (with a `(milestoneId, recordingId, ut, reward)`
+tuple as fallback if `ActionId` is empty). The intended invariant is
+"recalculating the SAME action collapses its log line"; two distinct
+record-milestone hits sharing the same milestoneId+recordingId but
+with different UT or reward have different `ActionId`s and still log
+on their first walk. Each emitted line now includes `actionId=...` so
+the identity is debuggable. Regressions
+`FundsModuleTests.MilestoneEarning_SameActionRecalculated_RateLimitedToOneLine`,
+`MilestonesModuleTests.RepeatableRecordMilestone_SameActionRecalculated_RateLimitedToOneLine`,
+and `ReputationModuleTests.MilestoneRep_SameActionRecalculated_RateLimitedToOneLine`
+re-walk a single action 100 times and assert exactly one emitted line.
+Companion regressions
+`*_DistinctActionsSamePair_LogSeparately` and
+`*_NullRecordingId_StillKeysOnActionId` confirm distinct actions
+(including null-recording standalone/KSC paths) survive the gate.
 
 **Status:** CLOSED 2026-04-25. Fixed for v0.9.0.
 
@@ -1437,17 +1445,24 @@ no-op summary fires unconditionally at INFO on every PatchFacilities
 call.
 
 **Diagnosis (2026-04-25):** the summary's purpose is to make
-"facility patching ran" visible at INFO when it actually did
-something (level change, level mismatch skipped, or `notFound`
-diagnostic). When all three counts are zero, the summary is pure
-noise; INFO is the wrong tier for "we processed an empty list".
+"facility patching changed game state or hit a missing facility"
+visible at INFO. `skippedCount` increments on the no-op pass (a
+facility already at its target level), so a steady-state non-empty
+`FacilitiesModule` would still re-emit the INFO summary on every
+recalc if `skipped` counted toward the gate.
 
-**Fix:** `KspStatePatcher.PatchFacilities` (`KspStatePatcher.cs:691`)
-now branches on `patched + skipped + notFound > 0`. The work case
-keeps the existing INFO summary unchanged. The no-work case routes
-to `VerboseRateLimited` with key `patch-facilities-empty` so the
-diagnostic is still available when somebody is investigating an
-empty FacilitiesModule, without flooding INFO at steady state.
+**Fix:** `KspStatePatcher.PatchFacilities` now gates the INFO summary
+on `patchedCount + notFoundCount > 0`. The skipped-only steady-state
+case (`patched=0, notFound=0, skipped>0`) routes through
+`VerboseRateLimited` with key `patch-facilities-skipped-only`. The
+empty-totals case (no tracked facilities at all) keeps its existing
+`patch-facilities-empty` rate-limited Verbose path. Regressions
+`KspStatePatcherTests.PatchFacilities_NotFound_LogsInfoSummary` and
+`PatchFacilities_Empty_DoesNotLogInfo_UsesRateLimitedVerbose` pin
+the INFO branch (notFound>0) and the empty-Verbose branch. The
+skipped-only branch needs real `UpgradeableFacility` refs in
+`ScenarioUpgradeableFacilities.protoUpgradeables` and is verified
+in-game during the next playtest pass instead of an xUnit canary.
 
 **Status:** CLOSED 2026-04-25. Fixed for v0.9.0.
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1304,6 +1304,192 @@ state transitions in the log when grepping for `OnVesselSwitchComplete`.
 
 ---
 
+## ~~592. Log spam: time-warp rate-change checkpoint logs fire ~3300 times per session from KSP's chatty `onTimeWarpRateChanged` GameEvent~~
+
+**Source:** `logs/2026-04-25_1933_refly-bugs/KSP.log` — 1122 ×
+`[BgRecorder] CheckpointAllVessels at UT=...`, 1121 ×
+`[Checkpoint] Time warp rate changed to N x at UT=... — checkpointing
+all background vessels`, and 1121 × `[Checkpoint] Active vessel orbit
+segments handled by on-rails events`. ~3364 lines total — the single
+biggest log-spam source not already in #591 / #160.
+
+**Diagnosis (2026-04-25):** of the 1121 rate-change events, 1090 were
+`1.0x` and only 248 unique UT values were seen — KSP's
+`GameEvents.onTimeWarpRateChanged` re-fires aggressively at the same
+rate during scene transitions, warp-to-here, and similar transients.
+Three `Verbose` log lines were emitted per event with no rate-limit,
+plus the underlying `CheckpointAllVessels` walk did real work each
+time even though closing+reopening an orbit segment at the same UT is
+idempotent.
+
+**Fix:** all three log calls in `ParsekFlight.OnTimeWarpRateChanged`
+(`ParsekFlight.cs:5889` / `:5899`) and the summary in
+`BackgroundRecorder.CheckpointAllVessels`
+(`BackgroundRecorder.cs:2084`) now route through
+`ParsekLog.VerboseRateLimited`. The two `Checkpoint` lines are keyed
+per warp-rate string (so transitions between distinct rates still log
+on the first event), and the BgRecorder summary is keyed by the
+`(checkpointed, skippedNotOrbital, skippedNoVessel)` shape so a
+genuine count change still surfaces immediately. Regression
+`BackgroundRecorderTests.CheckpointAllVessels_RepeatedCallsSameShape_RateLimitedToOneLine`
+calls 50x with the same shape and asserts a single emitted summary
+line.
+
+**Status:** CLOSED 2026-04-25. Fixed for v0.9.0. Log-only fix; the
+underlying "KSP fires rate-change at 1x ~4x more often than there are
+real rate changes" concern is tracked separately as #597.
+
+---
+
+## ~~593. Log spam: repeatable record milestones (`RecordsSpeed`/`RecordsAltitude`/`RecordsDistance`) re-emit the same `Milestone funds` / `stays effective` / `Milestone rep at UT` line on every recalc walk~~
+
+**Source:** `logs/2026-04-25_1933_refly-bugs/KSP.log` — ~1190 lines:
+- 510 × `[Milestones] Repeatable record milestone '<id>' stays
+  effective at UT=...` (170 each for Speed / Altitude / Distance).
+- 510 × `[Funds] Milestone funds: +N, milestoneId=Records...,
+  runningBalance=...` (170 each).
+- 393 × `[Reputation] Milestone rep at UT=...: milestoneId=Records...,
+  ...`.
+
+**Diagnosis (2026-04-25):** `MilestonesModule.ProcessMilestoneAchievement`
+walks every committed action in the ledger on every recalc; for the
+three repeatable record-milestone IDs the credit is established on
+the first hit and every subsequent walk re-takes the
+`isRepeatableRecordMilestone` branch with identical milestoneId,
+recordingId, fundsAwarded and repAwarded, producing structurally
+identical log lines. With ~57 recalcs in a 30-min session times three
+record-milestones, that produces ~170 lines per branch.
+
+**Fix:** `MilestonesModule.ProcessMilestoneAchievement` (the repeatable
+"stays effective" branch), `FundsModule.ProcessMilestoneEarning`, and
+`ReputationModule.ProcessMilestoneRep` now all route through
+`ParsekLog.VerboseRateLimited` with the key
+`(milestoneId, recordingId)` so each unique pair logs at most once
+per rate-limit window. Regressions
+`FundsModuleTests.MilestoneEarning_RepeatedSamePair_RateLimitedToOneLine`
+and
+`MilestonesModuleTests.RepeatableRecordMilestone_RepeatedSamePair_RateLimitedToOneLine`
+call 100x with the same `(milestoneId, recordingId)` pair and assert a
+single emitted line.
+
+**Status:** CLOSED 2026-04-25. Fixed for v0.9.0.
+
+---
+
+## ~~594. Log spam: `KspStatePatcher.PatchMilestones` bare-Id fallback fires per recalc for the same `(nodeId, qualifiedId)` pair~~
+
+**Source:** `logs/2026-04-25_1933_refly-bugs/KSP.log` — 221 ×
+`[KspStatePatcher] PatchMilestones: bare-Id fallback match for 'Orbit'
+(qualified='...' not found — old recording?)`.
+
+**Diagnosis (2026-04-25):** the bare-Id fallback diagnostic exists to
+flag old-format recordings whose milestones stored the bare body-
+specific node ID (`Landing`) instead of the qualified path
+(`Mun/Landing`). Once such a fallback exists, every recalc walk
+re-emits the same line because the recording's milestone-credit
+state is steady. Useful as a one-shot "old recording detected" hint;
+useless and noisy as a per-recalc line.
+
+**Fix:** the `Verbose` call at `KspStatePatcher.cs:988` now routes
+through `VerboseRateLimited` keyed by `(nodeId, qualifiedId)` so each
+distinct fallback pair logs at most once per rate-limit window; new
+fallback pairs surface immediately on first match.
+
+**Status:** CLOSED 2026-04-25. Fixed for v0.9.0.
+
+---
+
+## ~~595. Log spam: `OrbitalCheckpoint point playback` and `Recorder Sample skipped` rate-limit windows were too tight~~
+
+**Source:** `logs/2026-04-25_1933_refly-bugs/KSP.log` — 413 ×
+`[Playback] OrbitalCheckpoint point playback: rec=<HEX> currentUT=...`
+and 197 × `[Recorder] Sample skipped at ut=...; waiting for motion/
+attitude trigger`. Both lines were already routed through
+`VerboseRateLimited`, but with custom 1.0s and 2.0s windows
+respectively — tight enough that long-playing OrbitalCheckpoint
+sections still emitted ~14 lines/min per `(recId, sectionIdx)` and
+stationary recordings ~7 lines/min.
+
+**Diagnosis (2026-04-25):** both lines convey steady-state telemetry
+(per-section ghost playback / "still stationary, no sample taken"),
+not state transitions, so the rate-limit window can safely widen to
+the project default 5s without losing diagnostic value — the per-key
+identity (`recId+sectionIdx` for OrbitalCheckpoint, single shared key
+for Sample skipped) means new sections / new recorders still log on
+their first frame.
+
+**Fix:** both call sites (`ParsekFlight.cs:13870` and
+`FlightRecorder.cs:5458`) now use the default 5s rate-limit window
+inherited from `ParsekLog.DefaultRateLimitSeconds`.
+
+**Status:** CLOSED 2026-04-25. Fixed for v0.9.0.
+
+---
+
+## ~~596. Log spam: `KspStatePatcher.PatchFacilities` emits an INFO summary on every recalc even when there is nothing to patch~~
+
+**Source:** `logs/2026-04-25_1933_refly-bugs/KSP.log` — 42 ×
+`[KspStatePatcher] PatchFacilities: levels patched=0, skipped=0,
+notFound=0, total=0`. Earlier playtests (the same KSP.log around lines
+26791-27996) showed several thousand of these once the recalculation
+engine churned the same empty `FacilitiesModule` repeatedly — the
+no-op summary fires unconditionally at INFO on every PatchFacilities
+call.
+
+**Diagnosis (2026-04-25):** the summary's purpose is to make
+"facility patching ran" visible at INFO when it actually did
+something (level change, level mismatch skipped, or `notFound`
+diagnostic). When all three counts are zero, the summary is pure
+noise; INFO is the wrong tier for "we processed an empty list".
+
+**Fix:** `KspStatePatcher.PatchFacilities` (`KspStatePatcher.cs:691`)
+now branches on `patched + skipped + notFound > 0`. The work case
+keeps the existing INFO summary unchanged. The no-work case routes
+to `VerboseRateLimited` with key `patch-facilities-empty` so the
+diagnostic is still available when somebody is investigating an
+empty FacilitiesModule, without flooding INFO at steady state.
+
+**Status:** CLOSED 2026-04-25. Fixed for v0.9.0.
+
+---
+
+## 597. Underlying logic: KSP's `onTimeWarpRateChanged` GameEvent fires at 1x roughly 4x more often than there are real rate changes, and `OnTimeWarpRateChanged` always re-runs `CheckpointAllVessels`
+
+**Source:** `logs/2026-04-25_1933_refly-bugs/KSP.log` — 1090 of 1121
+events were `1.0x`, but only 248 unique UT values appeared, and many
+of those 248 had multiple sub-second-apart 1.0x events (e.g.
+`19:08:26.557` and `19:08:26.567` both at UT≈21526.10). KSP fires the
+event spuriously across scene transitions, warp-to-here, save/load
+boundaries, and similar transients.
+
+**Why it matters:** Bug #592 only addresses the LOG noise. The
+underlying `BackgroundRecorder.CheckpointAllVessels` call still runs
+every event, closing and re-opening the same orbit segment at the
+same UT for every background vessel. The work is idempotent (same
+UT → identical segment shape → no observable behaviour change), so
+it has not produced a known correctness defect, but it is wasted
+work scaling with `backgroundVesselCount × eventCount` and could
+mask a real correctness regression in the future ("why is this orbit
+segment getting reopened mid-flight?").
+
+**Files to investigate:**
+
+- `Source/Parsek/ParsekFlight.cs:5842` — `OnTimeWarpRateChanged`. Add
+  a `lastSeenWarpRate` field and short-circuit when both the rate and
+  the UT have not advanced past the last invocation. Care needed
+  because the warp-start / warp-end branch above this call also
+  depends on the event firing.
+- `Source/Parsek/BackgroundRecorder.cs:2030` — `CheckpointAllVessels`.
+  An alternate fix is to make this method itself idempotent at the
+  same UT (skip the close+reopen if the segment is already closed
+  at this exact UT).
+
+**Status:** Open. Performance / hygiene; no observed correctness
+defect. Defer until a measurable hot-path latency or a specific
+ghost-orbit anomaly points at it.
+
+---
+
 ## ~~570. Warp-deferred survivor spawn stayed queued outside the active vessel's physics bubble~~
 
 **Source:** `logs/2026-04-25_1314_marker-validator-fix/KSP.log`. Recording #15
@@ -1609,6 +1795,21 @@ so each vessel logs at most once per window. Regression
 `EffectiveStateTests.IsUnfinishedFlight_RepeatedCallsSameRec_RateLimitedToOneLine`
 calls the predicate 100x with the same recording and asserts a single emitted
 line.
+
+2026-04-25 update (post-#591 second-tier cleanup): the `2026-04-25_1933_refly-bugs`
+KSP.log surfaced six more spam sources, addressed as numbered bugs #592-#596
+(closed in this commit) plus #597 (open underlying-logic concern). #592 covers
+the ~3300 `Time warp rate changed` / `CheckpointAllVessels` / `Active vessel
+orbit segments handled` lines from KSP's chatty `onTimeWarpRateChanged`
+GameEvent. #593 covers ~1190 lines from repeatable record milestones
+(`Records*` IDs) re-emitting the same `Milestone funds` / `stays effective` /
+`Milestone rep at UT` line on every recalc walk. #594 covers 221 KspStatePatcher
+bare-Id fallback lines. #595 widens the OrbitalCheckpoint playback and Recorder
+sample-skipped rate-limit windows from 1-2s to the default 5s. #596 gates the
+PatchFacilities INFO summary on having actual work. #597 tracks the underlying
+"KSP fires rate-change at 1x ~4x more often than real rate changes" concern as
+a separate open todo (performance / hygiene only — no observed correctness
+defect).
 
 **Priority:** Deferred to Phase 11.5 (Recording Optimization & Observability)
 


### PR DESCRIPTION
## Summary

Triages and closes six log-spam sources from the `logs/2026-04-25_1933_refly-bugs/KSP.log` fixture that are not covered by #591 (`OnVesselSwitchComplete:entry/post` recovery loop) or #160 (the post-ComputeTotal cleanup list). Closes bugs #592-#596; opens #597 for an underlying redundant-fire concern surfaced during triage.

- **#592 Time-warp checkpoint logs (~3364 lines / ~3.3 KLine):** the three `Verbose` calls around `OnTimeWarpRateChanged` + `CheckpointAllVessels` now route through `VerboseRateLimited`. KSP's `onTimeWarpRateChanged` GameEvent fired 1121 times in one playtest, of which 1090 were `1.0x` and only 248 were unique UTs — KSP re-fires the event spuriously across scene transitions, warp-to-here, and similar transients. The two `Checkpoint` lines are keyed per warp rate, so distinct rate transitions still log on first occurrence; the BgRecorder summary is keyed by the `(checkpointed, skippedNotOrbital, skippedNoVessel)` shape so a real change still logs on first occurrence.
- **#593 Repeatable record milestones (~1190 lines):** `RecordsSpeed`/`RecordsAltitude`/`RecordsDistance` re-emitted the same `Milestone funds`, `Repeatable record milestone stays effective`, and `Milestone rep at UT` line on every recalc walk. All three branches (`FundsModule.ProcessMilestoneEarning`, `MilestonesModule.ProcessMilestoneAchievement` repeatable branch, `ReputationModule.ProcessMilestoneRep`) now route through `VerboseRateLimited` keyed by `(milestoneId, recordingId)`.
- **#594 KspStatePatcher bare-Id fallback (221 lines):** old-format-recording diagnostic now rate-limits per `(nodeId, qualifiedId)` pair.
- **#595 OrbitalCheckpoint playback (413 lines) and Recorder sample-skipped (197 lines):** rate-limit windows widened from 1.0s and 2.0s to the project default 5s. Identities still per-section and per-recorder so transitions still log on first frame.
- **#596 PatchFacilities INFO summary (42 lines):** now gated on `patched+skipped+notFound > 0`. The no-op case routes to a rate-limited `Verbose` line so the diagnostic is still available when investigating an empty `FacilitiesModule`.
- **#597 (open) underlying-logic concern:** KSP's `onTimeWarpRateChanged` event itself fires ~4x more often at `1.0x` than there are real rate changes, and `CheckpointAllVessels` still runs the same idempotent close-and-reopen for every event. No observed correctness defect; tracked as performance / hygiene follow-up.

Group F (`GhostMap` lifecycle-summary, 145 lines) was checked and confirmed already-healthy: 5s rate-limited with `suppressed=N` summaries firing at the expected cadence.

Three new regression tests (`CheckpointAllVessels_RepeatedCallsSameShape_RateLimitedToOneLine`, `MilestoneEarning_RepeatedSamePair_RateLimitedToOneLine`, `RepeatableRecordMilestone_RepeatedSamePair_RateLimitedToOneLine`) follow the canonical `IsUnfinishedFlight_RepeatedCallsSameRec_RateLimitedToOneLine` pattern: call the suspect path 50-100x with the same input and assert one emitted line.

This PR avoids the parallel `fix/591-recovery-vessel-switch-spam` work area entirely (`ParsekFlight.cs:1881`, `:2030`, `:6700-6710` are untouched).

## Test plan

- [x] `cd Source/Parsek && dotnet build` — succeeds, 0 warnings, 0 errors.
- [x] Deployed DLL verified: file size + mtime match worktree-built DLL; UTF-16 grep finds all six new rate-limit keys.
- [x] `cd Source/Parsek.Tests && dotnet test` — 8738 / 8738 pass (was 8735 before this PR; +3 new).
- [x] `pwsh -File scripts/grep-audit-ers-els.ps1` — OK (254 hits, all allowlisted).
- [x] `pwsh -File scripts/validate-ksp-log.ps1` — passes.
- [ ] Live playtest replay against the original fixture (fixture replay not part of CI; rate-limit math projected drop: ~5500 spam lines -> ~30 lines per 30-min session).