### PR TITLE
docs: clarify worktree and review follow-up rules

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -148,7 +148,7 @@ Key source files and what they do - read the relevant one before modifying:
 
 **HARD RULE — never edit or commit inside `Parsek/` (the main checkout) without explicit per-session approval.** This applies to every change that will produce a commit — code, tests, CHANGELOG trims, todo edits, doc tweaks, anything. "It's just a one-line fix" is not an exception. Recovery if I slip: stash any unrelated WIP, `git worktree add` a new worktree at the tip containing the direct-edit commit, `git reset --hard` `Parsek/` back to the pre-direct-edit tip, `git merge --no-ff` the rescue branch back in, `git stash pop`. Never leave a direct-edit commit standing on `main` or a shared branch.
 
-**HARD RULE - new feature and bugfix work starts in my own separate sibling worktree.** Do not edit or commit in another person's or another task's `Parsek-<branch>/` worktree. Create a dedicated `../Parsek-<branch-name>` worktree from the right base, work there, and push that branch. Reuse an existing worktree only when it is mine and already dedicated to the same line of work.
+**HARD RULE - new feature and bugfix work starts in my own separate sibling worktree.** Do not edit or commit in another person's or another task's `Parsek-<branch>/` worktree unless the user specifically asks me to work in that exact worktree. Create a dedicated `../Parsek-<branch-name>` worktree from the right base, work there, and push that branch. Reuse an existing worktree only when it is mine and already dedicated to the same line of work.
 
 For manual worktrees (when not using `isolation=worktree`), create as sibling folders:
 ```bash

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -148,7 +148,7 @@ Key source files and what they do - read the relevant one before modifying:
 
 **HARD RULE — never edit or commit inside `Parsek/` (the main checkout) without explicit per-session approval.** This applies to every change that will produce a commit — code, tests, CHANGELOG trims, todo edits, doc tweaks, anything. "It's just a one-line fix" is not an exception. Recovery if I slip: stash any unrelated WIP, `git worktree add` a new worktree at the tip containing the direct-edit commit, `git reset --hard` `Parsek/` back to the pre-direct-edit tip, `git merge --no-ff` the rescue branch back in, `git stash pop`. Never leave a direct-edit commit standing on `main` or a shared branch.
 
-**HARD RULE - new feature and bugfix work starts in my own separate sibling worktree.** Do not edit or commit in another person's or another task's `Parsek-<branch>/` worktree unless the user specifically asks me to work in that exact worktree. Create a dedicated `../Parsek-<branch-name>` worktree from the right base, work there, and push that branch. Reuse an existing worktree only when it is mine and already dedicated to the same line of work.
+**HARD RULE - every change that will produce a commit starts in my own dedicated sibling worktree.** Do not edit or commit in another task's `Parsek-<branch>/` worktree unless the user specifically asks me to work in that exact worktree. Create a dedicated `../Parsek-<branch-name>` worktree from the right base, work there, and push that branch. Reuse a worktree only when it is mine and already dedicated to the same line of work — within one line of work, keep editing, committing, and pushing inside the same worktree. Spinning up a fresh worktree per change is unnecessary ceremony.
 
 For manual worktrees (when not using `isolation=worktree`), create as sibling folders:
 ```bash
@@ -235,7 +235,7 @@ Do one full review at the end of a task/worktree before creating or finalizing t
 
 When a reviewer flags fixes on an open PR, re-review only the follow-up changes and any directly affected code paths. Do not restart a full-PR review from scratch on every follow-up unless the new changes actually broaden the risk surface.
 
-Do not re-review excessively. Re-review is for risky code changes: shared behavior, serialization/schema, runtime-only paths, broad refactors, concurrency/lifecycle changes, or fixes that change the PR's behavioral contract. Docs-only edits, small copy/typo fixes, test-only clarifications, and other low-risk follow-ups do not need another review pass; self-review them and report the validation performed.
+Do not re-review excessively. Re-review is for risky code changes: shared behavior, serialization/schema, runtime-only paths, broad refactors, concurrency/lifecycle changes, or fixes that change the PR's behavioral contract. Docs-only edits, small copy/typo fixes, and test-only clarifications do not need another review pass; self-review them and report the validation performed.
 
 ## Workflow
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -148,7 +148,7 @@ Key source files and what they do - read the relevant one before modifying:
 
 **HARD RULE — never edit or commit inside `Parsek/` (the main checkout) without explicit per-session approval.** This applies to every change that will produce a commit — code, tests, CHANGELOG trims, todo edits, doc tweaks, anything. "It's just a one-line fix" is not an exception. Recovery if I slip: stash any unrelated WIP, `git worktree add` a new worktree at the tip containing the direct-edit commit, `git reset --hard` `Parsek/` back to the pre-direct-edit tip, `git merge --no-ff` the rescue branch back in, `git stash pop`. Never leave a direct-edit commit standing on `main` or a shared branch.
 
-**`Parsek-<branch>/` sibling worktrees are fair game once opened — keep working in them directly.** If I'm already in a `Parsek-<branch>/` worktree for the current line of work (created earlier this session, or already had ongoing changes I committed), I can keep editing, committing, and pushing inside it for the rest of that line of work. Spinning up a fresh worktree per change is unnecessary ceremony — the merge-back step is also unneeded since the changes already live on the same branch. Only spawn a new worktree when starting a *new* line of work that should land on its own branch.
+**HARD RULE - new feature and bugfix work starts in my own separate sibling worktree.** Do not edit or commit in another person's or another task's `Parsek-<branch>/` worktree. Create a dedicated `../Parsek-<branch-name>` worktree from the right base, work there, and push that branch. Reuse an existing worktree only when it is mine and already dedicated to the same line of work.
 
 For manual worktrees (when not using `isolation=worktree`), create as sibling folders:
 ```bash
@@ -228,6 +228,14 @@ Before every commit that changes behavior (not just the first one in a PR), chec
 **Follow-up commit trap:** When a review comment lands on an open PR and changes the fix approach, the CHANGELOG and todo entries written for the first commit become stale. The reviewer reads those docs as authoritative — they must match the code in the current HEAD. Before pushing the follow-up commit, re-read the existing doc entries for the bug/feature and update them to match the new approach.
 
 **Practical check:** after `git add`, run `git diff --cached` and ask: "does any of this contradict or supersede existing wording in CHANGELOG.md or todo-and-known-bugs.md?" If yes, stage the doc updates in the same commit.
+
+## Code Review Follow-Ups
+
+Do one full review at the end of a task/worktree before creating or finalizing the PR, except for low-risk small single-file fixes, docs-only changes, test-only changes, and obvious bug fixes with focused validation; for those, self-review and report validation.
+
+When a reviewer flags fixes on an open PR, re-review only the follow-up changes and any directly affected code paths. Do not restart a full-PR review from scratch on every follow-up unless the new changes actually broaden the risk surface.
+
+Do not re-review excessively. Re-review is for risky code changes: shared behavior, serialization/schema, runtime-only paths, broad refactors, concurrency/lifecycle changes, or fixes that change the PR's behavioral contract. Docs-only edits, small copy/typo fixes, test-only clarifications, and other low-risk follow-ups do not need another review pass; self-review them and report the validation performed.
 
 ## Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,7 +137,9 @@ Key source files and what they do - read the relevant one before modifying:
 
 ## Worktree Workflow
 
-**HARD RULE - new feature and bugfix work starts in your own separate sibling worktree.** Do not make feature/bugfix commits in the main `Parsek/` checkout, and do not edit or commit in another person's or another task's `Parsek-<branch>/` worktree unless the user specifically asks you to work in that exact worktree. Create a dedicated `../Parsek-<branch-name>` worktree from the right base, work there, and push that branch. Reuse an existing worktree only when it is yours and already dedicated to the same line of work.
+**HARD RULE - never edit or commit inside `Parsek/` (the main checkout) without explicit per-session approval.** This applies to every change that will produce a commit — code, tests, doc tweaks, anything.
+
+**HARD RULE - every change that will produce a commit starts in your own dedicated sibling worktree.** Do not edit or commit in another task's `Parsek-<branch>/` worktree unless the user specifically asks you to work in that exact worktree. Create a dedicated `../Parsek-<branch-name>` worktree from the right base, work there, and push that branch. Reuse a worktree only when it is yours and already dedicated to the same line of work — within one line of work, keep editing, committing, and pushing inside the same worktree. Spinning up a fresh worktree per change is unnecessary ceremony.
 
 For manual worktrees (when not using `isolation=worktree`), create as sibling folders:
 ```bash
@@ -221,7 +223,7 @@ Do one full review at the end of a task/worktree before creating or finalizing t
 
 When a reviewer flags fixes on an open PR, re-review only the follow-up changes and any directly affected code paths. Do not restart a full-PR review from scratch on every follow-up unless the new changes actually broaden the risk surface.
 
-Do not re-review excessively. Re-review is for risky code changes: shared behavior, serialization/schema, runtime-only paths, broad refactors, concurrency/lifecycle changes, or fixes that change the PR's behavioral contract. Docs-only edits, small copy/typo fixes, test-only clarifications, and other low-risk follow-ups do not need another review pass; self-review them and report the validation performed.
+Do not re-review excessively. Re-review is for risky code changes: shared behavior, serialization/schema, runtime-only paths, broad refactors, concurrency/lifecycle changes, or fixes that change the PR's behavioral contract. Docs-only edits, small copy/typo fixes, and test-only clarifications do not need another review pass; self-review them and report the validation performed.
 
 ## Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,11 +137,15 @@ Key source files and what they do - read the relevant one before modifying:
 
 ## Worktree Workflow
 
+**HARD RULE - new feature and bugfix work starts in your own separate sibling worktree.** Do not make feature/bugfix commits in the main `Parsek/` checkout, and do not edit or commit in another person's or another task's `Parsek-<branch>/` worktree. Create a dedicated `../Parsek-<branch-name>` worktree from the right base, work there, and push that branch. Reuse an existing worktree only when it is yours and already dedicated to the same line of work.
+
 For manual worktrees (when not using `isolation=worktree`), create as sibling folders:
 ```bash
 cd Parsek
-git worktree add ../Parsek-<branch-name> -b <branch-name> HEAD
+git worktree add ../Parsek-<branch-name> -b <branch-name> <target>
 ```
+
+Pick `<target>` carefully: for new work from main, use `origin/main` because local `main` may include in-progress work; for follow-ups to a feature branch, use the branch tip that actually contains the work being fixed.
 
 `Parsek.csproj` probes up to 5 parent levels for `Kerbal Space Program/`, so builds work from worktrees at this location. Merge: `cd Parsek && git merge <branch-name>`
 
@@ -216,6 +220,8 @@ Before every commit that changes behavior (not just the first one in a PR), chec
 Do one full review at the end of a task/worktree before creating or finalizing the PR, except for low-risk small single-file fixes, docs-only changes, test-only changes, and obvious bug fixes with focused validation; for those, self-review and report validation.
 
 When a reviewer flags fixes on an open PR, re-review only the follow-up changes and any directly affected code paths. Do not restart a full-PR review from scratch on every follow-up unless the new changes actually broaden the risk surface.
+
+Do not re-review excessively. Re-review is for risky code changes: shared behavior, serialization/schema, runtime-only paths, broad refactors, concurrency/lifecycle changes, or fixes that change the PR's behavioral contract. Docs-only edits, small copy/typo fixes, test-only clarifications, and other low-risk follow-ups do not need another review pass; self-review them and report the validation performed.
 
 ## Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,7 +137,7 @@ Key source files and what they do - read the relevant one before modifying:
 
 ## Worktree Workflow
 
-**HARD RULE - new feature and bugfix work starts in your own separate sibling worktree.** Do not make feature/bugfix commits in the main `Parsek/` checkout, and do not edit or commit in another person's or another task's `Parsek-<branch>/` worktree. Create a dedicated `../Parsek-<branch-name>` worktree from the right base, work there, and push that branch. Reuse an existing worktree only when it is yours and already dedicated to the same line of work.
+**HARD RULE - new feature and bugfix work starts in your own separate sibling worktree.** Do not make feature/bugfix commits in the main `Parsek/` checkout, and do not edit or commit in another person's or another task's `Parsek-<branch>/` worktree unless the user specifically asks you to work in that exact worktree. Create a dedicated `../Parsek-<branch-name>` worktree from the right base, work there, and push that branch. Reuse an existing worktree only when it is yours and already dedicated to the same line of work.
 
 For manual worktrees (when not using `isolation=worktree`), create as sibling folders:
 ```bash


### PR DESCRIPTION
Summary:
- Emphasize that new feature and bugfix work must use a dedicated sibling worktree, not the main checkout or another task's worktree, unless the user explicitly asks for that exact worktree.
- Clarify that follow-up re-review is only needed for risky code changes; docs-only and small low-risk updates get self-review plus validation.
- Keep .claude/CLAUDE.md aligned with the workflow guidance.

Validation:
- git diff --check