### PR TITLE
Keep stationary ghosts visible at high warp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
-- `#599` Stationary surface ghosts now stay visible above the 50x high-warp mesh-hide threshold. Flight and KSC playback still hide moving ghosts and overlap clones for performance, and still suppress FX/audio above the existing FX threshold, but `SurfaceStationary` track sections keep their primary mesh active because the ghost is not chasing a high-rate trajectory.
+- `#599` Stationary landed or splashed ghosts now stay visible above the 50x high-warp mesh-hide threshold. Moving ghosts and overlap clones still hide for performance, and FX/audio suppression is unchanged.
 
 - `#571` In-game regression `GhostMapCheckpointSourceLogResolvesWorldPosition` now matches the shipped resolver contract: an OrbitalCheckpoint section that coexists with its seed orbit segment resolves to `Segment` (the densified frames sample along the same Keplerian arc), not `StateVector`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- `#599` Stationary surface ghosts now stay visible above the 50x high-warp mesh-hide threshold. Flight and KSC playback still hide moving ghosts and overlap clones for performance, and still suppress FX/audio above the existing FX threshold, but `SurfaceStationary` track sections keep their primary mesh active because the ghost is not chasing a high-rate trajectory.
+
 - `#571` In-game regression `GhostMapCheckpointSourceLogResolvesWorldPosition` now matches the shipped resolver contract: an OrbitalCheckpoint section that coexists with its seed orbit segment resolves to `Segment` (the densified frames sample along the same Keplerian arc), not `StateVector`.
 
 - `#526` Time-jump auto-record suppression now also reports synthetic-spawn-vessel situation flickers as "suppressing time-jump transient" (instead of as a generic non-active-vessel skip), so the in-game pad canaries reliably observe the protective branch firing during Real Spawn Control and Timeline FF jumps. Auto-record start behaviour for the real pad vessel is unchanged.

--- a/Source/Parsek.Tests/Bug290Tests.cs
+++ b/Source/Parsek.Tests/Bug290Tests.cs
@@ -200,6 +200,21 @@ namespace Parsek.Tests
 
     public class Bug290_WarpSuppressionMapViewTests
     {
+        private static MockTrajectory MakeSectionTrajectory(SegmentEnvironment environment)
+        {
+            var traj = new MockTrajectory().WithTimeRange(0.0, 100.0);
+            traj.TrackSections.Add(new TrackSection
+            {
+                environment = environment,
+                referenceFrame = ReferenceFrame.Absolute,
+                startUT = 0.0,
+                endUT = 100.0,
+                frames = traj.Points,
+                source = TrackSectionSource.Active
+            });
+            return traj;
+        }
+
         [Fact]
         public void ShouldSuppressGhosts_HighWarp_ReturnsTrue()
         {
@@ -242,6 +257,81 @@ namespace Parsek.Tests
             bool suppress = !mapViewEnabled
                 && GhostPlaybackLogic.ShouldSuppressGhosts(lowWarp);
             Assert.False(suppress);
+        }
+
+        [Fact]
+        public void ShouldSuppressGhostMeshAtWarp_SurfaceStationarySection_ReturnsFalse()
+        {
+            var traj = MakeSectionTrajectory(SegmentEnvironment.SurfaceStationary);
+
+            Assert.False(GhostPlaybackLogic.ShouldSuppressGhostMeshAtWarp(100f, traj, 50.0));
+        }
+
+        [Fact]
+        public void ShouldSuppressGhostMeshAtWarp_SurfaceMobileSection_ReturnsTrue()
+        {
+            var traj = MakeSectionTrajectory(SegmentEnvironment.SurfaceMobile);
+
+            Assert.True(GhostPlaybackLogic.ShouldSuppressGhostMeshAtWarp(100f, traj, 50.0));
+        }
+
+        [Fact]
+        public void ShouldSuppressGhostMeshAtWarp_SurfaceOnlyTrajectory_ReturnsFalse()
+        {
+            var traj = new MockTrajectory
+            {
+                SurfacePos = new SurfacePosition
+                {
+                    body = "Kerbin",
+                    situation = SurfaceSituation.Landed
+                }
+            };
+
+            Assert.False(GhostPlaybackLogic.ShouldSuppressGhostMeshAtWarp(100f, traj, 50.0));
+        }
+
+        [Fact]
+        public void ShouldSuppressGhostMeshAtWarp_LowWarpMovingSection_ReturnsFalse()
+        {
+            var traj = MakeSectionTrajectory(SegmentEnvironment.Atmospheric);
+
+            Assert.False(GhostPlaybackLogic.ShouldSuppressGhostMeshAtWarp(10f, traj, 50.0));
+        }
+
+        [Fact]
+        public void ShouldSuppressGhostMeshAtWarp_NewestStationaryOverlapCycle_ReturnsFalse()
+        {
+            var traj = MakeSectionTrajectory(SegmentEnvironment.SurfaceStationary);
+
+            Assert.True(GhostPlaybackLogic.TryComputeNewestOverlapPlaybackUT(
+                currentUT: 65.0,
+                intervalSeconds: 30.0,
+                duration: 100.0,
+                playbackStartUT: 0.0,
+                scheduleStartUT: 0.0,
+                out double playbackUT,
+                out long cycleIndex));
+            Assert.Equal(2, cycleIndex);
+            Assert.Equal(5.0, playbackUT, 6);
+            Assert.False(GhostPlaybackLogic.ShouldSuppressGhostMeshAtWarp(
+                100f, traj, playbackUT));
+        }
+
+        [Fact]
+        public void ShouldSuppressGhostMeshAtWarp_NewestMovingOverlapCycle_ReturnsTrue()
+        {
+            var traj = MakeSectionTrajectory(SegmentEnvironment.SurfaceMobile);
+
+            Assert.True(GhostPlaybackLogic.TryComputeNewestOverlapPlaybackUT(
+                currentUT: 65.0,
+                intervalSeconds: 30.0,
+                duration: 100.0,
+                playbackStartUT: 0.0,
+                scheduleStartUT: 0.0,
+                out double playbackUT,
+                out _));
+            Assert.True(GhostPlaybackLogic.ShouldSuppressGhostMeshAtWarp(
+                100f, traj, playbackUT));
         }
     }
 }

--- a/Source/Parsek.Tests/GhostPlaybackEngineTests.cs
+++ b/Source/Parsek.Tests/GhostPlaybackEngineTests.cs
@@ -1328,6 +1328,63 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void UpdateOverlapPlayback_HighWarpStationaryOverlap_KeepsPrimaryAndClearsOverlaps()
+        {
+            var positioner = new SpawnPrimingPositioner();
+            var engine = new GhostPlaybackEngine(positioner);
+            var traj = new MockTrajectory
+            {
+                IsDebris = true, // keep xUnit on the no-Unity-GameObject path
+                VesselName = "StationaryOverlap",
+                RecordingId = "rec-stationary-overlap",
+            }.WithTimeRange(100, 200).WithLoop(30);
+            traj.TrackSections.Add(new TrackSection
+            {
+                environment = SegmentEnvironment.SurfaceStationary,
+                referenceFrame = ReferenceFrame.Absolute,
+                startUT = 100,
+                endUT = 200,
+                frames = traj.Points,
+                source = TrackSectionSource.Active,
+            });
+
+            var primaryState = new GhostPlaybackState
+            {
+                vesselName = "StationaryOverlap",
+                loopCycleIndex = 2,
+            };
+            engine.ghostStates[5] = primaryState;
+            engine.overlapGhosts[5] = new List<GhostPlaybackState>
+            {
+                null
+            };
+
+            engine.UpdateOverlapPlaybackForTesting(
+                index: 5,
+                traj,
+                flags: default,
+                ctx: new FrameContext
+                {
+                    currentUT = 160,
+                    warpRate = 100f,
+                    activeVesselPos = new Vector3d(0, 0, 0),
+                    protectedIndex = -1,
+                    protectedLoopCycleIndex = -1,
+                    autoLoopIntervalSeconds = 30,
+                },
+                primaryState,
+                suppressVisualFx: true,
+                suppressOverlapGhosts: true,
+                stopAfterSuppressOverlapGhosts: true);
+
+            Assert.True(engine.TryGetGhostState(5, out var keptPrimary));
+            Assert.Same(primaryState, keptPrimary);
+            Assert.True(engine.TryGetOverlapGhosts(5, out var overlaps));
+            Assert.Empty(overlaps);
+            Assert.Equal(0, engine.FrameOverlapGhostIterationCountForTesting);
+        }
+
+        [Fact]
         public void ShouldPrewarmHiddenGhost_NearVisibleTierBoundary_ReturnsTrue()
         {
             var traj = new MockTrajectory().WithTimeRange(100, 200);

--- a/Source/Parsek/GhostPlaybackEngine.cs
+++ b/Source/Parsek/GhostPlaybackEngine.cs
@@ -1306,7 +1306,8 @@ namespace Parsek
             GhostPlaybackState primaryState,
             double intervalSeconds, double duration,
             double playbackStartUT, double scheduleStartUT,
-            bool suppressVisualFx, bool suppressOverlapGhosts = false)
+            bool suppressVisualFx, bool suppressOverlapGhosts = false,
+            bool stopAfterSuppressOverlapGhostsForTesting = false)
         {
             if (ctx.currentUT < scheduleStartUT)
             {
@@ -1347,6 +1348,8 @@ namespace Parsek
             {
                 DestroyAllOverlapGhosts(index);
             }
+            if (suppressOverlapGhosts && stopAfterSuppressOverlapGhostsForTesting)
+                return;
 
             // Primary ghost represents the newest (lastCycle)
             bool primaryCycleChanged = HasLoopCycleChanged(primaryState, lastCycle);
@@ -3083,7 +3086,9 @@ namespace Parsek
 
         internal void UpdateOverlapPlaybackForTesting(
             int index, IPlaybackTrajectory traj, TrajectoryPlaybackFlags flags,
-            FrameContext ctx, GhostPlaybackState primaryState, bool suppressVisualFx)
+            FrameContext ctx, GhostPlaybackState primaryState, bool suppressVisualFx,
+            bool suppressOverlapGhosts = false,
+            bool stopAfterSuppressOverlapGhosts = false)
         {
             if (!TryResolveLoopSchedule(
                     traj, ctx.autoLoopIntervalSeconds, index,
@@ -3094,7 +3099,8 @@ namespace Parsek
                 return;
 
             UpdateOverlapPlayback(index, traj, flags, ctx, primaryState,
-                intervalSeconds, duration, playbackStartUT, scheduleStartUT, suppressVisualFx);
+                intervalSeconds, duration, playbackStartUT, scheduleStartUT,
+                suppressVisualFx, suppressOverlapGhosts, stopAfterSuppressOverlapGhosts);
         }
 
         private GhostVisualLoadStatus TryPopulateGhostVisuals(

--- a/Source/Parsek/GhostPlaybackEngine.cs
+++ b/Source/Parsek/GhostPlaybackEngine.cs
@@ -503,7 +503,10 @@ namespace Parsek
                             continue;
                         }
 
-                        if (parentPaused || suppressGhosts)
+                        bool suppressLoopSyncGhost = suppressGhosts
+                            && GhostPlaybackLogic.ShouldSuppressGhostMeshAtWarp(
+                                ctx.warpRate, traj, parentLoopUT);
+                        if (parentPaused || suppressLoopSyncGhost)
                         {
                             if (state != null)
                                 DestroyGhost(i, traj, f, reason: "parent loop paused/warp");
@@ -543,8 +546,9 @@ namespace Parsek
                     }
                 }
 
-                // === Warp suppression: hide ghost during high warp ===
-                if (suppressGhosts && state != null)
+                // === Warp suppression: hide moving ghosts during high warp ===
+                if (suppressGhosts && GhostPlaybackLogic.ShouldSuppressGhostMeshAtWarp(
+                        ctx.warpRate, traj, ctx.currentUT))
                 {
                     if (ghostActive && state.ghost.activeSelf)
                     {
@@ -1039,8 +1043,67 @@ namespace Parsek
                 return;
             }
 
-            // High time warp: hide ghost, destroy overlaps
-            if (suppressGhosts)
+            // #381: If the period is shorter than the recording duration, successive
+            // launches overlap — use multi-cycle path.
+            if (GhostPlaybackLogic.IsOverlapLoop(intervalSeconds, duration))
+            {
+                bool suppressOverlapGhosts = false;
+                if (suppressGhosts
+                    && (!GhostPlaybackLogic.TryComputeNewestOverlapPlaybackUT(
+                            ctx.currentUT,
+                            intervalSeconds,
+                            duration,
+                            playbackStartUT,
+                            scheduleStartUT,
+                            out double overlapLoopUT,
+                            out _)
+                        || GhostPlaybackLogic.ShouldSuppressGhostMeshAtWarp(
+                            ctx.warpRate, traj, overlapLoopUT)))
+                {
+                    if (ghostActive && state.ghost.activeSelf)
+                    {
+                        state.ghost.SetActive(false);
+                        ParsekLog.Info("Engine",
+                            $"Ghost #{index} \"{traj.VesselName}\" (loop) hidden: warp > {WarpThresholds.GhostHide}x");
+                        OnLoopCameraAction?.Invoke(new CameraActionEvent
+                        {
+                            Index = index, Action = CameraActionType.ExitWatch,
+                            Trajectory = traj, Flags = flags
+                        });
+                    }
+                    DestroyAllOverlapGhosts(index);
+                    return;
+                }
+                else if (suppressGhosts)
+                {
+                    // Keep the newest stationary primary mesh visible, but continue
+                    // culling overlap clones at high warp for the original perf reason.
+                    suppressOverlapGhosts = true;
+                }
+
+                UpdateOverlapPlayback(index, traj, flags, ctx, state,
+                    intervalSeconds, duration, playbackStartUT, scheduleStartUT,
+                    suppressVisualFx, suppressOverlapGhosts);
+                return;
+            }
+
+            // --- Period >= duration: single ghost path (pause window may apply) ---
+            DestroyAllOverlapGhosts(index);
+            double loopUT;
+            long cycleIndex;
+            bool inPauseWindow;
+            if (!TryComputeLoopPlaybackUT(traj, ctx.currentUT, ctx.autoLoopIntervalSeconds,
+                    out loopUT, out cycleIndex, out inPauseWindow, index))
+            {
+                if (ghostActive)
+                    DestroyGhost(index, traj, flags, reason: "loop UT computation failed");
+                return;
+            }
+
+            // High time warp: hide moving loop ghosts, but keep stationary surface
+            // segments visible because their mesh is not chasing a high-rate trajectory.
+            if (suppressGhosts && GhostPlaybackLogic.ShouldSuppressGhostMeshAtWarp(
+                    ctx.warpRate, traj, loopUT))
             {
                 if (ghostActive && state.ghost.activeSelf)
                 {
@@ -1055,28 +1118,6 @@ namespace Parsek
                     });
                 }
                 DestroyAllOverlapGhosts(index);
-                return;
-            }
-
-            // #381: If the period is shorter than the recording duration, successive
-            // launches overlap — use multi-cycle path.
-            if (GhostPlaybackLogic.IsOverlapLoop(intervalSeconds, duration))
-            {
-                UpdateOverlapPlayback(index, traj, flags, ctx, state,
-                    intervalSeconds, duration, playbackStartUT, scheduleStartUT, suppressVisualFx);
-                return;
-            }
-
-            // --- Period >= duration: single ghost path (pause window may apply) ---
-            DestroyAllOverlapGhosts(index);
-            double loopUT;
-            long cycleIndex;
-            bool inPauseWindow;
-            if (!TryComputeLoopPlaybackUT(traj, ctx.currentUT, ctx.autoLoopIntervalSeconds,
-                    out loopUT, out cycleIndex, out inPauseWindow, index))
-            {
-                if (ghostActive)
-                    DestroyGhost(index, traj, flags, reason: "loop UT computation failed");
                 return;
             }
 
@@ -1265,7 +1306,7 @@ namespace Parsek
             GhostPlaybackState primaryState,
             double intervalSeconds, double duration,
             double playbackStartUT, double scheduleStartUT,
-            bool suppressVisualFx)
+            bool suppressVisualFx, bool suppressOverlapGhosts = false)
         {
             if (ctx.currentUT < scheduleStartUT)
             {
@@ -1302,6 +1343,10 @@ namespace Parsek
                 overlaps = new List<GhostPlaybackState>();
                 overlapGhosts[index] = overlaps;
             }
+            else if (suppressOverlapGhosts)
+            {
+                DestroyAllOverlapGhosts(index);
+            }
 
             // Primary ghost represents the newest (lastCycle)
             bool primaryCycleChanged = HasLoopCycleChanged(primaryState, lastCycle);
@@ -1319,21 +1364,29 @@ namespace Parsek
                 // Move old primary to overlap list if still alive
                 if (primaryState != null)
                 {
-                    ghostStates.Remove(index);
-                    if (primaryState.pendingSpawnLifecycle != PendingSpawnLifecycle.None)
+                    if (suppressOverlapGhosts)
                     {
-                        // Bug #450 B2: a primary that gets demoted to the overlap list before
-                        // its split build completes must NOT later finalize as a brand-new
-                        // overlap-primary enter. The old cycle should quietly finish as an
-                        // overlap shell with no ghost-created / camera-retarget side effects.
-                        primaryState.pendingSpawnLifecycle = PendingSpawnLifecycle.None;
-                        primaryState.pendingSpawnFlags = default(TrajectoryPlaybackFlags);
+                        DestroyGhost(index, traj, flags,
+                            reason: "stationary high-warp overlap primary advanced");
                     }
-                    if (primaryState.ghost != null)
-                        GhostPlaybackLogic.MuteAllAudio(primaryState); // overlap ghosts get no audio
-                    overlaps.Add(primaryState);
-                    ParsekLog.VerboseRateLimited("Engine", "overlap-move",
-                        $"Ghost #{index} cycle={primaryState.loopCycleIndex} moved to overlap list (audio muted)");
+                    else
+                    {
+                        ghostStates.Remove(index);
+                        if (primaryState.pendingSpawnLifecycle != PendingSpawnLifecycle.None)
+                        {
+                            // Bug #450 B2: a primary that gets demoted to the overlap list before
+                            // its split build completes must NOT later finalize as a brand-new
+                            // overlap-primary enter. The old cycle should quietly finish as an
+                            // overlap shell with no ghost-created / camera-retarget side effects.
+                            primaryState.pendingSpawnLifecycle = PendingSpawnLifecycle.None;
+                            primaryState.pendingSpawnFlags = default(TrajectoryPlaybackFlags);
+                        }
+                        if (primaryState.ghost != null)
+                            GhostPlaybackLogic.MuteAllAudio(primaryState); // overlap ghosts get no audio
+                        overlaps.Add(primaryState);
+                        ParsekLog.VerboseRateLimited("Engine", "overlap-move",
+                            $"Ghost #{index} cycle={primaryState.loopCycleIndex} moved to overlap list (audio muted)");
+                    }
                 }
 
                 // Spawn new primary for lastCycle
@@ -1426,6 +1479,9 @@ namespace Parsek
                     }
                 }
             }
+
+            if (suppressOverlapGhosts)
+                return;
 
             // Update overlap ghosts (older cycles)
             UpdateExpireAndPositionOverlaps(index, traj, flags, ctx, overlaps,

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -126,6 +126,30 @@ namespace Parsek
             return currentWarpRate > WarpThresholds.GhostHide;
         }
 
+        internal static bool ShouldSuppressGhostMeshAtWarp(
+            float currentWarpRate, IPlaybackTrajectory traj, double playbackUT)
+        {
+            return ShouldSuppressGhosts(currentWarpRate)
+                && !IsSurfaceStationaryAtPlaybackUT(traj, playbackUT);
+        }
+
+        internal static bool IsSurfaceStationaryAtPlaybackUT(
+            IPlaybackTrajectory traj, double playbackUT)
+        {
+            if (traj == null)
+                return false;
+
+            int sectionIdx = TrajectoryMath.FindTrackSectionForUT(traj.TrackSections, playbackUT);
+            if (sectionIdx >= 0)
+                return traj.TrackSections[sectionIdx].environment == SegmentEnvironment.SurfaceStationary;
+
+            // Surface-only trajectories have no moving payload to replay; keep their
+            // already-static mesh visible even when no TrackSections are available.
+            return traj.SurfacePos.HasValue
+                && (traj.Points == null || traj.Points.Count == 0)
+                && !traj.HasOrbitSegments;
+        }
+
         /// <summary>
         /// Returns true if a ghost should be exempt from zone-based hiding during time warp.
         /// Orbital ghosts travel far from the player during warp; hiding them at 120km causes
@@ -257,6 +281,47 @@ namespace Parsek
             if (phase < 0) phase = 0;
             if (phase > duration) phase = duration;
             return playbackStartUT + phase;
+        }
+
+        internal static bool TryComputeNewestOverlapPlaybackUT(
+            double currentUT,
+            double intervalSeconds,
+            double duration,
+            double playbackStartUT,
+            double scheduleStartUT,
+            out double playbackUT,
+            out long cycleIndex)
+        {
+            playbackUT = playbackStartUT;
+            cycleIndex = 0;
+
+            if (currentUT < scheduleStartUT)
+                return false;
+
+            double effectiveCadence = ComputeEffectiveLaunchCadence(
+                intervalSeconds, duration, GhostPlayback.MaxOverlapGhostsPerRecording);
+            double cycleDuration = Math.Max(effectiveCadence, LoopTiming.MinCycleDuration);
+
+            long firstCycle;
+            long lastCycle;
+            GetActiveCycles(
+                currentUT,
+                scheduleStartUT,
+                scheduleStartUT + duration,
+                effectiveCadence,
+                GhostPlayback.MaxOverlapGhostsPerRecording,
+                out firstCycle,
+                out lastCycle);
+
+            cycleIndex = lastCycle;
+            playbackUT = ComputeOverlapCyclePlaybackUT(
+                currentUT,
+                scheduleStartUT,
+                playbackStartUT,
+                duration,
+                cycleDuration,
+                lastCycle);
+            return true;
         }
 
         internal static bool TryComputeLoopPlaybackPhase(

--- a/Source/Parsek/ParsekKSC.cs
+++ b/Source/Parsek/ParsekKSC.cs
@@ -651,6 +651,8 @@ namespace Parsek
 
             if (suppressGhosts)
             {
+                DestroyAllKscOverlapGhosts(recIdx);
+
                 if (GhostPlaybackLogic.ShouldSuppressGhostMeshAtWarp(
                         warpRate, rec, primaryLoopUT))
                 {
@@ -660,26 +662,25 @@ namespace Parsek
                         ParsekLog.Verbose("KSCGhost",
                             $"Ghost #{recIdx} hidden: warp {warpRate.ToString("F1", CultureInfo.InvariantCulture)}x > {WarpThresholds.GhostHide}x");
                     }
-                    DestroyAllKscOverlapGhosts(recIdx);
                     return;
                 }
 
-                // Keep the newest stationary mesh only during high warp.
-                DestroyAllKscOverlapGhosts(recIdx);
+                // Keep the newest stationary primary mesh only during high warp.
             }
 
             if (primaryCycleChanged)
             {
-                // Move old primary to overlap list (don't destroy — it keeps playing)
                 if (primaryActive)
                 {
                     kscGhosts.Remove(recIdx);
                     if (suppressGhosts)
                     {
+                        // Do not accumulate overlap clones while high-warp culling is active.
                         DestroyKscGhost(primaryState, recIdx);
                     }
                     else
                     {
+                        // Move old primary to the overlap list so it keeps playing.
                         overlaps.Add(primaryState);
                         ParsekLog.Verbose("KSCGhost",
                             $"Ghost #{recIdx} cycle={primaryState.loopCycleIndex} moved to overlap list");

--- a/Source/Parsek/ParsekKSC.cs
+++ b/Source/Parsek/ParsekKSC.cs
@@ -209,22 +209,7 @@ namespace Parsek
             RebuildAutoLoopLaunchScheduleCache(committed);
 
             if (suppressGhosts)
-            {
-                // High time warp: hide primary ghosts, destroy overlap ghosts.
-                // KSC scene does not apply resource deltas (flight-only), so no
-                // ApplyResourceDeltas call needed here.
                 loggedReshow.Clear();
-                foreach (var kvp in kscGhosts)
-                    if (kvp.Value.ghost != null && kvp.Value.ghost.activeSelf)
-                    {
-                        kvp.Value.ghost.SetActive(false);
-                        ParsekLog.Verbose("KSCGhost",
-                            $"Ghost #{kvp.Key} hidden: warp {warpRate.ToString("F1", CultureInfo.InvariantCulture)}x > {WarpThresholds.GhostHide}x");
-                    }
-                foreach (int key in new List<int>(kscOverlapGhosts.Keys))
-                    DestroyAllKscOverlapGhosts(key);
-                return;
-            }
 
             for (int i = 0; i < committed.Count; i++)
             {
@@ -297,6 +282,8 @@ namespace Parsek
                                 duration,
                                 playbackStartUT,
                                 scheduleStartUT,
+                                warpRate,
+                                suppressGhosts,
                                 suppressVisualFx);
                         }
                         continue;
@@ -312,14 +299,15 @@ namespace Parsek
                         out targetUT, out cycleIndex, out inPauseWindow, i, autoLoopLaunchSchedules);
 
                     UpdateSingleGhostKsc(i, rec, currentUT, targetUT, cycleIndex,
-                        inRange, inPauseWindow, suppressVisualFx);
+                        inRange, inPauseWindow, warpRate, suppressGhosts, suppressVisualFx);
                 }
                 else
                 {
                     // Non-looping: raw UT range check
                     DestroyAllKscOverlapGhosts(i);
                     bool inRange = currentUT >= rec.StartUT && currentUT <= rec.EndUT;
-                    UpdateSingleGhostKsc(i, rec, currentUT, currentUT, 0, inRange, false, suppressVisualFx);
+                    UpdateSingleGhostKsc(i, rec, currentUT, currentUT, 0, inRange, false,
+                        warpRate, suppressGhosts, suppressVisualFx);
                 }
             }
         }
@@ -485,11 +473,24 @@ namespace Parsek
         /// </summary>
         void UpdateSingleGhostKsc(int recIdx, Recording rec,
             double currentUT, double targetUT, long cycleIndex,
-            bool inRange, bool inPauseWindow, bool suppressVisualFx)
+            bool inRange, bool inPauseWindow, float warpRate,
+            bool suppressGhosts, bool suppressVisualFx)
         {
             GhostPlaybackState state;
             kscGhosts.TryGetValue(recIdx, out state);
             bool ghostActive = state != null && state.ghost != null;
+
+            if (suppressGhosts && GhostPlaybackLogic.ShouldSuppressGhostMeshAtWarp(
+                    warpRate, rec, targetUT))
+            {
+                if (ghostActive && state.ghost.activeSelf)
+                {
+                    state.ghost.SetActive(false);
+                    ParsekLog.Verbose("KSCGhost",
+                        $"Ghost #{recIdx} hidden: warp {warpRate.ToString("F1", CultureInfo.InvariantCulture)}x > {WarpThresholds.GhostHide}x");
+                }
+                return;
+            }
 
             if (inRange && !inPauseWindow)
             {
@@ -601,7 +602,7 @@ namespace Parsek
         void UpdateOverlapKsc(int recIdx, Recording rec,
             double currentUT, double intervalSeconds, double duration,
             double playbackStartUT, double scheduleStartUT,
-            bool suppressVisualFx)
+            float warpRate, bool suppressGhosts, bool suppressVisualFx)
         {
             GhostPlaybackState primaryState;
             kscGhosts.TryGetValue(recIdx, out primaryState);
@@ -640,6 +641,32 @@ namespace Parsek
             // primaryActive already guarantees primaryState != null && ghost != null
             bool primaryCycleChanged = !primaryActive
                 || primaryState.loopCycleIndex != lastCycle;
+            double primaryLoopUT = GhostPlaybackLogic.ComputeOverlapCyclePlaybackUT(
+                currentUT,
+                scheduleStartUT,
+                playbackStartUT,
+                duration,
+                cycleDuration,
+                lastCycle);
+
+            if (suppressGhosts)
+            {
+                if (GhostPlaybackLogic.ShouldSuppressGhostMeshAtWarp(
+                        warpRate, rec, primaryLoopUT))
+                {
+                    if (primaryActive && primaryState.ghost.activeSelf)
+                    {
+                        primaryState.ghost.SetActive(false);
+                        ParsekLog.Verbose("KSCGhost",
+                            $"Ghost #{recIdx} hidden: warp {warpRate.ToString("F1", CultureInfo.InvariantCulture)}x > {WarpThresholds.GhostHide}x");
+                    }
+                    DestroyAllKscOverlapGhosts(recIdx);
+                    return;
+                }
+
+                // Keep the newest stationary mesh only during high warp.
+                DestroyAllKscOverlapGhosts(recIdx);
+            }
 
             if (primaryCycleChanged)
             {
@@ -647,9 +674,16 @@ namespace Parsek
                 if (primaryActive)
                 {
                     kscGhosts.Remove(recIdx);
-                    overlaps.Add(primaryState);
-                    ParsekLog.Verbose("KSCGhost",
-                        $"Ghost #{recIdx} cycle={primaryState.loopCycleIndex} moved to overlap list");
+                    if (suppressGhosts)
+                    {
+                        DestroyKscGhost(primaryState, recIdx);
+                    }
+                    else
+                    {
+                        overlaps.Add(primaryState);
+                        ParsekLog.Verbose("KSCGhost",
+                            $"Ghost #{recIdx} cycle={primaryState.loopCycleIndex} moved to overlap list");
+                    }
                 }
 
                 // Spawn new primary for lastCycle
@@ -664,13 +698,7 @@ namespace Parsek
 
             // Position and animate primary (SpawnKscGhost above guarantees non-null)
             {
-                double loopUT = GhostPlaybackLogic.ComputeOverlapCyclePlaybackUT(
-                    currentUT,
-                    scheduleStartUT,
-                    playbackStartUT,
-                    duration,
-                    cycleDuration,
-                    lastCycle);
+                double loopUT = primaryLoopUT;
 
                 InterpolateAndPositionKsc(primaryState.ghost, rec.Points,
                     ref primaryState.playbackIndex, loopUT);

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -1673,6 +1673,18 @@ in-game during the next playtest pass instead of an xUnit canary.
 
 ---
 
+## ~~599. Stationary surface ghosts are hidden above 50x warp even though their mesh does not need per-frame motion~~
+
+**Source:** User investigation request on 2026-04-25: high-warp playback hides all ghost vessels in KSC and flight view for performance, but vessels that are actually standing still should remain visible at any warp speed.
+
+**Cause:** The high-warp mesh suppression policy was a global `warpRate > WarpThresholds.GhostHide` decision. It ran before the per-trajectory render path in flight and before the per-recording playback path in KSC, so it could not distinguish a moving trajectory from a `SurfaceStationary` section.
+
+**Fix:** Added `GhostPlaybackLogic.ShouldSuppressGhostMeshAtWarp`, which preserves the old threshold for moving ghosts but exempts the current playback UT when its `TrackSection.environment` is `SurfaceStationary` (plus surface-only static trajectories). Flight playback now applies the decision per trajectory/loop UT, and KSC playback no longer returns early for all ghosts during high warp. FX suppression is unchanged, and overlap clones remain culled during high warp so the exemption only keeps the newest stationary primary mesh visible. Regression coverage lives in `Bug290_WarpSuppressionMapViewTests`.
+
+**Status:** CLOSED. Fixed for v0.9.0.
+
+---
+
 ## 597. Underlying logic: KSP's `onTimeWarpRateChanged` GameEvent fires at 1x roughly 4x more often than there are real rate changes, and `OnTimeWarpRateChanged` always re-runs `CheckpointAllVessels`
 
 **Source:** `logs/2026-04-25_1933_refly-bugs/KSP.log` — 1090 of 1121


### PR DESCRIPTION
## Summary
- Keep SurfaceStationary ghost primaries visible above the 50x mesh-hide threshold in flight and KSC playback.
- Continue hiding moving ghosts and overlap clones for high-warp performance; FX/audio suppression remains unchanged.
- Add regression coverage and update CHANGELOG/todo docs.

## Tests
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter Bug290
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter FullyQualifiedName~GhostPlaybackEngineTests.UpdateOverlapPlayback_PendingPrimaryDemotion_ClearsLifecycleBeforeOverlapList
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj

## Review
- Required focused review ran; initial flight-overlap finding fixed; follow-up review had no findings.