### PR TITLE
Auto-seal stable landed EVA side branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- Stable landed/splashed EVA side-branches created during tree commits now auto-seal their rewind slot instead of being promoted to an open Unfinished Flight. This prevents cases where a safe, landed EVA row exposed only Seal while Fly was globally blocked by the active Re-Fly session marker.
 - An orphaned chain predecessor (same vessel pid, contiguous boundary, missing `ChainId`) is grafted back as the chain's `[0]` entry on load and re-saved, restoring the seamless ghost handoff so the next stage no longer respawns engine FX/audio at the chain boundary.
 - Unowned science subjects from stock transmission and vessel recovery now enter the ledger immediately, so Parsek no longer patches the science pool back down before those rewards are committed.
 - Re-Fly temp quicksaves now force the selected real vessel's `CTRLSTATE/mainThrottle`, `CTRLSTATE/wheelThrottle`, and persisted engine-module throttle fields to `0` before KSP loads it, so the player never spawns into a Re-Fly attempt with recorded throttle input already open.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- Stable landed/splashed EVA side-branches created during tree commits now auto-seal their rewind slot instead of being promoted to an open Unfinished Flight. This prevents cases where a safe, landed EVA row exposed only Seal while Fly was globally blocked by the active Re-Fly session marker.
+- Timeline now shows Fly/Seal for every STASH-eligible recording, including active-parent breakup slots, so the Re-Fly filter matches the Recordings table.
+
 ### Enhancements
 
 ### Internals
@@ -20,7 +23,6 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
-- Stable landed/splashed EVA side-branches created during tree commits now auto-seal their rewind slot instead of being promoted to an open Unfinished Flight. This prevents cases where a safe, landed EVA row exposed only Seal while Fly was globally blocked by the active Re-Fly session marker.
 - An orphaned chain predecessor (same vessel pid, contiguous boundary, missing `ChainId`) is grafted back as the chain's `[0]` entry on load and re-saved, restoring the seamless ghost handoff so the next stage no longer respawns engine FX/audio at the chain boundary.
 - Unowned science subjects from stock transmission and vessel recovery now enter the ledger immediately, so Parsek no longer patches the science pool back down before those rewards are committed.
 - Re-Fly temp quicksaves now force the selected real vessel's `CTRLSTATE/mainThrottle`, `CTRLSTATE/wheelThrottle`, and persisted engine-module throttle fields to `0` before KSP loads it, so the player never spawns into a Re-Fly attempt with recorded throttle input already open.
@@ -46,7 +48,6 @@ All notable changes to Parsek are documented here.
 - Recording sidecar files are no longer wiped from disk when the scenario file lost its `RECORDING_TREE` metadata. `CleanOrphanFiles` now refuses to delete sidecars when the scenario reports zero known recording IDs but the disk still holds sidecar-shaped IDs, preserving recovery options when a save's metadata can be restored from `quicksave.sfs` or a backup. The save path also warns when about to write zero `RECORDING_TREE` nodes over a directory that still has stranded sidecars, surfacing the originating state-management bug.
 - Sealing an Unfinished Flight slot now persists immediately before destructive cleanup, and skips rewind-point file deletion if that save fails, so Rewind-to-Launch or quickload can no longer un-seal a slot whose quicksave file was already deleted. Load-time recovery also cleans persistent missing-file RPs while leaving active/session-provisional RPs untouched.
 - The Recordings table now has separate Rewind and Re-Fly columns with matching default window widths. Rewind/Forward stays in the Rewind column, while Fly/Seal and stable-row Stash/Seal live under Re-Fly, so stable leaves can now be stashed or sealed directly without hiding Rewind-to-Launch.
-- Timeline now shows Fly/Seal for every STASH-eligible recording, including active-parent breakup slots, so the Re-Fly filter matches the Recordings table.
 - STASH no longer allows manual Stash on `Recovered`, `Docked`, or `Boarded` recordings. Those outcomes imply career recovery, vessel merge/absorption, or crew transfer into another world object, so existing stashed slots with those terminals now close on the next membership/reaper pass instead of remaining re-flyable.
 - Re-Fly merges from STASH now auto-seal the chosen slot when the player reaches a stable terminal, because the merge concludes that Re-Fly attempt. Safety also closes the slot for `Recovered`/`Docked`/`Boarded`, downstream structural interaction, or a retry-blocking `ScienceEarning` recording-linked action. Destroyed vessels and non-boarded EVA kerbals remain re-flyable when their ledger effects are limited to automatic consequences (milestones, funds/rep earnings, contract complete/fail), KSC-scene player decisions, or the tombstoneable kerbal-death carve-out.
 - Auto-included STASH rows now use the same retry-blocking recording-action safety gate as manual Stash and merge finalization. A crashed vessel or stranded EVA that already credited science via Crew Report / EVA Report / Surface Sample / Transmit / Recover no longer remains re-flyable; automatic milestone/funds/rep/contract/kerbal consequence rows, KSC-scene player decisions, and bundled kerbal-death reputation penalties stay retryable.

--- a/Source/Parsek.Tests/TreeCommitTests.cs
+++ b/Source/Parsek.Tests/TreeCommitTests.cs
@@ -34,7 +34,8 @@ namespace Parsek.Tests
             TerminalState? terminalState = null,
             ConfigNode vesselSnapshot = null,
             string childBranchPointId = null,
-            string parentBranchPointId = null)
+            string parentBranchPointId = null,
+            string evaCrewName = null)
         {
             return new Recording
             {
@@ -45,7 +46,8 @@ namespace Parsek.Tests
                 TerminalStateValue = terminalState,
                 VesselSnapshot = vesselSnapshot,
                 ChildBranchPointId = childBranchPointId,
-                ParentBranchPointId = parentBranchPointId
+                ParentBranchPointId = parentBranchPointId,
+                EvaCrewName = evaCrewName
             };
         }
 
@@ -629,6 +631,68 @@ namespace Parsek.Tests
             Assert.Equal(MergeState.Immutable, tree.Recordings["child1"].MergeState);
             Assert.Equal(MergeState.CommittedProvisional, tree.Recordings["child2"].MergeState);
             Assert.False(rp.SessionProvisional);
+        }
+
+        [Fact]
+        public void CommitTree_LandedEvaChildUnderRewindPoint_AutoSealsInsteadOfPromoting()
+        {
+            bool priorSuppress = ParsekLog.SuppressLogging;
+            bool? priorVerboseOverride = ParsekLog.VerboseOverrideForTesting;
+            var logLines = new List<string>();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.VerboseOverrideForTesting = true;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+
+            try
+            {
+                var tree = MakeTreeWithBranch("stable_eva_tree");
+                tree.BranchPoints[0].Type = BranchPointType.EVA;
+                tree.BranchPoints[0].RewindPointId = "rp_stage";
+                tree.Recordings["child1"].TerminalStateValue = TerminalState.Landed;
+                tree.Recordings["child2"].TerminalStateValue = TerminalState.Landed;
+                tree.Recordings["child2"].VesselName = "Jebediah Kerman";
+                tree.Recordings["child2"].EvaCrewName = "Jebediah Kerman";
+
+                var rp = new RewindPoint
+                {
+                    RewindPointId = "rp_stage",
+                    BranchPointId = "bp1",
+                    SessionProvisional = true,
+                    CreatingSessionId = null,
+                    FocusSlotIndex = 0,
+                    ChildSlots = new List<ChildSlot>
+                    {
+                        Slot(0, "child1"),
+                        Slot(1, "child2"),
+                    }
+                };
+                var scenario = InstallScenarioWithRps(rp);
+                int versionBefore = scenario.SupersedeStateVersion;
+
+                RecordingStore.CommitTree(tree);
+
+                Assert.Equal(MergeState.Immutable, tree.Recordings["child1"].MergeState);
+                Assert.Equal(MergeState.Immutable, tree.Recordings["child2"].MergeState);
+                Assert.True(rp.ChildSlots[1].Sealed);
+                Assert.False(string.IsNullOrEmpty(rp.ChildSlots[1].SealedRealTime));
+                Assert.NotEqual(versionBefore, scenario.SupersedeStateVersion);
+                Assert.False(UnfinishedFlightClassifier.TryQualify(
+                    tree.Recordings["child2"], rp.ChildSlots[1], rp, true,
+                    out string sealedReason, tree));
+                Assert.Equal("slotSealed", sealedReason);
+                Assert.Contains(logLines, l =>
+                    l.Contains("[UnfinishedFlights]")
+                    && l.Contains("CommitTree auto-sealed stable EVA")
+                    && l.Contains("rec=child2")
+                    && l.Contains("terminal=Landed")
+                    && l.Contains("reason=strandedEva"));
+            }
+            finally
+            {
+                ParsekLog.ResetTestOverrides();
+                ParsekLog.SuppressLogging = priorSuppress;
+                ParsekLog.VerboseOverrideForTesting = priorVerboseOverride;
+            }
         }
 
         [Fact]

--- a/Source/Parsek.Tests/TreeCommitTests.cs
+++ b/Source/Parsek.Tests/TreeCommitTests.cs
@@ -636,6 +636,17 @@ namespace Parsek.Tests
         [Fact]
         public void CommitTree_LandedEvaChildUnderRewindPoint_AutoSealsInsteadOfPromoting()
         {
+            AssertStableSurfaceEvaChildAutoSeals(TerminalState.Landed);
+        }
+
+        [Fact]
+        public void CommitTree_SplashedEvaChildUnderRewindPoint_AutoSealsInsteadOfPromoting()
+        {
+            AssertStableSurfaceEvaChildAutoSeals(TerminalState.Splashed);
+        }
+
+        private void AssertStableSurfaceEvaChildAutoSeals(TerminalState terminal)
+        {
             bool priorSuppress = ParsekLog.SuppressLogging;
             bool? priorVerboseOverride = ParsekLog.VerboseOverrideForTesting;
             var logLines = new List<string>();
@@ -649,7 +660,7 @@ namespace Parsek.Tests
                 tree.BranchPoints[0].Type = BranchPointType.EVA;
                 tree.BranchPoints[0].RewindPointId = "rp_stage";
                 tree.Recordings["child1"].TerminalStateValue = TerminalState.Landed;
-                tree.Recordings["child2"].TerminalStateValue = TerminalState.Landed;
+                tree.Recordings["child2"].TerminalStateValue = terminal;
                 tree.Recordings["child2"].VesselName = "Jebediah Kerman";
                 tree.Recordings["child2"].EvaCrewName = "Jebediah Kerman";
 
@@ -684,7 +695,7 @@ namespace Parsek.Tests
                     l.Contains("[UnfinishedFlights]")
                     && l.Contains("CommitTree auto-sealed stable EVA")
                     && l.Contains("rec=child2")
-                    && l.Contains("terminal=Landed")
+                    && l.Contains($"terminal={terminal}")
                     && l.Contains("reason=strandedEva"));
             }
             finally
@@ -693,6 +704,39 @@ namespace Parsek.Tests
                 ParsekLog.SuppressLogging = priorSuppress;
                 ParsekLog.VerboseOverrideForTesting = priorVerboseOverride;
             }
+        }
+
+        [Fact]
+        public void CommitTree_OrbitingEvaChildUnderRewindPoint_StillPromotesToCommittedProvisional()
+        {
+            var tree = MakeTreeWithBranch("orbiting_eva_tree");
+            tree.BranchPoints[0].Type = BranchPointType.EVA;
+            tree.BranchPoints[0].RewindPointId = "rp_stage";
+            tree.Recordings["child1"].TerminalStateValue = TerminalState.Landed;
+            tree.Recordings["child2"].TerminalStateValue = TerminalState.Orbiting;
+            tree.Recordings["child2"].VesselName = "Jebediah Kerman";
+            tree.Recordings["child2"].EvaCrewName = "Jebediah Kerman";
+            var rp = new RewindPoint
+            {
+                RewindPointId = "rp_stage",
+                BranchPointId = "bp1",
+                SessionProvisional = true,
+                CreatingSessionId = null,
+                FocusSlotIndex = 0,
+                ChildSlots = new List<ChildSlot>
+                {
+                    Slot(0, "child1"),
+                    Slot(1, "child2"),
+                }
+            };
+            InstallScenarioWithRps(rp);
+
+            RecordingStore.CommitTree(tree);
+
+            Assert.Equal(MergeState.Immutable, tree.Recordings["child1"].MergeState);
+            Assert.Equal(MergeState.CommittedProvisional, tree.Recordings["child2"].MergeState);
+            Assert.False(rp.ChildSlots[1].Sealed);
+            Assert.True(string.IsNullOrEmpty(rp.ChildSlots[1].SealedRealTime));
         }
 
         [Fact]

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -732,9 +732,11 @@ namespace Parsek
         /// <summary>
         /// A child under a Rewind Point that qualifies as an unfinished flight
         /// is committed, but its rewind slot stays open until a later successful
-        /// re-fly or explicit Seal closes it. Legacy/default recordings are
-        /// born Immutable, so stamp that precise shape during the normal tree
-        /// commit path.
+        /// re-fly or explicit Seal closes it. Stable surface EVA side-branches
+        /// are the exception: when the only classifier reason is stranded EVA
+        /// and the terminal is safe, the commit closes the slot immediately.
+        /// Legacy/default recordings are born Immutable, so stamp that precise
+        /// shape during the normal tree commit path.
         /// </summary>
         private static void ApplyRewindProvisionalMergeStates(RecordingTree tree)
         {
@@ -744,6 +746,7 @@ namespace Parsek
                 return;
 
             int promoted = 0;
+            int autoSealed = 0;
             foreach (var rec in tree.Recordings.Values)
             {
                 if (rec == null) continue;
@@ -778,6 +781,13 @@ namespace Parsek
                     continue;
                 }
 
+                if (ShouldAutoSealStableEvaCommitSlot(rec, qualifyReason, tree))
+                {
+                    AutoSealStableEvaCommitSlot(rec, rp, slot, slotListIndex, tree, qualifyReason);
+                    autoSealed++;
+                    continue;
+                }
+
                 rec.MergeState = MergeState.CommittedProvisional;
                 rec.FilesDirty = true;
                 promoted++;
@@ -788,8 +798,55 @@ namespace Parsek
                     $"to CommittedProvisional");
             }
 
-            if (promoted > 0)
+            if (promoted > 0 || autoSealed > 0)
                 BumpStateVersion();
+        }
+
+        private static bool ShouldAutoSealStableEvaCommitSlot(
+            Recording rec,
+            string qualifyReason,
+            RecordingTree tree)
+        {
+            if (!string.Equals(qualifyReason, "strandedEva", StringComparison.Ordinal))
+                return false;
+
+            Recording tip = EffectiveState.ResolveChainTerminalRecording(rec, tree);
+            if (tip == null || string.IsNullOrEmpty(tip.EvaCrewName)
+                || !tip.TerminalStateValue.HasValue)
+                return false;
+
+            return tip.TerminalStateValue.Value == TerminalState.Landed
+                || tip.TerminalStateValue.Value == TerminalState.Splashed;
+        }
+
+        private static void AutoSealStableEvaCommitSlot(
+            Recording rec,
+            RewindPoint rp,
+            ChildSlot slot,
+            int slotListIndex,
+            RecordingTree tree,
+            string qualifyReason)
+        {
+            if (slot == null || slot.Sealed)
+                return;
+
+            Recording tip = EffectiveState.ResolveChainTerminalRecording(rec, tree);
+            string terminal = tip?.TerminalStateValue.HasValue == true
+                ? tip.TerminalStateValue.Value.ToString()
+                : "<none>";
+
+            slot.Sealed = true;
+            slot.SealedRealTime =
+                DateTime.UtcNow.ToString("o", CultureInfo.InvariantCulture);
+
+            var scenario = ParsekScenario.Instance;
+            if (!object.ReferenceEquals(null, scenario))
+                scenario.BumpSupersedeStateVersion();
+
+            ParsekLog.Info("UnfinishedFlights",
+                $"CommitTree auto-sealed stable EVA slot={slotListIndex} " +
+                $"rec={rec?.RecordingId ?? "<no-id>"} vessel='{rec?.VesselName ?? "<unnamed>"}' " +
+                $"rp={rp?.RewindPointId ?? "<no-rp>"} terminal={terminal} reason={qualifyReason}");
         }
 
         private static BranchPoint FindBranchPointById(RecordingTree tree, string branchPointId)

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -783,9 +783,11 @@ namespace Parsek
 
                 if (ShouldAutoSealStableEvaCommitSlot(rec, qualifyReason, tree))
                 {
-                    AutoSealStableEvaCommitSlot(rec, rp, slot, slotListIndex, tree, qualifyReason);
-                    autoSealed++;
-                    continue;
+                    if (AutoSealStableEvaCommitSlot(rec, rp, slot, slotListIndex, tree, qualifyReason))
+                    {
+                        autoSealed++;
+                        continue;
+                    }
                 }
 
                 rec.MergeState = MergeState.CommittedProvisional;
@@ -819,7 +821,7 @@ namespace Parsek
                 || tip.TerminalStateValue.Value == TerminalState.Splashed;
         }
 
-        private static void AutoSealStableEvaCommitSlot(
+        private static bool AutoSealStableEvaCommitSlot(
             Recording rec,
             RewindPoint rp,
             ChildSlot slot,
@@ -828,7 +830,7 @@ namespace Parsek
             string qualifyReason)
         {
             if (slot == null || slot.Sealed)
-                return;
+                return false;
 
             Recording tip = EffectiveState.ResolveChainTerminalRecording(rec, tree);
             string terminal = tip?.TerminalStateValue.HasValue == true
@@ -839,6 +841,8 @@ namespace Parsek
             slot.SealedRealTime =
                 DateTime.UtcNow.ToString("o", CultureInfo.InvariantCulture);
 
+            // CommitTree is already inside the merge/save lifecycle. Unlike the
+            // manual Seal button, do not force a persistent save or RP reap here.
             var scenario = ParsekScenario.Instance;
             if (!object.ReferenceEquals(null, scenario))
                 scenario.BumpSupersedeStateVersion();
@@ -847,6 +851,7 @@ namespace Parsek
                 $"CommitTree auto-sealed stable EVA slot={slotListIndex} " +
                 $"rec={rec?.RecordingId ?? "<no-id>"} vessel='{rec?.VesselName ?? "<unnamed>"}' " +
                 $"rp={rp?.RewindPointId ?? "<no-rp>"} terminal={terminal} reason={qualifyReason}");
+            return true;
         }
 
         private static BranchPoint FindBranchPointById(RecordingTree tree, string branchPointId)

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -23,6 +23,18 @@ When referencing prior item numbers from source comments or plans, consult the r
 
 ---
 
+## Done - v0.9.1 stable landed EVA side-branch auto-seal
+
+- ~~A Jebediah EVA side-branch that ended safely landed could still be promoted to an open Unfinished Flight as `strandedEva`, leaving Fly disabled by the active Re-Fly marker while Seal remained available.~~ Source: `logs/2026-05-04_1817`. The recording `b1c726b9a36b4c3082ff41d532f1289c` finalized as `TerminalState=Landed`, with `type=EVA`, `sit=LANDED`, and `landed=True` in its vessel sidecar. `RecordingStore.CommitTree` then classified it as `strandedEva` and promoted it to `CommittedProvisional`; the re-fly auto-seal helper never ran because this was a tree-commit side branch, not the active supersede provisional.
+
+**Fix:** `RecordingStore.ApplyRewindProvisionalMergeStates` now treats `strandedEva` as an auto-seal close when the effective terminal recording is an EVA with a safe surface terminal (`Landed` or `Splashed`). The slot receives `Sealed=true` plus `sealedRealTime`, the supersede state version is bumped, and the recording remains `Immutable` instead of becoming `CommittedProvisional`. The legacy classifier still reports normal loaded landed EVAs as stranded unless the commit-time auto-seal has stamped the slot.
+
+**Coverage:** `TreeCommitTests.CommitTree_LandedEvaChildUnderRewindPoint_AutoSealsInsteadOfPromoting`, plus existing `UnfinishedFlightsMembershipTests.StrandedEvaLegacyNoFocusSignal_IsMember`.
+
+**Status:** CLOSED 2026-05-04.
+
+---
+
 ## Done - v0.9.1 pending-tree cleanup view for Re-Fly restore
 
 - ~~After Rewind + Watch, re-entering a spawned Re-Fly vessel could leave the Recordings window showing zero rows until the deferred merge dialog restored the mission tree, and that pending-tree window could also drop supersede rows and auto-generated group hierarchy.~~ Source: `logs/2026-05-03_0059_newest`. Runtime trace: `TryTakeCommittedTreeForSpawnedVesselRestore` detached the 13-recording `Kerbal X` tree from `CommittedTrees` / `CommittedRecordings` so the active vessel could own it again, then `OnSave` wrote `0 committed recordings` plus an `ACTIVE` tree. On the following KSC load, `TryRestoreActiveTreeNode` kept the in-memory finalized pending tree and skipped `.sfs` replacement, but `LoadTimeSweep.SweepOrphanSupersedes` still checked only committed recordings and removed a valid supersede relation as fully orphaned. The group hierarchy prune had the same committed-only view, so it could treat pending-tree-only mission/debris groups as stale.

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -23,13 +23,13 @@ When referencing prior item numbers from source comments or plans, consult the r
 
 ---
 
-## Done - v0.9.1 stable landed EVA side-branch auto-seal
+## Done - v0.9.2 stable landed EVA side-branch auto-seal
 
 - ~~A Jebediah EVA side-branch that ended safely landed could still be promoted to an open Unfinished Flight as `strandedEva`, leaving Fly disabled by the active Re-Fly marker while Seal remained available.~~ Source: `logs/2026-05-04_1817`. The recording `b1c726b9a36b4c3082ff41d532f1289c` finalized as `TerminalState=Landed`, with `type=EVA`, `sit=LANDED`, and `landed=True` in its vessel sidecar. `RecordingStore.CommitTree` then classified it as `strandedEva` and promoted it to `CommittedProvisional`; the re-fly auto-seal helper never ran because this was a tree-commit side branch, not the active supersede provisional.
 
 **Fix:** `RecordingStore.ApplyRewindProvisionalMergeStates` now treats `strandedEva` as an auto-seal close when the effective terminal recording is an EVA with a safe surface terminal (`Landed` or `Splashed`). The slot receives `Sealed=true` plus `sealedRealTime`, the supersede state version is bumped, and the recording remains `Immutable` instead of becoming `CommittedProvisional`. The legacy classifier still reports normal loaded landed EVAs as stranded unless the commit-time auto-seal has stamped the slot.
 
-**Coverage:** `TreeCommitTests.CommitTree_LandedEvaChildUnderRewindPoint_AutoSealsInsteadOfPromoting`, plus existing `UnfinishedFlightsMembershipTests.StrandedEvaLegacyNoFocusSignal_IsMember`.
+**Coverage:** `TreeCommitTests.CommitTree_LandedEvaChildUnderRewindPoint_AutoSealsInsteadOfPromoting`, `TreeCommitTests.CommitTree_SplashedEvaChildUnderRewindPoint_AutoSealsInsteadOfPromoting`, `TreeCommitTests.CommitTree_OrbitingEvaChildUnderRewindPoint_StillPromotesToCommittedProvisional`, plus existing `UnfinishedFlightsMembershipTests.StrandedEvaLegacyNoFocusSignal_IsMember`.
 
 **Status:** CLOSED 2026-05-04.
 


### PR DESCRIPTION
Summary
- Auto-seal safe landed/splashed EVA side-branch slots during CommitTree instead of promoting them to open Unfinished Flights.
- Keep legacy stranded EVA classifier behavior for already-open slots.
- Document the 2026-05-04 log-package regression and add tree-commit coverage.

Tests
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter 'FullyQualifiedName~TreeCommitTests|FullyQualifiedName~UnfinishedFlightsMembershipTests|FullyQualifiedName~UnfinishedFlightClassifierTests'
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter 'FullyQualifiedName!~InjectAllRecordings'
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter 'FullyQualifiedName~TreeCommitTests'

Note: full unfiltered dotnet test was blocked by the KSP safety guard because KSP.log was locked by another process; I did not close or restart KSP.