### PR TITLE
maprender(8d.3): decompose UpdateFlightMapGhostLifecycle into named passes + extract pure predicates

### DIFF
--- a/Source/Parsek.Tests/MapRender/MapPresenceSeamTests.cs
+++ b/Source/Parsek.Tests/MapRender/MapPresenceSeamTests.cs
@@ -216,5 +216,78 @@ namespace Parsek.Tests
             Assert.Contains("public override void DriveMapPresence(", source);
             Assert.Contains("UpdateTrackingStationGhostLifecycle(", source);
         }
+
+        // ----- Phase 8d.3 decomposition source-gate -----
+
+        [Fact]
+        public void UpdateFlightMapGhostLifecycle_DecomposedIntoNamedPasses_8d3()
+        {
+            string source = ReadSource("Source", "Parsek", "GhostMapPresence.cs");
+
+            // Phase 8d.3 split the ~655-line orchestrator into three named sub-pass methods
+            // (behavior-preserving). The three pass methods exist as private static voids...
+            Assert.Contains("private static void RunFlightMapDeferredCreatePass(", source);
+            Assert.Contains("private static void RunFlightMapOrbitReseedPass(", source);
+            Assert.Contains("private static void RunFlightMapStateVectorUpdatePass(", source);
+
+            // ...and the orchestrator body calls all three IN ORDER, with the Pass 2 gate
+            // (ShouldRunMapOrbitReseed) + the second committed-null early-return still sitting in the
+            // orchestrator BETWEEN the Pass 1 call and the Pass 2 call, so the early-returns keep
+            // skipping the reseed + state-vector passes. Bound the orchestrator body between its own
+            // signature and the first pass-method declaration (the next member after it).
+            string orchestrator = ExtractMethodRegion(
+                source,
+                "internal static void UpdateFlightMapGhostLifecycle(",
+                "private static void RunFlightMapDeferredCreatePass(");
+
+            int deferredCall = orchestrator.IndexOf("RunFlightMapDeferredCreatePass(", StringComparison.Ordinal);
+            int gate = orchestrator.IndexOf("ShouldRunMapOrbitReseed(", StringComparison.Ordinal);
+            int committedReturn = orchestrator.IndexOf("if (committed == null) return;", StringComparison.Ordinal);
+            int reseedCall = orchestrator.IndexOf("RunFlightMapOrbitReseedPass(", StringComparison.Ordinal);
+            int stateVectorCall = orchestrator.IndexOf("RunFlightMapStateVectorUpdatePass(", StringComparison.Ordinal);
+
+            Assert.True(deferredCall >= 0, "orchestrator must call RunFlightMapDeferredCreatePass");
+            Assert.True(gate >= 0, "orchestrator must keep the ShouldRunMapOrbitReseed gate");
+            Assert.True(committedReturn >= 0, "orchestrator must keep the committed-null early-return");
+            Assert.True(reseedCall >= 0, "orchestrator must call RunFlightMapOrbitReseedPass");
+            Assert.True(stateVectorCall >= 0, "orchestrator must call RunFlightMapStateVectorUpdatePass");
+
+            // Order: Pass1 call -> gate + committed early-return -> Pass2 call -> Pass3 call.
+            Assert.True(deferredCall < gate, "Pass 1 call must precede the reseed gate");
+            Assert.True(gate < reseedCall, "the reseed gate must precede the Pass 2 call");
+            Assert.True(committedReturn < reseedCall, "the committed early-return must precede the Pass 2 call");
+            Assert.True(reseedCall < stateVectorCall, "Pass 2 call must precede Pass 3 call");
+        }
+
+        // ----- Phase 8d.3 extracted pure predicates (truth tables) -----
+
+        // The enum is internal, so [InlineData] passes the int value (a public-safe parameter type)
+        // and the test casts it back. This keeps the xUnit test methods public while still locking
+        // each enum member's truth-table cell.
+        [Theory]
+        [InlineData((int)GhostMapPresence.TrackingStationGhostSource.Segment, true)]
+        [InlineData((int)GhostMapPresence.TrackingStationGhostSource.StateVector, true)]
+        [InlineData((int)GhostMapPresence.TrackingStationGhostSource.StateVectorSoiGap, true)]
+        [InlineData((int)GhostMapPresence.TrackingStationGhostSource.TerminalOrbit, true)]
+        [InlineData((int)GhostMapPresence.TrackingStationGhostSource.EndpointTail, true)]
+        [InlineData((int)GhostMapPresence.TrackingStationGhostSource.None, false)]
+        public void IsMapCreateAcceptedSource_AcceptsEverythingExceptNone(int sourceValue, bool expected)
+        {
+            var source = (GhostMapPresence.TrackingStationGhostSource)sourceValue;
+            Assert.Equal(expected, GhostMapPresence.IsMapCreateAcceptedSource(source));
+        }
+
+        [Theory]
+        [InlineData((int)GhostMapPresence.TrackingStationGhostSource.Segment, true)]
+        [InlineData((int)GhostMapPresence.TrackingStationGhostSource.TerminalOrbit, true)]
+        [InlineData((int)GhostMapPresence.TrackingStationGhostSource.EndpointTail, true)]
+        [InlineData((int)GhostMapPresence.TrackingStationGhostSource.StateVector, false)]
+        [InlineData((int)GhostMapPresence.TrackingStationGhostSource.StateVectorSoiGap, false)]
+        [InlineData((int)GhostMapPresence.TrackingStationGhostSource.None, false)]
+        public void IsSegmentBearingGhostSource_OnlySegmentTerminalOrbitAndEndpointTail(int sourceValue, bool expected)
+        {
+            var source = (GhostMapPresence.TrackingStationGhostSource)sourceValue;
+            Assert.Equal(expected, GhostMapPresence.IsSegmentBearingGhostSource(source));
+        }
     }
 }

--- a/Source/Parsek/GhostMapPresence.cs
+++ b/Source/Parsek/GhostMapPresence.cs
@@ -46,6 +46,33 @@ namespace Parsek
         }
 
         /// <summary>
+        /// Pure: a resolved ghost source the deferred map-create pass is willing to materialize
+        /// (everything except <see cref="TrackingStationGhostSource.None"/>): a covering Segment,
+        /// either state-vector flavor, the loop-synthesis TerminalOrbit fallback, or the EndpointTail
+        /// consistency fix. Extracted byte-for-byte from the inline create-acceptance check.
+        /// </summary>
+        internal static bool IsMapCreateAcceptedSource(TrackingStationGhostSource source)
+        {
+            return source == TrackingStationGhostSource.Segment
+                || IsStateVectorGhostSource(source)
+                || source == TrackingStationGhostSource.TerminalOrbit
+                || source == TrackingStationGhostSource.EndpointTail;
+        }
+
+        /// <summary>
+        /// Pure: a resolved ghost source that populates a valid <c>segment</c> out-param (Segment,
+        /// the loop-synthesis no-segment TerminalOrbit fallback, or EndpointTail, which populates the
+        /// segment exactly like TerminalOrbit). Used by the state-vector update pass to decide whether
+        /// to consume the segment branch instead of falling through to the flat point path.
+        /// </summary>
+        internal static bool IsSegmentBearingGhostSource(TrackingStationGhostSource source)
+        {
+            return source == TrackingStationGhostSource.Segment
+                || source == TrackingStationGhostSource.TerminalOrbit
+                || source == TrackingStationGhostSource.EndpointTail;
+        }
+
+        /// <summary>
         /// Tracking-station per-tick orbit-source precedence for an already-created ghost:
         /// a wrapped/closed OrbitSegment covering the effective UT is the trusted source and
         /// wins over a co-located OrbitalCheckpoint state-vector. The checkpoint state-vector is
@@ -10129,6 +10156,40 @@ namespace Parsek
             // range). Empty (the common case) makes every ResolveMapPresenceSampleUT below return
             // the unchanged live UT with shift 0, so non-looping behavior is byte-identical.
 
+            RunFlightMapDeferredCreatePass(currentUT, loopUnits);            // Pass 1 (always runs)
+
+            // 2. Map-orbit reseed for existing ProtoVessels. Rate-limited to the real-time timer, BUT
+            // warp-aware: under time warp the playback head sprints through short segments (e.g. the many
+            // short Duna-capture conics) faster than the 0.5 s timer reseeds, so the applied orbit goes
+            // stale and GhostOrbitLinePatch's stale-segment guard blanks the line every frame (the ~1-min
+            // warped-approach blink). Also reseed the moment a ghost's head leaves its applied segment so
+            // the orbit stays current and the stale-segment guard (which still suppresses the genuine
+            // pre-burn arc on a propulsive->orbital handoff) stops firing on reseed lag alone. The head-left
+            // scan is computed only while warping + before the timer (so 1x is byte-identical + cost-free).
+            //
+            // Pass 2 gate + preamble stay HERE so the two early-returns keep skipping Pass 3.
+            bool mapReseedTimerElapsed = UnityEngine.Time.time >= nextMapOrbitUpdateTime;
+            bool mapReseedHeadLeftSegment = !mapReseedTimerElapsed
+                && TimeWarp.CurrentRate > 1.0f
+                && GhostMapPresence.AnyGhostHeadLeftAppliedSegment(currentUT);
+            if (!ParsekPlaybackPolicy.ShouldRunMapOrbitReseed(mapReseedTimerElapsed, TimeWarp.CurrentRate, mapReseedHeadLeftSegment))
+                return;
+            nextMapOrbitUpdateTime = UnityEngine.Time.time + MapOrbitUpdateIntervalSec;
+
+            var committed = RecordingStore.CommittedRecordings;
+            if (committed == null) return;
+            PruneTerminalMapRetentionLogKeys(committed);
+
+            RunFlightMapOrbitReseedPass(currentUT, loopUnits, committed);    // Pass 2 body
+            RunFlightMapStateVectorUpdatePass(currentUT, loopUnits, committed); // Pass 3 body
+        }
+
+        // Pass 1 — deferred create. Always runs (no gate). Creates deferred ProtoVessels for ghosts
+        // that just entered an orbital segment OR for physics-only recordings that crossed the
+        // state-vector threshold. Body relocated verbatim from the former inline pass.
+        private static void RunFlightMapDeferredCreatePass(
+            double currentUT, GhostPlaybackLogic.LoopUnitSet loopUnits)
+        {
             // 1. Create deferred ProtoVessels for ghosts that just entered an orbital segment
             //    OR for physics-only recordings that crossed the state-vector threshold.
             if (flightPendingMapVessels.Count > 0)
@@ -10215,10 +10276,7 @@ namespace Parsek
                             segment, out segment))
                         continue;
 
-                    if (source == TrackingStationGhostSource.Segment
-                        || GhostMapPresence.IsStateVectorGhostSource(source)
-                        || source == TrackingStationGhostSource.TerminalOrbit
-                        || source == TrackingStationGhostSource.EndpointTail)
+                    if (GhostMapPresence.IsMapCreateAcceptedSource(source))
                     {
                         if (toCreate == null)
                             toCreate = new List<(int, TrackingStationGhostSource, OrbitSegment, TrajectoryPoint, string, double)>();
@@ -10304,27 +10362,15 @@ namespace Parsek
                     }
                 }
             }
+        }
 
-            // 2. Map-orbit reseed for existing ProtoVessels. Rate-limited to the real-time timer, BUT
-            // warp-aware: under time warp the playback head sprints through short segments (e.g. the many
-            // short Duna-capture conics) faster than the 0.5 s timer reseeds, so the applied orbit goes
-            // stale and GhostOrbitLinePatch's stale-segment guard blanks the line every frame (the ~1-min
-            // warped-approach blink). Also reseed the moment a ghost's head leaves its applied segment so
-            // the orbit stays current and the stale-segment guard (which still suppresses the genuine
-            // pre-burn arc on a propulsive->orbital handoff) stops firing on reseed lag alone. The head-left
-            // scan is computed only while warping + before the timer (so 1x is byte-identical + cost-free).
-            bool mapReseedTimerElapsed = UnityEngine.Time.time >= nextMapOrbitUpdateTime;
-            bool mapReseedHeadLeftSegment = !mapReseedTimerElapsed
-                && TimeWarp.CurrentRate > 1.0f
-                && GhostMapPresence.AnyGhostHeadLeftAppliedSegment(currentUT);
-            if (!ParsekPlaybackPolicy.ShouldRunMapOrbitReseed(mapReseedTimerElapsed, TimeWarp.CurrentRate, mapReseedHeadLeftSegment))
-                return;
-            nextMapOrbitUpdateTime = UnityEngine.Time.time + MapOrbitUpdateIntervalSec;
-
-            var committed = RecordingStore.CommittedRecordings;
-            if (committed == null) return;
-            PruneTerminalMapRetentionLogKeys(committed);
-
+        // Pass 2 — segment-based map-orbit reseed for existing ProtoVessels. Runs only after the
+        // orchestrator's gate + preamble passed (committed already resolved, non-null, and the
+        // terminal-retention log keys already pruned). Body relocated verbatim from the former
+        // "2a. Segment-based orbit updates" pass.
+        private static void RunFlightMapOrbitReseedPass(
+            double currentUT, GhostPlaybackLogic.LoopUnitSet loopUnits, IReadOnlyList<Recording> committed)
+        {
             // 2a. Segment-based orbit updates (existing)
             List<KeyValuePair<int, (string body, double sma, double ecc)>> orbitUpdates = null;
             List<int> toRemoveFromMap = null;
@@ -10589,7 +10635,15 @@ namespace Parsek
                     }
                 }
             }
+        }
 
+        // Pass 3 — state-vector orbit updates (physics-only suborbital) for existing ProtoVessels.
+        // Runs only after the orchestrator's gate + preamble passed (committed already resolved and
+        // non-null). Body relocated verbatim from the former "2b. State-vector orbit updates" pass,
+        // including the EmitLifecycleSummary tail.
+        private static void RunFlightMapStateVectorUpdatePass(
+            double currentUT, GhostPlaybackLogic.LoopUnitSet loopUnits, IReadOnlyList<Recording> committed)
+        {
             // 2b. State-vector orbit updates (new — physics-only suborbital)
             if (flightStateVectorOrbitTrajectories.Count > 0)
             {
@@ -10667,9 +10721,7 @@ namespace Parsek
                             continue;
                         }
 
-                        if (source == TrackingStationGhostSource.Segment
-                            || source == TrackingStationGhostSource.TerminalOrbit
-                            || source == TrackingStationGhostSource.EndpointTail)
+                        if (GhostMapPresence.IsSegmentBearingGhostSource(source))
                         {
                             // EndpointTail populates a valid `segment` out-param exactly
                             // like TerminalOrbit (the loop-synthesis no-segment fallback),

--- a/docs/dev/plans/maprender-8d-presence-extraction.md
+++ b/docs/dev/plans/maprender-8d-presence-extraction.md
@@ -121,10 +121,29 @@ Faithful copy (empty code-only diff on both moved blocks under the permitted edi
 `ShouldDeferLoopShiftedMapPresence` qualification). No behavior change, no gate. Source-gate tests added.
 Build clean; full suite green (13418).
 
-### 8d.3 - decompose + pure-extract
-Once the body lives in the render layer, split it into named sub-passes and extract the pure decision
-predicates (eligibility, retire, state-vector refresh) as `internal static` helpers with unit tests, so
-the migrated body is covered the way the rest of the pipeline is.
+### 8d.3 - decompose + pure-extract (DONE - behavior-preserving)
+Decomposed `UpdateFlightMapGhostLifecycle` (~655 lines) into three named `private static void` pass
+methods + an orchestrator, and extracted the trivial pure predicates. Note: most decision logic was
+ALREADY delegated to extracted pure helpers (`ResolveMapPresenceSampleUT`,
+`IsTerminalOrbitSynthesisSafeForLoopMember`, `ResolveMapPresenceGhostSource`, `IsStateVectorGhostSource`,
+`TryGetMapOrbitKey`, `ShouldRunMapOrbitReseed`, `ShouldDeferLoopShiftedMapPresence`, etc.), so the new
+pure-test surface was small; the main deliverable was the structural decomposition.
+
+- Orchestrator: `RunFlightMapDeferredCreatePass(currentUT, loopUnits)` (Pass 1, always); then the gate +
+  preamble stay INLINE (the `mapReseedTimerElapsed`/`mapReseedHeadLeftSegment` computation, the
+  `ShouldRunMapOrbitReseed` early-return, `nextMapOrbitUpdateTime`, the `committed == null` early-return,
+  `PruneTerminalMapRetentionLogKeys`) so BOTH early-returns still skip Pass 2 AND Pass 3; then
+  `RunFlightMapOrbitReseedPass(currentUT, loopUnits, committed)` (Pass 2 body) and
+  `RunFlightMapStateVectorUpdatePass(currentUT, loopUnits, committed)` (Pass 3 body).
+- Each pass body is line-for-line identical to its original location (verified against HEAD).
+- Two pure predicates extracted (`internal static bool`, unit-tested): `IsMapCreateAcceptedSource`
+  (Pass-1 create-accept: `Segment || IsStateVectorGhostSource || TerminalOrbit || EndpointTail`) and
+  `IsSegmentBearingGhostSource` (Pass-3: `Segment || TerminalOrbit || EndpointTail`). Correct sites
+  verified (the state-vector-inclusive one at create-accept, the segment-bearing-only one in Pass 3).
+
+No behavior change, no gate. Source-gate decomposition test + predicate truth-table tests added. Build
+clean; full suite green (13431). This completes the 8d presence migration; the flight map-presence
+lifecycle now lives entirely in `GhostMapPresence` with the policy as the thin engine-event subscriber.
 
 ### 8e - delete legacy + drop the gate (final, shared with the rest of the cutover)
 Delete the legacy in-policy presence body, the autonomous Driver walk, the

--- a/docs/dev/plans/maprender-rewrite-status.md
+++ b/docs/dev/plans/maprender-rewrite-status.md
@@ -311,7 +311,23 @@ reconciler for decision-vs-old-truth parity, and resolve the in-game probes befo
     `ClearFlightMapPresenceState()` (8d.1). `ShouldDeferLoopShiftedMapPresence` stays in the policy
     (`RuntimePolicyTests` callers), called cross-class. Faithful copy (empty code-only diff on both moved
     blocks), no behavior change. Source-gate tests added; build clean; full suite green (13418).
-  - **8d.3** - decompose into named sub-passes + pure-extract predicates with unit tests.
+  - **8d.3 - DONE (behavior-preserving).** Decomposed `UpdateFlightMapGhostLifecycle` into three named
+    `private static void` pass methods (`RunFlightMapDeferredCreatePass`, `RunFlightMapOrbitReseedPass`,
+    `RunFlightMapStateVectorUpdatePass`) + an orchestrator that keeps the reseed gate + both early-returns
+    + preamble INLINE (so they still skip Pass 2+3). Each pass body line-for-line identical to HEAD. Most
+    predicates were already extracted, so the new pure surface was small: two trivial predicates extracted
+    + unit-tested (`IsMapCreateAcceptedSource`, `IsSegmentBearingGhostSource`), correct sites verified. No
+    behavior change. Build clean; full suite green (13431). **This completes the 8d presence migration**:
+    the flight map-presence lifecycle now lives entirely in `GhostMapPresence`, policy is the thin
+    engine-event subscriber.
+- **Phase 8d - all sub-slices DONE (8d.0-8d.3).** The ghost map-presence lifecycle (seam, per-frame body
+  + 6 dicts, lifecycle handlers, decomposition) is fully migrated from `ParsekPlaybackPolicy` into
+  `GhostMapPresence`, no behavior change. Remaining cutover work is Phase 8e (delete the 8a/8b/8c legacy
+  draw-side fallbacks + the autonomous Driver walk + grace fields, then drop the `mapRenderDirectorDrive`
+  gate). NOTE: 8e legacy DELETION is still gated on closing the coverage gap (cutover Step 2: the
+  re-aim / overlap members + the hyperbolic-escape segment that fall back to the legacy draw path); that
+  needs its own scoping before deletion. Presence (8d) is independent of that gap (presence was never
+  gated and always runs).
 - **Phase 8** per-surface cutover (8a-8e) - deletes the scattered gates; in-game per sub-phase.
 - **Workstream B** B2 `IEncounterSolver` (wraps `CalculatePatch`, §15.4 test-gap decision) + B3
   `TransferConic` frame-agnostic return - touch the in-game-validated re-aim path.


### PR DESCRIPTION
## Phase 8d.3 - presence body decomposition (behavior-preserving)

Final slice of phase 8d, completing the ghost map-presence migration into `GhostMapPresence`. Decomposes the ~655-line `UpdateFlightMapGhostLifecycle` into three named pass methods + an orchestrator, and extracts two trivial pure predicates with unit tests. No behavior change. Full sub-plan: `docs/dev/plans/maprender-8d-presence-extraction.md`.

### Decomposition
- Orchestrator `UpdateFlightMapGhostLifecycle` now calls `RunFlightMapDeferredCreatePass(currentUT, loopUnits)` (Pass 1, always), then keeps the reseed gate + preamble INLINE (the timer/warp computation, the `ShouldRunMapOrbitReseed` early-return, `nextMapOrbitUpdateTime`, the `committed == null` early-return, `PruneTerminalMapRetentionLogKeys`) so both early-returns still skip Pass 2 AND Pass 3, then calls `RunFlightMapOrbitReseedPass(...)` (Pass 2 body) and `RunFlightMapStateVectorUpdatePass(...)` (Pass 3 body) with the resolved `committed` list.
- Each pass body is line-for-line identical to its prior location (verified against HEAD).

### Pure-extract
Most decision logic was already delegated to extracted pure helpers, so the new pure-test surface was small. Two trivial predicates extracted (`internal static bool`, unit-tested):
- `IsMapCreateAcceptedSource` (Pass-1 create-accept: `Segment || IsStateVectorGhostSource || TerminalOrbit || EndpointTail`).
- `IsSegmentBearingGhostSource` (Pass-3: `Segment || TerminalOrbit || EndpointTail`).

Correct substitution sites verified (the state-vector-inclusive one at the create-accept site, the segment-bearing-only one in Pass 3 - a swap would be a behavior change).

### Review
Clean-context review verdict: SHIP, all items PASS. Line-for-line diffs on all three pass bodies; orchestrator gate + both early-returns confirmed to sit before the Pass 2/3 calls; predicate truth tables confirmed to match the replaced expressions at the correct sites.

### Tests + build
- Build clean (0 warnings / 0 errors).
- Full suite green: 13431 passed, 0 failed, 0 skipped.
- Predicate truth-table tests (all enum members, true + false cells) + a decomposition source-gate (the three pass methods exist; the orchestrator calls them in order with the gate + `committed`-null return between Pass 1 and Pass 2).

No CHANGELOG entry (no user-facing change).

### This completes phase 8d
The flight map-presence lifecycle (seam, per-frame body + 6 dicts, lifecycle handlers, decomposition) is fully migrated from `ParsekPlaybackPolicy` into `GhostMapPresence`. Remaining cutover work is phase 8e (delete the 8a/8b/8c legacy draw-side fallbacks + the autonomous Driver walk + grace fields, then drop the `mapRenderDirectorDrive` gate). Note: 8e legacy deletion is still gated on closing the coverage gap (re-aim / overlap members + the hyperbolic-escape segment that fall back to the legacy draw path), which needs its own scoping. Presence (8d) is independent of that gap.