### PR TITLE
Widen timeline row action buttons

### DIFF
--- a/Source/Parsek.Tests/TimelineWindowUITests.cs
+++ b/Source/Parsek.Tests/TimelineWindowUITests.cs
@@ -13,7 +13,7 @@ namespace Parsek.Tests
             float loop = TimelineWindowUI.GetRowActionButtonWidth(TimelineWindowUI.TimelineRowActionButtonKind.Loop);
             float goTo = TimelineWindowUI.GetRowActionButtonWidth(TimelineWindowUI.TimelineRowActionButtonKind.GoTo);
 
-            Assert.Equal(35f, watch);
+            Assert.Equal(40f, watch);
             Assert.Equal(watch, fastForward);
             Assert.Equal(watch, rewind);
             Assert.Equal(watch, loop);

--- a/Source/Parsek/UI/TimelineWindowUI.cs
+++ b/Source/Parsek/UI/TimelineWindowUI.cs
@@ -54,7 +54,7 @@ namespace Parsek
         private const float MinWindowHeight = 150f;
         private const float ApproxRowHeight = 20f;
         // Keep the short row actions aligned; GoTo stays wider for its text label.
-        private const float RowActionButtonWidth = 35f;
+        private const float RowActionButtonWidth = 40f;
         private const float GoToButtonWidth = 48f;
 
         // Shared width for top filter/source/preset buttons: Overview, Details,


### PR DESCRIPTION
## Summary
- Widen Timeline row action buttons by 5 px so the Seal label fits.
- Update the focused width contract test.

## Tests
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter TimelineWindowUITests