### PR TITLE
docs: drop v0.10 label from planned stable-leaf extension

### DIFF
--- a/docs/dev/research/extending-rewind-to-stable-leaves.md
+++ b/docs/dev/research/extending-rewind-to-stable-leaves.md
@@ -907,8 +907,8 @@ In-game tests:
 ### 9.6 Documentation
 
 - Update `parsek-rewind-to-separation-design.md` §1.2 ("Out of scope: stable-end splits") and §7.31 ("intended behaviour, not a limitation") -- both are reversed by this extension.
-- New `parsek-unfinished-flights-extension-design.md` (or fold into a v0.10 revision of the rewind-to-separation doc) once this research note is promoted.
-- `roadmap.md` entry under v0.10+.
+- New `parsek-unfinished-flights-extension-design.md` (or fold into a future revision of the rewind-to-separation doc) once this research note is promoted.
+- `roadmap.md` entry under the next 0.9.x patch (no fixed version number until the patch ships).
 - CHANGELOG: "Unfinished Flights now also surfaces stable leaves left hanging -- probes deployed and forgotten in orbit, stranded EVA kerbals. Each row now has a Fly button and a Seal button (Seal marks the slot final so the rewind point can be cleaned up). Vessels that auto-parachuted to a safe landing still don't appear (they reached a stable conclusion)."
 
 ---
@@ -959,7 +959,7 @@ R17 is ready to promote to a formal design doc, modulo one explicit unresolved i
 
 **Promotion to a formal design doc requires resolving §7.0 (UI layout) and confirming §9.2.1 (v0.9 invocation rewrite is in scope, not a separate v0.9 fix PR).** If the v0.9 invocation change is treated as a prerequisite separate-PR rather than part of this feature, the feature blocks on that PR landing first.
 
-Promote this to `Parsek/docs/parsek-unfinished-flights-stable-leaves-design.md` (or merge into a v0.10 revision of the rewind-to-separation doc) following the design-doc template in `development-workflow.md` step 3. Resolve the §7.0 UI layout question with a UX mock during the design-doc phase. Plan + build cycle follows.
+Promote this to `Parsek/docs/parsek-unfinished-flights-stable-leaves-design.md` (or merge into a future revision of the rewind-to-separation doc) following the design-doc template in `development-workflow.md` step 3. Resolve the §7.0 UI layout question with a UX mock during the design-doc phase. Plan + build cycle follows.
 
 ---
 

--- a/docs/parsek-unfinished-flights-stable-leaves-design.md
+++ b/docs/parsek-unfinished-flights-stable-leaves-design.md
@@ -2,7 +2,7 @@
 
 *Forward-looking design specification for broadening v0.9's Unfinished Flights group to include stable-but-unconcluded leaves of multi-controllable splits — probes deployed and forgotten in orbit, stranded EVA kerbals, sub-orbital coast that never resolved — alongside today's Crashed-only siblings. This document is the contract for the implementation PRs; it does not describe shipped behavior yet.*
 
-*Status: planned for v0.10+. Promoted from the research note `docs/dev/research/extending-rewind-to-stable-leaves.md` (R17, merged in PR #634). Related docs: `parsek-rewind-to-separation-design.md` (the v0.9 source of truth this feature extends), `parsek-recording-finalization-design.md` (terminal-state contract this feature relies on), `parsek-flight-recorder-design.md` (recording DAG, branch-points, chain semantics), `parsek-timeline-design.md` (read-only consumer of ERS).*
+*Status: planned for a 0.9.x patch. Promoted from the research note `docs/dev/research/extending-rewind-to-stable-leaves.md` (R17, merged in PR #634). Related docs: `parsek-rewind-to-separation-design.md` (the v0.9 source of truth this feature extends), `parsek-recording-finalization-design.md` (terminal-state contract this feature relies on), `parsek-flight-recorder-design.md` (recording DAG, branch-points, chain semantics), `parsek-timeline-design.md` (read-only consumer of ERS).*
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -282,7 +282,7 @@ The pre-implementation spec that drove v0.9 is archived at
 
 ---
 
-## Phase 12.5: Unfinished Flights stable-leaf extension (planned, v0.10)
+## Phase 12.5: Unfinished Flights stable-leaf extension (planned, 0.9.x)
 
 Broadens the v0.9 Unfinished Flights group beyond Crashed-only siblings to include stable-but-unconcluded leaves of multi-controllable splits — probes deployed and forgotten in orbit, stranded EVA kerbals, sub-orbital coast that never resolved. Full design: [`docs/parsek-unfinished-flights-stable-leaves-design.md`](parsek-unfinished-flights-stable-leaves-design.md). Pre-implementation research note (R17) at [`docs/dev/research/extending-rewind-to-stable-leaves.md`](dev/research/extending-rewind-to-stable-leaves.md).
 


### PR DESCRIPTION
## Summary

- The Unfinished Flights stable-leaf extension was incorrectly labelled `v0.10` in the roadmap; it's targeted for a 0.9.x patch, so the label is now `0.9.x` (`docs/roadmap.md` Phase 12.5 heading).
- More generally, planned/WIP features shouldn't carry a version number until they actually ship. The promoted design doc (`docs/parsek-unfinished-flights-stable-leaves-design.md` status line) and the originating research note (`docs/dev/research/extending-rewind-to-stable-leaves.md` §9.6 documentation list and §12 recommendation) both repeated the `v0.10` / `v0.10+` label and now read "0.9.x patch" / "future revision" instead.
- No code changes; docs only.

## Test plan

- [ ] `git grep "v0.10"` (and v0.11..v0.16) returns no hits anywhere in the repo.
- [ ] Roadmap Phase 12.5 heading reads `(planned, 0.9.x)`.
- [ ] No completed-version markers (e.g. `v0.7 ✓`, `v0.9 ✓`) were touched — only the planned/WIP labels.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVFji3ZuLXDZXLrTYWEcGs)_