### PR TITLE
Fix SOI-gap checkpoint state-vector map ghosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,8 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- `#588` Flight Map View now allows `OrbitalCheckpoint` state-vector map ghosts only for explicit orbit-segment gap recovery after an SOI/body transition: a current segment still wins when available, the fallback body must match the post-gap body, and the UT must stay inside the playback window. Accepted recoveries log `source=StateVectorSoiGap` / `reason=soi-gap-state-vector-fallback`; rejected checkpoint candidates now say whether a safer segment existed, the source was not an SOI-gap recovery, the body mismatched, or the UT was outside the valid window.
+
 - `#574` Already-Destroyed recordings no longer re-run the sub-surface ballistic finalizer on cache refresh. The first Destroyed classification now logs once with body, altitude, and threshold; later refreshes emit a rate-limited skip diagnostic plus refresh summary instead of a repeated WARN storm.
 - `#577` Re-Fly session markers loaded from an earlier game session now survive fresh-load scenes where KSP reports UT 0 during validation. The validator still rejects corrupt `InvokedUT` values and now logs current-UT/RP-UT comparisons for both accepts and rejects.
 

--- a/Source/Parsek.Tests/GhostMapSoiGapStateVectorTests.cs
+++ b/Source/Parsek.Tests/GhostMapSoiGapStateVectorTests.cs
@@ -1,0 +1,357 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    [Collection("Sequential")]
+    public class GhostMapSoiGapStateVectorTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public GhostMapSoiGapStateVectorTests()
+        {
+            GhostMapPresence.ResetForTesting();
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.VerboseOverrideForTesting = true;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+        }
+
+        public void Dispose()
+        {
+            GhostMapPresence.ResetForTesting();
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+        }
+
+        [Fact]
+        public void ResolveMapPresenceGhostSource_SoiGapCheckpointFallbackAccepted_ReturnsMunStateVectorSource()
+        {
+            Recording rec = MakeSoiGapRecording(
+                "soi-gap-accepted",
+                checkpointBody: "Mun",
+                futureSegmentBody: "Mun");
+
+            GhostMapPresence.TrackingStationGhostSource source = Resolve(
+                rec,
+                currentUT: 160.0,
+                allowSoiGapStateVectorFallback: true,
+                expectedSoiGapBody: "Mun",
+                out _,
+                out TrajectoryPoint point,
+                out string skipReason);
+
+            Assert.Equal(GhostMapPresence.TrackingStationGhostSource.StateVectorSoiGap, source);
+            Assert.Equal("Mun", point.bodyName);
+            Assert.Equal("soi-gap-state-vector-fallback", skipReason);
+            Assert.Contains(logLines, l =>
+                l.Contains("[GhostMap]")
+                && l.Contains("source-resolve:")
+                && l.Contains("source=StateVectorSoiGap")
+                && l.Contains("body=Mun")
+                && l.Contains("reason=soi-gap-state-vector-fallback"));
+            Assert.Contains(logLines, l =>
+                l.Contains("[GhostMap]")
+                && l.Contains("test-soi-gap-state-vector:")
+                && l.Contains("orbitalCheckpointFallback=accept")
+                && l.Contains("fallbackReason=soi-gap-state-vector-fallback"));
+        }
+
+        [Fact]
+        public void ResolveMapPresenceGhostSource_NormalCheckpointStateVectorStillRejects()
+        {
+            Recording rec = MakeSoiGapRecording(
+                "checkpoint-not-soi-gap",
+                checkpointBody: "Mun",
+                futureSegmentBody: "Mun");
+
+            GhostMapPresence.TrackingStationGhostSource source = Resolve(
+                rec,
+                currentUT: 160.0,
+                allowSoiGapStateVectorFallback: false,
+                expectedSoiGapBody: "Mun",
+                out _,
+                out _,
+                out string skipReason);
+
+            Assert.Equal(GhostMapPresence.TrackingStationGhostSource.None, source);
+            Assert.Equal("orbital-checkpoint-state-vector-not-soi-gap-recovery", skipReason);
+            Assert.Contains(logLines, l =>
+                l.Contains("[GhostMap]")
+                && l.Contains("source-resolve:")
+                && l.Contains("source=None")
+                && l.Contains("reason=orbital-checkpoint-state-vector-not-soi-gap-recovery"));
+            Assert.Contains(logLines, l =>
+                l.Contains("[GhostMap]")
+                && l.Contains("test-soi-gap-state-vector:")
+                && l.Contains("fallbackReason=orbital-checkpoint-state-vector-not-soi-gap-recovery")
+                && l.Contains("isSoiGapRecovery=False"));
+        }
+
+        [Fact]
+        public void ResolveMapPresenceGhostSource_SoiGapCheckpointFallbackRejectsBodyMismatch()
+        {
+            Recording rec = MakeSoiGapRecording(
+                "checkpoint-body-mismatch",
+                checkpointBody: "Kerbin",
+                futureSegmentBody: "Mun");
+
+            GhostMapPresence.TrackingStationGhostSource source = Resolve(
+                rec,
+                currentUT: 160.0,
+                allowSoiGapStateVectorFallback: true,
+                expectedSoiGapBody: "Mun",
+                out _,
+                out _,
+                out string skipReason);
+
+            Assert.Equal(GhostMapPresence.TrackingStationGhostSource.None, source);
+            Assert.Equal("orbital-checkpoint-state-vector-body-mismatch", skipReason);
+            Assert.Contains(logLines, l =>
+                l.Contains("[GhostMap]")
+                && l.Contains("source-resolve:")
+                && l.Contains("reason=orbital-checkpoint-state-vector-body-mismatch"));
+            Assert.Contains(logLines, l =>
+                l.Contains("[GhostMap]")
+                && l.Contains("test-soi-gap-state-vector:")
+                && l.Contains("fallbackReason=orbital-checkpoint-state-vector-body-mismatch")
+                && l.Contains("stateVectorBody=Kerbin")
+                && l.Contains("expectedBody=Mun")
+                && l.Contains("bodyMatches=False"));
+        }
+
+        [Fact]
+        public void ResolveMapPresenceGhostSource_SameBodyGapIsNotSoiRecovery()
+        {
+            Recording rec = MakeSoiGapRecording(
+                "same-body-gap",
+                checkpointBody: "Kerbin",
+                futureSegmentBody: "Kerbin");
+
+            GhostMapPresence.TrackingStationGhostSource source = Resolve(
+                rec,
+                currentUT: 160.0,
+                allowSoiGapStateVectorFallback: true,
+                expectedSoiGapBody: "Kerbin",
+                out _,
+                out _,
+                out string skipReason);
+
+            Assert.Equal(GhostMapPresence.TrackingStationGhostSource.None, source);
+            Assert.Equal("orbital-checkpoint-state-vector-not-soi-gap-recovery", skipReason);
+            Assert.Contains(logLines, l =>
+                l.Contains("[GhostMap]")
+                && l.Contains("test-soi-gap-state-vector:")
+                && l.Contains("fallbackReason=orbital-checkpoint-state-vector-not-soi-gap-recovery")
+                && l.Contains("gapBodyTransition=False")
+                && l.Contains("gapPreviousBody=Kerbin")
+                && l.Contains("gapNextBody=Kerbin"));
+        }
+
+        [Fact]
+        public void ResolveMapPresenceGhostSource_UsesActualNextSegmentBodyOverStaleExpectedBody()
+        {
+            Recording rec = MakeSoiGapRecording(
+                "stale-expected-body",
+                checkpointBody: "Duna",
+                futureSegmentBody: "Mun");
+
+            GhostMapPresence.TrackingStationGhostSource source = Resolve(
+                rec,
+                currentUT: 160.0,
+                allowSoiGapStateVectorFallback: true,
+                expectedSoiGapBody: "Duna",
+                out _,
+                out _,
+                out string skipReason);
+
+            Assert.Equal(GhostMapPresence.TrackingStationGhostSource.None, source);
+            Assert.Equal("orbital-checkpoint-state-vector-body-mismatch", skipReason);
+            Assert.Contains(logLines, l =>
+                l.Contains("[GhostMap]")
+                && l.Contains("test-soi-gap-state-vector:")
+                && l.Contains("fallbackReason=orbital-checkpoint-state-vector-body-mismatch")
+                && l.Contains("stateVectorBody=Duna")
+                && l.Contains("expectedBody=Mun")
+                && l.Contains("gapNextBody=Mun"));
+        }
+
+        [Fact]
+        public void ResolveMapPresenceGhostSource_CurrentSegmentWinsOverCheckpointFallback()
+        {
+            Recording rec = MakeSegmentAvailableRecording(
+                "segment-wins",
+                checkpointBody: "Mun");
+
+            GhostMapPresence.TrackingStationGhostSource source = Resolve(
+                rec,
+                currentUT: 160.0,
+                allowSoiGapStateVectorFallback: true,
+                expectedSoiGapBody: "Mun",
+                out OrbitSegment segment,
+                out _,
+                out string skipReason);
+
+            Assert.Equal(GhostMapPresence.TrackingStationGhostSource.Segment, source);
+            Assert.Equal("Mun", segment.bodyName);
+            Assert.Null(skipReason);
+            Assert.Contains(logLines, l =>
+                l.Contains("[GhostMap]")
+                && l.Contains("source-resolve:")
+                && l.Contains("source=Segment")
+                && l.Contains("body=Mun"));
+            Assert.Contains(logLines, l =>
+                l.Contains("[GhostMap]")
+                && l.Contains("test-soi-gap-state-vector:")
+                && l.Contains("segmentBody=Mun")
+                && l.Contains("fallbackReason=orbital-checkpoint-state-vector-safer-segment-source")
+                && l.Contains("segmentSourceAvailable=True"));
+        }
+
+        private static GhostMapPresence.TrackingStationGhostSource Resolve(
+            Recording rec,
+            double currentUT,
+            bool allowSoiGapStateVectorFallback,
+            string expectedSoiGapBody,
+            out OrbitSegment segment,
+            out TrajectoryPoint point,
+            out string skipReason)
+        {
+            int cachedStateVectorIndex = -1;
+            return GhostMapPresence.ResolveMapPresenceGhostSource(
+                rec,
+                isSuppressed: false,
+                alreadyMaterialized: false,
+                currentUT: currentUT,
+                allowTerminalOrbitFallback: true,
+                logOperationName: "test-soi-gap-state-vector",
+                stateVectorCachedIndex: ref cachedStateVectorIndex,
+                segment: out segment,
+                stateVectorPoint: out point,
+                skipReason: out skipReason,
+                recordingIndex: 1,
+                allowSoiGapStateVectorFallback: allowSoiGapStateVectorFallback,
+                expectedSoiGapBody: expectedSoiGapBody);
+        }
+
+        private static Recording MakeSoiGapRecording(
+            string recordingId,
+            string checkpointBody,
+            string futureSegmentBody)
+        {
+            var rec = MakeBaseRecording(recordingId);
+            rec.OrbitSegments = new List<OrbitSegment>
+            {
+                Segment(100.0, 140.0, "Kerbin", 750000.0, 0.01),
+                Segment(200.0, 300.0, futureSegmentBody, 250000.0, 0.2)
+            };
+            rec.TrackSections = new List<TrackSection>
+            {
+                OrbitalCheckpointSection(150.0, 190.0, checkpointBody)
+            };
+            return rec;
+        }
+
+        private static Recording MakeSegmentAvailableRecording(
+            string recordingId,
+            string checkpointBody)
+        {
+            var rec = MakeBaseRecording(recordingId);
+            rec.OrbitSegments = new List<OrbitSegment>
+            {
+                Segment(100.0, 300.0, "Mun", 250000.0, 0.2)
+            };
+            rec.TrackSections = new List<TrackSection>
+            {
+                OrbitalCheckpointSection(150.0, 190.0, checkpointBody)
+            };
+            return rec;
+        }
+
+        private static Recording MakeBaseRecording(string recordingId)
+        {
+            return new Recording
+            {
+                RecordingId = recordingId,
+                RecordingFormatVersion = 6,
+                VesselName = "Kerbal X",
+                TerminalStateValue = TerminalState.Orbiting,
+                TerminalOrbitBody = "Mun",
+                TerminalOrbitSemiMajorAxis = 250000.0,
+                TerminalOrbitEccentricity = 0.2,
+                TerminalOrbitInclination = 0.0,
+                TerminalOrbitLAN = 0.0,
+                TerminalOrbitArgumentOfPeriapsis = 0.0,
+                TerminalOrbitMeanAnomalyAtEpoch = 0.0,
+                TerminalOrbitEpoch = 100.0,
+            };
+        }
+
+        private static TrackSection OrbitalCheckpointSection(
+            double startUT,
+            double endUT,
+            string bodyName)
+        {
+            return new TrackSection
+            {
+                environment = SegmentEnvironment.ExoBallistic,
+                referenceFrame = ReferenceFrame.OrbitalCheckpoint,
+                source = TrackSectionSource.Checkpoint,
+                startUT = startUT,
+                endUT = endUT,
+                frames = new List<TrajectoryPoint>
+                {
+                    new TrajectoryPoint
+                    {
+                        ut = startUT,
+                        latitude = 1.0,
+                        longitude = 2.0,
+                        altitude = 47481.0,
+                        bodyName = bodyName,
+                        velocity = new Vector3(515.4f, 0.0f, 0.0f),
+                    },
+                    new TrajectoryPoint
+                    {
+                        ut = endUT,
+                        latitude = 1.1,
+                        longitude = 2.1,
+                        altitude = 47500.0,
+                        bodyName = bodyName,
+                        velocity = new Vector3(515.4f, 0.0f, 0.0f),
+                    }
+                },
+                checkpoints = new List<OrbitSegment>
+                {
+                    Segment(startUT, endUT, bodyName, 250000.0, 0.2)
+                },
+                sampleRateHz = 1.0f,
+                minAltitude = 47481.0f,
+                maxAltitude = 47500.0f,
+            };
+        }
+
+        private static OrbitSegment Segment(
+            double startUT,
+            double endUT,
+            string bodyName,
+            double semiMajorAxis,
+            double eccentricity)
+        {
+            return new OrbitSegment
+            {
+                startUT = startUT,
+                endUT = endUT,
+                bodyName = bodyName,
+                semiMajorAxis = semiMajorAxis,
+                eccentricity = eccentricity,
+                inclination = 0.0,
+                longitudeOfAscendingNode = 0.0,
+                argumentOfPeriapsis = 0.0,
+                meanAnomalyAtEpoch = 0.0,
+                epoch = startUT,
+            };
+        }
+    }
+}

--- a/Source/Parsek.Tests/GhostMapSoiGapStateVectorTests.cs
+++ b/Source/Parsek.Tests/GhostMapSoiGapStateVectorTests.cs
@@ -45,18 +45,18 @@ namespace Parsek.Tests
 
             Assert.Equal(GhostMapPresence.TrackingStationGhostSource.StateVectorSoiGap, source);
             Assert.Equal("Mun", point.bodyName);
-            Assert.Equal("soi-gap-state-vector-fallback", skipReason);
+            Assert.Equal(GhostMapPresence.SoiGapStateVectorFallbackReason, skipReason);
             Assert.Contains(logLines, l =>
                 l.Contains("[GhostMap]")
                 && l.Contains("source-resolve:")
                 && l.Contains("source=StateVectorSoiGap")
                 && l.Contains("body=Mun")
-                && l.Contains("reason=soi-gap-state-vector-fallback"));
+                && l.Contains("reason=" + GhostMapPresence.SoiGapStateVectorFallbackReason));
             Assert.Contains(logLines, l =>
                 l.Contains("[GhostMap]")
                 && l.Contains("test-soi-gap-state-vector:")
                 && l.Contains("orbitalCheckpointFallback=accept")
-                && l.Contains("fallbackReason=soi-gap-state-vector-fallback"));
+                && l.Contains("fallbackReason=" + GhostMapPresence.SoiGapStateVectorFallbackReason));
         }
 
         [Fact]
@@ -77,16 +77,16 @@ namespace Parsek.Tests
                 out string skipReason);
 
             Assert.Equal(GhostMapPresence.TrackingStationGhostSource.None, source);
-            Assert.Equal("orbital-checkpoint-state-vector-not-soi-gap-recovery", skipReason);
+            Assert.Equal(GhostMapPresence.OrbitalCheckpointStateVectorRejectNotSoiGap, skipReason);
             Assert.Contains(logLines, l =>
                 l.Contains("[GhostMap]")
                 && l.Contains("source-resolve:")
                 && l.Contains("source=None")
-                && l.Contains("reason=orbital-checkpoint-state-vector-not-soi-gap-recovery"));
+                && l.Contains("reason=" + GhostMapPresence.OrbitalCheckpointStateVectorRejectNotSoiGap));
             Assert.Contains(logLines, l =>
                 l.Contains("[GhostMap]")
                 && l.Contains("test-soi-gap-state-vector:")
-                && l.Contains("fallbackReason=orbital-checkpoint-state-vector-not-soi-gap-recovery")
+                && l.Contains("fallbackReason=" + GhostMapPresence.OrbitalCheckpointStateVectorRejectNotSoiGap)
                 && l.Contains("isSoiGapRecovery=False"));
         }
 
@@ -108,18 +108,53 @@ namespace Parsek.Tests
                 out string skipReason);
 
             Assert.Equal(GhostMapPresence.TrackingStationGhostSource.None, source);
-            Assert.Equal("orbital-checkpoint-state-vector-body-mismatch", skipReason);
+            Assert.Equal(GhostMapPresence.OrbitalCheckpointStateVectorRejectBodyMismatch, skipReason);
             Assert.Contains(logLines, l =>
                 l.Contains("[GhostMap]")
                 && l.Contains("source-resolve:")
-                && l.Contains("reason=orbital-checkpoint-state-vector-body-mismatch"));
+                && l.Contains("reason=" + GhostMapPresence.OrbitalCheckpointStateVectorRejectBodyMismatch));
             Assert.Contains(logLines, l =>
                 l.Contains("[GhostMap]")
                 && l.Contains("test-soi-gap-state-vector:")
-                && l.Contains("fallbackReason=orbital-checkpoint-state-vector-body-mismatch")
+                && l.Contains("fallbackReason=" + GhostMapPresence.OrbitalCheckpointStateVectorRejectBodyMismatch)
                 && l.Contains("stateVectorBody=Kerbin")
                 && l.Contains("expectedBody=Mun")
                 && l.Contains("bodyMatches=False"));
+        }
+
+        [Fact]
+        public void ResolveMapPresenceGhostSource_SoiGapCheckpointFallbackRejectsOutsidePlaybackWindow()
+        {
+            Recording rec = MakeSoiGapRecording(
+                "checkpoint-outside-window",
+                checkpointBody: "Mun",
+                futureSegmentBody: "Mun");
+            TrajectoryPoint outsideWindowPoint = rec.TrackSections[0].frames[0];
+            outsideWindowPoint.ut = 50.0;
+            rec.TrackSections[0].frames[0] = outsideWindowPoint;
+
+            GhostMapPresence.TrackingStationGhostSource source = Resolve(
+                rec,
+                currentUT: 160.0,
+                allowSoiGapStateVectorFallback: true,
+                expectedSoiGapBody: "Mun",
+                out _,
+                out _,
+                out string skipReason);
+
+            Assert.Equal(GhostMapPresence.TrackingStationGhostSource.None, source);
+            Assert.Equal(GhostMapPresence.OrbitalCheckpointStateVectorRejectOutsideWindow, skipReason);
+            Assert.Contains(logLines, l =>
+                l.Contains("[GhostMap]")
+                && l.Contains("source-resolve:")
+                && l.Contains("source=None")
+                && l.Contains("reason=" + GhostMapPresence.OrbitalCheckpointStateVectorRejectOutsideWindow));
+            Assert.Contains(logLines, l =>
+                l.Contains("[GhostMap]")
+                && l.Contains("test-soi-gap-state-vector:")
+                && l.Contains("pointUT=50.0")
+                && l.Contains("fallbackReason=" + GhostMapPresence.OrbitalCheckpointStateVectorRejectOutsideWindow)
+                && l.Contains("withinPlaybackWindow=False"));
         }
 
         [Fact]
@@ -140,11 +175,11 @@ namespace Parsek.Tests
                 out string skipReason);
 
             Assert.Equal(GhostMapPresence.TrackingStationGhostSource.None, source);
-            Assert.Equal("orbital-checkpoint-state-vector-not-soi-gap-recovery", skipReason);
+            Assert.Equal(GhostMapPresence.OrbitalCheckpointStateVectorRejectNotSoiGap, skipReason);
             Assert.Contains(logLines, l =>
                 l.Contains("[GhostMap]")
                 && l.Contains("test-soi-gap-state-vector:")
-                && l.Contains("fallbackReason=orbital-checkpoint-state-vector-not-soi-gap-recovery")
+                && l.Contains("fallbackReason=" + GhostMapPresence.OrbitalCheckpointStateVectorRejectNotSoiGap)
                 && l.Contains("gapBodyTransition=False")
                 && l.Contains("gapPreviousBody=Kerbin")
                 && l.Contains("gapNextBody=Kerbin"));
@@ -168,11 +203,11 @@ namespace Parsek.Tests
                 out string skipReason);
 
             Assert.Equal(GhostMapPresence.TrackingStationGhostSource.None, source);
-            Assert.Equal("orbital-checkpoint-state-vector-body-mismatch", skipReason);
+            Assert.Equal(GhostMapPresence.OrbitalCheckpointStateVectorRejectBodyMismatch, skipReason);
             Assert.Contains(logLines, l =>
                 l.Contains("[GhostMap]")
                 && l.Contains("test-soi-gap-state-vector:")
-                && l.Contains("fallbackReason=orbital-checkpoint-state-vector-body-mismatch")
+                && l.Contains("fallbackReason=" + GhostMapPresence.OrbitalCheckpointStateVectorRejectBodyMismatch)
                 && l.Contains("stateVectorBody=Duna")
                 && l.Contains("expectedBody=Mun")
                 && l.Contains("gapNextBody=Mun"));
@@ -206,7 +241,7 @@ namespace Parsek.Tests
                 l.Contains("[GhostMap]")
                 && l.Contains("test-soi-gap-state-vector:")
                 && l.Contains("segmentBody=Mun")
-                && l.Contains("fallbackReason=orbital-checkpoint-state-vector-safer-segment-source")
+                && l.Contains("fallbackReason=" + GhostMapPresence.OrbitalCheckpointStateVectorRejectSaferSegment)
                 && l.Contains("segmentSourceAvailable=True"));
         }
 

--- a/Source/Parsek.Tests/OrbitalCheckpointDensifierTests.cs
+++ b/Source/Parsek.Tests/OrbitalCheckpointDensifierTests.cs
@@ -121,7 +121,7 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void MapSourceLog_CheckpointPointsUseStructuredStateVectorDecision()
+        public void MapSourceLog_CheckpointPointsDoNotOverrideSegmentDecision()
         {
             Recording rec = BuildWarpRecording(LongWarpEndUT);
             DensifySynthetic(rec);
@@ -137,21 +137,28 @@ namespace Parsek.Tests
                     allowTerminalOrbitFallback: true,
                     logOperationName: "571a-map-source-test",
                     ref cachedIndex,
-                    out _,
+                    out OrbitSegment segment,
                     out TrajectoryPoint stateVectorPoint,
                     out string skipReason);
 
-            Assert.Equal(GhostMapPresence.TrackingStationGhostSource.StateVector, source);
+            Assert.Equal(GhostMapPresence.TrackingStationGhostSource.Segment, source);
             Assert.Null(skipReason);
-            Assert.Equal("Kerbin", stateVectorPoint.bodyName);
+            Assert.Equal("Kerbin", segment.bodyName);
+            Assert.Equal(default(TrajectoryPoint), stateVectorPoint);
             Assert.Contains(logLines, line =>
                 line.Contains("[GhostMap]")
                 && line.Contains("571a-map-source-test")
                 && line.Contains("rec=571a-long-warp")
-                && line.Contains("source=StateVector")
-                && line.Contains("stateVectorSource=OrbitalCheckpoint")
-                && line.Contains("sourceKind=StateVector")
+                && line.Contains("source=Segment")
+                && line.Contains("segmentBody=Kerbin")
+                && line.Contains("sourceKind=Segment")
                 && line.Contains("world="));
+            Assert.Contains(logLines, line =>
+                line.Contains("[GhostMap]")
+                && line.Contains("571a-map-source-test")
+                && line.Contains("rec=571a-long-warp")
+                && line.Contains("stateVectorSource=OrbitalCheckpoint")
+                && line.Contains("fallbackReason=orbital-checkpoint-state-vector-safer-segment-source"));
         }
 
         [Fact]

--- a/Source/Parsek.Tests/OrbitalCheckpointDensifierTests.cs
+++ b/Source/Parsek.Tests/OrbitalCheckpointDensifierTests.cs
@@ -158,7 +158,7 @@ namespace Parsek.Tests
                 && line.Contains("571a-map-source-test")
                 && line.Contains("rec=571a-long-warp")
                 && line.Contains("stateVectorSource=OrbitalCheckpoint")
-                && line.Contains("fallbackReason=orbital-checkpoint-state-vector-safer-segment-source"));
+                && line.Contains("fallbackReason=" + GhostMapPresence.OrbitalCheckpointStateVectorRejectSaferSegment));
         }
 
         [Fact]

--- a/Source/Parsek.Tests/StateVectorWorldFrameTests.cs
+++ b/Source/Parsek.Tests/StateVectorWorldFrameTests.cs
@@ -287,6 +287,39 @@ namespace Parsek.Tests
             Assert.Equal("state-vector-from-orbital-checkpoint", result.FailureReason);
         }
 
+        [Fact]
+        public void OrbitalCheckpoint_ExplicitSoiGapRecovery_UsesSurfaceLookup()
+        {
+            var point = new TrajectoryPoint
+            {
+                ut = 100.0,
+                latitude = 1.0,
+                longitude = 2.0,
+                altitude = 47481.0,
+                bodyName = "Mun",
+            };
+            var sentinel = new Vector3d(10.0, 20.0, 30.0);
+            var section = OrbitalCheckpointSection(50.0, 150.0);
+
+            var result = GhostMapPresence.ResolveStateVectorWorldPositionPure(
+                point,
+                section,
+                recordingFormatVersion: 6,
+                absoluteSurfaceLookup: SurfaceLookupReturning(sentinel),
+                anchorFound: false,
+                anchorWorldPos: default(Vector3d),
+                anchorWorldRot: Quaternion.identity,
+                anchorVesselId: 0u,
+                allowOrbitalCheckpointStateVector: true);
+
+            Assert.True(result.Resolved);
+            Assert.Equal("orbital-checkpoint", result.Branch);
+            Assert.Null(result.FailureReason);
+            Assert.Equal(sentinel.x, result.WorldPos.x, 6);
+            Assert.Equal(sentinel.y, result.WorldPos.y, 6);
+            Assert.Equal(sentinel.z, result.WorldPos.z, 6);
+        }
+
         // -----------------------------------------------------------------
         // No-section fallback — preserves Absolute interpretation for legacy
         // recordings that have not been split into sections.

--- a/Source/Parsek/GhostMapPresence.cs
+++ b/Source/Parsek/GhostMapPresence.cs
@@ -313,6 +313,11 @@ namespace Parsek
         internal const string TrackingStationSpawnSkipIntermediateChainSegment = "intermediate-chain-segment";
         internal const string TrackingStationSpawnSkipIntermediateGhostChainLink = "intermediate-ghost-chain-link";
         internal const string TrackingStationSpawnSkipTerminatedGhostChain = "terminated-ghost-chain";
+        internal const string SoiGapStateVectorFallbackReason = "soi-gap-state-vector-fallback";
+        internal const string OrbitalCheckpointStateVectorRejectSaferSegment = "orbital-checkpoint-state-vector-safer-segment-source";
+        internal const string OrbitalCheckpointStateVectorRejectNotSoiGap = "orbital-checkpoint-state-vector-not-soi-gap-recovery";
+        internal const string OrbitalCheckpointStateVectorRejectBodyMismatch = "orbital-checkpoint-state-vector-body-mismatch";
+        internal const string OrbitalCheckpointStateVectorRejectOutsideWindow = "orbital-checkpoint-state-vector-outside-window";
         internal const double StateVectorCreateAltitude = 1500;   // meters (airless bodies only)
         internal const double StateVectorCreateSpeed = 60;        // m/s
         internal const double StateVectorRemoveAltitude = 500;    // meters (airless bodies only)
@@ -1572,6 +1577,11 @@ namespace Parsek
             return false;
         }
 
+        /// <summary>
+        /// Finds the immediate orbit-segment gap bracketing <paramref name="ut"/>.
+        /// <paramref name="segments"/> must be sorted by increasing UT, matching the
+        /// playback trajectory invariant.
+        /// </summary>
         internal static bool TryFindOrbitSegmentGap(
             IReadOnlyList<OrbitSegment> segments,
             double ut,
@@ -1604,6 +1614,11 @@ namespace Parsek
             return false;
         }
 
+        /// <summary>
+        /// Evaluates the narrow OrbitalCheckpoint state-vector carve-out for SOI gaps.
+        /// <paramref name="expectedSoiGapBody"/> is a caller hint; when the segment
+        /// list contains the bracketing gap, the actual post-gap segment body wins.
+        /// </summary>
         internal static OrbitalCheckpointStateVectorFallbackDecision EvaluateOrbitalCheckpointStateVectorFallback(
             IPlaybackTrajectory traj,
             double currentUT,
@@ -1646,17 +1661,17 @@ namespace Parsek
             string reason;
             bool accepted = false;
             if (segmentSourceAvailable)
-                reason = "orbital-checkpoint-state-vector-safer-segment-source";
+                reason = OrbitalCheckpointStateVectorRejectSaferSegment;
             else if (!isSoiGapRecovery)
-                reason = "orbital-checkpoint-state-vector-not-soi-gap-recovery";
+                reason = OrbitalCheckpointStateVectorRejectNotSoiGap;
             else if (!bodyMatches)
-                reason = "orbital-checkpoint-state-vector-body-mismatch";
+                reason = OrbitalCheckpointStateVectorRejectBodyMismatch;
             else if (!withinPlaybackWindow)
-                reason = "orbital-checkpoint-state-vector-outside-window";
+                reason = OrbitalCheckpointStateVectorRejectOutsideWindow;
             else
             {
                 accepted = true;
-                reason = "soi-gap-state-vector-fallback";
+                reason = SoiGapStateVectorFallbackReason;
             }
 
             return new OrbitalCheckpointStateVectorFallbackDecision
@@ -2532,7 +2547,7 @@ namespace Parsek
                     dispatch.StateVecAlt = stateVectorPoint.altitude;
                     dispatch.StateVecSpeed = stateVectorPoint.velocity.magnitude;
                     if (source == TrackingStationGhostSource.StateVectorSoiGap)
-                        dispatch.Reason = "soi-gap-state-vector-fallback";
+                        dispatch.Reason = SoiGapStateVectorFallbackReason;
                     break;
                 case TrackingStationGhostSource.TerminalOrbit:
                     dispatch.Body = traj?.TerminalOrbitBody;
@@ -2563,7 +2578,7 @@ namespace Parsek
                         currentUT,
                         allowOrbitalCheckpointStateVector: source == TrackingStationGhostSource.StateVectorSoiGap,
                         stateVectorCreateReason: source == TrackingStationGhostSource.StateVectorSoiGap
-                            ? "soi-gap-state-vector-fallback"
+                            ? SoiGapStateVectorFallbackReason
                             : null);
 
                 default:

--- a/Source/Parsek/GhostMapPresence.cs
+++ b/Source/Parsek/GhostMapPresence.cs
@@ -33,7 +33,14 @@ namespace Parsek
             None = 0,
             Segment = 1,
             TerminalOrbit = 2,
-            StateVector = 3
+            StateVector = 3,
+            StateVectorSoiGap = 4
+        }
+
+        internal static bool IsStateVectorGhostSource(TrackingStationGhostSource source)
+        {
+            return source == TrackingStationGhostSource.StateVector
+                || source == TrackingStationGhostSource.StateVectorSoiGap;
         }
 
         internal struct TrackingStationSpawnHandoffState
@@ -321,6 +328,23 @@ namespace Parsek
             public string FallbackReason;
         }
 
+        internal struct OrbitalCheckpointStateVectorFallbackDecision
+        {
+            public bool Accepted;
+            public string Reason;
+            public string ExpectedBody;
+            public string StateVectorBody;
+            public bool SegmentSourceAvailable;
+            public bool IsSoiGapRecovery;
+            public bool GapBodyTransition;
+            public bool BodyMatches;
+            public bool WithinPlaybackWindow;
+            public string GapPreviousBody;
+            public string GapNextBody;
+            public double ActivationStartUT;
+            public double EndUT;
+        }
+
         private sealed class TrackingStationGhostSourceBatch
         {
             private readonly string context;
@@ -348,7 +372,7 @@ namespace Parsek
                     segmentCount++;
                 else if (source == TrackingStationGhostSource.TerminalOrbit)
                     terminalCount++;
-                else if (source == TrackingStationGhostSource.StateVector)
+                else if (IsStateVectorGhostSource(source))
                     stateVectorCount++;
                 else
                     skippedCount++;
@@ -532,6 +556,8 @@ namespace Parsek
                     return "terminal-orbit";
                 case TrackingStationGhostSource.StateVector:
                     return "state-vector";
+                case TrackingStationGhostSource.StateVectorSoiGap:
+                    return "soi-gap-state-vector";
                 default:
                     return "none";
             }
@@ -1546,6 +1572,131 @@ namespace Parsek
             return false;
         }
 
+        internal static bool TryFindOrbitSegmentGap(
+            IReadOnlyList<OrbitSegment> segments,
+            double ut,
+            out OrbitSegment previous,
+            out OrbitSegment next)
+        {
+            previous = default(OrbitSegment);
+            next = default(OrbitSegment);
+            if (segments == null || segments.Count < 2)
+                return false;
+
+            int previousIndex = -1;
+            for (int i = 0; i < segments.Count; i++)
+            {
+                OrbitSegment candidate = segments[i];
+                if (candidate.endUT <= ut)
+                {
+                    previousIndex = i;
+                    continue;
+                }
+
+                if (previousIndex < 0 || candidate.startUT <= ut)
+                    return false;
+
+                previous = segments[previousIndex];
+                next = candidate;
+                return true;
+            }
+
+            return false;
+        }
+
+        internal static OrbitalCheckpointStateVectorFallbackDecision EvaluateOrbitalCheckpointStateVectorFallback(
+            IPlaybackTrajectory traj,
+            double currentUT,
+            TrajectoryPoint point,
+            bool segmentSourceAvailable,
+            bool allowSoiGapRecovery,
+            string expectedSoiGapBody)
+        {
+            double activationStartUT = PlaybackTrajectoryBoundsResolver.ResolveGhostActivationStartUT(traj);
+            double endUT = traj?.EndUT ?? double.NaN;
+            bool withinPlaybackWindow =
+                traj != null
+                && currentUT >= activationStartUT
+                && currentUT <= endUT
+                && point.ut >= activationStartUT
+                && point.ut <= endUT;
+
+            string expectedBody = expectedSoiGapBody;
+            bool hasGap = false;
+            bool gapBodyTransition = false;
+            string gapPreviousBody = null;
+            string gapNextBody = null;
+            if (traj?.OrbitSegments != null
+                && TryFindOrbitSegmentGap(traj.OrbitSegments, currentUT, out OrbitSegment previousSegment, out OrbitSegment nextSegment))
+            {
+                hasGap = true;
+                gapPreviousBody = previousSegment.bodyName;
+                gapNextBody = nextSegment.bodyName;
+                gapBodyTransition = !string.Equals(
+                    previousSegment.bodyName,
+                    nextSegment.bodyName,
+                    StringComparison.Ordinal);
+                expectedBody = nextSegment.bodyName;
+            }
+
+            bool isSoiGapRecovery = allowSoiGapRecovery && hasGap && gapBodyTransition;
+            bool bodyMatches = !string.IsNullOrEmpty(expectedBody)
+                && string.Equals(point.bodyName, expectedBody, StringComparison.Ordinal);
+
+            string reason;
+            bool accepted = false;
+            if (segmentSourceAvailable)
+                reason = "orbital-checkpoint-state-vector-safer-segment-source";
+            else if (!isSoiGapRecovery)
+                reason = "orbital-checkpoint-state-vector-not-soi-gap-recovery";
+            else if (!bodyMatches)
+                reason = "orbital-checkpoint-state-vector-body-mismatch";
+            else if (!withinPlaybackWindow)
+                reason = "orbital-checkpoint-state-vector-outside-window";
+            else
+            {
+                accepted = true;
+                reason = "soi-gap-state-vector-fallback";
+            }
+
+            return new OrbitalCheckpointStateVectorFallbackDecision
+            {
+                Accepted = accepted,
+                Reason = reason,
+                ExpectedBody = expectedBody,
+                StateVectorBody = point.bodyName,
+                SegmentSourceAvailable = segmentSourceAvailable,
+                IsSoiGapRecovery = isSoiGapRecovery,
+                GapBodyTransition = gapBodyTransition,
+                BodyMatches = bodyMatches,
+                WithinPlaybackWindow = withinPlaybackWindow,
+                GapPreviousBody = gapPreviousBody,
+                GapNextBody = gapNextBody,
+                ActivationStartUT = activationStartUT,
+                EndUT = endUT
+            };
+        }
+
+        private static string FormatOrbitalCheckpointStateVectorFallbackDecision(
+            OrbitalCheckpointStateVectorFallbackDecision decision)
+        {
+            return string.Format(ic,
+                "orbitalCheckpointFallback={0} fallbackReason={1} isSoiGapRecovery={2} gapBodyTransition={3} gapPreviousBody={4} gapNextBody={5} segmentSourceAvailable={6} bodyMatches={7} stateVectorBody={8} expectedBody={9} withinPlaybackWindow={10} activationStartUT={11:F1} endUT={12:F1}",
+                decision.Accepted ? "accept" : "reject",
+                decision.Reason ?? "(none)",
+                decision.IsSoiGapRecovery,
+                decision.GapBodyTransition,
+                decision.GapPreviousBody ?? "(none)",
+                decision.GapNextBody ?? "(none)",
+                decision.SegmentSourceAvailable,
+                decision.BodyMatches,
+                decision.StateVectorBody ?? "(null)",
+                decision.ExpectedBody ?? "(none)",
+                decision.WithinPlaybackWindow,
+                decision.ActivationStartUT,
+                decision.EndUT);
+        }
+
         internal static bool StartsInOrbit(IPlaybackTrajectory traj, double ut)
         {
             if (!traj.HasOrbitSegments)
@@ -1598,7 +1749,7 @@ namespace Parsek
                 srf.Body = resolvedSegment.bodyName;
                 srf.Segment = resolvedSegment;
             }
-            else if (source == TrackingStationGhostSource.StateVector)
+            else if (IsStateVectorGhostSource(source))
             {
                 srf.Body = resolvedStatePoint.bodyName;
                 srf.StateVecAlt = resolvedStatePoint.altitude;
@@ -1632,7 +1783,9 @@ namespace Parsek
             out OrbitSegment segment,
             out TrajectoryPoint stateVectorPoint,
             out string skipReason,
-            int recordingIndex = -1)
+            int recordingIndex = -1,
+            bool allowSoiGapStateVectorFallback = false,
+            string expectedSoiGapBody = null)
         {
             segment = default(OrbitSegment);
             stateVectorPoint = default(TrajectoryPoint);
@@ -1736,30 +1889,8 @@ namespace Parsek
                     string.Format(ic, "terminal={0}", terminal.Value));
             }
 
-            // Dense OrbitalCheckpoint frames are derived from the matching OrbitSegment,
-            // but they are the higher-fidelity source for map icons during the checkpoint window.
-            if (TryResolveCheckpointStateVectorMapPoint(
-                traj,
-                currentUT,
-                ref stateVectorCachedIndex,
-                out stateVectorPoint,
-                out _,
-                out TrackSection checkpointSection))
-            {
-                resolvedStatePoint = stateVectorPoint;
-                return ReturnDecision(
-                    TrackingStationGhostSource.StateVector,
-                    skipReason,
-                    string.Format(ic,
-                        "stateVectorSource=OrbitalCheckpoint sectionUT={0:F1}-{1:F1} pointUT={2:F1} stateVectorBody={3} alt={4:F0} speed={5:F1}",
-                        checkpointSection.startUT,
-                        checkpointSection.endUT,
-                        stateVectorPoint.ut,
-                        stateVectorPoint.bodyName ?? "(null)",
-                        stateVectorPoint.altitude,
-                        stateVectorPoint.velocity.magnitude));
-            }
-
+            string checkpointFallbackDetail = null;
+            string checkpointFallbackRejectReason = null;
             if (traj.HasOrbitSegments)
             {
                 OrbitSegment? currentSegment =
@@ -1768,15 +1899,89 @@ namespace Parsek
                 {
                     segment = currentSegment.Value;
                     resolvedSegment = segment;
+
+                    if (TryResolveCheckpointStateVectorMapPoint(
+                        traj,
+                        currentUT,
+                        ref stateVectorCachedIndex,
+                        out TrajectoryPoint checkpointPoint,
+                        out _,
+                        out TrackSection checkpointSection))
+                    {
+                        OrbitalCheckpointStateVectorFallbackDecision checkpointDecision =
+                            EvaluateOrbitalCheckpointStateVectorFallback(
+                                traj,
+                                currentUT,
+                                checkpointPoint,
+                                segmentSourceAvailable: true,
+                                allowSoiGapRecovery: allowSoiGapStateVectorFallback,
+                                expectedSoiGapBody: expectedSoiGapBody);
+                        checkpointFallbackDetail = string.Format(ic,
+                            "stateVectorSource=OrbitalCheckpoint sectionUT={0:F1}-{1:F1} pointUT={2:F1} stateVectorBody={3} alt={4:F0} speed={5:F1} {6}",
+                            checkpointSection.startUT,
+                            checkpointSection.endUT,
+                            checkpointPoint.ut,
+                            checkpointPoint.bodyName ?? "(null)",
+                            checkpointPoint.altitude,
+                            checkpointPoint.velocity.magnitude,
+                            FormatOrbitalCheckpointStateVectorFallbackDecision(checkpointDecision));
+                    }
+
                     return ReturnDecision(
                         TrackingStationGhostSource.Segment,
                         skipReason,
-                        string.Format(ic,
+                        CombineSourceDetails(string.Format(ic,
                             "segmentBody={0} segmentUT={1:F1}-{2:F1}",
                             segment.bodyName ?? "(null)",
                             segment.startUT,
-                            segment.endUT));
+                            segment.endUT),
+                            checkpointFallbackDetail));
                 }
+            }
+
+            // Dense OrbitalCheckpoint frames are only safe as a map-presence
+            // state-vector source when a caller explicitly marks the create/update
+            // as recovery from an orbit-segment gap. Normal checkpoint windows keep
+            // using segment or terminal-orbit sources so stale/wrong-frame checkpoint
+            // data cannot reintroduce the #571 / #584 wrong-position class.
+            if (TryResolveCheckpointStateVectorMapPoint(
+                traj,
+                currentUT,
+                ref stateVectorCachedIndex,
+                out stateVectorPoint,
+                out _,
+                out TrackSection fallbackCheckpointSection))
+            {
+                OrbitalCheckpointStateVectorFallbackDecision checkpointDecision =
+                    EvaluateOrbitalCheckpointStateVectorFallback(
+                        traj,
+                        currentUT,
+                        stateVectorPoint,
+                        segmentSourceAvailable: false,
+                        allowSoiGapRecovery: allowSoiGapStateVectorFallback,
+                        expectedSoiGapBody: expectedSoiGapBody);
+                string detail = string.Format(ic,
+                    "stateVectorSource=OrbitalCheckpoint sectionUT={0:F1}-{1:F1} pointUT={2:F1} stateVectorBody={3} alt={4:F0} speed={5:F1} {6}",
+                    fallbackCheckpointSection.startUT,
+                    fallbackCheckpointSection.endUT,
+                    stateVectorPoint.ut,
+                    stateVectorPoint.bodyName ?? "(null)",
+                    stateVectorPoint.altitude,
+                    stateVectorPoint.velocity.magnitude,
+                    FormatOrbitalCheckpointStateVectorFallbackDecision(checkpointDecision));
+
+                if (checkpointDecision.Accepted)
+                {
+                    resolvedStatePoint = stateVectorPoint;
+                    skipReason = checkpointDecision.Reason;
+                    return ReturnDecision(
+                        TrackingStationGhostSource.StateVectorSoiGap,
+                        checkpointDecision.Reason,
+                        detail);
+                }
+
+                checkpointFallbackRejectReason = checkpointDecision.Reason;
+                checkpointFallbackDetail = detail;
             }
 
             string stateVectorSkipReason = null;
@@ -1804,23 +2009,27 @@ namespace Parsek
             if (!allowTerminalOrbitFallback)
             {
                 skipReason = traj.HasOrbitSegments
-                    ? "no-current-segment"
+                    ? checkpointFallbackRejectReason ?? "no-current-segment"
                     : NormalizeStateVectorSkipReasonForNoOrbit(stateVectorSkipReason);
                 return ReturnDecision(
                     TrackingStationGhostSource.None,
                     skipReason,
-                    string.Format(ic, "terminalFallback=False hasOrbitSegments={0}", traj.HasOrbitSegments));
+                    CombineSourceDetails(
+                        string.Format(ic, "terminalFallback=False hasOrbitSegments={0}", traj.HasOrbitSegments),
+                        checkpointFallbackDetail));
             }
 
             if (!HasOrbitData(traj))
             {
                 skipReason = traj.HasOrbitSegments
-                    ? "no-current-segment"
+                    ? checkpointFallbackRejectReason ?? "no-current-segment"
                     : NormalizeStateVectorSkipReasonForNoOrbit(stateVectorSkipReason);
                 return ReturnDecision(
                     TrackingStationGhostSource.None,
                     skipReason,
-                    string.Format(ic, "hasOrbitSegments={0}", traj.HasOrbitSegments));
+                    CombineSourceDetails(
+                        string.Format(ic, "hasOrbitSegments={0}", traj.HasOrbitSegments),
+                        checkpointFallbackDetail));
             }
 
             if (!IsTerminalStateEligibleForTerminalOrbitMapPresence(terminal))
@@ -1829,17 +2038,21 @@ namespace Parsek
                 return ReturnDecision(
                     TrackingStationGhostSource.None,
                     skipReason,
-                    string.Format(ic, "terminal={0} terminalOrbitFallback=True", terminal.Value));
+                    CombineSourceDetails(
+                        string.Format(ic, "terminal={0} terminalOrbitFallback=True", terminal.Value),
+                        checkpointFallbackDetail));
             }
 
             double activationStartUT = PlaybackTrajectoryBoundsResolver.ResolveGhostActivationStartUT(traj);
             if (currentUT < activationStartUT)
             {
-                skipReason = "before-activation";
+                skipReason = checkpointFallbackRejectReason ?? "before-activation";
                 return ReturnDecision(
                     TrackingStationGhostSource.None,
                     skipReason,
-                    string.Format(ic, "activationStartUT={0:F1}", activationStartUT));
+                    CombineSourceDetails(
+                        string.Format(ic, "activationStartUT={0:F1}", activationStartUT),
+                        checkpointFallbackDetail));
             }
 
             bool allowSparseOrbitGapFallback =
@@ -1848,11 +2061,13 @@ namespace Parsek
                 && !HasRecordedTrackCoverageAtUT(traj, currentUT);
             if (currentUT < traj.EndUT && !allowSparseOrbitGapFallback)
             {
-                skipReason = "before-terminal-orbit";
+                skipReason = checkpointFallbackRejectReason ?? "before-terminal-orbit";
                 return ReturnDecision(
                     TrackingStationGhostSource.None,
                     skipReason,
-                    string.Format(ic, "endUT={0:F1}", traj.EndUT));
+                    CombineSourceDetails(
+                        string.Format(ic, "endUT={0:F1}", traj.EndUT),
+                        checkpointFallbackDetail));
             }
 
             if (!TryResolveGhostProtoOrbitSeed(
@@ -1873,12 +2088,13 @@ namespace Parsek
                 return ReturnDecision(
                     TrackingStationGhostSource.None,
                     skipReason,
-                    string.Format(ic,
+                    CombineSourceDetails(string.Format(ic,
                         "terminalBody={0} endUT={1:F1} seedFailure={2} endpointBody={3}",
                         traj.TerminalOrbitBody ?? "(null)",
                         traj.EndUT,
                         seedDiagnostics.FailureReason ?? "(none)",
-                        seedDiagnostics.EndpointBodyName ?? "(none)"));
+                        seedDiagnostics.EndpointBodyName ?? "(none)"),
+                        checkpointFallbackDetail));
             }
 
             segment = new OrbitSegment
@@ -1899,14 +2115,15 @@ namespace Parsek
             return ReturnDecision(
                 TrackingStationGhostSource.TerminalOrbit,
                 skipReason,
-                string.Format(ic,
+                CombineSourceDetails(string.Format(ic,
                     "terminalBody={0} endUT={1:F1} seedBody={2} seedSource={3} endpointBody={4} seedFallback={5}",
                     traj.TerminalOrbitBody ?? "(null)",
                     traj.EndUT,
                     seedBodyName ?? "(null)",
                     seedDiagnostics.Source ?? "(none)",
                     seedDiagnostics.EndpointBodyName ?? "(none)",
-                    seedDiagnostics.FallbackReason ?? "(none)"));
+                    seedDiagnostics.FallbackReason ?? "(none)"),
+                    checkpointFallbackDetail));
         }
 
         private static string BuildTrackingStationGhostSourceDetail(
@@ -1941,6 +2158,7 @@ namespace Parsek
                         segment.endUT));
 
                 case TrackingStationGhostSource.StateVector:
+                case TrackingStationGhostSource.StateVectorSoiGap:
                     return WithStructured(string.Format(ic,
                         "stateVectorBody={0} alt={1:F0} speed={2:F1}",
                         stateVectorPoint.bodyName ?? "(null)",
@@ -2051,7 +2269,10 @@ namespace Parsek
                     return BuildOrbitSourceStructuredDetail("TerminalOrbit", recId, currentUT, segment);
 
                 case TrackingStationGhostSource.StateVector:
-                    return BuildStateVectorSourceStructuredDetail(recId, stateVectorPoint);
+                    return BuildStateVectorSourceStructuredDetail("StateVector", recId, stateVectorPoint);
+
+                case TrackingStationGhostSource.StateVectorSoiGap:
+                    return BuildStateVectorSourceStructuredDetail("SoiGapStateVector", recId, stateVectorPoint);
 
                 default:
                     return string.Format(ic,
@@ -2083,6 +2304,7 @@ namespace Parsek
         }
 
         private static string BuildStateVectorSourceStructuredDetail(
+            string sourceKind,
             string recId,
             TrajectoryPoint point)
         {
@@ -2090,7 +2312,8 @@ namespace Parsek
                 ? FormatWorldPosition(worldPos)
                 : "(unresolved)";
             return string.Format(ic,
-                "sourceKind=StateVector rec={0} body={1} sourceUT={2:F1} pointUT={3:F1} alt={4:F0} speed={5:F1} world={6}",
+                "sourceKind={0} rec={1} body={2} sourceUT={3:F1} pointUT={4:F1} alt={5:F0} speed={6:F1} world={7}",
+                sourceKind,
                 recId,
                 point.bodyName ?? "(null)",
                 point.ut,
@@ -2304,9 +2527,12 @@ namespace Parsek
                     dispatch.Segment = segment;
                     break;
                 case TrackingStationGhostSource.StateVector:
+                case TrackingStationGhostSource.StateVectorSoiGap:
                     dispatch.Body = stateVectorPoint.bodyName;
                     dispatch.StateVecAlt = stateVectorPoint.altitude;
                     dispatch.StateVecSpeed = stateVectorPoint.velocity.magnitude;
+                    if (source == TrackingStationGhostSource.StateVectorSoiGap)
+                        dispatch.Reason = "soi-gap-state-vector-fallback";
                     break;
                 case TrackingStationGhostSource.TerminalOrbit:
                     dispatch.Body = traj?.TerminalOrbitBody;
@@ -2329,11 +2555,16 @@ namespace Parsek
                     return segmentGhost;
 
                 case TrackingStationGhostSource.StateVector:
+                case TrackingStationGhostSource.StateVectorSoiGap:
                     return CreateGhostVesselFromStateVectors(
                         recordingIndex,
                         traj,
                         stateVectorPoint,
-                        currentUT);
+                        currentUT,
+                        allowOrbitalCheckpointStateVector: source == TrackingStationGhostSource.StateVectorSoiGap,
+                        stateVectorCreateReason: source == TrackingStationGhostSource.StateVectorSoiGap
+                            ? "soi-gap-state-vector-fallback"
+                            : null);
 
                 default:
                     return null;
@@ -2439,7 +2670,7 @@ namespace Parsek
                 if (v != null)
                 {
                     lifecycleCreated++;
-                    if (source == TrackingStationGhostSource.StateVector)
+                    if (IsStateVectorGhostSource(source))
                         trackingStationStateVectorOrbitTrajectories[i] = rec;
                     else
                         trackingStationStateVectorOrbitTrajectories.Remove(i);
@@ -2829,7 +3060,8 @@ namespace Parsek
             bool anchorFound,
             Vector3d anchorWorldPos,
             Quaternion anchorWorldRot,
-            uint anchorVesselId)
+            uint anchorVesselId,
+            bool allowOrbitalCheckpointStateVector = false)
         {
             // No track sections at all — fall back to the original Absolute interpretation.
             // This preserves behaviour for legacy / synthetic recordings that have not yet
@@ -2897,9 +3129,25 @@ namespace Parsek
                 };
             }
 
-            // OrbitalCheckpoint: state-vector entry points should never come from a
-            // checkpoint section (those carry Keplerian elements, not point samples).
-            // If we get here, the upstream caller fed mismatched data — refuse.
+            // OrbitalCheckpoint state-vector entry points are normally refused:
+            // checkpoint sections are supposed to have segment/terminal-orbit
+            // sources available, and stale checkpoint-frame interpretation can
+            // reintroduce wrong-position bugs. The only caller that may opt in is
+            // the explicit SOI/orbit-segment-gap recovery path after it has already
+            // proven there is no safer source and the body/window match.
+            if (allowOrbitalCheckpointStateVector)
+            {
+                Vector3d pos = absoluteSurfaceLookup(point.latitude, point.longitude, point.altitude);
+                return new StateVectorWorldFrame
+                {
+                    Resolved = true,
+                    WorldPos = pos,
+                    Branch = "orbital-checkpoint",
+                    FailureReason = null,
+                    AnchorPid = 0
+                };
+            }
+
             return new StateVectorWorldFrame
             {
                 Resolved = false,
@@ -2917,7 +3165,8 @@ namespace Parsek
         private static StateVectorWorldFrame ResolveStateVectorWorldPosition(
             IPlaybackTrajectory traj,
             TrajectoryPoint point,
-            CelestialBody body)
+            CelestialBody body,
+            bool allowOrbitalCheckpointStateVector = false)
         {
             TrackSection? section = null;
             if (traj?.TrackSections != null && traj.TrackSections.Count > 0)
@@ -2955,7 +3204,8 @@ namespace Parsek
                 anchorFound,
                 anchorPos,
                 anchorRot,
-                anchorPid);
+                anchorPid,
+                allowOrbitalCheckpointStateVector);
         }
 
         /// <summary>
@@ -2968,7 +3218,10 @@ namespace Parsek
         /// </summary>
         internal static Vessel CreateGhostVesselFromStateVectors(
             int recordingIndex, IPlaybackTrajectory traj,
-            TrajectoryPoint point, double ut)
+            TrajectoryPoint point,
+            double ut,
+            bool allowOrbitalCheckpointStateVector = false,
+            string stateVectorCreateReason = null)
         {
             if (traj == null) return null;
 
@@ -2994,6 +3247,7 @@ namespace Parsek
                 intent.StateVecAlt = point.altitude;
                 intent.StateVecSpeed = point.velocity.magnitude;
                 intent.UT = ut;
+                intent.Reason = stateVectorCreateReason;
                 ParsekLog.Verbose(Tag, BuildGhostMapDecisionLine(intent));
             }
 
@@ -3013,7 +3267,11 @@ namespace Parsek
             }
 
             StateVectorWorldFrame resolution =
-                ResolveStateVectorWorldPosition(traj, point, body);
+                ResolveStateVectorWorldPosition(
+                    traj,
+                    point,
+                    body,
+                    allowOrbitalCheckpointStateVector);
             if (!resolution.Resolved)
             {
                 var skip = NewDecisionFields("create-state-vector-skip");
@@ -3054,12 +3312,15 @@ namespace Parsek
             string logContext = string.Format(ic,
                 "recording #{0} (state vectors alt={1:F0} spd={2:F1} frame={3})",
                 recordingIndex, point.altitude, point.velocity.magnitude, resolution.Branch);
+            string protoSource = string.IsNullOrEmpty(stateVectorCreateReason)
+                ? "state-vector-fallback"
+                : stateVectorCreateReason;
             Vessel vessel = BuildAndLoadGhostProtoVesselCore(
                 traj,
                 orbit,
                 body,
                 logContext,
-                "state-vector-fallback",
+                protoSource,
                 string.Format(ic,
                     "stateBody={0} stateUT={1:F1} stateAlt={2:F0} stateSpeed={3:F1} frame={4} anchorPid={5}",
                     point.bodyName ?? "(null)",
@@ -3089,7 +3350,9 @@ namespace Parsek
                 done.StateVecAlt = point.altitude;
                 done.StateVecSpeed = point.velocity.magnitude;
                 done.UT = ut;
-                done.Reason = string.Format(ic, "formatV={0}", traj.RecordingFormatVersion);
+                done.Reason = string.IsNullOrEmpty(stateVectorCreateReason)
+                    ? string.Format(ic, "formatV={0}", traj.RecordingFormatVersion)
+                    : string.Format(ic, "{0} formatV={1}", stateVectorCreateReason, traj.RecordingFormatVersion);
                 ParsekLog.Info(Tag, BuildGhostMapDecisionLine(done));
 
                 StashLastKnownFrame(recordingIndex, new LastKnownGhostFrame
@@ -3136,7 +3399,10 @@ namespace Parsek
         /// </summary>
         internal static void UpdateGhostOrbitFromStateVectors(
             int recordingIndex, IPlaybackTrajectory traj,
-            TrajectoryPoint point, double ut)
+            TrajectoryPoint point,
+            double ut,
+            bool allowOrbitalCheckpointStateVector = false,
+            string stateVectorUpdateReason = null)
         {
             if (!vesselsByRecordingIndex.TryGetValue(recordingIndex, out Vessel vessel))
                 return;
@@ -3173,7 +3439,11 @@ namespace Parsek
             }
 
             StateVectorWorldFrame resolution =
-                ResolveStateVectorWorldPosition(traj, point, body);
+                ResolveStateVectorWorldPosition(
+                    traj,
+                    point,
+                    body,
+                    allowOrbitalCheckpointStateVector);
             if (!resolution.Resolved)
             {
                 var skip = NewDecisionFields("update-state-vector-skip");
@@ -3220,6 +3490,7 @@ namespace Parsek
                 soi.Body = body.name;
                 soi.GhostPid = vessel.persistentId;
                 soi.UT = ut;
+                soi.Reason = stateVectorUpdateReason;
                 ParsekLog.Info(Tag, BuildGhostMapDecisionLine(soi));
             }
 
@@ -3258,6 +3529,7 @@ namespace Parsek
             done.StateVecAlt = point.altitude;
             done.StateVecSpeed = point.velocity.magnitude;
             done.UT = ut;
+            done.Reason = stateVectorUpdateReason;
             ParsekLog.VerboseRateLimited(Tag, updateKey, BuildGhostMapDecisionLine(done), 5.0);
 
             StashLastKnownFrame(recordingIndex, new LastKnownGhostFrame
@@ -3717,7 +3989,7 @@ namespace Parsek
                     sourceTerminalOrbit++;
                 else if (source == TrackingStationGhostSource.Segment)
                     sourceVisibleSegment++;
-                else if (source == TrackingStationGhostSource.StateVector)
+                else if (IsStateVectorGhostSource(source))
                     sourceStateVector++;
 
                 Vessel v = CreateGhostVesselFromSource(
@@ -3731,7 +4003,7 @@ namespace Parsek
                 if (v != null)
                 {
                     created++;
-                    if (source == TrackingStationGhostSource.StateVector)
+                    if (IsStateVectorGhostSource(source))
                     {
                         trackingStationStateVectorOrbitTrajectories[i] = rec;
                     }

--- a/Source/Parsek/ParsekPlaybackPolicy.cs
+++ b/Source/Parsek/ParsekPlaybackPolicy.cs
@@ -647,8 +647,28 @@ namespace Parsek
         /// the ghost enters an orbital segment. Avoids showing orbit lines during
         /// atmospheric ascent when the ghost mesh is still on the pad.
         /// </summary>
-        private readonly Dictionary<int, IPlaybackTrajectory> pendingMapVessels =
-            new Dictionary<int, IPlaybackTrajectory>();
+        private struct PendingMapVessel
+        {
+            internal IPlaybackTrajectory Trajectory;
+            internal bool AllowSoiGapStateVectorFallback;
+            internal string ExpectedSoiGapBody;
+
+            internal PendingMapVessel(
+                IPlaybackTrajectory trajectory,
+                bool allowSoiGapStateVectorFallback,
+                string expectedSoiGapBody)
+            {
+                Trajectory = trajectory;
+                AllowSoiGapStateVectorFallback = allowSoiGapStateVectorFallback;
+                ExpectedSoiGapBody = expectedSoiGapBody;
+            }
+        }
+
+        private readonly Dictionary<int, PendingMapVessel> pendingMapVessels =
+            new Dictionary<int, PendingMapVessel>();
+
+        private readonly Dictionary<int, string> soiGapStateVectorExpectedBodies =
+            new Dictionary<int, string>();
 
         /// <summary>
         /// Tracks the last orbit segment body+SMA per recording index for change detection.
@@ -753,15 +773,25 @@ namespace Parsek
                     startUT);
                 if (ghost != null)
                 {
-                    if (source == TrackingStationGhostSource.StateVector)
+                    if (GhostMapPresence.IsStateVectorGhostSource(source))
+                    {
                         stateVectorOrbitTrajectories[evt.Index] = evt.Trajectory;
+                        if (source != TrackingStationGhostSource.StateVectorSoiGap)
+                            soiGapStateVectorExpectedBodies.Remove(evt.Index);
+                    }
                     else if (TryGetMapOrbitKey(source, segment, out var orbitKey))
+                    {
+                        soiGapStateVectorExpectedBodies.Remove(evt.Index);
                         lastMapOrbitByIndex[evt.Index] = orbitKey;
+                    }
                 }
             }
             else
             {
-                pendingMapVessels[evt.Index] = evt.Trajectory;
+                pendingMapVessels[evt.Index] = new PendingMapVessel(
+                    evt.Trajectory,
+                    allowSoiGapStateVectorFallback: false,
+                    expectedSoiGapBody: null);
                 ParsekLog.Verbose("Policy",
                     $"Deferred ghost map vessel for #{evt.Index} \"{evt.Trajectory.VesselName}\" " +
                     "— recording starts pre-orbital");
@@ -820,12 +850,13 @@ namespace Parsek
             //    OR for physics-only recordings that crossed the state-vector threshold.
             if (pendingMapVessels.Count > 0)
             {
-                List<(int idx, TrackingStationGhostSource source, OrbitSegment segment, TrajectoryPoint point)> toCreate = null;
+                List<(int idx, TrackingStationGhostSource source, OrbitSegment segment, TrajectoryPoint point, string expectedBody)> toCreate = null;
 
                 foreach (var kvp in pendingMapVessels)
                 {
                     int idx = kvp.Key;
-                    IPlaybackTrajectory traj = kvp.Value;
+                    PendingMapVessel pending = kvp.Value;
+                    IPlaybackTrajectory traj = pending.Trajectory;
 
                     int cachedStateVectorIndex = stateVectorCachedIndices.TryGetValue(idx, out int cached)
                         ? cached
@@ -841,16 +872,18 @@ namespace Parsek
                         out OrbitSegment segment,
                         out TrajectoryPoint point,
                         out _,
-                        recordingIndex: idx);
+                        recordingIndex: idx,
+                        allowSoiGapStateVectorFallback: pending.AllowSoiGapStateVectorFallback,
+                        expectedSoiGapBody: pending.ExpectedSoiGapBody);
                     stateVectorCachedIndices[idx] = cachedStateVectorIndex;
 
                     if (source == TrackingStationGhostSource.Segment
-                        || source == TrackingStationGhostSource.StateVector
+                        || GhostMapPresence.IsStateVectorGhostSource(source)
                         || source == TrackingStationGhostSource.TerminalOrbit)
                     {
                         if (toCreate == null)
-                            toCreate = new List<(int, TrackingStationGhostSource, OrbitSegment, TrajectoryPoint)>();
-                        toCreate.Add((idx, source, segment, point));
+                            toCreate = new List<(int, TrackingStationGhostSource, OrbitSegment, TrajectoryPoint, string)>();
+                        toCreate.Add((idx, source, segment, point, pending.ExpectedSoiGapBody));
                     }
                 }
 
@@ -859,8 +892,9 @@ namespace Parsek
                     for (int i = 0; i < toCreate.Count; i++)
                     {
                         int idx = toCreate[i].idx;
-                        if (pendingMapVessels.TryGetValue(idx, out var traj))
+                        if (pendingMapVessels.TryGetValue(idx, out var pending))
                         {
+                            IPlaybackTrajectory traj = pending.Trajectory;
                             // Per-chain dedup before deferred creation
                             RemovePreviousChainMapVessel(idx);
                             Vessel ghost = GhostMapPresence.CreateGhostVesselFromSource(
@@ -874,17 +908,25 @@ namespace Parsek
 
                             if (ghost != null)
                             {
-                                if (toCreate[i].source == TrackingStationGhostSource.StateVector)
+                                if (GhostMapPresence.IsStateVectorGhostSource(toCreate[i].source))
                                 {
                                     stateVectorOrbitTrajectories[idx] = traj;
+                                    if (toCreate[i].source == TrackingStationGhostSource.StateVectorSoiGap)
+                                        soiGapStateVectorExpectedBodies[idx] = toCreate[i].expectedBody;
+                                    else
+                                        soiGapStateVectorExpectedBodies.Remove(idx);
                                     ParsekLog.Info("Policy", string.Format(CultureInfo.InvariantCulture,
-                                        "Created state-vector ghost map vessel for #{0} \"{1}\" — alt={2:F0} speed={3:F1}",
+                                        "Created state-vector ghost map vessel for #{0} \"{1}\" — alt={2:F0} speed={3:F1} source={4}",
                                         idx, traj.VesselName,
                                         toCreate[i].point.altitude,
-                                        toCreate[i].point.velocity.magnitude));
+                                        toCreate[i].point.velocity.magnitude,
+                                        toCreate[i].source == TrackingStationGhostSource.StateVectorSoiGap
+                                            ? "soi-gap-state-vector"
+                                            : "state-vector"));
                                 }
                                 else if (TryGetMapOrbitKey(toCreate[i].source, toCreate[i].segment, out var orbitKey))
                                 {
+                                    soiGapStateVectorExpectedBodies.Remove(idx);
                                     lastMapOrbitByIndex[idx] = orbitKey;
 
                                     ParsekLog.Info("Policy",
@@ -907,7 +949,7 @@ namespace Parsek
             // 2a. Segment-based orbit updates (existing)
             List<KeyValuePair<int, (string body, double sma, double ecc)>> orbitUpdates = null;
             List<int> toRemoveFromMap = null;
-            List<int> toRequeue = null;
+            List<(int idx, string expectedBody)> toRequeue = null;
 
             foreach (var kvp in lastMapOrbitByIndex)
             {
@@ -949,10 +991,16 @@ namespace Parsek
                     stateVectorCachedIndices[idx] = cachedStateVectorIndex;
 
                     bool hasFutureSegment = false;
+                    string futureSegmentBody = null;
                     var segs = rec.OrbitSegments;
                     for (int s = 0; s < segs.Count; s++)
                     {
-                        if (segs[s].startUT > currentUT) { hasFutureSegment = true; break; }
+                        if (segs[s].startUT > currentUT)
+                        {
+                            hasFutureSegment = true;
+                            futureSegmentBody = segs[s].bodyName;
+                            break;
+                        }
                     }
 
                     GhostMapPresence.RemoveGhostVesselForRecording(idx,
@@ -961,8 +1009,8 @@ namespace Parsek
                     if (hasFutureSegment)
                     {
                         // Re-add to pending so the next segment creates a new ProtoVessel
-                        if (toRequeue == null) toRequeue = new List<int>();
-                        toRequeue.Add(idx);
+                        if (toRequeue == null) toRequeue = new List<(int, string)>();
+                        toRequeue.Add((idx, futureSegmentBody));
                     }
 
                     if (toRemoveFromMap == null) toRemoveFromMap = new List<int>();
@@ -995,15 +1043,18 @@ namespace Parsek
             {
                 for (int i = 0; i < toRequeue.Count; i++)
                 {
-                    int idx = toRequeue[i];
+                    int idx = toRequeue[i].idx;
                     if (!pendingMapVessels.ContainsKey(idx) && idx < committed.Count)
                     {
                         var traj = committed[idx] as IPlaybackTrajectory;
                         if (traj != null)
                         {
-                            pendingMapVessels[idx] = traj;
+                            pendingMapVessels[idx] = new PendingMapVessel(
+                                traj,
+                                allowSoiGapStateVectorFallback: true,
+                                expectedSoiGapBody: toRequeue[i].expectedBody);
                             ParsekLog.Verbose("MapPresence",
-                                $"Re-queued recording #{idx} to pendingMapVessels (gap between orbit segments)");
+                                $"Re-queued recording #{idx} to pendingMapVessels (gap between orbit segments expectedBody={toRequeue[i].expectedBody ?? "(none)"})");
                         }
                     }
                 }
@@ -1013,6 +1064,8 @@ namespace Parsek
             if (stateVectorOrbitTrajectories.Count > 0)
             {
                 List<int> toReDefer = null;
+                List<int> toExitStateVector = null;
+                List<KeyValuePair<int, (string body, double sma, double ecc)>> stateVectorSegmentUpdates = null;
 
                 foreach (var kvp in stateVectorOrbitTrajectories)
                 {
@@ -1022,6 +1075,54 @@ namespace Parsek
                     if (!stateVectorCachedIndices.ContainsKey(idx))
                         stateVectorCachedIndices[idx] = -1;
                     int cached = stateVectorCachedIndices[idx];
+
+                    if (soiGapStateVectorExpectedBodies.TryGetValue(idx, out string expectedSoiGapBody))
+                    {
+                        TrackingStationGhostSource source = GhostMapPresence.ResolveMapPresenceGhostSource(
+                            traj,
+                            false,
+                            IsMaterializedForMapPresence(traj),
+                            currentUT,
+                            true,
+                            "map-presence-soi-gap-state-vector-update",
+                            ref cached,
+                            out OrbitSegment segment,
+                            out TrajectoryPoint soiGapPoint,
+                            out _,
+                            recordingIndex: idx,
+                            allowSoiGapStateVectorFallback: true,
+                            expectedSoiGapBody: expectedSoiGapBody);
+                        stateVectorCachedIndices[idx] = cached;
+
+                        if (source == TrackingStationGhostSource.StateVectorSoiGap)
+                        {
+                            GhostMapPresence.UpdateGhostOrbitFromStateVectors(
+                                idx,
+                                traj,
+                                soiGapPoint,
+                                currentUT,
+                                allowOrbitalCheckpointStateVector: true,
+                                stateVectorUpdateReason: "soi-gap-state-vector-fallback");
+                            continue;
+                        }
+
+                        if (source == TrackingStationGhostSource.Segment
+                            || source == TrackingStationGhostSource.TerminalOrbit)
+                        {
+                            GhostMapPresence.UpdateGhostOrbitForRecording(idx, segment);
+                            if (TryGetMapOrbitKey(source, segment, out var segmentKey))
+                            {
+                                if (stateVectorSegmentUpdates == null)
+                                    stateVectorSegmentUpdates = new List<KeyValuePair<int, (string, double, double)>>();
+                                stateVectorSegmentUpdates.Add(new KeyValuePair<int, (string, double, double)>(idx, segmentKey));
+                            }
+
+                            if (toExitStateVector == null) toExitStateVector = new List<int>();
+                            toExitStateVector.Add(idx);
+                            continue;
+                        }
+                    }
+
                     TrajectoryPoint? pt = TrajectoryMath.BracketPointAtUT(traj.Points, currentUT, ref cached);
                     stateVectorCachedIndices[idx] = cached;
 
@@ -1064,10 +1165,30 @@ namespace Parsek
                     {
                         int idx = toReDefer[i];
                         if (stateVectorOrbitTrajectories.TryGetValue(idx, out var traj))
-                            pendingMapVessels[idx] = traj;
+                            pendingMapVessels[idx] = new PendingMapVessel(
+                                traj,
+                                allowSoiGapStateVectorFallback: false,
+                                expectedSoiGapBody: null);
                         stateVectorOrbitTrajectories.Remove(idx);
+                        soiGapStateVectorExpectedBodies.Remove(idx);
                         // stateVectorCachedIndices[idx] intentionally kept — avoids
                         // O(n) re-scan if the ghost re-ascends above threshold.
+                    }
+                }
+
+                if (stateVectorSegmentUpdates != null)
+                {
+                    for (int i = 0; i < stateVectorSegmentUpdates.Count; i++)
+                        lastMapOrbitByIndex[stateVectorSegmentUpdates[i].Key] = stateVectorSegmentUpdates[i].Value;
+                }
+
+                if (toExitStateVector != null)
+                {
+                    for (int i = 0; i < toExitStateVector.Count; i++)
+                    {
+                        int idx = toExitStateVector[i];
+                        stateVectorOrbitTrajectories.Remove(idx);
+                        soiGapStateVectorExpectedBodies.Remove(idx);
                     }
                 }
             }
@@ -1231,6 +1352,7 @@ namespace Parsek
             pendingMapVessels.Remove(evt.Index);
             lastMapOrbitByIndex.Remove(evt.Index);
             stateVectorOrbitTrajectories.Remove(evt.Index);
+            soiGapStateVectorExpectedBodies.Remove(evt.Index);
             stateVectorCachedIndices.Remove(evt.Index);
 
             // Remove both recording-index and chain-based ghost map ProtoVessels
@@ -1267,6 +1389,7 @@ namespace Parsek
             lastMapOrbitByIndex.Clear();
             chainMapOwner.Clear();
             stateVectorOrbitTrajectories.Clear();
+            soiGapStateVectorExpectedBodies.Clear();
             stateVectorCachedIndices.Clear();
         }
 
@@ -1286,6 +1409,7 @@ namespace Parsek
             lastMapOrbitByIndex.Clear();
             chainMapOwner.Clear();
             stateVectorOrbitTrajectories.Clear();
+            soiGapStateVectorExpectedBodies.Clear();
             stateVectorCachedIndices.Clear();
             ParsekLog.Info("Policy", "ParsekPlaybackPolicy disposed and unsubscribed from 6 engine events");
         }

--- a/Source/Parsek/ParsekPlaybackPolicy.cs
+++ b/Source/Parsek/ParsekPlaybackPolicy.cs
@@ -788,6 +788,8 @@ namespace Parsek
             }
             else
             {
+                // Initial/pre-orbital deferrals are not SOI-gap recoveries; only the
+                // gap-between-orbit-segments requeue path opts into this fallback.
                 pendingMapVessels[evt.Index] = new PendingMapVessel(
                     evt.Trajectory,
                     allowSoiGapStateVectorFallback: false,

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1159,7 +1159,21 @@ segment endpoint and nothing, never settling into a Mun orbit.
 #589 (real-vessel spawns at end of recordings after rewind) are
 sibling symptoms in the same playtest.
 
-**Status:** Open.
+**Fix:** `ResolveMapPresenceGhostSource` now treats checkpoint-derived
+state vectors as a distinct `StateVectorSoiGap` source only when the
+flight map lifecycle explicitly re-queued the recording after
+`gap-between-orbit-segments`, no current segment source is available,
+the checkpoint body matches the post-gap SOI/body, and both the current
+UT and candidate state-vector UT are inside the recording playback
+window. Normal `OrbitalCheckpoint` state-vector creates still reject,
+and current segments still win. The structured `[GhostMap]` lines now
+emit `reason=soi-gap-state-vector-fallback` for accepted recoveries and
+specific reject reasons for safer segment, not-SOI-gap, body mismatch,
+or outside-window cases. Covered by
+`GhostMapSoiGapStateVectorTests` plus the explicit opt-in branch in
+`StateVectorWorldFrameTests`.
+
+**Status:** ~~done~~.
 
 ---
 


### PR DESCRIPTION
## Summary
- add a narrow StateVectorSoiGap map-presence source for explicit SOI/body-transition orbit-segment gaps
- keep ordinary OrbitalCheckpoint state-vector ghosts rejected, with segment sources still taking precedence
- add GhostMap diagnostics and xUnit coverage for accepted SOI-gap fallback, normal rejection, body mismatch, stale expected body, same-body gaps, and segment precedence
- update CHANGELOG.md and mark #588 done in docs/dev/todo-and-known-bugs.md

## Tests
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj (8742 passed)