### PR TITLE
diag: log map/TS ghost icon + orbit drawing path

### DIFF
--- a/Source/Parsek.Tests/MapTrajLoggingTests.cs
+++ b/Source/Parsek.Tests/MapTrajLoggingTests.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using Parsek;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    // Log-assertion coverage for the MapTraj covering-segment diagnostic
+    // (GhostMapPresence.LogMapCoveringSegmentChange). Verifies the body/covered/source
+    // formatting, the GAP and StateVector branches, and - the regression guard for the
+    // review fix - that a same-body segment->segment advance registers as a new on-change
+    // line because the segment start UT is part of the on-change key.
+    [Collection("Sequential")]
+    public class MapTrajLoggingTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public MapTrajLoggingTests()
+        {
+            ParsekLog.ResetTestOverrides();           // clears on-change + rate-limit state
+            ParsekLog.VerboseOverrideForTesting = true;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+        }
+
+        public void Dispose()
+        {
+            ParsekLog.ResetTestOverrides();
+        }
+
+        private static OrbitSegment Seg(string body, double startUT, double endUT, double sma, double ecc)
+        {
+            return new OrbitSegment
+            {
+                bodyName = body,
+                startUT = startUT,
+                endUT = endUT,
+                semiMajorAxis = sma,
+                eccentricity = ecc,
+            };
+        }
+
+        private int MapTrajCount(int member)
+        {
+            return logLines.FindAll(l =>
+                l.Contains("[MapTraj]") && l.Contains("member=" + member)).Count;
+        }
+
+        [Fact]
+        public void CoveredSegment_LogsBodyCoveredSourceAndSpan()
+        {
+            GhostMapPresence.LogMapCoveringSegmentChange(
+                "FLIGHT", 30, 52569495.6,
+                Seg("Kerbin", 52569494.7, 52569925.6, 671928, 0.088),
+                segmentCoversEffUT: true, isStateVector: false, effectiveSegmentCount: 20);
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[MapTraj]")
+                && l.Contains("FLIGHT covering-segment CHANGED")
+                && l.Contains("member=30")
+                && l.Contains("body=Kerbin")
+                && l.Contains("covered=True")
+                && l.Contains("source=Segment")
+                && l.Contains("sma=671928"));
+        }
+
+        [Fact]
+        public void NoCoveringSegment_LogsGapAndUncovered()
+        {
+            GhostMapPresence.LogMapCoveringSegmentChange(
+                "TS", 7, 1000.0, (OrbitSegment?)null,
+                segmentCoversEffUT: false, isStateVector: false, effectiveSegmentCount: 0);
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[MapTraj]")
+                && l.Contains("TS covering-segment CHANGED")
+                && l.Contains("body=GAP(no-segment)")
+                && l.Contains("covered=False")
+                && l.Contains("seg=n/a"));
+        }
+
+        [Fact]
+        public void StateVectorSource_LogsStateVector()
+        {
+            GhostMapPresence.LogMapCoveringSegmentChange(
+                "TS", 12, 2000.0, Seg("Kerbin", 1000, 3000, 700000, 0.0),
+                segmentCoversEffUT: true, isStateVector: true, effectiveSegmentCount: 5);
+
+            Assert.Contains(logLines, l => l.Contains("[MapTraj]") && l.Contains("source=StateVector"));
+        }
+
+        [Fact]
+        public void SameBodySegmentAdvance_LogsAgain()
+        {
+            // Two consecutive same-body (Kerbin) covering segments differing only by their UT span.
+            // The on-change key includes the segment start UT, so the advance must register as a new
+            // line. Without that key component the second call would be suppressed and the
+            // segment->segment transition would be invisible (the bug this diagnostic must catch).
+            GhostMapPresence.LogMapCoveringSegmentChange(
+                "FLIGHT", 30, 52569500,
+                Seg("Kerbin", 52569494.7, 52569925.6, 671928, 0.088),
+                segmentCoversEffUT: true, isStateVector: false, effectiveSegmentCount: 20);
+            GhostMapPresence.LogMapCoveringSegmentChange(
+                "FLIGHT", 30, 52569940,
+                Seg("Kerbin", 52569937.8, 52569969.5, 671928, 0.088),
+                segmentCoversEffUT: true, isStateVector: false, effectiveSegmentCount: 20);
+
+            Assert.Equal(2, MapTrajCount(30));
+            Assert.Contains(logLines, l => l.Contains("[52569494.7,52569925.6]"));
+            Assert.Contains(logLines, l => l.Contains("[52569937.8,52569969.5]"));
+        }
+
+        [Fact]
+        public void IdenticalCoveringSegmentRepeated_SuppressesSecond()
+        {
+            // Same covering segment twice in a row -> on-change coalesces the repeat (no per-frame churn).
+            var seg = Seg("Kerbin", 1000, 2000, 700000, 0.0);
+            GhostMapPresence.LogMapCoveringSegmentChange("FLIGHT", 99, 1500, seg, true, false, 3);
+            GhostMapPresence.LogMapCoveringSegmentChange("FLIGHT", 99, 1600, seg, true, false, 3);
+
+            Assert.Equal(1, MapTrajCount(99));
+        }
+    }
+}

--- a/Source/Parsek/Display/GhostTrajectoryPolylineRenderer.cs
+++ b/Source/Parsek/Display/GhostTrajectoryPolylineRenderer.cs
@@ -1230,6 +1230,21 @@ namespace Parsek.Display
                                 set.legs[set.legs.Length - 1].startUT, set.legs[set.legs.Length - 1].endUT,
                                 set.legs[0].bodyName ?? "(null)", set.legs[set.legs.Length - 1].bodyName ?? "(null)"),
                             2.0);
+
+                        // CHANGE-based companion to the rate-limited head log: a discrete event whenever the
+                        // active leg, its body, or the drawn state flips. The polyline's part of the SOI-exit
+                        // blink (active leg jumps a Kerbin escape leg -> the Sun transfer leg, or drawn toggles
+                        // on/off in a head-in-gap frame) shows as alternating MapTraj-style lines instead of
+                        // being hidden in the 2s rate-limited samples.
+                        string activeLegBody = activeLeg >= 0
+                            ? (set.legs[activeLeg].bodyName ?? "(null)") : "none";
+                        ParsekLog.VerboseOnChange(DriverTag, "polyline-active." + rec.RecordingId,
+                            string.Format(System.Globalization.CultureInfo.InvariantCulture,
+                                "{0}|{1}|{2}", activeLeg, activeLegBody, anyDrawn),
+                            string.Format(System.Globalization.CultureInfo.InvariantCulture,
+                                "Polyline active-leg CHANGED: rec={0} headUT={1:F1} activeLeg={2} body={3} " +
+                                "drawn={4} legs={5}",
+                                rec.RecordingId, headUT, activeLeg, activeLegBody, anyDrawn, set.legs.Length));
                     }
 
                     if (anyDrawn)

--- a/Source/Parsek/GhostMapPresence.cs
+++ b/Source/Parsek/GhostMapPresence.cs
@@ -5877,6 +5877,45 @@ namespace Parsek
                     kind, idx, segs.Count, helioCount, firstHelioSma), 2.0);
         }
 
+        // MAP/TS TRAJECTORY DIAGNOSTIC: the covering OrbitSegment the map icon + orbit line follow for this
+        // member THIS frame, logged ON CHANGE (keyed per member+scene) so the reader sees discrete transition
+        // events rather than per-frame spam. This is the chokepoint that decides "inside Kerbin SOI" (a
+        // Kerbin-bodied segment) vs "heliocentric" (the Sun-bodied transfer). It catches: the SOI-exit blink
+        // (body flip-flops Kerbin<->Sun back and forth => rapid alternating lines), the orbit line going dark
+        // (covered -> GAP(no-segment)), and the Segment<->StateVector route flip. A reader greps tag MapTraj
+        // for one member to see the exact sequence of what the map drew. <paramref name="scene"/> = "TS" or
+        // "FLIGHT". Pairs with the icon-pos-delta (stall) and the existing "SOI change" orbit-line log.
+        internal static void LogMapCoveringSegmentChange(
+            string scene, int idx, double effUT, OrbitSegment? coveringSegment,
+            bool segmentCoversEffUT, bool isStateVector, int effectiveSegmentCount)
+        {
+            string coveringBody = coveringSegment.HasValue
+                ? (coveringSegment.Value.bodyName ?? "(null)")
+                : "GAP(no-segment)";
+            string source = isStateVector ? "StateVector" : "Segment";
+            string segSpan = coveringSegment.HasValue
+                ? string.Format(ic, "[{0:F1},{1:F1}] sma={2:F0} ecc={3:F3}",
+                    coveringSegment.Value.startUT, coveringSegment.Value.endUT,
+                    coveringSegment.Value.semiMajorAxis, coveringSegment.Value.eccentricity)
+                : "n/a";
+            // Include the covering segment's start UT (coarse, whole-second) in the on-change key so a
+            // same-body segment->segment advance (e.g. several consecutive Kerbin-frame segments, or a
+            // same-body carry stepping to the next segment) registers as a CHANGE. Without it the key
+            // body|covered|source stays constant across same-body advances and the transition - the exact
+            // thing this diagnostic exists to trace - would never log. Segment startUT is a fixed per-segment
+            // value, so F0 introduces no float-jitter churn.
+            string segKey = coveringSegment.HasValue
+                ? coveringSegment.Value.startUT.ToString("F0", ic)
+                : "none";
+            ParsekLog.VerboseOnChange("MapTraj",
+                string.Format(ic, "covering-{0}-{1}", scene, idx),
+                string.Format(ic, "{0}|{1}|{2}|{3}", coveringBody, segmentCoversEffUT, source, segKey),
+                string.Format(ic,
+                    "{0} covering-segment CHANGED: member={1} effUT={2:F1} body={3} covered={4} source={5} " +
+                    "effSegs={6} seg={7}",
+                    scene, idx, effUT, coveringBody, segmentCoversEffUT, source, effectiveSegmentCount, segSpan));
+        }
+
         private static void RefreshTrackingStationGhosts(
             IReadOnlyList<Recording> committed,
             HashSet<string> suppressed,
@@ -5974,6 +6013,8 @@ namespace Parsek
                     ? TrajectoryMath.FindOrbitSegmentOrSameBodyCarry(effectiveSegments, effUT)
                     : (OrbitSegment?)null;
                 bool segmentCoversEffUT = coveringSegment.HasValue;
+                LogMapCoveringSegmentChange("TS", idx, effUT, coveringSegment, segmentCoversEffUT,
+                    isStateVector, effectiveSegments != null ? effectiveSegments.Count : 0);
 
                 int cachedStateVectorIndex = trackingStationStateVectorCachedIndices.TryGetValue(idx, out int cached)
                     ? cached
@@ -6497,7 +6538,8 @@ namespace Parsek
             }
 
             Vector3d worldPos = vessel.GetWorldPos3D();
-            string recId = TryGetLastKnownFrame(recordingIndex, out var prev) ? prev.RecordingId : null;
+            bool hasPrev = TryGetLastKnownFrame(recordingIndex, out var prev);
+            string recId = hasPrev ? prev.RecordingId : null;
             string vesselName = prev.VesselName;
             string updateKey = string.Format(ic, "rec-orbit-update-{0}",
                 recId ?? recordingIndex.ToString(ic));
@@ -6516,6 +6558,28 @@ namespace Parsek
             done.GhostPid = vessel.persistentId;
             done.Segment = segment;
             ParsekLog.VerboseRateLimited(Tag, updateKey, BuildGhostMapDecisionLine(done), 5.0);
+
+            // Frozen-icon diagnostic (the "icon frozen near Kerbin" bug): the map icon's world-position delta
+            // from the PREVIOUS FRAME. This method runs every frame; the log line itself is rate-limited to 5s,
+            // so consecutive emitted lines are ~5s apart but the delta is still measured frame-to-frame against
+            // the immediately preceding frame's position (stashed unconditionally below). dPos ~= 0 on an
+            // emitted frame means the icon did not move that frame; when that persists while the loop clock
+            // advances, the icon is STALLED (frozen) at a fixed orbital anomaly and only the floating-origin
+            // frame shift moves its world position between samples. The body + segment span make it obvious
+            // WHICH segment it is stuck on (e.g. a Kerbin parking-orbit segment near the launch body).
+            // Distinguishes a real freeze from a ghost merely moving slowly at low warp (small but non-zero).
+            double dPosFromLastFrame = hasPrev ? (worldPos - prev.WorldPos).magnitude : double.NaN;
+            ParsekLog.VerboseRateLimited(Tag, "rec-icon-delta-" + (recId ?? recordingIndex.ToString(ic)),
+                string.Format(ic,
+                    "icon-pos-delta: member={0} body={1} worldPos={2} dPosFromLastFrame={3} status={4} " +
+                    "source={5} segUT={6:F1}-{7:F1} sma={8:F0} ecc={9:F3}",
+                    recordingIndex, segment.bodyName, FormatVec3d(worldPos),
+                    double.IsNaN(dPosFromLastFrame) ? "n/a" : dPosFromLastFrame.ToString("F1", ic) + "m",
+                    double.IsNaN(dPosFromLastFrame) ? "first-frame"
+                        : (dPosFromLastFrame < 1.0 ? "STALLED(frozen?)" : "moving"),
+                    sourceLabel, segment.startUT, segment.endUT,
+                    segment.semiMajorAxis, segment.eccentricity),
+                5.0);
 
             // Refresh last-known so destroy can read the current orbit shape.
             StashLastKnownFrame(recordingIndex, new LastKnownGhostFrame

--- a/Source/Parsek/GhostMapPresence.cs
+++ b/Source/Parsek/GhostMapPresence.cs
@@ -7466,7 +7466,20 @@ namespace Parsek
                 ? drv.getPositionFromEccAnomaly(maxE * 0.99) : Vector3d.zero; // 0.99 to avoid singularity
             double farDist = farPos.magnitude;
 
-            ParsekLog.Verbose(Tag,
+            // This apply runs every frame the orbit is re-applied (per ghost), so an unconditional
+            // Verbose floods the log (it was ~31% of all Parsek output in a 2-minute capture). Log ON
+            // CHANGE per ghost instead, keyed on the orbit SHAPE (body + sma + ecc + renderer state):
+            // every distinct orbit applied still logs, a frozen/steady orbit logs once and then reports a
+            // suppressed=N count (which is clearer than thousands of identical lines for spotting a stuck
+            // orbit), and SOI/body changes and renderer flips register as discrete events. No debugging
+            // signal is lost; the per-frame repeat noise is. Ghost create/recreate is still logged loudly
+            // at INFO ("Created ghost vessel" / "create-segment-done"). sma:F0/ecc:F4 in the key are coarse
+            // enough to avoid float-jitter churn (these come from a fixed segment, so they are stable).
+            ParsekLog.VerboseOnChange(Tag,
+                "orbit-applied-" + vessel.persistentId.ToString(ic),
+                string.Format(ic, "{0}|{1:F0}|{2:F4}|{3}|{4}",
+                    body.name, segment.semiMajorAxis, drv.eccentricity,
+                    vessel.orbitRenderer?.enabled, vessel.orbitRenderer?.drawMode),
                 string.Format(ic,
                     "Orbit updated for {0} body={1} sma={2:F0} ecc={3:F6} " +
                     "periapsis={4:F0} semiMinor={5:F0} maxE={6:F2}rad farDist={7:F0}m " +

--- a/Source/Parsek/ParsekPlaybackPolicy.cs
+++ b/Source/Parsek/ParsekPlaybackPolicy.cs
@@ -1581,6 +1581,17 @@ namespace Parsek
                 // when the recording is truly past its last segment. Body-frame carry keeps
                 // the previous segment's orbit active until UT enters the next segment.
                 OrbitSegment? seg = TrajectoryMath.FindOrbitSegmentOrSameBodyCarry(effectiveSegments, effUT);
+                // Flight-map companion to the TS covering-segment log: same MapTraj on-change diagnostic so the
+                // SOI-exit blink / orbit-line GAP / body flip-flop is visible on the flight path too. When a
+                // segment covers effUT the icon follows that OrbitSegment (source=Segment); when none does and
+                // a terminal state-vector fallback is cached for this member, the icon is driven by that
+                // fallback (resolved in the !seg.HasValue branch below), so report source=StateVector. The
+                // membership check is stable frame-to-frame (it does not flip-flop) and mirrors the TS path's
+                // trackingStationStateVectorOrbitTrajectories check.
+                bool flightIsStateVector = !seg.HasValue && stateVectorCachedIndices.ContainsKey(idx);
+                GhostMapPresence.LogMapCoveringSegmentChange("FLIGHT", idx, effUT, seg, seg.HasValue,
+                    flightIsStateVector,
+                    effectiveSegments != null ? effectiveSegments.Count : 0);
 
                 // No map-visible orbit at current UT — either we've truly left orbital
                 // playback, or the next segment is in a different SOI/body.


### PR DESCRIPTION
## What

Diagnostic-logging hygiene for the map-view and Tracking Station ghost icon + orbit-line drawing path: adds three targeted diagnostics, and collapses one pre-existing per-frame log that dominated the output. Logging only, no behavior change.

### New diagnostics
- **LogMapCoveringSegmentChange** (`MapTraj` tag): on-change log of which covering `OrbitSegment` + body the icon and orbit line follow, wired on both the Tracking Station path (`GhostMapPresence`) and the flight-map path (`ParsekPlaybackPolicy`). The on-change key includes body, covered, source and the segment start UT, so SOI flips, covered to GAP transitions, and same-body segment to segment advances all register as discrete events. The flight path reports `source=StateVector` when the icon is on the cached terminal fallback, otherwise `Segment`.
- **Polyline active-leg change** (`GhostMap` tag): on-change companion to the rate-limited polyline head log, fires when the non-orbital polyline's active leg, body, or drawn state flips.
- **icon-pos-delta / STALL** (`GhostMap` tag): per-5s frame-to-frame icon world-position delta with a `STALLED(frozen?)` / `moving` status, to tell a frozen icon from one merely moving slowly at low warp.

### Spam reduction
- **"Orbit updated for ..."**: this verbose log fired every frame the ghost orbit was re-applied (per ghost) and accounted for ~31% of all Parsek output in a 2-minute capture. Converted to `VerboseOnChange` keyed per ghost on the orbit shape (body + sma + ecc + renderer state). Every distinct orbit applied still logs, a steady/stuck orbit logs once with a `suppressed=N` count (clearer than thousands of identical lines), and SOI/body changes and renderer flips register as discrete events. Create/recreate stays logged loudly at INFO. No debugging signal lost.

## Why

These diagnostics already paid off: they pinned the "ghost icon frozen on a Kerbin orbit segment" bug to the short clipped injection-arc segments (icon pinned to a fixed anomaly, teleporting at segment seams), now being fixed on a separate branch.

## Spam check

Over a 120s / 8352-line `[Parsek]` session, the three new diagnostics produced 19 lines total (0.23%): MapTraj 1, Polyline 8, icon-pos-delta 10, peak 2 lines/sec. The "Orbit updated" conversion removes the single largest source (2617 lines, ~31%).

## Tests

New `MapTrajLoggingTests` (5 cases) covering the covered/GAP/StateVector branches and the same-body-advance vs identical-segment on-change behavior. The "Orbit updated" change is in a Unity-dependent apply method with no xUnit seam (the VerboseOnChange behavior it relies on is covered generally). Full suite: 13068 passing, 0 failures. Build clean (0 warnings, 0 errors).