### PR TITLE
fix(saves): delete orphaned .loadmeta sidecar after quicksave move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ All notable changes to Parsek are documented here.
 - The post-flight Merge/Discard dialog could be silently suppressed after you returned to flight from another scene while a recording restore was in progress. The restore guard that caused this is now cleared on the scene change, so the dialog appears as expected.
 - A looped interplanetary mission's orbit line no longer blinks on and off at the start of the heliocentric transfer (just after leaving the launch body's SOI) and on the approach to the destination planet. A short grace window now keeps the line steady across the rapid recorded segment changes at those phase boundaries, where the line, the trajectory polyline, and the per-frame orbit refresh were briefly disagreeing each frame.
 - A re-aimed interplanetary mission's final descent to the destination planet now draws a map trajectory again. The descent's recorded orbit segments dive below the surface, where the orbit line cannot be drawn, and the trajectory polyline was skipping those samples as orbit-covered, leaving a gap with no line at all; the polyline now picks up the descent that the orbit line abandons.
+- Parsek's internal quicksaves (rewind, re-fly, and the career-start snapshot) no longer leave stray ".loadmeta" files cluttering your save folder. Each quicksave is moved into Parsek's own subfolder, but its sidecar metadata file used to be left behind in the save root; that leftover is now cleaned up.
 
 ### Log Hygiene
 

--- a/Source/Parsek.Tests/FileIOUtilsLoadMetaTests.cs
+++ b/Source/Parsek.Tests/FileIOUtilsLoadMetaTests.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Tests for <see cref="FileIOUtils.DeleteSaveSidecarLoadMeta"/>: the orphan-cleanup
+    /// helper called after the rewind / career-start / rewind-point capture sites move a
+    /// stock <c>.sfs</c> into a Parsek subdirectory, leaving the <c>.loadmeta</c> sidecar
+    /// behind in the save root.
+    /// </summary>
+    [Collection("Sequential")]
+    public class FileIOUtilsLoadMetaTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+        private readonly string tempDir;
+
+        public FileIOUtilsLoadMetaTests()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+
+            tempDir = Path.Combine(
+                Path.GetTempPath(), "parsek_loadmeta_test_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+            try { Directory.Delete(tempDir, recursive: true); } catch { /* best-effort */ }
+        }
+
+        private string WriteFile(string name)
+        {
+            string path = Path.Combine(tempDir, name);
+            File.WriteAllText(path, "stub");
+            return path;
+        }
+
+        [Fact]
+        public void DeletesOrphanedLoadMeta_LeavesOtherFilesAlone()
+        {
+            string loadMeta = WriteFile("parsek_rw_abc123.loadmeta");
+            // A sibling .sfs that would normally have been moved out already, plus the
+            // legitimate stock saves that must never be touched.
+            string persistentMeta = WriteFile("persistent.loadmeta");
+            string quicksaveMeta = WriteFile("quicksave.loadmeta");
+
+            FileIOUtils.DeleteSaveSidecarLoadMeta(tempDir, "parsek_rw_abc123", "Recorder");
+
+            Assert.False(File.Exists(loadMeta), "orphaned .loadmeta should be deleted");
+            Assert.True(File.Exists(persistentMeta), "stock persistent.loadmeta must survive");
+            Assert.True(File.Exists(quicksaveMeta), "stock quicksave.loadmeta must survive");
+        }
+
+        [Fact]
+        public void LogsVerbose_WhenSidecarDeleted()
+        {
+            WriteFile("parsek_career_start.loadmeta");
+            logLines.Clear();
+
+            FileIOUtils.DeleteSaveSidecarLoadMeta(tempDir, "parsek_career_start", "CareerStart");
+
+            Assert.Contains(logLines, l => l.Contains("[CareerStart]")
+                && l.Contains("Deleted orphaned save sidecar")
+                && l.Contains("parsek_career_start.loadmeta"));
+        }
+
+        [Fact]
+        public void NoOp_WhenSidecarMissing()
+        {
+            logLines.Clear();
+
+            // No file on disk: must not throw, must not log a deletion.
+            FileIOUtils.DeleteSaveSidecarLoadMeta(tempDir, "parsek_rw_missing", "Recorder");
+
+            Assert.DoesNotContain(logLines, l => l.Contains("Deleted orphaned save sidecar"));
+            Assert.DoesNotContain(logLines, l => l.Contains("Failed to delete orphaned save sidecar"));
+        }
+
+        [Fact]
+        public void NoOp_WhenSavesDirNullOrEmpty()
+        {
+            FileIOUtils.DeleteSaveSidecarLoadMeta(null, "parsek_rw_x", "Recorder");
+            FileIOUtils.DeleteSaveSidecarLoadMeta("", "parsek_rw_x", "Recorder");
+            // No exception expected; no deletion logged.
+            Assert.DoesNotContain(logLines, l => l.Contains("Deleted orphaned save sidecar"));
+        }
+
+        [Fact]
+        public void NoOp_WhenBaseNameNullOrEmpty()
+        {
+            FileIOUtils.DeleteSaveSidecarLoadMeta(tempDir, null, "Recorder");
+            FileIOUtils.DeleteSaveSidecarLoadMeta(tempDir, "", "Recorder");
+            Assert.DoesNotContain(logLines, l => l.Contains("Deleted orphaned save sidecar"));
+        }
+
+        [Fact]
+        public void DoesNotDeleteSfs_OnlyLoadMeta()
+        {
+            string sfs = WriteFile("parsek_rw_keep.sfs");
+            string loadMeta = WriteFile("parsek_rw_keep.loadmeta");
+
+            FileIOUtils.DeleteSaveSidecarLoadMeta(tempDir, "parsek_rw_keep", "Recorder");
+
+            Assert.False(File.Exists(loadMeta), ".loadmeta should be deleted");
+            Assert.True(File.Exists(sfs), ".sfs must not be touched");
+        }
+    }
+}

--- a/Source/Parsek/CareerStartSnapshot.cs
+++ b/Source/Parsek/CareerStartSnapshot.cs
@@ -84,6 +84,11 @@ namespace Parsek
 
                 string destPath = Path.Combine(rewindDir, SaveFileName + ".sfs");
                 File.Move(rootPath, destPath);
+
+                // SaveGame also wrote a .loadmeta sidecar to the root; only the .sfs
+                // moves, so delete the orphan instead of leaving it to litter the save folder.
+                FileIOUtils.DeleteSaveSidecarLoadMeta(savesDir, SaveFileName, Tag);
+
                 ParsekLog.Info(Tag, $"Captured career-start snapshot: {destPath}");
                 return true;
             }

--- a/Source/Parsek/FileIOUtils.cs
+++ b/Source/Parsek/FileIOUtils.cs
@@ -9,6 +9,48 @@ namespace Parsek
     internal static class FileIOUtils
     {
         /// <summary>
+        /// Extension of the sidecar metadata file that <c>GamePersistence.SaveGame</c>
+        /// writes next to every <c>.sfs</c> in the saves root (load-dialog metadata:
+        /// UT, funds, science, reputation, thumbnail hash, etc.).
+        /// </summary>
+        internal const string LoadMetaExtension = ".loadmeta";
+
+        /// <summary>
+        /// Deletes the orphaned <c>.loadmeta</c> sidecar that <c>GamePersistence.SaveGame</c>
+        /// leaves in the saves root after Parsek moves the matching <c>.sfs</c> into a Parsek
+        /// subdirectory (<c>Parsek/Saves</c>, <c>Parsek/RewindPoints</c>). KSP's
+        /// <c>SaveGame</c> always writes the <c>.sfs</c> + <c>.loadmeta</c> pair to the root;
+        /// Parsek's quicksaves are loaded programmatically (the <c>.sfs</c> is copied back to
+        /// the root first), so the root <c>.loadmeta</c> serves no purpose and only litters the
+        /// save folder and the stock load dialog. Best-effort: a missing sidecar is a no-op and
+        /// a delete failure is logged and swallowed (the orphan is harmless).
+        /// </summary>
+        /// <param name="savesDir">Absolute path to the save folder where SaveGame wrote.</param>
+        /// <param name="saveBaseName">The save base name passed to SaveGame (no extension).</param>
+        /// <param name="tag">Subsystem tag for log lines.</param>
+        internal static void DeleteSaveSidecarLoadMeta(string savesDir, string saveBaseName, string tag)
+        {
+            if (string.IsNullOrEmpty(savesDir) || string.IsNullOrEmpty(saveBaseName))
+                return;
+
+            string loadMetaPath = Path.Combine(savesDir, saveBaseName + LoadMetaExtension);
+            try
+            {
+                if (File.Exists(loadMetaPath))
+                {
+                    File.Delete(loadMetaPath);
+                    ParsekLog.Verbose(tag,
+                        $"Deleted orphaned save sidecar '{saveBaseName}{LoadMetaExtension}'");
+                }
+            }
+            catch (Exception ex)
+            {
+                ParsekLog.Warn(tag,
+                    $"Failed to delete orphaned save sidecar '{saveBaseName}{LoadMetaExtension}': {ex.Message}");
+            }
+        }
+
+        /// <summary>
         /// Writes a ConfigNode to disk using the safe-write pattern: write to .tmp, then
         /// atomic rename. Ensures parent directory exists. Logs and re-throws on failure.
         /// </summary>

--- a/Source/Parsek/FlightRecorder.cs
+++ b/Source/Parsek/FlightRecorder.cs
@@ -5028,6 +5028,10 @@ namespace Parsek
                 string destPath = System.IO.Path.Combine(rewindDir, saveFileName + ".sfs");
                 System.IO.File.Move(rootPath, destPath);
 
+                // SaveGame also wrote a .loadmeta sidecar to the root; only the .sfs
+                // moves, so delete the orphan instead of leaving it to litter the save folder.
+                FileIOUtils.DeleteSaveSidecarLoadMeta(savesDir, saveFileName, "Recorder");
+
                 RewindSaveFileName = saveFileName;
             }
             catch (Exception ex)

--- a/Source/Parsek/InGameTests/SavePathRootThenMoveTest.cs
+++ b/Source/Parsek/InGameTests/SavePathRootThenMoveTest.cs
@@ -8,8 +8,9 @@ namespace Parsek.InGameTests
     /// Rewind-to-Staging (Phase 4, design §5.10 + §6.1): verifies the root-save
     /// -then-move flow. KSP <c>GamePersistence.SaveGame</c> writes to the save
     /// folder root; the RewindPointAuthor atomically moves the file into
-    /// <c>Parsek/RewindPoints/</c>. After capture, no <c>Parsek_TempRP_*.sfs</c>
-    /// should remain in the save root.
+    /// <c>Parsek/RewindPoints/</c>. After capture, neither a <c>Parsek_TempRP_*.sfs</c>
+    /// nor its orphaned <c>Parsek_TempRP_*.loadmeta</c> sidecar should remain in the
+    /// save root.
     /// </summary>
     public class SavePathRootThenMoveTest
     {
@@ -17,7 +18,7 @@ namespace Parsek.InGameTests
             AllowBatchExecution = false,
             RestoreBatchFlightBaselineAfterExecution = true,
             BatchSkipReason = "Isolated-run only — drives stock staging which permanently mutates the vessel; excluded from ordinary Run All / Run category. Use Run All + Isolated or the row play button in a disposable FLIGHT session.",
-            Description = "RewindPoint quicksave ends up in Parsek/RewindPoints/, no leftover Parsek_TempRP_*.sfs in save root")]
+            Description = "RewindPoint quicksave ends up in Parsek/RewindPoints/, no leftover Parsek_TempRP_*.sfs or .loadmeta in save root")]
         public IEnumerator SavePathRootThenMove()
         {
             var vessel = FlightGlobals.ActiveVessel;
@@ -87,6 +88,22 @@ namespace Parsek.InGameTests
             }
             InGameAssert.AreEqual(0, stray.Length,
                 $"Expected no Parsek_TempRP_*.sfs in save root; found {stray.Length}");
+
+            // No stray Parsek_TempRP_*.loadmeta sidecar in save root either: SaveGame
+            // writes the .sfs + .loadmeta pair to the root, only the .sfs is moved, and
+            // FileIOUtils.DeleteSaveSidecarLoadMeta must clean up the orphaned sidecar.
+            string[] strayMeta = Directory.Exists(saveRoot)
+                ? Directory.GetFiles(saveRoot, "Parsek_TempRP_*.loadmeta", SearchOption.TopDirectoryOnly)
+                : new string[0];
+            if (strayMeta.Length > 0)
+            {
+                ParsekLog.Error("RewindTest",
+                    $"[CRITICAL] SavePathRootThenMove: {strayMeta.Length} orphaned Parsek_TempRP_*.loadmeta " +
+                    $"sidecar(s) left in save root after move: " +
+                    string.Join(", ", strayMeta));
+            }
+            InGameAssert.AreEqual(0, strayMeta.Length,
+                $"Expected no Parsek_TempRP_*.loadmeta in save root; found {strayMeta.Length}");
 
             ParsekLog.Info("RewindTest",
                 $"SavePathRootThenMove: PASS rp={rp.RewindPointId} path={expectedPath}");

--- a/Source/Parsek/RewindPointAuthor.cs
+++ b/Source/Parsek/RewindPointAuthor.cs
@@ -338,6 +338,11 @@ namespace Parsek
                 {
                     FileIOUtils.SafeMove(src, dst, "RewindSave");
                     try { bytes = new FileInfo(dst).Length; } catch { /* best-effort */ }
+
+                    // SaveGame also wrote a .loadmeta sidecar next to the temp .sfs in the
+                    // save root; only the .sfs moves, so delete the orphan instead of leaving
+                    // it to litter the save folder.
+                    FileIOUtils.DeleteSaveSidecarLoadMeta(saveDir, tempName, "RewindSave");
                 }
                 catch (Exception ex)
                 {

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -396,11 +396,12 @@ Four distinct in-game test failures from the 2026-05-28 batch run, root-caused a
 
 ---
 
-## Open - v0.10.0 Rewind / career-start quicksave capture leaves an orphan .loadmeta in the save root
+## Done - v0.10.0 Rewind / career-start quicksave capture leaves an orphan .loadmeta in the save root
 
-- `FlightRecorder.CaptureRewindSave` and `CareerStartSnapshot.Capture` (PR #947) both `GamePersistence.SaveGame` to the save root then `File.Move` only the `.sfs` into `Parsek/Saves/`, leaving the sidecar `.loadmeta` (`parsek_rw_*.loadmeta`, `parsek_career_start.loadmeta`) orphaned in the save root (observed in save `s10`). Pre-existing for the rewind saves; career-start adds one more.
-- **Fix:** delete (or move) the matching `.loadmeta` after moving the `.sfs` in both capture sites. Cosmetic — the orphan is harmless, it just litters the save folder.
-- **Status:** OPEN — cosmetic.
+- `FlightRecorder.CaptureRewindSave` and `CareerStartSnapshot.Capture` (PR #947) both `GamePersistence.SaveGame` to the save root then `File.Move` only the `.sfs` into `Parsek/Saves/`, leaving the sidecar `.loadmeta` (`parsek_rw_*.loadmeta`, `parsek_career_start.loadmeta`) orphaned in the save root (observed in save `s10`). Pre-existing for the rewind saves; career-start adds one more. Investigation found a third site with the identical orphan class: `RewindPointAuthor` moves the RP temp `.sfs` (`Parsek_TempRP_<rpId>.sfs`) into `Parsek/RewindPoints/` and leaves `Parsek_TempRP_<rpId>.loadmeta` behind (observed in s14/s15).
+- **Fix:** new shared `FileIOUtils.DeleteSaveSidecarLoadMeta(savesDir, saveBaseName, tag)` best-effort helper (guarded by `File.Exists`, swallows + warn-logs failures) deletes the orphaned root `.loadmeta` after the `.sfs` move. Called from all three capture sites (`FlightRecorder.CaptureRewindSave`, `CareerStartSnapshot.Capture`, `RewindPointAuthor.ExecuteDeferredBody`). Delete, not move: Parsek loads these saves programmatically (copies the `.sfs` back to root first), so the `.loadmeta` serves no purpose and must stay out of the stock load dialog. Stock `persistent.loadmeta` / `quicksave.loadmeta` are untouched (their base names never match a Parsek save). Cosmetic: the orphan is harmless, it just litters the save folder.
+- **Tests:** 6 `FileIOUtilsLoadMetaTests` cases (deletes orphan + leaves stock sidecars, verbose log, missing-sidecar no-op, null/empty arg no-ops, never touches the `.sfs`). Full suite green (13049).
+- **Status:** CLOSED 2026-05-31.
 
 ---
 


### PR DESCRIPTION
## Problem

KSP's `GamePersistence.SaveGame` writes an `.sfs` + a sidecar `.loadmeta` pair to the saves **root**. Three Parsek capture sites move only the `.sfs` into a Parsek subfolder, leaving the `.loadmeta` orphaned in the save root (observed across saves `s14`/`s15`/`logi1`/`s13`):

| Site | Orphan | Moved to |
|------|--------|----------|
| `FlightRecorder.CaptureRewindSave` | `parsek_rw_*.loadmeta` | `Parsek/Saves/` |
| `CareerStartSnapshot.Capture` | `parsek_career_start.loadmeta` | `Parsek/Saves/` |
| `RewindPointAuthor.ExecuteDeferredBody` | `Parsek_TempRP_*.loadmeta` | `Parsek/RewindPoints/` |

Closes the `v0.10.0 Rewind / career-start quicksave ... orphan .loadmeta` known-bug entry. That entry named only the first two sites; the third (RP quicksave) was found during investigation and has the identical orphan class.

## Fix

New best-effort `FileIOUtils.DeleteSaveSidecarLoadMeta(savesDir, saveBaseName, tag)` helper, called after the `.sfs` move at all three sites. It is guarded by `File.Exists` and swallows + warn-logs failures, so it cannot break the capture path or the RP rollback flow.

Delete, not move: Parsek loads these saves programmatically by copying the `.sfs` back to the root first, so the `.loadmeta` serves no purpose and should stay out of the stock load dialog. Stock `persistent.loadmeta` / `quicksave.loadmeta` are never matched (their base names differ from the Parsek-namespaced save names).

Verified that the other `GamePersistence.SaveGame` callers (`SceneExitInterceptor`, `UnfinishedFlightSealHandler`, `MergeJournalOrchestrator`, `RecordingStore`, `MergeDialog`) save the persistent/quicksave file in place with no move, so their sidecars are legitimate and untouched.

## Tests

- 6 new `FileIOUtilsLoadMetaTests` unit cases: deletes the orphan and leaves stock sidecars alone, asserts the verbose log, missing-sidecar no-op, null/empty-arg no-ops, never touches the `.sfs`.
- The existing in-game `SavePathRootThenMove` test now also asserts no orphaned `Parsek_TempRP_*.loadmeta` survives in the save root, giving end-to-end coverage of the RP path.
- Full xUnit suite green (13049).

## Notes

- Cosmetic: the orphan was harmless, it just littered the save folder.
- Forward-looking only. `.loadmeta` files already present in existing saves are not retroactively swept (no cleanup sweeper added for a cosmetic issue).
- A clean-context Opus review of the branch returned ship-with-nits; the actionable nits (a stray em-dash in the todo doc, the missing in-game `.loadmeta` assertion) are folded into this commit.