### PR TITLE
docs: update refactor-4 closeout status

### DIFF
--- a/docs/dev/plans/refactor-4-inventory.md
+++ b/docs/dev/plans/refactor-4-inventory.md
@@ -25,6 +25,12 @@ Build warning note: the build emits MSB3026/MSB3027/MSB3021 warnings when the
 post-build copy cannot replace the deployed KSP `Parsek.dll`. This matches the
 locked KSP process/log condition above; the build itself succeeds.
 
+Closeout note after PR #621: global baseline counts above remain the original
+Pass 0 snapshot. The Pass 3 KSC split leaves
+`LedgerOrchestrator.cs` at 6,596 lines and adds
+`KscActionExpectationClassifier.cs` (281 lines) plus
+`KscActionReconciler.cs` (309 lines).
+
 ## Directory Size Summary
 
 | Directory | Files | Lines |
@@ -43,7 +49,7 @@ locked KSP process/log condition above; the build itself succeeds.
 |------|-------|----------------|
 | `Source/Parsek/ParsekFlight.cs` | 14,503 | Pass1-Done; post-switch auto-record trigger helpers extracted, finalization deferred |
 | `Source/Parsek/GhostVisualBuilder.cs` | 7,193 | Pass1-Deferred; visual-builder split needs owner plan and runtime validation |
-| `Source/Parsek/GameActions/LedgerOrchestrator.cs` | 6,976 | Pass1-Done; earnings-window, vessel-cost, and recalculation helpers extracted |
+| `Source/Parsek/GameActions/LedgerOrchestrator.cs` | 6,596 | Pass3-Done for KSC classifier/reconciler extraction; earnings-window, vessel-cost, and recalculation helpers remain Pass1-Done |
 | `Source/Parsek/FlightRecorder.cs` | 6,689 | Pass1-Done; visual coverage logging helpers extracted |
 | `Source/Parsek/GhostPlaybackLogic.cs` | 5,343 | Pass1-Done; ghost info population and part-event helpers extracted |
 | `Source/Parsek/UI/RecordingsTableUI.cs` | 4,868 | Pass1-Deferred; high-coupling IMGUI row/tree split deferred |
@@ -324,11 +330,30 @@ Validation:
 
 No remaining Pass 1 same-file candidates are planned for this file.
 
-Cross-file decomposition should wait for Pass 2. Likely owners to evaluate are
-ledger migration/load repair, KSC expectation reconciliation, post-walk
-reconciliation, recovery-funds pairing, and rollout adoption. These regions are
-large enough to justify a split, but they share tolerances, ledger/action
-classification details, and commit-window state.
+Pass 3 KSC split completed:
+
+- PR #620 added the proposal for the KSC action classifier/reconciler slice.
+- PR #621 extracted `KscActionExpectationClassifier` for the
+  `CreateExpectationLeg` and `ClassifyAction` body, then moved the KSC
+  DTO/enum types into that classifier.
+- PR #621 also extracted `KscActionReconciler` for
+  `KscExpectedLegMatch`, `ReconcileKscAction`, KSC expectation-leg matching,
+  aggregate expected-delta computation, resource channel tagging, and the
+  canonical `KscReconcileEpsilonSeconds` source.
+- `LedgerOrchestrator` keeps compatibility facades for `ClassifyAction`,
+  `ReconcileKscAction`, `ResourceChannelTag`, and
+  `KscReconcileEpsilonSeconds`.
+- KSC event entry points, ledger writes, sequence assignment, post-walk
+  reconciliation, legacy migration/load repair, ledger mutation, and
+  resource/currency mutation order remain in `LedgerOrchestrator`.
+- Validation for the landed slice: build passed, focused ledger/career gate
+  passed 326 tests, and the full non-injection xUnit gate passed 9,261 tests.
+
+Remaining LedgerOrchestrator cross-file decomposition candidates are ledger
+migration/load repair, post-walk reconciliation, recovery-funds pairing, and
+rollout adoption. These regions are large enough to justify future proposals,
+but they still share tolerances, ledger/action classification details, and
+commit-window state.
 
 Magic-value follow-up candidates include the resource tolerances used by
 earnings/post-walk reconciliation, `KscReconcileEpsilonSeconds`,
@@ -999,18 +1024,18 @@ raw scan with a manual map for the high-risk owners:
 
 ## Next Investigation Priorities
 
-1. Prepare Pass 2 owner proposals for the deferred architectural areas before
-   moving code across files: visual builders, foreground/background part-event
-   pollers, KSC/flight playback, event handler families, state patchers,
-   serialization codecs, and rewind invocation.
+1. Prepare the next Pass 3 owner proposal before moving more code across files:
+   candidates include LedgerOrchestrator post-walk/migration/recovery-rollout
+   bands, visual builders, foreground/background part-event pollers,
+   KSC/flight playback, event handler families, state patchers, and rewind
+   invocation.
 2. Compare `RecordingStore.cs`, `TrajectorySidecarBinary.cs`, and snapshot
    sidecar helpers for repeated binary/text serialization patterns before any
    deduplication. Initial result: `refactor-4-pass2-storage-sidecars.md`
    recommends separate sidecar commit, sidecar orchestration, trajectory text
-   codec, manifest codec, and tree-record codec owners. The sidecar commit
-  batch and save/load-path orchestration slices are complete; schema redesign
-  remains out of scope, and binary/text format unification is deferred until
-  the manifest codec owner lands.
+   codec, manifest codec, and tree-record codec owners. Those Pass 2 slices are
+   complete; schema redesign remains out of scope, and binary/text format
+   unification is deferred.
 3. Build a static mutable state map for `GameStateRecorder`,
    `LedgerOrchestrator`, `RecordingStore`, `ParsekScenario`,
    `WatchModeController`, and `GhostPlaybackEngine`.

--- a/docs/dev/plans/refactor-4-plan.md
+++ b/docs/dev/plans/refactor-4-plan.md
@@ -228,7 +228,11 @@ Pass 3 starts only after the Pass 2 analysis is reviewed and approved.
 Likely candidates to evaluate, not promises:
 
 - `LedgerOrchestrator` decomposition if Pass 2 finds separable lifecycle,
-  reconciliation, migration, or UI-reporting responsibilities.
+  reconciliation, migration, or UI-reporting responsibilities. The first Pass 3
+  LedgerOrchestrator slice is complete: PR #620 proposed the KSC action
+  classifier/reconciler boundary and PR #621 extracted
+  `KscActionExpectationClassifier` plus `KscActionReconciler` behind stable
+  `LedgerOrchestrator` facades with zero production logic changes.
 - `UI/RecordingsTableUI` sub-splitting if the field/callback coupling has a
   clean ownership boundary.
 - storage helper extraction across `RecordingStore`,
@@ -238,6 +242,8 @@ Likely candidates to evaluate, not promises:
 - finalization cache producer/applier/shared endpoint helpers.
 
 Every Pass 3 change must be a separate logical commit with a focused review.
+Do not fold more work into the completed PR #621 stack; the next Pass 3 split
+needs its own proposal/update and PR.
 
 ## Magic Values Pass
 
@@ -254,7 +260,7 @@ Run separately from structural moves. For each candidate literal:
 | Gate | When | Criteria |
 |------|------|----------|
 | `dotnet build Source/Parsek/Parsek.csproj` | After every Tier 1 file or Tier 2 batch | Build succeeds; no new warnings from code changes |
-| Filtered xUnit baseline | While KSP is open/locked | `dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter FullyQualifiedName!~InjectAllRecordings` passes 8,625+ tests |
+| Filtered xUnit baseline | While KSP is open/locked | `dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter FullyQualifiedName!~InjectAllRecordings` passes the current non-injection gate (9,261 tests at PR #621 closeout) |
 | Full xUnit baseline | When KSP is closed or a clean `KSPDIR` is provided | `dotnet test Source/Parsek.Tests/Parsek.Tests.csproj` passes, including `InjectAllRecordings` |
 | Orchestrator diff review | Every change | No behavior change; logs/tests meaningful |
 | Refactor checklist review | Every commit or small group | Use `docs/dev/done/refactor/refactor-review-checklist.md` |


### PR DESCRIPTION
## Summary
- Update the refactor-4 inventory/audit to record the merged #620/#621 KSC classifier/reconciler split.
- Update the refactor-4 plan with the completed first Pass 3 LedgerOrchestrator slice and current non-injection gate count.
- Clarify the next Pass 3 split should be a separate proposal/PR, not folded into #621.

## Validation
- Docs-only; no tests run.