### PR TITLE
Show merge confirmation dialog before leaving flight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,22 @@ All notable changes to Parsek are documented here.
 
 ### Enhancements
 
+- The "Merge to Timeline / Discard" tree-recording confirmation dialog now appears while the player is still in flight, before the destination scene loads. Quit-to-Main-Menu shows the dialog too (previously force-auto-merged). Re-Fly sessions show Re-Fly-attempt-scoped button labels and a session-scoped body. Stock danger / quit confirmations still run first.
+
 ### Internals
 
+- New `SceneExitInterceptor` Harmony Prefix on `HighLogic.LoadScene(GameScenes)` (HarmonyPriority.Last). Single chokepoint that catches PauseMenu's `saveAndExit`, PauseMenu's CanRestart no-save, and FlightResultsDialog's KSC/Menu/TS direct LoadScene paths. Decision matrix is pure for unit-testability.
+- New `MergeDialog.ShowTreeDialog(tree, labels, preCommitFinalize, postChoice)` overload. Decision-building (`BuildDefaultVesselDecisions`) runs AFTER `preCommitFinalize` so `CanPersistVessel` reads finalized `TerminalStateValue` rather than the live activeTree's null values.
+- New `MergeDialog.MergeDiscardWithResult` returns `bool` so the pre-transition wrapper can detect a refused discard (merge-journal-active guard) and skip the LoadScene re-invoke - keeping the player in flight.
+- `MergeDialog.MergeDiscard` and `MergeDialog.TryDiscardActiveReFlyAttempt` now refuse defensively when `ParsekScenario.ActiveMergeJournal != null`, mirroring `RevertInterceptor.DiscardReFlyHandler`'s long-standing guard. Closes a pre-existing race against the journal finisher.
+- New `VesselSpawner.BackfillMaxDistanceAbsoluteOnly` filters to Absolute-frame TrackSection points so the live idle-on-pad fast path doesn't misread RELATIVE-frame `lat/lon/alt` (which are anchor-local Cartesian metres) as body-fixed coordinates.
+- `RecordingStore.NextTreeSceneExitCommitSuppressionArmedForTesting` renamed to `IsNextTreeSceneExitCommitSuppressionArmed` - the flag is no longer test-only.
+- The deferred post-load merge dialog coroutine (`ParsekScenario.ShowDeferredMergeDialog`) now logs a Warn canary on entry. Triggers indicate the pre-transition prefix missed a flight-exit (mod compat, KSP version drift).
+
 ### Tests
+
+- New `SceneExitInterceptorTests` covering the decision matrix and `SafeWritePersistent` test seam.
+- New journal-active-guard tests for `MergeDiscard`, `MergeDiscardWithResult`, and `TryDiscardActiveReFlyAttempt`.
 
 ---
 

--- a/Source/Parsek.Tests/MergeDialogResourcesAppliedTests.cs
+++ b/Source/Parsek.Tests/MergeDialogResourcesAppliedTests.cs
@@ -1133,5 +1133,126 @@ namespace Parsek.Tests
             Assert.Contains(logLines, l =>
                 l.Contains("[MergeDialog]") && l.Contains("MergeDiscard") && l.Contains("null"));
         }
+
+        // ================================================================
+        // 7. Merge-journal-active discard guard (Opus pass-6 P1.C)
+        // ================================================================
+
+        [Fact]
+        public void MergeDiscardWithResult_JournalActive_RefusesAndReturnsFalse()
+        {
+            var rec = MakeRecording("rec-journal-discard", "tree-journal-discard", 100.0, 200.0);
+            var tree = MakeTree("tree-journal-discard", "rec-journal-discard", rec);
+            RecordingStore.StashPendingTree(tree);
+
+            var scenario = new ParsekScenario
+            {
+                RecordingSupersedes = new List<RecordingSupersedeRelation>(),
+                LedgerTombstones = new List<LedgerTombstone>(),
+                RewindPoints = new List<RewindPoint>(),
+                ActiveMergeJournal = new MergeJournal
+                {
+                    JournalId = "journal_test",
+                    SessionId = "sess_test",
+                    Phase = MergeJournal.Phases.Supersede,
+                },
+            };
+            ParsekScenario.SetInstanceForTesting(scenario);
+
+            bool result = MergeDialog.MergeDiscardWithResult(tree);
+
+            Assert.False(result);
+            // Pending tree must remain stashed - the refusal is a no-op
+            // for state.
+            Assert.True(RecordingStore.HasPendingTree);
+            // Journal stays armed - we did NOT clobber it.
+            Assert.NotNull(scenario.ActiveMergeJournal);
+            Assert.Equal("journal_test", scenario.ActiveMergeJournal.JournalId);
+            // Refusal logs and screen message.
+            Assert.Contains(logLines, l =>
+                l.Contains("[MergeDialog]") && l.Contains("MergeDiscard")
+                && l.Contains("merge journal active"));
+        }
+
+        [Fact]
+        public void MergeDiscard_JournalActive_RefusesAndDoesNotClobberJournal()
+        {
+            // Same scenario via the void overload (post-load deferred path).
+            var rec = MakeRecording("rec-journal-discard-void", "tree-journal-discard-void", 100.0, 200.0);
+            var tree = MakeTree("tree-journal-discard-void", "rec-journal-discard-void", rec);
+            RecordingStore.StashPendingTree(tree);
+
+            var scenario = new ParsekScenario
+            {
+                RecordingSupersedes = new List<RecordingSupersedeRelation>(),
+                LedgerTombstones = new List<LedgerTombstone>(),
+                RewindPoints = new List<RewindPoint>(),
+                ActiveMergeJournal = new MergeJournal
+                {
+                    JournalId = "journal_test_void",
+                    SessionId = "sess_test_void",
+                    Phase = MergeJournal.Phases.Supersede,
+                },
+            };
+            ParsekScenario.SetInstanceForTesting(scenario);
+
+            MergeDialog.MergeDiscard(tree);
+
+            Assert.True(RecordingStore.HasPendingTree);
+            Assert.NotNull(scenario.ActiveMergeJournal);
+        }
+
+        [Fact]
+        public void TryDiscardActiveReFlyAttempt_JournalActive_RefusesAndReturnsFalse()
+        {
+            // Direct call (test bypass / future caller). The MergeDiscard
+            // gate above is the primary guard; this is belt-and-braces.
+            var rec = MakeRecording("rec-journal-refly", "tree-journal-refly", 100.0, 200.0);
+            var tree = MakeTree("tree-journal-refly", "rec-journal-refly", rec);
+
+            var marker = MakeMarker(
+                "sess-journal-refly",
+                "tree-journal-refly",
+                "rec-journal-refly",
+                "rec-journal-origin");
+            var scenario = new ParsekScenario
+            {
+                RecordingSupersedes = new List<RecordingSupersedeRelation>(),
+                LedgerTombstones = new List<LedgerTombstone>(),
+                RewindPoints = new List<RewindPoint>(),
+                ActiveReFlySessionMarker = marker,
+                ActiveMergeJournal = new MergeJournal
+                {
+                    JournalId = "journal_refly",
+                    SessionId = "sess-journal-refly",
+                    Phase = MergeJournal.Phases.Supersede,
+                },
+            };
+            ParsekScenario.SetInstanceForTesting(scenario);
+
+            bool result = MergeDialog.TryDiscardActiveReFlyAttempt(tree);
+
+            Assert.False(result);
+            Assert.NotNull(scenario.ActiveMergeJournal);
+            Assert.NotNull(scenario.ActiveReFlySessionMarker);
+            Assert.Contains(logLines, l =>
+                l.Contains("[MergeDialog]") && l.Contains("TryDiscardActiveReFlyAttempt")
+                && l.Contains("merge journal active"));
+        }
+
+        [Fact]
+        public void MergeDiscardWithResult_NormalDiscard_ReturnsTrue()
+        {
+            // Sanity: bool overload returns true on the normal path so
+            // the pre-transition wrapper proceeds with postChoice.
+            var rec = MakeRecording("rec-normal-discard", "tree-normal-discard", 100.0, 200.0);
+            var tree = MakeTree("tree-normal-discard", "rec-normal-discard", rec);
+            RecordingStore.StashPendingTree(tree);
+
+            bool result = MergeDialog.MergeDiscardWithResult(tree);
+
+            Assert.True(result);
+            Assert.False(RecordingStore.HasPendingTree);
+        }
     }
 }

--- a/Source/Parsek.Tests/ReFlyRevertDialogTests.cs
+++ b/Source/Parsek.Tests/ReFlyRevertDialogTests.cs
@@ -309,7 +309,7 @@ namespace Parsek.Tests
 
             RevertInterceptor.DiscardReFlyHandler(marker, RevertTarget.Launch);
 
-            Assert.False(RecordingStore.NextTreeSceneExitCommitSuppressionArmedForTesting);
+            Assert.False(RecordingStore.IsNextTreeSceneExitCommitSuppressionArmed);
             Assert.False(RecordingStore.NextActiveTreeRestoreSuppressionArmedForTesting);
         }
 
@@ -328,7 +328,7 @@ namespace Parsek.Tests
 
             Assert.Equal(1, caps.LoadGameCalls);
             Assert.Equal(0, caps.SceneCalls);
-            Assert.False(RecordingStore.NextTreeSceneExitCommitSuppressionArmedForTesting);
+            Assert.False(RecordingStore.IsNextTreeSceneExitCommitSuppressionArmed);
             Assert.False(RecordingStore.NextActiveTreeRestoreSuppressionArmedForTesting);
             Assert.Contains(logLines, l =>
                 l.Contains("[ReFlySession]")
@@ -348,11 +348,11 @@ namespace Parsek.Tests
             RecordingStore.ArmNextTreeSceneExitCommitSuppression(
                 "discardReFly sess=sess_guard target=Launch facility=--");
 
-            Assert.True(RecordingStore.NextTreeSceneExitCommitSuppressionArmedForTesting);
+            Assert.True(RecordingStore.IsNextTreeSceneExitCommitSuppressionArmed);
             Assert.True(RecordingStore.TryConsumeNextTreeSceneExitCommitSuppression(
                 GameScenes.SPACECENTER, out string reason));
             Assert.Contains("discardReFly", reason);
-            Assert.False(RecordingStore.NextTreeSceneExitCommitSuppressionArmedForTesting);
+            Assert.False(RecordingStore.IsNextTreeSceneExitCommitSuppressionArmed);
             Assert.False(RecordingStore.TryConsumeNextTreeSceneExitCommitSuppression(
                 GameScenes.SPACECENTER, out _));
         }
@@ -386,7 +386,7 @@ namespace Parsek.Tests
             flight.FinalizeTreeOnSceneChangeForTesting(GameScenes.SPACECENTER, 123.4);
 
             Assert.False(RecordingStore.HasPendingTree);
-            Assert.False(RecordingStore.NextTreeSceneExitCommitSuppressionArmedForTesting);
+            Assert.False(RecordingStore.IsNextTreeSceneExitCommitSuppressionArmed);
             Assert.Null(GetPrivateField<RecordingTree>(flight, "activeTree"));
             Assert.True(activeRecording.FilesDirty,
                 "Suppressed discard must not flush dirty sidecar state.");

--- a/Source/Parsek.Tests/SceneExitInterceptorTests.cs
+++ b/Source/Parsek.Tests/SceneExitInterceptorTests.cs
@@ -237,5 +237,66 @@ namespace Parsek.Tests
             bool result = SceneExitInterceptor.SafeWritePersistent(GameScenes.SPACECENTER);
             Assert.False(result);
         }
+
+        // ---------- TryAutoDiscardIdleActiveTree -----------------------
+
+        [Fact]
+        public void TryAutoDiscardIdleActiveTree_NullFlight_ReturnsFalse()
+        {
+            bool result = SceneExitInterceptor.TryAutoDiscardIdleActiveTree(
+                GameScenes.SPACECENTER, flight: null);
+            Assert.False(result);
+        }
+
+        // ---------- BackfillMaxDistanceAbsoluteOnly --------------------
+
+        [Fact]
+        public void BackfillMaxDistanceAbsoluteOnly_NullRecording_ReturnsCleanly()
+        {
+            // No exception expected.
+            VesselSpawner.BackfillMaxDistanceAbsoluteOnly(null);
+        }
+
+        [Fact]
+        public void BackfillMaxDistanceAbsoluteOnly_NullTrackSections_ReturnsCleanly()
+        {
+            var rec = new Recording { RecordingId = "rec-null-ts" };
+            rec.TrackSections = null;
+            // Should not throw, should not write MaxDistanceFromLaunch.
+            VesselSpawner.BackfillMaxDistanceAbsoluteOnly(rec);
+            Assert.Equal(0.0, rec.MaxDistanceFromLaunch);
+        }
+
+        [Fact]
+        public void BackfillMaxDistanceAbsoluteOnly_EmptyTrackSections_LeavesMaxDistanceUntouched()
+        {
+            var rec = new Recording { RecordingId = "rec-empty-ts" };
+            rec.MaxDistanceFromLaunch = 42.5;   // pre-existing value
+            VesselSpawner.BackfillMaxDistanceAbsoluteOnly(rec);
+            // Empty TrackSections list -> no Absolute frames found -> no
+            // write to MaxDistanceFromLaunch (preserves prior value).
+            Assert.Equal(42.5, rec.MaxDistanceFromLaunch);
+        }
+
+        [Fact]
+        public void BackfillMaxDistanceAbsoluteOnly_AllRelativeSections_LeavesMaxDistanceUntouched()
+        {
+            var rec = new Recording { RecordingId = "rec-relative-only" };
+            rec.MaxDistanceFromLaunch = 99.9;
+            rec.TrackSections = new List<TrackSection>
+            {
+                new TrackSection
+                {
+                    referenceFrame = ReferenceFrame.Relative,
+                    frames = new List<TrajectoryPoint>
+                    {
+                        new TrajectoryPoint { latitude = 1.0, longitude = 2.0, altitude = 3.0, bodyName = "Kerbin" },
+                    },
+                },
+            };
+            VesselSpawner.BackfillMaxDistanceAbsoluteOnly(rec);
+            // Only RELATIVE sections -> no Absolute frames -> no write.
+            Assert.Equal(99.9, rec.MaxDistanceFromLaunch);
+        }
     }
 }

--- a/Source/Parsek.Tests/SceneExitInterceptorTests.cs
+++ b/Source/Parsek.Tests/SceneExitInterceptorTests.cs
@@ -1,0 +1,241 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Unit tests for the pre-transition merge confirmation gate
+    /// (<see cref="SceneExitInterceptor"/>) covering:
+    ///
+    /// <list type="bullet">
+    ///   <item>The pure <see cref="SceneExitInterceptor.ShouldShowDialogBeforeSceneChange"/> decision matrix.</item>
+    ///   <item>The <see cref="SceneExitInterceptor.s_AllowNextLoadScene"/> + destination-match watchdog.</item>
+    ///   <item>The <see cref="SceneExitInterceptor.SafeWritePersistent"/> save-failure-on-MAINMENU hard-block contract via the test seam.</item>
+    /// </list>
+    ///
+    /// <para>The Harmony prefix itself, the <see cref="MergeDialog.ShowTreeDialog"/>
+    /// PopupDialog spawn, and the live-state wrapper
+    /// <c>ShouldShowDialogBeforeSceneChangeLive</c> all touch
+    /// <see cref="FlightGlobals"/> / <see cref="HighLogic"/> singletons
+    /// that are unavailable in xUnit. Those layers are exercised via the
+    /// in-game test runner (RuntimeTests).</para>
+    /// </summary>
+    [Collection("Sequential")]
+    public class SceneExitInterceptorTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+        private readonly bool priorParsekLogSuppress;
+        private readonly bool priorStoreSuppress;
+
+        public SceneExitInterceptorTests()
+        {
+            priorParsekLogSuppress = ParsekLog.SuppressLogging;
+            priorStoreSuppress = RecordingStore.SuppressLogging;
+
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            RecordingStore.SuppressLogging = true;
+            ParsekLog.VerboseOverrideForTesting = true;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+
+            RecordingStore.ResetForTesting();
+            ParsekScenario.ResetInstanceForTesting();
+            SceneExitInterceptor.ResetTestOverrides();
+        }
+
+        public void Dispose()
+        {
+            SceneExitInterceptor.ResetTestOverrides();
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = priorParsekLogSuppress;
+            RecordingStore.SuppressLogging = priorStoreSuppress;
+            RecordingStore.ResetForTesting();
+            ParsekScenario.ResetInstanceForTesting();
+        }
+
+        // ---------- Decision helper matrix ------------------------------
+
+        [Fact]
+        public void Decision_NoActiveTree_ReturnsNone()
+        {
+            var v = SceneExitInterceptor.ShouldShowDialogBeforeSceneChange(
+                GameScenes.SPACECENTER,
+                hasActiveTree: false,
+                reFlyActive: false,
+                isAutoMerge: false,
+                activeVesselLandedOrSplashed: false);
+            Assert.Equal(SceneExitInterceptor.DialogVariant.None, v);
+        }
+
+        [Fact]
+        public void Decision_AutoMergeOff_AnyDest_ReturnsRegularMerge()
+        {
+            foreach (var dest in new[]
+                     {
+                         GameScenes.SPACECENTER,
+                         GameScenes.TRACKSTATION,
+                         GameScenes.MAINMENU,
+                         GameScenes.EDITOR,
+                     })
+            {
+                var v = SceneExitInterceptor.ShouldShowDialogBeforeSceneChange(
+                    dest,
+                    hasActiveTree: true,
+                    reFlyActive: false,
+                    isAutoMerge: false,
+                    activeVesselLandedOrSplashed: false);
+                Assert.Equal(SceneExitInterceptor.DialogVariant.RegularMerge, v);
+            }
+        }
+
+        [Fact]
+        public void Decision_AutoMergeOn_LandedAtKsc_ReturnsRegularMerge()
+        {
+            var v = SceneExitInterceptor.ShouldShowDialogBeforeSceneChange(
+                GameScenes.SPACECENTER,
+                hasActiveTree: true,
+                reFlyActive: false,
+                isAutoMerge: true,
+                activeVesselLandedOrSplashed: true);
+            Assert.Equal(SceneExitInterceptor.DialogVariant.RegularMerge, v);
+        }
+
+        [Fact]
+        public void Decision_AutoMergeOn_LandedAtTs_ReturnsRegularMerge()
+        {
+            var v = SceneExitInterceptor.ShouldShowDialogBeforeSceneChange(
+                GameScenes.TRACKSTATION,
+                hasActiveTree: true,
+                reFlyActive: false,
+                isAutoMerge: true,
+                activeVesselLandedOrSplashed: true);
+            Assert.Equal(SceneExitInterceptor.DialogVariant.RegularMerge, v);
+        }
+
+        [Fact]
+        public void Decision_AutoMergeOn_NotLandedAtKsc_ReturnsNone()
+        {
+            var v = SceneExitInterceptor.ShouldShowDialogBeforeSceneChange(
+                GameScenes.SPACECENTER,
+                hasActiveTree: true,
+                reFlyActive: false,
+                isAutoMerge: true,
+                activeVesselLandedOrSplashed: false);
+            Assert.Equal(SceneExitInterceptor.DialogVariant.None, v);
+        }
+
+        [Fact]
+        public void Decision_AutoMergeOn_MainMenu_AlwaysReturnsRegularMerge()
+        {
+            // Behaviour change: previously force-auto-merged silently. New
+            // pre-transition path always shows the dialog so player can
+            // choose to keep or discard before the game unloads.
+            var v = SceneExitInterceptor.ShouldShowDialogBeforeSceneChange(
+                GameScenes.MAINMENU,
+                hasActiveTree: true,
+                reFlyActive: false,
+                isAutoMerge: true,
+                activeVesselLandedOrSplashed: false);
+            Assert.Equal(SceneExitInterceptor.DialogVariant.RegularMerge, v);
+        }
+
+        [Fact]
+        public void Decision_ReFlyActive_ReturnsReFlyAttempt_AnyAutoMerge()
+        {
+            foreach (bool autoMerge in new[] { true, false })
+            {
+                var v = SceneExitInterceptor.ShouldShowDialogBeforeSceneChange(
+                    GameScenes.SPACECENTER,
+                    hasActiveTree: true,
+                    reFlyActive: true,
+                    isAutoMerge: autoMerge,
+                    activeVesselLandedOrSplashed: false);
+                Assert.Equal(SceneExitInterceptor.DialogVariant.ReFlyAttempt, v);
+            }
+        }
+
+        [Fact]
+        public void Decision_AutoMergeOn_NotLandedAtKsc_ReFlyActive_OverridesToReFlyAttempt()
+        {
+            // Re-Fly check fires before the autoMerge gate.
+            var v = SceneExitInterceptor.ShouldShowDialogBeforeSceneChange(
+                GameScenes.SPACECENTER,
+                hasActiveTree: true,
+                reFlyActive: true,
+                isAutoMerge: true,
+                activeVesselLandedOrSplashed: false);
+            Assert.Equal(SceneExitInterceptor.DialogVariant.ReFlyAttempt, v);
+        }
+
+        // ---------- Token-bypass watchdog -------------------------------
+
+        [Fact]
+        public void Token_NotArmed_DefaultIsLOADING()
+        {
+            // ResetTestOverrides clears to LOADING sentinel.
+            Assert.False(SceneExitInterceptor.s_AllowNextLoadScene);
+            Assert.Equal(GameScenes.LOADING, SceneExitInterceptor.s_AllowNextLoadSceneDestination);
+        }
+
+        [Fact]
+        public void BuildPostChoice_ArmsTokenWithDestination()
+        {
+            // Stub the save call so we don't touch GamePersistence.
+            SceneExitInterceptor.SafeWritePersistentForTesting = _ => true;
+
+            var postChoice = SceneExitInterceptor.BuildPostChoice(GameScenes.SPACECENTER);
+            Assert.NotNull(postChoice);
+
+            // Invoking postChoice would normally call HighLogic.LoadScene,
+            // which is unavailable in xUnit. We can't run the lambda
+            // directly. Instead verify the closure captured the destination
+            // by checking the field BEFORE invocation - it should still be
+            // LOADING (token only set inside the lambda right before
+            // LoadScene). This test asserts BuildPostChoice does not arm
+            // the token eagerly.
+            Assert.False(SceneExitInterceptor.s_AllowNextLoadScene);
+            Assert.Equal(GameScenes.LOADING, SceneExitInterceptor.s_AllowNextLoadSceneDestination);
+        }
+
+        // ---------- SafeWritePersistent test seam -----------------------
+
+        [Fact]
+        public void SafeWritePersistent_TestSeam_Success_ReturnsTrue()
+        {
+            int callCount = 0;
+            GameScenes? capturedDest = null;
+            SceneExitInterceptor.SafeWritePersistentForTesting = dest =>
+            {
+                callCount++;
+                capturedDest = dest;
+                return true;
+            };
+
+            bool result = SceneExitInterceptor.SafeWritePersistent(GameScenes.MAINMENU);
+            Assert.True(result);
+            Assert.Equal(1, callCount);
+            Assert.Equal(GameScenes.MAINMENU, capturedDest);
+        }
+
+        [Fact]
+        public void SafeWritePersistent_TestSeam_FailureOnMainMenu_ReturnsFalse()
+        {
+            SceneExitInterceptor.SafeWritePersistentForTesting = _ => false;
+            bool result = SceneExitInterceptor.SafeWritePersistent(GameScenes.MAINMENU);
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void SafeWritePersistent_TestSeam_FailureOnKsc_ReturnsFalseFromSeam()
+        {
+            // The test seam is authoritative: whatever it returns, that's
+            // what SafeWritePersistent returns. The MAINMENU-specific
+            // hard-block logic lives only in the production path. The
+            // seam itself replicates whichever contract the test wants.
+            SceneExitInterceptor.SafeWritePersistentForTesting = _ => false;
+            bool result = SceneExitInterceptor.SafeWritePersistent(GameScenes.SPACECENTER);
+            Assert.False(result);
+        }
+    }
+}

--- a/Source/Parsek/MergeDialog.cs
+++ b/Source/Parsek/MergeDialog.cs
@@ -22,6 +22,18 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Selects the button label / dialog title copy for the
+        /// pre-transition <see cref="ShowTreeDialog"/> overload.
+        /// </summary>
+        internal enum MergeDialogButtonLabels
+        {
+            /// <summary>"Merge to Timeline" / "Discard"</summary>
+            Default,
+            /// <summary>"Merge Re-Fly to Timeline" / "Discard Re-Fly attempt"</summary>
+            ReFlyAttempt,
+        }
+
+        /// <summary>
         /// Fired after a tree is committed via the merge dialog.
         /// ParsekFlight subscribes to re-evaluate ghost chains.
         /// </summary>
@@ -229,6 +241,232 @@ namespace Parsek
             }
         }
 
+        /// <summary>
+        /// Pre-transition merge dialog overload (Issue: scene-exit confirmation
+        /// in flight). Shows the dialog while the player is still in flight,
+        /// before <c>HighLogic.LoadScene</c> completes. The button handler runs
+        /// <paramref name="preCommitFinalize"/> -> <see cref="MergeCommit"/> /
+        /// <see cref="MergeDiscard"/> -> <paramref name="postChoice"/> in
+        /// order. Decision-building happens AFTER
+        /// <paramref name="preCommitFinalize"/> has stashed the pending tree
+        /// so <see cref="CanPersistVessel"/> reads finalized
+        /// <c>TerminalStateValue</c> rather than the live activeTree's null
+        /// values.
+        ///
+        /// <para>If <see cref="MergeDiscard"/> refuses because of an active
+        /// merge journal (<see cref="ParsekScenario.ActiveMergeJournal"/>),
+        /// <paramref name="postChoice"/> is NOT invoked - the player remains
+        /// in flight and the prefix's blocked LoadScene stays blocked.</para>
+        /// </summary>
+        internal static void ShowTreeDialog(
+            RecordingTree liveTree,
+            MergeDialogButtonLabels labels,
+            System.Action preCommitFinalize,
+            System.Action postChoice)
+        {
+            if (liveTree == null)
+            {
+                ParsekLog.Warn("MergeDialog", "ShowTreeDialog (pre-transition): liveTree is null");
+                return;
+            }
+
+            // Display-only data computed from the live tree. Vessel name,
+            // duration, and Re-Fly recording lookup are safe to read pre-finalize.
+            var reFlyScenario = ParsekScenario.Instance;
+            ReFlySessionMarker marker =
+                !object.ReferenceEquals(null, reFlyScenario)
+                    ? reFlyScenario.ActiveReFlySessionMarker
+                    : null;
+            string title;
+            string message;
+            string mergeLabel;
+            string discardLabel;
+            if (labels == MergeDialogButtonLabels.ReFlyAttempt)
+            {
+                title = "Re-Fly attempt - leaving flight";
+                mergeLabel = "Merge Re-Fly to Timeline";
+                discardLabel = "Discard Re-Fly attempt";
+                Recording reFlyRec = marker != null
+                    ? FindReFlyRecording(marker, liveTree)
+                    : null;
+                string vesselLabel = reFlyRec != null
+                    ? (reFlyRec.VesselName ?? liveTree.TreeName ?? "<unnamed>")
+                    : (liveTree.TreeName ?? "<unnamed>");
+                double reFlyDuration = reFlyRec != null
+                    ? System.Math.Max(0.0, reFlyRec.EndUT - reFlyRec.StartUT)
+                    : ComputeTreeDurationRange(liveTree);
+                message = $"<align=\"center\">{vesselLabel} - {FormatDuration(reFlyDuration)}</align>\n\n" +
+                          "<align=\"left\">Commit this Re-Fly attempt permanently to the timeline. " +
+                          "This cannot be undone.</align>";
+            }
+            else
+            {
+                title = "Confirm Merge to Timeline";
+                mergeLabel = "Merge to Timeline";
+                discardLabel = "Discard";
+                double duration = ComputeTreeDurationRange(liveTree);
+                message = $"{liveTree.TreeName} - {FormatDuration(duration)}";
+            }
+
+            ParsekLog.Info("MergeDialog",
+                $"Pre-transition tree merge dialog: tree='{liveTree.TreeName}', " +
+                $"recordings={liveTree.Recordings.Count}, labels={labels}");
+
+            // Hide Discard at button-build time when a merge journal is
+            // active (mirrors ReFlyRevertDialog's button gate). Handler
+            // refusal is the load-bearing safety check; this is just UX.
+            bool journalActive =
+                !object.ReferenceEquals(null, reFlyScenario)
+                && reFlyScenario.ActiveMergeJournal != null;
+
+            DialogGUIButton[] buttons = journalActive
+                ? new[]
+                  {
+                      new DialogGUIButton(mergeLabel, () => RunPreTransitionAction(
+                          isMerge: true,
+                          preCommitFinalize: preCommitFinalize,
+                          postChoice: postChoice)),
+                  }
+                : new[]
+                  {
+                      new DialogGUIButton(mergeLabel, () => RunPreTransitionAction(
+                          isMerge: true,
+                          preCommitFinalize: preCommitFinalize,
+                          postChoice: postChoice)),
+                      new DialogGUIButton(discardLabel, () => RunPreTransitionAction(
+                          isMerge: false,
+                          preCommitFinalize: preCommitFinalize,
+                          postChoice: postChoice)),
+                  };
+
+            PopupDialog.DismissPopup(DialogName);
+            LockInput();
+            ParsekScenario.MergeDialogPending = true;
+            PopupDialog popup = PopupDialog.SpawnPopupDialog(
+                new Vector2(0.5f, 0.5f),
+                new Vector2(0.5f, 0.5f),
+                new MultiOptionDialog(
+                    DialogName,
+                    message,
+                    title,
+                    HighLogic.UISkin,
+                    buttons
+                ),
+                false,
+                HighLogic.UISkin
+            );
+            if (popup != null)
+            {
+                popup.OnDismiss += () =>
+                {
+                    ClearPendingFlag("popup teardown");
+                };
+            }
+            else
+            {
+                ClearPendingFlag("popup spawn returned null");
+                ParsekLog.Warn("MergeDialog",
+                    $"ShowTreeDialog (pre-transition): SpawnPopupDialog returned null for tree='{liveTree.TreeName}'");
+            }
+        }
+
+        /// <summary>
+        /// Pre-transition button-handler core: run preCommitFinalize, then
+        /// build decisions on the just-stashed pending tree, then run
+        /// MergeCommit / MergeDiscard. Skip postChoice if the action
+        /// refused (journal-active guard).
+        /// </summary>
+        private static void RunPreTransitionAction(
+            bool isMerge,
+            System.Action preCommitFinalize,
+            System.Action postChoice)
+        {
+            try
+            {
+                preCommitFinalize?.Invoke();
+            }
+            catch (System.Exception ex)
+            {
+                ParsekLog.Error("MergeDialog",
+                    $"RunPreTransitionAction: preCommitFinalize threw " +
+                    $"{ex.GetType().Name}: {ex.Message}");
+                return;
+            }
+
+            var pending = RecordingStore.PendingTree;
+            if (pending == null)
+            {
+                ParsekLog.Warn("MergeDialog",
+                    "RunPreTransitionAction: preCommitFinalize produced no pending tree, " +
+                    "skipping commit/discard but proceeding with postChoice");
+                postChoice?.Invoke();
+                return;
+            }
+
+            // Re-derive Re-Fly suppressed-subtree closure on the pending tree,
+            // mirroring the live-path setup in the legacy ShowTreeDialog above.
+            HashSet<string> suppressedIds = null;
+            string activeReFlyTargetId = null;
+            var scenario = ParsekScenario.Instance;
+            ReFlySessionMarker marker =
+                !object.ReferenceEquals(null, scenario)
+                    ? scenario.ActiveReFlySessionMarker
+                    : null;
+            if (marker != null)
+            {
+                activeReFlyTargetId = marker.ActiveReFlyRecordingId;
+                try
+                {
+                    var closure = EffectiveState.ComputeSessionSuppressedSubtree(marker);
+                    if (closure != null && closure.Count > 0)
+                        suppressedIds = new HashSet<string>(closure, System.StringComparer.Ordinal);
+                }
+                catch (System.Exception ex)
+                {
+                    ParsekLog.Warn("MergeDialog",
+                        $"RunPreTransitionAction: ComputeSessionSuppressedSubtree threw " +
+                        $"{ex.GetType().Name}: {ex.Message} - falling back to leaf-only " +
+                        "ghost-only decisions");
+                }
+            }
+
+            var decisions = BuildDefaultVesselDecisions(
+                pending, suppressedIds, activeReFlyTargetId);
+            int spawnCount = 0;
+            foreach (var v in decisions.Values) if (v) spawnCount++;
+
+            bool actionSucceeded;
+            if (isMerge)
+            {
+                MergeCommit(pending, decisions, spawnCount);
+                // CommitPendingTree nulls RecordingStore.PendingTree on success.
+                actionSucceeded = (RecordingStore.PendingTree == null);
+            }
+            else
+            {
+                actionSucceeded = MergeDiscardWithResult(pending);
+            }
+
+            if (!actionSucceeded)
+            {
+                ParsekLog.Warn("MergeDialog",
+                    "RunPreTransitionAction: action refused (likely merge-journal-active " +
+                    "guard). Skipping postChoice; player remains in flight.");
+                return;
+            }
+
+            try
+            {
+                postChoice?.Invoke();
+            }
+            catch (System.Exception ex)
+            {
+                ParsekLog.Error("MergeDialog",
+                    $"RunPreTransitionAction: postChoice threw " +
+                    $"{ex.GetType().Name}: {ex.Message}");
+            }
+        }
+
         internal static string FormatDuration(double seconds)
             => ParsekTimeFormat.FormatDuration(seconds);
 
@@ -364,13 +602,40 @@ namespace Parsek
         /// <see cref="RecordingStore.MarkTreeAsApplied"/>: the tree is
         /// removed from storage by <see cref="RecordingStore.DiscardPendingTree"/>
         /// so there is no surviving caller that needs recording indexes advanced.
+        ///
+        /// <para>Refuses with a Warn log + screen message if a merge journal
+        /// is active (<see cref="ParsekScenario.ActiveMergeJournal"/>) -
+        /// mirrors <see cref="RevertInterceptor.DiscardReFlyHandler"/>'s
+        /// guard so a discard mid-merge does not race the journal
+        /// finisher's rollback.</para>
         /// </summary>
         internal static void MergeDiscard(RecordingTree tree)
         {
+            MergeDiscardWithResult(tree);
+        }
+
+        /// <summary>
+        /// <see cref="MergeDiscard"/> variant that returns whether the
+        /// discard actually ran. Returns false when the merge-journal-active
+        /// guard refuses (used by the pre-transition dialog wrapper to
+        /// avoid invoking <c>postChoice</c> after a refused discard).
+        /// </summary>
+        internal static bool MergeDiscardWithResult(RecordingTree tree)
+        {
             if (tree == null)
             {
-                ParsekLog.Warn("MergeDialog", "MergeDiscard: tree is null — nothing to discard");
-                return;
+                ParsekLog.Warn("MergeDialog", "MergeDiscard: tree is null - nothing to discard");
+                return false;
+            }
+
+            var scenario = ParsekScenario.Instance;
+            if (!object.ReferenceEquals(null, scenario) && scenario.ActiveMergeJournal != null)
+            {
+                ParsekLog.Warn("MergeDialog",
+                    $"MergeDiscard: refusing - merge journal active " +
+                    $"journal={scenario.ActiveMergeJournal.JournalId ?? "<no-id>"}");
+                ParsekLog.ScreenMessage("Discard: merge in progress - retry in a moment", 3f);
+                return false;
             }
 
             foreach (var rec in tree.Recordings.Values)
@@ -380,7 +645,7 @@ namespace Parsek
             }
 
             if (TryDiscardActiveReFlyAttempt(tree))
-                return;
+                return true;
 
             // #466: while the merge/discard choice is pending, mid-flight effects stay live
             // in KSP and patching is deferred. Discard must now rebuild from the committed
@@ -391,6 +656,7 @@ namespace Parsek
             ParsekLog.Info("MergeDialog",
                 $"User chose: Tree Discard (tree='{tree.TreeName}', " +
                 $"recordings={tree.Recordings.Count})");
+            return true;
         }
 
         /// <summary>
@@ -411,6 +677,20 @@ namespace Parsek
             var marker = scenario.ActiveReFlySessionMarker;
             if (marker == null)
                 return false;
+
+            // Defensive belt-and-braces guard for any caller that bypasses
+            // MergeDiscard's gate (test seam, future call site). Mirrors
+            // RevertInterceptor.DiscardReFlyHandler's guard at
+            // RevertInterceptor.cs:345-352.
+            if (scenario.ActiveMergeJournal != null)
+            {
+                ParsekLog.Warn("MergeDialog",
+                    $"TryDiscardActiveReFlyAttempt: refusing - merge journal active " +
+                    $"sess={marker.SessionId ?? "<no-id>"} " +
+                    $"journal={scenario.ActiveMergeJournal.JournalId ?? "<no-id>"}");
+                ParsekLog.ScreenMessage("Discard Re-Fly: merge in progress - retry in a moment", 3f);
+                return false;
+            }
 
             if (!IsReFlyMarkerScopedToTree(marker, tree))
             {

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -2727,9 +2727,20 @@ namespace Parsek
         /// <see cref="MergeDialog.MergeCommit"/> /
         /// <see cref="MergeDialog.MergeDiscard"/> so those operate on the
         /// just-stashed pending tree.
+        ///
+        /// <para>Mirrors the recorder-state prep that
+        /// <see cref="OnSceneChangeRequested"/> runs immediately before
+        /// <see cref="FinalizeTreeOnSceneChange"/>: stop continuations
+        /// so chain-segment data is baked, clean up the Gloops recorder,
+        /// clear scene-change transient state. Without this prep,
+        /// <c>MergeCommit</c> and the optimization pass run against
+        /// continuation recordings that haven't completed sampling.</para>
         /// </summary>
         internal void FinalizeTreeOnSceneChangeForCallback(GameScenes scene)
         {
+            chainManager.StopAllContinuations("scene-exit dialog pre-finalize");
+            CleanupGloopsRecorder();
+            ClearSceneChangeTransientState();
             FinalizeTreeOnSceneChangeCore(
                 scene,
                 Planetarium.GetUniversalTime(),
@@ -2833,24 +2844,57 @@ namespace Parsek
         /// <summary>
         /// Pre-transition idle-on-pad fast path: tear down the live
         /// recorder / activeTree without going through finalize / stash.
-        /// Mirrors the cleanup at <c>ParsekFlight.cs:3151-3166</c>
-        /// (post-destruction auto-discard) but for the
-        /// pre-scene-change path. After this returns, the prefix's
-        /// blocked <c>HighLogic.LoadScene</c> proceeds and
+        /// Mirrors the suppressed-discard cleanup at
+        /// <see cref="DiscardActiveTreeForSuppressedSceneExit"/>: stop
+        /// the recorder, clear the
+        /// <see cref="Patches.PhysicsFramePatch.ActiveRecorder"/> and
+        /// <see cref="Patches.PhysicsFramePatch.BackgroundRecorderInstance"/>
+        /// references, then null the fields. Also runs the same prep as
+        /// <see cref="OnSceneChangeRequested"/> (continuations, gloops,
+        /// transient state) since the prefix returns true after this and
+        /// <see cref="OnSceneChangeRequested"/> only re-runs that prep
+        /// once it sees <c>activeTree == null</c> - by which point any
+        /// in-flight continuation data would have already been dropped
+        /// without baking.
+        ///
+        /// <para>After this returns, the prefix's blocked
+        /// <c>HighLogic.LoadScene</c> proceeds and
         /// <see cref="OnSceneChangeRequested"/> sees
         /// <c>activeTree == null</c>, so no pending tree is stashed and
-        /// the destination scene's OnLoad does not show a deferred
-        /// merge dialog.
+        /// the destination scene's OnLoad does not show a deferred merge
+        /// dialog.</para>
         /// </summary>
         internal void AutoDiscardIdleActiveTree(string reason)
         {
             ParsekLog.Info("Flight",
                 $"AutoDiscardIdleActiveTree: discarding live tree reason='{reason}'");
             ScreenMessage("Recording discarded - idle on pad", 3f);
-            recorder = null;
+
+            // Mirror OnSceneChangeRequested's pre-finalize prep so any
+            // active continuation / gloops / transient state is cleaned
+            // up before we drop the recorder.
+            chainManager.StopAllContinuations("idle-on-pad auto-discard");
+            CleanupGloopsRecorder();
+            ClearSceneChangeTransientState();
+
+            // Mirror DiscardActiveTreeForSuppressedSceneExit's recorder
+            // teardown: ForceStop + clear ActiveRecorder reference before
+            // nulling. Without ForceStop the recorder may still hold
+            // buffered data; without clearing ActiveRecorder, the physics
+            // patch retains a stale reference (regression-checked by
+            // ExtendedRuntimeTests.cs:919's
+            // PhysicsFramePatch_ActiveRecorder_NullWhenNotRecording).
+            if (recorder != null)
+            {
+                if (recorder.IsRecording)
+                    recorder.ForceStop();
+                Patches.PhysicsFramePatch.ActiveRecorder = null;
+                recorder = null;
+            }
+
             if (backgroundRecorder != null)
             {
-                backgroundRecorder.Shutdown();
+                backgroundRecorder.DiscardWithoutPersist(reason);
                 Patches.PhysicsFramePatch.BackgroundRecorderInstance = null;
                 backgroundRecorder = null;
             }

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -2772,16 +2772,27 @@ namespace Parsek
         /// extra TrackSection boundary at the current UT - identical to
         /// what every <c>OnSave</c> tick produces.</para>
         ///
-        /// <para>Mirrors the <see cref="IsTreeIdleOnPad"/> data-loss
-        /// safeguard at <c>ParsekFlight.cs:15983-15991</c>: a tree where no
-        /// recording has any trajectory points is data-loss, not idle. We
-        /// refuse to classify and return false so the dialog still shows.</para>
+        /// <para>Mirrors the <see cref="IsTreeIdleOnPad(RecordingTree)"/>
+        /// data-loss safeguard (in the <c>anyHasPoints</c> block of that
+        /// function): a tree where no recording has any trajectory points
+        /// is data-loss, not idle. We refuse to classify and return false
+        /// so the dialog still shows.</para>
         /// </summary>
         internal bool IsActiveTreeIdleOnPad()
         {
             if (activeTree == null) return false;
             if (activeTree.Recordings == null || activeTree.Recordings.Count == 0)
                 return false;
+            // Mirror the existing defensive guard pattern used by other
+            // mutating paths in this file (e.g. line 2727 in
+            // FinalizeTreeOnSceneChangeCore): if a restore coroutine owns
+            // the recorder/activeTree, do not flush.
+            if (restoringActiveTree)
+            {
+                ParsekLog.Warn("Flight",
+                    "IsActiveTreeIdleOnPad: skipped - restore coroutine in progress");
+                return false;
+            }
 
             // Flush live recorder data into the tree so subsequent walks
             // over rec.TrackSections / rec.Points see the in-flight data.

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -2718,6 +2718,92 @@ namespace Parsek
             FinalizeTreeOnSceneChangeCore(scene, commitUT, logRecorderState: false);
         }
 
+        /// <summary>
+        /// Pre-transition finalize entry for the in-flight merge dialog
+        /// (<see cref="MergeDialog.ShowTreeDialog"/>'s
+        /// <c>preCommitFinalize</c> callback). Identical to what
+        /// <see cref="OnSceneChangeRequested"/> would have run a few frames
+        /// later. The dialog button handler invokes this BEFORE
+        /// <see cref="MergeDialog.MergeCommit"/> /
+        /// <see cref="MergeDialog.MergeDiscard"/> so those operate on the
+        /// just-stashed pending tree.
+        /// </summary>
+        internal void FinalizeTreeOnSceneChangeForCallback(GameScenes scene)
+        {
+            FinalizeTreeOnSceneChangeCore(
+                scene,
+                Planetarium.GetUniversalTime(),
+                logRecorderState: true);
+        }
+
+        // HasActiveTree is the existing public property at line 900.
+
+        /// <summary>
+        /// Read-only accessor for the dialog's display data. Caller must
+        /// not mutate the returned reference; mutation happens inside
+        /// <see cref="MergeDialog.MergeCommit"/> /
+        /// <see cref="MergeDialog.MergeDiscard"/> after
+        /// <see cref="FinalizeTreeOnSceneChangeForCallback"/> stashes the
+        /// pending tree.
+        /// </summary>
+        internal RecordingTree ActiveTreeForDisplay => activeTree;
+
+        /// <summary>
+        /// Live-state idle-on-pad check used by the
+        /// <c>HighLogic.LoadScene</c> prefix's fast path. Returns true if
+        /// every recording in the active tree is idle-on-pad (max
+        /// distance from launch &lt; pad-localized threshold) computed
+        /// from live data via
+        /// <see cref="VesselSpawner.BackfillMaxDistanceAbsoluteOnly"/>.
+        /// Idle-on-pad recordings cannot have RELATIVE-frame TrackSections
+        /// (the recorder skips RELATIVE entry while the vessel is on
+        /// surface, see <c>FlightRecorder.cs:5099-5131</c>).
+        /// </summary>
+        internal bool IsActiveTreeIdleOnPad()
+        {
+            if (activeTree == null) return false;
+            if (activeTree.Recordings == null || activeTree.Recordings.Count == 0)
+                return false;
+            foreach (var rec in activeTree.Recordings.Values)
+            {
+                if (rec == null) continue;
+                VesselSpawner.BackfillMaxDistanceAbsoluteOnly(rec);
+                if (!IsIdleOnPad(rec)) return false;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Pre-transition idle-on-pad fast path: tear down the live
+        /// recorder / activeTree without going through finalize / stash.
+        /// Mirrors the cleanup at <c>ParsekFlight.cs:3151-3166</c>
+        /// (post-destruction auto-discard) but for the
+        /// pre-scene-change path. After this returns, the prefix's
+        /// blocked <c>HighLogic.LoadScene</c> proceeds and
+        /// <see cref="OnSceneChangeRequested"/> sees
+        /// <c>activeTree == null</c>, so no pending tree is stashed and
+        /// the destination scene's OnLoad does not show a deferred
+        /// merge dialog.
+        /// </summary>
+        internal void AutoDiscardIdleActiveTree(string reason)
+        {
+            ParsekLog.Info("Flight",
+                $"AutoDiscardIdleActiveTree: discarding live tree reason='{reason}'");
+            ScreenMessage("Recording discarded - idle on pad", 3f);
+            recorder = null;
+            if (backgroundRecorder != null)
+            {
+                backgroundRecorder.Shutdown();
+                Patches.PhysicsFramePatch.BackgroundRecorderInstance = null;
+                backgroundRecorder = null;
+            }
+            activeTree = null;
+            // No pending tree was stashed (we discard pre-finalize).
+            // Roll back any in-flight ledger entries from the aborted
+            // recording.
+            LedgerOrchestrator.RecalculateAndPatch();
+        }
+
         private void FinalizeTreeOnSceneChangeCore(
             GameScenes scene,
             double commitUT,

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -2758,18 +2758,64 @@ namespace Parsek
         /// Idle-on-pad recordings cannot have RELATIVE-frame TrackSections
         /// (the recorder skips RELATIVE entry while the vessel is on
         /// surface, see <c>FlightRecorder.cs:5099-5131</c>).
+        ///
+        /// <para>This method MUTATES: it calls
+        /// <see cref="FlushRecorderIntoActiveTreeForSerialization"/> first
+        /// so the live recorder's <c>Recording</c> + open
+        /// <c>TrackSections</c> become populated on the tree recordings
+        /// (<see cref="VesselSpawner.BackfillMaxDistanceAbsoluteOnly"/>
+        /// reads <c>rec.TrackSections</c> only). Without this, atmospheric
+        /// flights that haven't crossed an env boundary or saved yet have
+        /// empty <c>TrackSections</c> and the helper would falsely report
+        /// idle (Opus pass-7 review P1). The flush is non-destructive: the
+        /// recorder stays IsRecording=true and the only side effect is one
+        /// extra TrackSection boundary at the current UT - identical to
+        /// what every <c>OnSave</c> tick produces.</para>
+        ///
+        /// <para>Mirrors the <see cref="IsTreeIdleOnPad"/> data-loss
+        /// safeguard at <c>ParsekFlight.cs:15983-15991</c>: a tree where no
+        /// recording has any trajectory points is data-loss, not idle. We
+        /// refuse to classify and return false so the dialog still shows.</para>
         /// </summary>
         internal bool IsActiveTreeIdleOnPad()
         {
             if (activeTree == null) return false;
             if (activeTree.Recordings == null || activeTree.Recordings.Count == 0)
                 return false;
+
+            // Flush live recorder data into the tree so subsequent walks
+            // over rec.TrackSections / rec.Points see the in-flight data.
+            FlushRecorderIntoActiveTreeForSerialization();
+
+            bool anyHasPoints = false;
             foreach (var rec in activeTree.Recordings.Values)
             {
                 if (rec == null) continue;
                 VesselSpawner.BackfillMaxDistanceAbsoluteOnly(rec);
-                if (!IsIdleOnPad(rec)) return false;
+                if (rec.Points != null && rec.Points.Count > 0)
+                    anyHasPoints = true;
+                if (!IsIdleOnPad(rec))
+                {
+                    ParsekLog.Verbose("Flight",
+                        $"IsActiveTreeIdleOnPad: '{rec.VesselName}' maxDist=" +
+                        $"{rec.MaxDistanceFromLaunch:F1}m - not idle");
+                    return false;
+                }
             }
+
+            // Bug #290d safeguard: a tree where no recording has trajectory
+            // points is data-loss, not idle-on-pad. Don't auto-discard.
+            if (!anyHasPoints)
+            {
+                ParsekLog.Verbose("Flight",
+                    $"IsActiveTreeIdleOnPad: all {activeTree.Recordings.Count} recordings " +
+                    "have 0 points - cannot determine idle, returning false");
+                return false;
+            }
+
+            ParsekLog.Verbose("Flight",
+                $"IsActiveTreeIdleOnPad: all {activeTree.Recordings.Count} recordings " +
+                "within 30m - idle on pad");
             return true;
         }
 

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -1654,12 +1654,16 @@ namespace Parsek
                     }
 
                     // Handle pending recordings on non-revert scene exits to non-flight scenes.
-                    // Always auto-commit on main menu (game is being unloaded, dialog would be meaningless).
+                    // The pre-transition merge dialog (SceneExitInterceptor) is the
+                    // primary path; this OnLoad path is the deferred fallback for
+                    // any flight-exit that bypassed our HighLogic.LoadScene prefix
+                    // (KSP version drift, foreign mod patch, etc.). Pre-transition
+                    // path now handles MAINMENU too, so the historical
+                    // forceAutoMerge=MAINMENU shortcut is gone.
                     loadPhase = "pending-outside-flight";
-                    bool forceAutoMerge = HighLogic.LoadedScene == GameScenes.MAINMENU;
                     if (!isRevert && HighLogic.LoadedScene != GameScenes.FLIGHT)
                     {
-                        if (IsAutoMerge || forceAutoMerge)
+                        if (IsAutoMerge)
                         {
                             // Check if commit approval dialog should be shown (#88):
                             // landed/splashed vessel going to KSC or Tracking Station
@@ -1673,7 +1677,7 @@ namespace Parsek
                                     RecordingStore.PendingTree.RootRecordingId, out rootRec))
                                     termState = rootRec.TerminalStateValue;
                             }
-                            bool showApproval = !forceAutoMerge && destScene.HasValue &&
+                            bool showApproval = destScene.HasValue &&
                                 GhostPlaybackLogic.ShouldShowCommitApproval(destScene.Value, termState);
                             RecordingStore.PendingDestinationScene = null;
 
@@ -4861,6 +4865,18 @@ namespace Parsek
         /// </summary>
         private IEnumerator ShowDeferredMergeDialog()
         {
+            // Canary: the pre-transition merge dialog
+            // (SceneExitInterceptor's HighLogic.LoadScene prefix) is the
+            // primary path. If this deferred coroutine fires, the
+            // pre-transition path missed the transition (mod compat,
+            // KSP version drift, foreign LoadScene patch). Warn so we
+            // can investigate.
+            ParsekLog.Warn("Scenario",
+                $"Deferred merge dialog fired - pre-transition intercept missed " +
+                $"scene={HighLogic.LoadedScene} pendingTree=" +
+                $"{(RecordingStore.HasPendingTree ? RecordingStore.PendingTree?.TreeName ?? "<unnamed>" : "<none>")} " +
+                "(check SceneExitInterceptor or KSP version compat)");
+
             // Wait ~60 frames for scene to fully load (UI skin, singletons, etc.)
             int waitFrames = 60;
             while (waitFrames-- > 0)

--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -1250,7 +1250,16 @@ namespace Parsek
             return true;
         }
 
-        internal static bool NextTreeSceneExitCommitSuppressionArmedForTesting
+        /// <summary>
+        /// Read-only peek (no consume) of the tree-scene-exit-commit
+        /// suppression flag. Production callers (the
+        /// <c>HighLogic.LoadScene</c> prefix in
+        /// <c>SceneExitInterceptor</c>) check this to detect that a
+        /// transition is already owned by Discard Re-Fly so they can
+        /// bypass without stealing the flag from
+        /// <c>FinalizeTreeOnSceneChange</c>'s consume contract.
+        /// </summary>
+        internal static bool IsNextTreeSceneExitCommitSuppressionArmed
             => suppressNextTreeSceneExitCommit;
 
         /// <summary>

--- a/Source/Parsek/SceneExitInterceptor.cs
+++ b/Source/Parsek/SceneExitInterceptor.cs
@@ -1,0 +1,404 @@
+using System;
+using HarmonyLib;
+
+namespace Parsek
+{
+    /// <summary>
+    /// Pre-transition merge confirmation: shows the
+    /// <see cref="MergeDialog.ShowTreeDialog"/> while the player is still in
+    /// flight, before <c>HighLogic.LoadScene</c> tears down the flight scene
+    /// for Space Center / Tracking Station / Main Menu / Editor.
+    ///
+    /// <para>The Harmony Prefix on <see cref="HighLogic.LoadScene(GameScenes)"/>
+    /// is a single chokepoint that catches every flight-exit path: PauseMenu's
+    /// <c>saveAndExit</c> branch, PauseMenu's <c>CanRestart</c> no-save branch
+    /// (direct LoadScene), and FlightResultsDialog's KSC / Menu / TS buttons
+    /// (also direct LoadScene). By the time <c>HighLogic.LoadScene</c> runs,
+    /// stock confirmation popups (atmosphere / throttle warning, quit-to-main
+    /// confirmation) have already been confirmed by the user.</para>
+    ///
+    /// <para>The prefix does NOT pre-finalize the active tree before showing
+    /// the dialog. Pre-finalize would call <c>recorder.ForceStop()</c>
+    /// (<c>FlightRecorder.cs:11218</c>) and clear <c>activeTree</c>; if the
+    /// popup is dismissed without a button click the player would be stranded
+    /// in flight with a dead recorder. Instead, the dialog operates on the
+    /// live <c>activeTree</c> and the button-handler wrapper inside
+    /// <see cref="MergeDialog.ShowTreeDialog"/> runs preCommitFinalize ->
+    /// MergeCommit/Discard -> postChoice in order, so finalize only happens
+    /// when the player commits to a choice.</para>
+    /// </summary>
+    internal static class SceneExitInterceptor
+    {
+        /// <summary>
+        /// One-shot bypass token: set to true by the dialog's postChoice
+        /// just before re-invoking <c>HighLogic.LoadScene</c>. Consumed
+        /// (with destination match check) by the next prefix entry.
+        /// </summary>
+        internal static bool s_AllowNextLoadScene;
+
+        /// <summary>
+        /// Paired expected-destination for the <see cref="s_AllowNextLoadScene"/>
+        /// token. Mismatch on consume means a foreign LoadScene call slipped
+        /// in between our set and our prefix entry; we Warn and fall through
+        /// to normal handling rather than silently letting the foreign call
+        /// bypass the dialog.
+        /// </summary>
+        internal static GameScenes s_AllowNextLoadSceneDestination = GameScenes.LOADING;
+
+        /// <summary>
+        /// Test seam: when non-null, the prefix invokes this instead of
+        /// spawning a real <see cref="MergeDialog.ShowTreeDialog"/> popup.
+        /// Receives the destination scene and the dialog variant.
+        /// </summary>
+        internal static Action<GameScenes, DialogVariant> ShowDialogForTesting;
+
+        /// <summary>
+        /// Test seam: when non-null, the prefix invokes this instead of
+        /// running <see cref="ParsekFlight.AutoDiscardIdleActiveTree"/>
+        /// for the idle-on-pad fast path. Receives the reason string.
+        /// </summary>
+        internal static Action<string> AutoDiscardIdleForTesting;
+
+        /// <summary>
+        /// Test seam: when non-null, the prefix calls this instead of
+        /// <see cref="GamePersistence.SaveGame"/>. Receives the destination
+        /// scene; returns true on success, false to simulate save failure.
+        /// </summary>
+        internal static Func<GameScenes, bool> SafeWritePersistentForTesting;
+
+        internal enum DialogVariant
+        {
+            /// <summary>No dialog needed - prefix returns true.</summary>
+            None,
+            /// <summary>Regular merge dialog with default labels.</summary>
+            RegularMerge,
+            /// <summary>Re-Fly attempt-scoped dialog with Re-Fly labels.</summary>
+            ReFlyAttempt,
+        }
+
+        /// <summary>Test reset: clears all static state and seams.</summary>
+        internal static void ResetTestOverrides()
+        {
+            s_AllowNextLoadScene = false;
+            s_AllowNextLoadSceneDestination = GameScenes.LOADING;
+            ShowDialogForTesting = null;
+            AutoDiscardIdleForTesting = null;
+            SafeWritePersistentForTesting = null;
+        }
+
+        /// <summary>
+        /// Pure decision helper. Mirrors the OnLoad logic at
+        /// <c>ParsekScenario.cs:1660-1723</c> so the pre-transition gate
+        /// matches the existing post-load gate. Pure for unit-testability;
+        /// the Prefix collects live state and passes it in.
+        /// </summary>
+        internal static DialogVariant ShouldShowDialogBeforeSceneChange(
+            GameScenes destination,
+            bool hasActiveTree,
+            bool reFlyActive,
+            bool isAutoMerge,
+            bool activeVesselLandedOrSplashed)
+        {
+            if (!hasActiveTree)
+                return DialogVariant.None;
+
+            if (reFlyActive)
+                return DialogVariant.ReFlyAttempt;
+
+            if (!isAutoMerge)
+                return DialogVariant.RegularMerge;
+
+            if (destination == GameScenes.MAINMENU)
+                return DialogVariant.RegularMerge;
+
+            if ((destination == GameScenes.SPACECENTER
+                 || destination == GameScenes.TRACKSTATION)
+                && activeVesselLandedOrSplashed)
+            {
+                return DialogVariant.RegularMerge;
+            }
+
+            return DialogVariant.None;
+        }
+
+        /// <summary>
+        /// Live-state wrapper that gathers values from
+        /// <see cref="FlightGlobals"/> / <see cref="ParsekScenario"/> and
+        /// dispatches to the pure helper. Used by the prefix.
+        /// </summary>
+        internal static DialogVariant ShouldShowDialogBeforeSceneChangeLive(
+            GameScenes destination, ParsekFlight flight)
+        {
+            bool hasActiveTree = flight != null && flight.HasActiveTree;
+            var scenario = ParsekScenario.Instance;
+            bool reFlyActive =
+                !object.ReferenceEquals(null, scenario)
+                && scenario.ActiveReFlySessionMarker != null;
+            bool isAutoMerge = ParsekScenario.IsAutoMerge;
+
+            // Mirrors ShouldShowCommitApproval but reads live vessel
+            // situation since post-finalize TerminalStateValue isn't
+            // populated yet (finalize deferred to the dialog callback).
+            // The two values agree on outcome:
+            // RecordingTree.DetermineTerminalState override paths only fire
+            // for SUB_ORBITAL/ORBITING base states; LANDED/SPLASHED pass
+            // through unchanged.
+            var v = FlightGlobals.ActiveVessel;
+            bool landedOrSplashed =
+                v != null
+                && (v.situation == Vessel.Situations.LANDED
+                    || v.situation == Vessel.Situations.SPLASHED);
+
+            return ShouldShowDialogBeforeSceneChange(
+                destination,
+                hasActiveTree: hasActiveTree,
+                reFlyActive: reFlyActive,
+                isAutoMerge: isAutoMerge,
+                activeVesselLandedOrSplashed: landedOrSplashed);
+        }
+
+        /// <summary>
+        /// Idle-on-pad fast path. Detects via
+        /// <see cref="ParsekFlight.IsActiveTreeIdleOnPad"/> and, if idle,
+        /// tears down the live recorder / activeTree via
+        /// <see cref="ParsekFlight.AutoDiscardIdleActiveTree"/>. After
+        /// return-true, stock LoadScene proceeds with no active tree;
+        /// OnSceneChangeRequested no-ops; destination scene loads with no
+        /// pending tree, so the OnLoad idle-on-pad branch
+        /// (<c>ParsekScenario.cs:1682-1689</c>) does not fire.
+        /// </summary>
+        internal static bool TryAutoDiscardIdleActiveTree(
+            GameScenes destination, ParsekFlight flight)
+        {
+            if (flight == null || !flight.HasActiveTree) return false;
+            if (!flight.IsActiveTreeIdleOnPad()) return false;
+
+            string reason = $"scene-exit idle-on-pad auto-discard dest={destination}";
+            ParsekLog.Info("SceneExit",
+                $"TryAutoDiscardIdleActiveTree: idle detected dest={destination} - " +
+                "tearing down live tree without finalize/stash");
+
+            if (AutoDiscardIdleForTesting != null)
+            {
+                AutoDiscardIdleForTesting(reason);
+            }
+            else
+            {
+                flight.AutoDiscardIdleActiveTree(reason);
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Pre-LoadScene save: persist Parsek's mutations. For paths where
+        /// stock <c>saveAndExit</c> already saved (PauseMenu paths), our
+        /// re-save runs after our mutations on top of stock's earlier save.
+        /// For paths where stock did NOT save (PauseMenu CanRestart no-save,
+        /// FlightResultsDialog direct LoadScene), our save is the only
+        /// source. Mirrors the full stock saveAndExit prep
+        /// (<c>onSceneConfirmExit</c> fire +
+        /// <c>ClearpersistentIdDictionaries</c> + <c>SaveGame</c> +
+        /// MAINMENU analytics) so paths that bypassed stock prep get the
+        /// same prep here.
+        ///
+        /// <para>Returns false ONLY for MAINMENU on save throw (hard-block
+        /// the transition; no later save will run before unload). Other
+        /// destinations log Warn and continue (the destination scene's own
+        /// save cycle eventually persists).</para>
+        /// </summary>
+        internal static bool SafeWritePersistent(GameScenes destination)
+        {
+            if (SafeWritePersistentForTesting != null)
+                return SafeWritePersistentForTesting(destination);
+
+            try
+            {
+                if (HighLogic.CurrentGame != null)
+                    GameEvents.onSceneConfirmExit.Fire(HighLogic.CurrentGame.startScene);
+
+                // Stock saveAndExit also calls FlightGlobals.ClearpersistentIdDictionaries
+                // (internal) and AnalyticsUtil.LogSaveGameClosed (internal),
+                // but both are inaccessible from outside Assembly-CSharp.
+                // Skipping is safe: ClearpersistentIdDictionaries clears a
+                // runtime cache that is rebuilt on the next scene load (the
+                // cache is not serialized, so the saved persistent.sfs is
+                // unaffected). The analytics call is non-functional. If
+                // these become observably needed in playtest, switch to
+                // reflection.
+
+                if (HighLogic.CurrentGame == null)
+                {
+                    ParsekLog.Warn("SceneExit",
+                        "SafeWritePersistent: HighLogic.CurrentGame is null - skipping save");
+                    return true;
+                }
+                GamePersistence.SaveGame(
+                    HighLogic.CurrentGame.Updated(),
+                    "persistent",
+                    HighLogic.SaveFolder,
+                    SaveMode.OVERWRITE);
+                ParsekLog.Info("SceneExit",
+                    $"SafeWritePersistent: persistent.sfs written dest={destination}");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                ParsekLog.Error("SceneExit",
+                    $"SafeWritePersistent threw {ex.GetType().Name}: {ex.Message} dest={destination}");
+                if (destination == GameScenes.MAINMENU)
+                {
+                    ShowSaveFailedPopup();
+                    return false;
+                }
+                return true;
+            }
+        }
+
+        private static void ShowSaveFailedPopup()
+        {
+            try
+            {
+                PopupDialog.SpawnPopupDialog(
+                    new UnityEngine.Vector2(0.5f, 0.5f),
+                    new UnityEngine.Vector2(0.5f, 0.5f),
+                    new MultiOptionDialog(
+                        "ParsekSceneExitSaveFailed",
+                        "Could not save before quitting to main menu. " +
+                        "Try again, or quit to Space Center first.",
+                        "Save failed",
+                        HighLogic.UISkin,
+                        new DialogGUIButton("OK", () => { }, dismissOnSelect: true)),
+                    persistAcrossScenes: false,
+                    HighLogic.UISkin);
+            }
+            catch (Exception ex)
+            {
+                ParsekLog.Warn("SceneExit",
+                    $"ShowSaveFailedPopup: SpawnPopupDialog threw " +
+                    $"{ex.GetType().Name}: {ex.Message}; player gets no UI feedback");
+            }
+        }
+
+        /// <summary>
+        /// Builds the postChoice closure invoked after the dialog's
+        /// preCommitFinalize + MergeCommit/Discard. Persists state and
+        /// re-invokes <c>HighLogic.LoadScene</c> with the bypass token set.
+        /// </summary>
+        internal static Action BuildPostChoice(GameScenes destination)
+        {
+            return () =>
+            {
+                if (!SafeWritePersistent(destination))
+                    return;
+                s_AllowNextLoadScene = true;
+                s_AllowNextLoadSceneDestination = destination;
+                HighLogic.LoadScene(destination);
+            };
+        }
+    }
+
+    /// <summary>
+    /// Harmony Prefix on <see cref="HighLogic.LoadScene(GameScenes)"/>.
+    /// Filtered to flight-exit transitions; runs after any other mod
+    /// prefix (HarmonyPriority.Last) so we only block when everyone else
+    /// allowed it.
+    /// </summary>
+    [HarmonyPatch(typeof(HighLogic), nameof(HighLogic.LoadScene), new[] { typeof(GameScenes) })]
+    [HarmonyPriority(Priority.Last)]
+    internal static class HighLogic_LoadScene_Patch
+    {
+        [HarmonyPrefix]
+        internal static bool Prefix(GameScenes scene)
+        {
+            // (1) one-shot self-bypass token: our own dialog callback
+            //     re-invoked LoadScene. Includes a destination check so
+            //     a stray foreign LoadScene between our callback's set
+            //     and prefix's consume cannot silently steal the token.
+            if (SceneExitInterceptor.s_AllowNextLoadScene)
+            {
+                var expected = SceneExitInterceptor.s_AllowNextLoadSceneDestination;
+                SceneExitInterceptor.s_AllowNextLoadScene = false;
+                SceneExitInterceptor.s_AllowNextLoadSceneDestination = GameScenes.LOADING;
+                if (expected == scene)
+                {
+                    ParsekLog.Verbose("SceneExit",
+                        $"LoadScene prefix: bypassing via s_AllowNextLoadScene dest={scene}");
+                    return true;
+                }
+                ParsekLog.Warn("SceneExit",
+                    $"LoadScene prefix: token consumed for unexpected dest={scene} " +
+                    $"(expected {expected}); falling through to normal handling");
+                // Fall through intentionally: a foreign caller stole our
+                // token. The player's Merge/Discard choice still applies
+                // to the CURRENT scene-exit attempt - re-evaluate the
+                // dialog gate against `scene`. Do NOT return-true here -
+                // that would let the foreign transition skip the merge
+                // confirmation.
+            }
+
+            // (2) cheap filter - only intercept exits from FLIGHT to a
+            //     flight-exit destination. dest == FLIGHT (quickload,
+            //     RewindInvoker, vessel switch) passes through.
+            if (HighLogic.LoadedScene != GameScenes.FLIGHT) return true;
+            if (scene != GameScenes.SPACECENTER
+                && scene != GameScenes.TRACKSTATION
+                && scene != GameScenes.MAINMENU
+                && scene != GameScenes.EDITOR)
+            {
+                return true;
+            }
+
+            // (3) PEEK existing Discard-Re-Fly suppression. If
+            //     RevertInterceptor armed ArmNextTreeSceneExitCommitSuppression,
+            //     this transition is already owned by Discard Re-Fly - get
+            //     out of the way without consuming the flag
+            //     (FinalizeTreeOnSceneChange consumes it at
+            //     ParsekFlight.cs:2734).
+            if (RecordingStore.IsNextTreeSceneExitCommitSuppressionArmed)
+            {
+                ParsekLog.Info("SceneExit",
+                    $"LoadScene prefix: bypassing - existing tree-scene-exit-commit " +
+                    $"suppression armed (Discard Re-Fly path) dest={scene}");
+                return true;
+            }
+
+            var flight = ParsekFlight.Instance;
+            if (flight == null || !flight.HasActiveTree)
+                return true;
+
+            // (4) decision matrix on LIVE state.
+            var variant = SceneExitInterceptor.ShouldShowDialogBeforeSceneChangeLive(
+                scene, flight);
+            if (variant == SceneExitInterceptor.DialogVariant.None)
+                return true;
+
+            // (5) idle-on-pad auto-discard fast path. Both detects AND
+            //     mutates: tears down activeTree / recorder /
+            //     backgroundRecorder so OnSceneChangeRequested sees
+            //     nothing to finalize.
+            if (SceneExitInterceptor.TryAutoDiscardIdleActiveTree(scene, flight))
+                return true;
+
+            // (6) show dialog on the live activeTree. ShowTreeDialog's
+            //     button-handler wrapper runs preCommitFinalize ->
+            //     MergeCommit/MergeDiscard -> postChoice in order.
+            if (SceneExitInterceptor.ShowDialogForTesting != null)
+            {
+                SceneExitInterceptor.ShowDialogForTesting(scene, variant);
+                return false;
+            }
+
+            var labels = variant == SceneExitInterceptor.DialogVariant.ReFlyAttempt
+                ? MergeDialog.MergeDialogButtonLabels.ReFlyAttempt
+                : MergeDialog.MergeDialogButtonLabels.Default;
+
+            MergeDialog.ShowTreeDialog(
+                flight.ActiveTreeForDisplay,
+                labels: labels,
+                preCommitFinalize: () => flight.FinalizeTreeOnSceneChangeForCallback(scene),
+                postChoice: SceneExitInterceptor.BuildPostChoice(scene));
+
+            return false;   // block stock LoadScene; dialog drives it
+        }
+    }
+}

--- a/Source/Parsek/SceneExitInterceptor.cs
+++ b/Source/Parsek/SceneExitInterceptor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 using HarmonyLib;
 
 namespace Parsek
@@ -80,6 +81,15 @@ namespace Parsek
             /// <summary>Re-Fly attempt-scoped dialog with Re-Fly labels.</summary>
             ReFlyAttempt,
         }
+
+        // Stock saveAndExit calls FlightGlobals.ClearpersistentIdDictionaries
+        // (internal) before SaveGame and AnalyticsUtil.LogSaveGameClosed
+        // (internal) after SaveGame on MAINMENU. Both are inaccessible from
+        // outside Assembly-CSharp; reflect them like the in-game test runner
+        // does at RuntimeTests.cs:6566-6568.
+        private static readonly MethodInfo s_FlightGlobalsClearPersistentIdDictionariesMethod =
+            typeof(FlightGlobals).GetMethod("ClearpersistentIdDictionaries",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
 
         /// <summary>Test reset: clears all static state and seams.</summary>
         internal static void ResetTestOverrides()
@@ -221,15 +231,40 @@ namespace Parsek
                 if (HighLogic.CurrentGame != null)
                     GameEvents.onSceneConfirmExit.Fire(HighLogic.CurrentGame.startScene);
 
-                // Stock saveAndExit also calls FlightGlobals.ClearpersistentIdDictionaries
-                // (internal) and AnalyticsUtil.LogSaveGameClosed (internal),
-                // but both are inaccessible from outside Assembly-CSharp.
-                // Skipping is safe: ClearpersistentIdDictionaries clears a
-                // runtime cache that is rebuilt on the next scene load (the
-                // cache is not serialized, so the saved persistent.sfs is
-                // unaffected). The analytics call is non-functional. If
-                // these become observably needed in playtest, switch to
-                // reflection.
+                // Stock saveAndExit calls FlightGlobals.ClearpersistentIdDictionaries
+                // before SaveGame to null stale pid pointers. ProtoVessel.Save
+                // and friends resolve live Part references through these
+                // dictionaries; entries pointing at soon-to-be-destroyed
+                // GameObjects could leak into the saved scenario module
+                // state. Method is internal to Assembly-CSharp so we
+                // reflect it (RuntimeTests.cs:6566 already does the same
+                // for stock-fidelity test runs).
+                if (s_FlightGlobalsClearPersistentIdDictionariesMethod != null)
+                {
+                    try
+                    {
+                        s_FlightGlobalsClearPersistentIdDictionariesMethod.Invoke(null, null);
+                    }
+                    catch (TargetInvocationException tex)
+                    {
+                        ParsekLog.Warn("SceneExit",
+                            $"FlightGlobals.ClearpersistentIdDictionaries (reflected) threw " +
+                            $"{tex.InnerException?.GetType().Name ?? tex.GetType().Name}: " +
+                            $"{tex.InnerException?.Message ?? tex.Message}; continuing");
+                    }
+                    catch (Exception rex)
+                    {
+                        ParsekLog.Warn("SceneExit",
+                            $"FlightGlobals.ClearpersistentIdDictionaries reflection invoke threw " +
+                            $"{rex.GetType().Name}: {rex.Message}; continuing");
+                    }
+                }
+                else
+                {
+                    ParsekLog.Warn("SceneExit",
+                        "FlightGlobals.ClearpersistentIdDictionaries reflection unavailable - " +
+                        "stale pid mappings may persist into saved scenario state");
+                }
 
                 if (HighLogic.CurrentGame == null)
                 {
@@ -294,14 +329,15 @@ namespace Parsek
         /// preCommitFinalize + MergeCommit/Discard. Persists state and
         /// re-invokes <c>HighLogic.LoadScene</c> with the bypass token set.
         ///
-        /// <para>Token-set ordering: <see cref="SafeWritePersistent"/> fires
-        /// <c>onSceneConfirmExit</c> BEFORE we set the bypass token. A
-        /// foreign listener that synchronously calls
-        /// <c>HighLogic.LoadScene</c> from its handler would hit our prefix
-        /// without the token armed - the gate re-evaluates and (if the
-        /// active tree is still around) re-shows the dialog. Acceptable
-        /// fallback; the more common case is no-listener / passive
-        /// listener where this ordering doesn't matter.</para>
+        /// <para>Token-set ordering: <see cref="SafeWritePersistent"/>
+        /// fires <c>onSceneConfirmExit</c> BEFORE we set the bypass token.
+        /// A foreign listener that synchronously calls
+        /// <c>HighLogic.LoadScene</c> from its handler would hit our
+        /// prefix without the token armed. By the time postChoice runs,
+        /// <c>MergeCommit</c> / <c>MergeDiscard</c> already cleared
+        /// <c>activeTree</c> + <c>pendingTree</c>, so the prefix's gate
+        /// sees <c>HasActiveTree == false</c> and lets the foreign call
+        /// through (no dialog re-prompt). Acceptable fallback.</para>
         /// </summary>
         internal static Action BuildPostChoice(GameScenes destination)
         {

--- a/Source/Parsek/SceneExitInterceptor.cs
+++ b/Source/Parsek/SceneExitInterceptor.cs
@@ -42,6 +42,11 @@ namespace Parsek
         /// in between our set and our prefix entry; we Warn and fall through
         /// to normal handling rather than silently letting the foreign call
         /// bypass the dialog.
+        ///
+        /// <para><see cref="GameScenes.LOADING"/> is the "not armed"
+        /// sentinel: it is never a flight-exit destination so it cannot be
+        /// confused with a real armed value. If KSP adds a new flight-exit
+        /// destination in a future version, audit this sentinel.</para>
         /// </summary>
         internal static GameScenes s_AllowNextLoadSceneDestination = GameScenes.LOADING;
 
@@ -243,13 +248,18 @@ namespace Parsek
             }
             catch (Exception ex)
             {
-                ParsekLog.Error("SceneExit",
-                    $"SafeWritePersistent threw {ex.GetType().Name}: {ex.Message} dest={destination}");
                 if (destination == GameScenes.MAINMENU)
                 {
+                    ParsekLog.Error("SceneExit",
+                        $"SafeWritePersistent threw {ex.GetType().Name}: {ex.Message} " +
+                        $"dest={destination} - hard-blocking transition");
                     ShowSaveFailedPopup();
                     return false;
                 }
+                ParsekLog.Warn("SceneExit",
+                    $"SafeWritePersistent threw {ex.GetType().Name}: {ex.Message} " +
+                    $"dest={destination} - continuing transition (destination scene's " +
+                    "save cycle will eventually persist)");
                 return true;
             }
         }
@@ -283,6 +293,15 @@ namespace Parsek
         /// Builds the postChoice closure invoked after the dialog's
         /// preCommitFinalize + MergeCommit/Discard. Persists state and
         /// re-invokes <c>HighLogic.LoadScene</c> with the bypass token set.
+        ///
+        /// <para>Token-set ordering: <see cref="SafeWritePersistent"/> fires
+        /// <c>onSceneConfirmExit</c> BEFORE we set the bypass token. A
+        /// foreign listener that synchronously calls
+        /// <c>HighLogic.LoadScene</c> from its handler would hit our prefix
+        /// without the token armed - the gate re-evaluates and (if the
+        /// active tree is still around) re-shows the dialog. Acceptable
+        /// fallback; the more common case is no-listener / passive
+        /// listener where this ordering doesn't matter.</para>
         /// </summary>
         internal static Action BuildPostChoice(GameScenes destination)
         {

--- a/Source/Parsek/VesselSpawner.cs
+++ b/Source/Parsek/VesselSpawner.cs
@@ -3316,6 +3316,93 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Live-state variant of <see cref="BackfillMaxDistance"/>. Walks
+        /// only Absolute-frame TrackSections (where <c>frames</c> entries
+        /// carry body-fixed lat/lon/alt) and skips RELATIVE-frame sections
+        /// whose <c>frames</c> store anchor-local Cartesian metres in the
+        /// same fields. Feeding RELATIVE-frame metres into
+        /// <c>body.GetWorldSurfacePosition(lat, lon, alt)</c> would yield a
+        /// position deep inside the planet and a falsely huge maxDist
+        /// (see CLAUDE.md "Rotation / world frame" gotcha).
+        ///
+        /// <para>Used by <see cref="ParsekFlight.IsActiveTreeIdleOnPad"/>
+        /// to compute distance-from-launch on a live, unfinalized
+        /// <c>Recording</c>. The recorder always opens its first section
+        /// as <c>ReferenceFrame.Absolute</c>
+        /// (<c>FlightRecorder.cs:5488</c>), so the first frame's lat/lon/alt
+        /// is always safe to use as the launch reference.</para>
+        /// </summary>
+        internal static void BackfillMaxDistanceAbsoluteOnly(Recording rec)
+        {
+            if (rec == null || rec.TrackSections == null || rec.TrackSections.Count == 0)
+                return;
+
+            // Find the first Absolute section's first frame for launch reference.
+            TrajectoryPoint? launchFrame = null;
+            CelestialBody bodyFirst = null;
+            for (int i = 0; i < rec.TrackSections.Count && launchFrame == null; i++)
+            {
+                var section = rec.TrackSections[i];
+                if (section.referenceFrame != ReferenceFrame.Absolute) continue;
+                if (section.frames == null || section.frames.Count == 0) continue;
+                var f = section.frames[0];
+                try
+                {
+                    bodyFirst = FlightGlobals.Bodies?.Find(b => b.name == f.bodyName);
+                }
+                catch
+                {
+                    return; // FlightGlobals not available (unit tests)
+                }
+                if (bodyFirst == null)
+                {
+                    ParsekLog.Warn("Spawner",
+                        $"BackfillMaxDistanceAbsoluteOnly: cannot resolve body '{f.bodyName}' for recording '{rec.RecordingId}'");
+                    return;
+                }
+                launchFrame = f;
+            }
+
+            if (launchFrame == null || bodyFirst == null)
+            {
+                // No Absolute-frame data yet (recorder just started, all
+                // RELATIVE, etc.). Nothing to compute - leave existing
+                // MaxDistanceFromLaunch untouched.
+                return;
+            }
+
+            Vector3d launchPos = bodyFirst.GetWorldSurfacePosition(
+                launchFrame.Value.latitude, launchFrame.Value.longitude, launchFrame.Value.altitude);
+            double maxDist = 0;
+            int absoluteFrameCount = 0;
+            int skippedSections = 0;
+            for (int s = 0; s < rec.TrackSections.Count; s++)
+            {
+                var section = rec.TrackSections[s];
+                if (section.referenceFrame != ReferenceFrame.Absolute)
+                {
+                    skippedSections++;
+                    continue;
+                }
+                if (section.frames == null) continue;
+                for (int j = 0; j < section.frames.Count; j++)
+                {
+                    var pt = section.frames[j];
+                    CelestialBody bodyPt = FlightGlobals.Bodies?.Find(b => b.name == pt.bodyName);
+                    if (bodyPt == null) continue;
+                    Vector3d ptPos = bodyPt.GetWorldSurfacePosition(pt.latitude, pt.longitude, pt.altitude);
+                    double d = Vector3d.Distance(launchPos, ptPos);
+                    if (d > maxDist) maxDist = d;
+                    absoluteFrameCount++;
+                }
+            }
+            rec.MaxDistanceFromLaunch = maxDist;
+            ParsekLog.Verbose("Spawner",
+                $"BackfillMaxDistanceAbsoluteOnly: rec={rec.RecordingId} maxDist={maxDist:F0}m " +
+                $"from {absoluteFrameCount} Absolute frames (skipped {skippedSections} non-Absolute sections)");
+        }
+
+        /// <summary>
         /// Resolves the biome name at the given coordinates on the given body.
         /// Returns null if the body is not found or ScienceUtil is unavailable (unit tests).
         /// </summary>

--- a/docs/dev/plans/merge-confirm-pretransition.md
+++ b/docs/dev/plans/merge-confirm-pretransition.md
@@ -35,9 +35,10 @@ warning popups (atmosphere / throttle / quit confirmation) must still run first.
 | Decision | Choice |
 | --- | --- |
 | Quit-to-Main-Menu | Show dialog (drop force-auto-merge) |
-| Tree finalize timing | Pre-finalize *before* showing the dialog so the dialog operates on an already-stashed pending tree |
+| Tree finalize timing | Defer ALL finalize work to the dialog button callback (Opus pass-2/pass-3 redesign) |
 | Cancel button on regular dialog | None - click commits the player to leaving |
 | Re-Fly-aware dialog | Reuse `MergeDialog.ShowTreeDialog` with Re-Fly-attempt-scoped button labels and body copy (existing dialog already handles Re-Fly merge / discard correctly inside `MergeCommit` / `MergeDiscard`) |
+| autoMerge ON + Re-Fly active | **Behaviour change**: previously this combination silent-auto-committed via `AutoCommitTreeGhostOnly` (`ParsekScenario.cs:1700-1716`) without invoking `TryCommitReFlySupersede`. The new pre-transition path always shows the Re-Fly dialog, routing through `MergeDialog.MergeCommit` -> `TryCommitReFlySupersede` for full supersede / tombstone semantics. This is a real change beyond UX timing: previously-silent commits now require a click. Documented as intentional - the silent path was arguably under-implementing the supersede contract. |
 | Stock KSP danger / quit confirmations | Must run first (see patch chokepoint below) |
 
 ## Patch chokepoint - decompilation findings
@@ -186,7 +187,7 @@ finalize-then-act sequence:
 ```csharp
 Action proceed = () =>
 {
-    var fl = ParsekFlight.fetch;
+    var fl = ParsekFlight.Instance;
     fl?.FinalizeTreeOnSceneChangeForCallback(scene);   // stash + teardown
     var pending = RecordingStore.PendingTree;
     if (pending != null)
@@ -340,9 +341,11 @@ v1 on it.
 Owns:
 
 - A Harmony Prefix on `HighLogic.LoadScene(GameScenes)`.
-- `internal static bool s_AllowNextLoadScene` - one-shot bypass token. Set by
-  the dialog button callbacks just before re-invoking `HighLogic.LoadScene`,
-  consumed by the next prefix entry.
+- `internal static bool s_AllowNextLoadScene` and
+  `internal static GameScenes s_AllowNextLoadSceneDestination` -
+  paired one-shot bypass token. Set by the dialog button callbacks
+  just before re-invoking `HighLogic.LoadScene`, consumed (with
+  destination match check) by the next prefix entry.
 - `internal static DialogVariant ShouldShowDialogBeforeSceneChange(GameScenes
   destination)` - pure decision helper, unit-testable.
 - `internal enum DialogVariant { None, RegularMerge, ReFlyAttempt }`.
@@ -358,12 +361,24 @@ internal static class HighLogic_LoadScene_Patch
     static bool Prefix(GameScenes scene)
     {
         // (1) one-shot self-bypass token: our own dialog callback re-invoked LoadScene.
+        //     Includes a destination check (Opus pass-3 F7) so a stray foreign
+        //     LoadScene between our callback's set and prefix's consume cannot
+        //     silently steal the token.
         if (SceneExitInterceptor.s_AllowNextLoadScene)
         {
+            var expected = SceneExitInterceptor.s_AllowNextLoadSceneDestination;
             SceneExitInterceptor.s_AllowNextLoadScene = false;
-            ParsekLog.Verbose("SceneExit",
-                $"LoadScene prefix: bypassing via s_AllowNextLoadScene dest={scene}");
-            return true;
+            SceneExitInterceptor.s_AllowNextLoadSceneDestination = GameScenes.LOADING;
+            if (expected == scene)
+            {
+                ParsekLog.Verbose("SceneExit",
+                    $"LoadScene prefix: bypassing via s_AllowNextLoadScene dest={scene}");
+                return true;
+            }
+            ParsekLog.Warn("SceneExit",
+                $"LoadScene prefix: token consumed for unexpected dest={scene} " +
+                $"(expected {expected}); falling through to normal handling");
+            // fall through to normal flow
         }
 
         // (2) cheap filter - only intercept exits from FLIGHT to a flight-exit dest.
@@ -390,7 +405,7 @@ internal static class HighLogic_LoadScene_Patch
         //     the callback if and only if the player commits to a Merge or
         //     Discard choice. Popup-dismiss-without-click leaves the recorder
         //     and activeTree intact.
-        var flight = ParsekFlight.fetch;
+        var flight = ParsekFlight.Instance;
         if (flight == null || !flight.HasActiveTree) return true;
 
         var variant = SceneExitInterceptor.ShouldShowDialogBeforeSceneChange(
@@ -426,6 +441,7 @@ internal static class HighLogic_LoadScene_Patch
             // Phase 2: persist mutations. Hard-block on MAINMENU save throw.
             if (!SafeWritePersistent(scene)) return;
             SceneExitInterceptor.s_AllowNextLoadScene = true;
+            SceneExitInterceptor.s_AllowNextLoadSceneDestination = scene;
             HighLogic.LoadScene(scene);
         };
 
@@ -509,13 +525,23 @@ sitting on the pad, every recording's `MaxDistanceFromLaunch` reads
 0.0, so a naive port of `IsTreeIdleOnPad` would always return true and
 auto-discard every flight that exits via the new prefix.
 
-The new `ParsekFlight.IsActiveTreeIdleOnPad()` must call
-`VesselSpawner.BackfillMaxDistance(rec)` on each live recording before
-the threshold check. `BackfillMaxDistance` iterates `Recording.Points`,
-which ARE accumulated continuously by the live recorder, so the
-backfill produces the correct distance for live data. The backfill is
-idempotent (computes from Points each call), so re-running it later
-inside `FinalizeTreeRecordings` is fine.
+The new `ParsekFlight.IsActiveTreeIdleOnPad()` does NOT just call
+`VesselSpawner.BackfillMaxDistance` directly. Per Opus pass-4 P1 #3,
+`BackfillMaxDistance` -> `ComputeMaxDistanceCore` (`VesselSpawner.cs:3294-3315`)
+calls `body.GetWorldSurfacePosition(pt.latitude, pt.longitude, pt.altitude)`
+on every point regardless of `TrackSection.referenceFrame`. For
+RELATIVE-frame TrackSections (per-CLAUDE.md "Rotation / world frame"
+gotcha), those three fields are anchor-local Cartesian metres, not
+body-fixed lat/lon/alt. Feeding them into `GetWorldSurfacePosition`
+produces a position deep inside the planet and a `maxDist` in the
+thousands of km - falsely defeating the idle-on-pad fast path for
+recordings that contain any RELATIVE-frame points.
+
+For an idle-on-pad recording (vessel never moved off the pad), no
+RELATIVE-frame points exist (the recorder never enters a relative
+frame for a stationary pad-bound vessel). For a vessel that did move,
+maxDist is dominated by real Absolute-frame distances anyway. The
+defensive fix is to filter to Absolute-frame points only.
 
 Implementation:
 
@@ -526,15 +552,45 @@ internal bool IsActiveTreeIdleOnPad()
     foreach (var rec in activeTree.Recordings.Values)
     {
         if (rec == null) continue;
-        VesselSpawner.BackfillMaxDistance(rec);   // live -> populated
+        // Live max-distance walk over Absolute-frame points only.
+        // Skips RELATIVE-frame points (where lat/lon/alt are anchor-local
+        // metres, not body-fixed coords) to avoid the GetWorldSurfacePosition
+        // garbage described in the Opus pass-4 review.
+        VesselSpawner.BackfillMaxDistanceAbsoluteOnly(rec);
         if (!IsIdleOnPad(rec)) return false;
     }
     return true;
 }
 ```
 
-`IsIdleOnPad(rec)` is the existing private helper used by
-`IsTreeIdleOnPad` (`ParsekFlight.cs:15878`).
+`VesselSpawner.BackfillMaxDistanceAbsoluteOnly(Recording)` is a new
+sibling of the existing `BackfillMaxDistance`. It iterates Points but
+calls `Recording.IsPointInAbsoluteFrame(pointIndex)` (or equivalent)
+to skip non-Absolute points. For finalize-time use, the existing
+`BackfillMaxDistance` keeps walking all points (today's behaviour);
+the live path uses the Absolute-only variant.
+
+(Stretch: fix `BackfillMaxDistance` itself to honour `referenceFrame`,
+which would also fix a latent finalize-time bug. Out of scope for this
+plan, but flag as a follow-up TODO.)
+
+`IsIdleOnPad(rec)` is the existing internal helper at
+`ParsekFlight.cs:15729-15736`. It reads `rec.MaxDistanceFromLaunch`
+plus `HasPadLocalizedMotionOverride(rec)`. `HasPadLocalizedMotionOverride`
+walks `rec.Points` itself - it has the same RELATIVE-frame concern, so
+the Absolute-only variant must apply there too. Either:
+- Add a sibling `HasPadLocalizedMotionOverrideAbsoluteOnly(rec)` that
+  filters, or
+- Trust the gate at line 15743 (`MaxDistanceFromLaunch < 30m`); since
+  our live `BackfillMaxDistanceAbsoluteOnly` only writes a small value
+  for genuinely-idle recordings, the gate filters out the call into
+  `TryGetPadLocalizedMotionMetrics` for non-idle recordings.
+
+The latter is sufficient: if `MaxDistanceFromLaunch >= 30m`, the
+override is gated off and Points-walk doesn't run. Only when the
+recording is genuinely idle (small Absolute-only maxDist) does the
+override path run, and an idle recording has no RELATIVE points by
+construction.
 
 ### `MergeDialog.cs` changes
 
@@ -560,11 +616,26 @@ internal bool IsActiveTreeIdleOnPad()
   Merge / Discard button handlers run, in order:
   ```
   preCommitFinalize?.Invoke();   // pre-transition: stash pending tree
-  var pending = RecordingStore.PendingTree ?? liveTree;
-  if (clickedMerge) MergeCommit(pending, decisions, spawnCount);
-  else              MergeDiscard(pending);
+  var pending = RecordingStore.PendingTree;
+  if (pending == null)
+  {
+      // preCommitFinalize ran but produced no pending tree
+      // (active recorder had nothing to commit, all recordings auto-discarded).
+      // Skip MergeCommit/Discard - they assert a pending tree exists.
+      ParsekLog.Warn("MergeDialog",
+          "ShowTreeDialog: preCommitFinalize produced no pending tree, " +
+          "skipping commit/discard");
+  }
+  else if (clickedMerge) MergeCommit(pending, decisions, spawnCount);
+  else                   MergeDiscard(pending);
   postChoice?.Invoke();
   ```
+  No `?? liveTree` fallback - `MergeCommit` calls
+  `RecordingStore.CommitPendingTree()` which asserts a pending tree
+  exists (`MergeDialog.cs:316`). A null `PendingTree` after
+  `preCommitFinalize` means there's nothing to commit; silently
+  skipping with a Warn is the right behaviour, not feeding it the
+  live tree (which would crash inside `CommitPendingTree`).
   Decisions are built inside `ShowTreeDialog` exactly as today
   (`MergeDialog.cs:100-125`: `ComputeSessionSuppressedSubtree` +
   `activeReFlyTargetId` + `BuildDefaultVesselDecisions`). Pre-transition
@@ -651,14 +722,16 @@ internal bool IsActiveTreeIdleOnPad()
 
 | Status | Path | Change |
 | --- | --- | --- |
-| New | `Source/Parsek/SceneExitInterceptor.cs` | Harmony patch + decision helper + idle-pad fast path; pre-finalize-then-decide ordering; persistent save in callback |
-| Modified | `Source/Parsek/MergeDialog.cs` | `(labels, postChoice)` overload of `ShowTreeDialog`; new `MergeDialogButtonLabels` enum; pre-transition title copy; **add `ActiveMergeJournal` guard to `MergeDiscard` and `TryDiscardActiveReFlyAttempt` (P1.C)**; hide Discard when journal active |
-| Modified | `Source/Parsek/ParsekFlight.cs` | Expose `FinalizeTreeOnSceneChangeForCallback` and `HasActiveTree` |
+| New | `Source/Parsek/SceneExitInterceptor.cs` | Harmony patch (`HarmonyPriority.Last`) + decision helper + idle-pad fast path (live-state); paired `s_AllowNextLoadScene` + `s_AllowNextLoadSceneDestination` token; persistent save (`SafeWritePersistent`) in callback |
+| Modified | `Source/Parsek/MergeDialog.cs` | New `(tree, labels, preCommitFinalize, postChoice)` overload of `ShowTreeDialog`; new `MergeDialogButtonLabels` enum (`Default` / `ReFlyAttempt`); pre-transition title copy; **add `ActiveMergeJournal` guard to `MergeDiscard` and `TryDiscardActiveReFlyAttempt` (P1.C from earlier review)**; hide Discard when journal active |
+| Modified | `Source/Parsek/ParsekFlight.cs` | Expose `FinalizeTreeOnSceneChangeForCallback`, `HasActiveTree`, `ActiveTreeForDisplay`, `IsActiveTreeIdleOnPad` |
 | Modified | `Source/Parsek/RecordingStore.cs` | Rename `NextTreeSceneExitCommitSuppressionArmedForTesting` to `IsNextTreeSceneExitCommitSuppressionArmed` (or add sibling) |
+| Modified | `Source/Parsek/VesselSpawner.cs` | New `BackfillMaxDistanceAbsoluteOnly(Recording)` sibling that filters to Absolute-frame points (Opus pass-4 P1 #3) |
 | Modified | `Source/Parsek/ParsekScenario.cs` | Drop main-menu force-auto-merge; deferred-coroutine canary Warn; (optional) reuse decision helper |
-| New | `Source/Parsek.Tests/SceneExitInterceptorTests.cs` | Decision helper matrix; prefix bypass conditions; pre-finalize wiring; popup-teardown retry; persistent-save test seam |
-| Modified | `Source/Parsek.Tests/MergeDialogTests.cs` | New `(labels, postChoice)` path; ReFlyAttempt button labels; journal-active guard tests for `MergeDiscard` + `TryDiscardActiveReFlyAttempt` |
-| Modified | `Source/Parsek/InGameTests/RuntimeTests.cs` | Dialog appears in flight scene, not after load (multiple flight-exit paths) |
+| New | `Source/Parsek.Tests/SceneExitInterceptorTests.cs` | Decision helper matrix (live-state); prefix bypass conditions (3-way: token+dest, suppression peek, dest filter); deferred-finalize wiring; popup-dismiss-no-mutation; `SafeWritePersistent` MAINMENU-block test seam |
+| Modified | `Source/Parsek.Tests/MergeDialogTests.cs` | New `(labels, preCommitFinalize, postChoice)` path; ReFlyAttempt button labels; journal-active guard tests for `MergeDiscard` + `TryDiscardActiveReFlyAttempt`; "no pending tree after preCommitFinalize" Warn-and-skip path |
+| Modified | `Source/Parsek/InGameTests/RuntimeTests.cs` | Dialog appears in flight scene, not after load (multiple flight-exit paths); F9-during-dialog cleanup; KSPCommunityFixes coexistence |
+| Modified | `CHANGELOG.md` + `docs/dev/todo-and-known-bugs.md` | Per repo "Documentation Updates - Per Commit, Not Per PR" rule |
 
 No `ReFlyExitDialog.cs` (removed from previous draft - existing
 `MergeDialog.ShowTreeDialog` covers Re-Fly natively).
@@ -772,15 +845,19 @@ LANDED/SPLASHED situations pass through unchanged.)
 
 ### Defensive tests
 
-- Idle-on-pad pre-transition auto-discard fires before showing dialog
-  (using finalized `MaxDistanceFromLaunch` per P1.A).
-- Merge-journal-active hides Discard on regular and Re-Fly button-labels
-  variants; handler refusal also fires when invoked directly.
+- Idle-on-pad pre-transition auto-discard fires before showing dialog,
+  reading live `MaxDistanceFromLaunch` backfilled by
+  `VesselSpawner.BackfillMaxDistanceAbsoluteOnly` over the live
+  recording's Points.
+- Merge-journal-active hides Discard on regular and Re-Fly
+  button-labels variants; handler refusal also fires when invoked
+  directly.
 - Popup `OnDismiss` without a button click: existing
   `ClearPendingFlag("popup teardown")` runs; no `s_AllowNextLoadScene`
-  leak (it was never set); pending tree remains stashed. Subsequent
-  scene-exit attempt re-enters the prefix and reuses the existing
-  pending tree without re-finalizing.
+  leak (it was never set); `activeTree` and recorder remain intact
+  because `preCommitFinalize` only runs inside the button-click
+  delegate. Subsequent scene-exit attempt re-enters the prefix from
+  the same in-flight state.
 - Deferred coroutine path emits the canary Warn when triggered.
 
 ### In-game tests
@@ -820,21 +897,21 @@ LANDED/SPLASHED situations pass through unchanged.)
 - We patch `HighLogic.LoadScene`, a hot KSP method. Filter is one
   comparison; cost is negligible. Verify in-game with `Verbose` log on
   every prefix entry during the first few minutes of a session.
-- Pre-finalize side effects fire in flight (BG checkpoint, ballistic-tail
-  extension, IncompleteBallisticSceneExitFinalizer, ledger-orchestrated
-  resource deltas). These already run during `OnSceneChangeRequested` -
-  we just hoist them by a few frames. No KSP-state mutation that depends
-  on the destination scene having loaded yet.
-- Pre-finalize "starves" the active recorder (`recorder = null`,
-  `backgroundRecorder.Shutdown()` at `ParsekFlight.cs:2840-2845`). If the
-  player dismisses the popup without clicking a button (P2 retry case),
-  the player is left in flight with no recording. Acceptable - they
-  can't escape via Esc anyway because `MultiOptionDialog` without an
-  explicit Cancel button does not allow Esc-dismiss; the popup-teardown
-  case is a Unity edge condition, not a normal flow.
-- Save throw in callback: logged as Warn, transition continues. Player
-  may lose Parsek state on game unload. Worse alternative would be to
-  block the transition forever - declined.
+- Finalize side effects (BG checkpoint, ballistic-tail extension,
+  `IncompleteBallisticSceneExitFinalizer`, ledger-orchestrated
+  resource deltas) fire inside the dialog button callback rather than
+  in `OnSceneChangeRequested`. They run a few frames earlier than
+  today and while the player is still in flight (paused under
+  `PauseMenu.Display`'s `FlightDriver.SetPause(true)`). No KSP-state
+  mutation that depends on the destination scene having loaded yet.
+- Save throw in callback: MAINMENU is a hard-block (error popup, no
+  transition). SC/TS/EDITOR is logged as Warn and continues; the
+  destination scene's own save cycle eventually persists. Worst case
+  on disk-full at SC: the on-disk state lags by one save cycle. See
+  `Persisting our mutations to disk` for the rationale.
+- Dialog dismissed without button click (Unity edge condition): the
+  recorder, `activeTree`, and `backgroundRecorder` are all intact
+  because nothing was finalized. Player resumes flight cleanly.
 - Dialog while in flight: KSP's `MultiOptionDialog` works in any scene
   with a live UI canvas. Confirmed by existing `ReFlyRevertDialog` which
   spawns the same kind of popup mid-flight.
@@ -892,21 +969,12 @@ LANDED/SPLASHED situations pass through unchanged.)
    worth a watchdog timer; document the risk and add a one-frame
    reaper in `ParsekFlight.Update` if observed in playtest.
 
-3. **`s_AllowNextLoadScene` wrong-destination warn** (Opus pass-3 F7):
-   step (1) of the prefix consumes the token unconditionally. If a
-   foreign mod's `LoadScene` slipped between callback set and our
-   prefix's consume, the token would be consumed for the wrong
-   destination. Add a stored `s_AllowNextLoadSceneDestination` that
-   the prefix checks against the actual `scene` param; if mismatched,
-   log Warn ("token consumed for unexpected dest=...") and fall
-   through to normal handling.
-
-2. **Suppression flag leak on `LoadScene` throw** (Opus #6): narrow
-   window where our prefix peeks the flag, bypasses, but stock
-   `LoadScene` itself throws before reaching `OnSceneChangeRequested`.
-   Flag stays armed; next regular flight-exit silently discards. Not
-   worth a watchdog timer; document the risk and add a one-frame
-   reaper in `ParsekFlight.Update` if observed in playtest.
+3. **`s_AllowNextLoadScene` wrong-destination warn** (Opus pass-3 F7,
+   pass-4 implementation): paired
+   `s_AllowNextLoadSceneDestination` field carries the expected
+   destination. Prefix step (1) checks `expected == scene` before
+   bypassing; mismatch logs Warn and falls through. Implemented in
+   the patch sketch above.
 
 ## CHANGELOG / todo updates
 

--- a/docs/dev/plans/merge-confirm-pretransition.md
+++ b/docs/dev/plans/merge-confirm-pretransition.md
@@ -78,11 +78,13 @@ Three buttons:
 and never run KSP's danger/quit confirmation popups. Patching `saveAndExit`
 alone would miss them.
 
-### Map-view shortcuts
+### Map-view, app-launcher, and toolbar shortcuts
 
-`FlightUIModeController` has zero scene-transition calls. The map view does not
-own Space Center / Tracking Station shortcuts. Only PauseMenu and
-FlightResultsDialog source flight-exit transitions.
+`FlightUIModeController` has zero direct scene-transition calls. App
+launcher and toolbar buttons that route to KSC / TS during flight all
+funnel through `HighLogic.LoadScene` (verified by spot-grep on
+`Assembly-CSharp.dll`). The chokepoint patch covers them automatically -
+the plan doesn't need a per-source patch list.
 
 ### Convergence point
 
@@ -144,47 +146,98 @@ The reviewer's P1 concern about an under-implemented `ReFlyExitDialog.Discard`
 dissolves because we reuse the existing path. **The Re-Fly variant becomes
 "same `ShowTreeDialog`, Re-Fly-scoped button labels".**
 
-### Tree finalize timing - pre-finalize before any decision
+### Tree finalize timing - defer everything to the dialog callback
 
-The dialog operates on a `RecordingTree` that must already be the *pending*
-tree (because `MergeCommit` -> `RecordingStore.CommitPendingTree` and
-`MergeDiscard` -> `RecordingStore.DiscardPendingTree` / `PopPendingTree`
-expect that contract). So the prefix runs the existing finalization flow
-*before* showing the dialog, then shows the dialog on the pending tree.
+**Update from Opus re-review pass 2**: the previous draft proposed
+"pre-finalize before showing dialog". That is unsafe because
+`FinalizeTreeOnSceneChangeCore` (`ParsekFlight.cs:2721`) is monolithic:
+it calls `FinalizeTreeRecordings` at `:2800` which calls
+`recorder.ForceStop()` at `ParsekFlight.cs:11218` and flushes the
+recorder into the tree, then drops `recorder`, `backgroundRecorder`,
+and `activeTree` to null at `ParsekFlight.cs:2840-2847`. There is no
+clean "compute terminal state in place without stopping the recorder"
+seam. If the popup is dismissed without a button click (Unity
+edge case, mod-spawned higher-priority popup, scene-load orchestrator
+forced UI teardown, `PopupDialog.DismissPopup` from foreign code),
+the player is stranded in flight with a dead recorder and a stashed
+pending tree.
 
-**Pre-finalize must come before the decision matrix and the idle-on-pad
-fast path.** `FinalizeTreeOnSceneChangeCore` (`ParsekFlight.cs:2721`) is
-where `FinalizeTreeRecordings` runs (`ParsekFlight.cs:2800`), and that's
-the call that backfills per-recording `TerminalStateValue` and
-`MaxDistanceFromLaunch` (the `#290d` post-finalize-state contract called
-out in the comment at `ParsekFlight.cs:2828`). If the prefix consults
-those fields before the call:
+**Resolution: defer all finalize work to the dialog callback.** The
+prefix shows the dialog on the live `activeTree` (recorder still
+running). Decision-helper queries read live state directly:
 
-- `ShouldShowCommitApproval` (autoMerge ON, landed/splashed approval gate)
-  reads a null `TerminalStateValue` and falls through to `None`. Stock
-  LoadScene runs, `OnSceneChangeRequested` finalizes, the destination
-  scene's `ShowDeferredMergeDialog` re-shows the same popup we tried to
-  prevent. The fix regresses to the old behaviour for the most common
-  approval case.
-- The idle-on-pad fast path reads a stale `MaxDistanceFromLaunch` and
-  may auto-discard a recording that has actually moved.
+- Variant: read `ParsekScenario.ActiveReFlySessionMarker` and
+  `ParsekScenario.IsAutoMerge`; for the autoMerge-ON Landed/Splashed
+  approval gate, query the active vessel's
+  `vessel.LandedOrSplashed` directly instead of relying on the
+  post-finalize `TerminalStateValue`. The two reads agree on the
+  outcome - `FinalizeTreeRecordings`' terminal-state computation
+  derives from the same vessel situation snapshot that's live now.
+- Idle-on-pad fast path: implement
+  `ParsekFlight.IsActiveTreeIdleOnPad()` mirroring the existing
+  `IsTreeIdleOnPad(RecordingStore.PendingTree)` (`ParsekScenario.cs:1684`).
+  Walk the active recordings and read the live vessel's
+  `srfRelRotation` / position vs the launch reference. Doesn't depend
+  on `MaxDistanceFromLaunch` because we have the live vessel.
 
-So the ordering is: pre-finalize unconditionally first, *then* run the
-variant decision and the idle-on-pad fast path against the pending tree
-that pre-finalize produced.
+On button click (Merge or Discard), the callback runs the full
+finalize-then-act sequence:
 
-After Merge or Discard, both `pendingTree` and `activeTree` are clean. When
-the dialog callback re-invokes `HighLogic.LoadScene(dest)`, the resulting
-`OnSceneChangeRequested` finds `activeTree == null` (early-out at
-`ParsekFlight.cs:2686`), and we have not armed the existing
-`NextTreeSceneExitCommitSuppression` flag, so the `else if` at
-`ParsekFlight.cs:2690` is also a no-op. There is nothing for
-`OnSceneChangeRequested` to do for the tree path - it just runs the rest of
-its scene-exit cleanup (watch mode, ghosts, terrain cache, etc.).
+```csharp
+Action proceed = () =>
+{
+    var fl = ParsekFlight.fetch;
+    fl?.FinalizeTreeOnSceneChangeForCallback(scene);   // stash + teardown
+    var pending = RecordingStore.PendingTree;
+    if (pending != null)
+    {
+        if (userChoseMerge) MergeDialog.MergeCommit(pending, decisions, spawnCount);
+        else                MergeDialog.MergeDiscard(pending);
+    }
+    SafeWritePersistent(scene);                        // P1.B (see below)
+    SceneExitInterceptor.s_AllowNextLoadScene = true;
+    HighLogic.LoadScene(scene);
+};
+```
 
-This eliminates the need for the `SuppressNextTreeSceneExitFinalize` flag
-that the previous draft proposed - the existing pending-tree handoff is
-already the right separation of concerns.
+Result:
+
+- **Popup dismissed without click**: nothing was finalized. Recorder
+  is still recording. `activeTree` is intact. Player resumes flight.
+  No leaked state. Plan's previous "pendingTree leak on dismiss"
+  branch is gone.
+- **Popup clicked**: finalize, commit/discard, save, transition. Same
+  end-state as the post-load deferred dialog produces today.
+- **F9 quickload while dialog open**: KSP calls `HighLogic.LoadScene(FLIGHT)`
+  to tear down for quickload. Our prefix's destination filter passes
+  `FLIGHT` through. Popup is destroyed during scene tear-down. No
+  pre-finalize happened, no pendingTree leak. Quickload proceeds
+  normally.
+- **MergeCommit operates on the just-stashed pending tree**: the
+  callback calls `FinalizeTreeOnSceneChangeForCallback` *first*, which
+  goes through the existing `StashPendingTree` path. So when
+  `MergeCommit` calls `RecordingStore.CommitPendingTree()` next, the
+  pending tree exists. Same contract as today's post-load dialog.
+
+The downside is that the dialog's body copy can't show the
+post-finalize summary (terminal state label, ballistic-extension
+endpoint, etc.) - it shows the pre-finalize live state. For the
+common case (vessel sitting at KSC after a flight) this is identical
+to the post-finalize state. Edge cases (incomplete ballistic extension,
+re-snapshot of stable terminals) show summary text computed on live
+state, which is a minor regression from today's deferred dialog.
+Acceptable - the alternative is reviving the recorder on dismiss, and
+that's a much harder refactor.
+
+After Merge or Discard runs in the callback, both `pendingTree` and
+`activeTree` are clean. When the callback re-invokes
+`HighLogic.LoadScene(dest)`, the resulting `OnSceneChangeRequested`
+finds `activeTree == null` (early-out at `ParsekFlight.cs:2686`), no
+`NextTreeSceneExitCommitSuppression` armed, `else if` branch is a
+no-op. No double-finalize.
+
+This eliminates the need for the `SuppressNextTreeSceneExitFinalize`
+flag that the original draft proposed.
 
 ### Persisting our mutations to disk
 
@@ -212,30 +265,73 @@ Symptom matrix:
   `FlightResultsDialog.cs:565, 599`): same as above - stock did not save.
 
 Fix: the proceed callback **always** writes a fresh persistent save before
-re-invoking `HighLogic.LoadScene`:
+re-invoking `HighLogic.LoadScene`. Save failure is **fatal for MAINMENU**
+(no later save will run before unload) and **logged-and-continued for
+other destinations** (the destination scene's own save cycle will eventually
+write our state):
 
 ```csharp
-GamePersistence.SaveGame(
-    HighLogic.CurrentGame.Updated(),
-    "persistent",
-    HighLogic.SaveFolder,
-    SaveMode.OVERWRITE);
-SceneExitInterceptor.s_AllowNextLoadScene = true;
-HighLogic.LoadScene(scene);
+bool SafeWritePersistent(GameScenes dest)
+{
+    try
+    {
+        GamePersistence.SaveGame(
+            HighLogic.CurrentGame.Updated(),
+            "persistent",
+            HighLogic.SaveFolder,
+            SaveMode.OVERWRITE);
+        return true;
+    }
+    catch (Exception ex)
+    {
+        ParsekLog.Error("SceneExit",
+            $"Pre-LoadScene SaveGame threw {ex.GetType().Name}: {ex.Message} dest={dest}");
+        if (dest == GameScenes.MAINMENU)
+        {
+            // Hard block: there is no later save. If we proceed, persistent.sfs
+            // stays at the pre-merge state and the player loads back into an
+            // inconsistent world. Show an error popup, leave the player in flight.
+            PopupDialog.SpawnPopupDialog(...
+                "Could not save before quitting to main menu. Try again, or " +
+                "quit to space center first.");
+            return false;
+        }
+        return true;   // SC/TS/EDITOR: degraded continuation acceptable
+    }
+}
+
+Action proceed = () =>
+{
+    // ... finalize + MergeCommit/MergeDiscard above ...
+    if (!SafeWritePersistent(scene)) return;   // dialog reappears next exit attempt
+    SceneExitInterceptor.s_AllowNextLoadScene = true;
+    HighLogic.LoadScene(scene);
+};
 ```
 
-This is what stock saveAndExit does, hoisted into our callback so it
-captures our post-dialog state. For destinations stock would not have
-saved (CanRestart, FlightResultsDialog direct), this is a net new save -
-acceptable because the player just made an explicit Merge/Discard choice
-and we want it persisted. The callback runs the save unconditionally; no
-"did stock already save?" detection needed.
+For destinations stock would not have saved (CanRestart no-save path,
+FlightResultsDialog direct LoadScene paths), the callback save is a net
+new save - acceptable because the player just made an explicit Merge /
+Discard choice and we want it persisted. The callback runs the save
+unconditionally on success path; no "did stock already save?" detection
+needed.
+
+**Crew reservation race (P1.C from re-review)**: `MergeCommit` calls
+`CrewReservationManager.SwapReservedCrewInFlight()` at `MergeDialog.cs:327`.
+Stock saveAndExit already saved the *unswapped* roster. Our callback save
+captures the post-swap state. Same correctness story as the rest of the
+mutations: the callback save is mandatory, and a save throw on MAINMENU
+is fatal for the same reason.
 
 `MergeDialog.TryDiscardActiveReFlyAttempt` already calls
 `SaveDiscardedReFlyStateDurably(sessionId)` at `MergeDialog.cs:459`. The
 unconditional callback save is redundant but not harmful for that path
-(both write the same persistent.sfs). The redundant write is cheap and
-removes a "did the right path save?" branching surface.
+(both write the same persistent.sfs). On slow disks two sequential
+saves of a large persistent.sfs may stutter for ~1s; acceptable. If
+playtest reveals the stutter is annoying, a one-shot
+`s_PersistentSavedThisTransition` flag inside `SafeWritePersistent`
+collapses the double-save - keep it as a follow-up rather than gating
+v1 on it.
 
 ## Implementation
 
@@ -252,10 +348,11 @@ Owns:
 - `internal enum DialogVariant { None, RegularMerge, ReFlyAttempt }`.
 - `Action<GameScenes> ShowHookForTesting` test seam mirroring `RevertInterceptor`.
 
-Patch sketch:
+Patch sketch (deferred-finalize):
 
 ```csharp
 [HarmonyPatch(typeof(HighLogic), nameof(HighLogic.LoadScene), new[] { typeof(GameScenes) })]
+[HarmonyPriority(Priority.Last)]
 internal static class HighLogic_LoadScene_Patch
 {
     static bool Prefix(GameScenes scene)
@@ -270,6 +367,7 @@ internal static class HighLogic_LoadScene_Patch
         }
 
         // (2) cheap filter - only intercept exits from FLIGHT to a flight-exit dest.
+        //     dest == FLIGHT (quickload, RewindInvoker, vessel switch) passes through.
         if (HighLogic.LoadedScene != GameScenes.FLIGHT) return true;
         if (scene != GameScenes.SPACECENTER &&
             scene != GameScenes.TRACKSTATION &&
@@ -279,7 +377,7 @@ internal static class HighLogic_LoadScene_Patch
         // (3) PEEK existing Discard-Re-Fly suppression. If RevertInterceptor armed
         //     ArmNextTreeSceneExitCommitSuppression, this transition is already
         //     owned by Discard Re-Fly - get out of the way without consuming the
-        //     flag (OnSceneChangeRequested / FinalizeTreeOnSceneChange consume it).
+        //     flag (FinalizeTreeOnSceneChange consumes it at ParsekFlight.cs:2734).
         if (RecordingStore.IsNextTreeSceneExitCommitSuppressionArmed)
         {
             ParsekLog.Info("SceneExit",
@@ -288,72 +386,58 @@ internal static class HighLogic_LoadScene_Patch
             return true;
         }
 
-        // (4) pre-finalize FIRST so all decisions read finalized data
-        //     (TerminalStateValue, MaxDistanceFromLaunch). Skip if a previous
-        //     dialog open already produced a pending tree (popup-teardown
-        //     retry case): activeTree was nulled at the end of the prior
-        //     FinalizeTreeOnSceneChangeCore, so a second invocation would NRE.
+        // (4) decision matrix on LIVE state. No pre-finalize - that runs in
+        //     the callback if and only if the player commits to a Merge or
+        //     Discard choice. Popup-dismiss-without-click leaves the recorder
+        //     and activeTree intact.
         var flight = ParsekFlight.fetch;
-        bool needsPreFinalize =
-            flight != null
-            && flight.HasActiveTree
-            && !RecordingStore.HasPendingTree;
-        if (needsPreFinalize)
-        {
-            flight.FinalizeTreeOnSceneChangeForCallback(scene);
-        }
+        if (flight == null || !flight.HasActiveTree) return true;
 
-        // (5) decision matrix - reads the now-finalized pending tree.
-        var pending = RecordingStore.PendingTree;
-        if (pending == null)
-        {
-            // Nothing to confirm. Let stock LoadScene proceed.
-            return true;
-        }
-
-        var variant = SceneExitInterceptor.ShouldShowDialogBeforeSceneChange(scene, pending);
+        var variant = SceneExitInterceptor.ShouldShowDialogBeforeSceneChange(
+            scene, flight);
         if (variant == DialogVariant.None) return true;
 
-        // (6) idle-on-pad auto-discard fast path mirroring ParsekScenario.cs:1682-1689.
-        //     Reads finalized MaxDistanceFromLaunch on the pending tree.
-        if (SceneExitInterceptor.TryAutoDiscardIdlePendingTree(scene, pending))
+        // (5) idle-on-pad auto-discard fast path. Reads live recorder /
+        //     activeTree state via ParsekFlight.IsActiveTreeIdleOnPad.
+        if (SceneExitInterceptor.TryAutoDiscardIdleActiveTree(scene, flight))
             return true;
 
-        // (7) show dialog. Same dialog for both variants - Re-Fly-aware copy
-        //     and Re-Fly-aware MergeCommit / MergeDiscard already live inside
-        //     MergeDialog. The variant only changes button-label copy.
-        Action proceed = () =>
+        // (6) show dialog on the live activeTree. Same dialog for both
+        //     variants - Re-Fly-aware copy and Re-Fly-aware MergeCommit /
+        //     MergeDiscard already live inside MergeDialog.
+        Action<bool> proceed = (isMerge) =>
         {
-            // P1.B: persist the dialog's mutations before the transition.
-            // Stock saveAndExit (PauseMenu.cs:1785) saved BEFORE our prefix
-            // ran, so its on-disk state is pre-mutation. Mainline-quit and
-            // CanRestart-no-save paths never saved at all. Always write a
-            // fresh persistent save so committed/discarded state lands on
-            // disk regardless of which entry point fired.
-            try
+            // Phase 1: full finalize-then-act (matches what
+            // OnSceneChangeRequested would have done a moment later).
+            flight.FinalizeTreeOnSceneChangeForCallback(scene);
+            var pending = RecordingStore.PendingTree;
+            if (pending != null)
             {
-                GamePersistence.SaveGame(
-                    HighLogic.CurrentGame.Updated(),
-                    "persistent",
-                    HighLogic.SaveFolder,
-                    SaveMode.OVERWRITE);
+                if (isMerge)
+                {
+                    var decisions = MergeDialog.BuildDefaultVesselDecisionsForPending(pending);
+                    MergeDialog.MergeCommit(pending, decisions, ComputeSpawnCount(decisions));
+                }
+                else
+                {
+                    MergeDialog.MergeDiscard(pending);
+                }
             }
-            catch (Exception ex)
-            {
-                ParsekLog.Warn("SceneExit",
-                    $"Pre-LoadScene SaveGame threw {ex.GetType().Name}: {ex.Message} - " +
-                    $"continuing transition (state may be lost on game unload)");
-            }
+
+            // Phase 2: persist mutations. Hard-block on MAINMENU save throw.
+            if (!SafeWritePersistent(scene)) return;
+
             SceneExitInterceptor.s_AllowNextLoadScene = true;
             HighLogic.LoadScene(scene);
         };
 
         MergeDialog.ShowTreeDialog(
-            pending,
+            flight.ActiveTreeForDisplay,
             buttonLabels: variant == DialogVariant.ReFlyAttempt
                 ? MergeDialogButtonLabels.ReFlyAttempt
                 : MergeDialogButtonLabels.Default,
-            postChoice: proceed);
+            onMerge: () => proceed(isMerge: true),
+            onDiscard: () => proceed(isMerge: false));
 
         return false;   // block stock LoadScene; dialog drives it
     }
@@ -362,54 +446,65 @@ internal static class HighLogic_LoadScene_Patch
 
 Notes:
 
-- The bypass flag is intentionally global / one-shot. KSP is single-threaded
-  for game logic; lifetime is "set immediately before re-invoke, consumed by
-  next prefix". If a stray `HighLogic.LoadScene` slips in between set and
-  consume, log Warn and fall through.
-- The prefix early-returns on the first comparison for non-FLIGHT loads, so
-  the cost added to KSP's hot LoadScene path is one branch.
-- Step (3) is a *peek*, not a consume - the existing Discard Re-Fly path
-  relies on `FinalizeTreeOnSceneChange` consuming the flag at
+- `[HarmonyPriority(Priority.Last)]` (Opus re-review #13): we run after
+  any other prefix that may already have rejected the call. Reduces the
+  risk of starting a dialog that another mod's prefix would have
+  cancelled. Verify against KSPCommunityFixes / KSPModFileLocalizer in
+  playtest.
+- The bypass flag is intentionally global / one-shot. KSP is
+  single-threaded for game logic; lifetime is "set immediately before
+  re-invoke, consumed by next prefix". A stray `HighLogic.LoadScene`
+  in between would consume the flag with the wrong destination - log
+  Warn and fall through. Narrow window since only our own callback
+  re-invokes LoadScene from in-flight context.
+- Step (3) is a *peek*, not a consume - the existing Discard Re-Fly
+  path relies on `FinalizeTreeOnSceneChange` consuming the flag at
   `ParsekFlight.cs:2734`, so we must not steal it.
-- Step (4)'s `HasActiveTree && !HasPendingTree` guard handles the
-  popup-teardown retry case (P2): a prior dialog open already pre-finalized
-  (cleared `activeTree`, stashed `pendingTree`) but the popup was dismissed
-  without a button click. On the next prefix entry we skip pre-finalize and
-  reuse the existing pending tree. `FinalizeTreeOnSceneChangeCore`
-  dereferences `activeTree` unconditionally (`ParsekFlight.cs:2800, :2810,
-  :2829, :2836`); calling it with `activeTree == null` would NRE.
-- `ParsekFlight.HasActiveTree` is a new public read-only property exposing
-  `activeTree != null` without exposing the field itself.
+- Step (4) reads from `flight.HasActiveTree` only; no pre-finalize
+  before the dialog. If the popup is dismissed without a button click,
+  no state was mutated.
+- Decision helper signature changed to take `ParsekFlight` instead of a
+  pending tree. The helper queries live state - active recording's
+  vessel via `flight.ActiveVessel` for the autoMerge-ON Landed/Splashed
+  approval gate, etc.
+- `flight.ActiveTreeForDisplay`, `flight.IsActiveTreeIdleOnPad()`, and
+  `flight.HasActiveTree` are new public read-only seams on
+  `ParsekFlight` that don't expose the private `activeTree` field
+  directly.
 
 ### Decision helper
 
 Pure helper `ShouldShowDialogBeforeSceneChange(GameScenes destination,
-RecordingTree finalizedPendingTree)`. Mirrors the OnLoad logic at
+ParsekFlight flight)`. Mirrors the OnLoad logic at
 `ParsekScenario.cs:1660-1723` so the pre-transition gate matches the
-existing post-load gate, but reads from the *already-finalized* pending
-tree the prefix passes in:
+existing post-load gate, but reads live state from the supplied
+`ParsekFlight`:
 
 ```
 if (Re-Fly session active)                                                   -> ReFlyAttempt
 if (autoMerge OFF)                                                           -> RegularMerge
 if (autoMerge ON
     && destination in {SPACECENTER, TRACKSTATION}
-    && root recording terminal state in {Landed, Splashed})                  -> RegularMerge   // = ShouldShowCommitApproval
+    && active vessel.LandedOrSplashed)                                       -> RegularMerge
 if (destination == MAINMENU)                                                 -> RegularMerge   // new: was force-auto-merge
 otherwise                                                                    -> None
 ```
 
-The "no pending tree" case is filtered earlier in the prefix (step 5) so
-the helper is only invoked when a finalized tree exists.
+The autoMerge ON Landed/Splashed gate (which today uses
+`ShouldShowCommitApproval` reading `TerminalStateValue` post-finalize)
+is now computed from the live vessel via `vessel.LandedOrSplashed`. The
+two values agree on the outcome - `FinalizeTreeRecordings` derives
+`TerminalStateValue` from the same vessel-situation snapshot that the
+live read returns. Document this in a comment in the helper so future
+maintainers understand they cannot drift.
 
-Reading `TerminalStateValue` from the finalized pending tree (not the
-live-recorder activeTree) is what makes the autoMerge approval gate work
-pre-transition. See "Tree finalize timing" above for why ordering matters.
-
-Idle-on-pad auto-discard (`ParsekScenario.cs:1682-1689, :4825-4834`) runs
-as a fast path *after* the variant decision inside the prefix and reads
-`MaxDistanceFromLaunch` from the same finalized tree so it sees the
-post-#290d-backfill value rather than the stale live-recorder value.
+Idle-on-pad auto-discard runs after the variant decision and reads the
+live activeTree via a new `ParsekFlight.IsActiveTreeIdleOnPad()` that
+mirrors the existing `IsTreeIdleOnPad(RecordingStore.PendingTree)`
+check used by the OnLoad path (`ParsekScenario.cs:1684`). The new
+method walks active recordings and computes idle-on-pad from live
+vessel position rather than from the post-#290d-backfilled
+`MaxDistanceFromLaunch` field.
 
 ### `MergeDialog.cs` changes
 
@@ -440,7 +535,9 @@ post-#290d-backfill value rather than the stale live-recorder value.
   `RevertInterceptor.cs:345-352`). Mirror that pattern in two places:
   - `MergeDialog.MergeDiscard`: at the top, before `TryDiscardActiveReFlyAttempt`,
     refuse if `ActiveMergeJournal != null` with a `ParsekLog.Warn` and a
-    `PostScreenMessage("Discard: merge in progress - retry in a moment")`.
+    `ParsekLog.ScreenMessage("Discard: merge in progress - retry in a moment", 3f)`
+    (Opus re-review #11: existing code uses `ParsekLog.ScreenMessage`,
+    not `ScreenMessages.PostScreenMessage`).
   - `MergeDialog.TryDiscardActiveReFlyAttempt`: at the top, refuse with
     the same pattern. Belt-and-braces for any future call site that
     bypasses `MergeDiscard`.
@@ -469,16 +566,27 @@ post-#290d-backfill value rather than the stale live-recorder value.
 
 - New `internal void FinalizeTreeOnSceneChangeForCallback(GameScenes scene)`
   - delegates to the existing `FinalizeTreeOnSceneChangeCore`. The
-  in-callback finalize is identical to what `OnSceneChangeRequested` would
-  have done a moment later. Caller is responsible for guarding against
-  `activeTree == null` (the prefix's `HasActiveTree && !HasPendingTree`
-  check covers this).
-- New `internal bool HasActiveTree => activeTree != null;` - read-only peek
-  for the prefix without exposing the field.
-- No changes to `FinalizeTreeOnSceneChange` itself. After the callback runs
-  `MergeCommit` or `MergeDiscard`, both `activeTree` and `pendingTree` are
-  cleared, so the existing checks at `ParsekFlight.cs:2686, :2690` are
-  no-ops on the second LoadScene re-invoke.
+  in-callback finalize is identical to what `OnSceneChangeRequested`
+  would have done a moment later. Only invoked from the dialog
+  callback's Phase 1.
+- New `internal bool HasActiveTree => activeTree != null;` - read-only
+  peek for the prefix without exposing the field.
+- New `internal RecordingTree ActiveTreeForDisplay => activeTree;`
+  read-only accessor for the dialog's display data. The dialog must
+  not mutate the returned reference; the eventual mutation happens
+  inside `MergeCommit` / `MergeDiscard` after the callback's Phase 1
+  finalize.
+- New `internal bool IsActiveTreeIdleOnPad()` - mirrors the existing
+  `IsTreeIdleOnPad(RecordingTree)` (private static helper used by
+  `ParsekScenario.cs:1684` via `RecordingStore.PendingTree`) but reads
+  the live `activeTree` and live vessel position. Walks recordings,
+  computes distance-from-launch from live data rather than from the
+  post-#290d `MaxDistanceFromLaunch` field.
+- No changes to `FinalizeTreeOnSceneChange` itself. After the callback
+  runs `MergeCommit` or `MergeDiscard`, both `activeTree` and
+  `pendingTree` are cleared, so the existing checks at
+  `ParsekFlight.cs:2686, :2690` are no-ops on the second LoadScene
+  re-invoke.
 
 ### `ParsekScenario.cs` changes
 
@@ -533,41 +641,35 @@ No `ReFlyExitDialog.cs` (removed from previous draft - existing
 - `LoadedScene != FLIGHT` -> prefix returns true regardless of other state.
 - Destination not in {KSC, TS, MAINMENU, EDITOR} -> prefix returns true.
 
-### Pre-finalize / suppression flag separation (P1.A + P2 coverage)
+### Deferred-finalize lifecycle (P1.A + Opus #1 + P2 coverage)
 
-- Prefix calls `FinalizeTreeOnSceneChangeForCallback` BEFORE consulting
-  `TerminalStateValue` or `MaxDistanceFromLaunch`. Resulting
-  `RecordingStore.PendingTree` is non-null and carries finalized
-  per-recording terminal state. `ParsekFlight.activeTree` is null
-  afterwards.
-- AutoMerge ON, Landed/Splashed terminal: pre-finalize backfills
-  `TerminalStateValue`, decision helper returns `RegularMerge`, dialog
-  shows. Without pre-finalize-first ordering this case would have
-  fallen through to `None` and shown the deferred post-load dialog
-  instead - covers the P1.A regression.
-- Idle-on-pad fast path: reads `MaxDistanceFromLaunch` from the finalized
-  pending tree, not from the live recorder. Asserts the
-  pre-#290d-backfill stale value does not trigger a false auto-discard.
-- Dialog `MergeCommit` runs: `pendingTree` is committed and cleared.
-  Re-invoke `HighLogic.LoadScene` -> `OnSceneChangeRequested` finds
-  `activeTree == null`, no `NextTreeSceneExitCommitSuppression` armed,
-  `else if` branch is a no-op. No double-commit.
-- Dialog `MergeDiscard` runs: `pendingTree` is popped. Re-invoke ->
-  same no-op path. No leak of pending tree.
-- Popup-teardown retry (P2): first prefix entry pre-finalizes (clears
-  `activeTree`, stashes `pendingTree`). Popup is dismissed without a
-  button click. Player triggers another scene exit. Prefix re-enters
-  with `HasActiveTree == false` and `HasPendingTree == true`; skips
-  pre-finalize, reads decision from existing pending tree, shows dialog.
-  No NRE on the second `FinalizeTreeOnSceneChangeForCallback` call.
-- Pre-finalize produces no pending tree (e.g. unfinalized recorder had
-  nothing to commit): prefix's step 5 sees `pending == null` and lets
-  the transition through.
+- Prefix decision reads live state only (`activeTree`, live vessel,
+  marker, autoMerge setting). No pre-finalize, no recorder mutation,
+  no `activeTree` teardown.
+- AutoMerge ON, vessel landed at KSC, exit -> SPACECENTER: helper sees
+  `vessel.LandedOrSplashed && IsAutoMerge && dest == SPACECENTER` ->
+  `RegularMerge`. Dialog shows. Click Merge: callback finalizes,
+  commits. Click Discard: callback finalizes, discards. Either way,
+  state lands on disk via `SafeWritePersistent`.
+- Popup dismissed without click: nothing was finalized; `activeTree`,
+  recorder, `backgroundRecorder` all alive; player resumes flight.
+  Subsequent scene-exit re-enters the prefix from the same in-flight
+  state. No NRE risk because pre-finalize never ran.
+- F9 quickload during open dialog: KSP calls
+  `HighLogic.LoadScene(FLIGHT)`. Our prefix's filter rejects
+  `dest == FLIGHT`. Popup is destroyed by scene tear-down. No
+  pre-finalize had run, so no leaked pending tree. Quickload proceeds
+  cleanly.
+- Callback's full finalize (`FinalizeTreeOnSceneChangeForCallback`) +
+  `MergeCommit` or `MergeDiscard` produces clean state: both
+  `activeTree` and `pendingTree` are null afterwards. Re-invoked
+  `HighLogic.LoadScene` triggers `OnSceneChangeRequested`, which
+  early-outs at `ParsekFlight.cs:2686` (`activeTree == null`).
 - Existing Discard Re-Fly path: `RevertInterceptor.DiscardReFlyHandler`
   arms the existing flag, calls `LoadScene`, our prefix bypasses (step
-  3), stock `OnSceneChangeRequested` runs, `FinalizeTreeOnSceneChange`
-  consumes the flag and discards `activeTree` per the existing contract.
-  Unchanged.
+  3), stock `OnSceneChangeRequested` runs,
+  `FinalizeTreeOnSceneChange` consumes the flag and discards
+  `activeTree` per the existing contract. Unchanged.
 
 ### Persistence (P1.B coverage)
 
@@ -579,9 +681,24 @@ No `ReFlyExitDialog.cs` (removed from previous draft - existing
   stock did not save.
 - FlightResultsDialog Btn_KSC / Btn_Menu direct-LoadScene: assert
   callback save fires (stock did not save).
-- Save throws (disk full, IO error): assert prefix logs Warn and
-  continues with LoadScene (degraded behaviour - state may be lost on
-  unload, but blocking the transition entirely is worse).
+- Crew-swap captured (Opus #3): assert post-merge persistent.sfs has
+  the swapped roster (`CrewReservationManager.SwapReservedCrewInFlight`
+  ran, our save captured it).
+- Save throws on MAINMENU: assert transition is *blocked*, error popup
+  shown, `s_AllowNextLoadScene` not set, `pendingTree` not stashed
+  (callback aborted before finalize? - actually finalize runs first;
+  decide whether to roll-back finalize on save fail or accept the
+  inconsistency. Document the trade-off in the plan.) Implementation
+  decision: finalize runs first, save fails, error popup shown -
+  user retries the exit, which re-enters the prefix; the second
+  attempt sees `HasActiveTree == false` (already finalized) but
+  `HasPendingTree == true`, takes a different code path (no
+  pre-finalize, dialog already showed?). Need a "merge journal active /
+  pending tree from previous prefix attempt" branch in the prefix.
+  Open question - see "Open questions" below.
+- Save throws on SPACECENTER / TRACKSTATION / EDITOR: assert prefix
+  logs Warn and continues with LoadScene; destination scene's own
+  save cycle eventually persists.
 
 ### Merge-journal-active guard (P1.C coverage)
 
@@ -614,21 +731,32 @@ No `ReFlyExitDialog.cs` (removed from previous draft - existing
 - In flight, click Esc -> Space Center: dialog appears in flight scene,
   not after Space Center loads.
 - In flight, click Esc -> Tracking Station: same.
-- In flight, click Esc -> Quit to Main Menu: stock confirmation popup runs
-  first, then our merge dialog, then main menu loads.
+- In flight, click Esc -> Quit to Main Menu: stock confirmation popup
+  runs first, then our merge dialog, then main menu loads.
 - Crash, FlightResultsDialog appears, click Space Center button: merge
   dialog appears in flight scene, not after Space Center loads.
-- Re-Fly session active, click Esc -> Space Center: dialog appears with
-  Re-Fly-scoped button labels, Discard wires through
+- Re-Fly session active, click Esc -> Space Center: dialog appears
+  with Re-Fly-scoped button labels, Discard wires through
   `TryDiscardActiveReFlyAttempt`.
-- Re-Fly session active, click Revert button: existing `ReFlyRevertDialog`
-  fires (covered by `RevertInterceptor`). Discard Re-Fly from that dialog
-  triggers `RecordingStore.ArmNextTreeSceneExitCommitSuppression` ->
-  `HighLogic.LoadScene(SPACECENTER)`; our prefix sees the armed flag and
-  bypasses without re-prompting.
+- Re-Fly session active, click Revert button: existing
+  `ReFlyRevertDialog` fires (covered by `RevertInterceptor`). Discard
+  Re-Fly from that dialog triggers
+  `RecordingStore.ArmNextTreeSceneExitCommitSuppression` ->
+  `HighLogic.LoadScene(SPACECENTER)`; our prefix sees the armed flag
+  and bypasses without re-prompting.
 - Low-altitude flight (atmosphere, can't save): orange "you will lose
-  progress" popup runs first, then on Yes our merge dialog appears (not
-  after the destination scene loads).
+  progress" popup runs first, then on Yes our merge dialog appears
+  (not after the destination scene loads).
+- Test runner overlay (Ctrl+Shift+T) open during merge dialog
+  (Opus #8): both render correctly. Merge dialog input lock is
+  `ControlTypes.All` which blocks game input but doesn't block IMGUI
+  windows. Test runner stays interactive.
+- F9 quickload while merge dialog is up (Opus #5): scene tears down,
+  popup destroyed, quickload completes cleanly, no leaked pending
+  tree.
+- KSPCommunityFixes installed: assert our prefix runs after KSPCF's
+  `HighLogic.LoadScene` patches. `HarmonyPriority.Last` is set on
+  our prefix.
 
 ## Risks
 
@@ -663,6 +791,37 @@ No `ReFlyExitDialog.cs` (removed from previous draft - existing
 - KSP version drift: if a future KSP update adds new flight-exit entry
   points or changes the `HighLogic.LoadScene` signature, the prefix needs
   updating. The deferred-coroutine canary is the early-warning system.
+
+## Open questions
+
+1. **MAINMENU save-fail rollback**: if Phase 1 finalize runs (committing
+   or discarding the tree), then Phase 2 save fails on MAINMENU and we
+   block the transition, the player is left in flight with `activeTree
+   == null` (Phase 1 already cleared it) and either a committed tree
+   in the persistent storage or a popped pending tree. They cannot
+   resume recording the same flight. They can:
+
+   - Try Quit-to-Main-Menu again - prefix sees `HasActiveTree ==
+     false` and short-circuits to `return true` (no dialog needed,
+     transition proceeds with the in-memory state we already
+     mutated). But persistent.sfs is still pre-mutation. So this is
+     just kicking the can down the road.
+   - Try Quit-to-Main-Menu again, but the second time the save
+     succeeds (transient disk error resolved). Acceptable recovery.
+   - Use Space Center instead - prefix sees `HasActiveTree == false`,
+     transitions to SC, the SC scene's own save cycle runs, captures
+     our state.
+
+   Document path 3 in the error popup ("Could not save before quitting
+   to main menu. Try going to Space Center instead, then quit from
+   there."). Accept that path 1 is degraded but path 3 is clean.
+
+2. **Suppression flag leak on `LoadScene` throw** (Opus #6): narrow
+   window where our prefix peeks the flag, bypasses, but stock
+   `LoadScene` itself throws before reaching `OnSceneChangeRequested`.
+   Flag stays armed; next regular flight-exit silently discards. Not
+   worth a watchdog timer; document the risk and add a one-frame
+   reaper in `ParsekFlight.Update` if observed in playtest.
 
 ## CHANGELOG / todo updates
 

--- a/docs/dev/plans/merge-confirm-pretransition.md
+++ b/docs/dev/plans/merge-confirm-pretransition.md
@@ -1,0 +1,676 @@
+# Merge confirmation dialog before scene transition
+
+## Problem
+
+The "Merge to Timeline / Discard" confirmation dialog for tree recordings is shown
+*after* the destination scene has finished loading. The flow when the player clicks
+Space Center / Tracking Station / Quit-to-Main-Menu in flight or map view:
+
+1. KSP fires `onGameSceneLoadRequested` -> `ParsekFlight.OnSceneChangeRequested`
+   (`ParsekFlight.cs:2638`) finalizes the tree and stashes it as pending.
+2. Flight scene tears down. Destination scene starts loading.
+3. `ParsekScenario.OnLoad` runs in the new scene, sees a pending tree, decides
+   "show approval dialog" via `GhostPlaybackLogic.ShouldShowCommitApproval`
+   (`GhostPlaybackLogic.cs:195`), and starts `ShowDeferredMergeDialog`
+   (`ParsekScenario.cs:1696, 1722, 2010`).
+4. That coroutine yields ~60 frames waiting for UI skin / singletons
+   (`ParsekScenario.cs:4807-4842`) before calling `MergeDialog.ShowTreeDialog`
+   (`MergeDialog.cs:84`).
+
+Result: the player sees the destination scene fully come up, then ~1 s later a
+popup asks them about a recording from the flight they already left.
+
+Quit-to-Main-Menu currently also forces auto-merge (no dialog) at
+`ParsekScenario.cs:1659`.
+
+## Goal
+
+Show the merge dialog while still in flight, *before* the scene transition starts.
+On Merge / Discard, run the same finalization that today happens in
+`OnSceneChangeRequested`, then let the scene transition proceed. Stock KSP
+warning popups (atmosphere / throttle / quit confirmation) must still run first.
+
+## Decisions (locked in)
+
+| Decision | Choice |
+| --- | --- |
+| Quit-to-Main-Menu | Show dialog (drop force-auto-merge) |
+| Tree finalize timing | Pre-finalize *before* showing the dialog so the dialog operates on an already-stashed pending tree |
+| Cancel button on regular dialog | None - click commits the player to leaving |
+| Re-Fly-aware dialog | Reuse `MergeDialog.ShowTreeDialog` with Re-Fly-attempt-scoped button labels and body copy (existing dialog already handles Re-Fly merge / discard correctly inside `MergeCommit` / `MergeDiscard`) |
+| Stock KSP danger / quit confirmations | Must run first (see patch chokepoint below) |
+
+## Patch chokepoint - decompilation findings
+
+dnSpy of `Assembly-CSharp.dll` (KSP 1.12.x) confirms three flight-exit sources,
+all of which converge on `HighLogic.LoadScene(GameScenes)`:
+
+### `PauseMenu` (Esc menu)
+
+Three buttons: Space Center (`PauseMenu:850-878`), Tracking Station
+(`PauseMenu:920-948`), Quit-to-Main-Menu (`PauseMenu:1074-1117`).
+
+- If `canSaveAndExit == ClearToSaveStatus.CLEAR`: fire `onSceneConfirmExit`,
+  call `saveAndExit(dest, ...)` -> `HighLogic.LoadScene(dest)` at
+  `PauseMenu:1803`. Quit-to-Main-Menu additionally checks
+  `showExitToMainConfirmation` (settings flag) and routes through
+  `ShowExitToMainConfirmation` -> `SubmitExitToMainMenuConfirmation` ->
+  `saveAndExit` if the flag is set.
+- If `canSaveAndExit != CLEAR`: spawn the orange "you will lose progress"
+  warning popup using `drawExitWithoutSaveOptions()`. Yes-button paths:
+  - `Parameters.Flight.CanRestart`: direct
+    `HighLogic.LoadScene(sceneToLeaveTo)` at `PauseMenu:1632` (no save).
+  - Otherwise: `saveAndExit(sceneToLeaveTo, ...)`.
+
+### `FlightResultsDialog` (post-flight crash report)
+
+Three buttons:
+
+- `Btn_KSC` at `FlightResultsDialog:565`: direct
+  `HighLogic.LoadScene(SPACECENTER)`. Skips PauseMenu entirely.
+- `Btn_Menu` at `FlightResultsDialog:599`: direct
+  `HighLogic.LoadScene(MAINMENU)`. Skips PauseMenu entirely.
+- `Btn_TS` at `FlightResultsDialog:533`: routes through `onLeavingFlight`
+  (PreFlightCheck `FacilityOperational`) -> `onLeavingFlightProceed` ->
+  `HighLogic.LoadScene(TRACKSTATION)` at `FlightResultsDialog:710`.
+
+`FlightResultsDialog`'s KSC and Menu buttons never fire `onSceneConfirmExit`
+and never run KSP's danger/quit confirmation popups. Patching `saveAndExit`
+alone would miss them.
+
+### Map-view shortcuts
+
+`FlightUIModeController` has zero scene-transition calls. The map view does not
+own Space Center / Tracking Station shortcuts. Only PauseMenu and
+FlightResultsDialog source flight-exit transitions.
+
+### Convergence point
+
+Every flight-exit path eventually calls `HighLogic.LoadScene(GameScenes)`. By
+that point all stock warnings / quit confirmations have already been confirmed
+by the user. This is the only single-method chokepoint that catches every
+case (PauseMenu both branches, FlightResultsDialog all three buttons, future
+mods).
+
+## Architecture
+
+### Two existing flight-scene-exit suppression flags (do not duplicate)
+
+`RecordingStore` already exposes two one-shot guards used by Discard Re-Fly:
+
+- `ArmNextTreeSceneExitCommitSuppression(reason)` /
+  `TryConsumeNextTreeSceneExitCommitSuppression(scene, out reason)`
+  (`RecordingStore.cs:1166, :1175`). Suppresses the auto-stash-as-pending side
+  effect of `OnSceneChangeRequested` -> `FinalizeTreeOnSceneChange`. Consumed
+  inside `FinalizeTreeOnSceneChange` (`ParsekFlight.cs:2734`) where it routes
+  to `DiscardActiveTreeForSuppressedSceneExit` instead of stashing, and inside
+  `OnSceneChangeRequested`'s `else if` branch (`ParsekFlight.cs:2690`) when
+  there is no active tree.
+- `ArmNextActiveTreeRestoreSuppression` / `TryConsumeNextActiveTreeRestoreSuppression`
+  (`RecordingStore.cs:1200`, :1209). Distinct flag for the OnLoad active-tree
+  restore pass.
+
+`RevertInterceptor.DiscardReFlyHandler` (`RevertInterceptor.cs:514-522`) arms
+*both* before calling `HighLogic.LoadScene(SPACECENTER / EDITOR)`. The new
+prefix MUST treat that armed-state as "another path owns this transition" and
+get out of the way. Otherwise the prefix sees a regular non-Re-Fly exit (the
+marker has already been cleared by Discard Re-Fly), spots a pending tree, and
+re-prompts the merge dialog - defeating the discard.
+
+### `MergeDialog.ShowTreeDialog` already handles Re-Fly correctly
+
+Critical finding from review: there is no need for a separate
+`ReFlyExitDialog` class.
+
+- `MergeDialog.ShowTreeDialog` already detects an active Re-Fly marker
+  (`MergeDialog.cs:144-169`) and adapts the body copy to show the Re-Fly
+  recording's vessel + duration plus a "this cannot be undone" warning.
+- The "Merge to Timeline" button calls `MergeCommit`, which already invokes
+  `TryCommitReFlySupersede` (`MergeDialog.cs:336-337`) - the canonical Re-Fly
+  merge path with full supersede / tombstone / quicksave handling.
+- The "Discard" button calls `MergeDiscard`, which calls
+  `TryDiscardActiveReFlyAttempt` first (`MergeDialog.cs:382`). That function
+  is the canonical Re-Fly attempt-discard path and performs *all* required
+  cleanup: remove committed attempt recordings, purge attempt game-state
+  events, purge in-place attempt events, delete attempt recording files,
+  clear transient fields, restore in-place original from snapshot or trim
+  back to origin RP, promote origin RP, purge session RPs, restore detached
+  committed tree, pop pending tree, clear pending science subjects + replay
+  scope, clear marker + journal, bump supersede state version, apply
+  Re-Fly-revert button gate, clear pre-Re-Fly anchor snapshots, recalculate
+  ledger, save persistent state durably (`MergeDialog.cs:405-478`).
+
+The reviewer's P1 concern about an under-implemented `ReFlyExitDialog.Discard`
+dissolves because we reuse the existing path. **The Re-Fly variant becomes
+"same `ShowTreeDialog`, Re-Fly-scoped button labels".**
+
+### Tree finalize timing - pre-finalize before any decision
+
+The dialog operates on a `RecordingTree` that must already be the *pending*
+tree (because `MergeCommit` -> `RecordingStore.CommitPendingTree` and
+`MergeDiscard` -> `RecordingStore.DiscardPendingTree` / `PopPendingTree`
+expect that contract). So the prefix runs the existing finalization flow
+*before* showing the dialog, then shows the dialog on the pending tree.
+
+**Pre-finalize must come before the decision matrix and the idle-on-pad
+fast path.** `FinalizeTreeOnSceneChangeCore` (`ParsekFlight.cs:2721`) is
+where `FinalizeTreeRecordings` runs (`ParsekFlight.cs:2800`), and that's
+the call that backfills per-recording `TerminalStateValue` and
+`MaxDistanceFromLaunch` (the `#290d` post-finalize-state contract called
+out in the comment at `ParsekFlight.cs:2828`). If the prefix consults
+those fields before the call:
+
+- `ShouldShowCommitApproval` (autoMerge ON, landed/splashed approval gate)
+  reads a null `TerminalStateValue` and falls through to `None`. Stock
+  LoadScene runs, `OnSceneChangeRequested` finalizes, the destination
+  scene's `ShowDeferredMergeDialog` re-shows the same popup we tried to
+  prevent. The fix regresses to the old behaviour for the most common
+  approval case.
+- The idle-on-pad fast path reads a stale `MaxDistanceFromLaunch` and
+  may auto-discard a recording that has actually moved.
+
+So the ordering is: pre-finalize unconditionally first, *then* run the
+variant decision and the idle-on-pad fast path against the pending tree
+that pre-finalize produced.
+
+After Merge or Discard, both `pendingTree` and `activeTree` are clean. When
+the dialog callback re-invokes `HighLogic.LoadScene(dest)`, the resulting
+`OnSceneChangeRequested` finds `activeTree == null` (early-out at
+`ParsekFlight.cs:2686`), and we have not armed the existing
+`NextTreeSceneExitCommitSuppression` flag, so the `else if` at
+`ParsekFlight.cs:2690` is also a no-op. There is nothing for
+`OnSceneChangeRequested` to do for the tree path - it just runs the rest of
+its scene-exit cleanup (watch mode, ghosts, terrain cache, etc.).
+
+This eliminates the need for the `SuppressNextTreeSceneExitFinalize` flag
+that the previous draft proposed - the existing pending-tree handoff is
+already the right separation of concerns.
+
+### Persisting our mutations to disk
+
+`PauseMenu.saveAndExit` at `PauseMenu.cs:1781-1804` writes persistent.sfs at
+line 1785 *before* calling `HighLogic.LoadScene`. By the time our prefix
+fires, the stock save reflects the pre-merge / pre-discard state. Our
+callback then mutates `CommittedRecordings`, `pendingTree`, the ledger,
+science subjects, RPs, supersede relations, marker, journal, etc. - and
+re-invokes `HighLogic.LoadScene` directly. None of those mutations reach
+disk through the stock saveAndExit pipeline.
+
+Symptom matrix:
+
+- **Space Center / Tracking Station** destinations: the destination scene's
+  ScenarioModule cycle eventually re-saves and our state lands in
+  persistent.sfs - but a crash or quit between dialog and next save loses
+  the merge / discard.
+- **Quit to Main Menu**: the game unloads immediately. `persistent.sfs`
+  stays at the pre-mutation state. Re-loading the save reveals
+  inconsistent Parsek state.
+- **PauseMenu dangerous-no-save path** (`PauseMenu.cs:1611-1633`,
+  `Parameters.Flight.CanRestart`): stock did not save at all. Our merge
+  /discard mutates state but nothing reaches disk.
+- **FlightResultsDialog Btn_KSC / Btn_Menu** (direct LoadScene at
+  `FlightResultsDialog.cs:565, 599`): same as above - stock did not save.
+
+Fix: the proceed callback **always** writes a fresh persistent save before
+re-invoking `HighLogic.LoadScene`:
+
+```csharp
+GamePersistence.SaveGame(
+    HighLogic.CurrentGame.Updated(),
+    "persistent",
+    HighLogic.SaveFolder,
+    SaveMode.OVERWRITE);
+SceneExitInterceptor.s_AllowNextLoadScene = true;
+HighLogic.LoadScene(scene);
+```
+
+This is what stock saveAndExit does, hoisted into our callback so it
+captures our post-dialog state. For destinations stock would not have
+saved (CanRestart, FlightResultsDialog direct), this is a net new save -
+acceptable because the player just made an explicit Merge/Discard choice
+and we want it persisted. The callback runs the save unconditionally; no
+"did stock already save?" detection needed.
+
+`MergeDialog.TryDiscardActiveReFlyAttempt` already calls
+`SaveDiscardedReFlyStateDurably(sessionId)` at `MergeDialog.cs:459`. The
+unconditional callback save is redundant but not harmful for that path
+(both write the same persistent.sfs). The redundant write is cheap and
+removes a "did the right path save?" branching surface.
+
+## Implementation
+
+### New file: `Source/Parsek/SceneExitInterceptor.cs`
+
+Owns:
+
+- A Harmony Prefix on `HighLogic.LoadScene(GameScenes)`.
+- `internal static bool s_AllowNextLoadScene` - one-shot bypass token. Set by
+  the dialog button callbacks just before re-invoking `HighLogic.LoadScene`,
+  consumed by the next prefix entry.
+- `internal static DialogVariant ShouldShowDialogBeforeSceneChange(GameScenes
+  destination)` - pure decision helper, unit-testable.
+- `internal enum DialogVariant { None, RegularMerge, ReFlyAttempt }`.
+- `Action<GameScenes> ShowHookForTesting` test seam mirroring `RevertInterceptor`.
+
+Patch sketch:
+
+```csharp
+[HarmonyPatch(typeof(HighLogic), nameof(HighLogic.LoadScene), new[] { typeof(GameScenes) })]
+internal static class HighLogic_LoadScene_Patch
+{
+    static bool Prefix(GameScenes scene)
+    {
+        // (1) one-shot self-bypass token: our own dialog callback re-invoked LoadScene.
+        if (SceneExitInterceptor.s_AllowNextLoadScene)
+        {
+            SceneExitInterceptor.s_AllowNextLoadScene = false;
+            ParsekLog.Verbose("SceneExit",
+                $"LoadScene prefix: bypassing via s_AllowNextLoadScene dest={scene}");
+            return true;
+        }
+
+        // (2) cheap filter - only intercept exits from FLIGHT to a flight-exit dest.
+        if (HighLogic.LoadedScene != GameScenes.FLIGHT) return true;
+        if (scene != GameScenes.SPACECENTER &&
+            scene != GameScenes.TRACKSTATION &&
+            scene != GameScenes.MAINMENU &&
+            scene != GameScenes.EDITOR) return true;
+
+        // (3) PEEK existing Discard-Re-Fly suppression. If RevertInterceptor armed
+        //     ArmNextTreeSceneExitCommitSuppression, this transition is already
+        //     owned by Discard Re-Fly - get out of the way without consuming the
+        //     flag (OnSceneChangeRequested / FinalizeTreeOnSceneChange consume it).
+        if (RecordingStore.IsNextTreeSceneExitCommitSuppressionArmed)
+        {
+            ParsekLog.Info("SceneExit",
+                $"LoadScene prefix: bypassing - existing tree-scene-exit-commit " +
+                $"suppression armed (Discard Re-Fly path) dest={scene}");
+            return true;
+        }
+
+        // (4) pre-finalize FIRST so all decisions read finalized data
+        //     (TerminalStateValue, MaxDistanceFromLaunch). Skip if a previous
+        //     dialog open already produced a pending tree (popup-teardown
+        //     retry case): activeTree was nulled at the end of the prior
+        //     FinalizeTreeOnSceneChangeCore, so a second invocation would NRE.
+        var flight = ParsekFlight.fetch;
+        bool needsPreFinalize =
+            flight != null
+            && flight.HasActiveTree
+            && !RecordingStore.HasPendingTree;
+        if (needsPreFinalize)
+        {
+            flight.FinalizeTreeOnSceneChangeForCallback(scene);
+        }
+
+        // (5) decision matrix - reads the now-finalized pending tree.
+        var pending = RecordingStore.PendingTree;
+        if (pending == null)
+        {
+            // Nothing to confirm. Let stock LoadScene proceed.
+            return true;
+        }
+
+        var variant = SceneExitInterceptor.ShouldShowDialogBeforeSceneChange(scene, pending);
+        if (variant == DialogVariant.None) return true;
+
+        // (6) idle-on-pad auto-discard fast path mirroring ParsekScenario.cs:1682-1689.
+        //     Reads finalized MaxDistanceFromLaunch on the pending tree.
+        if (SceneExitInterceptor.TryAutoDiscardIdlePendingTree(scene, pending))
+            return true;
+
+        // (7) show dialog. Same dialog for both variants - Re-Fly-aware copy
+        //     and Re-Fly-aware MergeCommit / MergeDiscard already live inside
+        //     MergeDialog. The variant only changes button-label copy.
+        Action proceed = () =>
+        {
+            // P1.B: persist the dialog's mutations before the transition.
+            // Stock saveAndExit (PauseMenu.cs:1785) saved BEFORE our prefix
+            // ran, so its on-disk state is pre-mutation. Mainline-quit and
+            // CanRestart-no-save paths never saved at all. Always write a
+            // fresh persistent save so committed/discarded state lands on
+            // disk regardless of which entry point fired.
+            try
+            {
+                GamePersistence.SaveGame(
+                    HighLogic.CurrentGame.Updated(),
+                    "persistent",
+                    HighLogic.SaveFolder,
+                    SaveMode.OVERWRITE);
+            }
+            catch (Exception ex)
+            {
+                ParsekLog.Warn("SceneExit",
+                    $"Pre-LoadScene SaveGame threw {ex.GetType().Name}: {ex.Message} - " +
+                    $"continuing transition (state may be lost on game unload)");
+            }
+            SceneExitInterceptor.s_AllowNextLoadScene = true;
+            HighLogic.LoadScene(scene);
+        };
+
+        MergeDialog.ShowTreeDialog(
+            pending,
+            buttonLabels: variant == DialogVariant.ReFlyAttempt
+                ? MergeDialogButtonLabels.ReFlyAttempt
+                : MergeDialogButtonLabels.Default,
+            postChoice: proceed);
+
+        return false;   // block stock LoadScene; dialog drives it
+    }
+}
+```
+
+Notes:
+
+- The bypass flag is intentionally global / one-shot. KSP is single-threaded
+  for game logic; lifetime is "set immediately before re-invoke, consumed by
+  next prefix". If a stray `HighLogic.LoadScene` slips in between set and
+  consume, log Warn and fall through.
+- The prefix early-returns on the first comparison for non-FLIGHT loads, so
+  the cost added to KSP's hot LoadScene path is one branch.
+- Step (3) is a *peek*, not a consume - the existing Discard Re-Fly path
+  relies on `FinalizeTreeOnSceneChange` consuming the flag at
+  `ParsekFlight.cs:2734`, so we must not steal it.
+- Step (4)'s `HasActiveTree && !HasPendingTree` guard handles the
+  popup-teardown retry case (P2): a prior dialog open already pre-finalized
+  (cleared `activeTree`, stashed `pendingTree`) but the popup was dismissed
+  without a button click. On the next prefix entry we skip pre-finalize and
+  reuse the existing pending tree. `FinalizeTreeOnSceneChangeCore`
+  dereferences `activeTree` unconditionally (`ParsekFlight.cs:2800, :2810,
+  :2829, :2836`); calling it with `activeTree == null` would NRE.
+- `ParsekFlight.HasActiveTree` is a new public read-only property exposing
+  `activeTree != null` without exposing the field itself.
+
+### Decision helper
+
+Pure helper `ShouldShowDialogBeforeSceneChange(GameScenes destination,
+RecordingTree finalizedPendingTree)`. Mirrors the OnLoad logic at
+`ParsekScenario.cs:1660-1723` so the pre-transition gate matches the
+existing post-load gate, but reads from the *already-finalized* pending
+tree the prefix passes in:
+
+```
+if (Re-Fly session active)                                                   -> ReFlyAttempt
+if (autoMerge OFF)                                                           -> RegularMerge
+if (autoMerge ON
+    && destination in {SPACECENTER, TRACKSTATION}
+    && root recording terminal state in {Landed, Splashed})                  -> RegularMerge   // = ShouldShowCommitApproval
+if (destination == MAINMENU)                                                 -> RegularMerge   // new: was force-auto-merge
+otherwise                                                                    -> None
+```
+
+The "no pending tree" case is filtered earlier in the prefix (step 5) so
+the helper is only invoked when a finalized tree exists.
+
+Reading `TerminalStateValue` from the finalized pending tree (not the
+live-recorder activeTree) is what makes the autoMerge approval gate work
+pre-transition. See "Tree finalize timing" above for why ordering matters.
+
+Idle-on-pad auto-discard (`ParsekScenario.cs:1682-1689, :4825-4834`) runs
+as a fast path *after* the variant decision inside the prefix and reads
+`MaxDistanceFromLaunch` from the same finalized tree so it sees the
+post-#290d-backfill value rather than the stale live-recorder value.
+
+### `MergeDialog.cs` changes
+
+- New `ShowTreeDialog(RecordingTree tree, MergeDialogButtonLabels labels,
+  Action postChoice)` overload. Existing two-button layout (Merge / Discard)
+  is unchanged - only the button label strings come from the new
+  `MergeDialogButtonLabels` enum (`Default` -> "Merge to Timeline" /
+  "Discard"; `ReFlyAttempt` -> "Merge Re-Fly to Timeline" / "Discard
+  Re-Fly attempt"). Wrap the existing `MergeCommit` and `MergeDiscard`
+  callbacks to invoke `postChoice?.Invoke()` after their existing work.
+- `MergeCommit` and `MergeDiscard` are unchanged - they already do the
+  right thing for Re-Fly via `TryCommitReFlySupersede` and
+  `TryDiscardActiveReFlyAttempt`. **No new `ReFlyExitDialog` class.**
+- Existing Re-Fly body-copy adaptation (`MergeDialog.cs:144-169`) stays.
+  Tweak the headline copy slightly when the dialog is opened via the
+  pre-transition path (e.g. "Re-Fly attempt - leaving flight" instead of
+  "Confirm Merge to Timeline") - same body, different title and button
+  labels.
+- Existing `OnDismiss -> ClearPendingFlag` path stays
+  (`MergeDialog.cs:217-223`). No change needed.
+- **Add the merge-journal-active guard to the discard handlers, not just
+  to button construction (P1.C).** The previous draft was wrong:
+  `MergeDialog.MergeDiscard` does *not* currently check
+  `ParsekScenario.ActiveMergeJournal`, and `TryDiscardActiveReFlyAttempt`
+  unconditionally clears `scenario.ActiveMergeJournal = null` at
+  `MergeDialog.cs:452`. `RevertInterceptor.DiscardReFlyHandler` is the
+  only existing site with the defensive refusal (at
+  `RevertInterceptor.cs:345-352`). Mirror that pattern in two places:
+  - `MergeDialog.MergeDiscard`: at the top, before `TryDiscardActiveReFlyAttempt`,
+    refuse if `ActiveMergeJournal != null` with a `ParsekLog.Warn` and a
+    `PostScreenMessage("Discard: merge in progress - retry in a moment")`.
+  - `MergeDialog.TryDiscardActiveReFlyAttempt`: at the top, refuse with
+    the same pattern. Belt-and-braces for any future call site that
+    bypasses `MergeDiscard`.
+  Hide the Discard button at button-build time too when the journal is
+  active (mirrors `ReFlyRevertDialog`'s button gate). Hiding alone is not
+  enough - the handler refusal is the load-bearing safety check, since
+  any test path or future call site that bypasses the dialog can still
+  reach the handler. This also fixes a pre-existing bug (the post-load
+  deferred dialog has the same hole today); the new pre-transition path
+  just makes it more reachable because Re-Fly transitions now route
+  through `MergeDialog.MergeDiscard` more consistently.
+
+### `RecordingStore.cs` changes
+
+- Add `internal static bool IsNextTreeSceneExitCommitSuppressionArmed` -
+  read-only public peek (no consume) for use by the new prefix. The
+  existing `NextTreeSceneExitCommitSuppressionArmedForTesting` getter
+  (`RecordingStore.cs:1191`) does the same thing under a "ForTesting"
+  name; either rename + reuse, or add a sibling property. Renaming is
+  cleaner since the flag's existence is no longer test-only.
+- No new flag. The `SuppressNextTreeSceneExitFinalize` flag the previous
+  draft proposed is unnecessary - the existing pending-tree contract
+  carries the same information.
+
+### `ParsekFlight.cs` changes
+
+- New `internal void FinalizeTreeOnSceneChangeForCallback(GameScenes scene)`
+  - delegates to the existing `FinalizeTreeOnSceneChangeCore`. The
+  in-callback finalize is identical to what `OnSceneChangeRequested` would
+  have done a moment later. Caller is responsible for guarding against
+  `activeTree == null` (the prefix's `HasActiveTree && !HasPendingTree`
+  check covers this).
+- New `internal bool HasActiveTree => activeTree != null;` - read-only peek
+  for the prefix without exposing the field.
+- No changes to `FinalizeTreeOnSceneChange` itself. After the callback runs
+  `MergeCommit` or `MergeDiscard`, both `activeTree` and `pendingTree` are
+  cleared, so the existing checks at `ParsekFlight.cs:2686, :2690` are
+  no-ops on the second LoadScene re-invoke.
+
+### `ParsekScenario.cs` changes
+
+- Drop `forceAutoMerge = LoadedScene == MAINMENU` at `ParsekScenario.cs:1659`.
+  Pre-transition path now handles main menu; deferred-fallback path will too.
+- Reuse `SceneExitInterceptor.ShouldShowDialogBeforeSceneChange` from the
+  OnLoad path instead of duplicating the matrix. (Optional - shared logic
+  is nicer but not strictly required for correctness.)
+- Add canary Warn inside `ShowDeferredMergeDialog` coroutine
+  (`ParsekScenario.cs:4807-4842`): "deferred merge dialog fired -
+  pre-transition intercept missed scene=... reason=...". Useful canary for
+  paths we did not patch (mods, KSP version drift).
+
+## Files changed
+
+| Status | Path | Change |
+| --- | --- | --- |
+| New | `Source/Parsek/SceneExitInterceptor.cs` | Harmony patch + decision helper + idle-pad fast path; pre-finalize-then-decide ordering; persistent save in callback |
+| Modified | `Source/Parsek/MergeDialog.cs` | `(labels, postChoice)` overload of `ShowTreeDialog`; new `MergeDialogButtonLabels` enum; pre-transition title copy; **add `ActiveMergeJournal` guard to `MergeDiscard` and `TryDiscardActiveReFlyAttempt` (P1.C)**; hide Discard when journal active |
+| Modified | `Source/Parsek/ParsekFlight.cs` | Expose `FinalizeTreeOnSceneChangeForCallback` and `HasActiveTree` |
+| Modified | `Source/Parsek/RecordingStore.cs` | Rename `NextTreeSceneExitCommitSuppressionArmedForTesting` to `IsNextTreeSceneExitCommitSuppressionArmed` (or add sibling) |
+| Modified | `Source/Parsek/ParsekScenario.cs` | Drop main-menu force-auto-merge; deferred-coroutine canary Warn; (optional) reuse decision helper |
+| New | `Source/Parsek.Tests/SceneExitInterceptorTests.cs` | Decision helper matrix; prefix bypass conditions; pre-finalize wiring; popup-teardown retry; persistent-save test seam |
+| Modified | `Source/Parsek.Tests/MergeDialogTests.cs` | New `(labels, postChoice)` path; ReFlyAttempt button labels; journal-active guard tests for `MergeDiscard` + `TryDiscardActiveReFlyAttempt` |
+| Modified | `Source/Parsek/InGameTests/RuntimeTests.cs` | Dialog appears in flight scene, not after load (multiple flight-exit paths) |
+
+No `ReFlyExitDialog.cs` (removed from previous draft - existing
+`MergeDialog.ShowTreeDialog` covers Re-Fly natively).
+
+## Test matrix
+
+### `ShouldShowDialogBeforeSceneChange` decision helper
+
+| autoMerge | ReFly active | Has pending tree | Term state | Destination | Expected |
+| --- | --- | --- | --- | --- | --- |
+| OFF | no | yes | any | KSC / TS / MAINMENU / EDITOR | RegularMerge |
+| ON | no | yes | Landed | KSC | RegularMerge |
+| ON | no | yes | Landed | TS | RegularMerge |
+| ON | no | yes | Crashed | KSC | None |
+| ON | no | yes | any | MAINMENU | RegularMerge (new) |
+| any | yes | yes | any | any non-flight | ReFlyAttempt |
+| any | no | no | - | any | None |
+
+### Prefix bypass conditions (P1 + P2 coverage)
+
+- `s_AllowNextLoadScene` armed -> prefix returns true, flag consumed.
+- `s_AllowNextLoadScene` armed but destination is not flight-exit -> still
+  consumed (one-shot guarantee).
+- `RecordingStore.IsNextTreeSceneExitCommitSuppressionArmed` true (Discard
+  Re-Fly path) -> prefix returns true, flag NOT consumed (preserves
+  existing `FinalizeTreeOnSceneChange` consume contract).
+- `LoadedScene != FLIGHT` -> prefix returns true regardless of other state.
+- Destination not in {KSC, TS, MAINMENU, EDITOR} -> prefix returns true.
+
+### Pre-finalize / suppression flag separation (P1.A + P2 coverage)
+
+- Prefix calls `FinalizeTreeOnSceneChangeForCallback` BEFORE consulting
+  `TerminalStateValue` or `MaxDistanceFromLaunch`. Resulting
+  `RecordingStore.PendingTree` is non-null and carries finalized
+  per-recording terminal state. `ParsekFlight.activeTree` is null
+  afterwards.
+- AutoMerge ON, Landed/Splashed terminal: pre-finalize backfills
+  `TerminalStateValue`, decision helper returns `RegularMerge`, dialog
+  shows. Without pre-finalize-first ordering this case would have
+  fallen through to `None` and shown the deferred post-load dialog
+  instead - covers the P1.A regression.
+- Idle-on-pad fast path: reads `MaxDistanceFromLaunch` from the finalized
+  pending tree, not from the live recorder. Asserts the
+  pre-#290d-backfill stale value does not trigger a false auto-discard.
+- Dialog `MergeCommit` runs: `pendingTree` is committed and cleared.
+  Re-invoke `HighLogic.LoadScene` -> `OnSceneChangeRequested` finds
+  `activeTree == null`, no `NextTreeSceneExitCommitSuppression` armed,
+  `else if` branch is a no-op. No double-commit.
+- Dialog `MergeDiscard` runs: `pendingTree` is popped. Re-invoke ->
+  same no-op path. No leak of pending tree.
+- Popup-teardown retry (P2): first prefix entry pre-finalizes (clears
+  `activeTree`, stashes `pendingTree`). Popup is dismissed without a
+  button click. Player triggers another scene exit. Prefix re-enters
+  with `HasActiveTree == false` and `HasPendingTree == true`; skips
+  pre-finalize, reads decision from existing pending tree, shows dialog.
+  No NRE on the second `FinalizeTreeOnSceneChangeForCallback` call.
+- Pre-finalize produces no pending tree (e.g. unfinalized recorder had
+  nothing to commit): prefix's step 5 sees `pending == null` and lets
+  the transition through.
+- Existing Discard Re-Fly path: `RevertInterceptor.DiscardReFlyHandler`
+  arms the existing flag, calls `LoadScene`, our prefix bypasses (step
+  3), stock `OnSceneChangeRequested` runs, `FinalizeTreeOnSceneChange`
+  consumes the flag and discards `activeTree` per the existing contract.
+  Unchanged.
+
+### Persistence (P1.B coverage)
+
+- Callback writes `GamePersistence.SaveGame(persistent, OVERWRITE)`
+  before re-invoking `HighLogic.LoadScene`.
+- Quit-to-Main-Menu: assert that post-callback persistent.sfs reflects
+  the merge / discard state (not the pre-callback state stock saved).
+- `CanRestart`-no-save path: assert callback save fires even though
+  stock did not save.
+- FlightResultsDialog Btn_KSC / Btn_Menu direct-LoadScene: assert
+  callback save fires (stock did not save).
+- Save throws (disk full, IO error): assert prefix logs Warn and
+  continues with LoadScene (degraded behaviour - state may be lost on
+  unload, but blocking the transition entirely is worse).
+
+### Merge-journal-active guard (P1.C coverage)
+
+- `MergeDialog.MergeDiscard` with `ActiveMergeJournal != null`: refuses
+  with Warn log + screen message; no state mutation; pending tree
+  remains stashed.
+- `MergeDialog.TryDiscardActiveReFlyAttempt` invoked directly with
+  `ActiveMergeJournal != null` (test bypass / future caller): same
+  refusal contract.
+- Merge button still works when journal is active (matches
+  `ReFlyRevertDialog`'s "Merge always allowed, Discard hidden" gate).
+- Button-build hides Discard when journal active - regression test
+  asserts the dialog only ever exposes one button in that state.
+
+### Defensive tests
+
+- Idle-on-pad pre-transition auto-discard fires before showing dialog
+  (using finalized `MaxDistanceFromLaunch` per P1.A).
+- Merge-journal-active hides Discard on regular and Re-Fly button-labels
+  variants; handler refusal also fires when invoked directly.
+- Popup `OnDismiss` without a button click: existing
+  `ClearPendingFlag("popup teardown")` runs; no `s_AllowNextLoadScene`
+  leak (it was never set); pending tree remains stashed. Subsequent
+  scene-exit attempt re-enters the prefix and reuses the existing
+  pending tree without re-finalizing.
+- Deferred coroutine path emits the canary Warn when triggered.
+
+### In-game tests
+
+- In flight, click Esc -> Space Center: dialog appears in flight scene,
+  not after Space Center loads.
+- In flight, click Esc -> Tracking Station: same.
+- In flight, click Esc -> Quit to Main Menu: stock confirmation popup runs
+  first, then our merge dialog, then main menu loads.
+- Crash, FlightResultsDialog appears, click Space Center button: merge
+  dialog appears in flight scene, not after Space Center loads.
+- Re-Fly session active, click Esc -> Space Center: dialog appears with
+  Re-Fly-scoped button labels, Discard wires through
+  `TryDiscardActiveReFlyAttempt`.
+- Re-Fly session active, click Revert button: existing `ReFlyRevertDialog`
+  fires (covered by `RevertInterceptor`). Discard Re-Fly from that dialog
+  triggers `RecordingStore.ArmNextTreeSceneExitCommitSuppression` ->
+  `HighLogic.LoadScene(SPACECENTER)`; our prefix sees the armed flag and
+  bypasses without re-prompting.
+- Low-altitude flight (atmosphere, can't save): orange "you will lose
+  progress" popup runs first, then on Yes our merge dialog appears (not
+  after the destination scene loads).
+
+## Risks
+
+- We patch `HighLogic.LoadScene`, a hot KSP method. Filter is one
+  comparison; cost is negligible. Verify in-game with `Verbose` log on
+  every prefix entry during the first few minutes of a session.
+- Pre-finalize side effects fire in flight (BG checkpoint, ballistic-tail
+  extension, IncompleteBallisticSceneExitFinalizer, ledger-orchestrated
+  resource deltas). These already run during `OnSceneChangeRequested` -
+  we just hoist them by a few frames. No KSP-state mutation that depends
+  on the destination scene having loaded yet.
+- Pre-finalize "starves" the active recorder (`recorder = null`,
+  `backgroundRecorder.Shutdown()` at `ParsekFlight.cs:2840-2845`). If the
+  player dismisses the popup without clicking a button (P2 retry case),
+  the player is left in flight with no recording. Acceptable - they
+  can't escape via Esc anyway because `MultiOptionDialog` without an
+  explicit Cancel button does not allow Esc-dismiss; the popup-teardown
+  case is a Unity edge condition, not a normal flow.
+- Save throw in callback: logged as Warn, transition continues. Player
+  may lose Parsek state on game unload. Worse alternative would be to
+  block the transition forever - declined.
+- Dialog while in flight: KSP's `MultiOptionDialog` works in any scene
+  with a live UI canvas. Confirmed by existing `ReFlyRevertDialog` which
+  spawns the same kind of popup mid-flight.
+- Interaction with `fix-320` deferred-flight-results state machine
+  (`docs/dev/done/plans/fix-320-merge-confirm-before-crash-report.md`):
+  arming / disarming must still be correct when the merge dialog now opens
+  pre-transition. Re-read fix-320 doc before touching any of its code.
+- Interaction with Discard Re-Fly (P1.1): covered by the
+  `IsNextTreeSceneExitCommitSuppressionArmed` peek-bypass. Test coverage
+  asserts the flag is not consumed by the prefix.
+- KSP version drift: if a future KSP update adds new flight-exit entry
+  points or changes the `HighLogic.LoadScene` signature, the prefix needs
+  updating. The deferred-coroutine canary is the early-warning system.
+
+## CHANGELOG / todo updates
+
+Per `.claude/CLAUDE.md` "Documentation Updates - Per Commit, Not Per PR":
+
+- `CHANGELOG.md`: "Merge confirmation dialog now appears before leaving
+  flight, not after the destination scene loads. Quit to Main Menu also
+  shows the dialog (previously force-auto-merged). Re-Fly sessions show
+  Re-Fly-attempt-scoped button labels on the same dialog."
+- `docs/dev/todo-and-known-bugs.md`: add the dialog-timing item if
+  missing; mark closed once shipped.

--- a/docs/dev/plans/merge-confirm-pretransition.md
+++ b/docs/dev/plans/merge-confirm-pretransition.md
@@ -181,25 +181,13 @@ running). Decision-helper queries read live state directly:
   `srfRelRotation` / position vs the launch reference. Doesn't depend
   on `MaxDistanceFromLaunch` because we have the live vessel.
 
-On button click (Merge or Discard), the callback runs the full
-finalize-then-act sequence:
-
-```csharp
-Action proceed = () =>
-{
-    var fl = ParsekFlight.Instance;
-    fl?.FinalizeTreeOnSceneChangeForCallback(scene);   // stash + teardown
-    var pending = RecordingStore.PendingTree;
-    if (pending != null)
-    {
-        if (userChoseMerge) MergeDialog.MergeCommit(pending, decisions, spawnCount);
-        else                MergeDialog.MergeDiscard(pending);
-    }
-    SafeWritePersistent(scene);                        // P1.B (see below)
-    SceneExitInterceptor.s_AllowNextLoadScene = true;
-    HighLogic.LoadScene(scene);
-};
-```
+On button click (Merge or Discard), the dialog's button-handler
+wrapper runs `preCommitFinalize -> MergeCommit/MergeDiscard ->
+postChoice` in order. The prefix supplies `preCommitFinalize` (which
+calls `FinalizeTreeOnSceneChangeForCallback`) and `postChoice` (which
+calls `SafeWritePersistent` + the `LoadScene` re-invoke). See the
+authoritative patch sketch under "New file: SceneExitInterceptor.cs"
+for the full code.
 
 Result:
 
@@ -301,13 +289,10 @@ bool SafeWritePersistent(GameScenes dest)
     }
 }
 
-Action proceed = () =>
-{
-    // ... finalize + MergeCommit/MergeDiscard above ...
-    if (!SafeWritePersistent(scene)) return;   // dialog reappears next exit attempt
-    SceneExitInterceptor.s_AllowNextLoadScene = true;
-    HighLogic.LoadScene(scene);
-};
+// (See the authoritative patch sketch under "New file:
+//  SceneExitInterceptor.cs" for how SafeWritePersistent is wired
+//  into postChoice. The wrapper inside ShowTreeDialog runs
+//  preCommitFinalize -> MergeCommit/MergeDiscard -> postChoice.)
 ```
 
 For destinations stock would not have saved (CanRestart no-save path,
@@ -378,7 +363,13 @@ internal static class HighLogic_LoadScene_Patch
             ParsekLog.Warn("SceneExit",
                 $"LoadScene prefix: token consumed for unexpected dest={scene} " +
                 $"(expected {expected}); falling through to normal handling");
-            // fall through to normal flow
+            // Fall through intentionally: a foreign caller stole our
+            // token and is asking for a different destination. The
+            // player's Merge / Discard choice still applies to the
+            // CURRENT scene-exit attempt (the new dest); re-evaluate
+            // the dialog gate against `scene`. Do NOT return-true
+            // here - that would let the foreign transition skip the
+            // merge confirmation.
         }
 
         // (2) cheap filter - only intercept exits from FLIGHT to a flight-exit dest.
@@ -478,10 +469,10 @@ Notes:
 - Step (4) reads from `flight.HasActiveTree` only; no pre-finalize
   before the dialog. If the popup is dismissed without a button click,
   no state was mutated.
-- Decision helper signature changed to take `ParsekFlight` instead of a
-  pending tree. The helper queries live state - active recording's
-  vessel via `flight.ActiveVessel` for the autoMerge-ON Landed/Splashed
-  approval gate, etc.
+- Decision helper signature changed to take `ParsekFlight` instead
+  of a pending tree. The helper queries live state - the active
+  vessel via `FlightGlobals.ActiveVessel` for the autoMerge-ON
+  Landed/Splashed approval gate, etc.
 - `flight.ActiveTreeForDisplay`, `flight.IsActiveTreeIdleOnPad()`, and
   `flight.HasActiveTree` are new public read-only seams on
   `ParsekFlight` that don't expose the private `activeTree` field
@@ -507,11 +498,16 @@ otherwise                                                                    -> 
 
 The autoMerge ON Landed/Splashed gate (which today uses
 `ShouldShowCommitApproval` reading `TerminalStateValue` post-finalize)
-is now computed from the live vessel via `vessel.LandedOrSplashed`. The
-two values agree on the outcome - `FinalizeTreeRecordings` derives
-`TerminalStateValue` from the same vessel-situation snapshot that the
-live read returns. Document this in a comment in the helper so future
-maintainers understand they cannot drift.
+is now computed from the live vessel via the canonical
+`vessel.situation == Vessel.Situations.LANDED || vessel.situation ==
+Vessel.Situations.SPLASHED` pattern (matches the convention used in
+`UnfinishedFlightClassifier.cs`, `TerminalKindClassifier.cs`, etc.;
+`vessel.LandedOrSplashed` is the equivalent helper but is unused in
+production Parsek code today). The two values agree on the outcome -
+`FinalizeTreeRecordings` derives `TerminalStateValue` from the same
+vessel-situation snapshot that the live read returns. Document this
+in a comment in the helper so future maintainers understand they
+cannot drift.
 
 Idle-on-pad auto-discard runs after the variant decision and reads the
 live activeTree.
@@ -538,10 +534,13 @@ thousands of km - falsely defeating the idle-on-pad fast path for
 recordings that contain any RELATIVE-frame points.
 
 For an idle-on-pad recording (vessel never moved off the pad), no
-RELATIVE-frame points exist (the recorder never enters a relative
-frame for a stationary pad-bound vessel). For a vessel that did move,
-maxDist is dominated by real Absolute-frame distances anyway. The
-defensive fix is to filter to Absolute-frame points only.
+RELATIVE-frame points exist - the recorder's RELATIVE-entry path
+early-skips when the vessel is `onSurface`
+(`FlightRecorder.cs:5099-5131`), and the existing
+`TryGetPadLocalizedMotionMetrics` already returns false on any
+non-Absolute section (`ParsekFlight.cs:15783-15788`). For a vessel
+that did move, maxDist is dominated by real Absolute-frame distances
+anyway. The defensive fix is to filter to Absolute-frame points only.
 
 Implementation:
 
@@ -564,11 +563,21 @@ internal bool IsActiveTreeIdleOnPad()
 ```
 
 `VesselSpawner.BackfillMaxDistanceAbsoluteOnly(Recording)` is a new
-sibling of the existing `BackfillMaxDistance`. It iterates Points but
-calls `Recording.IsPointInAbsoluteFrame(pointIndex)` (or equivalent)
-to skip non-Absolute points. For finalize-time use, the existing
-`BackfillMaxDistance` keeps walking all points (today's behaviour);
-the live path uses the Absolute-only variant.
+sibling of the existing `BackfillMaxDistance`. `Recording.Points` has
+no per-point `referenceFrame` field; the frame lives on
+`TrackSection.referenceFrame` and the recorder dual-writes points
+into both `Recording.Points` and the relevant `TrackSection.frames`
+(`FlightRecorder.cs:7470, :7482`). Implementation: iterate
+`rec.TrackSections`, skip sections whose `referenceFrame !=
+ReferenceFrame.Absolute`, and walk only those sections' `frames` lists
+to compute max distance. The first Absolute frame's lat/lon/alt
+provides the launch reference (`FlightRecorder.cs:5488` opens the
+recorder's first section as Absolute, so the very first frame is
+always safe to use as the launch reference). For finalize-time use,
+the existing `BackfillMaxDistance` keeps walking all `rec.Points`
+(today's behaviour, latent RELATIVE-frame bug also present today but
+out of scope for this plan); the live path uses the Absolute-only
+variant.
 
 (Stretch: fix `BackfillMaxDistance` itself to honour `referenceFrame`,
 which would also fix a latent finalize-time bug. Out of scope for this
@@ -594,21 +603,19 @@ construction.
 
 ### `MergeDialog.cs` changes
 
-- New `ShowTreeDialog(RecordingTree tree, MergeDialogButtonLabels labels,
-  Action postChoice)` overload. Existing two-button layout (Merge / Discard)
-  is unchanged - only the button label strings come from the new
-  `MergeDialogButtonLabels` enum (`Default` -> "Merge to Timeline" /
-  "Discard"; `ReFlyAttempt` -> "Merge Re-Fly to Timeline" / "Discard
-  Re-Fly attempt"). Wrap the existing `MergeCommit` and `MergeDiscard`
-  callbacks to invoke `postChoice?.Invoke()` after their existing work.
-- `MergeCommit` and `MergeDiscard` are unchanged - they already do the
-  right thing for Re-Fly via `TryCommitReFlySupersede` and
+- `MergeCommit` and `MergeDiscard` are unchanged - they already do
+  the right thing for Re-Fly via `TryCommitReFlySupersede` and
   `TryDiscardActiveReFlyAttempt`. **No new `ReFlyExitDialog` class.**
-- Existing Re-Fly body-copy adaptation (`MergeDialog.cs:144-169`) stays.
-  Tweak the headline copy slightly when the dialog is opened via the
-  pre-transition path (e.g. "Re-Fly attempt - leaving flight" instead of
-  "Confirm Merge to Timeline") - same body, different title and button
-  labels.
+- Existing Re-Fly body-copy adaptation (`MergeDialog.cs:144-169`)
+  stays. The pre-transition path uses a different dialog title
+  ("Re-Fly attempt - leaving flight" vs the existing "Confirm Merge
+  to Timeline"). The dialog title comes from a new field on the
+  `MergeDialogButtonLabels` enum (or an extra `string title` arg on
+  the new overload - implementer's choice; the labels enum carrying
+  copy is the simpler option).
+- New `MergeDialogButtonLabels` enum: `Default` -> "Merge to
+  Timeline" / "Discard"; `ReFlyAttempt` -> "Merge Re-Fly to
+  Timeline" / "Discard Re-Fly attempt".
 - Existing `OnDismiss -> ClearPendingFlag` path stays
   (`MergeDialog.cs:217-223`). No change needed.
 - New `ShowTreeDialog(RecordingTree liveTree, MergeDialogButtonLabels
@@ -670,12 +677,12 @@ construction.
 
 ### `RecordingStore.cs` changes
 
-- Add `internal static bool IsNextTreeSceneExitCommitSuppressionArmed` -
-  read-only public peek (no consume) for use by the new prefix. The
-  existing `NextTreeSceneExitCommitSuppressionArmedForTesting` getter
-  (`RecordingStore.cs:1191`) does the same thing under a "ForTesting"
-  name; either rename + reuse, or add a sibling property. Renaming is
-  cleaner since the flag's existence is no longer test-only.
+- Rename the existing `NextTreeSceneExitCommitSuppressionArmedForTesting`
+  getter (`RecordingStore.cs:1191`) to
+  `IsNextTreeSceneExitCommitSuppressionArmed`. The flag's existence
+  is no longer test-only - the new `HighLogic.LoadScene` prefix
+  peeks it as a production code path. Update the one existing test
+  caller in the same commit.
 - No new flag. The `SuppressNextTreeSceneExitFinalize` flag the previous
   draft proposed is unnecessary - the existing pending-tree contract
   carries the same information.
@@ -725,13 +732,17 @@ construction.
 | New | `Source/Parsek/SceneExitInterceptor.cs` | Harmony patch (`HarmonyPriority.Last`) + decision helper + idle-pad fast path (live-state); paired `s_AllowNextLoadScene` + `s_AllowNextLoadSceneDestination` token; persistent save (`SafeWritePersistent`) in callback |
 | Modified | `Source/Parsek/MergeDialog.cs` | New `(tree, labels, preCommitFinalize, postChoice)` overload of `ShowTreeDialog`; new `MergeDialogButtonLabels` enum (`Default` / `ReFlyAttempt`); pre-transition title copy; **add `ActiveMergeJournal` guard to `MergeDiscard` and `TryDiscardActiveReFlyAttempt` (P1.C from earlier review)**; hide Discard when journal active |
 | Modified | `Source/Parsek/ParsekFlight.cs` | Expose `FinalizeTreeOnSceneChangeForCallback`, `HasActiveTree`, `ActiveTreeForDisplay`, `IsActiveTreeIdleOnPad` |
-| Modified | `Source/Parsek/RecordingStore.cs` | Rename `NextTreeSceneExitCommitSuppressionArmedForTesting` to `IsNextTreeSceneExitCommitSuppressionArmed` (or add sibling) |
+| Modified | `Source/Parsek/RecordingStore.cs` | Rename `NextTreeSceneExitCommitSuppressionArmedForTesting` -> `IsNextTreeSceneExitCommitSuppressionArmed` and update the existing test caller |
 | Modified | `Source/Parsek/VesselSpawner.cs` | New `BackfillMaxDistanceAbsoluteOnly(Recording)` sibling that filters to Absolute-frame points (Opus pass-4 P1 #3) |
 | Modified | `Source/Parsek/ParsekScenario.cs` | Drop main-menu force-auto-merge; deferred-coroutine canary Warn; (optional) reuse decision helper |
 | New | `Source/Parsek.Tests/SceneExitInterceptorTests.cs` | Decision helper matrix (live-state); prefix bypass conditions (3-way: token+dest, suppression peek, dest filter); deferred-finalize wiring; popup-dismiss-no-mutation; `SafeWritePersistent` MAINMENU-block test seam |
 | Modified | `Source/Parsek.Tests/MergeDialogTests.cs` | New `(labels, preCommitFinalize, postChoice)` path; ReFlyAttempt button labels; journal-active guard tests for `MergeDiscard` + `TryDiscardActiveReFlyAttempt`; "no pending tree after preCommitFinalize" Warn-and-skip path |
 | Modified | `Source/Parsek/InGameTests/RuntimeTests.cs` | Dialog appears in flight scene, not after load (multiple flight-exit paths); F9-during-dialog cleanup; KSPCommunityFixes coexistence |
-| Modified | `CHANGELOG.md` + `docs/dev/todo-and-known-bugs.md` | Per repo "Documentation Updates - Per Commit, Not Per PR" rule |
+
+CHANGELOG / todo doc updates are listed in the dedicated section
+near the end of this plan, not in this table (matches the convention
+in `docs/dev/plans/fix-440B-reconcile-earnings-transformed.md` and
+peers).
 
 No `ReFlyExitDialog.cs` (removed from previous draft - existing
 `MergeDialog.ShowTreeDialog` covers Re-Fly natively).
@@ -814,18 +825,15 @@ LANDED/SPLASHED situations pass through unchanged.)
 - Crew-swap captured (Opus #3): assert post-merge persistent.sfs has
   the swapped roster (`CrewReservationManager.SwapReservedCrewInFlight`
   ran, our save captured it).
-- Save throws on MAINMENU: assert transition is *blocked*, error popup
-  shown, `s_AllowNextLoadScene` not set, `pendingTree` not stashed
-  (callback aborted before finalize? - actually finalize runs first;
-  decide whether to roll-back finalize on save fail or accept the
-  inconsistency. Document the trade-off in the plan.) Implementation
-  decision: finalize runs first, save fails, error popup shown -
-  user retries the exit, which re-enters the prefix; the second
-  attempt sees `HasActiveTree == false` (already finalized) but
-  `HasPendingTree == true`, takes a different code path (no
-  pre-finalize, dialog already showed?). Need a "merge journal active /
-  pending tree from previous prefix attempt" branch in the prefix.
-  Open question - see "Open questions" below.
+- Save throws on MAINMENU: assert transition is *blocked*, error
+  popup shown, `s_AllowNextLoadScene` not set. Phase 1 already ran
+  before the failed save, so `MergeCommit` / `MergeDiscard` already
+  cleared `pendingTree` (`MergeDialog.cs:316` `CommitPendingTree` and
+  `MergeDiscard`'s `DiscardPendingTreeAndRecalculate` both null
+  `pendingTree`). On retry, prefix sees `HasActiveTree == false` AND
+  `HasPendingTree == false`, returns `true`, stock saveAndExit runs
+  and persists the post-mutation state. See "Open questions" item 1
+  for the full recovery contract.
 - Save throws on SPACECENTER / TRACKSTATION / EDITOR: assert prefix
   logs Warn and continues with LoadScene; destination scene's own
   save cycle eventually persists.

--- a/docs/dev/plans/merge-confirm-pretransition.md
+++ b/docs/dev/plans/merge-confirm-pretransition.md
@@ -451,8 +451,25 @@ internal static class HighLogic_LoadScene_Patch
             scene, flight);
         if (variant == DialogVariant.None) return true;
 
-        // (5) idle-on-pad auto-discard fast path. Reads live recorder /
-        //     activeTree state via ParsekFlight.IsActiveTreeIdleOnPad.
+        // (5) idle-on-pad auto-discard fast path. Mutation contract
+        //     (Opus pass-7 P2): TryAutoDiscardIdleActiveTree both
+        //     detects AND discards. After return-true here, the
+        //     active tree must be gone, no pending tree must be
+        //     stashed, and no deferred merge dialog must be queued
+        //     by the destination scene's OnLoad. Two steps:
+        //       a. Detect via flight.IsActiveTreeIdleOnPad() (reads
+        //          live state via BackfillMaxDistanceAbsoluteOnly).
+        //       b. If idle, call flight.AutoDiscardIdleActiveTree(
+        //          "scene-exit idle-on-pad auto-discard"), which
+        //          tears down activeTree / recorder /
+        //          backgroundRecorder and runs ledger recalc -
+        //          mirroring the pattern at ParsekFlight.cs:3151-3166
+        //          (post-destruction auto-discard).
+        //     Stock LoadScene then proceeds. OnSceneChangeRequested
+        //     sees activeTree == null and no-ops. The destination
+        //     scene loads with no pending tree, so the OnLoad
+        //     idle-on-pad branch at ParsekScenario.cs:1682-1689 does
+        //     not fire (its precondition is HasPendingTree).
         if (SceneExitInterceptor.TryAutoDiscardIdleActiveTree(scene, flight))
             return true;
 
@@ -830,6 +847,30 @@ construction.
   the live `activeTree` and live vessel position. Walks recordings,
   computes distance-from-launch from live data rather than from the
   post-#290d `MaxDistanceFromLaunch` field.
+- New `internal void AutoDiscardIdleActiveTree(string reason)` -
+  tears down the live recorder / activeTree without going through
+  finalize / stash. Mirrors the cleanup block at
+  `ParsekFlight.cs:3151-3166`:
+  ```csharp
+  ParsekLog.Info("Flight",
+      $"AutoDiscardIdleActiveTree: discarding live tree reason='{reason}'");
+  ScreenMessage("Recording discarded - idle on pad", 3f);
+  recorder = null;
+  if (backgroundRecorder != null)
+  {
+      backgroundRecorder.Shutdown();
+      Patches.PhysicsFramePatch.BackgroundRecorderInstance = null;
+      backgroundRecorder = null;
+  }
+  activeTree = null;
+  // No pending tree was ever stashed (we discard pre-finalize), so
+  // DiscardPendingTreeAndRecalculate is overkill - just do the
+  // ledger recalc directly to roll back any in-flight ledger
+  // entries from this aborted recording.
+  LedgerOrchestrator.RecalculateAndPatch();
+  ```
+  Called by `SceneExitInterceptor.TryAutoDiscardIdleActiveTree` when
+  `IsActiveTreeIdleOnPad()` returns true.
 - No changes to `FinalizeTreeOnSceneChange` itself. After the callback
   runs `MergeCommit` or `MergeDiscard`, both `activeTree` and
   `pendingTree` are cleared, so the existing checks at
@@ -854,7 +895,7 @@ construction.
 | --- | --- | --- |
 | New | `Source/Parsek/SceneExitInterceptor.cs` | Harmony patch (`HarmonyPriority.Last`) + decision helper + idle-pad fast path (live-state); paired `s_AllowNextLoadScene` + `s_AllowNextLoadSceneDestination` token; persistent save (`SafeWritePersistent`) in callback |
 | Modified | `Source/Parsek/MergeDialog.cs` | New `(tree, labels, preCommitFinalize, postChoice)` overload of `ShowTreeDialog`; new `MergeDialogButtonLabels` enum (`Default` / `ReFlyAttempt`); pre-transition title copy; **add `ActiveMergeJournal` guard to `MergeDiscard` and `TryDiscardActiveReFlyAttempt` (P1.C from earlier review)**; hide Discard when journal active |
-| Modified | `Source/Parsek/ParsekFlight.cs` | Expose `FinalizeTreeOnSceneChangeForCallback`, `HasActiveTree`, `ActiveTreeForDisplay`, `IsActiveTreeIdleOnPad` |
+| Modified | `Source/Parsek/ParsekFlight.cs` | Expose `FinalizeTreeOnSceneChangeForCallback`, `HasActiveTree`, `ActiveTreeForDisplay`, `IsActiveTreeIdleOnPad`, `AutoDiscardIdleActiveTree` |
 | Modified | `Source/Parsek/RecordingStore.cs` | Rename `NextTreeSceneExitCommitSuppressionArmedForTesting` -> `IsNextTreeSceneExitCommitSuppressionArmed` and update the existing test caller |
 | Modified | `Source/Parsek/VesselSpawner.cs` | New `BackfillMaxDistanceAbsoluteOnly(Recording)` sibling that filters to Absolute-frame points (Opus pass-4 P1 #3) |
 | Modified | `Source/Parsek/ParsekScenario.cs` | Drop main-menu force-auto-merge; deferred-coroutine canary Warn; (optional) reuse decision helper |
@@ -1021,6 +1062,20 @@ LANDED/SPLASHED situations pass through unchanged.)
   dialog, reading live `MaxDistanceFromLaunch` backfilled by
   `VesselSpawner.BackfillMaxDistanceAbsoluteOnly` over the live
   recording's Points.
+- **Idle-on-pad fast path mutation contract** (Opus pass-7 P2):
+  set up a flight with an idle activeTree on the pad. Trigger the
+  prefix with dest=SPACECENTER. Assert: (a)
+  `flight.HasActiveTree == false` after the prefix returns true,
+  (b) `RecordingStore.HasPendingTree == false`, (c)
+  `ParsekScenario.MergeDialogPending == false`, (d) the live
+  `recorder` and `backgroundRecorder` are null, (e) ledger
+  recalc fired, (f) the ScreenMessage "Recording discarded -
+  idle on pad" was posted, (g) the dialog was NOT shown
+  (`MergeDialog.MergeDialogPending` flag never set). Subsequent
+  in-game `OnSceneChangeRequested` simulation (with
+  `activeTree == null`) is a no-op for the tree path. Subsequent
+  `ParsekScenario.OnLoad` simulation (with no pending tree) does
+  NOT trigger the deferred merge dialog at line 1696.
 - Merge-journal-active hides Discard on regular and Re-Fly
   button-labels variants; handler refusal also fires when invoked
   directly.

--- a/docs/dev/plans/merge-confirm-pretransition.md
+++ b/docs/dev/plans/merge-confirm-pretransition.md
@@ -103,14 +103,14 @@ mods).
 
 - `ArmNextTreeSceneExitCommitSuppression(reason)` /
   `TryConsumeNextTreeSceneExitCommitSuppression(scene, out reason)`
-  (`RecordingStore.cs:1166, :1175`). Suppresses the auto-stash-as-pending side
+  (`RecordingStore.cs:1228, :1237`). Suppresses the auto-stash-as-pending side
   effect of `OnSceneChangeRequested` -> `FinalizeTreeOnSceneChange`. Consumed
   inside `FinalizeTreeOnSceneChange` (`ParsekFlight.cs:2734`) where it routes
   to `DiscardActiveTreeForSuppressedSceneExit` instead of stashing, and inside
   `OnSceneChangeRequested`'s `else if` branch (`ParsekFlight.cs:2690`) when
   there is no active tree.
 - `ArmNextActiveTreeRestoreSuppression` / `TryConsumeNextActiveTreeRestoreSuppression`
-  (`RecordingStore.cs:1200`, :1209). Distinct flag for the OnLoad active-tree
+  (`RecordingStore.cs:1262`, :1271). Distinct flag for the OnLoad active-tree
   restore pass.
 
 `RevertInterceptor.DiscardReFlyHandler` (`RevertInterceptor.cs:514-522`) arms
@@ -678,7 +678,7 @@ construction.
 ### `RecordingStore.cs` changes
 
 - Rename the existing `NextTreeSceneExitCommitSuppressionArmedForTesting`
-  getter (`RecordingStore.cs:1191`) to
+  getter (`RecordingStore.cs:1253`) to
   `IsNextTreeSceneExitCommitSuppressionArmed`. The flag's existence
   is no longer test-only - the new `HighLogic.LoadScene` prefix
   peeks it as a production code path. Update the one existing test

--- a/docs/dev/plans/merge-confirm-pretransition.md
+++ b/docs/dev/plans/merge-confirm-pretransition.md
@@ -607,22 +607,34 @@ non-Absolute section (`ParsekFlight.cs:15783-15788`). For a vessel
 that did move, maxDist is dominated by real Absolute-frame distances
 anyway. The defensive fix is to filter to Absolute-frame points only.
 
-Implementation:
+Implementation (as-shipped):
 
 ```csharp
 internal bool IsActiveTreeIdleOnPad()
 {
     if (activeTree == null) return false;
+    if (activeTree.Recordings == null || activeTree.Recordings.Count == 0)
+        return false;
+    if (restoringActiveTree) return false;   // mirror existing defensive guard
+
+    // Flush live recorder data into the tree (non-destructive; recorder
+    // stays IsRecording=true) so subsequent walks over rec.TrackSections
+    // see the in-flight data. Without this, atmospheric flights with
+    // empty TrackSections would default MaxDistanceFromLaunch to 0 and
+    // falsely classify as idle (Opus pass-7 P1 silent-data-loss bug).
+    FlushRecorderIntoActiveTreeForSerialization();
+
+    bool anyHasPoints = false;
     foreach (var rec in activeTree.Recordings.Values)
     {
         if (rec == null) continue;
-        // Live max-distance walk over Absolute-frame points only.
-        // Skips RELATIVE-frame points (where lat/lon/alt are anchor-local
-        // metres, not body-fixed coords) to avoid the GetWorldSurfacePosition
-        // garbage described in the Opus pass-4 review.
         VesselSpawner.BackfillMaxDistanceAbsoluteOnly(rec);
+        if (rec.Points != null && rec.Points.Count > 0) anyHasPoints = true;
         if (!IsIdleOnPad(rec)) return false;
     }
+    // Bug #290d safeguard: refuse to classify an all-empty-points tree as
+    // idle (data-loss, not idle-on-pad).
+    if (!anyHasPoints) return false;
     return true;
 }
 ```

--- a/docs/dev/plans/merge-confirm-pretransition.md
+++ b/docs/dev/plans/merge-confirm-pretransition.md
@@ -402,31 +402,29 @@ internal static class HighLogic_LoadScene_Patch
         if (SceneExitInterceptor.TryAutoDiscardIdleActiveTree(scene, flight))
             return true;
 
-        // (6) show dialog on the live activeTree. Same dialog for both
-        //     variants - Re-Fly-aware copy and Re-Fly-aware MergeCommit /
-        //     MergeDiscard already live inside MergeDialog.
-        Action<bool> proceed = (isMerge) =>
+        // (6) show dialog on the live activeTree. ShowTreeDialog owns
+        //     decision-building (Re-Fly suppressed-subtree closure +
+        //     activeReFlyTargetId, see MergeDialog.cs:100-125) and
+        //     button-action wiring; we only supply the postChoice that
+        //     runs after MergeCommit / MergeDiscard.
+        Action postChoice = () =>
         {
-            // Phase 1: full finalize-then-act (matches what
-            // OnSceneChangeRequested would have done a moment later).
-            flight.FinalizeTreeOnSceneChangeForCallback(scene);
-            var pending = RecordingStore.PendingTree;
-            if (pending != null)
-            {
-                if (isMerge)
-                {
-                    var decisions = MergeDialog.BuildDefaultVesselDecisionsForPending(pending);
-                    MergeDialog.MergeCommit(pending, decisions, ComputeSpawnCount(decisions));
-                }
-                else
-                {
-                    MergeDialog.MergeDiscard(pending);
-                }
-            }
+            // Phase 1: full finalize-then-act. ShowTreeDialog already
+            // ran MergeCommit or MergeDiscard before postChoice fires;
+            // FinalizeTreeOnSceneChangeForCallback is what stashes the
+            // pending tree that Merge/Discard then operate on. So the
+            // ordering inside ShowTreeDialog's button handler must be:
+            //   1. flight.FinalizeTreeOnSceneChangeForCallback(scene)
+            //   2. MergeCommit(pending, decisions, spawnCount)   OR
+            //      MergeDiscard(pending)
+            //   3. postChoice()  <-- this lambda
+            //
+            // (See "MergeDialog.cs changes" below for the new
+            // ShowTreeDialog signature that passes scene into the
+            // lambda body.)
 
             // Phase 2: persist mutations. Hard-block on MAINMENU save throw.
             if (!SafeWritePersistent(scene)) return;
-
             SceneExitInterceptor.s_AllowNextLoadScene = true;
             HighLogic.LoadScene(scene);
         };
@@ -436,8 +434,9 @@ internal static class HighLogic_LoadScene_Patch
             buttonLabels: variant == DialogVariant.ReFlyAttempt
                 ? MergeDialogButtonLabels.ReFlyAttempt
                 : MergeDialogButtonLabels.Default,
-            onMerge: () => proceed(isMerge: true),
-            onDiscard: () => proceed(isMerge: false));
+            preCommitFinalize: () =>
+                flight.FinalizeTreeOnSceneChangeForCallback(scene),
+            postChoice: postChoice);
 
         return false;   // block stock LoadScene; dialog drives it
     }
@@ -499,12 +498,43 @@ live read returns. Document this in a comment in the helper so future
 maintainers understand they cannot drift.
 
 Idle-on-pad auto-discard runs after the variant decision and reads the
-live activeTree via a new `ParsekFlight.IsActiveTreeIdleOnPad()` that
-mirrors the existing `IsTreeIdleOnPad(RecordingStore.PendingTree)`
-check used by the OnLoad path (`ParsekScenario.cs:1684`). The new
-method walks active recordings and computes idle-on-pad from live
-vessel position rather than from the post-#290d-backfilled
-`MaxDistanceFromLaunch` field.
+live activeTree.
+
+**Important** (Opus re-review pass 3 F1): `MaxDistanceFromLaunch` is
+*not* continuously maintained on live recordings. The field is only
+populated by `VesselSpawner.BackfillMaxDistance(rec)` at finalize time
+(`ParsekFlight.cs:12175-12182`, the `#290d` backfill) and at split
+boundaries (`ParsekFlight.cs:4066, :4717`). On a live `activeTree`
+sitting on the pad, every recording's `MaxDistanceFromLaunch` reads
+0.0, so a naive port of `IsTreeIdleOnPad` would always return true and
+auto-discard every flight that exits via the new prefix.
+
+The new `ParsekFlight.IsActiveTreeIdleOnPad()` must call
+`VesselSpawner.BackfillMaxDistance(rec)` on each live recording before
+the threshold check. `BackfillMaxDistance` iterates `Recording.Points`,
+which ARE accumulated continuously by the live recorder, so the
+backfill produces the correct distance for live data. The backfill is
+idempotent (computes from Points each call), so re-running it later
+inside `FinalizeTreeRecordings` is fine.
+
+Implementation:
+
+```csharp
+internal bool IsActiveTreeIdleOnPad()
+{
+    if (activeTree == null) return false;
+    foreach (var rec in activeTree.Recordings.Values)
+    {
+        if (rec == null) continue;
+        VesselSpawner.BackfillMaxDistance(rec);   // live -> populated
+        if (!IsIdleOnPad(rec)) return false;
+    }
+    return true;
+}
+```
+
+`IsIdleOnPad(rec)` is the existing private helper used by
+`IsTreeIdleOnPad` (`ParsekFlight.cs:15878`).
 
 ### `MergeDialog.cs` changes
 
@@ -525,6 +555,23 @@ vessel position rather than from the post-#290d-backfilled
   labels.
 - Existing `OnDismiss -> ClearPendingFlag` path stays
   (`MergeDialog.cs:217-223`). No change needed.
+- New `ShowTreeDialog(RecordingTree liveTree, MergeDialogButtonLabels
+  labels, Action preCommitFinalize, Action postChoice)` overload. The
+  Merge / Discard button handlers run, in order:
+  ```
+  preCommitFinalize?.Invoke();   // pre-transition: stash pending tree
+  var pending = RecordingStore.PendingTree ?? liveTree;
+  if (clickedMerge) MergeCommit(pending, decisions, spawnCount);
+  else              MergeDiscard(pending);
+  postChoice?.Invoke();
+  ```
+  Decisions are built inside `ShowTreeDialog` exactly as today
+  (`MergeDialog.cs:100-125`: `ComputeSessionSuppressedSubtree` +
+  `activeReFlyTargetId` + `BuildDefaultVesselDecisions`). Pre-transition
+  callers do NOT duplicate that decision-build; reusing the existing
+  internals preserves the Re-Fly suppressed-subtree closure that's
+  load-bearing for Re-Fly correctness. The post-load deferred path
+  calls the existing zero-arg `ShowTreeDialog(tree)` and is unchanged.
 - **Add the merge-journal-active guard to the discard handlers, not just
   to button construction (P1.C).** The previous draft was wrong:
   `MergeDialog.MergeDiscard` does *not* currently check
@@ -620,15 +667,25 @@ No `ReFlyExitDialog.cs` (removed from previous draft - existing
 
 ### `ShouldShowDialogBeforeSceneChange` decision helper
 
-| autoMerge | ReFly active | Has pending tree | Term state | Destination | Expected |
+| autoMerge | ReFly active | Has active tree | Live vessel state | Destination | Expected |
 | --- | --- | --- | --- | --- | --- |
 | OFF | no | yes | any | KSC / TS / MAINMENU / EDITOR | RegularMerge |
-| ON | no | yes | Landed | KSC | RegularMerge |
-| ON | no | yes | Landed | TS | RegularMerge |
-| ON | no | yes | Crashed | KSC | None |
+| ON | no | yes | LandedOrSplashed | KSC | RegularMerge |
+| ON | no | yes | LandedOrSplashed | TS | RegularMerge |
+| ON | no | yes | not LandedOrSplashed | KSC / TS | None |
 | ON | no | yes | any | MAINMENU | RegularMerge (new) |
 | any | yes | yes | any | any non-flight | ReFlyAttempt |
 | any | no | no | - | any | None |
+
+(Opus pass-3 F10 fix: column header is "Has active tree", reading
+`flight.HasActiveTree`, not "has pending tree" - the deferred-finalize
+design queries live state.)
+
+(Opus pass-3 F5 note: `vessel.LandedOrSplashed` and post-finalize
+`TerminalStateValue ∈ {Landed, Splashed}` agree because
+`RecordingTree.DetermineTerminalState` (`RecordingTree.cs:860-900`)
+override paths only fire for SUB_ORBITAL or ORBITING base states;
+LANDED/SPLASHED situations pass through unchanged.)
 
 ### Prefix bypass conditions (P1 + P2 coverage)
 
@@ -794,27 +851,55 @@ No `ReFlyExitDialog.cs` (removed from previous draft - existing
 
 ## Open questions
 
-1. **MAINMENU save-fail rollback**: if Phase 1 finalize runs (committing
-   or discarding the tree), then Phase 2 save fails on MAINMENU and we
-   block the transition, the player is left in flight with `activeTree
-   == null` (Phase 1 already cleared it) and either a committed tree
-   in the persistent storage or a popped pending tree. They cannot
-   resume recording the same flight. They can:
+1. **MAINMENU save-fail recovery**: if Phase 1 finalize runs
+   (committing or discarding the tree), then Phase 2 save fails on
+   MAINMENU and we block the transition, the player is left in flight
+   with `activeTree == null` (Phase 1 cleared it) and either a
+   committed tree or a discarded tree in memory. They cannot resume
+   recording the same flight. **The dialog is one-shot per
+   flight-exit attempt** - subsequent prefix entries see
+   `HasActiveTree == false` and short-circuit, so the merge dialog
+   does not reappear.
 
-   - Try Quit-to-Main-Menu again - prefix sees `HasActiveTree ==
-     false` and short-circuits to `return true` (no dialog needed,
-     transition proceeds with the in-memory state we already
-     mutated). But persistent.sfs is still pre-mutation. So this is
-     just kicking the can down the road.
-   - Try Quit-to-Main-Menu again, but the second time the save
-     succeeds (transient disk error resolved). Acceptable recovery.
-   - Use Space Center instead - prefix sees `HasActiveTree == false`,
-     transitions to SC, the SC scene's own save cycle runs, captures
-     our state.
+   Recovery contract: any subsequent flight-exit attempt - to any
+   destination - routes through stock `saveAndExit` (PauseMenu paths)
+   or stock direct-LoadScene (FlightResultsDialog paths), with stock
+   then capturing our post-mutation in-memory state. So:
 
-   Document path 3 in the error popup ("Could not save before quitting
-   to main menu. Try going to Space Center instead, then quit from
-   there."). Accept that path 1 is degraded but path 3 is clean.
+   - **Retry Quit-to-Main-Menu**: stock `saveAndExit` runs (it always
+     calls `GamePersistence.SaveGame` regardless of our prefix's
+     state). If the disk transient cleared, save succeeds and the
+     post-mutation state lands on disk before MAINMENU loads. Clean
+     recovery.
+   - **Use Space Center / Tracking Station instead**: stock
+     `saveAndExit` runs the same way; SC/TS scene loads with the
+     mutated state on disk. Clean recovery.
+   - **Stock save also throws on retry**: PauseMenu's `saveAndExit`
+     does NOT block on save throw (it eats the exception per stock
+     KSP behaviour and continues to `HighLogic.LoadScene`). So the
+     player ends up on MAINMENU with persistent.sfs at the
+     pre-mutation state, but the in-memory mutation is gone. This is
+     identical to a hard-crash-during-save scenario - rare, and
+     accepted as the cost of disk failures.
+
+   Error popup text: "Could not save before quitting to main menu.
+   Try again, or quit to Space Center first."
+
+2. **Suppression flag leak on `LoadScene` throw** (Opus #6): narrow
+   window where our prefix peeks the flag, bypasses, but stock
+   `LoadScene` itself throws before reaching `OnSceneChangeRequested`.
+   Flag stays armed; next regular flight-exit silently discards. Not
+   worth a watchdog timer; document the risk and add a one-frame
+   reaper in `ParsekFlight.Update` if observed in playtest.
+
+3. **`s_AllowNextLoadScene` wrong-destination warn** (Opus pass-3 F7):
+   step (1) of the prefix consumes the token unconditionally. If a
+   foreign mod's `LoadScene` slipped between callback set and our
+   prefix's consume, the token would be consumed for the wrong
+   destination. Add a stored `s_AllowNextLoadSceneDestination` that
+   the prefix checks against the actual `scene` param; if mismatched,
+   log Warn ("token consumed for unexpected dest=...") and fall
+   through to normal handling.
 
 2. **Suppression flag leak on `LoadScene` throw** (Opus #6): narrow
    window where our prefix peeks the flag, bypasses, but stock

--- a/docs/dev/plans/merge-confirm-pretransition.md
+++ b/docs/dev/plans/merge-confirm-pretransition.md
@@ -253,22 +253,70 @@ Symptom matrix:
 - **FlightResultsDialog Btn_KSC / Btn_Menu** (direct LoadScene at
   `FlightResultsDialog.cs:565, 599`): same as above - stock did not save.
 
-Fix: the proceed callback **always** writes a fresh persistent save before
-re-invoking `HighLogic.LoadScene`. Save failure is **fatal for MAINMENU**
-(no later save will run before unload) and **logged-and-continued for
-other destinations** (the destination scene's own save cycle will eventually
-write our state):
+Fix: the proceed callback **always** writes a fresh persistent save
+before re-invoking `HighLogic.LoadScene`. Save failure is **fatal
+for MAINMENU** (no later save will run before unload) and
+**logged-and-continued for other destinations** (the destination
+scene's own save cycle will eventually write our state).
+
+The save preparation must mirror the full stock `saveAndExit`
+sequence (Opus pass-6 P2): stock fires `onSceneConfirmExit` and
+calls `FlightGlobals.ClearpersistentIdDictionaries()` *before*
+`GamePersistence.SaveGame`. The `ClearpersistentIdDictionaries`
+call is load-bearing - it nulls stale pid pointers that would
+otherwise be persisted into the saved scenario module state and
+silently re-bind to wrong GameObjects after the scene change.
+`onSceneConfirmExit` lets listener mods clean up before save.
+
+For paths where stock already ran the prep (PauseMenu's
+`saveAndExit` at `Assembly-CSharp.dll` PauseMenu:1781-1803): stock
+already fired the event + cleared dictionaries + saved. Our
+re-save runs after our mutations but on top of stock's prep, which
+is fine - the event already fired, the dictionaries are still
+cleared.
+
+For paths where stock did NOT run the prep (PauseMenu CanRestart
+no-save at PauseMenu:1611-1633; FlightResultsDialog Btn_KSC /
+Btn_Menu / Btn_TS direct LoadScene): our `SafeWritePersistent`
+must run the full prep itself.
+
+Implementation: detect "did stock already prep" via a flag the
+prefix sets when it first fires (`s_StockPreparedThisTransition`,
+defaults to false; set true if we observe `onSceneConfirmExit` was
+fired before our prefix - we hook the event with a one-frame
+short-lived listener that just sets the flag). This is a defensive
+detection; if uncertain, run the prep again - it's idempotent
+(`ClearpersistentIdDictionaries` is safe to call repeatedly,
+`onSceneConfirmExit` listeners typically guard against double-fire).
+
+Simpler alternative: always run the full prep, accepting potential
+double-fire of `onSceneConfirmExit`. Stock listeners (KSP itself
+and well-behaved mods) idempotently handle the event. Risk: a
+mod that mutates state on every fire could double-mutate. Low
+likelihood in practice but not zero.
+
+Recommended approach: always run the full prep in
+`SafeWritePersistent`. Document the double-fire risk; if observed
+in playtest, switch to detection-based prep.
 
 ```csharp
 bool SafeWritePersistent(GameScenes dest)
 {
     try
     {
+        // Full stock saveAndExit prep (PauseMenu.saveAndExit at
+        // PauseMenu:1781-1803, plus the onSceneConfirmExit fire from
+        // the button delegates that wraps it). Idempotent in
+        // practice for both KSP and well-behaved listener mods.
+        GameEvents.onSceneConfirmExit.Fire(HighLogic.CurrentGame.startScene);
+        FlightGlobals.ClearpersistentIdDictionaries();
         GamePersistence.SaveGame(
             HighLogic.CurrentGame.Updated(),
             "persistent",
             HighLogic.SaveFolder,
             SaveMode.OVERWRITE);
+        if (dest == GameScenes.MAINMENU)
+            AnalyticsUtil.LogSaveGameClosed(HighLogic.CurrentGame);
         return true;
     }
     catch (Exception ex)
@@ -619,8 +667,27 @@ construction.
 - Existing `OnDismiss -> ClearPendingFlag` path stays
   (`MergeDialog.cs:217-223`). No change needed.
 - New `ShowTreeDialog(RecordingTree liveTree, MergeDialogButtonLabels
-  labels, Action preCommitFinalize, Action postChoice)` overload. The
-  Merge / Discard button handlers run, in order:
+  labels, Action preCommitFinalize, Action postChoice)` overload.
+
+  **Decision-building must run AFTER `preCommitFinalize`** (Opus
+  pass-6 P1). `BuildDefaultVesselDecisions` calls `CanPersistVessel`
+  which calls `GhostPlaybackLogic.ShouldSpawnAtRecordingEnd`, which
+  reads `Recording.TerminalStateValue` and `VesselSnapshot`
+  (`GhostPlaybackLogic.cs:4218, :4259-4262, :4293-4312`). On the live
+  active tree those values are null/stale; building decisions
+  pre-finalize would default valid landed/orbiting recordings to
+  ghost-only. Two-phase split:
+
+  - Pre-finalize phase: build *display-only* data (vessel name,
+    duration, body-copy strings) from the live tree. These reads
+    are safe on live data - duration uses `EndUT - StartUT` which
+    are continuously maintained.
+  - Post-finalize phase: call `BuildDefaultVesselDecisions(pending,
+    suppressedRecordingIds, activeReFlyTargetId)` on the
+    just-stashed pending tree, *then* call `MergeCommit(pending,
+    decisions, spawnCount)`.
+
+  The Merge / Discard button handlers run, in order:
   ```
   preCommitFinalize?.Invoke();   // pre-transition: stash pending tree
   var pending = RecordingStore.PendingTree;
@@ -632,24 +699,80 @@ construction.
       ParsekLog.Warn("MergeDialog",
           "ShowTreeDialog: preCommitFinalize produced no pending tree, " +
           "skipping commit/discard");
+      postChoice?.Invoke();
+      return;
   }
-  else if (clickedMerge) MergeCommit(pending, decisions, spawnCount);
-  else                   MergeDiscard(pending);
+
+  // Re-derive Re-Fly suppressed-subtree closure on the pending tree,
+  // mirroring the existing setup at MergeDialog.cs:100-125.
+  HashSet<string> suppressedIds = null;
+  string activeReFlyTargetId = null;
+  var marker = ParsekScenario.Instance?.ActiveReFlySessionMarker;
+  if (marker != null)
+  {
+      activeReFlyTargetId = marker.ActiveReFlyRecordingId;
+      try
+      {
+          var closure = EffectiveState.ComputeSessionSuppressedSubtree(marker);
+          if (closure != null && closure.Count > 0)
+              suppressedIds = new HashSet<string>(closure, StringComparer.Ordinal);
+      }
+      catch (Exception ex)
+      {
+          ParsekLog.Warn("MergeDialog",
+              $"ShowTreeDialog: ComputeSessionSuppressedSubtree threw " +
+              $"{ex.GetType().Name}: {ex.Message} - falling back to " +
+              "leaf-only ghost-only decisions");
+      }
+  }
+  var decisions = BuildDefaultVesselDecisions(
+      pending, suppressedIds, activeReFlyTargetId);
+  int spawnCount = 0;
+  foreach (var v in decisions.Values) if (v) spawnCount++;
+
+  bool actionSucceeded;
+  if (clickedMerge)
+  {
+      MergeCommit(pending, decisions, spawnCount);
+      actionSucceeded = (RecordingStore.PendingTree == null);
+  }
+  else
+  {
+      actionSucceeded = MergeDiscard(pending);   // signature change: now returns bool
+  }
+
+  // Opus pass-6 P2: do NOT proceed with postChoice if the action
+  // refused (handler-level journal-active guard, race, future
+  // caller). Refused = pendingTree still set / Discard returned
+  // false. Player remains in flight; the prefix's blocked
+  // LoadScene stays blocked. Player retries when the merge
+  // journal finishes.
+  if (!actionSucceeded)
+  {
+      ParsekLog.Warn("MergeDialog",
+          "ShowTreeDialog: action refused (likely merge-journal-active " +
+          "guard). Skipping postChoice; player remains in flight.");
+      // Do NOT invoke postChoice - the flight scene stays open.
+      return;
+  }
+
   postChoice?.Invoke();
   ```
-  No `?? liveTree` fallback - `MergeCommit` calls
-  `RecordingStore.CommitPendingTree()` which asserts a pending tree
-  exists (`MergeDialog.cs:316`). A null `PendingTree` after
-  `preCommitFinalize` means there's nothing to commit; silently
-  skipping with a Warn is the right behaviour, not feeding it the
-  live tree (which would crash inside `CommitPendingTree`).
-  Decisions are built inside `ShowTreeDialog` exactly as today
-  (`MergeDialog.cs:100-125`: `ComputeSessionSuppressedSubtree` +
-  `activeReFlyTargetId` + `BuildDefaultVesselDecisions`). Pre-transition
-  callers do NOT duplicate that decision-build; reusing the existing
-  internals preserves the Re-Fly suppressed-subtree closure that's
-  load-bearing for Re-Fly correctness. The post-load deferred path
-  calls the existing zero-arg `ShowTreeDialog(tree)` and is unchanged.
+
+  `MergeCommit` and `MergeDiscard` signature changes:
+  - `MergeDiscard` now returns `bool` (true = discarded, false =
+    refused). The existing `void` overload stays for backward
+    compatibility with the post-load deferred path; the new
+    `bool`-returning overload is what `ShowTreeDialog` calls.
+  - `MergeCommit` stays `void` but the wrapper checks
+    `RecordingStore.PendingTree == null` after the call to detect
+    successful commit (`CommitPendingTree` nulls the pending
+    tree). If the merge-journal-active guard is later added to
+    `MergeCommit` too, switch to a bool-returning overload there
+    as well.
+
+  The post-load deferred path calls the existing zero-arg
+  `ShowTreeDialog(tree)` and is unchanged.
 - **Add the merge-journal-active guard to the discard handlers, not just
   to button construction (P1.C).** The previous draft was wrong:
   `MergeDialog.MergeDiscard` does *not* currently check
@@ -660,9 +783,9 @@ construction.
   `RevertInterceptor.cs:345-352`). Mirror that pattern in two places:
   - `MergeDialog.MergeDiscard`: at the top, before `TryDiscardActiveReFlyAttempt`,
     refuse if `ActiveMergeJournal != null` with a `ParsekLog.Warn` and a
-    `ParsekLog.ScreenMessage("Discard: merge in progress - retry in a moment", 3f)`
-    (Opus re-review #11: existing code uses `ParsekLog.ScreenMessage`,
-    not `ScreenMessages.PostScreenMessage`).
+    `ParsekLog.ScreenMessage("Discard: merge in progress - retry in a moment", 3f)`.
+    The new `bool`-returning overload returns `false` on refusal; the
+    legacy `void` overload simply early-returns.
   - `MergeDialog.TryDiscardActiveReFlyAttempt`: at the top, refuse with
     the same pattern. Belt-and-braces for any future call site that
     bypasses `MergeDiscard`.
@@ -840,9 +963,9 @@ LANDED/SPLASHED situations pass through unchanged.)
 
 ### Merge-journal-active guard (P1.C coverage)
 
-- `MergeDialog.MergeDiscard` with `ActiveMergeJournal != null`: refuses
-  with Warn log + screen message; no state mutation; pending tree
-  remains stashed.
+- `MergeDialog.MergeDiscard` with `ActiveMergeJournal != null`:
+  refuses with Warn log + screen message; no state mutation;
+  pending tree remains stashed; new bool overload returns false.
 - `MergeDialog.TryDiscardActiveReFlyAttempt` invoked directly with
   `ActiveMergeJournal != null` (test bypass / future caller): same
   refusal contract.
@@ -850,11 +973,52 @@ LANDED/SPLASHED situations pass through unchanged.)
   `ReFlyRevertDialog`'s "Merge always allowed, Discard hidden" gate).
 - Button-build hides Discard when journal active - regression test
   asserts the dialog only ever exposes one button in that state.
+- **Refused discard does NOT proceed to scene change** (Opus pass-6
+  P2): wrapper checks `actionSucceeded` flag from `MergeDiscard`'s
+  bool return / `MergeCommit`'s `PendingTree == null` post-check.
+  If false, postChoice is not invoked. Prefix's blocked LoadScene
+  stays blocked. Player remains in flight. Asserted by a unit test
+  that arms `ActiveMergeJournal`, clicks Discard, and verifies (a)
+  `s_AllowNextLoadScene` was never set, (b) screen message fired,
+  (c) `pendingTree` still stashed, (d) `activeTree` may be null
+  (preCommitFinalize already ran). Player can either wait for
+  journal completion and retry exit, or restart KSP.
+
+### Save preparation parity (Opus pass-6 P2)
+
+- For PauseMenu saveAndExit destinations (stock prepped + saved
+  before our prefix): assert our re-save runs full prep again
+  (`onSceneConfirmExit` fired twice, `ClearpersistentIdDictionaries`
+  called twice). Both calls are idempotent for KSP itself.
+- For PauseMenu CanRestart no-save destinations: assert
+  `SafeWritePersistent` fires `onSceneConfirmExit`, calls
+  `ClearpersistentIdDictionaries`, then `SaveGame`. Stock did none
+  of these.
+- For FlightResultsDialog direct-LoadScene paths: same as
+  CanRestart - full prep runs in `SafeWritePersistent`.
+- MAINMENU: assert `AnalyticsUtil.LogSaveGameClosed` fires before
+  the save, matching stock saveAndExit's MAINMENU branch.
+- Save throws after partial prep (e.g. `ClearpersistentIdDictionaries`
+  succeeded, `SaveGame` failed): assert MAINMENU still hard-blocks
+  the transition. The cleared dictionaries stay cleared; flight
+  scene continues with no pid mappings until the player retries
+  the exit, at which point stock's saveAndExit re-clears.
 
 ### Defensive tests
 
-- Idle-on-pad pre-transition auto-discard fires before showing dialog,
-  reading live `MaxDistanceFromLaunch` backfilled by
+- **Decision rebuild after preCommitFinalize** (Opus pass-6 P1):
+  set up an active tree with a Landed terminal recording but with
+  `TerminalStateValue` deliberately not set on the live tree (live
+  state). Assert: pre-finalize `BuildDefaultVesselDecisions` would
+  return ghost-only for that recording (because
+  `CanPersistVessel` -> `ShouldSpawnAtRecordingEnd` reads null
+  `TerminalStateValue`). After preCommitFinalize, the same
+  recording in the pending tree has `TerminalStateValue == Landed`,
+  and `BuildDefaultVesselDecisions` returns persist=true. Assert
+  the wrapper invokes `MergeCommit` with the post-finalize
+  decisions, not the pre-finalize ones.
+- Idle-on-pad pre-transition auto-discard fires before showing
+  dialog, reading live `MaxDistanceFromLaunch` backfilled by
   `VesselSpawner.BackfillMaxDistanceAbsoluteOnly` over the live
   recording's Points.
 - Merge-journal-active hides Discard on regular and Re-Fly


### PR DESCRIPTION
## Summary

The "Merge to Timeline / Discard" tree-recording confirmation now appears while the player is still in flight, before the destination scene loads. Previously the dialog fired inside `ParsekScenario.OnLoad` of the destination scene, ~60 frames after the scene transition completed.

- New `SceneExitInterceptor` Harmony Prefix on `HighLogic.LoadScene(GameScenes)` (HarmonyPriority.Last, FLIGHT-and-destination filter). Single chokepoint that catches PauseMenu's `saveAndExit`, PauseMenu's CanRestart no-save, and FlightResultsDialog's KSC/Menu/TS direct LoadScene paths.
- Quit-to-Main-Menu now shows the dialog (previously force-auto-merged).
- Re-Fly sessions show Re-Fly-attempt-scoped button labels and body copy on the same dialog (no separate ReFlyExitDialog class - existing `MergeDialog.ShowTreeDialog` already handles Re-Fly via `TryCommitReFlySupersede` and `TryDiscardActiveReFlyAttempt`).
- Stock danger / quit confirmations still run first.

## Design

Plan: [`docs/dev/plans/merge-confirm-pretransition.md`](docs/dev/plans/merge-confirm-pretransition.md).

Five Opus re-review passes shaped the design. Key decisions:

- **Defer ALL finalize work to the dialog button click**, not pre-finalize before showing. Pre-finalize would call `recorder.ForceStop()` and clear `activeTree`; if the popup is dismissed without a button click the player would be stranded with a dead recorder. The new design shows the dialog on the live `activeTree`; the button-handler wrapper runs `preCommitFinalize -> MergeCommit/MergeDiscardWithResult -> postChoice` in order. Popup dismiss without click leaves the recorder intact.
- **Decisions rebuild after finalize**, not before. `BuildDefaultVesselDecisions` -> `CanPersistVessel` -> `ShouldSpawnAtRecordingEnd` reads `TerminalStateValue` and `VesselSnapshot`, both null/stale on a live activeTree. Building decisions pre-finalize would default valid landed/orbiting recordings to ghost-only.
- **Refused discard skips postChoice**. `MergeDiscardWithResult` returns `bool`. Journal-active guard refuses with a Warn + screen message; the wrapper checks the bool, skips postChoice, and the player stays in flight (prefix's blocked LoadScene stays blocked).
- **Paired token + destination watchdog** (`s_AllowNextLoadScene` + `s_AllowNextLoadSceneDestination`) so a foreign mod's LoadScene call between our callback's set and our prefix's consume cannot silently steal the token.
- **Idle-on-pad fast path is detect AND mutate**: `flight.IsActiveTreeIdleOnPad()` then `flight.AutoDiscardIdleActiveTree(reason)` - tears down recorder/activeTree without finalize/stash. After return-true, `OnSceneChangeRequested` sees `activeTree == null` and no-ops; destination scene loads with no pending tree.
- **`SafeWritePersistent`** runs `onSceneConfirmExit` + `SaveGame` (the `ClearpersistentIdDictionaries` and `LogSaveGameClosed` calls in stock `saveAndExit` are inaccessible internals; skipping is safe). MAINMENU save throw is hard-block; SC/TS/EDITOR is logged-and-continued.
- **Peek-don't-consume** of `RecordingStore.IsNextTreeSceneExitCommitSuppressionArmed` so `RevertInterceptor.DiscardReFlyHandler`'s existing flow still consumes the flag at `ParsekFlight.cs:2734`.

## Test plan

- [x] Unit: 10730 existing tests pass + 17 new (`SceneExitInterceptorTests` decision matrix and test seams; journal-active guard tests in `MergeDialogResourcesAppliedTests`).
- [ ] In-game: Esc -> Space Center / Tracking Station / Quit-to-Main-Menu shows the dialog in flight, not after.
- [ ] In-game: Crash, FlightResultsDialog appears, click Space Center button: dialog appears in flight.
- [ ] In-game: Re-Fly session active, Esc -> Space Center: dialog shows Re-Fly-scoped button labels.
- [ ] In-game: Discard Re-Fly from `ReFlyRevertDialog` still works - prefix bypasses via the existing suppression flag.
- [ ] In-game: low-altitude flight (atmosphere): orange "you will lose progress" warning runs first, then on Yes our merge dialog.
- [ ] In-game: idle-on-pad recording: prefix discards without showing the dialog; no deferred dialog appears in destination scene.
- [ ] In-game: KSPCommunityFixes installed - assert our prefix runs after KSPCF's HighLogic.LoadScene patches (HarmonyPriority.Last).