### PR TITLE
Clear ghost-skip VerboseOnChange identities on scene unload

### DIFF
--- a/Source/Parsek.Tests/FlightGhostSkipCacheCleanupTests.cs
+++ b/Source/Parsek.Tests/FlightGhostSkipCacheCleanupTests.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    [Collection("Sequential")]
+    public class FlightGhostSkipCacheCleanupTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public FlightGhostSkipCacheCleanupTests()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.VerboseOverrideForTesting = true;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+        }
+
+        [Fact]
+        public void ClearGhostSkipReasonLogStateForTesting_AllowsPerRecordingSkipReasonsToReEmit()
+        {
+            ParsekFlight host = CreateFlightHostWithGhostSkipState(
+                new HashSet<string> { "rec-cache-a", "rec-cache-b" });
+
+            LogNoRenderableData("rec-cache-a", 0);
+            LogNoRenderableData("rec-cache-b", 1);
+            LogNoRenderableData("rec-cache-a", 0);
+            LogNoRenderableData("rec-cache-b", 1);
+
+            Assert.Equal(1, CountGhostSkipLines("rec-cache-a"));
+            Assert.Equal(1, CountGhostSkipLines("rec-cache-b"));
+
+            host.ClearGhostSkipReasonLogStateForTesting();
+
+            Assert.Empty(GetActiveGhostSkipReasonIdentities(host));
+
+            LogNoRenderableData("rec-cache-a", 0);
+            LogNoRenderableData("rec-cache-b", 1);
+
+            Assert.Equal(2, CountGhostSkipLines("rec-cache-a"));
+            Assert.Equal(2, CountGhostSkipLines("rec-cache-b"));
+        }
+
+        private void LogNoRenderableData(string recordingId, int index)
+        {
+            ParsekFlight.LogGhostSkipReasonChangeForTesting(
+                index,
+                recordingId,
+                "Skip Vessel",
+                GhostPlaybackSkipReason.NoRenderableData,
+                hasRenderableData: false,
+                playbackEnabled: true,
+                externalVesselSuppressed: false);
+        }
+
+        private int CountGhostSkipLines(string recordingId)
+        {
+            return logLines.Count(line =>
+                line.Contains("[Parsek][VERBOSE][Flight]")
+                && line.Contains("Ghost playback skip state")
+                && line.Contains("id=" + recordingId));
+        }
+
+        private static ParsekFlight CreateFlightHostWithGhostSkipState(HashSet<string> identities)
+        {
+            var host = (ParsekFlight)FormatterServices.GetUninitializedObject(typeof(ParsekFlight));
+            SetActiveGhostSkipReasonIdentities(host, identities);
+            return host;
+        }
+
+        private static HashSet<string> GetActiveGhostSkipReasonIdentities(ParsekFlight host)
+        {
+            FieldInfo field = GetActiveGhostSkipReasonIdentitiesField();
+            return (HashSet<string>)field.GetValue(host);
+        }
+
+        private static void SetActiveGhostSkipReasonIdentities(
+            ParsekFlight host,
+            HashSet<string> identities)
+        {
+            FieldInfo field = GetActiveGhostSkipReasonIdentitiesField();
+            field.SetValue(host, identities);
+        }
+
+        private static FieldInfo GetActiveGhostSkipReasonIdentitiesField()
+        {
+            FieldInfo field = typeof(ParsekFlight).GetField(
+                "activeGhostSkipReasonLogIdentities",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(field);
+            return field;
+        }
+    }
+}

--- a/Source/Parsek.Tests/FlightGhostSkipCacheCleanupTests.cs
+++ b/Source/Parsek.Tests/FlightGhostSkipCacheCleanupTests.cs
@@ -51,6 +51,26 @@ namespace Parsek.Tests
             Assert.Equal(2, CountGhostSkipLines("rec-cache-b"));
         }
 
+        [Fact]
+        public void DestroyAllTimelineGhosts_AllowsPerRecordingSkipReasonsToReEmit()
+        {
+            ParsekFlight host = CreateFlightHostForDestroyAllTimelineGhosts(
+                new HashSet<string> { "rec-cache-a" });
+
+            LogNoRenderableData("rec-cache-a", 0);
+            LogNoRenderableData("rec-cache-a", 0);
+
+            Assert.Equal(1, CountGhostSkipLines("rec-cache-a"));
+
+            host.DestroyAllTimelineGhosts();
+
+            Assert.Empty(GetActiveGhostSkipReasonIdentities(host));
+
+            LogNoRenderableData("rec-cache-a", 0);
+
+            Assert.Equal(2, CountGhostSkipLines("rec-cache-a"));
+        }
+
         private void LogNoRenderableData(string recordingId, int index)
         {
             ParsekFlight.LogGhostSkipReasonChangeForTesting(
@@ -78,6 +98,22 @@ namespace Parsek.Tests
             return host;
         }
 
+        private static ParsekFlight CreateFlightHostForDestroyAllTimelineGhosts(
+            HashSet<string> identities)
+        {
+            ParsekFlight host = CreateFlightHostWithGhostSkipState(identities);
+            SetPrivateField(host, "engine", new GhostPlaybackEngine(null));
+            SetPrivateFieldFromDefaultConstructor(host, "orbitCache");
+            SetPrivateFieldFromDefaultConstructor(host, "loggedOrbitSegments");
+            SetPrivateFieldFromDefaultConstructor(host, "loggedOrbitRotationSegments");
+            SetPrivateFieldFromDefaultConstructor(host, "nearbySpawnCandidates");
+            SetPrivateFieldFromDefaultConstructor(host, "proximityVelocitySamples");
+            SetPrivateFieldFromDefaultConstructor(host, "notifiedSpawnRecordingIds");
+            SetPrivateFieldFromDefaultConstructor(host, "loggedRelativeStart");
+            SetPrivateFieldFromDefaultConstructor(host, "loggedAnchorNotFound");
+            return host;
+        }
+
         private static HashSet<string> GetActiveGhostSkipReasonIdentities(ParsekFlight host)
         {
             FieldInfo field = GetActiveGhostSkipReasonIdentitiesField();
@@ -99,6 +135,26 @@ namespace Parsek.Tests
                 BindingFlags.Instance | BindingFlags.NonPublic);
             Assert.NotNull(field);
             return field;
+        }
+
+        private static void SetPrivateField(ParsekFlight host, string fieldName, object value)
+        {
+            FieldInfo field = typeof(ParsekFlight).GetField(
+                fieldName,
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(field);
+            field.SetValue(host, value);
+        }
+
+        private static void SetPrivateFieldFromDefaultConstructor(
+            ParsekFlight host,
+            string fieldName)
+        {
+            FieldInfo field = typeof(ParsekFlight).GetField(
+                fieldName,
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(field);
+            field.SetValue(host, Activator.CreateInstance(field.FieldType));
         }
     }
 }

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -13106,6 +13106,7 @@ namespace Parsek
             notifiedSpawnRecordingIds.Clear();
             loggedRelativeStart.Clear();
             loggedAnchorNotFound.Clear();
+            ClearGhostSkipReasonLogState();
         }
 
         /// <summary>

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -1398,6 +1398,7 @@ namespace Parsek
             notifiedSpawnRecordingIds.Clear();
             loggedRelativeStart.Clear();
             loggedAnchorNotFound.Clear();
+            ClearGhostSkipReasonLogState();
 
             ui?.Cleanup();
         }
@@ -12558,6 +12559,17 @@ namespace Parsek
                     hasRenderableData,
                     playbackEnabled,
                     externalVesselSuppressed));
+        }
+
+        private void ClearGhostSkipReasonLogState()
+        {
+            activeGhostSkipReasonLogIdentities.Clear();
+            ParsekLog.ClearVerboseOnChangeIdentitiesWithPrefix("Flight", "ghost-skip|");
+        }
+
+        internal void ClearGhostSkipReasonLogStateForTesting()
+        {
+            ClearGhostSkipReasonLogState();
         }
 
         internal static void LogGhostSkipReasonChangeForTesting(

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -57,6 +57,9 @@ suppression, renderer force-enable, and watched-ghost map-focus restore blockers
 Review follow-up: map-focus restore logging now uses one stable on-change
 identity with the watched recording/pid/reason in the state key, avoiding
 per-recording cache growth while preserving reason-change visibility.
+Review follow-up: Flight scene teardown now clears ghost-skip reason state and
+the matching `Flight|ghost-skip|` `VerboseOnChange` identities, with coverage
+showing per-recording skip reasons re-emit after scene cleanup.
 Remaining observability audit items stay open.
 
 Phase 3 persistence/rewind observability is closed on

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -57,9 +57,10 @@ suppression, renderer force-enable, and watched-ghost map-focus restore blockers
 Review follow-up: map-focus restore logging now uses one stable on-change
 identity with the watched recording/pid/reason in the state key, avoiding
 per-recording cache growth while preserving reason-change visibility.
-Review follow-up: Flight scene teardown now clears ghost-skip reason state and
-the matching `Flight|ghost-skip|` `VerboseOnChange` identities, with coverage
-showing per-recording skip reasons re-emit after scene cleanup.
+Review follow-up: Flight scene teardown and `DestroyAllTimelineGhosts` now clear
+ghost-skip reason state and the matching `Flight|ghost-skip|` `VerboseOnChange`
+identities, with coverage showing per-recording skip reasons re-emit after
+scene cleanup and rewind/timeline destruction.
 Remaining observability audit items stay open.
 
 Phase 3 persistence/rewind observability is closed on


### PR DESCRIPTION
Summary:
- Clears ParsekFlight ghost-skip reason state during scene teardown.
- Clears the matching Flight ghost-skip VerboseOnChange identities through the prefix-clear API.
- Adds unit coverage showing two recording ids re-emit after the scene-unload clear.
- Updates docs/dev/todo-and-known-bugs.md for the closed follow-up.

Tests:
- dotnet test --filter FullyQualifiedName~ClearGhostSkipReasonLogStateForTesting_AllowsPerRecordingSkipReasonsToReEmit (1 passed)
- dotnet test --filter FullyQualifiedName!~SyntheticRecordingTests.InjectAllRecordings (9009 passed)
- Full unfiltered dotnet test is blocked locally by locked KSP.log / deployed Parsek.dll from the local KSP process; only SyntheticRecordingTests.InjectAllRecordings is affected.