### PR TITLE
Normalize Re-Fly timeline dialog copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to Parsek are documented here.
 - The "Ghost render tracing" diagnostics toggle (both the Parsek settings window and the stock difficulty-settings entry) now reads "Ghost render tracing (Warning: huge logs)" so the log-volume cost is visible before enabling it.
 - The readable sidecar mirrors toggle (both the Parsek settings window and the stock difficulty-settings entry) now carries a "(Warning: extra disk usage)" suffix so the on-disk cost is visible before enabling it.
 - Re-Fly merge/discard dialog descriptions are shorter. The no-seal body now asks "Do you want to commit this Re-Fly attempt to the timeline?", and the auto-seal body lists each reason on its own dashed line, followed by the auto-seal explanation without a redundant undo warning.
-- Timeline dialog action buttons now distinguish permanent merges from still-re-flyable commits: regular recordings and auto-sealed Re-Fly attempts say "Merge to Timeline", while unsealed Re-Fly attempts say "Commit to Timeline".
+- Timeline dialog action buttons now distinguish permanent merges from still-re-flyable commits using the production merge-state classifier: regular recordings and auto-sealed Re-Fly attempts say "Merge to Timeline", while unsealed Re-Fly attempts say "Commit to Timeline". Deferred dialog titles follow the same Merge/Commit wording.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ All notable changes to Parsek are documented here.
 
 - The "Ghost render tracing" diagnostics toggle (both the Parsek settings window and the stock difficulty-settings entry) now reads "Ghost render tracing (Warning: huge logs)" so the log-volume cost is visible before enabling it.
 - The readable sidecar mirrors toggle (both the Parsek settings window and the stock difficulty-settings entry) now carries a "(Warning: extra disk usage)" suffix so the on-disk cost is visible before enabling it.
-- Re-Fly merge/discard dialog descriptions are shorter. The no-seal body now asks "Do you want to commit this Re-Fly attempt to the timeline?", and the auto-seal body lists the reasons, explains that auto-seal makes the slot permanent (you cannot Re-Fly that line again), and warns "This cannot be undone" regardless of where the dialog appears.
+- Re-Fly merge/discard dialog descriptions are shorter. The no-seal body now asks "Do you want to commit this Re-Fly attempt to the timeline?", and the auto-seal body lists each reason on its own dashed line, then keeps the auto-seal explanation and "This cannot be undone" warning together on one line regardless of where the dialog appears.
+- Timeline dialog action buttons now distinguish permanent merges from still-re-flyable commits: regular recordings and auto-sealed Re-Fly attempts say "Merge to Timeline", while unsealed Re-Fly attempts say "Commit to Timeline".
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ All notable changes to Parsek are documented here.
 
 - The "Ghost render tracing" diagnostics toggle (both the Parsek settings window and the stock difficulty-settings entry) now reads "Ghost render tracing (Warning: huge logs)" so the log-volume cost is visible before enabling it.
 - The readable sidecar mirrors toggle (both the Parsek settings window and the stock difficulty-settings entry) now carries a "(Warning: extra disk usage)" suffix so the on-disk cost is visible before enabling it.
-- Re-Fly merge/discard dialog descriptions are shorter. The no-seal body now asks "Do you want to commit this Re-Fly attempt to the timeline?", and the auto-seal body lists each reason on its own dashed line, then keeps the auto-seal explanation and "This cannot be undone" warning together on one line regardless of where the dialog appears.
+- Re-Fly merge/discard dialog descriptions are shorter. The no-seal body now asks "Do you want to commit this Re-Fly attempt to the timeline?", and the auto-seal body lists each reason on its own dashed line, followed by the auto-seal explanation without a redundant undo warning.
 - Timeline dialog action buttons now distinguish permanent merges from still-re-flyable commits: regular recordings and auto-sealed Re-Fly attempts say "Merge to Timeline", while unsealed Re-Fly attempts say "Commit to Timeline".
 
 ### Bug Fixes

--- a/Source/Parsek.Tests/ReFlyAutoSealPreviewTests.cs
+++ b/Source/Parsek.Tests/ReFlyAutoSealPreviewTests.cs
@@ -605,10 +605,9 @@ namespace Parsek.Tests
         [Fact]
         public void Format_MixedSubjectPhrases_StillReadsCleanly()
         {
-            // "the vessel broke up" is subject-led; under the colon-list
-            // form ("for the following reason(s): the vessel broke up
-            // and docked with another vessel.") the implicit subject of
-            // the second clause is "the vessel" too, which is fine.
+            // "the vessel broke up" is subject-led; callers that still use
+            // the sentence form get a readable implicit subject for the
+            // second clause too.
             var result = new ReFlyAutoSealPreviewResult
             {
                 WillAutoSeal = true,
@@ -624,6 +623,52 @@ namespace Parsek.Tests
         }
 
         // ---------- BuildReFlyDialogBody --------------------------------
+
+        [Fact]
+        public void BuildTimelineActionButtonLabel_PermanentAction_UsesMergeToTimeline()
+        {
+            Assert.Equal("Merge to Timeline",
+                MergeDialog.BuildTimelineActionButtonLabel(isPermanent: true));
+        }
+
+        [Fact]
+        public void BuildTimelineActionButtonLabel_ReFlyAttemptNotSealed_UsesCommitToTimeline()
+        {
+            Assert.Equal("Commit to Timeline",
+                MergeDialog.BuildTimelineActionButtonLabel(isPermanent: false));
+        }
+
+        [Fact]
+        public void BuildReFlyAutoSealReasonLines_MultipleReasons_UsesDashedLines()
+        {
+            var preview = new ReFlyAutoSealPreviewResult
+            {
+                WillAutoSeal = true,
+                Reasons = new List<ReFlyAutoSealReason>
+                {
+                    ReFlyAutoSealReason.TransmittedScience,
+                    ReFlyAutoSealReason.Undocked,
+                    ReFlyAutoSealReason.DockedWithAnother,
+                },
+            };
+
+            Assert.Equal(
+                "- transmitted science\n- undocked\n- docked with another vessel",
+                MergeDialog.BuildReFlyAutoSealReasonLines(preview));
+        }
+
+        [Fact]
+        public void BuildReFlyAutoSealReasonLines_EmptyReasons_UsesFallbackLine()
+        {
+            var preview = new ReFlyAutoSealPreviewResult
+            {
+                WillAutoSeal = true,
+                Reasons = new List<ReFlyAutoSealReason>(),
+            };
+
+            Assert.Equal("- auto-seal condition met",
+                MergeDialog.BuildReFlyAutoSealReasonLines(preview));
+        }
 
         [Fact]
         public void BuildBody_NoSeal_UsesDefaultCopy()
@@ -652,13 +697,16 @@ namespace Parsek.Tests
                 "TestVessel", 123.0, preview);
             Assert.Contains("If not discarded, this Re-Fly attempt", body);
             Assert.Contains("merged AND auto-sealed", body);
-            Assert.Contains("for the following reason(s): transmitted science.",
+            Assert.Contains("for the following reason(s):\n- transmitted science\n",
                 body);
             // Auto-seal jargon translation - tells the player what
             // "auto-sealed" actually means in gameplay terms.
             Assert.Contains("Auto-seal makes the slot permanent", body);
             Assert.Contains("cannot Re-Fly this line again", body);
-            Assert.Contains("This cannot be undone", body);
+            Assert.Contains(
+                "cannot Re-Fly this line again. This cannot be undone.</align>",
+                body);
+            Assert.DoesNotContain("cannot Re-Fly this line again.\nThis cannot be undone", body);
         }
 
         [Fact]
@@ -677,8 +725,11 @@ namespace Parsek.Tests
             string body = MergeDialog.BuildReFlyDialogBody(
                 "TestVessel", 123.0, preview);
             Assert.Contains(
-                "for the following reason(s): transmitted science, undocked, " +
-                "and docked with another vessel.",
+                "for the following reason(s):\n" +
+                "- transmitted science\n" +
+                "- undocked\n" +
+                "- docked with another vessel\n" +
+                "Auto-seal makes the slot permanent",
                 body);
         }
 

--- a/Source/Parsek.Tests/ReFlyAutoSealPreviewTests.cs
+++ b/Source/Parsek.Tests/ReFlyAutoSealPreviewTests.cs
@@ -639,6 +639,96 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void BuildTimelineActionDialogTitle_NotPermanent_UsesCommitToTimeline()
+        {
+            Assert.Equal("Confirm Commit to Timeline",
+                MergeDialog.BuildTimelineActionDialogTitle(isPermanent: false));
+        }
+
+        [Fact]
+        public void DetermineReFlyTimelineActionIsPermanent_ClassifierOverridesNoSealPreview()
+        {
+            var rec = MakeRecording();
+            rec.MergeState = MergeState.NotCommitted;
+            rec.TerminalStateValue = TerminalState.Orbiting;
+            rec.ParentBranchPointId = "bp-test";
+            rec.SupersedeTargetId = "rec-origin";
+            var marker = MakeMarker(activeReFlyRecordingId: rec.RecordingId);
+            marker.OriginChildRecordingId = "rec-origin";
+            marker.SupersedeTargetId = "rec-origin";
+            var scenario = MakeScenario(marker);
+            scenario.RewindPoints.Add(new RewindPoint
+            {
+                RewindPointId = marker.RewindPointId,
+                BranchPointId = rec.ParentBranchPointId,
+                FocusSlotIndex = 0,
+                ChildSlots = new List<ChildSlot>
+                {
+                    new ChildSlot
+                    {
+                        SlotIndex = 0,
+                        OriginChildRecordingId = "rec-origin",
+                        Controllable = true,
+                    },
+                },
+            });
+
+            string source;
+            bool permanent = MergeDialog.DetermineReFlyTimelineActionIsPermanent(
+                rec,
+                marker,
+                ReFlyAutoSealPreviewResult.NoSeal(),
+                out source);
+
+            Assert.True(permanent);
+            Assert.StartsWith("classifier:", source);
+        }
+
+        [Fact]
+        public void DetermineReFlyTimelineActionIsPermanent_CommittedProvisionalPredictionUsesCommit()
+        {
+            var rec = MakeRecording();
+            rec.MergeState = MergeState.NotCommitted;
+            rec.TerminalStateValue = TerminalState.Destroyed;
+            rec.ParentBranchPointId = "bp-test";
+            rec.SupersedeTargetId = "rec-origin";
+            var marker = MakeMarker(activeReFlyRecordingId: rec.RecordingId);
+            marker.OriginChildRecordingId = "rec-origin";
+            marker.SupersedeTargetId = "rec-origin";
+            var scenario = MakeScenario(marker);
+            scenario.RewindPoints.Add(new RewindPoint
+            {
+                RewindPointId = marker.RewindPointId,
+                BranchPointId = rec.ParentBranchPointId,
+                FocusSlotIndex = 0,
+                ChildSlots = new List<ChildSlot>
+                {
+                    new ChildSlot
+                    {
+                        SlotIndex = 0,
+                        OriginChildRecordingId = "rec-origin",
+                        Controllable = true,
+                    },
+                },
+            });
+
+            string source;
+            bool permanent = MergeDialog.DetermineReFlyTimelineActionIsPermanent(
+                rec,
+                marker,
+                new ReFlyAutoSealPreviewResult
+                {
+                    WillAutoSeal = true,
+                    Reasons = new List<ReFlyAutoSealReason>
+                        { ReFlyAutoSealReason.TransmittedScience },
+                },
+                out source);
+
+            Assert.False(permanent);
+            Assert.StartsWith("classifier:", source);
+        }
+
+        [Fact]
         public void BuildReFlyAutoSealReasonLines_MultipleReasons_UsesDashedLines()
         {
             var preview = new ReFlyAutoSealPreviewResult
@@ -685,7 +775,7 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void BuildBody_AutoSeal_SingleReason_IncludesReasonConsequenceAndUndoWarning()
+        public void BuildBody_AutoSeal_SingleReason_IncludesReasonAndConsequence()
         {
             var preview = new ReFlyAutoSealPreviewResult
             {

--- a/Source/Parsek.Tests/ReFlyAutoSealPreviewTests.cs
+++ b/Source/Parsek.Tests/ReFlyAutoSealPreviewTests.cs
@@ -758,6 +758,9 @@ namespace Parsek.Tests
 
             Assert.Equal("- auto-seal condition met",
                 MergeDialog.BuildReFlyAutoSealReasonLines(preview));
+            Assert.Contains(logLines,
+                l => l.Contains("[MergeDialog]") &&
+                     l.Contains("auto-seal preview returned no reasons"));
         }
 
         [Fact]
@@ -787,7 +790,7 @@ namespace Parsek.Tests
                 "TestVessel", 123.0, preview);
             Assert.Contains("If not discarded, this Re-Fly attempt", body);
             Assert.Contains("merged AND auto-sealed", body);
-            Assert.Contains("for the following reason(s):\n- transmitted science\n",
+            Assert.Contains("for the following reason(s):\n- transmitted science\n\n",
                 body);
             // Auto-seal jargon translation - tells the player what
             // "auto-sealed" actually means in gameplay terms.
@@ -818,7 +821,7 @@ namespace Parsek.Tests
                 "for the following reason(s):\n" +
                 "- transmitted science\n" +
                 "- undocked\n" +
-                "- docked with another vessel\n" +
+                "- docked with another vessel\n\n" +
                 "Auto-seal makes the slot permanent",
                 body);
         }

--- a/Source/Parsek.Tests/ReFlyAutoSealPreviewTests.cs
+++ b/Source/Parsek.Tests/ReFlyAutoSealPreviewTests.cs
@@ -341,8 +341,8 @@ namespace Parsek.Tests
         // Deferred merge fallback (ShowTreeDialog 1-arg overload) can fire
         // in Space Center / Tracking Station with FlightGlobals.ActiveVessel
         // null. The recorded-terminal classifier must surface the seal
-        // reason from Recording.TerminalStateValue so the dialog still
-        // warns "This cannot be undone" when production would seal.
+        // reason from Recording.TerminalStateValue so the dialog still tells
+        // the player when production would seal.
 
         [Fact]
         public void Preview_RecordedTerminalLanded_NullVessel_FlagsLanded()
@@ -704,9 +704,9 @@ namespace Parsek.Tests
             Assert.Contains("Auto-seal makes the slot permanent", body);
             Assert.Contains("cannot Re-Fly this line again", body);
             Assert.Contains(
-                "cannot Re-Fly this line again. This cannot be undone.</align>",
+                "cannot Re-Fly this line again.</align>",
                 body);
-            Assert.DoesNotContain("cannot Re-Fly this line again.\nThis cannot be undone", body);
+            Assert.DoesNotContain("This cannot be undone", body);
         }
 
         [Fact]

--- a/Source/Parsek.Tests/ReFlyAutoSealPreviewTests.cs
+++ b/Source/Parsek.Tests/ReFlyAutoSealPreviewTests.cs
@@ -729,6 +729,37 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void DetermineReFlyTimelineActionIsPermanent_ClassifierThrows_FallsBackToPreview()
+        {
+            var rec = MakeRecording();
+            rec.MergeState = MergeState.NotCommitted;
+            rec.TerminalStateValue = TerminalState.Orbiting;
+            rec.ParentBranchPointId = "bp-missing";
+            rec.SupersedeTargetId = "rec-origin";
+            var marker = MakeMarker(activeReFlyRecordingId: rec.RecordingId);
+            marker.OriginChildRecordingId = "rec-origin";
+            marker.SupersedeTargetId = "rec-origin";
+            MakeScenario(marker);
+
+            string source;
+            bool permanent = MergeDialog.DetermineReFlyTimelineActionIsPermanent(
+                rec,
+                marker,
+                ReFlyAutoSealPreviewResult.NoSeal(),
+                out source);
+
+            Assert.False(permanent);
+            Assert.Equal("preview:InvalidOperationException", source);
+            Assert.Contains(logLines,
+                l => l.Contains("[WARN][Supersede]") &&
+                     l.Contains("Prediction fallback") &&
+                     l.Contains("using preview label"));
+            Assert.DoesNotContain(logLines,
+                l => l.Contains("[ERROR][Supersede]") &&
+                     l.Contains("aborting because stable-leaf"));
+        }
+
+        [Fact]
         public void BuildReFlyAutoSealReasonLines_MultipleReasons_UsesDashedLines()
         {
             var preview = new ReFlyAutoSealPreviewResult

--- a/Source/Parsek/MergeDialog.cs
+++ b/Source/Parsek/MergeDialog.cs
@@ -149,11 +149,13 @@ namespace Parsek
             // the body through the same auto-seal preview the pre-transition
             // path uses - this deferred fallback can still finalize via
             // TryCommitReFlySupersede and auto-seal the slot Immutable, so
-            // the auto-seal copy + "cannot be undone" tail must appear here
+            // the auto-seal copy and reason list must appear here
             // too when the preview classifies the attempt as sealable.
             var reFlyScenario = ParsekScenario.Instance;
             string message;
-            string mergeLabel = BuildTimelineActionButtonLabel(isPermanent: true);
+            bool timelineActionPermanent = true;
+            string mergeLabel = BuildTimelineActionButtonLabel(timelineActionPermanent);
+            string title = BuildTimelineActionDialogTitle(timelineActionPermanent);
             if (!object.ReferenceEquals(null, reFlyScenario)
                 && reFlyScenario.ActiveReFlySessionMarker != null)
             {
@@ -178,14 +180,21 @@ namespace Parsek
                     ? ReFlyAutoSealPreviewer.Preview(
                         reFlyRec, marker, FlightGlobals.ActiveVessel)
                     : ReFlyAutoSealPreviewResult.NoSeal();
-                mergeLabel = BuildTimelineActionButtonLabel(preview.WillAutoSeal);
+                string labelSource;
+                timelineActionPermanent =
+                    DetermineReFlyTimelineActionIsPermanent(
+                        reFlyRec, marker, preview, out labelSource);
+                mergeLabel = BuildTimelineActionButtonLabel(timelineActionPermanent);
+                title = BuildTimelineActionDialogTitle(timelineActionPermanent);
                 message = BuildReFlyDialogBody(
                     vesselLabel, reFlyDuration, preview);
 
                 ParsekLog.Info("MergeDialog",
                     $"Re-Fly auto-seal preview (post-transition): " +
                     $"willSeal={preview.WillAutoSeal} " +
+                    $"actionPermanent={timelineActionPermanent} " +
                     $"button='{mergeLabel}' " +
+                    $"labelSource={labelSource ?? "<none>"} " +
                     $"reasons=[{string.Join(",", preview.Reasons)}] " +
                     $"sess={marker.SessionId ?? "<no-id>"}");
             }
@@ -229,7 +238,7 @@ namespace Parsek
                 new MultiOptionDialog(
                     DialogName,
                     message,
-                    "Confirm Merge to Timeline",
+                    title,
                     HighLogic.UISkin,
                     buttons
                 ),
@@ -313,12 +322,18 @@ namespace Parsek
                 // affects the dialog wording, not the seal verdict).
                 var preview = ReFlyAutoSealPreviewer.Preview(
                     reFlyRec, marker, FlightGlobals.ActiveVessel);
-                mergeLabel = BuildTimelineActionButtonLabel(preview.WillAutoSeal);
+                string labelSource;
+                bool timelineActionPermanent =
+                    DetermineReFlyTimelineActionIsPermanent(
+                        reFlyRec, marker, preview, out labelSource);
+                mergeLabel = BuildTimelineActionButtonLabel(timelineActionPermanent);
                 message = BuildReFlyDialogBody(vesselLabel, reFlyDuration, preview);
 
                 ParsekLog.Info("MergeDialog",
                     $"Re-Fly auto-seal preview: willSeal={preview.WillAutoSeal} " +
+                    $"actionPermanent={timelineActionPermanent} " +
                     $"button='{mergeLabel}' " +
+                    $"labelSource={labelSource ?? "<none>"} " +
                     $"reasons=[{string.Join(",", preview.Reasons)}] " +
                     $"sess={marker?.SessionId ?? "<no-id>"}");
             }
@@ -496,6 +511,34 @@ namespace Parsek
         internal static string BuildTimelineActionButtonLabel(bool isPermanent)
         {
             return isPermanent ? "Merge to Timeline" : "Commit to Timeline";
+        }
+
+        internal static string BuildTimelineActionDialogTitle(bool isPermanent)
+        {
+            return isPermanent ? "Confirm Merge to Timeline" : "Confirm Commit to Timeline";
+        }
+
+        internal static bool DetermineReFlyTimelineActionIsPermanent(
+            Recording reFlyRec,
+            ReFlySessionMarker marker,
+            ReFlyAutoSealPreviewResult preview,
+            out string source)
+        {
+            bool classifierPermanent;
+            string classifierReason;
+            if (SupersedeCommit.TryPredictReFlyMergeIsPermanent(
+                    marker,
+                    reFlyRec,
+                    ParsekScenario.Instance,
+                    out classifierPermanent,
+                    out classifierReason))
+            {
+                source = "classifier:" + (classifierReason ?? "<none>");
+                return classifierPermanent;
+            }
+
+            source = "preview:" + (classifierReason ?? "<unavailable>");
+            return preview.WillAutoSeal;
         }
 
         /// <summary>

--- a/Source/Parsek/MergeDialog.cs
+++ b/Source/Parsek/MergeDialog.cs
@@ -581,7 +581,7 @@ namespace Parsek
             return headline +
                 "<align=\"left\"><b>If not discarded, this Re-Fly attempt " +
                 $"will be merged AND auto-sealed</b> for the following " +
-                $"reason(s):\n{reasons}\n" +
+                $"reason(s):\n{reasons}\n\n" +
                 "Auto-seal makes the slot permanent and you cannot Re-Fly this line again.</align>";
         }
 
@@ -589,12 +589,16 @@ namespace Parsek
             ReFlyAutoSealPreviewResult preview)
         {
             if (preview.Reasons == null || preview.Reasons.Count == 0)
+            {
+                ParsekLog.Warn("MergeDialog",
+                    "BuildReFlyAutoSealReasonLines: auto-seal preview returned no reasons; using fallback line");
                 return "- auto-seal condition met";
+            }
 
             var lines = new List<string>(preview.Reasons.Count);
             for (int i = 0; i < preview.Reasons.Count; i++)
                 lines.Add("- " + ReFlyAutoSealPreviewResult.PhraseFor(preview.Reasons[i]));
-            return string.Join("\n", lines.ToArray());
+            return string.Join("\n", lines);
         }
 
         private static string FormatClearReason(string reason)

--- a/Source/Parsek/MergeDialog.cs
+++ b/Source/Parsek/MergeDialog.cs
@@ -539,8 +539,7 @@ namespace Parsek
                 "<align=\"left\"><b>If not discarded, this Re-Fly attempt " +
                 $"will be merged AND auto-sealed</b> for the following " +
                 $"reason(s):\n{reasons}\n" +
-                "Auto-seal makes the slot permanent and you cannot Re-Fly this line again. " +
-                "This cannot be undone.</align>";
+                "Auto-seal makes the slot permanent and you cannot Re-Fly this line again.</align>";
         }
 
         internal static string BuildReFlyAutoSealReasonLines(

--- a/Source/Parsek/MergeDialog.cs
+++ b/Source/Parsek/MergeDialog.cs
@@ -28,7 +28,7 @@ namespace Parsek
         {
             /// <summary>"Merge to Timeline" / "Discard"</summary>
             Default,
-            /// <summary>"Merge" / "Discard"</summary>
+            /// <summary>Dynamic timeline action label / "Discard"</summary>
             ReFlyAttempt,
         }
 
@@ -153,6 +153,7 @@ namespace Parsek
             // too when the preview classifies the attempt as sealable.
             var reFlyScenario = ParsekScenario.Instance;
             string message;
+            string mergeLabel = BuildTimelineActionButtonLabel(isPermanent: true);
             if (!object.ReferenceEquals(null, reFlyScenario)
                 && reFlyScenario.ActiveReFlySessionMarker != null)
             {
@@ -177,12 +178,14 @@ namespace Parsek
                     ? ReFlyAutoSealPreviewer.Preview(
                         reFlyRec, marker, FlightGlobals.ActiveVessel)
                     : ReFlyAutoSealPreviewResult.NoSeal();
+                mergeLabel = BuildTimelineActionButtonLabel(preview.WillAutoSeal);
                 message = BuildReFlyDialogBody(
                     vesselLabel, reFlyDuration, preview);
 
                 ParsekLog.Info("MergeDialog",
                     $"Re-Fly auto-seal preview (post-transition): " +
                     $"willSeal={preview.WillAutoSeal} " +
+                    $"button='{mergeLabel}' " +
                     $"reasons=[{string.Join(",", preview.Reasons)}] " +
                     $"sess={marker.SessionId ?? "<no-id>"}");
             }
@@ -205,7 +208,7 @@ namespace Parsek
 
             DialogGUIButton[] buttons = new[]
             {
-                new DialogGUIButton("Merge to Timeline", () =>
+                new DialogGUIButton(mergeLabel, () =>
                 {
                     MergeCommit(tree, capturedDecisions, capturedSpawnCount);
                 }),
@@ -291,7 +294,6 @@ namespace Parsek
             if (labels == MergeDialogButtonLabels.ReFlyAttempt)
             {
                 title = "Re-Fly attempt - leaving flight";
-                mergeLabel = "Merge";
                 discardLabel = "Discard";
                 Recording reFlyRec = marker != null
                     ? FindReFlyRecording(marker, liveTree)
@@ -311,10 +313,12 @@ namespace Parsek
                 // affects the dialog wording, not the seal verdict).
                 var preview = ReFlyAutoSealPreviewer.Preview(
                     reFlyRec, marker, FlightGlobals.ActiveVessel);
+                mergeLabel = BuildTimelineActionButtonLabel(preview.WillAutoSeal);
                 message = BuildReFlyDialogBody(vesselLabel, reFlyDuration, preview);
 
                 ParsekLog.Info("MergeDialog",
                     $"Re-Fly auto-seal preview: willSeal={preview.WillAutoSeal} " +
+                    $"button='{mergeLabel}' " +
                     $"reasons=[{string.Join(",", preview.Reasons)}] " +
                     $"sess={marker?.SessionId ?? "<no-id>"}");
             }
@@ -489,6 +493,11 @@ namespace Parsek
         internal static string FormatDuration(double seconds)
             => ParsekTimeFormat.FormatDuration(seconds);
 
+        internal static string BuildTimelineActionButtonLabel(bool isPermanent)
+        {
+            return isPermanent ? "Merge to Timeline" : "Commit to Timeline";
+        }
+
         /// <summary>
         /// Composes the Re-Fly merge dialog body. Shared by the pre-
         /// transition <see cref="ShowTreeDialog"/> 4-arg overload and the
@@ -515,7 +524,7 @@ namespace Parsek
                     "to the timeline?</align>";
             }
 
-            string reasons = preview.FormatHumanReadable();
+            string reasons = BuildReFlyAutoSealReasonLines(preview);
             // Auto-seal flips MergeState to Immutable and closes the rewind
             // slot, so this branch *is* the irreversible one. Keep the
             // short translation of what "auto-seal" means in player terms
@@ -529,9 +538,21 @@ namespace Parsek
             return headline +
                 "<align=\"left\"><b>If not discarded, this Re-Fly attempt " +
                 $"will be merged AND auto-sealed</b> for the following " +
-                $"reason(s): {reasons}. Auto-seal makes the slot permanent " +
-                "and you cannot Re-Fly this line again. " +
+                $"reason(s):\n{reasons}\n" +
+                "Auto-seal makes the slot permanent and you cannot Re-Fly this line again. " +
                 "This cannot be undone.</align>";
+        }
+
+        internal static string BuildReFlyAutoSealReasonLines(
+            ReFlyAutoSealPreviewResult preview)
+        {
+            if (preview.Reasons == null || preview.Reasons.Count == 0)
+                return "- auto-seal condition met";
+
+            var lines = new List<string>(preview.Reasons.Count);
+            for (int i = 0; i < preview.Reasons.Count; i++)
+                lines.Add("- " + ReFlyAutoSealPreviewResult.PhraseFor(preview.Reasons[i]));
+            return string.Join("\n", lines.ToArray());
         }
 
         private static string FormatClearReason(string reason)

--- a/Source/Parsek/ReFlyAutoSealPreview.cs
+++ b/Source/Parsek/ReFlyAutoSealPreview.cs
@@ -64,9 +64,9 @@ namespace Parsek
         }
 
         /// <summary>
-        /// Composes a player-facing phrase from <see cref="Reasons"/>.
+        /// Composes a player-facing sentence phrase from <see cref="Reasons"/>.
         /// Subject-free phrasing (e.g. "transmitted science and undocked")
-        /// for the dialog body's "for the following reason(s):" wrapping.
+        /// is kept for callers that need compact inline copy.
         ///
         /// <list type="bullet">
         ///   <item><description>0 reasons: returns null. Caller shows default copy.</description></item>

--- a/Source/Parsek/SupersedeCommit.cs
+++ b/Source/Parsek/SupersedeCommit.cs
@@ -410,6 +410,48 @@ namespace Parsek
             ClassifyMergeStateOrThrow(marker, provisional, scenario, logFallback: false);
         }
 
+        internal static bool TryPredictReFlyMergeIsPermanent(
+            ReFlySessionMarker marker,
+            Recording provisional,
+            ParsekScenario scenario,
+            out bool isPermanent,
+            out string reason)
+        {
+            isPermanent = false;
+            reason = null;
+            if (marker == null)
+            {
+                reason = "marker-null";
+                return false;
+            }
+            if (provisional == null)
+            {
+                reason = "provisional-null";
+                return false;
+            }
+            if (object.ReferenceEquals(null, scenario))
+            {
+                reason = "scenario-null";
+                return false;
+            }
+
+            try
+            {
+                MergeStateClassification classification =
+                    ClassifyMergeStateOrThrow(
+                        marker, provisional, scenario, logFallback: false);
+                isPermanent = classification.NewState == MergeState.Immutable;
+                reason = classification.ClassifierReason
+                    ?? classification.Kind.ToString();
+                return true;
+            }
+            catch (Exception ex)
+            {
+                reason = ex.GetType().Name;
+                return false;
+            }
+        }
+
         private struct MergeStateClassification
         {
             public TerminalKind Kind;

--- a/Source/Parsek/SupersedeCommit.cs
+++ b/Source/Parsek/SupersedeCommit.cs
@@ -305,7 +305,9 @@ namespace Parsek
                 || object.ReferenceEquals(null, scenario)) return;
 
             MergeStateClassification classification =
-                ClassifyMergeStateOrThrow(marker, provisional, scenario, logFallback: true);
+                ClassifyMergeStateOrThrow(
+                    marker, provisional, scenario, logFallback: true,
+                    isPrediction: false);
 
             provisional.MergeState = classification.NewState;
             // Re-Fly provisionals are created with PlaybackEnabled=false in
@@ -439,7 +441,8 @@ namespace Parsek
             {
                 MergeStateClassification classification =
                     ClassifyMergeStateOrThrow(
-                        marker, provisional, scenario, logFallback: false);
+                        marker, provisional, scenario, logFallback: false,
+                        isPrediction: true);
                 isPermanent = classification.NewState == MergeState.Immutable;
                 reason = classification.ClassifierReason
                     ?? classification.Kind.ToString();
@@ -512,7 +515,8 @@ namespace Parsek
             ReFlySessionMarker marker,
             Recording provisional,
             ParsekScenario scenario,
-            bool logFallback)
+            bool logFallback,
+            bool isPrediction = false)
         {
             TerminalKind kind = TerminalKindClassifier.Classify(provisional);
             var result = new MergeStateClassification
@@ -586,9 +590,18 @@ namespace Parsek
             if (!IsInPlaceContinuation(marker, provisional)
                 && RequiresSlotAwareMergeClassification(provisional))
             {
-                ParsekLog.Error(Tag,
-                    slotLookupFailure +
-                    "; aborting because stable-leaf classification cannot safely fall back");
+                if (isPrediction)
+                {
+                    ParsekLog.Warn(Tag,
+                        "Prediction fallback: stable-leaf slot lookup failed; using preview label. " +
+                        slotLookupFailure);
+                }
+                else
+                {
+                    ParsekLog.Error(Tag,
+                        slotLookupFailure +
+                        "; aborting because stable-leaf classification cannot safely fall back");
+                }
                 throw new InvalidOperationException(slotLookupFailure);
             }
 


### PR DESCRIPTION
Summary: normalize Re-Fly timeline dialog button labels and auto-seal reason layout. Validation: dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter ReFlyAutoSealPreviewTests; dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter FullyQualifiedName!~InjectAllRecordings. Note: full dotnet test is blocked locally because InjectAllRecordings refuses while KSP.log is locked by another process; deploy-copy warnings appear because deployed GameData files are locked/access-denied.