### PR TITLE
Add cost warnings to diagnostics settings labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ All notable changes to Parsek are documented here.
 - Trajectory `.prec` reader now bounds every list-count int32 read from the file against the remaining stream size before any per-element loop or `List<T>` allocation. Corrupted counts -- including large-but-allocatable values like 100M that would previously succeed `new List<T>(count)`, consume hundreds of MB, and only fail far later mid-read -- are rejected up front with `InvalidDataException` carrying the bound-violation detail. Negative counts are similarly rejected at the same gate. This closes the OOM-allocation hazard that the post-probe payload validator's exception catch could not handle in time.
 - Current-magic sidecar probes now fail closed on malformed binary headers, and `InjectAllRecordings` explicitly excludes the frozen pre-reset `DefaultCareer` corpus until it is rebaked to v0/generation-1 files instead of copying unloadable legacy sidecars into runtime smoke saves.
 
+### UI
+
+- The "Ghost render tracing" diagnostics toggle (both the Parsek settings window and the stock difficulty-settings entry) now reads "Ghost render tracing (Warning: huge logs)" so the log-volume cost is visible before enabling it.
+- The readable sidecar mirrors toggle (both the Parsek settings window and the stock difficulty-settings entry) now carries a "(Warning: extra disk usage)" suffix so the on-disk cost is visible before enabling it.
+
 ---
 
 ## 0.9.2

--- a/Source/Parsek/ParsekSettings.cs
+++ b/Source/Parsek/ParsekSettings.cs
@@ -49,11 +49,11 @@ namespace Parsek
             toolTip = "When enabled, write detailed diagnostics to KSP.log (default for development)")]
         public bool verboseLogging = true;
 
-        [GameParameters.CustomParameterUI("Ghost render tracing",
+        [GameParameters.CustomParameterUI("Ghost render tracing (Warning: huge logs)",
             toolTip = "When enabled, write detailed per-ghost render placement diagnostics to KSP.log. Leave off for normal playtests.")]
         public bool ghostRenderTracing = false;
 
-        [GameParameters.CustomParameterUI("Readable sidecar mirrors",
+        [GameParameters.CustomParameterUI("Readable sidecar mirrors (Warning: extra disk usage)",
             toolTip = "When enabled, also write human-readable .txt mirrors of recording sidecars for debugging and binary/text comparison")]
         public bool writeReadableSidecarMirrors = true;
 

--- a/Source/Parsek/UI/SettingsWindowUI.cs
+++ b/Source/Parsek/UI/SettingsWindowUI.cs
@@ -420,7 +420,7 @@ namespace Parsek
             }
 
             bool ghostRenderTracing = GUILayout.Toggle(s.ghostRenderTracing,
-                new GUIContent(" Ghost render tracing",
+                new GUIContent(" Ghost render tracing (Warning: huge logs)",
                     "Write detailed per-ghost render placement diagnostics to KSP.log. Leave off unless investigating playback placement."));
             if (ghostRenderTracing != s.ghostRenderTracing)
             {
@@ -430,7 +430,7 @@ namespace Parsek
             }
 
             bool writeReadableSidecarMirrors = GUILayout.Toggle(s.writeReadableSidecarMirrors,
-                new GUIContent(" Write readable sidecar mirrors",
+                new GUIContent(" Write readable sidecar mirrors (Warning: extra disk usage)",
                     "Also write human-readable .txt mirrors of .prec and snapshot sidecars for debugging and binary/text comparison"));
             if (writeReadableSidecarMirrors != s.writeReadableSidecarMirrors)
             {

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -240,7 +240,8 @@ Diagnostics:
 | Setting | Default | Description |
 |---------|---------|-------------|
 | Verbose logging | On | Write detailed diagnostics to `KSP.log` |
-| Write readable sidecar mirrors | On | Also write human-readable `.txt` mirrors alongside binary recording sidecars |
+| Ghost render tracing (Warning: huge logs) | Off | Write detailed per-ghost render placement diagnostics to `KSP.log` |
+| Write readable sidecar mirrors (Warning: extra disk usage) | On | Also write human-readable `.txt` mirrors alongside binary recording sidecars |
 | In-Game Test Runner | - | Opens the runtime-test window (same as Ctrl+Shift+T) |
 | Run Diagnostics Report | - | Dumps a full diagnostics snapshot to `KSP.log` |
 


### PR DESCRIPTION
## Summary

- "Ghost render tracing" toggle now reads **"Ghost render tracing (Warning: huge logs)"** — surfaces the log-volume cost before enabling.
- "Readable sidecar mirrors" toggle now reads **"... (Warning: extra disk usage)"** — surfaces the on-disk cost before enabling.
- Both settings exist in two UIs (the Parsek settings window and the stock difficulty-settings entry); both were updated for each.
- `Verbose logging` was intentionally left alone — it ships on as the development default, so a "huge logs" warning would conflict with that framing.

## Test plan

- [ ] Open the Parsek settings window → Diagnostics: both toggles show the new warning suffixes.
- [ ] Open stock difficulty settings → Parsek section: both entries show the new warning suffixes.
- [ ] Toggling either setting still persists and logs as before (label text only, no behavior change).


---
_Generated by [Claude Code](https://claude.ai/code/session_01T1yjKRDTWBuzyB4pDWYi15)_