### PR TITLE
Add observability log-assertion test coverage gaps

### DIFF
--- a/Source/Parsek.Tests/DiagnosticsIntegrationTests.cs
+++ b/Source/Parsek.Tests/DiagnosticsIntegrationTests.cs
@@ -472,6 +472,41 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void SafeGetFileSize_MissingFile_DifferentPathsHaveIndependentWarnWindows()
+        {
+            double clockSeconds = 0.0;
+            ParsekLog.ClockOverrideForTesting = () => clockSeconds;
+            string firstPath = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(), $"parsek_test_{System.Guid.NewGuid():N}_a.prec");
+            string secondPath = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(), $"parsek_test_{System.Guid.NewGuid():N}_b.prec");
+
+            Assert.Equal(0L, DiagnosticsComputation.SafeGetFileSize(firstPath, warnIfMissing: true));
+            Assert.Equal(0L, DiagnosticsComputation.SafeGetFileSize(secondPath, warnIfMissing: true));
+
+            Assert.Single(logLines.FindAll(l =>
+                l.Contains("[Parsek][WARN][Diagnostics]")
+                && l.Contains("Missing sidecar file")
+                && l.Contains(firstPath)));
+            Assert.Single(logLines.FindAll(l =>
+                l.Contains("[Parsek][WARN][Diagnostics]")
+                && l.Contains("Missing sidecar file")
+                && l.Contains(secondPath)));
+
+            Assert.Equal(0L, DiagnosticsComputation.SafeGetFileSize(firstPath, warnIfMissing: true));
+            Assert.Equal(0L, DiagnosticsComputation.SafeGetFileSize(secondPath, warnIfMissing: true));
+
+            Assert.Single(logLines.FindAll(l =>
+                l.Contains("[Parsek][WARN][Diagnostics]")
+                && l.Contains("Missing sidecar file")
+                && l.Contains(firstPath)));
+            Assert.Single(logLines.FindAll(l =>
+                l.Contains("[Parsek][WARN][Diagnostics]")
+                && l.Contains("Missing sidecar file")
+                && l.Contains(secondPath)));
+        }
+
+        [Fact]
         public void SafeGetFileSize_MissingFile_WarnIfMissingFalse_NoWarning()
         {
             string nonExistent = System.IO.Path.Combine(

--- a/Source/Parsek.Tests/FlightPlaybackExplainabilityTests.cs
+++ b/Source/Parsek.Tests/FlightPlaybackExplainabilityTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
 using Xunit;
 
 namespace Parsek.Tests
@@ -125,6 +127,62 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void ComputePlaybackFlags_LogsGhostSkipReasonAndSuppressesStableRepeats()
+        {
+            RecordingStore.ResetForTesting();
+            try
+            {
+                ParsekFlight host = CreateFlightHostForPlaybackFlagTests();
+                var noData = new Recording
+                {
+                    RecordingId = "rec-flags",
+                    VesselName = "Flagged Vessel",
+                    PlaybackEnabled = true
+                };
+                var committed = new List<Recording> { noData };
+
+                TrajectoryPlaybackFlags[] flags = ComputePlaybackFlagsForTesting(host, committed, 100.0);
+
+                Assert.Single(flags);
+                Assert.True(flags[0].skipGhost);
+                Assert.Equal(GhostPlaybackSkipReason.NoRenderableData, flags[0].skipReason);
+                Assert.Equal(1, logLines.Count(line =>
+                    line.Contains("[Parsek][VERBOSE][Flight]")
+                    && line.Contains("Ghost playback skip state")
+                    && line.Contains("id=rec-flags")
+                    && line.Contains("reason=no-renderable-data")));
+
+                flags = ComputePlaybackFlagsForTesting(host, committed, 100.0);
+
+                Assert.Equal(GhostPlaybackSkipReason.NoRenderableData, flags[0].skipReason);
+                Assert.Equal(1, logLines.Count(line =>
+                    line.Contains("Ghost playback skip state")
+                    && line.Contains("id=rec-flags")));
+
+                var playbackDisabled = MakeRecording(
+                    "rec-flags",
+                    "Flagged Vessel",
+                    playbackEnabled: false);
+                committed[0] = playbackDisabled;
+
+                flags = ComputePlaybackFlagsForTesting(host, committed, 100.0);
+
+                Assert.True(flags[0].skipGhost);
+                Assert.Equal(GhostPlaybackSkipReason.PlaybackDisabled, flags[0].skipReason);
+                Assert.Contains(logLines, line =>
+                    line.Contains("[Parsek][VERBOSE][Flight]")
+                    && line.Contains("Ghost playback skip state")
+                    && line.Contains("id=rec-flags")
+                    && line.Contains("reason=playback-disabled")
+                    && line.Contains("suppressed=1"));
+            }
+            finally
+            {
+                RecordingStore.ResetForTesting();
+            }
+        }
+
+        [Fact]
         public void FrameSummary_IncludesAggregateSkipCounters()
         {
             var counters = new GhostPlaybackFrameCounters
@@ -233,6 +291,37 @@ namespace Parsek.Tests
             Assert.False(decision.warn);
             Assert.False(decision.recordingExists);
             Assert.Equal("stale-recording-id", decision.reason);
+        }
+
+        private static ParsekFlight CreateFlightHostForPlaybackFlagTests()
+        {
+            var host = (ParsekFlight)FormatterServices.GetUninitializedObject(typeof(ParsekFlight));
+            SetPrivateField(host, "chainManager", new ChainSegmentManager());
+            SetPrivateField(host, "activeGhostSkipReasonLogIdentities", new HashSet<string>());
+            return host;
+        }
+
+        private static TrajectoryPlaybackFlags[] ComputePlaybackFlagsForTesting(
+            ParsekFlight host,
+            IReadOnlyList<Recording> committed,
+            double currentUT)
+        {
+            MethodInfo method = typeof(ParsekFlight).GetMethod(
+                "ComputePlaybackFlags",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(method);
+            return (TrajectoryPlaybackFlags[])method.Invoke(
+                host,
+                new object[] { committed, currentUT });
+        }
+
+        private static void SetPrivateField(object target, string fieldName, object value)
+        {
+            FieldInfo field = target.GetType().GetField(
+                fieldName,
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(field);
+            field.SetValue(target, value);
         }
     }
 }

--- a/Source/Parsek.Tests/FlightPlaybackExplainabilityTests.cs
+++ b/Source/Parsek.Tests/FlightPlaybackExplainabilityTests.cs
@@ -297,6 +297,7 @@ namespace Parsek.Tests
         {
             var host = (ParsekFlight)FormatterServices.GetUninitializedObject(typeof(ParsekFlight));
             SetPrivateField(host, "chainManager", new ChainSegmentManager());
+            SetPrivateField(host, "activeGhostChains", new Dictionary<uint, GhostChain>());
             SetPrivateField(host, "activeGhostSkipReasonLogIdentities", new HashSet<string>());
             return host;
         }

--- a/Source/Parsek.Tests/ObservabilityPersistencePhase3Tests.cs
+++ b/Source/Parsek.Tests/ObservabilityPersistencePhase3Tests.cs
@@ -175,7 +175,24 @@ namespace Parsek.Tests
                 };
                 RecordingStore.StashPendingTree(pendingTree, PendingTreeState.Limbo);
 
-                var scenario = new ParsekScenario();
+                var scenario = new ParsekScenario
+                {
+                    ActiveReFlySessionMarker = new ReFlySessionMarker
+                    {
+                        SessionId = "sess_save_log",
+                        TreeId = "tree_save_live",
+                        ActiveReFlyRecordingId = "rec_save_active",
+                        OriginChildRecordingId = "rec_save_origin",
+                        RewindPointId = "rp_save_log"
+                    },
+                    ActiveMergeJournal = new MergeJournal
+                    {
+                        JournalId = "journal_save_log",
+                        SessionId = "sess_save_log",
+                        TreeId = "tree_save_live",
+                        Phase = MergeJournal.Phases.Durable1Done
+                    }
+                };
                 SetPrivateField(scenario, "scenarioSaveFolder", "observability_save");
 
                 var ex = Assert.Throws<InvalidOperationException>(() =>
@@ -194,6 +211,12 @@ namespace Parsek.Tests
                 Assert.Contains("committedRecordings=1", errorLine);
                 Assert.Contains("committedTrees=0", errorLine);
                 Assert.Contains("pendingTree=id=tree_save_pending,state=Limbo,recordings=1", errorLine);
+                Assert.Contains(
+                    "marker=sess=sess_save_log,tree=tree_save_live,active=rec_save_active,origin=rec_save_origin,rp=rp_save_log",
+                    errorLine);
+                Assert.Contains(
+                    "journal=journal_save_log,sess=sess_save_log,tree=tree_save_live,phase=Durable1Done",
+                    errorLine);
                 Assert.Contains("ex=InvalidOperationException:save boom", errorLine);
                 Assert.Contains(logLines, line =>
                     line.Contains("[INFO][RecState]") &&

--- a/Source/Parsek.Tests/ObservabilityPersistencePhase3Tests.cs
+++ b/Source/Parsek.Tests/ObservabilityPersistencePhase3Tests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using Xunit;
 
@@ -150,6 +151,61 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void OnSaveScenarioLifecycleExceptionLog_IncludesTopLevelContextAndRecState()
+        {
+            string previousSaveFolder = HighLogic.SaveFolder;
+            try
+            {
+                HighLogic.SaveFolder = "observability_save";
+                RecordingStore.AddCommittedInternal(new Recording
+                {
+                    RecordingId = "rec_committed",
+                    VesselName = "Committed Vessel"
+                });
+
+                var pendingTree = new RecordingTree
+                {
+                    Id = "tree_save_pending",
+                    TreeName = "Save Pending"
+                };
+                pendingTree.Recordings["rec_save_pending"] = new Recording
+                {
+                    RecordingId = "rec_save_pending",
+                    VesselName = "Pending Save Vessel"
+                };
+                RecordingStore.StashPendingTree(pendingTree, PendingTreeState.Limbo);
+
+                var scenario = new ParsekScenario();
+                SetPrivateField(scenario, "scenarioSaveFolder", "observability_save");
+
+                var ex = Assert.Throws<InvalidOperationException>(() =>
+                    scenario.ExecuteOnSaveLifecyclePhaseForTesting(
+                        "recordings",
+                        () => throw new InvalidOperationException("save boom")));
+
+                Assert.Equal("save boom", ex.Message);
+                string errorLine = logLines.FirstOrDefault(line =>
+                    line.Contains("[ERROR][Scenario]") &&
+                    line.Contains("OnSave: exception"));
+                Assert.NotNull(errorLine);
+                Assert.Contains("phase=recordings", errorLine);
+                Assert.Contains("saveFolder=<null>", errorLine);
+                Assert.Contains("scenarioSaveFolder=observability_save", errorLine);
+                Assert.Contains("committedRecordings=1", errorLine);
+                Assert.Contains("committedTrees=0", errorLine);
+                Assert.Contains("pendingTree=id=tree_save_pending,state=Limbo,recordings=1", errorLine);
+                Assert.Contains("ex=InvalidOperationException:save boom", errorLine);
+                Assert.Contains(logLines, line =>
+                    line.Contains("[INFO][RecState]") &&
+                    line.Contains("[OnSave:exception]"));
+            }
+            finally
+            {
+                HighLogic.SaveFolder = previousSaveFolder;
+            }
+        }
+
+        [Fact]
         public void SnapshotSidecarInvalidLog_IncludesRecordingPathEpochAndProbeContext()
         {
             string vesselPath = Path.Combine(tempDir, "rec_sidecar_vessel.craft");
@@ -174,6 +230,38 @@ namespace Parsek.Tests
                 line.Contains("fileKind=vessel") &&
                 line.Contains(vesselPath) &&
                 line.Contains("failure='binary header truncated'"));
+        }
+
+        [Fact]
+        public void SnapshotSidecarUnsupportedLog_IncludesProbeVersionContext()
+        {
+            string vesselPath = Path.Combine(tempDir, "rec_sidecar_unsupported_vessel.craft");
+            int unsupportedVersion = SnapshotSidecarCodec.CurrentVersion + 1;
+            WriteSnapshotSidecarHeader(vesselPath, unsupportedVersion, codec: 1);
+            var rec = new Recording
+            {
+                RecordingId = "rec_sidecar_unsupported",
+                SidecarEpoch = 8,
+                GhostSnapshotMode = GhostSnapshotMode.Separate
+            };
+
+            RecordingStore.SnapshotSidecarLoadSummary summary =
+                RecordingStore.LoadSnapshotSidecarsFromPaths(rec, vesselPath, ghostPath: null);
+
+            Assert.Equal(RecordingStore.SnapshotSidecarLoadState.Unsupported, summary.VesselState);
+            Assert.Equal("snapshot-vessel-unsupported", summary.FailureReason);
+            Assert.Contains(logLines, line =>
+                line.Contains("[WARN][RecordingStore]") &&
+                line.Contains("unsupported vessel snapshot sidecar") &&
+                line.Contains("id=rec_sidecar_unsupported") &&
+                line.Contains("epoch=8") &&
+                line.Contains("ghostSnapshotMode=Separate") &&
+                line.Contains("fileKind=vessel") &&
+                line.Contains(vesselPath) &&
+                line.Contains("supported=False") &&
+                line.Contains("encoding=UnknownBinary") &&
+                line.Contains("version=" + unsupportedVersion) &&
+                line.Contains("failure='unsupported snapshot sidecar version " + unsupportedVersion + " codec 1'"));
         }
 
         [Fact]
@@ -460,6 +548,29 @@ namespace Parsek.Tests
 
             throw new InvalidOperationException(
                 "Could not locate repo root from " + AppContext.BaseDirectory);
+        }
+
+        private static void WriteSnapshotSidecarHeader(string path, int version, byte codec)
+        {
+            using (var stream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None))
+            using (var writer = new BinaryWriter(stream, Encoding.UTF8))
+            {
+                writer.Write(Encoding.ASCII.GetBytes("PRKS"));
+                writer.Write(version);
+                writer.Write(codec);
+                writer.Write(0);
+                writer.Write(0);
+                writer.Write(0u);
+            }
+        }
+
+        private static void SetPrivateField(object target, string fieldName, object value)
+        {
+            FieldInfo field = target.GetType().GetField(
+                fieldName,
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(field);
+            field.SetValue(target, value);
         }
     }
 }

--- a/Source/Parsek.Tests/RecordingFinalizationCacheProducerTests.cs
+++ b/Source/Parsek.Tests/RecordingFinalizationCacheProducerTests.cs
@@ -230,6 +230,7 @@ namespace Parsek.Tests
             double clockSeconds = 0.0;
             ParsekLog.ClockOverrideForTesting = () => clockSeconds;
             const uint sharedVesselPid = 111u;
+            // Intentional: VerboseOnChange identity is keyed by recordingId, not vessel pid.
             var first = new Recording
             {
                 RecordingId = "rec-refresh-a",

--- a/Source/Parsek.Tests/RecordingFinalizationCacheProducerTests.cs
+++ b/Source/Parsek.Tests/RecordingFinalizationCacheProducerTests.cs
@@ -225,6 +225,63 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void LogRefreshSummary_CrossRecordingIdentitiesDoNotShareRateLimitWindow()
+        {
+            double clockSeconds = 0.0;
+            ParsekLog.ClockOverrideForTesting = () => clockSeconds;
+            const uint sharedVesselPid = 111u;
+            var first = new Recording
+            {
+                RecordingId = "rec-refresh-a",
+                VesselPersistentId = sharedVesselPid
+            };
+            var second = new Recording
+            {
+                RecordingId = "rec-refresh-b",
+                VesselPersistentId = sharedVesselPid
+            };
+
+            LogStableRefresh(first);
+            LogStableRefresh(second);
+
+            Assert.Equal(1, CountLogLines(
+                "[Parsek][VERBOSE][Extrapolator]",
+                "FinalizerCache refresh summary",
+                "rec=rec-refresh-a"));
+            Assert.Equal(1, CountLogLines(
+                "[Parsek][VERBOSE][Extrapolator]",
+                "FinalizerCache refresh summary",
+                "rec=rec-refresh-b"));
+
+            LogStableRefresh(first);
+            LogStableRefresh(second);
+
+            Assert.Equal(1, CountLogLines(
+                "[Parsek][VERBOSE][Extrapolator]",
+                "FinalizerCache refresh summary",
+                "rec=rec-refresh-a"));
+            Assert.Equal(1, CountLogLines(
+                "[Parsek][VERBOSE][Extrapolator]",
+                "FinalizerCache refresh summary",
+                "rec=rec-refresh-b"));
+
+            clockSeconds += 31.0;
+            LogStableRefresh(first);
+            LogStableRefresh(second);
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[Parsek][VERBOSE][Extrapolator]")
+                && l.Contains("FinalizerCache refresh summary")
+                && l.Contains("rec=rec-refresh-a")
+                && l.Contains("suppressed=1"));
+            Assert.Contains(logLines, l =>
+                l.Contains("[Parsek][VERBOSE][Extrapolator]")
+                && l.Contains("FinalizerCache refresh summary")
+                && l.Contains("rec=rec-refresh-b")
+                && l.Contains("suppressed=1"));
+        }
+
+        [Fact]
         public void LogRefreshSummary_RepeatedClassification_InfoOnceThenVerboseRateLimited()
         {
             double clockSeconds = 0.0;
@@ -793,6 +850,21 @@ namespace Parsek.Tests
             Assert.Equal(250.0, cache.TerminalUT);
             Assert.True(cache.LastWasInAtmosphere);
             Assert.Equal("Kerbin", cache.TerminalBodyName);
+        }
+
+        private static void LogStableRefresh(Recording recording)
+        {
+            RecordingFinalizationCacheProducer.LogRefreshSummary(
+                FinalizationCacheOwner.ActiveRecorder,
+                "periodic",
+                recordingsExamined: 1,
+                alreadyClassified: 0,
+                newlyClassified: 0,
+                recordingId: recording.RecordingId,
+                vesselPid: recording.VesselPersistentId,
+                status: FinalizationCacheStatus.Fresh,
+                terminalState: TerminalState.Orbiting,
+                predictedSegmentCount: 1);
         }
 
         private int CountLogLines(params string[] requiredFragments)

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -2119,6 +2119,11 @@ namespace Parsek
             }
         }
 
+        internal void ExecuteOnSaveLifecyclePhaseForTesting(string phase, Action body)
+        {
+            ExecuteScenarioLifecyclePhaseForTesting("OnSave", phase, body);
+        }
+
         private void LogScenarioLifecycleException(string lifecycle, string phase, Exception ex)
         {
             try

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -97,6 +97,11 @@ save/load exception context, sidecar/path severity expansion, rewind
 `CanInvoke` reason-change logging, playback-engine frame skip counters, and
 Phase 6 retained in-game log-package validation still need separate passes.
 
+Review follow-up coverage (2026-04-26): closed the deferred log-assertion gaps
+for finalizer refresh identity isolation, Diagnostics missing-sidecar path
+warning scopes, `ComputePlaybackFlags` ghost-skip emit/suppress behavior,
+`OnSave` exception context/RecState, and unsupported snapshot probe logging.
+
 ---
 
 ## Rewind to Staging — v0.9 carryover follow-ups


### PR DESCRIPTION
Summary:
- Adds log assertion coverage for finalizer refresh identity isolation, diagnostics missing-sidecar warn path scopes, ComputePlaybackFlags ghost-skip emit/suppress, OnSave exception context/RecState, and unsupported snapshot probe logging.
- Adds an OnSave lifecycle test seam mirroring the existing scenario lifecycle seam.
- Updates docs/dev/todo-and-known-bugs.md for the closed follow-ups.

Tests:
- dotnet test --filter changed observability test names (5 passed)
- dotnet test --filter FullyQualifiedName!~SyntheticRecordingTests.InjectAllRecordings (9013 passed)
- Full unfiltered dotnet test is blocked locally by locked KSP.log / deployed Parsek.dll from the local KSP process; only SyntheticRecordingTests.InjectAllRecordings is affected.

Note:
- LogRefreshSummary is VerboseRateLimited on main, so the new coverage asserts independent per-recording rate-limit windows and suppressed counts rather than VerboseOnChange state flips.