### PR TITLE
docs: reconcile roadmap and refactor inventory

### DIFF
--- a/docs/dev/plans/refactor-remaining-opportunities.md
+++ b/docs/dev/plans/refactor-remaining-opportunities.md
@@ -1,27 +1,53 @@
 # Remaining Refactor Opportunities
 
-Date: 2026-04-29
+Date: 2026-04-30
 
-Status: active reference after the Refactor-4 archive. This is not approval to
-move production code. Every item below still needs a focused proposal, explicit
-scope, and review before implementation.
+Status: active reference after the Refactor-4 archive and the merged
+post-archive cleanup work. This is not approval to move production code. Every
+item below still needs a focused proposal, explicit scope, and review before
+implementation.
 
-Refactor-4 completed the behavior-neutral owner splits that were ready to land:
-storage and sidecar owners, tree record codec extraction, KSC action
-classifier/reconciler extraction, post-walk reconciliation extraction,
-LedgerOrchestrator load migration, recovery/rollout helpers,
-FacilityStatePatcher, GameStateFacilityRecorder, RecordingGroupStore, and
-RecordingsTableFormatters. The completed planning docs are archived under
-`docs/dev/done/refactor/`.
+This document is intentionally a short live inventory. Completed design and
+implementation notes are archived under `docs/dev/done/refactor/`; do not
+re-open those slices unless a new behavior-changing design explicitly requires
+it.
 
-The remaining opportunities below are structural only. They should preserve
-serialized formats, log text and tags, event ordering, mutation ordering,
-reflection behavior, public/internal compatibility facades, and existing test
-surfaces unless a separate behavior-changing design is approved first.
+## Already Landed
 
-## Best Orthogonal Candidates
+The previous inventory listed several areas that are now complete or covered by
+new owner seams. Treat these as closed for generic refactor planning:
 
-### KspStatePatcher State Families
+- Recording storage and sidecar ownership: `SidecarFileCommitBatch`,
+  `RecordingSidecarStore`, `TrajectoryTextSidecarCodec`,
+  `RecordingManifestCodec`, `RecordingTreeRecordCodec`, and
+  `SnapshotSidecarCodec` own the current sidecar/codecs surface behind
+  compatibility wrappers.
+- Recording group ownership: `RecordingGroupStore` owns auto-generated tree
+  groups, standalone auto-assignment, group naming, and group mutation helpers.
+- Ledger decomposition: `KscActionExpectationClassifier`,
+  `KscActionReconciler`, `PostWalkActionReconciler`, `LedgerLoadMigration`,
+  `LedgerRecoveryFundsPairing`, and `LedgerRolloutAdoption` cover the
+  high-value low-risk LedgerOrchestrator slices.
+- KSP state / game-state first slices: `FacilityStatePatcher` and
+  `GameStateFacilityRecorder` own the facility patching and facility polling
+  slices. Other state and event families remain listed below only when a crisp
+  proposal is still useful.
+- Thin UI presentation seams: `TestRunnerPresentation`,
+  `SettingsWindowPresentation`, `SpawnControlPresentation`,
+  `GroupPickerPresentation`, `RecordingsTableFormatters`, and
+  `UnfinishedFlightsGroup` cover the pure decision/formatting seams that were
+  safe to extract without moving broad IMGUI state.
+- Recording finalization support: `RecordingFinalizationCache`,
+  `RecordingFinalizationCacheProducer`, `RecordingFinalizationCacheApplier`,
+  and `IncompleteBallisticSceneExitFinalizer` now own the reliability hooks
+  that used to make finalization look like one generic extraction target.
+- Runtime builder seams: `EngineFxBuilder` and `GhostVisualBuilder` now have
+  explicit headless ownership-style coverage for important builder decisions.
+  Further runtime/rendering movement is still coupled and remains below.
+
+## Best Remaining Candidates
+
+### KspStatePatcher Non-Facility Families
 
 Done: `FacilityStatePatcher`.
 
@@ -32,9 +58,10 @@ Remaining candidates:
 - Milestones/progress patch helpers.
 - Contract patch helpers.
 
-Why it remains: `KspStatePatcher.PatchAll` still owns several distinct state
-families after the facilities split. Each family has clear method clusters, but
-the patch order and suppression scope are behavior-critical.
+Why it remains: `KspStatePatcher.PatchAll` still owns several state families
+after the facilities split. The remaining methods are coherent clusters, but
+the patch order, suppression scope, singleton readiness probes, and exact log
+text are behavior-critical.
 
 Proposal requirements:
 
@@ -44,7 +71,7 @@ Proposal requirements:
 - List every reflection and UI mutation dependency for the chosen family.
 - Validate with focused patcher tests plus the full non-injection xUnit gate.
 
-### GameStateRecorder Handler Families
+### GameStateRecorder Non-Facility Handler Families
 
 Done: `GameStateFacilityRecorder`.
 
@@ -56,9 +83,9 @@ Remaining candidates:
 - Progress/milestone handlers.
 - Strategy and KSC action handlers.
 
-Why it remains: `GameStateRecorder` still contains multiple event-handler
-families with subscription, suppression, emit, and ledger-forwarding rules. A
-handler-family extraction can be low risk only if it is scoped around one
+Why it remains: `GameStateRecorder` still owns multiple event-handler families
+with subscription, suppression, emit, and ledger-forwarding rules. A handler
+family extraction can be low risk only if it is scoped around one
 subscription/emit cluster.
 
 Proposal requirements:
@@ -70,7 +97,7 @@ Proposal requirements:
 - Validate with focused recorder/ledger tests and the full non-injection xUnit
   gate.
 
-### RecordingStore Orchestration
+### RecordingStore Remaining Orchestration
 
 Done: sidecar commit/store/codecs, manifest codec, tree record codec, and
 `RecordingGroupStore`.
@@ -79,13 +106,14 @@ Remaining candidates:
 
 - Optimizer orchestration and commit-time optimizer plumbing.
 - Deletion and cleanup orchestration.
-- Rewind/recording finalization orchestration.
+- Rewind/load invocation helpers that still live behind `RecordingStore`.
 - State-version and timeline notification ownership.
 
 Why it remains: `RecordingStore` has fewer storage responsibilities than before,
-but still mixes orchestration, lifecycle, and UI-facing compatibility state.
-These slices should avoid active unfinished-flight or recording-tree work unless
-that work has merged and the proposal is rebased.
+but still mixes timeline hub state, lifecycle orchestration, and UI-facing
+compatibility facades. These slices should avoid active Re-Fly, unfinished-flight,
+or Phase 13 logistics work unless that work has merged and the proposal is
+rebased.
 
 Proposal requirements:
 
@@ -97,33 +125,22 @@ Proposal requirements:
 - Validate with focused recording-store/tree tests and the full non-injection
   xUnit gate.
 
-### RecordingsTableUI Row And Tree Surfaces
+## Coupled Or Lower-Priority Candidates
 
-Done: `RecordingsTableFormatters`.
+### RecordingsTableUI Stateful Surfaces
+
+Done: `RecordingsTableFormatters` and `UnfinishedFlightsGroup`.
 
 Remaining candidates:
 
 - Row rendering for recording entries.
 - Group tree rendering.
-- Unfinished Flights group rendering and action cells.
 - Recording block/chain rendering.
-- Loop period editing cell.
+- Loop period editing cell and edit-focus state.
 
-Why it remains: the formatter split lowered the risk for future UI work, but
-the table still has broad shared IMGUI state and callback coupling. This area is
-not a good parallel target while unfinished-flight UI changes are active.
-
-Proposal requirements:
-
-- Start with a field and callback ownership map.
-- Keep all visible labels, tooltips, sort behavior, selection behavior, and
-  button enablement stable.
-- Prefer a render-helper owner before moving stateful editor/session logic.
-- Validate with focused formatter/table tests where possible, then run the full
-  non-injection xUnit gate. Runtime visual review is required for visible UI
-  changes.
-
-## Lower-Priority Or Coupled Candidates
+Why it is coupled: the table still has broad shared IMGUI state and callback
+coupling. The easy pure helpers have already moved; future work needs a field
+and callback ownership map before touching code.
 
 ### LedgerOrchestrator Residual Bands
 
@@ -139,24 +156,24 @@ Remaining candidates only if a crisp owner emerges:
   paths.
 - Tree-commit notification helpers.
 
-Why it is lower priority: the highest-value low-risk LedgerOrchestrator slices
-have already landed. Further splits risk crossing ledger mutation order,
+Why it is lower priority: the highest-value low-risk `LedgerOrchestrator`
+slices have already landed. Further splits risk crossing ledger mutation order,
 resource/currency ordering, patch timing, and logging policy boundaries.
 
 ### Runtime, Ghost, And Rendering Owners
 
 Candidates:
 
-- `GhostVisualBuilder`
 - `GhostPlaybackEngine`
 - `GhostMapPresence`
 - `ParsekKSC`
-- `EngineFxBuilder`
 - `VesselGhoster`
+- deeper `EngineFxBuilder` / `GhostVisualBuilder` behavior movement beyond the
+  current test seams
 
 Why it is coupled: these files touch runtime-only KSP behavior, rendering, map
 presence, and ghost trajectory work. They should be deferred while ghost
-trajectory/rendering branches are active.
+trajectory/rendering or Re-Fly hardening branches are active.
 
 Proposal requirements:
 
@@ -186,12 +203,13 @@ Candidates:
 
 - Rewind invocation helpers.
 - Scenario lifecycle hooks in `ParsekScenario`.
-- Finalization producer/applier boundaries.
+- Remaining finalization boundary cleanup after the cache producer/applier split.
 - `ParsekFlight` finalization and checkpoint helpers.
 
-Why it is coupled: these paths interact with unfinished-flight behavior, rewind
-point routing, save/load lifecycle, and scene transitions. They need checkpoint
-ownership and rollback planning before code moves.
+Why it is coupled: these paths interact with unfinished-flight behavior, Rewind
+Point routing, save/load lifecycle, scene transitions, and active Re-Fly
+session state. They need checkpoint ownership and rollback planning before code
+moves.
 
 ## Cross-Cutting Follow-Ups
 
@@ -200,13 +218,12 @@ ownership and rollback planning before code moves.
   `WatchModeController`, and `GhostPlaybackEngine`.
 - Audit magic thresholds, literal reason keys, and rate-limit keys after
   `ParsekConfig` centralization.
-- Identify any remaining compatibility facades that can be removed only after
-  source and reflection call sites move.
+- Identify compatibility facades that can be removed only after source and
+  reflection call sites move.
 
 ## Suggested Next Proposal
 
-The lowest-overlap next proposal is a remaining `KspStatePatcher` state-family
-map or a `GameStateRecorder` handler-family map, depending on which nearby
-branches are active. Avoid `RecordingStore`, `RecordingsTableUI`, ghost
-rendering, and rewind/finalization slices while unfinished-flight or ghost
-trajectory work is still moving.
+The lowest-overlap next proposal is a non-facility `KspStatePatcher` state
+family map or a non-facility `GameStateRecorder` handler-family map. Avoid
+`RecordingStore`, `RecordingsTableUI`, ghost rendering, and rewind/finalization
+slices while Phase 13 logistics prerequisites or Re-Fly follow-ups are moving.

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -131,13 +131,13 @@ fallback or warning semantics.
 ## 637. Track remaining refactor opportunities after Refactor-4 archive
 
 **Status:** TODO - active reference in
-`docs/dev/plans/refactor-remaining-opportunities.md`.
+`docs/dev/plans/refactor-remaining-opportunities.md`, reconciled 2026-04-30.
 
 Refactor-4's completed planning docs are archived under
 `docs/dev/done/refactor/`. The remaining opportunities are not approved
 implementation work; use the linked document to choose the next focused
-proposal and avoid overlap with active unfinished-flight, ghost trajectory, or
-rendering branches.
+proposal and avoid overlap with active Re-Fly follow-ups, ghost
+trajectory/rendering, or Phase 13 logistics prerequisite work.
 
 ## 636. Destroyed staged flights could miss Unfinished Flights when finalization stamped stale SubOrbital ~~done~~
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -282,16 +282,43 @@ The pre-implementation spec that drove v0.9 is archived at
 
 ---
 
-## Phase 12.5: Unfinished Flights stable-leaf extension (planned, 0.9.x)
+### v0.9.1 — Unfinished Flights Stable Leaves & Re-Fly Hardening
 
-Broadens the v0.9 Unfinished Flights group beyond Crashed-only siblings to include stable-but-unconcluded leaves of multi-controllable splits — probes deployed and forgotten in orbit, stranded EVA kerbals, sub-orbital coast that never resolved. Full design: [`docs/parsek-unfinished-flights-stable-leaves-design.md`](parsek-unfinished-flights-stable-leaves-design.md). Pre-implementation research note (R17) at [`docs/dev/research/extending-rewind-to-stable-leaves.md`](dev/research/extending-rewind-to-stable-leaves.md).
+The 0.9.1 line shipped the Phase 12.5 Unfinished Flights stable-leaf extension
+and a focused Re-Fly hardening pass. Full design:
+[`docs/parsek-unfinished-flights-stable-leaves-design.md`](parsek-unfinished-flights-stable-leaves-design.md).
+Pre-implementation research note (R17) at
+[`docs/dev/research/extending-rewind-to-stable-leaves.md`](dev/research/extending-rewind-to-stable-leaves.md).
 
-- **Broader UF predicate** — `IsUnfinishedFlight` extends to non-focus stable-terminal leaves (Orbiting/SubOrbital) and stranded EVA kerbals, while keeping focus-continuation upper stages and successful auto-recovered boosters out of the list.
-- **Per-row Seal action** — new in-table affordance closes a slot permanently without touching the underlying recording. Gives the player a cleanup escape hatch for over-included rows; the recording continues to play back as a ghost.
-- **Three new persistent fields** — `ChildSlot.Sealed` (close signal), `RewindPoint.FocusSlotIndex` (focus attribution at split time, gates stable-terminal qualification), `ReFlySessionMarker.SupersedeTargetId` (linear supersede chain root for chain extension).
-- **Helper extraction** — `TryResolveRewindPointForRecording` and friends move from `UI/RecordingsTableUI.cs` into a new `UnfinishedFlightClassifier` so non-UI consumers (`RecordingStore`, `SupersedeCommit`) can call them without a layering inversion.
-- **Forward-only migration for vessels, retroactive for stranded EVAs** — pre-upgrade Orbiting siblings stay Immutable (no focus signal on legacy RPs); pre-upgrade stranded EVA kerbals do retroactively appear (intentional carve-out).
-- **Prerequisite v0.9 invocation linearization PR** — separate PR fixes a v0.9 chain-extension bug where re-fly invocation produces a star-shaped supersede graph that resolves incorrectly under multiple re-flies. Lands first; this feature builds on the linear-graph behavior it establishes.
+- **Broader Unfinished Flights predicate** — `IsUnfinishedFlight` now includes
+  controllable non-focus Rewind Point children that end `Orbiting` or
+  `SubOrbital`, plus stranded EVA kerbals with non-boarded terminal states.
+  Focus-continuation upper stages, debris, and successful auto-recovered
+  boosters stay out of the list.
+- **STASH system group and row actions** — the virtual Unfinished Flights group
+  is now displayed as `STASH`; rows expose `Fly` and `Seal`, and stable terminal
+  leaves backed by a Rewind Point can be manually `Stash`ed without changing the
+  underlying recording or merge state.
+- **Persistent slot signals** — `ChildSlot.Sealed`, `ChildSlot.Stashed`,
+  `RewindPoint.FocusSlotIndex`, and `ReFlySessionMarker.SupersedeTargetId`
+  preserve stable-leaf qualification, manual closure, and linear re-fly chain
+  extension across save/load.
+- **Helper extraction** — Unfinished Flight membership and route resolution now
+  live outside the table UI so commit/merge/reap code can use the same predicate
+  as the Recordings Manager.
+- **Re-Fly supersede linearization** — repeated re-flies append from the slot's
+  prior effective tip rather than creating origin-rooted star relations. Legacy
+  star-shaped portions are tolerated while new appends form the dominant linear
+  chain.
+- **Re-Fly visibility and resume hardening** — session suppression no longer
+  hides unrelated side-off siblings, raw playback/materialization paths share
+  relation-supersede filtering, doubled GhostMap ProtoVessels are suppressed
+  during pending-tree restore windows, and quickload-resume keeps active-only
+  trim scope intact.
+- **Ghost trajectory follow-through** — 0.9.1 also folded in the current ghost
+  trajectory rendering hardening: continuous terrain correction, structural-event
+  snapshots, outlier rejection, anchor/co-bubble fixes, and recorded-anchor
+  fallbacks for Re-Fly relative playback.
 
 ---
 
@@ -404,6 +431,11 @@ Phase 12: Rewind to Separation (v0.9 ✓)
     │  Rewind Points at multi-controllable splits, Unfinished Flights
     │  group, append-only supersede, narrow v1 scope. Independent of
     │  Phase 13 — both consume Phase 11 resource/inventory/crew manifests.
+    │
+    ▼
+Phase 12.5: Stable Leaves + Re-Fly Hardening (v0.9.1 ✓)
+    │  STASH, Fly/Seal/Stash, slot-aware stable leaves, linear supersede,
+    │  quickload/visibility/relative-playback hardening
     │
     ▼
 Phase 13: Logistics (Supply Routes)


### PR DESCRIPTION
Summary: Reconcile roadmap status now that Phase 12.5/STASH and Re-Fly hardening have landed in v0.9.1. Refresh the remaining refactor opportunities inventory to separate already-landed owner seams from the few remaining proposal-worthy areas, and update the TODO cross-reference. Tests: Not run (docs-only).