### PR TITLE
fix: chain-shadow path now respects IsGhostHeld so it cannot hide the watched ghost

### DIFF
--- a/Source/Parsek/GhostPlaybackEngine.cs
+++ b/Source/Parsek/GhostPlaybackEngine.cs
@@ -1070,7 +1070,31 @@ namespace Parsek
                     : -1;
                 bool continuationHasActiveGhost = chainNextIndex >= 0
                     && HasActiveGhost(chainNextIndex);
-                if (inRange && ChainHandoffLogic.DecideShadow(
+                // Defensive: never shadow the watched head. WatchModeController
+                // already coordinates the chain transition via its own destroy
+                // path (`auto-followed during hold`) and only fires after the
+                // continuation's ghost is active, so in normal flow the watch
+                // transfer wins the race and the head is destroyed before
+                // the shadow ever runs. But for chains whose head and
+                // continuation sectionUTs overlap (post-optimizer splits
+                // routinely leave a sub-second overlap), there is a 1-2 frame
+                // window where the head is still in-range AND watched AND the
+                // continuation has just activated. Without this guard the
+                // shadow would SetActive(false) on the watched ghost mesh in
+                // that window. The downstream watch transfer then destroys
+                // the head a frame or two later. Mesh hiding is visually
+                // subtle because the continuation's mesh is at an
+                // approximately overlapping world position, but the watch
+                // camera target should never be a deactivated ghost
+                // GameObject — IsGhostHeld(i) returns true only for the
+                // watched slot (or a held-pending-spawn slot), so the guard
+                // closes the race without affecting non-watched chain
+                // segments which is the primary case the shadow fixes.
+                // Bridge-hold path below is already gated by !IsGhostHeld
+                // via the surrounding stale-past-end cleanup branch.
+                if (inRange
+                    && (IsGhostHeld == null || !IsGhostHeld(i))
+                    && ChainHandoffLogic.DecideShadow(
                         chainNextIndex, continuationHasActiveGhost))
                 {
                     if (ghostActive && state != null && state.ghost != null


### PR DESCRIPTION
## Summary

Defensive follow-up to PR #897. The chain-seam shadow path in `GhostPlaybackEngine.UpdatePlayback` was missing the `IsGhostHeld` guard that its sibling bridge-hold path already had.

## Race window this guard closes

For chains whose head and continuation sectionUTs overlap (post-optimizer splits routinely leave a sub-second overlap), there is a 1-2 frame interval where:

- The head is still in-range (`currentUT <= traj.EndUT`)
- The head is the watched slot (`IsGhostHeld(i) == true`)
- The continuation has just activated (`HasActiveGhost(chainNextIndex) == true`)

In that window, the shadow path would call `state.ghost.SetActive(false)` on the watched head's mesh. `WatchModeController.ProcessWatchEndHoldTimer` then runs in a later frame and destroys the head normally via its `auto-followed during hold` path. Visually it's subtle (the continuation's mesh is at an overlapping world position so the player still sees a vessel), but the watch camera target should never be a deactivated `GameObject`.

## The fix

One-line conjunction on the shadow gate at [`GhostPlaybackEngine.cs:1073`](Source/Parsek/GhostPlaybackEngine.cs):

```csharp
if (inRange
    && (IsGhostHeld == null || !IsGhostHeld(i))   // ← new
    && ChainHandoffLogic.DecideShadow(chainNextIndex, continuationHasActiveGhost))
```

This mirrors the `IsGhostHeld == null || !IsGhostHeld(i)` pattern already in use immediately below in the stale-past-end cleanup branch (where the chain-bridge-hold path lives). With this guard, `WatchModeController`'s auto-follow remains the only path that touches the watched head's `GameObject` lifecycle at the seam.

## Why no new test

- `ChainHandoffLogic.DecideShadow` is unchanged. The 30 existing xUnit cases continue to pin the decision logic.
- The new conjunction is a short-circuit boolean at the engine call site mirroring an existing pattern; a parallel engine-level test would require substantial fixture setup (mock `IsGhostHeld`, mock `ResolveChainNextIndex`, configured chain in `committed[]`, full `UpdatePlayback` cycle) for a one-line guard.
- Per the local "low-risk small single-file fixes... self-review and report validation" convention.

## Test plan

- [x] `dotnet build` clean.
- [x] `dotnet test` green (12211 passing, up from 12203 in #897 thanks to PRs #898/#899 landed in the meantime).
- [ ] Optional playtest: watch a chain across the seam (the user's previous playtest did this); expect identical behavior to PR #897, no regression in normal-case shadow firing on non-watched chain segments.