### PR TITLE
Fix Watch availability after rewind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- Watch buttons remain actionable immediately after rewinding before future ghosts have activated. Row, group, and Timeline `W` buttons now route future inactive recordings through the existing fast-forward confirmation and deferred Watch handoff, targeting the first ghost activation UT so the camera enters Watch after playback has spawned and positioned the target ghost. Superseding fast-forwards clear any older deferred Watch target, and Watch availability logs now distinguish an active playback state from a loaded ghost visual object.
 - An orphaned chain predecessor (same vessel pid, contiguous boundary, missing `ChainId`) is grafted back as the chain's `[0]` entry on load and re-saved, restoring the seamless ghost handoff so the next stage no longer respawns engine FX/audio at the chain boundary.
 - Unowned science subjects from stock transmission and vessel recovery now enter the ledger immediately, so Parsek no longer patches the science pool back down before those rewards are committed.
 - Re-Fly temp quicksaves now force the selected real vessel's `CTRLSTATE/mainThrottle`, `CTRLSTATE/wheelThrottle`, and persisted engine-module throttle fields to `0` before KSP loads it, so the player never spawns into a Re-Fly attempt with recorded throttle input already open.

--- a/Source/Parsek.Tests/FastForwardTests.cs
+++ b/Source/Parsek.Tests/FastForwardTests.cs
@@ -120,6 +120,24 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void CanFastForwardToUT_UsesExplicitTargetBeyondStartUT()
+        {
+            var rec = new Recording { VesselName = "Delayed activation" };
+            rec.ExplicitStartUT = 100.0;
+            rec.Points.Add(new TrajectoryPoint { ut = 120.0 });
+            rec.Points.Add(new TrajectoryPoint { ut = 150.0 });
+
+            string reason;
+            Assert.False(RecordingStore.CanFastForwardAtUT(
+                rec, 110.0, out reason, isRecording: false));
+            Assert.Equal("Recording is not in the future", reason);
+
+            Assert.True(RecordingStore.CanFastForwardToUT(
+                rec, 110.0, 120.0, out reason, isRecording: false));
+            Assert.Equal(string.Empty, reason);
+        }
+
+        [Fact]
         public void CanFastForward_IsRecording_ReturnsFalse()
         {
             var rec = MakeFutureRecording();

--- a/Source/Parsek.Tests/RecordingsTableUITests.cs
+++ b/Source/Parsek.Tests/RecordingsTableUITests.cs
@@ -811,6 +811,49 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void ShouldOfferFastForwardWatch_RequiresInactiveFutureNonDebris()
+        {
+            Assert.True(RecordingsTableUI.ShouldOfferFastForwardWatch(
+                hasGhost: false, canFastForward: true, isDebris: false));
+            Assert.False(RecordingsTableUI.ShouldOfferFastForwardWatch(
+                hasGhost: true, canFastForward: true, isDebris: false));
+            Assert.False(RecordingsTableUI.ShouldOfferFastForwardWatch(
+                hasGhost: false, canFastForward: false, isDebris: false));
+            Assert.False(RecordingsTableUI.ShouldOfferFastForwardWatch(
+                hasGhost: false, canFastForward: true, isDebris: true));
+        }
+
+        [Fact]
+        public void ShouldEnableWatchButton_AllowsFastForwardWatch()
+        {
+            Assert.True(RecordingsTableUI.ShouldEnableWatchButton(
+                canWatch: false,
+                isWatching: false,
+                canFastForwardToWatch: true));
+        }
+
+        [Fact]
+        public void CanFastForwardWatchAtUT_UsesGhostActivationStartAfterExplicitStart()
+        {
+            var rec = new Recording
+            {
+                VesselName = "Delayed",
+                ExplicitStartUT = 100.0
+            };
+            rec.Points.Add(new TrajectoryPoint { ut = 120.0 });
+            rec.Points.Add(new TrajectoryPoint { ut = 150.0 });
+
+            string reason;
+            Assert.Equal(120.0, RecordingsTableUI.ResolveFastForwardWatchTargetUT(rec));
+            Assert.True(RecordingsTableUI.CanFastForwardWatchAtUT(
+                rec, now: 110.0, out reason, isRecording: false));
+            Assert.Equal(string.Empty, reason);
+            Assert.False(RecordingsTableUI.CanFastForwardWatchAtUT(
+                rec, now: 120.0, out reason, isRecording: false));
+            Assert.Equal("Recording is not in the future", reason);
+        }
+
+        [Fact]
         public void UpdateWatchButtonTransitionCache_TracksFirstChangeAndSuppressesDuplicates()
         {
             var cache = new Dictionary<string, bool>();
@@ -840,6 +883,35 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void GetWatchButtonReason_FastForwardWatchExplainsEnabledRoute()
+        {
+            string reason = RecordingsTableUI.GetWatchButtonReason(
+                canWatch: false,
+                hasGhost: false,
+                sameBody: false,
+                inRange: false,
+                isDebris: false,
+                canFastForwardToWatch: true);
+
+            Assert.Equal("enabled (fast-forward to watch)", reason);
+        }
+
+        [Fact]
+        public void GetWatchButtonTooltip_FastForwardWatchExplainsJumpAndWatch()
+        {
+            string tooltip = RecordingsTableUI.GetWatchButtonTooltip(
+                isWatching: false,
+                hasGhost: false,
+                sameBody: false,
+                inRange: false,
+                isDebris: false,
+                canFastForwardToWatch: true);
+
+            Assert.Contains("Fast-forward", tooltip);
+            Assert.Contains("watch mode", tooltip);
+        }
+
+        [Fact]
         public void GetWatchButtonTooltip_WatchingPrioritizesExit()
         {
             string tooltip = RecordingsTableUI.GetWatchButtonTooltip(
@@ -859,11 +931,9 @@ namespace Parsek.Tests
 
             // Per-row site still uses (flight, ri).
             Assert.Contains("BuildWatchObservabilitySuffix(flight, ri)", uiSrc);
-            // Bug #382: group site now passes nextTargetIdx (the cycle's next
-            // vessel) instead of resolvedWatchIdx, but the 3-arg observability
-            // helper signature (flight, sourceIndex, resolvedOrNextIndex) is
-            // unchanged so the log still names the watched/source/next pair.
-            Assert.Contains("BuildWatchObservabilitySuffix(flight, mainIdx, nextTargetIdx)", uiSrc);
+            // Bug #382: group site passes the active rotation target, or the
+            // fast-forward target when W routes through FF+Watch.
+            Assert.Contains("BuildWatchObservabilitySuffix(flight, mainIdx, logTargetIdx)", uiSrc);
             Assert.Contains("beforeFocus={beforeFocus} afterFocus={flight.DescribeWatchFocusForLogs()}", uiSrc);
         }
 
@@ -1199,6 +1269,53 @@ namespace Parsek.Tests
                 new List<int> { 0, 1 }, committed, now: 300.0);
 
             Assert.Equal(-1, result);
+        }
+
+        [Fact]
+        public void FindAggregateFastForwardWatchRecordingIndex_PicksEarliestFutureNonDebris()
+        {
+            var pastMain = MakeRec(100, 200, "Past main");
+            var debrisFuture = MakeRec(250, 300, "Future debris");
+            debrisFuture.IsDebris = true;
+            var laterFuture = MakeRec(500, 600, "Later future");
+            var earlierFuture = MakeRec(300, 400, "Earlier future");
+            var committed = new List<Recording> { pastMain, debrisFuture, laterFuture, earlierFuture };
+
+            int result = RecordingsTableUI.FindAggregateFastForwardWatchRecordingIndex(
+                new List<int> { 0, 1, 2, 3 }, committed, now: 225.0, isRecording: false);
+
+            Assert.Equal(3, result);
+        }
+
+        [Fact]
+        public void FindAggregateFastForwardWatchRecordingIndex_ReturnsNegativeOneWhileRecording()
+        {
+            var future = MakeRec(300, 400, "Future");
+            var committed = new List<Recording> { future };
+
+            int result = RecordingsTableUI.FindAggregateFastForwardWatchRecordingIndex(
+                new List<int> { 0 }, committed, now: 225.0, isRecording: true);
+
+            Assert.Equal(-1, result);
+        }
+
+        [Fact]
+        public void FindAggregateFastForwardWatchRecordingIndex_OrdersByActivationStart()
+        {
+            var delayedEarlyStart = new Recording
+            {
+                VesselName = "Delayed early start",
+                ExplicitStartUT = 100.0
+            };
+            delayedEarlyStart.Points.Add(new TrajectoryPoint { ut = 400.0 });
+            delayedEarlyStart.Points.Add(new TrajectoryPoint { ut = 450.0 });
+            var normalFuture = MakeRec(300, 350, "Normal future");
+            var committed = new List<Recording> { delayedEarlyStart, normalFuture };
+
+            int result = RecordingsTableUI.FindAggregateFastForwardWatchRecordingIndex(
+                new List<int> { 0, 1 }, committed, now: 150.0, isRecording: false);
+
+            Assert.Equal(1, result);
         }
 
         [Fact]

--- a/Source/Parsek.Tests/TimelineWindowUITests.cs
+++ b/Source/Parsek.Tests/TimelineWindowUITests.cs
@@ -115,6 +115,41 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void BuildWatchButtonDescriptor_FutureInactiveRow_EnablesFastForwardWatch()
+        {
+            var descriptor = TimelineWindowUI.BuildWatchButtonDescriptor(
+                isWatching: false,
+                hasGhost: false,
+                sameBody: false,
+                inRange: false,
+                isDebris: false,
+                canFastForwardToWatch: true);
+
+            Assert.Equal("W", descriptor.Label);
+            Assert.Contains("Fast-forward", descriptor.Tooltip);
+            Assert.True(descriptor.Enabled);
+            Assert.False(descriptor.CanWatch);
+            Assert.True(descriptor.CanFastForwardToWatch);
+            Assert.Equal(TimelineWindowUI.TimelineWatchButtonAction.FastForwardAndEnter, descriptor.Action);
+        }
+
+        [Fact]
+        public void BuildWatchButtonDescriptor_DebrisDoesNotUseFastForwardWatch()
+        {
+            var descriptor = TimelineWindowUI.BuildWatchButtonDescriptor(
+                isWatching: false,
+                hasGhost: false,
+                sameBody: false,
+                inRange: false,
+                isDebris: true,
+                canFastForwardToWatch: true);
+
+            Assert.Equal("Debris is not watchable", descriptor.Tooltip);
+            Assert.False(descriptor.Enabled);
+            Assert.False(descriptor.CanFastForwardToWatch);
+        }
+
+        [Fact]
         public void BuildFlySealButtonDescriptor_ResolvedSlot_EnablesBothActions()
         {
             var descriptor = TimelineWindowUI.BuildFlySealButtonDescriptor(
@@ -205,6 +240,10 @@ namespace Parsek.Tests
                 TimelineWindowUI.GetWatchButtonAction(isWatching: false));
             Assert.Equal(TimelineWindowUI.TimelineWatchButtonAction.Exit,
                 TimelineWindowUI.GetWatchButtonAction(isWatching: true));
+            Assert.Equal(TimelineWindowUI.TimelineWatchButtonAction.FastForwardAndEnter,
+                TimelineWindowUI.GetWatchButtonAction(
+                    isWatching: false,
+                    canFastForwardToWatch: true));
         }
 
         [Fact]
@@ -237,6 +276,25 @@ namespace Parsek.Tests
 
             Assert.False(exitCalled);
             Assert.Equal(7, enteredIndex);
+        }
+
+        [Fact]
+        public void ApplyWatchButtonAction_FastForwardAction_CallsFastForwardOnly()
+        {
+            bool exitCalled = false;
+            int enteredIndex = -1;
+            bool fastForwardCalled = false;
+
+            TimelineWindowUI.ApplyWatchButtonAction(
+                TimelineWindowUI.TimelineWatchButtonAction.FastForwardAndEnter,
+                recIndex: 7,
+                exitWatchMode: () => exitCalled = true,
+                enterWatchMode: index => enteredIndex = index,
+                fastForwardAndEnterWatch: () => fastForwardCalled = true);
+
+            Assert.False(exitCalled);
+            Assert.Equal(-1, enteredIndex);
+            Assert.True(fastForwardCalled);
         }
 
         [Fact]

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -26918,13 +26918,20 @@ namespace Parsek
         /// </summary>
         internal void FastForwardToRecording(Recording rec)
         {
+            FastForwardToRecording(rec, enterWatchAfterFastForward: false);
+        }
+
+        internal void FastForwardToRecording(Recording rec, bool enterWatchAfterFastForward)
+        {
             if (rec == null)
             {
                 ParsekLog.Warn("Flight", "FastForwardToRecording: null recording — aborted");
                 return;
             }
 
-            double targetUT = rec.StartUT;
+            double targetUT = enterWatchAfterFastForward
+                ? PlaybackTrajectoryBoundsResolver.ResolveGhostActivationStartUT(rec)
+                : rec.StartUT;
             double currentUT = Planetarium.GetUniversalTime();
 
             if (!TimeJumpManager.IsValidJump(currentUT, targetUT))
@@ -26936,25 +26943,50 @@ namespace Parsek
                 return;
             }
 
+            if (pendingWatchAfterFFId != null)
+            {
+                string supersededWatchId = pendingWatchAfterFFId;
+                pendingWatchAfterFFId = null;
+                ParsekLog.Info("CameraFollow",
+                    $"FF pending watch target id={supersededWatchId} superseded by fast-forward to \"{rec.VesselName}\"");
+            }
+
             ParsekLog.Info("Flight",
                 string.Format(CultureInfo.InvariantCulture,
                     "FastForwardToRecording: jumping to UT={0:F1} for '{1}' (delta={2:F1}s)",
                     targetUT, rec.VesselName, targetUT - currentUT));
 
+            var committed = RecordingStore.CommittedRecordings;
+            int ffTargetIdx = -1;
+            for (int i = 0; i < committed.Count; i++)
+            {
+                if (committed[i].RecordingId == rec.RecordingId)
+                {
+                    ffTargetIdx = i;
+                    break;
+                }
+            }
+
+            if (enterWatchAfterFastForward)
+            {
+                if (ffTargetIdx >= 0)
+                {
+                    if (watchMode.IsWatchingGhost)
+                        ExitWatchMode();
+                    pendingWatchAfterFFId = rec.RecordingId;
+                    ParsekLog.Info("CameraFollow",
+                        $"FF watch requested: target=#{ffTargetIdx} \"{rec.VesselName}\"");
+                }
+                else
+                {
+                    ParsekLog.Warn("CameraFollow",
+                        $"FF watch requested for \"{rec.VesselName}\" but recording id was not committed");
+                }
+            }
             // If watching, transfer watch to the FF target recording.
             // The current watched ghost may be far away after the time jump.
-            if (watchMode.IsWatchingGhost)
+            else if (watchMode.IsWatchingGhost)
             {
-                var committed = RecordingStore.CommittedRecordings;
-                int ffTargetIdx = -1;
-                for (int i = 0; i < committed.Count; i++)
-                {
-                    if (committed[i].RecordingId == rec.RecordingId)
-                    {
-                        ffTargetIdx = i;
-                        break;
-                    }
-                }
                 if (ffTargetIdx >= 0 && ffTargetIdx != watchMode.WatchedRecordingIndex)
                 {
                     ParsekLog.Info("CameraFollow",

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -3398,10 +3398,16 @@ namespace Parsek
         /// </summary>
         internal static bool CanFastForwardAtUT(Recording rec, double now, out string reason, bool isRecording)
         {
+            return CanFastForwardToUT(rec, now, rec?.StartUT ?? double.NaN, out reason, isRecording);
+        }
+
+        internal static bool CanFastForwardToUT(
+            Recording rec, double now, double targetUT, out string reason, bool isRecording)
+        {
             if (!CanFastForwardPreRuntime(rec, out reason, isRecording))
                 return false;
 
-            if (now >= rec.StartUT)
+            if (double.IsNaN(targetUT) || now >= targetUT)
             {
                 reason = "Recording is not in the future";
                 // Per-frame logging removed (was 20% of all log output); reason returned to caller

--- a/Source/Parsek/UI/RecordingsTableUI.cs
+++ b/Source/Parsek/UI/RecordingsTableUI.cs
@@ -697,9 +697,31 @@ namespace Parsek
             return hasGhost && sameBody && inRange && !isDebris;
         }
 
-        internal static bool ShouldEnableWatchButton(bool canWatch, bool isWatching)
+        internal static bool ShouldOfferFastForwardWatch(
+            bool hasGhost, bool canFastForward, bool isDebris)
         {
-            return canWatch || isWatching;
+            return !hasGhost && canFastForward && !isDebris;
+        }
+
+        internal static double ResolveFastForwardWatchTargetUT(Recording rec)
+        {
+            if (rec == null)
+                return double.NaN;
+            return PlaybackTrajectoryBoundsResolver.ResolveGhostActivationStartUT(rec);
+        }
+
+        internal static bool CanFastForwardWatchAtUT(
+            Recording rec, double now, out string reason, bool isRecording)
+        {
+            double targetUT = ResolveFastForwardWatchTargetUT(rec);
+            return RecordingStore.CanFastForwardToUT(
+                rec, now, targetUT, out reason, isRecording);
+        }
+
+        internal static bool ShouldEnableWatchButton(
+            bool canWatch, bool isWatching, bool canFastForwardToWatch = false)
+        {
+            return canWatch || isWatching || canFastForwardToWatch;
         }
 
         internal static bool UpdateWatchButtonTransitionCache(
@@ -718,10 +740,16 @@ namespace Parsek
         }
 
         internal static string GetWatchButtonReason(
-            bool canWatch, bool hasGhost, bool sameBody, bool inRange, bool isDebris)
+            bool canWatch,
+            bool hasGhost,
+            bool sameBody,
+            bool inRange,
+            bool isDebris,
+            bool canFastForwardToWatch = false)
         {
             if (canWatch) return "enabled";
             if (isDebris) return "disabled (debris)";
+            if (canFastForwardToWatch) return "enabled (fast-forward to watch)";
             if (!hasGhost) return "disabled (no ghost)";
             if (!sameBody) return "disabled (different body)";
             if (!inRange) return "disabled (out of range)";
@@ -729,12 +757,19 @@ namespace Parsek
         }
 
         internal static string GetWatchButtonTooltip(
-            bool isWatching, bool hasGhost, bool sameBody, bool inRange, bool isDebris)
+            bool isWatching,
+            bool hasGhost,
+            bool sameBody,
+            bool inRange,
+            bool isDebris,
+            bool canFastForwardToWatch = false)
         {
             if (isWatching)
                 return "Exit watch mode";
             if (isDebris)
                 return "Debris is not watchable";
+            if (canFastForwardToWatch)
+                return "Fast-forward to this launch and enter watch mode";
             if (!hasGhost)
                 return "No active ghost - recording is in the past/future or has no trajectory points";
             if (!sameBody)
@@ -1551,6 +1586,16 @@ namespace Parsek
                 bool inRange = flight.IsGhostWithinVisualRange(ri);
                 bool isWatching = flight.WatchedRecordingIndex == ri;
                 bool canWatch = IsWatchButtonEnabled(hasGhost, sameBody, inRange, rec.IsDebris);
+                string watchFastForwardReason;
+                bool canFastForwardToWatch = ShouldOfferFastForwardWatch(
+                    hasGhost,
+                    CanFastForwardWatchAtUT(
+                        rec,
+                        Planetarium.GetUniversalTime(),
+                        out watchFastForwardReason,
+                        isRecording: flight.IsRecording),
+                    rec.IsDebris);
+                bool watchAvailable = canWatch || canFastForwardToWatch;
 
                 // Bug #279: log enabled/disabled transitions at INFO level so future
                 // playtests can distinguish "user didn't try" from "UI was broken".
@@ -1562,29 +1607,54 @@ namespace Parsek
                 // doesn't inherit the previous occupant's cached canWatch and emit
                 // a spurious transition log line.
                 string watchKey = rec.RecordingId;
-                if (UpdateWatchButtonTransitionCache(lastCanWatchByRecId, watchKey, canWatch))
+                if (UpdateWatchButtonTransitionCache(lastCanWatchByRecId, watchKey, watchAvailable))
                 {
-                    string reason = GetWatchButtonReason(canWatch, hasGhost, sameBody, inRange, rec.IsDebris);
+                    string reason = GetWatchButtonReason(
+                        canWatch,
+                        hasGhost,
+                        sameBody,
+                        inRange,
+                        rec.IsDebris,
+                        canFastForwardToWatch);
                     ParsekLog.Info("UI",
                         $"Watch button #{ri} \"{rec.VesselName}\" {reason} " +
-                        $"(hasGhost={hasGhost} sameBody={sameBody} inRange={inRange} debris={rec.IsDebris}) " +
+                        $"(hasGhost={hasGhost} sameBody={sameBody} inRange={inRange} debris={rec.IsDebris} " +
+                        $"ffWatch={canFastForwardToWatch}) " +
                         $"{BuildWatchObservabilitySuffix(flight, ri)}");
                 }
 
-                GUI.enabled = ShouldEnableWatchButton(canWatch, isWatching);
+                GUI.enabled = ShouldEnableWatchButton(canWatch, isWatching, canFastForwardToWatch);
                 string watchLabel = isWatching ? "W*" : "W";
-                string watchTooltip = GetWatchButtonTooltip(isWatching, hasGhost, sameBody, inRange, rec.IsDebris);
+                string watchTooltip = GetWatchButtonTooltip(
+                    isWatching,
+                    hasGhost,
+                    sameBody,
+                    inRange,
+                    rec.IsDebris,
+                    canFastForwardToWatch);
                 var watchContent = new GUIContent(watchLabel, watchTooltip);
                 if (DrawBodyCenteredButton(watchContent, ColW_Watch))
                 {
                     string beforeFocus = flight.DescribeWatchFocusForLogs();
                     string beforeEligibility = flight.DescribeWatchEligibilityForLogs(ri);
+                    string watchAction;
                     if (isWatching)
+                    {
                         flight.ExitWatchMode();
-                    else
+                        watchAction = "exit";
+                    }
+                    else if (canWatch)
+                    {
                         flight.EnterWatchMode(ri);
+                        watchAction = "enter";
+                    }
+                    else
+                    {
+                        ShowFastForwardConfirmation(rec, enterWatchAfterFastForward: true);
+                        watchAction = "fast-forward-watch";
+                    }
                     ParsekLog.Info("UI",
-                        $"Recording #{ri} W button clicked: {(isWatching ? "exit" : "enter")} watch on \"{rec.VesselName}\" " +
+                        $"Recording #{ri} W button clicked: {watchAction} watch on \"{rec.VesselName}\" " +
                         $"before={beforeEligibility} beforeFocus={beforeFocus} afterFocus={flight.DescribeWatchFocusForLogs()}");
                 }
                 GUI.enabled = true;
@@ -1937,6 +2007,7 @@ namespace Parsek
 
             // Find the "main" (earliest non-debris) recording for group-level W and Rewind/Forward buttons
             int mainIdx = FindGroupMainRecordingIndex(descendants, committed);
+            bool isRecording = parentUI.InFlightMode && flight.IsRecording;
 
             // Watch button (flight only) — Bug #382: cycles through eligible
             // descendants on repeated presses instead of toggling a single main.
@@ -1983,6 +2054,12 @@ namespace Parsek
                 bool canWatch = rotation.NextRecordingId != null && nextTargetIdx >= 0 && !rotation.IsToggleOff;
                 bool isToggleOffPress = rotation.IsToggleOff && anyDescendantWatched;
                 bool isWatching = anyDescendantWatched;
+                int fastForwardWatchIdx = (!anyDescendantWatched && rotation.TotalEligible == 0)
+                    ? FindAggregateFastForwardWatchRecordingIndex(
+                        descendants, committed, now, isRecording)
+                    : -1;
+                bool canFastForwardToWatch = fastForwardWatchIdx >= 0;
+                bool watchAvailable = canWatch || canFastForwardToWatch;
 
                 // Bug #279 transition logging. Key by groupName + mainRecId (unchanged).
                 // To keep this log silent on cursor rotations (would otherwise spam
@@ -1996,36 +2073,43 @@ namespace Parsek
                     if (!string.IsNullOrEmpty(mainRecId))
                     {
                         string groupWatchKey = groupName + "/" + mainRecId;
-                        string resolvedTargetId = BuildEligibleSetFingerprint(
-                            descendants, committed, isEligibleForWatch);
+                        string resolvedTargetId = canFastForwardToWatch
+                            ? "ff:" + committed[fastForwardWatchIdx].RecordingId
+                            : BuildEligibleSetFingerprint(
+                                descendants, committed, isEligibleForWatch);
                         bool prevGroupCanWatch;
                         string prevResolvedTargetId;
                         if (!lastCanWatchByGroup.TryGetValue(groupWatchKey, out prevGroupCanWatch)
-                            || prevGroupCanWatch != canWatch
+                            || prevGroupCanWatch != watchAvailable
                             || !lastResolvedWatchTargetByGroup.TryGetValue(groupWatchKey, out prevResolvedTargetId)
                             || prevResolvedTargetId != resolvedTargetId)
                         {
-                            lastCanWatchByGroup[groupWatchKey] = canWatch;
+                            lastCanWatchByGroup[groupWatchKey] = watchAvailable;
                             lastResolvedWatchTargetByGroup[groupWatchKey] = resolvedTargetId;
+                            int logTargetIdx = nextTargetIdx >= 0 ? nextTargetIdx : fastForwardWatchIdx;
                             string reason = GetWatchButtonReason(canWatch,
                                 hasGhost: nextTargetIdx >= 0,
                                 sameBody: nextTargetIdx >= 0,
                                 inRange: nextTargetIdx >= 0,
-                                isDebris: false);
+                                isDebris: false,
+                                canFastForwardToWatch: canFastForwardToWatch);
                             ParsekLog.Info("UI",
                                 $"Group Watch button '{groupName}' source=#{mainIdx} \"{committed[mainIdx].VesselName}\" " +
-                                $"next={(nextTargetIdx >= 0 ? "#" + nextTargetIdx + " \"" + committed[nextTargetIdx].VesselName + "\"" : "<none>")} " +
+                                $"next={(logTargetIdx >= 0 ? "#" + logTargetIdx + " \"" + committed[logTargetIdx].VesselName + "\"" : "<none>")} " +
                                 $"pos={rotation.Position}/{rotation.TotalEligible} eligibleSet=[{resolvedTargetId}] {reason} " +
-                                $"{BuildWatchObservabilitySuffix(flight, mainIdx, nextTargetIdx)}");
+                                $"ffWatch={canFastForwardToWatch} " +
+                                $"{BuildWatchObservabilitySuffix(flight, mainIdx, logTargetIdx)}");
                         }
                     }
                 }
 
-                GUI.enabled = canWatch || isToggleOffPress;
+                GUI.enabled = canWatch || isToggleOffPress || canFastForwardToWatch;
                 string watchLabel = isWatching ? "W*" : "W";
                 string watchTooltip;
                 if (rotation.TotalEligible == 0)
-                    watchTooltip = "no watchable vessels in this group";
+                    watchTooltip = canFastForwardToWatch
+                        ? $"fast-forward and enter watch on {committed[fastForwardWatchIdx].VesselName}"
+                        : "no watchable vessels in this group";
                 else if (isWatching && nextTargetIdx >= 0 && rotation.NextRecordingId != watchedDescendantRecId)
                     watchTooltip = $"switch to {committed[nextTargetIdx].VesselName}";
                 else if (isWatching && rotation.IsToggleOff)
@@ -2054,21 +2138,27 @@ namespace Parsek
                             ? "enter"
                             : (rotation.IsWrap ? "wrap" : "advance");
                     }
+                    else if (canFastForwardToWatch)
+                    {
+                        var target = committed[fastForwardWatchIdx];
+                        ShowFastForwardConfirmation(target, enterWatchAfterFastForward: true);
+                        pressKind = "fast-forward-watch";
+                    }
                     else
                     {
-                        // Unreachable: GUI.enabled is canWatch || isToggleOffPress,
-                        // and canWatch==true implies nextTargetIdx>=0. If this branch
-                        // ever fires, the enable-gate has drifted — log a warning so
-                        // the regression surfaces instead of silently no-opping.
+                        // Unreachable: GUI.enabled mirrors the three handled actions
+                        // above. If this branch ever fires, the enable-gate has drifted
+                        // from press-dispatch; log it instead of silently no-opping.
                         ParsekLog.Warn("UI",
                             $"Group '{groupName}' W button press reached unreachable branch " +
-                            $"(canWatch={canWatch} isToggleOffPress={isToggleOffPress} nextTargetIdx={nextTargetIdx}) — " +
+                            $"(canWatch={canWatch} isToggleOffPress={isToggleOffPress} " +
+                            $"canFastForwardToWatch={canFastForwardToWatch} nextTargetIdx={nextTargetIdx}) — " +
                             "enable-gate and press-dispatch are out of sync");
                         pressKind = "no-op";
                     }
                     ParsekLog.Info("UI",
                         $"Group '{groupName}' W button: {pressKind} " +
-                        $"next={(nextTargetIdx >= 0 ? "#" + nextTargetIdx + " \"" + committed[nextTargetIdx].VesselName + "\"" : "<none>")} " +
+                        $"next={(nextTargetIdx >= 0 ? "#" + nextTargetIdx + " \"" + committed[nextTargetIdx].VesselName + "\"" : canFastForwardToWatch ? "#" + fastForwardWatchIdx + " \"" + committed[fastForwardWatchIdx].VesselName + "\"" : "<none>")} " +
                         $"pos={rotation.Position}/{rotation.TotalEligible} " +
                         $"cursorBefore={cursorRecId ?? "<null>"} " +
                         $"before={beforeEligibility} beforeFocus={beforeFocus} afterFocus={flight.DescribeWatchFocusForLogs()}");
@@ -2080,7 +2170,6 @@ namespace Parsek
             // recording because "next launch" is a single group-level time
             // affordance. Rewind scans descendants because a parent folder is
             // an escalation surface for any child launch rewind.
-            bool isRecording = parentUI.InFlightMode && flight.IsRecording;
             if (mainIdx >= 0 && now < committed[mainIdx].StartUT)
             {
                 var mainRec = committed[mainIdx];
@@ -3539,18 +3628,26 @@ namespace Parsek
                 false, HighLogic.UISkin);
         }
 
-        internal void ShowFastForwardConfirmation(Recording rec)
+        internal void ShowFastForwardConfirmation(
+            Recording rec, bool enterWatchAfterFastForward = false)
         {
             var ic = System.Globalization.CultureInfo.InvariantCulture;
             double now = Planetarium.GetUniversalTime();
-            double delta = rec.StartUT - now;
-            string launchDate = KSPUtil.PrintDateCompact(rec.StartUT, true);
+            double targetUT = enterWatchAfterFastForward
+                ? ResolveFastForwardWatchTargetUT(rec)
+                : rec.StartUT;
+            double delta = targetUT - now;
+            string targetDate = KSPUtil.PrintDateCompact(targetUT, true);
             string message = string.Format(ic,
-                "Fast-forward to \"{0}\" launch at {1}?\n\nTime will advance by {2:F0} seconds.",
-                rec.VesselName, launchDate, delta);
+                enterWatchAfterFastForward
+                    ? "Fast-forward to \"{0}\" watch start at {1} and enter watch mode?\n\nTime will advance by {2:F0} seconds."
+                    : "Fast-forward to \"{0}\" launch at {1}?\n\nTime will advance by {2:F0} seconds.",
+                rec.VesselName, targetDate, delta);
 
             var flight = parentUI.Flight;
             var capturedRec = rec;
+            double capturedTargetUT = targetUT;
+            bool capturedEnterWatchAfterFastForward = enterWatchAfterFastForward;
             PopupDialog.SpawnPopupDialog(
                 new Vector2(0.5f, 0.5f),
                 new Vector2(0.5f, 0.5f),
@@ -3559,14 +3656,20 @@ namespace Parsek
                     message,
                     "Confirm Fast-Forward",
                     HighLogic.UISkin,
-                    new DialogGUIButton("Fast-Forward", () =>
+                    new DialogGUIButton(
+                        capturedEnterWatchAfterFastForward ? "Fast-Forward + Watch" : "Fast-Forward",
+                        () =>
                     {
                         ParsekLog.Info("FastForward",
                             string.Format(ic,
-                                "User confirmed fast-forward to \"{0}\" at UT {1:F1}",
-                                capturedRec.VesselName, capturedRec.StartUT));
+                                capturedEnterWatchAfterFastForward
+                                    ? "User confirmed fast-forward + watch to \"{0}\" at UT {1:F1}"
+                                    : "User confirmed fast-forward to \"{0}\" at UT {1:F1}",
+                                capturedRec.VesselName, capturedTargetUT));
                         if (parentUI.InFlightMode && flight != null)
-                            flight.FastForwardToRecording(capturedRec);
+                            flight.FastForwardToRecording(
+                                capturedRec,
+                                enterWatchAfterFastForward: capturedEnterWatchAfterFastForward);
                         else
                         {
                             // KSC or other non-flight scene: advance UT directly.
@@ -3574,12 +3677,12 @@ namespace Parsek
                             // flight path has additional steps (NotifyRecorder, recorder state)
                             // that don't apply outside flight.
                             double preJumpUT = Planetarium.GetUniversalTime();
-                            double jumpDelta = capturedRec.StartUT - preJumpUT;
+                            double jumpDelta = capturedTargetUT - preJumpUT;
                             ParsekLog.Info("FastForward",
                                 string.Format(ic,
                                     "Non-flight FF to UT={0:F1} for '{1}' (delta={2:F1}s)",
-                                    capturedRec.StartUT, capturedRec.VesselName, jumpDelta));
-                            TimeJumpManager.ExecuteForwardJump(capturedRec.StartUT);
+                                    capturedTargetUT, capturedRec.VesselName, jumpDelta));
+                            TimeJumpManager.ExecuteForwardJump(capturedTargetUT);
                             ParsekLog.ScreenMessage(
                                 string.Format(ic,
                                     "Fast-forwarded to \"{0}\" ({1:F0}s)",
@@ -4032,6 +4135,35 @@ namespace Parsek
                 return -1;
             var main = committed[mainIdx];
             return main != null && now < main.StartUT ? mainIdx : -1;
+        }
+
+        internal static int FindAggregateFastForwardWatchRecordingIndex(
+            IEnumerable<int> members, IReadOnlyList<Recording> committed, double now, bool isRecording)
+        {
+            if (members == null || committed == null) return -1;
+
+            int bestIdx = -1;
+            double bestUT = double.MaxValue;
+            foreach (int idx in members)
+            {
+                if (idx < 0 || idx >= committed.Count) continue;
+                var rec = committed[idx];
+                if (rec == null || rec.IsDebris) continue;
+
+                double targetUT = ResolveFastForwardWatchTargetUT(rec);
+                string reason;
+                if (!RecordingStore.CanFastForwardToUT(
+                        rec, now, targetUT, out reason, isRecording: isRecording))
+                    continue;
+
+                if (targetUT < bestUT || (targetUT == bestUT && (bestIdx < 0 || idx < bestIdx)))
+                {
+                    bestUT = targetUT;
+                    bestIdx = idx;
+                }
+            }
+
+            return bestIdx;
         }
 
         /// <summary>

--- a/Source/Parsek/UI/TimelineWindowUI.cs
+++ b/Source/Parsek/UI/TimelineWindowUI.cs
@@ -16,7 +16,8 @@ namespace Parsek
         internal enum TimelineWatchButtonAction
         {
             Enter,
-            Exit
+            Exit,
+            FastForwardAndEnter
         }
 
         /// <summary>
@@ -111,12 +112,14 @@ namespace Parsek
                 string tooltip,
                 bool enabled,
                 bool canWatch,
+                bool canFastForwardToWatch,
                 TimelineWatchButtonAction action)
             {
                 Label = label;
                 Tooltip = tooltip;
                 Enabled = enabled;
                 CanWatch = canWatch;
+                CanFastForwardToWatch = canFastForwardToWatch;
                 Action = action;
             }
 
@@ -124,6 +127,7 @@ namespace Parsek
             internal string Tooltip { get; }
             internal bool Enabled { get; }
             internal bool CanWatch { get; }
+            internal bool CanFastForwardToWatch { get; }
             internal TimelineWatchButtonAction Action { get; }
         }
 
@@ -874,20 +878,37 @@ namespace Parsek
                         bool sameBody = recIndex >= 0 && flight.IsGhostOnSameBody(recIndex);
                         bool inRange = recIndex >= 0 && flight.IsGhostWithinVisualRange(recIndex);
                         bool isWatching = recIndex >= 0 && flight.WatchedRecordingIndex == recIndex;
+                        string watchFastForwardReason;
+                        bool canFastForwardToWatch = RecordingsTableUI.ShouldOfferFastForwardWatch(
+                            hasGhost,
+                            CanFastForwardWatchNow(rec, out watchFastForwardReason),
+                            rec.IsDebris);
                         TimelineWatchButtonDescriptor watchButton = BuildWatchButtonDescriptor(
-                            isWatching, hasGhost, sameBody, inRange, rec.IsDebris);
+                            isWatching,
+                            hasGhost,
+                            sameBody,
+                            inRange,
+                            rec.IsDebris,
+                            canFastForwardToWatch);
+                        bool watchAvailable = watchButton.CanWatch || watchButton.CanFastForwardToWatch;
 
                         if (RecordingsTableUI.UpdateWatchButtonTransitionCache(
-                            lastCanWatchByRecId, rec.RecordingId, watchButton.CanWatch))
+                            lastCanWatchByRecId, rec.RecordingId, watchAvailable))
                         {
                             string reason = RecordingsTableUI.GetWatchButtonReason(
-                                watchButton.CanWatch, hasGhost, sameBody, inRange, rec.IsDebris);
+                                watchButton.CanWatch,
+                                hasGhost,
+                                sameBody,
+                                inRange,
+                                rec.IsDebris,
+                                watchButton.CanFastForwardToWatch);
                             string eligibility = recIndex >= 0
                                 ? flight.DescribeWatchEligibilityForLogs(recIndex)
                                 : "watchEval(rec=<missing-index>)";
                             ParsekLog.Info("UI",
                                 $"Timeline watch button \"{rec.VesselName}\" id={rec.RecordingId} {reason} " +
-                                $"(hasGhost={hasGhost} sameBody={sameBody} inRange={inRange} debris={rec.IsDebris}) " +
+                                $"(hasGhost={hasGhost} sameBody={sameBody} inRange={inRange} debris={rec.IsDebris} " +
+                                $"ffWatch={watchButton.CanFastForwardToWatch}) " +
                                 $"{eligibility} {flight.DescribeWatchFocusForLogs()}");
                         }
 
@@ -902,9 +923,14 @@ namespace Parsek
                                 watchButton.Action,
                                 recIndex,
                                 () => flight.ExitWatchMode(),
-                                index => flight.EnterWatchMode(index));
+                                index => flight.EnterWatchMode(index),
+                                () => tableUI.ShowFastForwardConfirmation(
+                                    rec, enterWatchAfterFastForward: true));
+                            string watchAction = watchButton.Action == TimelineWatchButtonAction.FastForwardAndEnter
+                                ? "fast-forward-watch"
+                                : (isWatching ? "exit" : "enter");
                             ParsekLog.Info("UI",
-                                $"Timeline W button clicked: {(isWatching ? "exit" : "enter")} watch on " +
+                                $"Timeline W button clicked: {watchAction} watch on " +
                                 $"\"{rec.VesselName}\" id={rec.RecordingId} before={beforeEligibility} " +
                                 $"beforeFocus={beforeFocus} afterFocus={flight.DescribeWatchFocusForLogs()}");
                         }
@@ -1156,23 +1182,43 @@ namespace Parsek
             return inFlightMode && rec != null;
         }
 
-        internal static TimelineWatchButtonAction GetWatchButtonAction(bool isWatching)
+        internal static TimelineWatchButtonAction GetWatchButtonAction(
+            bool isWatching, bool canFastForwardToWatch = false)
         {
-            return isWatching ? TimelineWatchButtonAction.Exit : TimelineWatchButtonAction.Enter;
+            if (isWatching)
+                return TimelineWatchButtonAction.Exit;
+            return canFastForwardToWatch
+                ? TimelineWatchButtonAction.FastForwardAndEnter
+                : TimelineWatchButtonAction.Enter;
         }
 
         internal static TimelineWatchButtonDescriptor BuildWatchButtonDescriptor(
-            bool isWatching, bool hasGhost, bool sameBody, bool inRange, bool isDebris)
+            bool isWatching,
+            bool hasGhost,
+            bool sameBody,
+            bool inRange,
+            bool isDebris,
+            bool canFastForwardToWatch = false)
         {
+            canFastForwardToWatch = canFastForwardToWatch && !isDebris;
             bool canWatch = RecordingsTableUI.IsWatchButtonEnabled(
                 hasGhost, sameBody, inRange, isDebris);
             return new TimelineWatchButtonDescriptor(
                 isWatching ? "W*" : "W",
                 RecordingsTableUI.GetWatchButtonTooltip(
-                    isWatching, hasGhost, sameBody, inRange, isDebris),
-                RecordingsTableUI.ShouldEnableWatchButton(canWatch, isWatching),
+                    isWatching,
+                    hasGhost,
+                    sameBody,
+                    inRange,
+                    isDebris,
+                    canFastForwardToWatch),
+                RecordingsTableUI.ShouldEnableWatchButton(
+                    canWatch,
+                    isWatching,
+                    canFastForwardToWatch),
                 canWatch,
-                GetWatchButtonAction(isWatching));
+                canFastForwardToWatch,
+                GetWatchButtonAction(isWatching, canFastForwardToWatch));
         }
 
         internal static TimelineFlySealButtonDescriptor BuildFlySealButtonDescriptor(
@@ -1196,10 +1242,13 @@ namespace Parsek
             TimelineWatchButtonAction watchAction,
             int recIndex,
             Action exitWatchMode,
-            Action<int> enterWatchMode)
+            Action<int> enterWatchMode,
+            Action fastForwardAndEnterWatch = null)
         {
             if (watchAction == TimelineWatchButtonAction.Exit)
                 exitWatchMode?.Invoke();
+            else if (watchAction == TimelineWatchButtonAction.FastForwardAndEnter)
+                fastForwardAndEnterWatch?.Invoke();
             else
                 enterWatchMode?.Invoke(recIndex);
         }
@@ -1231,6 +1280,15 @@ namespace Parsek
             double currentUT = 0;
             try { currentUT = Planetarium.GetUniversalTime(); } catch { }
             return CanFastForwardAtCurrentUT(rec, currentUT, out reason);
+        }
+
+        private bool CanFastForwardWatchNow(Recording rec, out string reason)
+        {
+            double currentUT = 0;
+            try { currentUT = Planetarium.GetUniversalTime(); } catch { }
+            bool isRecording = parentUI.InFlightMode && parentUI.Flight != null && parentUI.Flight.IsRecording;
+            return RecordingsTableUI.CanFastForwardWatchAtUT(
+                rec, currentUT, out reason, isRecording: isRecording);
         }
 
         private bool CanFastForwardAtCurrentUT(Recording rec, double currentUT, out string reason)

--- a/Source/Parsek/WatchModeController.cs
+++ b/Source/Parsek/WatchModeController.cs
@@ -751,7 +751,8 @@ namespace Parsek
         {
             var ghostStates = host.Engine.ghostStates;
             GhostPlaybackState state;
-            bool hasGhost = ghostStates.TryGetValue(index, out state) && state != null && state.ghost != null;
+            bool hasGhost = ghostStates.TryGetValue(index, out state) && state != null;
+            bool hasGhostObject = hasGhost && state.ghost != null;
             string ghostBody = hasGhost ? (state.lastInterpolatedBodyName ?? "null") : "null";
             string activeBodyName = FlightGlobals.ActiveVessel?.mainBody?.name;
             string activeBody = activeBodyName ?? "null";
@@ -766,7 +767,7 @@ namespace Parsek
 
             return
                 $"watchEval(rec=#{index} watched={isWatched} watchedIndex={watchedRecordingIndex} " +
-                $"hasGhost={hasGhost} ghostActive={(hasGhost && state.ghost.activeSelf)} zone={zone} " +
+                $"hasGhost={hasGhost} ghostObject={hasGhostObject} ghostActive={(hasGhostObject && state.ghost.activeSelf)} zone={zone} " +
                 $"dist={FormatWatchDistanceForLogs(distMeters)} " +
                 $"enterCutoff={(WatchEnterCutoffMeters / 1000f).ToString("F0", CultureInfo.InvariantCulture)}km " +
                 $"exitCutoff={(WatchExitCutoffMeters / 1000f).ToString("F0", CultureInfo.InvariantCulture)}km " +

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -23,6 +23,18 @@ When referencing prior item numbers from source comments or plans, consult the r
 
 ---
 
+## Done - v0.9.1 Watch unavailable after rewind before ghost activation
+
+- ~~After rewinding to a launch and reloading into the lead-in window, the Recordings table and Timeline showed `W` as unavailable for future recordings until playback time reached each ghost's activation UT.~~ Source: `logs/2026-05-04_1817`. The post-rewind session loaded around UT `3.64` with `active=0`, while the next watchable ghosts were still future (`Kerbal X Probe` at UT `55.840`, `Jebediah Kerman` at UT `232.933`). UI transition logs therefore reported `disabled (no ghost)`, and the group Watch button reported no watchable vessels, even though the row already had a valid Fast Forward route. The eligibility log also made this harder to read because `DescribeWatchEligibilityForLogs` used `hasGhost` to mean "visual GameObject exists", while the actual Watch gate treats a `GhostPlaybackState` as active even when hidden-tier visuals are unloaded.
+
+**Fix:** row, group, and Timeline Watch buttons now offer a `fast-forward + deferred Watch` route when the recording's ghost activation start is future, non-debris, and the usual FF runtime guards pass but no active ghost state exists yet. The click reuses the Fast Forward confirmation, targets `ResolveGhostActivationStartUT` rather than the recording's wider semantic `StartUT`, then arms the existing `pendingWatchAfterFFId` handoff so Watch entry happens after the engine has spawned and positioned the target ghost at the new UT. A later valid fast-forward supersedes and clears any older deferred Watch target before arming a fresh one if the new action needs it. Group Watch falls back to the earliest future non-debris descendant only when there are no directly watchable descendants, and no longer advances its rotation cursor until the player actually enters Watch. Watch transition logs now include `ffWatch`, and eligibility logs report both `hasGhost` (playback state) and `ghostObject` (loaded visual).
+
+**Coverage:** `RecordingsTableUITests` for FF+Watch availability/reason/tooltip and aggregate future-target selection, `TimelineWindowUITests` for the new FastForwardAndEnter action, plus focused UI/playback xUnit validation.
+
+**Status:** CLOSED 2026-05-04.
+
+---
+
 ## Done - v0.9.1 pending-tree cleanup view for Re-Fly restore
 
 - ~~After Rewind + Watch, re-entering a spawned Re-Fly vessel could leave the Recordings window showing zero rows until the deferred merge dialog restored the mission tree, and that pending-tree window could also drop supersede rows and auto-generated group hierarchy.~~ Source: `logs/2026-05-03_0059_newest`. Runtime trace: `TryTakeCommittedTreeForSpawnedVesselRestore` detached the 13-recording `Kerbal X` tree from `CommittedTrees` / `CommittedRecordings` so the active vessel could own it again, then `OnSave` wrote `0 committed recordings` plus an `ACTIVE` tree. On the following KSC load, `TryRestoreActiveTreeNode` kept the in-memory finalized pending tree and skipped `.sfs` replacement, but `LoadTimeSweep.SweepOrphanSupersedes` still checked only committed recordings and removed a valid supersede relation as fully orphaned. The group hierarchy prune had the same committed-only view, so it could treat pending-tree-only mission/debris groups as stale.


### PR DESCRIPTION
## Summary
- keep row, group, and Timeline Watch buttons actionable for future inactive recordings by routing through Fast Forward plus deferred Watch
- target FF plus Watch at the first ghost activation UT, not the recording's wider semantic StartUT, so widened ExplicitStartUT lead-in gaps enter Watch reliably
- clear stale deferred Watch handoffs when a later valid fast-forward supersedes them
- clarify Watch eligibility logs by separating playback state hasGhost from loaded visual object ghostObject
- document the log-package root cause in CHANGELOG and known-bugs notes

## Review Follow-up
- addressed item 1: confirmation logs now report the resolved FF plus Watch target UT
- addressed item 2: each valid fast-forward clears any older pending Watch handoff before arming the current one if needed
- addressed item 3: group aggregate FF plus Watch computes activation UT once per candidate
- confirmed item 4 as intended: group FF plus Watch is an aggregate fallback only when no descendant is directly watchable
- prior GPT-5.5 xhigh narrow re-review found no remaining actionable findings before this additional review pass

## Validation
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter RecordingsTableUITests|TimelineWindowUITests|FastForwardTests|FlightPlaybackExplainabilityTests (189/189 passed)
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter FullyQualifiedName!~InjectAllRecordings (10697/10697 passed)
- dotnet build Source/Parsek.Tests/Parsek.Tests.csproj --no-restore (passed)

## Note
- Full unfiltered dotnet test remains blocked by the running KSP instance locking KSP.log / deployed Parsek files; InjectAllRecordings refuses to purge live save recording sidecars as designed.