### PR TITLE
Audit observability logging gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ All notable changes to Parsek are documented here.
 - Phase 14 — polish + pre-release prep: disk-usage diagnostics line in Settings; rename persists + hide warns on Unfinished Flight rows; dialog copy polish (Merge + ReFlyRevert).
 - Continued refactor-4 (Pass 2) with a behavior-neutral `SidecarFileCommitBatch` extraction: staged sidecar write/delete commit, rollback, and artifact cleanup now live in a focused helper while preserving the `[RecordingStore]` log tag, per-step rollback semantics from `#366`, sidecar epoch ordering, and `FilesDirty` mutation order.
 
+### Documentation
+
+- Added `docs/dev/observability-audit-2026-04-26.md`, a full logging-coverage audit covering spam controls, silent skip gates, persistence/rewind context gaps, UI/map diagnostics, and follow-up test-contract work needed to keep Parsek decisions reconstructable from `KSP.log`.
+
 ### Enhancements
 
 - `#541` Main-window navigation labels now keep `Kerbals` count-free and shorten `Career State` to `Career`, leaving the detailed roster totals inside the destination windows instead of on the launch surface.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ All notable changes to Parsek are documented here.
 
 ### Documentation
 
-- Added `docs/dev/observability-audit-2026-04-26.md`, a full logging-coverage audit covering spam controls, silent skip gates, persistence/rewind context gaps, UI/map diagnostics, and follow-up test-contract work needed to keep Parsek decisions reconstructable from `KSP.log`.
+- Added `docs/dev/observability-audit-2026-04-26.md` and `docs/dev/plan-observability-logging-visibility.md`, a full logging-coverage audit plus phased implementation plan covering spam controls, silent skip gates, persistence/rewind context gaps, UI/map diagnostics, and follow-up test-contract work needed to keep Parsek decisions reconstructable from `KSP.log`.
 
 ### Enhancements
 

--- a/docs/dev/observability-audit-2026-04-26.md
+++ b/docs/dev/observability-audit-2026-04-26.md
@@ -1,0 +1,462 @@
+# Observability Audit - 2026-04-26
+
+## Scope
+
+This audit reviews Parsek's current logging coverage after the recent growth in
+recording, rewind, ghost playback, map presence, KSC playback, UI, diagnostics,
+and game-action systems. The goal is not more logs everywhere. The goal is that
+each user-visible decision path can be reconstructed from `KSP.log` without
+burying the useful lines under per-frame noise.
+
+The audit was performed on branch `observability-audit` at `ee893e38` plus
+read-only parallel subsystem reviews. No production code changes are included in
+this report.
+
+## Existing Logging Tools
+
+Parsek already has the right primitives in `Source/Parsek/ParsekLog.cs`:
+
+- `Info`, `Warn`, `Error`: durable state transitions, player-visible outcomes,
+  unexpected conditions, and failures that change behavior.
+- `Verbose`: detailed diagnostics for one-shot operations.
+- `VerboseRateLimited`: per-frame, per-ghost, per-loop-cycle, or repeated
+  diagnostics. Default window is 5 seconds.
+- `WarnRateLimited`: repeated abnormal conditions that still need WARN
+  visibility.
+- `VerboseOnChange`: best fit for hot-path gates whose reason stays stable for
+  many frames. It logs the first state, stays quiet while unchanged, and reports
+  suppressed count on the next change.
+- `RecState` and `RecStateRateLimited`: structured recorder/scenario state
+  snapshots for lifecycle edges and hot-path summaries.
+- `TestSinkForTesting` / `TestObserverForTesting`: log-capture seams for tests.
+
+`ParsekSettings.verboseLogging` defaults to true (`Source/Parsek/ParsekSettings.cs:50`),
+so verbose diagnostics are currently part of the normal support workflow. That
+makes rate limiting and batching mandatory.
+
+## Logging Policy For The Follow-Up Work
+
+Use this split when implementing the audit findings:
+
+- One-shot lifecycle edge: `Info` or `Warn`, include IDs and numeric context.
+- Expected hot-path skip: `VerboseOnChange` keyed by stable identity and reason.
+- Per-frame aggregate: counters plus one `VerboseRateLimited` summary.
+- Repeated abnormal hot-path state: `WarnRateLimited` keyed by stable identity.
+- Exceptions that alter control flow: `Warn` or `Error` with exception type,
+  message, path/pid/recording id, then preserve existing flow or rethrow.
+- Collection loops: count decisions and log one summary. Do not add unbounded
+  per-item logs.
+- Rate-limit keys: use stable recording id, vessel pid, rewind-point id, or an
+  aggregate key. Avoid bare dense list indexes when the list can shift.
+
+## Current Strengths
+
+- Recorder start/stop, sample summaries, and many `RecState` lifecycle snapshots
+  are strong.
+- `ParsekScenario.OnSave` / `OnLoad` log broad save/load counts and timings.
+- Ghost map source decisions have improved substantially, especially around
+  `Segment`, `TerminalOrbit`, `StateVector`, endpoint conflicts, and already
+  materialized vessels.
+- Recent spam fixes moved several formerly chatty paths to `VerboseRateLimited`
+  or `VerboseOnChange`.
+- In-game `LogContractTests` validate the synthetic `ParsekLog` primitive
+  format, levels, rate-limit suppressed counts, and several resource
+  invariants. Production-line warning-prefix coverage is still incomplete; see
+  P3.5.
+
+The remaining problem is concentrated in skip gates, negative decisions, and
+places where repeated diagnostics either spam or hide different identities under
+one shared rate-limit key.
+
+## P1 Findings
+
+### P1.1 Save/load exceptions lack top-level Parsek context
+
+`ParsekScenario.OnSave` (`Source/Parsek/ParsekScenario.cs:435`) and
+`ParsekScenario.OnLoad` (`Source/Parsek/ParsekScenario.cs:990`) use `finally`
+timing logs, but they do not wrap the full phase in a top-level catch that logs
+Parsek-specific context before the exception leaves the method.
+
+Impact: failures in tree persistence, sidecar loading, game-state persistence,
+rewind staging, merge finishing, or pending tree restore can appear as a raw
+Unity/KSP exception without the save folder, counts, active tree state, rewind
+state, or pending marker state.
+
+Recommendation: add top-level `ParsekLog.Error("Scenario", ...)` with phase,
+scene, save folder, committed/pending counts, active tree id/name, rewind marker
+state, and exception type/message. Emit `RecState("OnSave:exception", ...)` or
+`RecState("OnLoad:exception", ...)`, then rethrow.
+
+### P1.2 KSC playback has current spam risks
+
+`ParsekKSC.Update` calls `RebuildAutoLoopLaunchScheduleCache` every frame
+(`Source/Parsek/ParsekKSC.cs:209`), and that rebuild logs unconditionally at
+`Source/Parsek/ParsekKSC.cs:348` while auto-loop candidates exist.
+
+Playback-disabled past-end KSC spawn attempts log before the one-shot spawn
+dedupe (`Source/Parsek/ParsekKSC.cs:249`, with dedupe later around
+`Source/Parsek/ParsekKSC.cs:1238`). Looping skip logs also happen before dedupe
+around `Source/Parsek/ParsekKSC.cs:1230`.
+
+Impact: KSC can flood `KSP.log` in a normal steady state, making the real
+decision lines hard to find.
+
+Recommendation: use `VerboseOnChange` with a queue fingerprint for rebuilds, or
+a `VerboseRateLimited` aggregate. Move past-end spawn attempt logging after the
+dedupe, or make the pre-dedupe line `VerboseOnChange` keyed by
+`RecordingId + reason`.
+
+## P2 Findings
+
+### P2.1 Missing flight ghost skip reasons
+
+`ComputePlaybackFlags` collapses `!hasData`, `!rec.PlaybackEnabled`, and
+external-vessel suppression into one `skipGhost` bit
+(`Source/Parsek/ParsekFlight.cs:12218`). `GhostPlaybackEngine.UpdatePlayback`
+then skips at `Source/Parsek/GhostPlaybackEngine.cs:388`, and the
+`!HasRenderableGhostData` guard skips at `Source/Parsek/GhostPlaybackEngine.cs:414`.
+
+Impact: "the ghost is missing" often has no reason trail in `KSP.log`.
+
+Recommendation: carry a compact skip reason through `TrajectoryPlaybackFlags`,
+then log `VerboseOnChange` per recording id and include aggregate per-frame
+counts in the existing engine frame summary.
+
+### P2.2 Additional playback skips are silent or under-summarized
+
+Important skip paths currently have no summary when the ghost was never active:
+
+- Loop anchor configured but not loaded:
+  `Source/Parsek/GhostPlaybackEngine.cs:459`.
+- Parent loop sync failure and parent pause/warp skip:
+  `Source/Parsek/GhostPlaybackEngine.cs:492`.
+- Warp mesh suppression hides/destroys without a reason count:
+  `Source/Parsek/GhostPlaybackEngine.cs:549`.
+- `EnsureGhostVisualsLoaded` returns failed for null state or debris without a
+  snapshot (`Source/Parsek/GhostPlaybackEngine.cs:3362`).
+- `TryPopulateGhostVisuals` returns failed for null state or null ghost
+  (`Source/Parsek/GhostPlaybackEngine.cs:3106`).
+
+Recommendation: add skip counters such as `beforeActivation`, `anchorMissing`,
+`loopSyncFailed`, `warpHidden`, `visualLoadFailed`, and `noRenderableData` to
+the frame summary. Use `VerboseOnChange` for per-recording reason flips.
+
+### P2.3 Background recorder can stop sampling silently
+
+`BackgroundRecorder.OnBackgroundPhysicsFrame` returns without logging when the
+tree is null, the vessel is not in `BackgroundMap`, the vessel is packed, the
+loaded state is missing, or the tree recording is missing
+(`Source/Parsek/BackgroundRecorder.cs:1163`,
+`Source/Parsek/BackgroundRecorder.cs:1194`,
+`Source/Parsek/BackgroundRecorder.cs:1198`).
+
+Impact: background sampling can disappear because the tree maps and loaded
+states drifted, without a diagnostic that explains the lost samples.
+
+Recommendation: keep expected null/tree skips quiet, but add `WarnRateLimited`
+for map/state disagreements keyed by vessel pid and recording id.
+
+### P2.4 Transition to background can miss vessel context
+
+`FlightRecorder` transitions active recordings to background around
+`Source/Parsek/FlightRecorder.cs:6368`. If live vessel lookup fails, boundary
+sample/orbit/finalization-cache work can be skipped before the generic
+transition log near `Source/Parsek/FlightRecorder.cs:6413`.
+
+Recommendation: add a `Warn` with pid, recording id, vessel name, points,
+orbit segments, track sections, and finalization-cache state when the lookup is
+null during this transition.
+
+### P2.5 Post-switch auto-record no-trigger decisions are invisible
+
+`OnPostSwitchAutoRecordPhysicsFrame` logs the watch state once per second
+(`Source/Parsek/ParsekFlight.cs:5834`) and logs settle waits, but when
+`EvaluatePostSwitchAutoRecordTrigger` returns `None` it returns silently.
+
+Impact: "why did Parsek not start recording after I modified the switched
+vessel?" cannot be reconstructed. The trigger inputs are precisely the useful
+data: engine, RCS, attitude, crew, resource, part, motion, orbit, manifest
+evaluation cadence, and thresholds.
+
+Recommendation: add a `VerboseOnChange` summary keyed by watched vessel pid with
+suppression, baseline, settle, and trigger state. Add a rate-limited manifest
+delta summary at the existing manifest-evaluation cadence.
+
+### P2.6 Crew board/EVA split gates have silent early returns
+
+`OnCrewBoardVessel` logs entry and some null/no-tree paths, but
+`pendingSplitInProgress` returns silently (`Source/Parsek/ParsekFlight.cs:4791`).
+`OnCrewOnEva` returns silently for `pendingSplitInProgress` and for source
+vessel mismatch during an active recording (`Source/Parsek/ParsekFlight.cs:4817`).
+
+Recommendation: use `VerboseRateLimited` or `VerboseOnChange` keyed by active
+recording id/source pid so real crew transitions explain why no branch or
+auto-record was started.
+
+### P2.7 Rewind button precondition failures are not logged
+
+`RewindInvoker.CanInvoke` returns false for null RP, wrong scene, pending invoke,
+corrupt RP, missing quicksave, active re-fly marker, and deep-parse failure
+without a Parsek log line (`Source/Parsek/RewindInvoker.cs:63`).
+
+Spam risk: this can be called from UI draw loops.
+
+Recommendation: use `VerboseOnChange` keyed by RP id and reason, or a
+`VerboseRateLimited` cache summary. Keep the returned user-facing reason intact.
+
+### P2.8 Fast-forward watch handoff can disappear silently
+
+`pendingWatchAfterFFId` is cleared after engine playback
+(`Source/Parsek/ParsekFlight.cs:12292`). If the recording exists but no active
+ghost is available, the watch request can vanish with no log.
+
+Recommendation: emit `Warn` when the recording exists but no active ghost is
+watchable, and `Verbose` when the recording id no longer exists.
+
+### P2.9 Watch camera infrastructure failures are silent
+
+`WatchModeController` returns if `FlightCamera.fetch`, its transform, or its
+parent is null (`Source/Parsek/WatchModeController.cs:2477`).
+
+Impact: the user sees broken watch/camera behavior without a Parsek context.
+
+Recommendation: `WarnRateLimited` with watched recording id/name, cycle, active
+scene, target state, and which camera object was null.
+
+### P2.10 Sidecar and path failures need richer context
+
+`RecordingStore` sidecar load/save catches at
+`Source/Parsek/RecordingStore.cs:5796`,
+`Source/Parsek/RecordingStore.cs:5920`, and
+`Source/Parsek/RecordingStore.cs:6636` log recording id plus message, but not
+enough path/save-folder/epoch/file-kind context. `SnapshotSidecarCodec.TryProbe`
+can fail before codec-level details are surfaced
+(`Source/Parsek/SnapshotSidecarCodec.cs:67`). `RecordingPaths` directory
+creation calls can throw without a Parsek path-context log
+(`Source/Parsek/RecordingPaths.cs:74`,
+`Source/Parsek/RecordingPaths.cs:131`,
+`Source/Parsek/RecordingPaths.cs:152`,
+`Source/Parsek/RecordingPaths.cs:184`).
+
+There is also a severity mapping problem: `RecordingStore.Log` maps messages
+without `WARNING:` or `WARN:` to `Info`
+(`Source/Parsek/RecordingStore.cs:182`), while failed save/load sidecar
+operations return false but currently call it with plain "Failed to ..."
+messages (`Source/Parsek/RecordingStore.cs:5796`,
+`Source/Parsek/RecordingStore.cs:5920`,
+`Source/Parsek/RecordingStore.cs:6636`). These are control-flow-changing
+failures and should not be INFO.
+
+Recommendation: log sidecar path, file kind, save name/folder, sidecar epoch,
+encoding/probe version, staged-file counts, exception type, and message at
+`Warn` or `Error` as appropriate. Prefer structured failure reasons from codecs
+to duplicate direct logging.
+
+### P2.11 Scenario OnLoad timing can duplicate and miscount
+
+`ParsekScenario.OnLoad` calls `WriteLoadTiming` on several successful-return
+paths (`Source/Parsek/ParsekScenario.cs:1044`,
+`Source/Parsek/ParsekScenario.cs:1595`,
+`Source/Parsek/ParsekScenario.cs:1822`) and again in `finally`
+(`Source/Parsek/ParsekScenario.cs:1869`). The final call can use stale
+`loadedRecordingCount`.
+
+Impact: cold-start or early-return load logs can contain duplicate timing lines
+or a misleading recording count, which weakens the save/load timeline when
+debugging persistence bugs.
+
+Recommendation: centralize load timing emission so each `OnLoad` invocation logs
+one timing line with the final count and clear phase/status fields.
+
+### P2.12 Kerbal assignment and finalization cache decisions need batch summaries
+
+`KerbalsModule` skips tourist actions, empty recording ids, missing metadata,
+loop recordings, and empty kerbal names in assignment processing around
+`Source/Parsek/KerbalsModule.cs:156`.
+
+`RecordingFinalizationCacheProducer` accepts and declines cache decisions at
+`VerboseRateLimited` around
+`Source/Parsek/RecordingFinalizationCacheProducer.cs:667`; unexpected declines
+that affect rewind/resource reconciliation may disappear when verbose is off.
+
+Recommendation: add one batch summary for kerbal pre-pass/post-walk decisions.
+Keep cache accepts verbose, but promote unexpected or terminal-state-impacting
+declines to `WarnRateLimited`.
+
+### P2.13 Game-action capture has silent null and baseline gates
+
+`GameStateRecorder` returns silently for several event shapes:
+
+- Tech researched null host or unsuccessful operation:
+  `Source/Parsek/GameStateRecorder.cs:561`.
+- Part purchase null part:
+  `Source/Parsek/GameStateRecorder.cs:609`.
+- Kerbal type change suppression or irrelevant transition:
+  `Source/Parsek/GameStateRecorder.cs:846`.
+- Resource event baseline not seeded:
+  `Source/Parsek/GameStateRecorder.cs:894`,
+  `Source/Parsek/GameStateRecorder.cs:954`,
+  `Source/Parsek/GameStateRecorder.cs:1004`.
+
+`GameStateEventConverter.ConvertEvents` logs converted/skipped totals
+(`Source/Parsek/GameActions/GameStateEventConverter.cs:31`) but not skip
+reason counts by event type.
+
+Recommendation: log one-shot event rejects at `Verbose` or `VerboseRateLimited`
+with event type and reason. Add per-type skip counters to converter summaries.
+
+### P2.14 Map/UI marker skips lack summaries
+
+Flight map marker drawing silently skips camera unavailable, native-icon
+suppression, chain non-tip rows, hidden ghost position failure, and missing body
+around `Source/Parsek/ParsekUI.cs:982`,
+`Source/Parsek/ParsekUI.cs:1044`, and `Source/Parsek/ParsekUI.cs:1069`.
+
+Tracking Station atmospheric marker success is per-recording, while skip
+reasons are silent around `Source/Parsek/ParsekTrackingStation.cs:443`.
+
+Recommendation: add per-frame or per-refresh counters and one
+`VerboseRateLimited` summary. Keep per-index logs only for state changes.
+
+### P2.15 UI window transitions are mostly logged, but not all
+
+Main window toggles log Timeline, Recordings, Kerbals, Gloops, Settings, Close,
+and Real Spawn Control. The Career window toggle is missing the matching UI log
+(`Source/Parsek/ParsekUI.cs:155`).
+
+`SpawnControlUI.DrawIfOpen` auto-closes with no log when not in flight, flight is
+null, or candidate count is zero (`Source/Parsek/UI/SpawnControlUI.cs:64`).
+
+Recommendation: add `Verbose` for Career toggle and `VerboseOnChange` for Real
+Spawn Control auto-close reasons.
+
+### P2.16 Harmony/diagnostics/test infrastructure has observability gaps
+
+- `PhysicsFramePatch.BackgroundRecorderInstance` has no attach/clear transition
+  log, while active and Gloops recorders do (`Source/Parsek/Patches/PhysicsFramePatch.cs:35`).
+- Ghost orbit Harmony suppression returns false or hides icons without summary
+  (`Source/Parsek/Patches/GhostOrbitLinePatch.cs:17`,
+  `Source/Parsek/Patches/GhostOrbitLinePatch.cs:152`).
+- In-game test scene eligibility skips only show final counts; per-scene skip
+  reasons are not visible enough (`Source/Parsek/InGameTests/InGameTestRunner.cs:754`).
+- Diagnostics missing-sidecar warnings can repeat on every storage scan
+  (`Source/Parsek/Diagnostics/DiagnosticsComputation.cs:193`).
+- Post-hoc log validation skips malformed `[Parsek]` lines even though the
+  parser records them (`Source/Parsek.Tests/LogValidation/ParsekLogContractChecker.cs:55`).
+
+Recommendation: add attach/clear `Info` for background recorder, aggregate
+Harmony suppression summaries, one `Info` scene-skip batch summary for tests,
+`WarnRateLimited` or scan aggregates for diagnostics, and post-hoc checks for
+unstructured Parsek lines, invalid levels, and redundant warning prefixes.
+
+## P3 Findings
+
+### P3.1 Shared rate-limit keys hide identities
+
+Some `VerboseRateLimited` keys are shared across different recordings or cycles,
+including loop/overlap events in `ParsekPlaybackPolicy` and `GhostPlaybackEngine`
+around `Source/Parsek/ParsekPlaybackPolicy.cs:1388`,
+`Source/Parsek/ParsekPlaybackPolicy.cs:1395`,
+`Source/Parsek/GhostPlaybackEngine.cs:1390`, and
+`Source/Parsek/GhostPlaybackEngine.cs:4185`.
+
+Impact: the first identity in the window can suppress later identities.
+
+Recommendation: either key by stable identity when identity matters, or log one
+aggregate summary with counts and first sample.
+
+### P3.2 Repeated warnings still need rate limits
+
+Potential repeaters:
+
+- Map state-vector/body/anchor failures in `GhostMapPresence`.
+- Ballistic terrain/PQS resolver warnings in `BallisticExtrapolator`.
+- Diagnostics `SafeGetFileSize` missing-sidecar warnings.
+- Watch horizon-basis `Info` changes when the source is effectively steady.
+- Terrain correction helper decisions.
+
+Recommendation: keep first failure visible, then use `WarnRateLimited` keyed by
+recording/body/path/reason. Demote helper-level steady decisions to
+`VerboseRateLimited`.
+
+### P3.3 Resource event logging can crowd out decision logs
+
+Accepted funds/science/reputation events are logged individually through
+`GameStateStore` and `GameStateRecorder` (`Source/Parsek/GameStateStore.cs:31`,
+`Source/Parsek/GameStateRecorder.cs:883`). This is useful for irreversible
+player-visible actions, but resource-heavy sessions can crowd out diagnostics.
+
+Recommendation: keep `Info` for durable ledger milestones and user-visible
+resource commitments. Use rate-limited aggregate summaries for noisy recalcs and
+high-frequency resource deltas.
+
+### P3.4 Cleanup errors are swallowed in low-risk paths
+
+`SidecarFileCommitBatch` swallows transient artifact cleanup failures around
+`Source/Parsek/SidecarFileCommitBatch.cs:197`. `PartStateSeeder` has a silent
+catch at `Source/Parsek/PartStateSeeder.cs:82`. Several reflection helpers in
+`GhostMapPresence` catch and return null/false.
+
+Recommendation: do not promote these to noisy WARNs by default. Add
+`VerboseRateLimited` cleanup/reflection summaries, and promote only when the
+failure changes runtime behavior.
+
+### P3.5 Production WARN messages still include redundant WARNING prefixes
+
+`LogContractTests.WarnLinesNoRedundantPrefix` validates synthetic
+`ParsekLog.Warn` output, but it does not scan production call sites. Current
+production messages still include redundant `WARNING:` text before being emitted
+at WARN level, for example `Source/Parsek/TimeJumpManager.cs:440` and
+`Source/Parsek/TimeJumpManager.cs:568`.
+
+Recommendation: remove redundant prefixes from production messages and add a
+post-hoc or source-level check that catches real emitted `[Parsek][WARN]`
+messages whose payload starts with `WARNING:` or `WARN:`.
+
+## Suggested Implementation Order
+
+1. Fix current spam first: KSC auto-loop rebuild logging, playback-disabled
+   KSC spawn-attempt logging, diagnostics missing-sidecar scan warnings, and
+   shared rate-limit keys that hide identities.
+2. Add flight playback decision visibility: explicit ghost skip reason, frame
+   skip counters, loop anchor/warp/visual-load summaries, and fast-forward watch
+   miss logs.
+3. Add persistence/rewind context: scenario top-level exception logs,
+   `CanInvoke` reason logging, sidecar/path context, and active-tree restore
+   no-op summaries.
+4. Add recorder/game-action negative-path logs: background recorder state drift,
+   active-to-background missing-vessel warning, post-switch auto-record
+   no-trigger summaries, EVA/boarding split skips, and game-action skip counts.
+5. Add UI/map/diagnostic/test contract coverage: map marker summaries, Real
+   Spawn Control auto-close reasons, background recorder attach/clear logs,
+   ghost orbit Harmony summaries, and post-hoc malformed-log validation.
+
+## Test Strategy
+
+Add log assertions with `ParsekLog.TestSinkForTesting` for each new decision
+helper or state transition. Prefer pure helpers that return reason enums or
+summary structs, then test both behavior and emitted log shape.
+
+Minimum regression set:
+
+- Flight playback: each `TrajectoryPlaybackFlags` skip reason emits once and
+  stable repeats are suppressed.
+- Engine frame summary: no-renderable-data, anchor-missing, warp-hidden,
+  visual-load-failed, and session-suppressed counters appear in one summary.
+- KSC playback: auto-loop queue rebuild logs once per fingerprint change, not
+  every `Update`.
+- Rewind: `CanInvoke` logs reason changes without per-frame UI spam.
+- Scenario: injected `OnSave`/`OnLoad` exception logs phase context and rethrows.
+- Game actions: converter summaries include per-type skip reason counts.
+- Log validation: malformed `[Parsek]` lines fail post-hoc validation.
+
+## Definition Of Done For The Follow-Up
+
+- A user-visible skip or state change has a grep target in `KSP.log`.
+- Hot-path logs are either batched, rate-limited, or on-change.
+- Repeated abnormal conditions use stable keys so one identity does not hide
+  another unless the log is intentionally aggregate.
+- The log line includes enough context to reproduce the decision: recording id,
+  vessel pid/name, rewind point id, tree id, UT, body, path, and reason as
+  applicable.
+- Tests assert both the behavior and the log contract for the new coverage.

--- a/docs/dev/observability-audit-2026-04-26.md
+++ b/docs/dev/observability-audit-2026-04-26.md
@@ -12,6 +12,8 @@ The audit was performed on branch `observability-audit` at `ee893e38` plus
 read-only parallel subsystem reviews. No production code changes are included in
 this report.
 
+Implementation plan: `docs/dev/plan-observability-logging-visibility.md`.
+
 ## Existing Logging Tools
 
 Parsek already has the right primitives in `Source/Parsek/ParsekLog.cs`:

--- a/docs/dev/plan-observability-logging-visibility.md
+++ b/docs/dev/plan-observability-logging-visibility.md
@@ -1,7 +1,6 @@
 # Plan: Observability Logging Visibility
 
 Branch: `observability-audit`
-Worktree: `C:/Users/vlad3/Documents/Code/Parsek/Parsek-observability-audit`
 Date: 2026-04-26
 
 ## Source Material

--- a/docs/dev/plan-observability-logging-visibility.md
+++ b/docs/dev/plan-observability-logging-visibility.md
@@ -1,0 +1,649 @@
+# Plan: Observability Logging Visibility
+
+Branch: `observability-audit`
+Worktree: `C:/Users/vlad3/Documents/Code/Parsek/Parsek-observability-audit`
+Date: 2026-04-26
+
+## Source Material
+
+- Audit: `docs/dev/observability-audit-2026-04-26.md`
+- Workflow: `docs/dev/development-workflow.md`
+- Latest log packages sampled:
+  - `logs/2026-04-26_0118_refly-postfix-still-broken`
+  - `logs/2026-04-25_2334_refly-followup-test`
+  - `logs/2026-04-25_2243_stationary-ghost-visibility`
+
+## Problem
+
+Parsek's logs are structurally better than the older 96 MB playtest logs, but
+the current signal is still not good enough for debugging game-visible bugs.
+The newest package (`2026-04-26_0118_refly-postfix-still-broken`) has
+19,087 Parsek lines out of 19,137 total KSP.log lines. That means Parsek is
+still effectively the whole log, and missing decision-path logs are made worse
+by repeated low-value summaries.
+
+The work should not add raw "log everything" output. It should make every
+important runtime decision reconstructable while reducing repeated steady-state
+noise.
+
+## Current Log Signal
+
+### Latest package: `2026-04-26_0118_refly-postfix-still-broken`
+
+KSP.log size is about 2.6 MB. Top structured Parsek subsystem/level counts:
+
+| Count | Level | Subsystem |
+| ---: | --- | --- |
+| 686 | VERBOSE | GhostVisual |
+| 524 | VERBOSE | RecordingStore |
+| 404 | VERBOSE | Recorder |
+| 361 | VERBOSE | KspStatePatcher |
+| 356 | VERBOSE | Milestones |
+| 348 | VERBOSE | Extrapolator |
+| 343 | INFO | Extrapolator |
+| 299 | VERBOSE | Flight |
+| 243 | VERBOSE | Funds |
+| 197 | VERBOSE | LedgerOrchestrator |
+| 185 | VERBOSE | KerbalsModule |
+| 179 | VERBOSE | ScienceModule |
+
+Top exact repeaters in that package:
+
+| Count | Message shape |
+| ---: | --- |
+| 80 | `FinalizerCache refresh summary: owner=ActiveRecorder reason=periodic recordingsExamined=1 alreadyClassified=0 newlyClassified=0` |
+| 67 | `SnapshotPatchedConicChain: ... patchIndex=1 body=(missing-reference-body); truncated chain after 1 valid patch(es)` |
+| 67 | `SnapshotPatchedConicChain: ... captured=1 hasTruncatedTail=True ...` |
+| 67 | `TryFinalizeRecording: seeded orbital-frame rotation on 1/1 predicted segments ...` |
+| 59 | `FinalizerCache refresh summary: owner=BackgroundLoaded reason=background_periodic recordingsExamined=1 alreadyClassified=0 newlyClassified=1` |
+| 45 | repeated all-zero game-action reset/seed/spending summaries |
+| 39 | repeated sandbox/no-target `KspStatePatcher` skip lines plus `PatchAll complete` |
+
+Warn/error signal in the newest package is not a storm. Most warning shapes are
+singletons or rate-limited pairs. That supports focusing first on repeated
+verbose/info output and missing decision-path coverage, not on blanket warning
+demotion.
+
+### Previous package: `2026-04-25_2334_refly-followup-test`
+
+This package still shows the recently fixed GhostMap shape:
+
+- 1,613 exact repeats of
+  `HasOrbitData(IPlaybackTrajectory): body=Kerbin sma=742959.380465312 result=True`
+- 65 exact repeats of the same shape for another SMA.
+
+Because this is not visible in the newest package, treat GhostMap `HasOrbitData`
+as a regression guard, not Phase 1 work, unless it reappears in current-branch
+logs.
+
+## Goals
+
+1. Reduce low-value repeated output in the newest log packages.
+2. Add missing decision logs where gameplay-visible behavior is currently
+   unexplained.
+3. Keep hot paths safe with `VerboseOnChange`, `VerboseRateLimited`,
+   `WarnRateLimited`, and aggregate counters.
+4. Add log assertion tests so future refactors cannot silently remove the new
+   observability.
+5. Make `collect-logs.py` / log validation catch malformed or misleading log
+   output early.
+
+## Non-Goals
+
+- Do not turn verbose logging off by default as the primary fix.
+- Do not add per-frame per-recording logs without on-change or rate-limit gates.
+- Do not change gameplay behavior unless a logging fix exposes an existing
+  behavior bug that must be addressed to make the log truthful.
+- Do not rewrite `ParsekLog` wholesale; existing primitives are sufficient.
+
+## Phase 0 - Baseline And Guardrails
+
+Purpose: make every later phase measurable.
+
+### Task 0.1 - Add a repeat-signal analysis script
+
+Files:
+
+- `scripts/analyze-log-signal.ps1` or a small C# test utility if preferred.
+
+Behavior:
+
+- Input: path to `KSP.log`.
+- Output: total lines, Parsek line count, top subsystem/level counts, top exact
+  repeated messages, top WARN/ERROR messages, and rate-limit suppressed counts.
+- Keep it read-only and independent of KSP runtime.
+
+Verification:
+
+- Run against the three sampled packages above and confirm the script reports
+  the counts used in this plan within expected formatting differences.
+
+### Task 0.2 - Tighten post-hoc log validation
+
+Files:
+
+- `Source/Parsek.Tests/LogValidation/ParsekLogContractChecker.cs`
+- `Source/Parsek.Tests/LogValidation/ParsekKspLogParser.cs`
+- tests under `Source/Parsek.Tests/LogValidation/`
+
+Behavior:
+
+- Fail on malformed `[Parsek]` lines in the latest session.
+- Fail on invalid levels in real parsed log lines.
+- Fail on `[Parsek][WARN]` payloads that start with `WARNING:` or `WARN:`.
+- Ensure timeout/generic validation failures from `scripts/collect-logs.py`
+  still produce a failed `log-validation.txt` artifact.
+
+Verification:
+
+- Unit tests with synthetic log snippets for malformed lines, bad levels,
+  redundant warning prefixes, and clean logs.
+- Run `pwsh -File scripts/validate-ksp-log.ps1` on a current retained log.
+
+## Phase 1 - Current Spam Hygiene
+
+Purpose: reduce repeated current-branch output before adding new coverage.
+
+### Task 1.1 - Fix KSC steady-state spam risks
+
+Files:
+
+- `Source/Parsek/ParsekKSC.cs`
+- related tests in `Source/Parsek.Tests/`
+
+Changes:
+
+- Gate `RebuildAutoLoopLaunchScheduleCache` logging with `VerboseOnChange`
+  using a queue fingerprint: count, anchor UT, cadence, ordered recording ids.
+- Move playback-disabled past-end spawn-attempt logging behind one-shot dedupe,
+  or convert the pre-dedupe log to `VerboseOnChange` keyed by recording id and
+  reason.
+
+Verification:
+
+- Unit test that repeated `Update` calls with unchanged auto-loop queue emit one
+  rebuild log, then emit again when the fingerprint changes.
+- Unit test that playback-disabled past-end spawn attempt logs once per
+  recording/reason and does not repeat per frame.
+
+### Task 1.2 - Rate-limit diagnostics storage warnings
+
+Files:
+
+- `Source/Parsek/Diagnostics/DiagnosticsComputation.cs`
+- `Source/Parsek/UI/RecordingsTableUI.cs` if call-site context is needed.
+
+Changes:
+
+- Convert repeated missing-sidecar `Warn` in `SafeGetFileSize` to
+  `WarnRateLimited` keyed by recording/file type/path, or aggregate missing
+  sidecar counts per storage scan.
+
+Verification:
+
+- Log assertion test that repeated scans of the same missing file emit once and
+  later include `suppressed=N`.
+
+### Task 1.3 - Quiet finalizer cache periodic summaries
+
+Files:
+
+- `Source/Parsek/RecordingFinalizationCacheProducer.cs`
+- `Source/Parsek/FlightRecorder.cs`
+- `Source/Parsek/BackgroundRecorder.cs`
+
+Changes:
+
+- Investigate why the newest log repeats active no-delta finalizer summaries
+  80 times and background `newlyClassified=1` summaries 59 times.
+- Keep first classification and unexpected declines visible.
+- Route stable no-delta periodic refreshes through `VerboseRateLimited` with a
+  wider cadence or `VerboseOnChange` keyed by owner/recording/terminal digest.
+- If `BackgroundLoaded newlyClassified=1` is repeatedly classifying the same
+  record, fix the stale identity/cache update first, then adjust logging.
+
+Verification:
+
+- Unit/log assertion test for first classification, stable no-delta refresh, and
+  terminal-impacting decline.
+- Re-run the log signal script on the latest retained package after an in-game
+  run; target is no repeated exact finalizer summary in the top 10 unless the
+  recording state actually changes.
+
+### Task 1.4 - Collapse patched-snapshot/extrapolator periodic repeats
+
+Files:
+
+- `Source/Parsek/PatchedConicSnapshot.cs`
+- `Source/Parsek/BallisticExtrapolator.cs`
+- `Source/Parsek/RecordingFinalizationCacheProducer.cs` if finalizer cadence is
+  the root trigger.
+
+Changes:
+
+- The newest package repeats the same partial-tail truncation/captured/seeded
+  rotation trio 67 times. Keep first occurrence and reason changes; suppress
+  stable repeats by recording id, vessel name, patch index, and failure reason.
+- Consider folding "seeded orbital-frame rotation on N/N predicted segments"
+  into the finalizer summary when it is a stable periodic refresh detail.
+
+Verification:
+
+- Log assertion tests that repeated NullSolver/missing-reference-body truncation
+  emits once per stable tuple and emits again when patch index/body/reason
+  changes.
+
+### Task 1.5 - Reduce game-state recalculation boilerplate
+
+Files:
+
+- `Source/Parsek/GameActions/LedgerOrchestrator.cs`
+- `Source/Parsek/GameActions/*Module.cs`
+- `Source/Parsek/KspStatePatcher.cs`
+
+Changes:
+
+- Repeated all-zero reset/seed/spending summaries and sandbox/no-target patch
+  skips currently occupy many top repeat slots.
+- Add a per-recalc aggregate summary for boring no-op recalculations.
+- Use `VerboseOnChange` for stable sandbox/no-target patch skip state.
+- Keep `Info` only when a patch mutates visible KSP state or a baseline changes.
+
+Verification:
+
+- Existing ledger behavior tests remain unchanged.
+- Log assertion test for one no-op recalculation summary with per-module counts.
+
+## Phase 2 - Flight Playback Explainability
+
+Purpose: when a ghost is missing, hidden, delayed, or never spawned, the log must
+say why without per-frame spam.
+
+### Task 2.1 - Carry explicit ghost skip reasons
+
+Files:
+
+- `Source/Parsek/GhostPlaybackEvents.cs`
+- `Source/Parsek/ParsekFlight.cs`
+- `Source/Parsek/GhostPlaybackEngine.cs`
+
+Changes:
+
+- Add a compact skip reason enum/string to `TrajectoryPlaybackFlags`.
+- Populate it in `ComputePlaybackFlags` for no renderable data,
+  playback-disabled, external-vessel suppression, and any existing structural
+  skip.
+- Log reason flips via `VerboseOnChange` keyed by recording id.
+- Add aggregate counters to the existing engine frame summary.
+
+Verification:
+
+- Unit tests for every skip reason.
+- Log assertion tests prove stable repeats suppress and reason changes re-emit.
+
+### Task 2.2 - Add engine skip counters for under-summarized paths
+
+Files:
+
+- `Source/Parsek/GhostPlaybackEngine.cs`
+- `Source/Parsek/Diagnostics/DiagnosticsStructs.cs` if diagnostics structs need
+  fields.
+
+Changes:
+
+- Count and summarize: `beforeActivation`, `anchorMissing`, `loopSyncFailed`,
+  `parentLoopPaused`, `warpHidden`, `visualLoadFailed`, `noRenderableData`,
+  `sessionSuppressed`.
+- Use `VerboseRateLimited("Engine", "frame-summary", ...)` for aggregate counts.
+- Use `VerboseOnChange` only for per-recording reason flips.
+
+Verification:
+
+- Headless tests for frame-summary counter construction where possible.
+- Existing in-game playback tests should not show top repeated frame-summary
+  spam.
+
+### Task 2.3 - Log fast-forward watch handoff failures
+
+Files:
+
+- `Source/Parsek/ParsekFlight.cs`
+- `Source/Parsek/WatchModeController.cs` if helper extraction is useful.
+
+Changes:
+
+- When `pendingWatchAfterFFId` clears and no active ghost is watchable, log:
+  recording id, whether committed recording exists, playback enabled, current
+  UT, active ghost state, and reason.
+- Use `Warn` when the recording exists but no ghost is available; use `Verbose`
+  for stale id.
+
+Verification:
+
+- Unit/log assertion test around a pure helper that classifies watch handoff
+  result.
+
+### Task 2.4 - Log watch camera infrastructure failures
+
+Files:
+
+- `Source/Parsek/WatchModeController.cs`
+
+Changes:
+
+- Add `WarnRateLimited` when watch mode cannot update because
+  `FlightCamera.fetch`, transform, or transform parent is null.
+- Include watched recording id/name, cycle, scene, target state, and which
+  object was null.
+
+Verification:
+
+- Log assertion test through a seam/helper if direct Unity objects are not
+  constructible in xUnit.
+
+## Phase 3 - Save/Load, Sidecars, And Rewind Preconditions
+
+Purpose: persistence failures and disabled rewind buttons must be diagnosable
+from one log package.
+
+### Task 3.1 - Add scenario top-level exception context
+
+Files:
+
+- `Source/Parsek/ParsekScenario.cs`
+
+Changes:
+
+- Wrap `OnSave` and `OnLoad` phase bodies with top-level catch blocks that log
+  `Error("Scenario", ...)` with phase, scene, save folder, committed/pending
+  counts, active tree state, marker state, and exception type/message.
+- Emit `RecState("OnSave:exception", ...)` or `RecState("OnLoad:exception", ...)`.
+- Rethrow after logging.
+
+Verification:
+
+- Injected exception tests through test seams, asserting both rethrow and log
+  context.
+
+### Task 3.2 - Fix duplicate/miscounted OnLoad timing
+
+Files:
+
+- `Source/Parsek/ParsekScenario.cs`
+
+Changes:
+
+- Centralize `WriteLoadTiming` so each `OnLoad` invocation emits one timing line.
+- Make recording count final and phase/status explicit.
+
+Verification:
+
+- Unit/log assertion tests for cold-start, early-return, and normal load paths.
+
+### Task 3.3 - Upgrade sidecar/path failure severity and context
+
+Files:
+
+- `Source/Parsek/RecordingStore.cs`
+- `Source/Parsek/SnapshotSidecarCodec.cs`
+- `Source/Parsek/RecordingPaths.cs`
+- `Source/Parsek/SidecarFileCommitBatch.cs`
+
+Changes:
+
+- Save/load sidecar exceptions that return false must log at `Warn` or `Error`,
+  not INFO.
+- Include sidecar path, file kind, save folder, epoch, probe encoding/version,
+  staged-file count, ghost snapshot mode, exception type, and message.
+- Add low-noise cleanup summaries for transient artifact deletion failures.
+
+Verification:
+
+- Tests for sidecar save exception, sidecar load exception, stale/unsupported
+  probe, directory create failure, and cleanup failure summary.
+
+### Task 3.4 - Log RewindInvoker.CanInvoke reason changes
+
+Files:
+
+- `Source/Parsek/RewindInvoker.cs`
+- `Source/Parsek/UI/RecordingsTableUI.cs` if cache coordination is needed.
+
+Changes:
+
+- Add `VerboseOnChange` keyed by rewind point id and reason for precondition
+  failures.
+- Keep UI draw loops quiet by logging only when reason changes, not every draw.
+
+Verification:
+
+- Log assertion tests for null/corrupt/missing-quicksave/pending-invoke/deep
+  parse failure paths and stable repeat suppression.
+
+## Phase 4 - Recorder And Auto-Record Decision Visibility
+
+Purpose: recording did not start, stopped sampling, or moved to background must
+always have a reason.
+
+### Task 4.1 - Background recorder state-drift warnings
+
+Files:
+
+- `Source/Parsek/BackgroundRecorder.cs`
+- `Source/Parsek/Patches/PhysicsFramePatch.cs`
+
+Changes:
+
+- Add `Info` attach/clear logs for `BackgroundRecorderInstance`.
+- Add `WarnRateLimited` for background map/state disagreements where a vessel is
+  in `BackgroundMap` but loaded/on-rails state or tree recording is missing.
+
+Verification:
+
+- Tests around extracted decision helper; live KSP smoke can confirm attach/clear
+  lines.
+
+### Task 4.2 - Active-to-background missing-vessel warning
+
+Files:
+
+- `Source/Parsek/FlightRecorder.cs`
+
+Changes:
+
+- When transition-to-background cannot resolve the live vessel, emit `Warn` with
+  pid, recording id, vessel name, points, orbit segments, track sections, and
+  finalizer-cache state.
+
+Verification:
+
+- Unit/log assertion test via `FindVesselByPid` seam if available; otherwise
+  introduce a small helper for decision formatting.
+
+### Task 4.3 - Post-switch auto-record no-trigger summaries
+
+Files:
+
+- `Source/Parsek/ParsekFlight.cs`
+
+Changes:
+
+- Add a `VerboseOnChange` summary keyed by watched vessel pid for suppression,
+  baseline, settle, and trigger state.
+- Add a rate-limited manifest delta summary at the existing manifest-evaluation
+  cadence.
+
+Verification:
+
+- Existing post-switch auto-record tests plus log assertions for no-trigger,
+  suppression, and accepted trigger paths.
+
+### Task 4.4 - EVA/boarding split skip logs
+
+Files:
+
+- `Source/Parsek/ParsekFlight.cs`
+
+Changes:
+
+- Log `pendingSplitInProgress`, source-vessel mismatch, and target/source null
+  paths using `VerboseOnChange` or `VerboseRateLimited` keyed by active
+  recording id/source pid.
+
+Verification:
+
+- Log assertion tests for active-recording EVA skip and boarding skip helpers.
+
+## Phase 5 - Game Actions, UI, Map Markers, And Test Runner
+
+Purpose: lower-priority but still user-visible paths get complete summaries.
+
+### Task 5.1 - Game-action skip reason summaries
+
+Files:
+
+- `Source/Parsek/GameStateRecorder.cs`
+- `Source/Parsek/GameActions/GameStateEventConverter.cs`
+- `Source/Parsek/KerbalsModule.cs`
+
+Changes:
+
+- Log null/unsuccessful event rejects at `Verbose` or `VerboseRateLimited`.
+- Add per-event-type skip counters to converter summaries.
+- Add kerbal assignment pre-pass/post-walk batch counters.
+
+Verification:
+
+- Unit/log assertion tests for event rejects and converter skip counts.
+
+### Task 5.2 - UI/window and Real Spawn Control visibility
+
+Files:
+
+- `Source/Parsek/ParsekUI.cs`
+- `Source/Parsek/UI/SpawnControlUI.cs`
+
+Changes:
+
+- Add missing Career window toggle log.
+- Add `VerboseOnChange` for Real Spawn Control auto-close reasons:
+  not in flight, flight null, zero candidates.
+
+Verification:
+
+- UI helper tests where available; otherwise log assertion on extracted
+  reason-format helpers.
+
+### Task 5.3 - Map marker and Tracking Station skip summaries
+
+Files:
+
+- `Source/Parsek/ParsekUI.cs`
+- `Source/Parsek/ParsekTrackingStation.cs`
+- `Source/Parsek/Patches/GhostOrbitLinePatch.cs`
+
+Changes:
+
+- Add per-frame/per-refresh counters for map-marker skips:
+  camera unavailable, native-icon skip, chain non-tip, position failure,
+  missing body.
+- Add Tracking Station atmospheric marker skip counts.
+- Add Harmony orbit suppression `VerboseRateLimited` / `VerboseOnChange`
+  summaries.
+
+Verification:
+
+- Headless tests for pure classification helpers.
+- In-game smoke for map/tracking station scenes.
+
+### Task 5.4 - Runtime test runner skip visibility
+
+Files:
+
+- `Source/Parsek/InGameTests/InGameTestRunner.cs`
+
+Changes:
+
+- Emit one `Info` aggregate per batch for scene eligibility skips.
+- Keep optional per-test names at `Verbose`.
+
+Verification:
+
+- In-game test runner unit coverage or direct log assertion around skip
+  aggregation helper.
+
+## Phase 6 - End-To-End Validation
+
+Purpose: prove the plan improves the support workflow.
+
+### Required automated checks
+
+- `dotnet test Source/Parsek.Tests/Parsek.Tests.csproj`
+- `pwsh -File scripts/validate-ksp-log.ps1`
+- New log signal script against retained packages and current generated package.
+
+### Required retained evidence
+
+Run at least one fresh in-game session after phases 1-5 and collect:
+
+- `python scripts/collect-logs.py observability-followup`
+- `log-validation.txt`
+- `parsek-test-results.txt`
+- log signal summary output
+
+### Acceptance targets
+
+- Parsek remains visible but does not dominate >95% of KSP.log lines in a normal
+  short session unless the session is intentionally running diagnostic tests.
+- No exact repeated message should appear in the top 10 unless it is explicitly
+  rate-limited with `suppressed=N` or it represents a real repeated gameplay
+  event.
+- A missing/hidden ghost has a reason line or a frame-summary counter.
+- A disabled Rewind/Re-Fly button has a reason-change line.
+- Save/load and sidecar failures include phase/path/recording context.
+- Log validation fails malformed Parsek lines and redundant warning prefixes.
+
+## Phase Ordering Rationale
+
+Phase 0 and Phase 1 come first because adding more logs before reducing current
+repeaters will make the support signal worse. Phase 2 follows because ghost
+visibility failures are the main player-visible symptom class. Phase 3 covers
+persistence and rewind, the highest-risk failure domain. Phase 4 covers
+recording start/continuation decisions. Phase 5 fills UI/map/game-action gaps.
+Phase 6 validates the whole support workflow against real KSP log packages.
+
+## Parallelization Notes
+
+After Phase 0, these workstreams can run in separate worktrees with low conflict
+risk:
+
+- KSC/diagnostics spam hygiene (`ParsekKSC`, diagnostics).
+- Playback explainability (`GhostPlaybackEvents`, `ParsekFlight`,
+  `GhostPlaybackEngine`).
+- Persistence/rewind (`ParsekScenario`, `RecordingStore`, `RewindInvoker`).
+- Game actions/UI/map summaries (`GameStateRecorder`, `GameActions`, UI files).
+
+Do not parallelize tasks that edit `ParsekFlight.cs` with each other unless the
+write scopes are split carefully.
+
+## Documentation Updates Per Phase
+
+Each implementation PR should update:
+
+- `CHANGELOG.md` under the current version.
+- `docs/dev/todo-and-known-bugs.md`, marking the relevant plan item closed or
+  adding discoveries from new log packages.
+- `docs/dev/observability-audit-2026-04-26.md` only if the audit findings are
+  superseded or materially corrected.
+
+## Review Checklist
+
+For every phase, review against these questions:
+
+- Does every new decision path log why it chose that path?
+- Is every hot-path log batched, rate-limited, or on-change?
+- Are rate-limit keys stable and identity-aware where identity matters?
+- Do tests assert both behavior and log output?
+- Does the phase reduce or preserve log volume in the newest packages?
+- Can a future support pass answer "what happened and why" from `KSP.log`
+  alone?

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -11,6 +11,25 @@ When referencing prior item numbers from source comments or plans, consult the r
 
 ---
 
+## Observability Audit - 2026-04-26
+
+Full report: `docs/dev/observability-audit-2026-04-26.md`.
+
+Open implementation follow-up: make Parsek's runtime decisions reconstructable
+from `KSP.log` without reintroducing per-frame spam. The audit prioritizes:
+
+- P1 save/load exception context and KSC playback spam fixes.
+- P2 flight ghost skip reasons, playback frame skip summaries, rewind
+  `CanInvoke` reason logging, sidecar/path severity and context, duplicate
+  `OnLoad` timing cleanup, post-switch auto-record no-trigger summaries,
+  background recorder drift warnings, game-action skip summaries, and UI/map
+  marker skip summaries.
+- P3 shared rate-limit key cleanup, repeated-warning rate limits, noisy resource
+  event aggregation, production warning-prefix cleanup, and low-risk
+  cleanup/reflection summaries.
+
+---
+
 ## Rewind to Staging — v0.9 carryover follow-ups
 
 The feature itself shipped on `feat/rewind-staging` across the v0.9 cycle (design: `docs/parsek-rewind-to-staging-design.md`; pre-implementation spec archived at `docs/dev/done/parsek-rewind-staging-design.md`; roadmap + CHANGELOG under v0.9.0). Items 1-18 of the post-merge follow-up cascade are archived in `done/todo-and-known-bugs-v4.md`.

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -14,6 +14,7 @@ When referencing prior item numbers from source comments or plans, consult the r
 ## Observability Audit - 2026-04-26
 
 Full report: `docs/dev/observability-audit-2026-04-26.md`.
+Implementation plan: `docs/dev/plan-observability-logging-visibility.md`.
 
 Open implementation follow-up: make Parsek's runtime decisions reconstructable
 from `KSP.log` without reintroducing per-frame spam. The audit prioritizes:


### PR DESCRIPTION
## Summary
- add a full observability/logging audit for current Parsek runtime coverage
- add a phased implementation plan calibrated against the newest retained log packages
- track the observability follow-up in changelog and known-bugs docs

## Validation
- checked all report source references resolve to existing files/lines
- ran git diff --check
- docs-only change; no build/test run