### PR TITLE
fix: re-enable Esc-menu Revert button during active Re-Fly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- The Esc-menu Revert to Launch button is no longer grayed out during an active Re-Fly. The loaded rewind-point quicksave is mid-flight so KSP correctly disables the button, but Parsek's interceptor (Retry / Discard Re-Fly / Cancel dialog) was unreachable as a result. While a Re-Fly session marker is active the button is force-enabled so clicking it routes into the Parsek dialog; on marker clear the engine's natural state is restored.
 - The Recordings table uses the original Actions column width again, with full-word `Rewind` and `Forward` action labels plus compact button padding so `Fly`/`Seal` and `Stash` still fit without widening the table.
 - Stock retractable ladders no longer render extended in the ghost when the recorded vessel had them stowed. Solar panels, gear, animation groups, animate-generic, and aero/control-surface deployables get the same first-spawn stow baseline.
 - Re-flying an upper stage no longer hides the previous lower stage (or any other side-off vessel from the original separation) while the re-fly is in progress. The session-suppressed subtree closure now only walks same-PID linear continuations of the recording being re-flown; side-off branches keep playing as ghosts and showing on the map view, and only get superseded when the new flight produces its own side-offs at a comparable staging event.

--- a/Source/Parsek.Tests/ReFlyRevertButtonGateTests.cs
+++ b/Source/Parsek.Tests/ReFlyRevertButtonGateTests.cs
@@ -232,6 +232,59 @@ namespace Parsek.Tests
                 && l.Contains("test:second"));
         }
 
+        // ---------- Reset-branch ordering safety -------------------------
+
+        [Fact]
+        public void Apply_ResetBranch_FlagAlreadyAtNatural_StillClearsForcedFlag()
+        {
+            // Edge case: the force was applied while marker was active, then
+            // some external code (test or unrelated subsystem) reset the
+            // engine flag to false on its own before the marker cleared.
+            // Reset branch hits the "already at natural" arm and must still
+            // drop the forcedFlag override so a future Apply does not skip
+            // a legitimate reset.
+            var scenario = InstallScenario(marker: MakeMarker());
+            FlightDriver.CanRevertToPostInit = false;
+            ReFlyRevertButtonGate.ResetForTesting();
+            ReFlyRevertButtonGate.Apply("test:setup");
+            Assert.True(ReFlyRevertButtonGate.ForcedFlagForTesting);
+            FlightDriver.CanRevertToPostInit = false; // external reset
+            scenario.ActiveReFlySessionMarker = null;
+            logLines.Clear();
+
+            ReFlyRevertButtonGate.Apply("test:reset-already-natural");
+
+            Assert.False(ReFlyRevertButtonGate.ForcedFlagForTesting);
+            Assert.False(FlightDriver.CanRevertToPostInit);
+            Assert.Contains(logLines, l =>
+                l.Contains("[ReFlySession]")
+                && l.Contains("reset cleared override")
+                && l.Contains("test:reset-already-natural"));
+        }
+
+        [Fact]
+        public void ApplyForTesting_Hook_BypassesRealFlagAndForcedFlag()
+        {
+            // Test seam contract: when ApplyForTesting is set, Apply must not
+            // touch the live FlightDriver static state OR forcedFlag — both
+            // are owned by the test harness for that call. Without this
+            // guarantee a unit test that drives Apply through the seam would
+            // randomly mutate the xUnit-process-shared FlightDriver flag and
+            // silently break a follow-up integration test in the same run.
+            InstallScenario(marker: MakeMarker());
+            FlightDriver.CanRevertToPostInit = false;
+            ReFlyRevertButtonGate.ResetForTesting();
+
+            bool? observed = null;
+            ReFlyRevertButtonGate.ApplyForTesting = active => observed = active;
+
+            ReFlyRevertButtonGate.Apply("test:seam-no-mutation");
+
+            Assert.True(observed ?? false);
+            Assert.False(FlightDriver.CanRevertToPostInit);
+            Assert.False(ReFlyRevertButtonGate.ForcedFlagForTesting);
+        }
+
         // ---------- Subscribe / Unsubscribe ------------------------------
 
         [Fact]

--- a/Source/Parsek.Tests/ReFlyRevertButtonGateTests.cs
+++ b/Source/Parsek.Tests/ReFlyRevertButtonGateTests.cs
@@ -1,0 +1,260 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Guards <see cref="ReFlyRevertButtonGate"/>'s decision logic:
+    /// <list type="bullet">
+    ///   <item><description>Active marker → forces <c>FlightDriver.CanRevertToPostInit = true</c> so the Esc-menu Revert button is clickable and routes to <see cref="RevertInterceptor.Prefix"/>.</description></item>
+    ///   <item><description>No marker / no scenario → no override.</description></item>
+    ///   <item><description>Marker cleared after a force → reset path drops the override and logs the transition.</description></item>
+    ///   <item><description>Engine-set true (legitimate launch) → not clobbered; <c>forcedFlag</c> stays false.</description></item>
+    /// </list>
+    ///
+    /// <para>
+    /// Touching <see cref="FlightDriver.CanRevertToPostInit"/> directly from
+    /// xUnit is cheap (it's a public static field), but exercising the natural
+    /// state recompute requires <c>FlightGlobals.ActiveVessel</c> which is
+    /// Unity-only. Tests use <see cref="ReFlyRevertButtonGate.ApplyForTesting"/>
+    /// to observe the decision, plus log-capture assertions to verify the
+    /// force/reset transitions emit their tagged log lines.
+    /// </para>
+    /// </summary>
+    [Collection("Sequential")]
+    public class ReFlyRevertButtonGateTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+        private readonly bool priorParsekLogSuppress;
+
+        public ReFlyRevertButtonGateTests()
+        {
+            priorParsekLogSuppress = ParsekLog.SuppressLogging;
+
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.VerboseOverrideForTesting = true;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+
+            ParsekScenario.ResetInstanceForTesting();
+            ReFlyRevertButtonGate.ResetForTesting();
+        }
+
+        public void Dispose()
+        {
+            ReFlyRevertButtonGate.ResetForTesting();
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = priorParsekLogSuppress;
+            ParsekScenario.ResetInstanceForTesting();
+        }
+
+        // ---------- Helpers ---------------------------------------------
+
+        private static ReFlySessionMarker MakeMarker(string sessionId = "sess_btn_gate_test")
+        {
+            return new ReFlySessionMarker
+            {
+                SessionId = sessionId,
+                TreeId = "tree_btn_gate",
+                ActiveReFlyRecordingId = "rec_provisional_btn_gate",
+                OriginChildRecordingId = "rec_origin_btn_gate",
+                RewindPointId = "rp_btn_gate",
+                InvokedUT = 100.0,
+                InvokedRealTime = "2026-04-30T00:00:00.000Z",
+            };
+        }
+
+        private static ParsekScenario InstallScenario(ReFlySessionMarker marker = null)
+        {
+            var scenario = new ParsekScenario
+            {
+                ActiveReFlySessionMarker = marker,
+            };
+            ParsekScenario.SetInstanceForTesting(scenario);
+            return scenario;
+        }
+
+        // ---------- Apply: decision routing ------------------------------
+
+        [Fact]
+        public void Apply_NoScenario_TreatedAsInactive()
+        {
+            ParsekScenario.ResetInstanceForTesting();
+
+            bool? observed = null;
+            ReFlyRevertButtonGate.ApplyForTesting = active => observed = active;
+
+            ReFlyRevertButtonGate.Apply("test:no-scenario");
+
+            Assert.False(observed ?? true);
+        }
+
+        [Fact]
+        public void Apply_ScenarioWithoutMarker_TreatedAsInactive()
+        {
+            InstallScenario(marker: null);
+
+            bool? observed = null;
+            ReFlyRevertButtonGate.ApplyForTesting = active => observed = active;
+
+            ReFlyRevertButtonGate.Apply("test:no-marker");
+
+            Assert.False(observed ?? true);
+        }
+
+        [Fact]
+        public void Apply_ScenarioWithMarker_TreatedAsActive()
+        {
+            InstallScenario(marker: MakeMarker());
+
+            bool? observed = null;
+            ReFlyRevertButtonGate.ApplyForTesting = active => observed = active;
+
+            ReFlyRevertButtonGate.Apply("test:active-marker");
+
+            Assert.True(observed ?? false);
+        }
+
+        // ---------- Force / reset cycle on the real flag -----------------
+
+        [Fact]
+        public void Apply_ActiveMarker_FlagWasFalse_ForcesTrueAndLogs()
+        {
+            InstallScenario(marker: MakeMarker(sessionId: "sess_force_test"));
+
+            FlightDriver.CanRevertToPostInit = false;
+            ReFlyRevertButtonGate.ResetForTesting();
+            Assert.False(ReFlyRevertButtonGate.ForcedFlagForTesting);
+
+            ReFlyRevertButtonGate.Apply("test:force");
+
+            Assert.True(FlightDriver.CanRevertToPostInit);
+            Assert.True(ReFlyRevertButtonGate.ForcedFlagForTesting);
+            Assert.Contains(logLines, l =>
+                l.Contains("[ReFlySession]")
+                && l.Contains("ReFlyRevertButtonGate")
+                && l.Contains("forced FlightDriver.CanRevertToPostInit=true")
+                && l.Contains("sess=sess_force_test")
+                && l.Contains("test:force"));
+        }
+
+        [Fact]
+        public void Apply_ActiveMarker_FlagAlreadyTrue_LeavesForcedFlagFalse()
+        {
+            // Engine-set true (e.g. fresh PRELAUNCH launch). We must not claim
+            // ownership of a flag we did not flip — otherwise the eventual
+            // reset would clobber the engine's legitimate value.
+            InstallScenario(marker: MakeMarker());
+            FlightDriver.CanRevertToPostInit = true;
+            ReFlyRevertButtonGate.ResetForTesting();
+
+            ReFlyRevertButtonGate.Apply("test:already-true");
+
+            Assert.True(FlightDriver.CanRevertToPostInit);
+            Assert.False(ReFlyRevertButtonGate.ForcedFlagForTesting);
+            Assert.Contains(logLines, l =>
+                l.Contains("[ReFlySession]")
+                && l.Contains("CanRevertToPostInit already true")
+                && l.Contains("no override needed"));
+        }
+
+        [Fact]
+        public void Apply_MarkerCleared_AfterForce_ResetsFlagAndLogs()
+        {
+            // Step 1: force.
+            var scenario = InstallScenario(marker: MakeMarker(sessionId: "sess_reset_test"));
+            FlightDriver.CanRevertToPostInit = false;
+            ReFlyRevertButtonGate.ResetForTesting();
+            ReFlyRevertButtonGate.Apply("test:force-then-reset:force");
+            Assert.True(ReFlyRevertButtonGate.ForcedFlagForTesting);
+            logLines.Clear();
+
+            // Step 2: marker cleared, Apply called from a clear-site.
+            scenario.ActiveReFlySessionMarker = null;
+            ReFlyRevertButtonGate.Apply("test:force-then-reset:clear");
+
+            Assert.False(FlightDriver.CanRevertToPostInit);
+            Assert.False(ReFlyRevertButtonGate.ForcedFlagForTesting);
+            Assert.Contains(logLines, l =>
+                l.Contains("[ReFlySession]")
+                && l.Contains("reset FlightDriver.CanRevertToPostInit=False")
+                && l.Contains("re-fly marker cleared")
+                && l.Contains("test:force-then-reset:clear"));
+        }
+
+        [Fact]
+        public void Apply_MarkerCleared_NoPriorForce_DoesNotTouchFlag()
+        {
+            // Engine-set true that we never claimed → reset path must be a
+            // no-op so a non-Parsek launch keeps its legitimate flag value.
+            InstallScenario(marker: null);
+            FlightDriver.CanRevertToPostInit = true;
+            ReFlyRevertButtonGate.ResetForTesting();
+            Assert.False(ReFlyRevertButtonGate.ForcedFlagForTesting);
+
+            ReFlyRevertButtonGate.Apply("test:engine-set-true");
+
+            Assert.True(FlightDriver.CanRevertToPostInit);
+            Assert.False(ReFlyRevertButtonGate.ForcedFlagForTesting);
+            // No reset log line — the gate did not fire.
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("ReFlyRevertButtonGate")
+                && l.Contains("reset FlightDriver.CanRevertToPostInit"));
+        }
+
+        [Fact]
+        public void Apply_Idempotent_RepeatedActiveCalls_LogVerboseAfterFirstForce()
+        {
+            InstallScenario(marker: MakeMarker());
+            FlightDriver.CanRevertToPostInit = false;
+            ReFlyRevertButtonGate.ResetForTesting();
+
+            ReFlyRevertButtonGate.Apply("test:first");
+            int forceLogs = 0;
+            foreach (var l in logLines)
+            {
+                if (l.Contains("forced FlightDriver.CanRevertToPostInit=true")
+                    && l.Contains("test:first"))
+                    forceLogs++;
+            }
+            Assert.Equal(1, forceLogs);
+
+            logLines.Clear();
+            ReFlyRevertButtonGate.Apply("test:second");
+
+            Assert.True(FlightDriver.CanRevertToPostInit);
+            Assert.True(ReFlyRevertButtonGate.ForcedFlagForTesting);
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("forced FlightDriver.CanRevertToPostInit=true"));
+            Assert.Contains(logLines, l =>
+                l.Contains("CanRevertToPostInit already true")
+                && l.Contains("test:second"));
+        }
+
+        // ---------- Subscribe / Unsubscribe ------------------------------
+
+        [Fact]
+        public void Subscribe_Then_Unsubscribe_AreIdempotent()
+        {
+            // Cannot probe GameEvents from xUnit (Unity-only static state),
+            // but the no-op-on-second-call invariant is observable through
+            // the log lines emitted around the subscribed-bool.
+            ReFlyRevertButtonGate.Subscribe();
+            ReFlyRevertButtonGate.Subscribe();
+            ReFlyRevertButtonGate.Unsubscribe();
+            ReFlyRevertButtonGate.Unsubscribe();
+
+            int subscribeLogs = 0;
+            int unsubscribeLogs = 0;
+            foreach (var l in logLines)
+            {
+                if (l.Contains("subscribed to GameEvents.onFlightReady")
+                    && !l.Contains("unsubscribed")) subscribeLogs++;
+                if (l.Contains("unsubscribed from GameEvents.onFlightReady")) unsubscribeLogs++;
+            }
+            Assert.Equal(1, subscribeLogs);
+            Assert.Equal(1, unsubscribeLogs);
+        }
+    }
+}

--- a/Source/Parsek/InGameTests/ReFlyRevertButtonGateTest.cs
+++ b/Source/Parsek/InGameTests/ReFlyRevertButtonGateTest.cs
@@ -1,0 +1,132 @@
+using System;
+using UnityEngine;
+
+namespace Parsek.InGameTests
+{
+    /// <summary>
+    /// Live-scene verification that <see cref="ReFlyRevertButtonGate"/> drives
+    /// the real <c>FlightDriver.CanRevertToPostInit</c> static field while a
+    /// re-fly session marker is active — re-enabling the Esc-menu Revert
+    /// button so <see cref="RevertInterceptor"/>'s 3-option dialog becomes
+    /// reachable.
+    ///
+    /// <para>
+    /// The xUnit unit-test counterpart in <c>ReFlyRevertButtonGateTests.cs</c>
+    /// covers the decision logic with a test seam; this in-game test is the
+    /// canary for the real flag mutation, which the seam suppresses. Runs as
+    /// a synthetic in-memory fixture: installs a fake marker on the live
+    /// scenario, invokes <c>Apply</c>, asserts the engine flag flipped, and
+    /// restores prior state on teardown.
+    /// </para>
+    /// </summary>
+    public class ReFlyRevertButtonGateTest
+    {
+        [InGameTest(Category = "Rewind", Scene = GameScenes.FLIGHT,
+            Description = "ReFlyRevertButtonGate forces FlightDriver.CanRevertToPostInit=true while marker active")]
+        public void Gate_ForcesFlagTrue_WhenMarkerActive_AndRestoresOnClear()
+        {
+            var scenario = ParsekScenario.Instance;
+            InGameAssert.IsNotNull(scenario, "ParsekScenario.Instance is null");
+
+            // Snapshot prior state — restored unconditionally on teardown so a
+            // failure here does not corrupt the player's session.
+            bool savedFlag = FlightDriver.CanRevertToPostInit;
+            var savedMarker = scenario.ActiveReFlySessionMarker;
+            ReFlyRevertButtonGate.ResetForTesting();
+
+            string sessionId = "sess_btn_gate_igt_" + Guid.NewGuid().ToString("N").Substring(0, 8);
+            string rpId = "rp_btn_gate_igt_" + Guid.NewGuid().ToString("N").Substring(0, 8);
+
+            var marker = new ReFlySessionMarker
+            {
+                SessionId = sessionId,
+                TreeId = "tree_btn_gate_igt",
+                ActiveReFlyRecordingId = "rec_provisional_btn_gate_igt",
+                OriginChildRecordingId = "rec_origin_btn_gate_igt",
+                RewindPointId = rpId,
+                InvokedUT = 0.0,
+                InvokedRealTime = DateTime.UtcNow.ToString("o"),
+            };
+
+            try
+            {
+                // Force the engine flag false to simulate the post-LoadGame
+                // state RewindInvoker leaves us in: vessel mid-flight, KSP
+                // computed CanRevertToPostInit=false, button grayed out.
+                FlightDriver.CanRevertToPostInit = false;
+                ReFlyRevertButtonGate.ResetForTesting();
+                InGameAssert.IsFalse(ReFlyRevertButtonGate.ForcedFlagForTesting,
+                    "ForcedFlag must start false — fixture sanity");
+
+                // Install marker, invoke gate. This is what AtomicMarkerWrite
+                // does in production, immediately after the marker is set.
+                scenario.ActiveReFlySessionMarker = marker;
+                ReFlyRevertButtonGate.Apply("igt:force-after-marker-set");
+
+                InGameAssert.IsTrue(FlightDriver.CanRevertToPostInit,
+                    "ReFlyRevertButtonGate should force CanRevertToPostInit=true while marker active");
+                InGameAssert.IsTrue(ReFlyRevertButtonGate.ForcedFlagForTesting,
+                    "ForcedFlag should record that the gate flipped the engine value");
+                InGameAssert.IsTrue(FlightDriver.CanRevert,
+                    "FlightDriver.CanRevert must be true so the Esc-menu Revert button is interactable");
+
+                // Clear the marker — this is what RetryHandler / DiscardReFlyHandler
+                // / SupersedeCommit do on teardown. Apply must drop the override.
+                scenario.ActiveReFlySessionMarker = null;
+                ReFlyRevertButtonGate.Apply("igt:reset-after-marker-cleared");
+
+                InGameAssert.IsFalse(ReFlyRevertButtonGate.ForcedFlagForTesting,
+                    "ForcedFlag must clear after the marker becomes null");
+                // The natural state for a non-PRELAUNCH active vessel is
+                // false; for an on-pad PRELAUNCH vessel it's true. The gate
+                // recomputes this in ComputeNaturalCanRevertToPostInit so
+                // either outcome is consistent with the engine.
+                bool prelaunch = FlightGlobals.ActiveVessel != null
+                    && FlightGlobals.ActiveVessel.situation == Vessel.Situations.PRELAUNCH;
+                InGameAssert.AreEqual(prelaunch, FlightDriver.CanRevertToPostInit,
+                    "After marker cleared, gate must restore CanRevertToPostInit to the engine-natural value (PRELAUNCH-true / otherwise-false)");
+            }
+            finally
+            {
+                scenario.ActiveReFlySessionMarker = savedMarker;
+                FlightDriver.CanRevertToPostInit = savedFlag;
+                ReFlyRevertButtonGate.ResetForTesting();
+            }
+        }
+
+        [InGameTest(Category = "Rewind", Scene = GameScenes.FLIGHT,
+            Description = "ReFlyRevertButtonGate does not clobber an engine-set true flag when marker is null")]
+        public void Gate_DoesNotClobber_LegitimateFlagTrue_WhenInactive()
+        {
+            var scenario = ParsekScenario.Instance;
+            InGameAssert.IsNotNull(scenario, "ParsekScenario.Instance is null");
+
+            bool savedFlag = FlightDriver.CanRevertToPostInit;
+            var savedMarker = scenario.ActiveReFlySessionMarker;
+            ReFlyRevertButtonGate.ResetForTesting();
+
+            try
+            {
+                // Engine-set true (mimics a fresh PRELAUNCH launch where
+                // FlightDriver.Start legitimately set the flag). No marker
+                // active. Apply must be a no-op — clobbering this would
+                // gray out the Revert button on an ordinary launch.
+                FlightDriver.CanRevertToPostInit = true;
+                scenario.ActiveReFlySessionMarker = null;
+
+                ReFlyRevertButtonGate.Apply("igt:no-op-on-engine-true");
+
+                InGameAssert.IsTrue(FlightDriver.CanRevertToPostInit,
+                    "Gate must not clobber an engine-set true flag when no marker is active");
+                InGameAssert.IsFalse(ReFlyRevertButtonGate.ForcedFlagForTesting,
+                    "ForcedFlag must stay false — gate did not claim ownership");
+            }
+            finally
+            {
+                scenario.ActiveReFlySessionMarker = savedMarker;
+                FlightDriver.CanRevertToPostInit = savedFlag;
+                ReFlyRevertButtonGate.ResetForTesting();
+            }
+        }
+    }
+}

--- a/Source/Parsek/InGameTests/ReFlyRevertButtonGateTest.cs
+++ b/Source/Parsek/InGameTests/ReFlyRevertButtonGateTest.cs
@@ -28,10 +28,19 @@ namespace Parsek.InGameTests
             var scenario = ParsekScenario.Instance;
             InGameAssert.IsNotNull(scenario, "ParsekScenario.Instance is null");
 
+            // Refuse to run while a real Re-Fly is in flight: ResetForTesting
+            // clobbers forcedFlag and our finally-block restore would
+            // mis-classify the engine flag's ownership for the live session.
+            if (scenario.ActiveReFlySessionMarker != null)
+            {
+                InGameAssert.Skip(
+                    "Cannot exercise gate while a live Re-Fly session is active — would clobber ownership tracking");
+                return;
+            }
+
             // Snapshot prior state — restored unconditionally on teardown so a
             // failure here does not corrupt the player's session.
             bool savedFlag = FlightDriver.CanRevertToPostInit;
-            var savedMarker = scenario.ActiveReFlySessionMarker;
             ReFlyRevertButtonGate.ResetForTesting();
 
             string sessionId = "sess_btn_gate_igt_" + Guid.NewGuid().ToString("N").Substring(0, 8);
@@ -73,6 +82,7 @@ namespace Parsek.InGameTests
                 // Clear the marker — this is what RetryHandler / DiscardReFlyHandler
                 // / SupersedeCommit do on teardown. Apply must drop the override.
                 scenario.ActiveReFlySessionMarker = null;
+                Parsek.Rendering.RenderSessionState.Clear("igt:reset-after-marker-cleared");
                 ReFlyRevertButtonGate.Apply("igt:reset-after-marker-cleared");
 
                 InGameAssert.IsFalse(ReFlyRevertButtonGate.ForcedFlagForTesting,
@@ -88,7 +98,13 @@ namespace Parsek.InGameTests
             }
             finally
             {
-                scenario.ActiveReFlySessionMarker = savedMarker;
+                // Order matters: clear the synthetic marker first, restore
+                // the engine flag, then ResetForTesting wipes forcedFlag last.
+                // Skipping above guarantees we never enter the finally with a
+                // pre-existing live marker, so this restore sequence cannot
+                // corrupt a live session.
+                scenario.ActiveReFlySessionMarker = null;
+                Parsek.Rendering.RenderSessionState.Clear("igt:gate-test-teardown");
                 FlightDriver.CanRevertToPostInit = savedFlag;
                 ReFlyRevertButtonGate.ResetForTesting();
             }
@@ -101,8 +117,17 @@ namespace Parsek.InGameTests
             var scenario = ParsekScenario.Instance;
             InGameAssert.IsNotNull(scenario, "ParsekScenario.Instance is null");
 
+            if (scenario.ActiveReFlySessionMarker != null)
+            {
+                InGameAssert.Skip(
+                    "Cannot exercise inactive-gate behaviour while a live Re-Fly session is active");
+                return;
+            }
+
             bool savedFlag = FlightDriver.CanRevertToPostInit;
-            var savedMarker = scenario.ActiveReFlySessionMarker;
+            // Reset BEFORE Apply so a stale forcedFlag from a prior test or
+            // session does not route us through the reset branch and clobber
+            // the very flag this test is supposed to verify is preserved.
             ReFlyRevertButtonGate.ResetForTesting();
 
             try
@@ -113,6 +138,7 @@ namespace Parsek.InGameTests
                 // gray out the Revert button on an ordinary launch.
                 FlightDriver.CanRevertToPostInit = true;
                 scenario.ActiveReFlySessionMarker = null;
+                Parsek.Rendering.RenderSessionState.Clear("igt:engine-true-test-setup");
 
                 ReFlyRevertButtonGate.Apply("igt:no-op-on-engine-true");
 
@@ -123,7 +149,6 @@ namespace Parsek.InGameTests
             }
             finally
             {
-                scenario.ActiveReFlySessionMarker = savedMarker;
                 FlightDriver.CanRevertToPostInit = savedFlag;
                 ReFlyRevertButtonGate.ResetForTesting();
             }

--- a/Source/Parsek/LoadTimeSweep.cs
+++ b/Source/Parsek/LoadTimeSweep.cs
@@ -76,6 +76,12 @@ namespace Parsek
                 LogMarkerInvalid(marker, validation.Reason, validation.Details);
                 scenario.ActiveReFlySessionMarker = null;
                 Parsek.Rendering.RenderSessionState.Clear("marker-cleared");
+                // Sweep runs during OnLoad before flight-scene Start, so
+                // FlightDriver state is unset and Apply is a logged no-op.
+                // Defensive: keep the call symmetric with other clear sites
+                // so the gate's forcedFlag tracking stays consistent if
+                // OnLoad fires inside an already-loaded flight scene.
+                ReFlyRevertButtonGate.Apply("LoadTimeSweep:invalid-marker");
             }
             else if (markerValid)
             {

--- a/Source/Parsek/MergeJournalOrchestrator.cs
+++ b/Source/Parsek/MergeJournalOrchestrator.cs
@@ -241,6 +241,7 @@ namespace Parsek
             scenario.ActiveReFlySessionMarker = null;
             Parsek.Rendering.RenderSessionState.Clear("marker-cleared");
             scenario.BumpSupersedeStateVersion();
+            ReFlyRevertButtonGate.Apply("MergeJournal:marker-cleared");
             ParsekLog.Info("ReFlySession",
                 $"End reason=merged sess={sessionId} provisional={provisionalId}");
             AdvancePhase(scenario, MergeJournal.Phases.MarkerCleared);
@@ -343,6 +344,7 @@ namespace Parsek
             Parsek.Rendering.RenderSessionState.Clear("marker-cleared");
             scenario.ActiveMergeJournal = null;
             scenario.BumpSupersedeStateVersion();
+            ReFlyRevertButtonGate.Apply("MergeJournal:rollback");
 
             DurableSave("rollback", persistSynchronously: false);
 
@@ -381,6 +383,7 @@ namespace Parsek
                 scenario.ActiveReFlySessionMarker = null;
                 Parsek.Rendering.RenderSessionState.Clear("marker-cleared");
                 scenario.BumpSupersedeStateVersion();
+                ReFlyRevertButtonGate.Apply("MergeJournal:complete-marker-cleared");
                 AdvancePhase(scenario, MergeJournal.Phases.MarkerCleared);
                 stepsDriven++;
             }

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -937,6 +937,15 @@ namespace Parsek
                 }
             }
 
+            // Re-fly Esc-menu button gate: covers the case where a save was
+            // made mid-re-fly and is being loaded fresh. If the load lands in
+            // a non-flight scene the call is a logged no-op; the next
+            // onFlightReady (handled by ReFlyRevertButtonGate.Subscribe) will
+            // re-assert when the player enters flight. If the load lands in
+            // flight (rare — KSP normally loads to KSC first), this is the
+            // immediate force.
+            ReFlyRevertButtonGate.Apply("OnLoad:after-marker-load");
+
             ConfigNode journalNode = node.GetNode(MergeJournal.NodeName);
             if (journalNode != null)
                 ActiveMergeJournal = MergeJournal.LoadFrom(journalNode);
@@ -2480,6 +2489,10 @@ namespace Parsek
             GameEvents.onVesselSwitching.Add(OnVesselSwitching);
             // #434: subscribe idempotently so revert detection is armed from first OnLoad.
             RevertDetector.Subscribe();
+            // Re-fly Esc-menu button gate: Apply() on every onFlightReady so a
+            // save loaded with an active re-fly marker re-enables the Revert
+            // button before the player can click it.
+            ReFlyRevertButtonGate.Subscribe();
         }
 
         /// <summary>
@@ -5622,6 +5635,7 @@ namespace Parsek
             // lifetime of the game session; tearing them down here so a scenario-module
             // shutdown doesn't leak dangling delegates if the session ends mid-flight.
             RevertDetector.Unsubscribe();
+            ReFlyRevertButtonGate.Unsubscribe();
             // Phase 6 of Rewind-to-Staging: clear the per-RP precondition
             // cache so the dict does not grow unbounded across long sessions
             // (Fix 8). The cache is 60s-TTL'd anyway but long-lived scene loops

--- a/Source/Parsek/ReFlyRevertButtonGate.cs
+++ b/Source/Parsek/ReFlyRevertButtonGate.cs
@@ -1,0 +1,189 @@
+using System;
+
+namespace Parsek
+{
+    /// <summary>
+    /// Re-enables the flight-scene Esc-menu Revert-to-Launch button while a
+    /// re-fly session is active so the player can route into Parsek's
+    /// Retry / Discard Re-fly / Cancel dialog (see <see cref="RevertInterceptor"/>).
+    ///
+    /// <para>
+    /// KSP's <c>FlightDriver.Start</c> sets <c>CanRevertToPostInit</c> based on
+    /// the active vessel's situation on the <c>RESUME_SAVED_CACHE</c> branch
+    /// (true only when <c>vessel.situation == PRELAUNCH</c>; see decompiled
+    /// <c>FlightDriver.cs:386-387</c>). When <see cref="RewindInvoker"/> loads
+    /// a rewind point's quicksave via <c>FlightDriver.StartAndFocusVessel</c>,
+    /// the loaded vessel is mid-flight at the staging point, so KSP correctly
+    /// considers the state non-revertable and the pause menu's Revert button
+    /// (interactable predicate <c>FlightDriver.CanRevert</c>; see decompiled
+    /// <c>PauseMenu.cs:573</c>) grays out — blocking access to
+    /// <see cref="RevertInterceptor.Prefix"/> and the re-fly dialog.
+    /// </para>
+    ///
+    /// <para>
+    /// While a re-fly marker is active we forcibly set
+    /// <c>FlightDriver.CanRevertToPostInit = true</c> so the button is clickable.
+    /// This is safe because the Harmony prefix on <c>FlightDriver.RevertToLaunch</c>
+    /// short-circuits the stock body before it can dereference the null
+    /// <c>PostInitState</c> we never had — every click reaches our 3-option
+    /// dialog instead.
+    /// </para>
+    ///
+    /// <para>
+    /// <see cref="Apply"/> is idempotent and is invoked at every site where the
+    /// marker can change while the player is in flight: on
+    /// <c>GameEvents.onFlightReady</c> (covers OnLoad-with-active-marker), right
+    /// after <see cref="RewindInvoker.AtomicMarkerWrite"/> (covers in-flight
+    /// invocation), and at every marker-clear site reachable from a flight
+    /// scene (atomic-write rollback, Retry handler, Discard handler failure
+    /// branches). When the marker becomes null after we forced the flag, the
+    /// reset branch puts it back: PRELAUNCH if the vessel is still on the pad
+    /// (matches the natural state the engine would compute), otherwise false.
+    /// We track our own override via <see cref="forcedFlag"/> so we never
+    /// clobber a legitimate engine-set value (e.g., a fresh launch that's
+    /// genuinely revertable).
+    /// </para>
+    /// </summary>
+    internal static class ReFlyRevertButtonGate
+    {
+        private const string Tag = "ReFlySession";
+
+        // True iff Parsek's last Apply() forced CanRevertToPostInit from false
+        // to true. Cleared in the reset branch (marker cleared post-force) and
+        // by ResetForTesting. We only restore engine-default state when this is
+        // true, so a normal launch that legitimately set the flag (line
+        // 835/387 of FlightDriver) is never disturbed.
+        private static bool forcedFlag;
+        internal static bool ForcedFlagForTesting => forcedFlag;
+
+        // Test seam: when non-null, Apply() routes to this hook instead of
+        // touching FlightDriver / FlightGlobals static state. The bool argument
+        // is the "marker active" decision Apply computed.
+        internal static Action<bool> ApplyForTesting;
+
+        internal static void ResetForTesting()
+        {
+            ApplyForTesting = null;
+            forcedFlag = false;
+        }
+
+        // KSP's EventData<T>.EvtDelegate..ctor reads evt.Target.GetType().Name
+        // without a null check; a delegate bound to a static method has
+        // Target == null and NREs inside GameEvents.*.Add. RevertDetector
+        // solved this by routing through an instance singleton — mirror that
+        // pattern here. Handler state still lives in static fields, not on
+        // the instance.
+        private sealed class Handlers
+        {
+            public void OnFlightReady() => Apply("onFlightReady");
+        }
+
+        private static readonly Handlers handlers = new Handlers();
+        private static bool subscribed;
+
+        /// <summary>
+        /// Wires the GameEvents subscription. Idempotent; safe to call from
+        /// every <see cref="ParsekScenario"/> lifecycle.
+        /// </summary>
+        internal static void Subscribe()
+        {
+            if (subscribed) return;
+            subscribed = true;
+            GameEvents.onFlightReady.Add(handlers.OnFlightReady);
+            ParsekLog.Verbose(Tag,
+                "ReFlyRevertButtonGate: subscribed to GameEvents.onFlightReady");
+        }
+
+        internal static void Unsubscribe()
+        {
+            if (!subscribed) return;
+            subscribed = false;
+            GameEvents.onFlightReady.Remove(handlers.OnFlightReady);
+            ParsekLog.Verbose(Tag,
+                "ReFlyRevertButtonGate: unsubscribed from GameEvents.onFlightReady");
+        }
+
+        /// <summary>
+        /// Re-evaluates the gate against the current re-fly marker state.
+        /// <list type="bullet">
+        ///   <item><description>Marker active + flag false → force flag true, log Info, remember override.</description></item>
+        ///   <item><description>Marker active + flag already true → no-op (engine or earlier Apply already set it).</description></item>
+        ///   <item><description>Marker null + we previously forced → restore natural state (PRELAUNCH-true / otherwise-false), log Info, drop override.</description></item>
+        ///   <item><description>Marker null + we did not force → no-op (engine value is authoritative).</description></item>
+        /// </list>
+        /// </summary>
+        /// <param name="site">Short identifier of the call-site for log diagnostics
+        /// (e.g. <c>"onFlightReady"</c>, <c>"AtomicMarkerWrite"</c>).</param>
+        internal static void Apply(string site)
+        {
+            var scenario = ParsekScenario.Instance;
+            bool active = !ReferenceEquals(null, scenario)
+                && scenario.ActiveReFlySessionMarker != null;
+
+            var hook = ApplyForTesting;
+            if (hook != null)
+            {
+                hook(active);
+                return;
+            }
+
+            try
+            {
+                if (active)
+                {
+                    if (!FlightDriver.CanRevertToPostInit)
+                    {
+                        FlightDriver.CanRevertToPostInit = true;
+                        forcedFlag = true;
+                        string sessionId = scenario.ActiveReFlySessionMarker.SessionId ?? "<no-id>";
+                        ParsekLog.Info(Tag,
+                            $"ReFlyRevertButtonGate: forced FlightDriver.CanRevertToPostInit=true at {site ?? "(no-site)"} sess={sessionId} — Esc menu Revert button re-enabled for re-fly dialog");
+                    }
+                    else
+                    {
+                        ParsekLog.Verbose(Tag,
+                            $"ReFlyRevertButtonGate: CanRevertToPostInit already true at {site ?? "(no-site)"} — no override needed");
+                    }
+                }
+                else if (forcedFlag)
+                {
+                    bool natural = ComputeNaturalCanRevertToPostInit();
+                    forcedFlag = false;
+                    if (FlightDriver.CanRevertToPostInit != natural)
+                    {
+                        FlightDriver.CanRevertToPostInit = natural;
+                        ParsekLog.Info(Tag,
+                            $"ReFlyRevertButtonGate: reset FlightDriver.CanRevertToPostInit={natural} at {site ?? "(no-site)"} — re-fly marker cleared");
+                    }
+                    else
+                    {
+                        ParsekLog.Verbose(Tag,
+                            $"ReFlyRevertButtonGate: reset cleared override at {site ?? "(no-site)"} — flag already at natural value {natural}");
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                ParsekLog.Warn(Tag,
+                    $"ReFlyRevertButtonGate.Apply threw at {site ?? "(no-site)"}: {ex.GetType().Name}: {ex.Message}");
+            }
+        }
+
+        // Mirrors the engine-side computation FlightDriver.Start would have
+        // performed if it ran right now: true on PRELAUNCH, false otherwise.
+        // No exceptions allowed — callers are in catch-all blocks already and
+        // a defensive false matches the gray-out behaviour the player sees.
+        private static bool ComputeNaturalCanRevertToPostInit()
+        {
+            try
+            {
+                var v = FlightGlobals.ActiveVessel;
+                return v != null && v.situation == Vessel.Situations.PRELAUNCH;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/Source/Parsek/ReFlyRevertButtonGate.cs
+++ b/Source/Parsek/ReFlyRevertButtonGate.cs
@@ -24,9 +24,10 @@ namespace Parsek
     /// While a re-fly marker is active we forcibly set
     /// <c>FlightDriver.CanRevertToPostInit = true</c> so the button is clickable.
     /// This is safe because the Harmony prefix on <c>FlightDriver.RevertToLaunch</c>
-    /// short-circuits the stock body before it can dereference the null
-    /// <c>PostInitState</c> we never had — every click reaches our 3-option
-    /// dialog instead.
+    /// short-circuits the stock body before it can replay the captured
+    /// <c>PostInitState</c> (which holds the mid-flight RP-quicksave state, not
+    /// a launch-time backup — <c>FlightDriver.PostInit</c> rebuilds it on every
+    /// scene load) — every click reaches our 3-option dialog instead.
     /// </para>
     ///
     /// <para>
@@ -51,8 +52,11 @@ namespace Parsek
         // True iff Parsek's last Apply() forced CanRevertToPostInit from false
         // to true. Cleared in the reset branch (marker cleared post-force) and
         // by ResetForTesting. We only restore engine-default state when this is
-        // true, so a normal launch that legitimately set the flag (line
-        // 835/387 of FlightDriver) is never disturbed.
+        // true, so a normal launch that legitimately set the flag (NEW_FROM_FILE
+        // hits line 835 of decompiled FlightDriver, RESUME_SAVED_CACHE hits line
+        // 387) is never disturbed. ComputeNaturalCanRevertToPostInit below
+        // mirrors only the RESUME_SAVED_CACHE formula, which is the only branch
+        // where forcedFlag could plausibly have been set true beforehand.
         private static bool forcedFlag;
         internal static bool ForcedFlagForTesting => forcedFlag;
 
@@ -65,6 +69,11 @@ namespace Parsek
         {
             ApplyForTesting = null;
             forcedFlag = false;
+            // Tear down any leftover GameEvents subscription so a test that
+            // called Subscribe() can re-Subscribe() in a follow-up test
+            // without double-registration. The Unsubscribe call is a no-op
+            // when subscribed=false.
+            Unsubscribe();
         }
 
         // KSP's EventData<T>.EvtDelegate..ctor reads evt.Target.GetType().Name
@@ -147,16 +156,24 @@ namespace Parsek
                 }
                 else if (forcedFlag)
                 {
+                    // Mirror the force-branch ordering: assign the engine
+                    // field FIRST, then drop the override-tracking bool. If the
+                    // field assignment threw, forcedFlag stays true and the
+                    // next Apply gets another chance to reset; if we dropped
+                    // forcedFlag first and the assignment threw, the override
+                    // would be silently forgotten and the engine flag stuck at
+                    // true forever.
                     bool natural = ComputeNaturalCanRevertToPostInit();
-                    forcedFlag = false;
                     if (FlightDriver.CanRevertToPostInit != natural)
                     {
                         FlightDriver.CanRevertToPostInit = natural;
+                        forcedFlag = false;
                         ParsekLog.Info(Tag,
                             $"ReFlyRevertButtonGate: reset FlightDriver.CanRevertToPostInit={natural} at {site ?? "(no-site)"} — re-fly marker cleared");
                     }
                     else
                     {
+                        forcedFlag = false;
                         ParsekLog.Verbose(Tag,
                             $"ReFlyRevertButtonGate: reset cleared override at {site ?? "(no-site)"} — flag already at natural value {natural}");
                     }

--- a/Source/Parsek/ReconciliationBundle.cs
+++ b/Source/Parsek/ReconciliationBundle.cs
@@ -208,6 +208,11 @@ namespace Parsek
 
                 scenario.ActiveReFlySessionMarker = bundle.ActiveReFlySessionMarker;
                 scenario.ActiveMergeJournal = bundle.ActiveMergeJournal;
+                // Re-fly Esc-menu button gate: this Restore can change the
+                // marker in either direction (success path before
+                // AtomicMarkerWrite — Apply re-fires there harmlessly;
+                // rollback path on a failed LoadGame — only reachable here).
+                ReFlyRevertButtonGate.Apply("ReconciliationBundle:Restore");
             }
 
             // CrewReservationManager.

--- a/Source/Parsek/RevertInterceptor.cs
+++ b/Source/Parsek/RevertInterceptor.cs
@@ -262,6 +262,7 @@ namespace Parsek
                 scenario.ActiveReFlySessionMarker = null;
                 Parsek.Rendering.RenderSessionState.Clear("marker-cleared");
                 scenario.BumpSupersedeStateVersion();
+                ReFlyRevertButtonGate.Apply("RetryHandler:marker-cleared");
                 ParsekLog.Verbose(SessionTag,
                     $"RetryHandler: marker cleared for sess={oldSessionId} target={target}; re-invoking rewind");
             }
@@ -353,6 +354,7 @@ namespace Parsek
                     Parsek.Rendering.RenderSessionState.Clear("marker-cleared");
                     scenario.ActiveMergeJournal = null;
                     scenario.BumpSupersedeStateVersion();
+                    ReFlyRevertButtonGate.Apply("DiscardReFlyHandler:rp-unresolvable");
                 }
 
                 PostScreenMessage("Discard Re-fly failed: rewind point missing");
@@ -395,6 +397,12 @@ namespace Parsek
                 Parsek.Rendering.RenderSessionState.Clear("marker-cleared");
                 scenario.ActiveMergeJournal = null;
                 scenario.BumpSupersedeStateVersion();
+                // Apply now so the failure paths in steps 8-9 (which may bail
+                // and leave the player in flight) do not strand a forced
+                // CanRevertToPostInit. The success path transitions out of
+                // flight where the next FlightDriver.Start will recompute,
+                // making the call a logged no-op there — cheap and consistent.
+                ReFlyRevertButtonGate.Apply("DiscardReFlyHandler:marker-cleared");
             }
 
             // Step 7: defensively clean up the prior session's temp quicksave

--- a/Source/Parsek/RewindInvoker.cs
+++ b/Source/Parsek/RewindInvoker.cs
@@ -914,6 +914,10 @@ namespace Parsek
                 CheckpointHookForTesting?.Invoke("CheckpointB:BeforeMarker");
                 scenario.ActiveReFlySessionMarker = marker;
                 scenario.BumpSupersedeStateVersion();
+                // Re-enable the Esc-menu Revert button (KSP grays it out
+                // because the loaded vessel is mid-flight, not PRELAUNCH;
+                // see ReFlyRevertButtonGate doc-comment).
+                ReFlyRevertButtonGate.Apply("AtomicMarkerWrite");
                 CheckpointHookForTesting?.Invoke("CheckpointB:AfterMarker");
             }
             catch
@@ -945,6 +949,7 @@ namespace Parsek
                     if (ParsekScenario.Instance != null)
                         ParsekScenario.Instance.ActiveReFlySessionMarker = null;
                     Parsek.Rendering.RenderSessionState.Clear("marker-cleared");
+                    ReFlyRevertButtonGate.Apply("AtomicMarkerWrite:rollback");
                 }
                 catch { /* idempotent rollback; swallow secondary failure */ }
                 throw;

--- a/Source/Parsek/SupersedeCommit.cs
+++ b/Source/Parsek/SupersedeCommit.cs
@@ -320,6 +320,11 @@ namespace Parsek
             scenario.ActiveReFlySessionMarker = null;
             Parsek.Rendering.RenderSessionState.Clear("marker-cleared");
             scenario.BumpSupersedeStateVersion();
+            // Drop any forced CanRevertToPostInit override now that the
+            // session is committed. Normally this commit happens at scene
+            // exit (KSC), so it's a no-op there; defensive against any future
+            // call site that commits while still in flight.
+            ReFlyRevertButtonGate.Apply("SupersedeCommit:marker-cleared");
 
             ParsekLog.Info(SessionTag,
                 $"End reason=merged sess={sessionId ?? "<no-id>"} provisional={provisional.RecordingId ?? "<no-id>"}");

--- a/Source/Parsek/TreeDiscardPurge.cs
+++ b/Source/Parsek/TreeDiscardPurge.cs
@@ -440,6 +440,7 @@ namespace Parsek
             scenario.ActiveReFlySessionMarker = null;
             Parsek.Rendering.RenderSessionState.Clear("marker-cleared");
             scenario.BumpSupersedeStateVersion();
+            ReFlyRevertButtonGate.Apply("TreeDiscardPurge:tree-discarded");
             ParsekLog.Info(SessionTag,
                 $"End reason=treeDiscarded sess={sessionId} tree={treeId}");
             return true;

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -110,38 +110,49 @@ When referencing prior item numbers from source comments or plans, consult the r
 - ~~P3-2: Cluster-Warn dedup regression test missing (plan §10.2 line item).~~ New `Outlier_ClusterWarn_DedupedAcrossRecompute` test in `SmoothingPipelineLoggingTests.cs` calls `FitAndStorePerSection` twice on the same kraken-clustered fixture and asserts exactly one Cluster Warn line emits across both calls. Pins the `s_clusterWarnLogged` HashSet behaviour. Companion `Outlier_PerSectionInfo_AlwaysEmitted_OnCleanSection` test pins the HR-9-visibility contract for clean sections.
 - ~~P3-4: `Pipeline_Outlier_Kraken` in-game test residual ratio too coarse + leaked overrides.~~ Added an absolute residual cap (10 km) alongside the existing 5x ratio so the test fails if the spline blows up to some other large offset. Removed the redundant `flags.SampleCount = sampleCount` line (Classify already sets it). The test already calls `SmoothingPipeline.ResetForTesting` before `yield break`, which clears `BodyResolverForTesting` and `UseOutlierRejectionResolverForTesting` (and `s_clusterWarnLogged`); a comment now documents that explicitly.
 
-## ~~681. Esc-menu Revert button grayed out during an active Re-Fly~~
+## ~~681. Esc-menu Revert to Launch grayed out during an active Re-Fly~~
 
-**Status:** ~~done~~ on PR #fix-revert-button-during-refly.
+**Status:** ~~done~~ on PR #670 (`fix-revert-button-during-refly`).
 
 KSP's `FlightDriver.Start` `RESUME_SAVED_CACHE` branch sets
 `CanRevertToPostInit = (vessel.situation == PRELAUNCH)` (decompile of
-`FlightDriver.cs:386-387`). When `RewindInvoker.StartInvoke` loads a rewind
+`FlightDriver.cs:387`). When `RewindInvoker.StartInvoke` loads a rewind
 point's quicksave via `FlightDriver.StartAndFocusVessel`, the focused vessel
 is mid-flight at the staging point, so the engine correctly computes false.
-`PreLaunchState` / `PostInitState` are also wiped by `GamePersistence.LoadGame`
-so `CanRevertToPrelaunch` lands false too. The pause menu's Revert button is
+`PreLaunchState` is also wiped by `GamePersistence.LoadGame` so
+`CanRevertToPrelaunch` lands false too. The pause menu's Revert button row is
 gated on `FlightDriver.CanRevert` (decompile of `PauseMenu.cs:573`) and
 gray-outs, blocking access to `RevertInterceptor.Prefix` and the 3-option
-Re-Fly dialog (Retry Re-Fly / Discard Re-Fly / Cancel) entirely.
+Re-Fly dialog (Retry Re-Fly / Discard Re-Fly / Cancel).
+
+Scope: this fix re-enables the **Revert to Launch** button only. The
+**Revert to VAB / SPH** options gate on `CanRevertToPrelaunch` (decompile of
+`PauseMenu.cs:1364`), which would also need `PreLaunchState` /
+`ShipConstruction.ShipConfig` repopulated — those are not safe to synthesise
+post-Re-Fly-load, so the prelaunch revert button stays gray. Re-fly cleanup
+through Revert-to-Launch + Discard Re-fly is the canonical exit path; the
+prelaunch path adds no functional capability the dialog does not already
+expose.
 
 **Fix:** new `ReFlyRevertButtonGate` static type force-sets
 `FlightDriver.CanRevertToPostInit = true` whenever an active re-fly marker
-exists, so the button stays clickable. The Harmony prefix on
-`FlightDriver.RevertToLaunch` short-circuits the stock body before it can
-dereference the null `PostInitState`, so the click only ever reaches our
-dialog. The gate tracks a single `forcedFlag` so it only restores engine
-defaults when we previously claimed ownership — a normal launch's
-legitimately-true flag (line 835/387) is never disturbed. Apply is wired at
-every marker change reachable from a flight scene: `AtomicMarkerWrite` (set),
-`OnLoad` (load with marker), `RetryHandler` / `DiscardReFlyHandler` /
-`SupersedeCommit` / `MergeJournalOrchestrator` / `LoadTimeSweep` /
-`TreeDiscardPurge` (clear), plus `GameEvents.onFlightReady` for the cold-load
-path. xUnit coverage in `ReFlyRevertButtonGateTests` (9 tests, force/reset
-cycle + idempotence + engine-true non-clobber + subscribe idempotence). Live
-in-game canary in `ReFlyRevertButtonGateTest` asserts the engine flag actually
-flips on the live `FlightDriver` static and that `FlightDriver.CanRevert` is
-true while the marker is active.
+exists. The Harmony prefix on `FlightDriver.RevertToLaunch` short-circuits the
+stock body before it can replay the captured `PostInitState`, which now
+holds the mid-flight RP-quicksave state rather than a launch-time backup —
+`FlightDriver.PostInit` rebuilds it on every scene load. The click only ever
+reaches our dialog. The gate tracks a single `forcedFlag` so it only restores
+engine defaults when we previously claimed ownership — a normal launch's
+legitimately-true flag is never disturbed. Apply is wired at every marker
+change reachable from a flight scene: `AtomicMarkerWrite` (set),
+`ReconciliationBundle.Restore` (load + rollback), `OnLoad` (cold load with
+marker), `RetryHandler` / `DiscardReFlyHandler` / `SupersedeCommit` /
+`MergeJournalOrchestrator` / `LoadTimeSweep` / `TreeDiscardPurge` (clear),
+plus `GameEvents.onFlightReady` for the cold-load-then-flight path. xUnit
+coverage in `ReFlyRevertButtonGateTests` (force/reset cycle + idempotence +
+engine-true non-clobber + subscribe idempotence). Live in-game canary in
+`ReFlyRevertButtonGateTest` asserts the engine flag actually flips on the
+live `FlightDriver` static and that `FlightDriver.CanRevert` is true while
+the marker is active.
 
 ## 638. Historical reference: Re-Fly post-merge RELATIVE-to-ABSOLUTE promotion plan
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -110,6 +110,39 @@ When referencing prior item numbers from source comments or plans, consult the r
 - ~~P3-2: Cluster-Warn dedup regression test missing (plan §10.2 line item).~~ New `Outlier_ClusterWarn_DedupedAcrossRecompute` test in `SmoothingPipelineLoggingTests.cs` calls `FitAndStorePerSection` twice on the same kraken-clustered fixture and asserts exactly one Cluster Warn line emits across both calls. Pins the `s_clusterWarnLogged` HashSet behaviour. Companion `Outlier_PerSectionInfo_AlwaysEmitted_OnCleanSection` test pins the HR-9-visibility contract for clean sections.
 - ~~P3-4: `Pipeline_Outlier_Kraken` in-game test residual ratio too coarse + leaked overrides.~~ Added an absolute residual cap (10 km) alongside the existing 5x ratio so the test fails if the spline blows up to some other large offset. Removed the redundant `flags.SampleCount = sampleCount` line (Classify already sets it). The test already calls `SmoothingPipeline.ResetForTesting` before `yield break`, which clears `BodyResolverForTesting` and `UseOutlierRejectionResolverForTesting` (and `s_clusterWarnLogged`); a comment now documents that explicitly.
 
+## ~~681. Esc-menu Revert button grayed out during an active Re-Fly~~
+
+**Status:** ~~done~~ on PR #fix-revert-button-during-refly.
+
+KSP's `FlightDriver.Start` `RESUME_SAVED_CACHE` branch sets
+`CanRevertToPostInit = (vessel.situation == PRELAUNCH)` (decompile of
+`FlightDriver.cs:386-387`). When `RewindInvoker.StartInvoke` loads a rewind
+point's quicksave via `FlightDriver.StartAndFocusVessel`, the focused vessel
+is mid-flight at the staging point, so the engine correctly computes false.
+`PreLaunchState` / `PostInitState` are also wiped by `GamePersistence.LoadGame`
+so `CanRevertToPrelaunch` lands false too. The pause menu's Revert button is
+gated on `FlightDriver.CanRevert` (decompile of `PauseMenu.cs:573`) and
+gray-outs, blocking access to `RevertInterceptor.Prefix` and the 3-option
+Re-Fly dialog (Retry Re-Fly / Discard Re-Fly / Cancel) entirely.
+
+**Fix:** new `ReFlyRevertButtonGate` static type force-sets
+`FlightDriver.CanRevertToPostInit = true` whenever an active re-fly marker
+exists, so the button stays clickable. The Harmony prefix on
+`FlightDriver.RevertToLaunch` short-circuits the stock body before it can
+dereference the null `PostInitState`, so the click only ever reaches our
+dialog. The gate tracks a single `forcedFlag` so it only restores engine
+defaults when we previously claimed ownership — a normal launch's
+legitimately-true flag (line 835/387) is never disturbed. Apply is wired at
+every marker change reachable from a flight scene: `AtomicMarkerWrite` (set),
+`OnLoad` (load with marker), `RetryHandler` / `DiscardReFlyHandler` /
+`SupersedeCommit` / `MergeJournalOrchestrator` / `LoadTimeSweep` /
+`TreeDiscardPurge` (clear), plus `GameEvents.onFlightReady` for the cold-load
+path. xUnit coverage in `ReFlyRevertButtonGateTests` (9 tests, force/reset
+cycle + idempotence + engine-true non-clobber + subscribe idempotence). Live
+in-game canary in `ReFlyRevertButtonGateTest` asserts the engine flag actually
+flips on the live `FlightDriver` static and that `FlightDriver.CanRevert` is
+true while the marker is active.
+
 ## 638. Historical reference: Re-Fly post-merge RELATIVE-to-ABSOLUTE promotion plan
 
 **Status:** Historical, deferred — not active correctness work.


### PR DESCRIPTION
## Summary

- KSP's pause-menu Revert button was grayed out for the entire duration of a Re-Fly because `FlightDriver.Start` (RESUME_SAVED_CACHE branch) sets `CanRevertToPostInit` only when `vessel.situation == PRELAUNCH`. The button is gated on `FlightDriver.CanRevert` (per [PauseMenu decompile](https://github.com/PrincipiaCode/KSP-decomp) line 573 equivalent), so the existing `RevertInterceptor` 3-option dialog (Retry Re-Fly / Discard Re-Fly / Cancel) was unreachable from the Esc menu.
- New `ReFlyRevertButtonGate` static type force-sets `FlightDriver.CanRevertToPostInit = true` while a re-fly marker is active. The Harmony prefix on `FlightDriver.RevertToLaunch` already short-circuits the stock body before it can deref the null `PostInitState`, so the click only ever reaches our dialog.
- Single `forcedFlag` tracks ownership: the gate only restores engine defaults when it previously claimed the override, so a normal launch's legitimately-true flag is never disturbed.
- Apply is wired at every marker change reachable from a flight scene: `AtomicMarkerWrite` (set), `OnLoad`-after-marker-load (cold load), `RetryHandler` / `DiscardReFlyHandler` / `SupersedeCommit` / `MergeJournalOrchestrator` / `LoadTimeSweep` / `TreeDiscardPurge` (clear), plus `GameEvents.onFlightReady` for the cold-load path.

## Investigation

Decompile reference (under `KSP_x64_Data/Managed/Assembly-CSharp.dll`):
- `FlightDriver.cs:386-387` — `CanRevertToPostInit = vessel.situation == Vessel.Situations.PRELAUNCH;`
- `FlightDriver.cs:94-117` — `CanRevert => CanRevertToPrelaunch || CanRevertToPostInit`
- `PauseMenu.cs:573` — Revert button interactable predicate `=> FlightDriver.CanRevert`

The bug surfaces because `RewindInvoker` loads via `FlightDriver.StartAndFocusVessel(game, idx)` which takes the `RESUME_SAVED_CACHE` path and the focused vessel at a Rewind Point is mid-flight (FLYING/SUB_ORBITAL), not PRELAUNCH. `PreLaunchState` and `PostInitState` were also wiped by `GamePersistence.LoadGame`, so `CanRevertToPrelaunch` lands false too.

## Test plan

- [x] `dotnet test` — 9986 / 9986 pass (9 new in `ReFlyRevertButtonGateTests`).
- [x] DLL deployed and verified (UTF-16 strings present in Plugins copy).
- [ ] In-game smoke: start a Re-Fly of a side-off booster, click Esc — Revert to Launch button is interactable. Click Revert: Parsek dialog appears (Retry Re-Fly / Discard Re-Fly / Cancel).
- [ ] Discard Re-Fly transitions to Space Center cleanly.
- [ ] Retry Re-Fly re-runs the rewind and lands back in flight.
- [ ] Normal launch (no Re-Fly) Revert button still works (control case — engine-set-true non-clobber).
- [ ] In-game tests `Gate_ForcesFlagTrue_WhenMarkerActive_AndRestoresOnClear` and `Gate_DoesNotClobber_LegitimateFlagTrue_WhenInactive` pass via Ctrl+Shift+T.