### PR TITLE
maprender(8d.1): relocate the flight map-presence lifecycle into GhostMapPresence

### DIFF
--- a/Source/Parsek.Tests/MapRender/MapPresenceSeamTests.cs
+++ b/Source/Parsek.Tests/MapRender/MapPresenceSeamTests.cs
@@ -5,17 +5,21 @@ using Xunit;
 namespace Parsek.Tests
 {
     /// <summary>
-    /// Phase 8d.0 source-gate for the map-presence adapter seam. The per-frame map-presence
-    /// (proto-vessel) tick must route through <c>IGhostMapScene.DriveMapPresence</c> instead of the
-    /// host calling <c>ParsekPlaybackPolicy.CheckPendingMapVessels</c> directly, and the FLIGHT scene's
-    /// <c>MapViewScene.DriveMapPresence</c> override must delegate VERBATIM to that same method.
+    /// Phase 8d.0 / 8d.1 source-gate for the map-presence adapter seam. The per-frame map-presence
+    /// (proto-vessel) tick routes through <c>IGhostMapScene.DriveMapPresence</c> instead of the host
+    /// calling the policy directly. Phase 8d.1 relocated the former
+    /// <c>ParsekPlaybackPolicy.CheckPendingMapVessels</c> body wholesale into
+    /// <c>GhostMapPresence.UpdateFlightMapGhostLifecycle</c> (a faithful move, no behavior change, no
+    /// gate); the FLIGHT scene's <c>MapViewScene.DriveMapPresence</c> override now calls that directly,
+    /// threading the policy's exact per-frame loop units via <c>CurrentLoopUnitsForPresence</c>.
     ///
-    /// <para>The seam is byte-identical today (a pure indirection); these gates lock the wiring so a
-    /// later refactor cannot silently re-route the host back to the direct call or change the FLIGHT
-    /// override's delegation target. The scene-iterating drive itself is KSP-coupled (needs a live
-    /// <c>ParsekPlaybackPolicy</c> + Unity), so it is validated in-game; this is the Unity-free
-    /// equivalent, mirroring the <c>ChainSaveLoadTests.ChainStateNotPersistedInScenario</c>
-    /// source-gate pattern.</para>
+    /// <para>These gates lock the new structure so a later refactor cannot silently (a) re-route the
+    /// host back to a direct policy call, (b) duplicate the presence dicts back into the policy, or
+    /// (c) sneak a director-drive gate into the relocated presence body (presence is behavior-identical
+    /// across the cutover, so it must never branch on <c>IsDirectorDriveActive</c> /
+    /// <c>IsDirectorTracedPathActive</c>). The relocated body is Unity/proto-coupled (needs a live KSP),
+    /// so it is validated in-game; this is the Unity-free equivalent, mirroring the
+    /// <c>ChainSaveLoadTests.ChainStateNotPersistedInScenario</c> source-gate pattern.</para>
     /// </summary>
     public class MapPresenceSeamTests
     {
@@ -69,15 +73,84 @@ namespace Parsek.Tests
         }
 
         [Fact]
-        public void MapViewScene_DriveMapPresence_DelegatesToCheckPendingMapVessels()
+        public void MapViewScene_DriveMapPresence_DelegatesToGhostMapPresenceLifecycle()
         {
             string source = ReadSource("Source", "Parsek", "MapRender", "MapViewScene.cs");
 
-            // The FLIGHT override exists and delegates VERBATIM to CheckPendingMapVessels.
+            // The FLIGHT override exists and now drives the relocated GhostMapPresence lifecycle
+            // directly (Phase 8d.1), threading the policy's exact per-frame loop units.
             Assert.Contains("public override void DriveMapPresence(", source);
-            Assert.Contains("CheckPendingMapVessels(currentUT)", source);
-            // The presence driver is injected (the established SetFrameInputs-style wiring).
+            Assert.Contains("GhostMapPresence.UpdateFlightMapGhostLifecycle(", source);
+            Assert.Contains("CurrentLoopUnitsForPresence", source);
+            // The presence driver (policy, the loop-units source) is still injected.
             Assert.Contains("SetPresenceDriver(", source);
+
+            // ...and the override no longer routes back through the deleted policy method.
+            string codeOnly = StripLineComments(source);
+            Assert.DoesNotContain("CheckPendingMapVessels(", codeOnly);
+        }
+
+        [Fact]
+        public void GhostMapPresence_Declares_UpdateFlightMapGhostLifecycle()
+        {
+            string source = ReadSource("Source", "Parsek", "GhostMapPresence.cs");
+
+            // The relocated per-frame flight presence body lives here as an internal static method.
+            Assert.Contains("internal static void UpdateFlightMapGhostLifecycle(", source);
+        }
+
+        [Fact]
+        public void ParsekPlaybackPolicy_NoLongerOwns_MapPresenceBodyOrDicts()
+        {
+            string source = ReadSource("Source", "Parsek", "ParsekPlaybackPolicy.cs");
+            string codeOnly = StripLineComments(source);
+
+            // The per-frame body is gone (wholesale move, not a copy). The doc/seam comments still
+            // legitimately name the method, so strip line comments before the negative.
+            Assert.DoesNotContain("void CheckPendingMapVessels(", codeOnly);
+
+            // The 6 presence dicts moved wholesale to GhostMapPresence (proving move, not
+            // duplication). Match the field declaration shapes that were unique to those dicts.
+            Assert.DoesNotContain("Dictionary<int, PendingMapVessel>", codeOnly);
+            Assert.DoesNotContain("Dictionary<int, IPlaybackTrajectory> stateVectorOrbitTrajectories", codeOnly);
+            Assert.DoesNotContain("Dictionary<int, int> stateVectorCachedIndices", codeOnly);
+            Assert.DoesNotContain("Dictionary<string, int> chainMapOwner", codeOnly);
+            Assert.DoesNotContain("Dictionary<int, (string body, double sma, double ecc)> lastMapOrbitByIndex", codeOnly);
+            Assert.DoesNotContain("Dictionary<int, string> soiGapStateVectorExpectedBodies", codeOnly);
+
+            // The loop-units pass-through the scene needs is exposed.
+            Assert.Contains("CurrentLoopUnitsForPresence", source);
+        }
+
+        [Fact]
+        public void UpdateFlightMapGhostLifecycle_DoesNotGateOnDirectorDrive()
+        {
+            string source = ReadSource("Source", "Parsek", "GhostMapPresence.cs");
+            // Bound the body region between this method's signature and the next method declaration
+            // (PruneTerminalMapRetentionLogKeys is the next member after the relocated body). This
+            // avoids brace counting, which the body's string-literal {0}/{idx} placeholders would
+            // otherwise unbalance.
+            string body = ExtractMethodRegion(
+                source,
+                "internal static void UpdateFlightMapGhostLifecycle(",
+                "private static void PruneTerminalMapRetentionLogKeys(");
+
+            // Presence is behavior-identical across the map-render cutover; the relocated body must
+            // never branch on the director-drive / traced-path gate (no mapRenderDirectorDrive branch).
+            Assert.DoesNotContain("IsDirectorDriveActive", body);
+            Assert.DoesNotContain("IsDirectorTracedPathActive", body);
+        }
+
+        // Returns the source slice from <paramref name="startNeedle"/> up to (not including) the next
+        // occurrence of <paramref name="endNeedle"/>. Used to bound a method body by the following
+        // method's signature, sidestepping brace counting that string-literal braces would break.
+        private static string ExtractMethodRegion(string source, string startNeedle, string endNeedle)
+        {
+            int start = source.IndexOf(startNeedle, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Method signature not found: {startNeedle}");
+            int end = source.IndexOf(endNeedle, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Region end signature not found after start: {endNeedle}");
+            return source.Substring(start, end - start);
         }
 
         [Fact]

--- a/Source/Parsek/GhostMapPresence.cs
+++ b/Source/Parsek/GhostMapPresence.cs
@@ -9997,5 +9997,887 @@ namespace Parsek
                     typeStr));
             return VesselType.Ship;
         }
+
+        // ===================================================================================
+        // Flight-scene map-presence lifecycle (Phase 8d.1 relocation from ParsekPlaybackPolicy).
+        // FAITHFUL MOVE — the body, struct, dicts, scalars, and dict-touching helpers below were
+        // copied VERBATIM from ParsekPlaybackPolicy.CheckPendingMapVessels and its helpers. The
+        // only edits are: (a) engine.CurrentLoopUnits -> the loopUnits parameter, and (b) the
+        // internal-static ShouldRunMapOrbitReseed / TryResolveTerminalFallbackMapOrbitUpdate /
+        // ShouldRetainMapPresenceForTerminalRealSpawn helpers (left in ParsekPlaybackPolicy per the
+        // plan) are now qualified with ParsekPlaybackPolicy. — those helpers' bodies are unchanged.
+        // The fields use a flight* prefix to mirror the trackingStation* twin naming. They are
+        // internal (not private) because the still-in-policy enqueue tail + teardowns reach them
+        // until Phase 8d.2 relocates those too.
+        // ===================================================================================
+
+        /// <summary>
+        /// Recording indices eligible for ghost map ProtoVessels but deferred until
+        /// the ghost enters an orbital segment. Avoids showing orbit lines during
+        /// atmospheric ascent when the ghost mesh is still on the pad.
+        /// </summary>
+        internal struct PendingMapVessel
+        {
+            internal IPlaybackTrajectory Trajectory;
+            internal bool AllowSoiGapStateVectorFallback;
+            internal string ExpectedSoiGapBody;
+
+            internal PendingMapVessel(
+                IPlaybackTrajectory trajectory,
+                bool allowSoiGapStateVectorFallback,
+                string expectedSoiGapBody)
+            {
+                Trajectory = trajectory;
+                AllowSoiGapStateVectorFallback = allowSoiGapStateVectorFallback;
+                ExpectedSoiGapBody = expectedSoiGapBody;
+            }
+        }
+
+        internal static readonly Dictionary<int, PendingMapVessel> flightPendingMapVessels =
+            new Dictionary<int, PendingMapVessel>();
+
+        internal static readonly Dictionary<int, string> flightSoiGapStateVectorExpectedBodies =
+            new Dictionary<int, string>();
+
+        /// <summary>
+        /// Tracks the last orbit segment body+SMA per recording index for change detection.
+        /// Used to update the ghost ProtoVessel orbit as the ghost traverses segments.
+        /// </summary>
+        private const float MapOrbitUpdateIntervalSec = 0.5f;
+        private static float nextMapOrbitUpdateTime;
+
+        internal static readonly Dictionary<int, (string body, double sma, double ecc)> flightLastMapOrbitByIndex =
+            new Dictionary<int, (string body, double sma, double ecc)>();
+
+        internal static readonly HashSet<string> flightTerminalMapRetentionLoggedIds =
+            new HashSet<string>();
+
+        /// <summary>
+        /// Per-chain dedup: maps chainId → recording index that currently owns the ghost map vessel.
+        /// When a new chain segment creates a ghost map vessel, the previous segment's is removed.
+        /// Prevents duplicate orbit lines during fast time warp across chain boundaries.
+        /// </summary>
+        internal static readonly Dictionary<string, int> flightChainMapOwner = new Dictionary<string, int>();
+
+        /// <summary>
+        /// State-vector orbit tracking: recording indices with physics-only suborbital
+        /// orbit lines (no orbit segments). Maps index → trajectory for re-defer.
+        /// </summary>
+        internal static readonly Dictionary<int, IPlaybackTrajectory> flightStateVectorOrbitTrajectories =
+            new Dictionary<int, IPlaybackTrajectory>();
+
+        /// <summary>
+        /// Per-recording cached waypoint indices for InterpolateAtUT calls (avoids
+        /// O(n) scan on every 0.5s orbit update).
+        /// </summary>
+        internal static readonly Dictionary<int, int> flightStateVectorCachedIndices =
+            new Dictionary<int, int>();
+
+        /// <summary>
+        /// Bulk-clear all flight-scene map-presence collections + reset the reseed timer.
+        /// Faithfully reproduces the exact set of clears that ParsekPlaybackPolicy's
+        /// HandleAllGhostsDestroying + Dispose performed for these collections (Phase 8d.1).
+        /// </summary>
+        internal static void ClearFlightMapPresenceState()
+        {
+            flightPendingMapVessels.Clear();
+            flightLastMapOrbitByIndex.Clear();
+            flightChainMapOwner.Clear();
+            flightStateVectorOrbitTrajectories.Clear();
+            flightSoiGapStateVectorExpectedBodies.Clear();
+            flightStateVectorCachedIndices.Clear();
+            flightTerminalMapRetentionLoggedIds.Clear();
+            nextMapOrbitUpdateTime = 0f;
+        }
+
+        /// <summary>
+        /// Resolve the Mission-loop sample UT for a flight-scene map ghost and the matching
+        /// live-frame epoch shift. Thin wrapper over
+        /// <see cref="GhostPlaybackLogic.ResolveTrackingStationSampleUT"/> (the same seam the
+        /// Tracking Station and KSC map drivers use): returns the loop-mapped <c>effUT</c> for a
+        /// looping member (and <paramref name="renderHidden"/>=true when it is outside its loop
+        /// window this cycle), or the unchanged <paramref name="currentUT"/> with shift 0 for a
+        /// non-member / when no Mission loops. <paramref name="loopEpochShiftSeconds"/> is
+        /// <c>currentUT - effUT</c>: the amount the seeded orbit epoch + stored arc bounds must be
+        /// pushed forward so the icon, drawn at the live clock, lands on the replayed position.
+        /// </summary>
+        internal static double ResolveMapPresenceSampleUT(
+            int idx, double memberStartUT, double memberEndUT, double currentUT,
+            GhostPlaybackLogic.LoopUnitSet loopUnits,
+            out bool renderHidden, out double loopEpochShiftSeconds)
+        {
+            double effUT = GhostPlaybackLogic.ResolveTrackingStationSampleUT(
+                idx, memberStartUT, memberEndUT, currentUT, loopUnits, out renderHidden);
+            loopEpochShiftSeconds = currentUT - effUT;
+            return effUT;
+        }
+
+        /// <summary>
+        /// Per-frame check for ghost map ProtoVessels. Handles three responsibilities:
+        /// 1. Creates deferred ProtoVessels when ghosts enter their first orbital segment
+        /// 2. Creates state-vector orbit ProtoVessels for physics-only suborbital recordings
+        /// 3. Updates existing ProtoVessel orbits (segment-based and state-vector-based)
+        /// </summary>
+        internal static void UpdateFlightMapGhostLifecycle(
+            double currentUT, GhostPlaybackLogic.LoopUnitSet loopUnits)
+        {
+            // Mission-loop span clock: the same per-frame LoopUnitSet the flight engine drives the
+            // ghost MESHES with (engine.CurrentLoopUnits). The Tracking Station and KSC map drivers
+            // already remap the live UT through this clock; this is the flight-scene equivalent so
+            // a looped Mission's map orbit lines + icons sample the recording at the loop-mapped
+            // effUT instead of the raw live UT (which is far outside a looped member's recorded UT
+            // range). Empty (the common case) makes every ResolveMapPresenceSampleUT below return
+            // the unchanged live UT with shift 0, so non-looping behavior is byte-identical.
+
+            // 1. Create deferred ProtoVessels for ghosts that just entered an orbital segment
+            //    OR for physics-only recordings that crossed the state-vector threshold.
+            if (flightPendingMapVessels.Count > 0)
+            {
+                List<(int idx, TrackingStationGhostSource source, OrbitSegment segment, TrajectoryPoint point, string expectedBody, double effUT)> toCreate = null;
+
+                foreach (var kvp in flightPendingMapVessels)
+                {
+                    int idx = kvp.Key;
+                    PendingMapVessel pending = kvp.Value;
+                    IPlaybackTrajectory traj = pending.Trajectory;
+
+                    // Loop-mapped sample UT for this member (effUT == currentUT off the loop path).
+                    // renderHidden => this member is outside its loop window this cycle: skip the
+                    // create, exactly like the Tracking Station create pass skips it.
+                    double effUT = ResolveMapPresenceSampleUT(
+                        idx, traj.StartUT, traj.EndUT, currentUT, loopUnits,
+                        out bool renderHidden, out double pendingLoopShift);
+                    if (renderHidden)
+                        continue;
+
+                    // A non-zero loop epoch shift means this is a Mission-loop member replaying
+                    // inside its window this cycle (effUT != live currentUT). Two consequences:
+                    //  - it unlocks the no-segment terminal-orbit synthesis (plan section 1.4); and
+                    //  - it lets the map ghost draw even when the recording already materialized a
+                    //    persisted real terminal vessel (loopMemberInWindow). Without the latter, a
+                    //    looped leg whose mission left a real craft parked at its terminal (e.g. the
+                    //    Mun-return leg) gets no trajectory following the ghost, because the static
+                    //    real vessel claims the materialization. Both flags default false off the loop
+                    //    path, so neither the terminal-orbit synthesis nor the materialization bypass
+                    //    affects non-loop members. (The EndpointTail entry in the acceptance check below
+                    //    is a SEPARATE, intentional consistency fix -- it materializes a non-loop
+                    //    member that resolves to EndpointTail, which the create path previously left
+                    //    pending -- and is NOT gated by these flags.)
+                    bool isLoopMemberInWindow = pendingLoopShift != 0.0;
+                    bool acceptTerminalOrbitForLoopSynthesis =
+                        isLoopMemberInWindow
+                        && GhostMapPresence.IsTerminalOrbitSynthesisSafeForLoopMember(traj);
+                    if (acceptTerminalOrbitForLoopSynthesis)
+                    {
+                        ParsekLog.VerboseRateLimited("Policy",
+                            string.Format(CultureInfo.InvariantCulture,
+                                "pending-map-accept-terminal-{0}", idx),
+                            string.Format(CultureInfo.InvariantCulture,
+                                "Pending map-create accepting terminal-orbit synthesis for loop member " +
+                                "rec=#{0} vessel=\"{1}\" pendingLoopShift={2:F1}",
+                                idx,
+                                traj.VesselName ?? "(null)",
+                                pendingLoopShift),
+                            5.0);
+                    }
+
+                    int cachedStateVectorIndex = flightStateVectorCachedIndices.TryGetValue(idx, out int cached)
+                        ? cached
+                        : -1;
+                    TrackingStationGhostSource source = GhostMapPresence.ResolveMapPresenceGhostSource(
+                        traj,
+                        false,
+                        IsMaterializedForMapPresence(traj),
+                        effUT,
+                        true,
+                        "map-presence-pending-create",
+                        ref cachedStateVectorIndex,
+                        out OrbitSegment segment,
+                        out TrajectoryPoint point,
+                        out _,
+                        recordingIndex: idx,
+                        allowSoiGapStateVectorFallback: pending.AllowSoiGapStateVectorFallback,
+                        expectedSoiGapBody: pending.ExpectedSoiGapBody,
+                        acceptTerminalOrbitForLoopSynthesis: acceptTerminalOrbitForLoopSynthesis,
+                        loopMemberInWindow: isLoopMemberInWindow);
+                    flightStateVectorCachedIndices[idx] = cachedStateVectorIndex;
+
+                    // Re-aim: swap the recorded covering segment for the re-aimed one at create time so
+                    // the orbit line is aimed at the target's CURRENT position from the first frame the
+                    // ghost re-enters its window. A re-aim owner in a TRIM GAP (between a recorded
+                    // body-relative leg and the trimmed interplanetary transfer) has no covering re-aimed
+                    // segment: skip the create entirely (keep the member pending / hidden) rather than
+                    // fall back to a recorded sub-segment, which re-created the ghost at a random orbit
+                    // position every frame while the refresh removed it (the SOI-boundary icon flicker).
+                    if (source == TrackingStationGhostSource.Segment
+                        && !GhostMapPresence.TryResolveReaimedCoveringSegment(
+                            idx, traj.RecordingId, traj.OrbitSegments, currentUT, effUT, loopUnits,
+                            segment, out segment))
+                        continue;
+
+                    if (source == TrackingStationGhostSource.Segment
+                        || GhostMapPresence.IsStateVectorGhostSource(source)
+                        || source == TrackingStationGhostSource.TerminalOrbit
+                        || source == TrackingStationGhostSource.EndpointTail)
+                    {
+                        if (toCreate == null)
+                            toCreate = new List<(int, TrackingStationGhostSource, OrbitSegment, TrajectoryPoint, string, double)>();
+                        toCreate.Add((idx, source, segment, point, pending.ExpectedSoiGapBody, effUT));
+                    }
+                }
+
+                if (toCreate != null)
+                {
+                    for (int i = 0; i < toCreate.Count; i++)
+                    {
+                        int idx = toCreate[i].idx;
+                        if (flightPendingMapVessels.TryGetValue(idx, out var pending))
+                        {
+                            IPlaybackTrajectory traj = pending.Trajectory;
+                            // Per-chain dedup before deferred creation
+                            RemovePreviousChainMapVessel(idx);
+                            // Create at the loop-mapped effUT so the source/segment/point match the
+                            // looped phase (effUT == currentUT off the loop path). Pass the live-frame
+                            // epoch shift through so the orbit + body-frame cache are shifted at
+                            // create-time too. Without this the body-frame cache holds raw recorded
+                            // UTs on the first frame, and the orbit-line patch sees currentUT past
+                            // those bounds and blanks the line until the next rate-limited update
+                            // pass refreshes it (up to ~0.5s in flight, ~2s in TS) -- visible as a
+                            // brief orbit-line blackout at first appearance and at every window
+                            // re-entry.
+                            double pendingLoopEpochShift = currentUT - toCreate[i].effUT;
+                            Vessel ghost = GhostMapPresence.CreateGhostVesselFromSource(
+                                idx,
+                                traj,
+                                toCreate[i].source,
+                                toCreate[i].segment,
+                                toCreate[i].point,
+                                toCreate[i].effUT,
+                                out bool retryLater,
+                                loopEpochShiftSeconds: pendingLoopEpochShift);
+                            // PR #574 review P2 (retry-later semantics): keep
+                            // the pending entry alive when the active-Re-Fly
+                            // suppression gate fires — otherwise a parent
+                            // recording mid-flight in a Relative-anchored
+                            // section would be permanently dropped from the
+                            // pending-map queue and never re-attempt after
+                            // the Re-Fly session ends.
+                            if (retryLater && ghost == null)
+                            {
+                                ParsekLog.Verbose("Policy", string.Format(CultureInfo.InvariantCulture,
+                                    "CheckPendingMapVessels: kept pending entry for #{0} \"{1}\" — " +
+                                    "map ghost creation requested retryLater, will retry next tick",
+                                    idx, traj.VesselName ?? "(null)"));
+                                continue;
+                            }
+                            flightPendingMapVessels.Remove(idx);
+
+                            if (ghost != null)
+                            {
+                                if (GhostMapPresence.IsStateVectorGhostSource(toCreate[i].source))
+                                {
+                                    flightStateVectorOrbitTrajectories[idx] = traj;
+                                    if (toCreate[i].source == TrackingStationGhostSource.StateVectorSoiGap)
+                                        flightSoiGapStateVectorExpectedBodies[idx] = toCreate[i].expectedBody;
+                                    else
+                                        flightSoiGapStateVectorExpectedBodies.Remove(idx);
+                                    ParsekLog.Info("Policy", string.Format(CultureInfo.InvariantCulture,
+                                        "Created state-vector ghost map vessel for #{0} \"{1}\" — alt={2:F0} speed={3:F1} source={4}",
+                                        idx, traj.VesselName,
+                                        toCreate[i].point.altitude,
+                                        toCreate[i].point.velocity.magnitude,
+                                        toCreate[i].source == TrackingStationGhostSource.StateVectorSoiGap
+                                            ? "soi-gap-state-vector"
+                                            : "state-vector"));
+                                }
+                                else if (TryGetMapOrbitKey(toCreate[i].source, toCreate[i].segment, out var orbitKey))
+                                {
+                                    flightSoiGapStateVectorExpectedBodies.Remove(idx);
+                                    flightLastMapOrbitByIndex[idx] = orbitKey;
+
+                                    ParsekLog.Info("Policy",
+                                        $"Created deferred ghost map vessel for #{idx} \"{traj.VesselName}\" " +
+                                        $"— source={toCreate[i].source} body={orbitKey.body} sma={orbitKey.sma:F0}");
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // 2. Map-orbit reseed for existing ProtoVessels. Rate-limited to the real-time timer, BUT
+            // warp-aware: under time warp the playback head sprints through short segments (e.g. the many
+            // short Duna-capture conics) faster than the 0.5 s timer reseeds, so the applied orbit goes
+            // stale and GhostOrbitLinePatch's stale-segment guard blanks the line every frame (the ~1-min
+            // warped-approach blink). Also reseed the moment a ghost's head leaves its applied segment so
+            // the orbit stays current and the stale-segment guard (which still suppresses the genuine
+            // pre-burn arc on a propulsive->orbital handoff) stops firing on reseed lag alone. The head-left
+            // scan is computed only while warping + before the timer (so 1x is byte-identical + cost-free).
+            bool mapReseedTimerElapsed = UnityEngine.Time.time >= nextMapOrbitUpdateTime;
+            bool mapReseedHeadLeftSegment = !mapReseedTimerElapsed
+                && TimeWarp.CurrentRate > 1.0f
+                && GhostMapPresence.AnyGhostHeadLeftAppliedSegment(currentUT);
+            if (!ParsekPlaybackPolicy.ShouldRunMapOrbitReseed(mapReseedTimerElapsed, TimeWarp.CurrentRate, mapReseedHeadLeftSegment))
+                return;
+            nextMapOrbitUpdateTime = UnityEngine.Time.time + MapOrbitUpdateIntervalSec;
+
+            var committed = RecordingStore.CommittedRecordings;
+            if (committed == null) return;
+            PruneTerminalMapRetentionLogKeys(committed);
+
+            // 2a. Segment-based orbit updates (existing)
+            List<KeyValuePair<int, (string body, double sma, double ecc)>> orbitUpdates = null;
+            List<int> toRemoveFromMap = null;
+            List<(int idx, string expectedBody)> toRequeue = null;
+
+            foreach (var kvp in flightLastMapOrbitByIndex)
+            {
+                int idx = kvp.Key;
+                if (idx < 0 || idx >= committed.Count) continue;
+
+                var rec = committed[idx];
+                if (!rec.HasOrbitSegments) continue;
+
+                // Loop-mapped sample UT + live-frame epoch shift (effUT == currentUT, shift 0 off
+                // the loop path). renderHidden => the member left its loop window this cycle: tear
+                // the orbit ghost down, mirroring the Tracking Station refresh pass.
+                double effUT = ResolveMapPresenceSampleUT(
+                    idx, rec.StartUT, rec.EndUT, currentUT, loopUnits,
+                    out bool renderHidden, out double loopEpochShiftSeconds);
+                if (renderHidden)
+                {
+                    GhostMapPresence.RemoveGhostVesselForRecording(idx, "mission-loop-out-of-window");
+                    if (toRemoveFromMap == null) toRemoveFromMap = new List<int>();
+                    toRemoveFromMap.Add(idx);
+                    // Re-queue to pendingMapVessels so the create pass re-materializes the orbit
+                    // ghost when the span clock sweeps back into this member's window next cycle.
+                    // Unlike the Tracking Station (which scans all committed indices every frame),
+                    // the flight driver only creates from the pending queue, and the ProtoVessel
+                    // was just removed, so 2a alone could never bring it back.
+                    if (toRequeue == null) toRequeue = new List<(int, string)>();
+                    toRequeue.Add((idx, null));
+                    continue;
+                }
+
+                // Re-aim: for a re-aim loop owner, the flight map orbit line must follow the per-window
+                // RE-AIMED transfer (aimed at the target's CURRENT position), not the recorded geometry
+                // (which points at the target's RECORDED position - the "wrong place in the target's
+                // orbit" the playtest showed). Resolved ONCE here from the LIVE currentUT (same window
+                // the flight engine + tracking station use) and threaded through every effUT-based read
+                // below; reference-identical to rec.OrbitSegments for every non-re-aim member.
+                List<OrbitSegment> effectiveSegments = GhostMapPresence.ResolveEffectiveMapOrbitSegments(
+                    idx, rec.RecordingId, rec.OrbitSegments, currentUT, loopUnits);
+
+                // Same-body carry: while the playback head is inside a body frame, briefly
+                // dropping the ghost between two non-orbit-equivalent segments (e.g., capture
+                // burn between two Mun orbits) would tear down and recreate the ProtoVessel,
+                // producing the visible flicker the user reported near Mun SOI. We only want
+                // to drop the ghost when the body actually changes (SOI / frame change) or
+                // when the recording is truly past its last segment. Body-frame carry keeps
+                // the previous segment's orbit active until UT enters the next segment.
+                OrbitSegment? seg = TrajectoryMath.FindOrbitSegmentOrSameBodyCarry(effectiveSegments, effUT);
+
+                // Gap-points glide: FindOrbitSegmentOrSameBodyCarry keeps seg.HasValue true across a
+                // same-body inter-segment gap by carrying the PREVIOUS segment forward. That is correct
+                // for an equivalent-orbit gap (capture burn between two same Mun orbits) but wrong for a
+                // real orbit RAISE (parking -> higher loiter, sma 671928 -> 731230 across a ~205s arc):
+                // the stale parking orbit freezes the icon, then it teleports ~1318 km onto the loiter
+                // orbit when UT enters the next segment. The recorder captured that raise as body-fixed
+                // Absolute trajectory POINTS, so route the icon onto those points and glide it across the
+                // gap. Gated to the NON-orbit-equivalent gap so the equivalent-orbit carry stays untouched.
+                bool driveGapFromPoints =
+                    seg.HasValue
+                    && GhostMapPresence.ShouldDriveGapFromPoints(effectiveSegments, rec, effUT);
+
+                // Flight-map companion to the TS covering-segment log: same MapTraj on-change diagnostic so the
+                // SOI-exit blink / orbit-line GAP / body flip-flop is visible on the flight path too. When a
+                // segment covers effUT the icon follows that OrbitSegment (source=Segment); when none does and
+                // a terminal state-vector fallback is cached for this member, the icon is driven by that
+                // fallback (resolved in the !seg.HasValue branch below), so report source=StateVector. The
+                // gap-points glide above also drives the icon from the state-vector point path, so report
+                // source=StateVector for it too. The membership check is stable frame-to-frame (it does not
+                // flip-flop) and mirrors the TS path's trackingStationStateVectorOrbitTrajectories check.
+                bool flightIsStateVector =
+                    driveGapFromPoints
+                    || (!seg.HasValue && flightStateVectorCachedIndices.ContainsKey(idx));
+                GhostMapPresence.LogMapCoveringSegmentChange("FLIGHT", idx, effUT, seg, seg.HasValue && !driveGapFromPoints,
+                    flightIsStateVector,
+                    effectiveSegments != null ? effectiveSegments.Count : 0);
+
+                // Gap-points glide branch: drive the existing (Segment-created) ghost from the recorded
+                // body-fixed point at effUT via the same state-vector positioner the SOI-gap fallback uses.
+                // UpdateGhostOrbitFromStateVectors clears the stale segment-drive dicts (bounds / loop-shift /
+                // epoch-shift) so GhostOrbitIconDrivePatch defers to stock at live UT instead of clamping the
+                // icon past-window on the parking orbit. continue skips the segment-apply tail below.
+                if (driveGapFromPoints)
+                {
+                    int gapCachedIndex = flightStateVectorCachedIndices.TryGetValue(idx, out int gapCached)
+                        ? gapCached
+                        : -1;
+                    TrajectoryPoint? gapPoint = TrajectoryMath.BracketPointAtUT(rec.Points, effUT, ref gapCachedIndex);
+                    flightStateVectorCachedIndices[idx] = gapCachedIndex;
+                    if (gapPoint.HasValue)
+                    {
+                        // UpdateGhostOrbitFromStateVectors returns true ONLY in the active-re-fly
+                        // suppression case; false on the normal success path. The flight scene removes the
+                        // ghost via its own re-fly suppression machinery (MarkStateVectorGhostDeferredForActiveReFly
+                        // runs inside the call), so we just record the result for the log here.
+                        bool reFlySuppressed = GhostMapPresence.UpdateGhostOrbitFromStateVectors(
+                            idx, rec, gapPoint.Value, effUT,
+                            stateVectorUpdateReason: "orbit-raise-gap-points",
+                            loopEpochShiftSeconds: loopEpochShiftSeconds);
+                        ParsekLog.VerboseRateLimited("Policy",
+                            "flight-gap-points-glide-" + idx,
+                            string.Format(CultureInfo.InvariantCulture,
+                                "Flight gap-points glide: member={0} effUT={1:F1} body={2} alt={3:F0} reFlySuppressed={4} " +
+                                "(orbit-raise gap, icon glides recorded ascent instead of segment carry)",
+                                idx, effUT, gapPoint.Value.bodyName ?? "(null)", gapPoint.Value.altitude, reFlySuppressed),
+                            2.0);
+                        // The ghost is now state-vector-driven; record a sentinel orbit key (sma/ecc 0)
+                        // via the deferred orbitUpdates list (we cannot mutate lastMapOrbitByIndex during
+                        // its own enumeration) so the next in-segment frame sees a differing key and
+                        // re-applies a fresh covering orbit instead of skip-unchanged.
+                        if (orbitUpdates == null) orbitUpdates = new List<KeyValuePair<int, (string, double, double)>>();
+                        orbitUpdates.Add(new KeyValuePair<int, (string, double, double)>(
+                            idx, (gapPoint.Value.bodyName, 0.0, 0.0)));
+                        continue;
+                    }
+                    // No bracketing point (effUT precedes first / past last recorded point): fall through
+                    // to the unchanged carry/segment-apply path. Never force a single stale point.
+                    ParsekLog.VerboseRateLimited("Policy",
+                        "flight-gap-points-nobracket-" + idx,
+                        string.Format(CultureInfo.InvariantCulture,
+                            "Flight gap-points glide skipped (no bracketing point): member={0} effUT={1:F1} " +
+                            "(falling through to same-body segment carry)",
+                            idx, effUT),
+                        5.0);
+                }
+
+                // No map-visible orbit at current UT — either we've truly left orbital
+                // playback, or the next segment is in a different SOI/body.
+                if (!seg.HasValue)
+                {
+                    int cachedStateVectorIndex = flightStateVectorCachedIndices.TryGetValue(idx, out int cached)
+                        ? cached
+                        : -1;
+                    if (ParsekPlaybackPolicy.TryResolveTerminalFallbackMapOrbitUpdate(
+                        rec,
+                        idx,
+                        effUT,
+                        loopEpochShiftSeconds,
+                        kvp.Value,
+                        IsMaterializedForMapPresence(rec),
+                        ref cachedStateVectorIndex,
+                        out OrbitSegment fallbackSegment,
+                        out var fallbackKey,
+                        out bool fallbackChanged))
+                    {
+                        flightStateVectorCachedIndices[idx] = cachedStateVectorIndex;
+                        if (fallbackChanged)
+                        {
+                            GhostMapPresence.UpdateGhostOrbitForRecording(
+                                idx, fallbackSegment,
+                                loopEpochShiftSeconds: loopEpochShiftSeconds);
+                            if (orbitUpdates == null) orbitUpdates = new List<KeyValuePair<int, (string, double, double)>>();
+                            orbitUpdates.Add(new KeyValuePair<int, (string, double, double)>(idx, fallbackKey));
+                        }
+                        continue;
+                    }
+                    flightStateVectorCachedIndices[idx] = cachedStateVectorIndex;
+
+                    bool hasFutureSegment = false;
+                    string futureSegmentBody = null;
+                    var segs = effectiveSegments;
+                    for (int s = 0; s < segs.Count; s++)
+                    {
+                        if (segs[s].startUT > effUT)
+                        {
+                            hasFutureSegment = true;
+                            futureSegmentBody = segs[s].bodyName;
+                            break;
+                        }
+                    }
+
+                    if (ParsekPlaybackPolicy.ShouldRetainMapPresenceForTerminalRealSpawn(rec, hasFutureSegment))
+                    {
+                        string retentionKey = rec.RecordingId ?? idx.ToString(CultureInfo.InvariantCulture);
+                        string reason = rec.TerminalSpawnCannotSpawnSafely
+                            ? rec.TerminalSpawnSafetyReasonCode ?? "cannot-spawn-safely"
+                            : rec.TerminalSpawnSafetyDeferred
+                                ? rec.TerminalSpawnSafetyReasonCode ?? "deferred"
+                                : "pending-terminal-real-spawn";
+                        string message = string.Format(CultureInfo.InvariantCulture,
+                            "Map presence retained because terminal real spawn is pending/deferred: " +
+                            "rec={0} idx={1} vessel=\"{2}\" currentUT={3:F2} reason={4}",
+                            rec.RecordingId ?? "(null)",
+                            idx,
+                            rec.VesselName ?? "(null)",
+                            currentUT,
+                            reason);
+                        if (flightTerminalMapRetentionLoggedIds.Add(retentionKey))
+                            ParsekLog.Info("Policy", message);
+                        else
+                            ParsekLog.VerboseRateLimited(
+                                "Policy",
+                                "terminal-map-retained-" + retentionKey,
+                                message);
+                        continue;
+                    }
+
+                    GhostMapPresence.RemoveGhostVesselForRecording(idx,
+                        hasFutureSegment ? "gap-between-orbit-segments" : "left-orbit-segments");
+
+                    if (hasFutureSegment)
+                    {
+                        // Re-add to pending so the next segment creates a new ProtoVessel
+                        if (toRequeue == null) toRequeue = new List<(int, string)>();
+                        toRequeue.Add((idx, futureSegmentBody));
+                    }
+
+                    if (toRemoveFromMap == null) toRemoveFromMap = new List<int>();
+                    toRemoveFromMap.Add(idx);
+                    continue;
+                }
+
+                // Skip re-applying an unchanged orbit — EXCEPT for loop members, whose stored key
+                // (body/sma/ecc) does not capture the per-cycle epoch + bounds shift, so a cycle
+                // wrap onto the same-shape segment would otherwise leave a stale shift and mis-clip
+                // the arc. Loop members re-apply every tick (cheap; the shift is constant within a
+                // cycle so this is idempotent until the wrap).
+                if (loopEpochShiftSeconds == 0.0
+                    && seg.Value.bodyName == kvp.Value.body
+                    && seg.Value.semiMajorAxis == kvp.Value.sma
+                    && seg.Value.eccentricity == kvp.Value.ecc)
+                    continue;
+
+                GhostMapPresence.UpdateGhostOrbitForRecording(
+                    idx, seg.Value,
+                    loopEpochShiftSeconds: loopEpochShiftSeconds,
+                    effectiveOrbitSegments: effectiveSegments);
+                if (orbitUpdates == null) orbitUpdates = new List<KeyValuePair<int, (string, double, double)>>();
+                orbitUpdates.Add(new KeyValuePair<int, (string, double, double)>(
+                    idx, (seg.Value.bodyName, seg.Value.semiMajorAxis, seg.Value.eccentricity)));
+            }
+
+            if (orbitUpdates != null)
+            {
+                for (int i = 0; i < orbitUpdates.Count; i++)
+                    flightLastMapOrbitByIndex[orbitUpdates[i].Key] = orbitUpdates[i].Value;
+            }
+            if (toRemoveFromMap != null)
+            {
+                for (int i = 0; i < toRemoveFromMap.Count; i++)
+                    flightLastMapOrbitByIndex.Remove(toRemoveFromMap[i]);
+            }
+            if (toRequeue != null)
+            {
+                for (int i = 0; i < toRequeue.Count; i++)
+                {
+                    int idx = toRequeue[i].idx;
+                    if (!flightPendingMapVessels.ContainsKey(idx) && idx < committed.Count)
+                    {
+                        var traj = committed[idx] as IPlaybackTrajectory;
+                        if (traj != null)
+                        {
+                            flightPendingMapVessels[idx] = new PendingMapVessel(
+                                traj,
+                                allowSoiGapStateVectorFallback: true,
+                                expectedSoiGapBody: toRequeue[i].expectedBody);
+                            ParsekLog.Verbose("MapPresence",
+                                $"Re-queued recording #{idx} to pendingMapVessels (gap between orbit segments expectedBody={toRequeue[i].expectedBody ?? "(none)"})");
+                        }
+                    }
+                }
+            }
+
+            // 2b. State-vector orbit updates (new — physics-only suborbital)
+            if (flightStateVectorOrbitTrajectories.Count > 0)
+            {
+                List<int> toReDefer = null;
+                List<int> toExitStateVector = null;
+                List<KeyValuePair<int, (string body, double sma, double ecc)>> stateVectorSegmentUpdates = null;
+
+                foreach (var kvp in flightStateVectorOrbitTrajectories)
+                {
+                    int idx = kvp.Key;
+                    IPlaybackTrajectory traj = kvp.Value;
+
+                    if (!flightStateVectorCachedIndices.ContainsKey(idx))
+                        flightStateVectorCachedIndices[idx] = -1;
+                    int cached = flightStateVectorCachedIndices[idx];
+
+                    // Loop-mapped sample UT + live-frame epoch shift (effUT == currentUT, shift 0
+                    // off the loop path). renderHidden => the member is outside its loop window
+                    // this cycle: tear the ghost down and re-defer so the create pass re-materializes
+                    // it when the span clock sweeps back into its window.
+                    double effUT = ResolveMapPresenceSampleUT(
+                        idx, traj.StartUT, traj.EndUT, currentUT, loopUnits,
+                        out bool renderHidden, out double loopEpochShiftSeconds);
+                    if (renderHidden)
+                    {
+                        GhostMapPresence.RemoveGhostVesselForRecording(idx, "mission-loop-out-of-window");
+                        if (toReDefer == null) toReDefer = new List<int>();
+                        toReDefer.Add(idx);
+                        continue;
+                    }
+
+                    if (flightSoiGapStateVectorExpectedBodies.TryGetValue(idx, out string expectedSoiGapBody))
+                    {
+                        // Loop-aware caller (state-vector orbit update pass): plan section 1.4.
+                        bool acceptTerminalOrbitForLoopSynthesis =
+                            loopEpochShiftSeconds != 0.0
+                            && GhostMapPresence.IsTerminalOrbitSynthesisSafeForLoopMember(traj);
+                        TrackingStationGhostSource source = GhostMapPresence.ResolveMapPresenceGhostSource(
+                            traj,
+                            false,
+                            IsMaterializedForMapPresence(traj),
+                            effUT,
+                            true,
+                            "map-presence-soi-gap-state-vector-update",
+                            ref cached,
+                            out OrbitSegment segment,
+                            out TrajectoryPoint soiGapPoint,
+                            out _,
+                            recordingIndex: idx,
+                            allowSoiGapStateVectorFallback: true,
+                            expectedSoiGapBody: expectedSoiGapBody,
+                            acceptTerminalOrbitForLoopSynthesis: acceptTerminalOrbitForLoopSynthesis,
+                            // Keep updating a loop member's ghost alongside any persisted real
+                            // terminal vessel (mirrors the create-path bypass).
+                            loopMemberInWindow: loopEpochShiftSeconds != 0.0);
+                        flightStateVectorCachedIndices[idx] = cached;
+
+                        if (source == TrackingStationGhostSource.StateVectorSoiGap)
+                        {
+                            if (GhostMapPresence.UpdateGhostOrbitFromStateVectors(
+                                idx,
+                                traj,
+                                soiGapPoint,
+                                effUT,
+                                allowOrbitalCheckpointStateVector: true,
+                                stateVectorUpdateReason: "soi-gap-state-vector-fallback",
+                                loopEpochShiftSeconds: loopEpochShiftSeconds))
+                            {
+                                GhostMapPresence.RemoveGhostVesselForRecording(
+                                    idx,
+                                    GhostMapPresence.TrackingStationGhostSkipActiveReFlyRelativeUpdate);
+                                if (toReDefer == null) toReDefer = new List<int>();
+                                toReDefer.Add(idx);
+                            }
+                            continue;
+                        }
+
+                        if (source == TrackingStationGhostSource.Segment
+                            || source == TrackingStationGhostSource.TerminalOrbit
+                            || source == TrackingStationGhostSource.EndpointTail)
+                        {
+                            // EndpointTail populates a valid `segment` out-param exactly
+                            // like TerminalOrbit (the loop-synthesis no-segment fallback),
+                            // so consume it here too; otherwise a terminal-region loop
+                            // member resolving to EndpointTail would fall through to the
+                            // flat BracketPointAtUT path below. Matches the pending-create
+                            // (line ~1387) and orbit-update (line ~1922) callers.
+                            GhostMapPresence.UpdateGhostOrbitForRecording(
+                                idx, segment,
+                                loopEpochShiftSeconds: loopEpochShiftSeconds);
+                            if (TryGetMapOrbitKey(source, segment, out var segmentKey))
+                            {
+                                if (stateVectorSegmentUpdates == null)
+                                    stateVectorSegmentUpdates = new List<KeyValuePair<int, (string, double, double)>>();
+                                stateVectorSegmentUpdates.Add(new KeyValuePair<int, (string, double, double)>(idx, segmentKey));
+                            }
+
+                            if (toExitStateVector == null) toExitStateVector = new List<int>();
+                            toExitStateVector.Add(idx);
+                            continue;
+                        }
+                    }
+
+                    TrajectoryPoint? pt = TrajectoryMath.BracketPointAtUT(traj.Points, effUT, ref cached);
+                    flightStateVectorCachedIndices[idx] = cached;
+
+                    if (!pt.HasValue) continue;
+
+                    // Relative-frame points reuse `TrajectoryPoint.altitude` as the
+                    // anchor-local dz offset (metres along the anchor's local z axis),
+                    // not as geographic altitude. Feeding the dz into the
+                    // `ShouldRemoveStateVectorOrbit` altitude threshold trips the
+                    // remove path on every typical rendezvous frame (dz ~ 0) and
+                    // re-defers the ghost — but pending-create currently skips
+                    // Relative frames, so the ghost disappears through the section
+                    // rather than staying attached to the anchor (#547 P1 review).
+                    // Skip the threshold check entirely for Relative-frame points;
+                    // `UpdateGhostOrbitFromStateVectors` already dispatches on
+                    // `referenceFrame` and resolves the world position via
+                    // anchor + offset for that branch.
+                    bool inRelativeFrame = GhostMapPresence.IsInRelativeFrame(traj, effUT);
+                    if (!inRelativeFrame)
+                    {
+                        double atmosRemove = GhostMapPresence.GetAtmosphereDepth(pt.Value.bodyName);
+                        if (GhostMapPresence.ShouldRemoveStateVectorOrbit(pt.Value.altitude, pt.Value.velocity.magnitude, atmosRemove))
+                        {
+                            GhostMapPresence.RemoveGhostVesselForRecording(idx, "below-state-vector-threshold");
+                            if (toReDefer == null) toReDefer = new List<int>();
+                            toReDefer.Add(idx);
+                            ParsekLog.Info("Policy", string.Format(CultureInfo.InvariantCulture,
+                                "Removed state-vector ghost map vessel for #{0} — alt={1:F0} speed={2:F1} below threshold",
+                                idx, pt.Value.altitude, pt.Value.velocity.magnitude));
+                            continue;
+                        }
+                    }
+
+                    if (GhostMapPresence.UpdateGhostOrbitFromStateVectors(idx, traj, pt.Value, effUT,
+                        loopEpochShiftSeconds: loopEpochShiftSeconds))
+                    {
+                        GhostMapPresence.RemoveGhostVesselForRecording(
+                            idx,
+                            GhostMapPresence.TrackingStationGhostSkipActiveReFlyRelativeUpdate);
+                        if (toReDefer == null) toReDefer = new List<int>();
+                        toReDefer.Add(idx);
+                    }
+                }
+
+                if (toReDefer != null)
+                {
+                    for (int i = 0; i < toReDefer.Count; i++)
+                    {
+                        int idx = toReDefer[i];
+                        if (flightStateVectorOrbitTrajectories.TryGetValue(idx, out var traj))
+                            flightPendingMapVessels[idx] = new PendingMapVessel(
+                                traj,
+                                allowSoiGapStateVectorFallback: false,
+                                expectedSoiGapBody: null);
+                        flightStateVectorOrbitTrajectories.Remove(idx);
+                        flightSoiGapStateVectorExpectedBodies.Remove(idx);
+                        // stateVectorCachedIndices[idx] intentionally kept — avoids
+                        // O(n) re-scan if the ghost re-ascends above threshold.
+                    }
+                }
+
+                if (stateVectorSegmentUpdates != null)
+                {
+                    for (int i = 0; i < stateVectorSegmentUpdates.Count; i++)
+                        flightLastMapOrbitByIndex[stateVectorSegmentUpdates[i].Key] = stateVectorSegmentUpdates[i].Value;
+                }
+
+                if (toExitStateVector != null)
+                {
+                    for (int i = 0; i < toExitStateVector.Count; i++)
+                    {
+                        int idx = toExitStateVector[i];
+                        flightStateVectorOrbitTrajectories.Remove(idx);
+                        flightSoiGapStateVectorExpectedBodies.Remove(idx);
+                    }
+                }
+            }
+
+            GhostMapPresence.EmitLifecycleSummary("flight-map-presence", currentUT);
+        }
+
+        private static void PruneTerminalMapRetentionLogKeys(IReadOnlyList<Recording> committed)
+        {
+            if (flightTerminalMapRetentionLoggedIds.Count == 0)
+                return;
+
+            if (committed == null || committed.Count == 0)
+            {
+                flightTerminalMapRetentionLoggedIds.Clear();
+                return;
+            }
+
+            List<string> staleKeys = null;
+            foreach (string key in flightTerminalMapRetentionLoggedIds)
+            {
+                bool found = false;
+                for (int i = 0; i < committed.Count; i++)
+                {
+                    var rec = committed[i];
+                    if (rec == null)
+                        continue;
+
+                    if (string.Equals(rec.RecordingId, key, StringComparison.Ordinal)
+                        || (string.IsNullOrEmpty(rec.RecordingId)
+                            && key == i.ToString(CultureInfo.InvariantCulture)))
+                    {
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (!found)
+                {
+                    if (staleKeys == null) staleKeys = new List<string>();
+                    staleKeys.Add(key);
+                }
+            }
+
+            if (staleKeys == null)
+                return;
+
+            for (int i = 0; i < staleKeys.Count; i++)
+                flightTerminalMapRetentionLoggedIds.Remove(staleKeys[i]);
+        }
+
+        internal static bool TryGetMapOrbitKey(
+            TrackingStationGhostSource source,
+            OrbitSegment segment,
+            out (string body, double sma, double ecc) orbitKey)
+        {
+            if (source == TrackingStationGhostSource.Segment
+                || source == TrackingStationGhostSource.TerminalOrbit)
+            {
+                orbitKey = (segment.bodyName, segment.semiMajorAxis, segment.eccentricity);
+                return true;
+            }
+
+            orbitKey = default((string, double, double));
+            return false;
+        }
+
+        internal static bool IsMaterializedForMapPresence(IPlaybackTrajectory traj)
+        {
+            var rec = traj as Recording;
+            if (rec == null)
+                return false;
+
+            bool realVesselExists = false;
+            if (rec.VesselPersistentId != 0)
+            {
+                try
+                {
+                    realVesselExists = FlightRecorder.FindVesselByPid(rec.VesselPersistentId) != null;
+                }
+                catch (Exception)
+                {
+                    realVesselExists = false;
+                }
+            }
+
+            return GhostMapPresence.IsTrackingStationRecordingMaterialized(rec, realVesselExists);
+        }
+
+        /// <summary>
+        /// If the recording at the given index belongs to a chain and another segment
+        /// from the same chain currently owns a ghost map vessel, remove the old one.
+        /// Updates chainMapOwner to track the new owner.
+        /// </summary>
+        internal static void RemovePreviousChainMapVessel(int newIndex)
+        {
+            var committed = RecordingStore.CommittedRecordings;
+            if (committed == null || newIndex < 0 || newIndex >= committed.Count) return;
+
+            string chainId = committed[newIndex].ChainId;
+            if (string.IsNullOrEmpty(chainId)) return;
+
+            if (flightChainMapOwner.TryGetValue(chainId, out int oldIndex) && oldIndex != newIndex)
+            {
+                GhostMapPresence.RemoveGhostVesselForRecording(oldIndex, "chain-segment-replaced");
+                flightLastMapOrbitByIndex.Remove(oldIndex);
+                ParsekLog.Verbose("Policy",
+                    $"Chain dedup: removed ghost map for #{oldIndex} (replaced by #{newIndex} in chain {chainId})");
+            }
+
+            flightChainMapOwner[chainId] = newIndex;
+        }
     }
 }

--- a/Source/Parsek/MapRender/MapViewScene.cs
+++ b/Source/Parsek/MapRender/MapViewScene.cs
@@ -11,10 +11,12 @@ namespace Parsek.MapRender
     /// </summary>
     internal sealed class MapViewScene : GhostMapSceneBase
     {
-        // The flight-scene presence driver. Injected by the owning ParsekFlight right after it builds
-        // the policy (SetPresenceDriver), the same way the controller pushes the per-frame inputs via
-        // SetFrameInputs. DriveMapPresence delegates here verbatim — the Phase 8d.0 seam is a pure
-        // indirection; relocating the CheckPendingMapVessels body behind the adapter is Phase 8d.1.
+        // The flight-scene policy. Injected by the owning ParsekFlight right after it builds the policy
+        // (SetPresenceDriver), the same way the controller pushes the per-frame inputs via
+        // SetFrameInputs. Phase 8d.1: the CheckPendingMapVessels body relocated to
+        // GhostMapPresence.UpdateFlightMapGhostLifecycle; the policy is still required here as the EXACT
+        // source of the per-frame loop units (engine.CurrentLoopUnits via CurrentLoopUnitsForPresence)
+        // that the relocated body needs.
         private ParsekPlaybackPolicy policy;
 
         public override bool IsActive => HighLogic.LoadedScene == GameScenes.FLIGHT;
@@ -25,11 +27,14 @@ namespace Parsek.MapRender
             policy = presenceDriver;
         }
 
-        // Byte-identical to the former direct ParsekFlight call site: same method, same argument, same
-        // execution-order slot, same surrounding try-catch. This is a pure pass-through (Phase 8d.0).
+        // Phase 8d.1: drives the relocated flight-scene map-presence lifecycle directly on
+        // GhostMapPresence, threading the policy's exact per-frame loop units (engine.CurrentLoopUnits
+        // via CurrentLoopUnitsForPresence). Faithful relocation (no behavior change, no gate) of the
+        // former policy.CheckPendingMapVessels(currentUT) call. The policy == null guard is preserved.
         public override void DriveMapPresence(double currentUT)
         {
-            policy?.CheckPendingMapVessels(currentUT);
+            if (policy == null) return;
+            GhostMapPresence.UpdateFlightMapGhostLifecycle(currentUT, policy.CurrentLoopUnitsForPresence);
         }
     }
 }

--- a/Source/Parsek/ParsekPlaybackPolicy.cs
+++ b/Source/Parsek/ParsekPlaybackPolicy.cs
@@ -917,40 +917,26 @@ namespace Parsek
             return HeldGhostAction.RetrySpawn;
         }
 
-        /// <summary>
-        /// Recording indices eligible for ghost map ProtoVessels but deferred until
-        /// the ghost enters an orbital segment. Avoids showing orbit lines during
-        /// atmospheric ascent when the ghost mesh is still on the pad.
-        /// </summary>
-        private struct PendingMapVessel
-        {
-            internal IPlaybackTrajectory Trajectory;
-            internal bool AllowSoiGapStateVectorFallback;
-            internal string ExpectedSoiGapBody;
-
-            internal PendingMapVessel(
-                IPlaybackTrajectory trajectory,
-                bool allowSoiGapStateVectorFallback,
-                string expectedSoiGapBody)
-            {
-                Trajectory = trajectory;
-                AllowSoiGapStateVectorFallback = allowSoiGapStateVectorFallback;
-                ExpectedSoiGapBody = expectedSoiGapBody;
-            }
-        }
-
-        private readonly Dictionary<int, PendingMapVessel> pendingMapVessels =
-            new Dictionary<int, PendingMapVessel>();
-
-        private readonly Dictionary<int, string> soiGapStateVectorExpectedBodies =
-            new Dictionary<int, string>();
+        // The map-presence state (PendingMapVessel struct, the 6 presence dicts,
+        // terminalMapRetentionLoggedIds, nextMapOrbitUpdateTime, MapOrbitUpdateIntervalSec) plus the
+        // per-frame body (CheckPendingMapVessels) and its dict-touching helpers
+        // (ResolveMapPresenceSampleUT, PruneTerminalMapRetentionLogKeys, TryGetMapOrbitKey,
+        // IsMaterializedForMapPresence, RemovePreviousChainMapVessel) moved to GhostMapPresence in
+        // Phase 8d.1 (faithful relocation). MapViewScene.DriveMapPresence now calls
+        // GhostMapPresence.UpdateFlightMapGhostLifecycle directly. The still-in-policy enqueue tail
+        // (HandleGhostCreated) and teardowns reach the moved state via GhostMapPresence.flight*. The
+        // three pure helpers below (ShouldRunMapOrbitReseed, TryResolveTerminalFallbackMapOrbitUpdate,
+        // ShouldRetainMapPresenceForTerminalRealSpawn) stay here per the plan and are called from the
+        // moved body via ParsekPlaybackPolicy.<helper>.
 
         /// <summary>
-        /// Tracks the last orbit segment body+SMA per recording index for change detection.
-        /// Used to update the ghost ProtoVessel orbit as the ghost traverses segments.
+        /// Loop-units pass-through for the flight-scene map-presence driver. Exposes the EXACT same
+        /// per-frame <see cref="GhostPlaybackEngine.CurrentLoopUnits"/> the engine drives the ghost
+        /// meshes with, so <see cref="MapRender.MapViewScene.DriveMapPresence"/> can thread it into
+        /// <see cref="GhostMapPresence.UpdateFlightMapGhostLifecycle"/>. Phase 8d.1: this is the source
+        /// the relocated body used to read directly as <c>engine.CurrentLoopUnits</c>.
         /// </summary>
-        private const float MapOrbitUpdateIntervalSec = 0.5f;
-        private float nextMapOrbitUpdateTime;
+        internal GhostPlaybackLogic.LoopUnitSet CurrentLoopUnitsForPresence => engine.CurrentLoopUnits;
 
         /// <summary>
         /// Pure gate for the rate-limited map-orbit reseed pass (warp-aware). Proceeds when the real-time
@@ -962,33 +948,6 @@ namespace Parsek
         internal static bool ShouldRunMapOrbitReseed(
             bool timerElapsed, float warpRate, bool anyGhostHeadLeftSegment)
             => timerElapsed || (warpRate > 1.0f && anyGhostHeadLeftSegment);
-
-        private readonly Dictionary<int, (string body, double sma, double ecc)> lastMapOrbitByIndex =
-            new Dictionary<int, (string body, double sma, double ecc)>();
-
-        private readonly HashSet<string> terminalMapRetentionLoggedIds =
-            new HashSet<string>();
-
-        /// <summary>
-        /// Per-chain dedup: maps chainId → recording index that currently owns the ghost map vessel.
-        /// When a new chain segment creates a ghost map vessel, the previous segment's is removed.
-        /// Prevents duplicate orbit lines during fast time warp across chain boundaries.
-        /// </summary>
-        private readonly Dictionary<string, int> chainMapOwner = new Dictionary<string, int>();
-
-        /// <summary>
-        /// State-vector orbit tracking: recording indices with physics-only suborbital
-        /// orbit lines (no orbit segments). Maps index → trajectory for re-defer.
-        /// </summary>
-        private readonly Dictionary<int, IPlaybackTrajectory> stateVectorOrbitTrajectories =
-            new Dictionary<int, IPlaybackTrajectory>();
-
-        /// <summary>
-        /// Per-recording cached waypoint indices for InterpolateAtUT calls (avoids
-        /// O(n) scan on every 0.5s orbit update).
-        /// </summary>
-        private readonly Dictionary<int, int> stateVectorCachedIndices =
-            new Dictionary<int, int>();
 
         // Hysteresis thresholds for state-vector orbit creation/removal.
         // Higher thresholds to create, lower to remove — prevents churn for borderline altitudes.
@@ -1044,13 +1003,13 @@ namespace Parsek
             // Per-chain dedup: if another segment from the same chain already has a ghost
             // map vessel, remove it before creating the new one. Prevents duplicate orbit
             // lines during fast time warp across chain boundaries.
-            RemovePreviousChainMapVessel(evt.Index);
+            GhostMapPresence.RemovePreviousChainMapVessel(evt.Index);
 
             // Check whether the ghost starts in a map-visible source. Otherwise,
             // defer — the per-frame shared resolver will create it when it enters
             // an orbital segment or state-vector fallback range.
             double startUT = evt.Trajectory.StartUT;
-            int cachedStateVectorIndex = stateVectorCachedIndices.TryGetValue(evt.Index, out int cached)
+            int cachedStateVectorIndex = GhostMapPresence.flightStateVectorCachedIndices.TryGetValue(evt.Index, out int cached)
                 ? cached
                 : -1;
             // Initial-create-on-first-loop-entry: pass acceptTerminalOrbitForLoopSynthesis:
@@ -1062,7 +1021,7 @@ namespace Parsek
             TrackingStationGhostSource source = GhostMapPresence.ResolveMapPresenceGhostSource(
                 evt.Trajectory,
                 false,
-                IsMaterializedForMapPresence(evt.Trajectory),
+                GhostMapPresence.IsMaterializedForMapPresence(evt.Trajectory),
                 startUT,
                 true,
                 "map-presence-initial-create",
@@ -1072,7 +1031,7 @@ namespace Parsek
                 out _,
                 recordingIndex: evt.Index,
                 acceptTerminalOrbitForLoopSynthesis: false);
-            stateVectorCachedIndices[evt.Index] = cachedStateVectorIndex;
+            GhostMapPresence.flightStateVectorCachedIndices[evt.Index] = cachedStateVectorIndex;
 
             // Loop-shifted members must be created on a loop-aware per-frame tick
             // (CheckPendingMapVessels): that path resolves the source at the loop-mapped
@@ -1086,7 +1045,7 @@ namespace Parsek
             // (shift 0, renderHidden false), so non-loop members keep the immediate create
             // byte-for-byte.
             double initialNowUT = Planetarium.GetUniversalTime();
-            ResolveMapPresenceSampleUT(
+            GhostMapPresence.ResolveMapPresenceSampleUT(
                 evt.Index, evt.Trajectory.StartUT, evt.Trajectory.EndUT, initialNowUT,
                 engine.CurrentLoopUnits, out bool initialRenderHidden, out double initialLoopShift);
             bool deferForLoopAware =
@@ -1105,14 +1064,14 @@ namespace Parsek
                 {
                     if (GhostMapPresence.IsStateVectorGhostSource(source))
                     {
-                        stateVectorOrbitTrajectories[evt.Index] = evt.Trajectory;
+                        GhostMapPresence.flightStateVectorOrbitTrajectories[evt.Index] = evt.Trajectory;
                         if (source != TrackingStationGhostSource.StateVectorSoiGap)
-                            soiGapStateVectorExpectedBodies.Remove(evt.Index);
+                            GhostMapPresence.flightSoiGapStateVectorExpectedBodies.Remove(evt.Index);
                     }
-                    else if (TryGetMapOrbitKey(source, segment, out var orbitKey))
+                    else if (GhostMapPresence.TryGetMapOrbitKey(source, segment, out var orbitKey))
                     {
-                        soiGapStateVectorExpectedBodies.Remove(evt.Index);
-                        lastMapOrbitByIndex[evt.Index] = orbitKey;
+                        GhostMapPresence.flightSoiGapStateVectorExpectedBodies.Remove(evt.Index);
+                        GhostMapPresence.flightLastMapOrbitByIndex[evt.Index] = orbitKey;
                     }
                 }
             }
@@ -1122,7 +1081,7 @@ namespace Parsek
                 // recoveries; only the gap-between-orbit-segments requeue path opts into that
                 // fallback. The per-frame CheckPendingMapVessels pass resolves the source at
                 // the loop-mapped effUT and creates with the live-frame epoch shift.
-                pendingMapVessels[evt.Index] = new PendingMapVessel(
+                GhostMapPresence.flightPendingMapVessels[evt.Index] = new GhostMapPresence.PendingMapVessel(
                     evt.Trajectory,
                     allowSoiGapStateVectorFallback: false,
                     expectedSoiGapBody: null);
@@ -1340,750 +1299,6 @@ namespace Parsek
                 || TerminalOrbitSpawnSafety.HasActiveHold(rec);
         }
 
-        /// <summary>
-        /// Resolve the Mission-loop sample UT for a flight-scene map ghost and the matching
-        /// live-frame epoch shift. Thin wrapper over
-        /// <see cref="GhostPlaybackLogic.ResolveTrackingStationSampleUT"/> (the same seam the
-        /// Tracking Station and KSC map drivers use): returns the loop-mapped <c>effUT</c> for a
-        /// looping member (and <paramref name="renderHidden"/>=true when it is outside its loop
-        /// window this cycle), or the unchanged <paramref name="currentUT"/> with shift 0 for a
-        /// non-member / when no Mission loops. <paramref name="loopEpochShiftSeconds"/> is
-        /// <c>currentUT - effUT</c>: the amount the seeded orbit epoch + stored arc bounds must be
-        /// pushed forward so the icon, drawn at the live clock, lands on the replayed position.
-        /// </summary>
-        private double ResolveMapPresenceSampleUT(
-            int idx, double memberStartUT, double memberEndUT, double currentUT,
-            GhostPlaybackLogic.LoopUnitSet loopUnits,
-            out bool renderHidden, out double loopEpochShiftSeconds)
-        {
-            double effUT = GhostPlaybackLogic.ResolveTrackingStationSampleUT(
-                idx, memberStartUT, memberEndUT, currentUT, loopUnits, out renderHidden);
-            loopEpochShiftSeconds = currentUT - effUT;
-            return effUT;
-        }
-
-        /// <summary>
-        /// Per-frame check for ghost map ProtoVessels. Handles three responsibilities:
-        /// 1. Creates deferred ProtoVessels when ghosts enter their first orbital segment
-        /// 2. Creates state-vector orbit ProtoVessels for physics-only suborbital recordings
-        /// 3. Updates existing ProtoVessel orbits (segment-based and state-vector-based)
-        /// </summary>
-        internal void CheckPendingMapVessels(double currentUT)
-        {
-            // Mission-loop span clock: the same per-frame LoopUnitSet the flight engine drives the
-            // ghost MESHES with (engine.CurrentLoopUnits). The Tracking Station and KSC map drivers
-            // already remap the live UT through this clock; this is the flight-scene equivalent so
-            // a looped Mission's map orbit lines + icons sample the recording at the loop-mapped
-            // effUT instead of the raw live UT (which is far outside a looped member's recorded UT
-            // range). Empty (the common case) makes every ResolveMapPresenceSampleUT below return
-            // the unchanged live UT with shift 0, so non-looping behavior is byte-identical.
-            GhostPlaybackLogic.LoopUnitSet loopUnits = engine.CurrentLoopUnits;
-
-            // 1. Create deferred ProtoVessels for ghosts that just entered an orbital segment
-            //    OR for physics-only recordings that crossed the state-vector threshold.
-            if (pendingMapVessels.Count > 0)
-            {
-                List<(int idx, TrackingStationGhostSource source, OrbitSegment segment, TrajectoryPoint point, string expectedBody, double effUT)> toCreate = null;
-
-                foreach (var kvp in pendingMapVessels)
-                {
-                    int idx = kvp.Key;
-                    PendingMapVessel pending = kvp.Value;
-                    IPlaybackTrajectory traj = pending.Trajectory;
-
-                    // Loop-mapped sample UT for this member (effUT == currentUT off the loop path).
-                    // renderHidden => this member is outside its loop window this cycle: skip the
-                    // create, exactly like the Tracking Station create pass skips it.
-                    double effUT = ResolveMapPresenceSampleUT(
-                        idx, traj.StartUT, traj.EndUT, currentUT, loopUnits,
-                        out bool renderHidden, out double pendingLoopShift);
-                    if (renderHidden)
-                        continue;
-
-                    // A non-zero loop epoch shift means this is a Mission-loop member replaying
-                    // inside its window this cycle (effUT != live currentUT). Two consequences:
-                    //  - it unlocks the no-segment terminal-orbit synthesis (plan section 1.4); and
-                    //  - it lets the map ghost draw even when the recording already materialized a
-                    //    persisted real terminal vessel (loopMemberInWindow). Without the latter, a
-                    //    looped leg whose mission left a real craft parked at its terminal (e.g. the
-                    //    Mun-return leg) gets no trajectory following the ghost, because the static
-                    //    real vessel claims the materialization. Both flags default false off the loop
-                    //    path, so neither the terminal-orbit synthesis nor the materialization bypass
-                    //    affects non-loop members. (The EndpointTail entry in the acceptance check below
-                    //    is a SEPARATE, intentional consistency fix -- it materializes a non-loop
-                    //    member that resolves to EndpointTail, which the create path previously left
-                    //    pending -- and is NOT gated by these flags.)
-                    bool isLoopMemberInWindow = pendingLoopShift != 0.0;
-                    bool acceptTerminalOrbitForLoopSynthesis =
-                        isLoopMemberInWindow
-                        && GhostMapPresence.IsTerminalOrbitSynthesisSafeForLoopMember(traj);
-                    if (acceptTerminalOrbitForLoopSynthesis)
-                    {
-                        ParsekLog.VerboseRateLimited("Policy",
-                            string.Format(CultureInfo.InvariantCulture,
-                                "pending-map-accept-terminal-{0}", idx),
-                            string.Format(CultureInfo.InvariantCulture,
-                                "Pending map-create accepting terminal-orbit synthesis for loop member " +
-                                "rec=#{0} vessel=\"{1}\" pendingLoopShift={2:F1}",
-                                idx,
-                                traj.VesselName ?? "(null)",
-                                pendingLoopShift),
-                            5.0);
-                    }
-
-                    int cachedStateVectorIndex = stateVectorCachedIndices.TryGetValue(idx, out int cached)
-                        ? cached
-                        : -1;
-                    TrackingStationGhostSource source = GhostMapPresence.ResolveMapPresenceGhostSource(
-                        traj,
-                        false,
-                        IsMaterializedForMapPresence(traj),
-                        effUT,
-                        true,
-                        "map-presence-pending-create",
-                        ref cachedStateVectorIndex,
-                        out OrbitSegment segment,
-                        out TrajectoryPoint point,
-                        out _,
-                        recordingIndex: idx,
-                        allowSoiGapStateVectorFallback: pending.AllowSoiGapStateVectorFallback,
-                        expectedSoiGapBody: pending.ExpectedSoiGapBody,
-                        acceptTerminalOrbitForLoopSynthesis: acceptTerminalOrbitForLoopSynthesis,
-                        loopMemberInWindow: isLoopMemberInWindow);
-                    stateVectorCachedIndices[idx] = cachedStateVectorIndex;
-
-                    // Re-aim: swap the recorded covering segment for the re-aimed one at create time so
-                    // the orbit line is aimed at the target's CURRENT position from the first frame the
-                    // ghost re-enters its window. A re-aim owner in a TRIM GAP (between a recorded
-                    // body-relative leg and the trimmed interplanetary transfer) has no covering re-aimed
-                    // segment: skip the create entirely (keep the member pending / hidden) rather than
-                    // fall back to a recorded sub-segment, which re-created the ghost at a random orbit
-                    // position every frame while the refresh removed it (the SOI-boundary icon flicker).
-                    if (source == TrackingStationGhostSource.Segment
-                        && !GhostMapPresence.TryResolveReaimedCoveringSegment(
-                            idx, traj.RecordingId, traj.OrbitSegments, currentUT, effUT, loopUnits,
-                            segment, out segment))
-                        continue;
-
-                    if (source == TrackingStationGhostSource.Segment
-                        || GhostMapPresence.IsStateVectorGhostSource(source)
-                        || source == TrackingStationGhostSource.TerminalOrbit
-                        || source == TrackingStationGhostSource.EndpointTail)
-                    {
-                        if (toCreate == null)
-                            toCreate = new List<(int, TrackingStationGhostSource, OrbitSegment, TrajectoryPoint, string, double)>();
-                        toCreate.Add((idx, source, segment, point, pending.ExpectedSoiGapBody, effUT));
-                    }
-                }
-
-                if (toCreate != null)
-                {
-                    for (int i = 0; i < toCreate.Count; i++)
-                    {
-                        int idx = toCreate[i].idx;
-                        if (pendingMapVessels.TryGetValue(idx, out var pending))
-                        {
-                            IPlaybackTrajectory traj = pending.Trajectory;
-                            // Per-chain dedup before deferred creation
-                            RemovePreviousChainMapVessel(idx);
-                            // Create at the loop-mapped effUT so the source/segment/point match the
-                            // looped phase (effUT == currentUT off the loop path). Pass the live-frame
-                            // epoch shift through so the orbit + body-frame cache are shifted at
-                            // create-time too. Without this the body-frame cache holds raw recorded
-                            // UTs on the first frame, and the orbit-line patch sees currentUT past
-                            // those bounds and blanks the line until the next rate-limited update
-                            // pass refreshes it (up to ~0.5s in flight, ~2s in TS) -- visible as a
-                            // brief orbit-line blackout at first appearance and at every window
-                            // re-entry.
-                            double pendingLoopEpochShift = currentUT - toCreate[i].effUT;
-                            Vessel ghost = GhostMapPresence.CreateGhostVesselFromSource(
-                                idx,
-                                traj,
-                                toCreate[i].source,
-                                toCreate[i].segment,
-                                toCreate[i].point,
-                                toCreate[i].effUT,
-                                out bool retryLater,
-                                loopEpochShiftSeconds: pendingLoopEpochShift);
-                            // PR #574 review P2 (retry-later semantics): keep
-                            // the pending entry alive when the active-Re-Fly
-                            // suppression gate fires — otherwise a parent
-                            // recording mid-flight in a Relative-anchored
-                            // section would be permanently dropped from the
-                            // pending-map queue and never re-attempt after
-                            // the Re-Fly session ends.
-                            if (retryLater && ghost == null)
-                            {
-                                ParsekLog.Verbose("Policy", string.Format(CultureInfo.InvariantCulture,
-                                    "CheckPendingMapVessels: kept pending entry for #{0} \"{1}\" — " +
-                                    "map ghost creation requested retryLater, will retry next tick",
-                                    idx, traj.VesselName ?? "(null)"));
-                                continue;
-                            }
-                            pendingMapVessels.Remove(idx);
-
-                            if (ghost != null)
-                            {
-                                if (GhostMapPresence.IsStateVectorGhostSource(toCreate[i].source))
-                                {
-                                    stateVectorOrbitTrajectories[idx] = traj;
-                                    if (toCreate[i].source == TrackingStationGhostSource.StateVectorSoiGap)
-                                        soiGapStateVectorExpectedBodies[idx] = toCreate[i].expectedBody;
-                                    else
-                                        soiGapStateVectorExpectedBodies.Remove(idx);
-                                    ParsekLog.Info("Policy", string.Format(CultureInfo.InvariantCulture,
-                                        "Created state-vector ghost map vessel for #{0} \"{1}\" — alt={2:F0} speed={3:F1} source={4}",
-                                        idx, traj.VesselName,
-                                        toCreate[i].point.altitude,
-                                        toCreate[i].point.velocity.magnitude,
-                                        toCreate[i].source == TrackingStationGhostSource.StateVectorSoiGap
-                                            ? "soi-gap-state-vector"
-                                            : "state-vector"));
-                                }
-                                else if (TryGetMapOrbitKey(toCreate[i].source, toCreate[i].segment, out var orbitKey))
-                                {
-                                    soiGapStateVectorExpectedBodies.Remove(idx);
-                                    lastMapOrbitByIndex[idx] = orbitKey;
-
-                                    ParsekLog.Info("Policy",
-                                        $"Created deferred ghost map vessel for #{idx} \"{traj.VesselName}\" " +
-                                        $"— source={toCreate[i].source} body={orbitKey.body} sma={orbitKey.sma:F0}");
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            // 2. Map-orbit reseed for existing ProtoVessels. Rate-limited to the real-time timer, BUT
-            // warp-aware: under time warp the playback head sprints through short segments (e.g. the many
-            // short Duna-capture conics) faster than the 0.5 s timer reseeds, so the applied orbit goes
-            // stale and GhostOrbitLinePatch's stale-segment guard blanks the line every frame (the ~1-min
-            // warped-approach blink). Also reseed the moment a ghost's head leaves its applied segment so
-            // the orbit stays current and the stale-segment guard (which still suppresses the genuine
-            // pre-burn arc on a propulsive->orbital handoff) stops firing on reseed lag alone. The head-left
-            // scan is computed only while warping + before the timer (so 1x is byte-identical + cost-free).
-            bool mapReseedTimerElapsed = UnityEngine.Time.time >= nextMapOrbitUpdateTime;
-            bool mapReseedHeadLeftSegment = !mapReseedTimerElapsed
-                && TimeWarp.CurrentRate > 1.0f
-                && GhostMapPresence.AnyGhostHeadLeftAppliedSegment(currentUT);
-            if (!ShouldRunMapOrbitReseed(mapReseedTimerElapsed, TimeWarp.CurrentRate, mapReseedHeadLeftSegment))
-                return;
-            nextMapOrbitUpdateTime = UnityEngine.Time.time + MapOrbitUpdateIntervalSec;
-
-            var committed = RecordingStore.CommittedRecordings;
-            if (committed == null) return;
-            PruneTerminalMapRetentionLogKeys(committed);
-
-            // 2a. Segment-based orbit updates (existing)
-            List<KeyValuePair<int, (string body, double sma, double ecc)>> orbitUpdates = null;
-            List<int> toRemoveFromMap = null;
-            List<(int idx, string expectedBody)> toRequeue = null;
-
-            foreach (var kvp in lastMapOrbitByIndex)
-            {
-                int idx = kvp.Key;
-                if (idx < 0 || idx >= committed.Count) continue;
-
-                var rec = committed[idx];
-                if (!rec.HasOrbitSegments) continue;
-
-                // Loop-mapped sample UT + live-frame epoch shift (effUT == currentUT, shift 0 off
-                // the loop path). renderHidden => the member left its loop window this cycle: tear
-                // the orbit ghost down, mirroring the Tracking Station refresh pass.
-                double effUT = ResolveMapPresenceSampleUT(
-                    idx, rec.StartUT, rec.EndUT, currentUT, loopUnits,
-                    out bool renderHidden, out double loopEpochShiftSeconds);
-                if (renderHidden)
-                {
-                    GhostMapPresence.RemoveGhostVesselForRecording(idx, "mission-loop-out-of-window");
-                    if (toRemoveFromMap == null) toRemoveFromMap = new List<int>();
-                    toRemoveFromMap.Add(idx);
-                    // Re-queue to pendingMapVessels so the create pass re-materializes the orbit
-                    // ghost when the span clock sweeps back into this member's window next cycle.
-                    // Unlike the Tracking Station (which scans all committed indices every frame),
-                    // the flight driver only creates from the pending queue, and the ProtoVessel
-                    // was just removed, so 2a alone could never bring it back.
-                    if (toRequeue == null) toRequeue = new List<(int, string)>();
-                    toRequeue.Add((idx, null));
-                    continue;
-                }
-
-                // Re-aim: for a re-aim loop owner, the flight map orbit line must follow the per-window
-                // RE-AIMED transfer (aimed at the target's CURRENT position), not the recorded geometry
-                // (which points at the target's RECORDED position - the "wrong place in the target's
-                // orbit" the playtest showed). Resolved ONCE here from the LIVE currentUT (same window
-                // the flight engine + tracking station use) and threaded through every effUT-based read
-                // below; reference-identical to rec.OrbitSegments for every non-re-aim member.
-                List<OrbitSegment> effectiveSegments = GhostMapPresence.ResolveEffectiveMapOrbitSegments(
-                    idx, rec.RecordingId, rec.OrbitSegments, currentUT, loopUnits);
-
-                // Same-body carry: while the playback head is inside a body frame, briefly
-                // dropping the ghost between two non-orbit-equivalent segments (e.g., capture
-                // burn between two Mun orbits) would tear down and recreate the ProtoVessel,
-                // producing the visible flicker the user reported near Mun SOI. We only want
-                // to drop the ghost when the body actually changes (SOI / frame change) or
-                // when the recording is truly past its last segment. Body-frame carry keeps
-                // the previous segment's orbit active until UT enters the next segment.
-                OrbitSegment? seg = TrajectoryMath.FindOrbitSegmentOrSameBodyCarry(effectiveSegments, effUT);
-
-                // Gap-points glide: FindOrbitSegmentOrSameBodyCarry keeps seg.HasValue true across a
-                // same-body inter-segment gap by carrying the PREVIOUS segment forward. That is correct
-                // for an equivalent-orbit gap (capture burn between two same Mun orbits) but wrong for a
-                // real orbit RAISE (parking -> higher loiter, sma 671928 -> 731230 across a ~205s arc):
-                // the stale parking orbit freezes the icon, then it teleports ~1318 km onto the loiter
-                // orbit when UT enters the next segment. The recorder captured that raise as body-fixed
-                // Absolute trajectory POINTS, so route the icon onto those points and glide it across the
-                // gap. Gated to the NON-orbit-equivalent gap so the equivalent-orbit carry stays untouched.
-                bool driveGapFromPoints =
-                    seg.HasValue
-                    && GhostMapPresence.ShouldDriveGapFromPoints(effectiveSegments, rec, effUT);
-
-                // Flight-map companion to the TS covering-segment log: same MapTraj on-change diagnostic so the
-                // SOI-exit blink / orbit-line GAP / body flip-flop is visible on the flight path too. When a
-                // segment covers effUT the icon follows that OrbitSegment (source=Segment); when none does and
-                // a terminal state-vector fallback is cached for this member, the icon is driven by that
-                // fallback (resolved in the !seg.HasValue branch below), so report source=StateVector. The
-                // gap-points glide above also drives the icon from the state-vector point path, so report
-                // source=StateVector for it too. The membership check is stable frame-to-frame (it does not
-                // flip-flop) and mirrors the TS path's trackingStationStateVectorOrbitTrajectories check.
-                bool flightIsStateVector =
-                    driveGapFromPoints
-                    || (!seg.HasValue && stateVectorCachedIndices.ContainsKey(idx));
-                GhostMapPresence.LogMapCoveringSegmentChange("FLIGHT", idx, effUT, seg, seg.HasValue && !driveGapFromPoints,
-                    flightIsStateVector,
-                    effectiveSegments != null ? effectiveSegments.Count : 0);
-
-                // Gap-points glide branch: drive the existing (Segment-created) ghost from the recorded
-                // body-fixed point at effUT via the same state-vector positioner the SOI-gap fallback uses.
-                // UpdateGhostOrbitFromStateVectors clears the stale segment-drive dicts (bounds / loop-shift /
-                // epoch-shift) so GhostOrbitIconDrivePatch defers to stock at live UT instead of clamping the
-                // icon past-window on the parking orbit. continue skips the segment-apply tail below.
-                if (driveGapFromPoints)
-                {
-                    int gapCachedIndex = stateVectorCachedIndices.TryGetValue(idx, out int gapCached)
-                        ? gapCached
-                        : -1;
-                    TrajectoryPoint? gapPoint = TrajectoryMath.BracketPointAtUT(rec.Points, effUT, ref gapCachedIndex);
-                    stateVectorCachedIndices[idx] = gapCachedIndex;
-                    if (gapPoint.HasValue)
-                    {
-                        // UpdateGhostOrbitFromStateVectors returns true ONLY in the active-re-fly
-                        // suppression case; false on the normal success path. The flight scene removes the
-                        // ghost via its own re-fly suppression machinery (MarkStateVectorGhostDeferredForActiveReFly
-                        // runs inside the call), so we just record the result for the log here.
-                        bool reFlySuppressed = GhostMapPresence.UpdateGhostOrbitFromStateVectors(
-                            idx, rec, gapPoint.Value, effUT,
-                            stateVectorUpdateReason: "orbit-raise-gap-points",
-                            loopEpochShiftSeconds: loopEpochShiftSeconds);
-                        ParsekLog.VerboseRateLimited("Policy",
-                            "flight-gap-points-glide-" + idx,
-                            string.Format(CultureInfo.InvariantCulture,
-                                "Flight gap-points glide: member={0} effUT={1:F1} body={2} alt={3:F0} reFlySuppressed={4} " +
-                                "(orbit-raise gap, icon glides recorded ascent instead of segment carry)",
-                                idx, effUT, gapPoint.Value.bodyName ?? "(null)", gapPoint.Value.altitude, reFlySuppressed),
-                            2.0);
-                        // The ghost is now state-vector-driven; record a sentinel orbit key (sma/ecc 0)
-                        // via the deferred orbitUpdates list (we cannot mutate lastMapOrbitByIndex during
-                        // its own enumeration) so the next in-segment frame sees a differing key and
-                        // re-applies a fresh covering orbit instead of skip-unchanged.
-                        if (orbitUpdates == null) orbitUpdates = new List<KeyValuePair<int, (string, double, double)>>();
-                        orbitUpdates.Add(new KeyValuePair<int, (string, double, double)>(
-                            idx, (gapPoint.Value.bodyName, 0.0, 0.0)));
-                        continue;
-                    }
-                    // No bracketing point (effUT precedes first / past last recorded point): fall through
-                    // to the unchanged carry/segment-apply path. Never force a single stale point.
-                    ParsekLog.VerboseRateLimited("Policy",
-                        "flight-gap-points-nobracket-" + idx,
-                        string.Format(CultureInfo.InvariantCulture,
-                            "Flight gap-points glide skipped (no bracketing point): member={0} effUT={1:F1} " +
-                            "(falling through to same-body segment carry)",
-                            idx, effUT),
-                        5.0);
-                }
-
-                // No map-visible orbit at current UT — either we've truly left orbital
-                // playback, or the next segment is in a different SOI/body.
-                if (!seg.HasValue)
-                {
-                    int cachedStateVectorIndex = stateVectorCachedIndices.TryGetValue(idx, out int cached)
-                        ? cached
-                        : -1;
-                    if (TryResolveTerminalFallbackMapOrbitUpdate(
-                        rec,
-                        idx,
-                        effUT,
-                        loopEpochShiftSeconds,
-                        kvp.Value,
-                        IsMaterializedForMapPresence(rec),
-                        ref cachedStateVectorIndex,
-                        out OrbitSegment fallbackSegment,
-                        out var fallbackKey,
-                        out bool fallbackChanged))
-                    {
-                        stateVectorCachedIndices[idx] = cachedStateVectorIndex;
-                        if (fallbackChanged)
-                        {
-                            GhostMapPresence.UpdateGhostOrbitForRecording(
-                                idx, fallbackSegment,
-                                loopEpochShiftSeconds: loopEpochShiftSeconds);
-                            if (orbitUpdates == null) orbitUpdates = new List<KeyValuePair<int, (string, double, double)>>();
-                            orbitUpdates.Add(new KeyValuePair<int, (string, double, double)>(idx, fallbackKey));
-                        }
-                        continue;
-                    }
-                    stateVectorCachedIndices[idx] = cachedStateVectorIndex;
-
-                    bool hasFutureSegment = false;
-                    string futureSegmentBody = null;
-                    var segs = effectiveSegments;
-                    for (int s = 0; s < segs.Count; s++)
-                    {
-                        if (segs[s].startUT > effUT)
-                        {
-                            hasFutureSegment = true;
-                            futureSegmentBody = segs[s].bodyName;
-                            break;
-                        }
-                    }
-
-                    if (ShouldRetainMapPresenceForTerminalRealSpawn(rec, hasFutureSegment))
-                    {
-                        string retentionKey = rec.RecordingId ?? idx.ToString(CultureInfo.InvariantCulture);
-                        string reason = rec.TerminalSpawnCannotSpawnSafely
-                            ? rec.TerminalSpawnSafetyReasonCode ?? "cannot-spawn-safely"
-                            : rec.TerminalSpawnSafetyDeferred
-                                ? rec.TerminalSpawnSafetyReasonCode ?? "deferred"
-                                : "pending-terminal-real-spawn";
-                        string message = string.Format(CultureInfo.InvariantCulture,
-                            "Map presence retained because terminal real spawn is pending/deferred: " +
-                            "rec={0} idx={1} vessel=\"{2}\" currentUT={3:F2} reason={4}",
-                            rec.RecordingId ?? "(null)",
-                            idx,
-                            rec.VesselName ?? "(null)",
-                            currentUT,
-                            reason);
-                        if (terminalMapRetentionLoggedIds.Add(retentionKey))
-                            ParsekLog.Info("Policy", message);
-                        else
-                            ParsekLog.VerboseRateLimited(
-                                "Policy",
-                                "terminal-map-retained-" + retentionKey,
-                                message);
-                        continue;
-                    }
-
-                    GhostMapPresence.RemoveGhostVesselForRecording(idx,
-                        hasFutureSegment ? "gap-between-orbit-segments" : "left-orbit-segments");
-
-                    if (hasFutureSegment)
-                    {
-                        // Re-add to pending so the next segment creates a new ProtoVessel
-                        if (toRequeue == null) toRequeue = new List<(int, string)>();
-                        toRequeue.Add((idx, futureSegmentBody));
-                    }
-
-                    if (toRemoveFromMap == null) toRemoveFromMap = new List<int>();
-                    toRemoveFromMap.Add(idx);
-                    continue;
-                }
-
-                // Skip re-applying an unchanged orbit — EXCEPT for loop members, whose stored key
-                // (body/sma/ecc) does not capture the per-cycle epoch + bounds shift, so a cycle
-                // wrap onto the same-shape segment would otherwise leave a stale shift and mis-clip
-                // the arc. Loop members re-apply every tick (cheap; the shift is constant within a
-                // cycle so this is idempotent until the wrap).
-                if (loopEpochShiftSeconds == 0.0
-                    && seg.Value.bodyName == kvp.Value.body
-                    && seg.Value.semiMajorAxis == kvp.Value.sma
-                    && seg.Value.eccentricity == kvp.Value.ecc)
-                    continue;
-
-                GhostMapPresence.UpdateGhostOrbitForRecording(
-                    idx, seg.Value,
-                    loopEpochShiftSeconds: loopEpochShiftSeconds,
-                    effectiveOrbitSegments: effectiveSegments);
-                if (orbitUpdates == null) orbitUpdates = new List<KeyValuePair<int, (string, double, double)>>();
-                orbitUpdates.Add(new KeyValuePair<int, (string, double, double)>(
-                    idx, (seg.Value.bodyName, seg.Value.semiMajorAxis, seg.Value.eccentricity)));
-            }
-
-            if (orbitUpdates != null)
-            {
-                for (int i = 0; i < orbitUpdates.Count; i++)
-                    lastMapOrbitByIndex[orbitUpdates[i].Key] = orbitUpdates[i].Value;
-            }
-            if (toRemoveFromMap != null)
-            {
-                for (int i = 0; i < toRemoveFromMap.Count; i++)
-                    lastMapOrbitByIndex.Remove(toRemoveFromMap[i]);
-            }
-            if (toRequeue != null)
-            {
-                for (int i = 0; i < toRequeue.Count; i++)
-                {
-                    int idx = toRequeue[i].idx;
-                    if (!pendingMapVessels.ContainsKey(idx) && idx < committed.Count)
-                    {
-                        var traj = committed[idx] as IPlaybackTrajectory;
-                        if (traj != null)
-                        {
-                            pendingMapVessels[idx] = new PendingMapVessel(
-                                traj,
-                                allowSoiGapStateVectorFallback: true,
-                                expectedSoiGapBody: toRequeue[i].expectedBody);
-                            ParsekLog.Verbose("MapPresence",
-                                $"Re-queued recording #{idx} to pendingMapVessels (gap between orbit segments expectedBody={toRequeue[i].expectedBody ?? "(none)"})");
-                        }
-                    }
-                }
-            }
-
-            // 2b. State-vector orbit updates (new — physics-only suborbital)
-            if (stateVectorOrbitTrajectories.Count > 0)
-            {
-                List<int> toReDefer = null;
-                List<int> toExitStateVector = null;
-                List<KeyValuePair<int, (string body, double sma, double ecc)>> stateVectorSegmentUpdates = null;
-
-                foreach (var kvp in stateVectorOrbitTrajectories)
-                {
-                    int idx = kvp.Key;
-                    IPlaybackTrajectory traj = kvp.Value;
-
-                    if (!stateVectorCachedIndices.ContainsKey(idx))
-                        stateVectorCachedIndices[idx] = -1;
-                    int cached = stateVectorCachedIndices[idx];
-
-                    // Loop-mapped sample UT + live-frame epoch shift (effUT == currentUT, shift 0
-                    // off the loop path). renderHidden => the member is outside its loop window
-                    // this cycle: tear the ghost down and re-defer so the create pass re-materializes
-                    // it when the span clock sweeps back into its window.
-                    double effUT = ResolveMapPresenceSampleUT(
-                        idx, traj.StartUT, traj.EndUT, currentUT, loopUnits,
-                        out bool renderHidden, out double loopEpochShiftSeconds);
-                    if (renderHidden)
-                    {
-                        GhostMapPresence.RemoveGhostVesselForRecording(idx, "mission-loop-out-of-window");
-                        if (toReDefer == null) toReDefer = new List<int>();
-                        toReDefer.Add(idx);
-                        continue;
-                    }
-
-                    if (soiGapStateVectorExpectedBodies.TryGetValue(idx, out string expectedSoiGapBody))
-                    {
-                        // Loop-aware caller (state-vector orbit update pass): plan section 1.4.
-                        bool acceptTerminalOrbitForLoopSynthesis =
-                            loopEpochShiftSeconds != 0.0
-                            && GhostMapPresence.IsTerminalOrbitSynthesisSafeForLoopMember(traj);
-                        TrackingStationGhostSource source = GhostMapPresence.ResolveMapPresenceGhostSource(
-                            traj,
-                            false,
-                            IsMaterializedForMapPresence(traj),
-                            effUT,
-                            true,
-                            "map-presence-soi-gap-state-vector-update",
-                            ref cached,
-                            out OrbitSegment segment,
-                            out TrajectoryPoint soiGapPoint,
-                            out _,
-                            recordingIndex: idx,
-                            allowSoiGapStateVectorFallback: true,
-                            expectedSoiGapBody: expectedSoiGapBody,
-                            acceptTerminalOrbitForLoopSynthesis: acceptTerminalOrbitForLoopSynthesis,
-                            // Keep updating a loop member's ghost alongside any persisted real
-                            // terminal vessel (mirrors the create-path bypass).
-                            loopMemberInWindow: loopEpochShiftSeconds != 0.0);
-                        stateVectorCachedIndices[idx] = cached;
-
-                        if (source == TrackingStationGhostSource.StateVectorSoiGap)
-                        {
-                            if (GhostMapPresence.UpdateGhostOrbitFromStateVectors(
-                                idx,
-                                traj,
-                                soiGapPoint,
-                                effUT,
-                                allowOrbitalCheckpointStateVector: true,
-                                stateVectorUpdateReason: "soi-gap-state-vector-fallback",
-                                loopEpochShiftSeconds: loopEpochShiftSeconds))
-                            {
-                                GhostMapPresence.RemoveGhostVesselForRecording(
-                                    idx,
-                                    GhostMapPresence.TrackingStationGhostSkipActiveReFlyRelativeUpdate);
-                                if (toReDefer == null) toReDefer = new List<int>();
-                                toReDefer.Add(idx);
-                            }
-                            continue;
-                        }
-
-                        if (source == TrackingStationGhostSource.Segment
-                            || source == TrackingStationGhostSource.TerminalOrbit
-                            || source == TrackingStationGhostSource.EndpointTail)
-                        {
-                            // EndpointTail populates a valid `segment` out-param exactly
-                            // like TerminalOrbit (the loop-synthesis no-segment fallback),
-                            // so consume it here too; otherwise a terminal-region loop
-                            // member resolving to EndpointTail would fall through to the
-                            // flat BracketPointAtUT path below. Matches the pending-create
-                            // (line ~1387) and orbit-update (line ~1922) callers.
-                            GhostMapPresence.UpdateGhostOrbitForRecording(
-                                idx, segment,
-                                loopEpochShiftSeconds: loopEpochShiftSeconds);
-                            if (TryGetMapOrbitKey(source, segment, out var segmentKey))
-                            {
-                                if (stateVectorSegmentUpdates == null)
-                                    stateVectorSegmentUpdates = new List<KeyValuePair<int, (string, double, double)>>();
-                                stateVectorSegmentUpdates.Add(new KeyValuePair<int, (string, double, double)>(idx, segmentKey));
-                            }
-
-                            if (toExitStateVector == null) toExitStateVector = new List<int>();
-                            toExitStateVector.Add(idx);
-                            continue;
-                        }
-                    }
-
-                    TrajectoryPoint? pt = TrajectoryMath.BracketPointAtUT(traj.Points, effUT, ref cached);
-                    stateVectorCachedIndices[idx] = cached;
-
-                    if (!pt.HasValue) continue;
-
-                    // Relative-frame points reuse `TrajectoryPoint.altitude` as the
-                    // anchor-local dz offset (metres along the anchor's local z axis),
-                    // not as geographic altitude. Feeding the dz into the
-                    // `ShouldRemoveStateVectorOrbit` altitude threshold trips the
-                    // remove path on every typical rendezvous frame (dz ~ 0) and
-                    // re-defers the ghost — but pending-create currently skips
-                    // Relative frames, so the ghost disappears through the section
-                    // rather than staying attached to the anchor (#547 P1 review).
-                    // Skip the threshold check entirely for Relative-frame points;
-                    // `UpdateGhostOrbitFromStateVectors` already dispatches on
-                    // `referenceFrame` and resolves the world position via
-                    // anchor + offset for that branch.
-                    bool inRelativeFrame = GhostMapPresence.IsInRelativeFrame(traj, effUT);
-                    if (!inRelativeFrame)
-                    {
-                        double atmosRemove = GetAtmosphereDepth(pt.Value.bodyName);
-                        if (ShouldRemoveStateVectorOrbit(pt.Value.altitude, pt.Value.velocity.magnitude, atmosRemove))
-                        {
-                            GhostMapPresence.RemoveGhostVesselForRecording(idx, "below-state-vector-threshold");
-                            if (toReDefer == null) toReDefer = new List<int>();
-                            toReDefer.Add(idx);
-                            ParsekLog.Info("Policy", string.Format(CultureInfo.InvariantCulture,
-                                "Removed state-vector ghost map vessel for #{0} — alt={1:F0} speed={2:F1} below threshold",
-                                idx, pt.Value.altitude, pt.Value.velocity.magnitude));
-                            continue;
-                        }
-                    }
-
-                    if (GhostMapPresence.UpdateGhostOrbitFromStateVectors(idx, traj, pt.Value, effUT,
-                        loopEpochShiftSeconds: loopEpochShiftSeconds))
-                    {
-                        GhostMapPresence.RemoveGhostVesselForRecording(
-                            idx,
-                            GhostMapPresence.TrackingStationGhostSkipActiveReFlyRelativeUpdate);
-                        if (toReDefer == null) toReDefer = new List<int>();
-                        toReDefer.Add(idx);
-                    }
-                }
-
-                if (toReDefer != null)
-                {
-                    for (int i = 0; i < toReDefer.Count; i++)
-                    {
-                        int idx = toReDefer[i];
-                        if (stateVectorOrbitTrajectories.TryGetValue(idx, out var traj))
-                            pendingMapVessels[idx] = new PendingMapVessel(
-                                traj,
-                                allowSoiGapStateVectorFallback: false,
-                                expectedSoiGapBody: null);
-                        stateVectorOrbitTrajectories.Remove(idx);
-                        soiGapStateVectorExpectedBodies.Remove(idx);
-                        // stateVectorCachedIndices[idx] intentionally kept — avoids
-                        // O(n) re-scan if the ghost re-ascends above threshold.
-                    }
-                }
-
-                if (stateVectorSegmentUpdates != null)
-                {
-                    for (int i = 0; i < stateVectorSegmentUpdates.Count; i++)
-                        lastMapOrbitByIndex[stateVectorSegmentUpdates[i].Key] = stateVectorSegmentUpdates[i].Value;
-                }
-
-                if (toExitStateVector != null)
-                {
-                    for (int i = 0; i < toExitStateVector.Count; i++)
-                    {
-                        int idx = toExitStateVector[i];
-                        stateVectorOrbitTrajectories.Remove(idx);
-                        soiGapStateVectorExpectedBodies.Remove(idx);
-                    }
-                }
-            }
-
-            GhostMapPresence.EmitLifecycleSummary("flight-map-presence", currentUT);
-        }
-
-        private void PruneTerminalMapRetentionLogKeys(IReadOnlyList<Recording> committed)
-        {
-            if (terminalMapRetentionLoggedIds.Count == 0)
-                return;
-
-            if (committed == null || committed.Count == 0)
-            {
-                terminalMapRetentionLoggedIds.Clear();
-                return;
-            }
-
-            List<string> staleKeys = null;
-            foreach (string key in terminalMapRetentionLoggedIds)
-            {
-                bool found = false;
-                for (int i = 0; i < committed.Count; i++)
-                {
-                    var rec = committed[i];
-                    if (rec == null)
-                        continue;
-
-                    if (string.Equals(rec.RecordingId, key, StringComparison.Ordinal)
-                        || (string.IsNullOrEmpty(rec.RecordingId)
-                            && key == i.ToString(CultureInfo.InvariantCulture)))
-                    {
-                        found = true;
-                        break;
-                    }
-                }
-
-                if (!found)
-                {
-                    if (staleKeys == null) staleKeys = new List<string>();
-                    staleKeys.Add(key);
-                }
-            }
-
-            if (staleKeys == null)
-                return;
-
-            for (int i = 0; i < staleKeys.Count; i++)
-                terminalMapRetentionLoggedIds.Remove(staleKeys[i]);
-        }
-
-        private static bool TryGetMapOrbitKey(
-            TrackingStationGhostSource source,
-            OrbitSegment segment,
-            out (string body, double sma, double ecc) orbitKey)
-        {
-            if (source == TrackingStationGhostSource.Segment
-                || source == TrackingStationGhostSource.TerminalOrbit)
-            {
-                orbitKey = (segment.bodyName, segment.semiMajorAxis, segment.eccentricity);
-                return true;
-            }
-
-            orbitKey = default((string, double, double));
-            return false;
-        }
-
         internal static bool TryResolveTerminalFallbackMapOrbitUpdate(
             Recording rec,
             int idx,
@@ -2174,28 +1389,6 @@ namespace Parsek
             return true;
         }
 
-        private static bool IsMaterializedForMapPresence(IPlaybackTrajectory traj)
-        {
-            var rec = traj as Recording;
-            if (rec == null)
-                return false;
-
-            bool realVesselExists = false;
-            if (rec.VesselPersistentId != 0)
-            {
-                try
-                {
-                    realVesselExists = FlightRecorder.FindVesselByPid(rec.VesselPersistentId) != null;
-                }
-                catch (Exception)
-                {
-                    realVesselExists = false;
-                }
-            }
-
-            return GhostMapPresence.IsTrackingStationRecordingMaterialized(rec, realVesselExists);
-        }
-
         /// <summary>
         /// Returns true if the trajectory is in an orbital segment at the given UT
         /// (i.e., recording starts in orbit, no atmospheric ascent phase before first segment).
@@ -2203,30 +1396,6 @@ namespace Parsek
         internal static bool StartsInOrbit(IPlaybackTrajectory traj, double ut)
         {
             return GhostMapPresence.StartsInOrbit(traj, ut);
-        }
-
-        /// <summary>
-        /// If the recording at the given index belongs to a chain and another segment
-        /// from the same chain currently owns a ghost map vessel, remove the old one.
-        /// Updates chainMapOwner to track the new owner.
-        /// </summary>
-        private void RemovePreviousChainMapVessel(int newIndex)
-        {
-            var committed = RecordingStore.CommittedRecordings;
-            if (committed == null || newIndex < 0 || newIndex >= committed.Count) return;
-
-            string chainId = committed[newIndex].ChainId;
-            if (string.IsNullOrEmpty(chainId)) return;
-
-            if (chainMapOwner.TryGetValue(chainId, out int oldIndex) && oldIndex != newIndex)
-            {
-                GhostMapPresence.RemoveGhostVesselForRecording(oldIndex, "chain-segment-replaced");
-                lastMapOrbitByIndex.Remove(oldIndex);
-                ParsekLog.Verbose("Policy",
-                    $"Chain dedup: removed ghost map for #{oldIndex} (replaced by #{newIndex} in chain {chainId})");
-            }
-
-            chainMapOwner[chainId] = newIndex;
         }
 
         private void HandleGhostDestroyed(GhostLifecycleEvent evt)
@@ -2238,11 +1407,11 @@ namespace Parsek
             // If a held ghost was destroyed externally (e.g. soft cap, DestroyAllGhosts),
             // remove it from the held set so we don't try to destroy it again
             heldGhosts.Remove(evt.Index);
-            pendingMapVessels.Remove(evt.Index);
-            lastMapOrbitByIndex.Remove(evt.Index);
-            stateVectorOrbitTrajectories.Remove(evt.Index);
-            soiGapStateVectorExpectedBodies.Remove(evt.Index);
-            stateVectorCachedIndices.Remove(evt.Index);
+            GhostMapPresence.flightPendingMapVessels.Remove(evt.Index);
+            GhostMapPresence.flightLastMapOrbitByIndex.Remove(evt.Index);
+            GhostMapPresence.flightStateVectorOrbitTrajectories.Remove(evt.Index);
+            GhostMapPresence.flightSoiGapStateVectorExpectedBodies.Remove(evt.Index);
+            GhostMapPresence.flightStateVectorCachedIndices.Remove(evt.Index);
 
             // Remove both recording-index and chain-based ghost map ProtoVessels
             var committed = RecordingStore.CommittedRecordings;
@@ -2251,7 +1420,7 @@ namespace Parsek
             {
                 vesselPid = committed[evt.Index].VesselPersistentId;
                 if (!string.IsNullOrEmpty(committed[evt.Index].RecordingId))
-                    terminalMapRetentionLoggedIds.Remove(committed[evt.Index].RecordingId);
+                    GhostMapPresence.flightTerminalMapRetentionLoggedIds.Remove(committed[evt.Index].RecordingId);
             }
 
             GhostMapPresence.RemoveAllGhostPresenceForIndex(evt.Index, vesselPid, "ghost-destroyed");
@@ -2278,13 +1447,7 @@ namespace Parsek
             pendingFlagReplayFailureCounts.Clear();
             pendingWatchRecordingId = null;
             heldGhosts.Clear();
-            pendingMapVessels.Clear();
-            lastMapOrbitByIndex.Clear();
-            chainMapOwner.Clear();
-            stateVectorOrbitTrajectories.Clear();
-            soiGapStateVectorExpectedBodies.Clear();
-            stateVectorCachedIndices.Clear();
-            terminalMapRetentionLoggedIds.Clear();
+            GhostMapPresence.ClearFlightMapPresenceState();
         }
 
         /// <summary>
@@ -2299,13 +1462,7 @@ namespace Parsek
             engine.OnOverlapExpired -= HandleOverlapExpired;
             engine.OnAllGhostsDestroying -= HandleAllGhostsDestroying;
             heldGhosts.Clear();
-            pendingMapVessels.Clear();
-            lastMapOrbitByIndex.Clear();
-            chainMapOwner.Clear();
-            stateVectorOrbitTrajectories.Clear();
-            soiGapStateVectorExpectedBodies.Clear();
-            stateVectorCachedIndices.Clear();
-            terminalMapRetentionLoggedIds.Clear();
+            GhostMapPresence.ClearFlightMapPresenceState();
             ParsekLog.Info("Policy", "ParsekPlaybackPolicy disposed and unsubscribed from 6 engine events");
         }
 

--- a/docs/dev/plans/maprender-8d-presence-extraction.md
+++ b/docs/dev/plans/maprender-8d-presence-extraction.md
@@ -50,15 +50,53 @@ Byte-identical: same method, same argument, same execution slot. `policy?.` cann
 unconditional `policy.` because `SetPresenceDriver` runs unconditionally at init before any frame. No
 director gate added. Source-gate test `MapPresenceSeamTests` locks the host off the direct call.
 
-### 8d.1 - relocate the body (gated, legacy as gate-off fallback)
-Move the ~660-line `CheckPendingMapVessels` body and the six presence dictionaries into
-`GhostMapPresence.UpdateFlightMapGhostLifecycle`. Under `mapRenderDirectorDrive` the seam dispatches to
-the migrated body; with the gate off it dispatches to the legacy in-policy body (kept verbatim as the
-fallback, deleted in 8e). This is the riskiest slice: the body owns proto creation/destruction,
-state-vector orbit caching, SOI-gap handling, and chain map ownership. Expect multiple in-game
-validation cycles (looped re-aim "Duna One" + a non-looped Mun mission through landing), watching for
-any presence regression: a ghost that should be on the map vanishing, a stale ghost that should be torn
-down lingering, or a state-vector / SOI-gap glitch. Gate OFF must stay byte-identical.
+### 8d.1 - relocate the body (PURE MOVE, no gate)
+Move the ~660-line `CheckPendingMapVessels` body and the six presence dictionaries
+(`pendingMapVessels`, `lastMapOrbitByIndex`, `stateVectorOrbitTrajectories`, `stateVectorCachedIndices`,
+`soiGapStateVectorExpectedBodies`, `chainMapOwner`) + `terminalMapRetentionLoggedIds` +
+`nextMapOrbitUpdateTime` into `GhostMapPresence.UpdateFlightMapGhostLifecycle(double currentUT,
+LoopUnitSet loopUnits)`.
+
+**Decision (2026-06-05): pure move, NOT a gated dispatch.** The original sketch kept the legacy body as
+a `mapRenderDirectorDrive` gate-off fallback, but the plan analysis showed the body is already a thin
+orchestrator over `GhostMapPresence.*` statics (every proto/KSP mutation already routes through them; the
+only engine read is `CurrentLoopUnits`; the six dicts are touched ONLY inside `ParsekPlaybackPolicy.cs`,
+zero external sites). So the relocation is a FAITHFUL COPY with no logic change. A gate would toggle
+between two behaviorally identical paths (validating nothing) at the cost of ~655 lines of duplication
+held in sync until 8e, and gate-off could not stay literally untouched anyway (the dicts move, so the
+legacy body's dict accesses would be redirected regardless). Therefore 8d.1 is a no-behavior-change
+relocation (like 8d.0 / 8b.0): cut the body to `GhostMapPresence`, the seam ALWAYS calls it, no gate
+branch, `CheckPendingMapVessels` deleted from the policy.
+
+Mechanics:
+- The six dicts + 2 scalars + the `PendingMapVessel` struct move to `GhostMapPresence` as `internal
+  static` members (`flight*`-prefixed, matching the existing `trackingStation*` TS twins). They become
+  `internal` (not `private`) so the still-in-policy enqueue tail + teardowns (8d.2) reach them directly
+  during the 8d.1->8d.2 window.
+- The helpers that touch only these dicts move with the body and become static:
+  `RemovePreviousChainMapVessel`, `PruneTerminalMapRetentionLogKeys`, `ResolveMapPresenceSampleUT`,
+  `TryGetMapOrbitKey`, `IsMaterializedForMapPresence`. Already-static helpers
+  (`ShouldRunMapOrbitReseed`, `TryResolveTerminalFallbackMapOrbitUpdate`,
+  `ShouldRetainMapPresenceForTerminalRealSpawn`) co-locate.
+- `loopUnits` is supplied as `engine.CurrentLoopUnits` (the EXACT source the body used). The dispatcher
+  must NOT substitute the scene's cached `LoopUnits` (the `MissionLoopUnitBuilder.Build` output pushed
+  via `SetFrameInputs`), which is a different source per the integration contract. Add a policy
+  pass-through (e.g. `ParsekPlaybackPolicy.CurrentLoopUnitsForPresence => engine.CurrentLoopUnits`) and
+  have `MapViewScene.DriveMapPresence` call `GhostMapPresence.UpdateFlightMapGhostLifecycle(currentUT,
+  policy.CurrentLoopUnitsForPresence)`.
+- The enqueue tail (`HandleGhostCreated`) and teardowns (`HandleGhostDestroyed`,
+  `HandleAllGhostsDestroying`, `Dispose`) STAY in the policy (that is 8d.2); they redirect their dict
+  references to the moved `GhostMapPresence.flight*` fields. Add a `ClearFlightMapPresenceState()` for
+  the bulk-clear teardowns.
+- ERS/ELS: the body reads `RecordingStore.CommittedRecordings`; confirm `GhostMapPresence` is in
+  `scripts/ers-els-audit-allowlist.txt` (it almost certainly already is, since the resolver statics it
+  already hosts read that collection). `GrepAuditTests` is the backstop.
+
+This is still the riskiest slice (a 655-line faithful cut-paste touching proto create/destroy,
+state-vector caching, SOI-gap, chain ownership), so it ships on a HARD clean-context review + green
+tests. No in-game A/B gate is needed (behavior is unchanged by construction), though the maintainer
+still playtests the merged build (Duna One looped re-aim + a non-looped Mun mission through landing)
+as the standard post-merge check, watching for any presence regression.
 
 ### 8d.2 - enqueue + teardown ownership
 Move the presence enqueue tail and the scene-change teardown into the same migrated owner, behind the

--- a/docs/dev/plans/maprender-rewrite-status.md
+++ b/docs/dev/plans/maprender-rewrite-status.md
@@ -288,10 +288,19 @@ reconciler for decision-vs-old-truth parity, and resolve the in-game probes befo
     because `SetPresenceDriver` runs unconditionally at init before any frame; no director gate added.
     The `CheckPendingMapVessels` body + the 6 dictionaries are UNTOUCHED (that is 8d.1). Source-gate test
     `MapPresenceSeamTests` (4) locks the host off the direct call. Build clean; full suite green (13412).
-  - **8d.1 (next, single PR) - relocate the body.** Move `CheckPendingMapVessels` + the 6 dictionaries
-    into `GhostMapPresence.UpdateFlightMapGhostLifecycle`, gate ON -> migrated body, gate OFF -> legacy
-    in-policy body (verbatim fallback, deleted in 8e). Riskiest slice; multiple in-game validation cycles
-    (looped re-aim "Duna One" + a non-looped Mun mission through landing).
+  - **8d.1 (next, single PR) - relocate the body (PURE MOVE, no gate).** Move `CheckPendingMapVessels`
+    + the 6 dictionaries (+ `terminalMapRetentionLoggedIds` + `nextMapOrbitUpdateTime` + the
+    `PendingMapVessel` struct) into `GhostMapPresence.UpdateFlightMapGhostLifecycle(currentUT,
+    loopUnits)`; the seam ALWAYS calls it, `CheckPendingMapVessels` deleted from the policy. **Decision
+    (2026-06-05):** the body is a thin orchestrator over `GhostMapPresence.*` statics (every proto/KSP
+    mutation already routes through them; only engine read is `CurrentLoopUnits`; the 6 dicts are touched
+    ONLY in `ParsekPlaybackPolicy.cs`), so the relocation is a FAITHFUL COPY with no logic change; a gate
+    would toggle two identical paths and duplicate ~655 lines, so 8d.1 is a no-behavior-change move (like
+    8d.0 / 8b.0). `loopUnits` MUST be `engine.CurrentLoopUnits` (NOT the scene's cached `LoopUnits`,
+    a different source). The 6 dicts become `internal static` on `GhostMapPresence` (the still-in-policy
+    enqueue tail + teardowns reach them directly until 8d.2 moves them). Riskiest slice (655-line cut),
+    so it ships on a HARD clean-context review + green tests; maintainer playtests the merged build
+    (Duna One looped re-aim + a non-looped Mun mission through landing) as the standard post-merge check.
   - **8d.2** - enqueue + scene-change teardown ownership (gated, legacy fallback).
   - **8d.3** - decompose into named sub-passes + pure-extract predicates with unit tests.
 - **Phase 8** per-surface cutover (8a-8e) - deletes the scattered gates; in-game per sub-phase.


### PR DESCRIPTION
## Phase 8d.1 - flight map-presence relocation (pure move, no behavior change)

Second slice of phase 8d. Moves the last big autonomous render surface, the ghost map-presence lifecycle, out of `ParsekPlaybackPolicy` and into `GhostMapPresence`, so phase 8e can finish the cutover. Full sub-plan: `docs/dev/plans/maprender-8d-presence-extraction.md`.

### What moved
- `ParsekPlaybackPolicy.CheckPendingMapVessels` (~655 lines) -> `GhostMapPresence.UpdateFlightMapGhostLifecycle(double currentUT, GhostPlaybackLogic.LoopUnitSet loopUnits)`. The 8d.0 flight seam `MapViewScene.DriveMapPresence` now calls the relocated method directly; `CheckPendingMapVessels` is deleted from the policy.
- The 6 presence dictionaries (`pendingMapVessels`, `lastMapOrbitByIndex`, `stateVectorOrbitTrajectories`, `stateVectorCachedIndices`, `soiGapStateVectorExpectedBodies`, `chainMapOwner`) + `terminalMapRetentionLoggedIds` + `nextMapOrbitUpdateTime` (+ `MapOrbitUpdateIntervalSec`) + the `PendingMapVessel` struct moved to `GhostMapPresence` as `internal static` (`flight*`-prefixed, mirroring the existing `trackingStation*` twins).
- Dict-touching helpers moved with the body (`ResolveMapPresenceSampleUT`, `PruneTerminalMapRetentionLogKeys`, `TryGetMapOrbitKey`, `IsMaterializedForMapPresence`, `RemovePreviousChainMapVessel`); new `ClearFlightMapPresenceState()` for the bulk-clear teardowns.

### Why it is no behavior change
The body was already a thin orchestrator over `GhostMapPresence.*` statics: every proto/KSP mutation already routed through them, the only engine read was `CurrentLoopUnits`, and the 6 dicts were touched only inside `ParsekPlaybackPolicy.cs` (zero external sites). So the relocation is a faithful copy. A `mapRenderDirectorDrive` gate would only toggle two behaviorally identical paths while duplicating ~655 lines, so this ships as a pure move (like 8d.0 / 8b.0), not a gated dispatch.

Key fidelity points:
- `loopUnits` is supplied as `policy.CurrentLoopUnitsForPresence => engine.CurrentLoopUnits`, the exact original source (NOT the scene's cached `LoopUnits` from `SetFrameInputs`, which is a different source per the integration contract).
- Presence still runs for re-aim / overlap members the Director skips: no `IsDirectorDriveActive` coupling anywhere.
- The enqueue tail (`HandleGhostCreated`) and teardowns (`HandleGhostDestroyed` / `HandleAllGhostsDestroying` / `Dispose`) stay in the policy (that is 8d.2); they redirect their dict references to the moved members via the `internal static` visibility.

### Review
Clean-context review verdict: SHIP. Independent empty-diff faithfulness check on both the 655-line relocated body and the edited teardown/enqueue redirects (only the permitted transforms: signature, `engine.CurrentLoopUnits` -> param, `flight*` re-qualification, cross-class helper qualification). `ClearFlightMapPresenceState` verified to clear the exact 7-collection set both `HandleAllGhostsDestroying` and `Dispose` cleared. `RemovePreviousChainMapVessel` reachable + correctly qualified from both callers.

### Tests + build
- Build clean (0 warnings / 0 errors).
- Full suite green: 13415 passed, 0 failed, 0 skipped.
- `GhostMapPresence` is already ERS-exempt (allowlist + file-level comment), so the moved `RecordingStore.CommittedRecordings` read keeps `GrepAuditTests` green.
- Source-gate `MapPresenceSeamTests` extended to lock the routing target, the loop-units source, the `UpdateFlightMapGhostLifecycle` declaration, the absence of `CheckPendingMapVessels` + the 6 dict declarations in the policy, and the no-director-gate property of the relocated body.

No CHANGELOG entry (no user-facing change). Standard post-merge in-game check: Duna One looped re-aim + a non-looped Mun mission through landing.