### PR TITLE
docs: archive refactor planning docs (implemented in #923/#926/#927)

### DIFF
--- a/docs/dev/done/refactor/ghostplayback-hotpath-decomposition.md
+++ b/docs/dev/done/refactor/ghostplayback-hotpath-decomposition.md
@@ -1,0 +1,671 @@
+> STATUS: Implemented in PR #926 (GhostPlaybackEngine hot-path decomposition). Archived as a historical reference. The Part 6 hot-path invariants still constrain any future edit to UpdatePlayback / RenderInRangeGhost.
+
+# GhostPlaybackEngine Hot-Path Decomposition Plan
+
+Read-only planning doc. NO `.cs` edits land with this commit. This plan covers the two
+large per-frame hot-path methods in `Source/Parsek/GhostPlaybackEngine.cs`:
+
+- `UpdatePlayback(...)` (the per-frame outer loop + diagnostics finalization)
+- `RenderInRangeGhost(...)` (in-range spawn / position / visuals pipeline)
+
+Both were flagged as too risky for opportunistic one-shot extraction: many
+`continue`-terminated guard branches sharing mutable locals (`state`, `ghostActive`),
+and allocation sensitivity (these run for every trajectory every frame, with many
+ghosts active simultaneously).
+
+The implementation that follows this plan is a separate, disciplined,
+zero-logic-change pass governed by `docs/dev/refactor-guidelines.md` (the 13-item
+behavior-preserving checklist). Every extraction below names which checklist items
+make it safe, the allocation analysis, and the risk.
+
+## Hard constraints carried from the guidelines
+
+- Same call position, no reordering (item 2).
+- No logic changes: no condition added / removed / reordered, no new branch (item 3).
+- Control flow preserved: every `continue` / `break` / `return` keeps identical timing
+  (item 4). In the per-frame loop this is the dominant hazard: a guard that does
+  `if (cond) { log; continue; }` must keep firing the `continue` from inside the loop
+  body, so a guard cluster can only be extracted as a **predicate** that the loop body
+  still acts on (`if (ShouldSkipX(...)) { ...same body...; continue; }`), never as a
+  method that itself owns the `continue`.
+- Logging content + timing + level unchanged (item 9). Several guard branches emit a
+  `GhostRenderTrace.EmitGuardSkip`, a `CountFrameSkip(reason)`, and sometimes a
+  `ParsekLog.VerboseRateLimited`. The order and the exact strings stay put.
+- No pre-existing access-modifier change (items 7, 13). If a candidate helper needs a
+  `private` type, it stays `private` (scale back, never widen the pre-existing type).
+- **ZERO new allocation in these per-frame paths**: no closures, no params objects, no
+  LINQ, no `string.Format`/interpolation that wasn't already there, no boxing. New pure
+  helpers take primitives / structs / interface refs by value and return a primitive or
+  a `readonly struct`. `out` is used instead of returning a tuple where the parent needs
+  more than one value back (a tuple of value types does not allocate, but `out` keeps
+  the call shape closest to the inline original and is the project convention).
+
+## Pre-condition: M2 is already merged on this base
+
+This base (`origin/main`) already contains the M2 narrow-pass extractions:
+`RelativeAnchorResolution.ShouldSkipPostPositionPipeline(...)` (called at 11 sites) and
+the static `ResolveRenderSurface(...)` helper. Do NOT re-plan those. This plan anchors
+on block/function semantics, not line numbers, because the surrounding line numbers will
+keep shifting.
+
+A large amount of pure logic is **already** carved out of these two methods into
+`GhostPlaybackLogic`, `ChainHandoffLogic`, `RelativeAnchorResolution`, and
+`PlaybackTrajectoryBoundsResolver` (`ShouldSuppressGhosts`, `ShouldSuppressVisualFx`,
+`ShouldSuppressGhostMeshAtWarp`, `ShouldFireHiddenPastEndCompletion`, `DecideShadow`,
+`DecideBridgeHold`, `ShouldLoopPlayback`, `HasRenderableGhostData`,
+`ResolveGhostActivationStartUT`, `ShouldHoldInitialActivationHiddenThisFrame`,
+`ShouldRestoreDeferredRuntimeFxState`, `ResolveVisiblePlaybackUT`, ...). This shrinks the
+high-value testability surface that remains: most decision math is already a tested pure
+helper. What is left inline is mostly *orchestration* (call this engine method, then
+that one, mutate `state`, `continue`) which is exactly the part that resists
+behavior-preserving extraction.
+
+---
+
+# Part 1 - `UpdatePlayback`
+
+## 1.1 Structural map
+
+`UpdatePlayback(IReadOnlyList<IPlaybackTrajectory> trajectories, TrajectoryPlaybackFlags[] flags, FrameContext ctx)`
+
+### Phase A - Preamble (before the loop)
+1. `ClearPrimaryGhostPositionedThisFrame()`.
+2. Three early-return guards (null/empty trajectories, null positioner, flags array
+   mismatch). Each sets `DiagnosticsState.playbackBudget = default` and returns; the
+   third also warns.
+3. Compute frame-wide flags: `suppressGhosts`, `suppressVisualFx`,
+   `RebuildAutoLoopLaunchScheduleCache(...)`, `ResetPerFramePlaybackCounters(...)`.
+4. Initialize loop-scoped accumulators: `spawnMicroseconds`, `ghostsProcessed`,
+   `trajectoriesIterated`.
+5. Build the optional engine-iteration trace `StringBuilder` (allocated **only** when
+   `ghostRenderTracing == true`; steady-state cost zero).
+
+### Phase B - Per-trajectory loop (`for i in [0, count)`)
+Shared mutable locals that flow across blocks inside one iteration:
+- `traj` (read-only after assignment), `f` (read-only struct copy).
+- `state` (`GhostPlaybackState`, **mutated**: assigned from dictionary, nulled and
+  rebuilt in loop-sync cycle-change, reassigned inside `RenderInRangeGhost` via `ref`).
+- `ghostActive` (`bool`, **mutated** across blocks and via `ref` into
+  `RenderInRangeGhost`).
+- Per-iteration read-only derived booleans: `hasPointData`, `hasInterpolatedPoints`,
+  `hasOrbitData`, `hasSurfaceData`, `inRange`, `pastEnd`, `pastEffectiveEnd`,
+  `activationStartUT`, `chainNextIndex`, `continuationHasActiveGhost`.
+
+Guard / dispatch branches in order (each terminates the iteration with `continue`,
+except the in-range render which `continue`s only on `true`, and the past-end tail which
+falls through):
+
+| # | Block | Terminator | Mutates before terminator |
+|---|-------|-----------|----------------------------|
+| B0 | engine-iter trace append | none (side effect) | builder |
+| B1 | `f.skipGhost` (destroy + maybe hidden-past-end completion) | `continue` | destroys ghost, may fire completion |
+| B2 | `!HasRenderableGhostData` | `continue` | none |
+| B3 | re-fly `sessionSuppressed` (unless companion debris) | `continue` | destroys ghost |
+| B4 | read `state` / compute `ghostActive` / `ghostsProcessed++` | none | reads state |
+| B5 | `f.anchorReFlyUnstable` | `continue` | deactivates ghost, resets appearance |
+| B6 | `currentUT < activationStartUT` | `continue` | removes dedup sets, destroys ghost |
+| B7 | compute `inRange` / `pastEnd` / `pastEffectiveEnd` | none | none |
+| B8 | `ShouldLoopPlayback(traj)` -> loop dispatch | `continue` | calls `UpdateLoopingPlayback`, anchor-gate destroy |
+| B9 | non-loop overlap-ghost cleanup | none | destroys overlap ghosts |
+| B10 | loop-synced debris (parent loop clock) | `continue` | destroys ghost, rebuilds state, renders via parent clock |
+| B11 | warp suppression | `continue` | deactivates ghost |
+| B12 | chain-seam **shadow** (head hidden while continuation renders) | `continue` | deactivates ghost, clears bridge map |
+| B13 | in-range render `if (RenderInRangeGhost(...)) continue;` | conditional `continue` | mutates `state`/`ghostActive` by `ref` |
+| B14 | past-end completion (`HandlePastEndGhost`) | fall-through | fires completion |
+| B15 | stale past-end cleanup + chain-seam **bridge-hold** | fall-through (loop end) | holds or destroys head |
+
+### Phase C - Post-loop finalization (after the loop)
+1. Emit the engine-iteration trace line (only when builder was created).
+2. Frame batch summary (`BuildCurrentFrameCounters` -> `ShouldEmitFrameSummary` ->
+   `VerboseRateLimited`).
+3. Capture `elapsedTicksAtLoopEnd`.
+4. Fire deferred created events; fire deferred completed events (two simple loops over
+   `deferredCreatedEvents` / `deferredCompletedEvents`, each timed by a stopwatch).
+5. Observability capture (timed).
+6. Stop `updateStopwatch`; convert ticks->microseconds for total / spawn / destroy.
+7. Populate `DiagnosticsState.playbackBudget.*` and append frame history.
+8. Compute the `#414` / `#450` per-phase microsecond breakdown locals (a dozen
+   tick->us divisions, several `if (x < 0) x = 0` floors).
+9. Build the `PlaybackBudgetPhases phases = new PlaybackBudgetPhases { ... }` struct
+   (it is a `struct`; the object-initializer is a stack value, **not** a heap alloc).
+10. `DiagnosticsComputation.CheckPlaybackBudgetThresholdWithBreakdown(...)`.
+
+## 1.2 Decomposition proposal for `UpdatePlayback`
+
+The loop body (Phase B) is the part the maintainer flagged, and it is genuinely the
+hardest to carve safely because every block shares `state` / `ghostActive` and ends in a
+`continue` that must fire from the loop body. The high-value, low-risk wins here are
+**(a) the Phase C finalization tail** (no loop, no `continue`, no shared mutable ghost
+state, pure arithmetic + struct population) and **(b) a small number of read-only
+predicate / pure-computation extractions inside the loop**.
+
+### U1 (lowest risk, do first) - Extract the budget-phase arithmetic into a pure builder
+
+- **Helper:** `internal static PlaybackBudgetPhases BuildPlaybackBudgetPhases(...)`
+- **What it covers:** Phase C step 8 + step 9 - the dozen tick->microsecond conversions,
+  the three `if (x < 0) x = 0` floors, and the `new PlaybackBudgetPhases { ... }`
+  initializer. It is currently a straight-line block with no branches other than the
+  floors and no instance-state writes (it only reads stopwatch elapsed-tick values and
+  per-frame counter fields, then returns the struct).
+- **Signature (all by value, no `out`):**
+  ```
+  internal static PlaybackBudgetPhases BuildPlaybackBudgetPhases(
+      long elapsedTicksAtLoopEnd,
+      long spawnMicroseconds,
+      long destroyMicroseconds,
+      long deferredCreatedTicks, long deferredCompletedTicks, long observabilityTicks,
+      int trajectoriesIterated, int overlapGhostIterationCount,
+      int createdEventsFired, int completedEventsFired,
+      int spawnsAttempted, int spawnsThrottled, long frameMaxSpawnTicks,
+      long buildSnapshotResolveTicks, long buildTimelineTicks,
+      long buildDictionariesTicks, long buildReentryFxTicks,
+      long heaviestSnapshotResolveTicks, long heaviestTimelineTicks,
+      long heaviestDictionariesTicks, long heaviestReentryTicks,
+      long heaviestOtherTicks, HeaviestSpawnBuildType heaviestBuildType)
+  ```
+  The parent still does the four `*Stopwatch.ElapsedTicks` reads and passes ticks in;
+  the helper does the `* 1000000L / Stopwatch.Frequency` divisions and floors. Reason for
+  passing ticks (not pre-divided microseconds): the parent already pre-divides
+  `spawnMicroseconds` / `destroyMicroseconds` before this point (they feed the
+  `DiagnosticsState` writes), so those two come in as microseconds; everything else is
+  internal to the breakdown and is passed as raw ticks so the division stays in one
+  place. Match the existing pre-divided values exactly (`spawnMicroseconds`,
+  `destroyMicroseconds` are reused, not recomputed).
+- **Allocation:** zero. `PlaybackBudgetPhases` is a value struct; the `new { ... }`
+  expression constructs it on the caller's stack slot via copy-return. No params object,
+  no closure.
+- **Checklist items that make it safe:** 2 (called from exact same position), 3 (no
+  condition change; the floors are copied verbatim), 11 (primitives in, struct out - no
+  field-to-param laundering beyond what the block already read locally), 12 (pure
+  `static`, touches no instance field once the tick values are passed in).
+- **Risk:** Low. The one trap is the `spawnMicroseconds` value: it is both written into
+  `DiagnosticsState.playbackBudget.spawnMicroseconds` AND fed into the breakdown's
+  `buildOtherMicroseconds = spawnMicroseconds - (sub-phases)`. The helper must receive
+  the **same** already-divided `spawnMicroseconds` long, not recompute it from ticks, or
+  rounding could differ by 1us. Pass the local through; do not re-read the stopwatch.
+- **Testability win:** Yes. A `GhostPlaybackEngineExtractedTests` case can assert the
+  floor behavior (negative `buildOtherMicroseconds` clamps to 0; negative
+  `mainLoopMicroseconds` clamps to 0) and the tick->us conversion, with deterministic
+  `Stopwatch.Frequency`-independent inputs by passing ticks chosen relative to
+  `Stopwatch.Frequency`. This is the single best testability win in `UpdatePlayback`.
+
+### U2 (low risk) - Extract the deferred-event firing tail into a private method
+
+- **Helper:** `private void FireDeferredFrameEvents(out int createdEventsFired, out int completedEventsFired)`
+- **What it covers:** Phase C step 4 - start/stop of `deferredCreatedStopwatch`, the loop
+  firing `OnGhostCreated?.Invoke(...)`, the count capture, then the same for completed.
+- **Signature:** `out int, out int` (parent needs both counts back for the budget struct).
+  No `ref`. Reads `deferredCreatedEvents` / `deferredCompletedEvents` / the two
+  stopwatches / the two events - all instance state, so the method is `private`
+  (non-static) per item 12.
+- **Allocation:** zero (two index `for` loops, no `foreach` enumerator boxing - keep the
+  index-`for` form exactly; do NOT switch to `foreach`, which would change IL and could
+  allocate an enumerator for some collection types).
+- **Checklist items:** 2, 3, 4 (the loops fire the same events in the same order), 8 (NOT
+  a loop-split - these are two already-separate loops, kept separate), 9 (event
+  invocations are the existing side effects, unchanged), 12.
+- **Risk:** Low-medium. The subtle point: the `out` counts are captured **before** the
+  loops in the original (`int createdEventsFired = deferredCreatedEvents.Count;` then the
+  loop). Preserve that ordering - capture count, then iterate - because nothing adds to
+  the lists during firing, but matching the original read order is the safe default.
+- **Testability:** Low (touches events + stopwatches; better verified by the existing
+  budget/event integration tests than a new unit test). Extract for readability, not for
+  a new test.
+
+### U3 (low risk) - Extract the three Phase-A early-return guards' shared epilogue? NO.
+
+Considered and rejected. The three guards each do
+`DiagnosticsState.playbackBudget = default; return;` and the third also warns. They look
+dedup-able but they are three **distinct** `return` sites with different conditions, and
+collapsing them would either (a) change when the warn fires or (b) bury a `return` inside
+a helper (forbidden by item 4 unless done as `if (TryX()) return;`, which buys nothing
+here because there is no shared body to extract). Leave inline. See Do-NOT-touch list.
+
+### U4 (medium risk, optional) - Extract the loop-synced-debris block (B10) as a whole
+
+- **Helper:** `private bool TryUpdateLoopSyncedDebris(int i, IPlaybackTrajectory traj, TrajectoryPlaybackFlags f, FrameContext ctx, IReadOnlyList<IPlaybackTrajectory> trajectories, bool suppressGhosts, bool suppressVisualFx, ref GhostPlaybackState state, ref bool ghostActive)`
+  returning `true` when the caller should `continue` (i.e. when B10's parent-loop branch
+  was taken, including all its internal `continue` paths).
+- **What it covers:** the entire `if (traj.LoopSyncParentIdx >= 0 && ... ) { if
+  (ShouldLoopPlayback(parent)) { ... } }` block. The outer `if` body's only exit when the
+  inner `ShouldLoopPlayback(parent)` is true is `continue` (every internal path either
+  `continue`s or falls to the trailing `continue` at the block's end). When the parent is
+  NOT looping, the block falls through to B11.
+- **Shape:** `if (TryUpdateLoopSyncedDebris(...)) continue;` placed at B10's exact
+  position. The helper returns `false` in exactly two cases that today fall through:
+  (a) `LoopSyncParentIdx` out of range, (b) parent not looping. Returns `true` in every
+  case where the original block reaches a `continue`.
+- **Allocation:** The block contains `var syncCtx = ctx; syncCtx.currentUT = parentLoopUT;`
+  - `FrameContext` is a struct, this is a stack copy, zero heap. Keep it as a local inside
+  the helper. No closures.
+- **Checklist items:** 2, 3, 4 (every `continue` becomes `return true`, the fall-throughs
+  become `return false`; the caller's `if (...) continue;` reproduces the control flow
+  exactly), 5 (the block is cohesive - it does not interleave with B11's mutations because
+  B10 always either `continue`s or falls through having mutated nothing B11 reads beyond
+  `state`/`ghostActive`, which are passed by `ref`), 11 (`ref state` / `ref ghostActive`
+  because the cycle-change path nulls `state` and the inner render reassigns both; the
+  caller does not actually read them after a fall-through, but passing by `ref` keeps the
+  mutation contract identical to inline), 12 (`private`, reads `overlapGhosts`,
+  `ghostStates`, `completedEventFired`, calls instance methods - must be non-static).
+- **Risk:** Medium. This is the most aggressive `UpdatePlayback` extraction proposed. The
+  hazard is the `out`-style multi-exit: B10 has 4 distinct `continue` points plus a
+  trailing one, and a `parentLoopUT`/`parentCycle`/`parentPaused` triple from
+  `TryComputeLoopPlaybackUT`. The implementer must map each original `continue` to a
+  `return true` and each fall-through to `return false`, and must NOT let the
+  `state = null` / `ghostActive = false` writes in the cycle-change path escape the helper
+  in a way that differs from inline (they are `ref`, so they propagate identically - but
+  the caller never reads them on the `true` path because it `continue`s, and on the
+  `false` path B10 did not write them, so it is safe either way). **Recommend gating U4
+  behind a dedicated review pass** (clean-context Opus reviewer per the guidelines)
+  because it is the one block here where a misplaced `continue`/`return` mapping would
+  silently change ghost lifecycle.
+- **Testability:** Low directly (instance-heavy), but it isolates the parent-loop-clock
+  dispatch into one named method, which makes the surrounding loop readable.
+
+### Verdict for `UpdatePlayback`
+
+Safe extractions found: **U1, U2, U4** (3). U3 rejected for cause.
+- Top picks: **U1 `BuildPlaybackBudgetPhases`** (pure, the one real testability win) and
+  **U2 `FireDeferredFrameEvents`** (clean tail, readability).
+- U4 is worth doing but only with its own review gate.
+
+**Honest verdict:** `UpdatePlayback` should be **only partially / conservatively
+decomposed.** The Phase C finalization tail (U1 + U2) carves cleanly and is worth it. The
+Phase B loop body should stay largely inline: it is 15 sequential guard/dispatch blocks
+that all share `state` + `ghostActive` and each end in a `continue` that must fire from
+the loop body. Carving more than U4 out of it would either (a) require predicate helpers
+so thin they add a call without removing logic (the decisions are already in
+`GhostPlaybackLogic`/`ChainHandoffLogic`), or (b) bury `continue`s inside helpers
+(forbidden). A "full" decomposition of the loop body cannot be done behavior-preservingly
+without turning each block into a `Try…(…, out bool shouldContinue)` shim, which is more
+error-prone than the inline form and adds zero testability (the math is already extracted).
+Stop at U1 + U2 (+ optionally U4 behind review).
+
+---
+
+# Part 2 - `RenderInRangeGhost`
+
+## 2.1 Structural map
+
+`private bool RenderInRangeGhost(int i, IPlaybackTrajectory traj, TrajectoryPlaybackFlags f, FrameContext ctx, bool suppressVisualFx, bool hasPointData, bool hasInterpolatedPoints, bool hasSurfaceData, bool hasOrbitData, bool allowEarlyDestroyedDebrisCompletion, ref GhostPlaybackState state, ref bool ghostActive)`
+
+Returns `bool`: `true` => caller should `continue` (ghost processed / handled);
+`false` => caller falls through to the past-end / cleanup tail.
+
+Shared mutable locals across the method: `state` (`ref`, reassigned), `ghostActive`
+(`ref`, reassigned), `usedBodyFixedPrimary` (`bool`, set by the positioning chain via
+`out`), `visiblePlaybackUT`, `retired`, `zoneResult` (struct).
+
+### Phase R0 - early-completion short-circuit
+`if (allowEarlyDestroyedDebrisCompletion && earlyDestroyedDebrisCompleted.Contains(i)) return true;`
+
+### Phase R1 - pre-spawn parent-anchored coverage retire
+Resolve `initialCoveragePlaybackUT`, then
+`if (TryHandleParentAnchoredDebrisCoverageRetired(...)) return true;` (sets `ghostActive`
+via `out`).
+
+### Phase R2 - flag events
+`GhostPlaybackLogic.ApplyFlagEvents(state, traj, ctx.currentUT);` (runs whether or not
+`state` exists - independent of ghost visuals).
+
+### Phase R3 - first-spawn (when `state == null`)
+1. dead-on-arrival suppression: `if (deadOnArrivalPastEnd && deadOnArrivalNotHeld) { count; log; return false; }`
+2. spawn-slot throttle: `if (!TryReserveSpawnSlot(...)) return false;`
+3. create pending state, store in `ghostStates[i]`, `EnsureGhostVisualsLoaded(...)`.
+4. on `Failed`: count, remove, `ghostActive = false`, `return false`.
+5. on `Pending`: `ghostActive = false`, `return true`.
+
+### Phase R4 - `if (state == null) return false;` (defensive)
+
+### Phase R5 - zone rendering
+1. resolve `renderDistance`, `activeVesselDistance`, `CachePlaybackDistances(...)`.
+2. `zoneResult = positioner.ApplyZoneRendering(...)`.
+3. `if (zoneResult.hiddenByZone) { trace; ghostActive = HandleHiddenGhostVisualState(...); return true; }`
+
+### Phase R6 - rehydrate visuals when not loaded
+`if (!HasLoadedGhostVisuals(state)) { throttle; EnsureGhostVisualsLoaded(...); handle Failed/Pending; }`
+(Failed -> `return false`; Pending -> `return true`.)
+
+### Phase R7 - recompute `ghostActive`; `if (!ghostActive) return false;`
+
+### Phase R8 - LOD fidelity + begin-frame trace + clear retire signal
+`ApplyDistanceLodFidelity`, resolve `visiblePlaybackUT`, `BeginFrame`,
+`state.anchorRetiredThisFrame = false`, `usedBodyFixedPrimary = false`.
+
+### Phase R9 - positioning chain (the big nested `if`)
+`if (!TryRetireParentAnchoredDebrisOutsideRecordedRelativeCoverage(...)) { ... }` containing
+the `hasInterpolatedPoints` / `hasPointData` / `hasSurfaceData` / `hasOrbitData` dispatch,
+each branch choosing orbit-tail vs relative-section vs interpolate/point/surface/orbit
+positioning. Sets `usedBodyFixedPrimary` via `out`.
+
+### Phase R10 - post-position pipeline
+1. `retired = RelativeAnchorResolution.ShouldSkipPostPositionPipeline(state.anchorRetiredThisFrame);`
+2. `GhostRenderTrace.EmitPostUpdate(... ResolveRenderSurface(usedBodyFixedPrimary, retired) ...)`.
+3. `if (!retired) MarkPrimaryGhostPositionedThisFrame(state);`
+4. `if (retired) { ApplyFrameVisuals(skipPartEvents:true, suppress:true, transient:false); }`
+   `else { ... initial-activation-hidden decision + ApplyFrameVisuals + activation ... }`
+   The `else` branch is itself a two-way split on `initialActivationHidden`.
+
+### Phase R11 - playback trace (non-retired only)
+`if (!retired) PlaybackTrace.MaybeEmitFrame(...);`
+
+### Phase R12 - early-destroyed-debris completion (side-effect only)
+`if (allowEarlyDestroyedDebrisCompletion && !retired) TryHandleEarlyDestroyedDebrisCompletion(...);`
+`else if (allowEarlyDestroyedDebrisCompletion && retired) VerboseRateLimited(...);`
+
+### Phase R13 - `return true;`
+
+## 2.2 Decomposition proposal for `RenderInRangeGhost`
+
+`RenderInRangeGhost` is already heavily delegated: most of its phases are single calls to
+already-extracted helpers (`TryHandleParentAnchoredDebrisCoverageRetired`,
+`ApplyZoneRendering`, `EnsureGhostVisualsLoaded`, `ApplyFrameVisuals`,
+`ShouldHoldInitialActivationHiddenThisFrame`, `RelativeAnchorResolution.*`,
+`ResolveRenderSurface`). The two remaining cohesive multi-statement blocks worth carving
+are R3 (first-spawn) and the R10 non-retired `else` branch (the
+initial-activation-hidden vs activate split).
+
+### R-A (low risk, do first) - Extract the dead-on-arrival predicate (pure)
+
+- **Helper:** `internal static bool IsSpawnSuppressedDeadOnArrival(double currentUT, double endUT, double chainEndUT, bool ghostHeld)`
+- **What it covers:** the boolean computation inside R3 step 1:
+  `bool deadOnArrivalPastEnd = currentUT > endUT || currentUT > chainEndUT;` and
+  `bool deadOnArrivalNotHeld = !ghostHeld;` collapsed into the single decision
+  `deadOnArrivalPastEnd && deadOnArrivalNotHeld`. The call site keeps the `count + log +
+  return false` body inline (item 4: do not bury the `return`).
+- **Call shape:** `if (IsSpawnSuppressedDeadOnArrival(ctx.currentUT, traj.EndUT, f.chainEndUT, IsGhostHeld != null && IsGhostHeld(i))) { ...count/log/return false... }`
+  The `IsGhostHeld == null || !IsGhostHeld(i)` short-circuit must be evaluated **at the
+  call site** and passed in as the already-resolved `ghostHeld` bool, NOT re-derived in
+  the helper (the helper has no access to the `IsGhostHeld` delegate, and we will not pass
+  a delegate - that would be a closure-ish param the project avoids). Compute
+  `bool ghostHeld = IsGhostHeld != null && IsGhostHeld(i);` at the site and pass
+  `ghostHeld`. Watch the De Morgan (item 1): original is
+  `deadOnArrivalNotHeld = IsGhostHeld == null || !IsGhostHeld(i)`, i.e.
+  "not held". The helper's last param is named `ghostHeld`, so the site passes
+  `IsGhostHeld != null && IsGhostHeld(i)` and the helper does
+  `... && !ghostHeld`. Verify this inversion carefully in review.
+- **Allocation:** zero (4 primitives in, bool out).
+- **Checklist items:** 1 (De Morgan on the held inversion - flagged above), 2, 3, 11
+  (primitives, no delegate param), 12 (`static`, no instance state).
+- **Risk:** Low, with one explicit De Morgan trap called out above.
+- **Testability:** Yes. Truth-table test across `currentUT` vs `endUT`/`chainEndUT` and
+  the held flag. Good unit-test win.
+
+### R-B (low risk) - Extract the first-spawn block (R3) as a private method
+
+- **Helper:** `private FirstSpawnOutcome TryFirstSpawn(int i, IPlaybackTrajectory traj, TrajectoryPlaybackFlags f, FrameContext ctx, ref GhostPlaybackState state, ref bool ghostActive)`
+  where `FirstSpawnOutcome` is a `private enum { ContinueOuter, ReturnTrue, ReturnFalse, Proceed }`.
+- **What it covers:** all of R3 (the `if (state == null) { ... }` block): dead-on-arrival
+  (using R-A), spawn-slot throttle, create pending state + store, `EnsureGhostVisualsLoaded`,
+  Failed/Pending handling.
+- **Call shape:**
+  ```
+  if (state == null)
+  {
+      switch (TryFirstSpawn(i, traj, f, ctx, ref state, ref ghostActive))
+      {
+          case FirstSpawnOutcome.ReturnTrue:  return true;
+          case FirstSpawnOutcome.ReturnFalse: return false;
+          // Proceed: fall through to R4
+      }
+  }
+  ```
+  This keeps every `return` at the **caller's** statement level (item 4: the helper
+  returns an outcome enum; the caller owns the `return`). `state` and `ghostActive` are
+  `ref` because the helper assigns `state = CreatePendingSpawnState(...)`, writes
+  `ghostStates[i] = state`, and sets `ghostActive = false` on Failed/Pending.
+- **Access-modifier note (item 13):** `FirstSpawnOutcome` is a NEW `private enum`, so the
+  helper that consumes it must be `private` (not `internal`) per item 13 - a `private`
+  param/return type forces the method `private`. That is acceptable: `TryFirstSpawn`
+  touches `ghostStates`, `IsGhostHeld`, `TryReserveSpawnSlot`, `CreatePendingSpawnState`,
+  `EnsureGhostVisualsLoaded` (all instance), so it must be `private` anyway.
+- **Allocation:** zero. The enum return is a value type; no params object; the existing
+  `VerboseRateLimited` string concat inside the dead-on-arrival branch is the SAME string
+  building that already exists (do not "improve" it). The `state` rebuild allocates a
+  `GhostPlaybackState` exactly as the inline code does today - that is pre-existing
+  allocation, not new.
+- **Checklist items:** 2, 3, 4 (outcome enum keeps `return`s at caller), 5 (R3 is
+  cohesive; on `Proceed` the only mutation that escapes is `state`/`ghostActive` by `ref`,
+  which is exactly what R4+ read next - identical to inline), 9 (logs unchanged), 11
+  (`ref` justified, no delegate param), 12/13 (`private` forced by the `private enum`).
+- **Risk:** Medium. Two traps: (1) the `Pending` path returns `true` with
+  `ghostActive = false`, while `Failed` returns `false` with `ghostActive = false` and a
+  `ghostStates.Remove(i)` - the enum mapping must preserve which one removes from the
+  dictionary; (2) on the success path the original FALLS THROUGH to R4 (`if (state ==
+  null) return false;`) - the helper must return `Proceed` (not touch the dictionary
+  beyond the store) so R4 still runs. Recommend a review gate on R-B.
+- **Testability:** Low (instance + Unity-ish via `CreatePendingSpawnState`). Extract for
+  readability; rely on existing `Bug414SpawnThrottleTests` / `HeldGhostSpawnTests` for
+  behavioral coverage rather than a new unit test.
+
+### R-C (low risk, do first alongside R-A) - Extract the orbit-tail-vs-relative decision booleans (pure)
+
+- **Helper:** none new needed at the top level, but the two booleans at the head of R9
+  are pure and worth a named pure helper IF they are not already one:
+  `bool authoredGapHasShadow = AuthoredFrameGapHasShadowCoverage(traj, visiblePlaybackUT);`
+  and `bool orbitTailPlayback = !authoredGapHasShadow && ShouldUseOrbitTailPlayback(traj, visiblePlaybackUT);`
+  Both `AuthoredFrameGapHasShadowCoverage` and `ShouldUseOrbitTailPlayback` are ALREADY
+  extracted helpers. The composite `orbitTailPlayback` is a one-liner that is read in two
+  sibling branches (`hasInterpolatedPoints` and `hasPointData`).
+- **Recommendation:** Do **not** extract a `ResolveOrbitTailPlayback(...)` wrapper. It
+  would save nothing (the inputs are already computed once and the expression is one
+  `&&`), and folding it into a helper risks moving the `!authoredGapHasShadow`
+  short-circuit. **Leave inline.** Listed here so the implementer does not "discover" it
+  as a candidate and carve a pointless wrapper.
+
+### R-D (medium risk, optional, review-gated) - Extract the non-retired post-position branch (R10 `else`)
+
+- **Helper:** `private void ApplyNonRetiredPostPosition(int i, IPlaybackTrajectory traj, FrameContext ctx, GhostPlaybackState state, double visiblePlaybackUT, bool suppressVisualFx, ZoneRenderResult zoneResult, ref bool ghostActive)`
+  (param type `ZoneRenderResult` must match `positioner.ApplyZoneRendering`'s return type;
+  if that type is `private`/nested, the helper must be `private` too - it already is).
+- **What it covers:** the `else` arm of `if (retired) { ... } else { ... }` in R10 -
+  computing `effectiveSkipPartEvents` / `effectiveSuppressVisualFx`, the
+  `ShouldHoldInitialActivationHiddenThisFrame` call, the `EmitActivationDecision` trace,
+  and the two-way split (`initialActivationHidden` -> hide + suppressed `ApplyFrameVisuals`
+  + the long `VerboseRateLimited`; else -> `ActivateGhostVisualsIfNeeded` +
+  `ApplyFrameVisuals` + `RestoreDeferredRuntimeFxState` + `TrackGhostAppearance`).
+- **Allocation:** zero new - the long `VerboseRateLimited` message concat already exists;
+  pass `zoneResult` by value (struct) so no boxing. `ghostActive` by `ref` (the hidden
+  path sets `ghostActive = false`).
+- **Checklist items:** 2, 3, 4 (no `return`/`continue` inside - it is straight-line with
+  an inner `if/else`, both arms fall out the bottom), 5 (cohesive; the `ghostActive`
+  write is the only escape, by `ref`), 9 (the activation-decision trace + the long
+  verbose line are byte-for-byte preserved), 11, 12.
+- **Risk:** Medium. It is a faithful block move with no control-flow exits, which is the
+  *easiest* shape to preserve, BUT it reads several locals (`zoneResult`,
+  `visiblePlaybackUT`, `suppressVisualFx`) and the `state?.ghost` null-checks must keep
+  their exact short-circuit form (item 1). The `Vector3 ghostPosition = hasGhostTransform
+  ? state.ghost.transform.position : Vector3.zero;` and the `EmitActivationDecision`
+  argument list must be copied verbatim. Recommend review gate.
+- **Testability:** Low (Unity transforms, FX). Readability extraction only.
+
+### R-E (rejected) - Do NOT extract the R9 positioning dispatch
+
+The nested `if (!TryRetire...) { if (hasInterpolatedPoints) {...} else if (hasPointData)
+{...} ... }` looks extractable but it (a) writes `usedBodyFixedPrimary` via `out` that
+R10 reads, (b) calls four different `positioner.*` methods plus
+`TryPositionRelativeSectionAtPlaybackUT`, and (c) the branch ordering
+(`hasInterpolatedPoints` before `hasPointData`) is load-bearing. Extracting it gains no
+testability (it is pure dispatch into already-tested positioners) and risks reordering the
+data-shape branches (item 3) or mis-threading `usedBodyFixedPrimary` (item 11). Leave
+inline. See Do-NOT-touch list.
+
+### Verdict for `RenderInRangeGhost`
+
+Safe extractions found: **R-A, R-B, R-D** (3). R-C and R-E rejected for cause.
+- Top picks: **R-A `IsSpawnSuppressedDeadOnArrival`** (pure, testable, De-Morgan flagged)
+  and **R-B `TryFirstSpawn`** (the biggest cohesive block, readability + isolates the
+  spawn lifecycle).
+- R-D is a clean straight-line block move worth doing behind a review gate.
+
+**Honest verdict:** `RenderInRangeGhost` can be **moderately decomposed** - more usefully
+than `UpdatePlayback`'s loop body, because R3 (first-spawn) and R10-`else` are cohesive
+blocks rather than a chain of `continue`-guards. But it should still be a *conservative*
+carve: R-A (pure predicate) is the only new testability win; R-B and R-D are readability
+moves that each need their own review pass. The positioning dispatch (R9) and the
+data-shape branch ordering must stay inline. Do not attempt a "full" carve into one helper
+per phase - phases R1, R2, R5, R6, R7, R8 are already single delegated calls, so wrapping
+them buys nothing and multiplies `ref`-threading risk.
+
+---
+
+# Part 3 - Explicit ordering (lowest-risk-first, one commit each)
+
+Each step is independently compilable, the suite (`cd Source/Parsek.Tests && dotnet test`)
+must pass between steps, and each is a separate commit. Steps marked **(review gate)**
+should get a clean-context Opus reviewer per `docs/dev/refactor-guidelines.md` before the
+next step.
+
+1. **U1** - `BuildPlaybackBudgetPhases` (pure; add `GhostPlaybackEngineExtractedTests`
+   cases). Lowest risk, highest testability. No `ref`, no control flow.
+2. **R-A** - `IsSpawnSuppressedDeadOnArrival` (pure; add tests). Watch the De Morgan.
+3. **U2** - `FireDeferredFrameEvents` (private, `out` counts, two index-loops). Readability.
+4. **R-D** - `ApplyNonRetiredPostPosition` (private block move, no control-flow exits).
+   **(review gate)** - straight-line but reads many locals.
+5. **R-B** - `TryFirstSpawn` + `private enum FirstSpawnOutcome`. **(review gate)** -
+   multi-exit mapping + dictionary side effects.
+6. **U4** - `TryUpdateLoopSyncedDebris`. **(review gate)** - the most aggressive carve;
+   4+ `continue` sites to map to `return true`/`false`. Do this LAST so the easier wins
+   are banked first and the suite is green before the riskiest change.
+
+If review on any of steps 4-6 surfaces a behavior-preservation doubt, scale that step
+back (drop the extraction) rather than weakening the guideline - a `private` method that
+ships untested is fine; a behavior change is not.
+
+---
+
+# Part 4 - Do-NOT-touch list (stays inline)
+
+These blocks must remain inline because extracting them would change control flow, bury a
+`return`/`continue`, or let block N's mutation alter block N+1 (checklist item 5).
+
+1. **`UpdatePlayback` Phase-A early-return guards (B-pre).** Three distinct `return`
+   sites with different conditions; the third also warns. No shared body to extract;
+   collapsing them risks moving the warn or burying a `return`. (Item 4.)
+2. **`UpdatePlayback` Phase-B guard chain B1, B3, B5, B6, B8, B11, B12, B15.** Each is a
+   guard that ends in a `continue` that MUST fire from the loop body. They share `state`
+   and `ghostActive`. The decision math each one uses is already a pure helper
+   (`ShouldSuppressGhostMeshAtWarp`, `DecideShadow`, `DecideBridgeHold`,
+   `ShouldFireHiddenPastEndCompletion`, ...). Wrapping the *bodies* would bury the
+   `continue`; wrapping the *conditions* buys nothing because they are already extracted.
+   Leave inline. (Items 3, 4, 5.)
+3. **`UpdatePlayback` B13 in-range render call.** It is already a single
+   `if (RenderInRangeGhost(...)) continue;`. Nothing to extract.
+4. **`UpdatePlayback` B14 + B15 boundary.** `HandlePastEndGhost` (B14) is already a
+   helper. B15's stale-cleanup + bridge-hold mutates `chainBridgeOpenedUT` and either
+   holds (logs, traces, counts) or destroys. Grouping B14 and B15 would let B14's
+   completion side effects reorder against B15's bridge decision. Keep separate. (Item 5.)
+5. **`RenderInRangeGhost` R9 positioning dispatch.** Branch ordering
+   (`hasInterpolatedPoints` before `hasPointData` before `hasSurfaceData` before
+   `hasOrbitData`) is load-bearing; `usedBodyFixedPrimary` is threaded out and read by
+   R10. Extraction risks reordering data-shape branches or mis-threading the `out`.
+   (Items 3, 11.)
+6. **`RenderInRangeGhost` R0/R1/R2/R4/R5/R6/R7/R8 single-call phases.** Already delegated
+   to extracted helpers or trivial one-liners; wrapping multiplies `ref`-threading risk
+   for zero gain.
+7. **`RenderInRangeGhost` R10 `retired` (true) arm.** It is a single `ApplyFrameVisuals`
+   call with fixed suppress flags. Do not pair it with the `else` arm into one method -
+   the two arms have different `ApplyFrameVisuals` argument sets and the `if (retired)`
+   branch must stay the decision point (the `else` is R-D, extracted alone).
+8. **`TryHandleEarlyDestroyedDebrisCompletion`, `HandlePastEndGhost`,
+   `UpdateLoopingPlayback`, `TryComputeLoopPlaybackUT`** - already separate methods; out
+   of scope for this plan (not the two flagged methods).
+
+---
+
+# Part 5 - New tests enabled
+
+Add a new file `Source/Parsek.Tests/GhostPlaybackEngineExtractedTests.cs` following the
+existing `*ExtractedTests.cs` pattern (`[Collection("Sequential")]`, `IDisposable`,
+`ParsekLog.TestSinkForTesting` capture, `RecordingStore.SuppressLogging = true`,
+`ParsekLog.ResetTestOverrides()` in `Dispose`). There is no `GhostPlaybackEngineExtracted`
+file yet (`GhostPlaybackEngineTests.cs` exists and is the sibling to reference for the
+constructor/teardown shape).
+
+Pure helpers that gain unit tests:
+
+1. **`BuildPlaybackBudgetPhases` (U1).** Tests:
+   - `NegativeBuildOther_ClampsToZero` - sub-phase ticks summing above `spawnMicroseconds`
+     floor `buildOtherMicroseconds` to 0.
+   - `NegativeMainLoop_ClampsToZero` - spawn+destroy exceeding loop-end elapsed floors
+     `mainLoopMicroseconds` to 0.
+   - `TicksConvertToMicroseconds` - a known tick count converts via
+     `* 1000000L / Stopwatch.Frequency` (compute the expected with the same formula so the
+     test is frequency-independent).
+   - `PassThroughFields` - `trajectoriesIterated`, `createdEventsFired`,
+     `heaviestBuildType`, etc. land in the struct unchanged.
+
+2. **`IsSpawnSuppressedDeadOnArrival` (R-A).** Tests (truth table):
+   - past `endUT` + not held => true.
+   - past `chainEndUT` only + not held => true.
+   - past end + held => false.
+   - before both ends + not held => false.
+   - boundary `currentUT == endUT` (strict `>` in original) => false.
+
+`FireDeferredFrameEvents` (U2), `TryFirstSpawn` (R-B), `ApplyNonRetiredPostPosition`
+(R-D), and `TryUpdateLoopSyncedDebris` (U4) are instance/Unity-heavy and are NOT given new
+unit tests; they are covered by existing integration suites
+(`Bug414BudgetBreakdownTests`, `Bug460MainLoopBreakdownTests`, `Bug414SpawnThrottleTests`,
+`HeldGhostSpawnTests`, `Bug406GhostReuseLoopCycleTests`, `AutoLoopTests`). If a behavioral
+question arises during their review, prefer an in-game test in
+`InGameTests/RuntimeTests.cs` over a Unity-xUnit harness (per the project's Unity-runtime
+test-coverage rule).
+
+---
+
+# Part 6 - Allocation + S16-style invariant notes for the implementer
+
+## Allocation hazards (must stay zero-new-alloc)
+
+- **No `foreach` substitutions.** U2's two deferred-event loops are index `for` loops
+  today; keep them as index loops. Switching to `foreach` can allocate an enumerator for
+  some collection types and changes IL.
+- **No params arrays / no closures.** R-A and R-B pass primitives and `ref`s; do NOT pass
+  the `IsGhostHeld` delegate into a helper (resolve it to a `bool` at the call site).
+- **Structs stay structs.** `PlaybackBudgetPhases`, `FrameContext`, `ZoneRenderResult`,
+  `TrajectoryPlaybackFlags`, and the proposed `FirstSpawnOutcome` enum are all value
+  types. Passing them by value is a stack copy, not a heap allocation. Do not "optimize"
+  any of them into a class.
+- **The engine-iteration trace `StringBuilder`** is allocated only when
+  `ghostRenderTracing == true`. None of the proposed extractions touch that gate; keep it.
+- **Existing string concats** (the `VerboseRateLimited` messages in R3, R10, B12, B15)
+  are pre-existing allocations gated by verbose/rate-limit. Extraction must move them
+  verbatim, not duplicate or eagerly evaluate them outside their existing guards.
+- **`new PlaybackBudgetPhases { ... }` is NOT a heap alloc** (struct initializer). The
+  U1 helper returning it by value is allocation-free.
+
+## Ordering invariants the implementer must preserve
+
+- **B10 (loop-synced debris) must stay AFTER B8 (loop dispatch) and B9 (overlap cleanup)
+  and BEFORE B11 (warp suppression).** The parent-loop-clock path depends on B9 having
+  removed overlap ghosts for non-looping slots. If U4 is extracted, the
+  `if (TryUpdateLoopSyncedDebris(...)) continue;` call must sit in exactly B10's slot.
+- **R2 `ApplyFlagEvents` runs before R3 first-spawn and is independent of `state`.** Flags
+  are permanent world entities applied whether or not the ghost mesh exists. R-B's
+  `TryFirstSpawn` extraction must NOT pull `ApplyFlagEvents` inside it - flag application
+  precedes and is independent of the spawn decision.
+- **R1 pre-spawn coverage retire runs before R2 flag events** ("intentionally precedes
+  permanent flag-event playback" per the inline comment). Preserve that order; do not let
+  any extraction reorder R1 and R2.
+- **R8 clears `state.anchorRetiredThisFrame = false` before R9 positioning,** and R9's
+  relative positioner may set it back to `true`; R10 reads it via
+  `ShouldSkipPostPositionPipeline`. Any extraction around R9/R10 must keep this
+  clear-then-maybe-set-then-read ordering intact (this is the #613 fix invariant).
+- **R10 `retired` is computed once and reused** by the post-update trace, the
+  mark-positioned guard, the visuals branch, R11's `PlaybackTrace.MaybeEmitFrame` gate,
+  and R12's early-completion gate. R-D extracts only the `else` arm; `retired` itself
+  stays computed in the parent and is passed in / read by the parent's surrounding
+  `if (retired)` so R11/R12 still see the same value.
+- **U1 must reuse the already-divided `spawnMicroseconds` / `destroyMicroseconds`** longs
+  rather than recomputing from ticks, so the breakdown's `buildOtherMicroseconds`
+  subtraction matches `DiagnosticsState.playbackBudget.spawnMicroseconds` to the
+  microsecond (avoids a 1us rounding drift between the budget total and the phase sum -
+  the exact invariant bug #414 established).
+
+## S16-style note
+
+None of these extractions touch recording/serialization schema, the optimizer split
+predicate, the on-rails BG TrackSection invariant, or the parent-anchored debris
+coverage contract. They are pure structural reshuffles of in-memory per-frame
+orchestration. The only contract-adjacent code touched is the #613 relative-anchor
+retire ordering (R8->R9->R10), flagged above; preserve it exactly.

--- a/docs/dev/done/refactor/refactor-extract-method-testability.md
+++ b/docs/dev/done/refactor/refactor-extract-method-testability.md
@@ -1,0 +1,527 @@
+> STATUS: Implemented in PR #927 (extract-method + testability pass). Archived as a historical reference.
+
+# Refactor Inventory: Extract-Method, Testability Seams, and Test Gaps
+
+## Scope and intent
+
+This is a READ-ONLY inventory of behavior-preserving refactor opportunities in the
+recording/rendering subsystem. It covers three kinds of work, all additive plus
+behavior-preserving:
+
+1. **Extract-method**: cohesive code blocks inside large multi-responsibility methods
+   that can be lifted into a private/internal-static helper called from the exact same
+   position.
+2. **Testability seams**: pure logic currently buried in a large method that could
+   become `internal static` and get a unit test.
+3. **Test gaps**: existing untested decision points (guards, classifiers, transitions)
+   worth characterization tests even without an extraction.
+
+Every item here is a candidate, not a committed change. Each one must get its own
+focused proposal and a fresh-context review against
+`docs/dev/refactor-guidelines.md` (the 13-item checklist) before it is implemented.
+A confident, narrow extraction beats a sprawling one: when in doubt, scale back.
+
+**Hard constraint reminder (checklist item 13):** never change a pre-existing member's
+access modifier to make an extraction `internal static`. If lifting a block to
+`internal static` would require touching a pre-existing `private` type or member, the
+correct answer is a `private static` (or `private`) helper that cannot be unit-tested.
+A private helper that is untestable is strictly better than an `internal` one bought by
+violating the no-access-change rule.
+
+**Line numbers are approximate.** A separate in-flight "narrow pass" PR
+(`refactor-recording-rendering-pass`) is editing several of these same files and will
+shift line numbers. Anchor on the function name plus the block description, not the line
+number, when relocating an item.
+
+### Excluded: the in-flight narrow pass
+
+The narrow pass already implements the following items. They are **NOT** re-proposed
+here:
+
+- H1 dead ternary in `AnchorPropagator` failTag.
+- H2 redundant format/gen re-parse in `RecordingTreeRecordCodec.LoadRecordingPlaybackAndLinkage`.
+- H3 read-parse-assign idiom extraction in `RecordingTreeRecordCodec` load path.
+- M1 dedup of the two `switch(referenceFrame)` pose-dispatches in `RelativeAnchorResolver`.
+- M2 `ShouldSkipPostPositionPipeline` + `ResolveRenderSurface` per-frame preamble pairing in `GhostPlaybackEngine`.
+- M3 capped-dedup-set housekeeping in `SmoothingPipeline`.
+- M4 save-helper comment-delimited block split in `RecordingTreeRecordCodec` save path.
+- L2 duplicate `IsFinite` delegation in `TrajectoryMath`.
+
+---
+
+## Priority summary
+
+| Priority | Count |
+|----------|-------|
+| High     | 6     |
+| Medium   | 8     |
+| Low      | 5     |
+
+Top extract-method opportunities (detail below):
+
+1. `RecordingStore.RunOptimizationSplitPass` -> lift the Re-Fly-deferred split-candidate selection loop into a pure picker.
+2. `RecordingStore.RunOptimizationSplitPass` -> lift the `second`-recording identity-copy block into `CopySplitIdentityFields`.
+3. `TrajectoryMath.ComputeStats` -> lift the per-point distance accumulation block into `AccumulatePointDistance`.
+4. `TrajectoryMath.ComputeStats` -> lift the per-point max-range computation into `ComputePointRangeFromStart`.
+5. `IncompleteBallisticSceneExitFinalizer.Apply` -> lift the terminal surface-metadata block into `ApplyTerminalSurfaceMetadata`.
+
+Top testability seams:
+
+1. `TrajectoryMath` distance/range blocks (above) become directly unit-testable pure helpers (frame-aware Relative vs surface-haversine math).
+2. `RecordingStore.RunOptimizationSplitPass` deferred-candidate picker becomes a pure function over `(candidates, recordings, deferredId)`.
+3. `BallisticExtrapolator.ChooseEarliestEvent` / `CreateSegment` already pure `private static`; promote to `internal static` for direct unit tests.
+
+Top test gaps (characterization tests, no extraction needed):
+
+1. `FlightRecorder.TryClassifyAeroSurfaceState` and `TryClassifyControlSurfaceState`: untested `internal static` event/field/deflection classifiers.
+2. `RecordingStore.ShouldMoveChildBranchPointToSplitSecondHalf`: untested `internal static` branch-point-move decision.
+3. `BallisticExtrapolator.ChooseEarliestEvent`: untested earliest-event tie-break ordering (Destroyed vs Horizon vs SOI).
+
+### Flagged for a dedicated decomposition plan (not a one-shot extraction)
+
+- `GhostPlaybackEngine.UpdatePlayback` (~613 lines) and its callee `RenderInRangeGhost`
+  (~348 lines): per-frame hot path, dozens of interleaved guard branches with
+  `continue`/early-exit and shared mutable locals (`state`, `ghostActive`). Do not
+  attempt a one-shot carve; see the "dedicated plan" note in the GhostPlaybackEngine
+  section.
+- `BallisticExtrapolator.Extrapolate` (~346 lines): single `while` loop with
+  interleaved mutation of loop carry-state. Already covered end-to-end by 25 tests, so
+  decomposition is low-value and high-risk; treat as a dedicated plan only if it ever
+  needs structural change.
+
+---
+
+## RecordingStore.cs
+
+### HIGH - RunOptimizationSplitPass: extract the deferred split-candidate picker
+
+- **Function:** `RunOptimizationSplitPass(List<Recording> recordings)` (private static, ~L4284).
+- **Block:** the `chosen` selection logic (~L4312-4345): when no Re-Fly id is deferred,
+  `chosen = 0`; otherwise walk `splitCandidates` skipping any whose recording id equals
+  `deferredActiveReFlyId`, counting `deferredCandidatesThisIter`. Returns the chosen index
+  and the deferred-observed count.
+- **Proposed helper:** `internal static int ChooseSplitCandidateIndex(IReadOnlyList<(int,int)> splitCandidates, IReadOnlyList<Recording> recordings, string deferredActiveReFlyId, out int deferredObserved)`.
+- **Why behavior-preserving:** the block is a pure read over `splitCandidates`,
+  `recordings`, and a string id; it produces `chosen` and a counter with no side effects.
+  Called from the exact same position (item 2). No control-flow change: the outer
+  `if (chosen < 0) break;` stays in the loop (item 4). No mutation hazard with later blocks
+  (item 5) because it only reads.
+- **Testability:** YES, genuinely pure. Inputs: candidate index list, recordings list,
+  deferred id. Output: chosen index plus deferred-observed count. No instance-field access.
+  `Recording` is already `internal`-visible to tests (used widely in existing tests), and
+  the tuple list element type is the optimizer's existing public-shape return. Confirm the
+  tuple element type does not force a `private`-type parameter; if it does, fall back to
+  passing the candidate recording ids as a `List<string>` projected at the call site, or
+  scale back to `private static`.
+- **Risk:** low (cold path, optimizer pass). **Effort:** small. **Priority:** high.
+
+### HIGH - RunOptimizationSplitPass: extract the split-identity copy block
+
+- **Function:** same, ~L4352-4377.
+- **Block:** the run of assignments copying identity/lineage fields from `original` to
+  `second` (RecordingId assignment via `Guid.NewGuid`, ChainId/TreeId/VesselName/
+  VesselPersistentId/PreLaunch*/RecordingGroups/CreatingSessionId/ProvisionalForRpId/
+  SupersedeTargetId/SwitchSegmentSessionId). Note `RecordingGroups` is deep-copied.
+- **Proposed helper:** `private static void CopySplitIdentityFields(Recording original, Recording second)` (instance-free, mutates the passed `second`).
+- **Why behavior-preserving:** a straight-line run of field copies with no branching and
+  no reads of state mutated later in the method (item 5: the BranchPoint block below reads
+  `original.ChildBranchPointId`, which this block does not touch). Same call position
+  (item 2). The `second.RecordingId = Guid.NewGuid()...` non-determinism is identical
+  whether inline or in the helper.
+- **Testability:** NOT a pure value-out function (it mutates `second`), so propose
+  `private static`. It could be `internal static` for an assert-the-copy test since
+  `Recording` is test-visible, but the `Guid.NewGuid()` line makes one field
+  non-deterministic; if tested, the helper would need the new id passed in or the test
+  asserts only the copied fields. Keep `private static` unless a test is clearly worth it.
+- **Risk:** low. **Effort:** small. **Priority:** high.
+
+### MEDIUM - RunOptimizationSplitPass: extract the branch-point-parent retarget block
+
+- **Function:** same, ~L4416-4447.
+- **Block:** when `movedChildBranchPointId` is set, the nested loop over `committedTrees`
+  -> `BranchPoints` -> `ParentRecordingIds` that retargets `original.RecordingId` to
+  `second.RecordingId`.
+- **Proposed helper:** `private static void RetargetMovedBranchPointParent(string treeId, string movedChildBranchPointId, string oldRecordingId, string newRecordingId)` (reads/mutates `committedTrees`, so instance-static on the store, not pure).
+- **Why behavior-preserving:** the block is a self-contained guarded mutation; the
+  surrounding code already gates entry with
+  `if (!string.IsNullOrEmpty(movedChildBranchPointId) && !string.IsNullOrEmpty(original.TreeId))`.
+  Moving that guard inside or keeping it at the call site are both valid; keep it at the
+  call site to preserve exact branch shape (item 3). No later block reads
+  `ParentRecordingIds`.
+- **Testability:** touches the static `committedTrees` collection, so `private static`
+  on `RecordingStore`. Not a clean pure seam.
+- **Risk:** low. **Effort:** small. **Priority:** medium.
+
+### TEST GAP - ShouldMoveChildBranchPointToSplitSecondHalf
+
+- **Function:** `internal static bool ShouldMoveChildBranchPointToSplitSecondHalf(string treeId, string childBranchPointId, double secondHalfStartUT)` (~L4497).
+- **Gap:** already `internal static` and pure-ish, but no test references it (confirmed:
+  zero hits in `Source/Parsek.Tests`). It governs whether a child branch point moves to the
+  second half of an optimizer split (the Re-Fly atmo/exo-after-staging-branch case noted in
+  the comment at ~L4385-4397). A characterization test would pin: branch-point UT before
+  vs after `secondHalfStartUT`, null/empty id short-circuit.
+- **Effort:** small. **Priority:** medium (governs tree topology correctness across splits).
+
+---
+
+## TrajectoryMath.cs
+
+### HIGH - ComputeStats: extract per-point distance accumulation
+
+- **Function:** `internal static RecordingStats ComputeStats(Recording rec, Func<string,double[]> bodyLookup = null)` (~L618).
+- **Block:** the per-point `distanceTravelled` accumulation (~L668-704): for `i > 0` same-body
+  points not inside an orbit segment, dispatch on the mid-UT `TrackSection.referenceFrame` to
+  either a Relative dx/dy/dz Euclidean delta or a haversine surface distance plus altitude
+  delta.
+- **Proposed helper:** `internal static double ComputePairwiseTravelDistance(in TrajectoryPoint prev, in TrajectoryPoint cur, ReferenceFrame frame, double bodyRadius)`.
+- **Why behavior-preserving:** the block is a pure computation of one pairwise distance from
+  two points, a frame tag, and a radius. The caller keeps the orbit-segment guard
+  (`FindOrbitSegment(... midUT) != null`) and the section lookup at the call site so the
+  branch shape is unchanged (item 3). Same call position (item 2); accumulates into the same
+  `stats.distanceTravelled +=`. No mutation hazard: the range block that follows reads only
+  `stats.maxRange` and point fields (item 5).
+- **Testability:** YES, genuinely pure (inputs in, double out, no instance state). This
+  mirrors the existing `AccumulateOrbitSegmentStats` / `DeterminePrimaryBody` extractions
+  already tested in `ComputeStatsExtractedTests.cs`. `TrajectoryPoint` and `ReferenceFrame`
+  are already test-visible (used throughout the test suite). The CLAUDE.md "metres-as-degrees"
+  Relative-frame contract makes this a high-value test target: a unit test pins that Relative
+  frames use raw dx/dy/dz and Absolute frames use haversine.
+- **Risk:** low (cold path, called on commit/UI). **Effort:** small. **Priority:** high.
+
+### HIGH - ComputeStats: extract per-point max-range computation
+
+- **Function:** same, ~L706-736.
+- **Block:** the `body == body0` max-range computation: dispatch on first-point frame vs
+  current-point frame to either an Euclidean dx/dy/dz range (both Relative), zero (current
+  Relative only), or a haversine range from the first point (Absolute).
+- **Proposed helper:** `internal static double ComputePointRangeFromStart(in TrajectoryPoint start, in TrajectoryPoint cur, ReferenceFrame startFrame, ReferenceFrame curFrame, double bodyRadius)`.
+- **Why behavior-preserving:** pure computation of one range value; the `body == body0`
+  outer guard and `if (range > stats.maxRange)` update stay at the call site. No reordering,
+  no logic change (item 3).
+- **Testability:** YES, pure. Pins the three-way frame dispatch (the
+  `else if (pointFrame == Relative) range = 0.0` branch is a subtle correctness case worth a
+  characterization test).
+- **Risk:** low. **Effort:** small. **Priority:** high.
+
+### LOW - ComputeStats: bodyData unpacking is fine as-is
+
+- The `double bodyRadius = bodyData[0]` indexing is trivial; not worth a helper. Noted so a
+  later implementer does not over-extract.
+
+---
+
+## IncompleteBallisticSceneExitFinalizer.cs
+
+### HIGH - Apply: extract the terminal surface-metadata block
+
+- **Function:** `private static void Apply(Recording recording, IncompleteBallisticFinalizationResult result, string logContext)` (~L2163).
+- **Block:** the surface-metadata block (~L2224-2255): when terminalState is Landed/Splashed,
+  set `TerminalPosition` + `TerrainHeightAtEnd` from the result (with the `ghostOnlySnapshot`
+  warn-and-keep branch), else null both.
+- **Proposed helper:** `private static void ApplyTerminalSurfaceMetadata(Recording recording, in IncompleteBallisticFinalizationResult result, bool ghostOnlySnapshot, string logContext)`.
+- **Why behavior-preserving:** a self-contained conditional that writes two recording fields
+  based on the result. It runs after the snapshot block and before `MarkFilesDirty()`; no
+  later code re-reads `TerminalPosition`/`TerrainHeightAtEnd` inside `Apply` (item 5). Same
+  call position (item 2). Logging is observational and preserved verbatim (item 9).
+- **Testability:** mutates `recording`, so `private static` (NOT pure). Would require
+  `IncompleteBallisticFinalizationResult` to be test-visible to make it `internal static`;
+  if that type is `private`/internal-to-file, keep `private static` per item 13. Do not change
+  its access to gain testability.
+- **Risk:** low (scene-exit, cold path). **Effort:** small. **Priority:** high.
+
+### MEDIUM - Apply: extract the snapshot-application block
+
+- **Function:** same, ~L2179-2212.
+- **Block:** the vessel-snapshot vs ghost-only-snapshot application (the two
+  `if (result.vesselSnapshot != null)` / `else if (result.ghostVisualSnapshot != null)`
+  branches with their `CreateCopy()` and ConfigNode-equivalence warn logs).
+- **Proposed helper:** `private static void ApplyTerminalSnapshots(Recording recording, in IncompleteBallisticFinalizationResult result, bool ghostOnlySnapshot, string logContext)`.
+- **Why behavior-preserving:** the block computes nothing the surface-metadata block depends
+  on except `ghostOnlySnapshot`, which is computed once before both blocks and passed in
+  unchanged. No reordering. The ghost-snapshot-mode recompute (~L2214-2222) reads
+  `recording.GhostVisualSnapshot`, which this block sets, so the helper must run in the same
+  position before the mode recompute (item 5).
+- **Testability:** `private static` (mutates recording, reads file-local result type).
+- **Risk:** low. **Effort:** medium (two nested branches, careful equivalence with originals
+  under item 10). **Priority:** medium.
+
+---
+
+## FlightRecorder.cs
+
+### TEST GAP (HIGH) - TryClassifyAeroSurfaceState / TryClassifyControlSurfaceState
+
+- **Functions:** `internal static bool TryClassifyAeroSurfaceState(PartModule, out bool isDeployed, out bool isRetracted)` (~L2313, ~117 lines) and the adjacent `TryClassifyControlSurfaceState` (~L2431).
+- **Gap:** both are already `internal static`, both have zero test references. They classify
+  deploy/retract state via three fallback strategies: (1) event-name/guiName keyword scan +
+  `TryClassifyLadderStateFromEventActivity`, (2) boolean field probe over a fixed name list,
+  (3) deflection float probe with NaN/Inf rejection and a `> 0.01f` threshold.
+- **Constraint:** the `PartModule.Events` path needs a live KSP `PartModule`, which xUnit
+  cannot build. But the boolean-field and deflection-float fallback paths route through
+  `TryReadModuleBoolField` / `TryReadModuleFloatField`, which may already have test seams (the
+  ladder-state classifier `TryClassifyLadderStateFromEventActivity` is already tested in
+  `FlightRecorderExtractedTests.cs` / `PartEventTests.cs`). The genuinely-pure sub-decision is
+  the event-keyword classification and the deflection threshold logic. If those cannot be
+  reached without a live `PartModule`, this is an **in-game test** in `RuntimeTests.cs` (per
+  the memory note on Unity-runtime test coverage), not an xUnit test.
+- **Testability seam (smaller, pure):** the event-name keyword matching (~L2335-2345, the two
+  `isDeployEvent`/`isRetractEvent` boolean expressions) could be lifted to
+  `internal static void ClassifyAeroEventName(string evtName, string guiName, out bool isDeploy, out bool isRetract)` and unit-tested directly. Pure: two strings in, two bools out.
+  This is the cleanest pure carve in this method.
+- **Effort:** small (keyword helper) / medium (full in-game test). **Priority:** high for the
+  keyword-classifier seam; medium for the in-game characterization test.
+
+### MEDIUM - UpdateAnchorDetection: extract the close-and-reopen-section sequence
+
+- **Function:** `private void UpdateAnchorDetection(Vessel v)` (~L5727, ~169 lines).
+- **Block:** the repeated sequence that appears three times (relative-exit-landing ~L5741-5757,
+  relative-enter ~L5825-5854, relative-exit-distance ~L5867-5892): sample a boundary point,
+  capture old anchor id/pid, flip `isRelativeMode`, clear/set the recording anchor,
+  `CloseCurrentTrackSection(boundaryUT)`, resolve env from `environmentHysteresis`,
+  `StartNewTrackSection(env, frame, boundaryUT)`, `ActivateHighFidelitySampling(...)`, append a
+  seam point, and log.
+- **Proposed helper:** the three call sites differ in frame (Absolute vs Relative), reason
+  string, anchor set vs clear, and the relative-enter seed-failure early-return. A SINGLE
+  shared helper would have to thread all of those as parameters and would obscure the
+  seed-failure `return` (item 4). RECOMMENDATION: do NOT fully unify. The safe, narrow carve is
+  the common tail `CloseCurrentTrackSection -> resolve env -> StartNewTrackSection -> Activate
+  -> AppendSectionStartSeamPoint` into
+  `private void RotateToNewTrackSection(double boundaryUT, ReferenceFrame frame, string activationReason, string seamReason)`,
+  applied only to the two exit cases (landing and distance) which are structurally identical
+  except their reason strings. The relative-enter case has the seed-failure branch and must
+  stay inline.
+- **Why behavior-preserving (for the two exit cases only):** the tail is straight-line, both
+  exit blocks call exactly the same five methods with the same env resolution; deduplication is
+  semantically identical (item 10). The `isRelativeMode = false; ClearCurrentRecordingAnchor();`
+  prefix differs in log content, so leave that at the call site.
+- **Testability:** instance method (touches `environmentHysteresis`, `currentAnchor*`, calls
+  instance methods), so `private`, NOT testable in xUnit. This is a readability/dedup carve,
+  not a testability seam.
+- **Risk:** medium (recorder hot-ish path, frame-contract correctness; the
+  `CloseCurrentTrackSection` discard rules are subtle, see `FlightRecorderExtractedTests`).
+  **Effort:** medium. **Priority:** medium. Requires its own focused proposal and review.
+
+---
+
+## BackgroundRecorder.cs
+
+### MEDIUM - OnBackgroundPhysicsFrame: extract the environment-transition block
+
+- **Function:** `public void OnBackgroundPhysicsFrame(Vessel bgVessel)` (~L1929, ~271 lines).
+- **Block:** the environment-transition handling (~L2014-2041): classify the raw env from the
+  vessel, call `state.environmentHysteresis.Update(rawEnv, ut)`, and on a transition
+  activate high-fidelity sampling, log, capture the boundary point, close the current BG track
+  section, start a new Absolute section, and seed the boundary point.
+- **Proposed helper:** `private void HandleBackgroundEnvironmentTransition(BackgroundVesselState state, Vessel bgVessel, uint pid, double ut)`.
+- **Why behavior-preserving:** the block is a self-contained guarded action gated by
+  `if (state.environmentHysteresis != null)`. It runs in fixed position before
+  `UpdateDebrisProximityState` / `UpdateBackgroundAnchorDetection`; none of those re-read the
+  hysteresis transition flag (item 5). The `bgVessel.packed` early-return that protects the
+  eccentric-orbit invariant (CLAUDE.md S16) is upstream and is NOT moved (item 4) - critical:
+  the proposal must keep the extracted call strictly below the existing packed/isOnRails gates.
+- **Testability:** instance method touching `state` and calling instance helpers
+  (`CloseBackgroundTrackSection`, `StartBackgroundTrackSection`, `SeedBackgroundBoundaryPoint`),
+  so `private`, not a pure seam. The pure sub-decision (the `ClassifyBackgroundEnvironment`
+  argument mapping from a vessel) is already a separate `internal static`
+  `ClassifyBackgroundEnvironment` and is tested elsewhere.
+- **Risk:** medium (per-frame BG path, but the block only fires on a transition;
+  no-allocation concern is minimal since it is the cold branch). **Effort:** medium.
+  **Priority:** medium. Must be reviewed against the S16 invariant
+  (`EccentricOrbitOptimizerInvariantTests`).
+
+### LOW - InitializeLoadedState: too tangled for a one-shot carve
+
+- **Function:** `private void InitializeLoadedState(...)` (~L3705, ~319 lines).
+- **Assessment:** large but heavily interleaved: it threads `treeRecForSeed`,
+  `hasTreeRecording`, `initialTrajectoryPoint`, and `debrisContractApplies` through a long
+  debris-seed decision with multiple early `Warn` paths and a live-anchor-pose construction.
+  The debris-seed sub-block (~L3789 onward) reads several locals computed earlier in the method.
+  A clean extraction would need many parameters and risks item-5 mutation-order hazards.
+  RECOMMENDATION: leave for a dedicated decomposition plan if it is ever touched; do not carve
+  opportunistically. **Priority:** low.
+
+---
+
+## BallisticExtrapolator.cs
+
+### LOW (testability) - Promote ChooseEarliestEvent and CreateSegment to internal static
+
+- **Functions:** `private static EventCandidate ChooseEarliestEvent(...)` (~L631) and
+  `private static OrbitSegment CreateSegment(...)` (~L607).
+- **Seam:** both are already pure `private static`. Promoting to `internal static` enables
+  direct unit tests of the earliest-event tie-break ordering (Destroyed vs Horizon vs
+  ParentExit vs ChildEntry) and the segment-construction frame math, instead of only the
+  current 25 end-to-end `Extrapolate` tests.
+- **Constraint (item 13):** verify the parameter/return types (`EventCandidate`,
+  `OrbitSegment`, `TwoBodyOrbit`, `ExtrapolationBody`) are not `private`. `OrbitSegment` is
+  test-visible. If `EventCandidate` or `TwoBodyOrbit` is a `private`/file-local type, do NOT
+  widen its access; leave the helper `private static` and rely on the existing integration
+  tests. This item is conditional on those types already being `internal`+.
+- **Risk:** low (no behavior change, access widening only). **Effort:** small.
+  **Priority:** low (already covered indirectly).
+
+### NOT PROPOSED - Extrapolate loop-body decomposition
+
+See "Explicitly NOT proposed" below.
+
+---
+
+## GhostVisualBuilder.cs
+
+### MEDIUM (testability seam) - BuildHeatMaterialStates: extract the heat-color math
+
+- **Function:** `private static List<HeatMaterialState> BuildHeatMaterialStates(...)` (~L4389, ~146 lines).
+- **Block:** the cold/hot/medium color and emission computation (~L4488-4514): given a cold
+  color and whether a color/emissive property exists, compute `hotColor` (Lerp toward
+  `HeatTintColor` at 0.45), `hotEmission`, and the medium midpoints, then populate a
+  `HeatMaterialState`.
+- **Proposed helper:** `internal static HeatMaterialState BuildHeatMaterialState(Material materialClone, string colorProperty, Color coldColor, string emissiveProperty)` OR a purer
+  `internal static (Color hot, Color medium, Color hotEmission, Color mediumEmission) ComputeHeatColorRamp(Color coldColor, bool hasColorProperty, bool hasEmissiveProperty)`.
+- **Why behavior-preserving:** the color ramp is pure math (`Color.Lerp`, constant tint/emission
+  colors). The surrounding Unity material cloning (`new Material(source)`, `renderer.materials`)
+  stays inline. The ramp helper takes the cold color and two booleans and returns four colors.
+- **Testability:** the ramp variant is genuinely pure (`Color`, `Color.Lerp`, and the constant
+  `HeatTintColor`/`HeatEmissionColor` are usable without a live Unity scene since `Color` is a
+  plain struct). Confirm `HeatTintColor`/`HeatEmissionColor` are not `private` instance state -
+  they are static readonly fields; if `private`, pass them in or keep the helper `private
+  static` (item 13). NOTE: the rest of `BuildHeatMaterialStates` (Renderer/Material enumeration)
+  cannot be xUnit-tested and should stay as-is.
+- **Risk:** low (the ramp is leaf math; the hot path concern is the per-renderer loop, which is
+  unchanged). **Effort:** small. **Priority:** medium.
+
+### LOW - Other large GhostVisualBuilder methods are Unity-bound
+
+- `ApplyVariantTextureRules` (~L3460), `GenerateFairingConeMesh` (~L3755),
+  `TryBuildParachuteInfo` (~L4543), `BuildReentryFireParticleSystem` (~L6228),
+  `SpawnExplosionFx` (~L6882): all are dominated by Unity mesh/particle/material construction
+  with little extractable pure logic. `GenerateFairingConeMesh` has pure vertex math that could
+  in principle be lifted, but the payoff is low and the risk of an off-by-one in vertex ordering
+  is real. RECOMMENDATION: not proposed; if touched, prefer in-game tests over extraction.
+  **Priority:** low.
+
+---
+
+## RecordingTree.cs
+
+### MEDIUM (testability seam) - PruneRejectedRecordingReferences: extract the per-recording reference clear
+
+- **Function:** `private static void PruneRejectedRecordingReferences(RecordingTree tree, HashSet<string> rejectedRecordingIds)` (~L263, ~95 lines).
+- **Block:** the `foreach (Recording rec in tree.Recordings.Values)` loop (~L321-352) that
+  clears `ParentRecordingId`, `DebrisParentRecordingId`, `ParentBranchPointId`,
+  `ChildBranchPointId` when they reference a rejected recording or a removed branch point.
+- **Proposed helper:** `internal static void ClearRejectedRecordingReferences(Recording rec, HashSet<string> rejectedRecordingIds, HashSet<string> removedBranchPointIds)`.
+- **Why behavior-preserving:** per-recording field clears with no cross-recording state; the
+  loop iterates and calls the helper once per recording (item 8: this is NOT splitting a loop,
+  it is extracting the loop BODY into a helper called once per iteration, which is allowed).
+  Same order. The two outer blocks (whole-tree drop, branch-point removal) stay in the parent
+  and produce `removedBranchPointIds`, passed in unchanged.
+- **Testability:** YES, pure given `(rec, rejectedIds, removedBranchPointIds)`. `Recording` is
+  test-visible. A unit test pins each of the four field-clear conditions independently and the
+  `removedBranchPointIds == null` short-circuit.
+- **Risk:** low (load-time, cold). **Effort:** small. **Priority:** medium.
+
+### LOW - PruneRejectedRecordingReferences: whole-tree-drop block
+
+- The root-rejected whole-tree-drop block (~L270-289) is a single guarded clear-and-log. It
+  could be `private static DropEntireTree(tree, rootRecordingId)` but the payoff is marginal
+  (one call site). **Priority:** low.
+
+---
+
+## Rendering/SmoothingPipeline.cs
+
+### MEDIUM - FitAndStorePerSection: extract the per-section fit body
+
+- **Function:** `internal static void FitAndStorePerSection(Recording rec)` (~L108, ~141 lines).
+- **Block:** the per-section loop body (~L131-234): the `ShouldFitSection` skip, the inertial
+  frame-tag decision, body resolution with the `ReferenceEquals(body, null)` test seam, the
+  outlier classification, the `CatmullRomFit.Fit` call with timing, validity check, spline
+  store, and the per-section logging.
+- **Proposed helper:** `private static void FitAndStoreSection(Recording rec, int sectionIndex, ref int fitOk, ref int fitFailed, ref int skipped)` (the three `ref int` counters preserve the post-loop summary log).
+- **Why behavior-preserving:** this is extracting the loop BODY into a helper invoked once per
+  iteration (allowed; not loop-splitting per item 8). The `continue` statements inside the
+  current body become `return` in the helper (item 4: each `continue` maps to an early `return`
+  in the void helper, with the counter incremented before the return exactly as today). Same
+  call order. The post-loop summary log reads the three counters, threaded via `ref`.
+- **Constraint:** the `continue`-to-`return` mapping must be verified carefully for each of the
+  three skip/fail paths (item 4). The `ref int` counters must be incremented at the identical
+  point relative to the early exit.
+- **Testability:** touches static `SectionAnnotationStore` and the static config; `private
+  static`, not a pure seam. This is a length/cohesion carve.
+- **Risk:** medium (the `continue`-to-`return` rewrite is the classic extraction footgun; needs
+  a line-by-line review). **Effort:** medium. **Priority:** medium.
+
+### Note - ClassifyDrift already pure and tested
+
+`ClassifyDrift` (~L635) is already a clean pure `private static` and is tested in
+`Rendering/SmoothingPipelineTests.cs`. No action.
+
+---
+
+## Rendering/AnchorPropagator.cs
+
+### LOW - TryEvaluateSmoothedWorldPos is already well-factored
+
+- **Function:** `private static Vector3d? TryEvaluateSmoothedWorldPos(...)` (~L823, ~69 lines).
+- **Assessment:** has a test seam (`SmoothedPositionForTesting`), a clean OrbitalCheckpoint
+  branch, and a body-resolution fallback with `surfaceLookup`. It already delegates to
+  `TrajectoryMath.EvaluateOrbitSegmentAtUT`, `CatmullRomFit.Evaluate`, and
+  `FrameTransform.DispatchSplineWorldByFrameTag`. There is no large cohesive block worth
+  carving. Not proposed. **Priority:** low.
+
+---
+
+## Explicitly NOT proposed (would change behavior or restructure protected code)
+
+1. **`GhostPlaybackEngine.UpdatePlayback` (~613 lines) one-shot decomposition.** Per-frame hot
+   path with ~15 guard branches each ending in `continue`, plus shared mutable locals
+   (`state`, `ghostActive`, `suppressGhosts`) read and written across branches. Any extraction
+   of a guard block changes the `continue`/local-mutation interaction (item 5). The loop body
+   also builds a per-frame `engineIterBuilder` and rate-limited trace. This needs a dedicated
+   decomposition plan with per-branch review, not a line-item here. The narrow pass already
+   takes the safe M2 preamble pair; further carving is out of scope until a plan exists.
+
+2. **`GhostPlaybackEngine.RenderInRangeGhost` (~348 lines).** Same hot-path/interleaved-mutation
+   concerns; it takes `ref state, ref ghostActive` and threads them through positioning, FX, and
+   completion logic. Dedicated plan only.
+
+3. **`BallisticExtrapolator.Extrapolate` (~346 lines) while-loop decomposition.** The loop
+   carries `currentState`, `currentBody`, `soiTransitions`, and three `suppressedImmediate*`
+   variables that are read and written across iterations. The ~8 "set 5 terminal fields + log +
+   return" stanzas look deduplicable, but each logs a DIFFERENT message (item 9 keeps logging
+   observational, but a shared "SetTerminal" helper that also logged would change which message
+   fires) and several also set `failureReason`. A field-only `SetTerminal(result, state, ut,
+   body, pos, vel)` helper with the log left at the call site is borderline acceptable but
+   low-value given the 25 existing end-to-end tests; not proposed to avoid touching a
+   well-covered hot loop. The two SOI-transition `currentState = new BallisticStateVector{...}`
+   blocks (ParentExit / ChildEntry) differ in the sign of the body offset, the
+   `suppressedImmediate*` assignment, and which body becomes current; unifying them would need
+   enough parameters to obscure the difference. Leave as a dedicated plan.
+
+4. **`FlightRecorder.OnPhysicsFrame` (~143 lines) and `OnPartJointBreak` (~181 lines).**
+   `OnPhysicsFrame` is the per-frame recorder entry; `OnPartJointBreak` is a KSP event handler
+   with interleaved decoupler/joint state. Both are event-driven with ordering-sensitive
+   side effects; not safe for opportunistic carving. Dedicated review if touched.
+
+5. **`UpdateAnchorDetection` full three-way unification.** As noted above, only the two exit-case
+   tails are safely deduplicable; unifying all three (including the relative-enter seed-failure
+   `return`) would bury control flow (item 4). The full unification is explicitly NOT proposed.
+
+6. **Coroutine bodies.** Any `IEnumerator` in these files (e.g. `AdvanceTimelineGhostBuild`
+   in `GhostVisualBuilder`) is off-limits for structural change per item 6 (logging-only edits
+   allowed). Not proposed.
+
+---
+
+## How to use this inventory
+
+Each item above is a starting point. Before implementing any one:
+
+1. Re-locate the block by function name and description (line numbers will have drifted).
+2. Write a focused proposal: exact block, helper signature, access modifier, and the
+   checklist items that make it safe.
+3. Confirm item 13: no pre-existing access modifier change. If `internal static` is blocked by
+   a `private` parameter/return type, scale back to `private static`.
+4. Implement, then dispatch a fresh-context Opus review per `docs/dev/refactor-guidelines.md`.
+5. Add the unit test (for genuine pure seams) or characterization test (for test gaps) in the
+   same change.

--- a/docs/dev/done/refactor/refactor-opportunities-recording-rendering.md
+++ b/docs/dev/done/refactor/refactor-opportunities-recording-rendering.md
@@ -1,0 +1,359 @@
+> STATUS: Implemented in PR #923 (narrow zero-logic-change refactor pass). Archived as a historical reference. The "Explicitly NOT proposed" rejection reasoning remains useful guidance for future refactor work.
+
+# Refactor Opportunities: Recording + Rendering Subsystem
+
+Analysis-only inventory. No production code changed by this scan.
+
+## Scope and baseline
+
+This document inventories ZERO-logic-change (behavior-preserving) refactor
+opportunities in the recording and rendering subsystem, scanned against the
+gen-3 clean baseline (`origin/main`, `RecordingStore.CurrentRecordingFormatVersion = 1`,
+`CurrentRecordingSchemaGeneration = 3`). The baseline is freshly cleaned: the
+co-bubble subsystem, the re-fly bypass + force-Absolute toggle, and the
+pre-reset legacy compatibility seams (legacy v5 world-offset RELATIVE contract,
+committed-bool migration, Phase-F tree-resource residual seam, rewind-suppression
+marker normalizer, no-op format-version upgrade helpers) were all removed.
+
+Files scanned: recording side (`FlightRecorder.cs`, `BackgroundRecorder.cs`,
+`RecordingStore.cs`, `RecordingTree.cs`, `RecordingSidecarStore.cs`,
+`RecordingTreeRecordCodec.cs`, `TrajectorySidecarBinary.cs`,
+`SnapshotSidecarCodec.cs`, `PannotationsSidecarBinary.cs`); rendering side
+(`GhostPlaybackEngine.cs`, `GhostPlaybackLogic.cs`, `TrajectoryMath.cs`,
+`RelativeAnchorResolver.cs`, `RecordedRelativeAnchorPoseResolver.cs`,
+`AnchorDetector.cs`, `ReFlyAnchorSelection.cs`, `GhostVisualBuilder.cs`,
+`Rendering/AnchorCorrection.cs`, `Rendering/AnchorPriority.cs`,
+`Rendering/AnchorPropagator.cs`, `Rendering/SmoothingPipeline.cs`).
+
+Every item below is constrained by `docs/dev/refactor-guidelines.md`
+(13-item checklist): no condition changes, no reordering, control flow
+preserved, deduplication only when blocks are semantically identical
+(checklist item 10), extraction position unchanged (item 2), no access-modifier
+changes to pre-existing members (item 7 / 13), logging additions must be
+observational (item 9). Anything that would need a logic change to be safe is
+listed under "Explicitly NOT proposed."
+
+This is an ANALYSIS deliverable. Every item still needs its own focused
+proposal, explicit scope, and a clean-context Opus review (per the guidelines)
+before any code moves. The maintainer triages this list into separate PRs.
+
+Headline finding: the recent cleanup PRs (co-bubble / bypass / legacy-seam
+removals) were thorough. A repo-wide heuristic scan for unused private methods
+and write-once/unused private fields across the recording+rendering files
+returned ZERO hits, and an explicit-warning build (CS0169 / CS0414 / CS0649 /
+CS8321) reported 0 warnings. The few co-bubble remnants that survive
+(`AnchorSource.BubbleEntry/BubbleExit/Reserved7`,
+`PannotationsSidecarBinary.CanonicalEncodingLength`) are DELIBERATELY preserved
+for persisted-byte-layout stability and are documented as such; they are NOT
+dead-code stragglers. The behavior-preserving wins are therefore a small number
+of high-confidence micro-cleanups plus a handful of extract-method candidates in
+the large files.
+
+## Summary counts
+
+- High: 3
+- Medium: 4
+- Low: 3
+
+## High priority
+
+### H1. Dead ternary in AnchorPropagator failTag initializer
+
+- **File:line**: `Source/Parsek/Rendering/AnchorPropagator.cs:610`
+- **What**: `string failTag = !parentOk ? "no-sample-skip" : "no-sample-skip";`
+  has two identical ternary arms, and `failTag` is then unconditionally
+  reassigned by the `if (...) failTag = "section-not-absolute-skip"; else if
+  (...) failTag = "no-sample-skip"; else failTag = "no-spline-skip";` chain
+  (lines 614-619) before its only read at line 622. Simplify the initializer to
+  `string failTag = "no-sample-skip";` (or restructure as a plain assignment).
+- **Why behavior-preserving**: The initializer value is never observed; every
+  control-flow path through the `if/else-if/else` chain assigns `failTag` before
+  it is read. The ternary evaluates the same string on both branches, so the
+  result is identical regardless of `parentOk`. No condition, branch, or read is
+  changed (checklist items 3, 4). Pure dead-store removal.
+- **Risk**: Low. No behavior depends on the discarded value; the surrounding
+  diagnostic Verbose log text is unchanged.
+- **Effort**: Small (one line).
+- **Priority**: High (clear win, zero risk, trivial churn).
+
+### H2. Redundant format-version / schema-generation re-parse in RecordingTreeRecordCodec
+
+- **File:line**: `Source/Parsek/RecordingTreeRecordCodec.cs:481-499`
+  (inside `LoadRecordingPlaybackAndLinkage`), redundant with
+  `LoadRecordingFrom:345-365`.
+- **What**: `LoadRecordingFrom` parses `recordingFormatVersion` and
+  `recordingSchemaGeneration` (lines 345-365), then early-returns if the schema
+  is incompatible. If it passes, it calls `LoadRecordingPlaybackAndLinkage`
+  (line 462), which re-reads the SAME two keys and re-assigns
+  `rec.RecordingFormatVersion` / `rec.RecordingSchemaGeneration` with the
+  identical default-to-0-on-missing logic. The second parse is redundant work
+  that always computes the same values already set. Remove the format/schema
+  re-parse from `LoadRecordingPlaybackAndLinkage` (lines 481-499), leaving the
+  rest of that method untouched.
+- **Why behavior-preserving**: Both blocks read the same ConfigNode keys with
+  the same parse + default-0 fallback, so the field values after the second
+  block are byte-for-byte identical to the values the first block already set
+  (checklist item 10: semantically identical computations). The first block runs
+  unconditionally before the call site, and on the only path that reaches
+  `LoadRecordingPlaybackAndLinkage` the schema was already accepted. No condition
+  or control flow changes.
+- **Risk**: Medium. The safety argument requires confirming the two parse
+  blocks are exactly equivalent (they are: same key names, same
+  `int.TryParse(..., NumberStyles.Integer, ic, ...)`, same default 0) and that
+  no caller invokes `LoadRecordingPlaybackAndLinkage` independently of
+  `LoadRecordingFrom`. Verify call sites before removing.
+- **Effort**: Small.
+- **Priority**: High (concrete dedup, low churn; the only caveat is the call-site
+  uniqueness check).
+
+### H3. Extract repeated GetValue+TryParse+assign idiom in RecordingTreeRecordCodec load helpers
+
+- **File:line**: `Source/Parsek/RecordingTreeRecordCodec.cs` throughout
+  `LoadRecordingPlaybackAndLinkage` (475-592) and `LoadRecordingResourceAndState`
+  (599-913). Representative blocks: 502-509 (sidecarEpoch int), 519-525
+  (loopStartUT double), 545-551 (loopAnchorPid uint), 616-622 (preLaunchFunds
+  double), 786-792 (maxDist double), 820-826 (startInvSlots int), etc.
+- **What**: The pattern `string s = recNode.GetValue("k"); if (s != null) { T v;
+  if (T.TryParse(s, style, ic, out v)) rec.Field = v; }` repeats ~25 times for
+  double / int / uint / float. Extract small private static helpers
+  (`TryReadDouble(ConfigNode, string, ref double)`,
+  `TryReadInt`, `TryReadUint`, `TryReadFloat`) that exactly mirror the inline
+  idiom (read key, parse with the same NumberStyles + InvariantCulture, assign
+  only on success). Replace each inline block with one call.
+- **Why behavior-preserving**: Each helper reproduces the existing
+  read-parse-assign-on-success-only semantics one-for-one. No defaulting is
+  added where the original had none; fields keep their prior value on a
+  missing/unparseable key exactly as today. Pure mechanical deduplication of
+  identical blocks (checklist item 10) with no control-flow change. The helpers
+  are newly-extracted, so marking them `private static` does not touch any
+  pre-existing access modifier (items 7, 13).
+- **Risk**: Medium. Several blocks differ in NumberStyles (`NumberStyles.Float`
+  for doubles via the `inv` local vs `NumberStyles.Integer` for ints) and in the
+  field type. The proposal must keep one helper per (type, NumberStyles)
+  combination so no parse semantics drift. A few blocks have side logic beyond
+  the plain assign (e.g. the `spawnedPid` block at 663-678 also sets
+  `rec.VesselSpawned`; the `recordingGroup` block at 721-740 does localization +
+  rename) and MUST be left inline, not folded into the helper.
+- **Effort**: Medium.
+- **Priority**: High value if scoped to only the pure read-parse-assign blocks;
+  drop every block that carries extra side effects.
+
+## Medium priority
+
+### M1. Extract terminal-clamp section dispatch in RelativeAnchorResolver
+
+- **File:line**: `Source/Parsek/RelativeAnchorResolver.cs:671-700`
+  (`TryResolveTerminalClampedPose`), structurally mirrored by the
+  `switch (section.referenceFrame)` block in `TryResolveRecordingPose:310-349`.
+- **What**: Both methods switch on `section.referenceFrame` and dispatch to
+  `TryResolveAbsoluteSectionPose` / `TryResolveRelativeSectionPose` /
+  `TryResolveOrbitalSectionPose` with the same argument shape (the only
+  difference is the UT passed: the requested UT vs the clamped UT, plus the
+  `default:` arm). The dispatch table could be extracted into one private helper
+  `TryResolveSectionPoseByFrame(context, recording, section, sectionIndex, ut,
+  visited, out pose, out failure)` called from both sites with the appropriate
+  UT.
+- **Why behavior-preserving**: The two switches are the same mapping
+  frame->resolver with identical call argument order; extracting preserves the
+  exact dispatch and is called from the same position in each caller (checklist
+  items 2, 3). Control flow (the `resolved` bool capture in the clamp path) is
+  preserved by returning the resolver result.
+- **Risk**: Medium. The two existing switches are NOT byte-identical: the
+  `TryResolveRecordingPose` version's `default:` arm calls `WarnUnresolved` with
+  `sectionIndex`, while the clamp version's `default:` (not shown above the cut)
+  must be checked for the same failure shape before claiming identity. Verify the
+  `default:` arms match before deduplicating; if they differ, scope the
+  extraction to the three known frame cases only and leave each `default:`
+  inline.
+- **Effort**: Medium.
+- **Priority**: Medium (real structural duplication, but identity of the
+  `default:` arms must be proven first).
+
+### M2. Extract the per-frame "retired post-position" preamble in GhostPlaybackEngine
+
+- **File:line**: `Source/Parsek/GhostPlaybackEngine.cs` repeated preamble at
+  1664-1668 (non-loop), 1848-1849 + 2284-2285 (loop-primary / past-end),
+  2281-2285, 2523-2527 (overlap-primary), 2707-2713 (overlap),
+  2752-2753 (loop-pause).
+- **What**: Each playback path opens with the same three-step preamble:
+  `state.anchorRetiredThisFrame = false;` is set earlier, then
+  `bool X = RelativeAnchorResolution.ShouldSkipPostPositionPipeline(state.anchorRetiredThisFrame);`
+  followed by a `GhostRenderTrace.EmitPostUpdate(..., X, ResolveRenderSurface(usedBodyFixed, X), ...)`
+  call. The `ShouldSkipPostPositionPipeline` + `ResolveRenderSurface` pairing is
+  the stable, identical part across paths. A narrow helper that returns
+  `(bool retired, RenderSurface surface)` from `(state, usedBodyFixed)` could
+  replace the two-line pairing at each site.
+- **Why behavior-preserving**: The `ShouldSkipPostPositionPipeline(state.anchorRetiredThisFrame)`
+  call and `ResolveRenderSurface(usedBodyFixed, retired)` call are pure and
+  identical at every site; extracting only that pairing keeps the
+  `GhostRenderTrace.EmitPostUpdate` call (with its per-path string label and
+  side-effect bookkeeping) inline and unchanged.
+- **Risk**: Medium. This is a hot per-frame, per-ghost path (multiplies across
+  all active ghosts). The extraction must not add allocation (return a value
+  tuple / out params, not a heap object) and must not move the
+  `EmitPostUpdate` call or the divergent post-`retired` branches. The bulk of
+  each block (the `if (retired) { ... } else { ... }` bodies) is genuinely
+  DIFFERENT per path (different log keys, different FX suppression, different
+  side effects) and must stay inline; only the identical 2-line pairing is a
+  safe target.
+- **Effort**: Medium.
+- **Priority**: Medium (touches a hot path; the safe surface is small).
+
+### M3. Extract the env-classified frame-decision logging dedup pattern
+
+- **File:line**: `Source/Parsek/Rendering/SmoothingPipeline.cs` `EmitClusterWarnOnce`
+  (354-377) and `LogFrameDecisionOnce` (379-400).
+- **What**: Both methods implement the identical "dedup-by-key with capped set,
+  clear-and-reseed-on-overflow" pattern: build `key = recordingId + "|" + sectionIndex`,
+  lock, `if (!set.Add(key)) return;`, `if (set.Count >= Cap) { clear; re-add key;
+  Info log }`, then emit the payload log. The cap-overflow housekeeping block
+  (lines 361-369 vs 387-395) is structurally the same modulo the cap constant,
+  set, lock, and Info text. A private helper `AddToCappedDedupSet(set, lock, key,
+  cap, overflowSubsystem, overflowMessage)` returning a bool ("is new key") could
+  back both.
+- **Why behavior-preserving**: The two housekeeping blocks perform the same
+  operations in the same order; the only differences (cap constant, set
+  instance, lock object, Info subsystem/message) become parameters. The payload
+  log after the helper stays inline in each method (different tags/fields), so
+  no log text is altered.
+- **Risk**: Medium. The two locks (`s_clusterWarnLock`, `s_frameDecisionLock`)
+  guard different sets; the helper must take both the set and its lock so the
+  locking discipline is preserved exactly (no lock widening / no shared lock).
+  The overflow Info-log text differs between the two and must be passed through,
+  not unified. Verify the `Add`-before-overflow-check ordering is preserved
+  (current code adds the key, then checks count: a subtle ordering the helper
+  must reproduce).
+- **Effort**: Medium.
+- **Priority**: Medium (clean identical pattern, but the lock+set parameterization
+  must be exact).
+
+### M4. Split the two save-helper bodies in RecordingTreeRecordCodec by the "AddValue-if-non-default" idiom
+
+- **File:line**: `Source/Parsek/RecordingTreeRecordCodec.cs`
+  `SaveRecordingResourceAndState:136-334` and
+  `SaveRecordingPlaybackAndLinkage:82-130`.
+- **What**: These two methods are long sequential walls of
+  `if (cond) recNode.AddValue("key", value.ToString(...));`. They are already
+  decomposed into two helpers, but each remains 50-200 lines of independent,
+  side-effect-free `AddValue` blocks separated by comment headers ("Pre-launch
+  resources", "Rewind save metadata", "Mutable playback state", etc.). The
+  comment-delimited sections are candidates for further extract-method into
+  named private helpers (`SaveTerminalOrbit`, `SaveRewindMetadata`,
+  `SaveResourceAndInventoryManifests`, etc.) called from the same positions.
+- **Why behavior-preserving**: Each comment-delimited block is a pure sequential
+  run of `AddValue` calls with no early returns, no shared mutable local that a
+  later block reads (the only shared local is `ic`, a culture handle), and no
+  inter-block ordering dependency beyond the on-disk key order, which extraction
+  preserves by calling the helpers in the same order (checklist items 2, 5, 8).
+- **Risk**: Medium. ConfigNode key ORDER on disk is observable (saves are
+  diffed). The extraction must call the new helpers in the exact original
+  sequence so the emitted node ordering is byte-identical. The `PRE_REFLY_ANCHOR`
+  block (305-326) reads live `rec` state and builds a child node; keep it inline
+  or extract it whole, never split.
+- **Effort**: Medium to large (many blocks; mechanical but needs care on order).
+- **Priority**: Medium (improves readability of a 200-line method; ordering risk
+  is the main caveat).
+
+## Low priority
+
+### L1. Rename misleading `IsDebrisFocusRecording` in RelativeAnchorResolver
+
+- **File:line**: `Source/Parsek/RelativeAnchorResolver.cs:175-180`.
+- **What**: The method is named `IsDebrisFocusRecording` but its body checks
+  `DebrisParentRecordingId` (parent-anchored, true for both genuine debris AND
+  controlled-decoupled children), not `IsDebris`. The existing doc-comment
+  already flags this: "Method name keeps the historical 'IsDebrisFocusRecording'
+  because the rename is sibling-plan scope." A purely cosmetic rename to
+  `HasParentAnchorSurface` (or `IsParentAnchoredFocusRecording`) would match the
+  body.
+- **Why behavior-preserving**: A private-method rename with all call sites
+  updated is purely cosmetic; no logic, signature, or access modifier changes.
+- **Risk**: Low. Private method, few call sites in one file.
+- **Effort**: Small.
+- **Priority**: Low. The doc-comment notes the canonical rename
+  (`DebrisParentRecordingId` -> `ParentAnchorRecordingId`) is "sibling-plan
+  scope"; renaming this one helper ahead of the field rename may create churn
+  that the field rename then re-touches. Defer to the sibling field-rename plan
+  rather than doing it in isolation.
+
+### L2. Consolidate the duplicate-but-near-identical IsFinite overloads note
+
+- **File:line**: `Source/Parsek/TrajectoryMath.cs:269-283` (three top-level
+  `IsFinite` overloads: double / Vector3d / Vector3) and `:1170`
+  (`CatmullRomFit.IsFinite(double)`).
+- **What**: `CatmullRomFit.IsFinite(double)` (line 1170) duplicates the top-level
+  `IsFinite(double)` (line 269). The nested copy could call the outer one.
+- **Why behavior-preserving**: IF the two `double` bodies are byte-identical
+  (both `!double.IsNaN(value) && !double.IsInfinity(value)`), the nested one can
+  delegate to the outer with no behavior change.
+- **Risk**: Low to medium. Must confirm the two `double` bodies are identical;
+  the nested helper lives inside a nested static class, so visibility is fine
+  (the outer is `private static` on the enclosing class, accessible from the
+  nested class). Verify accessibility before collapsing - if the outer were not
+  reachable from the nested scope this would be out of scope (no access-modifier
+  change allowed, item 13).
+- **Effort**: Small.
+- **Priority**: Low (tiny helper; churn rarely worth it).
+
+### L3. Drop the dead local `string failTag` initial value style elsewhere - none found beyond H1
+
+- **File:line**: subsystem-wide scan result.
+- **What**: A targeted scan for `? X : X` dead ternaries and reassigned-before-read
+  string locals across the recorder + rendering files found only the
+  `AnchorPropagator` case (H1). This entry records the negative result so the
+  maintainer knows the pattern was searched and is not widespread.
+- **Why behavior-preserving**: N/A (no change proposed).
+- **Risk**: N/A.
+- **Effort**: N/A.
+- **Priority**: Low (informational; nothing to do).
+
+## Explicitly NOT proposed (considered and rejected)
+
+These look like refactors but would require a logic or behavior change to be
+safe, so they are OUT OF SCOPE for a zero-logic-change pass:
+
+- **Dedup the orphan engine/audio auto-start across
+  `GhostPlaybackLogic.AutoStartOrphanEnginePlayback` (1298-1334) and
+  `ReapplySpawnTimeModuleBaselinesForLoopCycle` (1734-1758).** The class comment
+  says the loop-cycle block "duplicates the zero-engine-event branch," but the
+  two blocks are NOT semantically identical: `AutoStartOrphanEnginePlayback`
+  emits per-engine and per-audio `ParsekLog.Verbose` lines ("Auto-started audio
+  for orphan engine ...", "Auto-started engine FX for orphan engine ...") while
+  the loop-cycle version intentionally omits them, and the two guard structures
+  differ (one builds the key set internally and checks `== 0`; the other
+  early-returns on `Count != 0`). Deduplicating would either add or remove log
+  lines, violating checklist items 3 and 9. Rejected.
+
+- **Deduplicate `TrajectoryMath.CatmullRomFit.WrapLongitude` (1160-1168) with
+  `FrameTransform.WrapLongitudeDegrees` (1376-1387).** The two are NOT identical:
+  `WrapLongitudeDegrees` has an extra `if (double.IsNaN(lonDeg) ||
+  double.IsInfinity(lonDeg)) return lonDeg;` guard that `WrapLongitude` lacks.
+  Collapsing them would change behavior for one caller (either adding a NaN guard
+  to the body-fixed path or removing it from the inertial path). Rejected
+  (checklist item 10 fails: blocks not semantically identical).
+
+- **Remove `AnchorSource.BubbleEntry` / `BubbleExit` / `Reserved7`
+  (`Rendering/AnchorCorrection.cs:27-32`) and shrink
+  `PannotationsSidecarBinary.CanonicalEncodingLength` (132) accordingly.** These
+  are deliberately preserved for persisted-byte-layout stability of the `.pann`
+  `AnchorCandidate` type byte (documented at AnchorCorrection.cs:29-31 and
+  PannotationsSidecarBinary.cs:113-132). `BubbleEntry`/`BubbleExit` are LIVE
+  (emitted by `AnchorCandidateBuilder`, resolved by `AnchorPropagator` and
+  `ProductionAnchorWorldFrameResolver`), and `Reserved7` is an intentional gap.
+  Removing or renumbering would force a `.pann` algorithm-stamp bump and cache
+  invalidation, which is a behavior change. Rejected (not dead code).
+
+- **Merge the divergent `if (retired) { ... } else { ... }` bodies in the
+  GhostPlaybackEngine playback paths (M2's surrounding blocks).** The retired vs
+  non-retired bodies and the per-path variants (non-loop / loop-primary /
+  overlap / loop-pause) carry different FX-suppression flags, different log
+  dedup keys, and different side-effect calls. They are similar in shape but not
+  semantically identical, so merging is not a checklist-item-10 dedup. Only the
+  small 2-line `ShouldSkipPostPositionPipeline` + `ResolveRenderSurface` pairing
+  (M2) is safe. Rejected for the bodies.
+
+- **Convert `RelativeAnchorResolver` / `GhostPlaybackEngine` private instance
+  helpers to `internal static` for testability.** Several would require touching
+  pre-existing access modifiers or pulling in instance state, which violates
+  checklist items 7, 12, 13. The correct resolution per the guidelines is to
+  scale back, not to change pre-existing modifiers. Rejected.


### PR DESCRIPTION
## Summary

Consolidates the three refactor planning/inventory docs into `docs/dev/done/refactor/`, each with a `STATUS:` header pointing at the PR that implemented it. Replaces the three separate doc-only PRs #920, #922, #924 (being closed in favor of this single archive PR).

## What landed

- `refactor-opportunities-recording-rendering.md` (narrow inventory) implemented in **#923**.
- `refactor-extract-method-testability.md` (extract-method + testability inventory) implemented in **#927**.
- `ghostplayback-hotpath-decomposition.md` (UpdatePlayback / RenderInRangeGhost hot-path plan) implemented in **#926**.

## Why archive rather than discard

The durable value:
- The "Explicitly NOT proposed" rejection reasoning (what NOT to refactor and why) guards future refactor passes from re-attempting unsafe changes.
- The decomposition plan's Part 6 hot-path invariants (#613 retire ordering, #414 microsecond rounding, no-foreach, no-delegate-param, the De Morgan trap) constrain any future edit to the GhostPlaybackEngine per-frame methods, not just refactors.

## Notes

- Docs-only. No code change.
- Em / en dashes present in the source docs were converted to hyphens per the repo no-em-dash rule.