### PR TITLE
maprender(overlap): let the Director render overlap members (remove the conservative SkipOverlap skip)

### DIFF
--- a/Source/Parsek.Tests/MapRender/ChainSamplerTests.cs
+++ b/Source/Parsek.Tests/MapRender/ChainSamplerTests.cs
@@ -60,5 +60,97 @@ namespace Parsek.Tests
             var s = ChainSampler.Sample(Chain(), 200, NonLooped);
             Assert.Equal(Coverage.OutsideWindow, s.Coverage);
         }
+
+        // ---- Overlap-member parity: the sampler resolves the SAME selected-cycle head-UT the legacy
+        //      single head uses. (Integration #2: the Director now renders overlap members; this locks
+        //      the parity the fix relies on - the map shows ONE ghost at the span-clock head-UT.)
+
+        // A single-member SELF-OVERLAP unit: span [100,200] with CadenceSeconds == span (the span-raised
+        // cadence the single-instance scenes use -> one span instance) but OverlapCadenceSeconds < span
+        // (so it IS classified overlap). The member window is the full span. This is exactly what a
+        // Kerbin launch-to-orbit mission looped shorter than its length produces on the map.
+        private static GhostPlaybackLogic.LoopUnitSet OverlapUnit(
+            int idx = 0, double spanStart = 100, double spanEnd = 200,
+            double cadence = 100, double overlapCadence = 25, double anchor = 100)
+        {
+            var unit = new GhostPlaybackLogic.LoopUnit(
+                idx, new[] { idx }, spanStart, spanEnd, cadenceSeconds: cadence,
+                phaseAnchorUT: anchor, overlapCadenceSeconds: overlapCadence);
+            // Sanity: this MUST be an overlap unit (OverlapCadenceSeconds < span), else the test is moot.
+            Assert.True(GhostPlaybackLogic.UnitMemberOverlaps(unit));
+            var unitsByOwner = new Dictionary<int, GhostPlaybackLogic.LoopUnit> { { idx, unit } };
+            var ownerByIndex = new Dictionary<int, int> { { idx, idx } };
+            return new GhostPlaybackLogic.LoopUnitSet(unitsByOwner, ownerByIndex);
+        }
+
+        private static GhostRenderChain OverlapMemberChain(double spanStart = 100, double spanEnd = 200)
+        {
+            // One segment spanning the whole member window, so any in-window selected-cycle head-UT
+            // lands InSegment and its DriveUT is observable.
+            var segs = new List<RenderSegment> { Seg(spanStart, spanEnd) };
+            return new GhostRenderChain("rec-overlap", committedIndex: 0, instanceKey: 0,
+                segments: segs, windowStartUT: spanStart, windowEndUT: spanEnd);
+        }
+
+        [Fact]
+        public void OverlapMember_SampledUT_EqualsResolveTrackingStationSampleUT()
+        {
+            // THE PARITY THE FIX RELIES ON: for an overlap member, the UT ChainSampler.Sample resolves
+            // (DriveUT) must equal what GhostPlaybackLogic.ResolveTrackingStationSampleUT - the SAME pure
+            // span clock the legacy single head uses - returns for that member at the same liveUT. Both
+            // run on the unit's span-raised CadenceSeconds, NOT OverlapCadenceSeconds, so they pick the
+            // identical selected-cycle head-UT (one ghost on the map, not N instances).
+            var units = OverlapUnit();
+            var chain = OverlapMemberChain();
+
+            // liveUT 350: elapsed 250, cadence 100 -> cycle 2, phaseInCycle 50 -> loopUT 150 (in window).
+            const double liveUT = 350.0;
+            double expected = GhostPlaybackLogic.ResolveTrackingStationSampleUT(
+                i: 0, memberStartUT: 100, memberEndUT: 200, liveUT: liveUT, units, out bool hidden);
+            Assert.False(hidden); // selected cycle is inside the member window -> render, not hidden
+
+            var s = ChainSampler.Sample(chain, liveUT, units);
+            Assert.Equal(Coverage.InSegment, s.Coverage);
+            Assert.Equal(expected, s.DriveUT, 6);      // sampler lands on the legacy single-head UT
+            Assert.Equal(150.0, s.DriveUT, 6);         // and that UT is the selected-cycle head (sanity)
+        }
+
+        [Theory]
+        [InlineData(110.0)] // cycle 0, phase 10 -> loopUT 110
+        [InlineData(225.0)] // cycle 1, phase 25 -> loopUT 125
+        [InlineData(380.0)] // cycle 2, phase 80 -> loopUT 180
+        public void OverlapMember_SampledUT_TracksLegacyHead_AcrossCycles(double liveUT)
+        {
+            // Across several relaunch cycles the sampler stays glued to the legacy single-head UT: the
+            // map ghost rides ONE span instance (the selected cycle), never enumerating instances.
+            var units = OverlapUnit();
+            var chain = OverlapMemberChain();
+
+            double expected = GhostPlaybackLogic.ResolveTrackingStationSampleUT(
+                i: 0, memberStartUT: 100, memberEndUT: 200, liveUT: liveUT, units, out bool hidden);
+            Assert.False(hidden);
+
+            var s = ChainSampler.Sample(chain, liveUT, units);
+            Assert.Equal(Coverage.InSegment, s.Coverage);
+            Assert.Equal(expected, s.DriveUT, 6);
+        }
+
+        [Fact]
+        public void OverlapMember_BeforeSpanStart_IsOutside_LikeLegacyHidden()
+        {
+            // Before the phase anchor the span clock is unresolved -> ResolveTrackingStationSampleUT
+            // reports hidden, and ChainSampler routes the same frame to Outside (render nothing). Parity
+            // on the hide path too.
+            var units = OverlapUnit(anchor: 100);
+            var chain = OverlapMemberChain();
+
+            const double liveUT = 50.0; // before the anchor -> span clock unresolved -> hidden
+            GhostPlaybackLogic.ResolveTrackingStationSampleUT(
+                i: 0, memberStartUT: 100, memberEndUT: 200, liveUT: liveUT, units, out bool hidden);
+            Assert.True(hidden);
+
+            var s = ChainSampler.Sample(chain, liveUT, units);
+            Assert.Equal(Coverage.OutsideWindow, s.Coverage);
+        }
     }
 }

--- a/Source/Parsek.Tests/MapRender/ShadowRenderDriverTests.cs
+++ b/Source/Parsek.Tests/MapRender/ShadowRenderDriverTests.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.IO;
 using Parsek;
 using Parsek.MapRender;
 using Xunit;
@@ -271,6 +273,120 @@ namespace Parsek.Tests
         {
             var intent = Decide(31.0);          // gap, nothing drawn yet
             Assert.False(intent.Visible);
+        }
+
+        // ---- Integration #2: an OVERLAP member is now PROCESSED (no longer skipped to legacy) ----
+        // The Director renders an overlap member as ONE ghost at the span-clock head-UT. RunFrame is
+        // Unity-coupled (Time.frameCount), so the PURE proof is that the same assemble→sample→decide
+        // composition RunFrame runs (DecideForGhost) produces a visible intent for an overlap member,
+        // at the selected-cycle head-UT the legacy single head would use. (The ClassifyScope tests above
+        // keep the SkipOverlap enum; production simply no longer drops on it - locked by the source gate.)
+
+        // A single-member SELF-OVERLAP unit: span [0,40], CadenceSeconds == span (single span instance)
+        // but OverlapCadenceSeconds < span (so it classifies as overlap). Member window = full span. This
+        // is what a Kerbin launch-to-orbit mission looped shorter than its length produces on the map.
+        private static GhostPlaybackLogic.LoopUnitSet OverlapUnitFullSpan()
+        {
+            var unit = new GhostPlaybackLogic.LoopUnit(
+                0, new[] { 0 }, spanStartUT: 0, spanEndUT: 40, cadenceSeconds: 40,
+                phaseAnchorUT: 0, overlapCadenceSeconds: 10);
+            Assert.True(GhostPlaybackLogic.UnitMemberOverlaps(unit)); // must be overlap, else the test is moot
+            var unitsByOwner = new Dictionary<int, GhostPlaybackLogic.LoopUnit> { { 0, unit } };
+            var ownerByIndex = new Dictionary<int, int> { { 0, 0 } };
+            return new GhostPlaybackLogic.LoopUnitSet(unitsByOwner, ownerByIndex);
+        }
+
+        [Fact]
+        public void DecideForGhost_OverlapMember_OnOrbit_IsProcessedAndVisible()
+        {
+            // liveUT 60: elapsed 60, cadence 40 -> cycle 1, phaseInCycle 20 -> span-clock loopUT 20, which
+            // is inside the FaithfulChain orbit segment [10,30]. The overlap member is PROCESSED (not
+            // dropped) and renders the StockConic at the span-clock head-UT, exactly like the legacy single
+            // head. WHAT MAKES IT FAIL: re-introducing the RunFrame overlap skip would route this to legacy
+            // and DecideForGhost would never be reached for an overlap member in production.
+            var units = OverlapUnitFullSpan();
+            double expectedHead = GhostPlaybackLogic.ResolveTrackingStationSampleUT(
+                i: 0, memberStartUT: 0, memberEndUT: 40, liveUT: 60.0, units, out bool hidden);
+            Assert.False(hidden);
+            Assert.Equal(20.0, expectedHead, 6); // selected-cycle head-UT
+
+            var intent = ShadowRenderDriver.DecideForGhost(
+                FaithfulChain(), committedIndex: 0, windowStartUT: 0, windowEndUT: 40,
+                currentUT: 60.0, units: units, surface: null, prior: default(GhostRenderIntent));
+
+            Assert.True(intent.Visible);                       // processed + rendered, not skipped
+            Assert.Equal(Treatment.StockConic, intent.Treatment);
+            Assert.Equal("Kerbin", intent.FrameBodyName);
+            Assert.Equal(expectedHead, intent.DriveUT, 6);     // at the legacy single-head UT
+        }
+
+        // ---- Source gate: RunFrame no longer DROPS an overlap member (the skip is lifted) ----
+
+        private static string ReadShadowRenderDriverSource()
+        {
+            string root = Path.GetFullPath(Path.Combine(
+                AppDomain.CurrentDomain.BaseDirectory, "..", "..", "..", "..", ".."));
+            string path = Path.Combine(root, "Source", "Parsek", "MapRender", "ShadowRenderDriver.cs");
+            if (!File.Exists(path))
+            {
+                // Fallback layout (mirrors MapPresenceSeamTests): some checkouts root at Parsek/.
+                path = Path.Combine(root, "Parsek", "MapRender", "ShadowRenderDriver.cs");
+            }
+            Assert.True(File.Exists(path), $"Source file not found at {path}");
+            return File.ReadAllText(path);
+        }
+
+        // Strips trailing // line comments so the doc prose (which legitimately names SkipOverlap /
+        // continue) does not trip the negative gate; the assertions are about real statements.
+        private static string StripLineComments(string source)
+        {
+            var sb = new System.Text.StringBuilder(source.Length);
+            foreach (string line in source.Split('\n'))
+            {
+                int idx = line.IndexOf("//", StringComparison.Ordinal);
+                sb.Append(idx >= 0 ? line.Substring(0, idx) : line);
+                sb.Append('\n');
+            }
+            return sb.ToString();
+        }
+
+        // Collapse every run of whitespace (incl. newlines / CRLF / tabs) to a single space so the
+        // source gate is robust to formatting and line endings.
+        private static string CollapseWhitespace(string source)
+        {
+            var sb = new System.Text.StringBuilder(source.Length);
+            bool inWs = false;
+            foreach (char c in source)
+            {
+                if (char.IsWhiteSpace(c))
+                {
+                    if (!inWs) { sb.Append(' '); inWs = true; }
+                }
+                else { sb.Append(c); inWs = false; }
+            }
+            return sb.ToString();
+        }
+
+        [Fact]
+        public void RunFrame_DoesNotSkipOverlapMembers_SourceGate()
+        {
+            // Integration #2 lifted the RunFrame overlap early-skip. A regression that re-introduces it
+            // (a "scope == ShadowScope.SkipOverlap" guard that continues / drops the member) is caught
+            // here. The classifier and its ClassifyScope tests stay (the enum is retained), so this gate
+            // is specifically about the RunFrame DROP, not the enum value.
+            // Normalize: strip // comments, then collapse all runs of whitespace to single spaces so the
+            // gate is robust to formatting / CRLF. The old drop looked like:
+            //   if (... == ShadowScope.SkipOverlap) { skipOverlap++; continue; }
+            string normalized = CollapseWhitespace(StripLineComments(ReadShadowRenderDriverSource()));
+
+            // The old per-drop counter is gone (it was unique to the dropped overlap path)...
+            Assert.DoesNotContain("skipOverlap++", normalized);
+            // ...and no SkipOverlap comparison leads into a continue-drop block (whitespace-tolerant).
+            Assert.DoesNotContain("SkipOverlap) { skipOverlap++; continue; }", normalized);
+
+            // Positively: an overlap-classified member is COUNTED-then-PROCEEDS (the diagnostic counter
+            // increments WITHOUT a continue), proving the member flows into the normal pipeline.
+            Assert.Contains("overlapShadowed++", normalized);
         }
     }
 }

--- a/Source/Parsek/MapRender/ShadowRenderDriver.cs
+++ b/Source/Parsek/MapRender/ShadowRenderDriver.cs
@@ -19,14 +19,20 @@ namespace Parsek.MapRender
     /// scene adapter (the <see cref="MissionLoopUnitBuilder.Build"/> output), not the engine
     /// passthrough.</para>
     ///
-    /// <para><b>Shadow scope (MVP): faithful, single-instance members only — decided PER MEMBER.</b>
+    /// <para><b>Shadow scope: faithful + overlap single-instance members — decided PER MEMBER.</b>
     /// Re-aim is per member, not per mission (design §4): only the heliocentric (Sun-relative) member
     /// is re-synthesized, so ONLY it is skipped; the Kerbin-departure and destination-arrival members
     /// of the SAME re-aimed mission are faithful and ARE shadowed (they render their recorded surface
-    /// tracks). Overlap members are still skipped (their per-instance phasing is not modelled by a
-    /// single pid→recording resolve). Skips carry a logged reason and land fully with the re-aim /
-    /// overlap wiring in a later phase. Both the faithful same-body case (Mun/Minmus) AND the faithful
-    /// departure/arrival members of an interplanetary mission are validated here.</para>
+    /// tracks). OVERLAP members (a looped mission whose launch cadence is shorter than its span, so it
+    /// relaunches and several staggered instances run at once) are NOW shadowed too (integration #2):
+    /// the MAP has no per-instance model — an overlapping mission renders as exactly ONE ghost at the
+    /// SELECTED cycle's span-clock head-UT, chosen by the SAME pure span clock
+    /// (<see cref="GhostPlaybackLogic.ResolveTrackingStationSampleUT"/>) the legacy single head uses
+    /// (the unit's <c>CadenceSeconds</c>, raised to at least the span, gives a single span instance).
+    /// The N simultaneous instances are flight-MESH-only (<c>GhostPlaybackEngine.overlapGhosts</c>),
+    /// out of scope here. Re-aim skips still carry a logged reason. Both the faithful same-body case
+    /// (Mun/Minmus) AND the faithful departure/arrival members of an interplanetary mission are
+    /// validated here.</para>
     /// </summary>
     internal static class ShadowRenderDriver
     {
@@ -37,7 +43,11 @@ namespace Parsek.MapRender
             Faithful = 0,
             /// <summary>Re-aim member: raw recording lacks the synthesized transfer → skip (later phase).</summary>
             SkipReaim = 1,
-            /// <summary>Overlap member: per-instance phasing not modelled here → skip (later phase).</summary>
+            /// <summary>Overlap member classification (RETAINED for <see cref="ClassifyScope"/> + its tests).
+            /// PRODUCTION NO LONGER ACTS ON THIS: integration #2 lifted the RunFrame overlap skip, so an
+            /// overlap member now flows through the normal assemble→sample→decide path and renders one ghost
+            /// at the span-clock head-UT (the map has no per-instance model). The enum value stays so the pure
+            /// classifier and its unit tests keep documenting the overlap predicate.</summary>
             SkipOverlap = 2,
         }
 
@@ -247,7 +257,7 @@ namespace Parsek.MapRender
             double currentUT = scene.CurrentUT;
             var surface = scene.BodySurface;
 
-            int shadowed = 0, skipReaim = 0, skipOverlap = 0, unresolved = 0;
+            int shadowed = 0, skipReaim = 0, overlapShadowed = 0, unresolved = 0;
             if (pids != null)
             {
                 foreach (uint pid in pids)
@@ -258,14 +268,18 @@ namespace Parsek.MapRender
                         continue;
                     }
 
-                    // Overlap is a per-MEMBER property (the unit's cadence shorter than its span), decided
-                    // before sampling. Re-aim is decided PER ACTIVE SEGMENT after Decide (below), not here.
-                    if (ClassifyOverlapForMember(units, idx, out double wStart, out double wEnd,
-                            traj.StartUT, traj.EndUT) == ShadowScope.SkipOverlap)
-                    {
-                        skipOverlap++;
-                        continue;
-                    }
+                    // Resolve this member's trimmed render window (interval-level start/end trim if it
+                    // belongs to a unit). Integration #2: overlap members are NO LONGER skipped here. On
+                    // the map there is no per-instance model — an overlapping mission renders as exactly
+                    // ONE ghost at the SELECTED cycle's span-clock head-UT, which ChainSampler.Sample
+                    // resolves through the SAME pure clock (ResolveTrackingStationSampleUT, driven by the
+                    // unit's span-raised CadenceSeconds) the legacy single head uses. So an overlap member
+                    // flows through the normal assemble→sample→decide path like any faithful single
+                    // instance. Re-aim is still decided PER ACTIVE SEGMENT after Decide (below).
+                    ShadowScope scope = ClassifyOverlapForMember(
+                        units, idx, out double wStart, out double wEnd, traj.StartUT, traj.EndUT);
+                    if (scope == ShadowScope.SkipOverlap)
+                        overlapShadowed++; // counted for diagnostics; it now PROCEEDS, not skipped
 
                     GhostRenderChain chain = GetOrBuildChain(
                         pid, traj, idx, wStart, wEnd, currentUT, units, surface,
@@ -325,8 +339,8 @@ namespace Parsek.MapRender
 
             ParsekLog.VerboseRateLimited("MapRender", "shadow-frame-summary",
                 string.Format(CultureInfo.InvariantCulture,
-                    "shadow frame ghosts={0} shadowed={1} skipReaim={2} skipOverlap={3} unresolved={4}",
-                    pids?.Count ?? 0, shadowed, skipReaim, skipOverlap, unresolved),
+                    "shadow frame ghosts={0} shadowed={1} skipReaim={2} overlapShadowed={3} unresolved={4}",
+                    pids?.Count ?? 0, shadowed, skipReaim, overlapShadowed, unresolved),
                 5.0);
         }
 
@@ -358,8 +372,11 @@ namespace Parsek.MapRender
                 && !(chainHasReaimedSegments && sampleInSegment);
         }
 
-        // Resolve a member's window (trimmed if it belongs to a unit) and classify ONLY its overlap
-        // scope (re-aim is now decided per active segment via ShouldSkipReaimSegment after Decide).
+        // Resolve a member's window (trimmed if it belongs to a unit) and classify its overlap scope
+        // (re-aim is decided per active segment via ShouldSkipReaimSegment after Decide). Integration #2:
+        // the RunFrame caller no longer DROPS a SkipOverlap member — the scope is used only for a
+        // diagnostic counter; the member proceeds through the normal pipeline. The window resolution
+        // (trimmed MemberStartUT/MemberEndUT) is the load-bearing output now.
         private static ShadowScope ClassifyOverlapForMember(
             GhostPlaybackLogic.LoopUnitSet units, int idx,
             out double windowStartUT, out double windowEndUT,

--- a/docs/dev/plans/maprender-rewrite-status.md
+++ b/docs/dev/plans/maprender-rewrite-status.md
@@ -361,11 +361,23 @@ reconciler for decision-vs-old-truth parity, and resolve the in-game probes befo
     + tracing-on: re-aim ghost's icon rides its heliocentric line (`angleIconVsOrbitEff` -> ~0, was
     >45deg), `decision-vs-truth` parity, trim-gap frames stay hidden, no SOI-seam blink; toggle gate-off
     -> byte-identical.
-  - **Integration 2 - overlap rendering (planned, near-trivial).** No per-instance MAP model exists
+  - **Integration 2 - overlap rendering (DONE, awaiting in-game gate).** No per-instance MAP model exists
     (`GhostMapPresence` is one-vessel-per-recording); an overlapping mission renders as ONE ProtoVessel +
-    one polyline head at the selected cycle. So integration = delete the conservative `SkipOverlap` gate
-    in `ShadowRenderDriver` after a reconciler parity check (`ChainSampler` already shares the loop clock).
-    Needs an overlapping-loop save (period < span) to validate; s15/Mun don't overlap.
+    one polyline head at the selected cycle. Fix: removed the conservative `SkipOverlap` early-skip in
+    `ShadowRenderDriver.RunFrame` so an overlap member flows through the normal assemble->sample->decide->
+    seed/stamp path. The sampler-parity precondition is CONFIRMED (clean review): `ChainSampler.Sample`
+    maps live->assembled UT via the SAME `GhostPlaybackLogic.ResolveTrackingStationSampleUT` the legacy
+    single-head uses, driven by `unit.CadenceSeconds` (span-raised single-instance), NOT
+    `unit.OverlapCadenceSeconds` (the short relaunch cadence consumed only by the flight MESH engine), so
+    the Director lands on the SAME selected-cycle head-UT as legacy. `ShadowScope.SkipOverlap` enum +
+    `ClassifyScope`/`ClassifyOverlapForMember` retained (classifier + its tests stay; production just stops
+    skipping; counter renamed `skipOverlap`->`overlapShadowed`). Gate-OFF byte-identical (skip lived only
+    in the gate/tracing-gated `RunFrame`; the new seed/stamp is consumed only under `IsDirectorDriveActive`
+    /`IsDirectorTracedPathActive`). No per-instance model / InstanceKey added. Build clean; suite green
+    (13477); clean review SHIP. **In-game gate:** a LAUNCH-TO-ORBIT mission looped with period < length so
+    it overlaps (interplanetary can't - pinned to its transfer window), map view + tracing on: the single
+    overlap map icon rides its line at the selected cycle, hides cleanly in inter-cycle gaps; gate-off
+    byte-identical. (The N staggered instances are flight-MESH-only; the map shows one at the live cycle.)
   - **Rendering polish - polyline + marker pan-stability (DONE, gated-neutral).** Fixed map polylines +
     yellow label markers jittering / flickering when panning the camera (pre-existing, NOT from the
     cutover). Root cause: the polyline draw ran at `[DefaultExecutionOrder(-50)]`, BEFORE the map camera
@@ -381,15 +393,25 @@ reconciler for decision-vs-old-truth parity, and resolve the in-game probes befo
     (confirm in re-fly: fixed iff that root is ride-dropout, not leg-non-construction). Gate-off
     byte-identical (only the draw slot moved). FIX 2 is flight-map-scoped (the TS marker path does not use
     the ride; TS line stability still benefits). Two clean reviews SHIP; build clean, suite green (13470).
-  - **Integration 3 - shared polyline draw host (planned, structural).** The ownership DECISION +
-    publish stay at `-50` (publish-before-orbit-patch-read); the per-leg DRAW now runs in the map
-    camera's `onPreCull` (LANDED with the pan-stability fix above, so the "draw must stay in LateUpdate"
-    constraint is superseded). Remaining: fold the autonomous `CommittedRecordings` walk's ITERATION
-    under the Director and close the pid-0 atmospheric-only enumeration gap (Director enumerates
-    `ghostMapVesselPids`; the Driver walks `CommittedRecordings`). Medium.
-  - **Then 8e (deletion LAST):** once 1-3 land and nothing rides the legacy draw path, delete the legacy
-    fallbacks + autonomous walk + grace fields, grep-audit no readers, drop the `mapRenderDirectorDrive`
-    gate -> single modular system.
+  - **Integration 3 - shared polyline draw host (DEFERRED - read-only scoping verdict 2026-06-06).** Do
+    NOT do the "fold the autonomous walk under the Director" rewrite. The scoping found it is NOT worth it
+    now and NOT a true 8e prerequisite: #1050 made the `onPreCull` DRAW the sanctioned shared mechanism
+    (not legacy); the `-50` LateUpdate already does only the DECIDE + ownership publish. The ONLY piece 8e
+    genuinely needs is closing the pid-0 atmospheric-only enumeration gap (the Director enumerates
+    `ghostMapVesselPids` = proto-bearing; atmospheric-only no-orbit no-terminal-state recordings are pid-0,
+    reached only by the Driver's `CommittedRecordings` walk - `GetGhostVesselPidForRecording` returns 0,
+    `ghostMapVesselPids.Add` only in the proto-create funnel). That gap is NEAR-EMPTY in practice and
+    ALREADY DRAWS CORRECTLY today (a pid-0 leg always takes Driver-direct `TryDrawLeg`); it is only a
+    coverage-accounting bookkeeping item for the eventual deletion. The full rewrite is high-risk against
+    the now-working, user-praised pan-stable host for ZERO behavior change. **Recommendation: defer #3;
+    do the MINIMAL pid-0 coverage surface as PART of 8e, when the deletion actually consumes it - add a
+    proto-less-recording coverage set, leave the `-50`/`onPreCull` draw path byte-identical, prove the
+    Director's accounted set is a superset of the autonomous walk's drawn set, THEN delete.**
+  - **Then 8e (deletion LAST):** once #2 is validated + the minimal pid-0 coverage (folded from #3) lands
+    and nothing rides the legacy draw path uncovered, delete the legacy fallbacks + the autonomous
+    `CommittedRecordings` DECIDE-walk + grace fields (KEEP the `onPreCull` DRAW mechanism - it is the
+    sanctioned shared host, not legacy), grep-audit no readers, drop the `mapRenderDirectorDrive` gate ->
+    single modular system.
 - **Phase 8** per-surface cutover (8a-8e) - deletes the scattered gates; in-game per sub-phase.
 - **Workstream B** B2 `IEncounterSolver` (wraps `CalculatePatch`, §15.4 test-gap decision) + B3
   `TransferConic` frame-agnostic return - touch the in-game-validated re-aim path.


### PR DESCRIPTION
## Integration #2 - overlap rendering (gated, no behavior change by construction)

Lets the Director render OVERLAP members (a looped mission whose loop period is shorter than its length, so it relaunches and several staggered replays run at once) instead of skipping them to the legacy renderer. Runs UNDER `mapRenderDirectorDrive`; gate-off byte-identical.

### What changed
The Director was skipping overlap members via a conservative MVP `SkipOverlap` gate in `ShadowRenderDriver.RunFrame`. Removed the skip so an overlap member flows through the normal `assemble -> sample -> decide -> seed/stamp` path like any faithful single-instance ghost.

### Why it's safe (sampler-parity precondition, clean-review confirmed)
On the MAP there is **no per-instance model** - an overlapping mission renders as exactly ONE ProtoVessel + one polyline head at the SELECTED cycle (the N staggered instances are flight-MESH-only, `GhostPlaybackEngine.overlapGhosts`). `ChainSampler.Sample` maps live->assembled UT via the **same** `GhostPlaybackLogic.ResolveTrackingStationSampleUT` the legacy single-head uses, driven by `unit.CadenceSeconds` (span-raised single-instance), **NOT** `unit.OverlapCadenceSeconds` (the short relaunch cadence consumed only by the flight mesh engine). So the Director lands on the same selected-cycle head-UT as legacy. Window inputs match (idempotent `MemberStartUT/MemberEndUT` trim).

- `ShadowScope.SkipOverlap` enum + `ClassifyScope`/`ClassifyOverlapForMember` retained (classifier + its unit tests stay; production just stops acting on the value; diagnostic counter renamed `skipOverlap` -> `overlapShadowed`).
- No per-instance map model / `InstanceKey` added (`instanceKey: 0` stays correct, each pid processed once).

### Safety
- **Gate-off byte-identical:** the skip lived only in `RunFrame` (runs when `Enabled` = tracing OR gate-on); the new overlap seed/stamp is consumed only under `IsDirectorDriveActive` / `IsDirectorTracedPathActive`, both gate-on.
- Faithful single-instance + re-aim members unaffected (a looped-but-NOT-overlapping member classifies `Faithful`, not `SkipOverlap`).
- Inter-cycle gaps still hide (the span clock returns `renderHidden` -> `Outside`), so no stale-cycle draw.

### Tests + build
- Build clean (0 warnings / 0 errors). Full suite green: 13477 passed, 0 failed, 0 skipped.
- `ChainSampler` overlap-head parity tests (sampled UT == `ResolveTrackingStationSampleUT`, across cycles, + the hide path), a `DecideForGhost` overlap-member-is-processed test, and a `RunFrame` source-gate locking out a re-introduced skip.

### In-game gate (please)
A **launch-to-orbit** mission looped with **period < length** so it overlaps (interplanetary missions can't - they're pinned to a transfer window), map view + `mapRenderTracing` on, run past at least one relaunch: the single overlap map icon should ride its line at the live cycle and hide cleanly in inter-cycle gaps; toggle the gate off -> byte-identical. (You'll see one map icon at the live cycle even though the flight scene shows N staggered copies - that's by design.)

No CHANGELOG entry (internal ownership migration with parity; the overlap member's icon-off-orbit fix is covered by the existing 0.10.0 entry).