### PR TITLE
Bump project version to 0.10.0; open empty 0.10.0 CHANGELOG section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Parsek are documented here.
 
 ---
 
+## 0.10.0
+
+---
+
 ## 0.9.2
 
 ### Breaking Changes

--- a/GameData/Parsek/Parsek.version
+++ b/GameData/Parsek/Parsek.version
@@ -1,7 +1,7 @@
 {
     "NAME": "Parsek",
     "URL": "https://raw.githubusercontent.com/vl3c/Parsek/main/GameData/Parsek/Parsek.version",
-    "VERSION": { "MAJOR": 0, "MINOR": 9, "PATCH": 2 },
+    "VERSION": { "MAJOR": 0, "MINOR": 10, "PATCH": 0 },
     "KSP_VERSION": { "MAJOR": 1, "MINOR": 12, "PATCH": 5 },
     "KSP_VERSION_MIN": { "MAJOR": 1, "MINOR": 12, "PATCH": 0 },
     "KSP_VERSION_MAX": { "MAJOR": 1, "MINOR": 12, "PATCH": 99 }

--- a/Source/Parsek/Properties/AssemblyInfo.cs
+++ b/Source/Parsek/Properties/AssemblyInfo.cs
@@ -17,7 +17,7 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("a1b2c3d4-e5f6-7890-abcd-ef1234567890")]
 
-[assembly: AssemblyVersion("0.9.2.0")]
-[assembly: AssemblyFileVersion("0.9.2.0")]
+[assembly: AssemblyVersion("0.10.0.0")]
+[assembly: AssemblyFileVersion("0.10.0.0")]
 
-[assembly: KSPAssembly("Parsek", 0, 9)]
+[assembly: KSPAssembly("Parsek", 0, 10)]


### PR DESCRIPTION
## Summary

Starts the next development cycle. Three file edits in lockstep:

- `Source/Parsek/Properties/AssemblyInfo.cs`: `AssemblyVersion` / `AssemblyFileVersion` `0.9.2.0` -> `0.10.0.0`; `KSPAssembly("Parsek", 0, 9)` -> `KSPAssembly("Parsek", 0, 10)`.
- `GameData/Parsek/Parsek.version`: `VERSION.MINOR` `9` -> `10`, `PATCH` `2` -> `0`. KSP min/max unchanged (still `1.12.x`).
- `CHANGELOG.md`: new empty `## 0.10.0` section inserted above `## 0.9.2`. Per-PR changelog updates land here from now on.

The `release.py` validator pairs the version string from `Parsek.version` (`0.10.0`) with the AssemblyInfo string (`0.10.0.0`), so both files step in lockstep.

This PR is independent of [#880](https://github.com/vl3c/Parsek/pull/880) (CHANGELOG trim of the released 0.9.2 section). No textual conflict expected: that PR touches lines inside the 0.9.2 section; this PR adds lines above it.

## Test plan

- [x] Debug build green (`dotnet build Source/Parsek/Parsek.csproj -c Debug` -> 0 warnings, 0 errors).
- [x] `release.py check_assembly_version()` will pair `0.10.0` from `Parsek.version` with `0.10.0.0` from `AssemblyInfo.cs`, both match.
- [x] No source / test / public-API changes; no rebuild of test suite required.