### PR TITLE
Drop the count from the main UI Recordings button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to Parsek are documented here.
 - Removed the Timeline window stats line ("n Recordings, m Actions, p Events"); it added little once a timeline has many entries.
 - The Timeline window's current-time ("now") divider now draws a separator line across the rest of the row that grows with the window width, making the present-time boundary easy to spot.
 - Recordings window groups and chains now draw tree-branch connectors on each row under an expanded caret, so it is clearer which entries belong to which group. This matches the style already used in the Kerbals window lists.
+- The main window's "Recordings" button no longer shows a count in parentheses; the per-state counts live inside the window.
 
 ### Bug Fixes
 

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -196,11 +196,9 @@ namespace Parsek
                 ParsekLog.Verbose("UI", $"Timeline window toggled: {(timelineUI.IsOpen ? "open" : "closed")}");
             }
 
-            // [Phase 3] ERS-routed: top-level Recordings button shows the
-            // user-facing effective count (hides NotCommitted / superseded /
-            // session-suppressed).
-            int committedCount = EffectiveState.ComputeERS().Count;
-            if (GUILayout.Button($"Recordings ({committedCount})"))
+            // Top-level Recordings button. The per-state count lives inside the
+            // window; the launch-surface label stays short.
+            if (GUILayout.Button("Recordings"))
                 ToggleRecordingsWindow();
 
             GUILayout.Space(SpacingLarge);


### PR DESCRIPTION
## Summary
- The top-level "Recordings" button in the main window now reads just "Recordings" instead of "Recordings (n)".
- Removed the now-unused `committedCount` / `EffectiveState.ComputeERS()` lookup from that button render path. Per-state counts still live inside the recordings window.

## Test plan
- [x] `dotnet build` succeeds (0 warnings, 0 errors)
- [ ] In game: main window button shows "Recordings" with no parenthetical count