### PR TITLE
Skip deferred merge dialog while a Re-Fly session is active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- The deferred merge-dialog fallback that fires when `SceneExitInterceptor`'s pre-transition prefix misses a FLIGHT->non-FLIGHT transition (mod compat, KSP version drift, foreign LoadScene patch) now skips when an active Re-Fly session owns the pending tree. Mirrors the OnFlightReady fallback guard so the same shape of leak does not reach the deferred coroutine path.
 - Planted flags now survive Re-Fly. The post-load strip used to delete flag vessels along with other unmatched siblings, silently erasing the FlagPlant career milestone; the stripper now preserves any `VesselType.Flag` vessel regardless of slot-map membership.
 - Re-Fly now re-spawns prior-committed sibling vessels (e.g. a landed capsule from an earlier mission) at their terminal endpoint instead of leaving them permanently un-materialized after the Re-Fly load strip removes them from the save.
 - Re-Fly fork ghosts no longer flame their booster engines at full throttle when the recorded engine was shut down. Chain-promotion seed emission now scopes narrowly to engine sentinels, fires only when the active recording lacks any engine events, and anchors the sentinel UT at the recording's StartUT when the recording has real trajectory data (including sandbox-epoch starts at UT 0) and current UT for genuinely fresh forks, so the ghost playback orphan-engine heuristic stays correct without poisoning boring-tail trim.

--- a/Source/Parsek.Tests/DeferredMergeDialogGuardTests.cs
+++ b/Source/Parsek.Tests/DeferredMergeDialogGuardTests.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Unit tests for <see cref="ParsekScenario.ShouldShowDeferredMergeDialog"/>.
+    /// The deferred-merge-dialog fallback opens the tree merge dialog only when
+    /// there is a pending tree AND no active Re-Fly session owns it. Mirrors
+    /// <see cref="ParsekFlight.ShouldShowOnFlightReadyMergeDialog"/> (PR #839)
+    /// for the FLIGHT→non-FLIGHT exit fallback path that runs when
+    /// <c>SceneExitInterceptor</c>'s pre-transition prefix missed the scene
+    /// change (mod compat, KSP version drift, foreign LoadScene patch).
+    /// </summary>
+    [Collection("Sequential")]
+    public class DeferredMergeDialogGuardTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public DeferredMergeDialogGuardTests()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.VerboseOverrideForTesting = true;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+        }
+
+        [Fact]
+        public void NoPendingTree_ReturnsFalse()
+        {
+            Assert.False(ParsekScenario.ShouldShowDeferredMergeDialog(
+                hasPendingTree: false,
+                reFlySessionActive: false));
+        }
+
+        [Fact]
+        public void PendingTree_NoReFly_ReturnsTrue()
+        {
+            // Canonical fallback case: SceneExitInterceptor missed a
+            // FLIGHT→KSC/TS/MAINMENU transition outside any Re-Fly session,
+            // and the OnLoad fallback queued ShowDeferredMergeDialog. This
+            // is the only configuration that opens the dialog.
+            Assert.True(ParsekScenario.ShouldShowDeferredMergeDialog(
+                hasPendingTree: true,
+                reFlySessionActive: false));
+        }
+
+        [Fact]
+        public void PendingTree_ReFlySessionActive_ReturnsFalse()
+        {
+            // SceneExitInterceptor missed a FLIGHT→non-FLIGHT transition
+            // while a Re-Fly session was active. AtomicMarkerWrite attached
+            // a fresh fork to the pending tree, the session marker survived
+            // the transition, and the deferred coroutine resumed in the
+            // new scene. The merge decision belongs to the active Re-Fly
+            // session, not to this fallback.
+            Assert.False(ParsekScenario.ShouldShowDeferredMergeDialog(
+                hasPendingTree: true,
+                reFlySessionActive: true));
+        }
+
+        [Fact]
+        public void NoPendingTree_ReFlySessionActive_ReturnsFalse()
+        {
+            // Defense in depth: either skip reason is sufficient.
+            Assert.False(ParsekScenario.ShouldShowDeferredMergeDialog(
+                hasPendingTree: false,
+                reFlySessionActive: true));
+        }
+    }
+}

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -5157,6 +5157,31 @@ namespace Parsek
         #region Deferred Merge Dialog
 
         /// <summary>
+        /// Pure decision for the deferred-merge-dialog fallback (the
+        /// FLIGHT→non-FLIGHT exit fallback used when
+        /// <c>SceneExitInterceptor</c>'s pre-transition prefix missed the
+        /// scene change). Returns <c>true</c> when the dialog should be
+        /// shown: a pending tree exists AND no active Re-Fly session owns it.
+        ///
+        /// <para>
+        /// The Re-Fly guard mirrors
+        /// <see cref="ParsekFlight.ShouldShowOnFlightReadyMergeDialog"/>
+        /// (PR #839): when a Re-Fly attempt is in progress, the pending
+        /// tree has a freshly-attached fork and the merge decision belongs
+        /// to <c>SceneExitInterceptor</c>'s <c>ReFlyAttempt</c> dialog or
+        /// the post-attempt scene-exit dialog — not to this deferred
+        /// fallback that fires only when the pre-transition intercept
+        /// missed the transition.
+        /// </para>
+        /// </summary>
+        internal static bool ShouldShowDeferredMergeDialog(
+            bool hasPendingTree,
+            bool reFlySessionActive)
+        {
+            return hasPendingTree && !reFlySessionActive;
+        }
+
+        /// <summary>
         /// Shows the merge dialog after a short delay, allowing the scene to fully load.
         /// Used when autoMerge is off and the player leaves Flight with a pending recording.
         /// </summary>
@@ -5184,6 +5209,25 @@ namespace Parsek
             {
                 mergeDialogPending = false;
                 ParsekLog.Verbose("Scenario", "Deferred merge dialog: pending consumed during wait — aborting");
+                yield break;
+            }
+
+            // Re-Fly guard: mirrors the OnFlightReady fallback guard from
+            // PR #839 (ParsekFlight.ShouldShowOnFlightReadyMergeDialog). If
+            // the pre-transition intercept missed a FLIGHT→non-FLIGHT
+            // transition while a Re-Fly session was active, the marker is
+            // still set when this coroutine resumes; the new fork belongs
+            // to the active attempt and the merge decision is not ours to
+            // make here.
+            bool reFlySessionActive = IsReFlySessionActiveForQuickloadDiscard();
+            if (!ShouldShowDeferredMergeDialog(
+                    hasPendingTree: RecordingStore.HasPendingTree,
+                    reFlySessionActive: reFlySessionActive))
+            {
+                ParsekLog.Info("Scenario",
+                    $"Pending tree '{RecordingStore.PendingTree?.TreeName ?? "<unnamed>"}' reached deferred merge dialog — " +
+                    "skipping merge dialog: active Re-Fly session owns the pending tree (Retry/initial invoke)");
+                mergeDialogPending = false;
                 yield break;
             }
 

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -12,6 +12,20 @@ When referencing prior item numbers from source comments or plans, consult the r
 
 ---
 
+## Done - v0.9.2 Deferred merge-dialog fallback could leak a tree merge dialog over an active Re-Fly session
+
+- ~~PR #839 added a Re-Fly guard on the `OnFlightReady` fallback that opens the tree merge dialog when a pending tree leaks through to flight entry, gated on a new pure helper `ParsekFlight.ShouldShowOnFlightReadyMergeDialog(hasPendingTree, restoringActiveTree, reFlySessionActive)` consulting `ParsekScenario.IsReFlySessionActiveForQuickloadDiscard()`. The post-PR Opus review flagged the same shape of leak on the deferred-merge-dialog coroutine `ParsekScenario.ShowDeferredMergeDialog` (`ParsekScenario.cs:~5163`): it is the FLIGHT->non-FLIGHT exit fallback for when `SceneExitInterceptor`'s pre-transition `HighLogic.LoadScene` prefix misses the transition (mod compat, KSP version drift, foreign LoadScene patch). All three call sites in `ParsekScenario.OnLoad` (lines ~1862, ~1888, ~2211) are gated by `HighLogic.LoadedScene != GameScenes.FLIGHT`, which is exactly the missed FLIGHT->KSC/TS/MAINMENU case. During an active Re-Fly attempt the marker survives the scene change in the miss case, and `MergeDialog.ShowTreeDialog(RecordingStore.PendingTree)` would have fired over a tree owned by the active Re-Fly session.~~
+
+**Root cause:** Symmetric oversight with the OnFlightReady fallback in PR #839. The Re-Fly guard was added at the entry side (`OnFlightReady`) but not at the exit-side fallback (`ShowDeferredMergeDialog`).
+
+**Fix:** Added pure helper `ParsekScenario.ShouldShowDeferredMergeDialog(bool hasPendingTree, bool reFlySessionActive)` mirroring `ParsekFlight.ShouldShowOnFlightReadyMergeDialog`. The coroutine now consults `IsReFlySessionActiveForQuickloadDiscard()` after the 60-frame wait (right after the existing "pending consumed during wait" guard) and bails out with an Info skip line matching the OnFlightReady wording (`"Pending tree '<name>' reached deferred merge dialog — skipping merge dialog: active Re-Fly session owns the pending tree (Retry/initial invoke)"`), clearing `mergeDialogPending` so subsequent dispatches are not blocked.
+
+**Coverage:** `DeferredMergeDialogGuardTests` covers the four-quadrant truth table for the pure helper (`NoPendingTree`, `PendingTree_NoReFly`, `PendingTree_ReFlySessionActive`, `NoPendingTree_ReFlySessionActive`).
+
+**Status:** CLOSED 2026-05-13.
+
+---
+
 ## Done - v0.9.2 Re-Fly post-load strip silently deleted planted flag vessels
 
 - ~~After a player planted a flag during a recorded EVA, accepted the post-flight tree-merge dialog, and clicked Re-Fly on the Probe slot, the `PostLoadStripper.Strip` invocation deleted the flag vessel along with the other 11 unmatched sibling vessels (`vesselsBefore=13 kept=1 removed=12` in `logs/2026-05-13_2101_refly-spawn-investigation`). KSP stores planted flags as real save-level vessels of `VesselType.Flag`, and the strict-unmatched branch (enabled by `RewindInvoker.InvokeReFly`) does not consult vessel type — any vessel whose `persistentId` is not in `RewindPoint.PidSlotMap`/`RootPartPidMap` is killed via `Vessel.Die()`. Flags are not tracked by the Parsek recorder, so once stripped there is no recording-driven respawn path; the FlagPlant career milestone (a permanent player achievement) is silently destroyed.~~


### PR DESCRIPTION
## Summary

PR [#839](https://github.com/vl3c/Parsek/pull/839) added a Re-Fly guard on the `OnFlightReady` merge-dialog fallback. The post-PR Opus review flagged the same shape of leak on the symmetric **exit-side** fallback `ParsekScenario.ShowDeferredMergeDialog` (the coroutine the `OnLoad` fallback queues when `SceneExitInterceptor`'s pre-transition `HighLogic.LoadScene` prefix misses a FLIGHT->non-FLIGHT transition: mod compat, KSP version drift, foreign LoadScene patch).

All three call sites in `ParsekScenario.OnLoad` (`~1862` / `~1888` / `~2211`) are gated by `HighLogic.LoadedScene != GameScenes.FLIGHT`, which is exactly the missed FLIGHT->KSC/TS/MAINMENU case. In that miss case the Re-Fly marker survives the scene change (because the SceneExitInterceptor `ReFlyAttempt` dialog never fired), and the deferred coroutine would have opened `MergeDialog.ShowTreeDialog` over a pending tree owned by the active Re-Fly attempt.

- New pure helper `ParsekScenario.ShouldShowDeferredMergeDialog(hasPendingTree, reFlySessionActive)` mirrors `ParsekFlight.ShouldShowOnFlightReadyMergeDialog`.
- The coroutine now consults `IsReFlySessionActiveForQuickloadDiscard()` after the 60-frame wait (right after the existing "pending consumed during wait" guard) and bails with an Info skip line whose wording matches the OnFlightReady skip line. `mergeDialogPending` is cleared on the skip so subsequent dispatches are not blocked.
- xUnit `DeferredMergeDialogGuardTests` covers the four-quadrant truth table for the new helper.

## Test plan

- [x] `dotnet build Source/Parsek/Parsek.csproj` (0 warnings, 0 errors)
- [x] `dotnet test Source/Parsek.Tests/Parsek.Tests.csproj` (11590 passed, 0 failed)
- [x] `dotnet test --filter "FullyQualifiedName~DeferredMergeDialogGuardTests"` (4 passed)
- [ ] In-game smoke: not runnable without a live KSP repro of the SceneExitInterceptor-missed path; the pure helper truth table plus the existing OnFlightReady in-game test cover the parallel behavior.