### PR TITLE
Extract shared ExecuteRewindSaveLoad helper for both rewind entry points

### DIFF
--- a/Source/Parsek/RecordingStore.cs
+++ b/Source/Parsek/RecordingStore.cs
@@ -6381,88 +6381,13 @@ namespace Parsek
 
             BeginRewindForOwner(owner);
 
-            string tempCopyName = null;
-            try
-            {
-                string savesDir = Path.Combine(
-                    KSPUtil.ApplicationRootPath ?? "",
-                    "saves",
-                    HighLogic.SaveFolder ?? "");
-
-                string sourcePath = Path.Combine(savesDir,
-                    RecordingPaths.BuildRewindSaveRelativePath(owner.RewindSaveFileName));
-                tempCopyName = owner.RewindSaveFileName;
-                string tempPath = Path.Combine(savesDir, tempCopyName + ".sfs");
-
-                // Copy from Parsek/Saves/ to root saves dir
-                File.Copy(sourcePath, tempPath, true);
-
-                // Pre-process the save file before KSP parses it:
-                // 1. Remove recorded vessel + any EVA child vessels (other vessels stay intact)
-                // 2. Wind back UT by the rewind-to-launch lead time so the player can
-                //    regain control on the pad before launch.
-
-                var stripNames = BuildRewindStripNames(owner);
-                // Collect spawned vessel PIDs for PID-based stripping (belt-and-suspenders
-                // alongside name matching — catches renamed vessels or debris)
-                var (stripPids, _) = CollectSpawnedVesselInfo();
-                PreProcessRewindSave(tempPath, stripNames, stripPids, RewindToLaunchLeadTimeSeconds);
-
-                Game game = GamePersistence.LoadGame(tempCopyName, HighLogic.SaveFolder, true, false);
-
-                // Delete the temp copy (file already parsed into Game object)
-                TryDeleteFileQuietly(tempPath);
-
-                if (game == null)
-                {
-                    ResetRewindFlags();
-                    if (!SuppressLogging)
-                        ParsekLog.Error("Rewind",
-                            $"Rewind failed: LoadGame returned null for save '{owner.RewindSaveFileName}'. " +
-                            $"Flags reset: IsRewinding={IsRewinding}, RewindUT={RewindUT}, RewindAdjustedUT={RewindAdjustedUT}");
-                    return;
-                }
-
-                // Capture the adjusted UT from the preprocessed save.
-                RewindContext.SetAdjustedUT(game.flightState.universalTime);
-
-                if (!SuppressLogging)
-                    ParsekLog.Info("Rewind",
-                        $"Rewind: adjustedUT={RewindAdjustedUT:F1}, " +
-                        $"rewindUT={RewindUT:F1}, flags=[IsRewinding={IsRewinding}]");
-
-                // Drop supersede relations whose forks are entirely in the rewound-out
-                // future. Without this, a rewound-to-launch source recording stays
-                // suppressed by `reason=superseded-by-relation` after re-launch even
-                // though the user has rewound past the moment the forks were created.
-                // Walk the whole rewound owner's tree so branch recordings (e.g. an
-                // upper-stage Probe) are unsuppressed too, not just the owner. Runs
-                // AFTER SetAdjustedUT so the comparison `fork.StartUT >= rewindAdjustedUT`
-                // uses the post-load UT.
-                int droppedSupersedes = DropSupersedesRewoundOutOfExistence(owner, RewindAdjustedUT);
-                if (droppedSupersedes > 0 && !SuppressLogging)
-                    ParsekLog.Info("Rewind",
-                        $"Dropped {droppedSupersedes} supersede relation(s) rewound out of existence " +
-                        $"(rewindUT={RewindAdjustedUT:F1} owner='{owner.VesselName}')");
-
-                HighLogic.CurrentGame = game;
-                HighLogic.LoadScene(GameScenes.SPACECENTER);
-
-                if (!SuppressLogging)
-                    ParsekLog.Info("Rewind",
-                        $"Rewind: loading save '{owner.RewindSaveFileName}' into SpaceCenter");
-            }
-            catch (Exception ex)
-            {
-                ResetRewindFlags();
-
-                DeleteTemporaryRewindSaveCopy(tempCopyName);
-
-                if (!SuppressLogging)
-                    ParsekLog.Error("Rewind",
-                        $"Rewind failed: {ex.Message}. " +
-                        $"Flags reset: IsRewinding={IsRewinding}, RewindUT={RewindUT}, RewindAdjustedUT={RewindAdjustedUT}");
-            }
+            // Shared load: pre-process (strip + lead-time windback) keyed by the owner, and
+            // drop supersede relations rewound out of existence for the owner's tree.
+            ExecuteRewindSaveLoad(
+                owner.RewindSaveFileName,
+                preProcessOwner: owner,
+                dropSupersedeOwner: owner,
+                messageLabel: "Rewind");
         }
 
         private static void BeginRewindForOwner(Recording owner)
@@ -6485,6 +6410,128 @@ namespace Parsek
                     $"Rewind-to-Launch initiated to UT {owner.StartUT} " +
                     $"(save: {owner.RewindSaveFileName}). Plain launch rewind via parsek_rw_* quicksave; " +
                     $"this is NOT a Re-Fly (no RewindPoint / ReFlySessionMarker / MergeJournal)");
+        }
+
+        /// <summary>
+        /// Shared load mechanics for both rewind entry points (<see cref="InitiateRewind"/>
+        /// and <see cref="InitiateRewindToCareerStart"/>). Copies the Parsek/Saves snapshot to
+        /// the root saves dir (KSP's LoadGame cannot read subdirectory paths), optionally
+        /// pre-processes it, loads it via <see cref="GamePersistence.LoadGame"/>, deletes the
+        /// temp copy, captures the adjusted UT, optionally drops supersede relations rewound
+        /// out of existence, swaps in the loaded game, and loads the Space Center. On any
+        /// failure resets the rewind flags and removes the temp copy. Returns true when the
+        /// scene load was initiated.
+        ///
+        /// <para>Callers own the precondition gates (merge-journal refusal, supersede-count
+        /// refusal) and the rewind-context setup (<see cref="BeginRewindForOwner"/> vs the
+        /// UT-0 reset) BEFORE calling this; this helper is purely the mechanical save-copy /
+        /// load / scene-swap wrapper that the two entry points used to duplicate.</para>
+        /// </summary>
+        /// <param name="saveFileName">Parsek/Saves snapshot base name (no .sfs extension).</param>
+        /// <param name="preProcessOwner">When non-null, runs <see cref="PreProcessRewindSave"/>
+        /// with that owner's strip set plus the rewind-to-launch lead-time windback. Null skips
+        /// pre-processing (the pristine career-start snapshot, which must not be wound back
+        /// below UT 0).</param>
+        /// <param name="dropSupersedeOwner">When non-null, drops supersede relations rewound
+        /// out of existence for that owner's tree once the adjusted UT is known. Null skips the
+        /// drop (the career-start path refuses up front when any supersede relation exists).</param>
+        /// <param name="messageLabel">Message-text prefix for the adjusted-UT / failure logs
+        /// ("Rewind" vs "Warp-to-game-start"); the subsystem tag stays "Rewind" either way.</param>
+        private static bool ExecuteRewindSaveLoad(
+            string saveFileName,
+            Recording preProcessOwner,
+            Recording dropSupersedeOwner,
+            string messageLabel)
+        {
+            string tempCopyName = null;
+            try
+            {
+                string savesDir = Path.Combine(
+                    KSPUtil.ApplicationRootPath ?? "",
+                    "saves",
+                    HighLogic.SaveFolder ?? "");
+
+                string sourcePath = Path.Combine(savesDir,
+                    RecordingPaths.BuildRewindSaveRelativePath(saveFileName));
+                tempCopyName = saveFileName;
+                string tempPath = Path.Combine(savesDir, tempCopyName + ".sfs");
+
+                // Copy from Parsek/Saves/ to the root saves dir so LoadGame can find it.
+                File.Copy(sourcePath, tempPath, true);
+
+                if (preProcessOwner != null)
+                {
+                    // Pre-process the save file before KSP parses it:
+                    // 1. Remove recorded vessel + any EVA child vessels (other vessels stay intact)
+                    // 2. Wind back UT by the rewind-to-launch lead time so the player can
+                    //    regain control on the pad before launch.
+                    var stripNames = BuildRewindStripNames(preProcessOwner);
+                    // Collect spawned vessel PIDs for PID-based stripping (belt-and-suspenders
+                    // alongside name matching, catches renamed vessels or debris)
+                    var (stripPids, _) = CollectSpawnedVesselInfo();
+                    PreProcessRewindSave(tempPath, stripNames, stripPids, RewindToLaunchLeadTimeSeconds);
+                }
+
+                Game game = GamePersistence.LoadGame(tempCopyName, HighLogic.SaveFolder, true, false);
+
+                // Delete the temp copy (file already parsed into Game object)
+                TryDeleteFileQuietly(tempPath);
+
+                if (game == null)
+                {
+                    ResetRewindFlags();
+                    if (!SuppressLogging)
+                        ParsekLog.Error("Rewind",
+                            $"{messageLabel} failed: LoadGame returned null for save '{saveFileName}'. " +
+                            $"Flags reset: IsRewinding={IsRewinding}, RewindUT={RewindUT}, RewindAdjustedUT={RewindAdjustedUT}");
+                    return false;
+                }
+
+                // Capture the adjusted UT from the (possibly preprocessed) save.
+                RewindContext.SetAdjustedUT(game.flightState.universalTime);
+
+                if (!SuppressLogging)
+                    ParsekLog.Info("Rewind",
+                        $"{messageLabel}: adjustedUT={RewindAdjustedUT:F1}, " +
+                        $"rewindUT={RewindUT:F1}, flags=[IsRewinding={IsRewinding}]");
+
+                if (dropSupersedeOwner != null)
+                {
+                    // Drop supersede relations whose forks are entirely in the rewound-out
+                    // future. Without this, a rewound-to-launch source recording stays
+                    // suppressed by `reason=superseded-by-relation` after re-launch even
+                    // though the user has rewound past the moment the forks were created.
+                    // Walk the whole rewound owner's tree so branch recordings (e.g. an
+                    // upper-stage Probe) are unsuppressed too, not just the owner. Runs
+                    // AFTER SetAdjustedUT so the comparison `fork.StartUT >= rewindAdjustedUT`
+                    // uses the post-load UT.
+                    int droppedSupersedes = DropSupersedesRewoundOutOfExistence(dropSupersedeOwner, RewindAdjustedUT);
+                    if (droppedSupersedes > 0 && !SuppressLogging)
+                        ParsekLog.Info("Rewind",
+                            $"Dropped {droppedSupersedes} supersede relation(s) rewound out of existence " +
+                            $"(rewindUT={RewindAdjustedUT:F1} owner='{dropSupersedeOwner.VesselName}')");
+                }
+
+                HighLogic.CurrentGame = game;
+                HighLogic.LoadScene(GameScenes.SPACECENTER);
+
+                if (!SuppressLogging)
+                    ParsekLog.Info("Rewind",
+                        $"{messageLabel}: loading save '{saveFileName}' into SpaceCenter");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                ResetRewindFlags();
+
+                DeleteTemporaryRewindSaveCopy(tempCopyName);
+
+                if (!SuppressLogging)
+                    ParsekLog.Error("Rewind",
+                        $"{messageLabel} failed: {ex.Message}. " +
+                        $"Flags reset: IsRewinding={IsRewinding}, RewindUT={RewindUT}, RewindAdjustedUT={RewindAdjustedUT}");
+                return false;
+            }
         }
 
         /// <summary>
@@ -6541,49 +6588,14 @@ namespace Parsek
                     $"Warp-to-game-start initiated to UT 0 (snapshot: {saveFileName}). Keeps in-memory " +
                     "recordings as future ghosts; NOT a Re-Fly.");
 
-            string tempCopyName = null;
-            try
-            {
-                string savesDir = Path.Combine(
-                    KSPUtil.ApplicationRootPath ?? "", "saves", HighLogic.SaveFolder ?? "");
-                string sourcePath = Path.Combine(savesDir,
-                    RecordingPaths.BuildRewindSaveRelativePath(saveFileName));
-                tempCopyName = saveFileName;
-                string tempPath = Path.Combine(savesDir, tempCopyName + ".sfs");
-
-                // Copy from Parsek/Saves/ to the root saves dir so LoadGame can find it.
-                File.Copy(sourcePath, tempPath, true);
-
-                // No PreProcessRewindSave: the snapshot is pristine (no future vessels to
-                // strip) and must NOT be wound back below UT 0.
-                Game game = GamePersistence.LoadGame(tempCopyName, HighLogic.SaveFolder, true, false);
-                TryDeleteFileQuietly(tempPath);
-
-                if (game == null)
-                {
-                    ResetRewindFlags();
-                    if (!SuppressLogging)
-                        ParsekLog.Error("Rewind",
-                            $"Warp-to-game-start failed: LoadGame returned null for snapshot '{saveFileName}'");
-                    return false;
-                }
-
-                RewindContext.SetAdjustedUT(game.flightState.universalTime);
-                if (!SuppressLogging)
-                    ParsekLog.Info("Rewind", $"Warp-to-game-start: adjustedUT={RewindAdjustedUT:F1}");
-
-                HighLogic.CurrentGame = game;
-                HighLogic.LoadScene(GameScenes.SPACECENTER);
-                return true;
-            }
-            catch (Exception ex)
-            {
-                ResetRewindFlags();
-                DeleteTemporaryRewindSaveCopy(tempCopyName);
-                if (!SuppressLogging)
-                    ParsekLog.Error("Rewind", $"Warp-to-game-start failed: {ex.Message}");
-                return false;
-            }
+            // Pristine snapshot: no PreProcessRewindSave (no future vessels to strip, and it
+            // must NOT be wound back below UT 0) and no supersede drop (refused above when any
+            // supersede relation exists).
+            return ExecuteRewindSaveLoad(
+                saveFileName,
+                preProcessOwner: null,
+                dropSupersedeOwner: null,
+                messageLabel: "Warp-to-game-start");
         }
 
         /// <summary>

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -388,11 +388,13 @@ Four distinct in-game test failures from the 2026-05-28 batch run, root-caused a
 
 ---
 
-## Open - v0.10.0 Warp-to-time: InitiateRewindToCareerStart duplicates InitiateRewind load boilerplate
+## Done - v0.10.0 Warp-to-time: InitiateRewindToCareerStart duplicates InitiateRewind load boilerplate
 
 - `RecordingStore.InitiateRewindToCareerStart` (PR #947) repeats ~25 lines of the load sequence from `InitiateRewind` (copy temp save to root -> `GamePersistence.LoadGame` -> temp delete -> `SetAdjustedUT` -> `HighLogic.CurrentGame = game` -> `LoadScene(SPACECENTER)`, plus the try/catch + `ResetRewindFlags` + `DeleteTemporaryRewindSaveCopy` failure path). The behavior-critical parts (RewindContext setup, `HandleRewindOnLoad`, ledger recalc) are already shared; only this mechanical wrapper is duplicated.
-- **Fix (deferred):** extract a shared private helper parameterized by whether to run `PreProcessRewindSave` (strip + lead-time windback) and whether to drop supersedes for an owner, so both entries call it. Deferred from PR #947 because it edits the proven `InitiateRewind` path, which xUnit cannot cover end-to-end (needs the Unity `LoadGame` round-trip) — land it as a separately-reviewed change with a fresh Rewind-to-Launch playtest, not bundled with the warp feature.
-- **Status:** OPEN — low-priority cleanup.
+- **Fix:** extracted `RecordingStore.ExecuteRewindSaveLoad(saveFileName, preProcessOwner, dropSupersedeOwner, messageLabel)`. `preProcessOwner != null` runs `PreProcessRewindSave` (strip + lead-time windback) for that owner; `dropSupersedeOwner != null` drops supersedes rewound out of existence for that owner's tree; `messageLabel` is the log message-text prefix ("Rewind" vs "Warp-to-game-start", subsystem tag stays "Rewind"). `InitiateRewind` calls it with the owner for both (behavior + log wording byte-identical to before); `InitiateRewindToCareerStart` calls it with both null. The callers keep their own precondition gates (merge-journal / supersede-count refusal) and `RewindContext` setup.
+- **Note:** the career-start path now shares the proven path's richer logging (its `adjustedUT` line gains `rewindUT` + flags, it gains a post-`LoadScene` "loading save into SpaceCenter" line, and its failure logs gain the `Flags reset:` suffix). No gameplay behavior change on either path.
+- **Tests:** no new unit tests (the helper is Unity-only file I/O + `LoadGame` + `LoadScene`, which xUnit cannot cover end-to-end). Full suite green (13043).
+- **Status:** FIX LANDED 2026-05-31. Behavior-preserving refactor; the prescribed fresh Rewind-to-Launch playtest is still recommended before final close.
 
 ---
 


### PR DESCRIPTION
## What

`RecordingStore.InitiateRewindToCareerStart` (Warp-to-time UT-0 reset, PR #947) duplicated ~25 lines of the load sequence from `InitiateRewind` (Rewind-to-Launch): copy the snapshot to the save root, `GamePersistence.LoadGame`, delete the temp copy, `SetAdjustedUT`, swap `HighLogic.CurrentGame`, `LoadScene(SPACECENTER)`, plus the `try/catch` + `ResetRewindFlags` + `DeleteTemporaryRewindSaveCopy` failure path.

This pulls that mechanical wrapper into a single private helper, `ExecuteRewindSaveLoad(saveFileName, preProcessOwner, dropSupersedeOwner, messageLabel)`:

- `preProcessOwner != null` runs `PreProcessRewindSave` (strip + lead-time windback) for that owner; null skips it (pristine career-start snapshot, never wound back below UT 0).
- `dropSupersedeOwner != null` drops supersedes rewound out of existence for that owner's tree after `SetAdjustedUT`; null skips it (career-start refuses up front when any supersede relation exists).
- `messageLabel` is the log message-text prefix ("Rewind" vs "Warp-to-game-start"); the subsystem tag stays "Rewind".

`InitiateRewind` calls it with `(owner.RewindSaveFileName, owner, owner, "Rewind")`; `InitiateRewindToCareerStart` calls it with `(saveFileName, null, null, "Warp-to-game-start")`. Each entry point keeps its own precondition gates (merge-journal / supersede-count refusal) and `RewindContext` setup.

## Behavior

`InitiateRewind` is byte-identical (same statements, ordering, arguments, return semantics, and log strings). The only change anywhere is that the career-start path now shares the proven path's richer logging (its `adjustedUT` line gains `rewindUT` + flags, it gains a post-`LoadScene` "loading save into SpaceCenter" line, and its failure logs gain the `Flags reset:` suffix). No gameplay behavior change on either path.

## Validation

- Build clean (0 warnings / 0 errors).
- Full xUnit suite green: 13043 passed, 0 failed (includes the ERS/ELS grep audit and rewind logging tests).
- Clean-context Opus review: no issues; confirmed `InitiateRewind` byte-identical.
- No new unit tests: the helper is Unity-only file I/O + `LoadGame` + `LoadScene`, which xUnit cannot cover end-to-end. A fresh Rewind-to-Launch playtest is still recommended before final close (as the original deferred-todo prescribed).

Closes the deferred cleanup tracked in `docs/dev/todo-and-known-bugs.md` ("v0.10.0 Warp-to-time: InitiateRewindToCareerStart duplicates InitiateRewind load boilerplate"); that entry is flipped to Done in this PR.