### PR TITLE
Bump version to 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Parsek are documented here.
 
 ---
 
+## 0.10.0
+
+---
+
 ## 0.9.3
 
 ### Breaking Changes

--- a/GameData/Parsek/Parsek.version
+++ b/GameData/Parsek/Parsek.version
@@ -1,7 +1,7 @@
 {
     "NAME": "Parsek",
     "URL": "https://raw.githubusercontent.com/vl3c/Parsek/main/GameData/Parsek/Parsek.version",
-    "VERSION": { "MAJOR": 0, "MINOR": 9, "PATCH": 3 },
+    "VERSION": { "MAJOR": 0, "MINOR": 10, "PATCH": 0 },
     "KSP_VERSION": { "MAJOR": 1, "MINOR": 12, "PATCH": 5 },
     "KSP_VERSION_MIN": { "MAJOR": 1, "MINOR": 12, "PATCH": 0 },
     "KSP_VERSION_MAX": { "MAJOR": 1, "MINOR": 12, "PATCH": 99 }

--- a/Source/Parsek/Properties/AssemblyInfo.cs
+++ b/Source/Parsek/Properties/AssemblyInfo.cs
@@ -17,7 +17,7 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("a1b2c3d4-e5f6-7890-abcd-ef1234567890")]
 
-[assembly: AssemblyVersion("0.9.3.0")]
-[assembly: AssemblyFileVersion("0.9.3.0")]
+[assembly: AssemblyVersion("0.10.0.0")]
+[assembly: AssemblyFileVersion("0.10.0.0")]
 
 [assembly: KSPAssembly("Parsek", 0, 9)]


### PR DESCRIPTION
## Summary

- Bumps `AssemblyInfo.cs` and `Parsek.version` from 0.9.3 to 0.10.0.
- Opens an empty `## 0.10.0` section in CHANGELOG.md.

Establishes 0.10.0 on `main` so in-flight feature work (e.g. the Warp-to-time PR #947) lands its CHANGELOG entries under this section. No code changes.

## Test plan

- [x] Versions match: `AssemblyInfo` 0.10.0.0 and `Parsek.version` MAJOR 0 / MINOR 10 / PATCH 0 (release.py validates they agree).
- [ ] Merge to main before / alongside the 0.10.0 feature PRs.