### PR TITLE
Fix watch spike at relative-to-absolute boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,8 @@ All notable changes to Parsek are documented here.
 
 - Re-Fly watch playback no longer treats unresolved, `NaN`, infinite, or negative ghost distances as in-range full-fidelity watched ghosts, preventing watch camera resets caused by stale relative-section transforms after rewind.
 
+- Re-Fly watch playback no longer spikes the watched ghost hundreds of kilometres away at a RELATIVE-to-ABSOLUTE split boundary. Flight playback, loop playback, and watch cutoff distance checks now use the active ABSOLUTE `TrackSection`'s section-local frames when available instead of interpolating through the flat point list, which can contain adjacent RELATIVE metre-offset samples.
+
 - Re-Fly ghost reentry FX no longer activates during hidden spawn priming at the stale KSC-surface pose; first-frame visual FX are suppressed until after the playback transform and ghost activation order are synchronized.
 
 - Breakup coalescing now drops dead-on-arrival controlled children whenever their live vessel is already gone, even if a pre-captured snapshot exists, preventing single-point `Unknown` 0s rows from being committed after Re-Fly merge.

--- a/Source/Parsek.Tests/ZoneRenderingTests.cs
+++ b/Source/Parsek.Tests/ZoneRenderingTests.cs
@@ -223,6 +223,69 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void TryGetAbsoluteSectionPlaybackFrames_AbsoluteSection_UsesSectionFrames()
+        {
+            var sectionFrame = new TrajectoryPoint { ut = 1373.8077522469166, altitude = 53728.0 };
+            var relativeOffsetFrame = new TrajectoryPoint { ut = 1373.7277522469167, altitude = -0.05 };
+            var sectionFrames = new List<TrajectoryPoint> { sectionFrame };
+            var section = new TrackSection
+            {
+                referenceFrame = ReferenceFrame.Absolute,
+                startUT = 1373.8077522469166,
+                endUT = 1423.4706489753898,
+                frames = sectionFrames
+            };
+
+            Assert.True(ParsekFlight.TryGetAbsoluteSectionPlaybackFrames(
+                section,
+                out List<TrajectoryPoint> resolvedFrames));
+            Assert.Same(sectionFrames, resolvedFrames);
+            Assert.Single(resolvedFrames);
+            Assert.Equal(53728.0, resolvedFrames[0].altitude);
+            Assert.DoesNotContain(resolvedFrames, p =>
+                p.ut == relativeOffsetFrame.ut && p.altitude == relativeOffsetFrame.altitude);
+        }
+
+        [Fact]
+        public void TryGetAbsoluteSectionPlaybackFrames_RelativeSection_ReturnsFalse()
+        {
+            var section = new TrackSection
+            {
+                referenceFrame = ReferenceFrame.Relative,
+                frames = new List<TrajectoryPoint>
+                {
+                    new TrajectoryPoint { ut = 1373.7277522469167, altitude = -0.05 }
+                }
+            };
+
+            Assert.False(ParsekFlight.TryGetAbsoluteSectionPlaybackFrames(
+                section,
+                out List<TrajectoryPoint> resolvedFrames));
+            Assert.Null(resolvedFrames);
+        }
+
+        [Fact]
+        public void TryGetAbsoluteSectionPlaybackFrames_AbsoluteSectionWithoutFrames_ReturnsFalse()
+        {
+            var section = new TrackSection
+            {
+                referenceFrame = ReferenceFrame.Absolute
+            };
+
+            Assert.False(ParsekFlight.TryGetAbsoluteSectionPlaybackFrames(
+                section,
+                out List<TrajectoryPoint> resolvedFrames));
+            Assert.Null(resolvedFrames);
+
+            section.frames = new List<TrajectoryPoint>();
+
+            Assert.False(ParsekFlight.TryGetAbsoluteSectionPlaybackFrames(
+                section,
+                out resolvedFrames));
+            Assert.Null(resolvedFrames);
+        }
+
+        [Fact]
         public void ApplyWatchedFullFidelityOverride_Forced_ClearsAllSuppression()
         {
             var (shouldHide, skipPartEvents, skipPositioning) =

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -14468,13 +14468,36 @@ namespace Parsek
                 return;
             }
 
-            bool surfaceSkip = TrajectoryMath.IsSurfaceAtUT(traj.TrackSections, ut);
-            // Phase 1: pass section index so the body-fixed spline lookup can
-            // gate per-section. Falls through to legacy lerp when sections
-            // are absent (-1) — older flat-point recordings remain bit-exact.
             int splineSectionIdx = traj.TrackSections != null && traj.TrackSections.Count > 0
                 ? TrajectoryMath.FindTrackSectionForUT(traj.TrackSections, ut)
                 : -1;
+            if (splineSectionIdx >= 0
+                && TryGetAbsoluteSectionPlaybackFrames(
+                    traj.TrackSections[splineSectionIdx],
+                    out List<TrajectoryPoint> absoluteFrames))
+            {
+                int absolutePlaybackIdx = playbackIdx;
+                InterpolateAndPosition(
+                    state.ghost,
+                    absoluteFrames,
+                    null,
+                    ref absolutePlaybackIdx,
+                    ut,
+                    index * 10000,
+                    out interpResult,
+                    allowActivation: ShouldAutoActivateGhost(state),
+                    skipOrbitSegments: true,
+                    recordingId: traj.RecordingId,
+                    sectionIndex: splineSectionIdx);
+                state.SetInterpolated(interpResult);
+                state.playbackIndex = absolutePlaybackIdx;
+                return;
+            }
+
+            bool surfaceSkip = TrajectoryMath.IsSurfaceAtUT(traj.TrackSections, ut);
+            // Phase 1: pass section index so the body-fixed spline lookup can
+            // gate per-section. Falls through to legacy lerp when sections
+            // are absent (-1) - older flat-point recordings remain bit-exact.
             InterpolateAndPosition(state.ghost, traj.Points, traj.OrbitSegments,
                 ref playbackIdx, ut, index * 10000, out interpResult,
                 allowActivation: ShouldAutoActivateGhost(state), skipOrbitSegments: surfaceSkip,
@@ -16111,6 +16134,19 @@ namespace Parsek
                         LogCheckpointPointPlayback(traj, sectionIdx, section, playbackUT, worldPos);
                         return true;
                     }
+                    else if (TryGetAbsoluteSectionPlaybackFrames(section, out List<TrajectoryPoint> absoluteFrames))
+                    {
+                        // Section-local absolute frames are authoritative at
+                        // frame boundaries. The flat Points list can contain
+                        // adjacent Relative metre-offset samples; interpreting
+                        // those as lat/lon/alt causes planet-scale spikes.
+                        int sectionCachedIndex = 0;
+                        return TryResolvePointWorldPosition(
+                            absoluteFrames,
+                            ref sectionCachedIndex,
+                            playbackUT,
+                            out worldPos);
+                    }
                 }
             }
 
@@ -16144,6 +16180,22 @@ namespace Parsek
             }
 
             return TryResolvePointWorldPosition(points, ref cachedIndex, targetUT, out worldPos);
+        }
+
+        internal static bool TryGetAbsoluteSectionPlaybackFrames(
+            TrackSection section,
+            out List<TrajectoryPoint> frames)
+        {
+            frames = null;
+            if (section.referenceFrame != ReferenceFrame.Absolute
+                || section.frames == null
+                || section.frames.Count == 0)
+            {
+                return false;
+            }
+
+            frames = section.frames;
+            return true;
         }
 
         bool TryResolvePointWorldPosition(
@@ -17551,13 +17603,31 @@ namespace Parsek
                 }
             }
 
+            if (sectionIdx >= 0
+                && TryGetAbsoluteSectionPlaybackFrames(
+                    rec.TrackSections[sectionIdx],
+                    out List<TrajectoryPoint> absoluteSectionFrames))
+            {
+                InterpolateAndPosition(
+                    ghost,
+                    absoluteSectionFrames,
+                    null,
+                    ref playbackIdx,
+                    loopUT,
+                    ghostIdSalt,
+                    out interpResult,
+                    allowActivation: allowActivation,
+                    skipOrbitSegments: true,
+                    recordingId: rec.RecordingId,
+                    sectionIndex: sectionIdx);
+                return;
+            }
+
             // Absolute positioning fallback
             // Phase 1: pass section context for spline lookup. The fallback is
             // the body-fixed loop path, which is exactly where ABSOLUTE
             // ExoPropulsive / ExoBallistic splines are meant to apply.
-            int splineSectionIdx = rec.TrackSections != null && rec.TrackSections.Count > 0
-                ? TrajectoryMath.FindTrackSectionForUT(rec.TrackSections, loopUT)
-                : -1;
+            int splineSectionIdx = sectionIdx;
             InterpolateAndPosition(ghost, rec.Points, rec.OrbitSegments,
                 ref playbackIdx, loopUT, ghostIdSalt, out interpResult,
                 allowActivation: allowActivation,

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -514,6 +514,26 @@ bogus frame followed by within-range frame: counter resets, no exit) and
 `RegisterWatchCutoffSampleAndShouldExit_ConsecutiveCutoffFrames_ExitsAtThreshold`
 (N consecutive cutoff frames trip the exit at exactly the threshold).
 
+**Follow-up (2026-04-29, `logs/2026-04-29_2112_reflight-supersede-investigation`):**
+the same camera-reset symptom reproduced after watching ghost `#0 "Kerbal X"`
+through upper/lower stage separation, but this was not the one-frame
+FloatingOrigin/Krakensbane seam that PR #617 debounced. The cached distance
+stayed bad for the whole 3-frame debounce window, so watch mode correctly
+exited. Root cause: immediately after the RELATIVE-to-ABSOLUTE section
+boundary, ABSOLUTE playback and watch-distance resolution could fall back to
+the flattened `traj.Points` list. That list can contain RELATIVE v6
+anchor-local metre-offset samples adjacent to ABSOLUTE latitude/longitude/
+altitude samples; interpolating across them as body-fixed coordinates produced
+a planet-scale false position, terrain clamp, and ~800 km distance spike even
+though the section-local ABSOLUTE frame was around 54 km altitude. Fix:
+flight playback, loop playback, and watch cutoff distance resolution now use
+the active ABSOLUTE `TrackSection.frames` when present, reserving the flat-list
+path for legacy/no-section data only. Regression coverage:
+`ZoneRenderingTests.TryGetAbsoluteSectionPlaybackFrames_AbsoluteSection_UsesSectionFrames`
+and
+`ZoneRenderingTests.TryGetAbsoluteSectionPlaybackFrames_RelativeSection_ReturnsFalse`
+plus the empty-frame guard.
+
 ## 626. Watch-mode W->W switches restored a stale world camera direction instead of preserving the local viewing angle
 
 When the user clicked Watch on ghost B while watching ghost A, returned to A


### PR DESCRIPTION
## Summary
- route ABSOLUTE flight and loop playback through active TrackSection frames when available
- route watch cutoff distance resolution through the same section-local ABSOLUTE frames
- add regression coverage for avoiding RELATIVE offset samples in ABSOLUTE section playback

## Validation
- dotnet test Source\Parsek.Tests\Parsek.Tests.csproj --filter ZoneRenderingTests
- dotnet test Source\Parsek.Tests\Parsek.Tests.csproj