### PR TITLE
Optimize ghost map IsVesselRegistered to O(1) lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to Parsek are documented here.
 - `#543` `LoopTimeUnit.Auto` now uses one global launch queue instead of per-recording independent cadence. Flight playback, KSC playback, and watch-mode loop reconstruction all schedule Auto recordings from the shared queue order, so the global Auto interval is the gap between successive launches across the queue and each recording's relaunch cadence scales by queue length instead of clumping at each recording's own start UT.
 - `#544` Rewind-to-launch now restores 15 seconds of pre-launch setup time instead of 10 before loading the stripped launch save, and the rewind UT coverage now reads the same shared launch lead-time constant as the production path.
 - Added active and background recording-finalization cache refresh producers, including the 5-second dynamic refresh cadence, stable-coast digest skipping, background on-rails orbit summaries, and maneuver-node-safe tail generation.
+- `#586` Ghost map `IsVesselRegistered` now reads from `FlightGlobals.PersistentVesselIds` instead of scanning the full `FlightGlobals.Vessels` list, dropping the per-`Set As Target` cost from O(N) to O(1).
 
 ### Bug Fixes
 

--- a/Source/Parsek/GhostMapPresence.cs
+++ b/Source/Parsek/GhostMapPresence.cs
@@ -1424,11 +1424,21 @@ namespace Parsek
 
         internal static bool IsVesselRegistered(Vessel vessel)
         {
-            if (vessel == null || FlightGlobals.fetch == null || FlightGlobals.Vessels == null)
+            if (vessel == null || FlightGlobals.fetch == null)
+                return false;
+
+            // O(1) persistent-id lookup against FlightGlobals.PersistentVesselIds
+            // (stock FlightGlobals.FindVessel is a thin wrapper around it).
+            if (vessel.persistentId != 0u)
+                return FlightGlobals.FindVessel(vessel.persistentId, out _);
+
+            // pid==0 vessels (unregistered / mid-construction) fall back to an
+            // identity scan so callers still get a meaningful answer.
+            if (FlightGlobals.Vessels == null)
                 return false;
             for (int i = 0; i < FlightGlobals.Vessels.Count; i++)
             {
-                if (IsSameVessel(FlightGlobals.Vessels[i], vessel))
+                if (ReferenceEquals(FlightGlobals.Vessels[i], vessel))
                     return true;
             }
             return false;


### PR DESCRIPTION
## Summary

Follow-up to [#563](https://github.com/vl3c/Parsek/pull/563) review. `GhostMapPresence.IsVesselRegistered` is called four times per `Set As Target` click (preflight, before, after-set, final) via `CaptureGhostTargetState`. The previous implementation scanned the full `FlightGlobals.Vessels` list with `IsSameVessel` on every probe.

This swaps the linear scan for `FlightGlobals.FindVessel(persistentId, out _)`, which is a thin wrapper over `FlightGlobals.PersistentVesselIds` (a `DictionaryValueList<uint, Vessel>` with O(1) `Contains`). Net effect: per-click cost drops from O(N) to O(1) in the common path.

The pid==0 fallback (unregistered or mid-construction vessels) still does an identity scan so callers keep a meaningful answer when persistent-id assignment hasn't happened yet — ghost vessels created via the Parsek pipeline always have a non-zero pid after `ProtoVessel.Load`, so this path is rare.

## Validation

- `dotnet build Source/Parsek/Parsek.csproj` — clean.
- `dotnet test Source/Parsek.Tests/Parsek.Tests.csproj` — 8808 passed, 0 failed.
- Verified deployed `GameData/Parsek/Plugins/Parsek.dll` decompiles to the new `FindVessel`-based body (size + mtime match the worktree build, ILSpy confirms `FlightGlobals.FindVessel(vessel.persistentId, ref val)` in the deployed assembly).

The existing in-game canary `GhostMapVesselTargeting_SyntheticSameBodyGhost_Sticks` continues to assert `IsVesselRegistered(ghost)` is true on a freshly created same-body ghost, exercising the new dictionary-lookup path live.