### PR TITLE
Fix relative exit distance logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- RELATIVE mode exit diagnostics now print `dist=unresolved` when the previous anchor cannot be resolved at a decouple boundary, instead of formatting the `double.MaxValue` sentinel as a real metres distance.
 - Decoupled subtrees no longer leave phantom engine/RCS audio playing on the parent ghost. When a stage decouples mid-playback the Decoupled event now stops FX and audio for every part in the decoupled subtree, not just the decoupler itself, so a watched capsule no longer keeps emitting the upper-stage rumble after the (now-debris) booster carrying that engine has hit the ground and exploded.
 - During an active Re-Fly, debris ghosts of the recording being re-flown stay hidden along with their parent. The session-suppressed-subtree closure now follows the v12 `DebrisParentRecordingId` ownership link only when the candidate's `ParentBranchPointId` resolves to a Breakup branch point owned by the re-flown recording, so destroyed parents with multiple breakup branch points propagate suppression to every breakup descendant while background-split anchor-only side-off debris stay visible.
 - Warp-exit and time-jump ledger recalculations now refresh Mission Control and Administration slot limits after the recalculation walk, so a facility upgrade in the same walk takes effect on availability. Facility tiers also migrate to a 1/2/3 ledger contract that translates back to KSP's zero-based level index.

--- a/Source/Parsek.Tests/FlightRecorderExtractedTests.cs
+++ b/Source/Parsek.Tests/FlightRecorderExtractedTests.cs
@@ -123,6 +123,42 @@ namespace Parsek.Tests
 
         #endregion
 
+        #region Relative anchor exit diagnostics
+
+        [Fact]
+        public void BuildRelativeModeExitedLogMessage_UnresolvedAnchor_LogsUnresolvedDistance()
+        {
+            string message = FlightRecorder.BuildRelativeModeExitedLogMessage(
+                "anchor-rec",
+                528453942u,
+                anchorFound: false,
+                distanceMeters: double.MaxValue,
+                vesselPid: 2708531065u);
+
+            Assert.Contains("RELATIVE mode exited", message);
+            Assert.Contains("previousAnchorRecordingId=anchor-rec", message);
+            Assert.Contains("diagnosticPid=528453942", message);
+            Assert.Contains("dist=unresolved", message);
+            Assert.Contains("vesselPid=2708531065", message);
+            Assert.Equal(
+                "dist=unresolved",
+                FlightRecorder.FormatRelativeExitDistanceFieldForLog(false, double.MaxValue));
+            Assert.DoesNotContain("179769313486232", message);
+            Assert.DoesNotContain("1.79e+308", message);
+        }
+
+        [Fact]
+        public void FormatRelativeExitDistanceForLog_FiniteAnchorDistance_FormatsMeters()
+        {
+            string distance = FlightRecorder.FormatRelativeExitDistanceForLog(
+                anchorFound: true,
+                distanceMeters: 4.06);
+
+            Assert.Equal("4.1m", distance);
+        }
+
+        #endregion
+
         #region Re-Fly post-load settle gate
 
         [Fact]

--- a/Source/Parsek.Tests/FlightRecorderExtractedTests.cs
+++ b/Source/Parsek.Tests/FlightRecorderExtractedTests.cs
@@ -153,8 +153,19 @@ namespace Parsek.Tests
             string distance = FlightRecorder.FormatRelativeExitDistanceForLog(
                 anchorFound: true,
                 distanceMeters: 4.06);
+            string message = FlightRecorder.BuildRelativeModeExitedLogMessage(
+                previousAnchorRecordingId: null,
+                diagnosticPid: 528453942u,
+                anchorFound: true,
+                distanceMeters: 4.06,
+                vesselPid: 2708531065u);
 
             Assert.Equal("4.1m", distance);
+            Assert.Equal(
+                "dist=4.1m",
+                FlightRecorder.FormatRelativeExitDistanceFieldForLog(true, 4.06));
+            Assert.Contains("dist=4.1m", message);
+            Assert.DoesNotContain("dist=unresolved", message);
         }
 
         #endregion

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -5474,6 +5474,45 @@ namespace Parsek
                 situation: situation);
         }
 
+        internal static string FormatRelativeExitDistanceForLog(
+            bool anchorFound,
+            double distanceMeters)
+        {
+            if (!anchorFound
+                || double.IsNaN(distanceMeters)
+                || double.IsInfinity(distanceMeters)
+                || distanceMeters < 0.0
+                || distanceMeters == double.MaxValue)
+            {
+                return "unresolved";
+            }
+
+            return distanceMeters.ToString("F1", CultureInfo.InvariantCulture) + "m";
+        }
+
+        internal static string FormatRelativeExitDistanceFieldForLog(
+            bool anchorFound,
+            double distanceMeters)
+        {
+            string distance = FormatRelativeExitDistanceForLog(anchorFound, distanceMeters);
+            return distance == "unresolved"
+                ? "dist=unresolved"
+                : "dist=" + distance;
+        }
+
+        internal static string BuildRelativeModeExitedLogMessage(
+            string previousAnchorRecordingId,
+            uint diagnosticPid,
+            bool anchorFound,
+            double distanceMeters,
+            uint vesselPid)
+        {
+            return $"RELATIVE mode exited: previousAnchorRecordingId={previousAnchorRecordingId ?? "(none)"} " +
+                   $"diagnosticPid={diagnosticPid} " +
+                   $"{FormatRelativeExitDistanceFieldForLog(anchorFound, distanceMeters)} " +
+                   $"vesselPid={vesselPid}";
+        }
+
         private void UpdateAnchorDetection(Vessel v)
         {
             // Skip anchor detection while on the surface — RELATIVE mode is for orbital
@@ -5490,7 +5529,6 @@ namespace Parsek
                 // skipped frames, so last recorded point could be far from here.
                 double boundaryUT = Planetarium.GetUniversalTime();
                 SamplePositionAtUT(v, boundaryUT);
-                var ic = CultureInfo.InvariantCulture;
                 string oldAnchorRecordingId = currentAnchorRecordingId;
                 uint oldAnchorPid = currentAnchorPid;
                 isRelativeMode = false;
@@ -5590,7 +5628,6 @@ namespace Parsek
                     // skipped frames, so last recorded point could be far from here.
                     double boundaryUT = Planetarium.GetUniversalTime();
                     SamplePositionAtUT(v, boundaryUT);
-                    var ic = CultureInfo.InvariantCulture;
                     string oldAnchorRecordingId = currentAnchorRecordingId;
                     uint oldAnchorPid = currentAnchorPid;
                     if (!result.found)
@@ -5609,10 +5646,12 @@ namespace Parsek
                     ActivateHighFidelitySampling(boundaryUT, "relative-exit");
                     AppendSectionStartSeamPoint(v, boundaryUT, "relative-exit-distance");
                     ParsekLog.Info("Anchor",
-                        $"RELATIVE mode exited: previousAnchorRecordingId={oldAnchorRecordingId ?? "(none)"} " +
-                        $"diagnosticPid={oldAnchorPid} " +
-                        $"dist={(result.found ? result.distance : double.MaxValue).ToString("F1", ic)}m " +
-                        $"vesselPid={RecordingVesselId}");
+                        BuildRelativeModeExitedLogMessage(
+                            oldAnchorRecordingId,
+                            oldAnchorPid,
+                            result.found,
+                            result.distance,
+                            RecordingVesselId));
                 }
             }
         }

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -789,11 +789,13 @@ Coverage: two new in-game tests — `MergeNonFocusReFlyToOrbitImmutableTest` (au
 
 ---
 
-## TODO - Relative frame decouple distance overflow
+## Done - Relative frame decouple distance overflow
 
 - `logs/2026-05-01_1545_optimizer-merge-investigation/KSP.log` logged `RELATIVE mode exited` with `dist=1.79e+308m` immediately after the decouple at UT 279.53. This did not affect the reported playback because the chain was classified Absolute by the time it played, but the double.MaxValue-like displacement points to a degenerate relative-frame distance calculation at the decouple boundary.
 
-**Status:** OPEN.
+**Fix:** RELATIVE exit diagnostics now render unresolved anchor distances as `dist=unresolved` instead of formatting the `double.MaxValue` sentinel as metres.
+
+**Status:** DONE.
 
 ---
 


### PR DESCRIPTION
Summary: Render unresolved RELATIVE exit distances as dist=unresolved instead of formatting double.MaxValue at decouple boundaries. Tests: dotnet test from Source/Parsek.Tests; deployed DLL verified with ilspycmd.