### PR TITLE
Fix rewind suppression for future tree spawns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,7 @@ All notable changes to Parsek are documented here.
 
 - Patched-conic snapshots now keep the valid prefix of a chain when KSP's stock solver leaves a later patch with a null reference body, instead of discarding everything. Recordings now retain their predicted-tail orbit data through transient ascent solver hiccups, and the previous WARN tier downgrades to a single VERBOSE truncation note.
 
-- Plain Rewind-to-Launch (R-button) no longer materialises a real upper-stage copy when chain replay later reaches a chain-leaf in the rewound tree. The rewind path now marks every recording in the rewound tree as `SpawnSuppressedByRewind`, so the chain-tip activation that fires after warp (well after the rewind flag has cleared) finds the recording flagged as ghost-only past and refuses to spawn.
+- `#589` Plain Rewind-to-Launch (R-button) now scopes `SpawnSuppressedByRewind` to the active/source recording stripped during rewind instead of marking the whole tree. The #573 duplicate-source protection still blocks that same recording from respawning, while future same-tree terminal recordings (EVA kerbals, flags, landers, etc.) remain spawn-eligible when playback crosses their `endUT`; stale legacy whole-tree markers are cleared/ignored at the spawn gate with diagnostics.
 
 - Merging an in-place re-fly now reaps the Rewind Point and seals the recording as Immutable, so it's promoted out of Unfinished Flights even if the re-flight crashed.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,7 @@ All notable changes to Parsek are documented here.
 
 - Patched-conic snapshots now keep the valid prefix of a chain when KSP's stock solver leaves a later patch with a null reference body, instead of discarding everything. Recordings now retain their predicted-tail orbit data through transient ascent solver hiccups, and the previous WARN tier downgrades to a single VERBOSE truncation note.
 
-- `#589` Plain Rewind-to-Launch (R-button) now scopes `SpawnSuppressedByRewind` to the active/source recording stripped during rewind instead of marking the whole tree. The #573 duplicate-source protection still blocks that same recording from respawning, while future same-tree terminal recordings (EVA kerbals, flags, landers, etc.) remain spawn-eligible when playback crosses their `endUT`; stale legacy whole-tree markers are cleared/ignored at the spawn gate with diagnostics.
+- Plain Rewind-to-Launch (R-button) now scopes `SpawnSuppressedByRewind` to the active/source recording stripped during rewind instead of marking the whole tree (#589). The #573 duplicate-source protection still blocks that same recording from respawning, while future same-tree terminal recordings (EVA kerbals, flags, landers, etc.) remain spawn-eligible when playback crosses their `endUT`; stale legacy whole-tree markers are cleared/ignored at the spawn gate with diagnostics.
 
 - Merging an in-place re-fly now reaps the Rewind Point and seals the recording as Immutable, so it's promoted out of Unfinished Flights even if the re-flight crashed.
 

--- a/Source/Parsek.Tests/RewindSpawnSuppressionTests.cs
+++ b/Source/Parsek.Tests/RewindSpawnSuppressionTests.cs
@@ -235,6 +235,23 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void RecordingTree_LoadStraySuppressionMetadataWithoutBool_IgnoresReasonAndUT()
+        {
+            var node = new ConfigNode("RECORDING");
+            node.AddValue("id", "stray-metadata");
+            node.AddValue("spawnSuppressedByRewindReason",
+                ParsekScenario.RewindSpawnSuppressionReasonSameRecording);
+            node.AddValue("spawnSuppressedByRewindUT", "12.5");
+
+            var loaded = new Recording();
+            RecordingTree.LoadRecordingFrom(node, loaded);
+
+            Assert.False(loaded.SpawnSuppressedByRewind);
+            Assert.Null(loaded.SpawnSuppressedByRewindReason);
+            Assert.True(double.IsNaN(loaded.SpawnSuppressedByRewindUT));
+        }
+
+        [Fact]
         public void RecordingTree_LoadLegacyWholeTreeMarkers_PreservesProbableSourceAndAllowsFuture()
         {
             var source = MakeRecording(
@@ -332,6 +349,8 @@ namespace Parsek.Tests
             {
                 Id = "legacy-tree-active-case",
                 TreeName = "Legacy Tree Active Case",
+                // ActiveRecordingId can persist as a future terminal leaf on committed
+                // legacy trees, so normalization must prefer the root when both exist.
                 RootRecordingId = source.RecordingId,
                 ActiveRecordingId = activeFutureLeaf.RecordingId,
             };
@@ -368,6 +387,63 @@ namespace Parsek.Tests
                 treeContext: reloadedTree);
             Assert.True(futureResult.needsSpawn);
             Assert.False(reloadedFuture.SpawnSuppressedByRewind);
+        }
+
+        [Fact]
+        public void ShouldApplyRewindSpawnSuppression_BoundaryOverlapUsesEpsilonOnly()
+        {
+            const uint sourcePid = 888u;
+            const string treeId = "boundary-tree";
+            const double rewindUT = 100.0;
+
+            var endsExactlyAtRewind = MakeRecording(
+                "ends-exactly",
+                "Boundary Exact",
+                sourcePid,
+                treeId,
+                startUT: 0.0,
+                endUT: rewindUT);
+            var endsWithinBoundaryEpsilon = MakeRecording(
+                "ends-within-epsilon",
+                "Boundary Within",
+                sourcePid,
+                treeId,
+                startUT: 0.0,
+                endUT: rewindUT - 0.0005);
+            var endedBeforeBoundary = MakeRecording(
+                "ended-before",
+                "Boundary Before",
+                sourcePid,
+                treeId,
+                startUT: 0.0,
+                endUT: rewindUT - 0.01);
+
+            Assert.True(ParsekScenario.ShouldApplyRewindSpawnSuppression(
+                endsExactlyAtRewind,
+                rewindRecordingId: "different-source",
+                rewindSourcePid: sourcePid,
+                rewoundTreeId: treeId,
+                rewindUT: rewindUT,
+                out string exactReason));
+            Assert.Equal(ParsekScenario.RewindSpawnSuppressionReasonSameRecording, exactReason);
+
+            Assert.True(ParsekScenario.ShouldApplyRewindSpawnSuppression(
+                endsWithinBoundaryEpsilon,
+                rewindRecordingId: "different-source",
+                rewindSourcePid: sourcePid,
+                rewoundTreeId: treeId,
+                rewindUT: rewindUT,
+                out string withinReason));
+            Assert.Equal(ParsekScenario.RewindSpawnSuppressionReasonSameRecording, withinReason);
+
+            Assert.False(ParsekScenario.ShouldApplyRewindSpawnSuppression(
+                endedBeforeBoundary,
+                rewindRecordingId: "different-source",
+                rewindSourcePid: sourcePid,
+                rewoundTreeId: treeId,
+                rewindUT: rewindUT,
+                out string beforeReason));
+            Assert.Null(beforeReason);
         }
 
         private static Recording MakeRecording(

--- a/Source/Parsek.Tests/RewindSpawnSuppressionTests.cs
+++ b/Source/Parsek.Tests/RewindSpawnSuppressionTests.cs
@@ -1,0 +1,394 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Focused tests for the scoped SpawnSuppressedByRewind lifecycle (#573/#589).
+    /// </summary>
+    [Collection("Sequential")]
+    public class RewindSpawnSuppressionTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public RewindSpawnSuppressionTests()
+        {
+            RecordingStore.SuppressLogging = false;
+            RecordingStore.ResetForTesting();
+            MilestoneStore.ResetForTesting();
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.VerboseOverrideForTesting = true;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+            RecordingStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+            MilestoneStore.ResetForTesting();
+        }
+
+        [Fact]
+        public void MarkRewoundTreeRecordingsAsGhostOnly_LogsSourceProtectionAndFutureSkip()
+        {
+            const uint sourcePid = 2708531065u;
+            const string treeId = "tree-589";
+            const double rewindUT = 10.0;
+
+            var source = MakeRecording(
+                "source",
+                "Kerbal X",
+                sourcePid,
+                treeId,
+                startUT: 0.0,
+                endUT: 30.0);
+            var futureSameTree = MakeRecording(
+                "future-bob",
+                "Bob Kerman",
+                sourcePid,
+                treeId,
+                startUT: 24034.0,
+                endUT: 24062.0);
+
+            RecordingStore.RewindReplayTargetSourcePid = sourcePid;
+            RecordingStore.RewindReplayTargetRecordingId = source.RecordingId;
+            RewindContext.BeginRewind(rewindUT, default(BudgetSummary), 0, 0, 0);
+
+            int marked = ParsekScenario.MarkRewoundTreeRecordingsAsGhostOnly(
+                new List<Recording> { source, futureSameTree });
+
+            Assert.Equal(1, marked);
+            Assert.True(source.SpawnSuppressedByRewind);
+            Assert.Equal(ParsekScenario.RewindSpawnSuppressionReasonSameRecording,
+                source.SpawnSuppressedByRewindReason);
+            Assert.False(futureSameTree.SpawnSuppressedByRewind);
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[Rewind]") &&
+                l.Contains("SpawnSuppressedByRewind applied") &&
+                l.Contains("reason=same-recording") &&
+                l.Contains("#573 active/source recording protection"));
+            Assert.Contains(logLines, l =>
+                l.Contains("[Rewind]") &&
+                l.Contains("SpawnSuppressedByRewind not applied") &&
+                l.Contains("reason=same-tree-future-recording") &&
+                l.Contains("spawn allowed when endpoint is reached post-rewind"));
+            Assert.Contains(logLines, l =>
+                l.Contains("[Rewind]") &&
+                l.Contains("SpawnSuppressedByRewind scope summary") &&
+                l.Contains("futureAllowed=1"));
+        }
+
+        [Fact]
+        public void ShouldSpawnAtRecordingEnd_LegacyUnscopedMarker_IsClearedAndSpawnAllowed()
+        {
+            var futureSameTree = MakeRecording(
+                "future-legacy",
+                "Bob Kerman",
+                736156658u,
+                "tree-legacy",
+                startUT: 24034.0,
+                endUT: 24062.0);
+            futureSameTree.SpawnSuppressedByRewind = true;
+
+            var result = GhostPlaybackLogic.ShouldSpawnAtRecordingEnd(
+                futureSameTree,
+                isActiveChainMember: false,
+                isChainLooping: false);
+
+            Assert.True(result.needsSpawn);
+            Assert.False(futureSameTree.SpawnSuppressedByRewind);
+            Assert.Null(futureSameTree.SpawnSuppressedByRewindReason);
+            Assert.True(double.IsNaN(futureSameTree.SpawnSuppressedByRewindUT));
+            Assert.Contains(logLines, l =>
+                l.Contains("[Rewind]") &&
+                l.Contains("SpawnSuppressedByRewind cleared") &&
+                l.Contains("reason=legacy-unscoped"));
+            Assert.Contains(logLines, l =>
+                l.Contains("[Rewind]") &&
+                l.Contains("Spawn allowed despite same-tree rewind") &&
+                l.Contains("markerReason=legacy-unscoped"));
+        }
+
+        [Fact]
+        public void RepeatedRewind_ClearsStaleSuppressionOnUnrelatedRecording()
+        {
+            const uint firstPid = 111u;
+            const uint secondPid = 222u;
+
+            var staleFirstTree = MakeRecording(
+                "first-source",
+                "First Source",
+                firstPid,
+                "first-tree",
+                startUT: 0.0,
+                endUT: 20.0);
+            staleFirstTree.SpawnSuppressedByRewind = true;
+            staleFirstTree.SpawnSuppressedByRewindReason =
+                ParsekScenario.RewindSpawnSuppressionReasonSameRecording;
+            staleFirstTree.SpawnSuppressedByRewindUT = 0.0;
+
+            var secondSource = MakeRecording(
+                "second-source",
+                "Second Source",
+                secondPid,
+                "second-tree",
+                startUT: 100.0,
+                endUT: 160.0);
+
+            RecordingStore.RewindReplayTargetSourcePid = secondPid;
+            RecordingStore.RewindReplayTargetRecordingId = secondSource.RecordingId;
+            RewindContext.BeginRewind(120.0, default(BudgetSummary), 0, 0, 0);
+
+            int marked = ParsekScenario.MarkRewoundTreeRecordingsAsGhostOnly(
+                new List<Recording> { staleFirstTree, secondSource });
+
+            Assert.Equal(1, marked);
+            Assert.False(staleFirstTree.SpawnSuppressedByRewind);
+            Assert.True(secondSource.SpawnSuppressedByRewind);
+            Assert.Contains(logLines, l =>
+                l.Contains("[Rewind]") &&
+                l.Contains("SpawnSuppressedByRewind cleared") &&
+                l.Contains("stale marker no longer matches active/source scope"));
+        }
+
+        [Fact]
+        public void ResetAllPlaybackState_LogsSuppressionClearLifecycle()
+        {
+            var rec = MakeRecording(
+                "reset-source",
+                "Reset Source",
+                333u,
+                "reset-tree",
+                startUT: 0.0,
+                endUT: 30.0);
+            rec.SpawnSuppressedByRewind = true;
+            rec.SpawnSuppressedByRewindReason =
+                ParsekScenario.RewindSpawnSuppressionReasonSameRecording;
+            rec.SpawnSuppressedByRewindUT = 0.0;
+            RecordingStore.AddRecordingWithTreeForTesting(rec);
+
+            RecordingStore.ResetAllPlaybackState();
+
+            Assert.False(rec.SpawnSuppressedByRewind);
+            Assert.Null(rec.SpawnSuppressedByRewindReason);
+            Assert.True(double.IsNaN(rec.SpawnSuppressedByRewindUT));
+            Assert.Contains(logLines, l =>
+                l.Contains("[Rewind]") &&
+                l.Contains("SpawnSuppressedByRewind reset") &&
+                l.Contains("reason=same-recording"));
+        }
+
+        [Fact]
+        public void RecordingTree_SaveLoadRoundTrip_PreservesScopedSuppressionMetadata()
+        {
+            var source = MakeRecording(
+                "persist-source",
+                "Persist Source",
+                444u,
+                "persist-tree",
+                startUT: 0.0,
+                endUT: 30.0);
+            source.SpawnSuppressedByRewind = true;
+            source.SpawnSuppressedByRewindReason =
+                ParsekScenario.RewindSpawnSuppressionReasonSameRecording;
+            source.SpawnSuppressedByRewindUT = 12.5;
+
+            var node = new ConfigNode("RECORDING");
+            RecordingTree.SaveRecordingInto(node, source);
+
+            var loaded = new Recording();
+            RecordingTree.LoadRecordingFrom(node, loaded);
+
+            Assert.True(loaded.SpawnSuppressedByRewind);
+            Assert.Equal(ParsekScenario.RewindSpawnSuppressionReasonSameRecording,
+                loaded.SpawnSuppressedByRewindReason);
+            Assert.Equal(12.5, loaded.SpawnSuppressedByRewindUT);
+        }
+
+        [Fact]
+        public void RecordingTree_LoadLegacyBoolOnlySuppression_TagsLegacyUnscoped()
+        {
+            var legacy = MakeRecording(
+                "legacy-source",
+                "Legacy Source",
+                555u,
+                "legacy-tree",
+                startUT: 0.0,
+                endUT: 30.0);
+            legacy.SpawnSuppressedByRewind = true;
+
+            var node = new ConfigNode("RECORDING");
+            RecordingTree.SaveRecordingInto(node, legacy);
+
+            var loaded = new Recording();
+            RecordingTree.LoadRecordingFrom(node, loaded);
+
+            Assert.True(loaded.SpawnSuppressedByRewind);
+            Assert.Equal(ParsekScenario.RewindSpawnSuppressionReasonLegacyUnscoped,
+                loaded.SpawnSuppressedByRewindReason);
+            Assert.True(double.IsNaN(loaded.SpawnSuppressedByRewindUT));
+        }
+
+        [Fact]
+        public void RecordingTree_LoadLegacyWholeTreeMarkers_PreservesProbableSourceAndAllowsFuture()
+        {
+            var source = MakeRecording(
+                "legacy-root",
+                "Legacy Root",
+                666u,
+                "legacy-tree",
+                startUT: 0.0,
+                endUT: 30.0);
+            source.TreeOrder = 0;
+            source.SpawnSuppressedByRewind = true;
+
+            var futureSameTree = MakeRecording(
+                "legacy-future",
+                "Legacy Future Lander",
+                666u,
+                "legacy-tree",
+                startUT: 24034.0,
+                endUT: 24062.0);
+            futureSameTree.TreeOrder = 1;
+            futureSameTree.ParentRecordingId = source.RecordingId;
+            futureSameTree.SpawnSuppressedByRewind = true;
+
+            var tree = new RecordingTree
+            {
+                Id = "legacy-tree",
+                TreeName = "Legacy Tree",
+                RootRecordingId = source.RecordingId,
+            };
+            tree.AddOrReplaceRecording(source);
+            tree.AddOrReplaceRecording(futureSameTree);
+
+            var node = new ConfigNode("TREE");
+            tree.Save(node);
+
+            var loadedTree = RecordingTree.Load(node);
+            var loadedSource = loadedTree.Recordings[source.RecordingId];
+            var loadedFuture = loadedTree.Recordings[futureSameTree.RecordingId];
+            loadedSource.VesselSnapshot = new ConfigNode("VESSEL");
+            loadedFuture.VesselSnapshot = new ConfigNode("VESSEL");
+
+            Assert.Equal(ParsekScenario.RewindSpawnSuppressionReasonSameRecording,
+                loadedSource.SpawnSuppressedByRewindReason);
+            Assert.Equal(ParsekScenario.RewindSpawnSuppressionReasonLegacyUnscoped,
+                loadedFuture.SpawnSuppressedByRewindReason);
+
+            var sourceResult = GhostPlaybackLogic.ShouldSpawnAtRecordingEnd(
+                loadedSource,
+                isActiveChainMember: false,
+                isChainLooping: false,
+                treeContext: loadedTree);
+            Assert.False(sourceResult.needsSpawn);
+            Assert.Contains("#573", sourceResult.reason);
+
+            var futureResult = GhostPlaybackLogic.ShouldSpawnAtRecordingEnd(
+                loadedFuture,
+                isActiveChainMember: false,
+                isChainLooping: false,
+                treeContext: loadedTree);
+            Assert.True(futureResult.needsSpawn);
+            Assert.False(loadedFuture.SpawnSuppressedByRewind);
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[RecordingTree]") &&
+                l.Contains("Legacy SpawnSuppressedByRewind markers normalized") &&
+                l.Contains("sourceProtected=1") &&
+                l.Contains("futureEligible=1"));
+        }
+
+        [Fact]
+        public void RecordingTree_LoadLegacyWholeTreeMarkers_DoesNotTreatFutureActiveLeafAsSource()
+        {
+            var source = MakeRecording(
+                "legacy-root-active-case",
+                "Legacy Root Active Case",
+                777u,
+                "legacy-tree-active-case",
+                startUT: 0.0,
+                endUT: 30.0);
+            source.TreeOrder = 0;
+            source.SpawnSuppressedByRewind = true;
+
+            var activeFutureLeaf = MakeRecording(
+                "legacy-active-future",
+                "Legacy Active Future Lander",
+                777u,
+                "legacy-tree-active-case",
+                startUT: 24034.0,
+                endUT: 24062.0);
+            activeFutureLeaf.TreeOrder = 1;
+            activeFutureLeaf.ParentRecordingId = source.RecordingId;
+            activeFutureLeaf.SpawnSuppressedByRewind = true;
+
+            var tree = new RecordingTree
+            {
+                Id = "legacy-tree-active-case",
+                TreeName = "Legacy Tree Active Case",
+                RootRecordingId = source.RecordingId,
+                ActiveRecordingId = activeFutureLeaf.RecordingId,
+            };
+            tree.AddOrReplaceRecording(source);
+            tree.AddOrReplaceRecording(activeFutureLeaf);
+
+            var node = new ConfigNode("TREE");
+            tree.Save(node);
+
+            var loadedTree = RecordingTree.Load(node);
+            var loadedSource = loadedTree.Recordings[source.RecordingId];
+            var loadedFuture = loadedTree.Recordings[activeFutureLeaf.RecordingId];
+            loadedSource.VesselSnapshot = new ConfigNode("VESSEL");
+            loadedFuture.VesselSnapshot = new ConfigNode("VESSEL");
+
+            Assert.Equal(ParsekScenario.RewindSpawnSuppressionReasonSameRecording,
+                loadedSource.SpawnSuppressedByRewindReason);
+            Assert.Equal(ParsekScenario.RewindSpawnSuppressionReasonLegacyUnscoped,
+                loadedFuture.SpawnSuppressedByRewindReason);
+
+            var secondNode = new ConfigNode("TREE");
+            loadedTree.Save(secondNode);
+            var reloadedTree = RecordingTree.Load(secondNode);
+            var reloadedFuture = reloadedTree.Recordings[activeFutureLeaf.RecordingId];
+            reloadedFuture.VesselSnapshot = new ConfigNode("VESSEL");
+
+            Assert.Equal(ParsekScenario.RewindSpawnSuppressionReasonLegacyUnscoped,
+                reloadedFuture.SpawnSuppressedByRewindReason);
+
+            var futureResult = GhostPlaybackLogic.ShouldSpawnAtRecordingEnd(
+                reloadedFuture,
+                isActiveChainMember: false,
+                isChainLooping: false,
+                treeContext: reloadedTree);
+            Assert.True(futureResult.needsSpawn);
+            Assert.False(reloadedFuture.SpawnSuppressedByRewind);
+        }
+
+        private static Recording MakeRecording(
+            string recordingId,
+            string vesselName,
+            uint pid,
+            string treeId,
+            double startUT,
+            double endUT)
+        {
+            return new Recording
+            {
+                RecordingId = recordingId,
+                VesselName = vesselName,
+                VesselPersistentId = pid,
+                TreeId = treeId,
+                ExplicitStartUT = startUT,
+                ExplicitEndUT = endUT,
+                VesselSnapshot = new ConfigNode("VESSEL"),
+                TerminalStateValue = TerminalState.Landed,
+            };
+        }
+    }
+}

--- a/Source/Parsek.Tests/RewindTimelineTests.cs
+++ b/Source/Parsek.Tests/RewindTimelineTests.cs
@@ -809,33 +809,33 @@ namespace Parsek.Tests
         #region SpawnSuppressedByRewind (#573 follow-up to PR #541)
 
         /// <summary>
-        /// Production-sequence regression for #573: a chain-leaf recording from
-        /// a rewound tree (its <c>VesselPersistentId</c> matches the rewind
-        /// owner's pid because chain segments share the source pid) must NOT
-        /// spawn a real vessel after a plain Rewind-to-Launch, even though
+        /// Production-sequence regression for #573: the active/source recording
+        /// protected by rewind strip cleanup must NOT spawn a duplicate real vessel
+        /// after a plain Rewind-to-Launch, even though
         /// <see cref="ParsekScenario.HandleRewindOnLoad"/> has already cleared
         /// <see cref="RewindContext.IsRewinding"/> by the time the FLIGHT
-        /// update path picks up the chain-tip activation.
+        /// update path picks up terminal activation.
         /// </summary>
         [Fact]
-        public void ShouldSpawn_PostRewindChainLeafSameSourcePid_ReturnsFalse()
+        public void ShouldSpawn_PostRewindSameRecordingProtection_ReturnsFalse()
         {
             const uint kBoosterPid = 2708531065u;
-            var chainLeaf = new Recording
+            var sourceRecording = new Recording
             {
-                RecordingId = "chain-leaf-rewound",
-                VesselName = "Kerbal X (post-rewind chain leaf)",
+                RecordingId = "source-rewound",
+                VesselName = "Kerbal X (post-rewind source)",
                 VesselSnapshot = new ConfigNode("VESSEL"),
                 VesselSpawned = false,
                 VesselPersistentId = kBoosterPid,
                 ChainId = "89e6ecae5d184f26bf84973c138e36aa",
-                ChainIndex = 1,
+                ChainIndex = 0,
                 TerminalStateValue = TerminalState.Splashed,
                 SpawnSuppressedByRewind = true,
+                SpawnSuppressedByRewindReason = ParsekScenario.RewindSpawnSuppressionReasonSameRecording,
             };
 
             var (needsSpawn, reason) = GhostPlaybackLogic.ShouldSpawnAtRecordingEnd(
-                chainLeaf, isActiveChainMember: false, isChainLooping: false);
+                sourceRecording, isActiveChainMember: false, isChainLooping: false);
 
             Assert.False(needsSpawn);
             Assert.Contains("spawn suppressed post-rewind", reason);
@@ -847,17 +847,17 @@ namespace Parsek.Tests
         /// <see cref="ParsekScenario.MarkRewoundTreeRecordingsAsGhostOnly"/>
         /// (the helper that <see cref="ParsekScenario.HandleRewindOnLoad"/>
         /// invokes after <see cref="RecordingStore.ResetAllPlaybackState"/>):
-        /// every recording in the rewound tree gets <c>SpawnSuppressedByRewind</c>
-        /// set, and <see cref="GhostPlaybackLogic.ShouldSpawnAtRecordingEnd"/>
-        /// refuses to spawn the chain leaf afterward — independently of
-        /// <see cref="RewindContext.IsRewinding"/>'s post-EndRewind state.
+        /// only the active/source recording gets <c>SpawnSuppressedByRewind</c>
+        /// set. Same-tree future recordings remain eligible for normal terminal
+        /// materialization when playback reaches their EndUT (#589).
         /// </summary>
         [Fact]
-        public void HandleRewindOnLoad_MarksAllRewoundTreeChainLeavesGhostOnly_AllSpawnRefused()
+        public void HandleRewindOnLoad_SuppressesSourceOnly_FutureSameTreeSpawnAllowed()
         {
             const uint kBoosterPid = 2708531065u;
             const string kTreeId = "7e46a9f16c9a4dcd90d1c1baaea6e2f5";
             const string kChainId = "89e6ecae5d184f26bf84973c138e36aa";
+            const double kRewindUT = 100.0;
 
             var boosterRoot = new Recording
             {
@@ -868,29 +868,20 @@ namespace Parsek.Tests
                 TreeId = kTreeId,
                 ChainId = kChainId,
                 ChainIndex = 0,
+                ExplicitStartUT = 0.0,
+                ExplicitEndUT = 200.0,
                 TerminalStateValue = TerminalState.Splashed,
             };
-            var orbitingSegment = new Recording
+            var futureLander = new Recording
             {
                 RecordingId = "b85acd51ea7f4005bb5d879207749e8c",
-                VesselName = "Kerbal X",
+                VesselName = "Kerbal X Mun Lander",
                 VesselSnapshot = new ConfigNode("VESSEL"),
                 VesselPersistentId = kBoosterPid,
                 TreeId = kTreeId,
-                ChainId = kChainId,
-                ChainIndex = 1,
-                SegmentPhase = "exo",
-            };
-            var splashedLeaf = new Recording
-            {
-                RecordingId = "2c276b3c6a9c438eb288dc4cbd55a3ee",
-                VesselName = "Kerbal X",
-                VesselSnapshot = new ConfigNode("VESSEL"),
-                VesselPersistentId = kBoosterPid,
-                TreeId = kTreeId,
-                ChainId = "9b7dcf47740644a7995992170445dd41",
-                ChainIndex = 1,
-                TerminalStateValue = TerminalState.Splashed,
+                ExplicitStartUT = 24034.0,
+                ExplicitEndUT = 24062.0,
+                TerminalStateValue = TerminalState.Landed,
             };
             var unrelatedFromOtherTree = new Recording
             {
@@ -904,7 +895,7 @@ namespace Parsek.Tests
 
             var recordings = new List<Recording>
             {
-                boosterRoot, orbitingSegment, splashedLeaf, unrelatedFromOtherTree
+                boosterRoot, futureLander, unrelatedFromOtherTree
             };
 
             // Simulate HandleRewindOnLoad's state right after ResetAllPlaybackState:
@@ -912,39 +903,34 @@ namespace Parsek.Tests
             // RewindReplayTargetRecordingId points at the booster root.
             RecordingStore.RewindReplayTargetSourcePid = kBoosterPid;
             RecordingStore.RewindReplayTargetRecordingId = boosterRoot.RecordingId;
+            RewindContext.BeginRewind(kRewindUT, default(BudgetSummary), 0, 0, 0);
 
             int marked = ParsekScenario.MarkRewoundTreeRecordingsAsGhostOnly(recordings);
 
             try
             {
-                Assert.Equal(3, marked);
+                Assert.Equal(1, marked);
                 Assert.True(boosterRoot.SpawnSuppressedByRewind);
-                Assert.True(orbitingSegment.SpawnSuppressedByRewind);
-                Assert.True(splashedLeaf.SpawnSuppressedByRewind);
+                Assert.Equal(ParsekScenario.RewindSpawnSuppressionReasonSameRecording,
+                    boosterRoot.SpawnSuppressedByRewindReason);
+                Assert.False(futureLander.SpawnSuppressedByRewind);
                 Assert.False(unrelatedFromOtherTree.SpawnSuppressedByRewind);
 
-                // Chain-leaf spawn refused — the production duplicate at
-                // 13:13:19.600 (PlaybackCompleted index=15 needsSpawn=True)
-                // is now blocked here.
-                var leafResult = GhostPlaybackLogic.ShouldSpawnAtRecordingEnd(
-                    splashedLeaf, isActiveChainMember: false, isChainLooping: false);
-                Assert.False(leafResult.needsSpawn);
-                Assert.Contains("spawn suppressed post-rewind", leafResult.reason);
-
-                // Root and mid-chain are also blocked (so the chain-tip propagation
-                // path can't fall through to a sibling segment).
                 var rootResult = GhostPlaybackLogic.ShouldSpawnAtRecordingEnd(
                     boosterRoot, isActiveChainMember: false, isChainLooping: false);
                 Assert.False(rootResult.needsSpawn);
                 Assert.Contains("spawn suppressed post-rewind", rootResult.reason);
 
-                var midResult = GhostPlaybackLogic.ShouldSpawnAtRecordingEnd(
-                    orbitingSegment, isActiveChainMember: false, isChainLooping: false);
-                Assert.False(midResult.needsSpawn);
-                Assert.Contains("spawn suppressed post-rewind", midResult.reason);
+                var futureResult = GhostPlaybackLogic.ShouldSpawnAtRecordingEnd(
+                    futureLander, isActiveChainMember: false, isChainLooping: false);
+                Assert.True(futureResult.needsSpawn);
+
+                var kscResult = GhostPlaybackLogic.ShouldSpawnAtKscEnd(
+                    futureLander, currentUT: futureLander.EndUT + 1.0);
+                Assert.True(kscResult.needsSpawn);
 
                 // Unrelated tree is unaffected — only the rewound tree's
-                // recordings flip to ghost-only.
+                // source recording flips to protected.
                 var unrelatedResult = GhostPlaybackLogic.ShouldSpawnAtRecordingEnd(
                     unrelatedFromOtherTree, isActiveChainMember: false, isChainLooping: false);
                 Assert.True(unrelatedResult.needsSpawn);
@@ -953,6 +939,7 @@ namespace Parsek.Tests
             {
                 RecordingStore.RewindReplayTargetSourcePid = 0;
                 RecordingStore.RewindReplayTargetRecordingId = null;
+                RewindContext.ResetForTesting();
             }
         }
 
@@ -994,6 +981,8 @@ namespace Parsek.Tests
 
                 Assert.Equal(1, marked);
                 Assert.True(standaloneRec.SpawnSuppressedByRewind);
+                Assert.Equal(ParsekScenario.RewindSpawnSuppressionReasonSameRecording,
+                    standaloneRec.SpawnSuppressedByRewindReason);
                 Assert.False(unrelated.SpawnSuppressedByRewind);
             }
             finally
@@ -1004,10 +993,9 @@ namespace Parsek.Tests
         }
 
         /// <summary>
-        /// Idempotency: calling the helper twice on the same recording set
-        /// does not double-count or re-emit the per-recording log line, and
-        /// the flag stays sticky across repeats (exercises the
-        /// <c>SpawnSuppressedByRewind</c> early-skip branch).
+        /// Idempotency: an already-suppressed source recording is retained
+        /// without incrementing the newly-marked count, and missing legacy
+        /// metadata is refreshed to the scoped same-recording reason.
         /// </summary>
         [Fact]
         public void MarkRewoundTreeRecordingsAsGhostOnly_AlreadyMarked_NoOp()
@@ -1033,6 +1021,8 @@ namespace Parsek.Tests
 
                 Assert.Equal(0, marked);
                 Assert.True(rec.SpawnSuppressedByRewind);
+                Assert.Equal(ParsekScenario.RewindSpawnSuppressionReasonSameRecording,
+                    rec.SpawnSuppressedByRewindReason);
             }
             finally
             {
@@ -1057,12 +1047,16 @@ namespace Parsek.Tests
                 VesselSnapshot = new ConfigNode("VESSEL"),
                 VesselPersistentId = 5555u,
                 SpawnSuppressedByRewind = true,
+                SpawnSuppressedByRewindReason = ParsekScenario.RewindSpawnSuppressionReasonSameRecording,
+                SpawnSuppressedByRewindUT = 123.0,
             };
             RecordingStore.AddRecordingWithTreeForTesting(rec);
 
             RecordingStore.ResetAllPlaybackState();
 
             Assert.False(rec.SpawnSuppressedByRewind);
+            Assert.Null(rec.SpawnSuppressedByRewindReason);
+            Assert.True(double.IsNaN(rec.SpawnSuppressedByRewindUT));
         }
 
         #endregion

--- a/Source/Parsek.Tests/RewindTimelineTests.cs
+++ b/Source/Parsek.Tests/RewindTimelineTests.cs
@@ -993,12 +993,12 @@ namespace Parsek.Tests
         }
 
         /// <summary>
-        /// Idempotency: an already-suppressed source recording is retained
-        /// without incrementing the newly-marked count, and missing legacy
-        /// metadata is refreshed to the scoped same-recording reason.
+        /// Idempotency: an already-suppressed source recording is retained in
+        /// the protected-source count, and missing legacy metadata is refreshed
+        /// to the scoped same-recording reason.
         /// </summary>
         [Fact]
-        public void MarkRewoundTreeRecordingsAsGhostOnly_AlreadyMarked_NoOp()
+        public void MarkRewoundTreeRecordingsAsGhostOnly_AlreadyMarked_ReturnsRetainedSource()
         {
             const uint kSourcePid = 7777u;
             var rec = new Recording
@@ -1017,9 +1017,9 @@ namespace Parsek.Tests
 
             try
             {
-                int marked = ParsekScenario.MarkRewoundTreeRecordingsAsGhostOnly(recordings);
+                int protectedCount = ParsekScenario.MarkRewoundTreeRecordingsAsGhostOnly(recordings);
 
-                Assert.Equal(0, marked);
+                Assert.Equal(1, protectedCount);
                 Assert.True(rec.SpawnSuppressedByRewind);
                 Assert.Equal(ParsekScenario.RewindSpawnSuppressionReasonSameRecording,
                     rec.SpawnSuppressedByRewindReason);

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -4042,14 +4042,14 @@ namespace Parsek
                     rec.TerminalSpawnSupersededByRecordingId);
             }
 
-            // Plain Rewind-to-Launch ghost-only past (#573 / PR #541 follow-up):
-            // After HandleRewindOnLoad marks the rewound tree's recordings, chain replay
-            // must not materialize a duplicate real vessel even when a chain leaf has
-            // a VesselSnapshot. The flag persists with tree mutable state so the
-            // suppression survives quickload, scene change, and warp-deferred spawn.
-            if (rec.SpawnSuppressedByRewind)
+            // Plain Rewind-to-Launch source protection (#573) remains an absolute
+            // block for the active/source recording that was stripped during rewind.
+            // Legacy broad tree markers from the old implementation are consumed and
+            // ignored here so future same-tree recordings can materialize normally
+            // when playback reaches their terminal EndUT (#589).
+            if (ShouldBlockSpawnForRewindSuppression(rec, out string rewindSuppressionReason))
             {
-                return (false, "spawn suppressed post-rewind (ghost-only past, #573)");
+                return (false, rewindSuppressionReason);
             }
 
             // Preserve the existing "already spawned" precedence, but make destroyed
@@ -4173,6 +4173,36 @@ namespace Parsek
             }
 
             return (true, "");
+        }
+
+        private static bool ShouldBlockSpawnForRewindSuppression(
+            Recording rec,
+            out string reason)
+        {
+            reason = "";
+            if (rec == null || !rec.SpawnSuppressedByRewind)
+                return false;
+
+            string markerReason = rec.SpawnSuppressedByRewindReason;
+            if (string.Equals(markerReason,
+                    ParsekScenario.RewindSpawnSuppressionReasonSameRecording,
+                    StringComparison.Ordinal))
+            {
+                reason = "spawn suppressed post-rewind (same-recording active/source protection, #573)";
+                return true;
+            }
+
+            if (string.IsNullOrEmpty(markerReason))
+                markerReason = ParsekScenario.RewindSpawnSuppressionReasonLegacyUnscoped;
+
+            ParsekScenario.ClearRewindSpawnSuppression(
+                rec,
+                $"reason={markerReason} endpointUT={ParsekScenario.FormatRewindUT(rec.EndUT)}",
+                "spawn allowed despite same-tree rewind because marker is not same-recording");
+            ParsekLog.Info("Rewind",
+                $"Spawn allowed despite same-tree rewind: \"{rec.VesselName}\" id={rec.RecordingId} " +
+                $"endpointUT={ParsekScenario.FormatRewindUT(rec.EndUT)} markerReason={markerReason}");
+            return false;
         }
 
         /// <summary>

--- a/Source/Parsek/ParsekPlaybackPolicy.cs
+++ b/Source/Parsek/ParsekPlaybackPolicy.cs
@@ -91,16 +91,17 @@ namespace Parsek
         /// runs <see cref="RunSpawnDeathChecks"/> after a plain rewind,
         /// <see cref="ParsekScenario.HandleRewindOnLoad"/> has already
         /// called <see cref="RewindContext.EndRewind"/>, so the flag is
-        /// false. It does NOT close the production duplicate-spawn from
-        /// the 2026-04-25_1314 marker-validator-fix playtest — that
-        /// duplicate fired through <see cref="VesselGhoster.SpawnAtChainTip"/>
-        /// during a warp-deferred chain-tip activation, not through
-        /// the spawn-death-then-respawn loop. The real fix sets
-        /// <see cref="Recording.SpawnSuppressedByRewind"/> on every
-        /// recording in the rewound tree (see
+        /// false. It does NOT close the source duplicate-spawn from the
+        /// #573 playtest — that duplicate fired through
+        /// <see cref="VesselGhoster.SpawnAtChainTip"/> during a
+        /// warp-deferred activation, not through the spawn-death-then-respawn
+        /// loop. The real fix sets scoped
+        /// <see cref="Recording.SpawnSuppressedByRewind"/> metadata only on
+        /// the active/source recording stripped by rewind (see
         /// <see cref="ParsekScenario.MarkRewoundTreeRecordingsAsGhostOnly"/>),
         /// which <see cref="GhostPlaybackLogic.ShouldSpawnAtRecordingEnd"/>
-        /// honours regardless of the rewind flag's state.
+        /// honours regardless of the rewind flag's state. Same-tree future
+        /// recordings remain spawn-eligible for #589.
         /// </para>
         /// </summary>
         internal void RunSpawnDeathChecks()
@@ -120,7 +121,7 @@ namespace Parsek
                 ParsekLog.VerboseRateLimited("Policy", "spawn-death-skip-rewind",
                     "RunSpawnDeathChecks: defense-in-depth skip during active rewind — " +
                     "production sequence ends rewind before this path runs; " +
-                    "the real plain-rewind fix is SpawnSuppressedByRewind (#573)");
+                    "the real plain-rewind fix is scoped SpawnSuppressedByRewind (#573/#589)");
                 return;
             }
 

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -1919,11 +1919,10 @@ namespace Parsek
             // from flightState. Same-tree future recordings remain spawn-eligible so
             // their normal terminal materialization can happen after playback reaches
             // their EndUT (#589), while #573 still blocks the source duplicate.
-            int suppressedCount = MarkRewoundTreeRecordingsAsGhostOnly(recordings);
-            if (suppressedCount > 0)
-                ParsekLog.Info("Rewind",
-                    $"OnLoad: SpawnSuppressedByRewind=true on {suppressedCount} active/source recording(s) — " +
-                    $"same-tree future recordings remain spawn-eligible (#573/#589)");
+            int protectedCount = MarkRewoundTreeRecordingsAsGhostOnly(recordings);
+            ParsekLog.Info("Rewind",
+                $"OnLoad: SpawnSuppressedByRewind scope evaluated — " +
+                $"protectedActiveSource={protectedCount}; same-tree future recordings remain spawn-eligible (#573/#589)");
 
             // Strip ALL vessels matching recording names from flightState.
             // The rewind save was preprocessed to strip the recorded vessel,
@@ -3660,7 +3659,7 @@ namespace Parsek
                 $"cleared={cleared} futureAllowed={futureAllowed} skipped={skipped} " +
                 $"rewindRec={rewindRecId ?? "<null>"} tree={rewoundTreeId ?? "<none>"} " +
                 $"rewindUT={FormatRewindUT(rewindUT)}");
-            return marked;
+            return marked + retained;
         }
 
         internal static bool ShouldApplyRewindSpawnSuppression(

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -16,6 +16,12 @@ namespace Parsek
         GameScenes.FLIGHT, GameScenes.SPACECENTER, GameScenes.TRACKSTATION, GameScenes.EDITOR)]
     public class ParsekScenario : ScenarioModule
     {
+        internal const string RewindSpawnSuppressionReasonSameRecording = "same-recording";
+        internal const string RewindSpawnSuppressionReasonSameTreeFutureRecording = "same-tree-future-recording";
+        internal const string RewindSpawnSuppressionReasonLegacyUnscoped = "legacy-unscoped";
+
+        private const double RewindSpawnSuppressionUTEpsilon = 1e-3;
+
         #region Game State Recording
 
         private GameStateRecorder stateRecorder;
@@ -1909,18 +1915,15 @@ namespace Parsek
             ParsekLog.Info("Rewind",
                 $"OnLoad: resetting playback state for {standaloneCount} recordings + {treeCount} trees");
 
-            // Mark the rewound tree's future-of-rewind-point recordings as "ghost-only past"
-            // so chain-tip / effective-leaf playback in the new FLIGHT timeline cannot
-            // materialize them as real vessels (#573 follow-up). The strip above removed
-            // them from flightState; this flag prevents the same recordings from being
-            // re-spawned later when chain replay reaches their activation UT (the
-            // production duplicate-spawn that the IsRewinding guard could not catch
-            // because it runs from the Flight Update path AFTER EndRewind() fires).
+            // Mark only the active/source recording that plain Rewind-to-Launch stripped
+            // from flightState. Same-tree future recordings remain spawn-eligible so
+            // their normal terminal materialization can happen after playback reaches
+            // their EndUT (#589), while #573 still blocks the source duplicate.
             int suppressedCount = MarkRewoundTreeRecordingsAsGhostOnly(recordings);
             if (suppressedCount > 0)
                 ParsekLog.Info("Rewind",
-                    $"OnLoad: SpawnSuppressedByRewind=true on {suppressedCount} recording(s) — " +
-                    $"chain-leaf spawns blocked for the rewound tree (#573)");
+                    $"OnLoad: SpawnSuppressedByRewind=true on {suppressedCount} active/source recording(s) — " +
+                    $"same-tree future recordings remain spawn-eligible (#573/#589)");
 
             // Strip ALL vessels matching recording names from flightState.
             // The rewind save was preprocessed to strip the recorded vessel,
@@ -3554,28 +3557,14 @@ namespace Parsek
         }
 
         /// <summary>
-        /// After plain Rewind-to-Launch, mark every committed recording in the rewound
-        /// tree as <see cref="Recording.SpawnSuppressedByRewind"/> = true so chain-tip
-        /// playback in the new FLIGHT timeline cannot materialize a duplicate real vessel
-        /// (#573 follow-up to PR #541).
+        /// After plain Rewind-to-Launch, mark only the active/source recording that was
+        /// stripped from flightState as <see cref="Recording.SpawnSuppressedByRewind"/>.
+        /// This preserves #573's duplicate-source protection without turning every
+        /// future same-tree recording into permanent ghost-only history (#589).
         ///
-        /// <para>Why this is needed: <see cref="RecordingStore.ResetAllPlaybackState"/>
-        /// zeros every recording's <c>VesselSpawned</c> + <c>SpawnedVesselPersistentId</c>
-        /// to allow legitimate re-spawn after revert. After a rewind, however, the tree's
-        /// future-of-rewind-point segments are ghost-only history — they should NEVER
-        /// re-materialize, even when the chain replay reaches a leaf with a
-        /// <c>VesselSnapshot</c>. The earlier <see cref="RewindContext.IsRewinding"/>
-        /// short-circuit in <see cref="ParsekPlaybackPolicy.RunSpawnDeathChecks"/> only
-        /// covered the spawn-death code path, which the production duplicate-spawn does
-        /// not actually traverse: by the time the chain replay reaches the leaf
-        /// activation UT in FLIGHT, <c>IsRewinding</c> is already false (cleared at the
-        /// end of <see cref="HandleRewindOnLoad"/>) and the spawn fires through
-        /// <see cref="VesselGhoster.SpawnAtChainTip"/>.</para>
-        ///
-        /// <para>Scope: every recording is checked. The rewind owner's TreeId (if any)
-        /// is the primary scope; standalone recordings whose <c>VesselPersistentId</c>
-        /// matches <see cref="RecordingStore.RewindReplayTargetSourcePid"/> are also
-        /// included so a non-tree rewind still suppresses duplicates.</para>
+        /// <para>Same-tree future recordings are logged and deliberately left
+        /// spawn-eligible. Legacy unscoped markers from older saves are cleared when
+        /// this helper can prove they are future-of-rewind.</para>
         /// </summary>
         internal static int MarkRewoundTreeRecordingsAsGhostOnly(
             IReadOnlyList<Recording> recordings)
@@ -3586,30 +3575,184 @@ namespace Parsek
             uint rewindSourcePid = RecordingStore.RewindReplayTargetSourcePid;
             string rewindRecId = RecordingStore.RewindReplayTargetRecordingId;
             string rewoundTreeId = ResolveRewoundTreeId(recordings, rewindRecId);
+            double rewindUT = RewindContext.RewindUT;
 
             int marked = 0;
+            int retained = 0;
+            int futureAllowed = 0;
+            int cleared = 0;
+            int skipped = 0;
             for (int i = 0; i < recordings.Count; i++)
             {
                 var rec = recordings[i];
-                if (rec == null || rec.SpawnSuppressedByRewind)
+                if (rec == null)
+                {
+                    skipped++;
                     continue;
+                }
 
                 bool inRewoundTree = rewoundTreeId != null
                     && string.Equals(rec.TreeId, rewoundTreeId, StringComparison.Ordinal);
-                bool matchesRewindSource = rewindSourcePid != 0
-                    && rec.VesselPersistentId == rewindSourcePid;
+                bool sameTreeFuture = inRewoundTree && IsFutureOfRewindTarget(rec, rewindUT);
 
-                if (!inRewoundTree && !matchesRewindSource)
+                if (ShouldApplyRewindSpawnSuppression(
+                        rec,
+                        rewindRecId,
+                        rewindSourcePid,
+                        rewoundTreeId,
+                        rewindUT,
+                        out string applyReason))
+                {
+                    if (!rec.SpawnSuppressedByRewind)
+                        marked++;
+                    else
+                        retained++;
+
+                    rec.SpawnSuppressedByRewind = true;
+                    rec.SpawnSuppressedByRewindReason = applyReason;
+                    rec.SpawnSuppressedByRewindUT = rewindUT;
+
+                    ParsekLog.Verbose("Rewind",
+                        $"SpawnSuppressedByRewind applied: #{i} \"{rec.VesselName}\" " +
+                        $"id={rec.RecordingId} tree={(rec.TreeId ?? "<none>")} " +
+                        $"reason={applyReason} rewindUT={FormatRewindUT(rewindUT)} " +
+                        $"startUT={FormatRewindUT(rec.StartUT)} endUT={FormatRewindUT(rec.EndUT)} " +
+                        "(#573 active/source recording protection)");
                     continue;
+                }
 
-                rec.SpawnSuppressedByRewind = true;
-                marked++;
-                ParsekLog.Verbose("Rewind",
-                    $"SpawnSuppressedByRewind: #{i} \"{rec.VesselName}\" id={rec.RecordingId} " +
-                    $"tree={(rec.TreeId ?? "<none>")} reason={(inRewoundTree ? "tree-match" : "pid-match")}");
+                if (sameTreeFuture)
+                {
+                    futureAllowed++;
+                    if (rec.SpawnSuppressedByRewind)
+                    {
+                        ClearRewindSpawnSuppression(
+                            rec,
+                            $"reason={RewindSpawnSuppressionReasonSameTreeFutureRecording} " +
+                            $"rewindUT={FormatRewindUT(rewindUT)} startUT={FormatRewindUT(rec.StartUT)} " +
+                            $"endUT={FormatRewindUT(rec.EndUT)}",
+                            "future-of-rewind same-tree recording remains spawn-eligible");
+                        cleared++;
+                    }
+
+                    ParsekLog.Verbose("Rewind",
+                        $"SpawnSuppressedByRewind not applied: #{i} \"{rec.VesselName}\" " +
+                        $"id={rec.RecordingId} tree={rec.TreeId} " +
+                        $"reason={RewindSpawnSuppressionReasonSameTreeFutureRecording} " +
+                        $"rewindUT={FormatRewindUT(rewindUT)} startUT={FormatRewindUT(rec.StartUT)} " +
+                        $"endUT={FormatRewindUT(rec.EndUT)} — spawn allowed when endpoint is reached post-rewind");
+                    continue;
+                }
+
+                if (rec.SpawnSuppressedByRewind)
+                {
+                    ClearRewindSpawnSuppression(
+                        rec,
+                        $"reason=unrelated-to-current-rewind rewindUT={FormatRewindUT(rewindUT)}",
+                        "stale marker no longer matches active/source scope");
+                    cleared++;
+                }
+                skipped++;
             }
 
+            ParsekLog.Verbose("Rewind",
+                $"SpawnSuppressedByRewind scope summary: marked={marked} retained={retained} " +
+                $"cleared={cleared} futureAllowed={futureAllowed} skipped={skipped} " +
+                $"rewindRec={rewindRecId ?? "<null>"} tree={rewoundTreeId ?? "<none>"} " +
+                $"rewindUT={FormatRewindUT(rewindUT)}");
             return marked;
+        }
+
+        internal static bool ShouldApplyRewindSpawnSuppression(
+            Recording rec,
+            string rewindRecordingId,
+            uint rewindSourcePid,
+            string rewoundTreeId,
+            double rewindUT,
+            out string reason)
+        {
+            reason = null;
+            if (rec == null)
+                return false;
+
+            if (!string.IsNullOrEmpty(rewindRecordingId)
+                && string.Equals(rec.RecordingId, rewindRecordingId, StringComparison.Ordinal))
+            {
+                reason = RewindSpawnSuppressionReasonSameRecording;
+                return true;
+            }
+
+            bool matchesRewindSource = rewindSourcePid != 0
+                && rec.VesselPersistentId == rewindSourcePid;
+            if (!matchesRewindSource)
+                return false;
+
+            bool inRewoundTree = rewoundTreeId != null
+                && string.Equals(rec.TreeId, rewoundTreeId, StringComparison.Ordinal);
+            if (inRewoundTree && IsFutureOfRewindTarget(rec, rewindUT))
+                return false;
+
+            if (string.IsNullOrEmpty(rewoundTreeId))
+            {
+                reason = RewindSpawnSuppressionReasonSameRecording;
+                return true;
+            }
+
+            if (RecordingOverlapsRewindTarget(rec, rewindUT))
+            {
+                reason = RewindSpawnSuppressionReasonSameRecording;
+                return true;
+            }
+
+            return false;
+        }
+
+        internal static bool IsFutureOfRewindTarget(Recording rec, double rewindUT)
+        {
+            if (rec == null)
+                return false;
+
+            return rec.StartUT > rewindUT + RewindSpawnSuppressionUTEpsilon
+                && rec.EndUT > rewindUT + RewindSpawnSuppressionUTEpsilon;
+        }
+
+        internal static bool RecordingOverlapsRewindTarget(Recording rec, double rewindUT)
+        {
+            if (rec == null)
+                return false;
+
+            return rec.StartUT <= rewindUT + RewindSpawnSuppressionUTEpsilon
+                && rec.EndUT >= rewindUT - RewindSpawnSuppressionUTEpsilon;
+        }
+
+        internal static void ClearRewindSpawnSuppression(
+            Recording rec,
+            string reason,
+            string lifecycle)
+        {
+            if (rec == null || !rec.SpawnSuppressedByRewind)
+                return;
+
+            string oldReason = string.IsNullOrEmpty(rec.SpawnSuppressedByRewindReason)
+                ? "<none>"
+                : rec.SpawnSuppressedByRewindReason;
+            double oldUT = rec.SpawnSuppressedByRewindUT;
+
+            rec.SpawnSuppressedByRewind = false;
+            rec.SpawnSuppressedByRewindReason = null;
+            rec.SpawnSuppressedByRewindUT = double.NaN;
+
+            ParsekLog.Info("Rewind",
+                $"SpawnSuppressedByRewind cleared: \"{rec.VesselName}\" id={rec.RecordingId} " +
+                $"previousReason={oldReason} previousRewindUT={FormatRewindUT(oldUT)} " +
+                $"{reason} lifecycle=\"{lifecycle}\"");
+        }
+
+        internal static string FormatRewindUT(double ut)
+        {
+            return double.IsNaN(ut)
+                ? "<nan>"
+                : ut.ToString("F3", CultureInfo.InvariantCulture);
         }
 
         /// <summary>

--- a/Source/Parsek/Recording.cs
+++ b/Source/Parsek/Recording.cs
@@ -270,7 +270,9 @@ namespace Parsek
         public bool DuplicateBlockerRecovered;   // True after a same-name blocker was recovered once — prevents recovery loops (transient, #112)
         public int SpawnDeathCount;              // Spawn-then-die cycles: vessel spawned but immediately destroyed (transient)
         public int SceneExitSituation = -1;     // Vessel.Situations at scene exit (-1 = still in flight/unknown)
-        public bool SpawnSuppressedByRewind;     // True after plain Rewind-to-Launch marked this recording's tree as ghost-only past (#573 / PR #541 follow-up). Persisted with tree mutable state. Survives across save/load until the rewound tree is committed/discarded. Distinct from SpawnAbandoned (transient, collision/death) and TerminalSpawnSupersededByRecordingId (continuation-superseded).
+        public bool SpawnSuppressedByRewind;     // True only for the active/source recording protected by plain Rewind-to-Launch strip cleanup (#573). Persisted with scoped metadata below so legacy broad markers can be ignored/cleared (#589).
+        public string SpawnSuppressedByRewindReason;
+        public double SpawnSuppressedByRewindUT = double.NaN;
 
         public double StartUT
         {
@@ -629,6 +631,8 @@ namespace Parsek
             clone.SpawnDeathCount = source.SpawnDeathCount;
             clone.SceneExitSituation = source.SceneExitSituation;
             clone.SpawnSuppressedByRewind = source.SpawnSuppressedByRewind;
+            clone.SpawnSuppressedByRewindReason = source.SpawnSuppressedByRewindReason;
+            clone.SpawnSuppressedByRewindUT = source.SpawnSuppressedByRewindUT;
 
             return clone;
         }

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -3094,8 +3094,14 @@ namespace Parsek
             rec.LastAppliedResourceIndex = -1;
             // SpawnSuppressedByRewind is cleared here so a subsequent rewind starts
             // from a clean slate. ParsekScenario.HandleRewindOnLoad re-marks the
-            // rewound tree's recordings AFTER ResetAllPlaybackState fires.
+            // active/source recording AFTER ResetAllPlaybackState fires.
+            if (rec.SpawnSuppressedByRewind && !SuppressLogging)
+                ParsekLog.Verbose("Rewind",
+                    $"SpawnSuppressedByRewind reset: \"{rec.VesselName}\" id={rec.RecordingId} " +
+                    $"reason={rec.SpawnSuppressedByRewindReason ?? "<none>"}");
             rec.SpawnSuppressedByRewind = false;
+            rec.SpawnSuppressedByRewindReason = null;
+            rec.SpawnSuppressedByRewindUT = double.NaN;
 
             rec.SceneExitSituation = -1;
         }

--- a/Source/Parsek/RecordingTree.cs
+++ b/Source/Parsek/RecordingTree.cs
@@ -255,6 +255,9 @@ namespace Parsek
             Recording fallbackSource = null;
             var legacyMarkers = new List<Recording>();
             string sourceRecordingId = null;
+            // Prefer the saved root over ActiveRecordingId when both exist.
+            // Committed trees can retain ActiveRecordingId as a future leaf, and
+            // treating that as the legacy source would re-block #589 terminal spawns.
             if (!string.IsNullOrEmpty(tree.RootRecordingId)
                 && tree.Recordings.ContainsKey(tree.RootRecordingId))
             {
@@ -1158,16 +1161,20 @@ namespace Parsek
                 if (bool.TryParse(spawnSuppressedStr, out spawnSuppressed))
                     rec.SpawnSuppressedByRewind = spawnSuppressed;
             }
-            rec.SpawnSuppressedByRewindReason = recNode.GetValue("spawnSuppressedByRewindReason");
-            string spawnSuppressedUTStr = recNode.GetValue("spawnSuppressedByRewindUT");
-            if (spawnSuppressedUTStr != null)
+            if (rec.SpawnSuppressedByRewind)
             {
-                double spawnSuppressedUT;
-                if (double.TryParse(spawnSuppressedUTStr, NumberStyles.Float, ic, out spawnSuppressedUT))
-                    rec.SpawnSuppressedByRewindUT = spawnSuppressedUT;
+                rec.SpawnSuppressedByRewindReason = recNode.GetValue("spawnSuppressedByRewindReason");
+                string spawnSuppressedUTStr = recNode.GetValue("spawnSuppressedByRewindUT");
+                if (spawnSuppressedUTStr != null)
+                {
+                    double spawnSuppressedUT;
+                    if (double.TryParse(spawnSuppressedUTStr, NumberStyles.Float, ic, out spawnSuppressedUT))
+                        rec.SpawnSuppressedByRewindUT = spawnSuppressedUT;
+                }
+
+                if (string.IsNullOrEmpty(rec.SpawnSuppressedByRewindReason))
+                    rec.SpawnSuppressedByRewindReason = ParsekScenario.RewindSpawnSuppressionReasonLegacyUnscoped;
             }
-            if (rec.SpawnSuppressedByRewind && string.IsNullOrEmpty(rec.SpawnSuppressedByRewindReason))
-                rec.SpawnSuppressedByRewindReason = ParsekScenario.RewindSpawnSuppressionReasonLegacyUnscoped;
             string resIdxStr = recNode.GetValue("lastResIdx");
             if (resIdxStr != null)
             {

--- a/Source/Parsek/RecordingTree.cs
+++ b/Source/Parsek/RecordingTree.cs
@@ -208,6 +208,7 @@ namespace Parsek
             }
 
             tree.RebuildBackgroundMap();
+            NormalizeLegacyRewindSuppressionMarkers(tree);
 
             ParsekLog.Verbose("RecordingTree",
                 $"Load: id={tree.Id} tree='{tree.TreeName}' recordings={tree.Recordings.Count} " +
@@ -241,6 +242,106 @@ namespace Parsek
                     "LedgerOrchestrator.MigrateLegacyTreeResources will reconcile.");
             }
             return tree;
+        }
+
+        private static void NormalizeLegacyRewindSuppressionMarkers(RecordingTree tree)
+        {
+            if (tree == null || tree.Recordings == null || tree.Recordings.Count == 0)
+                return;
+
+            int legacyCount = 0;
+            int sourceProtected = 0;
+            int futureEligible = 0;
+            Recording fallbackSource = null;
+            var legacyMarkers = new List<Recording>();
+            string sourceRecordingId = null;
+            if (!string.IsNullOrEmpty(tree.RootRecordingId)
+                && tree.Recordings.ContainsKey(tree.RootRecordingId))
+            {
+                sourceRecordingId = tree.RootRecordingId;
+            }
+            else if (!string.IsNullOrEmpty(tree.ActiveRecordingId)
+                && tree.Recordings.ContainsKey(tree.ActiveRecordingId))
+            {
+                sourceRecordingId = tree.ActiveRecordingId;
+            }
+            bool hasKnownSourceCandidate = !string.IsNullOrEmpty(sourceRecordingId);
+            if (hasKnownSourceCandidate
+                && tree.Recordings.TryGetValue(sourceRecordingId, out var existingSource)
+                && existingSource != null
+                && existingSource.SpawnSuppressedByRewind
+                && string.Equals(existingSource.SpawnSuppressedByRewindReason,
+                    ParsekScenario.RewindSpawnSuppressionReasonSameRecording,
+                    StringComparison.Ordinal))
+            {
+                sourceProtected = 1;
+            }
+
+            foreach (var rec in tree.Recordings.Values)
+            {
+                if (rec == null
+                    || !rec.SpawnSuppressedByRewind
+                    || !string.Equals(rec.SpawnSuppressedByRewindReason,
+                        ParsekScenario.RewindSpawnSuppressionReasonLegacyUnscoped,
+                        StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                legacyCount++;
+                legacyMarkers.Add(rec);
+                bool isSavedSource = !string.IsNullOrEmpty(sourceRecordingId)
+                    && string.Equals(rec.RecordingId, sourceRecordingId, StringComparison.Ordinal);
+                if (isSavedSource)
+                {
+                    MarkLegacyRewindSuppressionAsSource(rec);
+                    sourceProtected++;
+                    continue;
+                }
+
+                if (fallbackSource == null || CompareRecordingTreeOrder(rec, fallbackSource) < 0)
+                    fallbackSource = rec;
+            }
+
+            if (legacyCount == 0)
+                return;
+
+            if (sourceProtected == 0 && fallbackSource != null && !hasKnownSourceCandidate)
+            {
+                MarkLegacyRewindSuppressionAsSource(fallbackSource);
+                sourceProtected++;
+            }
+
+            for (int i = 0; i < legacyMarkers.Count; i++)
+            {
+                var rec = legacyMarkers[i];
+                if (rec != null
+                    && string.Equals(rec.SpawnSuppressedByRewindReason,
+                        ParsekScenario.RewindSpawnSuppressionReasonLegacyUnscoped,
+                        StringComparison.Ordinal))
+                {
+                    futureEligible++;
+                }
+            }
+
+            ParsekLog.Info("RecordingTree",
+                $"Legacy SpawnSuppressedByRewind markers normalized: tree='{tree.TreeName}' " +
+                $"id={tree.Id} legacy={legacyCount} sourceProtected={sourceProtected} " +
+                $"futureEligible={futureEligible}");
+        }
+
+        private static void MarkLegacyRewindSuppressionAsSource(Recording rec)
+        {
+            rec.SpawnSuppressedByRewindReason =
+                ParsekScenario.RewindSpawnSuppressionReasonSameRecording;
+            if (double.IsNaN(rec.SpawnSuppressedByRewindUT))
+                rec.SpawnSuppressedByRewindUT = rec.StartUT;
+
+            ParsekLog.Verbose("RecordingTree",
+                $"Legacy SpawnSuppressedByRewind retained as same-recording source: " +
+                $"id={rec.RecordingId} name='{rec.VesselName}' " +
+                $"treeOrder={rec.TreeOrder.ToString(CultureInfo.InvariantCulture)} " +
+                $"rewindUT={ParsekScenario.FormatRewindUT(rec.SpawnSuppressedByRewindUT)}");
         }
 
         private static LegacyResourceResidual LoadLegacyResidual(
@@ -612,10 +713,18 @@ namespace Parsek
                 recNode.AddValue("terminalSpawnSupersededBy", rec.TerminalSpawnSupersededByRecordingId);
             if (rec.VesselDestroyed)
                 recNode.AddValue("vesselDestroyed", rec.VesselDestroyed.ToString());
-            // #573 follow-up to PR #541: persist the rewind ghost-only marker so plain
-            // Rewind-to-Launch suppression survives save/load until commit/discard.
+            // #573/#589: persist scoped rewind suppression metadata. New saves only
+            // write this for the active/source recording; unscoped legacy markers are
+            // recognized at load/spawn time and cleared instead of blocking future
+            // same-tree terminal materialization forever.
             if (rec.SpawnSuppressedByRewind)
+            {
                 recNode.AddValue("spawnSuppressedByRewind", rec.SpawnSuppressedByRewind.ToString());
+                if (!string.IsNullOrEmpty(rec.SpawnSuppressedByRewindReason))
+                    recNode.AddValue("spawnSuppressedByRewindReason", rec.SpawnSuppressedByRewindReason);
+                if (!double.IsNaN(rec.SpawnSuppressedByRewindUT))
+                    recNode.AddValue("spawnSuppressedByRewindUT", rec.SpawnSuppressedByRewindUT.ToString("R", ic));
+            }
             recNode.AddValue("lastResIdx", rec.LastAppliedResourceIndex);
             recNode.AddValue("pointCount", rec.Points != null ? rec.Points.Count : 0);
 
@@ -1039,7 +1148,9 @@ namespace Parsek
                     rec.VesselDestroyed = destroyed;
             }
             rec.TerminalSpawnSupersededByRecordingId = recNode.GetValue("terminalSpawnSupersededBy");
-            // #573 follow-up: load post-rewind ghost-only marker.
+            // #573/#589: load scoped post-rewind suppression marker. Older saves
+            // only contain the bool because the original fix marked whole trees;
+            // tag those as legacy-unscoped so the spawn gate can clear them.
             string spawnSuppressedStr = recNode.GetValue("spawnSuppressedByRewind");
             if (spawnSuppressedStr != null)
             {
@@ -1047,6 +1158,16 @@ namespace Parsek
                 if (bool.TryParse(spawnSuppressedStr, out spawnSuppressed))
                     rec.SpawnSuppressedByRewind = spawnSuppressed;
             }
+            rec.SpawnSuppressedByRewindReason = recNode.GetValue("spawnSuppressedByRewindReason");
+            string spawnSuppressedUTStr = recNode.GetValue("spawnSuppressedByRewindUT");
+            if (spawnSuppressedUTStr != null)
+            {
+                double spawnSuppressedUT;
+                if (double.TryParse(spawnSuppressedUTStr, NumberStyles.Float, ic, out spawnSuppressedUT))
+                    rec.SpawnSuppressedByRewindUT = spawnSuppressedUT;
+            }
+            if (rec.SpawnSuppressedByRewind && string.IsNullOrEmpty(rec.SpawnSuppressedByRewindReason))
+                rec.SpawnSuppressedByRewindReason = ParsekScenario.RewindSpawnSuppressionReasonLegacyUnscoped;
             string resIdxStr = recNode.GetValue("lastResIdx");
             if (resIdxStr != null)
             {

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -212,7 +212,7 @@ The actual production duplicate-spawn fires through a different code path. Concr
 5. `[LOG 13:13:19.600] PlaybackCompleted index=15 vessel=Kerbal X ... needsSpawn=True ... Deferred spawn during warp: #15 "Kerbal X"` — recording `2c276b3c6a9c438eb288dc4cbd55a3ee` (chain leaf, terminal Splashed at UT 194195.7, `vesselPersistentId = 2708531065` because chain segments share the source pid) reports `needsSpawn=True` because it has a `VesselSnapshot`, terminal Splashed, and is the effective leaf for that pid.
 6. After the player exits warp the deferred-spawn flush calls `ParsekFlight.SpawnVesselOrChainTipFromPolicy → SpawnAtChainTip → SpawnChainTipWithResolvedState → RespawnVessel(preserveIdentity:true)`. `TryAdoptExistingSourceVesselForSpawn` cannot adopt (no real vessel with pid 2708531065 exists — it was stripped). `RespawnVessel` then materialises a fresh vessel with pid 2708531065 — the user's "real vessel copy of the upper stage". `RunSpawnDeathChecks` never runs on this path because spawn-death only fires AFTER a vessel was successfully tracked, then disappeared; here the vessel is being created from scratch.
 
-**Fix:** introduce `Recording.SpawnSuppressedByRewind` (transient field, persisted in tree mutable state). `ParsekScenario.HandleRewindOnLoad` calls a new helper `MarkRewoundTreeRecordingsAsGhostOnly` after `ResetAllPlaybackState` that walks the committed list and sets the flag on every recording either (a) in the rewound tree (matched by TreeId of the rewind owner from `RewindReplayTargetRecordingId`) or (b) whose `VesselPersistentId` matches the armed `RewindReplayTargetSourcePid` (covers standalone-recording rewind). `GhostPlaybackLogic.ShouldSpawnAtRecordingEnd` consults the flag immediately after `TerminalSpawnSupersededByRecordingId` and returns `(false, "spawn suppressed post-rewind (ghost-only past, #573)")`. This blocks every spawn entry-point downstream (`SpawnAtChainTip`, `SpawnOrRecoverIfTooClose`, KSC spawn, tracking-station handoff — all gate on `ShouldSpawnAtRecordingEnd` or its `ShouldSpawnAtKscEnd` / `ShouldSpawnAtTrackingStationEnd` callers). `RecordingStore.ResetRecordingPlaybackFields` clears the flag so a subsequent rewind starts clean. Regression coverage in `RewindTimelineTests`: `ShouldSpawn_PostRewindChainLeafSameSourcePid_ReturnsFalse`, `HandleRewindOnLoad_MarksAllRewoundTreeChainLeavesGhostOnly_AllSpawnRefused` (drives the production sequence end-to-end through the helper and asserts every spawn entry-point refuses), `MarkRewoundTreeRecordingsAsGhostOnly_StandaloneRecording_MarksByPidMatch`, `MarkRewoundTreeRecordingsAsGhostOnly_AlreadyMarked_NoOp`, `ResetAllPlaybackState_ClearsSpawnSuppressedByRewind`.
+**Fix:** introduce scoped `Recording.SpawnSuppressedByRewind` metadata, persisted in tree mutable state as `spawnSuppressedByRewind`, `spawnSuppressedByRewindReason`, and `spawnSuppressedByRewindUT`. `ParsekScenario.HandleRewindOnLoad` calls `MarkRewoundTreeRecordingsAsGhostOnly` after `ResetAllPlaybackState`, but the helper now applies the marker only to the active/source recording (`reason=same-recording`) or a same-source recording whose UT range overlaps the rewind target. Same-tree future recordings are logged as `reason=same-tree-future-recording` and intentionally left spawn-eligible, so #573 no longer turns an entire tree into ghost-only history (#589). `GhostPlaybackLogic.ShouldSpawnAtRecordingEnd` still treats `same-recording` as an absolute #573 duplicate-source block, but consumes/clears legacy unscoped markers before continuing through normal spawn-at-end gates. `RecordingStore.ResetRecordingPlaybackFields` clears the marker and metadata so repeated rewinds start clean. Regression coverage in `RewindTimelineTests` and `RewindSpawnSuppressionTests`: same-recording #573 suppression, future same-tree spawn eligibility at `endUT`, legacy marker consumption, repeated-rewind stale-marker clearing, reset lifecycle logging, and log assertions for applied/skipped/cleared decisions.
 
 The `RewindContext.IsRewinding` short-circuit in `RunSpawnDeathChecks` from `c9d257f8` is retained as defense-in-depth (with corrected wording in code + tests calling out that it does NOT cover the production sequence), so a future regression that splits the rewind sequence across update ticks can't trip the spawn-death detector.
 
@@ -1163,7 +1163,7 @@ sibling symptoms in the same playtest.
 
 ---
 
-## 589. Real-vessel spawns at end of mission recordings never materialize after a tree-wide rewind — `SpawnSuppressedByRewind` keeps the entire tree ghost-only forever
+## ~~589. Real-vessel spawns at end of mission recordings never materialize after a tree-wide rewind — `SpawnSuppressedByRewind` keeps the entire tree ghost-only forever~~
 
 **Source:** same playtest as #585. After the booster Re-Fly merge, the
 user issued a second rewind from the recordings table back to
@@ -1219,9 +1219,20 @@ re-flying over), not every recording in the tree.
   `same-tree-future-recording` (the case that needs an `endUT >
   rewindUT` carve-out).
 
-**Status:** Open. User flagged the missing spawns as a separate
-concern from the Mun ghost positioning (#588) but they share the
-playtest and likely overlap in symptom space.
+**Fix:** split the rewind suppression semantics. `reason=same-recording`
+is the #573 strip-kill/source duplicate protection case and remains an
+absolute spawn-at-end block. `reason=same-tree-future-recording` is now
+logged as an intentional skip: recordings whose `StartUT` and `EndUT`
+are ahead of the rewind UT are not marked ghost-only and materialize
+normally when playback reaches their endpoint. New persisted metadata
+(`spawnSuppressedByRewindReason`, `spawnSuppressedByRewindUT`) scopes
+future saves, and the spawn gate consumes/clears legacy unscoped markers
+so broken saves from the whole-tree implementation stop blocking future
+terminal spawns. Diagnostics now distinguish applied #573 protection,
+future same-tree skip, stale marker clear/reset, and spawn allowed despite
+same-tree rewind.
+
+**Status:** CLOSED 2026-04-25. Fixed for v0.9.0.
 
 ---
 


### PR DESCRIPTION
## Summary
- Scope post-rewind spawn suppression to the protected same-recording source case for #573 instead of the whole tree.
- Keep same-tree future recordings spawn-eligible at their terminal endpoint and clear/ignore stale legacy broad markers at the spawn gate.
- Persist suppression reason/UT metadata, normalize legacy whole-tree markers on tree load, and update diagnostics/docs for #589.

## Validation
- dotnet test Source\\Parsek.Tests\\Parsek.Tests.csproj (8743 passed)
- gpt-5.5 xhigh review completed; compatibility findings fixed and re-reviewed clean

Closes #589