### PR TITLE
Shorten Re-Fly merge dialog buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ All notable changes to Parsek are documented here.
 ### Enhancements
 
 - Tracking Station ghost actions now use the same native KSP popup as the flight map-view ghost menu. The popup opens from ghost icon and atmospheric marker clicks, shows compact Name / Recording / End-state status, and the Materialize button can fast-forward to the endpoint when needed while keeping the stock vessel list in sync.
-- The "Merge to Timeline / Discard" tree-recording confirmation dialog now appears while the player is still in flight, before the destination scene loads. Quit-to-Main-Menu shows the dialog too (previously force-auto-merged). Re-Fly sessions show Re-Fly-attempt-scoped button labels and a session-scoped body. Stock danger / quit confirmations still run first.
+- The "Merge to Timeline / Discard" tree-recording confirmation dialog now appears while the player is still in flight, before the destination scene loads. Quit-to-Main-Menu shows the dialog too (previously force-auto-merged). Re-Fly sessions use the same short Merge / Discard button labels with a session-scoped body. Stock danger / quit confirmations still run first.
 - The Re-Fly merge confirmation dialog now announces auto-seal explicitly when a merge will permanently seal the slot, and lists the player-attributable reason (transmitted science, undocked, docked with another vessel, etc.). Previously the dialog said the commit was permanent but did not distinguish auto-seal from a regular commit that left the slot re-flyable.
 
 ### Internals

--- a/Source/Parsek/MergeDialog.cs
+++ b/Source/Parsek/MergeDialog.cs
@@ -28,7 +28,7 @@ namespace Parsek
         {
             /// <summary>"Merge to Timeline" / "Discard"</summary>
             Default,
-            /// <summary>"Merge Re-Fly to Timeline" / "Discard Re-Fly attempt"</summary>
+            /// <summary>"Merge" / "Discard"</summary>
             ReFlyAttempt,
         }
 
@@ -283,8 +283,8 @@ namespace Parsek
             if (labels == MergeDialogButtonLabels.ReFlyAttempt)
             {
                 title = "Re-Fly attempt - leaving flight";
-                mergeLabel = "Merge Re-Fly to Timeline";
-                discardLabel = "Discard Re-Fly attempt";
+                mergeLabel = "Merge";
+                discardLabel = "Discard";
                 Recording reFlyRec = marker != null
                     ? FindReFlyRecording(marker, liveTree)
                     : null;

--- a/docs/dev/plans/merge-confirm-pretransition.md
+++ b/docs/dev/plans/merge-confirm-pretransition.md
@@ -37,7 +37,7 @@ warning popups (atmosphere / throttle / quit confirmation) must still run first.
 | Quit-to-Main-Menu | Show dialog (drop force-auto-merge) |
 | Tree finalize timing | Defer ALL finalize work to the dialog button callback (Opus pass-2/pass-3 redesign) |
 | Cancel button on regular dialog | None - click commits the player to leaving |
-| Re-Fly-aware dialog | Reuse `MergeDialog.ShowTreeDialog` with Re-Fly-attempt-scoped button labels and body copy (existing dialog already handles Re-Fly merge / discard correctly inside `MergeCommit` / `MergeDiscard`) |
+| Re-Fly-aware dialog | Reuse `MergeDialog.ShowTreeDialog` with the short Merge / Discard labels and Re-Fly-scoped body copy (existing dialog already handles Re-Fly merge / discard correctly inside `MergeCommit` / `MergeDiscard`) |
 | autoMerge ON + Re-Fly active | **Behaviour change**: previously this combination silent-auto-committed via `AutoCommitTreeGhostOnly` (`ParsekScenario.cs:1700-1716`) without invoking `TryCommitReFlySupersede`. The new pre-transition path always shows the Re-Fly dialog, routing through `MergeDialog.MergeCommit` -> `TryCommitReFlySupersede` for full supersede / tombstone semantics. This is a real change beyond UX timing: previously-silent commits now require a click. Documented as intentional - the silent path was arguably under-implementing the supersede contract. |
 | Stock KSP danger / quit confirmations | Must run first (see patch chokepoint below) |
 
@@ -691,8 +691,7 @@ construction.
   the new overload - implementer's choice; the labels enum carrying
   copy is the simpler option).
 - New `MergeDialogButtonLabels` enum: `Default` -> "Merge to
-  Timeline" / "Discard"; `ReFlyAttempt` -> "Merge Re-Fly to
-  Timeline" / "Discard Re-Fly attempt".
+  Timeline" / "Discard"; `ReFlyAttempt` -> "Merge" / "Discard".
 - Existing `OnDismiss -> ClearPendingFlag` path stays
   (`MergeDialog.cs:217-223`). No change needed.
 - New `ShowTreeDialog(RecordingTree liveTree, MergeDialogButtonLabels
@@ -1221,7 +1220,7 @@ Per `.claude/CLAUDE.md` "Documentation Updates - Per Commit, Not Per PR":
 
 - `CHANGELOG.md`: "Merge confirmation dialog now appears before leaving
   flight, not after the destination scene loads. Quit to Main Menu also
-  shows the dialog (previously force-auto-merged). Re-Fly sessions show
-  Re-Fly-attempt-scoped button labels on the same dialog."
+  shows the dialog (previously force-auto-merged). Re-Fly sessions use
+  the same short Merge / Discard labels on the same dialog."
 - `docs/dev/todo-and-known-bugs.md`: add the dialog-timing item if
   missing; mark closed once shipped.

--- a/docs/dev/plans/refly-autoseal-dialog-copy.md
+++ b/docs/dev/plans/refly-autoseal-dialog-copy.md
@@ -3,7 +3,7 @@
 ## Problem
 
 When the player ends a Re-Fly attempt at KSC / TS / Main Menu and clicks
-"Merge Re-Fly to Timeline" in the pre-transition merge dialog, a hidden
+"Merge" in the pre-transition merge dialog, a hidden
 policy decides whether the slot stays re-flyable or is **auto-sealed**
 (slot becomes immutable; the line of flight cannot be Re-Flown again).
 


### PR DESCRIPTION
## Summary
- Shorten the Re-Fly pre-transition merge dialog buttons from long attempt-specific copy to Merge / Discard.
- Update the changelog and design notes that referenced the old labels.

## Validation
- dotnet test Source\Parsek.Tests\Parsek.Tests.csproj - built and ran; 10,806 passed, SyntheticRecordingTests.InjectAllRecordings failed because running KSP has KSP.log locked. I did not close or kill KSP per process-safety rules.
- dotnet build Source\Parsek.Tests\Parsek.Tests.csproj --no-restore - passed; post-build deploy emitted locked-file warnings for the KSP GameData DLL/PDB/version files.