### PR TITLE
Coalesce per-frame log spam in chain walker and ghost off-rails patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- Tracking Station with a ghost selected no longer floods `KSP.log` — the chain-walk diagnostic lines (`HasGhostingTriggerEvents`, `Vessel PID claimed`, `WalkToLeaf`, `ResolveTermination`, `Chain built`, `Found claims`) now coalesce silently when the chain state is unchanged, so per-frame `RefreshGhostActionCache` calls stop multiplying into ~30 verbose lines per frame.
 - Tracking Station ghost-detail panel now matches the rest of the Parsek window family (opaque dark style, consistent title font / padding) and no longer flickers; the always-disabled stock `Fly` / `Delete` / `Recover` buttons are gone, leaving `Materialize` on its own row with a clear hint of what it does.
 - Custom ghost map icons, ghost labels, and Parsek windows now hide while the Esc / pause overlay is open in flight, KSC, and Tracking Station, so they no longer punch through the pause menu.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ All notable changes to Parsek are documented here.
 ### Bug Fixes
 
 - Tracking Station with a ghost selected no longer floods `KSP.log` — the chain-walk diagnostic lines (`HasGhostingTriggerEvents`, `Vessel PID claimed`, `WalkToLeaf`, `ResolveTermination`, `Chain built`, `Found claims`) now coalesce silently when the chain state is unchanged, so per-frame `RefreshGhostActionCache` calls stop multiplying into ~30 verbose lines per frame.
+- Ghost vessels in physics range no longer flood `KSP.log` with one `Blocked GoOffRails` line per FixedUpdate — the Harmony prefix that keeps ghost ProtoVessels on rails now emits once per ghost PID and stays silent across the per-physics-tick retry storm.
 - Tracking Station ghost-detail panel now matches the rest of the Parsek window family (opaque dark style, consistent title font / padding) and no longer flickers; the always-disabled stock `Fly` / `Delete` / `Recover` buttons are gone, leaving `Materialize` on its own row with a clear hint of what it does.
 - Custom ghost map icons, ghost labels, and Parsek windows now hide while the Esc / pause overlay is open in flight, KSC, and Tracking Station, so they no longer punch through the pause menu.
 

--- a/Source/Parsek.Tests/ChainSaveLoadTests.cs
+++ b/Source/Parsek.Tests/ChainSaveLoadTests.cs
@@ -572,36 +572,35 @@ namespace Parsek.Tests
         #region Log assertions
 
         /// <summary>
-        /// Deterministic re-derivation logs "Chain built" both times with
-        /// matching fields. Verifies the chain walker exercises the same
-        /// code path on repeated calls.
+        /// Deterministic re-derivation: repeated calls with stable input return
+        /// identical chains. Per-frame callers (tracking station Update) hit this
+        /// path every tick; the diagnostic lines are emitted once via
+        /// VerboseOnChange and silently coalesced on stable repeats. The
+        /// determinism guarantee asserted here is on the returned chain map,
+        /// not on log-line counts.
         /// </summary>
         [Fact]
-        public void DeterministicReDerivation_LogsChainBuiltBothTimes()
+        public void DeterministicReDerivation_StableInput_ReturnsIdenticalChains()
         {
             var (trees, _) = BuildSingleChainScenario();
 
             logLines.Clear();
-            GhostChainWalker.ComputeAllGhostChains(trees, 900);
-            int firstCount = 0;
-            for (int i = 0; i < logLines.Count; i++)
-            {
-                if (logLines[i].Contains("[ChainWalker]")
-                    && logLines[i].Contains("Chain built"))
-                    firstCount++;
-            }
+            var first = GhostChainWalker.ComputeAllGhostChains(trees, 900);
+            Assert.Contains(logLines, l =>
+                l.Contains("[ChainWalker]") && l.Contains("Chain built"));
 
-            GhostChainWalker.ComputeAllGhostChains(trees, 900);
-            int totalCount = 0;
-            for (int i = 0; i < logLines.Count; i++)
-            {
-                if (logLines[i].Contains("[ChainWalker]")
-                    && logLines[i].Contains("Chain built"))
-                    totalCount++;
-            }
+            var second = GhostChainWalker.ComputeAllGhostChains(trees, 900);
 
-            Assert.True(firstCount > 0, "First computation did not log 'Chain built'");
-            Assert.Equal(firstCount * 2, totalCount);
+            Assert.Equal(first.Count, second.Count);
+            foreach (var kvp in first)
+            {
+                Assert.True(second.TryGetValue(kvp.Key, out var s));
+                Assert.Equal(kvp.Value.OriginalVesselPid, s.OriginalVesselPid);
+                Assert.Equal(kvp.Value.Links.Count, s.Links.Count);
+                Assert.Equal(kvp.Value.TipRecordingId, s.TipRecordingId);
+                Assert.Equal(kvp.Value.SpawnUT, s.SpawnUT);
+                Assert.Equal(kvp.Value.IsTerminated, s.IsTerminated);
+            }
         }
 
         /// <summary>

--- a/Source/Parsek.Tests/GhostChainWalkerTests.cs
+++ b/Source/Parsek.Tests/GhostChainWalkerTests.cs
@@ -898,6 +898,56 @@ namespace Parsek.Tests
         }
 
         /// <summary>
+        /// Regression: a chain that spans two trees via PID-based linking
+        /// (CrossTree_TwoLinks_ChainsExtend shape) hits the cross-tree merge
+        /// path on every ComputeAllGhostChains call. The "Cross-tree link"
+        /// per-merge line and the "MergeCrossTreeLinks: absorbed N chain(s)"
+        /// summary must coalesce; otherwise a selected ghost whose chain spans
+        /// trees re-emits both lines per frame.
+        /// </summary>
+        [Fact]
+        public void RepeatedCalls_CrossTreeLinkedChain_DoNotRespamMergeLines()
+        {
+            // Tree1: R1 docks to S(100), resulting vessel keeps PID 100.
+            var r1 = MakeRecording("R1", 50, 1000, 1060, childBpId: "bp-dock1");
+            var r1Leaf = MakeRecording("R1-leaf", 100, 1060, 1120,
+                parentBpId: "bp-dock1");
+            var dock1 = MakeBranchPoint("bp-dock1", BranchPointType.Dock,
+                1060, 100, new[] { "R1" }, new[] { "R1-leaf" });
+            var tree1 = MakeTree("tree-1", new[] { r1, r1Leaf },
+                new[] { dock1 });
+
+            // Tree2: R2 docks to the same vessel (PID 100).
+            var r2 = MakeRecording("R2", 60, 1200, 1260, childBpId: "bp-dock2");
+            var r2Leaf = MakeRecording("R2-leaf", 100, 1260, 1320,
+                parentBpId: "bp-dock2");
+            var dock2 = MakeBranchPoint("bp-dock2", BranchPointType.Dock,
+                1260, 100, new[] { "R2" }, new[] { "R2-leaf" });
+            var tree2 = MakeTree("tree-2", new[] { r2, r2Leaf },
+                new[] { dock2 });
+
+            var trees = new List<RecordingTree> { tree1, tree2 };
+
+            GhostChainWalker.ComputeAllGhostChains(trees, 900);
+            logLines.Clear();
+
+            for (int i = 0; i < 8; i++)
+                GhostChainWalker.ComputeAllGhostChains(trees, 900);
+
+            int respam = 0;
+            foreach (var l in logLines)
+            {
+                if (!l.Contains("[ChainWalker]")) continue;
+                if (l.Contains("Cross-tree link:") && l.Contains("merged with chain"))
+                    respam++;
+                else if (l.Contains("MergeCrossTreeLinks: absorbed"))
+                    respam++;
+            }
+
+            Assert.Equal(0, respam);
+        }
+
+        /// <summary>
         /// Regression: when multiple branch points claim the same vessel PID in
         /// the same tree, the per-claim VerboseOnChange identity must scope to
         /// the individual claim (bp.Id / rec.RecordingId), not just the

--- a/Source/Parsek.Tests/GhostChainWalkerTests.cs
+++ b/Source/Parsek.Tests/GhostChainWalkerTests.cs
@@ -803,32 +803,39 @@ namespace Parsek.Tests
 
         /// <summary>
         /// Regression: per-frame callers (e.g. ParsekTrackingStation.RefreshGhostActionCache)
-        /// invoke ComputeAllGhostChains every Update tick. The chain-walk diagnostic
-        /// lines (claim, chain-built, walk-to-leaf, terminate, claims-summary) must
-        /// coalesce silently when the input is stable — only the first call should
-        /// emit them, repeats with the same state-key must be suppressed via
-        /// VerboseOnChange.
+        /// invoke ComputeAllGhostChains every Update tick. Every diagnostic in the
+        /// chain-walk path — claim, chain-built, walk-step, walk-reached-leaf,
+        /// terminate, claims summary, has-ghosting-trigger — must coalesce silently
+        /// when the input is stable. Counts every flavor of ChainWalker line, not
+        /// just the leaf summary, so per-step walk diagnostics can't silently slip
+        /// back into the per-frame path.
         /// </summary>
         [Fact]
         public void RepeatedCalls_StableInput_DoNotRespamDiagnostics()
         {
+            // Multi-step chain: R1 → R1-mid → R1-leaf so WalkToLeaf takes >1 step.
             var r1 = MakeRecording("R1", 50, 1000, 1060, childBpId: "bp-dock");
-            var r1Leaf = MakeRecording("R1-leaf", 100, 1060, 1120,
-                terminal: TerminalState.Destroyed, parentBpId: "bp-dock");
-            var r1LeafB = MakeRecording("R1-leafB", 200, 1060, 1120,
-                terminal: TerminalState.Landed, parentBpId: "bp-dock");
+            var r1Mid = MakeRecording("R1-mid", 100, 1060, 1090,
+                parentBpId: "bp-dock", childBpId: "bp-split");
+            var r1Leaf = MakeRecording("R1-leaf", 100, 1090, 1120,
+                terminal: TerminalState.Destroyed, parentBpId: "bp-split");
+            var r1LeafB = MakeRecording("R1-leafB", 200, 1090, 1120,
+                terminal: TerminalState.Landed, parentBpId: "bp-split");
             var dockBp = MakeBranchPoint("bp-dock", BranchPointType.Dock,
-                1060, 100, new[] { "R1" }, new[] { "R1-leaf", "R1-leafB" });
-            var tree = MakeTree("tree-1", new[] { r1, r1Leaf, r1LeafB },
-                new[] { dockBp });
+                1060, 100, new[] { "R1" }, new[] { "R1-mid" });
+            var splitBp = MakeBranchPoint("bp-split", BranchPointType.Breakup,
+                1090, 0, new[] { "R1-mid" }, new[] { "R1-leaf", "R1-leafB" });
+            var tree = MakeTree("tree-1", new[] { r1, r1Mid, r1Leaf, r1LeafB },
+                new[] { dockBp, splitBp });
             var trees = new List<RecordingTree> { tree };
 
             // Warm-up call seeds VerboseOnChange state and emits each diagnostic once.
             GhostChainWalker.ComputeAllGhostChains(trees, 900);
             logLines.Clear();
 
-            // Subsequent calls with identical input must emit zero new lines for the
-            // per-frame-spammy diagnostics. Suppressed counters absorb the repeats.
+            // Subsequent calls with identical input must emit zero new lines for any
+            // of the per-frame-spammy diagnostics. Suppressed counters absorb the
+            // repeats; only the next genuine state flip would re-emit.
             for (int i = 0; i < 8; i++)
                 GhostChainWalker.ComputeAllGhostChains(trees, 900);
 
@@ -839,12 +846,104 @@ namespace Parsek.Tests
                 if (l.Contains("claimed by tree=")) spamCount++;
                 else if (l.Contains("Chain built:")) spamCount++;
                 else if (l.Contains("WalkToLeaf: reached leaf=")) spamCount++;
+                else if (l.Contains("WalkToLeaf: step ")) spamCount++;
                 else if (l.Contains("ResolveTermination:") && l.Contains("marked terminated")) spamCount++;
                 else if (l.Contains("Found claims for")) spamCount++;
                 else if (l.Contains("HasGhostingTriggerEvents:")) spamCount++;
             }
 
             Assert.Equal(0, spamCount);
+        }
+
+        /// <summary>
+        /// Regression: per-frame callers also hit the no-claim path in saves with
+        /// no chain claims yet (e.g. fresh sandbox with one selected ghost). The
+        /// "No claims found" and "No committed trees" summaries must coalesce.
+        /// </summary>
+        [Fact]
+        public void RepeatedCalls_NoClaims_DoNotRespamSummary()
+        {
+            // Tree with no ghosting-trigger events and no claiming branch points.
+            var r1 = MakeRecording("R1", 50, 1000, 1120);
+            var tree = MakeTree("tree-1", new[] { r1 }, null);
+            var trees = new List<RecordingTree> { tree };
+
+            GhostChainWalker.ComputeAllGhostChains(trees, 900);
+            logLines.Clear();
+
+            for (int i = 0; i < 8; i++)
+                GhostChainWalker.ComputeAllGhostChains(trees, 900);
+
+            int spamCount = 0;
+            foreach (var l in logLines)
+            {
+                if (!l.Contains("[ChainWalker]")) continue;
+                if (l.Contains("No claims found in")) spamCount++;
+                else if (l.Contains("No committed trees")) spamCount++;
+                else if (l.Contains("HasGhostingTriggerEvents:")) spamCount++;
+            }
+
+            Assert.Equal(0, spamCount);
+
+            // And the empty-input path is also coalesced.
+            var empty = new List<RecordingTree>();
+            GhostChainWalker.ComputeAllGhostChains(empty, 900);
+            logLines.Clear();
+
+            for (int i = 0; i < 8; i++)
+                GhostChainWalker.ComputeAllGhostChains(empty, 900);
+
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("[ChainWalker]") && l.Contains("No committed trees"));
+        }
+
+        /// <summary>
+        /// Regression: when multiple branch points claim the same vessel PID in
+        /// the same tree, the per-claim VerboseOnChange identity must scope to
+        /// the individual claim (bp.Id / rec.RecordingId), not just the
+        /// (pid, treeId) pair. Otherwise the two claims share an identity slot
+        /// and their differing state keys ping-pong, re-emitting on every frame.
+        /// </summary>
+        [Fact]
+        public void RepeatedCalls_MultipleClaimsSamePidSameTree_DoNotRespam()
+        {
+            // Same tree, two Dock branch points, both claiming PID=100.
+            var root = MakeRecording("root", 50, 1000, 1020, childBpId: "bp-split");
+            var branchA = MakeRecording("branch-a", 60, 1020, 1060,
+                parentBpId: "bp-split", childBpId: "bp-dock-a");
+            var branchALeaf = MakeRecording("branch-a-leaf", 100, 1060, 1120,
+                parentBpId: "bp-dock-a");
+            var branchB = MakeRecording("branch-b", 70, 1020, 1080,
+                parentBpId: "bp-split", childBpId: "bp-dock-b");
+            var branchBLeaf = MakeRecording("branch-b-leaf", 100, 1080, 1160,
+                parentBpId: "bp-dock-b");
+
+            var splitBp = MakeBranchPoint("bp-split", BranchPointType.Breakup,
+                1020, 0, new[] { "root" }, new[] { "branch-a", "branch-b" });
+            var dockA = MakeBranchPoint("bp-dock-a", BranchPointType.Dock,
+                1060, 100, new[] { "branch-a" }, new[] { "branch-a-leaf" });
+            var dockB = MakeBranchPoint("bp-dock-b", BranchPointType.Dock,
+                1080, 100, new[] { "branch-b" }, new[] { "branch-b-leaf" });
+
+            var tree = MakeTree("tree-1",
+                new[] { root, branchA, branchALeaf, branchB, branchBLeaf },
+                new[] { splitBp, dockA, dockB });
+            var trees = new List<RecordingTree> { tree };
+
+            GhostChainWalker.ComputeAllGhostChains(trees, 900);
+            logLines.Clear();
+
+            for (int i = 0; i < 8; i++)
+                GhostChainWalker.ComputeAllGhostChains(trees, 900);
+
+            int respam = 0;
+            foreach (var l in logLines)
+            {
+                if (l.Contains("[ChainWalker]") && l.Contains("claimed by tree="))
+                    respam++;
+            }
+
+            Assert.Equal(0, respam);
         }
 
         #endregion

--- a/Source/Parsek.Tests/GhostChainWalkerTests.cs
+++ b/Source/Parsek.Tests/GhostChainWalkerTests.cs
@@ -801,6 +801,52 @@ namespace Parsek.Tests
                 l.Contains("[ChainWalker]") && l.Contains("No claims found"));
         }
 
+        /// <summary>
+        /// Regression: per-frame callers (e.g. ParsekTrackingStation.RefreshGhostActionCache)
+        /// invoke ComputeAllGhostChains every Update tick. The chain-walk diagnostic
+        /// lines (claim, chain-built, walk-to-leaf, terminate, claims-summary) must
+        /// coalesce silently when the input is stable — only the first call should
+        /// emit them, repeats with the same state-key must be suppressed via
+        /// VerboseOnChange.
+        /// </summary>
+        [Fact]
+        public void RepeatedCalls_StableInput_DoNotRespamDiagnostics()
+        {
+            var r1 = MakeRecording("R1", 50, 1000, 1060, childBpId: "bp-dock");
+            var r1Leaf = MakeRecording("R1-leaf", 100, 1060, 1120,
+                terminal: TerminalState.Destroyed, parentBpId: "bp-dock");
+            var r1LeafB = MakeRecording("R1-leafB", 200, 1060, 1120,
+                terminal: TerminalState.Landed, parentBpId: "bp-dock");
+            var dockBp = MakeBranchPoint("bp-dock", BranchPointType.Dock,
+                1060, 100, new[] { "R1" }, new[] { "R1-leaf", "R1-leafB" });
+            var tree = MakeTree("tree-1", new[] { r1, r1Leaf, r1LeafB },
+                new[] { dockBp });
+            var trees = new List<RecordingTree> { tree };
+
+            // Warm-up call seeds VerboseOnChange state and emits each diagnostic once.
+            GhostChainWalker.ComputeAllGhostChains(trees, 900);
+            logLines.Clear();
+
+            // Subsequent calls with identical input must emit zero new lines for the
+            // per-frame-spammy diagnostics. Suppressed counters absorb the repeats.
+            for (int i = 0; i < 8; i++)
+                GhostChainWalker.ComputeAllGhostChains(trees, 900);
+
+            int spamCount = 0;
+            foreach (var l in logLines)
+            {
+                if (!l.Contains("[ChainWalker]")) continue;
+                if (l.Contains("claimed by tree=")) spamCount++;
+                else if (l.Contains("Chain built:")) spamCount++;
+                else if (l.Contains("WalkToLeaf: reached leaf=")) spamCount++;
+                else if (l.Contains("ResolveTermination:") && l.Contains("marked terminated")) spamCount++;
+                else if (l.Contains("Found claims for")) spamCount++;
+                else if (l.Contains("HasGhostingTriggerEvents:")) spamCount++;
+            }
+
+            Assert.Equal(0, spamCount);
+        }
+
         #endregion
 
         #region IsIntermediateChainLink — null/empty safety

--- a/Source/Parsek.Tests/GhostVesselLoadPatchTests.cs
+++ b/Source/Parsek.Tests/GhostVesselLoadPatchTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using Parsek.Patches;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    [Collection("Sequential")]
+    public class GhostVesselLoadPatchTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public GhostVesselLoadPatchTests()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.VerboseOverrideForTesting = true;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+        }
+
+        /// <summary>
+        /// KSP retries Vessel.GoOffRails on every FixedUpdate while a ghost is in
+        /// physics range, and the Harmony prefix returns false to keep it on rails.
+        /// The 2026-04-26_2357_newest playtest captured 2941 raw Verbose lines for
+        /// a single ghost PID in 25 seconds (~117 Hz). LogBlockedOffRails must
+        /// coalesce the per-frame stream so the first block emits and identical
+        /// repeats stay silent.
+        /// </summary>
+        [Fact]
+        public void LogBlockedOffRails_RepeatedCallsSamePid_EmitOnceForStableName()
+        {
+            GhostVesselLoadPatch.LogBlockedOffRails(940887686u, "Ghost: Kerbal X");
+
+            int initialCount = 0;
+            for (int i = 0; i < logLines.Count; i++)
+            {
+                if (logLines[i].Contains("[GhostMap]")
+                    && logLines[i].Contains("Blocked GoOffRails")
+                    && logLines[i].Contains("pid=940887686"))
+                    initialCount++;
+            }
+            Assert.Equal(1, initialCount);
+
+            logLines.Clear();
+            for (int i = 0; i < 100; i++)
+                GhostVesselLoadPatch.LogBlockedOffRails(940887686u, "Ghost: Kerbal X");
+
+            int respam = 0;
+            foreach (var l in logLines)
+            {
+                if (l.Contains("[GhostMap]") && l.Contains("Blocked GoOffRails"))
+                    respam++;
+            }
+            Assert.Equal(0, respam);
+        }
+
+        /// <summary>
+        /// Each ghost PID gets its own VerboseOnChange identity slot. Two
+        /// distinct ghosts must each emit on first block; cross-PID alternation
+        /// must not ping-pong like a shared identity would.
+        /// </summary>
+        [Fact]
+        public void LogBlockedOffRails_DistinctPids_EachEmitsOnceAndStaysSilent()
+        {
+            GhostVesselLoadPatch.LogBlockedOffRails(100u, "Ghost: A");
+            GhostVesselLoadPatch.LogBlockedOffRails(200u, "Ghost: B");
+
+            int firstA = 0, firstB = 0;
+            foreach (var l in logLines)
+            {
+                if (!l.Contains("Blocked GoOffRails")) continue;
+                if (l.Contains("pid=100")) firstA++;
+                else if (l.Contains("pid=200")) firstB++;
+            }
+            Assert.Equal(1, firstA);
+            Assert.Equal(1, firstB);
+
+            logLines.Clear();
+            for (int i = 0; i < 50; i++)
+            {
+                GhostVesselLoadPatch.LogBlockedOffRails(100u, "Ghost: A");
+                GhostVesselLoadPatch.LogBlockedOffRails(200u, "Ghost: B");
+            }
+
+            int respam = 0;
+            foreach (var l in logLines)
+            {
+                if (l.Contains("[GhostMap]") && l.Contains("Blocked GoOffRails"))
+                    respam++;
+            }
+            Assert.Equal(0, respam);
+        }
+    }
+}

--- a/Source/Parsek/GhostChainWalker.cs
+++ b/Source/Parsek/GhostChainWalker.cs
@@ -501,8 +501,11 @@ namespace Parsek
 
                     pidsToMerge.Add(tipVesselPid);
 
-                    ParsekLog.Verbose(Tag,
-                        string.Format(ic,
+                    ParsekLog.VerboseOnChange(Tag,
+                        identity: string.Format(ic,
+                            "cross-tree-link|{0}|{1}", originPid, tipVesselPid),
+                        stateKey: chain.TipRecordingId ?? "null",
+                        message: string.Format(ic,
                             "Cross-tree link: vessel={0} → merged with chain for vessel={1}, new tip={2}",
                             originPid, tipVesselPid, chain.TipRecordingId));
 
@@ -518,8 +521,11 @@ namespace Parsek
 
             if (pidsToMerge.Count > 0)
             {
-                ParsekLog.Verbose(Tag,
-                    string.Format(ic, "MergeCrossTreeLinks: absorbed {0} chain(s)", pidsToMerge.Count));
+                ParsekLog.VerboseOnChange(Tag,
+                    identity: "cross-tree-merge-summary",
+                    stateKey: pidsToMerge.Count.ToString(ic),
+                    message: string.Format(ic,
+                        "MergeCrossTreeLinks: absorbed {0} chain(s)", pidsToMerge.Count));
             }
         }
 

--- a/Source/Parsek/GhostChainWalker.cs
+++ b/Source/Parsek/GhostChainWalker.cs
@@ -24,7 +24,10 @@ namespace Parsek
 
             if (committedTrees == null || committedTrees.Count == 0)
             {
-                ParsekLog.Verbose(Tag, "No committed trees — returning empty chain map");
+                ParsekLog.VerboseOnChange(Tag,
+                    identity: "claims-summary",
+                    stateKey: "no-trees",
+                    message: "No committed trees — returning empty chain map");
                 return new Dictionary<uint, GhostChain>();
             }
 
@@ -52,8 +55,11 @@ namespace Parsek
 
             if (skippedTerminated > 0)
             {
-                ParsekLog.Verbose(Tag,
-                    string.Format(ic, "Skipped {0} fully-terminated tree(s)", skippedTerminated));
+                ParsekLog.VerboseOnChange(Tag,
+                    identity: "skipped-terminated",
+                    stateKey: skippedTerminated.ToString(ic),
+                    message: string.Format(ic,
+                        "Skipped {0} fully-terminated tree(s)", skippedTerminated));
             }
 
             // Phase 7 of Rewind-to-Staging (design §3.3): during an active re-fly
@@ -62,22 +68,27 @@ namespace Parsek
             // ERS from the walker's perspective.
             if (skippedSessionSuppressed > 0)
             {
-                ParsekLog.Verbose(Tag,
-                    string.Format(ic,
+                ParsekLog.VerboseOnChange(Tag,
+                    identity: "skipped-session-suppressed",
+                    stateKey: skippedSessionSuppressed.ToString(ic),
+                    message: string.Format(ic,
                         "Skipped {0} claim(s) from session-suppressed recording(s)",
                         skippedSessionSuppressed));
             }
 
             if (claimsByPid.Count == 0)
             {
-                ParsekLog.Verbose(Tag,
-                    string.Format(ic, "No claims found in {0} committed trees", committedTrees.Count));
+                ParsekLog.VerboseOnChange(Tag,
+                    identity: "claims-summary",
+                    stateKey: string.Format(ic, "no-claims|{0}", committedTrees.Count),
+                    message: string.Format(ic,
+                        "No claims found in {0} committed trees", committedTrees.Count));
                 return new Dictionary<uint, GhostChain>();
             }
 
             ParsekLog.VerboseOnChange(Tag,
                 identity: "claims-summary",
-                stateKey: string.Format(ic, "{0}|{1}",
+                stateKey: string.Format(ic, "found|{0}|{1}",
                     claimsByPid.Count, committedTrees.Count),
                 message: string.Format(ic, "Found claims for {0} vessel(s) across {1} committed trees",
                     claimsByPid.Count, committedTrees.Count));
@@ -261,9 +272,8 @@ namespace Parsek
                 list.Add(link);
 
                 ParsekLog.VerboseOnChange(Tag,
-                    identity: string.Format(ic, "claim|{0}|{1}", pid, tree.Id),
-                    stateKey: string.Format(ic, "{0}|{1:F1}|{2}",
-                        interactionType, bp.UT, bp.Id),
+                    identity: string.Format(ic, "claim|{0}|{1}|{2}", pid, tree.Id, bp.Id),
+                    stateKey: string.Format(ic, "{0}|{1:F1}", interactionType, bp.UT),
                     message: string.Format(ic,
                         "Vessel PID={0} claimed by tree={1} via {2} at UT={3:F1}",
                         pid, tree.Id, interactionType, bp.UT));
@@ -325,8 +335,9 @@ namespace Parsek
                 list.Add(link);
 
                 ParsekLog.VerboseOnChange(Tag,
-                    identity: string.Format(ic, "claim-bg|{0}|{1}", pid, tree.Id),
-                    stateKey: string.Format(ic, "{0}|{1:F1}", rec.RecordingId, rec.StartUT),
+                    identity: string.Format(ic, "claim-bg|{0}|{1}|{2}",
+                        pid, tree.Id, rec.RecordingId),
+                    stateKey: string.Format(ic, "{0:F1}", rec.StartUT),
                     message: string.Format(ic,
                         "Vessel PID={0} claimed by tree={1} via BACKGROUND_EVENT at UT={2:F1}",
                         pid, tree.Id, rec.StartUT));
@@ -613,8 +624,12 @@ namespace Parsek
                 if (tree.Recordings.TryGetValue(bestChildId, out child))
                 {
                     steps++;
-                    ParsekLog.Verbose(Tag,
-                        string.Format(ic,
+                    ParsekLog.VerboseOnChange(Tag,
+                        identity: string.Format(ic,
+                            "walk-step|{0}|{1}", rec.RecordingId, steps),
+                        stateKey: string.Format(ic,
+                            "{0}|{1}|{2}", current.RecordingId, bestChildId, bp.Id),
+                        message: string.Format(ic,
                             "WalkToLeaf: step {0}: rec={1} → child={2} via bp={3}",
                             steps, current.RecordingId, bestChildId, bp.Id));
                     current = child;

--- a/Source/Parsek/GhostChainWalker.cs
+++ b/Source/Parsek/GhostChainWalker.cs
@@ -75,8 +75,11 @@ namespace Parsek
                 return new Dictionary<uint, GhostChain>();
             }
 
-            ParsekLog.Verbose(Tag,
-                string.Format(ic, "Found claims for {0} vessel(s) across {1} committed trees",
+            ParsekLog.VerboseOnChange(Tag,
+                identity: "claims-summary",
+                stateKey: string.Format(ic, "{0}|{1}",
+                    claimsByPid.Count, committedTrees.Count),
+                message: string.Format(ic, "Found claims for {0} vessel(s) across {1} committed trees",
                     claimsByPid.Count, committedTrees.Count));
 
             // Step 4: Build chains from sorted claims
@@ -108,8 +111,12 @@ namespace Parsek
                 var chain = kvp.Value;
                 ResolveTermination(chain, committedTrees);
 
-                ParsekLog.Verbose(Tag,
-                    string.Format(ic,
+                ParsekLog.VerboseOnChange(Tag,
+                    identity: string.Format(ic, "chain|{0}", chain.OriginalVesselPid),
+                    stateKey: string.Format(ic, "{0}|{1}|{2:F1}|{3}",
+                        chain.Links.Count,
+                        chain.TipRecordingId ?? "null", chain.SpawnUT, chain.IsTerminated),
+                    message: string.Format(ic,
                         "Chain built: vessel={0} links={1} tip={2} spawnUT={3:F1} terminated={4}",
                         chain.OriginalVesselPid, chain.Links.Count,
                         chain.TipRecordingId ?? "null", chain.SpawnUT, chain.IsTerminated));
@@ -253,8 +260,11 @@ namespace Parsek
                 }
                 list.Add(link);
 
-                ParsekLog.Verbose(Tag,
-                    string.Format(ic,
+                ParsekLog.VerboseOnChange(Tag,
+                    identity: string.Format(ic, "claim|{0}|{1}", pid, tree.Id),
+                    stateKey: string.Format(ic, "{0}|{1:F1}|{2}",
+                        interactionType, bp.UT, bp.Id),
+                    message: string.Format(ic,
                         "Vessel PID={0} claimed by tree={1} via {2} at UT={3:F1}",
                         pid, tree.Id, interactionType, bp.UT));
             }
@@ -314,8 +324,10 @@ namespace Parsek
                 }
                 list.Add(link);
 
-                ParsekLog.Verbose(Tag,
-                    string.Format(ic,
+                ParsekLog.VerboseOnChange(Tag,
+                    identity: string.Format(ic, "claim-bg|{0}|{1}", pid, tree.Id),
+                    stateKey: string.Format(ic, "{0}|{1:F1}", rec.RecordingId, rec.StartUT),
+                    message: string.Format(ic,
                         "Vessel PID={0} claimed by tree={1} via BACKGROUND_EVENT at UT={2:F1}",
                         pid, tree.Id, rec.StartUT));
             }
@@ -617,8 +629,10 @@ namespace Parsek
                 }
             }
 
-            ParsekLog.Verbose(Tag,
-                string.Format(ic,
+            ParsekLog.VerboseOnChange(Tag,
+                identity: string.Format(ic, "walk|{0}", rec.RecordingId),
+                stateKey: string.Format(ic, "{0}|{1}", current.RecordingId, steps),
+                message: string.Format(ic,
                     "WalkToLeaf: reached leaf={0} after {1} steps from start={2}",
                     current.RecordingId, steps, rec.RecordingId));
             return current;
@@ -657,8 +671,10 @@ namespace Parsek
                 if (ts == TerminalState.Destroyed || ts == TerminalState.Recovered)
                 {
                     chain.IsTerminated = true;
-                    ParsekLog.Verbose(Tag,
-                        string.Format(ic,
+                    ParsekLog.VerboseOnChange(Tag,
+                        identity: string.Format(ic, "terminate|{0}", chain.OriginalVesselPid),
+                        stateKey: string.Format(ic, "{0}|{1}", chain.TipRecordingId, ts),
+                        message: string.Format(ic,
                             "ResolveTermination: vessel={0} tip={1} terminalState={2} — marked terminated",
                             chain.OriginalVesselPid, chain.TipRecordingId, ts));
                 }

--- a/Source/Parsek/GhostingTriggerClassifier.cs
+++ b/Source/Parsek/GhostingTriggerClassifier.cs
@@ -172,8 +172,10 @@ namespace Parsek
                 segCount = rec.SegmentEvents.Count;
             }
 
-            ParsekLog.Verbose("ChainWalker",
-                $"HasGhostingTriggerEvents: rec={rec.RecordingId} found={result} (scanned {partCount} part events, {segCount} segment events)");
+            ParsekLog.VerboseOnChange("ChainWalker",
+                identity: $"trigger|{rec.RecordingId}",
+                stateKey: $"{result}|{partCount}|{segCount}",
+                message: $"HasGhostingTriggerEvents: rec={rec.RecordingId} found={result} (scanned {partCount} part events, {segCount} segment events)");
 
             return result;
         }

--- a/Source/Parsek/Patches/GhostVesselLoadPatch.cs
+++ b/Source/Parsek/Patches/GhostVesselLoadPatch.cs
@@ -413,11 +413,23 @@ namespace Parsek.Patches
         {
             if (GhostMapPresence.IsGhostMapVessel(__instance.persistentId))
             {
-                ParsekLog.Verbose("GhostMap",
-                    $"Blocked GoOffRails for ghost vessel '{__instance.vesselName}' pid={__instance.persistentId}");
+                LogBlockedOffRails(__instance.persistentId, __instance.vesselName);
                 return false; // skip original — keep ghost on rails
             }
             return true;
+        }
+
+        // Extracted so the spam-coalescing contract is testable without a live
+        // Unity Vessel. KSP retries GoOffRails on every FixedUpdate while a ghost
+        // is in physics range; a raw Verbose here floods at ~117 Hz per ghost
+        // (logs/2026-04-26_2357_newest/KSP.log: 2941 lines in 25 s for one PID).
+        // VerboseOnChange keyed by pid emits once per ghost, then stays silent.
+        internal static void LogBlockedOffRails(uint pid, string vesselName)
+        {
+            ParsekLog.VerboseOnChange("GhostMap",
+                identity: $"block-offrails|{pid}",
+                stateKey: vesselName ?? "(null)",
+                message: $"Blocked GoOffRails for ghost vessel '{vesselName}' pid={pid}");
         }
     }
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -3029,38 +3029,67 @@ With ~6 vessels in claims, a single per-frame call fanned out to ~30
 verbose lines, dominating every tracking-station session that had a
 selected ghost.
 
-**Resolution (2026-04-26):** Routed all six diagnostic emissions
-through `ParsekLog.VerboseOnChange` with state keys that capture the
-decision tuple:
+**Resolution (2026-04-26):** Routed every diagnostic in the chain-walk
+hot path through `ParsekLog.VerboseOnChange` with state keys that
+capture the decision tuple — including the no-claim and skipped-tree
+summaries that fire once per call regardless of whether any claims
+were found:
 
 - `HasGhostingTriggerEvents` — identity `trigger|<recId>`,
   state `(found, partCount, segCount)`.
 - `Vessel PID claimed via {Dock|Board|Undock|EVA|JointBreak}` —
-  identity `claim|<pid>|<treeId>`, state `(interactionType, bp.UT, bpId)`.
+  identity `claim|<pid>|<treeId>|<bp.Id>`, state `(interactionType, bp.UT)`.
+  The bp.Id is in the identity (not the state key) so multiple claims
+  for the same `(pid, treeId)` pair don't share a single VerboseOnChange
+  slot and ping-pong their differing state keys on every frame.
 - `Vessel PID claimed via BACKGROUND_EVENT` — identity
-  `claim-bg|<pid>|<treeId>`, state `(rec.RecordingId, rec.StartUT)`.
+  `claim-bg|<pid>|<treeId>|<rec.RecordingId>`, state `rec.StartUT`.
+  Same disambiguation reason — multiple background recordings of the
+  same `(pid, treeId)` would otherwise oscillate.
+- `WalkToLeaf: step N: rec=… → child=…` — identity `walk-step|<startId>|<step>`,
+  state `(currentId, childId, bpId)`. Per-step diagnostic gets one
+  identity slot per step so a stable multi-step walk emits each step
+  exactly once, then stays silent.
 - `WalkToLeaf reached leaf` — identity `walk|<startId>`,
   state `(leafId, steps)`.
 - `ResolveTermination marked terminated` — identity `terminate|<pid>`,
   state `(tipId, terminalState)`.
 - `Chain built` — identity `chain|<pid>`,
   state `(links, tip, spawnUT, terminated)`.
-- `Found claims for N vessel(s) across N committed trees` — identity
-  `claims-summary`, state `(Nvessels, Ntrees)`.
+- Mutually-exclusive summary lines (`No committed trees`,
+  `No claims found in N committed trees`,
+  `Found claims for N vessel(s) across N committed trees`) all share
+  identity `claims-summary` with state-key prefixes `no-trees` /
+  `no-claims|<N>` / `found|<Nvessels>|<Ntrees>` so flipping between
+  the variants is a real state change but stable repeats inside a
+  variant coalesce.
+- `Skipped N fully-terminated tree(s)` — identity `skipped-terminated`,
+  state `N`.
+- `Skipped N claim(s) from session-suppressed recording(s)` — identity
+  `skipped-session-suppressed`, state `N`.
 
-Stable per-frame rebuilds (the dominant case in the tracking station)
-now emit each diagnostic exactly once, then stay completely silent
-across identical-state repeats; the next genuine state flip surfaces
-`| suppressed=N` to confirm coalescing happened.
+Stable per-frame rebuilds (the dominant case in the tracking station,
+including the no-claim case for sandbox saves) now emit each diagnostic
+exactly once and surface `| suppressed=N` on the next genuine state
+flip.
 
 Cold paths (`Warn` for missing parents, `Verbose` for null-tree /
 unfound-child fallbacks) remain raw `Verbose` since they are decision
 flips rather than per-frame stable repeats. Regression coverage:
-`GhostChainWalkerTests.RepeatedCalls_StableInput_DoNotRespamDiagnostics`
-(8 repeat calls after warm-up emit zero new spam lines), and
-`ChainSaveLoadTests.DeterministicReDerivation_StableInput_ReturnsIdenticalChains`
-flipped from log-count assertion to chain-result equivalence so the
-determinism guarantee survives the coalescing change.
+
+- `GhostChainWalkerTests.RepeatedCalls_StableInput_DoNotRespamDiagnostics`
+  — multi-step chain (R1 → R1-mid → R1-leaf) so `WalkToLeaf: step …`
+  is exercised; counts every flavor of ChainWalker line and asserts 0
+  new lines after warm-up.
+- `GhostChainWalkerTests.RepeatedCalls_NoClaims_DoNotRespamSummary` —
+  covers the per-frame no-claim path that a fresh sandbox with a
+  selected ghost would hit, plus the empty-trees variant.
+- `GhostChainWalkerTests.RepeatedCalls_MultipleClaimsSamePidSameTree_DoNotRespam`
+  — two Dock BPs claiming the same PID in the same tree; pins the
+  identity-disambiguation against the bp.Id-in-identity choice.
+- `ChainSaveLoadTests.DeterministicReDerivation_StableInput_ReturnsIdenticalChains`
+  — flipped from log-count assertion to chain-result equivalence so
+  the determinism guarantee survives the coalescing change.
 
 **Status:** CLOSED 2026-04-26.
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -3095,6 +3095,45 @@ flips rather than per-frame stable repeats. Regression coverage:
 
 ---
 
+## ~~625. Log spam: `Blocked GoOffRails for ghost vessel` Harmony prefix fires ~117 Hz per ghost ProtoVessel in physics range~~
+
+**Source:** `logs/2026-04-26_2357_newest/KSP.log`. 2,941 lines for a
+single ghost PID `940887686` over 25 seconds (23:51:57-23:52:22), at
+~117 Hz (FixedUpdate × 2.3). Shape:
+
+```
+[Parsek][VERBOSE][GhostMap] Blocked GoOffRails for ghost vessel 'Ghost: Kerbal X' pid=940887686
+```
+
+Per-second distribution: `109, 118, 116, 118, 118, 117, 117, 115, …`
+
+**Cause:** `GhostVesselLoadPatch.Prefix` (Harmony prefix on
+`Vessel.GoOffRails`) returns `false` to keep ghost ProtoVessels on
+rails. KSP retries the off-rails transition every FixedUpdate while
+the ghost is inside physics range, so the prefix fires per physics
+tick and emits a raw `ParsekLog.Verbose` every time. With one ghost
+in range it floods at FixedUpdate × 2.3.
+
+**Resolution (2026-04-27):** Extracted the log into
+`GhostVesselLoadPatch.LogBlockedOffRails(uint pid, string vesselName)`
+and routed it through `ParsekLog.VerboseOnChange` with identity
+`block-offrails|<pid>` and stateKey `<vesselName>`. Each ghost gets its
+own VerboseOnChange slot, so two distinct ghosts each emit on first
+block while per-PID repeats coalesce silently. The next genuine state
+flip (a vessel rename, vanishingly rare for ghosts) surfaces
+`| suppressed=N`.
+
+Regression coverage:
+- `GhostVesselLoadPatchTests.LogBlockedOffRails_RepeatedCallsSamePid_EmitOnceForStableName`
+  — 100 repeat calls after first block emit zero new lines.
+- `GhostVesselLoadPatchTests.LogBlockedOffRails_DistinctPids_EachEmitsOnceAndStaysSilent`
+  — two PIDs each emit on first block, then 50 alternating calls
+  (which would ping-pong a shared identity slot) emit zero new lines.
+
+**Status:** CLOSED 2026-04-27.
+
+---
+
 ## ~~607. Misleading `Strip left N pre-existing vessel(s)` WARN reports stale, deduped count after post-supplement kill~~
 
 **Source:** `logs/2026-04-25_2334_refly-followup-test/KSP.log:12906-12907`:

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -3056,6 +3056,11 @@ were found:
   state `(tipId, terminalState)`.
 - `Chain built` — identity `chain|<pid>`,
   state `(links, tip, spawnUT, terminated)`.
+- `Cross-tree link: vessel=… → merged with chain for vessel=…` —
+  identity `cross-tree-link|<originPid>|<tipVesselPid>`,
+  state `chain.TipRecordingId`.
+- `MergeCrossTreeLinks: absorbed N chain(s)` — identity
+  `cross-tree-merge-summary`, state `N`.
 - Mutually-exclusive summary lines (`No committed trees`,
   `No claims found in N committed trees`,
   `Found claims for N vessel(s) across N committed trees`) all share
@@ -3087,6 +3092,10 @@ flips rather than per-frame stable repeats. Regression coverage:
 - `GhostChainWalkerTests.RepeatedCalls_MultipleClaimsSamePidSameTree_DoNotRespam`
   — two Dock BPs claiming the same PID in the same tree; pins the
   identity-disambiguation against the bp.Id-in-identity choice.
+- `GhostChainWalkerTests.RepeatedCalls_CrossTreeLinkedChain_DoNotRespamMergeLines`
+  — two trees both claim PID 100 (the `CrossTree_TwoLinks_ChainsExtend`
+  shape); pins the cross-tree merge path against per-frame re-emission
+  of the merge line and the absorbed-N summary.
 - `ChainSaveLoadTests.DeterministicReDerivation_StableInput_ReturnsIdenticalChains`
   — flipped from log-count assertion to chain-result equivalence so
   the determinism guarantee survives the coalescing change.

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -2991,6 +2991,81 @@ flipped to assert Verbose for `alreadyClassified=1, newlyClassified=0`.
 
 ---
 
+## ~~624. Log spam: ChainWalker emits ~30 verbose lines per frame from `ParsekTrackingStation.RefreshGhostActionCache` while a ghost is selected~~
+
+**Source:** `logs/2026-04-26_2301_tracking-station-ui-and-esc-menu/KSP.log`.
+KSP.log was 26 MB / 160,108 lines, of which 134,509 (84%) were
+`[ChainWalker]` verbose lines. Steady-state shape, repeated every
+Update tick over ~3 minutes:
+
+```
+[Parsek][VERBOSE][ChainWalker] HasGhostingTriggerEvents: rec=… found=True (scanned 8 part events, 0 segment events)
+[Parsek][VERBOSE][ChainWalker] Vessel PID=… claimed by tree=… via BACKGROUND_EVENT at UT=21.8
+[Parsek][VERBOSE][ChainWalker] WalkToLeaf: reached leaf=… after 0 steps from start=…
+[Parsek][VERBOSE][ChainWalker] ResolveTermination: vessel=… tip=… terminalState=Destroyed — marked terminated
+[Parsek][VERBOSE][ChainWalker] Chain built: vessel=… links=1 tip=… spawnUT=… terminated=True
+[Parsek][VERBOSE][ChainWalker] Found claims for 6 vessel(s) across 1 committed trees
+```
+
+Counts (single playtest):
+
+```bash
+grep -c "\[ChainWalker\]" KSP.log                 # 134509
+grep -c "WalkToLeaf: reached leaf="  KSP.log      # 26034 (×6 vessels)
+grep -c "Found claims for"           KSP.log      # 4339 (calls/sec ≈ 22 = per-frame)
+```
+
+**Cause:** `ParsekTrackingStation.Update` calls
+`RefreshGhostActionCache()` every frame while a ghost is selected
+(`ParsekTrackingStation.cs:259`). The cache itself is `Time.frameCount`
+gated to one rebuild per frame, but the rebuild dispatches to
+`GhostChainWalker.ComputeAllGhostChains`, which used raw
+`ParsekLog.Verbose` for six per-vessel/per-recording diagnostic lines
+(`HasGhostingTriggerEvents` in `GhostingTriggerClassifier.cs:175`,
+`Vessel PID claimed` × 2 in `GhostChainWalker.cs:256`/`:317`,
+`WalkToLeaf reached leaf` at `:620`, `ResolveTermination` at `:660`,
+`Chain built` at `:111`, plus the `Found claims` summary at `:78`).
+With ~6 vessels in claims, a single per-frame call fanned out to ~30
+verbose lines, dominating every tracking-station session that had a
+selected ghost.
+
+**Resolution (2026-04-26):** Routed all six diagnostic emissions
+through `ParsekLog.VerboseOnChange` with state keys that capture the
+decision tuple:
+
+- `HasGhostingTriggerEvents` — identity `trigger|<recId>`,
+  state `(found, partCount, segCount)`.
+- `Vessel PID claimed via {Dock|Board|Undock|EVA|JointBreak}` —
+  identity `claim|<pid>|<treeId>`, state `(interactionType, bp.UT, bpId)`.
+- `Vessel PID claimed via BACKGROUND_EVENT` — identity
+  `claim-bg|<pid>|<treeId>`, state `(rec.RecordingId, rec.StartUT)`.
+- `WalkToLeaf reached leaf` — identity `walk|<startId>`,
+  state `(leafId, steps)`.
+- `ResolveTermination marked terminated` — identity `terminate|<pid>`,
+  state `(tipId, terminalState)`.
+- `Chain built` — identity `chain|<pid>`,
+  state `(links, tip, spawnUT, terminated)`.
+- `Found claims for N vessel(s) across N committed trees` — identity
+  `claims-summary`, state `(Nvessels, Ntrees)`.
+
+Stable per-frame rebuilds (the dominant case in the tracking station)
+now emit each diagnostic exactly once, then stay completely silent
+across identical-state repeats; the next genuine state flip surfaces
+`| suppressed=N` to confirm coalescing happened.
+
+Cold paths (`Warn` for missing parents, `Verbose` for null-tree /
+unfound-child fallbacks) remain raw `Verbose` since they are decision
+flips rather than per-frame stable repeats. Regression coverage:
+`GhostChainWalkerTests.RepeatedCalls_StableInput_DoNotRespamDiagnostics`
+(8 repeat calls after warm-up emit zero new spam lines), and
+`ChainSaveLoadTests.DeterministicReDerivation_StableInput_ReturnsIdenticalChains`
+flipped from log-count assertion to chain-result equivalence so the
+determinism guarantee survives the coalescing change.
+
+**Status:** CLOSED 2026-04-26.
+
+---
+
 ## ~~607. Misleading `Strip left N pre-existing vessel(s)` WARN reports stale, deduped count after post-supplement kill~~
 
 **Source:** `logs/2026-04-25_2334_refly-followup-test/KSP.log:12906-12907`:


### PR DESCRIPTION
## Summary

Two related per-frame log-spam clusters in the ghost-presence path, both fixed by routing raw `ParsekLog.Verbose` through `ParsekLog.VerboseOnChange` so identical-state per-frame repeats coalesce silently and only genuine state flips re-emit.

### Cluster 1 — ChainWalker (Tracking Station)

Source: `logs/2026-04-26_2301_tracking-station-ui-and-esc-menu/KSP.log` — 134,509 / 160,108 lines (84%) were `[ChainWalker]` verbose. `ParsekTrackingStation.RefreshGhostActionCache` calls `GhostChainWalker.ComputeAllGhostChains` every frame while a ghost is selected; each call fanned out to ~30 verbose lines (5 per claimed vessel × 6 vessels + summary). Routed every diagnostic in the chain-walk hot path through `VerboseOnChange`, including the no-claim and skipped-tree summaries that fire even when no claims exist:

- `HasGhostingTriggerEvents` — identity `trigger|<recId>`
- `Vessel PID claimed via {Dock|Board|Undock|EVA|JointBreak}` — identity `claim|<pid>|<treeId>|<bp.Id>`
- `Vessel PID claimed via BACKGROUND_EVENT` — identity `claim-bg|<pid>|<treeId>|<rec.RecordingId>`
- `WalkToLeaf: step N` — identity `walk-step|<startId>|<step>`
- `WalkToLeaf reached leaf` — identity `walk|<startId>`
- `ResolveTermination marked terminated` — identity `terminate|<pid>`
- `Chain built` — identity `chain|<pid>`
- `claims-summary` shared by `No committed trees` / `No claims found` / `Found claims` with mutually-exclusive state-key prefixes
- `Skipped N fully-terminated tree(s)` and `Skipped N session-suppressed claim(s)` each get their own slot

Cold paths (warnings, null-tree fallbacks) stay as raw Verbose since they are decision flips, not per-frame stable repeats.

### Cluster 2 — `Blocked GoOffRails` Harmony prefix

Source: `logs/2026-04-26_2357_newest/KSP.log` — 2,941 lines for a single ghost PID over 25 s (~117 Hz, FixedUpdate × 2.3). KSP retries `Vessel.GoOffRails` every FixedUpdate while a ghost ProtoVessel sits in physics range; the Harmony prefix at `GhostVesselLoadPatch.cs:412` returns `false` to keep it on rails and was logging a raw Verbose every time. Extracted `LogBlockedOffRails(pid, vesselName)` and routed through `VerboseOnChange` with identity `block-offrails|<pid>` so each ghost emits once on first block.

Sibling Harmony prefixes in the same file (`Suppressed CommNetVessel`, `Suppressed OrbitTargeter`) fire <10× per session — left as raw Verbose since they aren't per-frame.

New entries `#624` and `#625` in `docs/dev/todo-and-known-bugs.md` carry the investigation detail.

## Test plan

- [x] `dotnet test` — all 9,219 tests pass (no skips, no failures)
- [x] `GhostChainWalkerTests.RepeatedCalls_StableInput_DoNotRespamDiagnostics` — multi-step chain (R1 → R1-mid → R1-leaf), 8 repeat calls after warm-up emit zero new spam lines (counts every flavor including `WalkToLeaf: step `)
- [x] `GhostChainWalkerTests.RepeatedCalls_NoClaims_DoNotRespamSummary` — sandbox-style no-claim path + empty-trees variant
- [x] `GhostChainWalkerTests.RepeatedCalls_MultipleClaimsSamePidSameTree_DoNotRespam` — two Dock BPs claiming the same PID in tree-1 (the `SameTree_OverlappingHistoricalReuse_StillExtendsChain` shape) — pins the bp.Id-in-identity disambiguation
- [x] `ChainSaveLoadTests.DeterministicReDerivation_StableInput_ReturnsIdenticalChains` — flipped from log-count assertion to chain-result equivalence
- [x] `GhostVesselLoadPatchTests.LogBlockedOffRails_RepeatedCallsSamePid_EmitOnceForStableName` — 100 repeat calls after first emit zero new lines
- [x] `GhostVesselLoadPatchTests.LogBlockedOffRails_DistinctPids_EachEmitsOnceAndStaysSilent` — two PIDs each emit, 50 alternating calls produce zero new lines
- [x] `dotnet build` — Source/Parsek + Source/Parsek.Tests build with 0 warnings, 0 errors
- [ ] Live KSP playtest: open Tracking Station with a selected ghost, then load a save with a ghost in physics range — expected: each diagnostic emits once and then stays silent; no per-frame `[ChainWalker]` or `[GhostMap] Blocked GoOffRails` flood