### PR TITLE
Fix Logistics tooltip-echo IMGUI control-count storm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ All notable changes to Parsek are documented here.
 - Fixed a looped re-aimed mission's map orbit icon sitting rotated far around the planet from its own orbit line (the icon was drawn at the live time while the line was time-shifted for the loop). A rebuilt map and Tracking-Station ghost render path, now on by default, drives each ghost's orbit line and icon from one source so the icon rides its line; you can turn it off in Settings (Map/TS director render drive) to use the old path.
 - Fixed map ghost trajectory lines (ascent, burn, transfer, descent) and their labels jittering or drifting when you pan the camera. The lines now draw against the committed camera view each frame and the labels hold their position on the line, so both stay glued in place during a pan.
 - Removed two spurious "Script error: OnLevelWasLoaded" messages printed to the log at startup. Two internal scene-load handlers collided with a deprecated Unity method name; renaming them clears the errors with no behavior change.
+- Fixed a continuous error spam in the log when hovering controls in the Logistics window. The bottom tooltip echo box drew a different number of UI controls when a tooltip was showing than when it was empty, which threw an IMGUI layout error every frame and aborted the rest of the window's draw; it now draws a fixed layout either way.
 
 ### UI
 

--- a/Source/Parsek.Tests/Logistics/LogisticsWindowUISendingButtonTests.cs
+++ b/Source/Parsek.Tests/Logistics/LogisticsWindowUISendingButtonTests.cs
@@ -289,10 +289,11 @@ namespace Parsek.Tests.Logistics
 
     /// <summary>
     /// Pins <see cref="LogisticsWindowUI.ResolveTooltipEcho"/>, the pure decision
-    /// (QW6) behind the bottom tooltip echo box: render the box only when a control
-    /// is hovered (GUI.tooltip non-empty), otherwise signal the zero-height
-    /// placeholder branch so the IMGUI control count stays stable. Unity-free, so
-    /// exercised directly.
+    /// (QW6) behind the bottom tooltip echo box: report whether a control is hovered
+    /// (GUI.tooltip non-empty) so the box renders boxed help text, or collapses to
+    /// zero height. The boolean drives the box's spacing / content / style only; the
+    /// control count emitted by DrawTooltipEchoBox is invariant across the IMGUI
+    /// Layout and Repaint passes. Unity-free, so exercised directly.
     /// </summary>
     public class LogisticsWindowUITooltipEchoTests
     {

--- a/Source/Parsek/InGameTests/LogisticsTooltipEchoImguiTest.cs
+++ b/Source/Parsek/InGameTests/LogisticsTooltipEchoImguiTest.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections;
+using UnityEngine;
+
+namespace Parsek.InGameTests
+{
+    /// <summary>
+    /// Live-IMGUI regression guard for the Logistics window bottom tooltip echo box.
+    /// The original QW6 echo block emitted a DIFFERENT number of GUILayout controls
+    /// between the Layout pass (GUI.tooltip empty: 1 control) and the Repaint pass
+    /// (GUI.tooltip populated: 2 controls). GUI.tooltip is empty during Layout and
+    /// only becomes populated during Repaint, so the count diverged and the trailing
+    /// Close button overran its layout group, throwing a continuous
+    /// "Getting control N's position in a group with only N controls when doing
+    /// repaint" exception on every hover.
+    ///
+    /// This cannot be caught by a headless unit test (it needs a real IMGUI
+    /// Layout+Repaint cycle), and the InGameTestRunner coroutine itself does not
+    /// reliably execute during OnGUI. So the test installs a tiny probe
+    /// MonoBehaviour whose OWN OnGUI runs on Unity's real event loop, feeds the real
+    /// <see cref="LogisticsWindowUI.DrawTooltipEchoBox"/> an empty tooltip during
+    /// Layout and a populated one during Repaint (the exact field condition), draws
+    /// a trailing button after it (mirroring the Close button), and captures any
+    /// exception. With the fix the echo box emits an invariant control count, so no
+    /// exception fires.
+    /// </summary>
+    public sealed class LogisticsTooltipEchoImguiTest
+    {
+        [InGameTest(Category = "Logistics",
+            Description = "Logistics tooltip echo box emits an invariant IMGUI control count across Layout/Repaint, so a populated GUI.tooltip during Repaint does not overrun the trailing button's layout group")]
+        public IEnumerator TooltipEchoBox_StableControlCount_NoImguiException()
+        {
+            var go = new GameObject("ParsekLogisticsTooltipEchoProbe");
+            UnityEngine.Object.DontDestroyOnLoad(go);
+            TooltipEchoImguiProbe probe = go.AddComponent<TooltipEchoImguiProbe>();
+
+            try
+            {
+                // Give the probe several frames to run multiple full Layout/Repaint
+                // cycles. Two clean repaint passes is enough to prove the count is
+                // stable; the probe sets Completed once it reaches that (or faults).
+                int guardFrames = 0;
+                while (!probe.Completed && guardFrames < 240)
+                {
+                    guardFrames++;
+                    yield return null;
+                }
+
+                if (probe.RepaintPasses == 0)
+                {
+                    InGameAssert.Skip(
+                        $"probe never observed an IMGUI Repaint pass (frames={guardFrames}); cannot validate the echo box in this context");
+                    yield break;
+                }
+
+                InGameAssert.IsFalse(probe.Faulted,
+                    "Logistics tooltip echo box threw an IMGUI exception during Repaint with a populated GUI.tooltip: "
+                        + probe.FaultMessage);
+
+                ParsekLog.Info("TestRunner",
+                    $"LogisticsTooltipEcho_InGame: PASS layoutPasses={probe.LayoutPasses} repaintPasses={probe.RepaintPasses} faulted={probe.Faulted}");
+            }
+            finally
+            {
+                UnityEngine.Object.Destroy(go);
+            }
+        }
+
+        /// <summary>
+        /// Probe MonoBehaviour: each OnGUI draws a 1x1 layout area containing the real
+        /// <see cref="LogisticsWindowUI.DrawTooltipEchoBox"/> followed by a trailing
+        /// button. It feeds the echo box an empty tooltip on the Layout event and a
+        /// non-empty one on the Repaint event, reproducing the divergence that throws
+        /// "Getting control N's position in a group with only N controls when doing
+        /// repaint" if the echo box control count is not invariant. The trailing
+        /// button is the control that overruns the group.
+        /// </summary>
+        private sealed class TooltipEchoImguiProbe : MonoBehaviour
+        {
+            internal bool Faulted;
+            internal string FaultMessage = string.Empty;
+            internal int RepaintPasses;
+            internal int LayoutPasses;
+            internal bool Completed;
+
+            private void OnGUI()
+            {
+                if (Completed)
+                    return;
+
+                EventType evt = Event.current.type;
+                // Only Layout builds and Repaint reads the layout group; input
+                // events do not exercise the control-count path.
+                if (evt != EventType.Layout && evt != EventType.Repaint)
+                    return;
+
+                if (evt == EventType.Layout)
+                    LayoutPasses++;
+
+                // GUI.tooltip is empty during Layout and populated during Repaint in
+                // the real window (it reflects the hovered control, whose tooltip
+                // only resolves at Repaint). Reproduce that exact divergence.
+                string tooltip = evt == EventType.Repaint ? "parsek probe tooltip" : string.Empty;
+
+                GUILayout.BeginArea(new Rect(0f, 0f, 1f, 1f));
+                try
+                {
+                    LogisticsWindowUI.DrawTooltipEchoBox(tooltip);
+                    // Trailing controls mirror the real Close button block.
+                    GUILayout.Space(3f);
+                    GUILayout.Button("probe-close");
+                }
+                catch (Exception ex)
+                {
+                    if (!Faulted)
+                    {
+                        Faulted = true;
+                        FaultMessage = ex.GetType().Name + ": " + ex.Message;
+                        ParsekLog.Warn("TestRunner",
+                            "LogisticsTooltipEcho_InGame probe caught IMGUI exception: " + FaultMessage);
+                    }
+                }
+                finally
+                {
+                    GUILayout.EndArea();
+                }
+
+                if (evt == EventType.Repaint)
+                {
+                    RepaintPasses++;
+                    if (RepaintPasses >= 2 || Faulted)
+                        Completed = true;
+                }
+            }
+        }
+    }
+}

--- a/Source/Parsek/UI/LogisticsWindowUI.cs
+++ b/Source/Parsek/UI/LogisticsWindowUI.cs
@@ -389,23 +389,11 @@ namespace Parsek
 
             GUILayout.EndScrollView();
 
-            // Tooltip echo box (matches SpawnControlUI / SettingsWindowUI house
-            // style). Read GUI.tooltip AFTER all controls have drawn this frame so
-            // it reflects the currently hovered control, then echo it in a box so
-            // hovering any cell / button shows its help text in-window. When no
-            // control is hovered, emit a zero-height placeholder label so the
-            // window keeps a layout entry here and does not pop its height as the
-            // box appears and disappears (same approach as SpawnControlUI).
-            (bool showEcho, string echoText) = ResolveTooltipEcho(GUI.tooltip);
-            if (showEcho)
-            {
-                GUILayout.Space(SpacingSmall);
-                GUILayout.Label(echoText, GUI.skin.box);
-            }
-            else
-            {
-                GUILayout.Label("", GUILayout.Height(0));
-            }
+            // Tooltip echo box (matches SettingsWindowUI house style). Read
+            // GUI.tooltip AFTER all controls have drawn this frame so it reflects
+            // the currently hovered control, then echo it in a box so hovering any
+            // cell / button shows its help text in-window.
+            DrawTooltipEchoBox(GUI.tooltip);
 
             // Full-width Close button at the bottom (matches Kerbals / Settings windows).
             GUILayout.Space(SpacingSmall);
@@ -2754,17 +2742,43 @@ namespace Parsek
         }
 
         /// <summary>
-        /// Decides whether the bottom tooltip echo box should render and with what
+        /// Decides whether the bottom tooltip echo box should render boxed help
         /// text. Returns (false, "") when there is no hovered-control tooltip this
-        /// frame (the caller then emits a zero-height placeholder so the IMGUI
-        /// control count stays stable), or (true, tooltip) when a control is
-        /// hovered. Pure and Unity-free for unit testing.
+        /// frame (the echo box collapses to zero height), or (true, tooltip) when a
+        /// control is hovered. The boolean drives the box's spacing / content /
+        /// style only, never the number of IMGUI controls emitted (see
+        /// <see cref="DrawTooltipEchoBox"/>). Pure and Unity-free for unit testing.
         /// </summary>
         internal static (bool show, string text) ResolveTooltipEcho(string guiTooltip)
         {
             if (string.IsNullOrEmpty(guiTooltip))
                 return (false, string.Empty);
             return (true, guiTooltip);
+        }
+
+        /// <summary>
+        /// Draws the bottom tooltip echo box with a control count that is invariant
+        /// across the IMGUI Layout and Repaint passes: it ALWAYS emits exactly one
+        /// GUILayout.Space plus one GUILayout.Label, and only varies their spacing,
+        /// content, and style by whether a control is hovered. This matters because
+        /// GUI.tooltip is empty during Layout and only becomes populated during
+        /// Repaint (after a hovered control draws), so any branch here that emits a
+        /// DIFFERENT number of controls between the two passes desyncs the layout
+        /// group and makes the next control (the Close button) overrun it, throwing
+        /// "Getting control N's position in a group with only N controls when doing
+        /// repaint". Mirrors the invariant-count pattern in SettingsWindowUI.
+        /// </summary>
+        internal static void DrawTooltipEchoBox(string guiTooltip)
+        {
+            (bool showEcho, string echoText) = ResolveTooltipEcho(guiTooltip);
+            // Always one Space + always one Label. When there is no tooltip the
+            // Space collapses to 0 and the Label renders empty at zero height, so
+            // the box disappears visually without changing the control count.
+            GUILayout.Space(showEcho ? SpacingSmall : 0f);
+            GUILayout.Label(
+                showEcho ? echoText : string.Empty,
+                showEcho ? GUI.skin.box : GUI.skin.label,
+                showEcho ? GUILayout.ExpandWidth(true) : GUILayout.Height(0f));
         }
 
         // Human-readable reason for a status. For blocked-active states this

--- a/docs/dev/todo-and-known-bugs.md
+++ b/docs/dev/todo-and-known-bugs.md
@@ -13,6 +13,12 @@ When referencing prior item numbers from source comments or plans, consult the r
 
 ---
 
+## Done - Logistics window tooltip-echo IMGUI control-count storm
+
+- ~~Hovering any tooltip-bearing control in the Logistics (Supply Routes) window threw a continuous `ArgumentException: Getting control N's position in a group with only N controls when doing repaint` at the Close button (256 times over ~45s in the 2026-06-06 orbital-route playtest log), aborting the rest of the window's draw every frame.~~ FIXED (branch `fix-logistics-tooltip-echo`). Root cause: the QW6 bottom tooltip-echo block (`LogisticsWindowUI.DrawWindow`) emitted a different GUILayout control count between the Layout pass and the Repaint pass. When `GUI.tooltip` was empty it drew 1 control (a zero-height Label); when populated it drew 2 (a `GUILayout.Space` plus a Label). `GUI.tooltip` is empty during Layout and only populated during Repaint, so the count diverged and the trailing Close button overran its layout group. Fix: extracted the emit into `DrawTooltipEchoBox(string guiTooltip)`, which now always emits exactly one `GUILayout.Space` plus one `GUILayout.Label` (varying only spacing/content/style by hover state), matching the invariant-count pattern in `SettingsWindowUI`. The pure decision `ResolveTooltipEcho` is unchanged and still unit-tested; added an in-game probe test (`LogisticsTooltipEchoImguiTest`) that drives a real IMGUI Layout+Repaint cycle with the same tooltip divergence and a trailing button, asserting no exception. (Note: `SpawnControlUI` carries the same conditional-Space shape but does not throw because nothing in its layout group follows the echo box; only Logistics has a trailing control.)
+
+---
+
 ## In progress - v0.10.0 Map/TS render tracer SECOND CUT: recordingId keying + decision-vs-truth reconciliation
 
 - Branch `maprender-second-cut` (off origin/main, which has the probe-only MVP from PR #1005). Design: `docs/dev/design-map-ts-render-tracer.md` (the second-cut sections). Builds the deferred reconciliation / shared-window / reverse-map work on top of the merged MVP.


### PR DESCRIPTION
## Summary

Fixes a HIGH-severity IMGUI exception storm in the Logistics (Supply Routes) window. Hovering any tooltip-bearing control threw a continuous `ArgumentException: Getting control N's position in a group with only N controls when doing repaint` at the Close button (256 times over ~45s in the 2026-06-06 orbital-route playtest log), aborting the rest of the window's draw every frame.

## Root cause

The QW6 bottom tooltip-echo block in `LogisticsWindowUI.DrawWindow` emitted a different number of `GUILayout` controls between the Layout pass and the Repaint pass:

- `GUI.tooltip` empty: 1 control (a zero-height `Label`)
- `GUI.tooltip` populated: 2 controls (a `GUILayout.Space` plus a `Label`)

`GUI.tooltip` is empty during Layout and only becomes populated during Repaint (after a hovered control draws), so the control count diverged between the two passes and the trailing Close button overran its layout group. This is the textbook IMGUI "control N in a group with only N controls when doing repaint" bug.

## Fix

Extract the emit into `DrawTooltipEchoBox(string guiTooltip)`, which always emits exactly one `GUILayout.Space` plus one `GUILayout.Label`, varying only their spacing, content, and style by hover state. The control count is now invariant across Layout and Repaint. This mirrors the invariant-count pattern already used by `SettingsWindowUI`. The pure decision helper `ResolveTooltipEcho` is unchanged.

Note: `SpawnControlUI` carries the same conditional-Space shape but does not throw, because nothing in its layout group follows its echo box; only the Logistics window has a trailing control (the Close button) to overrun.

## Validation

- Added an in-game probe test (`LogisticsTooltipEchoImguiTest`) that installs a `MonoBehaviour` whose own `OnGUI` runs on Unity's real event loop, driving a genuine IMGUI Layout+Repaint cycle against the production `DrawTooltipEchoBox` with the exact tooltip divergence (empty on Layout, populated on Repaint) and a trailing button, then asserts no exception is thrown. The InGameTestRunner coroutine itself does not reliably execute during OnGUI, so the probe sidesteps that.
- Existing `ResolveTooltipEcho` unit tests still pass; their doc comment was updated to the new contract.
- `dotnet test`: 14397 passed, 0 failed.
- ERS/ELS grep gate green; Missions subsystem untouched (empty diff).
- Built and deployed; the deployed `GameData/Parsek/Plugins/Parsek.dll` is byte-identical (sha256) to the build output and contains the new symbols.

Live in-game confirmation (hover the Logistics window, then grep `KSP.log` for lines containing `with only` + `DrawWindow` and confirm zero) is the remaining manual playtest step.

## Docs

- `CHANGELOG.md`: one user-facing line under 0.10.0 / Bug Fixes.
- `docs/dev/todo-and-known-bugs.md`: a Done entry with the root cause and fix.