### PR TITLE
Keep RP alive when an Immutable chain-tip slot still qualifies as Unfinished Flight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to Parsek are documented here.
 - Re-Fly abandon-and-retry no longer leaves the prior session's provisional in the timeline as a phantom row. The new attempt reaps any abandoned attempt on the same rewind point before its closure walk runs, so the retry's supersede table cannot pick up an invalid row pointing at the orphan.
 - Timeline W (Watch) button now works for every launch row after a Re-Fly. The button used to render permanently disabled for any launch sitting after a superseded recording.
 - Vessels spawned at a recording's terminal orbit no longer cascade-explode the first time you Switch-To, Watch, or TS-Fly them. The fix seeds part rigidbody masses right after the spawn so landing-leg autostruts anchor to the actual heaviest part instead of whichever sibling happens to be closest.
+- Re-Fly is no longer silently stripped from a crashed slot whose recording continued through a vessel switch before being destroyed. The rewind-point reaper was reaping the RP on the next scene change even while the timeline still showed the slot as a re-flyable unfinished flight.
 
 ---
 

--- a/Source/Parsek.Tests/RewindPointReaperTests.cs
+++ b/Source/Parsek.Tests/RewindPointReaperTests.cs
@@ -335,6 +335,201 @@ namespace Parsek.Tests
             Assert.Equal(new[] { "rp_1" }, deletedRpIds);
         }
 
+        // ---------- Auto-UF keep-open (fix-rp-reap-auto-uf) -----------------
+        //
+        // An Immutable slot whose chain ends in an automatic Unfinished Flight
+        // outcome (crashed terminal, stranded EVA, non-focused stable leaf)
+        // must keep its RP alive even when the slot has never been manually
+        // stashed. The UI shows these slots as re-flyable; reaping the RP
+        // would silently strip the Re-Fly button.
+
+        [Fact]
+        public void Reap_ImmutableCrashedSlot_KeepsRpAlive()
+        {
+            // Slot's origin recording ended Destroyed. The slot is unsealed
+            // and not stashed (auto-UF, not manual). Reaper must keep RP.
+            var bp = Bp("bp_1", "rp_1");
+            InstallTree("tree_1",
+                new List<Recording>
+                {
+                    Rec("rec_a", MergeState.Immutable, TerminalState.Landed,
+                        parentBranchPointId: "bp_1"),
+                    Rec("rec_destroyed", MergeState.Immutable, TerminalState.Destroyed,
+                        parentBranchPointId: "bp_1"),
+                },
+                new List<BranchPoint> { bp });
+            var rp = Rp("rp_1", "bp_1", sessionProvisional: false,
+                Slot(0, "rec_a", sealedSlot: true),
+                Slot(1, "rec_destroyed"));
+            var scenario = InstallScenario(new List<RewindPoint> { rp });
+
+            int reaped = RewindPointReaper.ReapOrphanedRPs();
+
+            Assert.Equal(0, reaped);
+            Assert.Single(scenario.RewindPoints);
+            Assert.Equal("rp_1", bp.RewindPointId);
+            Assert.Empty(deletedRpIds);
+            Assert.Contains(logLines, l =>
+                l.Contains("[Rewind]")
+                && l.Contains("immutable-qualifies-as-unfinished-flight")
+                && l.Contains("rec=rec_destroyed"));
+        }
+
+        [Fact]
+        public void Reap_ImmutableDestroyedChainTipSlot_KeepsRpAlive()
+        {
+            // Regression for the kerbalx-probe-stash-refly playtest:
+            //   chain HEAD = CommittedProvisional (promoted by
+            //   ApplyRewindProvisionalMergeStates because it had a parentBp
+            //   link), chain TIP = Immutable (born default and never promoted,
+            //   because it has no branch link and is no slot's origin).
+            // The slot's EffectiveRecordingId walks to the TIP. Pre-fix, the
+            // reaper saw the TIP as Immutable + not stashed and dropped the
+            // RP, breaking Re-Fly on the destroyed chain.
+            var bp = Bp("bp_1", "rp_1");
+            var chainHead = new Recording
+            {
+                RecordingId = "rec_head",
+                VesselName = "Probe",
+                TreeId = "tree_1",
+                MergeState = MergeState.CommittedProvisional,
+                ParentBranchPointId = "bp_1",
+                ChainId = "chain_1",
+                ChainIndex = 0,
+            };
+            var chainTip = new Recording
+            {
+                RecordingId = "rec_tip",
+                VesselName = "Probe",
+                TreeId = "tree_1",
+                MergeState = MergeState.Immutable,
+                TerminalStateValue = TerminalState.Destroyed,
+                ChainId = "chain_1",
+                ChainIndex = 1,
+            };
+            var siblingA = Rec("rec_a", MergeState.Immutable, TerminalState.Landed,
+                parentBranchPointId: "bp_1");
+            InstallTree("tree_1",
+                new List<Recording> { siblingA, chainHead, chainTip },
+                new List<BranchPoint> { bp });
+            var rp = Rp("rp_1", "bp_1", sessionProvisional: false,
+                Slot(0, "rec_a", sealedSlot: true),
+                Slot(1, "rec_head"));
+            var scenario = InstallScenario(new List<RewindPoint> { rp });
+
+            int reaped = RewindPointReaper.ReapOrphanedRPs();
+
+            Assert.Equal(0, reaped);
+            Assert.Single(scenario.RewindPoints);
+            Assert.Equal("rp_1", bp.RewindPointId);
+            Assert.Empty(deletedRpIds);
+            // The keep-alive log must name the chain TIP (the recording the
+            // slot's effective walker landed on), proving the reaper saw the
+            // Immutable tip and still routed through Qualifies rather than
+            // the legacy unconditional `continue`.
+            Assert.Contains(logLines, l =>
+                l.Contains("[Rewind]")
+                && l.Contains("immutable-qualifies-as-unfinished-flight")
+                && l.Contains("rec=rec_tip"));
+        }
+
+        [Fact]
+        public void Reap_ImmutableStrandedEvaSlot_KeepsRpAlive()
+        {
+            // EVA crew Landed (not Boarded) qualifies as `strandedEva` per the
+            // classifier. Without manual stash, an Immutable slot in this
+            // state must still keep the RP alive.
+            var bp = Bp("bp_1", "rp_1");
+            InstallTree("tree_1",
+                new List<Recording>
+                {
+                    Rec("rec_a", MergeState.Immutable, TerminalState.Landed,
+                        parentBranchPointId: "bp_1"),
+                    Rec("rec_eva", MergeState.Immutable, TerminalState.Landed,
+                        evaCrewName: "Jebediah Kerman",
+                        parentBranchPointId: "bp_1"),
+                },
+                new List<BranchPoint> { bp });
+            var rp = Rp("rp_1", "bp_1", sessionProvisional: false,
+                Slot(0, "rec_a", sealedSlot: true),
+                Slot(1, "rec_eva"));
+            var scenario = InstallScenario(new List<RewindPoint> { rp });
+
+            int reaped = RewindPointReaper.ReapOrphanedRPs();
+
+            Assert.Equal(0, reaped);
+            Assert.Single(scenario.RewindPoints);
+            Assert.Equal("rp_1", bp.RewindPointId);
+            Assert.Empty(deletedRpIds);
+        }
+
+        [Fact]
+        public void Reap_ImmutableNonFocusStableLeafSlot_KeepsRpAlive()
+        {
+            // Non-focused stable leaf (Orbiting at a slot that isn't
+            // rp.FocusSlotIndex) qualifies as `stableLeafUnconcluded`. The
+            // focus slot must close on its own terminal path; the non-focus
+            // slot stays open until the player Seals it.
+            var bp = Bp("bp_1", "rp_1");
+            InstallTree("tree_1",
+                new List<Recording>
+                {
+                    Rec("rec_focus", MergeState.Immutable, TerminalState.Landed,
+                        parentBranchPointId: "bp_1"),
+                    Rec("rec_other", MergeState.Immutable, TerminalState.Orbiting,
+                        parentBranchPointId: "bp_1"),
+                },
+                new List<BranchPoint> { bp });
+            var rp = Rp("rp_1", "bp_1", sessionProvisional: false,
+                Slot(0, "rec_focus", sealedSlot: true),
+                Slot(1, "rec_other"));
+            rp.FocusSlotIndex = 0;
+            var scenario = InstallScenario(new List<RewindPoint> { rp });
+
+            int reaped = RewindPointReaper.ReapOrphanedRPs();
+
+            Assert.Equal(0, reaped);
+            Assert.Single(scenario.RewindPoints);
+            Assert.Equal("rp_1", bp.RewindPointId);
+            Assert.Empty(deletedRpIds);
+        }
+
+        [Fact]
+        public void Reap_ImmutableCrashedSlot_SealedClosesIt()
+        {
+            // Auto-UF keep-open is conditional on !slot.Sealed. Once the
+            // player explicitly seals a crashed slot, it counts as closed
+            // and the RP reaps on the next pass.
+            var bp = Bp("bp_1", "rp_1");
+            InstallTree("tree_1",
+                new List<Recording>
+                {
+                    Rec("rec_a", MergeState.Immutable, TerminalState.Landed,
+                        parentBranchPointId: "bp_1"),
+                    Rec("rec_destroyed", MergeState.Immutable, TerminalState.Destroyed,
+                        parentBranchPointId: "bp_1"),
+                },
+                new List<BranchPoint> { bp });
+            var crashedSlot = Slot(1, "rec_destroyed");
+            var rp = Rp("rp_1", "bp_1", sessionProvisional: false,
+                Slot(0, "rec_a", sealedSlot: true),
+                crashedSlot);
+            var scenario = InstallScenario(new List<RewindPoint> { rp });
+
+            int first = RewindPointReaper.ReapOrphanedRPs();
+            Assert.Equal(0, first);
+            Assert.Single(scenario.RewindPoints);
+
+            crashedSlot.Sealed = true;
+            crashedSlot.SealedRealTime = "2026-05-17T18:00:00.0000000Z";
+
+            int second = RewindPointReaper.ReapOrphanedRPs();
+            Assert.Equal(1, second);
+            Assert.Empty(scenario.RewindPoints);
+            Assert.Null(bp.RewindPointId);
+            Assert.Equal(new[] { "rp_1" }, deletedRpIds);
+        }
+
         [Fact]
         public void Reap_AnySlotNotCommitted_Retained()
         {

--- a/Source/Parsek.Tests/RewindPointReaperTests.cs
+++ b/Source/Parsek.Tests/RewindPointReaperTests.cs
@@ -383,9 +383,15 @@ namespace Parsek.Tests
             //   ApplyRewindProvisionalMergeStates because it had a parentBp
             //   link), chain TIP = Immutable (born default and never promoted,
             //   because it has no branch link and is no slot's origin).
-            // The slot's EffectiveRecordingId walks to the TIP. Pre-fix, the
-            // reaper saw the TIP as Immutable + not stashed and dropped the
-            // RP, breaking Re-Fly on the destroyed chain.
+            // The slot's OriginChildRecordingId = "rec_head" (chainIndex=0).
+            // slot.EffectiveRecordingId calls EffectiveState.EffectiveTipRecordingId,
+            // which hops via ResolveChainTerminalRecording: same ChainId,
+            // same ChainBranch (both default 0), higher ChainIndex wins, so
+            // rec_head (0) -> rec_tip (1). The reaper looks up rec_tip
+            // (Immutable + Destroyed) and pre-fix would drop the RP.
+            // Post-fix it routes through Qualifies, which walks the chain
+            // again from rec_tip (tip-of-self), sees terminal=Destroyed,
+            // and returns true (reason=crashed) -> RP retained.
             var bp = Bp("bp_1", "rp_1");
             var chainHead = new Recording
             {
@@ -426,11 +432,83 @@ namespace Parsek.Tests
             // The keep-alive log must name the chain TIP (the recording the
             // slot's effective walker landed on), proving the reaper saw the
             // Immutable tip and still routed through Qualifies rather than
-            // the legacy unconditional `continue`.
+            // the legacy unconditional `continue`. If the chain hop ever
+            // regresses, this assertion catches it: a broken hop would log
+            // rec=rec_head instead.
             Assert.Contains(logLines, l =>
                 l.Contains("[Rewind]")
                 && l.Contains("immutable-qualifies-as-unfinished-flight")
                 && l.Contains("rec=rec_tip"));
+        }
+
+        [Fact]
+        public void Reap_ImmutableDestroyedChainTipWithDownstreamRp_Reaped()
+        {
+            // The classifier's `downstreamBp` reject branch: a chain-tip
+            // recording whose ChildBranchPointId points at a downstream BP
+            // that has its own real RewindPoint. The destroyed terminal is
+            // no longer "open" from the upstream RP's perspective because
+            // the player can re-fly from the downstream RP instead, so the
+            // UPSTREAM rp_1 must be reapable even though the slot's
+            // effective recording is Immutable + Destroyed. The DOWNSTREAM
+            // rp_2 still owns its own re-fly slot and must NOT reap.
+            //
+            // The downstreamBp check fires only when the downstream RP's
+            // slot resolves to the chain tip via ResolveRewindPointSlotIndex
+            // ForRecording. The simplest synthetic representation is
+            // slot.OriginChildRecordingId = rec_tip (mechanism #1: direct
+            // origin-id equality); a real re-fly chain would resolve via
+            // the supersede walker, but the predicate is the same.
+            var bpUpstream = Bp("bp_1", "rp_1");
+            var bpDownstream = Bp("bp_2", "rp_2");
+            var chainHead = new Recording
+            {
+                RecordingId = "rec_head",
+                VesselName = "Probe",
+                TreeId = "tree_1",
+                MergeState = MergeState.Immutable,
+                ParentBranchPointId = "bp_1",
+                ChainId = "chain_1",
+                ChainIndex = 0,
+            };
+            var chainTip = new Recording
+            {
+                RecordingId = "rec_tip",
+                VesselName = "Probe",
+                TreeId = "tree_1",
+                MergeState = MergeState.Immutable,
+                TerminalStateValue = TerminalState.Destroyed,
+                ChildBranchPointId = "bp_2",
+                ChainId = "chain_1",
+                ChainIndex = 1,
+            };
+            InstallTree("tree_1",
+                new List<Recording> { chainHead, chainTip },
+                new List<BranchPoint> { bpUpstream, bpDownstream });
+            // Upstream slot: origin walks chain rec_head -> rec_tip.
+            var rpUpstream = Rp("rp_1", "bp_1", sessionProvisional: false,
+                Slot(0, "rec_head"));
+            // Downstream slot: origin resolves directly to rec_tip, so
+            // HasResolvedRewindPointForBranch finds a real downstream rewind
+            // route and Qualifies on rp_1's slot returns false with
+            // reason=downstreamBp.
+            var rpDownstream = Rp("rp_2", "bp_2", sessionProvisional: false,
+                Slot(0, "rec_tip"));
+            var scenario = InstallScenario(
+                new List<RewindPoint> { rpUpstream, rpDownstream });
+
+            int reaped = RewindPointReaper.ReapOrphanedRPs();
+
+            // rp_1 reaped (upstream RP no longer needed). rp_2 stays (the
+            // chain-tip's ChildBranchPointId matches rp_2.BranchPointId, so
+            // rp_2's own slot evaluates as `crashed` and keeps its RP
+            // alive for the downstream re-fly path).
+            Assert.Equal(1, reaped);
+            Assert.Single(scenario.RewindPoints);
+            Assert.Equal("rp_2", scenario.RewindPoints[0].RewindPointId);
+            Assert.Null(bpUpstream.RewindPointId);
+            Assert.Equal("rp_2", bpDownstream.RewindPointId);
+            Assert.Equal(new[] { "rp_1" }, deletedRpIds);
         }
 
         [Fact]

--- a/Source/Parsek/RewindPointReaper.cs
+++ b/Source/Parsek/RewindPointReaper.cs
@@ -237,9 +237,15 @@ namespace Parsek
                     // match. Without this branch, the reaper would treat a
                     // Destroyed chain-tip slot as closed and drop the RP that
                     // the UI is still listing as a re-flyable unfinished
-                    // flight. Qualifies(considerSealed:true) filters sealed
-                    // slots internally; the explicit !slot.Sealed short-
-                    // circuits the common case before the classifier walk.
+                    // flight. Passing considerSealed:true makes Qualifies
+                    // reject sealed slots with reason=slotSealed, so the
+                    // explicit !slot.Sealed short-circuit is purely a perf
+                    // hint (skip the classifier walk for the closed path);
+                    // removing it would not bypass the seal gate. Perf: one
+                    // Qualifies call per Immutable+unsealed slot; acceptable
+                    // at current RP counts. If reap latency ever shows up,
+                    // EffectiveTipRecordingId has a hot-loop dict overload
+                    // that can memoize chain-tip lookups across slots.
                     if (!slot.Sealed
                         && UnfinishedFlightClassifier.Qualifies(rec, slot, rp, considerSealed: true))
                     {

--- a/Source/Parsek/RewindPointReaper.cs
+++ b/Source/Parsek/RewindPointReaper.cs
@@ -174,13 +174,13 @@ namespace Parsek
         /// A <see cref="RewindPoint"/> is reap-eligible when <b>all</b> of:
         /// <list type="bullet">
         ///   <item><description><see cref="RewindPoint.SessionProvisional"/> is false (the owning session has merged).</description></item>
-        ///   <item><description>Every <see cref="ChildSlot"/>'s effective recording resolves to a closed <see cref="Recording"/>: <see cref="MergeState.Immutable"/> unless the slot is unsealed, stashed, and still qualifies as an Unfinished Flight, or sealed <see cref="MergeState.CommittedProvisional"/>.</description></item>
+        ///   <item><description>Every <see cref="ChildSlot"/>'s effective recording resolves to a closed <see cref="Recording"/>: <see cref="MergeState.Immutable"/> unless the slot is unsealed and still qualifies as an Unfinished Flight (the canonical UI-visibility predicate, which covers manual stashed-keep-open AND auto-UF outcomes: crashed terminal, stranded EVA, non-focused stable leaf), or sealed <see cref="MergeState.CommittedProvisional"/>.</description></item>
         /// </list>
         /// A slot whose OriginChildRecordingId is null/blank is treated as
         /// terminal-Immutable (there is no recording that could still be
-        /// re-flown). An RP with no slots at all is eligible — the feature
+        /// re-flown). An RP with no slots at all is eligible (the feature
         /// doesn't create empty RPs, but defensive: an empty slot list has
-        /// no open rewind arrows.
+        /// no open rewind arrows).
         /// </summary>
         internal static bool IsReapEligible(
             RewindPoint rp, IReadOnlyList<RecordingSupersedeRelation> supersedes)
@@ -225,10 +225,29 @@ namespace Parsek
                     return false;
                 if (rec.MergeState == MergeState.Immutable)
                 {
-                    if (slot.Stashed
-                        && !slot.Sealed
+                    // Keep the RP alive for any slot that still qualifies as
+                    // an Unfinished Flight. Covers the manual stashed-keep-
+                    // open exception AND the auto-UF cases (crashed terminal,
+                    // stranded EVA, non-focused stable leaf) where the slot's
+                    // chain HEAD is CommittedProvisional but its chain TIP
+                    // (the recording returned by slot.EffectiveRecordingId)
+                    // was born Immutable and never promoted, because
+                    // ApplyRewindProvisionalMergeStates only promotes
+                    // recordings with a branch-point link or origin-slot
+                    // match. Without this branch, the reaper would treat a
+                    // Destroyed chain-tip slot as closed and drop the RP that
+                    // the UI is still listing as a re-flyable unfinished
+                    // flight. Qualifies(considerSealed:true) filters sealed
+                    // slots internally; the explicit !slot.Sealed short-
+                    // circuits the common case before the classifier walk.
+                    if (!slot.Sealed
                         && UnfinishedFlightClassifier.Qualifies(rec, slot, rp, considerSealed: true))
+                    {
+                        ParsekLog.Verbose(Tag,
+                            $"IsReapEligible: keeping rp={rp.RewindPointId ?? "<no-id>"} " +
+                            $"slot={s} rec={rec.RecordingId ?? "<no-id>"} reason=immutable-qualifies-as-unfinished-flight");
                         return false;
+                    }
                     continue;
                 }
                 if (slot.Sealed)

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -12,6 +12,18 @@ When referencing prior item numbers from source comments or plans, consult the r
 
 ---
 
+## Done - v0.10.0 RewindPointReaper dropped the RP for crashed chain-tip slots, silently stripping Re-Fly
+
+- ~~User playtest `logs/2026-05-17_1728_kerbalx-probe-stash-refly/` (switch-fly-autorecord build; bug is in shared code on main). Player launched Kerbal X, decoupled "Kerbal X Probe", vessel-switched between probe and parent, eventually let the probe crash on rails at UT 1307.7. The classifier correctly marked the probe's chain-head recording `50560293…` as `IsUnfinishedFlight=true reason=crashed` (KSP.log line 20547) and `ApplyRewindProvisionalMergeStates` promoted it to `CommittedProvisional`. Two seconds later, on the FLIGHT->SPACECENTER scene change, `RewindPointReaper.ReapOrphanedRPs` deleted `rp_e2ce2420…` (line 22132). From that point on the recording stayed visible in the timeline but no longer matched any RP, so neither Re-Fly nor manual Stash was available.~~
+
+**Root cause:** `RewindPointReaper.IsReapEligible` resolves each slot's effective recording via `slot.EffectiveRecordingId(supersedes)`, a composite chain+supersede walker that returns the chain TIP. For the probe slot the walker returned `ef843aae…` (chainIndex=1), which was born `Immutable` and never promoted by `ApplyRewindProvisionalMergeStates` (it has no `parentBranchPointId`/`childBranchPointId` and no slot lists it as `OriginChildRecordingId`, so `IsUnfinishedFlightCandidateShape` rejects it). The reaper's Immutable branch only kept the RP alive when `slot.Stashed && !slot.Sealed && UnfinishedFlightClassifier.Qualifies(...)`, so any auto-UF outcome (crashed terminal, stranded EVA, non-focused stable leaf) that wasn't manually stashed fell through to `continue` (closed). The chain-head's `CommittedProvisional` state was invisible to the reaper because the walker landed on the tip.
+
+**Fix:** In `RewindPointReaper.IsReapEligible`, route all unsealed Immutable slots through `UnfinishedFlightClassifier.Qualifies(rec, slot, rp, considerSealed:true)`. The classifier already walks the chain via `ResolveChainTerminalRecording`, matches the slot via `ResolveRewindPointSlotIndexForRecording`'s composite tip walker, and returns true for `crashed` / `strandedEva` / `stashedStableLeaf` / `stableLeafUnconcluded`, giving a single source of truth with `IsVisibleUnfinishedFlight` (the UI predicate). Sealed slots return false from `Qualifies(considerSealed:true)`, so the explicit `!slot.Sealed` short-circuit just avoids the classifier walk for the closed path. Five new unit tests in `RewindPointReaperTests`:`Reap_ImmutableCrashedSlot_KeepsRpAlive`, `Reap_ImmutableDestroyedChainTipSlot_KeepsRpAlive` (regression for this exact scenario), `Reap_ImmutableStrandedEvaSlot_KeepsRpAlive`, `Reap_ImmutableNonFocusStableLeafSlot_KeepsRpAlive`, and `Reap_ImmutableCrashedSlot_SealedClosesIt`.
+
+**Status:** CLOSED 2026-05-17.
+
+---
+
 ## Done - v0.10.0 Parsek-spawned terminal-orbit vessels cascade-exploded on first Switch-To / Watch / TS-Fly
 
 - ~~A vessel spawned at a recording's terminal orbit (canonical case: the stock Kerbal X with three `ForceHeaviest`-autostrutted `landingLeg1-2` legs surface-attached to the Rockomax fuel tank) cascade-exploded within ~40 ms of being focused. The central stack (pod, heatshield, parachute, tank, decoupler, antenna) blew up while the legs detached cleanly. Reproduced in `logs/2026-05-17_1437_switch-fly-test/` against a Parsek-spawned Kerbal X at alt 418 km.~~


### PR DESCRIPTION
## Summary

- Fix: `RewindPointReaper` was dropping the rewind point for crashed slots whose recording continued through a vessel switch and ended Destroyed on the chain TIP. The UI kept listing the recording as a re-flyable Unfinished Flight, but Re-Fly / Stash silently went away on the next scene change.
- Routes all unsealed Immutable slots through `UnfinishedFlightClassifier.Qualifies(considerSealed:true)`, the same predicate the UI uses, so the reaper's notion of "closed" matches `IsVisibleUnfinishedFlight`.
- Five new `RewindPointReaperTests` cover the four `Qualifies`-true reasons (`crashed`, `strandedEva`, `stashedStableLeaf` already covered, `stableLeafUnconcluded`) plus the sealed-closes-it transition. The chain-tip-Destroyed test is the explicit regression for the playtest scenario.

## Root cause

`RewindPointReaper.IsReapEligible` looked up each slot's effective recording via `slot.EffectiveRecordingId(supersedes)`, a composite chain+supersede walker that returns the chain TIP. The chain TIP of a Destroyed Probe chain is born `Immutable` and never promoted by `ApplyRewindProvisionalMergeStates`, because `IsUnfinishedFlightCandidateShape` requires either a branch-point link or an origin-slot match and a chain continuation has neither. The reaper's Immutable branch kept the RP alive only when `slot.Stashed && !slot.Sealed && Qualifies(...)`, so any unstashed auto-UF outcome fell through to `continue` (closed) and the RP was reaped.

## Test plan

- [x] `dotnet build` clean.
- [x] `dotnet test` clean: 11937 passed, 0 failed.
- [x] `dotnet test --filter RewindPointReaperTests` clean: 27 passed (22 existing + 5 new).
- [ ] In-game: re-walk the kerbalx-probe-stash-refly scenario (launch, decouple probe, vessel-switch, let probe crash on rails, return to KSC, verify Re-Fly stays on the timeline).

## References

- Playtest: `logs/2026-05-17_1728_kerbalx-probe-stash-refly/` (chain head `50560293…` CP + chain tip `ef843aae…` Immutable+Destroyed, RP `rp_e2ce2420…` reaped at line 22132).
- Investigation thread in this session; docs/dev/todo-and-known-bugs.md "Done - v0.10.0 RewindPointReaper dropped the RP for crashed chain-tip slots".