### PR TITLE
Declutter Timeline Details tab: de-dup and hide no-op rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to Parsek are documented here.
 ### UI
 
 - Watch mode now cycles to the next watchable ghost on W. Stock pitch input (W and S) is locked out on the unattended active vessel while watching, and the watch overlay hint reads `[ ] return  |  V camera  |  W cycle`.
+- Timeline Details tab is far less cluttered: part purchases, tech unlocks, and contract events that already appear as ledger rows are no longer also listed as duplicate legacy rows, and free (zero-funds) part unlocks are hidden entirely. Part-purchase rows now read "Part: {name} -{cost}" instead of "Expense -0".
 
 ### Bug Fixes
 

--- a/Source/Parsek.Tests/GameStateEventConverterTests.cs
+++ b/Source/Parsek.Tests/GameStateEventConverterTests.cs
@@ -1091,5 +1091,36 @@ namespace Parsek.Tests
             Assert.Equal(100.0, action.UT);
             Assert.Equal("rec-wf", action.RecordingId);
         }
+
+        // ================================================================
+        // ParsePartPurchaseChargedCost — shared by the converter and the
+        // Timeline legacy-collector free-part skip.
+        // ================================================================
+
+        [Fact]
+        public void ParsePartPurchaseChargedCost_PrefersCostTokenOverEntryCost()
+        {
+            // Stock-default bypass shape: charged cost is 0 even though entryCost is set.
+            Assert.Equal(0f, GameStateEventConverter.ParsePartPurchaseChargedCost("cost=0;entryCost=800"));
+        }
+
+        [Fact]
+        public void ParsePartPurchaseChargedCost_UsesCostWhenPositive()
+        {
+            Assert.Equal(1200f, GameStateEventConverter.ParsePartPurchaseChargedCost("cost=1200;entryCost=1200"));
+        }
+
+        [Fact]
+        public void ParsePartPurchaseChargedCost_FallsBackToEntryCost_WhenCostAbsent()
+        {
+            Assert.Equal(600f, GameStateEventConverter.ParsePartPurchaseChargedCost("entryCost=600"));
+        }
+
+        [Fact]
+        public void ParsePartPurchaseChargedCost_NoTokens_ReturnsZero()
+        {
+            Assert.Equal(0f, GameStateEventConverter.ParsePartPurchaseChargedCost(null));
+            Assert.Equal(0f, GameStateEventConverter.ParsePartPurchaseChargedCost(""));
+        }
     }
 }

--- a/Source/Parsek.Tests/TimelineBuilderTests.cs
+++ b/Source/Parsek.Tests/TimelineBuilderTests.cs
@@ -2150,5 +2150,198 @@ namespace Parsek.Tests
                 ParsekScenario.SetInstanceForTesting(null);
             }
         }
+
+        // ================================================================
+        // Zero-cost part-purchase noise suppression (timeline display)
+        // ================================================================
+
+        [Fact]
+        public void NoOpZeroFundsSpending_IsFilteredFromTimeline()
+        {
+            // A free part unlock (bypass-entry-purchase) records a FundsSpending(0)
+            // action in the ledger as an audit record, but it carries no information
+            // in the timeline. It must not produce a row. A real (non-zero) spend must.
+            var actions = new List<GameAction>
+            {
+                new GameAction
+                {
+                    UT = 100,
+                    Type = GameActionType.FundsSpending,
+                    Effective = true,
+                    FundsSpendingSource = FundsSpendingSource.Other,
+                    FundsSpent = 0f,
+                    DedupKey = "solidBooster.v2"
+                },
+                new GameAction
+                {
+                    UT = 200,
+                    Type = GameActionType.FundsSpending,
+                    Effective = true,
+                    FundsSpendingSource = FundsSpendingSource.Other,
+                    FundsSpent = 1200f,
+                    DedupKey = "liquidEngine2"
+                }
+            };
+
+            var result = TimelineBuilder.Build(
+                new List<Recording>(),
+                actions,
+                new List<Milestone>(),
+                _ => true);
+
+            Assert.DoesNotContain(result, e =>
+                e.Source == TimelineSource.GameAction && e.UT == 100);
+            var shown = Assert.Single(result.Where(e => e.Source == TimelineSource.GameAction));
+            Assert.Equal(200, shown.UT);
+            Assert.Contains(logLines, l =>
+                l.Contains("[Timeline]") && l.Contains("no-op (zero-funds) spending action"));
+        }
+
+        [Fact]
+        public void NonZeroPartPurchase_RowShowsPartName()
+        {
+            // The legacy PartPurchased twin (which used to supply the part name) is
+            // de-duped away, so the surviving ledger row must carry the part name.
+            var actions = new List<GameAction>
+            {
+                new GameAction
+                {
+                    UT = 200,
+                    Type = GameActionType.FundsSpending,
+                    Effective = true,
+                    FundsSpendingSource = FundsSpendingSource.Other,
+                    FundsSpent = 1200f,
+                    DedupKey = "liquidEngine2"
+                }
+            };
+
+            var result = TimelineBuilder.Build(
+                new List<Recording>(),
+                actions,
+                new List<Milestone>(),
+                _ => true);
+
+            var row = Assert.Single(result.Where(e => e.Source == TimelineSource.GameAction));
+            Assert.Equal("Part: liquidEngine2 -1200", row.DisplayText);
+        }
+
+        [Fact]
+        public void LegacyFreePartPurchaseEvent_IsSkipped()
+        {
+            // A legacy PartPurchased event with charged cost 0 (bypass shape
+            // "cost=0;entryCost=<raw>") is pure noise — its ledger twin is filtered
+            // as a no-op spend, so the legacy row must be skipped too.
+            var milestone = new Milestone
+            {
+                Committed = true,
+                Epoch = 0,
+                Events = new List<GameStateEvent>
+                {
+                    new GameStateEvent
+                    {
+                        ut = 100,
+                        eventType = GameStateEventType.PartPurchased,
+                        key = "solidBooster.v2",
+                        detail = "cost=0;entryCost=800"
+                    }
+                }
+            };
+
+            var result = TimelineBuilder.Build(
+                new List<Recording>(),
+                new List<GameAction>(),
+                new List<Milestone> { milestone },
+                _ => true);
+
+            Assert.DoesNotContain(result, e => e.Source == TimelineSource.Legacy);
+            Assert.Contains(logLines, l =>
+                l.Contains("[Timeline]") && l.Contains("free (zero-cost) legacy part-purchase"));
+        }
+
+        [Fact]
+        public void LegacyTechContractPartDuplicates_AreFilteredWhenMatchingGameActionsExist()
+        {
+            // Tech research, contract accept, and (non-zero) part purchase all appear in
+            // both the ledger and the legacy milestone store. The legacy twin must be
+            // de-duped against the matching ledger action so each shows exactly once.
+            var milestone = new Milestone
+            {
+                Committed = true,
+                Epoch = 0,
+                Events = new List<GameStateEvent>
+                {
+                    new GameStateEvent
+                    {
+                        ut = 300,
+                        eventType = GameStateEventType.TechResearched,
+                        key = "basicRocketry",
+                        detail = "cost=5"
+                    },
+                    new GameStateEvent
+                    {
+                        ut = 310,
+                        eventType = GameStateEventType.ContractAccepted,
+                        key = "guid-1",
+                        detail = "title=Test Contract"
+                    },
+                    new GameStateEvent
+                    {
+                        ut = 320,
+                        eventType = GameStateEventType.PartPurchased,
+                        key = "liquidEngine2",
+                        detail = "cost=1200"
+                    }
+                }
+            };
+
+            var actions = new List<GameAction>
+            {
+                new GameAction
+                {
+                    UT = 300,
+                    Type = GameActionType.ScienceSpending,
+                    Effective = true,
+                    NodeId = "basicRocketry",
+                    Cost = 5f
+                },
+                new GameAction
+                {
+                    UT = 310,
+                    Type = GameActionType.ContractAccept,
+                    Effective = true,
+                    ContractId = "guid-1",
+                    ContractTitle = "Test Contract"
+                },
+                new GameAction
+                {
+                    UT = 320,
+                    Type = GameActionType.FundsSpending,
+                    Effective = true,
+                    FundsSpendingSource = FundsSpendingSource.Other,
+                    FundsSpent = 1200f,
+                    DedupKey = "liquidEngine2"
+                }
+            };
+
+            var result = TimelineBuilder.Build(
+                new List<Recording>(),
+                actions,
+                new List<Milestone> { milestone },
+                _ => true);
+
+            // No legacy rows survive — all three are de-duped against the ledger.
+            Assert.DoesNotContain(result, e => e.Source == TimelineSource.Legacy);
+
+            // The ledger rows are present and self-describing.
+            Assert.Contains(result, e =>
+                e.Source == TimelineSource.GameAction &&
+                e.Type == TimelineEntryType.ScienceSpending);
+            Assert.Contains(result, e =>
+                e.Source == TimelineSource.GameAction &&
+                e.Type == TimelineEntryType.ContractAccept);
+            Assert.Contains(result, e =>
+                e.Source == TimelineSource.GameAction &&
+                e.DisplayText == "Part: liquidEngine2 -1200");
+        }
     }
 }

--- a/Source/Parsek/GameActions/GameActionDisplay.cs
+++ b/Source/Parsek/GameActions/GameActionDisplay.cs
@@ -284,6 +284,7 @@ namespace Parsek
                 case FundsSpendingSource.KerbalHire:      return "Hire";
                 case FundsSpendingSource.ContractPenalty:  return "Contract penalty";
                 case FundsSpendingSource.Strategy:        return "Strategy";
+                case FundsSpendingSource.Other:           return "Part";
                 default:                                  return "Expense";
             }
         }

--- a/Source/Parsek/GameActions/GameStateEventConverter.cs
+++ b/Source/Parsek/GameActions/GameStateEventConverter.cs
@@ -439,11 +439,7 @@ namespace Parsek
         /// </remarks>
         private static GameAction ConvertPartPurchased(GameStateEvent evt, string recordingId)
         {
-            float cost = 0f;
-            string costStr = ExtractDetail(evt.detail, "cost")
-                          ?? ExtractDetail(evt.detail, "entryCost");
-            if (costStr != null)
-                float.TryParse(costStr, NumberStyles.Float, IC, out cost);
+            float cost = ParsePartPurchaseChargedCost(evt.detail);
 
             // DedupKey uses the part name so multiple part purchases at KSC (where
             // RecordingId is null) do not collide under GetActionKey. See #F in
@@ -458,6 +454,22 @@ namespace Parsek
                 FundsSpendingSource = FundsSpendingSource.Other,
                 DedupKey = evt.key ?? ""
             };
+        }
+
+        /// <summary>
+        /// Parses the actual charged cost from a PartPurchased event detail. `cost=` is
+        /// authoritative (0 under bypass-entry-purchase); falls back to `entryCost=` only
+        /// when `cost=` is absent (pre-#451 events). Shared by the converter guard and the
+        /// Timeline legacy-collector skip so both agree on what counts as a free unlock.
+        /// </summary>
+        internal static float ParsePartPurchaseChargedCost(string detail)
+        {
+            string costStr = ExtractDetail(detail, "cost")
+                          ?? ExtractDetail(detail, "entryCost");
+            float cost = 0f;
+            if (costStr != null)
+                float.TryParse(costStr, NumberStyles.Float, IC, out cost);
+            return cost;
         }
 
         /// <summary>

--- a/Source/Parsek/Timeline/TimelineBuilder.cs
+++ b/Source/Parsek/Timeline/TimelineBuilder.cs
@@ -580,6 +580,52 @@ namespace Parsek
                         action.UT,
                         action.StrategyId);
 
+                // ScienceSpending is the ledger form of a TechResearched legacy event
+                // (ConvertTechResearched). Match on the node id.
+                case GameActionType.ScienceSpending:
+                    return EncodeLegacyDuplicateKey(
+                        GameStateEventType.TechResearched,
+                        action.UT,
+                        action.NodeId);
+
+                // Part purchases are the only FundsSpending source that has a legacy
+                // GameStateEvent twin (PartPurchased). VesselBuild / facility / hire
+                // spending has no PartPurchased equivalent, so leave those alone.
+                // DedupKey carries the part name set by ConvertPartPurchased.
+                case GameActionType.FundsSpending:
+                    return action.FundsSpendingSource == FundsSpendingSource.Other
+                        ? EncodeLegacyDuplicateKey(
+                            GameStateEventType.PartPurchased,
+                            action.UT,
+                            action.DedupKey)
+                        : null;
+
+                // Contract lifecycle actions duplicate their legacy GameStateEvent twins;
+                // match on the contract guid carried in ContractId / legacy event key.
+                case GameActionType.ContractAccept:
+                    return EncodeLegacyDuplicateKey(
+                        GameStateEventType.ContractAccepted,
+                        action.UT,
+                        action.ContractId);
+
+                case GameActionType.ContractComplete:
+                    return EncodeLegacyDuplicateKey(
+                        GameStateEventType.ContractCompleted,
+                        action.UT,
+                        action.ContractId);
+
+                case GameActionType.ContractFail:
+                    return EncodeLegacyDuplicateKey(
+                        GameStateEventType.ContractFailed,
+                        action.UT,
+                        action.ContractId);
+
+                case GameActionType.ContractCancel:
+                    return EncodeLegacyDuplicateKey(
+                        GameStateEventType.ContractCancelled,
+                        action.UT,
+                        action.ContractId);
+
                 default:
                     return null;
             }
@@ -609,6 +655,7 @@ namespace Parsek
             int evaReassignSkipped = 0;
             int modeSeedSkipped = 0;
             int hireCostSuffixSuppressed = 0;
+            int noopSpendSkipped = 0;
             for (int i = 0; i < ledgerActions.Count; i++)
             {
                 var action = ledgerActions[i];
@@ -616,6 +663,17 @@ namespace Parsek
                 if (!IsInitialResourceSeedVisibleInMode(action.Type, currentMode))
                 {
                     modeSeedSkipped++;
+                    continue;
+                }
+
+                // A FundsSpending action that moves no funds (e.g. a free part unlock
+                // under bypass-entry-purchase) is kept in the ledger as an audit record
+                // but carries no information in the timeline. Skip these so the Details
+                // tab isn't flooded with "Part: x -0" / "Expense -0" no-op rows. The
+                // ledger row, recovery, and load-repair contracts are unaffected.
+                if (action.Type == GameActionType.FundsSpending && action.FundsSpent <= 0f)
+                {
+                    noopSpendSkipped++;
                     continue;
                 }
 
@@ -687,6 +745,10 @@ namespace Parsek
             if (hireCostSuffixSuppressed > 0)
                 ParsekLog.Verbose("Timeline",
                     $"Filtered {hireCostSuffixSuppressed} kerbal-hire funds suffix(es) in mode {FormatModeForLog(currentMode)}");
+
+            if (noopSpendSkipped > 0)
+                ParsekLog.Verbose("Timeline",
+                    $"Filtered {noopSpendSkipped} no-op (zero-funds) spending action(s)");
 
             return count;
         }
@@ -775,6 +837,7 @@ namespace Parsek
         {
             int count = 0;
             int duplicateSkipped = 0;
+            int freePartSkipped = 0;
 
             for (int i = 0; i < milestones.Count; i++)
             {
@@ -786,6 +849,18 @@ namespace Parsek
                     var e = m.Events[j];
                     if (!isLegacyEventVisible(e)) continue;
                     if (GameStateStore.IsMilestoneFilteredEvent(e.eventType)) continue;
+
+                    // Free part unlocks (charged cost 0) move no funds and are pure noise.
+                    // Their ledger twin is filtered as a no-op spend (FundsSpent <= 0) in
+                    // CollectGameActionEntries rather than de-duped, so the de-dup set below
+                    // never holds a key for them. Skip the legacy event directly here too.
+                    if (e.eventType == GameStateEventType.PartPurchased &&
+                        GameStateEventConverter.ParsePartPurchaseChargedCost(e.detail) <= 0f)
+                    {
+                        freePartSkipped++;
+                        continue;
+                    }
+
                     if (legacyDuplicateKeys.Contains(EncodeLegacyDuplicateKey(e.eventType, e.ut, e.key)))
                     {
                         duplicateSkipped++;
@@ -811,7 +886,11 @@ namespace Parsek
 
             if (duplicateSkipped > 0)
                 ParsekLog.Verbose("Timeline",
-                    $"Filtered {duplicateSkipped} duplicate legacy milestone/strategy event(s)");
+                    $"Filtered {duplicateSkipped} duplicate legacy event(s) already shown as ledger actions");
+
+            if (freePartSkipped > 0)
+                ParsekLog.Verbose("Timeline",
+                    $"Filtered {freePartSkipped} free (zero-cost) legacy part-purchase event(s)");
 
             return count;
         }

--- a/Source/Parsek/Timeline/TimelineEntryDisplay.cs
+++ b/Source/Parsek/Timeline/TimelineEntryDisplay.cs
@@ -339,6 +339,16 @@ namespace Parsek
 
                 case GameActionType.FundsSpending:
                 {
+                    // Part purchases (source==Other) carry the part name in DedupKey.
+                    // Render it inline so the row is self-describing: the legacy
+                    // PartPurchased twin that used to supply the name is now de-duped
+                    // away in TimelineBuilder.
+                    if (action.FundsSpendingSource == FundsSpendingSource.Other)
+                    {
+                        string part = string.IsNullOrEmpty(action.DedupKey) ? "part" : action.DedupKey;
+                        return string.Format(IC, "Part: {0} -{1:0}", part, action.FundsSpent);
+                    }
+
                     string source;
                     switch (action.FundsSpendingSource)
                     {

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -12,6 +12,17 @@ When referencing prior item numbers from source comments or plans, consult the r
 
 ---
 
+## Done - v0.10.0 Timeline Details tab flooded with duplicate and no-op part/tech/contract rows
+
+- Investigation 2026-05-20 (`logs/2026-05-20_1833_timeline-investigation/`). The Details tab listed 50 rows for a short two-launch career, dominated by noise: a VAB build burst at one UT produced ~20 rows. Two distinct causes.
+- **Cause 1 (duplication):** the timeline merges ledger game-actions and the legacy milestone-store events, but the legacy de-dup (`TimelineBuilder.GetLegacyDuplicateKey`) only covered `MilestoneAchievement` / `StrategyActivate` / `StrategyDeactivate`. `PartPurchased`, `TechResearched`, and the contract lifecycle events exist in BOTH stores and were rendered twice (once as a ledger row, once as a legacy row).
+- **Cause 2 (no-op rows):** under the stock `BypassEntryPurchaseAfterResearch` setting, researching a tech node auto-unlocks its parts for free; stock KSP still fires `OnPartPurchased` per part, so `ConvertPartPurchased` records a `FundsSpending(Other, 0)` ledger action per part. That zero-funds action is an intentional ledger audit record (also synthesized by `TryRecoverBrokenLedgerOnLoad` / `RepairLegacyPartPurchaseActionsOnLoad`, pinned by tests), so it is NOT dropped at the converter; it is purely a display problem.
+- **Fix (display-only, ledger contract untouched):** (1) `GetLegacyDuplicateKey` now also de-dups `TechResearched` (NodeId), `PartPurchased` (DedupKey, source==Other only), and `ContractAccepted/Completed/Failed/Cancelled` (ContractId) against their ledger twins. (2) `CollectGameActionEntries` skips `FundsSpending` actions with `FundsSpent <= 0` (no-op spends). (3) `CollectLegacyEntries` skips `PartPurchased` legacy events whose charged cost is 0 (their ledger twin is filtered, so de-dup can't catch them). (4) Surviving (non-zero) part-purchase rows now render `Part: {name} -{cost}` via the part name in `DedupKey`, instead of the generic `Expense -0`. Charged-cost parsing is shared via `GameStateEventConverter.ParsePartPurchaseChargedCost`.
+- **Tests:** four `TimelineBuilderTests` (no-op spend filtered, part-name relabel, free legacy part skipped, Tech/Contract/Part legacy de-dup end-to-end) plus four `GameStateEventConverterTests` for the shared cost parser.
+- **Status:** CLOSED 2026-05-20.
+
+---
+
 ## Done - v0.10.0 Live Re-Fly fork floated at the recordings-table root instead of nesting in its mission folder
 
 - Playtest 2026-05-20 (`logs/2026-05-20_1737_refly-orphan-recording/`). During an in-place Rewind-to-Separation on "Kerbal X" (tree `e7ca34dc...`), the in-flight fork `rec_77dbe31a...` showed in the recordings list as a row outside any mission folder; it vanished when the user discarded the re-fly attempt.


### PR DESCRIPTION
## Summary

The Timeline **Details** tab was cluttered with duplicate and no-op rows. Investigated against a real two-launch career save (`logs/2026-05-20_1833_timeline-investigation/`), the tab rendered 50 rows, ~20 of them at a single VAB-build timestamp. Two root causes:

- **Duplication:** the timeline merges ledger game-actions with the legacy milestone-store events, but the legacy de-dup (`TimelineBuilder.GetLegacyDuplicateKey`) only covered milestones and strategies. Part purchases, tech unlocks, and contract events exist in *both* stores and were rendered twice.
- **No-op rows:** under the stock `BypassEntryPurchaseAfterResearch` setting, researching a tech node auto-unlocks its parts for free; stock KSP still fires `OnPartPurchased` per part, so a `FundsSpending(Other, 0)` ledger action is recorded per part. That zero-funds action is an **intentional** ledger audit record (also synthesized by `TryRecoverBrokenLedgerOnLoad` / `RepairLegacyPartPurchaseActionsOnLoad`, pinned by tests), so it is NOT a bug to fix at the converter. It is purely a display problem.

### Changes (display-only, ledger contract untouched)

- `GetLegacyDuplicateKey` now also de-dups `TechResearched` (NodeId), `PartPurchased` (DedupKey, `source==Other` only), and the four contract lifecycle events (ContractId) against their ledger twins.
- `CollectGameActionEntries` skips `FundsSpending` actions with `FundsSpent <= 0` (no-op spends).
- `CollectLegacyEntries` skips `PartPurchased` legacy events whose charged cost is 0 (their ledger twin is filtered, so de-dup can't catch them).
- Surviving (non-zero) part-purchase rows now render `Part: {name} -{cost}` instead of the generic `Expense -0`. Charged-cost parsing is shared via the new `GameStateEventConverter.ParsePartPurchaseChargedCost`.

In the sample save this drops the Details tab from 50 rows to ~30, and the VAB-build burst collapses to the two real tech unlocks.

### Approach note

An earlier plan dropped the zero-cost action at the converter. Investigation showed that action is a deliberate cross-path ledger contract (capture + recovery + load-repair, ~6 test files), so suppression was kept at the display layer instead. This also cleans up already-persisted saves, which a converter-side change would not.

## Test plan

- [x] `dotnet test` green: 12218 passed, 0 failed (8 new).
- [x] New `TimelineBuilderTests`: no-op spend filtered, part-name relabel, free legacy part skipped, Tech/Contract/Part legacy de-dup end-to-end.
- [x] New `GameStateEventConverterTests` for the shared `ParsePartPurchaseChargedCost`.
- [ ] In-game spot check of the Details tab on a bypass-on career (no `Expense -0` rows; no duplicate Part/Tech/Contract rows).