### PR TITLE
Rename Unfinished Flights Re-Fly button to Fly; hide loop on UF rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ All notable changes to Parsek are documented here.
 - `#586` Ghost map `IsVesselRegistered` now reads from `FlightGlobals.PersistentVesselIds` instead of scanning the full `FlightGlobals.Vessels` list, dropping the per-`Set As Target` cost from O(N) to O(1).
 - Runtime observability now adds compact recorder, map, Tracking Station, post-switch, game-action, and in-game test summaries without repeating stable no-op decisions.
 - Recordings table renames the Unfinished Flights `Re-Fly` button to `Fly` so the rec window and Timeline window use the same glyph for the same action; the confirmation popup that follows the click also relabels its accept button from `Re-Fly` to `Fly` for consistency.
-- Recordings table hides the loop checkbox on rows shown inside the virtual `Unfinished Flights` group, and the Timeline window hides the `L` button on Unfinished Flight rows; loop remains editable from the recording's row in its real (mission) group.
+- Recordings table hides every loop control inside the virtual `Unfinished Flights` group — the per-row loop checkbox and period editor on member rows, plus the group-header aggregate loop toggle — and the Timeline window hides the `L` button on Unfinished Flight rows; loop remains editable from the recording's row in its real (mission) group.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ All notable changes to Parsek are documented here.
 - Added active and background recording-finalization cache refresh producers, including the 5-second dynamic refresh cadence, stable-coast digest skipping, background on-rails orbit summaries, and maneuver-node-safe tail generation.
 - `#586` Ghost map `IsVesselRegistered` now reads from `FlightGlobals.PersistentVesselIds` instead of scanning the full `FlightGlobals.Vessels` list, dropping the per-`Set As Target` cost from O(N) to O(1).
 - Runtime observability now adds compact recorder, map, Tracking Station, post-switch, game-action, and in-game test summaries without repeating stable no-op decisions.
+- Recordings table renames the Unfinished Flights `Re-Fly` button to `Fly` so the rec window and Timeline window use the same glyph for the same action.
+- Recordings table hides the loop checkbox on rows shown inside the virtual `Unfinished Flights` group, and the Timeline window hides the `L` button on Unfinished Flight rows; loop remains editable from the recording's row in its real (mission) group.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ All notable changes to Parsek are documented here.
 - Added active and background recording-finalization cache refresh producers, including the 5-second dynamic refresh cadence, stable-coast digest skipping, background on-rails orbit summaries, and maneuver-node-safe tail generation.
 - `#586` Ghost map `IsVesselRegistered` now reads from `FlightGlobals.PersistentVesselIds` instead of scanning the full `FlightGlobals.Vessels` list, dropping the per-`Set As Target` cost from O(N) to O(1).
 - Runtime observability now adds compact recorder, map, Tracking Station, post-switch, game-action, and in-game test summaries without repeating stable no-op decisions.
-- Recordings table renames the Unfinished Flights `Re-Fly` button to `Fly` so the rec window and Timeline window use the same glyph for the same action.
+- Recordings table renames the Unfinished Flights `Re-Fly` button to `Fly` so the rec window and Timeline window use the same glyph for the same action; the confirmation popup that follows the click also relabels its accept button from `Re-Fly` to `Fly` for consistency.
 - Recordings table hides the loop checkbox on rows shown inside the virtual `Unfinished Flights` group, and the Timeline window hides the `L` button on Unfinished Flight rows; loop remains editable from the recording's row in its real (mission) group.
 
 ### Bug Fixes

--- a/Source/Parsek.Tests/TimelineWindowUITests.cs
+++ b/Source/Parsek.Tests/TimelineWindowUITests.cs
@@ -54,6 +54,24 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void ShouldShowLoopToggle_PastLoopableUnfinishedFlight_ReturnsFalse()
+        {
+            var rec = new Recording { SegmentPhase = "atmo" };
+
+            Assert.False(TimelineWindowUI.ShouldShowLoopToggle(
+                rec, isFuture: false, isUnfinishedFlight: true));
+        }
+
+        [Fact]
+        public void ShouldShowLoopToggle_PastActiveLoopUnfinishedFlight_ReturnsFalse()
+        {
+            var rec = new Recording { LoopPlayback = true };
+
+            Assert.False(TimelineWindowUI.ShouldShowLoopToggle(
+                rec, isFuture: false, isUnfinishedFlight: true));
+        }
+
+        [Fact]
         public void ShouldShowFastForwardButton_FutureRecording_ReturnsTrue()
         {
             var rec = new Recording();

--- a/Source/Parsek/RewindInvoker.cs
+++ b/Source/Parsek/RewindInvoker.cs
@@ -246,7 +246,7 @@ namespace Parsek
                     message,
                     title,
                     HighLogic.UISkin,
-                    new DialogGUIButton("Re-Fly", () =>
+                    new DialogGUIButton("Fly", () =>
                     {
                         ParsekLog.Info(UITag,
                             $"Invoked rec={capturedSelected?.OriginChildRecordingId ?? "<none>"} " +

--- a/Source/Parsek/UI/RecordingsTableUI.cs
+++ b/Source/Parsek/UI/RecordingsTableUI.cs
@@ -1442,21 +1442,36 @@ namespace Parsek
             }
             if (captureThisRow) AlignDebugLogLastRect(alignmentDebugRowLog, "rowGroup");
 
-            // Loop checkbox
-            GUILayout.BeginHorizontal(GUILayout.Width(ColW_Loop));
-            GUILayout.FlexibleSpace();
-            bool loop = GUILayout.Toggle(rec.LoopPlayback, "");
-            GUILayout.FlexibleSpace();
-            GUILayout.EndHorizontal();
-            if (captureThisRow) AlignDebugLogLastRect(alignmentDebugRowLog, "rowLoop");
-            if (loop != rec.LoopPlayback)
+            // Loop checkbox — suppressed when this row is being drawn inside the
+            // virtual Unfinished Flights group (unfinishedFlightRowDepth > 0).
+            // The group is a re-fly TODO list; surfacing a loop toggle there
+            // is misleading because the user's next action on these rows is
+            // Fly, not playback configuration. The same recording's row in
+            // its real (mission) group still exposes the toggle, so loop
+            // remains editable for unfinished-flight recordings — just not
+            // from inside the virtual group itself. We render an empty cell
+            // of the same column width to keep the table grid aligned.
+            if (unfinishedFlightRowDepth > 0)
             {
-                rec.LoopPlayback = loop;
-                ApplyAutoLoopRange(rec, loop);
-                if (!loop && loopPeriodFocusedRi == ri)
-                    loopPeriodFocusedRi = -1;
-                ParsekLog.Info("UI", $"Recording '{rec.VesselName}' loop playback set to {loop}");
+                GUILayout.Label("", bodyCellLabel, GUILayout.Width(ColW_Loop));
             }
+            else
+            {
+                GUILayout.BeginHorizontal(GUILayout.Width(ColW_Loop));
+                GUILayout.FlexibleSpace();
+                bool loop = GUILayout.Toggle(rec.LoopPlayback, "");
+                GUILayout.FlexibleSpace();
+                GUILayout.EndHorizontal();
+                if (loop != rec.LoopPlayback)
+                {
+                    rec.LoopPlayback = loop;
+                    ApplyAutoLoopRange(rec, loop);
+                    if (!loop && loopPeriodFocusedRi == ri)
+                        loopPeriodFocusedRi = -1;
+                    ParsekLog.Info("UI", $"Recording '{rec.VesselName}' loop playback set to {loop}");
+                }
+            }
+            if (captureThisRow) AlignDebugLogLastRect(alignmentDebugRowLog, "rowLoop");
 
             // Period — wrapped with Space(BodyCellButtonLeftInset) on the left so
             // val+unit start 10 px into the cell, matching the shifted-right treatment
@@ -2556,16 +2571,17 @@ namespace Parsek
                 return false;
             }
 
-            // Always "Re-Fly" — the action is qualitatively different from
-            // the legacy R / FF buttons (rewind time and watch playback).
-            // Clicking this loads a Rewind Point quicksave, places the
-            // player in control of the destroyed sibling vessel, and
-            // starts a re-fly session (marker, supersede tracking, merge
-            // dialog later). Past-vs-future relative to current UT is
-            // irrelevant for the user-facing label: the action is "go to
-            // the breakup point and re-fly" in either direction. `now` is
-            // kept on the signature for future per-row state if needed.
-            const string kReFlyLabel = "Re-Fly";
+            // Always "Fly" — matches the Timeline-window separation-row label
+            // (DrawTimelineFlyButton) so the same action carries the same
+            // glyph in both surfaces. The action is qualitatively different
+            // from the legacy R / FF buttons (rewind time and watch
+            // playback): clicking this loads a Rewind Point quicksave,
+            // places the player in control of the destroyed sibling vessel,
+            // and starts a re-fly session (marker, supersede tracking,
+            // merge dialog later). Past-vs-future relative to current UT is
+            // irrelevant for the user-facing label. `now` is kept on the
+            // signature for future per-row state if needed.
+            const string kReFlyLabel = "Fly";
             _ = now;
 
             if (route == UnfinishedFlightRewindRoute.MissingSlot)
@@ -2627,7 +2643,7 @@ namespace Parsek
             }
 
             GUI.enabled = false;
-            DrawBodyCenteredButton(new GUIContent("Re-Fly", reason), ColW_Rewind);
+            DrawBodyCenteredButton(new GUIContent("Fly", reason), ColW_Rewind);
             GUI.enabled = true;
         }
 

--- a/Source/Parsek/UI/RecordingsTableUI.cs
+++ b/Source/Parsek/UI/RecordingsTableUI.cs
@@ -1476,10 +1476,24 @@ namespace Parsek
             // Period — wrapped with Space(BodyCellButtonLeftInset) on the left so
             // val+unit start 10 px into the cell, matching the shifted-right treatment
             // applied to single-button body cells (DrawBodyCenteredButton).
-            GUILayout.BeginHorizontal(bodyCellWrapStyle, GUILayout.Width(ColW_Period));
-            GUILayout.Space(BodyCellButtonLeftInset);
-            DrawLoopPeriodCell(rec, ri);
-            GUILayout.EndHorizontal();
+            // Suppressed alongside the loop checkbox when this row is being
+            // drawn inside the virtual Unfinished Flights group: the period
+            // editor is editable for any recording with LoopPlayback=true,
+            // so leaving it active would re-open loop configuration on the
+            // re-fly TODO surface that the loop-checkbox hide was meant to
+            // remove. Render an empty cell of the same column width to keep
+            // the table grid aligned.
+            if (unfinishedFlightRowDepth > 0)
+            {
+                GUILayout.Label("", bodyCellLabel, GUILayout.Width(ColW_Period));
+            }
+            else
+            {
+                GUILayout.BeginHorizontal(bodyCellWrapStyle, GUILayout.Width(ColW_Period));
+                GUILayout.Space(BodyCellButtonLeftInset);
+                DrawLoopPeriodCell(rec, ri);
+                GUILayout.EndHorizontal();
+            }
             if (captureThisRow) AlignDebugLogLastRect(alignmentDebugRowLog, "rowPeriod");
 
             // Watch button (flight only)
@@ -2431,26 +2445,18 @@ namespace Parsek
             // aligned.
             GUILayout.Label("", bodyCellLabel, GUILayout.Width(ColW_Group));
 
-            // Loop aggregate (acts on member rows; members are real recordings
-            // so the per-row loop toggle remains valid).
-            int loopCount = 0;
-            foreach (int idx in descendants)
-                if (committed[idx].LoopPlayback) loopCount++;
-            bool allLoop = memberCount > 0 && loopCount == memberCount;
-            GUILayout.BeginHorizontal(GUILayout.Width(ColW_Loop));
-            GUILayout.FlexibleSpace();
-            bool newLoop = GUILayout.Toggle(allLoop, "");
-            GUILayout.FlexibleSpace();
-            GUILayout.EndHorizontal();
-            if (newLoop != allLoop)
-            {
-                foreach (int idx in descendants)
-                    committed[idx].LoopPlayback = newLoop;
-                ParsekLog.Info("UI",
-                    $"Virtual group '{groupName}' loop set to {newLoop} ({memberCount} recordings)");
-            }
+            // Loop aggregate placeholder — the virtual Unfinished Flights group
+            // hides its loop toggle (and the per-member rows hide theirs too,
+            // see DrawRecordingRow) because the group is a re-fly TODO list.
+            // Surfacing an aggregate "loop all" toggle here would write
+            // LoopPlayback back to every member, undoing the hide-from-the-
+            // TODO-surface intent. The per-recording loop state stays
+            // editable from the same recording's row in its real (mission)
+            // group. Render an empty cell to keep the column aligned.
+            GUILayout.Label("", bodyCellLabel, GUILayout.Width(ColW_Loop));
 
-            // Period placeholder.
+            // Period placeholder — paired with the suppressed loop aggregate
+            // above so the virtual group exposes no playback configuration.
             GUILayout.Label("", bodyCellLabel, GUILayout.Width(ColW_Period));
 
             // Watch placeholder (flight only) — Unfinished Flights row does

--- a/Source/Parsek/UI/TimelineWindowUI.cs
+++ b/Source/Parsek/UI/TimelineWindowUI.cs
@@ -898,7 +898,12 @@ namespace Parsek
                     // or any recording already looping so the timeline can still disable it.
                     // Uses the shared toggleButtonStyle so the "on" state looks pressed in
                     // (same idiom as the filter/tab toggles); text color stays default.
-                    if (ShouldShowLoopToggle(rec, isFuture))
+                    // Suppressed for Unfinished Flight recordings: loop on a crashed
+                    // sibling that the user is meant to re-fly is misleading. Mirrors
+                    // the rec window's hide-loop-checkbox treatment for the virtual
+                    // "Unfinished Flights" group.
+                    bool isUnfinishedFlight = EffectiveState.IsUnfinishedFlight(rec);
+                    if (ShouldShowLoopToggle(rec, isFuture, isUnfinishedFlight))
                     {
                         string lTooltip = rec.LoopPlayback ? "Disable looping" : "Enable looping (uses saved interval)";
                         bool newLoop = GUILayout.Toggle(rec.LoopPlayback, new GUIContent("L", lTooltip),
@@ -1043,9 +1048,10 @@ namespace Parsek
                 : RowActionButtonWidth;
         }
 
-        internal static bool ShouldShowLoopToggle(Recording rec, bool isFuture)
+        internal static bool ShouldShowLoopToggle(Recording rec, bool isFuture, bool isUnfinishedFlight = false)
         {
             return !isFuture
+                && !isUnfinishedFlight
                 && rec != null
                 && (rec.LoopPlayback || Recording.IsLoopableRecording(rec));
         }


### PR DESCRIPTION
## Summary

- Recordings table renames the Unfinished Flights row button from `Re-Fly` to `Fly` (live + disabled branches in `RecordingsTableUI.DrawUnfinishedFlightRewindButton` / `DrawDisabledUnfinishedFlightRewindButton`) so it matches the Timeline-window separation-row label (`DrawTimelineFlyButton`). The follow-up confirmation popup (`RewindInvoker.ShowDialog`, "Parsek - Finish Flight") also relabels its accept button from `Re-Fly` to `Fly` so the click path stays consistent end-to-end. Internal log/concept names ("Re-Fly slot precondition", existing tooltips, `ReFlySessionMarker`, etc.) are unchanged.
- Recordings table suppresses the loop checkbox on rows rendered inside the virtual `Unfinished Flights` group (gated on the existing `unfinishedFlightRowDepth > 0` counter). An empty cell of the same column width keeps the table grid aligned. The same recording's row in its real (mission) group still exposes the toggle, so loop remains editable for unfinished flights — just not from the re-fly TODO list.
- Timeline window extends `ShouldShowLoopToggle` with an `isUnfinishedFlight` parameter (default false to keep existing call sites working) and the row-draw site passes `EffectiveState.IsUnfinishedFlight(rec)` so the `L` button is hidden on Unfinished Flight rows for the same reason.
- Two new `TimelineWindowUITests` cases cover the new flag against the past-loopable and past-active-loop paths; full xUnit suite stays green at 9110 / 9110.
- CHANGELOG: two `0.9.0` Enhancements entries (button rename incl. dialog, loop-hide treatment).

## Test plan

- [x] `dotnet build` from `Source/Parsek/` (Debug, no warnings).
- [x] `dotnet test` from `Source/Parsek.Tests/` — 9110 / 9110 pass.
- [x] Deployed DLL grep: `"Fly"` literal present, `"Re-Fly"` count drops from 7 → 6 (the remaining 6 are descriptive tooltips / log strings, not button glyphs).
- [ ] In-game smoke (manual): in a save with at least one Unfinished Flight row, confirm the rec-window button reads `Fly`, the confirm popup's accept reads `Fly`, the row inside the virtual `Unfinished Flights` group has no loop checkbox while the same recording's row in its real group still does, and the Timeline `L` button is gone for the corresponding `RecordingStart` row.