### PR TITLE
Use delayed tooltip bubbles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ All notable changes to Parsek are documented here.
 - Test Runner window title bar now uses the same enlarged font + vertical padding as the rest of the Parsek windows (regression: the Test Runner built its own opaque window style and skipped the title-bar enhancement that the main UI applied separately). The enhancement now lives inside the shared `BuildOpaqueWindowStyleFromSource` builder so every caller gets the same title bar automatically.
 - Tracking Station ghost-actions popup title is now `Parsek - Ghost Actions` (was `Parsek Ghost`) so it matches the `Parsek - <name>` format used by every other top-level Parsek window.
 - Settings Diagnostics now splits rewind-point disk usage into live crashed, stable, and sealed-pending RP counts so stable-leaf cleanup pressure is visible without reading the save file.
+- Hover help now uses a shared 1-second delayed bubble near the hovered control instead of bottom-of-window footer rows. Recordings, Timeline, Settings, Spawn Control, Tracking Station, and both Test Runner surfaces share the same renderer, tooltip copy has been shortened, and an orphaned rich recording-hover method was removed.
 
 ### Tests
 

--- a/Source/Parsek.Tests/GhostTrackingStationPatchTests.cs
+++ b/Source/Parsek.Tests/GhostTrackingStationPatchTests.cs
@@ -399,7 +399,7 @@ namespace Parsek.Tests
             TrackingStationGhostActionState materialize = FindState(states, TrackingStationGhostActionKind.Materialize);
 
             Assert.False(recording.Enabled);
-            Assert.Contains("no direct committed recording", recording.Reason);
+            Assert.Contains("No direct recording row", recording.Reason);
             Assert.False(materialize.Enabled);
             Assert.Contains("No committed recording", materialize.Reason);
         }

--- a/Source/Parsek.Tests/RecordingsTableUITests.cs
+++ b/Source/Parsek.Tests/RecordingsTableUITests.cs
@@ -790,7 +790,7 @@ namespace Parsek.Tests
             string tooltip = RecordingsTableUI.GetWatchButtonTooltip(
                 isWatching: false, hasGhost: false, sameBody: true, inRange: true, isDebris: false);
 
-            Assert.Contains("No active ghost", tooltip);
+            Assert.Equal("No loaded ghost for this row.", tooltip);
         }
 
         [Fact]
@@ -799,7 +799,7 @@ namespace Parsek.Tests
             string tooltip = RecordingsTableUI.GetWatchButtonTooltip(
                 isWatching: true, hasGhost: false, sameBody: false, inRange: false, isDebris: false);
 
-            Assert.Equal("Exit watch mode", tooltip);
+            Assert.Equal("Exit watch.", tooltip);
         }
 
         [Fact]

--- a/Source/Parsek.Tests/SelectiveSpawnUITests.cs
+++ b/Source/Parsek.Tests/SelectiveSpawnUITests.cs
@@ -450,7 +450,7 @@ namespace Parsek.Tests
         public void FormatNextSpawnTooltip_NullCandidate()
         {
             string result = SelectiveSpawnUI.FormatNextSpawnTooltip(null, 100);
-            Assert.Equal("No nearby craft to spawn", result);
+            Assert.Equal("No nearby craft.", result);
         }
     }
 }

--- a/Source/Parsek.Tests/TimelineWindowUITests.cs
+++ b/Source/Parsek.Tests/TimelineWindowUITests.cs
@@ -108,7 +108,7 @@ namespace Parsek.Tests
                 isWatching: false, hasGhost: true, sameBody: true, inRange: true, isDebris: false);
 
             Assert.Equal("W", descriptor.Label);
-            Assert.Equal("Follow ghost in watch mode", descriptor.Tooltip);
+            Assert.Equal("Watch this ghost.", descriptor.Tooltip);
             Assert.True(descriptor.Enabled);
             Assert.True(descriptor.CanWatch);
             Assert.Equal(TimelineWindowUI.TimelineWatchButtonAction.Enter, descriptor.Action);
@@ -144,7 +144,7 @@ namespace Parsek.Tests
                 isWatching: true, hasGhost: false, sameBody: false, inRange: false, isDebris: false);
 
             Assert.Equal("W*", descriptor.Label);
-            Assert.Equal("Exit watch mode", descriptor.Tooltip);
+            Assert.Equal("Exit watch.", descriptor.Tooltip);
             Assert.True(descriptor.Enabled);
             Assert.False(descriptor.CanWatch);
             Assert.Equal(TimelineWindowUI.TimelineWatchButtonAction.Exit, descriptor.Action);

--- a/Source/Parsek.Tests/TooltipBubbleTests.cs
+++ b/Source/Parsek.Tests/TooltipBubbleTests.cs
@@ -1,0 +1,75 @@
+using UnityEngine;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    [Collection("Sequential")]
+    public class TooltipBubbleTests
+    {
+        public TooltipBubbleTests()
+        {
+            TooltipBubble.ResetForTesting();
+        }
+
+        [Fact]
+        public void ShouldShow_WaitsForOneSecondOfStableHover()
+        {
+            Assert.False(TooltipBubble.ShouldShow("Help text", 10f, 10.999f));
+            Assert.True(TooltipBubble.ShouldShow("Help text", 10f, 11f));
+            Assert.False(TooltipBubble.ShouldShow(string.Empty, 10f, 12f));
+        }
+
+        [Fact]
+        public void ShouldResetHover_TracksPointerAndTooltipChanges()
+        {
+            Assert.False(TooltipBubble.ShouldResetHover("Help text", "Help text", pointerInWindow: true));
+            Assert.True(TooltipBubble.ShouldResetHover("Help text", "Help text", pointerInWindow: false));
+            Assert.True(TooltipBubble.ShouldResetHover("Help text", string.Empty, pointerInWindow: true));
+            Assert.True(TooltipBubble.ShouldResetHover("Old help", "New help", pointerInWindow: true));
+        }
+
+        [Fact]
+        public void ComputeTextWidth_ClampsToUsableWindowWidth()
+        {
+            float textWidth = TooltipBubble.ComputeTextWidth(naturalWidth: 500f, windowWidth: 180f);
+
+            Assert.Equal(152f, textWidth);
+        }
+
+        [Fact]
+        public void ComputeBubbleRect_KeepsBubbleInsideWindow()
+        {
+            Rect rect = TooltipBubble.ComputeBubbleRect(
+                new Vector2(195f, 115f),
+                new Vector2(80f, 40f),
+                new Rect(0f, 0f, 200f, 120f));
+
+            Assert.InRange(rect.xMin, 6f, 114f);
+            Assert.InRange(rect.yMin, 6f, 74f);
+            Assert.InRange(rect.xMax, 86f, 194f);
+            Assert.InRange(rect.yMax, 46f, 114f);
+        }
+
+        [Fact]
+        public void ComputeLocalBounds_InfersAutoSizedGUILayoutWindowHeight()
+        {
+            Rect bounds = TooltipBubble.ComputeLocalBounds(
+                new Rect(10f, 20f, 250f, 0f),
+                new Rect(8f, 120f, 220f, 24f));
+
+            Assert.Equal(250f, bounds.width);
+            Assert.Equal(150f, bounds.height);
+        }
+
+        [Fact]
+        public void ComputeLocalBounds_PreservesKnownWindowHeight()
+        {
+            Rect bounds = TooltipBubble.ComputeLocalBounds(
+                new Rect(10f, 20f, 250f, 180f),
+                new Rect(8f, 120f, 220f, 24f));
+
+            Assert.Equal(250f, bounds.width);
+            Assert.Equal(180f, bounds.height);
+        }
+    }
+}

--- a/Source/Parsek/InGameTests/TestRunnerShortcut.cs
+++ b/Source/Parsek/InGameTests/TestRunnerShortcut.cs
@@ -28,7 +28,6 @@ namespace Parsek.InGameTests
         private GUIStyle opaqueStyle;
         private GUIStyle zeroHeightLabelStyle;
         private GUIStyle wrappedErrorLabelStyle;
-        private GUIStyle wrappedTooltipStyle;
         private GameScenes opaqueStyleScene;
         private bool hasOpaqueStyleScene;
 
@@ -171,7 +170,6 @@ namespace Parsek.InGameTests
             ClearOpaqueStyle();
             zeroHeightLabelStyle = null;
             wrappedErrorLabelStyle = null;
-            wrappedTooltipStyle = null;
         }
 
         internal bool TryEnsureOpaqueStyleForTesting(GUISkin skin)
@@ -287,9 +285,9 @@ namespace Parsek.InGameTests
 
             GUILayout.BeginHorizontal();
             GUI.enabled = !running;
-            if (GUILayout.Button("Run All")) { runner.ResetResults(); runner.RunAll(); }
+            if (GUILayout.Button(new GUIContent("Run All", "Run all batch-safe tests."))) { runner.ResetResults(); runner.RunAll(); }
             if (GUILayout.Button(new GUIContent("Run All + Isolated",
-                "Runs ordinary batch-safe tests plus [isolated] FLIGHT tests by capturing a temporary baseline save and quickloading it after each destructive test.")))
+                "Run batch-safe tests plus isolated FLIGHT tests.")))
             {
                 runner.ResetResults();
                 runner.RunAllIncludingFlightRestore();
@@ -299,12 +297,12 @@ namespace Parsek.InGameTests
             // report on the next run. The implicit pre-run ResetResults (above)
             // preserves per-scene history so KSC→Flight accumulation works.
             if (GUILayout.Button(new GUIContent("Reset",
-                "Clears the table AND per-scene history used by the auto-exported results file.")))
+                "Clear results and scene history.")))
             {
                 runner.ClearAllSceneHistory();
             }
             GUI.enabled = running;
-            if (GUILayout.Button("Cancel")) { runner.Cancel(); }
+            if (GUILayout.Button(new GUIContent("Cancel", "Stop the current test run."))) { runner.Cancel(); }
             GUI.enabled = true;
             GUILayout.EndHorizontal();
 
@@ -345,13 +343,13 @@ namespace Parsek.InGameTests
                     else expandedCategories.Add(cat);
                 }
                 GUI.enabled = !running;
-                if (GUILayout.Button("Run", GUILayout.Width(40)))
+                if (GUILayout.Button(new GUIContent("Run", "Run this category."), GUILayout.Width(40)))
                 {
                     runner.ResetCategory(cat);
                     runner.RunCategory(cat);
                 }
                 if (GUILayout.Button(new GUIContent("Run+",
-                    "Runs this category plus any [isolated] FLIGHT tests by restoring a temporary baseline between destructive tests."),
+                    "Run this category plus isolated FLIGHT tests."),
                     GUILayout.Width(44)))
                 {
                     runner.ResetCategory(cat);
@@ -412,21 +410,15 @@ namespace Parsek.InGameTests
 
             GUILayout.BeginHorizontal();
             if (GUILayout.Button(new GUIContent("Export Results",
-                "Auto-exported after every Run All / Run Category / row-play — click to re-write now.")))
+                "Write the current results file now.")))
                 runner.ExportResultsFile();
-            if (GUILayout.Button("Close")) showWindow = false;
+            if (GUILayout.Button(new GUIContent("Close", "Close this window."))) showWindow = false;
             GUILayout.EndHorizontal();
             GUILayout.Label("Results file auto-updates after each run. Multi-scene runs accumulate.",
                 GUI.skin.label);
             GUILayout.Label("Ctrl+Shift+T to toggle from any scene", GUI.skin.label);
 
-            // Always render tooltip label — conditional rendering causes
-            // Layout/Repaint control count mismatch (IMGUI exception).
-            string tooltip = GUI.tooltip ?? "";
-            GUILayout.Label(
-                tooltip.Length > 0 ? tooltip : string.Empty,
-                tooltip.Length > 0 ? wrappedTooltipStyle : zeroHeightLabelStyle,
-                tooltip.Length > 0 ? GUILayout.ExpandWidth(true) : GUILayout.Height(0f));
+            Parsek.TooltipBubble.DrawForWindow("GlobalTestRunner", windowRect);
 
             GUI.DragWindow();
         }
@@ -469,15 +461,6 @@ namespace Parsek.InGameTests
                     wordWrap = true
                 };
                 wrappedErrorLabelStyle.margin = new RectOffset(0, 0, 0, 0);
-            }
-
-            if (wrappedTooltipStyle == null)
-            {
-                wrappedTooltipStyle = new GUIStyle(GUI.skin.label)
-                {
-                    wordWrap = true
-                };
-                wrappedTooltipStyle.margin = new RectOffset(0, 0, 0, 0);
             }
         }
 

--- a/Source/Parsek/ParsekSettings.cs
+++ b/Source/Parsek/ParsekSettings.cs
@@ -30,27 +30,27 @@ namespace Parsek
         public override bool HasPresets => false;
 
         [GameParameters.CustomParameterUI("Auto-record on launch",
-            toolTip = "Automatically start recording when a vessel leaves the pad or runway")]
+            toolTip = "Record launches automatically.")]
         public bool autoRecordOnLaunch = true;
 
         [GameParameters.CustomParameterUI("Auto-record on EVA",
-            toolTip = "Automatically start recording when a kerbal goes EVA from the pad")]
+            toolTip = "Record pad EVAs automatically.")]
         public bool autoRecordOnEva = true;
 
         [GameParameters.CustomParameterUI("Auto-record on first modification after switch",
-            toolTip = "Automatically arm after switching to a real vessel and start recording on the first meaningful physical change")]
+            toolTip = "After switching vessels, record the first meaningful change.")]
         public bool autoRecordOnFirstModificationAfterSwitch = true;
 
         [GameParameters.CustomParameterUI("Auto-merge recordings",
-            toolTip = "When enabled, recordings are committed to the timeline automatically. When disabled, a confirmation dialog appears after each recording.")]
+            toolTip = "Off: ask before adding each recording to the timeline.")]
         public bool autoMerge = false;
 
         [GameParameters.CustomParameterUI("Verbose logging",
-            toolTip = "When enabled, write detailed diagnostics to KSP.log (default for development)")]
+            toolTip = "Write detailed diagnostics to KSP.log.")]
         public bool verboseLogging = true;
 
         [GameParameters.CustomParameterUI("Readable sidecar mirrors",
-            toolTip = "When enabled, also write human-readable .txt mirrors of recording sidecars for debugging and binary/text comparison")]
+            toolTip = "Write readable .txt mirrors beside binary sidecars.")]
         public bool writeReadableSidecarMirrors = true;
 
         /// <summary>
@@ -59,7 +59,7 @@ namespace Parsek
         /// Toggles are picked up live via force-tick in <c>ParsekTrackingStation.Update</c>.
         /// </summary>
         [GameParameters.CustomParameterUI("Show ghosts in Tracking Station",
-            toolTip = "When off, Parsek ghosts are hidden from the tracking station vessel list and map view")]
+            toolTip = "Show ghost vessels and map markers in Tracking Station.")]
         public bool showGhostsInTrackingStation = true;
 
         /// <summary>
@@ -278,9 +278,9 @@ namespace Parsek
 
         internal static string DensityTooltip(SamplingDensity level) =>
             level == SamplingDensity.Low
-                ? "Fewer samples \u2014 smaller files, less CPU. Trajectories may look angular during sharp maneuvers."
+                ? "Small files, lower CPU; sharp turns may look angular."
             : level == SamplingDensity.High
-                ? "Dense sampling \u2014 smooth curves for cinematic recordings. Larger files."
+                ? "Smoothest curves; larger files."
             : "Balanced sampling for most flights.";
 
         internal static string DensitySummary(SamplingDensity level)
@@ -304,7 +304,7 @@ namespace Parsek
 
         [GameParameters.CustomFloatParameterUI("Ghost audio volume", minValue = 0f, maxValue = 1f,
             stepCount = 20, displayFormat = "P0",
-            toolTip = "Volume multiplier for ghost vessel audio (engines, decouplers, explosions). 0 = muted.")]
+            toolTip = "Volume for ghost engines, RCS, and events.")]
         public float ghostAudioVolume = 0.7f;
 
         public LoopTimeUnit AutoLoopDisplayUnit

--- a/Source/Parsek/ParsekTrackingStation.cs
+++ b/Source/Parsek/ParsekTrackingStation.cs
@@ -454,7 +454,7 @@ namespace Parsek
                 state.ShowGhosts,
                 new GUIContent(
                     " Show ghosts in Tracking Station",
-                    "Show or hide Parsek ghost vessels and markers in the Tracking Station"));
+                    "Show or hide ghost vessels and markers."));
             if (showGhosts != state.ShowGhosts)
                 SetShowGhostsFromControlSurface(showGhosts);
 
@@ -480,6 +480,7 @@ namespace Parsek
             }
 
             GUILayout.EndVertical();
+            TooltipBubble.DrawForWindow("TrackingStationMain", windowRect);
             GUI.DragWindow();
         }
 
@@ -763,6 +764,7 @@ namespace Parsek
                 GhostTrackingStationSelection.ClearSelectedGhost("ghost action panel closed");
 
             GUILayout.EndVertical();
+            TooltipBubble.DrawForWindow("TrackingStationGhostActions", ghostActionsWindowRect);
             GUI.DragWindow();
         }
 

--- a/Source/Parsek/Patches/GhostTrackingStationPatch.cs
+++ b/Source/Parsek/Patches/GhostTrackingStationPatch.cs
@@ -105,8 +105,8 @@ namespace Parsek.Patches
                     TrackingStationGhostActionSafety.SafeOnGhost,
                     context.HasGhostVessel && context.CanFocus,
                     context.HasGhostVessel && context.CanFocus
-                        ? "Center the Tracking Station camera on this ghost."
-                        : "Tracking Station camera or ghost map object is not ready."),
+                        ? "Center the camera on this ghost."
+                        : "Camera or ghost map object is not ready."),
 
                 new TrackingStationGhostActionState(
                     TrackingStationGhostActionKind.SetTarget,
@@ -115,7 +115,7 @@ namespace Parsek.Patches
                     context.HasGhostVessel && context.CanSetTarget,
                     context.HasGhostVessel && context.CanSetTarget
                         ? "Set this ghost as the navigation target."
-                        : "Targeting is not available in the current Tracking Station state."),
+                        : "Targeting is unavailable right now."),
 
                 new TrackingStationGhostActionState(
                     TrackingStationGhostActionKind.ShowRecording,
@@ -123,8 +123,8 @@ namespace Parsek.Patches
                     TrackingStationGhostActionSafety.SafeOnGhost,
                     hasRecording,
                     hasRecording
-                        ? "Open the owning recording details."
-                        : "This chain ghost has no direct committed recording row."),
+                        ? "Open this ghost's recording details."
+                        : "No direct recording row for this chain ghost."),
 
                 new TrackingStationGhostActionState(
                     TrackingStationGhostActionKind.Materialize,
@@ -140,26 +140,26 @@ namespace Parsek.Patches
             bool hasRecording)
         {
             if (!hasRecording)
-                return "No committed recording is attached to this ghost.";
+                return "No committed recording is attached.";
             if (context.AlreadyMaterialized)
-                return "The owning recording is already materialized.";
+                return "This recording is already materialized.";
             if (context.MaterializeEligible)
-                return "Spawn the recorded vessel at its resolved Tracking Station endpoint.";
+                return "Spawn the vessel at its recorded endpoint.";
 
             switch (context.MaterializeReason)
             {
                 case GhostMapPresence.TrackingStationSpawnSkipBeforeEnd:
-                    return "Recording has not reached its endpoint yet.";
+                    return "Recording has not reached its endpoint.";
                 case GhostMapPresence.TrackingStationSpawnSkipRewindPending:
-                    return "Waiting for the pending rewind UT adjustment.";
+                    return "Waiting for pending rewind time adjustment.";
                 case GhostMapPresence.TrackingStationSpawnSkipIntermediateChainSegment:
                 case GhostMapPresence.TrackingStationSpawnSkipIntermediateGhostChainLink:
-                    return "Intermediate chain segments materialize through their chain tip.";
+                    return "Materialize from the chain tip instead.";
                 case GhostMapPresence.TrackingStationSpawnSkipTerminatedGhostChain:
                     return "Terminated ghost chains do not materialize.";
                 case null:
                 case "":
-                    return "Recording is not eligible to materialize yet.";
+                    return "Recording is not eligible yet.";
                 default:
                     return "Materialize blocked: " + context.MaterializeReason;
             }

--- a/Source/Parsek/SelectiveSpawnUI.cs
+++ b/Source/Parsek/SelectiveSpawnUI.cs
@@ -177,20 +177,20 @@ namespace Parsek
             NearbySpawnCandidate? candidate, double currentUT)
         {
             if (candidate == null)
-                return "No nearby craft to spawn";
+                return "No nearby craft.";
 
             var c = candidate.Value;
             if (c.willDepart)
             {
                 double depDelta = c.departureUT - currentUT;
                 return string.Format(IC,
-                    "Warp to {0} departure (departs in {1})",
+                    "Warp to {0}'s departure in {1}.",
                     c.vesselName, FormatTimeDelta(depDelta));
             }
 
             double delta = c.endUT - currentUT;
             return string.Format(IC,
-                "Warp to {0} (spawns in {1})",
+                "Warp to {0}'s spawn in {1}.",
                 c.vesselName, FormatTimeDelta(delta));
         }
 

--- a/Source/Parsek/UI/RecordingsTableUI.cs
+++ b/Source/Parsek/UI/RecordingsTableUI.cs
@@ -133,12 +133,9 @@ namespace Parsek
         private int[] sortedIndices; // maps display row -> CommittedRecordings index
         private int lastSortedCount = -1;
 
-        // Tooltip state
-        private GUIStyle tooltipLabelStyle;
-        private Rect scrollViewRect;
-        private GUIStyle zeroHeightLabelStyle;
-        private GUIStyle wrappedTooltipStyle;
-        private string recordingsWindowTooltipText = "";
+        // Loop-period clamp help is attached to a value label, not a GUIContent
+        // control, so it feeds the shared tooltip renderer directly.
+        private string recordingsWindowTooltipOverride = "";
 
         // Expanded stats columns
         private bool showExpandedStats;
@@ -732,16 +729,16 @@ namespace Parsek
             bool isWatching, bool hasGhost, bool sameBody, bool inRange, bool isDebris)
         {
             if (isWatching)
-                return "Exit watch mode";
+                return "Exit watch.";
             if (isDebris)
-                return "Debris is not watchable";
+                return "Debris cannot be watched.";
             if (!hasGhost)
-                return "No active ghost - recording is in the past/future or has no trajectory points";
+                return "No loaded ghost for this row.";
             if (!sameBody)
-                return "Ghost is on a different body";
+                return "Ghost is around another body.";
             if (!inRange)
-                return "Ghost is beyond the fixed 300 km watch range";
-            return "Follow ghost in watch mode";
+                return "Ghost is beyond watch range.";
+            return "Watch this ghost.";
         }
 
         private string BuildWatchObservabilitySuffix(ParsekFlight flight, int index)
@@ -973,7 +970,7 @@ namespace Parsek
             }
 
             GUILayout.Label(new GUIContent("Period",
-                "Launch-to-launch period: how often the ghost relaunches.\nWhen shorter than the recording duration, successive launches overlap.\nClick unit to cycle: sec \u2192 min \u2192 hr \u2192 auto.\n\"auto\" inherits from Settings > Looping."),
+                "Launch-to-launch period. Shorter than duration creates overlap. Unit cycles sec/min/hr/auto."),
                 colHdr, GUILayout.Width(ColW_Period), GUILayout.Height(ColHeaderHeight));
             if (alignmentDebugArmed && !alignmentDebugHeaderCaptured) AlignDebugLogLastRect(alignmentDebugHeaderLog, "hdrPeriod");
 
@@ -1116,7 +1113,7 @@ namespace Parsek
             var committed = RecordingStore.CommittedRecordings;
             var supersedes = CurrentRecordingSupersedesForDisplay();
             double now = Planetarium.GetUniversalTime();
-            recordingsWindowTooltipText = string.Empty;
+            recordingsWindowTooltipOverride = string.Empty;
 
             // Bug #279 follow-up: drop watch-transition cache entries whose
             // RecordingId is no longer in the committed list (rewind, truncate,
@@ -1318,13 +1315,10 @@ namespace Parsek
                 GUILayout.EndVertical();
                 GUILayout.EndScrollView();
 
-                // Capture scroll view rect for tooltip visibility guard
-                if (Event.current.type == EventType.Repaint)
-                    scrollViewRect = GUILayoutUtility.GetLastRect();
             }
 
             DrawRecordingsBottomBar(committed);
-            DrawRecordingsWindowTooltip();
+            TooltipBubble.DrawForWindow("Recordings", recordingsWindowRect, recordingsWindowTooltipOverride);
         }
 
         /// <summary>
@@ -2025,13 +2019,13 @@ namespace Parsek
                 string watchLabel = isWatching ? "W*" : "W";
                 string watchTooltip;
                 if (rotation.TotalEligible == 0)
-                    watchTooltip = "no watchable vessels in this group";
+                    watchTooltip = "No watchable ghosts in this group.";
                 else if (isWatching && nextTargetIdx >= 0 && rotation.NextRecordingId != watchedDescendantRecId)
-                    watchTooltip = $"switch to {committed[nextTargetIdx].VesselName}";
+                    watchTooltip = $"Watch {committed[nextTargetIdx].VesselName} next.";
                 else if (isWatching && rotation.IsToggleOff)
-                    watchTooltip = "exit watch (no other watchable vessels)";
+                    watchTooltip = "Exit watch.";
                 else if (nextTargetIdx >= 0)
-                    watchTooltip = $"enter watch on {committed[nextTargetIdx].VesselName}";
+                    watchTooltip = $"Watch {committed[nextTargetIdx].VesselName}.";
                 else
                     watchTooltip = GetWatchButtonTooltip(isWatching, false, false, false, false);
 
@@ -2090,7 +2084,7 @@ namespace Parsek
                     string ffReason;
                     bool canFF = RecordingStore.CanFastForward(mainRec, out ffReason, isRecording: isRecording);
                     GUI.enabled = canFF;
-                    string tooltip = canFF ? "Fast-forward to this launch" : ffReason;
+                    string tooltip = canFF ? "Fast-forward to launch." : ffReason;
                     if (DrawRewindColumnButton(new GUIContent(FastForwardActionLabel, tooltip)))
                     {
                         ParsekLog.Info("UI", $"Group '{groupName}' Forward button: #{mainIdx} \"{mainRec.VesselName}\"");
@@ -2109,7 +2103,7 @@ namespace Parsek
                     string rewindReason;
                     bool canRewind = RecordingStore.CanRewind(mainRec, out rewindReason, isRecording: isRecording);
                     GUI.enabled = canRewind;
-                    string tooltip = canRewind ? "Rewind to this launch" : rewindReason;
+                    string tooltip = canRewind ? "Rewind to launch." : rewindReason;
                     if (DrawRewindColumnButton(new GUIContent(RewindActionLabel, tooltip)))
                     {
                         ParsekLog.Info("UI", $"Group '{groupName}' Rewind button: #{mainIdx} \"{mainRec.VesselName}\"");
@@ -2522,7 +2516,7 @@ namespace Parsek
 
                 GUI.enabled = canFF;
                 string tooltip = canFF
-                    ? "Fast-forward to this launch"
+                    ? "Fast-forward to launch."
                     : ffReason;
                 if (DrawRewindColumnButton(new GUIContent(FastForwardActionLabel, tooltip)))
                 {
@@ -2553,7 +2547,7 @@ namespace Parsek
                 ClearLegacyRewindSuppressionForOwnerRow(rec, ri);
                 GUI.enabled = canRewind;
                 string tooltip = canRewind
-                    ? "Rewind to this launch"
+                    ? "Rewind to launch."
                     : rewindReason;
                 if (DrawRewindColumnButton(new GUIContent(RewindActionLabel, tooltip)))
                 {
@@ -2691,13 +2685,13 @@ namespace Parsek
             }
 
             string tooltip = canInvoke
-                ? "Re-fly this unfinished flight from the separation moment"
-                : (reason ?? "Re-Fly unavailable");
+                ? "Re-fly from the separation moment."
+                : (reason ?? "Re-fly unavailable.");
             bool flyClicked;
             bool sealClicked;
             DrawBodyCenteredTwoButtons(
                 new GUIContent(kReFlyLabel, tooltip), canInvoke,
-                new GUIContent("Seal", "Close this re-fly slot permanently without changing the recording"), true,
+                new GUIContent("Seal", "Close this slot without changing the recording."), true,
                 ColW_ReFly, out flyClicked, out sealClicked);
             if (flyClicked)
             {
@@ -2716,7 +2710,7 @@ namespace Parsek
         private void DrawDisabledUnfinishedFlightRewindButton(
             Recording rec, int ri, string reason)
         {
-            reason = string.IsNullOrEmpty(reason) ? "Re-Fly unavailable" : reason;
+            reason = string.IsNullOrEmpty(reason) ? "Re-fly unavailable." : reason;
             string recId = rec?.RecordingId ?? "<no-id>";
             string key = "disabled/" + recId + "/" + reason;
             bool prev;
@@ -2762,10 +2756,10 @@ namespace Parsek
         }
 
         private const string StashUnfinishedFlightTooltip =
-            "Stash this stable Rewind Point slot in STASH so it can be re-flown later";
+            "Save this slot in STASH for later re-fly.";
 
         private const string SealStableSlotTooltip =
-            "Close this Rewind Point slot permanently without changing the recording";
+            "Close this slot without changing the recording.";
 
         private bool DrawStashSealUnfinishedFlightButtons(Recording rec, int ri)
         {
@@ -4303,85 +4297,6 @@ namespace Parsek
             return stats;
         }
 
-        private void DrawRecordingTooltip(Recording rec)
-        {
-            var stats = GetOrComputeStats(rec);
-
-            string text = $"Max Altitude: {FormatAltitude(stats.maxAltitude)}\n" +
-                          $"Max Speed: {FormatSpeed(stats.maxSpeed)}\n" +
-                          $"Distance: {FormatDistance(stats.distanceTravelled)}\n" +
-                          $"Points: {stats.pointCount}";
-
-            // Phase 6d-3: Chain status in recording tooltip
-            var flight = parentUI.Flight;
-            if (parentUI.InFlightMode && flight != null)
-            {
-                string chainStatus = ParsekFlight.GetChainStatusForRecording(
-                    flight.ActiveGhostChains, rec);
-                if (chainStatus != null)
-                    text += $"\n{chainStatus}";
-            }
-
-            if (stats.orbitSegmentCount > 0)
-                text += $"\nOrbit Segments: {stats.orbitSegmentCount}";
-            if (stats.partEventCount > 0)
-                text += $"\nPart Events: {stats.partEventCount}";
-            if (!string.IsNullOrEmpty(stats.primaryBody))
-                text += $"\nBody: {stats.primaryBody}";
-            if (stats.maxRange > 0)
-                text += $"\nMax Range: {FormatDistance(stats.maxRange)}";
-
-            // Observability: append storage breakdown from cached file sizes
-            try
-            {
-                double currentUT = Planetarium.GetUniversalTime();
-                var storage = DiagnosticsComputation.GetCachedStorageBreakdown(rec, currentUT);
-                if (storage.totalBytes > 0)
-                {
-                    text += $"\nStorage: {DiagnosticsComputation.FormatBytes(storage.totalBytes)}" +
-                            $" (trajectory: {DiagnosticsComputation.FormatBytes(storage.trajectoryFileBytes)}" +
-                            $", vessel: {DiagnosticsComputation.FormatBytes(storage.vesselSnapshotBytes)}" +
-                            $", ghost: {DiagnosticsComputation.FormatBytes(storage.ghostSnapshotBytes)}" +
-                            $", readable mirrors: {DiagnosticsComputation.FormatBytes(storage.readableMirrorBytes)})";
-                    text += $"\nEfficiency: {DiagnosticsComputation.FormatBytes((long)storage.bytesPerSecond)}/s of flight time";
-                }
-            }
-            catch { /* Non-KSP context or Planetarium unavailable */ }
-
-            string resourceText = FormatResourceManifest(rec.StartResources, rec.EndResources);
-            if (resourceText != null)
-                text += "\n" + resourceText;
-
-            string inventoryText = FormatInventoryManifest(rec.StartInventory, rec.EndInventory);
-            if (inventoryText != null)
-                text += "\n" + inventoryText;
-
-            string crewText = FormatCrewManifest(rec.StartCrew, rec.EndCrew);
-            if (crewText != null)
-                text += "\n" + crewText;
-
-            EnsureTooltipStyle();
-
-            GUIContent content = new GUIContent(text);
-            Vector2 size = tooltipLabelStyle.CalcSize(content);
-            size.x += 12;
-            size.y += 8;
-
-            Vector2 mousePos = Event.current.mousePosition;
-            float tooltipX = mousePos.x + 15;
-            float tooltipY = mousePos.y - size.y - 5;
-
-            if (tooltipX + size.x > recordingsWindowRect.width)
-                tooltipX = mousePos.x - size.x - 5;
-            if (tooltipY < 0)
-                tooltipY = mousePos.y + 20;
-
-            Rect tooltipRect = new Rect(tooltipX, tooltipY, size.x, size.y);
-            GUI.Box(tooltipRect, "");
-            GUI.Label(new Rect(tooltipX + 6, tooltipY + 4, size.x - 12, size.y - 8),
-                content, tooltipLabelStyle);
-        }
-
         // --- Loop helpers exclusive to recordings table ---
 
         internal static string UnitSuffix(LoopTimeUnit unit)
@@ -4517,7 +4432,7 @@ namespace Parsek
                     }
                     Rect valueRect = GUILayoutUtility.GetLastRect();
                     if (displayClamped && valueRect.Contains(Event.current.mousePosition))
-                        recordingsWindowTooltipText = clampTooltip;
+                        recordingsWindowTooltipOverride = clampTooltip;
                     if (GUI.GetNameOfFocusedControl() == controlName)
                     {
                         loopPeriodEditText = FormatLoopPeriodEditStartText(
@@ -4629,7 +4544,7 @@ namespace Parsek
             {
                 return string.Format(
                     CultureInfo.InvariantCulture,
-                    "Runtime cadence clamped to {0}s to keep concurrent cycles <= {1} (requested: {2}s, minimum period: {3}s, duration: {4}s).",
+                    "Using {0}s. Limit: <= {1} cycles; requested: {2}s; minimum period is {3}s; duration: {4}s.",
                     effectiveText, cap, requestedText, minText, durationText);
             }
 
@@ -4637,7 +4552,7 @@ namespace Parsek
             {
                 return string.Format(
                     CultureInfo.InvariantCulture,
-                    "Runtime cadence clamped to {0}s to keep concurrent cycles <= {1} (requested: {2}s, duration: {3}s).",
+                    "Using {0}s. Limit: <= {1} cycles; requested: {2}s; duration: {3}s.",
                     effectiveText, cap, requestedText, durationText);
             }
 
@@ -4647,13 +4562,13 @@ namespace Parsek
                 {
                     return string.Format(
                         CultureInfo.InvariantCulture,
-                        "Runtime cadence repaired to {0}s from an invalid stored value (minimum period: {1}s).",
+                        "Using {0}s. Stored value was invalid; minimum period is {1}s.",
                         effectiveText, minText);
                 }
 
                 return string.Format(
                     CultureInfo.InvariantCulture,
-                    "Runtime cadence raised to {0}s because the minimum period is {1}s (requested: {2}s).",
+                    "Using {0}s. The minimum period is {1}s; requested: {2}s.",
                     effectiveText, minText, requestedText);
             }
 
@@ -4706,52 +4621,6 @@ namespace Parsek
             loopPeriodFocusedRi = -1;
             loopPeriodEditRect = default;
             GUIUtility.keyboardControl = 0;
-        }
-
-        private void EnsureTooltipStyle()
-        {
-            if (tooltipLabelStyle != null) return;
-            tooltipLabelStyle = new GUIStyle(GUI.skin.label);
-            tooltipLabelStyle.wordWrap = false;
-            tooltipLabelStyle.fontSize = 11;
-        }
-
-        private void EnsureWindowTooltipStyles()
-        {
-            if (zeroHeightLabelStyle == null)
-            {
-                zeroHeightLabelStyle = new GUIStyle(GUI.skin.label)
-                {
-                    fixedHeight = 0f,
-                    stretchHeight = false,
-                    wordWrap = false
-                };
-                zeroHeightLabelStyle.margin = new RectOffset(0, 0, 0, 0);
-                zeroHeightLabelStyle.padding = new RectOffset(0, 0, 0, 0);
-            }
-
-            if (wrappedTooltipStyle == null)
-            {
-                wrappedTooltipStyle = new GUIStyle(GUI.skin.box)
-                {
-                    wordWrap = true,
-                    alignment = TextAnchor.UpperLeft
-                };
-            }
-        }
-
-        private void DrawRecordingsWindowTooltip()
-        {
-            EnsureWindowTooltipStyles();
-
-            string tooltip = !string.IsNullOrEmpty(recordingsWindowTooltipText)
-                ? recordingsWindowTooltipText
-                : (GUI.tooltip ?? string.Empty);
-            GUILayout.Space(tooltip.Length > 0 ? SpacingSmall : 0f);
-            GUILayout.Label(
-                tooltip.Length > 0 ? tooltip : string.Empty,
-                tooltip.Length > 0 ? wrappedTooltipStyle : zeroHeightLabelStyle,
-                tooltip.Length > 0 ? GUILayout.ExpandWidth(true) : GUILayout.Height(0f));
         }
 
         private void EnsureStatusStyles()

--- a/Source/Parsek/UI/SettingsWindowUI.cs
+++ b/Source/Parsek/UI/SettingsWindowUI.cs
@@ -24,8 +24,6 @@ namespace Parsek
 
         private const float SpacingSmall = 3f;
         private const float SpacingLarge = 10f;
-        private GUIStyle zeroHeightLabelStyle;
-        private GUIStyle wrappedTooltipStyle;
 
         public bool IsOpen
         {
@@ -142,7 +140,6 @@ namespace Parsek
 
         private void DrawSettingsWindow(int windowID)
         {
-            EnsureLayoutStyles();
             // Breathing room below the title bar — matches Timeline's visual spacing.
             GUILayout.Space(5);
             var s = ParsekSettings.Current;
@@ -206,44 +203,16 @@ namespace Parsek
             }
             GUILayout.EndHorizontal();
 
-            string tooltip = GUI.tooltip ?? "";
-            GUILayout.Space(tooltip.Length > 0 ? SpacingSmall : 0f);
-            GUILayout.Label(
-                tooltip.Length > 0 ? tooltip : string.Empty,
-                tooltip.Length > 0 ? wrappedTooltipStyle : zeroHeightLabelStyle,
-                tooltip.Length > 0 ? GUILayout.ExpandWidth(true) : GUILayout.Height(0f));
+            TooltipBubble.DrawForWindow("Settings", settingsWindowRect);
 
             GUI.DragWindow();
-        }
-
-        private void EnsureLayoutStyles()
-        {
-            if (zeroHeightLabelStyle == null)
-            {
-                zeroHeightLabelStyle = new GUIStyle(GUI.skin.label)
-                {
-                    fixedHeight = 0f,
-                    stretchHeight = false,
-                    wordWrap = false
-                };
-                zeroHeightLabelStyle.margin = new RectOffset(0, 0, 0, 0);
-                zeroHeightLabelStyle.padding = new RectOffset(0, 0, 0, 0);
-            }
-
-            if (wrappedTooltipStyle == null)
-            {
-                wrappedTooltipStyle = new GUIStyle(GUI.skin.box)
-                {
-                    wordWrap = true
-                };
-            }
         }
 
         private void DrawRecordingSettings(ParsekSettings s)
         {
             GUILayout.Label("Recording", parentUI.GetSectionHeaderStyle());
             bool autoRecordOnLaunch = GUILayout.Toggle(s.autoRecordOnLaunch,
-                new GUIContent(" Auto-record on launch", "Start recording when a vessel leaves the pad or runway"));
+                new GUIContent(" Auto-record on launch", "Record launches automatically."));
             if (autoRecordOnLaunch != s.autoRecordOnLaunch)
             {
                 s.autoRecordOnLaunch = autoRecordOnLaunch;
@@ -251,7 +220,7 @@ namespace Parsek
             }
 
             bool autoRecordOnEva = GUILayout.Toggle(s.autoRecordOnEva,
-                new GUIContent(" Auto-record on EVA", "Start recording when a kerbal goes EVA from the pad"));
+                new GUIContent(" Auto-record on EVA", "Record pad EVAs automatically."));
             if (autoRecordOnEva != s.autoRecordOnEva)
             {
                 s.autoRecordOnEva = autoRecordOnEva;
@@ -262,7 +231,7 @@ namespace Parsek
                 s.autoRecordOnFirstModificationAfterSwitch,
                 new GUIContent(
                     " Auto-record on first modification after switch",
-                    "Arm after switching to a real vessel and start recording on the first meaningful physical change"));
+                    "After switching vessels, record the first meaningful change."));
             if (autoRecordOnFirstModificationAfterSwitch != s.autoRecordOnFirstModificationAfterSwitch)
             {
                 s.autoRecordOnFirstModificationAfterSwitch = autoRecordOnFirstModificationAfterSwitch;
@@ -271,7 +240,7 @@ namespace Parsek
             }
 
             bool autoMerge = GUILayout.Toggle(s.autoMerge,
-                new GUIContent(" Auto-merge recordings", "When off, a confirmation dialog appears after each recording"));
+                new GUIContent(" Auto-merge recordings", "Off: ask before adding each recording to the timeline."));
             if (autoMerge != s.autoMerge)
             {
                 s.autoMerge = autoMerge;
@@ -284,7 +253,7 @@ namespace Parsek
             GUILayout.Label("Looping", parentUI.GetSectionHeaderStyle());
             GUILayout.BeginHorizontal();
             GUILayout.Label(new GUIContent("Auto-launch every",
-                "Default launch-to-launch period (seconds) for recordings set to 'auto' unit. Overlap occurs naturally when the period is shorter than the recording duration."),
+                "Default launch-to-launch interval for Auto periods."),
                 GUILayout.ExpandWidth(false));
             GUILayout.FlexibleSpace();
             {
@@ -338,7 +307,7 @@ namespace Parsek
 
             GUILayout.BeginHorizontal();
             GUILayout.Label(new GUIContent("Ghost audio",
-                "Volume multiplier for ghost vessel audio (engines, RCS, events). 0% = muted."),
+                "Volume for ghost engines, RCS, and events."),
                 GUILayout.Width(85));
             float newAudioVol = GUILayout.HorizontalSlider(s.ghostAudioVolume, 0f, 1f);
             GUILayout.Label(
@@ -356,7 +325,7 @@ namespace Parsek
 
             bool showGhostsTS = GUILayout.Toggle(s.showGhostsInTrackingStation,
                 new GUIContent(" Show ghosts in Tracking Station",
-                    "When off, Parsek ghosts are hidden from the tracking station vessel list and map view"));
+                    "Show ghost vessels and map markers in Tracking Station."));
             if (showGhostsTS != s.showGhostsInTrackingStation)
             {
                 s.showGhostsInTrackingStation = showGhostsTS;
@@ -382,7 +351,7 @@ namespace Parsek
 
             bool writeReadableSidecarMirrors = GUILayout.Toggle(s.writeReadableSidecarMirrors,
                 new GUIContent(" Write readable sidecar mirrors",
-                    "Also write human-readable .txt mirrors of .prec and snapshot sidecars for debugging and binary/text comparison"));
+                    "Write readable .txt mirrors beside binary sidecars."));
             if (writeReadableSidecarMirrors != s.writeReadableSidecarMirrors)
             {
                 s.writeReadableSidecarMirrors = writeReadableSidecarMirrors;
@@ -392,13 +361,13 @@ namespace Parsek
             }
 
             if (GUILayout.Button(new GUIContent("In-Game Test Runner",
-                "Run runtime tests to verify ghost spawning, playback, and visuals.\nAlso available via Ctrl+Shift+T in any scene.")))
+                "Open runtime tests. Ctrl+Shift+T also toggles it.")))
             {
                 parentUI.ToggleTestRunner();
             }
 
             if (GUILayout.Button(new GUIContent("Run Diagnostics Report",
-                "Compute full diagnostics snapshot and dump report to KSP.log")))
+                "Write a diagnostics snapshot to KSP.log.")))
             {
                 ParsekLog.Info("UI", "Run Diagnostics Report button clicked");
                 DiagnosticsComputation.RunDiagnosticsReport();
@@ -412,9 +381,7 @@ namespace Parsek
             var rpSnap = RewindPointDiskUsage.GetSnapshot(rpDir);
             GUILayout.Label(new GUIContent(
                 RewindPointDiskUsage.FormatLine(rpSnap),
-                "Total size of rewind-point quicksaves under saves/<save>/Parsek/RewindPoints/. "
-                + "Also shows live RP counts split by crashed, stable, and sealed-pending slots. "
-                + "Refreshed every 10 seconds or when RP state changes."));
+                "Rewind point quicksaves: size and live slot counts. Refreshes every 10s."));
         }
 
         private void DrawSamplingSettings(ParsekSettings s)

--- a/Source/Parsek/UI/SpawnControlUI.cs
+++ b/Source/Parsek/UI/SpawnControlUI.cs
@@ -43,7 +43,6 @@ namespace Parsek
         private const float SpawnColW_State = 110f;
         private const float SpawnColW_Warp = 85f;
 
-        private const float SpacingSmall = 3f;
         private const float MinWindowWidth = 350f;
         private const float MinWindowHeight = 150f;
 
@@ -346,19 +345,9 @@ namespace Parsek
             }
             GUILayout.EndHorizontal();
 
-            string guiTooltip = GUI.tooltip ?? "";
-            if (guiTooltip.Length > 0)
-            {
-                GUILayout.Space(SpacingSmall);
-                GUILayout.Label(guiTooltip, GUI.skin.box);
-            }
-            else
-            {
-                GUILayout.Label("", GUILayout.Height(0));
-            }
-
             ParsekUI.DrawResizeHandle(spawnControlWindowRect, ref isResizingSpawnControlWindow,
                 "Real Spawn Control window");
+            TooltipBubble.DrawForWindow("SpawnControl", spawnControlWindowRect);
 
             GUI.DragWindow();
         }

--- a/Source/Parsek/UI/TestRunnerUI.cs
+++ b/Source/Parsek/UI/TestRunnerUI.cs
@@ -25,7 +25,6 @@ namespace Parsek
         private bool testRunnerWasRunning;
         private GUIStyle zeroHeightLabelStyle;
         private GUIStyle wrappedErrorLabelStyle;
-        private GUIStyle wrappedTooltipStyle;
 
         private const float SpacingSmall = 3f;
         private const float DefaultWindowWidth = 440f;
@@ -160,14 +159,14 @@ namespace Parsek
                 }
                 // Run category button
                 GUI.enabled = !testRunner.IsRunning;
-                if (GUILayout.Button("Run", GUILayout.Width(40)))
+                if (GUILayout.Button(new GUIContent("Run", "Run this category."), GUILayout.Width(40)))
                 {
                     testRunner.ResetCategory(category);
                     testRunner.RunCategory(category);
                     ParsekLog.Verbose("UI", $"Test runner: Run category '{category}'");
                 }
                 if (GUILayout.Button(new GUIContent("Run+",
-                    "Runs this category plus any [isolated] FLIGHT tests by restoring a temporary baseline between destructive tests."),
+                    "Run this category plus isolated FLIGHT tests."),
                     GUILayout.Width(44)))
                 {
                     testRunner.ResetCategory(category);
@@ -256,15 +255,6 @@ namespace Parsek
                 };
                 wrappedErrorLabelStyle.margin = new RectOffset(0, 0, 0, 0);
             }
-
-            if (wrappedTooltipStyle == null)
-            {
-                wrappedTooltipStyle = new GUIStyle(GUI.skin.label)
-                {
-                    wordWrap = true
-                };
-                wrappedTooltipStyle.margin = new RectOffset(0, 0, 0, 0);
-            }
         }
 
         private void DrawTestRunnerWindow(int windowID)
@@ -281,21 +271,21 @@ namespace Parsek
             // --- Controls bar ---
             GUILayout.BeginHorizontal();
             GUI.enabled = !testRunner.IsRunning;
-            if (GUILayout.Button("Run All"))
+            if (GUILayout.Button(new GUIContent("Run All", "Run all batch-safe tests.")))
             {
                 testRunner.ResetResults();
                 testRunner.RunAll();
                 ParsekLog.Info("UI", "Test runner: Run All clicked");
             }
             if (GUILayout.Button(new GUIContent("Run All + Isolated",
-                "Runs ordinary batch-safe tests plus [isolated] FLIGHT tests by capturing a temporary baseline save and quickloading it after each destructive test.")))
+                "Run batch-safe tests plus isolated FLIGHT tests.")))
             {
                 testRunner.ResetResults();
                 testRunner.RunAllIncludingFlightRestore();
                 ParsekLog.Info("UI", "Test runner: Run All + Isolated clicked");
             }
             if (GUILayout.Button(new GUIContent("Reset",
-                "Clears the table AND per-scene history used by the auto-exported results file.")))
+                "Clear results and scene history.")))
             {
                 // Explicit Reset wipes per-scene history so the auto-export on the
                 // next run produces a clean report. The implicit pre-run ResetResults
@@ -304,7 +294,7 @@ namespace Parsek
                 ParsekLog.Verbose("UI", "Test runner: Reset clicked (full history wipe)");
             }
             GUI.enabled = testRunner.IsRunning;
-            if (GUILayout.Button("Cancel"))
+            if (GUILayout.Button(new GUIContent("Cancel", "Stop the current test run.")))
             {
                 testRunner.Cancel();
             }
@@ -350,12 +340,12 @@ namespace Parsek
             // --- Bottom bar ---
             GUILayout.Space(SpacingSmall);
             GUILayout.BeginHorizontal();
-            if (GUILayout.Button("Export Results"))
+            if (GUILayout.Button(new GUIContent("Export Results", "Write the current results file now.")))
             {
                 testRunner.ExportResultsFile();
                 ParsekLog.Info("UI", "Test runner: manually exported results file");
             }
-            if (GUILayout.Button("Close"))
+            if (GUILayout.Button(new GUIContent("Close", "Close this window.")))
             {
                 showTestRunnerWindow = false;
                 ParsekLog.Verbose("UI", "Test runner window closed");
@@ -363,14 +353,7 @@ namespace Parsek
             GUILayout.EndHorizontal();
             GUILayout.Label("Ctrl+Shift+T to toggle from any scene", GUI.skin.label);
 
-            // Always render tooltip label — conditional rendering causes
-            // Layout/Repaint control count mismatch (IMGUI exception).
-            string tooltip = GUI.tooltip ?? "";
-            GUILayout.Space(SpacingSmall);
-            GUILayout.Label(
-                tooltip.Length > 0 ? tooltip : string.Empty,
-                tooltip.Length > 0 ? wrappedTooltipStyle : zeroHeightLabelStyle,
-                tooltip.Length > 0 ? GUILayout.ExpandWidth(true) : GUILayout.Height(0f));
+            TooltipBubble.DrawForWindow("TestRunner", testRunnerWindowRect);
 
             GUI.DragWindow();
         }

--- a/Source/Parsek/UI/TimelineWindowUI.cs
+++ b/Source/Parsek/UI/TimelineWindowUI.cs
@@ -394,6 +394,7 @@ namespace Parsek
 
             ParsekUI.DrawResizeHandle(timelineWindowRect, ref isResizingTimelineWindow,
                 "Timeline window");
+            TooltipBubble.DrawForWindow("Timeline", timelineWindowRect);
 
             GUI.DragWindow();
         }
@@ -869,7 +870,7 @@ namespace Parsek
                         string ffReason;
                         bool canFF = CanFastForwardNow(rec, out ffReason);
                         GUI.enabled = canFF;
-                        if (GUILayout.Button(new GUIContent("FF", canFF ? "Fast-forward to this launch" : ffReason),
+                        if (GUILayout.Button(new GUIContent("FF", canFF ? "Fast-forward to launch." : ffReason),
                             GUILayout.Width(GetRowActionButtonWidth(TimelineRowActionButtonKind.FastForward))))
                         {
                             ParsekLog.Info("UI",
@@ -884,7 +885,7 @@ namespace Parsek
                         string rewindReason;
                         bool canRewind = CanRewindWithResolvedSaveState(rec, out rewindReason);
                         GUI.enabled = canRewind;
-                        if (GUILayout.Button(new GUIContent("R", canRewind ? "Rewind to this launch" : rewindReason),
+                        if (GUILayout.Button(new GUIContent("R", canRewind ? "Rewind to launch." : rewindReason),
                             GUILayout.Width(GetRowActionButtonWidth(TimelineRowActionButtonKind.Rewind))))
                         {
                             ParsekLog.Info("UI",
@@ -905,7 +906,7 @@ namespace Parsek
                     bool isUnfinishedFlight = EffectiveState.IsUnfinishedFlight(rec);
                     if (ShouldShowLoopToggle(rec, isFuture, isUnfinishedFlight))
                     {
-                        string lTooltip = rec.LoopPlayback ? "Disable looping" : "Enable looping (uses saved interval)";
+                        string lTooltip = rec.LoopPlayback ? "Disable looping." : "Enable looping with saved interval.";
                         bool newLoop = GUILayout.Toggle(rec.LoopPlayback, new GUIContent("L", lTooltip),
                             toggleButtonStyle, GUILayout.Width(GetRowActionButtonWidth(TimelineRowActionButtonKind.Loop)));
                         if (newLoop != rec.LoopPlayback)
@@ -921,7 +922,7 @@ namespace Parsek
 
                     // GoTo button — always last, right-aligned
                     if (GUILayout.Button(
-                            new GUIContent("GoTo", "Show in Recordings Manager"),
+                            new GUIContent("GoTo", "Show in Recordings."),
                             GUILayout.Width(GetRowActionButtonWidth(TimelineRowActionButtonKind.GoTo))))
                     {
                         parentUI.SelectedRecordingId = entry.RecordingId;
@@ -951,7 +952,7 @@ namespace Parsek
                     }
 
                     if (GUILayout.Button(
-                            new GUIContent("GoTo", "Show in Recordings Manager"),
+                            new GUIContent("GoTo", "Show in Recordings."),
                             GUILayout.Width(GetRowActionButtonWidth(TimelineRowActionButtonKind.GoTo))))
                     {
                         parentUI.SelectedRecordingId = entry.RecordingId;
@@ -995,7 +996,7 @@ namespace Parsek
             {
                 GUI.enabled = false;
                 GUILayout.Button(
-                    new GUIContent("Fly", routeReason ?? "Re-Fly unavailable"),
+                    new GUIContent("Fly", routeReason ?? "Re-fly unavailable."),
                     GUILayout.Width(width));
                 GUI.enabled = true;
                 return;
@@ -1006,8 +1007,8 @@ namespace Parsek
                 rp, slotListIndex, out reason);
             GUI.enabled = canInvoke;
             string tooltip = canInvoke
-                ? "Re-fly this unfinished flight from the separation moment"
-                : (reason ?? "Re-Fly unavailable");
+                ? "Re-fly from the separation moment."
+                : (reason ?? "Re-fly unavailable.");
             if (GUILayout.Button(new GUIContent("Fly", tooltip), GUILayout.Width(width)))
             {
                 ParsekLog.Info("UI",

--- a/Source/Parsek/UI/TooltipBubble.cs
+++ b/Source/Parsek/UI/TooltipBubble.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Parsek
+{
+    /// <summary>
+    /// Shared delayed IMGUI tooltip bubble renderer for Parsek windows.
+    /// </summary>
+    internal static class TooltipBubble
+    {
+        internal const float HoverDelaySeconds = 1.0f;
+
+        private const float CursorOffsetX = 16f;
+        private const float CursorOffsetY = 18f;
+        private const float WindowPadding = 6f;
+        private const float BubblePaddingX = 8f;
+        private const float BubblePaddingY = 6f;
+        private const float MaxTextWidth = 320f;
+        private const float MinTextWidth = 120f;
+        private const float MinimumUsableTextWidth = 48f;
+
+        private sealed class HoverState
+        {
+            internal string Text = string.Empty;
+            internal float HoverStartRealtime;
+        }
+
+        private static readonly Dictionary<string, HoverState> hoverStates =
+            new Dictionary<string, HoverState>();
+
+        private static GUIStyle bubbleLabelStyle;
+        private static GUIStyle bubbleBoxStyle;
+
+        internal static void DrawForWindow(string scopeKey, Rect windowRect, string overrideTooltip = null)
+        {
+            Event current = Event.current;
+            if (current == null || string.IsNullOrEmpty(scopeKey))
+                return;
+
+            string tooltip = string.IsNullOrEmpty(overrideTooltip)
+                ? (GUI.tooltip ?? string.Empty)
+                : overrideTooltip;
+
+            Rect lastLayoutRect = current.type == EventType.Repaint
+                ? GUILayoutUtility.GetLastRect()
+                : default(Rect);
+            Rect localBounds = ComputeLocalBounds(windowRect, lastLayoutRect);
+            DrawForWindow(
+                scopeKey,
+                localBounds,
+                current.mousePosition,
+                tooltip,
+                Time.realtimeSinceStartup,
+                current.type);
+        }
+
+        internal static void ResetForTesting()
+        {
+            hoverStates.Clear();
+        }
+
+        internal static bool ShouldShow(string tooltip, float hoverStartRealtime, float nowRealtime)
+        {
+            return !string.IsNullOrEmpty(tooltip)
+                && nowRealtime - hoverStartRealtime >= HoverDelaySeconds;
+        }
+
+        internal static bool ShouldResetHover(string previousTooltip, string currentTooltip, bool pointerInWindow)
+        {
+            return !pointerInWindow
+                || string.IsNullOrEmpty(currentTooltip)
+                || !string.Equals(previousTooltip, currentTooltip, StringComparison.Ordinal);
+        }
+
+        internal static float ComputeTextWidth(float naturalWidth, float windowWidth)
+        {
+            float maxWidth = Mathf.Max(
+                MinimumUsableTextWidth,
+                Mathf.Min(MaxTextWidth, windowWidth - (WindowPadding * 2f) - (BubblePaddingX * 2f)));
+            float minWidth = Mathf.Min(MinTextWidth, maxWidth);
+            return Mathf.Clamp(naturalWidth, minWidth, maxWidth);
+        }
+
+        internal static Rect ComputeBubbleRect(Vector2 mousePosition, Vector2 bubbleSize, Rect bounds)
+        {
+            float minX = bounds.xMin + WindowPadding;
+            float maxX = bounds.xMax - bubbleSize.x - WindowPadding;
+            float x = mousePosition.x + CursorOffsetX;
+            if (x > maxX)
+                x = mousePosition.x - bubbleSize.x - CursorOffsetX;
+            x = maxX < minX ? minX : Mathf.Clamp(x, minX, maxX);
+
+            float minY = bounds.yMin + WindowPadding;
+            float maxY = bounds.yMax - bubbleSize.y - WindowPadding;
+            float y = mousePosition.y + CursorOffsetY;
+            if (y > maxY)
+                y = mousePosition.y - bubbleSize.y - CursorOffsetY;
+            y = maxY < minY ? minY : Mathf.Clamp(y, minY, maxY);
+
+            return new Rect(x, y, bubbleSize.x, bubbleSize.y);
+        }
+
+        internal static Rect ComputeLocalBounds(Rect windowRect, Rect lastLayoutRect)
+        {
+            float height = windowRect.height;
+            if (height <= 0f && lastLayoutRect.height > 0f)
+                height = lastLayoutRect.yMax + WindowPadding;
+
+            return new Rect(
+                0f,
+                0f,
+                Mathf.Max(0f, windowRect.width),
+                Mathf.Max(0f, height));
+        }
+
+        private static void DrawForWindow(
+            string scopeKey,
+            Rect localBounds,
+            Vector2 mousePosition,
+            string tooltip,
+            float nowRealtime,
+            EventType eventType)
+        {
+            if (eventType != EventType.Repaint)
+                return;
+
+            bool pointerInWindow = localBounds.Contains(mousePosition);
+            HoverState state;
+            hoverStates.TryGetValue(scopeKey, out state);
+
+            if (state == null)
+            {
+                state = new HoverState();
+                hoverStates[scopeKey] = state;
+            }
+
+            if (ShouldResetHover(state.Text, tooltip, pointerInWindow))
+            {
+                state.Text = pointerInWindow && !string.IsNullOrEmpty(tooltip)
+                    ? tooltip
+                    : string.Empty;
+                state.HoverStartRealtime = nowRealtime;
+                return;
+            }
+
+            if (!ShouldShow(tooltip, state.HoverStartRealtime, nowRealtime))
+                return;
+
+            EnsureStyles();
+            DrawBubble(tooltip, mousePosition, localBounds);
+        }
+
+        private static void EnsureStyles()
+        {
+            if (bubbleLabelStyle == null)
+            {
+                bubbleLabelStyle = new GUIStyle(GUI.skin.label)
+                {
+                    wordWrap = true,
+                    fontSize = 11,
+                    alignment = TextAnchor.UpperLeft
+                };
+                bubbleLabelStyle.normal.textColor = Color.white;
+                bubbleLabelStyle.margin = new RectOffset(0, 0, 0, 0);
+                bubbleLabelStyle.padding = new RectOffset(0, 0, 0, 0);
+            }
+
+            if (bubbleBoxStyle == null)
+            {
+                bubbleBoxStyle = new GUIStyle(GUI.skin.box)
+                {
+                    alignment = TextAnchor.UpperLeft
+                };
+            }
+        }
+
+        private static void DrawBubble(string tooltip, Vector2 mousePosition, Rect localBounds)
+        {
+            GUIContent content = new GUIContent(tooltip);
+            float naturalWidth = bubbleLabelStyle.CalcSize(content).x;
+            float textWidth = ComputeTextWidth(naturalWidth, localBounds.width);
+            float textHeight = bubbleLabelStyle.CalcHeight(content, textWidth);
+            Vector2 bubbleSize = new Vector2(
+                textWidth + BubblePaddingX * 2f,
+                textHeight + BubblePaddingY * 2f);
+            Rect bubbleRect = ComputeBubbleRect(mousePosition, bubbleSize, localBounds);
+            Rect labelRect = new Rect(
+                bubbleRect.x + BubblePaddingX,
+                bubbleRect.y + BubblePaddingY,
+                textWidth,
+                textHeight);
+
+            Color previousColor = GUI.color;
+            Color previousBackground = GUI.backgroundColor;
+            Color previousContent = GUI.contentColor;
+            try
+            {
+                GUI.color = Color.white;
+                GUI.backgroundColor = new Color(0.05f, 0.05f, 0.05f, 0.96f);
+                GUI.contentColor = Color.white;
+                GUI.Box(bubbleRect, GUIContent.none, bubbleBoxStyle);
+                GUI.Label(labelRect, content, bubbleLabelStyle);
+            }
+            finally
+            {
+                GUI.color = previousColor;
+                GUI.backgroundColor = previousBackground;
+                GUI.contentColor = previousContent;
+            }
+        }
+    }
+}

--- a/Source/Parsek/UI/UnfinishedFlightsGroup.cs
+++ b/Source/Parsek/UI/UnfinishedFlightsGroup.cs
@@ -40,7 +40,7 @@ namespace Parsek
         public const string GroupName = "STASH";
 
         public const string Tooltip =
-            "Vessels and kerbals that ended up in a state where you might want to re-fly them -- crashed, abandoned in orbit, stranded on a surface. Click Fly to take control at the separation moment; click Seal to close the slot permanently if you're done with it.";
+            "Crashed, stranded, or parked outcomes you may want to re-fly. Use Fly, Stash, or Seal below.";
 
         /// <summary>
         /// True iff <paramref name="name"/> equals the virtual group name.

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -11,6 +11,14 @@ When referencing prior item numbers from source comments or plans, consult the r
 
 ---
 
+## Done - v0.9.1 delayed tooltip bubbles
+
+- ~~Hover helper text was rendered in bottom-of-window footer rows, but cramped windows left only a dark horizontal strip and the messages were easy to miss.~~ Source: UI playtest report on 2026-05-01. Fix: Parsek windows now use a shared delayed tooltip bubble that appears after 1 second of stable hover near the hovered control, clamped inside the window. The footer rows were removed from Recordings, Timeline, Settings, Spawn Control, Tracking Station, and both Test Runner surfaces, and the player-facing tooltip copy was shortened.
+
+**Status:** CLOSED 2026-05-01.
+
+---
+
 ## Done — v0.9.1 orphan-cleanup safety guard
 
 - ~~`RecordingStore.CleanOrphanFiles` unconditionally deletes every sidecar file whose recording ID is not in the in-memory known-IDs set, with no protection for the "load lost its tree state" case.~~ Source: `Kerbal Space Program/KSP.log` from save `s19` showed `Save folder changed to 's19' — resetting session state` at 10:13:42 followed by `OnLoad initial: cleared CommittedTrees, loading 0 tree(s)` and then `CleanOrphanFiles: scanning 84 file(s) against 0 known recording ID(s)` deleting 84 sidecars across 12 recordings. The save's `quicksave.sfs` (last saved 09:31, before the bad session) still contained all 12 `RECORDING_TREE` blocks with the same IDs that just got physically deleted, but the trajectory/craft sidecars were unrecoverable. Some earlier session had loaded `persistent.sfs` (presumably with the trees), dropped the in-memory trees, and saved 0 trees back — leaving the sidecars stranded. The next load then deleted them, turning a recoverable accident (restore `RECORDING_TREE` blocks from `quicksave.sfs`) into permanent bulk-data loss.


### PR DESCRIPTION
## Summary
- Replace bottom-window tooltip footers with a shared 1-second delayed bubble renderer.
- Wire the renderer into Recordings, Timeline, Settings, Spawn Control, Tracking Station, and both Test Runner surfaces.
- Shorten tooltip copy and add focused tests/docs.

## Validation
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj (10,099 passed)
- dotnet build Source/Parsek/Parsek.csproj

Stacked on PR #690 / base branch fix/uf-stash-seal-rewind.