### PR TITLE
Demote per-snapshot ORBIT/crew-remap logs from INFO to VerboseRateLimited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,10 @@ All notable changes to Parsek are documented here.
 - A recording whose saved trajectory had a small backwards time step (a glitch at a relative-to-absolute tracking handoff) now loads and replays cleanly. The recorder no longer writes such a point, and any recording already saved with one drops it on load.
 - The post-flight Merge/Discard dialog could be silently suppressed after you returned to flight from another scene while a recording restore was in progress. The restore guard that caused this is now cleared on the scene change, so the dialog appears as expected.
 
+### Log Hygiene
+
+- Capturing a vessel snapshot no longer writes two INFO lines to the log every time (the surface-orbit normalization and the stand-in-crew remap). A long time-warped recording was adding roughly 2,200 such lines per session; both are now rate-limited diagnostic lines.
+
 ### Known limitations
 
 - Looping a mission to a body that orbits the Sun (an interplanetary target like Duna) does not yet line up the replay with the live sky, so the transfer may not reach the target; it keeps relaunching as before until a future update adds the interplanetary launch window. Single-body missions and missions to a moon of the launch body (Mun, Minmus) now do relaunch at the correct window. For a moon mission the transfer reaches the moon, though the orbit may still sit slightly off the launch site (closed in a later update).

--- a/Source/Parsek/KerbalsModule.cs
+++ b/Source/Parsek/KerbalsModule.cs
@@ -540,8 +540,13 @@ namespace Parsek
 
             if (rewritten > 0)
             {
-                ParsekLog.Info(Tag,
-                    $"ReverseMapCrewNamesInSnapshot: rewrote {rewritten} stand-in crew name(s) " +
+                // VerboseRateLimited (not Info): TryBackupSnapshot fires often (the
+                // recorder's periodic snapshot refresh drives it ~1100+ times across a
+                // long time-warped recording), and any vessel carrying a seated stand-in
+                // rewrites a crew name on every one. Routine, not a notable event, so it
+                // must not log unconditionally. The zero-rewrite case stays silent.
+                ParsekLog.VerboseRateLimited(Tag, "reverse-map-crew",
+                    () => $"ReverseMapCrewNamesInSnapshot: rewrote {rewritten} stand-in crew name(s) " +
                     $"back to originals in snapshot ({contextForLog ?? "no-context"})");
             }
 

--- a/Source/Parsek/VesselSpawner.cs
+++ b/Source/Parsek/VesselSpawner.cs
@@ -4251,8 +4251,13 @@ namespace Parsek
             orbitNode.AddValue("EPH", "0");
             orbitNode.AddValue("REF", bodyIndex.ToString(CultureInfo.InvariantCulture));
             snapshot.AddNode(orbitNode);
-            ParsekLog.Info("Spawner",
-                $"ApplySurfaceOrbitToSnapshot: rewrote ORBIT to canonical surface tuple for " +
+            // VerboseRateLimited (not Info): this fires once per TryBackupSnapshot for
+            // every landed/splashed-vessel snapshot. The recorder's periodic snapshot
+            // refresh (FlightRecorder.RefreshBackupSnapshot, 10s-UT throttle) drives it
+            // ~1100+ times across a long time-warped recording. Routine normalization,
+            // not a notable event, so it must not log unconditionally.
+            ParsekLog.VerboseRateLimited("Spawner", "apply-surface-orbit",
+                () => $"ApplySurfaceOrbitToSnapshot: rewrote ORBIT to canonical surface tuple for " +
                 $"{(string.IsNullOrEmpty(logContext) ? "snapshot" : logContext)} on body " +
                 $"'{DescribeBodyForLog(body)}' (REF={bodyIndex})");
             return true;

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -328,6 +328,16 @@ Four distinct in-game test failures from the 2026-05-28 batch run, root-caused a
 
 ---
 
+## Done - v0.10.0 Snapshot capture flooded KSP.log with two INFO lines per backup
+
+- Investigation 2026-05-29 (`Kerbal Space Program/KSP.log`). `[INFO][Spawner] ApplySurfaceOrbitToSnapshot: rewrote ORBIT to canonical surface tuple ...` and `[INFO][KerbalsModule] ReverseMapCrewNamesInSnapshot: rewrote N stand-in crew name(s) ...` each logged 1121 times (~2242 INFO lines) for a single landed vessel ('Jumping Flea') in one session. Both fire inside `VesselSpawner.TryBackupSnapshot` (the crew remap and the surface-orbit normalization of the backed-up snapshot).
+- **Root cause (frequency is legitimate, not a per-frame loop):** the dominant `TryBackupSnapshot` caller is `FlightRecorder.RefreshBackupSnapshot(v, "periodic")` (`FlightRecorder.cs`), invoked from the per-recorded-sample path and gated by a 10 s-UT throttle (`ShouldRefreshSnapshot`, `snapshotRefreshIntervalUT = 10.0`). The session was a ~6.75 game-hour recording (1840 points, UT 46701606 -> 46725917) captured under heavy time warp, so the 10 s-UT throttle elapsed ~1121 times. Confirmed: 1121 snapshots < 1840 recorded points < 2431 (UT span / 10 s), and the recorder's own `OnPhysicsFrame sample` verbose fired only 23 times (rate-limited), ruling out a per-real-frame loop. The orbit rewrite (a landed/splashed snapshot) and crew remap (a seated stand-in) are correct routine work; only the unconditional INFO logging was wrong.
+- **Fix:** both lines demoted from `ParsekLog.Info` to `ParsekLog.VerboseRateLimited` (shared keys `apply-surface-orbit` / `reverse-map-crew`, default 5 s real-time interval), using the `Func<string>` overload so the message is not built on suppressed calls. The zero-rewrite crew case stays silent as before. Existing assertions (`Bug278FinalizeLimboTests` ORBIT log, `ReverseMapCrewNamesInSnapshotTests` rewrote-1 log) still pass: both test classes enable verbose and reset rate-limit state per test, and `VerboseRateLimited` emits on the first call per key.
+- **Note (not changed):** the 10 s-UT throttle is UT-based, so under time warp the refresh fires far more often in real-time than the "every ~10 s" intent implies. Making it hybrid (UT + real-time) would cut the snapshot work itself, but that changes recording fidelity and is out of scope here; left as a possible follow-up.
+- **Status:** CLOSED 2026-05-29.
+
+---
+
 ## Done - v0.9.3 Fast-Forward / Warp to Departure landed exactly at the event instead of before it
 
 - Request 2026-05-22. Fast-Forward (recordings table + timeline) jumped to a recording's launch UT exactly, and Warp to Departure (Real Spawn Control) jumped to the ghost's departure UT exactly, dropping the player into the event with no setup time. Rewind already restores `RewindToLaunchLeadTimeSeconds` (15 s) of pre-launch lead; the forward jumps should match. Warp to Spawn must stay precise at the spawn moment.


### PR DESCRIPTION
## Problem

In one play session, two INFO logs each fired 1121 times (~2242 lines) for a single landed vessel (`Jumping Flea`):

- `[INFO][Spawner] ApplySurfaceOrbitToSnapshot: rewrote ORBIT to canonical surface tuple ...`
- `[INFO][KerbalsModule] ReverseMapCrewNamesInSnapshot: rewrote N stand-in crew name(s) ...`

Both fire 1:1 per `VesselSpawner.TryBackupSnapshot` call. INFO logs unconditionally, so this is pure noise for every player.

## Root cause (frequency is legitimate, not a per-frame loop)

The dominant `TryBackupSnapshot` caller is `FlightRecorder.RefreshBackupSnapshot(v, "periodic")`, invoked from the per-recorded-sample path and gated by a 10s-UT throttle (`snapshotRefreshIntervalUT = 10.0`). The session was a ~6.75 game-hour recording captured under heavy time warp, so the throttle elapsed ~1121 times.

Evidence from KSP.log:

- 1840 recorded points spanning UT 46701606 to 46725917 (~24,311s of game-time), all for one vessel.
- 1121 snapshots, with `1121 < 1840 points < 2431 (UT span / 10s)`, so the throttle is working.
- The recorder's own `OnPhysicsFrame sample` verbose fired only 23 times (rate-limited), ruling out a per-real-frame loop.

The underlying work (surface-orbit normalization of a landed snapshot, crew remap of a seated stand-in) is correct and bounded by the throttle, so only the logging was wrong.

## Fix

Demote both lines from `ParsekLog.Info` to `ParsekLog.VerboseRateLimited` (per CLAUDE.md's hot-path logging convention), using the `Func<string>` overload so the message is not built on suppressed calls. Shared keys `apply-surface-orbit` / `reverse-map-crew`, default 5s interval. The `rewritten > 0` guard (zero-rewrite stays silent) is preserved. The one-shot spawn-validation repair path that also calls `ApplySurfaceOrbitToSnapshot` keeps its own adjacent WARN, so no notable event is hidden.

## Validation

- `dotnet test --filter "FullyQualifiedName!~InjectAllRecordings"`: 12788 passed, 0 failed.
- The two existing log-assertion test classes (`Bug278FinalizeLimboTests`, `ReverseMapCrewNamesInSnapshotTests`) stay green: both enable verbose and reset rate-limit state per test, and `VerboseRateLimited` emits on the first call per key.
- Clean-context Opus review: no blockers.

## Docs

- `CHANGELOG.md`: new `### Log Hygiene` entry under 0.10.0.
- `docs/dev/todo-and-known-bugs.md`: a "Done - v0.10.0" entry with the root-cause analysis.

## Note (out of scope, recorded in todo doc)

The 10s throttle is UT-based, so under time warp the refresh fires far more often in real-time than the "every ~10s" intent. A hybrid UT+real-time throttle would cut the snapshot work itself, but it changes recording fidelity, so it is left as a possible follow-up.
