### PR TITLE
Clarify agent review workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Produces `Parsek-v{version}.zip` in repo root with `GameData/Parsek/` layout (DL
 
 ## Utility Scripts
 
-- `build.bat [Debug|Release] [KSP_PATH]` - wrapper around `dotnet build Source/Parsek/Parsek.csproj`; resolves `KSPDIR` automatically and relies on the project post-build copy to deploy `Parsek.dll` into `GameData/Parsek/Plugins`.
+- `build.bat [Debug|Release] [KSP_PATH]` - wrapper around `dotnet build Source/Parsek/Parsek.csproj`; resolves `KSPDIR` automatically, syncs this canonical `AGENTS.md` to the parent workspace, and relies on the project post-build copy to deploy `Parsek.dll` into `GameData/Parsek/Plugins`.
 - `python scripts/collect-logs.py [label] [--save NAME] [--skip-validation] [--skip-recordings] [--ksp-dir PATH]` - gathers `KSP.log`, `Player.log`, `parsek-test-results.txt`, save snapshots, and recording sidecars into `../logs/<timestamp>[_label]/`; runs log validation unless explicitly skipped.
 - `pwsh -File scripts/inject-recordings.ps1 [--clean-start] [--save-name NAME] [--target-save FILE] [--build] [--run-diagnostics-tests]` - injects synthetic test recordings into a chosen KSP save, optionally rebuilding first and/or running the diagnostics/observability test slice before injection.
 - `python scripts/release.py` - builds Release, runs the full headless test suite, and packages `Parsek-v{version}.zip` with the `GameData/Parsek/` release layout.
@@ -207,7 +207,9 @@ Before every commit that changes behavior (not just the first one in a PR), chec
 
 ## Code Review Follow-Ups
 
-When a reviewer flags fixes on an open PR, re-review only the changed fixes and any directly affected code paths. Do not restart a full-PR review from scratch on every follow-up unless the new changes actually broaden the risk surface.
+Do one full review at the end of a task/worktree before creating or finalizing the PR, except for low-risk small single-file fixes, docs-only changes, test-only changes, and obvious bug fixes with focused validation; for those, self-review and report validation.
+
+When a reviewer flags fixes on an open PR, re-review only the follow-up changes and any directly affected code paths. Do not restart a full-PR review from scratch on every follow-up unless the new changes actually broaden the risk surface.
 
 ## Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Produces `Parsek-v{version}.zip` in repo root with `GameData/Parsek/` layout (DL
 
 ## Utility Scripts
 
-- `build.bat [Debug|Release] [KSP_PATH]` - wrapper around `dotnet build Source/Parsek/Parsek.csproj`; resolves `KSPDIR` automatically, syncs this canonical `AGENTS.md` to the parent workspace, and relies on the project post-build copy to deploy `Parsek.dll` into `GameData/Parsek/Plugins`.
+- `build.bat [Debug|Release] [KSP_PATH]` - wrapper around `dotnet build Source/Parsek/Parsek.csproj`; resolves `KSPDIR` automatically, syncs this canonical `AGENTS.md` and `.claude/CLAUDE.md` to the parent workspace, and relies on the project post-build copy to deploy `Parsek.dll` into `GameData/Parsek/Plugins`.
 - `python scripts/collect-logs.py [label] [--save NAME] [--skip-validation] [--skip-recordings] [--ksp-dir PATH]` - gathers `KSP.log`, `Player.log`, `parsek-test-results.txt`, save snapshots, and recording sidecars into `../logs/<timestamp>[_label]/`; runs log validation unless explicitly skipped.
 - `pwsh -File scripts/inject-recordings.ps1 [--clean-start] [--save-name NAME] [--target-save FILE] [--build] [--run-diagnostics-tests]` - injects synthetic test recordings into a chosen KSP save, optionally rebuilding first and/or running the diagnostics/observability test slice before injection.
 - `python scripts/release.py` - builds Release, runs the full headless test suite, and packages `Parsek-v{version}.zip` with the `GameData/Parsek/` release layout.

--- a/build.bat
+++ b/build.bat
@@ -38,6 +38,8 @@ echo KSP Dir: %KSPDIR%
 echo Engine:  dotnet build
 echo.
 
+copy /Y "%~dp0AGENTS.md" "%~dp0..\AGENTS.md" >nul
+
 :: Build the mod project directly.
 :: This avoids a flaky solution-level parallel restore/build path on the local .NET SDK
 :: and keeps deployment behavior identical via Parsek.csproj's post-build copy target.

--- a/build.bat
+++ b/build.bat
@@ -39,6 +39,7 @@ echo Engine:  dotnet build
 echo.
 
 copy /Y "%~dp0AGENTS.md" "%~dp0..\AGENTS.md" >nul
+copy /Y "%~dp0.claude\CLAUDE.md" "%~dp0..\.claude\CLAUDE.md" >nul
 
 :: Build the mod project directly.
 :: This avoids a flaky solution-level parallel restore/build path on the local .NET SDK

--- a/docs/dev/development-workflow.md
+++ b/docs/dev/development-workflow.md
@@ -405,8 +405,8 @@ Once a phase passes review, the orchestrator:
 |-----------|----------|
 | First task in a new area (sets the pattern) | Full cycle: plan → implement → review → fix |
 | Tasks that change serialization format | Full cycle with extra review attention on round-trip |
-| Well-defined task following existing pattern | Shortcut: implement → review (skip separate plan) |
-| Bug fix with obvious cause | Shortcut: implement directly, review only if multi-file |
+| Well-defined task following existing pattern | Shortcut: implement → final review (skip separate plan) |
+| Low-risk small single-file fix, docs-only change, test-only change, or obvious bug fix with focused validation | Shortcut: implement directly, self-review, report validation |
 | Design doc says "needs investigation" | Research agent first, then full cycle |
 
 ### When to Intervene vs. Let Agents Work
@@ -510,7 +510,7 @@ git worktree remove ../Parsek-<branch-name>
 
 **Reusing agent context across stages.** The same agent that wrote code should NOT review it - it has the author's blind spots baked in. Clean-context review agents catch issues that the author would rationalize away. This is the single biggest quality lever in the workflow.
 
-**Skipping review for "simple" changes.** Even simple changes benefit from a clean-context read. A review agent that finds nothing wrong costs little. A review agent that catches a serialization bug saves hours of debugging in KSP.
+**Skipping review for risky changes.** Small single-file fixes, docs-only changes, test-only changes, and obvious bug fixes with focused validation can use self-review. Behavioral, multi-file, serialization, runtime-only, or release-critical changes still need a clean-context final review.
 
 **Skipping the post-change checklist.** Serialization bugs and test gaps are the most common regressions. The checklist exists because these were missed before.
 


### PR DESCRIPTION
Summary:
- make repo AGENTS.md and .claude/CLAUDE.md canonical and sync both to the parent workspace from build.bat
- clarify final full-review expectations while allowing self-review for low-risk changes
- align the development workflow shortcut guidance with the updated review policy

Validation:
- self-reviewed the staged diff
- ran git diff --check
- verified repo and parent AGENTS.md hashes match
- verified repo and parent .claude/CLAUDE.md hashes match