### PR TITLE
docs(maprender): reframe overlap as 2a (foundation, done) + 2b per-instance (the accurate goal)

### DIFF
--- a/docs/dev/plans/maprender-overlap-per-instance.md
+++ b/docs/dev/plans/maprender-overlap-per-instance.md
@@ -1,0 +1,110 @@
+# Overlap rendering 2b - one map icon per live overlap instance
+
+*Part of the map/TS render cutover (`docs/dev/plans/maprender-rewrite-status.md`). Integration #2 has two
+parts: 2a (PR #1051, DONE) removed the conservative `SkipOverlap` skip so the Director processes an
+overlap member and renders ONE ghost at the newest cycle. 2b (this doc) makes the map render ONE icon +
+orbit line + polyline PER LIVE OVERLAP INSTANCE so the map matches flight reality.*
+
+## Why (decided 2026-06-06)
+
+A looped mission whose loop period is shorter than its length relaunches before the previous replay
+finishes, so several staggered replays run at once (overlap). In FLIGHT there are N meshes; on the MAP
+today there is exactly ONE icon (the newest/selected cycle). The maintainer's call: "render a single
+icon on the polyline and keep it unique until the loop run ends... that's lying to the player. Render an
+icon for every vessel that launches, even when overlapping, so the player sees the overlap in map view
+and it reflects rendering reality from flight view. Make it accurate."
+
+So the map must show N icons (one per live overlap instance), each at its own cycle's phase, with its own
+trajectory.
+
+## The architectural fact: N icons require N ProtoVessels
+
+The on-map icon is the stock orbit-driver's icon, one per `Vessel.persistentId` (`GhostOrbitLinePatch`
+keys on `__instance.vessel.persistentId`). There is no "draw N icons against one vessel" path in KSP. So
+N icons means N ProtoVessels. Today `GhostMapPresence` is strictly one-ProtoVessel-per-recording
+(`vesselsByRecordingIndex`, `ghostMapVesselPids`); 2b makes it N-per-overlapping-recording.
+
+## Mirror the flight engine (do NOT reinvent the math)
+
+The flight engine already computes everything 2b needs - reuse it:
+- `GhostPlaybackEngine.overlapGhosts` = `Dictionary<int, List<GhostPlaybackState>>` keyed by recording
+  index (the staggered instances; the primary `ghostStates[i]` is the newest cycle).
+- `GhostPlaybackLogic.GetActiveCycles` -> `[firstActiveCycle, lastActiveCycle]` (the simultaneously-live
+  cycle range; `firstCycle` clamped to `lastCycle - cap + 1`).
+- `GhostPlaybackLogic.ComputeOverlapCyclePlaybackUT(...)` -> the per-instance playback UT (pure,
+  deterministic). The map's per-instance epoch shift = `currentUT - ComputeOverlapCyclePlaybackUT(...)`.
+- Stable per-instance identity = `(recordingIndex, cycleIndex)` (the flight `GhostPlaybackState.
+  loopCycleIndex`). Key the map's per-instance ProtoVessels / chains / polylines / markers on this.
+- Cap = `MaxOverlapGhostsPerRecording = 20` (cadence is already raised so `ceil(duration/cadence) <= cap`,
+  so the map inherits the bound for free; do not add a new cap).
+
+## Scope: FULL per-instance (not icon-only)
+
+Each instance gets its own orbit line + icon + non-orbital polyline + marker. Icon-only (N icons sharing
+one orbit line) is rejected: it is visibly wrong for non-orbital ascent/descent instances (an icon with
+no polyline under it), and the orbit line comes free with the per-instance ProtoVessel anyway. The cost
+driver (ProtoVessel count) is identical either way.
+
+## What is already per-instance-ready vs what must change
+
+Ready (keyed by pid, not recording index): the Director caches (`priorIntentByPid`, `chainByPid`,
+`seedByPid`, `tracedPathByPid`), `ChainAssembler.Build` / `GhostRenderChain` already carry a real
+`instanceKey` dimension (the map just hardcodes `0`), `vesselPidToRecordingId` is already many-pids->one-
+recId, the marker decision `ShouldDrawNonProtoMarkerForGhost(pid)` is per-pid. So once each instance is a
+distinct ProtoVessel with a distinct pid, the Director / seed patches / icon "just work" per-pid.
+
+Must become per-(recording, cycle): the presence store (`vesselsByRecordingIndex`), the create/destroy
+lifecycle funnel, `GetGhostVesselPidForRecording`, the polyline cache + active-leg sets + marker-hold
+(`polylineCache`, `activeLegRecordings`, `directorOwnedLegRecordings`, `lastGoodOnLine` - keyed by
+`RecordingId` today), and the polyline Driver's single-head-UT walk.
+
+## Slices
+
+- **(i) Map presence - N-per-overlapping-recording lifecycle [the bulk].** A per-instance store
+  (`(recIdx, cycle) -> Vessel`) alongside the existing one-per-recording store (for non-overlap).
+  `EnsureOverlapInstances(recIdx, traj, units, currentUT)`: call `GetActiveCycles`, create a ProtoVessel
+  per missing live cycle (each gets a fresh KSP-unique pid), destroy instances whose cycle < firstCycle,
+  store the per-instance epoch shift. Hook into both `UpdateFlightMapGhostLifecycle` and
+  `UpdateTrackingStationGhostLifecycle` behind the overlap-only gate. Throttle creates (mirror the flight
+  engine's `MaxSpawnsPerFrame`). Extend the scene-switch teardown to clear the new store.
+- **(ii) Director per-instance enumeration + instanceKey.** `scene.GhostPids` already yields every
+  instance pid once they are real ProtoVessels, so `RunFrame` enumerates them unchanged. Feed
+  `ChainAssembler.Build` the instance's `cycle` as `instanceKey` instead of `0` (resolve pid->cycle via
+  the per-instance store). Per-pid seed/epoch-shift flow through the existing pid-keyed paths.
+- **(iii) Polyline + marker per-instance.** Re-key `polylineCache` (geometry shared by RecordingId; only
+  the head-UT / active-leg / hold STATE goes per-(RecordingId, cycle)), `activeLegRecordings` /
+  `directorOwnedLegRecordings`, `lastGoodOnLine`. The Driver's LateUpdate walk enumerates the recording's
+  live cycles and draws one leg per cycle at each `ComputeOverlapCyclePlaybackUT`. Preserve the #1050
+  timing invariants (decide+publish at -50, draw at `onPreCull`).
+
+## Efficiency + safety
+
+- **Overlap-ONLY gate:** gate the per-instance path on `units.TryGetUnitForMember(i,..) && cadence < span`
+  (the predicate `ClassifyScope` already computes). Non-overlapping recordings (the vast majority) stay
+  EXACTLY one-per-recording: zero new objects, zero new cost.
+- **Bounded N** = `min(ceil(duration/cadence), 20)`; typical 3-6.
+- **Biggest risk:** ProtoVessel create/destroy churn under time warp (cycles relaunching fast ->
+  `pv.Load`/`Die` storms). Mitigate: reuse the engine's computed cycles, throttle creates, cap at 20.
+- **Gate-OFF** stays legacy one-per-recording. Faithful + non-overlap members unaffected.
+
+## Tests + validation
+
+- xUnit pure: "map instance set == engine cycle set" equivalence against `overlapGhosts`; per-instance
+  key/signature uniqueness; gate-off / non-overlap one-per-recording assertion.
+- In-game (`ExtendedRuntimeTests`): map instance count == flight `overlapGhosts[i].Count + 1`, capped at 20.
+- Maintainer in-game: an overlapping launch-to-orbit / short mission (loop period < length), map / TS
+  view - see N icons matching the N flight ghosts 1:1, each on its own orbit + polyline, appearing /
+  expiring as cycles relaunch; gate-off -> byte-identical one-per-recording.
+
+## Size + sequencing
+
+LARGE (multi-PR, ~3 slices). Stacks on 2a (PR #1051). The hard math is done (flight engine); the work is
+mechanical breadth (re-key ~12 maps recording->instance) plus the one genuinely new piece, the
+per-instance ProtoVessel lifecycle (slice i). Land the slices in order, each behind the overlap-only gate
+and in-game gated.
+
+## Adjacent follow-up (separate, not 2b)
+
+The #1051 validation log surfaced two SUPPRESSED `TS shadow RunFrame threw ArgumentNullException` (caught
+by the try/catch, in the Tracking Station, not in the overlap window). Pre-existing, harmless at runtime,
+but a swallowed NRE in the TS shadow path worth a small separate investigation.

--- a/docs/dev/plans/maprender-rewrite-status.md
+++ b/docs/dev/plans/maprender-rewrite-status.md
@@ -361,23 +361,37 @@ reconciler for decision-vs-old-truth parity, and resolve the in-game probes befo
     + tracing-on: re-aim ghost's icon rides its heliocentric line (`angleIconVsOrbitEff` -> ~0, was
     >45deg), `decision-vs-truth` parity, trim-gap frames stay hidden, no SOI-seam blink; toggle gate-off
     -> byte-identical.
-  - **Integration 2 - overlap rendering (DONE, awaiting in-game gate).** No per-instance MAP model exists
-    (`GhostMapPresence` is one-vessel-per-recording); an overlapping mission renders as ONE ProtoVessel +
-    one polyline head at the selected cycle. Fix: removed the conservative `SkipOverlap` early-skip in
-    `ShadowRenderDriver.RunFrame` so an overlap member flows through the normal assemble->sample->decide->
-    seed/stamp path. The sampler-parity precondition is CONFIRMED (clean review): `ChainSampler.Sample`
-    maps live->assembled UT via the SAME `GhostPlaybackLogic.ResolveTrackingStationSampleUT` the legacy
-    single-head uses, driven by `unit.CadenceSeconds` (span-raised single-instance), NOT
-    `unit.OverlapCadenceSeconds` (the short relaunch cadence consumed only by the flight MESH engine), so
-    the Director lands on the SAME selected-cycle head-UT as legacy. `ShadowScope.SkipOverlap` enum +
-    `ClassifyScope`/`ClassifyOverlapForMember` retained (classifier + its tests stay; production just stops
-    skipping; counter renamed `skipOverlap`->`overlapShadowed`). Gate-OFF byte-identical (skip lived only
-    in the gate/tracing-gated `RunFrame`; the new seed/stamp is consumed only under `IsDirectorDriveActive`
-    /`IsDirectorTracedPathActive`). No per-instance model / InstanceKey added. Build clean; suite green
-    (13477); clean review SHIP. **In-game gate:** a LAUNCH-TO-ORBIT mission looped with period < length so
-    it overlaps (interplanetary can't - pinned to its transfer window), map view + tracing on: the single
-    overlap map icon rides its line at the selected cycle, hides cleanly in inter-cycle gaps; gate-off
-    byte-identical. (The N staggered instances are flight-MESH-only; the map shows one at the live cycle.)
+  - **Integration 2 - overlap rendering. TWO parts: 2a FOUNDATION (DONE, PR #1051), 2b PER-INSTANCE
+    (planned, multi-PR - the real goal).** Full plan for 2b: `docs/dev/plans/maprender-overlap-per-instance.md`.
+    - **2a (DONE, PR #1051, validated):** removed the conservative `SkipOverlap` early-skip in
+      `ShadowRenderDriver.RunFrame` so an overlap member flows through the normal assemble->sample->decide->
+      seed/stamp path instead of falling back to legacy. It renders ONE ghost at the newest (selected)
+      cycle. Sampler-parity CONFIRMED (clean review + in-game): `ChainSampler.Sample` maps live->assembled
+      UT via the SAME `GhostPlaybackLogic.ResolveTrackingStationSampleUT` the legacy single-head uses,
+      driven by `unit.CadenceSeconds` (span-raised single-instance), NOT `unit.OverlapCadenceSeconds` (the
+      short relaunch cadence consumed only by the flight MESH engine), so the Director lands on the same
+      selected-cycle head-UT as legacy. `ShadowScope.SkipOverlap` enum + `ClassifyScope`/
+      `ClassifyOverlapForMember` retained (classifier + tests stay; production stops skipping; counter
+      `skipOverlap`->`overlapShadowed`). Gate-OFF byte-identical. Build clean; suite green (13477).
+      In-game validated 2026-06-06 (flight-map, save s16, "Kerbal X" self-overlap): single icon rode its
+      line, 1112/1112 `drawn-non-proto`, no blink, clean teardown of 17 live overlap meshes / 8 recordings.
+    - **2b - PER-INSTANCE (decided 2026-06-06; the accurate end state):** 2a's single icon MISREPRESENTS
+      reality - flight shows N staggered overlap meshes, the map shows ONE. The goal (maintainer's call:
+      "render an icon for every ghost, make it accurate") is ONE map icon + orbit line + polyline PER LIVE
+      overlap INSTANCE, so the map matches flight. **This is a real per-instance build-out, multi-PR**
+      (comparable to 8c/8d), because N icons require N ProtoVessels (the icon is the stock orbit-driver's
+      icon, one per vessel) and the whole map layer (~12 keyed maps + the presence lifecycle) is
+      one-per-recording and must become per-(recording, cycleIndex). The flight engine ALREADY has the
+      per-instance model to MIRROR (`overlapGhosts`, `GhostPlaybackLogic.GetActiveCycles` /
+      `ComputeOverlapCyclePlaybackUT`, the `(recording, cycleIndex)` identity, cap
+      `MaxOverlapGhostsPerRecording=20`) - reuse it, do not reinvent. FULL per-instance (not icon-only:
+      N icons on one shared line is visibly wrong for non-orbital ascent/descent instances). Stacks on 2a
+      (instance 0 = newest cycle = today's single ghost). Slices: (i) map presence N-per-overlapping-
+      recording lifecycle [the bulk], (ii) Director per-instance enumeration + the existing `instanceKey`
+      wiring (caches are already pid-keyed), (iii) polyline + marker per-instance. Efficiency: overlap-ONLY
+      gate so non-overlap recordings stay EXACTLY one-per-recording (zero new cost); reuse the engine's
+      cycles; throttle per-instance ProtoVessel create/destroy (the biggest risk = warp-time cycle churn);
+      cap at 20. Gate-OFF stays legacy one-per-recording.
   - **Rendering polish - polyline + marker pan-stability (DONE, gated-neutral).** Fixed map polylines +
     yellow label markers jittering / flickering when panning the camera (pre-existing, NOT from the
     cutover). Root cause: the polyline draw ran at `[DefaultExecutionOrder(-50)]`, BEFORE the map camera


### PR DESCRIPTION
Docs-only. Reflects the decision (2026-06-06) that overlap rendering has two parts: **2a** (the merged #1051 foundation - Director processes the overlap member, renders ONE ghost at the newest cycle) and **2b** (the real goal - one icon + orbit line + polyline PER LIVE OVERLAP INSTANCE so the map matches flight).

The status doc previously described the single-icon state as "by design", which misrepresents reality (flight shows N staggered overlap meshes, the map shows one). This corrects that framing and records the 2b plan.

- `docs/dev/plans/maprender-rewrite-status.md`: split Integration #2 into 2a (DONE, #1051) and 2b (PER-INSTANCE, planned, multi-PR); corrected the "one icon by design" wording to "interim foundation".
- New `docs/dev/plans/maprender-overlap-per-instance.md`: the durable 2b plan - the architectural fact that N icons require N ProtoVessels, the flight engine model to mirror (`overlapGhosts` / `GetActiveCycles` / `ComputeOverlapCyclePlaybackUT`, cap 20), full-vs-icon-only (full), the ~12 one-per-recording keys to re-key, slices i/ii/iii, efficiency (overlap-only gate so non-overlap stays one-per-recording) + safety, tests, size estimate, and an adjacent suppressed-TS-NRE follow-up note.

No code change.