### PR TITLE
Coalesce ghost-map and spawner per-frame log spam via VerboseOnChange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- Map-vessel source-resolve and spawn-suppression diagnostics no longer storm `KSP.log` when the same per-frame decision repeats every tick. Stable `(source, reason)` tuples now emit once per recording and stay quiet until the decision flips, with the suppressed count surfaced as `| suppressed=N` on the next state change.
+
 - `#591` Missed-vessel-switch recovery no longer floods `KSP.log` with redundant recorder-state snapshots. Identical recovery frames now collapse into 5-second `suppressed=N` summaries while normal vessel-switch diagnostics are unchanged.
 
 - `#571` Long on-rails OrbitalCheckpoint warp sections now get derived trajectory samples every 5 degrees of true anomaly, so ghost icons follow the checkpoint window instead of replaying one sparse Kepler segment. The representative 22 ks Kerbin warp adds 42 points and preserves them through format-v6 `.prec` round trips.

--- a/Source/Parsek.Tests/LogSpamRateLimitTests.cs
+++ b/Source/Parsek.Tests/LogSpamRateLimitTests.cs
@@ -1,0 +1,286 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Integration tests covering the ghost-map source-resolve verbose line and
+    /// the spawner suppression line. Both fire from per-frame hot paths and
+    /// previously stormed the log when the same decision tuple repeated for
+    /// the entire session. The fix routes both through
+    /// <see cref="ParsekLog.VerboseOnChange"/> so a stable
+    /// <c>(source, reason)</c> tuple emits exactly once until the decision flips,
+    /// with the suppressed count surfaced as <c>| suppressed=N</c> on the next
+    /// state change.
+    /// </summary>
+    [Collection("Sequential")]
+    public class LogSpamRateLimitTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public LogSpamRateLimitTests()
+        {
+            GhostMapPresence.ResetForTesting();
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.VerboseOverrideForTesting = true;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+        }
+
+        public void Dispose()
+        {
+            GhostMapPresence.ResetForTesting();
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+        }
+
+        // -------------------------------------------------------------------
+        // GhostMap source-resolve — the (recId, source, reason) tuple is
+        // stable across per-frame repeats while a recording sits in the
+        // pending-map-vessel queue. Confirm we emit once and stay quiet
+        // until the decision flips.
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void GhostMapSourceResolve_StablePendingDecision_EmitsOncePerOperation()
+        {
+            Recording rec = MakeBelowThresholdRecording("logspam-pending");
+
+            // Drive 100 calls with the same operation/recording/decision tuple.
+            for (int i = 0; i < 100; i++)
+            {
+                ResolveOnce(rec, currentUT: 200.0 + i, op: "map-presence-pending-create");
+            }
+
+            int verboseLines = logLines.Count(l =>
+                l.Contains("[GhostMap]")
+                && l.Contains("map-presence-pending-create:")
+                && l.Contains("source=None")
+                && l.Contains("reason=" + GhostMapPresence.TrackingStationGhostSkipStateVectorThreshold));
+            int structuredLines = logLines.Count(l =>
+                l.Contains("[GhostMap]")
+                && l.Contains("source-resolve:")
+                && l.Contains("source=None"));
+
+            // Each call site emits exactly one line on first contact and then
+            // stays silent for the rest of the stable streak.
+            Assert.Equal(1, verboseLines);
+            Assert.Equal(1, structuredLines);
+        }
+
+        [Fact]
+        public void GhostMapSourceResolve_DifferentOperations_TrackedIndependently()
+        {
+            Recording rec = MakeBelowThresholdRecording("logspam-multi-op");
+
+            // Both call sites in ParsekPlaybackPolicy hit the same recording
+            // through different operationName strings; each must emit once.
+            ResolveOnce(rec, currentUT: 200.0, op: "map-presence-initial-create");
+            ResolveOnce(rec, currentUT: 200.5, op: "map-presence-initial-create");
+            ResolveOnce(rec, currentUT: 201.0, op: "map-presence-pending-create");
+            ResolveOnce(rec, currentUT: 201.5, op: "map-presence-pending-create");
+
+            int initialLines = logLines.Count(l =>
+                l.Contains("[GhostMap]")
+                && l.Contains("map-presence-initial-create:"));
+            int pendingLines = logLines.Count(l =>
+                l.Contains("[GhostMap]")
+                && l.Contains("map-presence-pending-create:"));
+
+            Assert.Equal(1, initialLines);
+            Assert.Equal(1, pendingLines);
+        }
+
+        [Fact]
+        public void GhostMapSourceResolve_DifferentRecordings_TrackedIndependently()
+        {
+            Recording recA = MakeBelowThresholdRecording("logspam-rec-A");
+            Recording recB = MakeBelowThresholdRecording("logspam-rec-B");
+
+            for (int i = 0; i < 5; i++)
+            {
+                ResolveOnce(recA, currentUT: 200.0 + i, op: "map-presence-pending-create");
+                ResolveOnce(recB, currentUT: 200.0 + i, op: "map-presence-pending-create");
+            }
+
+            int recALines = logLines.Count(l =>
+                l.Contains("[GhostMap]")
+                && l.Contains("map-presence-pending-create:")
+                && l.Contains("rec=logspam-rec-A"));
+            int recBLines = logLines.Count(l =>
+                l.Contains("[GhostMap]")
+                && l.Contains("map-presence-pending-create:")
+                && l.Contains("rec=logspam-rec-B"));
+
+            // Each recording is its own identity scope — A doesn't suppress B.
+            Assert.Equal(1, recALines);
+            Assert.Equal(1, recBLines);
+        }
+
+        [Fact]
+        public void GhostMapSourceResolve_DecisionFlip_ReemitsWithSuppressedCount()
+        {
+            // First two calls hit the below-threshold (None|state-vector-threshold)
+            // branch; the third uses a recording with a real orbit segment so
+            // ResolveMapPresenceGhostSource returns Segment instead. The flip
+            // must reopen the gate AND surface the suppressed counter.
+            Recording belowThreshold = MakeBelowThresholdRecording("logspam-flip");
+            for (int i = 0; i < 3; i++)
+            {
+                ResolveOnce(belowThreshold, currentUT: 200.0 + i, op: "map-presence-pending-create");
+            }
+
+            Recording withSegment = MakeOrbitSegmentRecording("logspam-flip");
+            ResolveOnce(withSegment, currentUT: 250.0, op: "map-presence-pending-create");
+
+            var pendingLines = logLines
+                .Where(l => l.Contains("[GhostMap]") && l.Contains("map-presence-pending-create:"))
+                .ToList();
+
+            Assert.Equal(2, pendingLines.Count);
+            Assert.Contains("source=None", pendingLines[0]);
+            Assert.DoesNotContain("suppressed=", pendingLines[0]);
+            Assert.Contains("source=Segment", pendingLines[1]);
+            Assert.Contains("| suppressed=2", pendingLines[1]);
+        }
+
+        // -------------------------------------------------------------------
+        // VerboseOnChange itself, exercised through a faux Spawner pattern
+        // that mirrors ParsekFlight.ComputePlaybackFlags. The real call site
+        // is private inside the flight controller, but the helper IS the
+        // contract — testing it here covers the spawner fix end-to-end.
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void Spawner_NoVesselSnapshotPattern_EmitsOncePerRecording()
+        {
+            // Simulate ComputePlaybackFlags running 50 frames over 5 recordings
+            // all stuck in "no vessel snapshot". The fix keys identity per
+            // recording index and state per reason — stable reason on each
+            // recording must collapse to one line per recording.
+            for (int frame = 0; frame < 50; frame++)
+            {
+                for (int recIdx = 0; recIdx < 5; recIdx++)
+                {
+                    EmitSpawnerSuppression(recIdx, "Vessel " + recIdx, "no vessel snapshot");
+                }
+            }
+
+            int suppressedLines = logLines.Count(l =>
+                l.Contains("[Spawner]")
+                && l.Contains("Spawn suppressed for #")
+                && l.Contains("no vessel snapshot"));
+
+            Assert.Equal(5, suppressedLines);
+        }
+
+        [Fact]
+        public void Spawner_ReasonFlipForSameRecording_ReemitsWithSuppressedCount()
+        {
+            // Stable "no vessel snapshot" repeats, then the recording flips
+            // to a different reason — the new reason must emit and carry
+            // the suppressed count from the prior streak.
+            EmitSpawnerSuppression(7, "Showcase", "no vessel snapshot");
+            EmitSpawnerSuppression(7, "Showcase", "no vessel snapshot");
+            EmitSpawnerSuppression(7, "Showcase", "no vessel snapshot");
+            EmitSpawnerSuppression(7, "Showcase", "chain-suppressed");
+
+            var lines = logLines
+                .Where(l => l.Contains("[Spawner]") && l.Contains("Spawn suppressed for #7"))
+                .ToList();
+
+            Assert.Equal(2, lines.Count);
+            Assert.Contains("no vessel snapshot", lines[0]);
+            Assert.DoesNotContain("suppressed=", lines[0]);
+            Assert.Contains("chain-suppressed", lines[1]);
+            Assert.Contains("| suppressed=2", lines[1]);
+        }
+
+        // -------------------------------------------------------------------
+        // Helpers
+        // -------------------------------------------------------------------
+
+        private static GhostMapPresence.TrackingStationGhostSource ResolveOnce(
+            Recording rec, double currentUT, string op)
+        {
+            int cachedStateVectorIndex = -1;
+            return GhostMapPresence.ResolveMapPresenceGhostSource(
+                rec,
+                isSuppressed: false,
+                alreadyMaterialized: false,
+                currentUT: currentUT,
+                allowTerminalOrbitFallback: false,
+                logOperationName: op,
+                stateVectorCachedIndex: ref cachedStateVectorIndex,
+                segment: out _,
+                stateVectorPoint: out _,
+                skipReason: out _,
+                recordingIndex: 1);
+        }
+
+        private static Recording MakeBelowThresholdRecording(string recordingId)
+        {
+            return new Recording
+            {
+                RecordingId = recordingId,
+                TerminalStateValue = TerminalState.SubOrbital,
+                Points = new List<TrajectoryPoint>
+                {
+                    new TrajectoryPoint
+                    {
+                        ut = 100,
+                        bodyName = "Mun",
+                        altitude = 200,
+                        velocity = new Vector3(0, 10, 0)
+                    },
+                    new TrajectoryPoint
+                    {
+                        ut = 300,
+                        bodyName = "Mun",
+                        altitude = 250,
+                        velocity = new Vector3(0, 15, 0)
+                    }
+                }
+            };
+        }
+
+        private static Recording MakeOrbitSegmentRecording(string recordingId)
+        {
+            return new Recording
+            {
+                RecordingId = recordingId,
+                TerminalStateValue = TerminalState.Orbiting,
+                OrbitSegments = new List<OrbitSegment>
+                {
+                    new OrbitSegment
+                    {
+                        startUT = 200.0,
+                        endUT = 400.0,
+                        bodyName = "Mun",
+                        semiMajorAxis = 250000.0,
+                        eccentricity = 0.1,
+                        inclination = 0.0,
+                        longitudeOfAscendingNode = 0.0,
+                        argumentOfPeriapsis = 0.0,
+                        meanAnomalyAtEpoch = 0.0,
+                        epoch = 200.0,
+                    }
+                }
+            };
+        }
+
+        // Mirrors the production call site in ParsekFlight.ComputePlaybackFlags
+        // exactly so the test pins the (identity, stateKey) shape we ship.
+        private static void EmitSpawnerSuppression(int idx, string vesselName, string reason)
+        {
+            ParsekLog.VerboseOnChange(
+                "Spawner",
+                "spawn-suppressed|" + idx,
+                reason ?? "(none)",
+                $"Spawn suppressed for #{idx} \"{vesselName}\": {reason}");
+        }
+    }
+}

--- a/Source/Parsek.Tests/LogSpamRateLimitTests.cs
+++ b/Source/Parsek.Tests/LogSpamRateLimitTests.cs
@@ -159,13 +159,17 @@ namespace Parsek.Tests
         {
             // Simulate ComputePlaybackFlags running 50 frames over 5 recordings
             // all stuck in "no vessel snapshot". The fix keys identity per
-            // recording index and state per reason — stable reason on each
+            // RecordingId and state per reason — stable reason on each
             // recording must collapse to one line per recording.
             for (int frame = 0; frame < 50; frame++)
             {
                 for (int recIdx = 0; recIdx < 5; recIdx++)
                 {
-                    EmitSpawnerSuppression(recIdx, "Vessel " + recIdx, "no vessel snapshot");
+                    EmitSpawnerSuppression(
+                        recIdx,
+                        "rec-" + recIdx,
+                        "Vessel " + recIdx,
+                        "no vessel snapshot");
                 }
             }
 
@@ -183,10 +187,10 @@ namespace Parsek.Tests
             // Stable "no vessel snapshot" repeats, then the recording flips
             // to a different reason — the new reason must emit and carry
             // the suppressed count from the prior streak.
-            EmitSpawnerSuppression(7, "Showcase", "no vessel snapshot");
-            EmitSpawnerSuppression(7, "Showcase", "no vessel snapshot");
-            EmitSpawnerSuppression(7, "Showcase", "no vessel snapshot");
-            EmitSpawnerSuppression(7, "Showcase", "chain-suppressed");
+            EmitSpawnerSuppression(7, "rec-7", "Showcase", "no vessel snapshot");
+            EmitSpawnerSuppression(7, "rec-7", "Showcase", "no vessel snapshot");
+            EmitSpawnerSuppression(7, "rec-7", "Showcase", "no vessel snapshot");
+            EmitSpawnerSuppression(7, "rec-7", "Showcase", "chain-suppressed");
 
             var lines = logLines
                 .Where(l => l.Contains("[Spawner]") && l.Contains("Spawn suppressed for #7"))
@@ -197,6 +201,92 @@ namespace Parsek.Tests
             Assert.DoesNotContain("suppressed=", lines[0]);
             Assert.Contains("chain-suppressed", lines[1]);
             Assert.Contains("| suppressed=2", lines[1]);
+        }
+
+        // -------------------------------------------------------------------
+        // Spawner identity-by-RecordingId regression. The bare list index is
+        // not a stable identity — when a recording is discarded, recordings
+        // after it shift down one slot and the same index becomes a different
+        // recording. Keying VerboseOnChange on the index alone would let the
+        // new occupant inherit the prior recording's cached state (silently
+        // masking its first-emission line, or surfacing a stale suppressed
+        // counter on the next flip). Keying on RecordingId restores per-
+        // recording independence.
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void SpawnSuppression_IndexReuseAcrossRecordings_KeepsIndependentState()
+        {
+            // Two distinct recordings end up sharing index 294 (one was
+            // discarded between observations) and both report the same
+            // suppression reason. Each must emit its own first-emission line.
+            EmitSpawnerSuppression(294, "rec-A", "Untitled Space Craft", "no vessel snapshot");
+            EmitSpawnerSuppression(294, "rec-A", "Untitled Space Craft", "no vessel snapshot");
+            EmitSpawnerSuppression(294, "rec-A", "Untitled Space Craft", "no vessel snapshot");
+
+            // Index 294 is now occupied by recording B (rec-A discarded).
+            // Same reason — but a different RecordingId means a fresh
+            // first-emission, not silent inheritance of rec-A's cache.
+            EmitSpawnerSuppression(294, "rec-B", "Different Vessel", "no vessel snapshot");
+            EmitSpawnerSuppression(294, "rec-B", "Different Vessel", "no vessel snapshot");
+
+            var lines = logLines
+                .Where(l => l.Contains("[Spawner]") && l.Contains("Spawn suppressed for #294"))
+                .ToList();
+
+            Assert.Equal(2, lines.Count);
+            Assert.Contains("Untitled Space Craft", lines[0]);
+            Assert.DoesNotContain("suppressed=", lines[0]);
+            // The second line is rec-B's first emission — a clean first hit,
+            // NOT a delayed flip carrying rec-A's suppressed counter.
+            Assert.Contains("Different Vessel", lines[1]);
+            Assert.DoesNotContain("suppressed=", lines[1]);
+        }
+
+        [Fact]
+        public void SpawnSuppression_IndexReuse_StableReasonStillCoalescesPerRecording()
+        {
+            // Once each recording has emitted its first line, subsequent
+            // stable repeats must coalesce per-RecordingId — the cache must
+            // not be globally indexed by idx in a way that thrashes between
+            // recordings sharing the same slot.
+            EmitSpawnerSuppression(50, "rec-X", "Vessel X", "no vessel snapshot");
+            EmitSpawnerSuppression(50, "rec-Y", "Vessel Y", "no vessel snapshot");
+
+            // Interleave further per-frame calls — all stable. Each recording
+            // has its own state, so neither emits again until its reason flips.
+            for (int i = 0; i < 10; i++)
+            {
+                EmitSpawnerSuppression(50, "rec-X", "Vessel X", "no vessel snapshot");
+                EmitSpawnerSuppression(50, "rec-Y", "Vessel Y", "no vessel snapshot");
+            }
+
+            int xLines = logLines.Count(l =>
+                l.Contains("[Spawner]") && l.Contains("Vessel X"));
+            int yLines = logLines.Count(l =>
+                l.Contains("[Spawner]") && l.Contains("Vessel Y"));
+
+            Assert.Equal(1, xLines);
+            Assert.Equal(1, yLines);
+        }
+
+        [Fact]
+        public void SpawnSuppression_NullRecordingId_FallsBackToIndexInIdentity()
+        {
+            // Defensive case: if RecordingId is somehow null/empty, the call
+            // site falls back to "idx-{N}" so emissions still flow. Two
+            // null-Id recordings sharing the same index DO collide (no better
+            // identity is available), but a real RecordingId on a sibling
+            // recording is still tracked independently.
+            EmitSpawnerSuppressionRaw(idx: 9, recordingId: null, vesselName: "Anon",
+                reason: "no vessel snapshot");
+            EmitSpawnerSuppressionRaw(idx: 9, recordingId: null, vesselName: "Anon",
+                reason: "no vessel snapshot");
+
+            int anonLines = logLines.Count(l =>
+                l.Contains("[Spawner]") && l.Contains("Spawn suppressed for #9"));
+
+            Assert.Equal(1, anonLines);
         }
 
         // -------------------------------------------------------------------
@@ -274,11 +364,23 @@ namespace Parsek.Tests
 
         // Mirrors the production call site in ParsekFlight.ComputePlaybackFlags
         // exactly so the test pins the (identity, stateKey) shape we ship.
-        private static void EmitSpawnerSuppression(int idx, string vesselName, string reason)
+        // Identity is keyed on RecordingId (with an idx-{N} fallback for
+        // null/empty Ids) so two recordings that briefly share the same list
+        // index do not inherit each other's cached state.
+        private static void EmitSpawnerSuppression(
+            int idx, string recordingId, string vesselName, string reason)
         {
+            EmitSpawnerSuppressionRaw(idx, recordingId, vesselName, reason);
+        }
+
+        private static void EmitSpawnerSuppressionRaw(
+            int idx, string recordingId, string vesselName, string reason)
+        {
+            string identity = "spawn-suppressed|"
+                + (!string.IsNullOrEmpty(recordingId) ? recordingId : "idx-" + idx);
             ParsekLog.VerboseOnChange(
                 "Spawner",
-                "spawn-suppressed|" + idx,
+                identity,
                 reason ?? "(none)",
                 $"Spawn suppressed for #{idx} \"{vesselName}\": {reason}");
         }

--- a/Source/Parsek.Tests/ParsekLogTests.cs
+++ b/Source/Parsek.Tests/ParsekLogTests.cs
@@ -148,5 +148,137 @@ namespace Parsek.Tests
             Assert.False(ParsekLog.SuppressLogging);
             Assert.Null(ParsekLog.TestObserverForTesting);
         }
+
+        [Fact]
+        public void VerboseOnChange_FirstCallEmits()
+        {
+            var lines = new List<string>();
+            ParsekLog.TestSinkForTesting = line => lines.Add(line);
+            ParsekLog.VerboseOverrideForTesting = true;
+            ParsekLog.ResetRateLimitsForTesting();
+
+            ParsekLog.VerboseOnChange("UnitTest", "rec-A", "None|threshold", "decision A");
+
+            Assert.Single(lines);
+            Assert.Equal("[Parsek][VERBOSE][UnitTest] decision A", lines[0]);
+        }
+
+        [Fact]
+        public void VerboseOnChange_StableKey_SuppressesRepeats()
+        {
+            var lines = new List<string>();
+            ParsekLog.TestSinkForTesting = line => lines.Add(line);
+            ParsekLog.VerboseOverrideForTesting = true;
+            ParsekLog.ResetRateLimitsForTesting();
+
+            ParsekLog.VerboseOnChange("UnitTest", "rec-A", "None|threshold", "decision A1");
+            ParsekLog.VerboseOnChange("UnitTest", "rec-A", "None|threshold", "decision A2");
+            ParsekLog.VerboseOnChange("UnitTest", "rec-A", "None|threshold", "decision A3");
+
+            Assert.Single(lines);
+            Assert.Equal("[Parsek][VERBOSE][UnitTest] decision A1", lines[0]);
+        }
+
+        [Fact]
+        public void VerboseOnChange_KeyFlip_ReemitsWithSuppressedCount()
+        {
+            var lines = new List<string>();
+            ParsekLog.TestSinkForTesting = line => lines.Add(line);
+            ParsekLog.VerboseOverrideForTesting = true;
+            ParsekLog.ResetRateLimitsForTesting();
+
+            ParsekLog.VerboseOnChange("UnitTest", "rec-A", "None|threshold", "stable A");
+            ParsekLog.VerboseOnChange("UnitTest", "rec-A", "None|threshold", "stable A");
+            ParsekLog.VerboseOnChange("UnitTest", "rec-A", "None|threshold", "stable A");
+            ParsekLog.VerboseOnChange("UnitTest", "rec-A", "Segment|ok", "flipped to segment");
+
+            Assert.Equal(2, lines.Count);
+            Assert.Equal("[Parsek][VERBOSE][UnitTest] stable A", lines[0]);
+            Assert.Equal("[Parsek][VERBOSE][UnitTest] flipped to segment | suppressed=2", lines[1]);
+        }
+
+        [Fact]
+        public void VerboseOnChange_DifferentIdentities_TrackedIndependently()
+        {
+            var lines = new List<string>();
+            ParsekLog.TestSinkForTesting = line => lines.Add(line);
+            ParsekLog.VerboseOverrideForTesting = true;
+            ParsekLog.ResetRateLimitsForTesting();
+
+            ParsekLog.VerboseOnChange("UnitTest", "rec-A", "None|threshold", "A first");
+            ParsekLog.VerboseOnChange("UnitTest", "rec-B", "None|threshold", "B first");
+            ParsekLog.VerboseOnChange("UnitTest", "rec-A", "None|threshold", "A repeat");
+            ParsekLog.VerboseOnChange("UnitTest", "rec-B", "None|threshold", "B repeat");
+
+            Assert.Equal(2, lines.Count);
+            Assert.Equal("[Parsek][VERBOSE][UnitTest] A first", lines[0]);
+            Assert.Equal("[Parsek][VERBOSE][UnitTest] B first", lines[1]);
+        }
+
+        [Fact]
+        public void VerboseOnChange_SuppressedCountResetsAfterEmission()
+        {
+            var lines = new List<string>();
+            ParsekLog.TestSinkForTesting = line => lines.Add(line);
+            ParsekLog.VerboseOverrideForTesting = true;
+            ParsekLog.ResetRateLimitsForTesting();
+
+            ParsekLog.VerboseOnChange("UnitTest", "rec-A", "K1", "first");
+            ParsekLog.VerboseOnChange("UnitTest", "rec-A", "K1", "first");
+            ParsekLog.VerboseOnChange("UnitTest", "rec-A", "K1", "first");
+            ParsekLog.VerboseOnChange("UnitTest", "rec-A", "K2", "second");
+            ParsekLog.VerboseOnChange("UnitTest", "rec-A", "K2", "second");
+            ParsekLog.VerboseOnChange("UnitTest", "rec-A", "K1", "back to first");
+
+            Assert.Equal(3, lines.Count);
+            Assert.Equal("[Parsek][VERBOSE][UnitTest] first", lines[0]);
+            Assert.Equal("[Parsek][VERBOSE][UnitTest] second | suppressed=2", lines[1]);
+            Assert.Equal("[Parsek][VERBOSE][UnitTest] back to first | suppressed=1", lines[2]);
+        }
+
+        [Fact]
+        public void VerboseOnChange_SuppressedWhenVerboseDisabled()
+        {
+            var lines = new List<string>();
+            ParsekLog.TestSinkForTesting = line => lines.Add(line);
+            ParsekLog.VerboseOverrideForTesting = false;
+            ParsekLog.ResetRateLimitsForTesting();
+
+            ParsekLog.VerboseOnChange("UnitTest", "rec-A", "K1", "would emit");
+
+            Assert.Empty(lines);
+        }
+
+        [Fact]
+        public void VerboseOnChange_NullStateKeyTreatedAsEmpty()
+        {
+            var lines = new List<string>();
+            ParsekLog.TestSinkForTesting = line => lines.Add(line);
+            ParsekLog.VerboseOverrideForTesting = true;
+            ParsekLog.ResetRateLimitsForTesting();
+
+            ParsekLog.VerboseOnChange("UnitTest", "rec-A", null, "first");
+            ParsekLog.VerboseOnChange("UnitTest", "rec-A", null, "second");
+            ParsekLog.VerboseOnChange("UnitTest", "rec-A", "", "third");
+
+            Assert.Single(lines);
+            Assert.Equal("[Parsek][VERBOSE][UnitTest] first", lines[0]);
+        }
+
+        [Fact]
+        public void VerboseOnChange_EmptyIdentityFallsBackToVerbose()
+        {
+            var lines = new List<string>();
+            ParsekLog.TestSinkForTesting = line => lines.Add(line);
+            ParsekLog.VerboseOverrideForTesting = true;
+            ParsekLog.ResetRateLimitsForTesting();
+
+            ParsekLog.VerboseOnChange("UnitTest", null, "K1", "always");
+            ParsekLog.VerboseOnChange("UnitTest", "", "K1", "always");
+
+            Assert.Equal(2, lines.Count);
+            Assert.Equal("[Parsek][VERBOSE][UnitTest] always", lines[0]);
+            Assert.Equal("[Parsek][VERBOSE][UnitTest] always", lines[1]);
+        }
     }
 }

--- a/Source/Parsek/GhostMapPresence.cs
+++ b/Source/Parsek/GhostMapPresence.cs
@@ -2298,14 +2298,21 @@ namespace Parsek
                 srf.TerminalSma = traj?.TerminalOrbitSemiMajorAxis ?? double.NaN;
                 srf.TerminalEcc = traj?.TerminalOrbitEccentricity ?? double.NaN;
             }
-            ParsekLog.VerboseRateLimited(
+            // State-change-driven so a stuck (source, reason) decision doesn't
+            // re-emit on a wall-clock cadence. Identity scopes the cache per
+            // (operation, recording); the state key encodes (source, reason)
+            // so any decision flip reopens the gate.
+            ParsekLog.VerboseOnChange(
                 Tag,
                 string.Format(ic,
                     "gm-source-resolve-{0}-{1}",
-                    recId,
-                    source),
-                BuildGhostMapDecisionLine(srf),
-                5.0);
+                    logOperationName ?? "(none)",
+                    recId),
+                string.Format(ic,
+                    "{0}|{1}",
+                    source,
+                    string.IsNullOrEmpty(reason) ? "none" : reason),
+                BuildGhostMapDecisionLine(srf));
         }
 
         internal static TrackingStationGhostSource ResolveMapPresenceGhostSource(
@@ -2354,12 +2361,21 @@ namespace Parsek
                         resolvedStatePoint));
                 if (!string.IsNullOrEmpty(logOperationName))
                 {
-                    ParsekLog.VerboseRateLimited(
+                    // Per-frame caller — emit only when the (source, reason) decision
+                    // flips for this (operation, recording) pair. A stable
+                    // (None, state-vector-threshold) loop in the pending-create queue
+                    // would otherwise pour ~one line per recording per second; here
+                    // we emit once on entry into the state and again only when the
+                    // state actually changes. Suppressed-count is preserved on the
+                    // next emission so post-hoc audits can reconstruct the volume.
+                    ParsekLog.VerboseOnChange(
                         Tag,
                         string.Format(ic,
-                            "map-ghost-source-{0}-{1}-{2}-{3}",
+                            "map-ghost-source-{0}-{1}",
                             logOperationName,
-                            recId,
+                            recId),
+                        string.Format(ic,
+                            "{0}|{1}",
                             source,
                             reason ?? "none"),
                         string.Format(ic,

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -12063,11 +12063,19 @@ namespace Parsek
 
                 bool finalNeedsSpawn = spawnResult.needsSpawn && !chainSuppressed.suppressed;
 
-                // Log spawn suppression reason for non-debris recordings (diagnostic)
+                // Log spawn suppression reason for non-debris recordings (diagnostic).
+                // Emit only when the suppression reason flips for this recording —
+                // stable per-frame repeats (e.g., "no vessel snapshot" for the entire
+                // session) are coalesced into the suppressed counter and surfaced
+                // on the next reason change. Per-recording identity ensures a real
+                // reason flip on one recording doesn't mask another's stable state.
                 if (!finalNeedsSpawn && !rec.IsDebris)
                 {
                     string reason = !spawnResult.needsSpawn ? spawnResult.reason : chainSuppressed.reason;
-                    ParsekLog.VerboseRateLimited("Spawner", "spawn-suppressed-" + i,
+                    ParsekLog.VerboseOnChange(
+                        "Spawner",
+                        "spawn-suppressed|" + i,
+                        reason ?? "(none)",
                         $"Spawn suppressed for #{i} \"{rec.VesselName}\": {reason}");
                 }
 

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -12067,14 +12067,23 @@ namespace Parsek
                 // Emit only when the suppression reason flips for this recording —
                 // stable per-frame repeats (e.g., "no vessel snapshot" for the entire
                 // session) are coalesced into the suppressed counter and surfaced
-                // on the next reason change. Per-recording identity ensures a real
-                // reason flip on one recording doesn't mask another's stable state.
+                // on the next reason change. Identity is keyed on the stable
+                // RecordingId rather than the bare list index because the committed
+                // list is dense — when a recording is discarded, later recordings
+                // shift down and the same index gets reused for a different
+                // recording. Keying on index alone would let the new occupant
+                // inherit the prior recording's cached state and mask its first
+                // emission (or surface a stale suppressed counter on the next
+                // flip). The index still appears in the message body so audits
+                // can resolve recordings post-hoc.
                 if (!finalNeedsSpawn && !rec.IsDebris)
                 {
                     string reason = !spawnResult.needsSpawn ? spawnResult.reason : chainSuppressed.reason;
+                    string identity = "spawn-suppressed|"
+                        + (!string.IsNullOrEmpty(rec.RecordingId) ? rec.RecordingId : "idx-" + i);
                     ParsekLog.VerboseOnChange(
                         "Spawner",
-                        "spawn-suppressed|" + i,
+                        identity,
                         reason ?? "(none)",
                         $"Spawn suppressed for #{i} \"{rec.VesselName}\": {reason}");
                 }

--- a/Source/Parsek/ParsekLog.cs
+++ b/Source/Parsek/ParsekLog.cs
@@ -37,12 +37,28 @@ namespace Parsek
             public int suppressedCount;
         }
 
+        private struct OnChangeState
+        {
+            public string lastKey;
+            public int suppressedCount;
+        }
+
         // ThreadStatic so each xUnit thread gets its own rate-limit state.
         // Backing field is null on non-initial threads; property lazy-creates.
         [ThreadStatic]
         private static Dictionary<string, RateLimitState> t_rateLimitStateByKey;
         private static Dictionary<string, RateLimitState> rateLimitStateByKey =>
             t_rateLimitStateByKey ?? (t_rateLimitStateByKey = new Dictionary<string, RateLimitState>());
+
+        // Tracks last-emitted key per stable identity for VerboseOnChange. The
+        // dictionary is keyed by a caller-chosen "identity" (e.g., "GhostMap|<recId>")
+        // and stores the most recent decision key plus a suppressed counter. A new
+        // emission fires only when the decision key flips; otherwise the suppressed
+        // counter is bumped and surfaced via "| suppressed=N" on the next change.
+        [ThreadStatic]
+        private static Dictionary<string, OnChangeState> t_onChangeStateByIdentity;
+        private static Dictionary<string, OnChangeState> onChangeStateByIdentity =>
+            t_onChangeStateByIdentity ?? (t_onChangeStateByIdentity = new Dictionary<string, OnChangeState>());
 
         private const double DefaultRateLimitSeconds = 5.0;
         private static readonly DateTime UnixEpochUtc = new DateTime(1970, 1, 1);
@@ -69,6 +85,7 @@ namespace Parsek
         internal static void ResetRateLimitsForTesting()
         {
             rateLimitStateByKey.Clear();
+            onChangeStateByIdentity.Clear();
         }
 
         internal static void ResetTestOverrides()
@@ -184,6 +201,67 @@ namespace Parsek
             }
 
             rateLimitStateByKey[compositeKey] = state;
+        }
+
+        /// <summary>
+        /// State-change-driven verbose log. Emits <paramref name="message"/> only when
+        /// <paramref name="stateKey"/> differs from the last emitted state for the
+        /// given <paramref name="identity"/>. Stable per-frame repeats with the same
+        /// <paramref name="stateKey"/> are coalesced into a suppressed counter that
+        /// is surfaced as <c>| suppressed=N</c> on the next change emission.
+        /// </summary>
+        /// <remarks>
+        /// Use when the line should fire on every decision flip (None to Segment, etc.)
+        /// but stay completely silent across stable per-frame repeats — the time-based
+        /// re-emission of <see cref="VerboseRateLimited"/> would still spam the log
+        /// for long-stable states (e.g., a recording stuck in pending for the entire
+        /// session). The <paramref name="identity"/> is the stable scope to track
+        /// (typically "<![CDATA[<subsystem>|<recId>]]>") and <paramref name="stateKey"/>
+        /// encodes the decision tuple whose changes you care about.
+        /// </remarks>
+        public static void VerboseOnChange(
+            string subsystem,
+            string identity,
+            string stateKey,
+            string message)
+        {
+            if (!IsVerboseEnabled)
+                return;
+
+            if (string.IsNullOrEmpty(identity))
+            {
+                Verbose(subsystem, message);
+                return;
+            }
+
+            string compositeIdentity = $"{subsystem}|{identity}";
+            string normalizedKey = stateKey ?? string.Empty;
+            if (!onChangeStateByIdentity.TryGetValue(compositeIdentity, out var state))
+            {
+                onChangeStateByIdentity[compositeIdentity] = new OnChangeState
+                {
+                    lastKey = normalizedKey,
+                    suppressedCount = 0
+                };
+                Verbose(subsystem, message);
+                return;
+            }
+
+            if (state.lastKey != normalizedKey)
+            {
+                string suffix = state.suppressedCount > 0
+                    ? $" | suppressed={state.suppressedCount}"
+                    : string.Empty;
+                Verbose(subsystem, $"{message}{suffix}");
+                state.lastKey = normalizedKey;
+                state.suppressedCount = 0;
+            }
+            else
+            {
+                state.suppressedCount++;
+            }
+
+            onChangeStateByIdentity[compositeIdentity] = state;
         }
 
         /// <summary>

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1621,12 +1621,21 @@ inherited from `ParsekLog.DefaultRateLimitSeconds`.
 
 ## ~~Log spam: `[GhostMap] map-presence-{pending,initial}-create` and `[Spawner] Spawn suppressed: no vessel snapshot` re-emit on every frame across stable per-frame decisions~~
 
-**Source:** `logs/2026-04-25_2147/Player.log` — 228k Parsek lines in a
-27-minute playtest, ~13,719 of which were `[GhostMap]
-map-presence-pending-create` (9,950) / `map-presence-initial-create`
-(3,769) verbose lines, plus ~5,000 `[Spawner] Spawn suppressed for #X
-"Y": no vessel snapshot` lines (51 distinct `(idx, vessel)` tuples,
-each repeated ~99 times).
+**Source:** `logs/2026-04-25_2147/` (KSP.log + Player.log mirror the
+same Parsek output — counts below are per-file; sum across both is
+the same number doubled) — 228k Parsek lines in a 27-minute playtest,
+~13,719 of which were `[GhostMap] map-presence-pending-create` (9,950)
+/ `map-presence-initial-create` (3,769) verbose lines, plus 14,487
+`[Spawner] Spawn suppressed for #X "Y": <reason>` lines spanning 286
+distinct `(idx, vessel)` tuples. Reproduce with:
+
+```bash
+grep -c "Spawn suppressed for #" logs/2026-04-25_2147/KSP.log
+grep -c "Spawn suppressed for #" logs/2026-04-25_2147/Player.log
+grep -h "Spawn suppressed for #" logs/2026-04-25_2147/KSP.log \
+    logs/2026-04-25_2147/Player.log \
+    | grep -oE '#[0-9]+ "[^"]+"' | sort -u | wc -l
+```
 
 **Diagnosis (2026-04-25):** `GhostMapPresence.ResolveMapPresenceGhostSource`
 fires from two per-frame call sites (`ParsekPlaybackPolicy.cs:867` for
@@ -1656,16 +1665,25 @@ now route through the helper:
   — identity `gm-source-resolve-<op>-<recId>`, state key
   `(source, reason)`.
 - `ParsekFlight.ComputePlaybackFlags` (`ParsekFlight.cs:12070`) —
-  identity `spawn-suppressed|<idx>`, state key is the suppression
-  reason itself, so a reason flip on the same recording emits a
-  fresh line.
+  identity `spawn-suppressed|<rec.RecordingId>` (with `idx-<i>`
+  fallback when RecordingId is null/empty), state key is the
+  suppression reason itself. The 2026-04-25_2147 logs show index 294
+  reused across recordings as discards reshuffle the committed list,
+  so keying on `RecordingId` rather than the bare index keeps each
+  recording's first-emission line and suppressed counter independent.
+  The bare index still appears in the message body so audits can
+  resolve recordings post-hoc.
 
 **Tests:** `ParsekLogTests.VerboseOnChange_*` (8 cases covering first
 emission, stable suppression, key flip with suppressed counter,
 independent identities, suppressed-count reset, verbose disabled, null
 state key, empty identity fallback) plus
 `LogSpamRateLimitTests.GhostMapSourceResolve_*` and
-`LogSpamRateLimitTests.Spawner_*` for the call-site integration.
+`LogSpamRateLimitTests.Spawner_*` for the call-site integration. The
+index-reuse-across-recordings case is pinned by
+`LogSpamRateLimitTests.SpawnSuppression_IndexReuseAcrossRecordings_KeepsIndependentState`
+(plus `_StableReasonStillCoalescesPerRecording` and
+`_NullRecordingId_FallsBackToIndexInIdentity`).
 
 **Status:** CLOSED 2026-04-25. Fixed for v0.9.0. Reproduced from the
 `logs/2026-04-25_2147` playtest folder.

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1619,6 +1619,59 @@ inherited from `ParsekLog.DefaultRateLimitSeconds`.
 
 ---
 
+## ~~Log spam: `[GhostMap] map-presence-{pending,initial}-create` and `[Spawner] Spawn suppressed: no vessel snapshot` re-emit on every frame across stable per-frame decisions~~
+
+**Source:** `logs/2026-04-25_2147/Player.log` — 228k Parsek lines in a
+27-minute playtest, ~13,719 of which were `[GhostMap]
+map-presence-pending-create` (9,950) / `map-presence-initial-create`
+(3,769) verbose lines, plus ~5,000 `[Spawner] Spawn suppressed for #X
+"Y": no vessel snapshot` lines (51 distinct `(idx, vessel)` tuples,
+each repeated ~99 times).
+
+**Diagnosis (2026-04-25):** `GhostMapPresence.ResolveMapPresenceGhostSource`
+fires from two per-frame call sites (`ParsekPlaybackPolicy.cs:867` for
+the pending queue and `:758` for initial create) and emits two verbose
+diagnostic lines per call. The previous wiring used
+`VerboseRateLimited` with the default 5s window keyed on
+`(operation, recId, source, reason)`, so a recording stuck in
+`source=None reason=state-vector-threshold` for the entire session
+still emitted ~one line per recording per 5 seconds (50 recordings ×
+324 5-second windows ≈ 16,200 emissions). `ParsekFlight.ComputePlaybackFlags`
+emitted `Spawn suppressed for #X "Y": <reason>` keyed by `idx` only
+(no reason in the key), so a recording whose suppression reason
+flipped between e.g. `"no vessel snapshot"` and `"chain-suppressed"`
+mid-session would only surface one of them per 5s window.
+
+**Fix:** added `ParsekLog.VerboseOnChange(subsystem, identity,
+stateKey, message)` — emits only when `stateKey` flips for the given
+`identity`, surfacing the suppressed count as `| suppressed=N` on the
+next change. Per-frame stable streaks coalesce into a single emission
+on entry plus one on exit, regardless of duration. Three call sites
+now route through the helper:
+
+- `GhostMapPresence.ResolveMapPresenceGhostSource.ReturnDecision`
+  (`GhostMapPresence.cs:2357`) — identity `map-ghost-source-<op>-<recId>`,
+  state key `(source, reason)`.
+- `GhostMapPresence.EmitSourceResolveLine` (`GhostMapPresence.cs:2301`)
+  — identity `gm-source-resolve-<op>-<recId>`, state key
+  `(source, reason)`.
+- `ParsekFlight.ComputePlaybackFlags` (`ParsekFlight.cs:12070`) —
+  identity `spawn-suppressed|<idx>`, state key is the suppression
+  reason itself, so a reason flip on the same recording emits a
+  fresh line.
+
+**Tests:** `ParsekLogTests.VerboseOnChange_*` (8 cases covering first
+emission, stable suppression, key flip with suppressed counter,
+independent identities, suppressed-count reset, verbose disabled, null
+state key, empty identity fallback) plus
+`LogSpamRateLimitTests.GhostMapSourceResolve_*` and
+`LogSpamRateLimitTests.Spawner_*` for the call-site integration.
+
+**Status:** CLOSED 2026-04-25. Fixed for v0.9.0. Reproduced from the
+`logs/2026-04-25_2147` playtest folder.
+
+---
+
 ## ~~596. Log spam: `KspStatePatcher.PatchFacilities` emits an INFO summary on every recalc even when there is nothing to patch~~
 
 **Source:** `logs/2026-04-25_1933_refly-bugs/KSP.log` — 42 ×


### PR DESCRIPTION
## Summary

The `2026-04-25_2147` playtest emitted **13,719** `[GhostMap]
map-presence-{pending,initial}-create` lines and **~5,000** `[Spawner]
"no vessel snapshot"` lines across a 27-minute session. Both call sites used
time-based `VerboseRateLimited`, so a recording stuck in a single
`(source, reason)` decision (e.g. a long-pending pre-orbital recording) kept
re-emitting on the 5s window.

- New `ParsekLog.VerboseOnChange(subsystem, identity, stateKey, message)`
  emits only when the state key flips for a given identity. Stable streaks
  coalesce into one emission on entry plus one on exit; the suppressed count
  is surfaced as `| suppressed=N` on the next change so post-hoc audits can
  reconstruct volume.
- Three per-frame hot-path call sites now route through the helper:
  - `GhostMapPresence.ResolveMapPresenceGhostSource.ReturnDecision`
  - `GhostMapPresence.EmitSourceResolveLine`
  - `ParsekFlight.ComputePlaybackFlags` spawn-suppression diagnostic
    (the reason is now part of the state key, so a reason flip on the same
    recording emits a fresh line instead of being masked by the prior window)

## Test plan

- [x] `dotnet build` from `Source/Parsek` succeeds; deployed DLL contains the
  new `spawn-suppressed|` and `gm-source-resolve-` keys.
- [x] `dotnet test` from `Source/Parsek.Tests` passes (8829 / 8829, the one
  pre-existing skip is `InjectAllRecordings` because KSP is running).
- [x] 8 new `ParsekLogTests.VerboseOnChange_*` cases cover first emission,
  stable suppression, key flip with suppressed counter, independent identities,
  suppressed-count reset, verbose disabled, null state key, and empty identity
  fallback.
- [x] `LogSpamRateLimitTests` integration tests pin the GhostMap source-resolve
  and Spawner call sites end-to-end (multi-operation, multi-recording, decision
  flip with `| suppressed=N` tail).
- [ ] In-game playtest after merge: confirm the next session's `KSP.log` no
  longer carries the pending/initial-create or "no vessel snapshot" floods.