### PR TITLE
maprender(8d.2): extract the presence portions of the ghost lifecycle handlers into GhostMapPresence

### DIFF
--- a/Source/Parsek.Tests/MapRender/MapPresenceSeamTests.cs
+++ b/Source/Parsek.Tests/MapRender/MapPresenceSeamTests.cs
@@ -154,6 +154,53 @@ namespace Parsek.Tests
         }
 
         [Fact]
+        public void GhostMapPresence_Declares_GhostCreatedAndDestroyedMapPresence_8d2()
+        {
+            string source = ReadSource("Source", "Parsek", "GhostMapPresence.cs");
+
+            // Phase 8d.2 relocated the map-presence portions of the policy's two ghost-lifecycle
+            // handlers here as internal static methods.
+            Assert.Contains("internal static void HandleFlightGhostCreatedMapPresence(", source);
+            Assert.Contains("internal static void HandleFlightGhostDestroyedMapPresence(", source);
+        }
+
+        [Fact]
+        public void ParsekPlaybackPolicy_HandleGhostCreated_DelegatesPresence_KeepsCameraConcern_8d2()
+        {
+            string source = ReadSource("Source", "Parsek", "ParsekPlaybackPolicy.cs");
+            string codeOnly = StripLineComments(source);
+
+            // The handler delegates the presence enqueue to the relocated GhostMapPresence method...
+            Assert.Contains("GhostMapPresence.HandleFlightGhostCreatedMapPresence(", codeOnly);
+            // ...while the camera-follow concern stays in the policy.
+            Assert.Contains("TryAutoFollowChainSeamSpawn(", codeOnly);
+
+            // ...and the moved enqueue statements no longer live in the policy (proving move, not
+            // copy): the pending-queue write (both the indexer access and the PendingMapVessel
+            // construction) is gone. (ResolveMapPresenceGhostSource is intentionally NOT asserted
+            // absent: TryResolveTerminalFallbackMapOrbitUpdate, a helper kept in the policy per the
+            // plan, still calls it.)
+            Assert.DoesNotContain("flightPendingMapVessels[", codeOnly);
+            Assert.DoesNotContain("new GhostMapPresence.PendingMapVessel(", codeOnly);
+        }
+
+        [Fact]
+        public void ParsekPlaybackPolicy_HandleGhostDestroyed_DelegatesPresence_KeepsHeldGhosts_8d2()
+        {
+            string source = ReadSource("Source", "Parsek", "ParsekPlaybackPolicy.cs");
+            string codeOnly = StripLineComments(source);
+
+            // The handler delegates the presence teardown to the relocated GhostMapPresence method...
+            Assert.Contains("GhostMapPresence.HandleFlightGhostDestroyedMapPresence(", codeOnly);
+            // ...while the soft-cap held-ghost removal stays in the policy.
+            Assert.Contains("heldGhosts.Remove(", codeOnly);
+
+            // ...and the moved teardown statements no longer live in the policy (proving move, not
+            // copy): the per-index ghost-presence removal call is gone.
+            Assert.DoesNotContain("RemoveAllGhostPresenceForIndex(", codeOnly);
+        }
+
+        [Fact]
         public void IGhostMapScene_Declares_DriveMapPresence()
         {
             string source = ReadSource("Source", "Parsek", "MapRender", "IGhostMapScene.cs");

--- a/Source/Parsek/GhostMapPresence.cs
+++ b/Source/Parsek/GhostMapPresence.cs
@@ -10879,5 +10879,184 @@ namespace Parsek
 
             flightChainMapOwner[chainId] = newIndex;
         }
+
+        // ===================================================================================
+        // Flight-scene ghost-create / ghost-destroy MAP-PRESENCE portions (Phase 8d.2 relocation
+        // from ParsekPlaybackPolicy.HandleGhostCreated / HandleGhostDestroyed). FAITHFUL MOVE —
+        // the blocks below were copied VERBATIM from those two handlers. The only edits are:
+        // (a) engine.CurrentLoopUnits -> the loopUnits parameter (HandleFlightGhostCreatedMapPresence),
+        // (b) the ShouldDeferLoopShiftedMapPresence predicate (left in ParsekPlaybackPolicy — it has
+        // test callers there) is qualified with ParsekPlaybackPolicy., and (c) now-redundant
+        // GhostMapPresence. self-qualifiers on members that are in-class here were stripped. The
+        // policy keeps the engine-event subscription wiring + the non-presence concerns
+        // (TryAutoFollowChainSeamSpawn camera follow, heldGhosts soft-cap state).
+        // ===================================================================================
+
+        /// <summary>
+        /// Map-presence ENQUEUE portion of <c>ParsekPlaybackPolicy.HandleGhostCreated</c> (Phase 8d.2
+        /// relocation): debris-skip gate, terminal-eligibility / orbit-data gates, per-chain dedup,
+        /// initial source resolution, the loop-aware defer decision, and the immediate-create vs
+        /// pending-queue branch. The policy's handler runs <c>TryAutoFollowChainSeamSpawn(evt)</c>
+        /// (camera concern) first, then calls this. <paramref name="loopUnits"/> is the engine's
+        /// per-frame <c>CurrentLoopUnits</c> the policy reads at the call site.
+        /// </summary>
+        internal static void HandleFlightGhostCreatedMapPresence(
+            GhostLifecycleEvent evt, GhostPlaybackLogic.LoopUnitSet loopUnits)
+        {
+            // KEEP debris-only: this is the policy decision to NOT give debris
+            // recordings their own tracking-station map presence / orbit lines.
+            // Controlled-decoupled children (extension of the parent-anchor
+            // contract) carry IsDebris=false and correctly pass this gate so
+            // they continue to receive map presence as today.
+            if (evt.Trajectory == null || evt.Trajectory.IsDebris)
+            {
+                if (evt.Trajectory?.IsDebris == true)
+                    ParsekLog.Verbose("Policy",
+                        $"Skipped ghost map for #{evt.Index} \"{evt.Trajectory?.VesselName}\" - debris");
+                return;
+            }
+
+            var terminal = evt.Trajectory.TerminalStateValue;
+            if (!IsTerminalStateEligibleForMapPresence(terminal))
+            {
+                ParsekLog.VerboseRateLimited("Policy", $"skip-map-terminal-{evt.Index}",
+                    $"Skipped ghost map for #{evt.Index} \"{evt.Trajectory.VesselName}\" — terminal={terminal.Value}");
+                return;
+            }
+
+            // Accept recordings with terminal orbit data, orbit segments, or trajectory
+            // points (physics-only suborbital recordings have points but no orbit data).
+            bool hasOrbitData = HasOrbitData(evt.Trajectory);
+            bool hasOrbitSegments = evt.Trajectory.HasOrbitSegments;
+            bool hasPoints = evt.Trajectory.Points != null && evt.Trajectory.Points.Count > 0;
+            if (!hasOrbitData && !hasOrbitSegments && !hasPoints)
+                return;
+
+            // Per-chain dedup: if another segment from the same chain already has a ghost
+            // map vessel, remove it before creating the new one. Prevents duplicate orbit
+            // lines during fast time warp across chain boundaries.
+            RemovePreviousChainMapVessel(evt.Index);
+
+            // Check whether the ghost starts in a map-visible source. Otherwise,
+            // defer — the per-frame shared resolver will create it when it enters
+            // an orbital segment or state-vector fallback range.
+            double startUT = evt.Trajectory.StartUT;
+            int cachedStateVectorIndex = flightStateVectorCachedIndices.TryGetValue(evt.Index, out int cached)
+                ? cached
+                : -1;
+            // Initial-create-on-first-loop-entry: pass acceptTerminalOrbitForLoopSynthesis:
+            // false. This path runs at startUT with no loopUnits / effUT / shift in scope, so
+            // the relaxed terminal-orbit source would seed at the raw recorded UT (wrong
+            // position). The proto-vessel is created later on a loop-aware tick once the
+            // pending queue and per-frame ResolveMapPresenceSampleUT compute effUT and the
+            // accompanying loop epoch shift. Same reasoning as the TS-startup wrapper. Plan section 1.4.
+            TrackingStationGhostSource source = ResolveMapPresenceGhostSource(
+                evt.Trajectory,
+                false,
+                IsMaterializedForMapPresence(evt.Trajectory),
+                startUT,
+                true,
+                "map-presence-initial-create",
+                ref cachedStateVectorIndex,
+                out OrbitSegment segment,
+                out TrajectoryPoint stateVectorPoint,
+                out _,
+                recordingIndex: evt.Index,
+                acceptTerminalOrbitForLoopSynthesis: false);
+            flightStateVectorCachedIndices[evt.Index] = cachedStateVectorIndex;
+
+            // Loop-shifted members must be created on a loop-aware per-frame tick
+            // (CheckPendingMapVessels): that path resolves the source at the loop-mapped
+            // effUT and threads the live-frame epoch shift into the orbit + arc-clip bounds.
+            // Creating here at the raw recorded startUT with the default shift=0 seeds
+            // recorded-UT bounds and leaves ghostOrbitLoopShiftedPids clear, so for one tick
+            // the map-orbit window resolver returns a recorded-UT fallback window (the
+            // icon-clamp / orbit-line glitch at first appearance and at every window re-entry).
+            // Defer so the per-frame path owns loop-member creation, mirroring the TS create
+            // sites and the flight pending-create path. Off the loop path effUT == currentUT
+            // (shift 0, renderHidden false), so non-loop members keep the immediate create
+            // byte-for-byte.
+            double initialNowUT = Planetarium.GetUniversalTime();
+            ResolveMapPresenceSampleUT(
+                evt.Index, evt.Trajectory.StartUT, evt.Trajectory.EndUT, initialNowUT,
+                loopUnits, out bool initialRenderHidden, out double initialLoopShift);
+            bool deferForLoopAware =
+                ParsekPlaybackPolicy.ShouldDeferLoopShiftedMapPresence(initialLoopShift, initialRenderHidden);
+
+            if (source != TrackingStationGhostSource.None && !deferForLoopAware)
+            {
+                Vessel ghost = CreateGhostVesselFromSource(
+                    evt.Index,
+                    evt.Trajectory,
+                    source,
+                    segment,
+                    stateVectorPoint,
+                    startUT);
+                if (ghost != null)
+                {
+                    if (IsStateVectorGhostSource(source))
+                    {
+                        flightStateVectorOrbitTrajectories[evt.Index] = evt.Trajectory;
+                        if (source != TrackingStationGhostSource.StateVectorSoiGap)
+                            flightSoiGapStateVectorExpectedBodies.Remove(evt.Index);
+                    }
+                    else if (TryGetMapOrbitKey(source, segment, out var orbitKey))
+                    {
+                        flightSoiGapStateVectorExpectedBodies.Remove(evt.Index);
+                        flightLastMapOrbitByIndex[evt.Index] = orbitKey;
+                    }
+                }
+            }
+            else
+            {
+                // Initial/pre-orbital deferrals and loop-shifted members are not SOI-gap
+                // recoveries; only the gap-between-orbit-segments requeue path opts into that
+                // fallback. The per-frame CheckPendingMapVessels pass resolves the source at
+                // the loop-mapped effUT and creates with the live-frame epoch shift.
+                flightPendingMapVessels[evt.Index] = new PendingMapVessel(
+                    evt.Trajectory,
+                    allowSoiGapStateVectorFallback: false,
+                    expectedSoiGapBody: null);
+                ParsekLog.Verbose("Policy",
+                    string.Format(CultureInfo.InvariantCulture,
+                        "Deferred ghost map vessel for #{0} \"{1}\": {2} (source={3} loopShift={4:F2} renderHidden={5})",
+                        evt.Index,
+                        evt.Trajectory.VesselName,
+                        deferForLoopAware
+                            ? "loop-shifted member, deferring to loop-aware per-frame create"
+                            : "recording starts pre-orbital",
+                        source,
+                        initialLoopShift,
+                        initialRenderHidden));
+            }
+        }
+
+        /// <summary>
+        /// Map-presence TEARDOWN portion of <c>ParsekPlaybackPolicy.HandleGhostDestroyed</c> (Phase
+        /// 8d.2 relocation): clears the five per-index presence dicts, resolves the committed
+        /// vesselPid (and drops the terminal-retention log key), then removes both recording-index
+        /// and chain-based ghost map ProtoVessels. The policy's handler keeps the Verbose log and the
+        /// <c>heldGhosts.Remove</c> (soft-cap state) and calls this with <c>evt.Index</c>.
+        /// </summary>
+        internal static void HandleFlightGhostDestroyedMapPresence(int index)
+        {
+            flightPendingMapVessels.Remove(index);
+            flightLastMapOrbitByIndex.Remove(index);
+            flightStateVectorOrbitTrajectories.Remove(index);
+            flightSoiGapStateVectorExpectedBodies.Remove(index);
+            flightStateVectorCachedIndices.Remove(index);
+
+            // Remove both recording-index and chain-based ghost map ProtoVessels
+            var committed = RecordingStore.CommittedRecordings;
+            uint vesselPid = 0;
+            if (committed != null && index >= 0 && index < committed.Count)
+            {
+                vesselPid = committed[index].VesselPersistentId;
+                if (!string.IsNullOrEmpty(committed[index].RecordingId))
+                    flightTerminalMapRetentionLoggedIds.Remove(committed[index].RecordingId);
+            }
+
+            RemoveAllGhostPresenceForIndex(index, vesselPid, "ghost-destroyed");
+        }
     }
 }

--- a/Source/Parsek/ParsekPlaybackPolicy.cs
+++ b/Source/Parsek/ParsekPlaybackPolicy.cs
@@ -971,132 +971,11 @@ namespace Parsek
             // "duplicate ghost suspended in air" the Kerbal X playtest 2026-05-19 reproduced).
             TryAutoFollowChainSeamSpawn(evt);
 
-            // KEEP debris-only: this is the policy decision to NOT give debris
-            // recordings their own tracking-station map presence / orbit lines.
-            // Controlled-decoupled children (extension of the parent-anchor
-            // contract) carry IsDebris=false and correctly pass this gate so
-            // they continue to receive map presence as today.
-            if (evt.Trajectory == null || evt.Trajectory.IsDebris)
-            {
-                if (evt.Trajectory?.IsDebris == true)
-                    ParsekLog.Verbose("Policy",
-                        $"Skipped ghost map for #{evt.Index} \"{evt.Trajectory?.VesselName}\" - debris");
-                return;
-            }
-
-            var terminal = evt.Trajectory.TerminalStateValue;
-            if (!GhostMapPresence.IsTerminalStateEligibleForMapPresence(terminal))
-            {
-                ParsekLog.VerboseRateLimited("Policy", $"skip-map-terminal-{evt.Index}",
-                    $"Skipped ghost map for #{evt.Index} \"{evt.Trajectory.VesselName}\" — terminal={terminal.Value}");
-                return;
-            }
-
-            // Accept recordings with terminal orbit data, orbit segments, or trajectory
-            // points (physics-only suborbital recordings have points but no orbit data).
-            bool hasOrbitData = GhostMapPresence.HasOrbitData(evt.Trajectory);
-            bool hasOrbitSegments = evt.Trajectory.HasOrbitSegments;
-            bool hasPoints = evt.Trajectory.Points != null && evt.Trajectory.Points.Count > 0;
-            if (!hasOrbitData && !hasOrbitSegments && !hasPoints)
-                return;
-
-            // Per-chain dedup: if another segment from the same chain already has a ghost
-            // map vessel, remove it before creating the new one. Prevents duplicate orbit
-            // lines during fast time warp across chain boundaries.
-            GhostMapPresence.RemovePreviousChainMapVessel(evt.Index);
-
-            // Check whether the ghost starts in a map-visible source. Otherwise,
-            // defer — the per-frame shared resolver will create it when it enters
-            // an orbital segment or state-vector fallback range.
-            double startUT = evt.Trajectory.StartUT;
-            int cachedStateVectorIndex = GhostMapPresence.flightStateVectorCachedIndices.TryGetValue(evt.Index, out int cached)
-                ? cached
-                : -1;
-            // Initial-create-on-first-loop-entry: pass acceptTerminalOrbitForLoopSynthesis:
-            // false. This path runs at startUT with no loopUnits / effUT / shift in scope, so
-            // the relaxed terminal-orbit source would seed at the raw recorded UT (wrong
-            // position). The proto-vessel is created later on a loop-aware tick once the
-            // pending queue and per-frame ResolveMapPresenceSampleUT compute effUT and the
-            // accompanying loop epoch shift. Same reasoning as the TS-startup wrapper. Plan section 1.4.
-            TrackingStationGhostSource source = GhostMapPresence.ResolveMapPresenceGhostSource(
-                evt.Trajectory,
-                false,
-                GhostMapPresence.IsMaterializedForMapPresence(evt.Trajectory),
-                startUT,
-                true,
-                "map-presence-initial-create",
-                ref cachedStateVectorIndex,
-                out OrbitSegment segment,
-                out TrajectoryPoint stateVectorPoint,
-                out _,
-                recordingIndex: evt.Index,
-                acceptTerminalOrbitForLoopSynthesis: false);
-            GhostMapPresence.flightStateVectorCachedIndices[evt.Index] = cachedStateVectorIndex;
-
-            // Loop-shifted members must be created on a loop-aware per-frame tick
-            // (CheckPendingMapVessels): that path resolves the source at the loop-mapped
-            // effUT and threads the live-frame epoch shift into the orbit + arc-clip bounds.
-            // Creating here at the raw recorded startUT with the default shift=0 seeds
-            // recorded-UT bounds and leaves ghostOrbitLoopShiftedPids clear, so for one tick
-            // the map-orbit window resolver returns a recorded-UT fallback window (the
-            // icon-clamp / orbit-line glitch at first appearance and at every window re-entry).
-            // Defer so the per-frame path owns loop-member creation, mirroring the TS create
-            // sites and the flight pending-create path. Off the loop path effUT == currentUT
-            // (shift 0, renderHidden false), so non-loop members keep the immediate create
-            // byte-for-byte.
-            double initialNowUT = Planetarium.GetUniversalTime();
-            GhostMapPresence.ResolveMapPresenceSampleUT(
-                evt.Index, evt.Trajectory.StartUT, evt.Trajectory.EndUT, initialNowUT,
-                engine.CurrentLoopUnits, out bool initialRenderHidden, out double initialLoopShift);
-            bool deferForLoopAware =
-                ShouldDeferLoopShiftedMapPresence(initialLoopShift, initialRenderHidden);
-
-            if (source != TrackingStationGhostSource.None && !deferForLoopAware)
-            {
-                Vessel ghost = GhostMapPresence.CreateGhostVesselFromSource(
-                    evt.Index,
-                    evt.Trajectory,
-                    source,
-                    segment,
-                    stateVectorPoint,
-                    startUT);
-                if (ghost != null)
-                {
-                    if (GhostMapPresence.IsStateVectorGhostSource(source))
-                    {
-                        GhostMapPresence.flightStateVectorOrbitTrajectories[evt.Index] = evt.Trajectory;
-                        if (source != TrackingStationGhostSource.StateVectorSoiGap)
-                            GhostMapPresence.flightSoiGapStateVectorExpectedBodies.Remove(evt.Index);
-                    }
-                    else if (GhostMapPresence.TryGetMapOrbitKey(source, segment, out var orbitKey))
-                    {
-                        GhostMapPresence.flightSoiGapStateVectorExpectedBodies.Remove(evt.Index);
-                        GhostMapPresence.flightLastMapOrbitByIndex[evt.Index] = orbitKey;
-                    }
-                }
-            }
-            else
-            {
-                // Initial/pre-orbital deferrals and loop-shifted members are not SOI-gap
-                // recoveries; only the gap-between-orbit-segments requeue path opts into that
-                // fallback. The per-frame CheckPendingMapVessels pass resolves the source at
-                // the loop-mapped effUT and creates with the live-frame epoch shift.
-                GhostMapPresence.flightPendingMapVessels[evt.Index] = new GhostMapPresence.PendingMapVessel(
-                    evt.Trajectory,
-                    allowSoiGapStateVectorFallback: false,
-                    expectedSoiGapBody: null);
-                ParsekLog.Verbose("Policy",
-                    string.Format(CultureInfo.InvariantCulture,
-                        "Deferred ghost map vessel for #{0} \"{1}\": {2} (source={3} loopShift={4:F2} renderHidden={5})",
-                        evt.Index,
-                        evt.Trajectory.VesselName,
-                        deferForLoopAware
-                            ? "loop-shifted member, deferring to loop-aware per-frame create"
-                            : "recording starts pre-orbital",
-                        source,
-                        initialLoopShift,
-                        initialRenderHidden));
-            }
+            // Map-presence enqueue (Phase 8d.2): the debris-skip gate, terminal/orbit-data gates,
+            // per-chain dedup, source resolution, loop-aware defer decision, and immediate-create vs
+            // pending-queue branch moved VERBATIM into GhostMapPresence. The engine's per-frame
+            // CurrentLoopUnits the moved body needs is threaded in as a parameter.
+            GhostMapPresence.HandleFlightGhostCreatedMapPresence(evt, engine.CurrentLoopUnits);
         }
 
         /// <summary>
@@ -1407,23 +1286,11 @@ namespace Parsek
             // If a held ghost was destroyed externally (e.g. soft cap, DestroyAllGhosts),
             // remove it from the held set so we don't try to destroy it again
             heldGhosts.Remove(evt.Index);
-            GhostMapPresence.flightPendingMapVessels.Remove(evt.Index);
-            GhostMapPresence.flightLastMapOrbitByIndex.Remove(evt.Index);
-            GhostMapPresence.flightStateVectorOrbitTrajectories.Remove(evt.Index);
-            GhostMapPresence.flightSoiGapStateVectorExpectedBodies.Remove(evt.Index);
-            GhostMapPresence.flightStateVectorCachedIndices.Remove(evt.Index);
 
-            // Remove both recording-index and chain-based ghost map ProtoVessels
-            var committed = RecordingStore.CommittedRecordings;
-            uint vesselPid = 0;
-            if (committed != null && evt.Index >= 0 && evt.Index < committed.Count)
-            {
-                vesselPid = committed[evt.Index].VesselPersistentId;
-                if (!string.IsNullOrEmpty(committed[evt.Index].RecordingId))
-                    GhostMapPresence.flightTerminalMapRetentionLoggedIds.Remove(committed[evt.Index].RecordingId);
-            }
-
-            GhostMapPresence.RemoveAllGhostPresenceForIndex(evt.Index, vesselPid, "ghost-destroyed");
+            // Map-presence teardown (Phase 8d.2): the five per-index presence dict removals, the
+            // committed vesselPid lookup + terminal-retention log-key drop, and the combined
+            // recording-index + chain ghost ProtoVessel removal moved VERBATIM into GhostMapPresence.
+            GhostMapPresence.HandleFlightGhostDestroyedMapPresence(evt.Index);
         }
 
         private void HandleLoopRestarted(LoopRestartedEvent evt)

--- a/docs/dev/plans/maprender-8d-presence-extraction.md
+++ b/docs/dev/plans/maprender-8d-presence-extraction.md
@@ -98,9 +98,28 @@ tests. No in-game A/B gate is needed (behavior is unchanged by construction), th
 still playtests the merged build (Duna One looped re-aim + a non-looped Mun mission through landing)
 as the standard post-merge check, watching for any presence regression.
 
-### 8d.2 - enqueue + teardown ownership
-Move the presence enqueue tail and the scene-change teardown into the same migrated owner, behind the
-same gate, legacy as the gate-off fallback.
+### 8d.2 - enqueue + teardown ownership (DONE - PURE MOVE, no gate)
+Extract the PRESENCE portions of the two mixed-concern engine-event handlers out of the policy into
+`GhostMapPresence` static methods. Both handlers do presence work AND a non-presence concern, so only
+the presence half moves; the policy stays the engine-event subscriber (its documented role) and keeps
+the subscription wiring + the non-presence concerns.
+
+- `HandleGhostCreated` = camera auto-follow (`TryAutoFollowChainSeamSpawn`, STAYS) + the map-presence
+  enqueue (MOVED). New `GhostMapPresence.HandleFlightGhostCreatedMapPresence(GhostLifecycleEvent evt,
+  GhostPlaybackLogic.LoopUnitSet loopUnits)`; `engine.CurrentLoopUnits` becomes the `loopUnits` param.
+  The policy handler becomes `TryAutoFollowChainSeamSpawn(evt);
+  GhostMapPresence.HandleFlightGhostCreatedMapPresence(evt, engine.CurrentLoopUnits);`.
+- `HandleGhostDestroyed` = the Verbose log + `heldGhosts.Remove` (policy soft-cap state, STAYS) + the
+  map-presence teardown (MOVED). New `GhostMapPresence.HandleFlightGhostDestroyedMapPresence(int index)`.
+- `HandleAllGhostsDestroying` + `Dispose` already delegate via `ClearFlightMapPresenceState()` (8d.1), so
+  they are unchanged. The engine-event subscription/unsubscription wiring stays in the policy.
+- `ShouldDeferLoopShiftedMapPresence` stays `internal static` in the policy (it has `RuntimePolicyTests`
+  callers); the moved create method calls it cross-class.
+
+Faithful copy (empty code-only diff on both moved blocks under the permitted edits: `engine.CurrentLoopUnits`
+-> param, `evt.Index` -> `index`, stripped redundant `GhostMapPresence.` self-qualifiers, cross-class
+`ShouldDeferLoopShiftedMapPresence` qualification). No behavior change, no gate. Source-gate tests added.
+Build clean; full suite green (13418).
 
 ### 8d.3 - decompose + pure-extract
 Once the body lives in the render layer, split it into named sub-passes and extract the pure decision

--- a/docs/dev/plans/maprender-rewrite-status.md
+++ b/docs/dev/plans/maprender-rewrite-status.md
@@ -301,7 +301,16 @@ reconciler for decision-vs-old-truth parity, and resolve the in-game probes befo
     enqueue tail + teardowns reach them directly until 8d.2 moves them). Riskiest slice (655-line cut),
     so it ships on a HARD clean-context review + green tests; maintainer playtests the merged build
     (Duna One looped re-aim + a non-looped Mun mission through landing) as the standard post-merge check.
-  - **8d.2** - enqueue + scene-change teardown ownership (gated, legacy fallback).
+  - **8d.2 - DONE (PURE MOVE, no gate).** Extracted the PRESENCE portions of the two mixed-concern
+    engine-event handlers out of the policy into `GhostMapPresence`: `HandleGhostCreated`'s enqueue ->
+    `GhostMapPresence.HandleFlightGhostCreatedMapPresence(evt, loopUnits)` (the policy handler keeps the
+    camera `TryAutoFollowChainSeamSpawn`), `HandleGhostDestroyed`'s teardown ->
+    `GhostMapPresence.HandleFlightGhostDestroyedMapPresence(index)` (the policy handler keeps the log +
+    `heldGhosts.Remove`). The policy stays the engine-event subscriber (subscription wiring + non-presence
+    concerns stay); `HandleAllGhostsDestroying` / `Dispose` already delegated via
+    `ClearFlightMapPresenceState()` (8d.1). `ShouldDeferLoopShiftedMapPresence` stays in the policy
+    (`RuntimePolicyTests` callers), called cross-class. Faithful copy (empty code-only diff on both moved
+    blocks), no behavior change. Source-gate tests added; build clean; full suite green (13418).
   - **8d.3** - decompose into named sub-passes + pure-extract predicates with unit tests.
 - **Phase 8** per-surface cutover (8a-8e) - deletes the scattered gates; in-game per sub-phase.
 - **Workstream B** B2 `IEncounterSolver` (wraps `CalculatePatch`, §15.4 test-gap decision) + B3


### PR DESCRIPTION
## Phase 8d.2 - lifecycle-handler presence extraction (pure move, no behavior change)

Third slice of phase 8d. After 8d.1 moved the per-frame presence body + the 6 presence dicts into `GhostMapPresence`, the policy still hosted the presence halves of two mixed-concern engine-event handlers. 8d.2 extracts those, leaving the policy as the engine-event subscriber (its documented role). Full sub-plan: `docs/dev/plans/maprender-8d-presence-extraction.md`.

### What moved
Both handlers are mixed-concern, so only the presence half moves:
- `HandleGhostCreated` = camera auto-follow (`TryAutoFollowChainSeamSpawn`, STAYS) + the map-presence enqueue (MOVED to `GhostMapPresence.HandleFlightGhostCreatedMapPresence(GhostLifecycleEvent evt, GhostPlaybackLogic.LoopUnitSet loopUnits)`; `engine.CurrentLoopUnits` becomes the `loopUnits` param).
- `HandleGhostDestroyed` = the Verbose log + `heldGhosts.Remove` (policy soft-cap state, STAYS) + the map-presence teardown (MOVED to `GhostMapPresence.HandleFlightGhostDestroyedMapPresence(int index)`).

The policy handlers become thin: camera/log + the delegate call. The engine-event subscription/unsubscription wiring stays in the policy. `HandleAllGhostsDestroying` / `Dispose` already delegate via `ClearFlightMapPresenceState()` (8d.1), so they are unchanged. `ShouldDeferLoopShiftedMapPresence` stays `internal static` in the policy (it has `RuntimePolicyTests` callers); the moved create method calls it cross-class.

### Why it is no behavior change
Faithful copy: an empty code-only diff on both moved blocks under the permitted edits (`engine.CurrentLoopUnits` -> param, `evt.Index` -> `index`, stripped redundant `GhostMapPresence.` self-qualifiers, cross-class `ShouldDeferLoopShiftedMapPresence` qualification). Presence still fires for re-aim / overlap members the Director skips (no `IsDirectorDriveActive` coupling). No gate (a gate would toggle two identical paths).

### Review
Clean-context review verdict: SHIP, all items PASS. Independent empty code-only diffs on both moved blocks; the policy diff contains exactly the two handler bodies replaced by delegation and nothing else; subscription wiring + `HandleAllGhostsDestroying`/`Dispose` byte-identical to HEAD.

### Tests + build
- Build clean (0 warnings / 0 errors).
- Full suite green: 13418 passed, 0 failed, 0 skipped.
- `GhostMapPresence` is already ERS-exempt, so the moved `RecordingStore.CommittedRecordings` read keeps `GrepAuditTests` green (the policy lost that read).
- Source-gate `MapPresenceSeamTests` extended (the two new declarations, both delegations, the retained camera + held-ghost concerns, the moved presence statements absent from the policy).

No CHANGELOG entry (no user-facing change). Standard post-merge in-game check: Duna One looped re-aim + a non-looped Mun mission through landing.