### PR TITLE
Fix KSC relative-frame ghost playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- KSC ghost playback now honors v6 RELATIVE track sections, keeping rendezvous/docking ghosts attached to their anchor instead of drawing them underground.
+
 - Re-Fly slot precondition log no longer spams `KSP.log` with thousands of identical `slot-ok` lines per session; the on-change gate now uses a per-call-site decision cache that reliably suppresses repeats from the OnGUI draw loop.
 
 - `#612` Boring-tail trim now actually fires for stable on-rails orbits. The orbital-shape match used exact float equality so rails/pack-unpack jitter blocked every real recording; the comparison now uses tolerances, angular fields (LAN, argument of periapsis, inclination) use a shortest-angle delta so a tail that crosses the 0/360 boundary still matches, and each `TrimBoringTail` skip reports which guard rejected.

--- a/Source/Parsek.Tests/KscGhostPlaybackTests.cs
+++ b/Source/Parsek.Tests/KscGhostPlaybackTests.cs
@@ -101,6 +101,395 @@ namespace Parsek.Tests
             return rec;
         }
 
+        static Recording MakeKscRelativeRecording()
+        {
+            var before = new TrajectoryPoint
+            {
+                ut = 100,
+                latitude = 10,
+                longitude = 20,
+                altitude = 30,
+                bodyName = "Kerbin",
+                rotation = new Quaternion(0, 0, 0, 1),
+                velocity = Vector3.zero
+            };
+            var after = new TrajectoryPoint
+            {
+                ut = 110,
+                latitude = 30,
+                longitude = 40,
+                altitude = 50,
+                bodyName = "Kerbin",
+                rotation = new Quaternion(0, 0, 0, 1),
+                velocity = Vector3.zero
+            };
+            var rec = new Recording
+            {
+                VesselName = "RelativeKsc",
+                RecordingFormatVersion = RecordingStore.RelativeLocalFrameFormatVersion
+            };
+            rec.Points.Add(before);
+            rec.Points.Add(after);
+            rec.TrackSections.Add(new TrackSection
+            {
+                referenceFrame = ReferenceFrame.Relative,
+                startUT = 100,
+                endUT = 110,
+                anchorVesselId = 42u,
+                frames = new List<TrajectoryPoint> { before, after }
+            });
+            return rec;
+        }
+
+        static Recording MakeKscAbsoluteSectionRecording()
+        {
+            var before = new TrajectoryPoint
+            {
+                ut = 100,
+                latitude = 1,
+                longitude = 2,
+                altitude = 3,
+                bodyName = "Kerbin",
+                rotation = new Quaternion(0, 0, 0, 1),
+                velocity = Vector3.zero
+            };
+            var after = new TrajectoryPoint
+            {
+                ut = 110,
+                latitude = 11,
+                longitude = 12,
+                altitude = 13,
+                bodyName = "Kerbin",
+                rotation = new Quaternion(0, 0, 0, 1),
+                velocity = Vector3.zero
+            };
+            var rec = new Recording
+            {
+                VesselName = "AbsoluteKsc",
+                RecordingFormatVersion = RecordingStore.RelativeLocalFrameFormatVersion
+            };
+            rec.Points.Add(before);
+            rec.Points.Add(after);
+            rec.TrackSections.Add(new TrackSection
+            {
+                referenceFrame = ReferenceFrame.Absolute,
+                startUT = 100,
+                endUT = 110,
+                frames = new List<TrajectoryPoint> { before, after }
+            });
+            return rec;
+        }
+
+        static Recording MakeKscOrbitalCheckpointSectionRecording()
+        {
+            var before = new TrajectoryPoint
+            {
+                ut = 100,
+                latitude = 1,
+                longitude = 2,
+                altitude = 3,
+                bodyName = "Kerbin",
+                rotation = new Quaternion(0, 0, 0, 1),
+                velocity = Vector3.zero
+            };
+            var after = new TrajectoryPoint
+            {
+                ut = 110,
+                latitude = 11,
+                longitude = 12,
+                altitude = 13,
+                bodyName = "Kerbin",
+                rotation = new Quaternion(0, 0, 0, 1),
+                velocity = Vector3.zero
+            };
+            var rec = new Recording
+            {
+                VesselName = "CheckpointKsc",
+                RecordingFormatVersion = RecordingStore.RelativeLocalFrameFormatVersion
+            };
+            rec.Points.Add(before);
+            rec.Points.Add(after);
+            rec.TrackSections.Add(new TrackSection
+            {
+                referenceFrame = ReferenceFrame.OrbitalCheckpoint,
+                startUT = 100,
+                endUT = 110,
+                frames = new List<TrajectoryPoint> { before, after }
+            });
+            return rec;
+        }
+
+        static ParsekKSC.KscSurfaceLookup SurfaceLookupFromLatLonAlt(Action onCall = null)
+        {
+            return (string bodyName, double lat, double lon, double alt,
+                out Vector3d worldPos, out Quaternion bodyRot) =>
+            {
+                onCall?.Invoke();
+                bodyRot = Quaternion.identity;
+                if (bodyName != "Kerbin")
+                {
+                    worldPos = Vector3d.zero;
+                    return false;
+                }
+
+                worldPos = new Vector3d(lat * 100.0, lon * 100.0, alt);
+                return true;
+            };
+        }
+
+        static ParsekKSC.KscAnchorLookup AnchorLookup(uint expectedPid, Vector3d anchorPos)
+        {
+            return (uint pid, out ParsekKSC.KscAnchorFrame anchor) =>
+            {
+                if (pid != expectedPid)
+                {
+                    anchor = default(ParsekKSC.KscAnchorFrame);
+                    return false;
+                }
+
+                anchor = new ParsekKSC.KscAnchorFrame(anchorPos, Quaternion.identity);
+                return true;
+            };
+        }
+
+        static bool MissingAnchorLookup(uint pid, out ParsekKSC.KscAnchorFrame anchor)
+        {
+            anchor = default(ParsekKSC.KscAnchorFrame);
+            return false;
+        }
+
+        #endregion
+
+        #region KSC reference-frame dispatch
+
+        [Fact]
+        public void TryInterpolateKscPlaybackPose_RelativeSection_UsesAnchorLocalOffset()
+        {
+            var rec = MakeKscRelativeRecording();
+            int cachedIndex = 0;
+            int cachedFrameSourceKey = ParsekKSC.KscFlatPointFrameSourceKey;
+            bool surfaceCalled = false;
+
+            bool resolved = ParsekKSC.TryInterpolateKscPlaybackPose(
+                rec,
+                ref cachedIndex,
+                ref cachedFrameSourceKey,
+                105,
+                SurfaceLookupFromLatLonAlt(() => surfaceCalled = true),
+                AnchorLookup(42u, new Vector3d(1000, 2000, 3000)),
+                out ParsekKSC.KscPoseResolution pose);
+
+            Assert.True(resolved);
+            Assert.False(surfaceCalled);
+            Assert.Equal(1, cachedFrameSourceKey);
+            Assert.Equal("relative", pose.Branch);
+            Assert.Equal(42u, pose.AnchorPid);
+            Assert.Equal(1020.0, pose.WorldPos.x, 6);
+            Assert.Equal(2030.0, pose.WorldPos.y, 6);
+            Assert.Equal(3040.0, pose.WorldPos.z, 6);
+            Assert.Contains(logLines, line =>
+                line.Contains("[KSCGhost]") &&
+                line.Contains("RELATIVE KSC playback resolved") &&
+                line.Contains("anchorPid=42"));
+        }
+
+        [Fact]
+        public void TryInterpolateKscPlaybackPose_RelativeSection_UnresolvedAnchorSkips()
+        {
+            var rec = MakeKscRelativeRecording();
+            int cachedIndex = 0;
+            int cachedFrameSourceKey = ParsekKSC.KscFlatPointFrameSourceKey;
+
+            bool resolved = ParsekKSC.TryInterpolateKscPlaybackPose(
+                rec,
+                ref cachedIndex,
+                ref cachedFrameSourceKey,
+                105,
+                SurfaceLookupFromLatLonAlt(),
+                MissingAnchorLookup,
+                out ParsekKSC.KscPoseResolution pose);
+
+            Assert.False(resolved);
+            Assert.Equal("relative", pose.Branch);
+            Assert.Equal("relative-anchor-unresolved", pose.FailureReason);
+            Assert.Equal(42u, pose.AnchorPid);
+            Assert.Contains(logLines, line =>
+                line.Contains("[KSCGhost]") &&
+                line.Contains("RELATIVE KSC playback skipped") &&
+                line.Contains("anchorPid=42"));
+        }
+
+        [Fact]
+        public void ShouldHideKscRelativeAnchorUnresolvedGhost_HidesOnlyBeforeFirstPose()
+        {
+            Assert.True(ParsekKSC.ShouldHideKscRelativeAnchorUnresolvedGhost(null));
+
+            var state = new GhostPlaybackState
+            {
+                deferVisibilityUntilPlaybackSync = true
+            };
+            Assert.True(ParsekKSC.ShouldHideKscRelativeAnchorUnresolvedGhost(state));
+
+            state.deferVisibilityUntilPlaybackSync = false;
+            Assert.False(ParsekKSC.ShouldHideKscRelativeAnchorUnresolvedGhost(state));
+        }
+
+        [Fact]
+        public void TryInterpolateKscPlaybackPose_AbsoluteSection_UsesSurfaceLookup()
+        {
+            var rec = MakeKscAbsoluteSectionRecording();
+            int cachedIndex = 0;
+            int cachedFrameSourceKey = ParsekKSC.KscFlatPointFrameSourceKey;
+            int surfaceCalls = 0;
+
+            bool resolved = ParsekKSC.TryInterpolateKscPlaybackPose(
+                rec,
+                ref cachedIndex,
+                ref cachedFrameSourceKey,
+                105,
+                SurfaceLookupFromLatLonAlt(() => surfaceCalls++),
+                AnchorLookup(42u, new Vector3d(1000, 2000, 3000)),
+                out ParsekKSC.KscPoseResolution pose);
+
+            Assert.True(resolved);
+            Assert.Equal(2, surfaceCalls);
+            Assert.Equal(1, cachedFrameSourceKey);
+            Assert.Equal("absolute", pose.Branch);
+            Assert.Equal(600.0, pose.WorldPos.x, 6);
+            Assert.Equal(700.0, pose.WorldPos.y, 6);
+            Assert.Equal(8.0, pose.WorldPos.z, 6);
+            Assert.Contains(logLines, line =>
+                line.Contains("[KSCGhost]") &&
+                line.Contains("KSC SURFACE playback resolved"));
+        }
+
+        [Fact]
+        public void ShouldTriggerKscExplosionAtCurrentPose_UsesFrozenPoseAfterFirstPosition()
+        {
+            Assert.False(ParsekKSC.ShouldTriggerKscExplosionAtCurrentPoseForTesting(
+                positioned: false,
+                hasValidPose: false));
+            Assert.True(ParsekKSC.ShouldTriggerKscExplosionAtCurrentPoseForTesting(
+                positioned: false,
+                hasValidPose: true));
+            Assert.True(ParsekKSC.ShouldTriggerKscExplosionAtCurrentPoseForTesting(
+                positioned: true,
+                hasValidPose: false));
+        }
+
+        [Fact]
+        public void TryInterpolateKscPlaybackPose_OrbitalCheckpointFrames_UseSurfaceLookup()
+        {
+            var rec = MakeKscOrbitalCheckpointSectionRecording();
+            int cachedIndex = 0;
+            int cachedFrameSourceKey = ParsekKSC.KscFlatPointFrameSourceKey;
+            int surfaceCalls = 0;
+            bool anchorCalled = false;
+            ParsekKSC.KscAnchorLookup anchorLookup = (uint pid, out ParsekKSC.KscAnchorFrame anchor) =>
+            {
+                anchorCalled = true;
+                anchor = default(ParsekKSC.KscAnchorFrame);
+                return false;
+            };
+
+            bool resolved = ParsekKSC.TryInterpolateKscPlaybackPose(
+                rec,
+                ref cachedIndex,
+                ref cachedFrameSourceKey,
+                105,
+                SurfaceLookupFromLatLonAlt(() => surfaceCalls++),
+                anchorLookup,
+                out ParsekKSC.KscPoseResolution pose);
+
+            Assert.True(resolved);
+            Assert.Equal(2, surfaceCalls);
+            Assert.Equal(1, cachedFrameSourceKey);
+            Assert.False(anchorCalled);
+            Assert.Equal("orbital-checkpoint", pose.Branch);
+            Assert.Equal(600.0, pose.WorldPos.x, 6);
+            Assert.Equal(700.0, pose.WorldPos.y, 6);
+            Assert.Equal(8.0, pose.WorldPos.z, 6);
+            Assert.Contains(logLines, line =>
+                line.Contains("[KSCGhost]") &&
+                line.Contains("KSC SURFACE playback resolved") &&
+                line.Contains("branch=orbital-checkpoint"));
+        }
+
+        [Fact]
+        public void TryInterpolateKscPlaybackPose_NoSection_UsesAbsoluteSurfaceLookup()
+        {
+            var rec = MakeKerbinRecording();
+            int cachedIndex = 0;
+            int cachedFrameSourceKey = ParsekKSC.KscFlatPointFrameSourceKey;
+            int surfaceCalls = 0;
+            bool anchorCalled = false;
+            ParsekKSC.KscAnchorLookup anchorLookup = (uint pid, out ParsekKSC.KscAnchorFrame anchor) =>
+            {
+                anchorCalled = true;
+                anchor = default(ParsekKSC.KscAnchorFrame);
+                return false;
+            };
+
+            bool resolved = ParsekKSC.TryInterpolateKscPlaybackPose(
+                rec,
+                ref cachedIndex,
+                ref cachedFrameSourceKey,
+                150,
+                SurfaceLookupFromLatLonAlt(() => surfaceCalls++),
+                anchorLookup,
+                out ParsekKSC.KscPoseResolution pose);
+
+            Assert.True(resolved);
+            Assert.Equal(2, surfaceCalls);
+            Assert.Equal(ParsekKSC.KscFlatPointFrameSourceKey, cachedFrameSourceKey);
+            Assert.False(anchorCalled);
+            Assert.Equal("no-section", pose.Branch);
+            Assert.Equal(-9.72, pose.WorldPos.x, 6);
+            Assert.Equal(-7455.75, pose.WorldPos.y, 6);
+            Assert.Equal(2535.0, pose.WorldPos.z, 6);
+            Assert.Contains(logLines, line =>
+                line.Contains("[KSCGhost]") &&
+                line.Contains("KSC SURFACE playback resolved") &&
+                line.Contains("branch=no-section"));
+        }
+
+        [Fact]
+        public void TryInterpolateKscPlaybackPose_ResetsCacheWhenFrameSourceChanges()
+        {
+            var relative = MakeKscRelativeRecording();
+            int cachedIndex = 99;
+            int cachedFrameSourceKey = ParsekKSC.KscFlatPointFrameSourceKey;
+
+            bool relativeResolved = ParsekKSC.TryInterpolateKscPlaybackPose(
+                relative,
+                ref cachedIndex,
+                ref cachedFrameSourceKey,
+                105,
+                SurfaceLookupFromLatLonAlt(),
+                AnchorLookup(42u, new Vector3d(1000, 2000, 3000)),
+                out ParsekKSC.KscPoseResolution relativePose);
+
+            Assert.True(relativeResolved);
+            Assert.Equal("relative", relativePose.Branch);
+            Assert.Equal(1, cachedFrameSourceKey);
+            Assert.InRange(cachedIndex, 0, relative.TrackSections[0].frames.Count - 1);
+
+            var noSection = MakeKerbinRecording();
+            bool absoluteResolved = ParsekKSC.TryInterpolateKscPlaybackPose(
+                noSection,
+                ref cachedIndex,
+                ref cachedFrameSourceKey,
+                150,
+                SurfaceLookupFromLatLonAlt(),
+                MissingAnchorLookup,
+                out ParsekKSC.KscPoseResolution absolutePose);
+
+            Assert.True(absoluteResolved);
+            Assert.Equal("no-section", absolutePose.Branch);
+            Assert.Equal(ParsekKSC.KscFlatPointFrameSourceKey, cachedFrameSourceKey);
+            Assert.InRange(cachedIndex, 0, noSection.Points.Count - 1);
+        }
+
         #endregion
 
         #region ShouldShowInKSC

--- a/Source/Parsek.Tests/TrajectoryMathTests.cs
+++ b/Source/Parsek.Tests/TrajectoryMathTests.cs
@@ -1,4 +1,5 @@
 using Xunit;
+using UnityEngine;
 
 namespace Parsek.Tests
 {
@@ -8,6 +9,33 @@ namespace Parsek.Tests
         // matching (LAN / argP / inclination); promoted to internal in the #612
         // wraparound follow-up so the math stays centralized.
         private const double Eps = 1e-12;
+
+        [Fact]
+        public void PureSlerp_ClampsTLikeUnitySlerp()
+        {
+            var from = new Quaternion(0f, 0f, 0f, 1f);
+            var to = new Quaternion(0f, 0.7071068f, 0f, 0.7071068f);
+
+            AssertQuaternionClose(from, TrajectoryMath.PureSlerp(from, to, -0.5f), 1e-6f);
+            AssertQuaternionClose(to, TrajectoryMath.PureSlerp(from, to, 1.5f), 1e-6f);
+        }
+
+        [Fact]
+        public void PureSlerp_UsesShortestPathForSignEquivalentEndpoint()
+        {
+            var from = new Quaternion(0f, 0f, 0f, 1f);
+            var to = new Quaternion(0f, 0f, 0f, -1f);
+
+            AssertQuaternionClose(from, TrajectoryMath.PureSlerp(from, to, 0.5f), 1e-6f);
+        }
+
+        private static void AssertQuaternionClose(Quaternion expected, Quaternion actual, float tolerance)
+        {
+            Assert.InRange(System.Math.Abs(expected.x - actual.x), 0, tolerance);
+            Assert.InRange(System.Math.Abs(expected.y - actual.y), 0, tolerance);
+            Assert.InRange(System.Math.Abs(expected.z - actual.z), 0, tolerance);
+            Assert.InRange(System.Math.Abs(expected.w - actual.w), 0, tolerance);
+        }
 
         [Fact]
         public void AngularDeltaDegrees_SimpleDelta_ReturnsAbsoluteDifference()

--- a/Source/Parsek/GhostPlaybackState.cs
+++ b/Source/Parsek/GhostPlaybackState.cs
@@ -16,6 +16,7 @@ namespace Parsek
         public GameObject ghost;
         public List<Material> materials;
         public int playbackIndex;
+        public int kscPlaybackFrameSourceKey;
         public int partEventIndex;
         public long loopCycleIndex = -1;
         public Dictionary<uint, List<uint>> partTree;

--- a/Source/Parsek/InGameTests/ExtendedRuntimeTests.cs
+++ b/Source/Parsek/InGameTests/ExtendedRuntimeTests.cs
@@ -766,6 +766,116 @@ namespace Parsek.InGameTests
             ParsekLog.Verbose("TestRunner", "ParsekKSC instance found");
         }
 
+        [InGameTest(Category = "SceneAndPatch", Scene = GameScenes.SPACECENTER,
+            Description = "KSC RELATIVE playback resolves against a live anchor vessel")]
+        public void ParsekKscRelativePlaybackUsesLiveAnchor()
+        {
+            var ksc = Object.FindObjectOfType<ParsekKSC>();
+            if (ksc == null)
+                InGameAssert.Skip("No ParsekKSC instance");
+
+            Vessel anchor = FindLoadedAnchorForKscRelativePlaybackTest();
+            if (anchor == null)
+                InGameAssert.Skip("No loaded non-ghost vessel available as KSC RELATIVE anchor");
+
+            var before = new TrajectoryPoint
+            {
+                ut = 100,
+                latitude = 10,
+                longitude = 20,
+                altitude = 30,
+                bodyName = "Kerbin",
+                rotation = Quaternion.identity,
+                velocity = Vector3.zero
+            };
+            var after = new TrajectoryPoint
+            {
+                ut = 110,
+                latitude = 20,
+                longitude = 30,
+                altitude = 40,
+                bodyName = "Kerbin",
+                rotation = Quaternion.identity,
+                velocity = Vector3.zero
+            };
+            var rec = new Recording
+            {
+                RecordingId = "runtime-ksc-relative-anchor",
+                VesselName = "Runtime KSC Relative Probe",
+                RecordingFormatVersion = RecordingStore.RelativeLocalFrameFormatVersion
+            };
+            rec.Points.Add(before);
+            rec.Points.Add(after);
+            rec.TrackSections.Add(new TrackSection
+            {
+                referenceFrame = ReferenceFrame.Relative,
+                startUT = 100,
+                endUT = 110,
+                anchorVesselId = anchor.persistentId,
+                frames = new List<TrajectoryPoint> { before, after }
+            });
+
+            GameObject probe = new GameObject("Parsek_KSC_RelativeRuntimeProbe");
+            var state = new GhostPlaybackState
+            {
+                ghost = probe,
+                deferVisibilityUntilPlaybackSync = true
+            };
+            int cachedIndex = 0;
+            int cachedFrameSourceKey = ParsekKSC.KscFlatPointFrameSourceKey;
+
+            try
+            {
+                bool positioned = ksc.InterpolateAndPositionKsc(
+                    state,
+                    rec,
+                    ref cachedIndex,
+                    ref cachedFrameSourceKey,
+                    105);
+
+                InGameAssert.IsTrue(positioned, "KSC relative runtime probe should resolve a live anchor");
+                InGameAssert.IsFalse(state.deferVisibilityUntilPlaybackSync,
+                    "Successful KSC relative positioning should clear deferred visibility");
+
+                Vector3d expected = TrajectoryMath.ResolveRelativePlaybackPosition(
+                    anchor.GetWorldPos3D(),
+                    anchor.transform.rotation,
+                    15,
+                    25,
+                    35,
+                    rec.RecordingFormatVersion);
+                Vector3d actual = probe.transform.position;
+                double error = (actual - expected).magnitude;
+                InGameAssert.IsTrue(error < 0.25,
+                    $"KSC relative runtime probe should land at anchor-local offset; error={error:F3}m");
+                ParsekLog.Verbose("TestRunner",
+                    $"KSC relative runtime probe resolved anchorPid={anchor.persistentId} error={error:F3}m");
+            }
+            finally
+            {
+                if (probe != null)
+                    Object.Destroy(probe);
+            }
+        }
+
+        private static Vessel FindLoadedAnchorForKscRelativePlaybackTest()
+        {
+            if (FlightGlobals.Vessels == null)
+                return null;
+
+            for (int i = 0; i < FlightGlobals.Vessels.Count; i++)
+            {
+                Vessel vessel = FlightGlobals.Vessels[i];
+                if (vessel == null || !vessel.loaded || vessel.transform == null)
+                    continue;
+                if (GhostMapPresence.IsGhostMapVessel(vessel.persistentId))
+                    continue;
+                return vessel;
+            }
+
+            return null;
+        }
+
         [InGameTest(Category = "SceneAndPatch", Scene = GameScenes.TRACKSTATION,
             Description = "ParsekTrackingStation MonoBehaviour exists in Tracking Station")]
         public void ParsekTrackingStationExists()

--- a/Source/Parsek/ParsekKSC.cs
+++ b/Source/Parsek/ParsekKSC.cs
@@ -36,6 +36,7 @@ namespace Parsek
         // One-time log tracking (avoids repeating the same log every frame)
         private HashSet<int> loggedGhostSpawn = new HashSet<int>();
         private HashSet<int> loggedReshow = new HashSet<int>();
+        private HashSet<long> loggedKscRelativeAnchorNotFound = new HashSet<long>();
 
         // #443: Non-spamming cadence-adjustment log — one INFO per
         // (recording index, userPeriod, effectiveCadence, duration) tuple.
@@ -79,6 +80,75 @@ namespace Parsek
             internal double PlaybackEndUT { get; }
             internal string RecordingId { get; }
         }
+
+        internal struct KscAnchorFrame
+        {
+            internal KscAnchorFrame(Vector3d worldPos, Quaternion worldRot)
+            {
+                WorldPos = worldPos;
+                WorldRot = worldRot;
+            }
+
+            internal Vector3d WorldPos;
+            internal Quaternion WorldRot;
+        }
+
+        internal struct KscPoseResolution
+        {
+            internal bool Resolved;
+            internal Vector3d WorldPos;
+            internal Quaternion WorldRot;
+            internal string Branch;
+            internal string FailureReason;
+            internal uint AnchorPid;
+
+            internal static KscPoseResolution Success(
+                Vector3d worldPos,
+                Quaternion worldRot,
+                string branch,
+                uint anchorPid)
+            {
+                return new KscPoseResolution
+                {
+                    Resolved = true,
+                    WorldPos = worldPos,
+                    WorldRot = worldRot,
+                    Branch = branch,
+                    FailureReason = null,
+                    AnchorPid = anchorPid
+                };
+            }
+
+            internal static KscPoseResolution Failure(
+                string branch,
+                string failureReason,
+                uint anchorPid)
+            {
+                return new KscPoseResolution
+                {
+                    Resolved = false,
+                    WorldPos = Vector3d.zero,
+                    WorldRot = Quaternion.identity,
+                    Branch = branch,
+                    FailureReason = failureReason,
+                    AnchorPid = anchorPid
+                };
+            }
+        }
+
+        internal delegate bool KscSurfaceLookup(
+            string bodyName,
+            double latitude,
+            double longitude,
+            double altitude,
+            out Vector3d worldPos,
+            out Quaternion bodyWorldRot);
+
+        internal delegate bool KscAnchorLookup(
+            uint anchorVesselId,
+            out KscAnchorFrame anchorFrame);
+
+        internal const int KscFlatPointFrameSourceKey = 0;
 
         private static int CompareAutoLoopQueueCandidates(AutoLoopQueueCandidate a, AutoLoopQueueCandidate b)
         {
@@ -563,8 +633,9 @@ namespace Parsek
                 if (ghostActive && rec.LoopPlayback && state.loopCycleIndex != cycleIndex)
                 {
                     long oldCycle = state.loopCycleIndex;
-                    PositionGhostAtLoopEndpoint(recIdx, rec, state);
-                    if (GhostPlaybackLogic.ShouldTriggerExplosionAtPlaybackUT(
+                    bool endpointPositioned = PositionGhostAtLoopEndpoint(recIdx, rec, state);
+                    if (ShouldTriggerKscExplosionAtCurrentPose(state, endpointPositioned, recIdx, rec, "cycle-change")
+                        && GhostPlaybackLogic.ShouldTriggerExplosionAtPlaybackUT(
                             rec, GhostPlaybackEngine.ResolveLoopPlaybackEndpointUT(rec)))
                     {
                         TriggerExplosionIfDestroyed(state, rec, recIdx);
@@ -599,32 +670,40 @@ namespace Parsek
                             $"Ghost #{recIdx} \"{rec.VesselName}\" re-shown after warp-down");
                 }
 
-                InterpolateAndPositionKsc(
-                    state.ghost, rec.Points,
-                    ref state.playbackIndex, targetUT);
+                bool positioned = InterpolateAndPositionKsc(
+                    state, rec,
+                    ref state.playbackIndex,
+                    ref state.kscPlaybackFrameSourceKey,
+                    targetUT);
 
                 // Distance culling: skip expensive part events for ghosts too far from camera
-                if (ShouldApplyRuntimeGhostEvents(pauseMenuOpen, IsGhostInCullRange(state.ghost)))
+                bool canRunRuntimeEvents = positioned && ShouldApplyRuntimeGhostEvents(pauseMenuOpen, IsGhostInCullRange(state.ghost));
+                if (canRunRuntimeEvents)
                 {
                     GhostPlaybackLogic.ApplyPartEvents(recIdx, rec, targetUT, state);
                     GhostPlaybackLogic.ApplyFlagEvents(state, rec, targetUT);
                 }
-                if (suppressVisualFx)
-                    GhostPlaybackLogic.StopAllRcsEmissions(state);
-                else
-                    GhostPlaybackLogic.RestoreAllRcsEmissions(state);
+                if (positioned)
+                {
+                    if (suppressVisualFx)
+                        GhostPlaybackLogic.StopAllRcsEmissions(state);
+                    else
+                        GhostPlaybackLogic.RestoreAllRcsEmissions(state);
+                }
 
                 bool shouldTriggerExplosion = GhostPlaybackLogic.ShouldTriggerExplosionAtPlaybackUT(rec, targetUT);
 
-                if (!state.explosionFired && shouldTriggerExplosion)
+                if (ShouldTriggerKscExplosionAtCurrentPose(state, positioned, recIdx, rec, "single-update")
+                    && !state.explosionFired && shouldTriggerExplosion)
                     TriggerExplosionIfDestroyed(state, rec, recIdx);
             }
             else if (ghostActive)
             {
                 if (inPauseWindow)
                 {
-                    PositionGhostAtLoopEndpoint(recIdx, rec, state);
-                    if (!state.explosionFired
+                    bool positioned = PositionGhostAtLoopEndpoint(recIdx, rec, state);
+                    if (ShouldTriggerKscExplosionAtCurrentPose(state, positioned, recIdx, rec, "pause-window")
+                        && !state.explosionFired
                         && GhostPlaybackLogic.ShouldTriggerExplosionAtPlaybackUT(
                             rec, GhostPlaybackEngine.ResolveLoopPlaybackEndpointUT(rec)))
                     {
@@ -640,7 +719,9 @@ namespace Parsek
                 }
                 else
                 {
-                    TriggerExplosionIfDestroyed(state, rec, recIdx);
+                    bool endpointPositioned = PositionGhostAtLoopEndpoint(recIdx, rec, state);
+                    if (ShouldTriggerKscExplosionAtCurrentPose(state, endpointPositioned, recIdx, rec, "timeline-complete"))
+                        TriggerExplosionIfDestroyed(state, rec, recIdx);
                     // Spawn real vessel when ghost timeline completes (bug #99)
                     TrySpawnAtRecordingEnd(recIdx, rec);
                     ParsekLog.Verbose("KSCGhost",
@@ -766,22 +847,29 @@ namespace Parsek
             {
                 double loopUT = primaryLoopUT;
 
-                InterpolateAndPositionKsc(primaryState.ghost, rec.Points,
-                    ref primaryState.playbackIndex, loopUT);
+                bool primaryPositioned = InterpolateAndPositionKsc(primaryState, rec,
+                    ref primaryState.playbackIndex,
+                    ref primaryState.kscPlaybackFrameSourceKey,
+                    loopUT);
 
-                if (ShouldApplyRuntimeGhostEvents(pauseMenuOpen, IsGhostInCullRange(primaryState.ghost)))
+                bool canRunPrimaryEvents = primaryPositioned && ShouldApplyRuntimeGhostEvents(pauseMenuOpen, IsGhostInCullRange(primaryState.ghost));
+                if (canRunPrimaryEvents)
                 {
                     GhostPlaybackLogic.ApplyPartEvents(recIdx, rec, loopUT, primaryState);
                     GhostPlaybackLogic.ApplyFlagEvents(primaryState, rec, loopUT);
                 }
-                if (suppressVisualFx)
-                    GhostPlaybackLogic.StopAllRcsEmissions(primaryState);
-                else
-                    GhostPlaybackLogic.RestoreAllRcsEmissions(primaryState);
+                if (primaryPositioned)
+                {
+                    if (suppressVisualFx)
+                        GhostPlaybackLogic.StopAllRcsEmissions(primaryState);
+                    else
+                        GhostPlaybackLogic.RestoreAllRcsEmissions(primaryState);
+                }
 
                 bool shouldTriggerExplosion = GhostPlaybackLogic.ShouldTriggerExplosionAtPlaybackUT(rec, loopUT);
 
-                if (!primaryState.explosionFired && shouldTriggerExplosion)
+                if (ShouldTriggerKscExplosionAtCurrentPose(primaryState, primaryPositioned, recIdx, rec, "overlap-primary")
+                    && !primaryState.explosionFired && shouldTriggerExplosion)
                     TriggerExplosionIfDestroyed(primaryState, rec, recIdx);
             }
 
@@ -801,8 +889,9 @@ namespace Parsek
                 if (phase > duration)
                 {
                     // Cycle expired — position at end, explode, destroy
-                    PositionGhostAtLoopEndpoint(recIdx, rec, ovState);
-                    if (GhostPlaybackLogic.ShouldTriggerExplosionAtPlaybackUT(
+                    bool endpointPositioned = PositionGhostAtLoopEndpoint(recIdx, rec, ovState);
+                    if (ShouldTriggerKscExplosionAtCurrentPose(ovState, endpointPositioned, recIdx, rec, "overlap-expired")
+                        && GhostPlaybackLogic.ShouldTriggerExplosionAtPlaybackUT(
                             rec, GhostPlaybackEngine.ResolveLoopPlaybackEndpointUT(rec)))
                     {
                         TriggerExplosionIfDestroyed(ovState, rec, recIdx);
@@ -817,20 +906,27 @@ namespace Parsek
                 if (phase < 0) phase = 0;
                 double loopUT = playbackStartUT + phase;
 
-                InterpolateAndPositionKsc(ovState.ghost, rec.Points,
-                    ref ovState.playbackIndex, loopUT);
+                bool positioned = InterpolateAndPositionKsc(ovState, rec,
+                    ref ovState.playbackIndex,
+                    ref ovState.kscPlaybackFrameSourceKey,
+                    loopUT);
 
-                if (ShouldApplyRuntimeGhostEvents(pauseMenuOpen, IsGhostInCullRange(ovState.ghost)))
+                bool canRunOverlapEvents = positioned && ShouldApplyRuntimeGhostEvents(pauseMenuOpen, IsGhostInCullRange(ovState.ghost));
+                if (canRunOverlapEvents)
                 {
                     GhostPlaybackLogic.ApplyPartEvents(recIdx, rec, loopUT, ovState);
                     GhostPlaybackLogic.ApplyFlagEvents(ovState, rec, loopUT);
                 }
-                if (suppressVisualFx)
-                    GhostPlaybackLogic.StopAllRcsEmissions(ovState);
-                else
-                    GhostPlaybackLogic.RestoreAllRcsEmissions(ovState);
+                if (positioned)
+                {
+                    if (suppressVisualFx)
+                        GhostPlaybackLogic.StopAllRcsEmissions(ovState);
+                    else
+                        GhostPlaybackLogic.RestoreAllRcsEmissions(ovState);
+                }
 
-                if (!ovState.explosionFired
+                if (ShouldTriggerKscExplosionAtCurrentPose(ovState, positioned, recIdx, rec, "overlap-update")
+                    && !ovState.explosionFired
                     && GhostPlaybackLogic.TryGetEarlyDestroyedDebrisExplosionUT(rec, out double earlyExplosionUT)
                     && loopUT >= earlyExplosionUT)
                 {
@@ -839,13 +935,18 @@ namespace Parsek
             }
         }
 
-        void PositionGhostAtLoopEndpoint(int recIdx, Recording rec, GhostPlaybackState state)
+        bool PositionGhostAtLoopEndpoint(int recIdx, Recording rec, GhostPlaybackState state)
         {
             if (state?.ghost == null || rec?.Points == null || rec.Points.Count == 0)
-                return;
+                return false;
 
             double endpointUT = GhostPlaybackEngine.ResolveLoopPlaybackEndpointUT(rec);
-            InterpolateAndPositionKsc(state.ghost, rec.Points, ref state.playbackIndex, endpointUT);
+            return InterpolateAndPositionKsc(
+                state,
+                rec,
+                ref state.playbackIndex,
+                ref state.kscPlaybackFrameSourceKey,
+                endpointUT);
         }
 
         /// <summary>
@@ -923,10 +1024,14 @@ namespace Parsek
                 // cameraPivot intentionally null — RecalculateCameraPivot no-ops
                 // reentryFxInfo intentionally null — RebuildReentryMeshes no-ops
                 playbackIndex = 0,
+                kscPlaybackFrameSourceKey = KscFlatPointFrameSourceKey,
                 partEventIndex = 0,
                 partTree = GhostVisualBuilder.BuildPartSubtreeMap(snapshot),
-                logicalPartIds = GhostVisualBuilder.BuildSnapshotPartIdSet(snapshot)
+                logicalPartIds = GhostVisualBuilder.BuildSnapshotPartIdSet(snapshot),
+                deferVisibilityUntilPlaybackSync = true
             };
+            if (ghost != null)
+                ghost.SetActive(false);
 
             GhostPlaybackLogic.PopulateGhostInfoDictionaries(state, buildResult);
 
@@ -951,97 +1056,504 @@ namespace Parsek
         /// <summary>
         /// Position a ghost by interpolating between trajectory points.
         /// Simplified version — no FloatingOrigin GhostPosEntry registration
-        /// (positions are recomputed from lat/lon/alt each frame, so origin
-        /// shifts are handled automatically).
+        /// (positions are recomputed from the active reference frame each frame,
+        /// so origin shifts are handled automatically).
         /// Stops positioning when the trajectory leaves Kerbin.
         /// </summary>
-        internal void InterpolateAndPositionKsc(
-            GameObject ghost, List<TrajectoryPoint> points,
-            ref int cachedIndex, double targetUT)
+        internal bool InterpolateAndPositionKsc(
+            GhostPlaybackState state, Recording rec,
+            ref int cachedIndex,
+            ref int cachedFrameSourceKey,
+            double targetUT)
         {
-            TrajectoryPoint before, after;
-            float t;
-            bool hasSegment = TrajectoryMath.InterpolatePoints(
-                points, ref cachedIndex, targetUT, out before, out after, out t);
-
-            if (!hasSegment)
+            GameObject ghost = state != null ? state.ghost : null;
+            KscPoseResolution pose;
+            if (!TryInterpolateKscPlaybackPose(
+                    rec,
+                    ref cachedIndex,
+                    ref cachedFrameSourceKey,
+                    targetUT,
+                    TryLookupKscSurfacePose,
+                    TryLookupKscAnchorFrame,
+                    out pose))
             {
-                // Either empty list or before recording start
-                if (points == null || points.Count == 0)
+                if (pose.FailureReason == "relative-anchor-unresolved")
                 {
-                    ghost.SetActive(false);
-                    return;
+                    bool hideUntilFirstPose = ShouldHideKscRelativeAnchorUnresolvedGhost(state);
+                    if (hideUntilFirstPose && ghost != null)
+                        ghost.SetActive(false);
+
+                    long key = ((long)pose.AnchorPid << 32) ^ (uint)(rec?.RecordingId?.GetHashCode() ?? 0);
+                    if (loggedKscRelativeAnchorNotFound.Add(key))
+                    {
+                        ParsekLog.Warn("KSCGhost",
+                            $"RELATIVE KSC playback: anchor vessel pid={pose.AnchorPid} not found; " +
+                            (hideUntilFirstPose
+                                ? "ghost hidden until first valid anchor pose"
+                                : "ghost frozen at last known position"));
+                    }
+                    return false;
                 }
-                PositionGhostAtPoint(ghost, before);
-                return;
+
+                if (ghost != null)
+                    ghost.SetActive(false);
+                ParsekLog.VerboseRateLimited("KSCGhost", "ksc-pose-unresolved",
+                    $"KSC ghost positioning skipped: branch={pose.Branch ?? "unknown"} " +
+                    $"reason={pose.FailureReason ?? "unknown"} targetUT={targetUT:F2}");
+                return false;
             }
 
-            // Degenerate segment (t == 0 from zero-duration segment)
-            if (t == 0f && before.ut == after.ut)
-            {
-                PositionGhostAtPoint(ghost, before);
-                return;
-            }
+            if (ghost == null)
+                return false;
 
-            // Stop positioning when trajectory leaves Kerbin
-            if (before.bodyName != "Kerbin" || after.bodyName != "Kerbin")
-            {
-                ghost.SetActive(false);
-                return;
-            }
-
-            CelestialBody bodyBefore = LookupBody(before.bodyName);
-            CelestialBody bodyAfter = LookupBody(after.bodyName);
-            if (bodyBefore == null || bodyAfter == null)
-            {
-                ParsekLog.VerboseRateLimited("KSCGhost", "interp-no-body",
-                    $"Body not found: {(bodyBefore == null ? before.bodyName : after.bodyName)}");
-                ghost.SetActive(false);
-                return;
-            }
+            ghost.transform.position = pose.WorldPos;
+            ghost.transform.rotation = pose.WorldRot;
+            if (state != null)
+                state.deferVisibilityUntilPlaybackSync = false;
             if (!ghost.activeSelf) ghost.SetActive(true);
+            return true;
+        }
 
-            Vector3d posBefore = bodyBefore.GetWorldSurfacePosition(
-                before.latitude, before.longitude, before.altitude);
-            Vector3d posAfter = bodyAfter.GetWorldSurfacePosition(
-                after.latitude, after.longitude, after.altitude);
+        internal static bool ShouldHideKscRelativeAnchorUnresolvedGhost(GhostPlaybackState state)
+        {
+            return state == null || state.deferVisibilityUntilPlaybackSync;
+        }
 
-            Vector3d interpolatedPos = Vector3d.Lerp(posBefore, posAfter, t);
-            Quaternion interpolatedRot = Quaternion.Slerp(before.rotation, after.rotation, t);
-            interpolatedRot = TrajectoryMath.SanitizeQuaternion(interpolatedRot);
+        internal static bool HasKscValidPose(GhostPlaybackState state)
+        {
+            return state?.ghost != null && !state.deferVisibilityUntilPlaybackSync;
+        }
 
-            if (double.IsNaN(interpolatedPos.x) || double.IsNaN(interpolatedPos.y) ||
-                double.IsNaN(interpolatedPos.z))
+        private static bool ShouldTriggerKscExplosionAtCurrentPose(
+            GhostPlaybackState state,
+            bool positioned,
+            int recIdx,
+            Recording rec,
+            string context)
+        {
+            bool hasValidPose = HasKscValidPose(state);
+            if (!ShouldTriggerKscExplosionAtCurrentPoseForTesting(positioned, hasValidPose))
+                return false;
+
+            if (!positioned)
             {
-                interpolatedPos = posBefore;
+                ParsekLog.VerboseRateLimited("KSCGhost", $"ksc-explosion-frozen-pose-{recIdx}-{context}",
+                    $"KSC explosion using last valid ghost pose: recording={rec?.DebugName ?? "null"} " +
+                    $"context={context}");
             }
+            return true;
+        }
 
-            ghost.transform.position = interpolatedPos;
-            ghost.transform.rotation = bodyBefore.bodyTransform.rotation * interpolatedRot;
+        internal static bool ShouldTriggerKscExplosionAtCurrentPoseForTesting(
+            bool positioned,
+            bool hasValidPose)
+        {
+            return positioned || hasValidPose;
         }
 
         /// <summary>
-        /// Position ghost at a single trajectory point (no interpolation).
+        /// Interpolates the KSC playback pose and dispatches the point payload
+        /// through the originating TrackSection reference frame.
         /// </summary>
-        void PositionGhostAtPoint(GameObject ghost, TrajectoryPoint point)
+        internal static bool TryInterpolateKscPlaybackPose(
+            Recording rec,
+            ref int cachedIndex,
+            ref int cachedFrameSourceKey,
+            double targetUT,
+            KscSurfaceLookup surfaceLookup,
+            KscAnchorLookup anchorLookup,
+            out KscPoseResolution pose)
+        {
+            pose = KscPoseResolution.Failure("none", "recording-null", 0);
+            if (rec == null)
+            {
+                ParsekLog.Verbose("KSCGhost",
+                    $"KSC pose interpolation skipped: recording=null targetUT={targetUT:F2}");
+                return false;
+            }
+
+            int targetSectionIndex = FindKscTrackSectionIndex(rec, targetUT);
+            TrackSection? targetSection = GetKscTrackSection(rec, targetSectionIndex);
+            bool usingSectionFrames;
+            List<TrajectoryPoint> frames = SelectKscInterpolationFrames(
+                rec, targetSection, out usingSectionFrames);
+            if (frames == null || frames.Count == 0)
+            {
+                pose = KscPoseResolution.Failure(
+                    targetSection.HasValue ? targetSection.Value.referenceFrame.ToString() : "no-section",
+                    "no-points",
+                    targetSection.HasValue ? targetSection.Value.anchorVesselId : 0);
+                ParsekLog.Verbose("KSCGhost",
+                    $"KSC pose interpolation skipped: no points recording={rec.DebugName} " +
+                    $"targetUT={targetUT:F2} sections={rec.TrackSections?.Count ?? 0}");
+                return false;
+            }
+
+            int frameSourceKey = usingSectionFrames
+                ? targetSectionIndex + 1
+                : KscFlatPointFrameSourceKey;
+            if (cachedFrameSourceKey != frameSourceKey)
+            {
+                cachedIndex = 0;
+                cachedFrameSourceKey = frameSourceKey;
+            }
+
+            int interpolationIndex = cachedIndex;
+            TrajectoryPoint before, after;
+            float t;
+            bool hasSegment = TrajectoryMath.InterpolatePoints(
+                frames, ref interpolationIndex, targetUT, out before, out after, out t);
+            cachedIndex = interpolationIndex;
+
+            if (!hasSegment)
+            {
+                if (frames.Count == 0)
+                {
+                    pose = KscPoseResolution.Failure("none", "no-points", 0);
+                    return false;
+                }
+
+                TrackSection? pointSection = targetSection ?? FindKscTrackSection(rec, before.ut);
+                return TryResolveKscPointPose(
+                    rec,
+                    before,
+                    pointSection,
+                    surfaceLookup,
+                    anchorLookup,
+                    out pose);
+            }
+
+            if (t == 0f && before.ut == after.ut)
+            {
+                TrackSection? pointSection = targetSection ?? FindKscTrackSection(rec, before.ut);
+                return TryResolveKscPointPose(
+                    rec,
+                    before,
+                    pointSection,
+                    surfaceLookup,
+                    anchorLookup,
+                    out pose);
+            }
+
+            TrackSection? section = targetSection ?? FindKscTrackSection(rec, before.ut);
+            return TryResolveKscSegmentPose(
+                rec,
+                before,
+                after,
+                t,
+                section,
+                surfaceLookup,
+                anchorLookup,
+                out pose);
+        }
+
+        private static List<TrajectoryPoint> SelectKscInterpolationFrames(
+            Recording rec,
+            TrackSection? targetSection,
+            out bool usingSectionFrames)
+        {
+            usingSectionFrames = false;
+            if (targetSection.HasValue
+                && targetSection.Value.frames != null
+                && targetSection.Value.frames.Count > 0)
+            {
+                usingSectionFrames = true;
+                return targetSection.Value.frames;
+            }
+
+            return rec?.Points;
+        }
+
+        private static TrackSection? FindKscTrackSection(Recording rec, double targetUT)
+        {
+            return GetKscTrackSection(rec, FindKscTrackSectionIndex(rec, targetUT));
+        }
+
+        private static TrackSection? GetKscTrackSection(Recording rec, int sectionIdx)
+        {
+            if (rec?.TrackSections == null || sectionIdx < 0 || sectionIdx >= rec.TrackSections.Count)
+                return null;
+
+            return rec.TrackSections[sectionIdx];
+        }
+
+        private static int FindKscTrackSectionIndex(Recording rec, double targetUT)
+        {
+            if (rec?.TrackSections == null || rec.TrackSections.Count == 0)
+                return -1;
+
+            int sectionIdx = TrajectoryMath.FindTrackSectionForUT(rec.TrackSections, targetUT);
+            if (sectionIdx < 0 || sectionIdx >= rec.TrackSections.Count)
+                return -1;
+
+            return sectionIdx;
+        }
+
+        private static bool TryResolveKscPointPose(
+            Recording rec,
+            TrajectoryPoint point,
+            TrackSection? section,
+            KscSurfaceLookup surfaceLookup,
+            KscAnchorLookup anchorLookup,
+            out KscPoseResolution pose)
         {
             if (point.bodyName != "Kerbin")
             {
-                ghost.SetActive(false);
-                return;
+                pose = KscPoseResolution.Failure(
+                    DescribeKscBranch(section),
+                    "non-kerbin",
+                    section.HasValue ? section.Value.anchorVesselId : 0);
+                ParsekLog.VerboseRateLimited("KSCGhost", "ksc-point-non-kerbin",
+                    $"KSC point skipped: body={point.bodyName ?? "null"} ut={point.ut:F2}");
+                return false;
             }
 
-            CelestialBody body = LookupBody(point.bodyName);
-            if (body == null) return;
+            ReferenceFrame frame = section.HasValue
+                ? section.Value.referenceFrame
+                : ReferenceFrame.Absolute;
+            if (frame == ReferenceFrame.Relative)
+            {
+                Quaternion storedRot = TrajectoryMath.SanitizeQuaternion(point.rotation);
+                return TryResolveKscRelativePose(
+                    rec,
+                    point.latitude,
+                    point.longitude,
+                    point.altitude,
+                    storedRot,
+                    section.Value.anchorVesselId,
+                    anchorLookup,
+                    out pose);
+            }
 
-            Vector3d worldPos = body.GetWorldSurfacePosition(
-                point.latitude, point.longitude, point.altitude);
+            Vector3d worldPos;
+            Quaternion bodyWorldRot;
+            if (!surfaceLookup(
+                    point.bodyName,
+                    point.latitude,
+                    point.longitude,
+                    point.altitude,
+                    out worldPos,
+                    out bodyWorldRot))
+            {
+                pose = KscPoseResolution.Failure("absolute", "body-not-found", 0);
+                ParsekLog.VerboseRateLimited("KSCGhost", "interp-no-body",
+                    $"Body not found: {point.bodyName ?? "null"}");
+                return false;
+            }
 
-            Quaternion sanitized = TrajectoryMath.SanitizeQuaternion(point.rotation);
-            ghost.transform.position = worldPos;
-            ghost.transform.rotation = body.bodyTransform.rotation * sanitized;
+            Quaternion worldRot = TrajectoryMath.PureMultiply(
+                bodyWorldRot,
+                TrajectoryMath.SanitizeQuaternion(point.rotation));
+            pose = KscPoseResolution.Success(worldPos, worldRot, DescribeKscBranch(section), 0);
+            ParsekLog.VerboseRateLimited("KSCGhost", "ksc-surface-position",
+                $"KSC SURFACE playback resolved: recording={rec.DebugName} " +
+                $"ut={point.ut:F2} body={point.bodyName} branch={pose.Branch}",
+                2.0);
+            return true;
+        }
 
-            if (!ghost.activeSelf) ghost.SetActive(true);
+        private static bool TryResolveKscSegmentPose(
+            Recording rec,
+            TrajectoryPoint before,
+            TrajectoryPoint after,
+            float t,
+            TrackSection? section,
+            KscSurfaceLookup surfaceLookup,
+            KscAnchorLookup anchorLookup,
+            out KscPoseResolution pose)
+        {
+            if (before.bodyName != "Kerbin" || after.bodyName != "Kerbin")
+            {
+                pose = KscPoseResolution.Failure(
+                    DescribeKscBranch(section),
+                    "non-kerbin",
+                    section.HasValue ? section.Value.anchorVesselId : 0);
+                ParsekLog.VerboseRateLimited("KSCGhost", "ksc-segment-non-kerbin",
+                    $"KSC segment skipped: beforeBody={before.bodyName ?? "null"} " +
+                    $"afterBody={after.bodyName ?? "null"} targetUT={before.ut + (after.ut - before.ut) * t:F2}");
+                return false;
+            }
+
+            ReferenceFrame frame = section.HasValue
+                ? section.Value.referenceFrame
+                : ReferenceFrame.Absolute;
+            if (frame == ReferenceFrame.Relative)
+            {
+                double dx = before.latitude + (after.latitude - before.latitude) * t;
+                double dy = before.longitude + (after.longitude - before.longitude) * t;
+                double dz = before.altitude + (after.altitude - before.altitude) * t;
+                Quaternion storedRot = TrajectoryMath.PureSlerp(before.rotation, after.rotation, t);
+                return TryResolveKscRelativePose(
+                    rec,
+                    dx,
+                    dy,
+                    dz,
+                    storedRot,
+                    section.Value.anchorVesselId,
+                    anchorLookup,
+                    out pose);
+            }
+
+            Vector3d posBefore;
+            Vector3d posAfter;
+            Quaternion bodyRotBefore;
+            Quaternion bodyRotAfter;
+            if (!surfaceLookup(
+                    before.bodyName,
+                    before.latitude,
+                    before.longitude,
+                    before.altitude,
+                    out posBefore,
+                    out bodyRotBefore)
+                || !surfaceLookup(
+                    after.bodyName,
+                    after.latitude,
+                    after.longitude,
+                    after.altitude,
+                    out posAfter,
+                    out bodyRotAfter))
+            {
+                pose = KscPoseResolution.Failure("absolute", "body-not-found", 0);
+                ParsekLog.VerboseRateLimited("KSCGhost", "interp-no-body",
+                    $"Body not found: before={before.bodyName ?? "null"} after={after.bodyName ?? "null"}");
+                return false;
+            }
+
+            Vector3d interpolatedPos = new Vector3d(
+                posBefore.x + (posAfter.x - posBefore.x) * t,
+                posBefore.y + (posAfter.y - posBefore.y) * t,
+                posBefore.z + (posAfter.z - posBefore.z) * t);
+            if (double.IsNaN(interpolatedPos.x) || double.IsNaN(interpolatedPos.y) ||
+                double.IsNaN(interpolatedPos.z))
+            {
+                ParsekLog.VerboseRateLimited("KSCGhost", "ksc-pos-nan-fallback",
+                    $"KSC interpolation produced NaN; using before point at ut={before.ut:F2}");
+                interpolatedPos = posBefore;
+            }
+
+            Quaternion interpolatedRot = TrajectoryMath.PureSlerp(before.rotation, after.rotation, t);
+            Quaternion worldRot = TrajectoryMath.PureMultiply(bodyRotBefore, interpolatedRot);
+            pose = KscPoseResolution.Success(
+                interpolatedPos,
+                worldRot,
+                DescribeKscBranch(section),
+                0);
+            ParsekLog.VerboseRateLimited("KSCGhost", "ksc-surface-position",
+                $"KSC SURFACE playback resolved: recording={rec.DebugName} " +
+                $"targetUT={before.ut + (after.ut - before.ut) * t:F2} branch={pose.Branch}",
+                2.0);
+            return true;
+        }
+
+        private static bool TryResolveKscRelativePose(
+            Recording rec,
+            double dx,
+            double dy,
+            double dz,
+            Quaternion storedRot,
+            uint anchorVesselId,
+            KscAnchorLookup anchorLookup,
+            out KscPoseResolution pose)
+        {
+            if (anchorVesselId == 0 || anchorLookup == null)
+            {
+                pose = KscPoseResolution.Failure(
+                    "relative",
+                    "relative-anchor-unresolved",
+                    anchorVesselId);
+                ParsekLog.VerboseRateLimited("KSCGhost", "ksc-relative-anchor-unresolved",
+                    $"RELATIVE KSC playback skipped: recording={rec.DebugName} " +
+                    $"anchorPid={anchorVesselId} reason=no-anchor-lookup");
+                return false;
+            }
+
+            KscAnchorFrame anchor;
+            if (!anchorLookup(anchorVesselId, out anchor))
+            {
+                pose = KscPoseResolution.Failure(
+                    "relative",
+                    "relative-anchor-unresolved",
+                    anchorVesselId);
+                ParsekLog.VerboseRateLimited("KSCGhost", "ksc-relative-anchor-unresolved",
+                    $"RELATIVE KSC playback skipped: recording={rec.DebugName} " +
+                    $"anchorPid={anchorVesselId} reason=anchor-not-found");
+                return false;
+            }
+
+            Vector3d worldPos = TrajectoryMath.ResolveRelativePlaybackPosition(
+                anchor.WorldPos,
+                anchor.WorldRot,
+                dx,
+                dy,
+                dz,
+                rec.RecordingFormatVersion);
+            if (double.IsNaN(worldPos.x) || double.IsNaN(worldPos.y) || double.IsNaN(worldPos.z))
+            {
+                ParsekLog.Warn("KSCGhost",
+                    $"RELATIVE KSC playback produced NaN position; using anchor position " +
+                    $"recording={rec.DebugName} anchorPid={anchorVesselId}");
+                worldPos = anchor.WorldPos;
+            }
+
+            Quaternion worldRot = TrajectoryMath.ResolveRelativePlaybackRotation(
+                anchor.WorldRot,
+                storedRot);
+            pose = KscPoseResolution.Success(worldPos, worldRot, "relative", anchorVesselId);
+            ParsekLog.VerboseRateLimited("KSCGhost", "ksc-relative-position",
+                $"RELATIVE KSC playback resolved: recording={rec.DebugName} " +
+                $"contract={RecordingStore.DescribeRelativeFrameContract(rec.RecordingFormatVersion)} " +
+                $"version={rec.RecordingFormatVersion} dx={dx:F2} dy={dy:F2} dz={dz:F2} " +
+                $"anchorPid={anchorVesselId} |offset|={Math.Sqrt(dx * dx + dy * dy + dz * dz):F2}m",
+                2.0);
+            return true;
+        }
+
+        private static string DescribeKscBranch(TrackSection? section)
+        {
+            if (!section.HasValue)
+                return "no-section";
+            return section.Value.referenceFrame == ReferenceFrame.Absolute
+                ? "absolute"
+                : section.Value.referenceFrame == ReferenceFrame.Relative
+                    ? "relative"
+                    : "orbital-checkpoint";
+        }
+
+        internal bool TryLookupKscSurfacePose(
+            string bodyName,
+            double latitude,
+            double longitude,
+            double altitude,
+            out Vector3d worldPos,
+            out Quaternion bodyWorldRot)
+        {
+            worldPos = Vector3d.zero;
+            bodyWorldRot = Quaternion.identity;
+            CelestialBody body = LookupBody(bodyName);
+            if (body == null)
+                return false;
+
+            worldPos = body.GetWorldSurfacePosition(latitude, longitude, altitude);
+            bodyWorldRot = body.bodyTransform != null
+                ? body.bodyTransform.rotation
+                : Quaternion.identity;
+            return true;
+        }
+
+        internal bool TryLookupKscAnchorFrame(uint anchorVesselId, out KscAnchorFrame anchorFrame)
+        {
+            anchorFrame = default(KscAnchorFrame);
+            if (anchorVesselId == 0)
+                return false;
+
+            Vessel anchor = FlightRecorder.FindVesselByPid(anchorVesselId);
+            if (anchor == null)
+                return false;
+
+            anchorFrame = new KscAnchorFrame(
+                anchor.GetWorldPos3D(),
+                anchor.transform != null ? anchor.transform.rotation : Quaternion.identity);
+            return true;
         }
 
         /// <summary>
@@ -1601,6 +2113,7 @@ namespace Parsek
                 ParsekLog.Info("KSCGhost", $"Destroyed {primaryCount} primary + {overlapCount} overlap KSC ghosts");
             loggedGhostSpawn.Clear();
             loggedReshow.Clear();
+            loggedKscRelativeAnchorNotFound.Clear();
             kscSpawnAttempted.Clear();
             loggedPlaybackDisabledPastEndSpawnAttempts.Clear();
 

--- a/Source/Parsek/TrajectoryMath.cs
+++ b/Source/Parsek/TrajectoryMath.cs
@@ -892,6 +892,52 @@ namespace Parsek
             return new Quaternion(q.x / mag, q.y / mag, q.z / mag, q.w / mag);
         }
 
+        /// <summary>
+        /// Pure-math quaternion slerp equivalent to Quaternion.Slerp without Unity native calls.
+        /// </summary>
+        internal static Quaternion PureSlerp(Quaternion from, Quaternion to, float t)
+        {
+            if (t < 0f) t = 0f;
+            else if (t > 1f) t = 1f;
+
+            from = PureNormalize(SanitizeQuaternion(from));
+            to = PureNormalize(SanitizeQuaternion(to));
+
+            float dot =
+                from.x * to.x +
+                from.y * to.y +
+                from.z * to.z +
+                from.w * to.w;
+            if (dot < 0f)
+            {
+                to = new Quaternion(-to.x, -to.y, -to.z, -to.w);
+                dot = -dot;
+            }
+
+            if (dot > 0.9995f)
+            {
+                return PureNormalize(new Quaternion(
+                    from.x + (to.x - from.x) * t,
+                    from.y + (to.y - from.y) * t,
+                    from.z + (to.z - from.z) * t,
+                    from.w + (to.w - from.w) * t));
+            }
+
+            if (dot > 1f) dot = 1f;
+            double theta0 = System.Math.Acos(dot);
+            double theta = theta0 * t;
+            double sinTheta = System.Math.Sin(theta);
+            double sinTheta0 = System.Math.Sin(theta0);
+
+            double s0 = System.Math.Cos(theta) - dot * sinTheta / sinTheta0;
+            double s1 = sinTheta / sinTheta0;
+            return PureNormalize(new Quaternion(
+                (float)(from.x * s0 + to.x * s1),
+                (float)(from.y * s0 + to.y * s1),
+                (float)(from.z * s0 + to.z * s1),
+                (float)(from.w * s0 + to.w * s1)));
+        }
+
         /// <summary>Pure-math AngleAxis rotation.</summary>
         internal static Quaternion PureAngleAxis(float angleDeg, Vector3 axis)
         {

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -295,6 +295,40 @@ already pins this case.
 
 ---
 
+## ~~615. KSC ghost playback interpreted v6 RELATIVE offsets as lat/lon/alt~~
+
+**Source:** PR #594 review follow-up. This is a separate latent playback bug
+from `#613` / the RelativeAnchorResolution retire work: it affects the Space
+Center visual ghost path even when no anchor-retire suppression is involved.
+
+**Diagnosis (2026-04-26):** `ParsekKSC.InterpolateAndPositionKsc` accepted the
+flat `Recording.Points` list and called `body.GetWorldSurfacePosition` on
+`TrajectoryPoint.latitude` / `longitude` / `altitude` without first resolving
+the covering `TrackSection.referenceFrame`. For format-v6 `ReferenceFrame.Relative`
+sections those fields are anchor-local Cartesian metres, not geographic
+coordinates, so KSC ghosts could be drawn deep underground while the flight
+playback path resolved the same data correctly through the anchor vessel.
+
+**Fix:** `InterpolateAndPositionKsc` now takes the full `Recording`, selects the
+active `TrackSection` (using section-local frames when available), and routes
+RELATIVE sections through `TrajectoryMath.ResolveRelativePlaybackPosition` /
+`ResolveRelativePlaybackRotation` using `FlightRecorder.FindVesselByPid`, matching
+flight-scene playback. If the anchor is not resolvable before the ghost has a
+valid pose, the KSC ghost stays hidden; after a valid pose, it freezes at its
+last known transform with a WARN / Verbose diagnostic instead of reinterpreting
+dx/dy/dz as lat/lon/alt. Destroyed-recording explosion FX may still use that
+last valid frozen pose, but never an unpositioned default transform. Absolute,
+OrbitalCheckpoint, and no-section playback continue through the body surface
+lookup path. `KscGhostPlaybackTests` pins resolvable relative playback,
+unresolved-anchor hide/freeze semantics, cache reset across frame sources,
+frozen-pose explosion eligibility, and the unchanged absolute/checkpoint/no-section
+paths. `SceneAndPatch.ParsekKscRelativePlaybackUsesLiveAnchor` adds a live KSP
+runtime canary for the production KSC surface/anchor lookup path.
+
+**Status:** CLOSED 2026-04-26. Fixed on `fix/ksc-relative-frame-dispatch`.
+
+---
+
 ## ~~610. Quickload-resume tail trim destroys other vessels' continued recordings during Re-Fly load~~
 
 **Source:** `logs/2026-04-26_0118_refly-postfix-still-broken/KSP.log`. Same


### PR DESCRIPTION
Summary
- Dispatch KSC ghost pose interpolation by active TrackSection reference frame.
- Resolve v6 RELATIVE KSC frames through anchor-local playback math; hide before first valid anchor pose and freeze after a valid pose if the anchor disappears.
- Preserve absolute, no-section, and OrbitalCheckpoint surface-frame playback with explicit frame-source cache reset.
- Keep destroyed-recording explosion FX off unpositioned default transforms, while allowing last-valid frozen poses.
- Add xUnit coverage plus a live KSP in-game canary for the production KSC relative anchor path.

Tests
- dotnet test Source\Parsek.Tests\Parsek.Tests.csproj --filter KscGhostPlaybackTests (58 passed)
- dotnet test Source\Parsek.Tests\Parsek.Tests.csproj --filter "KscGhostPlaybackTests|TrajectoryMathTests" (68 passed)
- dotnet test Source\Parsek.Tests\Parsek.Tests.csproj (9062 passed)
- Force-copied Source\Parsek\bin\Debug\Parsek.dll to ../Kerbal Space Program/GameData/Parsek/Plugins/Parsek.dll; verified both DLLs are 3027456 bytes, deployed UTF-16 marker RELATIVE KSC playback count=4, and KSC SURFACE playback count=1.
- Review follow-up pass: no findings.