### PR TITLE
Add tree-branch connectors to recordings window subentries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to Parsek are documented here.
 - Warping to Year 1 / Day 1 (1/1/0/0) resets a new career to its true starting state (resources, facilities, clock), keeping your recordings as future ghosts. New careers get a one-time start snapshot for this; saves created before this version instead land at your earliest launch.
 - Removed the Timeline window stats line ("n Recordings, m Actions, p Events"); it added little once a timeline has many entries.
 - The Timeline window's current-time ("now") divider now draws a separator line across the rest of the row that grows with the window width, making the present-time boundary easy to spot.
+- Recordings window groups and chains now draw tree-branch connectors on each row under an expanded caret, so it is clearer which entries belong to which group. This matches the style already used in the Kerbals window lists.
 
 ### Bug Fixes
 

--- a/Source/Parsek.Tests/RecordingsTableUITests.cs
+++ b/Source/Parsek.Tests/RecordingsTableUITests.cs
@@ -2193,5 +2193,33 @@ namespace Parsek.Tests
                 RecordingsTableUI.TreeConnector(true),
                 RecordingsTableUI.TreeConnector(false));
         }
+
+        // The internal TreeChildSection enum cannot appear in a public xUnit
+        // signature (CS0051), so the precedence table is asserted inline rather
+        // than via [Theory] InlineData. Order tested: virtual > child group >
+        // block, and None when nothing renders.
+        [Fact]
+        public void ResolveLastChildSection_FollowsPrecedence()
+        {
+            // Single-section cases.
+            Assert.Equal(RecordingsTableUI.TreeChildSection.None,
+                RecordingsTableUI.ResolveLastChildSection(false, false, false));
+            Assert.Equal(RecordingsTableUI.TreeChildSection.Block,
+                RecordingsTableUI.ResolveLastChildSection(true, false, false));
+            Assert.Equal(RecordingsTableUI.TreeChildSection.ChildGroup,
+                RecordingsTableUI.ResolveLastChildSection(false, true, false));
+            Assert.Equal(RecordingsTableUI.TreeChildSection.Virtual,
+                RecordingsTableUI.ResolveLastChildSection(false, false, true));
+
+            // Precedence: virtual beats child group beats block.
+            Assert.Equal(RecordingsTableUI.TreeChildSection.ChildGroup,
+                RecordingsTableUI.ResolveLastChildSection(true, true, false));
+            Assert.Equal(RecordingsTableUI.TreeChildSection.Virtual,
+                RecordingsTableUI.ResolveLastChildSection(true, false, true));
+            Assert.Equal(RecordingsTableUI.TreeChildSection.Virtual,
+                RecordingsTableUI.ResolveLastChildSection(false, true, true));
+            Assert.Equal(RecordingsTableUI.TreeChildSection.Virtual,
+                RecordingsTableUI.ResolveLastChildSection(true, true, true));
+        }
     }
 }

--- a/Source/Parsek.Tests/RecordingsTableUITests.cs
+++ b/Source/Parsek.Tests/RecordingsTableUITests.cs
@@ -2163,5 +2163,35 @@ namespace Parsek.Tests
                 }
             }
         }
+
+        [Fact]
+        public void TreeConnector_LastSibling_IsCornerBranch()
+        {
+            // Last sibling => U+2514 (corner) + U+2500 (horizontal) + space.
+            string last = RecordingsTableUI.TreeConnector(true);
+            Assert.Equal(3, last.Length);
+            Assert.Equal((char)0x2514, last[0]);
+            Assert.Equal((char)0x2500, last[1]);
+            Assert.Equal(' ', last[2]);
+        }
+
+        [Fact]
+        public void TreeConnector_EarlierSibling_IsTeeBranch()
+        {
+            // Non-last sibling => U+251C (tee) + U+2500 (horizontal) + space.
+            string mid = RecordingsTableUI.TreeConnector(false);
+            Assert.Equal(3, mid.Length);
+            Assert.Equal((char)0x251C, mid[0]);
+            Assert.Equal((char)0x2500, mid[1]);
+            Assert.Equal(' ', mid[2]);
+        }
+
+        [Fact]
+        public void TreeConnector_CornerAndTeeDiffer()
+        {
+            Assert.NotEqual(
+                RecordingsTableUI.TreeConnector(true),
+                RecordingsTableUI.TreeConnector(false));
+        }
     }
 }

--- a/Source/Parsek/UI/RecordingsTableUI.cs
+++ b/Source/Parsek/UI/RecordingsTableUI.cs
@@ -1334,7 +1334,7 @@ namespace Parsek
         /// Draws a single recording row. Returns true if the list was modified (break iteration).
         /// </summary>
         private bool DrawRecordingRow(int ri, IReadOnlyList<Recording> committed, double now, float indentPx,
-            IReadOnlyList<RecordingSupersedeRelation> supersedes = null)
+            IReadOnlyList<RecordingSupersedeRelation> supersedes = null, string treeConnector = null)
         {
             var rec = committed[ri];
             if (IsInactiveForDisplay(
@@ -1379,7 +1379,7 @@ namespace Parsek
             GUILayout.Space(NameColumnLeadGap);
 
             // Name (double-click to rename, deferred to next frame)
-            DrawRecordingNameCell(ri, rec, committed, indentPx);
+            DrawRecordingNameCell(ri, rec, committed, indentPx, treeConnector);
             if (captureThisRow) AlignDebugLogLastRect(alignmentDebugRowLog, "rowName");
 
             // Phase label
@@ -1673,7 +1673,7 @@ namespace Parsek
         /// inline rename text field, double-click-to-rename, and auto-focus.
         /// </summary>
         private void DrawRecordingNameCell(int ri, Recording rec,
-            IReadOnlyList<Recording> committed, float indentPx)
+            IReadOnlyList<Recording> committed, float indentPx, string treeConnector = null)
         {
             // Uniform 2px nudge so rows (which have a "#" number in col 1) line up
             // their Name text with the group/chain header Name text above. Group/
@@ -1715,7 +1715,11 @@ namespace Parsek
             }
             else
             {
-                if (GUILayout.Button(name, GUI.skin.label, GUILayout.ExpandWidth(true)))
+                // Tree connector prefix (├─ / └─) for rows rendered as a subentry
+                // under an expanded group/chain caret. Mirrors the Kerbals window
+                // roster-tree style. Top-level rows pass a null connector.
+                string nameLabel = (treeConnector ?? "") + name;
+                if (GUILayout.Button(nameLabel, GUI.skin.label, GUILayout.ExpandWidth(true)))
                 {
                     float now2 = Time.realtimeSinceStartup;
                     if (lastClickedRecIdx == ri && now2 - lastClickTime < DoubleClickThreshold)
@@ -1741,6 +1745,25 @@ namespace Parsek
 
         // --- Group tree rendering helpers ---
 
+        // Box-drawing tree-branch prefixes built from char codes so the source
+        // stays ASCII (matching the \u arrow constants in this file and the
+        // Kerbals roster tree). U+251C "├" + U+2500 "─" = tee; U+2514 "└" = corner.
+        private static readonly string TreeConnectorMid =
+            new string(new[] { (char)0x251C, (char)0x2500, ' ' });
+        private static readonly string TreeConnectorLast =
+            new string(new[] { (char)0x2514, (char)0x2500, ' ' });
+
+        /// <summary>
+        /// Tree-branch glyph prefix for a subentry rendered under an expanded
+        /// group/chain caret. <paramref name="isLast"/> picks the corner glyph;
+        /// every other sibling gets the tee glyph. Mirrors the Kerbals roster
+        /// window style (see KerbalsWindowUI.FormatRosterChainMemberText).
+        /// </summary>
+        internal static string TreeConnector(bool isLast)
+        {
+            return isLast ? TreeConnectorLast : TreeConnectorMid;
+        }
+
         /// <summary>
         /// Recursively draws a group and its children. Returns true if the recording list was modified.
         /// </summary>
@@ -1749,7 +1772,8 @@ namespace Parsek
             Dictionary<string, List<int>> grpToRecs,
             Dictionary<string, List<int>> chainToRecs,
             Dictionary<string, List<string>> grpChildren,
-            IReadOnlyList<RecordingSupersedeRelation> supersedes = null)
+            IReadOnlyList<RecordingSupersedeRelation> supersedes = null,
+            string treeConnector = null)
         {
             // Compute this tree's unfinished-flight members up front so the
             // nested virtual subgroup can be rendered even when the mission
@@ -1836,7 +1860,7 @@ namespace Parsek
             }
             else
             {
-                if (GUILayout.Button($"{arrow} {groupName} ({memberCount})",
+                if (GUILayout.Button($"{treeConnector ?? ""}{arrow} {groupName} ({memberCount})",
                     GUI.skin.label, GUILayout.ExpandWidth(true)))
                 {
                     float t = Time.realtimeSinceStartup;
@@ -2179,8 +2203,33 @@ namespace Parsek
             if (!expanded) return false;
 
             // -- Draw children --
+            // Children render in three sections, in order: display blocks
+            // (chain/grouped blocks + single recording rows), child sub-groups,
+            // then the nested Unfinished Flights virtual group. The structurally
+            // last child gets the corner (└─) connector; earlier siblings get
+            // the tee (├─). With the hide filter active a trailing hidden child
+            // can render nothing, so this is best-effort structural placement,
+            // not a guarantee the corner lands on the last *visible* row.
             List<int> directMembers;
             grpToRecs.TryGetValue(groupName, out directMembers);
+
+            List<GroupDisplayBlock> displayBlocks = null;
+            int lastBlockIdx = -1;
+            if (directMembers != null)
+            {
+                displayBlocks = BuildGroupDisplayBlocks(groupName, directMembers, committed, chainToRecs);
+                for (int i = 0; i < displayBlocks.Count; i++)
+                    if (displayBlocks[i].Members != null && displayBlocks[i].Members.Count > 0)
+                        lastBlockIdx = i;
+            }
+
+            List<string> children;
+            grpChildren.TryGetValue(groupName, out children);
+            bool hasChildGroups = children != null && children.Count > 0;
+
+            bool lastIsVirtual = hasNestedUnfinished;
+            bool lastIsChildGroup = !lastIsVirtual && hasChildGroups;
+            bool lastIsBlock = !lastIsVirtual && !lastIsChildGroup && lastBlockIdx >= 0;
 
             // STASH is a mirror, not a destination: when this tree owns
             // Unfinished Flight members (rendered below as the nested
@@ -2189,34 +2238,34 @@ namespace Parsek
             // group too. The nested STASH subgroup just surfaces the
             // Fly/Seal-eligible rows so they're easy to act on without
             // hunting through the tree.
-            if (directMembers != null)
+            if (displayBlocks != null)
             {
-                var displayBlocks = BuildGroupDisplayBlocks(groupName, directMembers, committed, chainToRecs);
                 for (int i = 0; i < displayBlocks.Count; i++)
                 {
                     var block = displayBlocks[i];
                     if (block.Members == null || block.Members.Count == 0)
                         continue;
 
+                    string connector = TreeConnector(lastIsBlock && i == lastBlockIdx);
                     if (block.Members.Count > 1)
                     {
                         if (DrawGroupedRecordingBlock(block.Key, block.DisplayName,
-                            block.Members, depth + 1, committed, now, supersedes))
+                            block.Members, depth + 1, committed, now, supersedes, connector))
                             return true;
                     }
-                    else if (DrawRecordingRow(block.Members[0], committed, now, (depth + 1) * 15f, supersedes))
+                    else if (DrawRecordingRow(block.Members[0], committed, now, (depth + 1) * 15f, supersedes, connector))
                         return true;
                 }
             }
 
             // Draw child groups
-            List<string> children;
-            if (grpChildren.TryGetValue(groupName, out children))
+            if (hasChildGroups)
             {
                 for (int c = 0; c < children.Count; c++)
                 {
+                    string connector = TreeConnector(lastIsChildGroup && c == children.Count - 1);
                     if (DrawGroupTree(children[c], depth + 1, committed, now,
-                        grpToRecs, chainToRecs, grpChildren, supersedes))
+                        grpToRecs, chainToRecs, grpChildren, supersedes, connector))
                         return true;
                 }
             }
@@ -2229,7 +2278,7 @@ namespace Parsek
             // `nestedUnfinished` was already computed at the top of
             // DrawGroupTree so the hide-escape path can use it too.
             if (hasNestedUnfinished
-                && DrawVirtualUnfinishedFlightsGroup(committed, now, supersedes, depth + 1, nestedUnfinished))
+                && DrawVirtualUnfinishedFlightsGroup(committed, now, supersedes, depth + 1, nestedUnfinished, TreeConnector(true)))
                 return true;
 
             return false;
@@ -2304,7 +2353,8 @@ namespace Parsek
             IReadOnlyList<Recording> committed, double now,
             IReadOnlyList<RecordingSupersedeRelation> supersedes = null,
             int depth = 0,
-            IReadOnlyList<Recording> filteredMembers = null)
+            IReadOnlyList<Recording> filteredMembers = null,
+            string treeConnector = null)
         {
             var members = filteredMembers ?? UnfinishedFlightsGroup.ComputeMembers();
             if (members == null || members.Count == 0)
@@ -2361,7 +2411,7 @@ namespace Parsek
             bool expanded = expandedGroups.Contains(groupName);
             string arrow = expanded ? "\u25bc" : "\u25b6";
             var ufGroupContent = new GUIContent(
-                $"{arrow} {groupName} ({memberCount})",
+                $"{treeConnector ?? ""}{arrow} {groupName} ({memberCount})",
                 UnfinishedFlightsGroup.Tooltip);
             if (GUILayout.Button(ufGroupContent, GUI.skin.label, GUILayout.ExpandWidth(true)))
             {
@@ -2495,7 +2545,8 @@ namespace Parsek
                 float memberIndent = (depth + 1) * 15f;
                 for (int i = 0; i < sortedMembers.Count; i++)
                 {
-                    if (DrawRecordingRow(sortedMembers[i], committed, now, memberIndent, supersedes))
+                    string connector = TreeConnector(i == sortedMembers.Count - 1);
+                    if (DrawRecordingRow(sortedMembers[i], committed, now, memberIndent, supersedes, connector))
                         return true;
                 }
             }
@@ -3238,24 +3289,27 @@ namespace Parsek
         /// </summary>
         private bool DrawChainBlock(string chainId, List<int> members, int depth,
             IReadOnlyList<Recording> committed, double now,
-            IReadOnlyList<RecordingSupersedeRelation> supersedes = null)
+            IReadOnlyList<RecordingSupersedeRelation> supersedes = null,
+            string treeConnector = null)
         {
             string chainName = members.Count > 0 ? committed[members[0]].VesselName : null;
             return DrawRecordingBlock(chainId, chainName, members, depth,
-                committed, now, chainId, "Chain", supersedes);
+                committed, now, chainId, "Chain", supersedes, treeConnector);
         }
 
         private bool DrawGroupedRecordingBlock(string blockKey, string blockName, List<int> members, int depth,
             IReadOnlyList<Recording> committed, double now,
-            IReadOnlyList<RecordingSupersedeRelation> supersedes = null)
+            IReadOnlyList<RecordingSupersedeRelation> supersedes = null,
+            string treeConnector = null)
         {
             return DrawRecordingBlock(blockKey, blockName, members, depth,
-                committed, now, null, "Block", supersedes);
+                committed, now, null, "Block", supersedes, treeConnector);
         }
 
         private bool DrawRecordingBlock(string blockId, string blockName, List<int> members, int depth,
             IReadOnlyList<Recording> committed, double now, string chainIdForPopup, string logKind,
-            IReadOnlyList<RecordingSupersedeRelation> supersedes = null)
+            IReadOnlyList<RecordingSupersedeRelation> supersedes = null,
+            string treeConnector = null)
         {
             if (members == null || members.Count == 0)
                 return false;
@@ -3307,7 +3361,7 @@ namespace Parsek
                 if (mr.EndUT > blockEnd) blockEnd = mr.EndUT;
             }
 
-            if (GUILayout.Button($"{arrow} {blockName} ({members.Count})",
+            if (GUILayout.Button($"{treeConnector ?? ""}{arrow} {blockName} ({members.Count})",
                 GUI.skin.label, GUILayout.ExpandWidth(true)))
             {
                 if (expanded) expandedChains.Remove(blockId);
@@ -3430,7 +3484,8 @@ namespace Parsek
             {
                 for (int m = 0; m < members.Count; m++)
                 {
-                    if (DrawRecordingRow(members[m], committed, now, (depth + 1) * 15f, supersedes))
+                    string connector = TreeConnector(m == members.Count - 1);
+                    if (DrawRecordingRow(members[m], committed, now, (depth + 1) * 15f, supersedes, connector))
                         return true;
                 }
             }

--- a/Source/Parsek/UI/RecordingsTableUI.cs
+++ b/Source/Parsek/UI/RecordingsTableUI.cs
@@ -1764,6 +1764,43 @@ namespace Parsek
             return isLast ? TreeConnectorLast : TreeConnectorMid;
         }
 
+        // Marginal pixel width the connector glyphs add inside a label, measured
+        // once and cached. The per-level indent step equals this width so a
+        // child's connector sits exactly under its parent's caret at every depth:
+        // the connector occupies one indent step, the parent's caret is the first
+        // glyph after the parent's own connector, and both land at the same x.
+        // The legacy fixed 15px step did not match the glyph width and drifted
+        // a few pixels per level in deeper subgroups.
+        private static float cachedConnectorWidth = -1f;
+
+        internal static float ConnectorWidth()
+        {
+            if (cachedConnectorWidth > 0f) return cachedConnectorWidth;
+            if (GUI.skin == null) return 15f; // skin only valid inside OnGUI
+            GUIStyle style = GUI.skin.label;
+            float w = style.CalcSize(new GUIContent(TreeConnectorMid)).x
+                    - style.CalcSize(GUIContent.none).x;
+            if (w <= 0f) return 15f;
+            cachedConnectorWidth = w;
+            return w;
+        }
+
+        // Blank indent before a connector item's OWN label (group / chain /
+        // virtual header). A depth-D item leaves D-1 connector-width steps blank;
+        // the connector itself fills the Dth step. Depth 0 (top level) has no
+        // connector and no indent.
+        private static float SelfConnectorIndent(int depth)
+        {
+            return Math.Max(0, depth - 1) * ConnectorWidth();
+        }
+
+        // Blank indent to pass to a child drawn at parentDepth + 1 so the child's
+        // connector lands under the parent's caret.
+        private static float ChildConnectorIndent(int parentDepth)
+        {
+            return parentDepth * ConnectorWidth();
+        }
+
         /// <summary>
         /// Which of a group's three child sections owns the corner connector.
         /// Render order is blocks then child sub-groups then the nested
@@ -1870,7 +1907,7 @@ namespace Parsek
             CollectDescendantRecordings(groupName, grpToRecs, grpChildren, descendants);
             int memberCount = descendants.Count;
 
-            float indent = depth * 15f;
+            float indent = SelfConnectorIndent(depth);
 
             // -- Group header --
             GUILayout.BeginHorizontal();
@@ -2335,7 +2372,7 @@ namespace Parsek
                             block.Members, depth + 1, committed, now, supersedes, connector))
                             return true;
                     }
-                    else if (DrawRecordingRow(block.Members[0], committed, now, (depth + 1) * 15f, supersedes, connector))
+                    else if (DrawRecordingRow(block.Members[0], committed, now, ChildConnectorIndent(depth), supersedes, connector))
                         return true;
                 }
             }
@@ -2445,7 +2482,7 @@ namespace Parsek
                 return false;
 
             string groupName = UnfinishedFlightsGroup.GroupName;
-            float indent = depth * 15f;
+            float indent = SelfConnectorIndent(depth);
 
             // Build descendants set (committed-list indices) so the shared
             // group helpers (status / earliest / duration) can work unchanged.
@@ -2626,7 +2663,7 @@ namespace Parsek
             unfinishedFlightRowDepth++;
             try
             {
-                float memberIndent = (depth + 1) * 15f;
+                float memberIndent = ChildConnectorIndent(depth);
                 int lastVisibleMember = -1;
                 for (int i = 0; i < sortedMembers.Count; i++)
                     if (IsRowVisible(committed[sortedMembers[i]], supersedes))
@@ -3410,7 +3447,7 @@ namespace Parsek
                 if (!anyVisible) return false;
             }
 
-            float indent = depth * 15f;
+            float indent = SelfConnectorIndent(depth);
 
             GUILayout.BeginHorizontal();
 
@@ -3577,7 +3614,7 @@ namespace Parsek
                 for (int m = 0; m < members.Count; m++)
                 {
                     string connector = TreeConnector(m == lastVisibleMember);
-                    if (DrawRecordingRow(members[m], committed, now, (depth + 1) * 15f, supersedes, connector))
+                    if (DrawRecordingRow(members[m], committed, now, ChildConnectorIndent(depth), supersedes, connector))
                         return true;
                 }
             }

--- a/Source/Parsek/UI/RecordingsTableUI.cs
+++ b/Source/Parsek/UI/RecordingsTableUI.cs
@@ -1765,6 +1765,77 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Which of a group's three child sections owns the corner connector.
+        /// Render order is blocks then child sub-groups then the nested
+        /// Unfinished Flights group, so the last section that renders anything
+        /// owns the corner and everything before it draws tees. Pure, so the
+        /// precedence table is unit-testable independent of IMGUI.
+        /// </summary>
+        internal enum TreeChildSection { None, Block, ChildGroup, Virtual }
+
+        internal static TreeChildSection ResolveLastChildSection(
+            bool hasVisibleBlock, bool hasRenderableChildGroup, bool hasRenderableVirtual)
+        {
+            if (hasRenderableVirtual) return TreeChildSection.Virtual;
+            if (hasRenderableChildGroup) return TreeChildSection.ChildGroup;
+            if (hasVisibleBlock) return TreeChildSection.Block;
+            return TreeChildSection.None;
+        }
+
+        /// <summary>
+        /// Mirrors the two early-returns at the top of <see cref="DrawRecordingRow"/>:
+        /// a row renders only when it is neither inactive-for-display nor hidden
+        /// under an active hide filter. Used to land the corner connector on the
+        /// last *visible* sibling rather than the last by raw index.
+        /// </summary>
+        private static bool IsRowVisible(Recording rec, IReadOnlyList<RecordingSupersedeRelation> supersedes)
+        {
+            if (rec == null) return false;
+            if (IsInactiveForDisplay(
+                    rec,
+                    supersedes ?? CurrentRecordingSupersedesForDisplay(),
+                    CurrentRecordingRewindRetirementsForDisplay())) return false;
+            if (rec.Hidden && GroupHierarchyStore.HideActive) return false;
+            return true;
+        }
+
+        /// <summary>
+        /// True when a display block would render at least its header row.
+        /// Single-member blocks render iff the row is visible; multi-member
+        /// (chain/grouped) blocks render the header unless the hide filter is
+        /// active and every member is hidden, mirroring <see cref="DrawRecordingBlock"/>.
+        /// </summary>
+        private static bool DisplayBlockRendersAnything(
+            GroupDisplayBlock block,
+            IReadOnlyList<Recording> committed,
+            IReadOnlyList<RecordingSupersedeRelation> supersedes)
+        {
+            if (block.Members == null || block.Members.Count == 0) return false;
+            if (block.Members.Count == 1)
+                return IsRowVisible(committed[block.Members[0]], supersedes);
+            if (!GroupHierarchyStore.HideActive) return true;
+            for (int m = 0; m < block.Members.Count; m++)
+                if (!committed[block.Members[m]].Hidden) return true;
+            return false;
+        }
+
+        /// <summary>
+        /// True when a child sub-group would render anything. A visible group
+        /// always renders its header row; a hidden group (under an active hide
+        /// filter) renders only its nested Unfinished Flights escape hatch, if
+        /// any. Mirrors the hide-escape early-return in <see cref="DrawGroupTree"/>.
+        /// </summary>
+        private static bool ChildGroupRendersAnything(string childGroupName)
+        {
+            if (GroupHierarchyStore.HideActive && GroupHierarchyStore.IsGroupHidden(childGroupName))
+            {
+                var nested = CollectUnfinishedFlightsForTreeGroup(childGroupName);
+                return nested != null && nested.Count > 0;
+            }
+            return true;
+        }
+
+        /// <summary>
         /// Recursively draws a group and its children. Returns true if the recording list was modified.
         /// </summary>
         private bool DrawGroupTree(string groupName, int depth,
@@ -2205,31 +2276,41 @@ namespace Parsek
             // -- Draw children --
             // Children render in three sections, in order: display blocks
             // (chain/grouped blocks + single recording rows), child sub-groups,
-            // then the nested Unfinished Flights virtual group. The structurally
-            // last child gets the corner (└─) connector; earlier siblings get
-            // the tee (├─). With the hide filter active a trailing hidden child
-            // can render nothing, so this is best-effort structural placement,
-            // not a guarantee the corner lands on the last *visible* row.
+            // then the nested Unfinished Flights virtual group. Exactly one
+            // section owns the corner (└─) connector; the last child in that
+            // section that actually renders gets the corner, every earlier
+            // sibling gets the tee (├─). Sections / rows that render nothing
+            // (filtered out under the hide filter, inactive-for-display, or a
+            // hidden child group with no escape hatch) are excluded from the
+            // "last visible" computation so the corner never lands on a row
+            // that draws nothing.
             List<int> directMembers;
             grpToRecs.TryGetValue(groupName, out directMembers);
 
             List<GroupDisplayBlock> displayBlocks = null;
-            int lastBlockIdx = -1;
+            int lastVisibleBlockIdx = -1;
             if (directMembers != null)
             {
                 displayBlocks = BuildGroupDisplayBlocks(groupName, directMembers, committed, chainToRecs);
                 for (int i = 0; i < displayBlocks.Count; i++)
-                    if (displayBlocks[i].Members != null && displayBlocks[i].Members.Count > 0)
-                        lastBlockIdx = i;
+                    if (DisplayBlockRendersAnything(displayBlocks[i], committed, supersedes))
+                        lastVisibleBlockIdx = i;
             }
 
             List<string> children;
             grpChildren.TryGetValue(groupName, out children);
-            bool hasChildGroups = children != null && children.Count > 0;
+            int lastRenderableChildGroupIdx = -1;
+            if (children != null)
+            {
+                for (int c = 0; c < children.Count; c++)
+                    if (ChildGroupRendersAnything(children[c]))
+                        lastRenderableChildGroupIdx = c;
+            }
 
-            bool lastIsVirtual = hasNestedUnfinished;
-            bool lastIsChildGroup = !lastIsVirtual && hasChildGroups;
-            bool lastIsBlock = !lastIsVirtual && !lastIsChildGroup && lastBlockIdx >= 0;
+            TreeChildSection cornerSection = ResolveLastChildSection(
+                hasVisibleBlock: lastVisibleBlockIdx >= 0,
+                hasRenderableChildGroup: lastRenderableChildGroupIdx >= 0,
+                hasRenderableVirtual: hasNestedUnfinished);
 
             // STASH is a mirror, not a destination: when this tree owns
             // Unfinished Flight members (rendered below as the nested
@@ -2246,7 +2327,8 @@ namespace Parsek
                     if (block.Members == null || block.Members.Count == 0)
                         continue;
 
-                    string connector = TreeConnector(lastIsBlock && i == lastBlockIdx);
+                    string connector = TreeConnector(
+                        cornerSection == TreeChildSection.Block && i == lastVisibleBlockIdx);
                     if (block.Members.Count > 1)
                     {
                         if (DrawGroupedRecordingBlock(block.Key, block.DisplayName,
@@ -2259,11 +2341,12 @@ namespace Parsek
             }
 
             // Draw child groups
-            if (hasChildGroups)
+            if (children != null)
             {
                 for (int c = 0; c < children.Count; c++)
                 {
-                    string connector = TreeConnector(lastIsChildGroup && c == children.Count - 1);
+                    string connector = TreeConnector(
+                        cornerSection == TreeChildSection.ChildGroup && c == lastRenderableChildGroupIdx);
                     if (DrawGroupTree(children[c], depth + 1, committed, now,
                         grpToRecs, chainToRecs, grpChildren, supersedes, connector))
                         return true;
@@ -2278,7 +2361,8 @@ namespace Parsek
             // `nestedUnfinished` was already computed at the top of
             // DrawGroupTree so the hide-escape path can use it too.
             if (hasNestedUnfinished
-                && DrawVirtualUnfinishedFlightsGroup(committed, now, supersedes, depth + 1, nestedUnfinished, TreeConnector(true)))
+                && DrawVirtualUnfinishedFlightsGroup(committed, now, supersedes, depth + 1, nestedUnfinished,
+                    TreeConnector(cornerSection == TreeChildSection.Virtual)))
                 return true;
 
             return false;
@@ -2543,9 +2627,13 @@ namespace Parsek
             try
             {
                 float memberIndent = (depth + 1) * 15f;
+                int lastVisibleMember = -1;
+                for (int i = 0; i < sortedMembers.Count; i++)
+                    if (IsRowVisible(committed[sortedMembers[i]], supersedes))
+                        lastVisibleMember = i;
                 for (int i = 0; i < sortedMembers.Count; i++)
                 {
-                    string connector = TreeConnector(i == sortedMembers.Count - 1);
+                    string connector = TreeConnector(i == lastVisibleMember);
                     if (DrawRecordingRow(sortedMembers[i], committed, now, memberIndent, supersedes, connector))
                         return true;
                 }
@@ -3482,9 +3570,13 @@ namespace Parsek
 
             if (expanded)
             {
+                int lastVisibleMember = -1;
+                for (int m = 0; m < members.Count; m++)
+                    if (IsRowVisible(committed[members[m]], supersedes))
+                        lastVisibleMember = m;
                 for (int m = 0; m < members.Count; m++)
                 {
-                    string connector = TreeConnector(m == members.Count - 1);
+                    string connector = TreeConnector(m == lastVisibleMember);
                     if (DrawRecordingRow(members[m], committed, now, (depth + 1) * 15f, supersedes, connector))
                         return true;
                 }


### PR DESCRIPTION
## Summary

- Recordings window groups and chains now prefix each subentry under an expanded caret with a tree-branch connector (corner glyph for the last sibling, tee glyph otherwise), matching the Kerbals window roster tree, so it is clearer which entries belong to which group.
- Applies to every subentry type: single recording rows, chain / grouped blocks, child sub-groups, and the nested Unfinished Flights virtual group. Top-level entries (not under a caret) are unchanged.
- New `RecordingsTableUI.TreeConnector(bool isLast)` helper, built from char codes so the source stays ASCII (matching the existing `\u` arrow constants and the Kerbals roster tree).

## Alignment

The connector is prepended to the existing Name-cell / header label only. No column widths (`ColW_*`), indents, `NameColumnLeadGap`, or row structure changed. The Name cell is the only `ExpandWidth(true)` element, so the fixed-width columns to its right stay pinned; the connector just consumes a few pixels of Name-cell slack (same as the existing arrow / count text). Connectors land at each item's existing indent, so they form one clean vertical column per depth.

The structurally-last child gets the corner connector; earlier siblings get the tee. With the hide filter active, a trailing hidden child can render nothing, so corner placement is best-effort structural, not a guarantee it lands on the last *visible* row.

## Test plan

- [x] `dotnet build` clean (0 warnings, 0 errors)
- [x] Full unit suite green: 12,398 passed, including 3 new `TreeConnector` tests asserting the exact code points
- [ ] In-game: open the recordings window, expand a group and a chain, confirm connectors render and the column grid stays aligned (not yet eyeballed in KSP)