### PR TITLE
maprender(8d.0): route flight map-presence tick through the scene adapter

### DIFF
--- a/Source/Parsek.Tests/MapRender/MapPresenceSeamTests.cs
+++ b/Source/Parsek.Tests/MapRender/MapPresenceSeamTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Phase 8d.0 source-gate for the map-presence adapter seam. The per-frame map-presence
+    /// (proto-vessel) tick must route through <c>IGhostMapScene.DriveMapPresence</c> instead of the
+    /// host calling <c>ParsekPlaybackPolicy.CheckPendingMapVessels</c> directly, and the FLIGHT scene's
+    /// <c>MapViewScene.DriveMapPresence</c> override must delegate VERBATIM to that same method.
+    ///
+    /// <para>The seam is byte-identical today (a pure indirection); these gates lock the wiring so a
+    /// later refactor cannot silently re-route the host back to the direct call or change the FLIGHT
+    /// override's delegation target. The scene-iterating drive itself is KSP-coupled (needs a live
+    /// <c>ParsekPlaybackPolicy</c> + Unity), so it is validated in-game; this is the Unity-free
+    /// equivalent, mirroring the <c>ChainSaveLoadTests.ChainStateNotPersistedInScenario</c>
+    /// source-gate pattern.</para>
+    /// </summary>
+    public class MapPresenceSeamTests
+    {
+        private static string ProjectRoot =>
+            Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory,
+                "..", "..", "..", "..", ".."));
+
+        private static string ReadSource(params string[] relativeParts)
+        {
+            string path = Path.Combine(ProjectRoot, Path.Combine(relativeParts));
+            if (!File.Exists(path))
+            {
+                // Fallback layout (mirrors ChainSaveLoadTests): some checkouts root at Parsek/.
+                var trimmed = new string[relativeParts.Length - 1];
+                Array.Copy(relativeParts, 1, trimmed, 0, trimmed.Length);
+                path = Path.Combine(ProjectRoot, Path.Combine(trimmed));
+            }
+            Assert.True(File.Exists(path), $"Source file not found at {path}");
+            return File.ReadAllText(path);
+        }
+
+        [Fact]
+        public void ParsekFlight_DrivesMapPresence_ThroughScene_NotPolicyDirectly()
+        {
+            string source = ReadSource("Source", "Parsek", "ParsekFlight.cs");
+
+            // The per-frame presence tick routes through the scene adapter seam...
+            Assert.Contains("mapViewScene.DriveMapPresence(", source);
+            // ...and the flight scene is injected with the presence driver during init.
+            Assert.Contains("mapViewScene.SetPresenceDriver(", source);
+
+            // ...and the host no longer CALLS CheckPendingMapVessels directly. Strip line comments
+            // first so the doc references in the seam comments (which legitimately name the method)
+            // don't trip the gate; the negative is about an actual call statement, not prose.
+            string codeOnly = StripLineComments(source);
+            Assert.DoesNotContain("policy.CheckPendingMapVessels(", codeOnly);
+        }
+
+        // Removes the trailing // line-comment from each line (string literals in this codebase do
+        // not contain "//", so a plain split is sufficient for this source-gate).
+        private static string StripLineComments(string source)
+        {
+            var sb = new System.Text.StringBuilder(source.Length);
+            foreach (string line in source.Split('\n'))
+            {
+                int idx = line.IndexOf("//", StringComparison.Ordinal);
+                sb.Append(idx >= 0 ? line.Substring(0, idx) : line);
+                sb.Append('\n');
+            }
+            return sb.ToString();
+        }
+
+        [Fact]
+        public void MapViewScene_DriveMapPresence_DelegatesToCheckPendingMapVessels()
+        {
+            string source = ReadSource("Source", "Parsek", "MapRender", "MapViewScene.cs");
+
+            // The FLIGHT override exists and delegates VERBATIM to CheckPendingMapVessels.
+            Assert.Contains("public override void DriveMapPresence(", source);
+            Assert.Contains("CheckPendingMapVessels(currentUT)", source);
+            // The presence driver is injected (the established SetFrameInputs-style wiring).
+            Assert.Contains("SetPresenceDriver(", source);
+        }
+
+        [Fact]
+        public void IGhostMapScene_Declares_DriveMapPresence()
+        {
+            string source = ReadSource("Source", "Parsek", "MapRender", "IGhostMapScene.cs");
+            Assert.Contains("void DriveMapPresence(double currentUT)", source);
+        }
+
+        [Fact]
+        public void TrackingStationScene_DriveMapPresence_DelegatesToLifecycle()
+        {
+            string source = ReadSource("Source", "Parsek", "MapRender", "TrackingStationScene.cs");
+
+            // The TS override exists for symmetry and delegates to the TS lifecycle pass.
+            Assert.Contains("public override void DriveMapPresence(", source);
+            Assert.Contains("UpdateTrackingStationGhostLifecycle(", source);
+        }
+    }
+}

--- a/Source/Parsek/MapRender/GhostMapSceneBase.cs
+++ b/Source/Parsek/MapRender/GhostMapSceneBase.cs
@@ -70,5 +70,10 @@ namespace Parsek.MapRender
         }
 
         public CelestialBody ResolveBody(string bodyName) => FlightGlobals.GetBodyByName(bodyName);
+
+        // Presence-drive differs per scene: FLIGHT runs the pending-queue model
+        // (ParsekPlaybackPolicy.CheckPendingMapVessels); the Tracking Station runs
+        // GhostMapPresence.UpdateTrackingStationGhostLifecycle. Each scene supplies its own body.
+        public abstract void DriveMapPresence(double currentUT);
     }
 }

--- a/Source/Parsek/MapRender/IGhostMapScene.cs
+++ b/Source/Parsek/MapRender/IGhostMapScene.cs
@@ -66,5 +66,16 @@ namespace Parsek.MapRender
 
         /// <summary>Resolve a body by name against the live bodies (null when unknown).</summary>
         CelestialBody ResolveBody(string bodyName);
+
+        /// <summary>
+        /// Drive this scene's per-frame ghost map-presence (proto-vessel) lifecycle at
+        /// <paramref name="currentUT"/>. The FLIGHT scene delegates to the pending-queue model
+        /// (<c>ParsekPlaybackPolicy.CheckPendingMapVessels</c>); the Tracking Station drives
+        /// <c>GhostMapPresence.UpdateTrackingStationGhostLifecycle</c>. This is the seam (Phase 8d.0)
+        /// that routes the host scene's presence tick through the scene adapter so the body can be
+        /// relocated behind the adapter later (Phase 8d.1); the override is byte-identical to the
+        /// direct host call today.
+        /// </summary>
+        void DriveMapPresence(double currentUT);
     }
 }

--- a/Source/Parsek/MapRender/MapViewScene.cs
+++ b/Source/Parsek/MapRender/MapViewScene.cs
@@ -11,6 +11,25 @@ namespace Parsek.MapRender
     /// </summary>
     internal sealed class MapViewScene : GhostMapSceneBase
     {
+        // The flight-scene presence driver. Injected by the owning ParsekFlight right after it builds
+        // the policy (SetPresenceDriver), the same way the controller pushes the per-frame inputs via
+        // SetFrameInputs. DriveMapPresence delegates here verbatim — the Phase 8d.0 seam is a pure
+        // indirection; relocating the CheckPendingMapVessels body behind the adapter is Phase 8d.1.
+        private ParsekPlaybackPolicy policy;
+
         public override bool IsActive => HighLogic.LoadedScene == GameScenes.FLIGHT;
+
+        /// <summary>Inject the flight-scene presence driver (called once by ParsekFlight after it builds the policy).</summary>
+        internal void SetPresenceDriver(ParsekPlaybackPolicy presenceDriver)
+        {
+            policy = presenceDriver;
+        }
+
+        // Byte-identical to the former direct ParsekFlight call site: same method, same argument, same
+        // execution-order slot, same surrounding try-catch. This is a pure pass-through (Phase 8d.0).
+        public override void DriveMapPresence(double currentUT)
+        {
+            policy?.CheckPendingMapVessels(currentUT);
+        }
     }
 }

--- a/Source/Parsek/MapRender/TrackingStationScene.cs
+++ b/Source/Parsek/MapRender/TrackingStationScene.cs
@@ -17,5 +17,15 @@ namespace Parsek.MapRender
     internal sealed class TrackingStationScene : GhostMapSceneBase
     {
         public override bool IsActive => HighLogic.LoadedScene == GameScenes.TRACKSTATION;
+
+        // TS presence-drive seam for symmetry with MapViewScene (Phase 8d.0). Delegates to the TS
+        // lifecycle pass, sampling the same per-frame loop units the base already carries
+        // (SetFrameInputs). NOT yet routed from ParsekTrackingStation — its existing direct
+        // UpdateTrackingStationGhostLifecycle(cachedLoopUnits) calls are untouched in 8d.0; routing
+        // the TS host through this seam is a later phase. Byte-identical to that direct call.
+        public override void DriveMapPresence(double currentUT)
+        {
+            GhostMapPresence.UpdateTrackingStationGhostLifecycle(LoopUnits);
+        }
     }
 }

--- a/Source/Parsek/ParsekFlight.cs
+++ b/Source/Parsek/ParsekFlight.cs
@@ -1143,6 +1143,9 @@ namespace Parsek
             engine.ResolvePlaybackDistanceOverride = ResolvePlaybackDistanceForEngine;
             engine.ResolvePlaybackActiveVesselDistanceOverride = ResolvePlaybackActiveVesselDistanceForEngine;
             policy = new ParsekPlaybackPolicy(engine, this);
+            // Phase 8d.0: route the per-frame map-presence tick through the scene adapter. The seam
+            // delegates verbatim to policy.CheckPendingMapVessels; relocating the body is Phase 8d.1.
+            mapViewScene.SetPresenceDriver(policy);
 
             // Clean up any orphaned toolbar from rapid scene transitions (e.g. rewind)
             if (toolbarControl != null)
@@ -18523,8 +18526,11 @@ namespace Parsek
             // waiting for a blocked/deferred spawn to resolve
             policy.RetryHeldGhostSpawns();
 
-            // Create deferred ghost map ProtoVessels when ghosts enter orbital segments
-            policy.CheckPendingMapVessels(Planetarium.GetUniversalTime());
+            // Create deferred ghost map ProtoVessels when ghosts enter orbital segments.
+            // Phase 8d.0: routed through the scene adapter; MapViewScene.DriveMapPresence delegates
+            // VERBATIM to policy.CheckPendingMapVessels(currentUT) with the identical argument. Pure
+            // indirection — same method, same arg, same slot, same surrounding guard/try-catch.
+            mapViewScene.DriveMapPresence(Planetarium.GetUniversalTime());
 
             // Phase 4 decision-only shadow: run the new map-render pipeline (chain -> sample -> intent)
             // over the live map ghosts and reconcile each intent against the OLD path's rendered truth

--- a/docs/dev/plans/maprender-8d-presence-extraction.md
+++ b/docs/dev/plans/maprender-8d-presence-extraction.md
@@ -1,0 +1,81 @@
+# Phase 8d - map-presence ownership migration into the scene adapter
+
+*Sub-plan of the map/TS render cutover (`docs/dev/plans/maprender-rewrite-status.md`,
+`docs/dev/plans/map-ts-render-rewrite-phases.md`). Phases 8a-8c are merged: the Director now owns the
+StockConic icon/line drive (8a + Cat-1), the TracedPath polyline leg ownership (8b), and the
+marker / icon-suppression decision (8c), all behind the `mapRenderDirectorDrive` gate. Phase 8d
+migrates the remaining big legacy surface, the ghost MAP-PRESENCE lifecycle, behind the same gate so
+that 8e can delete the legacy path and drop the gate.*
+
+## What 8d migrates
+
+The ghost map-presence lifecycle is the last large autonomous surface the Director does not own. Today
+it lives in `ParsekPlaybackPolicy.CheckPendingMapVessels` (about 660 lines) plus six presence
+dictionaries (`pendingMapVessels`, `lastMapOrbitByIndex`, `stateVectorOrbitTrajectories`,
+`stateVectorCachedIndices`, `soiGapStateVectorExpectedBodies`, `chainMapOwner`), an enqueue tail, and a
+scene-change teardown. The flight controller drives it once per playback frame via a direct
+`policy.CheckPendingMapVessels(...)` call. Tracking-station presence is driven separately through
+`GhostMapPresence.UpdateTrackingStationGhostLifecycle`.
+
+The migration target is `GhostMapPresence` (the existing ProtoVessel-lifecycle owner), reached through
+the `IGhostMapScene` adapter so the flight host stops calling the policy directly and the presence body
+moves out of `ParsekPlaybackPolicy` into the render layer.
+
+## Hard constraint - presence does NOT gate on the director drive
+
+The presence tick MUST run regardless of `mapRenderDirectorDrive` / `IsDirectorDriveActive`. The
+Director deliberately SKIPS re-aim and overlap members (the shadow can only resolve a single faithful
+pid->recording mapping); those ghosts still need their map presence created and torn down every frame.
+Gating presence on the director drive would silently drop them from the map. The gate in 8d selects
+only WHERE the identical presence work runs (legacy in-policy vs migrated in-GhostMapPresence), never
+WHETHER it runs.
+
+## Slicing
+
+### 8d.0 - adapter presence seam (DONE - no behavior change)
+Route the flight per-frame presence tick through the scene adapter instead of calling the policy
+directly. The `CheckPendingMapVessels` body and the six dictionaries stay exactly where they are; only
+the call path changes.
+
+- `IGhostMapScene.DriveMapPresence(double currentUT)` - new adapter member.
+- `GhostMapSceneBase` declares it `abstract` (the FLIGHT and TS bodies differ).
+- `MapViewScene` overrides it as `policy?.CheckPendingMapVessels(currentUT)`, with the policy injected
+  once at init via `SetPresenceDriver(policy)` (same injected-ref style as `SetFrameInputs`).
+- `TrackingStationScene` overrides it (delegating to `UpdateTrackingStationGhostLifecycle(LoopUnits)`)
+  for compile symmetry; NOT yet routed from any TS caller.
+- `ParsekFlight` calls `mapViewScene.DriveMapPresence(Planetarium.GetUniversalTime())` in the same
+  per-frame slot the direct call used (between `RetryHeldGhostSpawns()` and the shadow-driver block).
+
+Byte-identical: same method, same argument, same execution slot. `policy?.` cannot diverge from the old
+unconditional `policy.` because `SetPresenceDriver` runs unconditionally at init before any frame. No
+director gate added. Source-gate test `MapPresenceSeamTests` locks the host off the direct call.
+
+### 8d.1 - relocate the body (gated, legacy as gate-off fallback)
+Move the ~660-line `CheckPendingMapVessels` body and the six presence dictionaries into
+`GhostMapPresence.UpdateFlightMapGhostLifecycle`. Under `mapRenderDirectorDrive` the seam dispatches to
+the migrated body; with the gate off it dispatches to the legacy in-policy body (kept verbatim as the
+fallback, deleted in 8e). This is the riskiest slice: the body owns proto creation/destruction,
+state-vector orbit caching, SOI-gap handling, and chain map ownership. Expect multiple in-game
+validation cycles (looped re-aim "Duna One" + a non-looped Mun mission through landing), watching for
+any presence regression: a ghost that should be on the map vanishing, a stale ghost that should be torn
+down lingering, or a state-vector / SOI-gap glitch. Gate OFF must stay byte-identical.
+
+### 8d.2 - enqueue + teardown ownership
+Move the presence enqueue tail and the scene-change teardown into the same migrated owner, behind the
+same gate, legacy as the gate-off fallback.
+
+### 8d.3 - decompose + pure-extract
+Once the body lives in the render layer, split it into named sub-passes and extract the pure decision
+predicates (eligibility, retire, state-vector refresh) as `internal static` helpers with unit tests, so
+the migrated body is covered the way the rest of the pipeline is.
+
+### 8e - delete legacy + drop the gate (final, shared with the rest of the cutover)
+Delete the legacy in-policy presence body, the autonomous Driver walk, the
+`activeLegRecordings` / `ghostsWithSuppressedIcon` legacy fallbacks, and the grace fields; grep-audit no
+readers remain; remove the `mapRenderDirectorDrive` gate so the Director pipeline is the single default.
+
+## Validation discipline
+Every behavioral slice (8d.1 onward) is in-game gated by the maintainer before merge: build, deploy,
+verify the deployed DLL is the one just built (size+mtime + a UTF-16 log-string signature), run the two
+reference missions with the gate on, then toggle the gate off and confirm byte-identical legacy
+behavior. 8d.0 is structural (no behavior change), so it ships on review + green tests like 8b.0.

--- a/docs/dev/plans/maprender-rewrite-status.md
+++ b/docs/dev/plans/maprender-rewrite-status.md
@@ -269,6 +269,31 @@ reconciler for decision-vs-old-truth parity, and resolve the in-game probes befo
   to run:** s15 "Duna One" looped re-aim + a non-looped Mun mission through landing with
   `mapRenderDirectorDrive` on: marker present and riding the line on owned legs, no double marker, no blank
   frame at the TracedPath<->StockConic seam; toggle the gate OFF -> byte-identical to the legacy marker paths.
+- **Phase 8d - map-presence migration into the scene adapter (in progress).** Full sub-plan:
+  `docs/dev/plans/maprender-8d-presence-extraction.md`. Migrates the last big autonomous surface, the
+  ghost MAP-PRESENCE lifecycle (`ParsekPlaybackPolicy.CheckPendingMapVessels`, ~660 lines + 6 presence
+  dictionaries), into `GhostMapPresence` behind the same gate so 8e can delete the legacy path. **HARD
+  CONSTRAINT:** presence must NOT gate on `IsDirectorDriveActive` - the Director deliberately skips
+  re-aim / overlap members, which still need presence created + torn down every frame; the gate selects
+  only WHERE the identical work runs, never WHETHER it runs.
+  - **8d.0 - DONE (no behavior change).** Routed the flight per-frame presence tick through the scene
+    adapter instead of the direct policy call. New `IGhostMapScene.DriveMapPresence(double currentUT)`,
+    `abstract` on `GhostMapSceneBase`; `MapViewScene` overrides it as `policy?.CheckPendingMapVessels(
+    currentUT)` with the policy injected once at init via `SetPresenceDriver(policy)` (same style as
+    `SetFrameInputs`); `TrackingStationScene` overrides it for compile symmetry (delegating to
+    `UpdateTrackingStationGhostLifecycle(LoopUnits)`), NOT yet routed from any TS caller. `ParsekFlight`
+    now calls `mapViewScene.DriveMapPresence(Planetarium.GetUniversalTime())` in the SAME per-frame slot
+    the direct call used (between `RetryHeldGhostSpawns()` and the shadow-driver block). Byte-identical:
+    same method, same argument, same slot; `policy?.` cannot diverge from the old unconditional `policy.`
+    because `SetPresenceDriver` runs unconditionally at init before any frame; no director gate added.
+    The `CheckPendingMapVessels` body + the 6 dictionaries are UNTOUCHED (that is 8d.1). Source-gate test
+    `MapPresenceSeamTests` (4) locks the host off the direct call. Build clean; full suite green (13412).
+  - **8d.1 (next, single PR) - relocate the body.** Move `CheckPendingMapVessels` + the 6 dictionaries
+    into `GhostMapPresence.UpdateFlightMapGhostLifecycle`, gate ON -> migrated body, gate OFF -> legacy
+    in-policy body (verbatim fallback, deleted in 8e). Riskiest slice; multiple in-game validation cycles
+    (looped re-aim "Duna One" + a non-looped Mun mission through landing).
+  - **8d.2** - enqueue + scene-change teardown ownership (gated, legacy fallback).
+  - **8d.3** - decompose into named sub-passes + pure-extract predicates with unit tests.
 - **Phase 8** per-surface cutover (8a-8e) - deletes the scattered gates; in-game per sub-phase.
 - **Workstream B** B2 `IEncounterSolver` (wraps `CalculatePatch`, §15.4 test-gap decision) + B3
   `TransferConic` frame-agnostic return - touch the in-game-validated re-aim path.


### PR DESCRIPTION
## Phase 8d.0 - adapter presence seam (no behavior change)

First slice of phase 8d, which migrates the last big autonomous render surface (the ghost map-presence lifecycle) into the scene adapter behind the `mapRenderDirectorDrive` gate so phase 8e can delete the legacy path. Full sub-plan: `docs/dev/plans/maprender-8d-presence-extraction.md`.

8d.0 is the structural seam only. The flight controller stops calling `policy.CheckPendingMapVessels(...)` directly and drives map presence through the map-scene adapter. The ~660-line presence body and its 6 dictionaries are NOT moved (that is 8d.1).

### Change
- `IGhostMapScene`: new `DriveMapPresence(double currentUT)` member.
- `GhostMapSceneBase`: declares it `abstract` (the FLIGHT and TS bodies differ).
- `MapViewScene`: overrides it as `policy?.CheckPendingMapVessels(currentUT)`; the policy is injected once at init via `SetPresenceDriver` (same injected-ref style as `SetFrameInputs`).
- `TrackingStationScene`: overrides it for compile symmetry (delegates to `UpdateTrackingStationGhostLifecycle(LoopUnits)`); not yet routed from any TS caller, so the TS lifecycle path is unchanged.
- `ParsekFlight`: calls `mapViewScene.DriveMapPresence(Planetarium.GetUniversalTime())` in the same per-frame slot the direct call used (between `RetryHeldGhostSpawns()` and the shadow-driver block).

### Why it is byte-identical
Same method, same argument (`Planetarium.GetUniversalTime()` flows in as `currentUT`), same execution slot. `policy?.` cannot diverge from the old unconditional `policy.` because `SetPresenceDriver(policy)` runs unconditionally during `ParsekFlight` init before any playback frame, so the policy reference is always non-null when `DriveMapPresence` fires.

### Hard constraint preserved
No `IsDirectorDriveActive` / `mapRenderDirectorDrive` gate was added. Presence must run regardless of the director drive: the Director deliberately skips re-aim / overlap members, which still need their map presence created and torn down every frame. The seam selects only WHERE the identical work runs, never WHETHER it runs.

### Tests
- New source-gate `MapPresenceSeamTests` (4) locks the host off the direct call (mirrors `ChainSaveLoadTests.ChainStateNotPersistedInScenario`; a true runtime drive needs a live policy + Unity, validated in-game like the existing shadow-driver path).
- Build clean (0 warnings / 0 errors). Full suite green: 13412 passed, 0 failed, 0 skipped (+4). GrepAudit (ERS/ELS) clean.

Reviewed in a clean context: same method / same arg / same slot, `policy?.` non-divergence, no director gate, TS override inert, diff scoped to the 5 MapRender/ParsekFlight files + the new test + the plan/status docs.