### PR TITLE
Shorten Re-Fly merge/discard dialog descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ All notable changes to Parsek are documented here.
 
 - The "Ghost render tracing" diagnostics toggle (both the Parsek settings window and the stock difficulty-settings entry) now reads "Ghost render tracing (Warning: huge logs)" so the log-volume cost is visible before enabling it.
 - The readable sidecar mirrors toggle (both the Parsek settings window and the stock difficulty-settings entry) now carries a "(Warning: extra disk usage)" suffix so the on-disk cost is visible before enabling it.
-- Re-Fly merge/discard dialog descriptions are shorter. The pre-transition no-seal body and the post-transition body now read "Do you want to commit this Re-Fly attempt to the timeline? This cannot be undone later." The auto-seal body drops the slot/line-of-flight tail and ends at the reasons list.
+- Re-Fly merge/discard dialog descriptions are shorter. The pre-transition no-seal body and the post-transition body now read "Do you want to commit this Re-Fly attempt to the timeline?" — the "this cannot be undone" tail was dropped because an unsealed committed Re-Fly can still be replaced by another Re-Fly. The auto-seal body drops the slot/line-of-flight tail and ends at the reasons list.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ All notable changes to Parsek are documented here.
 
 - The "Ghost render tracing" diagnostics toggle (both the Parsek settings window and the stock difficulty-settings entry) now reads "Ghost render tracing (Warning: huge logs)" so the log-volume cost is visible before enabling it.
 - The readable sidecar mirrors toggle (both the Parsek settings window and the stock difficulty-settings entry) now carries a "(Warning: extra disk usage)" suffix so the on-disk cost is visible before enabling it.
-- Re-Fly merge/discard dialog descriptions are shorter. The pre-transition no-seal body and the post-transition body now read "Do you want to commit this Re-Fly attempt to the timeline?" — the "this cannot be undone" tail was dropped because an unsealed committed Re-Fly can still be replaced by another Re-Fly. The auto-seal body drops the slot/line-of-flight tail and ends at the reasons list.
+- Re-Fly merge/discard dialog descriptions are shorter. The no-seal and post-transition bodies now ask "Do you want to commit this Re-Fly attempt to the timeline?", and the auto-seal body trims to the reasons list followed by a brief "This cannot be undone" tail.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ All notable changes to Parsek are documented here.
 
 - The "Ghost render tracing" diagnostics toggle (both the Parsek settings window and the stock difficulty-settings entry) now reads "Ghost render tracing (Warning: huge logs)" so the log-volume cost is visible before enabling it.
 - The readable sidecar mirrors toggle (both the Parsek settings window and the stock difficulty-settings entry) now carries a "(Warning: extra disk usage)" suffix so the on-disk cost is visible before enabling it.
-- Re-Fly merge/discard dialog descriptions are shorter. The no-seal and post-transition bodies now ask "Do you want to commit this Re-Fly attempt to the timeline?", and the auto-seal body trims to the reasons list followed by a brief "This cannot be undone" tail.
+- Re-Fly merge/discard dialog descriptions are shorter. The no-seal body now asks "Do you want to commit this Re-Fly attempt to the timeline?", and the auto-seal body trims to the reasons list followed by a brief "This cannot be undone" tail; the deferred merge fallback shares the same preview-driven copy as the pre-transition dialog.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to Parsek are documented here.
 
 - The "Ghost render tracing" diagnostics toggle (both the Parsek settings window and the stock difficulty-settings entry) now reads "Ghost render tracing (Warning: huge logs)" so the log-volume cost is visible before enabling it.
 - The readable sidecar mirrors toggle (both the Parsek settings window and the stock difficulty-settings entry) now carries a "(Warning: extra disk usage)" suffix so the on-disk cost is visible before enabling it.
+- Re-Fly merge/discard dialog descriptions are shorter. The pre-transition no-seal body and the post-transition body now read "Do you want to commit this Re-Fly attempt to the timeline? This cannot be undone later." The auto-seal body drops the slot/line-of-flight tail and ends at the reasons list.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ All notable changes to Parsek are documented here.
 
 - The "Ghost render tracing" diagnostics toggle (both the Parsek settings window and the stock difficulty-settings entry) now reads "Ghost render tracing (Warning: huge logs)" so the log-volume cost is visible before enabling it.
 - The readable sidecar mirrors toggle (both the Parsek settings window and the stock difficulty-settings entry) now carries a "(Warning: extra disk usage)" suffix so the on-disk cost is visible before enabling it.
-- Re-Fly merge/discard dialog descriptions are shorter. The no-seal body now asks "Do you want to commit this Re-Fly attempt to the timeline?", and the auto-seal body trims to the reasons list followed by a brief "This cannot be undone" tail; the deferred merge fallback shares the same preview-driven copy as the pre-transition dialog.
+- Re-Fly merge/discard dialog descriptions are shorter. The no-seal body now asks "Do you want to commit this Re-Fly attempt to the timeline?", and the auto-seal body lists the reasons, explains that auto-seal makes the slot permanent (you cannot Re-Fly that line again), and warns "This cannot be undone" regardless of where the dialog appears.
 
 ### Bug Fixes
 

--- a/Source/Parsek.Tests/ReFlyAutoSealPreviewTests.cs
+++ b/Source/Parsek.Tests/ReFlyAutoSealPreviewTests.cs
@@ -447,9 +447,9 @@ namespace Parsek.Tests
             string body = MergeDialog.BuildReFlyDialogBody(
                 "TestVessel", 123.0, preview);
             Assert.Contains("TestVessel", body);
-            Assert.Contains("If not discarded, this Re-Fly attempt", body);
-            Assert.Contains("committed permanently to the timeline", body);
-            Assert.Contains("This cannot be undone", body);
+            Assert.Contains("Do you want to commit this Re-Fly attempt", body);
+            Assert.Contains("to the timeline", body);
+            Assert.Contains("This cannot be undone later", body);
             Assert.DoesNotContain("auto-sealed", body);
             Assert.DoesNotContain("for the following reason", body);
         }
@@ -469,10 +469,6 @@ namespace Parsek.Tests
             Assert.Contains("merged AND auto-sealed", body);
             Assert.Contains("for the following reason(s): transmitted science.",
                 body);
-            Assert.Contains("slot will become permanent", body);
-            Assert.Contains("not be able to Re-Fly this line of flight",
-                body);
-            Assert.Contains("This cannot be undone", body);
         }
 
         [Fact]

--- a/Source/Parsek.Tests/ReFlyAutoSealPreviewTests.cs
+++ b/Source/Parsek.Tests/ReFlyAutoSealPreviewTests.cs
@@ -505,21 +505,6 @@ namespace Parsek.Tests
             Assert.Contains("<align=\"center\">MyShip - ", body);
         }
 
-        // ---------- BuildPostTransitionReFlyMessage ---------------------
-
-        [Fact]
-        public void BuildPostTransitionReFlyMessage_AsksToCommit_NoUndoWarning()
-        {
-            string body = MergeDialog.BuildPostTransitionReFlyMessage(
-                "TestVessel", 123.0);
-            Assert.Contains("<align=\"center\">TestVessel - ", body);
-            Assert.Contains("Do you want to commit this Re-Fly attempt", body);
-            Assert.Contains("to the timeline", body);
-            Assert.DoesNotContain("cannot be undone", body);
-            Assert.DoesNotContain("permanently", body);
-            Assert.DoesNotContain("auto-sealed", body);
-        }
-
         // ---------- ShouldUseLiveVesselForReFlyTarget (pid match) -------
 
         [Fact]

--- a/Source/Parsek.Tests/ReFlyAutoSealPreviewTests.cs
+++ b/Source/Parsek.Tests/ReFlyAutoSealPreviewTests.cs
@@ -455,7 +455,7 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void BuildBody_AutoSeal_SingleReason_IncludesReasonAndSlotWarning()
+        public void BuildBody_AutoSeal_SingleReason_IncludesReasonAndUndoWarning()
         {
             var preview = new ReFlyAutoSealPreviewResult
             {
@@ -468,6 +468,10 @@ namespace Parsek.Tests
             Assert.Contains("If not discarded, this Re-Fly attempt", body);
             Assert.Contains("merged AND auto-sealed", body);
             Assert.Contains("for the following reason(s): transmitted science.",
+                body);
+            Assert.Contains("This cannot be undone", body);
+            Assert.DoesNotContain("slot will become permanent", body);
+            Assert.DoesNotContain("not be able to Re-Fly this line of flight",
                 body);
         }
 
@@ -499,6 +503,21 @@ namespace Parsek.Tests
             string body = MergeDialog.BuildReFlyDialogBody(
                 "MyShip", 65.0, preview);
             Assert.Contains("<align=\"center\">MyShip - ", body);
+        }
+
+        // ---------- BuildPostTransitionReFlyMessage ---------------------
+
+        [Fact]
+        public void BuildPostTransitionReFlyMessage_AsksToCommit_NoUndoWarning()
+        {
+            string body = MergeDialog.BuildPostTransitionReFlyMessage(
+                "TestVessel", 123.0);
+            Assert.Contains("<align=\"center\">TestVessel - ", body);
+            Assert.Contains("Do you want to commit this Re-Fly attempt", body);
+            Assert.Contains("to the timeline", body);
+            Assert.DoesNotContain("cannot be undone", body);
+            Assert.DoesNotContain("permanently", body);
+            Assert.DoesNotContain("auto-sealed", body);
         }
 
         // ---------- ShouldUseLiveVesselForReFlyTarget (pid match) -------

--- a/Source/Parsek.Tests/ReFlyAutoSealPreviewTests.cs
+++ b/Source/Parsek.Tests/ReFlyAutoSealPreviewTests.cs
@@ -336,6 +336,132 @@ namespace Parsek.Tests
             Assert.Equal(beforeCount, Ledger.Actions.Count);
         }
 
+        // ---------- Recorded-terminal classifier ------------------------
+        //
+        // Deferred merge fallback (ShowTreeDialog 1-arg overload) can fire
+        // in Space Center / Tracking Station with FlightGlobals.ActiveVessel
+        // null. The recorded-terminal classifier must surface the seal
+        // reason from Recording.TerminalStateValue so the dialog still
+        // warns "This cannot be undone" when production would seal.
+
+        [Fact]
+        public void Preview_RecordedTerminalLanded_NullVessel_FlagsLanded()
+        {
+            var rec = MakeRecording();
+            rec.TerminalStateValue = TerminalState.Landed;
+            var marker = MakeMarker();
+            MakeScenario(marker);
+
+            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null);
+
+            Assert.True(result.WillAutoSeal);
+            Assert.Contains(ReFlyAutoSealReason.Landed, result.Reasons);
+        }
+
+        [Fact]
+        public void Preview_RecordedTerminalSplashed_NullVessel_FlagsSplashedDown()
+        {
+            var rec = MakeRecording();
+            rec.TerminalStateValue = TerminalState.Splashed;
+            var marker = MakeMarker();
+            MakeScenario(marker);
+
+            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null);
+
+            Assert.True(result.WillAutoSeal);
+            Assert.Contains(ReFlyAutoSealReason.SplashedDown, result.Reasons);
+        }
+
+        [Fact]
+        public void Preview_RecordedTerminalOrbiting_NullVessel_FlagsStableOrbit()
+        {
+            var rec = MakeRecording();
+            rec.TerminalStateValue = TerminalState.Orbiting;
+            var marker = MakeMarker();
+            MakeScenario(marker);
+
+            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null);
+
+            Assert.True(result.WillAutoSeal);
+            Assert.Contains(ReFlyAutoSealReason.StableOrbit, result.Reasons);
+        }
+
+        [Fact]
+        public void Preview_RecordedTerminalSubOrbital_NullVessel_FlagsSubOrbitalArc()
+        {
+            var rec = MakeRecording();
+            rec.TerminalStateValue = TerminalState.SubOrbital;
+            var marker = MakeMarker();
+            MakeScenario(marker);
+
+            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null);
+
+            Assert.True(result.WillAutoSeal);
+            Assert.Contains(ReFlyAutoSealReason.SubOrbitalArc, result.Reasons);
+        }
+
+        [Fact]
+        public void Preview_RecordedTerminalDocked_NullVessel_FlagsDocked()
+        {
+            var rec = MakeRecording();
+            rec.TerminalStateValue = TerminalState.Docked;
+            var marker = MakeMarker();
+            MakeScenario(marker);
+
+            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null);
+
+            Assert.True(result.WillAutoSeal);
+            Assert.Contains(ReFlyAutoSealReason.DockedWithAnother, result.Reasons);
+        }
+
+        [Fact]
+        public void Preview_RecordedTerminalRecovered_NullVessel_FlagsRecovered()
+        {
+            var rec = MakeRecording();
+            rec.TerminalStateValue = TerminalState.Recovered;
+            var marker = MakeMarker();
+            MakeScenario(marker);
+
+            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null);
+
+            Assert.True(result.WillAutoSeal);
+            Assert.Contains(ReFlyAutoSealReason.VesselRecovered, result.Reasons);
+        }
+
+        [Fact]
+        public void Preview_RecordedTerminalDestroyed_DoesNotFlag()
+        {
+            // Destroyed routes through the "crashed" classifier reason and
+            // does NOT auto-seal; the Re-Fly retry-on-crash flow takes over.
+            // Preview must not surface a seal reason here.
+            var rec = MakeRecording();
+            rec.TerminalStateValue = TerminalState.Destroyed;
+            var marker = MakeMarker();
+            MakeScenario(marker);
+
+            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null);
+
+            Assert.False(result.WillAutoSeal);
+            Assert.Empty(result.Reasons);
+        }
+
+        [Fact]
+        public void Preview_NoTerminalSet_DoesNotFlagFromRecordedPath()
+        {
+            // Pre-transition: recording not yet finalized, TerminalStateValue
+            // is null. Recorded-terminal classifier must skip; only the
+            // live-vessel proxy (not exercised here, null vessel) would
+            // contribute terminal reasons.
+            var rec = MakeRecording();
+            Assert.Null(rec.TerminalStateValue);
+            var marker = MakeMarker();
+            MakeScenario(marker);
+
+            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null);
+
+            Assert.False(result.WillAutoSeal);
+        }
+
         // ---------- FormatHumanReadable standalone ----------------------
 
         [Fact]
@@ -351,6 +477,7 @@ namespace Parsek.Tests
                 { ReFlyAutoSealReason.PartBrokeOff, "broke off a part" },
                 { ReFlyAutoSealReason.VesselBrokeUp, "the vessel broke up" },
                 { ReFlyAutoSealReason.DockedWithAnother, "docked with another vessel" },
+                { ReFlyAutoSealReason.VesselRecovered, "the vessel was recovered" },
                 { ReFlyAutoSealReason.Landed, "landed" },
                 { ReFlyAutoSealReason.SplashedDown, "splashed down" },
                 { ReFlyAutoSealReason.StableOrbit, "reached a stable orbit" },

--- a/Source/Parsek.Tests/ReFlyAutoSealPreviewTests.cs
+++ b/Source/Parsek.Tests/ReFlyAutoSealPreviewTests.cs
@@ -483,6 +483,42 @@ namespace Parsek.Tests
             Assert.False(result.WillAutoSeal);
         }
 
+        // ---------- AddIfMissing dedup contract -------------------------
+        //
+        // Live-vessel and recorded-terminal classifiers both contribute to
+        // the same reasons list. AddIfMissing must ensure that a Landed
+        // recording with a Landed live vessel (or any other overlap) yields
+        // one reason entry, not two. The live-vessel side requires Unity
+        // runtime so we cannot stage the actual crossing in xUnit; pin the
+        // dedup helper directly instead.
+
+        [Fact]
+        public void AddIfMissing_DuplicateReason_DropsSecond()
+        {
+            var reasons = new List<ReFlyAutoSealReason>();
+            ReFlyAutoSealPreviewer.AddIfMissing(
+                reasons, ReFlyAutoSealReason.Landed);
+            ReFlyAutoSealPreviewer.AddIfMissing(
+                reasons, ReFlyAutoSealReason.Landed);
+
+            Assert.Single(reasons);
+            Assert.Equal(ReFlyAutoSealReason.Landed, reasons[0]);
+        }
+
+        [Fact]
+        public void AddIfMissing_DistinctReasons_AppendsBoth()
+        {
+            var reasons = new List<ReFlyAutoSealReason>();
+            ReFlyAutoSealPreviewer.AddIfMissing(
+                reasons, ReFlyAutoSealReason.Landed);
+            ReFlyAutoSealPreviewer.AddIfMissing(
+                reasons, ReFlyAutoSealReason.TransmittedScience);
+
+            Assert.Equal(2, reasons.Count);
+            Assert.Contains(ReFlyAutoSealReason.Landed, reasons);
+            Assert.Contains(ReFlyAutoSealReason.TransmittedScience, reasons);
+        }
+
         // ---------- FormatHumanReadable standalone ----------------------
 
         [Fact]
@@ -604,7 +640,7 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void BuildBody_AutoSeal_SingleReason_IncludesReasonAndUndoWarning()
+        public void BuildBody_AutoSeal_SingleReason_IncludesReasonConsequenceAndUndoWarning()
         {
             var preview = new ReFlyAutoSealPreviewResult
             {
@@ -618,10 +654,11 @@ namespace Parsek.Tests
             Assert.Contains("merged AND auto-sealed", body);
             Assert.Contains("for the following reason(s): transmitted science.",
                 body);
+            // Auto-seal jargon translation - tells the player what
+            // "auto-sealed" actually means in gameplay terms.
+            Assert.Contains("Auto-seal makes the slot permanent", body);
+            Assert.Contains("cannot Re-Fly this line again", body);
             Assert.Contains("This cannot be undone", body);
-            Assert.DoesNotContain("slot will become permanent", body);
-            Assert.DoesNotContain("not be able to Re-Fly this line of flight",
-                body);
         }
 
         [Fact]

--- a/Source/Parsek.Tests/ReFlyAutoSealPreviewTests.cs
+++ b/Source/Parsek.Tests/ReFlyAutoSealPreviewTests.cs
@@ -449,7 +449,7 @@ namespace Parsek.Tests
             Assert.Contains("TestVessel", body);
             Assert.Contains("Do you want to commit this Re-Fly attempt", body);
             Assert.Contains("to the timeline", body);
-            Assert.Contains("This cannot be undone later", body);
+            Assert.DoesNotContain("cannot be undone", body);
             Assert.DoesNotContain("auto-sealed", body);
             Assert.DoesNotContain("for the following reason", body);
         }

--- a/Source/Parsek.Tests/ReFlyAutoSealPreviewTests.cs
+++ b/Source/Parsek.Tests/ReFlyAutoSealPreviewTests.cs
@@ -429,6 +429,27 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void Preview_RecordedTerminalBoarded_NullVessel_FlagsBoarded()
+        {
+            // Production seals on Boarded via IsHardSafetyTerminal
+            // (SupersedeCommit:1052-1062). The structural classifier excludes
+            // BranchPointType.Board, and any upstream EVA BP that produced
+            // the kerbal recording typically sits in
+            // marker.PreSessionBranchPointIds (skipped by the structural
+            // scan). The recorded-terminal classifier is the only path that
+            // surfaces this seal reason in the preview.
+            var rec = MakeRecording();
+            rec.TerminalStateValue = TerminalState.Boarded;
+            var marker = MakeMarker();
+            MakeScenario(marker);
+
+            var result = ReFlyAutoSealPreviewer.Preview(rec, marker, null);
+
+            Assert.True(result.WillAutoSeal);
+            Assert.Contains(ReFlyAutoSealReason.KerbalBoarded, result.Reasons);
+        }
+
+        [Fact]
         public void Preview_RecordedTerminalDestroyed_DoesNotFlag()
         {
             // Destroyed routes through the "crashed" classifier reason and
@@ -478,6 +499,7 @@ namespace Parsek.Tests
                 { ReFlyAutoSealReason.VesselBrokeUp, "the vessel broke up" },
                 { ReFlyAutoSealReason.DockedWithAnother, "docked with another vessel" },
                 { ReFlyAutoSealReason.VesselRecovered, "the vessel was recovered" },
+                { ReFlyAutoSealReason.KerbalBoarded, "the kerbal boarded another vessel" },
                 { ReFlyAutoSealReason.Landed, "landed" },
                 { ReFlyAutoSealReason.SplashedDown, "splashed down" },
                 { ReFlyAutoSealReason.StableOrbit, "reached a stable orbit" },

--- a/Source/Parsek/MergeDialog.cs
+++ b/Source/Parsek/MergeDialog.cs
@@ -166,8 +166,7 @@ namespace Parsek
                     ? System.Math.Max(0.0, reFlyRec.EndUT - reFlyRec.StartUT)
                     : ComputeTreeDurationRange(tree);
                 message = $"<align=\"center\">{vesselLabel} - {FormatDuration(reFlyDuration)}</align>\n\n" +
-                          "<align=\"left\">Do you want to commit this Re-Fly attempt to the timeline? " +
-                          "This cannot be undone later.</align>";
+                          "<align=\"left\">Do you want to commit this Re-Fly attempt to the timeline?</align>";
             }
             else
             {
@@ -493,7 +492,7 @@ namespace Parsek
             {
                 return headline +
                     "<align=\"left\">Do you want to commit this Re-Fly attempt " +
-                    "to the timeline? This cannot be undone later.</align>";
+                    "to the timeline?</align>";
             }
 
             string reasons = preview.FormatHumanReadable();

--- a/Source/Parsek/MergeDialog.cs
+++ b/Source/Parsek/MergeDialog.cs
@@ -165,18 +165,9 @@ namespace Parsek
                 double reFlyDuration = reFlyRec != null
                     ? System.Math.Max(0.0, reFlyRec.EndUT - reFlyRec.StartUT)
                     : ComputeTreeDurationRange(tree);
-                // TMP rich-text alignment: center the headline (vessel name +
-                // re-flight duration), one blank line, then the warning text
-                // left-aligned. KSP's MultiOptionDialog body renders through
-                // TMP which honours the <align> tag; a one-line headline with
-                // a paragraph break before the body keeps the dialog short
-                // (per playtest feedback the long supersede paragraph that
-                // used to live here was confusing on the in-place
-                // continuation path and just plain wrong about
-                // ghost-of-retired-attempt / kerbal-deaths-reversed).
                 message = $"<align=\"center\">{vesselLabel} - {FormatDuration(reFlyDuration)}</align>\n\n" +
-                          "<align=\"left\">Commit this Re-Fly attempt permanently to the timeline. " +
-                          "This cannot be undone.</align>";
+                          "<align=\"left\">Do you want to commit this Re-Fly attempt to the timeline? " +
+                          "This cannot be undone later.</align>";
             }
             else
             {
@@ -498,26 +489,18 @@ namespace Parsek
         {
             string headline = $"<align=\"center\">{vesselLabel} - " +
                               $"{FormatDuration(reFlyDuration)}</align>\n\n";
-            // The "If not discarded" prefix reminds the player that
-            // Discard remains an option: discarding throws this attempt
-            // away and leaves the slot re-flyable for a future retry.
-            // Merge commits the attempt permanently (and seals the
-            // slot, when the auto-seal preview fires).
             if (!preview.WillAutoSeal)
             {
                 return headline +
-                    "<align=\"left\">If not discarded, this Re-Fly attempt " +
-                    "will be committed permanently to the timeline. This " +
-                    "cannot be undone.</align>";
+                    "<align=\"left\">Do you want to commit this Re-Fly attempt " +
+                    "to the timeline? This cannot be undone later.</align>";
             }
 
             string reasons = preview.FormatHumanReadable();
             return headline +
                 "<align=\"left\"><b>If not discarded, this Re-Fly attempt " +
                 $"will be merged AND auto-sealed</b> for the following " +
-                $"reason(s): {reasons}. The slot will become permanent and " +
-                "you will not be able to Re-Fly this line of flight again. " +
-                "This cannot be undone.</align>";
+                $"reason(s): {reasons}.</align>";
         }
 
         private static string FormatClearReason(string reason)

--- a/Source/Parsek/MergeDialog.cs
+++ b/Source/Parsek/MergeDialog.cs
@@ -145,26 +145,46 @@ namespace Parsek
             // Re-fly merge: a marker is active and the dialog is asking the
             // player to lock in the re-flight as the canonical entry. Show
             // the re-flight recording's own vessel name + duration (not the
-            // whole-tree summary used for ordinary tree merges) and a short
-            // question body. An unsealed committed Re-Fly remains re-
-            // rewindable so no "cannot be undone" tail is needed here; the
-            // pre-transition auto-seal path is the only branch that warns
-            // about permanence.
+            // whole-tree summary used for ordinary tree merges) and route
+            // the body through the same auto-seal preview the pre-transition
+            // path uses - this deferred fallback can still finalize via
+            // TryCommitReFlySupersede and auto-seal the slot Immutable, so
+            // the auto-seal copy + "cannot be undone" tail must appear here
+            // too when the preview classifies the attempt as sealable.
             var reFlyScenario = ParsekScenario.Instance;
             string message;
             if (!object.ReferenceEquals(null, reFlyScenario)
                 && reFlyScenario.ActiveReFlySessionMarker != null)
             {
-                Recording reFlyRec = FindReFlyRecording(
-                    reFlyScenario.ActiveReFlySessionMarker, tree);
+                var marker = reFlyScenario.ActiveReFlySessionMarker;
+                Recording reFlyRec = FindReFlyRecording(marker, tree);
                 string vesselLabel = reFlyRec != null
                     ? (reFlyRec.VesselName ?? tree.TreeName ?? "<unnamed>")
                     : (tree.TreeName ?? "<unnamed>");
                 double reFlyDuration = reFlyRec != null
                     ? System.Math.Max(0.0, reFlyRec.EndUT - reFlyRec.StartUT)
                     : ComputeTreeDurationRange(tree);
-                message = BuildPostTransitionReFlyMessage(
-                    vesselLabel, reFlyDuration);
+
+                // Preview.NoSeal is the safe fallback when reFlyRec is null
+                // (rec missing from the pending tree AND the committed list -
+                // FindReFlyRecording returned null). Preview's null-guard
+                // would also collapse to NoSeal but skipping the call avoids
+                // a CollectRecordingIdsForSafetyGate walk on a null. Live
+                // vessel may legitimately be null in Space Center / Tracking
+                // Station fallback - Preview tolerates it (skips the live-
+                // terminal reasons; science + structural reasons still fire).
+                ReFlyAutoSealPreviewResult preview = reFlyRec != null
+                    ? ReFlyAutoSealPreviewer.Preview(
+                        reFlyRec, marker, FlightGlobals.ActiveVessel)
+                    : ReFlyAutoSealPreviewResult.NoSeal();
+                message = BuildReFlyDialogBody(
+                    vesselLabel, reFlyDuration, preview);
+
+                ParsekLog.Info("MergeDialog",
+                    $"Re-Fly auto-seal preview (post-transition): " +
+                    $"willSeal={preview.WillAutoSeal} " +
+                    $"reasons=[{string.Join(",", preview.Reasons)}] " +
+                    $"sess={marker.SessionId ?? "<no-id>"}");
             }
             else
             {
@@ -470,12 +490,14 @@ namespace Parsek
             => ParsekTimeFormat.FormatDuration(seconds);
 
         /// <summary>
-        /// Composes the pre-transition Re-Fly merge dialog body. Pure
-        /// helper for unit-testability - the callable
-        /// <see cref="ShowTreeDialog"/> 4-arg overload spawns a
-        /// <see cref="PopupDialog"/> which requires Unity runtime, but
-        /// the body string itself is data-driven and worth pinning in
-        /// xUnit. Callers pass a precomputed
+        /// Composes the Re-Fly merge dialog body. Shared by the pre-
+        /// transition <see cref="ShowTreeDialog"/> 4-arg overload and the
+        /// deferred post-transition 1-arg overload - both paths can land
+        /// in <c>TryCommitReFlySupersede</c> and auto-seal, so both must
+        /// render the auto-seal warning when the preview classifies the
+        /// attempt as sealable. Pure helper for unit-testability: the
+        /// dialog spawn requires Unity runtime, but the body string is
+        /// data-driven. Callers pass a precomputed
         /// <see cref="ReFlyAutoSealPreviewResult"/>; this method only
         /// formats it.
         /// </summary>
@@ -501,21 +523,6 @@ namespace Parsek
                 "<align=\"left\"><b>If not discarded, this Re-Fly attempt " +
                 $"will be merged AND auto-sealed</b> for the following " +
                 $"reason(s): {reasons}. This cannot be undone.</align>";
-        }
-
-        /// <summary>
-        /// Composes the post-transition Re-Fly merge dialog body shown by
-        /// <see cref="ShowTreeDialog"/> once the Re-Fly marker is active.
-        /// Extracted for unit-testability - the dialog spawn requires Unity
-        /// but the body string itself is data-driven.
-        /// </summary>
-        internal static string BuildPostTransitionReFlyMessage(
-            string vesselLabel, double reFlyDuration)
-        {
-            return $"<align=\"center\">{vesselLabel} - " +
-                   $"{FormatDuration(reFlyDuration)}</align>\n\n" +
-                   "<align=\"left\">Do you want to commit this Re-Fly " +
-                   "attempt to the timeline?</align>";
         }
 
         private static string FormatClearReason(string reason)

--- a/Source/Parsek/MergeDialog.cs
+++ b/Source/Parsek/MergeDialog.cs
@@ -517,12 +517,21 @@ namespace Parsek
 
             string reasons = preview.FormatHumanReadable();
             // Auto-seal flips MergeState to Immutable and closes the rewind
-            // slot, so this branch *is* the irreversible one - keep a short
-            // terminal warning even though the no-seal branch dropped it.
+            // slot, so this branch *is* the irreversible one. Keep the
+            // short translation of what "auto-seal" means in player terms
+            // (the slot becomes permanent, the line of flight can no longer
+            // be Re-Flown) - dropping that sentence in the original trim
+            // left "auto-sealed" undefined for players unfamiliar with the
+            // term. Voice stays declarative ("If not discarded, ... will be
+            // ...") instead of matching the no-seal branch's question form;
+            // the "If not discarded" anchor signals that the Discard button
+            // is still the escape hatch and that asymmetry is intentional.
             return headline +
                 "<align=\"left\"><b>If not discarded, this Re-Fly attempt " +
                 $"will be merged AND auto-sealed</b> for the following " +
-                $"reason(s): {reasons}. This cannot be undone.</align>";
+                $"reason(s): {reasons}. Auto-seal makes the slot permanent " +
+                "and you cannot Re-Fly this line again. " +
+                "This cannot be undone.</align>";
         }
 
         private static string FormatClearReason(string reason)

--- a/Source/Parsek/MergeDialog.cs
+++ b/Source/Parsek/MergeDialog.cs
@@ -145,13 +145,11 @@ namespace Parsek
             // Re-fly merge: a marker is active and the dialog is asking the
             // player to lock in the re-flight as the canonical entry. Show
             // the re-flight recording's own vessel name + duration (not the
-            // whole-tree summary used for ordinary tree merges) and a one-
-            // line warning that the commit cannot be undone. The supersede
-            // / ghost-of-retired-attempt / kerbal-deaths-reversed paragraph
-            // we used to show was misleading on the in-place continuation
-            // path (no separate retired attempt exists, no ghost playback,
-            // tombstones not reversed in v1) so we drop the advisory and
-            // keep the dialog short and unambiguous instead.
+            // whole-tree summary used for ordinary tree merges) and a short
+            // question body. An unsealed committed Re-Fly remains re-
+            // rewindable so no "cannot be undone" tail is needed here; the
+            // pre-transition auto-seal path is the only branch that warns
+            // about permanence.
             var reFlyScenario = ParsekScenario.Instance;
             string message;
             if (!object.ReferenceEquals(null, reFlyScenario)
@@ -165,8 +163,8 @@ namespace Parsek
                 double reFlyDuration = reFlyRec != null
                     ? System.Math.Max(0.0, reFlyRec.EndUT - reFlyRec.StartUT)
                     : ComputeTreeDurationRange(tree);
-                message = $"<align=\"center\">{vesselLabel} - {FormatDuration(reFlyDuration)}</align>\n\n" +
-                          "<align=\"left\">Do you want to commit this Re-Fly attempt to the timeline?</align>";
+                message = BuildPostTransitionReFlyMessage(
+                    vesselLabel, reFlyDuration);
             }
             else
             {
@@ -496,10 +494,28 @@ namespace Parsek
             }
 
             string reasons = preview.FormatHumanReadable();
+            // Auto-seal flips MergeState to Immutable and closes the rewind
+            // slot, so this branch *is* the irreversible one - keep a short
+            // terminal warning even though the no-seal branch dropped it.
             return headline +
                 "<align=\"left\"><b>If not discarded, this Re-Fly attempt " +
                 $"will be merged AND auto-sealed</b> for the following " +
-                $"reason(s): {reasons}.</align>";
+                $"reason(s): {reasons}. This cannot be undone.</align>";
+        }
+
+        /// <summary>
+        /// Composes the post-transition Re-Fly merge dialog body shown by
+        /// <see cref="ShowTreeDialog"/> once the Re-Fly marker is active.
+        /// Extracted for unit-testability - the dialog spawn requires Unity
+        /// but the body string itself is data-driven.
+        /// </summary>
+        internal static string BuildPostTransitionReFlyMessage(
+            string vesselLabel, double reFlyDuration)
+        {
+            return $"<align=\"center\">{vesselLabel} - " +
+                   $"{FormatDuration(reFlyDuration)}</align>\n\n" +
+                   "<align=\"left\">Do you want to commit this Re-Fly " +
+                   "attempt to the timeline?</align>";
         }
 
         private static string FormatClearReason(string reason)

--- a/Source/Parsek/ReFlyAutoSealPreview.cs
+++ b/Source/Parsek/ReFlyAutoSealPreview.cs
@@ -5,18 +5,23 @@ using System.Text;
 namespace Parsek
 {
     /// <summary>
-    /// Pre-transition merge dialog (Re-Fly variant) preview of whether the
-    /// merge will trigger auto-seal of the slot, and the player-attributable
+    /// Re-Fly merge dialog (both the pre-transition 4-arg
+    /// <see cref="MergeDialog.ShowTreeDialog"/> overload and the deferred
+    /// post-transition 1-arg overload) preview of whether the merge will
+    /// trigger auto-seal of the slot, plus the player-attributable
     /// reason(s). Mirrors a subset of the production classifier in
-    /// <see cref="SupersedeCommit"/>: detects the cases that are reliable
-    /// from live state (Ledger.Actions for science, tree topology for
-    /// structural mutations, live <see cref="Vessel.Situations"/> for
-    /// stable terminals).
+    /// <see cref="SupersedeCommit"/>: detects the cases reachable from
+    /// the recording's own state - <c>Ledger.Actions</c> for science,
+    /// tree topology for structural mutations, the recording's
+    /// <c>TerminalStateValue</c> AND (when available) the live
+    /// <see cref="Vessel.Situations"/> for stable / hard-safety
+    /// terminals.
     ///
-    /// <para>Read-only and conservative: false negatives over false positives.
-    /// When the preview cannot determine seal, the dialog falls back to the
-    /// default "permanently to the timeline" copy. The production classifier
-    /// runs at finalize and seals correctly regardless of what the preview
+    /// <para>Read-only and conservative: false negatives over false
+    /// positives. When the preview cannot determine seal, the dialog
+    /// renders the no-seal copy ("Do you want to commit this Re-Fly
+    /// attempt to the timeline?"). The production classifier runs at
+    /// finalize and seals correctly regardless of what the preview
     /// said.</para>
     /// </summary>
     internal enum ReFlyAutoSealReason

--- a/Source/Parsek/ReFlyAutoSealPreview.cs
+++ b/Source/Parsek/ReFlyAutoSealPreview.cs
@@ -28,11 +28,12 @@ namespace Parsek
         KerbalEva,             // BranchPointType.EVA
         PartBrokeOff,          // BranchPointType.JointBreak
         VesselBrokeUp,         // BranchPointType.Breakup
-        DockedWithAnother,     // live vessel.situation == DOCKED -> IsHardSafetyTerminal
-        Landed,                // live vessel.situation == LANDED  -> stableTerminalFocusSlot
-        SplashedDown,          // live vessel.situation == SPLASHED -> stableTerminalFocusSlot
-        StableOrbit,           // live vessel.situation == ORBITING && PeR > atmosphere
-        SubOrbitalArc,         // live vessel.situation == SUB_ORBITAL or decaying ORBITING
+        DockedWithAnother,     // DOCKED situation (live) or TerminalState.Docked (recorded) -> IsHardSafetyTerminal
+        VesselRecovered,       // TerminalState.Recovered -> IsHardSafetyTerminal
+        Landed,                // LANDED situation (live) or TerminalState.Landed (recorded) -> stableTerminalFocusSlot
+        SplashedDown,          // SPLASHED situation (live) or TerminalState.Splashed (recorded) -> stableTerminalFocusSlot
+        StableOrbit,           // ORBITING situation && PeR > atmosphere (live) or TerminalState.Orbiting (recorded) -> stableTerminalFocusSlot
+        SubOrbitalArc,         // SUB_ORBITAL situation (live) or TerminalState.SubOrbital (recorded) -> stableTerminalFocusSlot
     }
 
     /// <summary>
@@ -106,6 +107,7 @@ namespace Parsek
                 case ReFlyAutoSealReason.PartBrokeOff:       return "broke off a part";
                 case ReFlyAutoSealReason.VesselBrokeUp:      return "the vessel broke up";
                 case ReFlyAutoSealReason.DockedWithAnother:  return "docked with another vessel";
+                case ReFlyAutoSealReason.VesselRecovered:    return "the vessel was recovered";
                 case ReFlyAutoSealReason.Landed:             return "landed";
                 case ReFlyAutoSealReason.SplashedDown:       return "splashed down";
                 case ReFlyAutoSealReason.StableOrbit:        return "reached a stable orbit";
@@ -185,6 +187,21 @@ namespace Parsek
                     ? liveActiveVessel
                     : null;
             CollectLiveVesselReasons(reFlyVessel, reasons);
+
+            // Recorded-terminal fallback. Production seals on the recording's
+            // own terminal via stableTerminalFocusSlot (Orbiting / SubOrbital
+            // / Landed / Splashed; UnfinishedFlightClassifier:241) and
+            // stableTerminal + IsHardSafetyTerminal (Recovered / Docked;
+            // SupersedeCommit:1017-1019, 1052-1062). The deferred merge
+            // fallback (ShowTreeDialog's 1-arg overload, fired in Space
+            // Center / Tracking Station / re-entered flight when the
+            // pre-transition dialog was missed) cannot rely on
+            // FlightGlobals.ActiveVessel for terminal signal, so derive the
+            // reason from the finalized recording too. In pre-transition the
+            // recording is still being produced so TerminalStateValue is
+            // typically null - the live-vessel proxy above is the source.
+            // Duplicates de-dup via AddIfMissing.
+            CollectRecordedTerminalReasons(liveProvisional, reasons);
 
             SortReasonsByGroup(reasons);
 
@@ -317,6 +334,44 @@ namespace Parsek
             }
         }
 
+        private static void CollectRecordedTerminalReasons(
+            Recording reFlyRec,
+            List<ReFlyAutoSealReason> reasons)
+        {
+            if (reFlyRec == null) return;
+            TerminalState? terminal = reFlyRec.TerminalStateValue;
+            if (!terminal.HasValue) return;
+            switch (terminal.Value)
+            {
+                case TerminalState.Landed:
+                    AddIfMissing(reasons, ReFlyAutoSealReason.Landed);
+                    break;
+                case TerminalState.Splashed:
+                    AddIfMissing(reasons, ReFlyAutoSealReason.SplashedDown);
+                    break;
+                case TerminalState.Orbiting:
+                    AddIfMissing(reasons, ReFlyAutoSealReason.StableOrbit);
+                    break;
+                case TerminalState.SubOrbital:
+                    AddIfMissing(reasons, ReFlyAutoSealReason.SubOrbitalArc);
+                    break;
+                case TerminalState.Docked:
+                    AddIfMissing(reasons, ReFlyAutoSealReason.DockedWithAnother);
+                    break;
+                case TerminalState.Recovered:
+                    AddIfMissing(reasons, ReFlyAutoSealReason.VesselRecovered);
+                    break;
+                // Destroyed: returns "crashed" earlier in the classifier (no
+                // seal here, the Re-Fly retry-on-crash flow takes over).
+                // Boarded: kerbal EVA recordings ending Boarded almost
+                // always share a structural KerbalEva reason via the parent
+                // tree's BranchPointType.EVA; the structural classifier
+                // covers that user-facing warning. A pure-Boarded recording
+                // with no upstream EVA structural row is rare and left to
+                // the production classifier's authoritative seal verdict.
+            }
+        }
+
         private static void AddIfMissing(
             List<ReFlyAutoSealReason> reasons, ReFlyAutoSealReason reason)
         {
@@ -334,7 +389,7 @@ namespace Parsek
         /// <list type="number">
         ///   <item><description>Science group: TransmittedScience, RecoveredScience, EarnedScience</description></item>
         ///   <item><description>Structural group: Undocked, KerbalEva, PartBrokeOff, VesselBrokeUp</description></item>
-        ///   <item><description>Live terminal group: DockedWithAnother, Landed, SplashedDown, StableOrbit, SubOrbitalArc</description></item>
+        ///   <item><description>Terminal group: DockedWithAnother, VesselRecovered, Landed, SplashedDown, StableOrbit, SubOrbitalArc</description></item>
         /// </list>
         /// </summary>
         private static void SortReasonsByGroup(List<ReFlyAutoSealReason> reasons)
@@ -354,6 +409,7 @@ namespace Parsek
                 case ReFlyAutoSealReason.PartBrokeOff:       return 220;
                 case ReFlyAutoSealReason.VesselBrokeUp:      return 230;
                 case ReFlyAutoSealReason.DockedWithAnother:  return 300;
+                case ReFlyAutoSealReason.VesselRecovered:    return 305;
                 case ReFlyAutoSealReason.Landed:             return 310;
                 case ReFlyAutoSealReason.SplashedDown:       return 320;
                 case ReFlyAutoSealReason.StableOrbit:        return 330;

--- a/Source/Parsek/ReFlyAutoSealPreview.cs
+++ b/Source/Parsek/ReFlyAutoSealPreview.cs
@@ -374,12 +374,24 @@ namespace Parsek
                     // skips it too. Map directly.
                     AddIfMissing(reasons, ReFlyAutoSealReason.KerbalBoarded);
                     break;
-                // Destroyed: returns "crashed" earlier in the classifier
-                // (no seal here, the Re-Fly retry-on-crash flow takes over).
+                // Destroyed: no seal here - the upstream Re-Fly
+                // retry-on-crash flow (UnfinishedFlightClassifier returns
+                // "crashed", SupersedeCommit short-circuits before
+                // IsHardSafetyTerminal) handles it outside this method.
             }
         }
 
-        private static void AddIfMissing(
+        /// <summary>
+        /// Append <paramref name="reason"/> to <paramref name="reasons"/>
+        /// only when it is not already present. Used to de-dup contributions
+        /// from the live-vessel proxy and the recorded-terminal classifier
+        /// when both fire for the same outcome (e.g. live vessel Landed +
+        /// recording's TerminalStateValue Landed = one Landed entry, not
+        /// two). Internal so the dedup contract can be pinned in xUnit
+        /// without needing a Unity live-vessel fake to exercise the
+        /// live+recorded crossing.
+        /// </summary>
+        internal static void AddIfMissing(
             List<ReFlyAutoSealReason> reasons, ReFlyAutoSealReason reason)
         {
             for (int i = 0; i < reasons.Count; i++)

--- a/Source/Parsek/ReFlyAutoSealPreview.cs
+++ b/Source/Parsek/ReFlyAutoSealPreview.cs
@@ -30,6 +30,7 @@ namespace Parsek
         VesselBrokeUp,         // BranchPointType.Breakup
         DockedWithAnother,     // DOCKED situation (live) or TerminalState.Docked (recorded) -> IsHardSafetyTerminal
         VesselRecovered,       // TerminalState.Recovered -> IsHardSafetyTerminal
+        KerbalBoarded,         // TerminalState.Boarded -> IsHardSafetyTerminal
         Landed,                // LANDED situation (live) or TerminalState.Landed (recorded) -> stableTerminalFocusSlot
         SplashedDown,          // SPLASHED situation (live) or TerminalState.Splashed (recorded) -> stableTerminalFocusSlot
         StableOrbit,           // ORBITING situation && PeR > atmosphere (live) or TerminalState.Orbiting (recorded) -> stableTerminalFocusSlot
@@ -108,6 +109,7 @@ namespace Parsek
                 case ReFlyAutoSealReason.VesselBrokeUp:      return "the vessel broke up";
                 case ReFlyAutoSealReason.DockedWithAnother:  return "docked with another vessel";
                 case ReFlyAutoSealReason.VesselRecovered:    return "the vessel was recovered";
+                case ReFlyAutoSealReason.KerbalBoarded:      return "the kerbal boarded another vessel";
                 case ReFlyAutoSealReason.Landed:             return "landed";
                 case ReFlyAutoSealReason.SplashedDown:       return "splashed down";
                 case ReFlyAutoSealReason.StableOrbit:        return "reached a stable orbit";
@@ -361,14 +363,19 @@ namespace Parsek
                 case TerminalState.Recovered:
                     AddIfMissing(reasons, ReFlyAutoSealReason.VesselRecovered);
                     break;
-                // Destroyed: returns "crashed" earlier in the classifier (no
-                // seal here, the Re-Fly retry-on-crash flow takes over).
-                // Boarded: kerbal EVA recordings ending Boarded almost
-                // always share a structural KerbalEva reason via the parent
-                // tree's BranchPointType.EVA; the structural classifier
-                // covers that user-facing warning. A pure-Boarded recording
-                // with no upstream EVA structural row is rare and left to
-                // the production classifier's authoritative seal verdict.
+                case TerminalState.Boarded:
+                    // Production seals on Boarded via IsHardSafetyTerminal
+                    // (SupersedeCommit:1052-1062). The structural classifier
+                    // cannot be relied on as a fallback here:
+                    // SupersedeCommit.IsStructuralBranchPointType excludes
+                    // BranchPointType.Board (and Dock), and the upstream EVA
+                    // BP that produced the kerbal recording is typically in
+                    // marker.PreSessionBranchPointIds so the structural scan
+                    // skips it too. Map directly.
+                    AddIfMissing(reasons, ReFlyAutoSealReason.KerbalBoarded);
+                    break;
+                // Destroyed: returns "crashed" earlier in the classifier
+                // (no seal here, the Re-Fly retry-on-crash flow takes over).
             }
         }
 
@@ -389,7 +396,7 @@ namespace Parsek
         /// <list type="number">
         ///   <item><description>Science group: TransmittedScience, RecoveredScience, EarnedScience</description></item>
         ///   <item><description>Structural group: Undocked, KerbalEva, PartBrokeOff, VesselBrokeUp</description></item>
-        ///   <item><description>Terminal group: DockedWithAnother, VesselRecovered, Landed, SplashedDown, StableOrbit, SubOrbitalArc</description></item>
+        ///   <item><description>Terminal group: DockedWithAnother, VesselRecovered, KerbalBoarded, Landed, SplashedDown, StableOrbit, SubOrbitalArc</description></item>
         /// </list>
         /// </summary>
         private static void SortReasonsByGroup(List<ReFlyAutoSealReason> reasons)
@@ -410,6 +417,7 @@ namespace Parsek
                 case ReFlyAutoSealReason.VesselBrokeUp:      return 230;
                 case ReFlyAutoSealReason.DockedWithAnother:  return 300;
                 case ReFlyAutoSealReason.VesselRecovered:    return 305;
+                case ReFlyAutoSealReason.KerbalBoarded:      return 307;
                 case ReFlyAutoSealReason.Landed:             return 310;
                 case ReFlyAutoSealReason.SplashedDown:       return 320;
                 case ReFlyAutoSealReason.StableOrbit:        return 330;


### PR DESCRIPTION
The post-transition body and the pre-transition no-seal body now ask
"Do you want to commit this Re-Fly attempt to the timeline? This
cannot be undone later." The auto-seal pre-transition body trims the
slot/line-of-flight tail and ends at the reasons list. Stale comments
that justified the previous wording are removed, and the asserting
unit tests are updated.