### PR TITLE
Fix spurious 'Script error: OnLevelWasLoaded' at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to Parsek are documented here.
 - Fixed a brief stale ghost orbit-line and icon flash when a looping recording first appears on the flight map (the loop time-shift was applied one frame late on initial map creation).
 - Fixed a brief flash of the previous orbit circle on the map at the moment a looped mission's next orbit was about to appear (the old orbit line was redrawn for a fraction of a second before the new one loaded).
 - Fixed a looped mission's map icon vanishing off into deep space on its escape trajectory out of a planet's sphere of influence (the icon was placed at the live time instead of the replayed time, so the open escape path flung it far past where the mission actually was).
+- Removed two spurious "Script error: OnLevelWasLoaded" messages printed to the log at startup. Two internal scene-load handlers collided with a deprecated Unity method name; renaming them clears the errors with no behavior change.
 
 ### UI
 

--- a/Source/Parsek/Display/GhostTrajectoryPolylineRenderer.cs
+++ b/Source/Parsek/Display/GhostTrajectoryPolylineRenderer.cs
@@ -868,7 +868,7 @@ namespace Parsek.Display
                 instance = this;
                 DontDestroyOnLoad(gameObject);
                 GameEvents.onGameStateLoad.Add(OnGameStateLoad);
-                GameEvents.onLevelWasLoaded.Add(OnLevelWasLoaded);
+                GameEvents.onLevelWasLoaded.Add(HandleLevelWasLoaded);
                 ParsekLog.Verbose(DriverTag,
                     "GhostTrajectoryPolylineRenderer.Driver awake (DDOL singleton)");
             }
@@ -879,7 +879,7 @@ namespace Parsek.Display
                 {
                     instance = null;
                     GameEvents.onGameStateLoad.Remove(OnGameStateLoad);
-                    GameEvents.onLevelWasLoaded.Remove(OnLevelWasLoaded);
+                    GameEvents.onLevelWasLoaded.Remove(HandleLevelWasLoaded);
                     ParsekLog.Verbose(DriverTag,
                         "GhostTrajectoryPolylineRenderer.Driver destroyed");
                 }
@@ -891,8 +891,15 @@ namespace Parsek.Display
             /// new scene (MINOR-1 / MINOR-2). The DDOL Driver outlives scene
             /// transitions, so a stale controller from the previous scene must
             /// not be reused.
+            ///
+            /// Named HandleLevelWasLoaded (not OnLevelWasLoaded) to avoid colliding
+            /// with Unity's deprecated magic message of that name: Unity scans
+            /// MonoBehaviours for a method called OnLevelWasLoaded and, finding our
+            /// GameScenes-typed handler instead of the magic int signature, logs a
+            /// spurious "[ERR] Script error: OnLevelWasLoaded" on every scene load.
+            /// The real subscription is the KSP GameEvent GameEvents.onLevelWasLoaded.
             /// </summary>
-            private void OnLevelWasLoaded(GameScenes scene)
+            private void HandleLevelWasLoaded(GameScenes scene)
             {
                 cachedControllerScene = (GameScenes)(-1);
                 cachedTsController = null;

--- a/Source/Parsek/WarpToTimeConsumer.cs
+++ b/Source/Parsek/WarpToTimeConsumer.cs
@@ -37,7 +37,7 @@ namespace Parsek
             }
             instance = this;
             DontDestroyOnLoad(gameObject);
-            GameEvents.onLevelWasLoaded.Add(OnLevelWasLoaded);
+            GameEvents.onLevelWasLoaded.Add(HandleLevelWasLoaded);
             ParsekLog.Verbose(Tag, "WarpToTimeConsumer initialized");
         }
 
@@ -46,11 +46,18 @@ namespace Parsek
             if (instance == this)
             {
                 instance = null;
-                GameEvents.onLevelWasLoaded.Remove(OnLevelWasLoaded);
+                GameEvents.onLevelWasLoaded.Remove(HandleLevelWasLoaded);
             }
         }
 
-        private void OnLevelWasLoaded(GameScenes scene)
+        // Renamed off the Unity magic-method name "OnLevelWasLoaded": a MonoBehaviour
+        // method called OnLevelWasLoaded collides with Unity's deprecated magic
+        // message of the same name, which Unity scans for by name. Our handler takes
+        // GameScenes (not the magic int), so Unity logs a spurious
+        // "[ERR] Script error: OnLevelWasLoaded ... has to be of type: int" on every
+        // scene load and ignores it. The real subscription is the KSP GameEvent
+        // GameEvents.onLevelWasLoaded above; renaming the handler removes the bogus ERR.
+        private void HandleLevelWasLoaded(GameScenes scene)
         {
             if (scene != GameScenes.SPACECENTER)
                 return;

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -12,6 +12,12 @@ When referencing prior item numbers from source comments or plans, consult the r
 
 ---
 
+## Done - v0.10.0 Spurious "Script error: OnLevelWasLoaded" logged at startup (Unity magic-method name collision)
+
+- Surfaced by a logistics-session log sweep: two `[ERR] Script error: OnLevelWasLoaded / This message parameter has to be of type: int / The message will be ignored.` lines at startup (preceded by the deprecation WRN `OnLevelWasLoaded was found on WarpToTimeConsumer` / `... on Driver`).
+- **Root cause:** `WarpToTimeConsumer` and `GhostTrajectoryPolylineRenderer.Driver` each subscribe a scene-load handler to the KSP GameEvent `GameEvents.onLevelWasLoaded`, but named the handler method `OnLevelWasLoaded` — which is also Unity's deprecated magic-message name. Unity scans MonoBehaviours for a method called `OnLevelWasLoaded`, finds our `(GameScenes)` signature instead of the magic `(int)`, logs the `[ERR]` and ignores the magic call. The GameEvent subscription still fires correctly, so there was no functional breakage; the only symptom was the bogus startup `[ERR]`.
+- **Fix:** renamed both handlers to `HandleLevelWasLoaded` (and the matching `GameEvents.onLevelWasLoaded.Add/Remove` references). The KSP GameEvent name `GameEvents.onLevelWasLoaded` is unchanged. No behavior change; the spurious magic-method `[ERR]` is gone. Verified both files were the only `OnLevelWasLoaded`-named handlers in `Source/Parsek`.
+
 ## Done - v0.10.0 Looping recording flashed a stale recorded-UT orbit line / icon on first flight-map appearance
 
 - Surfaced by the new map/TS draw-path logging (branch `add-map-ts-draw-logging`): a looping, re-aimed recording ("Kerbal X", rec 30) logged `Map-visible orbit window ... source=stored-bounds-fallback ... windowUT=52569494-52569925` (raw recorded UT) one tick, while the live clock was ~614212164, before the next tick computed the correct loop-shifted window.


### PR DESCRIPTION
## Problem

At startup the log shows two:

```
[WRN] OnLevelWasLoaded was found on WarpToTimeConsumer  (deprecated)
[ERR] Script error: OnLevelWasLoaded
      This message parameter has to be of type: int
      The message will be ignored.
```

(one for `WarpToTimeConsumer`, one for `GhostTrajectoryPolylineRenderer.Driver`). Surfaced by a log sweep during logistics playtesting.

## Cause

Both MonoBehaviours subscribe a scene-load handler to the KSP GameEvent `GameEvents.onLevelWasLoaded`, but they named the handler method `OnLevelWasLoaded` — which is also Unity's deprecated magic-message name. Unity scans MonoBehaviours for a method called `OnLevelWasLoaded`, finds our `(GameScenes)` signature instead of the magic `(int)`, logs the `[ERR]`, and ignores the magic invocation. The GameEvent subscription still fires correctly, so there was **no functional breakage** — only the spurious startup `[ERR]`.

## Fix

Renamed both handlers `OnLevelWasLoaded` -> `HandleLevelWasLoaded` (and the matching `GameEvents.onLevelWasLoaded.Add/Remove` references). The KSP GameEvent name `GameEvents.onLevelWasLoaded` is unchanged. No behavior change; the bogus magic-method `[ERR]` is gone.

## Validation

- Grep confirms these were the only `OnLevelWasLoaded`-named handlers in `Source/Parsek` (remaining matches are the GameEvent name + explanatory comments).
- Full xUnit suite green (13,202).
- CHANGELOG (Fixed) + todo doc updated.