### PR TITLE
Re-Fly merge dialog: announce auto-seal and the reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to Parsek are documented here.
 ### Enhancements
 
 - The "Merge to Timeline / Discard" tree-recording confirmation dialog now appears while the player is still in flight, before the destination scene loads. Quit-to-Main-Menu shows the dialog too (previously force-auto-merged). Re-Fly sessions show Re-Fly-attempt-scoped button labels and a session-scoped body. Stock danger / quit confirmations still run first.
+- The Re-Fly merge confirmation dialog now announces auto-seal explicitly when a merge will permanently seal the slot, and lists the player-attributable reason (transmitted science, undocked, docked with another vessel, etc.). Previously the dialog said the commit was permanent but did not distinguish auto-seal from a regular commit that left the slot re-flyable.
 
 ### Internals
 

--- a/Source/Parsek.Tests/ReFlyAutoSealPreviewTests.cs
+++ b/Source/Parsek.Tests/ReFlyAutoSealPreviewTests.cs
@@ -1,0 +1,441 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Unit tests for the pre-transition merge dialog auto-seal preview
+    /// (<see cref="ReFlyAutoSealPreviewer"/>). The preview is a read-only,
+    /// conservative subset of the production classifier in
+    /// <see cref="SupersedeCommit"/> - mirrors the gates that are reliable
+    /// from live state (Ledger.Actions, tree topology, live
+    /// <see cref="Vessel.Situations"/>) and surfaces them as
+    /// player-attributable reasons for the dialog body.
+    ///
+    /// <para>The live <see cref="Vessel"/> branches require Unity runtime
+    /// (vessel/orbit/body lookups via <see cref="FlightGlobals"/>); those
+    /// rows in the plan's matrix are exercised via in-game tests rather
+    /// than xUnit. These tests cover the null-vessel paths plus the
+    /// Ledger / tree-topology / format / state-version invariance
+    /// branches, which are reachable without Unity.</para>
+    /// </summary>
+    [Collection("Sequential")]
+    public class ReFlyAutoSealPreviewTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+        private readonly bool priorParsekLogSuppress;
+        private readonly bool priorStoreSuppress;
+
+        public ReFlyAutoSealPreviewTests()
+        {
+            priorParsekLogSuppress = ParsekLog.SuppressLogging;
+            priorStoreSuppress = RecordingStore.SuppressLogging;
+
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            RecordingStore.SuppressLogging = true;
+            ParsekLog.VerboseOverrideForTesting = true;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+
+            RecordingStore.ResetForTesting();
+            ParsekScenario.ResetInstanceForTesting();
+            Ledger.ResetForTesting();
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = priorParsekLogSuppress;
+            RecordingStore.SuppressLogging = priorStoreSuppress;
+            RecordingStore.ResetForTesting();
+            ParsekScenario.ResetInstanceForTesting();
+            Ledger.ResetForTesting();
+        }
+
+        // ---------- Helpers ---------------------------------------------
+
+        private const string TreeId = "tree-test";
+        private const string ProvisionalId = "rec-provisional";
+
+        private static Recording MakeRecording(
+            string id = ProvisionalId, string treeId = TreeId)
+        {
+            return new Recording
+            {
+                RecordingId = id,
+                VesselName = "TestVessel-" + id,
+                TreeId = treeId,
+            };
+        }
+
+        private static ReFlySessionMarker MakeMarker(
+            string treeId = TreeId,
+            string activeReFlyRecordingId = ProvisionalId)
+        {
+            return new ReFlySessionMarker
+            {
+                SessionId = "sess-test",
+                TreeId = treeId,
+                ActiveReFlyRecordingId = activeReFlyRecordingId,
+                OriginChildRecordingId = activeReFlyRecordingId,
+                RewindPointId = "rp-test",
+                InvokedUT = 100.0,
+                PreSessionBranchPointIds = new List<string>(),
+            };
+        }
+
+        private static ParsekScenario MakeScenario(
+            ReFlySessionMarker marker = null)
+        {
+            var scenario = new ParsekScenario
+            {
+                RecordingSupersedes = new List<RecordingSupersedeRelation>(),
+                LedgerTombstones = new List<LedgerTombstone>(),
+                RewindPoints = new List<RewindPoint>(),
+                ActiveReFlySessionMarker = marker,
+            };
+            ParsekScenario.SetInstanceForTesting(scenario);
+            return scenario;
+        }
+
+        private static GameAction MakeScienceEarning(
+            string recordingId,
+            ScienceMethod method,
+            string subjectId = "crewReport@KerbinSrfLandedShores",
+            float scienceAwarded = 5f)
+        {
+            return new GameAction
+            {
+                Type = GameActionType.ScienceEarning,
+                RecordingId = recordingId,
+                UT = 200.0,
+                SubjectId = subjectId,
+                ExperimentId = "crewReport",
+                Body = "Kerbin",
+                Situation = "SrfLanded",
+                Biome = "Shores",
+                ScienceAwarded = scienceAwarded,
+                Method = method,
+                ActionId = "act-" + Guid.NewGuid().ToString("N").Substring(0, 8),
+            };
+        }
+
+        // ---------- Null guards -----------------------------------------
+
+        [Fact]
+        public void Preview_NullMarker_ReturnsNoSeal()
+        {
+            var rec = MakeRecording();
+            var result = ReFlyAutoSealPreviewer.Preview(rec, null, null, null);
+            Assert.False(result.WillAutoSeal);
+            Assert.Empty(result.Reasons);
+            Assert.Null(result.FormatHumanReadable());
+        }
+
+        [Fact]
+        public void Preview_NullProvisional_ReturnsNoSeal()
+        {
+            var marker = MakeMarker();
+            var result = ReFlyAutoSealPreviewer.Preview(null, marker, null, null);
+            Assert.False(result.WillAutoSeal);
+        }
+
+        [Fact]
+        public void Preview_EmptyMarkerTreeId_ReturnsNoSeal()
+        {
+            var rec = MakeRecording();
+            var marker = MakeMarker();
+            marker.TreeId = null;
+            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null, null);
+            Assert.False(result.WillAutoSeal);
+        }
+
+        [Fact]
+        public void Preview_EmptyProvisionalTreeId_ReturnsNoSeal()
+        {
+            var rec = MakeRecording();
+            rec.TreeId = null;
+            var marker = MakeMarker();
+            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null, null);
+            Assert.False(result.WillAutoSeal);
+        }
+
+        [Fact]
+        public void Preview_TreeIdMismatch_ReturnsNoSeal()
+        {
+            var rec = MakeRecording(treeId: "tree-A");
+            var marker = MakeMarker(treeId: "tree-B");
+            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null, null);
+            Assert.False(result.WillAutoSeal);
+        }
+
+        [Fact]
+        public void Preview_RecordingIdMismatchSameTree_StillRunsOtherChecks()
+        {
+            // In-place continuation has provisional.RecordingId !=
+            // marker.ActiveReFlyRecordingId but same TreeId. The preview
+            // gates on TreeId only - RecordingId mismatch must NOT
+            // disqualify (otherwise in-place continuation would never
+            // surface a seal reason). Confirm by adding a science action
+            // tagged on the provisional and asserting it's surfaced.
+            var rec = MakeRecording(id: "rec-other-active");   // different from marker.ActiveReFlyRecordingId
+            var marker = MakeMarker();   // ActiveReFlyRecordingId == ProvisionalId
+            MakeScenario(marker);
+            Ledger.AddAction(MakeScienceEarning(
+                "rec-other-active", ScienceMethod.Transmitted));
+            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null, null);
+            Assert.True(result.WillAutoSeal);
+            Assert.Contains(ReFlyAutoSealReason.TransmittedScience, result.Reasons);
+        }
+
+        // ---------- Earned-science branch -------------------------------
+
+        [Fact]
+        public void Preview_TransmittedScience_AddsTransmittedReason()
+        {
+            var rec = MakeRecording();
+            var marker = MakeMarker();
+            MakeScenario(marker);
+            Ledger.AddAction(MakeScienceEarning(rec.RecordingId, ScienceMethod.Transmitted));
+
+            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null, null);
+
+            Assert.True(result.WillAutoSeal);
+            Assert.Equal(new[] { ReFlyAutoSealReason.TransmittedScience }, result.Reasons);
+            Assert.Equal("transmitted science", result.FormatHumanReadable());
+        }
+
+        [Fact]
+        public void Preview_RecoveredScience_AddsRecoveredReason()
+        {
+            var rec = MakeRecording();
+            var marker = MakeMarker();
+            MakeScenario(marker);
+            Ledger.AddAction(MakeScienceEarning(rec.RecordingId, ScienceMethod.Recovered));
+
+            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null, null);
+
+            Assert.True(result.WillAutoSeal);
+            Assert.Equal(new[] { ReFlyAutoSealReason.RecoveredScience }, result.Reasons);
+            Assert.Equal("recovered science", result.FormatHumanReadable());
+        }
+
+        [Fact]
+        public void Preview_TwoTransmittedRows_DedupesToOneReason()
+        {
+            var rec = MakeRecording();
+            var marker = MakeMarker();
+            MakeScenario(marker);
+            Ledger.AddAction(MakeScienceEarning(rec.RecordingId, ScienceMethod.Transmitted, subjectId: "subj-A"));
+            Ledger.AddAction(MakeScienceEarning(rec.RecordingId, ScienceMethod.Transmitted, subjectId: "subj-B"));
+
+            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null, null);
+
+            Assert.True(result.WillAutoSeal);
+            Assert.Single(result.Reasons);
+            Assert.Equal(ReFlyAutoSealReason.TransmittedScience, result.Reasons[0]);
+        }
+
+        [Fact]
+        public void Preview_MixedTransmittedAndRecovered_BothReasons()
+        {
+            var rec = MakeRecording();
+            var marker = MakeMarker();
+            MakeScenario(marker);
+            Ledger.AddAction(MakeScienceEarning(rec.RecordingId, ScienceMethod.Transmitted));
+            Ledger.AddAction(MakeScienceEarning(rec.RecordingId, ScienceMethod.Recovered));
+
+            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null, null);
+
+            Assert.True(result.WillAutoSeal);
+            Assert.Equal(new[]
+            {
+                ReFlyAutoSealReason.TransmittedScience,
+                ReFlyAutoSealReason.RecoveredScience,
+            }, result.Reasons);
+            Assert.Equal("transmitted science and recovered science",
+                result.FormatHumanReadable());
+        }
+
+        [Fact]
+        public void Preview_ScienceTaggedOnDifferentRecording_NoReason()
+        {
+            var rec = MakeRecording();
+            var marker = MakeMarker();
+            MakeScenario(marker);
+            // Tag science on a recording NOT in the lineage.
+            Ledger.AddAction(MakeScienceEarning("rec-unrelated", ScienceMethod.Transmitted));
+
+            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null, null);
+
+            Assert.False(result.WillAutoSeal);
+            Assert.Empty(result.Reasons);
+        }
+
+        [Fact]
+        public void Preview_NonScienceActionTaggedOnProvisional_NoReason()
+        {
+            var rec = MakeRecording();
+            var marker = MakeMarker();
+            MakeScenario(marker);
+            // FundsEarning is world-state-changing but not retry-blocking
+            // (filtered by IsRetryBlockingRecordingAction at SupersedeCommit.cs:1289).
+            // The preview filters non-ScienceEarning types by the same logic.
+            Ledger.AddAction(new GameAction
+            {
+                Type = GameActionType.FundsEarning,
+                RecordingId = rec.RecordingId,
+                UT = 200.0,
+                FundsAwarded = 1000f,
+                ActionId = "act-funds",
+            });
+
+            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null, null);
+
+            Assert.False(result.WillAutoSeal);
+        }
+
+        [Fact]
+        public void Preview_EmptyLedger_NoScienceReason()
+        {
+            var rec = MakeRecording();
+            var marker = MakeMarker();
+            MakeScenario(marker);
+
+            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null, null);
+
+            Assert.False(result.WillAutoSeal);
+        }
+
+        // ---------- State-version invariance ----------------------------
+
+        [Fact]
+        public void Preview_DoesNotMutateLedger()
+        {
+            // Read-only contract: Preview must not mutate Ledger.Actions
+            // even when it walks them. Pin the contract by snapshotting
+            // counts and comparing.
+            var rec = MakeRecording();
+            var marker = MakeMarker();
+            MakeScenario(marker);
+            Ledger.AddAction(MakeScienceEarning(rec.RecordingId, ScienceMethod.Transmitted));
+            Ledger.AddAction(new GameAction
+            {
+                Type = GameActionType.FundsEarning,
+                RecordingId = rec.RecordingId,
+                UT = 250.0,
+                FundsAwarded = 500f,
+                ActionId = "act-funds",
+            });
+            int beforeCount = Ledger.Actions.Count;
+
+            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null, null);
+
+            Assert.True(result.WillAutoSeal);
+            Assert.Equal(beforeCount, Ledger.Actions.Count);
+        }
+
+        // ---------- FormatHumanReadable standalone ----------------------
+
+        [Fact]
+        public void Phrase_AllReasons_MatchSpec()
+        {
+            var expected = new Dictionary<ReFlyAutoSealReason, string>
+            {
+                { ReFlyAutoSealReason.EarnedScience, "earned science" },
+                { ReFlyAutoSealReason.TransmittedScience, "transmitted science" },
+                { ReFlyAutoSealReason.RecoveredScience, "recovered science" },
+                { ReFlyAutoSealReason.Undocked, "undocked" },
+                { ReFlyAutoSealReason.KerbalEva, "sent a kerbal on EVA" },
+                { ReFlyAutoSealReason.PartBrokeOff, "broke off a part" },
+                { ReFlyAutoSealReason.VesselBrokeUp, "the vessel broke up" },
+                { ReFlyAutoSealReason.DockedWithAnother, "docked with another vessel" },
+                { ReFlyAutoSealReason.Landed, "landed" },
+                { ReFlyAutoSealReason.SplashedDown, "splashed down" },
+                { ReFlyAutoSealReason.StableOrbit, "reached a stable orbit" },
+                { ReFlyAutoSealReason.SubOrbitalArc, "reached a sub-orbital arc" },
+            };
+            foreach (var kvp in expected)
+                Assert.Equal(kvp.Value, ReFlyAutoSealPreviewResult.PhraseFor(kvp.Key));
+        }
+
+        [Fact]
+        public void Format_EmptyReasons_ReturnsNull()
+        {
+            var result = new ReFlyAutoSealPreviewResult
+            {
+                WillAutoSeal = false,
+                Reasons = new List<ReFlyAutoSealReason>(),
+            };
+            Assert.Null(result.FormatHumanReadable());
+        }
+
+        [Fact]
+        public void Format_SingleReason_BarePhrase()
+        {
+            var result = new ReFlyAutoSealPreviewResult
+            {
+                WillAutoSeal = true,
+                Reasons = new List<ReFlyAutoSealReason>
+                    { ReFlyAutoSealReason.TransmittedScience },
+            };
+            Assert.Equal("transmitted science", result.FormatHumanReadable());
+        }
+
+        [Fact]
+        public void Format_TwoReasons_AndJoiner()
+        {
+            var result = new ReFlyAutoSealPreviewResult
+            {
+                WillAutoSeal = true,
+                Reasons = new List<ReFlyAutoSealReason>
+                {
+                    ReFlyAutoSealReason.Undocked,
+                    ReFlyAutoSealReason.KerbalEva,
+                },
+            };
+            Assert.Equal("undocked and sent a kerbal on EVA",
+                result.FormatHumanReadable());
+        }
+
+        [Fact]
+        public void Format_ThreeReasons_OxfordComma()
+        {
+            var result = new ReFlyAutoSealPreviewResult
+            {
+                WillAutoSeal = true,
+                Reasons = new List<ReFlyAutoSealReason>
+                {
+                    ReFlyAutoSealReason.TransmittedScience,
+                    ReFlyAutoSealReason.Undocked,
+                    ReFlyAutoSealReason.DockedWithAnother,
+                },
+            };
+            Assert.Equal(
+                "transmitted science, undocked, and docked with another vessel",
+                result.FormatHumanReadable());
+        }
+
+        [Fact]
+        public void Format_MixedSubjectPhrases_StillReadsCleanly()
+        {
+            // "the vessel broke up" is subject-led; under the colon-list
+            // form ("for the following reason(s): the vessel broke up
+            // and docked with another vessel.") the implicit subject of
+            // the second clause is "the vessel" too, which is fine.
+            var result = new ReFlyAutoSealPreviewResult
+            {
+                WillAutoSeal = true,
+                Reasons = new List<ReFlyAutoSealReason>
+                {
+                    ReFlyAutoSealReason.VesselBrokeUp,
+                    ReFlyAutoSealReason.DockedWithAnother,
+                },
+            };
+            Assert.Equal(
+                "the vessel broke up and docked with another vessel",
+                result.FormatHumanReadable());
+        }
+    }
+}

--- a/Source/Parsek.Tests/ReFlyAutoSealPreviewTests.cs
+++ b/Source/Parsek.Tests/ReFlyAutoSealPreviewTests.cs
@@ -504,5 +504,50 @@ namespace Parsek.Tests
                 "MyShip", 65.0, preview);
             Assert.Contains("<align=\"center\">MyShip - ", body);
         }
+
+        // ---------- ShouldUseLiveVesselForReFlyTarget (pid match) -------
+
+        [Fact]
+        public void ShouldUseLiveVessel_MatchingPids_ReturnsTrue()
+        {
+            // Re-Fly recording's pid matches the live active vessel's pid:
+            // the live-vessel terminal branch is safe to run.
+            Assert.True(ReFlyAutoSealPreviewer.ShouldUseLiveVesselForReFlyTarget(
+                candidatePid: 12345u, expectedPid: 12345u));
+        }
+
+        [Fact]
+        public void ShouldUseLiveVessel_DifferentPids_ReturnsFalse()
+        {
+            // Active vessel has been switched mid-Re-Fly; live-terminal
+            // reasons would describe an unrelated vessel.
+            Assert.False(ReFlyAutoSealPreviewer.ShouldUseLiveVesselForReFlyTarget(
+                candidatePid: 12345u, expectedPid: 67890u));
+        }
+
+        [Fact]
+        public void ShouldUseLiveVessel_ZeroCandidatePid_ReturnsFalse()
+        {
+            // pid==0 is the unset sentinel; do not accept as match.
+            Assert.False(ReFlyAutoSealPreviewer.ShouldUseLiveVesselForReFlyTarget(
+                candidatePid: 0u, expectedPid: 12345u));
+        }
+
+        [Fact]
+        public void ShouldUseLiveVessel_ZeroExpectedPid_ReturnsFalse()
+        {
+            // The Re-Fly recording's VesselPersistentId is unset (0).
+            // Defensive: skip rather than pretend any vessel matches a 0
+            // sentinel.
+            Assert.False(ReFlyAutoSealPreviewer.ShouldUseLiveVesselForReFlyTarget(
+                candidatePid: 12345u, expectedPid: 0u));
+        }
+
+        [Fact]
+        public void ShouldUseLiveVessel_BothZero_ReturnsFalse()
+        {
+            Assert.False(ReFlyAutoSealPreviewer.ShouldUseLiveVesselForReFlyTarget(
+                candidatePid: 0u, expectedPid: 0u));
+        }
     }
 }

--- a/Source/Parsek.Tests/ReFlyAutoSealPreviewTests.cs
+++ b/Source/Parsek.Tests/ReFlyAutoSealPreviewTests.cs
@@ -447,8 +447,8 @@ namespace Parsek.Tests
             string body = MergeDialog.BuildReFlyDialogBody(
                 "TestVessel", 123.0, preview);
             Assert.Contains("TestVessel", body);
-            Assert.Contains("Commit this Re-Fly attempt permanently to the timeline",
-                body);
+            Assert.Contains("If not discarded, this Re-Fly attempt", body);
+            Assert.Contains("committed permanently to the timeline", body);
             Assert.Contains("This cannot be undone", body);
             Assert.DoesNotContain("auto-sealed", body);
             Assert.DoesNotContain("for the following reason", body);
@@ -465,6 +465,7 @@ namespace Parsek.Tests
             };
             string body = MergeDialog.BuildReFlyDialogBody(
                 "TestVessel", 123.0, preview);
+            Assert.Contains("If not discarded, this Re-Fly attempt", body);
             Assert.Contains("merged AND auto-sealed", body);
             Assert.Contains("for the following reason(s): transmitted science.",
                 body);

--- a/Source/Parsek.Tests/ReFlyAutoSealPreviewTests.cs
+++ b/Source/Parsek.Tests/ReFlyAutoSealPreviewTests.cs
@@ -127,7 +127,7 @@ namespace Parsek.Tests
         public void Preview_NullMarker_ReturnsNoSeal()
         {
             var rec = MakeRecording();
-            var result = ReFlyAutoSealPreviewer.Preview(rec, null, null, null);
+            var result = ReFlyAutoSealPreviewer.Preview(rec, null, null);
             Assert.False(result.WillAutoSeal);
             Assert.Empty(result.Reasons);
             Assert.Null(result.FormatHumanReadable());
@@ -137,7 +137,7 @@ namespace Parsek.Tests
         public void Preview_NullProvisional_ReturnsNoSeal()
         {
             var marker = MakeMarker();
-            var result = ReFlyAutoSealPreviewer.Preview(null, marker, null, null);
+            var result = ReFlyAutoSealPreviewer.Preview(null, marker, null);
             Assert.False(result.WillAutoSeal);
         }
 
@@ -147,7 +147,7 @@ namespace Parsek.Tests
             var rec = MakeRecording();
             var marker = MakeMarker();
             marker.TreeId = null;
-            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null, null);
+            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null);
             Assert.False(result.WillAutoSeal);
         }
 
@@ -157,7 +157,7 @@ namespace Parsek.Tests
             var rec = MakeRecording();
             rec.TreeId = null;
             var marker = MakeMarker();
-            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null, null);
+            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null);
             Assert.False(result.WillAutoSeal);
         }
 
@@ -166,7 +166,7 @@ namespace Parsek.Tests
         {
             var rec = MakeRecording(treeId: "tree-A");
             var marker = MakeMarker(treeId: "tree-B");
-            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null, null);
+            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null);
             Assert.False(result.WillAutoSeal);
         }
 
@@ -184,7 +184,7 @@ namespace Parsek.Tests
             MakeScenario(marker);
             Ledger.AddAction(MakeScienceEarning(
                 "rec-other-active", ScienceMethod.Transmitted));
-            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null, null);
+            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null);
             Assert.True(result.WillAutoSeal);
             Assert.Contains(ReFlyAutoSealReason.TransmittedScience, result.Reasons);
         }
@@ -199,7 +199,7 @@ namespace Parsek.Tests
             MakeScenario(marker);
             Ledger.AddAction(MakeScienceEarning(rec.RecordingId, ScienceMethod.Transmitted));
 
-            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null, null);
+            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null);
 
             Assert.True(result.WillAutoSeal);
             Assert.Equal(new[] { ReFlyAutoSealReason.TransmittedScience }, result.Reasons);
@@ -214,7 +214,7 @@ namespace Parsek.Tests
             MakeScenario(marker);
             Ledger.AddAction(MakeScienceEarning(rec.RecordingId, ScienceMethod.Recovered));
 
-            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null, null);
+            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null);
 
             Assert.True(result.WillAutoSeal);
             Assert.Equal(new[] { ReFlyAutoSealReason.RecoveredScience }, result.Reasons);
@@ -230,7 +230,7 @@ namespace Parsek.Tests
             Ledger.AddAction(MakeScienceEarning(rec.RecordingId, ScienceMethod.Transmitted, subjectId: "subj-A"));
             Ledger.AddAction(MakeScienceEarning(rec.RecordingId, ScienceMethod.Transmitted, subjectId: "subj-B"));
 
-            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null, null);
+            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null);
 
             Assert.True(result.WillAutoSeal);
             Assert.Single(result.Reasons);
@@ -246,7 +246,7 @@ namespace Parsek.Tests
             Ledger.AddAction(MakeScienceEarning(rec.RecordingId, ScienceMethod.Transmitted));
             Ledger.AddAction(MakeScienceEarning(rec.RecordingId, ScienceMethod.Recovered));
 
-            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null, null);
+            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null);
 
             Assert.True(result.WillAutoSeal);
             Assert.Equal(new[]
@@ -267,7 +267,7 @@ namespace Parsek.Tests
             // Tag science on a recording NOT in the lineage.
             Ledger.AddAction(MakeScienceEarning("rec-unrelated", ScienceMethod.Transmitted));
 
-            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null, null);
+            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null);
 
             Assert.False(result.WillAutoSeal);
             Assert.Empty(result.Reasons);
@@ -291,7 +291,7 @@ namespace Parsek.Tests
                 ActionId = "act-funds",
             });
 
-            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null, null);
+            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null);
 
             Assert.False(result.WillAutoSeal);
         }
@@ -303,7 +303,7 @@ namespace Parsek.Tests
             var marker = MakeMarker();
             MakeScenario(marker);
 
-            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null, null);
+            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null);
 
             Assert.False(result.WillAutoSeal);
         }
@@ -330,7 +330,7 @@ namespace Parsek.Tests
             });
             int beforeCount = Ledger.Actions.Count;
 
-            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null, null);
+            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null);
 
             Assert.True(result.WillAutoSeal);
             Assert.Equal(beforeCount, Ledger.Actions.Count);

--- a/Source/Parsek.Tests/ReFlyAutoSealPreviewTests.cs
+++ b/Source/Parsek.Tests/ReFlyAutoSealPreviewTests.cs
@@ -437,5 +437,71 @@ namespace Parsek.Tests
                 "the vessel broke up and docked with another vessel",
                 result.FormatHumanReadable());
         }
+
+        // ---------- BuildReFlyDialogBody --------------------------------
+
+        [Fact]
+        public void BuildBody_NoSeal_UsesDefaultCopy()
+        {
+            var preview = ReFlyAutoSealPreviewResult.NoSeal();
+            string body = MergeDialog.BuildReFlyDialogBody(
+                "TestVessel", 123.0, preview);
+            Assert.Contains("TestVessel", body);
+            Assert.Contains("Commit this Re-Fly attempt permanently to the timeline",
+                body);
+            Assert.Contains("This cannot be undone", body);
+            Assert.DoesNotContain("auto-sealed", body);
+            Assert.DoesNotContain("for the following reason", body);
+        }
+
+        [Fact]
+        public void BuildBody_AutoSeal_SingleReason_IncludesReasonAndSlotWarning()
+        {
+            var preview = new ReFlyAutoSealPreviewResult
+            {
+                WillAutoSeal = true,
+                Reasons = new List<ReFlyAutoSealReason>
+                    { ReFlyAutoSealReason.TransmittedScience },
+            };
+            string body = MergeDialog.BuildReFlyDialogBody(
+                "TestVessel", 123.0, preview);
+            Assert.Contains("merged AND auto-sealed", body);
+            Assert.Contains("for the following reason(s): transmitted science.",
+                body);
+            Assert.Contains("slot will become permanent", body);
+            Assert.Contains("not be able to Re-Fly this line of flight",
+                body);
+            Assert.Contains("This cannot be undone", body);
+        }
+
+        [Fact]
+        public void BuildBody_AutoSeal_MultipleReasons_Composes()
+        {
+            var preview = new ReFlyAutoSealPreviewResult
+            {
+                WillAutoSeal = true,
+                Reasons = new List<ReFlyAutoSealReason>
+                {
+                    ReFlyAutoSealReason.TransmittedScience,
+                    ReFlyAutoSealReason.Undocked,
+                    ReFlyAutoSealReason.DockedWithAnother,
+                },
+            };
+            string body = MergeDialog.BuildReFlyDialogBody(
+                "TestVessel", 123.0, preview);
+            Assert.Contains(
+                "for the following reason(s): transmitted science, undocked, " +
+                "and docked with another vessel.",
+                body);
+        }
+
+        [Fact]
+        public void BuildBody_HeadlineIncludesVesselNameAndDuration()
+        {
+            var preview = ReFlyAutoSealPreviewResult.NoSeal();
+            string body = MergeDialog.BuildReFlyDialogBody(
+                "MyShip", 65.0, preview);
+            Assert.Contains("<align=\"center\">MyShip - ", body);
+        }
     }
 }

--- a/Source/Parsek/MergeDialog.cs
+++ b/Source/Parsek/MergeDialog.cs
@@ -295,9 +295,21 @@ namespace Parsek
                 double reFlyDuration = reFlyRec != null
                     ? System.Math.Max(0.0, reFlyRec.EndUT - reFlyRec.StartUT)
                     : ComputeTreeDurationRange(liveTree);
-                message = $"<align=\"center\">{vesselLabel} - {FormatDuration(reFlyDuration)}</align>\n\n" +
-                          "<align=\"left\">Commit this Re-Fly attempt permanently to the timeline. " +
-                          "This cannot be undone.</align>";
+
+                // Auto-seal preview (situation sampled at dialog spawn
+                // only - while the dialog sits open under LockInput, KSP
+                // physics still runs and the active vessel situation
+                // could in theory flip; the production classifier
+                // re-classifies at finalize, so a transient flicker only
+                // affects the dialog wording, not the seal verdict).
+                var preview = ReFlyAutoSealPreviewer.Preview(
+                    reFlyRec, marker, reFlyScenario, FlightGlobals.ActiveVessel);
+                message = BuildReFlyDialogBody(vesselLabel, reFlyDuration, preview);
+
+                ParsekLog.Info("MergeDialog",
+                    $"Re-Fly auto-seal preview: willSeal={preview.WillAutoSeal} " +
+                    $"reasons=[{string.Join(",", preview.Reasons)}] " +
+                    $"sess={marker?.SessionId ?? "<no-id>"}");
             }
             else
             {
@@ -469,6 +481,38 @@ namespace Parsek
 
         internal static string FormatDuration(double seconds)
             => ParsekTimeFormat.FormatDuration(seconds);
+
+        /// <summary>
+        /// Composes the pre-transition Re-Fly merge dialog body. Pure
+        /// helper for unit-testability - the callable
+        /// <see cref="ShowTreeDialog"/> 4-arg overload spawns a
+        /// <see cref="PopupDialog"/> which requires Unity runtime, but
+        /// the body string itself is data-driven and worth pinning in
+        /// xUnit. Callers pass a precomputed
+        /// <see cref="ReFlyAutoSealPreviewResult"/>; this method only
+        /// formats it.
+        /// </summary>
+        internal static string BuildReFlyDialogBody(
+            string vesselLabel,
+            double reFlyDuration,
+            ReFlyAutoSealPreviewResult preview)
+        {
+            string headline = $"<align=\"center\">{vesselLabel} - " +
+                              $"{FormatDuration(reFlyDuration)}</align>\n\n";
+            if (!preview.WillAutoSeal)
+            {
+                return headline +
+                    "<align=\"left\">Commit this Re-Fly attempt permanently to " +
+                    "the timeline. This cannot be undone.</align>";
+            }
+
+            string reasons = preview.FormatHumanReadable();
+            return headline +
+                "<align=\"left\"><b>This Re-Fly attempt will be merged AND " +
+                $"auto-sealed</b> for the following reason(s): {reasons}. " +
+                "The slot will become permanent and you will not be able to " +
+                "Re-Fly this line of flight again. This cannot be undone.</align>";
+        }
 
         private static string FormatClearReason(string reason)
             => string.IsNullOrEmpty(reason) ? "<unspecified>" : reason;

--- a/Source/Parsek/MergeDialog.cs
+++ b/Source/Parsek/MergeDialog.cs
@@ -303,7 +303,7 @@ namespace Parsek
                 // re-classifies at finalize, so a transient flicker only
                 // affects the dialog wording, not the seal verdict).
                 var preview = ReFlyAutoSealPreviewer.Preview(
-                    reFlyRec, marker, reFlyScenario, FlightGlobals.ActiveVessel);
+                    reFlyRec, marker, FlightGlobals.ActiveVessel);
                 message = BuildReFlyDialogBody(vesselLabel, reFlyDuration, preview);
 
                 ParsekLog.Info("MergeDialog",

--- a/Source/Parsek/MergeDialog.cs
+++ b/Source/Parsek/MergeDialog.cs
@@ -499,19 +499,26 @@ namespace Parsek
         {
             string headline = $"<align=\"center\">{vesselLabel} - " +
                               $"{FormatDuration(reFlyDuration)}</align>\n\n";
+            // The "If not discarded" prefix reminds the player that
+            // Discard remains an option: discarding throws this attempt
+            // away and leaves the slot re-flyable for a future retry.
+            // Merge commits the attempt permanently (and seals the
+            // slot, when the auto-seal preview fires).
             if (!preview.WillAutoSeal)
             {
                 return headline +
-                    "<align=\"left\">Commit this Re-Fly attempt permanently to " +
-                    "the timeline. This cannot be undone.</align>";
+                    "<align=\"left\">If not discarded, this Re-Fly attempt " +
+                    "will be committed permanently to the timeline. This " +
+                    "cannot be undone.</align>";
             }
 
             string reasons = preview.FormatHumanReadable();
             return headline +
-                "<align=\"left\"><b>This Re-Fly attempt will be merged AND " +
-                $"auto-sealed</b> for the following reason(s): {reasons}. " +
-                "The slot will become permanent and you will not be able to " +
-                "Re-Fly this line of flight again. This cannot be undone.</align>";
+                "<align=\"left\"><b>If not discarded, this Re-Fly attempt " +
+                $"will be merged AND auto-sealed</b> for the following " +
+                $"reason(s): {reasons}. The slot will become permanent and " +
+                "you will not be able to Re-Fly this line of flight again. " +
+                "This cannot be undone.</align>";
         }
 
         private static string FormatClearReason(string reason)

--- a/Source/Parsek/ReFlyAutoSealPreview.cs
+++ b/Source/Parsek/ReFlyAutoSealPreview.cs
@@ -169,7 +169,22 @@ namespace Parsek
             // open under LockInput, so the situation could in theory flip
             // before the player clicks. Acceptable as a snapshot - the
             // production classifier re-classifies at finalize.
-            CollectLiveVesselReasons(liveActiveVessel, reasons);
+            //
+            // Re-Fly sessions can vessel-switch (background a recording,
+            // promote another vessel to active) while the marker still
+            // identifies the original slot, so FlightGlobals.ActiveVessel
+            // may be a different vessel than the one liveProvisional
+            // describes. Surfacing live-terminal reasons from an unrelated
+            // active vessel would mislead the player; the production
+            // classifier runs against the Re-Fly recording, not the live
+            // active vessel. Gate the live-vessel branch by persistent id:
+            // skip when the active vessel does not match the recording's
+            // VesselPersistentId.
+            Vessel reFlyVessel =
+                IsLiveVesselReFlyTarget(liveActiveVessel, liveProvisional)
+                    ? liveActiveVessel
+                    : null;
+            CollectLiveVesselReasons(reFlyVessel, reasons);
 
             SortReasonsByGroup(reasons);
 
@@ -221,6 +236,30 @@ namespace Parsek
                 AddIfMissing(reasons, ReFlyAutoSealReason.RecoveredScience);
             if (sawUnknownMethod)
                 AddIfMissing(reasons, ReFlyAutoSealReason.EarnedScience);
+        }
+
+        private static bool IsLiveVesselReFlyTarget(
+            Vessel candidate, Recording reFlyRec)
+        {
+            if (candidate == null) return false;
+            if (reFlyRec == null) return false;
+            return ShouldUseLiveVesselForReFlyTarget(
+                candidate.persistentId, reFlyRec.VesselPersistentId);
+        }
+
+        /// <summary>
+        /// Pure persistent-id comparison extracted for unit-testability.
+        /// The live-vessel terminal branch should run only when the
+        /// candidate vessel's pid matches the Re-Fly recording's pid AND
+        /// neither is the zero sentinel. Internal so tests can pin the
+        /// matching contract without faking a <see cref="Vessel"/>.
+        /// </summary>
+        internal static bool ShouldUseLiveVesselForReFlyTarget(
+            uint candidatePid, uint expectedPid)
+        {
+            if (candidatePid == 0) return false;
+            if (expectedPid == 0) return false;
+            return candidatePid == expectedPid;
         }
 
         private static ReFlyAutoSealReason? MapStructuralBranchPoint(

--- a/Source/Parsek/ReFlyAutoSealPreview.cs
+++ b/Source/Parsek/ReFlyAutoSealPreview.cs
@@ -1,0 +1,322 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Parsek
+{
+    /// <summary>
+    /// Pre-transition merge dialog (Re-Fly variant) preview of whether the
+    /// merge will trigger auto-seal of the slot, and the player-attributable
+    /// reason(s). Mirrors a subset of the production classifier in
+    /// <see cref="SupersedeCommit"/>: detects the cases that are reliable
+    /// from live state (Ledger.Actions for science, tree topology for
+    /// structural mutations, live <see cref="Vessel.Situations"/> for
+    /// stable terminals).
+    ///
+    /// <para>Read-only and conservative: false negatives over false positives.
+    /// When the preview cannot determine seal, the dialog falls back to the
+    /// default "permanently to the timeline" copy. The production classifier
+    /// runs at finalize and seals correctly regardless of what the preview
+    /// said.</para>
+    /// </summary>
+    internal enum ReFlyAutoSealReason
+    {
+        EarnedScience,         // any retry-blocking ScienceEarning row in the lineage
+        TransmittedScience,    // ScienceMethod.Transmitted
+        RecoveredScience,      // ScienceMethod.Recovered
+        Undocked,              // BranchPointType.Undock
+        KerbalEva,             // BranchPointType.EVA
+        PartBrokeOff,          // BranchPointType.JointBreak
+        VesselBrokeUp,         // BranchPointType.Breakup
+        DockedWithAnother,     // live vessel.situation == DOCKED -> IsHardSafetyTerminal
+        Landed,                // live vessel.situation == LANDED  -> stableTerminalFocusSlot
+        SplashedDown,          // live vessel.situation == SPLASHED -> stableTerminalFocusSlot
+        StableOrbit,           // live vessel.situation == ORBITING && PeR > atmosphere
+        SubOrbitalArc,         // live vessel.situation == SUB_ORBITAL or decaying ORBITING
+    }
+
+    /// <summary>
+    /// Result of <see cref="ReFlyAutoSealPreviewer.Preview"/>.
+    /// <see cref="WillAutoSeal"/> is true when at least one reason was
+    /// detected. <see cref="Reasons"/> is sorted by group (science ->
+    /// structural -> terminal) for stable test output and player
+    /// readability.
+    /// </summary>
+    internal struct ReFlyAutoSealPreviewResult
+    {
+        public bool WillAutoSeal;
+        public List<ReFlyAutoSealReason> Reasons;
+
+        public static ReFlyAutoSealPreviewResult NoSeal()
+        {
+            return new ReFlyAutoSealPreviewResult
+            {
+                WillAutoSeal = false,
+                Reasons = new List<ReFlyAutoSealReason>(0),
+            };
+        }
+
+        /// <summary>
+        /// Composes a player-facing phrase from <see cref="Reasons"/>.
+        /// Subject-free phrasing (e.g. "transmitted science and undocked")
+        /// for the dialog body's "for the following reason(s):" wrapping.
+        ///
+        /// <list type="bullet">
+        ///   <item><description>0 reasons: returns null. Caller shows default copy.</description></item>
+        ///   <item><description>1 reason: bare phrase, e.g. "transmitted science".</description></item>
+        ///   <item><description>2 reasons: "{a} and {b}".</description></item>
+        ///   <item><description>3+ reasons: "{a}, {b}, ..., and {n}" (Oxford comma).</description></item>
+        /// </list>
+        /// </summary>
+        public string FormatHumanReadable()
+        {
+            if (Reasons == null || Reasons.Count == 0)
+                return null;
+
+            if (Reasons.Count == 1)
+                return PhraseFor(Reasons[0]);
+
+            if (Reasons.Count == 2)
+                return PhraseFor(Reasons[0]) + " and " + PhraseFor(Reasons[1]);
+
+            var sb = new StringBuilder();
+            for (int i = 0; i < Reasons.Count; i++)
+            {
+                if (i > 0)
+                {
+                    if (i == Reasons.Count - 1)
+                        sb.Append(", and ");
+                    else
+                        sb.Append(", ");
+                }
+                sb.Append(PhraseFor(Reasons[i]));
+            }
+            return sb.ToString();
+        }
+
+        internal static string PhraseFor(ReFlyAutoSealReason reason)
+        {
+            switch (reason)
+            {
+                case ReFlyAutoSealReason.EarnedScience:      return "earned science";
+                case ReFlyAutoSealReason.TransmittedScience: return "transmitted science";
+                case ReFlyAutoSealReason.RecoveredScience:   return "recovered science";
+                case ReFlyAutoSealReason.Undocked:           return "undocked";
+                case ReFlyAutoSealReason.KerbalEva:          return "sent a kerbal on EVA";
+                case ReFlyAutoSealReason.PartBrokeOff:       return "broke off a part";
+                case ReFlyAutoSealReason.VesselBrokeUp:      return "the vessel broke up";
+                case ReFlyAutoSealReason.DockedWithAnother:  return "docked with another vessel";
+                case ReFlyAutoSealReason.Landed:             return "landed";
+                case ReFlyAutoSealReason.SplashedDown:       return "splashed down";
+                case ReFlyAutoSealReason.StableOrbit:        return "reached a stable orbit";
+                case ReFlyAutoSealReason.SubOrbitalArc:      return "reached a sub-orbital arc";
+                default:                                     return reason.ToString();
+            }
+        }
+    }
+
+    internal static class ReFlyAutoSealPreviewer
+    {
+        /// <summary>
+        /// Compute the auto-seal preview. Read-only: no Ledger / scenario /
+        /// state-version mutation. Returns <see cref="ReFlyAutoSealPreviewResult.NoSeal"/>
+        /// on null guards or TreeId mismatch.
+        /// </summary>
+        internal static ReFlyAutoSealPreviewResult Preview(
+            Recording liveProvisional,
+            ReFlySessionMarker marker,
+            ParsekScenario scenario,
+            Vessel liveActiveVessel)
+        {
+            // Null guards mirror the production gate's early-returns at
+            // SupersedeCommit.HasReFlySessionStructuralMutation:683-688.
+            if (marker == null) return ReFlyAutoSealPreviewResult.NoSeal();
+            if (liveProvisional == null) return ReFlyAutoSealPreviewResult.NoSeal();
+            if (string.IsNullOrEmpty(marker.TreeId)) return ReFlyAutoSealPreviewResult.NoSeal();
+            if (string.IsNullOrEmpty(liveProvisional.TreeId))
+                return ReFlyAutoSealPreviewResult.NoSeal();
+            if (!string.Equals(liveProvisional.TreeId, marker.TreeId,
+                    StringComparison.Ordinal))
+                return ReFlyAutoSealPreviewResult.NoSeal();
+
+            var reasons = new List<ReFlyAutoSealReason>();
+
+            // Earned-science check mirrors SupersedeCommit's
+            // IsRetryBlockingRecordingAction (:1257-1290) which calls
+            // IsWorldStateChangingRecordingAction (:1231-1255). Today only
+            // ScienceEarning rows are retry-blocking, but other action
+            // types are still walked through the same exclusion gates so
+            // future retry-blocking action types pick up automatically.
+            HashSet<string> lineageRecordingIds =
+                SupersedeCommit.CollectRecordingIdsForSafetyGate(liveProvisional);
+            CollectScienceReasons(lineageRecordingIds, reasons);
+
+            // Structural-mutation check via the typed accessor extracted
+            // alongside HasReFlySessionStructuralMutation.
+            if (SupersedeCommit.TryGetFirstReFlySessionStructuralMutationType(
+                    liveProvisional, marker, out BranchPointType firstType))
+            {
+                ReFlyAutoSealReason? mapped = MapStructuralBranchPoint(firstType);
+                if (mapped.HasValue) AddIfMissing(reasons, mapped.Value);
+            }
+
+            // Live vessel terminal proxy. Sampled at dialog spawn only;
+            // KSP physics may continue in background while the dialog is
+            // open under LockInput, so the situation could in theory flip
+            // before the player clicks. Acceptable as a snapshot - the
+            // production classifier re-classifies at finalize.
+            CollectLiveVesselReasons(liveActiveVessel, reasons);
+
+            SortReasonsByGroup(reasons);
+
+            return new ReFlyAutoSealPreviewResult
+            {
+                WillAutoSeal = reasons.Count > 0,
+                Reasons = reasons,
+            };
+        }
+
+        private static void CollectScienceReasons(
+            HashSet<string> lineageRecordingIds,
+            List<ReFlyAutoSealReason> reasons)
+        {
+            if (lineageRecordingIds == null || lineageRecordingIds.Count == 0)
+                return;
+            var actions = Ledger.Actions;
+            if (actions == null) return;
+
+            bool sawTransmitted = false;
+            bool sawRecovered = false;
+            bool sawUnknownMethod = false;
+            for (int i = 0; i < actions.Count; i++)
+            {
+                var action = actions[i];
+                if (action == null) continue;
+                if (action.Type != GameActionType.ScienceEarning) continue;
+                if (string.IsNullOrEmpty(action.RecordingId)) continue;
+                if (!lineageRecordingIds.Contains(action.RecordingId)) continue;
+
+                // Mirror the production filter: skip tombstone-eligible
+                // (e.g. paired with kerbal death penalty) actions.
+                if (TombstoneEligibility.IsEligible(action)) continue;
+                if (TombstoneEligibility.TryPairBundledRepPenalty(
+                        action, actions, out _))
+                    continue;
+
+                if (action.Method == ScienceMethod.Transmitted)
+                    sawTransmitted = true;
+                else if (action.Method == ScienceMethod.Recovered)
+                    sawRecovered = true;
+                else
+                    sawUnknownMethod = true;
+            }
+
+            if (sawTransmitted)
+                AddIfMissing(reasons, ReFlyAutoSealReason.TransmittedScience);
+            if (sawRecovered)
+                AddIfMissing(reasons, ReFlyAutoSealReason.RecoveredScience);
+            if (sawUnknownMethod)
+                AddIfMissing(reasons, ReFlyAutoSealReason.EarnedScience);
+        }
+
+        private static ReFlyAutoSealReason? MapStructuralBranchPoint(
+            BranchPointType type)
+        {
+            switch (type)
+            {
+                case BranchPointType.Undock:     return ReFlyAutoSealReason.Undocked;
+                case BranchPointType.EVA:        return ReFlyAutoSealReason.KerbalEva;
+                case BranchPointType.JointBreak: return ReFlyAutoSealReason.PartBrokeOff;
+                case BranchPointType.Breakup:    return ReFlyAutoSealReason.VesselBrokeUp;
+                default:                         return null;
+            }
+        }
+
+        private static void CollectLiveVesselReasons(
+            Vessel liveActiveVessel,
+            List<ReFlyAutoSealReason> reasons)
+        {
+            if (liveActiveVessel == null) return;
+            switch (liveActiveVessel.situation)
+            {
+                case Vessel.Situations.DOCKED:
+                    AddIfMissing(reasons, ReFlyAutoSealReason.DockedWithAnother);
+                    break;
+                case Vessel.Situations.LANDED:
+                    AddIfMissing(reasons, ReFlyAutoSealReason.Landed);
+                    break;
+                case Vessel.Situations.SPLASHED:
+                    AddIfMissing(reasons, ReFlyAutoSealReason.SplashedDown);
+                    break;
+                case Vessel.Situations.SUB_ORBITAL:
+                    AddIfMissing(reasons, ReFlyAutoSealReason.SubOrbitalArc);
+                    break;
+                case Vessel.Situations.ORBITING:
+                    // Defensive null-check (mirrors RecordingTree.cs:863):
+                    // vessel.orbit and vessel.orbit.referenceBody can be null
+                    // in transient pre-launch / scene-switch frames. Treat
+                    // as FLYING in that case (no live-terminal reason).
+                    Orbit orbit = liveActiveVessel.orbit;
+                    if (orbit == null) return;
+                    CelestialBody body = orbit.referenceBody;
+                    if (body == null) return;
+                    bool stable = RecordingTree.IsBoundOrbitAboveAtmosphere(
+                        orbit.eccentricity,
+                        orbit.PeR,
+                        body.Radius,
+                        body.atmosphere,
+                        body.atmosphereDepth);
+                    AddIfMissing(reasons, stable
+                        ? ReFlyAutoSealReason.StableOrbit
+                        : ReFlyAutoSealReason.SubOrbitalArc);
+                    break;
+                // PRELAUNCH / FLYING / ESCAPING: no stable terminal yet.
+            }
+        }
+
+        private static void AddIfMissing(
+            List<ReFlyAutoSealReason> reasons, ReFlyAutoSealReason reason)
+        {
+            for (int i = 0; i < reasons.Count; i++)
+                if (reasons[i] == reason) return;
+            reasons.Add(reason);
+        }
+
+        /// <summary>
+        /// Stable readability ordering. Production picks the first close-reason
+        /// hit and stops; the preview is intentionally a superset that lists all
+        /// player-attributable reasons in a deterministic order so tests are
+        /// stable and the player gets the full picture.
+        ///
+        /// <list type="number">
+        ///   <item><description>Science group: TransmittedScience, RecoveredScience, EarnedScience</description></item>
+        ///   <item><description>Structural group: Undocked, KerbalEva, PartBrokeOff, VesselBrokeUp</description></item>
+        ///   <item><description>Live terminal group: DockedWithAnother, Landed, SplashedDown, StableOrbit, SubOrbitalArc</description></item>
+        /// </list>
+        /// </summary>
+        private static void SortReasonsByGroup(List<ReFlyAutoSealReason> reasons)
+        {
+            reasons.Sort((a, b) => GroupOrdinal(a).CompareTo(GroupOrdinal(b)));
+        }
+
+        private static int GroupOrdinal(ReFlyAutoSealReason reason)
+        {
+            switch (reason)
+            {
+                case ReFlyAutoSealReason.TransmittedScience: return 100;
+                case ReFlyAutoSealReason.RecoveredScience:   return 110;
+                case ReFlyAutoSealReason.EarnedScience:      return 120;
+                case ReFlyAutoSealReason.Undocked:           return 200;
+                case ReFlyAutoSealReason.KerbalEva:          return 210;
+                case ReFlyAutoSealReason.PartBrokeOff:       return 220;
+                case ReFlyAutoSealReason.VesselBrokeUp:      return 230;
+                case ReFlyAutoSealReason.DockedWithAnother:  return 300;
+                case ReFlyAutoSealReason.Landed:             return 310;
+                case ReFlyAutoSealReason.SplashedDown:       return 320;
+                case ReFlyAutoSealReason.StableOrbit:        return 330;
+                case ReFlyAutoSealReason.SubOrbitalArc:      return 340;
+                default:                                     return 999;
+            }
+        }
+    }
+}

--- a/Source/Parsek/ReFlyAutoSealPreview.cs
+++ b/Source/Parsek/ReFlyAutoSealPreview.cs
@@ -121,11 +121,15 @@ namespace Parsek
         /// Compute the auto-seal preview. Read-only: no Ledger / scenario /
         /// state-version mutation. Returns <see cref="ReFlyAutoSealPreviewResult.NoSeal"/>
         /// on null guards or TreeId mismatch.
+        ///
+        /// <para>The structural-mutation gate resolves its rewind-point
+        /// cutoff through <c>ParsekScenario.Instance</c> internally; no
+        /// scenario parameter is needed here. Tests set the singleton via
+        /// <c>ParsekScenario.SetInstanceForTesting</c>.</para>
         /// </summary>
         internal static ReFlyAutoSealPreviewResult Preview(
             Recording liveProvisional,
             ReFlySessionMarker marker,
-            ParsekScenario scenario,
             Vessel liveActiveVessel)
         {
             // Null guards mirror the production gate's early-returns at

--- a/Source/Parsek/SupersedeCommit.cs
+++ b/Source/Parsek/SupersedeCommit.cs
@@ -680,6 +680,94 @@ namespace Parsek
             out string detail)
         {
             detail = null;
+            if (!ScanReFlySessionStructuralMutations(
+                    rec, marker,
+                    out int matchedCount,
+                    out int spliceExcludedCount,
+                    out int lineageExcludedCount,
+                    out string firstBpId,
+                    out BranchPointType? firstBpType,
+                    out double cutoffSource,
+                    out string cutoffOriginLabel,
+                    out int baselineCount,
+                    out int lineageCount))
+            {
+                return false;
+            }
+
+            var ic = CultureInfo.InvariantCulture;
+            detail = $"branchPoints={matchedCount.ToString(ic)}" +
+                $" spliceExcluded={spliceExcludedCount.ToString(ic)}" +
+                $" lineageExcluded={lineageExcludedCount.ToString(ic)}" +
+                $" firstBp={firstBpId ?? "<no-id>"}" +
+                $" firstType={(firstBpType.HasValue ? firstBpType.Value.ToString() : "<none>")}" +
+                $" sinceUT={cutoffSource.ToString("F2", ic)}" +
+                $" cutoffOrigin={cutoffOriginLabel}" +
+                $" baseline={baselineCount.ToString(ic)}" +
+                $" lineage={lineageCount.ToString(ic)}";
+            return true;
+        }
+
+        /// <summary>
+        /// Read-only typed accessor for the pre-transition merge dialog's
+        /// auto-seal preview (<see cref="ReFlyAutoSealPreviewer"/>): returns
+        /// the first structural <see cref="BranchPointType"/> encountered
+        /// during the same scan that <see cref="HasReFlySessionStructuralMutation"/>
+        /// runs. Returns false (and <c>default</c> for <paramref name="firstType"/>)
+        /// when no structural mutation has occurred yet, when the marker
+        /// pre-session baseline is missing, or when guard conditions match
+        /// the production gate's early-return.
+        /// </summary>
+        internal static bool TryGetFirstReFlySessionStructuralMutationType(
+            Recording rec,
+            ReFlySessionMarker marker,
+            out BranchPointType firstType)
+        {
+            if (ScanReFlySessionStructuralMutations(
+                    rec, marker,
+                    out _, out _, out _,
+                    out _,
+                    out BranchPointType? scannedFirstType,
+                    out _, out _, out _, out _)
+                && scannedFirstType.HasValue)
+            {
+                firstType = scannedFirstType.Value;
+                return true;
+            }
+            firstType = default(BranchPointType);
+            return false;
+        }
+
+        /// <summary>
+        /// Shared scan body for <see cref="HasReFlySessionStructuralMutation"/>
+        /// and <see cref="TryGetFirstReFlySessionStructuralMutationType"/>.
+        /// Pure: walks tree topology and the marker baseline; no mutation.
+        /// Returns false when the gate's early-returns trip; the out
+        /// parameters are populated only on success.
+        /// </summary>
+        private static bool ScanReFlySessionStructuralMutations(
+            Recording rec,
+            ReFlySessionMarker marker,
+            out int matchedCount,
+            out int spliceExcludedCount,
+            out int lineageExcludedCount,
+            out string firstBpId,
+            out BranchPointType? firstBpType,
+            out double cutoffSource,
+            out string cutoffOriginLabel,
+            out int baselineCount,
+            out int lineageCount)
+        {
+            matchedCount = 0;
+            spliceExcludedCount = 0;
+            lineageExcludedCount = 0;
+            firstBpId = null;
+            firstBpType = null;
+            cutoffSource = 0.0;
+            cutoffOriginLabel = null;
+            baselineCount = 0;
+            lineageCount = 0;
+
             if (rec == null || marker == null) return false;
             if (string.IsNullOrEmpty(marker.TreeId)) return false;
             if (string.IsNullOrEmpty(rec.TreeId)) return false;
@@ -699,9 +787,10 @@ namespace Parsek
             if (marker.PreSessionBranchPointIds == null) return false;
 
             ParsekScenario scenario = ParsekScenario.Instance;
-            double? cutoffSource = TryResolveReFlyStructuralCutoffUT(
-                marker, scenario, out string cutoffOriginLabel);
-            if (!cutoffSource.HasValue) return false;
+            double? cutoff = TryResolveReFlyStructuralCutoffUT(
+                marker, scenario, out cutoffOriginLabel);
+            if (!cutoff.HasValue) return false;
+            cutoffSource = cutoff.Value;
 
             RecordingTree tree = RecordingStore.CommittedTrees != null
                 ? RecordingStore.CommittedTrees.Find(t =>
@@ -714,6 +803,8 @@ namespace Parsek
             HashSet<string> preSessionSet = new HashSet<string>(
                 marker.PreSessionBranchPointIds, StringComparer.Ordinal);
             HashSet<string> lineageSet = BuildReFlyTargetLineageRecordingIds(rec);
+            baselineCount = marker.PreSessionBranchPointIds.Count;
+            lineageCount = lineageSet.Count;
 
             // A small UT slack absorbs floating-point round-trip drift
             // between the resolved cutoff UT and a branch-point UT that
@@ -721,19 +812,14 @@ namespace Parsek
             // does not author its own branch point at its UT, so this is
             // exclusion-safe.
             const double UtSlackSeconds = 0.001;
-            double cutoff = cutoffSource.Value + UtSlackSeconds;
+            double cutoffWithSlack = cutoffSource + UtSlackSeconds;
 
-            int matchedCount = 0;
-            int spliceExcludedCount = 0;
-            int lineageExcludedCount = 0;
-            string firstBpId = null;
-            BranchPointType? firstBpType = null;
             for (int i = 0; i < tree.BranchPoints.Count; i++)
             {
                 var bp = tree.BranchPoints[i];
                 if (bp == null) continue;
                 if (!IsStructuralBranchPointType(bp.Type)) continue;
-                if (bp.UT < cutoff) continue;
+                if (bp.UT < cutoffWithSlack) continue;
                 if (!string.IsNullOrEmpty(bp.Id)
                     && preSessionSet.Contains(bp.Id))
                 {
@@ -764,19 +850,7 @@ namespace Parsek
                 }
             }
 
-            if (matchedCount == 0) return false;
-
-            var ic = CultureInfo.InvariantCulture;
-            detail = $"branchPoints={matchedCount.ToString(ic)}" +
-                $" spliceExcluded={spliceExcludedCount.ToString(ic)}" +
-                $" lineageExcluded={lineageExcludedCount.ToString(ic)}" +
-                $" firstBp={firstBpId ?? "<no-id>"}" +
-                $" firstType={(firstBpType.HasValue ? firstBpType.Value.ToString() : "<none>")}" +
-                $" sinceUT={cutoffSource.Value.ToString("F2", ic)}" +
-                $" cutoffOrigin={cutoffOriginLabel}" +
-                $" baseline={marker.PreSessionBranchPointIds.Count.ToString(ic)}" +
-                $" lineage={lineageSet.Count.ToString(ic)}";
-            return true;
+            return matchedCount > 0;
         }
 
         /// <summary>
@@ -1134,7 +1208,10 @@ namespace Parsek
                 + rec.ChainBranch.ToString(CultureInfo.InvariantCulture);
         }
 
-        private static HashSet<string> CollectRecordingIdsForSafetyGate(Recording rec)
+        // Internal so the pre-transition merge dialog's auto-seal preview
+        // (ReFlyAutoSealPreviewer) can build the same lineage set the
+        // production retry-blocking science check uses.
+        internal static HashSet<string> CollectRecordingIdsForSafetyGate(Recording rec)
         {
             var ids = new HashSet<string>(StringComparer.Ordinal);
             AddRecordingId(ids, rec);

--- a/docs/dev/plans/refly-autoseal-dialog-copy.md
+++ b/docs/dev/plans/refly-autoseal-dialog-copy.md
@@ -1,0 +1,549 @@
+# Re-Fly merge dialog: announce auto-seal and the reason
+
+## Problem
+
+When the player ends a Re-Fly attempt at KSC / TS / Main Menu and clicks
+"Merge Re-Fly to Timeline" in the pre-transition merge dialog, a hidden
+policy decides whether the slot stays re-flyable or is **auto-sealed**
+(slot becomes immutable; the line of flight cannot be Re-Flown again).
+
+The current dialog body is generic:
+
+> Commit this Re-Fly attempt permanently to the timeline. This cannot be
+> undone.
+
+This is technically true but does not convey:
+
+1. that auto-seal will fire (vs the slot staying re-flyable for further
+   retry);
+2. **why** auto-seal will fire (the player's specific actions that
+   triggered the policy).
+
+Result: players hit Merge expecting they can still retry the line, then
+discover the slot is sealed.
+
+## Goal
+
+Customize the Re-Fly variant of `MergeDialog.ShowTreeDialog` (the
+4-arg `(tree, labels, preCommitFinalize, postChoice)` overload, line
+269-345 of `Source/Parsek/MergeDialog.cs`) so that when the merge will
+auto-seal the slot, the body copy:
+
+- Calls out auto-seal explicitly ("will be merged AND auto-sealed");
+- Lists the player-attributable reason(s) ("you transmitted science",
+  "you undocked", "you docked with another vessel", etc.);
+- States the consequence ("you will not be able to Re-Fly this line of
+  flight again").
+
+Default copy stays for non-auto-seal Re-Fly merges (slot remains
+re-flyable; current language is correct).
+
+## Auto-seal trigger map
+
+`SupersedeCommit.ShouldAutoSealReFlySlotAfterMerge`
+(`Source/Parsek/SupersedeCommit.cs:908-941`) seals when any of the
+following fire (close-reason builder at `:567-633`):
+
+| Internal reason | What the player did | Player-facing phrase |
+| --- | --- | --- |
+| `RecordingAction` (any retry-blocking `ScienceEarning` row tagged on the provisional or its chain segments) | Transmitted / earned science during the attempt | "transmitted science" or "recovered science" or "earned science" |
+| `StructuralMutation` with `BranchPointType == Undock` | Undocked | "undocked" |
+| `StructuralMutation` with `BranchPointType == EVA` | Sent a kerbal on EVA | "sent a kerbal on EVA" |
+| `StructuralMutation` with `BranchPointType == JointBreak` | A part broke off | "broke off a part" |
+| `StructuralMutation` with `BranchPointType == Breakup` | Vessel broke up | "the vessel broke up" |
+| `ClassifierClosed:stableTerminal` AND `IsHardSafetyTerminal` (Docked) | Docked with another vessel | "docked with another vessel" |
+| `ClassifierClosed:stableTerminal` AND `IsHardSafetyTerminal` (Boarded) | Kerbal boarded another vessel | (not reachable in-flight - skipped, see Risks) |
+| `ClassifierClosed:stableTerminal` AND `IsHardSafetyTerminal` (Recovered) | Vessel was recovered | (not reachable in-flight - skipped, see Risks) |
+| `ClassifierClosed:stableTerminalFocusSlot` (player-chosen slot reached stable Orbiting/SubOrbital) | Reached stable orbit | "reached a stable orbit" |
+| `ClassifierClosed:downstreamBp` | Created a downstream branch point | (subset case; covered by structural mutations in practice - skipped) |
+| `classifierQualifies` path with any close reason | Generic concluded outcome | (covered by the above specific cases) |
+
+## Constraint: preview is computed pre-finalize
+
+The dialog appears **before** `preCommitFinalize` runs (PR #750's
+deferred-finalize design). At dialog-show time:
+
+- `Recording.TerminalStateValue` is null on the live provisional.
+- `Ledger.Actions` IS populated for in-flight events (science
+  earnings emit on transmission/recovery as they happen).
+- Tree topology IS populated for branch points (decouple / stage /
+  EVA / joint-break write `BranchPoint` rows when they occur).
+- Live `vessel.situation` IS authoritative for the current
+  Docked / Orbiting / Landed status.
+
+This rules out calling `SupersedeCommit.ClassifyMergeStateOrThrow`
+directly: it reads `TerminalStateValue` via `UnfinishedFlightClassifier`
+and `IsHardSafetyTerminal`. We need a **parallel preview helper**
+that reads only data that is reliable pre-finalize.
+
+The preview is intentionally a **subset** of the production classifier:
+
+- Conservative (false negatives over false positives): if the preview
+  cannot determine seal, default copy applies. The player still gets
+  the truthful "permanently" wording, just not the auto-seal call-out.
+- Mirrors the production gates (`IsRetryBlockingRecordingAction`,
+  `HasReFlySessionStructuralMutation`) so when the preview says
+  "you transmitted science," the production classifier will agree.
+
+## Architecture
+
+### New file: `Source/Parsek/ReFlyAutoSealPreview.cs`
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Parsek
+{
+    internal enum ReFlyAutoSealReason
+    {
+        EarnedScience,         // any retry-blocking ScienceEarning row in the lineage
+        TransmittedScience,    // ScienceMethod.Transmitted (more specific override)
+        RecoveredScience,      // ScienceMethod.Recovered (more specific override)
+        Undocked,              // BranchPointType.Undock
+        KerbalEva,             // BranchPointType.EVA
+        PartBrokeOff,          // BranchPointType.JointBreak
+        VesselBrokeUp,         // BranchPointType.Breakup
+        DockedWithAnother,     // live vessel.situation == DOCKED
+        StableOrbit,           // live vessel.situation == ORBITING
+    }
+
+    internal struct ReFlyAutoSealPreviewResult
+    {
+        public bool WillAutoSeal;
+        public List<ReFlyAutoSealReason> Reasons;
+
+        public static readonly ReFlyAutoSealPreviewResult NoSeal =
+            new ReFlyAutoSealPreviewResult
+            {
+                WillAutoSeal = false,
+                Reasons = new List<ReFlyAutoSealReason>(0),
+            };
+
+        /// <summary>
+        /// Composes a player-facing phrase from <see cref="Reasons"/>:
+        ///   0 reasons -> null (caller shows default copy)
+        ///   1 reason  -> "you transmitted science"
+        ///   2 reasons -> "you transmitted science and undocked"
+        ///   3+ reasons -> "you transmitted science, undocked, and docked with another vessel"
+        /// </summary>
+        public string FormatHumanReadable() { /* see Format spec below */ }
+    }
+
+    internal static class ReFlyAutoSealPreviewer
+    {
+        internal static ReFlyAutoSealPreviewResult Preview(
+            Recording liveProvisional,
+            ReFlySessionMarker marker,
+            ParsekScenario scenario,
+            Vessel liveActiveVessel);
+    }
+}
+```
+
+### Preview body (read-only, conservative, no mutation)
+
+Sequence:
+
+1. **Null guards**:
+   - `marker == null` -> return `NoSeal`.
+   - `liveProvisional == null` -> return `NoSeal`.
+   - `marker.TreeId` empty OR `liveProvisional.TreeId` empty OR
+     `liveProvisional.TreeId != marker.TreeId` -> return `NoSeal`.
+
+2. **Earned-science check** (mirrors
+   `SupersedeCommit.IsRetryBlockingRecordingAction` at line 1257):
+
+   - Build the lineage recording-id set via
+     `SupersedeCommit.CollectRecordingIdsForSafetyGate(liveProvisional)`
+     (currently `private`; see Refactor below).
+   - Walk `Ledger.Actions`. For each action:
+     - Skip if `action == null` or `action.RecordingId` empty.
+     - Skip if `action.Type != GameActionType.ScienceEarning`.
+     - Skip if `!recordingIds.Contains(action.RecordingId)`.
+     - Skip if `TombstoneEligibility.IsEligible(action)` (mirror
+       `IsWorldStateChangingRecordingAction`).
+     - Skip if `TombstoneEligibility.TryPairBundledRepPenalty(action,
+       Ledger.Actions, out _)` (same).
+     - Otherwise add a reason: prefer `TransmittedScience` if
+       `action.Method == ScienceMethod.Transmitted`; otherwise
+       `RecoveredScience` if `Recovered`; else `EarnedScience` (defensive
+       fallback for unexpected enum values).
+
+   Multiple science rows of the same kind dedupe to one reason. Mixed
+   methods produce one of each (e.g. one Transmitted + one Recovered ->
+   both reasons listed).
+
+3. **Structural-mutation check**: call the new typed helper
+   `SupersedeCommit.TryGetFirstReFlySessionStructuralMutationType(
+   liveProvisional, marker, out BranchPointType firstType)` (see
+   Refactor below). If true, map `firstType`:
+
+   - `Undock` -> `Undocked`
+   - `EVA` -> `KerbalEva`
+   - `JointBreak` -> `PartBrokeOff`
+   - `Breakup` -> `VesselBrokeUp`
+
+   Only the first structural mutation is surfaced (production logs the
+   first too at `:773`). Multiple BPs of different kinds collapse to
+   one reason; this avoids long copy and matches what the player
+   typically remembers ("I undocked" rather than "I undocked and then
+   the booster broke up as a consequence").
+
+4. **Live vessel terminal proxy**: if `liveActiveVessel != null`:
+   - `vessel.situation == Vessel.Situations.DOCKED` ->
+     `DockedWithAnother`.
+   - `vessel.situation == Vessel.Situations.ORBITING` -> `StableOrbit`.
+     (KSP marks situation ORBITING only when periapsis is above the
+     body's surface, and above atmosphere if present, so this is a
+     reliable proxy for the production "stable orbit" classification.)
+   - Boarded / Recovered are unreachable in-flight (the vessel left the
+     scene before either could occur) so they are intentionally not
+     surfaced; their auto-seal still happens later via the production
+     classifier, but the dialog wouldn't have been shown for those
+     terminal states anyway because they exit flight first.
+
+5. **`WillAutoSeal = Reasons.Count > 0`**.
+
+### `FormatHumanReadable` spec
+
+| Reason | Phrase |
+| --- | --- |
+| `EarnedScience` | "earned science" |
+| `TransmittedScience` | "transmitted science" |
+| `RecoveredScience` | "recovered science" |
+| `Undocked` | "undocked" |
+| `KerbalEva` | "sent a kerbal on EVA" |
+| `PartBrokeOff` | "broke off a part" |
+| `VesselBrokeUp` | "the vessel broke up" |
+| `DockedWithAnother` | "docked with another vessel" |
+| `StableOrbit` | "reached a stable orbit" |
+
+Composition:
+- 0 reasons: return `null`. Caller shows default copy.
+- 1 reason: `"you {phrase}"`.
+- 2 reasons: `"you {phrase1} and {phrase2}"`.
+- 3+ reasons: `"you {phrase1}, {phrase2}, and {phraseN}"` (Oxford comma).
+
+Reason ordering for output stability (player-relevance, descending):
+1. `TransmittedScience` / `RecoveredScience` / `EarnedScience` (group)
+2. Structural mutations (`Undocked`, `KerbalEva`, `PartBrokeOff`, `VesselBrokeUp`)
+3. Live terminal (`DockedWithAnother`, `StableOrbit`)
+
+Within each group, preserve insertion order. The Reasons list is
+ordered at insertion to match this scheme - sort once at the end of
+`Preview` for predictable test output.
+
+### Refactor: minimal SupersedeCommit visibility changes
+
+Two helpers in `SupersedeCommit.cs` need `internal` visibility (currently
+`private`) so the preview can reuse them:
+
+1. `CollectRecordingIdsForSafetyGate(Recording rec)` at
+   `Source/Parsek/SupersedeCommit.cs:1137` -> change to `internal static`.
+
+2. New public surface for the structural mutation walk:
+
+   ```csharp
+   internal static bool TryGetFirstReFlySessionStructuralMutationType(
+       Recording rec,
+       ReFlySessionMarker marker,
+       out BranchPointType firstType);
+   ```
+
+   Implementation: refactor `HasReFlySessionStructuralMutation`
+   (line 677-780) to share its walk with the new method. Cleanest:
+   extract a private helper `ScanReFlySessionStructuralMutations` that
+   returns a tuple `(int matchedCount, BranchPointType? firstType,
+   string detail)`. Both `HasReFlySessionStructuralMutation` and
+   `TryGetFirstReFlySessionStructuralMutationType` call it; existing
+   behaviour is unchanged.
+
+   The new helper does NOT need `out string detail` for the preview path
+   - it gets `firstType` only. The existing `out detail` behaviour in
+   `HasReFlySessionStructuralMutation` stays for the production classifier
+   logs.
+
+3. (Optional / not required) `TryResolveReFlyStructuralCutoffUT` at
+   line 849 - the new typed helper will use `HasReFlySessionStructuralMutation`'s
+   internals via the shared private helper, so this stays private.
+
+### Dialog integration
+
+In `MergeDialog.ShowTreeDialog` (4-arg overload), inside the
+`labels == ReFlyAttempt` branch (currently line 282-309), replace the
+fixed body string with:
+
+```csharp
+var preview = ReFlyAutoSealPreviewer.Preview(
+    reFlyRec, marker, reFlyScenario, FlightGlobals.ActiveVessel);
+string body;
+if (preview.WillAutoSeal)
+{
+    string why = preview.FormatHumanReadable();
+    body = $"<align=\"center\">{vesselLabel} - {FormatDuration(reFlyDuration)}</align>\n\n" +
+           $"<align=\"left\"><b>This Re-Fly attempt will be merged AND auto-sealed</b> " +
+           $"because {why}. The slot will become permanent and you will not be " +
+           $"able to Re-Fly this line of flight again. This cannot be undone.</align>";
+}
+else
+{
+    body = $"<align=\"center\">{vesselLabel} - {FormatDuration(reFlyDuration)}</align>\n\n" +
+           "<align=\"left\">Commit this Re-Fly attempt permanently to the timeline. " +
+           "This cannot be undone.</align>";
+}
+message = body;
+```
+
+Notes:
+
+- `reFlyScenario` is already in scope (lines 268-272 of `MergeDialog.cs`).
+- `FlightGlobals.ActiveVessel` is the live active vessel - safe to read
+  in flight (the prefix that spawned this dialog ran while in flight).
+- The `<b>` emphasis flags the change as significant. Using
+  `<align="left">` matches the existing layout style.
+- `marker` is already resolved in scope.
+
+Logging:
+
+```csharp
+ParsekLog.Info("MergeDialog",
+    $"Re-Fly auto-seal preview: willSeal={preview.WillAutoSeal} " +
+    $"reasons=[{string.Join(",", preview.Reasons)}] " +
+    $"sess={marker?.SessionId ?? "<no-id>"}");
+```
+
+This logs at dialog-show time so we can correlate with the actual
+post-merge classifier outcome in case of preview drift.
+
+## Files to change
+
+| Status | Path | Change |
+| --- | --- | --- |
+| New | `Source/Parsek/ReFlyAutoSealPreview.cs` | Preview helper + `ReFlyAutoSealReason` enum + `ReFlyAutoSealPreviewResult` struct + `FormatHumanReadable` |
+| Modified | `Source/Parsek/SupersedeCommit.cs` | `CollectRecordingIdsForSafetyGate` -> `internal`; extract shared `ScanReFlySessionStructuralMutations` private helper; new `TryGetFirstReFlySessionStructuralMutationType` internal API |
+| Modified | `Source/Parsek/MergeDialog.cs` | Wire preview into the ReFlyAttempt body copy in the 4-arg `ShowTreeDialog` overload; add canary log line |
+| New | `Source/Parsek.Tests/ReFlyAutoSealPreviewTests.cs` | Unit tests per reason path + multi-reason composition + null guards + format spec |
+| Modified | `CHANGELOG.md` | Entry under 0.9.2 Enhancements |
+
+## Test matrix
+
+### `ReFlyAutoSealPreviewer.Preview` core matrix
+
+Pure unit tests, xUnit. `[Collection("Sequential")]` for shared
+`Ledger`, `RecordingStore`, `ParsekScenario` static state. Constructor
+calls `ParsekLog.ResetTestOverrides`, `Ledger.ResetForTesting`,
+`RecordingStore.ResetForTesting`, `ParsekScenario.ResetInstanceForTesting`.
+
+| Setup | Expected reasons | `FormatHumanReadable` |
+| --- | --- | --- |
+| `marker == null` | `WillAutoSeal=false`, empty | `null` |
+| `liveProvisional == null` | `WillAutoSeal=false`, empty | `null` |
+| `marker.TreeId == null` | `WillAutoSeal=false`, empty | `null` |
+| `liveProvisional.TreeId != marker.TreeId` | `WillAutoSeal=false`, empty | `null` |
+| Idle Re-Fly, no events, vessel landed | empty | `null` |
+| Ledger has `ScienceEarning` (Method=Transmitted) tagged on provisional | `[TransmittedScience]` | `"you transmitted science"` |
+| Ledger has `ScienceEarning` (Method=Recovered) tagged on provisional | `[RecoveredScience]` | `"you recovered science"` |
+| Ledger has `ScienceEarning` tagged on a chain-segment of the provisional | `[TransmittedScience]` (or whichever Method) | proportional |
+| Ledger has `ScienceEarning` tagged on a different recording (not in lineage) | empty | `null` |
+| Ledger has tombstone-eligible `ScienceEarning` (paired with kerbal death penalty) | empty | `null` |
+| Ledger has non-`ScienceEarning` action tagged on provisional (e.g. `FundsEarning`) | empty | `null` |
+| Tree has post-RP `Undock` BP in lineage | `[Undocked]` | `"you undocked"` |
+| Tree has post-RP `EVA` BP in lineage | `[KerbalEva]` | `"you sent a kerbal on EVA"` |
+| Tree has post-RP `JointBreak` BP in lineage | `[PartBrokeOff]` | `"you broke off a part"` |
+| Tree has post-RP `Breakup` BP in lineage | `[VesselBrokeUp]` | `"the vessel broke up"` (note: the canned phrase already includes "the vessel" so Format prefixes "you" only when grammatically appropriate; spec at end) |
+| Pre-RP BP only (UT < cutoff) | empty | `null` |
+| BP not in Re-Fly target lineage (background vessel) | empty | `null` |
+| BP in `marker.PreSessionBranchPointIds` (re-spliced from load) | empty | `null` |
+| `marker.PreSessionBranchPointIds == null` (legacy marker) | structural skipped, other paths still work | `null` if no other reason |
+| Multiple structural BPs of different types | first only (e.g. `[Undocked]` even if Breakup followed) | first phrase only |
+| Live vessel `situation == DOCKED` | `[DockedWithAnother]` | `"you docked with another vessel"` |
+| Live vessel `situation == ORBITING` | `[StableOrbit]` | `"you reached a stable orbit"` |
+| Live vessel `situation == LANDED` | empty | `null` |
+| `liveActiveVessel == null` | live-vessel reasons skipped, other paths still work | depends |
+| Multi-reason: science + undock | `[TransmittedScience, Undocked]` | `"you transmitted science and undocked"` |
+| Multi-reason: science + undock + dock | 3 reasons, ordered (science, struct, terminal) | `"you transmitted science, undocked, and docked with another vessel"` |
+| Multi-reason: undock + breakup | first structural only `[Undocked]` | `"you undocked"` |
+
+### `FormatHumanReadable` standalone
+
+| Reasons | Output |
+| --- | --- |
+| `[]` | `null` |
+| `[EarnedScience]` | `"you earned science"` |
+| `[TransmittedScience]` | `"you transmitted science"` |
+| `[Undocked]` | `"you undocked"` |
+| `[VesselBrokeUp]` | `"the vessel broke up"` (special case - phrase starts with "the vessel", no "you" prefix) |
+| `[Undocked, KerbalEva]` | `"you undocked and sent a kerbal on EVA"` |
+| `[VesselBrokeUp, DockedWithAnother]` | `"the vessel broke up and you docked with another vessel"` (mixed pronoun handled by sub-clause) |
+| `[TransmittedScience, Undocked, DockedWithAnother]` | `"you transmitted science, undocked, and docked with another vessel"` |
+| `[VesselBrokeUp, TransmittedScience, DockedWithAnother]` | `"the vessel broke up, you transmitted science, and you docked with another vessel"` |
+
+The pronoun-mix is awkward but accurate. Simpler alternative: drop the
+"you" prefix entirely and rely on phrasing -> `"transmitted science and
+undocked"`, `"the vessel broke up"`. Less natural but unambiguous.
+**Decision deferred to user**: pick one of the two styles in §Open
+questions before implementation.
+
+### Reason ordering test
+
+Insert reasons in random order; assert the `Reasons` list comes back
+sorted by group (science -> structural -> terminal) and within group by
+insertion order. Stability matters for deterministic test output and
+matches what production `SupersedeCommit.ShouldAutoSealReFlySlotAfterMerge`
+would prioritise (it picks the first close-reason hit).
+
+### Defensive tests
+
+- `Recording.Points` empty -> safe (preview reads metadata only).
+- Provisional has no chain segments -> `CollectRecordingIdsForSafetyGate`
+  returns just the provisional id; lineage check works.
+- `Ledger.Actions` empty -> no science reasons added.
+- `RecordingStore.CommittedTrees` empty -> structural check returns false
+  (matches production behaviour at `SupersedeCommit.cs:706-712`).
+- Marker with empty `RewindPointId` -> structural cutoff falls back to
+  `marker.InvokedUT`; preview still works.
+
+## Risks
+
+- **False positives** (preview says seal, finalize doesn't): would
+  mislead the player into thinking they cannot retry when they actually
+  could. Mitigation: mirror production gates exactly. Specifically
+  reuse `SupersedeCommit.IsRetryBlockingRecordingAction` (already
+  internal at line 1257) and the typed structural-mutation helper
+  refactored to share with `HasReFlySessionStructuralMutation`. A unit
+  test asserts science-action filtering matches `TombstoneEligibility`
+  exclusion rules.
+
+- **False negatives** (preview says no seal, finalize seals): default
+  copy shown, player learns of seal post-load via slot UI. Acceptable
+  degradation. The cases the preview deliberately skips
+  (`Boarded`/`Recovered` terminals, `downstreamBp`, generic
+  `classifierQualifies`) are either unreachable from the in-flight
+  dialog (`Boarded`/`Recovered`) or rare/redundant (`downstreamBp` is
+  almost always covered by a structural mutation that fires first;
+  generic `classifierQualifies` requires a specific terminal state which
+  is null pre-finalize).
+
+- **`vessel.situation == ORBITING` proxy correctness**: KSP sets
+  `Vessel.Situations.ORBITING` only when both apsides are above the
+  body's atmosphere (or surface for airless bodies). The
+  `RecordingTree.DetermineTerminalState` override path may still flip
+  between SUB_ORBITAL and ORBITING based on atmospheric drag
+  predictions, but for a vessel currently in stable orbit (no thrust,
+  no atmosphere intersection within current orbit), the live `situation`
+  enum and the post-finalize `TerminalStateValue` agree. Edge case: a
+  vessel coasting through a high-eccentricity orbit that grazes
+  atmosphere may flicker between SUB_ORBITAL and ORBITING; the dialog
+  is a one-shot snapshot at click time, so transient flicker is
+  acceptable.
+
+- **In-place continuation case**: `IsInPlaceContinuation(marker,
+  provisional)` returns true when
+  `provisional.RecordingId == marker.OriginChildRecordingId`. The
+  production classifier's slot-lookup branch (line 481-521) handles
+  in-place differently from new-attempt continuations, but the
+  auto-seal logic itself runs against the same `provisional` and same
+  close-reason classification. The preview is unaffected by in-place
+  vs new-attempt distinction.
+
+- **`ScienceMethod` enum drift**: today only `Transmitted` and
+  `Recovered`. If KSP adds new methods, `EarnedScience` is the
+  catch-all default. Added defensively.
+
+- **Wording length**: the longest possible composed phrase is roughly
+  `"you transmitted science, recovered science, undocked, sent a kerbal
+  on EVA, broke off a part, docked with another vessel, and reached a
+  stable orbit"` - ~150 chars. KSP `MultiOptionDialog` width handles
+  this with line wrapping. In practice 1-2 reasons covers the common
+  cases. No truncation needed.
+
+- **Logging volume**: one Info line per dialog spawn is bounded (dialog
+  shows at most once per scene exit). Not a spam concern.
+
+## Out of scope
+
+- The post-load deferred merge dialog (zero-arg `ShowTreeDialog`). The
+  user's ask is for the in-flight pre-transition dialog. Adding the
+  same preview to the post-load path is a logical extension but
+  requires different live-state handling (no `ActiveVessel` post-load;
+  classifier could be called directly post-finalize). Defer to a
+  follow-up.
+
+- An "abort merge / retain re-flyable slot" option. The auto-seal
+  policy is a deliberate gameplay design choice; the dialog only
+  *announces* the consequence, it does not let the player override it.
+
+- Localization. Parsek is English-only.
+
+- Per-action breakdown (which specific science subject the player
+  transmitted, which part broke off). Adds noise without helping the
+  player understand the consequence.
+
+## Open questions
+
+1. **Pronoun style**: "you transmitted science" vs "transmitted
+   science" vs "the recording transmitted science." First-person ("you")
+   is most direct but creates pronoun-mix awkwardness when combined
+   with subject-led phrases like "the vessel broke up". Three options:
+   - **A**: keep "you" prefix; accept mixed-subject sentences.
+   - **B**: drop "you", rely on phrasing -> `"transmitted science and
+     undocked"`. Less natural but uniform.
+   - **C**: rewrite "the vessel broke up" -> "you broke up the vessel"
+     so all phrases are "you"-led. Less accurate (vessel breakup is
+     usually involuntary).
+
+   Recommend **B** (drop "you"). Implementation defaults to B unless
+   user picks otherwise.
+
+2. **`Boarded` / `Recovered` detection**: the preview deliberately
+   skips these because they are unreachable in flight. But is there an
+   in-flight signal (e.g. a `Boarded` ledger row from an earlier crew
+   transfer in the attempt) we should surface? Likely no: the seal for
+   those triggers via `IsHardSafetyTerminal` which reads
+   `TerminalStateValue`, and the recording wouldn't have a Boarded
+   terminal state until finalize.
+
+   Recommend **skip them** (do not surface in dialog). The production
+   classifier still seals correctly post-finalize.
+
+3. **Single structural reason vs all structural reasons**: production
+   logs only the first BP. Should the dialog list all BP types
+   encountered, or just the first?
+
+   Recommend **first only**. The player typically remembers what they
+   actively did (undock); cascading consequences (a follow-on breakup)
+   would clutter the message.
+
+## Implementation order
+
+1. Refactor `SupersedeCommit.cs`: extract `ScanReFlySessionStructuralMutations`
+   shared helper; change `CollectRecordingIdsForSafetyGate` to internal;
+   add new `TryGetFirstReFlySessionStructuralMutationType` API. Verify
+   existing tests still pass. (1 commit.)
+
+2. Add `ReFlyAutoSealPreview.cs` with the enum, struct, and
+   `Preview` / `FormatHumanReadable` implementations. Add
+   `ReFlyAutoSealPreviewTests.cs` covering the matrix. (1 commit, or
+   split into "preview helper" + "tests" if the diff is large.)
+
+3. Wire the preview into `MergeDialog.ShowTreeDialog`'s ReFlyAttempt
+   body copy. Smoke-test in-game: trigger Re-Fly with a science
+   transmission, exit to KSC, confirm dialog says "transmitted science."
+   (1 commit.)
+
+4. CHANGELOG entry. Open PR.
+
+## CHANGELOG entry
+
+Per `.claude/CLAUDE.md` "Documentation Updates - Per Commit, Not Per PR":
+
+`CHANGELOG.md` -> `0.9.2 -> Enhancements`:
+
+> The Re-Fly merge confirmation dialog now announces auto-seal
+> explicitly when a merge will permanently seal the slot, and lists
+> the player-attributable reason (transmitted science, undocked,
+> docked with another vessel, etc.). Previously the dialog said the
+> commit was permanent but did not distinguish auto-seal from a
+> regular commit that left the slot re-flyable.

--- a/docs/dev/plans/refly-autoseal-dialog-copy.md
+++ b/docs/dev/plans/refly-autoseal-dialog-copy.md
@@ -210,8 +210,12 @@ Sequence:
    - `Vessel.Situations.DOCKED` -> `DockedWithAnother`.
    - `Vessel.Situations.LANDED` -> `Landed`.
    - `Vessel.Situations.SPLASHED` -> `SplashedDown`.
-   - `Vessel.Situations.ORBITING`: use
-     `RecordingTree.IsBoundOrbitAboveAtmosphere(orbit.eccentricity,
+   - `Vessel.Situations.ORBITING`: defensively null-check
+     `liveActiveVessel.orbit` AND `liveActiveVessel.orbit.referenceBody`.
+     If either is null (transient pre-launch / scene-switch frames -
+     mirror the production pattern at `RecordingTree.cs:863`), fall
+     back to no live-terminal reason (treat like FLYING). Otherwise
+     use `RecordingTree.IsBoundOrbitAboveAtmosphere(orbit.eccentricity,
      orbit.PeR, body.Radius, body.atmosphere, body.atmosphereDepth)`
      (already `internal static` at `RecordingTree.cs:827-852`,
      reachable from preview). True -> `StableOrbit`. False ->
@@ -443,7 +447,10 @@ dialog body wraps them in "for the following reason(s):" so the
 | Live vessel `situation == LANDED` | `[Landed]` | `"landed"` |
 | Live vessel `situation == SPLASHED` | `[SplashedDown]` | `"splashed down"` |
 | Live vessel `situation == ORBITING` && PeR > atmosphereDepth | `[StableOrbit]` | `"reached a stable orbit"` |
+| Live vessel `situation == ORBITING` && airless body (e.g. Mun) && PeR > body.Radius | `[StableOrbit]` | `"reached a stable orbit"` |
 | Live vessel `situation == ORBITING` && PeR <= atmosphereDepth (decaying) | `[SubOrbitalArc]` | `"reached a sub-orbital arc"` |
+| Live vessel `situation == ORBITING` && `vessel.orbit == null` (transient) | empty | `null` (treat like FLYING) |
+| Live vessel `situation == ORBITING` && `vessel.orbit.referenceBody == null` | empty | `null` (treat like FLYING) |
 | Live vessel `situation == SUB_ORBITAL` | `[SubOrbitalArc]` | `"reached a sub-orbital arc"` |
 | Live vessel `situation == FLYING` (no terminal yet) | empty | `null` (other paths may still apply) |
 | Live vessel `situation == PRELAUNCH` | empty | `null` |

--- a/docs/dev/plans/refly-autoseal-dialog-copy.md
+++ b/docs/dev/plans/refly-autoseal-dialog-copy.md
@@ -52,11 +52,18 @@ following fire (close-reason builder at `:567-633`):
 | `StructuralMutation` with `BranchPointType == JointBreak` | A part broke off | "broke off a part" |
 | `StructuralMutation` with `BranchPointType == Breakup` | Vessel broke up | "the vessel broke up" |
 | `ClassifierClosed:stableTerminal` AND `IsHardSafetyTerminal` (Docked) | Docked with another vessel | "docked with another vessel" |
-| `ClassifierClosed:stableTerminal` AND `IsHardSafetyTerminal` (Boarded) | Kerbal boarded another vessel | (not reachable in-flight - skipped, see Risks) |
-| `ClassifierClosed:stableTerminal` AND `IsHardSafetyTerminal` (Recovered) | Vessel was recovered | (not reachable in-flight - skipped, see Risks) |
-| `ClassifierClosed:stableTerminalFocusSlot` (player-chosen slot reached stable Orbiting/SubOrbital) | Reached stable orbit | "reached a stable orbit" |
+| `ClassifierClosed:stableTerminal` AND `IsHardSafetyTerminal` (Boarded / Recovered) | Kerbal boarded / vessel recovered | (not reachable in-flight - skipped, see Risks) |
+| `ClassifierClosed:stableTerminalFocusSlot` covers ALL of Landed / Splashed / Orbiting / SubOrbital at the merge-time focus slot (`UnfinishedFlightClassifier.cs:240-256, IsReFlyOverrideStableTerminal:351-363`) | Concluded the attempt at any stable terminal | "landed", "splashed down", "reached a stable orbit", "reached a sub-orbital arc" |
 | `ClassifierClosed:downstreamBp` | Created a downstream branch point | (subset case; covered by structural mutations in practice - skipped) |
 | `classifierQualifies` path with any close reason | Generic concluded outcome | (covered by the above specific cases) |
+
+Note: `stashedStableLeaf` (`UnfinishedFlightClassifier.cs:259-273`) and
+`stableLeafUnconcluded` (`:329`) both **keep the slot open** rather
+than seal it (`SupersedeCommit.cs:623-631`,
+`IsSafeStableRetryClassifierReason:975-981`). The preview does NOT
+need to detect these - the slot stays re-flyable and the default
+"permanently to the timeline" copy applies (which is still correct;
+the merge IS permanent, the slot just remains re-flyable for retry).
 
 ## Constraint: preview is computed pre-finalize
 
@@ -105,8 +112,11 @@ namespace Parsek
         KerbalEva,             // BranchPointType.EVA
         PartBrokeOff,          // BranchPointType.JointBreak
         VesselBrokeUp,         // BranchPointType.Breakup
-        DockedWithAnother,     // live vessel.situation == DOCKED
-        StableOrbit,           // live vessel.situation == ORBITING
+        DockedWithAnother,     // live vessel.situation == DOCKED -> IsHardSafetyTerminal
+        Landed,                // live vessel.situation == LANDED  -> stableTerminalFocusSlot
+        SplashedDown,          // live vessel.situation == SPLASHED -> stableTerminalFocusSlot
+        StableOrbit,           // live vessel.situation == ORBITING && PeR > atmosphere
+        SubOrbitalArc,         // live vessel.situation == SUB_ORBITAL OR ORBITING && PeR <= atmosphere
     }
 
     internal struct ReFlyAutoSealPreviewResult
@@ -191,24 +201,45 @@ Sequence:
    typically remembers ("I undocked" rather than "I undocked and then
    the booster broke up as a consequence").
 
-4. **Live vessel terminal proxy**: if `liveActiveVessel != null`:
-   - `vessel.situation == Vessel.Situations.DOCKED` ->
-     `DockedWithAnother`.
-   - `vessel.situation == Vessel.Situations.ORBITING` -> `StableOrbit`.
-     (KSP marks situation ORBITING only when periapsis is above the
-     body's surface, and above atmosphere if present, so this is a
-     reliable proxy for the production "stable orbit" classification.)
-   - Boarded / Recovered are unreachable in-flight (the vessel left the
-     scene before either could occur) so they are intentionally not
-     surfaced; their auto-seal still happens later via the production
-     classifier, but the dialog wouldn't have been shown for those
-     terminal states anyway because they exit flight first.
+4. **Live vessel terminal proxy**: if `liveActiveVessel != null`,
+   read `liveActiveVessel.situation` and surface a reason for any
+   stable terminal that production seals via `stableTerminalFocusSlot`
+   (`UnfinishedFlightClassifier.IsReFlyOverrideStableTerminal:351-363`
+   covers Landed, Splashed, Orbiting, SubOrbital) or `IsHardSafetyTerminal`
+   (`SupersedeCommit.cs:963-973` covers Docked):
+   - `Vessel.Situations.DOCKED` -> `DockedWithAnother`.
+   - `Vessel.Situations.LANDED` -> `Landed`.
+   - `Vessel.Situations.SPLASHED` -> `SplashedDown`.
+   - `Vessel.Situations.ORBITING`: use
+     `RecordingTree.IsBoundOrbitAboveAtmosphere(orbit.eccentricity,
+     orbit.PeR, body.Radius, body.atmosphere, body.atmosphereDepth)`
+     (already `internal static` at `RecordingTree.cs:827-852`,
+     reachable from preview). True -> `StableOrbit`. False ->
+     `SubOrbitalArc` (decaying orbit; production downgrades to
+     SubOrbital terminal at finalize but still seals via
+     `stableTerminalFocusSlot`).
+   - `Vessel.Situations.SUB_ORBITAL` -> `SubOrbitalArc`.
+   - Anything else (PRELAUNCH, FLYING, ESCAPING) -> no live-terminal
+     reason (other paths still apply).
+   - `Boarded` / `Recovered` are unreachable in-flight (the vessel
+     leaves the scene before either occurs) so they are intentionally
+     not surfaced. Their seal still fires via the production classifier
+     post-finalize, but the dialog never spawns for those terminal
+     states from this entry point.
+
+   The vessel `situation` enum is a one-shot snapshot at dialog spawn.
+   While the dialog is up with `LockInput()` applied, KSP physics still
+   runs in the background; the active vessel's situation could in
+   theory flip (e.g. an unstable orbit decays into atmosphere over a
+   minute while the dialog sits open). Acceptable - the player must
+   click eventually, and re-classification happens at finalize. Add a
+   "// situation sampled at dialog spawn only" comment at the call site.
 
 5. **`WillAutoSeal = Reasons.Count > 0`**.
 
 ### `FormatHumanReadable` spec
 
-| Reason | Phrase |
+| Reason | Phrase (subject-free; phrases are listed after a colon, no leading "you") |
 | --- | --- |
 | `EarnedScience` | "earned science" |
 | `TransmittedScience` | "transmitted science" |
@@ -218,22 +249,41 @@ Sequence:
 | `PartBrokeOff` | "broke off a part" |
 | `VesselBrokeUp` | "the vessel broke up" |
 | `DockedWithAnother` | "docked with another vessel" |
+| `Landed` | "landed" |
+| `SplashedDown` | "splashed down" |
 | `StableOrbit` | "reached a stable orbit" |
+| `SubOrbitalArc` | "reached a sub-orbital arc" |
 
-Composition:
+Composition (Opus pass-1 finding F6: drop "because" + "you" prefix to
+avoid pronoun-mix grammar problems with subject-led phrases like
+"the vessel broke up"):
+
 - 0 reasons: return `null`. Caller shows default copy.
-- 1 reason: `"you {phrase}"`.
-- 2 reasons: `"you {phrase1} and {phrase2}"`.
-- 3+ reasons: `"you {phrase1}, {phrase2}, and {phraseN}"` (Oxford comma).
+- 1 reason: return the bare phrase, e.g. `"transmitted science"`.
+- 2 reasons: `"{phrase1} and {phrase2}"`.
+- 3+ reasons: `"{phrase1}, {phrase2}, and {phraseN}"` (Oxford comma).
+
+The dialog body wraps the phrase in a "for the following reason(s):"
+prefix so the rendered sentence reads naturally regardless of the
+number of reasons. See "Dialog integration" below.
 
 Reason ordering for output stability (player-relevance, descending):
 1. `TransmittedScience` / `RecoveredScience` / `EarnedScience` (group)
 2. Structural mutations (`Undocked`, `KerbalEva`, `PartBrokeOff`, `VesselBrokeUp`)
-3. Live terminal (`DockedWithAnother`, `StableOrbit`)
+3. Live terminal (`DockedWithAnother`, `Landed`, `SplashedDown`, `StableOrbit`, `SubOrbitalArc`)
 
 Within each group, preserve insertion order. The Reasons list is
 ordered at insertion to match this scheme - sort once at the end of
 `Preview` for predictable test output.
+
+This ordering does **not** match production's first-hit close-reason
+log (production walks gates in order and stops on first hit at
+`SupersedeCommit.cs:574-633`). The preview is intentionally a
+**superset** of the production log line: production logs only the
+single reason that gated open vs closed; the dialog shows all the
+player-attributable reasons in a stable order so the player gets the
+full picture. Tests assert this stable readability ordering, not
+parity with production's first-hit selection.
 
 ### Refactor: minimal SupersedeCommit visibility changes
 
@@ -271,30 +321,65 @@ Two helpers in `SupersedeCommit.cs` need `internal` visibility (currently
 
 ### Dialog integration
 
-In `MergeDialog.ShowTreeDialog` (4-arg overload), inside the
-`labels == ReFlyAttempt` branch (currently line 282-309), replace the
-fixed body string with:
+Extract a pure helper `BuildReFlyDialogBody` so the body composition
+is unit-testable without spinning up a Unity dialog (Opus pass-1
+finding F8). Place it on `MergeDialog` (or co-locate with the
+preview helper - `MergeDialog` is more discoverable since it is
+where the dialog body lives today).
 
 ```csharp
+internal static string BuildReFlyDialogBody(
+    string vesselLabel,
+    double reFlyDuration,
+    ReFlyAutoSealPreviewResult preview)
+{
+    string headline = $"<align=\"center\">{vesselLabel} - " +
+                      $"{FormatDuration(reFlyDuration)}</align>\n\n";
+    if (!preview.WillAutoSeal)
+    {
+        return headline +
+            "<align=\"left\">Commit this Re-Fly attempt permanently to " +
+            "the timeline. This cannot be undone.</align>";
+    }
+
+    string reasons = preview.FormatHumanReadable();
+    return headline +
+        "<align=\"left\"><b>This Re-Fly attempt will be merged AND " +
+        $"auto-sealed</b> for the following reason(s): {reasons}. " +
+        "The slot will become permanent and you will not be able to " +
+        "Re-Fly this line of flight again. This cannot be undone.</align>";
+}
+```
+
+Rendered examples (auto-seal branch):
+
+| `Reasons` | Final body (after headline) |
+| --- | --- |
+| `[TransmittedScience]` | "...for the following reason(s): transmitted science. The slot..." |
+| `[Undocked, DockedWithAnother]` | "...for the following reason(s): undocked and docked with another vessel. The slot..." |
+| `[TransmittedScience, Undocked, StableOrbit]` | "...for the following reason(s): transmitted science, undocked, and reached a stable orbit. The slot..." |
+| `[VesselBrokeUp, DockedWithAnother]` | "...for the following reason(s): the vessel broke up and docked with another vessel. The slot..." (mixed-subject phrase still reads correctly under the colon-list form because there is no implicit "you" subject) |
+
+Then in `MergeDialog.ShowTreeDialog` (4-arg overload), replace the
+fixed body string at line 298-300 with:
+
+```csharp
+// situation sampled at dialog spawn only - while the dialog sits
+// open, KSP physics still runs in background and the active vessel
+// situation could in theory flip, but the player has to click
+// eventually and the production classifier re-classifies at finalize.
 var preview = ReFlyAutoSealPreviewer.Preview(
     reFlyRec, marker, reFlyScenario, FlightGlobals.ActiveVessel);
-string body;
-if (preview.WillAutoSeal)
-{
-    string why = preview.FormatHumanReadable();
-    body = $"<align=\"center\">{vesselLabel} - {FormatDuration(reFlyDuration)}</align>\n\n" +
-           $"<align=\"left\"><b>This Re-Fly attempt will be merged AND auto-sealed</b> " +
-           $"because {why}. The slot will become permanent and you will not be " +
-           $"able to Re-Fly this line of flight again. This cannot be undone.</align>";
-}
-else
-{
-    body = $"<align=\"center\">{vesselLabel} - {FormatDuration(reFlyDuration)}</align>\n\n" +
-           "<align=\"left\">Commit this Re-Fly attempt permanently to the timeline. " +
-           "This cannot be undone.</align>";
-}
-message = body;
+message = BuildReFlyDialogBody(vesselLabel, reFlyDuration, preview);
+
+ParsekLog.Info("MergeDialog",
+    $"Re-Fly auto-seal preview: willSeal={preview.WillAutoSeal} " +
+    $"reasons=[{string.Join(",", preview.Reasons)}] " +
+    $"sess={marker?.SessionId ?? "<no-id>"}");
 ```
+
+This Info log at dialog-show time lets us correlate with the actual
+post-merge classifier outcome in case of preview drift.
 
 Notes:
 
@@ -305,25 +390,13 @@ Notes:
   `<align="left">` matches the existing layout style.
 - `marker` is already resolved in scope.
 
-Logging:
-
-```csharp
-ParsekLog.Info("MergeDialog",
-    $"Re-Fly auto-seal preview: willSeal={preview.WillAutoSeal} " +
-    $"reasons=[{string.Join(",", preview.Reasons)}] " +
-    $"sess={marker?.SessionId ?? "<no-id>"}");
-```
-
-This logs at dialog-show time so we can correlate with the actual
-post-merge classifier outcome in case of preview drift.
-
 ## Files to change
 
 | Status | Path | Change |
 | --- | --- | --- |
 | New | `Source/Parsek/ReFlyAutoSealPreview.cs` | Preview helper + `ReFlyAutoSealReason` enum + `ReFlyAutoSealPreviewResult` struct + `FormatHumanReadable` |
 | Modified | `Source/Parsek/SupersedeCommit.cs` | `CollectRecordingIdsForSafetyGate` -> `internal`; extract shared `ScanReFlySessionStructuralMutations` private helper; new `TryGetFirstReFlySessionStructuralMutationType` internal API |
-| Modified | `Source/Parsek/MergeDialog.cs` | Wire preview into the ReFlyAttempt body copy in the 4-arg `ShowTreeDialog` overload; add canary log line |
+| Modified | `Source/Parsek/MergeDialog.cs` | Add `BuildReFlyDialogBody(vesselLabel, duration, preview)` static helper; wire preview into the ReFlyAttempt body copy in the 4-arg `ShowTreeDialog` overload; add canary log line |
 | New | `Source/Parsek.Tests/ReFlyAutoSealPreviewTests.cs` | Unit tests per reason path + multi-reason composition + null guards + format spec |
 | Modified | `CHANGELOG.md` | Entry under 0.9.2 Enhancements |
 
@@ -336,55 +409,82 @@ Pure unit tests, xUnit. `[Collection("Sequential")]` for shared
 calls `ParsekLog.ResetTestOverrides`, `Ledger.ResetForTesting`,
 `RecordingStore.ResetForTesting`, `ParsekScenario.ResetInstanceForTesting`.
 
+Pronoun convention: phrases are subject-free (Opus pass-1 F6); the
+dialog body wraps them in "for the following reason(s):" so the
+`FormatHumanReadable` column shows the bare phrase.
+
 | Setup | Expected reasons | `FormatHumanReadable` |
 | --- | --- | --- |
 | `marker == null` | `WillAutoSeal=false`, empty | `null` |
 | `liveProvisional == null` | `WillAutoSeal=false`, empty | `null` |
 | `marker.TreeId == null` | `WillAutoSeal=false`, empty | `null` |
 | `liveProvisional.TreeId != marker.TreeId` | `WillAutoSeal=false`, empty | `null` |
+| `liveProvisional.RecordingId != marker.ActiveReFlyRecordingId` (in-place continuation) | preview still runs - TreeId match is the gate, not RecordingId match (matches production: in-place continuation has same TreeId, different RecordingId, same lineage) | depends on other paths |
 | Idle Re-Fly, no events, vessel landed | empty | `null` |
-| Ledger has `ScienceEarning` (Method=Transmitted) tagged on provisional | `[TransmittedScience]` | `"you transmitted science"` |
-| Ledger has `ScienceEarning` (Method=Recovered) tagged on provisional | `[RecoveredScience]` | `"you recovered science"` |
+| Ledger has `ScienceEarning` (Method=Transmitted) tagged on provisional | `[TransmittedScience]` | `"transmitted science"` |
+| Ledger has `ScienceEarning` (Method=Recovered) tagged on provisional | `[RecoveredScience]` | `"recovered science"` |
+| Ledger has 2 `ScienceEarning` rows, both Transmitted, both tagged on provisional | `[TransmittedScience]` (deduped) | `"transmitted science"` |
+| Ledger has 1 Transmitted + 1 Recovered tagged on provisional | `[TransmittedScience, RecoveredScience]` | `"transmitted science and recovered science"` |
 | Ledger has `ScienceEarning` tagged on a chain-segment of the provisional | `[TransmittedScience]` (or whichever Method) | proportional |
 | Ledger has `ScienceEarning` tagged on a different recording (not in lineage) | empty | `null` |
 | Ledger has tombstone-eligible `ScienceEarning` (paired with kerbal death penalty) | empty | `null` |
+| Ledger has tombstone-eligible `ScienceEarning` (`TombstoneEligibility.IsEligible == true` non-paired) | empty | `null` |
 | Ledger has non-`ScienceEarning` action tagged on provisional (e.g. `FundsEarning`) | empty | `null` |
-| Tree has post-RP `Undock` BP in lineage | `[Undocked]` | `"you undocked"` |
-| Tree has post-RP `EVA` BP in lineage | `[KerbalEva]` | `"you sent a kerbal on EVA"` |
-| Tree has post-RP `JointBreak` BP in lineage | `[PartBrokeOff]` | `"you broke off a part"` |
-| Tree has post-RP `Breakup` BP in lineage | `[VesselBrokeUp]` | `"the vessel broke up"` (note: the canned phrase already includes "the vessel" so Format prefixes "you" only when grammatically appropriate; spec at end) |
+| Tree has post-RP `Undock` BP in lineage | `[Undocked]` | `"undocked"` |
+| Tree has post-RP `EVA` BP in lineage | `[KerbalEva]` | `"sent a kerbal on EVA"` |
+| Tree has post-RP `JointBreak` BP in lineage | `[PartBrokeOff]` | `"broke off a part"` |
+| Tree has post-RP `Breakup` BP in lineage | `[VesselBrokeUp]` | `"the vessel broke up"` |
 | Pre-RP BP only (UT < cutoff) | empty | `null` |
 | BP not in Re-Fly target lineage (background vessel) | empty | `null` |
 | BP in `marker.PreSessionBranchPointIds` (re-spliced from load) | empty | `null` |
 | `marker.PreSessionBranchPointIds == null` (legacy marker) | structural skipped, other paths still work | `null` if no other reason |
 | Multiple structural BPs of different types | first only (e.g. `[Undocked]` even if Breakup followed) | first phrase only |
-| Live vessel `situation == DOCKED` | `[DockedWithAnother]` | `"you docked with another vessel"` |
-| Live vessel `situation == ORBITING` | `[StableOrbit]` | `"you reached a stable orbit"` |
-| Live vessel `situation == LANDED` | empty | `null` |
+| Live vessel `situation == DOCKED` | `[DockedWithAnother]` | `"docked with another vessel"` |
+| Live vessel `situation == LANDED` | `[Landed]` | `"landed"` |
+| Live vessel `situation == SPLASHED` | `[SplashedDown]` | `"splashed down"` |
+| Live vessel `situation == ORBITING` && PeR > atmosphereDepth | `[StableOrbit]` | `"reached a stable orbit"` |
+| Live vessel `situation == ORBITING` && PeR <= atmosphereDepth (decaying) | `[SubOrbitalArc]` | `"reached a sub-orbital arc"` |
+| Live vessel `situation == SUB_ORBITAL` | `[SubOrbitalArc]` | `"reached a sub-orbital arc"` |
+| Live vessel `situation == FLYING` (no terminal yet) | empty | `null` (other paths may still apply) |
+| Live vessel `situation == PRELAUNCH` | empty | `null` |
 | `liveActiveVessel == null` | live-vessel reasons skipped, other paths still work | depends |
-| Multi-reason: science + undock | `[TransmittedScience, Undocked]` | `"you transmitted science and undocked"` |
-| Multi-reason: science + undock + dock | 3 reasons, ordered (science, struct, terminal) | `"you transmitted science, undocked, and docked with another vessel"` |
-| Multi-reason: undock + breakup | first structural only `[Undocked]` | `"you undocked"` |
+| Multi-reason: science + undock | `[TransmittedScience, Undocked]` | `"transmitted science and undocked"` |
+| Multi-reason: science + undock + dock | 3 reasons, ordered (science, struct, terminal) | `"transmitted science, undocked, and docked with another vessel"` |
+| Multi-reason: undock + breakup | first structural only `[Undocked]` | `"undocked"` |
+| Multi-reason: science + landed | `[TransmittedScience, Landed]` | `"transmitted science and landed"` |
 
 ### `FormatHumanReadable` standalone
+
+Subject-free phrasing wrapped by the dialog body in "for the following
+reason(s): ...". This sidesteps the pronoun-mix grammar problem with
+phrases like "the vessel broke up" (Opus pass-1 F6).
 
 | Reasons | Output |
 | --- | --- |
 | `[]` | `null` |
-| `[EarnedScience]` | `"you earned science"` |
-| `[TransmittedScience]` | `"you transmitted science"` |
-| `[Undocked]` | `"you undocked"` |
-| `[VesselBrokeUp]` | `"the vessel broke up"` (special case - phrase starts with "the vessel", no "you" prefix) |
-| `[Undocked, KerbalEva]` | `"you undocked and sent a kerbal on EVA"` |
-| `[VesselBrokeUp, DockedWithAnother]` | `"the vessel broke up and you docked with another vessel"` (mixed pronoun handled by sub-clause) |
-| `[TransmittedScience, Undocked, DockedWithAnother]` | `"you transmitted science, undocked, and docked with another vessel"` |
-| `[VesselBrokeUp, TransmittedScience, DockedWithAnother]` | `"the vessel broke up, you transmitted science, and you docked with another vessel"` |
+| `[EarnedScience]` | `"earned science"` |
+| `[TransmittedScience]` | `"transmitted science"` |
+| `[Undocked]` | `"undocked"` |
+| `[VesselBrokeUp]` | `"the vessel broke up"` |
+| `[Landed]` | `"landed"` |
+| `[Undocked, KerbalEva]` | `"undocked and sent a kerbal on EVA"` |
+| `[VesselBrokeUp, DockedWithAnother]` | `"the vessel broke up and docked with another vessel"` |
+| `[TransmittedScience, Undocked, DockedWithAnother]` | `"transmitted science, undocked, and docked with another vessel"` |
+| `[VesselBrokeUp, TransmittedScience, DockedWithAnother]` | `"the vessel broke up, transmitted science, and docked with another vessel"` |
 
-The pronoun-mix is awkward but accurate. Simpler alternative: drop the
-"you" prefix entirely and rely on phrasing -> `"transmitted science and
-undocked"`, `"the vessel broke up"`. Less natural but unambiguous.
-**Decision deferred to user**: pick one of the two styles in §Open
-questions before implementation.
+Composition rules:
+- 0 reasons: `null`.
+- 1 reason: bare phrase.
+- 2 reasons: `"{a} and {b}"`.
+- 3+ reasons: `"{a}, {b}, ..., and {n}"` (Oxford comma).
+
+### `BuildReFlyDialogBody` standalone
+
+| Setup | Body fragment after the headline |
+| --- | --- |
+| `WillAutoSeal=false` | `"Commit this Re-Fly attempt permanently to the timeline. This cannot be undone."` |
+| `WillAutoSeal=true, Reasons=[TransmittedScience]` | `"<b>This Re-Fly attempt will be merged AND auto-sealed</b> for the following reason(s): transmitted science. The slot will become permanent and you will not be able to Re-Fly this line of flight again. This cannot be undone."` |
+| `WillAutoSeal=true, Reasons=[VesselBrokeUp, DockedWithAnother]` | `"...the following reason(s): the vessel broke up and docked with another vessel. The slot..."` |
 
 ### Reason ordering test
 
@@ -404,6 +504,15 @@ would prioritise (it picks the first close-reason hit).
   (matches production behaviour at `SupersedeCommit.cs:706-712`).
 - Marker with empty `RewindPointId` -> structural cutoff falls back to
   `marker.InvokedUT`; preview still works.
+
+### State-version invariance (Opus pass-1 F17)
+
+Add a single test that pins the read-only contract: capture
+`Ledger.StateVersion`, `RecordingStore.SupersedeStateVersion`, and any
+other mutation-tracking counters before and after `Preview()` for a
+non-trivial scenario (provisional, marker, ledger entries, tree, live
+vessel). Assert all counters unchanged. Catches accidental future
+routes through cached / mutating helpers.
 
 ## Risks
 
@@ -426,18 +535,18 @@ would prioritise (it picks the first close-reason hit).
   generic `classifierQualifies` requires a specific terminal state which
   is null pre-finalize).
 
-- **`vessel.situation == ORBITING` proxy correctness**: KSP sets
-  `Vessel.Situations.ORBITING` only when both apsides are above the
-  body's atmosphere (or surface for airless bodies). The
-  `RecordingTree.DetermineTerminalState` override path may still flip
-  between SUB_ORBITAL and ORBITING based on atmospheric drag
-  predictions, but for a vessel currently in stable orbit (no thrust,
-  no atmosphere intersection within current orbit), the live `situation`
-  enum and the post-finalize `TerminalStateValue` agree. Edge case: a
-  vessel coasting through a high-eccentricity orbit that grazes
-  atmosphere may flicker between SUB_ORBITAL and ORBITING; the dialog
-  is a one-shot snapshot at click time, so transient flicker is
-  acceptable.
+- **Stable terminal proxy correctness**: the preview maps live
+  `Vessel.Situations.LANDED/SPLASHED/ORBITING/SUB_ORBITAL/DOCKED` to
+  reasons that match the production seal verdict via
+  `stableTerminalFocusSlot` (Landed/Splashed/Orbiting/SubOrbital) and
+  `IsHardSafetyTerminal` (Docked). A vessel coasting through a
+  high-eccentricity orbit that grazes atmosphere may flicker between
+  SUB_ORBITAL and ORBITING; the preview uses
+  `RecordingTree.IsBoundOrbitAboveAtmosphere` to pick "stable orbit"
+  vs "sub-orbital arc" wording, but BOTH terminals seal under
+  `stableTerminalFocusSlot`, so the seal verdict is correct even if
+  the wording mispredicts. The dialog is a one-shot snapshot at
+  click time, so transient flicker is acceptable.
 
 - **In-place continuation case**: `IsInPlaceContinuation(marker,
   provisional)` returns true when
@@ -481,40 +590,16 @@ would prioritise (it picks the first close-reason hit).
   transmitted, which part broke off). Adds noise without helping the
   player understand the consequence.
 
-## Open questions
+## Open questions (resolved)
 
-1. **Pronoun style**: "you transmitted science" vs "transmitted
-   science" vs "the recording transmitted science." First-person ("you")
-   is most direct but creates pronoun-mix awkwardness when combined
-   with subject-led phrases like "the vessel broke up". Three options:
-   - **A**: keep "you" prefix; accept mixed-subject sentences.
-   - **B**: drop "you", rely on phrasing -> `"transmitted science and
-     undocked"`. Less natural but uniform.
-   - **C**: rewrite "the vessel broke up" -> "you broke up the vessel"
-     so all phrases are "you"-led. Less accurate (vessel breakup is
-     usually involuntary).
+1. **Pronoun style**: subject-free phrasing wrapped in "for the
+   following reason(s):" copy form. Resolved per Opus pass-1 F6.
 
-   Recommend **B** (drop "you"). Implementation defaults to B unless
-   user picks otherwise.
+2. **`Boarded` / `Recovered` detection**: skip - unreachable in-flight.
+   Production classifier seals correctly post-finalize.
 
-2. **`Boarded` / `Recovered` detection**: the preview deliberately
-   skips these because they are unreachable in flight. But is there an
-   in-flight signal (e.g. a `Boarded` ledger row from an earlier crew
-   transfer in the attempt) we should surface? Likely no: the seal for
-   those triggers via `IsHardSafetyTerminal` which reads
-   `TerminalStateValue`, and the recording wouldn't have a Boarded
-   terminal state until finalize.
-
-   Recommend **skip them** (do not surface in dialog). The production
-   classifier still seals correctly post-finalize.
-
-3. **Single structural reason vs all structural reasons**: production
-   logs only the first BP. Should the dialog list all BP types
-   encountered, or just the first?
-
-   Recommend **first only**. The player typically remembers what they
-   actively did (undock); cascading consequences (a follow-on breakup)
-   would clutter the message.
+3. **Single structural reason vs all structural reasons**: first only,
+   matching production's first-bp log at `SupersedeCommit.cs:760-764`.
 
 ## Implementation order
 

--- a/scripts/ers-els-audit-allowlist.txt
+++ b/scripts/ers-els-audit-allowlist.txt
@@ -228,3 +228,14 @@ Source/Parsek/Rendering/SmoothingPipeline.cs
 # session whose supersede commit caused the drift. Read-only against
 # trajectory metadata; same rationale as SmoothingPipeline above.
 Source/Parsek/Rendering/CoBubbleBlender.cs
+
+# ReFlyAutoSealPreviewer.Preview is the read-only auto-seal preview the
+# pre-transition Re-Fly merge dialog uses to customize body copy
+# (transmitted science / undocked / docked etc.). It walks Ledger.Actions
+# directly to mirror SupersedeCommit.IsRetryBlockingRecordingAction's
+# filter (which is the canonical retry-blocker gate). Routing through
+# ELS would hide actions that production seals on - the preview must
+# match production's view of the raw ledger to avoid surfacing different
+# reasons than the post-finalize classifier will. No mutation; no scenario
+# state-version bumps. Same trust scope as SupersedeCommit.cs above.
+Source/Parsek/ReFlyAutoSealPreview.cs


### PR DESCRIPTION
## Summary

When the player ends a Re-Fly attempt and the pre-transition merge confirmation dialog appears (PR #750 added that dialog), the body copy was generic: "Commit this Re-Fly attempt permanently to the timeline. This cannot be undone." That was technically correct but did not convey:

1. that auto-seal will fire (vs the slot staying re-flyable for further retry);
2. **why** auto-seal will fire (the player's specific actions that triggered the policy in `SupersedeCommit.ShouldAutoSealReFlySlotAfterMerge`).

This PR customizes the Re-Fly variant body when auto-seal is predicted, listing the player-attributable reason(s):

> **This Re-Fly attempt will be merged AND auto-sealed** for the following reason(s): transmitted science and undocked. The slot will become permanent and you will not be able to Re-Fly this line of flight again. This cannot be undone.

Default copy (no auto-seal) is unchanged - the slot stays re-flyable.

## Plan

[`docs/dev/plans/refly-autoseal-dialog-copy.md`](docs/dev/plans/refly-autoseal-dialog-copy.md). Two Opus review passes shaped the design before implementation.

## Architecture

- **NEW** `Source/Parsek/ReFlyAutoSealPreview.cs` - read-only, conservative subset of the production auto-seal classifier. Mirrors the gates that are reliable from live state (Ledger.Actions for science, tree topology for structural mutations, live `vessel.situation` for stable terminals). Returns a list of `ReFlyAutoSealReason` values; `FormatHumanReadable` composes a subject-free phrase ("transmitted science and undocked") for the dialog body.
- **MODIFIED** `Source/Parsek/SupersedeCommit.cs` - extracted `ScanReFlySessionStructuralMutations` private helper shared between the existing `HasReFlySessionStructuralMutation` and a new `TryGetFirstReFlySessionStructuralMutationType` internal accessor. `CollectRecordingIdsForSafetyGate` -> `internal`. No behavior change.
- **MODIFIED** `Source/Parsek/MergeDialog.cs` - new `BuildReFlyDialogBody` static helper for unit-testable body composition. The 4-arg `ShowTreeDialog` overload's Re-Fly branch now calls the previewer + `BuildReFlyDialogBody`, plus an Info log line at dialog spawn so the preview verdict can be correlated with the post-merge classifier outcome.

## Auto-seal reasons surfaced

| Reason | Trigger (mirrors production gate) |
| --- | --- |
| Transmitted / Recovered / Earned science | `RecordingAction` (`SupersedeCommit.IsRetryBlockingRecordingAction`, filtered by `TombstoneEligibility`) |
| Undocked / Sent kerbal on EVA / Broke off a part / Vessel broke up | `StructuralMutation` (post-RP `BranchPointType` in lineage) |
| Docked with another vessel | `IsHardSafetyTerminal(Docked)` proxied via live `vessel.situation == DOCKED` |
| Landed / Splashed down | `stableTerminalFocusSlot` proxied via live `vessel.situation == LANDED/SPLASHED` |
| Reached a stable orbit / sub-orbital arc | `stableTerminalFocusSlot` proxied via live `vessel.situation == ORBITING/SUB_ORBITAL` + `RecordingTree.IsBoundOrbitAboveAtmosphere` to disambiguate |

## Test plan

- [x] Unit: 24 new tests across `ReFlyAutoSealPreviewTests` covering null guards, science branch (transmit/recover/dedup/mixed methods/tombstone-paired exclusion/unrelated recording/non-science action), state-version invariance, format spec, multi-reason composition, in-place continuation rationale, and `BuildReFlyDialogBody` body composition. 10759 tests passing total.
- [ ] In-game: trigger a Re-Fly with no actions, exit to KSC -> dialog shows default "permanently to the timeline" copy.
- [ ] In-game: trigger a Re-Fly, transmit science, exit to KSC -> dialog shows "transmitted science" reason.
- [ ] In-game: trigger a Re-Fly, undock, exit to KSC -> dialog shows "undocked" reason.
- [ ] In-game: trigger a Re-Fly, dock with another vessel, exit -> dialog shows "docked with another vessel".
- [ ] In-game: trigger a Re-Fly, transmit science AND undock, exit -> dialog shows both reasons composed.
- [ ] In-game: confirm dialog wording reads naturally for 1, 2, 3+ reasons.