### PR TITLE
maprender(trace): per-pid change-based marker-decision + polyline-ride logging

### DIFF
--- a/Source/Parsek.Tests/MapRenderTraceTests.cs
+++ b/Source/Parsek.Tests/MapRenderTraceTests.cs
@@ -722,5 +722,194 @@ namespace Parsek.Tests
                 MapRenderTrace.RenderSurface.AtmosphericMarker, "rec-marker-disabled", 100.0, "vessel=X");
             Assert.Empty(logLines);
         }
+
+        // ---- Marker-decision observability (per-pid WHY a marker drew / was skipped) ----
+
+        [Fact]
+        public void MarkerOutcomeToken_MapsEveryBranch()
+        {
+            Assert.Equal("drawn-non-proto",
+                MapRenderTrace.MarkerOutcomeToken(MapRenderTrace.MarkerOutcome.DrawnNonProto));
+            Assert.Equal("drawn-proto-icon",
+                MapRenderTrace.MarkerOutcomeToken(MapRenderTrace.MarkerOutcome.DrawnProtoIcon));
+            Assert.Equal("skipped-debris",
+                MapRenderTrace.MarkerOutcomeToken(MapRenderTrace.MarkerOutcome.SkippedDebris));
+            Assert.Equal("skipped-chain-non-tip",
+                MapRenderTrace.MarkerOutcomeToken(MapRenderTrace.MarkerOutcome.SkippedChainNonTip));
+            Assert.Equal("skipped-not-on-map",
+                MapRenderTrace.MarkerOutcomeToken(MapRenderTrace.MarkerOutcome.SkippedNotOnMap));
+            Assert.Equal("skipped-decision-false",
+                MapRenderTrace.MarkerOutcomeToken(MapRenderTrace.MarkerOutcome.SkippedDecisionFalse));
+            Assert.Equal("skipped-position-fail",
+                MapRenderTrace.MarkerOutcomeToken(MapRenderTrace.MarkerOutcome.SkippedPositionFail));
+            Assert.Equal("skipped-loop-hidden",
+                MapRenderTrace.MarkerOutcomeToken(MapRenderTrace.MarkerOutcome.SkippedLoopHidden));
+            Assert.Equal("unknown",
+                MapRenderTrace.MarkerOutcomeToken(MapRenderTrace.MarkerOutcome.Unknown));
+        }
+
+        [Fact]
+        public void MarkerRideReasonToken_RodeLeg_CarriesIndex()
+        {
+            Assert.Equal("rode-leg3",
+                MapRenderTrace.MarkerRideReasonToken(MapRenderTrace.MarkerRideReason.RodeLeg, 3));
+            Assert.Equal("fallback-leg-not-drawn-this-frame",
+                MapRenderTrace.MarkerRideReasonToken(
+                    MapRenderTrace.MarkerRideReason.FallbackLegNotDrawnThisFrame, -1));
+            Assert.Equal("fallback-head-outside-legs",
+                MapRenderTrace.MarkerRideReasonToken(
+                    MapRenderTrace.MarkerRideReason.FallbackHeadOutsideLegs, -1));
+            Assert.Equal("fallback-missing-recordedUTs",
+                MapRenderTrace.MarkerRideReasonToken(
+                    MapRenderTrace.MarkerRideReason.FallbackMissingRecordedUTs, -1));
+            Assert.Equal("fallback-no-cache",
+                MapRenderTrace.MarkerRideReasonToken(
+                    MapRenderTrace.MarkerRideReason.FallbackNoCache, -1));
+            Assert.Equal("not-attempted",
+                MapRenderTrace.MarkerRideReasonToken(
+                    MapRenderTrace.MarkerRideReason.NotAttempted, -1));
+        }
+
+        [Fact]
+        public void BuildMarkerDecisionSignature_DrawnNonProto_CarriesDisjunctsRideAndSource()
+        {
+            string sig = MapRenderTrace.BuildMarkerDecisionSignature(
+                recordingIndex: 4,
+                vesselName: "Munar Probe",
+                gateOn: true,
+                directorTracedPathActive: true,
+                polylineOwning: false,
+                iconSuppressed: false,
+                shouldDrawNonProto: true,
+                outcome: MapRenderTrace.MarkerOutcome.DrawnNonProto,
+                rideReason: MapRenderTrace.MarkerRideReason.RodeLeg,
+                legIndex: 2,
+                posSource: "polyline");
+
+            Assert.Contains("rec=4", sig);
+            Assert.Contains("vessel=Munar_Probe", sig);
+            Assert.Contains("gateOn=true", sig);
+            Assert.Contains("directorTracedPathActive=true", sig);
+            Assert.Contains("polylineOwning=false", sig);
+            Assert.Contains("iconSuppressed=false", sig);
+            Assert.Contains("shouldDrawNonProto=true", sig);
+            Assert.Contains("outcome=drawn-non-proto", sig);
+            Assert.Contains("ride=rode-leg2", sig);
+            Assert.Contains("posSource=polyline", sig);
+        }
+
+        [Fact]
+        public void BuildMarkerDecisionSignature_SkipOutcome_OmitsRideAndSource()
+        {
+            // A non-draw outcome carries no ride / posSource tokens (they are only meaningful
+            // for a drawn non-proto marker), so the signature stays compact and stable.
+            string sig = MapRenderTrace.BuildMarkerDecisionSignature(
+                recordingIndex: 1,
+                vesselName: "Probe",
+                gateOn: false,
+                directorTracedPathActive: false,
+                polylineOwning: false,
+                iconSuppressed: false,
+                shouldDrawNonProto: false,
+                outcome: MapRenderTrace.MarkerOutcome.SkippedDebris,
+                rideReason: MapRenderTrace.MarkerRideReason.NotAttempted,
+                legIndex: -1,
+                posSource: "?");
+
+            Assert.Contains("outcome=skipped-debris", sig);
+            Assert.DoesNotContain("ride=", sig);
+            Assert.DoesNotContain("posSource=", sig);
+        }
+
+        [Fact]
+        public void EmitMarkerDecisionOnChange_NoOpWhenDisabled()
+        {
+            MapRenderTrace.ForceEnabledForTesting = false;
+
+            MapRenderTrace.EmitMarkerDecisionOnChange(
+                MapRenderTrace.RenderSurface.ImguiLabeledMarker, "rec-1", 100.0, "outcome=drawn-non-proto");
+
+            Assert.Empty(logLines);
+        }
+
+        [Fact]
+        public void EmitMarkerDecisionOnChange_FirstSignatureEmits()
+        {
+            MapRenderTrace.ForceEnabledForTesting = true;
+
+            MapRenderTrace.EmitMarkerDecisionOnChange(
+                MapRenderTrace.RenderSurface.ImguiLabeledMarker, "rec-1", 100.0,
+                "rec=1 outcome=drawn-non-proto");
+
+            Assert.Contains(logLines, l =>
+                l.Contains("[MapRenderTrace]")
+                && l.Contains("phase=MarkerDecision")
+                && l.Contains("surface=ImguiLabeledMarker")
+                && l.Contains("pid=rec-1")
+                && l.Contains("outcome=drawn-non-proto"));
+        }
+
+        [Fact]
+        public void EmitMarkerDecisionOnChange_RepeatSignatureSuppressed()
+        {
+            MapRenderTrace.ForceEnabledForTesting = true;
+
+            MapRenderTrace.EmitMarkerDecisionOnChange(
+                MapRenderTrace.RenderSurface.ImguiLabeledMarker, "rec-1", 100.0, "outcome=drawn-non-proto");
+            int afterFirst = logLines.Count;
+            // Same signature, later UT -> suppressed (no new line).
+            MapRenderTrace.EmitMarkerDecisionOnChange(
+                MapRenderTrace.RenderSurface.ImguiLabeledMarker, "rec-1", 101.0, "outcome=drawn-non-proto");
+
+            Assert.Equal(afterFirst, logLines.Count);
+        }
+
+        [Fact]
+        public void EmitMarkerDecisionOnChange_ChangedSignatureReEmits()
+        {
+            MapRenderTrace.ForceEnabledForTesting = true;
+
+            MapRenderTrace.EmitMarkerDecisionOnChange(
+                MapRenderTrace.RenderSurface.ImguiLabeledMarker, "rec-1", 100.0, "outcome=drawn-non-proto");
+            int afterFirst = logLines.Count;
+            // A transition (different outcome) re-emits, capturing the sub-second change.
+            MapRenderTrace.EmitMarkerDecisionOnChange(
+                MapRenderTrace.RenderSurface.ImguiLabeledMarker, "rec-1", 100.5, "outcome=skipped-position-fail");
+
+            Assert.True(logLines.Count > afterFirst);
+            Assert.Contains(logLines, l => l.Contains("outcome=skipped-position-fail"));
+        }
+
+        [Fact]
+        public void EmitMarkerDecisionOnChange_PerPidIndependent()
+        {
+            MapRenderTrace.ForceEnabledForTesting = true;
+
+            // Two different ghosts with the same signature each emit once (change detection is per-pid).
+            MapRenderTrace.EmitMarkerDecisionOnChange(
+                MapRenderTrace.RenderSurface.ImguiLabeledMarker, "rec-1", 100.0, "outcome=drawn-non-proto");
+            MapRenderTrace.EmitMarkerDecisionOnChange(
+                MapRenderTrace.RenderSurface.ImguiLabeledMarker, "rec-2", 100.0, "outcome=drawn-non-proto");
+
+            Assert.Contains(logLines, l => l.Contains("pid=rec-1"));
+            Assert.Contains(logLines, l => l.Contains("pid=rec-2"));
+        }
+
+        [Fact]
+        public void EmitMarkerDecisionOnChange_ReEmitsAfterReset()
+        {
+            MapRenderTrace.ForceEnabledForTesting = true;
+
+            MapRenderTrace.EmitMarkerDecisionOnChange(
+                MapRenderTrace.RenderSurface.ImguiLabeledMarker, "rec-1", 100.0, "outcome=drawn-non-proto");
+            // Reset() (driven by the scene-switch hook) clears the per-pid signature dict, so the
+            // SAME signature emits again on re-entry rather than being silently suppressed.
+            MapRenderTrace.Reset();
+            int afterReset = logLines.Count;
+            MapRenderTrace.EmitMarkerDecisionOnChange(
+                MapRenderTrace.RenderSurface.ImguiLabeledMarker, "rec-1", 200.0, "outcome=drawn-non-proto");
+
+            Assert.True(logLines.Count > afterReset);
+        }
     }
 }

--- a/Source/Parsek.Tests/MarkerDrawDecisionTests.cs
+++ b/Source/Parsek.Tests/MarkerDrawDecisionTests.cs
@@ -114,5 +114,53 @@ namespace Parsek.Tests
                 Assert.True(!gateOff || gateOn);
             }
         }
+
+        // --- Marker-decision tracer: TS skip-reason -> shared MarkerOutcome mapping ---
+
+        [Fact]
+        public void MapSkipReasonToMarkerOutcome_NativeIcon_MapsToProtoIcon()
+        {
+            Assert.Equal(MapRenderTrace.MarkerOutcome.DrawnProtoIcon,
+                ParsekTrackingStation.MapSkipReasonToMarkerOutcome(
+                    ParsekTrackingStation.AtmosphericMarkerSkipReason.NativeIconActive));
+        }
+
+        [Fact]
+        public void MapSkipReasonToMarkerOutcome_Debris_MapsToSkippedDebris()
+        {
+            Assert.Equal(MapRenderTrace.MarkerOutcome.SkippedDebris,
+                ParsekTrackingStation.MapSkipReasonToMarkerOutcome(
+                    ParsekTrackingStation.AtmosphericMarkerSkipReason.Debris));
+        }
+
+        [Fact]
+        public void MapSkipReasonToMarkerOutcome_None_MapsToDrawnNonProto()
+        {
+            // None = eligible to draw; the caller upgrades to SkippedPositionFail only if the
+            // subsequent position resolve fails.
+            Assert.Equal(MapRenderTrace.MarkerOutcome.DrawnNonProto,
+                ParsekTrackingStation.MapSkipReasonToMarkerOutcome(
+                    ParsekTrackingStation.AtmosphericMarkerSkipReason.None));
+        }
+
+        [Fact]
+        public void MapSkipReasonToMarkerOutcome_DecisionSkips_MapToSkippedDecisionFalse()
+        {
+            // NullRecording / NoTrajectoryPoints / OutsideTimeRange / SuppressedByChainFilter /
+            // OrbitSegmentActive all collapse to "the decision said do not draw this marker".
+            // (A [Theory] with InlineData would expose the internal enum on a public method
+            // signature -> CS0051, so these are asserted inline in one Fact.)
+            var skips = new[]
+            {
+                ParsekTrackingStation.AtmosphericMarkerSkipReason.NullRecording,
+                ParsekTrackingStation.AtmosphericMarkerSkipReason.NoTrajectoryPoints,
+                ParsekTrackingStation.AtmosphericMarkerSkipReason.OutsideTimeRange,
+                ParsekTrackingStation.AtmosphericMarkerSkipReason.SuppressedByChainFilter,
+                ParsekTrackingStation.AtmosphericMarkerSkipReason.OrbitSegmentActive,
+            };
+            foreach (var reason in skips)
+                Assert.Equal(MapRenderTrace.MarkerOutcome.SkippedDecisionFalse,
+                    ParsekTrackingStation.MapSkipReasonToMarkerOutcome(reason));
+        }
     }
 }

--- a/Source/Parsek/Display/GhostTrajectoryPolylineRenderer.cs
+++ b/Source/Parsek/Display/GhostTrajectoryPolylineRenderer.cs
@@ -783,10 +783,33 @@ namespace Parsek.Display
         internal static bool TryAnchorMarkerToPolyline(
             string recordingId, double headUT, out Vector3 worldPos)
         {
+            // Thin wrapper preserving the original 3-arg contract; the reason/leg out-params are
+            // only consumed by the marker tracer. Behavior is byte-identical to the diagnostics
+            // overload below (same control flow, same returns).
+            return TryAnchorMarkerToPolyline(
+                recordingId, headUT, out worldPos, out _, out _);
+        }
+
+        /// <summary>
+        /// Diagnostics overload of <see cref="TryAnchorMarkerToPolyline(string,double,out Vector3)"/>
+        /// that ALSO reports WHY the ride did or did not happen (<paramref name="rideReason"/>) and,
+        /// on a successful ride, the leg index (<paramref name="legIndex"/>). The ride LOGIC is
+        /// unchanged - every branch sets the reason then takes the exact same return path as before -
+        /// so the marker still rides or falls back identically; only the explanation is surfaced.
+        /// </summary>
+        internal static bool TryAnchorMarkerToPolyline(
+            string recordingId, double headUT, out Vector3 worldPos,
+            out MapRenderTrace.MarkerRideReason rideReason, out int legIndex)
+        {
             worldPos = Vector3.zero;
+            rideReason = MapRenderTrace.MarkerRideReason.FallbackNoCache;
+            legIndex = -1;
             if (string.IsNullOrEmpty(recordingId)) return false;
             if (!polylineCache.TryGetValue(recordingId, out var set) || set.legs == null) return false;
 
+            // A cache entry exists; the default now becomes "head fell outside every leg" unless a
+            // leg matches below.
+            rideReason = MapRenderTrace.MarkerRideReason.FallbackHeadOutsideLegs;
             int frame = Time.frameCount;
             for (int li = 0; li < set.legs.Length; li++)
             {
@@ -794,9 +817,16 @@ namespace Parsek.Display
                 if (headUT < leg.startUT || headUT > leg.endUT) continue;
                 int m = leg.PointCount;
                 if (m < 2 || leg.scratchScaledSpace == null
-                    || leg.recordedUTs == null || leg.recordedUTs.Length != m
-                    || leg.lastDrawnFrame != frame)
+                    || leg.recordedUTs == null || leg.recordedUTs.Length != m)
+                {
+                    rideReason = MapRenderTrace.MarkerRideReason.FallbackMissingRecordedUTs;
+                    return false; // missing recorded-UT / scratch arrays -> cannot bracket
+                }
+                if (leg.lastDrawnFrame != frame)
+                {
+                    rideReason = MapRenderTrace.MarkerRideReason.FallbackLegNotDrawnThisFrame;
                     return false; // not drawn this frame -> scratch is stale -> keep the body-fixed head
+                }
 
                 // Bracket headUT between two recorded sample UTs and lerp the drawn (anchored) points.
                 int idx = m - 2;
@@ -810,6 +840,8 @@ namespace Parsek.Display
                 Vector3 scaled = Vector3.Lerp(
                     leg.scratchScaledSpace[idx], leg.scratchScaledSpace[idx + 1], frac);
                 worldPos = (Vector3)ScaledSpace.ScaledToLocalSpace(scaled);
+                rideReason = MapRenderTrace.MarkerRideReason.RodeLeg;
+                legIndex = li;
                 return true;
             }
             return false;

--- a/Source/Parsek/GhostMapPresence.cs
+++ b/Source/Parsek/GhostMapPresence.cs
@@ -1074,13 +1074,35 @@ namespace Parsek
         /// </summary>
         internal static bool ShouldDrawNonProtoMarkerForGhost(uint ghostPid)
         {
-            bool gateOn = ParsekSettings.Current != null && ParsekSettings.Current.mapRenderDirectorDrive;
+            return ShouldDrawNonProtoMarkerForGhost(
+                ghostPid, out _, out _, out _, out _);
+        }
+
+        /// <summary>
+        /// Diagnostics overload of <see cref="ShouldDrawNonProtoMarkerForGhost(uint)"/> that ALSO
+        /// surfaces the four decision inputs the marker tracer logs (the
+        /// <see cref="ResolveMarkerDrawDecision"/> disjuncts) WITHOUT changing the decision: the
+        /// parameterless overload above delegates here, so the returned bool is byte-identical. The
+        /// <c>out</c> values let the call site emit a per-pid change-based trace line explaining WHY
+        /// the marker drew or was skipped.
+        /// </summary>
+        internal static bool ShouldDrawNonProtoMarkerForGhost(
+            uint ghostPid,
+            out bool gateOn,
+            out bool directorTracedPathActive,
+            out bool polylineOwning,
+            out bool iconSuppressed)
+        {
+            gateOn = ParsekSettings.Current != null && ParsekSettings.Current.mapRenderDirectorDrive;
+            directorTracedPathActive = Parsek.MapRender.ShadowRenderDriver.IsDirectorTracedPathActive(
+                ghostPid, UnityEngine.Time.frameCount);
+            polylineOwning = IsPolylineOwningGhostPhase(ghostPid);
+            iconSuppressed = IsIconSuppressed(ghostPid);
             return ResolveMarkerDrawDecision(
                 gateOn,
-                Parsek.MapRender.ShadowRenderDriver.IsDirectorTracedPathActive(
-                    ghostPid, UnityEngine.Time.frameCount),
-                IsPolylineOwningGhostPhase(ghostPid),
-                IsIconSuppressed(ghostPid));
+                directorTracedPathActive,
+                polylineOwning,
+                iconSuppressed);
         }
 
         /// <summary>

--- a/Source/Parsek/MapRenderTrace.cs
+++ b/Source/Parsek/MapRenderTrace.cs
@@ -148,6 +148,182 @@ namespace Parsek
             }
         }
 
+        // ---- Marker-decision observability (per-ghost WHY a marker drew / was skipped) ----
+
+        /// <summary>
+        /// The terminal OUTCOME of one ghost's per-recording marker-decision pass in
+        /// <c>ParsekUI.DrawMapMarkers</c> / <c>ParsekTrackingStation.DrawAtmosphericMarkers</c>.
+        /// Every branch in those loops maps to exactly one of these so a single per-pid trace
+        /// line says, in one token, WHY this ghost's marker drew or did not this frame.
+        /// </summary>
+        internal enum MarkerOutcome : byte
+        {
+            /// <summary>Default / not yet decided.</summary>
+            Unknown = 0,
+
+            /// <summary>The Parsek non-proto labeled marker drew (proto icon hidden).</summary>
+            DrawnNonProto = 1,
+
+            /// <summary>
+            /// The stock proto vessel icon is the visible indicator, so the non-proto
+            /// marker was correctly skipped (no gap).
+            /// </summary>
+            DrawnProtoIcon = 2,
+
+            /// <summary>Skipped: the recording is debris.</summary>
+            SkippedDebris = 3,
+
+            /// <summary>Skipped: a non-tip chain member (the tip draws the marker).</summary>
+            SkippedChainNonTip = 4,
+
+            /// <summary>
+            /// Skipped: the ghost mesh is hidden and we are not in map view, so its
+            /// stale transform would project to the wrong place (#245/#247).
+            /// </summary>
+            SkippedNotOnMap = 5,
+
+            /// <summary>
+            /// Skipped: the marker-draw decision (<c>ShouldDrawNonProtoMarkerForGhost</c>)
+            /// returned false with no proto icon, or another classify-skip fired
+            /// (no trajectory points / outside time range / chain filter / orbit segment).
+            /// </summary>
+            SkippedDecisionFalse = 6,
+
+            /// <summary>Skipped: the world position could not be resolved this frame.</summary>
+            SkippedPositionFail = 7,
+
+            /// <summary>Skipped: a loop member is outside its render window this cycle.</summary>
+            SkippedLoopHidden = 8,
+        }
+
+        internal static string MarkerOutcomeToken(MarkerOutcome outcome)
+        {
+            switch (outcome)
+            {
+                case MarkerOutcome.DrawnNonProto: return "drawn-non-proto";
+                case MarkerOutcome.DrawnProtoIcon: return "drawn-proto-icon";
+                case MarkerOutcome.SkippedDebris: return "skipped-debris";
+                case MarkerOutcome.SkippedChainNonTip: return "skipped-chain-non-tip";
+                case MarkerOutcome.SkippedNotOnMap: return "skipped-not-on-map";
+                case MarkerOutcome.SkippedDecisionFalse: return "skipped-decision-false";
+                case MarkerOutcome.SkippedPositionFail: return "skipped-position-fail";
+                case MarkerOutcome.SkippedLoopHidden: return "skipped-loop-hidden";
+                default: return "unknown";
+            }
+        }
+
+        /// <summary>
+        /// Why the non-proto marker did (or did not) ride the trajectory polyline this frame.
+        /// Surfaces the previously-opaque bool return of
+        /// <c>GhostTrajectoryPolylineRenderer.TryAnchorMarkerToPolyline</c> without changing
+        /// its ride logic - the caller maps the new <c>out</c> reason straight into the trace line.
+        /// </summary>
+        internal enum MarkerRideReason : byte
+        {
+            /// <summary>Default / the marker path did not attempt a ride this frame.</summary>
+            NotAttempted = 0,
+
+            /// <summary>Rode a drawn leg (the leg index + interpolation t are logged alongside).</summary>
+            RodeLeg = 1,
+
+            /// <summary>Fallback: the head's leg was not drawn THIS frame (stale scratch).</summary>
+            FallbackLegNotDrawnThisFrame = 2,
+
+            /// <summary>Fallback: the head UT falls outside every leg's [start,end].</summary>
+            FallbackHeadOutsideLegs = 3,
+
+            /// <summary>Fallback: the leg is missing its recorded-UT / scratch arrays.</summary>
+            FallbackMissingRecordedUTs = 4,
+
+            /// <summary>Fallback: no polyline cache entry for this recording id.</summary>
+            FallbackNoCache = 5,
+        }
+
+        internal static string MarkerRideReasonToken(MarkerRideReason reason, int legIndex)
+        {
+            switch (reason)
+            {
+                case MarkerRideReason.RodeLeg: return "rode-leg" + legIndex.ToString(CultureInfo.InvariantCulture);
+                case MarkerRideReason.FallbackLegNotDrawnThisFrame: return "fallback-leg-not-drawn-this-frame";
+                case MarkerRideReason.FallbackHeadOutsideLegs: return "fallback-head-outside-legs";
+                case MarkerRideReason.FallbackMissingRecordedUTs: return "fallback-missing-recordedUTs";
+                case MarkerRideReason.FallbackNoCache: return "fallback-no-cache";
+                default: return "not-attempted";
+            }
+        }
+
+        /// <summary>
+        /// Pure builder for the per-pid marker-decision SIGNATURE (the change-detection key) AND
+        /// the human-readable detail tail (they are the same <c>key=value</c> string here, so one
+        /// build serves both: identical signature =&gt; identical line =&gt; suppressed). Carries the
+        /// four decision disjuncts from <c>ResolveMarkerDrawDecision</c>, the resolved
+        /// <c>shouldDrawNonProto</c> bool, the terminal outcome, and (for a drawn non-proto marker)
+        /// the polyline ride reason + the fallback position source actually used. Kept pure (no Unity
+        /// reads) so the schema is unit-testable. <paramref name="legIndex"/> is only meaningful when
+        /// <paramref name="rideReason"/> is <see cref="MarkerRideReason.RodeLeg"/>.
+        /// </summary>
+        internal static string BuildMarkerDecisionSignature(
+            int recordingIndex,
+            string vesselName,
+            bool gateOn,
+            bool directorTracedPathActive,
+            bool polylineOwning,
+            bool iconSuppressed,
+            bool shouldDrawNonProto,
+            MarkerOutcome outcome,
+            MarkerRideReason rideReason,
+            int legIndex,
+            string posSource)
+        {
+            string s = "rec=" + recordingIndex.ToString(CultureInfo.InvariantCulture)
+                + " vessel=" + Token(vesselName)
+                + " gateOn=" + Bool(gateOn)
+                + " directorTracedPathActive=" + Bool(directorTracedPathActive)
+                + " polylineOwning=" + Bool(polylineOwning)
+                + " iconSuppressed=" + Bool(iconSuppressed)
+                + " shouldDrawNonProto=" + Bool(shouldDrawNonProto)
+                + " outcome=" + MarkerOutcomeToken(outcome);
+            if (outcome == MarkerOutcome.DrawnNonProto)
+                s += " ride=" + MarkerRideReasonToken(rideReason, legIndex)
+                    + " posSource=" + Token(posSource);
+            return s;
+        }
+
+        // Per-pid (here pid = recordingId; the marker surfaces are recordingId-keyed, carried in the
+        // prefix pid= slot to match EmitMarker) last-emitted signature. CALLER-OWNED change detection:
+        // EmitMarkerDecisionOnChange emits only when the composed signature differs from the last one
+        // for that key. Cleared in Reset() (driven by MapRenderProbe's scene-switch hook), mirroring
+        // lineIntentByPid / detailedUntilByKey so a stale signature never suppresses the first
+        // post-re-entry transition.
+        private static readonly Dictionary<string, string> lastMarkerDecisionSignatureByPid =
+            new Dictionary<string, string>(StringComparer.Ordinal);
+
+        /// <summary>
+        /// Change-based per-pid marker-decision emit (Tier-B, routed to Verbose via
+        /// <see cref="EmitOnChange"/>). Owns the per-pid last-signature dict so the call sites stay
+        /// thin: pass the pre-built <paramref name="signature"/> (from
+        /// <see cref="BuildMarkerDecisionSignature"/>) and this emits ONE line only when that ghost's
+        /// signature changed since its last emit, capturing sub-second transitions without per-frame
+        /// spam. No-op when disabled (gate short-circuits before any dict touch, so a closed tracer
+        /// pays nothing beyond the caller's own <see cref="IsEnabled"/> guard).
+        /// </summary>
+        internal static void EmitMarkerDecisionOnChange(
+            RenderSurface surface, string pidKey, double currentUT, string signature)
+        {
+            if (!IsEnabled)
+                return;
+            if (string.IsNullOrEmpty(pidKey))
+                return;
+
+            string last;
+            if (lastMarkerDecisionSignatureByPid.TryGetValue(pidKey, out last)
+                && string.Equals(last, signature, StringComparison.Ordinal))
+                return; // unchanged outcome for this ghost -> suppress
+
+            lastMarkerDecisionSignatureByPid[pidKey] = signature;
+            EmitOnChange("MarkerDecision", surface, pidKey, currentUT, currentUT, signature);
+        }
+
         // MVP: detailed windows are keyed by pid.ToString(). recordingId keying
         // (and the shared registry with GhostRenderTrace) is a later cut.
         private static readonly Dictionary<string, double> detailedUntilByKey =
@@ -172,6 +348,7 @@ namespace Parsek
             detailedUntilByKey.Clear();
             lineIntentByPid.Clear();
             renderIntentByPid.Clear();
+            lastMarkerDecisionSignatureByPid.Clear();
         }
 
         private static int CurrentFrameCount()

--- a/Source/Parsek/ParsekTrackingStation.cs
+++ b/Source/Parsek/ParsekTrackingStation.cs
@@ -380,10 +380,31 @@ namespace Parsek
             // Update, never rebuilt here). Empty => the substitution below is inert.
             var loopUnits = cachedLoopUnits;
 
+            bool traceOn = MapRenderTrace.IsEnabled;
             for (int i = 0; i < committed.Count; i++)
             {
                 var rec = committed[i];
                 summary.Candidates++;
+
+                // ---- Marker-decision tracer state (per-pid, change-based; gated, off in normal play) ----
+                // Mirrors the flight-map DrawMapMarkers tracer: one change-based line per ghost saying
+                // WHY its atmospheric marker drew or was skipped, carrying the four
+                // ResolveMarkerDrawDecision disjuncts (resolved only when a proto ghost vessel exists,
+                // false otherwise). The TS path never rides the polyline, so the ride reason stays
+                // NotAttempted and the position source is always "traj".
+                bool decGateOn = false, decDirectorTraced = false, decPolylineOwning = false,
+                    decIconSuppressed = false, decShouldDraw = false;
+                void EmitMarkerDecision(MapRenderTrace.MarkerOutcome outcome)
+                {
+                    if (!traceOn || rec == null || string.IsNullOrEmpty(rec.RecordingId))
+                        return;
+                    MapRenderTrace.EmitMarkerDecisionOnChange(
+                        MapRenderTrace.RenderSurface.AtmosphericMarker, rec.RecordingId, currentUT,
+                        MapRenderTrace.BuildMarkerDecisionSignature(
+                            i, rec.VesselName, decGateOn, decDirectorTraced, decPolylineOwning,
+                            decIconSuppressed, decShouldDraw, outcome,
+                            MapRenderTrace.MarkerRideReason.NotAttempted, -1, "traj"));
+                }
 
                 // Phase F: substitute the shared Mission span-clock loopUT for the live UT when this
                 // committed index is a loop-unit member. A member outside its loop window this cycle
@@ -395,7 +416,20 @@ namespace Parsek
                 if (renderHidden)
                 {
                     summary.LoopMemberHidden++;
+                    EmitMarkerDecision(MapRenderTrace.MarkerOutcome.SkippedLoopHidden);
                     continue;
+                }
+
+                // Tracer: surface the decision disjuncts when a proto ghost vessel exists (the only
+                // case ShouldDrawNonProtoMarkerForGhost is consulted). Behavior-identical to the
+                // bare predicate ClassifyAtmosphericMarkerSkip already calls; this only reads them out.
+                if (traceOn && GhostMapPresence.HasGhostVesselForRecording(i))
+                {
+                    uint ghostPidTrace = GhostMapPresence.GetGhostVesselPidForRecording(i);
+                    if (ghostPidTrace != 0)
+                        decShouldDraw = GhostMapPresence.ShouldDrawNonProtoMarkerForGhost(
+                            ghostPidTrace, out decGateOn, out decDirectorTraced,
+                            out decPolylineOwning, out decIconSuppressed);
                 }
 
                 AtmosphericMarkerSkipReason skipReason =
@@ -403,6 +437,7 @@ namespace Parsek
                 if (skipReason != AtmosphericMarkerSkipReason.None)
                 {
                     CountAtmosphericMarkerSkip(ref summary, skipReason);
+                    EmitMarkerDecision(MapSkipReasonToMarkerOutcome(skipReason));
                     continue;
                 }
 
@@ -422,6 +457,7 @@ namespace Parsek
                         summary.MissingBody++;
                     else
                         summary.BracketMiss++;
+                    EmitMarkerDecision(MapRenderTrace.MarkerOutcome.SkippedPositionFail);
                     continue;
                 }
                 atmosCachedIndices[i] = cached;
@@ -438,6 +474,9 @@ namespace Parsek
                     vtype,
                     context => OnAtmosphericMarkerClicked(recordingIndex, markerRecording, context));
                 summary.Drawn++;
+
+                // Tracer: the atmospheric (non-proto) marker drew.
+                EmitMarkerDecision(MapRenderTrace.MarkerOutcome.DrawnNonProto);
 
                 ParsekLog.VerboseRateLimited(Tag, $"atmosMarker-{i}",
                     $"Drawing atmospheric marker #{i} \"{rec.VesselName}\" " +
@@ -529,6 +568,33 @@ namespace Parsek
         {
             return ClassifyAtmosphericMarkerSkip(rec, recordingIndex, currentUT, suppressedIds)
                 == AtmosphericMarkerSkipReason.None;
+        }
+
+        /// <summary>
+        /// Pure: map an <see cref="AtmosphericMarkerSkipReason"/> to the shared
+        /// <see cref="MapRenderTrace.MarkerOutcome"/> the marker tracer logs, so the TS marker path
+        /// and the flight-map path emit one common outcome vocabulary. <c>None</c> means the marker
+        /// will draw (the caller upgrades it to <see cref="MapRenderTrace.MarkerOutcome.DrawnNonProto"/>
+        /// after a successful position resolve, or to
+        /// <see cref="MapRenderTrace.MarkerOutcome.SkippedPositionFail"/> if the resolve fails).
+        /// </summary>
+        internal static MapRenderTrace.MarkerOutcome MapSkipReasonToMarkerOutcome(
+            AtmosphericMarkerSkipReason skipReason)
+        {
+            switch (skipReason)
+            {
+                case AtmosphericMarkerSkipReason.None:
+                    // Eligible to draw; the caller finalizes after the position resolve.
+                    return MapRenderTrace.MarkerOutcome.DrawnNonProto;
+                case AtmosphericMarkerSkipReason.NativeIconActive:
+                    return MapRenderTrace.MarkerOutcome.DrawnProtoIcon;
+                case AtmosphericMarkerSkipReason.Debris:
+                    return MapRenderTrace.MarkerOutcome.SkippedDebris;
+                // NullRecording / NoTrajectoryPoints / OutsideTimeRange / SuppressedByChainFilter /
+                // OrbitSegmentActive all collapse to "the decision said do not draw this marker".
+                default:
+                    return MapRenderTrace.MarkerOutcome.SkippedDecisionFalse;
+            }
         }
 
         internal static AtmosphericMarkerSkipReason ClassifyAtmosphericMarkerSkip(

--- a/Source/Parsek/ParsekUI.cs
+++ b/Source/Parsek/ParsekUI.cs
@@ -1135,6 +1135,11 @@ namespace Parsek
             // mesh is hidden by zone distance so every ghost is visible on the map.
             double currentUT = isMapView ? Planetarium.GetUniversalTime() : 0;
 
+            // Marker-decision tracer timestamp: currentUT is 0 in flight view (only map view needs
+            // it for positioning), so use the live UT for the trace line so it is meaningful in
+            // both views. Only read when tracing is enabled.
+            double traceUT = MapRenderTrace.IsEnabled ? Planetarium.GetUniversalTime() : 0.0;
+
             foreach (var kvp in flight.Engine.ghostStates)
             {
                 var state = kvp.Value;
@@ -1142,10 +1147,38 @@ namespace Parsek
                 summary.Candidates++;
                 bool meshActive = state.ghost != null && state.ghost.activeSelf;
 
+                // ---- Marker-decision tracer state (per-pid, change-based; gated, off in normal play) ----
+                // Carries the four ResolveMarkerDrawDecision disjuncts (resolved only at the proto-gate
+                // branch below; false elsewhere because no proto vessel exists / the gate was not
+                // consulted), the resolved shouldDrawNonProto bool, the terminal outcome, and (for a
+                // drawn non-proto marker) the polyline ride reason + the fallback position source. A
+                // single change-based line per ghost is emitted via EmitMarkerDecision() at each exit.
+                bool decGateOn = false, decDirectorTraced = false, decPolylineOwning = false,
+                    decIconSuppressed = false, decShouldDraw = false;
+                var decOutcome = MapRenderTrace.MarkerOutcome.Unknown;
+                var decRideReason = MapRenderTrace.MarkerRideReason.NotAttempted;
+                int decRideLeg = -1;
+                string decPosSource = "?";
+                string traceRecId = kvp.Key < committed.Count ? committed[kvp.Key].RecordingId : null;
+                string traceVessel = kvp.Key < committed.Count ? committed[kvp.Key].VesselName : "Ghost";
+                void EmitMarkerDecision()
+                {
+                    if (!MapRenderTrace.IsEnabled || string.IsNullOrEmpty(traceRecId))
+                        return;
+                    MapRenderTrace.EmitMarkerDecisionOnChange(
+                        MapRenderTrace.RenderSurface.ImguiLabeledMarker, traceRecId, traceUT,
+                        MapRenderTrace.BuildMarkerDecisionSignature(
+                            kvp.Key, traceVessel, decGateOn, decDirectorTraced, decPolylineOwning,
+                            decIconSuppressed, decShouldDraw, decOutcome, decRideReason, decRideLeg,
+                            decPosSource));
+                }
+
                 // In flight view, skip hidden ghosts (stale positions cause wrong markers #245/#247)
                 if (!meshActive && !isMapView)
                 {
                     summary.HiddenInFlight++;
+                    decOutcome = MapRenderTrace.MarkerOutcome.SkippedNotOnMap;
+                    EmitMarkerDecision();
                     continue;
                 }
 
@@ -1166,10 +1199,28 @@ namespace Parsek
                     // byte-identical. In the polyline / suppressed case our marker is the
                     // sole position indicator, so it must draw - otherwise an airless
                     // descent (e.g. the Mun) shows the polyline with no ghost icon.
-                    if (ghostPid == 0
-                        || !GhostMapPresence.ShouldDrawNonProtoMarkerForGhost(ghostPid))
+                    //
+                    // Tracer: resolve the decision through the diagnostics overload to surface the
+                    // four disjuncts (behavior-identical to the parameterless overload). ghostPid==0
+                    // means no resolvable proto pid -> proto icon assumed active, decShouldDraw stays
+                    // false.
+                    bool decision;
+                    if (ghostPid == 0)
+                    {
+                        decision = false;
+                    }
+                    else
+                    {
+                        decision = GhostMapPresence.ShouldDrawNonProtoMarkerForGhost(
+                            ghostPid, out decGateOn, out decDirectorTraced,
+                            out decPolylineOwning, out decIconSuppressed);
+                    }
+                    decShouldDraw = decision;
+                    if (ghostPid == 0 || !decision)
                     {
                         summary.NativeIcon++;
+                        decOutcome = MapRenderTrace.MarkerOutcome.DrawnProtoIcon;
+                        EmitMarkerDecision();
                         continue; // native icon is active — skip our marker
                     }
                 }
@@ -1178,6 +1229,8 @@ namespace Parsek
                     if (committed[kvp.Key].IsDebris)
                     {
                         summary.Debris++;
+                        decOutcome = MapRenderTrace.MarkerOutcome.SkippedDebris;
+                        EmitMarkerDecision();
                         continue;
                     }
                     string chainId = committed[kvp.Key].ChainId;
@@ -1185,6 +1238,8 @@ namespace Parsek
                         && chainTipIndexBuffer.TryGetValue(chainId, out int tip) && kvp.Key != tip)
                     {
                         summary.ChainNonTip++;
+                        decOutcome = MapRenderTrace.MarkerOutcome.SkippedChainNonTip;
+                        EmitMarkerDecision();
                         continue; // not the tip — skip duplicate
                     }
                 }
@@ -1257,9 +1312,11 @@ namespace Parsek
                 if (meshPositioned)
                 {
                     markerPos = state.ghost.transform.position;
+                    decPosSource = "mesh";
                 }
                 else
                 {
+                    decPosSource = "traj";
                     // A looped-mission member's recorded trajectory points sit at the ORIGINAL
                     // (past) recorded UTs, so sampling at the LIVE UT is always OutsideTimeRange and
                     // the custom icon never draws (the engine positions the mesh at the shared
@@ -1278,6 +1335,8 @@ namespace Parsek
                         if (loopHidden)
                         {
                             summary.LoopHidden++;
+                            decOutcome = MapRenderTrace.MarkerOutcome.SkippedLoopHidden;
+                            EmitMarkerDecision();
                             continue;
                         }
                         sampleUT = effUT;
@@ -1293,6 +1352,8 @@ namespace Parsek
                         summary.PositionFailure++;
                         if (failureReason == MapMarkerPositionFailureReason.MissingBody)
                             summary.MissingBody++;
+                        decOutcome = MapRenderTrace.MarkerOutcome.SkippedPositionFail;
+                        EmitMarkerDecision();
                         continue;
                     }
 
@@ -1301,12 +1362,15 @@ namespace Parsek
                     // head, which is ~96 deg off the loiter/hyperbola conics under the loop shift. Samples
                     // the same per-frame drawn points the line uses, so it matches exactly; a no-op outside
                     // an anchored leg or when the leg was not drawn this frame.
-                    if (polylinePhase && kvp.Key < committed.Count
+                    bool rideAttempted = polylinePhase && kvp.Key < committed.Count;
+                    if (rideAttempted
                         && Parsek.Display.GhostTrajectoryPolylineRenderer.TryAnchorMarkerToPolyline(
-                            committed[kvp.Key].RecordingId, sampleUT, out Vector3 onLineMarkerPos))
+                            committed[kvp.Key].RecordingId, sampleUT, out Vector3 onLineMarkerPos,
+                            out decRideReason, out decRideLeg))
                     {
                         markerPos = onLineMarkerPos;
                         markerRidesPolyline = true;
+                        decPosSource = "polyline";
                         if (ghostPidForPhase == 0)
                             ParsekLog.VerboseRateLimited(
                                 "GhostMap",
@@ -1326,6 +1390,11 @@ namespace Parsek
                 Color markerColor = GetGhostMarkerColorForType(vtype);
                 DrawMapMarkerAt(markerPos, markerKey, ghostName, markerColor, vtype);
                 summary.Drawn++;
+
+                // Tracer: the non-proto labeled marker drew. Emit the per-pid change-based decision
+                // line carrying WHY (the disjuncts), the ride reason + leg, and the position source.
+                decOutcome = MapRenderTrace.MarkerOutcome.DrawnNonProto;
+                EmitMarkerDecision();
 
                 // Comprehensive per-marker DRAW log (always available, rate-limited, NOT tracing-gated):
                 // EVERY non-proto labelled marker logs WHERE it drew + its position SOURCE - mesh-ridden


### PR DESCRIPTION
## Per-pid marker-decision + ride logging (gated, no behavior change)

Diagnostic logging only, to unblock two map-marker issues (a connector/deorbit TracedPath leg losing its vessel icon; markers flicker/drop when panning). The marker path had no per-pid decision logging - only a 2-second aggregate "Map marker summary" that misses sub-second legs and never says, per ghost, WHY a marker drew/skipped or whether it rode the polyline or fell back. This adds change-based per-pid logging so a single re-fly (tracing on) captures the exact decision on the connector leg and during a pan.

Gated behind `mapRenderTracing` (off by default), routed through `MapRenderTrace`. Behavior-neutral.

### What it logs (change-based, per pid)
At each marker decision in `ParsekUI.DrawMapMarkers` and `ParsekTrackingStation.DrawAtmosphericMarkers`: the four `ResolveMarkerDrawDecision` inputs (`gateOn` / `directorTracedPathActive` / `polylineOwning` / `iconSuppressed`), the resolved `shouldDrawNonProto`, the outcome (`drawn-non-proto` / `drawn-proto-icon` / `skipped-{debris,chain-non-tip,not-on-map,loop-hidden,position-fail,decision-false}`), and for a drawn non-proto marker the ride result (`rode-leg{idx}` / `fallback-{leg-not-drawn-this-frame,head-outside-legs,missing-recordedUTs,no-cache}`) + the position source.

### How (behavior-neutral surfacing)
- `GhostTrajectoryPolylineRenderer.TryAnchorMarkerToPolyline`: new 5-arg diagnostics overload (`out MarkerRideReason`, `out int legIndex`); the 3-arg signature is now a thin wrapper delegating with `out _`. Ride logic unchanged; the combined `return false` split into labeled returns evaluating the same conditions in the same short-circuit order.
- `GhostMapPresence.ShouldDrawNonProtoMarkerForGhost`: new `out`-overload surfacing the four disjuncts; the parameterless version delegates (returned bool byte-identical).
- `MapRenderTrace.EmitMarkerDecisionOnChange`: owns a per-pid last-signature dict (caller-owned change detection), emits only on transition, cleared in `Reset()` on scene switch (so the first post-re-entry transition isn't suppressed). Pure `BuildMarkerDecisionSignature` + `MapSkipReasonToMarkerOutcome`.

### Safety
- **Behavior-neutral** (clean-context review: the out-overloads + the ride return-split are byte-identical, same order/result; every `EmitMarkerDecision` is additive side-logging at existing branch points, no new control flow).
- **Gated / no-op when tracing off**: every emit early-returns on `MapRenderTrace.IsEnabled` before any string build or dict touch; the TS extra disjunct-resolve is behind the `traceOn` guard. With tracing off the added cost is a single bool check per ghost.

### Tests + build
- Build clean (0 warnings / 0 errors). Full suite green: 13457 passed, 0 failed, 0 skipped. GrepAudit green.
- New tests exercise the pure pieces (signature build, reason/skip token maps, first-emit / repeat-suppress / per-pid-independent / clear-on-reset, disabled no-op).

No CHANGELOG entry (internal diagnostic logging, no user-facing change). Next: re-fly s15 "Duna One" with tracing on to capture the connector-leg + a pan, then fix the marker ride-robustness + polyline pan-stability from the data.