### PR TITLE
Relax in-game sidecar-version test for legacy-loop-migrated recordings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- In-game `SaveLoadTests.CurrentFormatTrajectorySidecarsProbeAsBinary` no longer flags legacy-migrated recordings whose binary `.prec` sidecar predates the v4 loop-interval semantic bump. The on-disk binary version is allowed to lag the in-memory recording version because v4 was a metadata-only change.
+
 - `#591` Missed-vessel-switch recovery no longer floods `KSP.log` with redundant recorder-state snapshots. Identical recovery frames now collapse into 5-second `suppressed=N` summaries while normal vessel-switch diagnostics are unchanged.
 
 - `#571` Long on-rails OrbitalCheckpoint warp sections now get derived trajectory samples every 5 degrees of true anomaly, so ghost icons follow the checkpoint window instead of replaying one sparse Kepler segment. The representative 22 ks Kerbin warp adds 42 points and preserves them through format-v6 `.prec` round trips.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
-- In-game `SaveLoadTests.CurrentFormatTrajectorySidecarsProbeAsBinary` no longer flags legacy-migrated recordings whose binary `.prec` sidecar predates the v4 loop-interval semantic bump. The on-disk binary version is allowed to lag the in-memory recording version because v4 was a metadata-only change.
+- In-game `SaveLoadTests.CurrentFormatTrajectorySidecarsProbeAsBinary` no longer flags legacy-migrated recordings whose binary `.prec` sidecar predates the v4 loop-interval semantic bump. The lag exception is exactly v3 sidecar with v4 recording (the documented metadata-only migration); any other lag, including v3-or-older sidecar paired with a v5 / v6 recording, still fails the assertion so genuinely stale binary trajectory data is caught.
 
 - `#591` Missed-vessel-switch recovery no longer floods `KSP.log` with redundant recorder-state snapshots. Identical recovery frames now collapse into 5-second `suppressed=N` summaries while normal vessel-switch diagnostics are unchanged.
 

--- a/Source/Parsek.Tests/TrajectorySidecarProbeVersionContractTests.cs
+++ b/Source/Parsek.Tests/TrajectorySidecarProbeVersionContractTests.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Regression for #565: the in-game test
+    /// <c>SaveLoadTests.CurrentFormatTrajectorySidecarsProbeAsBinary</c> previously asserted strict
+    /// equality between <c>probe.FormatVersion</c> (the on-disk binary-encoding version stamped at
+    /// the last .prec write) and <c>rec.RecordingFormatVersion</c> (the in-memory semantic
+    /// version). Those values are not the same thing: post-load semantic migrations like
+    /// <c>RecordingStore.MigrateLegacyLoopIntervalAfterHydration</c> bump the in-memory format
+    /// version to v4 (launch-to-launch loop interval) without rewriting the sidecar — the v4
+    /// change was metadata-only, the binary layout is identical to v3. The contract guaranteed
+    /// by <c>TrajectorySidecarBinary.Read</c> is therefore the asymmetric:
+    /// <code>
+    ///   probe.FormatVersion &lt;= rec.RecordingFormatVersion &lt;= CurrentRecordingFormatVersion
+    /// </code>
+    /// not strict equality.
+    /// </summary>
+    [Collection("Sequential")]
+    public class TrajectorySidecarProbeVersionContractTests : IDisposable
+    {
+        private readonly string tempDir;
+
+        public TrajectorySidecarProbeVersionContractTests()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+            RecordingStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+
+            tempDir = Path.Combine(
+                Path.GetTempPath(),
+                "parsek-probe-version-contract-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+            RecordingStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
+
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, recursive: true); }
+                catch { }
+            }
+        }
+
+        /// <summary>
+        /// Replays the load-time sequence: a recording is written to .prec at semantic v3, then
+        /// a post-load migration (e.g. legacy loop-interval) bumps the in-memory recording to v4
+        /// without dirtying the sidecar. The probe must still report v3 (the on-disk truth), the
+        /// recording must be at v4 (the migrated semantic), and the
+        /// <c>probe.FormatVersion &lt;= rec.RecordingFormatVersion</c> contract must hold.
+        /// </summary>
+        [Fact]
+        public void Probe_PostLegacyLoopMigration_HoldsAsymmetricContract()
+        {
+            var rec = BuildSimpleRecordingAtVersion(
+                recordingId: "post-legacy-loop",
+                formatVersion: 3);
+
+            string path = Path.Combine(tempDir, rec.RecordingId + ".prec");
+            TrajectorySidecarBinary.Write(path, rec, sidecarEpoch: 5);
+
+            // Simulate MigrateLegacyLoopIntervalAfterHydration: in-memory bump to v4 with no
+            // sidecar rewrite. Production calls
+            // RecordingStore.NormalizeRecordingFormatVersionAfterLegacyLoopMigration; we do the
+            // same effective in-memory mutation here without taking the dependency on the loop
+            // helpers.
+            RecordingStore.NormalizeRecordingFormatVersionAfterLegacyLoopMigration(rec);
+            Assert.Equal(
+                RecordingStore.LaunchToLaunchLoopIntervalFormatVersion,
+                rec.RecordingFormatVersion);
+
+            TrajectorySidecarProbe probe;
+            Assert.True(TrajectorySidecarBinary.TryProbe(path, out probe));
+            Assert.True(probe.Success);
+            Assert.True(probe.Supported);
+
+            // On-disk binary version stays at the write-time v3 — v4 is metadata-only and the
+            // sidecar was never re-saved.
+            Assert.Equal(3, probe.FormatVersion);
+            Assert.Equal(TrajectorySidecarEncoding.BinaryV3, probe.Encoding);
+
+            // The contract the in-game test now enforces:
+            //   probe.FormatVersion <= rec.RecordingFormatVersion <= CurrentRecordingFormatVersion
+            // and the probe must report a known schema version this build understands.
+            Assert.True(probe.FormatVersion <= rec.RecordingFormatVersion,
+                $"probe.FormatVersion={probe.FormatVersion} must not exceed " +
+                $"rec.RecordingFormatVersion={rec.RecordingFormatVersion}");
+            Assert.True(probe.FormatVersion <= RecordingStore.CurrentRecordingFormatVersion,
+                $"probe.FormatVersion={probe.FormatVersion} must not exceed " +
+                $"CurrentRecordingFormatVersion={RecordingStore.CurrentRecordingFormatVersion}");
+            Assert.True(rec.RecordingFormatVersion <= RecordingStore.CurrentRecordingFormatVersion,
+                $"rec.RecordingFormatVersion={rec.RecordingFormatVersion} must not exceed " +
+                $"CurrentRecordingFormatVersion={RecordingStore.CurrentRecordingFormatVersion}");
+        }
+
+        /// <summary>
+        /// The complementary case: a current-format recording (rec at
+        /// <see cref="RecordingStore.CurrentRecordingFormatVersion"/>) writes its sidecar at the
+        /// matching version, and the contract reduces to equality. The relaxed assertion still
+        /// passes here, so freshly-written recordings are unaffected by the test relaxation.
+        /// </summary>
+        [Fact]
+        public void Probe_FreshlyWrittenAtCurrentVersion_ContractReducesToEquality()
+        {
+            var rec = BuildSimpleRecordingAtVersion(
+                recordingId: "fresh-current-version",
+                formatVersion: RecordingStore.CurrentRecordingFormatVersion);
+
+            string path = Path.Combine(tempDir, rec.RecordingId + ".prec");
+            TrajectorySidecarBinary.Write(path, rec, sidecarEpoch: 1);
+
+            TrajectorySidecarProbe probe;
+            Assert.True(TrajectorySidecarBinary.TryProbe(path, out probe));
+            Assert.Equal(rec.RecordingFormatVersion, probe.FormatVersion);
+            Assert.True(probe.FormatVersion <= rec.RecordingFormatVersion);
+            Assert.True(probe.FormatVersion <= RecordingStore.CurrentRecordingFormatVersion);
+        }
+
+        private static Recording BuildSimpleRecordingAtVersion(string recordingId, int formatVersion)
+        {
+            var rec = new Recording
+            {
+                RecordingId = recordingId,
+                VesselName = "Probe Fixture",
+                RecordingFormatVersion = formatVersion,
+                LoopPlayback = true,
+                // Pre-#412 legacy loop save: post-cycle gap stored as small seconds value.
+                LoopIntervalSeconds = 10.0,
+                LoopTimeUnit = LoopTimeUnit.Sec,
+            };
+            rec.Points.Add(new TrajectoryPoint
+            {
+                ut = 100,
+                latitude = -0.10,
+                longitude = -74.50,
+                altitude = 120,
+                rotation = new Quaternion(0f, 0f, 0f, 1f),
+                velocity = new Vector3(0f, 50f, 0f),
+                bodyName = "Kerbin",
+                funds = 0,
+                science = 0,
+                reputation = 0
+            });
+            rec.Points.Add(new TrajectoryPoint
+            {
+                ut = 168,
+                latitude = -0.09,
+                longitude = -74.49,
+                altitude = 300,
+                rotation = new Quaternion(0f, 0f, 0f, 1f),
+                velocity = new Vector3(0f, 75f, 0f),
+                bodyName = "Kerbin",
+                funds = 0,
+                science = 0,
+                reputation = 0
+            });
+            return rec;
+        }
+    }
+}

--- a/Source/Parsek.Tests/TrajectorySidecarProbeVersionContractTests.cs
+++ b/Source/Parsek.Tests/TrajectorySidecarProbeVersionContractTests.cs
@@ -7,19 +7,24 @@ using Xunit;
 namespace Parsek.Tests
 {
     /// <summary>
-    /// Regression for #565: the in-game test
-    /// <c>SaveLoadTests.CurrentFormatTrajectorySidecarsProbeAsBinary</c> previously asserted strict
-    /// equality between <c>probe.FormatVersion</c> (the on-disk binary-encoding version stamped at
-    /// the last .prec write) and <c>rec.RecordingFormatVersion</c> (the in-memory semantic
-    /// version). Those values are not the same thing: post-load semantic migrations like
-    /// <c>RecordingStore.MigrateLegacyLoopIntervalAfterHydration</c> bump the in-memory format
-    /// version to v4 (launch-to-launch loop interval) without rewriting the sidecar — the v4
-    /// change was metadata-only, the binary layout is identical to v3. The contract guaranteed
-    /// by <c>TrajectorySidecarBinary.Read</c> is therefore the asymmetric:
-    /// <code>
-    ///   probe.FormatVersion &lt;= rec.RecordingFormatVersion &lt;= CurrentRecordingFormatVersion
-    /// </code>
-    /// not strict equality.
+    /// Regression for #565 / #567: the in-game test
+    /// <c>SaveLoadTests.CurrentFormatTrajectorySidecarsProbeAsBinary</c> originally asserted
+    /// strict equality between <c>probe.FormatVersion</c> (the on-disk binary-encoding version
+    /// stamped at the last .prec write) and <c>rec.RecordingFormatVersion</c> (the in-memory
+    /// semantic version). Those are not the same thing: the post-load
+    /// <c>RecordingStore.MigrateLegacyLoopIntervalAfterHydration</c> migration promotes the
+    /// in-memory format version from v3 to v4 (launch-to-launch loop interval) without
+    /// rewriting the sidecar, because v4 is a metadata-only change — the binary layout is
+    /// identical to v3. The runtime test was first relaxed to <c>probe &lt;= rec</c>, but that
+    /// was too broad: v5 adds serialized <c>OrbitSegment.isPredicted</c> and v6 changes
+    /// RELATIVE TrackSection point semantics, so a v3 sidecar paired with a v5/v6 recording
+    /// indicates stale binary data on disk that the test must catch.
+    /// <para>
+    /// The narrow contract enforced by
+    /// <see cref="RecordingStore.IsAcceptableSidecarVersionLag(int, int)"/> is therefore:
+    /// equality, OR exactly the v3 sidecar / v4 recording metadata-only exception. Every
+    /// other combination is rejected.
+    /// </para>
     /// </summary>
     [Collection("Sequential")]
     public class TrajectorySidecarProbeVersionContractTests : IDisposable
@@ -57,11 +62,12 @@ namespace Parsek.Tests
         /// Replays the load-time sequence: a recording is written to .prec at semantic v3, then
         /// a post-load migration (e.g. legacy loop-interval) bumps the in-memory recording to v4
         /// without dirtying the sidecar. The probe must still report v3 (the on-disk truth), the
-        /// recording must be at v4 (the migrated semantic), and the
-        /// <c>probe.FormatVersion &lt;= rec.RecordingFormatVersion</c> contract must hold.
+        /// recording must be at v4 (the migrated semantic), and
+        /// <see cref="RecordingStore.IsAcceptableSidecarVersionLag(int, int)"/> must accept the
+        /// pair as the documented metadata-only exception.
         /// </summary>
         [Fact]
-        public void Probe_PostLegacyLoopMigration_HoldsAsymmetricContract()
+        public void Probe_PostLegacyLoopMigration_AllowedAsMetadataOnlyException()
         {
             var rec = BuildSimpleRecordingAtVersion(
                 recordingId: "post-legacy-loop",
@@ -90,12 +96,11 @@ namespace Parsek.Tests
             Assert.Equal(3, probe.FormatVersion);
             Assert.Equal(TrajectorySidecarEncoding.BinaryV3, probe.Encoding);
 
-            // The contract the in-game test now enforces:
-            //   probe.FormatVersion <= rec.RecordingFormatVersion <= CurrentRecordingFormatVersion
-            // and the probe must report a known schema version this build understands.
-            Assert.True(probe.FormatVersion <= rec.RecordingFormatVersion,
-                $"probe.FormatVersion={probe.FormatVersion} must not exceed " +
-                $"rec.RecordingFormatVersion={rec.RecordingFormatVersion}");
+            // The narrow contract the in-game test now enforces accepts this lag.
+            Assert.True(
+                RecordingStore.IsAcceptableSidecarVersionLag(probe.FormatVersion, rec.RecordingFormatVersion),
+                $"v{probe.FormatVersion} sidecar with v{rec.RecordingFormatVersion} recording " +
+                "must be accepted as the documented metadata-only legacy-loop migration");
             Assert.True(probe.FormatVersion <= RecordingStore.CurrentRecordingFormatVersion,
                 $"probe.FormatVersion={probe.FormatVersion} must not exceed " +
                 $"CurrentRecordingFormatVersion={RecordingStore.CurrentRecordingFormatVersion}");
@@ -105,10 +110,25 @@ namespace Parsek.Tests
         }
 
         /// <summary>
+        /// Equality case at the v3 anchor: a v3 sidecar paired with a v3 in-memory recording
+        /// (no migration ran) must be accepted by the predicate. Provides explicit coverage of
+        /// the equality branch at the lag boundary.
+        /// </summary>
+        [Fact]
+        public void Probe_V3SidecarV3Recording_AllowedByEquality()
+        {
+            Assert.True(
+                RecordingStore.IsAcceptableSidecarVersionLag(
+                    probeFormatVersion: 3,
+                    recordingFormatVersion: 3),
+                "v3 sidecar with v3 recording is the equality case and must be accepted.");
+        }
+
+        /// <summary>
         /// The complementary case: a current-format recording (rec at
         /// <see cref="RecordingStore.CurrentRecordingFormatVersion"/>) writes its sidecar at the
-        /// matching version, and the contract reduces to equality. The relaxed assertion still
-        /// passes here, so freshly-written recordings are unaffected by the test relaxation.
+        /// matching version, and the contract reduces to equality. The narrow predicate still
+        /// passes here, so freshly-written recordings are unaffected.
         /// </summary>
         [Fact]
         public void Probe_FreshlyWrittenAtCurrentVersion_ContractReducesToEquality()
@@ -123,8 +143,75 @@ namespace Parsek.Tests
             TrajectorySidecarProbe probe;
             Assert.True(TrajectorySidecarBinary.TryProbe(path, out probe));
             Assert.Equal(rec.RecordingFormatVersion, probe.FormatVersion);
-            Assert.True(probe.FormatVersion <= rec.RecordingFormatVersion);
+            Assert.True(
+                RecordingStore.IsAcceptableSidecarVersionLag(probe.FormatVersion, rec.RecordingFormatVersion),
+                "freshly-written sidecar at the current version must satisfy the contract by equality");
             Assert.True(probe.FormatVersion <= RecordingStore.CurrentRecordingFormatVersion);
+        }
+
+        /// <summary>
+        /// A v3 sidecar paired with a v5 recording indicates the binary on disk predates the
+        /// v5 <c>OrbitSegment.isPredicted</c> contract change — the predicted-flag field would
+        /// be missing from every orbit segment in the trajectory. The in-game runtime test must
+        /// flag this; the predicate rejects it.
+        /// </summary>
+        [Fact]
+        public void Probe_V3SidecarV5Recording_RejectedAsStale()
+        {
+            Assert.False(
+                RecordingStore.IsAcceptableSidecarVersionLag(
+                    probeFormatVersion: 3,
+                    recordingFormatVersion: RecordingStore.PredictedOrbitSegmentFormatVersion),
+                "v3 sidecar with v5 recording is a binary-layout lag (missing isPredicted) " +
+                "and must be rejected.");
+        }
+
+        /// <summary>
+        /// A v3 sidecar paired with a v6 recording indicates the binary on disk predates the
+        /// v6 RELATIVE TrackSection anchor-local point semantics — RELATIVE points would be
+        /// reinterpreted incorrectly on load. The in-game runtime test must flag this; the
+        /// predicate rejects it.
+        /// </summary>
+        [Fact]
+        public void Probe_V3SidecarV6Recording_RejectedAsStale()
+        {
+            Assert.False(
+                RecordingStore.IsAcceptableSidecarVersionLag(
+                    probeFormatVersion: 3,
+                    recordingFormatVersion: RecordingStore.RelativeLocalFrameFormatVersion),
+                "v3 sidecar with v6 recording is a binary-layout lag (RELATIVE point " +
+                "semantics changed) and must be rejected.");
+        }
+
+        /// <summary>
+        /// A v4 sidecar paired with a v6 recording is a multi-step lag: v4 -> v5 added the
+        /// predicted-flag, v5 -> v6 changed RELATIVE point semantics. The narrow contract is
+        /// equality OR the single explicit v3-&gt;v4 metadata-only exception, and this case is
+        /// neither, so the predicate rejects it.
+        /// </summary>
+        [Fact]
+        public void Probe_V4SidecarV6Recording_RejectedAsStale()
+        {
+            Assert.False(
+                RecordingStore.IsAcceptableSidecarVersionLag(
+                    probeFormatVersion: RecordingStore.LaunchToLaunchLoopIntervalFormatVersion,
+                    recordingFormatVersion: RecordingStore.RelativeLocalFrameFormatVersion),
+                "v4 sidecar with v6 recording is a multi-bump binary lag and must be rejected.");
+        }
+
+        /// <summary>
+        /// A probe version higher than the recording version should never happen in production
+        /// (<c>TrajectorySidecarBinary.Read</c> only promotes upward), but if it ever does the
+        /// predicate must reject it.
+        /// </summary>
+        [Fact]
+        public void Probe_HigherThanRecording_Rejected()
+        {
+            Assert.False(
+                RecordingStore.IsAcceptableSidecarVersionLag(
+                    probeFormatVersion: RecordingStore.CurrentRecordingFormatVersion,
+                    recordingFormatVersion: 3),
+                "probe version higher than recording version must be rejected.");
         }
 
         private static Recording BuildSimpleRecordingAtVersion(string recordingId, int formatVersion)

--- a/Source/Parsek/InGameTests/RuntimeTests.cs
+++ b/Source/Parsek/InGameTests/RuntimeTests.cs
@@ -4536,8 +4536,27 @@ namespace Parsek.InGameTests
                     $"Could not probe .prec sidecar for current-format recording '{rec.RecordingId}'");
                 InGameAssert.AreEqual(TrajectorySidecarEncoding.BinaryV3, probe.Encoding,
                     $"Current-format recording '{rec.RecordingId}' should use BinaryV3 sidecar encoding");
-                InGameAssert.AreEqual(rec.RecordingFormatVersion, probe.FormatVersion,
-                    $"Current-format recording '{rec.RecordingId}' should keep its on-disk format version");
+
+                // probe.FormatVersion is the on-disk binary-encoding version stamped at the
+                // last .prec write. rec.RecordingFormatVersion is the in-memory semantic
+                // version, which post-load migrations (e.g. the v4 launch-to-launch loop
+                // interval bump in MigrateLegacyLoopIntervalAfterHydration) can promote
+                // without rewriting the sidecar — the v4 change was a metadata semantic
+                // change, not a binary-layout change. The contract is therefore:
+                //   probe.FormatVersion <= rec.RecordingFormatVersion (never higher; see
+                //     TrajectorySidecarBinary.Read promote-only branch), AND
+                //   probe.FormatVersion <= CurrentRecordingFormatVersion (must be a known
+                //     schema this build understands).
+                // Strict equality would flag every legacy-loop-migrated recording whose
+                // .prec hasn't yet been rewritten, even though the file is correct.
+                InGameAssert.IsTrue(probe.FormatVersion <= rec.RecordingFormatVersion,
+                    $"Current-format recording '{rec.RecordingId}' has on-disk binary version " +
+                    $"{probe.FormatVersion} > in-memory recording format version " +
+                    $"{rec.RecordingFormatVersion}; probe should never exceed the recording");
+                InGameAssert.IsTrue(probe.FormatVersion <= RecordingStore.CurrentRecordingFormatVersion,
+                    $"Current-format recording '{rec.RecordingId}' has on-disk binary version " +
+                    $"{probe.FormatVersion}; latest known schema is " +
+                    $"{RecordingStore.CurrentRecordingFormatVersion}");
                 checkedCount++;
             }
 

--- a/Source/Parsek/InGameTests/RuntimeTests.cs
+++ b/Source/Parsek/InGameTests/RuntimeTests.cs
@@ -4534,25 +4534,35 @@ namespace Parsek.InGameTests
                 TrajectorySidecarProbe probe;
                 InGameAssert.IsTrue(RecordingStore.TryProbeTrajectorySidecar(precPath, out probe),
                     $"Could not probe .prec sidecar for current-format recording '{rec.RecordingId}'");
+                InGameAssert.IsTrue(probe.Supported,
+                    $"Current-format recording '{rec.RecordingId}' has unsupported sidecar version " +
+                    $"{probe.FormatVersion}; this build only understands up to v{RecordingStore.CurrentRecordingFormatVersion}");
                 InGameAssert.AreEqual(TrajectorySidecarEncoding.BinaryV3, probe.Encoding,
                     $"Current-format recording '{rec.RecordingId}' should use BinaryV3 sidecar encoding");
 
                 // probe.FormatVersion is the on-disk binary-encoding version stamped at the
                 // last .prec write. rec.RecordingFormatVersion is the in-memory semantic
-                // version, which post-load migrations (e.g. the v4 launch-to-launch loop
-                // interval bump in MigrateLegacyLoopIntervalAfterHydration) can promote
-                // without rewriting the sidecar — the v4 change was a metadata semantic
-                // change, not a binary-layout change. The contract is therefore:
-                //   probe.FormatVersion <= rec.RecordingFormatVersion (never higher; see
-                //     TrajectorySidecarBinary.Read promote-only branch), AND
-                //   probe.FormatVersion <= CurrentRecordingFormatVersion (must be a known
-                //     schema this build understands).
-                // Strict equality would flag every legacy-loop-migrated recording whose
-                // .prec hasn't yet been rewritten, even though the file is correct.
-                InGameAssert.IsTrue(probe.FormatVersion <= rec.RecordingFormatVersion,
-                    $"Current-format recording '{rec.RecordingId}' has on-disk binary version " +
-                    $"{probe.FormatVersion} > in-memory recording format version " +
-                    $"{rec.RecordingFormatVersion}; probe should never exceed the recording");
+                // version, which post-load migrations can promote without rewriting the
+                // sidecar. The contract is intentionally narrow: equality is the ordinary
+                // case, and the only allowed lag is the documented v3 -> v4 metadata-only
+                // migration (LaunchToLaunchLoopIntervalFormatVersion changed the meaning of
+                // loopIntervalSeconds without altering binary layout, so a v3 sidecar paired
+                // with a v4-promoted in-memory recording is correct on disk; see
+                // RecordingStore.NormalizeRecordingFormatVersionAfterLegacyLoopMigration).
+                // Every other lag must fail: v5 added serialized OrbitSegment.isPredicted and
+                // v6 changed RELATIVE TrackSection point semantics, so a v3-or-older sidecar
+                // paired with a v5/v6 recording would mean the binary on disk predates a
+                // contract change and the data is genuinely stale. The probe must always be
+                // a known schema this build understands.
+                InGameAssert.IsTrue(
+                    RecordingStore.IsAcceptableSidecarVersionLag(probe.FormatVersion, rec.RecordingFormatVersion),
+                    $"Current-format recording '{rec.RecordingId}' fails the probe/recording " +
+                    $"version contract: on-disk binary version {probe.FormatVersion} vs " +
+                    $"in-memory recording format version {rec.RecordingFormatVersion}. " +
+                    $"Allowed combinations are equality, or v{RecordingStore.LaunchToLaunchLoopIntervalFormatVersion - 1} " +
+                    $"sidecar with v{RecordingStore.LaunchToLaunchLoopIntervalFormatVersion} recording " +
+                    $"(the documented metadata-only legacy-loop migration). Anything else " +
+                    $"indicates stale or incomplete trajectory data on disk.");
                 InGameAssert.IsTrue(probe.FormatVersion <= RecordingStore.CurrentRecordingFormatVersion,
                     $"Current-format recording '{rec.RecordingId}' has on-disk binary version " +
                     $"{probe.FormatVersion}; latest known schema is " +

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -6400,6 +6400,39 @@ namespace Parsek
         }
 
         /// <summary>
+        /// #565 / #567: encodes the narrow contract between a trajectory sidecar's on-disk
+        /// binary-encoding version (<c>probe.FormatVersion</c>) and the in-memory recording's
+        /// semantic version (<c>rec.RecordingFormatVersion</c>) for a current-format committed
+        /// recording. The two values can differ ONLY by the v3 -&gt; v4 metadata-only
+        /// migration: <see cref="LaunchToLaunchLoopIntervalFormatVersion"/> changed the
+        /// meaning of <c>loopIntervalSeconds</c> without altering binary layout, so a v3
+        /// sidecar with a v4 in-memory recording is correct on disk and only the in-memory
+        /// state was promoted (see
+        /// <see cref="NormalizeRecordingFormatVersionAfterLegacyLoopMigration"/>).
+        /// Every other lag is rejected: v5 added serialized
+        /// <c>OrbitSegment.isPredicted</c> and v6 changed RELATIVE TrackSection point
+        /// semantics, so a v3 sidecar paired with a v5- or v6-tagged recording indicates
+        /// stale or incomplete trajectory data on disk that the runtime test must catch.
+        /// </summary>
+        internal static bool IsAcceptableSidecarVersionLag(int probeFormatVersion, int recordingFormatVersion)
+        {
+            // Equality: the ordinary case (sidecar was rewritten at the in-memory version).
+            if (probeFormatVersion == recordingFormatVersion)
+                return true;
+
+            // The single explicit metadata-only exception: v3 sidecar + v4 recording from the
+            // legacy-loop migration. v3 (sparse-point binary) and v4 (launch-to-launch loop
+            // interval semantic) share an identical binary layout, so an unrewritten v3
+            // sidecar is correct on disk for a v4-promoted in-memory recording.
+            int metadataOnlyProbeVersion = LaunchToLaunchLoopIntervalFormatVersion - 1;
+            if (probeFormatVersion == metadataOnlyProbeVersion
+                && recordingFormatVersion == LaunchToLaunchLoopIntervalFormatVersion)
+                return true;
+
+            return false;
+        }
+
+        /// <summary>
         /// #412: Normalize recordings whose <c>LoopIntervalSeconds</c> is below
         /// <see cref="LoopTiming.MinCycleDuration"/> while <c>LoopPlayback</c> is on.
         /// Such recordings otherwise hit <c>ResolveLoopInterval</c>'s defensive clamp on every

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1673,16 +1673,25 @@ version vs. in-memory semantic version) as the same number. They diverge by
 design at v4 and above whenever a legacy save loads.
 
 **Fix:** `RuntimeTests.CurrentFormatTrajectorySidecarsProbeAsBinary` now
-asserts the asymmetric contract `probe.FormatVersion <=
-rec.RecordingFormatVersion <= CurrentRecordingFormatVersion`, with an inline
-comment documenting the on-disk-binary vs. in-memory-semantic split. The
-production read path in `TrajectorySidecarBinary.Read` already uses
-promote-only (`if (rec.RecordingFormatVersion < probe.FormatVersion)`), so no
-production code change was needed. New xUnit regression
-`TrajectorySidecarProbeVersionContractTests` builds a recording at v3, writes
-the sidecar, simulates the legacy-loop migration, and pins the asymmetric
-contract; the matching freshly-written-at-current-version case pins that the
-contract reduces to equality when the sidecar is up to date.
+asserts a narrow contract via the new
+`RecordingStore.IsAcceptableSidecarVersionLag(probe, rec)` predicate:
+equality is the ordinary case, and the only allowed lag is v3 sidecar with
+v4 recording (the documented metadata-only legacy-loop migration). Every
+other lag fails the assertion. v5 added serialized
+`OrbitSegment.isPredicted` and v6 changed RELATIVE TrackSection point
+semantics, so a v3-or-older sidecar paired with a v5 / v6 recording would
+mean the binary on disk predates a contract change and the trajectory
+data is genuinely stale. The first PR #567 relaxation to the broad
+asymmetric `probe <= rec` would have hidden that case; review note P2
+narrowed the exception. The runtime test also now explicitly asserts
+`probe.Supported`. The production read path in `TrajectorySidecarBinary.Read`
+already uses promote-only (`if (rec.RecordingFormatVersion <
+probe.FormatVersion)`), so no production runtime code change was needed
+beyond exposing the predicate. xUnit
+`TrajectorySidecarProbeVersionContractTests` covers v3 / v3 (equality),
+v3 / v4 (allowed legacy-loop migration), v3 / v5, v3 / v6, v4 / v6, and
+probe&gt;rec (all rejected), plus the freshly-written-at-current-version
+case that reduces to equality.
 
 **Status:** CLOSED 2026-04-25. Fixed for v0.9.0.
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1653,6 +1653,41 @@ in-game during the next playtest pass instead of an xUnit canary.
 
 ---
 
+## ~~In-game test: `SaveLoadTests.CurrentFormatTrajectorySidecarsProbeAsBinary` failed for legacy-loop-migrated recording in every scene~~
+
+**Source:** `logs/2026-04-25_2147` playtest. The in-game test failed for
+recording `1bbb50cf98654a23a60b3248848b0301` ("Learstar A1") in EDITOR /
+FLIGHT / MAINMENU / SPACECENTER / TRACKSTATION with
+`Current-format recording '…' should keep its on-disk format version`.
+
+**Diagnosis (2026-04-25):** the recording loaded at `formatVersion=3`
+(`Player.log:31418`). `RecordingStore.MigrateLegacyLoopIntervalAfterHydration`
+then ran (`Player.log:31487`) and called
+`NormalizeRecordingFormatVersionAfterLegacyLoopMigration`, which bumps the
+in-memory `RecordingFormatVersion` to v4 (the launch-to-launch loop interval
+semantic). The `.prec` sidecar stayed at `BinaryV3 version=3` because v4 was
+metadata-only — the binary layout is byte-identical to v3 and no rewrite was
+required. The test asserted `AreEqual(rec.RecordingFormatVersion,
+probe.FormatVersion)`, treating two distinct concepts (on-disk binary-encoding
+version vs. in-memory semantic version) as the same number. They diverge by
+design at v4 and above whenever a legacy save loads.
+
+**Fix:** `RuntimeTests.CurrentFormatTrajectorySidecarsProbeAsBinary` now
+asserts the asymmetric contract `probe.FormatVersion <=
+rec.RecordingFormatVersion <= CurrentRecordingFormatVersion`, with an inline
+comment documenting the on-disk-binary vs. in-memory-semantic split. The
+production read path in `TrajectorySidecarBinary.Read` already uses
+promote-only (`if (rec.RecordingFormatVersion < probe.FormatVersion)`), so no
+production code change was needed. New xUnit regression
+`TrajectorySidecarProbeVersionContractTests` builds a recording at v3, writes
+the sidecar, simulates the legacy-loop migration, and pins the asymmetric
+contract; the matching freshly-written-at-current-version case pins that the
+contract reduces to equality when the sidecar is up to date.
+
+**Status:** CLOSED 2026-04-25. Fixed for v0.9.0.
+
+---
+
 ## 597. Underlying logic: KSP's `onTimeWarpRateChanged` GameEvent fires at 1x roughly 4x more often than there are real rate changes, and `OnTimeWarpRateChanged` always re-runs `CheckpointAllVessels`
 
 **Source:** `logs/2026-04-25_1933_refly-bugs/KSP.log` — 1090 of 1121


### PR DESCRIPTION
## Summary

The in-game test `SaveLoadTests.CurrentFormatTrajectorySidecarsProbeAsBinary` was failing in every scene for any recording that had been migrated from a pre-v4 loop save: a legacy `loopIntervalSeconds` was bumped to v4 (launch-to-launch period) in memory by `RecordingStore.MigrateLegacyLoopIntervalAfterHydration`, but the on-disk `.prec` sidecar was left at v3. The test compared the two values for strict equality, treating two distinct concepts as the same number:

- `probe.FormatVersion` is the **on-disk binary-encoding version** stamped at the last `.prec` write.
- `rec.RecordingFormatVersion` is the **in-memory semantic version**, which post-load migrations can promote without rewriting the sidecar.

The v4 bump was metadata-only (the binary layout is byte-identical to v3, see `TrajectorySidecarBinary.cs:32-39`), so leaving the sidecar at v3 is correct. The production read path in `TrajectorySidecarBinary.Read` already enforces `probe.FormatVersion <= rec.RecordingFormatVersion` via its promote-only branch (`TrajectorySidecarBinary.cs:226-227`), so no production code change was needed — only the test's strict-equality assumption was wrong. A grep for `probe.FormatVersion` confirmed no other production caller makes the same assumption.

The test now asserts the asymmetric contract that actually holds:

    probe.FormatVersion <= rec.RecordingFormatVersion <= RecordingStore.CurrentRecordingFormatVersion

with an inline comment documenting the on-disk-binary vs. in-memory-semantic split. New xUnit regression `TrajectorySidecarProbeVersionContractTests` covers both:

- the post-legacy-loop-migration case where the .prec stays at v3 and the recording is at v4 in memory (the asymmetric contract);
- the freshly-written-at-current-version case where the contract reduces to equality.

## Test plan

- [x] `cd Source/Parsek.Tests && dotnet test` — 8818 passed, 0 failed
- [x] `cd Source/Parsek && dotnet build` — succeeds; deployed DLL verified to contain the new assertion strings (`has on-disk binary version`, `probe should never exceed the recording`, `latest known schema is`) and not the old (`should keep its on-disk format version`)
- [ ] Reload `logs/2026-04-25_2147`'s save, run Ctrl+Shift+T, confirm `SaveLoadTests.CurrentFormatTrajectorySidecarsProbeAsBinary` passes for `1bbb50cf98654a23a60b3248848b0301` ("Learstar A1") in EDITOR / FLIGHT / MAINMENU / SPACECENTER / TRACKSTATION