### PR TITLE
maprender(overlap 2b-i): per-instance overlap map presence lifecycle (N ProtoVessels)

### DIFF
--- a/Source/Parsek.Tests/OverlapPerInstanceTests.cs
+++ b/Source/Parsek.Tests/OverlapPerInstanceTests.cs
@@ -1,0 +1,338 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using Xunit;
+
+namespace Parsek.Tests
+{
+    /// <summary>
+    /// Slice (i) of the per-instance overlap map render
+    /// (docs/dev/plans/maprender-overlap-per-instance.md): the PURE pieces of the
+    /// per-(recording, cycle) map-presence lifecycle in <see cref="GhostMapPresence"/>.
+    /// Verifies the overlap gate predicate, the cycle-set equivalence with the flight
+    /// engine's <see cref="GhostPlaybackLogic.GetActiveCycles"/>, and the create/destroy
+    /// decision helper (cap + throttle + expiry). All helpers here are Unity-free; the
+    /// live ProtoVessel create/destroy is covered by the in-game test.
+    /// </summary>
+    [Collection("Sequential")]
+    public class OverlapPerInstanceTests : IDisposable
+    {
+        private readonly List<string> logLines = new List<string>();
+
+        public OverlapPerInstanceTests()
+        {
+            GhostMapPresence.ResetForTesting();
+            RecordingStore.ClearCommittedInternal();
+            RecordingStore.CommittedTrees.Clear();
+            ParsekSettings.CurrentOverrideForTesting = new ParsekSettings
+            {
+                autoLoopIntervalSeconds = 30f,
+                mapRenderDirectorDrive = true
+            };
+            ParsekSettingsPersistence.ResetForTesting();
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = false;
+            ParsekLog.VerboseOverrideForTesting = true;
+            ParsekLog.TestSinkForTesting = line => logLines.Add(line);
+        }
+
+        public void Dispose()
+        {
+            GhostMapPresence.ResetForTesting();
+            RecordingStore.ClearCommittedInternal();
+            RecordingStore.CommittedTrees.Clear();
+            ParsekSettings.CurrentOverrideForTesting = null;
+            ParsekSettingsPersistence.ResetForTesting();
+            ParsekLog.ResetTestOverrides();
+            ParsekLog.SuppressLogging = true;
+        }
+
+        // -----------------------------------------------------------------
+        //  Recording factory
+        // -----------------------------------------------------------------
+
+        /// <summary>
+        /// A looping Kerbin recording. period &lt; (endUT-startUT) makes it an OVERLAP loop.
+        /// LoopTimeUnit.Sec keeps the interval explicit (no auto-launch-queue cadence).
+        /// </summary>
+        private static Recording MakeLoopRec(
+            double startUT, double endUT, double loopInterval,
+            bool loopPlayback = true,
+            LoopTimeUnit unit = LoopTimeUnit.Sec,
+            string id = "rec-overlap")
+        {
+            var rec = new Recording
+            {
+                RecordingId = id,
+                VesselName = "OverlapTest",
+                PlaybackEnabled = true,
+                LoopPlayback = loopPlayback,
+                LoopIntervalSeconds = loopInterval,
+                LoopTimeUnit = unit,
+            };
+            rec.Points.Add(new TrajectoryPoint
+            {
+                ut = startUT, latitude = 0, longitude = 0, altitude = 0,
+                bodyName = "Kerbin", rotation = Quaternion.identity, velocity = Vector3.zero
+            });
+            rec.Points.Add(new TrajectoryPoint
+            {
+                ut = endUT, latitude = 0, longitude = 0, altitude = 0,
+                bodyName = "Kerbin", rotation = Quaternion.identity, velocity = Vector3.zero
+            });
+            return rec;
+        }
+
+        // =================================================================
+        //  (b) Overlap gate predicate
+        // =================================================================
+
+        [Fact]
+        public void IsOverlapLoop_PeriodLessThanDuration_True()
+        {
+            // duration 100, period 30 -> overlap.
+            Assert.True(GhostPlaybackLogic.IsOverlapLoop(30.0, 100.0));
+        }
+
+        [Fact]
+        public void IsOverlapLoop_PeriodGreaterThanDuration_False()
+        {
+            Assert.False(GhostPlaybackLogic.IsOverlapLoop(150.0, 100.0));
+        }
+
+        [Fact]
+        public void IsOverlapLoop_PeriodEqualsDuration_False()
+        {
+            // Boundary: equal is NOT overlap (strict <).
+            Assert.False(GhostPlaybackLogic.IsOverlapLoop(100.0, 100.0));
+        }
+
+        [Fact]
+        public void IsOverlapRecording_LoopingShortPeriod_True()
+        {
+            var committed = new List<Recording> { MakeLoopRec(100, 300, 30) };
+            Assert.True(GhostMapPresence.IsOverlapRecording(committed[0], 0, committed));
+        }
+
+        [Fact]
+        public void IsOverlapRecording_NotLooping_False()
+        {
+            var committed = new List<Recording> { MakeLoopRec(100, 300, 30, loopPlayback: false) };
+            Assert.False(GhostMapPresence.IsOverlapRecording(committed[0], 0, committed));
+        }
+
+        [Fact]
+        public void IsOverlapRecording_LoopingLongPeriod_False()
+        {
+            // period (500) > duration (200): looping but NOT overlapping (single-ghost path).
+            var committed = new List<Recording> { MakeLoopRec(100, 300, 500) };
+            Assert.False(GhostMapPresence.IsOverlapRecording(committed[0], 0, committed));
+        }
+
+        [Fact]
+        public void IsOverlapRecording_Null_False()
+        {
+            Assert.False(GhostMapPresence.IsOverlapRecording(null, 0, new List<Recording>()));
+        }
+
+        [Fact]
+        public void ShouldDriveOverlapPerInstance_GateOff_False()
+        {
+            ParsekSettings.CurrentOverrideForTesting.mapRenderDirectorDrive = false;
+            var committed = new List<Recording> { MakeLoopRec(100, 300, 30) };
+            Assert.False(GhostMapPresence.ShouldDriveOverlapPerInstance(committed[0], 0, committed));
+            // The recording itself IS an overlap loop; only the gate is off.
+            Assert.True(GhostMapPresence.IsOverlapRecording(committed[0], 0, committed));
+        }
+
+        [Fact]
+        public void ShouldDriveOverlapPerInstance_GateOn_OverlapRecording_True()
+        {
+            var committed = new List<Recording> { MakeLoopRec(100, 300, 30) };
+            Assert.True(GhostMapPresence.ShouldDriveOverlapPerInstance(committed[0], 0, committed));
+        }
+
+        [Fact]
+        public void ShouldDriveOverlapPerInstance_GateOn_NonOverlap_False()
+        {
+            var committed = new List<Recording> { MakeLoopRec(100, 300, 30, loopPlayback: false) };
+            Assert.False(GhostMapPresence.ShouldDriveOverlapPerInstance(committed[0], 0, committed));
+        }
+
+        // =================================================================
+        //  (a) Cycle-set equivalence with GetActiveCycles (regression lock)
+        // =================================================================
+
+        [Fact]
+        public void ResolveOverlapSchedule_FeedsGetActiveCycles_MatchesDirectComputation()
+        {
+            // The map per-instance cycle set MUST equal the flight engine's GetActiveCycles set for
+            // the same inputs. ResolveOverlapSchedule resolves (scheduleStart, duration, effective
+            // cadence); feeding those into GetActiveCycles must reproduce a direct GetActiveCycles
+            // call on the same raw schedule + effective cadence.
+            var committed = new List<Recording> { MakeLoopRec(100, 300, 30) };
+            bool ok = GhostMapPresence.ResolveOverlapSchedule(
+                committed[0], 0, committed,
+                out double playbackStartUT, out double scheduleStartUT,
+                out double duration, out double effectiveCadence, out double cycleDuration);
+            Assert.True(ok);
+
+            // duration = 200, period 30 < 200 -> overlap. Effective cadence raised so
+            // ceil(duration/cadence) <= cap = 20; with 200/30 = 6.67 cycles, cadence stays 30.
+            Assert.Equal(200.0, duration, 3);
+            Assert.Equal(100.0, scheduleStartUT, 3); // no auto-launch-queue (Sec unit) -> own loop start
+            Assert.Equal(100.0, playbackStartUT, 3);
+
+            double currentUT = 250.0;
+            GhostMapPresence.OverlapCyclesForTesting(
+                committed[0], 0, committed, currentUT,
+                out long mapFirst, out long mapLast);
+
+            // Direct GetActiveCycles on the resolved schedule.
+            GhostPlaybackLogic.GetActiveCycles(
+                currentUT, scheduleStartUT, scheduleStartUT + duration,
+                effectiveCadence, GhostPlayback.MaxOverlapGhostsPerRecording,
+                out long engineFirst, out long engineLast);
+
+            Assert.Equal(engineFirst, mapFirst);
+            Assert.Equal(engineLast, mapLast);
+        }
+
+        [Theory]
+        [InlineData(130.0)] // 1 cycle live (cycle 1 just launched; cycle 0 still playing)
+        [InlineData(250.0)] // several overlapping
+        [InlineData(400.0)] // deep into overlap, cap may clamp
+        public void OverlapCyclesForTesting_MatchesGetActiveCycles(double currentUT)
+        {
+            // 5s period over a 200s duration -> up to 40 cycles, capped at 20: exercises the cap clamp.
+            var committed = new List<Recording> { MakeLoopRec(100, 300, 5) };
+            GhostMapPresence.ResolveOverlapSchedule(
+                committed[0], 0, committed,
+                out _, out double scheduleStartUT,
+                out double duration, out double effectiveCadence, out _);
+
+            GhostMapPresence.OverlapCyclesForTesting(
+                committed[0], 0, committed, currentUT,
+                out long mapFirst, out long mapLast);
+
+            GhostPlaybackLogic.GetActiveCycles(
+                currentUT, scheduleStartUT, scheduleStartUT + duration,
+                effectiveCadence, GhostPlayback.MaxOverlapGhostsPerRecording,
+                out long engineFirst, out long engineLast);
+
+            Assert.Equal(engineFirst, mapFirst);
+            Assert.Equal(engineLast, mapLast);
+            // Cap invariant: live cycle count never exceeds the per-recording cap.
+            Assert.True(mapLast - mapFirst + 1 <= GhostPlayback.MaxOverlapGhostsPerRecording);
+        }
+
+        // =================================================================
+        //  (c) Create/destroy decision helper
+        // =================================================================
+
+        [Fact]
+        public void DecideOverlapInstanceChanges_AllMissing_CreatesWithinBudget()
+        {
+            GhostMapPresence.DecideOverlapInstanceChanges(
+                existingCycles: new long[0],
+                firstCycle: 3, lastCycle: 6, spawnBudget: 2,
+                out List<long> toCreate, out List<long> toDestroy);
+
+            Assert.Empty(toDestroy);
+            // Budget 2 -> only 2 created this frame, newest-first (6 then 5).
+            Assert.Equal(2, toCreate.Count);
+            Assert.Contains(6L, toCreate);
+            Assert.Contains(5L, toCreate);
+        }
+
+        [Fact]
+        public void DecideOverlapInstanceChanges_NewestFirstUnderThrottle()
+        {
+            GhostMapPresence.DecideOverlapInstanceChanges(
+                existingCycles: new long[0],
+                firstCycle: 0, lastCycle: 9, spawnBudget: 1,
+                out List<long> toCreate, out List<long> toDestroy);
+
+            Assert.Empty(toDestroy);
+            Assert.Single(toCreate);
+            Assert.Equal(9L, toCreate[0]); // newest cycle wins the single budget slot
+        }
+
+        [Fact]
+        public void DecideOverlapInstanceChanges_ExpiredBelowFirst_Destroyed()
+        {
+            GhostMapPresence.DecideOverlapInstanceChanges(
+                existingCycles: new long[] { 0, 1, 2, 3 },
+                firstCycle: 2, lastCycle: 3, spawnBudget: 8,
+                out List<long> toCreate, out List<long> toDestroy);
+
+            Assert.Empty(toCreate); // 2 and 3 already present
+            Assert.Equal(2, toDestroy.Count);
+            Assert.Contains(0L, toDestroy);
+            Assert.Contains(1L, toDestroy);
+        }
+
+        [Fact]
+        public void DecideOverlapInstanceChanges_AheadOfNewest_Destroyed()
+        {
+            // A stale instance somehow ahead of the newest live cycle (e.g. cycle window moved back
+            // after a rewind): it is out of [first,last] and must be reaped.
+            GhostMapPresence.DecideOverlapInstanceChanges(
+                existingCycles: new long[] { 5 },
+                firstCycle: 0, lastCycle: 3, spawnBudget: 8,
+                out List<long> toCreate, out List<long> toDestroy);
+
+            Assert.Contains(5L, toDestroy);
+        }
+
+        [Fact]
+        public void DecideOverlapInstanceChanges_PartialPresent_CreatesOnlyMissing()
+        {
+            GhostMapPresence.DecideOverlapInstanceChanges(
+                existingCycles: new long[] { 4, 6 },
+                firstCycle: 4, lastCycle: 7, spawnBudget: 8,
+                out List<long> toCreate, out List<long> toDestroy);
+
+            Assert.Empty(toDestroy);
+            Assert.Equal(2, toCreate.Count);
+            Assert.Contains(7L, toCreate);
+            Assert.Contains(5L, toCreate);
+            Assert.DoesNotContain(4L, toCreate);
+            Assert.DoesNotContain(6L, toCreate);
+        }
+
+        [Fact]
+        public void DecideOverlapInstanceChanges_ZeroBudget_NoCreates()
+        {
+            GhostMapPresence.DecideOverlapInstanceChanges(
+                existingCycles: new long[] { 0 },
+                firstCycle: 0, lastCycle: 5, spawnBudget: 0,
+                out List<long> toCreate, out List<long> toDestroy);
+
+            Assert.Empty(toCreate);
+            Assert.Empty(toDestroy); // cycle 0 is still in window
+        }
+
+        [Fact]
+        public void DecideOverlapInstanceChanges_NoLiveWindow_OnlyDestroys()
+        {
+            // currentUT before schedule start: GetActiveCycles returns first=0,last=0 but the caller
+            // gates that separately; here simulate lastCycle < firstCycle (degenerate empty window).
+            GhostMapPresence.DecideOverlapInstanceChanges(
+                existingCycles: new long[] { 2, 3 },
+                firstCycle: 5, lastCycle: 4, spawnBudget: 8,
+                out List<long> toCreate, out List<long> toDestroy);
+
+            Assert.Empty(toCreate);
+            Assert.Equal(2, toDestroy.Count);
+        }
+
+        [Fact]
+        public void GetOverlapInstanceCount_EmptyByDefault()
+        {
+            Assert.Equal(0, GhostMapPresence.GetOverlapInstanceCount(0));
+            Assert.Equal(0u, GhostMapPresence.GetNewestOverlapInstancePidForRecording(0));
+        }
+    }
+}

--- a/Source/Parsek.Tests/OverlapPerInstanceTests.cs
+++ b/Source/Parsek.Tests/OverlapPerInstanceTests.cs
@@ -23,6 +23,10 @@ namespace Parsek.Tests
         public OverlapPerInstanceTests()
         {
             GhostMapPresence.ResetForTesting();
+            // CurrentUTNow defaults to Planetarium.GetUniversalTime() (Unity, NRE in xUnit). Override
+            // it after ResetForTesting (which restores GetCurrentUTSafe) so the gate-decision log path
+            // resolves a UT without Unity.
+            GhostMapPresence.CurrentUTNow = () => 5130.0;
             RecordingStore.ClearCommittedInternal();
             RecordingStore.CommittedTrees.Clear();
             ParsekSettings.CurrentOverrideForTesting = new ParsekSettings
@@ -84,6 +88,46 @@ namespace Parsek.Tests
             return rec;
         }
 
+        /// <summary>The empty loop-unit set (source-a-only path; no Mission loops).</summary>
+        private static GhostPlaybackLogic.LoopUnitSet NoUnits => GhostPlaybackLogic.LoopUnitSet.Empty;
+
+        /// <summary>
+        /// A non-looping recording (rec.LoopPlayback == false) with the given [start,end] window.
+        /// Used as a SOURCE (b) member: a Mission-unit overlap member does NOT carry its own loop flag.
+        /// </summary>
+        private static Recording MakeMemberRec(double startUT, double endUT, string id = "rec-member")
+            => MakeLoopRec(startUT, endUT, loopInterval: 30, loopPlayback: false, id: id);
+
+        /// <summary>
+        /// A single-member self-overlapping Mission unit over [spanStart, spanEnd] with the given
+        /// overlap cadence (&lt; span => self-overlap). Optional per-member trim window. PhaseAnchor
+        /// defaults to spanStart. Mirrors the construction in MissionSpanClockTests.
+        /// </summary>
+        private static GhostPlaybackLogic.LoopUnitSet MakeOverlapUnitSet(
+            int memberIdx, double spanStartUT, double spanEndUT, double overlapCadenceSeconds,
+            double phaseAnchorUT = double.NaN,
+            (double startUT, double endUT)? memberWindow = null)
+        {
+            if (double.IsNaN(phaseAnchorUT))
+                phaseAnchorUT = spanStartUT;
+
+            IReadOnlyDictionary<int, GhostPlaybackLogic.LoopUnit.MemberWindow> windows = null;
+            if (memberWindow.HasValue)
+                windows = new Dictionary<int, GhostPlaybackLogic.LoopUnit.MemberWindow>
+                {
+                    { memberIdx, new GhostPlaybackLogic.LoopUnit.MemberWindow(
+                        memberWindow.Value.startUT, memberWindow.Value.endUT) }
+                };
+
+            var unit = new GhostPlaybackLogic.LoopUnit(
+                memberIdx, new[] { memberIdx }, spanStartUT, spanEndUT,
+                cadenceSeconds: spanEndUT - spanStartUT, phaseAnchorUT: phaseAnchorUT,
+                overlapCadenceSeconds: overlapCadenceSeconds, memberWindows: windows);
+            var unitsByOwner = new Dictionary<int, GhostPlaybackLogic.LoopUnit> { { memberIdx, unit } };
+            var ownerByIndex = new Dictionary<int, int> { { memberIdx, memberIdx } };
+            return new GhostPlaybackLogic.LoopUnitSet(unitsByOwner, ownerByIndex);
+        }
+
         // =================================================================
         //  (b) Overlap gate predicate
         // =================================================================
@@ -112,14 +156,14 @@ namespace Parsek.Tests
         public void IsOverlapRecording_LoopingShortPeriod_True()
         {
             var committed = new List<Recording> { MakeLoopRec(100, 300, 30) };
-            Assert.True(GhostMapPresence.IsOverlapRecording(committed[0], 0, committed));
+            Assert.True(GhostMapPresence.IsOverlapRecording(committed[0], 0, committed, NoUnits));
         }
 
         [Fact]
         public void IsOverlapRecording_NotLooping_False()
         {
             var committed = new List<Recording> { MakeLoopRec(100, 300, 30, loopPlayback: false) };
-            Assert.False(GhostMapPresence.IsOverlapRecording(committed[0], 0, committed));
+            Assert.False(GhostMapPresence.IsOverlapRecording(committed[0], 0, committed, NoUnits));
         }
 
         [Fact]
@@ -127,13 +171,13 @@ namespace Parsek.Tests
         {
             // period (500) > duration (200): looping but NOT overlapping (single-ghost path).
             var committed = new List<Recording> { MakeLoopRec(100, 300, 500) };
-            Assert.False(GhostMapPresence.IsOverlapRecording(committed[0], 0, committed));
+            Assert.False(GhostMapPresence.IsOverlapRecording(committed[0], 0, committed, NoUnits));
         }
 
         [Fact]
         public void IsOverlapRecording_Null_False()
         {
-            Assert.False(GhostMapPresence.IsOverlapRecording(null, 0, new List<Recording>()));
+            Assert.False(GhostMapPresence.IsOverlapRecording(null, 0, new List<Recording>(), NoUnits));
         }
 
         [Fact]
@@ -141,23 +185,99 @@ namespace Parsek.Tests
         {
             ParsekSettings.CurrentOverrideForTesting.mapRenderDirectorDrive = false;
             var committed = new List<Recording> { MakeLoopRec(100, 300, 30) };
-            Assert.False(GhostMapPresence.ShouldDriveOverlapPerInstance(committed[0], 0, committed));
+            Assert.False(GhostMapPresence.ShouldDriveOverlapPerInstance(committed[0], 0, committed, NoUnits));
             // The recording itself IS an overlap loop; only the gate is off.
-            Assert.True(GhostMapPresence.IsOverlapRecording(committed[0], 0, committed));
+            Assert.True(GhostMapPresence.IsOverlapRecording(committed[0], 0, committed, NoUnits));
         }
 
         [Fact]
         public void ShouldDriveOverlapPerInstance_GateOn_OverlapRecording_True()
         {
             var committed = new List<Recording> { MakeLoopRec(100, 300, 30) };
-            Assert.True(GhostMapPresence.ShouldDriveOverlapPerInstance(committed[0], 0, committed));
+            Assert.True(GhostMapPresence.ShouldDriveOverlapPerInstance(committed[0], 0, committed, NoUnits));
         }
 
         [Fact]
         public void ShouldDriveOverlapPerInstance_GateOn_NonOverlap_False()
         {
             var committed = new List<Recording> { MakeLoopRec(100, 300, 30, loopPlayback: false) };
-            Assert.False(GhostMapPresence.ShouldDriveOverlapPerInstance(committed[0], 0, committed));
+            Assert.False(GhostMapPresence.ShouldDriveOverlapPerInstance(committed[0], 0, committed, NoUnits));
+        }
+
+        // =================================================================
+        //  Source (b): Mission-unit self-overlap gate (rec.LoopPlayback == false)
+        // =================================================================
+
+        [Fact]
+        public void IsOverlapRecording_MissionUnitOverlap_NoRecLoopFlag_True()
+        {
+            // The maintainer's case: the recording does NOT loop on its own (rec.LoopPlayback=false),
+            // but it is a member of a looped Mission unit whose overlap cadence (20s) is shorter than
+            // its span (200s) -> self-overlap. Source (b) must drive it even with no rec loop flag.
+            var committed = new List<Recording> { MakeMemberRec(1000, 1200) };
+            var units = MakeOverlapUnitSet(0, spanStartUT: 1000, spanEndUT: 1200, overlapCadenceSeconds: 20);
+
+            Assert.False(committed[0].LoopPlayback);
+            Assert.True(GhostMapPresence.IsOverlapRecording(committed[0], 0, committed, units));
+            Assert.True(GhostMapPresence.ShouldDriveOverlapPerInstance(committed[0], 0, committed, units));
+            // With NO loop units it is NOT an overlap recording (the bug: gate rejected it -> one icon).
+            Assert.False(GhostMapPresence.IsOverlapRecording(committed[0], 0, committed, NoUnits));
+        }
+
+        [Fact]
+        public void IsOverlapRecording_MissionUnit_CadenceAtOrAboveSpan_False()
+        {
+            // Cadence >= span: a single span-clock instance, NOT self-overlap. Source (b) rejects it.
+            var committed = new List<Recording> { MakeMemberRec(1000, 1200) };
+            var units = MakeOverlapUnitSet(0, 1000, 1200, overlapCadenceSeconds: 200); // == span
+            Assert.False(GhostMapPresence.IsOverlapRecording(committed[0], 0, committed, units));
+        }
+
+        [Fact]
+        public void IsOverlapRecording_MissionUnit_ZeroMemberDuration_False()
+        {
+            // A member trimmed to a zero-length window can't replay; the member-duration floor rejects it.
+            var committed = new List<Recording> { MakeMemberRec(1000, 1200) };
+            var units = MakeOverlapUnitSet(0, 1000, 1200, overlapCadenceSeconds: 20,
+                memberWindow: (1100, 1100));
+            Assert.False(GhostMapPresence.IsOverlapRecording(committed[0], 0, committed, units));
+        }
+
+        [Fact]
+        public void ShouldDriveOverlapPerInstance_MissionUnit_GateOff_False()
+        {
+            // Gate-off is preserved for source (b) too: the union only ADDS source b INSIDE the gate.
+            ParsekSettings.CurrentOverrideForTesting.mapRenderDirectorDrive = false;
+            var committed = new List<Recording> { MakeMemberRec(1000, 1200) };
+            var units = MakeOverlapUnitSet(0, 1000, 1200, overlapCadenceSeconds: 20);
+            Assert.False(GhostMapPresence.ShouldDriveOverlapPerInstance(committed[0], 0, committed, units));
+            // But the recording IS an overlap recording; only the gate is off.
+            Assert.True(GhostMapPresence.IsOverlapRecording(committed[0], 0, committed, units));
+        }
+
+        [Fact]
+        public void IsOverlapRecording_PreferUnitWhenBoth()
+        {
+            // A recording that is BOTH a standalone loop (rec.LoopPlayback, period 30 < dur) AND a
+            // self-overlapping unit member: source (b) is preferred. The resolved schedule must be the
+            // UNIT's (scheduleStart from the unit anchor + member offset), not the standalone loop's.
+            var committed = new List<Recording> { MakeLoopRec(1000, 1200, 30) }; // standalone overlap too
+            var units = MakeOverlapUnitSet(
+                0, spanStartUT: 1000, spanEndUT: 1200, overlapCadenceSeconds: 20, phaseAnchorUT: 5000);
+
+            Assert.True(GhostMapPresence.IsOverlapRecording(committed[0], 0, committed, units));
+            bool ok = GhostMapPresence.ResolveOverlapSchedule(
+                committed[0], 0, committed, units,
+                out double playbackStartUT, out double scheduleStartUT,
+                out double duration, out double effectiveCadence, out _);
+            Assert.True(ok);
+            // Unit tuple: memberStart == spanStart == 1000 (no trim); scheduleStart from the unit anchor
+            // (5000 + (1000-1000) = 5000), NOT the standalone loop's own EffectiveLoopStartUT (1000).
+            Assert.Equal(1000.0, playbackStartUT, 3);
+            Assert.Equal(5000.0, scheduleStartUT, 3);
+            Assert.Equal(200.0, duration, 3);
+            // overlapCadence 20s over a 200s span: ceil(200/20)=10 <= cap 20 -> cadence stays 20.
+            Assert.Equal(20.0, effectiveCadence, 3);
         }
 
         // =================================================================
@@ -173,7 +293,7 @@ namespace Parsek.Tests
             // call on the same raw schedule + effective cadence.
             var committed = new List<Recording> { MakeLoopRec(100, 300, 30) };
             bool ok = GhostMapPresence.ResolveOverlapSchedule(
-                committed[0], 0, committed,
+                committed[0], 0, committed, NoUnits,
                 out double playbackStartUT, out double scheduleStartUT,
                 out double duration, out double effectiveCadence, out double cycleDuration);
             Assert.True(ok);
@@ -186,7 +306,7 @@ namespace Parsek.Tests
 
             double currentUT = 250.0;
             GhostMapPresence.OverlapCyclesForTesting(
-                committed[0], 0, committed, currentUT,
+                committed[0], 0, committed, NoUnits, currentUT,
                 out long mapFirst, out long mapLast);
 
             // Direct GetActiveCycles on the resolved schedule.
@@ -208,12 +328,12 @@ namespace Parsek.Tests
             // 5s period over a 200s duration -> up to 40 cycles, capped at 20: exercises the cap clamp.
             var committed = new List<Recording> { MakeLoopRec(100, 300, 5) };
             GhostMapPresence.ResolveOverlapSchedule(
-                committed[0], 0, committed,
+                committed[0], 0, committed, NoUnits,
                 out _, out double scheduleStartUT,
                 out double duration, out double effectiveCadence, out _);
 
             GhostMapPresence.OverlapCyclesForTesting(
-                committed[0], 0, committed, currentUT,
+                committed[0], 0, committed, NoUnits, currentUT,
                 out long mapFirst, out long mapLast);
 
             GhostPlaybackLogic.GetActiveCycles(
@@ -225,6 +345,87 @@ namespace Parsek.Tests
             Assert.Equal(engineLast, mapLast);
             // Cap invariant: live cycle count never exceeds the per-recording cap.
             Assert.True(mapLast - mapFirst + 1 <= GhostPlayback.MaxOverlapGhostsPerRecording);
+        }
+
+        // =================================================================
+        //  Source (b): Mission-unit schedule + cycle-set equivalence
+        // =================================================================
+
+        [Fact]
+        public void ResolveOverlapSchedule_MissionUnit_MatchesEngineTuple()
+        {
+            // Mirror the engine's unit tuple (GhostPlaybackEngine.cs:2163-2183 + 3570-3571 cap re-clamp):
+            // member [1000,1200] (no trim), anchor 5000, overlapCadence 20s.
+            var committed = new List<Recording> { MakeMemberRec(1000, 1200) };
+            var units = MakeOverlapUnitSet(
+                0, spanStartUT: 1000, spanEndUT: 1200, overlapCadenceSeconds: 20, phaseAnchorUT: 5000);
+
+            bool ok = GhostMapPresence.ResolveOverlapSchedule(
+                committed[0], 0, committed, units,
+                out double playbackStartUT, out double scheduleStartUT,
+                out double duration, out double effectiveCadence, out double cycleDuration);
+            Assert.True(ok);
+
+            // Engine tuple (verbatim):
+            double memberStartUT = 1000, memberEndUT = 1200;
+            double expectedDuration = memberEndUT - memberStartUT;          // 200
+            double expectedSchedule = GhostPlaybackLogic.ComputeMemberOverlapScheduleStartUT(
+                5000, 1000, memberStartUT);                                 // 5000
+            double expectedCadence = GhostPlaybackLogic.ComputeEffectiveLaunchCadence(
+                20, expectedDuration, GhostPlayback.MaxOverlapGhostsPerRecording); // 20
+            Assert.Equal(memberStartUT, playbackStartUT, 3);
+            Assert.Equal(expectedSchedule, scheduleStartUT, 3);
+            Assert.Equal(expectedDuration, duration, 3);
+            Assert.Equal(expectedCadence, effectiveCadence, 3);
+            Assert.Equal(System.Math.Max(expectedCadence, LoopTiming.MinCycleDuration), cycleDuration, 3);
+        }
+
+        [Fact]
+        public void OverlapCyclesForTesting_MissionUnit_MatchesGetActiveCyclesFromUnitTuple()
+        {
+            var committed = new List<Recording> { MakeMemberRec(1000, 1200) };
+            var units = MakeOverlapUnitSet(
+                0, spanStartUT: 1000, spanEndUT: 1200, overlapCadenceSeconds: 20, phaseAnchorUT: 5000);
+
+            GhostMapPresence.ResolveOverlapSchedule(
+                committed[0], 0, committed, units,
+                out _, out double scheduleStartUT,
+                out double duration, out double effectiveCadence, out _);
+
+            double currentUT = 5130.0; // 130s into the schedule (launches every 20s from 5000)
+            GhostMapPresence.OverlapCyclesForTesting(
+                committed[0], 0, committed, units, currentUT,
+                out long mapFirst, out long mapLast);
+
+            GhostPlaybackLogic.GetActiveCycles(
+                currentUT, scheduleStartUT, scheduleStartUT + duration,
+                effectiveCadence, GhostPlayback.MaxOverlapGhostsPerRecording,
+                out long engineFirst, out long engineLast);
+
+            Assert.Equal(engineFirst, mapFirst);
+            Assert.Equal(engineLast, mapLast);
+            Assert.True(mapLast - mapFirst + 1 <= GhostPlayback.MaxOverlapGhostsPerRecording);
+        }
+
+        [Fact]
+        public void ResolveOverlapSchedule_MissionUnit_MemberTrim_YieldsTrimmedDuration()
+        {
+            // The mission trims this member to [1050, 1150] (a pod shown only after the decouple).
+            // The overlap schedule must use the TRIMMED window: duration 100, playbackStart 1050,
+            // schedule staggered by the member offset (memberStart - spanStart = 50) from the anchor.
+            var committed = new List<Recording> { MakeMemberRec(1000, 1200) };
+            var units = MakeOverlapUnitSet(
+                0, spanStartUT: 1000, spanEndUT: 1200, overlapCadenceSeconds: 20, phaseAnchorUT: 5000,
+                memberWindow: (1050, 1150));
+
+            bool ok = GhostMapPresence.ResolveOverlapSchedule(
+                committed[0], 0, committed, units,
+                out double playbackStartUT, out double scheduleStartUT,
+                out double duration, out _, out _);
+            Assert.True(ok);
+            Assert.Equal(1050.0, playbackStartUT, 3);
+            Assert.Equal(100.0, duration, 3);                       // trimmed (200 -> 100)
+            Assert.Equal(5050.0, scheduleStartUT, 3);               // 5000 + (1050 - 1000)
         }
 
         // =================================================================
@@ -333,6 +534,47 @@ namespace Parsek.Tests
         {
             Assert.Equal(0, GhostMapPresence.GetOverlapInstanceCount(0));
             Assert.Equal(0u, GhostMapPresence.GetNewestOverlapInstancePidForRecording(0));
+        }
+
+        // =================================================================
+        //  Gate-decision logging (the playtest blind spot)
+        // =================================================================
+
+        [Fact]
+        public void LogOverlapGateDecision_MissionLoop_ShowsIsMemberAndUnitOverlaps()
+        {
+            // The diagnostic the playtest lacked: a re-fly Mission member (rec.LoopPlayback=false)
+            // driven via source (b) must log isMember=true unitOverlaps=true so a "one icon instead of
+            // N" report is diagnosable from the log alone, without a rebuild.
+            var committed = new List<Recording> { MakeMemberRec(1000, 1200) };
+            var units = MakeOverlapUnitSet(0, 1000, 1200, overlapCadenceSeconds: 20, phaseAnchorUT: 5000);
+            bool shouldDrive = GhostMapPresence.ShouldDriveOverlapPerInstance(committed[0], 0, committed, units);
+            Assert.True(shouldDrive);
+
+            GhostMapPresence.LogOverlapGateDecision(
+                0, committed[0], committed, units, gateOn: true, shouldDrive: shouldDrive);
+
+            Assert.Contains(logLines, l =>
+                l.Contains("Overlap gate decision")
+                && l.Contains("isMember=True")
+                && l.Contains("unitOverlaps=True")
+                && l.Contains("loopPlayback=False")
+                && l.Contains("shouldDrive=True"));
+        }
+
+        [Fact]
+        public void LogOverlapGateDecision_StandaloneLoop_ShowsAutoOverlapNotMember()
+        {
+            // Source (a) standalone loop: the line shows autoIsOverlapLoop=True isMember=False.
+            var committed = new List<Recording> { MakeLoopRec(100, 300, 30) };
+            GhostMapPresence.LogOverlapGateDecision(
+                0, committed[0], committed, NoUnits, gateOn: true, shouldDrive: true);
+
+            Assert.Contains(logLines, l =>
+                l.Contains("Overlap gate decision")
+                && l.Contains("loopPlayback=True")
+                && l.Contains("autoIsOverlapLoop=True")
+                && l.Contains("isMember=False"));
         }
     }
 }

--- a/Source/Parsek/GhostMapPresence.cs
+++ b/Source/Parsek/GhostMapPresence.cs
@@ -884,6 +884,26 @@ namespace Parsek
         /// </summary>
         private static readonly Dictionary<uint, int> vesselPidToRecordingIndex = new Dictionary<uint, int>();
 
+        /// <summary>
+        /// Per-(recording index, loop cycle) ghost map ProtoVessels for OVERLAP-looped recordings
+        /// (slice i of the per-instance overlap render, design
+        /// docs/dev/plans/maprender-overlap-per-instance.md). When a looped recording's period is
+        /// shorter than its duration, several staggered replays run at once (overlap); flight shows
+        /// N meshes but the map historically showed ONE icon (the newest cycle). This store holds
+        /// ONE ProtoVessel per LIVE overlap cycle so the map shows N icons matching the N flight
+        /// meshes. Each instance is a fresh ProtoVessel with a KSP-minted unique pid (CreateVesselNode
+        /// vesselID:0), so the N siblings never collide. Non-overlap recordings keep using the
+        /// one-per-recording <see cref="vesselsByRecordingIndex"/> store untouched: this store is the
+        /// SOLE create/destroy/reseed authority for overlap recordings (single-ownership rule), and
+        /// the legacy passes branch overlap indices to <see cref="EnsureOverlapInstances"/> + continue.
+        /// Mirrors the KSC <c>kscOverlapGhosts</c> + <c>kscGhosts</c> model in <see cref="ParsekKSC"/>
+        /// (the proven per-instance overlap map ghost host, which uses no flight engine and resolves
+        /// the schedule through the pure <see cref="GhostPlaybackLogic.TryResolveAutoLoopLaunchSchedule"/>
+        /// so flight + Tracking Station resolve identically).
+        /// </summary>
+        private static readonly Dictionary<(int recIdx, long cycle), Vessel> overlapInstanceVessels =
+            new Dictionary<(int, long), Vessel>();
+
         private static readonly Dictionary<int, IPlaybackTrajectory> trackingStationStateVectorOrbitTrajectories =
             new Dictionary<int, IPlaybackTrajectory>();
 
@@ -3480,7 +3500,8 @@ namespace Parsek
         {
             int chainCount = vesselsByChainPid.Count;
             int indexCount = vesselsByRecordingIndex.Count;
-            if (chainCount == 0 && indexCount == 0)
+            int overlapInstanceCount = overlapInstanceVessels.Count;
+            if (chainCount == 0 && indexCount == 0 && overlapInstanceCount == 0)
             {
                 ParsekLog.VerboseRateLimited(Tag,
                     "remove-all-empty|" + (reason ?? "(none)"),
@@ -3491,10 +3512,11 @@ namespace Parsek
                 return;
             }
 
-            // Collect all vessels to destroy (chain + recording index)
-            var vessels = new List<Vessel>(chainCount + indexCount);
+            // Collect all vessels to destroy (chain + recording index + overlap instances)
+            var vessels = new List<Vessel>(chainCount + indexCount + overlapInstanceCount);
             vessels.AddRange(vesselsByChainPid.Values);
             vessels.AddRange(vesselsByRecordingIndex.Values);
+            vessels.AddRange(overlapInstanceVessels.Values);
 
             foreach (var vessel in vessels)
             {
@@ -3521,6 +3543,7 @@ namespace Parsek
             ghostOrbitEpochShift.Clear();
             vesselsByChainPid.Clear();
             vesselsByRecordingIndex.Clear();
+            overlapInstanceVessels.Clear();
             vesselPidToRecordingIndex.Clear();
             vesselPidToRecordingId.Clear();
             trackingStationStateVectorOrbitTrajectories.Clear();
@@ -3531,8 +3554,9 @@ namespace Parsek
 
             ParsekLog.Info(Tag,
                 string.Format(ic,
-                    "Removed all {0} ghost vessel(s) reason={1} (chain={2} index={3})",
-                    chainCount + indexCount, reason, chainCount, indexCount));
+                    "Removed all {0} ghost vessel(s) reason={1} (chain={2} index={3} overlapInstances={4})",
+                    chainCount + indexCount + overlapInstanceCount, reason,
+                    chainCount, indexCount, overlapInstanceCount));
         }
 
         // ------------------------------------------------------------------
@@ -6054,6 +6078,14 @@ namespace Parsek
 
             RefreshTrackingStationGhosts(committed, suppressed, currentUT, loopUnits);
 
+            // Per-instance overlap sweep (slice i): SOLE create/destroy authority for overlap
+            // recordings in the Tracking Station. The schedule resolves through the same pure
+            // GhostPlaybackLogic.TryResolveAutoLoopLaunchSchedule the flight + KSC paths use, so the
+            // cycle set is identical to flight (the flight engine does not exist in this scene). The
+            // per-index create loop below skips overlap indices. Run before the empty-return so a
+            // gate-off transition reaps any leftover instances even when no committed recordings exist.
+            RunOverlapPerInstanceSweep(currentUT, committed);
+
             if (!hasCommittedRecordings)
             {
                 RefreshTrackingStationVesselListAfterLifecycleMutation(
@@ -6080,6 +6112,10 @@ namespace Parsek
                 }
 
                 var rec = committed[i];
+
+                // Slice (i): overlap recordings are created by the per-instance sweep above, not here.
+                if (ShouldDriveOverlapPerInstance(rec, i, committed))
+                    continue;
 
                 // Phase F: substitute the shared Mission span-clock loopUT for the live UT when this
                 // committed index is a loop-unit member. Inert (effUT == currentUT, renderHidden
@@ -6408,6 +6444,16 @@ namespace Parsek
                 }
 
                 var rec = committed[idx];
+
+                // Slice (i): if this index became an overlap recording under the director-drive gate,
+                // it is now owned by the per-instance store. Tear down its leftover per-index ghost so
+                // there is no duplicate (the per-instance sweep created the N-per-cycle vessels).
+                if (ShouldDriveOverlapPerInstance(rec, idx, committed))
+                {
+                    if (toRemove == null) toRemove = new List<(int, string)>();
+                    toRemove.Add((idx, "overlap-handoff-to-per-instance"));
+                    continue;
+                }
 
                 // Phase F: resolve the effective sample UT for this member under the shared Mission
                 // span clock. A member outside its loop window this cycle is torn down (queued for
@@ -9019,7 +9065,13 @@ namespace Parsek
         /// </summary>
         internal static bool HasGhostVesselForRecording(int recordingIndex)
         {
-            return vesselsByRecordingIndex.ContainsKey(recordingIndex);
+            if (vesselsByRecordingIndex.ContainsKey(recordingIndex))
+                return true;
+            // Overlap recordings live in overlapInstanceVessels (single-ownership rule), NOT
+            // vesselsByRecordingIndex. Fall through to the newest live instance so watch-camera
+            // focus / TS-Fly / UI marker suppression / polyline owner resolution see a ghost
+            // (matching the legacy "one icon == newest cycle" behavior) instead of "no ghost".
+            return GetNewestOverlapInstancePidForRecording(recordingIndex) != 0;
         }
 
         /// <summary>
@@ -9030,7 +9082,10 @@ namespace Parsek
         {
             if (vesselsByRecordingIndex.TryGetValue(recordingIndex, out Vessel v))
                 return v.persistentId;
-            return 0;
+            // Overlap recordings: fall through to the NEWEST live overlap instance's pid (the cycle
+            // the legacy single-icon path represented). FindRecordingIndexByVesselPid still works for
+            // EVERY instance (vesselPidToRecordingIndex is populated per instance).
+            return GetNewestOverlapInstancePidForRecording(recordingIndex);
         }
 
         internal static bool TryGetCommittedRecordingById(
@@ -9304,6 +9359,7 @@ namespace Parsek
             ClearPolylineOwningStampsForTesting();
             vesselsByChainPid.Clear();
             vesselsByRecordingIndex.Clear();
+            overlapInstanceVessels.Clear();
             vesselPidToRecordingIndex.Clear();
             vesselPidToRecordingId.Clear();
             trackingStationStateVectorOrbitTrajectories.Clear();
@@ -9342,13 +9398,14 @@ namespace Parsek
             int orbitBoundsCount = ghostOrbitBounds.Count;
             int chainCount = vesselsByChainPid.Count;
             int indexCount = vesselsByRecordingIndex.Count;
+            int overlapInstanceCount = overlapInstanceVessels.Count;
             int reverseCount = vesselPidToRecordingIndex.Count;
             int reverseIdCount = vesselPidToRecordingId.Count;
             int tsStateVectorCount = trackingStationStateVectorOrbitTrajectories.Count;
             int tsStateVectorCacheCount = trackingStationStateVectorCachedIndices.Count;
 
             int totalTracked = pidCount + suppressedIconCount + orbitBoundsCount
-                + chainCount + indexCount + reverseCount + reverseIdCount
+                + chainCount + indexCount + overlapInstanceCount + reverseCount + reverseIdCount
                 + tsStateVectorCount + tsStateVectorCacheCount;
 
             if (totalTracked == 0)
@@ -9370,6 +9427,7 @@ namespace Parsek
             ghostOrbitEpochShift.Clear();
             vesselsByChainPid.Clear();
             vesselsByRecordingIndex.Clear();
+            overlapInstanceVessels.Clear();
             vesselPidToRecordingIndex.Clear();
             vesselPidToRecordingId.Clear();
             trackingStationStateVectorOrbitTrajectories.Clear();
@@ -9382,11 +9440,11 @@ namespace Parsek
                 string.Format(ic,
                     "ResetBetweenTestRuns: cleared bookkeeping reason={0} " +
                     "pids={1} suppressedIcons={2} orbitBounds={3} chainVessels={4} " +
-                    "indexVessels={5} reverseLookup={6} reverseIdLookup={7} " +
-                    "tsStateVectors={8} tsStateVectorCache={9}",
+                    "indexVessels={5} overlapInstances={6} reverseLookup={7} reverseIdLookup={8} " +
+                    "tsStateVectors={9} tsStateVectorCache={10}",
                     reason ?? "(null)",
                     pidCount, suppressedIconCount, orbitBoundsCount,
-                    chainCount, indexCount, reverseCount, reverseIdCount,
+                    chainCount, indexCount, overlapInstanceCount, reverseCount, reverseIdCount,
                     tsStateVectorCount, tsStateVectorCacheCount));
         }
 
@@ -10177,6 +10235,732 @@ namespace Parsek
             return effUT;
         }
 
+        // =====================================================================
+        //  Per-instance overlap map presence (slice i)
+        //  docs/dev/plans/maprender-overlap-per-instance.md
+        //
+        //  Mirrors the proven KSC per-instance overlap model (ParsekKSC.UpdateOverlapKsc /
+        //  SpawnKscGhost / kscOverlapGhosts) on the map + Tracking Station presence layer:
+        //  ONE map ProtoVessel per LIVE overlap cycle so the N map icons match the N flight
+        //  meshes 1:1. The schedule resolves through the PURE
+        //  GhostPlaybackLogic.TryResolveAutoLoopLaunchSchedule so flight AND Tracking Station
+        //  (no flight engine present) resolve identically; the cycle math reuses
+        //  GhostPlaybackLogic.GetActiveCycles + ComputeOverlapCyclePlaybackUT verbatim.
+        // =====================================================================
+
+        /// <summary>
+        /// Per-recording overlap gate (slice i). Mirrors the KSC dispatch
+        /// (<c>rec.LoopPlayback &amp;&amp; IsOverlapLoop</c>, ParsekKSC.cs:454-484): true when the
+        /// recording loops AND its launch-to-launch period is shorter than its duration, so
+        /// successive launches overlap. Covers BOTH a standalone looped recording (period &lt;
+        /// duration) AND a Mission-unit overlap member that loops. Resolves the interval +
+        /// duration through the same loop helpers the flight engine + KSC use. Pure-ish (reads
+        /// settings/committed only through the shared helpers); the cycle set it implies is
+        /// recomputed by <see cref="ResolveOverlapSchedule"/>.
+        /// </summary>
+        internal static bool IsOverlapRecording(
+            Recording rec, int recIdx, IReadOnlyList<Recording> committed)
+        {
+            if (rec == null || !rec.LoopPlayback)
+                return false;
+            if (!GhostPlaybackEngine.ShouldLoopPlayback(rec))
+                return false;
+
+            double duration = GhostPlaybackEngine.EffectiveLoopDuration(rec);
+            if (duration <= LoopTiming.MinLoopDurationSeconds)
+                return false;
+
+            double intervalSeconds = ResolveOverlapLoopIntervalSeconds(rec, recIdx, committed);
+            return GhostPlaybackLogic.IsOverlapLoop(intervalSeconds, duration);
+        }
+
+        /// <summary>
+        /// The director-drive gate for the per-instance overlap path. With
+        /// <c>mapRenderDirectorDrive</c> OFF the per-instance path is unreachable (we cannot bake N
+        /// correct per-cycle epochs without the director drive): the legacy one-per-recording create
+        /// runs instead (one honest icon). The legacy create early-out for overlap recordings and the
+        /// per-instance create MUST share this exact gate so gate-off does not render nothing.
+        /// </summary>
+        internal static bool IsOverlapPerInstanceGateOn()
+        {
+            return ParsekSettings.Current != null && ParsekSettings.Current.mapRenderDirectorDrive;
+        }
+
+        /// <summary>
+        /// Combined gate: should THIS recording be driven by the per-instance overlap path this frame?
+        /// True only when the director drive is ON (<see cref="IsOverlapPerInstanceGateOn"/>) AND the
+        /// recording is an overlap loop (<see cref="IsOverlapRecording"/>). When this is true the
+        /// legacy passes hand off to <see cref="EnsureOverlapInstances"/> and skip their own
+        /// single-instance create/reseed for the index.
+        /// </summary>
+        internal static bool ShouldDriveOverlapPerInstance(
+            Recording rec, int recIdx, IReadOnlyList<Recording> committed)
+        {
+            return IsOverlapPerInstanceGateOn() && IsOverlapRecording(rec, recIdx, committed);
+        }
+
+        /// <summary>
+        /// Resolve the launch-to-launch interval for an overlap-looped recording, threading the
+        /// global-auto-launch-queue schedule through the PURE
+        /// <see cref="GhostPlaybackLogic.TryResolveAutoLoopLaunchSchedule"/> (so the cadence matches
+        /// flight + KSC for an auto-interval recording). Falls back to
+        /// <see cref="GhostPlaybackLogic.ResolveLoopInterval"/> for non-queue recordings. Mirrors
+        /// ParsekKSC.GetLoopIntervalSeconds.
+        /// </summary>
+        private static double ResolveOverlapLoopIntervalSeconds(
+            Recording rec, int recIdx, IReadOnlyList<Recording> committed)
+        {
+            if (TryResolveOverlapScheduleAnchor(
+                    rec, recIdx, committed, out _, out double intervalSeconds))
+                return intervalSeconds;
+
+            double globalInterval = ParsekSettings.Current?.autoLoopIntervalSeconds
+                                    ?? LoopTiming.DefaultLoopIntervalSeconds;
+            return GhostPlaybackLogic.ResolveLoopInterval(
+                rec, globalInterval, LoopTiming.DefaultLoopIntervalSeconds, LoopTiming.MinCycleDuration);
+        }
+
+        /// <summary>
+        /// Resolve the (scheduleStartUT, intervalSeconds) anchor for an overlap-looped recording via
+        /// the PURE auto-launch-queue resolver. Mirrors ParsekKSC.TryGetLoopSchedule's schedule
+        /// branch: for a global-auto-launch-queue recording the schedule start + cadence come from
+        /// <see cref="GhostPlaybackLogic.TryResolveAutoLoopLaunchSchedule"/> (which sorts ALL queue
+        /// members so the slot/cadence is deterministic across scenes); otherwise the recording's own
+        /// effective loop start + resolved interval. Returns false when the recording is not a loop.
+        /// </summary>
+        private static bool TryResolveOverlapScheduleAnchor(
+            Recording rec, int recIdx, IReadOnlyList<Recording> committed,
+            out double scheduleStartUT, out double intervalSeconds)
+        {
+            scheduleStartUT = 0.0;
+            intervalSeconds = 0.0;
+            if (rec == null || !GhostPlaybackEngine.ShouldLoopPlayback(rec))
+                return false;
+
+            double playbackStartUT = GhostPlaybackEngine.EffectiveLoopStartUT(rec);
+            double globalInterval = ParsekSettings.Current?.autoLoopIntervalSeconds
+                                    ?? LoopTiming.DefaultLoopIntervalSeconds;
+            double baseIntervalSeconds = GhostPlaybackLogic.ResolveLoopInterval(
+                rec, globalInterval, LoopTiming.DefaultLoopIntervalSeconds, LoopTiming.MinCycleDuration);
+
+            scheduleStartUT = playbackStartUT;
+            intervalSeconds = baseIntervalSeconds;
+
+            if (recIdx >= 0
+                && committed != null
+                && GhostPlaybackLogic.ShouldUseGlobalAutoLaunchQueue(rec))
+            {
+                var trajectories = new List<IPlaybackTrajectory>(committed.Count);
+                for (int i = 0; i < committed.Count; i++)
+                    trajectories.Add(committed[i]);
+
+                if (GhostPlaybackLogic.TryResolveAutoLoopLaunchSchedule(
+                        trajectories,
+                        recIdx,
+                        baseIntervalSeconds,
+                        out GhostPlaybackLogic.AutoLoopLaunchSchedule autoSchedule))
+                {
+                    scheduleStartUT = autoSchedule.LaunchStartUT;
+                    intervalSeconds = autoSchedule.LaunchCadenceSeconds;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Resolve the full overlap schedule for a recording: playbackStartUT (where the replay
+        /// timeline begins), scheduleStartUT (the launch anchor), duration, the EFFECTIVE launch
+        /// cadence (raised so <c>ceil(duration/cadence) &lt;= cap</c>, mirroring
+        /// ParsekKSC.UpdateOverlapKsc + GhostPlaybackEngine.UpdateOverlapPlayback), and the
+        /// cycleDuration the cycle math uses. Returns false when the recording is not a loop.
+        /// </summary>
+        internal static bool ResolveOverlapSchedule(
+            Recording rec, int recIdx, IReadOnlyList<Recording> committed,
+            out double playbackStartUT, out double scheduleStartUT,
+            out double duration, out double effectiveCadence, out double cycleDuration)
+        {
+            playbackStartUT = 0.0;
+            scheduleStartUT = 0.0;
+            duration = 0.0;
+            effectiveCadence = 0.0;
+            cycleDuration = 0.0;
+            if (rec == null || !GhostPlaybackEngine.ShouldLoopPlayback(rec))
+                return false;
+
+            playbackStartUT = GhostPlaybackEngine.EffectiveLoopStartUT(rec);
+            duration = GhostPlaybackEngine.EffectiveLoopDuration(rec);
+            if (duration <= LoopTiming.MinLoopDurationSeconds)
+                return false;
+
+            if (!TryResolveOverlapScheduleAnchor(
+                    rec, recIdx, committed, out scheduleStartUT, out double intervalSeconds))
+                return false;
+
+            effectiveCadence = GhostPlaybackLogic.ComputeEffectiveLaunchCadence(
+                intervalSeconds, duration, GhostPlayback.MaxOverlapGhostsPerRecording);
+            cycleDuration = Math.Max(effectiveCadence, LoopTiming.MinCycleDuration);
+            return true;
+        }
+
+        /// <summary>
+        /// PURE create/destroy decision for the per-instance overlap lifecycle: given the cycles that
+        /// currently have a live instance, the active window <c>[firstCycle, lastCycle]</c>, and the
+        /// per-frame spawn budget, decides which cycles to create (live but missing, honoring the cap +
+        /// throttle) and which to destroy (expired below firstCycle). Unity-free so the policy is
+        /// xUnit-pinnable in isolation. <paramref name="spawnBudget"/> is the remaining
+        /// <see cref="GhostPlayback.MaxSpawnsPerFrame"/> headroom this frame; once exhausted,
+        /// remaining live-but-missing cycles are deferred to a later frame (the create path re-runs
+        /// every lifecycle tick), exactly like the flight engine's spawn throttle.
+        /// </summary>
+        internal static void DecideOverlapInstanceChanges(
+            IEnumerable<long> existingCycles,
+            long firstCycle,
+            long lastCycle,
+            int spawnBudget,
+            out List<long> toCreate,
+            out List<long> toDestroy)
+        {
+            toCreate = new List<long>();
+            toDestroy = new List<long>();
+            var present = new HashSet<long>();
+            if (existingCycles != null)
+            {
+                foreach (long c in existingCycles)
+                {
+                    present.Add(c);
+                    // Expired: a cycle that has dropped out of the live window (below firstCycle, the
+                    // cap clamp or natural completion) OR somehow ahead of the newest cycle.
+                    if (c < firstCycle || c > lastCycle)
+                        toDestroy.Add(c);
+                }
+            }
+
+            if (lastCycle < firstCycle)
+                return;
+
+            // Create newest-first so under a throttle the most-recently-launched (most visible)
+            // instances win the budget; older live cycles fill in on subsequent ticks.
+            int budget = spawnBudget;
+            for (long c = lastCycle; c >= firstCycle; c--)
+            {
+                if (present.Contains(c))
+                    continue;
+                if (budget <= 0)
+                    break;
+                toCreate.Add(c);
+                budget--;
+            }
+        }
+
+        /// <summary>
+        /// Slice (i) core: ensure ONE live map ProtoVessel per active overlap cycle for an
+        /// overlap-looped recording, mirroring ParsekKSC.UpdateOverlapKsc. Resolves the schedule via
+        /// the pure auto-launch-queue resolver, computes <c>[firstCycle, lastCycle]</c> via
+        /// <see cref="GhostPlaybackLogic.GetActiveCycles"/>, destroys instances whose cycle dropped
+        /// out of the window, and creates missing live cycles (each at its own
+        /// <c>effUT = ComputeOverlapCyclePlaybackUT(cycle)</c> with
+        /// <c>loopEpochShiftSeconds = currentUT - effUT</c>), throttled by the per-frame spawn budget.
+        /// ALL N instances (including the newest cycle) live in
+        /// <see cref="overlapInstanceVessels"/> (single-ownership rule). Returns the number of
+        /// instances created this call so the caller can debit a shared per-frame spawn counter.
+        /// </summary>
+        internal static int EnsureOverlapInstances(
+            int recIdx,
+            Recording rec,
+            double currentUT,
+            IReadOnlyList<Recording> committed,
+            ref int frameSpawnCount)
+        {
+            if (rec == null)
+                return 0;
+
+            if (!ResolveOverlapSchedule(
+                    rec, recIdx, committed,
+                    out double playbackStartUT, out double scheduleStartUT,
+                    out double duration, out double effectiveCadence, out double cycleDuration))
+            {
+                // Not a resolvable loop (defensive — caller already gated on IsOverlapRecording):
+                // tear down any leftover instances for this index.
+                DestroyAllOverlapInstancesForRecording(recIdx, "overlap-schedule-unresolved");
+                return 0;
+            }
+
+            // Before the schedule's first launch: no instances yet.
+            if (currentUT < scheduleStartUT)
+            {
+                DestroyAllOverlapInstancesForRecording(recIdx, "overlap-before-schedule-start");
+                return 0;
+            }
+
+            long firstCycle, lastCycle;
+            GhostPlaybackLogic.GetActiveCycles(
+                currentUT,
+                scheduleStartUT,
+                scheduleStartUT + duration,
+                effectiveCadence,
+                GhostPlayback.MaxOverlapGhostsPerRecording,
+                out firstCycle, out lastCycle);
+
+            // Collect the cycles currently live for THIS recording index.
+            var existing = new List<long>();
+            foreach (var kvp in overlapInstanceVessels)
+            {
+                if (kvp.Key.recIdx == recIdx)
+                    existing.Add(kvp.Key.cycle);
+            }
+
+            int spawnBudget = GhostPlayback.MaxSpawnsPerFrame - frameSpawnCount;
+            if (spawnBudget < 0) spawnBudget = 0;
+
+            DecideOverlapInstanceChanges(
+                existing, firstCycle, lastCycle, spawnBudget,
+                out List<long> toCreate, out List<long> toDestroy);
+
+            int destroyed = 0;
+            for (int i = 0; i < toDestroy.Count; i++)
+            {
+                RemoveOverlapInstance(recIdx, toDestroy[i], "overlap-cycle-expired");
+                destroyed++;
+            }
+
+            int created = 0;
+            for (int i = 0; i < toCreate.Count; i++)
+            {
+                // Respect the shared per-frame throttle (mirror the flight engine's MaxSpawnsPerFrame
+                // gate); DecideOverlapInstanceChanges already bounded toCreate by the budget, but
+                // re-check against the live counter in case multiple recordings spawn this frame.
+                if (GhostPlaybackLogic.ShouldThrottleSpawn(frameSpawnCount, GhostPlayback.MaxSpawnsPerFrame))
+                {
+                    ParsekLog.VerboseRateLimited(Tag, "overlap-instance-throttle",
+                        string.Format(ic,
+                            "Overlap per-instance create throttled rec=#{0} \"{1}\" " +
+                            "(used {2}/{3} spawns this frame, deferring remaining cycles)",
+                            recIdx, rec.VesselName ?? "(null)",
+                            frameSpawnCount, GhostPlayback.MaxSpawnsPerFrame),
+                        1.0);
+                    break;
+                }
+
+                long cycle = toCreate[i];
+                double effUT = GhostPlaybackLogic.ComputeOverlapCyclePlaybackUT(
+                    currentUT,
+                    scheduleStartUT,
+                    playbackStartUT,
+                    duration,
+                    cycleDuration,
+                    cycle);
+                double loopEpochShiftSeconds = currentUT - effUT;
+
+                Vessel inst = CreateOverlapInstanceVessel(
+                    recIdx, rec, cycle, effUT, loopEpochShiftSeconds);
+                if (inst != null)
+                {
+                    created++;
+                    frameSpawnCount++;
+                }
+            }
+
+            if (created > 0 || destroyed > 0)
+            {
+                ParsekLog.Verbose(Tag,
+                    string.Format(ic,
+                        "Overlap per-instance lifecycle rec=#{0} \"{1}\" cycles=[{2}..{3}] " +
+                        "created={4} destroyed={5} liveNow={6} currentUT={7:F1}",
+                        recIdx, rec.VesselName ?? "(null)", firstCycle, lastCycle,
+                        created, destroyed, GetOverlapInstanceCount(recIdx), currentUT));
+            }
+
+            return created;
+        }
+
+        /// <summary>
+        /// Per-frame overlap sweep, the SOLE create/destroy authority for overlap recordings on the
+        /// map + Tracking Station presence layers. Drives each overlap recording through
+        /// <see cref="EnsureOverlapInstances"/> (gated on
+        /// <see cref="ShouldDriveOverlapPerInstance"/>) and reaps any leftover per-instance vessels
+        /// for indices that are no longer overlap recordings (gate flipped off, recording stopped
+        /// looping, period grew past duration, or the committed list shrank). Threads a per-frame
+        /// spawn counter so a burst of newly-relaunching cycles is throttled exactly like the flight
+        /// engine. Called from both <see cref="UpdateFlightMapGhostLifecycle"/> and
+        /// <see cref="UpdateTrackingStationGhostLifecycle"/>. With the gate OFF nothing here runs
+        /// (every recording fails <see cref="ShouldDriveOverlapPerInstance"/>) AND the leftover reaper
+        /// tears down any instances created while the gate was on, so the scene falls cleanly back to
+        /// the legacy one-per-recording path.
+        /// </summary>
+        internal static void RunOverlapPerInstanceSweep(
+            double currentUT, IReadOnlyList<Recording> committed)
+        {
+            // Snapshot the set of indices that currently have any per-instance vessel, so we can
+            // reap the ones that should no longer be driven per-instance after the create pass below.
+            HashSet<int> indicesWithInstances = null;
+            if (overlapInstanceVessels.Count > 0)
+            {
+                indicesWithInstances = new HashSet<int>();
+                foreach (var kvp in overlapInstanceVessels)
+                    indicesWithInstances.Add(kvp.Key.recIdx);
+            }
+
+            int frameSpawnCount = 0;
+            HashSet<int> drivenThisFrame = null;
+            if (committed != null)
+            {
+                for (int i = 0; i < committed.Count; i++)
+                {
+                    var rec = committed[i];
+                    if (!ShouldDriveOverlapPerInstance(rec, i, committed))
+                        continue;
+                    EnsureOverlapInstances(i, rec, currentUT, committed, ref frameSpawnCount);
+                    if (drivenThisFrame == null) drivenThisFrame = new HashSet<int>();
+                    drivenThisFrame.Add(i);
+                }
+            }
+
+            // Reap: any index that has per-instance vessels but was NOT driven this frame is no longer
+            // an overlap recording under the active gate (or fell off the committed list). Tear its
+            // instances down so the legacy one-per-recording path can resume cleanly (or so the gate-off
+            // fallback renders the single legacy icon).
+            if (indicesWithInstances != null)
+            {
+                foreach (int idx in indicesWithInstances)
+                {
+                    if (drivenThisFrame != null && drivenThisFrame.Contains(idx))
+                        continue;
+                    DestroyAllOverlapInstancesForRecording(idx, "overlap-no-longer-per-instance");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Create ONE per-instance overlap map ProtoVessel for (recIdx, cycle) at its loop-mapped
+        /// <paramref name="effUT"/>. Mirrors ParsekKSC.SpawnKscGhost's "fresh object per instance, no
+        /// per-index early-return" model rather than the per-index
+        /// <see cref="CreateGhostVesselFromSource"/> funnel (which early-returns the existing
+        /// per-index vessel and writes the single <see cref="vesselsByRecordingIndex"/> slot via
+        /// <see cref="TrackRecordingGhostVessel"/>). Registers PER INSTANCE: the new pid into
+        /// <see cref="ghostMapVesselPids"/>, the pid-&gt;index / pid-&gt;id reverse maps, the per-pid
+        /// loop epoch shift, and the per-pid orbit bounds the icon-drive / arc-clip patches read. The
+        /// orbit source is resolved at <paramref name="effUT"/> exactly like the per-index create.
+        /// </summary>
+        private static Vessel CreateOverlapInstanceVessel(
+            int recIdx, Recording rec, long cycle, double effUT, double loopEpochShiftSeconds)
+        {
+            if (overlapInstanceVessels.ContainsKey((recIdx, cycle)))
+                return overlapInstanceVessels[(recIdx, cycle)];
+
+            // Resolve the covering orbit source at this instance's effUT (segment / state-vector /
+            // terminal-orbit), the same resolution the per-index create uses.
+            int cachedStateVectorIndex = -1;
+            TrackingStationGhostSource source = ResolveMapPresenceGhostSource(
+                rec,
+                false,
+                IsMaterializedForMapPresence(rec),
+                effUT,
+                true,
+                "overlap-instance-create",
+                ref cachedStateVectorIndex,
+                out OrbitSegment segment,
+                out TrajectoryPoint stateVectorPoint,
+                out string skipReason,
+                recordingIndex: recIdx,
+                // A live overlap instance always has a non-zero epoch shift, so it is "in window".
+                loopMemberInWindow: true);
+
+            if (!IsMapCreateAcceptedSource(source))
+            {
+                ParsekLog.VerboseRateLimited(Tag,
+                    string.Format(ic, "overlap-instance-no-source-{0}-{1}", recIdx, cycle),
+                    string.Format(ic,
+                        "Overlap per-instance create skipped rec=#{0} \"{1}\" cycle={2} effUT={3:F1} " +
+                        "source={4} reason={5} (no map-visible orbit this cycle yet)",
+                        recIdx, rec.VesselName ?? "(null)", cycle, effUT, source,
+                        skipReason ?? "(none)"),
+                    2.0);
+                return null;
+            }
+
+            // Build the ProtoVessel directly (fresh KSP-unique pid via CreateVesselNode vesselID:0).
+            // Segment / EndpointTail seed the orbit from the covering segment; TerminalOrbit /
+            // state-vector seed from the recording's terminal/endpoint orbit.
+            string logContext = string.Format(ic,
+                "overlap instance rec=#{0} cycle={1} (source={2})", recIdx, cycle, source);
+            Vessel vessel;
+            switch (source)
+            {
+                case TrackingStationGhostSource.Segment:
+                case TrackingStationGhostSource.EndpointTail:
+                    vessel = BuildAndLoadGhostProtoVessel(
+                        rec, segment, logContext,
+                        source == TrackingStationGhostSource.EndpointTail
+                            ? "overlap-instance-endpoint-tail"
+                            : "overlap-instance-segment");
+                    break;
+                case TrackingStationGhostSource.TerminalOrbit:
+                    vessel = BuildAndLoadGhostProtoVessel(rec, logContext);
+                    break;
+                case TrackingStationGhostSource.StateVector:
+                case TrackingStationGhostSource.StateVectorSoiGap:
+                    vessel = BuildAndLoadGhostProtoVesselFromStateVector(
+                        rec, stateVectorPoint, effUT, loopEpochShiftSeconds, logContext);
+                    break;
+                default:
+                    return null;
+            }
+
+            if (vessel == null)
+                return null;
+
+            // Register this instance PER PID (single-ownership store + the per-pid maps the icon /
+            // arc / marker paths read). Do NOT write vesselsByRecordingIndex (that is the legacy
+            // one-per-recording slot; overlap recordings live solely in overlapInstanceVessels).
+            uint pid = vessel.persistentId;
+            overlapInstanceVessels[(recIdx, cycle)] = vessel;
+            ghostMapVesselPids.Add(pid);
+            vesselPidToRecordingIndex[pid] = recIdx;
+            if (!string.IsNullOrEmpty(rec.RecordingId))
+                vesselPidToRecordingId[pid] = rec.RecordingId;
+            else
+                vesselPidToRecordingId.Remove(pid);
+
+            if (source == TrackingStationGhostSource.Segment
+                || source == TrackingStationGhostSource.EndpointTail)
+            {
+                // Segment / orbit path: seed the RAW recorded epoch + record the loop shift + per-pid
+                // bounds so GhostOrbitIconDrivePatch drives the OrbitDriver at effUT = liveUT - shift
+                // every frame (slice i: the per-pid ghostOrbitEpochShift IS the phase, NOT an
+                // instanceKey). Mirrors the per-index segment contract (ApplyOrbitToVessel).
+                ApplyOrbitToVessel(vessel, segment, logContext, loopEpochShiftSeconds);
+            }
+            else
+            {
+                // Terminal-orbit + state-vector instances mirror the per-index NON-segment contract:
+                // the orbit is seeded at the SHIFTED epoch (live UT) and stock OrbitDriver propagates
+                // it at the live Planetarium clock - there is no raw-epoch + effUT-drive contract
+                // (no OrbitSegments / bounds). So this branch MUST NOT register ghostOrbitEpochShift /
+                // ghostOrbitLoopShiftedPids: doing so makes GhostOrbitIconDrivePatch bail on the
+                // no-bounds branch and stock then advances the icon by `shift` along the orbit (wrong
+                // phase). Clear any stale segment-drive entries (defensive; the pid is fresh here, but
+                // this mirrors the per-index state-vector clear at GhostMapPresence.cs:7969-7973).
+                ghostOrbitBounds.Remove(pid);
+                ghostBodyFrameOrbitBounds.Remove(pid);
+                ghostOrbitLoopShiftedPids.Remove(pid);
+                ghostOrbitEpochShift.Remove(pid);
+            }
+
+            lifecycleCreatedThisTick++;
+
+            ParsekLog.Info(Tag,
+                string.Format(ic,
+                    "Created overlap per-instance map vessel rec=#{0} \"{1}\" cycle={2} pid={3} " +
+                    "source={4} effUT={5:F1} loopShift={6:F1}",
+                    recIdx, rec.VesselName ?? "(null)", cycle, pid, source, effUT, loopEpochShiftSeconds));
+
+            return vessel;
+        }
+
+        /// <summary>
+        /// Remove ONE per-instance overlap map ProtoVessel for (recIdx, cycle): Die() the vessel,
+        /// drop all per-pid map entries, and clear the store slot. Mirrors
+        /// <see cref="RemoveGhostVesselForRecording"/> but keyed on the (recIdx, cycle) instance and
+        /// the per-instance store (never touches <see cref="vesselsByRecordingIndex"/>).
+        /// </summary>
+        internal static void RemoveOverlapInstance(int recIdx, long cycle, string reason)
+        {
+            if (!overlapInstanceVessels.TryGetValue((recIdx, cycle), out Vessel vessel))
+                return;
+
+            uint ghostPid = vessel != null ? vessel.persistentId : 0u;
+
+            if (vessel != null)
+            {
+                try { vessel.Die(); }
+                catch (Exception ex)
+                {
+                    ParsekLog.Warn(Tag,
+                        string.Format(ic,
+                            "RemoveOverlapInstance: Die() threw for rec=#{0} cycle={1}: {2}",
+                            recIdx, cycle, ex.Message));
+                }
+            }
+
+            if (ghostPid != 0)
+            {
+                ghostMapVesselPids.Remove(ghostPid);
+                ghostsWithSuppressedIcon.Remove(ghostPid);
+                ghostOrbitLineGraceUntilFrame.Remove(ghostPid);
+                ghostOrbitBounds.Remove(ghostPid);
+                ghostBodyFrameOrbitBounds.Remove(ghostPid);
+                ghostLastAppliedOrbitBody.Remove(ghostPid);
+                ghostOrbitLoopShiftedPids.Remove(ghostPid);
+                ghostOrbitEpochShift.Remove(ghostPid);
+                vesselPidToRecordingIndex.Remove(ghostPid);
+                vesselPidToRecordingId.Remove(ghostPid);
+            }
+            overlapInstanceVessels.Remove((recIdx, cycle));
+            lifecycleDestroyedThisTick++;
+
+            ParsekLog.Verbose(Tag,
+                string.Format(ic,
+                    "Removed overlap per-instance map vessel rec=#{0} cycle={1} pid={2} reason={3}",
+                    recIdx, cycle, ghostPid, reason ?? "(none)"));
+        }
+
+        /// <summary>
+        /// Destroy every per-instance overlap map vessel for a recording index (e.g. when the
+        /// recording is no longer an overlap loop, became inactive, or the gate flipped off). Mirrors
+        /// ParsekKSC.DestroyAllKscOverlapGhosts.
+        /// </summary>
+        internal static void DestroyAllOverlapInstancesForRecording(int recIdx, string reason)
+        {
+            List<long> cycles = null;
+            foreach (var kvp in overlapInstanceVessels)
+            {
+                if (kvp.Key.recIdx != recIdx)
+                    continue;
+                if (cycles == null) cycles = new List<long>();
+                cycles.Add(kvp.Key.cycle);
+            }
+            if (cycles == null)
+                return;
+            for (int i = 0; i < cycles.Count; i++)
+                RemoveOverlapInstance(recIdx, cycles[i], reason);
+        }
+
+        /// <summary>
+        /// Number of live per-instance overlap map vessels for a recording index. Exposed for the
+        /// in-game test (asserts map count == flight overlap count + 1, capped at the per-recording
+        /// cap).
+        /// </summary>
+        internal static int GetOverlapInstanceCount(int recIdx)
+        {
+            int count = 0;
+            foreach (var kvp in overlapInstanceVessels)
+            {
+                if (kvp.Key.recIdx == recIdx)
+                    count++;
+            }
+            return count;
+        }
+
+        /// <summary>
+        /// The pid of the NEWEST live overlap instance (highest cycle) for a recording index, or 0
+        /// when none. Used by the <see cref="vesselsByRecordingIndex"/>-reader fall-through
+        /// (<see cref="GetGhostVesselPidForRecording"/> / <see cref="HasGhostVesselForRecording"/>) so
+        /// watch-camera focus, TS-Fly, UI marker suppression, and the polyline owner resolve get the
+        /// newest instance's pid (matching the legacy "one icon == newest cycle" behavior) instead of 0.
+        /// </summary>
+        internal static uint GetNewestOverlapInstancePidForRecording(int recIdx)
+        {
+            uint newestPid = 0;
+            long newestCycle = long.MinValue;
+            foreach (var kvp in overlapInstanceVessels)
+            {
+                if (kvp.Key.recIdx != recIdx)
+                    continue;
+                if (kvp.Value == null)
+                    continue;
+                if (kvp.Key.cycle > newestCycle)
+                {
+                    newestCycle = kvp.Key.cycle;
+                    newestPid = kvp.Value.persistentId;
+                }
+            }
+            return newestPid;
+        }
+
+        /// <summary>
+        /// Test-only (Unity-free): resolve the active cycle window [firstCycle, lastCycle] this
+        /// recording's per-instance path WOULD drive at <paramref name="currentUT"/>, without minting
+        /// any ProtoVessel. Mirrors the exact schedule resolution + GetActiveCycles call inside
+        /// <see cref="EnsureOverlapInstances"/> so xUnit can pin the cycle-set equivalence with the
+        /// flight engine. Returns (0, -1) (empty window) when the recording is not a resolvable loop
+        /// or currentUT precedes the schedule start.
+        /// </summary>
+        internal static void OverlapCyclesForTesting(
+            Recording rec, int recIdx, IReadOnlyList<Recording> committed, double currentUT,
+            out long firstCycle, out long lastCycle)
+        {
+            firstCycle = 0;
+            lastCycle = -1;
+            if (!ResolveOverlapSchedule(
+                    rec, recIdx, committed,
+                    out _, out double scheduleStartUT,
+                    out double duration, out double effectiveCadence, out _))
+                return;
+            if (currentUT < scheduleStartUT)
+                return;
+            GhostPlaybackLogic.GetActiveCycles(
+                currentUT, scheduleStartUT, scheduleStartUT + duration,
+                effectiveCadence, GhostPlayback.MaxOverlapGhostsPerRecording,
+                out firstCycle, out lastCycle);
+        }
+
+        /// <summary>Test-only: snapshot the live (recIdx, cycle) keys for an index.</summary>
+        internal static List<long> GetOverlapInstanceCyclesForTesting(int recIdx)
+        {
+            var cycles = new List<long>();
+            foreach (var kvp in overlapInstanceVessels)
+            {
+                if (kvp.Key.recIdx == recIdx)
+                    cycles.Add(kvp.Key.cycle);
+            }
+            cycles.Sort();
+            return cycles;
+        }
+
+        /// <summary>
+        /// Build a per-instance overlap map ProtoVessel from a recorded state-vector point (physics-only
+        /// suborbital ascent cycle), without the per-index <see cref="TrackRecordingGhostVessel"/> write
+        /// or the Re-Fly suppression machinery in <see cref="CreateGhostVesselFromStateVectors"/> (which
+        /// is per-index state and irrelevant to overlap loops). Resolves the world position via the same
+        /// <see cref="ResolveStateVectorWorldPosition"/> the per-index path uses, then seeds an orbit
+        /// from the world pos + recorded velocity.
+        ///
+        /// Mirrors the per-index state-vector contract (<c>UpdateGhostOrbitFromStateVectors</c>,
+        /// GhostMapPresence.cs:7956-8000): the orbit is seeded at the SHIFTED epoch
+        /// (<paramref name="effUT"/> + <paramref name="loopEpochShiftSeconds"/> == the instance's LIVE
+        /// UT) so stock <see cref="OrbitDriver"/> propagation at the live Planetarium clock lands the
+        /// icon on the world position recorded at <paramref name="effUT"/>. Physics-only recordings have
+        /// no <c>OrbitSegments</c>, so there is no segment-drive raw-epoch + effUT contract here: the
+        /// caller must NOT register <c>ghostOrbitEpochShift</c> / <c>ghostOrbitLoopShiftedPids</c> for a
+        /// state-vector instance (that would make <see cref="GhostOrbitIconDrivePatch"/> bail on the
+        /// no-bounds branch and re-subtract a shift from this already-shifted orbit). Returns null when
+        /// the body or world frame cannot resolve (the cycle is then retried next tick).
+        /// </summary>
+        private static Vessel BuildAndLoadGhostProtoVesselFromStateVector(
+            IPlaybackTrajectory traj, TrajectoryPoint point, double effUT, double loopEpochShiftSeconds,
+            string logContext)
+        {
+            CelestialBody body = FindBodyByName(point.bodyName);
+            if (body == null)
+                return null;
+
+            StateVectorWorldFrame resolution =
+                ResolveStateVectorWorldPosition(traj, point, body, allowOrbitalCheckpointStateVector: true);
+            if (!resolution.Resolved)
+                return null;
+
+            Vector3d worldPos = resolution.WorldPos;
+            Vector3d vel = new Vector3d(point.velocity.x, point.velocity.y, point.velocity.z);
+
+            // Seed at the SHIFTED epoch (live UT), mirroring the per-index state-vector path so stock
+            // propagation at the live clock lands the icon on the effUT-recorded world position.
+            Orbit orbit = new Orbit();
+            OrbitReseed.FromWorldPosAndRecordedVelocity(
+                orbit, body, worldPos, vel, effUT + loopEpochShiftSeconds);
+
+            return BuildAndLoadGhostProtoVesselCore(
+                traj,
+                orbit,
+                body,
+                logContext,
+                "overlap-instance-state-vector",
+                string.Format(ic,
+                    "stateBody={0} effUT={1:F1} liveUT={2:F1} stateAlt={3:F0} stateSpeed={4:F1} frame={5}",
+                    point.bodyName ?? "(null)", effUT, effUT + loopEpochShiftSeconds,
+                    point.altitude, point.velocity.magnitude, resolution.Branch));
+        }
+
         /// <summary>
         /// Per-frame check for ghost map ProtoVessels. Handles three responsibilities:
         /// 1. Creates deferred ProtoVessels when ghosts enter their first orbital segment
@@ -10195,6 +10979,13 @@ namespace Parsek
             // the unchanged live UT with shift 0, so non-looping behavior is byte-identical.
 
             RunFlightMapDeferredCreatePass(currentUT, loopUnits);            // Pass 1 (always runs)
+
+            // Per-instance overlap sweep (slice i). The SOLE create/destroy authority for overlap
+            // recordings on the flight map; the three legacy passes below skip overlap indices.
+            // Runs in the always-runs section so cycles relaunch/expire promptly. Resolves the live
+            // committed list here (the rate-limited section below resolves its own copy after the
+            // gate; the overlap path must run every frame).
+            RunOverlapPerInstanceSweep(currentUT, RecordingStore.CommittedRecordings);
 
             // 2. Map-orbit reseed for existing ProtoVessels. Rate-limited to the real-time timer, BUT
             // warp-aware: under time warp the playback head sprints through short segments (e.g. the many
@@ -10234,11 +11025,19 @@ namespace Parsek
             {
                 List<(int idx, TrackingStationGhostSource source, OrbitSegment segment, TrajectoryPoint point, string expectedBody, double effUT)> toCreate = null;
 
+                var committedForOverlapSkip = RecordingStore.CommittedRecordings;
                 foreach (var kvp in flightPendingMapVessels)
                 {
                     int idx = kvp.Key;
                     PendingMapVessel pending = kvp.Value;
                     IPlaybackTrajectory traj = pending.Trajectory;
+
+                    // Slice (i): overlap recordings are owned solely by the per-instance sweep
+                    // (RunOverlapPerInstanceSweep, run earlier this frame). Skip the legacy
+                    // single-instance deferred create for them so there is no double-management.
+                    if (committedForOverlapSkip != null && idx >= 0 && idx < committedForOverlapSkip.Count
+                        && ShouldDriveOverlapPerInstance(committedForOverlapSkip[idx], idx, committedForOverlapSkip))
+                        continue;
 
                     // Loop-mapped sample UT for this member (effUT == currentUT off the loop path).
                     // renderHidden => this member is outside its loop window this cycle: skip the
@@ -10421,6 +11220,10 @@ namespace Parsek
 
                 var rec = committed[idx];
                 if (!rec.HasOrbitSegments) continue;
+
+                // Slice (i): overlap recordings are reseeded by the per-instance sweep, not here.
+                if (ShouldDriveOverlapPerInstance(rec, idx, committed))
+                    continue;
 
                 // Loop-mapped sample UT + live-frame epoch shift (effUT == currentUT, shift 0 off
                 // the loop path). renderHidden => the member left its loop window this cycle: tear
@@ -10693,6 +11496,11 @@ namespace Parsek
                 {
                     int idx = kvp.Key;
                     IPlaybackTrajectory traj = kvp.Value;
+
+                    // Slice (i): overlap recordings are driven by the per-instance sweep, not here.
+                    if (committed != null && idx >= 0 && idx < committed.Count
+                        && ShouldDriveOverlapPerInstance(committed[idx], idx, committed))
+                        continue;
 
                     if (!flightStateVectorCachedIndices.ContainsKey(idx))
                         flightStateVectorCachedIndices[idx] = -1;
@@ -11021,6 +11829,25 @@ namespace Parsek
             bool hasPoints = evt.Trajectory.Points != null && evt.Trajectory.Points.Count > 0;
             if (!hasOrbitData && !hasOrbitSegments && !hasPoints)
                 return;
+
+            // Slice (i): overlap recordings (looped, period < duration) under the director-drive gate
+            // are owned solely by the per-frame per-instance sweep (RunOverlapPerInstanceSweep) which
+            // creates ONE map vessel per live cycle. Do NOT enqueue/create a single per-index ghost
+            // for them here. Off the gate (or for non-overlap recordings) this is byte-identical to
+            // before: the per-instance path is unreachable and the legacy enqueue runs.
+            {
+                var committedForOverlap = RecordingStore.CommittedRecordings;
+                if (committedForOverlap != null && evt.Index >= 0 && evt.Index < committedForOverlap.Count
+                    && ShouldDriveOverlapPerInstance(committedForOverlap[evt.Index], evt.Index, committedForOverlap))
+                {
+                    ParsekLog.Verbose("Policy",
+                        string.Format(CultureInfo.InvariantCulture,
+                            "Ghost map for #{0} \"{1}\" deferred to per-instance overlap sweep " +
+                            "(looped overlap recording, director-drive on)",
+                            evt.Index, evt.Trajectory.VesselName ?? "(null)"));
+                    return;
+                }
+            }
 
             // Per-chain dedup: if another segment from the same chain already has a ghost
             // map vessel, remove it before creating the new one. Prevents duplicate orbit

--- a/Source/Parsek/GhostMapPresence.cs
+++ b/Source/Parsek/GhostMapPresence.cs
@@ -6084,7 +6084,8 @@ namespace Parsek
             // cycle set is identical to flight (the flight engine does not exist in this scene). The
             // per-index create loop below skips overlap indices. Run before the empty-return so a
             // gate-off transition reaps any leftover instances even when no committed recordings exist.
-            RunOverlapPerInstanceSweep(currentUT, committed);
+            // loopUnits is the TS span-clock set so a Mission-tab loop (source b) drives per-instance.
+            RunOverlapPerInstanceSweep(currentUT, committed, loopUnits);
 
             if (!hasCommittedRecordings)
             {
@@ -6114,7 +6115,7 @@ namespace Parsek
                 var rec = committed[i];
 
                 // Slice (i): overlap recordings are created by the per-instance sweep above, not here.
-                if (ShouldDriveOverlapPerInstance(rec, i, committed))
+                if (ShouldDriveOverlapPerInstance(rec, i, committed, loopUnits))
                     continue;
 
                 // Phase F: substitute the shared Mission span-clock loopUT for the live UT when this
@@ -6448,7 +6449,7 @@ namespace Parsek
                 // Slice (i): if this index became an overlap recording under the director-drive gate,
                 // it is now owned by the per-instance store. Tear down its leftover per-index ghost so
                 // there is no duplicate (the per-instance sweep created the N-per-cycle vessels).
-                if (ShouldDriveOverlapPerInstance(rec, idx, committed))
+                if (ShouldDriveOverlapPerInstance(rec, idx, committed, loopUnits))
                 {
                     if (toRemove == null) toRemove = new List<(int, string)>();
                     toRemove.Add((idx, "overlap-handoff-to-per-instance"));
@@ -10249,19 +10250,33 @@ namespace Parsek
         // =====================================================================
 
         /// <summary>
-        /// Per-recording overlap gate (slice i). Mirrors the KSC dispatch
-        /// (<c>rec.LoopPlayback &amp;&amp; IsOverlapLoop</c>, ParsekKSC.cs:454-484): true when the
-        /// recording loops AND its launch-to-launch period is shorter than its duration, so
-        /// successive launches overlap. Covers BOTH a standalone looped recording (period &lt;
-        /// duration) AND a Mission-unit overlap member that loops. Resolves the interval +
-        /// duration through the same loop helpers the flight engine + KSC use. Pure-ish (reads
-        /// settings/committed only through the shared helpers); the cycle set it implies is
-        /// recomputed by <see cref="ResolveOverlapSchedule"/>.
+        /// Per-recording overlap gate (slice i). A UNION of two overlap sources, mirroring the flight
+        /// engine's two overlap entry points exactly:
+        ///   (b) MISSION-UNIT self-overlap (checked FIRST, preferred when both apply): this index is a
+        ///       member of a looped Mission unit whose overlap cadence is shorter than its span
+        ///       (<see cref="GhostPlaybackLogic.UnitMemberOverlaps"/>), so the whole mission relaunches
+        ///       before the prior instance finishes (GhostPlaybackEngine.cs:2144-2183). A Mission member
+        ///       does NOT carry its own <c>rec.LoopPlayback</c> flag, so this branch must run regardless
+        ///       of it - the bug that cost a playtest: the maintainer loops via the Missions tab.
+        ///   (a) STANDALONE per-recording overlap: the recording itself loops (<c>rec.LoopPlayback</c>)
+        ///       and its launch-to-launch period is shorter than its duration (ParsekKSC.cs:454-484).
+        /// Returns (a)||(b). <paramref name="loopUnits"/> is the per-frame
+        /// <see cref="GhostPlaybackEngine.CurrentLoopUnits"/> threaded from the scene driver; Empty
+        /// (the common case) collapses this to source (a) only - byte-identical to pre-Missions.
         /// </summary>
         internal static bool IsOverlapRecording(
-            Recording rec, int recIdx, IReadOnlyList<Recording> committed)
+            Recording rec, int recIdx, IReadOnlyList<Recording> committed,
+            GhostPlaybackLogic.LoopUnitSet loopUnits)
         {
-            if (rec == null || !rec.LoopPlayback)
+            if (rec == null)
+                return false;
+
+            // (b) Mission-unit self-overlap — checked first, regardless of rec.LoopPlayback.
+            if (IsUnitOverlapMember(rec, recIdx, loopUnits))
+                return true;
+
+            // (a) Standalone per-recording overlap loop.
+            if (!rec.LoopPlayback)
                 return false;
             if (!GhostPlaybackEngine.ShouldLoopPlayback(rec))
                 return false;
@@ -10272,6 +10287,29 @@ namespace Parsek
 
             double intervalSeconds = ResolveOverlapLoopIntervalSeconds(rec, recIdx, committed);
             return GhostPlaybackLogic.IsOverlapLoop(intervalSeconds, duration);
+        }
+
+        /// <summary>
+        /// Source (b) predicate: is <paramref name="recIdx"/> a member of a looped Mission unit that
+        /// SELF-OVERLAPS (span &gt; 0 &amp;&amp; OverlapCadenceSeconds &lt; span via
+        /// <see cref="GhostPlaybackLogic.UnitMemberOverlaps"/>) AND this member's trimmed render window
+        /// is long enough to replay? Mirrors the flight engine's unit-overlap branch entry
+        /// (GhostPlaybackEngine.cs:2163-2169 - the <c>memberDuration &gt; 0</c> guard, tightened here
+        /// to the same <see cref="LoopTiming.MinLoopDurationSeconds"/> floor the standalone path uses).
+        /// </summary>
+        private static bool IsUnitOverlapMember(
+            Recording rec, int recIdx, GhostPlaybackLogic.LoopUnitSet loopUnits)
+        {
+            if (rec == null || loopUnits == null)
+                return false;
+            if (!loopUnits.TryGetUnitForMember(recIdx, out GhostPlaybackLogic.LoopUnit unit))
+                return false;
+            if (!GhostPlaybackLogic.UnitMemberOverlaps(unit))
+                return false;
+
+            double memberStartUT = unit.MemberStartUT(recIdx, rec.StartUT);
+            double memberEndUT = unit.MemberEndUT(recIdx, rec.EndUT);
+            return memberEndUT - memberStartUT > LoopTiming.MinLoopDurationSeconds;
         }
 
         /// <summary>
@@ -10294,9 +10332,11 @@ namespace Parsek
         /// single-instance create/reseed for the index.
         /// </summary>
         internal static bool ShouldDriveOverlapPerInstance(
-            Recording rec, int recIdx, IReadOnlyList<Recording> committed)
+            Recording rec, int recIdx, IReadOnlyList<Recording> committed,
+            GhostPlaybackLogic.LoopUnitSet loopUnits)
         {
-            return IsOverlapPerInstanceGateOn() && IsOverlapRecording(rec, recIdx, committed);
+            return IsOverlapPerInstanceGateOn()
+                && IsOverlapRecording(rec, recIdx, committed, loopUnits);
         }
 
         /// <summary>
@@ -10369,14 +10409,20 @@ namespace Parsek
         }
 
         /// <summary>
-        /// Resolve the full overlap schedule for a recording: playbackStartUT (where the replay
+        /// Resolve the full overlap schedule tuple for a recording: playbackStartUT (where the replay
         /// timeline begins), scheduleStartUT (the launch anchor), duration, the EFFECTIVE launch
         /// cadence (raised so <c>ceil(duration/cadence) &lt;= cap</c>, mirroring
         /// ParsekKSC.UpdateOverlapKsc + GhostPlaybackEngine.UpdateOverlapPlayback), and the
-        /// cycleDuration the cycle math uses. Returns false when the recording is not a loop.
+        /// cycleDuration the cycle math uses. A UNION of the two overlap sources (the unit branch is
+        /// dispatched FIRST so a Mission member uses the unit's schedule even if it also carries its
+        /// own <c>rec.LoopPlayback</c>): both converge on the SAME tuple shape, so the SAME
+        /// <see cref="EnsureOverlapInstances"/> -&gt; GetActiveCycles -&gt;
+        /// <see cref="DecideOverlapInstanceChanges"/> -&gt; ComputeOverlapCyclePlaybackUT path runs for
+        /// both (no second create path). Returns false when the recording is neither.
         /// </summary>
         internal static bool ResolveOverlapSchedule(
             Recording rec, int recIdx, IReadOnlyList<Recording> committed,
+            GhostPlaybackLogic.LoopUnitSet loopUnits,
             out double playbackStartUT, out double scheduleStartUT,
             out double duration, out double effectiveCadence, out double cycleDuration)
         {
@@ -10385,7 +10431,18 @@ namespace Parsek
             duration = 0.0;
             effectiveCadence = 0.0;
             cycleDuration = 0.0;
-            if (rec == null || !GhostPlaybackEngine.ShouldLoopPlayback(rec))
+            if (rec == null)
+                return false;
+
+            // Source (b): Mission-unit self-overlap — dispatched first.
+            if (TryResolveUnitOverlapSchedule(
+                    rec, recIdx, loopUnits,
+                    out playbackStartUT, out scheduleStartUT,
+                    out duration, out effectiveCadence, out cycleDuration))
+                return true;
+
+            // Source (a): standalone per-recording overlap loop.
+            if (!GhostPlaybackEngine.ShouldLoopPlayback(rec))
                 return false;
 
             playbackStartUT = GhostPlaybackEngine.EffectiveLoopStartUT(rec);
@@ -10399,6 +10456,57 @@ namespace Parsek
 
             effectiveCadence = GhostPlaybackLogic.ComputeEffectiveLaunchCadence(
                 intervalSeconds, duration, GhostPlayback.MaxOverlapGhostsPerRecording);
+            cycleDuration = Math.Max(effectiveCadence, LoopTiming.MinCycleDuration);
+            return true;
+        }
+
+        /// <summary>
+        /// Source (b) schedule: resolve the overlap tuple for a Mission-unit self-overlap member,
+        /// mirroring the flight engine's unit-overlap branch EXACTLY (GhostPlaybackEngine.cs:2163-2183
+        /// for the member window + schedule anchor, GhostPlaybackEngine.cs:3570-3571 for the cap
+        /// re-clamp inside UpdateOverlapPlayback):
+        ///   memberStartUT   = unit.MemberStartUT(recIdx, rec.StartUT)   (interval-level start trim)
+        ///   memberEndUT     = unit.MemberEndUT(recIdx, rec.EndUT)       (interval-level end trim)
+        ///   duration        = memberEndUT - memberStartUT
+        ///   playbackStartUT = memberStartUT
+        ///   scheduleStartUT = ComputeMemberOverlapScheduleStartUT(PhaseAnchorUT, SpanStartUT, memberStartUT)
+        ///   effectiveCadence= ComputeEffectiveLaunchCadence(OverlapCadenceSeconds, duration, cap)
+        ///   cycleDuration   = max(effectiveCadence, MinCycleDuration)
+        /// SPAN-CLOCK CAVEAT: the overlap path uses this RAW schedule with ComputeOverlapCyclePlaybackUT,
+        /// NOT ResolveTrackingStationSampleUT / ResolveMapPresenceSampleUT (the span-clock NON-overlap
+        /// path with loiter-cut / arrival-hold / re-aim remapping). The engine's overlap branch
+        /// deliberately skips the span clock (GhostPlaybackEngine.cs:2152-2156); re-aim / zero-drift
+        /// units are non-overlapping by construction (cadence raised &gt;= span) so they never enter
+        /// here. Returns false when the recording is not a self-overlapping unit member.
+        /// </summary>
+        private static bool TryResolveUnitOverlapSchedule(
+            Recording rec, int recIdx, GhostPlaybackLogic.LoopUnitSet loopUnits,
+            out double playbackStartUT, out double scheduleStartUT,
+            out double duration, out double effectiveCadence, out double cycleDuration)
+        {
+            playbackStartUT = 0.0;
+            scheduleStartUT = 0.0;
+            duration = 0.0;
+            effectiveCadence = 0.0;
+            cycleDuration = 0.0;
+            if (rec == null || loopUnits == null)
+                return false;
+            if (!loopUnits.TryGetUnitForMember(recIdx, out GhostPlaybackLogic.LoopUnit unit))
+                return false;
+            if (!GhostPlaybackLogic.UnitMemberOverlaps(unit))
+                return false;
+
+            double memberStartUT = unit.MemberStartUT(recIdx, rec.StartUT);
+            double memberEndUT = unit.MemberEndUT(recIdx, rec.EndUT);
+            duration = memberEndUT - memberStartUT;
+            if (duration <= LoopTiming.MinLoopDurationSeconds)
+                return false;
+
+            playbackStartUT = memberStartUT;
+            scheduleStartUT = GhostPlaybackLogic.ComputeMemberOverlapScheduleStartUT(
+                unit.PhaseAnchorUT, unit.SpanStartUT, memberStartUT);
+            effectiveCadence = GhostPlaybackLogic.ComputeEffectiveLaunchCadence(
+                unit.OverlapCadenceSeconds, duration, GhostPlayback.MaxOverlapGhostsPerRecording);
             cycleDuration = Math.Max(effectiveCadence, LoopTiming.MinCycleDuration);
             return true;
         }
@@ -10470,13 +10578,14 @@ namespace Parsek
             Recording rec,
             double currentUT,
             IReadOnlyList<Recording> committed,
+            GhostPlaybackLogic.LoopUnitSet loopUnits,
             ref int frameSpawnCount)
         {
             if (rec == null)
                 return 0;
 
             if (!ResolveOverlapSchedule(
-                    rec, recIdx, committed,
+                    rec, recIdx, committed, loopUnits,
                     out double playbackStartUT, out double scheduleStartUT,
                     out double duration, out double effectiveCadence, out double cycleDuration))
             {
@@ -10583,14 +10692,21 @@ namespace Parsek
         /// looping, period grew past duration, or the committed list shrank). Threads a per-frame
         /// spawn counter so a burst of newly-relaunching cycles is throttled exactly like the flight
         /// engine. Called from both <see cref="UpdateFlightMapGhostLifecycle"/> and
-        /// <see cref="UpdateTrackingStationGhostLifecycle"/>. With the gate OFF nothing here runs
-        /// (every recording fails <see cref="ShouldDriveOverlapPerInstance"/>) AND the leftover reaper
-        /// tears down any instances created while the gate was on, so the scene falls cleanly back to
-        /// the legacy one-per-recording path.
+        /// <see cref="UpdateTrackingStationGhostLifecycle"/>. <paramref name="loopUnits"/> is the
+        /// per-frame <see cref="GhostPlaybackEngine.CurrentLoopUnits"/> the scene drivers already hold
+        /// (null-coalesced to Empty), so a Mission-tab loop (source b) drives the per-instance path
+        /// even when <c>rec.LoopPlayback</c> is false. With the gate OFF nothing here runs (every
+        /// recording fails <see cref="ShouldDriveOverlapPerInstance"/>) AND the leftover reaper tears
+        /// down any instances created while the gate was on, so the scene falls cleanly back to the
+        /// legacy one-per-recording path.
         /// </summary>
         internal static void RunOverlapPerInstanceSweep(
-            double currentUT, IReadOnlyList<Recording> committed)
+            double currentUT, IReadOnlyList<Recording> committed,
+            GhostPlaybackLogic.LoopUnitSet loopUnits)
         {
+            if (loopUnits == null)
+                loopUnits = GhostPlaybackLogic.LoopUnitSet.Empty;
+
             // Snapshot the set of indices that currently have any per-instance vessel, so we can
             // reap the ones that should no longer be driven per-instance after the create pass below.
             HashSet<int> indicesWithInstances = null;
@@ -10605,12 +10721,22 @@ namespace Parsek
             HashSet<int> drivenThisFrame = null;
             if (committed != null)
             {
+                bool gateOn = IsOverlapPerInstanceGateOn();
                 for (int i = 0; i < committed.Count; i++)
                 {
                     var rec = committed[i];
-                    if (!ShouldDriveOverlapPerInstance(rec, i, committed))
+                    bool shouldDrive = ShouldDriveOverlapPerInstance(rec, i, committed, loopUnits);
+
+                    // GATE-DECISION TRACE (the blind spot that cost us a playtest): one rate-limited
+                    // line PER committed recording explaining the verdict, BEFORE the continue. A
+                    // re-fly Mission member shows isMember=true unitOverlaps=true even when
+                    // rec.LoopPlayback=false, so a "one icon instead of N" report is diagnosable from
+                    // the log alone.
+                    LogOverlapGateDecision(i, rec, committed, loopUnits, gateOn, shouldDrive);
+
+                    if (!shouldDrive)
                         continue;
-                    EnsureOverlapInstances(i, rec, currentUT, committed, ref frameSpawnCount);
+                    EnsureOverlapInstances(i, rec, currentUT, committed, loopUnits, ref frameSpawnCount);
                     if (drivenThisFrame == null) drivenThisFrame = new HashSet<int>();
                     drivenThisFrame.Add(i);
                 }
@@ -10629,6 +10755,82 @@ namespace Parsek
                     DestroyAllOverlapInstancesForRecording(idx, "overlap-no-longer-per-instance");
                 }
             }
+        }
+
+        /// <summary>
+        /// Per-recording gate-decision trace (rate-limited, per-index key). Surfaces every input to the
+        /// overlap verdict so a "one icon instead of N" report is diagnosable from the log WITHOUT a
+        /// rebuild: the director-drive gate, the standalone source (a) inputs (rec.LoopPlayback +
+        /// IsOverlapLoop result), the Mission source (b) inputs (isMember / overlapCadence / span /
+        /// unitOverlaps), the resolved schedule tuple (scheduleStart / duration / effectiveCadence), and
+        /// the final ShouldDriveOverlapPerInstance verdict + the live cycle window when driven. Reuses
+        /// the same pure resolvers the verdict uses, so the log can never disagree with the decision.
+        /// Unity-free (reads only the pure resolvers + the test-overridable <c>CurrentUTNow</c>), so the
+        /// xUnit log-assertion test can drive it directly.
+        /// </summary>
+        internal static void LogOverlapGateDecision(
+            int recIdx, Recording rec, IReadOnlyList<Recording> committed,
+            GhostPlaybackLogic.LoopUnitSet loopUnits, bool gateOn, bool shouldDrive)
+        {
+            // Source (a) inputs.
+            bool recLoopPlayback = rec != null && rec.LoopPlayback;
+            double autoDuration = rec != null && GhostPlaybackEngine.ShouldLoopPlayback(rec)
+                ? GhostPlaybackEngine.EffectiveLoopDuration(rec) : double.NaN;
+            double autoInterval = double.NaN;
+            bool autoOverlap = false;
+            if (recLoopPlayback && !double.IsNaN(autoDuration) && autoDuration > LoopTiming.MinLoopDurationSeconds)
+            {
+                autoInterval = ResolveOverlapLoopIntervalSeconds(rec, recIdx, committed);
+                autoOverlap = GhostPlaybackLogic.IsOverlapLoop(autoInterval, autoDuration);
+            }
+
+            // Source (b) inputs.
+            bool isMember = loopUnits != null
+                && loopUnits.TryGetUnitForMember(recIdx, out GhostPlaybackLogic.LoopUnit unit);
+            double overlapCadence = double.NaN;
+            double span = double.NaN;
+            bool unitOverlaps = false;
+            if (isMember)
+            {
+                loopUnits.TryGetUnitForMember(recIdx, out unit);
+                overlapCadence = unit.OverlapCadenceSeconds;
+                span = unit.SpanEndUT - unit.SpanStartUT;
+                unitOverlaps = GhostPlaybackLogic.UnitMemberOverlaps(unit);
+            }
+
+            // Resolved schedule tuple (whichever source won), + the live cycle window when driven.
+            string scheduleStr = "(none)";
+            string cycleWindowStr = "(not-driven)";
+            if (ResolveOverlapSchedule(
+                    rec, recIdx, committed, loopUnits,
+                    out _, out double scheduleStartUT,
+                    out double duration, out double effectiveCadence, out _))
+            {
+                scheduleStr = string.Format(ic,
+                    "scheduleStart={0:F1} duration={1:F1} effectiveCadence={2:F1}",
+                    scheduleStartUT, duration, effectiveCadence);
+                if (shouldDrive)
+                {
+                    OverlapCyclesForTesting(rec, recIdx, committed, loopUnits, CurrentUTNow(),
+                        out long firstCycle, out long lastCycle);
+                    cycleWindowStr = string.Format(ic,
+                        "cycles=[{0}..{1}] liveNow={2}", firstCycle, lastCycle,
+                        GetOverlapInstanceCount(recIdx));
+                }
+            }
+
+            ParsekLog.VerboseRateLimited(Tag,
+                "overlap-gate-decision-" + recIdx.ToString(ic),
+                string.Format(ic,
+                    "Overlap gate decision rec=#{0} \"{1}\": directorDrive={2} | "
+                    + "(a) loopPlayback={3} autoIsOverlapLoop={4} | "
+                    + "(b) isMember={5} overlapCadence={6:F1} span={7:F1} unitOverlaps={8} | "
+                    + "{9} | verdict shouldDrive={10} {11}",
+                    recIdx, rec?.VesselName ?? "(null)", gateOn,
+                    recLoopPlayback, autoOverlap,
+                    isMember, overlapCadence, span, unitOverlaps,
+                    scheduleStr, shouldDrive, cycleWindowStr),
+                3.0);
         }
 
         /// <summary>
@@ -10877,13 +11079,14 @@ namespace Parsek
         /// or currentUT precedes the schedule start.
         /// </summary>
         internal static void OverlapCyclesForTesting(
-            Recording rec, int recIdx, IReadOnlyList<Recording> committed, double currentUT,
+            Recording rec, int recIdx, IReadOnlyList<Recording> committed,
+            GhostPlaybackLogic.LoopUnitSet loopUnits, double currentUT,
             out long firstCycle, out long lastCycle)
         {
             firstCycle = 0;
             lastCycle = -1;
             if (!ResolveOverlapSchedule(
-                    rec, recIdx, committed,
+                    rec, recIdx, committed, loopUnits,
                     out _, out double scheduleStartUT,
                     out double duration, out double effectiveCadence, out _))
                 return;
@@ -10985,7 +11188,7 @@ namespace Parsek
             // Runs in the always-runs section so cycles relaunch/expire promptly. Resolves the live
             // committed list here (the rate-limited section below resolves its own copy after the
             // gate; the overlap path must run every frame).
-            RunOverlapPerInstanceSweep(currentUT, RecordingStore.CommittedRecordings);
+            RunOverlapPerInstanceSweep(currentUT, RecordingStore.CommittedRecordings, loopUnits);
 
             // 2. Map-orbit reseed for existing ProtoVessels. Rate-limited to the real-time timer, BUT
             // warp-aware: under time warp the playback head sprints through short segments (e.g. the many
@@ -11036,7 +11239,7 @@ namespace Parsek
                     // (RunOverlapPerInstanceSweep, run earlier this frame). Skip the legacy
                     // single-instance deferred create for them so there is no double-management.
                     if (committedForOverlapSkip != null && idx >= 0 && idx < committedForOverlapSkip.Count
-                        && ShouldDriveOverlapPerInstance(committedForOverlapSkip[idx], idx, committedForOverlapSkip))
+                        && ShouldDriveOverlapPerInstance(committedForOverlapSkip[idx], idx, committedForOverlapSkip, loopUnits))
                         continue;
 
                     // Loop-mapped sample UT for this member (effUT == currentUT off the loop path).
@@ -11222,7 +11425,7 @@ namespace Parsek
                 if (!rec.HasOrbitSegments) continue;
 
                 // Slice (i): overlap recordings are reseeded by the per-instance sweep, not here.
-                if (ShouldDriveOverlapPerInstance(rec, idx, committed))
+                if (ShouldDriveOverlapPerInstance(rec, idx, committed, loopUnits))
                     continue;
 
                 // Loop-mapped sample UT + live-frame epoch shift (effUT == currentUT, shift 0 off
@@ -11499,7 +11702,7 @@ namespace Parsek
 
                     // Slice (i): overlap recordings are driven by the per-instance sweep, not here.
                     if (committed != null && idx >= 0 && idx < committed.Count
-                        && ShouldDriveOverlapPerInstance(committed[idx], idx, committed))
+                        && ShouldDriveOverlapPerInstance(committed[idx], idx, committed, loopUnits))
                         continue;
 
                     if (!flightStateVectorCachedIndices.ContainsKey(idx))
@@ -11838,12 +12041,12 @@ namespace Parsek
             {
                 var committedForOverlap = RecordingStore.CommittedRecordings;
                 if (committedForOverlap != null && evt.Index >= 0 && evt.Index < committedForOverlap.Count
-                    && ShouldDriveOverlapPerInstance(committedForOverlap[evt.Index], evt.Index, committedForOverlap))
+                    && ShouldDriveOverlapPerInstance(committedForOverlap[evt.Index], evt.Index, committedForOverlap, loopUnits))
                 {
                     ParsekLog.Verbose("Policy",
                         string.Format(CultureInfo.InvariantCulture,
                             "Ghost map for #{0} \"{1}\" deferred to per-instance overlap sweep " +
-                            "(looped overlap recording, director-drive on)",
+                            "(looped overlap recording / Mission-unit overlap member, director-drive on)",
                             evt.Index, evt.Trajectory.VesselName ?? "(null)"));
                     return;
                 }

--- a/Source/Parsek/InGameTests/ExtendedRuntimeTests.cs
+++ b/Source/Parsek/InGameTests/ExtendedRuntimeTests.cs
@@ -99,6 +99,113 @@ namespace Parsek.InGameTests
         }
 
         [InGameTest(Category = "GhostLifecycle", Scene = GameScenes.FLIGHT,
+            Description = "Per-instance overlap map vessel count matches flight overlap ghost count + 1 (capped)")]
+        public void OverlapMapInstanceCountMatchesFlight()
+        {
+            var flight = ParsekFlight.Instance;
+            if (flight == null) InGameAssert.Skip("No ParsekFlight instance");
+
+            // Slice (i) requires the director drive ON; off the gate the per-instance path is
+            // unreachable and the map stays one-per-recording (nothing to assert here).
+            if (ParsekSettings.Current == null || !ParsekSettings.Current.mapRenderDirectorDrive)
+                InGameAssert.Skip("mapRenderDirectorDrive off — per-instance overlap path inactive");
+
+            int cap = GhostPlayback.MaxOverlapGhostsPerRecording;
+            var ghostGOs = flight.Engine.GetGhostGameObjects();
+            int checkedRecordings = 0;
+            int mismatches = 0;
+
+            foreach (var kvp in ghostGOs)
+            {
+                int recIdx = kvp.Key;
+                if (!flight.Engine.TryGetOverlapGhosts(recIdx, out var overlaps) || overlaps == null)
+                    continue;
+
+                // Flight: primary ghost (ghostStates[recIdx]) + the staggered overlap list = N meshes.
+                int flightInstances = overlaps.Count + 1;
+                int expected = System.Math.Min(flightInstances, cap);
+                int mapInstances = GhostMapPresence.GetOverlapInstanceCount(recIdx);
+
+                checkedRecordings++;
+                // Allow a +/-1 transient: the map sweep is throttled (MaxSpawnsPerFrame) so a brand-new
+                // cycle can be one frame behind the flight mesh; never above the cap.
+                if (mapInstances > cap || System.Math.Abs(mapInstances - expected) > 1)
+                {
+                    mismatches++;
+                    ParsekLog.Warn("TestRunner",
+                        $"Overlap map instance count mismatch rec=#{recIdx}: map={mapInstances} " +
+                        $"flightMeshes={flightInstances} expected~={expected} cap={cap}");
+                }
+            }
+
+            if (checkedRecordings == 0)
+                InGameAssert.Skip("No overlap recordings active");
+
+            ParsekLog.Info("TestRunner",
+                $"Overlap map instance count: {checkedRecordings - mismatches}/{checkedRecordings} recordings match flight (cap={cap})");
+            InGameAssert.AreEqual(0, mismatches,
+                $"{mismatches} overlap recording(s) have map instance count mismatched vs flight meshes");
+        }
+
+        [InGameTest(Category = "GhostLifecycle", Scene = GameScenes.TRACKSTATION,
+            Description = "TS per-instance overlap map vessel count matches the pure GetActiveCycles size")]
+        public void OverlapMapInstanceCountMatchesScheduleTS()
+        {
+            // The flight engine does not exist in the Tracking Station; the map per-instance count must
+            // equal the PURE recomputed active-cycle set for each overlap recording.
+            if (ParsekSettings.Current == null || !ParsekSettings.Current.mapRenderDirectorDrive)
+                InGameAssert.Skip("mapRenderDirectorDrive off — per-instance overlap path inactive");
+
+            var committed = RecordingStore.CommittedRecordings;
+            if (committed == null || committed.Count == 0)
+                InGameAssert.Skip("No committed recordings");
+
+            int cap = GhostPlayback.MaxOverlapGhostsPerRecording;
+            double currentUT = Planetarium.GetUniversalTime();
+            int checkedRecordings = 0;
+            int mismatches = 0;
+
+            for (int i = 0; i < committed.Count; i++)
+            {
+                var rec = committed[i];
+                if (!GhostMapPresence.IsOverlapRecording(rec, i, committed))
+                    continue;
+                if (!GhostMapPresence.ResolveOverlapSchedule(
+                        rec, i, committed,
+                        out _, out double scheduleStartUT,
+                        out double duration, out double effectiveCadence, out _))
+                    continue;
+                if (currentUT < scheduleStartUT)
+                    continue;
+
+                GhostPlaybackLogic.GetActiveCycles(
+                    currentUT, scheduleStartUT, scheduleStartUT + duration,
+                    effectiveCadence, cap, out long firstCycle, out long lastCycle);
+                int expected = (int)System.Math.Min(cap, lastCycle - firstCycle + 1);
+                int mapInstances = GhostMapPresence.GetOverlapInstanceCount(i);
+
+                checkedRecordings++;
+                // +/-MaxSpawnsPerFrame transient for newly-relaunching cycles; never above the cap.
+                if (mapInstances > cap
+                    || System.Math.Abs(mapInstances - expected) > GhostPlayback.MaxSpawnsPerFrame)
+                {
+                    mismatches++;
+                    ParsekLog.Warn("TestRunner",
+                        $"TS overlap map instance count mismatch rec=#{i}: map={mapInstances} " +
+                        $"expectedCycles={expected} cap={cap}");
+                }
+            }
+
+            if (checkedRecordings == 0)
+                InGameAssert.Skip("No overlap recordings active");
+
+            ParsekLog.Info("TestRunner",
+                $"TS overlap map instance count: {checkedRecordings - mismatches}/{checkedRecordings} recordings match GetActiveCycles (cap={cap})");
+            InGameAssert.AreEqual(0, mismatches,
+                $"{mismatches} overlap recording(s) have TS map instance count mismatched vs GetActiveCycles");
+        }
+
+        [InGameTest(Category = "GhostLifecycle", Scene = GameScenes.FLIGHT,
             Description = "Loop phase offsets are all finite (no NaN/Infinity)")]
         public void LoopPhaseOffsetsFinite()
         {

--- a/Source/Parsek/InGameTests/ExtendedRuntimeTests.cs
+++ b/Source/Parsek/InGameTests/ExtendedRuntimeTests.cs
@@ -147,6 +147,65 @@ namespace Parsek.InGameTests
                 $"{mismatches} overlap recording(s) have map instance count mismatched vs flight meshes");
         }
 
+        [InGameTest(Category = "GhostLifecycle", Scene = GameScenes.FLIGHT,
+            Description = "Mission-loop overlap member: map instance count matches flight overlap ghost count + 1 (capped)")]
+        public void OverlapMapInstanceCountMatchesFlightMissionLoop()
+        {
+            var flight = ParsekFlight.Instance;
+            if (flight == null) InGameAssert.Skip("No ParsekFlight instance");
+            if (ParsekSettings.Current == null || !ParsekSettings.Current.mapRenderDirectorDrive)
+                InGameAssert.Skip("mapRenderDirectorDrive off — per-instance overlap path inactive");
+
+            // Source (b): a looped Mission unit that self-overlaps. The flight engine renders the
+            // staggered instances through overlapGhosts[memberIdx] (the SAME pure cycle math the map
+            // per-instance sweep uses), so the map count must match the flight mesh count even though
+            // the member's own rec.LoopPlayback is false.
+            var loopUnits = flight.Engine.CurrentLoopUnits;
+            if (loopUnits == null || loopUnits.Count == 0)
+                InGameAssert.Skip("No Mission loop units active (load a looped Mission to exercise source b)");
+
+            var committed = RecordingStore.CommittedRecordings;
+            if (committed == null || committed.Count == 0)
+                InGameAssert.Skip("No committed recordings");
+
+            int cap = GhostPlayback.MaxOverlapGhostsPerRecording;
+            int checkedMembers = 0;
+            int mismatches = 0;
+
+            for (int i = 0; i < committed.Count; i++)
+            {
+                // Only Mission-unit overlap members (source b), not standalone loops (covered above).
+                if (!loopUnits.TryGetUnitForMember(i, out var unit)
+                    || !GhostPlaybackLogic.UnitMemberOverlaps(unit))
+                    continue;
+                if (!GhostMapPresence.IsOverlapRecording(committed[i], i, committed, loopUnits))
+                    continue;
+                if (!flight.Engine.TryGetOverlapGhosts(i, out var overlaps) || overlaps == null)
+                    continue;
+
+                int flightInstances = overlaps.Count + 1; // primary (newest) + staggered list
+                int expected = System.Math.Min(flightInstances, cap);
+                int mapInstances = GhostMapPresence.GetOverlapInstanceCount(i);
+
+                checkedMembers++;
+                if (mapInstances > cap || System.Math.Abs(mapInstances - expected) > 1)
+                {
+                    mismatches++;
+                    ParsekLog.Warn("TestRunner",
+                        $"Mission-loop overlap map instance count mismatch member=#{i}: map={mapInstances} " +
+                        $"flightMeshes={flightInstances} expected~={expected} cap={cap}");
+                }
+            }
+
+            if (checkedMembers == 0)
+                InGameAssert.Skip("No self-overlapping Mission loop members active");
+
+            ParsekLog.Info("TestRunner",
+                $"Mission-loop overlap map instance count: {checkedMembers - mismatches}/{checkedMembers} members match flight (cap={cap})");
+            InGameAssert.AreEqual(0, mismatches,
+                $"{mismatches} Mission-loop overlap member(s) have map instance count mismatched vs flight meshes");
+        }
+
         [InGameTest(Category = "GhostLifecycle", Scene = GameScenes.TRACKSTATION,
             Description = "TS per-instance overlap map vessel count matches the pure GetActiveCycles size")]
         public void OverlapMapInstanceCountMatchesScheduleTS()
@@ -160,6 +219,15 @@ namespace Parsek.InGameTests
             if (committed == null || committed.Count == 0)
                 InGameAssert.Skip("No committed recordings");
 
+            // Rebuild the TS span-clock loop-unit set exactly as ParsekTrackingStation.DriveMissionLoopUnits
+            // does, so a Mission-tab loop (source b) is recognized identically to the live scene.
+            double autoLoopIntervalSeconds = ParsekSettings.Current?.autoLoopIntervalSeconds
+                                             ?? LoopTiming.DefaultLoopIntervalSeconds;
+            var loopUnits = MissionLoopUnitBuilder.Build(
+                MissionStore.Missions, RecordingStore.CommittedTrees, committed,
+                autoLoopIntervalSeconds, FlightGlobalsBodyInfo.Instance,
+                ParsekSettings.Current?.TransitedBodyRotationMode ?? TransitedBodyRotationMode.Loose);
+
             int cap = GhostPlayback.MaxOverlapGhostsPerRecording;
             double currentUT = Planetarium.GetUniversalTime();
             int checkedRecordings = 0;
@@ -168,10 +236,10 @@ namespace Parsek.InGameTests
             for (int i = 0; i < committed.Count; i++)
             {
                 var rec = committed[i];
-                if (!GhostMapPresence.IsOverlapRecording(rec, i, committed))
+                if (!GhostMapPresence.IsOverlapRecording(rec, i, committed, loopUnits))
                     continue;
                 if (!GhostMapPresence.ResolveOverlapSchedule(
-                        rec, i, committed,
+                        rec, i, committed, loopUnits,
                         out _, out double scheduleStartUT,
                         out double duration, out double effectiveCadence, out _))
                     continue;

--- a/docs/dev/plans/maprender-overlap-per-instance.md
+++ b/docs/dev/plans/maprender-overlap-per-instance.md
@@ -1,0 +1,110 @@
+# Overlap rendering 2b - one map icon per live overlap instance
+
+*Part of the map/TS render cutover (`docs/dev/plans/maprender-rewrite-status.md`). Integration #2 has two
+parts: 2a (PR #1051, DONE) removed the conservative `SkipOverlap` skip so the Director processes an
+overlap member and renders ONE ghost at the newest cycle. 2b (this doc) makes the map render ONE icon +
+orbit line + polyline PER LIVE OVERLAP INSTANCE so the map matches flight reality.*
+
+## Why (decided 2026-06-06)
+
+A looped mission whose loop period is shorter than its length relaunches before the previous replay
+finishes, so several staggered replays run at once (overlap). In FLIGHT there are N meshes; on the MAP
+today there is exactly ONE icon (the newest/selected cycle). The maintainer's call: "render a single
+icon on the polyline and keep it unique until the loop run ends... that's lying to the player. Render an
+icon for every vessel that launches, even when overlapping, so the player sees the overlap in map view
+and it reflects rendering reality from flight view. Make it accurate."
+
+So the map must show N icons (one per live overlap instance), each at its own cycle's phase, with its own
+trajectory.
+
+## The architectural fact: N icons require N ProtoVessels
+
+The on-map icon is the stock orbit-driver's icon, one per `Vessel.persistentId` (`GhostOrbitLinePatch`
+keys on `__instance.vessel.persistentId`). There is no "draw N icons against one vessel" path in KSP. So
+N icons means N ProtoVessels. Today `GhostMapPresence` is strictly one-ProtoVessel-per-recording
+(`vesselsByRecordingIndex`, `ghostMapVesselPids`); 2b makes it N-per-overlapping-recording.
+
+## Mirror the flight engine (do NOT reinvent the math)
+
+The flight engine already computes everything 2b needs - reuse it:
+- `GhostPlaybackEngine.overlapGhosts` = `Dictionary<int, List<GhostPlaybackState>>` keyed by recording
+  index (the staggered instances; the primary `ghostStates[i]` is the newest cycle).
+- `GhostPlaybackLogic.GetActiveCycles` -> `[firstActiveCycle, lastActiveCycle]` (the simultaneously-live
+  cycle range; `firstCycle` clamped to `lastCycle - cap + 1`).
+- `GhostPlaybackLogic.ComputeOverlapCyclePlaybackUT(...)` -> the per-instance playback UT (pure,
+  deterministic). The map's per-instance epoch shift = `currentUT - ComputeOverlapCyclePlaybackUT(...)`.
+- Stable per-instance identity = `(recordingIndex, cycleIndex)` (the flight `GhostPlaybackState.
+  loopCycleIndex`). Key the map's per-instance ProtoVessels / chains / polylines / markers on this.
+- Cap = `MaxOverlapGhostsPerRecording = 20` (cadence is already raised so `ceil(duration/cadence) <= cap`,
+  so the map inherits the bound for free; do not add a new cap).
+
+## Scope: FULL per-instance (not icon-only)
+
+Each instance gets its own orbit line + icon + non-orbital polyline + marker. Icon-only (N icons sharing
+one orbit line) is rejected: it is visibly wrong for non-orbital ascent/descent instances (an icon with
+no polyline under it), and the orbit line comes free with the per-instance ProtoVessel anyway. The cost
+driver (ProtoVessel count) is identical either way.
+
+## What is already per-instance-ready vs what must change
+
+Ready (keyed by pid, not recording index): the Director caches (`priorIntentByPid`, `chainByPid`,
+`seedByPid`, `tracedPathByPid`), `ChainAssembler.Build` / `GhostRenderChain` already carry a real
+`instanceKey` dimension (the map just hardcodes `0`), `vesselPidToRecordingId` is already many-pids->one-
+recId, the marker decision `ShouldDrawNonProtoMarkerForGhost(pid)` is per-pid. So once each instance is a
+distinct ProtoVessel with a distinct pid, the Director / seed patches / icon "just work" per-pid.
+
+Must become per-(recording, cycle): the presence store (`vesselsByRecordingIndex`), the create/destroy
+lifecycle funnel, `GetGhostVesselPidForRecording`, the polyline cache + active-leg sets + marker-hold
+(`polylineCache`, `activeLegRecordings`, `directorOwnedLegRecordings`, `lastGoodOnLine` - keyed by
+`RecordingId` today), and the polyline Driver's single-head-UT walk.
+
+## Slices
+
+- **(i) Map presence - N-per-overlapping-recording lifecycle [the bulk].** A per-instance store
+  (`(recIdx, cycle) -> Vessel`) alongside the existing one-per-recording store (for non-overlap).
+  `EnsureOverlapInstances(recIdx, traj, units, currentUT)`: call `GetActiveCycles`, create a ProtoVessel
+  per missing live cycle (each gets a fresh KSP-unique pid), destroy instances whose cycle < firstCycle,
+  store the per-instance epoch shift. Hook into both `UpdateFlightMapGhostLifecycle` and
+  `UpdateTrackingStationGhostLifecycle` behind the overlap-only gate. Throttle creates (mirror the flight
+  engine's `MaxSpawnsPerFrame`). Extend the scene-switch teardown to clear the new store.
+- **(ii) Director per-instance enumeration + instanceKey.** `scene.GhostPids` already yields every
+  instance pid once they are real ProtoVessels, so `RunFrame` enumerates them unchanged. Feed
+  `ChainAssembler.Build` the instance's `cycle` as `instanceKey` instead of `0` (resolve pid->cycle via
+  the per-instance store). Per-pid seed/epoch-shift flow through the existing pid-keyed paths.
+- **(iii) Polyline + marker per-instance.** Re-key `polylineCache` (geometry shared by RecordingId; only
+  the head-UT / active-leg / hold STATE goes per-(RecordingId, cycle)), `activeLegRecordings` /
+  `directorOwnedLegRecordings`, `lastGoodOnLine`. The Driver's LateUpdate walk enumerates the recording's
+  live cycles and draws one leg per cycle at each `ComputeOverlapCyclePlaybackUT`. Preserve the #1050
+  timing invariants (decide+publish at -50, draw at `onPreCull`).
+
+## Efficiency + safety
+
+- **Overlap-ONLY gate:** gate the per-instance path on `units.TryGetUnitForMember(i,..) && cadence < span`
+  (the predicate `ClassifyScope` already computes). Non-overlapping recordings (the vast majority) stay
+  EXACTLY one-per-recording: zero new objects, zero new cost.
+- **Bounded N** = `min(ceil(duration/cadence), 20)`; typical 3-6.
+- **Biggest risk:** ProtoVessel create/destroy churn under time warp (cycles relaunching fast ->
+  `pv.Load`/`Die` storms). Mitigate: reuse the engine's computed cycles, throttle creates, cap at 20.
+- **Gate-OFF** stays legacy one-per-recording. Faithful + non-overlap members unaffected.
+
+## Tests + validation
+
+- xUnit pure: "map instance set == engine cycle set" equivalence against `overlapGhosts`; per-instance
+  key/signature uniqueness; gate-off / non-overlap one-per-recording assertion.
+- In-game (`ExtendedRuntimeTests`): map instance count == flight `overlapGhosts[i].Count + 1`, capped at 20.
+- Maintainer in-game: an overlapping launch-to-orbit / short mission (loop period < length), map / TS
+  view - see N icons matching the N flight ghosts 1:1, each on its own orbit + polyline, appearing /
+  expiring as cycles relaunch; gate-off -> byte-identical one-per-recording.
+
+## Size + sequencing
+
+LARGE (multi-PR, ~3 slices). Stacks on 2a (PR #1051). The hard math is done (flight engine); the work is
+mechanical breadth (re-key ~12 maps recording->instance) plus the one genuinely new piece, the
+per-instance ProtoVessel lifecycle (slice i). Land the slices in order, each behind the overlap-only gate
+and in-game gated.
+
+## Adjacent follow-up (separate, not 2b)
+
+The #1051 validation log surfaced two SUPPRESSED `TS shadow RunFrame threw ArgumentNullException` (caught
+by the try/catch, in the Tracking Station, not in the overlap window). Pre-existing, harmless at runtime,
+but a swallowed NRE in the TS shadow path worth a small separate investigation.

--- a/docs/dev/plans/maprender-overlap-per-instance.md
+++ b/docs/dev/plans/maprender-overlap-per-instance.md
@@ -71,11 +71,20 @@ lifecycle funnel, `GetGhostVesselPidForRecording`, the polyline cache + active-l
   instance pid once they are real ProtoVessels, so `RunFrame` enumerates them unchanged. Feed
   `ChainAssembler.Build` the instance's `cycle` as `instanceKey` instead of `0` (resolve pid->cycle via
   the per-instance store). Per-pid seed/epoch-shift flow through the existing pid-keyed paths.
-- **(iii) Polyline + marker per-instance.** Re-key `polylineCache` (geometry shared by RecordingId; only
-  the head-UT / active-leg / hold STATE goes per-(RecordingId, cycle)), `activeLegRecordings` /
-  `directorOwnedLegRecordings`, `lastGoodOnLine`. The Driver's LateUpdate walk enumerates the recording's
-  live cycles and draws one leg per cycle at each `ComputeOverlapCyclePlaybackUT`. Preserve the #1050
-  timing invariants (decide+publish at -50, draw at `onPreCull`).
+- **(iii) ONE shared polyline + N markers riding it (NOT N polylines) - maintainer steer 2026-06-06.**
+  The recorded non-orbital geometry (ascent / descent / burn) is IDENTICAL for all N overlap instances
+  (same recorded path, replayed at staggered times), so drawing N overlapping polylines would be
+  redundant + costly ("do not draw 100 overlapping polylines"). Keep the polyline SINGLE per recording
+  (the `polylineCache` geometry is already keyed by RecordingId - one draw, as slice (i) already does),
+  and instead draw N MARKERS that RIDE that single shared polyline, each at its instance's current
+  position (`ComputeOverlapCyclePlaybackUT(cycle)` head along the leg). So slice (iii) = the MARKER path
+  becomes per-instance (N labels on the one shared line), NOT the polyline geometry. Today the marker
+  rides via `lastGoodOnLine` / `GetNewestOverlapInstancePidForRecording` (newest instance only); slice
+  (iii) makes ALL live instances' markers ride the single drawn leg at their own head positions. Do NOT
+  re-key `polylineCache` geometry or draw one leg per cycle. (Same logic for the ORBIT phase is already
+  satisfied by slice (i): the N ProtoVessels' orbit lines are identical and overlap exactly, so the
+  player sees one orbit line with N icons - no extra work.) Preserve the #1050 timing invariants
+  (decide+publish at -50, draw at `onPreCull`).
 
 ## Efficiency + safety
 

--- a/docs/dev/plans/maprender-rewrite-status.md
+++ b/docs/dev/plans/maprender-rewrite-status.md
@@ -361,23 +361,37 @@ reconciler for decision-vs-old-truth parity, and resolve the in-game probes befo
     + tracing-on: re-aim ghost's icon rides its heliocentric line (`angleIconVsOrbitEff` -> ~0, was
     >45deg), `decision-vs-truth` parity, trim-gap frames stay hidden, no SOI-seam blink; toggle gate-off
     -> byte-identical.
-  - **Integration 2 - overlap rendering (DONE, awaiting in-game gate).** No per-instance MAP model exists
-    (`GhostMapPresence` is one-vessel-per-recording); an overlapping mission renders as ONE ProtoVessel +
-    one polyline head at the selected cycle. Fix: removed the conservative `SkipOverlap` early-skip in
-    `ShadowRenderDriver.RunFrame` so an overlap member flows through the normal assemble->sample->decide->
-    seed/stamp path. The sampler-parity precondition is CONFIRMED (clean review): `ChainSampler.Sample`
-    maps live->assembled UT via the SAME `GhostPlaybackLogic.ResolveTrackingStationSampleUT` the legacy
-    single-head uses, driven by `unit.CadenceSeconds` (span-raised single-instance), NOT
-    `unit.OverlapCadenceSeconds` (the short relaunch cadence consumed only by the flight MESH engine), so
-    the Director lands on the SAME selected-cycle head-UT as legacy. `ShadowScope.SkipOverlap` enum +
-    `ClassifyScope`/`ClassifyOverlapForMember` retained (classifier + its tests stay; production just stops
-    skipping; counter renamed `skipOverlap`->`overlapShadowed`). Gate-OFF byte-identical (skip lived only
-    in the gate/tracing-gated `RunFrame`; the new seed/stamp is consumed only under `IsDirectorDriveActive`
-    /`IsDirectorTracedPathActive`). No per-instance model / InstanceKey added. Build clean; suite green
-    (13477); clean review SHIP. **In-game gate:** a LAUNCH-TO-ORBIT mission looped with period < length so
-    it overlaps (interplanetary can't - pinned to its transfer window), map view + tracing on: the single
-    overlap map icon rides its line at the selected cycle, hides cleanly in inter-cycle gaps; gate-off
-    byte-identical. (The N staggered instances are flight-MESH-only; the map shows one at the live cycle.)
+  - **Integration 2 - overlap rendering. TWO parts: 2a FOUNDATION (DONE, PR #1051), 2b PER-INSTANCE
+    (planned, multi-PR - the real goal).** Full plan for 2b: `docs/dev/plans/maprender-overlap-per-instance.md`.
+    - **2a (DONE, PR #1051, validated):** removed the conservative `SkipOverlap` early-skip in
+      `ShadowRenderDriver.RunFrame` so an overlap member flows through the normal assemble->sample->decide->
+      seed/stamp path instead of falling back to legacy. It renders ONE ghost at the newest (selected)
+      cycle. Sampler-parity CONFIRMED (clean review + in-game): `ChainSampler.Sample` maps live->assembled
+      UT via the SAME `GhostPlaybackLogic.ResolveTrackingStationSampleUT` the legacy single-head uses,
+      driven by `unit.CadenceSeconds` (span-raised single-instance), NOT `unit.OverlapCadenceSeconds` (the
+      short relaunch cadence consumed only by the flight MESH engine), so the Director lands on the same
+      selected-cycle head-UT as legacy. `ShadowScope.SkipOverlap` enum + `ClassifyScope`/
+      `ClassifyOverlapForMember` retained (classifier + tests stay; production stops skipping; counter
+      `skipOverlap`->`overlapShadowed`). Gate-OFF byte-identical. Build clean; suite green (13477).
+      In-game validated 2026-06-06 (flight-map, save s16, "Kerbal X" self-overlap): single icon rode its
+      line, 1112/1112 `drawn-non-proto`, no blink, clean teardown of 17 live overlap meshes / 8 recordings.
+    - **2b - PER-INSTANCE (decided 2026-06-06; the accurate end state):** 2a's single icon MISREPRESENTS
+      reality - flight shows N staggered overlap meshes, the map shows ONE. The goal (maintainer's call:
+      "render an icon for every ghost, make it accurate") is ONE map icon + orbit line + polyline PER LIVE
+      overlap INSTANCE, so the map matches flight. **This is a real per-instance build-out, multi-PR**
+      (comparable to 8c/8d), because N icons require N ProtoVessels (the icon is the stock orbit-driver's
+      icon, one per vessel) and the whole map layer (~12 keyed maps + the presence lifecycle) is
+      one-per-recording and must become per-(recording, cycleIndex). The flight engine ALREADY has the
+      per-instance model to MIRROR (`overlapGhosts`, `GhostPlaybackLogic.GetActiveCycles` /
+      `ComputeOverlapCyclePlaybackUT`, the `(recording, cycleIndex)` identity, cap
+      `MaxOverlapGhostsPerRecording=20`) - reuse it, do not reinvent. FULL per-instance (not icon-only:
+      N icons on one shared line is visibly wrong for non-orbital ascent/descent instances). Stacks on 2a
+      (instance 0 = newest cycle = today's single ghost). Slices: (i) map presence N-per-overlapping-
+      recording lifecycle [the bulk], (ii) Director per-instance enumeration + the existing `instanceKey`
+      wiring (caches are already pid-keyed), (iii) polyline + marker per-instance. Efficiency: overlap-ONLY
+      gate so non-overlap recordings stay EXACTLY one-per-recording (zero new cost); reuse the engine's
+      cycles; throttle per-instance ProtoVessel create/destroy (the biggest risk = warp-time cycle churn);
+      cap at 20. Gate-OFF stays legacy one-per-recording.
   - **Rendering polish - polyline + marker pan-stability (DONE, gated-neutral).** Fixed map polylines +
     yellow label markers jittering / flickering when panning the camera (pre-existing, NOT from the
     cutover). Root cause: the polyline draw ran at `[DefaultExecutionOrder(-50)]`, BEFORE the map camera

--- a/docs/dev/plans/maprender-rewrite-status.md
+++ b/docs/dev/plans/maprender-rewrite-status.md
@@ -400,7 +400,21 @@ reconciler for decision-vs-old-truth parity, and resolve the in-game probes befo
       the single-slot `CreateGhostVesselFromSource` funnel); schedule via the PURE
       `GhostPlaybackLogic.TryResolveAutoLoopLaunchSchedule` (works in flight AND TS); `GetActiveCycles` +
       `ComputeOverlapCyclePlaybackUT` for the live-cycle set + per-instance epoch shift; gate =
-      `mapRenderDirectorDrive && IsOverlapLoop(interval,duration)`. Each instance's icon phase comes from
+      `mapRenderDirectorDrive` AND (per-recording auto-loop `IsOverlapLoop` OR Mission-unit self-overlap
+      `loopUnits.TryGetUnitForMember && UnitMemberOverlaps`). **Mission-unit fix (playtest-caught
+      2026-06-06):** the maintainer loops via the Missions tab (a `LoopUnit` self-overlap, `Mission.
+      LoopPlayback`, NOT `rec.LoopPlayback`), so the original per-recording-only gate rejected it -> one
+      icon. The fix threads `loopUnits` through the sweep and unions the gate/schedule with the
+      Mission-unit source, sourcing `(scheduleStart, playbackStart, duration, cadence)` from the `LoopUnit`
+      exactly as the flight engine does (`GhostPlaybackEngine.cs:2163-2183` + the cadence re-clamp), so the
+      map cycles match the flight meshes 1:1. Re-aim / zero-drift units are non-overlapping by construction
+      (`UnitMemberOverlaps` false), so they stay single-ghost. A rate-limited per-recIdx
+      `overlap-gate-decision` log line now surfaces the gate inputs (directorDrive / loopPlayback / isMember
+      / unitOverlaps / schedule / cycle window) so a re-fly is self-diagnosing. **NOTE:**
+      `mapRenderDirectorDrive` is a per-save KSP custom param; an old save persisted `false` and KSP
+      restores it on load (the external override only re-asserts once toggled via the Parsek Settings
+      window), so the maintainer must toggle the setting ON for the save before validating - not a bug.
+      Each instance's icon phase comes from
       its per-pid `ghostOrbitEpochShift` (so slice i ships WITHOUT slice ii's instanceKey, which stays 0).
       `GetGhostVesselPidForRecording`/`HasGhostVesselForRecording` fall through to the newest-cycle
       instance so watch / TS-Fly / UI / polyline-owner readers don't get pid 0. Legacy create/reseed/

--- a/docs/dev/plans/maprender-rewrite-status.md
+++ b/docs/dev/plans/maprender-rewrite-status.md
@@ -386,12 +386,34 @@ reconciler for decision-vs-old-truth parity, and resolve the in-game probes befo
       `ComputeOverlapCyclePlaybackUT`, the `(recording, cycleIndex)` identity, cap
       `MaxOverlapGhostsPerRecording=20`) - reuse it, do not reinvent. FULL per-instance (not icon-only:
       N icons on one shared line is visibly wrong for non-orbital ascent/descent instances). Stacks on 2a
-      (instance 0 = newest cycle = today's single ghost). Slices: (i) map presence N-per-overlapping-
-      recording lifecycle [the bulk], (ii) Director per-instance enumeration + the existing `instanceKey`
-      wiring (caches are already pid-keyed), (iii) polyline + marker per-instance. Efficiency: overlap-ONLY
-      gate so non-overlap recordings stay EXACTLY one-per-recording (zero new cost); reuse the engine's
-      cycles; throttle per-instance ProtoVessel create/destroy (the biggest risk = warp-time cycle churn);
-      cap at 20. Gate-OFF stays legacy one-per-recording.
+      (instance 0 = newest cycle = today's single ghost). Slices: **(i) map presence N-per-overlapping-
+      recording lifecycle [the bulk] - DONE (awaiting in-game gate)**, (ii) Director per-instance
+      enumeration + the existing `instanceKey` wiring (caches are already pid-keyed), (iii) polyline +
+      marker per-instance. Efficiency: overlap-ONLY gate so non-overlap recordings stay EXACTLY
+      one-per-recording (zero new cost); reuse the engine's cycles; throttle per-instance ProtoVessel
+      create/destroy (the biggest risk = warp-time cycle churn); cap at 20. Gate-OFF stays legacy
+      one-per-recording.
+    - **Slice (i) DONE (this branch, awaiting in-game gate):** mirrors the proven `ParsekKSC`
+      per-instance overlap model (which already renders N overlap ghosts on the KSC map with NO flight
+      engine). New `overlapInstanceVessels : Dictionary<(recIdx,cycle),Vessel>` + `EnsureOverlapInstances`
+      / `RunOverlapPerInstanceSweep` / `CreateOverlapInstanceVessel` (its OWN per-instance create path, not
+      the single-slot `CreateGhostVesselFromSource` funnel); schedule via the PURE
+      `GhostPlaybackLogic.TryResolveAutoLoopLaunchSchedule` (works in flight AND TS); `GetActiveCycles` +
+      `ComputeOverlapCyclePlaybackUT` for the live-cycle set + per-instance epoch shift; gate =
+      `mapRenderDirectorDrive && IsOverlapLoop(interval,duration)`. Each instance's icon phase comes from
+      its per-pid `ghostOrbitEpochShift` (so slice i ships WITHOUT slice ii's instanceKey, which stays 0).
+      `GetGhostVesselPidForRecording`/`HasGhostVesselForRecording` fall through to the newest-cycle
+      instance so watch / TS-Fly / UI / polyline-owner readers don't get pid 0. Legacy create/reseed/
+      state-vector passes skip overlap indices (sweep is sole authority). Teardown + the two leak-skip
+      early-returns + all 3 reset sites extended; `RemoveOverlapInstance` cleans every per-pid map.
+      State-vector overlap instances mirror the per-index state-vector contract (seed at live UT, clear
+      the segment-drive dicts) - review-caught fix. Two clean reviews (plan + code) SHIP. Build clean;
+      suite green (13498). **In-game gate:** an ORBITAL launch-to-LOW-orbit mission looped with period <
+      length, map view, run past a relaunch: N icons on N orbit lines, one per live overlap instance,
+      matching the N flight ghosts (appearing/expiring as they relaunch); gate-off / non-overlap
+      byte-identical one-per-recording. (Use an ORBITAL mission: the per-instance ASCENT polyline is slice
+      iii, so in slice i the ascent line stays single per recording - the icons-on-orbit-lines are the
+      deliverable.)
   - **Rendering polish - polyline + marker pan-stability (DONE, gated-neutral).** Fixed map polylines +
     yellow label markers jittering / flickering when panning the camera (pre-existing, NOT from the
     cutover). Root cause: the polyline draw ran at `[DefaultExecutionOrder(-50)]`, BEFORE the map camera


### PR DESCRIPTION
## Overlap 2b, slice (i) - per-instance map presence lifecycle

Renders ONE map ProtoVessel per LIVE overlap instance, so the map shows N icons matching the N flight overlap meshes (instead of one-per-recording at the newest cycle). This is the bulk of the per-instance feature (2b); slices (ii) instanceKey + (iii) per-instance polyline/marker follow. Runs UNDER `mapRenderDirectorDrive`; gate-off + non-overlap stay byte-identical one-per-recording. Full plan: `docs/dev/plans/maprender-overlap-per-instance.md`.

> Stacked on #1052 (docs). Merge #1052 first and this narrows to the code; or merge this and it brings the doc commit too (same content).

### Approach: mirror the proven KSC model
`ParsekKSC.UpdateOverlapKsc` already renders N overlap ghosts on the KSC map with **no flight engine**. Slice (i) mirrors it, so the schedule resolves identically in flight and the Tracking Station (which has no flight engine).

### Change (all in `GhostMapPresence.cs`)
- New `overlapInstanceVessels : Dictionary<(int recIdx, long cycle), Vessel>` alongside the untouched one-per-recording `vesselsByRecordingIndex`.
- `EnsureOverlapInstances` / `RunOverlapPerInstanceSweep` / `CreateOverlapInstanceVessel` - its OWN per-instance create path (the single-slot `CreateGhostVesselFromSource` funnel early-returns the per-index vessel). Each instance is a fresh ProtoVessel with a KSP-minted unique pid, registered per-pid.
- Schedule via the PURE `GhostPlaybackLogic.TryResolveAutoLoopLaunchSchedule`; `GetActiveCycles` + `ComputeOverlapCyclePlaybackUT` give the live-cycle set + per-instance epoch shift.
- Gate = `mapRenderDirectorDrive` AND `GhostPlaybackLogic.IsOverlapLoop(interval, duration)` (covers standalone loops + Mission members).
- `GetGhostVesselPidForRecording` / `HasGhostVesselForRecording` fall through to the newest-cycle instance (so watch-camera / TS-Fly / UI marker / polyline-owner readers get the newest pid, not 0).
- Legacy create/reseed/state-vector passes skip overlap indices (the sweep is the sole authority); teardown + the two leak-skip early-returns + all 3 reset sites extended; `RemoveOverlapInstance` cleans every per-pid map.

### Independence (ships without slice ii)
Each instance's icon phase comes from its per-pid `ghostOrbitEpochShift` (the Director caches are per-pid; `chainByPid` has no cross-instance collision), so `ChainAssembler.Build` `instanceKey` stays `0`. Slice (ii) only matters once per-instance polyline/marker state (slice iii) needs keying.

### Review
Two clean-context reviews. Plan: SOUND WITH FIXES (all folded in - the KSC pure-schedule for TS, the newest-instance fallthrough, the own create path, the gate, the leak fixes). Code: SHIP WITH ONE FIX (applied) - state-vector overlap instances now mirror the per-index state-vector contract (seed at live UT, clear the segment-drive dicts) instead of seeding at the wrong phase.

### Tests + build
- Build clean. Full suite green: 13498 passed.
- Pure tests (`OverlapPerInstanceTests`, 24): cycle-set equivalence vs `GetActiveCycles`, the gate predicate, the create/destroy decision (`DecideOverlapInstanceChanges`). In-game tests (`ExtendedRuntimeTests`): flight count == `overlapGhosts[i].Count + 1` (cap 20); TS count == pure `GetActiveCycles` size.
- Gate-off + non-overlap byte-identical (the sweep short-circuits on the gate; non-overlap never enters it). `GrepAuditTests` green.

### In-game gate (please)
An **ORBITAL** launch-to-**low-orbit** mission looped with **period < length**, map view, run past a relaunch: **N icons on N orbit lines**, one per live overlap instance, matching the N flight ghosts (appearing/expiring as they relaunch). Toggle the gate off / a non-overlap recording -> byte-identical one-per-recording. Use an **orbital** mission specifically: the per-instance ASCENT polyline is slice (iii), so in slice (i) the ascent line stays single per recording - the icons-on-orbit-lines are the deliverable.

No CHANGELOG yet (the per-instance experience completes with slices ii/iii).