### PR TITLE
Fix relative map ghost segment-gap source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to Parsek are documented here.
 
 ### Bug Fixes
 
+- Ghost map presence now defers Relative-frame state-vector ProtoVessels while waiting between bounded orbit segments, preventing rewind/map time warp from briefly showing stock's unbounded suborbital proto-orbit for a ghost icon before Parsek's next bounded segment becomes active.
 - In-game test harness: `RuntimeTests.TerminalOrbitFromTail_DerivesPostBurnCircularOrbit` now builds a prograde equatorial velocity instead of a retrograde one, so the inclination assertion measures the orbit shape it was written to pin instead of reading 180°.
 - In-game test harness: `OnFlightReadyMergeDialogGuardInGameTest.OnFlightReady_ActiveReFlySession_SkipsMergeDialog` now installs an in-place-continuation marker, matching the narrower dispatch gate the dialog skip path actually checks; the placeholder-mode marker the test previously installed fell through to the dialog every run.
 - In-game test harness: `RuntimeTests.EvaKerbalGhostHasVesselSnapshot` now skips on PRELAUNCH/LANDED/SPLASHED parent vessels. The test's snapshot-before-first-sample wait depends on a brief live-recorder window that only exists for mid-flight EVAs; pad-launched parents produce an immediately auto-Landed kerbal recording with no live window.

--- a/Source/Parsek.Tests/GhostMapPresenceTests.cs
+++ b/Source/Parsek.Tests/GhostMapPresenceTests.cs
@@ -2585,6 +2585,68 @@ namespace Parsek.Tests
             Assert.Null(skipReason);
         }
 
+        [Fact]
+        public void ResolveMapPresenceGhostSource_RelativeFrame_BetweenOrbitSegments_DefersStateVectorBranch()
+        {
+            // Rewind/map-time-warp regression: in a Relative section between
+            // bounded orbit windows, the state-vector path produced a no-bounds
+            // ProtoVessel and stock briefly drew its full suborbital orbit. A
+            // later Parsek segment means the pending map vessel should wait for
+            // the bounded source instead of using Relative offsets as LLA.
+            var rec = BuildRelativeFrameRecording(
+                anchorRecordingId: "anchor-rec",
+                pointDz: 51.0,
+                pointSpeed: 2200.0);
+            rec.RecordingId = "relative-gap-between-segments";
+            rec.TerminalStateValue = TerminalState.SubOrbital;
+            rec.ExplicitEndUT = 300.0;
+            rec.OrbitSegments = new List<OrbitSegment>
+            {
+                new OrbitSegment
+                {
+                    startUT = 0.0,
+                    endUT = 150.0,
+                    bodyName = "Kerbin",
+                    semiMajorAxis = 654036.0,
+                    eccentricity = 0.235
+                },
+                new OrbitSegment
+                {
+                    startUT = 250.0,
+                    endUT = 300.0,
+                    bodyName = "Kerbin",
+                    semiMajorAxis = 1038510.0,
+                    eccentricity = 0.919531
+                }
+            };
+
+            int mapCached = -1;
+            var source = GhostMapPresence.ResolveMapPresenceGhostSource(
+                rec,
+                false,
+                false,
+                200.0,
+                true,
+                "test-rel-segment-gap",
+                ref mapCached,
+                out _,
+                out TrajectoryPoint statePoint,
+                out string skipReason);
+
+            Assert.Equal(GhostMapPresence.TrackingStationGhostSource.None, source);
+            Assert.Equal(
+                GhostMapPresence.TrackingStationGhostSkipRelativeStateVectorSegmentGap,
+                skipReason);
+            Assert.Equal(default(TrajectoryPoint), statePoint);
+            Assert.Contains(logLines,
+                l => l.Contains("[GhostMap]")
+                    && l.Contains("test-rel-segment-gap")
+                    && l.Contains("reason=" + GhostMapPresence.TrackingStationGhostSkipRelativeStateVectorSegmentGap));
+            Assert.Contains(logLines,
+                l => l.Contains("[GhostMap]")
+                    && l.Contains("orbitSegmentGap=True"));
+        }
+
         private static Recording BuildRelativeFrameRecording(
             string anchorRecordingId, double pointDz, double pointSpeed)
         {

--- a/Source/Parsek.Tests/GhostMapPresenceTests.cs
+++ b/Source/Parsek.Tests/GhostMapPresenceTests.cs
@@ -2593,32 +2593,7 @@ namespace Parsek.Tests
             // ProtoVessel and stock briefly drew its full suborbital orbit. A
             // later Parsek segment means the pending map vessel should wait for
             // the bounded source instead of using Relative offsets as LLA.
-            var rec = BuildRelativeFrameRecording(
-                anchorRecordingId: "anchor-rec",
-                pointDz: 51.0,
-                pointSpeed: 2200.0);
-            rec.RecordingId = "relative-gap-between-segments";
-            rec.TerminalStateValue = TerminalState.SubOrbital;
-            rec.ExplicitEndUT = 300.0;
-            rec.OrbitSegments = new List<OrbitSegment>
-            {
-                new OrbitSegment
-                {
-                    startUT = 0.0,
-                    endUT = 150.0,
-                    bodyName = "Kerbin",
-                    semiMajorAxis = 654036.0,
-                    eccentricity = 0.235
-                },
-                new OrbitSegment
-                {
-                    startUT = 250.0,
-                    endUT = 300.0,
-                    bodyName = "Kerbin",
-                    semiMajorAxis = 1038510.0,
-                    eccentricity = 0.919531
-                }
-            };
+            var rec = BuildRelativeFrameRecordingBetweenOrbitSegments();
 
             int mapCached = -1;
             var source = GhostMapPresence.ResolveMapPresenceGhostSource(
@@ -2645,6 +2620,68 @@ namespace Parsek.Tests
             Assert.Contains(logLines,
                 l => l.Contains("[GhostMap]")
                     && l.Contains("orbitSegmentGap=True"));
+        }
+
+        [Fact]
+        public void ResolveMapPresenceGhostSource_RelativeFrame_AfterSegmentGap_ReturnsBoundedSegment()
+        {
+            var rec = BuildRelativeFrameRecordingBetweenOrbitSegments();
+
+            int mapCached = -1;
+            var source = GhostMapPresence.ResolveMapPresenceGhostSource(
+                rec,
+                false,
+                false,
+                260.0,
+                true,
+                "test-rel-segment-gap-release",
+                ref mapCached,
+                out OrbitSegment segment,
+                out TrajectoryPoint statePoint,
+                out string skipReason);
+
+            Assert.Equal(GhostMapPresence.TrackingStationGhostSource.Segment, source);
+            Assert.Null(skipReason);
+            Assert.Equal("Kerbin", segment.bodyName);
+            Assert.Equal(250.0, segment.startUT);
+            Assert.Equal(300.0, segment.endUT);
+            Assert.Equal(default(TrajectoryPoint), statePoint);
+            Assert.Contains(logLines,
+                l => l.Contains("[GhostMap]")
+                    && l.Contains("test-rel-segment-gap-release")
+                    && l.Contains("source=Segment")
+                    && l.Contains("segmentUT=250.0-300.0"));
+        }
+
+        private static Recording BuildRelativeFrameRecordingBetweenOrbitSegments()
+        {
+            var rec = BuildRelativeFrameRecording(
+                anchorRecordingId: "anchor-rec",
+                pointDz: 51.0,
+                pointSpeed: 2200.0);
+            rec.RecordingId = "relative-gap-between-segments";
+            rec.TerminalStateValue = TerminalState.SubOrbital;
+            rec.ExplicitEndUT = 300.0;
+            rec.OrbitSegments = new List<OrbitSegment>
+            {
+                new OrbitSegment
+                {
+                    startUT = 0.0,
+                    endUT = 150.0,
+                    bodyName = "Kerbin",
+                    semiMajorAxis = 654036.0,
+                    eccentricity = 0.235
+                },
+                new OrbitSegment
+                {
+                    startUT = 250.0,
+                    endUT = 300.0,
+                    bodyName = "Kerbin",
+                    semiMajorAxis = 1038510.0,
+                    eccentricity = 0.919531
+                }
+            };
+            return rec;
         }
 
         private static Recording BuildRelativeFrameRecording(

--- a/Source/Parsek/GhostMapPresence.cs
+++ b/Source/Parsek/GhostMapPresence.cs
@@ -477,6 +477,8 @@ namespace Parsek
         internal const string TrackingStationGhostSkipUnseedableTerminalOrbit = "terminal-orbit-unseedable";
         internal const string TrackingStationGhostSkipStateVectorThreshold = "state-vector-threshold";
         internal const string TrackingStationGhostSkipRelativeFrame = "relative-frame";
+        internal const string TrackingStationGhostSkipRelativeStateVectorSegmentGap =
+            "relative-state-vector-segment-gap";
         internal const string TrackingStationGhostSkipBodyFixedPrimaryUnavailable = "body-fixed-primary-unavailable";
         // #583: Relative-frame state-vector ghost CREATION reaches the resolver
         // when the first map-visible UT lies inside a Relative section. Creation
@@ -4218,9 +4220,43 @@ namespace Parsek
             // rendezvous section; CreateGhostVesselFromStateVectors handles
             // Relative world-position resolution against the recorded anchor
             // pose for the target UT.
+            bool inRelativeFrame = IsInRelativeFrame(traj, currentUT);
+            bool hasPastOrbitSegment = false;
+            bool hasFutureOrbitSegment = false;
+            if (traj.HasOrbitSegments && inRelativeFrame && traj.OrbitSegments != null)
+            {
+                for (int i = 0; i < traj.OrbitSegments.Count; i++)
+                {
+                    OrbitSegment candidate = traj.OrbitSegments[i];
+                    if (candidate.endUT < currentUT)
+                        hasPastOrbitSegment = true;
+                    if (candidate.startUT > currentUT)
+                        hasFutureOrbitSegment = true;
+                    if (hasPastOrbitSegment && hasFutureOrbitSegment)
+                        break;
+                }
+            }
+
+            bool deferRelativeStateVectorForSegmentGap =
+                traj.HasOrbitSegments
+                && inRelativeFrame
+                && hasPastOrbitSegment
+                && hasFutureOrbitSegment;
+            if (deferRelativeStateVectorForSegmentGap)
+            {
+                // A Relative section with pending bounded orbit coverage should not
+                // create a no-bounds state-vector ProtoVessel. During rewind/map
+                // time warp that briefly exposed stock's full proto-orbit instead
+                // of waiting for the next Parsek-bounded segment.
+                stateVectorSkipReason = TrackingStationGhostSkipRelativeStateVectorSegmentGap;
+            }
+            string relativeSegmentGapDetail = deferRelativeStateVectorForSegmentGap
+                ? "relativeFrame=True orbitSegmentGap=True"
+                : null;
+
             bool considerStateVector =
                 !traj.HasOrbitSegments
-                || IsInRelativeFrame(traj, currentUT);
+                || (inRelativeFrame && !deferRelativeStateVectorForSegmentGap);
             if (considerStateVector)
             {
                 if (TryResolveStateVectorMapPoint(
@@ -4246,12 +4282,16 @@ namespace Parsek
             {
                 skipReason = checkpointFallbackRejectReason
                     ?? ResolveStateVectorOrSegmentSkipReason(
-                        traj, considerStateVector, stateVectorSkipReason);
+                        traj,
+                        considerStateVector || deferRelativeStateVectorForSegmentGap,
+                        stateVectorSkipReason);
                 return ReturnDecision(
                     TrackingStationGhostSource.None,
                     skipReason,
                     CombineSourceDetails(
-                        string.Format(ic, "terminalFallback=False hasOrbitSegments={0}", traj.HasOrbitSegments),
+                        CombineSourceDetails(
+                            string.Format(ic, "terminalFallback=False hasOrbitSegments={0}", traj.HasOrbitSegments),
+                            relativeSegmentGapDetail),
                         checkpointFallbackDetail));
             }
 
@@ -4259,12 +4299,16 @@ namespace Parsek
             {
                 skipReason = checkpointFallbackRejectReason
                     ?? ResolveStateVectorOrSegmentSkipReason(
-                        traj, considerStateVector, stateVectorSkipReason);
+                        traj,
+                        considerStateVector || deferRelativeStateVectorForSegmentGap,
+                        stateVectorSkipReason);
                 return ReturnDecision(
                     TrackingStationGhostSource.None,
                     skipReason,
                     CombineSourceDetails(
-                        string.Format(ic, "hasOrbitSegments={0}", traj.HasOrbitSegments),
+                        CombineSourceDetails(
+                            string.Format(ic, "hasOrbitSegments={0}", traj.HasOrbitSegments),
+                            relativeSegmentGapDetail),
                         checkpointFallbackDetail));
             }
 
@@ -4296,13 +4340,16 @@ namespace Parsek
                 && !HasRecordedTrackCoverageAtUT(traj, currentUT);
             if (currentUT < traj.EndUT && !allowSparseOrbitGapFallback)
             {
-                skipReason = checkpointFallbackRejectReason ?? "before-terminal-orbit";
+                skipReason = checkpointFallbackRejectReason
+                    ?? (deferRelativeStateVectorForSegmentGap
+                        ? stateVectorSkipReason
+                        : "before-terminal-orbit");
+                string detail = string.Format(ic, "endUT={0:F1}", traj.EndUT);
+                detail = CombineSourceDetails(detail, relativeSegmentGapDetail);
                 return ReturnDecision(
                     TrackingStationGhostSource.None,
                     skipReason,
-                    CombineSourceDetails(
-                        string.Format(ic, "endUT={0:F1}", traj.EndUT),
-                        checkpointFallbackDetail));
+                    CombineSourceDetails(detail, checkpointFallbackDetail));
             }
 
             if (TryResolveEndpointTailForMapPresence(
@@ -4503,6 +4550,11 @@ namespace Parsek
 
             if (skipReason == TrackingStationGhostSkipRelativeFrame)
                 return WithStructured("relativeFrame=True");
+
+            if (skipReason == TrackingStationGhostSkipRelativeStateVectorSegmentGap)
+                return WithStructured(string.Format(ic,
+                    "relativeFrame=True orbitSegmentGap=True endUT={0:F1}",
+                    rec.EndUT));
 
             if (skipReason == "no-state-vector-point")
                 return WithStructured(string.Format(ic, "stateVectorPointMissing=True hasOrbitSegments={0}", rec.HasOrbitSegments));
@@ -4731,8 +4783,9 @@ namespace Parsek
         // #583: when state-vector resolution was attempted (either because
         // there are no orbit segments OR because we're in a Relative section)
         // and produced a meaningful skip reason — relative-frame /
-        // relative-anchor-unresolved / state-vector-threshold — surface that
-        // reason. Otherwise fall back to the legacy split between
+        // relative-anchor-unresolved / relative-state-vector-segment-gap /
+        // state-vector-threshold — surface that reason. Otherwise fall back
+        // to the legacy split between
         // `no-current-segment` (orbit-bearing recording) and `no-orbit-data`
         // (state-vector-only recording with no points). Preserves the prior
         // log-shape contract for callers that don't reach the new Relative

--- a/Source/Parsek/GhostMapPresence.cs
+++ b/Source/Parsek/GhostMapPresence.cs
@@ -4247,7 +4247,9 @@ namespace Parsek
                 // A Relative section with pending bounded orbit coverage should not
                 // create a no-bounds state-vector ProtoVessel. During rewind/map
                 // time warp that briefly exposed stock's full proto-orbit instead
-                // of waiting for the next Parsek-bounded segment.
+                // of waiting for the next Parsek-bounded segment. The past+future
+                // bracket is intentional: future-only Relative windows still use
+                // the #583 state-vector path until a recorded segment gap exists.
                 stateVectorSkipReason = TrackingStationGhostSkipRelativeStateVectorSegmentGap;
             }
             string relativeSegmentGapDetail = deferRelativeStateVectorForSegmentGap
@@ -4285,14 +4287,14 @@ namespace Parsek
                         traj,
                         considerStateVector || deferRelativeStateVectorForSegmentGap,
                         stateVectorSkipReason);
+                string detail = string.Format(ic,
+                    "terminalFallback=False hasOrbitSegments={0}",
+                    traj.HasOrbitSegments);
+                detail = CombineSourceDetails(detail, relativeSegmentGapDetail);
                 return ReturnDecision(
                     TrackingStationGhostSource.None,
                     skipReason,
-                    CombineSourceDetails(
-                        CombineSourceDetails(
-                            string.Format(ic, "terminalFallback=False hasOrbitSegments={0}", traj.HasOrbitSegments),
-                            relativeSegmentGapDetail),
-                        checkpointFallbackDetail));
+                    CombineSourceDetails(detail, checkpointFallbackDetail));
             }
 
             if (!HasOrbitData(traj))
@@ -4302,14 +4304,12 @@ namespace Parsek
                         traj,
                         considerStateVector || deferRelativeStateVectorForSegmentGap,
                         stateVectorSkipReason);
+                string detail = string.Format(ic, "hasOrbitSegments={0}", traj.HasOrbitSegments);
+                detail = CombineSourceDetails(detail, relativeSegmentGapDetail);
                 return ReturnDecision(
                     TrackingStationGhostSource.None,
                     skipReason,
-                    CombineSourceDetails(
-                        CombineSourceDetails(
-                            string.Format(ic, "hasOrbitSegments={0}", traj.HasOrbitSegments),
-                            relativeSegmentGapDetail),
-                        checkpointFallbackDetail));
+                    CombineSourceDetails(detail, checkpointFallbackDetail));
             }
 
             if (!IsTerminalStateEligibleForTerminalOrbitMapPresence(terminal))

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -12,6 +12,18 @@ When referencing prior item numbers from source comments or plans, consult the r
 
 ---
 
+## Done - v0.9.2 Rewind map ghost briefly showed unbounded Relative state-vector orbit
+
+- ~~After rewind, watching ghost icons in map mode during time warp could briefly show the Kerbal X Probe's weird proto-vessel suborbital trajectory line. The retained `logs/2026-05-15_2119_rewind-map-ghost-icons/KSP.log` captured the bad source decision: `Ghost: Kerbal X Probe` was created from `state-vector-fallback` in a `frame=relative` section with `hasBounds=False`, then the orbit-line patch logged `reason=terminal-visible` and let stock draw the full unbounded proto-orbit. The Kerbal X upper stage, by contrast, resolved through the expected visible Parsek segment with `hasBounds=True`.~~
+
+**Fix:** `GhostMapPresence.ResolveMapPresenceGhostSource` now keeps the #583 Relative-frame state-vector path for physics-only recordings and recordings whose orbit segments are not bracketing the current UT, but defers that path when the current Relative section sits between a past bounded orbit segment and a future bounded orbit segment. The pending map vessel now stays uncreated with `relative-state-vector-segment-gap` instead of creating a no-bounds state-vector ProtoVessel during the gap, so the next Parsek-bounded segment owns the map icon/orbit line.
+
+**Coverage:** `GhostMapPresenceTests.ResolveMapPresenceGhostSource_RelativeFrame_BetweenOrbitSegments_DefersStateVectorBranch` mirrors the logged gap and asserts the resolver returns `None`, emits the new skip reason, and logs the segment-gap detail. Existing #583 coverage still proves Relative-frame recordings with only older orbit segments continue to reach the state-vector source.
+
+**Status:** CLOSED 2026-05-15.
+
+---
+
 ## Done - v0.9.2 second round of stale in-game harness failures
 
 - ~~Five in-game tests failed in the 2026-05-15 Run All + Isolated sweep: (1) `RuntimeTests.TerminalOrbitFromTail_DerivesPostBurnCircularOrbit` asserted inclination near zero but read 180° — the body-rotation-independent velocity rewrite from the previous in-game-harness fix used `Cross(Y, radial)` which, after `OrbitReseed`'s `.xzy` swap, produced angular momentum along KSP's south pole (retrograde equatorial). (2) `OnFlightReadyMergeDialogGuardInGameTest.OnFlightReady_ActiveReFlySession_SkipsMergeDialog` installed a synthetic Re-Fly marker without `InPlaceContinuation=true`; after the dispatch gate was narrowed to `IsReFlyInPlaceContinuationActive()` the synthetic marker no longer satisfied the skip, the dialog opened, and the assertion failed. (3) `RuntimeTests.EvaKerbalGhostHasVesselSnapshot` was running from a PRELAUNCH parent vessel — KSP's vessel switch to the kerbal took ~190 ms while Parsek's `DeferredEvaBranch` only deferred one frame, so the branch was built with the kerbal in BG, the periodic finalizer immediately auto-classified the kerbal as `Landed`, and the test's "active EVA branch with live recorder before first sample" wait never observed a live-EVA-recorder window. (4-5) `RnDOverlayDecoratesCommittedFutureNode` and `RnDOverlaysClearedOnDespawn` timed out for 15 s in Sandbox because `RnDBuilding.EnterBuilding()` in pure Sandbox does not instantiate an `RDController`.~~


### PR DESCRIPTION
## Summary
- Defer Relative-frame state-vector map ProtoVessels when playback is between bounded orbit segments.
- Add a GhostMapPresence regression for the rewind/map-time-warp no-bounds proto-orbit flicker.
- Document the retained log evidence and changelog entry.

## Validation
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter FullyQualifiedName~GhostMapPresenceTests
- dotnet test Source/Parsek.Tests/Parsek.Tests.csproj --filter FullyQualifiedName!~InjectAllRecordings
- Full dotnet test Source/Parsek.Tests/Parsek.Tests.csproj is blocked by the running KSP lock on KSP.log in InjectAllRecordings; KSP was not closed or modified.