### PR TITLE
Fix rewind crew reservation cutoff projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- Rewind and time-jump cutoff recalculations now rebuild crew reservations from the full committed timeline while keeping funds/science/tech at the cutoff UT, so crew from unrecovered future recordings no longer reappear in the VAB/SPH crew picker after rewinding.
 - An orphaned chain predecessor (same vessel pid, contiguous boundary, missing `ChainId`) is grafted back as the chain's `[0]` entry on load and re-saved, restoring the seamless ghost handoff so the next stage no longer respawns engine FX/audio at the chain boundary.
 - Unowned science subjects from stock transmission and vessel recovery now enter the ledger immediately, so Parsek no longer patches the science pool back down before those rewards are committed.
 - Re-Fly temp quicksaves now force the selected real vessel's `CTRLSTATE/mainThrottle`, `CTRLSTATE/wheelThrottle`, and persisted engine-module throttle fields to `0` before KSP loads it, so the player never spawns into a Re-Fly attempt with recorded throttle input already open.

--- a/Source/Parsek.Tests/LedgerOrchestratorTests.cs
+++ b/Source/Parsek.Tests/LedgerOrchestratorTests.cs
@@ -357,6 +357,8 @@ namespace Parsek.Tests
                 && l.Contains("SceneLoadTree"));
             Assert.DoesNotContain(logLines, l =>
                 l.Contains("[KspStatePatcher]") && l.Contains("PatchAll complete"));
+            Assert.DoesNotContain(logLines, l =>
+                l.Contains("[KerbalsModule]") && l.Contains("ApplyToRoster"));
         }
 
         [Fact]

--- a/Source/Parsek.Tests/RewindUtCutoffTests.cs
+++ b/Source/Parsek.Tests/RewindUtCutoffTests.cs
@@ -28,6 +28,7 @@ namespace Parsek.Tests
             ParsekLog.TestSinkForTesting = line => logLines.Add(line);
 
             RecordingStore.SuppressLogging = true;
+            RecordingStore.ResetForTesting();
             KspStatePatcher.SuppressUnityCallsForTesting = true;
             GameStateStore.SuppressLogging = true;
             GameStateStore.ResetForTesting();
@@ -39,6 +40,7 @@ namespace Parsek.Tests
         {
             LedgerOrchestrator.ResetForTesting();
             KspStatePatcher.ResetForTesting();
+            RecordingStore.ResetForTesting();
             RecordingStore.SuppressLogging = false;
             GameStateStore.ResetForTesting();
             RewindContext.ResetForTesting();
@@ -235,7 +237,12 @@ namespace Parsek.Tests
             };
         }
 
-        private static GameAction KerbalAssignment(double ut, string name, double startUt, double endUt)
+        private static GameAction KerbalAssignment(
+            double ut,
+            string name,
+            double startUt,
+            double endUt,
+            KerbalEndState endState = KerbalEndState.Unknown)
         {
             return new GameAction
             {
@@ -245,7 +252,35 @@ namespace Parsek.Tests
                 KerbalRole = "Pilot",
                 StartUT = (float)startUt,
                 EndUT = (float)endUt,
-                RecordingId = "rec-asn-" + name
+                RecordingId = "rec-asn-" + name,
+                KerbalEndStateField = endState
+            };
+        }
+
+        private static Recording CrewRecording(
+            string recordingId,
+            string crewName,
+            double startUt,
+            double endUt,
+            KerbalEndState endState)
+        {
+            var snapshot = new ConfigNode("VESSEL");
+            var part = snapshot.AddNode("PART");
+            part.AddValue("crew", crewName);
+
+            return new Recording
+            {
+                RecordingId = recordingId,
+                VesselName = recordingId,
+                VesselSnapshot = snapshot,
+                GhostVisualSnapshot = snapshot,
+                ExplicitStartUT = startUt,
+                ExplicitEndUT = endUt,
+                CrewEndStates = new Dictionary<string, KerbalEndState>
+                {
+                    { crewName, endState }
+                },
+                CrewEndStatesResolved = true
             };
         }
 
@@ -545,6 +580,39 @@ namespace Parsek.Tests
             // Only the seed (UT=0) contributes; all milestones are UT > 0.
             Assert.Equal(1000.0, LedgerOrchestrator.Funds.GetRunningBalance(), 1);
             AssertLogHasCutoffSummary(logLines, 4, 1, "0");
+        }
+
+        [Fact]
+        public void CutoffZero_KeepsCareerStateAtCutoffButProjectsCrewReservations()
+        {
+            RecordingStore.AddRecordingWithTreeForTesting(
+                CrewRecording(
+                    "rec-asn-Jeb",
+                    "Jeb",
+                    startUt: 100.0,
+                    endUt: 500.0,
+                    endState: KerbalEndState.Aboard));
+
+            AddAll(
+                FundsSeed(1000f),
+                Milestone(100.0, "FutureReward", 500f),
+                KerbalAssignment(
+                    100.0,
+                    "Jeb",
+                    startUt: 100.0,
+                    endUt: 500.0,
+                    endState: KerbalEndState.Aboard));
+
+            LedgerOrchestrator.RecalculateAndPatch(0.0);
+
+            Assert.Equal(1000.0, LedgerOrchestrator.Funds.GetRunningBalance(), 1);
+            Assert.True(LedgerOrchestrator.Kerbals.Reservations.ContainsKey("Jeb"));
+            Assert.True(LedgerOrchestrator.Kerbals.ShouldFilterFromCrewDialog("Jeb"));
+            AssertLogHasCutoffSummary(logLines, 3, 1, "0");
+            Assert.Contains(logLines, l =>
+                l.Contains("[CrewReservations]")
+                && l.Contains("Recomputed after cutoff walk: 1 reservations remain")
+                && l.Contains("cutoffUT=0"));
         }
 
         [Fact]

--- a/Source/Parsek.Tests/RewindUtCutoffTests.cs
+++ b/Source/Parsek.Tests/RewindUtCutoffTests.cs
@@ -616,6 +616,55 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void MidTimelineCutoff_ProjectsPreAndPostCutoffCrewReservations()
+        {
+            RecordingStore.AddRecordingWithTreeForTesting(
+                CrewRecording(
+                    "rec-asn-Bill",
+                    "Bill",
+                    startUt: 100.0,
+                    endUt: 300.0,
+                    endState: KerbalEndState.Aboard));
+            RecordingStore.AddRecordingWithTreeForTesting(
+                CrewRecording(
+                    "rec-asn-Jeb",
+                    "Jeb",
+                    startUt: 500.0,
+                    endUt: 900.0,
+                    endState: KerbalEndState.Aboard));
+
+            AddAll(
+                FundsSeed(1000f),
+                Milestone(100.0, "BeforeCutoff", 200f),
+                Milestone(500.0, "AfterCutoff", 400f),
+                KerbalAssignment(
+                    100.0,
+                    "Bill",
+                    startUt: 100.0,
+                    endUt: 300.0,
+                    endState: KerbalEndState.Aboard),
+                KerbalAssignment(
+                    500.0,
+                    "Jeb",
+                    startUt: 500.0,
+                    endUt: 900.0,
+                    endState: KerbalEndState.Aboard));
+
+            LedgerOrchestrator.RecalculateAndPatch(200.0);
+
+            Assert.Equal(1200.0, LedgerOrchestrator.Funds.GetRunningBalance(), 1);
+            Assert.True(LedgerOrchestrator.Kerbals.Reservations.ContainsKey("Bill"));
+            Assert.True(LedgerOrchestrator.Kerbals.Reservations.ContainsKey("Jeb"));
+            Assert.True(LedgerOrchestrator.Kerbals.ShouldFilterFromCrewDialog("Bill"));
+            Assert.True(LedgerOrchestrator.Kerbals.ShouldFilterFromCrewDialog("Jeb"));
+            AssertLogHasCutoffSummary(logLines, 5, 3, "200");
+            Assert.Contains(logLines, l =>
+                l.Contains("[CrewReservations]")
+                && l.Contains("Recomputed after cutoff walk: 2 reservations remain")
+                && l.Contains("cutoffUT=200"));
+        }
+
+        [Fact]
         public void CutoffZero_DistinctFromNull()
         {
             AddAll(

--- a/Source/Parsek/CrewReservationManager.cs
+++ b/Source/Parsek/CrewReservationManager.cs
@@ -1573,11 +1573,23 @@ namespace Parsek
         /// </summary>
         public static void RecomputeAfterTombstones()
         {
+            RecomputeFromEffectiveLedger("after tombstones", null);
+        }
+
+        internal static void RecomputeAfterCutoffWalk(double utCutoff)
+        {
+            RecomputeFromEffectiveLedger(
+                "after cutoff walk",
+                "cutoffUT=" + utCutoff.ToString("R", System.Globalization.CultureInfo.InvariantCulture));
+        }
+
+        private static void RecomputeFromEffectiveLedger(string reason, string detail)
+        {
             var kerbals = LedgerOrchestrator.Kerbals;
             if (kerbals == null)
             {
                 ParsekLog.Verbose("CrewReservations",
-                    "RecomputeAfterTombstones: no KerbalsModule — skipping");
+                    $"RecomputeFromEffectiveLedger: no KerbalsModule — skipping ({reason})");
                 return;
             }
 
@@ -1611,8 +1623,9 @@ namespace Parsek
             foreach (var _ in kerbals.Reservations)
                 remaining++;
 
+            string suffix = string.IsNullOrEmpty(detail) ? "." : $" ({detail}).";
             ParsekLog.Info("CrewReservations",
-                $"Recomputed after tombstones: {remaining} reservations remain.");
+                $"Recomputed {reason}: {remaining} reservations remain{suffix}");
         }
 
         #endregion

--- a/Source/Parsek/CrewReservationManager.cs
+++ b/Source/Parsek/CrewReservationManager.cs
@@ -1573,17 +1573,21 @@ namespace Parsek
         /// </summary>
         public static void RecomputeAfterTombstones()
         {
-            RecomputeFromEffectiveLedger("after tombstones", null);
+            RecomputeFromEffectiveLedger("after tombstones", null, applyToRoster: true);
         }
 
         internal static void RecomputeAfterCutoffWalk(double utCutoff)
         {
             RecomputeFromEffectiveLedger(
                 "after cutoff walk",
-                "cutoffUT=" + utCutoff.ToString("R", System.Globalization.CultureInfo.InvariantCulture));
+                "cutoffUT=" + utCutoff.ToString("R", System.Globalization.CultureInfo.InvariantCulture),
+                applyToRoster: false);
         }
 
-        private static void RecomputeFromEffectiveLedger(string reason, string detail)
+        private static void RecomputeFromEffectiveLedger(
+            string reason,
+            string detail,
+            bool applyToRoster)
         {
             var kerbals = LedgerOrchestrator.Kerbals;
             if (kerbals == null)
@@ -1615,9 +1619,12 @@ namespace Parsek
             kerbals.PostWalk();
 
             // ApplyToRoster refreshes the replacement dictionary via
-            // ClearReplacementsInternal + SetReplacement. Roster may be absent
-            // in headless / test contexts; ApplyToRoster logs and no-ops.
-            kerbals.ApplyToRoster(HighLogic.CurrentGame?.CrewRoster);
+            // ClearReplacementsInternal + SetReplacement. Cutoff recalculations
+            // defer roster mutation to LedgerOrchestrator's normal patch gate so
+            // post-rewind flight-load and pending-tree paths still honor KSP state
+            // patch deferral.
+            if (applyToRoster)
+                kerbals.ApplyToRoster(HighLogic.CurrentGame?.CrewRoster);
 
             int remaining = 0;
             foreach (var _ in kerbals.Reservations)

--- a/Source/Parsek/CrewReservationManager.cs
+++ b/Source/Parsek/CrewReservationManager.cs
@@ -1626,13 +1626,10 @@ namespace Parsek
             if (applyToRoster)
                 kerbals.ApplyToRoster(HighLogic.CurrentGame?.CrewRoster);
 
-            int remaining = 0;
-            foreach (var _ in kerbals.Reservations)
-                remaining++;
-
-            string suffix = string.IsNullOrEmpty(detail) ? "." : $" ({detail}).";
+            int remaining = kerbals.Reservations.Count;
+            string detailPart = string.IsNullOrEmpty(detail) ? "" : $" ({detail})";
             ParsekLog.Info("CrewReservations",
-                $"Recomputed {reason}: {remaining} reservations remain{suffix}");
+                $"Recomputed {reason}: {remaining} reservations remain{detailPart}.");
         }
 
         #endregion

--- a/Source/Parsek/GameActions/LedgerOrchestrator.cs
+++ b/Source/Parsek/GameActions/LedgerOrchestrator.cs
@@ -1577,6 +1577,7 @@ namespace Parsek
             // or jump target. Crew reservations are different: committed future
             // recordings still own their crew until recovery/death, so rebuild the
             // crew module from the full effective ledger after the cutoff walk.
+            // Roster mutation still happens below through the existing patch gate.
             if (utCutoff.HasValue)
                 CrewReservationManager.RecomputeAfterCutoffWalk(utCutoff.Value);
 

--- a/Source/Parsek/GameActions/LedgerOrchestrator.cs
+++ b/Source/Parsek/GameActions/LedgerOrchestrator.cs
@@ -1573,6 +1573,13 @@ namespace Parsek
             // branch decides whether this walk mutates live game state.
             ReconcilePostWalk(GameStateStore.Events, actions, utCutoff);
 
+            // Cutoff walks intentionally keep resources/career state at the rewind
+            // or jump target. Crew reservations are different: committed future
+            // recordings still own their crew until recovery/death, so rebuild the
+            // crew module from the full effective ledger after the cutoff walk.
+            if (utCutoff.HasValue)
+                CrewReservationManager.RecomputeAfterCutoffWalk(utCutoff.Value);
+
             // #466: a live or pending tree means KSP's mutable state may already include
             // uncommitted in-flight effects that the committed-only ledger cannot see yet.
             // Walking the committed ledger is still useful, but writing that partial state

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -2243,13 +2243,14 @@ namespace Parsek
             ParsekLog.Info("Rewind",
                 "OnLoad: resource + UT adjustment deferred (waiting for new scene singletons)");
 
-            // Re-reserve crew from all recording snapshots.
-            // Pass the adjusted rewind UT explicitly so the walk drops any ledger
-            // actions with UT > adjusted (e.g., milestones achieved after the rewind
-            // target). RewindContext.RewindAdjustedUT is still populated at this point;
-            // EndRewind() below clears it. The deferred coroutine captures the same
-            // value into a local BEFORE its yield so its second call is independent
-            // of RewindContext state.
+            // Restore career state to the rewind target. The cutoff walk keeps
+            // funds/science/tech at the adjusted UT; LedgerOrchestrator then
+            // reprojects crew reservations from the full committed timeline so
+            // future recorded crew remain unavailable for new missions.
+            // RewindContext.RewindAdjustedUT is still populated at this point;
+            // EndRewind() below clears it. The deferred coroutine captures the
+            // same value into a local BEFORE its yield so its second call is
+            // independent of RewindContext state.
             LedgerOrchestrator.RecalculateAndPatch(RewindContext.RewindAdjustedUT);
 
             // Clear rewind flags — rewind loads into SpaceCenter, not Flight
@@ -5009,8 +5010,9 @@ namespace Parsek
 
             // Pass the adjusted UT captured BEFORE `yield return null` above.
             // RewindContext.EndRewind() has already cleared the global by the time
-            // this coroutine resumes, so we cannot read from RewindContext here —
-            // the synchronous HandleRewindOnLoad call already ran and cleared state.
+            // this coroutine resumes, so we cannot read from RewindContext here.
+            // The cutoff applies to career resources; crew reservations are rebuilt
+            // from the full committed timeline inside LedgerOrchestrator.
             LedgerOrchestrator.RecalculateAndPatch(adjustedUT);
 
             // Belt-and-suspenders guard: if some future refactor accidentally schedules

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -23,6 +23,18 @@ When referencing prior item numbers from source comments or plans, consult the r
 
 ---
 
+## Done - v0.9.1 rewind crew reservations after cutoff
+
+- ~~After a plain Rewind, crew from a committed recording could become selectable for new missions even though the recorded flight never recovered them.~~ Source: `logs/2026-05-04_1817`. Runtime trace showed the pre-rewind ledger walk reserving Jebediah, Bill, and Bob, then `HandleRewindOnLoad` rescuing stripped/orphaned roster entries back to `Available` and calling `LedgerOrchestrator.RecalculateAndPatch(0)`. The cutoff walk correctly filtered future career rows, but it also filtered the future `KerbalAssignment` rows that `KerbalsModule` needs for crew-dialog reservations, leaving `reservations=0`.
+
+**Fix:** cutoff recalculations still walk resources/contracts/facilities at the supplied UT, but now immediately rebuild `KerbalsModule` from the full Effective Ledger Set so committed future recordings continue to own their crew until recovery/death. The existing tombstone recompute path was generalized and reused, keeping tombstoned crew assignments excluded while avoiding post-rewind resource re-credit.
+
+**Coverage:** `RewindUtCutoffTests.CutoffZero_KeepsCareerStateAtCutoffButProjectsCrewReservations`, plus the nearby `RewindUtCutoffTests` and `CrewReservationRecomputeTests` suites.
+
+**Status:** CLOSED 2026-05-04.
+
+---
+
 ## Done - v0.9.1 pending-tree cleanup view for Re-Fly restore
 
 - ~~After Rewind + Watch, re-entering a spawned Re-Fly vessel could leave the Recordings window showing zero rows until the deferred merge dialog restored the mission tree, and that pending-tree window could also drop supersede rows and auto-generated group hierarchy.~~ Source: `logs/2026-05-03_0059_newest`. Runtime trace: `TryTakeCommittedTreeForSpawnedVesselRestore` detached the 13-recording `Kerbal X` tree from `CommittedTrees` / `CommittedRecordings` so the active vessel could own it again, then `OnSave` wrote `0 committed recordings` plus an `ACTIVE` tree. On the following KSC load, `TryRestoreActiveTreeNode` kept the in-memory finalized pending tree and skipped `.sfs` replacement, but `LoadTimeSweep.SweepOrphanSupersedes` still checked only committed recordings and removed a valid supersede relation as fully orphaned. The group hierarchy prune had the same committed-only view, so it could treat pending-tree-only mission/debris groups as stale.


### PR DESCRIPTION
## Summary
- Rebuild crew reservations from the full effective ledger after cutoff recalculations, while leaving career resources at the cutoff UT.
- Reuse the existing tombstone recompute path and document the rewind behavior.
- Add a regression for cutoff UT 0 keeping future recorded crew filtered from the crew dialog.

## Tests
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter CutoffZero_KeepsCareerStateAtCutoffButProjectsCrewReservations
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter "FullyQualifiedName~RewindUtCutoffTests|FullyQualifiedName~CrewReservationRecomputeTests"
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter "FullyQualifiedName!~SyntheticRecordingTests.InjectAllRecordings"
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj reached 10688 passing tests, then InjectAllRecordings failed because KSP.log was locked by the running game. Per AGENTS.md, I did not close or restart KSP. Post-build GameData copy also warned with access denied for the same locked/protected KSP install files.