### PR TITLE
Fix pending-split destroyed capture finalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- Pending-split crashes now carry a late active-vessel destruction flag back into the stopped recorder's frozen capture before committing it. This prevents capsule water impacts that fire `OnVesselWillDestroy` after a chain-boundary stop from being appended as `destroyed=False` and then re-finalized as `Splashed` on scene exit, while keeping the pre-crash vessel snapshot for ghost geometry.
 - Debris ghosts no longer pop into place when playback starts inside a tiny gap between adjacent parent-section samples. New false-alarm resume seams also stay covered so future recordings avoid that gap.
 - Parent-anchored debris now disappears when its recorded parent path no longer covers the requested time, preventing stale debris from lingering after the recorded split has ended. Older debris without parent metadata keeps the previous compatibility path.
 

--- a/Source/Parsek.Tests/EffectiveLeafFinalizationTests.cs
+++ b/Source/Parsek.Tests/EffectiveLeafFinalizationTests.cs
@@ -232,6 +232,68 @@ namespace Parsek.Tests
                 l.Contains("from SubOrbital to Destroyed"));
         }
 
+        [Fact]
+        public void PendingSplitDestroyedCapture_AppendedActiveLeafBeatsLiveSplashedSceneExit()
+        {
+            var tree = new RecordingTree
+            {
+                Id = "tree-pending-split-crash",
+                TreeName = "Kerbal X",
+                RootRecordingId = "kerbal-x-root",
+                ActiveRecordingId = "kerbal-x-root"
+            };
+            var active = new Recording
+            {
+                RecordingId = tree.ActiveRecordingId,
+                TreeId = tree.Id,
+                VesselName = "Kerbal X",
+                VesselPersistentId = 2708531065
+            };
+            active.Points.Add(new TrajectoryPoint { ut = 410.2, altitude = 100.0, bodyName = "Kerbin" });
+            active.Points.Add(new TrajectoryPoint { ut = 434.2, altitude = 1200.0, bodyName = "Kerbin" });
+            tree.Recordings[active.RecordingId] = active;
+
+            var captured = new Recording
+            {
+                RecordingId = "stale-pending-split-capture",
+                VesselName = "Kerbal X",
+                VesselPersistentId = active.VesselPersistentId,
+                MaxDistanceFromLaunch = 7018.0,
+                EndBiome = "Water"
+            };
+            captured.Points.Add(new TrajectoryPoint { ut = 434.2, altitude = 1200.0, bodyName = "Kerbin" });
+            captured.Points.Add(new TrajectoryPoint { ut = 460.8, altitude = 0.0, bodyName = "Kerbin" });
+            var capturedSnapshot = new ConfigNode("VESSEL");
+            capturedSnapshot.AddValue("name", "Kerbal X");
+            captured.VesselSnapshot = capturedSnapshot;
+
+            Assert.True(ParsekFlight.ApplyPendingSplitDestructionToCapturedRecording(
+                captured,
+                vesselDestroyedDuringRecording: true,
+                source: "FallbackCommitSplitRecorder.entry"));
+            Assert.True(ParsekFlight.TryAppendCapturedToTree(tree, captured));
+            Assert.True(active.VesselDestroyed);
+            Assert.Equal(TerminalState.Destroyed, active.TerminalStateValue);
+            Assert.Same(capturedSnapshot, captured.VesselSnapshot);
+
+            Vessel liveSplashedVessel = TestVessel(
+                active.VesselPersistentId,
+                Vessel.Situations.SPLASHED);
+
+            ParsekFlight.FinalizeTreeRecordingsAfterFlush(
+                tree,
+                commitUT: 464.1,
+                isSceneExit: true,
+                resolveFinalizationCache: null,
+                findVesselByPid: pid => pid == active.VesselPersistentId ? liveSplashedVessel : null,
+                liveVesselAccess: TestLiveVesselAccess);
+
+            Assert.Equal(TerminalState.Destroyed, active.TerminalStateValue);
+            Assert.Contains(logLines, l =>
+                l.Contains("TryAppendCapturedToTree: appended 2 points") &&
+                l.Contains("destroyed=True"));
+        }
+
         [Theory]
         [InlineData(Vessel.Situations.LANDED, TerminalState.Landed)]
         [InlineData(Vessel.Situations.SPLASHED, TerminalState.Splashed)]

--- a/Source/Parsek.Tests/TryAppendCapturedToTreeTests.cs
+++ b/Source/Parsek.Tests/TryAppendCapturedToTreeTests.cs
@@ -182,6 +182,33 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void PendingSplitDestructionOverride_FlipsStaleCaptureAndKeepsSnapshot()
+        {
+            var captured = MakeCaptured(120.0, 180.0, destroyed: false);
+            captured.RecordingId = "late-capture";
+            captured.TerminalStateValue = TerminalState.Splashed;
+            var snapshot = new ConfigNode("VESSEL");
+            snapshot.AddValue("name", "Kerbal X");
+            captured.VesselSnapshot = snapshot;
+
+            bool changed = ParsekFlight.ApplyPendingSplitDestructionToCapturedRecording(
+                captured,
+                vesselDestroyedDuringRecording: true,
+                source: "FallbackCommitSplitRecorder.entry");
+
+            Assert.True(changed);
+            Assert.True(captured.VesselDestroyed);
+            Assert.Equal(TerminalState.Splashed, captured.TerminalStateValue);
+            Assert.Same(snapshot, captured.VesselSnapshot);
+            Assert.Contains(logLines, l =>
+                l.Contains("[Parsek][INFO][Flight]") &&
+                l.Contains("Pending split destruction override") &&
+                l.Contains("late-capture") &&
+                l.Contains("source=FallbackCommitSplitRecorder.entry") &&
+                l.Contains("priorTerminal=Splashed"));
+        }
+
+        [Fact]
         public void TreeMode_AppendsPartEventsAndOrbitSegments()
         {
             var tree = MakeTree("root-001");

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -3682,6 +3682,26 @@ namespace Parsek
             return true;
         }
 
+        internal static bool ApplyPendingSplitDestructionToCapturedRecording(
+            Recording captured,
+            bool vesselDestroyedDuringRecording,
+            string source)
+        {
+            if (captured == null || !vesselDestroyedDuringRecording)
+                return false;
+            if (captured.VesselDestroyed)
+                return false;
+
+            TerminalState? priorTerminal = captured.TerminalStateValue;
+            captured.VesselDestroyed = true;
+
+            ParsekLog.Info("Flight",
+                $"Pending split destruction override: capture='{captured.RecordingId ?? "(null)"}' " +
+                $"source={source ?? "(null)"} priorTerminal={priorTerminal?.ToString() ?? "null"} " +
+                $"points={captured.Points?.Count ?? 0} snapshot={captured.VesselSnapshot != null}");
+            return true;
+        }
+
         /// <summary>
         /// Tags the recording's SegmentPhase and SegmentBodyName based on the vessel's current
         /// body and altitude, if not already set. No-op if SegmentPhase is already non-empty
@@ -4292,6 +4312,10 @@ namespace Parsek
             if (splitRec?.CaptureAtStop == null) return;
 
             var captured = splitRec.CaptureAtStop;
+            ApplyPendingSplitDestructionToCapturedRecording(
+                captured,
+                splitRec.VesselDestroyedDuringRecording,
+                "FallbackCommitSplitRecorder.entry");
 
             // Bug #297: when in tree mode, append to the active tree recording
             // instead of orphaning data as a standalone recording.

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -91,6 +91,8 @@ The user's framing in their 2026-05-07 review was "if the capsule impact should 
 
 **Status:** OPEN 2026-05-07. Design choice required from the user before implementation.
 
+**Partial fix (2026-05-09):** `logs/2026-05-09_1135_radial-debris-diagnostics` exposed a narrower variant where `StopRecordingForChainBoundary` froze `CaptureAtStop` with `VesselDestroyed=false`, then `OnVesselWillDestroy` fired during the pending split before `FallbackCommitSplitRecorder` appended that stale capture. The pending-split fallback now bridges `FlightRecorder.VesselDestroyedDuringRecording` into the frozen capture's `VesselDestroyed` flag before tree append / standalone commit, so this explicit-destruction path persists the active capsule as `Destroyed` instead of letting scene-exit live-vessel finalization reclassify it as `Splashed`. The broader KSP water-impact lenience case remains open for recordings that never get an explicit destruction callback.
+
 ---
 
 ## Open - Splashed-on-ocean ghost mesh sinks below waterline during Watch playback


### PR DESCRIPTION
## Summary
- Bridge late pending-split destruction flags into the stopped recorder capture before tree append or standalone fallback commit.
- Preserve pre-crash snapshots while allowing the append path to persist Destroyed instead of scene-exit Splashed.
- Add regression coverage for the stale capture helper and live-SPLASHED finalization case; document the partial fix.

## Validation
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter TryAppendCapturedToTreeTests
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter EffectiveLeafFinalizationTests
- dotnet build Source/Parsek.Tests/Parsek.Tests.csproj --no-restore
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter "FullyQualifiedName!~SyntheticRecordingTests.InjectAllRecordings"

Unfiltered full suite was blocked by the local KSP install locking KSP.log / deployed files; per repo guidance I did not close or restart KSP. Build/test warnings are post-build GameData copy failures from that same local lock.

## Review
- GPT-5.5 xhigh agent review: no findings.
