### PR TITLE
Reduce KSP.log spam from per-recording diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ All notable changes to Parsek are documented here.
 ### Internals
 
 - The `[Engine] engine-frame-iter` diagnostic trace now reports each ghost's per-frame visibility outcome (`[out:vis=.. retired=.. zone=.. rdist=..]`), not just its pre-render inputs, and auto-enables during a Re-Fly session. This pins down the still-open "ghost vanishes at the Inertial-frame transition" case by showing whether a ghost was actually hidden and why, rather than only that it was iterated.
+- Cut KSP.log spam from several per-recording and per-frame diagnostics that scaled with the number of recordings. Spawn suppression is now one batched per-reason summary per frame instead of one line per recording (previously thousands of lines per second with a large save), the map "Marker pos" loiter-seam diagnostic is gated behind the map-render tracer and skips frames with nothing to compare (about 93 percent of its volume), the per-tree "Save" line folds into the existing committed-tree save summary, and the tech-tree bypass-rehydrate line is batched into one summary per recalc.
 
 ### Known limitations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,7 @@ All notable changes to Parsek are documented here.
 ### Internals
 
 - The `[Engine] engine-frame-iter` diagnostic trace now reports each ghost's per-frame visibility outcome (`[out:vis=.. retired=.. zone=.. rdist=..]`), not just its pre-render inputs, and auto-enables during a Re-Fly session. This pins down the still-open "ghost vanishes at the Inertial-frame transition" case by showing whether a ghost was actually hidden and why, rather than only that it was iterated.
-- Cut KSP.log spam from several per-recording and per-frame diagnostics that scaled with the number of recordings. Spawn suppression is now one batched per-reason summary per frame instead of one line per recording (previously thousands of lines per second with a large save), the map "Marker pos" loiter-seam diagnostic is gated behind the map-render tracer and skips frames with nothing to compare (about 93 percent of its volume), the per-tree "Save" line folds into the existing committed-tree save summary, and the tech-tree bypass-rehydrate line is batched into one summary per recalc.
+- Cut KSP.log spam from four per-recording / per-frame diagnostics that scaled with the recording count (spawn suppression, the map "Marker pos" loiter-seam trace, the per-tree save line, and the tech-tree bypass-rehydrate line). Each is now a batched summary or gated behind the map-render tracer instead of one line per recording per frame.
 
 ### Known limitations
 

--- a/Source/Parsek.Tests/FlightPlaybackExplainabilityTests.cs
+++ b/Source/Parsek.Tests/FlightPlaybackExplainabilityTests.cs
@@ -255,6 +255,39 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void ComputePlaybackFlags_EmitsOneBatchedSpawnSuppressedSummary()
+        {
+            RecordingStore.ResetForTesting();
+            try
+            {
+                ParsekFlight host = CreateFlightHostForPlaybackFlagTests();
+                // Three non-debris recordings with no vessel snapshot: all spawn-suppressed.
+                var committed = new List<Recording>
+                {
+                    MakeRecording("rec-a", "Vessel A"),
+                    MakeRecording("rec-b", "Vessel B"),
+                    MakeRecording("rec-c", "Vessel C"),
+                };
+
+                ComputePlaybackFlagsForTesting(host, committed, 100.0);
+
+                // One batched summary for the whole list, NOT one line per recording.
+                var summaryLines = logLines
+                    .Where(l => l.Contains("[Spawner]") && l.Contains("Spawn suppressed:"))
+                    .ToList();
+                Assert.Single(summaryLines);
+                Assert.Contains("3 recording(s)", summaryLines[0]);
+                // The former per-recording "Spawn suppressed for #N" line is gone.
+                Assert.DoesNotContain(logLines, l =>
+                    l.Contains("[Spawner]") && l.Contains("Spawn suppressed for #"));
+            }
+            finally
+            {
+                RecordingStore.ResetForTesting();
+            }
+        }
+
+        [Fact]
         public void ComputePlaybackFlags_RewindRetired_SkipsGhostAndSpawn()
         {
             RecordingStore.ResetForTesting();
@@ -649,6 +682,7 @@ namespace Parsek.Tests
             SetPrivateField(host, "reFlyAnchorHoldCountsThisFrame", new Dictionary<string, int>(StringComparer.Ordinal));
             SetPrivateField(host, "reFlyAnchorHoldReasonsThisFrame", new Dictionary<string, string>(StringComparer.Ordinal));
             SetPrivateField(host, "reFlyAnchorHoldReleaseScratch", new List<string>());
+            SetPrivateField(host, "spawnSuppressedReasonScratch", new Dictionary<string, int>(StringComparer.Ordinal));
             return host;
         }
 

--- a/Source/Parsek.Tests/LogSpamRateLimitTests.cs
+++ b/Source/Parsek.Tests/LogSpamRateLimitTests.cs
@@ -8,13 +8,21 @@ namespace Parsek.Tests
 {
     /// <summary>
     /// Integration tests covering the ghost-map source-resolve verbose line and
-    /// the spawner suppression line. Both fire from per-frame hot paths and
-    /// previously stormed the log when the same decision tuple repeated for
-    /// the entire session. The fix routes both through
-    /// <see cref="ParsekLog.VerboseOnChange"/> so a stable
-    /// <c>(source, reason)</c> tuple emits exactly once until the decision flips,
-    /// with the suppressed count surfaced as <c>| suppressed=N</c> on the next
-    /// state change.
+    /// the spawner suppression summary. Both fire from per-frame hot paths and
+    /// previously stormed the log when the same decision repeated for the entire
+    /// session.
+    /// <para>
+    /// GhostMap source-resolve routes through <see cref="ParsekLog.VerboseOnChange"/>
+    /// so a stable <c>(source, reason)</c> tuple emits exactly once until the
+    /// decision flips, with the suppressed count surfaced as <c>| suppressed=N</c>.
+    /// </para>
+    /// <para>
+    /// Spawner suppression is now a single batched, rate-limited summary
+    /// (per-reason histogram) emitted once after ComputePlaybackFlags' loop,
+    /// replacing the former one-line-per-recording diagnostic that was the worst
+    /// log-spam source (thousands of lines/second with a large committed list).
+    /// <see cref="ParsekFlight.BuildSpawnSuppressedSummary"/> is the pure core.
+    /// </para>
     /// </summary>
     [Collection("Sequential")]
     public class LogSpamRateLimitTests : IDisposable
@@ -148,145 +156,88 @@ namespace Parsek.Tests
         }
 
         // -------------------------------------------------------------------
-        // VerboseOnChange itself, exercised through a faux Spawner pattern
-        // that mirrors ParsekFlight.ComputePlaybackFlags. The real call site
-        // is private inside the flight controller, but the helper IS the
-        // contract — testing it here covers the spawner fix end-to-end.
+        // Spawner suppression summary: the pure histogram builder. Replaces
+        // the former one-line-per-recording diagnostic. The summary is sorted
+        // by descending count (ties broken by ordinal reason) so the line is
+        // deterministic and the dominant reason leads.
         // -------------------------------------------------------------------
 
         [Fact]
-        public void Spawner_NoVesselSnapshotPattern_EmitsOncePerRecording()
+        public void BuildSpawnSuppressedSummary_OrdersReasonsByDescendingCount()
         {
-            // Simulate ComputePlaybackFlags running 50 frames over 5 recordings
-            // all stuck in "no vessel snapshot". The fix keys identity per
-            // RecordingId and state per reason — stable reason on each
-            // recording must collapse to one line per recording.
-            for (int frame = 0; frame < 50; frame++)
+            var byReason = new Dictionary<string, int>
             {
-                for (int recIdx = 0; recIdx < 5; recIdx++)
-                {
-                    EmitSpawnerSuppression(
-                        recIdx,
-                        "rec-" + recIdx,
-                        "Vessel " + recIdx,
-                        "no vessel snapshot");
-                }
+                { "chain-suppressed", 3 },
+                { "no vessel snapshot", 280 },
+                { "non-leaf tree recording", 12 },
+            };
+
+            string summary = ParsekFlight.BuildSpawnSuppressedSummary(295, byReason);
+
+            Assert.Equal(
+                "Spawn suppressed: 295 recording(s) | "
+                + "no vessel snapshot=280, non-leaf tree recording=12, chain-suppressed=3",
+                summary);
+        }
+
+        [Fact]
+        public void BuildSpawnSuppressedSummary_TieBrokenByOrdinalReason()
+        {
+            var byReason = new Dictionary<string, int>
+            {
+                { "bbb", 5 },
+                { "aaa", 5 },
+            };
+
+            string summary = ParsekFlight.BuildSpawnSuppressedSummary(10, byReason);
+
+            Assert.Equal("Spawn suppressed: 10 recording(s) | aaa=5, bbb=5", summary);
+        }
+
+        [Fact]
+        public void BuildSpawnSuppressedSummary_NoReasons_TotalOnly()
+        {
+            Assert.Equal(
+                "Spawn suppressed: 0 recording(s)",
+                ParsekFlight.BuildSpawnSuppressedSummary(0, new Dictionary<string, int>()));
+            Assert.Equal(
+                "Spawn suppressed: 4 recording(s)",
+                ParsekFlight.BuildSpawnSuppressedSummary(4, null));
+        }
+
+        // -------------------------------------------------------------------
+        // Spawner summary: rate-limited shared key. A large committed list
+        // all stuck on the same reason for many frames must collapse to a
+        // handful of summary lines (one per rate-limit window), NOT one line
+        // per recording per frame. This is the structural anti-spam guarantee.
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void SpawnSuppressedSummary_ManyFramesLargeList_CollapsesViaRateLimit()
+        {
+            double clock = 0.0;
+            ParsekLog.ClockOverrideForTesting = () => clock;
+
+            // 300 frames, 286 recordings each frame all "no vessel snapshot",
+            // advancing 1/60 s per frame (~5 s of wall-clock). Mirrors the
+            // production call: one VerboseRateLimited summary after the loop.
+            for (int frame = 0; frame < 300; frame++)
+            {
+                var byReason = new Dictionary<string, int> { { "no vessel snapshot", 286 } };
+                ParsekLog.VerboseRateLimited(
+                    "Spawner",
+                    "spawn-suppressed-summary",
+                    () => ParsekFlight.BuildSpawnSuppressedSummary(286, byReason),
+                    2.0);
+                clock += 1.0 / 60.0;
             }
 
-            int suppressedLines = logLines.Count(l =>
-                l.Contains("[Spawner]")
-                && l.Contains("Spawn suppressed for #")
-                && l.Contains("no vessel snapshot"));
+            int summaryLines = logLines.Count(l =>
+                l.Contains("[Spawner]") && l.Contains("Spawn suppressed:"));
 
-            Assert.Equal(5, suppressedLines);
-        }
-
-        [Fact]
-        public void Spawner_ReasonFlipForSameRecording_ReemitsWithSuppressedCount()
-        {
-            // Stable "no vessel snapshot" repeats, then the recording flips
-            // to a different reason — the new reason must emit and carry
-            // the suppressed count from the prior streak.
-            EmitSpawnerSuppression(7, "rec-7", "Showcase", "no vessel snapshot");
-            EmitSpawnerSuppression(7, "rec-7", "Showcase", "no vessel snapshot");
-            EmitSpawnerSuppression(7, "rec-7", "Showcase", "no vessel snapshot");
-            EmitSpawnerSuppression(7, "rec-7", "Showcase", "chain-suppressed");
-
-            var lines = logLines
-                .Where(l => l.Contains("[Spawner]") && l.Contains("Spawn suppressed for #7"))
-                .ToList();
-
-            Assert.Equal(2, lines.Count);
-            Assert.Contains("no vessel snapshot", lines[0]);
-            Assert.DoesNotContain("suppressed=", lines[0]);
-            Assert.Contains("chain-suppressed", lines[1]);
-            Assert.Contains("| suppressed=2", lines[1]);
-        }
-
-        // -------------------------------------------------------------------
-        // Spawner identity-by-RecordingId regression. The bare list index is
-        // not a stable identity — when a recording is discarded, recordings
-        // after it shift down one slot and the same index becomes a different
-        // recording. Keying VerboseOnChange on the index alone would let the
-        // new occupant inherit the prior recording's cached state (silently
-        // masking its first-emission line, or surfacing a stale suppressed
-        // counter on the next flip). Keying on RecordingId restores per-
-        // recording independence.
-        // -------------------------------------------------------------------
-
-        [Fact]
-        public void SpawnSuppression_IndexReuseAcrossRecordings_KeepsIndependentState()
-        {
-            // Two distinct recordings end up sharing index 294 (one was
-            // discarded between observations) and both report the same
-            // suppression reason. Each must emit its own first-emission line.
-            EmitSpawnerSuppression(294, "rec-A", "Untitled Space Craft", "no vessel snapshot");
-            EmitSpawnerSuppression(294, "rec-A", "Untitled Space Craft", "no vessel snapshot");
-            EmitSpawnerSuppression(294, "rec-A", "Untitled Space Craft", "no vessel snapshot");
-
-            // Index 294 is now occupied by recording B (rec-A discarded).
-            // Same reason — but a different RecordingId means a fresh
-            // first-emission, not silent inheritance of rec-A's cache.
-            EmitSpawnerSuppression(294, "rec-B", "Different Vessel", "no vessel snapshot");
-            EmitSpawnerSuppression(294, "rec-B", "Different Vessel", "no vessel snapshot");
-
-            var lines = logLines
-                .Where(l => l.Contains("[Spawner]") && l.Contains("Spawn suppressed for #294"))
-                .ToList();
-
-            Assert.Equal(2, lines.Count);
-            Assert.Contains("Untitled Space Craft", lines[0]);
-            Assert.DoesNotContain("suppressed=", lines[0]);
-            // The second line is rec-B's first emission — a clean first hit,
-            // NOT a delayed flip carrying rec-A's suppressed counter.
-            Assert.Contains("Different Vessel", lines[1]);
-            Assert.DoesNotContain("suppressed=", lines[1]);
-        }
-
-        [Fact]
-        public void SpawnSuppression_IndexReuse_StableReasonStillCoalescesPerRecording()
-        {
-            // Once each recording has emitted its first line, subsequent
-            // stable repeats must coalesce per-RecordingId — the cache must
-            // not be globally indexed by idx in a way that thrashes between
-            // recordings sharing the same slot.
-            EmitSpawnerSuppression(50, "rec-X", "Vessel X", "no vessel snapshot");
-            EmitSpawnerSuppression(50, "rec-Y", "Vessel Y", "no vessel snapshot");
-
-            // Interleave further per-frame calls — all stable. Each recording
-            // has its own state, so neither emits again until its reason flips.
-            for (int i = 0; i < 10; i++)
-            {
-                EmitSpawnerSuppression(50, "rec-X", "Vessel X", "no vessel snapshot");
-                EmitSpawnerSuppression(50, "rec-Y", "Vessel Y", "no vessel snapshot");
-            }
-
-            int xLines = logLines.Count(l =>
-                l.Contains("[Spawner]") && l.Contains("Vessel X"));
-            int yLines = logLines.Count(l =>
-                l.Contains("[Spawner]") && l.Contains("Vessel Y"));
-
-            Assert.Equal(1, xLines);
-            Assert.Equal(1, yLines);
-        }
-
-        [Fact]
-        public void SpawnSuppression_NullRecordingId_FallsBackToIndexInIdentity()
-        {
-            // Defensive case: if RecordingId is somehow null/empty, the call
-            // site falls back to "idx-{N}" so emissions still flow. Two
-            // null-Id recordings sharing the same index DO collide (no better
-            // identity is available), but a real RecordingId on a sibling
-            // recording is still tracked independently.
-            EmitSpawnerSuppressionRaw(idx: 9, recordingId: null, vesselName: "Anon",
-                reason: "no vessel snapshot");
-            EmitSpawnerSuppressionRaw(idx: 9, recordingId: null, vesselName: "Anon",
-                reason: "no vessel snapshot");
-
-            int anonLines = logLines.Count(l =>
-                l.Contains("[Spawner]") && l.Contains("Spawn suppressed for #9"));
-
-            Assert.Equal(1, anonLines);
+            // ~5 s at a 2 s window: first emit + ~2 s + ~4 s = 3 lines.
+            // The point is it is a small constant, not 300 * 286 = 85,800.
+            Assert.InRange(summaryLines, 1, 4);
         }
 
         // -------------------------------------------------------------------
@@ -362,27 +313,5 @@ namespace Parsek.Tests
             };
         }
 
-        // Mirrors the production call site in ParsekFlight.ComputePlaybackFlags
-        // exactly so the test pins the (identity, stateKey) shape we ship.
-        // Identity is keyed on RecordingId (with an idx-{N} fallback for
-        // null/empty Ids) so two recordings that briefly share the same list
-        // index do not inherit each other's cached state.
-        private static void EmitSpawnerSuppression(
-            int idx, string recordingId, string vesselName, string reason)
-        {
-            EmitSpawnerSuppressionRaw(idx, recordingId, vesselName, reason);
-        }
-
-        private static void EmitSpawnerSuppressionRaw(
-            int idx, string recordingId, string vesselName, string reason)
-        {
-            string identity = "spawn-suppressed|"
-                + (!string.IsNullOrEmpty(recordingId) ? recordingId : "idx-" + idx);
-            ParsekLog.VerboseOnChange(
-                "Spawner",
-                identity,
-                reason ?? "(none)",
-                $"Spawn suppressed for #{idx} \"{vesselName}\": {reason}");
-        }
     }
 }

--- a/Source/Parsek.Tests/TreeLogVerificationTests.cs
+++ b/Source/Parsek.Tests/TreeLogVerificationTests.cs
@@ -111,11 +111,11 @@ namespace Parsek.Tests
         // C4: ComputeTotal logging removed — pure computation should not log (log spam fix)
 
         // ============================================================
-        // C5: RecordingTree.Save logs summary
+        // C5: RecordingTree.Save is intentionally silent (log-spam fix)
         // ============================================================
 
         [Fact]
-        public void RecordingTreeSave_LogsSummary()
+        public void RecordingTreeSave_DoesNotLogPerTreeLine()
         {
             var tree = new RecordingTree
             {
@@ -138,12 +138,17 @@ namespace Parsek.Tests
             var node = new ConfigNode("RECORDING_TREE");
             tree.Save(node);
 
-            // Phase F: Save no longer logs the resourcesApplied flag (that field
-            // is no longer persisted). The summary still includes recordings + branchPoints.
-            Assert.Contains(capturedLines,
-                line => line.Contains("Save Test")
-                     && line.Contains("recordings=2")
-                     && line.Contains("branchPoints=1"));
+            // Serialization still works...
+            Assert.Equal(2, node.GetNodes("RECORDING").Length);
+            Assert.Single(node.GetNodes("BRANCH_POINT"));
+
+            // ...but Save no longer emits its own per-tree summary line: it is called
+            // once per committed tree inside ParsekScenario.SaveTreeRecordings' loop, which
+            // would emit one line per tree (hundreds with a large save). The caller logs a
+            // single batched summary; the single-tree active/pending callers log their own
+            // Info line.
+            Assert.DoesNotContain(capturedLines,
+                line => line.Contains("[RecordingTree]") && line.Contains("Save: tree="));
         }
 
         // ============================================================

--- a/Source/Parsek/GameActions/KspStatePatcher.cs
+++ b/Source/Parsek/GameActions/KspStatePatcher.cs
@@ -303,6 +303,10 @@ namespace Parsek
             int alreadyAvailable = 0;
             int alreadyUnavailable = 0;
             int missingTargets = 0;
+            // Bypass-rehydrate stats accumulated across the tech-tree loop and emitted
+            // as ONE summary after it (the tree has ~80+ nodes; a per-node line here was
+            // a per-item-in-loop log over a large collection on every recalc).
+            int bypassRehydratedNodes = 0, bypassTotalPartsAdded = 0, bypassFallbackNodes = 0;
             var seen = new HashSet<string>(StringComparer.Ordinal);
             List<string> missingTargetIds = null;
 
@@ -324,7 +328,14 @@ namespace Parsek
                     else
                         alreadyAvailable++;
 
-                    proto = EnsureAvailableProtoTechNode(tech, proto);
+                    proto = EnsureAvailableProtoTechNode(
+                        tech, proto, out int bypassPartsAdded, out bool bypassFallbackUsed);
+                    if (bypassPartsAdded >= 0)
+                    {
+                        bypassRehydratedNodes++;
+                        bypassTotalPartsAdded += bypassPartsAdded;
+                        if (bypassFallbackUsed) bypassFallbackNodes++;
+                    }
                     ResearchAndDevelopment.Instance.SetTechState(techId, proto);
                     tech.state = RDTech.State.Available;
                 }
@@ -369,6 +380,11 @@ namespace Parsek
                 $"missingTargets={missingTargets.ToString(IC)}, " +
                 $"utCutoff={cutoffLabel}, baselineUt={baselineLabel}");
 
+            if (bypassRehydratedNodes > 0)
+                ParsekLog.Verbose(Tag,
+                    $"EnsureAvailableProtoTechNode: bypass rehydrated {bypassRehydratedNodes.ToString(IC)} tech node(s), " +
+                    $"{bypassTotalPartsAdded.ToString(IC)} part(s) added, {bypassFallbackNodes.ToString(IC)} via fallback");
+
             if (missingTargets > 0 && missingTargetIds != null)
             {
                 ParsekLog.Verbose(Tag,
@@ -377,8 +393,16 @@ namespace Parsek
             }
         }
 
-        private static ProtoTechNode EnsureAvailableProtoTechNode(ProtoTechNode tech, ProtoTechNode existing)
+        // Reports bypass-rehydrate stats to the caller for a batched summary instead of
+        // logging per node: <paramref name="bypassPartsAdded"/> is the net parts added by
+        // the rehydrate (-1 when bypass is inactive, so the caller skips this node), and
+        // <paramref name="bypassFallbackUsed"/> flags the AddPurchasedParts fallback path.
+        private static ProtoTechNode EnsureAvailableProtoTechNode(
+            ProtoTechNode tech, ProtoTechNode existing,
+            out int bypassPartsAdded, out bool bypassFallbackUsed)
         {
+            bypassPartsAdded = -1;
+            bypassFallbackUsed = false;
             var proto = existing ?? new ProtoTechNode();
             proto.techID = tech.techID;
             proto.state = RDTech.State.Available;
@@ -397,11 +421,11 @@ namespace Parsek
                 int beforeCount = proto.partsPurchased.Count;
                 int added = AddPurchasedPartsForTech(proto, tech.techID, PartLoader.LoadedPartsList);
                 if (added == 0 && beforeCount == 0 && tech.partsPurchased != null)
+                {
                     AddPurchasedParts(proto, tech.partsPurchased);
-                ParsekLog.Verbose(Tag,
-                    $"EnsureAvailableProtoTechNode: bypass rehydrate techId={tech.techID} " +
-                    $"before={beforeCount.ToString(IC)} added={added.ToString(IC)} " +
-                    $"after={proto.partsPurchased.Count.ToString(IC)}");
+                    bypassFallbackUsed = true;
+                }
+                bypassPartsAdded = proto.partsPurchased.Count - beforeCount;
             }
 
             return proto;

--- a/Source/Parsek/InGameTests/RuntimeTests.cs
+++ b/Source/Parsek/InGameTests/RuntimeTests.cs
@@ -2135,15 +2135,20 @@ namespace Parsek.InGameTests
                 InGameAssert.IsGreaterThan(renderers.Length, 0,
                     $"Sentinel EVA ghost {spawnedGhostIndex} should render at least one child part");
 
-                bool sawNoSnapshotSuppression = captured.Any(line =>
-                    line.Contains("Spawn suppressed")
-                    && line.Contains("no vessel snapshot")
-                    && (line.Contains(evaRecordingId) || line.Contains(crewMember.name)));
+                // Spawn-suppression is now a batched per-reason histogram (no
+                // per-recording line), so assert the decision directly for this EVA
+                // recording instead of scraping the log: the EVA branch must carry a
+                // vessel snapshot, so ShouldSpawnAtRecordingEnd must not report
+                // "no vessel snapshot" for it.
+                var evaSpawnDecision = GhostPlaybackLogic.ShouldSpawnAtRecordingEnd(
+                    finalizedEva, isActiveChainMember: false, isChainLooping: false);
+                bool sawNoSnapshotSuppression =
+                    evaSpawnDecision.reason == "no vessel snapshot";
                 bool sawDestroyedClassification = captured.Any(line =>
                     line.Contains("classified Destroyed by sub-surface path")
                     && line.Contains(evaRecordingId));
                 InGameAssert.IsFalse(sawNoSnapshotSuppression,
-                    "EVA branch canary should not log no-vessel-snapshot spawn suppression");
+                    "EVA branch canary should have a vessel snapshot (no no-vessel-snapshot spawn suppression)");
                 InGameAssert.IsFalse(sawDestroyedClassification,
                     "EVA branch canary should not accept a sub-surface Destroyed classification");
 

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -890,6 +890,10 @@ namespace Parsek
             new Dictionary<string, int>(StringComparer.Ordinal);
         private readonly Dictionary<string, string> reFlyAnchorHoldReasonsThisFrame =
             new Dictionary<string, string>(StringComparer.Ordinal);
+        // Reused per-frame scratch for the batched spawn-suppression summary (see
+        // ComputePlaybackFlags). Cleared and refilled each frame; never read across frames.
+        private readonly Dictionary<string, int> spawnSuppressedReasonScratch =
+            new Dictionary<string, int>(StringComparer.Ordinal);
         private readonly List<string> reFlyAnchorHoldReleaseScratch = new List<string>();
         private readonly Dictionary<string, ReFlyDenseAbsolutePlaybackFrameCacheEntry> reFlyDenseAbsolutePlaybackFrameCache =
             new Dictionary<string, ReFlyDenseAbsolutePlaybackFrameCacheEntry>(StringComparer.Ordinal);
@@ -18233,6 +18237,16 @@ namespace Parsek
                 committed,
                 object.ReferenceEquals(null, scenario) ? null : scenario.RecordingSupersedes,
                 object.ReferenceEquals(null, scenario) ? null : scenario.RecordingRewindRetirements);
+            // Spawn-suppression diagnostic is accumulated per-reason across the whole
+            // committed list and emitted as ONE batched summary after the loop (see the
+            // batch-counting convention in CLAUDE.md): a per-recording line here was the
+            // single worst log-spam source (one VerboseOnChange line per recording per
+            // frame, ballooning to thousands of lines/second once the committed list grows
+            // and a recording's reason oscillates frame-to-frame). The per-reason histogram
+            // preserves the "what is suppressed and why" signal without the per-item churn.
+            var spawnSuppressedByReason = spawnSuppressedReasonScratch;
+            spawnSuppressedByReason.Clear();
+            int spawnSuppressedCount = 0;
             for (int i = 0; i < committed.Count; i++)
             {
                 var rec = committed[i];
@@ -18283,29 +18297,15 @@ namespace Parsek
                     RecordReFlyAnchorHoldCandidate(
                         anchorReFlyUnstableAnchorId, anchorReFlyUnstableReason);
 
-                // Log spawn suppression reason for non-debris recordings (diagnostic).
-                // Emit only when the suppression reason flips for this recording —
-                // stable per-frame repeats (e.g., "no vessel snapshot" for the entire
-                // session) are coalesced into the suppressed counter and surfaced
-                // on the next reason change. Identity is keyed on the stable
-                // RecordingId rather than the bare list index because the committed
-                // list is dense — when a recording is discarded, later recordings
-                // shift down and the same index gets reused for a different
-                // recording. Keying on index alone would let the new occupant
-                // inherit the prior recording's cached state and mask its first
-                // emission (or surface a stale suppressed counter on the next
-                // flip). The index still appears in the message body so audits
-                // can resolve recordings post-hoc.
+                // Accumulate the spawn-suppression reason for non-debris recordings into
+                // the per-reason histogram; the batched summary is emitted after the loop.
                 if (!finalNeedsSpawn && !rec.IsDebris)
                 {
                     string reason = !spawnResult.needsSpawn ? spawnResult.reason : chainSuppressed.reason;
-                    string identity = "spawn-suppressed|"
-                        + (!string.IsNullOrEmpty(rec.RecordingId) ? rec.RecordingId : "idx-" + i);
-                    ParsekLog.VerboseOnChange(
-                        "Spawner",
-                        identity,
-                        reason ?? "(none)",
-                        $"Spawn suppressed for #{i} \"{rec.VesselName}\": {reason}");
+                    string reasonKey = string.IsNullOrEmpty(reason) ? "(none)" : reason;
+                    spawnSuppressedByReason.TryGetValue(reasonKey, out int reasonCount);
+                    spawnSuppressedByReason[reasonKey] = reasonCount + 1;
+                    spawnSuppressedCount++;
                 }
 
                 flags[i] = new TrajectoryPlaybackFlags
@@ -18340,8 +18340,46 @@ namespace Parsek
                     anchorReFlyUnstable = anchorReFlyUnstable,
                 };
             }
+            // One batched, rate-limited summary instead of one line per suppressed
+            // recording. Shared key + VerboseRateLimited hard-caps the rate so the
+            // per-frame summary cannot spam even when the committed list is large or a
+            // reason oscillates frame-to-frame.
+            if (spawnSuppressedCount > 0)
+            {
+                ParsekLog.VerboseRateLimited(
+                    "Spawner",
+                    "spawn-suppressed-summary",
+                    () => BuildSpawnSuppressedSummary(spawnSuppressedCount, spawnSuppressedByReason),
+                    2.0);
+            }
             LogReFlyAnchorHoldTransitions(frame);
             return flags;
+        }
+
+        /// <summary>
+        /// Builds the batched spawn-suppression summary line: a total plus a
+        /// per-reason histogram sorted by descending count (ties broken by reason text
+        /// for determinism). Replaces the former one-line-per-recording diagnostic that
+        /// was the worst log-spam source. Pure for unit testing.
+        /// </summary>
+        internal static string BuildSpawnSuppressedSummary(
+            int total, IReadOnlyDictionary<string, int> byReason)
+        {
+            string head = "Spawn suppressed: "
+                + total.ToString(CultureInfo.InvariantCulture) + " recording(s)";
+            if (byReason == null || byReason.Count == 0)
+                return head;
+
+            var ordered = new List<KeyValuePair<string, int>>(byReason);
+            ordered.Sort((a, b) =>
+            {
+                int byCount = b.Value.CompareTo(a.Value);
+                return byCount != 0 ? byCount : string.CompareOrdinal(a.Key, b.Key);
+            });
+            var parts = new List<string>(ordered.Count);
+            for (int r = 0; r < ordered.Count; r++)
+                parts.Add(ordered[r].Key + "=" + ordered[r].Value.ToString(CultureInfo.InvariantCulture));
+            return head + " | " + string.Join(", ", parts.ToArray());
         }
 
         /// <summary>

--- a/Source/Parsek/ParsekScenario.cs
+++ b/Source/Parsek/ParsekScenario.cs
@@ -971,10 +971,11 @@ namespace Parsek
             ParsekLog.Info("Scenario", $"OnSave: saving {committedTrees.Count} committed tree(s)");
             int treeRecCount = 0;
             int treeTotalPoints = 0, treeTotalOrbitSegments = 0, treeTotalPartEvents = 0;
-            int treeWithTrackSections = 0, treeWithSnapshots = 0;
+            int treeWithTrackSections = 0, treeWithSnapshots = 0, treeTotalBranchPoints = 0;
             for (int t = 0; t < committedTrees.Count; t++)
             {
                 var tree = committedTrees[t];
+                treeTotalBranchPoints += tree.BranchPoints.Count;
 
                 bool treeFilesCurrent = true;
                 foreach (var rec in tree.Recordings.Values)
@@ -1004,7 +1005,8 @@ namespace Parsek
                 ParsekLog.Verbose("Scenario",
                     $"Saved {committedTrees.Count} trees ({treeRecCount} recordings): {treeTotalPoints} points, " +
                     $"{treeTotalOrbitSegments} orbit segments, {treeTotalPartEvents} part events, " +
-                    $"{treeWithTrackSections} with track sections, {treeWithSnapshots} with snapshots");
+                    $"{treeWithTrackSections} with track sections, {treeWithSnapshots} with snapshots, " +
+                    $"{treeTotalBranchPoints} branch points");
 
             SaveActiveTreeIfAny(node);
             SavePendingTreeIfAny(node);

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -1306,23 +1306,31 @@ namespace Parsek
                 // recorded path (the "non-proto icon in the wrong location / not moving correctly on the
                 // polyline" seam), while a ~0 gap means the icon is on the path and any apparent freeze is
                 // just the sub-pixel parking circle at map scale. Rate-limited per recording.
-                if (meshActive && isMapView && kvp.Key < committed.Count)
+                //
+                // Gated behind the map-render tracer (off in normal play, so the per-frame
+                // TryComputeGhostWorldPosition probe is skipped too) and emitted only when a
+                // trajectory position exists to compare against: a NaN meshVsTraj (no trajPos)
+                // carries no signal, so those frames are skipped rather than logged (they were
+                // ~93% of this line's volume).
+                if (MapRenderTrace.IsEnabled && meshActive && isMapView && kvp.Key < committed.Count)
                 {
                     var recDiag = committed[kvp.Key];
                     double headUT = GhostPlaybackLogic.ResolveTrackingStationSampleUT(
                         kvp.Key, recDiag.StartUT, recDiag.EndUT, currentUT,
                         flight.Engine.CurrentLoopUnits, out bool _);
-                    bool haveTraj = TryComputeGhostWorldPosition(
-                        kvp.Key, committed, headUT, out Vector3 trajPos, out _);
-                    Vector3 meshXform = state.ghost.transform.position;
-                    double meshVsTraj = haveTraj ? (meshXform - trajPos).magnitude : double.NaN;
-                    ParsekLog.VerboseRateLimited("GhostMap",
-                        "marker-pos-" + kvp.Key.ToString(System.Globalization.CultureInfo.InvariantCulture),
-                        string.Format(System.Globalization.CultureInfo.InvariantCulture,
-                            "Marker pos: rec={0} meshPositioned={1} headUT={2:F1} drawnPos={3} meshXform={4} trajPos={5} meshVsTraj={6:F0}",
-                            kvp.Key, meshPositioned, headUT, markerPos.ToString("F0"),
-                            meshXform.ToString("F0"), haveTraj ? trajPos.ToString("F0") : "(none)", meshVsTraj),
-                        2.0);
+                    if (TryComputeGhostWorldPosition(
+                            kvp.Key, committed, headUT, out Vector3 trajPos, out _))
+                    {
+                        Vector3 meshXform = state.ghost.transform.position;
+                        double meshVsTraj = (meshXform - trajPos).magnitude;
+                        ParsekLog.VerboseRateLimited("GhostMap",
+                            "marker-pos-" + kvp.Key.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                            string.Format(System.Globalization.CultureInfo.InvariantCulture,
+                                "Marker pos: rec={0} meshPositioned={1} headUT={2:F1} drawnPos={3} meshXform={4} trajPos={5} meshVsTraj={6:F0}",
+                                kvp.Key, meshPositioned, headUT, markerPos.ToString("F0"),
+                                meshXform.ToString("F0"), trajPos.ToString("F0"), meshVsTraj),
+                            2.0);
+                    }
                 }
             }
 

--- a/Source/Parsek/RecordingTree.cs
+++ b/Source/Parsek/RecordingTree.cs
@@ -181,9 +181,11 @@ namespace Parsek
                 SaveBranchPointInto(bpNode, BranchPoints[i]);
             }
 
-            ParsekLog.Verbose("RecordingTree",
-                $"Save: tree='{TreeName}' formatVersion={TreeFormatVersion} " +
-                $"recordings={Recordings.Count} branchPoints={BranchPoints.Count}");
+            // No per-tree log line here: this method is called once per committed tree
+            // inside ParsekScenario.SaveTreeRecordings' loop, which would emit one line
+            // per tree (hundreds with a large save). The caller logs a single batched
+            // summary after the loop; the single-tree active/pending callers log their
+            // own Info line.
         }
 
         public static RecordingTree Load(ConfigNode treeNode)

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -25,6 +25,19 @@ When referencing prior item numbers from source comments or plans, consult the r
 
 ---
 
+## Done - v0.10.0 KSP.log spam reduction (maprender-checkpoint investigation)
+
+- Surfaced by investigating the `2026-06-02_1856_maprender-checkpoint` capture (map-render tracer on): 86 percent of KSP.log was `[Parsek]` lines, with several per-recording / per-frame diagnostics scaling with the recording count (the 286-recording synthetic test corpus amplified them; a single test-run second emitted ~19,800 lines). The map-render tracer itself (`MapRenderTrace`, ~11k lines) was the acknowledged volume; these four sites were the spam beyond it.
+- **Spawner "Spawn suppressed for #i" (worst burst, 4,802 lines in one second):** `ParsekFlight.ComputePlaybackFlags` emitted one `VerboseOnChange` line per committed recording per frame; the free-text reason oscillates frame-to-frame for some recordings (snapshot load/unload, VesselSpawned toggling), defeating the per-identity coalescing. **Fix:** accumulate a per-reason histogram across the loop and emit ONE `VerboseRateLimited` summary after it (`BuildSpawnSuppressedSummary`, pure + unit-tested). Reuses a per-frame scratch dict; no per-recording line survives.
+- **GhostMap "Marker pos" (`ParsekUI.DrawMapMarkers`, 7,084 lines, ~93 percent `meshVsTraj=NaN` / `trajPos=(none)`):** the loiter-seam debug diagnostic was always-on and mostly carried no usable comparison. **Fix:** gated behind `MapRenderTrace.IsEnabled` (silent + skips the per-frame `TryComputeGhostWorldPosition` probe in normal play, matching the sibling `EmitMarker` above it) and emitted only when a trajectory position exists to compare against.
+- **RecordingTree per-tree "Save: tree=..." (3,965 lines):** one `Verbose` line per tree inside `ParsekScenario.SaveTreeRecordings`' committed-tree loop. **Fix:** removed the per-tree line from `RecordingTree.Save`; the loop already logs a batched summary (now also carrying total branch points), and the single-tree active/pending callers log their own `Info` line.
+- **KspStatePatcher "EnsureAvailableProtoTechNode: bypass rehydrate" (1,480 lines):** one `Verbose` line per available tech node (~80+) on every `PatchTechTree` recalc when bypass-entry-purchase is on. **Fix:** the helper reports its rehydrate stats to the caller via out params; the loop accumulates and emits one summary after the existing `PatchTechTree` Info line.
+- **Assessed and left as-is:** GhostMap `source-resolve` / `map-presence-pending-create` are already `VerboseOnChange`-coalesced per (recording, operation, decision); their volume is genuine decision-flips amplified by the test corpus, not a per-frame leak (covered by `LogSpamRateLimitTests`).
+- **Tests:** updated `LogSpamRateLimitTests` (3 `BuildSpawnSuppressedSummary` + 1 rate-limit-collapse), `FlightPlaybackExplainabilityTests` (new end-to-end batched-summary assertion + scratch-field wiring in the reflection host), `TreeLogVerificationTests` (C5 now asserts `Save` is silent), and the `EvaKerbalGhostHasVesselSnapshot` in-game canary (asserts the spawn decision directly instead of scraping the removed line). Full suite green except the environmental `InjectAllRecordings` dynamic-skip (KSP running, KSP.log locked).
+- **Status:** CLOSED 2026-06-02.
+
+---
+
 ## In progress - v0.10.0 Map/TS render tracer SECOND CUT: recordingId keying + decision-vs-truth reconciliation
 
 - Branch `maprender-second-cut` (off origin/main, which has the probe-only MVP from PR #1005). Design: `docs/dev/design-map-ts-render-tracer.md` (the second-cut sections). Builds the deferred reconciliation / shared-window / reverse-map work on top of the merged MVP.


### PR DESCRIPTION
Investigating the `2026-06-02_1856_maprender-checkpoint` capture (map-render tracer on) showed 86% of KSP.log was `[Parsek]` lines, with several per-recording / per-frame diagnostics scaling with the recording count. The 286-recording synthetic test corpus amplified them so badly that one in-game-test second emitted ~19,800 lines. The map-render tracer itself (`MapRenderTrace`, ~11k lines) was the acknowledged volume; these four sites were the spam beyond it.

## Fixes

- **Spawner "Spawn suppressed for #i" (worst burst: 4,802 lines in one second).** `ParsekFlight.ComputePlaybackFlags` emitted one `VerboseOnChange` line per committed recording per frame; the free-text reason oscillates frame-to-frame for some recordings (snapshot load/unload, `VesselSpawned` toggling), defeating the per-identity coalescing. Now accumulates a per-reason histogram across the loop and emits one `VerboseRateLimited` summary after it (`BuildSpawnSuppressedSummary`, pure + unit-tested).
- **GhostMap "Marker pos" (`ParsekUI.DrawMapMarkers`, 7,084 lines, ~93% `meshVsTraj=NaN`).** The loiter-seam debug diagnostic was always-on and mostly carried no usable comparison. Now gated behind `MapRenderTrace.IsEnabled` (silent + skips the per-frame probe in normal play, matching the sibling `EmitMarker` above it) and emitted only when a trajectory position exists to compare against.
- **RecordingTree per-tree "Save: tree=..." (3,965 lines).** One `Verbose` line per tree inside `ParsekScenario.SaveTreeRecordings`' committed-tree loop. Removed; the loop already logs a batched summary (now also carrying total branch points), and the single-tree active/pending callers log their own `Info` line.
- **KspStatePatcher "bypass rehydrate" (1,480 lines).** One `Verbose` line per available tech node (~80+) on every `PatchTechTree` recalc when bypass-entry-purchase is on. The helper now reports its stats to the caller via out params; the loop emits one summary after the existing Info line.

**Assessed and left as-is:** GhostMap `source-resolve` / `map-presence-pending-create` are already `VerboseOnChange`-coalesced per (recording, operation, decision); their volume is genuine decision-flips amplified by the test corpus, not a per-frame leak (covered by existing `LogSpamRateLimitTests`).

## Tests

- `LogSpamRateLimitTests`: 3 `BuildSpawnSuppressedSummary` cases + 1 rate-limit-collapse integration test (replacing the old per-recording faux-helper tests).
- `FlightPlaybackExplainabilityTests`: new end-to-end assertion that `ComputePlaybackFlags` emits one batched summary (and no per-recording line) + scratch-field wiring in the reflection host.
- `TreeLogVerificationTests`: C5 now asserts `Save` is silent while serialization still works.
- `EvaKerbalGhostHasVesselSnapshot` in-game canary: asserts the spawn decision directly (`ShouldSpawnAtRecordingEnd`) instead of scraping the removed per-recording line.

Build green, full unit suite green except the environmental `InjectAllRecordings` dynamic-skip (KSP running, KSP.log locked).

Targets `claude/maprender-rewrite` since it is stacked on that unmerged branch.