### PR TITLE
Extract facility game state recorder

### DIFF
--- a/Source/Parsek/GameStateFacilityRecorder.cs
+++ b/Source/Parsek/GameStateFacilityRecorder.cs
@@ -1,0 +1,204 @@
+using System;
+using System.Collections.Generic;
+
+namespace Parsek
+{
+    internal sealed class GameStateFacilityRecorder
+    {
+        private readonly GameStateRecorder owner;
+
+        // Cached facility/building state for polling on scene change.
+        private readonly Dictionary<string, float> lastFacilityLevels = new Dictionary<string, float>();
+        private readonly Dictionary<string, bool> lastBuildingIntact = new Dictionary<string, bool>();
+
+        internal GameStateFacilityRecorder(GameStateRecorder owner)
+        {
+            this.owner = owner ?? throw new ArgumentNullException(nameof(owner));
+        }
+
+        internal void SeedFacilityCacheFromCurrentState()
+        {
+            // Facility levels
+            if (ScenarioUpgradeableFacilities.protoUpgradeables != null)
+            {
+                foreach (var kvp in ScenarioUpgradeableFacilities.protoUpgradeables)
+                {
+                    if (kvp.Value != null && kvp.Value.facilityRefs != null &&
+                        kvp.Value.facilityRefs.Count > 0)
+                    {
+                        var facility = kvp.Value.facilityRefs[0];
+                        if (facility != null)
+                            lastFacilityLevels[kvp.Key] = facility.GetNormLevel();
+                    }
+                }
+            }
+
+            // Building intact states
+            var destructibles = UnityEngine.Object.FindObjectsOfType<DestructibleBuilding>();
+            if (destructibles != null)
+            {
+                foreach (var db in destructibles)
+                {
+                    if (db != null && !string.IsNullOrEmpty(db.id))
+                        lastBuildingIntact[db.id] = !db.IsDestroyed;
+                }
+            }
+
+            ParsekLog.Info("GameStateRecorder", $"Game state: Facility cache seeded from current state " +
+                $"({lastFacilityLevels.Count} facilities, {lastBuildingIntact.Count} buildings)");
+        }
+
+        internal void PollFacilityState()
+        {
+            double ut = Planetarium.GetUniversalTime();
+            int facilitiesChecked = 0;
+            int buildingsChecked = 0;
+            int eventsEmitted = 0;
+
+            // Check facility levels
+            if (ScenarioUpgradeableFacilities.protoUpgradeables != null)
+            {
+                foreach (var kvp in ScenarioUpgradeableFacilities.protoUpgradeables)
+                {
+                    if (kvp.Value == null || kvp.Value.facilityRefs == null ||
+                        kvp.Value.facilityRefs.Count == 0) continue;
+
+                    var facility = kvp.Value.facilityRefs[0];
+                    if (facility == null) continue;
+
+                    facilitiesChecked++;
+                    float currentLevel = facility.GetNormLevel();
+                    float cachedLevel;
+
+                    if (lastFacilityLevels.TryGetValue(kvp.Key, out cachedLevel))
+                    {
+                        if (Math.Abs(currentLevel - cachedLevel) > 0.001f)
+                        {
+                            var eventType = currentLevel > cachedLevel
+                                ? GameStateEventType.FacilityUpgraded
+                                : GameStateEventType.FacilityDowngraded;
+
+                            var evt = new GameStateEvent
+                            {
+                                ut = ut,
+                                eventType = eventType,
+                                key = kvp.Key,
+                                valueBefore = cachedLevel,
+                                valueAfter = currentLevel
+                            };
+                            owner.EmitFacilityEvent(ref evt, eventType.ToString());
+                            eventsEmitted++;
+                            ParsekLog.Info("GameStateRecorder", $"Game state: {eventType} '{kvp.Key}' {cachedLevel:F2} → {currentLevel:F2}");
+
+                            // #553 follow-up: gate on ShouldForwardDirectLedgerEvent so
+                            // untagged pre-recording FLIGHT facility upgrades reach the
+                            // ledger too. Only FacilityUpgraded forwards (downgrades are
+                            // informational).
+                            if (eventType == GameStateEventType.FacilityUpgraded
+                                && owner.ShouldForwardFacilityLedgerEvent(evt.recordingId))
+                                LedgerOrchestrator.OnKscSpending(evt);
+                        }
+                    }
+
+                    lastFacilityLevels[kvp.Key] = currentLevel;
+                }
+            }
+
+            // Check building intact states
+            var destructibles = UnityEngine.Object.FindObjectsOfType<DestructibleBuilding>();
+            if (destructibles != null)
+            {
+                foreach (var db in destructibles)
+                {
+                    if (db == null || string.IsNullOrEmpty(db.id)) continue;
+
+                    buildingsChecked++;
+                    bool currentIntact = !db.IsDestroyed;
+                    bool cachedIntact;
+
+                    if (lastBuildingIntact.TryGetValue(db.id, out cachedIntact))
+                    {
+                        if (currentIntact != cachedIntact)
+                        {
+                            var eventType = currentIntact
+                                ? GameStateEventType.BuildingRepaired
+                                : GameStateEventType.BuildingDestroyed;
+
+                            var bldEvt = new GameStateEvent
+                            {
+                                ut = ut,
+                                eventType = eventType,
+                                key = db.id
+                            };
+                            owner.EmitFacilityEvent(ref bldEvt, eventType.ToString());
+                            eventsEmitted++;
+                            ParsekLog.Info("GameStateRecorder", $"Game state: {eventType} '{db.id}'");
+                        }
+                    }
+
+                    lastBuildingIntact[db.id] = currentIntact;
+                }
+            }
+
+            ParsekLog.Verbose("GameStateRecorder",
+                $"Facility poll pass: facilitiesChecked={facilitiesChecked}, buildingsChecked={buildingsChecked}, " +
+                $"eventsEmitted={eventsEmitted}");
+        }
+
+        internal static List<GameStateEvent> CheckFacilityTransitions(
+            Dictionary<string, float> cached, Dictionary<string, float> current, double ut)
+        {
+            var result = new List<GameStateEvent>();
+
+            foreach (var kvp in current)
+            {
+                float cachedLevel;
+                if (cached.TryGetValue(kvp.Key, out cachedLevel))
+                {
+                    if (Math.Abs(kvp.Value - cachedLevel) > 0.001f)
+                    {
+                        result.Add(new GameStateEvent
+                        {
+                            ut = ut,
+                            eventType = kvp.Value > cachedLevel
+                                ? GameStateEventType.FacilityUpgraded
+                                : GameStateEventType.FacilityDowngraded,
+                            key = kvp.Key,
+                            valueBefore = cachedLevel,
+                            valueAfter = kvp.Value
+                        });
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        internal static List<GameStateEvent> CheckBuildingTransitions(
+            Dictionary<string, bool> cached, Dictionary<string, bool> current, double ut)
+        {
+            var result = new List<GameStateEvent>();
+
+            foreach (var kvp in current)
+            {
+                bool cachedIntact;
+                if (cached.TryGetValue(kvp.Key, out cachedIntact))
+                {
+                    if (kvp.Value != cachedIntact)
+                    {
+                        result.Add(new GameStateEvent
+                        {
+                            ut = ut,
+                            eventType = kvp.Value
+                                ? GameStateEventType.BuildingRepaired
+                                : GameStateEventType.BuildingDestroyed,
+                            key = kvp.Key
+                        });
+                    }
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/Source/Parsek/GameStateRecorder.cs
+++ b/Source/Parsek/GameStateRecorder.cs
@@ -261,10 +261,7 @@ namespace Parsek
         }
 
         private bool subscribed = false;
-
-        // Cached facility/building state for polling on scene change
-        private Dictionary<string, float> lastFacilityLevels = new Dictionary<string, float>();
-        private Dictionary<string, bool> lastBuildingIntact = new Dictionary<string, bool>();
+        private readonly GameStateFacilityRecorder facilityRecorder;
 
         // Crew status debouncing (filters EVA start/board bounce: Assigned→Available→Assigned)
         private struct PendingCrewEvent
@@ -287,6 +284,11 @@ namespace Parsek
         private const float ScienceCaptureMatchDeltaTolerance = 0.05f;
         private const float ReputationThreshold = 1.0f;
         private const float ReputationThresholdEpsilon = 0.001f;
+
+        internal GameStateRecorder()
+        {
+            facilityRecorder = new GameStateFacilityRecorder(this);
+        }
 
         #region Subscription Management
 
@@ -1890,34 +1892,7 @@ namespace Parsek
         /// </summary>
         internal void SeedFacilityCacheFromCurrentState()
         {
-            // Facility levels
-            if (ScenarioUpgradeableFacilities.protoUpgradeables != null)
-            {
-                foreach (var kvp in ScenarioUpgradeableFacilities.protoUpgradeables)
-                {
-                    if (kvp.Value != null && kvp.Value.facilityRefs != null &&
-                        kvp.Value.facilityRefs.Count > 0)
-                    {
-                        var facility = kvp.Value.facilityRefs[0];
-                        if (facility != null)
-                            lastFacilityLevels[kvp.Key] = facility.GetNormLevel();
-                    }
-                }
-            }
-
-            // Building intact states
-            var destructibles = UnityEngine.Object.FindObjectsOfType<DestructibleBuilding>();
-            if (destructibles != null)
-            {
-                foreach (var db in destructibles)
-                {
-                    if (db != null && !string.IsNullOrEmpty(db.id))
-                        lastBuildingIntact[db.id] = !db.IsDestroyed;
-                }
-            }
-
-            ParsekLog.Info("GameStateRecorder", $"Game state: Facility cache seeded from current state " +
-                $"({lastFacilityLevels.Count} facilities, {lastBuildingIntact.Count} buildings)");
+            facilityRecorder.SeedFacilityCacheFromCurrentState();
         }
 
         /// <summary>
@@ -1926,99 +1901,7 @@ namespace Parsek
         /// </summary>
         internal void PollFacilityState()
         {
-            double ut = Planetarium.GetUniversalTime();
-            int facilitiesChecked = 0;
-            int buildingsChecked = 0;
-            int eventsEmitted = 0;
-
-            // Check facility levels
-            if (ScenarioUpgradeableFacilities.protoUpgradeables != null)
-            {
-                foreach (var kvp in ScenarioUpgradeableFacilities.protoUpgradeables)
-                {
-                    if (kvp.Value == null || kvp.Value.facilityRefs == null ||
-                        kvp.Value.facilityRefs.Count == 0) continue;
-
-                    var facility = kvp.Value.facilityRefs[0];
-                    if (facility == null) continue;
-
-                    facilitiesChecked++;
-                    float currentLevel = facility.GetNormLevel();
-                    float cachedLevel;
-
-                    if (lastFacilityLevels.TryGetValue(kvp.Key, out cachedLevel))
-                    {
-                        if (Math.Abs(currentLevel - cachedLevel) > 0.001f)
-                        {
-                            var eventType = currentLevel > cachedLevel
-                                ? GameStateEventType.FacilityUpgraded
-                                : GameStateEventType.FacilityDowngraded;
-
-                            var evt = new GameStateEvent
-                            {
-                                ut = ut,
-                                eventType = eventType,
-                                key = kvp.Key,
-                                valueBefore = cachedLevel,
-                                valueAfter = currentLevel
-                            };
-                            Emit(ref evt, eventType.ToString());
-                            eventsEmitted++;
-                            ParsekLog.Info("GameStateRecorder", $"Game state: {eventType} '{kvp.Key}' {cachedLevel:F2} → {currentLevel:F2}");
-
-                            // #553 follow-up: gate on ShouldForwardDirectLedgerEvent so
-                            // untagged pre-recording FLIGHT facility upgrades reach the
-                            // ledger too. Only FacilityUpgraded forwards (downgrades are
-                            // informational).
-                            if (eventType == GameStateEventType.FacilityUpgraded
-                                && ShouldForwardDirectLedgerEvent(evt.recordingId, HasLiveRecorder()))
-                                LedgerOrchestrator.OnKscSpending(evt);
-                        }
-                    }
-
-                    lastFacilityLevels[kvp.Key] = currentLevel;
-                }
-            }
-
-            // Check building intact states
-            var destructibles = UnityEngine.Object.FindObjectsOfType<DestructibleBuilding>();
-            if (destructibles != null)
-            {
-                foreach (var db in destructibles)
-                {
-                    if (db == null || string.IsNullOrEmpty(db.id)) continue;
-
-                    buildingsChecked++;
-                    bool currentIntact = !db.IsDestroyed;
-                    bool cachedIntact;
-
-                    if (lastBuildingIntact.TryGetValue(db.id, out cachedIntact))
-                    {
-                        if (currentIntact != cachedIntact)
-                        {
-                            var eventType = currentIntact
-                                ? GameStateEventType.BuildingRepaired
-                                : GameStateEventType.BuildingDestroyed;
-
-                            var bldEvt = new GameStateEvent
-                            {
-                                ut = ut,
-                                eventType = eventType,
-                                key = db.id
-                            };
-                            Emit(ref bldEvt, eventType.ToString());
-                            eventsEmitted++;
-                            ParsekLog.Info("GameStateRecorder", $"Game state: {eventType} '{db.id}'");
-                        }
-                    }
-
-                    lastBuildingIntact[db.id] = currentIntact;
-                }
-            }
-
-            ParsekLog.Verbose("GameStateRecorder",
-                $"Facility poll pass: facilitiesChecked={facilitiesChecked}, buildingsChecked={buildingsChecked}, " +
-                $"eventsEmitted={eventsEmitted}");
+            facilityRecorder.PollFacilityState();
         }
 
         #endregion
@@ -2032,30 +1915,7 @@ namespace Parsek
         internal static List<GameStateEvent> CheckFacilityTransitions(
             Dictionary<string, float> cached, Dictionary<string, float> current, double ut)
         {
-            var result = new List<GameStateEvent>();
-
-            foreach (var kvp in current)
-            {
-                float cachedLevel;
-                if (cached.TryGetValue(kvp.Key, out cachedLevel))
-                {
-                    if (Math.Abs(kvp.Value - cachedLevel) > 0.001f)
-                    {
-                        result.Add(new GameStateEvent
-                        {
-                            ut = ut,
-                            eventType = kvp.Value > cachedLevel
-                                ? GameStateEventType.FacilityUpgraded
-                                : GameStateEventType.FacilityDowngraded,
-                            key = kvp.Key,
-                            valueBefore = cachedLevel,
-                            valueAfter = kvp.Value
-                        });
-                    }
-                }
-            }
-
-            return result;
+            return GameStateFacilityRecorder.CheckFacilityTransitions(cached, current, ut);
         }
 
         /// <summary>
@@ -2065,30 +1925,19 @@ namespace Parsek
         internal static List<GameStateEvent> CheckBuildingTransitions(
             Dictionary<string, bool> cached, Dictionary<string, bool> current, double ut)
         {
-            var result = new List<GameStateEvent>();
-
-            foreach (var kvp in current)
-            {
-                bool cachedIntact;
-                if (cached.TryGetValue(kvp.Key, out cachedIntact))
-                {
-                    if (kvp.Value != cachedIntact)
-                    {
-                        result.Add(new GameStateEvent
-                        {
-                            ut = ut,
-                            eventType = kvp.Value
-                                ? GameStateEventType.BuildingRepaired
-                                : GameStateEventType.BuildingDestroyed,
-                            key = kvp.Key
-                        });
-                    }
-                }
-            }
-
-            return result;
+            return GameStateFacilityRecorder.CheckBuildingTransitions(cached, current, ut);
         }
 
         #endregion
+
+        internal void EmitFacilityEvent(ref GameStateEvent evt, string source)
+        {
+            Emit(ref evt, source);
+        }
+
+        internal bool ShouldForwardFacilityLedgerEvent(string recordingId)
+        {
+            return ShouldForwardDirectLedgerEvent(recordingId, HasLiveRecorder());
+        }
     }
 }

--- a/docs/dev/plans/game-state-recorder-handler-owner-refactor.md
+++ b/docs/dev/plans/game-state-recorder-handler-owner-refactor.md
@@ -1,0 +1,179 @@
+# GameStateRecorder Facility Polling Owner Extraction Plan
+
+Status: facility polling slice implemented in this worktree.
+
+Worktree: `C:\Users\vlad3\Documents\Code\Parsek\Parsek-proposal-gamestate-handlers`
+
+## Goal
+
+Move one coherent `GameStateRecorder` handler family into an internal helper/owner with zero behavior changes.
+
+This is slice 1 of a possible broader handler-owner refactor. Contracts, R&D, currency, milestones, and strategies are out of scope for this slice; they are mapped below only to define boundaries.
+
+The refactor must preserve:
+
+- `GameEvents` subscription targets and ordering.
+- Emitted `GameStateEvent` fields.
+- Suppression guards.
+- Recording tags and `Emit` behavior.
+- Event source strings.
+- Logs and log levels.
+- Direct ledger forwarding predicates.
+- Emit-before-ledger ordering.
+
+## Ownership Map
+
+`GameStateRecorder` remains the owner of cross-family policy:
+
+- `Subscribe` / `Unsubscribe`.
+- `Emit`.
+- recording tag resolution.
+- `SuppressCrewEvents`, `SuppressResourceEvents`, and `IsReplayingActions`.
+- `ResetForTesting`.
+- `ShouldForwardDirectLedgerEvent`.
+
+Handler family ownership:
+
+- Contracts: own contract payloads, contract snapshots, and direct KSC ledger forwarding.
+- Tech and part purchase: own R&D capture. Keep part-purchase bypass seams compatible with existing tests.
+- Funds, science, reputation, and science subjects: move together only. `OnScienceChanged` owns `latestScienceChangeCapture`, consumed by `OnScienceReceived`.
+- Progress milestones: keep in `GameStateRecorder` for now. This family is tightly coupled to Harmony static entry points and the pending reward map.
+- Strategy lifecycle / KSC actions: second-wave candidate only. Static Harmony/test entry points make this higher risk than facility polling.
+- Facility polling: best first slice. This family owns live facility/building cache state, seed/poll behavior, and pure transition helpers.
+
+## Best First Slice
+
+Move only facility polling into an internal owner, e.g. `GameStateFacilityRecorder`.
+
+`GameStateRecorder` should keep forwarding methods with the existing names:
+
+- `SeedFacilityCacheFromCurrentState()` as an instance facade.
+- `PollFacilityState()` as an instance facade.
+- `CheckFacilityTransitions(...)` as a static facade.
+- `CheckBuildingTransitions(...)` as a static facade.
+
+The new owner should own:
+
+- `lastFacilityLevels`.
+- `lastBuildingIntact`.
+- live facility/building seeding.
+- live facility/building polling.
+- pure transition helpers.
+
+Important implementation constraint: create one persistent `GameStateFacilityRecorder` instance per `GameStateRecorder`. Do not construct the helper per method call. `SeedFacilityCacheFromCurrentState()` and `PollFacilityState()` must share the same cache dictionaries.
+
+The helper should take the parent `GameStateRecorder` in its constructor and call back into the parent for cross-family policy:
+
+- `Emit(ref evt, ...)`
+- `ShouldForwardDirectLedgerEvent(...)`
+- `HasLiveRecorder()`
+
+Do not add new static policy seams for this slice. The helper owns only facility-polling state and mechanics; `GameStateRecorder` still owns event emission, recording tags, and ledger-forwarding policy.
+
+The existing call shape must remain unchanged:
+
+- `ParsekScenario` keeps calling `stateRecorder.SeedFacilityCacheFromCurrentState()` before `Subscribe()`.
+- `Subscribe()` keeps calling `PollFacilityState()` after resource seeding.
+- Tests keep calling `GameStateRecorder.CheckFacilityTransitions(...)` and `GameStateRecorder.CheckBuildingTransitions(...)`.
+
+Keep the live polling loops mechanically intact. Do not rebuild the live path through the pure dictionary helpers, because that risks changing event order, first-seen cache behavior, cache update timing, logs, or the `FacilityUpgraded`-only ledger forwarding gate.
+
+Preserve the existing `"GameStateRecorder"` log subsystem tag for moved facility logs. Do not rename these to `"GameStateFacilityRecorder"`:
+
+- `"Game state: Facility cache seeded from current state ..."`
+- `"Game state: {eventType} '{key}' ..."`
+- `"Facility poll pass: facilitiesChecked=..."`
+
+No new `ResetForTesting` hook is needed. `GameStateRecorder.ResetForTesting()` is static and does not touch the instance facility caches today; after extraction the helper caches still live on the recorder instance and are discarded with it.
+
+## Do-Not-Move Boundaries
+
+Do not move or alter:
+
+- `Subscribe` / `Unsubscribe` registration lines.
+- `Emit`.
+- recording tag resolution.
+- suppression flags.
+- `ShouldForwardDirectLedgerEvent`.
+- `OnScienceChanged` without `OnScienceReceived`.
+- milestone static APIs unless exact `GameStateRecorder.*` facades remain.
+- log strings, log levels, event source strings, or detail formats.
+- the `"GameStateRecorder"` log subsystem tag.
+- direct ledger forwarding order.
+
+## Validation
+
+Focused validation:
+
+```bash
+dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter "FullyQualifiedName~GameStateEventTests|FullyQualifiedName~GameStateEventConverterTests|FullyQualifiedName~DiscardFateTests|FullyQualifiedName~CommittedActionTests|FullyQualifiedName~QuickloadResumeTests|FullyQualifiedName~GameStateStoreExtractedTests|FullyQualifiedName~ResourceBudgetTests"
+```
+
+Full validation:
+
+```bash
+dotnet test Source/Parsek.Tests/Parsek.Tests.csproj
+dotnet build Source/Parsek/Parsek.csproj
+```
+
+The focused filter intentionally includes `GameStateEventTests`, which pins `CheckFacilityTransitions` and `CheckBuildingTransitions`.
+
+If the local environment blocks full xUnit execution, use the repo fallback:
+
+```bash
+dotnet build Source/Parsek.Tests/Parsek.Tests.csproj --no-restore
+```
+
+Record the environment blocker clearly if that fallback is needed.
+
+## Rollback
+
+Before commit:
+
+```bash
+git restore Source/Parsek/GameStateRecorder.cs
+git restore Source/Parsek/GameStateFacilityRecorder.cs
+```
+
+After commit:
+
+```bash
+git revert <commit>
+```
+
+This slice must not include schema, enum, serialization, or subscription behavior changes, so rollback should not require save migration or cleanup logic.
+
+## Review Result
+
+A separate GPT-5.5 xhigh review agreed that the facility-first boundary is clean after these corrections:
+
+- Add `GameStateEventTests` to targeted validation.
+- Require a single persistent facility owner instance per `GameStateRecorder`.
+- Keep the live facility/building polling loops verbatim instead of rebuilding them through pure transition helpers.
+
+Additional review tightening:
+
+- Use an explicit parent back-reference for `Emit`, tag/ledger policy, and live-recorder checks.
+- Preserve instance facades for live calls and static facades for pure helper tests.
+- Do not add reset plumbing for instance facility caches.
+- Preserve the `"GameStateRecorder"` subsystem tag on moved logs.
+
+Do not start a second slice until the facility extraction has shipped cleanly with no regressions in `GameStateEventTests` and the full xUnit suite on the target branch.
+
+## Implementation Result
+
+Implemented slice 1 by adding `GameStateFacilityRecorder` and keeping `GameStateRecorder` instance/static facades intact.
+
+Validation run:
+
+```bash
+dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter "FullyQualifiedName~GameStateEventTests|FullyQualifiedName~GameStateEventConverterTests|FullyQualifiedName~DiscardFateTests|FullyQualifiedName~CommittedActionTests|FullyQualifiedName~QuickloadResumeTests|FullyQualifiedName~GameStateStoreExtractedTests|FullyQualifiedName~ResourceBudgetTests"
+dotnet test Source/Parsek.Tests/Parsek.Tests.csproj
+dotnet build Source/Parsek/Parsek.csproj
+```
+
+Results:
+
+- Focused xUnit: 425 passed.
+- Full xUnit: 9679 passed.
+- `Parsek.csproj` build: succeeded with 0 warnings and 0 errors.


### PR DESCRIPTION
## Summary
- Extract facility/building polling state and live polling loops into GameStateFacilityRecorder.
- Keep GameStateRecorder instance/static facades for existing call sites and tests.
- Add the reviewed extraction plan with validation notes.

## Validation
- Focused xUnit filter: 425 passed.
- Full xUnit suite: 9679 passed.
- dotnet build Source/Parsek/Parsek.csproj: succeeded with 0 warnings and 0 errors.