### PR TITLE
Add Re-Fly trajectory shrink diagnostics

### DIFF
--- a/Source/Parsek.Tests/Bug585FollowupSaveSkipTests.cs
+++ b/Source/Parsek.Tests/Bug585FollowupSaveSkipTests.cs
@@ -329,5 +329,88 @@ namespace Parsek.Tests
                 l.Contains("SaveRecordingFiles: skipping write") &&
                 l.Contains(fresh.RecordingId));
         }
+
+        [Fact]
+        public void SaveRecordingFiles_OnePointSectionAuthoritativeShrink_LogsWarningAndStillWrites()
+        {
+            var original = new Recording
+            {
+                RecordingId = "refly-shrink-hardening",
+                RecordingFormatVersion = RecordingStore.CurrentRecordingFormatVersion,
+                SidecarEpoch = 8,
+            };
+
+            for (int i = 0; i < 12; i++)
+            {
+                original.Points.Add(new TrajectoryPoint
+                {
+                    ut = 100.0 + i,
+                    latitude = -0.05,
+                    longitude = -74.5,
+                    altitude = 1000.0 + i * 50.0,
+                    bodyName = "Kerbin",
+                });
+            }
+
+            string precPath = Path.Combine(tempDir, original.RecordingId + ".prec");
+            string vesselPath = Path.Combine(tempDir, original.RecordingId + "_vessel.craft");
+            string ghostPath = Path.Combine(tempDir, original.RecordingId + "_ghost.craft");
+
+            Assert.False(RecordingStore.ShouldWriteSectionAuthoritativeTrajectory(original));
+            Assert.True(RecordingStore.SaveRecordingFilesToPathsForTesting(
+                original, precPath, vesselPath, ghostPath, incrementEpoch: true));
+
+            int originalEpoch = original.SidecarEpoch;
+
+            TrajectoryPoint onlyPoint = original.Points[0];
+            var shrink = new Recording
+            {
+                RecordingId = original.RecordingId,
+                RecordingFormatVersion = RecordingStore.CurrentRecordingFormatVersion,
+                SidecarEpoch = originalEpoch,
+                FilesDirty = true,
+            };
+            shrink.Points.Add(onlyPoint);
+            shrink.TrackSections.Add(new TrackSection
+            {
+                environment = SegmentEnvironment.SurfaceMobile,
+                referenceFrame = ReferenceFrame.Absolute,
+                source = TrackSectionSource.Active,
+                startUT = onlyPoint.ut,
+                endUT = onlyPoint.ut,
+                frames = new List<TrajectoryPoint> { onlyPoint },
+                checkpoints = new List<OrbitSegment>(),
+            });
+            Assert.True(RecordingStore.ShouldWriteSectionAuthoritativeTrajectory(shrink));
+
+            logLines.Clear();
+            Assert.True(RecordingStore.SaveRecordingFilesToPathsForTesting(
+                shrink, precPath, vesselPath, ghostPath, incrementEpoch: true));
+            Assert.Equal(originalEpoch + 1, shrink.SidecarEpoch);
+
+            var restored = new Recording { RecordingId = original.RecordingId };
+            Assert.True(RecordingStore.LoadTrajectorySidecarForTesting(precPath, restored));
+            Assert.Single(restored.Points);
+            Assert.Equal(onlyPoint.ut, restored.Points[0].ut, 6);
+
+            TrajectorySidecarProbe diskProbe;
+            Assert.True(RecordingStore.TryProbeTrajectorySidecar(precPath, out diskProbe));
+            Assert.Equal(originalEpoch + 1, diskProbe.SidecarEpoch);
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[RecordingStore]") &&
+                l.Contains("near-empty section-authoritative trajectory will overwrite richer existing sidecar") &&
+                l.Contains("recId=" + original.RecordingId) &&
+                l.Contains("currentEpoch=" + originalEpoch) &&
+                l.Contains("nextEpoch=" + (originalEpoch + 1)) &&
+                l.Contains("existingProbeRecordingId=" + original.RecordingId) &&
+                l.Contains("existingProbeEpoch=" + originalEpoch) &&
+                l.Contains("existingProbeVersion=" + RecordingStore.CurrentRecordingFormatVersion) &&
+                l.Contains("existingProbeEncoding=BinaryV3") &&
+                l.Contains("existingPoints=12") &&
+                l.Contains("incomingPoints=1") &&
+                l.Contains("sectionAuthoritative=True") &&
+                l.Contains("continuing normal save"));
+        }
     }
 }

--- a/Source/Parsek.Tests/SpawnSafetyNetTests.cs
+++ b/Source/Parsek.Tests/SpawnSafetyNetTests.cs
@@ -884,6 +884,47 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void BuildValidatedRespawnSnapshot_EmptyVesselSnapshotWithGhostParts_LogsExplicitCounts()
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            snapshot.AddValue("sit", "LANDED");
+            snapshot.AddValue("lat", "1.0");
+            snapshot.AddValue("lon", "2.0");
+            snapshot.AddValue("alt", "3.0");
+
+            var ghostSnapshot = new ConfigNode("VESSEL");
+            ghostSnapshot.AddNode("PART").AddValue("name", "probeCoreOcto");
+
+            var rec = new Recording
+            {
+                RecordingId = "empty-vessel-with-ghost",
+                VesselName = "Surface Continuation",
+                VesselSnapshot = snapshot,
+                GhostVisualSnapshot = ghostSnapshot,
+                TerminalStateValue = TerminalState.Landed
+            };
+
+            ConfigNode validated = VesselSpawner.BuildValidatedRespawnSnapshot(
+                rec,
+                currentUT: 158.14,
+                logContext: "KSC spawn",
+                out string rejectionReason);
+
+            Assert.Null(validated);
+            Assert.Contains("no PART", rejectionReason);
+            Assert.Contains("terminalState=Landed", rejectionReason);
+            Assert.Contains("vesselSnapshotParts=0", rejectionReason);
+            Assert.Contains("ghostSnapshotParts=1", rejectionReason);
+            Assert.Contains("empty-vessel-with-ghost", rejectionReason);
+            Assert.Contains(logLines, l =>
+                l.Contains("[Spawner]") &&
+                l.Contains("rejected materialization") &&
+                l.Contains("Surface Continuation") &&
+                l.Contains("ghostSnapshotParts=1") &&
+                l.Contains("terminalState=Landed"));
+        }
+
+        [Fact]
         public void BuildValidatedRespawnSnapshot_NonFiniteSurfaceVector_RejectsBeforeMaterialization()
         {
             TestBodyRegistry.Install(("Kerbin", 600000.0, 3.5316e12));

--- a/Source/Parsek/RecordingSidecarStore.cs
+++ b/Source/Parsek/RecordingSidecarStore.cs
@@ -657,6 +657,130 @@ namespace Parsek
                 && !hasGhost;
         }
 
+        internal static bool TryBuildTrajectoryShrinkageWarningForSave(
+            Recording rec,
+            string precPath,
+            bool incrementEpoch,
+            out string warning)
+        {
+            warning = null;
+            if (rec == null || string.IsNullOrEmpty(precPath) || !File.Exists(precPath))
+                return false;
+
+            TrajectoryPersistenceSummary incoming = SummarizeTrajectoryForWrite(rec);
+            if (!incoming.SectionAuthoritative || incoming.EffectivePointCount > 1)
+                return false;
+
+            if (!TrySummarizeExistingTrajectorySidecar(precPath, rec, out TrajectoryPersistenceSummary existing))
+                return false;
+
+            const int existingPointThreshold = 10;
+            if (existing.EffectivePointCount < existingPointThreshold)
+                return false;
+
+            int nextSidecarEpoch = rec.SidecarEpoch + (incrementEpoch ? 1 : 0);
+            warning = string.Format(
+                CultureInfo.InvariantCulture,
+                "SaveRecordingFiles: near-empty section-authoritative trajectory will overwrite richer existing sidecar " +
+                "recId={0} currentEpoch={1} nextEpoch={2} existingProbeRecordingId={3} " +
+                "existingProbeEpoch={4} existingProbeVersion={5} existingProbeEncoding={6} " +
+                "existingPoints={7} incomingPoints={8} existingSections={9} incomingSections={10} " +
+                "sectionAuthoritative={11} path='{12}' - continuing normal save (diagnostic only)",
+                string.IsNullOrEmpty(rec.RecordingId) ? "<none>" : rec.RecordingId,
+                rec.SidecarEpoch,
+                nextSidecarEpoch,
+                string.IsNullOrEmpty(existing.ProbeRecordingId) ? "<none>" : existing.ProbeRecordingId,
+                existing.ProbeSidecarEpoch,
+                existing.ProbeFormatVersion,
+                existing.ProbeEncoding,
+                existing.EffectivePointCount,
+                incoming.EffectivePointCount,
+                existing.TrackSectionCount,
+                incoming.TrackSectionCount,
+                incoming.SectionAuthoritative,
+                FormatPathForSidecarLog(precPath));
+            return true;
+        }
+
+        private struct TrajectoryPersistenceSummary
+        {
+            public int EffectivePointCount;
+            public int TrackSectionCount;
+            public bool SectionAuthoritative;
+            public string ProbeRecordingId;
+            public int ProbeSidecarEpoch;
+            public int ProbeFormatVersion;
+            public TrajectorySidecarEncoding ProbeEncoding;
+        }
+
+        private static TrajectoryPersistenceSummary SummarizeTrajectoryForWrite(Recording rec)
+        {
+            var summary = new TrajectoryPersistenceSummary
+            {
+                TrackSectionCount = rec?.TrackSections?.Count ?? 0,
+                SectionAuthoritative = RecordingStore.ShouldWriteSectionAuthoritativeTrajectory(rec)
+            };
+
+            if (rec == null)
+                return summary;
+
+            if (summary.SectionAuthoritative)
+            {
+                var rebuiltPoints = new List<TrajectoryPoint>();
+                RecordingStore.RebuildPointsFromTrackSections(rec.TrackSections, rebuiltPoints);
+                summary.EffectivePointCount = rebuiltPoints.Count;
+            }
+            else
+            {
+                summary.EffectivePointCount = rec.Points?.Count ?? 0;
+            }
+
+            return summary;
+        }
+
+        private static bool TrySummarizeExistingTrajectorySidecar(
+            string precPath,
+            Recording rec,
+            out TrajectoryPersistenceSummary summary)
+        {
+            summary = default(TrajectoryPersistenceSummary);
+
+            try
+            {
+                TrajectorySidecarProbe probe;
+                if (!RecordingStore.TryProbeTrajectorySidecar(precPath, out probe) || !probe.Supported)
+                    return false;
+
+                var existing = new Recording
+                {
+                    RecordingId = rec?.RecordingId,
+                    RecordingFormatVersion = rec?.RecordingFormatVersion ?? RecordingStore.CurrentRecordingFormatVersion
+                };
+                RecordingStore.DeserializeTrajectorySidecar(precPath, probe, existing);
+                summary = new TrajectoryPersistenceSummary
+                {
+                    EffectivePointCount = existing.Points?.Count ?? 0,
+                    TrackSectionCount = existing.TrackSections?.Count ?? 0,
+                    SectionAuthoritative = RecordingStore.ShouldWriteSectionAuthoritativeTrajectory(existing),
+                    ProbeRecordingId = probe.RecordingId,
+                    ProbeSidecarEpoch = probe.SidecarEpoch,
+                    ProbeFormatVersion = probe.FormatVersion,
+                    ProbeEncoding = probe.Encoding
+                };
+                return true;
+            }
+            catch (Exception ex)
+            {
+                if (!RecordingStore.SuppressLogging)
+                {
+                    ParsekLog.Warn("RecordingStore",
+                        $"SaveRecordingFiles: unable to evaluate trajectory shrink diagnostic for {rec?.RecordingId ?? "<null>"} " +
+                        $"path='{FormatPathForSidecarLog(precPath)}' error={FormatExceptionForSidecarLog(ex)}");
+                }
+                return false;
+            }
+        }
+
         private static void ReconcileReadableSidecarMirrorsForRecordingSet(
             IEnumerable<Recording> recordings,
             HashSet<string> seenRecordingIds,
@@ -751,6 +875,16 @@ namespace Parsek
                 // Leave FilesDirty unchanged so subsequent OnSave passes will
                 // re-evaluate and skip again until the flag is cleared.
                 return true;
+            }
+
+            if (TryBuildTrajectoryShrinkageWarningForSave(
+                    rec,
+                    precPath,
+                    incrementEpoch,
+                    out string shrinkWarning)
+                && !RecordingStore.SuppressLogging)
+            {
+                ParsekLog.Warn("RecordingStore", shrinkWarning);
             }
 
             int originalSidecarEpoch = rec.SidecarEpoch;

--- a/Source/Parsek/VesselSpawner.cs
+++ b/Source/Parsek/VesselSpawner.cs
@@ -3471,6 +3471,9 @@ namespace Parsek
 
             if (!TryValidateSnapshotHasParts(snapshot, out materializationRejectionReason))
             {
+                materializationRejectionReason = AddRecordingSnapshotMaterializationContext(
+                    materializationRejectionReason,
+                    rec);
                 LogMaterializationSnapshotRejected(resolvedContext, materializationRejectionReason);
                 return null;
             }
@@ -3500,6 +3503,32 @@ namespace Parsek
             ParsekLog.Warn("Spawner",
                 $"Spawn validation rejected materialization for {logContext}: {reason} - " +
                 "keeping ghost-only/abandon instead of loading corrupt ProtoVessel (#620)");
+        }
+
+        private static string AddRecordingSnapshotMaterializationContext(string reason, Recording rec)
+        {
+            if (rec == null)
+                return reason;
+
+            int vesselPartCount = CountSnapshotParts(rec.VesselSnapshot);
+            int ghostPartCount = CountSnapshotParts(rec.GhostVisualSnapshot);
+            string terminalState = rec.TerminalStateValue.HasValue
+                ? rec.TerminalStateValue.Value.ToString()
+                : "(unset)";
+
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                "{0} (terminalState={1}, vesselSnapshotParts={2}, ghostSnapshotParts={3}, recordingId={4})",
+                reason ?? "(unknown)",
+                terminalState,
+                vesselPartCount,
+                ghostPartCount,
+                string.IsNullOrEmpty(rec.RecordingId) ? "<none>" : rec.RecordingId);
+        }
+
+        private static int CountSnapshotParts(ConfigNode snapshot)
+        {
+            return snapshot?.GetNodes("PART")?.Length ?? 0;
         }
 
         internal static void AbandonSpawnForInvalidMaterialization(


### PR DESCRIPTION
## Summary

- Adds warning-only diagnostics when a near-empty section-authoritative trajectory is about to overwrite a richer existing `.prec` sidecar, including recording id, current/next epoch, existing probe metadata, point counts, section counts, and path.
- Keeps normal save semantics: the warning does not block the write, so `.sfs` metadata and sidecar data remain aligned and legitimate one-point trims still persist.
- Improves empty vessel snapshot materialization rejection logs by including terminal state plus vessel/ghost snapshot part counts, which makes ghost-only continuation failures diagnosable.

## Test plan

- [x] `dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter Bug585FollowupSaveSkipTests` — 12/12 passed.
- [x] `dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter SpawnSafetyNetTests` — 118/118 passed.
- [x] `git diff --check` — no whitespace errors, only existing CRLF normalization warnings.
- [x] Initial delegated review found the blocking write-skip approach unsafe; branch was reworked to warning-only and re-reviewed cleanly.

## Merge order

Independent diagnostics/hardening. Can merge after the P0 trim fix, or separately; it does not overlap with PR #672/#673 terminal logic.