### PR TITLE
Fix #591 recovery RecState spam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- `#591` Missed-vessel-switch recovery still replays the normal `OnVesselSwitchComplete` path, but the recovery-context `RecState` `entry/post` snapshots now share a 5-second rate-limit keyed by active vessel plus recorder/tracking fingerprint. Normal player-driven vessel-switch boundaries continue to emit every `entry/post` diagnostic, while identical recovery frames collapse into `suppressed=N` summaries.
+
 - `#571` Long on-rails OrbitalCheckpoint warp sections now get derived trajectory samples every 5 degrees of true anomaly, so ghost icons follow the checkpoint window instead of replaying one sparse Kepler segment. The representative 22 ks Kerbin warp adds 42 points and preserves them through format-v6 `.prec` round trips.
 
 - `#576` PatchedConicSnapshot `solver unavailable` and the paired Extrapolator `patched-conic snapshot failed for ... with NullSolver; falling back to live orbit state` WARNs are now rate-limited per (vessel-name) and per (recording-id, failure-reason) respectively. The 2026-04-25 marker-validator-fix playtest emitted 146 of each — almost all from debris, EVA-kerbals, and probe-debris that have no patched-conic solver by design in stock KSP. Downstream NullSolver semantics (live-orbit fallback for the destroyed-vessel case) are unchanged; only the log-noise floor is trimmed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
-- `#591` Missed-vessel-switch recovery still replays the normal `OnVesselSwitchComplete` path, but the recovery-context `RecState` `entry/post` snapshots now share a 5-second rate-limit keyed by active vessel plus recorder/tracking fingerprint. Normal player-driven vessel-switch boundaries continue to emit every `entry/post` diagnostic, while identical recovery frames collapse into `suppressed=N` summaries.
+- `#591` Missed-vessel-switch recovery no longer floods `KSP.log` with redundant recorder-state snapshots. Identical recovery frames now collapse into 5-second `suppressed=N` summaries while normal vessel-switch diagnostics are unchanged.
 
 - `#571` Long on-rails OrbitalCheckpoint warp sections now get derived trajectory samples every 5 degrees of true anomaly, so ghost icons follow the checkpoint window instead of replaying one sparse Kepler segment. The representative 22 ks Kerbin warp adds 42 points and preserves them through format-v6 `.prec` round trips.
 

--- a/Source/Parsek.Tests/MissedVesselSwitchRecoveryTests.cs
+++ b/Source/Parsek.Tests/MissedVesselSwitchRecoveryTests.cs
@@ -310,6 +310,13 @@ namespace Parsek.Tests
             ParsekFlight.LogOnVesselSwitchCompleteRecState(
                 "OnVesselSwitchComplete:entry", newActiveSnapshot, newActiveContext);
 
+            var chainPendingContext = BuildRecoveryContext(
+                activeVesselPid: 736156658,
+                recorderVesselPid: 0,
+                recorderChainToVesselPending: true);
+            ParsekFlight.LogOnVesselSwitchCompleteRecState(
+                "OnVesselSwitchComplete:entry", originalSnapshot, chainPendingContext);
+
             var newRecorderContext = BuildRecoveryContext(
                 activeVesselPid: 736156658,
                 recorderVesselPid: 123,
@@ -324,10 +331,11 @@ namespace Parsek.Tests
                 "OnVesselSwitchComplete:entry", newRecorderSnapshot, newRecorderContext);
 
             List<string> recStateLines = RecStateLines();
-            Assert.Equal(3, recStateLines.Count);
+            Assert.Equal(4, recStateLines.Count);
             Assert.Contains("pid=736156658", recStateLines[0]);
             Assert.Contains("pid=42", recStateLines[1]);
-            Assert.Contains("pid=123", recStateLines[2]);
+            Assert.Contains("pid=736156658", recStateLines[2]);
+            Assert.Contains("pid=123", recStateLines[3]);
         }
 
         [Fact]
@@ -496,6 +504,7 @@ namespace Parsek.Tests
             bool hasRecorder = false,
             bool recorderIsRecording = false,
             bool recorderIsBackgrounded = false,
+            bool recorderChainToVesselPending = false,
             bool activeVesselTrackedInBackground = true,
             bool activeVesselAlreadyArmedForPostSwitchAutoRecord = false,
             string activeTreeRecordingId = "recA",
@@ -509,6 +518,7 @@ namespace Parsek.Tests
                 HasRecorder = hasRecorder,
                 RecorderIsRecording = recorderIsRecording,
                 RecorderIsBackgrounded = recorderIsBackgrounded,
+                RecorderChainToVesselPending = recorderChainToVesselPending,
                 ActiveVesselTrackedInBackground = activeVesselTrackedInBackground,
                 ActiveVesselAlreadyArmedForPostSwitchAutoRecord =
                     activeVesselAlreadyArmedForPostSwitchAutoRecord,

--- a/Source/Parsek.Tests/MissedVesselSwitchRecoveryTests.cs
+++ b/Source/Parsek.Tests/MissedVesselSwitchRecoveryTests.cs
@@ -1,12 +1,29 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using Xunit;
 
 namespace Parsek.Tests
 {
     [Collection("Sequential")]
-    public class MissedVesselSwitchRecoveryTests
+    public class MissedVesselSwitchRecoveryTests : IDisposable
     {
+        private readonly List<string> logLines = new List<string>();
+
+        public MissedVesselSwitchRecoveryTests()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.VerboseOverrideForTesting = true;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+        }
+
         [Fact]
         public void ShouldRecoverMissedVesselSwitch_RecorderPidMismatch_ReturnsTrue()
         {
@@ -188,6 +205,132 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void OnVesselSwitchRecState_NormalBoundary_LogsEveryEntryAndPost()
+        {
+            double now = 1000.0;
+            ParsekLog.ClockOverrideForTesting = () => now;
+
+            var context = default(ParsekFlight.MissedVesselSwitchRecoveryDiagnosticContext);
+            var snapshot = BuildRecStateSnapshot(activeVesselPid: 100, activeRecId: "recA");
+
+            ParsekFlight.LogOnVesselSwitchCompleteRecState(
+                "OnVesselSwitchComplete:entry", snapshot, context);
+            ParsekFlight.LogOnVesselSwitchCompleteRecState(
+                "OnVesselSwitchComplete:post", snapshot, context);
+            now = 1001.0;
+            ParsekFlight.LogOnVesselSwitchCompleteRecState(
+                "OnVesselSwitchComplete:entry", snapshot, context);
+            ParsekFlight.LogOnVesselSwitchCompleteRecState(
+                "OnVesselSwitchComplete:post", snapshot, context);
+
+            List<string> recStateLines = RecStateLines();
+            Assert.Equal(4, recStateLines.Count);
+            Assert.Equal(2, recStateLines.FindAll(l => l.Contains("[OnVesselSwitchComplete:entry]")).Count);
+            Assert.Equal(2, recStateLines.FindAll(l => l.Contains("[OnVesselSwitchComplete:post]")).Count);
+            Assert.All(recStateLines, l => Assert.DoesNotContain("suppressed=", l));
+        }
+
+        [Fact]
+        public void OnVesselSwitchRecState_RecoveryLoopSameFingerprint_CoalescesEntryAndPost()
+        {
+            double now = 1000.0;
+            ParsekLog.ClockOverrideForTesting = () => now;
+
+            var context = BuildRecoveryContext(activeVesselPid: 736156658, recorderVesselPid: 0);
+            var snapshot = BuildRecStateSnapshot(
+                activeVesselPid: 736156658,
+                activeRecId: "recBob",
+                vesselName: "Bob Kerman");
+
+            for (int i = 0; i < 3; i++)
+            {
+                ParsekFlight.LogOnVesselSwitchCompleteRecState(
+                    "OnVesselSwitchComplete:entry", snapshot, context);
+                ParsekFlight.LogOnVesselSwitchCompleteRecState(
+                    "OnVesselSwitchComplete:post", snapshot, context);
+                now += 1.0;
+            }
+
+            List<string> recStateLines = RecStateLines();
+            Assert.Equal(2, recStateLines.Count);
+            Assert.Single(recStateLines.FindAll(l => l.Contains("[OnVesselSwitchComplete:entry]")));
+            Assert.Single(recStateLines.FindAll(l => l.Contains("[OnVesselSwitchComplete:post]")));
+            Assert.Contains("Bob Kerman", recStateLines[0]);
+            Assert.Contains("pid=736156658", recStateLines[0]);
+            Assert.DoesNotContain("suppressed=", recStateLines[0]);
+        }
+
+        [Fact]
+        public void OnVesselSwitchRecState_RecoveryLoopSummary_PreservesSuppressedCountCadence()
+        {
+            double now = 2000.0;
+            ParsekLog.ClockOverrideForTesting = () => now;
+
+            var context = BuildRecoveryContext(activeVesselPid: 736156658, recorderVesselPid: 0);
+            var snapshot = BuildRecStateSnapshot(activeVesselPid: 736156658);
+
+            ParsekFlight.LogOnVesselSwitchCompleteRecState(
+                "OnVesselSwitchComplete:entry", snapshot, context);
+            now = 2001.0;
+            ParsekFlight.LogOnVesselSwitchCompleteRecState(
+                "OnVesselSwitchComplete:entry", snapshot, context);
+            now = 2002.0;
+            ParsekFlight.LogOnVesselSwitchCompleteRecState(
+                "OnVesselSwitchComplete:entry", snapshot, context);
+            now = 2005.1;
+            ParsekFlight.LogOnVesselSwitchCompleteRecState(
+                "OnVesselSwitchComplete:entry", snapshot, context);
+
+            List<string> recStateLines = RecStateLines();
+            Assert.Equal(2, recStateLines.Count);
+            Assert.DoesNotContain("suppressed=", recStateLines[0]);
+            Assert.Contains("suppressed=2", recStateLines[1]);
+        }
+
+        [Fact]
+        public void OnVesselSwitchRecState_RecoveryFingerprintChange_AllowsFreshDiagnostic()
+        {
+            double now = 3000.0;
+            ParsekLog.ClockOverrideForTesting = () => now;
+
+            var originalContext = BuildRecoveryContext(activeVesselPid: 736156658, recorderVesselPid: 0);
+            var originalSnapshot = BuildRecStateSnapshot(activeVesselPid: 736156658);
+            ParsekFlight.LogOnVesselSwitchCompleteRecState(
+                "OnVesselSwitchComplete:entry", originalSnapshot, originalContext);
+
+            now = 3001.0;
+            ParsekFlight.LogOnVesselSwitchCompleteRecState(
+                "OnVesselSwitchComplete:entry", originalSnapshot, originalContext);
+
+            var newActiveContext = BuildRecoveryContext(activeVesselPid: 42, recorderVesselPid: 0);
+            var newActiveSnapshot = BuildRecStateSnapshot(
+                activeVesselPid: 42,
+                activeRecId: "recNew",
+                vesselName: "New Vessel");
+            ParsekFlight.LogOnVesselSwitchCompleteRecState(
+                "OnVesselSwitchComplete:entry", newActiveSnapshot, newActiveContext);
+
+            var newRecorderContext = BuildRecoveryContext(
+                activeVesselPid: 736156658,
+                recorderVesselPid: 123,
+                hasRecorder: true,
+                recorderIsRecording: true,
+                activeVesselTrackedInBackground: false);
+            var newRecorderSnapshot = BuildRecStateSnapshot(
+                activeVesselPid: 123,
+                activeRecId: "recLive",
+                vesselName: "Live Recorder");
+            ParsekFlight.LogOnVesselSwitchCompleteRecState(
+                "OnVesselSwitchComplete:entry", newRecorderSnapshot, newRecorderContext);
+
+            List<string> recStateLines = RecStateLines();
+            Assert.Equal(3, recStateLines.Count);
+            Assert.Contains("pid=736156658", recStateLines[0]);
+            Assert.Contains("pid=42", recStateLines[1]);
+            Assert.Contains("pid=123", recStateLines[2]);
+        }
+
+        [Fact]
         public void ShouldAttemptCommittedSpawnedRestoreInUpdate_WhenStableAndDue_ReturnsTrue()
         {
             bool shouldAttempt = ParsekFlight.ShouldAttemptCommittedSpawnedRestoreInUpdate(
@@ -311,6 +454,67 @@ namespace Parsek.Tests
             Assert.True(closeBrace >= 0,
                 $"{methodSignature} has unbalanced braces in ParsekFlight.cs.");
             return src.Substring(methodStart, closeBrace - methodStart + 1);
+        }
+
+        private List<string> RecStateLines()
+        {
+            return logLines.FindAll(l => l.Contains("[RecState]"));
+        }
+
+        private static RecorderStateSnapshot BuildRecStateSnapshot(
+            uint activeVesselPid,
+            string activeRecId = "recA",
+            string vesselName = "Bob Kerman",
+            bool recorderExists = true,
+            bool isRecording = true,
+            bool isBackgrounded = false)
+        {
+            var snapshot = default(RecorderStateSnapshot);
+            snapshot.mode = RecorderMode.Tree;
+            snapshot.treeId = "treeA";
+            snapshot.treeName = "Recovery Tree";
+            snapshot.activeRecId = activeRecId;
+            snapshot.activeVesselName = vesselName;
+            snapshot.activeVesselPid = activeVesselPid;
+            snapshot.recorderExists = recorderExists;
+            snapshot.isRecording = isRecording;
+            snapshot.isBackgrounded = isBackgrounded;
+            snapshot.bufferedPoints = 3;
+            snapshot.bufferedPartEvents = 1;
+            snapshot.bufferedOrbitSegments = 0;
+            snapshot.lastRecordedUT = 123.4;
+            snapshot.treeRecordingCount = 1;
+            snapshot.treeBackgroundMapCount = 1;
+            snapshot.currentUT = 130.0;
+            snapshot.loadedScene = GameScenes.FLIGHT;
+            return snapshot;
+        }
+
+        private static ParsekFlight.MissedVesselSwitchRecoveryDiagnosticContext BuildRecoveryContext(
+            uint activeVesselPid,
+            uint recorderVesselPid,
+            bool hasRecorder = false,
+            bool recorderIsRecording = false,
+            bool recorderIsBackgrounded = false,
+            bool activeVesselTrackedInBackground = true,
+            bool activeVesselAlreadyArmedForPostSwitchAutoRecord = false,
+            string activeTreeRecordingId = "recA",
+            int activeTreeBackgroundMapCount = 1)
+        {
+            return new ParsekFlight.MissedVesselSwitchRecoveryDiagnosticContext
+            {
+                IsRecovery = true,
+                ActiveVesselPid = activeVesselPid,
+                RecorderVesselPid = recorderVesselPid,
+                HasRecorder = hasRecorder,
+                RecorderIsRecording = recorderIsRecording,
+                RecorderIsBackgrounded = recorderIsBackgrounded,
+                ActiveVesselTrackedInBackground = activeVesselTrackedInBackground,
+                ActiveVesselAlreadyArmedForPostSwitchAutoRecord =
+                    activeVesselAlreadyArmedForPostSwitchAutoRecord,
+                ActiveTreeRecordingId = activeTreeRecordingId,
+                ActiveTreeBackgroundMapCount = activeTreeBackgroundMapCount
+            };
         }
     }
 }

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -93,6 +93,37 @@ namespace Parsek
             PackedOrOnRails
         }
 
+        internal struct MissedVesselSwitchRecoveryDiagnosticContext
+        {
+            public bool IsRecovery;
+            public uint ActiveVesselPid;
+            public uint RecorderVesselPid;
+            public bool HasRecorder;
+            public bool RecorderIsRecording;
+            public bool RecorderIsBackgrounded;
+            public bool ActiveVesselTrackedInBackground;
+            public bool ActiveVesselAlreadyArmedForPostSwitchAutoRecord;
+            public string ActiveTreeRecordingId;
+            public int ActiveTreeBackgroundMapCount;
+
+            internal string BuildRecStateRateLimitKey()
+            {
+                if (!IsRecovery) return null;
+
+                return string.Format(CultureInfo.InvariantCulture,
+                    "missed-vessel-switch|activePid={0}|recorderPid={1}|hasRecorder={2}|rec={3}/{4}|tracked={5}|armed={6}|activeRec={7}|bgCount={8}",
+                    ActiveVesselPid,
+                    RecorderVesselPid,
+                    HasRecorder ? 1 : 0,
+                    RecorderIsRecording ? 1 : 0,
+                    RecorderIsBackgrounded ? 1 : 0,
+                    ActiveVesselTrackedInBackground ? 1 : 0,
+                    ActiveVesselAlreadyArmedForPostSwitchAutoRecord ? 1 : 0,
+                    string.IsNullOrEmpty(ActiveTreeRecordingId) ? "-" : ActiveTreeRecordingId,
+                    ActiveTreeBackgroundMapCount);
+            }
+        }
+
         internal struct PostSwitchOrbitSnapshot
         {
             public bool IsValid;
@@ -210,11 +241,13 @@ namespace Parsek
         private const double PostSwitchManifestEvaluationIntervalSeconds = 0.25;
         private const double PostSwitchManifestEvaluateNextFrameUt = 0.0;
         private const float CommittedSpawnedRestoreRetryIntervalSeconds = 1.0f;
+        internal const double MissedVesselSwitchRecoveryRecStateIntervalSeconds = 5.0;
 
         // Set true in OnSceneChangeRequested — suppresses Update() to prevent
         // ghost spawns and other processing into the dying scene.
         private bool sceneChangeInProgress;
         private float nextCommittedSpawnedRestoreRetryAt;
+        private MissedVesselSwitchRecoveryDiagnosticContext currentVesselSwitchRecoveryDiagnosticContext;
 
         // Deferred watch target after fast-forward — the ghost needs one frame
         // to be positioned after the time jump before we can enter watch mode.
@@ -1878,7 +1911,10 @@ namespace Parsek
                 return;
             }
 
-            ParsekLog.RecState("OnVesselSwitchComplete:entry", CaptureRecorderState());
+            LogOnVesselSwitchCompleteRecState(
+                "OnVesselSwitchComplete:entry",
+                CaptureRecorderState(),
+                currentVesselSwitchRecoveryDiagnosticContext);
 
             // Watch mode: re-target camera to ghost — KSP reparents pivot on vessel switch.
             // Don't early-return: tree vessel-switch logic below must still run so that
@@ -2027,7 +2063,44 @@ namespace Parsek
                         freshStartParentRecordingId);
                     break;
             }
-            ParsekLog.RecState("OnVesselSwitchComplete:post", CaptureRecorderState());
+            LogOnVesselSwitchCompleteRecState(
+                "OnVesselSwitchComplete:post",
+                CaptureRecorderState(),
+                currentVesselSwitchRecoveryDiagnosticContext);
+        }
+
+        private void ReplayVesselSwitchCompleteForMissedSwitchRecovery(
+            Vessel activeVessel,
+            MissedVesselSwitchRecoveryDiagnosticContext recoveryDiagnosticContext)
+        {
+            var previousContext = currentVesselSwitchRecoveryDiagnosticContext;
+            currentVesselSwitchRecoveryDiagnosticContext = recoveryDiagnosticContext;
+            try
+            {
+                OnVesselSwitchComplete(activeVessel);
+            }
+            finally
+            {
+                currentVesselSwitchRecoveryDiagnosticContext = previousContext;
+            }
+        }
+
+        internal static void LogOnVesselSwitchCompleteRecState(
+            string phase,
+            RecorderStateSnapshot snapshot,
+            MissedVesselSwitchRecoveryDiagnosticContext recoveryDiagnosticContext)
+        {
+            if (!recoveryDiagnosticContext.IsRecovery)
+            {
+                ParsekLog.RecState(phase, snapshot);
+                return;
+            }
+
+            ParsekLog.RecStateRateLimited(
+                phase,
+                snapshot,
+                recoveryDiagnosticContext.BuildRecStateRateLimitKey(),
+                MissedVesselSwitchRecoveryRecStateIntervalSeconds);
         }
 
         /// <summary>
@@ -6673,9 +6746,15 @@ namespace Parsek
 
             Vessel activeVessel = FlightGlobals.ActiveVessel;
             uint activeVesselPid = activeVessel != null ? activeVessel.persistentId : 0;
+            bool hasRecorder = recorder != null;
+            bool recorderIsRecording = hasRecorder && recorder.IsRecording;
+            bool recorderChainToVesselPending = hasRecorder && recorder.ChainToVesselPending;
+            uint recorderPid = hasRecorder ? recorder.RecordingVesselId : 0;
             bool activeVesselTrackedInBackground = activeTree != null
                 && activeVesselPid != 0
                 && activeTree.BackgroundMap.ContainsKey(activeVesselPid);
+            bool activeVesselAlreadyArmedForPostSwitchAutoRecord =
+                IsPostSwitchAutoRecordArmedForPid(activeVesselPid);
 
             if (!ShouldRecoverMissedVesselSwitch(
                     restoringActiveTree,
@@ -6683,31 +6762,51 @@ namespace Parsek
                     pendingTreeDockMerge,
                     pendingSplitRecorder != null,
                     pendingSplitInProgress,
-                    recorder != null,
-                    recorder != null && recorder.IsRecording,
-                    recorder != null && recorder.ChainToVesselPending,
-                    recorder != null ? recorder.RecordingVesselId : 0,
+                    hasRecorder,
+                    recorderIsRecording,
+                    recorderChainToVesselPending,
+                    recorderPid,
                     activeVesselPid,
                     activeVesselTrackedInBackground,
-                    IsPostSwitchAutoRecordArmedForPid(activeVesselPid)))
+                    activeVesselAlreadyArmedForPostSwitchAutoRecord))
             {
                 return;
             }
 
             if (GhostMapPresence.IsGhostMapVessel(activeVesselPid)) return;
 
-            uint recorderPid = recorder != null ? recorder.RecordingVesselId : 0;
+            var recoveryDiagnosticContext = new MissedVesselSwitchRecoveryDiagnosticContext
+            {
+                IsRecovery = true,
+                ActiveVesselPid = activeVesselPid,
+                RecorderVesselPid = recorderPid,
+                HasRecorder = hasRecorder,
+                RecorderIsRecording = recorderIsRecording,
+                RecorderIsBackgrounded = hasRecorder && recorder.IsBackgrounded,
+                ActiveVesselTrackedInBackground = activeVesselTrackedInBackground,
+                ActiveVesselAlreadyArmedForPostSwitchAutoRecord =
+                    activeVesselAlreadyArmedForPostSwitchAutoRecord,
+                ActiveTreeRecordingId = activeTree != null ? activeTree.ActiveRecordingId : null,
+                ActiveTreeBackgroundMapCount = activeTree != null && activeTree.BackgroundMap != null
+                    ? activeTree.BackgroundMap.Count
+                    : 0
+            };
+
             // Update() runs every frame; if the recovery handler does not clear
             // the predicate immediately (e.g. background recorder still pending),
             // this branch fires repeatedly for the same vessel. Rate-limit by
             // activePid so each vessel logs at most once per window — visibility
-            // is preserved (still a WARN), spam is bounded.
+            // is preserved (still a WARN), spam is bounded. The recovery context
+            // applies the same cadence to the nested RecState entry/post snapshots
+            // without affecting real onVesselChange boundaries.
             ParsekLog.WarnRateLimited("Flight",
                 $"missed-vessel-switch-{activeVesselPid}",
                 $"Update: recovering missed vessel switch for active vessel '{activeVessel.vesselName}' " +
                 $"(activePid={activeVesselPid}, recorderPid={recorderPid}, " +
                 $"trackedInBackground={activeVesselTrackedInBackground})");
-            OnVesselSwitchComplete(activeVessel);
+            ReplayVesselSwitchCompleteForMissedSwitchRecovery(
+                activeVessel,
+                recoveryDiagnosticContext);
         }
 
         /// <summary>

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -101,6 +101,7 @@ namespace Parsek
             public bool HasRecorder;
             public bool RecorderIsRecording;
             public bool RecorderIsBackgrounded;
+            public bool RecorderChainToVesselPending;
             public bool ActiveVesselTrackedInBackground;
             public bool ActiveVesselAlreadyArmedForPostSwitchAutoRecord;
             public string ActiveTreeRecordingId;
@@ -111,12 +112,13 @@ namespace Parsek
                 if (!IsRecovery) return null;
 
                 return string.Format(CultureInfo.InvariantCulture,
-                    "missed-vessel-switch|activePid={0}|recorderPid={1}|hasRecorder={2}|rec={3}/{4}|tracked={5}|armed={6}|activeRec={7}|bgCount={8}",
+                    "missed-vessel-switch|activePid={0}|recorderPid={1}|hasRecorder={2}|rec={3}/{4}|chain={5}|tracked={6}|armed={7}|activeRec={8}|bgCount={9}",
                     ActiveVesselPid,
                     RecorderVesselPid,
                     HasRecorder ? 1 : 0,
                     RecorderIsRecording ? 1 : 0,
                     RecorderIsBackgrounded ? 1 : 0,
+                    RecorderChainToVesselPending ? 1 : 0,
                     ActiveVesselTrackedInBackground ? 1 : 0,
                     ActiveVesselAlreadyArmedForPostSwitchAutoRecord ? 1 : 0,
                     string.IsNullOrEmpty(ActiveTreeRecordingId) ? "-" : ActiveTreeRecordingId,
@@ -6783,6 +6785,7 @@ namespace Parsek
                 HasRecorder = hasRecorder,
                 RecorderIsRecording = recorderIsRecording,
                 RecorderIsBackgrounded = hasRecorder && recorder.IsBackgrounded,
+                RecorderChainToVesselPending = recorderChainToVesselPending,
                 ActiveVesselTrackedInBackground = activeVesselTrackedInBackground,
                 ActiveVesselAlreadyArmedForPostSwitchAutoRecord =
                     activeVesselAlreadyArmedForPostSwitchAutoRecord,

--- a/Source/Parsek/ParsekLog.cs
+++ b/Source/Parsek/ParsekLog.cs
@@ -310,6 +310,13 @@ namespace Parsek
         /// full <c>[RecState]</c> snapshots on the first occurrence and on summary
         /// cadence. Normal lifecycle boundaries should call <see cref="RecState"/>.
         /// </summary>
+        /// <remarks>
+        /// Like the other rate-limited loggers, summaries are emitted only when the
+        /// same key fires again after the interval; trailing suppressed counts for
+        /// abandoned fingerprints are intentionally dropped. Keys live in the shared
+        /// per-session rate-limit dictionary until reset, so callers should use
+        /// coarse, stable fingerprints rather than per-frame values.
+        /// </remarks>
         internal static void RecStateRateLimited(
             string phase,
             RecorderStateSnapshot snap,

--- a/Source/Parsek/ParsekLog.cs
+++ b/Source/Parsek/ParsekLog.cs
@@ -306,6 +306,55 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Rate-limited variant for hot-path recovery diagnostics that still need
+        /// full <c>[RecState]</c> snapshots on the first occurrence and on summary
+        /// cadence. Normal lifecycle boundaries should call <see cref="RecState"/>.
+        /// </summary>
+        internal static void RecStateRateLimited(
+            string phase,
+            RecorderStateSnapshot snap,
+            string key,
+            double minIntervalSeconds = DefaultRateLimitSeconds)
+        {
+            if (string.IsNullOrEmpty(key))
+            {
+                RecState(phase, snap);
+                return;
+            }
+
+            string compositeKey = $"R|RecState|{phase}|{key}";
+            double now = GetLogClockSeconds();
+            if (!rateLimitStateByKey.TryGetValue(compositeKey, out var state))
+            {
+                rateLimitStateByKey[compositeKey] = new RateLimitState
+                {
+                    lastEmitSeconds = now,
+                    suppressedCount = 0
+                };
+                RecState(phase, snap);
+                return;
+            }
+
+            if ((now - state.lastEmitSeconds) >= minIntervalSeconds)
+            {
+                long seq = Interlocked.Increment(ref s_recStateSeq);
+                string line = FormatRecState(seq, phase, snap, ref t_lastSeenActiveRecId);
+                string suffix = state.suppressedCount > 0
+                    ? $" | suppressed={state.suppressedCount}"
+                    : string.Empty;
+                Write("INFO", "RecState", $"{line}{suffix}");
+                state.lastEmitSeconds = now;
+                state.suppressedCount = 0;
+            }
+            else
+            {
+                state.suppressedCount++;
+            }
+
+            rateLimitStateByKey[compositeKey] = state;
+        }
+
+        /// <summary>
         /// Pure formatting helper exposed for unit tests. The <paramref name="lastSeenRecId"/>
         /// ref parameter is updated to the current snapshot's activeRecId after rendering,
         /// implementing the "only show <c>rec.prev</c> on transitions" semantics.

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1305,10 +1305,10 @@ but passes a recovery diagnostic context so only the nested
 `RecState("OnVesselSwitchComplete:entry"/":post")` lines are
 rate-limited. The key includes activePid plus recorder/tracking
 fingerprint (recorder pid, live/background flags, tracked/armed state,
-active recording id, and BackgroundMap count), so repeated identical
-Update frames coalesce into 5s `suppressed=N` summaries while changed
-state or normal non-recovery vessel-switch boundaries emit fresh
-diagnostics.
+chain-to-vessel pending flag, active recording id, and BackgroundMap
+count), so repeated identical Update frames coalesce into 5s
+`suppressed=N` summaries while changed state or normal non-recovery
+vessel-switch boundaries emit fresh diagnostics.
 
 ---
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1256,7 +1256,7 @@ questions consistently.
 
 ---
 
-## 591. Log spam: `OnVesselSwitchComplete:entry/post` RecState lines fire ~10000 times in a single session during missed-vessel-switch recovery
+## ~~591. Log spam: `OnVesselSwitchComplete:entry/post` RecState lines fire ~10000 times in a single session during missed-vessel-switch recovery~~
 
 **Source:** `logs/2026-04-25_1933_refly-bugs/KSP.log` — 9969
 occurrences of `RecState [#NNNN][OnVesselSwitchComplete:entry|post]`,
@@ -1299,8 +1299,16 @@ shape, no useful per-frame state changes, on a hot path
   "recoverer is firing for the same activePid as last frame" and
   short-circuit before logging.
 
-**Status:** Open. Spam-only — no functional defect, but masks real
-state transitions in the log when grepping for `OnVesselSwitchComplete`.
+**Status:** ~~Open.~~ Done. Fix: the recovery branch still calls
+`OnVesselSwitchComplete(activeVessel)`, preserving the recovery behavior,
+but passes a recovery diagnostic context so only the nested
+`RecState("OnVesselSwitchComplete:entry"/":post")` lines are
+rate-limited. The key includes activePid plus recorder/tracking
+fingerprint (recorder pid, live/background flags, tracked/armed state,
+active recording id, and BackgroundMap count), so repeated identical
+Update frames coalesce into 5s `suppressed=N` summaries while changed
+state or normal non-recovery vessel-switch boundaries emit fresh
+diagnostics.
 
 ---
 


### PR DESCRIPTION
## Summary
- Rate-limit recovery-context OnVesselSwitchComplete RecState entry/post snapshots by active PID plus recorder/tracking fingerprint.
- Preserve normal OnVesselSwitchComplete diagnostics and missed-vessel-switch recovery behavior.
- Mark #591 done in docs and update the changelog entry.

## Validation
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter MissedVesselSwitchRecoveryTests
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj
- gpt-5.5 xhigh review: no actionable findings
- follow-up gpt-5.5 xhigh review: no actionable findings
- deployed DLL hash matched the worktree build after force-copy