### PR TITLE
Batch ghost audio playback cap enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to Parsek are documented here.
 ### Bug Fixes
 
 - Ghost trajectory rendering: Upper-stage ghosts now stay aligned through stage separation during Re-Fly and Watch mode. The trajectory line no longer bounces across the relative-to-absolute transition.
+- Ghost engine audio now batches simultaneous replayed engine events before enforcing the per-ghost loop-source cap, preventing same-frame Play/Stop churn during stage separation from producing audible crackles.
 - A vessel that was incorrectly stamped `Destroyed` mid-flight by a transient finalizer fallback (e.g. during stage decouple) no longer remains stuck as Destroyed in STASH after the player rewinds and resumes flying it. Re-Fly resume now clears the stale terminal verdict so the FinalizerCache re-evaluates the vessel's live state.
 - The Esc-menu Revert to Launch button is no longer grayed out during an active Re-Fly. The loaded rewind-point quicksave is mid-flight so KSP correctly disables the button, but Parsek's interceptor (Retry / Discard Re-Fly / Cancel dialog) was unreachable as a result. While a Re-Fly session marker is active the button is force-enabled so clicking it routes into the Parsek dialog; on marker clear the engine's natural state is restored.
 - Retrying a Re-Fly no longer lets the quickload-discard heuristic purge the active rewind point quicksave and pending tree before the retry finishes loading, so a follow-up Discard Re-Fly still finds the RP file it needs.

--- a/Source/Parsek.Tests/GhostAudioTests.cs
+++ b/Source/Parsek.Tests/GhostAudioTests.cs
@@ -18,6 +18,7 @@ namespace Parsek.Tests
         public void Dispose()
         {
             ParsekLog.ResetTestOverrides();
+            GhostPlaybackLogic.ResetForTesting();
             ParsekLog.SuppressLogging = true;
         }
 
@@ -205,8 +206,14 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void SetEngineAudio_DeferredPlaybackCapLeavesOnlyFinalBatchEnginesSelected()
+        public void SetEngineAudio_DeferredPlaybackCapEnforcesOnceAfterBatch()
         {
+            int enforceCount = 0;
+            GhostPlaybackLogic.EnforceLoopedAudioPlaybackCapOverrideForTesting = _ =>
+            {
+                enforceCount++;
+                return true;
+            };
             var infos = new List<AudioGhostInfo>();
             var state = new GhostPlaybackState
             {
@@ -229,28 +236,32 @@ namespace Parsek.Tests
 
             for (int i = 0; i < 4; i++)
             {
-                GhostPlaybackLogic.SetEngineAudio(
+                Assert.True(GhostPlaybackLogic.SetEngineAudio(
                     state,
                     new PartEvent { partPersistentId = infos[i].partPersistentId, moduleIndex = 0 },
                     1f,
-                    enforcePlaybackCap: false);
+                    enforcePlaybackCap: false));
             }
             for (int i = 0; i < 4; i++)
             {
-                GhostPlaybackLogic.SetEngineAudio(
+                Assert.True(GhostPlaybackLogic.SetEngineAudio(
                     state,
                     new PartEvent { partPersistentId = infos[i].partPersistentId, moduleIndex = 0 },
                     0f,
-                    enforcePlaybackCap: false);
+                    enforcePlaybackCap: false));
             }
             for (int i = 4; i < 8; i++)
             {
-                GhostPlaybackLogic.SetEngineAudio(
+                Assert.True(GhostPlaybackLogic.SetEngineAudio(
                     state,
                     new PartEvent { partPersistentId = infos[i].partPersistentId, moduleIndex = 0 },
                     1f,
-                    enforcePlaybackCap: false);
+                    enforcePlaybackCap: false));
             }
+
+            Assert.Equal(0, enforceCount);
+            GhostPlaybackLogic.EnforceLoopedAudioPlaybackCapWithTestingOverride(state);
+            Assert.Equal(1, enforceCount);
 
             var selected = GhostPlaybackLogic.SelectHighestPriorityActiveLoopedGhostAudioSources(
                 new List<AudioGhostInfo>(state.audioInfos.Values),

--- a/Source/Parsek.Tests/GhostAudioTests.cs
+++ b/Source/Parsek.Tests/GhostAudioTests.cs
@@ -204,6 +204,65 @@ namespace Parsek.Tests
             Assert.Equal(0f, info.currentPower);
         }
 
+        [Fact]
+        public void SetEngineAudio_DeferredPlaybackCapLeavesOnlyFinalBatchEnginesSelected()
+        {
+            var infos = new List<AudioGhostInfo>();
+            var state = new GhostPlaybackState
+            {
+                audioInfos = new Dictionary<ulong, AudioGhostInfo>()
+            };
+
+            for (int i = 0; i < 8; i++)
+            {
+                uint pid = (uint)(100 + i);
+                var info = new AudioGhostInfo
+                {
+                    partPersistentId = pid,
+                    moduleIndex = 0,
+                    selectionOrder = i,
+                    priorityClass = GhostAudioPriorityClass.RocketEngine
+                };
+                infos.Add(info);
+                state.audioInfos[FlightRecorder.EncodeEngineKey(pid, 0)] = info;
+            }
+
+            for (int i = 0; i < 4; i++)
+            {
+                GhostPlaybackLogic.SetEngineAudio(
+                    state,
+                    new PartEvent { partPersistentId = infos[i].partPersistentId, moduleIndex = 0 },
+                    1f,
+                    enforcePlaybackCap: false);
+            }
+            for (int i = 0; i < 4; i++)
+            {
+                GhostPlaybackLogic.SetEngineAudio(
+                    state,
+                    new PartEvent { partPersistentId = infos[i].partPersistentId, moduleIndex = 0 },
+                    0f,
+                    enforcePlaybackCap: false);
+            }
+            for (int i = 4; i < 8; i++)
+            {
+                GhostPlaybackLogic.SetEngineAudio(
+                    state,
+                    new PartEvent { partPersistentId = infos[i].partPersistentId, moduleIndex = 0 },
+                    1f,
+                    enforcePlaybackCap: false);
+            }
+
+            var selected = GhostPlaybackLogic.SelectHighestPriorityActiveLoopedGhostAudioSources(
+                new List<AudioGhostInfo>(state.audioInfos.Values),
+                GhostAudioPresets.MaxAudioSourcesPerGhost);
+
+            Assert.Equal(4, selected.Count);
+            for (int i = 0; i < 4; i++)
+                Assert.DoesNotContain(infos[i], selected);
+            for (int i = 4; i < 8; i++)
+                Assert.Contains(infos[i], selected);
+        }
+
         #endregion
 
         #region Thrust Classification

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -1867,6 +1867,7 @@ namespace Parsek
             var logicalPartIds = state.logicalPartIds;
             bool visibilityChanged = false;
             bool needsReentryMeshRebuild = false;
+            bool audioPowerChanged = false;
             HashSet<uint> placedTargetPartIds = null;
 
             while (evtIdx < rec.PartEvents.Count && rec.PartEvents[evtIdx].ut <= currentUT)
@@ -1934,15 +1935,22 @@ namespace Parsek
                         // for backward compatibility. New recordings skip zero-throttle
                         // engine seeds entirely (PartStateSeeder.EmitEngineSeedEvents).
                         SetEngineEmission(state, evt, System.Math.Max(evt.value, 0.01f));
-                        SetEngineAudio(state, evt, System.Math.Max(evt.value, 0.01f));
+                        SetEngineAudio(
+                            state,
+                            evt,
+                            System.Math.Max(evt.value, 0.01f),
+                            enforcePlaybackCap: false);
+                        audioPowerChanged = true;
                         break;
                     case PartEventType.EngineShutdown:
                         SetEngineEmission(state, evt, 0f);
-                        SetEngineAudio(state, evt, 0f);
+                        SetEngineAudio(state, evt, 0f, enforcePlaybackCap: false);
+                        audioPowerChanged = true;
                         break;
                     case PartEventType.EngineThrottle:
                         SetEngineEmission(state, evt, evt.value);
-                        SetEngineAudio(state, evt, evt.value);
+                        SetEngineAudio(state, evt, evt.value, enforcePlaybackCap: false);
+                        audioPowerChanged = true;
                         break;
                     case PartEventType.DeployableExtended:
                         ApplyDeployableState(state, evt, deployed: true);
@@ -2034,6 +2042,8 @@ namespace Parsek
 
             int appliedCount = evtIdx - state.partEventIndex;
             state.partEventIndex = evtIdx;
+            if (audioPowerChanged)
+                EnforceLoopedAudioPlaybackCap(state);
             if (appliedCount > 0)
                 ParsekLog.VerboseRateLimited("Flight", $"part-events-{recIdx}",
                     $"Applied {appliedCount} part events for ghost #{recIdx} (evtIdx now {evtIdx})");
@@ -2247,8 +2257,10 @@ namespace Parsek
                 {
                     partPersistentId = persistentId,
                     moduleIndex = restores[i].moduleIndex
-                }, restores[i].power);
+                }, restores[i].power, enforcePlaybackCap: false);
             }
+            if (restores.Count > 0)
+                EnforceLoopedAudioPlaybackCap(state);
         }
 
         internal static void InitializeInventoryPlacementVisibility(
@@ -2833,7 +2845,11 @@ namespace Parsek
         /// Set engine audio volume/pitch from recorded throttle power.
         /// Called alongside SetEngineEmission for EngineIgnited/Throttle/Shutdown events.
         /// </summary>
-        internal static void SetEngineAudio(GhostPlaybackState state, PartEvent evt, float power)
+        internal static void SetEngineAudio(
+            GhostPlaybackState state,
+            PartEvent evt,
+            float power,
+            bool enforcePlaybackCap = true)
         {
             if (state.audioInfos == null) return;
 
@@ -2851,7 +2867,8 @@ namespace Parsek
             }
             if (ReferenceEquals(info.audioSource, null)) return;
 
-            EnforceLoopedAudioPlaybackCap(state);
+            if (enforcePlaybackCap)
+                EnforceLoopedAudioPlaybackCap(state);
         }
 
         internal static bool CanStartLoopedGhostAudio(bool sourceExists, bool sourceIsActiveAndEnabled)
@@ -3595,6 +3612,7 @@ namespace Parsek
                 }, restore.power);
             }
 
+            bool restoredAudioPower = false;
             foreach (var restore in CollectDeferredAudioPowerRestores(state))
             {
                 uint partPersistentId;
@@ -3604,8 +3622,11 @@ namespace Parsek
                 {
                     partPersistentId = partPersistentId,
                     moduleIndex = moduleIndex
-                }, restore.power);
+                }, restore.power, enforcePlaybackCap: false);
+                restoredAudioPower = true;
             }
+            if (restoredAudioPower)
+                EnforceLoopedAudioPlaybackCap(state);
         }
 
         #endregion

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -26,6 +26,7 @@ namespace Parsek
         private static readonly HashSet<string> loopIntervalClampWarned = new HashSet<string>(StringComparer.Ordinal);
         private static Func<FlagEvent, bool> flagExistsOverrideForTesting;
         private static Func<FlagEvent, bool> spawnFlagOverrideForTesting;
+        internal static Func<GhostPlaybackState, bool> EnforceLoopedAudioPlaybackCapOverrideForTesting;
 
         internal readonly struct AutoLoopLaunchSchedule
         {
@@ -620,6 +621,7 @@ namespace Parsek
         {
             loopIntervalClampWarned.Clear();
             ResetFlagReplayOverridesForTesting();
+            EnforceLoopedAudioPlaybackCapOverrideForTesting = null;
         }
 
         /// <summary>
@@ -1867,7 +1869,7 @@ namespace Parsek
             var logicalPartIds = state.logicalPartIds;
             bool visibilityChanged = false;
             bool needsReentryMeshRebuild = false;
-            bool audioPowerChanged = false;
+            bool audioPowerTouched = false;
             HashSet<uint> placedTargetPartIds = null;
 
             while (evtIdx < rec.PartEvents.Count && rec.PartEvents[evtIdx].ut <= currentUT)
@@ -1935,22 +1937,22 @@ namespace Parsek
                         // for backward compatibility. New recordings skip zero-throttle
                         // engine seeds entirely (PartStateSeeder.EmitEngineSeedEvents).
                         SetEngineEmission(state, evt, System.Math.Max(evt.value, 0.01f));
-                        SetEngineAudio(
-                            state,
-                            evt,
-                            System.Math.Max(evt.value, 0.01f),
-                            enforcePlaybackCap: false);
-                        audioPowerChanged = true;
+                        if (SetEngineAudio(
+                                state,
+                                evt,
+                                System.Math.Max(evt.value, 0.01f),
+                                enforcePlaybackCap: false))
+                            audioPowerTouched = true;
                         break;
                     case PartEventType.EngineShutdown:
                         SetEngineEmission(state, evt, 0f);
-                        SetEngineAudio(state, evt, 0f, enforcePlaybackCap: false);
-                        audioPowerChanged = true;
+                        if (SetEngineAudio(state, evt, 0f, enforcePlaybackCap: false))
+                            audioPowerTouched = true;
                         break;
                     case PartEventType.EngineThrottle:
                         SetEngineEmission(state, evt, evt.value);
-                        SetEngineAudio(state, evt, evt.value, enforcePlaybackCap: false);
-                        audioPowerChanged = true;
+                        if (SetEngineAudio(state, evt, evt.value, enforcePlaybackCap: false))
+                            audioPowerTouched = true;
                         break;
                     case PartEventType.DeployableExtended:
                         ApplyDeployableState(state, evt, deployed: true);
@@ -2042,8 +2044,8 @@ namespace Parsek
 
             int appliedCount = evtIdx - state.partEventIndex;
             state.partEventIndex = evtIdx;
-            if (audioPowerChanged)
-                EnforceLoopedAudioPlaybackCap(state);
+            if (audioPowerTouched)
+                EnforceLoopedAudioPlaybackCapWithTestingOverride(state);
             if (appliedCount > 0)
                 ParsekLog.VerboseRateLimited("Flight", $"part-events-{recIdx}",
                     $"Applied {appliedCount} part events for ghost #{recIdx} (evtIdx now {evtIdx})");
@@ -2251,16 +2253,18 @@ namespace Parsek
             if (restores == null)
                 return;
 
+            bool audioPowerTouched = false;
             for (int i = 0; i < restores.Count; i++)
             {
-                SetEngineAudio(state, new PartEvent
-                {
-                    partPersistentId = persistentId,
-                    moduleIndex = restores[i].moduleIndex
-                }, restores[i].power, enforcePlaybackCap: false);
+                if (SetEngineAudio(state, new PartEvent
+                    {
+                        partPersistentId = persistentId,
+                        moduleIndex = restores[i].moduleIndex
+                    }, restores[i].power, enforcePlaybackCap: false))
+                    audioPowerTouched = true;
             }
-            if (restores.Count > 0)
-                EnforceLoopedAudioPlaybackCap(state);
+            if (audioPowerTouched)
+                EnforceLoopedAudioPlaybackCapWithTestingOverride(state);
         }
 
         internal static void InitializeInventoryPlacementVisibility(
@@ -2753,6 +2757,15 @@ namespace Parsek
             return result;
         }
 
+        internal static void EnforceLoopedAudioPlaybackCapWithTestingOverride(GhostPlaybackState state)
+        {
+            var overrideForTesting = EnforceLoopedAudioPlaybackCapOverrideForTesting;
+            if (overrideForTesting != null && overrideForTesting(state))
+                return;
+
+            EnforceLoopedAudioPlaybackCap(state);
+        }
+
         internal static void EnforceLoopedAudioPlaybackCap(GhostPlaybackState state)
         {
             if (state?.audioInfos == null)
@@ -2845,17 +2858,17 @@ namespace Parsek
         /// Set engine audio volume/pitch from recorded throttle power.
         /// Called alongside SetEngineEmission for EngineIgnited/Throttle/Shutdown events.
         /// </summary>
-        internal static void SetEngineAudio(
+        internal static bool SetEngineAudio(
             GhostPlaybackState state,
             PartEvent evt,
             float power,
             bool enforcePlaybackCap = true)
         {
-            if (state.audioInfos == null) return;
+            if (state.audioInfos == null) return false;
 
             ulong key = FlightRecorder.EncodeEngineKey(evt.partPersistentId, evt.moduleIndex);
             AudioGhostInfo info;
-            if (!state.audioInfos.TryGetValue(key, out info)) return;
+            if (!state.audioInfos.TryGetValue(key, out info)) return false;
 
             info.currentPower = power;
             if (state.audioMuted)
@@ -2863,12 +2876,13 @@ namespace Parsek
                 // Keep tracked power in sync during warp so unmute resumes the correct state.
                 if (!ReferenceEquals(info.audioSource, null))
                     StopLoopedGhostAudio(info, "muted");
-                return;
+                return true;
             }
-            if (ReferenceEquals(info.audioSource, null)) return;
+            if (ReferenceEquals(info.audioSource, null)) return true;
 
             if (enforcePlaybackCap)
-                EnforceLoopedAudioPlaybackCap(state);
+                EnforceLoopedAudioPlaybackCapWithTestingOverride(state);
+            return true;
         }
 
         internal static bool CanStartLoopedGhostAudio(bool sourceExists, bool sourceIsActiveAndEnabled)
@@ -3612,21 +3626,20 @@ namespace Parsek
                 }, restore.power);
             }
 
-            bool restoredAudioPower = false;
-            foreach (var restore in CollectDeferredAudioPowerRestores(state))
+            var audioRestores = CollectDeferredAudioPowerRestores(state);
+            for (int i = 0; i < audioRestores.Count; i++)
             {
                 uint partPersistentId;
                 int moduleIndex;
-                FlightRecorder.DecodeEngineKey(restore.key, out partPersistentId, out moduleIndex);
+                FlightRecorder.DecodeEngineKey(audioRestores[i].key, out partPersistentId, out moduleIndex);
                 SetEngineAudio(state, new PartEvent
                 {
                     partPersistentId = partPersistentId,
                     moduleIndex = moduleIndex
-                }, restore.power, enforcePlaybackCap: false);
-                restoredAudioPower = true;
+                }, audioRestores[i].power, enforcePlaybackCap: false);
             }
-            if (restoredAudioPower)
-                EnforceLoopedAudioPlaybackCap(state);
+            if (audioRestores.Count > 0)
+                EnforceLoopedAudioPlaybackCapWithTestingOverride(state);
         }
 
         #endregion


### PR DESCRIPTION
Summary: Batch replayed ghost engine audio power changes before enforcing the per-ghost loop-source cap, avoiding same-frame Play/Stop churn during stage-separation event batches. Keep SetEngineAudio immediate by default for direct callers, update deferred restore/visibility paths to enforce once after batch, and add GhostAudioTests regression coverage plus changelog entry. Validation: dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter GhostAudioTests passed 49 tests; dotnet build Source/Parsek.Tests/Parsek.Tests.csproj --no-restore succeeded; dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter FullyQualifiedName!~InjectAllRecordings --no-build passed 10052 tests. Full unfiltered xUnit was attempted earlier and only SyntheticRecordingTests.InjectAllRecordings failed because the live KSP.log was locked by the running game.