### PR TITLE
docs: renumber duplicate todo #626 to #628

### DIFF
--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -147,7 +147,7 @@ bodies (Mun, Minmus, etc.) keep the existing `PeR > Radius` semantics. Added
 explicit null guard for `vessel.orbit.referenceBody` and updated the Info log
 line to include `atmoTop` and `bodyHasAtmosphere`.
 
-## 626. Five flaky in-game tests at HEAD were failing for harness reasons, not code regressions ~~done~~
+## 628. Five flaky in-game tests at HEAD were failing for harness reasons, not code regressions ~~done~~
 
 Investigation log: `logs/2026-04-27_1902/parsek-test-results.txt` (5 FAILED in
 FLIGHT). All five turned out to be test-authoring bugs / a timing race against


### PR DESCRIPTION
Cosmetic doc cleanup. PR #618 and PR #616 both shipped with todo entry numbered `#626`; bump the test-flakes entry to `#628` so each heading is unique. Docs only, no code changes.