### PR TITLE
Remove the Parsek panel and toolbar button from the Tracking Station

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to Parsek are documented here.
 - The Timeline window's current-time ("now") divider now draws a separator line across the rest of the row that grows with the window width, making the present-time boundary easy to spot.
 - Recordings window groups and chains now draw tree-branch connectors on each row under an expanded caret, so it is clearer which entries belong to which group. This matches the style already used in the Kerbals window lists.
 - The main window's "Recordings" button no longer shows a count in parentheses; the per-state counts live inside the window.
+- Removed the Parsek panel and toolbar button from the Tracking Station. Ghosts still appear there with orbit lines and atmospheric markers; the "Show ghosts in Tracking Station" toggle stays in Settings.
 
 ### Bug Fixes
 

--- a/Source/Parsek.Tests/TrackingStationControlSurfaceUITests.cs
+++ b/Source/Parsek.Tests/TrackingStationControlSurfaceUITests.cs
@@ -10,68 +10,6 @@ namespace Parsek.Tests
     public class TrackingStationControlSurfaceUITests
     {
         [Fact]
-        public void BuildControlSurfaceState_CountsRecordingsAndMaterializedVessels()
-        {
-            var committed = new List<Recording>
-            {
-                new Recording(),
-                new Recording { VesselSpawned = true },
-                new Recording { SpawnedVesselPersistentId = 42 },
-                null
-            };
-
-            ParsekTrackingStation.TrackingStationControlSurfaceState state =
-                ParsekTrackingStation.BuildControlSurfaceState(
-                    committed,
-                    visibleGhostVessels: 3,
-                    suppressedRecordings: 2,
-                    showGhosts: true);
-
-            Assert.Equal(4, state.CommittedRecordings);
-            Assert.Equal(3, state.VisibleGhostVessels);
-            Assert.Equal(2, state.SuppressedRecordings);
-            Assert.Equal(2, state.MaterializedRecordings);
-            Assert.True(state.ShowGhosts);
-        }
-
-        [Fact]
-        public void BuildControlSurfaceState_ClampsNegativeExternalCounts()
-        {
-            ParsekTrackingStation.TrackingStationControlSurfaceState state =
-                ParsekTrackingStation.BuildControlSurfaceState(
-                    committed: null,
-                    visibleGhostVessels: -4,
-                    suppressedRecordings: -2,
-                    showGhosts: false);
-
-            Assert.Equal(0, state.CommittedRecordings);
-            Assert.Equal(0, state.VisibleGhostVessels);
-            Assert.Equal(0, state.SuppressedRecordings);
-            Assert.Equal(0, state.MaterializedRecordings);
-            Assert.False(state.ShowGhosts);
-        }
-
-        [Fact]
-        public void FormatControlSurfaceLines_UsesCompactStableLabels()
-        {
-            var state = new ParsekTrackingStation.TrackingStationControlSurfaceState
-            {
-                CommittedRecordings = 7,
-                VisibleGhostVessels = 3,
-                SuppressedRecordings = 2,
-                MaterializedRecordings = 1,
-                ShowGhosts = true
-            };
-
-            Assert.Equal(
-                "Recordings: 7 | Map ghosts: 3",
-                ParsekTrackingStation.FormatControlSurfaceCountsLine(state));
-            Assert.Equal(
-                "Suppressed: 2 | Spawned: 1",
-                ParsekTrackingStation.FormatControlSurfaceLifecycleLine(state));
-        }
-
-        [Fact]
         public void BuildGhostPopupText_UsesNativeMenuStatusLabels()
         {
             var selection = new TrackingStationGhostSelectionInfo(
@@ -423,29 +361,6 @@ namespace Parsek.Tests
             Assert.False(selected);
             Assert.Null(frames);
             Assert.Equal("checkpoint-section", reason);
-        }
-
-        [Fact]
-        public void TryApplyGhostVisibilitySetting_UpdatesLiveSettingsWhenPresent()
-        {
-            var settings = new ParsekSettings { showGhostsInTrackingStation = true };
-
-            bool applied = ParsekTrackingStation.TryApplyGhostVisibilitySetting(
-                settings,
-                showGhosts: false);
-
-            Assert.True(applied);
-            Assert.False(settings.showGhostsInTrackingStation);
-        }
-
-        [Fact]
-        public void TryApplyGhostVisibilitySetting_NullSettings_ReturnsFalse()
-        {
-            bool applied = ParsekTrackingStation.TryApplyGhostVisibilitySetting(
-                null,
-                showGhosts: false);
-
-            Assert.False(applied);
         }
 
         [Theory]

--- a/Source/Parsek/ParsekTrackingStation.cs
+++ b/Source/Parsek/ParsekTrackingStation.cs
@@ -1,10 +1,8 @@
 using System.Collections.Generic;
 using System.Globalization;
-using ClickThroughFix;
 using KSP.UI.Screens;
 using KSP.UI.Screens.Mapview;
 using Parsek.Patches;
-using ToolbarControl_NS;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -34,10 +32,6 @@ namespace Parsek
         private const float MaterializedFocusRetryDurationSec = 20.0f;
         private const float MaterializedFocusRetryIntervalSec = 0.1f;
         private float nextLifecycleCheckTime;
-        private ToolbarControl toolbarControl;
-        private ParsekUI ui;
-        private bool showUI;
-        private Rect windowRect = new Rect(20, 100, 250, 10);
         private PopupDialog currentGhostPopup;
         private string currentGhostPopupKey;
         private int ghostPopupOpenFrame;
@@ -70,15 +64,6 @@ namespace Parsek
         /// immediately without waiting for the 2-second interval.
         /// </summary>
         private bool lastKnownShowGhosts = true;
-
-        internal struct TrackingStationControlSurfaceState
-        {
-            internal int CommittedRecordings;
-            internal int VisibleGhostVessels;
-            internal int SuppressedRecordings;
-            internal int MaterializedRecordings;
-            internal bool ShowGhosts;
-        }
 
         internal enum AtmosphericMarkerSkipReason
         {
@@ -192,9 +177,6 @@ namespace Parsek
 
         void Start()
         {
-            ui = new ParsekUI(UIMode.TrackingStation);
-            InstallToolbar();
-
             // Read through the persistence store so the startup tick uses the
             // recorded user preference even when ParsekSettings.Current isn't
             // resolved yet (early-scene-load case, see ParsekScenario.cs:546).
@@ -216,26 +198,6 @@ namespace Parsek
                 $"showGhostsInTrackingStation={lastKnownShowGhosts}, " +
                 $"trackingStationSuppressed={suppressedForGhosts}, " +
                 "orbitSourceDiagnostics=aggregated");
-        }
-
-        private void InstallToolbar()
-        {
-            toolbarControl = gameObject.AddComponent<ToolbarControl>();
-            toolbarControl.AddToAllToolbars(
-                () => { showUI = true; ParsekLog.Verbose(Tag, "Toolbar button ON"); },
-                () => { showUI = false; ParsekLog.Verbose(Tag, "Toolbar button OFF"); },
-                ApplicationLauncher.AppScenes.TRACKSTATION,
-                ParsekFlight.MODID, "parsekTrackingStationButton",
-                "Parsek/Textures/parsek_64",
-                "Parsek/Textures/parsek_32",
-                ParsekFlight.MODNAME
-            );
-
-            ui.CloseMainWindow = () =>
-            {
-                showUI = false;
-                if (toolbarControl != null) toolbarControl.SetFalse();
-            };
         }
 
         void Update()
@@ -288,15 +250,14 @@ namespace Parsek
         void OnGUI()
         {
             // The Esc / pause overlay lives on KSP's Canvas and sorts above
-            // our IMGUI layer, so without this gate the ghost icons, ghost
-            // action panel, and control surface visually punch through the
-            // pause menu. Both the Layout pass AND the Repaint draw are
-            // skipped so width-clamped layouts can't flicker between events.
+            // our IMGUI layer, so without this gate the ghost icons and ghost
+            // action panel visually punch through the pause menu. Both the
+            // Layout pass AND the Repaint draw are skipped so width-clamped
+            // layouts can't flicker between events.
             if (PauseMenuGate.IsPauseMenuOpen())
                 return;
 
             DrawAtmosphericMarkers();
-            DrawControlSurface();
         }
 
         private void DrawAtmosphericMarkers()
@@ -328,9 +289,9 @@ namespace Parsek
                 return;
             }
 
-            if (!ShouldProcessAtmosphericMarkerEvent(
-                    etype,
-                    IsPointerOverParsekWindow(currentEvent.mousePosition)))
+            // No Parsek window is hosted in the Tracking Station scene, so a
+            // marker click can never land on a Parsek window here.
+            if (!ShouldProcessAtmosphericMarkerEvent(etype, pointerOverParsekWindow: false))
                 return;
             if (PlanetariumCamera.Camera == null)
             {
@@ -414,12 +375,6 @@ namespace Parsek
             LogAtmosphericMarkerSummary(summary);
         }
 
-        internal bool IsPointerOverParsekWindow(Vector2 mousePosition)
-        {
-            return ParsekUI.IsPointerOverOpenWindow(showUI, windowRect, mousePosition)
-                || (ui != null && ui.IsMouseOverOpenAuxiliaryWindows(mousePosition));
-        }
-
         internal static bool ShouldProcessAtmosphericMarkerEvent(
             EventType eventType,
             bool pointerOverParsekWindow)
@@ -450,107 +405,6 @@ namespace Parsek
                 && IsAtmosphericMarkerClickEvent(eventType);
         }
 
-        private void DrawControlSurface()
-        {
-            if (!showUI || ui == null) return;
-
-            windowRect.height = 0f;
-            var opaqueWindowStyle = ui.GetOpaqueWindowStyle();
-            if (opaqueWindowStyle == null)
-                return;
-
-            ParsekUI.ResetWindowGuiColors(
-                out Color prevColor,
-                out Color prevBackgroundColor,
-                out Color prevContentColor);
-            try
-            {
-                windowRect = ClickThruBlocker.GUILayoutWindow(
-                    GetInstanceID(),
-                    windowRect,
-                    DrawControlSurfaceWindow,
-                    "Parsek",
-                    opaqueWindowStyle,
-                    GUILayout.Width(250));
-            }
-            finally
-            {
-                ParsekUI.RestoreWindowGuiColors(prevColor, prevBackgroundColor, prevContentColor);
-            }
-
-            ui.LogMainWindowPosition(windowRect);
-            ui.DrawRecordingsWindowIfOpen(windowRect);
-            ui.DrawSettingsWindowIfOpen(windowRect);
-            ui.DrawTestRunnerWindowIfOpen(windowRect, this);
-        }
-
-        private void DrawControlSurfaceWindow(int windowID)
-        {
-            TrackingStationControlSurfaceState state = BuildControlSurfaceState(
-                RecordingStore.CommittedRecordings,
-                GhostMapPresence.ghostMapVesselPids.Count,
-                GhostMapPresence.CachedTrackingStationSuppressedIds?.Count ?? 0,
-                ParsekSettingsPersistence.EffectiveShowGhostsInTrackingStation());
-
-            GUILayout.BeginVertical();
-
-            GUILayout.Label("Tracking Station", GUI.skin.box);
-            GUILayout.Label(state.ShowGhosts ? "Ghosts: visible" : "Ghosts: hidden");
-            GUILayout.Label(FormatControlSurfaceCountsLine(state));
-            GUILayout.Label(FormatControlSurfaceLifecycleLine(state));
-
-            GUILayout.Space(10f);
-
-            bool showGhosts = GUILayout.Toggle(
-                state.ShowGhosts,
-                new GUIContent(
-                    " Show ghosts in Tracking Station",
-                    "Show or hide Parsek ghost vessels and markers in the Tracking Station"));
-            if (showGhosts != state.ShowGhosts)
-                SetShowGhostsFromControlSurface(showGhosts);
-
-            GUILayout.Space(10f);
-
-            if (GUILayout.Button(string.Format(
-                    CultureInfo.InvariantCulture,
-                    "Recordings ({0})",
-                    state.CommittedRecordings)))
-            {
-                ui.ToggleRecordingsWindow();
-            }
-
-            if (GUILayout.Button("Settings"))
-                ui.ToggleSettingsWindow();
-
-            GUILayout.Space(10f);
-            if (GUILayout.Button("Close"))
-            {
-                showUI = false;
-                if (toolbarControl != null) toolbarControl.SetFalse();
-                ParsekLog.Verbose(Tag, "Control surface closed via button");
-            }
-
-            GUILayout.EndVertical();
-            GUI.DragWindow();
-        }
-
-        private void SetShowGhostsFromControlSurface(bool showGhosts)
-        {
-            bool liveSettingsUpdated = TryApplyGhostVisibilitySetting(
-                ParsekSettings.Current,
-                showGhosts);
-            ParsekSettingsPersistence.RecordShowGhostsInTrackingStation(showGhosts);
-            lastKnownShowGhosts = showGhosts;
-
-            if (!showGhosts)
-                HideTrackingStationGhostsNow("tracking-station-ui-toggle");
-
-            nextLifecycleCheckTime = 0f;
-            ParsekLog.Info(Tag,
-                $"Control surface set showGhostsInTrackingStation={showGhosts} " +
-                $"liveSettingsUpdated={liveSettingsUpdated}");
-        }
-
         private void HideTrackingStationGhostsNow(string reason)
         {
             string safeReason = string.IsNullOrEmpty(reason)
@@ -563,68 +417,6 @@ namespace Parsek
             ghostActionChains.Clear();
             GhostMapPresence.RemoveAllGhostVessels(safeReason);
             GhostMapPresence.TryRefreshLiveTrackingStationVesselList(safeReason);
-        }
-
-        internal static bool TryApplyGhostVisibilitySetting(ParsekSettings settings, bool showGhosts)
-        {
-            if (settings == null)
-                return false;
-
-            settings.showGhostsInTrackingStation = showGhosts;
-            return true;
-        }
-
-        internal static TrackingStationControlSurfaceState BuildControlSurfaceState(
-            IReadOnlyList<Recording> committed,
-            int visibleGhostVessels,
-            int suppressedRecordings,
-            bool showGhosts)
-        {
-            int committedCount = committed?.Count ?? 0;
-            int materialized = 0;
-            if (committed != null)
-            {
-                for (int i = 0; i < committed.Count; i++)
-                {
-                    Recording rec = committed[i];
-                    if (rec != null && (rec.VesselSpawned || rec.SpawnedVesselPersistentId != 0))
-                        materialized++;
-                }
-            }
-
-            return new TrackingStationControlSurfaceState
-            {
-                CommittedRecordings = ClampNonNegative(committedCount),
-                VisibleGhostVessels = ClampNonNegative(visibleGhostVessels),
-                SuppressedRecordings = ClampNonNegative(suppressedRecordings),
-                MaterializedRecordings = ClampNonNegative(materialized),
-                ShowGhosts = showGhosts
-            };
-        }
-
-        internal static string FormatControlSurfaceCountsLine(
-            TrackingStationControlSurfaceState state)
-        {
-            return string.Format(
-                CultureInfo.InvariantCulture,
-                "Recordings: {0} | Map ghosts: {1}",
-                state.CommittedRecordings,
-                state.VisibleGhostVessels);
-        }
-
-        internal static string FormatControlSurfaceLifecycleLine(
-            TrackingStationControlSurfaceState state)
-        {
-            return string.Format(
-                CultureInfo.InvariantCulture,
-                "Suppressed: {0} | Spawned: {1}",
-                state.SuppressedRecordings,
-                state.MaterializedRecordings);
-        }
-
-        private static int ClampNonNegative(int value)
-        {
-            return value < 0 ? 0 : value;
         }
 
         /// <summary>
@@ -704,14 +496,6 @@ namespace Parsek
             // Flight scene's own OnSceneChangeRequested hook runs too, but this
             // addon is the only always-present TS listener — keep it defensive.
             MapMarkerRenderer.ResetForSceneChange();
-            ui?.Cleanup();
-            ui = null;
-            if (toolbarControl != null)
-            {
-                toolbarControl.OnDestroy();
-                Destroy(toolbarControl);
-                toolbarControl = null;
-            }
             ParsekLog.Info(Tag, "ParsekTrackingStation destroyed");
         }
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -10,7 +10,7 @@ Parsek lets you record missions, revert to launch, and merge them into the timel
 | **V** | Toggle watch camera between Free Orbit and Horizon-Locked (watch mode only) |
 | **Ctrl+Shift+T** | Open the in-game Test Runner (any scene) |
 
-The Parsek window is available from the toolbar button in Flight, Map, KSC, and Tracking Station views. Recording is triggered automatically on launch/EVA; there is no start/stop hotkey. Manual ghost-only recordings are made from the Gloops Flight Recorder window (see below).
+The Parsek window is available from the toolbar button in Flight, Map, and KSC views. Recording is triggered automatically on launch/EVA; there is no start/stop hotkey. Manual ghost-only recordings are made from the Gloops Flight Recorder window (see below).
 
 ## How It Works
 


### PR DESCRIPTION
## Summary
- The Tracking Station scene no longer shows a Parsek toolbar button or control-surface window. That panel (Tracking Station header, ghost-visibility toggle, Recordings/Settings/Close buttons) was the only Parsek window reachable in that scene, and it added little there.
- Ghost map presence is fully preserved: ghosts still appear in the vessel list with orbit lines, atmospheric-phase markers, and the click-to-select / Warp-to-Spawn popups. The lifecycle ticks, focus/materialize logic, and stock-action locking are untouched.
- The "Show ghosts in Tracking Station" toggle remains available in the Settings window (Flight / KSC), so the setting is not orphaned.
- Removed the now-unused control-surface helpers (`BuildControlSurfaceState`, `FormatControlSurface*`, `TryApplyGhostVisibilitySetting`, `ClampNonNegative`, `TrackingStationControlSurfaceState`) and their 5 unit tests. Dropped the unused `ClickThroughFix` / `ToolbarControl_NS` usings.

## Notes
- The in-game test runner (Ctrl+Shift+T) is unaffected: it lives in `TestRunnerShortcut`, a self-contained global addon with its own window, not the per-scene `ParsekUI` host that was removed here.
- `UIMode.TrackingStation` is intentionally retained (still referenced by `ParsekUI`'s ctor and `RecordingsTableUI.CanOfferGhostOnlyDelete`); fully pruning that enum value would ripple into the Flight/KSC UI and is out of scope.

## Test plan
- [x] `dotnet build` (mod) succeeds: 0 warnings, 0 errors
- [x] `dotnet test`: 12,394 passed, 0 failed
- [ ] In game: Tracking Station shows no Parsek toolbar button / panel, but ghosts, orbit lines, and atmospheric markers still render and remain clickable