### PR TITLE
Stop FX and audio for the whole decoupled subtree, not just the decoupler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- Decoupled subtrees no longer leave phantom engine/RCS audio playing on the parent ghost. When a stage decouples mid-playback the Decoupled event now stops FX and audio for every part in the decoupled subtree, not just the decoupler itself, so a watched capsule no longer keeps emitting the upper-stage rumble after the (now-debris) booster carrying that engine has hit the ground and exploded.
 - During an active Re-Fly, debris ghosts of the recording being re-flown stay hidden along with their parent. The session-suppressed-subtree closure now follows the v12 `DebrisParentRecordingId` ownership link only when the candidate's `ParentBranchPointId` resolves to a Breakup branch point owned by the re-flown recording, so destroyed parents with multiple breakup branch points propagate suppression to every breakup descendant while background-split anchor-only side-off debris stay visible.
 - Warp-exit and time-jump ledger recalculations now refresh Mission Control and Administration slot limits after the recalculation walk, so a facility upgrade in the same walk takes effect on availability. Facility tiers also migrate to a 1/2/3 ledger contract that translates back to KSP's zero-based level index.
 - Loading an earlier save no longer leaves future contract accepts, advances, completions, or penalties active.

--- a/Source/Parsek.Tests/DecoupledSubtreeAudioStopTests.cs
+++ b/Source/Parsek.Tests/DecoupledSubtreeAudioStopTests.cs
@@ -1,0 +1,130 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Regression tests for the phantom-engine-audio-after-decouple bug.
+    ///
+    /// When a decoupler fires mid-recording, KSP separates its entire subtree from
+    /// the parent vessel. The old playback path stopped FX/audio for ONLY the
+    /// decoupler's pid, so child engines/RCS in the decoupled subtree kept their
+    /// AudioGhostInfo / EngineGhostInfo / RcsGhostInfo entries on the parent ghost.
+    /// Audio sources had been reanchored to the ghost's cameraPivot at spawn (so
+    /// the per-frame visual hide via HidePartSubtree did NOT take them with it),
+    /// and the parent ghost kept playing the engine sound until it was destroyed.
+    /// In watch mode, the user heard the parent's "phantom" engine continuing past
+    /// the moment the (now-debris) ghost holding that same pid hit the ground and
+    /// exploded.
+    ///
+    /// These tests cover the pure subtree-walk side of the fix — the audio /
+    /// particle / emitter ECall side is Unity-only and is covered by an in-game
+    /// test in <c>RuntimeTests</c>.
+    /// </summary>
+    public class DecoupledSubtreeAudioStopTests
+    {
+        [Fact]
+        public void CollectSubtreePids_DecouplerWithEngineAndRcsChildren_ReturnsAllThree()
+        {
+            const uint decouplerPid = 100;
+            const uint enginePid = 200;
+            const uint rcsPid = 201;
+            var tree = new Dictionary<uint, List<uint>>
+            {
+                { decouplerPid, new List<uint> { enginePid, rcsPid } }
+            };
+
+            var pids = GhostPlaybackLogic.CollectSubtreePids(decouplerPid, tree);
+
+            Assert.Equal(3, pids.Count);
+            Assert.Contains(decouplerPid, pids);
+            Assert.Contains(enginePid, pids);
+            Assert.Contains(rcsPid, pids);
+        }
+
+        [Fact]
+        public void CollectSubtreePids_DeepSubtree_VisitsAllDescendants()
+        {
+            const uint decouplerPid = 100;
+            const uint stagePid = 150;
+            const uint enginePid = 200;
+            const uint nozzlePid = 250;
+            var tree = new Dictionary<uint, List<uint>>
+            {
+                { decouplerPid, new List<uint> { stagePid } },
+                { stagePid, new List<uint> { enginePid } },
+                { enginePid, new List<uint> { nozzlePid } }
+            };
+
+            var pids = GhostPlaybackLogic.CollectSubtreePids(decouplerPid, tree);
+
+            // Pre-fix single-pid stop would have left the deeply-nested engine
+            // and nozzle pids untouched.
+            Assert.Equal(4, pids.Count);
+            Assert.Contains(enginePid, pids);
+            Assert.Contains(nozzlePid, pids);
+        }
+
+        [Fact]
+        public void CollectSubtreePids_NullTree_ReturnsRootOnly()
+        {
+            var pids = GhostPlaybackLogic.CollectSubtreePids(rootPid: 100, tree: null);
+
+            // Matches HidePartSubtree's null-tree branch (single-part fallback).
+            Assert.Single(pids);
+            Assert.Equal(100u, pids[0]);
+        }
+
+        [Fact]
+        public void CollectSubtreePids_TreeMissingRootEntry_ReturnsRootOnly()
+        {
+            // A leaf decoupler whose pid doesn't appear as a key in the tree map
+            // (no children registered). Behaves like the null-tree fallback for
+            // that subtree.
+            var tree = new Dictionary<uint, List<uint>>
+            {
+                { 999, new List<uint> { 1000 } }  // unrelated entry
+            };
+
+            var pids = GhostPlaybackLogic.CollectSubtreePids(rootPid: 100, tree);
+
+            Assert.Single(pids);
+            Assert.Equal(100u, pids[0]);
+        }
+
+        [Fact]
+        public void CollectSubtreePids_TreeWithSiblingBranch_DoesNotCrossBranches()
+        {
+            // Tree shape:
+            //   root (1)
+            //   ├── decoupler (100)
+            //   │   └── engine (200)
+            //   └── unrelated (300)
+            //       └── tank (400)
+            // Walking from `decoupler` must not touch the unrelated branch.
+            var tree = new Dictionary<uint, List<uint>>
+            {
+                { 1, new List<uint> { 100, 300 } },
+                { 100, new List<uint> { 200 } },
+                { 300, new List<uint> { 400 } }
+            };
+
+            var pids = GhostPlaybackLogic.CollectSubtreePids(rootPid: 100, tree);
+
+            Assert.Equal(2, pids.Count);
+            Assert.Contains(100u, pids);
+            Assert.Contains(200u, pids);
+            Assert.DoesNotContain(300u, pids);
+            Assert.DoesNotContain(400u, pids);
+        }
+
+        [Fact]
+        public void StopFxAndAudioForSubtree_NullState_NoThrow()
+        {
+            // Null-state guard: the fast-path early-return must not enter the
+            // Unity-touching loop body. Other integration paths are covered in
+            // RuntimeTests.cs (Unity-runtime).
+            GhostPlaybackLogic.StopFxAndAudioForSubtree(state: null, rootPid: 100, tree: null);
+        }
+    }
+}

--- a/Source/Parsek/GhostPlaybackLogic.cs
+++ b/Source/Parsek/GhostPlaybackLogic.cs
@@ -2133,9 +2133,13 @@ namespace Parsek
             ref bool visibilityChanged,
             ref bool needsReentryMeshRebuild)
         {
-            StopEngineFxForPart(state, evt.partPersistentId);
-            StopRcsFxForPart(state, evt.partPersistentId);
-            StopAudioForPart(state, evt.partPersistentId);
+            // The decoupled subtree's parts are about to become a separate debris
+            // recording with its own AudioSources. The parent ghost's per-pid
+            // AudioGhostInfo / EngineGhostInfo / RcsGhostInfo entries for those parts
+            // would otherwise keep playing, because audio sources get reanchored to the
+            // ghost's cameraPivot at spawn (AttachGhostAudioToWatchPivot) — hiding the
+            // part visual no longer takes the audio with it. Walk the whole subtree.
+            StopFxAndAudioForSubtree(state, evt.partPersistentId, tree);
             ApplyHeatState(state, evt, HeatLevel.Cold);
             if (allowTransientEffects)
                 SpawnPartPuffAtPart(ghost, evt.partPersistentId);
@@ -2151,6 +2155,68 @@ namespace Parsek
             }
             visibilityChanged = true;
             needsReentryMeshRebuild = true;
+        }
+
+        /// <summary>
+        /// Walks the part-tree subtree rooted at <paramref name="rootPid"/> and returns
+        /// every pid reachable through it (root + descendants). Pure logic: no Unity
+        /// dependencies, safe to call from xUnit. If <paramref name="tree"/> is null
+        /// only the root pid is returned, matching HidePartSubtree's null-tree
+        /// fallback.
+        /// </summary>
+        internal static List<uint> CollectSubtreePids(
+            uint rootPid, Dictionary<uint, List<uint>> tree)
+        {
+            var result = new List<uint>();
+            var stack = new Stack<uint>();
+            stack.Push(rootPid);
+            while (stack.Count > 0)
+            {
+                uint pid = stack.Pop();
+                result.Add(pid);
+                if (tree == null) continue;
+                List<uint> children;
+                if (tree.TryGetValue(pid, out children))
+                {
+                    for (int i = 0; i < children.Count; i++)
+                        stack.Push(children[i]);
+                }
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Walks the part-tree subtree rooted at <paramref name="rootPid"/> and stops
+        /// engine FX, RCS FX, and ghost audio for every pid in the subtree. Used by
+        /// Decoupled events so the parent ghost's per-pid FX/audio entries for parts
+        /// that are physically gone (and now belong to a separate debris recording)
+        /// stop emitting on the parent. The single-pid Stop helpers were not enough:
+        /// HidePartSubtree hides every descendant of the decoupler, but FX and audio
+        /// dictionaries are keyed by part pid, so a child engine's plume/audio survived
+        /// the decouple and kept playing under the parent's cameraPivot until the
+        /// parent ghost itself was destroyed.
+        ///
+        /// Touches Unity APIs through the per-pid Stop helpers so it cannot be
+        /// invoked from xUnit (`System.Security.SecurityException : ECall methods
+        /// must be packaged into a system module.`). The pure-walk logic is exposed
+        /// via <see cref="CollectSubtreePids"/> for unit testing; the integrated
+        /// audio-stop behavior is covered by in-game tests.
+        /// </summary>
+        internal static void StopFxAndAudioForSubtree(
+            GhostPlaybackState state, uint rootPid, Dictionary<uint, List<uint>> tree)
+        {
+            if (state == null) return;
+            var pids = CollectSubtreePids(rootPid, tree);
+            for (int i = 0; i < pids.Count; i++)
+            {
+                StopEngineFxForPart(state, pids[i]);
+                StopRcsFxForPart(state, pids[i]);
+                StopAudioForPart(state, pids[i]);
+            }
+            if (pids.Count > 1)
+                ParsekLog.VerboseRateLimited("GhostAudio", $"subtree-fx-stop-{rootPid}",
+                    $"Stopped FX/audio for decoupled subtree rooted at pid={rootPid}: {pids.Count} pid(s)",
+                    5.0);
         }
 
         private static void ApplyDestroyedPartEvent(

--- a/Source/Parsek/InGameTests/RuntimeTests.cs
+++ b/Source/Parsek/InGameTests/RuntimeTests.cs
@@ -9888,6 +9888,62 @@ namespace Parsek.InGameTests
         }
 
         [InGameTest(Category = "GhostAudio", Scene = GameScenes.FLIGHT,
+            Description = "Phantom-engine-after-decouple regression: StopFxAndAudioForSubtree must stop a child engine's looping AudioSource on the parent ghost when the decoupler fires, not just the decoupler's own pid.")]
+        public IEnumerator StopFxAndAudioForSubtree_DecoupledChildEngineAudioStops()
+        {
+            const uint decouplerPid = 100;
+            const uint enginePid = 200;
+            ulong engineKey = FlightRecorder.EncodeEngineKey(enginePid, 0);
+
+            var engineGo = new GameObject("ParsekTest_DecoupledEngineAudio");
+            runner.TrackForCleanup(engineGo);
+            var engineSource = engineGo.AddComponent<AudioSource>();
+            engineSource.clip = AudioClip.Create("test_decoupled_engine", 44100, 1, 44100, false);
+            engineSource.loop = true;
+            engineSource.volume = 0f;
+            engineSource.Play();
+
+            yield return null;
+            InGameAssert.IsTrue(engineSource.isPlaying,
+                "Engine AudioSource should be playing before the decouple");
+
+            var state = new GhostPlaybackState
+            {
+                audioInfos = new Dictionary<ulong, AudioGhostInfo>
+                {
+                    {
+                        engineKey,
+                        new AudioGhostInfo
+                        {
+                            partPersistentId = enginePid,
+                            moduleIndex = 0,
+                            audioSource = engineSource,
+                            currentPower = 1f
+                        }
+                    }
+                },
+                partTree = new Dictionary<uint, List<uint>>
+                {
+                    { decouplerPid, new List<uint> { enginePid } }
+                }
+            };
+
+            GhostPlaybackLogic.StopFxAndAudioForSubtree(state, decouplerPid, state.partTree);
+            yield return null;
+
+            // Pre-fix: only decouplerPid's audio info would be processed, so the
+            // engine child's AudioSource would keep playing. Post-fix: subtree
+            // walk reaches the engine and StopAudioForPart stops it.
+            InGameAssert.IsFalse(engineSource.isPlaying,
+                "Engine AudioSource on a child of the decoupled subtree must be stopped, not just the decoupler's own pid");
+            InGameAssert.ApproxEqual(0f, state.audioInfos[engineKey].currentPower, 0.001f,
+                "Engine currentPower must be cleared by the subtree walk");
+
+            ParsekLog.Verbose("TestRunner",
+                "Phantom-engine-after-decouple regression: subtree walk stopped the child engine's AudioSource on decouple");
+        }
+
+        [InGameTest(Category = "GhostAudio", Scene = GameScenes.FLIGHT,
             Description = "#265: OneShotAudio pause/unpause path works")]
         public IEnumerator PauseUnpauseAudio_OneShotPath()
         {

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -11,6 +11,16 @@ When referencing prior item numbers from source comments or plans, consult the r
 
 ---
 
+## Done - v0.9.2 phantom engine audio after decouple
+
+- ~~In watch mode, after a stage decoupled mid-recording the parent ghost kept emitting the upper-stage engine sound — even after the (now-debris) subtree carrying that engine had hit the ground / water and exploded.~~ Reproduced by `logs/2026-05-10_1014_watch-engine-sound-after-explosion`. User watched Kerbal X #0 (parent capsule, no engines visible). Engine `pid=2032658568` (`liquidEngine2-2.v2`, upper stage) ignited at 10:10:22.104, decoupled into debris ghost #9 at 10:10:24.807, which fell and exploded at 10:10:42.324 muting only its own audio. The parent's matching audio source kept playing for ~10s longer, until the chain transition at 10:10:52.053 finally tore it down (`Cleanup: stopped 1 audio source(s) for 'Kerbal X'`). Root cause in `GhostPlaybackLogic.ApplyDecoupledPartEvent`: `HidePartSubtree` walks the entire subtree below the decoupler and `SetActive(false)`s every descendant, but `StopEngineFxForPart` / `StopRcsFxForPart` / `StopAudioForPart` were called only on the decoupler's own pid. Audio sources had been reanchored to the ghost's `cameraPivot` at spawn (`AttachGhostAudioToWatchPivot`), so hiding the part visual no longer took the audio with it — the parent's `state.audioInfos[engineKey]` survived with `currentPower > 0` and kept emitting through `cameraPivot`.
+
+**Fix:** Added `StopFxAndAudioForSubtree` in `GhostPlaybackLogic.cs` that walks the same subtree as `HidePartSubtree` (stack-based, uses `state.partTree`) and calls the per-pid `StopEngineFxForPart` / `StopRcsFxForPart` / `StopAudioForPart` for every pid in the subtree. `ApplyDecoupledPartEvent` replaces its three single-pid stop calls with one call to the new helper. The null-tree fallback walks only the root pid, matching `HidePartSubtree`'s null-tree branch. A `[GhostAudio] Stopped FX/audio for decoupled subtree rooted at pid=...` summary log fires when the walk visits more than one pid.
+
+**Coverage:** `DecoupledSubtreeAudioStopTests` covers the engine + RCS child case, deep grandchild walks, the null-tree fallback, the null-state guard, the single-pid no-summary case, and a regression-shape test that pins the pre-fix single-pid stop did not clear engine power.
+
+---
+
 ## Done - v0.9.2 Re-Fly settle anchor jump
 
 - ~~After Re-Fly load, anchor-dependent ghosts could jump by hundreds of metres for one frame while KSP's floating origin and Krakensbane frames settled.~~ The recorder already held new trajectory samples during the post-load settle window, but playback continued to render old ghosts through the same origin shift.

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -17,7 +17,7 @@ When referencing prior item numbers from source comments or plans, consult the r
 
 **Fix:** Added `StopFxAndAudioForSubtree` in `GhostPlaybackLogic.cs` that walks the same subtree as `HidePartSubtree` (stack-based, uses `state.partTree`) and calls the per-pid `StopEngineFxForPart` / `StopRcsFxForPart` / `StopAudioForPart` for every pid in the subtree. `ApplyDecoupledPartEvent` replaces its three single-pid stop calls with one call to the new helper. The null-tree fallback walks only the root pid, matching `HidePartSubtree`'s null-tree branch. A `[GhostAudio] Stopped FX/audio for decoupled subtree rooted at pid=...` summary log fires when the walk visits more than one pid.
 
-**Coverage:** `DecoupledSubtreeAudioStopTests` covers the engine + RCS child case, deep grandchild walks, the null-tree fallback, the null-state guard, the single-pid no-summary case, and a regression-shape test that pins the pre-fix single-pid stop did not clear engine power.
+**Coverage:** `DecoupledSubtreeAudioStopTests` covers the pure subtree-walk side of the fix — `CollectSubtreePids_DecouplerWithEngineAndRcsChildren_ReturnsAllThree`, `CollectSubtreePids_DeepSubtree_VisitsAllDescendants`, `CollectSubtreePids_NullTree_ReturnsRootOnly`, `CollectSubtreePids_TreeMissingRootEntry_ReturnsRootOnly`, `CollectSubtreePids_TreeWithSiblingBranch_DoesNotCrossBranches`, and `StopFxAndAudioForSubtree_NullState_NoThrow`. The integrated audio-stop side is covered by the in-game test `StopFxAndAudioForSubtree_DecoupledChildEngineAudioStops` (real `AudioSource.Play()` on a child engine pid + decoupler subtree walk asserting `isPlaying == false` and `currentPower == 0`) — the per-pid Stop helpers reference Unity ECalls and cannot run from xUnit.
 
 ---
 


### PR DESCRIPTION
## Summary

- Decoupled-event playback path now walks the whole subtree below the decoupler when stopping engine FX, RCS FX, and ghost audio, instead of only the decoupler's own pid.
- Audio sources are reanchored to `cameraPivot` at spawn, so hiding the part visual no longer takes them with it. Only `MuteAllAudio`/`StopAudioForPart` actually stops the per-pid `AudioGhostInfo` — and those used to be called for one pid only on decouple.
- In watch mode this manifested as the parent capsule continuing to emit the upper-stage engine sound for ~10 s after the (now-debris) ghost holding that same engine pid had hit the ground and exploded. Reproduced by `logs/2026-05-10_1014_watch-engine-sound-after-explosion`.

## Approach

`GhostPlaybackLogic.ApplyDecoupledPartEvent` now calls a new `StopFxAndAudioForSubtree` that:
- Walks the same subtree as `HidePartSubtree` (stack-based, `state.partTree`).
- Calls per-pid `StopEngineFxForPart` / `StopRcsFxForPart` / `StopAudioForPart` for every pid.
- Falls back to root-only when `tree` is null (matches `HidePartSubtree`'s null-tree branch).
- Logs a single summary line via `VerboseRateLimited` when the walk visits more than one pid.

The pure walk is exposed as `CollectSubtreePids(rootPid, tree)` for unit testing because the per-pid stop helpers touch Unity ECalls (`AudioSource.isPlaying`, `ParticleSystem.Stop`) and cannot run from xUnit.

## Test plan

- [x] `dotnet test` — full suite passes (11197/11197).
- [x] `DecoupledSubtreeAudioStopTests` (new): engine + RCS children, deep grandchild walk, sibling-branch isolation, null-tree fallback, missing-root fallback, null-state guard.
- [x] `RuntimeTests.StopFxAndAudioForSubtree_DecoupledChildEngineAudioStops` (new in-game test): real `AudioSource.Play()` on a child engine pid, decoupler subtree walk, asserts `isPlaying == false` and `currentPower == 0` after.
- [ ] Manual flight playtest with the reproducing save: watch a Kerbal X chain with upper-stage decouple. Confirm the parent capsule no longer emits engine sound after debris hit ground.

## Docs

- `CHANGELOG.md` — bug-fix entry under 0.9.2.
- `docs/dev/todo-and-known-bugs.md` — `Done - v0.9.2 phantom engine audio after decouple` block with reproducing log path, root cause, fix shape, coverage list.