### PR TITLE
Reduce breakup log hygiene noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ All notable changes to Parsek are documented here.
 
 ### Log Hygiene
 
-- Collapsed `TreeDestruction.AreAllLeavesTerminal` per-leaf verbose diagnostics into one counted summary per call, and downgraded the routine `Extrapolator` NullSolver patched-conic fallback from WARN to verbose while keeping non-NullSolver snapshot failures at WARN.
+- Collapsed `TreeDestruction.AreAllLeavesTerminal` per-leaf verbose diagnostics into one counted summary per call, downgraded the routine `Extrapolator` NullSolver patched-conic fallback from WARN to verbose, and corrected non-NullSolver snapshot-failure WARN text to say the live-orbit fallback is skipped.
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ All notable changes to Parsek are documented here.
 - Background-recorded peer vessels now receive structural-event snapshot points at the same dock / undock / EVA / joint-break UT as the focused recorder, so independently recorded halves of the same structural event no longer fall back to one-tick interpolated anchor alignment. Parent split closure trims deferred post-branch samples and flushes the active background `TrackSection` before dropping loaded state, keeping flagged boundary frames visible to section-based anchor paths.
 - Anchor propagation now avoids kraken-classified raw boundary samples when Phase 8 outlier flags are available, selecting a clean same-section frame instead of computing correction from a rejected spike.
 
+### Log Hygiene
+
+- Collapsed `TreeDestruction.AreAllLeavesTerminal` per-leaf verbose diagnostics into one counted summary per call, and downgraded the routine `Extrapolator` NullSolver patched-conic fallback from WARN to verbose while keeping non-NullSolver snapshot failures at WARN.
+
 ### Enhancements
 
 - Unfinished Flights now includes post-upgrade stable leaves: controllable non-focus Rewind Point children that end `Orbiting` or `SubOrbital`, plus stranded EVA kerbals with non-boarded terminal states. New rows offer `Fly` and explicit `Seal` actions; legacy orbiting/suborbital rows without a focused-slot signal stay forward-only, while stranded EVA rows remain retroactive.

--- a/Source/Parsek.Tests/SceneExitFinalizationIntegrationTests.cs
+++ b/Source/Parsek.Tests/SceneExitFinalizationIntegrationTests.cs
@@ -1073,6 +1073,10 @@ namespace Parsek.Tests
                 l.Contains("[Extrapolator]")
                 && l.Contains("skipping live-orbit fallback")
                 && l.Contains("MissingPatchBody"));
+            Assert.Contains(logLines, l =>
+                l.Contains("[Parsek][WARN][Extrapolator]")
+                && l.Contains("patched-conic snapshot failed for 'scene-exit-missing-patch-body'")
+                && l.Contains("with MissingPatchBody"));
         }
 
         [Fact]
@@ -1211,14 +1215,14 @@ namespace Parsek.Tests
         /// WARNs were emitted in the 2026-04-25 marker-validator-fix playtest, one
         /// per upstream `[PatchedSnapshot] solver unavailable` hit. The same root
         /// cause (debris/EVA-kerbal/probe vessels with no patched-conic solver by
-        /// design) drives the floor on this paired warn. Per-(recordingId,
-        /// failureReason) rate-limiting collapses repeats within the 30-second
-        /// window into a single emission with `suppressed=N` suffix, while the
-        /// downstream NullSolver→live-orbit fallback continues to run because
-        /// only the LOG ROUTING changes.
+        /// design) is now a routine verbose path. Per-(recordingId, failureReason)
+        /// rate-limiting collapses repeats within the 30-second window into a
+        /// single emission with `suppressed=N` suffix, while the downstream
+        /// NullSolver→live-orbit fallback continues to run because only the LOG
+        /// ROUTING changes.
         /// </summary>
         [Fact]
-        public void TryCompleteFinalizationFromPatchedSnapshot_NullSolver_WarnRateLimitedPerRecordingAndReason()
+        public void TryCompleteFinalizationFromPatchedSnapshot_NullSolver_VerboseRateLimitedPerRecordingAndReason()
         {
             double clockSeconds = 0.0;
             ParsekLog.ClockOverrideForTesting = () => clockSeconds;
@@ -1276,7 +1280,12 @@ namespace Parsek.Tests
                 "[Parsek][WARN][Extrapolator]",
                 "patched-conic snapshot failed for 'scene-exit-rate-limit-floor'",
                 "with NullSolver");
-            Assert.Equal(1, snapshotFailedWarnCount);
+            int snapshotFailedVerboseCount = CountLogLines(
+                "[Parsek][VERBOSE][Extrapolator]",
+                "patched-conic snapshot failed for 'scene-exit-rate-limit-floor'",
+                "with NullSolver");
+            Assert.Equal(0, snapshotFailedWarnCount);
+            Assert.Equal(1, snapshotFailedVerboseCount);
 
             // A different recording-id has its own key — its first hit must
             // emit immediately rather than being suppressed by the prior
@@ -1314,13 +1323,18 @@ namespace Parsek.Tests
                 "[Parsek][WARN][Extrapolator]",
                 "patched-conic snapshot failed for 'scene-exit-rate-limit-other-recording'",
                 "with NullSolver");
-            Assert.Equal(1, otherWarnCount);
+            int otherVerboseCount = CountLogLines(
+                "[Parsek][VERBOSE][Extrapolator]",
+                "patched-conic snapshot failed for 'scene-exit-rate-limit-other-recording'",
+                "with NullSolver");
+            Assert.Equal(0, otherWarnCount);
+            Assert.Equal(1, otherVerboseCount);
         }
 
         /// <summary>
         /// Regression for PR #553 P2 review: the paired Extrapolator
-        /// `WarnRateLimited` call must use the documented 30-second window, not
-        /// the 5-second `WarnRateLimited` default. Walking the test clock past
+        /// rate-limited call must use the documented 30-second window, not
+        /// the 5-second default. Walking the test clock past
         /// 5 s but before 30 s and emitting another hit must NOT re-emit; the
         /// next emission only happens after the 30 s window closes.
         /// </summary>
@@ -1371,12 +1385,16 @@ namespace Parsek.Tests
                         startState, extrapolationBodies, warnOnSubSurfaceStart: false),
                 out IncompleteBallisticFinalizationResult _);
             Assert.Equal(1, CountLogLines(
+                "[Parsek][VERBOSE][Extrapolator]",
+                "patched-conic snapshot failed for 'scene-exit-30s-window'",
+                "with NullSolver"));
+            Assert.Equal(0, CountLogLines(
                 "[Parsek][WARN][Extrapolator]",
                 "patched-conic snapshot failed for 'scene-exit-30s-window'",
                 "with NullSolver"));
 
             // Helper that fires another finalisation pass with the same
-            // synthetic state so each clock-tick can re-trigger the warn path.
+            // synthetic state so each clock-tick can re-trigger the log path.
             Action fireAgain = () =>
                 IncompleteBallisticSceneExitFinalizer.TryCompleteFinalizationFromPatchedSnapshotForTesting(
                     rec, snapshot, bodies,
@@ -1402,7 +1420,7 @@ namespace Parsek.Tests
             clockSeconds += 10.0;
             fireAgain();
             Assert.Equal(1, CountLogLines(
-                "[Parsek][WARN][Extrapolator]",
+                "[Parsek][VERBOSE][Extrapolator]",
                 "patched-conic snapshot failed for 'scene-exit-30s-window'",
                 "with NullSolver"));
 
@@ -1410,7 +1428,7 @@ namespace Parsek.Tests
             clockSeconds += 15.0;
             fireAgain();
             Assert.Equal(1, CountLogLines(
-                "[Parsek][WARN][Extrapolator]",
+                "[Parsek][VERBOSE][Extrapolator]",
                 "patched-conic snapshot failed for 'scene-exit-30s-window'",
                 "with NullSolver"));
 
@@ -1418,7 +1436,7 @@ namespace Parsek.Tests
             clockSeconds += 6.0; // total 31 s since seed
             fireAgain();
             Assert.Contains(logLines, l =>
-                l.Contains("[Parsek][WARN][Extrapolator]")
+                l.Contains("[Parsek][VERBOSE][Extrapolator]")
                 && l.Contains("patched-conic snapshot failed for 'scene-exit-30s-window'")
                 && l.Contains("with NullSolver")
                 && l.Contains("suppressed=2"));

--- a/Source/Parsek.Tests/TreeDestructionTests.cs
+++ b/Source/Parsek.Tests/TreeDestructionTests.cs
@@ -241,7 +241,7 @@ namespace Parsek.Tests
             bool result = RecordingTree.AreAllLeavesTerminal(recs, null, true);
 
             Assert.False(result);
-            Assert.True(logLines.Count <= 2, "AreAllLeavesTerminal should emit at most an entry and summary line.");
+            Assert.Single(logLines);
             Assert.Contains(logLines, l =>
                 l.Contains("[TreeDestruction]")
                 && l.Contains("AreAllLeavesTerminal")

--- a/Source/Parsek.Tests/TreeDestructionTests.cs
+++ b/Source/Parsek.Tests/TreeDestructionTests.cs
@@ -138,7 +138,11 @@ namespace Parsek.Tests
 
             Assert.True(result);
             Assert.Contains(logLines, l =>
-                l.Contains("active but vessel destroyed") && l.Contains("terminal"));
+                l.Contains("[TreeDestruction]")
+                && l.Contains("leaves=2")
+                && l.Contains("terminal=2")
+                && l.Contains("alive=0")
+                && l.Contains("True"));
         }
 
         [Fact]
@@ -225,7 +229,7 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void LoggingTest_EachLeafLogged()
+        public void LoggingTest_SummarizesLeavesOnce()
         {
             var recs = MakeDict(
                 MakeLeaf("a", "Rocket A", TerminalState.Destroyed),
@@ -234,15 +238,19 @@ namespace Parsek.Tests
 
             logLines.Clear();
 
-            RecordingTree.AreAllLeavesTerminal(recs, null, true);
+            bool result = RecordingTree.AreAllLeavesTerminal(recs, null, true);
 
-            // Leaf "a" (Destroyed) should be logged as dead
+            Assert.False(result);
+            Assert.True(logLines.Count <= 2, "AreAllLeavesTerminal should emit at most an entry and summary line.");
             Assert.Contains(logLines, l =>
-                l.Contains("[TreeDestruction]") && l.Contains("Rocket A") && l.Contains("dead"));
-
-            // Leaf "b" (Orbiting) should be logged as spawnable, NOT terminal
-            Assert.Contains(logLines, l =>
-                l.Contains("[TreeDestruction]") && l.Contains("Orbiter B") && l.Contains("spawnable"));
+                l.Contains("[TreeDestruction]")
+                && l.Contains("AreAllLeavesTerminal")
+                && l.Contains("leaves=2")
+                && l.Contains("terminal=1")
+                && l.Contains("alive=1")
+                && l.Contains("False"));
+            Assert.DoesNotContain(logLines, l => l.Contains("Rocket A"));
+            Assert.DoesNotContain(logLines, l => l.Contains("Orbiter B"));
         }
 
         [Fact]
@@ -256,7 +264,11 @@ namespace Parsek.Tests
 
             Assert.False(result);
             Assert.Contains(logLines, l =>
-                l.Contains("[TreeDestruction]") && l.Contains("active and alive"));
+                l.Contains("[TreeDestruction]")
+                && l.Contains("leaves=1")
+                && l.Contains("terminal=0")
+                && l.Contains("alive=1")
+                && l.Contains("False"));
         }
 
         [Fact]

--- a/Source/Parsek/IncompleteBallisticSceneExitFinalizer.cs
+++ b/Source/Parsek/IncompleteBallisticSceneExitFinalizer.cs
@@ -392,23 +392,29 @@ namespace Parsek
             }
             else if (snapshot.FailureReason != PatchedConicSnapshotFailureReason.None)
             {
-                // #576: rate-limit per (recordingId, failureReason). The same
-                // 2026-04-25 playtest emitted 146 of these paired with the
-                // `[PatchedSnapshot] solver unavailable` floor — same root cause
-                // (debris/EVA-kerbal/probe vessels with no patched-conic solver
-                // by design). The downstream NullSolver branch at lines 287-289
-                // still runs unchanged: NullSolver remains the
-                // destroyed-vessel / no-solver-by-design fingerprint that drives
-                // the live-orbit fallback, only the log-noise floor changes.
-                // Keying on (recordingId, failureReason) lets a fresh regression
-                // on the SAME recording with a DIFFERENT failure mode surface
-                // immediately while the repeating same-cause floor is absorbed
-                // into a single line per 30 s with a `suppressed=N` suffix.
-                ParsekLog.WarnRateLimited("Extrapolator",
-                    $"finalize-snapshot-failed-{recordingId}-{snapshot.FailureReason}",
+                // #576: rate-limit per (recordingId, failureReason). NullSolver
+                // is the expected no-solver path for destroyed stock debris/EVA
+                // vessels and still falls through to the live-orbit fallback.
+                // Other snapshot failures are unexpected enough to stay WARN.
+                string key = $"finalize-snapshot-failed-{recordingId}-{snapshot.FailureReason}";
+                string message =
                     $"TryFinalizeRecording: patched-conic snapshot failed for '{recordingId}' " +
-                    $"with {snapshot.FailureReason}; falling back to live orbit state",
-                    minIntervalSeconds: 30.0);
+                    $"with {snapshot.FailureReason}; falling back to live orbit state";
+                if (snapshot.FailureReason == PatchedConicSnapshotFailureReason.NullSolver)
+                {
+                    ParsekLog.VerboseRateLimited("Extrapolator",
+                        key,
+                        message,
+                        minIntervalSeconds: 30.0);
+                }
+                else
+                {
+                    ParsekLog.WarnRateLimited("Extrapolator",
+                        key,
+                        $"TryFinalizeRecording: patched-conic snapshot failed for '{recordingId}' " +
+                        $"with {snapshot.FailureReason}; skipping live orbit fallback",
+                        minIntervalSeconds: 30.0);
+                }
             }
 
             // Early ascent / transient patched-conic failures (`MissingPatchBody`,

--- a/Source/Parsek/RecordingTree.cs
+++ b/Source/Parsek/RecordingTree.cs
@@ -969,11 +969,10 @@ namespace Parsek
             string activeRecordingId,
             bool activeVesselDestroyed)
         {
-            if (recordings.Count == 0)
-            {
-                ParsekLog.Verbose("TreeDestruction", "AreAllLeavesTerminal: empty recordings dict — returning true");
-                return true;
-            }
+            int total = 0;
+            int terminalCount = 0;
+            int aliveCount = 0;
+            bool result = true;
 
             foreach (var kvp in recordings)
             {
@@ -983,51 +982,48 @@ namespace Parsek
                 if (rec.ChildBranchPointId != null)
                     continue;
 
+                total++;
                 bool isActiveRecording = activeRecordingId != null && rec.RecordingId == activeRecordingId;
+                bool isTerminal;
 
                 // Leaf: active recording still alive — tree is not fully terminal
                 if (isActiveRecording && !activeVesselDestroyed)
                 {
-                    ParsekLog.Verbose("TreeDestruction",
-                        $"AreAllLeavesTerminal: leaf '{rec.RecordingId}' ({rec.VesselName}) is active and alive — NOT terminal");
-                    return false;
+                    isTerminal = false;
                 }
-
                 // Active recording with destroyed vessel: treat as terminal even if
                 // TerminalStateValue hasn't been set yet (recorder knows it's dead,
                 // but FinalizeTreeRecordings hasn't run to set the terminal state)
-                if (isActiveRecording && activeVesselDestroyed)
+                else if (isActiveRecording && activeVesselDestroyed)
                 {
-                    ParsekLog.Verbose("TreeDestruction",
-                        $"AreAllLeavesTerminal: leaf '{rec.RecordingId}' ({rec.VesselName}) is active but vessel destroyed — terminal");
-                    continue;
+                    isTerminal = true;
                 }
-
                 // Leaf: no terminal state means still recording / not finalized
-                if (!rec.TerminalStateValue.HasValue)
+                else if (!rec.TerminalStateValue.HasValue)
                 {
-                    ParsekLog.Verbose("TreeDestruction",
-                        $"AreAllLeavesTerminal: leaf '{rec.RecordingId}' ({rec.VesselName}) has no terminal state — NOT terminal");
-                    return false;
+                    isTerminal = false;
+                }
+                else
+                {
+                    var ts = rec.TerminalStateValue.Value;
+                    isTerminal = IsNonSpawnableTerminal(ts);
                 }
 
-                var ts = rec.TerminalStateValue.Value;
-                if (IsNonSpawnableTerminal(ts))
+                if (isTerminal)
                 {
-                    // Non-spawnable terminal state — this leaf is done
-                    ParsekLog.Verbose("TreeDestruction",
-                        $"AreAllLeavesTerminal: leaf '{rec.RecordingId}' ({rec.VesselName}) terminal={ts} — dead");
-                    continue;
+                    terminalCount++;
                 }
-
-                // Spawnable terminal state (Orbiting, Landed, SubOrbital, Splashed) — vessel could be spawned
-                ParsekLog.Verbose("TreeDestruction",
-                    $"AreAllLeavesTerminal: leaf '{rec.RecordingId}' ({rec.VesselName}) terminal={ts} — spawnable, NOT terminal");
-                return false;
+                else
+                {
+                    aliveCount++;
+                    result = false;
+                }
             }
 
-            ParsekLog.Verbose("TreeDestruction", "AreAllLeavesTerminal: all leaves are terminal — returning true");
-            return true;
+            ParsekLog.Verbose("TreeDestruction",
+                $"AreAllLeavesTerminal: leaves={total} terminal={terminalCount} " +
+                $"alive={aliveCount} -> {result}");
+            return result;
         }
 
         /// <summary>

--- a/Source/Parsek/RecordingTree.cs
+++ b/Source/Parsek/RecordingTree.cs
@@ -974,6 +974,10 @@ namespace Parsek
             int aliveCount = 0;
             bool result = true;
 
+            // Deliberately scan every leaf here: this is a destruction merge gate,
+            // and the log summary is useful only when its counts describe the
+            // whole tree. The all-terminal path had to inspect every leaf before
+            // this log-hygiene change as well.
             foreach (var kvp in recordings)
             {
                 var rec = kvp.Value;


### PR DESCRIPTION
## Summary
- Collapse TreeDestruction.AreAllLeavesTerminal per-leaf verbose output into one counted summary per call.
- Downgrade routine Extrapolator NullSolver patched-conic fallback diagnostics from WARN to verbose while preserving WARN for non-NullSolver snapshot failures.
- Correct the non-NullSolver WARN text to say it skips live-orbit fallback, matching the early-ascent guard behavior.
- Update log assertions and CHANGELOG coverage for the log-hygiene cleanup.

## Validation
- dotnet build from Source/Parsek
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter "FullyQualifiedName~TreeDestructionTests|FullyQualifiedName~SceneExitFinalizationIntegrationTests": 69 passed
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj: 10024 passed
- Final self-review per AGENTS workflow; separate clean-context review reported no findings.

## Review follow-up
- Tightened TreeDestructionTests.LoggingTest_SummarizesLeavesOnce from <=2 lines to Assert.Single(logLines), so a returning per-leaf line now fails the test.
- Kept the full AreAllLeavesTerminal leaf walk deliberately for accurate whole-tree summary counts; documented the trade-off in code after checking that callers are destruction/merge gates, not normal playback paths.
- Expanded CHANGELOG wording to call out the non-NullSolver WARN message correction.

## Log impact
- Supplied logs/2026-04-30_2118_refly-bugs/KSP.log had 225 AreAllLeavesTerminal lines in the breakup window: 200 per-leaf lines plus 25 old summaries. New output is estimated at 25 summaries, about 200 fewer lines.
- The same sample had 9 NullSolver Extrapolator WARNs; these now move out of WARN and remain verbose rate-limited diagnostics when verbose logging is enabled.