### PR TITLE
Fix part PID save-load readiness canary

### DIFF
--- a/Source/Parsek.Tests/QuickloadResumeHelperReadinessTests.cs
+++ b/Source/Parsek.Tests/QuickloadResumeHelperReadinessTests.cs
@@ -39,6 +39,39 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void IsReloadedFlightReady_RequiresFlightScene()
+        {
+            Assert.False(QuickloadResumeHelpers.IsReloadedFlightReady(
+                GameScenes.SPACECENTER,
+                flightGlobalsReady: true,
+                activeVesselPresent: true,
+                currentFlightInstanceId: 42,
+                previousFlightInstanceId: 0));
+        }
+
+        [Fact]
+        public void IsReloadedFlightReady_RequiresFlightGlobalsReady()
+        {
+            Assert.False(QuickloadResumeHelpers.IsReloadedFlightReady(
+                GameScenes.FLIGHT,
+                flightGlobalsReady: false,
+                activeVesselPresent: true,
+                currentFlightInstanceId: 42,
+                previousFlightInstanceId: 0));
+        }
+
+        [Fact]
+        public void IsReloadedFlightReady_RequiresCurrentFlightInstance()
+        {
+            Assert.False(QuickloadResumeHelpers.IsReloadedFlightReady(
+                GameScenes.FLIGHT,
+                flightGlobalsReady: true,
+                activeVesselPresent: true,
+                currentFlightInstanceId: 0,
+                previousFlightInstanceId: 0));
+        }
+
+        [Fact]
         public void PartPersistentIdStability_UsesStockQuickloadBackend()
         {
             string path = LocateParsekSourceFile(
@@ -48,8 +81,6 @@ namespace Parsek.Tests
 
             string src = File.ReadAllText(path);
 
-            Assert.Contains("TriggerQuicksave(testSaveName)", src);
-            Assert.Contains("TriggerQuickload(testSaveName)", src);
             Assert.DoesNotContain("HighLogic.CurrentGame = loaded", src);
             Assert.DoesNotContain("HighLogic.LoadScene(GameScenes.FLIGHT)", src);
         }
@@ -57,21 +88,20 @@ namespace Parsek.Tests
         private static string LocateParsekSourceFile(params string[] segments)
         {
             string dir = AppDomain.CurrentDomain.BaseDirectory;
+            string lastCandidate = null;
             while (!string.IsNullOrEmpty(dir))
             {
                 string candidate = Path.Combine(dir, "Source", "Parsek");
                 foreach (string segment in segments)
                     candidate = Path.Combine(candidate, segment);
+                lastCandidate = candidate;
                 if (File.Exists(candidate))
                     return candidate;
 
                 dir = Directory.GetParent(dir)?.FullName;
             }
 
-            return Path.Combine(
-                AppDomain.CurrentDomain.BaseDirectory,
-                "..", "..", "..", "..", "Parsek",
-                Path.Combine(segments));
+            return lastCandidate ?? string.Empty;
         }
     }
 }

--- a/Source/Parsek.Tests/QuickloadResumeHelperReadinessTests.cs
+++ b/Source/Parsek.Tests/QuickloadResumeHelperReadinessTests.cs
@@ -1,0 +1,77 @@
+using System;
+using System.IO;
+using Parsek.InGameTests.Helpers;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    public class QuickloadResumeHelperReadinessTests
+    {
+        [Fact]
+        public void IsReloadedFlightReady_NegativeUnityIdsStillRequireDifferentInstance()
+        {
+            const int previousFlightInstanceId = -1087176;
+
+            Assert.False(QuickloadResumeHelpers.IsReloadedFlightReady(
+                GameScenes.FLIGHT,
+                flightGlobalsReady: true,
+                activeVesselPresent: true,
+                currentFlightInstanceId: previousFlightInstanceId,
+                previousFlightInstanceId: previousFlightInstanceId));
+
+            Assert.True(QuickloadResumeHelpers.IsReloadedFlightReady(
+                GameScenes.FLIGHT,
+                flightGlobalsReady: true,
+                activeVesselPresent: true,
+                currentFlightInstanceId: -1123806,
+                previousFlightInstanceId: previousFlightInstanceId));
+        }
+
+        [Fact]
+        public void IsReloadedFlightReady_RequiresActiveVessel()
+        {
+            Assert.False(QuickloadResumeHelpers.IsReloadedFlightReady(
+                GameScenes.FLIGHT,
+                flightGlobalsReady: true,
+                activeVesselPresent: false,
+                currentFlightInstanceId: 42,
+                previousFlightInstanceId: 0));
+        }
+
+        [Fact]
+        public void PartPersistentIdStability_UsesStockQuickloadBackend()
+        {
+            string path = LocateParsekSourceFile(
+                "InGameTests",
+                "PartPersistentIdStabilityTest.cs");
+            Assert.True(File.Exists(path), $"Could not locate source file at {path}");
+
+            string src = File.ReadAllText(path);
+
+            Assert.Contains("TriggerQuicksave(testSaveName)", src);
+            Assert.Contains("TriggerQuickload(testSaveName)", src);
+            Assert.DoesNotContain("HighLogic.CurrentGame = loaded", src);
+            Assert.DoesNotContain("HighLogic.LoadScene(GameScenes.FLIGHT)", src);
+        }
+
+        private static string LocateParsekSourceFile(params string[] segments)
+        {
+            string dir = AppDomain.CurrentDomain.BaseDirectory;
+            while (!string.IsNullOrEmpty(dir))
+            {
+                string candidate = Path.Combine(dir, "Source", "Parsek");
+                foreach (string segment in segments)
+                    candidate = Path.Combine(candidate, segment);
+                if (File.Exists(candidate))
+                    return candidate;
+
+                dir = Directory.GetParent(dir)?.FullName;
+            }
+
+            return Path.Combine(
+                AppDomain.CurrentDomain.BaseDirectory,
+                "..", "..", "..", "..", "Parsek",
+                Path.Combine(segments));
+        }
+    }
+}

--- a/Source/Parsek/InGameTests/Helpers/QuickloadResumeHelpers.cs
+++ b/Source/Parsek/InGameTests/Helpers/QuickloadResumeHelpers.cs
@@ -138,8 +138,9 @@ namespace Parsek.InGameTests.Helpers
         }
 
         /// <summary>
-        /// Waits until FlightGlobals.ready is true and HighLogic.LoadedScene matches
-        /// the target scene, or until timeout.
+        /// Waits until the reloaded FLIGHT scene has a new ParsekFlight instance,
+        /// FlightGlobals.ready is true, and an active vessel is present, or until
+        /// timeout. Pass 0 when there is no previous ParsekFlight instance.
         /// </summary>
         internal static IEnumerator WaitForFlightReady(int previousFlightInstanceId, float timeoutSeconds = 10f)
         {
@@ -147,12 +148,13 @@ namespace Parsek.InGameTests.Helpers
             while (Time.time < deadline)
             {
                 var flight = ParsekFlight.Instance;
-                bool replacedFlight = flight != null
-                    && (previousFlightInstanceId <= 0
-                        || flight.GetInstanceID() != previousFlightInstanceId);
-                if (HighLogic.LoadedScene == GameScenes.FLIGHT
-                    && FlightGlobals.ready
-                    && replacedFlight)
+                int currentFlightInstanceId = flight != null ? flight.GetInstanceID() : 0;
+                if (IsReloadedFlightReady(
+                    HighLogic.LoadedScene,
+                    FlightGlobals.ready,
+                    FlightGlobals.ActiveVessel != null,
+                    currentFlightInstanceId,
+                    previousFlightInstanceId))
                     yield break;
                 yield return null;
             }
@@ -165,6 +167,22 @@ namespace Parsek.InGameTests.Helpers
                 $"(scene={HighLogic.LoadedScene}, flightReady={FlightGlobals.ready}, activeVessel={activeVesselName}, " +
                 $"parsekFlight={(timedOutFlight != null ? timedOutFlight.GetInstanceID().ToString() : "null")}, " +
                 $"expectedDifferentFrom={previousFlightInstanceId})");
+        }
+
+        internal static bool IsReloadedFlightReady(
+            GameScenes loadedScene,
+            bool flightGlobalsReady,
+            bool activeVesselPresent,
+            int currentFlightInstanceId,
+            int previousFlightInstanceId)
+        {
+            bool replacedFlight = currentFlightInstanceId != 0
+                && (previousFlightInstanceId == 0
+                    || currentFlightInstanceId != previousFlightInstanceId);
+            return loadedScene == GameScenes.FLIGHT
+                && flightGlobalsReady
+                && activeVesselPresent
+                && replacedFlight;
         }
 
         /// <summary>

--- a/Source/Parsek/InGameTests/Helpers/QuickloadResumeHelpers.cs
+++ b/Source/Parsek/InGameTests/Helpers/QuickloadResumeHelpers.cs
@@ -139,8 +139,9 @@ namespace Parsek.InGameTests.Helpers
 
         /// <summary>
         /// Waits until the reloaded FLIGHT scene has a new ParsekFlight instance,
-        /// FlightGlobals.ready is true, and an active vessel is present, or until
-        /// timeout. Pass 0 when there is no previous ParsekFlight instance.
+        /// FlightGlobals.ready is true, and FlightGlobals.ActiveVessel is
+        /// non-null, or until timeout. Pass 0 when there is no previous
+        /// ParsekFlight instance.
         /// </summary>
         internal static IEnumerator WaitForFlightReady(int previousFlightInstanceId, float timeoutSeconds = 10f)
         {
@@ -176,6 +177,8 @@ namespace Parsek.InGameTests.Helpers
             int currentFlightInstanceId,
             int previousFlightInstanceId)
         {
+            // Unity GetInstanceID() uses non-zero values for valid objects; 0 is
+            // the local sentinel for "no ParsekFlight instance".
             bool replacedFlight = currentFlightInstanceId != 0
                 && (previousFlightInstanceId == 0
                     || currentFlightInstanceId != previousFlightInstanceId);

--- a/Source/Parsek/InGameTests/PartPersistentIdStabilityTest.cs
+++ b/Source/Parsek/InGameTests/PartPersistentIdStabilityTest.cs
@@ -58,62 +58,60 @@ namespace Parsek.InGameTests
 
             int preFlightInstanceId = ParsekFlight.Instance != null
                 ? ParsekFlight.Instance.GetInstanceID()
-                : -1;
+                : 0;
 
             const string testSaveName = "Parsek_PartIdStabilityTest";
 
-            string saveResult = GamePersistence.SaveGame(
-                testSaveName, HighLogic.SaveFolder, SaveMode.OVERWRITE);
-            InGameAssert.IsTrue(!string.IsNullOrEmpty(saveResult),
-                $"SaveGame('{testSaveName}') returned empty result");
-
-            yield return null;
-
-            Game loaded = GamePersistence.LoadGame(
-                testSaveName, HighLogic.SaveFolder, true, false);
-            InGameAssert.IsNotNull(loaded,
-                $"LoadGame('{testSaveName}') returned null");
-
-            HighLogic.CurrentGame = loaded;
-            HighLogic.LoadScene(GameScenes.FLIGHT);
-
-            yield return Helpers.QuickloadResumeHelpers.WaitForFlightReady(
-                preFlightInstanceId, 30f);
-
-            var postVessel = FlightGlobals.ActiveVessel;
-            InGameAssert.IsNotNull(postVessel, "Active vessel missing after reload");
-            InGameAssert.IsTrue(postVessel.parts != null && postVessel.parts.Count > 0,
-                "Active vessel has no parts after reload");
-
-            var postPids = new HashSet<uint>();
-            for (int i = 0; i < postVessel.parts.Count; i++)
+            try
             {
-                var part = postVessel.parts[i];
-                if (part == null) continue;
-                postPids.Add(part.persistentId);
+                ParsekLog.Info("Rewind",
+                    $"PartPersistentIdStability: saving '{testSaveName}' before stock quickload round-trip");
+                Helpers.QuickloadResumeHelpers.TriggerQuicksave(testSaveName);
+                yield return new WaitForSeconds(0.5f);
+
+                Helpers.QuickloadResumeHelpers.TriggerQuickload(testSaveName);
+                yield return Helpers.QuickloadResumeHelpers.WaitForFlightReady(
+                    preFlightInstanceId, 30f);
+
+                var postVessel = FlightGlobals.ActiveVessel;
+                InGameAssert.IsNotNull(postVessel, "Active vessel missing after reload");
+                InGameAssert.IsTrue(postVessel.parts != null && postVessel.parts.Count > 0,
+                    "Active vessel has no parts after reload");
+
+                var postPids = new HashSet<uint>();
+                for (int i = 0; i < postVessel.parts.Count; i++)
+                {
+                    var part = postVessel.parts[i];
+                    if (part == null) continue;
+                    postPids.Add(part.persistentId);
+                }
+
+                bool match = prePids.SetEquals(postPids);
+                ParsekLog.Info("Rewind",
+                    $"PartPersistentIdStability: prePids={prePids.Count} postPids={postPids.Count} " +
+                    $"match={match}");
+
+                if (!match)
+                {
+                    var missing = new HashSet<uint>(prePids);
+                    missing.ExceptWith(postPids);
+                    var added = new HashSet<uint>(postPids);
+                    added.ExceptWith(prePids);
+                    ParsekLog.Error("Rewind",
+                        "[CRITICAL] Part.persistentId unstable across save/load — " +
+                        $"pre={prePids.Count} post={postPids.Count} missing={missing.Count} " +
+                        $"added={added.Count}. RootPartPidMap fallback DESIGN INVALID — " +
+                        "escalate to design-doc amendment before continuing");
+                }
+
+                InGameAssert.IsTrue(match,
+                    $"Part.persistentId HashSet differs after save/load " +
+                    $"(pre={prePids.Count}, post={postPids.Count})");
             }
-
-            bool match = prePids.SetEquals(postPids);
-            ParsekLog.Info("Rewind",
-                $"PartPersistentIdStability: prePids={prePids.Count} postPids={postPids.Count} " +
-                $"match={match}");
-
-            if (!match)
+            finally
             {
-                var missing = new HashSet<uint>(prePids);
-                missing.ExceptWith(postPids);
-                var added = new HashSet<uint>(postPids);
-                added.ExceptWith(prePids);
-                ParsekLog.Error("Rewind",
-                    "[CRITICAL] Part.persistentId unstable across save/load — " +
-                    $"pre={prePids.Count} post={postPids.Count} missing={missing.Count} " +
-                    $"added={added.Count}. RootPartPidMap fallback DESIGN INVALID — " +
-                    "escalate to design-doc amendment before continuing");
+                Helpers.QuickloadResumeHelpers.TryDeleteSaveSlot(testSaveName);
             }
-
-            InGameAssert.IsTrue(match,
-                $"Part.persistentId HashSet differs after save/load " +
-                $"(pre={prePids.Count}, post={postPids.Count})");
         }
     }
 }


### PR DESCRIPTION
Summary: moves the part persistent-id in-game test onto the stock quickload helper and tightens flight-ready polling to require FLIGHT, FlightGlobals.ready, an active vessel, and a replaced non-zero ParsekFlight instance. Review follow-up: documented the 0 sentinel/Unity instance-id contract, audited callers for stale -1 sentinel usage, removed fragile positive source-string assertions, removed the guessed source-location fallback, and added predicate coverage for scene/ready/current-instance guards. Validation: QuickloadResumeHelperReadinessTests passed after follow-up; worker also passed full xUnit suite and mod build. Residual: single-run live KSP part-PID test still needs Ctrl+Shift+T rerun.