### PR TITLE
Drop stale v13 naming from recording-schema comments

### DIFF
--- a/Source/Parsek/AnchorDetector.cs
+++ b/Source/Parsek/AnchorDetector.cs
@@ -214,7 +214,7 @@ namespace Parsek
                 return false;
 
             // Debris recordings are not eligible as anchor candidates for OTHER
-            // recordings. v13 records a debris-owned body-fixed primary surface
+            // recordings. The parent-anchor contract records a debris-owned body-fixed primary surface
             // and a proximity-limited parent-relative secondary surface, but the
             // debris lifetime is still owned by its parent recording and may end
             // when that parent is closed/superseded. Any non-debris recording

--- a/Source/Parsek/BackgroundRecorder.cs
+++ b/Source/Parsek/BackgroundRecorder.cs
@@ -1209,7 +1209,7 @@ namespace Parsek
         /// and BackgroundMap, initializes tracking state, and sets TTL for debris children.
         ///
         /// Per plan §3b §"Primary creation sites — invocation and ordering" (PR 3b),
-        /// `IsDebris` and the v13 <see cref="Recording.ParentAnchorRecordingId"/> contract
+        /// `IsDebris` and the <see cref="Recording.ParentAnchorRecordingId"/> contract
         /// are set on the Recording BEFORE <see cref="RecordingTree.AddOrReplaceRecording"/>
         /// and BEFORE <see cref="OnVesselBackgrounded"/>. The seed-point orchestration in
         /// <see cref="InitializeLoadedState"/> reads these fields to decide whether to open
@@ -1357,7 +1357,7 @@ namespace Parsek
                     IsDebris = !newVesselInfos[i].hasController,
                     Generation = parentGeneration + 1
                 };
-                // PR 3b: stamp the v13 debris parent-anchor contract on the new
+                // PR 3b: stamp the debris parent-anchor contract on the new
                 // child Recording adjacent to the IsDebris assignment. String
                 // overload because this static factory is invoked with the
                 // parent recording id.
@@ -1444,7 +1444,7 @@ namespace Parsek
                     continue;
                 }
 
-                // PR 3b §"Parent on-rails hook" (Decision §10): for v13 debris
+                // PR 3b §"Parent on-rails hook" (Decision §10): for debris
                 // carrying the parent-anchor contract, end the debris recording when
                 // the parent's recorded data is gone or the parent vessel is no
                 // longer live. Three end-conditions, one for each failure mode.
@@ -1486,7 +1486,7 @@ namespace Parsek
                 // can validate the truth table. Do NOT regress to
                 // parentRec.ExplicitEndUT < currentUT — active background recordings
                 // update ExplicitEndUT only at sample boundaries, so that signal
-                // lags by the sample interval and would end every v13 debris on
+                // lags by the sample interval and would end every parent-anchored debris on
                 // the next TTL tick.
                 if (DebrisParentStateGate.IsParentRecordingClosedOrSuperseded(parentRec, tree))
                 {
@@ -1704,8 +1704,8 @@ namespace Parsek
         }
 
         /// <summary>
-        /// Pure gate predicate for the body-fixed-shadow clearance path
-        /// (v13 follow-up). Mirrors
+        /// Pure gate predicate for the body-fixed-shadow clearance path.
+        /// Mirrors
         /// <see cref="ShouldEmitBackgroundSurfaceClearance"/> but forces
         /// <see cref="ReferenceFrame.Absolute"/> -- the shadow carries
         /// genuine body-fixed lat/lon/alt regardless of the active
@@ -1725,12 +1725,12 @@ namespace Parsek
         }
 
         /// <summary>
-        /// v13 follow-up: apply v9 surface clearance to the body-fixed shadow
+        /// Apply v9 surface clearance to the body-fixed shadow
         /// copy that gets stored in <c>TrackSection.bodyFixedFrames</c>
         /// alongside a RELATIVE section. The in-frames <c>point</c> stays
         /// NaN-clearance because anchor-local metre offsets in
         /// <c>lat/lon/alt</c> are not body-fixed coordinates -- but the shadow
-        /// carries genuine body-fixed lat/lon/alt and the v13 body-fixed
+        /// carries genuine body-fixed lat/lon/alt and the body-fixed
         /// primary playback path applies terrain correction via
         /// <c>recordedGroundClearance</c>. Without this helper, parent-
         /// anchored surface debris recorded inside a parent-relative section
@@ -2187,10 +2187,10 @@ namespace Parsek
             // Non-surface / RELATIVE-frame / missing-PQS keep NaN, the
             // sentinel for the legacy altitude path.
             ApplySurfaceClearanceToPoint(state, bgVessel, ref point);
-            // v13 follow-up: when the active section is RELATIVE, also apply
+            // When the active section is RELATIVE, also apply
             // surface clearance to the body-fixed shadow that gets persisted
             // in bodyFixedFrames. The shadow carries body-fixed lat/lon/alt
-            // and the v13 body-fixed-primary playback path needs
+            // and the body-fixed-primary playback path needs
             // recordedGroundClearance for v9 terrain correction; without
             // this, parent-anchored surface debris replays at raw recorded
             // altitude.
@@ -4894,7 +4894,7 @@ namespace Parsek
 
             // When the recording carries the debris parent-anchor contract,
             // bypass the generic candidate-list / nearest-search entirely and
-            // pin the anchor to the parent recording. v13 still decides
+            // pin the anchor to the parent recording. The recorder still decides
             // Absolute-vs-Relative sections by parent proximity; the parent id is
             // ownership, not a generic live-anchor candidate.
             if (!string.IsNullOrEmpty(treeRec.ParentAnchorRecordingId))
@@ -5259,7 +5259,7 @@ namespace Parsek
         /// <summary>
         /// PR 3b (Decision §5 + plan §3b §"Per-frame anchor write" / §"Structural-event
         /// seam"): pins <paramref name="state"/>'s anchor to the parent recording id
-        /// carried by the v13 <see cref="Recording.ParentAnchorRecordingId"/> contract.
+        /// carried by the <see cref="Recording.ParentAnchorRecordingId"/> contract.
         /// Skips the candidate-list / nearest-search and lets
         /// <see cref="ApplyBackgroundCurrentAnchorToTrackSection"/> propagate the anchor
         /// id into <see cref="TrackSection.anchorRecordingId"/>. Builds a Live anchor
@@ -5319,7 +5319,7 @@ namespace Parsek
                 // v.latitude/longitude/altitude derived from vesselTransform via
                 // KSP's UpdatePosVel). Mixing CoM position with vesselTransform
                 // rotation was the v0.9 radial-booster ~10 m forward offset bug
-                // -- body-fixed primary masks the inconsistency for normal v13
+                // -- body-fixed primary masks the inconsistency for normal
                 // rendering, but the live candidate also leaks into diagnostics,
                 // fallback paths, and future anchor-based render logic. Falls
                 // back to CoM when transform is null (mid-teardown fake-null).
@@ -5454,7 +5454,7 @@ namespace Parsek
 
             // PR 3b §"Structural-event seam": the structural-event snapshot path
             // bypasses UpdateBackgroundAnchorDetection, so the debris contract must
-            // be enforced here too. For v13 debris, pin state to the parent
+            // be enforced here too. For parent-anchored debris, pin state to the parent
             // recording id before any pose resolution. Re-runs of the periodic path
             // hit the same helper but it's idempotent when the contract is already
             // applied (anchorChanged=false → no log spam, no section flip).
@@ -5549,7 +5549,7 @@ namespace Parsek
             // relativePoint goes into a Relative section so the helper's
             // frame gate correctly skips it (anchor-local metres in
             // lat/lon/alt would corrupt terrain math), but the body-fixed
-            // shadow carries genuine lat/lon/alt and the v13 body-fixed
+            // shadow carries genuine lat/lon/alt and the body-fixed
             // primary playback path applies terrain correction via
             // recordedGroundClearance. Mirrors the periodic-sample,
             // structural-event, and debris-seed wirings.
@@ -6179,7 +6179,7 @@ namespace Parsek
             return distanceMeters <= threshold;
         }
 
-        // For v13 debris recordings whose parent recording id is known, cap the
+        // For parent-anchored debris recordings whose parent recording id is known, cap the
         // proximity-derived sample interval (the adaptive sampler's MIN floor)
         // at MidInterval (0.5 s) regardless of distance from the focused vessel.
         // Without this cap, radial debris that flies past 1000 m of its parent
@@ -7921,7 +7921,7 @@ namespace Parsek
                 TrajectoryPoint absolutePoint = point;
                 bool relativeApplied = ApplyBackgroundRelativeOffset(state, ref point, v, eventUT);
                 ApplySurfaceClearanceToPoint(state, v, ref point);
-                // v13 follow-up: body-fixed shadow gets clearance too when
+                // Body-fixed shadow gets clearance too when
                 // the active section is RELATIVE (see helper docstring).
                 if (relativeApplied)
                 {

--- a/Source/Parsek/DebrisRelativePlaybackPolicy.cs
+++ b/Source/Parsek/DebrisRelativePlaybackPolicy.cs
@@ -5,7 +5,7 @@ namespace Parsek
 {
     /// <summary>
     /// Playback policy for debris that carries the explicit parent-recording
-    /// anchor contract. The v13 render contract uses body-fixed primary data
+    /// anchor contract. The current render contract uses body-fixed primary data
     /// for ordinary debris and only relies on anchor-local replay for
     /// loop-anchored chains.
     /// </summary>
@@ -83,7 +83,7 @@ namespace Parsek
 
         /// <summary>
         /// Ordinary parent-anchored debris must not route through recorded
-        /// Relative playback once v13 body-fixed primary data is the authored
+        /// Relative playback since body-fixed primary data is the authored
         /// render surface. A true result means callers should skip the
         /// recorded-relative resolver and either use body-fixed primary or
         /// fail closed.

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -8748,12 +8748,12 @@ namespace Parsek
         }
 
         /// <summary>
-        /// v13 follow-up: apply v9 surface clearance to the body-fixed shadow
+        /// Apply v9 surface clearance to the body-fixed shadow
         /// copy that gets stored in <c>TrackSection.bodyFixedFrames</c>
         /// alongside a RELATIVE section. The in-frames primary <c>point</c>
         /// stays NaN-clearance because anchor-local metres-in-lat/lon/alt are
         /// not body-fixed coordinates, but the shadow carries genuine
-        /// body-fixed lat/lon/alt and v13 playback applies terrain correction
+        /// body-fixed lat/lon/alt and playback applies terrain correction
         /// via <c>recordedGroundClearance</c>. Without this, parent-anchored
         /// surface debris recorded inside a parent-relative section would
         /// replay at raw recorded altitude and bury / pop on terrain.
@@ -8844,9 +8844,9 @@ namespace Parsek
                 if (currentTrackSection.referenceFrame == ReferenceFrame.Relative
                     && bodyFixedPrimaryPoint.HasValue)
                 {
-                    // v13 follow-up: apply surface clearance to the body-fixed
+                    // Apply surface clearance to the body-fixed
                     // shadow before appending it to bodyFixedFrames. The shadow
-                    // carries body-fixed lat/lon/alt that v13 playback applies
+                    // carries body-fixed lat/lon/alt that playback applies
                     // terrain correction against.
                     TrajectoryPoint shadow = bodyFixedPrimaryPoint.Value;
                     ApplySurfaceClearanceToBodyFixedShadow(v, ref shadow);

--- a/Source/Parsek/GhostMapPresence.cs
+++ b/Source/Parsek/GhostMapPresence.cs
@@ -5819,7 +5819,7 @@ namespace Parsek
             bool allowOrbitalCheckpointStateVector = false,
             TrajectoryPoint? bodyFixedPrimaryPoint = null)
         {
-            // v13 parent-anchored debris uses `bodyFixedFrames` as the primary
+            // Parent-anchored debris uses `bodyFixedFrames` as the primary
             // surface for ordinary debris. Callers pass the selected body-fixed
             // point here after deciding the recording is not a loop-anchored
             // chain. Resolved through the standard surface lookup it yields the

--- a/Source/Parsek/GhostPlaybackEngine.cs
+++ b/Source/Parsek/GhostPlaybackEngine.cs
@@ -1761,7 +1761,7 @@ namespace Parsek
             state.anchorRetiredThisFrame = false;
             bool usedBodyFixedPrimary = false;
 
-            // Position the ghost. Parent-anchored v13 debris is only valid
+            // Position the ghost. Parent-anchored debris is only valid
             // while a recorded Relative section covers the playback UT; outside
             // that coverage, hide instead of falling through to flat points,
             // surface, or orbit-tail playback. The ShadowPositioned route has
@@ -6106,7 +6106,7 @@ namespace Parsek
             if (!state.deferVisibilityUntilPlaybackSync || state.appearanceCount != 0)
                 return playbackUT;
 
-            // v13 carve-out (matches the hide-gate carve-out): parent-anchored
+            // Body-fixed-primary carve-out (matches the hide-gate carve-out): parent-anchored
             // debris with body-fixed primary covering the activation UT does
             // NOT get clamped to activationStartUT for one frame either.
             // Without this, the clamp produces a one-frame seed render that
@@ -6172,7 +6172,7 @@ namespace Parsek
                 return false;
             }
 
-            // v13 carve-out: parent-anchored debris that has a body-fixed primary
+            // Body-fixed-primary carve-out: parent-anchored debris that has a body-fixed primary
             // surface covering the activation UT does not need the generic
             // relative-start hide. The body-fixed primary path resolves the
             // recorded world pose directly from the section's bodyFixedFrames
@@ -6197,7 +6197,7 @@ namespace Parsek
         }
 
         /// <summary>
-        /// Shared predicate for the v13 parent-anchored debris activation-hide
+        /// Shared predicate for the parent-anchored debris activation-hide
         /// carve-outs: returns true when the trajectory is parent-anchored
         /// debris AND the section covering the activation UT is Relative AND
         /// body-fixed primary coverage exists at the activation UT. Both the
@@ -6430,7 +6430,7 @@ namespace Parsek
                 || withinRelativeWindow
                 || withinAbsoluteBridge
                 || withinAbsoluteToRelativePrimer;
-            // v13 carve-out: parent-anchored debris that has body-fixed primary
+            // Body-fixed-primary carve-out: parent-anchored debris that has body-fixed primary
             // covering the activation UT does not need ANY initial-hide path --
             // not the UT-window gates above, and not the activation-settle
             // time-warp guard below. Body-fixed primary playback resolves the

--- a/Source/Parsek/GhostRenderTrace.cs
+++ b/Source/Parsek/GhostRenderTrace.cs
@@ -121,7 +121,7 @@ namespace Parsek
 
             /// <summary>
             /// Recording's <c>bodyFixedFrames</c> body-fixed primary lerp.
-            /// Used for parent-anchored debris (v13+) whenever the loop-chain
+            /// Used for parent-anchored debris whenever the loop-chain
             /// relative surface is not deliberately selected.
             /// </summary>
             BodyFixedPrimary = 2,
@@ -161,7 +161,7 @@ namespace Parsek
             // Debris-frame bracket span at the current playback UT: the time
             // gap between the two recorded `frames` entries that contain
             // playbackUT. NaN when not Relative or fewer than two frames are
-            // available. This surfaces the wide-bracket pattern that format v13
+            // available. This surfaces the wide-bracket pattern that the current format
             // avoids for parent-anchored debris by rendering body-fixed primary
             // frames first.
             public double DebrisBracketSeconds;

--- a/Source/Parsek/IGhostPositioner.cs
+++ b/Source/Parsek/IGhostPositioner.cs
@@ -70,7 +70,7 @@ namespace Parsek
         /// outside coverage.
         /// </summary>
         /// <remarks>
-        /// Format v13: parent-anchored debris normally renders through this
+        /// Parent-anchored debris normally renders through this
         /// recorded-data-only surface. It is never a substitute for live anchors.
         /// </remarks>
         bool TryPositionFromBodyFixedPrimary(int index, IPlaybackTrajectory traj,

--- a/Source/Parsek/ParsekConfig.cs
+++ b/Source/Parsek/ParsekConfig.cs
@@ -203,7 +203,7 @@ namespace Parsek
         internal const double InitialDebrisSeedBridgeActivationHiddenMaxSeconds = 1.0;
 
         /// <summary>
-        /// Minimum anchor-local distance that marks a v13 debris structural seed
+        /// Minimum anchor-local distance that marks a parent-anchored debris structural seed
         /// bridge as synthetic enough to hide. Correctly anchored radial debris
         /// should start near the parent and separate only a few metres before the
         /// first ordinary sample; the bad live-parent-at-init conversion produced

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -19684,7 +19684,7 @@ namespace Parsek
         /// population are reused.
         /// </summary>
         /// <remarks>
-        /// Format v13 contract: this is the primary rendering surface for
+        /// Parent-anchored contract: this is the primary rendering surface for
         /// parent-anchored debris whenever the active Relative section's
         /// `bodyFixedFrames` covers the playback UT. Loop-anchored chains still
         /// try relative replay first and use this as the recorded fallback when

--- a/Source/Parsek/ParsekTrackingStation.cs
+++ b/Source/Parsek/ParsekTrackingStation.cs
@@ -1444,7 +1444,7 @@ namespace Parsek
             if (section.referenceFrame == ReferenceFrame.Relative)
             {
                 // TryResolveRecordingWorldPosition consumes the selected list as
-                // body-fixed lat/lon/alt. v13 Relative frames are anchor-local
+                // body-fixed lat/lon/alt. Relative frames are anchor-local
                 // metre offsets, so Tracking Station focus/icon positioning must
                 // use the body-fixed primary surface unless this path grows a
                 // real relative world-pose resolver.

--- a/Source/Parsek/RecordingOptimizer.cs
+++ b/Source/Parsek/RecordingOptimizer.cs
@@ -1083,7 +1083,7 @@ namespace Parsek
             second.AntennaSpecs = original.AntennaSpecs != null
                 ? new List<AntennaSpec>(original.AntennaSpecs) : null;
             second.IsDebris = original.IsDebris;
-            // PR 3b: propagate the v13 debris parent-anchor contract to both halves of
+            // PR 3b: propagate the debris parent-anchor contract to both halves of
             // a SplitAtSection split. The `original` half retains its field by virtue of
             // in-place mutation; the `second` (newly-allocated) half needs the explicit copy.
             second.ParentAnchorRecordingId = original.ParentAnchorRecordingId;
@@ -1168,7 +1168,7 @@ namespace Parsek
         ///
         /// Returns null (without mutating <paramref name="original"/>) on any guard
         /// failure: bad pre-conditions (null input, NaN splitUT, recording's UT bounds
-        /// don't strictly span splitUT) or a v13 debris contract violation (post-split
+        /// don't strictly span splitUT) or a debris contract violation (post-split
         /// half ends up with fewer than 2 bodyFixedFrames samples). Straddling
         /// OrbitSegments are safe — <see cref="SplitAtSection"/>'s OrbitSegments
         /// partition tail-clones them into TIP at startUT=splitUT (the Kepler
@@ -1219,7 +1219,7 @@ namespace Parsek
             // CachedStats — all in place on `original`. The plan §r4
             // mutation-ordering rule requires "a guarded return leaves
             // the input recording byte-identical." Snapshot the affected
-            // fields BEFORE Ensure so the v13 guard / gap-fallback /
+            // fields BEFORE Ensure so the debris guard / gap-fallback /
             // boundary-search guarded-return paths below can restore.
             //
             // Cheap on the happy path: list shallow-copies of structs,
@@ -1426,7 +1426,7 @@ namespace Parsek
                         }
                     }
 
-                    // Partition v13 body-fixed primary surface samples by UT.
+                    // Partition body-fixed primary surface samples by UT.
                     bool hadBodyFixedFrames = straddle.bodyFixedFrames != null
                         && straddle.bodyFixedFrames.Count > 0;
                     if (straddle.bodyFixedFrames != null)
@@ -1441,7 +1441,7 @@ namespace Parsek
                         }
                     }
 
-                    // v13 debris frame contract guard: each half must retain at least 2
+                    // Debris frame contract guard: each half must retain at least 2
                     // bodyFixedFrames samples when the straddling section had them.
                     if (hadBodyFixedFrames)
                     {

--- a/Source/Parsek/RecordingTreeSplitter.cs
+++ b/Source/Parsek/RecordingTreeSplitter.cs
@@ -639,7 +639,7 @@ namespace Parsek
                 Recording tip = RecordingOptimizer.SplitAtUT(origin, rewindUT);
                 if (tip == null)
                 {
-                    // SplitAtUT's remaining guards (v13 debris contract
+                    // SplitAtUT's remaining guards (debris contract
                     // minimum bodyFixedFrames sample count, precondition
                     // violations such as origin not strictly spanning
                     // splitUT or NaN splitUT) all return null without

--- a/Source/Parsek/RelativeAnchorResolver.cs
+++ b/Source/Parsek/RelativeAnchorResolver.cs
@@ -1376,7 +1376,7 @@ namespace Parsek
                 // resolution in ProductionAnchorWorldFrameResolver) don't run
                 // through the engine dispatch. Fall through to the rejection
                 // path here so we don't compose against a non-loop live PID
-                // across loop iterations. Under v13 invariants non-loop
+                // across loop iterations. Under the current invariants non-loop
                 // recordings never write section.anchorVesselId != 0u, so
                 // this guard only fires on the explicit mismatch.
                 bool loopAnchorMismatch = recording.LoopAnchorVesselId != 0u

--- a/Source/Parsek/Rendering/AnchorPropagator.cs
+++ b/Source/Parsek/Rendering/AnchorPropagator.cs
@@ -322,7 +322,7 @@ namespace Parsek.Rendering
                         // stage halves AND short-lived debris fragments. The
                         // controlled halves are continuing vessels and need
                         // ε just like an Undock/JointBreak child; debris
-                        // keeps the v13 parent-anchored contract and is
+                        // keeps the parent-anchored contract and is
                         // skipped per-child below.
                         if (bp.Type != BranchPointType.Dock
                             && bp.Type != BranchPointType.Board
@@ -346,7 +346,7 @@ namespace Parsek.Rendering
                                 // Breakup BPs list debris children alongside
                                 // controlled stage halves; debris must not
                                 // receive a propagated DockOrMerge ε (it plays
-                                // back through the v13 parent-anchored debris
+                                // back through the parent-anchored debris
                                 // contract). Only controlled children walk.
                                 if (bp.Type == BranchPointType.Breakup
                                     && byId.TryGetValue(cid, out Recording rChildClassify)

--- a/Source/Parsek/RewindInvoker.cs
+++ b/Source/Parsek/RewindInvoker.cs
@@ -239,7 +239,7 @@ namespace Parsek
             provisional.VesselPersistentId = inheritFrom.VesselPersistentId;
             provisional.VesselName = inheritFrom.VesselName;
             provisional.IsDebris = inheritFrom.IsDebris;
-            // PR 3b: critical Re-Fly safety hook — propagate the v13 debris
+            // PR 3b: critical Re-Fly safety hook: propagate the debris
             // parent-anchor contract so a re-fly of a flight with debris children
             // doesn't silently lose the contract on the provisional. Without this,
             // the resolver's chain-walk would not have a parent recording id to

--- a/Source/Parsek/SessionMerger.cs
+++ b/Source/Parsek/SessionMerger.cs
@@ -145,7 +145,7 @@ namespace Parsek
                 if (srcRec.Controllers != null)
                     merged.Controllers = new List<ControllerInfo>(srcRec.Controllers);
                 merged.IsDebris = srcRec.IsDebris;
-                // PR 3b: propagate the v13 debris parent-anchor contract through merges.
+                // PR 3b: propagate the debris parent-anchor contract through merges.
                 merged.ParentAnchorRecordingId = srcRec.ParentAnchorRecordingId;
 
                 // Location context (Phase 10)

--- a/Source/Parsek/TraceSeparation.cs
+++ b/Source/Parsek/TraceSeparation.cs
@@ -194,7 +194,7 @@ namespace Parsek
         /// <summary>
         /// Pure helper: returns the magnitude of the anchor-local offset vector
         /// at <paramref name="playbackUT"/> linearly interpolated between the
-        /// bracketing entries of <paramref name="frames"/>. In v13 Relative
+        /// bracketing entries of <paramref name="frames"/>. In Relative
         /// debris sections, <c>frames[i].latitude/longitude/altitude</c> are
         /// anchor-local Cartesian metres (NOT body-fixed lat/lon/alt), so the
         /// magnitude of the lerped vector is the parent-vs-debris distance the


### PR DESCRIPTION
## Summary
- The recording schema is now a single contract (`RecordingStore.CurrentRecordingFormatVersion = 1`, `CurrentRecordingSchemaGeneration = 4`). The `v13` version qualifier left in code comments is stale and misleading for anyone reading the parent-anchored debris paths.
- Updated every stale `v13` comment across the recorder, optimizer, playback, and rendering source (18 files) to describe the current contract instead (e.g. "parent-anchored debris contract", "body-fixed-primary carve-out").
- Comment-only, no behavior change: build passes with 0 warnings/errors.

## Scope notes (intentionally left)
- **Identifiers** kept their names (`GhostPlaybackEngine.IsV13ParentAnchoredDebrisWithBodyFixedPrimaryAtActivationUT`, the `v13ParentAnchoredDebrisExempt` local) since renaming touches call sites and is not comment-only.
- **`RecordingOptimizer.cs` log strings** (`"v13 debris contract ..."`) are left intact because `RecordingOptimizerSplitAtUTTests` asserts on that substring; changing them would be a behavior change.
- **`RuntimeTests.cs`** `V13Debris_*` test/helper/class names, `Description` attribute strings, and `v13-*` recording-id data literals are test identifiers/data, not comments.
- **Historical docs** (CHANGELOG, `docs/dev/plans/debris-frame-contract-v13.md`, todo "DONE via ...-v13.md" status lines) are point-in-time records and left untouched. The design-doc `v6`/`v7`/`v13` reconciliation is separately tracked in `docs/dev/plans/schema-reset-v-next.md`.
- Scoped strictly to the `v13` token per the request; adjacent `v7`/`v9`/`v11` references were left as-is.

## Test plan
- [x] `dotnet build` succeeds (0 warnings, 0 errors)
- [x] No production-source `v13` comments remain (verified via grep; only identifiers, test fixtures, and the asserted log strings remain)
- [x] Comment-only diff (48 insertions / 48 deletions, symmetric)