### PR TITLE
Land Fast-Forward and Warp to Departure before the event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ All notable changes to Parsek are documented here.
 - Debris of a re-fly fork that gets rewound out of the timeline no longer renders as a duplicate ghost alongside the restored recording's own debris. Existing saves with these duplicate ghosts are fixed automatically on the next load.
 - Switching control to the docking target mid-approach no longer drops the chaser's recording from precise relative tracking to body-fixed absolute for the rest of the close approach. The still-backgrounded chaser now keeps the target as its relative anchor (the target had become the active recording, which the anchor scan previously ignored), so two co-recorded ghosts stay aligned through docking instead of drifting apart at the sub-meter scale.
 - Undocking two vessels at a docking port during recording now splits the recording into the two correct vessels at the undock moment, instead of recording the departing pod as destroyed and only picking it up a few seconds later as a separate launch. Crew aboard the undocked vessel are no longer wrongly flagged as lost.
+- Fast-Forward and Warp to Departure now land 15 seconds before the event (the same pre-launch lead Rewind uses) instead of exactly at it, so you arrive with a moment to get oriented. Warp to Spawn still lands precisely at the spawn moment.
 
 ### Internals
 

--- a/Source/Parsek.Tests/TimeJumpManagerTests.cs
+++ b/Source/Parsek.Tests/TimeJumpManagerTests.cs
@@ -503,6 +503,86 @@ namespace Parsek.Tests
 
         #endregion
 
+        #region ApplyJumpLead
+
+        /// <summary>
+        /// With ample room before the event, the target is shifted back by exactly the
+        /// rewind lead time so fast-forward / warp-to-departure land before the event.
+        /// </summary>
+        [Fact]
+        public void ApplyJumpLead_AmpleRoom_SubtractsLeadTime()
+        {
+            double eventUT = 10000.0;
+            double currentUT = 1000.0;
+
+            double target = TimeJumpManager.ApplyJumpLead(eventUT, currentUT);
+
+            Assert.Equal(eventUT - RecordingStore.RewindToLaunchLeadTimeSeconds, target);
+        }
+
+        /// <summary>
+        /// The lead time matches Rewind's pre-launch lead constant (currently 15s) so
+        /// fast-forward and rewind land the same distance before the event.
+        /// </summary>
+        [Fact]
+        public void ApplyJumpLead_LeadMatchesRewindConstant()
+        {
+            double eventUT = 5000.0;
+            double currentUT = 0.0;
+
+            double target = TimeJumpManager.ApplyJumpLead(eventUT, currentUT);
+
+            Assert.Equal(15.0, RecordingStore.RewindToLaunchLeadTimeSeconds);
+            Assert.Equal(eventUT - 15.0, target);
+        }
+
+        /// <summary>
+        /// When now is already inside the lead window (less than the lead before the event),
+        /// the target clamps to the exact event UT so the jump stays forward.
+        /// </summary>
+        [Fact]
+        public void ApplyJumpLead_InsideLeadWindow_ClampsToEventUT()
+        {
+            double eventUT = 1000.0;
+            // 5s before the event — closer than the 15s lead.
+            double currentUT = 995.0;
+
+            double target = TimeJumpManager.ApplyJumpLead(eventUT, currentUT);
+
+            Assert.Equal(eventUT, target);
+            Assert.True(target > currentUT, "Clamped target must remain a forward jump");
+        }
+
+        /// <summary>
+        /// At exactly the lead-time boundary the shifted target equals currentUT, which is
+        /// not a forward jump, so it clamps to the event UT.
+        /// </summary>
+        [Fact]
+        public void ApplyJumpLead_ExactlyAtLeadBoundary_ClampsToEventUT()
+        {
+            double eventUT = 1000.0;
+            double currentUT = eventUT - RecordingStore.RewindToLaunchLeadTimeSeconds;
+
+            double target = TimeJumpManager.ApplyJumpLead(eventUT, currentUT);
+
+            Assert.Equal(eventUT, target);
+        }
+
+        /// <summary>
+        /// ApplyJumpLead logs its decision (event, current, lead, target, clamped).
+        /// </summary>
+        [Fact]
+        public void ApplyJumpLead_Logs()
+        {
+            TimeJumpManager.ApplyJumpLead(10000.0, 1000.0);
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[TimeJump]") && l.Contains("ApplyJumpLead") &&
+                l.Contains("clamped=False"));
+        }
+
+        #endregion
+
         #region Time-jump auto-record suppression
 
         [Fact]

--- a/Source/Parsek/InGameTests/RuntimeTests.cs
+++ b/Source/Parsek/InGameTests/RuntimeTests.cs
@@ -10922,7 +10922,11 @@ namespace Parsek.InGameTests
 
                 flight.FastForwardToRecording(recording);
 
-                yield return WaitForActiveTimelineGhost(flight, recordingIndex, 4f);
+                // FastForwardToRecording now lands RewindToLaunchLeadTimeSeconds (15s) before
+                // the recording start (matching Rewind's pre-launch lead), so the ghost only
+                // becomes active after that lead elapses at 1x. Wait past the lead plus a buffer.
+                yield return WaitForActiveTimelineGhost(flight, recordingIndex,
+                    (float)RecordingStore.RewindToLaunchLeadTimeSeconds + 6f);
                 yield return WaitForRecordingSpawn(recording, 10f);
 
                 spawnedPid = recording.SpawnedVesselPersistentId;

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -26389,29 +26389,31 @@ namespace Parsek
 
             Recording rec = committed[recordingIndex];
             double currentUT = Planetarium.GetUniversalTime();
+            // Land RewindToLaunchLeadTimeSeconds before departure, matching Rewind's pre-launch lead.
+            double targetUT = TimeJumpManager.ApplyJumpLead(departureUT, currentUT);
 
-            if (!TimeJumpManager.IsValidJump(currentUT, departureUT))
+            if (!TimeJumpManager.IsValidJump(currentUT, targetUT))
             {
                 ParsekLog.Warn("Flight",
                     string.Format(CultureInfo.InvariantCulture,
                         "WarpToDeparture: invalid jump current={0:F1} target={1:F1} — aborted",
-                        currentUT, departureUT));
+                        currentUT, targetUT));
                 return;
             }
 
             ParsekLog.Info("Flight",
                 string.Format(CultureInfo.InvariantCulture,
-                    "WarpToDeparture: jumping to UT={0:F1} for '{1}' (delta={2:F1}s, endUT={3:F1})",
-                    departureUT, rec.VesselName, departureUT - currentUT, rec.EndUT));
+                    "WarpToDeparture: jumping to UT={0:F1} for '{1}' (delta={2:F1}s, departUT={3:F1}, endUT={4:F1})",
+                    targetUT, rec.VesselName, targetUT - currentUT, departureUT, rec.EndUT));
 
-            TimeJumpManager.NotifyRecorder(recorder, currentUT, departureUT);
+            TimeJumpManager.NotifyRecorder(recorder, currentUT, targetUT);
             // Epoch-shifted jump: preserves rendezvous geometry
-            TimeJumpManager.ExecuteJump(departureUT, null, vesselGhoster);
+            TimeJumpManager.ExecuteJump(targetUT, null, vesselGhoster);
 
             ParsekLog.ScreenMessage(
                 string.Format(CultureInfo.InvariantCulture,
                     "Warped to departure of \"{0}\" ({1:F0}s)",
-                    rec.VesselName, departureUT - currentUT), 5f);
+                    rec.VesselName, targetUT - currentUT), 5f);
         }
 
         /// <summary>
@@ -26428,8 +26430,9 @@ namespace Parsek
                 return;
             }
 
-            double targetUT = rec.StartUT;
             double currentUT = Planetarium.GetUniversalTime();
+            // Land RewindToLaunchLeadTimeSeconds before launch, matching Rewind's pre-launch lead.
+            double targetUT = TimeJumpManager.ApplyJumpLead(rec.StartUT, currentUT);
 
             if (!RecordingStore.CanFastForwardAtUT(rec, currentUT, out string ffReason, IsRecording))
             {

--- a/Source/Parsek/TimeJumpManager.cs
+++ b/Source/Parsek/TimeJumpManager.cs
@@ -228,6 +228,30 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Pure: shifts a jump target back so the player lands
+        /// <see cref="RecordingStore.RewindToLaunchLeadTimeSeconds"/> before the event,
+        /// matching the pre-launch lead Rewind restores. Fast-forward and warp-to-departure
+        /// use this; warp-to-spawn must stay precise and does NOT call it. Falls back to the
+        /// exact event UT when the lead window would land at or before now (already inside the
+        /// lead window) so the jump stays a forward jump.
+        /// </summary>
+        internal static double ApplyJumpLead(double eventUT, double currentUT)
+        {
+            double lead = RecordingStore.RewindToLaunchLeadTimeSeconds;
+            double target = eventUT - lead;
+            bool clamped = target <= currentUT;
+            if (clamped)
+                target = eventUT;
+
+            ParsekLog.Verbose(Tag,
+                string.Format(ic,
+                    "ApplyJumpLead: event={0:F1} current={1:F1} lead={2:F0}s target={3:F1} clamped={4}",
+                    eventUT, currentUT, lead, target, clamped));
+
+            return target;
+        }
+
+        /// <summary>
         /// KSP runtime: execute the full time jump sequence.
         /// 1. Set Planetarium UT
         /// 2. Epoch-shift all vessel orbits (keep position/velocity, update epoch)

--- a/Source/Parsek/UI/RecordingsTableUI.cs
+++ b/Source/Parsek/UI/RecordingsTableUI.cs
@@ -3624,10 +3624,12 @@ namespace Parsek
         {
             var ic = System.Globalization.CultureInfo.InvariantCulture;
             double now = Planetarium.GetUniversalTime();
-            double delta = rec.StartUT - now;
+            // Land RewindToLaunchLeadTimeSeconds before launch, matching Rewind's pre-launch lead.
+            double leadTarget = TimeJumpManager.ApplyJumpLead(rec.StartUT, now);
+            double delta = leadTarget - now;
             string launchDate = KSPUtil.PrintDateCompact(rec.StartUT, true);
             string message = string.Format(ic,
-                "Fast-forward to \"{0}\" launch at {1}?\n\nTime will advance by {2:F0} seconds.",
+                "Fast-forward to just before \"{0}\" launch at {1}?\n\nTime will advance by {2:F0} seconds.",
                 rec.VesselName, launchDate, delta);
 
             var flight = parentUI.Flight;
@@ -3666,12 +3668,14 @@ namespace Parsek
                                     $"id={capturedRec.RecordingId ?? "<none>"}: {ffReason}");
                                 return;
                             }
-                            double jumpDelta = capturedRec.StartUT - preJumpUT;
+                            // Land RewindToLaunchLeadTimeSeconds before launch, matching Rewind's pre-launch lead.
+                            double ffTarget = TimeJumpManager.ApplyJumpLead(capturedRec.StartUT, preJumpUT);
+                            double jumpDelta = ffTarget - preJumpUT;
                             ParsekLog.Info("FastForward",
                                 string.Format(ic,
-                                    "Non-flight FF to UT={0:F1} for '{1}' (delta={2:F1}s)",
-                                    capturedRec.StartUT, capturedRec.VesselName, jumpDelta));
-                            TimeJumpManager.ExecuteForwardJump(capturedRec.StartUT);
+                                    "Non-flight FF to UT={0:F1} for '{1}' (delta={2:F1}s, launchUT={3:F1})",
+                                    ffTarget, capturedRec.VesselName, jumpDelta, capturedRec.StartUT));
+                            TimeJumpManager.ExecuteForwardJump(ffTarget);
                             ParsekLog.ScreenMessage(
                                 string.Format(ic,
                                     "Fast-forwarded to \"{0}\" ({1:F0}s)",

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -12,6 +12,15 @@ When referencing prior item numbers from source comments or plans, consult the r
 
 ---
 
+## Done - v0.9.3 Fast-Forward / Warp to Departure landed exactly at the event instead of before it
+
+- Request 2026-05-22. Fast-Forward (recordings table + timeline) jumped to a recording's launch UT exactly, and Warp to Departure (Real Spawn Control) jumped to the ghost's departure UT exactly, dropping the player into the event with no setup time. Rewind already restores `RewindToLaunchLeadTimeSeconds` (15 s) of pre-launch lead; the forward jumps should match. Warp to Spawn must stay precise at the spawn moment.
+- **Fix:** new pure helper `TimeJumpManager.ApplyJumpLead(eventUT, currentUT)` returns `eventUT - RecordingStore.RewindToLaunchLeadTimeSeconds`, clamped to `eventUT` when that would land at or before now (already inside the lead window) so the jump stays forward. `FastForwardToRecording` (flight) and the non-flight FF path in `RecordingsTableUI.ShowFastForwardConfirmation` apply it to `rec.StartUT`; `WarpToDeparture` applies it to `departureUT`. `WarpToRecordingEnd` (Warp to Spawn) is intentionally left precise. `WarpToNextCraftSpawn` inherits both behaviors via its dispatch. Constant is shared so FF and Rewind stay equal.
+- **Tests:** 5 new `TimeJumpManagerTests.ApplyJumpLead*` cases (ample-room subtracts lead, lead matches the Rewind constant, inside-lead-window clamps to event, exact-boundary clamps, logs). Full suite green (12336).
+- **Status:** CLOSED 2026-05-22.
+
+---
+
 ## Done - v0.9.3 Relative frame dropped to Absolute when switching control to the docking target mid-approach
 
 - Playtest 2026-05-21 (`logs/2026-05-21_2050_rendezvous-docking/`, save `x8`). During a rendezvous the chaser `Kerbal X` (pid 9871332, rec `91a6d717`, TreeOrder 8) recorded `ReferenceFrame.Relative` against the target (pid 1963925040, rec `b2685b5e`, TreeOrder 0) for only ~2 s (UT 16783.18-16785.28, ~9 m apart), then recorded the entire final 57 s close approach to docking (UT 16785.28-16842.31) in `Absolute`, despite staying within ~4-10 m of the target the whole time. Dock at UT 16842.26 recorded fine. Log: `RELATIVE exit: pid=9871332 no eligible recording anchor candidates liveCandidates=0/1` then `RELATIVE mode exited ... reason=distance-or-missing-anchor` while `dist=4m`.


### PR DESCRIPTION
## Summary

Fast-Forward (recordings table + timeline) and Warp to Departure (Real Spawn Control) jumped exactly to the event UT, dropping the player into launch/departure with no setup time. Rewind already restores `RewindToLaunchLeadTimeSeconds` (15s) of pre-launch lead; the forward jumps now match it. Warp to Spawn stays precise at the spawn moment.

- New pure helper `TimeJumpManager.ApplyJumpLead(eventUT, currentUT)` subtracts the shared lead constant, clamping back to the exact event UT when now is already inside the lead window (so the jump stays forward).
- Applied to `FastForwardToRecording` (flight), the non-flight FF path in `RecordingsTableUI.ShowFastForwardConfirmation`, and `WarpToDeparture`.
- `WarpToRecordingEnd` (Warp to Spawn) intentionally left precise. `WarpToNextCraftSpawn` inherits both behaviors via its dispatch (lead on departure, precise on spawn).
- The non-flight FF confirmation dialog now reads "just before … launch" and shows the lead-adjusted advance.

## Tests

- 5 new `TimeJumpManagerTests.ApplyJumpLead*` cases (ample-room subtracts lead, lead matches the Rewind constant, inside-lead-window clamps to event, exact-boundary clamps, logs).
- Adjusted the `KeepVessel_FastForwardIntoPlayback_SpawnsExactlyOnce` in-game test: its synthetic recording starts now+30s, so the ghost now activates ~15s after the FF landing; the `WaitForActiveTimelineGhost` timeout was bumped from 4s to `RewindToLaunchLeadTimeSeconds + 6s`.
- Full unit suite green (12336 passed, 0 failed).

## Test plan

- [ ] In flight, FF to a future recording from the recordings table / timeline and confirm you land ~15s before its launch (not exactly at it).
- [ ] In Real Spawn Control, Warp to Departure on a departing ghost and confirm you land ~15s before departure.
- [ ] Warp to Spawn still lands precisely at the spawn moment.
- [ ] Warp to Next Spawn: lead on a departing candidate, precise on a spawning candidate.
- [ ] KSC-scene FF advances to ~15s before launch and the dialog wording reads correctly.