### PR TITLE
Logistics window polish: dark section subtitles + wider Name column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ All notable changes to Parsek are documented here.
 - The Active and Paused Routes tables now have clickable column headers (Name, Origin, Destination, Interval, Cyc, Next, Status, Delivery): click to sort, click again to reverse. The window also dropped its standalone Transit column to read narrower (transit time moved to the Interval cell tooltip and the detail panel).
 - The Candidates section now has its own header (Name, Origin, Destination, Would deliver, Transit) instead of borrowing the route table's columns, so a candidate no longer shows blank "-" cells for Interval, Cycles, Next, and Delivery or a placeholder "eligible" Status. The per-cycle delivery manifest is now visible directly in the table.
 - The Logistics window's section subtitles (Active Routes, Paused Routes, Candidates) now sit on the same dark background bar as the table column headers below them.
+- The Logistics window is 50 px wider so the route Name column has more room.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ All notable changes to Parsek are documented here.
 - In the Paused Routes section, a route that has never run reads "New (not yet run)" in cyan with a "use Send Once to test" hint, so it stands apart from a route you deliberately paused (which reads grey "Paused").
 - The Active and Paused Routes tables now have clickable column headers (Name, Origin, Destination, Interval, Cyc, Next, Status, Delivery): click to sort, click again to reverse. The window also dropped its standalone Transit column to read narrower (transit time moved to the Interval cell tooltip and the detail panel).
 - The Candidates section now has its own header (Name, Origin, Destination, Would deliver, Transit) instead of borrowing the route table's columns, so a candidate no longer shows blank "-" cells for Interval, Cycles, Next, and Delivery or a placeholder "eligible" Status. The per-cycle delivery manifest is now visible directly in the table.
+- The Logistics window's section subtitles (Active Routes, Paused Routes, Candidates) now sit on the same dark background bar as the table column headers below them.
 
 ### Bug Fixes
 

--- a/Source/Parsek/UI/LogisticsWindowUI.cs
+++ b/Source/Parsek/UI/LogisticsWindowUI.cs
@@ -1613,7 +1613,16 @@ namespace Parsek
                 };
             }
             GUILayout.Space(SpacingSmall);
+            // Nest the header label inside a skin box so the section-subtitle cell carries
+            // the SAME dark "box-on-box" background the column-header row has. The column
+            // header draws its box-styled cells INSIDE a BeginVertical(GUI.skin.box)
+            // container (two box layers, reading as a solid dark bar); a bare full-width
+            // box-label sits on only the window background (one layer) and looks lighter.
+            // Wrapping the label in a box horizontal adds the second box layer so the
+            // subtitle matches the table-header shade.
+            GUILayout.BeginHorizontal(GUI.skin.box);
             GUILayout.Label(text, sectionHeaderCenteredStyle, GUILayout.ExpandWidth(true));
+            GUILayout.EndHorizontal();
         }
         private GUIStyle sectionHeaderCenteredStyle;
 

--- a/Source/Parsek/UI/LogisticsWindowUI.cs
+++ b/Source/Parsek/UI/LogisticsWindowUI.cs
@@ -241,7 +241,7 @@ namespace Parsek
         // than its content. The remaining columns (Status / Destination) are candidates
         // for a further fold in a later pass; this L2 step does a conservative one-column
         // compression that is safe without in-game validation.
-        private const float MinWindowWidth = 1360f;
+        private const float MinWindowWidth = 1410f;
         private const float MinWindowHeight = 220f;
 
         public bool IsOpen


### PR DESCRIPTION
Two small cosmetic tweaks to the Logistics (Supply Routes) window, both deployed and eyeballed in-game.

- Section subtitles (Active Routes / Paused Routes / Candidates) now sit on the same dark background bar as the table column headers. The column header reads dark because its box cells draw inside a BeginVertical(GUI.skin.box) container (two box layers); the subtitle was a single bare box-label on the window background and looked lighter. Wrapping the subtitle label in a box horizontal adds the matching second layer.
- Window min width 1360 -> 1410 (+50 px). The route Name column uses ExpandWidth, so the extra width flows straight into it.

CHANGELOG updated under 0.10.0 / UI. No logic change, no tests affected; build clean, deployed DLL byte-verified.