### PR TITLE
Bump version to 0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to Parsek are documented here.
 
 ---
 
+## 0.9.2
+
+### Bug Fixes
+
+### Enhancements
+
+### Internals
+
+### Tests
+
+---
+
 ## 0.9.1
 
 ### Bug Fixes

--- a/GameData/Parsek/Parsek.version
+++ b/GameData/Parsek/Parsek.version
@@ -1,7 +1,7 @@
 {
     "NAME": "Parsek",
     "URL": "https://raw.githubusercontent.com/vl3c/Parsek/main/GameData/Parsek/Parsek.version",
-    "VERSION": { "MAJOR": 0, "MINOR": 9, "PATCH": 1 },
+    "VERSION": { "MAJOR": 0, "MINOR": 9, "PATCH": 2 },
     "KSP_VERSION": { "MAJOR": 1, "MINOR": 12, "PATCH": 5 },
     "KSP_VERSION_MIN": { "MAJOR": 1, "MINOR": 12, "PATCH": 0 },
     "KSP_VERSION_MAX": { "MAJOR": 1, "MINOR": 12, "PATCH": 99 }

--- a/Source/Parsek/Properties/AssemblyInfo.cs
+++ b/Source/Parsek/Properties/AssemblyInfo.cs
@@ -17,7 +17,7 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("a1b2c3d4-e5f6-7890-abcd-ef1234567890")]
 
-[assembly: AssemblyVersion("0.9.1.0")]
-[assembly: AssemblyFileVersion("0.9.1.0")]
+[assembly: AssemblyVersion("0.9.2.0")]
+[assembly: AssemblyFileVersion("0.9.2.0")]
 
 [assembly: KSPAssembly("Parsek", 0, 9)]


### PR DESCRIPTION
## Summary

- v0.9.1 has been released ([release notes](https://github.com/vl3c/Parsek/releases/tag/v0.9.1)).
- Bumps `Parsek.version` and `AssemblyInfo.cs` (`AssemblyVersion` + `AssemblyFileVersion`) from 0.9.1 to 0.9.2.
- Opens an empty `## 0.9.2` section in `CHANGELOG.md` with the standard `Bug Fixes / Enhancements / Internals / Tests` subsections so post-release commits have a place to land.

## Test plan

- [ ] `dotnet build Source/Parsek/Parsek.csproj -c Release` succeeds (version match check passes inside `release.py`)
- [ ] `dotnet test Source/Parsek.Tests/Parsek.Tests.csproj` passes