### PR TITLE
Clear stale Destroyed terminal on Re-Fly resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- A vessel that was incorrectly stamped `Destroyed` mid-flight by a transient finalizer fallback (e.g. during stage decouple) no longer remains stuck as Destroyed in STASH after the player rewinds and resumes flying it. Re-Fly resume now clears the stale terminal verdict so the FinalizerCache re-evaluates the vessel's live state.
 - The Esc-menu Revert to Launch button is no longer grayed out during an active Re-Fly. The loaded rewind-point quicksave is mid-flight so KSP correctly disables the button, but Parsek's interceptor (Retry / Discard Re-Fly / Cancel dialog) was unreachable as a result. While a Re-Fly session marker is active the button is force-enabled so clicking it routes into the Parsek dialog; on marker clear the engine's natural state is restored.
 - The Recordings table uses the original Actions column width again, with full-word `Rewind` and `Forward` action labels plus compact button padding so `Fly`/`Seal` and `Stash` still fit without widening the table.
 - Stock retractable ladders no longer render extended in the ghost when the recorded vessel had them stowed. Solar panels, gear, animation groups, animate-generic, and aero/control-surface deployables get the same first-spawn stow baseline.

--- a/Source/Parsek.Tests/SceneExitFinalizationIntegrationTests.cs
+++ b/Source/Parsek.Tests/SceneExitFinalizationIntegrationTests.cs
@@ -2248,5 +2248,142 @@ namespace Parsek.Tests
             });
             return cache;
         }
+
+        [Fact]
+        public void ClearStaleDestroyedTerminalForResume_RecordingWithDestroyedVerdict_ClearsAndReleasesShortCircuit()
+        {
+            // Regression for the FinalizerCache sticky-Destroyed bug: a transient
+            // NullSolver event mid-flight stamped TerminalStateValue=Destroyed
+            // via the sub-surface path. After the player rewinds and resumes
+            // flight, we must clear the stale verdict so subsequent FinalizerCache
+            // refreshes can re-evaluate the (now alive) vessel.
+            var rec = new Recording
+            {
+                RecordingId = "stale-destroyed-rec",
+                TerminalStateValue = TerminalState.Destroyed,
+                ExplicitEndUT = 159.7
+            };
+            rec.Points.Add(new TrajectoryPoint { ut = 100.0, altitude = 5000.0, bodyName = "Kerbin" });
+            rec.Points.Add(new TrajectoryPoint { ut = 159.0, altitude = 80000.0, bodyName = "Kerbin" });
+
+            // Pre-condition: the short-circuit fires while the verdict is sticky.
+            Assert.True(IncompleteBallisticSceneExitFinalizer.IsAlreadyClassifiedDestroyed(rec));
+
+            bool cleared = IncompleteBallisticSceneExitFinalizer.ClearStaleDestroyedTerminalForResume(
+                rec,
+                "RestoreActiveTreeFromPending");
+
+            Assert.True(cleared);
+            Assert.False(rec.TerminalStateValue.HasValue);
+            Assert.True(double.IsNaN(rec.ExplicitEndUT));
+            // Post-condition: the short-circuit no longer fires, so the cache producer
+            // can re-evaluate the recording from the live vessel state.
+            Assert.False(IncompleteBallisticSceneExitFinalizer.IsAlreadyClassifiedDestroyed(rec));
+            Assert.Contains(logLines, l =>
+                l.Contains("[Parsek][INFO][Extrapolator]") &&
+                l.Contains("RestoreActiveTreeFromPending") &&
+                l.Contains("cleared stale Destroyed terminal for resume") &&
+                l.Contains("rec=stale-destroyed-rec") &&
+                l.Contains("previousTerminalUT=159.7"));
+        }
+
+        [Fact]
+        public void ClearStaleDestroyedTerminalForResume_RecordingWithoutTerminalState_NoOp()
+        {
+            // Recording that hasn't been finalized yet — never had a Destroyed
+            // verdict, so ClearStaleDestroyedTerminalForResume must do nothing
+            // and emit no log line.
+            var rec = new Recording
+            {
+                RecordingId = "live-rec-not-destroyed",
+                ExplicitEndUT = double.NaN
+            };
+            rec.Points.Add(new TrajectoryPoint { ut = 100.0, altitude = 5000.0, bodyName = "Kerbin" });
+
+            bool cleared = IncompleteBallisticSceneExitFinalizer.ClearStaleDestroyedTerminalForResume(
+                rec,
+                "RestoreActiveTreeFromPending");
+
+            Assert.False(cleared);
+            Assert.False(rec.TerminalStateValue.HasValue);
+            Assert.True(double.IsNaN(rec.ExplicitEndUT));
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("cleared stale Destroyed terminal for resume"));
+        }
+
+        [Fact]
+        public void ClearStaleDestroyedTerminalForResume_RecordingWithOrbitingVerdict_NoOpAndKeepsVerdict()
+        {
+            // Only Destroyed verdicts trigger the short-circuit, so only Destroyed
+            // verdicts get cleared. A legitimate Orbiting/Landed/Splashed verdict
+            // must survive (it represents a real terminal classification that
+            // ghost playback / spawning depend on).
+            var rec = new Recording
+            {
+                RecordingId = "orbiting-rec",
+                TerminalStateValue = TerminalState.Orbiting,
+                ExplicitEndUT = 500.0
+            };
+
+            bool cleared = IncompleteBallisticSceneExitFinalizer.ClearStaleDestroyedTerminalForResume(
+                rec,
+                "RestoreActiveTreeFromPending");
+
+            Assert.False(cleared);
+            Assert.Equal(TerminalState.Orbiting, rec.TerminalStateValue);
+            Assert.Equal(500.0, rec.ExplicitEndUT);
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("cleared stale Destroyed terminal for resume"));
+        }
+
+        [Fact]
+        public void ClearStaleDestroyedTerminalForResume_NullRecording_ReturnsFalseSafely()
+        {
+            bool cleared = IncompleteBallisticSceneExitFinalizer.ClearStaleDestroyedTerminalForResume(
+                null,
+                "RestoreActiveTreeFromPending");
+
+            Assert.False(cleared);
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("cleared stale Destroyed terminal for resume"));
+        }
+
+        [Fact]
+        public void ClearStaleDestroyedTerminalForResume_AfterClear_FinalizerCacheRefreshNoLongerShortCircuits()
+        {
+            // End-to-end: with a stale Destroyed verdict, TryBuildAlreadyClassifiedDestroyedSkip
+            // returns true (cache short-circuits). After ClearStaleDestroyedTerminalForResume,
+            // it returns false — releasing the cache to do a real refresh.
+            var rec = new Recording
+            {
+                RecordingId = "end-to-end-rec",
+                VesselPersistentId = 12345u,
+                TerminalStateValue = TerminalState.Destroyed,
+                ExplicitEndUT = 150.0
+            };
+
+            bool skipsBefore = RecordingFinalizationCacheProducer.TryBuildAlreadyClassifiedDestroyedSkip(
+                rec,
+                vesselPid: 12345u,
+                owner: FinalizationCacheOwner.ActiveRecorder,
+                refreshUT: 200.0,
+                reason: "test-before-clear",
+                cache: out _);
+            Assert.True(skipsBefore);
+
+            bool cleared = IncompleteBallisticSceneExitFinalizer.ClearStaleDestroyedTerminalForResume(
+                rec,
+                "RestoreActiveTreeFromPending");
+            Assert.True(cleared);
+
+            bool skipsAfter = RecordingFinalizationCacheProducer.TryBuildAlreadyClassifiedDestroyedSkip(
+                rec,
+                vesselPid: 12345u,
+                owner: FinalizationCacheOwner.ActiveRecorder,
+                refreshUT: 200.0,
+                reason: "test-after-clear",
+                cache: out _);
+            Assert.False(skipsAfter);
+        }
     }
 }

--- a/Source/Parsek/IncompleteBallisticSceneExitFinalizer.cs
+++ b/Source/Parsek/IncompleteBallisticSceneExitFinalizer.cs
@@ -251,6 +251,47 @@ namespace Parsek
                 && recording.TerminalStateValue.Value == TerminalState.Destroyed;
         }
 
+        /// <summary>
+        /// Clears a stale <c>Destroyed</c> terminal verdict on a recording that
+        /// is being re-armed for active recording (Re-Fly resume / quickload).
+        /// The earlier verdict came from <c>TryFinalizeRecording</c>'s sub-surface
+        /// path firing on a transient <c>NullSolver</c> live-orbit fallback (e.g.
+        /// during stage decouple). Once the player rewinds and resumes flight,
+        /// the vessel is alive again, but the cached verdict makes
+        /// <see cref="IsAlreadyClassifiedDestroyed"/> short-circuit every
+        /// FinalizerCache refresh thereafter. Clearing
+        /// <c>TerminalStateValue</c> + <c>ExplicitEndUT</c> releases that
+        /// short-circuit so the next refresh observes the live (now orbiting)
+        /// state. Returns <c>true</c> when a stale verdict was actually cleared,
+        /// so callers can attribute the log line to a real state change.
+        /// </summary>
+        internal static bool ClearStaleDestroyedTerminalForResume(
+            Recording recording,
+            string logContext)
+        {
+            if (!IsAlreadyClassifiedDestroyed(recording))
+                return false;
+
+            string recordingId = recording.RecordingId ?? "(null)";
+            double previousTerminalUT = !double.IsNaN(recording.ExplicitEndUT)
+                ? recording.ExplicitEndUT
+                : recording.EndUT;
+
+            recording.TerminalStateValue = null;
+            recording.ExplicitEndUT = double.NaN;
+            recording.MarkFilesDirty();
+
+            ParsekLog.Info("Extrapolator",
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    "{0}: cleared stale Destroyed terminal for resume rec={1} previousTerminalUT={2:F1}; " +
+                    "FinalizerCache will re-evaluate on next refresh",
+                    string.IsNullOrEmpty(logContext) ? "ResumeRecording" : logContext,
+                    recordingId,
+                    previousTerminalUT));
+            return true;
+        }
+
         internal static void LogAlreadyClassifiedDestroyedSkip(
             Recording recording,
             string context,

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -9297,6 +9297,20 @@ namespace Parsek
             // unset produces one extra boundary point on the next chain continuation,
             // which is benign. See SaveActiveTreeIfAny for the write-side comment.
 
+            // Bug fix: clear any stale Destroyed terminal verdict on the
+            // recording we're about to resume. A transient NullSolver event
+            // earlier in the recording (e.g. stage decouple) may have made
+            // TryFinalizeRecording fall back to live-orbit and stamp Destroyed
+            // via the sub-surface path. Without this clear, FinalizerCache's
+            // already-classified-destroyed short-circuit declines every refresh
+            // for the rest of the session, and the vessel stays labelled
+            // "Destroyed" in the STASH UI even though the player is flying it
+            // again post-rewind. The stamp lives on the Recording, so resetting
+            // the in-memory FinalizationCache via StartRecording is not enough.
+            IncompleteBallisticSceneExitFinalizer.ClearStaleDestroyedTerminalForResume(
+                activeRec,
+                "RestoreActiveTreeFromPending");
+
             // Start recording as a promotion (isPromotion: true) so the Bug A seed-event
             // skip kicks in — no duplicate DeployableExtended / LightOn / etc. events at
             // the quickload UT. The new recorder's buffers start empty and will append

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -110,6 +110,59 @@ When referencing prior item numbers from source comments or plans, consult the r
 - ~~P3-2: Cluster-Warn dedup regression test missing (plan §10.2 line item).~~ New `Outlier_ClusterWarn_DedupedAcrossRecompute` test in `SmoothingPipelineLoggingTests.cs` calls `FitAndStorePerSection` twice on the same kraken-clustered fixture and asserts exactly one Cluster Warn line emits across both calls. Pins the `s_clusterWarnLogged` HashSet behaviour. Companion `Outlier_PerSectionInfo_AlwaysEmitted_OnCleanSection` test pins the HR-9-visibility contract for clean sections.
 - ~~P3-4: `Pipeline_Outlier_Kraken` in-game test residual ratio too coarse + leaked overrides.~~ Added an absolute residual cap (10 km) alongside the existing 5x ratio so the test fails if the spline blows up to some other large offset. Removed the redundant `flags.SampleCount = sampleCount` line (Classify already sets it). The test already calls `SmoothingPipeline.ResetForTesting` before `yield break`, which clears `BodyResolverForTesting` and `UseOutlierRejectionResolverForTesting` (and `s_clusterWarnLogged`); a comment now documents that explicitly.
 
+## ~~682. FinalizerCache sticky `Destroyed` survives Re-Fly resume, vessel stays in STASH labelled "Destroyed"~~
+
+**Status:** ~~done~~ on branch `fix-uf-finalizer-sticky`.
+
+A vessel mid-flight can hit a transient `PatchedConicSnapshot` `NullSolver`
+(e.g. during a stage-decouple frame where KSP has torn down the patched-conic
+solver). `IncompleteBallisticSceneExitFinalizer.TryFinalizeRecording` falls
+back to the live-orbit state, which can be degenerate (position collapsed
+near the body frame origin → altitude ≈ -bodyRadius). The
+`BallisticExtrapolator` sub-surface guard then stamps
+`recording.TerminalStateValue = TerminalState.Destroyed` and
+`recording.ExplicitEndUT = terminalUT` (this stamping is intentional — the
+fingerprint matches a real torn-down vessel and the in-game test
+`Extrapolate_SubSurfaceStart_ClassifiesAsDestroyedWithoutRunningScan` pins it).
+
+The bug: when the player rewinds and resumes flight via Re-Fly,
+`ParsekFlight.RestoreActiveTreeFromPending` reinstalls the tree and starts a
+fresh `FlightRecorder`. `StartRecording` resets the in-memory
+`FinalizationCache` to null, but the stale `TerminalStateValue = Destroyed`
+on the Recording itself survives. Every subsequent FinalizerCache refresh
+calls `IncompleteBallisticSceneExitFinalizer.IsAlreadyClassifiedDestroyed`,
+sees the verdict, and short-circuits via
+`TryBuildAlreadyClassifiedDestroyedSkip` with
+`decline=already-classified-destroyed`. The vessel stays labelled "Destroyed"
+in the STASH UI for the rest of the session even though the player flies it
+to a stable orbit.
+
+Reproduction: rewind a multi-stage flight via Rewind-to-Separation after the
+upper stage was ever momentarily flagged Destroyed mid-flight, then continue
+the upper stage to orbit. Pre-fix the recording stays Destroyed in STASH;
+post-fix it re-evaluates to `Orbiting` once the vessel reaches a stable orbit.
+See `logs/2026-04-30_2011_uf-stash-bug/KSP.log` for the canonical trace.
+
+**Fix:** new `IncompleteBallisticSceneExitFinalizer.ClearStaleDestroyedTerminalForResume(recording, logContext)`
+helper clears `TerminalStateValue` + `ExplicitEndUT` and emits an Info log
+with the previous terminalUT, only when the recording was actually
+classified Destroyed (no-op otherwise, including `null` recordings). The
+helper is called from `RestoreActiveTreeFromPending` immediately before the
+fresh `FlightRecorder.StartRecording(isPromotion: true)`, after the in-place
+continuation marker swap and PID remap so the cleared recording matches
+exactly the one that's about to be resumed. `MarkFilesDirty` is invoked so
+the cleared verdict persists across the next save. xUnit coverage in
+`SceneExitFinalizationIntegrationTests` (5 tests): clears + log assertion,
+no-op when never classified, no-op when verdict is non-Destroyed
+(Orbiting/Landed/Splashed survive), null-safe path, and an end-to-end test
+that walks `RecordingFinalizationCacheProducer.TryBuildAlreadyClassifiedDestroyedSkip`
+before and after the clear to prove the cache short-circuit is actually
+released. The narrower NullSolver-rejection option (refusing to stamp
+Destroyed when the live-orbit fallback altitude is catastrophically
+sub-surface) was deferred — the existing `BallisticExtrapolator` sub-surface
+test pins the current behaviour as intentional, and reversing it without
+deeper analysis would risk legitimate torn-down-vessel detection.
+
 ## ~~681. Esc-menu Revert to Launch grayed out during an active Re-Fly~~
 
 **Status:** ~~done~~ on PR #670 (`fix-revert-button-during-refly`).


### PR DESCRIPTION
## Summary

- A vessel mid-flight can hit a transient `PatchedConicSnapshot` `NullSolver` (e.g. during stage decouple). The finalizer falls back to live-orbit, which can be degenerate (position collapsed near the body frame origin -> altitude near `-bodyRadius`), and the sub-surface guard stamps `TerminalStateValue = Destroyed` on the Recording. After Re-Fly resume the in-memory `FinalizationCache` is reset by `StartRecording`, but the stamp on the Recording itself survives, so every subsequent `FinalizerCache` refresh short-circuits via `IsAlreadyClassifiedDestroyed`. The vessel stays labelled "Destroyed" in STASH for the rest of the session even after it reaches a stable orbit.
- Fix: new `IncompleteBallisticSceneExitFinalizer.ClearStaleDestroyedTerminalForResume(recording, logContext)` helper clears `TerminalStateValue` + `ExplicitEndUT`, calls `MarkFilesDirty`, and emits an Info log when a stale Destroyed verdict was actually cleared (no-op otherwise, including null recordings). Called from `ParsekFlight.RestoreActiveTreeFromPending` immediately before `recorder.StartRecording(isPromotion: true)`, after the in-place continuation marker swap and PID remap so the cleared recording matches exactly the one being resumed.
- Scope: cache-invalidation-on-resume only (Option 1). The narrower NullSolver-rejection option (Option 2 — refusing to stamp Destroyed when the live-orbit fallback altitude is catastrophically sub-surface) was deferred. The existing `Extrapolate_SubSurfaceStart_ClassifiesAsDestroyedWithoutRunningScan` test pins the current sub-surface behaviour as intentional (it matches a real torn-down vessel fingerprint), and reversing that without deeper analysis would risk legitimate destroyed-vessel detection. The cache invalidation alone fully resolves the user-visible symptom.
- The fix only addresses the single active recording being resumed (`activeRec` after the marker swap + EVA-parent walk). `RestoreActiveTreeFromPendingForVesselSwitch` arms a watcher rather than resuming an active recording, so it does not have the same exposure.

## Test plan

- [x] `dotnet test` -- 10000 passed / 0 failed / 0 skipped.
- [x] `ClearStaleDestroyedTerminalForResume_RecordingWithDestroyedVerdict_ClearsAndReleasesShortCircuit` (clears + log assertion).
- [x] `ClearStaleDestroyedTerminalForResume_RecordingWithoutTerminalState_NoOp` (no-op when never classified).
- [x] `ClearStaleDestroyedTerminalForResume_RecordingWithOrbitingVerdict_NoOpAndKeepsVerdict` (legitimate Orbiting/Landed/Splashed survive).
- [x] `ClearStaleDestroyedTerminalForResume_NullRecording_ReturnsFalseSafely` (null-safe path).
- [x] `ClearStaleDestroyedTerminalForResume_AfterClear_FinalizerCacheRefreshNoLongerShortCircuits` (end-to-end through `RecordingFinalizationCacheProducer.TryBuildAlreadyClassifiedDestroyedSkip` before and after the clear).
- [ ] In-game playtest: load the original `2026-04-30_2011_uf-stash-bug` save with the Kerbal X recording stamped Destroyed, enter Re-Fly via Rewind-to-Separation, fly the upper stage to a stable orbit, observe Kerbal X exits the STASH "Destroyed" group on the next FinalizerCache refresh (within ~5 s of orbit insertion).
- [ ] In-game playtest: confirm the cleared verdict round-trips through quicksave/quickload during the Re-Fly session (the next save after the clear should not re-stamp Destroyed until a legitimate finalization fires).