### PR TITLE
Fix ghost map vessel targeting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,8 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- `#586` Ghost map vessel `Set As Target` now preserves the ghost as a vessel target instead of letting stock KSP immediately drop it as the active vessel's current main body. Ghost `OrbitDriver` identity is normalized so `OrbitDriver.vessel` points at the ghost and `OrbitDriver.celestialBody` stays null, while target menu actions now log success only after a post-validation target-state check. Rejected target attempts warn with before/after/final diagnostics covering `FlightGlobals.fetch.VesselTarget`, the active vessel's `targetObject`, target type/name/body, ghost map object, orbit driver, and registration state.
+
 - `#574` Already-Destroyed recordings no longer re-run the sub-surface ballistic finalizer on cache refresh. The first Destroyed classification now logs once with body, altitude, and threshold; later refreshes emit a rate-limited skip diagnostic plus refresh summary instead of a repeated WARN storm.
 - `#577` Re-Fly session markers loaded from an earlier game session now survive fresh-load scenes where KSP reports UT 0 during validation. The validator still rejects corrupt `InvokedUT` values and now logs current-UT/RP-UT comparisons for both accepts and rejects.
 
@@ -229,6 +231,7 @@ All notable changes to Parsek are documented here.
 
 ### Tests
 
+- `#586` Added log-capture regressions proving ghost target success is emitted only after verification passes, plus a live KSP runtime canary that creates a same-body synthetic ghost, confirms its `OrbitDriver` target identity, and verifies the production `SetGhostMapNavigationTarget` wrapper retains the ghost and emits verified success after stock validation frames.
 - Added focused regressions proving hidden old-branch events stay out of milestones, timeline legacy rows, reward write-back, and ledger recovery for recording-visibility reasons rather than `CurrentEpoch` checks, and updated the remaining fixtures that previously mutated `MilestoneStore.CurrentEpoch`.
 - `#552` Added recovery-pairing regressions for callback-before-funds-event ordering, the no-paired-event deferral path, vessel-name-preferred pairing over nearest-UT, ambiguous-tie warning, lifecycle-boundary staleness eviction, and queue-overflow threshold warning.
 - `#553` Added direct-ledger forwarding predicate coverage for tagged teardown suppression, untagged KSC events, and untagged pre-recording FLIGHT events across tech, part-purchase, crew-hire, milestone, strategy activate/deactivate, and facility upgrade handlers, plus an evt.recordingId-vs-resolver drift test.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,7 +206,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
-- `#586` Ghost map vessel `Set As Target` now preserves the ghost as a vessel target instead of letting stock KSP immediately drop it as the active vessel's current main body. Ghost `OrbitDriver` identity is normalized so `OrbitDriver.vessel` points at the ghost and `OrbitDriver.celestialBody` stays null, while target menu actions now log success only after a post-validation target-state check. Rejected target attempts warn with before/after/final diagnostics covering `FlightGlobals.fetch.VesselTarget`, the active vessel's `targetObject`, target type/name/body, ghost map object, orbit driver, and registration state.
+- `#586` Ghost map vessel `Set As Target` now sticks instead of being silently dropped by stock KSP. Failed targeting attempts now log a warning with diagnostic state instead of a false success.
 
 - `#574` Already-Destroyed recordings no longer re-run the sub-surface ballistic finalizer on cache refresh. The first Destroyed classification now logs once with body, altitude, and threshold; later refreshes emit a rate-limited skip diagnostic plus refresh summary instead of a repeated WARN storm.
 - `#577` Re-Fly session markers loaded from an earlier game session now survive fresh-load scenes where KSP reports UT 0 during validation. The validator still rejects corrupt `InvokedUT` values and now logs current-UT/RP-UT comparisons for both accepts and rejects.
@@ -231,7 +231,7 @@ All notable changes to Parsek are documented here.
 
 ### Tests
 
-- `#586` Added log-capture regressions proving ghost target success is emitted only after verification passes, plus a live KSP runtime canary that creates a same-body synthetic ghost, confirms its `OrbitDriver` target identity, and verifies the production `SetGhostMapNavigationTarget` wrapper retains the ghost and emits verified success after stock validation frames.
+- `#586` Added log-capture regressions and a live KSP runtime canary for verified ghost-map targeting.
 - Added focused regressions proving hidden old-branch events stay out of milestones, timeline legacy rows, reward write-back, and ledger recovery for recording-visibility reasons rather than `CurrentEpoch` checks, and updated the remaining fixtures that previously mutated `MilestoneStore.CurrentEpoch`.
 - `#552` Added recovery-pairing regressions for callback-before-funds-event ordering, the no-paired-event deferral path, vessel-name-preferred pairing over nearest-UT, ambiguous-tie warning, lifecycle-boundary staleness eviction, and queue-overflow threshold warning.
 - `#553` Added direct-ledger forwarding predicate coverage for tagged teardown suppression, untagged KSC events, and untagged pre-recording FLIGHT events across tech, part-purchase, crew-hire, milestone, strategy activate/deactivate, and facility upgrade handlers, plus an evt.recordingId-vs-resolver drift test.

--- a/Source/Parsek.Tests/GhostMapTargetingTests.cs
+++ b/Source/Parsek.Tests/GhostMapTargetingTests.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    [Collection("Sequential")]
+    public class GhostMapTargetingTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public GhostMapTargetingTests()
+        {
+            GhostMapPresence.ResetForTesting();
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.VerboseOverrideForTesting = true;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+        }
+
+        public void Dispose()
+        {
+            GhostMapPresence.ResetForTesting();
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+        }
+
+        [Fact]
+        public void TargetVerification_Accepted_LogsSetAsTargetSuccess()
+        {
+            bool accepted = GhostMapPresence.LogGhostTargetVerificationForTesting(
+                "Ghost: Kerbal X",
+                1,
+                "icon click",
+                GhostMapPresence.GhostTargetVerificationStatus.Accepted,
+                "target-vessel-matches-ghost",
+                "target=ghost");
+
+            Assert.True(accepted);
+            Assert.Contains(logLines, l =>
+                l.Contains("[INFO]")
+                && l.Contains("[GhostMap]")
+                && l.Contains("Ghost 'Ghost: Kerbal X' set as target via icon click")
+                && l.Contains("verified")
+                && l.Contains("recIndex=1"));
+        }
+
+        [Theory]
+        [InlineData((int)GhostMapPresence.GhostTargetVerificationStatus.NullTarget, "FlightGlobals.fetch.VesselTarget=null")]
+        [InlineData((int)GhostMapPresence.GhostTargetVerificationStatus.CurrentMainBody, "target-driver-celestialBody-is-current-main-body body=Kerbin")]
+        [InlineData((int)GhostMapPresence.GhostTargetVerificationStatus.WrongVessel, "target-vessel-mismatch ghostPid=100 targetPid=200")]
+        [InlineData((int)GhostMapPresence.GhostTargetVerificationStatus.WrongObject, "target-is-not-the-ghost-vessel")]
+        public void TargetVerification_Rejected_DoesNotLogSetAsTargetSuccess(
+            int statusValue,
+            string reason)
+        {
+            var status = (GhostMapPresence.GhostTargetVerificationStatus)statusValue;
+            bool accepted = GhostMapPresence.LogGhostTargetVerificationForTesting(
+                "Ghost: Kerbal X",
+                1,
+                "icon click",
+                status,
+                reason,
+                "final-target-state");
+
+            Assert.False(accepted);
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("set as target via icon click"));
+            Assert.Contains(logLines, l =>
+                l.Contains("[WARN]")
+                && l.Contains("[GhostMap]")
+                && l.Contains("target rejected via icon click")
+                && l.Contains("status=" + status)
+                && l.Contains(reason)
+                && l.Contains("final-target-state"));
+        }
+    }
+}

--- a/Source/Parsek.Tests/GhostMapTargetingTests.cs
+++ b/Source/Parsek.Tests/GhostMapTargetingTests.cs
@@ -46,8 +46,10 @@ namespace Parsek.Tests
         }
 
         [Theory]
+        [InlineData((int)GhostMapPresence.GhostTargetVerificationStatus.MissingFlightGlobals, "FlightGlobals.fetch=null")]
         [InlineData((int)GhostMapPresence.GhostTargetVerificationStatus.NullTarget, "FlightGlobals.fetch.VesselTarget=null")]
         [InlineData((int)GhostMapPresence.GhostTargetVerificationStatus.CurrentMainBody, "target-driver-celestialBody-is-current-main-body body=Kerbin")]
+        [InlineData((int)GhostMapPresence.GhostTargetVerificationStatus.ParentBody, "target-driver-celestialBody-is-parent-body targetBody=Sun currentBody=Kerbin")]
         [InlineData((int)GhostMapPresence.GhostTargetVerificationStatus.WrongVessel, "target-vessel-mismatch ghostPid=100 targetPid=200")]
         [InlineData((int)GhostMapPresence.GhostTargetVerificationStatus.WrongObject, "target-is-not-the-ghost-vessel")]
         public void TargetVerification_Rejected_DoesNotLogSetAsTargetSuccess(
@@ -73,6 +75,29 @@ namespace Parsek.Tests
                 && l.Contains("status=" + status)
                 && l.Contains(reason)
                 && l.Contains("final-target-state"));
+        }
+
+        [Fact]
+        public void TargetVerification_Unavailable_DoesNotLogSetAsTargetSuccess()
+        {
+            bool accepted = GhostMapPresence.LogGhostTargetVerificationForTesting(
+                "Ghost: Kerbal X",
+                1,
+                "icon click",
+                GhostMapPresence.GhostTargetVerificationStatus.VerificationUnavailable,
+                "ParsekScenario.Instance=null; post-validation target state cannot be observed",
+                "unverified-target-state");
+
+            Assert.False(accepted);
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("set as target via icon click"));
+            Assert.Contains(logLines, l =>
+                l.Contains("[WARN]")
+                && l.Contains("[GhostMap]")
+                && l.Contains("target verification unavailable via icon click")
+                && l.Contains("status=VerificationUnavailable")
+                && l.Contains("ParsekScenario.Instance=null")
+                && l.Contains("unverified-target-state"));
         }
     }
 }

--- a/Source/Parsek/GhostMapPresence.cs
+++ b/Source/Parsek/GhostMapPresence.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection;
@@ -51,6 +52,17 @@ namespace Parsek
                 WasNavigationTarget = wasNavigationTarget;
                 WasMapFocus = wasMapFocus;
             }
+        }
+
+        internal enum GhostTargetVerificationStatus
+        {
+            Accepted,
+            MissingFlightGlobals,
+            NullTarget,
+            CurrentMainBody,
+            ParentBody,
+            WrongVessel,
+            WrongObject
         }
 
         private const string Tag = "GhostMap";
@@ -781,7 +793,7 @@ namespace Parsek
                 lifecycleCreatedThisTick++;
 
                 Vector3d worldPos = vessel.GetWorldPos3D();
-                string body = vessel.orbitDriver?.celestialBody?.name ?? traj.TerminalOrbitBody;
+                string body = vessel.orbitDriver?.referenceBody?.name ?? traj.TerminalOrbitBody;
 
                 var done = NewDecisionFields("create-chain-done");
                 done.RecordingId = traj.RecordingId;
@@ -937,6 +949,440 @@ namespace Parsek
             bool isTrackingStationScene)
         {
             return mapViewEnabled || isTrackingStationScene;
+        }
+
+        internal static void SetGhostMapNavigationTarget(
+            Vessel vessel,
+            int recordingIndex,
+            string source)
+        {
+            string safeSource = string.IsNullOrEmpty(source) ? "unknown" : source;
+            string vesselName = vessel != null ? (vessel.vesselName ?? "Ghost") : "Ghost";
+            if (vessel == null)
+            {
+                LogGhostTargetVerificationOutcome(
+                    vesselName,
+                    recordingIndex,
+                    safeSource,
+                    GhostTargetVerificationStatus.WrongObject,
+                    "ghost-vessel-null",
+                    "target-request-vessel=null",
+                    "(not-captured)",
+                    "(not-captured)",
+                    "preflight");
+                return;
+            }
+
+            if (FlightGlobals.fetch == null)
+            {
+                LogGhostTargetVerificationOutcome(
+                    vesselName,
+                    recordingIndex,
+                    safeSource,
+                    GhostTargetVerificationStatus.MissingFlightGlobals,
+                    "FlightGlobals.fetch=null",
+                    CaptureGhostTargetState(vessel, "missing-flightglobals"),
+                    "(not-captured)",
+                    "(not-captured)",
+                    "preflight");
+                return;
+            }
+
+            NormalizeGhostOrbitDriverTargetIdentity(vessel, safeSource);
+
+            string before = CaptureGhostTargetState(vessel, "before");
+            ParsekLog.Verbose(Tag,
+                string.Format(ic,
+                    "Ghost target request via {0}: recIndex={1} ghost='{2}' before=[{3}]",
+                    safeSource,
+                    recordingIndex,
+                    vesselName,
+                    before));
+
+            FlightGlobals.fetch.SetVesselTarget(vessel, overrideInputLock: true);
+
+            string immediate = CaptureGhostTargetState(vessel, "after-set");
+            ParsekLog.Verbose(Tag,
+                string.Format(ic,
+                    "Ghost target request via {0}: recIndex={1} ghost='{2}' afterSet=[{3}]",
+                    safeSource,
+                    recordingIndex,
+                    vesselName,
+                    immediate));
+
+            ParsekScenario host = ParsekScenario.Instance;
+            if (host != null)
+            {
+                host.StartCoroutine(VerifyGhostMapNavigationTargetAfterKspValidation(
+                    vessel,
+                    recordingIndex,
+                    safeSource,
+                    vesselName,
+                    before,
+                    immediate));
+                return;
+            }
+
+            GhostTargetVerificationStatus status = EvaluateGhostTargetVerification(vessel, out string reason);
+            LogGhostTargetVerificationOutcome(
+                vesselName,
+                recordingIndex,
+                safeSource,
+                status,
+                reason,
+                CaptureGhostTargetState(vessel, "immediate-no-coroutine"),
+                before,
+                immediate,
+                "immediate-no-coroutine");
+        }
+
+        private static IEnumerator VerifyGhostMapNavigationTargetAfterKspValidation(
+            Vessel vessel,
+            int recordingIndex,
+            string source,
+            string vesselName,
+            string before,
+            string immediate)
+        {
+            yield return null;
+            yield return null;
+
+            GhostTargetVerificationStatus status = EvaluateGhostTargetVerification(vessel, out string reason);
+            string final = CaptureGhostTargetState(vessel, "after-ksp-validation");
+            LogGhostTargetVerificationOutcome(
+                vesselName,
+                recordingIndex,
+                source,
+                status,
+                reason,
+                final,
+                before,
+                immediate,
+                "after-ksp-validation");
+        }
+
+        internal static bool LogGhostTargetVerificationForTesting(
+            string vesselName,
+            int recordingIndex,
+            string source,
+            GhostTargetVerificationStatus status,
+            string reason,
+            string finalState)
+        {
+            return LogGhostTargetVerificationOutcome(
+                vesselName,
+                recordingIndex,
+                source,
+                status,
+                reason,
+                finalState,
+                "(test-before)",
+                "(test-immediate)",
+                "test");
+        }
+
+        private static bool LogGhostTargetVerificationOutcome(
+            string vesselName,
+            int recordingIndex,
+            string source,
+            GhostTargetVerificationStatus status,
+            string reason,
+            string finalState,
+            string beforeState,
+            string immediateState,
+            string phase)
+        {
+            string safeName = string.IsNullOrEmpty(vesselName) ? "Ghost" : vesselName;
+            string safeSource = string.IsNullOrEmpty(source) ? "unknown" : source;
+            string safeReason = string.IsNullOrEmpty(reason) ? "(none)" : reason;
+            string safeFinal = string.IsNullOrEmpty(finalState) ? "(none)" : finalState;
+
+            if (status == GhostTargetVerificationStatus.Accepted)
+            {
+                ParsekLog.Info(Tag,
+                    string.Format(ic,
+                        "Ghost '{0}' set as target via {1} (verified {2}; recIndex={3}; final=[{4}])",
+                        safeName,
+                        safeSource,
+                        phase ?? "(unknown)",
+                        recordingIndex,
+                        safeFinal));
+                return true;
+            }
+
+            ParsekLog.Warn(Tag,
+                string.Format(ic,
+                    "Ghost '{0}' target rejected via {1}: status={2} reason={3} recIndex={4} phase={5} before=[{6}] immediate=[{7}] final=[{8}]",
+                    safeName,
+                    safeSource,
+                    status,
+                    safeReason,
+                    recordingIndex,
+                    phase ?? "(unknown)",
+                    string.IsNullOrEmpty(beforeState) ? "(none)" : beforeState,
+                    string.IsNullOrEmpty(immediateState) ? "(none)" : immediateState,
+                    safeFinal));
+            return false;
+        }
+
+        private static GhostTargetVerificationStatus EvaluateGhostTargetVerification(
+            Vessel ghost,
+            out string reason)
+        {
+            reason = null;
+            if (FlightGlobals.fetch == null)
+            {
+                reason = "FlightGlobals.fetch=null";
+                return GhostTargetVerificationStatus.MissingFlightGlobals;
+            }
+
+            ITargetable target = FlightGlobals.fetch.VesselTarget;
+            if (target == null)
+            {
+                reason = "FlightGlobals.fetch.VesselTarget=null";
+                return GhostTargetVerificationStatus.NullTarget;
+            }
+
+            Vessel targetVessel = SafeGetTargetVessel(target);
+            if (targetVessel != null)
+            {
+                if (IsSameVessel(targetVessel, ghost))
+                {
+                    reason = "target-vessel-matches-ghost";
+                    return GhostTargetVerificationStatus.Accepted;
+                }
+
+                reason = string.Format(ic,
+                    "target-vessel-mismatch ghostPid={0} targetPid={1} targetName=\"{2}\"",
+                    ghost != null ? ghost.persistentId : 0u,
+                    targetVessel.persistentId,
+                    targetVessel.vesselName ?? "(null)");
+                return GhostTargetVerificationStatus.WrongVessel;
+            }
+
+            OrbitDriver targetDriver = SafeGetTargetOrbitDriver(target);
+            CelestialBody targetBody = targetDriver != null ? targetDriver.celestialBody : null;
+            CelestialBody currentBody = ResolveCurrentMainBody();
+            if (targetBody != null)
+            {
+                if (IsSameBody(targetBody, currentBody))
+                {
+                    reason = string.Format(ic,
+                        "target-driver-celestialBody-is-current-main-body body={0}",
+                        targetBody.name ?? "(null)");
+                    return GhostTargetVerificationStatus.CurrentMainBody;
+                }
+
+                if (currentBody != null && currentBody.HasParent(targetBody))
+                {
+                    reason = string.Format(ic,
+                        "target-driver-celestialBody-is-parent-body targetBody={0} currentBody={1}",
+                        targetBody.name ?? "(null)",
+                        currentBody.name ?? "(null)");
+                    return GhostTargetVerificationStatus.ParentBody;
+                }
+            }
+
+            reason = "target-is-not-the-ghost-vessel: " + DescribeTargetable(target);
+            return GhostTargetVerificationStatus.WrongObject;
+        }
+
+        private static string CaptureGhostTargetState(Vessel ghost, string phase)
+        {
+            FlightGlobals globals = FlightGlobals.fetch;
+            Vessel active = globals != null ? FlightGlobals.ActiveVessel : null;
+            CelestialBody currentBody = ResolveCurrentMainBody();
+            string mode = globals != null
+                ? globals.vesselTargetMode.ToString()
+                : "(no-flightglobals)";
+
+            return string.Format(ic,
+                "phase={0} mode={1} currentMainBody={2} active={3} target={4} activeTargetObject={5} ghost={6} ghostRegistered={7}",
+                phase ?? "(null)",
+                mode,
+                currentBody != null ? (currentBody.name ?? "(unnamed-body)") : "(null)",
+                DescribeVessel(active),
+                globals != null ? DescribeTargetable(globals.VesselTarget) : "(no-flightglobals)",
+                active != null ? DescribeTargetable(active.targetObject) : "(no-active-vessel)",
+                DescribeVessel(ghost) + " " + BuildGhostOrbitDriverIdentity(ghost),
+                IsVesselRegistered(ghost));
+        }
+
+        internal static void NormalizeGhostOrbitDriverTargetIdentity(
+            Vessel vessel,
+            string context)
+        {
+            if (vessel == null || vessel.orbitDriver == null)
+                return;
+
+            OrbitDriver driver = vessel.orbitDriver;
+            bool changed = false;
+            string before = BuildGhostOrbitDriverIdentity(vessel);
+
+            if (!IsSameVessel(driver.vessel, vessel))
+            {
+                driver.vessel = vessel;
+                changed = true;
+            }
+
+            if (driver.celestialBody != null)
+            {
+                driver.celestialBody = null;
+                changed = true;
+            }
+
+            if (changed)
+            {
+                ParsekLog.Verbose(Tag,
+                    string.Format(ic,
+                        "Normalized ghost target identity for {0}: before=[{1}] after=[{2}]",
+                        string.IsNullOrEmpty(context) ? "(none)" : context,
+                        before,
+                        BuildGhostOrbitDriverIdentity(vessel)));
+            }
+        }
+
+        internal static string BuildGhostOrbitDriverIdentity(Vessel vessel)
+        {
+            if (vessel == null)
+                return "driver=(ghost-null)";
+            OrbitDriver driver = vessel.orbitDriver;
+            if (driver == null)
+                return "driver=(null)";
+
+            string driverVessel = driver.vessel != null
+                ? string.Format(ic,
+                    "{0}/pid={1}",
+                    driver.vessel.vesselName ?? "(null)",
+                    driver.vessel.persistentId)
+                : "(null)";
+            string driverBody = driver.celestialBody != null
+                ? (driver.celestialBody.name ?? "(unnamed-body)")
+                : "(null)";
+            string referenceBody = driver.referenceBody != null
+                ? (driver.referenceBody.name ?? "(unnamed-body)")
+                : "(null)";
+
+            return string.Format(ic,
+                "driverVessel={0} driverCelestialBody={1} referenceBody={2} orbit={3} mapObj={4} orbitRenderer={5}",
+                driverVessel,
+                driverBody,
+                referenceBody,
+                driver.orbit != null,
+                vessel.mapObject != null,
+                vessel.orbitRenderer != null);
+        }
+
+        private static string DescribeTargetable(ITargetable target)
+        {
+            if (target == null)
+                return "null";
+
+            string typeName = target.GetType().Name;
+            Vessel vessel = SafeGetTargetVessel(target);
+            OrbitDriver driver = SafeGetTargetOrbitDriver(target);
+            string name = SafeGetTargetName(target);
+            string vesselText = vessel != null
+                ? DescribeVessel(vessel)
+                : "(null)";
+            string driverVessel = driver != null && driver.vessel != null
+                ? DescribeVessel(driver.vessel)
+                : "(null)";
+            string driverBody = driver != null && driver.celestialBody != null
+                ? (driver.celestialBody.name ?? "(unnamed-body)")
+                : "(null)";
+            string referenceBody = driver != null && driver.referenceBody != null
+                ? (driver.referenceBody.name ?? "(unnamed-body)")
+                : "(null)";
+
+            return string.Format(ic,
+                "type={0} name=\"{1}\" vessel={2} driverVessel={3} driverCelestialBody={4} referenceBody={5} transform={6}",
+                typeName,
+                name ?? "(null)",
+                vesselText,
+                driverVessel,
+                driverBody,
+                referenceBody,
+                SafeHasTransform(target));
+        }
+
+        private static string DescribeVessel(Vessel vessel)
+        {
+            if (vessel == null)
+                return "null";
+            return string.Format(ic,
+                "\"{0}\"/pid={1}/ghost={2}",
+                vessel.vesselName ?? "(null)",
+                vessel.persistentId,
+                IsGhostMapVessel(vessel.persistentId));
+        }
+
+        private static Vessel SafeGetTargetVessel(ITargetable target)
+        {
+            if (target == null) return null;
+            try { return target.GetVessel(); }
+            catch { return null; }
+        }
+
+        private static OrbitDriver SafeGetTargetOrbitDriver(ITargetable target)
+        {
+            if (target == null) return null;
+            try { return target.GetOrbitDriver(); }
+            catch { return null; }
+        }
+
+        private static string SafeGetTargetName(ITargetable target)
+        {
+            if (target == null) return null;
+            try { return target.GetName(); }
+            catch { return null; }
+        }
+
+        private static bool SafeHasTransform(ITargetable target)
+        {
+            if (target == null) return false;
+            try { return target.GetTransform() != null; }
+            catch { return false; }
+        }
+
+        private static CelestialBody ResolveCurrentMainBody()
+        {
+            if (FlightGlobals.currentMainBody != null)
+                return FlightGlobals.currentMainBody;
+            if (FlightGlobals.fetch == null)
+                return null;
+            Vessel active = FlightGlobals.ActiveVessel;
+            if (active != null && active.mainBody != null)
+                return active.mainBody;
+            return null;
+        }
+
+        internal static bool IsVesselRegistered(Vessel vessel)
+        {
+            if (vessel == null || FlightGlobals.fetch == null || FlightGlobals.Vessels == null)
+                return false;
+            for (int i = 0; i < FlightGlobals.Vessels.Count; i++)
+            {
+                if (IsSameVessel(FlightGlobals.Vessels[i], vessel))
+                    return true;
+            }
+            return false;
+        }
+
+        private static bool IsSameVessel(Vessel a, Vessel b)
+        {
+            if (a == null || b == null)
+                return false;
+            return ReferenceEquals(a, b)
+                || (a.persistentId != 0u && a.persistentId == b.persistentId);
+        }
+
+        private static bool IsSameBody(CelestialBody a, CelestialBody b)
+        {
+            if (a == null || b == null)
+                return false;
+            return ReferenceEquals(a, b)
+                || string.Equals(a.name, b.name, StringComparison.Ordinal);
         }
 
         private static TrackingStationSpawnHandoffState CaptureTrackingStationSpawnHandoffState(
@@ -1269,7 +1715,7 @@ namespace Parsek
                 lifecycleCreatedThisTick++;
 
                 Vector3d worldPos = vessel.GetWorldPos3D();
-                string body = vessel.orbitDriver?.celestialBody?.name ?? traj.TerminalOrbitBody;
+                string body = vessel.orbitDriver?.referenceBody?.name ?? traj.TerminalOrbitBody;
 
                 var done = NewDecisionFields("create-terminal-orbit-done");
                 done.RecordingId = traj.RecordingId;
@@ -3206,11 +3652,12 @@ namespace Parsek
                 }
             }
 
-            // SOI transition handling (same pattern as ApplyOrbitToVessel)
-            bool soiChanged = vessel.orbitDriver.celestialBody != body;
+            // SOI transition handling (same pattern as ApplyOrbitToVessel).
+            // OrbitDriver.celestialBody is only for real CelestialBody drivers;
+            // vessel targets must keep identity in OrbitDriver.vessel.
+            bool soiChanged = vessel.orbitDriver.referenceBody != body;
             if (soiChanged)
             {
-                vessel.orbitDriver.celestialBody = body;
                 var soi = NewDecisionFields("update-state-vector-soi-change");
                 soi.RecordingId = traj?.RecordingId;
                 soi.RecordingIndex = recordingIndex;
@@ -3228,6 +3675,7 @@ namespace Parsek
 
             vessel.orbitDriver.orbit.UpdateFromStateVectors(worldPos, vel, body, ut);
             vessel.orbitDriver.updateFromParameters();
+            NormalizeGhostOrbitDriverTargetIdentity(vessel, "update-state-vector");
 
             if (soiChanged && vessel.orbitRenderer != null)
             {
@@ -3296,13 +3744,12 @@ namespace Parsek
                 return;
             }
 
-            // SOI transition: update celestialBody BEFORE SetOrbit so that
-            // orbitDriver and orbit.referenceBody are consistent when
-            // updateFromParameters recalculates the orbit line (#189).
-            bool soiChanged = vessel.orbitDriver.celestialBody != body;
+            // SOI transition: compare the Orbit reference body. OrbitDriver.celestialBody
+            // must stay null for vessel targets; stock OrbitTargeter treats a non-null
+            // celestialBody on a target driver as a body target and drops same-body ghosts.
+            bool soiChanged = vessel.orbitDriver.referenceBody != body;
             if (soiChanged)
             {
-                vessel.orbitDriver.celestialBody = body;
                 ParsekLog.Info(Tag,
                     string.Format(ic, "SOI change for {0} — new body={1}", logContext, body.name));
             }
@@ -3321,6 +3768,7 @@ namespace Parsek
                 body);
 
             vessel.orbitDriver.updateFromParameters();
+            NormalizeGhostOrbitDriverTargetIdentity(vessel, logContext);
 
             // Store orbit segment time bounds for arc clipping (GhostOrbitArcPatch)
             ghostOrbitBounds[vessel.persistentId] = (segment.startUT, segment.endUT);
@@ -4517,6 +4965,7 @@ namespace Parsek
 
                 // Log creation + OrbitDriver state for diagnostics (#172)
                 Vessel v = pv.vesselRef;
+                NormalizeGhostOrbitDriverTargetIdentity(v, logContext);
                 string driverState = "no-orbitDriver";
                 if (v.orbitDriver != null)
                 {
@@ -4524,11 +4973,13 @@ namespace Parsek
 
                     driverState = string.Format(ic,
                         "updateMode={0} sma={1:F0} ecc={2:F6} inc={3:F4} " +
-                        "argPe={4:F4} mna={5:F6} epoch={6:F1} vesselPos=({7:F1},{8:F1},{9:F1})",
+                        "argPe={4:F4} mna={5:F6} epoch={6:F1} vesselPos=({7:F1},{8:F1},{9:F1}) {10} registered={11}",
                         v.orbitDriver.updateMode,
                         drv.semiMajorAxis, drv.eccentricity, drv.inclination,
                         drv.argumentOfPeriapsis, drv.meanAnomalyAtEpoch, drv.epoch,
-                        v.GetWorldPos3D().x, v.GetWorldPos3D().y, v.GetWorldPos3D().z);
+                        v.GetWorldPos3D().x, v.GetWorldPos3D().y, v.GetWorldPos3D().z,
+                        BuildGhostOrbitDriverIdentity(v),
+                        IsVesselRegistered(v));
                 }
 
                 // Ensure OrbitRenderer is enabled — in Tracking Station, pv.Load()

--- a/Source/Parsek/GhostMapPresence.cs
+++ b/Source/Parsek/GhostMapPresence.cs
@@ -57,6 +57,7 @@ namespace Parsek
         internal enum GhostTargetVerificationStatus
         {
             Accepted,
+            VerificationUnavailable,
             MissingFlightGlobals,
             NullTarget,
             CurrentMainBody,
@@ -67,6 +68,7 @@ namespace Parsek
 
         private const string Tag = "GhostMap";
         private static readonly CultureInfo ic = CultureInfo.InvariantCulture;
+        private static long ghostTargetRequestSequence;
 
         // -----------------------------------------------------------------
         // Observability (#582 follow-up): every create/position/update/destroy
@@ -951,6 +953,12 @@ namespace Parsek
             return mapViewEnabled || isTrackingStationScene;
         }
 
+        /// <summary>
+        /// Set a ghost as KSP's navigation target and log success only after
+        /// stock target validation has had frames to reject invalid targetables.
+        /// <paramref name="recordingIndex"/> is diagnostic-only; callers may pass
+        /// -1 when a selection path cannot resolve the recording index.
+        /// </summary>
         internal static void SetGhostMapNavigationTarget(
             Vessel vessel,
             int recordingIndex,
@@ -989,12 +997,18 @@ namespace Parsek
             }
 
             NormalizeGhostOrbitDriverTargetIdentity(vessel, safeSource);
+            long requestId;
+            unchecked
+            {
+                requestId = ++ghostTargetRequestSequence;
+            }
 
             string before = CaptureGhostTargetState(vessel, "before");
             ParsekLog.Verbose(Tag,
                 string.Format(ic,
-                    "Ghost target request via {0}: recIndex={1} ghost='{2}' before=[{3}]",
+                    "Ghost target request via {0}: requestId={1} recIndex={2} ghost='{3}' before=[{4}]",
                     safeSource,
+                    requestId,
                     recordingIndex,
                     vesselName,
                     before));
@@ -1004,8 +1018,9 @@ namespace Parsek
             string immediate = CaptureGhostTargetState(vessel, "after-set");
             ParsekLog.Verbose(Tag,
                 string.Format(ic,
-                    "Ghost target request via {0}: recIndex={1} ghost='{2}' afterSet=[{3}]",
+                    "Ghost target request via {0}: requestId={1} recIndex={2} ghost='{3}' afterSet=[{4}]",
                     safeSource,
+                    requestId,
                     recordingIndex,
                     vesselName,
                     immediate));
@@ -1019,21 +1034,21 @@ namespace Parsek
                     safeSource,
                     vesselName,
                     before,
-                    immediate));
+                    immediate,
+                    requestId));
                 return;
             }
 
-            GhostTargetVerificationStatus status = EvaluateGhostTargetVerification(vessel, out string reason);
             LogGhostTargetVerificationOutcome(
                 vesselName,
                 recordingIndex,
                 safeSource,
-                status,
-                reason,
-                CaptureGhostTargetState(vessel, "immediate-no-coroutine"),
+                GhostTargetVerificationStatus.VerificationUnavailable,
+                "ParsekScenario.Instance=null; post-validation target state cannot be observed",
+                CaptureGhostTargetState(vessel, "unverified-no-coroutine"),
                 before,
                 immediate,
-                "immediate-no-coroutine");
+                "unverified-no-coroutine");
         }
 
         private static IEnumerator VerifyGhostMapNavigationTargetAfterKspValidation(
@@ -1042,10 +1057,24 @@ namespace Parsek
             string source,
             string vesselName,
             string before,
-            string immediate)
+            string immediate,
+            long requestId)
         {
             yield return null;
             yield return null;
+
+            if (requestId != ghostTargetRequestSequence)
+            {
+                ParsekLog.Verbose(Tag,
+                    string.Format(ic,
+                        "Ghost target verification superseded via {0}: requestId={1} latestRequestId={2} recIndex={3} ghost='{4}'",
+                        source ?? "unknown",
+                        requestId,
+                        ghostTargetRequestSequence,
+                        recordingIndex,
+                        vesselName ?? "Ghost"));
+                yield break;
+            }
 
             GhostTargetVerificationStatus status = EvaluateGhostTargetVerification(vessel, out string reason);
             string final = CaptureGhostTargetState(vessel, "after-ksp-validation");
@@ -1108,6 +1137,23 @@ namespace Parsek
                         recordingIndex,
                         safeFinal));
                 return true;
+            }
+
+            if (status == GhostTargetVerificationStatus.VerificationUnavailable)
+            {
+                ParsekLog.Warn(Tag,
+                    string.Format(ic,
+                        "Ghost '{0}' target verification unavailable via {1}: status={2} reason={3} recIndex={4} phase={5} before=[{6}] immediate=[{7}] final=[{8}]",
+                        safeName,
+                        safeSource,
+                        status,
+                        safeReason,
+                        recordingIndex,
+                        phase ?? "(unknown)",
+                        string.IsNullOrEmpty(beforeState) ? "(none)" : beforeState,
+                        string.IsNullOrEmpty(immediateState) ? "(none)" : immediateState,
+                        safeFinal));
+                return false;
             }
 
             ParsekLog.Warn(Tag,
@@ -4557,6 +4603,7 @@ namespace Parsek
             lifecycleCreatedThisTick = 0;
             lifecycleDestroyedThisTick = 0;
             lifecycleUpdatedThisTick = 0;
+            ghostTargetRequestSequence = 0;
         }
 
         /// <summary>
@@ -4575,6 +4622,8 @@ namespace Parsek
         /// </summary>
         internal static void ResetBetweenTestRuns(string reason)
         {
+            ghostTargetRequestSequence = 0;
+
             int pidCount = ghostMapVesselPids.Count;
             int suppressedIconCount = ghostsWithSuppressedIcon.Count;
             int orbitBoundsCount = ghostOrbitBounds.Count;

--- a/Source/Parsek/InGameTests/RuntimeTests.cs
+++ b/Source/Parsek/InGameTests/RuntimeTests.cs
@@ -5476,6 +5476,101 @@ namespace Parsek.InGameTests
             }
         }
 
+        [InGameTest(Category = "MapPresence", Scene = GameScenes.FLIGHT,
+            Description = "#586: same-body ghost map vessels keep vessel target identity and survive stock SetVesselTarget validation")]
+        public IEnumerator GhostMapVesselTargeting_SyntheticSameBodyGhost_Sticks()
+        {
+            if (FlightGlobals.fetch == null || FlightGlobals.ActiveVessel == null)
+            {
+                InGameAssert.Skip("FlightGlobals or active vessel is unavailable");
+                yield break;
+            }
+
+            Vessel active = FlightGlobals.ActiveVessel;
+            if (active.mainBody == null)
+            {
+                InGameAssert.Skip("Active vessel main body is unavailable");
+                yield break;
+            }
+
+            int recordingIndex = 586000 + Time.frameCount;
+            Recording rec = BuildSyntheticFlightTargetRecording(active, Planetarium.GetUniversalTime());
+            Vessel ghost = null;
+            System.Action<string> priorObserver = null;
+            bool observerInstalled = false;
+            try
+            {
+                ghost = GhostMapPresence.CreateGhostVesselForRecording(recordingIndex, rec);
+                InGameAssert.IsNotNull(ghost,
+                    "Synthetic flight ghost should be created for targeting canary");
+
+                yield return null;
+                yield return null;
+
+                InGameAssert.IsTrue(ghost.orbitDriver != null && ghost.orbitDriver.orbit != null,
+                    "Synthetic flight ghost should have an OrbitDriver with an orbit");
+                InGameAssert.IsTrue(ghost.orbitDriver.vessel == ghost,
+                    "Synthetic flight ghost OrbitDriver.vessel should point at the ghost vessel");
+                InGameAssert.IsTrue(ghost.orbitDriver.celestialBody == null,
+                    "Synthetic flight ghost OrbitDriver.celestialBody must stay null so stock targeting treats it as a vessel");
+                InGameAssert.IsTrue(GhostMapPresence.IsVesselRegistered(ghost),
+                    "Synthetic flight ghost should be registered in FlightGlobals.Vessels");
+                InGameAssert.AreEqual(active.mainBody.name, ghost.orbitDriver.referenceBody.name,
+                    "Synthetic flight ghost should orbit the active vessel's current main body");
+
+                var captured = new List<string>();
+                priorObserver = ParsekLog.TestObserverForTesting;
+                ParsekLog.TestObserverForTesting = line => { captured.Add(line); priorObserver?.Invoke(line); };
+                observerInstalled = true;
+                GhostMapPresence.SetGhostMapNavigationTarget(
+                    ghost,
+                    recordingIndex,
+                    "ingame targeting canary");
+                yield return null;
+                yield return null;
+                yield return null;
+                ParsekLog.TestObserverForTesting = priorObserver;
+                observerInstalled = false;
+
+                Vessel targetVessel = FlightGlobals.fetch.VesselTarget != null
+                    ? FlightGlobals.fetch.VesselTarget.GetVessel()
+                    : null;
+                InGameAssert.IsNotNull(targetVessel,
+                    "Stock SetVesselTarget should still have a vessel target after validation frames");
+                InGameAssert.AreEqual(ghost.persistentId, targetVessel.persistentId,
+                    "Production SetGhostMapNavigationTarget should retain the synthetic ghost vessel target");
+                InGameAssert.IsTrue(captured.Any(line =>
+                        line.Contains("[GhostMap]")
+                        && line.Contains("set as target via ingame targeting canary")
+                        && line.Contains("verified")),
+                    "Production SetGhostMapNavigationTarget should emit verified success only after validation");
+                InGameAssert.IsFalse(captured.Any(line =>
+                        line.Contains("[GhostMap]")
+                        && line.Contains("target rejected via ingame targeting canary")),
+                    "Production SetGhostMapNavigationTarget should not reject the synthetic same-body ghost");
+
+                ParsekLog.Info("TestRunner",
+                    string.Format(CultureInfo.InvariantCulture,
+                        "GhostMapVesselTargeting_SyntheticSameBodyGhost_Sticks: activePid={0} ghostPid={1} body={2}",
+                        active.persistentId,
+                        ghost.persistentId,
+                        active.mainBody.name));
+            }
+            finally
+            {
+                if (observerInstalled)
+                    ParsekLog.TestObserverForTesting = priorObserver;
+                if (FlightGlobals.fetch != null
+                    && FlightGlobals.fetch.VesselTarget != null
+                    && ghost != null
+                    && FlightGlobals.fetch.VesselTarget.GetVessel() == ghost)
+                {
+                    FlightGlobals.fetch.SetVesselTarget(null, overrideInputLock: true);
+                }
+                GhostMapPresence.RemoveGhostVesselForRecording(recordingIndex, "ingame-targeting-canary-cleanup");
+            }
+        }
+
         [InGameTest(Category = "MapPresence",
             Description = "Recordings with antenna specs produce positive relay power")]
         public void AntennaSpecsProduceRelayPower()
@@ -5501,6 +5596,77 @@ namespace Parsek.InGameTests
 
             ParsekLog.Info("TestRunner",
                 $"Antenna specs: {withAntennas} recordings with antennas, {withRelayPower} with positive combined power");
+        }
+
+        private static Recording BuildSyntheticFlightTargetRecording(Vessel active, double currentUT)
+        {
+            CelestialBody body = active.mainBody;
+            double startUT = currentUT - 10.0;
+            double endUT = currentUT + 600.0;
+            double semiMajorAxis = System.Math.Max(
+                body.Radius + 100000.0,
+                active.orbit != null && active.orbit.semiMajorAxis > 0.0
+                    ? active.orbit.semiMajorAxis + 5000.0
+                    : body.Radius + 100000.0);
+
+            var rec = new Recording
+            {
+                RecordingId = "flight-target-runtime-" + System.Guid.NewGuid().ToString("N"),
+                VesselName = "Parsek Flight Target Canary",
+                TerminalStateValue = TerminalState.Orbiting,
+                EndpointPhase = RecordingEndpointPhase.OrbitSegment,
+                EndpointBodyName = body.name,
+                TerminalOrbitBody = body.name,
+                TerminalOrbitSemiMajorAxis = semiMajorAxis,
+                TerminalOrbitEccentricity = 0.001,
+                TerminalOrbitInclination = active.orbit != null ? active.orbit.inclination : 0.0,
+                TerminalOrbitLAN = active.orbit != null ? active.orbit.LAN : 0.0,
+                TerminalOrbitArgumentOfPeriapsis = active.orbit != null ? active.orbit.argumentOfPeriapsis : 0.0,
+                TerminalOrbitMeanAnomalyAtEpoch = 0.0,
+                TerminalOrbitEpoch = startUT,
+                ExplicitStartUT = startUT,
+                ExplicitEndUT = endUT,
+                PlaybackEnabled = true,
+            };
+
+            rec.Points.Add(new TrajectoryPoint
+            {
+                ut = startUT,
+                latitude = active.latitude,
+                longitude = active.longitude,
+                altitude = 100000.0,
+                rotation = Quaternion.identity,
+                velocity = new Vector3(0f, 2300f, 0f),
+                bodyName = body.name,
+            });
+            rec.Points.Add(new TrajectoryPoint
+            {
+                ut = endUT,
+                latitude = active.latitude,
+                longitude = active.longitude + 1.0,
+                altitude = 100000.0,
+                rotation = Quaternion.identity,
+                velocity = new Vector3(0f, 2300f, 0f),
+                bodyName = body.name,
+            });
+            rec.OrbitSegments.Add(new OrbitSegment
+            {
+                startUT = startUT,
+                endUT = endUT,
+                inclination = rec.TerminalOrbitInclination,
+                eccentricity = rec.TerminalOrbitEccentricity,
+                semiMajorAxis = rec.TerminalOrbitSemiMajorAxis,
+                longitudeOfAscendingNode = rec.TerminalOrbitLAN,
+                argumentOfPeriapsis = rec.TerminalOrbitArgumentOfPeriapsis,
+                meanAnomalyAtEpoch = rec.TerminalOrbitMeanAnomalyAtEpoch,
+                epoch = rec.TerminalOrbitEpoch,
+                bodyName = body.name,
+                isPredicted = false,
+                orbitalFrameRotation = Quaternion.identity,
+                angularVelocity = Vector3.zero,
+            });
+            rec.MarkFilesDirty();
+            return rec;
         }
     }
 

--- a/Source/Parsek/ParsekTrackingStation.cs
+++ b/Source/Parsek/ParsekTrackingStation.cs
@@ -692,16 +692,15 @@ namespace Parsek
 
         private static void TargetSelectedGhost(Vessel vessel)
         {
-            if (vessel == null || FlightGlobals.fetch == null)
+            if (vessel == null)
             {
                 ParsekLog.Warn(Tag,
-                    $"Target selected ghost failed: vessel={vessel != null} flightGlobals={FlightGlobals.fetch != null}");
+                    "Target selected ghost failed: vessel=False");
                 return;
             }
 
-            FlightGlobals.fetch.SetVesselTarget(vessel);
-            ParsekLog.Info(Tag,
-                $"Set Tracking Station ghost '{vessel.vesselName}' pid={vessel.persistentId} as target");
+            int recIndex = GhostMapPresence.FindRecordingIndexByVesselPid(vessel.persistentId);
+            GhostMapPresence.SetGhostMapNavigationTarget(vessel, recIndex, "tracking station panel");
         }
 
         private void ToggleSelectedRecordingDetails(TrackingStationGhostSelectionInfo selection)

--- a/Source/Parsek/Patches/GhostVesselLoadPatch.cs
+++ b/Source/Parsek/Patches/GhostVesselLoadPatch.cs
@@ -301,11 +301,7 @@ namespace Parsek.Patches
                 new DialogGUIButton("Set As Target", () =>
                 {
                     currentGhostMenu = null;
-                    if (FlightGlobals.fetch != null)
-                    {
-                        FlightGlobals.fetch.SetVesselTarget(v);
-                        ParsekLog.Info("GhostMap", $"Ghost '{vesselName}' set as target via icon click");
-                    }
+                    GhostMapPresence.SetGhostMapNavigationTarget(v, recIndex, "icon click");
                 }, dismissOnSelect: true),
                 new DialogGUIButton(() =>
                 {

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1003,7 +1003,7 @@ vessel unreachable.
 
 ---
 
-## 586. Ghost map vessel "Set Target" via icon click logs success but does nothing in KSP
+## 586. Ghost map vessel "Set Target" via icon click logs success but does nothing in KSP ~~done~~
 
 **Source:** same playtest as #585. User: "when controlling the booster, I
 tried to click on Set Target on the ghost proto-vessel (the upper stage
@@ -1022,23 +1022,28 @@ Parsek logs the click as if it succeeded, but the user-observable
 behaviour (target marker, distance / velocity readouts on the navball,
 encounter-prediction line to the ghost) never materialises.
 
-**Plausible root causes to confirm:**
+**Root cause confirmed:**
 
-- Ghost map vessels are lightweight ProtoVessel-wrapping `Vessel`
-  instances managed by `GhostMapPresence`. KSP's
-  `FlightGlobals.fetch.SetVesselTarget(...)` may accept the Vessel
-  reference but the very next physics frame finds the ghost is not in
-  `FlightGlobals.Vessels` for targeting purposes (it lives in the
-  tracking-station ProtoVessel set, not the active flight vessel set),
-  so the target is silently dropped.
-- Or: the ghost vessel has no `MapObject` of the right type for
-  KSP's encounter solver, which refuses to chain patched conics to
-  the target and clears the target state.
-- Or: Parsek logs the click before calling `SetVesselTarget`, but the
-  call site is gated by a precondition that fails (e.g. ghost vessel
-  is in a different SOI than the active vessel) — the log says
-  "set as target via icon click" even though SetVesselTarget never
-  actually fired.
+- KSP did accept Parsek's `FlightGlobals.fetch.SetVesselTarget(...)`
+  call, but Parsek had populated the ghost vessel `OrbitDriver` as if
+  it were a body driver: `orbitDriver.celestialBody = Kerbin`. Stock
+  `OrbitTargeter.DropInvalidTargets()` treats any target driver with a
+  `celestialBody` equal to the active vessel's reference body as "the
+  current main body" and clears the target. Normal vessel targets keep
+  identity in `OrbitDriver.vessel` and leave `OrbitDriver.celestialBody`
+  null.
+- Fixed by normalizing ghost orbit-driver target identity after
+  ProtoVessel load and every ghost orbit update: `OrbitDriver.vessel`
+  points at the ghost vessel, `OrbitDriver.celestialBody` stays null,
+  and the reference body remains on the `Orbit`.
+- The Set Target menu paths now capture target state before and
+  immediately after `SetVesselTarget`, then log success only after a
+  delayed KSP-validation check confirms `FlightGlobals.fetch.VesselTarget`
+  still resolves to the ghost vessel. Rejections log a warning with
+  the final reason (`null`, current-main-body, parent-body, wrong
+  vessel, wrong object) plus target type/name/body, active vessel
+  `targetObject`, ghost `MapObject`, orbit-driver identity, and
+  `FlightGlobals.Vessels` registration state.
 
 **Files to investigate:**
 
@@ -1050,8 +1055,11 @@ encounter-prediction line to the ghost) never materialises.
   is a valid KSP target (correct `vesselType`, has a `MapObject`,
   has an `OrbitDriver`, is registered with `FlightGlobals`).
 
-**Status:** Open. Workaround for the user: focus via the Parsek menu
-(`focused via menu` log line shows the click handler that *does* work).
+**Status:** Closed. Tests: `GhostMapTargetingTests` pins the verified
+success/failure logging contract, and
+`GhostMapVesselTargeting_SyntheticSameBodyGhost_Sticks` is an in-game
+runtime canary for production `SetGhostMapNavigationTarget` acceptance
+on a synthetic same-body ghost after stock validation frames.
 
 ---
 


### PR DESCRIPTION
## Summary
- Normalize ghost OrbitDriver target identity so map ghosts target as vessels instead of their current main body.
- Route ghost map Set Target actions through verified targeting diagnostics and only log success after KSP target state sticks.
- Add unit coverage plus an in-game runtime canary for ghost map target acceptance.

## Validation
- dotnet test Source\Parsek.Tests\Parsek.Tests.csproj
- Verified deployed GameData\Parsek\Plugins\Parsek.dll contains the new targeting diagnostics.
- gpt-5.5/xhigh review completed clean after follow-up fixes.