### PR TITLE
Fix in-game test stale dialog title assertions

### DIFF
--- a/Source/Parsek/InGameTests/RuntimeTests.cs
+++ b/Source/Parsek/InGameTests/RuntimeTests.cs
@@ -2367,7 +2367,7 @@ namespace Parsek.InGameTests
                 InGameAssert.IsNotNull(dialog, "Popup should expose a MultiOptionDialog");
 
                 string dialogTitle = MultiOptionDialogTitleField.GetValue(dialog) as string;
-                InGameAssert.AreEqual("Parsek - Merge to Timeline", dialogTitle,
+                InGameAssert.AreEqual("Confirm Merge to Timeline", dialogTitle,
                     "Merge dialog title should match the production popup");
 
                 DialogGUIButton[] buttons = GetDialogButtons(dialog);
@@ -2459,7 +2459,7 @@ namespace Parsek.InGameTests
                 InGameAssert.IsNotNull(dialog, "Popup should expose a MultiOptionDialog");
 
                 string dialogTitle = MultiOptionDialogTitleField.GetValue(dialog) as string;
-                InGameAssert.AreEqual("Parsek - Merge to Timeline", dialogTitle,
+                InGameAssert.AreEqual("Confirm Merge to Timeline", dialogTitle,
                     "Deferred merge dialog title should match the production popup");
 
                 DialogGUIButton[] buttons = GetDialogButtons(dialog);
@@ -8988,7 +8988,7 @@ namespace Parsek.InGameTests
                 InGameAssert.IsNotNull(dialog, "Popup should expose a MultiOptionDialog");
 
                 string dialogTitle = MultiOptionDialogTitleField.GetValue(dialog) as string;
-                InGameAssert.AreEqual("Parsek - Merge to Timeline", dialogTitle,
+                InGameAssert.AreEqual("Confirm Merge to Timeline", dialogTitle,
                     "Deferred merge dialog title should match the production popup");
 
                 DialogGUIButton[] buttons = GetDialogButtons(dialog);
@@ -9172,7 +9172,7 @@ namespace Parsek.InGameTests
                 InGameAssert.IsNotNull(dialog, "Popup should expose a MultiOptionDialog");
 
                 string dialogTitle = MultiOptionDialogTitleField.GetValue(dialog) as string;
-                InGameAssert.AreEqual("Parsek - Merge to Timeline", dialogTitle,
+                InGameAssert.AreEqual("Confirm Merge to Timeline", dialogTitle,
                     "Deferred merge dialog title should match the production popup");
 
                 DialogGUIButton[] buttons = GetDialogButtons(dialog);

--- a/Source/Parsek/InGameTests/UnfinishedFlightSealDialogTest.cs
+++ b/Source/Parsek/InGameTests/UnfinishedFlightSealDialogTest.cs
@@ -122,7 +122,7 @@ namespace Parsek.InGameTests
                 MultiOptionDialog dialog = PopupDialogToDisplayField.GetValue(popup) as MultiOptionDialog;
                 InGameAssert.IsNotNull(dialog, "Seal popup should expose a MultiOptionDialog");
                 string title = MultiOptionDialogTitleField.GetValue(dialog) as string;
-                InGameAssert.AreEqual("Seal Unfinished Flight?", title,
+                InGameAssert.AreEqual("Confirm Seal Unfinished Flight", title,
                     "Seal popup title should match production copy");
 
                 DialogGUIButton button = FindButton(dialog, buttonText);


### PR DESCRIPTION
## Summary

- Two `UnfinishedFlightSealDialogTest` methods were failing in-game with `Seal popup title should match production copy` because commit 797bb8f8 renamed the dialog title from `Seal Unfinished Flight?` to `Confirm Seal Unfinished Flight` in [UnfinishedFlightSealHandler.cs](Source/Parsek/UnfinishedFlightSealHandler.cs:175) but missed the test assertion at [UnfinishedFlightSealDialogTest.cs:125](Source/Parsek/InGameTests/UnfinishedFlightSealDialogTest.cs:125). The seal logic itself is fine — the test fails before exercising confirm/cancel.
- Audit of the same commit's other renames found 4 more stale assertions in `RuntimeTests.cs` (lines 2370, 2462, 8991, 9175) all expecting the old `Parsek - Merge to Timeline` against the current `Confirm Merge to Timeline` in [MergeDialog.cs:176](Source/Parsek/MergeDialog.cs:176). These would have failed any time the merge-dialog in-game tests were run.
- The other renamed strings from 797bb8f8 (`Parsek - Finish Flight`, `Parsek - Action Blocked`, `CANNOT BE UNDONE`, `cannot be undone!`) had no remaining references in `InGameTests/` or `Tests/`. Stale references in design docs and CHANGELOG history are out of scope.

## Test plan

- [x] `dotnet test` — 10269 passed, 0 failed, 0 skipped (~13s)
- [x] `dotnet build` — clean (0 warnings, 0 errors); DLL deployed
- [ ] In-game verification: run Ctrl+Shift+T at KSC and confirm both `UnfinishedFlightSealDialogTest` methods plus the four `RuntimeTests.cs` merge-dialog tests now pass