### PR TITLE
test(eva): fix EvaTwiceFromSameCapsule in-game test focus-switch race

### DIFF
--- a/Source/Parsek/InGameTests/RuntimeTests.cs
+++ b/Source/Parsek/InGameTests/RuntimeTests.cs
@@ -2131,14 +2131,47 @@ namespace Parsek.InGameTests
                 yield return WaitForEvaBranchCount(tree, initialEvaBranches + 1, 10f, "first EVA branch");
 
                 Vessel sourceVessel = firstSourcePart?.vessel ?? vessel;
+                uint sourcePid = sourceVessel.persistentId;
+
+                // After spawnEVA, KSP auto-switches focus to the freshly created EVA kerbal a few
+                // frames later. Wait for that hand-off: it parks the source capsule's recording into
+                // the tree BackgroundMap, which is the precondition the background-parent branch path
+                // is built for. Switching back before the hand-off would be a no-op (the capsule is
+                // still active), and KSP's later auto-switch would then steal focus away again.
+                yield return WaitForActiveVesselToLeavePid(sourcePid, 10f);
+                if (FlightGlobals.ActiveVessel != null && FlightGlobals.ActiveVessel.persistentId == sourcePid)
+                {
+                    InGameAssert.Skip(
+                        "KSP never auto-switched focus to the first EVA kerbal, so the source capsule " +
+                        "was never parked to background; cannot exercise the background-parent path");
+                    yield break;
+                }
+
+                // Switch back to the source capsule and wait for focus to settle on it.
                 if (!TrySetActiveVesselForTest(sourceVessel, out string switchSkipReason))
                 {
                     InGameAssert.Skip(switchSkipReason);
                     yield break;
                 }
 
-                yield return WaitForActiveVesselPid(sourceVessel.persistentId, 10f);
+                yield return WaitForActiveVesselPid(sourcePid, 10f);
                 yield return new WaitForSeconds(0.5f);
+
+                // Keep the capsule active-but-idle: the first EVA's switch-away already parked the
+                // capsule's recording into the tree BackgroundMap; disarm the post-switch auto-record
+                // watch so it cannot promote that still-backgrounded recording into a live recorder
+                // before the second EVA fires. A live recorder here would route the second EVA through
+                // the live mid-recording branch path instead of the background-parent path under test.
+                TryDisarmPostSwitchAutoRecord(
+                    flight, "EvaTwiceFromSameCapsule: keep source capsule idle before second EVA");
+                if (flight.IsPostSwitchAutoRecordArmedForPid(sourcePid) || flight.IsRecording)
+                {
+                    InGameAssert.Skip(
+                        "source capsule did not settle into an idle, non-recording state after " +
+                        "switch-back (post-switch auto-record still armed, or recording resumed), so " +
+                        "the second EVA would not take the background-parent path");
+                    yield break;
+                }
 
                 if (!TryGetEvaSource(sourceVessel, out Part secondSourcePart, out ProtoCrewMember secondCrew,
                     out Transform secondAirlock, out string secondEvaSourceSkipReason))
@@ -3013,6 +3046,22 @@ namespace Parsek.InGameTests
             InGameAssert.Fail(
                 $"WaitForActiveVesselPid timed out after {timeoutSeconds:F0}s " +
                 $"expected={expectedPid} active={FlightGlobals.ActiveVessel?.persistentId ?? 0u}");
+        }
+
+        // Waits (without asserting) until the active vessel is no longer the given pid, or the
+        // timeout elapses. Used to observe KSP's stock auto-switch to a freshly spawned EVA kerbal;
+        // the caller decides whether a non-switch is a Skip or an error.
+        private static IEnumerator WaitForActiveVesselToLeavePid(uint pid, float timeoutSeconds)
+        {
+            float deadline = Time.time + timeoutSeconds;
+            while (Time.time < deadline)
+            {
+                Vessel active = FlightGlobals.ActiveVessel;
+                if (active == null || active.persistentId != pid)
+                    yield break;
+
+                yield return null;
+            }
         }
 
         private static int CountEvaBranches(RecordingTree tree)

--- a/Source/Parsek/InGameTests/RuntimeTests.cs
+++ b/Source/Parsek/InGameTests/RuntimeTests.cs
@@ -55,8 +55,8 @@ namespace Parsek.InGameTests
                 null,
                 new[] { typeof(ProtoCrewMember), typeof(Part), typeof(Transform), typeof(bool) },
                 null);
-        private static readonly MethodInfo FlightEvaHatchIsObstructedMethod =
-            FlightEvaType?.GetMethod("HatchIsObstructed",
+        private static readonly MethodInfo FlightEvaHatchIsObstructedMoreMethod =
+            FlightEvaType?.GetMethod("HatchIsObstructedMore",
                 BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic,
                 null,
                 new[] { typeof(Part), typeof(Transform) },
@@ -3104,34 +3104,50 @@ namespace Parsek.InGameTests
         // before the second EVA (KSP's spawnEVA refuses a second EVA while the only hatch is blocked).
         private static void MoveVesselClearOfAnchor(Vessel mover, Vessel anchor, double metres)
         {
-            if (mover == null || anchor == null)
+            if (mover == null || anchor == null || VesselSetPositionMethod == null)
                 return;
 
+            Vector3d anchorPos = anchor.GetWorldPos3D();
             Vector3d moverPos = mover.GetWorldPos3D();
-            Vector3d up = anchor.upAxis;
-            Vector3d awayFromAnchor = moverPos - anchor.GetWorldPos3D();
+            // Derive up from body+position rather than anchor.upAxis: the anchor is backgrounded after
+            // the focus switch, so its cached upAxis can be stale.
+            Vector3d up = FlightGlobals.getUpAxis(anchor.mainBody, anchorPos);
+            Vector3d awayFromAnchor = moverPos - anchorPos;
             // Horizontal component of the anchor->mover direction (project out the local up axis).
             Vector3d horizontal = awayFromAnchor - up * Vector3d.Dot(awayFromAnchor, up);
             if (horizontal.magnitude < 0.1)
                 horizontal = (Vector3d)anchor.transform.forward; // degenerate: mover directly above anchor
             horizontal = horizontal.normalized;
 
-            mover.SetPosition(moverPos + horizontal * metres);
+            // Teleport only — velocity is intentionally left untouched; the kerbal is relocated and left
+            // to settle over the subsequent wait frames. Do not also zero velocity / nudge the rigidbody.
+            VesselSetPositionMethod.Invoke(mover, new object[] { moverPos + horizontal * metres });
         }
 
-        // Reflects FlightEVA.HatchIsObstructed(Part, Transform). Returns false when the check is
-        // unavailable so the test still proceeds (spawnEVA itself enforces the real obstruction gate).
+        // Reflects FlightEVA.HatchIsObstructedMore(Part, Transform) — the stricter check (outward ray +
+        // inward ray + overlap sphere) that spawnEVA applies to the PRIMARY hatch, so this precheck
+        // matches the gate that would actually refuse the second EVA. Returns false (treat as clear)
+        // when the check is unavailable so the test still proceeds (spawnEVA enforces the real gate);
+        // logs a breadcrumb so a later "timed out instead of skipping" investigation has a trail.
         private static bool IsHatchObstructed(Part part, Transform airlock)
         {
-            if (FlightEvaHatchIsObstructedMethod == null || part == null || airlock == null)
+            if (part == null || airlock == null)
                 return false;
+            if (FlightEvaHatchIsObstructedMoreMethod == null)
+            {
+                ParsekLog.Verbose("TestRunner",
+                    "IsHatchObstructed: FlightEVA.HatchIsObstructedMore not reflectable; treating hatch as clear");
+                return false;
+            }
 
             try
             {
-                return (bool)FlightEvaHatchIsObstructedMethod.Invoke(null, new object[] { part, airlock });
+                return (bool)FlightEvaHatchIsObstructedMoreMethod.Invoke(null, new object[] { part, airlock });
             }
             catch
             {
+                ParsekLog.Verbose("TestRunner",
+                    "IsHatchObstructed: HatchIsObstructedMore invoke threw; treating hatch as clear");
                 return false;
             }
         }

--- a/Source/Parsek/InGameTests/RuntimeTests.cs
+++ b/Source/Parsek/InGameTests/RuntimeTests.cs
@@ -55,6 +55,12 @@ namespace Parsek.InGameTests
                 null,
                 new[] { typeof(ProtoCrewMember), typeof(Part), typeof(Transform), typeof(bool) },
                 null);
+        private static readonly MethodInfo FlightEvaHatchIsObstructedMethod =
+            FlightEvaType?.GetMethod("HatchIsObstructed",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic,
+                null,
+                new[] { typeof(Part), typeof(Transform) },
+                null);
         private static readonly MethodInfo FlightGlobalsSetActiveVesselMethod =
             typeof(FlightGlobals).GetMethods(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
                 .FirstOrDefault(m =>
@@ -2147,6 +2153,23 @@ namespace Parsek.InGameTests
                     yield break;
                 }
 
+                // KSP's spawnEVA refuses a second EVA while a kerbal stands on the only hatch: it runs
+                // an obstruction check, posts a screen message, and returns null WITHOUT firing
+                // onCrewOnEva. So move the first EVA kerbal a few metres clear of the capsule before
+                // the second EVA — this mirrors the real reproducer, where the first kerbal had walked
+                // away (planted a flag) before the user EVA'd the second. The auto-switch above leaves
+                // the EVA kerbal as the active vessel, so it is the one to move.
+                Vessel firstEvaVessel = FlightGlobals.ActiveVessel;
+                if (firstEvaVessel == null || !firstEvaVessel.isEVA)
+                {
+                    InGameAssert.Skip(
+                        "expected the first EVA kerbal to be the active vessel after KSP's auto-switch, " +
+                        "but it was not; cannot clear the capsule hatch for the second EVA");
+                    yield break;
+                }
+                MoveVesselClearOfAnchor(firstEvaVessel, sourceVessel, 12.0);
+                yield return new WaitForSeconds(0.5f);
+
                 // Switch back to the source capsule and wait for focus to settle on it.
                 if (!TrySetActiveVesselForTest(sourceVessel, out string switchSkipReason))
                 {
@@ -2177,6 +2200,18 @@ namespace Parsek.InGameTests
                     out Transform secondAirlock, out string secondEvaSourceSkipReason))
                 {
                     InGameAssert.Skip(secondEvaSourceSkipReason);
+                    yield break;
+                }
+
+                // Guard against a misleading timeout: if the capsule hatch is still obstructed, KSP's
+                // spawnEVA returns null with no onCrewOnEva and no branch. Surface that as a clear Skip
+                // (the reposition above did not clear the hatch) instead of a 10s WaitForEvaBranchCount
+                // timeout that looks like a product regression.
+                if (IsHatchObstructed(secondSourcePart, secondAirlock))
+                {
+                    InGameAssert.Skip(
+                        "capsule hatch still obstructed after moving the first EVA kerbal clear; " +
+                        "spawnEVA would refuse the second EVA, so the background-parent path is unreachable");
                     yield break;
                 }
 
@@ -3061,6 +3096,43 @@ namespace Parsek.InGameTests
                     yield break;
 
                 yield return null;
+            }
+        }
+
+        // Moves a loaded vessel a fixed distance horizontally away from an anchor vessel, so it stops
+        // obstructing the anchor's hatch. Used to step the first EVA kerbal off the capsule ladder
+        // before the second EVA (KSP's spawnEVA refuses a second EVA while the only hatch is blocked).
+        private static void MoveVesselClearOfAnchor(Vessel mover, Vessel anchor, double metres)
+        {
+            if (mover == null || anchor == null)
+                return;
+
+            Vector3d moverPos = mover.GetWorldPos3D();
+            Vector3d up = anchor.upAxis;
+            Vector3d awayFromAnchor = moverPos - anchor.GetWorldPos3D();
+            // Horizontal component of the anchor->mover direction (project out the local up axis).
+            Vector3d horizontal = awayFromAnchor - up * Vector3d.Dot(awayFromAnchor, up);
+            if (horizontal.magnitude < 0.1)
+                horizontal = (Vector3d)anchor.transform.forward; // degenerate: mover directly above anchor
+            horizontal = horizontal.normalized;
+
+            mover.SetPosition(moverPos + horizontal * metres);
+        }
+
+        // Reflects FlightEVA.HatchIsObstructed(Part, Transform). Returns false when the check is
+        // unavailable so the test still proceeds (spawnEVA itself enforces the real obstruction gate).
+        private static bool IsHatchObstructed(Part part, Transform airlock)
+        {
+            if (FlightEvaHatchIsObstructedMethod == null || part == null || airlock == null)
+                return false;
+
+            try
+            {
+                return (bool)FlightEvaHatchIsObstructedMethod.Invoke(null, new object[] { part, airlock });
+            }
+            catch
+            {
+                return false;
             }
         }
 


### PR DESCRIPTION
## What
Fixes the isolated in-game test `EvaTwiceFromSameCapsuleProducesTwoBranches`, which fails with a misleading timeout (`WaitForEvaBranchCount timed out after 10s (second EVA branch); expected>=2 actual=1`). Two independent test-harness problems had to be solved for the test to reach the `background-parent` product path. Neither is a product bug.

## Problem 1 - focus-switch race
The test switched the active vessel back to the source capsule immediately after the first EVA branch was created, while the capsule was still active (KSP's stock auto-switch to the freshly spawned EVA kerbal had not fired yet). The switch-back was a no-op; KSP then auto-switched to the EVA kerbal and Parsek promoted it, and the capsule was never re-activated.

Fix: wait for the active vessel to leave the capsule pid (KSP's auto-switch, which parks the capsule into the tree `BackgroundMap`), then switch back and wait for focus; disarm post-switch auto-record so the still-backgrounded capsule cannot be promoted to a live recorder before the second EVA (a live recorder would route it through the live mid-recording path instead of `background-parent`); Skip cleanly if focus never left, or if the watch is still armed / recording resumed.

## Problem 2 - hatch obstruction
`FlightEVA.spawnEVA(..., tryAllHatches: true)` enforces the hatch-obstruction check internally (confirmed in decompiled Assembly-CSharp). With the only hatch blocked by the first EVA kerbal standing on the ladder, it posts `#autoLOC_111971` and returns null WITHOUT firing `onCrewOnEva` - so even with the capsule active, the second EVA was silently refused.

Fix: step the first EVA kerbal ~12 m clear of the capsule (`Vessel.SetPosition` along the horizontal away-vector) once KSP has auto-switched focus to it, before switching back and EVAing the second crew. This mirrors the real reproducer, where the first kerbal had walked away (planted a flag) before the second EVA. Also pre-check `FlightEVA.HatchIsObstructedMore` (the stricter gate - outward + inward ray + overlap sphere - that spawnEVA applies to the primary hatch) before the second spawn and Skip with a clear reason if still blocked, instead of a misleading timeout.

## New test helpers
`WaitForActiveVesselToLeavePid`, `MoveVesselClearOfAnchor`, `IsHatchObstructed` (plus the `FlightEVA.HatchIsObstructedMore` reflection handle).

## Validation
- Build: 0 errors.
- `EvaDeferredAutoRecordOrphanTests` (the feature's xUnit coverage): 27/27.
- Clean-context Opus reviews: the focus-race fix (SHIP WITH NITS, nits applied) and the hatch-clearing follow-up (SHIP WITH NITS; the major finding - precheck should use the stricter `HatchIsObstructedMore` - and all minor/nit items applied).
- In-game confirmation pending (isolated-run-only, `AllowBatchExecution = false`): run via Run All + Isolated or the row play button in a disposable FLIGHT session with a 2+ crew landed/pad vessel. Expected: PASS, or a clean SKIP with a specific reason if a precondition is not met.

Test-only change; no product behavior change.