### PR TITLE
maprender(8b.0): extract per-leg polyline draw into a reusable helper (no behavior change)

### DIFF
--- a/Source/Parsek/Display/GhostTrajectoryPolylineRenderer.cs
+++ b/Source/Parsek/Display/GhostTrajectoryPolylineRenderer.cs
@@ -1149,6 +1149,225 @@ namespace Parsek.Display
             return PolylineStaticSkipReason.None;
         }
 
+        // ------------------------------------------------------------------
+        // Per-leg draw mechanics (Phase 8b.0 extraction)
+        //
+        // The single-leg build + conic-anchor + VectorLine submit pipeline,
+        // pulled OUT of the autonomous Driver's per-frame walk verbatim and
+        // parameterized on EXPLICIT inputs so a future TracedPathTreatment
+        // (Phase 8b.1) can draw one leg through the SAME code instead of going
+        // through the Driver's CommittedRecordings walk. The Driver now calls
+        // TryDrawLeg per leg, so its per-frame output is byte-identical to the
+        // pre-extraction inlined body (the code below IS that body, with the
+        // captured locals passed as arguments). This is a mechanical move +
+        // parameterization, not a logic change: no draw decision, no anchor
+        // math, no VectorLine state, and no activation/deactivation differs.
+        // ------------------------------------------------------------------
+
+        /// <summary>
+        /// Builds (lazily, once), positions, fills, conic-anchors, and draws a
+        /// single non-orbital leg's own VectorLine for ONE frame, exactly as the
+        /// Driver's per-leg inner loop did inline. Scene-agnostic: every input it
+        /// needs is passed explicitly (the resolved <paramref name="body"/>, the
+        /// owning <paramref name="rec"/> for the conic-anchor, the target
+        /// <paramref name="targetLayer"/> and <paramref name="drawFrame"/>, and the
+        /// <paramref name="recordingId"/> / <paramref name="legIndex"/> used only to
+        /// name the lazily-inflated line). Mutates <paramref name="leg"/> in place
+        /// (inflates <c>vectorLine</c>, fills <c>scratchScaledSpace</c>, stamps
+        /// <c>lastDrawnFrame</c>) so the caller writes the struct back into its
+        /// cached array, identical to the old <c>set.legs[li] = leg</c>.
+        ///
+        /// Returns true when the leg was drawn this frame (the old <c>anyDrawn</c>
+        /// signal), false when it was skipped because it has fewer than two points
+        /// or its VectorLine could not be inflated (identical skip conditions to the
+        /// inlined body; the body-missing skip stays at the call site since it owns
+        /// the body resolution + the rate-limited missing-body log).
+        /// </summary>
+        internal static bool TryDrawLeg(
+            ref LegPolyline leg, Recording rec, CelestialBody body,
+            int targetLayer, int drawFrame, string recordingId, int legIndex)
+        {
+            int m = leg.PointCount;
+            if (m < 2) return false;
+
+            // Inflate this leg's own VectorLine lazily. One line PER
+            // leg: a single shared line drawn once per leg via
+            // drawStart/drawEnd range slicing does NOT work, because
+            // VectorLine.Draw3D() zeroes every vertex outside the
+            // current window on each call, leaving only the last leg.
+            if (leg.vectorLine == null)
+                leg.vectorLine = BuildLegVectorLine(recordingId, legIndex, m);
+            if (leg.vectorLine == null) return false;
+
+            leg.vectorLine.rectTransform.gameObject.layer = targetLayer;
+
+            // Stable scaled-space placement: zero the line's transform
+            // every frame (matches OrbitRendererBase's REDRAW path,
+            // which sets OrbitLine.rectTransform.position = zero before
+            // each redraw). The points3 we feed are ABSOLUTE ScaledSpace
+            // positions, so the line's GameObject transform must be the
+            // identity; otherwise the mesh inherits its parent/canvas
+            // transform and visibly drifts as the map camera pans
+            // (it is not anchored in space). Position is the load-bearing
+            // reset; rotation/scale are pinned defensively.
+            var lineXform = leg.vectorLine.rectTransform;
+            lineXform.position = Vector3.zero;
+            lineXform.rotation = Quaternion.identity;
+            lineXform.localScale = Vector3.one;
+
+            // CRITICAL geometry (warp-strobe fix, take 2 - strobe-free AND never invisible).
+            // A body-fixed surface point must follow the planet's spin. Two failed approaches and
+            // why, from the strobe probe:
+            //   (a) ABSOLUTE: scratchScaledSpace[i] = LocalToScaledSpace(GetWorldSurfacePosition(.))
+            //       STROBES under warp into a parallel duplicate - ScaledSpace.totalOffset (the
+            //       scaled-origin recentering) oscillates every RENDER frame and our non-registered
+            //       VectorLine inherits it (|dPlive| up to ~750 scaled units, alternating with 0).
+            //   (b) FREEZE: capture each point in scaledBody-local once and re-project - kills the
+            //       strobe but goes INVISIBLE under warp, because a capture taken at a strobe phase
+            //       bakes a bad totalOffset into the local and lands the line off-screen until a
+            //       clean 1x recapture.
+            // The probe shows GetWorldSurfacePosition is frame-stable (|dWorld|=0) and
+            // scaledBody.transform is a registered ScaledSpace object whose position is frame-stable
+            // (|dPfrozen|~0). So build the point from the STABLE pieces only: the scaled body centre
+            // (scaledXform.position) plus the body-relative surface offset (world - body.position) *
+            // invScale. That offset is totalOffset- AND floating-origin-free (both terms live in the
+            // same frame, so it cancels), and equals LocalToScaledSpace(world) exactly when
+            // scaledXform.position == LocalToScaledSpace(body.position) - but it never touches the
+            // strobing totalOffset. Recomputed LIVE every frame: strobe-free at all warps, and with
+            // no capture it can never go stale / invisible. scaledXform also feeds the conic anchor.
+            var scaledBody = body.scaledBody;
+            Transform scaledXform = scaledBody != null ? scaledBody.transform : null;
+            if (scaledXform != null)
+            {
+                Vector3 bodyCentreScaled = scaledXform.position;
+                double invScale = ScaledSpace.InverseScaleFactor;
+                Vector3d bodyPos = body.position;
+                for (int i = 0; i < m; i++)
+                {
+                    Vector3d world = body.GetWorldSurfacePosition(
+                        leg.lats[i], leg.lons[i], leg.alts[i]);
+                    leg.scratchScaledSpace[i] = bodyCentreScaled
+                        + (Vector3)((world - bodyPos) * invScale);
+                }
+            }
+            else
+            {
+                // No scaled body available (should not happen in map view): fall back to the
+                // direct absolute path. Strobes under warp, but at least renders on the surface.
+                for (int i = 0; i < m; i++)
+                {
+                    Vector3d world = body.GetWorldSurfacePosition(
+                        leg.lats[i], leg.lons[i], leg.alts[i]);
+                    leg.scratchScaledSpace[i] =
+                        (Vector3)ScaledSpace.LocalToScaledSpace(world);
+                }
+            }
+
+            // CONIC ANCHOR: for a vacuum maneuver between two orbits (escape burn, orbit
+            // raise) rotate the captured body-fixed scaled points onto the faithful bracketing
+            // conic seam so the leg CONNECTS the loiter/hyperbola lines instead of drawing
+            // ~96 deg off under the loop shift. No-op for legs not bracketed both sides (launch
+            // ascent / descent-to-surface) and where body-fixed already matches the conic.
+            TryAnchorLegToConicSeam(rec, leg, body, scaledXform);
+
+            CopyLegIntoVectorLine(leg.vectorLine, leg.scratchScaledSpace, 0);
+            leg.vectorLine.drawStart = 0;
+            leg.vectorLine.drawEnd = m - 1;
+            // Reactivate if a prior frame's sweep hid this leg, then
+            // draw and stamp the frame. The single write-back below
+            // persists BOTH the lazily-inflated line AND the frame
+            // stamp into the cached array (set.legs is the same array
+            // reference the dict holds, so writing set.legs[li]
+            // carries through without re-storing the struct).
+            if (!leg.vectorLine.active) leg.vectorLine.active = true;
+            leg.vectorLine.Draw3D();
+            leg.lastDrawnFrame = drawFrame;
+            return true;
+        }
+
+        /// <summary>
+        /// Constructs a fresh per-leg <c>LineType.Continuous</c>
+        /// VectorLine sized to hold exactly this leg's points. One line
+        /// per leg (see <see cref="LegPolyline.vectorLine"/>): a single
+        /// shared line drawn once per leg via <c>drawStart</c>/<c>drawEnd</c>
+        /// range slicing does NOT work, because <c>Draw3D()</c> zeroes
+        /// every vertex outside the current window on each call. Uses
+        /// <c>MapView.OrbitLinesMaterial</c> (the SOLID stock orbit-line
+        /// material, NOT the dotted/dashed one) with the same 5f width and
+        /// distance/direction fade, so each leg reads as one unbroken
+        /// orbit-style line with no dashes, gaps, or interruptions (mirrors
+        /// <c>OrbitRendererBase.MakeLine</c>). A per-line vertex colour via
+        /// <see cref="VectorLine.SetColor(Color)"/> is set to the EXACT stock
+        /// vessel orbit-line grey so the polyline matches the ghost's own
+        /// orbit arcs; being a per-line colour it does not mutate the shared
+        /// material (which would dim every stock orbit line).
+        /// </summary>
+        internal static VectorLine BuildLegVectorLine(
+            string recordingId, int legIndex, int pointCount)
+        {
+            if (pointCount <= 0) return null;
+            var points = new List<Vector3>(pointCount);
+            for (int i = 0; i < pointCount; i++)
+                points.Add(Vector3.zero);
+            var line = new VectorLine(
+                "ParsekGhostTrajectoryPolyline-" + recordingId + "-leg" + legIndex,
+                points,
+                5f,
+                LineType.Continuous);
+            // Match the stock map orbit line exactly: a SOLID continuous line
+            // via MapView.OrbitLinesMaterial (NOT the dotted/dashed material),
+            // the same 5f width and the same distance/direction fade, so the
+            // ghost's non-orbital path reads as one unbroken orbit-style line
+            // with no dashes, gaps, or interruptions. Mirrors
+            // OrbitRendererBase.MakeLine. _FadeStrength / _FadeSign are global
+            // GameSettings values set on the SHARED material (idempotent:
+            // stock sets the same values every time it makes an orbit line),
+            // so this does not disturb real orbit lines.
+            Material orbitMat = MapView.OrbitLinesMaterial;
+            if (orbitMat != null)
+            {
+                line.texture = orbitMat.mainTexture;
+                line.material = orbitMat;
+                orbitMat.SetFloat("_FadeStrength", GameSettings.ORBIT_FADE_STRENGTH);
+                orbitMat.SetFloat("_FadeSign",
+                    GameSettings.ORBIT_FADE_DIRECTION_INV ? -1f : 1f);
+            }
+            line.continuousTexture = true;
+            line.UpdateImmediate = true;
+            // EXACT stock vessel orbit-line colour so the polyline is
+            // indistinguishable from the ghost's own orbit arcs: KSP's
+            // OrbitRenderer seeds an unfocused vessel with
+            // SetColor(new Color(0.71,0.71,0.71,1)) and draws the line at
+            // orbitColor = nodeColor * 0.5 (alpha preserved) with lineOpacity
+            // 1 (OrbitRenderer.GetOrbitColour / OrbitRendererBase), i.e. the
+            // mid-grey below. Per-line vertex colour, so the shared
+            // OrbitLinesMaterial is left untouched.
+            Color stockNode = new Color(0.71f, 0.71f, 0.71f, 1f);
+            Color stockOrbit = stockNode * 0.5f;
+            stockOrbit.a = stockNode.a;
+            line.SetColor(stockOrbit);
+            return line;
+        }
+
+        /// <summary>
+        /// Copies a leg's scratch <c>Vector3[]</c> into the leg's own
+        /// VectorLine's <c>points3</c> list starting at the given offset
+        /// (0 for per-leg lines).
+        /// </summary>
+        internal static void CopyLegIntoVectorLine(
+            VectorLine line, Vector3[] scratch, int startIdx)
+        {
+            if (line == null || scratch == null) return;
+            var points3 = line.points3;
+            if (points3 == null) return;
+            for (int i = 0; i < scratch.Length; i++)
+            {
+                int dst = startIdx + i;
+                if (dst < 0 || dst >= points3.Count) continue;
+                points3[dst] = scratch[i];
+            }
+        }
+
         /// <summary>
         /// Scene-wide MonoBehaviour that performs the per-frame walk over
         /// <c>RecordingStore.CommittedRecordings</c>, refreshes the cache
@@ -1442,101 +1661,20 @@ namespace Parsek.Display
                             frameSkippedNoBody++;
                             continue;
                         }
-                        int m = leg.PointCount;
-                        if (m < 2) continue;
 
-                        // Inflate this leg's own VectorLine lazily. One line PER
-                        // leg: a single shared line drawn once per leg via
-                        // drawStart/drawEnd range slicing does NOT work, because
-                        // VectorLine.Draw3D() zeroes every vertex outside the
-                        // current window on each call, leaving only the last leg.
-                        if (leg.vectorLine == null)
-                            leg.vectorLine = BuildLegVectorLine(rec.RecordingId, li, m);
-                        if (leg.vectorLine == null) continue;
-
-                        leg.vectorLine.rectTransform.gameObject.layer = targetLayer;
-
-                        // Stable scaled-space placement: zero the line's transform
-                        // every frame (matches OrbitRendererBase's REDRAW path,
-                        // which sets OrbitLine.rectTransform.position = zero before
-                        // each redraw). The points3 we feed are ABSOLUTE ScaledSpace
-                        // positions, so the line's GameObject transform must be the
-                        // identity; otherwise the mesh inherits its parent/canvas
-                        // transform and visibly drifts as the map camera pans
-                        // (it is not anchored in space). Position is the load-bearing
-                        // reset; rotation/scale are pinned defensively.
-                        var lineXform = leg.vectorLine.rectTransform;
-                        lineXform.position = Vector3.zero;
-                        lineXform.rotation = Quaternion.identity;
-                        lineXform.localScale = Vector3.one;
-
-                        // CRITICAL geometry (warp-strobe fix, take 2 - strobe-free AND never invisible).
-                        // A body-fixed surface point must follow the planet's spin. Two failed approaches and
-                        // why, from the strobe probe:
-                        //   (a) ABSOLUTE: scratchScaledSpace[i] = LocalToScaledSpace(GetWorldSurfacePosition(.))
-                        //       STROBES under warp into a parallel duplicate - ScaledSpace.totalOffset (the
-                        //       scaled-origin recentering) oscillates every RENDER frame and our non-registered
-                        //       VectorLine inherits it (|dPlive| up to ~750 scaled units, alternating with 0).
-                        //   (b) FREEZE: capture each point in scaledBody-local once and re-project - kills the
-                        //       strobe but goes INVISIBLE under warp, because a capture taken at a strobe phase
-                        //       bakes a bad totalOffset into the local and lands the line off-screen until a
-                        //       clean 1x recapture.
-                        // The probe shows GetWorldSurfacePosition is frame-stable (|dWorld|=0) and
-                        // scaledBody.transform is a registered ScaledSpace object whose position is frame-stable
-                        // (|dPfrozen|~0). So build the point from the STABLE pieces only: the scaled body centre
-                        // (scaledXform.position) plus the body-relative surface offset (world - body.position) *
-                        // invScale. That offset is totalOffset- AND floating-origin-free (both terms live in the
-                        // same frame, so it cancels), and equals LocalToScaledSpace(world) exactly when
-                        // scaledXform.position == LocalToScaledSpace(body.position) - but it never touches the
-                        // strobing totalOffset. Recomputed LIVE every frame: strobe-free at all warps, and with
-                        // no capture it can never go stale / invisible. scaledXform also feeds the conic anchor.
-                        var scaledBody = body.scaledBody;
-                        Transform scaledXform = scaledBody != null ? scaledBody.transform : null;
-                        if (scaledXform != null)
-                        {
-                            Vector3 bodyCentreScaled = scaledXform.position;
-                            double invScale = ScaledSpace.InverseScaleFactor;
-                            Vector3d bodyPos = body.position;
-                            for (int i = 0; i < m; i++)
-                            {
-                                Vector3d world = body.GetWorldSurfacePosition(
-                                    leg.lats[i], leg.lons[i], leg.alts[i]);
-                                leg.scratchScaledSpace[i] = bodyCentreScaled
-                                    + (Vector3)((world - bodyPos) * invScale);
-                            }
-                        }
-                        else
-                        {
-                            // No scaled body available (should not happen in map view): fall back to the
-                            // direct absolute path. Strobes under warp, but at least renders on the surface.
-                            for (int i = 0; i < m; i++)
-                            {
-                                Vector3d world = body.GetWorldSurfacePosition(
-                                    leg.lats[i], leg.lons[i], leg.alts[i]);
-                                leg.scratchScaledSpace[i] =
-                                    (Vector3)ScaledSpace.LocalToScaledSpace(world);
-                            }
-                        }
-
-                        // CONIC ANCHOR: for a vacuum maneuver between two orbits (escape burn, orbit
-                        // raise) rotate the captured body-fixed scaled points onto the faithful bracketing
-                        // conic seam so the leg CONNECTS the loiter/hyperbola lines instead of drawing
-                        // ~96 deg off under the loop shift. No-op for legs not bracketed both sides (launch
-                        // ascent / descent-to-surface) and where body-fixed already matches the conic.
-                        TryAnchorLegToConicSeam(rec, leg, body, scaledXform);
-
-                        CopyLegIntoVectorLine(leg.vectorLine, leg.scratchScaledSpace, 0);
-                        leg.vectorLine.drawStart = 0;
-                        leg.vectorLine.drawEnd = m - 1;
-                        // Reactivate if a prior frame's sweep hid this leg, then
-                        // draw and stamp the frame. The single write-back below
-                        // persists BOTH the lazily-inflated line AND the frame
-                        // stamp into the cached array (set.legs is the same array
-                        // reference the dict holds, so writing set.legs[li]
-                        // carries through without re-storing the struct).
-                        if (!leg.vectorLine.active) leg.vectorLine.active = true;
-                        leg.vectorLine.Draw3D();
-                        leg.lastDrawnFrame = drawFrame;
+                        // Per-leg build + conic-anchor + VectorLine draw mechanics,
+                        // extracted (Phase 8b.0) into the scene-agnostic
+                        // GhostTrajectoryPolylineRenderer.TryDrawLeg so a future
+                        // TracedPathTreatment can draw a single leg through the SAME
+                        // code. The extracted method is the verbatim old inlined body
+                        // with these locals passed in, so the per-frame output is
+                        // byte-identical: same scaled-space points, same conic-anchor
+                        // decisions, same VectorLine state, same activation, same frame
+                        // stamp. It mutates leg in place (line/scratch/lastDrawnFrame);
+                        // the single write-back below persists that into the cached
+                        // array exactly as before.
+                        if (!TryDrawLeg(ref leg, rec, body, targetLayer, drawFrame, rec.RecordingId, li))
+                            continue;
                         set.legs[li] = leg;
                         anyDrawn = true;
                     }
@@ -1712,89 +1850,6 @@ namespace Parsek.Display
                     cachedControllerScene = scene;
                 }
                 return cachedFlightController;
-            }
-
-            /// <summary>
-            /// Constructs a fresh per-leg <c>LineType.Continuous</c>
-            /// VectorLine sized to hold exactly this leg's points. One line
-            /// per leg (see <see cref="LegPolyline.vectorLine"/>): a single
-            /// shared line drawn once per leg via <c>drawStart</c>/<c>drawEnd</c>
-            /// range slicing does NOT work, because <c>Draw3D()</c> zeroes
-            /// every vertex outside the current window on each call. Uses
-            /// <c>MapView.OrbitLinesMaterial</c> (the SOLID stock orbit-line
-            /// material, NOT the dotted/dashed one) with the same 5f width and
-            /// distance/direction fade, so each leg reads as one unbroken
-            /// orbit-style line with no dashes, gaps, or interruptions (mirrors
-            /// <c>OrbitRendererBase.MakeLine</c>). A per-line vertex colour via
-            /// <see cref="VectorLine.SetColor(Color)"/> is set to the EXACT stock
-            /// vessel orbit-line grey so the polyline matches the ghost's own
-            /// orbit arcs; being a per-line colour it does not mutate the shared
-            /// material (which would dim every stock orbit line).
-            /// </summary>
-            private static VectorLine BuildLegVectorLine(
-                string recordingId, int legIndex, int pointCount)
-            {
-                if (pointCount <= 0) return null;
-                var points = new List<Vector3>(pointCount);
-                for (int i = 0; i < pointCount; i++)
-                    points.Add(Vector3.zero);
-                var line = new VectorLine(
-                    "ParsekGhostTrajectoryPolyline-" + recordingId + "-leg" + legIndex,
-                    points,
-                    5f,
-                    LineType.Continuous);
-                // Match the stock map orbit line exactly: a SOLID continuous line
-                // via MapView.OrbitLinesMaterial (NOT the dotted/dashed material),
-                // the same 5f width and the same distance/direction fade, so the
-                // ghost's non-orbital path reads as one unbroken orbit-style line
-                // with no dashes, gaps, or interruptions. Mirrors
-                // OrbitRendererBase.MakeLine. _FadeStrength / _FadeSign are global
-                // GameSettings values set on the SHARED material (idempotent:
-                // stock sets the same values every time it makes an orbit line),
-                // so this does not disturb real orbit lines.
-                Material orbitMat = MapView.OrbitLinesMaterial;
-                if (orbitMat != null)
-                {
-                    line.texture = orbitMat.mainTexture;
-                    line.material = orbitMat;
-                    orbitMat.SetFloat("_FadeStrength", GameSettings.ORBIT_FADE_STRENGTH);
-                    orbitMat.SetFloat("_FadeSign",
-                        GameSettings.ORBIT_FADE_DIRECTION_INV ? -1f : 1f);
-                }
-                line.continuousTexture = true;
-                line.UpdateImmediate = true;
-                // EXACT stock vessel orbit-line colour so the polyline is
-                // indistinguishable from the ghost's own orbit arcs: KSP's
-                // OrbitRenderer seeds an unfocused vessel with
-                // SetColor(new Color(0.71,0.71,0.71,1)) and draws the line at
-                // orbitColor = nodeColor * 0.5 (alpha preserved) with lineOpacity
-                // 1 (OrbitRenderer.GetOrbitColour / OrbitRendererBase), i.e. the
-                // mid-grey below. Per-line vertex colour, so the shared
-                // OrbitLinesMaterial is left untouched.
-                Color stockNode = new Color(0.71f, 0.71f, 0.71f, 1f);
-                Color stockOrbit = stockNode * 0.5f;
-                stockOrbit.a = stockNode.a;
-                line.SetColor(stockOrbit);
-                return line;
-            }
-
-            /// <summary>
-            /// Copies a leg's scratch <c>Vector3[]</c> into the leg's own
-            /// VectorLine's <c>points3</c> list starting at the given offset
-            /// (0 for per-leg lines).
-            /// </summary>
-            private static void CopyLegIntoVectorLine(
-                VectorLine line, Vector3[] scratch, int startIdx)
-            {
-                if (line == null || scratch == null) return;
-                var points3 = line.points3;
-                if (points3 == null) return;
-                for (int i = 0; i < scratch.Length; i++)
-                {
-                    int dst = startIdx + i;
-                    if (dst < 0 || dst >= points3.Count) continue;
-                    points3[dst] = scratch[i];
-                }
             }
 
             /// <summary>

--- a/Source/Parsek/InGameTests/RuntimeTests.cs
+++ b/Source/Parsek/InGameTests/RuntimeTests.cs
@@ -9570,6 +9570,84 @@ namespace Parsek.InGameTests
                     + dist.ToString("R", System.Globalization.CultureInfo.InvariantCulture) + "m)");
             }
         }
+
+        /// <summary>
+        /// Phase 8b.0 extraction coverage (the Unity/Vectrosity-coupled draw
+        /// mechanics xUnit cannot reach). Exercises the extracted scene-agnostic
+        /// <see cref="Parsek.Display.GhostTrajectoryPolylineRenderer.TryDrawLeg"/>
+        /// with a LIVE CelestialBody + a real Vectrosity VectorLine, confirming the
+        /// extracted single-leg pipeline (lazy line inflate, scaled-space fill,
+        /// conic-anchor, Draw3D submit, frame stamp) runs end-to-end OUTSIDE the
+        /// Driver's per-frame walk: this is exactly the call shape a future
+        /// TracedPathTreatment (8b.1) uses to draw one leg. Builds one Absolute
+        /// ascent leg, calls TryDrawLeg directly, and asserts it reported drawn,
+        /// inflated + activated its own line, filled the scaled-space scratch, and
+        /// stamped the supplied draw frame.
+        /// </summary>
+        [InGameTest(Category = "GhostMap", Scene = GameScenes.TRACKSTATION,
+            Description = "Extracted TryDrawLeg draws a single leg through a live VectorLine (Phase 8b.0)")]
+        public void GhostTrajectoryPolyline_TryDrawLeg_DrawsSingleLeg()
+        {
+            var rec = new Recording { RecordingId = "ingame-trydrawleg-1" };
+            var frames = new System.Collections.Generic.List<TrajectoryPoint>
+            {
+                new TrajectoryPoint { ut = 100.0, latitude = -0.1, longitude = -74.5, altitude = 70.0, bodyName = "Kerbin", rotation = Quaternion.identity },
+                new TrajectoryPoint { ut = 200.0, latitude = -0.05, longitude = -74.5, altitude = 20000.0, bodyName = "Kerbin", rotation = Quaternion.identity },
+                new TrajectoryPoint { ut = 600.0, latitude = 0.0, longitude = -74.5, altitude = 100000.0, bodyName = "Kerbin", rotation = Quaternion.identity },
+            };
+            rec.TrackSections.Add(new TrackSection
+            {
+                environment = SegmentEnvironment.Atmospheric,
+                referenceFrame = ReferenceFrame.Absolute,
+                source = TrackSectionSource.Active,
+                startUT = 100.0,
+                endUT = 600.0,
+                frames = frames,
+                checkpoints = new System.Collections.Generic.List<OrbitSegment>(),
+                bodyFixedFrames = null,
+                sampleRateHz = 10f,
+            });
+
+            var legs = Parsek.Display.GhostTrajectoryPolylineRenderer.BuildLegsForRecording(rec);
+            InGameAssert.AreEqual(1, legs.Count, "expected one leg from one Absolute section");
+
+            CelestialBody kerbin = FlightGlobals.Bodies.Find(b => b.name == "Kerbin");
+            InGameAssert.IsTrue(kerbin != null, "Kerbin body must resolve");
+
+            var leg = legs[0];
+            int drawFrame = Time.frameCount;
+            bool drawn = Parsek.Display.GhostTrajectoryPolylineRenderer.TryDrawLeg(
+                ref leg, rec, kerbin, /*targetLayer*/ 31, drawFrame, rec.RecordingId, /*legIndex*/ 0);
+
+            try
+            {
+                InGameAssert.IsTrue(drawn, "TryDrawLeg must report the leg drawn for a 3-point leg");
+                InGameAssert.IsTrue(leg.vectorLine != null, "TryDrawLeg must lazily inflate the leg's VectorLine");
+                InGameAssert.IsTrue(leg.vectorLine.active, "the drawn leg's VectorLine must be active");
+                InGameAssert.AreEqual(drawFrame, leg.lastDrawnFrame, "TryDrawLeg must stamp the supplied draw frame");
+                InGameAssert.IsTrue(leg.vectorLine.drawEnd == leg.PointCount - 1,
+                    "drawEnd must be the leg's last point index");
+
+                // The scaled-space scratch must be populated (non-zero for a real
+                // surface point) and the VectorLine points3 must mirror it - the
+                // same fill the Driver produces inline.
+                bool anyNonZero = false;
+                for (int i = 0; i < leg.PointCount; i++)
+                    if (leg.scratchScaledSpace[i] != Vector3.zero) { anyNonZero = true; break; }
+                InGameAssert.IsTrue(anyNonZero, "TryDrawLeg must fill the scaled-space scratch buffer");
+                InGameAssert.IsTrue(leg.vectorLine.points3 != null
+                    && leg.vectorLine.points3.Count == leg.PointCount,
+                    "the inflated VectorLine must hold exactly the leg's points");
+            }
+            finally
+            {
+                // Clean up the Vectrosity GameObject this isolated test created
+                // (the cache never saw this leg, so the renderer will not destroy it).
+                var line = leg.vectorLine;
+                if (line != null)
+                    Vectrosity.VectorLine.Destroy(ref line);
+            }
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Phase 8b.0 of the map / Tracking-Station render cutover: a pure refactor, **no behavior change**.

Extracts the autonomous polyline `Driver`'s per-leg draw mechanics (scaled-space build + the conic-anchor call + VectorLine inflate/fill/draw) out of its `LateUpdate` walk into scene-agnostic `internal static` helpers on `GhostTrajectoryPolylineRenderer`: `TryDrawLeg`, plus `BuildLegVectorLine` / `CopyLegIntoVectorLine` (moved verbatim). The `Driver` now calls `TryDrawLeg` in its loop; the extracted body is the old inlined loop verbatim with captured locals passed as args, so per-frame output is pixel-identical (`LegPolyline` is a struct; the `ref` + write-back preserve the same aliasing).

Groundwork for 8b.1, where `TracedPathTreatment` will draw a single leg via the same code (the Director taking over the polyline). No ownership signal touched (`IsRenderingNonOrbitalLeg` / `activeLegRecordings` unchanged); nothing wired to the treatment yet.

- Build clean; full xUnit suite 13371 pass; ERS/ELS GrepAudit green; the 57 polyline tests unchanged.
- In-game test `GhostTrajectoryPolyline_TryDrawLeg_DrawsSingleLeg` exercises the extracted helper outside the Driver's walk.
- Independent clean-context review: SHIP (verified behavior-identical, incl. the struct-aliasing and skip/counter semantics).