### PR TITLE
Fix loop-shift miss on flight initial map-ghost create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Parsek are documented here.
 
 ## 0.10.0
 
+### Fixed
+
+- Fixed a brief stale ghost orbit-line and icon flash when a looping recording first appears on the flight map (the loop time-shift was applied one frame late on initial map creation).
+
 ### UI
 
 - The Recordings tab no longer shows a Loop checkbox or period field on debris rows, on the auto-generated "<mission> / Debris" subgroup, or on any row/group that only contains debris. Parent-anchored debris already replays in sync with its parent's loop (the booster falls back to Kerbin when the parent ship relaunches), so a separate per-debris loop toggle did nothing meaningful.

--- a/Source/Parsek.Tests/RuntimePolicyTests.cs
+++ b/Source/Parsek.Tests/RuntimePolicyTests.cs
@@ -1269,5 +1269,49 @@ namespace Parsek.Tests
         }
 
         #endregion
+
+        #region ShouldDeferLoopShiftedMapPresence (flight initial map-ghost create)
+
+        // The flight initial map-ghost create (HandleGhostCreated) must defer a loop-shifted
+        // member to the loop-aware per-frame create (CheckPendingMapVessels) instead of seeding
+        // ghost orbit/arc bounds at the raw recorded startUT with shift 0 (which left
+        // ghostOrbitLoopShiftedPids clear and produced a recorded-UT stored-bounds-fallback
+        // window for one tick). Off the loop path the helper must return false so non-loop
+        // members keep the immediate create byte-for-byte.
+
+        [Fact]
+        public void ShouldDeferLoopShiftedMapPresence_NonLoopMember_ReturnsFalse()
+        {
+            // effUT == currentUT (shift 0) and not hidden: the common non-loop case.
+            Assert.False(ParsekPlaybackPolicy.ShouldDeferLoopShiftedMapPresence(
+                loopEpochShiftSeconds: 0.0, renderHidden: false));
+        }
+
+        [Fact]
+        public void ShouldDeferLoopShiftedMapPresence_LoopMemberInWindow_ReturnsTrue()
+        {
+            // Positive live-frame shift: a looping member replaying inside its window this cycle.
+            Assert.True(ParsekPlaybackPolicy.ShouldDeferLoopShiftedMapPresence(
+                loopEpochShiftSeconds: 561642668.55, renderHidden: false));
+        }
+
+        [Fact]
+        public void ShouldDeferLoopShiftedMapPresence_NegativeShift_ReturnsTrue()
+        {
+            // Any non-zero shift (sign-agnostic) is loop-shifted and must defer.
+            Assert.True(ParsekPlaybackPolicy.ShouldDeferLoopShiftedMapPresence(
+                loopEpochShiftSeconds: -120.5, renderHidden: false));
+        }
+
+        [Fact]
+        public void ShouldDeferLoopShiftedMapPresence_RenderHidden_ReturnsTrue()
+        {
+            // Outside its loop window this cycle (shift resolves to 0 but renderHidden is set):
+            // still defer so the per-frame pass creates it when the window opens.
+            Assert.True(ParsekPlaybackPolicy.ShouldDeferLoopShiftedMapPresence(
+                loopEpochShiftSeconds: 0.0, renderHidden: true));
+        }
+
+        #endregion
     }
 }

--- a/Source/Parsek/ParsekPlaybackPolicy.cs
+++ b/Source/Parsek/ParsekPlaybackPolicy.cs
@@ -1074,7 +1074,25 @@ namespace Parsek
                 acceptTerminalOrbitForLoopSynthesis: false);
             stateVectorCachedIndices[evt.Index] = cachedStateVectorIndex;
 
-            if (source != TrackingStationGhostSource.None)
+            // Loop-shifted members must be created on a loop-aware per-frame tick
+            // (CheckPendingMapVessels): that path resolves the source at the loop-mapped
+            // effUT and threads the live-frame epoch shift into the orbit + arc-clip bounds.
+            // Creating here at the raw recorded startUT with the default shift=0 seeds
+            // recorded-UT bounds and leaves ghostOrbitLoopShiftedPids clear, so for one tick
+            // the map-orbit window resolver returns a recorded-UT fallback window (the
+            // icon-clamp / orbit-line glitch at first appearance and at every window re-entry).
+            // Defer so the per-frame path owns loop-member creation, mirroring the TS create
+            // sites and the flight pending-create path. Off the loop path effUT == currentUT
+            // (shift 0, renderHidden false), so non-loop members keep the immediate create
+            // byte-for-byte.
+            double initialNowUT = Planetarium.GetUniversalTime();
+            ResolveMapPresenceSampleUT(
+                evt.Index, evt.Trajectory.StartUT, evt.Trajectory.EndUT, initialNowUT,
+                engine.CurrentLoopUnits, out bool initialRenderHidden, out double initialLoopShift);
+            bool deferForLoopAware =
+                ShouldDeferLoopShiftedMapPresence(initialLoopShift, initialRenderHidden);
+
+            if (source != TrackingStationGhostSource.None && !deferForLoopAware)
             {
                 Vessel ghost = GhostMapPresence.CreateGhostVesselFromSource(
                     evt.Index,
@@ -1100,15 +1118,25 @@ namespace Parsek
             }
             else
             {
-                // Initial/pre-orbital deferrals are not SOI-gap recoveries; only the
-                // gap-between-orbit-segments requeue path opts into this fallback.
+                // Initial/pre-orbital deferrals and loop-shifted members are not SOI-gap
+                // recoveries; only the gap-between-orbit-segments requeue path opts into that
+                // fallback. The per-frame CheckPendingMapVessels pass resolves the source at
+                // the loop-mapped effUT and creates with the live-frame epoch shift.
                 pendingMapVessels[evt.Index] = new PendingMapVessel(
                     evt.Trajectory,
                     allowSoiGapStateVectorFallback: false,
                     expectedSoiGapBody: null);
                 ParsekLog.Verbose("Policy",
-                    $"Deferred ghost map vessel for #{evt.Index} \"{evt.Trajectory.VesselName}\" " +
-                    "— recording starts pre-orbital");
+                    string.Format(CultureInfo.InvariantCulture,
+                        "Deferred ghost map vessel for #{0} \"{1}\": {2} (source={3} loopShift={4:F2} renderHidden={5})",
+                        evt.Index,
+                        evt.Trajectory.VesselName,
+                        deferForLoopAware
+                            ? "loop-shifted member, deferring to loop-aware per-frame create"
+                            : "recording starts pre-orbital",
+                        source,
+                        initialLoopShift,
+                        initialRenderHidden));
             }
         }
 
@@ -1121,6 +1149,23 @@ namespace Parsek
         internal static bool ShouldCreateStateVectorOrbit(double altitude, double speed, double atmosphereDepth)
         {
             return GhostMapPresence.ShouldCreateStateVectorOrbit(altitude, speed, atmosphereDepth);
+        }
+
+        /// <summary>
+        /// Pure decision: should an initial ghost-map-presence create (<see cref="HandleGhostCreated"/>)
+        /// defer to the loop-aware per-frame pass (<see cref="CheckPendingMapVessels"/>) instead of
+        /// creating immediately at the raw recorded startUT? True when the member is replaying
+        /// loop-shifted this cycle (<paramref name="loopEpochShiftSeconds"/> != 0) or is outside its
+        /// loop window this cycle (<paramref name="renderHidden"/>). False off the loop path
+        /// (shift 0, not hidden), so non-loop members keep the immediate create unchanged. The
+        /// immediate create would otherwise seed recorded-UT orbit/arc bounds and leave the
+        /// loop-shifted flag clear for a tick, so the map-orbit window resolver hands back a
+        /// recorded-UT fallback window while the live clock is far ahead.
+        /// </summary>
+        internal static bool ShouldDeferLoopShiftedMapPresence(
+            double loopEpochShiftSeconds, bool renderHidden)
+        {
+            return renderHidden || loopEpochShiftSeconds != 0.0;
         }
 
         /// <summary>

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -12,6 +12,19 @@ When referencing prior item numbers from source comments or plans, consult the r
 
 ---
 
+## Done - v0.10.0 Looping recording flashed a stale recorded-UT orbit line / icon on first flight-map appearance
+
+- Surfaced by the new map/TS draw-path logging (branch `add-map-ts-draw-logging`): a looping, re-aimed recording ("Kerbal X", rec 30) logged `Map-visible orbit window ... source=stored-bounds-fallback ... windowUT=52569494-52569925` (raw recorded UT) one tick, while the live clock was ~614212164, before the next tick computed the correct loop-shifted window.
+- **Root cause:** the flight initial map-ghost create path `ParsekPlaybackPolicy.HandleGhostCreated` resolved the orbit source at the raw recorded `startUT` and called `GhostMapPresence.CreateGhostVesselFromSource(..., startUT)` with no `loopEpochShiftSeconds` (defaulting to 0). For a looping recording that seeds `ghostOrbitBounds` / `ghostBodyFrameOrbitBounds` in recorded UT and leaves `ghostOrbitLoopShiftedPids` clear, so for one tick `TryGetVisibleOrbitBoundsForGhostVessel` misses the live-UT segment (`no-active-equivalent-segment`) and the `stored-bounds-fallback` branch returns a recorded-UT window far behind the live clock. The per-frame `CheckPendingMapVessels` then re-applied with the real shift. `TryGetStoredOrbitBoundsForGhostVessel` returns its stored bounds verbatim (the `reason`/`source` string is only a log label), so this is a write-side / flag-state issue, not a read-branch asymmetry.
+- Three sibling create sites already thread the shift (the two Tracking Station create sites in `GhostMapPresence`, and the flight pending-create in `CheckPendingMapVessels`). Only the flight initial create was missed; this is the flight twin of the `fix-ts-startup-loop-shift` change.
+- **Fix:** new pure helper `ParsekPlaybackPolicy.ShouldDeferLoopShiftedMapPresence(loopEpochShiftSeconds, renderHidden) => renderHidden || loopEpochShiftSeconds != 0`. `HandleGhostCreated` computes the shift via the existing `ResolveMapPresenceSampleUT` and, when the helper returns true, defers the member to `pendingMapVessels` so the loop-aware per-frame `CheckPendingMapVessels` create owns it (resolving source at the loop-mapped effUT and threading the live-frame shift). Off the loop path effUT == currentUT (shift 0, not hidden), so non-loop members keep the immediate create byte-for-byte; the deferred path seeds the same `stateVectorOrbitTrajectories` / `lastMapOrbitByIndex` / `soiGapStateVectorExpectedBodies` bookkeeping.
+- **No-op risk checked (Opus review):** `engine.CurrentLoopUnits` is populated before this fires. `OnGhostCreated` is deferred during `UpdatePlayback` (the update stopwatch is running) and flushed at the Phase-C tail in the same call, after the per-frame `DriveMissionLoopUnits` -> `SetLoopUnits` ran, so the guard reads the populated set. Confirmed not a silent no-op.
+- **Tests:** 4 `ShouldDeferLoopShiftedMapPresence` truth-table cases in `RuntimePolicyTests` (shift!=0, negative shift, renderHidden, and the non-loop shift==0 case). Full suite green.
+- **Playtest verification still pending:** load a looping recording, enter the flight map, and grep `KSP.log` for `Deferred ghost map vessel ... loop-shifted member` and confirm the first `Cached body-frame bounds` for that ghost has `loopShift != 0` with no preceding recorded-UT `stored-bounds-fallback` read.
+- **Status:** CLOSED 2026-06-01 (pending playtest confirmation).
+
+---
+
 ## In progress - v0.10.0 Missions window: vessel composition over time (first cut, playtesting)
 
 - Goal (from 2026-05-25 design chat): show each vessel's COMPOSITION (controllers + crew) broken into intervals of compositional stability, as a nested tree. A node = a stable composition labeled with counts ("pod x1, probe x1, crew x3"); it branches at composition-change events; a stable composition that ends as a whole is a terminal leaf.


### PR DESCRIPTION
## Summary

Fixes a brief stale ghost orbit-line / icon flash when a **looping** recording's map ghost first appears in flight (and at every loop-window re-entry). The loop time-shift was applied one frame late on initial map-ghost creation.

## Root cause

The flight initial map-ghost create path `ParsekPlaybackPolicy.HandleGhostCreated` resolved the orbit source at the raw recorded `startUT` and called `GhostMapPresence.CreateGhostVesselFromSource(..., startUT)` with **no** `loopEpochShiftSeconds` (defaulting to 0). For a looping recording that seeds `ghostOrbitBounds` / `ghostBodyFrameOrbitBounds` in **recorded UT** and leaves `ghostOrbitLoopShiftedPids` clear. For one tick `TryGetVisibleOrbitBoundsForGhostVessel` misses the live-UT segment, logs `no-active-equivalent-segment`, and the `stored-bounds-fallback` branch returns a recorded-UT window (e.g. ~52.57M) while the live clock is ~614M. The per-frame `CheckPendingMapVessels` then re-applies with the real shift.

`TryGetStoredOrbitBoundsForGhostVessel` returns the stored bounds verbatim (the `reason`/`source` string is only a log label), so this is a write-side / flag-state issue, not a read-branch asymmetry. Three sibling create sites already thread the shift: the two Tracking Station create sites in `GhostMapPresence` and the flight pending-create in `CheckPendingMapVessels`. Only the flight initial create was missed (the flight twin of the `fix-ts-startup-loop-shift` change).

## Fix

New pure helper `ShouldDeferLoopShiftedMapPresence(loopEpochShiftSeconds, renderHidden) => renderHidden || loopEpochShiftSeconds != 0`. `HandleGhostCreated` computes the shift via the existing `ResolveMapPresenceSampleUT(...)` and, when the helper returns true, defers the member to `pendingMapVessels` so the loop-aware per-frame `CheckPendingMapVessels` create owns it (resolving the source at the loop-mapped effUT and threading the live-frame shift) instead of the immediate create. Off the loop path `effUT == currentUT` (shift 0, not hidden), so non-loop members keep the immediate create byte-for-byte. The deferred path seeds the same `stateVectorOrbitTrajectories` / `lastMapOrbitByIndex` / `soiGapStateVectorExpectedBodies` bookkeeping as the immediate branch, so nothing is lost by deferring.

## Scope note

Loop-shift / stored-bounds-window inconsistency only. NOT the separate "icon frozen on the eccentric Kerbin injection arc" symptom (fixed-anomaly / clipped-arc positioning), tracked elsewhere. In the captured log the orbit LINE never actually blanked (the per-frame correction landed in the same tick before the renderer gate ran); the stale window was read by the icon-clamp prefix, which overlaps the out-of-scope frozen-icon issue. This change removes the stale read at the source.

## Tests

- New `ShouldDeferLoopShiftedMapPresence` truth-table unit tests in `RuntimePolicyTests` (shift != 0, negative shift, renderHidden, non-loop shift == 0).
- `dotnet build`: clean. `dotnet test`: 13062 passed, 0 failed.

## Review

A clean-context Opus review passed (ship-with-changes). It confirmed: the fix is NOT a silent no-op (high confidence) because `engine.CurrentLoopUnits` is populated before `HandleGhostCreated` reads it (the `OnGhostCreated` event is deferred during `UpdatePlayback` and flushed at the Phase-C tail in the same frame, after `DriveMissionLoopUnits` -> `SetLoopUnits`); non-loop members are byte-identical even when other missions loop; deferred members are reliably created (not lost) and bookkeeping parity holds. Its one blocker (the unit test and todo-doc closure were missing from the first commit) is resolved in this PR.

## Verification still pending (playtest)

Per this repo's "pure tests prove the helper, not the patch site" rule, confirm in-game: load a looping recording, enter the flight map, and grep `KSP.log` for `Deferred ghost map vessel ... loop-shifted member`, and confirm the first `Cached body-frame bounds` for that ghost has `loopShift != 0` with no preceding recorded-UT `stored-bounds-fallback` read. I could not run KSP in this session.

## Base

Stacked on `add-map-ts-draw-logging` (the diagnostic logging that surfaced this), so this PR's diff is the fix only.
