### PR TITLE
docs: mark recording finalization design complete

### DIFF
--- a/docs/parsek-recording-finalization-design.md
+++ b/docs/parsek-recording-finalization-design.md
@@ -1,39 +1,58 @@
 # Design: Recording Finalization Reliability
 
-*Design specification for sealing active and background recordings when the live KSP vessel ends before Parsek can run the normal scene-exit finalizer. This document is the contract for future implementation PRs; it does not describe shipped behavior yet.*
+*Shipped design contract for sealing active and background recordings when the live KSP vessel ends before Parsek can run the normal scene-exit finalizer. The recording-finalization cache feature has landed and is treated as reliable baseline behavior, not a proposal.*
 
-*Related docs: [`parsek-flight-recorder-design.md`](parsek-flight-recorder-design.md), [`parsek-rewind-to-separation-design.md`](parsek-rewind-to-separation-design.md), [`dev/plans/incomplete-ballistic-extrapolation.md`](dev/plans/incomplete-ballistic-extrapolation.md), [`dev/plans/recording-finalization-reliability.md`](dev/plans/recording-finalization-reliability.md).*
+*Related docs: [`parsek-flight-recorder-design.md`](parsek-flight-recorder-design.md), [`parsek-rewind-to-separation-design.md`](parsek-rewind-to-separation-design.md), [`dev/done/plans/incomplete-ballistic-extrapolation.md`](dev/done/plans/incomplete-ballistic-extrapolation.md), [`dev/done/plans/recording-finalization-reliability.md`](dev/done/plans/recording-finalization-reliability.md), [`dev/manual-testing/test-recording-finalization-cache.md`](dev/manual-testing/test-recording-finalization-cache.md).*
 
 ---
 
+## Status
+
+Recording-finalization reliability is implemented and production behavior follows the precedence defined here:
+
+1. Fresh live finalization wins when the vessel/runtime can still be inspected.
+2. A matching finalization cache wins when the live finalizer declines or the vessel is missing.
+3. Trajectory inference remains only a degraded last-resort fallback and must log that degradation.
+
+The landed implementation includes:
+
+- `RecordingFinalizationCache` for in-memory terminal payloads.
+- `RecordingFinalizationCacheProducer` for active, loaded-background, and on-rails refreshes.
+- `RecordingFinalizationCacheApplier` for identity checks, stale/invalid rejection, predicted-tail trimming, terminal metadata stamping, and dirty-sidecar handling.
+- Active/background ownership transfer when a recording moves between focused and background sampling.
+- Scene-exit, crash, background destroy, unload/missing-vessel, debris TTL, and out-of-bubble cache consumers.
+- Maneuver-node-safe finalization: UI maneuver nodes are detected and stock node-contaminated tails are discarded in favor of current-state propagation.
+- Headless xUnit coverage and `RecordingFinalization` in-game runtime canaries, with the remaining gameplay checklist kept in the manual-testing doc.
+
 ## Problem
 
-Parsek can synthesize a predicted tail for some incomplete recordings when the player exits the flight scene while the live vessel still exists. That is not enough for mission-tree correctness. A recording can end because the player switches focus, a background sibling leaves the physics bubble, KSP deletes an unfocused atmospheric vessel, the active vessel crashes before scene exit, or `FlightGlobals` is unavailable during teardown. In those cases Parsek may commit only the last sampled point, infer a weak terminal state from stale data, or mark the vessel destroyed without the synthetic trajectory that explains how it got there.
+Historically, Parsek could synthesize a predicted tail for some incomplete recordings when the player exited the flight scene while the live vessel still existed. That was not enough for mission-tree correctness. A recording can end because the player switches focus, a background sibling leaves the physics bubble, KSP deletes an unfocused atmospheric vessel, the active vessel crashes before scene exit, or `FlightGlobals` is unavailable during teardown. Without a cached terminal payload, those paths could commit only the last sampled point, infer a weak terminal state from stale data, or mark the vessel destroyed without the synthetic trajectory that explains how it got there.
 
 This is foundational for Rewind to Separation. The Unfinished Flights classifier needs trustworthy terminal state and end-time data to decide whether a sibling really ended badly and whether a rewind point should stay actionable. A terminal state that depends on which KSP object happened to survive until scene exit is not a durable gameplay contract.
 
-## Current Implementation Audit
+## Landed Implementation Audit
 
-The current implementation has useful pieces:
+The shipped implementation keeps the original scene-exit finalizer and extrapolator, and adds cache refresh/application around the timing and ownership gaps:
 
 - `IncompleteBallisticSceneExitFinalizer.TryApply` snapshots a live vessel's patched-conic chain, then runs `BallisticExtrapolator.Extrapolate` when needed.
 - `BallisticExtrapolator.ShouldExtrapolate` correctly targets flying, suborbital, escaping, and low-periapsis orbital cases while skipping landed, splashed, prelaunch, docked, and stable orbiting vessels.
 - `BackgroundRecorder` records loaded physics-bubble siblings, on-rails orbit checkpoints, part death and joint-break events, debris TTL expiry, and background-vessel destruction.
 - `FinalizeTreeRecordings` runs for scene exit, manual commit, revert commit, and post-destruction merge paths.
+- `FlightRecorder` owns the focused recording cache and refreshes it at recording start, cadence, and lifecycle/state transitions.
+- `BackgroundRecorder` owns per-PID caches for loaded and on-rails background recordings, including inherited caches from active -> background transitions.
+- `ParsekFlight` resolves and applies active/background caches during tree finalization while preserving fresh-live precedence.
 
-The reliability gaps are about timing and ownership:
+The historical reliability gaps now resolve as follows:
 
-| End mode | Current behavior | Gap |
+| End mode | Landed behavior | Reliability contract |
 |---|---|---|
-| Scene exit, live vessel exists | Scene-exit finalizer can append predicted/extrapolated segments and terminal state. | Works only if the vessel and `FlightGlobals` are still usable at that moment. |
-| Scene exit, vessel missing | Falls back to trajectory inference or prior destroyed state. | No last-known predicted tail exists after the vessel object is gone. |
-| Active crash before scene exit | `FlightRecorder.OnVesselWillDestroy` samples final position and marks destroyed; post-destruction commit runs with `isSceneExit:false`. | No ballistic/predicted tail is synthesized for the last live approach to impact. |
-| Background vessel destroyed | `BackgroundRecorder.OnBackgroundVesselWillDestroy` flushes track sections and persists the sidecar. | No finalization tail; terminal data depends on whatever was already sampled. |
-| Debris TTL or out-of-bubble end | `EndDebrisRecording` sets `ExplicitEndUT` and either destroyed or situation-derived terminal state. | No predicted continuation to the KSP deletion/destruction endpoint. |
-| Focus switch / backgrounding | The active recorder transitions to background or promotes another tree member. | A recording that later becomes unreachable still depends on scene-exit or destruction-time inference. |
-| UI maneuver node present | Prior code recorded a segment ending in `Maneuver`, marked `StoppedBeforeManeuver`, and treated that as an orbiting terminus; Phase 2 retires that terminal behavior by falling back to current-state propagation when a UI node is detected. | Planned UI burns are hypothetical and must not truncate the real projected coast. |
-
-The design target is to keep the existing finalizer and extrapolator, but make their output available before the live vessel disappears.
+| Scene exit, live vessel exists | Fresh scene-exit finalizer appends predicted/extrapolated segments and terminal state. | Fresh live finalization wins over any cache. |
+| Scene exit, vessel missing | Tree finalization resolves the active/background cache and applies it before inference. | Missing runtime objects no longer imply weak last-sample finalization when a cache exists. |
+| Active crash before scene exit | `OnVesselWillDestroy` forces a cache refresh; post-destruction finalization consumes the cache after crash coalescing. | Destroyed active recordings keep a cache-extended endpoint instead of relying only on the final sampled point. |
+| Background vessel destroyed | Background destroy consumers apply the cache, trim to the actual deletion/destruction UT when needed, and persist the sidecar. | Background destroyed recordings get durable terminal state and synthetic tail metadata. |
+| Debris TTL or out-of-bubble end | Background TTL/missing-vessel paths refresh/apply cache before removing the recording from `BackgroundMap`. | KSP deletion endpoints are preserved and capped to stock deletion UT. |
+| Focus switch / backgrounding | Focus switch transfers cache ownership from `FlightRecorder` to `BackgroundRecorder`; it does not finalize by itself. | A later unload/destroy path still has the last focused projected ending. |
+| UI maneuver node present | `PatchedConicSnapshot` reports `EncounteredManeuverNode`; the finalizer discards stock node-contaminated tails and falls back to current-state propagation. | Planned UI burns remain hypothetical and cannot truncate or redirect finalization. |
 
 ## Terminology
 
@@ -77,7 +96,7 @@ when a recording ends:
         use today's inference fallback and log the degraded result
 ```
 
-KSP's unload model gives the policy its shape. Unloaded vessels move on rails; atmospheric forces are not applied to distant vessels. Community-facing KSP API docs describe unloaded/on-rails motion as orbital-only rather than full-atmosphere physics, and KSP players document the stock auto-delete behavior for objects below the body-specific deletion altitude and outside the active vessel's physics bubble. Parsek should mirror that gameplay outcome: in-atmosphere unfocused deletion is `Destroyed`; stable vacuum orbit is `Orbiting`.
+KSP's unload model gives the policy its shape. Unloaded vessels move on rails; atmospheric forces are not applied to distant vessels. Community-facing KSP API docs describe unloaded/on-rails motion as orbital-only rather than full-atmosphere physics, and KSP players document the stock auto-delete behavior for objects below the body-specific deletion altitude and outside the active vessel's physics bubble. Parsek mirrors that gameplay outcome: in-atmosphere unfocused deletion is `Destroyed`; stable vacuum orbit is `Orbiting`.
 
 ## Gameplay Scenarios
 
@@ -109,7 +128,7 @@ The player clicks Space Center during ascent while engines are firing.
 
 Expected Parsek behavior:
 
-- The cache may be up to 5 seconds stale, but the scene-exit path should still make one fresh live-vessel finalization attempt before teardown.
+- The cache may be up to 5 seconds stale, but the scene-exit path makes one fresh live-vessel finalization attempt before teardown.
 - If the live attempt succeeds, it wins over the cache.
 - If KSP has already torn down the vessel/runtime, the cache is good enough to avoid a frozen mid-burn endpoint.
 
@@ -146,7 +165,7 @@ Expected Parsek behavior:
 
 The cache is in-memory only. It is not serialized, and it does not change the recording sidecar format. Recordings are still committed only when a recording ends.
 
-Suggested shape:
+Landed shape:
 
 ```csharp
 internal sealed class RecordingFinalizationCache
@@ -166,6 +185,7 @@ internal sealed class RecordingFinalizationCache
     public Vessel.Situations LastSituation;
     public bool LastWasInAtmosphere;
     public bool LastHadMeaningfulThrust;
+    public string LastObservedOrbitDigest;
 
     public double TailStartsAtUT;
     public double TerminalUT;
@@ -206,31 +226,25 @@ Refresh every 5 seconds while a recording has a live vessel reference, plus forc
 - time-warp rate change
 - scene-exit finalization entry, before any fallback consumes stale data
 
-Refresh should early-out when the vessel state digest has not meaningfully changed. A stable coasting vacuum orbit does not need a new cache every 5 seconds if the orbit, body, situation, throttle state, and terminal result are unchanged.
+Refresh early-outs when the vessel state digest has not meaningfully changed. A stable coasting vacuum orbit does not need a new cache every 5 seconds if the orbit, body, situation, throttle state, and terminal result are unchanged.
 
 ### Actual Chain Only
 
 Finalization must ignore KSP maneuver nodes. A maneuver node is an editor/planning UI object, not recorded trajectory data and not something the vessel will actually do unless the player later burns.
 
-Implementation may use one of these strategies, in order of preference after code exploration:
-
-1. Obtain a node-free patched-conic chain from stock APIs without mutating player nodes.
-2. Temporarily suppress maneuver-node influence, refresh the solver, capture the real coast chain, and restore the player's solver/node state in `finally`.
-3. Bypass stock patched-conic capture for node-contaminated chains and use the current orbit state plus Parsek's own conic/ballistic propagation.
-
-The old `StoppedBeforeManeuver` behavior is not acceptable as the final design. It turned a hypothetical node into a real terminal boundary; Phase 2 replaces that with `EncounteredManeuverNode` detection and current-state propagation fallback.
+Landed behavior detects maneuver-node boundaries in `PatchedConicSnapshot` with `EncounteredManeuverNode`. When a stock patched-conic tail is node-contaminated, `IncompleteBallisticSceneExitFinalizer` discards that tail and falls back to current-state propagation through Parsek's conic/ballistic path. The old `StoppedBeforeManeuver` terminal behavior is retired because it turned a hypothetical UI node into a real terminal boundary.
 
 ### Active Recorder Refresh
 
-The active recorder can attempt the highest-fidelity cache:
+The active recorder attempts the highest-fidelity cache:
 
 - For live focused vessels, refresh from the live vessel state and stock node-free conic data when available.
 - During powered flight or atmospheric flight, the cache is expected to change; refresh by cadence and forced triggers.
-- During vacuum coast with no meaningful thrust, the cache should stabilize; repeated refreshes should be skipped unless an event invalidates the digest.
+- During vacuum coast with no meaningful thrust, the cache stabilizes; repeated refreshes are skipped unless an event invalidates the digest.
 
 ### Background Recorder Refresh
 
-Background recorders do not have the same solver access as the active vessel. They should still cache a reliable terminal outcome:
+Background recorders do not have the same solver access as the active vessel. They still cache a reliable terminal outcome:
 
 - Loaded background vessels in the physics bubble can refresh from live vessel/orbit state.
 - On-rails background vessels can refresh from `vessel.orbit` and existing on-rails checkpoints.
@@ -256,7 +270,7 @@ Fresh live finalization has precedence over cache application. Cache application
 
 ### Consumer Paths
 
-The implementation must consume cache at these seams:
+The implementation consumes cache at these seams:
 
 - scene exit for active and background recordings when the live finalizer declines or the vessel is missing
 - manual commit or revert commit when a leaf/background vessel is already missing but has a usable cache
@@ -264,9 +278,9 @@ The implementation must consume cache at these seams:
 - background `OnBackgroundVesselWillDestroy`
 - debris TTL, out-of-bubble, and missing-vessel termination in `BackgroundRecorder.CheckDebrisTTL`
 - vessel-unloaded paths that remove or strand a background recording
-- any future stop/abandon path that removes a recording from `BackgroundMap` or ends a live recorder without a fresh vessel
+- any stop/abandon path that removes a recording from `BackgroundMap` or ends a live recorder without a fresh vessel
 
-Focus switching is not itself a consumer unless the switch path actually ends the old recording. In the normal tree model, switching should transfer cache ownership to the background recorder instead.
+Focus switching is not itself a consumer unless the switch path actually ends the old recording. In the normal tree model, switching transfers cache ownership to the background recorder instead.
 
 ## Edge Cases
 
@@ -278,7 +292,7 @@ Focus switching is not itself a consumer unless the switch path actually ends th
 6. **Burn in progress.** Cache refreshes by cadence and throttle/engine triggers. Scene exit attempts one fresh refresh before consuming anything.
 7. **Thrust stops in vacuum.** Forced refresh captures the new coast. Later refreshes can early-out until SOI/warp/orbit changes.
 8. **Atmospheric unpowered flight.** Cache refreshes while loaded; if KSP unloads/deletes the vessel, terminal state is `Destroyed`.
-9. **Stable vacuum orbit.** Cache can settle as `Orbiting`; no synthetic destruction or 50-year horizon spawn should be invented for ordinary stable orbits.
+9. **Stable vacuum orbit.** Cache can settle as `Orbiting`; no synthetic destruction or 50-year horizon spawn is invented for ordinary stable orbits.
 10. **Suborbital vacuum arc with periapsis in atmosphere.** Cache predicts `Destroyed` even if the vessel is currently above atmosphere.
 11. **Non-atmospheric body impact.** Cache predicts ground impact using the same ballistic terrain/sea-level fallback policy as the existing extrapolator.
 12. **Background on-rails vessel lacks patched-conic solver.** Use orbit-state and ballistic/conic extrapolation only.
@@ -292,7 +306,7 @@ Focus switching is not itself a consumer unless the switch path actually ends th
 20. **Recording is already finalized.** Do not overwrite terminal metadata unless the consumer is explicitly repairing a known degraded finalization and logs the replacement.
 21. **Hard quit without commit.** Cache is in-memory, so it is lost. This is acceptable: Parsek commits on recording end, not continuously through power loss.
 22. **Old committed recordings.** No migration. They keep whatever terminal data they already have.
-23. **Many background vessels.** Refresh is per recording, but digest early-outs and 5-second cadence keep cost bounded. Implementation should log aggregate refresh counts rather than per-vessel spam.
+23. **Many background vessels.** Refresh is per recording, but digest early-outs and 5-second cadence keep cost bounded. Implementation logs aggregate refresh counts rather than per-vessel spam.
 
 ## What Doesn't Change
 
@@ -302,14 +316,14 @@ Focus switching is not itself a consumer unless the switch path actually ends th
 - Committed recordings remain immutable after commit. Cache application happens before commit or as part of the existing finalization path.
 - Background recording remains an in-flight, physics-bubble system. This design does not add cross-scene background simulation.
 - Parsek does not simulate full atmospheric drag for unloaded vessels. It mirrors stock KSP's practical outcome for unfocused atmospheric deletion/destruction.
-- Rewind to Separation UI and supersede semantics do not change here. They consume better terminal data after implementation.
+- Rewind to Separation UI and supersede semantics do not change here. They consume better terminal data from the finalization cache without changing their UI contract.
 - ERS/ELS access rules do not change. The cache is pre-commit finalization state and must not introduce new raw `RecordingStore.CommittedRecordings` or `Ledger.Actions` readers outside the existing grep-audit allowlist.
 
 ## Backward Compatibility
 
 There is no save migration and no new serialized cache node. Existing recordings keep their terminal state and predicted tail data as written.
 
-If a future implementation discovers it needs a small persisted marker for "finalization was degraded", that must be a separate design update. The locked decision for this plan is in-memory cache only.
+If later work discovers it needs a small persisted marker for "finalization was degraded", that must be a separate design update. The locked decision for this feature is in-memory cache only.
 
 ## Diagnostic Logging
 
@@ -335,9 +349,9 @@ Required log events:
 
 Per-frame refresh checks must use rate-limited logs or aggregate summaries.
 
-## Test Plan
+## Coverage Contract
 
-Every implementation PR must add tests in the same commit as the behavior it introduces.
+The feature landed with headless unit/integration/log-assertion coverage plus in-game runtime canaries. Future changes to this area must keep this coverage shape and add tests in the same commit as any behavior change.
 
 ### Unit Tests
 
@@ -379,19 +393,19 @@ Every implementation PR must add tests in the same commit as the behavior it int
 
 ## Implementation Notes
 
-The implementation plan lives in [`dev/plans/recording-finalization-reliability.md`](dev/plans/recording-finalization-reliability.md). The high-level PR shape should be:
+The completed phase plan is archived in [`dev/done/plans/recording-finalization-reliability.md`](dev/done/plans/recording-finalization-reliability.md). The landed code is split across these responsibilities:
 
-1. Cache primitives and pure apply/reject logic.
-2. Active/background refresh producers, including node-free capture and maneuver-node correctness.
-3. Scene-exit fallback consumption.
-4. Premature-end consumers for unload, destroy, TTL, and crash paths.
-5. Runtime coverage and calibration.
-
-Each phase should be independently testable and reviewed against this document.
+1. `RecordingFinalizationCache` - in-memory identity, freshness, terminal, and predicted-tail payload.
+2. `RecordingFinalizationCacheProducer` - active/background refresh cadence, stable-orbit cache production, atmospheric deletion cache production, and digest/no-op handling.
+3. `RecordingFinalizationCacheApplier` - pure apply/reject logic, predicted-tail trimming, terminal metadata stamping, and dirty-sidecar marking.
+4. `FlightRecorder` and `BackgroundRecorder` - cache ownership, refresh producers, active/background transfer, and background end consumers.
+5. `ParsekFlight` and `IncompleteBallisticSceneExitFinalizer` - fresh-live precedence, scene-exit fallback consumption, crash/deferred-destruction consumption, and maneuver-node-safe finalization.
 
 ## References
 
-- [`dev/plans/incomplete-ballistic-extrapolation.md`](dev/plans/incomplete-ballistic-extrapolation.md) - shipped scene-exit predicted-tail plan and current extrapolator context.
+- [`dev/done/plans/incomplete-ballistic-extrapolation.md`](dev/done/plans/incomplete-ballistic-extrapolation.md) - shipped scene-exit predicted-tail plan and current extrapolator context.
+- [`dev/done/plans/recording-finalization-reliability.md`](dev/done/plans/recording-finalization-reliability.md) - completed implementation phase plan.
+- [`dev/manual-testing/test-recording-finalization-cache.md`](dev/manual-testing/test-recording-finalization-cache.md) - runtime/manual validation checklist.
 - [`dev/development-workflow.md`](dev/development-workflow.md) - design and plan/build/review workflow.
 - [kOS Vessel Load Distance docs](https://ksp-kos.github.io/KOS_DOC/structures/misc/loaddistance.html) - describes loaded/unloaded and packed/on-rails behavior in KSP.
 - [KSP forum discussion: 25km auto delete](https://forum.kerbalspaceprogram.com/topic/164961-25km-auto-delete/) - community documentation of stock atmospheric auto-delete rules.

--- a/docs/parsek-recording-finalization-design.md
+++ b/docs/parsek-recording-finalization-design.md
@@ -1,6 +1,6 @@
 # Design: Recording Finalization Reliability
 
-*Shipped design contract for sealing active and background recordings when the live KSP vessel ends before Parsek can run the normal scene-exit finalizer. The recording-finalization cache feature has landed and is treated as reliable baseline behavior, not a proposal.*
+*Shipped design contract for sealing active and background recordings when the live KSP vessel ends before Parsek can run the normal scene-exit finalizer. The recording-finalization cache feature has landed and is treated as baseline behavior, with the known limitation below.*
 
 *Related docs: [`parsek-flight-recorder-design.md`](parsek-flight-recorder-design.md), [`parsek-rewind-to-separation-design.md`](parsek-rewind-to-separation-design.md), [`dev/done/plans/incomplete-ballistic-extrapolation.md`](dev/done/plans/incomplete-ballistic-extrapolation.md), [`dev/done/plans/recording-finalization-reliability.md`](dev/done/plans/recording-finalization-reliability.md), [`dev/manual-testing/test-recording-finalization-cache.md`](dev/manual-testing/test-recording-finalization-cache.md).*
 
@@ -23,6 +23,10 @@ The landed implementation includes:
 - Scene-exit, crash, background destroy, unload/missing-vessel, debris TTL, and out-of-bubble cache consumers.
 - Maneuver-node-safe finalization: UI maneuver nodes are detected and stock node-contaminated tails are discarded in favor of current-state propagation.
 - Headless xUnit coverage and `RecordingFinalization` in-game runtime canaries, with the remaining gameplay checklist kept in the manual-testing doc.
+
+Known limitation:
+
+- `docs/dev/todo-and-known-bugs.md` item 639 tracks a patched-conic atmospheric-tail cache refresh that can flip from `Destroyed` to `Orbiting` from a far-future segment. The active-recorder destruction override no longer depends on that cache, but diagnostics and any path without that authoritative override still need the follow-up fix.
 
 ## Problem
 
@@ -49,7 +53,7 @@ The historical reliability gaps now resolve as follows:
 | Scene exit, live vessel exists | Fresh scene-exit finalizer appends predicted/extrapolated segments and terminal state. | Fresh live finalization wins over any cache. |
 | Scene exit, vessel missing | Tree finalization resolves the active/background cache and applies it before inference. | Missing runtime objects no longer imply weak last-sample finalization when a cache exists. |
 | Active crash before scene exit | `OnVesselWillDestroy` forces a cache refresh; post-destruction finalization consumes the cache after crash coalescing. | Destroyed active recordings keep a cache-extended endpoint instead of relying only on the final sampled point. |
-| Background vessel destroyed | Background destroy consumers apply the cache, trim to the actual deletion/destruction UT when needed, and persist the sidecar. | Background destroyed recordings get durable terminal state and synthetic tail metadata. |
+| Background vessel destroyed | `OnBackgroundVesselWillDestroy` refreshes/flushes and keeps the cache; `ParsekFlight.DeferredDestructionCheck` applies it only after true destruction is confirmed, then persists the sidecar. | Background destroyed recordings get durable terminal state and synthetic tail metadata without treating false unload/docking signals as terminal. |
 | Debris TTL or out-of-bubble end | Background TTL/missing-vessel paths refresh/apply cache before removing the recording from `BackgroundMap`. | KSP deletion endpoints are preserved and capped to stock deletion UT. |
 | Focus switch / backgrounding | Focus switch transfers cache ownership from `FlightRecorder` to `BackgroundRecorder`; it does not finalize by itself. | A later unload/destroy path still has the last focused projected ending. |
 | UI maneuver node present | `PatchedConicSnapshot` reports `EncounteredManeuverNode`; the finalizer discards stock node-contaminated tails and falls back to current-state propagation. | Planned UI burns remain hypothetical and cannot truncate or redirect finalization. |
@@ -202,7 +206,7 @@ internal sealed class RecordingFinalizationCache
 Ownership:
 
 - `FlightRecorder` owns one cache for the focused recording it is currently sampling.
-- `BackgroundRecorder` owns a cache per `BackgroundMap` entry or per loaded/on-rails state. The cache is keyed by recording id and vessel PID so it survives active -> background and background -> active promotion.
+- `BackgroundRecorder` owns a cache per `BackgroundMap` entry or per loaded/on-rails state. The cache is keyed by recording id and vessel PID so active -> background transfer preserves the last focused cache; background -> active promotion starts a fresh active cache from the live vessel.
 - `VesselPersistentId = 0` means unknown legacy/test identity. Cache application still requires `RecordingId` to match, and when both sides have a nonzero vessel PID, those PIDs must match too.
 - The cache payload is copied into the target `Recording` only when a consumer finalizes that recording.
 
@@ -275,7 +279,7 @@ The implementation consumes cache at these seams:
 - scene exit for active and background recordings when the live finalizer declines or the vessel is missing
 - manual commit or revert commit when a leaf/background vessel is already missing but has a usable cache
 - active vessel destruction after crash coalescing decides the recording/tree should finalize
-- background `OnBackgroundVesselWillDestroy`
+- confirmed background destruction through `ParsekFlight.DeferredDestructionCheck` after `OnBackgroundVesselWillDestroy` has refreshed/flushed and kept the cache
 - debris TTL, out-of-bubble, and missing-vessel termination in `BackgroundRecorder.CheckDebrisTTL`
 - vessel-unloaded paths that remove or strand a background recording
 - any stop/abandon path that removes a recording from `BackgroundMap` or ends a live recorder without a fresh vessel
@@ -332,7 +336,7 @@ Use subsystem tags that make the finalization decision reconstructable from `KSP
 - `[FinalizerCache]` for refresh, cache status, cache application, cache rejection, and ownership transfer.
 - `[Extrapolator]` for ballistic/conic propagation, terminal reason, limits, and failures.
 - `[PatchedSnapshot]` for node-free stock chain capture and maneuver-node exclusion decisions.
-- `[BgRecorder]` for background consume paths: destroy, unload, TTL, out-of-bubble, and persistence.
+- `[BgRecorder]` for background cache application and persistence paths, including confirmed destruction, unload, TTL, and out-of-bubble.
 - `[Flight]` for tree-level finalization decisions and crash-coalescer timing.
 
 Required log events:
@@ -353,25 +357,27 @@ Per-frame refresh checks must use rate-limited logs or aggregate summaries.
 
 The feature landed with headless unit/integration/log-assertion coverage plus in-game runtime canaries. Future behavior changes should keep that coverage shape and follow the project testing rule.
 
-### Unit Tests
+### Headless Coverage Behaviors
 
-- `FinalizationCache_AppliesTailAfterLastRealSample` - fails if cached segments overwrite or duplicate authored trajectory history.
-- `FinalizationCache_RejectsTerminalBeforeLastSample` - fails if stale cache can shorten a recording.
-- `FinalizationCache_TransfersActiveToBackground` - fails if focus switching loses the cache for the old active recording.
-- `FinalizationCache_StaleAppliesOnlyWhenNoLiveRefresh` - fails if stale cache silently wins over fresh live state.
-- `FinalizationCache_InAtmosphereDeleteForcesDestroyed` - fails if stock atmospheric deletion can commit as `Orbiting`.
-- `FinalizationCache_StableOrbitDoesNotRefreshEveryCadence` - fails if stable coast creates avoidable refresh churn.
-- `PatchedSnapshot_IgnoresUiManeuverNodes` - fails if a planned node truncates finalization or becomes terminal data.
-- `BackgroundCache_OnRailsOrbitingClassifiesOrbiting` - fails if stable background orbiters become destroyed/unfinished.
-- `BackgroundCache_SuborbitalAtmosphericClassifiesDestroyed` - fails if falling boosters end as null/orbiting.
-- `CacheApply_MarksFilesDirtyWhenSidecarAlreadyFlushed` - fails if background finalization data is lost across scene load.
+The unit and integration suites cover:
+
+- cached tails append after the last real sample without overwriting or duplicating authored trajectory history
+- stale caches cannot shorten a recording by moving the terminal UT before the last real sample
+- active -> background transfer preserves the old focused recording cache
+- stale caches apply only when the consumer explicitly allows stale fallback and no live refresh is possible
+- stock atmospheric deletion forces `Destroyed` rather than `Orbiting`
+- stable coast avoids unnecessary refresh churn
+- planned UI maneuver nodes cannot truncate finalization or become terminal data
+- stable background/on-rails orbiters classify as `Orbiting`
+- falling atmospheric/suborbital background vessels classify as destroyed or degraded instead of null/orbiting
+- cache application marks sidecar data dirty/persistent when background finalization has already flushed files
 
 ### Integration Tests
 
 - Scene-exit finalization falls back to cache when `FlightGlobals` probe declines.
 - Manual commit after a background vessel unloads applies cache instead of a generic missing-vessel fallback.
 - Active crash path consumes cache after crash coalescer completion.
-- Background `OnBackgroundVesselWillDestroy` consumes cache and persists the updated sidecar.
+- Confirmed background destruction applies cache in `DeferredDestructionCheck` after `OnBackgroundVesselWillDestroy` refreshes/flushes and keeps the cache.
 - Debris TTL out-of-bubble path consumes cache before removing `BackgroundMap`.
 - Focus switch active -> background -> unload keeps one recording id and one cache.
 
@@ -383,13 +389,15 @@ The feature landed with headless unit/integration/log-assertion coverage plus in
 - Maneuver-node exclusion logs the node-free strategy used.
 - Background consume paths log aggregate counts instead of one noisy line per frame.
 
-### In-Game Runtime Tests
+### Runtime Canaries And Manual Checks
 
-- Booster separation in atmosphere: stage a controllable booster, fly away, let it unload/delete, commit, verify the booster recording has `Destroyed`, terminal UT beyond the last live sample, and a predicted tail.
-- Mun orbiter sibling: undock lander/orbiter, land the active lander, commit, verify the orbiter finalizes as `Orbiting`.
-- Scene exit mid-burn: exit during thrust, return to playback, verify ghost continues instead of freezing at the last sampled point.
-- Planned maneuver node ignored: create a maneuver node, do not burn, finalize, verify the committed tail follows real coast and does not stop at the node.
-- Focused crash: crash a focused vessel, commit through the destruction dialog path, verify the recording has a destroyed terminal and cache-extended endpoint.
+The `RecordingFinalization` in-game category currently has synthetic FLIGHT canaries for:
+
+- destroyed background cache trimming to stock deletion UT
+- stable background cache applying `Orbiting` to a missing vessel
+- non-scene active crash finalization consuming active cache before the destroyed fallback
+
+The gameplay checklist in [`dev/manual-testing/test-recording-finalization-cache.md`](dev/manual-testing/test-recording-finalization-cache.md) covers atmospheric booster unload/delete, stable background orbiters, scene exit mid-burn, planned maneuver-node ignoring, focused crash, log sweeps, and cadence calibration.
 
 ## Code Layout
 

--- a/docs/parsek-recording-finalization-design.md
+++ b/docs/parsek-recording-finalization-design.md
@@ -223,8 +223,8 @@ Refresh every 5 seconds while a recording has a live vessel reference, plus forc
 - go-on-rails or go-off-rails
 - vessel situation change
 - staging, undock, EVA, joint break, and part death
-- time-warp rate change
-- scene-exit finalization entry, before any fallback consumes stale data
+- time-warp rails/checkpoint boundaries
+- scene-exit/background-commit finalization entry, where fresh live finalization or background force-refresh runs before any fallback consumes stale data
 
 Refresh early-outs when the vessel state digest has not meaningfully changed. A stable coasting vacuum orbit does not need a new cache every 5 seconds if the orbit, body, situation, throttle state, and terminal result are unchanged.
 
@@ -351,7 +351,7 @@ Per-frame refresh checks must use rate-limited logs or aggregate summaries.
 
 ## Coverage Contract
 
-The feature landed with headless unit/integration/log-assertion coverage plus in-game runtime canaries. Future changes to this area must keep this coverage shape and add tests in the same commit as any behavior change.
+The feature landed with headless unit/integration/log-assertion coverage plus in-game runtime canaries. Future behavior changes should keep that coverage shape and follow the project testing rule.
 
 ### Unit Tests
 
@@ -391,7 +391,7 @@ The feature landed with headless unit/integration/log-assertion coverage plus in
 - Planned maneuver node ignored: create a maneuver node, do not burn, finalize, verify the committed tail follows real coast and does not stop at the node.
 - Focused crash: crash a focused vessel, commit through the destruction dialog path, verify the recording has a destroyed terminal and cache-extended endpoint.
 
-## Implementation Notes
+## Code Layout
 
 The completed phase plan is archived in [`dev/done/plans/recording-finalization-reliability.md`](dev/done/plans/recording-finalization-reliability.md). The landed code is split across these responsibilities:
 


### PR DESCRIPTION
## Summary
- Reframe the recording-finalization reliability design as shipped baseline behavior.
- Update the landed implementation audit, cache data model, maneuver-node behavior, coverage contract, and implementation notes.
- Point related links at archived done plans and the manual validation checklist.

## Validation
- git diff --check
- git diff --cached --check before commit
- Docs-only change; no dotnet tests run.